### PR TITLE
ENH: Improved logging for easier troubleshooting

### DIFF
--- a/Applications/SlicerApp/Resources/UI/qSlicerAppErrorReportDialog.ui
+++ b/Applications/SlicerApp/Resources/UI/qSlicerAppErrorReportDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>691</width>
-    <height>291</height>
+    <width>702</width>
+    <height>418</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -441,7 +441,7 @@
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="InstructionsLabel">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Questions and feature requests:&lt;/span&gt; post a message to &lt;a href=&quot;http://massmail.bwh.harvard.edu/mailman/listinfo/slicer-users&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;slicer-users&lt;/span&gt;&lt;/a&gt; mailing list.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bug reports: &lt;/span&gt;submit a bug report to the &lt;a href=&quot;http://www.na-mic.org/Bug/my_view_page.php&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;3D Slicer bugtracker&lt;/span&gt;&lt;/a&gt;. Describe the steps that lead to the error and also attach log messages.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Questions and feature requests:&lt;/span&gt; post a message to &lt;a href=&quot;http://massmail.bwh.harvard.edu/mailman/listinfo/slicer-users&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;slicer-users&lt;/span&gt;&lt;/a&gt; mailing list.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bug reports: &lt;/span&gt;submit a bug report to the &lt;a href=&quot;http://www.na-mic.org/Bug/my_view_page.php&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;3D Slicer bugtracker&lt;/span&gt;&lt;/a&gt;. Describe the steps that lead to the error and also attach log messages.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Warning - if you work with patient data:&lt;/span&gt; Check that the log messages do not contain any information that may identify a patient. Send the log messages to specific people instead of sharing them publicly on a mailing list or website.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -82,6 +82,7 @@
 
 // Logic includes
 #include <vtkSlicerApplicationLogic.h>
+#include <vtkSystemInformation.h>
 
 // MRML includes
 #include <vtkMRMLNode.h>
@@ -687,17 +688,72 @@ void qSlicerApplication::setupFileLogging()
   // Set current log file path
   d->ErrorLogModel->setFilePath(currentLogFilePath);
 
-  // Log essential information (platform, revision, date, etc.)
+  // Log essential information about the application version and the host computer.
+  // This helps in reproducing reported problems.
+
   QFile f(currentLogFilePath);
   if (f.open(QFile::Append))
     {
     QTextStream s(&f);
-    s << QString("Platform: %1").arg(this->platform()) << "\n";
-    s << QString("OS: %1").arg(this->os()) << "\n";
-    s << QString("Version: %1.%2").arg(this->majorVersion()).arg(this->minorVersion()) << "\n";
-    s << QString("Revision: %1").arg(this->repositoryRevision()) << "\n";
-    s << QString("DateTime: %1").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss")) << "\n";
-    s << "Installed: " << (this->isInstalled() ? "Yes" : "No") << "\n";
+    s << QString("Session start time: %1\n").arg(QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss"));
+    s << QString("Slicer version: %1 (revision %2) %3 - %4\n").arg(Slicer_VERSION_FULL).arg(this->repositoryRevision()).arg(this->platform()).arg((this->isInstalled() ? "installed" : "not installed"));
+
+    vtkNew<vtkSystemInformation> systemInfo;
+    systemInfo->RunCPUCheck();
+    systemInfo->RunOSCheck();
+    systemInfo->RunMemoryCheck();
+
+    s << QString("Operating system: %1 / %2 / %3 - %4\n").arg(systemInfo->GetOSName()).arg(systemInfo->GetOSRelease()).arg(systemInfo->GetOSVersion()).arg(systemInfo->Is64Bits() ? "64-bit" : "32-bit");
+
+    size_t totalPhysicalMemoryMb = systemInfo->GetTotalPhysicalMemory();
+    size_t totalVirtualMemoryMb = systemInfo->GetTotalVirtualMemory();
+#if defined(_WIN32)
+    // On Windows vtkSystemInformation::GetTotalVirtualMemory() returns the virtual address space,
+    // while memory allocation fails if total page file size is reached. Therefore,
+    // total page file size is a better indication of actually available memory for the process.
+  #if defined(_MSC_VER) && _MSC_VER < 1300
+    MEMORYSTATUS ms;
+    ms.dwLength = sizeof(ms);
+    GlobalMemoryStatus(&ms);
+    unsigned long totalPhysicalBytes = ms.dwTotalPhys;
+    totalPhysicalMemoryMb = totalPhysicalBytes>>10>>10;
+    unsigned long totalVirtualBytes = ms.dwTotalPageFile;
+    totalVirtualMemoryMb = totalVirtualBytes>>10>>10;
+  #else
+    MEMORYSTATUSEX ms;
+    ms.dwLength = sizeof(ms);
+    if (GlobalMemoryStatusEx(&ms))
+      {
+      DWORDLONG totalPhysicalBytes = ms.ullTotalPhys;
+      totalPhysicalMemoryMb = totalPhysicalBytes>>10>>10;
+      DWORDLONG totalVirtualBytes = ms.ullTotalPageFile;
+      totalVirtualMemoryMb = totalVirtualBytes>>10>>10;
+      }
+  #endif
+#endif
+    s << QString("Memory: %1 MB physical, %2 MB virtual\n").arg(totalPhysicalMemoryMb).arg(totalVirtualMemoryMb);
+
+    unsigned int numberOfPhysicalCPU = systemInfo->GetNumberOfPhysicalCPU();
+#if defined(_WIN32)
+    // On Windows number of physical CPUs are computed incorrectly by vtkSystemInformation::GetNumberOfPhysicalCPU(),
+    // if hyperthreading is enabled (typically 0 is reported), therefore get it directly from the OS instead.
+    SYSTEM_INFO info;
+    info.dwNumberOfProcessors = 0;
+    GetSystemInfo (&info);
+    numberOfPhysicalCPU = (unsigned int) info.dwNumberOfProcessors;
+#endif
+    s << QString("CPU: %1 %2 MHz, %3 processors\n").arg(systemInfo->GetVendorString()).arg(QString::number(systemInfo->GetProcessorClockFrequency()/1000, 'g', 3)).arg(numberOfPhysicalCPU);
+
+    QSettings settings;
+    bool developerModeEnabled = settings.value("Developer/DeveloperMode", false).toBool();
+    s << QString("Developer mode enabled: %1\n").arg(developerModeEnabled ? "yes" : "no");
+
+    bool preferExecutableCli = settings.value("Modules/PreferExecutableCLI", false).toBool();
+    s << QString("Prefer executable CLI: %1\n").arg(preferExecutableCli ? "yes" : "no");
+
+    QStringList additionalModulePaths = this->revisionUserSettings()->value("Modules/AdditionalPaths").toStringList();
+    s << QString("Additional module paths: %1\n").arg(additionalModulePaths.isEmpty() ? QString("(none)") : additionalModulePaths.join(", "));
+
     f.close();
     }
 }

--- a/Base/QTGUI/qSlicerModulePanel.cxx
+++ b/Base/QTGUI/qSlicerModulePanel.cxx
@@ -91,6 +91,10 @@ void qSlicerModulePanel::setModule(const QString& moduleName)
     return;
     }
 
+  // Log when the user switches netween modules so that if the application crashed
+  // we knew which module was active.
+  qDebug() << "Switch to module: " << moduleName;
+
   qSlicerAbstractCoreModule * module = 0;
   if (!moduleName.isEmpty())
     {

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -115,6 +115,56 @@ void class::Set##name (const char* _arg)            \
   }
 #endif
 
+// Macro for logging informational messages
+//
+// Informational messages log important information and non-error events
+// that can be used for approximately tracking user actions.
+// The information is essential for troubleshooting errors (as the user
+// can be asked to simply provide the application log instead of describing
+// what he did in detail).
+//
+// A new vtkInfoMacro logging macro had to be added as vtkDebugMacro only logs
+// the message if debug is enabled for the particular object (also, typically
+// debug output contains many low-level details), and Error and Warning macros
+// are reserved for reporting potential issues.
+
+#ifndef vtkInfoWithObjectMacro
+#define vtkInfoWithObjectMacro(self, x)                        \
+  {                                                            \
+  if (true)                                                    \
+    {                                                          \
+    vtkOStreamWrapper::EndlType endl;                          \
+    vtkOStreamWrapper::UseEndl(endl);                          \
+    vtkOStrStreamWrapper vtkmsg;                               \
+    vtkmsg << "INFO: In " __FILE__ ", line " << __LINE__       \
+          << "\n" << self->GetClassName() << " (" << self      \
+          << "): " x << "\n\n";                                \
+    vtkOutputWindowDisplayText(vtkmsg.str());                  \
+    vtkmsg.rdbuf()->freeze(0);                                 \
+    }                                                          \
+  }
+#endif
+
+#ifndef vtkInfoWithoutObjectMacro
+#define vtkInfoWithoutObjectMacro(x)                           \
+  {                                                            \
+  if (true)                                                    \
+    {                                                          \
+    vtkOStreamWrapper::EndlType endl;                          \
+    vtkOStreamWrapper::UseEndl(endl);                          \
+    vtkOStrStreamWrapper vtkmsg;                               \
+    vtkmsg << "INFO: In " __FILE__ ", line " << __LINE__       \
+          << "\n" x << "\n\n";                                 \
+    vtkOutputWindowDisplayText(vtkmsg.str());                  \
+    vtkmsg.rdbuf()->freeze(0);                                 \
+    }                                                          \
+  }
+#endif
+
+#ifndef vtkInfoMacro
+#define vtkInfoMacro(x)                                        \
+  vtkInfoWithObjectMacro(this,x);
+#endif
 
 /// \brief Abstract Superclass for all specific types of MRML nodes.
 ///

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -450,6 +450,12 @@ int vtkMRMLVolumeArchetypeStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
   iciOutputCopy->ShallowCopy(ici->GetOutput());
   volNode->SetAndObserveImageData(iciOutputCopy.GetPointer());
 
+  // Log volume size to the application log. It helps to identify potential out-of-memory issues.
+  vtkInfoMacro(<<"Loaded volume from file: "<<fullName \
+    <<". Dimensions: "<<iciOutputCopy->GetDimensions()[0]<<"x"<<iciOutputCopy->GetDimensions()[1]<<"x"<<iciOutputCopy->GetDimensions()[2] \
+    <<". Number of components: "<<iciOutputCopy->GetNumberOfScalarComponents() \
+    <<". Pixel type: "<<vtkImageScalarTypeNameMacro(iciOutputCopy->GetScalarType())<<".");
+
   vtkMatrix4x4* mat = reader->GetRasToIjkMatrix();
   if ( mat == NULL )
     {


### PR DESCRIPTION
When users report a crash we need to ask a lot of questions (what operating system, Slicer version is used, how much memory is in the computer, how large images are loaded, what module was used, etc). Instead, we will be able to just ask them to provide the application log, as it will contain all these information. Lots of useful information is included now and as we identify further important troubleshooting data, those should be added to the application log, too.

* Added vtkInfoMacro logging macro, that logs an INFO message from VTK objects. vtkDebugMacro was not usable for information logging, as it only logs the message if debug is enabled for the particular object (also, typically debug output contains many low-level details).
* Added more detailed system and application info logging (operating system, memory, CPU, additional module paths, developer mode flag, executable CLI preference flag).
* Fixed system info logging for Windows (vtksys computes returns incorrect virtual memory size and number of physical CPUs).
* Log whenever user switches to another module (in case of a crash we know then what module was active).
* Log loaded volume size (this allows us to see if the volume size is very large compared to the available memory), for example: vtkMRMLVolumeArchetypeStorageNode (000000DC38FDF230): Loaded volume from file: C:/S4/Libs/MRML/Core/Testing/TestData/fixed.nrrd. Dimensions: 65x65x32. Number of components: 1. Pixel type: short.

