### PR TITLE
BUG: avoid false positives on geometry check

### DIFF
--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -53,8 +53,8 @@
 #include <vtkImageReslice.h>
 #include <vtkTransform.h>
 
-
-
+/// CTK includes
+#include <ctkUtils.h>
 
 //----------------------------------------------------------------------------
 namespace
@@ -350,6 +350,9 @@ vtkSlicerVolumesLogic::vtkSlicerVolumesLogic()
   this->RegisterArchetypeVolumeNodeSetFactory( ArchetypeVectorVolumeNodeSetFactory );
   this->RegisterArchetypeVolumeNodeSetFactory( LabelMapVolumeNodeSetFactory );
   this->RegisterArchetypeVolumeNodeSetFactory( ScalarVolumeNodeSetFactory );
+
+  this->SetCompareVolumeGeometryEpsilon(0.000001);
+
 }
 
 //----------------------------------------------------------------------------
@@ -907,12 +910,36 @@ vtkSlicerVolumesLogic::CheckForLabelVolumeValidity(vtkMRMLScalarVolumeNode *volu
 }
 
 //----------------------------------------------------------------------------
+void vtkSlicerVolumesLogic::SetCompareVolumeGeometryEpsilon(double epsilon)
+{
+  vtkDebugMacro("vtkSlicerVolumesLogic setting "
+                << " CompareVolumeGeometryEpsilon to " << epsilon);
+
+  double positiveEpsilon = epsilon;
+  // check for negative values
+  if (positiveEpsilon < 0.0)
+    {
+    positiveEpsilon = fabs(epsilon);
+    }
+
+  if (this->CompareVolumeGeometryEpsilon != positiveEpsilon)
+    {
+    this->CompareVolumeGeometryEpsilon = positiveEpsilon;
+
+    // now set the precision
+    this->CompareVolumeGeometryPrecision = ctk::significantDecimals(this->CompareVolumeGeometryEpsilon);
+
+    this->Modified();
+    }
+}
+
+//----------------------------------------------------------------------------
 std::string
 vtkSlicerVolumesLogic::CompareVolumeGeometry(vtkMRMLScalarVolumeNode *volumeNode1,
                                              vtkMRMLScalarVolumeNode *volumeNode2)
 {
   std::stringstream warnings;
-  warnings << "";
+
   if (!volumeNode1 || !volumeNode2)
     {
     if (!volumeNode1)
@@ -943,6 +970,37 @@ vtkSlicerVolumesLogic::CompareVolumeGeometry(vtkMRMLScalarVolumeNode *volumeNode
       {
       int row, column;
       double volumeValue1, volumeValue2;
+      // set the floating point precision to match the precision of the espilon
+      // used for the fuzzy compare
+      warnings << std::setprecision(this->GetCompareVolumeGeometryPrecision());
+      // sanity check versus the volume spacings
+      double spacing1[3], spacing2[3];
+      volumeNode1->GetSpacing(spacing1);
+      volumeNode2->GetSpacing(spacing2);
+      double minSpacing = spacing1[0];
+      for (int i = 1; i < 3; ++i)
+        {
+        if (spacing1[i] < minSpacing)
+          {
+          minSpacing = spacing1[i];
+          }
+        }
+      for (int i = 0; i < 3; ++i)
+        {
+        if (spacing2[i] < minSpacing)
+          {
+          minSpacing = spacing2[i];
+          }
+        }
+      // in general the defaults assume that an epsilon of 1e-6 works with a min
+      // spacing of 1mm, check that the epsilon is scaled appropriately for the
+      // minimum spacing for these two volumes
+      double logDiff = ctk::orderOfMagnitude(minSpacing) - ctk::orderOfMagnitude(this->CompareVolumeGeometryEpsilon);
+      vtkDebugMacro("diff in order of mag between min spacing and epsilon = " << logDiff);
+      if (logDiff < 3.0 || logDiff > 10.0)
+        {
+        warnings << "(Minimum spacing for volumes of " << minSpacing << " mismatched with epsilon " << this->CompareVolumeGeometryEpsilon << ",\ngeometry comparison may not be useful.\nTry resetting the Volumes module logic compare volume geometry epsilon variable.)\n";
+        }
       for (row = 0; row < 3; row++)
         {
         volumeValue1 = volumeImage1->GetDimensions()[row];
@@ -978,9 +1036,12 @@ vtkSlicerVolumesLogic::CompareVolumeGeometry(vtkMRMLScalarVolumeNode *volumeNode
           {
           volumeValue1 = volumeIJKToRAS1->GetElement(row,column);
           volumeValue2 = volumeIJKToRAS2->GetElement(row,column);
-          if (!vtkMathUtilities::FuzzyCompare<double>(volumeValue1, volumeValue2))
+          if (!vtkMathUtilities::FuzzyCompare<double>(volumeValue1,
+                                                      volumeValue2,
+                                                      this->CompareVolumeGeometryEpsilon))
             {
-            warnings << "IJKToRAS mismatch at [" << row << ", " << column << "] (" << volumeValue1 << " != " << volumeValue2 << ")\n";
+            warnings << "IJKToRAS mismatch at [" << row << ", " << column << "] ("
+                     << volumeValue1 << " != " << volumeValue2 << ")\n";
             }
           }
         }
@@ -1174,6 +1235,10 @@ void vtkSlicerVolumesLogic::PrintSelf(ostream& os, vtkIndent indent)
 
   os << indent << "ActiveVolumeNode: " <<
     (this->ActiveVolumeNode ? this->ActiveVolumeNode->GetName() : "(none)") << "\n";
+  os << indent << "CompareVolumeGeometryEpsilon: "
+     << this->CompareVolumeGeometryEpsilon << "\n";
+  os << indent << "CompareVolumeGeometryPrecision: "
+     << this->CompareVolumeGeometryPrecision << "\n";
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
@@ -242,6 +242,20 @@ public:
   static vtkMRMLScalarVolumeNode* ResampleVolumeToReferenceVolume(vtkMRMLVolumeNode *inputVolumeNode,
                                                            vtkMRMLVolumeNode *referenceVolumeNode);
 
+  /// Getting the epsilon value to use when determining if the
+  /// elements of the IJK to RAS matrices of two volumes match.
+  /// Defaults to 10 to the minus 6.
+  vtkGetMacro(CompareVolumeGeometryEpsilon, double);
+  /// Setting the epsilon value and associated precision to use when determining
+  /// if the elements of the IJK to RAS matrices of two volumes match and how to
+  /// print out the mismatched elements.
+  void SetCompareVolumeGeometryEpsilon(double epsilon);
+
+  /// Get the precision with which to print out volume geometry mismatches,
+  /// value is set when setting the compare volume geometry epsilon.
+  /// \sa SetCompareVolumeGeometryEpsilon
+  vtkGetMacro(CompareVolumeGeometryPrecision, int);
+
 protected:
   vtkSlicerVolumesLogic();
   virtual ~vtkSlicerVolumesLogic();
@@ -273,6 +287,13 @@ protected:
   vtkSmartPointer<vtkMRMLColorLogic> ColorLogic;
 
   NodeSetFactoryRegistry VolumeRegistry;
+
+  /// Allowable difference in comparing volume geometry double values.
+  /// Defaults to 1 to the power of 10 to the minus 6
+  double CompareVolumeGeometryEpsilon;
+  /// Error print out precision, paried with CompareVolumeGeometryEpsilon.
+  /// defaults to 6
+  int CompareVolumeGeometryPrecision;
 };
 
 #endif

--- a/Modules/Loadable/Volumes/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/Testing/Python/CMakeLists.txt
@@ -2,3 +2,5 @@
 #  SLICER_ARGS --disable-cli-modules)
 
 slicer_add_python_unittest(SCRIPT LoadVolumeDisplaybleSceneModelClose.py)
+
+slicer_add_python_unittest(SLICER_ARGS --disable-cli-modules SCRIPT VolumesLogicCompareVolumeGeometry.py)

--- a/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
+++ b/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
@@ -1,0 +1,118 @@
+import unittest
+from  __main__ import vtk, qt, ctk, slicer
+
+
+class VolumesLogicCompareVolumeGeometryTesting(unittest.TestCase):
+  def setUp(self):
+    pass
+
+  def test_VolumesLogicCompareVolumeGeometry(self):
+    """
+    Load a volume, then call the compare volume geometry test with
+    different values of epsilon and precision.
+    """
+
+    #
+    # first, get some sample data
+    #
+    import SampleData
+    sampleDataLogic = SampleData.SampleDataLogic()
+    head = sampleDataLogic.downloadMRHead()
+
+    #
+    # get the volumes logic and print out default epsilon and precision
+    #
+    volumesLogic = slicer.modules.volumes.logic()
+    print 'Compare volume geometry epsilon: ', volumesLogic.GetCompareVolumeGeometryEpsilon()
+    print 'Compare volume geometry precision: ', volumesLogic.GetCompareVolumeGeometryPrecision()
+
+    #
+    # compare the head against itself, this shouldn't produce any warning
+    # string
+    #
+    warningString = volumesLogic.CompareVolumeGeometry(head, head)
+    if len(warningString) != 0:
+      print 'Error in checking MRHead geometry against itself'
+      print warningString
+      return False
+    else:
+      print 'Success in comparing MRHead vs itself with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+
+    #
+    # see if you can get it to fail with a tighter epsilon
+    #
+    volumesLogic.SetCompareVolumeGeometryEpsilon(1e-10)
+    precision = volumesLogic.GetCompareVolumeGeometryPrecision()
+    if precision != 10:
+      print 'Error in calculating precision from epsilon of ', volumesLogic.GetCompareVolumeGeometryEpsilon(), ', expected 10, got ', precision
+      return False
+    warningString = volumesLogic.CompareVolumeGeometry(head, head)
+    if len(warningString) != 0:
+      print 'Error in checking MRHead geometry against itself with strict epsilon'
+      print warningString
+      return False
+    else:
+      print 'Success in comparing MRHead vs itself with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+
+
+
+    #
+    # clone the volume so can test for mismatches in geometry with
+    # that operation
+    #
+    head2 = volumesLogic.CloneVolume(head, 'head2')
+
+    warningString  = volumesLogic.CompareVolumeGeometry(head, head2)
+    if len(warningString) != 0:
+      print 'Error in checking MRHead geometry against itself with epsilon ', volumesLogic.GetCompareVolumeGeometryEpsilon()
+      print warningString
+      return False
+    else:
+      print 'Success in comparing MRHead vs clone with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+
+    #
+    # now try with a label map volume
+    #
+    headLabel = volumesLogic.CreateAndAddLabelVolume(head, "label vol")
+    warningString = volumesLogic.CompareVolumeGeometry(head, headLabel)
+    if len(warningString) != 0:
+      print 'Error in comparing MRHead geometry against a label map of itself with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+      print warningString
+      return False
+    else:
+      print 'Success in comparing MRHead vs label map with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+
+    #
+    # adjust the geometry and make it fail
+    #
+    head2Matrix = vtk.vtkMatrix4x4()
+    head2.GetRASToIJKMatrix(head2Matrix)
+    val = head2Matrix.GetElement(2,0)
+    head2Matrix.SetElement(2,0,val+0.25)
+    head2.SetRASToIJKMatrix(head2Matrix)
+    head2.SetSpacing(0.12345678901234567890, 2.0, 3.4)
+
+    warningString = volumesLogic.CompareVolumeGeometry(head,head2)
+    if len(warningString) == 0:
+      print 'Error in comparing MRHead geometry against an updated clone, with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+      return False
+    else:
+      print 'Success in making the comparison fail, with with epsilon',volumesLogic.GetCompareVolumeGeometryEpsilon()
+      print warningString
+
+    #
+    # reset the epsilon with an invalid negative number
+    #
+    volumesLogic.SetCompareVolumeGeometryEpsilon(-0.01)
+    epsilon = volumesLogic.GetCompareVolumeGeometryEpsilon()
+    if epsilon != 0.01:
+      print 'Failed to use the absolute value for an epsilon of -0.01: ', epsilon
+      return False
+    precision = volumesLogic.GetCompareVolumeGeometryPrecision()
+    if precision != 2:
+      print 'Failed to set the precision to 2: ',precision
+      return False
+    warningString = volumesLogic.CompareVolumeGeometry(head,head2)
+    print warningString
+
+    return True


### PR DESCRIPTION
Add an epsilon value to the volumes logic and use it in the fuzzy compare instead
of the VTK default value. Add a precision calculation from the epsilon so that
any warning messages are printed out with the same precision as was used to
check the values.
Added a sanity check to see if the smallest volume spacing is within 3-10 orders
of magnitude of epsilon and print a warning if not.
Use the CTK significant decimals utility method to calculate the
precision with which to display differences in compared volumes.
Use the CTK order of magnitude utility method to compare the
spacing of the volumes with the current epsilon being used to
check them.
Added a python test to exercise the epsilon, precision and geometry check.

TBD: GUI for setting epsilon or just always use a volume spacing based value.