### PR TITLE
BUG: Fixed loading of DICOM image from files containing special characters

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -85,7 +85,8 @@ class DICOMPlugin(object):
       return None
     m = hashlib.md5()
     for f in files:
-      m.update(f)
+      # Unicode-objects must be encoded before hashing
+      m.update(f.encode('UTF-8', 'ignore'))
     return(m.digest())
 
   def getCachedLoadables(self,files):
@@ -201,7 +202,10 @@ class DICOMPlugin(object):
       if patientNode != None:
         # Add attributes for DICOM tags
         patientName = slicer.dicomDatabase.fileValue(firstFile,tags['patientName'])
-        if patientName == '':
+        if patientName:
+          # VTK set funcions all expect latin1 encoded strings
+          patientName = patientName.encode('latin1', 'ignore')
+        else:
           patientName = 'No name'
         patientNode.SetAttribute(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMPatientNameAttributeName(),patientName)
         patientNode.SetAttribute(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMPatientIDAttributeName(),slicer.dicomDatabase.fileValue(firstFile, tags['patientID']))
@@ -209,7 +213,6 @@ class DICOMPlugin(object):
         patientNode.SetAttribute(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMPatientBirthDateAttributeName(),slicer.dicomDatabase.fileValue(firstFile, tags['patientBirthDate']))
         patientNode.SetAttribute(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMPatientCommentsAttributeName(),slicer.dicomDatabase.fileValue(firstFile, tags['patientComments']))
         # Set node name
-        patientName = patientName.encode('UTF-8', 'ignore')
         patientNode.SetName(patientName + slicer.vtkMRMLSubjectHierarchyConstants.GetSubjectHierarchyNodeNamePostfix())
 
     if studyNode == None:

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -295,9 +295,10 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
     name = name.encode('latin1', 'ignore')
     fileList = vtk.vtkStringArray()
     for f in files:
-      fileList.InsertNextValue(f)
+      # VTK expects latin1 encoded strings
+      fileList.InsertNextValue(f.encode('latin1', 'ignore'))
     volumesLogic = slicer.modules.volumes.logic()
-    return(volumesLogic.AddArchetypeScalarVolume(files[0],name,0,fileList))
+    return(volumesLogic.AddArchetypeScalarVolume(files[0].encode('latin1', 'ignore'),name,0,fileList))
 
   def load(self,loadable):
     """Load the select as a scalar volume


### PR DESCRIPTION
Got some DICOM files that contained a special character in the file names and in the patient name. Slicer failed to load them because lack of proper encoding before using them.

Solution:
* Encode strings to latin1 before using them in VTK set functions.
* Encode file names to a byte stream before sending them to hashlib.