### PR TITLE
BUG: fix coordinate display and add distance

### DIFF
--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -2370,7 +2370,7 @@ void qSlicerMarkupsModuleWidget::addSelectedCoordinatesToMenu(QMenu *menu)
   // sort the list
   qSort(rows);
 
-  // keep track of point ot point distance
+  // keep track of point to point distance
   double distance = 0.0;
   double lastPoint[3] = {0.0, 0.0, 0.0};
 
@@ -2429,8 +2429,7 @@ void qSlicerMarkupsModuleWidget::addSelectedCoordinatesToMenu(QMenu *menu)
     }
   if (distance != 0.0)
     {
-    QString fiducialDistanceString = QString("Summed linear distance: ") + QString::number(distance);
-    menu->addAction(fiducialDistanceString);
+    menu->addAction(QString("Summed linear distance: %1").arg(distance));
     }
   menu->addSeparator();
 }


### PR DESCRIPTION
The right click menu on the Markups GUI wasn't always showing the
correct coordinates as there were some assumptions about how the
selected items mapped to rows. Take out the assumptions, iterate
through every selected item and collect unique rows.

Show the summed linear distance between selected fiducials.

Issue #1898