### PR TITLE
COMP: Suppress quoted var warn under CMake 3.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ if(POLICY CMP0017)
   cmake_policy(SET CMP0017 OLD)
 endif()
 
+# Under CMake 3.1.0  quoted variables will no longer be dereferenced
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 OLD)
+endif()
+
 #-----------------------------------------------------------------------------
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 include(ExternalProject)


### PR DESCRIPTION
Policy CMP0054 is not set:
Only interpret if() arguments as variables or keywords when unquoted.

Run "cmake --help-policy CMP0054" for policy details.

Quoted variables like "jqPlot_DIR" will no longer be dereferenced when the
policy is set to NEW.  Since the policy is not set the OLD behavior will be
used.