### PR TITLE
Allow mac osx1010 building

### DIFF
--- a/CMake/SlicerBlockSetCMakeOSXVariables.cmake
+++ b/CMake/SlicerBlockSetCMakeOSXVariables.cmake
@@ -47,12 +47,14 @@ if(APPLE)
   #  11.x == Mac OSX 10.7 (Lion)
   #  12.x == Mac OSX 10.8 (Mountain Lion)
   #  13.x == Mac OSX 10.9 (Mavericks)
+  #  14.x == Mac OSX 10.10 (Yosemite)
   set(OSX_SDK_104_NAME "Tiger")
   set(OSX_SDK_105_NAME "Leopard")
   set(OSX_SDK_106_NAME "Snow Leopard")
   set(OSX_SDK_107_NAME "Lion")
   set(OSX_SDK_108_NAME "Mountain Lion")
   set(OSX_SDK_109_NAME "Mavericks")
+  set(OSX_SDK_1010_NAME "Yosemite")
 
   set(OSX_SDK_ROOTS
     /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs
@@ -63,11 +65,13 @@ if(APPLE)
   #     and (3) Qt binaries are (as expected) build against 'libstdc++', we
   #     are removing 10.9 from the list of version to check.
   #     [1] http://stackoverflow.com/questions/19637164/c-linking-error-after-upgrading-to-mac-os-x-10-9-xcode-5-0-1/19637199#19637199
+  set(OSX_SYSROOT_SEARCHED "")
   set(SDK_VERSIONS_TO_CHECK 10.8 10.7 10.6 10.5)
   foreach(SDK_VERSION ${SDK_VERSIONS_TO_CHECK})
     if(NOT CMAKE_OSX_DEPLOYMENT_TARGET OR "${CMAKE_OSX_DEPLOYMENT_TARGET}" STREQUAL "")
       foreach(SDK_ROOT ${OSX_SDK_ROOTS})
         set(TEST_OSX_SYSROOT "${SDK_ROOT}/MacOSX${SDK_VERSION}.sdk")
+        list(APPEND OSX_SYSROOT_SEARCHED ${TEST_OSX_SYSROOT})
         if(EXISTS "${TEST_OSX_SYSROOT}")
           # Retrieve OSX target name
           string(REPLACE "." "" sdk_version_no_dot ${SDK_VERSION})
@@ -83,7 +87,9 @@ if(APPLE)
     endif()
   endforeach()
 
-  if(NOT "${CMAKE_OSX_SYSROOT}" STREQUAL "")
+  if("${CMAKE_OSX_SYSROOT}" STREQUAL "")
+    message(FATAL_ERROR "error: Required CMAKE_OSX_SYSROOT not found.  Searched in:\n${OSX_SYSROOT_SEARCHED}")
+  else()
     if(NOT EXISTS "${CMAKE_OSX_SYSROOT}")
       message(FATAL_ERROR "error: CMAKE_OSX_SYSROOT='${CMAKE_OSX_SYSROOT}' does not exist")
     endif()

--- a/CMake/SlicerBlockSetCMakeOSXVariables.cmake
+++ b/CMake/SlicerBlockSetCMakeOSXVariables.cmake
@@ -60,14 +60,22 @@ if(APPLE)
     /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs
     /Developer/SDKs
     )
-  # XXX Since (1) the default runtime associated with 10.9 is libc++ [1]
-  #     and (2) qt support for 'macx-clang-libc++' is listed as 'unsupported' mkspecs
+  # XXX Since
+  #         (1) the default runtime associated with 10.9 is libc++ [1]
+  #     and (2) qt support for 'macx-clang-libc++' is listed as 'unsupported' mkspecs (pre 2013-12-05 comment)
   #     and (3) Qt binaries are (as expected) build against 'libstdc++', we
   #     are removing 10.9 from the list of version to check.
   #     [1] http://stackoverflow.com/questions/19637164/c-linking-error-after-upgrading-to-mac-os-x-10-9-xcode-5-0-1/19637199#19637199
+
+  ## NOTE: https://codereview.qt-project.org/#/c/70930/ QT 4.8.6 no longer has the restrictions
+  ##       Binaries of QT 4.8.6 from homebrew are built with libc++
+  ##       QT 4.8.6 can be built with libc++, and the stackoverflow comment is not valid
+
   set(OSX_SYSROOT_SEARCHED "")
-  set(SDK_VERSIONS_TO_CHECK 10.8 10.7 10.6 10.5)
-  foreach(SDK_VERSION ${SDK_VERSIONS_TO_CHECK})
+  set(SDK_MAJOR_VERSIONS_TO_CHECK 10)
+  set(SDK_MINOR_VERSIONS_TO_CHECK 10 9 8 7 6 5)
+  foreach(SDK_MINOR_VERSION ${SDK_MINOR_VERSIONS_TO_CHECK})
+    set(SDK_VERSION ${SDK_MAJOR_VERSIONS_TO_CHECK}.${SDK_MINOR_VERSION})
     if(NOT CMAKE_OSX_DEPLOYMENT_TARGET OR "${CMAKE_OSX_DEPLOYMENT_TARGET}" STREQUAL "")
       foreach(SDK_ROOT ${OSX_SDK_ROOTS})
         set(TEST_OSX_SYSROOT "${SDK_ROOT}/MacOSX${SDK_VERSION}.sdk")
@@ -78,6 +86,7 @@ if(APPLE)
           set(OSX_NAME ${OSX_SDK_${sdk_version_no_dot}_NAME})
           set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "Force build for 64-bit ${OSX_NAME}." FORCE)
           set(CMAKE_OSX_DEPLOYMENT_TARGET "${SDK_VERSION}" CACHE STRING "Force build for 64-bit ${OSX_NAME}." FORCE)
+          set(CMAKE_OSX_SDK_MINOR_VERSION "${SDK_MINOR_VERSION}" CACHE STRING "Force build for 64-bit ${OSX_NAME}." FORCE)
           set(CMAKE_OSX_SYSROOT "${TEST_OSX_SYSROOT}" CACHE PATH "Force build for 64-bit ${OSX_NAME}." FORCE)
           message(STATUS "Setting OSX_ARCHITECTURES to '${CMAKE_OSX_ARCHITECTURES}' as none was specified.")
           message(STATUS "Setting OSX_DEPLOYMENT_TARGET to '${SDK_VERSION}' as none was specified.")
@@ -93,5 +102,12 @@ if(APPLE)
     if(NOT EXISTS "${CMAKE_OSX_SYSROOT}")
       message(FATAL_ERROR "error: CMAKE_OSX_SYSROOT='${CMAKE_OSX_SYSROOT}' does not exist")
     endif()
+  endif()
+
+  if(${CMAKE_OSX_SDK_MINOR_VERSION} GREATER 8 )
+    message(WARNING "OSX Minor version is greater than 8, and it assumes
+    default linkage against libc++ instead of libstd++.  It is the developers
+    responsibility to ensure that all system tools (i.e. qt) are also built
+    against libc++.  \"otool -L /usr/local/bin/qmake |fgrep libc++\"")
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(APPLE)
   #       we ensure that the bitness will be properly detected.
   include(SlicerBlockSetCMakeOSXVariables)
   mark_as_superbuild(
-    VARS CMAKE_OSX_ARCHITECTURES:STRING CMAKE_OSX_SYSROOT:PATH CMAKE_OSX_DEPLOYMENT_TARGET:STRING
+    VARS CMAKE_OSX_ARCHITECTURES:STRING CMAKE_OSX_SYSROOT:PATH CMAKE_OSX_DEPLOYMENT_TARGET:STRING CMAKE_OSX_SDK_MINOR_VERSION:STRING
     ALL_PROJECTS
     )
 endif()
@@ -143,7 +143,11 @@ mark_as_superbuild(GIT_EXECUTABLE)
 # Qt requirements
 #-----------------------------------------------------------------------------
 if(NOT DEFINED Slicer_REQUIRED_QT_VERSION)
-  set(Slicer_REQUIRED_QT_VERSION "4.7.4" CACHE STRING "Minimum required Qt version" FORCE)
+    if(APPLE AND ( ${CMAKE_OSX_SDK_MINOR_VERSION} GREATER 8 ) )
+      set(Slicer_REQUIRED_QT_VERSION "4.8.4" CACHE STRING "Minimum required Qt version" FORCE)
+    else()
+      set(Slicer_REQUIRED_QT_VERSION "4.7.4" CACHE STRING "Minimum required Qt version" FORCE)
+    endif()
 endif()
 mark_as_superbuild(Slicer_REQUIRED_QT_VERSION)
 

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -247,14 +247,15 @@ set(BRAINSTools_options
   USE_DWIConvert:BOOL=${Slicer_BUILD_DICOM_SUPPORT} ## Need to figure out library linking
   )
 Slicer_Remote_Add(BRAINSTools
-  GIT_REPOSITORY "${git_protocol}://github.com/Slicer/BRAINSTools.git"
+  #GIT_REPOSITORY "${git_protocol}://github.com/Slicer/BRAINSTools.git"
+  GIT_REPOSITORY "${git_protocol}://github.com/BRAINSia/BRAINSTools.git"
   # Version BRAINSia/BRAINSTools@411dee9 with find_package(VTK..) tweaks reverted,
   # ITKDeprecated dependency removed (See https://github.com/BRAINSia/BRAINSTools/issues/154),
   # and the following changes backported from BRAINSia/BRAINSTools@master:
   #  * ITKv3 compatibility removed
   #  * Tweaks to BRAINSFit.xml
   #  * Fixes for shadowed declarations
-  GIT_TAG "b82c7c841dcc9e7335c20a134ff97897e808e91d"
+  GIT_TAG "73a6e2d6c2488823ba7d312471982a1897099c98"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"
   LABELS REMOTE_MODULE

--- a/SuperBuild/External_PCRE.cmake
+++ b/SuperBuild/External_PCRE.cmake
@@ -13,7 +13,7 @@ endif()
 
 # Sanity checks
 if(DEFINED PCRE_DIR AND NOT EXISTS ${PCRE_DIR})
-  message(FATAL_ERROR "PCRE_DIR variable is defined but corresponds to nonexistent directory")
+  message(FATAL_ERROR "PCRE_DIR variable is defined but corresponds to non-existing directory")
 endif()
 
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -34,7 +34,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" PythonPacka
 ")
 
   set(SimpleITK_REPOSITORY ${git_protocol}://itk.org/SimpleITK.git)
-  set(SimpleITK_GIT_TAG f2241a13f6010cb6ea6da1b21c6f2d2e31641b16 ) # master branch 0.9.0.dev381
+  set(SimpleITK_GIT_TAG 57e6a5265ae45e535c9bb4887ca92cf95aa79cb9 ) # master 2015-01-06
 
   ExternalProject_add(SimpleITK
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -7,14 +7,15 @@ endif()
 
 # Sanity checks
 if(DEFINED Swig_DIR AND NOT EXISTS ${Swig_DIR})
-  message(FATAL_ERROR "Swig_DIR variable is defined but corresponds to nonexistent directory")
+  message(FATAL_ERROR "Swig_DIR variable is defined but corresponds to non-existing directory")
 endif()
 
 if(NOT SWIG_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
-  set(SWIG_TARGET_VERSION 2.0.12)
-  set(SWIG_DOWNLOAD_SOURCE_HASH "c3fb0b2d710cc82ed0154b91e43085a4")
-  set(SWIG_DOWNLOAD_WIN_HASH "3cc7dd131a87972f70fca1490b9e6e6b")
+  set(SWIG_TARGET_VERSION 3.0.2)
+  set(SWIG_DOWNLOAD_SOURCE_HASH "62f9b0d010cef36a13a010dc530d0d41")
+  set(SWIG_DOWNLOAD_WIN_HASH "3f18de4fc09ab9abb0d3be37c11fbc8f")
+
 
   if(WIN32)
     # swig.exe available as pre-built binary on Windows:
@@ -28,7 +29,7 @@ if(NOT SWIG_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       UPDATE_COMMAND ""
       )
 
-    set(SWIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/swigwin-${SWIG_TARGET_VERSION}") # ??
+    set(SWIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/swigwin-${SWIG_TARGET_VERSION}")  # path specified as source in ep
     set(SWIG_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}/swigwin-${SWIG_TARGET_VERSION}/swig.exe")
     set(Swig_DEPEND Swig)
 

--- a/SuperBuild/External_teem.cmake
+++ b/SuperBuild/External_teem.cmake
@@ -44,16 +44,19 @@ if(NOT DEFINED Teem_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       )
   endif()
 
-  set(teem_URL http://slicer.kitware.com/midas3/download/item/159431/teem-1.10.0-src.tar.gz)
-  set(teem_MD5 efe219575adc89f6470994154d86c05b)
+  if(NOT DEFINED git_protocol)
+      set(git_protocol "git")
+  endif()
+
+  set(teem_REPOSITORY ${git_protocol}://github.com/BRAINSia/teem.git)
+  set(teem_GIT_TAG 20150107_Slicer ) #Private version of teem on BRAINSia
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL ${teem_URL}
-    URL_MD5 ${teem_MD5}
-    DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}
-    SOURCE_DIR teem
-    BINARY_DIR teem-build
+    GIT_REPOSITORY ${teem_REPOSITORY}
+    GIT_TAG ${teem_GIT_TAG}
+    SOURCE_DIR ${proj}
+    BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       # Not needed -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}


### PR DESCRIPTION
@pieper @jcfr  This addresses isssues with building on 10.10 (Specifically Xcode 6).  Only 10.9 and 10.10 SDK's are available.  

The previous solutions were based on the now invalid assumption that QT would always be built agains libstd++.  As of QT 4.8.6 it is now possible to build against libc++.  The binaries from homebrew (for example) are defaulted to be built against libc++.  Additionally, if one builds QT from scratch on an Xcode 6 machine, it will default to be libc++ based build.

