### PR TITLE
ENH: add ability to refocus 3d cameras on a fiducial

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -31,6 +31,7 @@
 #include "vtkMRMLAnnotationTextDisplayNode.h"
 
 // MRML includes
+#include "vtkMRMLCameraNode.h"
 #include "vtkMRMLHierarchyNode.h"
 #include "vtkMRMLInteractionNode.h"
 #include "vtkMRMLScene.h"
@@ -561,7 +562,7 @@ void vtkSlicerMarkupsLogic::JumpSlicesToNthPointInMarkup(const char *id, int n, 
     }
   if (!this->GetMRMLScene())
     {
-    vtkErrorMacro("JumpSlicesToLocation: No scene defined");
+    vtkErrorMacro("JumpSlicesToNthPointInMarkup: No scene defined");
     return;
     }
   // get the markups node
@@ -577,6 +578,50 @@ void vtkSlicerMarkupsLogic::JumpSlicesToNthPointInMarkup(const char *id, int n, 
     // get the first point for now
     markup->GetMarkupPointWorld(n, 0, point);
     this->JumpSlicesToLocation(point[0], point[1], point[2], centered);
+    }
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerMarkupsLogic::FocusCamerasOnNthPointInMarkup(const char *id, int n)
+{
+  if (!id)
+    {
+    return;
+    }
+  if (!this->GetMRMLScene())
+    {
+    vtkErrorMacro("FocusCamerasOnNthPointInMarkup: No scene defined");
+    return;
+    }
+  // get the markups node
+  vtkMRMLNode *mrmlNode = this->GetMRMLScene()->GetNodeByID(id);
+  if (mrmlNode == NULL)
+    {
+    return;
+    }
+  vtkMRMLMarkupsNode *markup = vtkMRMLMarkupsNode::SafeDownCast(mrmlNode);
+  if (markup)
+    {
+    double point[4];
+    // get the first point for now
+    markup->GetMarkupPointWorld(n, 0, point);
+    // get all the cameras and reset focal points
+    std::vector<vtkMRMLNode *> cameraNodes;
+    this->GetMRMLScene()->GetNodesByClass("vtkMRMLCameraNode", cameraNodes);
+    vtkMRMLCameraNode *cameraNode;
+    vtkMRMLNode *node;
+    for (unsigned int i = 0; i < cameraNodes.size(); ++i)
+      {
+      node = cameraNodes[i];
+      if (node)
+        {
+        cameraNode = vtkMRMLCameraNode::SafeDownCast(node);
+        if (cameraNode)
+          {
+          cameraNode->SetFocalPoint(point[0], point[1], point[2]);
+          }
+        }
+      }
     }
 }
 

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -584,45 +584,71 @@ void vtkSlicerMarkupsLogic::JumpSlicesToNthPointInMarkup(const char *id, int n, 
 //---------------------------------------------------------------------------
 void vtkSlicerMarkupsLogic::FocusCamerasOnNthPointInMarkup(const char *id, int n)
 {
-  if (!id)
-    {
-    return;
-    }
+
   if (!this->GetMRMLScene())
     {
     vtkErrorMacro("FocusCamerasOnNthPointInMarkup: No scene defined");
     return;
     }
-  // get the markups node
-  vtkMRMLNode *mrmlNode = this->GetMRMLScene()->GetNodeByID(id);
-  if (mrmlNode == NULL)
+
+  std::vector<vtkMRMLNode *> cameraNodes;
+  this->GetMRMLScene()->GetNodesByClass("vtkMRMLCameraNode", cameraNodes);
+  vtkMRMLNode *node;
+  for (unsigned int i = 0; i < cameraNodes.size(); ++i)
+    {
+    node = cameraNodes[i];
+    if (node)
+      {
+      this->FocusCameraOnNthPointInMarkup(node->GetID(), id, n);
+      }
+    }
+}
+//---------------------------------------------------------------------------
+void vtkSlicerMarkupsLogic::FocusCameraOnNthPointInMarkup(const char *cameraNodeID, const char *markupNodeID, int n)
+{
+  if (!cameraNodeID || !markupNodeID)
     {
     return;
     }
-  vtkMRMLMarkupsNode *markup = vtkMRMLMarkupsNode::SafeDownCast(mrmlNode);
-  if (markup)
+  if (!this->GetMRMLScene())
     {
+    return;
+    }
+
+  // get the camera node
+  vtkMRMLNode *mrmlNode1 = this->GetMRMLScene()->GetNodeByID(cameraNodeID);
+  if (mrmlNode1 == NULL)
+    {
+    vtkErrorMacro("FocusCameraOnNthPointInMarkup: unable to find node with id " << markupNodeID);
+    return;
+    }
+  vtkMRMLCameraNode *cameraNode = vtkMRMLCameraNode::SafeDownCast(mrmlNode1);
+  if (!cameraNode)
+    {
+    vtkErrorMacro("FocusCameraOnNthPointInMarkup: unable to find camera with id " << markupNodeID);
+    return;
+    }
+
+  // get the markups node
+  vtkMRMLNode *mrmlNode2 = this->GetMRMLScene()->GetNodeByID(markupNodeID);
+  if (mrmlNode2 == NULL)
+    {
+    vtkErrorMacro("FocusCameraOnNthPointInMarkup: unable to find node with id " << markupNodeID);
+    return;
+    }
+  vtkMRMLMarkupsNode *markup = vtkMRMLMarkupsNode::SafeDownCast(mrmlNode2);
+  if (!markup)
+    {
+    vtkErrorMacro("FocusCameraOnNthPointInMarkup: unable to find markup with id " << markupNodeID);
+    return;
+    }
+
     double point[4];
     // get the first point for now
     markup->GetMarkupPointWorld(n, 0, point);
-    // get all the cameras and reset focal points
-    std::vector<vtkMRMLNode *> cameraNodes;
-    this->GetMRMLScene()->GetNodesByClass("vtkMRMLCameraNode", cameraNodes);
-    vtkMRMLCameraNode *cameraNode;
-    vtkMRMLNode *node;
-    for (unsigned int i = 0; i < cameraNodes.size(); ++i)
-      {
-      node = cameraNodes[i];
-      if (node)
-        {
-        cameraNode = vtkMRMLCameraNode::SafeDownCast(node);
-        if (cameraNode)
-          {
-          cameraNode->SetFocalPoint(point[0], point[1], point[2]);
-          }
-        }
-      }
-    }
+
+    // and focus the camera there
+    cameraNode->SetFocalPoint(point[0], point[1], point[2]);
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -92,6 +92,8 @@ public:
   void JumpSlicesToLocation(double x, double y, double z, bool centered);
   /// jump the slice windows to the nth markup with the mrml id id
   void JumpSlicesToNthPointInMarkup(const char *id, int n, bool centered = false);
+  /// refocus all of the 3D cameras to the nth markup with the mrml id id
+  void FocusCamerasOnNthPointInMarkup(const char *id, int n);
 
   /// Load a markups fiducial list from fileName, return NULL on error, node ID string
   /// otherwise. Adds the appropriate storage and display nodes to the scene

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -93,7 +93,12 @@ public:
   /// jump the slice windows to the nth markup with the mrml id id
   void JumpSlicesToNthPointInMarkup(const char *id, int n, bool centered = false);
   /// refocus all of the 3D cameras to the nth markup with the mrml id id
+  /// \sa FocusCameraOnNthPointInMarkup
   void FocusCamerasOnNthPointInMarkup(const char *id, int n);
+  /// refocus the camera with the given cameraNodeID on the nth markup in
+  /// the markups node with id markupNodeID
+  /// \sa FocusCamerasOnNthPointInMarkup
+  void FocusCameraOnNthPointInMarkup(const char *cameraNodeID, const char *markupNodeID, int n);
 
   /// Load a markups fiducial list from fileName, return NULL on error, node ID string
   /// otherwise. Adds the appropriate storage and display nodes to the scene

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
@@ -332,7 +332,7 @@ class MarkupsInViewsSelfTestLogic:
 
     # jump to the last fiducial
     slicer.modules.markups.logic().JumpSlicesToNthPointInMarkup(fidNode.GetID(), index, 1)
-    # refocus the camera in 3d as well
+    # refocus the 3D cameras as well
     slicer.modules.markups.logic().FocusCamerasOnNthPointInMarkup(fidNode.GetID(), index)
 
     # show only in red

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
@@ -332,6 +332,8 @@ class MarkupsInViewsSelfTestLogic:
 
     # jump to the last fiducial
     slicer.modules.markups.logic().JumpSlicesToNthPointInMarkup(fidNode.GetID(), index, 1)
+    # refocus the camera in 3d as well
+    slicer.modules.markups.logic().FocusCamerasOnNthPointInMarkup(fidNode.GetID(), index)
 
     # show only in red
     displayNode.AddViewNodeID('vtkMRMLSliceNodeRed')

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -2307,6 +2307,13 @@ void qSlicerMarkupsModuleWidget::onRightClickActiveMarkupTableWidget(QPoint pos)
   QObject::connect(jumpSlicesAction, SIGNAL(triggered()),
                    this, SLOT(onJumpSlicesActionTriggered()));
 
+  // Refocus 3D cameras
+  QAction *refocusCamerasAction =
+    new QAction(QString("Refocus all cameras"), &menu);
+  menu.addAction(refocusCamerasAction);
+  QObject::connect(refocusCamerasAction, SIGNAL(triggered()),
+                   this, SLOT(onRefocusCamerasActionTriggered()));
+
   // If there's another list in the scene
   if (this->mrmlScene()->GetNumberOfNodesByClass("vtkMRMLMarkupsNode") > 1)
     {
@@ -2467,6 +2474,35 @@ void qSlicerMarkupsModuleWidget::onJumpSlicesActionTriggered()
     {
     // use the first selected
     this->markupsLogic()->JumpSlicesToNthPointInMarkup(mrmlNode->GetID(), selectedItems.at(0)->row(), jumpCentered);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMarkupsModuleWidget::onRefocusCamerasActionTriggered()
+{
+ Q_D(qSlicerMarkupsModuleWidget);
+
+  // get the selected rows
+  QList<QTableWidgetItem *> selectedItems = d->activeMarkupTableWidget->selectedItems();
+
+  // first, check if nothing is selected
+  if (selectedItems.isEmpty())
+    {
+    return;
+    }
+
+  // get the active node
+  vtkMRMLNode *mrmlNode = d->activeMarkupMRMLNodeComboBox->currentNode();
+  if (!mrmlNode)
+    {
+    return;
+    }
+
+  // refocus on this point
+  if (this->markupsLogic())
+    {
+    // use the first selected
+    this->markupsLogic()->FocusCamerasOnNthPointInMarkup(mrmlNode->GetID(), selectedItems.at(0)->row());
     }
 }
 

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
@@ -189,6 +189,9 @@ public slots:
   void addSelectedCoordinatesToMenu(QMenu *menu);
   /// Jump slices action slot
   void onJumpSlicesActionTriggered();
+  /// Refocus cameras action slot
+  void onRefocusCamerasActionTriggered();
+
   /// Build a string list of the names of other nodes with the same
   /// class name as thisMarkup. Return an empty string list if no other
   /// markups in the scene


### PR DESCRIPTION
Added a right click context menu option to refocus the 3D camera to the
first selected fiducal. This can help localise the fiducial in a large scene.
Added logic method to get all camera nodes and set the focal point on them.
Added the call to a self test.

Issue #3683