### PR TITLE
BUG: Don't explicitly set the OSX_DEPLOYMENT_TARGET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ include(ExternalProjectDependency)
 #-----------------------------------------------------------------------------
 if(APPLE)
   # Note: By setting CMAKE_OSX_* variables before any enable_language() or project() calls,
-  #       we ensure that the bitness will be properly detected.
+  #       we ensure that the bitness, and C++ standard library will be properly detected.
   include(SlicerBlockSetCMakeOSXVariables)
   mark_as_superbuild(
     VARS CMAKE_OSX_ARCHITECTURES:STRING CMAKE_OSX_SYSROOT:PATH CMAKE_OSX_DEPLOYMENT_TARGET:STRING


### PR DESCRIPTION
Setting the OSX_DEPLOYMENT_TARGET implicitly controls which C++
standard library is used libstdc++ vs libc++. Mixing the two in
binaries can result in unstable behavior.

We now implicitly configure the OSX_SYSROOT to the latest SDK, but
require the user to explicitly set the OSX_DEPLOYMENT_TARGET to ensure
compatibility with the build environment.

Co-authored-by: Hans Johnson <hans-johnson@uiowa.edu>