### PR TITLE
ENH: Deprecate ::Zero and ::One

### DIFF
--- a/Base/CLI/Testing/itkTestMain.h
+++ b/Base/CLI/Testing/itkTestMain.h
@@ -316,7 +316,7 @@ int RegressionTestImage(const char *testImageFilename,
   diff->SetToleranceRadius(radiusTolerance);
   diff->UpdateLargestPossibleRegion();
 
-  itk::SizeValueType status = itk::NumericTraits<itk::SizeValueType>::Zero;
+  itk::SizeValueType status = itk::NumericTraits<itk::SizeValueType>::ZeroValue();
   status = diff->GetNumberOfPixelsWithDifferences();
 
   // if there are discrepencies, create an diff image

--- a/Libs/vtkITK/itkLevelTracingImageFilter.txx
+++ b/Libs/vtkITK/itkLevelTracingImageFilter.txx
@@ -284,7 +284,7 @@ LevelTracingImageFilter<TInputImage,TOutputImage>
   OutputImageRegionType regionOut =  outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion( regionOut );
   outputImage->Allocate();
-  outputImage->FillBuffer ( NumericTraits<OutputImagePixelType>::Zero );
+  outputImage->FillBuffer ( NumericTraits<OutputImagePixelType>::ZeroValue() );
 
   outputPath->Initialize();
 
@@ -397,7 +397,7 @@ LevelTracingImageFilter<TInputImage,TOutputImage>
 
   // Now we have the seed and the starting neighbor
   outputPath->SetStart(seed);
-  outputImage->SetPixel(pix, NumericTraits<OutputImagePixelType>::One);
+  outputImage->SetPixel(pix, NumericTraits<OutputImagePixelType>::OneValue());
   do
     {
     for(int s = 0; s<8; s++)
@@ -413,7 +413,7 @@ LevelTracingImageFilter<TInputImage,TOutputImage>
           {
           //condition is satisfied, label the output image and output path
           outputImage->SetPixel(pixTemp,
-                                NumericTraits<OutputImagePixelType>::One);
+                                NumericTraits<OutputImagePixelType>::OneValue());
           offset[0]=offsetX;
           offset[1]=offsetY;
           outputPath->InsertStep(noOfPixels, offset);
@@ -459,7 +459,7 @@ LevelTracingImageFilter<TInputImage,TOutputImage>
   OutputImageRegionType region =  outputImage->GetRequestedRegion();
   outputImage->SetBufferedRegion( region );
   outputImage->Allocate();
-  outputImage->FillBuffer ( NumericTraits<OutputImagePixelType>::Zero );
+  outputImage->FillBuffer ( NumericTraits<OutputImagePixelType>::ZeroValue() );
 
   typedef LevelTracingImageFunction<InputImageType, double> FunctionType;
   typedef FloodFilledImageFunctionConditionalIterator<OutputImageType, FunctionType> IteratorType;
@@ -475,7 +475,7 @@ LevelTracingImageFilter<TInputImage,TOutputImage>
 
   while( !it.IsAtEnd())
     {
-    it.Set(NumericTraits<OutputImagePixelType>::One);
+    it.Set(NumericTraits<OutputImagePixelType>::OneValue());
     ++it;
     progress.CompletedPixel();  // potential exception thrown here
     }

--- a/Libs/vtkITK/itkNewOtsuThresholdImageCalculator.txx
+++ b/Libs/vtkITK/itkNewOtsuThresholdImageCalculator.txx
@@ -34,7 +34,7 @@ NewOtsuThresholdImageCalculator<TInputImage>
 ::NewOtsuThresholdImageCalculator()
 {
   m_Image = NULL;
-  m_Threshold = NumericTraits<PixelType>::Zero;
+  m_Threshold = NumericTraits<PixelType>::ZeroValue();
   m_NumberOfHistogramBins = 128;
   m_Omega = 2;
 }

--- a/Libs/vtkITK/itkNewOtsuThresholdImageFilter.h
+++ b/Libs/vtkITK/itkNewOtsuThresholdImageFilter.h
@@ -78,7 +78,7 @@ public:
                       TOutputImage::ImageDimension ) ;
 
   /** Set the "outside" pixel value. The default value
-   * NumericTraits<OutputPixelType>::Zero. */
+   * NumericTraits<OutputPixelType>::ZeroValue(). */
   itkSetMacro(OutsideValue,OutputPixelType);
 
   /** Get the "outside" pixel value. */

--- a/Libs/vtkITK/itkNewOtsuThresholdImageFilter.txx
+++ b/Libs/vtkITK/itkNewOtsuThresholdImageFilter.txx
@@ -28,9 +28,9 @@ template<class TInputImage, class TOutputImage>
 NewOtsuThresholdImageFilter<TInputImage, TOutputImage>
 ::NewOtsuThresholdImageFilter()
 {
-  m_OutsideValue   = NumericTraits<OutputPixelType>::Zero;
+  m_OutsideValue   = NumericTraits<OutputPixelType>::ZeroValue();
   m_InsideValue    = NumericTraits<OutputPixelType>::max();
-  m_Threshold      = NumericTraits<InputPixelType>::Zero;
+  m_Threshold      = NumericTraits<InputPixelType>::ZeroValue();
   m_NumberOfHistogramBins = 128;
   m_Omega = 2;
 }

--- a/Libs/vtkITK/vtkITKNumericTraits.cxx
+++ b/Libs/vtkITK/vtkITKNumericTraits.cxx
@@ -3,11 +3,11 @@ namespace itk
 {
 
 #if defined(VTK_TYPE_USE___INT64)
-const __int64 NumericTraits<__int64>::Zero = 0;
-const __int64 NumericTraits<__int64>::One = 1;
+const __int64 NumericTraits<__int64>::ZeroValue() = 0;
+const __int64 NumericTraits<__int64>::OneValue() = 1;
 
-const unsigned __int64 NumericTraits<unsigned __int64>::Zero = 0ui64;
-const unsigned __int64 NumericTraits<unsigned __int64>::One = 1ui64;
+const unsigned __int64 NumericTraits<unsigned __int64>::ZeroValue() = 0ui64;
+const unsigned __int64 NumericTraits<unsigned __int64>::OneValue() = 1ui64;
 #endif
 
 };

--- a/Modules/CLI/DWIJointRicianLMMSEFilter/itkLMMSEVectorImageFilter.txx
+++ b/Modules/CLI/DWIJointRicianLMMSEFilter/itkLMMSEVectorImageFilter.txx
@@ -66,7 +66,7 @@ void LMMSEVectorImageFilter<TInputImage, TOutputImage>
     for( unsigned int k = 0; k < m_NDWI; ++k )       // Compare to each other gradient direction
       {
       orderElement[0] = (double)k;
-      orderElement[1] = itk::NumericTraits<double>::Zero;
+      orderElement[1] = itk::NumericTraits<double>::ZeroValue();
       for( unsigned int d = 0; d < TInputImage::ImageDimension; ++d ) // Sum of squared differences (euclidean norm)
         {
         orderElement[1] += ( m_GradientList[g][d] * m_GradientList[k][d] );
@@ -185,7 +185,7 @@ void LMMSEVectorImageFilter<TInputImage, TOutputImage>
         }
       // -----------------------------------------------------------------------------------------------------------------------
       // With this implementation, we only need to estimate the fourth order moment for the baseline images
-      dFourthAveragedMoment = itk::NumericTraits<double>::Zero;
+      dFourthAveragedMoment = itk::NumericTraits<double>::ZeroValue();
       voxelsUsedFor4Moment = 0;
       // -----------------------------------------------------------------------------------------------------------------------
       // Compute the sample statistics as the sum over the neighbourhood:
@@ -252,7 +252,7 @@ void LMMSEVectorImageFilter<TInputImage, TOutputImage>
           dSecondAveragedMoment[iJ] = 100000 * std::numeric_limits<double>::epsilon();
           }
         }
-      double aux4 = itk::NumericTraits<double>::Zero;
+      double aux4 = itk::NumericTraits<double>::ZeroValue();
       for( unsigned int k = 0; k < m_NBaselines; ++k )
         {
         aux4 += dSecondAveragedMoment[m_Baselines[k]];
@@ -270,7 +270,7 @@ void LMMSEVectorImageFilter<TInputImage, TOutputImage>
       const float        CFACT1          = 5.0f;
       //    -Initiallisation:
       OutputPixelType outPixel  = dMagnitude;
-      double          normal    = itk::NumericTraits<double>::Zero;
+      double          normal    = itk::NumericTraits<double>::ZeroValue();
       for( unsigned int k = 0; k < m_NBaselines; ++k )
         {
         normal += dSecondAveragedMoment[m_Baselines[k]];
@@ -330,7 +330,7 @@ void LMMSEVectorImageFilter<TInputImage, TOutputImage>
             }
           //    - Product with C_A2M2
           //          Scalar product with the vector of second order moments:
-          double dp = itk::NumericTraits<double>::Zero;
+          double dp = itk::NumericTraits<double>::ZeroValue();
           for( unsigned int iJ = 0; iJ < m_NBaselines; ++iJ )
             {
             dp += bRes[iJ] * bSqAvg[iJ];
@@ -375,7 +375,7 @@ void LMMSEVectorImageFilter<TInputImage, TOutputImage>
               }
             //    - Product with C_A2M2
             //          Scalar product with the vector of second order moments:
-            dp = itk::NumericTraits<double>::Zero;
+            dp = itk::NumericTraits<double>::ZeroValue();
             for( unsigned int iJ = 0; iJ < m_Neighbours; ++iJ )
               {
               dp += dRes[iJ] * dSqAvg[iJ];
@@ -487,7 +487,7 @@ void LMMSEVectorImageFilter<TInputImage, TOutput>
     whitened[0] = measures[0] / aux;
     return;
     }
-  normal     = itk::NumericTraits<double>::One / normal; // For convenience
+  normal     = itk::NumericTraits<double>::OneValue() / normal; // For convenience
   double aux = 4.0f * m_Sigma * m_Sigma * normal;
   // The terms in the inverse matrix:
   double  Ad = aux;
@@ -495,9 +495,9 @@ void LMMSEVectorImageFilter<TInputImage, TOutput>
   for( unsigned int k = 0; k < K; ++k )
     {
     Ad   += squaredAverages[k];
-    Ai[k] = itk::NumericTraits<double>::One / ( aux * squaredAverages[k] );
+    Ai[k] = itk::NumericTraits<double>::OneValue() / ( aux * squaredAverages[k] );
     }
-  Ad     = -itk::NumericTraits<double>::One / ( aux * Ad );
+  Ad     = -itk::NumericTraits<double>::OneValue() / ( aux * Ad );
   // Now, recursively process the output; initiallise w_0 = x
   for( unsigned int k = 0; k < K; ++k )
     {
@@ -508,7 +508,7 @@ void LMMSEVectorImageFilter<TInputImage, TOutput>
   // Iterate: w_{n+1} = x - D^{-1}w_n
   for( unsigned int o = 0; o < order; ++o )        // If order=0, this loop does nothing!
     { // Compute A_d*w
-    cum = itk::NumericTraits<double>::Zero;  // Initiallise acumulator
+    cum = itk::NumericTraits<double>::ZeroValue();  // Initiallise acumulator
     for( unsigned int k = 0; k < K; ++k )
       {
       cum += whitened[k];
@@ -523,7 +523,7 @@ void LMMSEVectorImageFilter<TInputImage, TOutput>
   // Now we have the truncated series of ( Id + D^(-1) )^(-1). It remains to
   // multiplicate by D^(-1):
   // Compute A_d*w
-  cum = itk::NumericTraits<double>::Zero; // Initiallise acumulator
+  cum = itk::NumericTraits<double>::ZeroValue(); // Initiallise acumulator
   for( unsigned int k = 0; k < K; ++k )
     {
     cum += whitened[k];
@@ -615,7 +615,7 @@ bool LMMSEVectorImageFilter<TInputImage, TOutput>
       }
     // At this point, we have a valid (col,col), element. We scale the whole
     // corresponding col-th row so that the pivoting element is simply 1:
-    double scale = itk::NumericTraits<double>::One / matrix[col][col];
+    double scale = itk::NumericTraits<double>::OneValue() / matrix[col][col];
     for( unsigned int cc = col; cc < K; ++cc )
       {
       matrix[col][cc]  *= scale;

--- a/Modules/CLI/DWIJointRicianLMMSEFilter/itkOtsuStatistics.txx
+++ b/Modules/CLI/DWIJointRicianLMMSEFilter/itkOtsuStatistics.txx
@@ -124,7 +124,7 @@ void OtsuStatistics<TInputImage, TOutputImage>
     for( bit.GoToBegin(), it.GoToBegin(); !bit.IsAtEnd(); ++bit, ++it )    // Iterate through pixels in the current
                                                                            // facet
       { // Depending on the mode of operation, take the center pixel or the whole vicinity:
-      double averagedValue = itk::NumericTraits<float>::Zero;
+      double averagedValue = itk::NumericTraits<float>::ZeroValue();
 
       switch( m_Mode )
         {

--- a/Modules/CLI/DWIJointRicianLMMSEFilter/itkOtsuThreshold.txx
+++ b/Modules/CLI/DWIJointRicianLMMSEFilter/itkOtsuThreshold.txx
@@ -69,7 +69,7 @@ template <class TInputImage, class TOutputImage>
 void OtsuThreshold<TInputImage, TOutputImage>
 ::AfterThreadedGenerateData( void )
 {
-  double totalSamples = itk::NumericTraits<double>::Zero;
+  double totalSamples = itk::NumericTraits<double>::ZeroValue();
 
   for( unsigned int k = 0; k < (unsigned int)(this->GetNumberOfThreads()); ++k )
     {
@@ -82,7 +82,7 @@ void OtsuThreshold<TInputImage, TOutputImage>
       m_ThreadHist[0][b] += m_ThreadHist[k][b];
       }
     }
-  double totalMean = itk::NumericTraits<double>::Zero;
+  double totalMean = itk::NumericTraits<double>::ZeroValue();
   for( unsigned int b = 0; b < m_Bins; ++b )
     {
     m_ThreadHist[0][b] /= totalSamples;

--- a/Modules/CLI/DWIRicianLMMSEFilter/itkComputeStatisticsWherePositiveFilter.txx
+++ b/Modules/CLI/DWIRicianLMMSEFilter/itkComputeStatisticsWherePositiveFilter.txx
@@ -77,8 +77,8 @@ void ComputeStatisticsWherePositiveFilter<TInputImage, TOutputImage>
   m_TMin.SetSize( k );
   m_TMax.SetSize( k );
   m_TCount.SetSize( k );
-  m_TMean.Fill( itk::NumericTraits<double>::Zero );
-  m_TStd.Fill( itk::NumericTraits<double>::Zero );
+  m_TMean.Fill( itk::NumericTraits<double>::ZeroValue() );
+  m_TStd.Fill( itk::NumericTraits<double>::ZeroValue() );
   m_TMin.Fill( itk::NumericTraits<double>::max() );
   m_TMax.Fill( itk::NumericTraits<double>::min() );
   m_TCount.Fill( 0 );
@@ -90,8 +90,8 @@ void ComputeStatisticsWherePositiveFilter<TInputImage, TOutputImage>
 {
   unsigned int k = this->GetNumberOfThreads();
 
-  m_Mean = itk::NumericTraits<double>::Zero;
-  m_Std  = itk::NumericTraits<double>::Zero;
+  m_Mean = itk::NumericTraits<double>::ZeroValue();
+  m_Std  = itk::NumericTraits<double>::ZeroValue();
   m_Min  = itk::NumericTraits<double>::max();
   m_Max  = itk::NumericTraits<double>::min();
   unsigned long count = 0;
@@ -120,7 +120,7 @@ void ComputeStatisticsWherePositiveFilter<TInputImage, TOutputImage>
       }
     else
       {
-      m_Std = itk::NumericTraits<double>::Zero;
+      m_Std = itk::NumericTraits<double>::ZeroValue();
       }
     m_Ready = true;
     }

--- a/Modules/CLI/DWIRicianLMMSEFilter/itkMaskedMeanImageFilter.txx
+++ b/Modules/CLI/DWIRicianLMMSEFilter/itkMaskedMeanImageFilter.txx
@@ -104,7 +104,7 @@ void MaskedMeanImageFilter<TInputImage, TOutputImage>
     for( bit.GoToBegin(), it.GoToBegin(); !bit.IsAtEnd(); ++bit, ++it )
       {
       int iNumberOfUsedVoxels = 0;
-      sum = NumericTraits<InputRealType>::Zero;
+      sum = NumericTraits<InputRealType>::ZeroValue();
       for( i = 0; i < neighborhoodSize; ++i )
         {
         if( bit.GetPixel(i) > 0 )

--- a/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkOtsuStatistics.txx
+++ b/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkOtsuStatistics.txx
@@ -124,7 +124,7 @@ void OtsuStatistics<TInputImage, TOutputImage>
     for( bit.GoToBegin(), it.GoToBegin(); !bit.IsAtEnd(); ++bit, ++it )    // Iterate through pixels in the current
                                                                            // facet
       { // Depending on the mode of operation, take the center pixel or the whole vicinity:
-      double averagedValue = itk::NumericTraits<float>::Zero;
+      double averagedValue = itk::NumericTraits<float>::ZeroValue();
 
       switch( m_Mode )
         {

--- a/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkOtsuThreshold.txx
+++ b/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkOtsuThreshold.txx
@@ -69,7 +69,7 @@ template <class TInputImage, class TOutputImage>
 void OtsuThreshold<TInputImage, TOutputImage>
 ::AfterThreadedGenerateData( void )
 {
-  double totalSamples = itk::NumericTraits<double>::Zero;
+  double totalSamples = itk::NumericTraits<double>::ZeroValue();
 
   for( unsigned int k = 0; k < (unsigned int)(this->GetNumberOfThreads()); ++k )
     {
@@ -82,7 +82,7 @@ void OtsuThreshold<TInputImage, TOutputImage>
       m_ThreadHist[0][b] += m_ThreadHist[k][b];
       }
     }
-  double totalMean = itk::NumericTraits<double>::Zero;
+  double totalMean = itk::NumericTraits<double>::ZeroValue();
   for( unsigned int b = 0; b < m_Bins; ++b )
     {
     m_ThreadHist[0][b] /= totalSamples;

--- a/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkUNLMFilter.txx
+++ b/Modules/CLI/DWIUnbiasedNonLocalMeansFilter/itkUNLMFilter.txx
@@ -70,7 +70,7 @@ void UNLMFilter<TInputImage, TOutputImage>
     for( unsigned int k = 0; k < m_NDWI; ++k )       // Compare to each other gradient direction
       {
       orderElement[0] = (double)k;
-      orderElement[1] = itk::NumericTraits<double>::Zero;
+      orderElement[1] = itk::NumericTraits<double>::ZeroValue();
       for( unsigned int d = 0; d < TInputImage::ImageDimension; ++d ) // Sum of squared differences (euclidean norm)
         {
         orderElement[1] += ( m_GradientList[g][d] * m_GradientList[k][d] );
@@ -169,13 +169,13 @@ void UNLMFilter<TInputImage, TOutputImage>
                                                                                                outputRegionForThread  );
   unsigned int neighborhoodSize = test.Size();
   float*       gw = new float[neighborhoodSize];      // The window itself
-  float        sum = itk::NumericTraits<float>::Zero; // To normalize the window to sum to 1
+  float        sum = itk::NumericTraits<float>::ZeroValue(); // To normalize the window to sum to 1
   for( unsigned int k = 0; k < neighborhoodSize; ++k )
     {
     if( k != neighborhoodSize / 2 )   // Not the center of the neighbourhhod
       {
       typename ConstNeighborhoodIterator<InputImageType>::OffsetType idx = test.GetOffset(k);
-      gw[k] = itk::NumericTraits<float>::Zero;
+      gw[k] = itk::NumericTraits<float>::ZeroValue();
       for( unsigned int d = 0; d < InputImageType::ImageDimension; ++d )
         {
         gw[k] += static_cast<float>( idx[d] * idx[d] );
@@ -277,7 +277,7 @@ void UNLMFilter<TInputImage, TOutputImage>
           {
           if( pos != midPosition )
             {
-            distB[pos] = itk::NumericTraits<float>::Zero;
+            distB[pos] = itk::NumericTraits<float>::ZeroValue();
             for( unsigned int k = 0; k < neighborhoodSize; ++k )  // For each pixel in the comparison neighbourhood
               {
               float aux   = bit.GetPixel(k)[m_Baselines[j]] - search.GetPixel(k)[m_Baselines[j]];
@@ -303,14 +303,14 @@ void UNLMFilter<TInputImage, TOutputImage>
           distB[midPosition] = 1.0f;
           norm = 1.0f / (1.0f + norm);
           }
-        float value = itk::NumericTraits<float>::Zero;
+        float value = itk::NumericTraits<float>::ZeroValue();
         for( unsigned int k = 0; k < pos; ++k )
           {
           value += distB[k] * valsB[k] * norm;
           }
         // Remove Rician bias:
         value -= 2.0f * m_Sigma * m_Sigma;
-        value = ( value > 1e-10 ? ::sqrt(value) : itk::NumericTraits<float>::Zero );
+        value = ( value > 1e-10 ? ::sqrt(value) : itk::NumericTraits<float>::ZeroValue() );
         op[m_Baselines[j]] = static_cast<ScalarType>(value);
         }
       // -------------------------------------------------------------------------------------------------------------
@@ -325,7 +325,7 @@ void UNLMFilter<TInputImage, TOutputImage>
           { // First, we process the gradients in the same direction as the one being processed:
           if( pos != midPosition )
             {
-            distD[pos] = itk::NumericTraits<float>::Zero;
+            distD[pos] = itk::NumericTraits<float>::ZeroValue();
             for( unsigned int k = 0; k < neighborhoodSize; ++k )  // For each pixel in the comparison neighbourhood
               {
               float aux = bit.GetPixel(k)[m_DWI[j]] - search.GetPixel(k)[m_DWI[j]];
@@ -342,7 +342,7 @@ void UNLMFilter<TInputImage, TOutputImage>
           // Now, we may process the gradient directions similar to the direction under study
           for( unsigned int g = 1; g < m_Neighbours; ++g )
             {
-            distD[pos + g * numNeighbours] = itk::NumericTraits<float>::Zero;
+            distD[pos + g * numNeighbours] = itk::NumericTraits<float>::ZeroValue();
             for( unsigned int k = 0; k < neighborhoodSize; ++k )  // For each pixel in the comparison neighbourhood
               {
               float aux = bit.GetPixel(k)[m_DWI[j]] - search.GetPixel(k)[m_NeighboursInd[j][g]];
@@ -369,7 +369,7 @@ void UNLMFilter<TInputImage, TOutputImage>
           distD[midPosition] = 1;
           norm = 1.0f / (1 + norm);
           }
-        float value = itk::NumericTraits<float>::Zero;
+        float value = itk::NumericTraits<float>::ZeroValue();
         for( unsigned int k = 0; k < pos; ++k )
           {
           for( unsigned int l = 0; l < m_Neighbours; ++l )
@@ -379,7 +379,7 @@ void UNLMFilter<TInputImage, TOutputImage>
           }
         // Remove Rician bias:
         value -= 2.0f * m_Sigma * m_Sigma;
-        value = ( value > 1e-10 ? ::sqrt(value) : itk::NumericTraits<float>::Zero );
+        value = ( value > 1e-10 ? ::sqrt(value) : itk::NumericTraits<float>::ZeroValue() );
         op[m_DWI[j]] = static_cast<ScalarType>(value);;
         }
       // -------------------------------------------------------------------------------------------------------------

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.txx
@@ -55,13 +55,13 @@ ImageRegionMomentsCalculator<TImage>::ImageRegionMomentsCalculator(void)
   m_Valid = false;
   m_Image = NULL;
   m_SpatialObjectMask = NULL;
-  m_M0 = NumericTraits<ScalarType>::Zero;
-  m_M1.Fill(NumericTraits<typename VectorType::ValueType>::Zero);
-  m_M2.Fill(NumericTraits<typename MatrixType::ValueType>::Zero);
-  m_Cg.Fill(NumericTraits<typename VectorType::ValueType>::Zero);
-  m_Cm.Fill(NumericTraits<typename MatrixType::ValueType>::Zero);
-  m_Pm.Fill(NumericTraits<typename VectorType::ValueType>::Zero);
-  m_Pa.Fill(NumericTraits<typename MatrixType::ValueType>::Zero);
+  m_M0 = NumericTraits<ScalarType>::ZeroValue();
+  m_M1.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
+  m_M2.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
+  m_Cg.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
+  m_Cm.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
+  m_Pm.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
+  m_Pa.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
   m_UseRegionOfInterest = false;
   m_RegionOfInterestPoint1.Fill(0);
   m_RegionOfInterestPoint2.Fill(0);
@@ -101,11 +101,11 @@ template <class TImage>
 void
 ImageRegionMomentsCalculator<TImage>::Compute()
 {
-  m_M0 = NumericTraits<ScalarType>::Zero;
-  m_M1.Fill(NumericTraits<typename VectorType::ValueType>::Zero);
-  m_M2.Fill(NumericTraits<typename MatrixType::ValueType>::Zero);
-  m_Cg.Fill(NumericTraits<typename VectorType::ValueType>::Zero);
-  m_Cm.Fill(NumericTraits<typename MatrixType::ValueType>::Zero);
+  m_M0 = NumericTraits<ScalarType>::ZeroValue();
+  m_M1.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
+  m_M2.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
+  m_Cg.Fill(NumericTraits<typename VectorType::ValueType>::ZeroValue());
+  m_Cm.Fill(NumericTraits<typename MatrixType::ValueType>::ZeroValue());
 
   typedef typename ImageType::IndexType IndexType;
 

--- a/Modules/CLI/N4ITKBiasFieldCorrection/SlicerITKv3BSplineControlPointImageFilter.txx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/SlicerITKv3BSplineControlPointImageFilter.txx
@@ -689,9 +689,9 @@ BSplineControlPointImageFilter<InputImage, TOutputImage>
   vnl_vector<RealType> p( ImageDimension );
   for( unsigned int i = 0; i < ImageDimension; i++ )
     {
-    if( params[i] == NumericTraits<RealType>::One )
+    if( params[i] == NumericTraits<RealType>::OneValue() )
       {
-      params[i] = NumericTraits<RealType>::One - this->m_BSplineEpsilon;
+      params[i] = NumericTraits<RealType>::OneValue() - this->m_BSplineEpsilon;
       }
     if( params[i] < 0.0 || params[i] >= 1.0 )
       {

--- a/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
+++ b/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
@@ -37,14 +37,14 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
   this->SetNumberOfRequiredInputs(2);
 
   // Set the default DifferenceThreshold.
-  m_DifferenceThreshold = NumericTraits<OutputPixelType>::Zero;
+  m_DifferenceThreshold = NumericTraits<OutputPixelType>::ZeroValue();
 
   // Set the default ToleranceRadius.
   m_ToleranceRadius = 0;
 
   // Initialize statistics about difference image.
-  m_MeanDifference = NumericTraits<RealType>::Zero;
-  m_TotalDifference = NumericTraits<AccumulateType>::Zero;
+  m_MeanDifference = NumericTraits<RealType>::ZeroValue();
+  m_TotalDifference = NumericTraits<AccumulateType>::ZeroValue();
   m_NumberOfPixelsWithDifferences = 0;
   m_IgnoreBoundaryPixels = false;
   measurementFrameValid.SetIdentity();
@@ -127,8 +127,8 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
   int numberOfThreads = this->GetNumberOfThreads();
 
   // Initialize statistics about difference image.
-  m_MeanDifference = NumericTraits<RealType>::Zero;
-  m_TotalDifference = NumericTraits<AccumulateType>::Zero;
+  m_MeanDifference = NumericTraits<RealType>::ZeroValue();
+  m_TotalDifference = NumericTraits<AccumulateType>::ZeroValue();
   m_NumberOfPixelsWithDifferences = 0;
 
   // Resize the thread temporaries
@@ -136,7 +136,7 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
   m_ThreadNumberOfPixels.SetSize(numberOfThreads);
 
   // Initialize the temporaries
-  m_ThreadDifferenceSum.Fill(NumericTraits<AccumulateType>::Zero);
+  m_ThreadDifferenceSum.Fill(NumericTraits<AccumulateType>::ZeroValue());
   m_ThreadNumberOfPixels.Fill(0);
 
   measurementFrameValid = GetMetaDataDictionary( this->GetInput(0) );
@@ -232,7 +232,7 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
         //  Assume a good match - so test center pixel first, for speed
         typename InputPixelType::Iterator it;
         typename InputPixelType::Iterator ittest;
-        RealType       sumdifference = NumericTraits<RealType>::Zero;
+        RealType       sumdifference = NumericTraits<RealType>::ZeroValue();
         InputPixelType centerTensor = ApplyMeasurementFrameToTensor( test.GetCenterPixel(), measurementFrameTest );
         for( it = t.Begin(), ittest = centerTensor.Begin(); it != t.End(); ++it, ++ittest )
           {
@@ -254,7 +254,7 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
             {
             // Use the RealType for the difference to make sure we get the
             // sign.
-            sumdifference = NumericTraits<RealType>::Zero;
+            sumdifference = NumericTraits<RealType>::ZeroValue();
             InputPixelType tensor = ApplyMeasurementFrameToTensor( test.GetPixel(i), measurementFrameTest );
             for( it = t.Begin(), ittest = tensor.Begin(); it != t.End(); ++it, ++ittest )
               {
@@ -290,7 +290,7 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
         else
           {
           // Difference is below threshold.
-          out.Set(NumericTraits<OutputPixelType>::Zero);
+          out.Set(NumericTraits<OutputPixelType>::ZeroValue());
           }
 
         // Update progress.
@@ -301,7 +301,7 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
       {
       for( out.GoToBegin(); !out.IsAtEnd(); ++out )
         {
-        out.Set(NumericTraits<OutputPixelType>::Zero);
+        out.Set(NumericTraits<OutputPixelType>::ZeroValue());
         progress.CompletedPixel();
         }
       }

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DFSAffineTransform.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DFSAffineTransform.txx
@@ -31,7 +31,7 @@ DiffusionTensor3DFSAffineTransform<TData>
   vnl_real_eigensystem             eig( M );
   vnl_matrix<vcl_complex<double> > D( 3, 3 );
   vnl_matrix<vcl_complex<double> > vnl_sqrMatrix( 3, 3 );
-  D.fill( NumericTraits<TData>::Zero );
+  D.fill( NumericTraits<TData>::ZeroValue() );
   for( int i = 0; i < 3; i++ )
     {
     D.put( i, i, vcl_pow( eig.D.get( i, i ), 0.5 ) );

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DMatrix3x3Transform.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DMatrix3x3Transform.txx
@@ -28,9 +28,9 @@ DiffusionTensor3DMatrix3x3Transform<TData>
   m_TransformT.SetIdentity();
   m_Lock = MutexLock::New();
   latestTime = 0;
-  m_Translation.Fill( NumericTraits<DataType>::Zero );
-  m_Offset.Fill( NumericTraits<DataType>::Zero );
-  m_Center.Fill( NumericTraits<DataType>::Zero );
+  m_Translation.Fill( NumericTraits<DataType>::ZeroValue() );
+  m_Offset.Fill( NumericTraits<DataType>::ZeroValue() );
+  m_Center.Fill( NumericTraits<DataType>::ZeroValue() );
 }
 
 template <class TData>


### PR DESCRIPTION
These were deprecated in 2012; just before the ITK 4.2 release.
ZeroValue() and OneValue() should be used instead.

-- This coforms to ITKv4 changes made in
    6c23e1daace315a40831cf255b2af57df5d3505c
    3f712cd09551e3c80d8beac8a7a097b8bfc73862

When building with clang on 10.9 where ITKv4 is a shared library,
a linking error occured for unfound symbols: NumericTraits<
OutputPixelType >::Zero but using the
NumericTraits< OutputPixelType >::ZeroValue() allows linkage to occur properly.