### PR TITLE
ENH: Update ITKv4, SimpleITK and Swig

### DIFF
--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -27,7 +27,7 @@ if(NOT DEFINED ITK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   endif()
 
   set(ITKv4_REPOSITORY ${git_protocol}://github.com/Slicer/ITK.git)
-  set(ITKv4_GIT_TAG f5e429abeba93b773ec52b8f012e16de338bcaaf) # slicer-v4.6.0-2014-09-19-554e46a
+  set(ITKv4_GIT_TAG 9a02d0eaa894637be7b684e6161f115d0d5b94d9) # slicer-v4.7.0
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -34,7 +34,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" PythonPacka
 ")
 
   set(SimpleITK_REPOSITORY ${git_protocol}://itk.org/SimpleITK.git)
-  set(SimpleITK_GIT_TAG f2241a13f6010cb6ea6da1b21c6f2d2e31641b16 ) # master branch 0.9.0.dev381
+  set(SimpleITK_GIT_TAG 57e6a5265ae45e535c9bb4887ca92cf95aa79cb9 ) # master 2015-01-06
 
   ExternalProject_add(SimpleITK
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -12,9 +12,9 @@ endif()
 
 if(NOT SWIG_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
-  set(SWIG_TARGET_VERSION 2.0.12)
-  set(SWIG_DOWNLOAD_SOURCE_HASH "c3fb0b2d710cc82ed0154b91e43085a4")
-  set(SWIG_DOWNLOAD_WIN_HASH "3cc7dd131a87972f70fca1490b9e6e6b")
+  set(SWIG_TARGET_VERSION 3.0.2)
+  set(SWIG_DOWNLOAD_SOURCE_HASH "62f9b0d010cef36a13a010dc530d0d41")
+  set(SWIG_DOWNLOAD_WIN_HASH "3f18de4fc09ab9abb0d3be37c11fbc8f")
 
   if(WIN32)
     # swig.exe available as pre-built binary on Windows:
@@ -28,7 +28,7 @@ if(NOT SWIG_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       UPDATE_COMMAND ""
       )
 
-    set(SWIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/swigwin-${SWIG_TARGET_VERSION}") # ??
+    set(SWIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/swigwin-${SWIG_TARGET_VERSION}") # path specified as source in ep
     set(SWIG_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}/swigwin-${SWIG_TARGET_VERSION}/swig.exe")
     set(Swig_DEPEND Swig)
 


### PR DESCRIPTION
// ------------------------------
ITKv4 changes:

Alexander Schmidt-Richberg (1):
      ENH: Updated Remote Module VariationalRegistration to new git tag

Ali Ghayoor (11):
      ENH: Make ITKv4 compatible with ITKSoftwareGuide
      ENH: Add GetCurrentStepLength to RegularStepGradDescentOptv4
      ENH: Convert three ImageRegistration Examples to ITKv4
      ENH: Add multi-Res and multistage registration Examples to ITKv4
      ENH: Convert DeformableReg examples to ITKv4 reg framework
      BUG: Expand a test to reflect multi-metric registration bug
      BUG: Fix multi metric point sampling bug in ImageRegistrationMethodv4
      ENH: Add direct initialization to SyN registration
      ENH: Direct initialization of SyN by restoring the state
      ENH: LandmarkBasedTransformInitializer supports BSplineTransformType
      DOC: Revise the registration examples of ITKSoftwareGuide

Arnaud Gelas (15):
      COMP: use find_package(VTK COMPONENTS) for LevelSetsv4Visualization
      ENH: Importing Laplacian Deformation for QuadEdgeMesh
      DOC: Add more explanation about SmoothingQuadEdgeMeshFilter's usage
      ENH: SmoothingQuadEdgeMeshFilter::SetCoefficientMethod calls Modified()
      ENH: Add progress report in itk::SmoothingQuadEdgeMeshFilter
      COMP: missing cast when calling gdcm::DataElement::SetByteValue
      ENH: increase LaplacianDeformation code coverage
      STYLE: use typedef rather than inheritance
      BUG: split include directories into appropriate cmake variables HDF5
      BUG: missing gdcm libraries when using system GDCM
      DOC: fix doxygen documentaiton for itk::LaplacianDeformationQuadEdgeMeshFilter
      ENH: Add one method to erase a tag into MetaDataDictionary
      ENH: Adding SubdivisionQuadEdgeMeshFilters to ITK as remote module
      COMP: address clang -Winconsistent-missing-override in ITKQuadEdgeMesh
      COMP: fix warnings on dashboard for Subdivision remote module

Bill Lorensen (5):
      ENH: Specify required VTK modules
      COMP: Wiki examples require additional vtk modules
      ENH: Modify WikiExamples remote config
      COMP: Bad test signature
      COMP: Update tag for wiki examples

Brad King (5):
      ENH: Use if(DEFINED) to simplify conditions
      COMP: Fix vxl_config_macros checks broken by refactoring
      COMP: Fix one more vxl_config_macros check broken by refactoring
      BUG: Fix itk_module_config for repeated calls
      BUG: Fix itk_module_config for repeated calls

Bradley Lowekamp (51):
      PERF: Remove dynamically allocated temporary in evaluate method
      BUG: Implement ITK Style Singleton design pattern
      ENH: Add no throw exception specification for UnRegister methods
      COMP: Must specify order as "noexcept override"
      BUG: Add GetInverse for IdentityTransform
      ENH: Adding SetIdentity method to base DisplacementField class
      BUG: Remove unused redefinition of NULL
      BUG: Don't print to std::cout in PrintSelf
      ENH: Prefer the PrintSelfObjectMacro for printing nested objects
      BUG: Use METER of sCAL scale unit
      BUG: Use PNG_SCALE_METER for PNG sCAL unit
      COMP: Fix signed to unsigned int comparison
      ENH: Extract TiffReaderInternal to separate file
      ENH: Refactor ReadTwoSamplePerPixelImage into template function
      ENH: Refactor GenericReadImage into template function
      BUG: Remove Zeiss 2-channel support code in TIFFImageIO ( and LSMImageIO )
      ENH: Refactor method to convert RGBA image to output buffer
      ENH: Refactor duplicated code to read a page
      BUG: Fix right oriented tiff images
      BUG: Remove dead separated plannar code, add test
      STYLE: Fix minor kwstyle defects in test and test results
      BUG: Use array delete operator for array new allocations
      ENH: add arbitrary TIFF TAGs to meta-data dictionary
      ENH: Reduce code duplicate in TIFFImageIO::ReadCurrentPage
      BUG: Address Coverity warning about null pointer dereferences
      ENH: Remove support for TIFF tile as 3D and dead code
      ENH: RGBA read images should stay unchanged.
      BUG: Override method to MakeOutput by name
      ENH: Refactor per pixel conversion function to per scan-line method
      PERF: Refactor color table lookup
      BUG: Adding missing parentheses around boolean expression
      ENH: adding TIFFImageIO test for RGB palette images
      PERF: Improve recursive Gaussian perfromance with VectorImages
      ENH: Query libtiff to determine compression support
      BUG: Support TIFF tiled image with TIFFReadRGBAImage
      BUG: Use SizeValueType for length of scanline
      PERF: Store causal results directly in output buffers
      COMP: Add explicit conversion to const char
      COMP: Explicitly add override to GetNameOfClass method
      COMP: Address internal segmentation fault with Intel compiler
      ENH: Adding method to set global physical space tolerance
      COMP: Explicitly add override to GetNameOfClass method
      BUG: Add new TypeMacro for non-overloaded classes
      BUG: Fix obscure race condition on access thread pool initialization
      BUG: Updating FDFImageIO remote module
      BUG: Fix segfault when setting displacement field as null
      BUG: Don't enable SSE rounding with OSX and gccxml
      BUG: Add portable access to Tiff field name
      BUG: Fix conversion compilation error
      BUG: Rename remote module FDFImageIO -> IOFDF
      BUG: IOFDF remote module should stay with InsightConsortium repo

Christopher Mullins (22):
      COMP: Allows latex to compile for ITKSoftwareGuide
      COMP: Wrap MeshBase templates
      COMP: Fix warning in BlockMatchingImageFilter
      STYLE: Line lengths in examples should be no longer than 80 chars.
      COMP: Wrap the remaining MeshBase and MeshToMeshFilter types.
      COMP: Fix LaTeX warnings.
      STYLE: Fix formatting/punctuation errors.
      STYLE: Formatting and punctuation fixes.
      DOC: Edits for Book 2 Chapter 1 documentation in the Examples.
      DOC: Edits for book 2 chapter 2.
      DOC: More chapter 2 edits
      DOC: Book 2 Chapter 3 edits (part 1)
      DOC: book 2 chapter 4 Segmentation edits
      STYLE: Fix line length in OpenJPEG license for 80 character.
      DOC: Finish the ImageLinearIteratorWithIndex example.
      DOC: Text and picture problems, book2
      BUG: Fix text in margin issues
      DOC: Edits for the beginning of chapter 5, Statistics
      DOC: Fix empty code block.
      DOC: Fix code overlapping figure
      STYLE: Keep the text in the margins
      STYLE: Put newline before long doxygen reference

Cory Quammen (2):
      COMP: Avoid including VTK_USE_FILE within ITK
      BUG: Fix segfaults in ITKExamples

Danny Perry (2):
      BUG: adding test for vnl_sparse_matrix::mult()
      BUG: size of q buffer should actually be (this->rows())*pcols.

Dirk Padfield (1):
      BUG: Corrected processing of last sigma

GCC-XML Upstream (1):
      ENH: pygccxml v1.6.2 (reduced)

Hans Johnson (12):
      COMP: Add tolerance for comparing floating point
      PERF: Remove non-threadable algorithm components
      BUG: Syntax error in comment
      PERF: Add non-blocking mutex locking.
      ENH: Use TryLock minimize thread stalls
      BUG: ThreadedIndexedContainerPartitioner is inclusive
      STYLE: Remove include_regular_expression from Examples
      BUG: Demonstrate Inv(Inv(T)) != T
      BUG: Ensure Inv(Inv(T)) == T for transforms
      COMP: Valgrind detects uninitialized memory read
      COMP: Missing required base class API component
      ENH: Expand interface for selecting threadpool

Ismael Belghiti (1):
      DOC: Spelling Error in PatchBasedDenoisingBaseImageFilter

Jean-Christophe Fillion-Robin (1):
      Ensure ITKDeprecated is always excluded from the default module list.

Jim Miller (1):
      STYLE: Removing what appears to be a temporary file

Johan Andruejol (1):
      ENH: Fix normalization for null vectors and return the norm

Jon Haitz Legarreta (1):
      ENH: New test for itkLabelShapeOpeningImageFilter

KWSys Robot (3):
      KWSys 2014-09-08 (80e852f6)
      KWSys 2014-10-31 (88c8cc7f)
      KWSys 2014-11-12 (5843f590)

Kent Williams (10):
      COMP: use find_package(VTK COMPONENTS) to specify just needed VTK Components
      BUG: ImageSources/test/CMakeLists.txt incorrect library var reference
      COMP: Fix coverity defects related to RegistrationV4 examples
      COMP: silence warning of vnl_vector_fixed_ref::assert_size
      COMP: Fix various Coverity warnings
      COMP: Fix a typo in an error message print statement.
      COMP: itk::Command-derived class used pointless dynamic_cast.
      PERF: Don't recompute InternalInverse repeatedly
      COMP: Correct orientation/spacing for Philips MultiFrame
      ENH: Add test to exercise issue with Transform::GetInverse

Mark Hiner (2):
      ENH: Update SCIFIO remote module hash
      BUG: Fix duplicate variables in Windows

Matthew McCormick (90):
      DOC: Fix itkSetGetDecoratedInputMacro Doxygen macro.
      ENH: Move FFTComplexToComplexImageFilter out of Review.
      ENH: Add VnlComplexToComplexFFTImageFilter.
      BUG: Use fixed seed for Vnl FFT tests for repeatibility.
      ENH: Bump CMakeLists.txt version to 4.7.0.
      BUG: Do not run vnl_test_na with broken libc++.
      DOC: Fix Software Guide page overruns in IterativeClosestPoint{1,2}.cxx.
      DOC: Remove duplicate text in LaplacianRecursiveGaussian example.
      BUG: Uninitialized m_TransformDirection in ComplexToComplexFFTImageFilter.
      BUG: Fix offset[2] in PointSetToSpatialObjectDemonsRegistrationTest.
      STYLE: Fix style in VoronoiDiagram2D.
      BUG: Fix invalid assignment of second VoronoiBoundaryOrigin.
      BUG: Remove unused m_{SplitEpsilon,SigmoidPrimeOffset}.
      BUG: Fix Win MultiThreader check for successful process creation.
      BUG: Fix VTKPolyDataMeshIO writing for 2D second rank tensor.
      COMP: Fix ImageRegistration8RegisteredSlice.png baseline name.
      DOC: itk::statistics -> itk::Statistics.
      COMP: Fix transform type for ITKv3/IterativeClosestPoint2.
      COMP: Improve const correctness of GradientRecursiveGaussianImageFilter.
      COMP: ThreadJob NULL not defined.
      COMP: Remove unused typedefs in LevelSetsv4Visualization.
      COMP: Remove unused typedef's in VtkGlue.
      ENH: Mark BSplineWarping2Test as RUNS_LONG.
      COMP: Remove call for non-existent variable in Nifti debugging.
      BUG: Close the file on Read and Write in HDF5TransformIO.
      BUG: Remove InsightLegacy test code from TransformHDF5Test.
      ENH: Add {Set,Get}TransformIO for TransformFile{Reader,Writer}.
      STYLE: Use SeriesUIDContainerType and FileNamesContainerType
      ENH: Allow specification of orthogonality tolerance in rigid transforms.
      BUG: TransformFileReader does not clear its TransformList.
      BUG: Prevent dangling pointer in HDF5TransformIO.
      COMP: Do not use _stat64 with MinGW-32.
      COMP: Address LaplacianDeformation Doxygen warnings.
      COMP: Do not wrap the FixedArray of Image SmartPointer's.
      COMP: Add missing wrapping for TransformIOBaseTemplate.
      COMP: Mark DeformableRegistration6Test as RUNS_LONG.
      BUG: Use -py3 when building wrapping for Python 3.
      DOC: Improve ImageRegistration4 grammar.
      ENH: Add IOTransformDCMTK Remote module.
      DOC: Add migration guide for GDCM Rescale slope intercept apply on write.
      COMP: Remove unused typedef's in GPU code.
      STYLE: Improve style of HoughTransform2DLinesImageFilter example.
      COMP: Use ConceptChecking for IterativeInverse dimension check.
      COMP: Wrap TransformIOBaseTemplate for const SmartPointer.
      COMP: Add warning exceptions for third party pcre, swig, gccxml.
      ENH: Bump ITK version to 4.6.1.
      BUG: Add missing ITK_OVERRIDE to ITKImageeSources module.
      BUG: Remove GaussianImageSource members shadowing GenerateImageSource.
      STYLE: Style fixes to ITKImageSources module.
      BUG: GaussianSpatialFunction and GaborImageSource use SpacePrecisionType.
      BUG: Do not perform itk_download_attempt_check when not building ITK.
      DOC: Update GDCMImageIO rescale slope intercept doc.
      BUG: Only register requestion IO COMPONENT modules.
      BUG: Fix wrapping .i, .idx CMake dependencies.
      COMP: Add VTK Python module when wrapping ITKVtkGlue.
      STYLE: Remove NULL definition in itkVoronoiDiagram2DGenerator.
      STYLE: VoronoiDiagram2DGenerator defines a VoronoiDiagramType typedef.
      COMP: Add missing VTK module dependency for LevelSetsv4Visualization.
      BUG: By default, do not create any fixed parameters.
      STYLE: Remove trivial method comments in itkTransform.hxx.
      BUG: PolylineMask Filter's GenerateData is protected / virtual.
      ENH: Add HigherOrderAccurateGradient Module.
      BUG: Use input RequestedRegion Index in SliceBySliceImageFilter internal.
      COMP: Remove extra semi-colon, variable scope in DCMTKFileReader.
      STYLE: Style fixes for Transform classes.
      DOC: Increase Doxygen LOOKUP_CACHE_SIZE.
      BUG: MatrixOffsetTransformBase::GetFixedParameters not thread safe.
      DOC: Index Wiki examples with Doxygen.
      COMP: Bump SphinxExamples remote module.
      DOC: Index Sphinx examples in Doxygen.
      COMP: Remove old java examples.
      COMP: Remove duplicate DiffusionTensor3DReconstruction example reference.
      COMP: Address GradientAnisotropicDiffusionImageFilter example settings.
      COMP: Bump Sphinx Examples remote.
      COMP: Bump WikiExamples remote.
      BUG: Register AzimuthElevationToCartesianTransform to factories.
      DOC: Update texture feature class references.
      BUG: Fix texture feature correlation computation for constant image.
      STYLE: Put ImageToImageFilterCommon in its own file.
      BUG: Wrap ImageToImageFilterCommon.
      STYLE: Put ImageSourceCommon in its own file.
      COMP: Add missing itkImageRegionSplitterBase to ImageSourceCommon.
      BUG: Reset ITK_MODULES_REQUESTED to all modules with multiple calls.
      BUG: Configure against VTK 5.
      COMP: Add ITK_SOURCE_DIR to doxygen EXAMPLE_PATH.
      COMP: Increase DOT_GRAPH_MAX_NODES.
      DOC: Add Doxygen macros for itkSetGetDecoratedObjectMacro.
      ENH: Warning when reading a PNG with UNKNOWN unit and non-unit spacing.
      BUG: Fix VTK5 module export code.
      BUG: Fix LevelSetsv4Visualization VTK variable names.

Michka Popoff (38):
      ENH: Fixes for python 3 support
      BUG: Add VTK_VERSION for older VTK versions
      BUG: Improve SWIG version check
      COMP: Add wrapping for ThreadPool and ThreadJob
      COMP: Remove unimplemented DestroyPool method
      COMP: Fix itkVnlComplexToComplexFFTImageFilter wrapping
      COMP: Do not hide pygccxml warnings
      ENH: Update links in readme file
      STYLE: Remove trailing whitespaces
      STYLE: Set ITK_USE_SYTEM_ZLIB and ITK_USE_SYTEM_SZIP
      BUG: Fix memory leak in MetaImageIO after exception
      ENH: Add script to update pygccxml from upstream
      ENH: Remove Sun OS compatibility for the wrappings
      COMP: Fix for conversion to non-pointer like type warning
      STYLE: LabelObject style
      DOC: Remove broken link from LabelObject class description
      ENH: Do not setup the python tests if not asked
      ENH: Add new GetTypes() and GetTypesAsList() methods to the template class
      COMP: Fix CMP0054 warnings in wrappings
      STYLE: Remove old cmake < 2.8.4 specific code
      STYLE: Remove old cmake < 2.8.5 specific code
      ENH: Update to PCRE 8.36
      COMP: Refactor Wrapping setup and fix legacy warnings
      ENH: Add wrapping configuration to ITKConfig.cmake
      STYLE: Some minor code cleanup in the wrapping setup
      DOC: Fix typo in RelabelComponentImageFilter
      ENH: Deprecate VectorResampleImageFilter
      DOC: Add migration guide for ::Zero and ::One
      ENH: Deprecate ::Zero and ::One
      ENH: Add option to disable sorting by size in itkRelabelComponentImageFilter
      ENH: Add Vector and RGB wrapping to linear interpolator
      STYLE: Remove SORT macro in wrappings
      COMP: Fix warning for InterpolateImageFunction wrapping
      COMP: Add a check for Blocks in GPU module
      COMP: Bump SCIFIO to fix test build warnings
      COMP: Fix wrapping of itkImageFunctionBase
      ENH: Add CVD and CVF types to VectorIndexSelectionCastImageFilter wrappings
      DOC: Improvements for Book1, Chap4

Nick Tustison (7):
      BUG:  Need to explicitly specify spline order.
      ENH:  Initializing the transform center.
      BUG:  Need to check the dynamic cast before any calls.
      ENH:  Adding modifications for point set metrics.
      BUG:  Need to specify TInternalComputationValueType for default metric.
      ENH:  Adding sparse points to B-spline field estimate.
      BUG:  Uninitialized variables.

Richard Beare (1):
      ENH: Include TIFF tags in the MetaDataDictionary

Taylor Braun-Jones (1):
      BUG: Fix SliceBySliceImageFilter doesn't propagate information internally

Umang B (1):
      ENH: Use thread pool to dispatch multithreading tasks

Vivien Delmon (2):
      BUG: ExtractImageFilter::CollapseToSubMatrix fix
      ENH: Add a test on extracted directions in CollapseToSubMatrix mode

Vladimir S. FONOV (1):
      BUG: Fixing incorrect MINC style inverse transform

Ziv Yaniv (1):
      COMP: fixed warnings from gcc4.1.2, made implicit casts explicit


// ------------------------------
SimpleITK changes:

$ git shortlog f2241a13..57e6a526 --no-merges
Bradley Lowekamp (199):
      Adding ANTS neighborhood correlation to registration method
      BUG: UseHistograms was not getting set on ITK filter
      Updating ITK tag along 4.6.0 release
      Hide visibility warnings
      Adding Compare class for transform classes.
      Adding basic comparison driver to compare a transformation
      Adding basic test of the transform compare driver
      Don't automatically convert to md5 hashes for files.
      Moving Python tests to the AdditionalTests file
      Update Python Examples and manual unit tests with standard DATA{}
      Remove the fixed image used for reference
      Adding TRANSFORM_COMPARE option to sitk_add_test
      rename cmake support file with sitk prefix
      Moving sitk custom add test function to separate cmake file
      rename variable SITK_DATA_ROOT to SimpleITK_DATA_ROOT
      Move python add_test wrapper to separate cmake file
      Moving CXX Example testing to examples directory
      Moving python example tests to example directory
      Moving Ruby Lua and TCL example tests to example directory
      remove check for build examples from add tests
      Use if COMMAND to detect if a function is defined
      Move Java test examples to example directory
      Moving R add test wrapper to common cmake file
      Adding missing R SimpleGaussian example
      Moving CSharp examples test to example directory
      Always allow sitk_add_?_test
      In test assert array is not empty
      Adding comparison for ImageRegistrationMethod1 example
      Improve CXX ImageRegistration2
      Switching to JointHistogram MI metric
      Adding verification of for python ImageRegistrationMethod2
      Adding baseline image for demons registration examples
      Always print dart measurement for RMSDifference
      Use "true" for bool values to avoid int to bool comparison warnings
      Adding initial Euler3DTransform class
      Adding Euler3DTransform to header and wrapping
      BUG: Add check for correct size of parameters to transforms
      Add virtual method to set pimple transform
      Core improvements to Euler3DTransform
      Adding comprehensive test of the Euler3DTransform.
      Fix some style issues with EulerTransform interface
      Adding specific translation transform interface
      Adding specific interface for the affine transform
      Adding specific interface for Euler2D transform
      Adding specific versor transform interface
      Adding transform interfaces for 2d and 3d similarity transforms
      Fix PatchBasedDenoising warning for double to in conversion
      Fix unused variable warning
      Set Scale function pointer to null
      Use setter methods for Euler3D constructor with values
      Adding skeleton test place holders for transforms
      Using const vector & for function object parameters
      Fix wrong function called for GetCenter
      COMP: VS11+ requires C++11 nullptr for assignment to std::function
      Detect C++11 nullptr keyword define SITK_NULLPTR as it or NULL
      Adding testing for affine transformation
      Adding gtest predicate and macro for tolerant vector compares
      completed testing for affine transformation
      Adding comprehensive testing for euler2d transform
      Fix default argument to euler2d constructor
      Set old function pointers to null before initializing
      Adding Set/GetTranslation method to Similarity3D
      Adding comprehensive test for Similarity3D Transform
      Remove reference to double for Scale variable
      Adding comprehensive test for similarity 2d transform
      Remove extra Translate method from Versor transform
      Adding specific interface for VersorRigid3D transform
      Adding tests for the versor rigid3d transform
      Remove pre argument for Translate methods
      Adding more testing for transforming points
      COMP: Fix operator<< for std:vector in custom gtest predicate
      Adding missing header files for testing
      Refine logic of using c++11 nullptr
      Adding testing for Similarity2D constructor
      Adding rough json file to generate initial code
      Adding initial generated code from json
      Rename CenterVersorTransformInitializer to add Filter Suffix
      Correct the Versor Initialization wrapping code
      Print parent process object and minor documentation tweaks
      Adding initial testing for Versor transform initializer
      Fixing conversion double to uint8_t conversion warning in test
      Improve error message for transform initializers
      Adding explicit constructor from base transform to vesor
      Moving vector testing facilities to SimpleITKTestHarness
      Must include test harness before gtest
      Moving VectorDoubleRMS Predicate to cxx file
      Adding inline keyword to functions in anonymous namespace
      Adding explicit conversion constructor to transform from base class
      Adding comprehensive testing for the versor initializer
      Explicitly use Self qualifier for virtual method in constructor
      Adding wrapping for ScaleSkewVersorTransform
      Adding comprehensive testing for ScaleSkewVersorTransform
      Don't take address of zero sized std::vector
      Move Matrix/Direction conversion function to TemplateFunctions header
      Adding protected constructor for derived classes to construct pimple
      Adding transform specific interface for bspline transforms
      Adding basic testing for BSplineTransform
      Adding testing of point transform and skew setter
      Adding rough json file to generate initial code
      Adding initial generate code from json
      Rename initial generated files
      Modify generate code for BSplineTransformInitializerFilter
      Adding testing for the BSplineTransfromInitalizerFilter
      Correct skewed point expected value
      Updated ITK super build to tag v4.6.0
      Updating to the official ITK v4.6.0 tag
      Adding GetCoefficientImages method
      Convert <sp\> tag to a space
      Updating JSON doc string from ITK 4.6 with spacing corrections.
      Fix errors in the BSpline test
      Setting BSpline functions pointers to null before initialization
      ENH: Adding masking of fixed and moving image for registration
      BUG: exit with failure code when not enough arguments are specified.
      Adding BSpline registration examples based on ITK DeformableRegistration4
      ITKv4.6 changes the results, renaming old baseline
      Update FFTConvolution baseline for change in origin
      Rename the registration tests file to sitkMethodRegistrationTests
      Create itk SpatialObject from image with conversion
      Move the logic for checking the dimensions of mask match
      Adding testing of mask with registration
      Fix miss matched parenthesizes.
      Fix logic in assert statement.
      Add basic filters library to registration
      ENH: Adding MultiResolutionIterationEvent
      Adding a Python example for multi-resolution BSpline registration
      Adding baseline for new bspline example
      Add SetIdentity method to transform interface
      Adding comprehensive testing for SetIdentity.
      Fix test not clearing string
      Add Transform IO support for BSpline of order 1,2,4
      Addd BSpline::GetOrder method
      Support creation of bspline of order 1,2,3,4
      Adding testing for bspline order
      BSplines of order 0,1,2,3 are support, not 4
      Use unsigned int for bspline order type
      Add support for different bspline order in the initializer.
      Adding GetInverse method to transforms
      Adding doxygen comment for SetInverse
      Adding comprehensive testing for GetInverse method
      Adding missing declaration of GetInverse in PimpleTransform base
      Adding Transform::IsLinear method
      BUG: Use fix image as reference image for bspline transform
      Rename registration SetTransform to SetInitialTransform
      Adding testing for registration transform inplace option
      Adding documentation for SetInitialTransform method
      Adding new registration methods to set moving and fixed transforms
      Adding testing for the initial transforms
      Adding doxygen documentation for initialize transform methods.
      Fix header guarder name to match file
      Use helper macro to set member function pointers
      BUG: Delete pimple before setting
      Remove extra std::auto_ptr in transform pimple
      Adding ScaleVersorTransform interface.
      Adding Get/Set Matrix method to affine transform
      Use the transform helper set macro in versor transforms too
      Add GetMatrix method to matrix offset based transforms
      Adding implementation of GetInverse method for transform class.
      Adding doxygen documentation to the GetInverse method.
      Adding testing for transform's GetInverse method
      Adding testing for GetMatrix method
      Adding testing for transform SetMatrix method
      Add accessor method to get the optimizer scales.
      Adding doxygen documentation for the GetOptimizerScales method
      Adding example which utilizes center estimator and scales estimator
      Adding baseline images and testing for the registration3 example
      Adjust RMS error for displacement field for IRM3 test
      Updating generated documentation strings for SWIG.
      Manually updating R package version.
      Update BugReports URL for R wrapping
      Updating ITK Superbuild version to 4.6.1
      BUG: Pass system search paths from system build to external builds
      Do a try import on setuptools then fall back to distutils
      Add setupegg.py which uses ez_setup to get setuptools
      When installing the wheel package use ez_setup
      Fix Python Download URL
      BUG: Adding missing cmake error variable for wheel process
      Replaced python execfile with python 3 compatible code
      Update ITK External superbuild to ITK 4.7rc01
      Add export specification for instantiated Transform::InternalInitialization
      Fix Registration library's dependency on library with Cast filter
      Make BasicFilters1 library manually specified.
      Correctly do explicit instantiation of member function with specified linkage.
      Updating ITK superbuild towards 4.7rc2
      Fixing conversion double to uint8_t conversion warning in test
      ENH: Updating JSON from ITK doxygen
      Revert "Updating generated documentation strings for SWIG."
      Add Doygen grouping to overloaded procedural methods
      Adds space before for ulink doxygen nodes to SWIG
      Updating SWIG doc strings from latest updated json files.
      Updating Lua Example to latest registration
      Update to v4.7rc01 tag for ITK superbuild
      Fix png inputs sCal flag
      Fixing png sCal field to METER
      Update ITK superbuild to the official 4.7.0 release
      Updating SimpleITK version to v0.8.1
      Updating PythonDownloadPage with 0.8.1 eggs
      BUG: Correct check for empty string for CMake variable type
      Explicitly use DEFINED to check if variable is set
      BUG: Apply escape sequence to problematic characters.

Dave Chen (3):
      Patch to remote -k flag for gzip
      Added missing commas in new JSON files
      DOC: Fixed spacing in the XML to JSON script

David T. Chen (4):
      ENH: Perform download of ITK tag file during build time
      Changed useSeriesDetails default to false
      Fixed for Python 3
      Added ImageRegistrationMethod1 example

Ziv Yaniv (1):
      COMP: CMake change that ensures ITK required modules are on.