### PR TITLE
ENH: Disable ITKv3 compatibility to enable 64-bit ids on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,7 +258,7 @@ option(Slicer_USE_QtTesting    "Integrate QtTesting framework into Slicer." ON)
 mark_as_advanced(Slicer_USE_QtTesting)
 mark_as_superbuild(Slicer_USE_QtTesting)
 
-option(Slicer_ITKV3_COMPATIBILITY "Enable ITKV3 compatibility later" ON)
+option(Slicer_ITKV3_COMPATIBILITY "Enable ITKV3 compatibility later" OFF)
 mark_as_advanced(Slicer_ITKV3_COMPATIBILITY)
 mark_as_superbuild(Slicer_ITKV3_COMPATIBILITY)
 


### PR DESCRIPTION
Enable processing of images greater that 4GB on windows. This changes
ITK's size type on windows from long to long long, by also turning on
ITK_USE64BITS_IDS.

Remove ITK's Deprecated and V3Compatibility modules. Additionally
deprecated APIs are also removed. Migration for these changes can be
found in the ITK migration guide: http://itk.org/migrationv4/