### PR TITLE
ENH: Fix 3943 and other enhancements for slice view annotaitons

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-import qt, vtk
+import qt, vtk, ctk
 from __main__ import slicer
 import DataProbeLib
 
@@ -271,19 +271,21 @@ class DataProbeInfoWidget(object):
     # this method makes SliceView Annotation
     self.sliceAnnotationsFrame = qt.QFrame(self.frame)
     self.sliceAnnotationsFrame.setLayout(qt.QHBoxLayout())
-    self.frame.layout().addWidget(self.sliceAnnotationsFrame)
+    #self.frame.layout().addWidget(self.sliceAnnotationsFrame)
 
-    sliceAnnotationsLabel = qt.QLabel('Slice Annotations:')
+    sliceAnnotationsLabel = qt.QLabel('Slice View Annotations:')
     self.sliceAnnotationsFrame.layout().addWidget(sliceAnnotationsLabel)
     # Slice Annotations Settings Button
     sliceAnnotationsSettings = qt.QPushButton()
     settingsIcon = qt.QIcon("%s/SlicerAdvancedGear-Small.png" %self.iconsDIR)
     sliceAnnotationsSettings.setIcon(settingsIcon)
+    sliceAnnotationsSettings.setMaximumWidth(sliceAnnotationsSettings.height)
     self.sliceAnnotationsFrame.layout().addWidget(sliceAnnotationsSettings)
 
     self.sliceAnnotations = DataProbeLib.SliceAnnotations()
     sliceAnnotationsSettings.connect('clicked()', self.sliceAnnotations.openSettingsPopup)
     self.sliceAnnotationsFrame.layout().addStretch(1)
+
     # goto module button
     self.goToModule = qt.QPushButton('->', self.frame)
     self.goToModule.setToolTip('Go to the DataProbe module for more information and options')
@@ -360,7 +362,6 @@ class DataProbeWidget:
 
   def __init__(self, parent=None):
     self.observerTags = []
-
     if not parent:
       self.parent = slicer.qMRMLWidget()
       self.parent.setLayout(qt.QVBoxLayout())
@@ -389,7 +390,7 @@ class DataProbeWidget:
     self.reloadButton = qt.QPushButton("Reload")
     self.reloadButton.toolTip = "Reload this module."
     self.reloadButton.name = "DataProbe Reload"
-    self.layout.addWidget(self.reloadButton)
+    #self.layout.addWidget(self.reloadButton)
     self.reloadButton.connect('clicked()', self.onReload)
 
     # reload and test button
@@ -397,8 +398,16 @@ class DataProbeWidget:
     #  your module to users)
     self.reloadAndTestButton = qt.QPushButton("Reload and Test")
     self.reloadAndTestButton.toolTip = "Reload this module and then run the self tests."
-    self.layout.addWidget(self.reloadAndTestButton)
+    #self.layout.addWidget(self.reloadAndTestButton)
     self.reloadAndTestButton.connect('clicked()', self.onReloadAndTest)
+
+    settingsCollapsibleButton = ctk.ctkCollapsibleButton()
+    settingsCollapsibleButton.text = "Settings"
+    self.layout.addWidget(settingsCollapsibleButton)
+    settingsVBoxLayout = qt.QVBoxLayout(settingsCollapsibleButton)
+    dataProbeInstance = slicer.modules.DataProbeInstance
+    sliceAnnotationsFrame = dataProbeInstance.infoWidget.sliceAnnotationsFrame
+    settingsVBoxLayout.addWidget(sliceAnnotationsFrame)
 
     self.parent.layout().addStretch(1)
 

--- a/Modules/Scripted/DataProbe/DataProbeLib/Resources/UI/settings.ui
+++ b/Modules/Scripted/DataProbe/DataProbeLib/Resources/UI/settings.ui
@@ -39,8 +39,8 @@
       </widget>
      </item>
      <item>
-      <widget class="ctkCollapsibleButton" name="cornerTextParametersCollapsibleButton">
-       <property name="text">
+      <widget class="ctkCollapsibleButton" name="cornerTextParametersCollapsibleButton" native="true">
+       <property name="text" stdset="0">
         <string>Corner Text Annotation</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -238,11 +238,11 @@
             <layout class="QVBoxLayout" name="verticalLayout_7">
              <item>
               <widget class="QCheckBox" name="backgroundLayerPersistenceCheckbox">
-               <property name="text">
-                <string>Background DICOM annotations persistence</string>
-               </property>
                <property name="toolTip">
                 <string>Show background volume DICOM annotations if foreground volume is non-DICOM.</string>
+               </property>
+               <property name="text">
+                <string>Background DICOM annotations persistence</string>
                </property>
               </widget>
              </item>
@@ -255,8 +255,8 @@
       </widget>
      </item>
      <item>
-      <widget class="ctkCollapsibleButton" name="scalingRulerCollapsibleButton">
-       <property name="text">
+      <widget class="ctkCollapsibleButton" name="scalingRulerCollapsibleButton" native="true">
+       <property name="text" stdset="0">
         <string>Scaling Ruler</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -271,8 +271,8 @@
       </widget>
      </item>
      <item>
-      <widget class="ctkCollapsibleButton" name="colorScalarBarCollapsibleButton">
-       <property name="text">
+      <widget class="ctkCollapsibleButton" name="colorScalarBarCollapsibleButton" native="true">
+       <property name="text" stdset="0">
         <string>Color Scalar Bar</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -330,31 +330,22 @@
          </widget>
         </item>
         <item>
-         <widget class="ctkCollapsibleGroupBox" name="widthSettingsCollapsibleGroupBox">
+         <widget class="ctkCollapsibleGroupBox" name="LabelsPropertiesCollapsibleGroupBox">
           <property name="title">
-           <string>Width Settings</string>
+           <string>Labels Properties</string>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayout_4">
            <item>
             <widget class="QLabel" name="label_5">
              <property name="text">
-              <string>Maximum width (pixels):</string>
+              <string>Range Label Format:</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="ctkSliderWidget" name="colorScalarBarMaxWidthSlider">
-             <property name="pageStep">
-              <double>10.000000000000000</double>
-             </property>
-             <property name="minimum">
-              <double>20.000000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>200.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>50.000000000000000</double>
+            <widget class="QLineEdit" name="rangeLabelFormatLineEdit">
+             <property name="text">
+              <string>%G</string>
              </property>
             </widget>
            </item>
@@ -416,11 +407,6 @@
    <extends>QGroupBox</extends>
    <header>ctkCollapsibleGroupBox.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkSliderWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
* Fixed #3943 [1] by replacing DICOM study date and study time with series date and series time.
* Moved slice view annotations settings gear from Data Probe small widget (main  screen) to the Data probe module in order to preserve more screen real estate for the module uis.
* Fixed problem with color scalarbar range labels.
* Added an option to change format of color scalarbar range label and save the user settings in application settings.
* Change ruler text font size and family according to other text annotations.

[1] http://na-mic.org/Mantis/view.php?id=3943