### PR TITLE
BUG: improve loading of DICOM referenced datasets

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -559,6 +559,7 @@ class DICOMDetailsPopup(object):
       self.referencesDialog = qt.QDialog(self.window)
       self.referencesDialog.modal = True
       layout = qt.QFormLayout()
+      layout.setSpacing(9)
       self.referencesDialog.setLayout(layout)
       windowTitle = "Referenced datasets found"
       self.referencesDialog.setWindowTitle(windowTitle)


### PR DESCRIPTION
See issue http://www.na-mic.org/Bug/view.php?id=3952

* try to improve the sizing policy for the popup (works as expected on Mac)
* make popup modal
* add checks for the referenced datasets that will prevent them from being
   loaded when the list of files for the referenced dataset matches the one
   user already selected in the DICOM widget GUI

@cpinter could you please review if it addresses the issue?