### PR TITLE
ENH: Allow application name to be defined by argv0

### DIFF
--- a/Applications/SlicerApp/Main.cxx
+++ b/Applications/SlicerApp/Main.cxx
@@ -105,7 +105,19 @@ int SlicerAppMain(int argc, char* argv[])
 #endif
 #endif
 
-  QCoreApplication::setApplicationName("Slicer");
+
+  // Allow a custom appliction name so that the settings
+  // can be distinct for differently named applications
+  QString applicationName("Slicer");
+  if (argv[0])
+    {
+    char *p = strrchr(argv[0], '/');
+    applicationName = QString::fromLocal8Bit(p ? p + 1 : argv[0]);
+    applicationName.remove(QString("App-real"));
+    qDebug() << "applicationName: " << applicationName;
+    }
+  QCoreApplication::setApplicationName(applicationName);
+
   QCoreApplication::setApplicationVersion(Slicer_VERSION_FULL);
   //vtkObject::SetGlobalWarningDisplay(false);
   QApplication::setDesktopSettingsAware(false);


### PR DESCRIPTION
The qCoreApplication::applicationName controls the discovery
of QSettings files and some other parts of the internal
machinery of the application.  When making a custom version of
slicer, we want to keep the settings independent of the
original slicer, so that, for example, they can have different
module paths related to the extensions that are bundled.

See:

http://www.slicer.org/slicerWiki/index.php/Documentation/Labs/CustomSlicerGenerator