### PR TITLE
ENH: Do no disable the picking in 2D since the widget is never pickable

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
@@ -793,10 +793,6 @@ void vtkMRMLMarkupsFiducialDisplayableManager2D::SetNthSeed(int n, vtkMRMLMarkup
 
               if (handleRep)
                 {
-#if (VTK_MAJOR_VERSION >= 6)
-                handleRep->DisablePicking();
-#endif
-
                 vtkNew<vtkMarkupsGlyphSource2D> glyphSource;
                 glyphSource->SetGlyphType(glyphType);
                 glyphSource->SetScale(glyphScale);


### PR DESCRIPTION
This prevent the following error to appear when using 2D projection:

```
ERROR: In c:\d\p\slicer-440-package\vtkv6\interaction\widgets\vtkWidgetRepresentation.h, line 176
vtkPointHandleRepresentation2D (0000000010537080): Subclass should allow enable/disable picking
```