### PR TITLE
3698 mrb saving remember last save location

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -3198,10 +3198,17 @@ void vtkMRMLScene::SetStorableNodesModifiedSinceRead()
 {
   vtkSmartPointer<vtkCollection> storableNodes;
   storableNodes.TakeReference(this->GetNodesByClass("vtkMRMLStorableNode"));
+  vtkMRMLScene::SetStorableNodesModifiedSinceRead(storableNodes);
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLScene::
+SetStorableNodesModifiedSinceRead(vtkCollection* storableNodes)
+{
   vtkCollectionSimpleIterator it;
   vtkMRMLStorableNode* storableNode;
   for (storableNodes->InitTraversal(it);
-       (storableNode= vtkMRMLStorableNode::SafeDownCast(
+       (storableNode = vtkMRMLStorableNode::SafeDownCast(
           storableNodes->GetNextItemAsObject(it))) ;)
     {
     if (!storableNode->GetHideFromEditors() &&

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -3194,6 +3194,25 @@ bool vtkMRMLScene
 }
 
 //-----------------------------------------------------------------------------
+void vtkMRMLScene::SetStorableNodesModifiedSinceRead()
+{
+  vtkSmartPointer<vtkCollection> storableNodes;
+  storableNodes.TakeReference(this->GetNodesByClass("vtkMRMLStorableNode"));
+  vtkCollectionSimpleIterator it;
+  vtkMRMLStorableNode* storableNode;
+  for (storableNodes->InitTraversal(it);
+       (storableNode= vtkMRMLStorableNode::SafeDownCast(
+          storableNodes->GetNextItemAsObject(it))) ;)
+    {
+    if (!storableNode->GetHideFromEditors() &&
+        !storableNode->GetModifiedSinceRead())
+      {
+      storableNode->StorableModified();
+      }
+    }
+}
+
+//-----------------------------------------------------------------------------
 int vtkMRMLScene::GetNumberOfNodeReferences()
 {
   int totalNumberOfReferences=0;

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -564,9 +564,13 @@ public:
   bool GetStorableNodesModifiedSinceRead(vtkCollection* modifiedStorableNodes = 0);
 
   /// Search the scene for storable nodes that are not "ModifiedSinceRead"
-  /// and call StorableModified() on them. Useful after loading a scene
-  /// from a temporary directory and deleting the files
+  /// and pass the list to SetStorableNodesModifiedSinceRead
+  /// Useful after loading a scene from a temporary directory and deleting
+  /// the files.
   void SetStorableNodesModifiedSinceRead();
+  /// Given a collection of storable nodes, iterate through
+  /// and call StorableModified() on them.
+  static void SetStorableNodesModifiedSinceRead(vtkCollection* storableNodes);
 protected:
 
   typedef std::map< std::string, std::set<std::string> > NodeReferencesType;

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -562,6 +562,11 @@ public:
   /// Note that the nodes see their reference count being incremented while
   /// being in the list. Don't forget to clear it as soon as you don't need it.
   bool GetStorableNodesModifiedSinceRead(vtkCollection* modifiedStorableNodes = 0);
+
+  /// Search the scene for storable nodes that are not "ModifiedSinceRead"
+  /// and call StorableModified() on them. Useful after loading a scene
+  /// from a temporary directory and deleting the files
+  void SetStorableNodesModifiedSinceRead();
 protected:
 
   typedef std::map< std::string, std::set<std::string> > NodeReferencesType;


### PR DESCRIPTION
Reset the save location for an MRB scene to the MRB location rather than the temporary extraction directory. Then mark storable nodes as modified since read to trigger a re-save since the temporary directory was removed.
Allow loading of MRBs from the command line with relative paths.