### PR TITLE
COMP: Fix redistributable system libraries in packaging

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -45,6 +45,24 @@ if(NOT APPLE)
     include(${Slicer_CMAKE_DIR}/SlicerBlockInstallLibArchive.cmake)
   endif()
   include(InstallRequiredSystemLibraries)
+
+  # XXX: Remove this once CMake minimum version has been updated.
+  #      See Slicer issue #3972 and CMake issue #15428
+  if(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS)
+    if(NOT CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP)
+      if(NOT CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION)
+        if(WIN32)
+          set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION bin)
+        else()
+          set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION lib)
+        endif()
+      endif()
+      install(PROGRAMS ${CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS}
+        DESTINATION ${CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION}
+        COMPONENT Runtime)
+    endif()
+  endif()
+
   include(${Slicer_CMAKE_DIR}/SlicerBlockInstallCMakeProjects.cmake)
 
 else()


### PR DESCRIPTION
When Slicer switched to using component for packaging (issue #2397), it
broke the packaging since CMake macro InstallRequiredSytemLibraries does
not support components (see http://www.cmake.org/Bug/view.php?id=15428).

Until the macro is fixed, we can install the system libs under the right
component. More information in issue #3972