### PR TITLE
BUG: Ensure libvtkViewsQt is packaged on MacOSX. Fixes #3973

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,6 +518,7 @@ if(${VTK_VERSION_MAJOR} GREATER 5)
     vtkRenderingQt
     vtkRenderingVolume${Slicer_VTK_RENDERING_BACKEND}
     vtkTestingRendering
+    vtkViewsQt
     vtkzlib
     )
   if(Slicer_USE_PYTHONQT)


### PR DESCRIPTION
This commit add libvtkViewsQt to the VTK component list so that it show up as a dependency when fixup script are used to create the MacOSX package.

See commit r23755 for more details on why this problem arises. This previous commit fixes the same issue for another VTK library.