### PR TITLE
BUG: Update SliceViewAnnotation to avoid error when restoring scene view

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -641,6 +641,8 @@ class SliceAnnotations(object):
 
     # Get slice view name
     sliceNode = backgroundLayer.GetSliceNode()
+    if not sliceNode:
+      return
     sliceViewName = sliceNode.GetLayoutName()
     self.currentSliceViewName = sliceViewName
 
@@ -744,6 +746,8 @@ class SliceAnnotations(object):
 
     # Get slice view name
     sliceNode = backgroundLayer.GetSliceNode()
+    if not sliceNode:
+      return
     sliceViewName = sliceNode.GetLayoutName()
     self.currentSliceViewName = sliceViewName
 
@@ -805,6 +809,8 @@ class SliceAnnotations(object):
 
     # Get slice view name
     sliceNode = backgroundLayer.GetSliceNode()
+    if not sliceNode:
+      return
     sliceViewName = sliceNode.GetLayoutName()
     self.currentSliceViewName = sliceViewName
 


### PR DESCRIPTION
Running the test "py_RSNA2012ProstateDemo" allows to reproduce the error.

Note that this commit does NOT fix the underlying issue. Indeed, after
restoring a scene view, no annotation are displayed.

The associated error message was:

```
Traceback (most recent call last):
  File "/path/to/Slicer-build/lib/Slicer-4.4/qt-scripted-modules/DataProbeLib/SliceViewAnnotations.py", line 622, in updateCornerAnnotations
    self.makeAnnotationText(caller)
  File "/path/to/Slicer-build/lib/Slicer-4.4/qt-scripted-modules/DataProbeLib/SliceViewAnnotations.py", line 808, in makeAnnotationText
    sliceViewName = sliceNode.GetLayoutName()
AttributeError: 'NoneType' object has no attribute 'GetLayoutName'
```