### PR TITLE
ENH: Added option to control the PropagateVolumeSelection behavior

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -68,9 +68,17 @@ vtkStandardNewMacro(vtkMRMLApplicationLogic);
 class vtkMRMLApplicationLogic::vtkInternal
 {
 public:
-  vtkInternal();
+  vtkInternal(vtkMRMLApplicationLogic * external);
+  void PropagateVolumeSelection(int layer, int fit);
   ~vtkInternal();
 
+  enum{
+    Background=0,
+    Foreground,
+    Label,
+    };
+
+  vtkMRMLApplicationLogic*        External;
   vtkSmartPointer<vtkMRMLSelectionNode>    SelectionNode;
   vtkSmartPointer<vtkMRMLInteractionNode>  InteractionNode;
   vtkSmartPointer<vtkCollection> SliceLogics;
@@ -85,8 +93,9 @@ public:
 // vtkInternal methods
 
 //----------------------------------------------------------------------------
-vtkMRMLApplicationLogic::vtkInternal::vtkInternal()
+vtkMRMLApplicationLogic::vtkInternal::vtkInternal(vtkMRMLApplicationLogic * external)
 {
+  this->External = external;
   this->SliceLinkLogic = vtkSmartPointer<vtkMRMLSliceLinkLogic>::New();
   this->ModelHierarchyLogic = vtkSmartPointer<vtkMRMLModelHierarchyLogic>::New();
   this->ColorLogic = vtkSmartPointer<vtkMRMLColorLogic>::New();
@@ -98,12 +107,54 @@ vtkMRMLApplicationLogic::vtkInternal::~vtkInternal()
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::vtkInternal::PropagateVolumeSelection(int layer, int fit)
+{
+  if ( !this->SelectionNode || !this->External->GetMRMLScene() )
+    {
+    std::cout << this->SelectionNode << "    " << this->External->GetMRMLScene() << std::endl;
+    return;
+    }
+
+  char *ID = this->SelectionNode->GetActiveVolumeID();
+  char *secondID = this->SelectionNode->GetSecondaryVolumeID();
+  char *labelID = this->SelectionNode->GetActiveLabelVolumeID();
+
+  vtkMRMLSliceCompositeNode *cnode;
+  const int nnodes = this->External->GetMRMLScene()->GetNumberOfNodesByClass("vtkMRMLSliceCompositeNode");
+
+  for (int i = 0; i < nnodes; i++)
+    {
+    cnode = vtkMRMLSliceCompositeNode::SafeDownCast (
+      this->External->GetMRMLScene()->GetNthNodeByClass( i, "vtkMRMLSliceCompositeNode" ) );
+    if(!cnode->GetDoPropagateVolumeSelection())
+      {
+      continue;
+      }
+    switch (layer)
+    {
+      case Background:
+        cnode->SetBackgroundVolumeID( ID );
+        break;
+      case Foreground:
+        cnode->SetForegroundVolumeID( secondID );
+        break;
+      case Label:
+        cnode->SetLabelVolumeID( labelID );
+        break;
+    }
+  if (fit)
+    {
+    this->External->FitSliceToAll();
+    }
+}
+}
+//----------------------------------------------------------------------------
 // vtkMRMLApplicationLogic methods
 
 //----------------------------------------------------------------------------
 vtkMRMLApplicationLogic::vtkMRMLApplicationLogic()
 {
-  this->Internal = new vtkInternal;
+  this->Internal = new vtkInternal(this);
   this->Internal->SliceLinkLogic->SetMRMLApplicationLogic(this);
   this->Internal->ModelHierarchyLogic->SetMRMLApplicationLogic(this);
   this->Internal->ColorLogic->SetMRMLApplicationLogic(this);
@@ -312,6 +363,24 @@ void vtkMRMLApplicationLogic::PropagateVolumeSelection(int fit)
     }
 }
 
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::PropagateBackgroundVolumeSelection(int fit)
+{
+  this->Internal->PropagateVolumeSelection(vtkInternal::Background,fit);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::PropagateForegroundVolumeSelection(int fit)
+{
+  this->Internal->PropagateVolumeSelection(vtkInternal::Foreground,fit);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::PropagateLabelVolumeSelection(int fit)
+{
+  this->Internal->PropagateVolumeSelection(vtkInternal::Label,fit);
+}
 
 //----------------------------------------------------------------------------
 void vtkMRMLApplicationLogic::FitSliceToAll()

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -80,6 +80,20 @@ public:
   void PropagateVolumeSelection(int fit);
   void PropagateVolumeSelection() {this->PropagateVolumeSelection(1);}
 
+  ///
+  /// Propagate only active background volume in the SelectionNode to slice composite
+  /// nodes
+  void PropagateBackgroundVolumeSelection(int fit);
+
+  ///
+  /// Propagate only active foreground volume in the SelectionNode to slice composite
+  /// nodes
+  void PropagateForegroundVolumeSelection(int fit);
+
+  ///
+  /// Propagate only active label volume in the SelectionNode to slice composite
+  /// nodes
+  void PropagateLabelVolumeSelection(int fit);
 
   /// Fit all the volumes into their views
   void FitSliceToAll();

--- a/Modules/Scripted/EditorLib/EditUtil.py
+++ b/Modules/Scripted/EditorLib/EditUtil.py
@@ -46,6 +46,7 @@ class EditUtil(object):
     node.SetModuleName( "Editor" )
     node.SetParameter( "label", "1" )
     node.SetParameter( "effect", "DefaultTool" )
+    node.SetParameter( "propagationMode", "Default" )
     slicer.mrmlScene.AddNode(node)
     # Since we are a singleton, the scene won't add our node into the scene,
     # but will instead insert a copy, so we find that and return it
@@ -131,6 +132,12 @@ class EditUtil(object):
 
   def setLabel(self,label):
     self.getParameterNode().SetParameter('label',str(label))
+
+  def getPropagationMode(self):
+    return int(self.getParameterNode().GetParameter('propagationMode'))
+
+  def setPropagateMode(self,propagationMode):
+    self.getParameterNode().SetParameter('propagationMode',str(propagationMode))
 
   def backupLabel(self):
     """Save current label into 'storedLabel' parameter node attribute"""

--- a/Modules/Scripted/EditorLib/HelperBox.py
+++ b/Modules/Scripted/EditorLib/HelperBox.py
@@ -120,7 +120,8 @@ class HelperBox(object):
         selectionNode = self.applicationLogic.GetSelectionNode()
         selectionNode.SetReferenceActiveVolumeID( self.master.GetID() )
         selectionNode.SetReferenceActiveLabelVolumeID( merge.GetID() )
-        self.applicationLogic.PropagateVolumeSelection(0)
+
+        self.propagateVolumeSelection()
         mergeText = merge.GetName()
         self.merge = merge
     else:
@@ -144,6 +145,15 @@ class HelperBox(object):
 
     if self.selectCommand:
       self.selectCommand()
+
+  def propagateVolumeSelection(self):
+    parameterNode = self.editUtil.getParameterNode()
+    mode = parameterNode.GetParameter("propagationMode")
+    if  mode == 'BackgroundAndLabel':
+      self.applicationLogic.PropagateBackgroundVolumeSelection(0)
+      self.applicationLogic.PropagateLabelVolumeSelection(0)
+    else:
+      self.applicationLogic.PropagateVolumeSelection(0)
 
   def setVolumes(self,masterVolume,mergeVolume):
     """set both volumes at the same time - trick the callback into
@@ -340,7 +350,7 @@ class HelperBox(object):
     selectionNode = self.applicationLogic.GetSelectionNode()
     selectionNode.SetReferenceActiveVolumeID( self.master.GetID() )
     selectionNode.SetReferenceActiveLabelVolumeID( merge.GetID() )
-    self.applicationLogic.PropagateVolumeSelection(0)
+    self.propagateVolumeSelection()
 
     self.statusText( "Finished merging." )
 
@@ -490,7 +500,7 @@ class HelperBox(object):
     selectionNode.SetReferenceActiveVolumeID(self.master.GetID())
     if structureVolume:
       selectionNode.SetReferenceActiveLabelVolumeID( structureVolume.GetID() )
-    self.applicationLogic.PropagateVolumeSelection(0)
+    self.propagateVolumeSelection()
 
     self.editUtil.setLabel(label)
 


### PR DESCRIPTION
Added the following features:
* Volume selection can propagate selectively to background, foreground and label layers.
* HelperBox and EditUtil were modified to use the new propagation mode. Default mode will propagate through all layers while "BackgroundAndLabel" mode only propagates to background and label and doesn't touch foreground. 

This feature is useful in cases where different foregrounds are set to different views and we don't want editor to reset foregrounds through propagate volume selection. A use case is the ongoing project PCampReview [1].

[1]  [PCampReview](https://github.com/fedorov/PCampReview )