### PR TITLE
BUG: Fixed editor behaviour in restoring correct label.

### DIFF
--- a/Modules/Scripted/EditorLib/EditUtil.py
+++ b/Modules/Scripted/EditorLib/EditUtil.py
@@ -120,6 +120,8 @@ class EditUtil(object):
         return slicer.mrmlScene.GetNodeByID(labelID)
 
   def getColorNode(self):
+    if not self.isEraseEffectEnabled():
+      self.backupLabel()
     labelNode = self.getLabelVolume()
     if labelNode:
       dispNode = labelNode.GetDisplayNode()

--- a/Modules/Scripted/EditorLib/HelperBox.py
+++ b/Modules/Scripted/EditorLib/HelperBox.py
@@ -734,7 +734,10 @@ class HelperBox(object):
     self.structuresView = qt.QTreeView()
     self.structuresView.objectName = 'StructuresView'
     self.structuresView.sortingEnabled = True
-    self.structuresFrame.layout().addWidget(self.structuresView)
+    structuresExpandableWidget = ctk.ctkExpandableWidget()
+    structuresExpandableWidget.setLayout(qt.QVBoxLayout())
+    self.structuresFrame.layout().addWidget(structuresExpandableWidget)
+    structuresExpandableWidget.layout().addWidget(self.structuresView)
 
     # all buttons frame
 


### PR DESCRIPTION
To reproduce the issue:
* Load a volume, go to editor and create a merge labelmap.
* With Paint effect paint something with label 1.
* While on Label 1 select eraser, erase something and go back to painteffect.
* Select another label e.g 2.
* Paint something with painteffect. It works fine (paint with label 2).
* Choose another effect (e.g draw or want effect) and it would go back to the label 1 as it only stores the backup label when eraser is selected.

Fix: Backup label should also be set when a new color (not zero) is chosen not only after switching to eraser.