### PR TITLE
ENH: Added support in vtkMRMLNode for multiple references to the same node

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDisplayableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayableNode.cxx
@@ -68,7 +68,7 @@ void vtkMRMLDisplayableNode::OnNodeReferenceAdded(vtkMRMLNodeReference *referenc
   this->Superclass::OnNodeReferenceAdded(reference);
   if (std::string(reference->GetReferenceRole()) == this->DisplayNodeReferenceRole)
     {
-    this->InvokeEvent(vtkMRMLDisplayableNode::DisplayModifiedEvent, reference->ReferencedNode);
+    this->InvokeEvent(vtkMRMLDisplayableNode::DisplayModifiedEvent, reference->GetReferencedNode());
     }
 }
 
@@ -78,7 +78,7 @@ void vtkMRMLDisplayableNode::OnNodeReferenceModified(vtkMRMLNodeReference *refer
   this->Superclass::OnNodeReferenceModified(reference);
   if (std::string(reference->GetReferenceRole()) == this->DisplayNodeReferenceRole)
     {
-    this->InvokeEvent(vtkMRMLDisplayableNode::DisplayModifiedEvent, reference->ReferencedNode);
+    this->InvokeEvent(vtkMRMLDisplayableNode::DisplayModifiedEvent, reference->GetReferencedNode());
     }
 }
 
@@ -88,7 +88,7 @@ void vtkMRMLDisplayableNode::OnNodeReferenceRemoved(vtkMRMLNodeReference *refere
   this->Superclass::OnNodeReferenceRemoved(reference);
   if (std::string(reference->GetReferenceRole()) == this->DisplayNodeReferenceRole)
     {
-    this->InvokeEvent(vtkMRMLDisplayableNode::DisplayModifiedEvent, reference->ReferencedNode);
+    this->InvokeEvent(vtkMRMLDisplayableNode::DisplayModifiedEvent, reference->GetReferencedNode());
     }
 }
 
@@ -159,7 +159,7 @@ void vtkMRMLDisplayableNode::RemoveNthDisplayNodeID(int n)
 //----------------------------------------------------------------------------
 void vtkMRMLDisplayableNode::RemoveAllDisplayNodeIDs()
 {
-  this->RemoveAllNodeReferenceIDs(this->GetDisplayNodeReferenceRole());
+  this->RemoveNodeReferenceIDs(this->GetDisplayNodeReferenceRole());
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLModelNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelNode.cxx
@@ -729,7 +729,7 @@ void vtkMRMLModelNode::OnNodeReferenceAdded(vtkMRMLNodeReference *reference)
 {
   if (std::string(reference->GetReferenceRole()) == this->DisplayNodeReferenceRole)
     {
-    this->UpdateDisplayNodePolyData(vtkMRMLDisplayNode::SafeDownCast(reference->ReferencedNode));
+    this->UpdateDisplayNodePolyData(vtkMRMLDisplayNode::SafeDownCast(reference->GetReferencedNode()));
     }
   Superclass::OnNodeReferenceAdded(reference);
 }
@@ -737,7 +737,7 @@ void vtkMRMLModelNode::OnNodeReferenceAdded(vtkMRMLNodeReference *reference)
 //---------------------------------------------------------------------------
 void vtkMRMLModelNode::OnNodeReferenceModified(vtkMRMLNodeReference *reference)
 {
-   this->UpdateDisplayNodePolyData(vtkMRMLDisplayNode::SafeDownCast(reference->ReferencedNode));
+   this->UpdateDisplayNodePolyData(vtkMRMLDisplayNode::SafeDownCast(reference->GetReferencedNode()));
    Superclass::OnNodeReferenceModified(reference);
 }
 

--- a/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
@@ -575,7 +575,7 @@ void vtkMRMLSelectionNode::GetUnitNodes(std::vector<vtkMRMLUnitNode*>& units)
       if (reference)
         {
         units.push_back(
-          vtkMRMLUnitNode::SafeDownCast(reference->ReferencedNode));
+          vtkMRMLUnitNode::SafeDownCast(reference->GetReferencedNode()));
         }
       }
     }

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.h
@@ -112,7 +112,7 @@ protected:
     Superclass::OnNodeReferenceAdded(reference);
     if (std::string(reference->GetReferenceRole()) == this->TransformNodeReferenceRole)
       {
-      this->InvokeCustomModifiedEvent(vtkMRMLTransformableNode::TransformModifiedEvent, reference->ReferencedNode);
+      this->InvokeCustomModifiedEvent(vtkMRMLTransformableNode::TransformModifiedEvent, reference->GetReferencedNode());
       }
   }
 
@@ -123,7 +123,7 @@ protected:
     Superclass::OnNodeReferenceModified(reference);
     if (std::string(reference->GetReferenceRole()) == this->TransformNodeReferenceRole)
     {
-      this->InvokeCustomModifiedEvent(vtkMRMLTransformableNode::TransformModifiedEvent, reference->ReferencedNode);
+      this->InvokeCustomModifiedEvent(vtkMRMLTransformableNode::TransformModifiedEvent, reference->GetReferencedNode());
     }
   }
 
@@ -134,7 +134,7 @@ protected:
     Superclass::OnNodeReferenceRemoved(reference);
     if (std::string(reference->GetReferenceRole()) == this->TransformNodeReferenceRole)
     {
-      this->InvokeCustomModifiedEvent(vtkMRMLTransformableNode::TransformModifiedEvent, reference->ReferencedNode);
+      this->InvokeCustomModifiedEvent(vtkMRMLTransformableNode::TransformModifiedEvent, reference->GetReferencedNode());
     }
   }
 

--- a/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
@@ -861,14 +861,14 @@ void vtkMRMLVolumeNode
 //----------------------------------------------------------------------------
 void vtkMRMLVolumeNode::OnNodeReferenceAdded(vtkMRMLNodeReference *reference)
 {
-  this->UpdateDisplayNodeImageData(vtkMRMLDisplayNode::SafeDownCast(reference->ReferencedNode));
+  this->UpdateDisplayNodeImageData(vtkMRMLDisplayNode::SafeDownCast(reference->GetReferencedNode()));
   Superclass::OnNodeReferenceAdded(reference);
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLVolumeNode:: OnNodeReferenceModified(vtkMRMLNodeReference *reference)
 {
-  this->UpdateDisplayNodeImageData(vtkMRMLDisplayNode::SafeDownCast(reference->ReferencedNode));
+  this->UpdateDisplayNodeImageData(vtkMRMLDisplayNode::SafeDownCast(reference->GetReferencedNode()));
   Superclass::OnNodeReferenceModified(reference);
 }
 

--- a/Libs/MRML/Core/vtkObserverManager.h
+++ b/Libs/MRML/Core/vtkObserverManager.h
@@ -51,13 +51,16 @@ class VTK_MRML_EXPORT vtkObserverManager : public vtkObject
   void SetObject(vtkObject **nodePtr, vtkObject *node);
 
   /// set vtkObject to a specified pointer, remove all observers for all events, add observer for Modify event
-  void SetAndObserveObject(vtkObject **nodePtr, vtkObject *node, float priority=0.0);
+  void SetAndObserveObject(vtkObject **nodePtr, vtkObject *node, float priority=0.0, bool logWarningIfSameObservationExists=true);
 
   /// set vtkObject to a specified pointer, remove all observers for all events, add observers for specified events
-  void SetAndObserveObjectEvents(vtkObject **nodePtr, vtkObject *node, vtkIntArray *events, vtkFloatArray *priorities=0);
+  void SetAndObserveObjectEvents(vtkObject **nodePtr, vtkObject *node, vtkIntArray *events, vtkFloatArray *priorities=0, bool logWarningIfSameObservationExists=true);
 
   /// remove all observers for all events
   void RemoveObjectEvents(vtkObject *nodePtr);
+
+  /// get a list of all observed events and priorities for the selected node
+  void GetObjectEvents(vtkObject *nodePtr, vtkIntArray *events, vtkFloatArray *priorities);
 
   /// Observe ModifiedEvent on the object
   void ObserveObject(vtkObject *node, float priority=0.0);


### PR DESCRIPTION
Fixed limitations of node references:
* Node reference modification request (SetAndObserveNthNodeReferenceID) was ignored if only events were different. This caused an issue in OpenIGTLinkIF, because different nodes in the same role required different event observations and so the role-default events that were restored from the scene were not correct.
* One node could only be referenced a single time only, otherwise the most recently added/removed/modified reference overwrote all the previous event observations. This limitation was not acceptable, because even a temporarily created reference (the user selects a node as input that is already selected as an input in another node selector) could remove event observations. This caused an issue in Fiducial registration wizard, which has two input fiducial lists, and when the user selected one input fiducial list it often removed the observer from the other input fiducial list.

Other related changes:
* Added more node reference tests
* Simplified node references implementation: all reference add/remove/modification operations go through a single method (SetAndObserveNthNodeReferenceID), previously there were many potential execution path for these operations, which made it difficult to make changes consistently.
* Fixed ObserverManager to update the observation even if only events or priorities are changed.
* Made vtkMRMLNodeReference data members ReferencingNode, ReferencedNode, Events accessible only by get/set functions to allow consistency checks.
* Renamed vtkMRMLNode::RemoveAllNodeReferenceIDs to RemoveNodeReferenceIDs to be consistent with similar method names