### PR TITLE
ENH: Extension Wizard: Substitute CMake variable reference if possible.

### DIFF
--- a/Utilities/Scripts/SlicerWizard/ExtensionDescription.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionDescription.py
@@ -165,12 +165,12 @@ class ExtensionDescription(object):
 
   #---------------------------------------------------------------------------
   def _setProjectAttribute(self, name, project, default=None, required=False,
-                           elideempty=False):
+                           elideempty=False, substitute=True):
 
     if default is None and not required:
       default=""
 
-    v = project.getValue("EXTENSION_" + name.upper(), default)
+    v = project.getValue("EXTENSION_" + name.upper(), default, substitute)
 
     if len(v) or not elideempty:
       setattr(self, name, v)


### PR DESCRIPTION
In case the main `CMakeLists.txt` of an extension contain references
to CMake variable, these will be expanded if possible.

For example, if the CMakeLists.txt contains the following:

```
  set(EXTENSION_DESCRIPTION "The ${PROJECT_NAME} module provides Slicer user with any easy way to export models into a KiwiViewer scene file.")
```

the generated description file will have the following description:

```
  description The SlicerToKiwiExporter module provides Slicer user with any easy way to export models into a KiwiViewer scene file.
```