### PR TITLE
Add module interactive property

### DIFF
--- a/Base/QTCore/qSlicerAbstractCoreModule.cxx
+++ b/Base/QTCore/qSlicerAbstractCoreModule.cxx
@@ -192,7 +192,13 @@ CTK_GET_CPP(qSlicerAbstractCoreModule, vtkSlicerApplicationLogic*, appLogic, App
 //-----------------------------------------------------------------------------
 bool qSlicerAbstractCoreModule::isHidden()const
 {
-  return false;
+  return this->isInteractive() ? false : true;
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerAbstractCoreModule::isInteractive()const
+{
+  return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -226,6 +232,11 @@ qSlicerAbstractModuleRepresentation* qSlicerAbstractCoreModule::widgetRepresenta
 qSlicerAbstractModuleRepresentation* qSlicerAbstractCoreModule::createNewWidgetRepresentation()
 {
   Q_D(qSlicerAbstractCoreModule);
+
+  if (!this->isInteractive())
+    {
+    return 0;
+    }
 
   // Since 'logic()' should have been called in 'initialize(), let's make
   // sure the 'logic()' method call is consistent and won't create a

--- a/Base/QTCore/qSlicerAbstractCoreModule.h
+++ b/Base/QTCore/qSlicerAbstractCoreModule.h
@@ -107,6 +107,12 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerAbstractCoreModule : public QObject
   /// \sa isHidden
   Q_PROPERTY(bool hidden READ isHidden)
 
+  /// This property holds whether the user can interact with the module or not.
+  /// If the module is non-interactive, it will not have a widget representation.
+  /// By default, modules are interactive (interactive == true).
+  /// \sa isHidden
+  Q_PROPERTY(bool interactive READ isInteractive)
+
   /// This property holds the help of the module.
   /// The help is displayed inside the module as a tab.
   /// \a helpText must be reimplemented for each module.
@@ -199,10 +205,17 @@ public:
   /// Return the category index of the module.
   virtual int index()const;
 
-  /// Returns true if the module should be hidden to the user.
-  /// By default, modules are not hidden.
-  /// \sa hidden
+  /// Returns \a true if the module should be hidden to the user.
+  /// By default, interactive modules are visible and non-interactive
+  /// modules are hidden.
+  /// \sa hidden, interactive
   virtual bool isHidden()const;
+
+  /// Return \a true if the module provide an interface allowing
+  /// the user to directly use the module.
+  /// Non-interactive module are not expected to provide a widget representation.
+  /// \sa widgetRepresentation(), hidden
+  virtual bool isInteractive()const;
 
   /// Return the contributors of the module
   virtual QStringList contributors()const;

--- a/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
@@ -55,6 +55,7 @@ public:
   QString AcknowledgementText;
   QIcon   Icon;
   bool   Hidden;
+  bool   Interactive;
   QVariantMap   Extensions;
   int Index;
 
@@ -87,6 +88,7 @@ qSlicerScriptedLoadableModulePrivate::qSlicerScriptedLoadableModulePrivate()
 {
   this->PythonSelf = 0;
   this->Hidden = false;
+  this->Interactive = true;
   this->Index = -1;
   for (int i = 0; i < Self::APIMethodCount; ++i)
     {
@@ -305,6 +307,11 @@ qSlicerAbstractModuleRepresentation* qSlicerScriptedLoadableModule::createWidget
 {
   Q_D(qSlicerScriptedLoadableModule);
 
+  if (!this->isInteractive())
+    {
+    return 0;
+    }
+
   QScopedPointer<qSlicerScriptedLoadableModuleWidget> widget(new qSlicerScriptedLoadableModuleWidget);
   bool ret = widget->setPythonSource(d->PythonSource);
   if (!ret)
@@ -363,6 +370,10 @@ CTK_GET_CPP(qSlicerScriptedLoadableModule, QIcon, icon, Icon)
 //-----------------------------------------------------------------------------
 CTK_SET_CPP(qSlicerScriptedLoadableModule, bool, setHidden, Hidden)
 CTK_GET_CPP(qSlicerScriptedLoadableModule, bool, isHidden, Hidden)
+
+//-----------------------------------------------------------------------------
+CTK_SET_CPP(qSlicerScriptedLoadableModule, bool, setInteractive, Interactive)
+CTK_GET_CPP(qSlicerScriptedLoadableModule, bool, isInteractive, Interactive)
 
 //-----------------------------------------------------------------------------
 CTK_SET_CPP(qSlicerScriptedLoadableModule, const QStringList&, setDependencies, Dependencies)

--- a/Base/QTGUI/qSlicerScriptedLoadableModule.h
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.h
@@ -43,6 +43,7 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerScriptedLoadableModule : public qSlicerL
   Q_PROPERTY(QVariantMap extensions READ extensions WRITE setExtensions)
   Q_PROPERTY(QIcon icon READ icon WRITE setIcon)
   Q_PROPERTY(bool hidden READ isHidden WRITE setHidden)
+  Q_PROPERTY(bool interactive READ isInteractive WRITE setInteractive)
   Q_PROPERTY(QStringList dependencies READ dependencies WRITE setDependencies)
   Q_PROPERTY(int index READ index WRITE setIndex)
 
@@ -87,6 +88,10 @@ public:
   /// Needs to be hidden before the module menu is created.
   virtual bool isHidden()const;
   void setHidden(bool hidden);
+
+  /// Enable/Disable interactive state of the module.
+  virtual bool isInteractive()const;
+  void setInteractive(bool interactive);
 
 protected:
 

--- a/Modules/Scripted/DICOMPlugins/DICOMDiffusionVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMDiffusionVolumePlugin.py
@@ -153,7 +153,6 @@ class DICOMDiffusionVolumePlugin:
     parent.helpText = """
     Plugin to the DICOM Module to parse and load diffusion volumes
     from DICOM files.
-    No module interface here, only in the DICOM module
     """
     parent.acknowledgementText = """
     This DICOM Plugin was developed by
@@ -161,8 +160,8 @@ class DICOMDiffusionVolumePlugin:
     and was partially funded by NIH grant 3P41RR013218.
     """
 
-    # don't show this module - it only appears in the DICOM module
-    parent.hidden = True
+    # This module does not provide a user interface
+    parent.interactive = False
 
     # Add this extension to the DICOM module's list for discovery when the module
     # is created.  Since this module may be discovered before DICOM itself,
@@ -172,23 +171,3 @@ class DICOMDiffusionVolumePlugin:
     except AttributeError:
       slicer.modules.dicomPlugins = {}
     slicer.modules.dicomPlugins['DICOMDiffusionVolumePlugin'] = DICOMDiffusionVolumePluginClass
-
-#
-# DICOMDiffusionVolumeWidget
-#
-
-class DICOMDiffusionVolumeWidget:
-  def __init__(self, parent = None):
-    self.parent = parent
-
-  def setup(self):
-    # don't display anything for this widget - it will be hidden anyway
-    pass
-
-  def enter(self):
-    pass
-
-  def exit(self):
-    pass
-
-

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -432,7 +432,6 @@ class DICOMScalarVolumePlugin:
     parent.helpText = """
     Plugin to the DICOM Module to parse and load scalar volumes
     from DICOM files.
-    No module interface here, only in the DICOM module
     """
     parent.acknowledgementText = """
     This DICOM Plugin was developed by
@@ -440,8 +439,8 @@ class DICOMScalarVolumePlugin:
     and was partially funded by NIH grant 3P41RR013218.
     """
 
-    # don't show this module - it only appears in the DICOM module
-    parent.hidden = True
+    # This module does not provide a user interface
+    parent.interactive = False
 
     # Add this extension to the DICOM module's list for discovery when the module
     # is created.  Since this module may be discovered before DICOM itself,
@@ -451,23 +450,3 @@ class DICOMScalarVolumePlugin:
     except AttributeError:
       slicer.modules.dicomPlugins = {}
     slicer.modules.dicomPlugins['DICOMScalarVolumePlugin'] = DICOMScalarVolumePluginClass
-
-#
-# DICOMScalarVolumeWidget
-#
-
-class DICOMScalarVolumeWidget:
-  def __init__(self, parent = None):
-    self.parent = parent
-
-  def setup(self):
-    # don't display anything for this widget - it will be hidden anyway
-    pass
-
-  def enter(self):
-    pass
-
-  def exit(self):
-    pass
-
-

--- a/Modules/Scripted/DICOMPlugins/DICOMSlicerDataBundlePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMSlicerDataBundlePlugin.py
@@ -120,7 +120,6 @@ class DICOMSlicerDataBundlePlugin:
     parent.helpText = """
     Plugin to the DICOM Module to parse and load diffusion volumes
     from DICOM files.
-    No module interface here, only in the DICOM module
     """
     parent.acknowledgementText = """
     This DICOM Plugin was developed by
@@ -128,8 +127,8 @@ class DICOMSlicerDataBundlePlugin:
     and was partially funded by NIH grant 3P41RR013218.
     """
 
-    # don't show this module - it only appears in the DICOM module
-    parent.hidden = True
+    # This module does not provide a user interface
+    parent.interactive = False
 
     # Add this extension to the DICOM module's list for discovery when the module
     # is created.  Since this module may be discovered before DICOM itself,
@@ -139,23 +138,3 @@ class DICOMSlicerDataBundlePlugin:
     except AttributeError:
       slicer.modules.dicomPlugins = {}
     slicer.modules.dicomPlugins['DICOMSlicerDataBundlePlugin'] = DICOMSlicerDataBundlePluginClass
-
-#
-# DICOMSlicerDataBundleWidget
-#
-
-class DICOMSlicerDataBundleWidget:
-  def __init__(self, parent = None):
-    self.parent = parent
-
-  def setup(self):
-    # don't display anything for this widget - it will be hidden anyway
-    pass
-
-  def enter(self):
-    pass
-
-  def exit(self):
-    pass
-
-

--- a/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
+++ b/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
@@ -1,5 +1,7 @@
 from __main__ import vtk, qt, ctk, slicer
 
+from slicer.ScriptedLoadableModule import *
+
 #
 # VectorToScalarVolume
 #


### PR DESCRIPTION
This PR introduces a new module property named `interactive`, by default it is enabled for all module. If set to `False`, no widget representation is expected.

Ping @lassoan @pieper @fedorov