### PR TITLE
3549 import scripted module as python module

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -116,6 +116,15 @@ nowarning_test(nomainwindow_noloadable_noscripted --no-main-window --disable-loa
 nowarning_test(nomainwindow_nocli_noloadable_noscripted --no-main-window --disable-cli-modules --disable-loadable-modules --disable-scripted-loadable-modules)
 nowarning_test(nomainwindow_ignoreslicerrc --no-main-window --ignore-slicerrc)
 
+#
+# Check if scripted module import works as expected
+#
+
+slicer_add_python_test(
+  SCRIPT ScriptedModuleDiscoveryTest.py
+  SLICER_ARGS --no-main-window --disable-builtin-modules --additional-module-path ${CMAKE_CURRENT_SOURCE_DIR}/ScriptedModuleDiscoveryTest
+  TESTNAME_PREFIX nomainwindow_
+  )
 
 #
 # Application tests

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
@@ -1,41 +1,59 @@
 
 import __main__
 
-# XXX #3549: This should not be a problem once issue #3549 is resolved.
-#assert not hasattr(__main__, 'SOMEVAR')
+assert not hasattr(__main__, 'SOMEVAR')
 
-# XXX #3549: By default, loaded module classes should not be in the global scope.
-assert hasattr(__main__, 'ModuleA')
-assert hasattr(__main__, 'ModuleB')
+assert not hasattr(__main__, 'ModuleA')
+assert not hasattr(__main__, 'ModuleB')
+assert not hasattr(__main__, 'ModuleC_WithoutWidget')
+assert not hasattr(__main__, 'ModuleD_WithFileDialog_WithoutWidget')
+assert not hasattr(__main__, 'ModuleE_WithFileWriter_WithoutWidget')
 
 from types import ClassType, ModuleType
-
-# XXX #3549: Once this is resolved, remove this.
-assert type(ModuleA) is ClassType
-assert type(ModuleB) is ClassType
-assert type(ModuleAWidget) is ClassType
-assert type(ModuleBWidget) is ClassType
-
 import slicer
 
 assert type(slicer.modules) is ModuleType
 
-# XXX #3549: Once the issue is resolved, expected value should be changed to 'A'.
-assert slicer.modules.ModuleAInstance.somevar() == 'B'
+# Global variable
+assert slicer.modules.ModuleAInstance.somevar() == 'A'
 assert slicer.modules.ModuleBInstance.somevar() == 'B'
+assert slicer.modules.ModuleC_WithoutWidgetInstance.somevar() == 'C'
+assert slicer.modules.ModuleD_WithFileDialog_WithoutWidgetInstance.somevar() == 'D'
+assert slicer.modules.ModuleE_WithFileWriter_WithoutWidgetInstance.somevar() == 'E'
 
+# Widget representation
 assert isinstance(slicer.modules.modulea.widgetRepresentation(), slicer.qSlicerScriptedLoadableModuleWidget)
 assert isinstance(slicer.modules.moduleb.widgetRepresentation(), slicer.qSlicerScriptedLoadableModuleWidget)
+assert slicer.modules.modulec_withoutwidget.widgetRepresentation() == None
+assert slicer.modules.moduled_withfiledialog_withoutwidget.widgetRepresentation() == None
+assert slicer.modules.modulee_withfilewriter_withoutwidget.widgetRepresentation() == None
 
 import ModuleA
 import ModuleB
+import ModuleC_WithoutWidget
+import ModuleD_WithFileDialog_WithoutWidget
+import ModuleE_WithFileWriter_WithoutWidget
 
+# Check module type
 assert type(ModuleA) is ModuleType
 assert type(ModuleB) is ModuleType
+assert type(ModuleC_WithoutWidget) is ModuleType
+assert type(ModuleD_WithFileDialog_WithoutWidget) is ModuleType
+assert type(ModuleE_WithFileWriter_WithoutWidget) is ModuleType
 
+# Check class type
 assert type(ModuleA.ModuleA) is ClassType
 assert type(ModuleB.ModuleB) is ClassType
+assert type(ModuleC_WithoutWidget.ModuleC_WithoutWidget) is ClassType
+assert type(ModuleD_WithFileDialog_WithoutWidget.ModuleD_WithFileDialog_WithoutWidget) is ClassType
+assert type(ModuleE_WithFileWriter_WithoutWidget.ModuleE_WithFileWriter_WithoutWidget) is ClassType
 
 assert type(ModuleA.ModuleAWidget) is ClassType
 assert type(ModuleB.ModuleBWidget) is ClassType
+assert not hasattr(ModuleC_WithoutWidget, 'ModuleC_WithoutWidgetWidget')
+assert not hasattr(ModuleC_WithoutWidget, 'ModuleD_WithFileDialog_WithoutWidget')
+assert not hasattr(ModuleC_WithoutWidget, 'ModuleE_WithFileWriter_WithoutWidget')
 
+
+# Plugins
+# XXX Will need to extend module API to list registered plugins

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
@@ -1,0 +1,41 @@
+
+import __main__
+
+# XXX #3549: This should not be a problem once issue #3549 is resolved.
+#assert not hasattr(__main__, 'SOMEVAR')
+
+# XXX #3549: By default, loaded module classes should not be in the global scope.
+assert hasattr(__main__, 'ModuleA')
+assert hasattr(__main__, 'ModuleB')
+
+from types import ClassType, ModuleType
+
+# XXX #3549: Once this is resolved, remove this.
+assert type(ModuleA) is ClassType
+assert type(ModuleB) is ClassType
+assert type(ModuleAWidget) is ClassType
+assert type(ModuleBWidget) is ClassType
+
+import slicer
+
+assert type(slicer.modules) is ModuleType
+
+# XXX #3549: Once the issue is resolved, expected value should be changed to 'A'.
+assert slicer.modules.ModuleAInstance.somevar() == 'B'
+assert slicer.modules.ModuleBInstance.somevar() == 'B'
+
+assert isinstance(slicer.modules.modulea.widgetRepresentation(), slicer.qSlicerScriptedLoadableModuleWidget)
+assert isinstance(slicer.modules.moduleb.widgetRepresentation(), slicer.qSlicerScriptedLoadableModuleWidget)
+
+import ModuleA
+import ModuleB
+
+assert type(ModuleA) is ModuleType
+assert type(ModuleB) is ModuleType
+
+assert type(ModuleA.ModuleA) is ClassType
+assert type(ModuleB.ModuleB) is ClassType
+
+assert type(ModuleA.ModuleAWidget) is ClassType
+assert type(ModuleB.ModuleBWidget) is ClassType
+

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
@@ -1,0 +1,24 @@
+
+from slicer.ScriptedLoadableModule import *
+
+SOMEVAR = 'A'
+
+class ModuleA(ScriptedLoadableModule):
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "Module A"
+    self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)",]
+    self.parent.helpText = """
+    This module allows to test the scripted module import.
+    """
+    self.parent.acknowledgementText = """
+    Developed by Jean-Christophe Fillion-Robin, Kitware Inc.,
+    partially funded by NIH grant 3P41RR013218-12S1.
+    """
+
+  def somevar(self):
+    return SOMEVAR
+
+class ModuleAWidget(ScriptedLoadableModuleWidget):
+  def setup(self):
+    ScriptedLoadableModuleWidget.setup(self)

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleB.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleB.py
@@ -1,0 +1,24 @@
+
+from slicer.ScriptedLoadableModule import *
+
+SOMEVAR = 'B'
+
+class ModuleB(ScriptedLoadableModule):
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "Module B"
+    self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)",]
+    self.parent.helpText = """
+    This module allows to test the scripted module import.
+    """
+    self.parent.acknowledgementText = """
+    Developed by Jean-Christophe Fillion-Robin, Kitware Inc.,
+    partially funded by NIH grant 3P41RR013218-12S1.
+    """
+
+  def somevar(self):
+    return SOMEVAR
+
+class ModuleBWidget(ScriptedLoadableModuleWidget):
+  def setup(self):
+    ScriptedLoadableModuleWidget.setup(self)

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleC_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleC_WithoutWidget.py
@@ -1,0 +1,20 @@
+
+from slicer.ScriptedLoadableModule import *
+
+SOMEVAR = 'C'
+
+class ModuleC_WithoutWidget(ScriptedLoadableModule):
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "Module A"
+    self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)",]
+    self.parent.helpText = """
+    This module allows to test the scripted module import.
+    """
+    self.parent.acknowledgementText = """
+    Developed by Jean-Christophe Fillion-Robin, Kitware Inc.,
+    partially funded by NIH grant 3P41RR013218-12S1.
+    """
+
+  def somevar(self):
+    return SOMEVAR

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleD_WithFileDialog_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleD_WithFileDialog_WithoutWidget.py
@@ -1,0 +1,38 @@
+
+from slicer.ScriptedLoadableModule import *
+
+SOMEVAR = 'D'
+
+class ModuleD_WithFileDialog_WithoutWidget(ScriptedLoadableModule):
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "Module A"
+    self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)",]
+    self.parent.helpText = """
+    This module allows to test the scripted module import.
+    """
+    self.parent.acknowledgementText = """
+    Developed by Jean-Christophe Fillion-Robin, Kitware Inc.,
+    partially funded by NIH grant 3P41RR013218-12S1.
+    """
+
+  def somevar(self):
+    return SOMEVAR
+
+
+class DICOMFileDialog:
+
+  def __init__(self,qSlicerFileDialog):
+    self.qSlicerFileDialog = qSlicerFileDialog
+    qSlicerFileDialog.fileType = 'Foo Directory'
+    qSlicerFileDialog.description = 'Do something awesome with Foo'
+    qSlicerFileDialog.action = slicer.qSlicerFileDialog.Read
+
+  def execDialog(self):
+    pass
+
+  def isMimeDataAccepted(self):
+    self.qSlicerFileDialog.acceptMimeData(True)
+
+  def dropEvent(self):
+    pass

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleE_WithFileWriter_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleE_WithFileWriter_WithoutWidget.py
@@ -1,0 +1,20 @@
+
+from slicer.ScriptedLoadableModule import *
+
+SOMEVAR = 'E'
+
+class ModuleE_WithFileWriter_WithoutWidget(ScriptedLoadableModule):
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "Module A"
+    self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)",]
+    self.parent.helpText = """
+    This module allows to test the scripted module import.
+    """
+    self.parent.acknowledgementText = """
+    Developed by Jean-Christophe Fillion-Robin, Kitware Inc.,
+    partially funded by NIH grant 3P41RR013218-12S1.
+    """
+
+  def somevar(self):
+    return SOMEVAR

--- a/Base/QTCore/qSlicerScriptedFileWriter.cxx
+++ b/Base/QTCore/qSlicerScriptedFileWriter.cxx
@@ -96,7 +96,7 @@ QString qSlicerScriptedFileWriter::pythonSource()const
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerScriptedFileWriter::setPythonSource(const QString& newPythonSource, const QString& className)
+bool qSlicerScriptedFileWriter::setPythonSource(const QString& newPythonSource, const QString& _className)
 {
   Q_D(qSlicerScriptedFileWriter);
 
@@ -111,24 +111,28 @@ bool qSlicerScriptedFileWriter::setPythonSource(const QString& newPythonSource, 
     }
 
   // Extract moduleName from the provided filename
-  QString classNameToLoad = className;
-  if (classNameToLoad.isEmpty())
+  QString moduleName = QFileInfo(newPythonSource).baseName();
+
+  QString className = _className;
+  if (className.isEmpty())
     {
-    QString moduleName = QFileInfo(newPythonSource).baseName();
-    classNameToLoad = moduleName;
+    className = moduleName;
     if (!moduleName.endsWith("FileWriter"))
       {
-      classNameToLoad.append("FileWriter");
+      className.append("FileWriter");
       }
     }
-  d->PythonClassName = classNameToLoad;
+  d->PythonClassName = className;
 
-  // Get a reference to the main module and global dictionary
-  PyObject * main_module = PyImport_AddModule("__main__");
-  PyObject * global_dict = PyModule_GetDict(main_module);
+  // Get a reference (or create if needed) the <moduleName> python module
+  PyObject * module = PyImport_AddModule(moduleName.toLatin1());
 
-  // Load class definition if needed
-  PyObject * classToInstantiate = PyDict_GetItemString(global_dict, classNameToLoad.toLatin1());
+  // Get a reference to the python module class to instantiate
+  PyObject * classToInstantiate = 0;
+  if (PyObject_HasAttrString(module, className.toLatin1()))
+    {
+    classToInstantiate = PyObject_GetAttrString(module, className.toLatin1());
+    }
   if (!classToInstantiate)
     {
     PythonQt::self()->handleError();

--- a/Base/QTCore/qSlicerScriptedUtils_p.h
+++ b/Base/QTCore/qSlicerScriptedUtils_p.h
@@ -50,7 +50,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerScriptedUtils
 public:
   typedef qSlicerScriptedUtils Self;
 
-  static bool executeFile(const QString& fileName, PyObject * global_dict, const QString& className);
+  static bool loadSourceAsModule(const QString& moduleName, const QString& fileName, PyObject * global_dict, PyObject *local_dict);
 
 private:
   /// Not implemented

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -2,6 +2,7 @@ import os
 from __main__ import vtk, qt, ctk, slicer
 from DICOMLib import DICOMPlugin
 from DICOMLib import DICOMLoadable
+from DICOMLib import DICOMExportScalarVolume
 
 #
 # This is the plugin to handle translation of scalar volumes
@@ -68,7 +69,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
       name = num + ": " + name
 
     # default loadable includes all files for series
-    loadable = DICOMLib.DICOMLoadable()
+    loadable = DICOMLoadable()
     loadable.files = files
     loadable.name = name
     loadable.tooltip = "%d files, first file: %s" % (len(loadable.files), loadable.files[0])
@@ -135,7 +136,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
       if len(subseriesValues[tag]) > 1:
         for value in subseriesValues[tag]:
           # default loadable includes all files for series
-          loadable = DICOMLib.DICOMLoadable()
+          loadable = DICOMLoadable()
           loadable.files = subseriesFiles[tag,value]
           loadable.name = name + " for %s of %s" % (tag,value)
           loadable.tooltip = "%d files, first file: %s" % (len(loadable.files), loadable.files[0])
@@ -411,7 +412,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
       #TODO: more tag checks
 
       # Perform export
-      exporter = DICOMLib.DICOMExportScalarVolume(tags['Study ID'], node.GetAssociatedNode(), tags, directory)
+      exporter = DICOMExportScalarVolume(tags['Study ID'], node.GetAssociatedNode(), tags, directory)
       exporter.export()
 
     # Success


### PR DESCRIPTION
 ENH: Fixes #3549. Import scripted module as python module

This will allow each scripted module to defined top-level variables that
will not clobber each other

See associated commits for more details.

Ping @pieper @fedorov @lassoan @blowekamp @cpinter @mehrtash @naucoin

Associated mantis issue is [#3549](http://www.na-mic.org/Bug/view.php?id=3549)

All test passes.

Building on this, this could potentially allow scripted module to alternatively be implemented as regular python module with a `__init__.py` ( See issue [#1365](http://www.na-mic.org/Bug/view.php?id=1365)). It means scripted module could also be organized [1] like this:
```
/path/to/Editor
/path/to/Editor/__init__.py
/path/to/Editor/Editor.py
/path/to/Editor/Effects/WandEffect.py
[...]
```

[1] This is just an example. some more discussion would need to happen to agree on a layout.