### PR TITLE
BUG: No measurement frame option was not taking into account output imag...

### DIFF
--- a/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.xml
+++ b/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.xml
@@ -3,7 +3,7 @@
   <category>Diffusion.Diffusion Tensor Images</category>
   <title>Resample DTI Volume</title>
   <description><![CDATA[Resampling an image is a very important task in image analysis. It is especially important in the frame of image registration. This module implements DT image resampling through the use of itk Transforms. The resampling is controlled by the Output Spacing. "Resampling" is performed in space coordinates, not pixel/grid coordinates. It is quite important to ensure that image spacing is properly set on the images involved. The interpolator is required since the mapping from one space to the other will often require evaluation of the intensity of the image at non-grid positions.]]></description>
-  <version>0.1</version>
+  <version>1.0.2</version>
   <documentation-url>http://wiki.slicer.org/slicerWiki/index.php/Documentation/4.4/Modules/ResampleDTI</documentation-url>
   <license/>
   <contributor>Francois Budin (UNC)</contributor>


### PR DESCRIPTION
...e orientation

When not using a measurement frame to specify the tensor orientation, but when instead using the image direction, the input image direction was taken into account, but the output image information was not taken into account. When resampling tensors in the same space then their original space, if the direction matrix of the output space was not the identity matrix, this was leading to the tensors being misaligned.