### PR TITLE
ENH: Update teem

### DIFF
--- a/SuperBuild/External_teem.cmake
+++ b/SuperBuild/External_teem.cmake
@@ -47,7 +47,7 @@ if(NOT DEFINED Teem_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/Slicer/teem"
-    GIT_TAG a0ae38afb8913119ca7d584816d81de091fb49d7
+    GIT_TAG b83e5461cca0f734677b3043d48074059012c807
     SOURCE_DIR teem
     BINARY_DIR teem-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
```
$ git shortlog a0ae38a..b83e546 --no-merges
kindlmann (14):
      initial (broken) implementation of nrrdEncodingZRL, and adding nrrdSpaceRightUp and nrrdSpaceRightDown; both of which are reasons for using nrrd magic 6
      forgot to add this
      adding mysteriously missing dyeSpace airEnum, and a utility for command-line image space conversion
      added dieSpace
      whoa! key/value pairs were never saved correctly in plain text files!
      the road ahead
      long-overdue update to logic test after signed->unsigned change
      added airBitsSet
      comment about importance of large values for seekContext->pldArrIncr
      removing copy/paste code from gzip
      first pass at ZRL decompression
      fix from Adam J Shaw
      no need
      fixed bug caused by saving a 3D 1-by-X-by-Y array to an image format like PNG, with fields like space directions that can be usefully preserved in the image meta data: 3 space directions were saved in the image, not two.  This fix is a pretty simplistic one, but it is used in a very targeted way, so it seems safe

rjosest (23):
      fixing double/float precision warnings
      fixing double/float precision warnings
      COMP: Add try_compile to test AIR_EXISTS MACRO
      COMP: adapt to older version of libpng that's part of VTK 5.1
      COMP: Get rid of warnings.
      COMP: fix warning
      COMP: remove debug print from CMakeLists.txt
      COMP: Build/Install modernization
      STYLE: Convert CMake-language commands to lower case
      STYLE: Remove CMake-language block-end command arguments
      COMP: Fix cmake warnings
      STYLE: Remove end-of-line spaces to improve maintenance
      COMP: Update to cmake 2.8 compatibility.
      ENH: Prefer to use $<TARGET_FILE:tgt> for testing
      STYLE: Remove outdated cmake variable
      STYLE: Remove unnecessary conditionals for cmake 2.6
      COMP: Associate component with teem install rules
      COMP: Restore library output path to "lib" folder
      COMP: Prevent target double inclusion with older version of CMake
      COMP: Remove discardd qualifiers warning
      COMP: Remove compiler warnings
      COMP: Fixes a set-but-not-used warning
      COMP: Fixes array-bounds warnings that occur when using O2 optimization on GNUC compilers
```