### PR TITLE
ENH: Make color selector search box case-insensitive

### DIFF
--- a/Modules/Scripted/EditorLib/ColorBox.py
+++ b/Modules/Scripted/EditorLib/ColorBox.py
@@ -116,7 +116,7 @@ class ColorBox(object):
       self.row+=1
     for c in xrange(self.colorNode.GetNumberOfColors()):
       name = self.colorNode.GetColorName(c)
-      if name != "(none)" and name.find(pattern) >= 0:
+      if name != "(none)" and name.lower().find(pattern.lower()) >= 0:
         self.addRow(c)
     self.view.setColumnWidth(0,75)
     self.view.setColumnWidth(1,50)


### PR DESCRIPTION
I'd like to propose that the search box in Editor's color selector be case-insensitive.  This is an extremely minor tweak.  Objections/concerns?