### PR TITLE
2267 add line thickness for label outline

### DIFF
--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.cxx
@@ -35,6 +35,10 @@ vtkMRMLLabelMapVolumeDisplayNode::vtkMRMLLabelMapVolumeDisplayNode()
 {
   this->MapToColors = vtkImageMapToColors::New();
   this->MapToColors->SetOutputFormatToRGBA();
+
+  // set a thicker default slice intersection thickness for use when showing
+  // the outline of the label map
+  this->SliceIntersectionThickness = 3;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Logic/vtkImageLabelOutline.cxx
+++ b/Libs/MRML/Logic/vtkImageLabelOutline.cxx
@@ -51,6 +51,7 @@ static void vtkImageLabelOutlineExecute(vtkImageLabelOutline *self,
                      vtkImageData *outData,
                      int outExt[6], int id)
 {
+  int *kernelMiddle, *kernelSize;
   // For looping though output (and input) pixels.
   int outMin0, outMax0, outMin1, outMax1, outMin2, outMax2;
   int outIdx0, outIdx1, outIdx2;
@@ -95,8 +96,14 @@ static void vtkImageLabelOutlineExecute(vtkImageLabelOutline *self,
   outMin2 = outExt[4];   outMax2 = outExt[5];
 
   // Neighborhood around current voxel
-  self->GetRelativeHoodExtent(hoodMin0, hoodMax0, hoodMin1,
-    hoodMax1, hoodMin2, hoodMax2);
+  kernelSize = self->GetKernelSize();
+  kernelMiddle = self->GetKernelMiddle();
+  hoodMin0 = - kernelMiddle[0];
+  hoodMin1 = - kernelMiddle[1];
+  hoodMin2 = - kernelMiddle[2];
+  hoodMax0 = hoodMin0 + kernelSize[0] - 1;
+  hoodMax1 = hoodMin1 + kernelSize[1] - 1;
+  hoodMax2 = hoodMin2 + kernelSize[2] - 1;
 
   // Set up mask info
   maskPtr = (unsigned char *)(self->GetMaskPointer());
@@ -136,11 +143,11 @@ static void vtkImageLabelOutlineExecute(vtkImageLabelOutline *self,
 
         if (pix != backgnd)
           {
-          // Loop through neighborhood pixels (kernel radius=1)
+          // Loop through neighborhood pixels
           // Note: input pointer marches out of bounds.
-          //hoodPtr2 = inPtr0 - inInc0 - inInc1 - inInc2;
-          hoodPtr2 = inPtr0 + inInc0*hoodMin0 + inInc1*hoodMin1
-            + inInc2*hoodMin2;
+          hoodPtr2 = inPtr0 - kernelMiddle[0] * inInc0
+              - kernelMiddle[1] * inInc1 - kernelMiddle[2] * inInc2;
+
           maskPtr2 = maskPtr;
           for (hoodIdx2 = hoodMin2; hoodIdx2 <= hoodMax2; ++hoodIdx2)
             {
@@ -279,3 +286,18 @@ void vtkImageLabelOutline::PrintSelf(ostream& os, vtkIndent indent)
       }
 }
 
+//----------------------------------------------------------------------------
+void vtkImageLabelOutline::SetOutline(int outline)
+{
+  if (this->Outline == outline)
+    {
+    return;
+    }
+
+  this->Outline = outline;
+
+  // also set the kernel size for 2D
+  this->SetKernelSize(outline, outline, 1);
+
+  this->Modified();
+}

--- a/Libs/MRML/Logic/vtkImageLabelOutline.cxx
+++ b/Libs/MRML/Logic/vtkImageLabelOutline.cxx
@@ -297,7 +297,8 @@ void vtkImageLabelOutline::SetOutline(int outline)
   this->Outline = outline;
 
   // also set the kernel size for 2D
-  this->SetKernelSize(outline, outline, 1);
+  int kernelSize = (outline * 2) + 1;
+  this->SetKernelSize(kernelSize, kernelSize, 1);
 
   this->Modified();
 }

--- a/Libs/MRML/Logic/vtkImageLabelOutline.h
+++ b/Libs/MRML/Logic/vtkImageLabelOutline.h
@@ -38,8 +38,8 @@ public:
   vtkGetMacro(Background, float);
 
   ///
-  /// not used (don't know what it was intended for)
-  vtkSetMacro(Outline, int);
+  /// Thickness of the outline, used to set the kernel size
+  void SetOutline(int outline);
   vtkGetMacro(Outline, int);
 
 protected:
@@ -50,7 +50,7 @@ protected:
   int Outline;
 
   void ThreadedExecute(vtkImageData *inData, vtkImageData *outData,
-  int extent[6], int id);
+                       int extent[6], int id);
 };
 
 #endif

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -874,11 +874,12 @@ void vtkMRMLSliceLayerLogic::UpdateImageDisplay()
       {
       vtkDebugMacro("UpdateImageDisplay: volume node (not diff tensor), using label outline");
 #if (VTK_MAJOR_VERSION <= 5)
-     this->LabelOutline->SetInput( this->Reslice->GetOutput() );
+      this->LabelOutline->SetInput( this->Reslice->GetOutput() );
 #else
       this->LabelOutline->SetInputConnection( this->Reslice->GetOutputPort() );
 #endif
-
+      int outlineThickness = labelMapVolumeDisplayNode->GetSliceIntersectionThickness();
+      this->LabelOutline->SetOutline(outlineThickness);
       // don't activate 3D UVW reslice pipeline if we use single 2D reslice pipeline
       if (this->SliceNode->GetSliceResolutionMode() != vtkMRMLSliceNode::SliceResolutionMatch2DView)
         {

--- a/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerLabelMapVolumeDisplayWidget.ui
+++ b/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerLabelMapVolumeDisplayWidget.ui
@@ -37,7 +37,7 @@
    <item row="1" column="0">
      <widget class="QLabel" name="SliceIntersectionThicknessLabel">
        <property name="text">
-         <string>Slice Intersections &amp;Thickness:</string>
+         <string>Label Outline &amp;Thickness:</string>
        </property>
        <property name="buddy">
          <cstring>SliceIntersectionThicknessSpinBox</cstring>
@@ -56,13 +56,13 @@
          <number>20</number>
        </property>
        <property name="value">
-         <number>1</number>
+         <number>3</number>
        </property>
        <property name="singleStep">
          <number>1</number>
        </property>
        <property name="toolTip">
-         <string>Width of the label outline when displayed unfilled</string>
+         <string>When displaying the label map with the outline/not filled option, this controls the width of the outline.</string>
        </property>
      </widget>
    </item>

--- a/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerLabelMapVolumeDisplayWidget.ui
+++ b/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerLabelMapVolumeDisplayWidget.ui
@@ -34,7 +34,39 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="1" column="0">
+     <widget class="QLabel" name="SliceIntersectionThicknessLabel">
+       <property name="text">
+         <string>Slice Intersections &amp;Thickness:</string>
+       </property>
+       <property name="buddy">
+         <cstring>SliceIntersectionThicknessSpinBox</cstring>
+       </property>
+     </widget>
+   </item>
+   <item row="1" column="1">
+     <widget class="QSpinBox" name="SliceIntersectionThicknessSpinBox">
+       <property name="suffix">
+         <string> px</string>
+       </property>
+       <property name="minimum">
+         <number>1</number>
+       </property>
+       <property name="maximum">
+         <number>20</number>
+       </property>
+       <property name="value">
+         <number>1</number>
+       </property>
+       <property name="singleStep">
+         <number>1</number>
+       </property>
+       <property name="toolTip">
+         <string>Width of the label outline when displayed unfilled</string>
+       </property>
+     </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/Modules/Loadable/Volumes/Widgets/qSlicerLabelMapVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerLabelMapVolumeDisplayWidget.cxx
@@ -66,6 +66,9 @@ void qSlicerLabelMapVolumeDisplayWidgetPrivate::init()
   this->setupUi(q);
   QObject::connect(this->ColorTableComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
                    q, SLOT(setColorNode(vtkMRMLNode*)));
+  QObject::connect(this->SliceIntersectionThicknessSpinBox, SIGNAL(valueChanged(int)),
+                   q, SLOT(setSliceIntersectionThickness(int)));
+
   // disable as there is not MRML Node associated with the widget
   q->setEnabled(false);
 }
@@ -127,6 +130,8 @@ void qSlicerLabelMapVolumeDisplayWidget::updateWidgetFromMRML()
   if (displayNode)
     {
     d->ColorTableComboBox->setCurrentNode(displayNode->GetColorNode());
+    d->SliceIntersectionThicknessSpinBox->setValue(
+       displayNode->GetSliceIntersectionThickness());
     }
 }
 
@@ -141,4 +146,24 @@ void qSlicerLabelMapVolumeDisplayWidget::setColorNode(vtkMRMLNode* colorNode)
     }
   Q_ASSERT(vtkMRMLColorNode::SafeDownCast(colorNode));
   displayNode->SetAndObserveColorNodeID(colorNode->GetID());
+}
+
+// --------------------------------------------------------------------------
+void qSlicerLabelMapVolumeDisplayWidget::setSliceIntersectionThickness(int thickness)
+{
+  Q_D(qSlicerLabelMapVolumeDisplayWidget);
+  vtkMRMLLabelMapVolumeDisplayNode* displayNode =
+    this->volumeDisplayNode();
+  if (!displayNode)
+    {
+    return;
+    }
+  displayNode->SetSliceIntersectionThickness(thickness);
+}
+
+//------------------------------------------------------------------------------
+int qSlicerLabelMapVolumeDisplayWidget::sliceIntersectionThickness()const
+{
+  Q_D(const qSlicerLabelMapVolumeDisplayWidget);
+  return d->SliceIntersectionThicknessSpinBox->value();
 }

--- a/Modules/Loadable/Volumes/Widgets/qSlicerLabelMapVolumeDisplayWidget.h
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerLabelMapVolumeDisplayWidget.h
@@ -50,6 +50,9 @@ public:
 
   vtkMRMLScalarVolumeNode* volumeNode()const;
   vtkMRMLLabelMapVolumeDisplayNode* volumeDisplayNode()const;
+
+  int sliceIntersectionThickness()const;
+
 public slots:
 
   /// Set the MRML node of interest
@@ -57,6 +60,8 @@ public slots:
   void setMRMLVolumeNode(vtkMRMLNode* node);
 
   void setColorNode(vtkMRMLNode* colorNode);
+
+  void setSliceIntersectionThickness(int);
 
 protected slots:
   void updateWidgetFromMRML();


### PR DESCRIPTION
Update the image label outline filter to use a kernel for thicker lines when displaying the label map layer in outline mode.
Uses the SliceIntersectionThickness setting on the display node, setting a default of 3 instead of 1 as used for model slice intersection thicknesses.