### PR TITLE
BUG: Editor: Ensure label map is updated each time a master volume is selected

### DIFF
--- a/Modules/Scripted/EditorLib/HelperBox.py
+++ b/Modules/Scripted/EditorLib/HelperBox.py
@@ -110,6 +110,7 @@ class HelperBox(object):
     """select master volume - load merge volume if one with the correct name exists"""
 
     self.master = self.masterSelector.currentNode()
+    self.merge = None
     merge = self.mergeVolume()
     mergeText = "None"
     if merge:


### PR DESCRIPTION
Before the commit, the following was failing:
(1) Go to SampleData -> Load MRHead
(2) Go to Editor -> Create GenericAnatomyColors label map
(3) Go to SampleData -> Load CTACardio
(4) Go to Editor -> Select CTACardio master volume -> Create GenericAnatomyColors label map
(5) Select MRHead master volume, select CTACardio master volume
-> Popup message with "Warning: Geometry of master and merge volumes do not match."
-> Label map associated with CTACardio is not selected

Note also that this problem is independent of commit r24202 (BUG: Pattern
matching for label volume does not account for underscore)