### PR TITLE
Add support for view node visibility

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -30,7 +30,7 @@ vtkMRMLAbstractViewNode::vtkMRMLAbstractViewNode()
 {
   this->LayoutLabel = NULL;
   this->Active = 0;
-  this->Visibility = 0;
+  this->Visibility = 1;
 
   double black[3] = {0.,0.,0.};
   memcpy(this->BackgroundColor, black, 3 * sizeof(double));

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -140,17 +140,27 @@ void vtkMRMLAbstractViewNode::ReadXMLAttributes(const char** atts)
         this->Active = 0;
         }
       }
-    else if (!strcmp(attName, "visibility"))
-      {
-      if (!strcmp(attValue,"true"))
-        {
-        this->Visibility = 1;
-        }
-      else
-        {
-        this->Visibility = 0;
-        }
-      }
+    // XXX Do not read 'visibility' attribute and default to 1 because:
+    // (1) commit r21034 (STYLE: Add abstract class for all view nodes)
+    // changed the default value for 'visibility' attribute from 1 to 0. This
+    // means there are a lot of already saved scene where visibility attribute
+    // value is saved as 0.
+    // (2) support for visibility attribute by the layout manager has been
+    // added.
+    // XXX Support for 'visibility' attribute could be restored by updating
+    // the mrml version. Scene with a newer version number would consider the
+    // serialized attribute whereas older scene would not.
+//    else if (!strcmp(attName, "visibility"))
+//      {
+//      if (!strcmp(attValue,"true"))
+//        {
+//        this->Visibility = 1;
+//        }
+//      else
+//        {
+//        this->Visibility = 0;
+//        }
+//      }
     }
 #if MRML_SUPPORT_VERSION < 0x040000
   if (!isBackgroundColor2Set)

--- a/Libs/MRML/Widgets/Testing/CMakeLists.txt
+++ b/Libs/MRML/Widgets/Testing/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_SOURCES
   qMRMLLayoutManagerTest2.cxx
   qMRMLLayoutManagerTest3.cxx
   qMRMLLayoutManagerTest4.cxx
+  qMRMLLayoutManagerVisibilityTest.cxx
   qMRMLLayoutManagerWithCustomFactoryTest.cxx
   qMRMLLinearTransformSliderTest1.cxx
   qMRMLListWidgetTest1.cxx
@@ -179,6 +180,7 @@ simple_test( qMRMLLayoutManagerTest1 )
 simple_test( qMRMLLayoutManagerTest2 )
 simple_test( qMRMLLayoutManagerTest3 )
 simple_test( qMRMLLayoutManagerTest4 )
+simple_test( qMRMLLayoutManagerVisibilityTest )
 simple_test( qMRMLLayoutManagerWithCustomFactoryTest )
 simple_test( qMRMLLinearTransformSliderTest1 )
 simple_test( qMRMLListWidgetTest1 )

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
@@ -1,0 +1,292 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
+  and was partially funded by NIH grant 3P41RR013218-12S1
+
+==============================================================================*/
+
+// Qt includes
+#include <QApplication>
+#include <QHash>
+#include <QWidget>
+
+// Slicer includes
+#include "qMRMLLayoutManager.h"
+
+// MRML includes
+#include <vtkMRMLAbstractViewNode.h>
+#include <vtkMRMLApplicationLogic.h>
+#include <vtkMRMLLayoutLogic.h>
+#include <vtkMRMLLayoutNode.h>
+#include <vtkMRMLScene.h>
+#include <vtkMRMLSliceNode.h>
+#include <vtkMRMLViewNode.h>
+
+// VTK includes
+#include <vtkNew.h>
+
+// --------------------------------------------------------------------------
+bool checkNodeVisibility(int line,
+                         vtkMRMLAbstractViewNode* viewNode,
+                         bool expectedNodeVisibility)
+{
+  int nodeVisibility = viewNode->GetVisibility();
+  if (nodeVisibility != expectedNodeVisibility)
+    {
+    std::cerr << "Line " << line << " - Problem with GetVisibility()"
+              << " associated with node " << viewNode->GetID() << "\n"
+              << "  visibility: " << nodeVisibility << "\n"
+              << "  expectedVisibility: " << expectedNodeVisibility << std::endl;
+    return false;
+    }
+  return true;
+}
+
+// --------------------------------------------------------------------------
+bool checkViews(int line,
+                qMRMLLayoutManager* layoutManager,
+                QHash<vtkMRMLAbstractViewNode*, bool> viewNodesToExpectedVisibility)
+{
+  foreach(vtkMRMLAbstractViewNode* viewNode, viewNodesToExpectedVisibility.keys())
+    {
+    if (!viewNode)
+      {
+      std::cerr << "Line " << line << " - Problem with to GetNodeByID()."
+               << " 'viewNode' should NOT be null." << std::endl;
+      return false;
+      }
+
+    if (!checkNodeVisibility(line, viewNode, viewNodesToExpectedVisibility[viewNode]))
+      {
+      return false;
+      }
+
+    QWidget* viewWidget = layoutManager->viewWidget(viewNode);
+    if (!viewWidget)
+      {
+      std::cerr << "Line " << line << " - Failed to retrieve view widget"
+               << "associated with view node " << viewNode->GetID() << std::endl;
+      return false;
+      }
+
+    bool widgetVisibility = viewWidget->isVisible();
+    bool expectedWidgetVisibility = viewNodesToExpectedVisibility[viewNode];
+    if (widgetVisibility != expectedWidgetVisibility)
+      {
+      std::cerr << "Line " << line << " - Problem with widget visibility"
+                << " associated with node " << viewNode->GetID() << "\n"
+                << "  widgetVisibility: " << widgetVisibility << "\n"
+                << "  expectedWidgetVisibility: " << expectedWidgetVisibility << std::endl;
+      return false;
+      }
+    }
+  return true;
+}
+
+// --------------------------------------------------------------------------
+bool runTests(vtkMRMLScene* scene,
+              vtkMRMLLayoutNode* layoutNode,
+              qMRMLLayoutManager* layoutManager)
+{
+  layoutNode->SetViewArrangement(vtkMRMLLayoutNode::SlicerLayoutConventionalView);
+  qApp->processEvents();
+
+  vtkMRMLAbstractViewNode* redNode = vtkMRMLAbstractViewNode::SafeDownCast(
+        scene->GetNodeByID("vtkMRMLSliceNodeRed"));
+  vtkMRMLAbstractViewNode* yellowNode = vtkMRMLAbstractViewNode::SafeDownCast(
+        scene->GetNodeByID("vtkMRMLSliceNodeYellow"));
+  vtkMRMLAbstractViewNode* greenNode = vtkMRMLAbstractViewNode::SafeDownCast(
+        scene->GetNodeByID("vtkMRMLSliceNodeGreen"));
+  vtkMRMLAbstractViewNode* threeDNode = vtkMRMLAbstractViewNode::SafeDownCast(
+        scene->GetNodeByID("vtkMRMLViewNode1"));
+
+
+  // All view widgets are expected to be visible
+  {
+    QHash<vtkMRMLAbstractViewNode*, bool> viewNodesToExpectedVisibility;
+    viewNodesToExpectedVisibility[redNode] = true;
+    viewNodesToExpectedVisibility[yellowNode] = true;
+    viewNodesToExpectedVisibility[greenNode] = true;
+    viewNodesToExpectedVisibility[threeDNode] = true;
+
+    if (!checkViews(__LINE__, layoutManager, viewNodesToExpectedVisibility))
+      {
+      return false;
+      }
+  }
+
+  yellowNode->SetVisibility(0);
+  qApp->processEvents();
+
+  // Yellow widget is expected to be hidden
+  {
+    QHash<vtkMRMLAbstractViewNode*, bool> viewNodesToExpectedVisibility;
+    viewNodesToExpectedVisibility[redNode] = true;
+    viewNodesToExpectedVisibility[yellowNode] = false;
+    viewNodesToExpectedVisibility[greenNode] = true;
+    viewNodesToExpectedVisibility[threeDNode] = true;
+
+    if (!checkViews(__LINE__, layoutManager, viewNodesToExpectedVisibility))
+      {
+      return false;
+      }
+  }
+
+  threeDNode->SetVisibility(0);
+  qApp->processEvents();
+
+  // Yellow and ThreeD widgets are expected to be hidden
+  {
+    QHash<vtkMRMLAbstractViewNode*, bool> viewNodesToExpectedVisibility;
+    viewNodesToExpectedVisibility[redNode] = true;
+    viewNodesToExpectedVisibility[yellowNode] = false;
+    viewNodesToExpectedVisibility[greenNode] = true;
+    viewNodesToExpectedVisibility[threeDNode] = false;
+
+    if (!checkViews(__LINE__, layoutManager, viewNodesToExpectedVisibility))
+      {
+      return false;
+      }
+  }
+
+  layoutNode->SetViewArrangement(vtkMRMLLayoutNode::SlicerLayoutFourUpQuantitativeView);
+  qApp->processEvents();
+
+  vtkMRMLAbstractViewNode* chartNode =
+      vtkMRMLAbstractViewNode::SafeDownCast(scene->GetNodeByID("vtkMRMLChartViewNodeChartView1"));
+
+  // Only yellow widgets is expected to be hidden
+  {
+    QHash<vtkMRMLAbstractViewNode*, bool> viewNodesToExpectedVisibility;
+    viewNodesToExpectedVisibility[redNode] = true;
+    viewNodesToExpectedVisibility[yellowNode] = false;
+    viewNodesToExpectedVisibility[greenNode] = true;
+    viewNodesToExpectedVisibility[chartNode] = true;
+
+    if (!checkViews(__LINE__, layoutManager, viewNodesToExpectedVisibility))
+      {
+      return false;
+      }
+  }
+
+  layoutNode->SetViewArrangement(vtkMRMLLayoutNode::SlicerLayoutConventionalView);
+  qApp->processEvents();
+
+  // Yellow and ThreeD widgets are expected to be hidden
+  {
+    QHash<vtkMRMLAbstractViewNode*, bool> viewNodesToExpectedVisibility;
+    viewNodesToExpectedVisibility[redNode] = true;
+    viewNodesToExpectedVisibility[yellowNode] = false;
+    viewNodesToExpectedVisibility[greenNode] = true;
+    viewNodesToExpectedVisibility[threeDNode] = false;
+
+    if (!checkViews(__LINE__, layoutManager, viewNodesToExpectedVisibility))
+      {
+      return false;
+      }
+  }
+
+  scene->Clear(/*removeSingletons = */ 0);
+  qApp->processEvents();
+
+  // All view widgets are expected to be visible
+  {
+    QHash<vtkMRMLAbstractViewNode*, bool> viewNodesToExpectedVisibility;
+    viewNodesToExpectedVisibility[redNode] = true;
+    viewNodesToExpectedVisibility[yellowNode] = true;
+    viewNodesToExpectedVisibility[greenNode] = true;
+    viewNodesToExpectedVisibility[threeDNode] = true;
+
+    if (!checkViews(__LINE__, layoutManager, viewNodesToExpectedVisibility))
+      {
+      return false;
+      }
+  }
+
+  {
+    // The following test will check that the view node visibility attribute
+    // is ignored when loading a scene.
+    // For more detailed, see comment in vtkMRMLAbstractViewNode::ReadXMLAttributes
+
+    yellowNode->SetVisibility(0);
+    qApp->processEvents();
+
+    if (!checkNodeVisibility(__LINE__,
+                             yellowNode,
+                             /* expectedNodeVisibility = */ 0))
+      {
+      return false;
+      }
+
+    scene->SetSaveToXMLString(1);
+    scene->Commit();
+
+    // Serialized scene has yellow node with visibility set to 0
+    std::string xmlScene = scene->GetSceneXMLString();
+
+    // Clear current scene
+    scene->Clear(/*removeSingletons = */ 0);
+    qApp->processEvents();
+
+    if (!checkNodeVisibility(__LINE__,
+                             yellowNode,
+                             /* expectedNodeVisibility = */ 1))
+      {
+      return false;
+      }
+
+    scene->SetLoadFromXMLString(1);
+    scene->SetSceneXMLString(xmlScene);
+    scene->Import();
+    qApp->processEvents();
+
+    if (!checkNodeVisibility(__LINE__,
+                             yellowNode,
+                             /* expectedNodeVisibility = */ 1))
+      {
+      return false;
+      }
+  }
+
+  return true;
+}
+
+// --------------------------------------------------------------------------
+int qMRMLLayoutManagerVisibilityTest(int argc, char * argv[] )
+{
+  QApplication app(argc, argv);
+
+  QWidget w;
+  w.show();
+
+  qMRMLLayoutManager layoutManager(&w, &w);
+
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+
+  vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLLayoutNode> layoutNode;
+
+  scene->AddNode(layoutNode.GetPointer());
+  applicationLogic->SetMRMLScene(scene.GetPointer());
+  layoutManager.setMRMLScene(scene.GetPointer());
+
+  if (!runTests(scene.GetPointer(), layoutNode.GetPointer(), &layoutManager))
+    {
+    return EXIT_FAILURE;
+    }
+
+  return EXIT_SUCCESS;
+}

--- a/Libs/MRML/Widgets/qMRMLLayoutViewFactory.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutViewFactory.h
@@ -108,8 +108,10 @@ public Q_SLOTS:
 
   virtual void onNodeAdded(vtkObject* scene, vtkObject* node);
   virtual void onNodeRemoved(vtkObject* scene, vtkObject* node);
+  virtual void onNodeModified(vtkObject* node);
   virtual void onViewNodeAdded(vtkMRMLAbstractViewNode* node);
   virtual void onViewNodeRemoved(vtkMRMLAbstractViewNode* node);
+  virtual void onViewNodeModified(vtkMRMLAbstractViewNode* node);
 
   /// Populate widgets from the scene. The widgets will then be used by viewFromXML()
   /// \sa viewFromXML()


### PR DESCRIPTION
After integrating this topic, calling `SetVisibility()` on a view node will effectively hide/show the associated widget in the layout.

Note that as detailed in 451973b, this set of patches disable the reading of view node visibility attribute from the MRML file. Associated comment is also reported below:

```
+    // XXX Do not read 'visibility' attribute and default to 1 because:
+    // (1) commit r21034 (STYLE: Add abstract class for all view nodes)
+    // changed the default value for 'visibility' attribute from 1 to 0. This
+    // means there are a lot of already saved scene where visibility attribute
+    // value is saved as 0.
+    // (2) support for visibility attribute by the layout manager has been
+    // added.
+    // XXX Support for 'visibility' attribute could be restored by updating
+    // the mrml version. Scene with a newer version number would consider the
+    // serialized attribute whereas older scene would not.
```