### PR TITLE
BUG: Fix "orphan view" issue in layout manager

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -246,3 +246,29 @@ void vtkMRMLAbstractViewNode::RemoveActiveFlagInScene()
       }
     }
 }
+
+//------------------------------------------------------------------------------
+int vtkMRMLAbstractViewNode::IsMappedInLayout()
+{
+  if (!this->GetAttribute("MappedInLayout"))
+    {
+    return 0;
+    }
+  return strcmp(this->GetAttribute("MappedInLayout"), "1") == 0;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLAbstractViewNode::SetMappedInLayout(int value)
+{
+  if (this->IsMappedInLayout() == value)
+    {
+    return;
+    }
+  this->SetAttribute("MappedInLayout", value ? "1" : "0");
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLAbstractViewNode::IsViewVisibleInLayout()
+{
+  return (this->IsMappedInLayout() && this->GetVisibility());
+}

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -71,12 +71,33 @@ public:
   vtkGetMacro (Active, int );
   vtkSetMacro (Active, int );
 
+  /// \brief Indicates whether or not the view is visible.
   ///
-  /// Indicates whether or not the view is visible (if it is not visible,
-  /// then the view is not shown in any of the view layouts, but can be privately
-  /// used by modules)
+  /// If it is not visible, then the view is not shown in any of the view
+  /// layouts, but can be privately used by modules.
+  ///
+  /// \sa IsViewVisibleInLayout()
+  /// \sa IsMappedInLayout()
   vtkGetMacro(Visibility, int);
   vtkSetMacro(Visibility, int);
+
+
+  /// Indicates whether or not the view is mapped in the current layout.
+  /// \sa GetVisibility()
+  /// \sa IsViewVisibleInLayout()
+  /// \sa vtkMRMLLayoutNode::SetViewArrangement()
+  virtual int IsMappedInLayout();
+  virtual void SetMappedInLayout(int value);
+
+  /// \brief Indicates whether or not the view is visible in the current layout.
+  ///
+  /// A view is visible in the current layout it is both mapped in layout
+  /// and visible.
+  ///
+  /// \sa GetVisibility()
+  /// \sa IsMappedInLayout()
+  /// \sa vtkMRMLLayoutNode::SetViewArrangement()
+  bool IsViewVisibleInLayout();
 
   ///
   /// 1st background color of the view.

--- a/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
@@ -301,6 +301,17 @@ int qMRMLLayoutViewFactory::viewCount()const
 }
 
 // --------------------------------------------------------------------------
+void qMRMLLayoutViewFactory::beginSetupLayout()
+{
+  Q_D(qMRMLLayoutViewFactory);
+  this->Superclass::beginSetupLayout();
+  foreach(vtkMRMLAbstractViewNode* viewNode, d->Views.keys())
+    {
+    viewNode->SetMappedInLayout(0);
+    }
+}
+
+// --------------------------------------------------------------------------
 void qMRMLLayoutViewFactory::onNodeAdded(vtkObject* scene, vtkObject* node)
 {
   Q_D(qMRMLLayoutViewFactory);
@@ -385,7 +396,8 @@ void qMRMLLayoutViewFactory::onViewNodeRemoved(vtkMRMLAbstractViewNode* node)
 // --------------------------------------------------------------------------
 void qMRMLLayoutViewFactory::onViewNodeModified(vtkMRMLAbstractViewNode* node)
 {
-  this->viewWidget(node)->setVisible(node->GetVisibility());
+  Q_D(qMRMLLayoutViewFactory);
+  this->viewWidget(node)->setVisible(node->IsViewVisibleInLayout());
 }
 
 // --------------------------------------------------------------------------
@@ -554,7 +566,7 @@ void qMRMLLayoutViewFactory::setupView(QDomElement viewElement, QWidget*view)
   this->Superclass::setupView(viewElement, view);
   vtkMRMLAbstractViewNode* viewNode = this->viewNode(view);
   Q_ASSERT(viewNode);
-  viewNode->SetAttribute("MappedInLayout", "1");
+  viewNode->SetMappedInLayout(1);
   view->setVisible(viewNode->GetVisibility());
   view->setWindowTitle(viewNode->GetName());
 }

--- a/Libs/MRML/Widgets/qMRMLLayoutViewFactory.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutViewFactory.h
@@ -90,6 +90,8 @@ public:
   QWidget* viewWidget(const QString& name)const;
   int viewCount()const;
 
+  virtual void beginSetupLayout();
+
   vtkMRMLAbstractViewNode* viewNode(QWidget* widget)const;
 
   /// Return all the names of the created view nodes.


### PR DESCRIPTION
**** WORK IN PROGRESS ****
Todo:
* Update test. Test doesn't pass yet. It needs to consider the
"MappedInLayout" attribute when checking visibility
* Update documentation to clearly document MappedInLayout vs Visibility.
**** WORK IN PROGRESS ****

The node visibility is now set considering both the "MappedInLayout"
and the Visibility properties.

It fixes a regression re-introduced in r24209 (ENH: Update layout
view factory to consider view node visibility property) that was
originally fixed in r24175 (BUG: Fixed orphaned views displayed in
secondary layout widgets).