### PR TITLE
BUG: Fixed labelmap selector in Editor

### DIFF
--- a/Modules/Scripted/EditorLib/HelperBox.py
+++ b/Modules/Scripted/EditorLib/HelperBox.py
@@ -110,8 +110,8 @@ class HelperBox(object):
     """select master volume - load merge volume if one with the correct name exists"""
 
     self.master = self.masterSelector.currentNode()
-    self.merge = None
     merge = self.mergeVolume()
+    self.merge = None
     mergeText = "None"
     if merge:
       if merge.GetClassName() != "vtkMRMLScalarVolumeNode" or not merge.GetLabelMap():
@@ -189,7 +189,7 @@ class HelperBox(object):
         return self.merge
 
     self.merge = None
-    self.masterWhenMergeWasSemasterWhenMergeWasSet = None
+    self.masterWhenMergeWasSet = None
 
     # otherwise pick the merge based on the master name
     # - either return the merge volume or empty string


### PR DESCRIPTION
It was not possible to select any other labelmap than the default.

For example:
* Download MRHead sample
* Go to Editor module, click apply in the colormap selector
* Click "Set..." button to set another labelmap
* Click "Create new...", click apply in the colormap selector
=> ERROR: still the old labelmap is selected
* Click "Set..." button to set another labelmap
* Select the new labelmap
=> ERROR: still the old labelmap is selected