### PR TITLE
ENH: added zoomed in view of the slice under the cursor.

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -95,6 +95,9 @@ class DataProbeInfoWidget(object):
     self.imageZoom = 10
     self.showImage = False
 
+    self.painter = qt.QPainter()
+    self.pen = qt.QPen()
+
     if type == 'small':
       self.createSmall()
 
@@ -309,6 +312,15 @@ class DataProbeInfoWidget(object):
           slicer.qMRMLUtils().vtkImageDataToQImage(vtkImage, qImage)
           self.imagePixmap = self.imagePixmap.fromImage(qImage)
           self.imagePixmap = self.imagePixmap.scaled(self.imageLabel.size, qt.Qt.KeepAspectRatio, qt.Qt.FastTransformation)
+
+          # draw crosshair
+          self.painter.begin(self.imagePixmap)
+          self.pen.setColor(color)
+          self.painter.setPen(self.pen)
+          self.painter.drawLine(0,self.imagePixmap.height()/2, self.imagePixmap.width(), self.imagePixmap.height()/2)
+          self.painter.drawLine(self.imagePixmap.width()/2,0, self.imagePixmap.width()/2, self.imagePixmap.height())
+          self.painter.end()
+
           self.imageLabel.setPixmap(self.imagePixmap)
           self.onShowImage(self.showImage)
 

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -289,7 +289,7 @@ class DataProbeInfoWidget(object):
         "<b>%s</b>" % self.getPixelString(volumeNode,ijk) if volumeNode else "")
 
     # set image
-    if sliceLogic and hasVolume and self.showImage:
+    if (not slicer.mrmlScene.IsBatchProcessing()) and sliceLogic and hasVolume and self.showImage:
       self.imageCrop.SetInputConnection(sliceLogic.GetBlend().GetOutputPort())
       xyzInt = [0, 0, 0]
       xyzInt = [_roundInt(value) for value in xyz]
@@ -300,16 +300,17 @@ class DataProbeInfoWidget(object):
       imax = min(dims[0]-1,  xyzInt[0]+imageSize)
       jmin = max(0,xyzInt[1]-imageSize)
       jmax = min(dims[1]-1,  xyzInt[1]+imageSize)
-      self.imageCrop.SetVOI(imin, imax, jmin, jmax, 0,0)
-      self.imageCrop.Update()
-      vtkImage = self.imageCrop.GetOutput()
-      if vtkImage:
-        qImage = qt.QImage()
-        slicer.qMRMLUtils().vtkImageDataToQImage(vtkImage, qImage)
-        self.imagePixmap = self.imagePixmap.fromImage(qImage)
-        self.imagePixmap = self.imagePixmap.scaled(self.imageLabel.size, qt.Qt.KeepAspectRatio, qt.Qt.FastTransformation)
-        self.imageLabel.setPixmap(self.imagePixmap)
-      self.onShowImage(self.showImage)
+      if (imin <= imax) and (jmin <= jmax):
+        self.imageCrop.SetVOI(imin, imax, jmin, jmax, 0,0)
+        self.imageCrop.Update()
+        vtkImage = self.imageCrop.GetOutput()
+        if vtkImage:
+          qImage = qt.QImage()
+          slicer.qMRMLUtils().vtkImageDataToQImage(vtkImage, qImage)
+          self.imagePixmap = self.imagePixmap.fromImage(qImage)
+          self.imagePixmap = self.imagePixmap.scaled(self.imageLabel.size, qt.Qt.KeepAspectRatio, qt.Qt.FastTransformation)
+          self.imageLabel.setPixmap(self.imagePixmap)
+          self.onShowImage(self.showImage)
 
     sceneName = slicer.mrmlScene.GetURL()
     if sceneName != "":

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -268,6 +268,7 @@ class DataProbeInfoWidget(object):
       except ValueError:
         return 0
 
+    hasVolume = False
     layerLogicCalls = (('L', sliceLogic.GetLabelLayer),
                        ('F', sliceLogic.GetForegroundLayer),
                        ('B', sliceLogic.GetBackgroundLayer))
@@ -276,6 +277,7 @@ class DataProbeInfoWidget(object):
       volumeNode = layerLogic.GetVolumeNode()
       ijk = [0, 0, 0]
       if volumeNode:
+        hasVolume = True
         xyToIJK = layerLogic.GetXYToIJKTransform()
         ijkFloat = xyToIJK.TransformDoublePoint(xyz)
         ijk = [_roundInt(value) for value in ijkFloat]
@@ -287,7 +289,7 @@ class DataProbeInfoWidget(object):
         "<b>%s</b>" % self.getPixelString(volumeNode,ijk) if volumeNode else "")
 
     # set image
-    if sliceLogic and self.showImage:
+    if sliceLogic and hasVolume and self.showImage:
       self.imageCrop.SetInputConnection(sliceLogic.GetBlend().GetOutputPort())
       xyzInt = [0, 0, 0]
       xyzInt = [_roundInt(value) for value in xyz]

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -62,7 +62,13 @@ See <a>http://www.slicer.org</a> for details.  Module implemented by Steve Piepe
       print("No Data Probe frame - cannot create DataProbe")
       return
     self.infoWidget = DataProbeInfoWidget(parent,type='small')
+    self.infoWidget.onShowImage(False)
     parent.layout().insertWidget(0,self.infoWidget.frame)
+
+  def showZoomedSlice(self, value=False):
+    self.showZoomedSlice = value
+    if self.infoWidget:
+      self.infoWidget.onShowImage(value)
 
 class DataProbeInfoWidget(object):
 
@@ -309,13 +315,18 @@ class DataProbeInfoWidget(object):
     self.goToModule.hide()
 
     # image view
-    if self.showImage:
-      self.imageLabel = qt.QLabel()
-      self.imagePixmap = qt.QPixmap()
-      qSize = qt.QSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding)
-      self.imageLabel.setSizePolicy(qSize)
-      #self.imageLabel.setScaledContents(True)
-      self.frame.layout().addWidget(self.imageLabel)
+    self.showImageBox = qt.QCheckBox('Show Zoomed Slice', self.frame)
+    self.frame.layout().addWidget(self.showImageBox)
+    self.showImageBox.connect("toggled(bool)", self.onShowImage)
+    self.showImageBox.setChecked(False)
+
+    self.imageLabel = qt.QLabel()
+    self.imagePixmap = qt.QPixmap()
+    qSize = qt.QSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding)
+    self.imageLabel.setSizePolicy(qSize)
+    #self.imageLabel.setScaledContents(True)
+    self.frame.layout().addWidget(self.imageLabel)
+    self.onShowImage(False)
 
     # top row - things about the viewer itself
     self.viewerFrame = qt.QFrame(self.frame)
@@ -374,6 +385,12 @@ class DataProbeInfoWidget(object):
   def onGoToModule(self):
     m = slicer.util.mainWindow()
     m.moduleSelector().selectModule('DataProbe')
+
+  def onShowImage(self, value=False):
+    if value:
+      self.imageLabel.show()
+    else:
+      self.imageLabel.hide()
 
 #
 # DataProbe widget


### PR DESCRIPTION
This functionality was available in Slicer2 and has been requested by Raul's COPD group. It creates a zoomed-in view of a slice centered on the mouse cursor in the Data Probe panel. The zoom factor is currently set to 10. Should it be configurable?
