### PR TITLE
BUG: ensure libvtkGUISupportQtOpenGL is packaged on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,7 @@ if(${VTK_VERSION_MAJOR} GREATER 5)
     vtkFiltersExtraction
     vtkFiltersFlowPaths
     vtkFiltersGeometry
+    vtkGUISupportQtOpenGL
     vtkIOImage
     vtkIOLegacy
     vtkIOPLY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,8 @@ if(${VTK_VERSION_MAJOR} GREATER 5)
     vtkFiltersFlowPaths
     vtkFiltersGeometry
     vtkGUISupportQtOpenGL
+    vtkGUISupportQtWebkit
+    vtkGUISupportQtSQL
     vtkIOImage
     vtkIOLegacy
     vtkIOPLY


### PR DESCRIPTION
The library is not packaged, and this appears to be a regression
from the earlier fix here

https://github.com/Slicer/Slicer/commit/17564f2aba3c59c9cc45ee6d38e321cf878caa11