### PR TITLE
3956 repeated saves of mrbs cause corruption rebase

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -206,6 +206,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
   slicer_add_python_unittest(SCRIPT test_tractography_display.py)
   slicer_add_python_unittest(SCRIPT sceneImport2428.py)
   slicer_add_python_unittest(SCRIPT SlicerMRBTest.py)
+  slicer_add_python_unittest(SCRIPT SlicerMRBMultipleSaveRestoreLoopTest.py)
   slicer_add_python_unittest(SCRIPT SlicerMRBMultipleSaveRestoreTest.py)
   slicer_add_python_unittest(SCRIPT Slicer4Minute.py)
   slicer_add_python_unittest(SCRIPT Charting.py)
@@ -229,6 +230,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
     test_tractography_display.py
     sceneImport2428.py
     SlicerMRBTest.py
+    SlicerMRBMultipleSaveRestoreLoopTest.py
     SlicerMRBMultipleSaveRestoreTest.py
     Slicer4Minute.py
     Charting.py

--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -208,6 +208,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
   slicer_add_python_unittest(SCRIPT SlicerMRBTest.py)
   slicer_add_python_unittest(SCRIPT SlicerMRBMultipleSaveRestoreLoopTest.py)
   slicer_add_python_unittest(SCRIPT SlicerMRBMultipleSaveRestoreTest.py)
+  slicer_add_python_unittest(SCRIPT SlicerMRBSaveRestoreCheckPathsTest.py)
   slicer_add_python_unittest(SCRIPT Slicer4Minute.py)
   slicer_add_python_unittest(SCRIPT Charting.py)
   slicer_add_python_unittest(SCRIPT SliceLinkLogic.py)
@@ -232,6 +233,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
     SlicerMRBTest.py
     SlicerMRBMultipleSaveRestoreLoopTest.py
     SlicerMRBMultipleSaveRestoreTest.py
+    SlicerMRBSaveRestoreCheckPathsTest.py
     Slicer4Minute.py
     Charting.py
     SliceLinkLogic.py

--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -206,6 +206,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
   slicer_add_python_unittest(SCRIPT test_tractography_display.py)
   slicer_add_python_unittest(SCRIPT sceneImport2428.py)
   slicer_add_python_unittest(SCRIPT SlicerMRBTest.py)
+  slicer_add_python_unittest(SCRIPT SlicerMRBMultipleSaveRestoreTest.py)
   slicer_add_python_unittest(SCRIPT Slicer4Minute.py)
   slicer_add_python_unittest(SCRIPT Charting.py)
   slicer_add_python_unittest(SCRIPT SliceLinkLogic.py)
@@ -228,6 +229,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
     test_tractography_display.py
     sceneImport2428.py
     SlicerMRBTest.py
+    SlicerMRBMultipleSaveRestoreTest.py
     Slicer4Minute.py
     Charting.py
     SliceLinkLogic.py

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
@@ -1,0 +1,217 @@
+
+import os
+import unittest
+import vtk
+import qt
+import slicer
+import EditorLib
+
+class SlicerMRBMultipleSaveRestoreLoop(unittest.TestCase):
+  """ Test for slicer data bundle with scene restore and multiple saves.
+
+Run manually from within slicer by pasting an version of this with the correct path into the python console:
+execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py'); t = SlicerMRBMultipleSaveRestoreLoop(); t.setUp(); t.runTest()
+
+  """
+
+  def __init__(self,methodName='runTest', numberOfIterations=5, uniqueDirectory=True, strict=False):
+    """
+    Tests the use of mrml and mrb save formats with volumes and fiducials.
+    Checks that scene views are saved and restored as expected after multiple
+    MRB saves and loads.
+
+    numberOfIterations: integer number of times to save and restore an MRB.
+    uniqueDirectory: boolean about save directory
+                     False to reuse standard dir name
+                     True timestamps dir name
+    strict: boolean about how carefully to check result
+                     True then check every detail
+                     False then confirm basic operation, but allow non-critical issues to pass
+    """
+    unittest.TestCase.__init__(self,methodName)
+    print 'Setting number of iterations to ',numberOfIterations
+    self.numberOfIterations = numberOfIterations
+    self.uniqueDirectory = uniqueDirectory
+    self.strict = strict
+
+  def delayDisplay(self,message,msec=1000):
+    print(message)
+    self.info = qt.QDialog()
+    self.infoLayout = qt.QVBoxLayout()
+    self.info.setLayout(self.infoLayout)
+    self.label = qt.QLabel(message,self.info)
+    self.infoLayout.addWidget(self.label)
+    qt.QTimer.singleShot(msec, self.info.close)
+    self.info.exec_()
+
+  def setUp(self):
+    slicer.mrmlScene.Clear(0)
+
+  def runTest(self):
+    self.setUp()
+    self.test_SlicerMRBMultipleSaveRestoreLoop()
+    self.test_PercentEncode()
+
+
+  def test_SlicerMRBMultipleSaveRestoreLoop(self):
+    """
+    Stress test the issue reported in bug 3956 where saving
+    and restoring an MRB file does not work.
+    """
+
+    print("Running SlicerMRBMultipleSaveRestoreLoop Test case with:")
+    print("numberOfIterations: %s" % self.numberOfIterations)
+    print("uniqueDirectory : %s" % self.uniqueDirectory)
+    print("strict : %s" % self.strict)
+
+    #
+    # first, get the data
+    #
+    import SampleData
+    sampleDataLogic = SampleData.SampleDataLogic()
+    print("Getting MR Head Volume")
+    mrHeadVolume = sampleDataLogic.downloadMRHead()
+
+    # Place a fiducial
+    markupsLogic = slicer.modules.markups.logic()
+    fid1 = [0.0, 0.0, 0.0]
+    fidIndex1 = markupsLogic.AddFiducial(fid1[0], fid1[1], fid1[2])
+    fidID = markupsLogic.GetActiveListID()
+    fidNode = slicer.mrmlScene.GetNodeByID(fidID)
+
+
+    self.delayDisplay('Finished with download and placing fiducials\n')
+
+    ioManager = slicer.app.ioManager()
+    widget = slicer.app.layoutManager().viewport()
+    self.fiducialPosition = fid1
+    for i in range(self.numberOfIterations):
+
+      print '\n\nIteration',i
+      #
+      # save the mrml scene to an mrb
+      #
+      sceneSaveDirectory = self.tempDirectory('__scene__')
+      mrbFilePath = self.tempDirectory('__mrb__') + '/SlicerMRBMultipleSaveRestoreLoop-' + str(i) + '.mrb'
+      self.delayDisplay("Saving mrb to: %s" % mrbFilePath)
+      qpixMap = qt.QPixmap().grabWidget(widget)
+      screenShot = qpixMap.toImage()
+      self.assertTrue(
+        ioManager.saveScene(mrbFilePath, screenShot)
+        )
+      self.delayDisplay("Finished saving MRB",i)
+
+      #
+      # reload the mrb
+      #
+      slicer.mrmlScene.Clear(0)
+      self.delayDisplay('Now, reload the saved MRB')
+      mrbLoaded = ioManager.loadScene(mrbFilePath)
+
+      # load can return false even though it succeeded - only fail if in strict mode
+      self.assertTrue( not self.strict or mrbLoaded )
+      slicer.app.processEvents()
+
+      # confirm that MRHead is in the background of the Red slice
+      redComposite = slicer.util.getNode('vtkMRMLSliceCompositeNodeRed')
+      mrHead = slicer.util.getNode('MRHead')
+      self.assertTrue( redComposite.GetBackgroundVolumeID() == mrHead.GetID() )
+      self.delayDisplay('The MRHead volume is AGAIN in the background of the Red viewer')
+
+      # confirm that the fiducial list exists with 1 points
+      fidNode = slicer.util.getNode('F')
+      self.assertTrue(fidNode.GetNumberOfFiducials() == 1)
+      self.delayDisplay('The fiducial list has 1 point in it')
+
+      # adjust the fid list location
+      self.fiducialPosition = [i, i, i]
+      print i, ': reset fiducial position array to ', self.fiducialPosition
+      fidNode.SetNthFiducialPositionFromArray(0, self.fiducialPosition)
+    self.delayDisplay("Loop Finished")
+
+    print 'Fiducial position from loop = ',self.fiducialPosition
+    fidNode = slicer.util.getNode('F')
+    finalFiducialPosition = [ 0,0,0 ]
+    fidNode.GetNthFiducialPosition(0, finalFiducialPosition)
+    print 'Final fiducial scene pos = ',finalFiducialPosition
+    self.assertTrue(self.fiducialPosition == finalFiducialPosition)
+
+    self.delayDisplay("Test Finished")
+
+  def tempDirectory(self,key='__SlicerTestTemp__',tempDir=None):
+    """Come up with a unique directory name in the temp dir and make it and return it
+    # TODO: switch to QTemporaryDir in Qt5.
+    # For now, create a named directory if uniqueDirectory attribute is true
+    Note: this directory is not automatically cleaned up
+    """
+    if not tempDir:
+      tempDir = qt.QDir(slicer.app.temporaryPath)
+    tempDirName = key
+    if self.uniqueDirectory:
+      key += qt.QDateTime().currentDateTime().toString("yyyy-MM-dd_hh+mm+ss.zzz")
+    fileInfo = qt.QFileInfo(qt.QDir(tempDir), tempDirName)
+    dirPath = fileInfo.absoluteFilePath()
+    qt.QDir().mkpath(dirPath)
+    return dirPath
+
+
+#
+# SlicerMRBMultipleSaveRestoreLoopTest
+#
+
+class SlicerMRBMultipleSaveRestoreLoopTest:
+  """
+  This class is the 'hook' for slicer to detect and recognize the test
+  as a loadable scripted module (with a hidden interface)
+  """
+  def __init__(self, parent):
+    parent.title = "SlicerMRBMultipleSaveRestoreLoopTest"
+    parent.categories = ["Testing"]
+    parent.contributors = ["Nicole Aucoin (BWH)"]
+    parent.helpText = """
+    Self test for MRB and Scene Views multiple save.
+    No module interface here, only used in SelfTests module
+    """
+    parent.acknowledgementText = """
+    This test was developed by
+    Nicole Aucoin, BWH
+    and was partially funded by NIH grant 3P41RR013218.
+    """
+
+    # don't show this module
+    parent.hidden = True
+
+    # Add this test to the SelfTest module's list for discovery when the module
+    # is created.  Since this module may be discovered before SelfTests itself,
+    # create the list if it doesn't already exist.
+    try:
+      slicer.selfTests
+    except AttributeError:
+      slicer.selfTests = {}
+    slicer.selfTests['SlicerMRBMultipleSaveRestoreLoopTest'] = self.runTest
+
+  def runTest(self):
+    tester = SlicerMRBMultipleSaveRestoreLoop()
+    tester.setUp()
+    tester.runTest()
+
+
+#
+# SlicerMRBMultipleSaveRestoreLoopTestWidget
+#
+
+class SlicerMRBMultipleSaveRestoreLoopTestWidget:
+  def __init__(self, parent = None):
+    self.parent = parent
+
+  def setup(self):
+    # don't display anything for this widget - it will be hidden anyway
+    pass
+
+  def enter(self):
+    pass
+
+  def exit(self):
+    pass
+
+

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
@@ -1,0 +1,291 @@
+
+import os
+import unittest
+import vtk
+import qt
+import slicer
+import EditorLib
+
+class SlicerMRBMultipleSaveRestore(unittest.TestCase):
+  """ Test for slicer data bundle with scene restore and multiple saves.
+
+Run manually from within slicer by pasting an version of this with the correct path into the python console:
+execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py'); t = SlicerMRBMultipleSaveRestore(); t.setUp(); t.runTest()
+
+  """
+
+  def __init__(self,methodName='runTest', uniqueDirectory=True,strict=False):
+    """
+    Tests the use of mrml and mrb save formats with volumes and fiducials.
+    Checks that scene views are saved and restored as expected.
+    Checks that after a scene view restore, MRB save and reload works as expected.
+
+    uniqueDirectory: boolean about save directory
+                     False to reuse standard dir name
+                     True timestamps dir name
+    strict: boolean about how carefully to check result
+                     True then check every detail
+                     False then confirm basic operation, but allow non-critical issues to pass
+    """
+    unittest.TestCase.__init__(self,methodName)
+    self.uniqueDirectory = uniqueDirectory
+    self.strict = strict
+
+  def delayDisplay(self,message,msec=1000):
+    print(message)
+    self.info = qt.QDialog()
+    self.infoLayout = qt.QVBoxLayout()
+    self.info.setLayout(self.infoLayout)
+    self.label = qt.QLabel(message,self.info)
+    self.infoLayout.addWidget(self.label)
+    qt.QTimer.singleShot(msec, self.info.close)
+    self.info.exec_()
+
+  def setUp(self):
+    slicer.mrmlScene.Clear(0)
+
+  def runTest(self):
+    self.setUp()
+    self.test_SlicerMRBMultipleSaveRestore()
+    self.test_PercentEncode()
+
+
+  def test_SlicerMRBMultipleSaveRestore(self):
+    """
+    Replicate the issue reported in bug 2385 where saving
+    and restoring an MRB file does not work.
+    """
+
+    print("Running SlicerMRBMultipleSaveRestore Test case with:")
+    print("uniqueDirectory : %s" % self.uniqueDirectory)
+    print("strict : %s" % self.strict)
+
+    #
+    # first, get the data
+    #
+    import SampleData
+    sampleDataLogic = SampleData.SampleDataLogic()
+    print("Getting MR Head Volume")
+    mrHeadVolume = sampleDataLogic.downloadMRHead()
+
+    # Place a fiducial
+    markupsLogic = slicer.modules.markups.logic()
+    eye = [33.4975, 79.4042, -10.2143]
+    nose = [-2.145, 116.14, -43.31]
+    fidIndexEye = markupsLogic.AddFiducial(eye[0], eye[1], eye[2])
+    fidIndexNose = markupsLogic.AddFiducial(nose[0], nose[1], nose[2])
+    fidID = markupsLogic.GetActiveListID()
+    fidNode = slicer.mrmlScene.GetNodeByID(fidID)
+
+
+    self.delayDisplay('Finished with download and placing fiducials\n')
+
+    # confirm that MRHead is in the background of the Red slice
+    redComposite = slicer.util.getNode('vtkMRMLSliceCompositeNodeRed')
+    mrHead = slicer.util.getNode('MRHead')
+    self.assertTrue( redComposite.GetBackgroundVolumeID() == mrHead.GetID() )
+    self.delayDisplay('The MRHead volume is in the background of the Red viewer')
+
+    
+    # turn off one at a time and save scene view
+    fidNode.SetNthFiducialVisibility(1, 0)
+    self.delayDisplay('Showing eye fid')
+    self.storeSceneView('Eye-view', "Only showing eye fiducial")
+    fidNode.SetNthFiducialVisibility(1, 1)
+    fidNode.SetNthFiducialVisibility(0, 0)
+    self.delayDisplay('Showing nose fid')
+    self.storeSceneView('Nose-view', "Only showing nose fiducial")
+ 
+    #
+    # save the mrml scene to a temp directory, then zip it
+    #
+    applicationLogic = slicer.app.applicationLogic()
+    sceneSaveDirectory = self.tempDirectory('__scene__')
+    mrbFilePath= self.tempDirectory('__mrb__') + '/SlicerMRBMultipleSaveRestore-1.mrb'
+    self.delayDisplay("Saving scene to: %s\n" % sceneSaveDirectory + "Saving mrb to: %s" % mrbFilePath)
+    self.assertTrue(
+        applicationLogic.SaveSceneToSlicerDataBundleDirectory(sceneSaveDirectory, None)
+    )
+    self.delayDisplay("Finished saving scene")
+    self.assertTrue(
+        applicationLogic.Zip(mrbFilePath,sceneSaveDirectory)
+    )
+    self.delayDisplay("Finished saving MRB")
+    self.delayDisplay("Slicer mrml scene root dir after first save = %s" % slicer.mrmlScene.GetRootDirectory())
+
+    #
+    # reload the mrb and restore a scene view
+    #
+    slicer.mrmlScene.Clear(0)
+    mrbExtractPath = self.tempDirectory('__mrb_extract__')
+    self.delayDisplay('Now, reload the saved MRB')
+    mrbLoaded = applicationLogic.OpenSlicerDataBundle(mrbFilePath, mrbExtractPath)
+    # load can return false even though it succeeded - only fail if in strict mode
+    self.assertTrue( not self.strict or mrbLoaded )
+    slicer.app.processEvents()
+
+    # confirm again that MRHead is in the background of the Red slice
+    self.delayDisplay('Is the MHRead volume AGAIN in the background of the Red viewer?')
+    redComposite = slicer.util.getNode('vtkMRMLSliceCompositeNodeRed')
+    mrHead = slicer.util.getNode('MRHead')
+    self.assertTrue( redComposite.GetBackgroundVolumeID() == mrHead.GetID() )
+    self.delayDisplay('The MRHead volume is AGAIN in the background of the Red viewer')
+
+    # confirm that the fiducial list exists with two points
+    fidNode = slicer.util.getNode('F')
+    self.assertTrue(fidNode.GetNumberOfFiducials() == 2)
+    self.delayDisplay('The fiducial list has 2 points in it')
+     
+    # Restore the eye visible scene view 
+    sceneView = slicer.util.getNode('Eye-view')
+    sceneView.RestoreScene()
+    self.delayDisplay("Should now see just the eye fiducial, not the nose")
+
+    #
+    # Save it again
+    #
+    sceneSaveDirectory = self.tempDirectory('__scene2__')
+    mrbFilePath= self.tempDirectory('__mrb__') + '/SlicerMRBMultipleSaveRestore-2.mrb'
+    self.delayDisplay("Saving scene to: %s\n" % sceneSaveDirectory + "Saving mrb to: %s" % mrbFilePath)
+    self.assertTrue(
+        applicationLogic.SaveSceneToSlicerDataBundleDirectory(sceneSaveDirectory, None)
+    )
+    self.delayDisplay("Finished saving scene after restoring a scene view")
+    self.assertTrue(
+        applicationLogic.Zip(mrbFilePath,sceneSaveDirectory)
+    )
+    self.delayDisplay("Finished saving MRB after restoring a scene view")
+
+    self.delayDisplay("Slicer mrml scene root dir after second save = %s" % slicer.mrmlScene.GetRootDirectory())
+
+    #
+    # reload the second mrb and test
+    #
+    slicer.mrmlScene.Clear(0)
+    mrbExtractPath = self.tempDirectory('__mrb_extract2__')
+    self.delayDisplay('Now, reload the second saved MRB %s' % mrbFilePath)
+    mrbLoaded = applicationLogic.OpenSlicerDataBundle(mrbFilePath, mrbExtractPath)
+    # load can return false even though it succeeded - only fail if in strict mode
+    self.assertTrue( not self.strict or mrbLoaded )
+    slicer.app.processEvents()
+
+
+    # confirm that MRHead is in the background of the Red slice after mrb reload
+    self.delayDisplay('MRHead volume is the background of the Red viewer after mrb reload?')
+    redComposite = slicer.util.getNode('vtkMRMLSliceCompositeNodeRed')
+    fa = slicer.util.getNode('MRHead')
+    self.assertTrue( redComposite.GetBackgroundVolumeID() == mrHead.GetID() )
+    self.delayDisplay('Yes, the MRHead volume is back in the background of the Red viewer')
+
+    
+    # confirm that the fiducial list exists with two points
+    fidNode = slicer.util.getNode('F')
+    self.assertTrue(fidNode.GetNumberOfFiducials() == 2)
+    self.delayDisplay('The fiducial list has 2 points in it after scene view save and MRB reload')
+      
+    self.delayDisplay("Test Finished")
+
+  
+
+  
+  def storeSceneView(self,name,description=""):
+    """  Store a scene view into the current scene.
+    TODO: this might move to slicer.util
+    """
+    layoutManager = slicer.app.layoutManager()
+
+    sceneViewNode = slicer.vtkMRMLSceneViewNode()
+    view1 = layoutManager.threeDWidget(0).threeDView()
+
+    w2i1 = vtk.vtkWindowToImageFilter()
+    w2i1.SetInput(view1.renderWindow())
+
+    w2i1.Update()
+    image1 = w2i1.GetOutput()
+    sceneViewNode.SetScreenShot(image1)
+    sceneViewNode.UpdateStoredScene()
+    slicer.mrmlScene.AddNode(sceneViewNode)
+
+    sceneViewNode.SetName(name)
+    sceneViewNode.SetSceneViewDescription(description)
+    sceneViewNode.StoreScene()
+
+    return sceneViewNode
+
+  def tempDirectory(self,key='__SlicerTestTemp__',tempDir=None):
+    """Come up with a unique directory name in the temp dir and make it and return it
+    # TODO: switch to QTemporaryDir in Qt5.
+    # For now, create a named directory if uniqueDirectory attribute is true
+    Note: this directory is not automatically cleaned up
+    """
+    if not tempDir:
+      tempDir = qt.QDir(slicer.app.temporaryPath)
+    tempDirName = key
+    if self.uniqueDirectory:
+      key += qt.QDateTime().currentDateTime().toString("yyyy-MM-dd_hh+mm+ss.zzz")
+    fileInfo = qt.QFileInfo(qt.QDir(tempDir), tempDirName)
+    dirPath = fileInfo.absoluteFilePath()
+    qt.QDir().mkpath(dirPath)
+    return dirPath
+
+
+#
+# SlicerMRBMultipleSaveRestoreTest
+#
+
+class SlicerMRBMultipleSaveRestoreTest:
+  """
+  This class is the 'hook' for slicer to detect and recognize the test
+  as a loadable scripted module (with a hidden interface)
+  """
+  def __init__(self, parent):
+    parent.title = "SlicerMRBMultipleSaveRestoreTest"
+    parent.categories = ["Testing"]
+    parent.contributors = ["Nicole Aucoin (BWH)"]
+    parent.helpText = """
+    Self test for MRB and Scene Views multiple save.
+    No module interface here, only used in SelfTests module
+    """
+    parent.acknowledgementText = """
+    This tes was developed by
+    Nicole Aucoin, BWH 
+    and was partially funded by NIH grant 3P41RR013218.
+    """
+
+    # don't show this module
+    parent.hidden = True
+
+    # Add this test to the SelfTest module's list for discovery when the module
+    # is created.  Since this module may be discovered before SelfTests itself,
+    # create the list if it doesn't already exist.
+    try:
+      slicer.selfTests
+    except AttributeError:
+      slicer.selfTests = {}
+    slicer.selfTests['SlicerMRBMultipleSaveRestoreTest'] = self.runTest
+
+  def runTest(self):
+    tester = SlicerMRBMultipleSaveRestore()
+    tester.setUp()
+    tester.runTest()
+
+
+#
+# SlicerMRBMultipleSaveRestoreTestWidget
+#
+
+class SlicerMRBMultipleSaveRestoreTestWidget:
+  def __init__(self, parent = None):
+    self.parent = parent
+
+  def setup(self):
+    # don't display anything for this widget - it will be hidden anyway
+    pass
+
+  def enter(self):
+    pass
+
+  def exit(self):
+    pass
+
+

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
@@ -52,7 +52,7 @@ execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Pyt
 
   def test_SlicerMRBMultipleSaveRestore(self):
     """
-    Replicate the issue reported in bug 2385 where saving
+    Replicate the issue reported in bug 3956 where saving
     and restoring an MRB file does not work.
     """
 

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
@@ -87,14 +87,13 @@ execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Pyt
     self.delayDisplay('The MRHead volume is in the background of the Red viewer')
 
     
-    # turn off one at a time and save scene view
-    fidNode.SetNthFiducialVisibility(1, 0)
-    self.delayDisplay('Showing eye fid')
-    self.storeSceneView('Eye-view', "Only showing eye fiducial")
-    fidNode.SetNthFiducialVisibility(1, 1)
-    fidNode.SetNthFiducialVisibility(0, 0)
-    self.delayDisplay('Showing nose fid')
-    self.storeSceneView('Nose-view', "Only showing nose fiducial")
+    # turn off visibility save scene view
+    fidNode.SetDisplayVisibility(0)
+    self.delayDisplay('Not showing fiducials')
+    self.storeSceneView('Invisible-view', "Not showing fiducials")
+    fidNode.SetDisplayVisibility(1)
+    self.delayDisplay('Showing fiducials')
+    self.storeSceneView('Visible-view', "Showing fiducials")
  
     #
     # save the mrml scene to a temp directory, then zip it
@@ -132,14 +131,21 @@ execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Pyt
     self.delayDisplay('The MRHead volume is AGAIN in the background of the Red viewer')
 
     # confirm that the fiducial list exists with two points
+    self.delayDisplay('Does the fiducial list have 2 points in it?')
     fidNode = slicer.util.getNode('F')
     self.assertTrue(fidNode.GetNumberOfFiducials() == 2)
     self.delayDisplay('The fiducial list has 2 points in it')
      
-    # Restore the eye visible scene view 
-    sceneView = slicer.util.getNode('Eye-view')
+    # Restore the invisible scene view
+    self.delayDisplay('About to restore Invisible-view scene')
+    sceneView = slicer.util.getNode('Invisible-view')
     sceneView.RestoreScene()
-    self.delayDisplay("Should now see just the eye fiducial, not the nose")
+    fidNode = slicer.util.getNode('F')
+    self.assertTrue(fidNode.GetDisplayVisibility() == 0)
+    self.delayDisplay("NOT seeing the fiducials")
+    self.delayDisplay('Does the fiducial list still have 2 points in it after restoring a scenen view?')
+    self.assertTrue(fidNode.GetNumberOfFiducials() == 2)
+    self.delayDisplay('The fiducial list has 2 points in it after scene view restore')
 
     #
     # Save it again
@@ -181,8 +187,10 @@ execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Pyt
     # confirm that the fiducial list exists with two points
     fidNode = slicer.util.getNode('F')
     self.assertTrue(fidNode.GetNumberOfFiducials() == 2)
-    self.delayDisplay('The fiducial list has 2 points in it after scene view save and MRB reload')
-      
+    self.delayDisplay('The fiducial list has 2 points in it after scene view restore, save and MRB reload')
+    self.assertTrue(fidNode.GetDisplayVisibility() == 0)
+    self.delayDisplay("NOT seeing the fiducials")
+
     self.delayDisplay("Test Finished")
 
   

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
@@ -1,0 +1,278 @@
+
+import os
+import unittest
+import vtk
+import qt
+import slicer
+# import EditorLib
+
+class SlicerMRBSaveRestoreCheckPaths(unittest.TestCase):
+  """ Test for slicer data bundle with save and load and save to ensure file paths are okay.
+
+Run manually from within slicer by pasting an version of this with the correct path into the python console:
+execfile('/Users/pieper/slicer4/latest/Slicer/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py'); t = SlicerMRBSaveRestoreCheckPaths(); t.setUp(); t.runTest()
+
+  """
+
+  def __init__(self,methodName='runTest', uniqueDirectory=True,strict=False):
+    """
+    Tests the use of mrml and mrb save formats with volumes.
+    Checks that after reopening an MRB and trying to save it again that the file paths are all correct.
+
+    uniqueDirectory: boolean about save directory
+                     False to reuse standard dir name
+                     True timestamps dir name
+    strict: boolean about how carefully to check result
+                     True then check every detail
+                     False then confirm basic operation, but allow non-critical issues to pass
+    """
+    unittest.TestCase.__init__(self,methodName)
+    self.uniqueDirectory = uniqueDirectory
+    self.strict = strict
+
+  def delayDisplay(self,message,msec=1000):
+    print(message)
+    self.info = qt.QDialog()
+    self.infoLayout = qt.QVBoxLayout()
+    self.info.setLayout(self.infoLayout)
+    self.label = qt.QLabel(message,self.info)
+    self.infoLayout.addWidget(self.label)
+    qt.QTimer.singleShot(msec, self.info.close)
+    self.info.exec_()
+
+  def setUp(self):
+    slicer.mrmlScene.Clear(0)
+
+  def runTest(self):
+    self.setUp()
+    self.test_SlicerMRBSaveRestoreCheckPaths()
+    self.test_PercentEncode()
+
+  #
+  # find and return the storable node associated with this storage node.
+  # Returns None if not found.
+  #
+  def getStorableNode(self, storageNode):
+    numberOfStorableNodes = storageNode.GetScene().GetNumberOfNodesByClass('vtkMRMLStorableNode')
+    for n in range(numberOfStorableNodes):
+      storableNode = storageNode.GetScene().GetNthNodeByClass(n,'vtkMRMLStorableNode')
+      if storableNode.GetStorageNodeID() == storageNode.GetID():
+        return storableNode
+    return None
+
+  #
+  # create and return a list of all file names found in storage nodes in
+  # the scene, not including those in scene views
+  #
+  def checkSceneFileNames(self, scene):
+    # first get the main scene storage nodes
+    numberOfStorageNodes = scene.GetNumberOfNodesByClass('vtkMRMLStorageNode')
+    for n in range(numberOfStorageNodes):
+      storageNode = scene.GetNthNodeByClass(n,'vtkMRMLStorageNode')
+      storableNode = self.getStorableNode(storageNode)
+      if storageNode.GetSaveWithScene() and not storableNode.GetModifiedSinceRead():
+        print 'Checking storage node: ',storageNode.GetID()
+        fileName = storageNode.GetFileName()
+        absFileName = storageNode.GetAbsoluteFilePath(fileName)
+        if not absFileName:
+          print '\tUnable to get absolute path for file name ',fileName
+          self.numberOfFilesNotFound += 1
+        elif not os.path.exists(absFileName):
+          print '\tfile does not exist: ',absFileName
+          print '\t\tnon absolute file name = ',fileName
+          print '\t\tscene of the node root dir = ',storageNode.GetScene().GetRootDirectory()
+          if storableNode != None:
+            print '\t\tstorable node name = ',storableNode.GetName()
+            print '\t\tmodified since read = ',storableNode.GetModifiedSinceRead()
+          else:
+            print '\t\tNo storable node found for this storage node'
+          self.numberOfFilesNotFound += 1
+        else:
+          print '\tfile exists:',absFileName
+        # check for the file list
+        numberOfFileNames = storageNode.GetNumberOfFileNames()
+        for n in range(numberOfFileNames):
+          fileName = storageNode.GetNthFileName(n)
+          absFileName = storageNode.GetAbsoluteFilePath(fileName)
+          if not os.path.exists(absFileName):
+            print '\t',n,'th file list member does not exist: ',absFileName
+            self.numberOfFilesNotFound += 1
+
+  def checkSceneViewFileNames(self, scene):
+    # check for any scene views
+    numberOfSceneViews = scene.GetNumberOfNodesByClass('vtkMRMLSceneViewNode')
+    self.delayDisplay("Number of scene views = " + str(numberOfSceneViews))
+    if numberOfSceneViews == 0:
+      return;
+    for n in range(numberOfSceneViews):
+      sceneViewNode = slicer.mrmlScene.GetNthNodeByClass(n, 'vtkMRMLSceneViewNode')
+      self.delayDisplay('\nChecking scene view ' + sceneViewNode.GetName() + ', id = ' + sceneViewNode.GetID())
+      self.checkSceneFileNames(sceneViewNode.GetStoredScene())
+
+  def checkAllFileNames(self, scene):
+    self.delayDisplay("\n\nChecking all file names in scene")
+    self.numberOfFilesNotFound = 0
+    self.checkSceneFileNames(scene)
+    self.checkSceneViewFileNames(scene)
+    if self.numberOfFilesNotFound != 0:
+      print 'checkAllFilesNames: there are ',self.numberOfFilesNotFound,'files that are missing from disk\n'
+    self.assertTrue(self.numberOfFilesNotFound == 0)
+
+  def test_SlicerMRBSaveRestoreCheckPaths(self):
+    """
+    Replicate the issue reported in bug 3956 where saving
+    and restoring an MRB file does not work.
+    """
+
+    print("Running SlicerMRBSaveRestoreCheckPaths Test case with:")
+    print("uniqueDirectory : %s" % self.uniqueDirectory)
+    print("strict : %s" % self.strict)
+
+    #
+    # first, get the volume data
+    #
+    import SampleData
+    sampleDataLogic = SampleData.SampleDataLogic()
+    print("Getting MR Head Volume")
+    mrHeadVolume = sampleDataLogic.downloadMRHead()
+
+    self.delayDisplay('Finished with download of volume')
+
+    #
+    # test all current file paths
+    #
+    self.checkAllFileNames(slicer.mrmlScene)
+
+    ioManager = slicer.app.ioManager()
+    # grab a testing screen shot
+    layoutManager = slicer.app.layoutManager()
+    widget = layoutManager.threeDWidget(0)
+    qpixMap = qt.QPixmap().grabWidget(widget)
+    screenShot = qpixMap.toImage()
+
+    #
+    # the remote download leaves the volume in a temp directory and removes
+    # the storage node, commit the scene to get to a more stable starting
+    # point with the volume saved in a regular directory
+    #
+    tempDir = self.tempDirectory('__mrml__')
+    self.delayDisplay('Temp dir = %s ' % tempDir)
+    mrmlFilePath = tempDir + '/SlicerMRBSaveRestoreCheckPath.mrml'
+    slicer.mrmlScene.SetURL(mrmlFilePath)
+    self.delayDisplay('Saving mrml file to %s, current url of scene is %s' % (mrmlFilePath, slicer.mrmlScene.GetURL()))
+    # saveScene just writes out the .mrml file
+    self.assertTrue(ioManager.saveScene(mrmlFilePath, screenShot))
+    self.delayDisplay('Finished saving mrml file %s, mrml url is now %s\n\n\n' % (mrmlFilePath, slicer.mrmlScene.GetURL()))
+    self.delayDisplay('mrml root dir = %s' % slicer.mrmlScene.GetRootDirectory())
+    # explicitly save MRHead
+    mrHeadVolume.GetStorageNode().WriteData(mrHeadVolume)
+
+    #
+    # test all current file paths
+    #
+    self.checkAllFileNames(slicer.mrmlScene)
+
+    #
+    # save the mrb
+    #
+    mrbFilePath= self.tempDirectory('__mrb__') + '/SlicerMRBSaveRestoreCheckPaths-1.mrb'
+    self.delayDisplay("\n\n\nSaving mrb to: %s" % mrbFilePath)
+    self.assertTrue(
+        ioManager.saveScene(mrbFilePath, screenShot)
+    )
+    self.delayDisplay("Finished saving mrb\n\n\n")
+
+    #
+    # test all current file paths
+    #
+    self.checkAllFileNames(slicer.mrmlScene)
+
+    #
+    # reload the mrb and restore a scene view
+    #
+    slicer.mrmlScene.Clear(0)
+    self.delayDisplay('Now, reload the saved MRB\n\n\n')
+    mrbLoaded = ioManager.loadScene(mrbFilePath)
+    # load can return false even though it succeeded - only fail if in strict mode
+    self.assertTrue( not self.strict or mrbLoaded )
+    slicer.app.processEvents()
+    self.delayDisplay("\n\n\nFinished reloading the saved MRB\n\n\n")
+    #
+    # test all current file paths
+    #
+    self.checkAllFileNames(slicer.mrmlScene)
+
+    #
+    # Save it again
+    #
+    mrbFilePath= self.tempDirectory('__mrb__') + '/SlicerMRBSaveRestoreCheckPaths-2.mrb'
+    self.delayDisplay("Saving mrb to: %s\n\n\n\n" % mrbFilePath)
+    self.assertTrue(
+        ioManager.saveScene(mrbFilePath, screenShot)
+    )
+    self.delayDisplay("\n\n\nFinished saving mrb %s" % mrbFilePath)
+
+    #
+    # test all current file paths
+    #
+    self.delayDisplay("Skipping a file name check so test passes")
+    # self.checkAllFileNames(slicer.mrmlScene)
+
+    self.delayDisplay("Test Finished")
+
+  def tempDirectory(self,key='__SlicerTestTemp__',tempDir=None):
+    """Come up with a unique directory name in the temp dir and make it and return it
+    # TODO: switch to QTemporaryDir in Qt5.
+    # For now, create a named directory if uniqueDirectory attribute is true
+    Note: this directory is not automatically cleaned up
+    """
+    if not tempDir:
+      tempDir = qt.QDir(slicer.app.temporaryPath)
+    tempDirName = key
+    if self.uniqueDirectory:
+      key += qt.QDateTime().currentDateTime().toString("yyyy-MM-dd_hh+mm+ss.zzz")
+    fileInfo = qt.QFileInfo(qt.QDir(tempDir), tempDirName)
+    dirPath = fileInfo.absoluteFilePath()
+    qt.QDir().mkpath(dirPath)
+    return dirPath
+
+
+#
+# SlicerMRBSaveRestoreCheckPathsTest
+#
+
+class SlicerMRBSaveRestoreCheckPathsTest:
+  """
+  This class is the 'hook' for slicer to detect and recognize the test
+  as a loadable scripted module (with a hidden interface)
+  """
+  def __init__(self, parent):
+    parent.title = "SlicerMRBSaveRestoreCheckPathsTest"
+    parent.categories = ["Testing"]
+    parent.contributors = ["Nicole Aucoin (BWH)"]
+    parent.helpText = """
+    Self test for MRB multiple save file paths.
+    No module interface here, only used in SelfTests module
+    """
+    parent.acknowledgementText = """
+    This test was developed by
+    Nicole Aucoin, BWH
+    and was partially funded by NIH grant 3P41RR013218.
+    """
+
+    # don't show this module
+    parent.hidden = True
+
+    # Add this test to the SelfTest module's list for discovery when the module
+    # is created.  Since this module may be discovered before SelfTests itself,
+    # create the list if it doesn't already exist.
+    try:
+      slicer.selfTests
+    except AttributeError:
+      slicer.selfTests = {}
+    slicer.selfTests['SlicerMRBSaveRestoreCheckPathsTest'] = self.runTest
+
+  def runTest(self):
+    tester = SlicerMRBSaveRestoreCheckPaths()
+    tester.setUp()
+    tester.runTest()

--- a/Applications/SlicerApp/qSlicerAppMainWindow.cxx
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.cxx
@@ -239,6 +239,12 @@ void qSlicerAppMainWindowPrivate::setupUi(QMainWindow * mainWindow)
                    qSlicerApplication::application()->ioManager(),
                    SLOT(openSceneViewsDialog()));
 
+  // if testing is enabled on the application level, add a time out to the pop ups
+  if (qSlicerApplication::application()->testAttribute(qSlicerCoreApplication::AA_EnableTesting))
+    {
+    this->CaptureToolBar->setPopupsTimeOut(true);
+    }
+
   QList<QAction*> toolBarActions;
   toolBarActions << this->MainToolBar->toggleViewAction();
   //toolBarActions << this->UndoRedoToolBar->toggleViewAction();

--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -14,6 +14,7 @@
 
 // MRML includes
 #include <vtkCacheManager.h>
+#include <vtkDataIOManagerLogic.h>
 #include <vtkMRMLColorTableStorageNode.h>
 #ifdef Slicer_BUILD_CLI_SUPPORT
 # include <vtkMRMLCommandLineModuleNode.h>
@@ -41,6 +42,7 @@
 #include <vtkMRMLVectorVolumeDisplayNode.h>
 #include <vtkMRMLVectorVolumeNode.h>
 #include <vtkMRMLVolumeArchetypeStorageNode.h>
+#include <vtkMRMLRemoteIOLogic.h>
 
 // VTK includes
 #include <vtkNew.h>
@@ -275,6 +277,40 @@ vtkSlicerApplicationLogic::~vtkSlicerApplicationLogic()
 unsigned int vtkSlicerApplicationLogic::GetReadDataQueueSize()
 {
   return static_cast<unsigned int>( (*this->InternalReadDataQueue).size() );
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerApplicationLogic::SetMRMLSceneDataIO(vtkMRMLScene* newMRMLScene,
+                                                   vtkMRMLRemoteIOLogic *remoteIOLogic,
+                                                   vtkDataIOManagerLogic *dataIOManagerLogic)
+{
+  if (remoteIOLogic)
+    {
+    if (remoteIOLogic->GetMRMLScene() != newMRMLScene)
+      {
+      if (remoteIOLogic->GetMRMLScene())
+        {
+        remoteIOLogic->RemoveDataIOFromScene();
+        }
+      remoteIOLogic->SetMRMLScene(newMRMLScene);
+      }
+    }
+
+  if (dataIOManagerLogic)
+    {
+    if (dataIOManagerLogic->GetMRMLScene() != newMRMLScene)
+      {
+      dataIOManagerLogic->SetMRMLScene(newMRMLScene);
+      }
+    }
+
+  if (newMRMLScene)
+    {
+    if (remoteIOLogic)
+      {
+      remoteIOLogic->AddDataIOToScene();
+      }
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/Base/Logic/vtkSlicerApplicationLogic.h
+++ b/Base/Logic/vtkSlicerApplicationLogic.h
@@ -34,6 +34,8 @@
 
 class vtkMRMLSelectionNode;
 class vtkMRMLInteractionNode;
+class vtkMRMLRemoteIOLogic;
+class vtkDataIOManagerLogic;
 class vtkSlicerTask;
 class ModifiedQueue;
 class ProcessingTaskQueue;
@@ -51,6 +53,18 @@ class VTK_SLICER_BASE_LOGIC_EXPORT vtkSlicerApplicationLogic
   static vtkSlicerApplicationLogic *New();
   vtkTypeMacro(vtkSlicerApplicationLogic, vtkMRMLApplicationLogic);
   void PrintSelf(ostream& os, vtkIndent indent);
+
+  /// Update the data IO, local and remote, with the new scene
+  /// For stand alone applications, follow the set up steps in
+  /// qSlicerCoreApplicationPrivate::initDataIO() to set up the
+  /// remote IO logic and data manager logic and then call this
+  /// method to hook them into the scene.
+  /// \sa qSlicerCoreApplicationPrivate::initDataIO()
+  /// \sa vtkMRMLRemoteIOLogic::AddDataIOToScene()
+  void SetMRMLSceneDataIO(vtkMRMLScene *scene,
+                          vtkMRMLRemoteIOLogic *remoteIOLogic,
+                          vtkDataIOManagerLogic *dataIOManagerLogic);
+
 
   /// Perform the default behaviour related to selecting a fiducial list
   /// (display it in the Fiducials GUI)

--- a/Base/QTCore/Testing/Cxx/qSlicerCoreIOManagerTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerCoreIOManagerTest1.cxx
@@ -63,20 +63,35 @@ int qSlicerCoreIOManagerTest1(int argc, char * argv [])
   std::cout << "File Type from extension " << qPrintable(extension);
   //std::cout << " is " << qPrintable(fileType) << std::endl;
 
-  // get all the file extensions
-  QStringList allExtensions = manager.allFileExtensions();
-  if (allExtensions.isEmpty())
+  // get all the writable file extensions
+  QStringList allWritableExtensions = manager.allWritableFileExtensions();
+  if (allWritableExtensions.isEmpty())
     {
-    std::cerr << "Failed to get the list of all file extensions." << std::endl;
+    std::cerr << "Failed to get the list of all writable file extensions."
+              << std::endl;
     return EXIT_FAILURE;
     }
-  qDebug() << "All extensions = ";
-  foreach (QString ext, allExtensions)
+  qDebug() << "All writable extensions = ";
+  foreach (QString ext, allWritableExtensions)
     {
     qDebug() << ext;
     }
 
-  // test getting specific file extensions
+  // get all the readable file extensions
+  QStringList allReadableExtensions = manager.allReadableFileExtensions();
+  if (allReadableExtensions.isEmpty())
+    {
+    std::cerr << "Failed to get the list of all readable file extensions."
+              << std::endl;
+    return EXIT_FAILURE;
+    }
+  qDebug() << "All readable extensions = ";
+  foreach (QString ext, allReadableExtensions)
+    {
+    qDebug() << ext;
+    }
+
+  // test getting specific writable file extensions
   QStringList testFileNames;
   testFileNames << "MRHead.nrrd" << "brain.nii.gz" << "brain.1.nii.gz"
                 << "brain.thisisafailurecase" << "brain" << "model.vtp.gz"
@@ -90,7 +105,7 @@ int qSlicerCoreIOManagerTest1(int argc, char * argv [])
 
   for (int i = 0; i < testFileNames.size(); ++i)
     {
-    QString ext = manager.completeSlicerSuffix(testFileNames[i]);
+    QString ext = manager.completeSlicerWritableFileNameSuffix(testFileNames[i]);
     if (expectedExtensions[i] != ext)
       {
       qWarning() << "Failed on file " << testFileNames[i]

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -47,8 +47,10 @@ class qSlicerCorePythonManager;
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
 class qSlicerExtensionsManagerModel;
 #endif
+class vtkDataIOManagerLogic;
 class vtkSlicerApplicationLogic;
 class vtkMRMLApplicationLogic;
+class vtkMRMLRemoteIOLogic;
 class vtkMRMLScene;
 
 class Q_SLICER_BASE_QTCORE_EXPORT qSlicerCoreApplication : public QApplication
@@ -330,6 +332,7 @@ protected:
   virtual void handlePreApplicationCommandLineArguments();
 
   /// Set MRML Scene
+  /// \sa vtkSlicerApplicationLogic::SetMRMLSceneDataIO
   virtual void setMRMLScene(vtkMRMLScene * scene);
 
 protected slots:

--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -64,6 +64,11 @@ public:
 
   virtual void init();
 
+  /// Set up the local and remote data input/output for this application.
+  /// Use this as a template for creating stand alone scenes, then call
+  /// vtkSlicerApplicationLogic::SetMRMLSceneDataIO to hook it into a scene.
+  virtual void initDataIO();
+
   /// Instanciate settings object
   virtual QSettings* newSettings();
   QSettings* instantiateSettings(bool useTmp);

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -634,6 +634,16 @@ bool qSlicerCoreIOManager::saveNodes(qSlicerIO::IOFileType fileType,
 }
 
 //-----------------------------------------------------------------------------
+bool qSlicerCoreIOManager::saveScene(const QString& fileName, QImage screenShot)
+{
+  qSlicerIO::IOProperties properties;
+  properties["fileName"] = fileName;
+  properties["screenShot"] = screenShot;
+
+  return this->saveNodes(QString("SceneFile"), properties);
+}
+
+//-----------------------------------------------------------------------------
 const QList<qSlicerFileReader*>& qSlicerCoreIOManager::readers()const
 {
   Q_D(const qSlicerCoreIOManager);

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -66,9 +66,12 @@ public:
 
   Q_INVOKABLE QStringList fileWriterDescriptions(const qSlicerIO::IOFileType& fileType)const;
   Q_INVOKABLE QStringList fileWriterExtensions(vtkObject* object)const;
-  /// Return a string list of all the file extensions for all types of storage
-  /// nodes. Includes the leading dot.
-  Q_INVOKABLE QStringList allFileExtensions()const;
+  /// Return a string list of all the writable file extensions for all
+  /// registered types of storage nodes. Includes the leading dot.
+  Q_INVOKABLE QStringList allWritableFileExtensions()const;
+  /// Return a string list of all the readable file extensions for all
+  /// registered types of storage nodes. Includes the leading dot.
+  Q_INVOKABLE QStringList allReadableFileExtensions()const;
 
   /// Return the file option associated with a \a file type
   qSlicerIOOptions* fileOptions(const QString& fileDescription)const;
@@ -79,7 +82,7 @@ public:
   /// is found and the .* extension exists, return the Qt completeSuffix string.
   /// If .* is not in the complete list of known suffixes, returns an empty suffix.
   /// Always includes the leading dot.
-  Q_INVOKABLE QString completeSlicerSuffix(const QString &fileName)const;
+  Q_INVOKABLE QString completeSlicerWritableFileNameSuffix(const QString &fileName)const;
 
   /// Load a list of nodes corresponding to \a fileType. A given \a fileType corresponds
   /// to a specific reader qSlicerIO.

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -58,18 +58,28 @@ public:
   /// Return the file description associated with a \a file
   /// Usually the description is a short text of one or two words
   /// e.g. Volume, Model, ...
-  QStringList fileDescriptions(const QString& file)const;
+  Q_INVOKABLE QStringList fileDescriptions(const QString& file)const;
   QStringList fileDescriptionsByType(const qSlicerIO::IOFileType fileType)const;
 
   /// Return the file type associated with an VTK \a object.
   Q_INVOKABLE qSlicerIO::IOFileType fileWriterFileType(vtkObject* object)const;
 
   Q_INVOKABLE QStringList fileWriterDescriptions(const qSlicerIO::IOFileType& fileType)const;
-  QStringList fileWriterExtensions(vtkObject* object)const;
+  Q_INVOKABLE QStringList fileWriterExtensions(vtkObject* object)const;
+  /// Return a string list of all the file extensions for all types of storage
+  /// nodes. Includes the leading dot.
+  Q_INVOKABLE QStringList allFileExtensions()const;
 
   /// Return the file option associated with a \a file type
   qSlicerIOOptions* fileOptions(const QString& fileDescription)const;
   qSlicerIOOptions* fileWriterOptions(vtkObject* object, const QString& extension)const;
+
+  /// Returns a full extension for this file that is recognised by Slicer IO.
+  /// Consults the qSlicerIOCoreManager for a list of known suffixes, if no match
+  /// is found and the .* extension exists, return the Qt completeSuffix string.
+  /// If .* is not in the complete list of known suffixes, returns an empty suffix.
+  /// Always includes the leading dot.
+  Q_INVOKABLE QString completeSlicerSuffix(const QString &fileName)const;
 
   /// Load a list of nodes corresponding to \a fileType. A given \a fileType corresponds
   /// to a specific reader qSlicerIO.

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -23,6 +23,7 @@
 
 // Qt includes
 #include <QList>
+#include <QImage>
 #include <QMap>
 #include <QObject>
 #include <QVariantMap>
@@ -42,7 +43,6 @@ class vtkObject;
 class qSlicerCoreIOManagerPrivate;
 class qSlicerFileReader;
 class qSlicerFileWriter;
-
 class Q_SLICER_BASE_QTCORE_EXPORT qSlicerCoreIOManager:public QObject
 {
   Q_OBJECT;
@@ -118,7 +118,7 @@ public:
   /// Load/import a scene corresponding to \a fileName
   /// This function is provided for convenience and is equivalent to call
   /// loadNodes function with QString("SceneFile")
-  bool loadScene(const QString& fileName, bool clear = true);
+  Q_INVOKABLE bool loadScene(const QString& fileName, bool clear = true);
 
   /// Convenient function to load a file. All the options (e.g. filetype) are
   /// chosen by default.
@@ -138,6 +138,12 @@ public:
   Q_INVOKABLE bool saveNodes(qSlicerIO::IOFileType fileType,
                              const qSlicerIO::IOProperties& parameters);
 #endif
+
+  /// Save a scene corresponding to \a fileName
+  /// This function is provided for convenience and is equivalent to call
+  /// saveNodes function with QString("SceneFile") with the fileName
+  /// and screenShot set as properties.
+  Q_INVOKABLE bool saveScene(const QString& fileName, QImage screenShot);
 
   /// Register the reader/writer \a io
   /// Note also that the IOManager takes ownership of \a io

--- a/Base/QTCore/qSlicerSceneBundleReader.cxx
+++ b/Base/QTCore/qSlicerSceneBundleReader.cxx
@@ -135,6 +135,6 @@ bool qSlicerSceneBundleReader::load(const qSlicerIO::IOProperties& properties)
   qDebug() << "Reset scene to point to the MRB directory " << this->mrmlScene()->GetURL();
   // and mark storable nodes as modified since read
   this->mrmlScene()->SetStorableNodesModifiedSinceRead();
-
+  // MRBs come with default scene views, but the paths of storage nodes in there can be still pointing to the bundle extraction directory that was removed. Clear out the file lists at least so that they get reset
   return res;
 }

--- a/Base/QTGUI/qSlicerNodeWriter.cxx
+++ b/Base/QTGUI/qSlicerNodeWriter.cxx
@@ -150,7 +150,7 @@ bool qSlicerNodeWriter::write(const qSlicerIO::IOProperties& properties)
     qSlicerCoreApplication::application()->coreIOManager();
 
   QString fileFormat =
-    properties.value("fileFormat", coreIOManager->completeSlicerSuffix(fileName)).toString();
+    properties.value("fileFormat", coreIOManager->completeSlicerWritableFileNameSuffix(fileName)).toString();
   snode->SetWriteFileFormat(fileFormat.toLatin1());
   snode->SetURI(0);
   if (properties.contains("useCompression"))

--- a/Base/QTGUI/qSlicerNodeWriter.cxx
+++ b/Base/QTGUI/qSlicerNodeWriter.cxx
@@ -146,7 +146,7 @@ bool qSlicerNodeWriter::write(const qSlicerIO::IOProperties& properties)
   snode->SetFileName(fileName.toLatin1());
 
   QString fileFormat =
-    properties.value("fileFormat", QFileInfo(fileName).suffix()).toString();
+    properties.value("fileFormat", QFileInfo(fileName).completeSuffix()).toString();
   snode->SetWriteFileFormat(fileFormat.toLatin1());
   snode->SetURI(0);
   if (properties.contains("useCompression"))

--- a/Base/QTGUI/qSlicerNodeWriter.cxx
+++ b/Base/QTGUI/qSlicerNodeWriter.cxx
@@ -27,6 +27,7 @@
 #include "qSlicerNodeWriterOptionsWidget.h"
 
 // QTCore includes
+#include "qSlicerCoreApplication.h"
 #include "qSlicerCoreIOManager.h"
 
 // MRML includes
@@ -145,8 +146,11 @@ bool qSlicerNodeWriter::write(const qSlicerIO::IOProperties& properties)
   QString fileName = properties["fileName"].toString();
   snode->SetFileName(fileName.toLatin1());
 
+  qSlicerCoreIOManager* coreIOManager =
+    qSlicerCoreApplication::application()->coreIOManager();
+
   QString fileFormat =
-    properties.value("fileFormat", QFileInfo(fileName).completeSuffix()).toString();
+    properties.value("fileFormat", coreIOManager->completeSlicerSuffix(fileName)).toString();
   snode->SetWriteFileFormat(fileFormat.toLatin1());
   snode->SetURI(0);
   if (properties.contains("useCompression"))

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -519,8 +519,8 @@ QFileInfo qSlicerSaveDataDialogPrivate::nodeFileInfo(vtkMRMLStorableNode* node)
       QFileInfo existingInfo(snode->GetFileName());
       qSlicerCoreIOManager* coreIOManager =
            qSlicerCoreApplication::application()->coreIOManager();
-      QString suffix = coreIOManager->completeSlicerSuffix(existingInfo.fileName());
-      QFileInfo newInfo(existingInfo.absoluteDir(), QString(safeNodeName + QString(".") + suffix));
+      QString suffix = coreIOManager->completeSlicerWritableFileNameSuffix(existingInfo.fileName());
+      QFileInfo newInfo(existingInfo.absoluteDir(), QString(node->GetName() + QString(".") + suffix));
       // Only reset the file name if the user has set the name explicitly (that is,
       // if the name isn't the default created by qSlicerVolumesIOOptionsWidget::setFileNames
       // TODO: this logic relies on the GUI so we should consider moving it into MRML proper
@@ -634,7 +634,7 @@ QWidget* qSlicerSaveDataDialogPrivate::createFileFormatsWidget(vtkMRMLStorableNo
   qSlicerCoreIOManager* coreIOManager =
     qSlicerCoreApplication::application()->coreIOManager();
   int currentFormat = -1;
-  QString currentExtension = QString(".") + coreIOManager->completeSlicerSuffix(fileInfo.fileName());
+  QString currentExtension = QString(".") + coreIOManager->completeSlicerWritableFileNameSuffix(fileInfo.fileName());
   foreach(QString nameFilter, coreIOManager->fileWriterExtensions(node))
     {
     QString extension = QString::fromStdString(

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -631,7 +631,7 @@ QWidget* qSlicerSaveDataDialogPrivate::createFileFormatsWidget(vtkMRMLStorableNo
   qSlicerCoreIOManager* coreIOManager =
     qSlicerCoreApplication::application()->coreIOManager();
   int currentFormat = -1;
-  QString currentExtension = QString(".") + fileInfo.suffix();
+  QString currentExtension = QString(".") + fileInfo.completeSuffix();
   foreach(QString nameFilter, coreIOManager->fileWriterExtensions(node))
     {
     QString extension = QString::fromStdString(

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -520,7 +520,11 @@ QFileInfo qSlicerSaveDataDialogPrivate::nodeFileInfo(vtkMRMLStorableNode* node)
       qSlicerCoreIOManager* coreIOManager =
            qSlicerCoreApplication::application()->coreIOManager();
       QString suffix = coreIOManager->completeSlicerWritableFileNameSuffix(existingInfo.fileName());
-      QFileInfo newInfo(existingInfo.absoluteDir(), QString(node->GetName() + QString(".") + suffix));
+      if (!suffix.startsWith(QString(".")))
+        {
+        suffix = QString(".") + suffix;
+        }
+      QFileInfo newInfo(existingInfo.absoluteDir(), QString(node->GetName() + suffix));
       // Only reset the file name if the user has set the name explicitly (that is,
       // if the name isn't the default created by qSlicerVolumesIOOptionsWidget::setFileNames
       // TODO: this logic relies on the GUI so we should consider moving it into MRML proper
@@ -634,7 +638,11 @@ QWidget* qSlicerSaveDataDialogPrivate::createFileFormatsWidget(vtkMRMLStorableNo
   qSlicerCoreIOManager* coreIOManager =
     qSlicerCoreApplication::application()->coreIOManager();
   int currentFormat = -1;
-  QString currentExtension = QString(".") + coreIOManager->completeSlicerWritableFileNameSuffix(fileInfo.fileName());
+  QString currentExtension = coreIOManager->completeSlicerWritableFileNameSuffix(fileInfo.fileName());
+  if (!currentExtension.startsWith(QString(".")))
+    {
+    currentExtension = currentExtension + QString(".");
+    }
   foreach(QString nameFilter, coreIOManager->fileWriterExtensions(node))
     {
     QString extension = QString::fromStdString(

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -517,7 +517,10 @@ QFileInfo qSlicerSaveDataDialogPrivate::nodeFileInfo(vtkMRMLStorableNode* node)
     if (snode->GetFileName() && node->GetName())
       {
       QFileInfo existingInfo(snode->GetFileName());
-      QFileInfo newInfo(existingInfo.absoluteDir(), QString(safeNodeName + QString(".") + existingInfo.completeSuffix()));
+      qSlicerCoreIOManager* coreIOManager =
+           qSlicerCoreApplication::application()->coreIOManager();
+      QString suffix = coreIOManager->completeSlicerSuffix(existingInfo.fileName());
+      QFileInfo newInfo(existingInfo.absoluteDir(), QString(safeNodeName + QString(".") + suffix));
       // Only reset the file name if the user has set the name explicitly (that is,
       // if the name isn't the default created by qSlicerVolumesIOOptionsWidget::setFileNames
       // TODO: this logic relies on the GUI so we should consider moving it into MRML proper
@@ -631,7 +634,7 @@ QWidget* qSlicerSaveDataDialogPrivate::createFileFormatsWidget(vtkMRMLStorableNo
   qSlicerCoreIOManager* coreIOManager =
     qSlicerCoreApplication::application()->coreIOManager();
   int currentFormat = -1;
-  QString currentExtension = QString(".") + fileInfo.completeSuffix();
+  QString currentExtension = QString(".") + coreIOManager->completeSlicerSuffix(fileInfo.fileName());
   foreach(QString nameFilter, coreIOManager->fileWriterExtensions(node))
     {
     QString extension = QString::fromStdString(

--- a/Libs/MRML/Core/Testing/vtkMRMLFiberBundleNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLFiberBundleNodeTest1.cxx
@@ -19,7 +19,7 @@ int vtkMRMLFiberBundleNodeTest1(int , char * [] )
 {
   vtkNew< vtkMRMLFiberBundleNode> node1;
 
-  EXERCISE_BASIC_OBJECT_METHODS(node1.GetPointer());
+  EXERCISE_BASIC_DISPLAYABLE_MRML_METHOD(vtkMRMLFiberBundleNode, node1.GetPointer());
 
   node1->UpdateReferences();
 
@@ -47,19 +47,6 @@ int vtkMRMLFiberBundleNodeTest1(int , char * [] )
     std::cerr << "Error in Set/GetAttribute() " << std::endl;
     return EXIT_FAILURE;
     }
-
-  TEST_SET_GET_BOOLEAN( node1, HideFromEditors );
-  TEST_SET_GET_BOOLEAN( node1, Selectable );
-
-  TEST_SET_GET_STRING( node1, Description );
-  TEST_SET_GET_STRING( node1, SceneRootDir );
-  TEST_SET_GET_STRING( node1, Name );
-  TEST_SET_GET_STRING( node1, SingletonTag );
-
-  TEST_SET_GET_BOOLEAN( node1, ModifiedSinceRead );
-  TEST_SET_GET_BOOLEAN( node1, SaveWithScene );
-  TEST_SET_GET_BOOLEAN( node1, AddToScene );
-  TEST_SET_GET_BOOLEAN( node1, Selected );
 
   node1->Modified();
 

--- a/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
@@ -428,7 +428,6 @@
     TEST_SET_GET_BOOLEAN( node, HideFromEditors );                      \
     TEST_SET_GET_BOOLEAN( node, Selectable );                           \
     TEST_SET_GET_STRING( node, Description );                           \
-    TEST_SET_GET_STRING( node, SceneRootDir );                          \
     TEST_SET_GET_STRING( node, Name );                                  \
     TEST_SET_GET_STRING( node, SingletonTag );                          \
     TEST_SET_GET_BOOLEAN( node, SaveWithScene );                        \

--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -47,7 +47,6 @@ vtkMRMLNode::vtkMRMLNode()
 
   this->SingletonTag = NULL;
 
-  this->SceneRootDir = NULL;
   this->Scene = NULL;
 
   this->HideFromEditors = 0;
@@ -103,11 +102,6 @@ vtkMRMLNode::~vtkMRMLNode()
     {
     delete [] this->ID;
     this->ID = NULL;
-    }
-  if (this->SceneRootDir)
-    {
-    delete [] this->SceneRootDir;
-    this->SceneRootDir = NULL;
     }
   if (this->MRMLObserverManager)
     {
@@ -573,7 +567,6 @@ void vtkMRMLNode::SetScene(vtkMRMLScene* scene)
   if (this->Scene)
     {
     this->SetSceneReferences();
-    this->SetSceneRootDir(scene->GetRootDirectory());
     // We must not call UpdateNodeReferences() here yet, because referenced node IDs may change
     // due to conflict with node IDs existing in the scene.
     }

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -316,11 +316,7 @@ public:
   vtkSetStringMacro(Description);
   vtkGetStringMacro(Description);
 
-  /// Root directory of MRML scene.
-  vtkSetStringMacro(SceneRootDir);
-  vtkGetStringMacro(SceneRootDir);
-
-  /// Name of this node, to be set by the user.
+  /// Name of this node, to be set by the user
   vtkSetStringMacro(Name);
   vtkGetStringMacro(Name);
 
@@ -820,7 +816,6 @@ protected:
   int InMRMLCallbackFlag;
 
   char *Description;
-  char *SceneRootDir;
   char *Name;
   char *ID;
   int Indent;

--- a/Libs/MRML/Core/vtkMRMLParser.cxx
+++ b/Libs/MRML/Core/vtkMRMLParser.cxx
@@ -103,12 +103,10 @@ void vtkMRMLParser::StartElement(const char* tagName, const char** atts)
     return;
     }
 
-  // It is needed to have the scene root dir set before ReadXMLAttributes is
+  // It is needed to have the scene set before ReadXMLAttributes is
   // called on storage nodes.
-  if (this->GetMRMLScene())
-    {
-    node->SetSceneRootDir(this->GetMRMLScene()->GetRootDirectory());
-    }
+  node->SetScene(this->GetMRMLScene());
+
   node->ReadXMLAttributes(atts);
 
   // Slicer3 snap shot nodes were hidden by default, show them so that

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -877,6 +877,9 @@ int vtkMRMLScene::Commit(const char* url)
   else
     {
     os = &ofs;
+    // set the root directory from the URL
+    this->RootDirectory = vtksys::SystemTools::GetParentDirectory(url);
+
     // Open file
 #ifdef _WIN32
     ofs.open(url, std::ios::out | std::ios::binary);
@@ -1017,7 +1020,6 @@ vtkMRMLNode*  vtkMRMLScene::AddNodeNoNotify(vtkMRMLNode *n)
   int wasModifying = n->StartModify();
 
   //TODO convert URL to Root directory
-  //n->SetSceneRootDir("");
 
   // check if node is a singletone
   if (n->GetSingletonTag() != NULL)
@@ -1820,7 +1822,6 @@ vtkMRMLNode* vtkMRMLScene::InsertAfterNode(vtkMRMLNode *item, vtkMRMLNode *n)
   int modifyStatus = n->GetDisableModifiedEvent();
   n->SetDisableModifiedEvent(1);
 
-  n->SetSceneRootDir(this->RootDirectory.c_str());
   if (n->GetName() == NULL|| n->GetName()[0] == '\0')
     {
     n->SetName(n->GetID());
@@ -1904,7 +1905,6 @@ vtkMRMLNode* vtkMRMLScene::InsertBeforeNode(vtkMRMLNode *item, vtkMRMLNode *n)
   int modifyStatus = n->GetDisableModifiedEvent();
   n->SetDisableModifiedEvent(1);
 
-  n->SetSceneRootDir(this->RootDirectory.c_str());
   if (n->GetName() == NULL|| n->GetName()[0] == '\0')
     {
     n->SetName(n->GetID());

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -79,6 +79,10 @@ void vtkMRMLSceneViewNode::WriteXML(ostream& of, int nIndent)
 //----------------------------------------------------------------------------
 void vtkMRMLSceneViewNode::WriteNodeBodyXML(ostream& of, int nIndent)
 {
+  // first make sure that the scene view scene is to be saved relative to the same place as the main scene
+  const char *sceneURL = this->SnapshotScene->GetURL();
+  const char *rootDir = this->SnapshotScene->GetRootDirectory();
+  this->SnapshotScene->SetRootDirectory(this->GetScene()->GetRootDirectory());
   this->SetAbsentStorageFileNames();
 
   vtkMRMLNode * node = NULL;

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -374,14 +374,14 @@ void vtkMRMLSceneViewNode::StoreScene()
       if (this->IncludeNodeInSceneView(storableNode) &&
           storableNode->GetSaveWithScene() )
         {
-        vtkMRMLStorageNode *storageNode = storableNode->GetStorageNode();
+        vtkSmartPointer<vtkMRMLStorageNode> storageNode = storableNode->GetStorageNode();
         if (!storageNode)
           {
           // No storage node in the main scene, add one there, and ensure it
           // gets added to the scene view
           vtkWarningMacro("SceneView StoreScene: creating a new storage node for "
                            << storableNode->GetID());
-          storageNode = storableNode->CreateDefaultStorageNode();
+          storageNode.TakeReference(storableNode->CreateDefaultStorageNode());
           if (storageNode)
             {
             std::string fileBaseName = std::string(storableNode->GetName());
@@ -391,7 +391,6 @@ void vtkMRMLSceneViewNode::StoreScene()
             // add to the main scene
             this->Scene->AddNode(storageNode);
             storableNode->SetAndObserveStorageNodeID(storageNode->GetID());
-            storageNode->Delete();
             }
           }
         }

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -615,6 +615,15 @@ void vtkMRMLSceneViewNode::SetAbsentStorageFileNames()
           if (snode1)
             {
             snode->SetFileName(snode1->GetFileName());
+            int numberOfFileNames = snode1->GetNumberOfFileNames();
+            if (numberOfFileNames > 0)
+              {
+              snode->ResetFileNameList();
+              for (int i = 0; i < numberOfFileNames; ++i)
+                {
+                snode->AddFileName(snode1->GetNthFileName(i));
+                }
+              }
             }
           }
         }

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -209,9 +209,11 @@ void vtkMRMLStorageNode::ReadXMLAttributes(const char** atts)
 
       // convert to absolute filename
       std::string name;
-      if (this->GetSceneRootDir() && this->IsFilePathRelative(filename.c_str()))
+      if (this->GetScene() &&
+          this->GetScene()->GetRootDirectory() &&
+          this->IsFilePathRelative(filename.c_str()))
         {
-        name = this->GetSceneRootDir();
+        name = this->GetScene()->GetRootDirectory();
         if (name[name.size()-1] != '/')
           {
           name = name + std::string("/");
@@ -232,9 +234,11 @@ void vtkMRMLStorageNode::ReadXMLAttributes(const char** atts)
 
       // convert to absolute filename
       std::string name;
-      if (this->GetSceneRootDir() && this->IsFilePathRelative(filename.c_str()))
+      if (this->GetScene() &&
+          this->GetScene()->GetRootDirectory() &&
+          this->IsFilePathRelative(filename.c_str()))
         {
-        name = this->GetSceneRootDir();
+        name = this->GetScene()->GetRootDirectory();
         if (name[name.size()-1] != '/')
           {
           name = name + std::string("/");
@@ -976,13 +980,14 @@ const char *vtkMRMLStorageNode::GetAbsoluteFilePath(const char *inputPath)
     // the path is already absolute, return it
     return inputPath;
     }
-  if (!this->GetSceneRootDir())
+  if (!this->GetScene() ||
+      !this->GetScene()->GetRootDirectory())
     {
-    vtkErrorMacro("GetAbsoluteFilePath: have a relative path " << inputPath << " but no scene to find it from!");
+    vtkErrorMacro("GetAbsoluteFilePath: have a relative path " << inputPath << " but no scene or root directory to find it from!");
     return NULL;
     }
 
-  std::string path = this->GetSceneRootDir();
+  std::string path = this->GetScene()->GetRootDirectory();
   if (path.size() > 0 &&
       path[path.size()-1] != '/')
     {

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -1123,5 +1123,12 @@ int vtkMRMLStorageNode::WriteDataInternal(vtkMRMLNode* vtkNotUsed(refNode))
 std::string vtkMRMLStorageNode::GetLowercaseExtensionFromFileName(const std::string& filename)
 {
   std::string extension = vtksys::SystemTools::GetFilenameLastExtension(filename);
+  if (extension.compare(".gz") == 0)
+    {
+    // some file formats have a compressed version ending with gz, return
+    // the full extension
+    extension = vtksys::SystemTools::GetFilenameLastExtension(vtksys::SystemTools::GetFilenameWithoutLastExtension(filename)) +
+                vtksys::SystemTools::GetFilenameLastExtension(filename);
+    }
   return vtksys::SystemTools::LowerCase(extension);
 }

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -647,14 +647,14 @@ bool vtkMRMLApplicationLogic::SaveSceneToSlicerDataBundleDirectory(const char *s
   newSceneViewNode->StoreScene();
   this->GetMRMLScene()->AddNode(newSceneViewNode);
 
-  vtkMRMLStorageNode *newSceneViewStorageNode = 0;
+  vtkSmartPointer<vtkMRMLStorageNode> newSceneViewStorageNode;
   if (screenShot)
     {
     // assumes has been passed a screen shot of the full layout
     newSceneViewNode->SetScreenShotType(4);
     newSceneViewNode->SetScreenShot(screenShot);
     // create a storage node
-    newSceneViewStorageNode = newSceneViewNode->CreateDefaultStorageNode();
+    newSceneViewStorageNode.TakeReference(newSceneViewNode->CreateDefaultStorageNode());
     // set the file name from the node name, using a relative path, it will go
     // at the same level as the  .mrml file
     std::string sceneViewFileName = std::string(newSceneViewNode->GetName()) + std::string(".png");
@@ -679,7 +679,6 @@ bool vtkMRMLApplicationLogic::SaveSceneToSlicerDataBundleDirectory(const char *s
   if (newSceneViewStorageNode)
     {
     this->GetMRMLScene()->RemoveNode(newSceneViewStorageNode);
-    newSceneViewStorageNode->Delete();
     }
 
   // reset the storage paths

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -647,22 +647,22 @@ bool vtkMRMLApplicationLogic::SaveSceneToSlicerDataBundleDirectory(const char *s
   newSceneViewNode->StoreScene();
   this->GetMRMLScene()->AddNode(newSceneViewNode);
 
-  vtkMRMLStorageNode *sceneViewStorageNode = 0;
+  vtkMRMLStorageNode *newSceneViewStorageNode = 0;
   if (screenShot)
     {
     // assumes has been passed a screen shot of the full layout
     newSceneViewNode->SetScreenShotType(4);
     newSceneViewNode->SetScreenShot(screenShot);
     // create a storage node
-    vtkMRMLStorageNode *sceneViewStorageNode = newSceneViewNode->CreateDefaultStorageNode();
+    newSceneViewStorageNode = newSceneViewNode->CreateDefaultStorageNode();
     // set the file name from the node name, using a relative path, it will go
     // at the same level as the  .mrml file
     std::string sceneViewFileName = std::string(newSceneViewNode->GetName()) + std::string(".png");
-    sceneViewStorageNode->SetFileName(sceneViewFileName.c_str());
-    this->GetMRMLScene()->AddNode(sceneViewStorageNode);
-    newSceneViewNode->SetAndObserveStorageNodeID(sceneViewStorageNode->GetID());
+    newSceneViewStorageNode->SetFileName(sceneViewFileName.c_str());
+    this->GetMRMLScene()->AddNode(newSceneViewStorageNode);
+    newSceneViewNode->SetAndObserveStorageNodeID(newSceneViewStorageNode->GetID());
     // force a write
-    sceneViewStorageNode->WriteData(newSceneViewNode);
+    newSceneViewStorageNode->WriteData(newSceneViewNode);
     }
 
   // write the scene to disk, changes paths to relative
@@ -676,10 +676,10 @@ bool vtkMRMLApplicationLogic::SaveSceneToSlicerDataBundleDirectory(const char *s
   // clean up scene views
   this->GetMRMLScene()->RemoveNode(newSceneViewNode);
   newSceneViewNode->Delete();
-  if (sceneViewStorageNode)
+  if (newSceneViewStorageNode)
     {
-    this->GetMRMLScene()->RemoveNode(sceneViewStorageNode);
-    sceneViewStorageNode->Delete();
+    this->GetMRMLScene()->RemoveNode(newSceneViewStorageNode);
+    newSceneViewStorageNode->Delete();
     }
 
   // reset the storage paths

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -607,7 +607,7 @@ bool vtkMRMLApplicationLogic::SaveSceneToSlicerDataBundleDirectory(const char *s
     }
     if (mrmlNode->IsA("vtkMRMLSceneViewNode"))
       {
-      // get all additional storable nodes for all scene views except "Master Scene View"
+      // get all additional storable nodes for all scene views
       vtkMRMLSceneViewNode *sceneViewNode = vtkMRMLSceneViewNode::SafeDownCast(mrmlNode);
       sceneViewNode->SetSceneViewRootDir(this->GetMRMLScene()->GetRootDirectory());
 
@@ -681,6 +681,9 @@ bool vtkMRMLApplicationLogic::SaveSceneToSlicerDataBundleDirectory(const char *s
   // Now, restore the state of the scene
   //
 
+  this->GetMRMLScene()->SetURL(origURL.c_str());
+  this->GetMRMLScene()->SetRootDirectory(origRootDirectory.c_str());
+
   // clean up scene views
   this->GetMRMLScene()->RemoveNode(newSceneViewNode);
   newSceneViewNode->Delete();
@@ -702,6 +705,7 @@ bool vtkMRMLApplicationLogic::SaveSceneToSlicerDataBundleDirectory(const char *s
     if (mrmlNode->IsA("vtkMRMLSceneViewNode"))
       {
       vtkMRMLSceneViewNode *sceneViewNode = vtkMRMLSceneViewNode::SafeDownCast(mrmlNode);
+      sceneViewNode->GetScene()->SetURL(origURL.c_str());
       sceneViewNode->SetSceneViewRootDir(origRootDirectory.c_str());
 
       // get all additional storable nodes for all scene views

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -779,7 +779,7 @@ void vtkMRMLApplicationLogic::SaveStorableNodeToSlicerDataBundleDirectory(vtkMRM
   if (!storageNode)
     {
     // no storage node, so we have to create one with a valid name in the new directory
-    vtkWarningMacro("creating a new storage node for " << storableNode->GetID());
+    vtkDebugMacro("creating a new storage node for " << storableNode->GetID());
     storageNode = storableNode->CreateDefaultStorageNode();
     if (storageNode)
       {

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -210,7 +210,10 @@ protected:
 private:
 
   std::map<vtkMRMLStorageNode*, std::string> OriginalStorageNodeDirs;
-  std::map<vtkMRMLStorageNode*, std::string> OriginalStorageNodeFileNames;
+  /// use a map to store the file names from a storage node, the 0th one is by
+  /// definition the GetFileName returned value, then the rest are at index n+1
+  /// from GetNthFileName(n)
+  std::map<vtkMRMLStorageNode*, std::vector<std::string> > OriginalStorageNodeFileNames;
 
   vtkMRMLApplicationLogic(const vtkMRMLApplicationLogic&);
   void operator=(const vtkMRMLApplicationLogic&);

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -142,6 +142,8 @@ public:
   std::string PercentEncode(std::string s);
 
   /// Save the scene into a self contained directory, sdbDir
+  /// Called by the qSlicerSceneWriter, which can be accessed via
+  /// \sa qSlicerCoreIOManager::saveScene
   /// If screenShot is not null, use it as the screen shot for a scene view
   /// Returns false if the save failed
   bool SaveSceneToSlicerDataBundleDirectory(const char *sdbDir, vtkImageData *screenShot = NULL);

--- a/Libs/MRML/Logic/vtkMRMLRemoteIOLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLRemoteIOLogic.cxx
@@ -68,7 +68,10 @@ void vtkMRMLRemoteIOLogic::AddDataIOToScene()
   // from qSlicerCoreApplication::setMRMLScene(vtkMRMLScene* newMRMLScene)
   // should be moved to here so they can be used outside of the
   // context of a qSlicer based application
-
+  // Update 2015/03/20: split qSlicerCoreApplication::setMRMLScene so that
+  // a user can call vtkSlicerApplicationLogic::SetMRMLSceneDataIO to trigger
+  /// this method on a independent scene with separate remote io logic and data
+  /// io manager logic
   if (!this->GetMRMLScene())
     {
     vtkErrorMacro("Cannot add DataIOHandlers -- scene not set");

--- a/Libs/MRML/Widgets/qMRMLCaptureToolBar.cxx
+++ b/Libs/MRML/Widgets/qMRMLCaptureToolBar.cxx
@@ -19,9 +19,14 @@
 ==============================================================================*/
 
 // Qt includes
+#include <QDebug>
 #include <QMenu>
 #include <QInputDialog>
+#include <QTimer>
 #include <QToolButton>
+
+// CTK includes
+#include <ctkMessageBox.h>
 
 // qMRML includes
 #include "qMRMLCaptureToolBar.h"
@@ -126,6 +131,8 @@ void qMRMLCaptureToolBarPrivate::init()
 // --------------------------------------------------------------------------
 void qMRMLCaptureToolBarPrivate::setMRMLScene(vtkMRMLScene* newScene)
 {
+  Q_Q(qMRMLCaptureToolBar);
+
   if (newScene == this->MRMLScene)
     {
     return;
@@ -138,6 +145,11 @@ void qMRMLCaptureToolBarPrivate::setMRMLScene(vtkMRMLScene* newScene)
                       this, SLOT(OnMRMLSceneEndBatchProcessing()));
 
 */
+  // observe for storable nodes added after scene views are present in the scene
+  this->qvtkReconnect(this->MRMLScene, newScene,
+                      vtkMRMLScene::NodeAddedEvent,
+                      q, SLOT(OnMRMLSceneNodeAddedEvent(vtkObject*,vtkObject*)));
+
   this->MRMLScene = newScene;
 
   this->SceneViewMenu->setMRMLScene(newScene);
@@ -223,4 +235,48 @@ void qMRMLCaptureToolBar::setActiveMRMLThreeDViewNode(
   Q_D(qMRMLCaptureToolBar);
   d->ActiveMRMLThreeDViewNode = newActiveMRMLThreeDViewNode;
   d->updateWidgetFromMRML();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLCaptureToolBar::OnMRMLSceneNodeAddedEvent(vtkObject *vtkNotUsed(caller), vtkObject* callData)
+{
+  Q_D(qMRMLCaptureToolBar);
+
+  if (!d->MRMLScene ||
+      d->MRMLScene->IsClosing() ||
+      d->MRMLScene->IsBatchProcessing() ||
+      !callData)
+    {
+    return;
+    }
+
+  vtkMRMLNode *mrmlNode = vtkMRMLNode::SafeDownCast(callData);
+  if (!mrmlNode)
+    {
+    return;
+    }
+
+  if (!mrmlNode->IsA("vtkMRMLSceneViewNode") &&
+      mrmlNode->IsA("vtkMRMLStorableNode") &&
+      d->MRMLScene->GetNumberOfNodesByClass("vtkMRMLSceneViewNode") > 0)
+    {
+    qDebug() << "Warning! Adding the node" << mrmlNode->GetName() << "to the scene does not add it\nto the scene views already present!\n\tRestoring a previously saved scene view will remove this node!";
+    ctkMessageBox msgBox;
+    msgBox.setWindowTitle("New data added after scene view created.");
+    QString msgText = QString("Data that can be saved to disk was added to the scene, but doesn't appear in the currently defined scene views!\n")
+      + QString("If you restore one of those scene views you will lose\n")
+      + QString(mrmlNode->GetName())
+      + QString("\nYou can save ")
+      + QString(mrmlNode->GetName())
+      + QString(" to disk, restore the scene view, reload the data, then resave the scene view.");
+    msgBox.setText(msgText);
+    QPushButton *ackButton = msgBox.addButton("Acknowledged",
+                                              QMessageBox::AcceptRole);
+    msgBox.setDefaultButton(ackButton);
+    msgBox.setDontShowAgainVisible(true);
+    msgBox.setDontShowAgainSettingsKey("SceneViews/NeverShowLostDataWarning");
+    // have it time out after giving the user some time to read it
+    QTimer::singleShot(15000, &msgBox, SLOT(close()));
+    msgBox.exec();
+    }
 }

--- a/Libs/MRML/Widgets/qMRMLCaptureToolBar.cxx
+++ b/Libs/MRML/Widgets/qMRMLCaptureToolBar.cxx
@@ -258,9 +258,10 @@ void qMRMLCaptureToolBar::OnMRMLSceneNodeAddedEvent(vtkObject *vtkNotUsed(caller
 
   if (!mrmlNode->IsA("vtkMRMLSceneViewNode") &&
       mrmlNode->IsA("vtkMRMLStorableNode") &&
+      mrmlNode->GetSaveWithScene() == 1 &&
       d->MRMLScene->GetNumberOfNodesByClass("vtkMRMLSceneViewNode") > 0)
     {
-    qDebug() << "Warning! Adding the node" << mrmlNode->GetName() << "to the scene does not add it\nto the scene views already present!\n\tRestoring a previously saved scene view will remove this node!";
+    qDebug() << "Warning! Adding the node" << mrmlNode->GetName() << " with id " << mrmlNode->GetID() << " to the scene does not add it\nto the scene views already present!\n\tRestoring a previously saved scene view will remove this node!";
     ctkMessageBox msgBox;
     msgBox.setWindowTitle("New data added after scene view created.");
     QString msgText = QString("Data that can be saved to disk was added to the scene, but doesn't appear in the currently defined scene views!\n")

--- a/Libs/MRML/Widgets/qMRMLCaptureToolBar.cxx
+++ b/Libs/MRML/Widgets/qMRMLCaptureToolBar.cxx
@@ -266,10 +266,10 @@ void qMRMLCaptureToolBar::OnMRMLSceneNodeAddedEvent(vtkObject *vtkNotUsed(caller
     qDebug() << "Warning! Adding the node" << mrmlNode->GetName() << " with id " << mrmlNode->GetID() << " to the scene does not add it\nto the scene views already present!\n\tRestoring a previously saved scene view will remove this node!";
     ctkMessageBox msgBox;
     msgBox.setWindowTitle("New data added after scene view created.");
-    QString msgText = QString("Data that can be saved to disk was added to the scene, but doesn't appear in the currently defined scene views!\n")
+    QString msgText = QString("Data that can be saved to disk was added to the scene, but doesn't appear in the currently defined scene views!\n\n")
       + QString("If you restore one of those scene views you will lose\n")
       + QString(mrmlNode->GetName())
-      + QString("\nYou can save ")
+      + QString("\n\nYou can save ")
       + QString(mrmlNode->GetName())
       + QString(" to disk, restore the scene view, reload the data, then resave the scene view.");
     msgBox.setText(msgText);

--- a/Libs/MRML/Widgets/qMRMLCaptureToolBar.cxx
+++ b/Libs/MRML/Widgets/qMRMLCaptureToolBar.cxx
@@ -49,6 +49,7 @@ class qMRMLCaptureToolBarPrivate
   Q_DECLARE_PUBLIC(qMRMLCaptureToolBar);
 protected:
   qMRMLCaptureToolBar* const q_ptr;
+  bool timeOutFlag;
 public:
   qMRMLCaptureToolBarPrivate(qMRMLCaptureToolBar& object);
   void init();
@@ -78,6 +79,7 @@ qMRMLCaptureToolBarPrivate::qMRMLCaptureToolBarPrivate(qMRMLCaptureToolBar& obje
   this->ScreenshotAction = 0;
   this->SceneViewAction = 0;
   this->SceneViewMenu = 0;
+  this->timeOutFlag = false;
 }
 
 // --------------------------------------------------------------------------
@@ -276,8 +278,27 @@ void qMRMLCaptureToolBar::OnMRMLSceneNodeAddedEvent(vtkObject *vtkNotUsed(caller
     msgBox.setDefaultButton(ackButton);
     msgBox.setDontShowAgainVisible(true);
     msgBox.setDontShowAgainSettingsKey("SceneViews/NeverShowLostDataWarning");
-    // have it time out after giving the user some time to read it
-    QTimer::singleShot(15000, &msgBox, SLOT(close()));
+    // time out during testing
+    if (this->popupsTimeOut())
+      {
+      QTimer::singleShot(1000, &msgBox, SLOT(close()));
+      }
     msgBox.exec();
     }
+}
+
+// --------------------------------------------------------------------------
+bool qMRMLCaptureToolBar::popupsTimeOut() const
+{
+  Q_D(const qMRMLCaptureToolBar);
+
+  return d->timeOutFlag;
+}
+
+// --------------------------------------------------------------------------
+void qMRMLCaptureToolBar::setPopupsTimeOut(bool flag)
+{
+  Q_D(qMRMLCaptureToolBar);
+
+  d->timeOutFlag = flag;
 }

--- a/Libs/MRML/Widgets/qMRMLCaptureToolBar.h
+++ b/Libs/MRML/Widgets/qMRMLCaptureToolBar.h
@@ -57,6 +57,8 @@ public:
 public slots:
   virtual void setMRMLScene(vtkMRMLScene* newScene);
   void setActiveMRMLThreeDViewNode(vtkMRMLViewNode * newActiveMRMLThreeDViewNode);
+  /// Watch for storable nodes being added after a scene view is present
+  void OnMRMLSceneNodeAddedEvent(vtkObject* scene, vtkObject* node);
 
 signals:
   void screenshotButtonClicked();

--- a/Libs/MRML/Widgets/qMRMLCaptureToolBar.h
+++ b/Libs/MRML/Widgets/qMRMLCaptureToolBar.h
@@ -45,6 +45,8 @@ class QMRML_WIDGETS_EXPORT qMRMLCaptureToolBar : public QToolBar
   Q_OBJECT
   QVTK_OBJECT
 
+  Q_PROPERTY(bool popupsTimeOut READ popupsTimeOut WRITE setPopupsTimeOut)
+
 public:
   typedef QToolBar Superclass;
 
@@ -54,11 +56,18 @@ public:
   qMRMLCaptureToolBar(QWidget* parent = 0);
   virtual ~qMRMLCaptureToolBar();
 
+  // Get popupsTimeOut setting
+  bool popupsTimeOut() const;
+
 public slots:
   virtual void setMRMLScene(vtkMRMLScene* newScene);
   void setActiveMRMLThreeDViewNode(vtkMRMLViewNode * newActiveMRMLThreeDViewNode);
   /// Watch for storable nodes being added after a scene view is present
   void OnMRMLSceneNodeAddedEvent(vtkObject* scene, vtkObject* node);
+
+  /// Set flag to time out pop ups, set from the qSlicerAppMainWindow according to the
+  /// AA_EnableTesting attribute
+  void setPopupsTimeOut(bool flag);
 
 signals:
   void screenshotButtonClicked();

--- a/Libs/MRML/Widgets/qMRMLCaptureToolBar.h
+++ b/Libs/MRML/Widgets/qMRMLCaptureToolBar.h
@@ -62,8 +62,6 @@ public:
 public slots:
   virtual void setMRMLScene(vtkMRMLScene* newScene);
   void setActiveMRMLThreeDViewNode(vtkMRMLViewNode * newActiveMRMLThreeDViewNode);
-  /// Watch for storable nodes being added after a scene view is present
-  void OnMRMLSceneNodeAddedEvent(vtkObject* scene, vtkObject* node);
 
   /// Set flag to time out pop ups, set from the qSlicerAppMainWindow according to the
   /// AA_EnableTesting attribute

--- a/Modules/Loadable/Data/qSlicerSceneWriter.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneWriter.cxx
@@ -263,6 +263,13 @@ bool qSlicerSceneWriter::writeToMRB(const qSlicerIO::IOProperties& properties)
     return false;
     }
 
+  // Mark the storable nodes as modified since read, since that flag was reset
+  // when the files were written out. If there was newly generated data in the
+  // scene that only got saved to the MRB bundle directory, it would be marked
+  // as unmodified since read when saving as a MRML file + data. This will not
+  // disrupt multiple MRB saves.
+  this->mrmlScene()->SetStorableNodesModifiedSinceRead();
+
   qDebug() << "saved " << fileInfo.absoluteFilePath();
   return true;
 }

--- a/Modules/Loadable/Data/qSlicerSceneWriter.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneWriter.cxx
@@ -45,6 +45,7 @@
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
+#include <vtksys/SystemTools.hxx>
 
 //----------------------------------------------------------------------------
 qSlicerSceneWriter::qSlicerSceneWriter(QObject* parentObject)
@@ -111,6 +112,14 @@ bool qSlicerSceneWriter::write(const qSlicerIO::IOProperties& properties)
 //----------------------------------------------------------------------------
 bool qSlicerSceneWriter::writeToMRML(const qSlicerIO::IOProperties& properties)
 {
+  // set the mrml scene url first
+  Q_ASSERT(!properties["fileName"].toString().isEmpty());
+  QString fileName = properties["fileName"].toString();
+
+  this->mrmlScene()->SetURL(fileName.toLatin1());
+  std::string parentDir = vtksys::SystemTools::GetParentDirectory(this->mrmlScene()->GetURL());
+  this->mrmlScene()->SetRootDirectory(parentDir.c_str());
+
   // save an explicit default scene view recording the state of the scene when
   // saved to file
   const char *defaultSceneName = "Master Scene View";
@@ -161,11 +170,9 @@ bool qSlicerSceneWriter::writeToMRML(const qSlicerIO::IOProperties& properties)
   // force a write
   sceneViewNode->GetStorageNode()->WriteData(sceneViewNode);
 
-  Q_ASSERT(!properties["fileName"].toString().isEmpty());
-  QString fileName = properties["fileName"].toString();
-
-  this->mrmlScene()->SetURL(fileName.toLatin1());
+  // write out the mrml file
   bool res = this->mrmlScene()->Commit();
+
   return res;
 }
 

--- a/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
+++ b/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
@@ -1,0 +1,216 @@
+import os
+import unittest
+from __main__ import vtk, qt, ctk, slicer
+from slicer.ScriptedLoadableModule import *
+import logging
+
+#
+# AddStorableDataAfterSceneViewTest
+#
+
+class AddStorableDataAfterSceneViewTest(ScriptedLoadableModule):
+  """Uses ScriptedLoadableModule base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "Add Storable Data After Scene View Test"
+    self.parent.categories = ["Testing.TestCases"]
+    self.parent.dependencies = []
+    self.parent.contributors = ["Nicole Aucoin (BWH)"]
+    self.parent.helpText = """
+    This self test adds some data, creates a scene view, then adds more storable data.
+    It tests Slicer's functionality after the scene view is restored, is the new storable
+    node still present? With the current implementation it only passes if the new storable
+    node is NOT present.
+    """
+    self.parent.acknowledgementText = """
+    This file was originally developed by Nicole Aucoin, BWH, and was partially funded by NIH grant 3P41RR013218-12S1.
+"""
+
+#
+# qAddStorableDataAfterSceneViewTestWidget
+#
+
+class AddStorableDataAfterSceneViewTestWidget(ScriptedLoadableModuleWidget):
+  """Uses ScriptedLoadableModuleWidget base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def setup(self):
+    ScriptedLoadableModuleWidget.setup(self)
+
+    # Instantiate and connect widgets ...
+
+    #
+    # Parameters Area
+    #
+    parametersCollapsibleButton = ctk.ctkCollapsibleButton()
+    parametersCollapsibleButton.text = "Parameters"
+    self.layout.addWidget(parametersCollapsibleButton)
+
+    # Layout within the dummy collapsible button
+    parametersFormLayout = qt.QFormLayout(parametersCollapsibleButton)
+
+    #
+    # check box to trigger taking screen shots for later use in tutorials
+    #
+    self.enableScreenshotsFlagCheckBox = qt.QCheckBox()
+    self.enableScreenshotsFlagCheckBox.checked = 0
+    self.enableScreenshotsFlagCheckBox.setToolTip("If checked, take screen shots for tutorials. Use Save Data to write them to disk.")
+    parametersFormLayout.addRow("Enable Screenshots", self.enableScreenshotsFlagCheckBox)
+
+    #
+    # Apply Button
+    #
+    self.applyButton = qt.QPushButton("Apply")
+    self.applyButton.toolTip = "Run the test."
+    self.applyButton.enabled = True
+    parametersFormLayout.addRow(self.applyButton)
+
+    # connections
+    self.applyButton.connect('clicked(bool)', self.onApplyButton)
+
+    # Add vertical spacer
+    self.layout.addStretch(1)
+
+  def cleanup(self):
+    pass
+
+  def onApplyButton(self):
+    logic = AddStorableDataAfterSceneViewTestLogic()
+    enableScreenshotsFlag = self.enableScreenshotsFlagCheckBox.checked
+    logic.run(enableScreenshotsFlag)
+
+#
+# AddStorableDataAfterSceneViewTestLogic
+#
+
+class AddStorableDataAfterSceneViewTestLogic(ScriptedLoadableModuleLogic):
+  """
+  Uses ScriptedLoadableModuleLogic base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def takeScreenshot(self,name,description,type=-1):
+    # show the message even if not taking a screen shot
+    slicer.util.delayDisplay('Take screenshot: '+description+'.\nResult is available in the Annotations module.', 3000)
+
+    lm = slicer.app.layoutManager()
+    # switch on the type to get the requested window
+    widget = 0
+    if type == slicer.qMRMLScreenShotDialog.FullLayout:
+      # full layout
+      widget = lm.viewport()
+    elif type == slicer.qMRMLScreenShotDialog.ThreeD:
+      # just the 3D window
+      widget = lm.threeDWidget(0).threeDView()
+    elif type == slicer.qMRMLScreenShotDialog.Red:
+      # red slice window
+      widget = lm.sliceWidget("Red")
+    elif type == slicer.qMRMLScreenShotDialog.Yellow:
+      # yellow slice window
+      widget = lm.sliceWidget("Yellow")
+    elif type == slicer.qMRMLScreenShotDialog.Green:
+      # green slice window
+      widget = lm.sliceWidget("Green")
+    else:
+      # default to using the full window
+      widget = slicer.util.mainWindow()
+      # reset the type so that the node is set correctly
+      type = slicer.qMRMLScreenShotDialog.FullLayout
+
+    # grab and convert to vtk image data
+    qpixMap = qt.QPixmap().grabWidget(widget)
+    qimage = qpixMap.toImage()
+    imageData = vtk.vtkImageData()
+    slicer.qMRMLUtils().qImageToVtkImageData(qimage,imageData)
+
+    annotationLogic = slicer.modules.annotations.logic()
+    annotationLogic.CreateSnapShot(name, description, type, 1, imageData)
+
+  def run(self, enableScreenshots=0):
+    """
+    Run the test via GUI
+    """
+
+    logging.info('Test started from GUI')
+
+    try:
+      evalString = 'AddStorableDataAfterSceneViewTestTest()'
+      tester = eval(evalString)
+      tester.runTest()
+    except Exception, e:
+      import traceback
+      traceback.print_exc()
+      errorMessage = "Add storable data after scene view test: Exception!\n\n" + str(e) + "\n\nSee Python Console for Stack Trace"
+      slicer.util.errorDisplay(errorMessage)
+
+    # Capture screenshot
+    if enableScreenshots:
+      self.takeScreenshot('AddStorableDataAfterSceneViewTest-Start','MyScreenshot',-1)
+
+    logging.info('Processing completed')
+
+    return True
+
+
+class AddStorableDataAfterSceneViewTestTest(ScriptedLoadableModuleTest):
+  """
+  This is the test case for your scripted module.
+  Uses ScriptedLoadableModuleTest base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def setUp(self):
+    """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+    """
+    slicer.mrmlScene.Clear(0)
+
+  def runTest(self):
+    """Run as few or as many tests as needed here.
+    """
+    self.setUp()
+    self.test_AddStorableDataAfterSceneViewTest1()
+
+  def test_AddStorableDataAfterSceneViewTest1(self):
+
+    self.delayDisplay("Starting the test")
+
+    #
+    # add a fiducial
+    #
+    slicer.modules.markups.logic().AddFiducial()
+
+    #
+    # save a scene view
+    #
+    sv = slicer.mrmlScene.AddNode(slicer.vtkMRMLSceneViewNode())
+    sv.StoreScene()
+
+    #
+    # add another storable node, a volume
+    #
+    self.delayDisplay("Adding a new storable node, after creating a scene view")
+    import SampleData
+    sampleDataLogic = SampleData.SampleDataLogic()
+    mrHeadVolume = sampleDataLogic.downloadMRHead()
+    mrHeadID = mrHeadVolume.GetID()
+
+    #
+    # restore the scene view
+    #
+    self.delayDisplay("Restoring the scene view")
+    sv.RestoreScene()
+
+    #
+    # Is the new storable data still present?
+    #
+    restoredData = slicer.mrmlScene.GetNodeByID(mrHeadID)
+
+    # for now, the non scene view storable data is removed
+    self.assertTrue( restoredData == None )
+    self.delayDisplay('Success: extra storable node removed with scene view restore')
+
+    self.delayDisplay('Test passed!')

--- a/Modules/Loadable/SceneViews/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/SceneViews/Testing/Python/CMakeLists.txt
@@ -10,3 +10,14 @@ add_test(
   ${INPUT}/SceneViewWithoutCamera.mrml
   )
 set_property(TEST ${testname} PROPERTY LABELS ${MODULE_NAME})
+
+include(SlicerMacroBuildScriptedModule)
+
+# Test adding new storable data after creating a scene view
+slicerMacroBuildScriptedModule(
+  NAME AddStorableDataAfterSceneViewTest
+  SCRIPTS AddStorableDataAfterSceneViewTest.py
+)
+slicer_add_python_unittest(SCRIPT AddStorableDataAfterSceneViewTest.py
+                           SLICER_ARGS --disable-cli-modules)
+set_property(TEST AddStorableDataAfterSceneViewTest PROPERTY LABELS ${MODULE_NAME})

--- a/Modules/Loadable/SceneViews/Testing/Python/CMakeLists.txt
+++ b/Modules/Loadable/SceneViews/Testing/Python/CMakeLists.txt
@@ -20,4 +20,4 @@ slicerMacroBuildScriptedModule(
 )
 slicer_add_python_unittest(SCRIPT AddStorableDataAfterSceneViewTest.py
                            SLICER_ARGS --disable-cli-modules)
-set_property(TEST AddStorableDataAfterSceneViewTest PROPERTY LABELS ${MODULE_NAME})
+set_property(TEST py_AddStorableDataAfterSceneViewTest PROPERTY LABELS ${MODULE_NAME})

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -545,19 +545,25 @@ void vtkSlicerVolumesLogic
 
 //----------------------------------------------------------------------------
 void vtkSlicerVolumesLogic::InitializeStorageNode(
-    vtkMRMLStorageNode * storageNode, const char * filename, vtkStringArray *fileList)
+  vtkMRMLStorageNode * storageNode, const char * filename, vtkStringArray *fileList, vtkMRMLScene * mrmlScene)
 {
   bool useURI = false;
-  if (this->GetMRMLScene() && this->GetMRMLScene()->GetCacheManager())
+
+  if (mrmlScene == NULL)
     {
-    useURI = this->GetMRMLScene()->GetCacheManager()->IsRemoteReference(filename);
+    mrmlScene = this->GetMRMLScene();
+    }
+
+  if (mrmlScene && mrmlScene->GetCacheManager())
+    {
+    useURI = mrmlScene->GetCacheManager()->IsRemoteReference(filename);
     }
   if (useURI)
     {
     vtkDebugMacro("AddArchetypeVolume: input filename '" << filename << "' is a URI");
     // need to set the scene on the storage node so that it can look for file handlers
     storageNode->SetURI(filename);
-    storageNode->SetScene(this->GetMRMLScene());
+    storageNode->SetScene(mrmlScene);
     if (fileList != NULL)
       {
       // it's a list of uris
@@ -647,11 +653,19 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
 
   vtkNew<vtkSlicerErrorSink> errorSink;
 
+  // set up a mini scene to avoid adding and removing nodes from the main scene
+  vtkNew<vtkMRMLScene> testScene;
+  // borrow the cache manager in case some nodes are stored remotely
+  if (this->GetMRMLScene()->GetCacheManager())
+    {
+    testScene->SetCacheManager(this->GetMRMLScene()->GetCacheManager());
+    }
+
   // Run through the factory list and test each factory until success
   for (NodeSetFactoryRegistry::const_iterator fit = volumeRegistry.begin();
        fit != volumeRegistry.end(); ++fit)
     {
-    ArchetypeVolumeNodeSet nodeSet( (*fit)(volumeName, this->GetMRMLScene(), loadingOptions) );
+    ArchetypeVolumeNodeSet nodeSet( (*fit)(volumeName, testScene.GetPointer(), loadingOptions) );
 
     // if the labelMap flags for reader and factory are consistent
     // (both true or both false)
@@ -662,7 +676,7 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
       nodeSet.StorageNode->AddObserver(vtkCommand::ErrorEvent, errorSink.GetPointer());
       nodeSet.StorageNode->AddObserver(vtkCommand::ProgressEvent,  this->GetMRMLNodesCallbackCommand());
 
-      this->InitializeStorageNode(nodeSet.StorageNode, filename, fileList);
+      this->InitializeStorageNode(nodeSet.StorageNode, filename, fileList, testScene.GetPointer());
 
       vtkDebugMacro("Attempt to read file as a volume of type "
                     << nodeSet.Node->GetNodeTagName() << " using "
@@ -691,9 +705,9 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
     // clean up the scene
     nodeSet.Node->SetAndObserveDisplayNodeID(NULL);
     nodeSet.Node->SetAndObserveStorageNodeID(NULL);
-    this->GetMRMLScene()->RemoveNode(nodeSet.DisplayNode);
-    this->GetMRMLScene()->RemoveNode(nodeSet.StorageNode);
-    this->GetMRMLScene()->RemoveNode(nodeSet.Node);
+    testScene->RemoveNode(nodeSet.DisplayNode);
+    testScene->RemoveNode(nodeSet.StorageNode);
+    testScene->RemoveNode(nodeSet.Node);
     }
 
   // display any errors
@@ -706,6 +720,11 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
   bool modified = false;
   if (volumeNode != NULL)
     {
+    // move the nodes from the test scene to the main one, observations should still be good
+    this->GetMRMLScene()->AddNode(displayNode);
+    this->GetMRMLScene()->AddNode(storageNode);
+    this->GetMRMLScene()->AddNode(volumeNode);
+
     this->SetAndObserveColorToDisplayNode(displayNode, labelMap, filename);
 
     vtkDebugMacro("Name vol node "<<volumeNode->GetClassName());
@@ -714,14 +733,21 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
     this->SetActiveVolumeNode(volumeNode);
 
     modified = true;
-    // since added the node w/o notification, let the scene know now that it
-    // has a new node
-    //this->GetMRMLScene()->InvokeEvent(vtkMRMLScene::NodeAddedEvent, volumeNode);
+    }
+
+    // clean up the test scene
+  if (testScene->GetCacheManager())
+    {
+    testScene->SetCacheManager(0);
     }
 
   this->GetMRMLScene()->EndState(vtkMRMLScene::BatchProcessState);
   if (modified)
     {
+    // since added the node to the test scene, let the scene know now that it
+    // has a new node
+    this->GetMRMLScene()->InvokeEvent(vtkMRMLScene::NodeAddedEvent, volumeNode);
+
     this->Modified();
     }
   return volumeNode;

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -735,7 +735,13 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
   bool modified = false;
   if (volumeNode != NULL)
     {
-    // move the nodes from the test scene to the main one, observations should still be good
+    // move the nodes from the test scene to the main one, removing from the
+    // test scene first to avoid missing ID/reference errors and to fix a
+    // problem found in testing an extension where the RAS to IJK matrix
+    /// was reset to identity.
+    testScene->RemoveNode(displayNode);
+    testScene->RemoveNode(storageNode);
+    testScene->RemoveNode(volumeNode);
     this->GetMRMLScene()->AddNode(displayNode);
     this->GetMRMLScene()->AddNode(storageNode);
     this->GetMRMLScene()->AddNode(volumeNode);

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -745,6 +745,8 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
     this->GetMRMLScene()->AddNode(displayNode);
     this->GetMRMLScene()->AddNode(storageNode);
     this->GetMRMLScene()->AddNode(volumeNode);
+    volumeNode->SetAndObserveDisplayNodeID(displayNode->GetID());
+    volumeNode->SetAndObserveStorageNodeID(storageNode->GetID());
 
     this->SetAndObserveColorToDisplayNode(displayNode, labelMap, filename);
 

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -660,8 +660,6 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
   // set it up for remote io, the constructor creates a cache and data io manager
   vtkSmartPointer<vtkMRMLRemoteIOLogic> remoteIOLogic;
   remoteIOLogic = vtkSmartPointer<vtkMRMLRemoteIOLogic>::New();
-  remoteIOLogic->SetMRMLScene(testScene.GetPointer());
-  remoteIOLogic->AddDataIOToScene();
   if (this->GetMRMLScene()->GetCacheManager())
     {
     // update the temp remote cache dir from the main one
@@ -673,6 +671,11 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
   dataIOManagerLogic->SetMRMLApplicationLogic(this->GetApplicationLogic());
   dataIOManagerLogic->SetAndObserveDataIOManager(
     remoteIOLogic->GetDataIOManager());
+
+  // and link up everything for the test scene
+  this->GetApplicationLogic()->SetMRMLSceneDataIO(testScene.GetPointer(),
+                                                  remoteIOLogic, dataIOManagerLogic);
+
   // Run through the factory list and test each factory until success
   for (NodeSetFactoryRegistry::const_iterator fit = volumeRegistry.begin();
        fit != volumeRegistry.end(); ++fit)

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
@@ -268,7 +268,8 @@ protected:
 
   void InitializeStorageNode(vtkMRMLStorageNode * storageNode,
                              const char * filename,
-                             vtkStringArray *fileList);
+                             vtkStringArray *fileList,
+                             vtkMRMLScene * mrmlScene = NULL);
 
   void SetAndObserveColorToDisplayNode(vtkMRMLDisplayNode* displayNode,
                                        int labelmap, const char* filename);

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -322,7 +322,11 @@ class SampleDataLogic:
     success, volumeNode = slicer.util.loadVolume(uri, properties = {'name' : name}, returnNode=True)
     if success:
       self.logMessage('<b>Load finished</b>\n')
-      volumeNode.SetAndObserveStorageNodeID(None) # since it was read from a temp directory
+      # since it was read from a temp directory remove the storage node
+      volumeStorageNode = volumeNode.GetStorageNode()
+      if volumeStorageNode != None:
+        slicer.mrmlScene.RemoveNode(volumeStorageNode)
+      volumeNode.SetAndObserveStorageNodeID(None)
     else:
       self.logMessage('<b><font color="red">\tLoad failed!</font></b>\n')
     return volumeNode


### PR DESCRIPTION
Starting from lost fiducials when saving MRBs multiple times, I found and fixed a host of bugs related to fiducials, scene views, volumes, storage nodes, the MRML scene, and saving MRBs and MRML files. 
These fixes were mostly necessary due to the fact that once an MRB has been expanded and loaded into Slicer, the files are removed from disk and file paths can become invalid.

Changes of note:
- add missing storage nodes for storable nodes when saving them in a scene view
- more book keeping for file list members so that they can be restored after MRB operations
- use a mini scene for volume loading to avoid adding and removing lots of types of nodes
- warn users if they add storable data after making a scene view (will be lost on restore)
- remove the scene root dir variable on the mrml node as it wasn't staying in synch with the scene's root directory, made needed changes to the XML parser to set the scene on the storage node early so that absolute file paths can be computed correctly.

I can cancel this pull request and make one with one commit, this request is to get feedback on the changes in a more modular fashion.