### PR TITLE
BUG: sitkUtils: Add 'LabelMap' to list of volume types supported by SimpleITK

### DIFF
--- a/Base/Python/sitkUtils.py
+++ b/Base/Python/sitkUtils.py
@@ -24,7 +24,7 @@ def CloneSlicerNode( NodeName, NewNodeNamePrefix ):
     newvol = vl.CloneVolume(slicer.mrmlScene,n,NewNodeNamePrefix)
     return newvol.GetName()
 
-__sitk__VOLUME_TYPES__ = [ 'Scalar' ]
+__sitk__VOLUME_TYPES__ = [ 'Scalar', 'LabelMap' ]
 
 def checkVolumeNodeType(nodeType):
     """ Raise an error if the node type is not a recognized volume node


### PR DESCRIPTION
This commit fixes support for vtkMRMLLabelMapVolumeNode added
in r24291 (ENH: Use vtkMRMLLabelMapVolumeNode class for labelmap volumes)

Fixes #4004