### PR TITLE
BUG: String containing list of dependencies was not split

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -1289,7 +1289,7 @@ bool qSlicerExtensionsManagerModel::installExtension(
     }
 
   // Gather information on dependency extensions
-  const QStringList dependencies = extensionIndexMetadata.value("depends").toStringList();
+  const QStringList dependencies = extensionIndexMetadata.value("depends").toString().split(" ");
   QHash<QString, ExtensionMetadataType> dependenciesMetadata;
   QStringList unresolvedDependencies;
   foreach (const QString& dependencyName, dependencies)


### PR DESCRIPTION
If one was creating an extension that depended on multiple other extensions and was giving, as specified in the s4ext files, a list of extensions separated by spaces, Slicer did not split that list when looking for dependencies upon download, and was trying to find an extension with all the names.
e.g. If your s4ext file contained the following line:
depends     DTIProcess ResampleDTIlogEuclidean
Slicer was trying to resolve the dependencies and was trying to find the extension named "DTIProcess ResampleDTIlogEuclidean", instead of finding both extensions separately.