### PR TITLE
COMP: Fix compilation of Segment subject hierarchy plugin with python…

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchySegmentPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchySegmentPlugin.cxx
@@ -56,7 +56,9 @@
 // SlicerQt includes
 #include "qSlicerAbstractModuleWidget.h"
 #include "qSlicerApplication.h"
-#include "PythonQt.h"
+#ifdef Slicer_USE_PYTHONQT
+# include "PythonQt.h"
+#endif
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
@@ -245,6 +247,7 @@ void qSlicerSubjectHierarchySegmentPlugin::segmentCurrentNodeWithEditor()
       }
     }
 
+#ifdef Slicer_USE_PYTHONQT
   // Switch to Editor module
   qSlicerAbstractModuleWidget* moduleWidget = qSlicerSubjectHierarchyAbstractPlugin::switchToModule("Editor");
 
@@ -261,4 +264,8 @@ void qSlicerSubjectHierarchySegmentPlugin::segmentCurrentNodeWithEditor()
       "editorWidget.setMergeNode(mergeNode)" )
       .arg(currentNode->GetAssociatedNode()->GetID()).arg(labelNode->GetID()) );
     }
+#else
+  qDebug() << "qSlicerSubjectHierarchySegmentPlugin::segmentCurrentNodeWithEditor -- "
+              "Editor module is not available to edit label map" << labelNode->GetName();
+#endif
 }


### PR DESCRIPTION
… disabled

This commit will fix the following error:

//--------------
[ 54%] Building CXX object Modules/Loadable/SubjectHierarchy/Widgets/CMakeFiles/qSlicerSubjectHierarchyModuleWidgets.dir/qSlicerSubjectHierarchySegmentPlugin.cxx.o
/Users/essert/DEV/Src/Slicer/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchySegmentPlugin.cxx:59:10: fatal error: 'PythonQt.h' file
      not found
#include "PythonQt.h"
         ^
1 error generated.
//--------------

Reported-by: Caroline Essert <essert@unistra.fr>