### PR TITLE
ENH: add support of DCMTK private dictionary

### DIFF
--- a/CMake/SlicerBlockInstallDCMTKResources.cmake
+++ b/CMake/SlicerBlockInstallDCMTKResources.cmake
@@ -1,0 +1,8 @@
+# -------------------------------------------------------------------------
+# Find and install DCMTK private dictionary
+# -------------------------------------------------------------------------
+
+find_package(DCMTK REQUIRED)
+message('Installing private.dic from ${DCMTK_SOURCE_DIR}')
+install(FILES ${DCMTK_SOURCE_DIR}/dcmdata/data/private.dic
+      DESTINATION ${Slicer_INSTALL_LIB_DIR} COMPONENT Runtime)

--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -15,6 +15,7 @@ endif()
 
 if(Slicer_BUILD_DICOM_SUPPORT AND NOT Slicer_USE_SYSTEM_DCMTK)
   include(${Slicer_CMAKE_DIR}/SlicerBlockInstallDCMTKApps.cmake)
+  include(${Slicer_CMAKE_DIR}/SlicerBlockInstallDCMTKResources.cmake)
 endif()
 
 set(CPACK_INSTALL_CMAKE_PROJECTS)

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -63,6 +63,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       ${${proj}_DEPENDENCIES}
   )
   set(DCMTK_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(DCMTK_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
 
   #-----------------------------------------------------------------------------
   # Launcher setting specific to build tree
@@ -76,6 +77,13 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   mark_as_superbuild(
     VARS ${proj}_LIBRARY_PATHS_LAUNCHER_BUILD
     LABELS "LIBRARY_PATHS_LAUNCHER_BUILD"
+    )
+
+  # environment variables
+  set(${proj}_ENVVARS_LAUNCHER_INSTALLED "DCMDICTHOME=<APPLAUNCHER_DIR>/lib/Slicer-4.4/private.dic")
+  mark_as_superbuild(
+    VARS ${proj}_ENVVARS_LAUNCHER_INSTALLED
+    LABELS "ENVVARS_LAUNCHER_INSTALLED"
     )
 
 else()


### PR DESCRIPTION
See issue [4013](http://www.na-mic.org/Bug/view.php?id=4013) and related discussion here:

http://slicer-devel.65872.n3.nabble.com/Enabling-support-for-DCMTK-private-dictionary-td4034305.html

This change installs private.dic of DCMTK in a runtime location,
and sets DCMDICTPATH launcher variable. This will allow for more robust
interpretation of DICOM private tags based on the information
contained in the DCMTK private dictionary.