### PR TITLE
ENH: Added node printself output to node inspector

### DIFF
--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -226,12 +226,14 @@ void vtkMRMLNode::Reset()
 //----------------------------------------------------------------------------
 void vtkMRMLNode::PrintSelf(ostream& os, vtkIndent indent)
 {
-  this->vtkObject::PrintSelf(os,indent);
-
   os << indent << "ID: " <<
     (this->ID ? this->ID : "(none)") << "\n";
 
-  os << indent << "Indent:      " << this->Indent << "\n";
+  // vtkObject's PrintSelf prints a long list of registered events, which
+  // is too long and not useful, therefore we don't call vtkObject::PrintSelf
+  // but print essential information on the vtkObject base.
+  os << indent << "Debug: " << (this->Debug ? "On\n" : "Off\n");
+  os << indent << "Modified Time: " << this->GetMTime() << "\n";
 
   os << indent << "Name: " <<
     (this->Name ? this->Name : "(none)") << "\n";
@@ -246,6 +248,7 @@ void vtkMRMLNode::PrintSelf(ostream& os, vtkIndent indent)
 
   os << indent << "Selectable: " << this->Selectable << "\n";
   os << indent << "Selected: " << this->Selected << "\n";
+  os << indent << "Indent:      " << this->Indent << "\n";
   if (this->Attributes.size())
     {
     os << indent << "Attributes:\n";
@@ -289,7 +292,6 @@ void vtkMRMLNode::PrintSelf(ostream& os, vtkIndent indent)
          << ss.str().c_str() << "\"" << "\n";
       }
     }
-
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLNodeAttributeTableWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLNodeAttributeTableWidget.ui
@@ -17,7 +17,7 @@
    <property name="margin">
     <number>0</number>
    </property>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QPushButton" name="AddAttributeButton">
@@ -66,8 +66,18 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
+   <item row="1" column="0">
     <widget class="qMRMLNodeAttributeTableView" name="MRMLNodeAttributeTableView"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="MRMLNodeInfoLabel">
+     <property name="text">
+      <string>No node information is available.</string>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/Libs/MRML/Widgets/qMRMLNodeAttributeTableWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeAttributeTableWidget.cxx
@@ -28,6 +28,9 @@
 // MRML includes
 #include <vtkMRMLNode.h>
 
+// STD includes
+#include <sstream>
+
 // --------------------------------------------------------------------------
 class qMRMLNodeAttributeTableWidgetPrivate: public Ui_qMRMLNodeAttributeTableWidget
 {
@@ -37,6 +40,8 @@ protected:
 public:
   qMRMLNodeAttributeTableWidgetPrivate(qMRMLNodeAttributeTableWidget& object);
   void init();
+
+  vtkWeakPointer<vtkMRMLNode> MRMLNode;
 };
 
 // --------------------------------------------------------------------------
@@ -75,10 +80,23 @@ qMRMLNodeAttributeTableWidget::~qMRMLNodeAttributeTableWidget()
 }
 
 // --------------------------------------------------------------------------
+vtkMRMLNode* qMRMLNodeAttributeTableWidget::mrmlNode()const
+{
+  Q_D(const qMRMLNodeAttributeTableWidget);
+  return d->MRMLNode.GetPointer();
+}
+
+// --------------------------------------------------------------------------
 void qMRMLNodeAttributeTableWidget::setMRMLNode(vtkMRMLNode* node)
 {
   Q_D(qMRMLNodeAttributeTableWidget);
   d->MRMLNodeAttributeTableView->setInspectedNode(node);
+
+  qvtkReconnect(d->MRMLNode.GetPointer(), node, vtkCommand::ModifiedEvent,
+                this, SLOT(updateWidgetFromMRML()));
+  d->MRMLNode = node;
+
+  this->updateWidgetFromMRML();
 }
 
 // --------------------------------------------------------------------------
@@ -86,4 +104,38 @@ qMRMLNodeAttributeTableView* qMRMLNodeAttributeTableWidget::tableView()
 {
   Q_D(qMRMLNodeAttributeTableWidget);
   return d->MRMLNodeAttributeTableView;
+}
+
+//------------------------------------------------------------------------------
+void qMRMLNodeAttributeTableWidget::showEvent(QShowEvent *)
+{
+  // Update the widget, now that it becomes becomes visible
+  // (we might have missed some updates, because widget contents is not updated
+  // if the widget is not visible).
+  updateWidgetFromMRML();
+}
+
+//------------------------------------------------------------------------------
+void qMRMLNodeAttributeTableWidget::updateWidgetFromMRML()
+{
+  Q_D(qMRMLNodeAttributeTableWidget);
+  if (!this->isVisible())
+    {
+    // Getting the node information may be expensive,
+    // so if the widget is not visible then do not update
+    return;
+    }
+
+  if (d->MRMLNode.GetPointer())
+    {
+    // EncapsulateMetaData<double>(dict, bValueKey, maxBValue);
+    std::stringstream infoStream;
+    d->MRMLNode->PrintSelf(infoStream, vtkIndent(0));
+    d->MRMLNodeInfoLabel->setText(QLatin1String(infoStream.str().c_str()));
+    }
+  else
+    {
+    d->MRMLNodeInfoLabel->clear();
+    }
+
 }

--- a/Libs/MRML/Widgets/qMRMLNodeAttributeTableWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeAttributeTableWidget.cxx
@@ -112,7 +112,7 @@ void qMRMLNodeAttributeTableWidget::showEvent(QShowEvent *)
   // Update the widget, now that it becomes becomes visible
   // (we might have missed some updates, because widget contents is not updated
   // if the widget is not visible).
-  updateWidgetFromMRML();
+  this->updateWidgetFromMRML();
 }
 
 //------------------------------------------------------------------------------
@@ -128,7 +128,6 @@ void qMRMLNodeAttributeTableWidget::updateWidgetFromMRML()
 
   if (d->MRMLNode.GetPointer())
     {
-    // EncapsulateMetaData<double>(dict, bValueKey, maxBValue);
     std::stringstream infoStream;
     d->MRMLNode->PrintSelf(infoStream, vtkIndent(0));
     d->MRMLNodeInfoLabel->setText(QLatin1String(infoStream.str().c_str()));
@@ -137,5 +136,4 @@ void qMRMLNodeAttributeTableWidget::updateWidgetFromMRML()
     {
     d->MRMLNodeInfoLabel->clear();
     }
-
 }

--- a/Libs/MRML/Widgets/qMRMLNodeAttributeTableWidget.h
+++ b/Libs/MRML/Widgets/qMRMLNodeAttributeTableWidget.h
@@ -39,6 +39,7 @@ class qMRMLNodeAttributeTableView;
 class QMRML_WIDGETS_EXPORT qMRMLNodeAttributeTableWidget : public QWidget
 {
   Q_OBJECT
+  QVTK_OBJECT
 
 public:
   /// Constructors
@@ -48,11 +49,19 @@ public:
   /// Get node attribute table view
   qMRMLNodeAttributeTableView* tableView();
 
+  /// Get the inspected MRML node
+  vtkMRMLNode* mrmlNode()const;
+
 public slots:
   /// Set the inspected MRML node
   void setMRMLNode(vtkMRMLNode* node);
 
+protected slots:
+  void updateWidgetFromMRML();
+
 protected:
+  virtual void showEvent(QShowEvent *);
+
   QScopedPointer<qMRMLNodeAttributeTableWidgetPrivate> d_ptr;
 
 private:


### PR DESCRIPTION
Detailed node content (output of node->PrintSelf) is now available in the node inspector.
If the node is changed then the window is updated automatically (if the node inspector is not visible then no update happens to avoid any potential performance regressions).
The vtkObject's irrelevant list of observers are removed from the output.