### PR TITLE
Update SimpleFilters with patches for LabelMapVolume node changes

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -203,7 +203,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeImporter Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(SimpleFilters
   GIT_REPOSITORY ${git_protocol}://github.com/SimpleITK/SlicerSimpleFilters.git
-  GIT_TAG ceb133c088860361e687ca5973893dca95b5eee7
+  GIT_TAG 48b7873fea3cb4541ced8469236d784f0d18ac88
   OPTION_NAME Slicer_BUILD_SimpleFilters
   OPTION_DEPENDS "Slicer_BUILD_QTSCRIPTEDMODULES;Slicer_USE_SimpleITK"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
48b7873 Remove input based automatic LabelMap output restriction.
c90a778 Replace LabelMap checkbox with option in output combo box
d3f3bf1 Restore support for label map volumes as input
a560064 Correct nodeType to be a list of one element.
2f392a5 Update to use new MRMLLabelmapNode