### PR TITLE
COMP: Fix narrowing warnings in qSlicerSimpleMarkupsWidget

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
@@ -237,7 +237,7 @@ void qSlicerSimpleMarkupsWidget::setNodeColor(QColor color)
     return;
     }
 
-  double rgbDoubleVector[3] = {color.red(),color.green(),color.blue()};
+  double rgbDoubleVector[3] = {color.redF(),color.greenF(),color.blueF()};
   currentMarkupsDisplayNode->SetColor( rgbDoubleVector );
   currentMarkupsDisplayNode->SetSelectedColor( rgbDoubleVector );
 }


### PR DESCRIPTION
This commit addresses the following warnings:

```
/home/jcfr/Projects/Slicer/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx:240:42: warning: narrowing conversion of ‘color.QColor::red()’ from ‘int’ to ‘double’ inside { } is ill-formed in C++11 [-Wnarrowing]
   double rgbDoubleVector[3] = {color.red(),color.green(),color.blue()};
                                          ^
/home/jcfr/Projects/Slicer/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx:240:56: warning: narrowing conversion of ‘color.QColor::green()’ from ‘int’ to ‘double’ inside { } is ill-formed in C++11 [-Wnarrowing]
   double rgbDoubleVector[3] = {color.red(),color.green(),color.blue()};
                                                        ^
/home/jcfr/Projects/Slicer/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx:240:69: warning: narrowing conversion of ‘color.QColor::blue()’ from ‘int’ to ‘double’ inside { } is ill-formed in C++11 [-Wnarrowing]
   double rgbDoubleVector[3] = {color.red(),color.green(),color.blue()};
```