### PR TITLE
ENH: support fiducial file transfer between Slicer and CLIs

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -904,6 +904,7 @@ void vtkSlicerApplicationLogic::ProcessReadNodeData(ReadDataRequest& req)
   vtkMRMLDisplayableNode *fbnd = 0;
   vtkMRMLColorTableNode *cnd = 0;
   vtkMRMLDoubleArrayNode *dand = 0;
+  vtkMRMLDisplayableNode *markupsFiducialNode = 0;
 #ifdef Slicer_BUILD_CLI_SUPPORT
   vtkMRMLCommandLineModuleNode *clp = 0;
 #endif
@@ -936,7 +937,7 @@ void vtkSlicerApplicationLogic::ProcessReadNodeData(ReadDataRequest& req)
     }
   else
     {
-    vtkWarningMacro("Unkown volume type");
+    vtkDebugMacro("Not a known volume type: " << nd->GetClassName());
     }
 
   mnd   = vtkMRMLModelNode::SafeDownCast(nd);
@@ -944,6 +945,7 @@ void vtkSlicerApplicationLogic::ProcessReadNodeData(ReadDataRequest& req)
   fbnd  = vtkMRMLDisplayableNode::SafeDownCast(nd);
   cnd = vtkMRMLColorTableNode::SafeDownCast(nd);
   dand = vtkMRMLDoubleArrayNode::SafeDownCast(nd);
+  markupsFiducialNode = vtkMRMLDisplayableNode::SafeDownCast(nd);
 #ifdef Slicer_BUILD_CLI_SUPPORT
   clp = vtkMRMLCommandLineModuleNode::SafeDownCast(nd);
 #endif
@@ -1011,6 +1013,10 @@ void vtkSlicerApplicationLogic::ProcessReadNodeData(ReadDataRequest& req)
         vtkDebugMacro("ProcessReadNodeData: node is a vtkMRMLFiberBundleNode");
         // Load a fiber bundle node
         storageNode = fbnd->CreateDefaultStorageNode();
+        }
+      else if (markupsFiducialNode && markupsFiducialNode->IsA("vtkMRMLMarkupsFiducialNode"))
+        {
+        storageNode = markupsFiducialNode->CreateDefaultStorageNode();
         }
       else if (cnd)
         {

--- a/Base/QTCLI/CMakeLists.txt
+++ b/Base/QTCLI/CMakeLists.txt
@@ -40,6 +40,8 @@ set(KIT_include_directories
   ${ModuleDescriptionParser_INCLUDE_DIRS}
   ${MRMLCLI_INCLUDE_DIRS}
   ${MRMLLogic_INCLUDE_DIRS}
+  ${vtkSlicerMarkupsModuleMRML_SOURCE_DIR}
+  ${vtkSlicerMarkupsModuleMRML_BINARY_DIR}
   )
 
 # Source files
@@ -93,6 +95,7 @@ set(KIT_target_libraries
   qSlicerBaseQTGUI
   ModuleDescriptionParser ${ITK_LIBRARIES}
   MRMLCLI
+  vtkSlicerMarkupsModuleMRML
   )
 
 if(Slicer_USE_QtTesting)

--- a/Base/QTCLI/CMakeLists.txt
+++ b/Base/QTCLI/CMakeLists.txt
@@ -40,8 +40,6 @@ set(KIT_include_directories
   ${ModuleDescriptionParser_INCLUDE_DIRS}
   ${MRMLCLI_INCLUDE_DIRS}
   ${MRMLLogic_INCLUDE_DIRS}
-  ${vtkSlicerMarkupsModuleMRML_SOURCE_DIR}
-  ${vtkSlicerMarkupsModuleMRML_BINARY_DIR}
   )
 
 # Source files
@@ -95,7 +93,6 @@ set(KIT_target_libraries
   qSlicerBaseQTGUI
   ModuleDescriptionParser ${ITK_LIBRARIES}
   MRMLCLI
-  vtkSlicerMarkupsModuleMRML
   )
 
 if(Slicer_USE_QtTesting)

--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -95,6 +95,7 @@ WIDGET_VALUE_WRAPPER(DoubleWithoutConstraints, ctkDoubleSpinBox, value, setValue
 WIDGET_VALUE_WRAPPER(DoubleWithConstraints, ctkSliderWidget, value, setValue, Double, valueChanged(double));
 WIDGET_VALUE_WRAPPER(String, QLineEdit, text, setText, String, textChanged(const QString&));
 WIDGET_VALUE_WRAPPER(Point, qMRMLNodeComboBox, currentNodeID, setCurrentNodeID, String, currentNodeIDChanged(QString));
+WIDGET_VALUE_WRAPPER(PointFile, qMRMLNodeComboBox, currentNodeID, setCurrentNodeID, String, currentNodeIDChanged(QString));
 WIDGET_VALUE_WRAPPER(Region, qMRMLNodeComboBox, currentNodeID, setCurrentNodeID, String, currentNodeIDChanged(QString));
 WIDGET_VALUE_WRAPPER(Image, qMRMLNodeComboBox, currentNodeID, setCurrentNodeID, String, currentNodeIDChanged(QString));
 WIDGET_VALUE_WRAPPER(Geometry, qMRMLNodeComboBox, currentNodeID, setCurrentNodeID, String, currentNodeIDChanged(QString));
@@ -171,6 +172,7 @@ public:
   QWidget* createDoubleTagWidget(const ModuleParameter& moduleParameter);
   QWidget* createStringTagWidget(const ModuleParameter& moduleParameter);
   QWidget* createPointTagWidget(const ModuleParameter& moduleParameter);
+  QWidget* createPointFileTagWidget(const ModuleParameter& moduleParameter);
   QWidget* createRegionTagWidget(const ModuleParameter& moduleParameter);
   QWidget* createImageTagWidget(const ModuleParameter& moduleParameter);
   QWidget* createGeometryTagWidget(const ModuleParameter& moduleParameter);
@@ -522,6 +524,31 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createPointTagWidget(const ModuleParam
                    widget, SLOT(setMRMLScene(vtkMRMLScene*)));
 
   INSTANCIATE_WIDGET_VALUE_WRAPPER(Point, _name, _label, widget);
+
+  return widget;
+}
+
+//-----------------------------------------------------------------------------
+QWidget* qSlicerCLIModuleUIHelperPrivate::createPointFileTagWidget(const ModuleParameter& moduleParameter)
+{
+  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _name = QString::fromStdString(moduleParameter.GetName());
+  qMRMLNodeComboBox* widget = new qMRMLNodeComboBox;
+  QStringList nodeTypes;
+  nodeTypes += "vtkMRMLMarkupsFiducialNode";
+
+  widget->setNodeTypes(nodeTypes);
+  //TODO - title + " FiducialList"
+  //TODO - tparameter->SetNewNodeEnabled(1);
+  //TODO - tparameter->SetNoneEnabled(noneEnabled);
+  widget->setBaseName(_label);
+  widget->setRenameEnabled(true);
+
+  widget->setMRMLScene(this->CLIModuleWidget->mrmlScene());
+  QObject::connect(this->CLIModuleWidget, SIGNAL(mrmlSceneChanged(vtkMRMLScene*)),
+                   widget, SLOT(setMRMLScene(vtkMRMLScene*)));
+
+  INSTANCIATE_WIDGET_VALUE_WRAPPER(PointFile, _name, _label, widget);
 
   return widget;
 }
@@ -913,6 +940,10 @@ QWidget* qSlicerCLIModuleUIHelper::createTagWidget(const ModuleParameter& module
   else if (moduleParameter.GetTag() == "point")
     {
     widget = d->createPointTagWidget(moduleParameter);
+    }
+  else if (moduleParameter.GetTag() == "pointfile")
+    {
+    widget = d->createPointFileTagWidget(moduleParameter);
     }
   else if (moduleParameter.GetTag() == "region")
     {

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -17,15 +17,13 @@
 // SlicerExecutionModel includes
 #include <ModuleDescription.h>
 
-// Markups includes
-#include <vtkMRMLMarkupsStorageNode.h>
-
 // MRML includes
 #include <vtkEventBroker.h>
 #include <vtkMRMLColorNode.h>
 #include <vtkMRMLDisplayableNode.h>
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLFiducialListNode.h>
+#include <vtkMRMLMarkupsStorageNode.h>
 #include <vtkMRMLModelHierarchyNode.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLROIListNode.h>

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -140,6 +140,7 @@ set(MRMLCore_SRCS
   vtkMRMLLabelMapVolumeDisplayNode.cxx
   vtkMRMLLabelMapVolumeNode.cxx
   vtkMRMLLinearTransformNode.cxx
+  vtkMRMLMarkupsStorageNode.cxx
   vtkMRMLModelDisplayNode.cxx
   vtkMRMLModelHierarchyNode.cxx
   vtkMRMLModelNode.cxx

--- a/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.cxx
@@ -15,8 +15,8 @@
 
 ==============================================================================*/
 
-#include "vtkMRMLMarkupsDisplayNode.h"
-#include "vtkMRMLMarkupsNode.h"
+//#include "vtkMRMLMarkupsDisplayNode.h"
+//#include "vtkMRMLMarkupsNode.h"
 #include "vtkMRMLMarkupsStorageNode.h"
 
 #include "vtkMRMLScene.h"

--- a/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.h
@@ -21,6 +21,7 @@
 ///
 /// vtkMRMLMarkupsStorageNode nodes describe the markups storage
 /// node that allows to read/write point data from/to file.
+/// In MRML/Core to facilitate passing markups to CLIs via file.
 
 #ifndef __vtkMRMLMarkupsStorageNode_h
 #define __vtkMRMLMarkupsStorageNode_h
@@ -28,14 +29,10 @@
 // MRML includes
 #include "vtkMRMLStorageNode.h"
 
-// Markups includes
-#include "vtkSlicerMarkupsModuleMRMLExport.h"
-
 /// Define a default buffer size for parsing files during read, number of characters
 #define MARKUPS_BUFFER_SIZE 1024
 
-/// \ingroup Slicer_QtModules_Markups
-class VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsStorageNode : public vtkMRMLStorageNode
+class VTK_MRML_EXPORT vtkMRMLMarkupsStorageNode : public vtkMRMLStorageNode
 {
 public:
   static vtkMRMLMarkupsStorageNode *New();

--- a/Modules/CLI/ExecutionModelTour/CMakeLists.txt
+++ b/Modules/CLI/ExecutionModelTour/CMakeLists.txt
@@ -17,8 +17,11 @@ SEMMacroBuildCLI(
   TARGET_LIBRARIES
     # ${VTK_LIBRARIES} # Not needed: All dependencies are transitively satisfied by other targets
     MRMLCore
+    vtkSlicerMarkupsModuleMRML
   INCLUDE_DIRECTORIES
     ${MRMLCore_INCLUDE_DIRS}
+    ${vtkSlicerMarkupsModuleMRML_SOURCE_DIR}
+    ${vtkSlicerMarkupsModuleMRML_BINARY_DIR}
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
@@ -87,7 +87,7 @@ int main(int argc, char *argv[])
     }
   // fiducials
   std::cout << "Have an input seed list of size " << seed.size() << std::endl;
-  for (int i = 0; i < seed.size(); ++i)
+  for (unsigned int i = 0; i < seed.size(); ++i)
     {
     std::cout << i << "\t" << seed[i][0] << "\t" << seed[i][1] << "\t" << seed[i][2] << std::endl;
     }
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
   // set the node name so that fiducials have names that don't just
   // start with -1, -2 etc
   copiedFiducialNode->SetName("seedsCopy");
-  for (int i = 0; i < seed.size(); ++i)
+  for (unsigned int i = 0; i < seed.size(); ++i)
     {
     std::cout << "Copying seed list to output file list: " << seed[i][0] << ", " << seed[i][1] << ", " << seed[i][2] << std::endl;
     copiedFiducialNode->AddFiducial(seed[i][0], seed[i][1], seed[i][2]);

--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
@@ -7,6 +7,10 @@
 // VTK includes
 #include <vtkNew.h>
 
+// Markups includes
+#include <vtkMRMLMarkupsFiducialNode.h>
+#include <vtkMRMLMarkupsFiducialStorageNode.h>
+
 int main(int argc, char *argv[])
 {
   PARSE_ARGS;
@@ -81,6 +85,52 @@ int main(int argc, char *argv[])
     std::cerr << "No input transform found! Specified transform ID = " << transform1ID << std::endl;
     return EXIT_FAILURE;
     }
+  // fiducials
+  std::cout << "Have an input seed list of size " << seed.size() << std::endl;
+  for (int i = 0; i < seed.size(); ++i)
+    {
+    std::cout << i << "\t" << seed[i][0] << "\t" << seed[i][1] << "\t" << seed[i][2] << std::endl;
+    }
+  if (seedsFile.size() > 0)
+    {
+    // read the input seeds file
+    std::cout << "Have an input seeds file with name " << seedsFile[0].c_str() << std::endl;
+    vtkNew<vtkMRMLMarkupsFiducialNode> fiducialNode;
+    vtkNew<vtkMRMLMarkupsFiducialStorageNode> fiducialStorageNode;
+    fiducialStorageNode->SetFileName(seedsFile[0].c_str());
+    fiducialStorageNode->ReadData(fiducialNode.GetPointer());
+    std::cout << "Number of fids read = " << fiducialNode->GetNumberOfFiducials() << ", coordinate system flag = " << fiducialStorageNode->GetCoordinateSystem() << std::endl;
+    for (int i = 0; i < fiducialNode->GetNumberOfFiducials(); ++i)
+      {
+      double pos[3];
+      fiducialNode->GetNthFiducialPosition(i, pos);
+      std::cout << i << "\t" << pos[0] << "\t" << pos[1] << "\t" << pos[2] << std::endl;
+      }
+    }
+  // copy the seeds list
+  vtkNew<vtkMRMLMarkupsFiducialNode> copiedFiducialNode;
+  // set the node name so that fiducials have names that don't just
+  // start with -1, -2 etc
+  copiedFiducialNode->SetName("seedsCopy");
+  for (int i = 0; i < seed.size(); ++i)
+    {
+    std::cout << "Copying seed list to output file list: " << seed[i][0] << ", " << seed[i][1] << ", " << seed[i][2] << std::endl;
+    copiedFiducialNode->AddFiducial(seed[i][0], seed[i][1], seed[i][2]);
+    // toggle some settings
+    if (i == 0)
+      {
+      copiedFiducialNode->SetNthMarkupLocked(i, 1);
+      copiedFiducialNode->SetNthFiducialSelected(i, 0);
+      copiedFiducialNode->SetNthFiducialVisibility(i, 0);
+      }
+    }
+  // write out the copy
+  vtkNew<vtkMRMLMarkupsFiducialStorageNode> outputFiducialStorageNode;
+  outputFiducialStorageNode->SetFileName(seedsOutFile.c_str());
+  // the .xml file specifies that it expects the output file in LPS
+  // coordinate system
+  outputFiducialStorageNode->UseLPSOn();
+  outputFiducialStorageNode->WriteData(copiedFiducialNode.GetPointer());
 
   // Write out the return parameters in "name = value" form
   std::ofstream rts;

--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
@@ -145,6 +145,13 @@
       <description><![CDATA[Lists of points in the CLI correspond to slicer fiducial lists]]></description>
       <default>0,0,0</default>
     </point>
+    <pointfile multiple="true" fileExtensions=".fcsv" coordinateSystem="lps">
+      <name>seedsFile</name>
+      <description><![CDATA[Test file of input fiducials, compared to seeds]]></description>
+      <label>Seeds file</label>
+      <longflag>seedsFile</longflag>
+      <channel>input</channel>
+    </pointfile>
   </parameters>
   <parameters>
     <label>Index Parameters</label>
@@ -247,5 +254,15 @@
       <element>Steve</element>
       <element>Will</element>
     </string-enumeration>
+  </parameters>
+  <parameters>
+    <label>File return types</label>
+    <pointfile fileExtensions=".fcsv" coordinateSystem="lps">
+      <name>seedsOutFile</name>
+      <label>Output Fiducials File</label>
+      <description><![CDATA[Output file to read back in, compare to seeds with flipped settings on first fiducial]]></description>
+      <longflag>seedsOutFile</longflag>
+      <channel>output</channel>
+    </pointfile>
   </parameters>
 </executable>

--- a/Modules/Loadable/Markups/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRML/CMakeLists.txt
@@ -12,7 +12,6 @@ set(${KIT}_SRCS
   vtkMRML${MODULE_NAME}FiducialNode.cxx
   vtkMRML${MODULE_NAME}Node.cxx
   vtkMRML${MODULE_NAME}FiducialStorageNode.cxx
-  vtkMRML${MODULE_NAME}StorageNode.cxx
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -22,6 +22,7 @@
 #include "vtkMRMLScene.h"
 
 // VTK includes
+#include <vtkNew.h>
 #include <vtkObjectFactory.h>
 
 // STD includes
@@ -135,6 +136,25 @@ void vtkMRMLMarkupsFiducialNode::PrintSelf(ostream& os, vtkIndent indent)
 vtkMRMLStorageNode* vtkMRMLMarkupsFiducialNode::CreateDefaultStorageNode()
 {
   return vtkMRMLStorageNode::SafeDownCast(vtkMRMLMarkupsFiducialStorageNode::New());
+}
+
+//-------------------------------------------------------------------------
+void vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes()
+{
+  if (this->GetDisplayNode() != NULL &&
+      vtkMRMLMarkupsDisplayNode::SafeDownCast(this->GetDisplayNode()) != NULL)
+    {
+    // display node already exists
+    return;
+    }
+  if (this->GetScene()==NULL)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes failed: scene is invalid");
+    return;
+    }
+  vtkNew<vtkMRMLMarkupsDisplayNode> dispNode;
+  this->GetScene()->AddNode(dispNode.GetPointer());
+  this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }
 
 //-------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -72,6 +72,9 @@ public:
   /// Create default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 
+  /// Create and observe default display node(s)
+  virtual void CreateDefaultDisplayNodes();
+
   /// Return a cast display node, returns null if none
   vtkMRMLMarkupsDisplayNode *GetMarkupsDisplayNode();
 

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/Slicer/SlicerExecutionModel.git"
-    GIT_TAG "b31b424a2e18fa7e9ada11433a16b1e148d6cdd8"
+    GIT_TAG "608c7b06f9402b35f0ec01550a3b9e313582f683"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
Expands the application logic to support reading and writing fiducial files.
Expands the CLI module UI helper to create a fiducial node selection combo
box when a point file type is detected.
Expands the CLI module logic to manage fiducial files. Need to link to the
Markups module to set the coordinate system flag on the markups storage node.
Currently setting an attribute on the fiducial node to pass the coordinate
system flag along to ApplyTask where the files get written to disk.
Added CreateDefaultDisplayNodes for the fiducial node so it can be called for
output node setup.
Add input and output fiducial file examples with coordinate
systems set to LPS to the execution model tour.
Required updates to the SlicerExecutionModel to define the new XML
tag --pointfile, the pull request was merged, so the external project
file is updated.

Issue #2979