### PR TITLE
ENH: units/coordinates display in DataProbe

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.h
@@ -186,7 +186,7 @@ class VTK_MRML_EXPORT vtkMRMLDiffusionTensorVolumeDisplayNode : public vtkMRMLGl
 
   ///
   /// Given a volume node, create a human readable string describing the contents
-  virtual const char* getPixelString(double *ijk);
+  virtual std::string GetPixelString(double *ijk);
 
 protected:
   vtkMRMLDiffusionTensorVolumeDisplayNode();
@@ -225,10 +225,10 @@ protected:
    /// Scalar display parameters
   int ScalarInvariant;
 
-  ///smart Pointer needed for calculatating PixelString
-  vtkSmartPointer<vtkDiffusionTensorMathematics> dtimath;
-  vtkSmartPointer<vtkImageData> singlepixelimage;
-  vtkSmartPointer<vtkFloatArray> tensordata;
+  /// Smart Pointer needed for calculatating PixelString
+  vtkSmartPointer<vtkDiffusionTensorMathematics> DTIMath;
+  vtkSmartPointer<vtkImageData> SinglePixelImage;
+  vtkSmartPointer<vtkFloatArray> TensorData;
 
 
 };

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.h
@@ -184,6 +184,10 @@ class VTK_MRML_EXPORT vtkMRMLDiffusionTensorVolumeDisplayNode : public vtkMRMLGl
   static int GetNumberOfScalarInvariants();
   static int GetNthScalarInvariant(int i);
 
+  ///
+  /// Given a volume node, create a human readable string describing the contents
+  virtual const char* getPixelString(double *ijk);
+
 protected:
   vtkMRMLDiffusionTensorVolumeDisplayNode();
   ~vtkMRMLDiffusionTensorVolumeDisplayNode();
@@ -220,6 +224,11 @@ protected:
 
    /// Scalar display parameters
   int ScalarInvariant;
+
+  ///smart Pointer needed for calculatating PixelString
+  vtkSmartPointer<vtkDiffusionTensorMathematics> dtimath;
+  vtkSmartPointer<vtkImageData> singlepixelimage;
+  vtkSmartPointer<vtkFloatArray> tensordata;
 
 
 };

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.cxx
@@ -64,5 +64,5 @@ vtkMRMLDiffusionTensorVolumeDisplayNode* vtkMRMLDiffusionTensorVolumeNode
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLDiffusionTensorVolumeNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLNRRDStorageNode::New();
+    return vtkMRMLNRRDStorageNode::New();
 }

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.cxx
@@ -64,5 +64,5 @@ vtkMRMLDiffusionTensorVolumeDisplayNode* vtkMRMLDiffusionTensorVolumeNode
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLDiffusionTensorVolumeNode::CreateDefaultStorageNode()
 {
-    return vtkMRMLNRRDStorageNode::New();
+  return vtkMRMLNRRDStorageNode::New();
 }

--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.cxx
@@ -181,23 +181,28 @@ void vtkMRMLLabelMapVolumeDisplayNode::UpdateImageDataPipeline()
 }
 
 //---------------------------------------------------------------------------
-const char *vtkMRMLLabelMapVolumeDisplayNode::getPixelString(double *ijk)
+std::string vtkMRMLLabelMapVolumeDisplayNode::GetPixelString(double *ijk)
 {
-    if(this->GetVolumeNode()->GetImageData() == NULL){
-        return "No Image";
+  if(this->GetVolumeNode()->GetImageData() == NULL)
+    {
+    return "No Image";
+    }
+  for(int i = 0; i < 3; i++)
+    {
+    if(ijk[i] < 0 or ijk[i] >=  this->GetVolumeNode()->GetImageData()->GetDimensions()[i])
+      {
+      return "Out of Frame";
+      }
     }
 
-    for(int i = 0; i < 3; i++){
-        if(ijk[i] < 0 or ijk[i] >=  this->GetVolumeNode()->GetImageData()->GetDimensions()[i])
-            return "Out of Frame";
+  std::string labelValue = "Unknown";
+  int labelIndex = int(this->GetVolumeNode()->GetImageData()->GetScalarComponentAsDouble(ijk[0],ijk[1],ijk[2],0));
+  vtkMRMLColorNode *colornode = this->GetColorNode();
+  if(colornode)
+    {
+    labelValue = colornode->GetColorName(labelIndex);
     }
+  labelValue += "(" + IntToString(labelIndex) + ")";
 
-    std::string labelValue = "Unknown";
-    int labelIndex = int(this->GetVolumeNode()->GetImageData()->GetScalarComponentAsDouble(ijk[0],ijk[1],ijk[2],0));
-
-    vtkMRMLColorNode *colornode = this->GetColorNode();
-    if(colornode) labelValue = colornode->GetColorName(labelIndex);
-
-    labelValue += "(" + IntToString(labelIndex) + ")";
-    return labelValue.c_str();
+  return labelValue;
 }

--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.h
@@ -66,7 +66,7 @@ class VTK_MRML_EXPORT vtkMRMLLabelMapVolumeDisplayNode : public vtkMRMLVolumeDis
 
   ///
   /// Given a volume node, create a human readable string describing the contents
-  virtual const char *getPixelString(double *ijk);
+  virtual std::string GetPixelString(double *ijk);
 
 protected:
   vtkMRMLLabelMapVolumeDisplayNode();

--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeDisplayNode.h
@@ -64,6 +64,10 @@ class VTK_MRML_EXPORT vtkMRMLLabelMapVolumeDisplayNode : public vtkMRMLVolumeDis
 
   virtual void UpdateImageDataPipeline();
 
+  ///
+  /// Given a volume node, create a human readable string describing the contents
+  virtual const char *getPixelString(double *ijk);
+
 protected:
   vtkMRMLLabelMapVolumeDisplayNode();
   virtual ~vtkMRMLLabelMapVolumeDisplayNode();

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -797,29 +797,33 @@ void vtkMRMLScalarVolumeDisplayNode::GetDisplayScalarRange(double range[2])
 }
 
 //----------------------------------------------------------------------------
-const char *vtkMRMLScalarVolumeDisplayNode::getPixelString(double *ijk)
+std::string vtkMRMLScalarVolumeDisplayNode::GetPixelString(double *ijk)
 {
-    if(this->GetVolumeNode()->GetImageData() == NULL){
-        return "No Image";
+  if(this->GetVolumeNode()->GetImageData() == NULL)
+    {
+    return "No Image";
     }
-
-    for(int i = 0; i < 3; i++){
-        if(ijk[i] < 0 or ijk[i] >=  this->GetVolumeNode()->GetImageData()->GetDimensions()[i])
-            return "Out of Frame";
+  for(int i = 0; i < 3; i++)
+    {
+    if(ijk[i] < 0 or ijk[i] >=  this->GetVolumeNode()->GetImageData()->GetDimensions()[i])
+      {
+      return "Out of Frame";
+      }
     }
-
-    int numberOfComponents = this->GetVolumeNode()->GetImageData()->GetNumberOfScalarComponents();
-    if(numberOfComponents > 3){
-        std::string s = IntToString(numberOfComponents) + " components";
-        return s.c_str();
+  int numberOfComponents = this->GetVolumeNode()->GetImageData()->GetNumberOfScalarComponents();
+  if(numberOfComponents > 3)
+    {
+    std::string s = IntToString(numberOfComponents) + " components";
+    return s.c_str();
     }
-    std::string pixel;
-    for(int i = 0; i < numberOfComponents; i++){
-        double component = this->GetVolumeNode()->GetImageData()->GetScalarComponentAsDouble(ijk[0],ijk[1],ijk[2],i);
-        pixel += DoubleToString(component) + ",";
+  std::string pixel;
+  for(int i = 0; i < numberOfComponents; i++)
+    {
+    double component = this->GetVolumeNode()->GetImageData()->GetScalarComponentAsDouble(ijk[0],ijk[1],ijk[2],i);
+    pixel += DoubleToString(component) + ",";
     }
-    pixel.erase(pixel.size()-1);
-    return pixel.c_str();
+  pixel.erase(pixel.size()-1);
+  return pixel;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -143,6 +143,32 @@ vtkMRMLScalarVolumeDisplayNode::~vtkMRMLScalarVolumeDisplayNode()
     }
 }
 
+namespace
+{
+//----------------------------------------------------------------------------
+template <typename T> std::string NumberToString(T V)
+{
+    std::string stringValue;
+    std::stringstream strstream;
+    strstream << V;
+    strstream >> stringValue;
+    return stringValue;
+}
+
+
+//----------------------------------------------------------------------------
+std::string DoubleToString(double Value)
+{
+    return NumberToString<double>(Value);
+}
+
+//----------------------------------------------------------------------------
+std::string IntToString(int Value)
+{
+    return NumberToString<int>(Value);
+}
+}// end namespace
+
 //----------------------------------------------------------------------------
 void vtkMRMLScalarVolumeDisplayNode::SetDefaultColorMap()
 {
@@ -767,7 +793,33 @@ void vtkMRMLScalarVolumeDisplayNode::GetDisplayScalarRange(double range[2])
     {
     range[0] = 0;
     range[1] = 255;
+  }
+}
+
+//----------------------------------------------------------------------------
+const char *vtkMRMLScalarVolumeDisplayNode::getPixelString(double *ijk)
+{
+    if(this->GetVolumeNode()->GetImageData() == NULL){
+        return "No Image";
     }
+
+    for(int i = 0; i < 3; i++){
+        if(ijk[i] < 0 or ijk[i] >=  this->GetVolumeNode()->GetImageData()->GetDimensions()[i])
+            return "Out of Frame";
+    }
+
+    int numberOfComponents = this->GetVolumeNode()->GetImageData()->GetNumberOfScalarComponents();
+    if(numberOfComponents > 3){
+        std::string s = IntToString(numberOfComponents) + " components";
+        return s.c_str();
+    }
+    std::string pixel;
+    for(int i = 0; i < numberOfComponents; i++){
+        double component = this->GetVolumeNode()->GetImageData()->GetScalarComponentAsDouble(ijk[0],ijk[1],ijk[2],i);
+        pixel += DoubleToString(component) + ",";
+    }
+    pixel.erase(pixel.size()-1);
+    return pixel.c_str();
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -814,7 +814,7 @@ std::string vtkMRMLScalarVolumeDisplayNode::GetPixelString(double *ijk)
   if(numberOfComponents > 3)
     {
     std::string s = IntToString(numberOfComponents) + " components";
-    return s.c_str();
+    return s;
     }
   std::string pixel;
   for(int i = 0; i < numberOfComponents; i++)

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
@@ -198,6 +198,10 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeDisplayNode : public vtkMRMLVolumeDispl
   /// Volume node and returns its image data scalar range.
   virtual void GetDisplayScalarRange(double range[2]);
 
+  ///
+  /// Given a volume node, create a human readable string describing the contents
+  virtual const char* getPixelString(double* ijk);
+
 protected:
   vtkMRMLScalarVolumeDisplayNode();
   virtual ~vtkMRMLScalarVolumeDisplayNode();

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
@@ -200,7 +200,7 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeDisplayNode : public vtkMRMLVolumeDispl
 
   ///
   /// Given a volume node, create a human readable string describing the contents
-  virtual const char* getPixelString(double* ijk);
+  virtual std::string GetPixelString(double* ijk);
 
 protected:
   vtkMRMLScalarVolumeDisplayNode();

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -126,7 +126,7 @@ vtkMRMLStorageNode* vtkMRMLScalarVolumeNode::CreateDefaultStorageNode()
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLScalarVolumeNode::GetCustomizeWorldCoordinates(double *ijk, double *SlicerWorld)
+void vtkMRMLScalarVolumeNode::GetCustomWorldCoordinates(double *ijk, double *SlicerWorld)
 {
     if(ijk != NULL && SlicerWorld != NULL){
         //here child class can implement this method for

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -122,5 +122,14 @@ void vtkMRMLScalarVolumeNode::PrintSelf(ostream& os, vtkIndent indent)
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLScalarVolumeNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLVolumeArchetypeStorageNode::New();
+    return vtkMRMLVolumeArchetypeStorageNode::New();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLScalarVolumeNode::GetCustomizeWorldCoordinates(double *ijk, double *SlicerWorld)
+{
+    if(ijk != NULL && SlicerWorld != NULL){
+        //here child class can implement this method for
+        //retrieving custom coordinates (needed for example by Dataprobe)
+    }
 }

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -16,6 +16,7 @@ Version:   $Revision: 1.14 $
 #include "vtkMRMLScalarVolumeNode.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLVolumeArchetypeStorageNode.h"
+#include "vtkMRMLTransformNode.h"
 
 // VTK includes
 #include <vtkDataArray.h>
@@ -140,9 +141,21 @@ void vtkMRMLScalarVolumeNode::GetReferenceSpace(const double ijk[3], const char 
         return;
       }
 
+    // get the nodes's transform node
+    vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
+
+    vtkSmartPointer<vtkMatrix4x4> transformToWorld =
+       vtkSmartPointer<vtkMatrix4x4>::New();
+    transformToWorld->Identity();
+    if (tnode)
+      {
+      tnode->GetMatrixTransformToWorld(transformToWorld);
+      }
     vtkSmartPointer<vtkMatrix4x4> IJKtoRAS =
       vtkSmartPointer<vtkMatrix4x4>::New();
     this->GetIJKToRASMatrix(IJKtoRAS);
+
+    IJKtoRAS->Multiply4x4(transformToWorld, IJKtoRAS, IJKtoRAS);
 
     vtkSmartPointer<vtkMatrix4x4> Rotation =
        vtkSmartPointer<vtkMatrix4x4>::New();

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -23,6 +23,7 @@ Version:   $Revision: 1.14 $
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkPointData.h>
+#include <vtkMatrix4x4.h>
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLScalarVolumeNode);
@@ -123,17 +124,4 @@ void vtkMRMLScalarVolumeNode::PrintSelf(ostream& os, vtkIndent indent)
 vtkMRMLStorageNode* vtkMRMLScalarVolumeNode::CreateDefaultStorageNode()
 {
   return vtkMRMLVolumeArchetypeStorageNode::New();
-}
-
-void vtkMRMLScalarVolumeNode::GetReferenceSpace(const double *ijk, const char *Space, double *SpaceCoordinates)
-{
-  if (ijk != NULL && SpaceCoordinates != NULL)
-    {
-    if (!strcmp(Space, "RAS"))
-      {
-      //here child class can implement this method for
-      //retrieving coordinates of a given Space of Reference
-      //for displaying reasons (needed for example by Dataprobe)
-      }
-    }
 }

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -122,14 +122,18 @@ void vtkMRMLScalarVolumeNode::PrintSelf(ostream& os, vtkIndent indent)
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLScalarVolumeNode::CreateDefaultStorageNode()
 {
-    return vtkMRMLVolumeArchetypeStorageNode::New();
+  return vtkMRMLVolumeArchetypeStorageNode::New();
 }
 
-//---------------------------------------------------------------------------
-void vtkMRMLScalarVolumeNode::GetCustomWorldCoordinates(double *ijk, double *SlicerWorld)
+void vtkMRMLScalarVolumeNode::GetReferenceSpace(const double *ijk, const char *Space, double *SpaceCoordinates)
 {
-    if(ijk != NULL && SlicerWorld != NULL){
-        //here child class can implement this method for
-        //retrieving custom coordinates (needed for example by Dataprobe)
+  if (ijk != NULL && SpaceCoordinates != NULL)
+    {
+    if (!strcmp(Space, "RAS"))
+      {
+      //here child class can implement this method for
+      //retrieving coordinates of a given Space of Reference
+      //for displaying reasons (needed for example by Dataprobe)
+      }
     }
 }

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -125,3 +125,48 @@ vtkMRMLStorageNode* vtkMRMLScalarVolumeNode::CreateDefaultStorageNode()
 {
   return vtkMRMLVolumeArchetypeStorageNode::New();
 }
+
+void vtkMRMLScalarVolumeNode::GetReferenceSpace(const double ijk[3], const char *Space, double SpaceCoordinates[3])
+{
+  if (Space != NULL)
+    {
+
+    if (!strcmp(Space, "IJK"))
+      {
+        for (int i=0; i<3; i++)
+          {
+          SpaceCoordinates[i] = ijk[i];
+          }
+        return;
+      }
+
+    vtkSmartPointer<vtkMatrix4x4> IJKtoRAS =
+      vtkSmartPointer<vtkMatrix4x4>::New();
+    this->GetIJKToRASMatrix(IJKtoRAS);
+
+    vtkSmartPointer<vtkMatrix4x4> Rotation =
+       vtkSmartPointer<vtkMatrix4x4>::New();
+    Rotation->Identity();
+    double ijkw[4] = {ijk[0], ijk[1], ijk[2], 1.0 };
+    double SpaceCoordinatesw[4] = {0.0, 0.0, 0.0, 1.0};
+
+    if (!strcmp(Space, "LAS"))
+      {
+      Rotation->SetElement(1, 1, -1);
+      Rotation->SetElement(2, 2, -1);
+      }
+    if (!strcmp(Space, "LPS") || !strcmp(Space, "scanner-xyz"))
+      {
+      Rotation->SetElement(0, 0, -1);
+      Rotation->SetElement(2, 2, -1);
+    }
+
+    Rotation->Multiply4x4(IJKtoRAS, Rotation, Rotation);
+    Rotation->MultiplyPoint(ijkw, SpaceCoordinatesw);
+
+    for (int i=0; i<3; i++)
+      {
+      SpaceCoordinates[i] = SpaceCoordinatesw[i];
+      }
+    }
+}

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
@@ -67,10 +67,6 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeNode : public vtkMRMLVolumeNode
   /// Create default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 
-  ///
-  /// This method return World coordinated given ijk and the Space
-  virtual void GetReferenceSpace(const double* ijk, const char* Space, double* SpaceCoordinates);
-
 protected:
   vtkMRMLScalarVolumeNode();
   ~vtkMRMLScalarVolumeNode();

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
@@ -67,6 +67,11 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeNode : public vtkMRMLVolumeNode
   /// Create default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 
+
+  ///
+  /// This method return customized SlicerWorld coordinated given ijk
+  virtual void GetCustomizeWorldCoordinates(double* ijk, double* SlicerWorld);
+
 protected:
   vtkMRMLScalarVolumeNode();
   ~vtkMRMLScalarVolumeNode();

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
@@ -67,6 +67,10 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeNode : public vtkMRMLVolumeNode
   /// Create default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 
+  ///
+  /// This method return World coordinated given ijk and the Space
+  virtual void GetReferenceSpace(const double ijk[3], const char *Space, double SpaceCoordinates[3]);
+
 protected:
   vtkMRMLScalarVolumeNode();
   ~vtkMRMLScalarVolumeNode();

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
@@ -67,10 +67,9 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeNode : public vtkMRMLVolumeNode
   /// Create default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 
-
   ///
-  /// This method return customized SlicerWorld coordinated given ijk
-  virtual void GetCustomWorldCoordinates(double* ijk, double* SlicerWorld);
+  /// This method return World coordinated given ijk and the Space
+  virtual void GetReferenceSpace(const double* ijk, const char* Space, double* SpaceCoordinates);
 
 protected:
   vtkMRMLScalarVolumeNode();

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
@@ -70,7 +70,7 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeNode : public vtkMRMLVolumeNode
 
   ///
   /// This method return customized SlicerWorld coordinated given ijk
-  virtual void GetCustomizeWorldCoordinates(double* ijk, double* SlicerWorld);
+  virtual void GetCustomWorldCoordinates(double* ijk, double* SlicerWorld);
 
 protected:
   vtkMRMLScalarVolumeNode();

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
@@ -23,6 +23,7 @@ Version:   $Revision: 1.14 $
 #include <vtkCommand.h>
 #include <vtkIntArray.h>
 #include <vtkTransform.h>
+#include <vtkGeneralTransform.h>
 #include <vtkMatrix4x4.h>
 
 const char* vtkMRMLTransformableNode::TransformNodeReferenceRole = "transform";
@@ -95,6 +96,66 @@ const char* vtkMRMLTransformableNode::GetTransformNodeID()
     this->GetNodeReferenceID(this->GetTransformNodeReferenceRole()));
 
   return this->GetTransformNodeIDInternal();
+}
+
+void vtkMRMLTransformableNode::GetReferenceSpace(const double ijk[3], const char *Space, double SpaceCoordinates[3])
+{
+  if (Space != NULL)
+    {
+
+    if (!strcmp(Space, "IJK"))
+      {
+        for (int i=0; i<3; i++)
+          {
+          SpaceCoordinates[i] = ijk[i];
+          }
+        return;
+      }
+
+    // get the nodes's transform node
+    vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
+
+    if (!tnode)
+      {
+      for (int i=0; i<3; i++)
+        {
+        SpaceCoordinates[i] = ijk[i];
+        }
+      }
+    else
+      {
+
+      vtkSmartPointer<vtkMatrix4x4> transformToWorld =
+         vtkSmartPointer<vtkMatrix4x4>::New();
+      transformToWorld->Identity();
+      tnode->GetMatrixTransformToWorld(transformToWorld);
+
+      vtkSmartPointer<vtkMatrix4x4> Rotation =
+         vtkSmartPointer<vtkMatrix4x4>::New();
+      Rotation->Identity();
+      double ijkw[4] = {ijk[0], ijk[1], ijk[2], 1.0 };
+      double SpaceCoordinatesw[4] = {0.0, 0.0, 0.0, 1.0};
+
+      if (!strcmp(Space, "LAS"))
+        {
+        Rotation->SetElement(1, 1, -1);
+        Rotation->SetElement(2, 2, -1);
+        }
+      if (!strcmp(Space, "LPS") || !strcmp(Space, "scanner-xyz"))
+        {
+        Rotation->SetElement(0, 0, -1);
+        Rotation->SetElement(2, 2, -1);
+        }
+
+      Rotation->Multiply4x4(transformToWorld, Rotation, Rotation);
+      Rotation->MultiplyPoint(ijkw, SpaceCoordinatesw);
+
+      for (int i=0; i<3; i++)
+        {
+        SpaceCoordinates[i] = SpaceCoordinatesw[i];
+        }
+      }
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
@@ -115,46 +115,40 @@ void vtkMRMLTransformableNode::GetReferenceSpace(const double ijk[3], const char
     // get the nodes's transform node
     vtkMRMLTransformNode* tnode = this->GetParentTransformNode();
 
-    if (!tnode)
+    vtkSmartPointer<vtkMatrix4x4> transformToWorld =
+      vtkSmartPointer<vtkMatrix4x4>::New();
+    transformToWorld->Identity();
+    if (tnode)
       {
-      for (int i=0; i<3; i++)
-        {
-        SpaceCoordinates[i] = ijk[i];
-        }
-      }
-    else
-      {
-
-      vtkSmartPointer<vtkMatrix4x4> transformToWorld =
-         vtkSmartPointer<vtkMatrix4x4>::New();
-      transformToWorld->Identity();
+      // assuming that GetMatrixTransformToWorld is IJK->RAS
+      // if tonde == NULL then IJK->RAS is Identity()
       tnode->GetMatrixTransformToWorld(transformToWorld);
-
-      vtkSmartPointer<vtkMatrix4x4> Rotation =
-         vtkSmartPointer<vtkMatrix4x4>::New();
-      Rotation->Identity();
-      double ijkw[4] = {ijk[0], ijk[1], ijk[2], 1.0 };
-      double SpaceCoordinatesw[4] = {0.0, 0.0, 0.0, 1.0};
-
-      if (!strcmp(Space, "LAS"))
-        {
-        Rotation->SetElement(1, 1, -1);
-        Rotation->SetElement(2, 2, -1);
-        }
-      if (!strcmp(Space, "LPS") || !strcmp(Space, "scanner-xyz"))
-        {
-        Rotation->SetElement(0, 0, -1);
-        Rotation->SetElement(2, 2, -1);
-        }
-
-      Rotation->Multiply4x4(transformToWorld, Rotation, Rotation);
-      Rotation->MultiplyPoint(ijkw, SpaceCoordinatesw);
-
-      for (int i=0; i<3; i++)
-        {
-        SpaceCoordinates[i] = SpaceCoordinatesw[i];
-        }
       }
+    vtkSmartPointer<vtkMatrix4x4> Rotation =
+      vtkSmartPointer<vtkMatrix4x4>::New();
+    Rotation->Identity();
+    double ijkw[4] = {ijk[0], ijk[1], ijk[2], 1.0 };
+    double SpaceCoordinatesw[4] = {0.0, 0.0, 0.0, 1.0};
+
+    if (!strcmp(Space, "LAS"))
+      {
+      Rotation->SetElement(1, 1, -1);
+      Rotation->SetElement(2, 2, -1);
+      }
+    if (!strcmp(Space, "LPS") || !strcmp(Space, "scanner-xyz"))
+      {
+      Rotation->SetElement(0, 0, -1);
+      Rotation->SetElement(2, 2, -1);
+      }
+
+    Rotation->Multiply4x4(transformToWorld, Rotation, Rotation);
+    Rotation->MultiplyPoint(ijkw, SpaceCoordinatesw);
+
+    for (int i=0; i<3; i++)
+      {
+      SpaceCoordinates[i] = SpaceCoordinatesw[i];
+      }
+
     }
 }
 

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.h
@@ -92,6 +92,9 @@ public:
   /// Get referenced transform node id
   const char *GetTransformNodeID();
 
+  /// This method return World coordinated given ijk and the Space
+  virtual void GetReferenceSpace(const double ijk[3], const char *Space, double SpaceCoordinates[3]);
+
 protected:
   vtkMRMLTransformableNode();
   ~vtkMRMLTransformableNode();

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.h
@@ -92,7 +92,6 @@ public:
   /// Get referenced transform node id
   const char *GetTransformNodeID();
 
-
 protected:
   vtkMRMLTransformableNode();
   ~vtkMRMLTransformableNode();

--- a/Libs/MRML/Core/vtkMRMLUnitNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLUnitNode.cxx
@@ -198,10 +198,10 @@ const char* vtkMRMLUnitNode::GetDisplayStringFromValue(double value)
 }
 
 //----------------------------------------------------------------------------
-const char* vtkMRMLUnitNode
-::GetDisplayValueStringFromDisplayValue(double displayValue)
+const char* vtkMRMLUnitNode::GetDisplayValueStringFromDisplayValue(double displayValue)
 {
   std::stringstream strstream;
+  strstream.setf(ios::fixed,ios::floatfield);
   strstream.precision(this->Precision);
   strstream << displayValue;
   strstream >> this->LastValueString;
@@ -238,7 +238,7 @@ std::string vtkMRMLUnitNode::WrapValueWithPrefix(const std::string& value) const
   std::string wrappedString = "";
   if (this->Prefix)
     {
-    wrappedString = std::string(this->Prefix) + " ";
+    wrappedString = std::string(this->Prefix);
     }
   return wrappedString + value;
 }
@@ -249,7 +249,7 @@ std::string vtkMRMLUnitNode::WrapValueWithSuffix(const std::string& value) const
   std::string wrappedString = "";
   if (this->Suffix)
     {
-    wrappedString = " " + std::string(this->Suffix);
+    wrappedString = std::string(this->Suffix);
     }
   return value + wrappedString;
 }

--- a/Libs/MRML/Core/vtkMRMLUnitNode.h
+++ b/Libs/MRML/Core/vtkMRMLUnitNode.h
@@ -94,7 +94,7 @@ public:
   ///
   /// Set/Get the unit prefix.
   /// Default is "".
-  // \sa SetSuffix(), GetSuffix()
+  /// \sa SetPrefix(), GetPrefix()
   vtkGetStringMacro(Prefix);
   vtkSetStringMacro(Prefix);
 
@@ -102,7 +102,7 @@ public:
   /// Set/Get the unit suffix. For example, the suffix for the unity
   /// meter would be "m".
   /// Default is "".
-  /// \sa SetPrefix(), GetPrefix()
+  /// \sa SetSuffix(), GetSuffix()
   vtkGetStringMacro(Suffix);
   vtkSetStringMacro(Suffix);
 

--- a/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.cxx
@@ -33,6 +33,10 @@ vtkMRMLVolumeDisplayNode::vtkMRMLVolumeDisplayNode()
 {
   // try setting a default greyscale color map
   //this->SetDefaultColorMap(0);
+    HorizontalQuantity = "length";
+    VerticalQuantity = "length";
+    DepthQuantity = "length";
+    sysref = "RAS";
 }
 
 //----------------------------------------------------------------------------
@@ -44,6 +48,12 @@ vtkMRMLVolumeDisplayNode::~vtkMRMLVolumeDisplayNode()
 void vtkMRMLVolumeDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
+  vtkIndent indent(nIndent);
+
+  of << indent << "HorizontalQuantity=\"" << HorizontalQuantity << "\"";
+  of << indent << "VerticalQuantity=\"" << VerticalQuantity << "\"";
+  of << indent << "DepthQuantity=\"" << DepthQuantity << "\"";
+  of << indent << "sysref=\"" << sysref << "\"";
 }
 
 //----------------------------------------------------------------------------
@@ -51,6 +61,36 @@ void vtkMRMLVolumeDisplayNode::ReadXMLAttributes(const char** atts)
 {
 
   Superclass::ReadXMLAttributes(atts);
+
+  const char* attName;
+  const char* attValue;
+
+  while (*atts != NULL){
+    attName = *(atts++);
+    attValue = *(atts++);
+
+    if (!strcmp(attName, "HorizontalQuantity")){
+      HorizontalQuantity = attValue;
+      continue;
+    }
+
+    if (!strcmp(attName, "VerticalQuantity")){
+      VerticalQuantity = attValue;
+      continue;
+    }
+
+    if (!strcmp(attName, "DepthQuantity")){
+      DepthQuantity = attValue;
+      continue;
+    }
+
+    if (!strcmp(attName, "sysref")){
+      sysref = attValue;
+      continue;
+    }
+  }
+
+  this->WriteXML(std::cout,0);
 }
 
 //----------------------------------------------------------------------------
@@ -66,10 +106,18 @@ void vtkMRMLVolumeDisplayNode::Copy(vtkMRMLNode *anode)
   if (node)
     {
     this->SetInputImageDataConnection(node->GetInputImageDataConnection());
+    node->HorizontalQuantity = this->HorizontalQuantity;
+    node->VerticalQuantity = this->VerticalQuantity;
+    node->DepthQuantity = this->DepthQuantity;
+    node->sysref = this->sysref;
     }
   this->UpdateImageDataPipeline();
 #endif
+
+
+
   this->EndModify(wasModifying);
+
 }
 
 //---------------------------------------------------------------------------
@@ -88,6 +136,11 @@ void vtkMRMLVolumeDisplayNode::ProcessMRMLEvents(vtkObject *caller,
 void vtkMRMLVolumeDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
+
+    os << indent << "HorizontalQuantity:   "<< HorizontalQuantity << std::endl;
+    os << indent << "VerticalQuantity=   " << VerticalQuantity << std::endl;
+    os << indent << "DepthQuantity=   " << DepthQuantity << std::endl;
+    os << indent << "sysref=   " << sysref << std::endl;
 }
 
 //-----------------------------------------------------------
@@ -241,7 +294,55 @@ void vtkMRMLVolumeDisplayNode::UpdateImageDataPipeline()
 //----------------------------------------------------------------------------
 void vtkMRMLVolumeDisplayNode::SetDefaultColorMap()
 {
-  this->SetAndObserveColorNodeID("vtkMRMLColorTableNodeGrey");
+    this->SetAndObserveColorNodeID("vtkMRMLColorTableNodeGrey");
+}
+
+//----------------------------------------------------------------------------
+const char *vtkMRMLVolumeDisplayNode::GetHorizontalQuantity()
+{
+    return HorizontalQuantity.c_str();
+}
+
+//----------------------------------------------------------------------------
+const char *vtkMRMLVolumeDisplayNode::GetVerticalQuantity()
+{
+    return VerticalQuantity.c_str();
+}
+
+//----------------------------------------------------------------------------
+const char *vtkMRMLVolumeDisplayNode::GetDepthQuantity()
+{
+    return DepthQuantity.c_str();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVolumeDisplayNode::SetHorizontalQuantity(const char *quantity)
+{
+    this->HorizontalQuantity = quantity;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVolumeDisplayNode::SetVerticalQuantity(const char *quantity)
+{
+    this->VerticalQuantity = quantity;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVolumeDisplayNode::SetDepthQuantity(const char *quantity)
+{
+    this->DepthQuantity = quantity;
+}
+
+//----------------------------------------------------------------------------
+const char *vtkMRMLVolumeDisplayNode::GetCoodinatesSystemName()
+{
+    return sysref.c_str();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLVolumeDisplayNode::SetCoodinatesSystemName(const char *sys)
+{
+    this->sysref = sys;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.cxx
@@ -33,15 +33,37 @@ vtkMRMLVolumeDisplayNode::vtkMRMLVolumeDisplayNode()
 {
   // try setting a default greyscale color map
   //this->SetDefaultColorMap(0);
-    HorizontalQuantity = "length";
-    VerticalQuantity = "length";
-    DepthQuantity = "length";
-    sysref = "RAS";
+    this->HorizontalQuantity = 0;
+    this->VerticalQuantity = 0;
+    this->DepthQuantity = 0;
+    this->CoordinateSystem = 0;
+
+    this->SetHorizontalQuantity("length");
+    this->SetVerticalQuantity("length");
+    this->SetDepthQuantity("length");
+    this->SetCoordinateSystem("RAS");
 }
 
 //----------------------------------------------------------------------------
 vtkMRMLVolumeDisplayNode::~vtkMRMLVolumeDisplayNode()
 {
+    if (this->HorizontalQuantity)
+      {
+      delete [] this->HorizontalQuantity;
+      }
+    if (this->VerticalQuantity)
+      {
+      delete [] this->VerticalQuantity;
+      }
+    if (this->DepthQuantity)
+      {
+      delete [] this->DepthQuantity;
+      }
+    if (this->CoordinateSystem)
+      {
+      delete [] this->CoordinateSystem;
+      }
+
 }
 
 //----------------------------------------------------------------------------
@@ -50,10 +72,10 @@ void vtkMRMLVolumeDisplayNode::WriteXML(ostream& of, int nIndent)
   Superclass::WriteXML(of, nIndent);
   vtkIndent indent(nIndent);
 
-  of << indent << "HorizontalQuantity=\"" << HorizontalQuantity << "\"";
-  of << indent << "VerticalQuantity=\"" << VerticalQuantity << "\"";
-  of << indent << "DepthQuantity=\"" << DepthQuantity << "\"";
-  of << indent << "sysref=\"" << sysref << "\"";
+  of << indent << " HorizontalQuantity=\"" << (this->HorizontalQuantity ? this->HorizontalQuantity : "") << "\"";
+  of << indent << " VerticalQuantity=\"" << (this->VerticalQuantity ? this->VerticalQuantity : "") << "\"";
+  of << indent << " DepthQuantity=\"" << (this->DepthQuantity ? this->DepthQuantity : "") << "\"";
+  of << indent << " CoordinateSystem=\"" << (this->CoordinateSystem ? this->CoordinateSystem : "") << "\"";
 }
 
 //----------------------------------------------------------------------------
@@ -70,22 +92,22 @@ void vtkMRMLVolumeDisplayNode::ReadXMLAttributes(const char** atts)
     attValue = *(atts++);
 
     if (!strcmp(attName, "HorizontalQuantity")){
-      HorizontalQuantity = attValue;
+      this->SetHorizontalQuantity(attValue);
       continue;
     }
 
     if (!strcmp(attName, "VerticalQuantity")){
-      VerticalQuantity = attValue;
+      this->SetVerticalQuantity(attValue);
       continue;
     }
 
     if (!strcmp(attName, "DepthQuantity")){
-      DepthQuantity = attValue;
+      this->SetDepthQuantity(attValue);
       continue;
     }
 
     if (!strcmp(attName, "sysref")){
-      sysref = attValue;
+      this->SetCoordinateSystem(attValue);
       continue;
     }
   }
@@ -106,10 +128,10 @@ void vtkMRMLVolumeDisplayNode::Copy(vtkMRMLNode *anode)
   if (node)
     {
     this->SetInputImageDataConnection(node->GetInputImageDataConnection());
-    node->HorizontalQuantity = this->HorizontalQuantity;
-    node->VerticalQuantity = this->VerticalQuantity;
-    node->DepthQuantity = this->DepthQuantity;
-    node->sysref = this->sysref;
+    this->SetHorizontalQuantity(node->GetHorizontalQuantity());
+    this->SetVerticalQuantity(node->GetVerticalQuantity());
+    this->SetDepthQuantity(node->GetDepthQuantity());
+    this->SetCoordinateSystem(node->GetCoordinateSystem());
     }
   this->UpdateImageDataPipeline();
 #endif
@@ -137,10 +159,14 @@ void vtkMRMLVolumeDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
 
-    os << indent << "HorizontalQuantity:   "<< HorizontalQuantity << std::endl;
-    os << indent << "VerticalQuantity=   " << VerticalQuantity << std::endl;
-    os << indent << "DepthQuantity=   " << DepthQuantity << std::endl;
-    os << indent << "sysref=   " << sysref << std::endl;
+    os << indent << "HorizontalQuantity: " <<
+      (this->HorizontalQuantity ? this->HorizontalQuantity : "(none)") << "\n";
+    os << indent << "VerticalQuantity: " <<
+      (this->VerticalQuantity ? this->VerticalQuantity : "(none)") << "\n";
+    os << indent << "DepthQuantity: " <<
+      (this->DepthQuantity ? this->DepthQuantity : "(none)") << "\n";
+    os << indent << "CoordinateSystem: " <<
+      (this->CoordinateSystem ? this->CoordinateSystem : "(none)") << "\n";
 }
 
 //-----------------------------------------------------------
@@ -295,54 +321,6 @@ void vtkMRMLVolumeDisplayNode::UpdateImageDataPipeline()
 void vtkMRMLVolumeDisplayNode::SetDefaultColorMap()
 {
     this->SetAndObserveColorNodeID("vtkMRMLColorTableNodeGrey");
-}
-
-//----------------------------------------------------------------------------
-const char *vtkMRMLVolumeDisplayNode::GetHorizontalQuantity()
-{
-    return HorizontalQuantity.c_str();
-}
-
-//----------------------------------------------------------------------------
-const char *vtkMRMLVolumeDisplayNode::GetVerticalQuantity()
-{
-    return VerticalQuantity.c_str();
-}
-
-//----------------------------------------------------------------------------
-const char *vtkMRMLVolumeDisplayNode::GetDepthQuantity()
-{
-    return DepthQuantity.c_str();
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLVolumeDisplayNode::SetHorizontalQuantity(const char *quantity)
-{
-    this->HorizontalQuantity = quantity;
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLVolumeDisplayNode::SetVerticalQuantity(const char *quantity)
-{
-    this->VerticalQuantity = quantity;
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLVolumeDisplayNode::SetDepthQuantity(const char *quantity)
-{
-    this->DepthQuantity = quantity;
-}
-
-//----------------------------------------------------------------------------
-const char *vtkMRMLVolumeDisplayNode::GetCoodinatesSystemName()
-{
-    return sysref.c_str();
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLVolumeDisplayNode::SetCoodinatesSystemName(const char *sys)
-{
-    this->sysref = sys;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.h
@@ -21,10 +21,10 @@ class vtkMRMLScene;
 class vtkMRMLVolumeNode;
 
 // VTK includes
+#include <vtkStringArray.h>
 class vtkAlgorithmOutput;
 class vtkImageData;
 class vtkImageStencilData;
-class vtkStringArray;
 
 /// \brief MRML node for representing a volume display attributes.
 ///
@@ -136,11 +136,14 @@ public:
 
   ///
   /// Set/Get the SpaceQuantities.
-  /// Default is "length;length;length".
+  /// The default is 3 and all the values are "length".
   /// \sa SetSpaceQuantities(), GetSpaceQuantities()
-  vtkGetStringMacro(SpaceQuantities);
-  vtkSetStringMacro(SpaceQuantities);
-  virtual vtkStringArray* GetSpaceQuantitiesList();
+  vtkGetObjectMacro(SpaceQuantities, vtkStringArray);
+  vtkSetObjectMacro(SpaceQuantities, vtkStringArray);
+
+  ///
+  /// Set the i-th SpaceQunatity name
+  int SetSpaceQuantity(int ind, const char *name);
 
   /// Search in the scene the volume node vtkMRMLVolumeDisplayNode is associated
   /// to
@@ -153,8 +156,7 @@ protected:
   void operator=(const vtkMRMLVolumeDisplayNode&);
 
   char* Space;
-  char* SpaceQuantities;
-  vtkStringArray *Tokens;
+  vtkStringArray* SpaceQuantities;
 
 #if (VTK_MAJOR_VERSION <= 5)
   virtual void SetInputToImageDataPipeline(vtkImageData *imageData);

--- a/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.h
@@ -125,6 +125,26 @@ public:
   /// set gray colormap or override in subclass
   virtual void SetDefaultColorMap();
 
+  ///
+  /// Get methods returning the reference quantity names
+  virtual const char* GetHorizontalQuantity();
+  virtual const char* GetVerticalQuantity();
+  virtual const char* GetDepthQuantity();
+
+  ///
+  /// Set methods for the reference quantity names
+  virtual void SetHorizontalQuantity(const char*);
+  virtual void SetVerticalQuantity(const char*);
+  virtual void SetDepthQuantity(const char*);
+
+  ///
+  /// Get the name of the system of reference
+  virtual const char* GetCoodinatesSystemName();
+
+  ///
+  /// Set the name of the system of reference
+  virtual void SetCoodinatesSystemName(const char*);
+
   /// Search in the scene the volume node vtkMRMLVolumeDisplayNode is associated
   /// to
   vtkMRMLVolumeNode* GetVolumeNode();
@@ -140,6 +160,12 @@ protected:
 #else
   virtual void SetInputToImageDataPipeline(vtkAlgorithmOutput *imageDataConnection);
 #endif
+
+  std::string sysref;
+  std::string HorizontalQuantity;
+  std::string VerticalQuantity;
+  std::string DepthQuantity;
+
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.h
@@ -24,6 +24,7 @@ class vtkMRMLVolumeNode;
 class vtkAlgorithmOutput;
 class vtkImageData;
 class vtkImageStencilData;
+class vtkStringArray;
 
 /// \brief MRML node for representing a volume display attributes.
 ///
@@ -129,31 +130,17 @@ public:
   ///
   /// Set/Get the unit CoordinateSystem.
   /// Default is "RAS".
-  /// \sa SetCoordinateSystem(), GetCoordinateSystem()
-  vtkGetStringMacro(CoordinateSystem);
-  vtkSetStringMacro(CoordinateSystem);
+  /// \sa SetSpace(), GetSpace()
+  vtkGetStringMacro(Space);
+  vtkSetStringMacro(Space);
 
   ///
-  /// Set/Get the unit HorizontalQuantity.
-  /// Default is "length".
-  /// \sa SetHorizontalQuantity(), GetHorizontalQuantity()
-  vtkGetStringMacro(HorizontalQuantity);
-  vtkSetStringMacro(HorizontalQuantity);
-
-  ///
-  /// Set/Get the unit VerticalQuantity.
-  /// Default is "length".
-  /// \sa SetVerticalQuantity(), GetVerticalQuantity()
-  vtkGetStringMacro(VerticalQuantity);
-  vtkSetStringMacro(VerticalQuantity);
-
-  ///
-  /// Set/Get the unit DepthQuantity.
-  /// Default is "length".
-  /// \sa SetDepthQuantity(), GetDepthQuantity()
-  vtkGetStringMacro(DepthQuantity);
-  vtkSetStringMacro(DepthQuantity);
-
+  /// Set/Get the SpaceQuantities.
+  /// Default is "length;length;length".
+  /// \sa SetSpaceQuantities(), GetSpaceQuantities()
+  vtkGetStringMacro(SpaceQuantities);
+  vtkSetStringMacro(SpaceQuantities);
+  virtual vtkStringArray* GetSpaceQuantitiesList();
 
   /// Search in the scene the volume node vtkMRMLVolumeDisplayNode is associated
   /// to
@@ -165,17 +152,15 @@ protected:
   vtkMRMLVolumeDisplayNode(const vtkMRMLVolumeDisplayNode&);
   void operator=(const vtkMRMLVolumeDisplayNode&);
 
+  char* Space;
+  char* SpaceQuantities;
+  vtkStringArray *Tokens;
+
 #if (VTK_MAJOR_VERSION <= 5)
   virtual void SetInputToImageDataPipeline(vtkImageData *imageData);
 #else
   virtual void SetInputToImageDataPipeline(vtkAlgorithmOutput *imageDataConnection);
 #endif
-
-  char* CoordinateSystem;
-  char* HorizontalQuantity;
-  char* VerticalQuantity;
-  char* DepthQuantity;
-
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeDisplayNode.h
@@ -125,25 +125,35 @@ public:
   /// set gray colormap or override in subclass
   virtual void SetDefaultColorMap();
 
-  ///
-  /// Get methods returning the reference quantity names
-  virtual const char* GetHorizontalQuantity();
-  virtual const char* GetVerticalQuantity();
-  virtual const char* GetDepthQuantity();
 
   ///
-  /// Set methods for the reference quantity names
-  virtual void SetHorizontalQuantity(const char*);
-  virtual void SetVerticalQuantity(const char*);
-  virtual void SetDepthQuantity(const char*);
+  /// Set/Get the unit CoordinateSystem.
+  /// Default is "RAS".
+  /// \sa SetCoordinateSystem(), GetCoordinateSystem()
+  vtkGetStringMacro(CoordinateSystem);
+  vtkSetStringMacro(CoordinateSystem);
 
   ///
-  /// Get the name of the system of reference
-  virtual const char* GetCoodinatesSystemName();
+  /// Set/Get the unit HorizontalQuantity.
+  /// Default is "length".
+  /// \sa SetHorizontalQuantity(), GetHorizontalQuantity()
+  vtkGetStringMacro(HorizontalQuantity);
+  vtkSetStringMacro(HorizontalQuantity);
 
   ///
-  /// Set the name of the system of reference
-  virtual void SetCoodinatesSystemName(const char*);
+  /// Set/Get the unit VerticalQuantity.
+  /// Default is "length".
+  /// \sa SetVerticalQuantity(), GetVerticalQuantity()
+  vtkGetStringMacro(VerticalQuantity);
+  vtkSetStringMacro(VerticalQuantity);
+
+  ///
+  /// Set/Get the unit DepthQuantity.
+  /// Default is "length".
+  /// \sa SetDepthQuantity(), GetDepthQuantity()
+  vtkGetStringMacro(DepthQuantity);
+  vtkSetStringMacro(DepthQuantity);
+
 
   /// Search in the scene the volume node vtkMRMLVolumeDisplayNode is associated
   /// to
@@ -161,10 +171,10 @@ protected:
   virtual void SetInputToImageDataPipeline(vtkAlgorithmOutput *imageDataConnection);
 #endif
 
-  std::string sysref;
-  std::string HorizontalQuantity;
-  std::string VerticalQuantity;
-  std::string DepthQuantity;
+  char* CoordinateSystem;
+  char* HorizontalQuantity;
+  char* VerticalQuantity;
+  char* DepthQuantity;
 
 };
 

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
@@ -204,7 +204,7 @@ void vtkSlicerUnitsLogic::AddBuiltInUnits(vtkMRMLScene* scene)
   this->AddUnitNodeToScene(scene,
     "Metre per second", "velocity", "", "m/s", 3, -10000., 10000., 1., 0.);
   this->AddUnitNodeToScene(scene,
-    "Kilometre per second", "velocity", "", "km/s", 3, -10000., 10000., 0.01, 0.);
+    "Kilometre per second", "velocity", "", "km/s", 3, -10000., 10000., 0.001, 0.);
 
   this->AddUnitNodeToScene(scene,
     "Intensity", "intensity", "", "W/m\xB2", 3, -10000., 10000., 1., 0.);

--- a/Modules/Loadable/Units/Widgets/qMRMLUnitWidget.cxx
+++ b/Modules/Loadable/Units/Widgets/qMRMLUnitWidget.cxx
@@ -98,7 +98,7 @@ void qMRMLUnitWidgetPrivate::setupUi(qMRMLUnitWidget* q)
   QObject::connect(this->MaximumSpinBox, SIGNAL(valueChanged(double)),
     q, SLOT(setMaximum(double)));
   QObject::connect(this->MaximumSpinBox, SIGNAL(valueChanged(double)),
-    q, SIGNAL(minimumChanged(double)));
+    q, SIGNAL(maximumChanged(double)));
 
   QObject::connect(this->CoefficientSpinBox, SIGNAL(valueChanged(double)),
     q, SLOT(setCoefficient(double)));
@@ -376,6 +376,7 @@ void qMRMLUnitWidget::setPrefix(const QString& newPrefix)
     {
     d->CurrentUnitNode->SetPrefix(newPrefix.toLatin1());
     }
+
   d->MaximumSpinBox->setPrefix(newPrefix);
   d->MinimumSpinBox->setPrefix(newPrefix);
 }
@@ -396,6 +397,7 @@ void qMRMLUnitWidget::setSuffix(const QString& newSuffix)
     {
     d->CurrentUnitNode->SetSuffix(newSuffix.toLatin1());
     }
+
   d->MaximumSpinBox->setSuffix(newSuffix);
   d->MinimumSpinBox->setSuffix(newSuffix);
 }

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -212,27 +212,27 @@ class DataProbeInfoWidget(object):
         if display:
           if layer == 'B':
             hasBLayer = True
-            volumeNode.GetCustomizeWorldCoordinates(ijk, ras)
+            volumeNode.GetCustomWorldCoordinates(ijk, ras)
             HorizontalUnitNode = selectionNode.GetUnitNode(display.GetHorizontalQuantity())
             VerticalUnitNode = selectionNode.GetUnitNode(display.GetVerticalQuantity())
             DepthUnitNode = selectionNode.GetUnitNode(display.GetDepthQuantity())
-            CoordinateSystemName = display.GetCoodinatesSystemName()
+            CoordinateSystemName = display.GetCoordinateSystem()
 
           if layer == "F" and hasBLayer == False:
             hasFLayer = True
-            volumeNode.GetCustomizeWorldCoordinates(ijk, ras)
+            volumeNode.GetCustomWorldCoordinates(ijk, ras)
             HorizontalUnitNode = selectionNode.GetUnitNode(display.GetHorizontalQuantity())
             VerticalUnitNode = selectionNode.GetUnitNode(display.GetVerticalQuantity())
             DepthUnitNode = selectionNode.GetUnitNode(display.GetDepthQuantity())
-            CoordinateSystemName = display.GetCoodinatesSystemName()
+            CoordinateSystemName = display.GetCoordinateSystem()
 
           if layer == "L" and hasBLayer == False and hasFLayer == False:
             hasLLayer = True
-            volumeNode.GetCustomizeWorldCoordinates(ijk, ras)
+            volumeNode.GetCustomWorldCoordinates(ijk, ras)
             HorizontalUnitNode = selectionNode.GetUnitNode(display.GetHorizontalQuantity())
             VerticalUnitNode = selectionNode.GetUnitNode(display.GetVerticalQuantity())
             DepthUnitNode = selectionNode.GetUnitNode(display.GetDepthQuantity())
-            CoordinateSystemName = display.GetCoodinatesSystemName()
+            CoordinateSystemName = display.GetCoordinateSystem()
         self.layerNames[layer].setText(
           "<b>%s</b>" % (self.fitName(volumeNode.GetName()) if volumeNode else "None"))
         self.layerIJKs[layer].setText(

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -129,11 +129,11 @@ class DataProbeInfoWidget(object):
   def processEvent(self,observee,event):
     # TODO: use a timer to delay calculation and compress events
     insideView = False
-    ras = [0.0,0.0,0.0]
+    world = [0.0,0.0,0.0]
     xyz = [0.0,0.0,0.0]
     sliceNode = None
     if self.CrosshairNode:
-      insideView = self.CrosshairNode.GetCursorPositionRAS(ras)
+      insideView = self.CrosshairNode.GetCursorPositionRAS(world)
       sliceNode = self.CrosshairNode.GetCursorPositionXYZ(xyz)
 
     selectionNode = slicer.mrmlScene.GetNthNodeByClass(0,'vtkMRMLSelectionNode')
@@ -212,43 +212,46 @@ class DataProbeInfoWidget(object):
         if display:
           if layer == 'B':
             hasBLayer = True
-            volumeNode.GetCustomWorldCoordinates(ijk, ras)
-            HorizontalUnitNode = selectionNode.GetUnitNode(display.GetHorizontalQuantity())
-            VerticalUnitNode = selectionNode.GetUnitNode(display.GetVerticalQuantity())
-            DepthUnitNode = selectionNode.GetUnitNode(display.GetDepthQuantity())
-            CoordinateSystemName = display.GetCoordinateSystem()
+            CoordinateSystemName = display.GetSpace()
+            volumeNode.GetReferenceSpace(ijk, CoordinateSystemName, world)
+            Quantities = display.GetSpaceQuantitiesList()
+            UnitNode1 = selectionNode.GetUnitNode(Quantities.GetValue(0))
+            UnitNode2 = selectionNode.GetUnitNode(Quantities.GetValue(1))
+            UnitNode3 = selectionNode.GetUnitNode(Quantities.GetValue(2))
 
           if layer == "F" and hasBLayer == False:
             hasFLayer = True
-            volumeNode.GetCustomWorldCoordinates(ijk, ras)
-            HorizontalUnitNode = selectionNode.GetUnitNode(display.GetHorizontalQuantity())
-            VerticalUnitNode = selectionNode.GetUnitNode(display.GetVerticalQuantity())
-            DepthUnitNode = selectionNode.GetUnitNode(display.GetDepthQuantity())
-            CoordinateSystemName = display.GetCoordinateSystem()
+            CoordinateSystemName = display.GetSpace()
+            volumeNode.GetReferenceSpace(ijk, CoordinateSystemName, world)
+            Quantities = display.GetSpaceQuantitiesList()
+            UnitNode1 = selectionNode.GetUnitNode(Quantities.GetValue(0))
+            UnitNode2 = selectionNode.GetUnitNode(Quantities.GetValue(1))
+            UnitNode3 = selectionNode.GetUnitNode(Quantities.GetValue(2))
 
           if layer == "L" and hasBLayer == False and hasFLayer == False:
             hasLLayer = True
-            volumeNode.GetCustomWorldCoordinates(ijk, ras)
-            HorizontalUnitNode = selectionNode.GetUnitNode(display.GetHorizontalQuantity())
-            VerticalUnitNode = selectionNode.GetUnitNode(display.GetVerticalQuantity())
-            DepthUnitNode = selectionNode.GetUnitNode(display.GetDepthQuantity())
-            CoordinateSystemName = display.GetCoordinateSystem()
+            CoordinateSystemName = display.GetSpace()
+            volumeNode.GetReferenceSpace(ijk, CoordinateSystemName, world)
+            Quantities = display.GetSpaceQuantitiesList()
+            UnitNode1 = selectionNode.GetUnitNode(Quantities.GetValue(0))
+            UnitNode2 = selectionNode.GetUnitNode(Quantities.GetValue(1))
+            UnitNode3 = selectionNode.GetUnitNode(Quantities.GetValue(2))
         self.layerNames[layer].setText(
           "<b>%s</b>" % (self.fitName(volumeNode.GetName()) if volumeNode else "None"))
         self.layerIJKs[layer].setText(
           "({i:4d}, {j:4d}, {k:4d})".format(i=ijk[0], j=ijk[1], k=ijk[2]) if volumeNode else "")
         self.layerValues[layer].setText(
-          "<b>%s</b>" % display.getPixelString(ijk) if display else "")
+          "<b>%s</b>" % display.GetPixelString(ijk) if display else "")
 
     if not (hasBLayer or hasFLayer or hasLLayer):
-      HorizontalUnitNode = selectionNode.GetUnitNode("length")
-      VerticalUnitNode = selectionNode.GetUnitNode("length")
-      DepthUnitNode = selectionNode.GetUnitNode("length")
+      UnitNode1 = selectionNode.GetUnitNode("length")
+      UnitNode2 = selectionNode.GetUnitNode("length")
+      UnitNode3 = selectionNode.GetUnitNode("length")
       CoordinateSystemName = "RAS"
 
-    world_x = HorizontalUnitNode.GetDisplayStringFromValue(ras[0])
-    world_y = VerticalUnitNode.GetDisplayStringFromValue(ras[1])
-    world_z = DepthUnitNode.GetDisplayStringFromValue(ras[2])
+    world_x = UnitNode1.GetDisplayStringFromValue(world[0])
+    world_y = UnitNode2.GetDisplayStringFromValue(world[1])
+    world_z = UnitNode3.GetDisplayStringFromValue(world[2])
 
     self.viewInfo.text = \
       "  {layoutName: <8s} {sys:s}:({world_x:>10s},{world_y:>10s},{world_z:>10s}) {orient: >8s} Sp:{spacing:s}" \

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -133,7 +133,6 @@ class DataProbeInfoWidget(object):
     xyz = [0.0,0.0,0.0]
     sliceNode = None
     if self.CrosshairNode:
-      insideView = self.CrosshairNode.GetCursorPositionRAS(world)
       sliceNode = self.CrosshairNode.GetCursorPositionXYZ(xyz)
 
     selectionNode = slicer.mrmlScene.GetNthNodeByClass(0,'vtkMRMLSelectionNode')
@@ -144,7 +143,7 @@ class DataProbeInfoWidget(object):
       if appLogic:
         sliceLogic = appLogic.GetSliceLogic(sliceNode)
 
-    if not insideView or not sliceNode or not sliceLogic:
+    if not sliceNode or not sliceLogic:
       self.currentLayoutName = None
       # reset all the readouts
       self.viewerColor.text = ""
@@ -214,7 +213,7 @@ class DataProbeInfoWidget(object):
             hasBLayer = True
             CoordinateSystemName = display.GetSpace()
             volumeNode.GetReferenceSpace(ijk, CoordinateSystemName, world)
-            Quantities = display.GetSpaceQuantitiesList()
+            Quantities = display.GetSpaceQuantities()
             UnitNode1 = selectionNode.GetUnitNode(Quantities.GetValue(0))
             UnitNode2 = selectionNode.GetUnitNode(Quantities.GetValue(1))
             UnitNode3 = selectionNode.GetUnitNode(Quantities.GetValue(2))
@@ -223,7 +222,7 @@ class DataProbeInfoWidget(object):
             hasFLayer = True
             CoordinateSystemName = display.GetSpace()
             volumeNode.GetReferenceSpace(ijk, CoordinateSystemName, world)
-            Quantities = display.GetSpaceQuantitiesList()
+            Quantities = display.GetSpaceQuantities()
             UnitNode1 = selectionNode.GetUnitNode(Quantities.GetValue(0))
             UnitNode2 = selectionNode.GetUnitNode(Quantities.GetValue(1))
             UnitNode3 = selectionNode.GetUnitNode(Quantities.GetValue(2))
@@ -232,7 +231,7 @@ class DataProbeInfoWidget(object):
             hasLLayer = True
             CoordinateSystemName = display.GetSpace()
             volumeNode.GetReferenceSpace(ijk, CoordinateSystemName, world)
-            Quantities = display.GetSpaceQuantitiesList()
+            Quantities = display.GetSpaceQuantities()
             UnitNode1 = selectionNode.GetUnitNode(Quantities.GetValue(0))
             UnitNode2 = selectionNode.GetUnitNode(Quantities.GetValue(1))
             UnitNode3 = selectionNode.GetUnitNode(Quantities.GetValue(2))


### PR DESCRIPTION
here I propose some modifications for implementing the two first points of:
http://www.na-mic.org/Bug/view.php?id=4020

main modifications:

1) GetPixelString is now a method of vtkMRMLScalarVolumeDisplayNode. Child class methods have
    been implemented (Label and DiffusionTensor).

2) for enabling customization of the coordinate and units display I have added the following method:
   a) GetCustomizeWorldCoordinates in the vtkMRMLScalarVolumeNode (extension can fill the method
        for showing different coordinate in DataProbe
   b) added in vtkMRMLVolumeDisplayNode the following attributes and relative GET/SET method (and         copy, WriteXML, etc.): 
         HorizontalQuantity = "length";
         VerticalQuantity = "length";
         DepthQuantity = "length";
         sysref = "RAS";

       extension can modify this attributes for displaying different coordinates and units for each
       each dimension (for the moment only for the GUI of DataProbe). DataProbe now use these, in 
       ProcessEvent, to format the string viewInfo.text. The coordinates and units display is set to the 
       first volume found with this order of priority : BackgroundLayer, ForegroundLayer and LabelLayer.

 @finetjul, @pieper may you check this and have your feedback?
Thanks.