### PR TITLE
Volume rendering now updated when volume node geometry is updated

### DIFF
--- a/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
@@ -771,7 +771,7 @@ void vtkMRMLVolumeNode::SetAndObserveImageData(vtkImageData *imageData)
     vtkNew<vtkTrivialProducer> tp;
     tp->SetOutput(imageData);
     // Propagate ModifiedEvent onto the trivial producer to make sure
-    // PolyDataModifiedEvent is triggered.
+    // ImageDataModifiedEvent is triggered.
     if (!this->DataEventForwarder)
       {
       this->DataEventForwarder = vtkEventForwarderCommand::New();

--- a/Libs/MRML/Core/vtkMRMLVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.h
@@ -173,7 +173,6 @@ public:
                                    unsigned long /*event*/,
                                    void * /*callData*/ );
 
-  /// DisplayModifiedEvent is generated when display node parameters is changed
   /// ImageDataModifiedEvent is generated when image data is changed
   enum
     {

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -537,7 +537,8 @@ void vtkMRMLVolumeRenderingDisplayableManager
     {
     vtkNew<vtkIntArray> events;
     events->InsertNextValue(vtkMRMLTransformableNode::TransformModifiedEvent);
-    events->InsertNextValue(vtkMRMLScalarVolumeNode::ImageDataModifiedEvent);
+    events->InsertNextValue(vtkMRMLVolumeNode::ImageDataModifiedEvent);
+    events->InsertNextValue(vtkCommand::ModifiedEvent);
     vtkObserveMRMLNodeEventsMacro(volumeNode, events.GetPointer());
     }
   this->SetupMapperFromVolumeNode(volumeNode, this->GetVolumeMapper(vspNode), 0);
@@ -910,6 +911,16 @@ void vtkMRMLVolumeRenderingDisplayableManager
 
       this->UpdateClipping(this->GetVolumeMapper(vspNode), vspNode);
       this->RequestRender();
+      }
+    else if(vtkMRMLVolumeNode::SafeDownCast(caller))
+      {
+        node = reinterpret_cast<vtkMRMLNode *>(caller);
+        vtkMRMLVolumeRenderingDisplayNode* vspNode =
+          this->VolumeRenderingLogic->GetVolumeRenderingDisplayNodeForViewNode(
+          vtkMRMLVolumeNode::SafeDownCast(node),
+          this->GetMRMLViewNode());
+        this->SetupMapperFromParametersNode(vspNode);
+        this->RequestRender();
       }
     }
   else if (event == vtkCommand::StartEvent ||


### PR DESCRIPTION
To address issue 4023 the vtkMRMLVolumeRenderingDisplayableManager now observes the vtkCommand::Modified event on any rendered vtkMRMLVolumeNode