### PR TITLE
COMP: Fix some compilation errors in Visual Studio 2013

### DIFF
--- a/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
@@ -763,7 +763,7 @@
         ", green = " << node1->IsDisplayableInView(green) <<            \
         ", yellow = " << node1->IsDisplayableInView(yellow) <<          \
         ", 3D = " << node1->IsDisplayableInView(threeD) <<              \
-        std::cout;                                                      \
+        std::endl;                                                      \
       return EXIT_FAILURE;                                              \
       }                                                                 \
     node1->AddViewNodeID(green);                                        \
@@ -777,7 +777,7 @@
         ", green = " << node1->IsDisplayableInView(green) <<            \
         ", yellow = " << node1->IsDisplayableInView(yellow) <<          \
         ", 3D = " << node1->IsDisplayableInView(threeD) <<              \
-        std::cout;                                                      \
+        std::endl;                                                      \
       return EXIT_FAILURE;                                              \
       }                                                                 \
     node1->SetDisplayableOnlyInView(red);                               \
@@ -791,7 +791,7 @@
         ", green = " << node1->IsDisplayableInView(green) <<            \
         ", yellow = " << node1->IsDisplayableInView(yellow) <<          \
         ", 3D = " << node1->IsDisplayableInView(threeD) <<              \
-        std::cout;                                                      \
+        std::endl;                                                      \
       return EXIT_FAILURE;                                              \
       }                                                                 \
   }

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -50,6 +50,9 @@
 //
 #include "vtkImageLabelOutline.h"
 
+// STD includes
+#include <algorithm>
+
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkMRMLSliceLayerLogic);
 

--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -192,6 +192,9 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
       # VS2010
       set(OpenSSL_1.0.1h_1600_URL http://packages.kitware.com/download/item/6096/OpenSSL_1_0_1h-install-msvc1600-32.tar.gz)
       set(OpenSSL_1.0.1h_1600_MD5 e80269ae7969276977a342cccc1df5c5)
+      # VS2013
+      set(OpenSSL_1.0.1h_1800_URL http://packages.kitware.com/download/bitstream/8918/OpenSSL_1_0_1h-install-msvc1800-32.tar.gz)
+      set(OpenSSL_1.0.1h_1800_MD5 f10ceb422ab37f2b0bd5e225c74fd1d4)
 
       # OpenSSL 1.0.1l
       # VS2008
@@ -211,6 +214,9 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
       # VS2010
       set(OpenSSL_1.0.1h_1600_URL http://packages.kitware.com/download/item/6099/OpenSSL_1_0_1h-install-msvc1600-64.tar.gz)
       set(OpenSSL_1.0.1h_1600_MD5 b54a0a4b396397fdf96e55f0f7345dd1)
+      # VS2013
+      set(OpenSSL_1.0.1h_1800_URL http://packages.kitware.com/download/bitstream/8915/OpenSSL_1_0_1h-install-msvc1800-64.tar.gz)
+      set(OpenSSL_1.0.1h_1800_MD5 7aefdd94babefbe603cca48ff86da768)
 
       # OpenSSL 1.0.1l
       # VS2008


### PR DESCRIPTION
Tested compilation in Debug configuration. Requires disabling numpy and EMSegment module.