### PR TITLE
ENH: check for data that will get deleted on scene view restore

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -313,7 +313,7 @@ void vtkMRMLSceneViewNode::UpdateStoredScene()
   // prevent data read in UpdateScene
   for (n=0; n<nnodesSanpshot; n++)
     {
-    node  = dynamic_cast < vtkMRMLNode *>(this->SnapshotScene->GetNodes()->GetItemAsObject(n));
+    node  = vtkMRMLNode::SafeDownCast(this->SnapshotScene->GetNodes()->GetItemAsObject(n));
     if (node)
       {
       node->SetAddToSceneNoModify(0);
@@ -323,7 +323,7 @@ void vtkMRMLSceneViewNode::UpdateStoredScene()
   // update nodes in the snapshot
   for (n=0; n<nnodesSanpshot; n++)
     {
-    node  = dynamic_cast < vtkMRMLNode *>(this->SnapshotScene->GetNodes()->GetItemAsObject(n));
+    node  = vtkMRMLNode::SafeDownCast(this->SnapshotScene->GetNodes()->GetItemAsObject(n));
     if (node)
       {
       node->UpdateScene(this->SnapshotScene);
@@ -334,7 +334,7 @@ void vtkMRMLSceneViewNode::UpdateStoredScene()
   // update nodes in the snapshot
   for (n=0; n<nnodesSanpshot; n++)
     {
-    node  = dynamic_cast < vtkMRMLNode *>(this->Nodes->GetNodes()->GetItemAsObject(n));
+    node  = vtkMRMLNode::SafeDownCast(this->Nodes->GetNodes()->GetItemAsObject(n));
     if (node)
       {
       node->SetAddToSceneNoModify(1);
@@ -428,7 +428,79 @@ void vtkMRMLSceneViewNode::StoreScene()
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLSceneViewNode::RestoreScene()
+void vtkMRMLSceneViewNode::AddMissingNodes()
+{
+  if (this->Scene == NULL)
+    {
+    vtkWarningMacro("No scene to add nodes from");
+    return;
+    }
+  if (this->SnapshotScene == NULL)
+    {
+    vtkWarningMacro("No scene to add to");
+    return;
+    }
+  unsigned int numNodesInSceneView = this->SnapshotScene->GetNodes()->GetNumberOfItems();
+  unsigned int n;
+  vtkMRMLNode *node = NULL;
+  // build the list of nodes in the scene view
+  std::map<std::string, vtkMRMLNode*> snapshotMap;
+  for (n=0; n<numNodesInSceneView; n++)
+    {
+    node  = vtkMRMLNode::SafeDownCast(this->SnapshotScene->GetNodes()->GetItemAsObject(n));
+    if (node && node->GetID())
+      {
+      snapshotMap[node->GetID()] = node;
+      }
+    }
+  if (snapshotMap.size() == 0)
+    {
+    // no missing nodes
+    return;
+    }
+
+  // add the missing ones from the scene
+  vtkCollectionSimpleIterator it;
+  vtkCollection* sceneNodes = this->Scene->GetNodes();
+  int nodesAdded = 0;
+  for (sceneNodes->InitTraversal(it);
+       (node = vtkMRMLNode::SafeDownCast(sceneNodes->GetNextItemAsObject(it))) ;)
+    {
+    std::map<std::string, vtkMRMLNode*>::iterator iter = snapshotMap.find(std::string(node->GetID()));
+    // ignore scene view nodes, the snapshot clip nodes, hierarchy nodes associated with the
+    // sceneview nodes nor top level scene view hierarchy nodes
+    if (iter == snapshotMap.end() &&
+        this->IncludeNodeInSceneView(node) &&
+        node->GetSaveWithScene())
+      {
+      vtkDebugMacro("AddMissingNodes: Adding node with id " << node->GetID());
+
+      vtkSmartPointer<vtkMRMLNode> newNode = vtkSmartPointer<vtkMRMLNode>::Take(node->CreateNodeInstance());
+
+      newNode->SetScene(this->SnapshotScene);
+      newNode->CopyWithoutModifiedEvent(node);
+      newNode->SetID(node->GetID());
+
+      newNode->SetAddToSceneNoModify(1);
+      this->SnapshotScene->AddNode(newNode);
+      newNode->SetAddToSceneNoModify(0);
+
+      // sanity check
+      assert(newNode->GetScene() == this->SnapshotScene);
+
+      nodesAdded++;
+      }
+    }
+  vtkDebugMacro("AddMissingNodes: Added " << nodesAdded << " nodes to this scene view");
+  if (nodesAdded > 0)
+    {
+    // update references for any ids that got changed
+    this->SnapshotScene->UpdateNodeReferences();
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSceneViewNode::RestoreScene(bool removeNodes)
 {
   if (this->Scene == NULL)
     {
@@ -451,7 +523,7 @@ void vtkMRMLSceneViewNode::RestoreScene()
   std::map<std::string, vtkMRMLNode*> snapshotMap;
   for (n=0; n<numNodesInSceneView; n++)
     {
-    node  = dynamic_cast < vtkMRMLNode *>(this->SnapshotScene->GetNodes()->GetItemAsObject(n));
+    node  = vtkMRMLNode::SafeDownCast(this->SnapshotScene->GetNodes()->GetItemAsObject(n));
     if (node)
       {
       /***
@@ -501,7 +573,20 @@ void vtkMRMLSceneViewNode::RestoreScene()
     removedNodes.pop();
     if (isNodeInScene)
       {
-      this->Scene->RemoveNode(nodeToRemove);
+      if (removeNodes)
+        {
+        this->Scene->RemoveNode(nodeToRemove);
+        }
+      else
+        {
+        vtkErrorMacro("RestoreScene encountered a node in the scene that needs to be removed to restore the scene view '" << this->GetSceneViewDescription().c_str() << "'.\n\tNot removing node named '" << nodeToRemove->GetName() << "',\n\tReturning without restoring the scene.");
+        // signal that done trying to restore the scene
+        this->Scene->EndState(vtkMRMLScene::RestoreState);
+        // signal that there is an error state
+        this->Scene->SetErrorMessage("Unable to restore scene, data in main Slicer scene that is not included in the scene view");
+        this->Scene->SetErrorCode(1);
+        return;
+        }
       }
     }
 
@@ -601,7 +686,7 @@ void vtkMRMLSceneViewNode::SetAbsentStorageFileNames()
 
   for (n=0; n<numNodesInSceneView; n++)
     {
-    node  = dynamic_cast < vtkMRMLNode *>(this->SnapshotScene->GetNodes()->GetItemAsObject(n));
+    node  = vtkMRMLNode::SafeDownCast(this->SnapshotScene->GetNodes()->GetItemAsObject(n));
     if (node)
       {
       // for storage nodes replace full path with relative

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -80,8 +80,6 @@ void vtkMRMLSceneViewNode::WriteXML(ostream& of, int nIndent)
 void vtkMRMLSceneViewNode::WriteNodeBodyXML(ostream& of, int nIndent)
 {
   // first make sure that the scene view scene is to be saved relative to the same place as the main scene
-  const char *sceneURL = this->SnapshotScene->GetURL();
-  const char *rootDir = this->SnapshotScene->GetRootDirectory();
   this->SnapshotScene->SetRootDirectory(this->GetScene()->GetRootDirectory());
   this->SetAbsentStorageFileNames();
 

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.h
@@ -73,10 +73,18 @@ class VTK_MRML_EXPORT vtkMRMLSceneViewNode : public vtkMRMLStorableNode
   /// \sa GetStoredScene() RestoreScene()
   void StoreScene();
 
+  /// Add missing nodes from the Slicer scene to the stored scene
+  /// \sa RestoreScene()
+  void AddMissingNodes();
+
   ///
-  /// Restore content of the scene from the node
-  /// \sa GetStoredScene() StoreScene()
-  void RestoreScene();
+  /// Restore content of the scene from the node.
+  /// If removeNodes is true (default), remove nodes from the main Slicer scene that
+  /// do no appear in the scene view. If it is false, and nodes are found that will be
+  /// deleted, don't remove them, print a warning, set the scene error code to 1, save
+  /// the warning to the scene error message, and return.
+  /// \sa GetStoredScene() StoreScene() AddMissingNodes()
+  void RestoreScene(bool removeNodes = true);
 
   void SetAbsentStorageFileNames();
 

--- a/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleWidget.cxx
+++ b/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleWidget.cxx
@@ -21,6 +21,7 @@
 #include <QMessageBox>
 #include <QPrintDialog>
 #include <QPrinter>
+#include <QPushButton>
 #include <QSettings>
 #include <QStatusBar>
 #include <QTextBrowser>
@@ -295,32 +296,42 @@ void qSlicerSceneViewsModuleWidget::restoreSceneView(const QString& mrmlId)
     // ask if the user wishes to save the current scene nodes, retore and delete them or cancel
     ctkMessageBox missingNodesMsgBox;
     missingNodesMsgBox.setWindowTitle("Data missing from Scene View");
-    QString labelText = QString(
+    vtkMRMLSceneViewNode* viewNode = vtkMRMLSceneViewNode::SafeDownCast(this->mrmlScene()->GetNodeByID(mrmlId.toLatin1()));
+    QString sceneViewName;
+    if (viewNode)
+      {
+      sceneViewName = QString(viewNode->GetName());
+      }
+    QString labelText = QString("Add data to scene view \"")
+      + sceneViewName
+      + QString("\" before restoring?\n"
+                "\n");
+    QString infoText = QString(
       "Data is present in the current scene but not in the scene view.\n"
       "\n"
-      "Continue restoring and Discard data, Save missing data to this scene view, or Cancel?\n"
-      "\n"
-      "Saved Volumes may not be shown in slice views after restore.\n"
-      "Default if don't show again: Save.");
-    missingNodesMsgBox.setText(labelText);
+      "If you don't add and restore, data not already saved to disk"
+      ", or saved in another scene view,"
+      " will be permanently lost!\n");
+    missingNodesMsgBox.setText(labelText + infoText);
+    // until CTK bug is fixed, informative text will overlap the don't show
+    // again message so put it all in the label text
+    // missingNodesMsgBox.setInformativeText(infoText);
     QPushButton *continueButton = missingNodesMsgBox.addButton(QMessageBox::Discard);
+    continueButton->setText("Restore without saving");
     QPushButton *addButton = missingNodesMsgBox.addButton(QMessageBox::Save);
+    addButton->setText("Add and Restore");
     missingNodesMsgBox.addButton(QMessageBox::Cancel);
 
-    missingNodesMsgBox.setIcon(QMessageBox::Question);
+    missingNodesMsgBox.setIcon(QMessageBox::Warning);
     missingNodesMsgBox.setDontShowAgainVisible(true);
     missingNodesMsgBox.setDontShowAgainSettingsKey("SceneViewsModule/AlwaysRemoveNodes");
-    missingNodesMsgBox.exec();
-    if (missingNodesMsgBox.clickedButton() != 0)
+    int ret = missingNodesMsgBox.exec();
+    switch (ret)
       {
-      if (missingNodesMsgBox.buttonRole(missingNodesMsgBox.clickedButton()) == QMessageBox::DestructiveRole)
-        {
+      case QMessageBox::Discard:
         d->logic()->RestoreSceneView(mrmlId.toLatin1(), true);
-        }
-      else if (missingNodesMsgBox.buttonRole(missingNodesMsgBox.clickedButton()) == QMessageBox::AcceptRole)
-        {
-        // add nodes to the scene
-        vtkMRMLSceneViewNode* viewNode = vtkMRMLSceneViewNode::SafeDownCast(this->mrmlScene()->GetNodeByID(mrmlId.toLatin1()));
+        break;
+      case QMessageBox::Save:
         if (viewNode)
           {
           viewNode->AddMissingNodes();
@@ -328,9 +339,13 @@ void qSlicerSceneViewsModuleWidget::restoreSceneView(const QString& mrmlId)
           // and restore again
           d->logic()->RestoreSceneView(mrmlId.toLatin1(), false);
           }
-        }
+        break;
+      case QMessageBox::Cancel:
+      default:
+        break;
       }
     }
+
   qSlicerApplication::application()->mainWindow()->statusBar()->showMessage("The SceneView was restored including the attached scene.", 2000);
 }
 

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -285,7 +285,7 @@ vtkImageData* vtkSlicerSceneViewsModuleLogic::GetSceneViewScreenshot(const char*
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerSceneViewsModuleLogic::RestoreSceneView(const char* id)
+void vtkSlicerSceneViewsModuleLogic::RestoreSceneView(const char* id, bool removeNodes)
 {
   if (!this->GetMRMLScene())
     {
@@ -302,7 +302,8 @@ void vtkSlicerSceneViewsModuleLogic::RestoreSceneView(const char* id)
     }
 
   this->GetMRMLScene()->SaveStateForUndo();
-  viewNode->RestoreScene();
+
+  viewNode->RestoreScene(removeNodes);
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.h
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.h
@@ -74,8 +74,10 @@ public:
   /// Return the screenshot of an existing sceneView.
   vtkImageData* GetSceneViewScreenshot(const char* id);
 
-  /// Restore an sceneView.
-  void RestoreSceneView(const char* id);
+  /// Restore a sceneView.
+  /// If removeNodes flag is false, don't restore the scene if it will remove data.
+  /// removeNodes defaults to true for backward compatibility.
+  void RestoreSceneView(const char* id, bool removeNodes = true);
 
   /// Move sceneView up
   const char* MoveSceneViewUp(const char* id);

--- a/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
+++ b/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
@@ -213,4 +213,28 @@ class AddStorableDataAfterSceneViewTestTest(ScriptedLoadableModuleTest):
     self.assertTrue( restoredData == None )
     self.delayDisplay('Success: extra storable node removed with scene view restore')
 
+
+    #
+    # add new storable again
+    mrHeadVolume = sampleDataLogic.downloadMRHead()
+    mrHeadID = mrHeadVolume.GetID()
+
+    #
+    # restore the scene view, but error on removing nodes
+    #
+    self.delayDisplay("Restoring the scene view with check for removed nodes")
+    sv.RestoreScene(0)
+
+    #
+    # Is the new storable data still present?
+    #
+    restoredData = slicer.mrmlScene.GetNodeByID(mrHeadID)
+
+    # in this case the non scene view storable data is kept' scene is not changed
+    self.assertTrue( restoredData != None )
+    self.delayDisplay('Success: extra storable node NOT removed with scene view restore')
+
+    print 'Scene error code = ' + str(slicer.mrmlScene.GetErrorCode())
+    print '\t' + slicer.mrmlScene.GetErrorMessage()
+
     self.delayDisplay('Test passed!')


### PR DESCRIPTION
Added a flag to the scene view node restore call that will cancel if
any nodes come up as being in the main Slicer scene but not in the
scene view scene about to be restored.
Added a method to add nodes to the scene view scene that are in the
main Slicer scene but not in the scene view.
Updated the GUI for restoring scenes via the tool bar and the Scene
Views module to pop up message boxes to give the user options to
discard the data, save it to the scene view, or cancel the restore.
Updated the test to include a failure case when removing nodes
is not allowed.
Unify scene view node to use SafeDownCast instead of a mix of
dynamic_cast and SafeDownCast.

Issue #3956