### PR TITLE
BUG: Fix Extension Wizard to write icon files correctly on Windows

### DIFF
--- a/Utilities/Scripts/SlicerWizard/TemplateManager.py
+++ b/Utilities/Scripts/SlicerWizard/TemplateManager.py
@@ -82,7 +82,7 @@ class TemplateManager(object):
 
     # Read file contents
     p = os.path.join(template, inFile)
-    with open(p) as fp:
+    with open(p, "rb") as fp:
       contents = fp.read()
 
     # Replace template key with copy name
@@ -111,7 +111,7 @@ class TemplateManager(object):
         pass
 
     # Write adjusted contents
-    with open(outFile, "w") as fp:
+    with open(outFile, "wb") as fp:
       fp.write(contents)
 
   #---------------------------------------------------------------------------


### PR DESCRIPTION
On Windows, slicerExtensionWizard creates invalid icon files for
extensions and modules. This happens because the script treats all
template files as text when opening them to replace the template key,
including the PNG icon files.

This changes the script to open and write files in binary mode.

Fixes #4027.