### PR TITLE
ENH: Adding boolean property to control behavior

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
@@ -62,6 +62,8 @@ public:
 public:
   QColor DefaultNodeColor;
 
+  bool EnterPlaceModeOnNodeChange;
+
   vtkWeakPointer<vtkSlicerMarkupsLogic> MarkupsLogic;
   vtkWeakPointer<vtkMRMLMarkupsNode> CurrentMarkupsNode;
   vtkWeakPointer<vtkMRMLSelectionNode> SelectionNode;
@@ -69,7 +71,9 @@ public:
 };
 
 // --------------------------------------------------------------------------
-qSlicerSimpleMarkupsWidgetPrivate::qSlicerSimpleMarkupsWidgetPrivate( qSlicerSimpleMarkupsWidget& object) : q_ptr(&object)
+qSlicerSimpleMarkupsWidgetPrivate::qSlicerSimpleMarkupsWidgetPrivate( qSlicerSimpleMarkupsWidget& object) 
+  : q_ptr(&object)
+  , EnterPlaceModeOnNodeChange(true)
 {
 }
 
@@ -216,6 +220,22 @@ void qSlicerSimpleMarkupsWidget::setDefaultNodeColor(QColor color)
   Q_D(qSlicerSimpleMarkupsWidget);
 
   d->DefaultNodeColor = color;
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerSimpleMarkupsWidget::enterPlaceModeOnNodeChange() const
+{
+  Q_D(const qSlicerSimpleMarkupsWidget);
+
+  return d->EnterPlaceModeOnNodeChange;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSimpleMarkupsWidget::setEnterPlaceModeOnNodeChange(bool enterPlaceMode)
+{
+  Q_D(qSlicerSimpleMarkupsWidget);
+
+  d->EnterPlaceModeOnNodeChange = enterPlaceMode;
 }
 
 //-----------------------------------------------------------------------------
@@ -448,10 +468,12 @@ void qSlicerSimpleMarkupsWidget::onMarkupsFiducialNodeChanged()
     if ( currentMarkupsNode != NULL )
       {
       d->MarkupsLogic->SetActiveListID( currentMarkupsNode ); // If there are other widgets, they are responsible for updating themselves
-      interactionNode->SetCurrentInteractionMode( vtkMRMLInteractionNode::Place );
-      // interactionNode->SetPlaceModePersistence( true ); // Use whatever persistence the user has already set
+      if( d->EnterPlaceModeOnNodeChange )
+        {
+        interactionNode->SetCurrentInteractionMode( vtkMRMLInteractionNode::Place );
+        }
       }
-    else
+    else if( d->EnterPlaceModeOnNodeChange )
       {
       interactionNode->SetCurrentInteractionMode( vtkMRMLInteractionNode::ViewTransform );
       }

--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.h
@@ -38,6 +38,7 @@ class Q_SLICER_MODULE_MARKUPS_WIDGETS_EXPORT
 qSlicerSimpleMarkupsWidget : public qSlicerWidget
 {
   Q_OBJECT
+  Q_PROPERTY(bool enterPlaceModeOnNodeChange READ enterPlaceModeOnNodeChange WRITE setEnterPlaceModeOnNodeChange)
 
 public:
   typedef qSlicerWidget Superclass;
@@ -49,6 +50,10 @@ public:
 
   /// Deprecated. Use currentNode() instead.
   Q_INVOKABLE vtkMRMLNode* getCurrentNode();
+
+  /// Accessors to control place mode behavior
+  void setEnterPlaceModeOnNodeChange(bool);
+  bool enterPlaceModeOnNodeChange() const;
   
 public slots:
   /// Set the currently selected markups node.


### PR DESCRIPTION
By default the qSlicerSimpleMarkupsWidget entered place mode when a fiducial list was chosen in the drop down. This behavior was not desirable to me so I made it controllable with a boolean set to True by default.