### PR TITLE
BUG: fix creating new extension

### DIFF
--- a/Modules/Scripted/ExtensionWizard/ExtensionWizard.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizard.py
@@ -214,9 +214,10 @@ class ExtensionWizardWidget:
         
         if repo is None:
           destination = os.path.join(dlg.destination, dlg.componentName)
-          if os.path.exists(dlg.destination):
+          if os.path.exists(destination):
             raise IOError("create extension: refusing to overwrite"
-                          " existing directory '%s'" % dlg.destination)
+                          " existing directory '%s'" % destination)
+          createInSubdirectory = False
 
         else:
           destination = SlicerWizard.Utilities.localRoot(repo)


### PR DESCRIPTION
Wrong variable was being checked for directory existence.

Creates new directory in selected target.