### PR TITLE
BUG: remove extra node added event

### DIFF
--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -772,10 +772,6 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
   this->GetMRMLScene()->EndState(vtkMRMLScene::BatchProcessState);
   if (modified)
     {
-    // since added the node to the test scene, let the scene know now that it
-    // has a new node
-    this->GetMRMLScene()->InvokeEvent(vtkMRMLScene::NodeAddedEvent, volumeNode);
-
     this->Modified();
     }
   return volumeNode;


### PR DESCRIPTION
When switching to using a mini scene to try various ways of
loading volumes, the final node added event wasn't removed
when I switched to using AddNode to move the final set of
nodes into the main scene. This change removes the extra
node added event triggered by adding a volume.

Issue #4033