### PR TITLE
COMP: Allow building EMSegment with C++11

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -261,7 +261,7 @@ list_conditional_append(Slicer_BUILD_BRAINSTOOLS Slicer_REMOTE_DEPENDENCIES BRAI
 
 Slicer_Remote_Add(EMSegment
   SVN_REPOSITORY "http://svn.slicer.org/Slicer3/branches/Slicer4-EMSegment"
-  SVN_REVISION -r "17105"
+  SVN_REVISION -r "17106"
   OPTION_NAME Slicer_BUILD_EMSegment
   OPTION_DEPENDS "Slicer_BUILD_BRAINSTOOLS;Slicer_BUILD_QTLOADABLEMODULES;Slicer_USE_PYTHONQT_WITH_TCL"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
EMSegment/CommandLineApplication/EMSegmentAPIHelper.h:112:21: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
  cout << "Setting "Slicer_HOME_ENVVAR_NAME" ..." << endl;