### PR TITLE
BUG: Default parameters allowed incorrect usage

### DIFF
--- a/Base/QTGUI/qSlicerNodeWriter.h
+++ b/Base/QTGUI/qSlicerNodeWriter.h
@@ -39,8 +39,8 @@ public:
   qSlicerNodeWriter(const QString& description,
                     const qSlicerIO::IOFileType& fileType,
                     const QStringList& nodeTags,
-                    bool useCompression = true,
-                    QObject* parent = 0);
+                    bool useCompression,
+                    QObject* parent);
 
   virtual ~qSlicerNodeWriter();
 

--- a/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
+++ b/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
@@ -90,7 +90,7 @@ void qSlicerAnnotationsModule::setup()
 
   ioManager->registerIO(new qSlicerNodeWriter(
     "Annotations", QString("AnnotationFile"),
-    QStringList() << "vtkMRMLAnnotationNode", this));
+    QStringList() << "vtkMRMLAnnotationNode", true, this));
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Colors/qSlicerColorsModule.cxx
+++ b/Modules/Loadable/Colors/qSlicerColorsModule.cxx
@@ -102,7 +102,7 @@ void qSlicerColorsModule::setup()
     new qSlicerColorsReader(colorLogic, this));
   app->coreIOManager()->registerIO(new qSlicerNodeWriter(
     "Colors", QString("ColorTableFile"),
-    QStringList() << "vtkMRMLColorNode", this));
+    QStringList() << "vtkMRMLColorNode", true, this));
 
   QStringList paths = app->userSettings()->value("QTCoreModules/Colors/ColorFilePaths").toStringList();
 #ifdef Q_OS_WIN32

--- a/Modules/Loadable/DoubleArrays/qSlicerDoubleArraysModule.cxx
+++ b/Modules/Loadable/DoubleArrays/qSlicerDoubleArraysModule.cxx
@@ -108,7 +108,7 @@ void qSlicerDoubleArraysModule::setup()
   ioManager->registerIO(new qSlicerDoubleArraysReader(doubleArraysLogic,this));
   ioManager->registerIO(new qSlicerNodeWriter(
     "Double Arrays", QString("DoubleArrayFile"),
-    QStringList() << "vtkMRMLDoubleArrayNode", this));
+    QStringList() << "vtkMRMLDoubleArrayNode", true, this));
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -135,7 +135,7 @@ void qSlicerMarkupsModule::setup()
   ioManager->registerIO(markupsIO);
   ioManager->registerIO(new qSlicerNodeWriter(
                             "MarkupsFiducials", markupsIO->fileType(),
-                            QStringList() << "vtkMRMLMarkupsNode", this));
+                            QStringList() << "vtkMRMLMarkupsNode", true, this));
 
   // settings
   /*

--- a/Modules/Loadable/Models/qSlicerModelsModule.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsModule.cxx
@@ -162,7 +162,7 @@ void qSlicerModelsModule::setup()
     ioManager->registerDialog(new qSlicerModelsDialog(this));
     ioManager->registerIO(new qSlicerNodeWriter(
       "Models", QString("ModelFile"),
-      QStringList() << "vtkMRMLModelNode", this));
+      QStringList() << "vtkMRMLModelNode", true, this));
     }
 
   // Register Subject Hierarchy core plugins

--- a/Modules/Loadable/SceneViews/qSlicerSceneViewsModule.cxx
+++ b/Modules/Loadable/SceneViews/qSlicerSceneViewsModule.cxx
@@ -46,7 +46,7 @@ void qSlicerSceneViewsModule::setup()
     qSlicerApplication::application()->coreIOManager();
   ioManager->registerIO(new qSlicerNodeWriter(
     "SceneViews", QString("SceneViewFile"),
-    QStringList() << "vtkMRMLSceneViewNode", this));
+    QStringList() << "vtkMRMLSceneViewNode", true, this));
 
   // Register Subject Hierarchy core plugins
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(

--- a/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.cxx
+++ b/Modules/Loadable/TractographyDisplay/qSlicerTractographyDisplayModule.cxx
@@ -65,7 +65,7 @@ void qSlicerTractographyDisplayModule::setup()
     new qSlicerFiberBundleReader(fiberBundleLogic, this));
   coreIOManager->registerIO(new qSlicerNodeWriter(
     "FiberBundles", QString("FiberBundleFile"),
-    QStringList() << "vtkMRMLFiberBundleNode", this));
+    QStringList() << "vtkMRMLFiberBundleNode", true, this));
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Transforms/qSlicerTransformsModule.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModule.cxx
@@ -146,7 +146,7 @@ void qSlicerTransformsModule::setup()
     new qSlicerTransformsReader(transformLogic, this));
   app->coreIOManager()->registerIO(new qSlicerNodeWriter(
     "Transforms", QString("TransformFile"),
-    QStringList() << "vtkMRMLTransformNode", this));
+    QStringList() << "vtkMRMLTransformNode", true, this));
 
   // Use the displayable manager class to make sure the the containing library is loaded
   vtkSmartPointer<vtkMRMLTransformsDisplayableManager2D> dm2d=vtkSmartPointer<vtkMRMLTransformsDisplayableManager2D>::New();

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
@@ -149,7 +149,7 @@ void qSlicerVolumeRenderingModule::setup()
     new qSlicerVolumeRenderingReader(volumeRenderingLogic, this));
   coreIOManager->registerIO(new qSlicerNodeWriter(
     "Transfer Function", QString("TransferFunctionFile"),
-    QStringList() << "vtkMRMLVolumePropertyNode", this));
+    QStringList() << "vtkMRMLVolumePropertyNode", true, this));
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
@@ -150,7 +150,7 @@ void qSlicerVolumesModule::setup()
   ioManager->registerIO(new qSlicerVolumesReader(volumesLogic,this));
   ioManager->registerIO(new qSlicerNodeWriter(
     "Volumes", QString("VolumeFile"),
-    QStringList() << "vtkMRMLVolumeNode", this));
+    QStringList() << "vtkMRMLVolumeNode", true, this));
 
   // Register Subject Hierarchy core plugins
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyVolumesPlugin());


### PR DESCRIPTION
Slicer/Modules/Loadable/Models/qSlicerModelsModule.cxx:165:44: warning: 'this' pointer cannot be null in
      well-defined C++ code; pointer may be assumed to always convert to true [-Wundefined-bool-conversion]
      QStringList() << "vtkMRMLModelNode", this));
                                           ^~~~

The 'this' pointer was interpreted as boolean.  To ensure complete proper usage, the default
parameters were removed, thus forcing compiler errors that were easy to identify and fix.