### PR TITLE
ENH: Create function GetValue()

### DIFF
--- a/Libs/MRML/Core/Testing/CMakeLists.txt
+++ b/Libs/MRML/Core/Testing/CMakeLists.txt
@@ -108,6 +108,7 @@ set_target_properties(${KIT}CxxTests PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER}
 
 #-----------------------------------------------------------------------------
 set(TEMP "${CMAKE_BINARY_DIR}/Testing/Temporary")
+set(DATAPATH "${CMAKE_CURRENT_SOURCE_DIR}/TestData")
 
 #-----------------------------------------------------------------------------
 simple_test( vtkMRMLBSplineTransformNodeTest1 )
@@ -127,7 +128,7 @@ simple_test( vtkMRMLDiffusionWeightedVolumeDisplayNodeTest1 )
 simple_test( vtkMRMLDiffusionWeightedVolumeNodeTest1 )
 simple_test( vtkMRMLDisplayableNodeTest1 )
 simple_test( vtkMRMLDisplayNodeTest1 )
-simple_test( vtkMRMLDoubleArrayNodeTest1 )
+simple_test( vtkMRMLDoubleArrayNodeTest1 ${TEMP} ${DATAPATH})
 simple_test( vtkMRMLFiducialListNodeTest1 )
 simple_test( vtkMRMLFiducialListStorageNodeTest1 )
 simple_test( vtkMRMLFreeSurferModelOverlayStorageNodeTest1 )

--- a/Libs/MRML/Core/Testing/TestData/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv
+++ b/Libs/MRML/Core/Testing/TestData/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv
@@ -1,0 +1,5 @@
+# measurement file /path/to/Slicer/Libs/MRML/Core/Testing/TestData/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv
+# columns = x,y,yerr
+x,y,yerr
+12.1,425.577,-454
+8.79633e+09,0,-1

--- a/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
@@ -10,18 +10,237 @@
 
 =========================================================================auto=*/
 
-#include "vtkMRMLDoubleArrayNode.h"
-
-
+// MRML includes
 #include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLDoubleArrayNode.h"
+#include "vtkMRMLDoubleArrayStorageNode.h"
 
-int vtkMRMLDoubleArrayNodeTest1(int , char * [] )
+// VTK includes
+#include <vtkNew.h>
+
+// STD includes
+#include <vector>
+#include <sstream>
+
+//---------------------------------------------------------------------------
+bool TestSetValues();
+bool TestSetValue();
+bool TestSetXYValue();
+bool TestSetXYerrValue();
+bool TestAddValues();
+bool TestAddValue();
+bool TestAddXYValue();
+bool TestAddXYerrValue();
+
+//---------------------------------------------------------------------------
+int vtkMRMLDoubleArrayNodeTest1(int argc, char * argv[])
 {
-  vtkSmartPointer< vtkMRMLDoubleArrayNode > node1 = vtkSmartPointer< vtkMRMLDoubleArrayNode >::New();
+  vtkNew<vtkMRMLDoubleArrayNode> node1;
 
-  EXERCISE_BASIC_OBJECT_METHODS( node1 );
+  EXERCISE_BASIC_OBJECT_METHODS(node1.GetPointer());
 
-  EXERCISE_BASIC_MRML_METHODS(vtkMRMLDoubleArrayNode, node1);
+  EXERCISE_BASIC_MRML_METHODS(vtkMRMLDoubleArrayNode, node1.GetPointer());
 
-  return EXIT_SUCCESS;
+  bool res = true;
+  res = res && TestSetValues();
+  res = res && TestSetValue();
+  res = res && TestSetXYValue();
+  res = res && TestSetXYerrValue();
+  res = res && TestAddValues();
+  res = res && TestAddValue();
+  res = res && TestAddXYValue();
+  res = res && TestAddXYerrValue();
+
+  return res ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+//---------------------------------------------------------------------------
+bool doubleArrayMatch(int line, double array1[], double array2[],
+	unsigned int sizeOfArray)
+{
+  for(unsigned int i = 0; i < sizeOfArray; i++)
+    {
+    std::ostringstream s1;
+    std::ostringstream s2;
+    s1 << array1[i];
+    s2 << array2[i];
+    if( s1.str() != s2.str() )
+      {
+      std::cerr << "Line " << line
+	      << " - Array do not match !\n"
+	      << array1[i] << " not equal to " << array2[i]
+	      << std::endl;
+      return false;
+      }
+    }
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool TestSetValues()
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArray;
+  doubleArray->SetSize(2);
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+  double testArray2[3];
+  double testArray3[3];
+
+  bool res = true;
+  res = res && doubleArray->SetValues(0, testArray0);
+  res = res && doubleArray->SetValues(1, testArray1);
+  res = res && doubleArray->GetValues(0, testArray2);
+  res = res && doubleArray->GetValues(1, testArray3);
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestSetValue()
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArray;
+  doubleArray->SetSize(2);
+  double testSet[3] = { 12.1, 4255444465.576817, -454};
+  double testGet[3];
+
+  bool res = true;
+  res = res && doubleArray->SetValue(0, 0, testSet[0]);
+  res = res && doubleArray->SetValue(0, 1, testSet[1]);
+  res = res && doubleArray->SetValue(1, 1, testSet[2]);
+  int success0;
+  testGet[0] = doubleArray->GetValue(0, 0, success0);
+  int success1;
+  testGet[1] = doubleArray->GetValue(0, 1, success1);
+  int success2;
+  testGet[2] = doubleArray->GetValue(1, 1, success2);
+  res = res && doubleArrayMatch(__LINE__, testSet, testGet, 3);
+
+  return (res && success0 && success1 && success2);
+}
+
+//---------------------------------------------------------------------------
+bool TestSetXYValue()
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArray;
+  doubleArray->SetSize(2);
+  double testArray0[2] = { 12.1, -454};
+  double testArray1[2] = { 8796325425.01, -1};
+  double testArray2[2];
+  double testArray3[2];
+
+  bool res = true;
+  res = res && doubleArray->SetXYValue(0, testArray0[0], testArray0[1]);
+  res = res && doubleArray->SetXYValue(1, testArray1[0], testArray1[1]);
+  res = res && doubleArray->GetXYValue(0, &testArray2[0], &testArray2[1]);
+  res = res && doubleArray->GetXYValue(1, &testArray3[0], &testArray3[1]);
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 2);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 2);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestSetXYerrValue()
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArray;
+  doubleArray->SetSize(2);
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+  double testArray2[3];
+  double testArray3[3];
+
+  bool res = true;
+  res = res && doubleArray->SetXYValue(0, testArray0[0], testArray0[1], testArray0[2]);
+  res = res && doubleArray->SetXYValue(1, testArray1[0], testArray1[1], testArray1[2]);
+  res = res && doubleArray->GetXYValue(0, &testArray2[0], &testArray2[1], &testArray2[2]);
+  res = res && doubleArray->GetXYValue(1, &testArray3[0], &testArray3[1], &testArray3[2]);
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestAddValues()
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArray;
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+  double testArray2[3];
+  double testArray3[3];
+
+  bool res = true;
+  res = res && doubleArray->AddValues(testArray0);
+  res = res && doubleArray->AddValues(testArray1);
+  res = res && doubleArray->GetValues(0, testArray2);
+  res = res && doubleArray->GetValues(1, testArray3);
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestAddValue()
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArray;
+  double testSet[3] = { 12.1, 4255444465.576817, -454};
+  double testGet[3];
+
+  bool res = true;
+  res = res && doubleArray->AddValue(0, testSet[0]);
+  res = res && doubleArray->AddValue(2, testSet[1]);
+  res = res && doubleArray->AddValue(1, testSet[2]);
+
+  int success0;
+  testGet[0] = doubleArray->GetValue(0, 0, success0);
+  int success1;
+  testGet[1] = doubleArray->GetValue(1, 2, success1);
+  int success2;
+  testGet[2] = doubleArray->GetValue(2, 1, success2);
+  res = res && doubleArrayMatch(__LINE__, testSet, testGet, 3);
+
+  return (res && success0 && success1 && success2);
+}
+
+//---------------------------------------------------------------------------
+bool TestAddXYValue()
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArray;
+  double testArray0[2] = { 12.1, -454};
+  double testArray1[2] = { 8796325425.01, -1};
+  double testArray2[2];
+  double testArray3[2];
+
+  bool res = true;
+  res = res && doubleArray->AddXYValue(testArray0[0], testArray0[1]);
+  res = res && doubleArray->AddXYValue(testArray1[0], testArray1[1]);
+  res = res && doubleArray->GetXYValue(0, &testArray2[0], &testArray2[1]);
+  res = res && doubleArray->GetXYValue(1, &testArray3[0], &testArray3[1]);
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 2);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 2);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestAddXYerrValue()
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArray;
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+  double testArray2[3];
+  double testArray3[3];
+
+  bool res = true;
+  res = res && doubleArray->AddXYValue(testArray0[0], testArray0[1], testArray0[2]);
+  res = res && doubleArray->AddXYValue(testArray1[0], testArray1[1], testArray1[2]);
+  res = res && doubleArray->GetXYValue(0, &testArray2[0], &testArray2[1], &testArray2[2]);
+  res = res && doubleArray->GetXYValue(1, &testArray3[0], &testArray3[1], &testArray3[2]);
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+
+  return res;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
@@ -31,6 +31,9 @@ bool TestAddValues();
 bool TestAddValue();
 bool TestAddXYValue();
 bool TestAddXYerrValue();
+bool TestReadFileWithLabels(std::string filepath);
+bool TestReadFileWithoutLabels(std::string filepath);
+bool TestReadOldFile(std::string filepath);
 
 //---------------------------------------------------------------------------
 int vtkMRMLDoubleArrayNodeTest1(int argc, char * argv[])
@@ -41,6 +44,22 @@ int vtkMRMLDoubleArrayNodeTest1(int argc, char * argv[])
 
   EXERCISE_BASIC_MRML_METHODS(vtkMRMLDoubleArrayNode, node1.GetPointer());
 
+  if (argc != 3)
+    {
+    std::cerr << "Line " << __LINE__
+	      << " - Missing parameters !\n"
+	      << "Usage: " << argv[0] << " /path/to/temp /path/to/testdata"
+	      << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const char* tempDir = argv[1];
+  const char* dataDir = argv[2];
+
+  std::string fileNameOldFile = std::string(dataDir) + "/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv";
+  std::string fileNameWithLabels = std::string(tempDir) + "/vtkMRMLDoubleArrayNodeTest1_WithLabels.mcsv";
+  std::string fileNameWithoutLabels = std::string(tempDir) + "/vtkMRMLDoubleArrayNodeTest1_WithoutLabels.mcsv";
+
   bool res = true;
   res = res && TestSetValues();
   res = res && TestSetValue();
@@ -50,6 +69,9 @@ int vtkMRMLDoubleArrayNodeTest1(int argc, char * argv[])
   res = res && TestAddValue();
   res = res && TestAddXYValue();
   res = res && TestAddXYerrValue();
+  res = res && TestReadFileWithLabels(fileNameWithLabels);
+  res = res && TestReadFileWithoutLabels(fileNameWithoutLabels);
+  res = res && TestReadOldFile(fileNameOldFile);
 
   return res ? EXIT_SUCCESS : EXIT_FAILURE;
 }
@@ -69,6 +91,24 @@ bool doubleArrayMatch(int line, double array1[], double array2[],
       std::cerr << "Line " << line
 	      << " - Array do not match !\n"
 	      << array1[i] << " not equal to " << array2[i]
+	      << std::endl;
+      return false;
+      }
+    }
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool labelsMatch(int line, std::vector< std::string > labels1,
+	std::vector< std::string > labels2, unsigned int sizeOfArray)
+{
+  for(unsigned int i = 0; i < sizeOfArray; i++)
+    {
+    if( labels1[i] != labels2[i] )
+      {
+      std::cerr << "Line " << line
+	      << " - Labels do not match !\n"
+	      << labels1[i] << " not equal to " << labels2[i]
 	      << std::endl;
       return false;
       }
@@ -241,6 +281,111 @@ bool TestAddXYerrValue()
   res = res && doubleArray->GetXYValue(1, &testArray3[0], &testArray3[1], &testArray3[2]);
   res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
   res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestReadFileWithLabels(std::string filepath)
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayIn;
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+  std::vector< std::string > labelsIn;
+  labelsIn.push_back("x");
+  labelsIn.push_back("y");
+  labelsIn.push_back("yerr");
+
+  doubleArrayIn->AddValues(testArray0);
+  doubleArrayIn->AddValues(testArray1);
+  doubleArrayIn->SetLabels(labelsIn);
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayWrite;
+  doubleArrayWrite->SetFileName(filepath.c_str());
+  doubleArrayWrite->WriteData(doubleArrayIn.GetPointer());
+
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayOut;
+  double testArray2[3];
+  double testArray3[3];
+  std::vector< std::string > labelsOut(3);
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayRead;
+  doubleArrayRead->SetFileName(filepath.c_str());
+  doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
+
+  doubleArrayOut->GetValues(0, testArray2);
+  doubleArrayOut->GetValues(1, testArray3);
+  labelsOut = doubleArrayOut->GetLabels();
+
+  bool res = true;
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+  res = res && labelsMatch(__LINE__, labelsIn, labelsOut, 3);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestReadFileWithoutLabels(std::string filepath)
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayIn;
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+
+  doubleArrayIn->AddValues(testArray0);
+  doubleArrayIn->AddValues(testArray1);
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayWrite;
+  doubleArrayWrite->SetFileName(filepath.c_str());
+  doubleArrayWrite->WriteData(doubleArrayIn.GetPointer());
+
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayOut;
+  double testArray2[3];
+  double testArray3[3];
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayRead;
+  doubleArrayRead->SetFileName(filepath.c_str());
+  doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
+
+  doubleArrayOut->GetValues(0, testArray2);
+  doubleArrayOut->GetValues(1, testArray3);
+
+  bool res = true;
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestReadOldFile(std::string filepath)
+{
+  // Set values from 'TestData/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv'
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayIn;
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+  std::vector< std::string > labelsIn;
+  labelsIn.push_back("x");
+  labelsIn.push_back("y");
+  labelsIn.push_back("yerr");
+
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayOut;
+  double testArray2[3];
+  double testArray3[3];
+  std::vector< std::string > labelsOut(3);
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayRead;
+  doubleArrayRead->SetFileName(filepath.c_str());
+  doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
+
+  doubleArrayOut->GetValues(0, testArray2);
+  doubleArrayOut->GetValues(1, testArray3);
+  labelsOut = doubleArrayOut->GetLabels();
+
+  bool res = true;
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+  res = res && labelsMatch(__LINE__, labelsIn, labelsOut, 3);
 
   return res;
 }

--- a/Libs/MRML/Core/vtkMRMLDoubleArrayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDoubleArrayNode.cxx
@@ -22,6 +22,7 @@ Version:   $Revision: 1.2 $
 
 // STD includes
 #include <sstream>
+#include <vector>
 
 //------------------------------------------------------------------------------
 vtkCxxSetObjectMacro(vtkMRMLDoubleArrayNode, Array, vtkDoubleArray)
@@ -259,6 +260,37 @@ unsigned int vtkMRMLDoubleArrayNode::GetSize()
 
 
 //----------------------------------------------------------------------------
+int vtkMRMLDoubleArrayNode::GetValues(int index, double* values)
+{
+  if (index < 0 ||
+    index >= this->Array->GetNumberOfTuples())
+    {
+    return 0;
+    }
+  this->Array->GetTupleValue(index, values);
+  return 1;
+}
+
+
+//----------------------------------------------------------------------------
+double vtkMRMLDoubleArrayNode::GetValue(int index, int component, int& success)
+{
+  if (component < 0 ||
+    component >= this->Array->GetNumberOfComponents() ||
+    index < 0 ||
+    index >= this->Array->GetNumberOfTuples())
+    {
+    success = 0;
+    return -1;
+    }
+  std::vector<double> tuple(this->Array->GetNumberOfComponents());
+  success = this->GetValues(index, &tuple[0]);
+
+  return tuple[component];
+}
+
+
+//----------------------------------------------------------------------------
 double vtkMRMLDoubleArrayNode::GetYAxisValue(double vtkNotUsed(x), int vtkNotUsed(interp))
 {
   // not implemented yet
@@ -273,123 +305,164 @@ double vtkMRMLDoubleArrayNode::GetYAxisValue(double vtkNotUsed(x), int vtkNotUse
 //----------------------------------------------------------------------------
 int vtkMRMLDoubleArrayNode::GetXYValue(int index, double* x, double* y)
 {
-  double xy[3];
-
-  if (this->Array->GetNumberOfComponents() >= 2 && index < this->Array->GetNumberOfTuples())
-    {
-    this->Array->GetTupleValue(index, xy);
-    *x = xy[0];
-    *y = xy[1];
-    return 1;
-    }
-  else
+  if ( this->Array->GetNumberOfComponents() < 2 ||
+    index < 0 ||
+    index >= this->Array->GetNumberOfTuples())
     {
     return 0;
     }
+
+  std::vector<double> tuple(this->Array->GetNumberOfComponents());
+  int success = this->GetValues(index, &tuple[0]);
+  
+  *x = tuple[0];
+  *y = tuple[1];
+  
+  return success;
 }
 
 
 //----------------------------------------------------------------------------
 int vtkMRMLDoubleArrayNode::GetXYValue(int index, double* x, double* y, double* yerr)
 {
-  double xy[3];
-
-  if (this->Array->GetNumberOfComponents() >= 3 && index < this->Array->GetNumberOfTuples())
-    {
-    this->Array->GetTupleValue(index, xy);
-    *x    = xy[0];
-    *y    = xy[1];
-    *yerr = xy[2];
-    return 1;
-    }
-  else
+  if ( this->Array->GetNumberOfComponents() < 3 ||
+    index < 0 ||
+    index >= this->Array->GetNumberOfTuples())
     {
     return 0;
     }
+
+  std::vector<double> tuple(this->Array->GetNumberOfComponents());
+  int success = this->GetValues(index, &tuple[0]);
+
+  *x = tuple[0];
+  *y = tuple[1];
+  *yerr = tuple[2];
+
+  return success;
+}
+
+
+//----------------------------------------------------------------------------
+int vtkMRMLDoubleArrayNode::SetValues(int index, double* values)
+{
+  if (index < 0 ||
+    index >= this->Array->GetNumberOfTuples())
+    {
+    return 0;
+    }
+  this->Array->SetTupleValue(index, values);
+  this->Modified();
+  return 1;
+}
+
+
+//----------------------------------------------------------------------------
+int vtkMRMLDoubleArrayNode::SetValue(int index, int component, double value)
+{
+  if (component < 0 ||
+    component >= this->Array->GetNumberOfComponents() ||
+    index < 0 ||
+    index >= this->Array->GetNumberOfTuples())
+    {
+    return 0;
+    }
+  std::vector<double> tuple(this->Array->GetNumberOfComponents());
+  int successGet = this->GetValues(index, &tuple[0]);
+
+  tuple[component] = value;
+  int successSet = this->SetValues(index, &tuple[0]);
+
+  return (successGet && successSet);
 }
 
 
 //----------------------------------------------------------------------------
 int vtkMRMLDoubleArrayNode::SetXYValue(int index, double x, double y)
 {
-  double xy[3];
-  if (this->Array->GetNumberOfComponents() >= 2 && index < this->Array->GetNumberOfTuples())
-    {
-    xy[0] = x;
-    xy[1] = y;
-    xy[2] = 0.0;
-    this->Array->SetTupleValue(index, xy);
-    this->Modified();
-    return 1;
-    }
-  else
+  if (this->Array->GetNumberOfComponents() < 2 ||
+    index < 0 ||
+    index >= this->Array->GetNumberOfTuples())
     {
     return 0;
     }
+  std::vector<double> tuple(this->Array->GetNumberOfComponents(), 0.0);
 
+  tuple[0] = x;
+  tuple[1] = y;
+  return this->SetValues(index, &tuple[0]);
 }
-
 
 //----------------------------------------------------------------------------
 int vtkMRMLDoubleArrayNode::SetXYValue(int index, double x, double y, double yerr)
 {
-  double xy[3];
-  if (this->Array->GetNumberOfComponents() >= 3 && index < this->Array->GetNumberOfTuples())
-    {
-    xy[0] = x;
-    xy[1] = y;
-    xy[2] = yerr;
-    this->Array->SetTupleValue(index, xy);
-    this->Modified();
-    return 1;
-    }
-  else
+  if (this->Array->GetNumberOfComponents() < 3 ||
+    index < 0 ||
+    index >= this->Array->GetNumberOfTuples())
     {
     return 0;
     }
+  std::vector<double> tuple(this->Array->GetNumberOfComponents(), 0.0);
 
+  tuple[0] = x;
+  tuple[1] = y;
+  tuple[2] = yerr;
+  return this->SetValues(index, &tuple[0]);
+}
+
+
+//----------------------------------------------------------------------------
+int vtkMRMLDoubleArrayNode::AddValues(double* values)
+{
+  this->Array->InsertNextTuple(values);
+  this->Modified();
+  return 1;
+}
+
+
+//----------------------------------------------------------------------------
+int vtkMRMLDoubleArrayNode::AddValue(int component, double value)
+{
+  if (component < 0 ||
+    component >= this->Array->GetNumberOfComponents())
+    {
+    return 0;
+    }
+  std::vector<double> tuple(this->Array->GetNumberOfComponents(), 0.0);
+
+  tuple[component] = value;
+  return this->AddValues(&tuple[0]);
 }
 
 
 //----------------------------------------------------------------------------
 int vtkMRMLDoubleArrayNode::AddXYValue(double x, double y)
 {
-  double xy[3];
-  if (this->Array->GetNumberOfComponents() >= 2)
-    {
-    xy[0] = x;
-    xy[1] = y;
-    xy[2] = 0.0;
-    this->Array->InsertNextTuple(xy);
-    this->Modified();
-    return 1;
-    }
-  else
+  if (this->Array->GetNumberOfComponents() < 2)
     {
     return 0;
     }
+  std::vector<double> tuple(this->Array->GetNumberOfComponents(), 0.0);
 
-
+  tuple[0] = x;
+  tuple[1] = y;
+  return this->AddValues(&tuple[0]);
 }
 
 
 //----------------------------------------------------------------------------
 int vtkMRMLDoubleArrayNode::AddXYValue(double x, double y, double yerr)
 {
-  double xy[3];
-  if (this->Array->GetNumberOfComponents() >= 3)
-    {
-    xy[0] = x;
-    xy[1] = y;
-    xy[2] = yerr;
-    this->Array->InsertNextTuple(xy);
-    this->Modified();
-    return 1;
-    }
-  else
+  if (this->Array->GetNumberOfComponents() < 3)
     {
     return 0;
     }
+  std::vector<double> tuple(this->Array->GetNumberOfComponents(), 0.0);
+
+  tuple[0] = x;
+  tuple[1] = y;
+  tuple[2] = yerr;
+  return this->AddValues(&tuple[0]);
 }
 
 

--- a/Libs/MRML/Core/vtkMRMLDoubleArrayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDoubleArrayNode.h
@@ -100,7 +100,15 @@ public:
   /// int GetXYAxisValue(int index, double* x, double* y, double*  yerr);
 
   ///
-  /// Set X and Y values at he data point specified by 'index'
+  /// Set values at the data point specified by 'index'
+  int SetValues(int index, double* values);
+
+  ///
+  /// Set value at the data point specified by 'index' at the given 'component'
+  int SetValue(int index, int component, double value);
+
+  ///
+  /// Set X and Y values at the data point specified by 'index'
   int SetXYValue(int index, double x, double y);
 
   ///
@@ -109,7 +117,15 @@ public:
   int SetXYValue(int index, double x, double y, double yerr);
 
   ///
-  /// Get X and Y values at he data point specified by 'index'
+  /// Get values at the data point specified by 'index'
+  int GetValues(int index, double* values);
+
+  ///
+  /// Get value at the data point specified by 'index' at the given 'component'
+  double GetValue(int index, int component, int& success);
+  
+  ///
+  /// Get X and Y values at the data point specified by 'index'
   int GetXYValue(int index, double* x, double* y);
 
   ///
@@ -117,6 +133,13 @@ public:
   /// at the data point specified by 'index'
   int GetXYValue(int index, double* x, double* y, double* yerr);
 
+  ///
+  /// Add values at the end of the array
+  int AddValues(double* values);
+
+  ///
+  /// Add value at the end of the array at the given 'component'
+  int AddValue(int component, double value);
 
   ///
   /// Add a set of X and Y values at the end of the array

--- a/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.cxx
@@ -87,19 +87,28 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
 
   int numColumns = 3;
   std::vector<std::string> labels;
-  // save the valid lines in a vector, parse them once know the max id
-  std::vector<std::string>lines;
-  bool firstLine = true;
+  bool haslabels = true;
 
   while (fstr.good())
     {
     fstr.getline(line, 1024);
 
-
     // does it start with a #?
     if (line[0] == '#')
       {
       vtkDebugMacro("Comment line, checking:\n\"" << line << "\"");
+
+      char *ptr;
+      if (strncmp(line, " ", 1) != 0)
+        {
+        ptr = strtok(line, " ");
+        ptr = strtok(NULL, " ");
+        if (strcmp(ptr, "nolabels") == 0)
+          {
+          haslabels = false;
+          vtkDebugMacro("No labels in this file");
+          }
+        }
       }
 
     else
@@ -132,7 +141,7 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
             {
             if (columnNumber == xColumn)
               {
-              if (firstLine)
+              if (haslabels)
                 {
                 labels.push_back(ptr);
                 }
@@ -143,7 +152,7 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
               }
             else if (columnNumber == yColumn)
               {
-              if (firstLine)
+              if (haslabels)
                 {
                 labels.push_back(ptr);
                 }
@@ -154,7 +163,7 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
               }
             else if (columnNumber == zColumn)
               {
-              if (firstLine)
+              if (haslabels)
                 {
                 labels.push_back(ptr);
                 }
@@ -177,9 +186,10 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
           columnNumber++;
           } // end while over columns
         int   fidIndex;
-        if (firstLine)
+        if (haslabels)
           {
           doubleArrayNode->vtkMRMLDoubleArrayNode::SetLabels(labels);
+          haslabels = false;
           }
         else
           {
@@ -189,15 +199,12 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
             vtkErrorMacro("Error adding a measurement to the list");
             }
           }
-        firstLine = false;
-
         } // point line
       }
     }
   fstr.close();
 
-  // If it's the first line, that means there was no point in the file.
-  return firstLine ? 0 : 1;
+  return (doubleArrayNode->GetSize() > 0) ? 0 : 1;
 }
 
 //----------------------------------------------------------------------------
@@ -221,16 +228,19 @@ int vtkMRMLDoubleArrayStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
       vtkMRMLDoubleArrayNode::SafeDownCast(refNode);
 
     if (doubleArrayNode == NULL)
-      {
-      vtkErrorMacro("WriteData: unable to cast input node " << refNode->GetID() << " to a known double array node");
-      return 0;
-      }
+    {
+	vtkErrorMacro("WriteData: unable to cast input node " << refNode->GetID() << " to a known double array node");
+	return 0;
+    }
+    if (doubleArrayNode->GetSize() == 0)
+    {
+	vtkErrorMacro("WriteData: " << refNode->GetID() << " is empty, no data to write in " << fullName.c_str());
+	return 0;
+    }
 
     // open the file for writing
     fstream of;
-
     of.open(fullName.c_str(), fstream::out);
-
     if (!of.is_open())
     {
         vtkErrorMacro("WriteData: unable to open file " << fullName.c_str() << " for writing");
@@ -240,8 +250,7 @@ int vtkMRMLDoubleArrayStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
     // put down a header
     of << "# measurement file " << (this->GetFileName() != NULL ? this->GetFileName() : "null") << endl;
 
-    // if change the ones being included, make sure to update the parsing in ReadData
-    of << "# columns = x,y,yerr" << endl;
+    // put labels
     std::vector< std::string > labels = doubleArrayNode->GetLabels();
     if (labels.size())
     {
@@ -251,9 +260,12 @@ int vtkMRMLDoubleArrayStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
         }
         of << labels.at(labels.size()-1) << endl;
     }
+    else
+    {
+        of << "# nolabels"<< endl;
+    }
 
-
-
+    // put values
     for (unsigned int i = 0; i < doubleArrayNode->GetSize(); i++)
     {
         double x,y,yerr;
@@ -270,10 +282,9 @@ int vtkMRMLDoubleArrayStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
             of << endl;
         }
     }
-  of.close();
+    of.close();
 
-
-  return 1;
+    return 1;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Until now vtkMRMLDoubleArrayNode values could only be obtained
using GetXYValue(int, double*, double*), by passing the index
as a copy and the values we want to get as pointers. In python
such a method can not be wrapped if it passes pointers.

The function double GetValue(int, int, int&) allows to return
one value by giving its index, and specifying the component
number. The last parameter is a reference to indicate if the
method succeeded or not, so that we can use GetValue() within
GetXYValue(). We also apply more robust conditions on the index
and the component number.

We were interested in creating this method for vtkMRMLDoubleArrayNode
because this node can be used to transfer double vectors between
CLIs and Slicer [1]. The needs we had were :
(1) Getting the returned values in a python module running the CLIs
(2) Being able to get a specified component (not limited to X and Y)

 [1] https://github.com/Slicer/Slicer/blob/866900a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml#L183-L199