### PR TITLE
ENH: add extra DCMTK apps

### DIFF
--- a/CMake/SlicerBlockInstallDCMTKApps.cmake
+++ b/CMake/SlicerBlockInstallDCMTKApps.cmake
@@ -2,7 +2,7 @@
 # Find and install DCMTK Apps
 # -------------------------------------------------------------------------
 
-set(DCMTK_Apps storescu storescp dcmdump dump2dcm img2dcm dcmdjpeg dcmqrscp dcm2xml dsr2xml dsrdump echoscu)
+set(DCMTK_Apps storescu storescp dcmdump dump2dcm img2dcm dcmdjpeg dcmqrscp dcm2xml xml2dcm dsr2html dsr2xml xml2dsr dsrdump echoscu)
 set(int_dir "")
 if(CMAKE_CONFIGURATION_TYPES)
   set(int_dir "Release/")


### PR DESCRIPTION
* dsr2html can be useful for creating human-readable representations of DICOM
structured reports
* xml2dcm and xml2dsr are reverse operations for existing converters to XML,
which is using DCMTK-specific schema