### PR TITLE
ENH: Display module name in qSlicerCLIProgressBar

### DIFF
--- a/Base/QTCLI/qSlicerCLIProgressBar.cxx
+++ b/Base/QTCLI/qSlicerCLIProgressBar.cxx
@@ -56,12 +56,14 @@ public:
 private:
 
   QGridLayout *  GridLayout;
+  QLabel *       NameLabel;
   QLabel *       StatusLabelLabel;
   QLabel *       StatusLabel;
   QProgressBar * ProgressBar;
   QProgressBar * StageProgressBar;
 
   vtkMRMLCommandLineModuleNode* CommandLineModuleNode;
+  qSlicerCLIProgressBar::Visibility NameVisibility;
   qSlicerCLIProgressBar::Visibility StatusVisibility;
   qSlicerCLIProgressBar::Visibility ProgressVisibility;
   qSlicerCLIProgressBar::Visibility StageProgressVisibility;
@@ -75,6 +77,7 @@ qSlicerCLIProgressBarPrivate::qSlicerCLIProgressBarPrivate(qSlicerCLIProgressBar
   :q_ptr(&object)
 {
   this->CommandLineModuleNode = 0;
+  this->NameVisibility = qSlicerCLIProgressBar::AlwaysHidden;
   this->StatusVisibility = qSlicerCLIProgressBar::AlwaysVisible;
   this->ProgressVisibility = qSlicerCLIProgressBar::VisibleAfterCompletion;
   this->StageProgressVisibility = qSlicerCLIProgressBar::HiddenWhenIdle;
@@ -88,6 +91,11 @@ void qSlicerCLIProgressBarPrivate::init()
   this->GridLayout = new QGridLayout(this->q_ptr);
   this->GridLayout->setObjectName(QString::fromUtf8("gridLayout"));
   this->GridLayout->setContentsMargins(0,0,0,0);
+
+  this->NameLabel = new QLabel();
+  this->NameLabel->setObjectName(QString::fromUtf8("NameLabel"));
+
+  this->GridLayout->addWidget(NameLabel, 1, 0, 1, 1);
 
   this->StatusLabelLabel = new QLabel();
   this->StatusLabelLabel->setObjectName(QString::fromUtf8("StatusLabelLabel"));
@@ -117,6 +125,7 @@ void qSlicerCLIProgressBarPrivate::init()
   this->StageProgressBar->setValue(0);
   this->GridLayout->addWidget(StageProgressBar, 3, 0, 1, 2);
 
+  this->NameLabel->setText(QObject::tr(""));
   this->StatusLabelLabel->setText(QObject::tr("Status:"));
   this->StatusLabel->setText(QObject::tr("Idle"));
 
@@ -171,6 +180,26 @@ vtkMRMLCommandLineModuleNode * qSlicerCLIProgressBar::commandLineModuleNode()con
 {
   Q_D(const qSlicerCLIProgressBar);
   return d->CommandLineModuleNode;
+}
+
+//-----------------------------------------------------------------------------
+qSlicerCLIProgressBar::Visibility qSlicerCLIProgressBar::nameVisibility()const
+{
+  Q_D(const qSlicerCLIProgressBar);
+  return d->NameVisibility;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerCLIProgressBar::setNameVisibility(qSlicerCLIProgressBar::Visibility visibility)
+{
+  Q_D(qSlicerCLIProgressBar);
+  if (visibility == d->NameVisibility)
+    {
+    return;
+    }
+
+  d->NameVisibility = visibility;
+  this->updateUiFromCommandLineModuleNode(d->CommandLineModuleNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -242,6 +271,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
   vtkMRMLCommandLineModuleNode * node =
     vtkMRMLCommandLineModuleNode::SafeDownCast(commandLineModuleNode);
 
+  d->NameLabel->setVisible(d->isVisible(d->NameVisibility));
   d->StatusLabelLabel->setVisible(d->isVisible(d->StatusVisibility));
   d->StatusLabel->setVisible(d->isVisible(d->StatusVisibility));
   d->ProgressBar->setVisible(d->isVisible(d->ProgressVisibility));
@@ -257,6 +287,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
 
   // Update progress
   d->StatusLabel->setText(node->GetStatusString());
+  d->NameLabel->setText(node->GetName());
 
   // Update Progress
   ModuleProcessInformation* info = node->GetModuleDescription().GetProcessInformation();

--- a/Base/QTCLI/qSlicerCLIProgressBar.h
+++ b/Base/QTCLI/qSlicerCLIProgressBar.h
@@ -40,10 +40,15 @@ class Q_SLICER_BASE_QTCLI_EXPORT qSlicerCLIProgressBar : public QWidget
   Q_ENUMS(Visibility)
   QVTK_OBJECT
 
+  /// This property controls how the module name is visible.
+  /// AlwaysHidden by default.
+  /// \sa nameVisibility(), setNameVisibility(),
+  /// nameVisibility
+  Q_PROPERTY(Visibility nameVisibility READ nameVisibility WRITE setNameVisibility)
   /// This property controls how the status label is visible.
   /// AlwaysVisible by default.
   /// \sa statusVisibility(), setStatusVisibility(),
-  /// progressVisibility
+  /// statusVisibility
   Q_PROPERTY(Visibility statusVisibility READ statusVisibility WRITE setStatusVisibility)
   /// This property controls how the progress bar is visible.
   /// VisibleAfterCompletion by default.
@@ -68,6 +73,9 @@ public:
     VisibleAfterCompletion
   };
 
+  /// Visiblity of the module name.
+  /// \sa nameVisibility
+  Visibility nameVisibility()const;
   /// Visiblity of the status label.
   /// \sa statusVisibility
   Visibility statusVisibility()const;
@@ -79,6 +87,10 @@ public slots:
 
   /// Set the \a commandLineModuleNode
   void setCommandLineModuleNode(vtkMRMLCommandLineModuleNode* commandLineModuleNode);
+
+  /// Set the module name visibility
+  /// \sa nameVisibility
+  void setNameVisibility(qSlicerCLIProgressBar::Visibility visibility);
 
   /// Set the status label visibility
   /// \sa statusVisibility


### PR DESCRIPTION
This commit allows to display the name of the CLI module node in
the top left corner of the progressbar. This new feature follows
the same implementation than for the status visibility and the
progressbar visibility. By default the CLI module node name is
always hidden.

Rational :

When creating a python module running a pipeline of CLI modules,
we usually link our main progressbar to the current CLI node.
This practice helps following the progress of one module, but was
lacking information regarding our progress in the whole pipeline.
Displaying the name of the CLI module node above the progressbar
allows for more explicit information.