### PR TITLE
ENH: Update CTK to include PythonQt cleanup fixes

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -58,7 +58,7 @@ if(NOT DEFINED CTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/commontk/CTK.git"
-    GIT_TAG "3884436e0e089360c900e786513f821281a00805"
+    GIT_TAG "0f2e0bec3a6d1c3be5b7924485b4fab933c797fb"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
Fixes crash on exit in py_nomainwindow_DCMTKPrivateDictTest.

    $ git shortlog 3884436e0e089360c900e786513f821281a00805..0f2e0bec3a6d1c3be5b7924485b4fab933c797fb --no-merges
    Max Smolens (1):
          ctkAbstractPythonManager: revert change to clean up PythonQt before finalizing the Python interpreter