### PR TITLE
BUG: Ensure value to string conversion account for precision. Fixes #4044

### DIFF
--- a/Libs/MRML/Core/vtkMRMLUnitNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLUnitNode.cxx
@@ -202,6 +202,7 @@ const char* vtkMRMLUnitNode
 ::GetDisplayValueStringFromDisplayValue(double displayValue)
 {
   std::stringstream strstream;
+  strstream.setf(ios::fixed,ios::floatfield);
   strstream.precision(this->Precision);
   strstream << displayValue;
   strstream >> this->LastValueString;

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
@@ -77,6 +77,38 @@ vtkMRMLScene* vtkSlicerUnitsLogic::GetUnitsScene() const
 }
 
 //----------------------------------------------------------------------------
+double vtkSlicerUnitsLogic::
+GetSIPrefixCoefficient(const char* prefix)
+{
+  if (!prefix)
+    {
+    return 1.;
+    }
+  if (strcmp("yotta", prefix) == 0) { return 1000000000000000000000000.; }
+  else if (strcmp("zetta", prefix) == 0) { return 1000000000000000000000.; }
+  else if (strcmp("exa", prefix) == 0) { return 1000000000000000000.; }
+  else if (strcmp("peta", prefix) == 0) { return 1000000000000000.; }
+  else if (strcmp("tera", prefix) == 0) { return 1000000000000.; }
+  else if (strcmp("giga", prefix) == 0) { return 1000000000.; }
+  else if (strcmp("mega", prefix) == 0) { return 1000000.; }
+  else if (strcmp("kilo", prefix) == 0) { return 1000.; }
+  else if (strcmp("hecto", prefix) == 0) { return 100.; }
+  else if (strcmp("deca", prefix) == 0) { return 10.; }
+  else if (strcmp("", prefix) == 0) { return 1.; }
+  else if (strcmp("deci", prefix) == 0) { return 0.1; }
+  else if (strcmp("centi", prefix) == 0) { return 0.01; }
+  else if (strcmp("milli", prefix) == 0) { return 0.001; }
+  else if (strcmp("micro", prefix) == 0) { return 0.000001; }
+  else if (strcmp("nano", prefix) == 0) { return 0.000000001; }
+  else if (strcmp("pico", prefix) == 0) { return 0.000000000001; }
+  else if (strcmp("femto", prefix) == 0) { return 0.000000000000001; }
+  else if (strcmp("atto", prefix) == 0) { return 0.000000000000000001; }
+  else if (strcmp("zepto", prefix) == 0) { return 0.000000000000000000001; }
+  else if (strcmp("yocto", prefix) == 0) { return 0.000000000000000000000001; }
+  else { return 1.; }
+}
+
+//----------------------------------------------------------------------------
 vtkMRMLUnitNode* vtkSlicerUnitsLogic
 ::AddUnitNodeToScene(vtkMRMLScene* scene, const char* name,
                      const char* quantity, const char* prefix,

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
@@ -109,6 +109,12 @@ GetSIPrefixCoefficient(const char* prefix)
 }
 
 //----------------------------------------------------------------------------
+double vtkSlicerUnitsLogic::GetDisplayCoefficient(const char* prefix, const char* basePrefix)
+{
+  return GetSIPrefixCoefficient(basePrefix) / GetSIPrefixCoefficient(prefix);
+}
+
+//----------------------------------------------------------------------------
 vtkMRMLUnitNode* vtkSlicerUnitsLogic
 ::AddUnitNodeToScene(vtkMRMLScene* scene, const char* name,
                      const char* quantity, const char* prefix,
@@ -189,16 +195,18 @@ void vtkSlicerUnitsLogic::AddBuiltInUnits(vtkMRMLScene* scene)
   this->RegisterNodesInternal(scene);
 
   // Add defaults nodes here
+
+  // in Slicer, "length" quantity values are always expressed in millimeters.
   this->AddUnitNodeToScene(scene,
-    "Meter", "length", "", "m", 3, -10000., 10000., 0.001, 0.);
+    "Meter", "length", "", "m", 3, -10000., 10000., Self::GetDisplayCoefficient("", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Centimeter", "length", "", "cm", 3, -10000., 10000., 0.1, 0.);
+    "Centimeter", "length", "", "cm", 3, -10000., 10000., Self::GetDisplayCoefficient("centi", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Millimeter", "length", "", "mm", 3, -10000., 10000., 1., 0.);
+    "Millimeter", "length", "", "mm", 3, -10000., 10000., Self::GetDisplayCoefficient("milli", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Micrometer", "length", "", "\xB5m", 3, -10000., 10000., 1000., 0.);
+    "Micrometer", "length", "", "\xB5m", 3, -10000., 10000., Self::GetDisplayCoefficient("micro", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Nanometer", "length", "", "nm", 3, -10000., 10000., 1000000., 0.);
+    "Nanometer", "length", "", "nm", 3, -10000., 10000., Self::GetDisplayCoefficient("nano", "milli"), 0.);
 
   // 30.436875 is average number of days in a month
   this->AddUnitNodeToScene(scene,
@@ -212,31 +220,31 @@ void vtkSlicerUnitsLogic::AddBuiltInUnits(vtkMRMLScene* scene)
   this->AddUnitNodeToScene(scene,
     "Minute", "time", "", "min", 2, -10000., 10000., 1.0/60.0, 0.);
   this->AddUnitNodeToScene(scene,
-    "Second", "time", "", "s", 3, -10000., 10000., 1., 0.);
+    "Second", "time", "", "s", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);
   this->AddUnitNodeToScene(scene,
-    "Millisecond", "time", "", "ms", 3, -10000., 10000., 1000., 0.);
+    "Millisecond", "time", "", "ms", 3, -10000., 10000., Self::GetDisplayCoefficient("milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Microsecond", "time", "", "\xB5s", 3, -10000., 10000., 1000., 0.);
+    "Microsecond", "time", "", "\xB5s", 3, -10000., 10000., Self::GetDisplayCoefficient("micro"), 0.);
 
   this->AddUnitNodeToScene(scene,
-    "Herz", "frequency", "", "Hz", 3, -10000., 10000., 1., 0.);
+    "Herz", "frequency", "", "Hz", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);
   this->AddUnitNodeToScene(scene,
-    "decahertz", "frequency", "", "daHz", 3, -10000., 10000., 0.1, 0.);
+    "decahertz", "frequency", "", "daHz", 3, -10000., 10000., Self::GetDisplayCoefficient("deca"), 0.);
   this->AddUnitNodeToScene(scene,
-    "HectoHerz", "frequency", "", "hHz", 3, -10000., 10000., 0.01, 0.);
+    "HectoHerz", "frequency", "", "hHz", 3, -10000., 10000., Self::GetDisplayCoefficient("hecto"), 0.);
   this->AddUnitNodeToScene(scene,
-    "KiloHerz", "frequency", "", "kHz", 3, -10000., 10000., 0.001, 0.);
+    "KiloHerz", "frequency", "", "kHz", 3, -10000., 10000., Self::GetDisplayCoefficient("kilo"), 0.);
   this->AddUnitNodeToScene(scene,
-    "MegaHerz", "frequency", "", "MHz", 3, -10000., 10000., 0.000001, 0.);
+    "MegaHerz", "frequency", "", "MHz", 3, -10000., 10000., Self::GetDisplayCoefficient("mega"), 0.);
   this->AddUnitNodeToScene(scene,
-    "GigaHerz", "frequency", "", "GHz", 3, -10000., 10000., 0.000000001, 0.);
+    "GigaHerz", "frequency", "", "GHz", 3, -10000., 10000., Self::GetDisplayCoefficient("giga"), 0.);
   this->AddUnitNodeToScene(scene,
-    "TeraHerz", "frequency", "", "THz", 3, -10000., 10000., 0.000000000001, 0.);
+    "TeraHerz", "frequency", "", "THz", 3, -10000., 10000., Self::GetDisplayCoefficient("tera"), 0.);
 
   this->AddUnitNodeToScene(scene,
-    "Metre per second", "velocity", "", "m/s", 3, -10000., 10000., 1., 0.);
+    "Metre per second", "velocity", "", "m/s", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);
   this->AddUnitNodeToScene(scene,
-    "Kilometre per second", "velocity", "", "km/s", 3, -10000., 10000., 0.001, 0.);
+    "Kilometre per second", "velocity", "", "km/s", 3, -10000., 10000., Self::GetDisplayCoefficient("kilo"), 0.);
 
   this->AddUnitNodeToScene(scene,
     "Intensity", "intensity", "", "W/m\xB2", 3, -10000., 10000., 1., 0.);

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
@@ -63,6 +63,42 @@ public:
   /// Get the scene with preset unit nodes in it.
   vtkMRMLScene* GetUnitsScene() const;
 
+  /// \brief Get the coefficient associated with the given SI prefix \a name.
+  ///
+  /// Returns the coefficient for all prefix names defined in the [International
+  /// System of Units (SI)](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes) reported in the table below.
+  ///
+  /// Otherwise, returns 1 if an empty name or an unknown prefix name is given.
+  ///
+  /// | Prefix | Coefficient                         |
+  /// |--------|-------------------------------------|
+  /// | yotta  | 10^24  (1000000000000000000000000)  |
+  /// | zetta  | 10^21  (1000000000000000000000)     |
+  /// | exa    | 10^18  (1000000000000000000)        |
+  /// | peta   | 10^15  (1000000000000000)           |
+  /// | tera   | 10^12  (1000000000000)              |
+  /// | giga   | 10^9   (1000000000)                 |
+  /// | mega   | 10^6   (1000000)                    |
+  /// | kilo   | 10^3   (1000)                       |
+  /// | hecto  | 10^2   (100)                        |
+  /// | deca   | 10^1   (10)                         |
+  /// |        | 10^0   (1)                          |
+  /// | deci   | 10^-1  (0.1)                        |
+  /// | centi  | 10^-2  (0.01)                       |
+  /// | milli  | 10^-3  (0.001)                      |
+  /// | micro  | 10^-6  (0.000001)                   |
+  /// | nano   | 10^-9  (0.000000001)                |
+  /// | pico   | 10^-12 (0.000000000001)             |
+  /// | femto  | 10^-15 (0.000000000000001)          |
+  /// | atto   | 10^-18 (0.000000000000000001)       |
+  /// | zepto  | 10^-21 (0.000000000000000000001)    |
+  /// | yocto  | 10^-24 (0.000000000000000000000001) |
+  ///
+  /// Source https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes
+  ///
+  /// \sa AddUnitNodeToScene()
+  static double GetSIPrefixCoefficient(const char* prefix);
+
 protected:
   vtkSlicerUnitsLogic();
   virtual ~vtkSlicerUnitsLogic();

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
@@ -18,12 +18,6 @@
 
 ==============================================================================*/
 
-// .NAME vtkSlicerUnitsLogic - Slicer logic for unit manipulation
-// .SECTION Description
-// This class manages the logic associated with the units. It allows to create
-// a new unit easily. The logic is in charge of calling a modify on the
-// the selection node every time a current unit is modified so the listeners
-// can update themselves.
 
 #ifndef __vtkSlicerUnitsLogic_h
 #define __vtkSlicerUnitsLogic_h
@@ -39,6 +33,12 @@ class vtkMRMLUnitNode;
 // STD includes
 #include <map>
 
+/// \brief Slicer logic for unit manipulation.
+///
+/// This class manages the logic associated with the units. It allows to create
+/// a new unit easily. The logic is in charge of calling a modify on the
+/// the selection node every time a current unit is modified so the listeners
+/// can update themselves.
 class VTK_SLICER_UNITS_MODULE_LOGIC_EXPORT vtkSlicerUnitsLogic
   : public vtkMRMLAbstractLogic
 {
@@ -47,9 +47,8 @@ public:
   vtkTypeMacro(vtkSlicerUnitsLogic, vtkMRMLAbstractLogic);
   virtual void PrintSelf(ostream& os, vtkIndent indent);
 
-  //
-  // Add unit node to the scene.
-  // Returns NULL if the logic has no scene.
+  /// Add unit node to the scene.
+  /// Returns NULL if the logic has no scene.
   vtkMRMLUnitNode* AddUnitNode(const char* name,
     const char* quantity = "length",
     const char* prefix = "",
@@ -58,12 +57,10 @@ public:
     double min = -10000.,
     double max = 10000.);
 
-  //
-  // Change the default unit for the corresponding quantity
+  /// Change the default unit for the corresponding quantity
   void SetDefaultUnit(const char* quantity, const char* id);
 
-  //
-  // Get the scene with preset unit nodes in it.
+  /// Get the scene with preset unit nodes in it.
   vtkMRMLScene* GetUnitsScene() const;
 
 protected:
@@ -79,13 +76,13 @@ protected:
   /// \sa SaveDefaultUnits(), RestoreDefaultUnits()
   virtual void OnMRMLNodeModified(vtkMRMLNode* modifiedNode);
 
-  // Add the built in units in the units logic scene.
+  /// Add the built in units in the units logic scene.
   virtual void AddDefaultsUnits();
 
-  // Add the default units in the application scene
+  /// Add the default units in the application scene
   virtual void AddBuiltInUnits(vtkMRMLScene* scene);
 
-  // Overloaded to add the defaults units in the application scene.
+  /// Overloaded to add the defaults units in the application scene.
   virtual void SetMRMLSceneInternal(vtkMRMLScene* newScene);
 
   /// Register MRML Node classes to Scene.
@@ -94,7 +91,7 @@ protected:
   virtual void RegisterNodes();
   virtual void RegisterNodesInternal(vtkMRMLScene* scene);
 
-  // Add a unit node to the given secne
+  /// \brief Add a unit node to the given scene.
   vtkMRMLUnitNode* AddUnitNodeToScene(vtkMRMLScene* scene,
     const char* name,
     const char* quantity = "length",
@@ -114,6 +111,7 @@ protected:
   /// singleton.
   /// \sa SaveDefaultUnits()
   void RestoreDefaultUnits();
+
   // Variables
   vtkMRMLScene* UnitsScene;
 private:

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
@@ -44,6 +44,7 @@ class VTK_SLICER_UNITS_MODULE_LOGIC_EXPORT vtkSlicerUnitsLogic
 {
 public:
   static vtkSlicerUnitsLogic *New();
+  typedef vtkSlicerUnitsLogic Self;
   vtkTypeMacro(vtkSlicerUnitsLogic, vtkMRMLAbstractLogic);
   virtual void PrintSelf(ostream& os, vtkIndent indent);
 
@@ -99,6 +100,32 @@ public:
   /// \sa AddUnitNodeToScene()
   static double GetSIPrefixCoefficient(const char* prefix);
 
+  /// \brief Get the coefficient to transform a value and display it.
+  ///
+  /// This function is used to conveniently compute the display coefficient
+  /// expected by AddUnitNodeToScene().
+  ///
+  /// The display coefficient is used to transform quantity values to a given
+  /// unit.
+  ///
+  /// By default, value for a given quantity are assumed to have no prefix. For
+  /// example, this means that `length` values are in `meter`, `time` values are
+  /// in `second`. In that case, the coefficient to transform quantity values to
+  /// a given unit can be computed using GetDisplayCoefficient() specifying only
+  /// the \a displayPrefix parameter.
+  ///
+  /// If the quantity values are associated with a specific unit, the \a valuePrefix
+  /// parameter should be provided. For example, in Slicer, since `length` values
+  /// are assumed to be in millimeter the display coefficient should be computed
+  /// specifying `milli` as \a valuePrefix.
+  ///
+  /// \a prefix and \a basePrefix can be any value documented in GetSIPrefixCoefficient().
+  ///
+  /// \sa GetSIPrefixCoefficient()
+  /// \sa AddUnitNodeToScene()
+  /// \sa AddDefaultsUnits(), AddBuiltInUnits()
+  static double GetDisplayCoefficient(const char* displayPrefix, const char* valuePrefix = "");
+
 protected:
   vtkSlicerUnitsLogic();
   virtual ~vtkSlicerUnitsLogic();
@@ -128,6 +155,11 @@ protected:
   virtual void RegisterNodesInternal(vtkMRMLScene* scene);
 
   /// \brief Add a unit node to the given scene.
+  ///
+  /// The display coefficient corresponds to the inverse of the
+  /// SI prefix coefficient associated with the unit.
+  ///
+  /// \sa GetDisplayCoefficient()
   vtkMRMLUnitNode* AddUnitNodeToScene(vtkMRMLScene* scene,
     const char* name,
     const char* quantity = "length",

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
@@ -156,8 +156,30 @@ protected:
 
   /// \brief Add a unit node to the given scene.
   ///
-  /// The display coefficient corresponds to the inverse of the
-  /// SI prefix coefficient associated with the unit.
+  /// A unit node is defined by the following properties:
+  ///
+  /// * Name: The property describes the unit itself. For example,
+  /// the name of a `length` unit can be `Millimeter`, `Meter` or
+  /// `Centimeter`. Setting the node's name also sets the node's singleton tag.
+  ///
+  /// * Quantity: This property describes what types of unit. For example the
+  /// quantity of `second` and `day` is `time`. This property is a Units node
+  /// attribute so it can be easily observed by the GUI.
+  ///
+  /// * Prefix and Suffix: Abbreviation/text displayed respectively before and
+  /// after the unit.
+  ///
+  /// * Precision: This property describes the number of digit used after the
+  /// comma. For example a precision of 2 gives 12.00 and -13.61.
+  ///
+  /// * Min and Max: Range of value allowed for the unit. For example, the
+  /// minimum for the Kelvin value would be 0.
+  ///
+  /// * DisplayCoeff: Coefficient multiplied to the value to display it with
+  /// the appropriate unit. The display coefficient corresponds to the inverse
+  /// of the SI prefix coefficient associated with the unit.
+  ///
+  /// * DisplayOffset: Offset added to the value being displayed.
   ///
   /// \sa GetDisplayCoefficient()
   vtkMRMLUnitNode* AddUnitNodeToScene(vtkMRMLScene* scene,

--- a/Modules/Loadable/Units/Testing/Cxx/vtkSlicerUnitsLogicTest1.cxx
+++ b/Modules/Loadable/Units/Testing/Cxx/vtkSlicerUnitsLogicTest1.cxx
@@ -46,6 +46,7 @@ bool testSelectionNode();
 bool testCloseScene();
 bool testSaveAndReloadScene();
 bool testImportScene(const char* sceneFilePath);
+bool testGetSIPrefixCoefficient();
 }
 
 //-----------------------------------------------------------------------------
@@ -56,6 +57,7 @@ int vtkSlicerUnitsLogicTest1( int argc , char * argv[] )
   res = res && testSelectionNode();
   res = res && testCloseScene();
   res = res && testSaveAndReloadScene();
+  res = res && testGetSIPrefixCoefficient();
   if (argc > 1)
     {
     res = res && testImportScene(argv[1]);
@@ -288,6 +290,51 @@ bool testImportScene(const char* sceneFilePath)
 
   selectionNode->GetUnitNodes(unitNodes);
   return areValidNodes(unitNodes, /*sorted =*/ true, "testImportScene->selectionNodeAfterClear");
+}
+
+//-----------------------------------------------------------------------------
+bool testGetSIPrefixCoefficient()
+{
+  std::map<std::string, double> coefficients;
+  coefficients["yotta"] = 1000000000000000000000000.;
+  coefficients["zetta"] = 1000000000000000000000.;
+  coefficients["exa"] = 1000000000000000000.;
+  coefficients["peta"] = 1000000000000000.;
+  coefficients["tera"] = 1000000000000.;
+  coefficients["giga"] = 1000000000.;
+  coefficients["mega"] = 1000000.;
+  coefficients["kilo"] = 1000.;
+  coefficients["hecto"] = 100.;
+  coefficients["deca"] = 10.;
+  coefficients[""] = 1.;
+  coefficients["deci"] = 0.1;
+  coefficients["centi"] = 0.01;
+  coefficients["milli"] = 0.001;
+  coefficients["micro"] = 0.000001;
+  coefficients["nano"] = 0.000000001;
+  coefficients["pico"] = 0.000000000001;
+  coefficients["femto"] = 0.000000000000001;
+  coefficients["atto"] = 0.000000000000000001;
+  coefficients["zepto"] = 0.000000000000000000001;
+  coefficients["yocto"] = 0.000000000000000000000001;
+
+  for (std::map<std::string, double>::iterator it = coefficients.begin();
+       it != coefficients.end(); ++it)
+    {
+    std::string prefix = it->first;
+    double expectedCoefficient = it->second;
+    double coefficient = vtkSlicerUnitsLogic::GetSIPrefixCoefficient(prefix.c_str());
+    if (coefficient != expectedCoefficient)
+      {
+      std::cerr << "Line " << __LINE__
+                << " - Problem with GetSIPrefixCoefficient(\"" << prefix << "\")\n"
+                << "  coefficient: " << coefficient << "\n"
+                << "  expectedCoefficient: " << expectedCoefficient
+                << std::endl;
+      return false;
+      }
+    }
+  return true;
 }
 
 } // end namespace


### PR DESCRIPTION
In addition to improve the Units logic API to facilitate the registration of new units node, this topic fixes issue #4044.

In a nutshell, calling `vtkMRMLUnitNode::GetDisplayStringFromValue()` was returning incorrect string. The following snippet illustrates the issue and confirm that this topic effectively address the problem.

```
import math
l = slicer.modules.units.logic()
s = l.GetUnitsScene()
n = s.GetNodesByName("Metre per second").GetItemAsObject(0)
n.SetPrecision(3)
for v in range(-5, 5):
  print("10^%d -> %s" % (v, n.GetDisplayStringFromValue(math.pow(10, v))))
```

Before the change:

```
10^-5 ->  1e-05 m/s
10^-4 ->  0.0001 m/s
10^-3 ->  0.001 m/s
10^-2 ->  0.01 m/s
10^-1 ->  0.1 m/s
10^0 ->  1 m/s
10^1 ->  10 m/s
10^2 ->  100 m/s
10^3 ->  1e+03 m/s
10^4 ->  1e+04 m/s
```

After the change:

```
10^-5 ->  0.000 m/s
10^-4 ->  0.000 m/s
10^-3 ->  0.001 m/s
10^-2 ->  0.010 m/s
10^-1 ->  0.100 m/s
10^0 ->  1.000 m/s
10^1 ->  10.000 m/s
10^2 ->  100.000 m/s
10^3 ->  1000.000 m/s
10^4 ->  10000.000 m/s
```