### PR TITLE
STYLE: Facilitate integration with python IDE

### DIFF
--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 set(Slicer_PYTHON_SCRIPTS
+  slicer/__init__
   slicer/logic
   slicer/ScriptedLoadableModule
   slicer/slicerqt
@@ -50,12 +51,12 @@ if(Slicer_BUILD_CLI_SUPPORT)
 endif()
 
 configure_file(
-  slicer/__init__.py.in
-  ${CMAKE_CURRENT_BINARY_DIR}/slicer/__init__.py
+  slicer/kits.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/slicer/kits.py
   @ONLY
   )
 
-list(APPEND Slicer_PYTHON_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/slicer/__init__.py)
+list(APPEND Slicer_PYTHON_SCRIPTS ${CMAKE_CURRENT_BINARY_DIR}/slicer/kits.py)
 
 set(Slicer_PYTHON_RESOURCES
   )

--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -113,9 +113,12 @@ The module attributes are the Slicer modules names, the associated
 value is the module name.
 """)
 
-__kits_to_load = [ @Slicer_PYTHON_MODULES_CONFIG@ ]
+try:
+  from kits import available_kits
+except ImportError:
+  available_kits = []
 
-for kit in __kits_to_load:
+for kit in available_kits:
    try:
      exec "from %s import *" % (kit)
    except ImportError as detail:
@@ -123,4 +126,5 @@ for kit in __kits_to_load:
 
 # Removing things the user shouldn't have to see.
 del _createModule
-del __kits_to_load
+del available_kits
+del kit

--- a/Base/Python/slicer/kits.py.in
+++ b/Base/Python/slicer/kits.py.in
@@ -1,0 +1,1 @@
+available_kits = [ @Slicer_PYTHON_MODULES_CONFIG@ ]


### PR DESCRIPTION
This PR introduces `slicer/kits.py` facilitating integration with IDE like
PyCharm when simply adding the "Slicer/Base/Python" folder as dependent
project for scripted module. In this case, the `slicer` module, while incomplete
because of unavailable kits, will still be importable.
