### PR TITLE
ENH: add ability to remove one series of an exam

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -58,7 +58,7 @@ if(NOT DEFINED CTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/commontk/CTK.git"
-    GIT_TAG "0f2e0bec3a6d1c3be5b7924485b4fab933c797fb"
+    GIT_TAG "33c899969669bf55c5952637299b98108d59249c"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
Author: Nicole Aucoin <nicole@bwh.harvard.edu>
Date:   Mon Aug 3 18:51:07 2015 -0400

    ENH: add ability to delete individual series, studies, patients

    Add to the browser Remove button the information that it will
    delete all selected series, studies, patients.

    Add support for right click custom context menus in the
    patient, study, series tables. Translate the local points
    to global ones in terms of the table view and signal
    right clicked with the global position so that the browser
    can position the context menu appropriately.

    Add the context menu to the DICOM browser to allow
    deleting at just one level, with number of items
    selected information, and a confirmation message box with descriptive
    information that can be set to not be shown again.

    Added a test for the DICOM browser, with the ability
    to open it in interactive mode to test the right clicks.

    Add query wrappers for the DICOM database to get the patient name
    as well as descriptions for series and study. They will return empty
    strings on failure.
    Use the new queries to give more meaningful information on the right
    click pop up menu in the DICOM browser.
    Added a test for the new DICOM database accessors.

    Slicer bug:
    http://www.na-mic.org/Bug/view.php?id=3792

    When Slicer makes a custom DICOM browser, it moves the table views
    directly into the new window, extracting them from the DICOM
    table.
    With this change, the table view takes care of mapping the point to
    global, the table manager propagates the signal as a table specific
    XRightClicked signal, and the browser responds to it with a table
    specific context menu.

Issue #3792