### PR TITLE
BUG: fix volume property file extensions for saving

### DIFF
--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -113,7 +113,7 @@ QString qSlicerFileNameItemDelegate::fixupFileName(const QString& fileName, cons
       }
     }
 
-  QString stippedFileName = fixup;
+  QString strippedFileName = fixup;
   if(mrmlScene)
     {
     vtkObject * object = mrmlScene;
@@ -122,10 +122,10 @@ QString qSlicerFileNameItemDelegate::fixupFileName(const QString& fileName, cons
       object = mrmlScene->GetNodeByID(nodeID.toLatin1());
       }
     Q_ASSERT(object);
-    stippedFileName = qSlicerSaveDataDialogPrivate::stripKnownExtension(fixup, object);
-    stippedFileName += extension;
+    strippedFileName = qSlicerSaveDataDialogPrivate::stripKnownExtension(fixup, object);
+    strippedFileName += extension;
     }
-  return stippedFileName;
+  return strippedFileName;
 }
 
 //-----------------------------------------------------------------------------
@@ -741,6 +741,12 @@ QString qSlicerSaveDataDialogPrivate::stripKnownExtension(const QString& fileNam
   if (!knownExtension.isEmpty())
     {
     strippedFileName.chop(knownExtension.length());
+    // check that the extension wasn't doubled by having the file name be
+    // constructed from a node name that included the extension
+    if (strippedFileName.endsWith(knownExtension))
+      {
+      return Self::stripKnownExtension(strippedFileName, object);
+      }
     return strippedFileName;
     }
   return strippedFileName;

--- a/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/CMakeLists.txt
@@ -3,6 +3,7 @@ set(KIT ${PROJECT_NAME})
 #-----------------------------------------------------------------------------
 set(KIT_TEST_SRCS
   vtkSlicerVolumeRenderingLogicTest.cxx
+  vtkSlicerVolumeRenderingLogicAddFromFileTest.cxx
   )
 
 #-----------------------------------------------------------------------------
@@ -14,3 +15,4 @@ slicerMacroConfigureModuleCxxTestDriver(
 
 #-----------------------------------------------------------------------------
 simple_test(vtkSlicerVolumeRenderingLogicTest ${Slicer_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_SHARE_DIR}/${MODULE_NAME})
+simple_test(vtkSlicerVolumeRenderingLogicAddFromFileTest ${Slicer_BINARY_DIR}/Testing/Temporary/)

--- a/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/vtkSlicerVolumeRenderingLogicAddFromFileTest.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/vtkSlicerVolumeRenderingLogicAddFromFileTest.cxx
@@ -1,0 +1,137 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Julien Finet, Kitware Inc.
+  and was partially funded by NIH grant 3P41RR013218-12S1
+
+==============================================================================*/
+
+// VolumeRendering includes
+#include <vtkMRMLVolumePropertyNode.h>
+#include <vtkMRMLVolumePropertyStorageNode.h>
+#include <vtkSlicerVolumeRenderingLogic.h>
+
+// MRML includes
+#include <vtkMRMLScene.h>
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkSmartPointer.h>
+#include <vtksys/SystemTools.hxx>
+
+//----------------------------------------------------------------------------
+bool testAddVolumePropertyFromFile(const std::string &temporaryDirectory);
+
+//----------------------------------------------------------------------------
+int vtkSlicerVolumeRenderingLogicAddFromFileTest(int argc, char* argv[])
+{
+  if (argc != 2)
+    {
+    std::cout << "Missing temporary directory argument !" << std::endl;
+    return EXIT_FAILURE;
+    }
+  std::string temporaryDirectory(argv[1]);
+
+  bool res = true;
+  res = testAddVolumePropertyFromFile(temporaryDirectory) && res;
+  return res ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+//----------------------------------------------------------------------------
+bool testAddVolumePropertyFromFile(const std::string& temporaryDirectory)
+{
+  vtkNew<vtkSlicerVolumeRenderingLogic> logic;
+
+  std::cout << "temporaryDirectory = " << temporaryDirectory.c_str() << std::endl;
+
+ 
+  // write out a defaults file
+  vtkNew<vtkMRMLVolumePropertyNode> defaultVolumePropertyNode;
+  vtkNew<vtkMRMLVolumePropertyStorageNode> volumePropertyStorageNode;
+
+  // set up the temporary file name
+  std::vector<std::string> components;
+  components.push_back(temporaryDirectory);
+  components.push_back(std::string("VolumeRenderingLogicVolumeProperty.vp"));
+  std::string fileName = vtksys::SystemTools::JoinPath(components);
+  std::cout << "fileName = " << fileName.c_str() << std::endl;
+
+  volumePropertyStorageNode->SetFileName(fileName.c_str());
+  int ret = volumePropertyStorageNode->WriteData(defaultVolumePropertyNode.GetPointer());
+
+  if (!ret)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Problem with vtkSlicerVolumeRenderingLogic::AddVolumePropertyFromFile\n"
+              << " - failed on writing to file name: "
+              << fileName.c_str()
+              << std::endl;
+    return false;
+    }
+  std::cout << "\tfile written okay" << std::endl;
+
+  // try reading without a scene
+  vtkMRMLVolumePropertyNode *vpNode = logic->AddVolumePropertyFromFile(fileName.c_str());
+  if (vpNode != NULL)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Problem with vtkSlicerVolumeRenderingLogic::AddVolumePropertyFromFile\n"
+              << " - failed on reading with no scene "
+              << fileName.c_str()
+              << std::endl;
+    return false;
+    }
+
+  // set the scene
+  vtkNew<vtkMRMLScene> scene;
+  logic->SetMRMLScene(scene.GetPointer());
+
+  // null file name
+  vpNode = logic->AddVolumePropertyFromFile(NULL);
+  if (vpNode != NULL)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Problem with vtkSlicerVolumeRenderingLogic::AddVolumePropertyFromFile\n"
+              << " - failed on null file  name"
+              << std::endl;
+    return false;
+    }
+
+  // empty file name
+  vpNode = logic->AddVolumePropertyFromFile("");
+  if (vpNode != NULL)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Problem with vtkSlicerVolumeRenderingLogic::AddVolumePropertyFromFile\n"
+              << " - failed on empty file name"
+              << std::endl;
+    return false;
+    }
+
+  // read it back in
+  vpNode = logic->AddVolumePropertyFromFile(fileName.c_str());
+  if (!vpNode)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Problem with vtkSlicerVolumeRenderingLogic::AddVolumePropertyFromFile\n"
+              << " - failed on reading from file name: "
+              << fileName.c_str()
+              << std::endl;
+    return false;
+    }
+
+  std::cout << "Test passed!" << std::endl;
+  return true;
+}

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -951,6 +951,17 @@ void vtkSlicerVolumeRenderingLogic::UpdateDisplayNodeFromVolumeNode(
 vtkMRMLVolumePropertyNode* vtkSlicerVolumeRenderingLogic
 ::AddVolumePropertyFromFile (const char* filename)
 {
+  if (!this->GetMRMLScene())
+    {
+    return NULL;
+    }
+  if (!filename ||
+      !strcmp(filename, ""))
+    {
+    vtkErrorMacro("AddVolumePropertyFromFile: can't load volume properties from empty file name");
+    return NULL;
+    }
+
   vtkMRMLVolumePropertyNode *vpNode = vtkMRMLVolumePropertyNode::New();
   vtkMRMLVolumePropertyStorageNode *vpStorageNode = vtkMRMLVolumePropertyStorageNode::New();
 
@@ -975,12 +986,13 @@ vtkMRMLVolumePropertyNode* vtkSlicerVolumeRenderingLogic
     localFile = filename;
     }
   const itksys_stl::string fname(localFile);
-  // the model name is based on the file name (itksys call should work even if
+  // the node name is based on the file name (itksys call should work even if
   // file is not on disk yet)
-  name = itksys::SystemTools::GetFilenameName(fname);
+  std::string filenameName = itksys::SystemTools::GetFilenameName(fname);
+  name = itksys::SystemTools::GetFilenameWithoutExtension(filenameName);
 
   // check to see which node can read this type of file
-  if (!vpStorageNode->SupportedFileType(name.c_str()))
+  if (!vpStorageNode->SupportedFileType(fname.c_str()))
     {
     vpStorageNode->Delete();
     vpStorageNode = NULL;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.cxx
@@ -214,6 +214,12 @@ int vtkMRMLVolumePropertyStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLVolumePropertyStorageNode::InitializeSupportedReadFileTypes()
+{
+  this->SupportedReadFileTypes->InsertNextValue("VolumeProperty (.vp)");
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLVolumePropertyStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("VolumeProperty (.vp)");

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.h
@@ -53,7 +53,9 @@ protected:
   vtkMRMLVolumePropertyStorageNode(const vtkMRMLVolumePropertyStorageNode&);
   void operator=(const vtkMRMLVolumePropertyStorageNode&);
 
-  ///
+  /// Initialize all the supported read file types
+  virtual void InitializeSupportedReadFileTypes();
+
   /// Initialize all the supported write file types
   virtual void InitializeSupportedWriteFileTypes();
 


### PR DESCRIPTION
When fixing the repeated file extensions problem, the
volume property files were missed. The problem
came up when loading in a volume property file
via add data (rather than a scene file) then
trying to save it again. The node was named with
the .vp file extension and then the file name
was adjusted to add another .vp to the end. This
fix changes the the name of the node to exclude
the extension so it will save correctly.

Added testing for the AddVolumePropertyFromFile
method and added some checks to it for missing
scene and file names. Added the supported
write types as well.

Issue #3956