### PR TITLE
BUG: Fix py_nomainwindow_DCMTKPrivateDictTest on Windows

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -27,13 +27,13 @@ class DICOMProcess(object):
     self.process = None
     self.connections = {}
     pathOptions = (
+        '/../DCMTK-build/bin/Debug',
+        '/../DCMTK-build/bin/Release',
         '/../DCMTK-build/bin',
         '/../CTK-build/CMakeExternals/Install/bin',
         '/bin'
         )
 
-    # note: even in a windows build tree DCMTK's install does not include
-    # a "Debug" or "Release" intDir
     self.exeDir = None
     for path in pathOptions:
       testPath = slicer.app.slicerHome + path


### PR DESCRIPTION
Test py_nomainwindow_DCMTKPrivateDictTest fails on Windows because DICOMLib
can't find the dcmdump.exe utility.

Based on a comment in DICOMProcesses.py, the DCMTK build tree didn't always
include the configuration name (i.e. 'Debug' or 'Release') in the build path for
the utilities. Now the build tree does include the configuration name. This
commit adds the 'Debug' and 'Release' subdirectories to the list of searched
paths.

Fixes #4049