### PR TITLE
BUG: Fix py_nomainwindow_DCMTKPrivateDictTest on Windows

### DIFF
--- a/Applications/SlicerApp/Testing/Python/DCMTKPrivateDictTest.py
+++ b/Applications/SlicerApp/Testing/Python/DCMTKPrivateDictTest.py
@@ -9,7 +9,7 @@ except KeyError:
   raise Exception("DCMDICTPATH environment variable is not defined !")
 
 dcmdump=DICOMLib.DICOMCommand('dcmdump',[dcmfile])
-dump=str(dcmdump.start()).split('\n')
+dump=str(dcmdump.start()).splitlines()
 
 found_private_tag = False
 for line in dump:


### PR DESCRIPTION
Test py_nomainwindow_DCMTKPrivateDictTest fails on Windows because of a line
ending issue. Although the test passed on a local build after r24557 [1], the
test still fails on factory-south-win7.kitware.

This commit changes the test to use Python's universal newlines [2] when parsing
dcmdump's output.

[1] http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=24557
[2] https://docs.python.org/2/glossary.html#term-universal-newlines