### PR TITLE
BUG: Fix memory leaks associated with py_DTINotReproducibleIssue3977 test

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -1230,7 +1230,7 @@ void vtkSlicerApplicationLogic::ProcessReadNodeData(ReadDataRequest& req)
    //       dtvdn->SetUpperThreshold(0);
    //       dtvdn->SetLowerThreshold(0);
    //       dtvdn->SetAutoWindowLevel(1);
-          disp = dtvdn; // assign to superclass pointer
+          disp.TakeReference(dtvdn); // assign to superclass pointer
           }
         else
           {


### PR DESCRIPTION
In a debug build running py_DTINotReproducibleIssue3977 reports that a
number of VTK class instances leak.

This commit fixes the leaks by fixing incorrect memory management on an instance
of vtkMRMLDiffusionTensorVolumeDisplayNode.

Fixes #4050

This may have been an inadvertent change in e4ffa1f:
https://github.com/Slicer/Slicer/commit/e4ffa1f6dcfafc1ca8f0015ecf02a0c23a8bd503#diff-e6c1e3f6844baf9d4ed1a1d2ca110320L1188