### PR TITLE
ENH: adding more Suffixes in Units

### DIFF
--- a/Libs/MRML/Core/vtkMRMLUnitNode.h
+++ b/Libs/MRML/Core/vtkMRMLUnitNode.h
@@ -112,7 +112,7 @@ public:
 
   ///
   /// Set/Get the unit suffix. For example, the suffix
-  /// for the unity metre would be "m".
+  /// for the unity meter would be "m".
   /// Default is "".
   /// \sa SetSuffix(), GetSuffix()
   vtkGetStringMacro(Suffix);
@@ -120,7 +120,7 @@ public:
 
   ///
   /// Set/Get the unit secondsuffix. For example, the secondsuffix
-  /// for the unity degree would be "\x27".
+  /// for the unity degree would be "arcminute (')".
   /// Default is "".
   /// \sa SetSecondSuffix(), GetSecondSuffix()
   vtkGetStringMacro(SecondSuffix);
@@ -128,7 +128,7 @@ public:
 
   ///
   /// Set/Get the unit thirdsuffix. For example, the thirdsuffix
-  /// for the unity degree would be "\x22".
+  /// for the unity degree would be "arcsecond (")".
   /// Default is "".
   /// \sa SetThirdSuffix(), GetThirdSuffix()
   vtkGetStringMacro(ThirdSuffix);

--- a/Libs/MRML/Core/vtkMRMLUnitNode.h
+++ b/Libs/MRML/Core/vtkMRMLUnitNode.h
@@ -58,6 +58,7 @@ public:
   /// Get node XML tag name (like Volume, Model)
   virtual const char* GetNodeTagName() {return "Unit";};
 
+  ///
   /// Reimplemented to prevent reset if unit node is a singleton.
   virtual void Reset();
 
@@ -67,19 +68,30 @@ public:
   const char* GetQuantity();
   void SetQuantity(const char* quantity);
 
+  ///
   /// Return the value multiplied by DisplayCoefficient and summed by
   /// DisplayOffset.
   /// \sa GetValueFromDisplayValue(), GetDisplayStringFromValue(),
   /// GetDisplayCoefficient(), GetDisplayOffset()
   virtual double GetDisplayValueFromValue(double value);
+
+  ///
   /// Return the value subtracted from DisplayOffset and divided by
   /// DisplayCoefficient.
   /// \sa GetDisplayValueFromValue(), GetDisplayStringFromValue()
   virtual double GetValueFromDisplayValue(double value);
+
+  ///
   /// Return the display value with prefix and suffix.
   /// \sa GetDisplayValueFromValue(), GetValueFromDisplayValue()
   const char* GetDisplayStringFromValue(double value);
 
+  ///
+  /// Return the display value with prefix and suffixes.
+  /// \sa GetDisplayValueFromValue(), GetValueFromDisplayValue()
+  const char* GetDisplayStringFromValue(double value[3]);
+
+  ///
   /// Return the display string format to use with printf/sprintf.
   /// Note that the value passed to the format must be the DisplayValue.
   /// For example: "%#6.3g mm" if the precision is 3 and the suffix mm.
@@ -99,12 +111,28 @@ public:
   vtkSetStringMacro(Prefix);
 
   ///
-  /// Set/Get the unit suffix. For example, the suffix for the unity
-  /// meter would be "m".
+  /// Set/Get the unit suffix. For example, the suffix
+  /// for the unity metre would be "m".
   /// Default is "".
   /// \sa SetSuffix(), GetSuffix()
   vtkGetStringMacro(Suffix);
   vtkSetStringMacro(Suffix);
+
+  ///
+  /// Set/Get the unit secondsuffix. For example, the secondsuffix
+  /// for the unity degree would be "\x27".
+  /// Default is "".
+  /// \sa SetSecondSuffix(), GetSecondSuffix()
+  vtkGetStringMacro(SecondSuffix);
+  vtkSetStringMacro(SecondSuffix);
+
+  ///
+  /// Set/Get the unit thirdsuffix. For example, the thirdsuffix
+  /// for the unity degree would be "\x22".
+  /// Default is "".
+  /// \sa SetThirdSuffix(), GetThirdSuffix()
+  vtkGetStringMacro(ThirdSuffix);
+  vtkSetStringMacro(ThirdSuffix);
 
   ///
   /// Set/Get the precision (i.e. number of decimals) of the unit.
@@ -145,7 +173,12 @@ protected:
   void operator=(const vtkMRMLUnitNode&);
 
   virtual const char* GetDisplayValueStringFromDisplayValue(double displayValue);
+
   virtual const char* GetDisplayStringFromDisplayValueString(const char* displayValue);
+  virtual const char* GetDisplayStringFromDisplayValueString(const char* firstDisplayValueString,
+                                                             const char* secondDisplayValueString,
+                                                             const char* thirdDisplayValueString);
+
   ///
   /// Helper functions that wrap the given string with the
   /// suffix and or the prefix. A space is used between the
@@ -154,8 +187,18 @@ protected:
   std::string WrapValueWithSuffix(const std::string& value) const;
   std::string WrapValueWithPrefixAndSuffix(const std::string& value) const;
 
+  std::string WrapValueWithSuffix(const std::string& firstValue,
+                                  const std::string& secondValue,
+                                  const std::string& thirdVvalue) const;
+  std::string WrapValueWithPrefixAndSuffix(const std::string& firstvValue,
+                                           const std::string& secondValue,
+                                           const std::string& thirdValue) const;
+
   char* Prefix;
   char* Suffix;
+  char* SecondSuffix;
+  char* ThirdSuffix;
+
   int Precision;
   double MinimumValue;
   double MaximumValue;

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
@@ -64,10 +64,11 @@ void vtkSlicerUnitsLogic::PrintSelf(ostream& os, vtkIndent indent)
 //----------------------------------------------------------------------------
 vtkMRMLUnitNode* vtkSlicerUnitsLogic
 ::AddUnitNode(const char* name, const char* quantity, const char* prefix,
-              const char* suffix, int precision, double min, double max)
+              const char* suffix, const char* secondSuffix, const char* thirdSuffix,
+              int precision, double min, double max)
 {
   return this->AddUnitNodeToScene(this->GetMRMLScene(), name, quantity,
-    prefix, suffix, precision, min, max);
+    prefix, suffix, secondSuffix, thirdSuffix, precision, min, max);
 }
 
 //----------------------------------------------------------------------------
@@ -118,7 +119,8 @@ double vtkSlicerUnitsLogic::GetDisplayCoefficient(const char* prefix, const char
 vtkMRMLUnitNode* vtkSlicerUnitsLogic
 ::AddUnitNodeToScene(vtkMRMLScene* scene, const char* name,
                      const char* quantity, const char* prefix,
-                     const char* suffix, int precision,
+                     const char* suffix, const char* secondSuffix,
+                     const char* thirdSuffix, int precision,
                      double min, double max,
                      double displayCoeff, double displayOffset)
 {
@@ -132,6 +134,8 @@ vtkMRMLUnitNode* vtkSlicerUnitsLogic
   unitNode->SetQuantity(quantity);
   unitNode->SetPrefix(prefix);
   unitNode->SetSuffix(suffix);
+  unitNode->SetSecondSuffix(secondSuffix);
+  unitNode->SetThirdSuffix(thirdSuffix);
   unitNode->SetPrecision(precision);
   unitNode->SetMinimumValue(min);
   unitNode->SetMaximumValue(max);
@@ -163,23 +167,23 @@ void vtkSlicerUnitsLogic::ObserveMRMLScene()
 void vtkSlicerUnitsLogic::AddDefaultsUnits()
 {
   vtkMRMLUnitNode* node =
-    this->AddUnitNode("ApplicationLength", "length", "", "mm", 3);
+    this->AddUnitNode("ApplicationLength", "length", "", "mm", "", "", 3);
   node->SetSaveWithScene(false);
   this->SetDefaultUnit(node->GetQuantity(), node->GetID());
 
-  node = this->AddUnitNode("ApplicationTime", "time", "", "s", 3);
+  node = this->AddUnitNode("ApplicationTime", "time", "", "s", "", "", 3);
   node->SetSaveWithScene(false);
   this->SetDefaultUnit(node->GetQuantity(), node->GetID());
 
-  node = this->AddUnitNode("ApplicationFrequency", "frequency", "", "Hz", 3);
+  node = this->AddUnitNode("ApplicationFrequency", "frequency", "", "Hz", "", "", 3);
   node->SetSaveWithScene(false);
   this->SetDefaultUnit(node->GetQuantity(), node->GetID());
 
-  node = this->AddUnitNode("ApplicationVelocity", "velocity", "", "m/s", 3);
+  node = this->AddUnitNode("ApplicationVelocity", "velocity", "", "m/s", "", "", 3);
   node->SetSaveWithScene(false);
   this->SetDefaultUnit(node->GetQuantity(), node->GetID());
 
-  node = this->AddUnitNode("ApplicationIntensity", "intensity", "", "W/m\xB2", 3);
+  node = this->AddUnitNode("ApplicationIntensity", "intensity", "", "W/m\xB2", "", "", 3);
   node->SetSaveWithScene(false);
   this->SetDefaultUnit(node->GetQuantity(), node->GetID());
 }
@@ -198,56 +202,56 @@ void vtkSlicerUnitsLogic::AddBuiltInUnits(vtkMRMLScene* scene)
 
   // in Slicer, "length" quantity values are always expressed in millimeters.
   this->AddUnitNodeToScene(scene,
-    "Meter", "length", "", "m", 3, -10000., 10000., Self::GetDisplayCoefficient("", "milli"), 0.);
+    "Meter", "length", "", "m", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Centimeter", "length", "", "cm", 3, -10000., 10000., Self::GetDisplayCoefficient("centi", "milli"), 0.);
+    "Centimeter", "length", "", "cm", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("centi", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Millimeter", "length", "", "mm", 3, -10000., 10000., Self::GetDisplayCoefficient("milli", "milli"), 0.);
+    "Millimeter", "length", "", "mm", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("milli", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Micrometer", "length", "", "\xB5m", 3, -10000., 10000., Self::GetDisplayCoefficient("micro", "milli"), 0.);
+    "Micrometer", "length", "", "\xB5m", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("micro", "milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Nanometer", "length", "", "nm", 3, -10000., 10000., Self::GetDisplayCoefficient("nano", "milli"), 0.);
+    "Nanometer", "length", "", "nm", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("nano", "milli"), 0.);
 
   // 30.436875 is average number of days in a month
   this->AddUnitNodeToScene(scene,
-    "Year", "time", "", "year", 2, -10000., 10000., 1.0 / 12.0*30.436875*24.0*60.0*60.0, 0.);
+    "Year", "time", "", "year", "", "", 2, -10000., 10000., 1.0 / 12.0*30.436875*24.0*60.0*60.0, 0.);
   this->AddUnitNodeToScene(scene,
-    "Month", "time", "", "month", 2, -10000., 10000., 1.0 / 30.436875*24.0*60.0*60.0, 0.);
+    "Month", "time", "", "month", "", "", 2, -10000., 10000., 1.0 / 30.436875*24.0*60.0*60.0, 0.);
   this->AddUnitNodeToScene(scene,
-    "Day", "time", "", "day", 2, -10000., 10000., 1.0 / 24.0*60.0*60.0, 0.);
+    "Day", "time", "", "day", "", "", 2, -10000., 10000., 1.0 / 24.0*60.0*60.0, 0.);
   this->AddUnitNodeToScene(scene,
-    "Hour", "time", "", "h", 2, -10000., 10000., 1.0 / 60.0*60.0, 0.);
+    "Hour", "time", "", "h", "", "", 2, -10000., 10000., 1.0 / 60.0*60.0, 0.);
   this->AddUnitNodeToScene(scene,
-    "Minute", "time", "", "min", 2, -10000., 10000., 1.0/60.0, 0.);
+    "Minute", "time", "", "min", "", "", 2, -10000., 10000., 1.0/60.0, 0.);
   this->AddUnitNodeToScene(scene,
-    "Second", "time", "", "s", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);
+    "Second", "time", "", "s", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);
   this->AddUnitNodeToScene(scene,
-    "Millisecond", "time", "", "ms", 3, -10000., 10000., Self::GetDisplayCoefficient("milli"), 0.);
+    "Millisecond", "time", "", "ms", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("milli"), 0.);
   this->AddUnitNodeToScene(scene,
-    "Microsecond", "time", "", "\xB5s", 3, -10000., 10000., Self::GetDisplayCoefficient("micro"), 0.);
+    "Microsecond", "time", "", "\xB5s", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("micro"), 0.);
 
   this->AddUnitNodeToScene(scene,
-    "Herz", "frequency", "", "Hz", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);
+    "Herz", "frequency", "", "Hz", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);
   this->AddUnitNodeToScene(scene,
-    "decahertz", "frequency", "", "daHz", 3, -10000., 10000., Self::GetDisplayCoefficient("deca"), 0.);
+    "decahertz", "frequency", "", "daHz", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("deca"), 0.);
   this->AddUnitNodeToScene(scene,
-    "HectoHerz", "frequency", "", "hHz", 3, -10000., 10000., Self::GetDisplayCoefficient("hecto"), 0.);
+    "HectoHerz", "frequency", "", "hHz", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("hecto"), 0.);
   this->AddUnitNodeToScene(scene,
-    "KiloHerz", "frequency", "", "kHz", 3, -10000., 10000., Self::GetDisplayCoefficient("kilo"), 0.);
+    "KiloHerz", "frequency", "", "kHz", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("kilo"), 0.);
   this->AddUnitNodeToScene(scene,
-    "MegaHerz", "frequency", "", "MHz", 3, -10000., 10000., Self::GetDisplayCoefficient("mega"), 0.);
+    "MegaHerz", "frequency", "", "MHz", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("mega"), 0.);
   this->AddUnitNodeToScene(scene,
-    "GigaHerz", "frequency", "", "GHz", 3, -10000., 10000., Self::GetDisplayCoefficient("giga"), 0.);
+    "GigaHerz", "frequency", "", "GHz", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("giga"), 0.);
   this->AddUnitNodeToScene(scene,
-    "TeraHerz", "frequency", "", "THz", 3, -10000., 10000., Self::GetDisplayCoefficient("tera"), 0.);
+    "TeraHerz", "frequency", "", "THz", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("tera"), 0.);
 
   this->AddUnitNodeToScene(scene,
-    "Metre per second", "velocity", "", "m/s", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);
+    "Metre per second", "velocity", "", "m/s", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient(""), 0.);
   this->AddUnitNodeToScene(scene,
-    "Kilometre per second", "velocity", "", "km/s", 3, -10000., 10000., Self::GetDisplayCoefficient("kilo"), 0.);
+    "Kilometre per second", "velocity", "", "km/s", "", "", 3, -10000., 10000., Self::GetDisplayCoefficient("kilo"), 0.);
 
   this->AddUnitNodeToScene(scene,
-    "Intensity", "intensity", "", "W/m\xB2", 3, -10000., 10000., 1., 0.);
+    "Intensity", "intensity", "", "W/m\xB2", "", "", 3, -10000., 10000., 1., 0.);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
@@ -54,6 +54,8 @@ public:
     const char* quantity = "length",
     const char* prefix = "",
     const char* suffix = "",
+    const char* secondSuffix = "",
+    const char* thirdSuffix = "",
     int precision = 3,
     double min = -10000.,
     double max = 10000.);
@@ -187,6 +189,8 @@ protected:
     const char* quantity = "length",
     const char* prefix = "",
     const char* suffix = "",
+    const char* secondSuffix = "",
+    const char* thirdSuffix = "",
     int precision = 3,
     double min = -10000.,
     double max = 10000.,

--- a/Modules/Loadable/Units/Widgets/Resources/UI/qMRMLUnitWidget.ui
+++ b/Modules/Loadable/Units/Widgets/Resources/UI/qMRMLUnitWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>296</width>
-    <height>283</height>
+    <height>339</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,10 +17,48 @@
    <property name="margin">
     <number>0</number>
    </property>
-   <item row="1" column="0">
-    <widget class="QLabel" name="PresetLabel">
+   <item row="11" column="0">
+    <widget class="QLabel" name="MaximumValueLabel">
      <property name="text">
-      <string>Preset</string>
+      <string>Maximum</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLineEdit" name="SuffixLineEdit">
+     <property name="toolTip">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Set the suffix of the unit. For example, the suffix for the unit &lt;/span&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;Meter&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt; should probably be &lt;/span&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;m&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1">
+    <widget class="ctkDoubleSpinBox" name="MaximumSpinBox">
+     <property name="toolTip">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Set the maximum value possible for the unit.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;For example, a speed unit (in &lt;/span&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;m.s&lt;/span&gt;&lt;span style=&quot; font-size:8pt; font-weight:600; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;) should probably have a maximum of 3e6. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="decimals">
+      <number>3</number>
+     </property>
+     <property name="decimalsOption">
+      <set>ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::InsertDecimals</set>
+     </property>
+     <property name="minimum">
+      <double>-10000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>10000.000000000000000</double>
      </property>
     </widget>
    </item>
@@ -54,10 +92,24 @@
      </property>
     </widget>
    </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="SuffixLabel">
+     <property name="text">
+      <string>Suffix</string>
+     </property>
+    </widget>
+   </item>
    <item row="5" column="0">
     <widget class="QLabel" name="PrefixLabel">
      <property name="text">
       <string>Prefix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="PresetLabel">
+     <property name="text">
+      <string>Preset</string>
      </property>
     </widget>
    </item>
@@ -73,66 +125,14 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="SuffixLabel">
-     <property name="text">
-      <string>Suffix</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QLineEdit" name="SuffixLineEdit">
-     <property name="toolTip">
-      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Set the suffix of the unit. For example, the suffix for the unit &lt;/span&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;Meter&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt; should probably be &lt;/span&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;m&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
    <item row="9" column="0">
-    <widget class="QLabel" name="MaximumValueLabel">
-     <property name="text">
-      <string>Maximum</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="ctkDoubleSpinBox" name="MaximumSpinBox">
-     <property name="toolTip">
-      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Set the maximum value possible for the unit.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;For example, a speed unit (in &lt;/span&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;m.s&lt;/span&gt;&lt;span style=&quot; font-size:8pt; font-weight:600; vertical-align:super;&quot;&gt;-1&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;) should probably have a maximum of 3e6. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="decimalsOption">
-      <set>ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::InsertDecimals</set>
-     </property>
-     <property name="minimum">
-      <double>-10000.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>10000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
     <widget class="QLabel" name="PrecisionLabel">
      <property name="text">
       <string>Precision</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="9" column="1">
     <widget class="QSpinBox" name="PrecisionSpinBox">
      <property name="toolTip">
       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -153,14 +153,24 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="7" column="0">
+    <widget class="QLabel" name="SecondSuffixLabel">
+     <property name="text">
+      <string>SecondSuffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
     <widget class="QLabel" name="MinimumValueLabel">
      <property name="text">
       <string>Minimum</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="NameLineEdit"/>
+   </item>
+   <item row="10" column="1">
     <widget class="ctkDoubleSpinBox" name="MinimumSpinBox">
      <property name="toolTip">
       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
@@ -191,20 +201,10 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="NameLineEdit"/>
-   </item>
    <item row="2" column="0" colspan="2">
     <widget class="Line" name="SeparationLine">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="QuantityLabel">
-     <property name="text">
-      <string>Quantity</string>
      </property>
     </widget>
    </item>
@@ -215,14 +215,21 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="10" column="0">
+   <item row="4" column="0">
+    <widget class="QLabel" name="QuantityLabel">
+     <property name="text">
+      <string>Quantity</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
     <widget class="QLabel" name="CoefficientLabel">
      <property name="text">
       <string>Coefficient</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
+   <item row="12" column="1">
     <widget class="ctkDoubleSpinBox" name="CoefficientSpinBox">
      <property name="decimalsOption">
       <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::DecimalsByValue|ctkDoubleSpinBox::InsertDecimals</set>
@@ -238,14 +245,14 @@ p, li { white-space: pre-wrap; }
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
+   <item row="13" column="0">
     <widget class="QLabel" name="OffsetLabel">
      <property name="text">
       <string>Offset</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="1">
+   <item row="13" column="1">
     <widget class="ctkDoubleSpinBox" name="OffsetSpinBox">
      <property name="decimals">
       <number>0</number>
@@ -260,6 +267,19 @@ p, li { white-space: pre-wrap; }
       <double>10000.000000000000000</double>
      </property>
     </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="ThirdSuffixLabel">
+     <property name="text">
+      <string>ThirdSuffix</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="SecondSuffixLineEdit"/>
+   </item>
+   <item row="8" column="1">
+    <widget class="QLineEdit" name="ThirdSuffixLineEdit"/>
    </item>
   </layout>
  </widget>

--- a/Modules/Loadable/Units/Widgets/qMRMLUnitWidget.cxx
+++ b/Modules/Loadable/Units/Widgets/qMRMLUnitWidget.cxx
@@ -85,6 +85,14 @@ void qMRMLUnitWidgetPrivate::setupUi(qMRMLUnitWidget* q)
     q, SLOT(setSuffix(QString)));
   QObject::connect(this->SuffixLineEdit, SIGNAL(textChanged(QString)),
     q, SIGNAL(suffixChanged(QString)));
+  QObject::connect(this->SecondSuffixLineEdit, SIGNAL(textChanged(QString)),
+    q, SLOT(setSecondSuffix(QString)));
+  QObject::connect(this->SecondSuffixLineEdit, SIGNAL(textChanged(QString)),
+    q, SIGNAL(secondSuffixChanged(QString)));
+  QObject::connect(this->ThirdSuffixLineEdit, SIGNAL(textChanged(QString)),
+    q, SLOT(setThirdSuffix(QString)));
+  QObject::connect(this->ThirdSuffixLineEdit, SIGNAL(textChanged(QString)),
+    q, SIGNAL(thirdSuffixChanged(QString)));
 
   QObject::connect(this->PrecisionSpinBox, SIGNAL(valueChanged(int)),
     q, SLOT(setPrecision(int)));
@@ -122,6 +130,8 @@ void qMRMLUnitWidgetPrivate::clear()
   this->QuantityLineEdit->clear();
   this->PrefixLineEdit->clear();
   this->SuffixLineEdit->clear();
+  this->SecondSuffixLineEdit->clear();
+  this->ThirdSuffixLineEdit->clear();
   this->PrecisionSpinBox->setValue(3);
   this->MinimumSpinBox->setValue(-1000);
   this->MaximumSpinBox->setValue(1000);
@@ -180,6 +190,24 @@ void qMRMLUnitWidgetPrivate::updatePropertyWidgets()
     this->DisplayFlags.testFlag(qMRMLUnitWidget::Suffix));
   this->SuffixLabel->setEnabled(
     this->EditableProperties.testFlag(qMRMLUnitWidget::Suffix));
+
+  this->SecondSuffixLineEdit->setVisible(
+    this->DisplayFlags.testFlag(qMRMLUnitWidget::SecondSuffix));
+  this->SecondSuffixLineEdit->setEnabled(
+    this->EditableProperties.testFlag(qMRMLUnitWidget::SecondSuffix));
+  this->SecondSuffixLabel->setVisible(
+    this->DisplayFlags.testFlag(qMRMLUnitWidget::SecondSuffix));
+  this->SecondSuffixLabel->setEnabled(
+    this->EditableProperties.testFlag(qMRMLUnitWidget::SecondSuffix));
+
+  this->ThirdSuffixLineEdit->setVisible(
+    this->DisplayFlags.testFlag(qMRMLUnitWidget::ThirdSuffix));
+  this->ThirdSuffixLineEdit->setEnabled(
+    this->EditableProperties.testFlag(qMRMLUnitWidget::ThirdSuffix));
+  this->ThirdSuffixLabel->setVisible(
+    this->DisplayFlags.testFlag(qMRMLUnitWidget::ThirdSuffix));
+  this->ThirdSuffixLabel->setEnabled(
+    this->EditableProperties.testFlag(qMRMLUnitWidget::ThirdSuffix));
 
   this->PrecisionSpinBox->setVisible(
     this->DisplayFlags.testFlag(qMRMLUnitWidget::Precision));
@@ -293,6 +321,8 @@ void qMRMLUnitWidget::updateWidgetFromNode()
   d->NameLineEdit->setEnabled(d->CurrentUnitNode != 0);
   d->PrefixLineEdit->setEnabled(d->CurrentUnitNode != 0);
   d->SuffixLineEdit->setEnabled(d->CurrentUnitNode != 0);
+  d->SecondSuffixLineEdit->setEnabled(d->CurrentUnitNode != 0);
+  d->ThirdSuffixLineEdit->setEnabled(d->CurrentUnitNode != 0);
   d->PrecisionSpinBox->setEnabled(d->CurrentUnitNode != 0);
   d->MinimumSpinBox->setEnabled(d->CurrentUnitNode != 0);
   d->MaximumSpinBox->setEnabled(d->CurrentUnitNode != 0);
@@ -316,6 +346,8 @@ void qMRMLUnitWidget::updateWidgetFromNode()
   d->NameLineEdit->setText(d->CurrentUnitNode->GetName());
   d->QuantityLineEdit->setText(d->CurrentUnitNode->GetQuantity());
   d->SuffixLineEdit->setText(d->CurrentUnitNode->GetSuffix());
+  d->SecondSuffixLineEdit->setText(d->CurrentUnitNode->GetSecondSuffix());
+  d->ThirdSuffixLineEdit->setText(d->CurrentUnitNode->GetThirdSuffix());
   d->PrefixLineEdit->setText(QString(d->CurrentUnitNode->GetPrefix()));
   d->PrecisionSpinBox->setValue(d->CurrentUnitNode->GetPrecision());
   d->MinimumSpinBox->setValue(d->CurrentUnitNode->GetMinimumValue());
@@ -388,6 +420,20 @@ QString qMRMLUnitWidget::suffix() const
 }
 
 //-----------------------------------------------------------------------------
+QString qMRMLUnitWidget::secondSuffix() const
+{
+  Q_D(const qMRMLUnitWidget);
+  return d->SecondSuffixLineEdit->text();
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLUnitWidget::thirdSuffix() const
+{
+  Q_D(const qMRMLUnitWidget);
+  return d->ThirdSuffixLineEdit->text();
+}
+
+//-----------------------------------------------------------------------------
 void qMRMLUnitWidget::setSuffix(const QString& newSuffix)
 {
   Q_D(qMRMLUnitWidget);
@@ -398,6 +444,28 @@ void qMRMLUnitWidget::setSuffix(const QString& newSuffix)
     }
   d->MaximumSpinBox->setSuffix(newSuffix);
   d->MinimumSpinBox->setSuffix(newSuffix);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLUnitWidget::setSecondSuffix(const QString& newSuffix)
+{
+  Q_D(qMRMLUnitWidget);
+
+  if (d->CurrentUnitNode)
+    {
+    d->CurrentUnitNode->SetSecondSuffix(newSuffix.toLatin1());
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLUnitWidget::setThirdSuffix(const QString& newSuffix)
+{
+  Q_D(qMRMLUnitWidget);
+
+  if (d->CurrentUnitNode)
+    {
+    d->CurrentUnitNode->SetThirdSuffix(newSuffix.toLatin1());
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -518,11 +586,12 @@ void qMRMLUnitWidget::setUnitFromPreset(vtkMRMLNode* presetNode)
   d->CurrentUnitNode->SetQuantity(presetUnitNode->GetQuantity());
   d->CurrentUnitNode->SetPrefix(presetUnitNode->GetPrefix());
   d->CurrentUnitNode->SetSuffix(presetUnitNode->GetSuffix());
+  d->CurrentUnitNode->SetSecondSuffix(presetUnitNode->GetSecondSuffix());
+  d->CurrentUnitNode->SetThirdSuffix(presetUnitNode->GetThirdSuffix());
   d->CurrentUnitNode->SetPrecision(presetUnitNode->GetPrecision());
   d->CurrentUnitNode->SetMinimumValue(presetUnitNode->GetMinimumValue());
   d->CurrentUnitNode->SetMaximumValue(presetUnitNode->GetMaximumValue());
-  d->CurrentUnitNode->SetDisplayCoefficient(
-    presetUnitNode->GetDisplayCoefficient());
+  d->CurrentUnitNode->SetDisplayCoefficient(presetUnitNode->GetDisplayCoefficient());
   d->CurrentUnitNode->SetDisplayOffset(presetUnitNode->GetDisplayOffset());
   d->CurrentUnitNode->EndModify(disabledModify);
 }

--- a/Modules/Loadable/Units/Widgets/qMRMLUnitWidget.h
+++ b/Modules/Loadable/Units/Widgets/qMRMLUnitWidget.h
@@ -55,6 +55,12 @@ class Q_SLICER_MODULE_UNITS_WIDGETS_EXPORT qMRMLUnitWidget : public qMRMLWidget
   /// This property controls the suffix of the unit node.
   /// \sa suffix(), setSuffix(), suffixChanged()
   Q_PROPERTY(QString suffix READ suffix WRITE setSuffix NOTIFY suffixChanged)
+  /// This property controls the secondSuffix of the unit node.
+  /// \sa secondSuffix(), setSecondSuffix(), secondSuffixChanged()
+  Q_PROPERTY(QString secondSuffix READ secondSuffix WRITE setSecondSuffix NOTIFY secondSuffixChanged)
+  /// This property controls the thirdSuffix of the unit node.
+  /// \sa thirdSuffix(), setThirdSuffix(), thirdSuffixChanged()
+  Q_PROPERTY(QString thirdSuffix READ thirdSuffix WRITE setThirdSuffix NOTIFY thirdSuffixChanged)
   /// This property controls the precision of the unit node.
   /// \sa precision(), setPrecision(), precisionChanged()
   Q_PROPERTY(int precision READ precision WRITE setPrecision NOTIFY precisionChanged)
@@ -100,6 +106,12 @@ public:
   /// Return the suffix property value.
   /// \sa suffix
   QString suffix() const;
+  /// Return the secondSuffix property value.
+  /// \sa secondSuffix
+  QString secondSuffix() const;
+  /// Return the thirdSuffix property value.
+  /// \sa thirdSuffix
+  QString thirdSuffix() const;
   /// Return the precision property value.
   /// \sa precision
   int precision() const;
@@ -125,6 +137,8 @@ public:
     Precision = 0x008,
     Prefix = 0x010,
     Suffix = 0x020,
+    SecondSuffix = 0x021,
+    ThirdSuffix = 0x022,
     Minimum = 0x040,
     Maximum = 0x080,
     Coefficient = 0x100,
@@ -160,6 +174,12 @@ public slots:
   /// Set the suffix property value.
   /// \sa suffix
   void setSuffix(const QString &);
+  /// Set the secondSuffix property value.
+  /// \sa secondSuffix
+  void setSecondSuffix(const QString &);
+  /// Set the thirdSuffix property value.
+  /// \sa thirdSuffix
+  void setThirdSuffix(const QString &);
   /// Set the precision property value.
   /// \sa precision
   void setPrecision(int);
@@ -194,6 +214,8 @@ signals:
   void quantityChanged(QString);
   void prefixChanged(QString);
   void suffixChanged(QString);
+  void secondSuffixChanged(QString);
+  void thirdSuffixChanged(QString);
   void precisionChanged(int);
   void minimumChanged(double);
   void maximumChanged(double);

--- a/Modules/Loadable/Units/qSlicerUnitsSettingsPanel.cxx
+++ b/Modules/Loadable/Units/qSlicerUnitsSettingsPanel.cxx
@@ -116,6 +116,12 @@ void qSlicerUnitsSettingsPanelPrivate
   q->registerProperty(quantity + "/suffix", unitWidget->unitWidget(),
     "suffix", SIGNAL(suffixChanged(QString)),
     QString(), ctkSettingsPanel::OptionNone, app->revisionUserSettings());
+  q->registerProperty(quantity + "/secondSuffix", unitWidget->unitWidget(),
+    "secondSuffix", SIGNAL(secondSuffixChanged(QString)),
+    QString(), ctkSettingsPanel::OptionNone, app->revisionUserSettings());
+  q->registerProperty(quantity + "/thirdSuffix", unitWidget->unitWidget(),
+    "thirdSuffix", SIGNAL(thirdSuffixChanged(QString)),
+    QString(), ctkSettingsPanel::OptionNone, app->revisionUserSettings());
   q->registerProperty(quantity + "/precision", unitWidget->unitWidget(),
     "precision", SIGNAL(precisionChanged(int)),
     QString(), ctkSettingsPanel::OptionNone, app->revisionUserSettings());
@@ -351,6 +357,7 @@ void qSlicerUnitsSettingsPanel::showAll(bool showAll)
     qMRMLUnitWidget::UnitProperties allButNameAndQuantity =
       qMRMLUnitWidget::Preset |
       qMRMLUnitWidget::Prefix | qMRMLUnitWidget::Suffix |
+      qMRMLUnitWidget::SecondSuffix |   qMRMLUnitWidget::ThirdSuffix |
       qMRMLUnitWidget::Precision |
       qMRMLUnitWidget::Minimum | qMRMLUnitWidget::Maximum |
       qMRMLUnitWidget::Coefficient | qMRMLUnitWidget::Offset;


### PR DESCRIPTION
Hi,

in order to enable proper format for units with more suffixes (see figure below), I'd like to propose the following changes:

1) adding SecondSuffix and ThirdSuffix in MRML, Logic and Qt classes of Units.

2)  Overload of GetDisplayStringFromValue

3) Overload of GetDisplayStringFromDisplayValueString

![capture](https://cloud.githubusercontent.com/assets/7985338/9981775/b5a65852-5fc6-11e5-953e-44ddf88c9ce2.png)

@pieper, @jcfr and @finetjul may you kindly check the pull request?

Thanks ,

Davide. 