### PR TITLE
BUG: Fix unitialized variable that causes py_LabelStatistics test failure

### DIFF
--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -471,6 +471,7 @@ vtkSlicerVolumesLogic::vtkSlicerVolumesLogic()
   this->RegisterArchetypeVolumeNodeSetFactory( ScalarVolumeNodeSetFactory );
 
   this->CompareVolumeGeometryEpsilon = 0.000001;
+  this->CompareVolumeGeometryPrecision = 6;
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
+++ b/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
@@ -25,6 +25,8 @@ class VolumesLogicCompareVolumeGeometryTesting(unittest.TestCase):
     volumesLogic = slicer.modules.volumes.logic()
     print 'Compare volume geometry epsilon: ', volumesLogic.GetCompareVolumeGeometryEpsilon()
     print 'Compare volume geometry precision: ', volumesLogic.GetCompareVolumeGeometryPrecision()
+    self.assertAlmostEqual(volumesLogic.GetCompareVolumeGeometryEpsilon(), 1e-6)
+    self.assertEqual(volumesLogic.GetCompareVolumeGeometryPrecision(), 6)
 
     #
     # compare the head against itself, this shouldn't produce any warning


### PR DESCRIPTION
In a release build running the py_LabelStatistics test intermittently results in
a hang or memory corruption.

This commit fixes the problem by initializing a member variable in
vtkSlicerVolumesLogic. The member variable, and therefore the regression, was
introduced in r23934 ("BUG: avoid false positives on geometry check"). The
initial value matches what's described in the member variable's comment.

The unit test is updated to check the initial value of the member variable.