### PR TITLE
Support new-style classes for scripted modules/widgets; use VTKObservationMixin in EditorWidget

### DIFF
--- a/Base/QTCore/qSlicerScriptedUtils.cxx
+++ b/Base/QTCore/qSlicerScriptedUtils.cxx
@@ -144,7 +144,17 @@ PyObject* qSlicerPythonCppAPI::instantiateClass(QObject* cpp, const QString& cla
 
   // Attempt to instantiate the associated python class
   PythonQtObjectPtr self;
-  self.setNewRef(PyInstance_New(classToInstantiate, arguments, 0));
+
+  if (PyType_Check(classToInstantiate))
+    {
+    // New style class
+    self.setNewRef(PyObject_Call(classToInstantiate, arguments, 0));
+    }
+  else
+    {
+    self.setNewRef(PyInstance_New(classToInstantiate, arguments, 0));
+    }
+
   Py_DECREF(arguments);
 
   if (!self)

--- a/Base/QTGUI/Testing/Cxx/Resources/qSlicerBaseQTGUITesting.qrc
+++ b/Base/QTGUI/Testing/Cxx/Resources/qSlicerBaseQTGUITesting.qrc
@@ -1,8 +1,10 @@
 <!DOCTYPE RCC><RCC version="1.0">
   <qresource>
     <file alias="qSlicerScriptedLoadableModuleTestWidget.py">../../Data/Input/qSlicerScriptedLoadableModuleTestWidget.py</file>
+    <file alias="qSlicerScriptedLoadableModuleNewStyleTestWidget.py">../../Data/Input/qSlicerScriptedLoadableModuleNewStyleTestWidget.py</file>
     <file alias="qSlicerScriptedLoadableModuleSyntaxErrorTestWidget.py">../../Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTestWidget.py</file>
     <file alias="qSlicerScriptedLoadableModuleTest.py">../../Data/Input/qSlicerScriptedLoadableModuleTest.py</file>
+    <file alias="qSlicerScriptedLoadableModuleNewStyleTest.py">../../Data/Input/qSlicerScriptedLoadableModuleNewStyleTest.py</file>
     <file alias="qSlicerScriptedLoadableModuleSyntaxErrorTest.py">../../Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTest.py</file>
     <file>Icons/AnnotationPointWithArrow.png</file>
     <file>Icons/AnnotationDistanceWithArrow.png</file>

--- a/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleTest.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleTest.cxx
@@ -125,6 +125,7 @@ void qSlicerScriptedLoadableModuleTester::testSetPythonSource_data()
 
   QTest::newRow("0") << "qSlicerScriptedLoadableModuleTest.py" << false;
   QTest::newRow("1") << "qSlicerScriptedLoadableModuleSyntaxErrorTest.py" << true;
+  QTest::newRow("2") << "qSlicerScriptedLoadableModuleNewStyleTest.py" << false;
 }
 
 namespace
@@ -160,6 +161,7 @@ void qSlicerScriptedLoadableModuleTester::testSetup_data()
   QTest::addColumn<QString>("scriptName");
 
   QTest::newRow("0") << "qSlicerScriptedLoadableModuleTest.py";
+  QTest::newRow("1") << "qSlicerScriptedLoadableModuleNewStyleTest.py";
 }
 
 // ----------------------------------------------------------------------------

--- a/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleWidgetTest.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleWidgetTest.cxx
@@ -129,6 +129,7 @@ void qSlicerScriptedLoadableModuleWidgetTester::testSetPythonSource_data()
   QTest::newRow("0") << "qSlicerScriptedLoadableModuleTestWidget.py" << false;
   QTest::newRow("1") << "qSlicerScriptedLoadableModuleTest.py" << false;
   QTest::newRow("2") << "qSlicerScriptedLoadableModuleSyntaxErrorTestWidget.py" << true;
+  QTest::newRow("3") << "qSlicerScriptedLoadableModuleNewStyleTestWidget.py" << false;
 }
 
 // ----------------------------------------------------------------------------
@@ -158,6 +159,7 @@ void qSlicerScriptedLoadableModuleWidgetTester::testEnterExit_data()
   QTest::addColumn<QString>("scriptName");
 
   QTest::newRow("0") << "qSlicerScriptedLoadableModuleTestWidget.py";
+  QTest::newRow("1") << "qSlicerScriptedLoadableModuleNewStyleTestWidget.py";
 }
 
 
@@ -194,6 +196,7 @@ void qSlicerScriptedLoadableModuleWidgetTester::testSetup_data()
   QTest::addColumn<QString>("scriptName");
 
   QTest::newRow("0") << "qSlicerScriptedLoadableModuleTestWidget.py";
+  QTest::newRow("1") << "qSlicerScriptedLoadableModuleNewStyleTestWidget.py";
 }
 
 // ----------------------------------------------------------------------------

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTest.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTest.py
@@ -1,0 +1,17 @@
+
+
+class qSlicerScriptedLoadableModuleNewStyleTest(object):
+  def __init__(self, parent):
+    parent.title = "qSlicerScriptedLoadableModuleNewStyle Test"
+    parent.categories = ["Testing"]
+    parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware); Max Smolens (Kitware)"]
+    parent.helpText = """
+    This module is for testing.
+    """
+    parent.acknowledgementText = """
+    Based on qSlicerScriptedLoadableModuleTest .
+    """
+    self.parent = parent
+
+  def setup(self):
+    self.parent.setProperty('setup_called_within_Python', True)

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTestWidget.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTestWidget.py
@@ -1,0 +1,14 @@
+
+
+class qSlicerScriptedLoadableModuleNewStyleTestWidget(object):
+  def __init__(self, parent=None):
+    self.parent = parent
+
+  def setup(self):
+    self.parent.setProperty('setup_called_within_Python', True)
+
+  def enter(self):
+    self.parent.setProperty('enter_called_within_Python', True)
+
+  def exit(self):
+    self.parent.setProperty('exit_called_within_Python', True)

--- a/Modules/Scripted/Editor/Editor.py
+++ b/Modules/Scripted/Editor/Editor.py
@@ -3,6 +3,8 @@ from __main__ import slicer
 import qt, ctk, vtk
 import EditorLib
 from EditorLib.EditUtil import EditUtil
+import slicer
+from slicer.util import VTKObservationMixin
 
 #
 # Editor
@@ -39,13 +41,13 @@ This work is partially supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colon
 # qSlicerPythonModuleExampleWidget
 #
 
-class EditorWidget:
+class EditorWidget(VTKObservationMixin):
 
   # Lower priorities:
   #->> additional option for list of allowed labels - texts
 
   def __init__(self, parent=None, showVolumesFrame=True):
-    self.observerTags = []
+    VTKObservationMixin.__init__(self)
     self.shortcuts = []
     self.toolsBox = None
 
@@ -150,9 +152,9 @@ class EditorWidget:
     # Observe the parameter node in order to make changes to
     # button states as needed
     self.parameterNode = EditUtil.getParameterNode()
-    self.parameterNodeTag = self.parameterNode.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
+    self.addObserver(self.parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
-    self.mrmlSceneTag = slicer.mrmlScene.AddObserver(slicer.mrmlScene.StartCloseEvent, self.resetInterface)
+    self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.resetInterface)
 
     if self.helper:
       self.helper.onEnter()
@@ -161,8 +163,7 @@ class EditorWidget:
       self.toolsColor.updateGUIFromMRML(self.parameterNode, vtk.vtkCommand.ModifiedEvent)
 
   def exit(self):
-    slicer.mrmlScene.RemoveObserver(self.mrmlSceneTag)
-    self.parameterNode.RemoveObserver(self.parameterNodeTag)
+    self.removeObservers()
     self.resetInterface()
     self.removeShortcutKeys()
 


### PR DESCRIPTION
This change makes EditorWidget use VTKObservationMixin to simplify managing observers, as suggested in https://github.com/Slicer/Slicer/pull/346#issuecomment-141474443.

To support using VTKObservationMixin with EditorWidget, this change also adds support for writing scripted module and widget classes as new-style Python classes.
