### PR TITLE
BUG: Fix memory leaks when saving scene fails

### DIFF
--- a/Libs/vtkITK/vtkITKImageWriter.cxx
+++ b/Libs/vtkITK/vtkITKImageWriter.cxx
@@ -130,8 +130,8 @@ void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *f
   typename ImageImportType::Pointer itkImporter = ImageImportType::New();
 
   // vtk export for  vtk image
-  vtkImageExport* vtkExporter = vtkImageExport::New();
-  vtkImageFlip* vtkFlip = vtkImageFlip::New();
+  vtkNew<vtkImageExport> vtkExporter;
+  vtkNew<vtkImageFlip> vtkFlip;
 
   // writer
   typedef typename itk::ImageFileWriter<ImageType> ImageWriterType;
@@ -158,7 +158,7 @@ void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *f
   vtkFlip->SetFilteredAxis(1);
   vtkFlip->FlipAboutOriginOn();
 
-  ConnectPipelines(vtkExporter, itkImporter);
+  ConnectPipelines(vtkExporter.GetPointer(), itkImporter);
 
   // write image
   if(self->GetImageIOClassName())
@@ -224,9 +224,6 @@ void ITKWriteVTKImage(vtkITKImageWriter *self, vtkImageData *inputImage, char *f
     exception.Print(std::cerr);
     throw exception;
     }
-  // clean up
-  vtkExporter->Delete();
-  vtkFlip->Delete();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This commit replaces manual memory management with smart pointers to fix memory
leaks in vtkITKImageWriter::Write() when an exception occurs while writing the
image.

Fixes issue #3717:

    To reproduce:
     -> Create folder ~/test
     -> Start Slicer
     -> Download MRHead
     -> File -> Save Scene
     -> Click "Change directory for selected files" and select "~/test"
     -> after selecting the folder and before clicking Save => chmod -w ~/test
     -> Click Save
     -> When you get the "Cannot write data file" error, click Yes to say you want to continue despite the problem
     -> When you get the "Cannot write scene file" error, click Yes to say you ignore these errors and close saving
     -> Close Slicer (click Exit and discard modification)

    Then, you get the following leaks:

    Class "vtkCellData" has 1 instance still around.
    Class "vtkInformationIntegerVectorValue" has 3 instances still around.
    Class "vtkInformationVector" has 15 instances still around.
    Class "vtkPointData" has 1 instance still around.
    Class "vtkImageFlip" has 1 instance still around.
    Class "vtkTrivialProducer" has 1 instance still around.
    Class "vtkMatrix4x4" has 1 instance still around.
    Class "vtkPoints" has 1 instance still around.
    Class "vtkInformation" has 21 instances still around.
    Class "vtkMultiThreader" has 1 instance still around.
    Class "vtkInformationIntegerPointerValue" has 2 instances still around.
    Class "vtkIdList" has 1 instance still around.
    Class "vtkImageExport" has 1 instance still around.
    Class "vtkDoubleArray" has 1 instance still around.
    Class "vtkAlgorithmOutput" has 1 instance still around.
    Class "vtkImageStencilData" has 1 instance still around.
    Class "vtkInformationIntegerValue" has 26 instances still around.
    Class "vtkExtentTranslator" has 1 instance still around.
    Class "vtkImageData" has 1 instance still around.
    Class "vtkInformationStringValue" has 1 instance still around.
    Class "vtkInformationExecutivePortVectorValue" has 1 instance still around.
    Class "vtkShortArray" has 1 instance still around.
    Class "vtkVoxel" has 1 instance still around.
    Class "vtkFieldData" has 2 instances still around.
    Class "vtkInformationDoubleVectorValue" has 2 instances still around.
    Class "vtkStreamingDemandDrivenPipeline" has 3 instances still around.
    Class "vtkInformationExecutivePortValue" has 4 instances still around.