### PR TITLE
ENH: Built-in module categories are listed separately in modules list

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -1728,6 +1728,34 @@ bool vtkSlicerApplicationLogic::IsPluginInstalled(const std::string& filePath,
   return true;
 }
 
+//----------------------------------------------------------------------------
+bool vtkSlicerApplicationLogic::IsPluginBuiltIn(const std::string& filePath,
+                                                  const std::string& applicationHomeDir)
+{
+  if (filePath.empty())
+    {
+    vtkGenericWarningMacro( << "filePath is an empty string !");
+    return false;
+    }
+  if (applicationHomeDir.empty())
+    {
+    vtkGenericWarningMacro( << "applicationHomeDir is an empty string !");
+    return false;
+    }
+
+  std::string path = itksys::SystemTools::GetFilenamePath(filePath);
+  std::string canonicalPath = itksys::SystemTools::GetRealPath(path.c_str());
+
+  // On MacOSX extensions are installed in the "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>"
+  // folder being a sub directory of the application dir, an extra test is required to make sure the
+  // tested filePath doesn't belong to that "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>" folder.
+  // Since package name can be rename from "Slicer.app" to "Something.app", let's compare
+  // using ".app/Contents/" instead of "Slicer_BUNDLE_LOCATION" which is "Slicer.app/Contents/"
+  bool macExtension = (canonicalPath.find(".app/Contents/" Slicer_EXTENSIONS_DIRBASENAME "-") != std::string::npos);
+
+  return itksys::SystemTools::StringStartsWith(canonicalPath.c_str(), applicationHomeDir.c_str()) && !macExtension;
+}
+
 namespace
 {
 //----------------------------------------------------------------------------

--- a/Base/Logic/vtkSlicerApplicationLogic.h
+++ b/Base/Logic/vtkSlicerApplicationLogic.h
@@ -182,6 +182,9 @@ class VTK_SLICER_BASE_LOGIC_EXPORT vtkSlicerApplicationLogic
   /// an other project.
   static bool IsPluginInstalled(const std::string& filePath, const std::string& applicationHomeDir);
 
+  /// Return \a true if the plugin identified with its \a filePath is a built-in Slicer module.
+  static bool IsPluginBuiltIn(const std::string& filePath, const std::string& applicationHomeDir);
+
   /// Get share directory associated with \a moduleName located in \a filePath
   static std::string GetModuleShareDirectory(const std::string& moduleName, const std::string& filePath);
 

--- a/Base/QTCLI/qSlicerCLIExecutableModuleFactory.cxx
+++ b/Base/QTCLI/qSlicerCLIExecutableModuleFactory.cxx
@@ -127,6 +127,7 @@ qSlicerAbstractCoreModule* qSlicerCLIExecutableModuleFactoryItem::instanciator()
   module->setTempDirectory(this->TempDirectory);
   module->setPath(this->path());
   module->setInstalled(qSlicerCLIModuleFactoryHelper::isInstalled(this->path()));
+  module->setBuiltIn(qSlicerCLIModuleFactoryHelper::isBuiltIn(this->path()));
 
   this->CLIModule = module.data();
 

--- a/Base/QTCLI/qSlicerCLILoadableModuleFactory.cxx
+++ b/Base/QTCLI/qSlicerCLILoadableModuleFactory.cxx
@@ -80,6 +80,7 @@ qSlicerAbstractCoreModule* qSlicerCLILoadableModuleFactoryItem::instanciator()
   module->setTempDirectory(this->TempDirectory);
   module->setPath(this->path());
   module->setInstalled(qSlicerCLIModuleFactoryHelper::isInstalled(this->path()));
+  module->setBuiltIn(qSlicerCLIModuleFactoryHelper::isBuiltIn(this->path()));
 
   ModuleLogo logo;
   if (updateLogo(this, logo))

--- a/Base/QTCLI/qSlicerCLIModuleFactoryHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleFactoryHelper.cxx
@@ -66,3 +66,10 @@ bool qSlicerCLIModuleFactoryHelper::isInstalled(const QString& path)
   qSlicerCoreApplication * app = qSlicerCoreApplication::application();
   return app ? qSlicerUtils::isPluginInstalled(path, app->slicerHome()) : false;
 }
+
+//-----------------------------------------------------------------------------
+bool qSlicerCLIModuleFactoryHelper::isBuiltIn(const QString& path)
+{
+  qSlicerCoreApplication * app = qSlicerCoreApplication::application();
+  return app ? qSlicerUtils::isPluginBuiltIn(path, app->slicerHome()) : true;
+}

--- a/Base/QTCLI/qSlicerCLIModuleFactoryHelper.h
+++ b/Base/QTCLI/qSlicerCLIModuleFactoryHelper.h
@@ -37,6 +37,9 @@ public:
   /// Convenient method returning True if the given CLI path corresponds to an installed module
   static bool isInstalled(const QString& path);
 
+  /// Convenient method returning True if the given CLI path corresponds to a built-in module
+  static bool isBuiltIn(const QString& path);
+
 private:
   /// Not implemented
   qSlicerCLIModuleFactoryHelper(){}

--- a/Base/QTCore/Testing/Cxx/qSlicerUtilsTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerUtilsTest1.cxx
@@ -30,6 +30,9 @@
 // SlicerQt includes
 #include <qSlicerUtils.h>
 
+// Slicer includes
+#include "vtkSlicerConfigure.h"
+
 // STD includes
 #include <cstdlib>
 #include <iostream>
@@ -70,6 +73,19 @@ bool isPluginInstalledTest(int line, bool expectedResult,
 //              << "\tpath: " << qPrintable(path) << "\n"
 //              << "\tapplicationHomeDir: " << qPrintable(applicationHomeDir) << std::endl;
     QString msg("Line %1 - Problem with isPluginInstalled()\n\tpath: %2\n\tapplicationHomeDir: %3");
+    throw std::runtime_error(qPrintable(msg.arg(line).arg(path).arg(applicationHomeDir)));
+    }
+  return res;
+}
+
+//-----------------------------------------------------------------------------
+bool isPluginBuiltInTest(int line, bool expectedResult,
+                           const QString& path, const QString& applicationHomeDir)
+{
+  bool res = qSlicerUtils::isPluginBuiltIn(path, applicationHomeDir);
+  if (res != expectedResult)
+    {
+    QString msg("Line %1 - Problem with isPluginBuiltIn()\n\tpath: %2\n\tapplicationHomeDir: %3");
     throw std::runtime_error(qPrintable(msg.arg(line).arg(path).arg(applicationHomeDir)));
     }
   return res;
@@ -269,7 +285,7 @@ int qSlicerUtilsTest1(int, char * [] )
     }
 
   //-----------------------------------------------------------------------------
-  // Test isPluginInstalled()
+  // Test isPluginInstalled() and isPluginBuiltIn()
   //-----------------------------------------------------------------------------
 
   QStringList directoriesToRemove;
@@ -318,6 +334,17 @@ int qSlicerUtilsTest1(int, char * [] )
   isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBarDebug + "/plugin.txt", tmp1.path());
   isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBarRelease + "/plugin.txt", tmp1.path());
 
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + debug + "/plugin.txt", tmp1.path());
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + release + "/plugin.txt", tmp1.path());
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + relWithDebInfo + "/plugin.txt", tmp1.path());
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + minSizeRel + "/plugin.txt", tmp1.path());
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + foo + "/plugin.txt", tmp1.path());
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + fooDebug + "/plugin.txt", tmp1.path());
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + fooRelease + "/plugin.txt", tmp1.path());
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + fooBar + "/plugin.txt", tmp1.path());
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + fooBarDebug + "/plugin.txt", tmp1.path());
+  isPluginBuiltInTest(__LINE__, true, tmp1.path() + "/" + fooBarRelease + "/plugin.txt", tmp1.path());
+
   directoriesToRemove << tmp1.path();
 
   //
@@ -347,6 +374,17 @@ int qSlicerUtilsTest1(int, char * [] )
   isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBarDebug + "/plugin.txt", tmp2.path());
   isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBarRelease + "/plugin.txt", tmp2.path());
 
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + debug + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + release + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + relWithDebInfo + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + minSizeRel + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + foo + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooDebug + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooRelease + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooBar + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooBarDebug + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooBarRelease + "/plugin.txt", tmp2.path());
+
   directoriesToRemove << tmp2.path();
 
   //
@@ -370,6 +408,9 @@ int qSlicerUtilsTest1(int, char * [] )
   isPluginInstalledTest(__LINE__, true, tmp3.path() + "/" + foo + "/plugin.txt", tmp2.path());
   isPluginInstalledTest(__LINE__, true, tmp3.path() + "/" + fooBar + "/plugin.txt", tmp2.path());
 
+  isPluginBuiltInTest(__LINE__, false, tmp3.path() + "/" + foo + "/plugin.txt", tmp2.path());
+  isPluginBuiltInTest(__LINE__, false, tmp3.path() + "/" + fooBar + "/plugin.txt", tmp2.path());
+
   directoriesToRemove << tmp3.path();
 
   //
@@ -385,16 +426,27 @@ int qSlicerUtilsTest1(int, char * [] )
   tmp4.mkdir(temporaryDirName);
   tmp4.cd(temporaryDirName);
 
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + debug + "/plugin.txt", tmp1.path());
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + release + "/plugin.txt", tmp1.path());
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + relWithDebInfo + "/plugin.txt", tmp1.path());
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + minSizeRel + "/plugin.txt", tmp1.path());
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + foo + "/plugin.txt", tmp1.path());
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooDebug + "/plugin.txt", tmp1.path());
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooRelease + "/plugin.txt", tmp1.path());
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBar + "/plugin.txt", tmp1.path());
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBarDebug + "/plugin.txt", tmp1.path());
-  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBarRelease + "/plugin.txt", tmp1.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + debug + "/plugin.txt", tmp4.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + release + "/plugin.txt", tmp4.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + relWithDebInfo + "/plugin.txt", tmp4.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + minSizeRel + "/plugin.txt", tmp4.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + foo + "/plugin.txt", tmp4.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooDebug + "/plugin.txt", tmp4.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooRelease + "/plugin.txt", tmp4.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBar + "/plugin.txt", tmp4.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBarDebug + "/plugin.txt", tmp4.path());
+  isPluginInstalledTest(__LINE__, false, tmp1.path() + "/" + fooBarRelease + "/plugin.txt", tmp4.path());
+
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + debug + "/plugin.txt", tmp4.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + release + "/plugin.txt", tmp4.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + relWithDebInfo + "/plugin.txt", tmp4.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + minSizeRel + "/plugin.txt", tmp4.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + foo + "/plugin.txt", tmp4.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooDebug + "/plugin.txt", tmp4.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooRelease + "/plugin.txt", tmp4.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooBar + "/plugin.txt", tmp4.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooBarDebug + "/plugin.txt", tmp4.path());
+  isPluginBuiltInTest(__LINE__, false, tmp1.path() + "/" + fooBarRelease + "/plugin.txt", tmp4.path());
 
   directoriesToRemove << tmp4.path();
 
@@ -403,6 +455,24 @@ int qSlicerUtilsTest1(int, char * [] )
     {
     ctk::removeDirRecursively(dir);
     }
+
+  //
+  // Case 5: Platform is MacOS, application is installed
+  //
+
+#ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
+  QString macSlicerAppDir("/Applications/Slicer.app");
+  QString macSlicerExtensionsPostfix("/Contents/" + QString(Slicer_EXTENSIONS_DIRNAME));
+  QString macSlicerAppExtensionsDir(macSlicerAppDir + macSlicerExtensionsPostfix);
+  QString macRenamedSlicerAppDir("/Applications/Something.app");
+  QString macRenamedSlicerAppExtensionsDir(macRenamedSlicerAppDir + macSlicerExtensionsPostfix);
+
+  isPluginInstalledTest(__LINE__, true, macSlicerAppExtensionsDir, macSlicerAppDir);
+  isPluginInstalledTest(__LINE__, true, macRenamedSlicerAppExtensionsDir, macRenamedSlicerAppDir);
+
+  isPluginBuiltInTest(__LINE__, false, macSlicerAppExtensionsDir, macSlicerAppDir);
+  isPluginBuiltInTest(__LINE__, false, macRenamedSlicerAppExtensionsDir, macRenamedSlicerAppDir);
+#endif
 
   //-----------------------------------------------------------------------------
   // 'tmp' directory is common to 'pathWithoutIntDir' and 'pathEndsWith' tests

--- a/Base/QTCore/qSlicerAbstractCoreModule.cxx
+++ b/Base/QTCore/qSlicerAbstractCoreModule.cxx
@@ -46,6 +46,7 @@ public:
   QString                                    Name;
   QString                                    Path;
   bool                                       Installed;
+  bool                                       BuiltIn;
   bool                                       WidgetRepresentationCreationEnabled;
   qSlicerAbstractModuleRepresentation*       WidgetRepresentation;
   QList<qSlicerAbstractModuleRepresentation*> WidgetRepresentations;
@@ -62,6 +63,7 @@ qSlicerAbstractCoreModulePrivate::qSlicerAbstractCoreModulePrivate()
   this->Name = "NA";
   this->WidgetRepresentation = 0;
   this->Installed = false;
+  this->BuiltIn = false;
   this->WidgetRepresentationCreationEnabled = true;
 }
 
@@ -210,6 +212,10 @@ CTK_SET_CPP(qSlicerAbstractCoreModule, const QString&, setPath, Path);
 //-----------------------------------------------------------------------------
 CTK_GET_CPP(qSlicerAbstractCoreModule, bool, isInstalled, Installed);
 CTK_SET_CPP(qSlicerAbstractCoreModule, bool, setInstalled, Installed);
+
+//-----------------------------------------------------------------------------
+CTK_GET_CPP(qSlicerAbstractCoreModule, bool, isBuiltIn, BuiltIn);
+CTK_SET_CPP(qSlicerAbstractCoreModule, bool, setBuiltIn, BuiltIn);
 
 //-----------------------------------------------------------------------------
 CTK_GET_CPP(qSlicerAbstractCoreModule, bool, isWidgetRepresentationCreationEnabled, WidgetRepresentationCreationEnabled);

--- a/Base/QTCore/qSlicerAbstractCoreModule.h
+++ b/Base/QTCore/qSlicerAbstractCoreModule.h
@@ -167,6 +167,12 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerAbstractCoreModule : public QObject
   /// reimplemented in each module.
   Q_PROPERTY(bool isInstalled READ isInstalled)
 
+  /// This property holds whether module is a built-in Slicer module or
+  /// one from an extension or any user-specified folder.
+  /// \a isBuiltIn is set by the module factory and shouldn't be
+  /// reimplemented in each module.
+  Q_PROPERTY(bool isBuiltIn READ isBuiltIn)
+
 public:
 
   typedef QObject Superclass;
@@ -269,6 +275,11 @@ public:
   /// \todo Ideally this function should be added within the qSlicerLoadableModule.
   bool isInstalled()const;
   void setInstalled(bool value);
+
+  /// Determine if this module is a built-in Slicer module or one from an extension
+  /// or any user-specified folder.
+  bool isBuiltIn()const;
+  void setBuiltIn(bool value);
 
 public slots:
 

--- a/Base/QTCore/qSlicerLoadableModuleFactory.cxx
+++ b/Base/QTCore/qSlicerLoadableModuleFactory.cxx
@@ -49,6 +49,7 @@ qSlicerAbstractCoreModule* qSlicerLoadableModuleFactoryItem::instanciator()
 
   qSlicerCoreApplication * app = qSlicerCoreApplication::application();
   module->setInstalled(qSlicerUtils::isPluginInstalled(this->path(), app->slicerHome()));
+  module->setBuiltIn(qSlicerUtils::isPluginBuiltIn(this->path(), app->slicerHome()));
 
   return module;
 }

--- a/Base/QTCore/qSlicerUtils.cxx
+++ b/Base/QTCore/qSlicerUtils.cxx
@@ -169,6 +169,12 @@ bool qSlicerUtils::isPluginInstalled(const QString& filePath, const QString& app
 }
 
 //-----------------------------------------------------------------------------
+bool qSlicerUtils::isPluginBuiltIn(const QString& filePath, const QString& applicationHomeDir)
+{
+  return vtkSlicerApplicationLogic::IsPluginBuiltIn(filePath.toStdString(), applicationHomeDir.toStdString());
+}
+
+//-----------------------------------------------------------------------------
 QString qSlicerUtils::pathWithoutIntDir(const QString& path, const QString& subDirWithoutIntDir)
 {
   QString tmp;

--- a/Base/QTCore/qSlicerUtils.h
+++ b/Base/QTCore/qSlicerUtils.h
@@ -81,6 +81,9 @@ public:
   /// an other project.
   static bool isPluginInstalled(const QString& filePath, const QString& applicationHomeDir);
 
+  /// Return \a true if the plugin identified with its \a filePath is a built-in Slicer module.
+  static bool isPluginBuiltIn(const QString& filePath, const QString& applicationHomeDir);
+
   /// Return the path without the intermediate directory or return \a path if there is no
   /// expected "IntDir".
   /// \a subDirWithoutIntDir corresponds to N last compononent of the path excluding

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
@@ -57,6 +57,7 @@ qSlicerAbstractCoreModule* ctkFactoryScriptedItem::instanciator()
 
   qSlicerCoreApplication * app = qSlicerCoreApplication::application();
   module->setInstalled(qSlicerUtils::isPluginInstalled(this->path(), app->slicerHome()));
+  module->setBuiltIn(qSlicerUtils::isPluginBuiltIn(this->path(), app->slicerHome()));
 
 #ifdef Slicer_USE_PYTHONQT
   if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))


### PR DESCRIPTION
Modules that are loaded from the Slicer build/install tree are marked as built-in, modules from different folders are not built-in. If a non-built-in module adds a category, then it is shown above the built-in categories, divided by a separator.