### PR TITLE
ENH: serialise singleton tags

### DIFF
--- a/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
@@ -435,6 +435,20 @@
     TEST_SET_GET_BOOLEAN( node, DisableModifiedEvent);                  \
     TEST_SET_GET_BOOLEAN( node, Selected );                             \
                                                                         \
+    /* Test singleton utility methods */                                \
+    node->SetSingletonOff();                                            \
+    if (node->IsSingleton())                                            \
+      {                                                                 \
+      std::cerr << "Error in SetSingletonOff() " << std::endl;          \
+      return EXIT_FAILURE;                                              \
+      }                                                                 \
+    node->SetSingletonOn();                                             \
+    if (!node->IsSingleton())                                           \
+      {                                                                 \
+      std::cerr << "Error in SetSingletonOn() " << std::endl;           \
+      return EXIT_FAILURE;                                              \
+      }                                                                 \
+                                                                        \
     node->Modified();                                                   \
     node->InvokePendingModifiedEvent();                                 \
     node1->SetName("copywithsinglemodified");                           \

--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -353,6 +353,10 @@ void vtkMRMLNode::ReadXMLAttributes(const char** atts)
         this->Selected = 0;
         }
       }
+     else if (!strcmp(attName, "singletonTag"))
+       {
+       this->SetSingletonTag(attValue);
+       }
      else if (!strcmp(attName, "attributes"))
        {
        std::stringstream attributes(attValue);
@@ -452,6 +456,12 @@ void vtkMRMLNode::WriteXML(ostream& of, int nIndent)
 
   of << indent << " selectable=\"" << (this->Selectable ? "true" : "false") << "\"";
   of << indent << " selected=\"" << (this->Selected ? "true" : "false") << "\"";
+
+  if (this->SingletonTag)
+    {
+    of << indent << " singletonTag=\"" << this->SingletonTag << "\"";
+    }
+
   if (this->Attributes.size())
     {
     of << indent << " attributes=\"";

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -339,12 +339,19 @@ public:
   /// The SingletonTag is used by the scene to build a unique ID.
   ///
   /// If the there can only be one instance of a given node class in the scene,
-  /// then the singleton tag should be Singleton.
+  /// then the singleton tag should be Singleton. For example, the interaction and
+  /// selection nodes are named Selection and Interaction, with Singleton tags set to
+  /// Singleton, and with IDs set to vtkMRMLSelectionNodeSingleton and
+  /// vtkMRMLInteractionNodeSingleton.
   /// If the singleton node is associated with a specific module it should be
-  /// named for the module, which already needs to be unique.
+  /// named for the module, which already needs to be unique. The Editor module
+  /// uses this naming convention, with a parameter node that has a singleton tag
+  /// of Editor and a node ID of vtkMRMLScriptedModuleNodeEditor.
   /// If the there is more than one instance of the node class then the
   /// singleton tag should be Singleton post-pended with a unique identifier
-  /// for that specific node (e.g. the name).
+  /// for that specific node (e.g. the name). Any new color nodes should use this
+  /// convention, with a name of NewName, a Singleton tag of SingletonNewName, leading
+  /// to an ID of vtkMRMLColroTableNodeSingletonNewName.
   /// \sa vtkMRMLScene::BuildID
   vtkSetStringMacro(SingletonTag);
   vtkGetStringMacro(SingletonTag);

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -333,13 +333,33 @@ public:
   ///
   /// If set to NULL, multiple instances of this node class are allowed.
   ///
-  /// If set to a non-NULL string, the node will be a singletong and
+  /// If set to a non-NULL string, the node will be a singleton and
   /// the scene will replace this node instead of adding new instances.
   ///
   /// The SingletonTag is used by the scene to build a unique ID.
+  ///
+  /// If the there can only be one instance of a given node class in the scene,
+  /// then the singleton tag should be Singleton.
+  /// If the singleton node is associated with a specific module it should be
+  /// named for the module, which already needs to be unique.
+  /// If the there is more than one instance of the node class then the
+  /// singleton tag should be Singleton post-pended with a unique identifier
+  /// for that specific node (e.g. the name).
   /// \sa vtkMRMLScene::BuildID
   vtkSetStringMacro(SingletonTag);
   vtkGetStringMacro(SingletonTag);
+  void SetSingletonOn()
+    {
+    this->SetSingletonTag("Singleton");
+    }
+  void SetSingletonOff()
+    {
+    this->SetSingletonTag(NULL);
+    }
+  bool IsSingleton()
+    {
+    return (this->GetSingletonTag() != NULL);
+    }
 
   /// Save node with MRML scene.
   vtkGetMacro(SaveWithScene, int);

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -343,8 +343,8 @@ public:
   /// selection nodes are named Selection and Interaction, with Singleton tags set to
   /// Singleton, and with IDs set to vtkMRMLSelectionNodeSingleton and
   /// vtkMRMLInteractionNodeSingleton.
-  /// If the singleton node is associated with a specific module it should be
-  /// named for the module, which already needs to be unique. The Editor module
+  /// If the singleton node is associated with a specific module it should use
+  /// the module name, which already needs to be unique, as a suffix. The Editor module
   /// uses this naming convention, with a parameter node that has a singleton tag
   /// of Editor and a node ID of vtkMRMLScriptedModuleNodeEditor.
   /// If the there is more than one instance of the node class then the

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -344,7 +344,7 @@ public:
   /// Singleton, and with IDs set to vtkMRMLSelectionNodeSingleton and
   /// vtkMRMLInteractionNodeSingleton.
   /// If the singleton node is associated with a specific module it should use
-  /// the module name, which already needs to be unique, as a suffix. The Editor module
+  /// the module name, which already needs to be unique, as the tag. The Editor module
   /// uses this naming convention, with a parameter node that has a singleton tag
   /// of Editor and a node ID of vtkMRMLScriptedModuleNodeEditor.
   /// If the there is more than one instance of the node class then the

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -351,7 +351,9 @@ public:
   /// singleton tag should be Singleton post-pended with a unique identifier
   /// for that specific node (e.g. the name). Any new color nodes should use this
   /// convention, with a name of NewName, a Singleton tag of SingletonNewName, leading
-  /// to an ID of vtkMRMLColroTableNodeSingletonNewName.
+  /// to an ID of vtkMRMLColorTableNodeSingletonNewName.
+  /// The existing MRML nodes don't always use these conventions but are kept unchanged
+  /// for backward compatibility.
   /// \sa vtkMRMLScene::BuildID
   vtkSetStringMacro(SingletonTag);
   vtkGetStringMacro(SingletonTag);

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1552,6 +1552,8 @@ vtkMRMLNode* vtkMRMLScene::GetSingletonNode(vtkMRMLNode* n)
 
   // No singleton node found, but it may be possible that a non-singleton node exists with
   // the same ID, which is probably a singleton node where the tag was not set by mistake.
+  // The vtkMRMLNode was updated to serialize the singleton tag but legacy scene files from
+  // before October 2015 may have saved nodes without the singleton tag having been set.
   std::string singletonId = this->GenerateUniqueID(n);
   sn = this->GetNodeByID(singletonId.c_str());
   if (sn != NULL)


### PR DESCRIPTION
Singleton nodes were not having their singleton tag serialized to MRML,
so on loading a scene back in, two nodes would be present in the scene
if the node logic is relying on the tag to update the node that was originally in
the scene.
This fix serializes the singleton tag to MRML, adds a utility method
to uniformly turn the property on or off, adds a test, and expands
the node documentation.

Issue #4006