### PR TITLE
ENH: Additional costructor slice widgets

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -1230,11 +1230,17 @@ void qMRMLSliceControllerWidgetPrivate::applyCustomLightbox()
 // qMRMLSliceView methods
 
 // --------------------------------------------------------------------------
-qMRMLSliceControllerWidget::qMRMLSliceControllerWidget(QWidget* _parent)
-  : Superclass(new qMRMLSliceControllerWidgetPrivate(*this), _parent)
+qMRMLSliceControllerWidget::qMRMLSliceControllerWidget(QWidget* parentWidget)
+  : Superclass(new qMRMLSliceControllerWidgetPrivate(*this), parentWidget)
 {
   Q_D(qMRMLSliceControllerWidget);
   d->init();
+}
+
+qMRMLSliceControllerWidget::qMRMLSliceControllerWidget(qMRMLSliceControllerWidgetPrivate *pimpl, QWidget *parentWidget)
+  : Superclass(pimpl, parentWidget)
+{
+  // init() should be called in the subclass constructor
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
@@ -269,6 +269,9 @@ signals:
 #endif
   void renderRequested();
 
+protected:
+  qMRMLSliceControllerWidget(qMRMLSliceControllerWidgetPrivate* pimpl, QWidget* parent = 0);
+
 private:
   Q_DECLARE_PRIVATE(qMRMLSliceControllerWidget);
   Q_DISABLE_COPY(qMRMLSliceControllerWidget);

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
@@ -43,7 +43,8 @@
 
 //---------------------------------------------------------------------------
 qMRMLSliceWidgetPrivate::qMRMLSliceWidgetPrivate(qMRMLSliceWidget& object)
-  : q_ptr(&object)
+  : QObject(0)
+  , q_ptr(&object)
 {
 }
 
@@ -103,11 +104,19 @@ void qMRMLSliceWidgetPrivate::setImageDataConnection(vtkAlgorithmOutput * imageD
 // qMRMLSliceView methods
 
 // --------------------------------------------------------------------------
-qMRMLSliceWidget::qMRMLSliceWidget(QWidget* _parent) : Superclass(_parent)
+qMRMLSliceWidget::qMRMLSliceWidget(QWidget* parentWidget)
+  : Superclass(parentWidget)
   , d_ptr(new qMRMLSliceWidgetPrivate(*this))
 {
   Q_D(qMRMLSliceWidget);
   d->init();
+}
+
+qMRMLSliceWidget::qMRMLSliceWidget(qMRMLSliceWidgetPrivate *pimpl, QWidget *parentWidget)
+  : Superclass(parentWidget)
+  , d_ptr(pimpl)
+{
+  // init() should be called in the subclass constructor
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.h
@@ -151,6 +151,7 @@ public slots:
 
 protected:
   QScopedPointer<qMRMLSliceWidgetPrivate> d_ptr;
+  qMRMLSliceWidget(qMRMLSliceWidgetPrivate* pimpl, QWidget* parent = 0);
 
 private:
   Q_DECLARE_PRIVATE(qMRMLSliceWidget);

--- a/Libs/MRML/Widgets/qMRMLSliceWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget_p.h
@@ -57,6 +57,7 @@ class qMRMLSliceWidgetPrivate
 protected:
   qMRMLSliceWidget* const q_ptr;
 public:
+  typedef QObject Superclass;
   qMRMLSliceWidgetPrivate(qMRMLSliceWidget& object);
   ~qMRMLSliceWidgetPrivate();
 


### PR DESCRIPTION
Hi,

I'd like to add the submitted constructors in the classes qMRMLSliceWidget and qMRMLSliceControllerWidget. In this way I can heridate the private calsses for custom widgets, then registered using the factory as described in https://github.com/Slicer/Slicer/pull/309#issuecomment-142910132 .

@jcfr may you take a look?