### PR TITLE
ENH: Introduce autoDeleteSubjectHierarchyChildren property

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -66,6 +66,10 @@ public:
   /// Flag determining whether subject hierarchy nodes are automatically created upon
   /// adding a supported data node in the scene, or just when entering the module.
   bool AutoCreateSubjectHierarchy;
+
+  /// Flag determining whether subject hierarchy children nodes are automatically
+  /// deleted upon deleting a parent subject hierarchy node.
+  bool AutoDeleteSubjectHierarchyChildren;
 };
 
 //-----------------------------------------------------------------------------
@@ -76,6 +80,7 @@ qSlicerSubjectHierarchyPluginLogicPrivate::qSlicerSubjectHierarchyPluginLogicPri
   : q_ptr(&object)
   , DeleteBranchInProgress(false)
   , AutoCreateSubjectHierarchy(false)
+  , AutoDeleteSubjectHierarchyChildren(false)
 {
 }
 
@@ -151,6 +156,20 @@ void qSlicerSubjectHierarchyPluginLogic::setAutoCreateSubjectHierarchy(bool flag
 {
   Q_D(qSlicerSubjectHierarchyPluginLogic);
   d->AutoCreateSubjectHierarchy = flag;
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerSubjectHierarchyPluginLogic::autoDeleteSubjectHierarchyChildren()const
+{
+  Q_D(const qSlicerSubjectHierarchyPluginLogic);
+  return d->AutoDeleteSubjectHierarchyChildren;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyPluginLogic::setAutoDeleteSubjectHierarchyChildren(bool flag)
+{
+  Q_D(qSlicerSubjectHierarchyPluginLogic);
+  d->AutoDeleteSubjectHierarchyChildren = flag;
 }
 
 //-----------------------------------------------------------------------------
@@ -340,11 +359,15 @@ void qSlicerSubjectHierarchyPluginLogic::onNodeAboutToBeRemoved(vtkObject* scene
       subjectHierarchyNode->GetAllChildrenNodes(childrenNodes);
       if (!childrenNodes.empty() && !d->DeleteBranchInProgress)
         {
-        QMessageBox::StandardButton answer =
-          QMessageBox::question(NULL, tr("Delete subject hierarchy branch?"),
-          tr("The deleted subject hierarchy node has children. Do you want to remove those too?\n\nIf you choose yes, the whole branch will be deleted, including all children."),
-          QMessageBox::Yes | QMessageBox::No,
-          QMessageBox::No);
+        QMessageBox::StandardButton answer = QMessageBox::Yes;
+        if (!d->AutoDeleteSubjectHierarchyChildren)
+          {
+          answer =
+            QMessageBox::question(NULL, tr("Delete subject hierarchy branch?"),
+            tr("The deleted subject hierarchy node has children. Do you want to remove those too?\n\nIf you choose yes, the whole branch will be deleted, including all children."),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+          }
         // Delete branch if the user chose yes
         if (answer == QMessageBox::Yes)
           {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
@@ -58,6 +58,12 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qSlicerSubjectHierarchyPlu
   /// if there are supported data nodes in the scene outside subject hierarchy.
   Q_PROPERTY (bool autoCreateSubjectHierarchy READ autoCreateSubjectHierarchy WRITE setAutoCreateSubjectHierarchy)
 
+  /// Flag determining whether children of subject hierarchy nodes are automatically
+  /// deleted upon deleting a parent subject hierarchy node.
+  /// By default, a pop-up question asking the user to confirm the deletion of
+  /// children nodes will be shown.
+  Q_PROPERTY (bool autoDeleteSubjectHierarchyChildren READ autoDeleteSubjectHierarchyChildren WRITE setAutoDeleteSubjectHierarchyChildren)
+
 public:
   typedef QObject Superclass;
   qSlicerSubjectHierarchyPluginLogic(QWidget *parent=0);
@@ -89,6 +95,9 @@ public:
 
   bool autoCreateSubjectHierarchy()const;
   void setAutoCreateSubjectHierarchy(bool flag);
+
+  bool autoDeleteSubjectHierarchyChildren()const;
+  void setAutoDeleteSubjectHierarchyChildren(bool flag);
 
 protected:
   /// Add supported nodes to subject hierarchy.


### PR DESCRIPTION
Flag determining whether children of subject hierarchy nodes are automatically
deleted upon deleting a parent subject hierarchy node.

By default, a pop-up question asking the user to confirm the deletion of
children nodes will be shown.