### PR TITLE
COMP: check if Extension Manager supported

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -1683,6 +1683,8 @@ bool vtkSlicerApplicationLogic::IsEmbeddedModule(const std::string& filePath,
     {
     isEmbedded = false;
     }
+#else
+  (void)slicerRevision;
 #endif
   return isEmbedded;
 }
@@ -1752,12 +1754,16 @@ bool vtkSlicerApplicationLogic::IsPluginBuiltIn(const std::string& filePath,
   bool isBuiltIn = itksys::SystemTools::StringStartsWith(
         canonicalPath.c_str(), canonicalApplicationHomeDir.c_str());
 
+#ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
   // On MacOSX extensions are installed in the "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>"
   // folder being a sub directory of the application dir, an extra test is required to make sure the
   // tested filePath doesn't belong to that "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>" folder.
   // Since package name can be rename from "Slicer.app" to "Something.app", let's compare
   // using ".app/Contents/" instead of "Slicer_BUNDLE_LOCATION" which is "Slicer.app/Contents/"
   bool macExtension = (canonicalPath.find(".app/Contents/" Slicer_EXTENSIONS_DIRBASENAME "-") != std::string::npos);
+#else
+  bool macExtension = false;
+#endif
 
   return  isBuiltIn && !macExtension;
 }


### PR DESCRIPTION
In `vtkSlicerApplicationLogic::IsEmbeddedModule` the variable
`Slicer_EXTENSIONS_DIRBASENAME` was not defined if the
`Slicer_BUILD_EXTENSIONMANAGER_SUPPORT` is false.

Also corrected a warning due to unused variable `slicerRevision`
in `vtkSlicerApplicationLogic::IsEmbeddedModule` in the case
where the Extension Manager was not build.

Co-authored-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>