### PR TITLE
BUG: CR and LF replaced in URL when uploading extensions

### DIFF
--- a/CMake/MIDASAPILogin.cmake
+++ b/CMake/MIDASAPILogin.cmake
@@ -104,5 +104,7 @@ function(midas_api_escape_for_url var str)
   string(REPLACE "[" "%5B" _tmp "${_tmp}") # Left Square Bracket
   string(REPLACE "]" "%5D" _tmp "${_tmp}") # Right Square Bracket
   string(REPLACE "`" "%60" _tmp "${_tmp}") # Grave Accent
+  string(REPLACE "\n" "%0A" _tmp "${_tmp}") # Line feed
+  string(REPLACE "\r" "%0D" _tmp "${_tmp}") # Carriage return
   set(${var} ${_tmp} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
CMake string variables can contain new lines [1][2]. The Slicer extension mechanism uses string CMake to create extension description files and to create the URL containing meta-data and the package file name to upload extensions to the Midas server. New lines need to be handled correctly, otherwise the user will receive a message that the Midas server did not accept the submission of the extension. Carriage Return (CR) and Line Feed (LF) need to be replace by equivalent URL-encoding characters.

[1] http://slicer-devel.65872.n3.nabble.com/Problem-with-the-factory-not-uploading-some-extensions-td4035069.html
[2] https://github.com/Slicer/ExtensionsIndex/pull/1112#issuecomment-145706433