### PR TITLE
COMP: KWSYS code for pre-C++98 STL is removed

### DIFF
--- a/Base/Logic/vtkSlicerTransformLogic.cxx
+++ b/Base/Logic/vtkSlicerTransformLogic.cxx
@@ -131,7 +131,6 @@ vtkMRMLTransformNode* vtkSlicerTransformLogic::AddTransform (const char* filenam
     useURI = scene->GetCacheManager()->IsRemoteReference(filename);
     }
 
-  itksys_stl::string name;
   const char *localFile;
   if (useURI)
     {
@@ -146,10 +145,10 @@ vtkMRMLTransformNode* vtkSlicerTransformLogic::AddTransform (const char* filenam
     localFile = filename;
     }
 
-  const itksys_stl::string fname(localFile);
+  const std::string fname(localFile);
   // the model name is based on the file name (itksys call should work even if
   // file is not on disk yet)
-  name = itksys::SystemTools::GetFilenameName(fname);
+  const std::string name = itksys::SystemTools::GetFilenameName(fname);
 
   if (!storageNode->SupportedFileType(name.c_str()))
     {
@@ -197,7 +196,7 @@ vtkMRMLTransformNode* vtkSlicerTransformLogic::AddTransform (const char* filenam
       tnode =  generalTransform.GetPointer();
     }
 
-  const itksys_stl::string basename(itksys::SystemTools::GetFilenameWithoutExtension(fname));
+  const std::string basename(itksys::SystemTools::GetFilenameWithoutExtension(fname));
   const std::string uname( scene->GetUniqueNameByString(basename.c_str()));
   tnode->SetName(uname.c_str());
   scene->AddNode(storageNode.GetPointer());

--- a/Modules/Loadable/ModelMirror/Logic/vtkModelMirrorLogic.cxx
+++ b/Modules/Loadable/ModelMirror/Logic/vtkModelMirrorLogic.cxx
@@ -156,10 +156,7 @@ void vtkModelMirrorLogic::CreateMirrorModel ( )
     {
     useURI = this->GetMRMLScene()->GetCacheManager()->IsRemoteReference (inputStorageNode->GetFileName() );
     }
-  itksys_stl::string name;
-  itksys_stl::string localFile;
-  itksys_stl::string newURI;
-  itksys_stl::string extension;
+  std::string localFile;
   if ( useURI )
     {
     localFile = ((this->GetMRMLScene())->GetCacheManager())->GetFilenameFromURI(inputStorageNode->GetFileName());
@@ -171,8 +168,8 @@ void vtkModelMirrorLogic::CreateMirrorModel ( )
 
   //--- use original file but tack a _Mirror onto the end.
     size_t index = localFile.find_last_of (".");
-    extension = localFile.substr ( index );
-    newURI = localFile.substr( 0, index );
+    std::string extension = localFile.substr ( index );
+    std::string newURI = localFile.substr( 0, index );
     newURI += "_Mirror";
     newURI += extension;
 
@@ -182,11 +179,11 @@ void vtkModelMirrorLogic::CreateMirrorModel ( )
     mStorageNode->SetFileName(localFile.c_str());
     fsmStorageNode->SetFileName(localFile.c_str());
 
-    const itksys_stl::string fname(localFile.c_str());
+    const std::string fname(localFile.c_str());
 
     // the model name is based on the file name (itksys call should work even if
     // file is not on disk yet)
-    name = itksys::SystemTools::GetFilenameName(fname);
+    const std::string name = itksys::SystemTools::GetFilenameName(fname);
 
     // check to see which node can read this type of file
     if (mStorageNode->SupportedFileType(name.c_str()))

--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
@@ -195,10 +195,10 @@ vtkMRMLModelNode* vtkSlicerModelsLogic::AddModel (const char* filename)
     fsmStorageNode->SetFileName(filename);
     localFile = filename;
     }
-  const itksys_stl::string fname(localFile?localFile:"");
+  const std::string fname(localFile?localFile:"");
   // the model name is based on the file name (itksys call should work even if
   // file is not on disk yet)
-  itksys_stl::string name = itksys::SystemTools::GetFilenameName(fname);
+  std::string name = itksys::SystemTools::GetFilenameName(fname);
   vtkDebugMacro("AddModel: got model name = " << name.c_str());
 
   // check to see which node can read this type of file
@@ -224,7 +224,7 @@ vtkMRMLModelNode* vtkSlicerModelsLogic::AddModel (const char* filename)
   */
   if (storageNode != NULL)
     {
-    itksys_stl::string baseName = itksys::SystemTools::GetFilenameWithoutExtension(fname);
+    std::string baseName = itksys::SystemTools::GetFilenameWithoutExtension(fname);
     std::string uname( this->GetMRMLScene()->GetUniqueNameByString(baseName.c_str()));
     modelNode->SetName(uname.c_str());
 

--- a/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.cxx
+++ b/Modules/Loadable/TractographyDisplay/Logic/vtkSlicerFiberBundleLogic.cxx
@@ -128,9 +128,9 @@ vtkMRMLFiberBundleNode* vtkSlicerFiberBundleLogic::AddFiberBundle (const char* f
   storageNode->SetFileName(filename);
   if (storageNode->ReadData(fiberBundleNode) != 0)
     {
-    const itksys_stl::string fname(filename);
-    itksys_stl::string name = itksys::SystemTools::GetFilenameWithoutExtension(fname);
-    std::string uname( this->GetMRMLScene()->GetUniqueNameByString(name.c_str()));
+    const std::string fname(filename);
+    const std::string name = itksys::SystemTools::GetFilenameWithoutExtension(fname);
+    const std::string uname( this->GetMRMLScene()->GetUniqueNameByString(name.c_str()));
     fiberBundleNode->SetName(uname.c_str());
 
     displayLineNode->SetVisibility(1);

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -972,7 +972,6 @@ vtkMRMLVolumePropertyNode* vtkSlicerVolumeRenderingLogic
     useURI = this->GetMRMLScene()->GetCacheManager()->IsRemoteReference(filename);
     }
 
-  itksys_stl::string name;
   const char *localFile;
   if (useURI)
     {
@@ -985,11 +984,11 @@ vtkMRMLVolumePropertyNode* vtkSlicerVolumeRenderingLogic
     vpStorageNode->SetFileName(filename);
     localFile = filename;
     }
-  const itksys_stl::string fname(localFile);
+  const std::string fname(localFile);
   // the node name is based on the file name (itksys call should work even if
   // file is not on disk yet)
   std::string filenameName = itksys::SystemTools::GetFilenameName(fname);
-  name = itksys::SystemTools::GetFilenameWithoutExtension(filenameName);
+  const std::string name = itksys::SystemTools::GetFilenameWithoutExtension(filenameName);
 
   // check to see which node can read this type of file
   if (!vpStorageNode->SupportedFileType(fname.c_str()))


### PR DESCRIPTION
Various work arounds for pre C++98 STL compilers
have been removed from KWSYS (and by extension, ITK).

For any C++98 or greater compliant compiler, these
constructs were simply aliases to the stl objects.

This is related to the changes made to
KWSYS(5f3fd465ecc0c2d78f7af2495dfe2604be90d4bd) by
Brad King in August 2015.

These changes will be needed when upgrading to ITK v4.9 or greater.