### PR TITLE
Fix vtk mrml double array storage node reader writer

### DIFF
--- a/Libs/MRML/Core/Testing/CMakeLists.txt
+++ b/Libs/MRML/Core/Testing/CMakeLists.txt
@@ -108,6 +108,7 @@ set_target_properties(${KIT}CxxTests PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER}
 
 #-----------------------------------------------------------------------------
 set(TEMP "${CMAKE_BINARY_DIR}/Testing/Temporary")
+set(DATAPATH "${CMAKE_CURRENT_SOURCE_DIR}/TestData")
 
 #-----------------------------------------------------------------------------
 simple_test( vtkMRMLBSplineTransformNodeTest1 )
@@ -127,7 +128,7 @@ simple_test( vtkMRMLDiffusionWeightedVolumeDisplayNodeTest1 )
 simple_test( vtkMRMLDiffusionWeightedVolumeNodeTest1 )
 simple_test( vtkMRMLDisplayableNodeTest1 )
 simple_test( vtkMRMLDisplayNodeTest1 )
-simple_test( vtkMRMLDoubleArrayNodeTest1 )
+simple_test( vtkMRMLDoubleArrayNodeTest1 ${TEMP} ${DATAPATH})
 simple_test( vtkMRMLFiducialListNodeTest1 )
 simple_test( vtkMRMLFiducialListStorageNodeTest1 )
 simple_test( vtkMRMLFreeSurferModelOverlayStorageNodeTest1 )

--- a/Libs/MRML/Core/Testing/TestData/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv
+++ b/Libs/MRML/Core/Testing/TestData/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv
@@ -1,0 +1,5 @@
+# measurement file /path/to/Slicer/Libs/MRML/Core/Testing/TestData/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv
+# columns = x,y,yerr
+x,y,yerr
+12.1,425.577,-454
+8.79633e+09,0,-1

--- a/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
@@ -31,15 +31,34 @@ bool TestAddValues();
 bool TestAddValue();
 bool TestAddXYValue();
 bool TestAddXYerrValue();
+bool TestReadFileWithLabels(std::string filepath);
+bool TestReadFileWithoutLabels(std::string filepath);
+bool TestReadOldFile(std::string filepath);
 
 //---------------------------------------------------------------------------
-int vtkMRMLDoubleArrayNodeTest1(int, char * [])
+int vtkMRMLDoubleArrayNodeTest1(int argc, char * argv[])
 {
   vtkNew<vtkMRMLDoubleArrayNode> node1;
 
   EXERCISE_BASIC_OBJECT_METHODS(node1.GetPointer());
 
   EXERCISE_BASIC_MRML_METHODS(vtkMRMLDoubleArrayNode, node1.GetPointer());
+
+  if (argc != 3)
+    {
+    std::cerr << "Line " << __LINE__
+	      << " - Missing parameters !\n"
+	      << "Usage: " << argv[0] << " /path/to/temp /path/to/testdata"
+	      << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const char* tempDir = argv[1];
+  const char* dataDir = argv[2];
+
+  std::string fileNameOldFile = std::string(dataDir) + "/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv";
+  std::string fileNameWithLabels = std::string(tempDir) + "/vtkMRMLDoubleArrayNodeTest1_WithLabels.mcsv";
+  std::string fileNameWithoutLabels = std::string(tempDir) + "/vtkMRMLDoubleArrayNodeTest1_WithoutLabels.mcsv";
 
   bool res = true;
   res = res && TestSetValues();
@@ -50,6 +69,9 @@ int vtkMRMLDoubleArrayNodeTest1(int, char * [])
   res = res && TestAddValue();
   res = res && TestAddXYValue();
   res = res && TestAddXYerrValue();
+  res = res && TestReadFileWithLabels(fileNameWithLabels);
+  res = res && TestReadFileWithoutLabels(fileNameWithoutLabels);
+  res = res && TestReadOldFile(fileNameOldFile);
 
   return res ? EXIT_SUCCESS : EXIT_FAILURE;
 }
@@ -70,6 +92,24 @@ bool doubleArrayMatch(int line, double array1[], double array2[],
                 << " - Array do not match !\n"
                 << array1[i] << " not equal to " << array2[i]
                 << std::endl;
+      return false;
+      }
+    }
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool labelsMatch(int line, std::vector< std::string > labels1,
+	std::vector< std::string > labels2, unsigned int sizeOfArray)
+{
+  for(unsigned int i = 0; i < sizeOfArray; i++)
+    {
+    if( labels1[i] != labels2[i] )
+      {
+      std::cerr << "Line " << line
+	      << " - Labels do not match !\n"
+	      << labels1[i] << " not equal to " << labels2[i]
+	      << std::endl;
       return false;
       }
     }
@@ -241,6 +281,111 @@ bool TestAddXYerrValue()
   res = res && doubleArray->GetXYValue(1, &testArray3[0], &testArray3[1], &testArray3[2]);
   res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
   res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestReadFileWithLabels(std::string filepath)
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayIn;
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+  std::vector< std::string > labelsIn;
+  labelsIn.push_back("x");
+  labelsIn.push_back("y");
+  labelsIn.push_back("yerr");
+
+  doubleArrayIn->AddValues(testArray0);
+  doubleArrayIn->AddValues(testArray1);
+  doubleArrayIn->SetLabels(labelsIn);
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayWrite;
+  doubleArrayWrite->SetFileName(filepath.c_str());
+  doubleArrayWrite->WriteData(doubleArrayIn.GetPointer());
+
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayOut;
+  double testArray2[3];
+  double testArray3[3];
+  std::vector< std::string > labelsOut(3);
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayRead;
+  doubleArrayRead->SetFileName(filepath.c_str());
+  doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
+
+  doubleArrayOut->GetValues(0, testArray2);
+  doubleArrayOut->GetValues(1, testArray3);
+  labelsOut = doubleArrayOut->GetLabels();
+
+  bool res = true;
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+  res = res && labelsMatch(__LINE__, labelsIn, labelsOut, 3);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestReadFileWithoutLabels(std::string filepath)
+{
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayIn;
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+
+  doubleArrayIn->AddValues(testArray0);
+  doubleArrayIn->AddValues(testArray1);
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayWrite;
+  doubleArrayWrite->SetFileName(filepath.c_str());
+  doubleArrayWrite->WriteData(doubleArrayIn.GetPointer());
+
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayOut;
+  double testArray2[3];
+  double testArray3[3];
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayRead;
+  doubleArrayRead->SetFileName(filepath.c_str());
+  doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
+
+  doubleArrayOut->GetValues(0, testArray2);
+  doubleArrayOut->GetValues(1, testArray3);
+
+  bool res = true;
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+
+  return res;
+}
+
+//---------------------------------------------------------------------------
+bool TestReadOldFile(std::string filepath)
+{
+  // Set values from 'TestData/vtkMRMLDoubleArrayNodeTest1_OldFile.mcsv'
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayIn;
+  double testArray0[3] = { 12.1, 425.576817, -454};
+  double testArray1[3] = { 8796325425.01, 0.0, -1};
+  std::vector< std::string > labelsIn;
+  labelsIn.push_back("x");
+  labelsIn.push_back("y");
+  labelsIn.push_back("yerr");
+
+  vtkNew<vtkMRMLDoubleArrayNode> doubleArrayOut;
+  double testArray2[3];
+  double testArray3[3];
+  std::vector< std::string > labelsOut(3);
+
+  vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayRead;
+  doubleArrayRead->SetFileName(filepath.c_str());
+  doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
+
+  doubleArrayOut->GetValues(0, testArray2);
+  doubleArrayOut->GetValues(1, testArray3);
+  labelsOut = doubleArrayOut->GetLabels();
+
+  bool res = true;
+  res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
+  res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
+  res = res && labelsMatch(__LINE__, labelsIn, labelsOut, 3);
 
   return res;
 }

--- a/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.cxx
@@ -87,19 +87,28 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
 
   int numColumns = 3;
   std::vector<std::string> labels;
-  // save the valid lines in a vector, parse them once know the max id
-  std::vector<std::string>lines;
-  bool firstLine = true;
+  bool haslabels = true;
 
   while (fstr.good())
     {
     fstr.getline(line, 1024);
 
-
     // does it start with a #?
     if (line[0] == '#')
       {
       vtkDebugMacro("Comment line, checking:\n\"" << line << "\"");
+
+      char *ptr;
+      if (strncmp(line, " ", 1) != 0)
+        {
+        ptr = strtok(line, " ");
+        ptr = strtok(NULL, " ");
+        if (strcmp(ptr, "nolabels") == 0)
+          {
+          haslabels = false;
+          vtkDebugMacro("No labels in this file");
+          }
+        }
       }
 
     else
@@ -132,7 +141,7 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
             {
             if (columnNumber == xColumn)
               {
-              if (firstLine)
+              if (haslabels)
                 {
                 labels.push_back(ptr);
                 }
@@ -143,7 +152,7 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
               }
             else if (columnNumber == yColumn)
               {
-              if (firstLine)
+              if (haslabels)
                 {
                 labels.push_back(ptr);
                 }
@@ -154,7 +163,7 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
               }
             else if (columnNumber == zColumn)
               {
-              if (firstLine)
+              if (haslabels)
                 {
                 labels.push_back(ptr);
                 }
@@ -177,9 +186,10 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
           columnNumber++;
           } // end while over columns
         int   fidIndex;
-        if (firstLine)
+        if (haslabels)
           {
           doubleArrayNode->vtkMRMLDoubleArrayNode::SetLabels(labels);
+          haslabels = false;
           }
         else
           {
@@ -189,15 +199,12 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
             vtkErrorMacro("Error adding a measurement to the list");
             }
           }
-        firstLine = false;
-
         } // point line
       }
     }
   fstr.close();
 
-  // If it's the first line, that means there was no point in the file.
-  return firstLine ? 0 : 1;
+  return (doubleArrayNode->GetSize() > 0) ? 0 : 1;
 }
 
 //----------------------------------------------------------------------------
@@ -221,16 +228,19 @@ int vtkMRMLDoubleArrayStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
       vtkMRMLDoubleArrayNode::SafeDownCast(refNode);
 
     if (doubleArrayNode == NULL)
-      {
-      vtkErrorMacro("WriteData: unable to cast input node " << refNode->GetID() << " to a known double array node");
-      return 0;
-      }
+    {
+	vtkErrorMacro("WriteData: unable to cast input node " << refNode->GetID() << " to a known double array node");
+	return 0;
+    }
+    if (doubleArrayNode->GetSize() == 0)
+    {
+	vtkErrorMacro("WriteData: " << refNode->GetID() << " is empty, no data to write in " << fullName.c_str());
+	return 0;
+    }
 
     // open the file for writing
     fstream of;
-
     of.open(fullName.c_str(), fstream::out);
-
     if (!of.is_open())
     {
         vtkErrorMacro("WriteData: unable to open file " << fullName.c_str() << " for writing");
@@ -240,8 +250,7 @@ int vtkMRMLDoubleArrayStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
     // put down a header
     of << "# measurement file " << (this->GetFileName() != NULL ? this->GetFileName() : "null") << endl;
 
-    // if change the ones being included, make sure to update the parsing in ReadData
-    of << "# columns = x,y,yerr" << endl;
+    // put labels
     std::vector< std::string > labels = doubleArrayNode->GetLabels();
     if (labels.size())
     {
@@ -251,9 +260,12 @@ int vtkMRMLDoubleArrayStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
         }
         of << labels.at(labels.size()-1) << endl;
     }
+    else
+    {
+        of << "# nolabels"<< endl;
+    }
 
-
-
+    // put values
     for (unsigned int i = 0; i < doubleArrayNode->GetSize(); i++)
     {
         double x,y,yerr;
@@ -270,10 +282,9 @@ int vtkMRMLDoubleArrayStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
             of << endl;
         }
     }
-  of.close();
+    of.close();
 
-
-  return 1;
+    return 1;
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
The reader in `vtkMRMLDoubleArrayStorage` was always setting the
first line of values in the `.mcsv` file as labels. If the stored
`vtkMRMLDoubleArray` had not labels set, then the retrieved double
array labels would be set to the first line of numerical values,
associated with the first data point. This resulted in a missing
data point as well as shifted indices for all remaining points,
and incorrect labels.

The correction this commit offers is to write the line '# nolabels'
in the file if labels exist. If the reader finds this line, it will
set the first line of values as the first data point, instead of
setting it as label values.

Examples :

Here are four examples with (u,v,w) as labels, (12.1,425.577,-454)
for the first data point, and (8.79633e+09,0,-1) for the second one:

(1) New writer: vtkMRMLDoubleArrayNode with labels

```
   # measurement file filename.mcsv
   u,v,w
   12.1,425.577,-454
   8.79633e+09,0,-1
```

(2) New writer: vtkMRMLDoubleArrayNode with no labels set

```
   # measurement file filename.mcsv
   # nolabels
   12.1,425.577,-454
   8.79633e+09,0,-1
```

(3) Old writer: vtkMRMLDoubleArrayNode with labels

```
   # measurement file filename.mcsv
   # columns = x,y,yerr
   u,v,w
   12.1,425.577,-454
   8.79633e+09,0,-1
```

(4) Old writer: vtkMRMLDoubleArrayNode with no labels set

```
   # measurement file filename.mcsv
   # columns = x,y,yerr
   12.1,425.577,-454
   8.79633e+09,0,-1
```

Observations :

The line '# columns = x,y,yerr' was hardcoded [1] in the former
writer and had no meaning related to the actual double array
node labels. The inspiration problably came from .mcsv or .acsv
writers/readers [2][3] but had no effect here.

[1] https://github.com/Slicer/Slicer/blob/6e63b4bf5dbc65a9973160de7397dfc47882e038/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.cxx#L244
[2] https://github.com/Slicer/Slicer/blob/master/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx#L159-L185
[3] https://github.com/Slicer/Slicer/blob/master/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationFiducialsStorageNode.cxx#L245-L268