### PR TITLE
Fix slice view annotations

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -475,32 +475,24 @@ class SliceAnnotations(VTKObservationMixin):
     self.scalarBarCollapsibleButton.enabled = enabled
     self.restorDefaultsButton.enabled = enabled
 
-    if enabled:
-      for sliceViewName in self.sliceViewNames:
-        sliceWidget = self.layoutManager.sliceWidget(sliceViewName)
-        sl = sliceWidget.sliceLogic()
+    for sliceViewName in self.sliceViewNames:
+      sliceWidget = self.layoutManager.sliceWidget(sliceViewName)
+      sl = sliceWidget.sliceLogic()
+      self.updateRuler(sl)
+      self.updateScalarBar(sl)
+      self.updateOrientationMarker(sl)
+
+      if enabled:
         self.makeAnnotationText(sl)
-        self.updateRuler(sl)
-        self.updateScalarBar(sl)
-        self.updateOrientationMarker(sl)
-    else:
-      # Remove Observers
-
-      for sliceViewName in self.sliceViewNames:
-        sliceWidget = self.layoutManager.sliceWidget(sliceViewName)
-        sl = sliceWidget.sliceLogic()
-        self.updateRuler(sl)
-        self.updateScalarBar(sl)
-        self.updateOrientationMarker(sl)
-
-      # Clear Annotations
-      for sliceViewName in self.sliceViewNames:
+      else:
+        # Clear Annotations
         self.sliceCornerAnnotations[sliceViewName].SetText(0, "")
         self.sliceCornerAnnotations[sliceViewName].SetText(1, "")
         self.sliceCornerAnnotations[sliceViewName].SetText(2, "")
         self.sliceCornerAnnotations[sliceViewName].SetText(3, "")
         self.sliceViews[sliceViewName].scheduleRender()
 
+    if not enabled:
       # reset global variables
       self.sliceCornerAnnotations = {}
 

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -1111,7 +1111,8 @@ class SliceAnnotations(VTKObservationMixin):
 
       self.drawCornerAnnotations()
 
-  def updateScalarBarRange(self, sliceLogic, volumeNode, scalarBar, selectedLayer):
+  @staticmethod
+  def updateScalarBarRange(sliceLogic, volumeNode, scalarBar, selectedLayer):
     vdn = volumeNode.GetDisplayNode()
     if vdn:
       vcn = vdn.GetColorNode()
@@ -1209,7 +1210,8 @@ class SliceAnnotations(VTKObservationMixin):
          self.cornerTexts[3]['6-TR']['text']  = 'TR ' + dicomDic['Repetition Time']
          self.cornerTexts[3]['7-TE']['text'] = 'TE ' + dicomDic['Echo Time']
 
-  def makePatientInfo(self,dicomDic):
+  @staticmethod
+  def makePatientInfo(dicomDic):
     # This will give an string of patient's birth date,
     # patient's age and sex
     patientInfo = dicomDic['Patient Birth Date'
@@ -1217,7 +1219,8 @@ class SliceAnnotations(VTKObservationMixin):
               ] + ', ' + dicomDic['Patient Sex']
     return patientInfo
 
-  def formatDICOMDate(self, date):
+  @staticmethod
+  def formatDICOMDate(date):
     standardDate = ''
     if date != '':
       date = date.rstrip()
@@ -1225,7 +1228,8 @@ class SliceAnnotations(VTKObservationMixin):
       standardDate = date[:4] + '-' + date[4:6]+ '-' + date[6:]
     return standardDate
 
-  def formatDICOMTime(self, time):
+  @staticmethod
+  def formatDICOMTime(time):
     if time == '':
       # time field is empty
       return ''
@@ -1240,7 +1244,8 @@ class SliceAnnotations(VTKObservationMixin):
     studyS = time[4:6]
     return studyH + ':' + studyM  + ':' + studyS +clockTime
 
-  def fitText(self,text,textSize):
+  @staticmethod
+  def fitText(text,textSize):
     if len(text) > textSize:
       preSize = int(textSize/2)
       postSize = preSize - 3
@@ -1289,7 +1294,8 @@ class SliceAnnotations(VTKObservationMixin):
       for key in cornerText.keys():
         self.cornerTexts[i][key]['text'] = ''
 
-  def extractDICOMValues(self,uid):
+  @staticmethod
+  def extractDICOMValues(uid):
     p ={}
     tags = {
     "0008,0021": "Series Date",

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -1281,8 +1281,6 @@ class SliceAnnotations(VTKObservationMixin):
       sliceCornerAnnotation.SetText(i, cornerAnnotation)
       textProperty = sliceCornerAnnotation.GetTextProperty()
       textProperty.SetShadow(1)
-      self.renderers[sliceViewName].RemoveActor(sliceCornerAnnotation)
-      self.renderers[sliceViewName].AddActor(sliceCornerAnnotation)
 
     self.sliceViews[sliceViewName].scheduleRender()
 

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -526,7 +526,7 @@ class SliceAnnotations(VTKObservationMixin):
     self.sliceViews[sliceViewName] = sliceView
     self.sliceCornerAnnotations[sliceViewName] = sliceView.cornerAnnotation()
     sliceLogic = sliceWidget.sliceLogic()
-    self.addObserver(sliceLogic, vtk.vtkCommand.ModifiedEvent, self.updateCornerAnnotations)
+    self.addObserver(sliceLogic, vtk.vtkCommand.ModifiedEvent, self.updateViewAnnotations)
     self.orientationMarkerRenderers[sliceViewName] = vtk.vtkRenderer()
 
 
@@ -611,7 +611,7 @@ class SliceAnnotations(VTKObservationMixin):
     '''
     return scalarBar
 
-  def updateCornerAnnotations(self,caller,event):
+  def updateViewAnnotations(self,caller,event):
     layoutManager = self.layoutManager
     if layoutManager is None:
       return

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -612,7 +612,7 @@ class SliceAnnotations(VTKObservationMixin):
     else:
       # Clear Annotations
       for position in range(3):
-        cornerAnnotation.SetText(position, "")
+        cornerAnnotation.SetText(position, " ")
 
   def updateOrientationMarker(self, sliceLogic):
     sliceNode = sliceLogic.GetBackgroundLayer().GetSliceNode()
@@ -1259,7 +1259,7 @@ class SliceAnnotations(VTKObservationMixin):
       sliceCornerAnnotation = self.sliceViews[sliceViewName].cornerAnnotation()
       # encode to avoid 'unicode conversion error' for patient names containing international characters
       cornerAnnotation = slicer.util.toVTKString(cornerAnnotation)
-      sliceCornerAnnotation.SetText(i, cornerAnnotation)
+      sliceCornerAnnotation.SetText(i, cornerAnnotation if len(cornerAnnotation) else ' ')
       textProperty = sliceCornerAnnotation.GetTextProperty()
       textProperty.SetShadow(1)
 

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -323,22 +323,15 @@ class SliceAnnotations(VTKObservationMixin):
     self.updateSliceViewFromGUI()
 
   def onCornerTextsActivationCheckBox(self):
-    if self.topLeftCheckBox.checked:
-      self.topLeft = 1
-    else:
-      self.topLeft = 0
+    self.topLeft = int(self.topLeftCheckBox.checked)
+    self.topRight = int(self.topRightCheckBox.checked)
+    self.bottomLeft = int(self.bottomLeftCheckBox.checked)
 
-    if self.topRightCheckBox.checked:
-      self.topRight = 1
+    if self.topRight:
       self.scalarBarEnalbeCheckBox.checked = False
-    else:
-      self.topRight = 0
 
-    if self.bottomLeftCheckBox.checked:
-      self.bottomLeft = 1
-    else:
-      self.bottomLeft = 0
     self.updateSliceViewFromGUI()
+
     settings = qt.QSettings()
     settings.setValue('DataProbe/sliceViewAnnotations.topLeft',
         self.topLeft)
@@ -476,16 +469,18 @@ class SliceAnnotations(VTKObservationMixin):
     elif self.level3RadioButton.checked:
       self.annotationsDisplayAmount = 2
 
-    if self.sliceViewAnnotationsEnabled:
-      self.cornerTextParametersCollapsibleButton.enabled = True
-      self.activateCornersGroupBox.enabled = True
-      self.fontPropertiesGroupBox.enabled = True
-      self.scalarBarLayerSelectionGroupBox.enabled = True
-      self.annotationsAmountGroupBox.enabled = True
-      self.rulerCollapsibleButton.enabled = True
-      self.scalarBarCollapsibleButton.enabled = True
-      self.restorDefaultsButton.enabled = True
+    enabled = self.sliceViewAnnotationsEnabled
 
+    self.cornerTextParametersCollapsibleButton.enabled = enabled
+    self.activateCornersGroupBox.enabled = enabled
+    self.fontPropertiesGroupBox.enabled = enabled
+    self.scalarBarLayerSelectionGroupBox.enabled = enabled
+    self.annotationsAmountGroupBox.enabled = enabled
+    self.rulerCollapsibleButton.enabled = enabled
+    self.scalarBarCollapsibleButton.enabled = enabled
+    self.restorDefaultsButton.enabled = enabled
+
+    if enabled:
       for sliceViewName in self.sliceViewNames:
         sliceWidget = self.layoutManager.sliceWidget(sliceViewName)
         sl = sliceWidget.sliceLogic()
@@ -494,14 +489,6 @@ class SliceAnnotations(VTKObservationMixin):
         self.updateScalarBar(sl)
         self.updateOrientationMarker(sl)
     else:
-      self.cornerTextParametersCollapsibleButton.enabled = False
-      self.activateCornersGroupBox.enabled = False
-      self.scalarBarLayerSelectionGroupBox.enabled = False
-      self.fontPropertiesGroupBox.enabled = False
-      self.annotationsAmountGroupBox.enabled = False
-      self.rulerCollapsibleButton.enabled = False
-      self.scalarBarCollapsibleButton.enabled = False
-      self.restorDefaultsButton.enabled = False
       # Remove Observers
 
       for sliceViewName in self.sliceViewNames:
@@ -780,7 +767,7 @@ class SliceAnnotations(VTKObservationMixin):
       modelPaths = [modulePath + "DataProbeLib/Resources/Models/"+ modelFile for modelFile in modelFiles]
       for modelPath in modelPaths:
         successfulLoad = slicer.util.loadModel(modelPath)
-        if successfulLoad != True:
+        if not successfulLoad:
           print 'Warning: Could not load model %s' %modelPath
     nodes.UnRegister(slicer.mrmlScene)
 
@@ -931,8 +918,7 @@ class SliceAnnotations(VTKObservationMixin):
         rulerArea = viewWidth/4
 
       #if self.rulerEnabled and \
-      if  viewWidth > self.minimumWidthForRuler and\
-         rulerArea>0.5 and rulerArea<500 and NUMPY_AVAILABLE:
+      if viewWidth > self.minimumWidthForRuler and 0.5 < rulerArea < 500 and NUMPY_AVAILABLE:
         rulerSizesArray = np.array([1,5,10,50,100])
         index = np.argmin(np.abs(rulerSizesArray- rulerArea))
 

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -87,8 +87,6 @@ class SliceAnnotations(VTKObservationMixin):
     self.humanActor = None
 
     # If there are no user settings load defaults
-    settings = qt.QSettings()
-
     self.sliceViewAnnotationsEnabled = settingsValue('DataProbe/sliceViewAnnotations.enabled', 1, converter=int)
 
     self.bottomLeft = settingsValue('DataProbe/sliceViewAnnotations.bottomLeft', 1, converter=int)
@@ -506,7 +504,7 @@ class SliceAnnotations(VTKObservationMixin):
         self.sliceCornerAnnotations[sliceViewName].SetText(3, "")
         self.sliceViews[sliceViewName].scheduleRender()
 
-      # reset golobal variables
+      # reset global variables
       self.sliceCornerAnnotations = {}
 
   def createGlobalVariables(self):
@@ -539,7 +537,6 @@ class SliceAnnotations(VTKObservationMixin):
     sliceView = sliceWidget.sliceView()
 
     renderWindow = sliceView.renderWindow()
-    renderWindow.GetRenderers()
     renderer = renderWindow.GetRenderers().GetItemAsObject(0)
     self.renderers[sliceViewName] = renderer
 
@@ -553,7 +550,6 @@ class SliceAnnotations(VTKObservationMixin):
   def createActors(self, sliceViewName):
     sliceWidget = self.layoutManager.sliceWidget(sliceViewName)
     self.sliceWidgets[sliceViewName] = sliceWidget
-    sliceView = sliceWidget.sliceView()
 
     self.rulerTextActors[sliceViewName] = vtk.vtkTextActor()
     textActor = self.rulerTextActors[sliceViewName]
@@ -611,8 +607,6 @@ class SliceAnnotations(VTKObservationMixin):
     actor.SetMapper(mapper)
     # color actor
     actor.GetProperty().SetLineWidth(1)
-    textActor = self.rulerTextActors[sliceViewName]
-    textProperty = textActor.GetTextProperty()
 
   def createScalarBar(self, sliceViewName):
     if self.hasVTKPVScalarBarActor:
@@ -898,13 +892,11 @@ class SliceAnnotations(VTKObservationMixin):
       #
       self.minimumWidthForRuler = 200
       viewWidth = self.sliceViews[sliceViewName].width
-      viewHeight = self.sliceViews[sliceViewName].height
 
       rasToXY = vtk.vtkMatrix4x4()
       m = sliceNode.GetXYToRAS()
       rasToXY.DeepCopy(m)
       rasToXY.Invert()
-      scalingFactorString = " mm"
 
       # TODO: The current logic only supports rulers from 1mm to 10cm
       # add support for other ranges.
@@ -998,8 +990,8 @@ class SliceAnnotations(VTKObservationMixin):
       renderer.SetLayer(0)
       if orientationRenderer != None:
         orientationRenderer.SetLayer(1)
-      renderWindow = renderer.GetRenderWindow()
-      interactor = renderWindow.GetInteractor()
+      #renderWindow = renderer.GetRenderWindow()
+      #interactor = renderWindow.GetInteractor()
 
       # create the scalarBarWidget
       #scalarBarWidget = self.scalarBarWidgets[sliceViewName]
@@ -1053,7 +1045,6 @@ class SliceAnnotations(VTKObservationMixin):
     sliceViewName = sliceNode.GetLayoutName()
     self.currentSliceViewName = sliceViewName
 
-    renderer = self.renderers[sliceViewName]
     if self.sliceViews[sliceViewName]:
       #
       # Update slice corner annotations
@@ -1263,7 +1254,6 @@ class SliceAnnotations(VTKObservationMixin):
     # adjust maximum text length based on fontsize and view width
     viewWidth = self.sliceViews[self.currentSliceViewName].width
     self.maximumTextLength = int((viewWidth - 40) / self.fontSize)
-    cornerAnnotation = ''
 
     for i, cornerText in enumerate(self.cornerTexts):
       keys = sorted(cornerText.keys())

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -70,8 +70,6 @@ class SliceAnnotations(VTKObservationMixin):
       '7-TE':{'text':'','category':'A'}
       })
 
-    self.sliceCornerAnnotations = {}
-
     self.annotationsDisplayAmount = 0
 
     #
@@ -425,7 +423,7 @@ class SliceAnnotations(VTKObservationMixin):
 
   def updateSliceViewFromGUI(self):
     # Create corner annotations if have not created already
-    if len(self.sliceCornerAnnotations.items()) == 0:
+    if len(self.sliceViewNames) == 0:
       self.createCornerAnnotations()
 
     for slider in [self.zoomSlider,self.widthSlider, self.heightSlider]:
@@ -458,16 +456,11 @@ class SliceAnnotations(VTKObservationMixin):
       self.updateOrientationMarker(sl)
       self.updateCornerAnnotation(sl)
 
-    if not enabled:
-      # reset global variables
-      self.sliceCornerAnnotations = {}
-
   def createGlobalVariables(self):
     self.sliceViewNames = []
     self.sliceWidgets = {}
     self.sliceViews = {}
     self.cameras = {}
-    self.sliceCornerAnnotations = {}
     self.renderers = {}
     self.rulerActors = {}
     self.points = {}
@@ -493,7 +486,6 @@ class SliceAnnotations(VTKObservationMixin):
     self.renderers[sliceViewName] = renderer
 
     self.sliceViews[sliceViewName] = sliceView
-    self.sliceCornerAnnotations[sliceViewName] = sliceView.cornerAnnotation()
     sliceLogic = sliceWidget.sliceLogic()
     self.addObserver(sliceLogic, vtk.vtkCommand.ModifiedEvent, self.updateViewAnnotations)
     self.orientationMarkerRenderers[sliceViewName] = vtk.vtkRenderer()
@@ -603,7 +595,7 @@ class SliceAnnotations(VTKObservationMixin):
 
     enabled = self.sliceViewAnnotationsEnabled
 
-    cornerAnnotation = self.sliceCornerAnnotations[sliceViewName]
+    cornerAnnotation = self.sliceViews[sliceViewName].cornerAnnotation()
 
     if enabled:
       # Font
@@ -1264,7 +1256,7 @@ class SliceAnnotations(VTKObservationMixin):
           elif self.annotationsDisplayAmount == 2:
             if (cornerText[key]['category'] == 'A'):
               cornerAnnotation = cornerAnnotation+ text + '\n'
-      sliceCornerAnnotation = self.sliceCornerAnnotations[sliceViewName]
+      sliceCornerAnnotation = self.sliceViews[sliceViewName].cornerAnnotation()
       # encode to avoid 'unicode conversion error' for patient names containing international characters
       cornerAnnotation = slicer.util.toVTKString(cornerAnnotation)
       sliceCornerAnnotation.SetText(i, cornerAnnotation)

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -416,9 +416,6 @@ class SliceAnnotations(VTKObservationMixin):
     settings.setValue('DataProbe/sliceViewAnnotations.rangeLabelFormat', self.rangeLabelFormat)
     self.updateSliceViewFromGUI()
 
-  def updateMRMLFromGUI(self):
-    self.parameterNode.SetParameter(self.parameter, str(sliceViewAnnotationsEnabled))
-
   def updateGUIFromMRML(self,caller,event):
     if self.parameterNode.GetParameter(self.parameter) == '':
       # parameter does not exist - probably intializing
@@ -846,9 +843,6 @@ class SliceAnnotations(VTKObservationMixin):
     transform.Translate(0,0,0)
     self.axes.SetUserTransform(transform)
 
-
-  def sliceLogicModifiedEvent(self, caller,event):
-    self.updateLayersAnnotation(caller)
 
   def updateRuler(self, sliceLogic):
     sliceCompositeNode = sliceLogic.GetSliceCompositeNode()

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -423,14 +423,6 @@ class SliceAnnotations(VTKObservationMixin):
     self.sliceViewAnnotationsEnabled = int(self.parameterNode.GetParameter(self.parameter))
     self.updateSliceViewFromGUI()
 
-  def openSettingsPopup(self):
-    if not self.window.isVisible():
-      self.window.show()
-    self.window.raise_()
-
-  def close(self):
-    self.window.hide()
-
   def updateSliceViewFromGUI(self):
     # Create corner annotations if have not created already
     if len(self.sliceCornerAnnotations.items()) == 0:

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -845,6 +845,9 @@ class SliceAnnotations(VTKObservationMixin):
 
   def updateRuler(self, sliceLogic):
     sliceCompositeNode = sliceLogic.GetSliceCompositeNode()
+    if not sliceCompositeNode:
+      return
+
     # Get the layers
     sliceNode = sliceLogic.GetBackgroundLayer().GetSliceNode()
     if not sliceNode:
@@ -859,6 +862,8 @@ class SliceAnnotations(VTKObservationMixin):
 
   def updateScalarBar(self, sliceLogic):
     sliceCompositeNode = sliceLogic.GetSliceCompositeNode()
+    if not sliceCompositeNode:
+      return
 
     # Get the layers
     backgroundLayer = sliceLogic.GetBackgroundLayer()
@@ -958,6 +963,8 @@ class SliceAnnotations(VTKObservationMixin):
 
   def modifyScalarBar(self, sliceLogic):
     sliceCompositeNode = sliceLogic.GetSliceCompositeNode()
+    if not sliceCompositeNode:
+      return
 
     # Get the layers
     backgroundLayer = sliceLogic.GetBackgroundLayer()

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -1006,21 +1006,21 @@ class SliceAnnotations(VTKObservationMixin):
         scalarBar.SetPosition(0.8,0.1)
         scalarBar.SetPosition2(0.17,0.8)
 
-    # Get the volumes
-    backgroundVolume = backgroundLayer.GetVolumeNode()
-    foregroundVolume = foregroundLayer.GetVolumeNode()
+      # Get the volumes
+      backgroundVolume = backgroundLayer.GetVolumeNode()
+      foregroundVolume = foregroundLayer.GetVolumeNode()
 
-    if (backgroundVolume != None and self.scalarBarSelectedLayer == 'background'):
-      self.updateScalarBarRange(sliceLogic, backgroundVolume, scalarBar, self.scalarBarSelectedLayer)
-      renderer.AddActor(scalarBar)
-      #scalarBarWidget.On()
-    elif (foregroundVolume != None and self.scalarBarSelectedLayer == 'foreground'):
-      self.updateScalarBarRange(sliceLogic, foregroundVolume, scalarBar, self.scalarBarSelectedLayer)
-      renderer.AddActor(scalarBar)
-      #scalarBarWidget.On()
-    else:
-      renderer.RemoveActor(scalarBar)
-      #scalarBarWidget.Off()
+      if (backgroundVolume != None and self.scalarBarSelectedLayer == 'background'):
+        self.updateScalarBarRange(sliceLogic, backgroundVolume, scalarBar, self.scalarBarSelectedLayer)
+        renderer.AddActor(scalarBar)
+        #scalarBarWidget.On()
+      elif (foregroundVolume != None and self.scalarBarSelectedLayer == 'foreground'):
+        self.updateScalarBarRange(sliceLogic, foregroundVolume, scalarBar, self.scalarBarSelectedLayer)
+        renderer.AddActor(scalarBar)
+        #scalarBarWidget.On()
+      else:
+        renderer.RemoveActor(scalarBar)
+        #scalarBarWidget.Off()
 
   def makeAnnotationText(self, sliceLogic):
     self.resetTexts()

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -486,10 +486,7 @@ class SliceAnnotations(VTKObservationMixin):
 
   def createCornerAnnotations(self):
     self.createGlobalVariables()
-    sliceViewNames = self.layoutManager.sliceViewNames()
-
-    for sliceViewName in sliceViewNames:
-      self.sliceViewNames.append(sliceViewName)
+    self.sliceViewNames = self.layoutManager.sliceViewNames()
     for sliceViewName in self.sliceViewNames:
       self.addSliceViewObserver(sliceViewName)
       self.createActors(sliceViewName)

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -439,17 +439,6 @@ class SliceAnnotations(VTKObservationMixin):
     for slider in [self.zoomSlider,self.widthSlider, self.heightSlider]:
       slider.enabled = self.orientationMarkerEnableCheckBox.checked
 
-    for sliceViewName in self.sliceViewNames:
-      cornerAnnotation = self.sliceCornerAnnotations[sliceViewName]
-      cornerAnnotation.SetMaximumFontSize(self.fontSize)
-      cornerAnnotation.SetMinimumFontSize(self.fontSize)
-      cornerAnnotation.SetNonlinearFontScaleFactor(1)
-      textProperty = cornerAnnotation.GetTextProperty()
-      if self.fontFamily == 'Times':
-        textProperty.SetFontFamilyToTimes()
-      else:
-        textProperty.SetFontFamilyToArial()
-
     # Updating Annotations Amount
     if self.level1RadioButton.checked:
       self.annotationsDisplayAmount = 0
@@ -475,16 +464,7 @@ class SliceAnnotations(VTKObservationMixin):
       self.updateRuler(sl)
       self.updateScalarBar(sl)
       self.updateOrientationMarker(sl)
-
-      if enabled:
-        self.makeAnnotationText(sl)
-      else:
-        # Clear Annotations
-        self.sliceCornerAnnotations[sliceViewName].SetText(0, "")
-        self.sliceCornerAnnotations[sliceViewName].SetText(1, "")
-        self.sliceCornerAnnotations[sliceViewName].SetText(2, "")
-        self.sliceCornerAnnotations[sliceViewName].SetText(3, "")
-        self.sliceViews[sliceViewName].scheduleRender()
+      self.updateCornerAnnotation(sl)
 
     if not enabled:
       # reset global variables
@@ -626,6 +606,32 @@ class SliceAnnotations(VTKObservationMixin):
     self.updateRuler(caller)
     self.updateScalarBar(caller)
     self.updateOrientationMarker(caller)
+
+  def updateCornerAnnotation(self, sliceLogic):
+
+    sliceNode = sliceLogic.GetBackgroundLayer().GetSliceNode()
+    sliceViewName = sliceNode.GetLayoutName()
+
+    enabled = self.sliceViewAnnotationsEnabled
+
+    cornerAnnotation = self.sliceCornerAnnotations[sliceViewName]
+
+    if enabled:
+      # Font
+      cornerAnnotation.SetMaximumFontSize(self.fontSize)
+      cornerAnnotation.SetMinimumFontSize(self.fontSize)
+      cornerAnnotation.SetNonlinearFontScaleFactor(1)
+      textProperty = cornerAnnotation.GetTextProperty()
+      if self.fontFamily == 'Times':
+        textProperty.SetFontFamilyToTimes()
+      else:
+        textProperty.SetFontFamilyToArial()
+      # Text
+      self.makeAnnotationText(sliceLogic)
+    else:
+      # Clear Annotations
+      for position in range(3):
+        cornerAnnotation.SetText(position, "")
 
   def updateOrientationMarker(self, sliceLogic):
     sliceNode = sliceLogic.GetBackgroundLayer().GetSliceNode()

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -445,16 +445,10 @@ class SliceAnnotations(VTKObservationMixin):
       cornerAnnotation.SetMinimumFontSize(self.fontSize)
       cornerAnnotation.SetNonlinearFontScaleFactor(1)
       textProperty = cornerAnnotation.GetTextProperty()
-      scalarBar = self.scalarBars[sliceViewName]
-      scalarBarTextProperty = scalarBar.GetLabelTextProperty()
-      scalarBarTextProperty.ItalicOff()
-      scalarBarTextProperty.BoldOff()
       if self.fontFamily == 'Times':
         textProperty.SetFontFamilyToTimes()
-        scalarBarTextProperty.SetFontFamilyToTimes()
       else:
         textProperty.SetFontFamilyToArial()
-        scalarBarTextProperty.SetFontFamilyToArial()
 
     # Updating Annotations Amount
     if self.level1RadioButton.checked:
@@ -968,6 +962,15 @@ class SliceAnnotations(VTKObservationMixin):
     orientationRenderer = self.orientationMarkerRenderers[sliceViewName]
     if self.sliceViews[sliceViewName]:
       scalarBar = self.scalarBars[sliceViewName]
+      # Font
+      scalarBarTextProperty = scalarBar.GetLabelTextProperty()
+      scalarBarTextProperty.ItalicOff()
+      scalarBarTextProperty.BoldOff()
+      if self.fontFamily == 'Times':
+        scalarBarTextProperty.SetFontFamilyToTimes()
+      else:
+        scalarBarTextProperty.SetFontFamilyToArial()
+
       scalarBar.SetTextPositionToPrecedeScalarBar()
       if self.hasVTKPVScalarBarActor:
         scalarBar.SetRangeLabelFormat(self.rangeLabelFormat)

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -59,7 +59,7 @@ class SliceAnnotations(VTKObservationMixin):
       '8-Bg-SeriesDescription':{'text':'','category':'C'},
       '9-Fg-SeriesDescription':{'text':'','category':'C'}
       })
-    # Top Rihgt Corner Text
+    # Top Right Corner Text
     self.cornerTexts.append({
       '1-Institution-Name':{'text':'','category':'B'},
       '2-Referring-Phisycian':{'text':'','category':'B'},
@@ -196,7 +196,7 @@ class SliceAnnotations(VTKObservationMixin):
     else:
       self.axesRadioButton.checked = True
 
-    self.restorDefaultsButton = find(window, 'restoreDefaultsButton')[0]
+    self.restoreDefaultsButton = find(window, 'restoreDefaultsButton')[0]
 
     # connections
     self.sliceViewAnnotationsCheckBox.connect('clicked()', self.onSliceViewAnnotationsCheckBox)
@@ -230,7 +230,7 @@ class SliceAnnotations(VTKObservationMixin):
     for radioButton in [self.cubeRadioButton, self.axesRadioButton, self.humanRadioButton]:
       radioButton.connect('clicked()', self.onOrientationMarkerTypeRadioButton)
 
-    self.restorDefaultsButton.connect('clicked()', self.restoreDefaultValues)
+    self.restoreDefaultsButton.connect('clicked()', self.restoreDefaultValues)
 
   def onLayoutManagerDestroyed(self):
     self.layoutManager = slicer.app.layoutManager()
@@ -448,7 +448,7 @@ class SliceAnnotations(VTKObservationMixin):
     self.annotationsAmountGroupBox.enabled = enabled
     self.rulerCollapsibleButton.enabled = enabled
     self.scalarBarCollapsibleButton.enabled = enabled
-    self.restorDefaultsButton.enabled = enabled
+    self.restoreDefaultsButton.enabled = enabled
 
     for sliceViewName in self.sliceViewNames:
       sliceWidget = self.layoutManager.sliceWidget(sliceViewName)

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -697,9 +697,8 @@ class SliceAnnotations(VTKObservationMixin):
             [m.GetElement(2,0),m.GetElement(2,1),m.GetElement(2,2)]])
         det = np.linalg.det(v)
         cameraPositionMultiplier = 100/self.zoomValue
-        if det > 0: # right hand
-          y = np.array([0,0,-cameraPositionMultiplier])
-        elif det < 0: # left hand
+        y = np.array([0,0,-cameraPositionMultiplier]) # right hand
+        if det < 0: # left hand
           y = np.array([0,0,cameraPositionMultiplier])
 
         x = np.matrix([[m.GetElement(0,0),m.GetElement(0,1),m.GetElement(0,2)],


### PR DESCRIPTION
In addition to applying various style fixes, removing dead code and re-factoring the code to improve its readability, this PR (more specifically  c89bfdc) fixes SlicerProstate/SliceTracker#33 to avoid blank rectangle from showing up in SliceViewAnnotations

Cc: @fedorov @cpinter @mehrtash @che85 @pieper @Slicer/slicer-core-team 