### PR TITLE
BUG: return value of "downloadExtension()" not always handled if 0

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -1130,6 +1130,11 @@ void qSlicerExtensionsManagerModel::downloadAndInstallExtension(const QString& e
     }
 
   qSlicerExtensionDownloadTask* const task = d->downloadExtension(extensionId);
+  if (!task)
+  {
+    d->critical("Failed to retrieve metadata for extension " + extensionId);
+    return;
+  }
   connect(task, SIGNAL(finished(qSlicerExtensionDownloadTask*)),
           this, SLOT(onInstallDownloadFinished(qSlicerExtensionDownloadTask*)));
 }

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -1355,14 +1355,18 @@ bool qSlicerExtensionsManagerModel::installExtension(
     if (result == QMessageBox::Yes)
       {
       // Install dependencies
+      QStringList extensionsNotInstalled ;
       foreach (const ExtensionMetadataType& dependency, dependenciesMetadata)
         {
-        bool res = this->downloadAndInstallExtension(dependency.value("extension_id").toString());
+        bool res = this->downloadAndInstallExtension(dependency.value("extension_id").toString() ) ;
         if( !res )
           {
-          QString msg = QString("<p>Error while installing %1</p><ul>").arg(dependency.value("extensionname").toString());
-          QMessageBox::warning(0, "Error installing dependencies", msg);
+          extensionsNotInstalled << "Error while installing: " + dependency.value("extensionname").toString() ;
           }
+        }
+      if( !extensionsNotInstalled.isEmpty() )
+        {
+          d->critical( extensionsNotInstalled.join("\n") ) ;
         }
       }
     }

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -1118,7 +1118,7 @@ qSlicerExtensionsManagerModelPrivate::downloadExtension(
 }
 
 // --------------------------------------------------------------------------
-void qSlicerExtensionsManagerModel::downloadAndInstallExtension(const QString& extensionId)
+bool qSlicerExtensionsManagerModel::downloadAndInstallExtension(const QString& extensionId)
 {
   Q_D(qSlicerExtensionsManagerModel);
 
@@ -1126,17 +1126,18 @@ void qSlicerExtensionsManagerModel::downloadAndInstallExtension(const QString& e
   if (!d->checkExtensionSettingsPermissions(error))
     {
     d->critical(error);
-    return;
+    return false;
     }
 
   qSlicerExtensionDownloadTask* const task = d->downloadExtension(extensionId);
   if (!task)
   {
     d->critical("Failed to retrieve metadata for extension " + extensionId);
-    return;
+    return false;
   }
   connect(task, SIGNAL(finished(qSlicerExtensionDownloadTask*)),
           this, SLOT(onInstallDownloadFinished(qSlicerExtensionDownloadTask*)));
+  return true;
 }
 
 // --------------------------------------------------------------------------
@@ -1356,7 +1357,12 @@ bool qSlicerExtensionsManagerModel::installExtension(
       // Install dependencies
       foreach (const ExtensionMetadataType& dependency, dependenciesMetadata)
         {
-        this->downloadAndInstallExtension(dependency.value("extension_id").toString());
+        bool res = this->downloadAndInstallExtension(dependency.value("extension_id").toString());
+        if( !res )
+          {
+          QString msg = QString("<p>Error while installing %1</p><ul>").arg(dependency.value("extensionname").toString());
+          QMessageBox::warning(0, "Error installing dependencies", msg);
+          }
         }
       }
     }

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -232,7 +232,7 @@ public slots:
   /// \brief Download and install \a extensionId
   /// The \a extensionId correponds to the identifier used on the extension server itself.
   /// \sa installExtension, scheduleExtensionForUninstall, uninstallScheduledExtensions
-  void downloadAndInstallExtension(const QString& extensionId);
+  bool downloadAndInstallExtension(const QString& extensionId);
 
   /// \brief Schedule \a extensionName of uninstall
   /// Tell the application to uninstall \a extensionName when it will restart


### PR DESCRIPTION
The function downloadAndInstallExtension(const QString& extensionId) did not handled the case of downloadExtension() returning 0. We used the same approach as in scheduleExtensionForUpdate(const QString& extensionName) to handle that case correctly in downloadAndInstallExtension(const QString& extensionId).