### PR TITLE
BUG + ENH:fixing ROI visibility and adding two signals in qSlicerVolumeRenderingModuleWidget

### DIFF
--- a/Modules/Loadable/Annotations/Widgets/qMRMLAnnotationROIWidget.cxx
+++ b/Modules/Loadable/Annotations/Widgets/qMRMLAnnotationROIWidget.cxx
@@ -26,6 +26,7 @@
 
 // MRML includes
 #include <vtkMRMLAnnotationROINode.h>
+#include <vtkMRMLDisplayNode.h>
 
 // 0.001 because the sliders only handle 2 decimals
 #define SLIDERS_EPSILON 0.001
@@ -100,11 +101,17 @@ vtkMRMLAnnotationROINode* qMRMLAnnotationROIWidget::mrmlROINode()const
 void qMRMLAnnotationROIWidget::setMRMLAnnotationROINode(vtkMRMLAnnotationROINode* roiNode)
 {
   Q_D(qMRMLAnnotationROIWidget);
-  qvtkReconnect(d->ROINode, roiNode, vtkCommand::ModifiedEvent,
+
+  this->qvtkReconnect(d->ROINode, roiNode, vtkCommand::ModifiedEvent,
                 this, SLOT(onMRMLNodeModified()));
 
+  this->qvtkReconnect(d->ROINode, roiNode, vtkMRMLDisplayableNode::DisplayModifiedEvent,
+                      this, SLOT(onMRMLDisplayNodeModified()));
+
   d->ROINode = roiNode;
+
   this->onMRMLNodeModified();
+  this->onMRMLDisplayNodeModified();
   this->setEnabled(roiNode != 0);
 }
 
@@ -125,9 +132,6 @@ void qMRMLAnnotationROIWidget::onMRMLNodeModified()
     }
 
   d->IsProcessingOnMRMLNodeModified = true;
-
-  // Visibility
-  d->DisplayClippingBoxButton->setChecked(d->ROINode->GetDisplayVisibility());
 
   // Interactive Mode
   bool interactive = d->ROINode->GetInteractiveMode();
@@ -191,8 +195,8 @@ void qMRMLAnnotationROIWidget::setExtent(double minLR, double maxLR,
 void qMRMLAnnotationROIWidget::setDisplayClippingBox(bool visible)
 {
   Q_D(qMRMLAnnotationROIWidget);
-  d->ROINode->SetDisplayVisibility(visible);
-  emit displayClippingBoxChanged(visible);
+  d->ROINode->SetDisplayClassVisibility
+        ("vtkMRMLAnnotationLineDisplayNode", visible);
 }
 
 // --------------------------------------------------------------------------
@@ -228,4 +232,19 @@ void qMRMLAnnotationROIWidget::updateROI()
                            0.5*(bounds[3]-bounds[2]),
                            0.5*(bounds[5]-bounds[4]));
   d->ROINode->EndModify(wasModifying);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLAnnotationROIWidget::onMRMLDisplayNodeModified()
+{
+  Q_D(qMRMLAnnotationROIWidget);
+
+  if (!d->ROINode)
+    {
+    return;
+    }
+
+  // Visibility
+  d->DisplayClippingBoxButton->setChecked(d->ROINode->
+          GetDisplayClassVisibility("vtkMRMLAnnotationLineDisplayNode"));
 }

--- a/Modules/Loadable/Annotations/Widgets/qMRMLAnnotationROIWidget.cxx
+++ b/Modules/Loadable/Annotations/Widgets/qMRMLAnnotationROIWidget.cxx
@@ -195,8 +195,19 @@ void qMRMLAnnotationROIWidget::setExtent(double minLR, double maxLR,
 void qMRMLAnnotationROIWidget::setDisplayClippingBox(bool visible)
 {
   Q_D(qMRMLAnnotationROIWidget);
-  d->ROINode->SetDisplayClassVisibility
-        ("vtkMRMLAnnotationLineDisplayNode", visible);
+
+  int n = d->ROINode->GetNumberOfDisplayNodes();
+  int wasModifying [n];
+  for(int i = 0; i < n; i++)
+    {
+    wasModifying[i] = d->ROINode->GetNthDisplayNode(i)->StartModify();
+    }
+  d->ROINode->SetDisplayVisibility(visible);
+  for(int i = 0; i < n; i++)
+    {
+    d->ROINode->GetNthDisplayNode(i)->EndModify(wasModifying[i]);
+    }
+
 }
 
 // --------------------------------------------------------------------------
@@ -245,6 +256,12 @@ void qMRMLAnnotationROIWidget::onMRMLDisplayNodeModified()
     }
 
   // Visibility
-  d->DisplayClippingBoxButton->setChecked(d->ROINode->
-          GetDisplayClassVisibility("vtkMRMLAnnotationLineDisplayNode"));
+  if(d->ROINode->GetDisplayVisibility())
+    {
+    d->DisplayClippingBoxButton->setChecked(true);
+    }
+  else
+    {
+    d->DisplayClippingBoxButton->setChecked(false);
+    }
 }

--- a/Modules/Loadable/Annotations/Widgets/qMRMLAnnotationROIWidget.h
+++ b/Modules/Loadable/Annotations/Widgets/qMRMLAnnotationROIWidget.h
@@ -75,6 +75,8 @@ protected slots:
   void onMRMLNodeModified();
   /// Internal function to update the ROI node based on the sliders
   void updateROI();
+  /// Internal function to update the ROIDisplay node
+  void onMRMLDisplayNodeModified();
 
 protected:
   QScopedPointer<qMRMLAnnotationROIWidgetPrivate> d_ptr;

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -555,7 +555,7 @@
   </customwidget>
   <customwidget>
    <class>ctkCheckablePushButton</class>
-   <extends>QPushButton</extends>
+   <extends>ctkPushButton</extends>
    <header>ctkCheckablePushButton.h</header>
   </customwidget>
   <customwidget>
@@ -584,6 +584,11 @@
    <class>ctkExpandButton</class>
    <extends>QToolButton</extends>
    <header>ctkExpandButton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkPushButton</class>
+   <extends>QPushButton</extends>
+   <header>ctkPushButton.h</header>
   </customwidget>
   <customwidget>
    <class>ctkSliderWidget</class>
@@ -817,38 +822,6 @@
     <hint type="destinationlabel">
      <x>230</x>
      <y>732</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ROICropDisplayCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>ROIWidget</receiver>
-   <slot>setDisplayClippingBox(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>238</x>
-     <y>193</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>114</x>
-     <y>541</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ROIWidget</sender>
-   <signal>displayClippingBoxChanged(bool)</signal>
-   <receiver>ROICropDisplayCheckBox</receiver>
-   <slot>setChecked(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>114</x>
-     <y>541</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>238</x>
-     <y>193</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -497,9 +497,20 @@ void qSlicerVolumeRenderingModuleWidget::updateFromMRMLDisplayROINode()
 {
   Q_D(qSlicerVolumeRenderingModuleWidget);
   //ROI visibility
-  d->ROICropDisplayCheckBox->setChecked(d->ROIWidget->mrmlROINode() ?
-         d->ROIWidget->mrmlROINode()->GetDisplayClassVisibility
-                     ("vtkMRMLAnnotationLineDisplayNode") : false);
+
+  if (!d->ROIWidget->mrmlROINode())
+    {
+    return;
+    }
+
+  if(d->ROIWidget->mrmlROINode()->GetDisplayVisibility())
+    {
+    d->ROICropDisplayCheckBox->setChecked(true);
+    }
+  else
+    {
+    d->ROICropDisplayCheckBox->setChecked(false);
+    }
 }
 
 
@@ -829,6 +840,19 @@ void qSlicerVolumeRenderingModuleWidget
     {
     d->DisplayNode->SetCroppingEnabled(toggle);
     }
-  d->ROIWidget->mrmlROINode()->SetDisplayClassVisibility
-         ("vtkMRMLAnnotationLineDisplayNode",toggle);
+
+  int n = d->ROIWidget->mrmlROINode()->GetNumberOfDisplayNodes();
+  int wasModifying [n];
+  for(int i = 0; i < n; i++)
+    {
+    wasModifying[i] = d->ROIWidget->mrmlROINode()->GetNthDisplayNode(i)->StartModify();
+    }
+
+  d->ROIWidget->mrmlROINode()->SetDisplayVisibility(toggle);
+
+  for(int i = 0; i < n; i++)
+    {
+    d->ROIWidget->mrmlROINode()->GetNthDisplayNode(i)->EndModify(wasModifying[i]);
+    }
+
 }

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -541,6 +541,13 @@ void qSlicerVolumeRenderingModuleWidget
 }
 
 // --------------------------------------------------------------------------
+void qSlicerVolumeRenderingModuleWidget::setDisplayROIEnabled(bool visibility)
+{
+  Q_D(qSlicerVolumeRenderingModuleWidget);
+  d->ROIWidget->setDisplayClippingBox(visibility);
+}
+
+// --------------------------------------------------------------------------
 vtkMRMLVolumePropertyNode* qSlicerVolumeRenderingModuleWidget
 ::mrmlVolumePropertyNode()const
 {

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -541,13 +541,6 @@ void qSlicerVolumeRenderingModuleWidget
 }
 
 // --------------------------------------------------------------------------
-void qSlicerVolumeRenderingModuleWidget::setDisplayROIEnabled(bool visibility)
-{
-  Q_D(qSlicerVolumeRenderingModuleWidget);
-  d->ROIWidget->setDisplayClippingBox(visibility);
-}
-
-// --------------------------------------------------------------------------
 vtkMRMLVolumePropertyNode* qSlicerVolumeRenderingModuleWidget
 ::mrmlVolumePropertyNode()const
 {

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
@@ -71,7 +71,6 @@ public slots:
   void addVolumeIntoView(vtkMRMLNode* node);
 
   void fitROIToVolume();
-  void setDisplayROIEnabled(bool visibility);
 
   void applyPreset(vtkMRMLNode* volumePropertyNode);
 

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
@@ -71,6 +71,7 @@ public slots:
   void addVolumeIntoView(vtkMRMLNode* node);
 
   void fitROIToVolume();
+  void setDisplayROIEnabled(bool visibility);
 
   void applyPreset(vtkMRMLNode* volumePropertyNode);
 

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
@@ -74,6 +74,10 @@ public slots:
 
   void applyPreset(vtkMRMLNode* volumePropertyNode);
 
+signals:
+  void newCurrentMRMLVolumeNode(vtkMRMLNode* node);
+  void newCurrentDisplayNode(vtkMRMLNode* node);
+
 protected slots:
   void onCurrentMRMLVolumeNodeChanged(vtkMRMLNode* node);
   void onVisibilityChanged(bool);
@@ -96,6 +100,7 @@ protected slots:
   void resetOffset();
   void updatePresetSliderRange();
   void updateFromMRMLDisplayNode();
+  void updateFromMRMLDisplayROINode();
 
   void synchronizeScalarDisplayNode();
   void setFollowVolumeDisplayNode(bool);


### PR DESCRIPTION
I'd like to add a slot setDisplayROIEnabled in qSlicerVolumeRenderingModuleWidget. 
For me it is necessary to enable the ROI display from my widget.

![animation](https://cloud.githubusercontent.com/assets/7985338/10513137/d301d998-7345-11e5-9dc5-775fb54eb1fa.gif)