### PR TITLE
BUG: Fix packaging on Windows

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -178,10 +178,10 @@ get_property(${project}_CPACK_PACKAGE_DESCRIPTION_FILE GLOBAL PROPERTY ${project
 get_property(${project}_CPACK_PACKAGE_DESCRIPTION_SUMMARY GLOBAL PROPERTY ${project}_DESCRIPTION_SUMMARY)
 get_property(${project}_CPACK_PACKAGE_ICON GLOBAL PROPERTY ${project}_APPLE_ICON_FILE)
 
-macro(slicer_verbose_set varname)
+function(slicer_verbose_set varname)
   message(STATUS "Setting ${varname} to '${ARGN}'")
-  set(${varname} ${ARGN})
-endmacro()
+  set(${varname} "${ARGN}" PARENT_SCOPE)
+endfunction()
 
 macro(slicer_cpack_set varname)
   if(DEFINED ${project}_${varname})


### PR DESCRIPTION
A regression was introduced in r24591 [1] and r24593 [2] that causes packaging
to fail on Windows because of the following errors:

    CMake Error: Error in cmake code at
    C:/D/N/Slicer-1-build/Slicer-build/CPackConfig.cmake:109:
    Parse error.  Function missing ending ")".  Instead found unterminated string wi
    th text ")
    endif()

    if(EXISTS ${CPACK_PROPERTIES_FILE})
      include(${CPACK_PROPERTIES_FILE})
    endif()
    ".
    CPack Error: Problem reading CPack config file: "C:/D/N/Slicer-1-build/Slicer-bu
    ild/CPackConfig.cmake"

and

    CMake Warning (dev) at C:/dev/SR2/Slicer-build/CPackConfig.cmake:74 (SET):
      Syntax error in cmake code at

        C:/dev/SR2/Slicer-build/CPackConfig.cmake:74

      when parsing string

        ..\Slicer;Slicer

      Invalid escape sequence \S

The issue is that the slicer_verbose_set() macro doesn't function as a drop-in
replacement for the CMake set() function.

The first error occurs because CPACK_NSIS_INSTALL_SUBDIRECTORY remains unset
even after the following lines:

    set(Slicer_CPACK_NSIS_INSTALL_SUBDIRECTORY "")
    slicer_cpack_set("CPACK_NSIS_INSTALL_SUBDIRECTORY")

and the conditional below erroneously evaluates to true:

    if(NOT CPACK_NSIS_INSTALL_SUBDIRECTORY STREQUAL "")

Adding quotation marks around the ${ARGN} variable address this error.

The second error occurs because macros consume escapes in string literals, as
documented in CMake bug 5389 [3].

Change the macro to a function and making its set() call use PARENT_SCOPE
addresses this error.

[1] http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=24591
[2] http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=24593
[3] https://cmake.org/Bug/view.php?id=5389

Co-authored-by: Francois Budin <fbudin@email.unc.edu>