### PR TITLE
ENH: update CTK to include exporting DICOM from browser

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -58,7 +58,7 @@ if(NOT DEFINED CTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/commontk/CTK.git"
-    GIT_TAG "7ea654e193b7d03d4186817b68a26a151fa129f0"
+    GIT_TAG "5f581323b6526caf5ff293d9a810a3c9f68343d9"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
Add an option to the right click table context menus after Delete
to export patients, studies, series to disk. Also incorporates
changes from two other developers:

git shortlog 7ea654e..5f58132 --no-merges

Gert Wollny (2):
      Fix compile and link errors when using QT5 on Debian
      Remove superfluous test on fontconfig

Johan Andruejol (2):
      Add an option to the ctkConsole to add/set the completion shortcuts
      Expose option on ctkConsole to control the runFile() interface

Nicole Aucoin (2):
      ENH: add the capability to export DICOM to disk
      BUG: stop after unable to create dir.