### PR TITLE
BUG: Incorporate fix for failing MultiVolumeExplorer GUI test

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -185,7 +185,7 @@ mark_as_advanced(Slicer_BUILD_MULTIVOLUME_SUPPORT)
 
 Slicer_Remote_Add(MultiVolumeExplorer
   GIT_REPOSITORY ${git_protocol}://github.com/fedorov/MultiVolumeExplorer.git
-  GIT_TAG c97e9d7b88abdd429b5410b5985d3fd03de851ec
+  GIT_TAG 9cd47306e7ee761072a07fef5ad1eaa7bb452816
   OPTION_NAME Slicer_BUILD_MultiVolumeExplorer
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_BUILD_MULTIVOLUME_SUPPORT;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Update the git tag for MultiVolumeExplorer to the version that
fixes the qSlicerMultiVolumeExplorerModuleWidgetGenericTest.

git shortlog c97e9d7b88abdd429b5410b5985d3fd03de851ec..9cd47306e7ee761072a07fef5ad1eaa7bb452816 --no-merges
Nicole Aucoin (1):
      BUG: fix failing widget generic test due to size hint