### PR TITLE
STYLE: Remove unused method itkWrapTransform3D::GetJacobian

### DIFF
--- a/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.h
+++ b/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.h
@@ -47,8 +47,6 @@ public:
   itkTypeMacro( WarpTransform3D, Transform );
   OutputPointType TransformPoint( const InputPointType & inputPoint ) const ITK_OVERRIDE;
 
-  const JacobianType & GetJacobian( const InputPointType & inputPoint ) const;
-
   virtual void ComputeJacobianWithRespectToParameters(const InputPointType  & p, JacobianType & jacobian ) const ITK_OVERRIDE;
 
   virtual void ComputeJacobianWithRespectToPosition(

--- a/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.txx
@@ -76,17 +76,6 @@ WarpTransform3D<FieldData>
   return transformedPoint;
 }
 
-// Copied and modified from dtiprocess
-// available there: http://www.nitrc.org/projects/dtiprocess/
-template <class FieldData>
-const typename WarpTransform3D<FieldData>::JacobianType
-& WarpTransform3D<FieldData>
-::GetJacobian( const InputPointType &inputPoint ) const
-  {
-  this->ComputeJacobianWithRespectToParameters( inputPoint, this->m_NonThreadsafeSharedJacobian );
-  return this->m_NonThreadsafeSharedJacobian;
-  }
-
 template <class FieldData>
 void
 WarpTransform3D<FieldData>


### PR DESCRIPTION
STYLE: Remove unused method itkWrapTransform3D::GetJacobian
    
Reviewing changes introduced in [r24669](https://github.com/Slicer/Slicer/commit/3c57b78d5bab0ac8c4ad3861414a2c498c8d4bbf) (COMP: Add ITK_OVERRIDE
designations for C++11) also identified some dead code that was
intended to override a parent class and provide exceptions or no
action, but infact did not override any parent virtual function.