### PR TITLE
BUG: Fix scaling of 3D window snapshots

### DIFF
--- a/Libs/MRML/Widgets/Resources/UI/qMRMLScreenShotDialog.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLScreenShotDialog.ui
@@ -141,6 +141,9 @@
    </item>
    <item row="2" column="1">
     <widget class="ctkDoubleSpinBox" name="scaleFactorSpinBox">
+     <property name="toolTip">
+      <string>Adjust the Magnification factor. Note that only the 3D view is rendered in high resolution, the other views are rescaled after the window is captured.</string>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
        <horstretch>0</horstretch>


### PR DESCRIPTION
Slicer svn revision 24668 incorporates a fix for a bug in vtkRenderLargeImage
so it now works with gradient backgrounds. Use this class to do off screen
magnified rendering of the 3D window when capturing screen shots.

A bug still remains for the 2D windows in that they get tiled by this
method instead of scaled, so continue using the Qt after capture
scaling for the full view and the slice views.

Issue #3885