### PR TITLE
COMP: Fix DiffusionWeightedVolumeMaskingTest linker error

### DIFF
--- a/Modules/CLI/DiffusionWeightedVolumeMasking/Testing/CMakeLists.txt
+++ b/Modules/CLI/DiffusionWeightedVolumeMasking/Testing/CMakeLists.txt
@@ -13,7 +13,7 @@ set(testname ${CLP}Test)
 add_test(NAME ${testname} COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:${CLP}Test>
   --compare ${BASELINE}/${CLP}Test_EstimatedBaseline.nhdr ${TEMP}/${CLP}Test_EstimatedBaseline.nhdr
   --compare ${BASELINE}/${CLP}Test_OtsuThresholdMask.nhdr ${TEMP}/${CLP}Test_OtsuThresholdMask.nhdr
-  ModuleEntryPoint
+  ${CLP}Test
     --otsuomegathreshold 0.5
     ${MRML_TEST_DATA}/helix-DWI.nhdr
     ${TEMP}/${CLP}Test_EstimatedBaseline.nhdr

--- a/Modules/CLI/DiffusionWeightedVolumeMasking/Testing/DiffusionWeightedVolumeMaskingTest.cxx
+++ b/Modules/CLI/DiffusionWeightedVolumeMasking/Testing/DiffusionWeightedVolumeMaskingTest.cxx
@@ -1,14 +1,10 @@
 #include "itkTestMain.h"
 
-#ifdef WIN32
-#define MODULE_IMPORT __declspec(dllimport)
-#else
-#define MODULE_IMPORT
-#endif
-
-extern "C" MODULE_IMPORT int ModuleEntryPoint(int, char * []);
-
 void RegisterTests()
 {
-  StringToTestFunctionMap["ModuleEntryPoint"] = ModuleEntryPoint;
+  REGISTER_TEST(DiffusionWeightedVolumeMaskingTest);
 }
+
+#undef main
+#define main DiffusionWeightedVolumeMaskingTest
+#include "../DiffusionWeightedVolumeMasking.cxx"


### PR DESCRIPTION
Changes in r24673 [1] cause a linker error when building
DiffusionWeightedVolumeMaskingTest in Visual Studio 2013:

    1>------ Build started: Project: DiffusionWeightedVolumeMaskingTest, Configuration: Debug x64 ------
    1>DiffusionWeightedVolumeMaskingTest.obj : error LNK2019: unresolved external symbol __imp_ModuleEntryPoint referenced in function "void __cdecl RegisterTests(void)" (?RegisterTests@@YAXXZ)
    1>C:\dev\SD\Slicer-build\bin\Debug\DiffusionWeightedVolumeMaskingTest.exe : fatal error LNK1120: 1 unresolved externals

This commit reverts some of the changes to make the test build and run.

[1] http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=24673