### PR TITLE
BUG: Fix vtkSlicerDoubleArraysLogicAddFileTest

### DIFF
--- a/Modules/Loadable/DoubleArrays/Testing/Cxx/vtkSlicerDoubleArraysLogicAddFileTest.cxx
+++ b/Modules/Loadable/DoubleArrays/Testing/Cxx/vtkSlicerDoubleArraysLogicAddFileTest.cxx
@@ -57,6 +57,7 @@ int vtkSlicerDoubleArraysLogicAddFileTest( int argc, char * argv[] )
 //-----------------------------------------------------------------------------
 bool testAddEmptyFile(const char * filePath)
 {
+  std::cout << "\n************************" << std::endl;
   vtkNew<vtkSlicerDoubleArraysLogic> doubleArraysLogic;
   vtkMRMLDoubleArrayNode* doubleArray = doubleArraysLogic->AddDoubleArray(filePath);
   if (doubleArray != 0)
@@ -65,6 +66,7 @@ bool testAddEmptyFile(const char * filePath)
               << ": Adding an invalid file (" << (filePath ? filePath : 0)
               << ") shall not return a valid doubleArray"
               << std::endl;
+    std::cout << "testAddEmptyFile(" << (filePath ? filePath : "0") << "): false" << std::endl;
     return false;
     }
 
@@ -82,9 +84,10 @@ bool testAddEmptyFile(const char * filePath)
               << ") shall not add nodes in scene. "
               << scene->GetNumberOfNodes() << " vs " << nodeCount
               << std::endl;
+    std::cout << "testAddEmptyFile(" << (filePath ? filePath : "0") << "): false" << std::endl;
     return false;
     }
-
+  std::cout << "testAddEmptyFile(" << (filePath ? filePath : "0") << "): true" << std::endl;
   return true;
 }
 


### PR DESCRIPTION
**WIP** DO NOT INTEGRATE

This commit fixes test vtkSlicerDoubleArraysLogicAddFileTest to account
for commit introduced in r24675 (BUG: Fix support for missing labels in
vtkMRMLDoubleArrayStorage reader)

At time of integration, only the test vtkMRMLDoubleArrayStorageNodeTest1
updated in r24676 (ENH: Add test for vtkMRMLDoubleArrayStorageNode
reader/writer) has been executed to confirm it was working.

Failure reported on the dashboard: 
* Linux: http://slicer.cdash.org/testDetails.php?test=6885663&build=700523
* MacOSX: http://slicer.cdash.org/testDetails.php?test=6885265&build=700522
* Windows: http://slicer.cdash.org/testDetails.php?test=6886406&build=700521