### PR TITLE
Fix DoubleArray tests

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
@@ -311,13 +311,12 @@ bool TestReadFileWithLabels(std::string filepath)
 
   vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayRead;
   doubleArrayRead->SetFileName(filepath.c_str());
-  doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
+  bool res = doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
 
   doubleArrayOut->GetValues(0, testArray2);
   doubleArrayOut->GetValues(1, testArray3);
   labelsOut = doubleArrayOut->GetLabels();
 
-  bool res = true;
   res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
   res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
   res = res && labelsMatch(__LINE__, labelsIn, labelsOut, 3);
@@ -345,12 +344,11 @@ bool TestReadFileWithoutLabels(std::string filepath)
 
   vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayRead;
   doubleArrayRead->SetFileName(filepath.c_str());
-  doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
+  bool res = doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
 
   doubleArrayOut->GetValues(0, testArray2);
   doubleArrayOut->GetValues(1, testArray3);
 
-  bool res = true;
   res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
   res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
 
@@ -376,13 +374,12 @@ bool TestReadOldFile(std::string filepath)
 
   vtkNew<vtkMRMLDoubleArrayStorageNode> doubleArrayRead;
   doubleArrayRead->SetFileName(filepath.c_str());
-  doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
+  bool res = doubleArrayRead->ReadData(doubleArrayOut.GetPointer());
 
   doubleArrayOut->GetValues(0, testArray2);
   doubleArrayOut->GetValues(1, testArray3);
   labelsOut = doubleArrayOut->GetLabels();
 
-  bool res = true;
   res = res && doubleArrayMatch(__LINE__, testArray0, testArray2, 3);
   res = res && doubleArrayMatch(__LINE__, testArray1, testArray3, 3);
   res = res && labelsMatch(__LINE__, labelsIn, labelsOut, 3);

--- a/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.cxx
@@ -204,7 +204,7 @@ int vtkMRMLDoubleArrayStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
     }
   fstr.close();
 
-  return (doubleArrayNode->GetSize() > 0) ? 0 : 1;
+  return doubleArrayNode->GetSize() > 0;
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/DoubleArrays/Logic/vtkSlicerDoubleArraysLogic.cxx
+++ b/Modules/Loadable/DoubleArrays/Logic/vtkSlicerDoubleArraysLogic.cxx
@@ -55,7 +55,15 @@ void vtkSlicerDoubleArraysLogic::PrintSelf(ostream& os, vtkIndent indent)
 vtkMRMLDoubleArrayNode* vtkSlicerDoubleArraysLogic
 ::AddDoubleArray(const char* fileName, const char* name)
 {
-  if (this->GetMRMLScene() == 0 || fileName == 0)
+  if (!fileName)
+    {
+    return 0;
+    }
+  if (fileName[0] == '\0')
+    {
+    return 0;
+    }
+  if (this->GetMRMLScene() == 0)
     {
     return 0;
     }

--- a/Modules/Loadable/DoubleArrays/Testing/Cxx/vtkSlicerDoubleArraysLogicAddFileTest.cxx
+++ b/Modules/Loadable/DoubleArrays/Testing/Cxx/vtkSlicerDoubleArraysLogicAddFileTest.cxx
@@ -109,7 +109,10 @@ bool testAddFile(const char * filePath)
   if (doubleArray == 0 ||
       scene->GetNumberOfNodes() != nodeCount + 2)
     {
-    std::cerr << "Adding an doubleArray should create 2 nodes" << std::endl;
+    std::cerr << "Line " << __LINE__
+	      << ": Adding an doubleArray should create 2 nodes. "
+              << scene->GetNumberOfNodes() << " vs " << nodeCount + 2
+              << std::endl;
     return false;
     }
 


### PR DESCRIPTION
Corrects typo returning wrong value at the end of `vtkMRMLDoubleArrayStorageNode::ReadDataInternal`.

It is now returning 0 if the DoubleArray is empty. This is not a usual behavior as we should allow reading an empty node, but we are doing this for backward compatibility [1].

[1] https://github.com/jcfr/Slicer/commit/96afb52#diff-8f3fa951eccab26a6d68e04cb1488da0L200

This fixes those two failing tests:
*  `vtkSlicerDoubleArraysLogicAddFileTest` : the error was shown by improving the test in commit d36d5ba
*  `vtkMRMLDoubleArrayNodeTest1` : error discovered by @jcfr in #392 

