### PR TITLE
3462 model maker breaks slice view display

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
@@ -717,9 +717,9 @@ vtkMRMLSelectionNode::GetModelHierarchyDisplayNodeClassNames()const
 
 //----------------------------------------------------------------------------
 void vtkMRMLSelectionNode::AddModelHierarchyDisplayNodeClassName(const std::string& dispayableNodeClass,
-                                                                 const std::string& dispayNodeClass)
+                                                                 const std::string& displayNodeClass)
 {
-  this->ModelHierarchyDisplayNodeClassName[dispayableNodeClass] = dispayNodeClass;
+  this->ModelHierarchyDisplayNodeClassName[dispayableNodeClass] = displayNodeClass;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSelectionNode.h
+++ b/Libs/MRML/Core/vtkMRMLSelectionNode.h
@@ -234,7 +234,7 @@ class VTK_MRML_EXPORT vtkMRMLSelectionNode : public vtkMRMLNode
   /// For example, parameters of "vtkMRMLFiberbundleNode" , "vtkMRMLFiberbundleTubeDisplayNode"
   /// will change tube visibility
   void AddModelHierarchyDisplayNodeClassName(const std::string& dispayableNodeClass,
-                                             const std::string& dispayNodeClass);
+                                             const std::string& displayNodeClass);
 
   /// Clear node display class names
   /// to which display node to apply properties in hierarchy display widgets

--- a/Libs/MRML/Widgets/qMRMLSceneDisplayableModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneDisplayableModel.cxx
@@ -73,7 +73,7 @@ vtkMRMLDisplayNode* qMRMLSceneDisplayableModelPrivate
   vtkMRMLDisplayableNode* displayableNode = vtkMRMLDisplayableNode::SafeDownCast(node);
   if (selectionNode && displayableNode)
     {
-    char *displayableType = (char *)node->GetClassName();
+    char *displayableType = (char *)displayableNode->GetClassName();
     std::string displayType =
         selectionNode->GetModelHierarchyDisplayNodeClassName(displayableType);
     if (!displayType.empty())

--- a/Libs/MRML/Widgets/qMRMLSceneDisplayableModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneDisplayableModel.cxx
@@ -41,6 +41,7 @@ qMRMLSceneDisplayableModelPrivate
 void qMRMLSceneDisplayableModelPrivate::init()
 {
   Q_Q(qMRMLSceneDisplayableModel);
+  q->setLazyUpdate(true);
   q->setVisibilityColumn(q->nameColumn());
 }
 

--- a/Libs/MRML/Widgets/qMRMLSceneDisplayableModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneDisplayableModel.cxx
@@ -74,15 +74,14 @@ vtkMRMLDisplayNode* qMRMLSceneDisplayableModelPrivate
   if (selectionNode && displayableNode)
     {
     char *displayableType = (char *)node->GetClassName();
-    char *displayType = 0;
-    std::string ds = selectionNode->GetModelHierarchyDisplayNodeClassName(displayableType);
-    if (!ds.empty())
+    std::string displayType =
+        selectionNode->GetModelHierarchyDisplayNodeClassName(displayableType);
+    if (!displayType.empty())
       {
-      displayType = (char *)ds.c_str();
       for (int  i=0; i<displayableNode->GetNumberOfDisplayNodes(); i++)
         {
         vtkMRMLDisplayNode *displayNode = displayableNode->GetNthDisplayNode(i);
-        if (displayNode && displayNode->IsA(displayType))
+        if (displayNode && displayNode->IsA(displayType.c_str()))
           {
             return displayNode;
           }


### PR DESCRIPTION
 BUG: Avoid confusion when importing scene model hierarchy. Fixes #3462

*** WIP ***

Considering that:

1. the slice view representation in the 3D view is done using a `vtkMRMLModelDisplayNode`

2. the IDs associated with these nodes are `vtkMRMLModelDisplayNode1`, `vtkMRMLModelDisplayNode2`, ...

3. node references are updated after nodes are added to the scene. Indeed, this is done in the `UpdateNodeReferences()` function called from  `vtkMRMLScene::Import()`

4. By default, `qMRMLSceneDisplayableModel` updates itself each time a node is added (`NodeAddedEvent`), it doesn't consider the Import state of the scene.

importing a scene containing hierarchy nodes referencing model display nodes also identified with `vtkMRMLModelDisplayNode1`, ... will cause the `qMRMLSceneDisplayableModel` to <TO BE CONTINUED>

This commit implements the solution consisting in always setting the `qMRMLSceneDisplayableModel` as LazyUpdate, this means that **To be continued**

  (a) the model will always ignore the NodeAdded/NodeRemoved events  when batch operation  (ie Import) are done on the scene

  and (b) will rescan the scene after the batch operation is complete.