### PR TITLE
BUG: Disable fiducials in light box mode.

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -24,12 +24,14 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMenu>
+#include <QMessageBox>
 #include <QPushButton>
 #include <QSpinBox>
 #include <QWidgetAction>
 
 // CTK includes
 #include <ctkDoubleSlider.h>
+#include <ctkMessageBox.h>
 #include <ctkPopupWidget.h>
 #include <ctkSignalMapper.h>
 #include <ctkDoubleSpinBox.h>
@@ -2157,6 +2159,28 @@ void qMRMLSliceControllerWidget::setSliceModelMode(int mode)
 void qMRMLSliceControllerWidget::setLightbox(int rows, int columns)
 {
   Q_D(qMRMLSliceControllerWidget);
+  // TBD: Mantis Issue #1690: disable fiducials in light box mode
+  int ret = QMessageBox::Yes;
+  if (rows * columns != 1)
+    {
+    ctkMessageBox disableFidsMsgBox;
+    disableFidsMsgBox.setWindowTitle("Disable fiducials?");
+    QString labelText = QString("Fiducials are disabled in light box mode. Press Continue to enter light box mode without fiducials.");
+    disableFidsMsgBox.setText(labelText);
+    QPushButton *continueButton =
+       disableFidsMsgBox.addButton(tr("Continue"), QMessageBox::AcceptRole);
+    disableFidsMsgBox.addButton(QMessageBox::Cancel);
+    disableFidsMsgBox.setIcon(QMessageBox::Question);
+    disableFidsMsgBox.setDontShowAgainVisible(true);
+    disableFidsMsgBox.setDontShowAgainSettingsKey("SliceController/AlwaysEnterLightBoxWithDisabledFiducials");
+    disableFidsMsgBox.exec();
+    if (disableFidsMsgBox.clickedButton() != continueButton)
+      {
+      d->actionLightbox1x1_view->setChecked(1);
+      return;
+      }
+    }
+
   vtkSmartPointer<vtkCollection> nodes = d->saveNodesForUndo("vtkMRMLSliceNode");
   if (!nodes.GetPointer())
     {

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
@@ -758,7 +758,15 @@ void vtkMRMLMarkupsDisplayableManager2D::UpdateWidgetVisibility(vtkMRMLMarkupsNo
          widget->GetRepresentation()->GetRenderer() &&
          widget->GetRepresentation()->GetRenderer()->IsActiveCameraCreated())
        {
-       widget->SetEnabled(1);
+       if (this->IsInLightboxMode())
+         {
+         // TBD: issue #1690
+         vtkDebugMacro("NOT setting widget enabled because in light box mode!");
+         }
+       else
+         {
+         widget->SetEnabled(1);
+         }
        }
      else
        {
@@ -799,6 +807,13 @@ void vtkMRMLMarkupsDisplayableManager2D::OnMRMLSliceNodeModifiedEvent()
 //---------------------------------------------------------------------------
 bool vtkMRMLMarkupsDisplayableManager2D::IsWidgetDisplayableOnSlice(vtkMRMLMarkupsNode* node, int markupIndex)
 {
+
+  if (this->IsInLightboxMode())
+    {
+    // TBD: issue 1690: disable fiducials in light box mode as they appear
+    // in the wrong location
+    return false;
+    }
 
   vtkMRMLSliceNode* sliceNode = this->GetMRMLSliceNode();
   // if no slice node, it doesn't constrain the visibility, so return that


### PR DESCRIPTION
Fiducials are not being properly positioned when in light box mode, this
change disables them and gives the user a warning that they are being disabled
(new fiducials can still be placed, but will not be visible until you exit light box mode).
This change fixes bugs that were left from the attempt to use the point handle
widgets in 2D so that they can be properly hidden: fix the visibility setting
on the point handles in light box mode, disable the point handles when invisible
so that they don't become visible when the mouse is near it, updated a
visibility check comparision to match return type from method.
Also removed warning messages by casting the 3d handles before changing the
picking state.
Fixed a bug wherein if you had a mix of fiducials having been placed in lightbox
and not light box mode, the seed widget would have a mix of 2d and 3d handles.
This fix removes all the current handles so that they're properly recreated as
the necessary type.

Issue #1690