### PR TITLE
BUG: Fix crash on saving node named with a single number

### DIFF
--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -490,7 +490,8 @@ QFileInfo qSlicerSaveDataDialogPrivate::nodeFileInfo(vtkMRMLStorableNode* node)
   // Make sure series number is not one digit (names like "1: something" confuse save dialog, see http://www.na-mic.org/Bug/view.php?id=3991)
   // TODO: This is a workaround, remove if good fix found
   QString safeNodeName(node->GetName());
-  if (safeNodeName.at(0).isNumber() && safeNodeName.at(1) == QChar(':'))
+  if (safeNodeName.length() > 1 &&
+      safeNodeName.at(0).isNumber() && safeNodeName.at(1) == QChar(':'))
     {
     safeNodeName.insert(0, tr("0"));
     }


### PR DESCRIPTION
A previous fix[1] to avoid crashes on windows when saving
volumes named "1:xxxx" leads to a crash when a node name
is just a single number (the first part of the check passes, but
crashes when trying to get the second character in the name string).
This fix adds a string length check so that valid node names like
"1" or "2" will not cause a crash on save.

[1] http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=24294

Issue #3991