### PR TITLE
BUG: 2466, MRMLIDImageIO crashes with DWMRI volume

### DIFF
--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
@@ -487,7 +487,7 @@ int vtkMRMLNRRDStorageNode::ParseDiffusionInformation(vtkNRRDReader *reader,vtkD
       rep = atoi(value.c_str());
       for (int i=0;i<rep-1;i++) {
         grad->InsertNextTuple3(g[0],g[1],g[2]);
-        factor->InsertNextValue(sqrt(g[0]*g[0]+g[1]*g[1]+g[2]*g[2]));
+        factor->InsertNextValue(sqrt( g[0]*g[0]+g[1]*g[1]+g[2]*g[2] ));
       }
     }
    pos = (unsigned int)keys.find(tag,pos+1);
@@ -508,7 +508,9 @@ int vtkMRMLNRRDStorageNode::ParseDiffusionInformation(vtkNRRDReader *reader,vtkD
   bvalues->SetNumberOfTuples(grad->GetNumberOfTuples());
   for (int i=0; i<grad->GetNumberOfTuples();i++)
     {
-    bvalues->SetValue(i,bval*factor->GetValue(i)/range[1]);
+    // note: this is norm^2, per the NA-MIC NRRD DWI convention
+    // http://wiki.na-mic.org/Wiki/index.php/NAMIC_Wiki:DTI:Nrrd_format
+    bvalues->SetValue(i, bval * (pow(factor->GetValue(i)/range[1], 2)));
     }
   return 1;
 }

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
@@ -819,7 +819,6 @@ MRMLIDImageIO
 
     for (unsigned int j=0; j < 3; ++j)
       {
-//      gradient[j] = g[j] * dw->GetBValue(i) / maxBValue;
         gradient[j] = g[j];
       }
 
@@ -920,7 +919,7 @@ MRMLIDImageIO
       gradientSS >> gradient[0];
       gradientSS >> gradient[1];
       gradientSS >> gradient[2];
-/*
+
       // gradient length is the b-value / max_b-value
       double sum = 0.0;
       for (unsigned int i=0; i < 3; ++i)
@@ -928,14 +927,10 @@ MRMLIDImageIO
         sum += (gradient[i] * gradient[i]);
         }
       sum = sqrt(sum);
-      bvalues.push_back( sum * maxBValue );
-
-      if (sum > 0)
-        for (unsigned int i=0; i < 3; ++i)
-          {
-            gradient[i] /= sum;
-          }
-*/
+      // for multiple b-values, scale factor is `sqrt(b/b_max)`
+      // per NA-MIC DWI convention. so we take `norm^2 * b_max`
+      // to get back the original b-values.
+      bvalues.push_back( pow(sum,2) * maxBValue );
       gradients.push_back(gradient);
       }
     }

--- a/Libs/vtkTeem/vtkNRRDWriter.cxx
+++ b/Libs/vtkTeem/vtkNRRDWriter.cxx
@@ -319,7 +319,10 @@ void vtkNRRDWriter::WriteData()
         {
         grad=this->DiffusionGradients->GetTuple3(ig);
         bVal = this->BValues->GetValue(ig);
-        factor = bVal/maxbVal;
+        // for multiple b-values, scale factor is `sqrt(b/b_max)`
+        // per NA-MIC DWI convention. so we take `norm^2 * b_max`
+        // to get back the original b-values.
+        factor = sqrt(bVal/maxbVal);
         sprintf(key,"%s%04d","DWMRI_gradient_",ig);
         sprintf(value,"%f %f %f",grad[0]*factor, grad[1]*factor, grad[2]*factor);
         nrrdKeyValueAdd(nrrd,key, value);


### PR DESCRIPTION
http://www.na-mic.org/Bug/view.php?id=2466

Restore handling of b-values and gradients, and make code consistent
with DWIConvert: use the `sqrt(b/b_max)` scaling factor as documented
on the NA-MIC wiki page:

http://wiki.na-mic.org/Wiki/index.php/NAMIC_Wiki:DTI:Nrrd_format