### PR TITLE
ENH: Added output checking to module CXX tests

### DIFF
--- a/Extensions/Testing/LoadableExtensionTemplate/LoadableModuleTemplate/Testing/Cxx/CMakeLists.txt
+++ b/Extensions/Testing/LoadableExtensionTemplate/LoadableModuleTemplate/Testing/Cxx/CMakeLists.txt
@@ -10,6 +10,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Extensions/Testing/SuperBuildExtensionTemplate/SuperLoadableModuleTemplate/Testing/Cxx/CMakeLists.txt
+++ b/Extensions/Testing/SuperBuildExtensionTemplate/SuperLoadableModuleTemplate/Testing/Cxx/CMakeLists.txt
@@ -10,6 +10,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -413,13 +413,13 @@ vtkMRMLNode* vtkMRMLScene::CreateNodeByClass(const char* className)
 }
 
 //------------------------------------------------------------------------------
-void vtkMRMLScene::RegisterNodeClass(vtkMRMLNode* node)
+void vtkMRMLScene::RegisterNodeClass(vtkMRMLNode* node, bool force /* = true*/)
 {
-  this->RegisterNodeClass(node, node->GetNodeTagName());
+  this->RegisterNodeClass(node, node->GetNodeTagName(), force);
 }
 
 //------------------------------------------------------------------------------
-void vtkMRMLScene::RegisterNodeClass(vtkMRMLNode* node, const char* tagName)
+void vtkMRMLScene::RegisterNodeClass(vtkMRMLNode* node, const char* tagName, bool force /*= true */)
 {
   if (!node)
     {
@@ -438,7 +438,7 @@ void vtkMRMLScene::RegisterNodeClass(vtkMRMLNode* node, const char* tagName)
     return;
     }
   std::string xmlTag(tagName);
-  // Replace the previously registered node if any.
+  // Check if a node with the same class is registered already.
   // By doing so we make sure there is no more than 1 node matching a given
   // XML tag. It allows plugins to MRML to overide default behavior when
   // instantiating nodes via XML tags.
@@ -446,6 +446,12 @@ void vtkMRMLScene::RegisterNodeClass(vtkMRMLNode* node, const char* tagName)
     {
     if (this->RegisteredNodeTags[i] == xmlTag)
       {
+      if (!force)
+        {
+        // The node is registered already. Overwriting of the class
+        // is not forced, so we just keep the current class.
+        return;
+        }
       vtkWarningMacro("Tag " << tagName
                       << " has already been registered, unregistering previous node class "
                       << (this->RegisteredNodeClasses[i]->GetClassName() ? this->RegisteredNodeClasses[i]->GetClassName() : "(no class name)")

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -121,14 +121,20 @@ public:
   /// where X is the major version of Slicer scene to support, Y the minor and
   /// Z the patch version.
   ///
+  /// If force is set to true then if a class with the same tag is already registered
+  /// it will be overwritten with the new class.
+  ///
   /// \sa CreateNodeByClass(), GetClassNameByTag()
-  void RegisterNodeClass(vtkMRMLNode* node, const char* tagName);
+  void RegisterNodeClass(vtkMRMLNode* node, const char* tagName, bool force = true);
 
   /// \brief Utility function to RegisterNodeClass(), the node tag name is used when
   /// registering the node.
   ///
+  /// If force is set to true then if a class with the same tag is already registered
+  /// it will be overwritten with the new class.
+  ///
   /// \sa RegisterNodeClass()
-  void RegisterNodeClass(vtkMRMLNode* node);
+  void RegisterNodeClass(vtkMRMLNode* node, bool force = true);
 
   /// Add a path to the list.
   const char* GetClassNameByTag(const char *tagName);

--- a/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
+++ b/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
@@ -748,39 +748,43 @@ void vtkSlicerAnnotationModuleLogic::RegisterNodes()
   // The core nodes
   //
 
+  // We just want to make sure the classes are registered, there
+  // is no need to overwrite them if they are already registered.
+  const bool forceOverwriteExistingClass = false;
+
   // base nodes
   vtkNew<vtkMRMLAnnotationNode> annotationNode;
-  scene->RegisterNodeClass(annotationNode.GetPointer());
+  scene->RegisterNodeClass(annotationNode.GetPointer(), forceOverwriteExistingClass);
 
   vtkNew<vtkMRMLAnnotationDisplayNode> annotationDisplayNode;
-  scene->RegisterNodeClass(annotationDisplayNode.GetPointer());
+  scene->RegisterNodeClass(annotationDisplayNode.GetPointer(), forceOverwriteExistingClass);
 
   vtkNew<vtkMRMLAnnotationStorageNode> annotationStorageNode;
-  scene->RegisterNodeClass(annotationStorageNode.GetPointer());
+  scene->RegisterNodeClass(annotationStorageNode.GetPointer(), forceOverwriteExistingClass);
 
   // Control Points
   vtkNew<vtkMRMLAnnotationControlPointsNode> annotationControlPointsNode;
-  scene->RegisterNodeClass(annotationControlPointsNode.GetPointer());
+  scene->RegisterNodeClass(annotationControlPointsNode.GetPointer(), forceOverwriteExistingClass);
 
   vtkNew<vtkMRMLAnnotationControlPointsStorageNode> annotationControlPointsStorageNode;
-  scene->RegisterNodeClass(annotationControlPointsStorageNode.GetPointer());
+  scene->RegisterNodeClass(annotationControlPointsStorageNode.GetPointer(), forceOverwriteExistingClass);
 
   vtkNew<vtkMRMLAnnotationPointDisplayNode> annotationControlPointsDisplayNode;
-  scene->RegisterNodeClass(annotationControlPointsDisplayNode.GetPointer());
+  scene->RegisterNodeClass(annotationControlPointsDisplayNode.GetPointer(), forceOverwriteExistingClass);
 
   // Lines
   vtkNew<vtkMRMLAnnotationLinesNode> annotationLinesNode;
-  scene->RegisterNodeClass(annotationLinesNode.GetPointer());
+  scene->RegisterNodeClass(annotationLinesNode.GetPointer(), forceOverwriteExistingClass);
 
   vtkNew<vtkMRMLAnnotationLinesStorageNode> annotationLinesStorageNode;
-  scene->RegisterNodeClass(annotationLinesStorageNode.GetPointer());
+  scene->RegisterNodeClass(annotationLinesStorageNode.GetPointer(), forceOverwriteExistingClass);
 
   vtkNew<vtkMRMLAnnotationLineDisplayNode> annotationLinesDisplayNode;
-  scene->RegisterNodeClass(annotationLinesDisplayNode.GetPointer());
+  scene->RegisterNodeClass(annotationLinesDisplayNode.GetPointer(), forceOverwriteExistingClass);
 
   // Text
   vtkNew<vtkMRMLAnnotationTextDisplayNode> annotationTextDisplayNode;
-  scene->RegisterNodeClass(annotationTextDisplayNode.GetPointer());
+  scene->RegisterNodeClass(annotationTextDisplayNode.GetPointer(), forceOverwriteExistingClass);
 
   //
   // Now the actual Annotation tool nodes
@@ -788,46 +792,46 @@ void vtkSlicerAnnotationModuleLogic::RegisterNodes()
 
   // Snapshot annotation
   vtkNew<vtkMRMLAnnotationSnapshotNode> annotationSnapshotNode;
-  scene->RegisterNodeClass(annotationSnapshotNode.GetPointer());
+  scene->RegisterNodeClass(annotationSnapshotNode.GetPointer(), forceOverwriteExistingClass);
 
   vtkNew<vtkMRMLAnnotationSnapshotStorageNode> annotationSnapshotStorageNode;
-  scene->RegisterNodeClass(annotationSnapshotStorageNode.GetPointer());
+  scene->RegisterNodeClass(annotationSnapshotStorageNode.GetPointer(), forceOverwriteExistingClass);
 
   // Text annotation
   vtkNew<vtkMRMLAnnotationTextNode> annotationTextNode;
-  scene->RegisterNodeClass(annotationTextNode.GetPointer());
+  scene->RegisterNodeClass(annotationTextNode.GetPointer(), forceOverwriteExistingClass);
 
   // Ruler annotation
   vtkNew<vtkMRMLAnnotationRulerNode> annotationRulerNode;
-  scene->RegisterNodeClass(annotationRulerNode.GetPointer());
+  scene->RegisterNodeClass(annotationRulerNode.GetPointer(), forceOverwriteExistingClass);
 
   vtkNew<vtkMRMLAnnotationRulerStorageNode> annotationRulerStorageNode;
-  scene->RegisterNodeClass(annotationRulerStorageNode.GetPointer());
+  scene->RegisterNodeClass(annotationRulerStorageNode.GetPointer(), forceOverwriteExistingClass);
 
   // ROI annotation
   vtkNew<vtkMRMLAnnotationROINode> annotationROINode;
-  scene->RegisterNodeClass(annotationROINode.GetPointer());
+  scene->RegisterNodeClass(annotationROINode.GetPointer(), forceOverwriteExistingClass);
   // ROI annotation backwards compatibility
 #if MRML_SUPPORT_VERSION < 0x040000
-  scene->RegisterNodeClass(annotationROINode.GetPointer(), "ROI");
+  scene->RegisterNodeClass(annotationROINode.GetPointer(), "ROI", forceOverwriteExistingClass);
 #endif
 
   // Bidimensional annotation
   vtkNew<vtkMRMLAnnotationBidimensionalNode> annotationBidimensionalNode;
-  scene->RegisterNodeClass(annotationBidimensionalNode.GetPointer());
+  scene->RegisterNodeClass(annotationBidimensionalNode.GetPointer(), forceOverwriteExistingClass);
 
   // Fiducial annotation
   vtkNew<vtkMRMLAnnotationFiducialNode> annotationFiducialNode;
-  scene->RegisterNodeClass(annotationFiducialNode.GetPointer());
+  scene->RegisterNodeClass(annotationFiducialNode.GetPointer(), forceOverwriteExistingClass);
 
   vtkNew<vtkMRMLAnnotationFiducialsStorageNode> annotationFiducialsStorageNode;
-  scene->RegisterNodeClass(annotationFiducialsStorageNode.GetPointer());
+  scene->RegisterNodeClass(annotationFiducialsStorageNode.GetPointer(), forceOverwriteExistingClass);
 
   //
   // Annotation hierarchies
   //
   vtkNew<vtkMRMLAnnotationHierarchyNode> annotationHierarchyNode;
-  scene->RegisterNodeClass(annotationHierarchyNode.GetPointer());
+  scene->RegisterNodeClass(annotationHierarchyNode.GetPointer(), forceOverwriteExistingClass);
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Annotations/Testing/Cxx/CMakeLists.txt
@@ -53,6 +53,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   TARGET_LIBRARIES qSlicer${MODULE_NAME}ModuleWidgets
   TESTS_TO_RUN_VAR KIT_TESTS_TO_RUN
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationDisplayableManagerTest2.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationDisplayableManagerTest2.cxx
@@ -35,6 +35,7 @@
 #include <vtkMRMLViewNode.h>
 
 // VTK includes
+#include <vtkCamera.h>
 #include <vtkNew.h>
 #include <vtkRenderer.h>
 #include <vtkRenderWindow.h>
@@ -52,6 +53,9 @@ int vtkMRMLAnnotationDisplayableManagerTest2(int vtkNotUsed(argc), char* vtkNotU
   vtkNew<vtkRenderWindowInteractor> renderWindowInteractor;
   renderWindow->SetSize(600, 600);
   renderWindow->SetMultiSamples(0); // Ensure to have the same test image everywhere
+
+  vtkNew<vtkCamera> camera;
+  renderer->SetActiveCamera(camera.GetPointer());
 
   renderWindow->AddRenderer(renderer.GetPointer());
   renderWindow->SetInteractor(renderWindowInteractor.GetPointer());
@@ -83,6 +87,8 @@ int vtkMRMLAnnotationDisplayableManagerTest2(int vtkNotUsed(argc), char* vtkNotU
 
   // Start test
   vtkNew<vtkMRMLAnnotationFiducialNode> fiducialNode;
+  double controlPoint[3]={0,0,0};
+  fiducialNode->AddControlPoint(controlPoint,0,1);
   /// Initializing a node should automatically create a display node
   fiducialNode->Initialize(scene);
   if (fiducialNode->GetNumberOfDisplayNodes() == 0)

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkSlicerAnnotationModuleLogicImportSceneTest.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkSlicerAnnotationModuleLogicImportSceneTest.cxx
@@ -46,14 +46,15 @@ int vtkSlicerAnnotationModuleLogicImportSceneTest(int vtkNotUsed(argc), char * v
 bool ImportTwiceTest(bool verbose)
 {
   vtkNew<vtkMRMLScene> scene;
-  vtkNew<vtkSlicerAnnotationModuleLogic > logic;
-  logic->SetMRMLScene(scene.GetPointer());
 
   vtkNew<vtkMRMLSelectionNode> selectionNode;
   scene->AddNode(selectionNode.GetPointer());
 
   vtkNew<vtkMRMLInteractionNode> interactionNode;
   scene->AddNode(interactionNode.GetPointer());
+
+  vtkNew<vtkSlicerAnnotationModuleLogic > logic;
+  logic->SetMRMLScene(scene.GetPointer());
 
   logic->AddHierarchy();
   vtkNew<vtkMRMLAnnotationRulerNode> rnode;
@@ -68,6 +69,10 @@ bool ImportTwiceTest(bool verbose)
   ///   - vtkMRMLModelHierarchyNode2 (parent of vtkMRMLModelHierarchyNode1)
   vtkMRMLAnnotationRulerNode* ruler1 = vtkMRMLAnnotationRulerNode::SafeDownCast(
     scene->GetNodeByID("vtkMRMLAnnotationRulerNode1"));
+  double controlPoint1[3]={34,56,78};
+  double controlPoint2[3]={134,156,178};
+  ruler1->SetControlPointWorldCoordinates(0,controlPoint1, 0, 1);
+  ruler1->SetControlPointWorldCoordinates(1,controlPoint2, 0, 1);
   vtkMRMLAnnotationHierarchyNode* rulerHierarchy1 = vtkMRMLAnnotationHierarchyNode::SafeDownCast(
     vtkMRMLDisplayableHierarchyNode::GetDisplayableHierarchyNode(
       scene.GetPointer(),

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkSlicerAnnotationModuleLogicTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkSlicerAnnotationModuleLogicTest1.cxx
@@ -8,7 +8,11 @@
 
 // MRML includes
 #include <vtkMRMLCoreTestingMacros.h>
+#include <vtkMRMLInteractionNode.h>
 #include <vtkMRMLScene.h>
+#include <vtkMRMLSelectionNode.h>
+
+#include "vtkTestingOutputWindow.h"
 
 void CheckTextColor(vtkMRMLAnnotationRulerNode *rnode)
 {
@@ -42,8 +46,13 @@ int vtkSlicerAnnotationModuleLogicTest1(int , char * [] )
   // ======================
   // Basic Setup
   // ======================
-  vtkSmartPointer<vtkSlicerAnnotationModuleLogic > node2 = vtkSmartPointer< vtkSlicerAnnotationModuleLogic >::New();
   vtkSmartPointer<vtkMRMLScene> mrmlScene = vtkSmartPointer<vtkMRMLScene>::New();
+  vtkNew<vtkMRMLSelectionNode> selectionNode;
+  mrmlScene->AddNode(selectionNode.GetPointer());
+  vtkNew<vtkMRMLInteractionNode> interactionNode;
+  mrmlScene->AddNode(interactionNode.GetPointer());
+
+  vtkSmartPointer<vtkSlicerAnnotationModuleLogic > node2 = vtkSmartPointer< vtkSlicerAnnotationModuleLogic >::New();
   node2->SetMRMLScene(mrmlScene);
 
   EXERCISE_BASIC_OBJECT_METHODS( node2 );
@@ -67,7 +76,10 @@ int vtkSlicerAnnotationModuleLogicTest1(int , char * [] )
 
   node2->CancelCurrentOrRemoveLastAddedAnnotationNode();
 
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   node2->RemoveAnnotationNode(NULL);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
   node2->RemoveAnnotationNode(rnode1);
 
   // TODO: test mrml event processing?
@@ -208,6 +220,10 @@ int vtkSlicerAnnotationModuleLogicTest1(int , char * [] )
     return EXIT_FAILURE;
     }
   vtkSmartPointer<vtkMRMLAnnotationFiducialNode> fnode = vtkSmartPointer<vtkMRMLAnnotationFiducialNode>::New();
+  double pos[3]={1,2,5};
+  fnode->SetControlPoint(0, pos, 0, 1);
+  mrmlScene->AddNode(fnode);
+
   char *toplevelfidid = node2->GetTopLevelHierarchyNodeIDForNodeClass(fnode);
   std::cout << "Top level fid id = " << (toplevelfidid ? toplevelfidid : "null") << std::endl;
 
@@ -218,7 +234,9 @@ int vtkSlicerAnnotationModuleLogicTest1(int , char * [] )
     }
 
   vtkMRMLAnnotationNode *nullNode = NULL;
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   const char *htmlRep = node2->GetHTMLRepresentation(nullNode, -1);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   if (htmlRep)
     {
     std::cout << htmlRep << std::endl;
@@ -237,7 +255,9 @@ int vtkSlicerAnnotationModuleLogicTest1(int , char * [] )
 
   // test adding a display node for a hierarchy node
 
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   const char *dID = node2->AddDisplayNodeForHierarchyNode(NULL);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   if (dID != NULL)
     {
     std::cerr << "Error testing null hierarchy node to add display node for, got a display node id of " << dID << std::endl;

--- a/Modules/Loadable/Cameras/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Cameras/Testing/Cxx/CMakeLists.txt
@@ -11,6 +11,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Colors/Logic/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Colors/Logic/Testing/Cxx/CMakeLists.txt
@@ -10,6 +10,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Colors/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Colors/Testing/Cxx/CMakeLists.txt
@@ -10,6 +10,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/CropVolume/Testing/CMakeLists.txt
+++ b/Modules/Loadable/CropVolume/Testing/CMakeLists.txt
@@ -10,6 +10,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 add_subdirectory(Python)

--- a/Modules/Loadable/Data/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Data/Testing/Cxx/CMakeLists.txt
@@ -13,6 +13,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/DoubleArrays/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/DoubleArrays/Testing/Cxx/CMakeLists.txt
@@ -13,6 +13,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/DoubleArrays/Testing/Cxx/vtkSlicerDoubleArraysLogicAddFileTest.cxx
+++ b/Modules/Loadable/DoubleArrays/Testing/Cxx/vtkSlicerDoubleArraysLogicAddFileTest.cxx
@@ -28,6 +28,7 @@
 // VTK includes
 #include <vtkNew.h>
 #include <vtkPolyData.h>
+#include <vtkTestingOutputWindow.h>
 
 //-----------------------------------------------------------------------------
 bool testAddEmptyFile(const char* filePath);
@@ -37,16 +38,13 @@ bool testAddFile(const char* filePath);
 int vtkSlicerDoubleArraysLogicAddFileTest( int argc, char * argv[] )
 {
   bool res = true;
-  std::cout << ">>>>>>>>>>>>>>>>>> "
-            << "The following can print errors and warnings"
-            << " <<<<<<<<<<<<<<<<<<" << std::endl;
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   res = testAddEmptyFile(0) && res;
   res = testAddEmptyFile("") && res;
   res = testAddEmptyFile("non existing file.badextension") && res;
   res = testAddEmptyFile("non existing file.vtk") && res;
-  std::cout << ">>>>>>>>>>>>>>>>>> "
-            << "end of normal errors and warnings"
-            << " <<<<<<<<<<<<<<<<<<" << std::endl;
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
   if (argc > 1)
     {
     res = testAddFile(argv[1]) && res;

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -1372,6 +1372,7 @@ int vtkSlicerMarkupsLogic::GetSliceIntersectionsVisibility()
 {
   if (!this->GetMRMLScene())
     {
+    vtkErrorMacro("GetSliceIntersectionsVisibility: no scene");
     return -1;
     }
   int numVisible = 0;

--- a/Modules/Loadable/Markups/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Testing/Cxx/CMakeLists.txt
@@ -27,6 +27,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   TARGET_LIBRARIES
     vtkSlicerAnnotationsModuleLogic
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 SIMPLE_TEST( vtkMRMLMarkupsDisplayNodeTest1 )

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest1.cxx
@@ -26,6 +26,7 @@
 
 // VTK includes
 #include <vtkNew.h>
+#include <vtkTestingOutputWindow.h>
 
 // STD includes
 #include <algorithm>
@@ -34,7 +35,7 @@ int vtkMRMLMarkupsFiducialStorageNodeTest1(int argc, char * argv[] )
 {
   vtkNew<vtkMRMLMarkupsFiducialStorageNode> node1;
 
-  EXERCISE_BASIC_STORAGE_MRML_METHODS( vtkMRMLMarkupsFiducialStorageNode, node1 );
+  EXERCISE_BASIC_STORAGE_MRML_METHODS( vtkMRMLMarkupsFiducialStorageNode, node1.GetPointer() );
 
   vtkNew<vtkMRMLMarkupsFiducialNode> markupsNode;
   vtkNew<vtkMRMLMarkupsDisplayNode> displayNode;
@@ -121,7 +122,10 @@ int vtkMRMLMarkupsFiducialStorageNodeTest1(int argc, char * argv[] )
 
   std::cout << "Reading from " << snode2->GetFileName() << std::endl;
 
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   retval = snode2->ReadData(markupsNode2.GetPointer());
+  TESTING_OUTPUT_ASSERT_WARNINGS(2); // 2 warnings are logged: display node is not available, display node is added
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
   if (!retval)
     {
     std::cerr << "Failed to read from file " << snode2->GetFileName()

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
@@ -26,7 +26,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-
+#include <vtkTestingOutputWindow.h>
 
 int vtkMRMLMarkupsFiducialStorageNodeTest2(int argc, char * argv[] )
 {
@@ -57,7 +57,10 @@ int vtkMRMLMarkupsFiducialStorageNodeTest2(int argc, char * argv[] )
   //
   std::cout << "Reading from " << node1->GetFileName() << std::endl;
 
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   int retval = node1->ReadData(markupsFiducialNode.GetPointer());
+  TESTING_OUTPUT_ASSERT_WARNINGS(1); // Expected warning: Have an unversioned file, assuming Slicer 3 format .fcsv
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
   if (!retval)
     {
     std::cerr << "Failed to read into Markups fiducial node from Slicer3 Fiducials file " << node1->GetFileName() << std::endl;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
@@ -24,7 +24,7 @@
 #include <vtkMath.h>
 #include <vtkMatrix4x4.h>
 #include <vtkNew.h>
-//#include <vtkPolyData.h>
+#include <vtkTestingOutputWindow.h>
 
 // STL includes
 #include <sstream>
@@ -93,6 +93,7 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
   std::cout << "Checking if markup exists in empty markups node" << std::endl;
   for (int m = -1; m < 3; m++)
     {
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
     if (node1->MarkupExists(m))
       {
       std::cerr << "Says that markup " << m << " exists, it shouldn't" << std::endl;
@@ -102,6 +103,7 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
       {
       std::cout << "\t" << m << " doesn't exist, good!" << std::endl;
       }
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
     }
 
   // Get Number of Markups
@@ -117,6 +119,7 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
     {
     for (int m = -1; m < 3; m++)
       {
+      TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
       if (node1->PointExistsInMarkup(p, m))
         {
         std::cerr << "Says that point " << p << " in markup " <<  m << " exists, it shouldn't" << std::endl;
@@ -126,11 +129,14 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
         {
         std::cout << "Points exists in markup: success on point " << p << " in markup " <<  m << std::endl;
         }
+      TESTING_OUTPUT_ASSERT_ERRORS_END();
       }
     }
 
   // Get Number Of Points in Markup
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   int numPoints = node1->GetNumberOfPointsInNthMarkup(0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   if (numPoints != 0)
     {
     std::cerr << "For empty markup 0, got " << numPoints << " instead of 0" << std::endl;
@@ -142,7 +148,9 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
   Markup *markup;
   for (int n = -1; n < 3; n++)
     {
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
     markup = node1->GetNthMarkup(n);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
     if (markup)
       {
       if (markup->points.size() != 0)
@@ -156,7 +164,9 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
     }
 
   // AddMarkupWithNPoints
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   node1->AddMarkupWithNPoints(-1);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   numMarkups = node1->GetNumberOfMarkups();
   if (numMarkups != 0)
     {
@@ -175,7 +185,9 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
   else { std::cout << "pass add markup with 0 points" << std::endl; }
 
   // RemoveMarkup
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   node1->RemoveMarkup(-1);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   std::cout << "Removed markup -1" << std::endl;
   node1->RemoveMarkup(0);
   std::cout << "Removed markup 0" << std::endl;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest2.cxx
@@ -20,6 +20,7 @@
 
 // VTK includes
 #include <vtkNew.h>
+#include <vtkTestingOutputWindow.h>
 
 // test copy and swap
 int vtkMRMLMarkupsNodeTest2(int , char * [] )
@@ -72,7 +73,9 @@ int vtkMRMLMarkupsNodeTest2(int , char * [] )
     }
 
   // test swap
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   node1->SwapMarkups(-1,100);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   std::cout << "Adding a markup with 1 point" << std::endl;
   node1->AddMarkupWithNPoints(1);
   double pos0[3];
@@ -81,11 +84,13 @@ int vtkMRMLMarkupsNodeTest2(int , char * [] )
   pos0[2] = -2.6;
   node1->SetMarkupPointFromArray(0, 0, pos0);
 
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   node1->SwapMarkups(-1,100);
   node1->SwapMarkups(-1,1);
   node1->SwapMarkups(1,-1);
   node1->SwapMarkups(1,100);
   node1->SwapMarkups(100,1);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
 
   std::cout << "Adding another markup with 1 point" << std::endl;
   node1->AddMarkupWithNPoints(1);

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
@@ -17,24 +17,31 @@
 
 // MRML includes
 #include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLInteractionNode.h"
 #include "vtkMRMLMarkupsNode.h"
 #include "vtkMRMLSelectionNode.h"
 #include "vtkMRMLScene.h"
+#include "vtkMRMLSelectionNode.h"
 #include "vtkMRMLSliceCompositeNode.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkSlicerMarkupsLogic.h"
 // VTK includes
 #include <vtkNew.h>
-
+#include <vtkTestingOutputWindow.h>
 
 int vtkSlicerMarkupsLogicTest1(int , char * [] )
 {
   vtkSmartPointer<vtkMRMLScene> scene = vtkSmartPointer<vtkMRMLScene>::New();
+/*vtkNew<vtkMRMLInteractionNode> interactionNode;
+  scene->AddNode(interactionNode.GetPointer());*/
+
   vtkNew<vtkSlicerMarkupsLogic> logic1;
 
   // test without a scene
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   std::string id = logic1->AddNewFiducialNode();
-  if (id.compare("") != 0)
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+  if (!id.empty())
     {
     std::cerr << "Failure to add a new markup node to empty scene, got id of '" << id.c_str() << "'" << std::endl;
     return EXIT_FAILURE;
@@ -44,7 +51,9 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
     std::cout << "Passed adding a node to no scene." << std::endl;
     }
 
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   int fidIndex = logic1->AddFiducial();
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   if (fidIndex != -1)
     {
     std::cerr << "Failure to add a new fiducial point to empty scene, got fidIndex of '" << fidIndex << "'" << std::endl;
@@ -55,7 +64,9 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
     std::cout << "Passed adding a fiducial point to no scene." << std::endl;
     }
 
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   int sliceIntersectionVisibility = logic1->GetSliceIntersectionsVisibility();
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   if (sliceIntersectionVisibility != -1)
     {
     std::cerr << "Failed to get no scene slice intersections visibility of -1, got "
@@ -65,11 +76,16 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
   logic1->SetSliceIntersectionsVisibility(true);
 
   // test with a scene
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   logic1->SetMRMLScene(scene);
+  TESTING_OUTPUT_ASSERT_ERRORS(1); // one error is expected to be reported due to lack of selection node
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
 
   const char *testName = "Test node 2";
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   id = logic1->AddNewFiducialNode(testName);
-  if (id.compare("") == 0)
+  TESTING_OUTPUT_ASSERT_ERRORS_END(); // error is expected to be reported due to lack of selection node
+  if (id.empty())
     {
     std::cerr << "Failure to add a new node to a valid scene, got id of '" << id.c_str() << "'" << std::endl;
     return EXIT_FAILURE;
@@ -184,7 +200,9 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
     }
 
   // test without a selection node
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   fidIndex = logic1->AddFiducial(5.0, 6.0, -7.0);
+  TESTING_OUTPUT_ASSERT_ERRORS_END(); // error is expected to be reported due to lack of selection node
   if (fidIndex != -1)
     {
     std::cerr << "Failed on adding a fiducial to the scene with no selection node, expected index of -1, but got: "
@@ -192,11 +210,13 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
       return EXIT_FAILURE;
     }
 
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   if (logic1->StartPlaceMode(0))
     {
     std::cerr << "Failed to fail starting place mode!" << std::endl;
     return EXIT_FAILURE;
     }
+  TESTING_OUTPUT_ASSERT_ERRORS_END(); // error is expected to be reported due to lack of selection node
 
   // add a selection node
   vtkNew<vtkMRMLApplicationLogic> applicationLogic;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest2.cxx
@@ -22,6 +22,7 @@
 
 // VTK includes
 #include <vtkNew.h>
+#include <vtkTestingOutputWindow.h>
 
 static void PrintLabels(vtkMRMLMarkupsNode *m)
 {
@@ -44,6 +45,7 @@ int vtkSlicerMarkupsLogicTest2(int , char * [] )
   vtkSmartPointer<vtkMRMLMarkupsNode> dest = vtkSmartPointer<vtkMRMLMarkupsNode>::New();
 
   // null cases
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   if (logic1->MoveNthMarkupToNewListAtIndex(0, NULL, NULL, 0))
     {
     std::cerr << "MoveNthMarkupToNewListAtIndex: Failed to return false when passed null lists" << std::endl;
@@ -59,13 +61,16 @@ int vtkSlicerMarkupsLogicTest2(int , char * [] )
     std::cerr << "MoveNthMarkupToNewListAtIndex: Failed to return false when passed null source list" << std::endl;
     return EXIT_FAILURE;
     }
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
 
   // empty lists
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   if (logic1->MoveNthMarkupToNewListAtIndex(0, source, dest, 0))
     {
     std::cerr << "MoveNthMarkupToNewListAtIndex: Failed to return false when passed emtpy source and dest list" << std::endl;
     return EXIT_FAILURE;
     }
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
 
   // dest list smaller than source list
   source->AddMarkupWithNPoints(1);
@@ -249,6 +254,7 @@ int vtkSlicerMarkupsLogicTest2(int , char * [] )
 
   // Test copying markup between lists
   // null cases
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   if (logic1->CopyNthMarkupToNewList(0, NULL, NULL))
     {
     std::cerr << "CopyNthMarkupToNewList: Failed to return false when passed null lists" << std::endl;
@@ -264,6 +270,8 @@ int vtkSlicerMarkupsLogicTest2(int , char * [] )
     std::cerr << "CopyNthMarkupToNewList: Failed to return false when passed null source list" << std::endl;
     return EXIT_FAILURE;
     }
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
   source->AddMarkupWithNPoints(1);
   int sourceSize = source->GetNumberOfMarkups();
   int destSize = dest->GetNumberOfMarkups();

--- a/Modules/Loadable/Markups/Widgets/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Widgets/Testing/Cxx/CMakeLists.txt
@@ -13,6 +13,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Models/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Models/Testing/Cxx/CMakeLists.txt
@@ -23,6 +23,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest.cxx
@@ -38,6 +38,7 @@
 
 // VTK includes
 #include <vtkNew.h>
+#include <vtkTestingOutputWindow.h>
 
 // --------------------------------------------------------------------------
 class qSlicerModelsModuleWidgetTester: public QObject
@@ -74,7 +75,9 @@ void qSlicerModelsModuleWidgetTester::testClearCurrentNode()
 
   // Instantiate Models module panel
   qSlicerModelsModule module;
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   module.initialize(0);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END(); // warning due to using 0 as application logic
   module.setMRMLScene(scene.GetPointer());
 
   QWidget* moduleWidget = dynamic_cast<QWidget*>(module.widgetRepresentation());

--- a/Modules/Loadable/Models/Widgets/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Models/Widgets/Testing/Cxx/CMakeLists.txt
@@ -14,6 +14,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/SceneViews/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/SceneViews/Testing/Cxx/CMakeLists.txt
@@ -10,6 +10,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/SceneViews/Testing/Cxx/vtkSlicerSceneViewsModuleLogicTest1.cxx
+++ b/Modules/Loadable/SceneViews/Testing/Cxx/vtkSlicerSceneViewsModuleLogicTest1.cxx
@@ -8,24 +8,31 @@
 
 // VTK includes
 #include <vtkImageData.h>
+#include <vtkSmartPointer.h>
+#include <vtkTestingOutputWindow.h>
 
 
 int vtkSlicerSceneViewsModuleLogicTest1(int , char * [] )
 {
 
   vtkSmartPointer<vtkMRMLScene> scene = vtkSmartPointer<vtkMRMLScene>::New();
+
   vtkSmartPointer< vtkSlicerSceneViewsModuleLogic > node1 = vtkSmartPointer< vtkSlicerSceneViewsModuleLogic >::New();
   EXERCISE_BASIC_OBJECT_METHODS( node1 );
 
   // should fail, no scene
   std::cout << "CreateSceneView with no mrml scene or screen shot" << std::endl;
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   node1->CreateSceneView("SceneViewTest0", "this is a scene view", 0, NULL);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
 
   node1->SetMRMLScene(scene);
   EXERCISE_BASIC_OBJECT_METHODS( node1 );
 
   std::cout << "CreateSceneView with no screenshot" << std::endl;
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   node1->CreateSceneView("SceneViewTest1", "this is a scene view", 0, NULL);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
 
   // should pass w/screen shot
   vtkSmartPointer< vtkImageData > screenShot = vtkSmartPointer< vtkImageData >::New();
@@ -44,23 +51,21 @@ int vtkSlicerSceneViewsModuleLogicTest1(int , char * [] )
   scene->Commit();
 
   // now reload it
-  vtkSmartPointer<vtkMRMLScene> sceneRead = vtkSmartPointer<vtkMRMLScene>::New();
-  sceneRead->SetURL(url.c_str());
-  if (1)
-    {
-    std::cout << "Reading MRML scene " << sceneRead->GetURL() << std::endl;
-    sceneRead->Connect();
-    std::cout << "After reading in MRML Scene " << url.c_str() << std::endl;
-    std::cout << "\tscene has " << scene->GetNumberOfNodesByClass("vtkMRMLSceneViewNode") << " scene view nodes" << std::endl;
-    }
+  scene->SetURL(url.c_str());
+  std::cout << "Reading MRML scene " << scene->GetURL() << std::endl;
+  scene->Connect();
+  std::cout << "After reading in MRML Scene " << url.c_str() << std::endl;
+  std::cout << "\tscene has " << scene->GetNumberOfNodesByClass("vtkMRMLSceneViewNode") << " scene view nodes" << std::endl;
 
-  node1->SetMRMLScene(sceneRead);
+  node1->SetMRMLScene(scene);
   // test trying to remove a null node
   std::cout << "Trying to remove a null node." << std::endl;
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   node1->RemoveSceneViewNode(NULL);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   // add a node to remove
   node1->CreateSceneView("SceneViewTestToRemove", "this is a scene view to remove", 0, screenShot);
-  vtkCollection *col = sceneRead->GetNodesByClassByName("vtkMRMLSceneViewNode", "SceneViewTestToRemove");
+  vtkCollection *col = scene->GetNodesByClassByName("vtkMRMLSceneViewNode", "SceneViewTestToRemove");
   if (col && col->GetNumberOfItems() > 0)
     {
     vtkMRMLSceneViewNode *nodeToRemove = vtkMRMLSceneViewNode::SafeDownCast(col->GetItemAsObject(0));

--- a/Modules/Loadable/SubjectHierarchy/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Cxx/CMakeLists.txt
@@ -14,6 +14,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   SOURCES ${KIT_TEST_SRCS}
   TARGET_LIBRARIES vtkSlicer${MODULE_NAME}ModuleLogic qSlicer${MODULE_NAME}Module
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/TractographyDisplay/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/TractographyDisplay/Testing/Cxx/CMakeLists.txt
@@ -10,6 +10,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/TractographyInteractiveSeeding/Testing/CMakeLists.txt
+++ b/Modules/Loadable/TractographyInteractiveSeeding/Testing/CMakeLists.txt
@@ -15,6 +15,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   SOURCES ${KIT_TEST_SRCS}
   TARGET_LIBRARIES vtkSlicerVolumesModuleLogic
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Transforms/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Transforms/Testing/Cxx/CMakeLists.txt
@@ -16,6 +16,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Units/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Units/Testing/Cxx/CMakeLists.txt
@@ -30,6 +30,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/CMakeLists.txt
@@ -11,6 +11,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/vtkSlicerVolumeRenderingLogicAddFromFileTest.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/Testing/Cxx/vtkSlicerVolumeRenderingLogicAddFromFileTest.cxx
@@ -30,6 +30,7 @@
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 #include <vtksys/SystemTools.hxx>
+#include <vtkTestingOutputWindow.h>
 
 //----------------------------------------------------------------------------
 bool testAddVolumePropertyFromFile(const std::string &temporaryDirectory);
@@ -99,7 +100,9 @@ bool testAddVolumePropertyFromFile(const std::string& temporaryDirectory)
   logic->SetMRMLScene(scene.GetPointer());
 
   // null file name
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   vpNode = logic->AddVolumePropertyFromFile(NULL);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   if (vpNode != NULL)
     {
     std::cerr << "Line " << __LINE__
@@ -110,7 +113,9 @@ bool testAddVolumePropertyFromFile(const std::string& temporaryDirectory)
     }
 
   // empty file name
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   vpNode = logic->AddVolumePropertyFromFile("");
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
   if (vpNode != NULL)
     {
     std::cerr << "Line " << __LINE__

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt
@@ -43,6 +43,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   SOURCES ${KIT_TEST_SRCS}
   TARGET_LIBRARIES vtkSlicerVolumesModuleLogic
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/Testing/Cxx/CMakeLists.txt
@@ -33,6 +33,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   SOURCES ${KIT_TEST_SRCS}
   TARGET_LIBRARIES vtkSlicerVolumesModuleLogic
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/Widgets/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/Widgets/Testing/Cxx/CMakeLists.txt
@@ -19,6 +19,7 @@ slicerMacroConfigureModuleCxxTestDriver(
     ${vtkSlicerVolumesModuleLogic_SOURCE_DIR}
     ${vtkSlicerVolumesModuleLogic_BINARY_DIR}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------

--- a/Utilities/Templates/Modules/Loadable/Testing/Cxx/CMakeLists.txt
+++ b/Utilities/Templates/Modules/Loadable/Testing/Cxx/CMakeLists.txt
@@ -10,6 +10,7 @@ slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
   WITH_VTK_DEBUG_LEAKS_CHECK
+  WITH_VTK_ERROR_OUTPUT_CHECK
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Added a new option (WITH_VTK_ERROR_OUTPUT_CHECK) to slicerMacroConfigureModuleCxxTestDriver
that enables checking of error and warning messages. If the option is enabled then the test
fails if unexpected error or warning is logged.

Enabled the option for all tests that had debug leaks check option (WITH_VTK_DEBUG_LEAKS_CHECK)
already enabled. Fixed failing tests by fixing the test, the tested code, or (most frequently) marking
expected errors/warning (using TESTING_OUTPUT_ASSERT_ERRORS_BEGIN() / TESTING_OUTPUT_ASSERT_ERRORS_END()
and similar macros).