### PR TITLE
ENH: Added labelmap conversion to Volumes module

### DIFF
--- a/Libs/MRML/Widgets/Resources/UI/qMRMLVolumeInfoWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLVolumeInfoWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>660</width>
-    <height>424</height>
+    <height>426</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,6 +20,9 @@
    <string>Volume Information</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item row="0" column="0">
     <widget class="QLabel" name="ImageDimensionsLabel">
      <property name="text">
@@ -45,7 +48,7 @@
       <string>1,1,1</string>
      </property>
      <property name="unitAwareProperties">
-      <set>qMRMLCoordinatesWidget::MaximumValue|qMRMLCoordinatesWidget::MinimumValue|qMRMLCoordinatesWidget::Precision|qMRMLCoordinatesWidget::Prefix|qMRMLCoordinatesWidget::Scaling|qMRMLCoordinatesWidget::Suffix</set>
+      <set>qMRMLCoordinatesWidget::All</set>
      </property>
     </widget>
    </item>
@@ -290,31 +293,21 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="LabelMapLabel">
-     <property name="text">
-      <string>LabelMap:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
-    <widget class="QCheckBox" name="LabelMapCheckBox">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
    <item row="11" column="0">
+    <widget class="QLabel" name="VolumeTypeLabel">
+     <property name="text">
+      <string>Volume type:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
     <widget class="QLabel" name="WindowLevelPresetsLabel">
      <property name="text">
       <string>Window/Level Presets:</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="1">
+   <item row="12" column="1">
     <widget class="QListWidget" name="WindowLevelPresetsListWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -327,6 +320,13 @@
        <width>16777215</width>
        <height>80</height>
       </size>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1">
+    <widget class="QLabel" name="VolumeTagLabel">
+     <property name="text">
+      <string>VolumeTag</string>
      </property>
     </widget>
    </item>

--- a/Libs/MRML/Widgets/qMRMLVolumeInfoWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLVolumeInfoWidget.cxx
@@ -29,8 +29,6 @@
 #include "ui_qMRMLVolumeInfoWidget.h"
 
 // MRML includes
-#include <vtkMRMLLabelMapVolumeDisplayNode.h>
-#include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLScalarVolumeDisplayNode.h>
@@ -93,6 +91,7 @@ void qMRMLVolumeInfoWidgetPrivate::init()
                    q, SLOT(setImageOrigin(double*)));
   QObject::connect(this->CenterVolumePushButton, SIGNAL(clicked()),
                    q, SLOT(center()));
+
   // setScanOrder is dangerous, it can loose orientation information because
   // ComputeScanOrderFromIJKToRAS is not the exact opposite of
   // ComputeIJKToRASFromScanOrder
@@ -106,6 +105,7 @@ void qMRMLVolumeInfoWidgetPrivate::init()
                    q, SLOT(setNumberOfScalars(int)));
   QObject::connect(this->ScalarTypeComboBox, SIGNAL(currentIndexChanged(int)),
                    q, SLOT(setScalarType(int)));
+
   // Window level presets are read-only
   q->setDataTypeEditable(false);
   q->setEnabled(this->VolumeNode != 0);
@@ -229,7 +229,7 @@ void qMRMLVolumeInfoWidget::updateWidgetFromMRML()
 
     d->FileNameLineEdit->setText("");
 
-    d->LabelMapCheckBox->setChecked(false);
+    d->VolumeTagLabel->setText("");
 
     d->WindowLevelPresetsListWidget->clear();
 
@@ -299,8 +299,22 @@ void qMRMLVolumeInfoWidget::updateWidgetFromMRML()
 
   vtkMRMLScalarVolumeNode *scalarNode = vtkMRMLScalarVolumeNode::SafeDownCast( d->VolumeNode );
 
-  vtkMRMLLabelMapVolumeNode *labelMapNode = vtkMRMLLabelMapVolumeNode::SafeDownCast( d->VolumeNode );
-  d->LabelMapCheckBox->setChecked(labelMapNode!=0);
+  // Remove "Volume" postfix from node tag name to get only the volume type
+  QString volumeType(d->VolumeNode->GetNodeTagName());
+  if (!volumeType.right(6).compare("Volume"))
+    {
+    volumeType = volumeType.left(volumeType.size()-6);
+    // Workaround for not having the "Scalar" tag in scalar volumes
+    if (volumeType.isEmpty())
+      {
+      volumeType = QString("Scalar");
+      }
+    }
+  else
+    {
+    qWarning() << __FUNCTION__ << "Invalid volume node tag '" << volumeType << "'!";
+    }
+  d->VolumeTagLabel->setText(volumeType);
 
   vtkMRMLScalarVolumeDisplayNode *displayNode =
     scalarNode ? scalarNode->GetScalarVolumeDisplayNode() : 0;

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
@@ -162,12 +162,14 @@ public:
                                              vtkMRMLVolumeNode *volumeNode,
                                              const char *name);
 
+  /// \deprecated
   /// Fill in a label map volume to match the given template volume node.
   /// \sa FillLabelVolumeFromTemplate(vtkMRMLScene*, vtkMRMLScalarVolumeNode*, vtkMRMLVolumeNode*)
   /// \sa GetMRMLScene()
   vtkMRMLLabelMapVolumeNode *FillLabelVolumeFromTemplate(vtkMRMLLabelMapVolumeNode *labelNode,
                                                        vtkMRMLVolumeNode *templateNode);
 
+  /// \deprecated
   /// Fill in a label map volume to match the given template volume node, under
   /// the assumption that the given label map node is already added to the scene.
   /// A display node will be added to it if the label node doesn't already have
@@ -176,6 +178,18 @@ public:
   vtkMRMLLabelMapVolumeNode *FillLabelVolumeFromTemplate(vtkMRMLScene *scene,
                                                        vtkMRMLLabelMapVolumeNode *labelNode,
                                                        vtkMRMLVolumeNode *templateNode);
+
+  /// Fill in a label map volume to match the given input volume node, under
+  /// the assumption that the given label map node is already added to the scene.
+  /// A display node will be added to it if the label node doesn't already have
+  /// one, and the image data associated with the label node will be allocated
+  /// according to the template volumeNode.
+  vtkMRMLLabelMapVolumeNode *CreateLabelVolumeFromVolume(vtkMRMLScene *scene,
+                                                       vtkMRMLLabelMapVolumeNode *labelNode,
+                                                       vtkMRMLVolumeNode *inputVolume);
+
+  /// Clear the image data of a volume node to contain all zeros
+  static void ClearVolumeImageData(vtkMRMLVolumeNode *volumeNode);
 
   /// Return a string listing any warnings about the spatial validity of
   /// the labelmap with respect to the volume.  An empty string indicates
@@ -283,7 +297,9 @@ protected:
       const char* filename, const char* volname, int loadingOptions,
       vtkStringArray *fileList);
 
+protected:
   vtkSmartPointer<vtkMRMLVolumeNode> ActiveVolumeNode;
+
   vtkSmartPointer<vtkMRMLColorLogic> ColorLogic;
 
   NodeSetFactoryRegistry VolumeRegistry;
@@ -291,6 +307,7 @@ protected:
   /// Allowable difference in comparing volume geometry double values.
   /// Defaults to 1 to the power of 10 to the minus 6
   double CompareVolumeGeometryEpsilon;
+
   /// Error print out precision, paried with CompareVolumeGeometryEpsilon.
   /// defaults to 6
   int CompareVolumeGeometryPrecision;

--- a/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesModuleWidget.ui
+++ b/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesModuleWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>237</width>
-    <height>158</height>
+    <width>431</width>
+    <height>573</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -21,6 +21,19 @@
    <property name="margin">
     <number>0</number>
    </property>
+   <item row="4" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>208</width>
+       <height>15</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="ActiveVolumeLabel">
      <property name="text">
@@ -46,7 +59,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <widget class="ctkCollapsibleButton" name="DisplayCollapsibleButton">
      <property name="text">
       <string>Display</string>
@@ -60,19 +73,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>208</width>
-       <height>15</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="1" column="0" colspan="2">
     <widget class="ctkCollapsibleButton" name="InfoCollapsibleButton">
@@ -88,6 +88,63 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="qMRMLVolumeInfoWidget" name="MRMLVolumeInfoWidget"/>
+      </item>
+      <item>
+       <widget class="QFrame" name="ConvertToLabelMapFrame">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="margin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Convert to LabelMap:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>32</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="qMRMLNodeComboBox" name="TargetLabelMapSelector">
+           <property name="nodeTypes">
+            <stringlist>
+             <string>vtkMRMLLabelMapVolumeNode</string>
+            </stringlist>
+           </property>
+           <property name="renameEnabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="ConvertToLabelMapButton">
+           <property name="text">
+            <string>Convert</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -162,6 +219,22 @@
     <hint type="destinationlabel">
      <x>230</x>
      <y>19</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerVolumesModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>TargetLabelMapSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>97</x>
+     <y>568</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>179</x>
+     <y>499</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.cxx
@@ -23,8 +23,15 @@
 // CTK includes
 //#include <ctkModelTester.h>
 
+// MRML includes
+#include <vtkMRMLScalarVolumeNode.h>
+#include <vtkMRMLLabelMapVolumeNode.h>
+
+// Volumes includes
 #include "qSlicerVolumesModuleWidget.h"
 #include "ui_qSlicerVolumesModuleWidget.h"
+
+#include "vtkSlicerVolumesLogic.h"
 
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_Volumes
@@ -57,6 +64,67 @@ void qSlicerVolumesModuleWidget::setup()
   QObject::connect(d->ActiveVolumeNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
                    d->VolumeDisplayWidget, SLOT(setMRMLVolumeNode(vtkMRMLNode*)));
 
+  QObject::connect(d->ActiveVolumeNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+                   this, SLOT(nodeSelectionChanged(vtkMRMLNode*)));
+
+  // Set up labelmap conversion
+  d->ConvertToLabelMapFrame->setVisible(false);
+  QObject::connect(d->ConvertToLabelMapButton, SIGNAL(clicked()),
+                   this, SLOT(convertToLabelmap()));
+  QObject::connect(d->TargetLabelMapSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+                   this, SLOT(nodeSelectionChanged(vtkMRMLNode*)));
+
   //ctkModelTester* tester = new ctkModelTester(this);
   //tester->setModel(d->ActiveVolumeNodeSelector->model());
+}
+
+//------------------------------------------------------------------------------
+void qSlicerVolumesModuleWidget::nodeSelectionChanged(vtkMRMLNode* node)
+{
+  Q_UNUSED(node);
+  this->updateWidgetFromMRML();
+}
+
+//------------------------------------------------------------------------------
+void qSlicerVolumesModuleWidget::updateWidgetFromMRML()
+{
+  Q_D(qSlicerVolumesModuleWidget);
+
+  vtkMRMLVolumeNode* currentVolumeNode = vtkMRMLVolumeNode::SafeDownCast(
+    d->ActiveVolumeNodeSelector->currentNode() );
+  if (!currentVolumeNode)
+    {
+    d->ConvertToLabelMapFrame->setVisible(false);
+    return;
+    }
+
+  // Show convert to labelmap frame only if the exact type is scalar volume
+  // (not labelmap, vector, tensor, DTI, etc.)
+  bool labelMapCoversionPossible =
+    !strcmp(currentVolumeNode->GetClassName(), "vtkMRMLScalarVolumeNode");
+  d->ConvertToLabelMapFrame->setVisible(labelMapCoversionPossible);
+
+  // Set base name of target labelmap node
+  d->TargetLabelMapSelector->setBaseName(QString("%1_Label").arg(currentVolumeNode->GetName()));
+
+  d->ConvertToLabelMapButton->setEnabled(
+    d->TargetLabelMapSelector->currentNode() != NULL );
+}
+
+//------------------------------------------------------------------------------
+void qSlicerVolumesModuleWidget::convertToLabelmap()
+{
+  Q_D(qSlicerVolumesModuleWidget);
+
+  vtkMRMLScalarVolumeNode* currentScalarVolumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(
+    d->ActiveVolumeNodeSelector->currentNode() );
+  vtkMRMLLabelMapVolumeNode* targetLabelMapNode = vtkMRMLLabelMapVolumeNode::SafeDownCast(
+    d->TargetLabelMapSelector->currentNode() );
+  if (!currentScalarVolumeNode || !targetLabelMapNode)
+    {
+    return;
+    }
+
+  vtkSlicerVolumesLogic* logic = vtkSlicerVolumesLogic::SafeDownCast(this->logic());
+  logic->CreateLabelVolumeFromVolume(this->mrmlScene(), targetLabelMapNode, currentScalarVolumeNode);
 }

--- a/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.h
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.h
@@ -44,6 +44,11 @@ public:
 protected:
   virtual void setup();
 
+protected slots:
+  void nodeSelectionChanged(vtkMRMLNode*);
+  void updateWidgetFromMRML();
+  void convertToLabelmap();
+
 protected:
   QScopedPointer<qSlicerVolumesModuleWidgetPrivate> d_ptr;
 


### PR DESCRIPTION
1. Changed LabelMap checkbox to Volume type label showing the node tag without the Volume postfix (as scalar volume has the tag "Volume", "Scalar" is shown instead of empty string)
2. Add extra section into Volumes module, because
a. Label volume conversion cannot be added in the volume info widget due to scope issues (volumes logic not accessible from MRML widgets)
b. Conversion operation doesn't fit into the idea of "volume info"
3. Reogranized labelmap creation functions in volumes logic. Moved and corrected the body of FillLabelVolumeFromTemplate to CreateLabelVolumeFromVolume. Call the new function from CreateAndAddLabelVolume and FillLabelVolumeFromTemplate. Correction in CreateLabelVolumeFromVolume includes deep copy of the image data instead of keeping a floating threshold filter and setting connection (besides it seems to be unstable, it also did not work, dimensions of the volume were zeroes)
4. Removed margin from volumes info widget to make volumes module look more uniform