### PR TITLE
ENH: Fix scene save with default parameters

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -23,6 +23,7 @@
 
 // Qt includes
 #include <QDebug>
+#include <QDesktopServices>
 #include <QDir>
 #include <QLocale>
 #include <QMessageBox>
@@ -1048,8 +1049,8 @@ void qSlicerCoreApplication::setMRMLScene(vtkMRMLScene* newMRMLScene)
     return;
     }
 
-  QString workingDirectory = QDir::currentPath();
-  newMRMLScene->SetRootDirectory(workingDirectory.toLatin1());
+  // Set the default scene save directory
+  newMRMLScene->SetRootDirectory(this->defaultScenePath().toLatin1());
 
 #ifdef Slicer_BUILD_CLI_SUPPORT
   // Register the node type for the command line modules
@@ -1085,6 +1086,28 @@ QString qSlicerCoreApplication::slicerHome() const
 {
   Q_D(const qSlicerCoreApplication);
   return d->SlicerHome;
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCoreApplication::defaultScenePath() const
+{
+  Q_D(const qSlicerCoreApplication);
+  QSettings* appSettings = this->userSettings();
+  Q_ASSERT(appSettings);
+  QString defaultScenePath = appSettings->value("DefaultScenePath", QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation)).toString();
+  return defaultScenePath;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerCoreApplication::setDefaultScenePath(const QString& path)
+{
+  if (this->defaultScenePath() == path)
+    {
+    return;
+    }
+  QSettings* appSettings = this->userSettings();
+  Q_ASSERT(appSettings);
+  appSettings->setValue("DefaultScenePath", path);
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -64,6 +64,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerCoreApplication : public QApplication
   /// "C:\Program Files (x86)\Slicer 4.4.0\".
   /// \sa slicerHome(), temporaryPath, isInstalled
   Q_PROPERTY(QString slicerHome READ slicerHome CONSTANT)
+  Q_PROPERTY(QString defaultScenePath READ defaultScenePath WRITE setDefaultScenePath)
   Q_PROPERTY(QString slicerSharePath READ slicerSharePath CONSTANT)
   Q_PROPERTY(QString temporaryPath READ temporaryPath WRITE setTemporaryPath)
   Q_PROPERTY(QString launcherExecutableFilePath READ launcherExecutableFilePath CONSTANT)
@@ -147,6 +148,15 @@ public:
   /// Get slicer home directory
   /// \sa slicerHome
   QString slicerHome() const;
+
+  /// Get default scene directory
+  ///
+  /// This returns the full path where scenes are saved to by default
+  ///
+  QString defaultScenePath() const;
+
+  /// Set default slicer scene directory
+  void setDefaultScenePath(const QString& path);
 
   /// Get slicer share directory
   ///

--- a/Base/QTGUI/Resources/UI/qSlicerSettingsGeneralPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsGeneralPanel.ui
@@ -15,27 +15,50 @@
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
+    <widget class="QLabel" name="DefaultScenePathLabel">
+     <property name="toolTip">
+      <string>Directory where scenes are saved to by default</string>
+     </property>
+     <property name="text">
+      <string>Default scene location:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="ctkDirectoryButton" name="DefaultScenePathButton"/>
+   </item>
+   <item row="1" column="0">
     <widget class="QLabel" name="ShowSplashScreenLabel">
      <property name="text">
       <string>Disable splash screen:</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="1" column="1">
     <widget class="QCheckBox" name="ShowSplashScreenCheckBox">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
+   <item row="2" column="1">
+    <widget class="ctkLanguageComboBox" name="LanguageComboBox"/>
+   </item>
    <item row="2" column="0">
+    <widget class="QLabel" name="LanguageLabel">
+     <property name="text">
+      <string>Language</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QLabel" name="ConfirmRestartLabel">
      <property name="text">
       <string>Confirm on restart:</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QCheckBox" name="ConfirmRestartCheckBox">
      <property name="text">
       <string/>
@@ -45,14 +68,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="ConfirmExitLabel">
      <property name="text">
       <string>Confirm on exit:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="1">
     <widget class="QCheckBox" name="ConfirmExitCheckBox">
      <property name="text">
       <string/>
@@ -62,27 +85,17 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="SlicerWikiURLLabel">
      <property name="text">
       <string>Slicer Wiki URL:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QLineEdit" name="SlicerWikiURLLineEdit"/>
    </item>
-   <item row="1" column="1">
-    <widget class="ctkLanguageComboBox" name="LanguageComboBox"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="LanguageLabel">
-     <property name="text">
-      <string>Language</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QSpinBox" name="NumOfRecentlyLoadedFiles">
      <property name="minimum">
       <number>1</number>
@@ -95,7 +108,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="NumOfRecentlyLoadedFilesLabel">
      <property name="text">
       <string>Max. number of 'Recently Loaded' menu items:</string>
@@ -115,6 +128,11 @@
    <class>ctkLanguageComboBox</class>
    <extends>QComboBox</extends>
    <header>ctkLanguageComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkDirectoryButton</class>
+   <extends>QWidget</extends>
+   <header>ctkDirectoryButton.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
@@ -87,6 +87,15 @@ void qSlicerSettingsGeneralPanelPrivate::init()
 #endif
 
   // Default values
+
+  this->DefaultScenePathButton->setDirectory(qSlicerCoreApplication::application()->defaultScenePath());
+  q->registerProperty("DefaultScenePath", this->DefaultScenePathButton,"directory",
+                      SIGNAL(directoryChanged(QString)),
+                      "Default scene path",
+                     ctkSettingsPanel::OptionRequireRestart);
+  QObject::connect(this->DefaultScenePathButton, SIGNAL(directoryChanged(QString)),
+                   q, SLOT(setDefaultScenePath(QString)));
+
   this->SlicerWikiURLLineEdit->setText("http://www.slicer.org/slicerWiki/index.php");
 
   q->registerProperty("no-splash", this->ShowSplashScreenCheckBox, "checked",
@@ -128,4 +137,10 @@ qSlicerSettingsGeneralPanel::qSlicerSettingsGeneralPanel(QWidget* _parent)
 // --------------------------------------------------------------------------
 qSlicerSettingsGeneralPanel::~qSlicerSettingsGeneralPanel()
 {
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsGeneralPanel::setDefaultScenePath(const QString& path)
+{
+  qSlicerCoreApplication::application()->setDefaultScenePath(path);
 }

--- a/Base/QTGUI/qSlicerSettingsGeneralPanel.h
+++ b/Base/QTGUI/qSlicerSettingsGeneralPanel.h
@@ -47,6 +47,9 @@ public:
   /// Destructor
   virtual ~qSlicerSettingsGeneralPanel();
 
+public slots:
+  void setDefaultScenePath(const QString& path);
+
 protected:
   QScopedPointer<qSlicerSettingsGeneralPanelPrivate> d_ptr;
 


### PR DESCRIPTION
Novice Slicer users often complain that scene saving fails. The problem is that Slicer offers scene saving in a read-only directory by default (into the current working directory, which is the read-only program binary directory by default).

Fixes applied:
1. Changed the default scene root directory to be the user's documents folder (determined the same way as the default DICOM database directory).
2. Made default scene directory configurable in the application settings GUI (selection is stored in application settings under "DefaultScenePath" key).