### PR TITLE
BUG: Fix hide from editor flag on volume rendering nodes

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLCPURayCastVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLCPURayCastVolumeRenderingDisplayNode.cxx
@@ -34,6 +34,8 @@ vtkMRMLNodeNewMacro(vtkMRMLCPURayCastVolumeRenderingDisplayNode);
 vtkMRMLCPURayCastVolumeRenderingDisplayNode::vtkMRMLCPURayCastVolumeRenderingDisplayNode()
 {
   this->RaycastTechnique = vtkMRMLCPURayCastVolumeRenderingDisplayNode::Composite;
+
+  this->SetHideFromEditors(1);
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
@@ -34,6 +34,8 @@ vtkMRMLNodeNewMacro(vtkMRMLGPURayCastVolumeRenderingDisplayNode);
 vtkMRMLGPURayCastVolumeRenderingDisplayNode::vtkMRMLGPURayCastVolumeRenderingDisplayNode()
 {
   this->RaycastTechnique = vtkMRMLGPURayCastVolumeRenderingDisplayNode::Composite;
+
+  this->SetHideFromEditors(1);
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingScenarioNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingScenarioNode.cxx
@@ -28,6 +28,8 @@ vtkMRMLNodeNewMacro(vtkMRMLVolumeRenderingScenarioNode);
 vtkMRMLVolumeRenderingScenarioNode::vtkMRMLVolumeRenderingScenarioNode()
 {
   this->ParametersNodeID = NULL;
+
+  this->SetHideFromEditors(1);
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -114,6 +114,9 @@
         <property name="addEnabled">
          <bool>false</bool>
         </property>
+        <property name="showHidden">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item row="1" column="0">


### PR DESCRIPTION
The volume rendering nodes are appearing in the Data tree
after the change to set the default of the hide from editors
flag to false on the MRML node superclass.
This change sets them hidden by default and sets up the
display node combo box to show them in the Volume
Rendering Inputs panel.

Issue #2906