### PR TITLE
BUG: Fixed crash in vtkMRMLTransformNode::GetMatrixTransformToNode

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLTransformNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformNodeTest1.cxx
@@ -10,16 +10,187 @@
 
 =========================================================================auto=*/
 
+#include "vtkMRMLBSplineTransformNode.h"
 #include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
 #include "vtkMRMLTransformNode.h"
 
 #include <vtkGeneralTransform.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkTransform.h>
+
+bool Matrix4x4AreEqual(vtkMatrix4x4 *m1, vtkMatrix4x4 *m2)
+{
+  const double tol = 1e-3;
+  for (int i = 0; i < 4; i++)
+    {
+    for (int j = 0; j < 4; j++)
+      {
+      if ( fabs(m1->GetElement(i, j) - m2->GetElement(i, j)) > tol )
+        {
+        return false;
+        }
+      }
+    }
+    return true;
+}
+
+vtkMatrix4x4* CreateTransformMatrix(double translateX, double translateY, double translateZ, double rotateX, double rotateY, double rotateZ)
+{
+  vtkNew<vtkTransform> tr;
+  tr->Translate(translateX, translateY, translateZ);
+  tr->RotateX(rotateX);
+  tr->RotateY(rotateY);
+  tr->RotateZ(rotateZ);
+  vtkMatrix4x4* matrix = vtkMatrix4x4::New();
+  tr->GetMatrix(matrix);
+  return matrix;
+}
 
 int vtkMRMLTransformNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLTransformNode> node1;
   EXERCISE_BASIC_OBJECT_METHODS(node1.GetPointer());
   EXERCISE_BASIC_TRANSFORM_MRML_METHODS(vtkMRMLTransformNode, node1.GetPointer());
+
+  /// Test matrix get/set functions
+
+  // Create transform nodes
+  vtkNew<vtkMRMLTransformNode> bTransform; // == b_to_w
+  vtkNew<vtkMRMLTransformNode> cTransform; // == c_to_b
+  vtkNew<vtkMRMLTransformNode> dTransform; // == d_to_c
+  vtkNew<vtkMRMLTransformNode> eTransform; // == e_to_d
+  vtkNew<vtkMRMLTransformNode> qTransform; // == q_to_b
+  vtkNew<vtkMRMLTransformNode> rTransform; // == r_to_q
+  vtkSmartPointer<vtkMatrix4x4> w_from_b_mx = vtkSmartPointer<vtkMatrix4x4>::Take(CreateTransformMatrix( 34,  23, -12,  44,  12,  78));
+  vtkSmartPointer<vtkMatrix4x4> b_from_c_mx = vtkSmartPointer<vtkMatrix4x4>::Take(CreateTransformMatrix(-34,  11,  12, -22, 128,  18));
+  vtkSmartPointer<vtkMatrix4x4> c_from_d_mx = vtkSmartPointer<vtkMatrix4x4>::Take(CreateTransformMatrix( 14, -23,  44,  11, -71,  38));
+  vtkSmartPointer<vtkMatrix4x4> d_from_e_mx = vtkSmartPointer<vtkMatrix4x4>::Take(CreateTransformMatrix( 73,  81,  35,  22,  11, -98));
+  vtkSmartPointer<vtkMatrix4x4> b_from_q_mx = vtkSmartPointer<vtkMatrix4x4>::Take(CreateTransformMatrix( 13, -71, 335, -42,  91, -28));
+  vtkSmartPointer<vtkMatrix4x4> q_from_r_mx = vtkSmartPointer<vtkMatrix4x4>::Take(CreateTransformMatrix( 53, -11,  65, -12,  21,   8));
+  bTransform->SetMatrixTransformToParent(w_from_b_mx.GetPointer());
+  cTransform->SetMatrixTransformToParent(b_from_c_mx.GetPointer());
+  dTransform->SetMatrixTransformToParent(c_from_d_mx.GetPointer());
+  eTransform->SetMatrixTransformToParent(d_from_e_mx.GetPointer());
+  qTransform->SetMatrixTransformToParent(b_from_q_mx.GetPointer());
+  rTransform->SetMatrixTransformToParent(q_from_r_mx.GetPointer());
+
+  // Create transfor hierarchy in the scene
+  //
+  // WORLD -> w coordinate system
+  //  |-- bTransform
+  //         |-- cTransform
+  //         |      |-- dTransform
+  //         |             |-- eTransform
+  //         |-- qTransform
+  //                |-- rTransform
+  //
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(bTransform.GetPointer());
+  scene->AddNode(cTransform.GetPointer());
+  scene->AddNode(dTransform.GetPointer());
+  scene->AddNode(eTransform.GetPointer());
+  scene->AddNode(qTransform.GetPointer());
+  scene->AddNode(rTransform.GetPointer());
+  cTransform->SetAndObserveTransformNodeID(bTransform->GetID());
+  dTransform->SetAndObserveTransformNodeID(cTransform->GetID());
+  eTransform->SetAndObserveTransformNodeID(dTransform->GetID());
+  qTransform->SetAndObserveTransformNodeID(bTransform->GetID());
+  rTransform->SetAndObserveTransformNodeID(qTransform->GetID());
+
+  // Pre-compute transform matrices that will be used for testing
+  vtkNew<vtkMatrix4x4> c_from_e_mx;
+  vtkMatrix4x4::Multiply4x4(c_from_d_mx.GetPointer(), d_from_e_mx.GetPointer(), c_from_e_mx.GetPointer());
+  vtkNew<vtkMatrix4x4> b_from_e_mx;
+  vtkMatrix4x4::Multiply4x4(b_from_c_mx.GetPointer(), c_from_e_mx.GetPointer(), b_from_e_mx.GetPointer());
+  vtkNew<vtkMatrix4x4> w_from_e_mx;
+  vtkMatrix4x4::Multiply4x4(w_from_b_mx.GetPointer(), b_from_e_mx.GetPointer(), w_from_e_mx.GetPointer());
+  vtkNew<vtkMatrix4x4> e_from_c_mx;
+  vtkMatrix4x4::Invert(c_from_e_mx.GetPointer(), e_from_c_mx.GetPointer());
+  vtkNew<vtkMatrix4x4> c_from_b_mx;
+  vtkNew<vtkMatrix4x4> b_from_r_mx;
+  vtkMatrix4x4::Multiply4x4(b_from_q_mx.GetPointer(), q_from_r_mx.GetPointer(), b_from_r_mx.GetPointer());
+  vtkMatrix4x4::Invert(b_from_c_mx.GetPointer(), c_from_b_mx.GetPointer());
+  vtkNew<vtkMatrix4x4> c_from_r_mx;
+  vtkMatrix4x4::Multiply4x4(c_from_b_mx.GetPointer(), b_from_r_mx.GetPointer(), c_from_r_mx.GetPointer());
+
+  // Test GetMatrixTransformToNode computations
+  vtkNew<vtkMatrix4x4> test_mx;
+
+  // GetMatrixTransformToNode: target node is parent
+  eTransform->GetMatrixTransformToNode(cTransform.GetPointer(), test_mx.GetPointer());
+  if (!Matrix4x4AreEqual(c_from_e_mx.GetPointer(), test_mx.GetPointer()))
+    {
+    std::cerr << __LINE__ << " vtkMRMLTransformNodeTest1 failed" << std::endl;
+    return EXIT_FAILURE;
+    }
+  // GetMatrixTransformToNode: target node is child
+  cTransform->GetMatrixTransformToNode(eTransform.GetPointer(), test_mx.GetPointer());
+  if (!Matrix4x4AreEqual(e_from_c_mx.GetPointer(), test_mx.GetPointer()))
+    {
+    std::cerr << __LINE__ << " vtkMRMLTransformNodeTest1 failed" << std::endl;
+    return EXIT_FAILURE;
+    }
+  // GetMatrixTransformToNode: target node is world
+  eTransform->GetMatrixTransformToNode(NULL, test_mx.GetPointer());
+  if (!Matrix4x4AreEqual(w_from_e_mx.GetPointer(), test_mx.GetPointer()))
+    {
+    std::cerr << __LINE__ << " vtkMRMLTransformNodeTest1 failed" << std::endl;
+    return EXIT_FAILURE;
+    }
+  // GetMatrixTransformToWorld
+  eTransform->GetMatrixTransformToWorld(test_mx.GetPointer());
+  if (!Matrix4x4AreEqual(w_from_e_mx.GetPointer(), test_mx.GetPointer()))
+    {
+    std::cerr << __LINE__ << " vtkMRMLTransformNodeTest1 failed" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  // GetMatrixTransformToNode: target node is in different branch
+  rTransform->GetMatrixTransformToNode(cTransform.GetPointer(), test_mx.GetPointer());
+  if (!Matrix4x4AreEqual(c_from_r_mx.GetPointer(), test_mx.GetPointer()))
+    {
+    std::cerr << __LINE__ << " vtkMRMLTransformNodeTest1 failed" << std::endl;
+    return EXIT_FAILURE;
+    }
+  // GetMatrixTransformToNode: target node is the same as the source
+  eTransform->GetMatrixTransformToNode(eTransform.GetPointer(), test_mx.GetPointer());
+  vtkNew<vtkMatrix4x4> identity;
+  if (!Matrix4x4AreEqual(identity.GetPointer(), test_mx.GetPointer()))
+    {
+    std::cerr << __LINE__ << " vtkMRMLTransformNodeTest1 failed" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  // Test when there is a nonlinear transform above the common parent of two transform nodes.
+  // Transform to world is nonlinear but the relative transform is linear.
+  vtkNew<vtkMRMLBSplineTransformNode> nonlinearTransform;
+  scene->AddNode(nonlinearTransform.GetPointer());
+  bTransform->SetAndObserveTransformNodeID(nonlinearTransform->GetID());
+  //
+  // WORLD -> w coordinate system
+  //  |-- nonlinearTransform
+  //       |-- bTransform
+  //              |-- cTransform
+  //              |      |-- dTransform
+  //              |             |-- eTransform
+  //              |-- qTransform
+  //                     |-- rTransform
+  //
+  rTransform->GetMatrixTransformToNode(cTransform.GetPointer(), test_mx.GetPointer());
+  if (!Matrix4x4AreEqual(c_from_r_mx.GetPointer(), test_mx.GetPointer()))
+    {
+    std::cerr << __LINE__ << " vtkMRMLTransformNodeTest1 failed" << std::endl;
+    return EXIT_FAILURE;
+    }
+  if (rTransform->GetFirstCommonParent(dTransform.GetPointer()) != bTransform.GetPointer())
+    {
+    std::cerr << __LINE__ << " vtkMRMLTransformNodeTest1 failed" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  std::cout << "vtkMRMLTransformNodeTest1 successfully completed" << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -155,7 +155,7 @@ int vtkMRMLTransformNode::DeepCopyTransform(vtkAbstractTransform* dst, vtkAbstra
 {
   if (src==NULL || dst==NULL)
     {
-    // we should log an error, but unfortunately we cannot log a VTK macro in a static method
+    vtkGenericWarningMacro("vtkMRMLTransformNode::DeepCopyTransform failed: source or destination transform is invalid");
     return 0;
     }
 
@@ -166,12 +166,18 @@ int vtkMRMLTransformNode::DeepCopyTransform(vtkAbstractTransform* dst, vtkAbstra
 
     // Flatten the transform list to make the copying simpler
     vtkGeneralTransform* dstGeneral=vtkGeneralTransform::SafeDownCast(dst);
+    if (dstGeneral==NULL)
+      {
+      vtkGenericWarningMacro("vtkMRMLTransformNode::DeepCopyTransform failed: destination transform has to be vtkGeneralTransform");
+      return 0;
+      }
     vtkNew<vtkCollection> sourceTransformList;
     FlattenGeneralTransform(sourceTransformList.GetPointer(), src);
 
     // Copy the concatentated transforms
     vtkCollectionSimpleIterator it;
     vtkAbstractTransform* concatenatedTransform = NULL;
+    dstGeneral->PreMultiply();
     for (sourceTransformList->InitTraversal(it); (concatenatedTransform = vtkAbstractTransform::SafeDownCast(sourceTransformList->GetNextItemAsObject(it))) ;)
       {
       vtkAbstractTransform* concatenatedTransformCopy=concatenatedTransform->MakeTransform();
@@ -184,8 +190,12 @@ int vtkMRMLTransformNode::DeepCopyTransform(vtkAbstractTransform* dst, vtkAbstra
     {
     // Fix up the DeepCopy for vtkBSplineTransform (it performs only a ShallowCopy on the coefficient grid)
     dst->DeepCopy(src);
+    if (vtkBSplineTransform::SafeDownCast(dst)==NULL)
+      {
+      vtkGenericWarningMacro("vtkMRMLTransformNode::DeepCopyTransform failed: destination transform has to be vtkBSplineTransform");
+      return 0;
+      }
     vtkImageData* srcCoefficients=vtkBSplineTransform::SafeDownCast(src)->GetCoefficientData();
-
     if (srcCoefficients)
       {
       vtkNew<vtkImageData> dstCoefficients;
@@ -197,6 +207,11 @@ int vtkMRMLTransformNode::DeepCopyTransform(vtkAbstractTransform* dst, vtkAbstra
     {
     // Fix up the DeepCopy for vtkGridTransform (it performs only a ShallowCopy on the displacement grid)
     dst->DeepCopy(src);
+    if (vtkGridTransform::SafeDownCast(dst)==NULL)
+      {
+      vtkGenericWarningMacro("vtkMRMLTransformNode::DeepCopyTransform failed: destination transform has to be vtkGridTransform");
+      return 0;
+      }
     vtkImageData* srcDisplacementGrid=vtkGridTransform::SafeDownCast(src)->GetDisplacementGrid();
     if (srcDisplacementGrid)
       {
@@ -209,6 +224,11 @@ int vtkMRMLTransformNode::DeepCopyTransform(vtkAbstractTransform* dst, vtkAbstra
     {
     // Fix up the DeepCopy for vtkThinPlateSplineTransform (it performs only a ShallowCopy on the landmark points)
     dst->DeepCopy(src);
+    if (vtkThinPlateSplineTransform::SafeDownCast(dst)==NULL)
+      {
+      vtkGenericWarningMacro("vtkMRMLTransformNode::DeepCopyTransform failed: destination transform has to be vtkThinPlateSplineTransform");
+      return 0;
+      }
     vtkPoints* srcSourceLandmarks=vtkThinPlateSplineTransform::SafeDownCast(src)->GetSourceLandmarks();
     if (srcSourceLandmarks)
       {
@@ -350,22 +370,15 @@ vtkAbstractTransform* vtkMRMLTransformNode::GetTransformFromParent()
 //----------------------------------------------------------------------------
 int  vtkMRMLTransformNode::IsTransformToWorldLinear()
 {
-  if (!this->IsLinear())
+  for (vtkMRMLTransformNode* current = this; current!=NULL; current = current->GetParentTransformNode())
     {
-    return 0;
-    }
-  else
-    {
-    vtkMRMLTransformNode *parent = this->GetParentTransformNode();
-    if (parent != NULL)
+    if (!current->IsLinear())
       {
-      return parent->IsTransformToWorldLinear();
-      }
-    else
-      {
-      return 1;
+      return 0;
       }
     }
+  // not found non-linear transform component, therefore it's a linear transform
+  return 1;
 }
 
 //----------------------------------------------------------------------------
@@ -376,25 +389,7 @@ void vtkMRMLTransformNode::GetTransformToWorld(vtkGeneralTransform* transformToW
     vtkErrorMacro("vtkMRMLTransformNode::GetTransformToWorld failed: transformToWorld is invalid");
     return;
     }
-
-  if (transformToWorld->GetNumberOfConcatenatedTransforms() == 0)
-    {
-    transformToWorld->Identity();
-    }
-
-  transformToWorld->PostMultiply();
-
-  vtkAbstractTransform* transformToParent=this->GetTransformToParent();
-  if (transformToParent!=NULL)
-    {
-    transformToWorld->Concatenate(transformToParent);
-    }
-
-  vtkMRMLTransformNode *parent = this->GetParentTransformNode();
-  if (parent != NULL)
-    {
-    parent->GetTransformToWorld(transformToWorld);
-    }
+  GetTransformToNode(NULL, transformToWorld);
 }
 
 //----------------------------------------------------------------------------
@@ -405,162 +400,164 @@ void vtkMRMLTransformNode::GetTransformFromWorld(vtkGeneralTransform* transformF
     vtkErrorMacro("vtkMRMLTransformNode::GetTransformFromWorld failed: transformToWorld is invalid");
     return;
     }
-
-  if (transformFromWorld->GetNumberOfConcatenatedTransforms() == 0)
-    {
-    transformFromWorld->Identity();
-    }
-
-  transformFromWorld->PreMultiply();
-
-  vtkAbstractTransform* transformFromParent=this->GetTransformFromParent();
-  if (transformFromParent!=NULL)
-    {
-    transformFromWorld->Concatenate(transformFromParent);
-    }
-
-  vtkMRMLTransformNode *parent = this->GetParentTransformNode();
-  if (parent != NULL)
-    {
-    parent->GetTransformFromWorld(transformFromWorld);
-    }
+  GetTransformToNode(NULL, transformFromWorld);
+  transformFromWorld->Inverse();
 }
 
 //----------------------------------------------------------------------------
-int  vtkMRMLTransformNode::IsTransformToNodeLinear(vtkMRMLTransformNode* node)
+int  vtkMRMLTransformNode::IsTransformToNodeLinear(vtkMRMLTransformNode* targetNode)
 {
-  if (this->IsTransformNodeMyParent(node))
+  if (this == targetNode)
     {
-    vtkMRMLTransformNode *parent = this->GetParentTransformNode();
-    if (parent != NULL)
+    return 1;
+    }
+  if (this->IsTransformNodeMyParent(targetNode))
+    {
+    // traverse the transform tree from bottom to top, from this to target
+    for (vtkMRMLTransformNode* current = this; current!=targetNode; current = current->GetParentTransformNode())
       {
-      if (!strcmp(parent->GetID(), node->GetID()) )
+      if (!current->IsLinear())
         {
-        return this->IsLinear();
-        }
-      else
-        {
-        return this->IsLinear() * parent->IsTransformToNodeLinear(node);
+        return 0;
         }
       }
-    else return this->IsLinear();
+    return 1;
     }
-  else if (this->IsTransformNodeMyChild(node))
+  else if (this->IsTransformNodeMyChild(targetNode))
     {
-    vtkMRMLTransformNode *parent = node->GetParentTransformNode();
-    if (parent != NULL)
+    // traverse the transform tree from bottom to top, from target to this
+    for (vtkMRMLTransformNode* current = targetNode; current!=this; current = current->GetParentTransformNode())
       {
-      if (!strcmp(parent->GetID(), this->GetID()) )
+      if (!current->IsLinear())
         {
-        return node->IsLinear();
-        }
-      else
-        {
-        return node->IsLinear() * parent->IsTransformToNodeLinear(this);
+        return 0;
         }
       }
-    else return node->IsLinear();
-    }
-  else if (this->IsTransformToWorldLinear() == 1 &&
-           node->IsTransformToWorldLinear() == 1)
-    {
     return 1;
     }
   else
     {
-    return 0;
+    vtkMRMLTransformNode* firstCommonParentNode = this->GetFirstCommonParent(targetNode);
+    if (this->IsTransformToNodeLinear(firstCommonParentNode) &&
+        targetNode->IsTransformToNodeLinear(firstCommonParentNode) )
+      {
+      return 1;
+      }
+    else
+      {
+      return 0;
+      }
     }
 }
 
 //----------------------------------------------------------------------------
-void  vtkMRMLTransformNode::GetTransformToNode(vtkMRMLTransformNode* node,
-                                               vtkGeneralTransform* transformToNode)
+void  vtkMRMLTransformNode::GetTransformToNode(vtkMRMLTransformNode* targetNode,
+                                               vtkGeneralTransform* transformToTargetNode)
 {
-  if (this->IsTransformNodeMyParent(node))
+  if (transformToTargetNode == NULL)
     {
-    vtkMRMLTransformNode *parent = this->GetParentTransformNode();
-    if (parent != NULL)
+    vtkErrorMacro("vtkMRMLTransformNode::GetTransformToNode failed: transformToTargetNode is invalid");
+    return;
+    }
+
+  transformToTargetNode->Identity();
+  transformToTargetNode->PostMultiply();
+
+  if (targetNode == this)
+    {
+    return;
+    }
+
+  if (this->IsTransformNodeMyParent(targetNode))
+    {
+    // traverse the transform tree from bottom to top, from this to target
+    for (vtkMRMLTransformNode* current = this; current!=targetNode; current = current->GetParentTransformNode())
       {
-      vtkAbstractTransform* transformToParent=this->GetTransformToParent();
+      vtkAbstractTransform* transformToParent=current->GetTransformToParent();
       if (transformToParent)
         {
-        transformToNode->Concatenate(transformToParent);
-        }
-      if (strcmp(parent->GetID(), node->GetID()) )
-        {
-        this->GetTransformToNode(node, transformToNode);
-        }
-      }
-    else if (this->GetTransformToParent())
-      {
-      vtkAbstractTransform* transformToParent=this->GetTransformToParent();
-      if (transformToParent)
-        {
-        transformToNode->Concatenate(transformToParent);
+        transformToTargetNode->Concatenate(transformToParent);
         }
       }
     }
-  else if (this->IsTransformNodeMyChild(node))
+  else if (this->IsTransformNodeMyChild(targetNode))
     {
-    vtkMRMLTransformNode *parent = node->GetParentTransformNode();
-    if (parent != NULL)
+    // traverse the transform tree from bottom to top, from target to this
+    for (vtkMRMLTransformNode* current = targetNode; current!=this; current = current->GetParentTransformNode())
       {
-      vtkAbstractTransform* transformToParent=node->GetTransformToParent();
+      vtkAbstractTransform* transformToParent=current->GetTransformToParent();
       if (transformToParent)
         {
-        transformToNode->Concatenate(transformToParent);
-        }
-      if (strcmp(parent->GetID(), this->GetID()) )
-        {
-        node->GetTransformToNode(this, transformToNode);
+        transformToTargetNode->Concatenate(transformToParent);
         }
       }
-    else
-      {
-      vtkAbstractTransform* transformToParent=node->GetTransformToParent();
-      if (transformToParent)
-        {
-        transformToNode->Concatenate(transformToParent);
-        }
-      }
+    // in transformToTargetNode we have transform target->this,
+    // need to invert to get this->target
+    transformToTargetNode->Inverse();
     }
   else
     {
-    this->GetTransformToWorld(transformToNode);
+    vtkMRMLTransformNode* firstCommonParentNode = this->GetFirstCommonParent(targetNode);
 
-    vtkNew<vtkGeneralTransform> transformToWorld2;
-    node->GetTransformToWorld(transformToWorld2.GetPointer());
-    transformToWorld2->Inverse();
+    this->GetTransformToNode(firstCommonParentNode, transformToTargetNode);
 
-    transformToNode->Concatenate(transformToWorld2.GetPointer());
+    vtkNew<vtkGeneralTransform> transformFromCommonParentNode;
+    targetNode->GetTransformToNode(firstCommonParentNode, transformFromCommonParentNode.GetPointer());
+    transformFromCommonParentNode->Inverse();
+
+    transformToTargetNode->Concatenate(transformFromCommonParentNode.GetPointer());
     }
 }
 
 //----------------------------------------------------------------------------
 int vtkMRMLTransformNode::IsTransformNodeMyParent(vtkMRMLTransformNode* node)
 {
-  vtkMRMLTransformNode *parent = this->GetParentTransformNode();
-  if (parent != NULL)
+  if (node == NULL)
     {
-    if (!strcmp(parent->GetID(), node->GetID()) )
+    // the NULL (world) node is parent of all nodes, we don't have to iterate through the parents to know that it's
+    // the parent of this transform node
+    return 1;
+    }
+  for (vtkMRMLTransformNode* current=this->GetParentTransformNode(); current!=NULL; current = current->GetParentTransformNode())
+    {
+    if (node == current)
       {
+      // node is a parent of this
       return 1;
       }
-    else
-      {
-      return parent->IsTransformNodeMyParent(node);
-      }
     }
-  else
-    {
-    return 0;
-    }
+  return 0;
 }
 
 //----------------------------------------------------------------------------
 int vtkMRMLTransformNode::IsTransformNodeMyChild(vtkMRMLTransformNode* node)
 {
+  if (node == NULL)
+    {
+    vtkErrorMacro("vtkMRMLTransformNode::IsTransformNodeMyChild failed: input node is invalid");
+    return 0;
+    }
   return node->IsTransformNodeMyParent(this);
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLTransformNode* vtkMRMLTransformNode::GetFirstCommonParent(vtkMRMLTransformNode* targetNode)
+{
+  if (targetNode==NULL)
+    {
+    // target is the world node, so the common parent is the world
+    return NULL;
+    }
+  // traverse the transform tree from bottom to top, from this to target
+  for (vtkMRMLTransformNode* current = this; current!=NULL; current = current->GetParentTransformNode())
+    {
+    if (targetNode->IsTransformNodeMyParent(current))
+      {
+      // parent of this and targetNode as well
+      return current;
+      }
+    }
+  return NULL;
 }
 
 //----------------------------------------------------------------------------
@@ -600,6 +597,7 @@ void vtkMRMLTransformNode::ApplyTransform(vtkAbstractTransform* transform)
   // (if the current transform is already a general transform tben we can just use that, otherwise we convert)
   // We arbitrarily pick the ToParent transform to store the new composited transform.
   vtkSmartPointer<vtkGeneralTransform> transformToParentGeneral = vtkGeneralTransform::SafeDownCast(oldTransformToParent);
+
   if (transformToParentGeneral.GetPointer()==NULL)
     {
     transformToParentGeneral = vtkSmartPointer<vtkGeneralTransform>::New();
@@ -817,99 +815,80 @@ int vtkMRMLTransformNode::GetMatrixTransformFromParent(vtkMatrix4x4* matrix)
 //----------------------------------------------------------------------------
 int  vtkMRMLTransformNode::GetMatrixTransformToWorld(vtkMatrix4x4* transformToWorld)
 {
-  if (!this->IsTransformToWorldLinear())
-    {
-    vtkWarningMacro("Failed to retrieve matrix to world from transform, the requested transform is not linear");
-    transformToWorld->Identity();
-    return 0;
-    }
-
-  // vtkMatrix4x4::Multiply4x4 computes the result in a separate buffer, so it is safe to use the input as output as well
-  vtkNew<vtkMatrix4x4> matrixTransformToParent;
-  if (!this->GetMatrixTransformToParent(matrixTransformToParent.GetPointer()))
-    {
-    vtkErrorMacro("Failed to retrieve matrix from linear transform");
-    transformToWorld->Identity();
-    return 0;
-    }
-  vtkMatrix4x4::Multiply4x4(matrixTransformToParent.GetPointer(), transformToWorld, transformToWorld);
-
-  vtkMRMLTransformNode *parent = this->GetParentTransformNode();
-  if (parent != NULL)
-    {
-    if (parent->IsLinear())
-      {
-      return (parent->GetMatrixTransformToWorld(transformToWorld));
-      }
-    else
-      {
-      vtkErrorMacro("vtkMRMLTransformNode::GetMatrixTransformToWorld failed: expected parent linear transform");
-      transformToWorld->Identity();
-      return 0;
-      }
-    }
-  return 1;
+  return this->GetMatrixTransformToNode(NULL, transformToWorld);
 }
 
 //----------------------------------------------------------------------------
-int  vtkMRMLTransformNode::GetMatrixTransformToNode(vtkMRMLTransformNode* node, vtkMatrix4x4* transformToNode)
+int  vtkMRMLTransformNode::GetMatrixTransformToNode(vtkMRMLTransformNode* targetNode, vtkMatrix4x4* transformToTargetNode)
 {
-  if (node == NULL)
+  if (transformToTargetNode == NULL)
     {
-    return this->GetMatrixTransformToWorld(transformToNode);
-    }
-  if (!this->IsTransformToNodeLinear(node))
-    {
-    vtkErrorMacro("vtkMRMLTransformNode::GetMatrixTransformToNode failed: expected linear transforms between nodes");
-    transformToNode->Identity();
+    vtkErrorMacro("vtkMRMLTransformNode::GetMatrixtransformToTargetNode failed: transformToTargetNode is invalid");
     return 0;
     }
 
-  if (this->IsTransformNodeMyParent(node))
+  if (targetNode == this)
     {
-    vtkMRMLTransformNode *parent = this->GetParentTransformNode();
-    vtkNew<vtkMatrix4x4> toParentMatrix;
-    this->GetMatrixTransformToParent(toParentMatrix.GetPointer());
-    if (parent != NULL)
+    transformToTargetNode->Identity();
+    return 1;
+    }
+
+  if (this->IsTransformNodeMyParent(targetNode))
+    {
+    transformToTargetNode->Identity();
+    // traverse the transform tree from bottom to top, from this to target
+    for (vtkMRMLTransformNode* current = this; current!=targetNode; current = current->GetParentTransformNode())
       {
-      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
-      if (strcmp(parent->GetID(), node->GetID()) )
+      vtkNew<vtkMatrix4x4> toParentMatrix;
+      if (!current->GetMatrixTransformToParent(toParentMatrix.GetPointer()))
         {
-        this->GetMatrixTransformToNode(node, transformToNode);
+        vtkErrorMacro("vtkMRMLTransformNode::GetMatrixtransformToTargetNode failed: expected linear transforms between nodes");
+        transformToTargetNode->Identity();
+        return 0;
         }
-      }
-    else
-      {
-      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
+      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToTargetNode, transformToTargetNode);
       }
     }
-  else if (this->IsTransformNodeMyChild(node))
+  else if (this->IsTransformNodeMyChild(targetNode))
     {
-    vtkNew<vtkMatrix4x4> toParentMatrix;
-    node->GetMatrixTransformToParent(toParentMatrix.GetPointer());
-    vtkMRMLTransformNode *parent = vtkMRMLTransformNode::SafeDownCast(node->GetParentTransformNode());
-    if (parent != NULL)
+    transformToTargetNode->Identity();
+    vtkNew<vtkMatrix4x4> transformFromTargetNode;
+    // traverse the transform tree from bottom to top, from target to this
+    for (vtkMRMLTransformNode* current = targetNode; current!=this; current = current->GetParentTransformNode())
       {
-      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
-      if (strcmp(parent->GetID(), this->GetID()) )
+      vtkNew<vtkMatrix4x4> toParentMatrix;
+      current->GetMatrixTransformToParent(toParentMatrix.GetPointer());
+      if (!current->GetMatrixTransformToParent(toParentMatrix.GetPointer()))
         {
-        this->GetMatrixTransformToNode(this, transformToNode);
+        vtkErrorMacro("vtkMRMLTransformNode::GetMatrixtransformToTargetNode failed: expected linear transforms between nodes");
+        transformToTargetNode->Identity();
+        return 0;
         }
+      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformFromTargetNode.GetPointer(), transformFromTargetNode.GetPointer());
       }
-    else
-      {
-      vtkMatrix4x4::Multiply4x4(toParentMatrix.GetPointer(), transformToNode, transformToNode);
-      }
+    vtkMatrix4x4::Invert(transformFromTargetNode.GetPointer(), transformToTargetNode);
     }
   else
     {
-    this->GetMatrixTransformToWorld(transformToNode);
-    vtkNew<vtkMatrix4x4> transformToWorld2;
+    vtkMRMLTransformNode* firstCommonParentNode = this->GetFirstCommonParent(targetNode);
 
-    node->GetMatrixTransformToWorld(transformToWorld2.GetPointer());
-    transformToWorld2->Invert();
+    if (!this->GetMatrixTransformToNode(firstCommonParentNode, transformToTargetNode))
+      {
+      vtkErrorMacro("vtkMRMLTransformNode::GetMatrixtransformToTargetNode failed: expected linear transforms between nodes");
+      transformToTargetNode->Identity();
+      return 0;
+      }
 
-    vtkMatrix4x4::Multiply4x4(transformToWorld2.GetPointer(), transformToNode, transformToNode);
+    vtkNew<vtkMatrix4x4> transformFromCommonParentNode;
+    if (!targetNode->GetMatrixTransformToNode(firstCommonParentNode, transformFromCommonParentNode.GetPointer()))
+      {
+      vtkErrorMacro("vtkMRMLTransformNode::GetMatrixtransformToTargetNode failed: expected linear transforms between nodes");
+      transformToTargetNode->Identity();
+      return 0;
+      }
+    transformFromCommonParentNode->Invert();
+
+    vtkMatrix4x4::Multiply4x4(transformFromCommonParentNode.GetPointer(), transformToTargetNode, transformToTargetNode);
     }
   return 1;
 }

--- a/Libs/MRML/Core/vtkMRMLTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.h
@@ -112,7 +112,7 @@ public:
 
   ///
   /// 1 if all the transforms to the top are linear, 0 otherwise
-  int  IsTransformToWorldLinear() ;
+  int  IsTransformToWorldLinear();
 
   ///
   /// 1 if all the transforms between nodes are linear, 0 otherwise
@@ -143,7 +143,18 @@ public:
                                        vtkMatrix4x4* transformToNode);
   ///
   /// Returns 1 if this node is one of the node's descendents
+  /// NULL designates the world transform node and so always returns with 1.
   int IsTransformNodeMyParent(vtkMRMLTransformNode* node);
+
+  ///
+  /// Returns 1 if the node is one of the this node's descendents
+  int IsTransformNodeMyChild(vtkMRMLTransformNode* node);
+
+  ///
+  /// Get the first common parent of he current and the target transform node
+  /// If there are no common parents then NULL is returned
+  /// \param targetNode The transform for which the current transform will be determined
+  vtkMRMLTransformNode* GetFirstCommonParent(vtkMRMLTransformNode* targetNode);
 
   ///
   /// Set a new matrix transform of this node to parent node.
@@ -185,10 +196,6 @@ public:
   /// Returns 0 if the current transform is not linear.
   /// Deprecated! Use SetMatrixTransformToParent instead.
   virtual int SetAndObserveMatrixTransformFromParent(vtkMatrix4x4 *matrix);
-
-  ///
-  /// Returns 1 if the node is one of the this node's descendents
-  int IsTransformNodeMyChild(vtkMRMLTransformNode* node);
 
   /// Reimplemented from vtkMRMLTransformableNode
   virtual bool CanApplyNonLinearTransforms()const;


### PR DESCRIPTION
How to reproduce the crash:

```
# Create transform hierarchy t1-t2-t3
t1=slicer.vtkMRMLTransformNode()
t2=slicer.vtkMRMLTransformNode()
t3=slicer.vtkMRMLTransformNode()
slicer.mrmlScene.AddNode(t1)
slicer.mrmlScene.AddNode(t2)
slicer.mrmlScene.AddNode(t3)
t2.SetAndObserveTransformNodeID(t1.GetID())
t3.SetAndObserveTransformNodeID(t2.GetID())
# Get t3 to t1 transform
m = vtk.vtkMatrix4x4()
t3.GetMatrixTransformToNode(t1, m)
```

The problem was caused by infinite recursion. There were no tests for GetMatrixTransformToNode and GetTransformToNode methods and they did not work well.
Also, the transform node heavily used recursion in several methods when only a simple iteration on the transform tree was needed, which made computation time magnitudes higher (although it was still very quick, so it was not noticeable) and made the code harder to read and debug.

Solution:
Replaced all the unnecessary recursive method calls by simple for loops.
Added tests for Get(Matrix)TransformToNode methods.