### PR TITLE
BUG: Fixed vtkTransform::ApplyTransformMatrix crash

### DIFF
--- a/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
@@ -1635,48 +1635,6 @@ bool vtkMRMLFiducialListNode::CanApplyNonLinearTransforms()const
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLFiducialListNode::ApplyTransformMatrix(vtkMatrix4x4* transformMatrix)
-{
-  int numPoints = this->GetNumberOfFiducials();
-  double (*matrix)[4] = transformMatrix->Element;
-  float xyzIn[3];
-  float xyzOut[3];
-  float orientationIn[4], quaternionIn[4];
-  float orientationMatrix3x3[3][3];
-  vtkNew<vtkMatrix4x4> orientationMatrix;
-  vtkNew<vtkMatrix4x4> newOrientationMatrix;
-  for (int n=0; n<numPoints; n++)
-    {
-    vtkMRMLFiducial *node = this->GetNthFiducial(n);
-
-    node->GetXYZ(xyzIn);
-    xyzOut[0] = matrix[0][0]*xyzIn[0] + matrix[0][1]*xyzIn[1] + matrix[0][2]*xyzIn[2] + matrix[0][3];
-    xyzOut[1] = matrix[1][0]*xyzIn[0] + matrix[1][1]*xyzIn[1] + matrix[1][2]*xyzIn[2] + matrix[1][3];
-    xyzOut[2] = matrix[2][0]*xyzIn[0] + matrix[2][1]*xyzIn[1] + matrix[2][2]*xyzIn[2] + matrix[2][3];
-    node->SetXYZ(xyzOut);
-
-    node->GetOrientationWXYZ(orientationIn);
-    quaternionIn[0] = cos(0.5*orientationIn[0]);
-    double f = sin(0.5*orientationIn[0])/sqrt(orientationIn[1]*orientationIn[1]+orientationIn[2]*orientationIn[2]+orientationIn[3]*orientationIn[3]);
-    quaternionIn[1] = f * orientationIn[1];
-    quaternionIn[2] = f * orientationIn[2];
-    quaternionIn[3] = f * orientationIn[3];
-    vtkMath::QuaternionToMatrix3x3(quaternionIn,orientationMatrix3x3);
-    orientationMatrix->Identity();
-    for (int i=0; i<3; i++)
-      {
-      orientationMatrix->Element[i][0] = orientationMatrix3x3[i][0];
-      orientationMatrix->Element[i][1] = orientationMatrix3x3[i][1];
-      orientationMatrix->Element[i][2] = orientationMatrix3x3[i][2];
-      }
-    vtkMatrix4x4::Multiply4x4(orientationMatrix.GetPointer(), transformMatrix, newOrientationMatrix.GetPointer());
-    node->SetOrientationWXYZFromMatrix4x4(newOrientationMatrix.GetPointer());
-    }
-  this->StorableModifiedTime.Modified();
-  this->Modified();
-}
-
-//---------------------------------------------------------------------------
 void vtkMRMLFiducialListNode::ApplyTransform(vtkAbstractTransform* transform)
 {
   int numPoints = this->GetNumberOfFiducials();

--- a/Libs/MRML/Core/vtkMRMLFiducialListNode.h
+++ b/Libs/MRML/Core/vtkMRMLFiducialListNode.h
@@ -253,7 +253,6 @@ public:
 
   /// transform utility functions
   virtual bool CanApplyNonLinearTransforms()const;
-  virtual void ApplyTransformMatrix(vtkMatrix4x4* transformMatrix);
   virtual void ApplyTransform(vtkAbstractTransform* transform);
 
   /// Create default storage node or NULL if does not have one

--- a/Libs/MRML/Core/vtkMRMLModelDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelDisplayNode.h
@@ -76,10 +76,6 @@ public:
   /// Update the pipeline based on this node attributes
   virtual void UpdatePolyDataPipeline();
 
-  /// Returns true since can apply non linear transforms
-  /// \sa ApplyTransformMatrix, ApplyTransform
-  virtual bool CanApplyNonLinearTransforms()const {return true;};
-
 protected:
   vtkMRMLModelDisplayNode();
   ~vtkMRMLModelDisplayNode();

--- a/Libs/MRML/Core/vtkMRMLROINode.cxx
+++ b/Libs/MRML/Core/vtkMRMLROINode.cxx
@@ -381,21 +381,6 @@ bool vtkMRMLROINode::CanApplyNonLinearTransforms()const
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLROINode::ApplyTransformMatrix(vtkMatrix4x4* transformMatrix)
-{
-  double (*matrix)[4] = transformMatrix->Element;
-  double *xyzIn  = this->GetXYZ();
-  double xyzOut[3];
-
-  xyzOut[0] = matrix[0][0]*xyzIn[0] + matrix[0][1]*xyzIn[1] + matrix[0][2]*xyzIn[2] + matrix[0][3];
-  xyzOut[1] = matrix[1][0]*xyzIn[0] + matrix[1][1]*xyzIn[1] + matrix[1][2]*xyzIn[2] + matrix[1][3];
-  xyzOut[2] = matrix[2][0]*xyzIn[0] + matrix[2][1]*xyzIn[1] + matrix[2][2]*xyzIn[2] + matrix[2][3];
-
-  this->SetXYZ(xyzOut);
-
-}
-
-//---------------------------------------------------------------------------
 void vtkMRMLROINode::ApplyTransform(vtkAbstractTransform* transform)
 {
   double *xyzIn  = this->GetXYZ();

--- a/Libs/MRML/Core/vtkMRMLROINode.h
+++ b/Libs/MRML/Core/vtkMRMLROINode.h
@@ -106,7 +106,6 @@ public:
   ///
   /// transform utility functions
   virtual bool CanApplyNonLinearTransforms()const;
-  virtual void ApplyTransformMatrix(vtkMatrix4x4* transformMatrix);
   virtual void ApplyTransform(vtkAbstractTransform* transform);
 
   /// Description

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
@@ -22,6 +22,7 @@ Version:   $Revision: 1.14 $
 // VTK includes
 #include <vtkCommand.h>
 #include <vtkIntArray.h>
+#include <vtkNew.h>
 #include <vtkTransform.h>
 #include <vtkMatrix4x4.h>
 
@@ -149,26 +150,15 @@ bool vtkMRMLTransformableNode::CanApplyNonLinearTransforms()const
 //-----------------------------------------------------------
 void vtkMRMLTransformableNode::ApplyTransformMatrix(vtkMatrix4x4* transformMatrix)
 {
-  vtkTransform* transform = vtkTransform::New();
+  vtkNew<vtkTransform> transform;
   transform->SetMatrix(transformMatrix);
-  this->ApplyTransform(transform);
-  transform->Delete();
+  this->ApplyTransform(transform.GetPointer());
 }
 
 //-----------------------------------------------------------
 void vtkMRMLTransformableNode::ApplyTransform(vtkAbstractTransform* transform)
 {
-  vtkHomogeneousTransform* linearTransform = vtkHomogeneousTransform::SafeDownCast(transform);
-  if (linearTransform)
-    {
-    this->ApplyTransformMatrix(linearTransform->GetMatrix());
-    return;
-    }
-  if (!this->CanApplyNonLinearTransforms())
-    {
-    vtkErrorMacro("Can't apply a non-linear transform");
-    return;
-    }
+  vtkErrorMacro("ApplyTransform is not implemented for node type "<<this->GetClassName());
 }
 
 //-----------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.h
@@ -67,18 +67,18 @@ public:
       TransformModifiedEvent = 15000
     };
 
-  /// Returns true if the transformable node can apply non linear transforms
+  /// Returns true if the transformable node can apply non-linear transforms.
+  /// A transformable node is always expected to apply linear transforms.
   /// \sa ApplyTransformMatrix, ApplyTransform
   virtual bool CanApplyNonLinearTransforms()const;
 
-  /// Concatenate a matrix to the current transform matrix.
-  /// \sa SetAndObserveTransformNodeID, ApplyTransform,
-  /// CanApplyNonLinearTransforms
+  /// Convenience function to allow transforming a node by specifying a
+  /// transformation matrix.
+  /// \sa ApplyTransformMatrix, ApplyTransform
   virtual void ApplyTransformMatrix(vtkMatrix4x4* transformMatrix);
 
-  /// Concatenate a transform to the current transform matrix.
-  /// \sa SetAndObserveTransformNodeID, ApplyMatrix,
-  /// CanApplyNonLinearTransforms
+  /// Transforms the node with the provided non-linear transform.
+  /// \sa SetAndObserveTransformNodeID, ApplyTransformMatrix, CanApplyNonLinearTransforms
   virtual void ApplyTransform(vtkAbstractTransform* transform);
 
   /// Apply the observed transform to the input point.
@@ -91,7 +91,6 @@ public:
 
   /// Get referenced transform node id
   const char *GetTransformNodeID();
-
 
 protected:
   vtkMRMLTransformableNode();

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationAngleNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationAngleNode.cxx
@@ -448,57 +448,6 @@ void vtkMRMLAnnotationAngleNode::SetLineColour(double initColor[3])
   node->SetSelectedColor(initColor);
 }
 
-//----------------------------------------------------------------------------
-void vtkMRMLAnnotationAngleNode::ApplyTransformMatrix(vtkMatrix4x4* transformMatrix)
-{
-  double (*matrix)[4] = transformMatrix->Element;
-  double xyzIn[3];
-  double xyzOut[3];
-  double *p = NULL;
-
-  // first point
-  p = this->GetPosition1();
-  if (p)
-    {
-    xyzIn[0] = p[0];
-    xyzIn[1] = p[1];
-    xyzIn[2] = p[2];
-
-    xyzOut[0] = matrix[0][0]*xyzIn[0] + matrix[0][1]*xyzIn[1] + matrix[0][2]*xyzIn[2] + matrix[0][3];
-    xyzOut[1] = matrix[1][0]*xyzIn[0] + matrix[1][1]*xyzIn[1] + matrix[1][2]*xyzIn[2] + matrix[1][3];
-    xyzOut[2] = matrix[2][0]*xyzIn[0] + matrix[2][1]*xyzIn[1] + matrix[2][2]*xyzIn[2] + matrix[2][3];
-    this->SetPosition1(xyzOut);
-    }
-
-  // second point
-  p = this->GetPosition2();
-  if (p)
-    {
-    xyzIn[0] = p[0];
-    xyzIn[1] = p[1];
-    xyzIn[2] = p[2];
-
-    xyzOut[0] = matrix[0][0]*xyzIn[0] + matrix[0][1]*xyzIn[1] + matrix[0][2]*xyzIn[2] + matrix[0][3];
-    xyzOut[1] = matrix[1][0]*xyzIn[0] + matrix[1][1]*xyzIn[1] + matrix[1][2]*xyzIn[2] + matrix[1][3];
-    xyzOut[2] = matrix[2][0]*xyzIn[0] + matrix[2][1]*xyzIn[1] + matrix[2][2]*xyzIn[2] + matrix[2][3];
-    this->SetPosition2(xyzOut);
-    }
-  // center
-  p = this->GetPositionCenter();
-  if (p)
-    {
-    xyzIn[0] = p[0];
-    xyzIn[1] = p[1];
-    xyzIn[2] = p[2];
-
-    xyzOut[0] = matrix[0][0]*xyzIn[0] + matrix[0][1]*xyzIn[1] + matrix[0][2]*xyzIn[2] + matrix[0][3];
-    xyzOut[1] = matrix[1][0]*xyzIn[0] + matrix[1][1]*xyzIn[1] + matrix[1][2]*xyzIn[2] + matrix[1][3];
-    xyzOut[2] = matrix[2][0]*xyzIn[0] + matrix[2][1]*xyzIn[1] + matrix[2][2]*xyzIn[2] + matrix[2][3];
-    this->SetPositionCenter(xyzOut);
-    }
-
-}
-
 //---------------------------------------------------------------------------
 void vtkMRMLAnnotationAngleNode::ApplyTransform(vtkAbstractTransform* transform)
 {

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationAngleNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationAngleNode.h
@@ -124,7 +124,6 @@ public:
 
  // Description:
   // transform utility functions
-  virtual void ApplyTransformMatrix(vtkMatrix4x4* transformMatrix);
   virtual void ApplyTransform(vtkAbstractTransform* transform);
 
   // Description:

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.cxx
@@ -332,43 +332,6 @@ void vtkMRMLAnnotationRulerNode::SetLineColour(double initColor[3])
   node->SetSelectedColor(initColor);
 }
 
-//----------------------------------------------------------------------------
-void vtkMRMLAnnotationRulerNode::ApplyTransformMatrix(vtkMatrix4x4* transformMatrix)
-{
-  double (*matrix)[4] = transformMatrix->Element;
-  double xyzIn[3];
-  double xyzOut[3];
-  double *p = NULL;
-
-  // first point
-  p = this->GetPosition1();
-  if (p)
-    {
-    xyzIn[0] = p[0];
-    xyzIn[1] = p[1];
-    xyzIn[2] = p[2];
-
-    xyzOut[0] = matrix[0][0]*xyzIn[0] + matrix[0][1]*xyzIn[1] + matrix[0][2]*xyzIn[2] + matrix[0][3];
-    xyzOut[1] = matrix[1][0]*xyzIn[0] + matrix[1][1]*xyzIn[1] + matrix[1][2]*xyzIn[2] + matrix[1][3];
-    xyzOut[2] = matrix[2][0]*xyzIn[0] + matrix[2][1]*xyzIn[1] + matrix[2][2]*xyzIn[2] + matrix[2][3];
-    this->SetPosition1(xyzOut);
-    }
-
-  // second point
-  p = this->GetPosition2();
-  if (p)
-    {
-    xyzIn[0] = p[0];
-    xyzIn[1] = p[1];
-    xyzIn[2] = p[2];
-
-    xyzOut[0] = matrix[0][0]*xyzIn[0] + matrix[0][1]*xyzIn[1] + matrix[0][2]*xyzIn[2] + matrix[0][3];
-    xyzOut[1] = matrix[1][0]*xyzIn[0] + matrix[1][1]*xyzIn[1] + matrix[1][2]*xyzIn[2] + matrix[1][3];
-    xyzOut[2] = matrix[2][0]*xyzIn[0] + matrix[2][1]*xyzIn[1] + matrix[2][2]*xyzIn[2] + matrix[2][3];
-    this->SetPosition2(xyzOut);
-    }
-}
-
 //---------------------------------------------------------------------------
 void vtkMRMLAnnotationRulerNode::ApplyTransform(vtkAbstractTransform* transform)
 {

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.h
@@ -158,7 +158,6 @@ public:
 
  // Description:
   // transform utility functions
-  virtual void ApplyTransformMatrix(vtkMatrix4x4* transformMatrix);
   virtual void ApplyTransform(vtkAbstractTransform* transform);
 
   // Description:

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.cxx
@@ -98,22 +98,6 @@ void vtkMRMLAnnotationSnapshotNode::ReadXMLAttributes(const char** atts)
 }
 
 //----------------------------------------------------------------------------
-bool vtkMRMLAnnotationSnapshotNode::CanApplyNonLinearTransforms()const
-{
-  return false;
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLAnnotationSnapshotNode::ApplyTransformMatrix(vtkMatrix4x4* vtkNotUsed(transformMatrix))
-{
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLAnnotationSnapshotNode::ApplyTransform(vtkAbstractTransform* vtkNotUsed(transform))
-{
-}
-
-//----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLAnnotationSnapshotNode::CreateDefaultStorageNode()
 {
   return vtkMRMLAnnotationSnapshotStorageNode::New();

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.h
@@ -60,11 +60,6 @@ public:
   /// Create default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 
-  /// Utility transformable methods
-  virtual bool CanApplyNonLinearTransforms()const;
-  virtual void ApplyTransformMatrix(vtkMatrix4x4* vtkNotUsed(transformMatrix));
-  virtual void ApplyTransform(vtkAbstractTransform* vtkNotUsed(transform));
-
   enum
   {
     SnapshotNodeAddedEvent = 0,

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -1260,30 +1260,6 @@ bool vtkMRMLMarkupsNode::CanApplyNonLinearTransforms()const
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLMarkupsNode::ApplyTransformMatrix(vtkMatrix4x4* transformMatrix)
-{
-  int numMarkups = this->GetNumberOfMarkups();
-  double (*matrix)[4] = transformMatrix->Element;
-  double xyzIn[3];
-  double xyzOut[3];
-  for (int m = 0; m < numMarkups; m++)
-    {
-    int numPoints = this->GetNumberOfPointsInNthMarkup(m);
-    for (int n=0; n<numPoints; n++)
-      {
-      this->GetMarkupPoint(m, n, xyzIn);
-      xyzOut[0] = matrix[0][0]*xyzIn[0] + matrix[0][1]*xyzIn[1] + matrix[0][2]*xyzIn[2] + matrix[0][3];
-      xyzOut[1] = matrix[1][0]*xyzIn[0] + matrix[1][1]*xyzIn[1] + matrix[1][2]*xyzIn[2] + matrix[1][3];
-      xyzOut[2] = matrix[2][0]*xyzIn[0] + matrix[2][1]*xyzIn[1] + matrix[2][2]*xyzIn[2] + matrix[2][3];
-      this->SetMarkupPointFromArray(m, n, xyzOut);
-      }
-    }
-
-  this->StorableModifiedTime.Modified();
-  this->Modified();
-}
-
-//---------------------------------------------------------------------------
 void vtkMRMLMarkupsNode::ApplyTransform(vtkAbstractTransform* transform)
 {
   int numMarkups = this->GetNumberOfMarkups();

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -303,13 +303,10 @@ public:
   // Transform utility functions
 
   /// Returns true since can apply non linear transforms
-  /// \sa ApplyTransformMatrix, ApplyTransform
+  /// \sa ApplyTransform
   virtual bool CanApplyNonLinearTransforms()const;
-  /// Apply the passed transformation matrix to all of the markup points
-  /// \sa CanApplyNonLinearTransforms, ApplyTransform
-  virtual void ApplyTransformMatrix(vtkMatrix4x4* transformMatrix);
   /// Apply the passed transformation to all of the markup points
-  /// \sa CanApplyNonLinearTransforms, ApplyTransformMatrix
+  /// \sa CanApplyNonLinearTransforms
   virtual void ApplyTransform(vtkAbstractTransform* transform);
 
   /// Get the markup label format string that defines the markup names.


### PR DESCRIPTION
How to reproduce:

c=getNode('FullRainbow')
m=vtk.vtkMatrix4x4()
c.ApplyTransformMatrix(m)

Problem:
vtkTransform::ApplyTransform and vtkTransform::ApplyTransformMatrix are calling each other. Most of the time at least one is overridden, so no crash occurs.

Solution:
Removed calling of vtkTransform::ApplyTransformMatrix from vtkTransform::ApplyTransform. If a class has a more efficient version of transform application for linear transforms then this call can be added to vtkTransform::ApplyTransform in that specific class.
Removed vtkTransform::ApplyTransformMatrix where it is not necessary (when it's just a more complicated and possibly slower version of ApplyTransform).