### PR TITLE
ENH: VolumeRenderingModuleWidget: Extend API adding two new signals:

### DIFF
--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -354,6 +354,8 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentMRMLVolumeNodeChanged(vtkMRMLN
     }
 
   this->setMRMLDisplayNode(dnode);
+
+  emit newCurrentMRMLVolumeNode(node);
 }
 
 // --------------------------------------------------------------------------
@@ -415,6 +417,8 @@ void qSlicerVolumeRenderingModuleWidget
   d->DisplayNode = displayNode;
 
   this->updateFromMRMLDisplayNode();
+
+  emit newCurrentDisplayNode(displayNode);
 }
 
 // --------------------------------------------------------------------------
@@ -648,6 +652,7 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentRenderingMethodChanged(int ind
     {
     this->mrmlScene()->RemoveNode(oldDisplayNode);
     }
+  emit newCurrentDisplayNode(displayNode);
 }
 
 // --------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
@@ -74,6 +74,10 @@ public slots:
 
   void applyPreset(vtkMRMLNode* volumePropertyNode);
 
+signals:
+  void newCurrentMRMLVolumeNode(vtkMRMLNode* node);
+  void newCurrentDisplayNode(vtkMRMLNode* node);
+
 protected slots:
   void onCurrentMRMLVolumeNodeChanged(vtkMRMLNode* node);
   void onVisibilityChanged(bool);


### PR DESCRIPTION
* newCurrentDisplayNode
* newCurrentMRMLVolumeNode

**** WIP ****

Why ?

signals to synch the current MRMLVolumeRendeingDisplayNode from the VolumeRenderingModuleWidget to another ModuleWidgets. 

if the signal approach is wrong, what about one of these two approaches (using MRML):
1) storing the current VolumeRenderingDisplayNodeID in the vtkMRMLVolumeRenderingScenarioNode.
or
2) storing the current VolumeRenderingDisplayNodeID in the SelectionNode.

Davide.