### PR TITLE
ENH: VolumeRenderingModuleWidget: Extend API adding a new signal

### DIFF
--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -355,6 +355,8 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentMRMLVolumeNodeChanged(vtkMRMLN
     }
 
   this->setMRMLDisplayNode(dnode);
+
+  emit currentVolumeRenderingDisplayNodeChanged(dnode);
 }
 
 // --------------------------------------------------------------------------
@@ -416,6 +418,8 @@ void qSlicerVolumeRenderingModuleWidget
   d->DisplayNode = displayNode;
 
   this->updateFromMRMLDisplayNode();
+
+  emit currentVolumeRenderingDisplayNodeChanged(displayNode);
 }
 
 // --------------------------------------------------------------------------
@@ -649,6 +653,8 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentRenderingMethodChanged(int ind
     {
     this->mrmlScene()->RemoveNode(oldDisplayNode);
     }
+
+  emit currentVolumeRenderingDisplayNodeChanged(displayNode);
 }
 
 // --------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -356,7 +356,7 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentMRMLVolumeNodeChanged(vtkMRMLN
 
   this->setMRMLDisplayNode(dnode);
 
-  emit currentVolumeRenderingDisplayNodeChanged(dnode);
+  emit currentVolumeNodeChanged(volumeNode);
 }
 
 // --------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
@@ -75,6 +75,7 @@ public slots:
   void applyPreset(vtkMRMLNode* volumePropertyNode);
 
 signals:
+  void currentVolumeNodeChanged(vtkMRMLNode* node);
   void currentVolumeRenderingDisplayNodeChanged(vtkMRMLNode* node);
 
 protected slots:

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
@@ -74,6 +74,9 @@ public slots:
 
   void applyPreset(vtkMRMLNode* volumePropertyNode);
 
+signals:
+  void currentVolumeRenderingDisplayNodeChanged(vtkMRMLNode* node);
+
 protected slots:
   void onCurrentMRMLVolumeNodeChanged(vtkMRMLNode* node);
   void onVisibilityChanged(bool);


### PR DESCRIPTION
signals to synch the current MRMLVolumeRendeingDisplayNode from the VolumeRenderingModuleWidget to another ModuleWidgets.

See:
https://github.com/Slicer/Slicer/pull/432
https://github.com/Slicer/Slicer/pull/377

P.S.: setting NodeReferenceID (i.e. restoring selected node at Slicer restart) as suggested by lassoan will be addressed later in another PR. 