### PR TITLE
BUG: Fix Slicer crash due to wrong value return in AddModel

### DIFF
--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
@@ -246,6 +246,7 @@ vtkMRMLModelNode* vtkSlicerModelsLogic::AddModel (const char* filename)
       {
       vtkErrorMacro("AddModel: error reading " << filename);
       this->GetMRMLScene()->RemoveNode(modelNode.GetPointer());
+      return 0;
       }
     }
   else


### PR DESCRIPTION
In `vtkSlicerModelsLogic::AddModel`, if the call to the storageNode
`ReadData()` failed, an error message was triggered and the node
removed from the scene, but `AddModel()` was still returning a pointer
to the `modelNode`, resulting in Slicer crashing.

The bug was encountered when loading a VTK Volume (DATASET set to
STRUCTURED_POINTS) and not selecting the 'Volume' description, since
the default description for the legacy VTK files is 'Model' in Slicer.