### PR TITLE
BUG: Fixed crash when calling widgetRepresentation().self()

### DIFF
--- a/Base/QTCore/qSlicerScriptedUtils.cxx
+++ b/Base/QTCore/qSlicerScriptedUtils.cxx
@@ -203,5 +203,12 @@ PyObject * qSlicerPythonCppAPI::callMethod(int id, PyObject * arguments)
 //-----------------------------------------------------------------------------
 PyObject* qSlicerPythonCppAPI::pythonSelf()const
 {
+  // returned object needs to get an extra ref count!
+  // Without increasing the ref count, the reference count would be decreased
+  // by one each time the object is passed to Python.
+  // For example, each call of calling of
+  // slicer.modules.endoscopy.widgetRepresentation().self()
+  // would decrease the ref count of the Python widget class by one.
+  Py_XINCREF(this->PythonSelf);
   return this->PythonSelf;
 }


### PR DESCRIPTION
How to reproduce:

1. Go to endoscopy module (just an example, the behavior is the same for every scripted modules)

2. Copy-paste this into the Python console:

```
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
slicer.modules.endoscopy.widgetRepresentation().self()
```
=> memory is corrupted now and Slicer will crash very soon (e.g., if the above code copy-pasted again or any other operation is performed)

Problem:
Each time pythonSelf() is used to return an reference to Python, the reference count is decreased by one (when the temporary Python object is deleted).

See how the reference count changes using this code snippet:

```
import sys
for i in range(30):
  w = slicer.modules.endoscopy.widgetRepresentation().self()
  print("Reference count of widget object: "+str(sys.getrefcount(w)))
```

Solution:
When returning a reference to Python, the reference count has to be increased by one.
(for example, the same is done in CTK-build\PythonQt\tests\PythonQtTests.h)

This might (hopefully) also solve the frequent crash of Slicer on application exit due to double-delete of PythonQt widgets.