### PR TITLE
ENH: Moved up vtkMRMLStorableNode is the MRML node hierarchy

### DIFF
--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -502,7 +502,7 @@ QFileInfo qSlicerSaveDataDialogPrivate::nodeFileInfo(vtkMRMLStorableNode* node)
     vtkMRMLStorageNode* storageNode = node->CreateDefaultStorageNode();
     if (storageNode == 0)
       {
-      qDebug() << "nodeFileInfo: unable to create a new default storage node for node " << node->GetID();
+      // node can be stored in the scene
       return QFileInfo();
       }
 

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeImportSceneTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeImportSceneTest.cxx
@@ -50,10 +50,7 @@ int populateScene(vtkMRMLScene* scene, bool saveInSceneView)
     vtkNew<vtkMRMLSceneViewNode> sceneViewNode;
     scene->AddNode(sceneViewNode.GetPointer());
 
-    TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
     sceneViewNode->StoreScene();
-    TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-    TESTING_OUTPUT_ASSERT_WARNINGS_END();
     }
 
   scene->RemoveNode(displayableNode.GetPointer());

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeRestoreSceneTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeRestoreSceneTest.cxx
@@ -75,10 +75,7 @@ int restoreEditAndRestore()
   vtkNew<vtkMRMLSceneViewNode> sceneViewNode;
   scene->AddNode(sceneViewNode.GetPointer());
 
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
 
   sceneViewNode->RestoreScene();
 
@@ -103,10 +100,7 @@ int removeRestoreEditAndRestore()
   vtkNew<vtkMRMLSceneViewNode> sceneViewNode;
   scene->AddNode(sceneViewNode.GetPointer());
 
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
 
   vtkMRMLScalarVolumeNode* volumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(
     scene->GetNodeByID("vtkMRMLScalarVolumeNode1"));

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeStoreSceneTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeStoreSceneTest.cxx
@@ -85,10 +85,7 @@ int store()
   vtkNew<vtkMRMLSceneViewNode> sceneViewNode;
   scene->AddNode(sceneViewNode.GetPointer());
 
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
 
   CHECK_NOT_NULL(sceneViewNode->GetStoredScene()->GetNodeByID("vtkMRMLScalarVolumeNode1"));
 
@@ -106,10 +103,7 @@ int storeAndRestore()
 
   vtkMRMLNode* volumeNode = scene->GetNodeByID("vtkMRMLScalarVolumeNode1");
 
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
 
   sceneViewNode->RestoreScene();
 
@@ -129,10 +123,7 @@ int storeAndRemoveVolume()
   vtkNew<vtkMRMLSceneViewNode> sceneViewNode;
   scene->AddNode(sceneViewNode.GetPointer());
 
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
 
   // Remove node from the scene to see if it gets restored.
   vtkMRMLNode* volumeNode = scene->GetNodeByID("vtkMRMLScalarVolumeNode1");
@@ -184,10 +175,7 @@ int storeTwice()
     sceneViewNode->GetStoredScene()->GetNumberOfNodes() : 0;
   CHECK_INT(defaultNodes, 0);
 
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
 
   // a storage node gets added
   int nodeCount = sceneViewNode->GetStoredScene()->GetNumberOfNodes();
@@ -210,10 +198,7 @@ int storeAndRestoreTwice()
   vtkNew<vtkMRMLSceneViewNode> sceneViewNode;
   scene->AddNode(sceneViewNode.GetPointer());
 
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
 
   sceneViewNode->StoreScene();
 
@@ -232,10 +217,7 @@ int storeTwiceAndRemoveVolume()
   vtkNew<vtkMRMLSceneViewNode> sceneViewNode;
   scene->AddNode(sceneViewNode.GetPointer());
 
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
 
   sceneViewNode->StoreScene();
 
@@ -269,10 +251,7 @@ int references()
     scene->GetReferencedNodes(volumeNode));
   CHECK_INT(sceneReferencedNodes->GetNumberOfItems(), 2);
 
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(1); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
 
   vtkMRMLNode* sceneViewVolumeNode =
     sceneViewNode->GetStoredScene()->GetNodeByID("vtkMRMLScalarVolumeNode1");
@@ -313,10 +292,7 @@ int storePerformance()
 
   vtkNew<vtkTimerLog> timer;
   timer->StartTimer();
-  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
   sceneViewNode->StoreScene();
-  TESTING_OUTPUT_ASSERT_WARNINGS(100); // SceneView StoreScene: creating a new storage node
-  TESTING_OUTPUT_ASSERT_WARNINGS_END();
   timer->StopTimer();
 
   std::cout<< "<DartMeasurement name=\"vtkMRMLSceneViewNode-StorePerformance-"

--- a/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingMacros.h
@@ -541,14 +541,14 @@
 // (className is no longer needed; usually EXERCISE_ALL_BASIC_MRML_METHODS can
 // be used instead of all the macros below)
 
-#define EXERCISE_BASIC_TRANSFORMABLE_MRML_METHODS( className, node )                 \
-  CHECK_EXIT_SUCCESS(vtkMRMLCoreTestingUtilities::ExerciseBasicTransformableMRMLMethods(node));
-
 #define EXERCISE_BASIC_MRML_METHODS( className, node )                               \
   CHECK_EXIT_SUCCESS(vtkMRMLCoreTestingUtilities::ExerciseBasicMRMLMethods(node));
 
 #define EXERCISE_BASIC_STORABLE_MRML_METHODS( className, node )                      \
   CHECK_EXIT_SUCCESS(vtkMRMLCoreTestingUtilities::ExerciseBasicStorableMRMLMethods(node));
+
+#define EXERCISE_BASIC_TRANSFORMABLE_MRML_METHODS( className, node )                 \
+  CHECK_EXIT_SUCCESS(vtkMRMLCoreTestingUtilities::ExerciseBasicTransformableMRMLMethods(node));
 
 #define EXERCISE_BASIC_DISPLAYABLE_MRML_METHODS( className, node )                   \
   CHECK_EXIT_SUCCESS(vtkMRMLCoreTestingUtilities::ExerciseBasicDisplayableMRMLMethods(node));

--- a/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
@@ -321,24 +321,9 @@ int ExerciseBasicMRMLMethods(vtkMRMLNode* node)
 }
 
 // ----------------------------------------------------------------------------
-int ExerciseBasicTransformableMRMLMethods(vtkMRMLTransformableNode* node)
-{
-  CHECK_EXIT_SUCCESS(ExerciseBasicMRMLMethods(node));
-
-  CHECK_NULL(node->GetParentTransformNode());
-
-  node->SetAndObserveTransformNodeID(NULL);
-  CHECK_NULL(node->GetTransformNodeID());
-
-  bool canApplyNonLinear = node->CanApplyNonLinearTransforms();
-  std::cout << "Node can apply non linear transforms? " << (canApplyNonLinear == true ? "yes" : "no") << std::endl;
-  return EXIT_SUCCESS;
-}
-
-// ----------------------------------------------------------------------------
 int ExerciseBasicStorableMRMLMethods(vtkMRMLStorableNode* node)
   {
-  CHECK_EXIT_SUCCESS(ExerciseBasicTransformableMRMLMethods(node));
+  CHECK_EXIT_SUCCESS(ExerciseBasicMRMLMethods(node));
 
   CHECK_INT(node->GetNumberOfStorageNodes(), 0);
 
@@ -353,13 +338,31 @@ int ExerciseBasicStorableMRMLMethods(vtkMRMLStorableNode* node)
   CHECK_NULL(node->GetNthStorageNode(0));
 
   vtkMRMLStorageNode* defaultStorageNode = node->CreateDefaultStorageNode();
-  CHECK_NOT_NULL(defaultStorageNode);
-  defaultStorageNode->Delete();
+  if (defaultStorageNode)
+    {
+    std::cout << "Default storage node created" << std::endl;
+    defaultStorageNode->Delete();
+    }
 
   CHECK_NOT_NULL(node->GetUserTagTable());
 
   return EXIT_SUCCESS;
   }
+
+// ----------------------------------------------------------------------------
+int ExerciseBasicTransformableMRMLMethods(vtkMRMLTransformableNode* node)
+{
+  CHECK_EXIT_SUCCESS(ExerciseBasicStorableMRMLMethods(node));
+
+  CHECK_NULL(node->GetParentTransformNode());
+
+  node->SetAndObserveTransformNodeID(NULL);
+  CHECK_NULL(node->GetTransformNodeID());
+
+  bool canApplyNonLinear = node->CanApplyNonLinearTransforms();
+  std::cout << "Node can apply non linear transforms? " << (canApplyNonLinear == true ? "yes" : "no") << std::endl;
+  return EXIT_SUCCESS;
+}
 
 // ----------------------------------------------------------------------------
 int ExerciseBasicDisplayableMRMLMethods(vtkMRMLDisplayableNode* node)
@@ -655,13 +658,13 @@ int ExerciseAllBasicMRMLMethods(vtkMRMLNode* node)
     {
     return ExerciseBasicDisplayableMRMLMethods(vtkMRMLDisplayableNode::SafeDownCast(node));
     }
-  if (vtkMRMLStorableNode::SafeDownCast(node))
-    {
-    return ExerciseBasicStorableMRMLMethods(vtkMRMLStorableNode::SafeDownCast(node));
-    }
   if (vtkMRMLTransformableNode::SafeDownCast(node))
     {
     return ExerciseBasicTransformableMRMLMethods(vtkMRMLTransformableNode::SafeDownCast(node));
+    }
+  if (vtkMRMLStorableNode::SafeDownCast(node))
+    {
+    return ExerciseBasicStorableMRMLMethods(vtkMRMLStorableNode::SafeDownCast(node));
     }
   return ExerciseBasicMRMLMethods(node);
 }

--- a/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.h
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.h
@@ -105,15 +105,15 @@ int ExerciseAllBasicMRMLMethods(vtkMRMLNode* object);
 VTK_MRML_EXPORT
 int ExerciseBasicMRMLMethods(vtkMRMLNode* node);
 
-/// For testing nodes in Libs/MRML that are transformable. Calls the basic
+/// For testing nodes in Libs/MRML that are storable. Calls the basic
 /// mrml methods macro first.
 VTK_MRML_EXPORT
-int ExerciseBasicTransformableMRMLMethods(vtkMRMLTransformableNode* node);
-
-/// For testing nodes in Libs/MRML that are storable. Calls the basic
-/// transformable mrml methods macro first.
-VTK_MRML_EXPORT
 int ExerciseBasicStorableMRMLMethods(vtkMRMLStorableNode* node);
+
+/// For testing nodes in Libs/MRML that are transformable. Calls the basic
+/// storable mrml methods macro first.
+VTK_MRML_EXPORT
+int ExerciseBasicTransformableMRMLMethods(vtkMRMLTransformableNode* node);
 
 /// For testing nodes in Libs/MRML that are displayable. Calls the basic
 /// transformable mrml methods macro first.

--- a/Libs/MRML/Core/vtkMRMLDisplayableNode.h
+++ b/Libs/MRML/Core/vtkMRMLDisplayableNode.h
@@ -16,7 +16,7 @@
 #define __vtkMRMLDisplayableNode_h
 
 // MRML includes
-#include "vtkMRMLStorableNode.h"
+#include "vtkMRMLTransformableNode.h"
 class vtkMRMLDisplayNode;
 
 // STD includes
@@ -40,10 +40,10 @@ class vtkMRMLDisplayNode;
 
 class vtkMRMLDisplayNode;
 
-class VTK_MRML_EXPORT vtkMRMLDisplayableNode : public vtkMRMLStorableNode
+class VTK_MRML_EXPORT vtkMRMLDisplayableNode : public vtkMRMLTransformableNode
 {
 public:
-  vtkTypeMacro(vtkMRMLDisplayableNode,vtkMRMLStorableNode);
+  vtkTypeMacro(vtkMRMLDisplayableNode,vtkMRMLTransformableNode);
   void PrintSelf(ostream& os, vtkIndent indent);
 
   //--------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLFiducialListNode.h
+++ b/Libs/MRML/Core/vtkMRMLFiducialListNode.h
@@ -16,7 +16,7 @@
 #define __vtkMRMLFiducialListNode_h
 
 // MRML includes
-#include "vtkMRMLStorableNode.h"
+#include "vtkMRMLTransformableNode.h"
 class vtkMRMLFiducial;
 class vtkMRMLFiducialListStorageNode;
 
@@ -43,14 +43,14 @@ typedef struct
 ///
 /// Fiducial list nodes describe a list of points in 3d space.  They indicate
 /// how to render it (color, opacity, etc).
-class VTK_MRML_EXPORT vtkMRMLFiducialListNode : public vtkMRMLStorableNode
+class VTK_MRML_EXPORT vtkMRMLFiducialListNode : public vtkMRMLTransformableNode
 {
 public:
   /// \deprecated Used for backward compatibility for Slicer3 fiducial lists, please use the Annotation Module MRML nodes
   /// \sa vtkMRMLAnnotationNode, vtkMRMLAnnotationFiducialNode
   ///
   static vtkMRMLFiducialListNode *New();
-  vtkTypeMacro(vtkMRMLFiducialListNode,vtkMRMLStorableNode);
+  vtkTypeMacro(vtkMRMLFiducialListNode,vtkMRMLTransformableNode);
   void PrintSelf(ostream& os, vtkIndent indent);
 
   ///--------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -379,10 +379,9 @@ void vtkMRMLSceneViewNode::StoreScene()
         vtkSmartPointer<vtkMRMLStorageNode> storageNode = storableNode->GetStorageNode();
         if (!storageNode)
           {
-          // No storage node in the main scene, add one there, and ensure it
-          // gets added to the scene view
-          vtkWarningMacro("SceneView StoreScene: creating a new storage node for "
-                           << storableNode->GetID());
+          // No storage node in the main scene, try add one.
+          // If CreateDefaultStorageNode returns NULL it means the node can be stored
+          // in the scene (without using a storage node).
           storageNode.TakeReference(storableNode->CreateDefaultStorageNode());
           if (storageNode)
             {

--- a/Libs/MRML/Core/vtkMRMLStorableNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorableNode.h
@@ -16,7 +16,7 @@
 #define __vtkMRMLStorableNode_h
 
 // MRML includes
-#include "vtkMRMLTransformableNode.h"
+#include "vtkMRMLNode.h"
 class vtkMRMLStorageNode;
 
 // VTK includes
@@ -30,10 +30,10 @@ class vtkTagTable;
 /// Model nodes describe polygonal data.  Models
 /// are assumed to have been constructed with the orientation and voxel
 /// dimensions of the original segmented volume.
-class VTK_MRML_EXPORT vtkMRMLStorableNode : public vtkMRMLTransformableNode
+class VTK_MRML_EXPORT vtkMRMLStorableNode : public vtkMRMLNode
 {
 public:
-  vtkTypeMacro(vtkMRMLStorableNode,vtkMRMLTransformableNode);
+  vtkTypeMacro(vtkMRMLStorableNode,vtkMRMLNode);
   void PrintSelf(ostream& os, vtkIndent indent);
 
   //--------------------------------------------------------------------------
@@ -97,7 +97,9 @@ public:
   vtkMRMLStorageNode* GetNthStorageNode(int n);
   vtkMRMLStorageNode* GetStorageNode();
 
-  /// Create a storage node for this node type or NULL if it doesn't have one.
+  /// Create a storage node for this node type.
+  /// If it returns NULL then it means the node can be stored
+  /// in the scene (in XML), without using a storage node.
   /// Null by default.
   /// This must be overwritten by subclasses that use storage nodes.
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();

--- a/Libs/MRML/Core/vtkMRMLTransformableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.h
@@ -16,7 +16,7 @@
 #define __vtkMRMLTransformableNode_h
 
 // MRML includes
-#include "vtkMRMLNode.h"
+#include "vtkMRMLStorableNode.h"
 class vtkMRMLTransformNode;
 
 // VTK includes
@@ -27,10 +27,10 @@ class vtkMatrix4x4;
 ///
 /// A superclass for other nodes that can have a transform to parent node
 /// like volume, model and transformation nodes.
-class VTK_MRML_EXPORT vtkMRMLTransformableNode : public vtkMRMLNode
+class VTK_MRML_EXPORT vtkMRMLTransformableNode : public vtkMRMLStorableNode
 {
 public:
-  vtkTypeMacro(vtkMRMLTransformableNode,vtkMRMLNode);
+  vtkTypeMacro(vtkMRMLTransformableNode,vtkMRMLStorableNode);
   void PrintSelf(ostream& os, vtkIndent indent);
 
   virtual vtkMRMLNode* CreateNodeInstance() = 0;

--- a/Libs/MRML/DisplayableManager/Testing/Data/vtkMRMLCameraDisplayableManagerTest1.mrml
+++ b/Libs/MRML/DisplayableManager/Testing/Data/vtkMRMLCameraDisplayableManagerTest1.mrml
@@ -6,5 +6,5 @@
  <View
   id="vtkMRMLViewNode1"  name="View"  hideFromEditors="false"  selectable="true"  selected="false"  layoutLabel="1"  active="false"  visibility="true"  backgroundColor="0.756863 0.764706 0.909804"  backgroundColor2="0.454902 0.470588 0.745098"  fieldOfView="200"  letterSize="0.05"  boxVisible="true"  fiducialsVisible="true"  fiducialLabelsVisible="true"  axisLabelsVisible="true"  axisLabelsCameraDependent="true"  animationMode="Off"  viewAxisMode="LookFrom"  spinDegrees="2"  spinMs="5"  spinDirection="YawLeft"  rotateDegrees="5"  rockLength="200"  rockCount="0"  stereoType="NoStereo"  renderMode="Perspective"  useDepthPeeling="0" ></View>
  <Camera
-  id="vtkMRMLCameraNode1"  name="Default Scene Camera"  hideFromEditors="false"  selectable="true"  selected="false"  position="0 500 0"  focalPoint="0 0 0"  viewUp="0 0 1"  parallelProjection="false"  parallelScale="1"  activetag="vtkMRMLViewNode1"  appliedTransform="1 0 0 0  0 1 0 0  0 0 1 0  0 0 0 1" ></Camera>
+  id="vtkMRMLCameraNode1"  name="Default Scene Camera"  hideFromEditors="false"  selectable="true"  selected="false"  userTags=""  position="0 500 0"  focalPoint="0 0 0"  viewUp="0 0 1"  parallelProjection="false"  parallelScale="1"  activetag="vtkMRMLViewNode1"  appliedTransform="1 0 0 0  0 1 0 0  0 0 1 0  0 0 0 1" ></Camera>
 </MRML>


### PR DESCRIPTION
vtkMRMLStorableNode is not a children of vtkMRMLTransformable node anymore, but directly a children of vtkMRMLNode.

This allows making a node storable without requiring it to be also transformable. It is important for several node types (color maps, tables, etc), which require separate storage node but not transformable.