### PR TITLE
ENH: update MultiVolumeImporting

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -194,7 +194,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeExplorer Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(MultiVolumeImporter
   GIT_REPOSITORY ${git_protocol}://github.com/fedorov/MultiVolumeImporter.git
-  GIT_TAG 9e4e9359816cea3a5f1e80f1effef13c626a9856
+  GIT_TAG 13bc5be298ad5536fa0eb1e19fecaa84c21f940e
   OPTION_NAME Slicer_BUILD_MultiVolumeImporter
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_BUILD_MULTIVOLUME_SUPPORT;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
This update should resolve the regression introduced by #440 and improves
robustness by not returning multivolumes that have single frames when parsed
based on ImagePositionPatient+AcquisitionTime. The frame identifying attribute for ImagePositionPatient+AcquisitionTime strategy is now set to AcquisitionTime.