### PR TITLE
BUG: Fixed the argument given to FileExists

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
@@ -77,7 +77,7 @@ int vtkMRMLTableStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
     }
 
   // check that the file exists
-  if (vtksys::SystemTools::FileExists(fullName) == false)
+  if (vtksys::SystemTools::FileExists(fullName.c_str()) == false)
     {
     vtkErrorMacro("ReadData: table file '" << fullName << "' not found.");
     return 0;


### PR DESCRIPTION
The argument for FileExists function was converted from std::string to char type since FileExists requires const char* argument. I failed to build Slicer application on OS X 10.10.5 by this part.  