### PR TITLE
ENH: Update Python to 2.7.11

### DIFF
--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -35,7 +35,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
    OR NOT DEFINED PYTHON_LIBRARY
    OR NOT DEFINED PYTHON_EXECUTABLE) AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
-  set(python_SOURCE_DIR "${CMAKE_BINARY_DIR}/Python-2.7.10")
+  set(python_SOURCE_DIR "${CMAKE_BINARY_DIR}/Python-2.7.11")
 
   set(EXTERNAL_PROJECT_OPTIONAL_ARGS)
   if(MSVC)
@@ -47,8 +47,8 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
   endif()
 
   ExternalProject_Add(python-source
-    URL "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz"
-    URL_MD5 "d7547558fd673bd9d38e2108c6b42521"
+    URL "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz"
+    URL_MD5 "6b6076ec9e93f05dd63e47eb9c15728b"
     DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}
     SOURCE_DIR ${python_SOURCE_DIR}
     ${EXTERNAL_PROJECT_OPTIONAL_ARGS}
@@ -111,7 +111,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/python-cmake-buildsystem/python-cmake-buildsystem.git"
-    GIT_TAG "ed5f9bcee540e47f82fa17f8360b820591aa6d66"
+    GIT_TAG "b012e1e718250b8d94256beca97dcbca24d463db"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS

--- a/SuperBuild/python_patched_msvc9compiler.py
+++ b/SuperBuild/python_patched_msvc9compiler.py
@@ -546,11 +546,11 @@ class MSVCCompiler(CCompiler) :
             self.ldflags_shared = ['/DLL', '/nologo', '/INCREMENTAL:NO', '/Manifest']
         if self.__version >= 7:
             self.ldflags_shared_debug = [
-                '/DLL', '/nologo', '/INCREMENTAL:no', '/DEBUG', '/pdb:None'
+                '/DLL', '/nologo', '/INCREMENTAL:no', '/DEBUG'
                 ]
         if self.__version >= 10:
             self.ldflags_shared_debug = [
-                '/DLL', '/nologo', '/INCREMENTAL:no', '/DEBUG', '/pdb:None', '/Manifest'
+                '/DLL', '/nologo', '/INCREMENTAL:no', '/DEBUG', '/Manifest'
                 ]
         self.ldflags_static = [ '/nologo']
 


### PR DESCRIPTION
Suggested-by: Michael Powell <mwpowellhtx@gmail.com>

Associated python-cmake-buildsystem are listed below:

$ git shortlog ed5f9bc..b012e1e --no-merges
Chuck Atkins (3):
      Create and use append_if_absent macro for constructing compiler options
      Use the POSITION_INDEPENDENT_CODE target property instead of -fPIC
      Adjust GCC-specific compiler options to work for Clang, Intel, and PGI

Jean-Christophe Fillion-Robin (6):
      Create CONTRIBUTING.md
      Add convenience macro "check_cmake_property_exists"
      Fix distutils.sysconfig._python_build() on windows
      Fix distutils.test_get_python_inc on windows copying headers into build dir
      Fix test_get_config_h_filename in test_sysconfig.py
      Add support for python 2.7.11rc1

Matt McCormick (4):
      Add the ability to specify the Python version in the CMake configuration.
      Update remark on supported Python versions.
      Add Python 2.7.11 download support.
      Make Python 2.7.11 the default.

Simon Su (1):
      Expect BZIP2_INCLUDE_DIR when building bz2 module.