### PR TITLE
ENH: Update Git tags for OpenIGTLink library and OpenIGTLink module to activate connection error log.

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -173,7 +173,7 @@ list(APPEND Slicer_REMOTE_DEPENDENCIES jqPlot)
 
 Slicer_Remote_Add(OpenIGTLinkIF
   GIT_REPOSITORY ${git_protocol}://github.com/openigtlink/OpenIGTLinkIF.git
-  GIT_TAG 480e5cff7aff729ea36be820081080e333f6d921
+  GIT_TAG 9271ec55d4cb0bbeaee4ead84e8c242e9d0ad320
   OPTION_NAME Slicer_BUILD_OpenIGTLinkIF
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_USE_OpenIGTLink"
   LABELS REMOTE_MODULE

--- a/SuperBuild/External_OpenIGTLink.cmake
+++ b/SuperBuild/External_OpenIGTLink.cmake
@@ -28,7 +28,7 @@ if(NOT DEFINED OpenIGTLink_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/openigtlink/OpenIGTLink.git"
-    GIT_TAG "849b434b4b45a28e3955adf4ba1f3ececd51581e"
+    GIT_TAG "daa957a6d8037fd01bd3c19f5bc34c12b766eba7"
     SOURCE_DIR OpenIGTLink
     BINARY_DIR OpenIGTLink-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
See: 

http://www.na-mic.org/Bug/view.php?id=4147

https://github.com/openigtlink/OpenIGTLinkIF/pull/63