### PR TITLE
COMP: Do not force VTK repository nor tag

### DIFF
--- a/SuperBuild/External_VTKv6.cmake
+++ b/SuperBuild/External_VTKv6.cmake
@@ -98,8 +98,8 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT ${CMAKE_PROJECT_N
     set(VTK_ENABLE_KITS 1)
   endif()
 
-  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY "github.com/Slicer/VTK.git" CACHE STRING "Repository from which to get VTK" FORCE)
-  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "fe92273888219edca422f3a308761ddcd2882e2b" CACHE STRING "VTK git tag to use" FORCE)
+  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY "github.com/Slicer/VTK.git" CACHE STRING "Repository from which to get VTK")
+  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "fe92273888219edca422f3a308761ddcd2882e2b" CACHE STRING "VTK git tag to use")
 
   mark_as_advanced(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG)
 


### PR DESCRIPTION
For external projects it is extremely beneficial to be able to prescribe
the VTK repository and tag so they can include project specific fixes of
VTK.