### PR TITLE
ENH: Enable full logging of python error and warning messages

### DIFF
--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -55,8 +55,9 @@ def initLogging(logger):
   # and all console outputs are sent automatically to the application log anyway.
   applicationLogHandler = SlicerApplicationLogHandler()
   applicationLogHandler.setLevel(logging.DEBUG)
-  # Filter messages at INFO level or above (they will be printed on the console)
-  applicationLogHandler.addFilter(_LogReverseLevelFilter(logging.INFO))
+  # We could filter out messages at INFO level or above (as they will be printed on the console anyway) by adding
+  # applicationLogHandler.addFilter(_LogReverseLevelFilter(logging.INFO))
+  # but then we would not log file name and line number of the log message.
   applicationLogHandler.setFormatter(logging.Formatter('%(levelname)s: %(message)s (%(pathname)s:%(lineno)d)'))
   logger.addHandler(applicationLogHandler)
 


### PR DESCRIPTION
Currently, if a non-debug message is logged from Python (using logging.info, logging.warning, logging.error) then the following appears in the log:
```
[CRITICAL][Stream] 11.02.2016 14:28:29 [] (unknown:0) - this is a warning message
```

If we enable full logging of non-debug messages then we get file name and line number as well:
```
[WARNING][Python] 11.02.2016 14:28:29 [Python] (MyLoggingTest.py:123) - this is a warning message
[CRITICAL][Stream] 11.02.2016 14:28:29 [] (unknown:0) - this is a warning message
```

The change in this commit enables full logging of non-debug messages, which has the slight disadvantage of having two entries for each error (one corresponding to the message appearing on the Python console and the other is the actual error log) but it provides the filename and line number, which is very useful for debugging.