### PR TITLE
BUG: Handle exception if string encoding fails

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -587,8 +587,14 @@ def toVTKString(str):
   """Convert unicode string into 8-bit encoded ascii string.
   Unicode characters without ascii equivalent will be stripped out.
   """
-  return str.encode('latin1', 'ignore')
-
+  vtkStr = ""
+  for c in str:
+    try:
+      cc = c.encode("latin1", "ignore")
+    except (UnicodeDecodeError):
+      cc = "?"
+    vtkStr = vtkStr + cc
+  return vtkStr
 
 #
 # File Utlities


### PR DESCRIPTION
Sometimes there are tricky characters in the strings that need to be encoded (in my case 0xe9), throwing a UnicodeDecodeError exception, which, if not handled properly, results in a long list of SliceViewAnnotations error messages, furthermore stoppage of the running script