### PR TITLE
ENH: bump SlicerDMRI git tag for recent fixes

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -308,7 +308,7 @@ Slicer_Remote_Add(SlicerDMRI
   GIT_REPOSITORY "${git_protocol}://github.com/SlicerDMRI/SlicerDMRI"
   # SlicerDMRI Maintainer: If new revision of the extension add or remove modules, consider updating
   #                        the module lists below. Thanks.
-  GIT_TAG "86dc8ec85d9318ad05420962652443da6bf95b2a"
+  GIT_TAG "17b96f4f1f7766788ebda1dfc8a3554c944c410d"
   OPTION_NAME Slicer_BUILD_SlicerDMRI
   OPTION_DEPENDS "Slicer_BUILD_DIFFUSION_SUPPORT"
   LABELS REMOTE_EXTENSION


### PR DESCRIPTION
git shortlog --no-merges 86dc8ec8..17b96f4f
```
Alex Yarmarkovich (1):
      BUG: 3044. Disable Fiber display options when no fiber is selected

Isaiah (1):
      Update LICENSE.md formatting

Isaiah Norton (3):
      ENH: fix #26: pick baseline imgs by b-val, not |grad|
      ENH: improve DWI masking results
      DWMasking: restore input image cast for better generality

Lauren O'Donnell (2):
      Create README.md
      Create LICENSE.md

zhangfanmark (2):
      STYLE: Update module name displayed with Space
      ENH: Add testing cases for FiberTractMeasurement
```