### PR TITLE
ENH: update DCMTK

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -33,11 +33,9 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       )
   endif()
 
-  # DCMTK-3.6.1_20150924 + patch for MacOSX/Windows build error
-  #  + patch for DcmSegmentation
-  #  + patches related to incorrect frame pixel data packing
-  set(${proj}_REPOSITORY ${git_protocol}://github.com/commontk/DCMTK.git)
-  set(${proj}_GIT_TAG "eb9c842fee8e2cc20fb1f3092eaad8b99919a998")
+  # DCMTK-3.6.1_20160216
+  set(${proj}_REPOSITORY ${git_protocol}://git.dcmtk.org/dcmtk)
+  set(${proj}_GIT_TAG "DCMTK-3.6.1_20160216")
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}


### PR DESCRIPTION
This updates DCMTK to the latest snapshot DCMTK-3.6.1_20160216

Note that the two patches that were applied to the previous update of DCMTK hash here https://github.com/commontk/DCMTK/commits/patched-DCMTK-3.6.1_20150924 are no longer needed, as they were integrated into the DCMTK master. Therefore, the repo is checked out from the official DCMTK source.

I tested that Slicer compiles with this change on Mac OS X (Yosemite 10.10.5, LLVM version 7.0.0), and that no test failures related to DCMTK are introduced (I looked at the individual failures, and there is nothing to indicate these are due to DCMTK update):

```
Total Test time (real) = 7071.30 sec

The following tests FAILED:
	 51 - vtkMRMLNonlinearTransformNodeTest1 (Failed)
	101 - vtkObserverManagerTest1 (Failed)
	475 - ModelToLabelMapTest (Failed)
	477 - N4ITKBiasFieldCorrectionTest (Failed)
	572 - py_RSNAVisTutorial (Timeout)
	601 - vtkMRMLFiberBundleNodeTest1 (Failed)
	609 - DiffusionWeightedVolumeMaskingTest (Failed)
Errors while running CTest
```

cc: @michaelonken @jriesmeier