### PR TITLE
Add include directories in slicerMacroBuildApplication

### DIFF
--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -379,6 +379,18 @@ macro(slicerMacroBuildApplication)
   endif(QT_MAC_USE_COCOA)
 
   # --------------------------------------------------------------------------
+  # Include dirs
+  # --------------------------------------------------------------------------
+
+  set(include_dirs
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${SLICERAPP_INCLUDE_DIRECTORIES}
+    )
+
+  include_directories(${include_dirs})
+
+  # --------------------------------------------------------------------------
   # Build the executable
   # --------------------------------------------------------------------------
   set(Slicer_HAS_CONSOLE_IO_SUPPORT TRUE)


### PR DESCRIPTION
The `slicerMacroBuildApplication` was not including the `SLICERAPP_INCLUDE_DIRECTORIES` defined in the macro by the `INCLUDE_DIRECTORIES` argument.
Co-authored-by: @jcfr 