### PR TITLE
BUG: Update BRAINSTools to fix mask checks

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -252,7 +252,7 @@ set(BRAINSTools_options
   )
 Slicer_Remote_Add(BRAINSTools
   GIT_REPOSITORY "${git_protocol}://github.com/BRAINSia/BRAINSTools.git"
-  GIT_TAG "29d203c63045f7b2c9bad64b9acebee9e3e7b463"  # post-v4.6.0
+  GIT_TAG "16526a5dbab238dfd9a82298953b277a30b4ef4d"  # post-v4.6.0
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
This should resolve the regression introduced in r24963 that caused failing
EMSegment test. The problem was identified and solution proposed by @jcfr

$ git shortlog 29d203c...16526a5 --no-merges
Andrey Fedorov (1):
      BUG: fix mask checks for centerOfROI initializer

cc: @hjmjohnson

also see https://github.com/Slicer/Slicer/pull/468 