### PR TITLE
ENH: Exposing jqplot options to select marker size and line width in …

### DIFF
--- a/Libs/MRML/Core/vtkMRMLChartNode.h
+++ b/Libs/MRML/Core/vtkMRMLChartNode.h
@@ -129,8 +129,10 @@ class VTK_MRML_EXPORT vtkMRMLChartNode : public vtkMRMLNode
   ///
   /// \li  "showLines" - show lines "on" or "off"
   /// \li  "showMarkers" - show markers "on" or "off"
+  /// \li  "size" - marker size is an integer larger than 0 and smaller than 2^32 - 1
   /// \li  "linePattern" - line pattern can be "solid", "dashed", "dotted",
   ///                      "dashed-dotted"
+  /// \li  "lineWidth" - line width is an integer larger than 0 and smaller than 2^32 - 1
   /// \li  "color" - color to use for the array lines and points (<code>\#RRGGBB</code>)
   /// \li  "lookupTable" - MRMLID of a ColorNode to use to color individual
   ///         bars in bar chart (useful with categorical data)

--- a/Libs/MRML/Widgets/qMRMLChartView.cxx
+++ b/Libs/MRML/Widgets/qMRMLChartView.cxx
@@ -841,6 +841,17 @@ QString qMRMLChartViewPrivate::lineOptions(vtkMRMLChartNode *cn)
     options << ", seriesColors: " << this->seriesColorsString(colorNode);
     }
 
+  // markerOptions
+  options << ", markerOptions: {" ;
+  // markers size
+  const char *markersSize = cn->GetProperty("default", "size");
+  if (markersSize && QString(markersSize).toInt() > 0)  // Checks if given size is an integer and if larger than 0
+    {
+    options << "size: " << markersSize;
+    }
+  options << "}" ;
+  // end of markerOptions
+
   // default properties for a series
   //
   //
@@ -904,6 +915,13 @@ QString qMRMLChartViewPrivate::lineOptions(vtkMRMLChartNode *cn)
     options << ", linePattern: '-.'";
     }
 
+  // line width
+  const char *lineWidth = cn->GetProperty("default", "lineWidth");
+  if (lineWidth && QString(lineWidth).toInt() > 0)  // Checks if given lineWidth is an integer and if larger than 0
+    {
+    options << ", lineWidth: " << lineWidth;
+    }
+
   // end of seriesDefaults properties
   options << "}";
 
@@ -964,6 +982,13 @@ QString qMRMLChartViewPrivate::lineOptions(vtkMRMLChartNode *cn)
       options << ", linePattern: '-.'";
       }
 
+    // line width
+  const char *lineWidth = cn->GetProperty(arrayName.c_str(), "lineWidth");
+  if (lineWidth && QString(lineWidth).toInt() > 0)  // Checks if given lineWidth is an integer and if larger than 0
+    {
+    options << ", lineWidth: " << lineWidth;
+    }
+
     // color
     const char *color = cn->GetProperty(arrayName.c_str(), "color");
 
@@ -972,6 +997,16 @@ QString qMRMLChartViewPrivate::lineOptions(vtkMRMLChartNode *cn)
       options << ", color: '" << color << "'";
       }
 
+    // markerOptions
+    options << ", markerOptions: {" ;
+    // markers size
+    const char *markersSize = cn->GetProperty(arrayName.c_str(), "size");
+    if (markersSize && QString(markersSize).toInt() > 0)  // Checks if given size is an integer and if larger than 0
+      {
+      options << "size: " << markersSize;
+      }
+    options << "}" ;
+    // end of markerOptions
     // end of a series
     options << "}";
     if (idx < arrayNames->GetNumberOfValues()-1)


### PR DESCRIPTION
…qMRMLChartView

Exposing two new options for jqplot: 'size' allows to select the size of the marker, and 'lineWidth' allows to select the width of a line. This allows to change these options when using qMRMLChartView. Both properties should be set with a string containing an integer (greater than 0).