### PR TITLE
ENH: Modernizing vcl_ to std::

### DIFF
--- a/Libs/vtkITK/itkGrowCutSegmentationImageFilter.h
+++ b/Libs/vtkITK/itkGrowCutSegmentationImageFilter.h
@@ -9,9 +9,11 @@
 
 //#include "itkGrowCutSegmentationUpdateFilter.h"
 
-#include "vcl_list.h"
+#include <vcl_compiler.h>
+#include <iostream>
+#include "list"
 
-#include <vcl_vector.h>
+#include <vector>
 
 
 #ifndef PixelState
@@ -297,7 +299,7 @@ template<class TInputImage,
 
   void GetRegionOfInterest();
 
-  void ComputeLabelVolumes(TOutputImage *outputImage, vcl_vector< unsigned > &volumes, vcl_vector< unsigned > &phyVolumes);
+  void ComputeLabelVolumes(TOutputImage *outputImage, std::vector< unsigned > &volumes, std::vector< unsigned > &phyVolumes);
 
   void MaskSegmentedImageByWeight(float upperThresh);
 

--- a/Libs/vtkITK/itkGrowCutSegmentationImageFilter.txx
+++ b/Libs/vtkITK/itkGrowCutSegmentationImageFilter.txx
@@ -20,11 +20,13 @@
 #include "itkProgressReporter.h"
 # include "itkIterationReporter.h"
 
-#include <vcl_map.h>
-#include <vcl_string.h>
-#include <vcl_cmath.h>
-#include <vcl_algorithm.h>
-#include <vcl_utility.h>
+#include <map>
+#include <string>
+#include <cmath>
+#include <vcl_compiler.h>
+#include <iostream>
+#include <algorithm>
+#include <utility>
 
 #include <iostream>
 #include <ctime>
@@ -253,15 +255,15 @@ GrowCutSegmentationImageFilter<TInputImage, TOutputImage, TWeightPixelType>
 
 template<class TInputImage, class TOutputImage, class TWeightPixelType>
 void GrowCutSegmentationImageFilter< TInputImage, TOutputImage, TWeightPixelType>::
-ComputeLabelVolumes(TOutputImage *outputImage, vcl_vector< unsigned > &volumes,
-                    vcl_vector< unsigned > &physicalVolumes)
+ComputeLabelVolumes(TOutputImage *outputImage, std::vector< unsigned > &volumes,
+                    std::vector< unsigned > &physicalVolumes)
 {
   //volumes.resize(3);
 
 #ifndef USE_LABELSHAPEFILTER
 
-  vcl_map<unsigned short, unsigned int>labelMap;
-  vcl_vector< unsigned short > labels;
+  std::map<unsigned short, unsigned int>labelMap;
+  std::vector< unsigned short > labels;
   unsigned int index = 0;
   ImageRegionConstIteratorWithIndex< OutputImageType > label( outputImage,
                                                               outputImage->GetBufferedRegion());
@@ -270,10 +272,10 @@ ComputeLabelVolumes(TOutputImage *outputImage, vcl_vector< unsigned > &volumes,
     {
 
     unsigned short pix = static_cast<unsigned short>(label.Get());
-    vcl_map<unsigned short, unsigned int>::iterator it = labelMap.find(pix);
+    std::map<unsigned short, unsigned int>::iterator it = labelMap.find(pix);
     if(it == labelMap.end())
       {
-      labelMap.insert(vcl_pair<unsigned short, unsigned int>(pix, index));
+      labelMap.insert(std::pair<unsigned short, unsigned int>(pix, index));
       volumes.push_back(1);
       labels.push_back(pix);
       ++index;
@@ -287,7 +289,7 @@ ComputeLabelVolumes(TOutputImage *outputImage, vcl_vector< unsigned > &volumes,
   // std::cout<<" label \t "<<" volume "<<std::endl;
   // for (unsigned int i = 0; i < index; i++)
   //   {
-  //   vcl_map<unsigned short, unsigned int>::iterator it = labelMap.find(labels[i]);
+  //   std::map<unsigned short, unsigned int>::iterator it = labelMap.find(labels[i]);
   //   std::cout<<labels[i]<<"\t"<<volumes[it->second]<<std::endl;
   //   }
 
@@ -631,7 +633,7 @@ GrowCutSegmentationImageFilter<TInputImage, TOutputImage, TWeightPixelType>
       }
     }
 
-  maxRadius = static_cast< unsigned int>(vcl_ceil(maxRadius*0.5));
+  maxRadius = static_cast< unsigned int>(std::ceil(maxRadius*0.5));
 
   // float threshSaturation = .96; //.999; // Determine the saturation according to the size of the object
   // float threshUnchanged = 0.05;
@@ -671,7 +673,7 @@ GrowCutSegmentationImageFilter<TInputImage, TOutputImage, TWeightPixelType>
     unsigned relUnlabeled = (unlabeled*100)/totalROIVolume;
     unsigned relSaturated = ((currSaturatedPix+currLocallySaturatedPix)*100)/totalROIVolume;
 
-    // unsigned permodified = (currModified > prevModifiedPix) ? ((currModified-prevModifiedPix)*100)/(vcl_max(static_cast<unsigned int>(1), vcl_max(currModified, prevModifiedPix))) : ((prevModifiedPix - currModified)*100)/(vcl_max(static_cast<unsigned int>(1), vcl_max(currModified, prevModifiedPix)));
+    // unsigned permodified = (currModified > prevModifiedPix) ? ((currModified-prevModifiedPix)*100)/(std::max(static_cast<unsigned int>(1), std::max(currModified, prevModifiedPix))) : ((prevModifiedPix - currModified)*100)/(std::max(static_cast<unsigned int>(1), std::max(currModified, prevModifiedPix)));
 
     converged = (prevModifiedPix == currModified) ||
       (relUnlabeled < threshUnchanged && relSaturated > threshSaturation);
@@ -723,8 +725,8 @@ GrowCutSegmentationImageFilter<TInputImage, TOutputImage, TWeightPixelType>
 
   time(&end);
 
-  vcl_vector< unsigned > labelVolumes;
-  vcl_vector< unsigned > physicalVolumes;
+  std::vector< unsigned > labelVolumes;
+  std::vector< unsigned > physicalVolumes;
 
   this->ComputeLabelVolumes(m_LabelImage, labelVolumes, physicalVolumes);
 
@@ -739,7 +741,7 @@ GrowCutSegmentationImageFilter<TInputImage, TOutputImage, TWeightPixelType>
   typedef ImageFileWriter < OutputImageType > WriterType;
   typename WriterType::Pointer writer = WriterType::New();
 
-  vcl_string outfilename = "segmented_img.mhd";
+  std::string outfilename = "segmented_img.mhd";
   writer->SetFileName(outfilename.c_str());
   writer->SetInput(m_LabelImage);
   writer->Update();

--- a/Libs/vtkITK/vtkITKNumericTraits.h
+++ b/Libs/vtkITK/vtkITKNumericTraits.h
@@ -14,7 +14,7 @@ namespace itk
 
 #if defined(VTK_TYPE_USE___INT64)
 template <>
-class NumericTraits<__int64> : public vcl_numeric_limits<__int64> {
+class NumericTraits<__int64> : public std::numeric_limits<__int64> {
 public:
   typedef __int64 ValueType;
   typedef __int64 PrintType;
@@ -26,10 +26,10 @@ public:
   static const __int64 VTK_ITK_EXPORT Zero;
   static const __int64 VTK_ITK_EXPORT One;
 
-  static __int64 min( ) { return vcl_numeric_limits<__int64>::min(); }
-  static __int64 max( ) { return vcl_numeric_limits<__int64>::max(); }
-  static __int64 min( __int64 ) { return vcl_numeric_limits<__int64>::min(); }
-  static __int64 max( __int64 ) { return vcl_numeric_limits<__int64>::max(); }
+  static __int64 min( ) { return std::numeric_limits<__int64>::min(); }
+  static __int64 max( ) { return std::numeric_limits<__int64>::max(); }
+  static __int64 min( __int64 ) { return std::numeric_limits<__int64>::min(); }
+  static __int64 max( __int64 ) { return std::numeric_limits<__int64>::max(); }
   static __int64 NonpositiveMin() { return min(); }
   static bool IsPositive(__int64 val) { return val > Zero; }
   static bool IsNonpositive(__int64 val) { return val <= Zero; }
@@ -39,7 +39,7 @@ public:
 };
 
 template <>
-class NumericTraits<unsigned __int64> : public vcl_numeric_limits<unsigned __int64> {
+class NumericTraits<unsigned __int64> : public std::numeric_limits<unsigned __int64> {
 public:
   typedef unsigned __int64 ValueType;
   typedef unsigned __int64 PrintType;
@@ -51,10 +51,10 @@ public:
   static const unsigned __int64 VTK_ITK_EXPORT Zero;
   static const unsigned __int64 VTK_ITK_EXPORT One;
 
-  static unsigned __int64 min( ) { return vcl_numeric_limits<unsigned __int64>::min(); }
-  static unsigned __int64 max( ) { return vcl_numeric_limits<unsigned __int64>::max(); }
-  static unsigned __int64 min( unsigned __int64 ) { return vcl_numeric_limits<unsigned __int64>::min(); }
-  static unsigned __int64 max( unsigned __int64 ) { return vcl_numeric_limits<unsigned __int64>::max(); }
+  static unsigned __int64 min( ) { return std::numeric_limits<unsigned __int64>::min(); }
+  static unsigned __int64 max( ) { return std::numeric_limits<unsigned __int64>::max(); }
+  static unsigned __int64 min( unsigned __int64 ) { return std::numeric_limits<unsigned __int64>::min(); }
+  static unsigned __int64 max( unsigned __int64 ) { return std::numeric_limits<unsigned __int64>::max(); }
   static unsigned __int64 NonpositiveMin() { return min(); }
   static bool IsPositive(unsigned __int64 val) { return val != Zero; }
   static bool IsNonpositive(unsigned __int64 val) { return val == Zero; }

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarity3DTransform.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarity3DTransform.txx
@@ -142,7 +142,7 @@ AnisotropicSimilarity3DTransform<TScalarType>
   axis[2] = parameters[2];
   if( norm > 0 )
     {
-    norm = vcl_sqrt(norm);
+    norm = std::sqrt(norm);
     }
 
   double epsilon = 1e-10;
@@ -180,7 +180,7 @@ AnisotropicSimilarity3DTransform<TScalarType>
 //
 // Parameters are ordered as:
 //
-// p[0:2] = right part of the versor (axis times vcl_sin(t/2))
+// p[0:2] = right part of the versor (axis times std::sin(t/2))
 // p[3:5} = translation components
 // p[6:8} = scaling factor (isotropic)
 //

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.txx
@@ -514,9 +514,9 @@ AnisotropicSimilarityLandmarkBasedTransformInitializer<TTransform, TFixedImage, 
           }
 
         itkDebugMacro(<< "Dot Product of landmarks: " << s_dot << " Cross Product: " << s_cross);
-        if( vcl_fabs(s_dot) > 0.00005 )
+        if( std::fabs(s_dot) > 0.00005 )
           {
-          rotationAngle = vcl_atan2(s_cross, s_dot);
+          rotationAngle = std::atan2(s_cross, s_dot);
           }
         else
           {

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.txx
@@ -211,8 +211,8 @@ ImageRegionMomentsCalculator<TImage>::Compute()
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
   vnl_real_eigensystem                  eigenrot( m_Pa.GetVnlMatrix() );
-  vnl_diag_matrix<vcl_complex<double> > eigenval = eigenrot.D;
-  vcl_complex<double>                   det( 1.0, 0.0 );
+  vnl_diag_matrix<std::complex<double> > eigenval = eigenrot.D;
+  std::complex<double>                   det( 1.0, 0.0 );
   for( unsigned int i = 0; i < ImageDimension; i++ )
     {
     det *= eigenval( i, i );

--- a/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
@@ -189,7 +189,7 @@ int main(int argc, char* * argv)
       {
       float domain = static_cast<RealType>( inputImage->
                                             GetLargestPossibleRegion().GetSize()[d] - 1 ) * inputImage->GetSpacing()[d];
-      unsigned int  numberOfSpans = static_cast<unsigned int>( vcl_ceil( domain / splineDistance ) );
+      unsigned int  numberOfSpans = static_cast<unsigned int>( std::ceil( domain / splineDistance ) );
       itk::SizeValueType extraPadding =
           static_cast<itk::SizeValueType>( ( numberOfSpans
                                              * splineDistance

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DFSAffineTransform.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DFSAffineTransform.txx
@@ -29,14 +29,14 @@ DiffusionTensor3DFSAffineTransform<TData>
   vnl_matrix<double> M( 3, 3 );
   M = matrix.GetVnlMatrix();
   vnl_real_eigensystem             eig( M );
-  vnl_matrix<vcl_complex<double> > D( 3, 3 );
-  vnl_matrix<vcl_complex<double> > vnl_sqrMatrix( 3, 3 );
+  vnl_matrix<std::complex<double> > D( 3, 3 );
+  vnl_matrix<std::complex<double> > vnl_sqrMatrix( 3, 3 );
   D.fill( NumericTraits<TData>::ZeroValue() );
   for( int i = 0; i < 3; i++ )
     {
-    D.put( i, i, vcl_pow( eig.D.get( i, i ), 0.5 ) );
+    D.put( i, i, std::pow( eig.D.get( i, i ), 0.5 ) );
     }
-  vnl_sqrMatrix = eig.V * D * vnl_matrix_inverse<vcl_complex<double> >( eig.V );
+  vnl_sqrMatrix = eig.V * D * vnl_matrix_inverse<std::complex<double> >( eig.V );
   vnl_matrix<double> vnl_sqrMatrix_real( 3, 3 );
   vnl_sqrMatrix_real = vnl_real( vnl_sqrMatrix );
   for( int i = 0; i < 3; i++ )


### PR DESCRIPTION
In all supported compilers, the need for vcl_ specialized
functions has been removed.  there is no longer a need
to have these overrides, and code is easier to read
and easier to maintain without these specializations.

The vcl_* definitions can now be greatly simplified.
After removing specializations for early non-conformant
c++ compilers the end result was that only the
std:: version of the functions could ever be
used by the compiler.

ITK_SCRIPT=ITK/Utilities/Maintenance/VCL_ModernizeNaming.py
SRC_BASE_DIR=$(pwd)
for ext in ".h" ".cxx" ".cpp" ".hxx" ".hpp" ".txx"; do
  find ${SRC_BASE_DIR} -type f -name "*${ext}" \         -exec python ${ITK_SCRIPT} {} \;
done