### PR TITLE
BUG: Slicer_EXTENSION_DESCRIPTION_DIR is a PATH, not a STRING

### DIFF
--- a/Extensions/CMake/CMakeLists.txt
+++ b/Extensions/CMake/CMakeLists.txt
@@ -79,7 +79,7 @@ if(NOT Slicer_SOURCE_DIR)
   # Options
   #-----------------------------------------------------------------------------
   set(Slicer_BUILD_EXTENSIONS ON CACHE INTERNAL "Build Slicer extensions.")
-  set(Slicer_EXTENSION_DESCRIPTION_DIR "${default_extension_description_dir}" CACHE STRING "Path to folder containing *.s4ext files to consider.")
+  set(Slicer_EXTENSION_DESCRIPTION_DIR "${default_extension_description_dir}" CACHE PATH "Path to folder containing *.s4ext files to consider.")
   set(Slicer_LOCAL_EXTENSIONS_DIR "${default_local_extension_dir}" CACHE STRING "Path to extension sources locally available")
   option(BUILD_TESTING "Test extensions." ${Slicer_BUILD_TESTING})
 else()


### PR DESCRIPTION
Slicer_EXTENSION_DESCRIPTION_DIR was declared as a STRING. cmake-gui does not offer the possibility to open a file browser and select a directory from the user interface if a variable is not defined as a PATH or FILEPATH.