### PR TITLE
ENH: update SlicerDMRI remote module to b5c262fc

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -308,7 +308,7 @@ Slicer_Remote_Add(SlicerDMRI
   GIT_REPOSITORY "${git_protocol}://github.com/SlicerDMRI/SlicerDMRI"
   # SlicerDMRI Maintainer: If new revision of the extension add or remove modules, consider updating
   #                        the module lists below. Thanks.
-  GIT_TAG "a82fde4870cbf03d8e418b01464cc23d5891d98f"
+  GIT_TAG "b5c262fc50a5ce113a76c90e37dff1b12643000a"
   OPTION_NAME Slicer_BUILD_SlicerDMRI
   OPTION_DEPENDS "Slicer_BUILD_DIFFUSION_SUPPORT"
   LABELS REMOTE_EXTENSION


### PR DESCRIPTION
```
> git shortlog a82fde48..b5c26
Isaiah Norton (8):
      COMP: set TEMP in FBMeasure test CMakeLists.txt
      STYLE: Refactor FBTractMeasurement and comments
      FBTractMeasurement: skip and record NaNs for each measure, fixes #34
      STYLE: FBTractMeasurements clean-up
      COMP: update FBTractMeasurement tests
      COMP: update SuperBuild.cmake for external index build
      COMP: CMake updates for extension build
      ENH: add helix test data from Slicer repository, fixes #18
```