### PR TITLE
ENH: Allow setting color node when loading volumes

### DIFF
--- a/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesIOOptionsWidget.ui
+++ b/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesIOOptionsWidget.ui
@@ -55,9 +55,35 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="qMRMLColorTableComboBox" name="ColorTableComboBox">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="addEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="removeEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>Color table node used to display this volume.</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>qMRMLColorTableComboBox</class>
+   <extends>qMRMLNodeComboBox</extends>
+   <header>qMRMLColorTableComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+  </customwidget>
   <customwidget>
    <class>qSlicerWidget</class>
    <extends>QWidget</extends>
@@ -66,5 +92,12 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>qSlicerVolumesIOOptionsWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>ColorTableComboBox</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+  </connection>
+ </connections>
 </ui>

--- a/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesIOOptionsWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesIOOptionsWidgetTest1.cxx
@@ -20,22 +20,51 @@
 
 // Qt includes
 #include <QApplication>
+#include <QDebug>
 #include <QTimer>
 
+// Slicer includes
+#include "qSlicerApplication.h"
+#include "vtkSlicerApplicationLogic.h"
 // Volumes includes
 #include "qSlicerVolumesIOOptionsWidget.h"
+
+// MRML includes
+#include "vtkMRMLColorLogic.h"
+#include "vtkMRMLScene.h"
 
 //-----------------------------------------------------------------------------
 int qSlicerVolumesIOOptionsWidgetTest1( int argc, char * argv[] )
 {
-  QApplication app(argc, argv);
+  qSlicerApplication app(argc, argv);
+
+  // set up the color nodes for access from the widget
+  vtkSlicerApplicationLogic* appLogic = qSlicerCoreApplication::application()->applicationLogic();
+  QString defaultLabelColor;
+  QString defaultGreyColor;
+  if (appLogic && appLogic->GetColorLogic())
+    {
+    appLogic->GetColorLogic()->SetMRMLScene(qSlicerApplication::application()->mrmlScene());
+    appLogic->GetColorLogic()->AddDefaultColorNodes();
+    defaultLabelColor = QString(appLogic->GetColorLogic()->GetDefaultLabelMapColorNodeID());
+    defaultGreyColor = QString(appLogic->GetColorLogic()->GetDefaultVolumeColorNodeID());
+    }
 
   qSlicerVolumesIOOptionsWidget optionsWidget;
+  optionsWidget.setMRMLScene(qSlicerApplication::application()->mrmlScene());
 
   optionsWidget.setFileName("mylabelmap-seg.nrrd");
   if (!optionsWidget.properties()["labelmap"].toBool())
     {
     std::cerr << "Must be a labelmap" << std::endl;
+    return EXIT_FAILURE;
+    }
+  QString colorID = optionsWidget.properties()["colorNodeID"].toString();
+  qDebug() << __LINE__ << ": Label map: color id: " << colorID;
+  if (colorID != defaultLabelColor)
+    {
+    std::cerr << __LINE__ << ": wrong color id set for a label map, expected "
+              << defaultLabelColor.toStdString() << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -45,6 +74,14 @@ int qSlicerVolumesIOOptionsWidgetTest1( int argc, char * argv[] )
     std::cerr << "Must be a labelmap" << std::endl;
     return EXIT_FAILURE;
     }
+  colorID = optionsWidget.properties()["colorNodeID"].toString();
+  qDebug() << __LINE__ << ": Label map: color id: " << colorID;
+  if (colorID != defaultLabelColor)
+    {
+    std::cerr << __LINE__ << ": wrong color id set for a label map, expected "
+              << defaultLabelColor.toStdString() << std::endl;
+    return EXIT_FAILURE;
+    }
 
   optionsWidget.setFileName("./segment.nrrd");
   if (optionsWidget.properties()["labelmap"].toBool())
@@ -52,6 +89,15 @@ int qSlicerVolumesIOOptionsWidgetTest1( int argc, char * argv[] )
     std::cerr << "Not a labelmap" << std::endl;
     return EXIT_FAILURE;
     }
+  colorID = optionsWidget.properties()["colorNodeID"].toString();
+  qDebug() << __LINE__ << ": Greyscale: color id: " << colorID;
+  if (colorID != defaultGreyColor)
+    {
+    std::cerr << __LINE__ << ": wrong color id set for a grey scale, expected "
+              << defaultGreyColor.toStdString() << std::endl;
+    return EXIT_FAILURE;
+    }
+
 
   optionsWidget.show();
 

--- a/Modules/Loadable/Volumes/qSlicerVolumesIOOptionsWidget.h
+++ b/Modules/Loadable/Volumes/qSlicerVolumesIOOptionsWidget.h
@@ -46,7 +46,12 @@ public slots:
   virtual void setFileNames(const QStringList& fileNames);
 
 protected slots:
+  /// Update the name, labelmap, center, singleFile, discardOrientation,
+  /// colorNodeID properties
   void updateProperties();
+  /// Update the color node selection to the default label map
+  /// or volume color node depending on the label map checkbox state.
+  void updateColorSelector();
 
 private:
   Q_DECLARE_PRIVATE_D(qGetPtrHelper(qSlicerIOOptions::d_ptr), qSlicerVolumesIOOptionsWidget);

--- a/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
@@ -30,6 +30,7 @@
 #include "vtkSlicerVolumesLogic.h"
 
 // MRML includes
+#include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLSelectionNode.h>
@@ -105,7 +106,10 @@ QStringList qSlicerVolumesReader::extensions()const
 //-----------------------------------------------------------------------------
 qSlicerIOOptions* qSlicerVolumesReader::options()const
 {
-  return new qSlicerVolumesIOOptionsWidget;
+  // set the mrml scene on the options widget to allow selecting a color node
+  qSlicerIOOptionsWidget* options = new qSlicerVolumesIOOptionsWidget;
+  options->setMRMLScene(this->mrmlScene());
+  return options;
 }
 
 //-----------------------------------------------------------------------------
@@ -158,6 +162,14 @@ bool qSlicerVolumesReader::load(const IOProperties& properties)
     fileList.GetPointer());
   if (node)
     {
+    if (properties.contains("colorNodeID"))
+      {
+      QString colorNodeID = properties["colorNodeID"].toString();
+      if (node->GetDisplayNode())
+        {
+        node->GetDisplayNode()->SetAndObserveColorNodeID(colorNodeID.toLatin1());
+        }
+      }
     vtkSlicerApplicationLogic* appLogic =
       d->Logic->GetApplicationLogic();
     vtkMRMLSelectionNode* selectionNode =


### PR DESCRIPTION
Add support to pick a non default color node when loading in a volume
via python or the Add Data widget.

In the volumes reader, check for a new property, colorNodeID, and use it to
set the color node information on the volume's display node after reading.

This can be used from python:

```
properties = {}
properties['colorNodeID'] = 'vtkMRMLColorTableNodeWarm1'
slicer.util.loadVolume(fileName, properties)
```

Added a color table node selector to the Volumes module IO widget. Set the
default color nodes via the color logic pointer, for label maps and
greyscales. Pass the colorNodeID property to the Volumes IO reader.
Added testing the color node setting to the widget test.


![add-color-to-vol-loading-labelmap](https://cloud.githubusercontent.com/assets/289054/14156586/33925ff8-f695-11e5-8698-c1ff6c5ef848.png)
![add-color-to-vol-loading-scalar](https://cloud.githubusercontent.com/assets/289054/14156594/3a4e7d40-f695-11e5-9d02-bdf695832a98.png)

