### PR TITLE
BUG: Correct warning display bug in GrowCutEffect

### DIFF
--- a/Modules/Scripted/EditorLib/GrowCutEffect.py
+++ b/Modules/Scripted/EditorLib/GrowCutEffect.py
@@ -90,8 +90,8 @@ class GrowCutEffectOptions(Effect.EffectOptions):
       logging.warning(self.logic.getInvalidInputsMessage())
       background = self.logic.getScopedBackground()
       labelInput = self.logic.getScopedLabelInput()
-      if not slicer.util.confirmOkCancel("Current image type is '{0}' and labelmap type is '{1}' GrowCut only works "
-                                         "reliably with 'short' type.\n\nIf the segmentation result is not satisfacory"
+      if not slicer.util.confirmOkCancelDisplay("Current image type is '{0}' and labelmap type is '{1}'. GrowCut only works "
+                                         "reliably with 'short' type.\n\nIf the segmentation result is not satisfactory"
                                          ", then cast the image and labelmap to 'short' type (using Cast Scalar Volume "
                                          "module) or install Fast GrowCut extension and use FastGrowCutEffect editor "
                                          "tool.".format(background.GetScalarTypeAsString(),


### PR DESCRIPTION
(1) Corrects wrongfully named method `confirmOkCancel` to `confirmOkCancelDisplay` introduced to replace manually created QMessageBox in commit 53f7c53c5fe30b0aa3dc766f2da6df9f528a3767, and implemented in [slicer.util.py](https://github.com/Slicer/Slicer/blob/97f63eef2642f8e56c6a3e4c879b5f53202676bc/Base/Python/slicer/util.py#L684).

This was creating the error below when trying to apply the filter with a non-short image:
```
Traceback (most recent call last):
  File "/Users/alexis/Projects/Dartmouth/nirfastslicer-rel/S-bld/Slicer-build/lib/Slicer-4.5/qt-scripted-modules/EditorLib/GrowCutEffect.py", line 93, in onApply
    if not slicer.util.confirmOkCancel("Current image type is '{0}' and labelmap type is '{1}' GrowCut only works "
AttributeError: 'module' object has no attribute 'confirmOkCancel'
```

(2) Correct typos in warning message.