### PR TITLE
BUG: Fixed edit properties option in node selectors

### DIFF
--- a/Base/QTCLI/qSlicerCLIModule.cxx
+++ b/Base/QTCLI/qSlicerCLIModule.cxx
@@ -28,6 +28,7 @@
 #include <ctkWidgetsUtils.h>
 
 // Slicer includes
+#include <qSlicerApplication.h>
 #include "qMRMLNodeComboBox.h"
 #include "qSlicerCLIModuleWidget.h"
 #include "vtkSlicerCLIModuleLogic.h"
@@ -93,6 +94,9 @@ void qSlicerCLIModule::setup()
   // Temporary directory should be set before the module is initialized
   Q_ASSERT(!d->TempDirectory.isEmpty());
 #endif
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLCommandLineModuleNode", this->name());
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCLI/qSlicerCLIModuleWidget.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleWidget.cxx
@@ -556,3 +556,53 @@ void qSlicerCLIModuleWidget::setAutoRunCancelsRunningProcess(bool autoRun)
     }
   d->commandLineModuleNode()->SetAutoRunMode(newAutoRunMode);
 }
+
+//-----------------------------------------------------------
+bool qSlicerCLIModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerCLIModuleWidget);
+  vtkMRMLCommandLineModuleNode* cmdLineModuleNode = vtkMRMLCommandLineModuleNode::SafeDownCast(node);
+  if (!cmdLineModuleNode)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: invalid input node";
+    return false;
+    }
+  const char* moduleTitle = cmdLineModuleNode->GetAttribute("CommandLineModule");
+  if (!moduleTitle)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: CommandLineModule attribute of node is not set";
+    return false;
+    }
+  if (moduleTitle != this->module()->title())
+    {
+    qWarning() << Q_FUNC_INFO << " failed: mismatch of module title in CommandLineModule attribute of node";
+    return false;
+    }
+  d->MRMLCommandLineModuleNodeSelector->setCurrentNode(node);
+  return true;
+}
+
+//-----------------------------------------------------------
+double qSlicerCLIModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLCommandLineModuleNode::SafeDownCast(node))
+    {
+    vtkMRMLCommandLineModuleNode* cmdLineModuleNode = vtkMRMLCommandLineModuleNode::SafeDownCast(node);
+    const char* moduleTitle = cmdLineModuleNode->GetAttribute("CommandLineModule");
+    if (!moduleTitle)
+      {
+      // node is not associated to any module
+      return 0.0;
+      }
+    if (moduleTitle != this->module()->title())
+      {
+      return 0.0;
+      }
+    // Module title matches, probably this module owns this node
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Base/QTCLI/qSlicerCLIModuleWidget.h
+++ b/Base/QTCLI/qSlicerCLIModuleWidget.h
@@ -48,6 +48,9 @@ public:
   /// Get the current \a commandLineModuleNode
   Q_INVOKABLE vtkMRMLCommandLineModuleNode * currentCommandLineModuleNode()const;
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 public slots:
   /// Set the current \a commandLineModuleNode
   void setCurrentCommandLineModuleNode(vtkMRMLNode* commandLineModuleNode);

--- a/Base/QTCore/qSlicerAbstractModuleRepresentation.cxx
+++ b/Base/QTCore/qSlicerAbstractModuleRepresentation.cxx
@@ -10,6 +10,9 @@
 
 =========================================================================auto=*/
 
+// Qt includes
+#include <QDebug>
+
 // SlicerQt includes
 #include "qSlicerAbstractCoreModule.h"
 #include "qSlicerAbstractModuleRepresentation.h"
@@ -80,4 +83,17 @@ void qSlicerAbstractModuleRepresentation::setModule(qSlicerAbstractCoreModule* m
   d->Module = module;
   d->Logic = module ? module->logic() : 0;
   this->setup();
+}
+
+//-----------------------------------------------------------
+bool qSlicerAbstractModuleRepresentation::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  qWarning() << Q_FUNC_INFO << " failed: method is not implemented in " << this->moduleName();
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerAbstractModuleRepresentation::nodeEditable(vtkMRMLNode* node)
+{
+  return 0.0;
 }

--- a/Base/QTCore/qSlicerAbstractModuleRepresentation.h
+++ b/Base/QTCore/qSlicerAbstractModuleRepresentation.h
@@ -21,6 +21,9 @@
 #ifndef __qSlicerAbstractModuleRepresentation_h
 #define __qSlicerAbstractModuleRepresentation_h
 
+// Qt includes
+#include <QString>
+
 // CTK includes
 #include <ctkPimpl.h>
 
@@ -31,6 +34,7 @@
 
 /// class vtkSlicerApplicationLogic;
 class vtkMRMLAbstractLogic;
+class vtkMRMLNode;
 class qSlicerAbstractCoreModule;
 class QAction;
 class qSlicerAbstractModuleRepresentationPrivate;
@@ -49,6 +53,24 @@ public:
   /// Returns the module the representation belongs to.
   /// The module is set right before setup() is called.
   qSlicerAbstractCoreModule* module()const;
+
+  /// Allows other modules to selecting input and output nodes in the module's GUI.
+  /// There may be multiple node selectors in a module widget, you can select between them
+  /// using the role argument.
+  /// Context can be specified to make a selection within that node (for example, a markup list
+  /// node may contain multiple markups; context can be used to select a specific item).
+  /// Returns true if the selection was successful.
+  /// This node has to be overridden in child classes that support editing certain node types.
+  /// Preferably each module that defines a new MRML node class should also make sure there
+  /// is a module widget that can edit that node.
+  /// If setEditedNode method is overridden then nodeEditable method has to be overridden, too.
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+
+  /// Returns a confidence value (between 0.0 and 1.0) that defines how much this widget is
+  /// suitable for editing the provided node. In general value of 0.5 should be used.
+  /// If the returned value is 0 then it means the node should not be attempted to set as edited node.
+  /// This node has to be overridden in child classes that override setEditedNode method.
+  virtual double nodeEditable(vtkMRMLNode* node);
 
 protected:
   /// All initialization code (typically setupUi()) must be done in setup()

--- a/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleWidgetTest.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerScriptedLoadableModuleWidgetTest.cxx
@@ -22,9 +22,13 @@
 #include <ctkTest.h>
 #include <ctkUtils.h>
 
+// VTK includes
+#include "vtkNew.h"
+
 // Slicer includes
 #include "qSlicerPythonManager.h"
 #include "qSlicerScriptedLoadableModuleWidget.h"
+#include "vtkMRMLModelNode.h"
 
 #include <PythonQt.h>
 // ----------------------------------------------------------------------------
@@ -54,6 +58,9 @@ private slots:
 
   void testSetup();
   void testSetup_data();
+
+  void testNodeEdit();
+  void testNodeEdit_data();
 
 };
 
@@ -162,6 +169,42 @@ void qSlicerScriptedLoadableModuleWidgetTester::testEnterExit_data()
   QTest::newRow("1") << "qSlicerScriptedLoadableModuleNewStyleTestWidget.py";
 }
 
+// ----------------------------------------------------------------------------
+void qSlicerScriptedLoadableModuleWidgetTester::testNodeEdit()
+{
+  QVERIFY(this->resetTmp());
+
+  QFETCH(QString, scriptName);
+  QString scriptPath = this->preparePythonSource(scriptName);
+  QVERIFY(QFile::exists(scriptPath));
+
+  qSlicerScriptedLoadableModuleWidget w;
+  w.setPythonSource(scriptPath);
+
+  vtkNew<vtkMRMLModelNode> node;
+  node->SetName("Some");
+
+  QVERIFY(w.nodeEditable(NULL) == 0.3);
+  QVERIFY(w.property("editableNodeName").toString() == QString(""));
+  QVERIFY(w.nodeEditable(node.GetPointer()) == 0.7);
+  QVERIFY(w.property("editableNodeName").toString() == QString("Some"));
+
+  QVERIFY(w.setEditedNode(NULL) == false);
+  QVERIFY(w.property("editedNodeName").toString() == QString(""));
+  QVERIFY(w.setEditedNode(node.GetPointer(), "someRole", "someContext") == true);
+  QVERIFY(w.property("editedNodeName").toString() == QString("Some"));
+  QVERIFY(w.property("editedNodeRole").toString() == QString("someRole"));
+  QVERIFY(w.property("editedNodeContext").toString() == QString("someContext"));
+}
+
+// ----------------------------------------------------------------------------
+void qSlicerScriptedLoadableModuleWidgetTester::testNodeEdit_data()
+{
+  QTest::addColumn<QString>("scriptName");
+
+  QTest::newRow("0") << "qSlicerScriptedLoadableModuleTestWidget.py";
+  QTest::newRow("1") << "qSlicerScriptedLoadableModuleNewStyleTestWidget.py";
+}
 
 namespace
 {

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTestWidget.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTestWidget.py
@@ -12,3 +12,13 @@ class qSlicerScriptedLoadableModuleNewStyleTestWidget(object):
 
   def exit(self):
     self.parent.setProperty('exit_called_within_Python', True)
+
+  def setEditedNode(self, node, role = '', context = ''):
+    self.parent.setProperty('editedNodeName', node.GetName() if node is not None else "")
+    self.parent.setProperty('editedNodeRole', role)
+    self.parent.setProperty('editedNodeContext', context)
+    return (node is not None)
+
+  def nodeEditable(self, node):
+    self.parent.setProperty('editableNodeName', node.GetName() if node is not None else "")
+    return 0.7 if node is not None else 0.3

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleTestWidget.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleTestWidget.py
@@ -12,3 +12,13 @@ class qSlicerScriptedLoadableModuleTestWidget:
 
   def exit(self):
     self.parent.setProperty('exit_called_within_Python', True)
+
+  def setEditedNode(self, node, role = '', context = ''):
+    self.parent.setProperty('editedNodeName', node.GetName() if node is not None else "")
+    self.parent.setProperty('editedNodeRole', role)
+    self.parent.setProperty('editedNodeContext', context)
+    return (node is not None)
+
+  def nodeEditable(self, node):
+    self.parent.setProperty('editableNodeName', node.GetName() if node is not None else "")
+    return 0.7 if node is not None else 0.3

--- a/Base/QTGUI/qSlicerAbstractModuleWidget.cxx
+++ b/Base/QTGUI/qSlicerAbstractModuleWidget.cxx
@@ -85,3 +85,17 @@ void qSlicerAbstractModuleWidget::setup()
     this->setWindowIcon(m->icon());
     }
 }
+
+//-----------------------------------------------------------
+bool qSlicerAbstractModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  // this method is redefined here to make it Q_INVOKABLE
+  return qSlicerAbstractModuleRepresentation::setEditedNode(node, role, context);
+}
+
+//-----------------------------------------------------------
+double qSlicerAbstractModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  // this method is redefined here to make it Q_INVOKABLE
+  return qSlicerAbstractModuleRepresentation::nodeEditable(node);
+}

--- a/Base/QTGUI/qSlicerAbstractModuleWidget.h
+++ b/Base/QTGUI/qSlicerAbstractModuleWidget.h
@@ -32,7 +32,7 @@
 #include "qSlicerAbstractModuleRepresentation.h"
 #include "qSlicerWidget.h"
 class qSlicerAbstractModuleWidgetPrivate;
-
+class vtkMRMLNode;
 ///
 /// Base class of all the Slicer module widgets. The widget is added in the module panels.
 /// Deriving from qSlicerWidget, it inherits the mrmlScene()/setMRMLScene() methods.
@@ -55,6 +55,9 @@ public:
   virtual void enter();
   virtual void exit();
   bool isEntered()const;
+
+  Q_INVOKABLE virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  Q_INVOKABLE virtual double nodeEditable(vtkMRMLNode* node);
 
 protected:
   QScopedPointer<qSlicerAbstractModuleWidgetPrivate> d_ptr;

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -23,6 +23,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QMainWindow>
+#include <QMultiMap>
 
 #include "vtkSlicerConfigure.h" // For Slicer_USE_*, Slicer_BUILD_*_SUPPORT
 
@@ -45,6 +46,7 @@
 
 // QTGUI includes
 #include "qSlicerAbstractModule.h"
+#include "qSlicerAbstractModuleRepresentation.h"
 #include "qSlicerApplication.h"
 #include "qSlicerCommandOptions.h"
 #include "qSlicerCoreApplication_p.h"
@@ -126,6 +128,8 @@ public:
 #ifdef Slicer_USE_QtTesting
   ctkQtTestingUtility*    TestingUtility;
 #endif
+
+  QMultiMap<QString, QString> EditorsForNodes; // key: node class name; values: module names
 };
 
 
@@ -509,87 +513,101 @@ void qSlicerApplication::confirmRestart(QString reason)
     }
 }
 
+// --------------------------------------------------------------------------
+void qSlicerApplication::registerNodeModule(const QString& nodeClassName, const QString& moduleName)
+{
+  Q_D(qSlicerApplication);
+  d->EditorsForNodes.insert(nodeClassName, moduleName);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerApplication::unregisterNodeModule(const QString& nodeClassName, const QString& moduleName)
+{
+  Q_D(qSlicerApplication);
+  d->EditorsForNodes.remove(nodeClassName, moduleName);
+}
+
 //-----------------------------------------------------------------------------
 QString qSlicerApplication::nodeModule(vtkMRMLNode* node)const
 {
+  Q_D(const qSlicerApplication);
+  QString mostSuitableModuleName = "Data";
+  double mostSuitableModuleConfidence = 0.0;
+
+  vtkMRMLNode* currentNode = node;
   QString nodeClassName = node->GetClassName();
-  if (node->IsA("vtkMRMLCameraNode") ||
-      node->IsA("vtkMRMLViewNode"))
+
+  // Modules that explicitly support the specified node type
+  QList<QString> moduleNames = d->EditorsForNodes.values(nodeClassName);
+
+  // Modules that support a parent class of the node
+  QList<QString> classNames = d->EditorsForNodes.uniqueKeys();
+  foreach(const QString& className, classNames)
     {
-    return "Cameras";
+    if (node->IsA(className.toLatin1()))
+      {
+      moduleNames << d->EditorsForNodes.values(className);
+      }
     }
-  else if (node->IsA("vtkMRMLSliceNode") ||
-           node->IsA("vtkMRMLSliceCompositeNode") ||
-           node->IsA("vtkMRMLSliceLayerNode"))
+
+  foreach(const QString& moduleName, moduleNames)
     {
-    return "SliceController";
+    qSlicerAbstractCoreModule* module = this->moduleManager()->module(moduleName);
+    if (!module)
+      {
+      qWarning() << "Module " << moduleName << " associated with node class " << nodeClassName << " was not found";
+      continue;
+      }
+    qSlicerAbstractModuleRepresentation* widget = module->widgetRepresentation();
+    if (!widget)
+      {
+      qWarning() << "Module " << moduleName << " associated with node class " << nodeClassName << " does not have widget";
+      continue;
+      }
+    double nodeEditableConfidence = widget->nodeEditable(node);
+    if (mostSuitableModuleConfidence < nodeEditableConfidence)
+      {
+      mostSuitableModuleName = moduleName;
+      mostSuitableModuleConfidence = nodeEditableConfidence;
+      }
     }
-  else if (node->IsA("vtkMRMLMarkupsNode") ||
-           node->IsA("vtkMRMLMarkupsDisplayNode") ||
-           node->IsA("vtkMRMLMarkupsStorageNode") ||
-           node->IsA("vtkMRMLAnnotationFiducialNode"))
+  if (mostSuitableModuleConfidence == 0.0)
     {
-    return "Markups";
+    qWarning() << "Couldn't find a module for node class" << nodeClassName;
     }
-  else if (node->IsA("vtkMRMLAnnotationNode") ||
-           node->IsA("vtkMRMLAnnotationDisplayNode") ||
-           node->IsA("vtkMRMLAnnotationStorageNode") ||
-           node->IsA("vtkMRMLAnnotationHierarchyNode"))
-    {
-    return "Annotations";
-    }
-  else if (node->IsA("vtkMRMLTransformNode") ||
-           node->IsA("vtkMRMLTransformStorageNode"))
-    {
-    return "Transforms";
-    }
-  else if (node->IsA("vtkMRMLColorNode"))
-    {
-    return "Colors";
-    }
-  else if (nodeClassName.contains("vtkMRMLFiberBundle"))
-    {
-    return "TractographyDisplay";
-    }
-  else if (node->IsA("vtkMRMLModelNode") ||
-           node->IsA("vtkMRMLModelDisplayNode") ||
-           node->IsA("vtkMRMLModelHierarchyNode") ||
-           node->IsA("vtkMRMLModelStorageNode"))
-    {
-    return "Models";
-    }
-  else if (node->IsA("vtkMRMLSceneViewNode") ||
-           node->IsA("vtkMRMLSceneViewStorageNode"))
-    {
-    return "SceneViews";
-    }
-  else if (node->IsA("vtkMRMLVolumeNode") ||
-           node->IsA("vtkMRMLVolumeDisplayNode") ||
-           node->IsA("vtkMRMLVolumeArchetypeStorageNode") ||
-           node->IsA("vtkMRMLVolumeHeaderlessStorageNode"))
-    {
-    return "Volumes";
-    }
-  else if (node->IsA("vtkMRMLVolumePropertyNode") ||
-           node->IsA("vtkMRMLVolumePropertyStorageNode") ||
-           node->IsA("vtkMRMLVolumeRenderingDisplayNode"))
-    {
-    return "VolumeRendering";
-    }
-  qWarning() << "Couldn't find a module for node class" << node->GetClassName();
-  return "data";
+  return mostSuitableModuleName;
 }
 
 //-----------------------------------------------------------------------------
 void qSlicerApplication::openNodeModule(vtkMRMLNode* node)
 {
+  if (!node)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: node is invalid";
+    return;
+    }
   QString moduleName = this->nodeModule(node);
   qSlicerAbstractCoreModule* module = this->moduleManager()->module(moduleName);
   qSlicerAbstractModule* moduleWithAction = qobject_cast<qSlicerAbstractModule*>(module);
-  if (moduleWithAction)
+  if (!moduleWithAction)
     {
-    moduleWithAction->action()->trigger();
+    qWarning() << Q_FUNC_INFO << " failed: suitable module was not found";
+    return;
     }
+  // Select node (select node before activate because some modules create a default node
+  // if activated without selecting a node)
+  qSlicerAbstractModuleRepresentation* widget = moduleWithAction->widgetRepresentation();
+  if (!widget)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: suitable module widget was not found";
+    return;
+    }
+  if (!widget->setEditedNode(node))
+    {
+    qWarning() << Q_FUNC_INFO << " failed: setEditedNode failed for node type " << node->GetClassName();
+    }
+  // Activate module widget
+  moduleWithAction->action()->trigger();
 }
 
 // --------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -111,11 +111,16 @@ public:
   /// Enable/Disable tooltips
   void setToolTipsEnabled(bool enable);
 
-  /// Return the best module name for a given node.
-  /// \note qSlicerApplication is a temporary host for the function as it should be
-  /// moved into a DataManager where module can register new node
-  /// types/modules
+  /// Return the module name that is most suitable for editing the specified node.
   QString nodeModule(vtkMRMLNode* node)const;
+
+  /// Register a module for a given node class.
+  /// If multiple modules are registered for the same class then the node widget's
+  /// nodeEditable method is used for determining which module is the most suitable for editing.
+  Q_INVOKABLE void registerNodeModule(const QString& nodeClassName, const QString& moduleName);
+
+  /// Unregister a module for a given node class.
+  Q_INVOKABLE void unregisterNodeModule(const QString& nodeClassName, const QString& moduleName);
 
   Q_INVOKABLE ctkSettingsDialog* settingsDialog()const;
 

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.h
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleWidget.h
@@ -53,6 +53,9 @@ public:
   virtual void enter();
   virtual void exit();
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 protected:
   virtual void setup();
 

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -213,18 +213,7 @@ void vtkMRMLSliceLogic::UpdateSliceNode()
     return;
     }
   // find SliceNode in the scene
-  vtkMRMLSliceNode *node= 0;
-  int nnodes = this->GetMRMLScene()->GetNumberOfNodesByClass("vtkMRMLSliceNode");
-  for (int n=0; n<nnodes; n++)
-    {
-    node = vtkMRMLSliceNode::SafeDownCast (
-          this->GetMRMLScene()->GetNthNodeByClass(n, "vtkMRMLSliceNode"));
-    if (node->GetLayoutName() && !strcmp(node->GetLayoutName(), this->GetName()))
-      {
-      break;
-      }
-    node = 0;
-    }
+  vtkMRMLSliceNode *node = vtkMRMLSliceLogic::GetSliceNode(this->GetMRMLScene(), this->GetName());
 
   if ( this->SliceNode != 0 && node != 0 &&
         this->SliceCompositeNode &&
@@ -2351,6 +2340,44 @@ vtkMRMLSliceCompositeNode* vtkMRMLSliceLogic
         !strcmp(sliceCompositeNode->GetLayoutName(), layoutName))
       {
       return sliceCompositeNode;
+      }
+    }
+  return 0;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLSliceNode* vtkMRMLSliceLogic
+::GetSliceNode(vtkMRMLSliceCompositeNode* sliceCompositeNode)
+{
+  if (!sliceCompositeNode)
+    {
+    return 0;
+    }
+  return sliceCompositeNode ? vtkMRMLSliceLogic::GetSliceNode(
+    sliceCompositeNode->GetScene(), sliceCompositeNode->GetLayoutName()) : 0;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLSliceNode* vtkMRMLSliceLogic
+::GetSliceNode(vtkMRMLScene* scene, const char* layoutName)
+{
+  if (!scene || !layoutName)
+    {
+    return 0;
+    }
+  vtkObject* itNode = NULL;
+  vtkCollectionSimpleIterator it;
+  for (scene->GetNodes()->InitTraversal(it); itNode = scene->GetNodes()->GetNextItemAsObject(it);)
+    {
+    vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(itNode);
+    if (!sliceNode)
+      {
+      continue;
+      }
+    if (sliceNode->GetLayoutName() &&
+      !strcmp(sliceNode->GetLayoutName(), layoutName))
+      {
+      return sliceNode;
       }
     }
   return 0;

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -327,6 +327,8 @@ public:
   std::vector< vtkMRMLDisplayNode*> GetPolyDataDisplayNodes();
   /// Return the associated slicerlayer nodes
   static vtkMRMLSliceCompositeNode* GetSliceCompositeNode(vtkMRMLSliceNode* node);
+  /// Return the associated slice node
+  static vtkMRMLSliceNode* GetSliceNode(vtkMRMLSliceCompositeNode* node);
 
   /// Default node name suffix for use with volume slice models to distinguish them
   /// as built in models rather than user accessible.
@@ -370,6 +372,8 @@ protected:
   virtual void OnMRMLNodeModified(vtkMRMLNode* node);
   static vtkMRMLSliceCompositeNode* GetSliceCompositeNode(vtkMRMLScene* scene,
                                                           const char* layoutName);
+  static vtkMRMLSliceNode* GetSliceNode(vtkMRMLScene* scene,
+    const char* layoutName);
 
   bool                        AddingSliceModelNodes;
   bool                        Initialized;

--- a/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModuleWidget.cxx
+++ b/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModuleWidget.cxx
@@ -31,6 +31,9 @@
 #include "GUI/qSlicerAnnotationModuleSnapShotDialog.h"
 
 // MRML includes
+#include "vtkMRMLAnnotationDisplayNode.h"
+#include "vtkMRMLAnnotationHierarchyNode.h"
+#include "vtkMRMLAnnotationNode.h"
 #include "vtkMRMLDisplayableHierarchyNode.h"
 #include "vtkMRMLInteractionNode.h"
 #include "vtkMRMLNode.h"
@@ -611,3 +614,42 @@ void qSlicerAnnotationModuleWidget::reportDialogRejected()
 
 }
 
+//-----------------------------------------------------------
+bool qSlicerAnnotationModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerAnnotationModuleWidget);
+  if (vtkMRMLAnnotationNode::SafeDownCast(node) || vtkMRMLAnnotationHierarchyNode::SafeDownCast(node))
+    {
+    d->hierarchyTreeView->setCurrentNode(node);
+    return true;
+    }
+
+  if (vtkMRMLAnnotationDisplayNode::SafeDownCast(node))
+    {
+    vtkMRMLAnnotationDisplayNode* displayNode = vtkMRMLAnnotationDisplayNode::SafeDownCast(node);
+    vtkMRMLAnnotationNode* displayableNode = vtkMRMLAnnotationNode::SafeDownCast(displayNode->GetDisplayableNode());
+    if (!displayableNode)
+      {
+      return false;
+      }
+    d->hierarchyTreeView->setCurrentNode(displayableNode);
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerAnnotationModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLAnnotationNode::SafeDownCast(node)
+    || vtkMRMLAnnotationDisplayNode::SafeDownCast(node)
+    || vtkMRMLAnnotationHierarchyNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModuleWidget.h
+++ b/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModuleWidget.h
@@ -25,10 +25,6 @@ public:
     qSlicerAnnotationModuleWidget(QWidget *parent=0);
     ~qSlicerAnnotationModuleWidget();
 
-
-
-
-
     /// Different Annotation Types
     enum
       {
@@ -47,6 +43,9 @@ public:
     /// step with the mouse modes tool bar. If interactionNode is null, try to
     /// get it from the scene.
     void updateWidgetFromInteractionMode(vtkMRMLInteractionNode *interactionNode);
+
+    virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+    virtual double nodeEditable(vtkMRMLNode* node);
 
 protected:
 

--- a/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
+++ b/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
@@ -91,6 +91,12 @@ void qSlicerAnnotationsModule::setup()
   ioManager->registerIO(new qSlicerNodeWriter(
     "Annotations", QString("AnnotationFile"),
     QStringList() << "vtkMRMLAnnotationNode", true, this));
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLAnnotationNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLAnnotationDisplayNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLAnnotationStorageNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLAnnotationHierarchyNode", this->name());
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Cameras/qSlicerCamerasModule.cxx
+++ b/Modules/Loadable/Cameras/qSlicerCamerasModule.cxx
@@ -21,6 +21,9 @@
 // Qt includes
 #include <QtPlugin>
 
+// QTGUI includes
+#include "qSlicerApplication.h"
+
 // SlicerQt includes
 #include "qSlicerCamerasModule.h"
 #include "qSlicerCamerasModuleWidget.h"
@@ -45,6 +48,16 @@ qSlicerCamerasModule::qSlicerCamerasModule(QObject* _parent)
 //-----------------------------------------------------------------------------
 qSlicerCamerasModule::~qSlicerCamerasModule()
 {
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerCamerasModule::setup()
+{
+  this->Superclass::setup();
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLCameraNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLViewNode", this->name());
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Cameras/qSlicerCamerasModule.h
+++ b/Modules/Loadable/Cameras/qSlicerCamerasModule.h
@@ -41,6 +41,8 @@ public:
   qSlicerCamerasModule(QObject *parent=0);
   virtual ~qSlicerCamerasModule();
 
+  virtual void setup();
+
   virtual QStringList categories()const;
   virtual QIcon icon()const;
 

--- a/Modules/Loadable/Cameras/qSlicerCamerasModuleWidget.cxx
+++ b/Modules/Loadable/Cameras/qSlicerCamerasModuleWidget.cxx
@@ -151,3 +151,42 @@ void  qSlicerCamerasModuleWidget::setMRMLScene(vtkMRMLScene* scene)
   // Let's resync here.
   this->synchronizeCameraWithView();
 }
+
+//-----------------------------------------------------------
+bool qSlicerCamerasModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerCamerasModuleWidget);
+
+  if (vtkMRMLViewNode::SafeDownCast(node))
+    {
+    d->ViewNodeSelector->setCurrentNode(node);
+    return true;
+    }
+
+  if (vtkMRMLCameraNode::SafeDownCast(node))
+    {
+    vtkMRMLCameraNode* cameraNode = vtkMRMLCameraNode::SafeDownCast(node);
+    vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(this->mrmlScene()->GetNodeByID(cameraNode->GetActiveTag()));
+    if (!viewNode)
+      {
+      return false;
+      }
+    d->ViewNodeSelector->setCurrentNode(viewNode);
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerCamerasModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLViewNode::SafeDownCast(node) || vtkMRMLCameraNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Modules/Loadable/Cameras/qSlicerCamerasModuleWidget.h
+++ b/Modules/Loadable/Cameras/qSlicerCamerasModuleWidget.h
@@ -39,6 +39,9 @@ public:
   qSlicerCamerasModuleWidget(QWidget *parent=0);
   virtual ~qSlicerCamerasModuleWidget();
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 public slots:
   ///
   /// Inherited from qSlicerWidget. Reimplemented for refresh issues.

--- a/Modules/Loadable/Colors/qSlicerColorsModule.cxx
+++ b/Modules/Loadable/Colors/qSlicerColorsModule.cxx
@@ -121,6 +121,9 @@ void qSlicerColorsModule::setup()
                                 "Labels", SIGNAL(colorSelected(QColor)),
                                 SIGNAL(colorNameSelected(QString)));
   ctkColorDialog::setDefaultTab(1);
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLColorNode", this->name());
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Colors/qSlicerColorsModuleWidget.cxx
+++ b/Modules/Loadable/Colors/qSlicerColorsModuleWidget.cxx
@@ -431,3 +431,29 @@ void qSlicerColorsModuleWidget::copyCurrentColorNode()
     d->ColorTableComboBox->setCurrentNode(colorNode);
     }
 }
+
+//-----------------------------------------------------------
+bool qSlicerColorsModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerColorsModuleWidget);
+  if (vtkMRMLColorNode::SafeDownCast(node))
+    {
+    d->ColorTableComboBox->setCurrentNode(node);
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerColorsModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLColorNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Modules/Loadable/Colors/qSlicerColorsModuleWidget.h
+++ b/Modules/Loadable/Colors/qSlicerColorsModuleWidget.h
@@ -40,6 +40,8 @@ public:
   qSlicerColorsModuleWidget(QWidget *parent=0);
   virtual ~qSlicerColorsModuleWidget();
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
 
 public slots:
   void setCurrentColorNode(vtkMRMLNode*);

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModule.cxx
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModule.cxx
@@ -4,6 +4,7 @@
 #include <QtPlugin>
 
 // Slicer includes
+#include <qSlicerApplication.h>
 #include <qSlicerCoreApplication.h>
 #include <qSlicerModuleManager.h>
 
@@ -125,6 +126,9 @@ void qSlicerCropVolumeModule::setup()
     {
     qWarning() << "ResampleScalarVectorDWIVolume module is not found";
     }
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLCropVolumeParametersNode", this->name());
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
@@ -732,3 +732,28 @@ void qSlicerCropVolumeModuleWidget::updateWidget()
 
   d->SpacingScalingSpinBox->setValue(parametersNode->GetSpacingScalingConst());
 }
+
+//-----------------------------------------------------------
+bool qSlicerCropVolumeModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerCropVolumeModuleWidget);
+  if (vtkMRMLCropVolumeParametersNode::SafeDownCast(node))
+    {
+    d->ParametersNodeComboBox->setCurrentNode(node);
+    return true;
+    }
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerCropVolumeModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLCropVolumeParametersNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.h
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.h
@@ -22,6 +22,9 @@ public:
   qSlicerCropVolumeModuleWidget(QWidget *parent=0);
   virtual ~qSlicerCropVolumeModuleWidget();
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 public slots:
 
 protected:

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -168,21 +168,3 @@ QIcon qSlicerSubjectHierarchyMarkupsPlugin::visibilityIcon(int visible)
   // Have the default plugin (which is not registered) take care of this
   return qSlicerSubjectHierarchyPluginHandler::instance()->defaultPlugin()->visibilityIcon(visible);
 }
-
-//---------------------------------------------------------------------------
-void qSlicerSubjectHierarchyMarkupsPlugin::editProperties(vtkMRMLSubjectHierarchyNode* node)
-{
-  // Switch to markups module
-  qSlicerAbstractModuleWidget* moduleWidget = qSlicerSubjectHierarchyAbstractPlugin::switchToModule("Markups");
-  if (moduleWidget)
-    {
-    // Get node selector combobox
-    qMRMLNodeComboBox* nodeSelector = moduleWidget->findChild<qMRMLNodeComboBox*>("activeMarkupMRMLNodeComboBox");
-
-    // Choose current data node
-    if (nodeSelector)
-      {
-      nodeSelector->setCurrentNode(node->GetAssociatedNode());
-      }
-    }
-}

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -78,9 +78,6 @@ public:
   /// Get visibility icon for a visibility state
   virtual QIcon visibilityIcon(int visible);
 
-  /// Open module belonging to node and set inputs in opened module
-  virtual void editProperties(vtkMRMLSubjectHierarchyNode* node);
-
 protected:
   QScopedPointer<qSlicerSubjectHierarchyMarkupsPluginPrivate> d_ptr;
 

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -162,8 +162,13 @@ void qSlicerMarkupsModule::setup()
 
   // Register Subject Hierarchy core plugins
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyMarkupsPlugin());
-}
 
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLAnnotationFiducialNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLMarkupsDisplayNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLMarkupsFiducialNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLMarkupsFiducialStorageNode", this->name());
+}
 
 //-----------------------------------------------------------------------------
 qSlicerAbstractModuleRepresentation * qSlicerMarkupsModule::createWidgetRepresentation()

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -3231,3 +3231,47 @@ void qSlicerMarkupsModuleWidget::onTransformedCoordinatesToggled(bool checked)
   // tbd: only update the coordinates
   this->updateWidgetFromMRML();
 }
+
+//-----------------------------------------------------------
+bool qSlicerMarkupsModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerMarkupsModuleWidget);
+  if (vtkMRMLMarkupsFiducialNode::SafeDownCast(node))
+    {
+    d->activeMarkupMRMLNodeComboBox->setCurrentNode(node);
+    return true;
+    }
+
+  if (vtkMRMLMarkupsDisplayNode::SafeDownCast(node))
+    {
+    vtkMRMLMarkupsDisplayNode* displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(node);
+    vtkMRMLMarkupsFiducialNode* displayableNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(displayNode->GetDisplayableNode());
+    if (!displayableNode)
+      {
+      return false;
+      }
+    d->activeMarkupMRMLNodeComboBox->setCurrentNode(displayableNode);
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerMarkupsModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLMarkupsFiducialNode::SafeDownCast(node)
+    || vtkMRMLMarkupsDisplayNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else if (node->IsA("vtkMRMLAnnotationFiducialNode"))
+    {
+    // The module cannot directly edit this type of node but can convert it
+    return 0.1;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
@@ -89,6 +89,9 @@ public:
   /// the slice composite nodes
   bool sliceIntersectionsVisible();
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 public slots:
 
   /// Respond to the scene events

--- a/Modules/Loadable/Models/SubjectHierarchyPlugins/qSlicerSubjectHierarchyModelsPlugin.cxx
+++ b/Modules/Loadable/Models/SubjectHierarchyPlugins/qSlicerSubjectHierarchyModelsPlugin.cxx
@@ -169,23 +169,6 @@ QIcon qSlicerSubjectHierarchyModelsPlugin::visibilityIcon(int visible)
   return qSlicerSubjectHierarchyPluginHandler::instance()->defaultPlugin()->visibilityIcon(visible);
 }
 
-//---------------------------------------------------------------------------
-void qSlicerSubjectHierarchyModelsPlugin::editProperties(vtkMRMLSubjectHierarchyNode* node)
-{
-  // Switch to models module
-  qSlicerAbstractModuleWidget* moduleWidget = qSlicerSubjectHierarchyAbstractPlugin::switchToModule("Models");
-  if (moduleWidget)
-    {
-    // Get filter search box
-    QLineEdit* searchBox = moduleWidget->findChild<QLineEdit*>("ScrollToModelSearchBox");
-    if (searchBox && node->GetAssociatedNode())
-      {
-      // Enter node name in the filter box to select it
-      searchBox->setText(node->GetAssociatedNode()->GetName());
-      }
-    }
-}
-
 //-----------------------------------------------------------------------------
 QString qSlicerSubjectHierarchyModelsPlugin::tooltip(vtkMRMLSubjectHierarchyNode* node)const
 {

--- a/Modules/Loadable/Models/SubjectHierarchyPlugins/qSlicerSubjectHierarchyModelsPlugin.h
+++ b/Modules/Loadable/Models/SubjectHierarchyPlugins/qSlicerSubjectHierarchyModelsPlugin.h
@@ -78,9 +78,6 @@ public:
   /// Get visibility icon for a visibility state
   virtual QIcon visibilityIcon(int visible);
 
-  /// Open module belonging to node and set inputs in opened module
-  virtual void editProperties(vtkMRMLSubjectHierarchyNode* node);
-
   /// Generate tooltip for a owned subject hierarchy node
   virtual QString tooltip(vtkMRMLSubjectHierarchyNode* node)const;
 

--- a/Modules/Loadable/Models/qSlicerModelsModule.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsModule.cxx
@@ -167,6 +167,11 @@ void qSlicerModelsModule::setup()
 
   // Register Subject Hierarchy core plugins
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyModelsPlugin());
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLModelNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLModelDisplayNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLModelHierarchyNode", this->name());
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Models/qSlicerModelsModuleWidget.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsModuleWidget.cxx
@@ -37,6 +37,7 @@
 #include "vtkSlicerModelsLogic.h"
 
 // MRML includes
+#include "vtkMRMLModelNode.h"
 #include "vtkMRMLModelHierarchyNode.h"
 #include "vtkMRMLModelDisplayNode.h"
 #include "vtkMRMLSelectionNode.h"
@@ -561,4 +562,44 @@ void qSlicerModelsModuleWidget::updateWidgetFromSelectionNode()
       }
     }
   d->ModelDisplayWidget->setMRMLModelOrHierarchyNode(d->ModelDisplayWidget->mrmlDisplayableNode());
+}
+
+//-----------------------------------------------------------
+bool qSlicerModelsModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerModelsModuleWidget);
+  if (vtkMRMLModelNode::SafeDownCast(node) || vtkMRMLModelHierarchyNode::SafeDownCast(node))
+    {
+    d->ModelHierarchyTreeView->setCurrentNode(node);
+    return true;
+    }
+
+  if (vtkMRMLModelDisplayNode::SafeDownCast(node))
+    {
+    vtkMRMLModelDisplayNode* displayNode = vtkMRMLModelDisplayNode::SafeDownCast(node);
+    vtkMRMLModelNode* displayableNode = vtkMRMLModelNode::SafeDownCast(displayNode->GetDisplayableNode());
+    if (!displayableNode)
+      {
+      return false;
+      }
+    d->ModelHierarchyTreeView->setCurrentNode(displayableNode);
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerModelsModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLModelNode::SafeDownCast(node)
+    || vtkMRMLModelDisplayNode::SafeDownCast(node)
+    || vtkMRMLModelHierarchyNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
 }

--- a/Modules/Loadable/Models/qSlicerModelsModuleWidget.h
+++ b/Modules/Loadable/Models/qSlicerModelsModuleWidget.h
@@ -45,6 +45,9 @@ public:
 
   vtkMRMLSelectionNode* getSelectionNode();
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 public slots:
   virtual void setMRMLScene(vtkMRMLScene* scene);
 

--- a/Modules/Loadable/Reformat/qSlicerReformatModule.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModule.cxx
@@ -21,6 +21,9 @@
 // Qt includes
 #include <QtPlugin>
 
+// QTGUI includes
+#include "qSlicerApplication.h"
+
 // Reformat Logic includes
 #include <vtkSlicerReformatLogic.h>
 
@@ -110,6 +113,10 @@ QStringList qSlicerReformatModule::contributors()const
 void qSlicerReformatModule::setup()
 {
   this->Superclass::setup();
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLSliceNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLSliceCompositeNode", this->name());
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
@@ -725,3 +725,42 @@ void qSlicerReformatModuleWidget::centerSliceNode()
   // Apply the center
   reformatLogic->SetSliceOrigin(d->MRMLSliceNode, center);
 }
+
+//-----------------------------------------------------------
+bool qSlicerReformatModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerReformatModuleWidget);
+
+  if (vtkMRMLSliceNode::SafeDownCast(node))
+    {
+    d->SliceNodeSelector->setCurrentNode(node);
+    return true;
+    }
+
+  if (vtkMRMLSliceCompositeNode::SafeDownCast(node))
+    {
+    vtkMRMLSliceCompositeNode* sliceCompositeNode = vtkMRMLSliceCompositeNode::SafeDownCast(node);
+    vtkMRMLSliceNode* sliceNode = vtkMRMLSliceLogic::GetSliceNode(sliceCompositeNode);
+    if (!sliceNode)
+      {
+      return false;
+      }
+    d->SliceNodeSelector->setCurrentNode(sliceNode);
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerReformatModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLSliceNode::SafeDownCast(node) || vtkMRMLSliceCompositeNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.h
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.h
@@ -46,6 +46,9 @@ public:
   /// Utility function that sets the normal of the slice plane.
   void setSliceNormal(double x, double y, double z);
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 protected:
   virtual void setup();
 

--- a/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleWidget.cxx
+++ b/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleWidget.cxx
@@ -552,3 +552,29 @@ void qSlicerSceneViewsModuleWidget::showSceneViewDialog()
   d->sceneViewDialog()->exec();
 }
 
+//-----------------------------------------------------------
+bool qSlicerSceneViewsModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerSceneViewsModuleWidget);
+  if (vtkMRMLSceneViewNode::SafeDownCast(node))
+    {
+    // Scene view is a webview and does not support selection
+    // TODO: change the webview to a native view (webview looks quite bad anyway, especially on high-DPI screens)
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerSceneViewsModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLSceneViewNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleWidget.h
+++ b/Modules/Loadable/SceneViews/GUI/qSlicerSceneViewsModuleWidget.h
@@ -34,6 +34,9 @@ public:
   /// Disconnect from scene when exiting
   virtual void exit();
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 public slots:
     /// a public slot allowing other modules to open up the scene view capture
     /// dialog (get the module manager, get the module sceneviews, get the

--- a/Modules/Loadable/SceneViews/SubjectHierarchyPlugins/qSlicerSubjectHierarchySceneViewsPlugin.cxx
+++ b/Modules/Loadable/SceneViews/SubjectHierarchyPlugins/qSlicerSubjectHierarchySceneViewsPlugin.cxx
@@ -165,15 +165,6 @@ QIcon qSlicerSubjectHierarchySceneViewsPlugin::icon(vtkMRMLSubjectHierarchyNode*
 }
 
 //---------------------------------------------------------------------------
-void qSlicerSubjectHierarchySceneViewsPlugin::editProperties(vtkMRMLSubjectHierarchyNode* node)
-{
-  Q_UNUSED(node);
-
-  // Switch to scene views module
-  qSlicerSubjectHierarchyAbstractPlugin::switchToModule("SceneViews");
-}
-
-//---------------------------------------------------------------------------
 QList<QAction*> qSlicerSubjectHierarchySceneViewsPlugin::nodeContextMenuActions()const
 {
   Q_D(const qSlicerSubjectHierarchySceneViewsPlugin);

--- a/Modules/Loadable/SceneViews/SubjectHierarchyPlugins/qSlicerSubjectHierarchySceneViewsPlugin.h
+++ b/Modules/Loadable/SceneViews/SubjectHierarchyPlugins/qSlicerSubjectHierarchySceneViewsPlugin.h
@@ -75,9 +75,6 @@ public:
   /// \return Icon to set, NULL if nothing to set
   virtual QIcon icon(vtkMRMLSubjectHierarchyNode* node);
 
-  /// Open module belonging to node and set inputs in opened module
-  virtual void editProperties(vtkMRMLSubjectHierarchyNode* node);
-
   /// Get node context menu item actions to add to tree view
   Q_INVOKABLE virtual QList<QAction*> nodeContextMenuActions()const;
 

--- a/Modules/Loadable/SceneViews/qSlicerSceneViewsModule.cxx
+++ b/Modules/Loadable/SceneViews/qSlicerSceneViewsModule.cxx
@@ -51,6 +51,9 @@ void qSlicerSceneViewsModule::setup()
   // Register Subject Hierarchy core plugins
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(
     new qSlicerSubjectHierarchySceneViewsPlugin());
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLSceneViewNode", this->name());
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
@@ -117,9 +117,7 @@ QIcon qSlicerSubjectHierarchyAbstractPlugin::visibilityIcon(int visible)
 //---------------------------------------------------------------------------
 void qSlicerSubjectHierarchyAbstractPlugin::editProperties(vtkMRMLSubjectHierarchyNode* node)
 {
-  Q_UNUSED(node);
-
-  // If there is no role, no edit properties action is needed
+  qSlicerApplication::application()->openNodeModule(node->GetAssociatedNode());
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.cxx
@@ -170,10 +170,3 @@ QIcon qSlicerSubjectHierarchyDefaultPlugin::visibilityIcon(int visible)
     return QIcon();
     }
 }
-
-//---------------------------------------------------------------------------
-void qSlicerSubjectHierarchyDefaultPlugin::editProperties(vtkMRMLSubjectHierarchyNode* node)
-{
-  Q_UNUSED(node);
-  // No role, no edit properties
-}

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.h
@@ -72,9 +72,6 @@ public:
   /// Get visibility icon for a visibility state
   virtual QIcon visibilityIcon(int visible);
 
-  /// Open module belonging to node and set inputs in opened module
-  virtual void editProperties(vtkMRMLSubjectHierarchyNode* node);
-
 public:
   /// Set default visibility icons owned by the scene model so that the default plugin can set them
   void setDefaultVisibilityIcons(QIcon visibleIcon, QIcon hiddenIcon, QIcon partiallyVisibleIcon);

--- a/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.cxx
+++ b/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.cxx
@@ -302,24 +302,6 @@ int qSlicerSubjectHierarchyTablesPlugin::getDisplayVisibility(vtkMRMLSubjectHier
 }
 
 //---------------------------------------------------------------------------
-void qSlicerSubjectHierarchyTablesPlugin::editProperties(vtkMRMLSubjectHierarchyNode* node)
-{
-  // Switch to tables module and select transform
-  qSlicerAbstractModuleWidget* moduleWidget = qSlicerSubjectHierarchyAbstractPlugin::switchToModule("Tables");
-  if (moduleWidget)
-    {
-    // Get node selector combobox
-    qMRMLNodeComboBox* nodeSelector = moduleWidget->findChild<qMRMLNodeComboBox*>("TableNodeSelector");
-
-    // Choose current data node
-    if (nodeSelector)
-      {
-      nodeSelector->setCurrentNode(node->GetAssociatedNode());
-      }
-    }
-}
-
-//---------------------------------------------------------------------------
 vtkMRMLTableViewNode* qSlicerSubjectHierarchyTablesPlugin::getTableViewNode()const
 {
   vtkMRMLScene* scene = qSlicerSubjectHierarchyPluginHandler::instance()->scene();

--- a/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.h
+++ b/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.h
@@ -79,9 +79,6 @@ public:
   /// Get visibility icon for a visibility state
   virtual QIcon visibilityIcon(int visible);
 
-  /// Open module belonging to node and set inputs in opened module
-  virtual void editProperties(vtkMRMLSubjectHierarchyNode* node);
-
   /// Set display visibility of a owned subject hierarchy node
   virtual void setDisplayVisibility(vtkMRMLSubjectHierarchyNode* node, int visible);
 

--- a/Modules/Loadable/Tables/qSlicerTablesModule.cxx
+++ b/Modules/Loadable/Tables/qSlicerTablesModule.cxx
@@ -24,7 +24,7 @@
 #include <QtPlugin>
 
 // Slice includes
-#include <qSlicerCoreApplication.h>
+#include <qSlicerApplication.h>
 #include <qSlicerCoreIOManager.h>
 #include <qSlicerNodeWriter.h>
 
@@ -131,6 +131,8 @@ void qSlicerTablesModule::setup()
     QStringList() << "vtkMRMLTableNode", false, this));
   // Register Subject Hierarchy core plugins
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyTablesPlugin());
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLTableNode", this->name());
 }
 
 

--- a/Modules/Loadable/Tables/qSlicerTablesModuleWidget.cxx
+++ b/Modules/Loadable/Tables/qSlicerTablesModuleWidget.cxx
@@ -232,3 +232,28 @@ void qSlicerTablesModuleWidget::setCurrentTableNode(vtkMRMLNode* tableNode)
   Q_D(qSlicerTablesModuleWidget);
   d->TableNodeSelector->setCurrentNode(tableNode);
 }
+
+//-----------------------------------------------------------
+bool qSlicerTablesModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerTablesModuleWidget);
+  if (vtkMRMLTableNode::SafeDownCast(node))
+    {
+    d->TableNodeSelector->setCurrentNode(node);
+    return true;
+    }
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerTablesModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLTableNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Modules/Loadable/Tables/qSlicerTablesModuleWidget.h
+++ b/Modules/Loadable/Tables/qSlicerTablesModuleWidget.h
@@ -44,6 +44,9 @@ public:
   qSlicerTablesModuleWidget(QWidget *parent=0);
   virtual ~qSlicerTablesModuleWidget();
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 public slots:
   /// Select the specified node as the current node in the user interface
   void setCurrentTableNode(vtkMRMLNode*);

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
@@ -241,24 +241,6 @@ void qSlicerSubjectHierarchyTransformsPlugin::showContextMenuActionsForNode(vtkM
 }
 
 //---------------------------------------------------------------------------
-void qSlicerSubjectHierarchyTransformsPlugin::editProperties(vtkMRMLSubjectHierarchyNode* node)
-{
-  // Switch to transforms module and select transform
-  qSlicerAbstractModuleWidget* moduleWidget = qSlicerSubjectHierarchyAbstractPlugin::switchToModule("Transforms");
-  if (moduleWidget)
-    {
-    // Get node selector combobox
-    qMRMLNodeComboBox* nodeSelector = moduleWidget->findChild<qMRMLNodeComboBox*>("TransformNodeSelector");
-
-    // Choose current data node
-    if (nodeSelector)
-      {
-      nodeSelector->setCurrentNode(node->GetAssociatedNode());
-      }
-    }
-}
-
-//---------------------------------------------------------------------------
 void qSlicerSubjectHierarchyTransformsPlugin::invert()
 {
   vtkMRMLSubjectHierarchyNode* currentNode = qSlicerSubjectHierarchyPluginHandler::instance()->currentNode();

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.h
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.h
@@ -78,9 +78,6 @@ public:
   /// Get visibility icon for a visibility state
   virtual QIcon visibilityIcon(int visible);
 
-  /// Open module belonging to node and set inputs in opened module
-  virtual void editProperties(vtkMRMLSubjectHierarchyNode* node);
-
   /// Generate tooltip for a owned subject hierarchy node
   virtual QString tooltip(vtkMRMLSubjectHierarchyNode* node)const;
 

--- a/Modules/Loadable/Transforms/qSlicerTransformsModule.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModule.cxx
@@ -158,4 +158,8 @@ void qSlicerTransformsModule::setup()
 
   // Register Subject Hierarchy core plugins
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyTransformsPlugin());
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLTransformNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLTransformDisplayNode", this->name());
 }

--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
@@ -614,3 +614,41 @@ void qSlicerTransformsModuleWidget::updateConvertButtonState()
     d->ConvertMagnitudeOnlyCheckBox->setChecked(false);
     }
 }
+
+//-----------------------------------------------------------
+bool qSlicerTransformsModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerTransformsModuleWidget);
+  if (vtkMRMLTransformNode::SafeDownCast(node))
+    {
+    d->TransformNodeSelector->setCurrentNode(node);
+    return true;
+    }
+
+  if (vtkMRMLTransformDisplayNode::SafeDownCast(node))
+    {
+    vtkMRMLTransformDisplayNode* displayNode = vtkMRMLTransformDisplayNode::SafeDownCast(node);
+    vtkMRMLTransformNode* displayableNode = vtkMRMLTransformNode::SafeDownCast(displayNode->GetDisplayableNode());
+    if (!displayableNode)
+      {
+      return false;
+      }
+    d->TransformNodeSelector->setCurrentNode(displayableNode);
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerTransformsModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLTransformNode::SafeDownCast(node) || vtkMRMLTransformDisplayNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
+    }
+}

--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.h
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.h
@@ -45,6 +45,9 @@ public:
   /// Reimplemented for internal reasons
   void setMRMLScene(vtkMRMLScene* scene);
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 public slots:
 
   /// Set the transform to identity. Only for linear transforms.

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
@@ -57,6 +57,9 @@ public:
   void addRenderingMethodWidget(const QString& methodClassName,
                                 qSlicerVolumeRenderingPropertiesWidget* widget);
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 public slots:
 
   /// Set the MRML node of interest

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
@@ -150,6 +150,11 @@ void qSlicerVolumeRenderingModule::setup()
   coreIOManager->registerIO(new qSlicerNodeWriter(
     "Transfer Function", QString("TransferFunctionFile"),
     QStringList() << "vtkMRMLVolumePropertyNode", true, this));
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLVolumePropertyNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLVolumeRenderingDisplayNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLAnnotationROINode", this->name()); // clipping box
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyLabelMapsPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyLabelMapsPlugin.cxx
@@ -452,21 +452,3 @@ void qSlicerSubjectHierarchyLabelMapsPlugin::toggleLabelmapOutlineDisplay(bool c
     sliceNode->SetUseLabelOutline(checked);
     }
 }
-
-//---------------------------------------------------------------------------
-void qSlicerSubjectHierarchyLabelMapsPlugin::editProperties(vtkMRMLSubjectHierarchyNode* node)
-{
-  // Switch to volumes module and volume already selected
-  qSlicerAbstractModuleWidget* moduleWidget = qSlicerSubjectHierarchyAbstractPlugin::switchToModule("Volumes");
-  if (moduleWidget)
-    {
-    // Get node selector combobox
-    qMRMLNodeComboBox* nodeSelector = moduleWidget->findChild<qMRMLNodeComboBox*>("ActiveVolumeNodeSelector");
-
-    // Choose current data node
-    if (nodeSelector)
-      {
-      nodeSelector->setCurrentNode(node->GetAssociatedNode());
-      }
-    }
-}

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyLabelMapsPlugin.h
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyLabelMapsPlugin.h
@@ -79,9 +79,6 @@ public:
   /// Get visibility icon for a visibility state
   virtual QIcon visibilityIcon(int visible);
 
-  /// Open module belonging to node and set inputs in opened module
-  virtual void editProperties(vtkMRMLSubjectHierarchyNode* node);
-
   /// Generate tooltip for a owned subject hierarchy node
   virtual QString tooltip(vtkMRMLSubjectHierarchyNode* node)const;
 

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
@@ -598,21 +598,3 @@ void qSlicerSubjectHierarchyVolumesPlugin::showVolumesInBranch()
     }
 
 }
-
-//---------------------------------------------------------------------------
-void qSlicerSubjectHierarchyVolumesPlugin::editProperties(vtkMRMLSubjectHierarchyNode* node)
-{
-  // Switch to volumes module and volume already selected
-  qSlicerAbstractModuleWidget* moduleWidget = qSlicerSubjectHierarchyAbstractPlugin::switchToModule("Volumes");
-  if (moduleWidget)
-    {
-    // Get node selector combobox
-    qMRMLNodeComboBox* nodeSelector = moduleWidget->findChild<qMRMLNodeComboBox*>("ActiveVolumeNodeSelector");
-
-    // Choose current data node
-    if (nodeSelector)
-      {
-      nodeSelector->setCurrentNode(node->GetAssociatedNode());
-      }
-    }
-}

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
@@ -79,9 +79,6 @@ public:
   /// Get visibility icon for a visibility state
   virtual QIcon visibilityIcon(int visible);
 
-  /// Open module belonging to node and set inputs in opened module
-  virtual void editProperties(vtkMRMLSubjectHierarchyNode* node);
-
   /// Generate tooltip for a owned subject hierarchy node
   virtual QString tooltip(vtkMRMLSubjectHierarchyNode* node)const;
 

--- a/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
@@ -155,6 +155,10 @@ void qSlicerVolumesModule::setup()
   // Register Subject Hierarchy core plugins
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyVolumesPlugin());
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(new qSlicerSubjectHierarchyLabelMapsPlugin());
+
+  // Register module for "Edit node" action
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLVolumeNode", this->name());
+  qSlicerApplication::application()->registerNodeModule("vtkMRMLVolumeDisplayNode", this->name());
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.cxx
@@ -26,6 +26,7 @@
 // MRML includes
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLLabelMapVolumeNode.h>
+#include <vtkMRMLVolumeDisplayNode.h>
 
 // Volumes includes
 #include "qSlicerVolumesModuleWidget.h"
@@ -141,5 +142,44 @@ void qSlicerVolumesModuleWidget::convertToLabelmap()
     {
     d->ActiveVolumeNodeSelector->setCurrentNode(targetLabelMapNode);
     this->mrmlScene()->RemoveNode(currentScalarVolumeNode);
+    }
+}
+
+//-----------------------------------------------------------
+bool qSlicerVolumesModuleWidget::setEditedNode(vtkMRMLNode* node, QString role /* = QString()*/, QString context /* = QString() */)
+{
+  Q_D(qSlicerVolumesModuleWidget);
+  if (vtkMRMLVolumeNode::SafeDownCast(node))
+    {
+    d->ActiveVolumeNodeSelector->setCurrentNode(node);
+    return true;
+    }
+
+  if (vtkMRMLVolumeDisplayNode::SafeDownCast(node))
+    {
+    vtkMRMLVolumeDisplayNode* displayNode = vtkMRMLVolumeDisplayNode::SafeDownCast(node);
+    vtkMRMLVolumeNode* displayableNode = vtkMRMLVolumeNode::SafeDownCast(displayNode->GetDisplayableNode());
+    if (!displayableNode)
+      {
+      return false;
+      }
+    d->ActiveVolumeNodeSelector->setCurrentNode(displayableNode);
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------
+double qSlicerVolumesModuleWidget::nodeEditable(vtkMRMLNode* node)
+{
+  if (vtkMRMLVolumeNode::SafeDownCast(node)
+    || vtkMRMLVolumeDisplayNode::SafeDownCast(node))
+    {
+    return 0.5;
+    }
+  else
+    {
+    return 0.0;
     }
 }

--- a/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.h
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModuleWidget.h
@@ -41,6 +41,9 @@ public:
   qSlicerVolumesModuleWidget(QWidget *parent=0);
   virtual ~qSlicerVolumesModuleWidget();
 
+  virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
+  virtual double nodeEditable(vtkMRMLNode* node);
+
 protected:
   virtual void setup();
 


### PR DESCRIPTION
Fixes http://www.na-mic.org/Bug/view.php?id=2109

Now any module can associate a MRML node type with a module (instead of having a hardcoded list of modules
in qSlicerApplication) and when switching to a module, the chosen node is selected as active node.
Associations can be added by calling qSlicerApplication::registerNodeModule().
Multiple modules can be associated with the same MRML node type.

The best module for a specific node instance is determined run-time, by calling
qSlicerAbstractModuleWidget::nodeEditable() for each candidate and choosing
the one that has the highest confidence in handling the node.
This mechanism is used for selecting the CLI module that corresponds to a specific CLI module parameter node.
This mechanism is also used for switching to volume rendering module if a volume rendering clipping ROI node
is selected for editing (instead of switching to the Annotations module).
The most suitable module's qSlicerAbstractModuleWidget::setEditedNode() method is called to select the currently edited node.
qSlicerAbstractModuleWidget::nodeEditable() and qSlicerAbstractModuleWidget::setEditedNode() methods can be overridden
in scripted loadable modules as well.

As edited node selection is now possible using a clean, unified method call, it is no longer necessary
to access GUI widgets directly. Therefore, almost all editProperties() method calls in subject hierarchy plugins were
removed (replaced by a common implementation in the base class). This new, simplified method fixes robustness issues
of using node name filters for selecting a node in model hierarchy, inability to choose annotation hierarchy nodes, etc.

qSlicerAbstractModuleWidget::setEditedNode(vtkMRMLNode* node, QString role, QString context) has two extra (optional)
arguments. Role can be used to specify additional nodes for a module (e.g., if there are multiple inputs for a module
then role argument can select between them). Context can be used for specifying a sub-selection within a node (for
example, Segment Editor module can be activated for a selected segment - specified by 'context' - of a specific
segmentation node - specified by 'node').