### PR TITLE
ENH: Hide symbols in the CLI modules.

### DIFF
--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -54,7 +54,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/Slicer/SlicerExecutionModel.git"
-    GIT_TAG "311eff9038be165c1341dab90196fbd7466e715a"
+    GIT_TAG "112076be4f7ee59cc67099f12f2c4c16719070da"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
Update SlicerExecutionModule to incorporate
Slicer/SlicerExecutionModel@8d607ff93a3be76274d9cedfb9f1148a6cdb6968
which hides non-CLI symbols so only ModuleEntryPoint, etc. are available in
the CLI shared libraries.

This results in the following `lib/Slicer-4.5/cli-modules` size improvements,
Slicer start-up time improvements, and reduction in
GradientAnisotropicDiffusionLib symbols:

```
                     MinSizeRel: no hidden | MinSizeRel: hidden | Release: no hidden | Release: hidden
                     ---------------------------------------------------------------------------------
size (MB)             104                     89                   119                 107
start-up time (sec)   20.2                    16.2                 20.0                18.7
example cli symbols   2593                    328                  2342                322
```  