### PR TITLE
Add builds of pull requests via CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,14 @@ machine:
     - docker
 
 dependencies:
+  cache_directories:
+        - "~/docker"
+
   override:
     - docker info
+    - if [[ -e ~/docker/image.tar ]]; then docker load -i ~/docker/image.tar; fi
     - docker pull slicer/slicer-build-deps
+    - mkdir -p ~/docker; docker save slicer/slicer-build-deps > ~/docker/image.tar
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -17,4 +17,5 @@ dependencies:
 test:
   override:
     - "git diff --name-only master | grep -q SuperBuild > /dev/null || echo 'Notice: TravisCI does not build changes to Slicer dependencies'"
-    - docker run -e "BUILD_TOOL_FLAGS=-j5" --rm -v ~/Slicer:/usr/src/Slicer slicer/slicer-build-deps
+    - docker run -e "BUILD_TOOL_FLAGS=-j5" --name slicer -v ~/Slicer:/usr/src/Slicer slicer/slicer-build-deps
+    - docker cp slicer:$(docker cp slicer:/usr/src/Slicer-build/Slicer-build/PACKAGE_FILE.txt - | tar xO) $CIRCLE_ARTIFACTS

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+  pre:
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker info
+    - docker pull slicer/slicer-build-deps
+
+test:
+  override:
+    - "git diff --name-only master | grep -q SuperBuild > /dev/null || echo 'Notice: TravisCI does not build changes to Slicer dependencies'"
+    - docker run -e "BUILD_TOOL_FLAGS=-j5" --rm -v ~/Slicer:/usr/src/Slicer slicer/slicer-build-deps


### PR DESCRIPTION
Pull requests are built with CircleCI. Slicer itself is built against a Docker image with Slicer's dependencies to reduce build time. If a change to dependency ExternalProject's are made, the build intentionally fails. The resulting package is made available as a CircleCI artifact.