### PR TITLE
More large scene optimizations

### DIFF
--- a/Libs/MRML/Core/Testing/vol_and_cube.mrml
+++ b/Libs/MRML/Core/Testing/vol_and_cube.mrml
@@ -1,12 +1,15 @@
 <MRML>
 
 <Selection
-  id="vtkMRMLSelectionNodeSingleton" name="vtkMRMLSelectionNode1" hideFromEditors="true"
-  activeVolumeID="vtkMRMLScalarVolumeNode1" activeLayoutID="vtkMRMLLayoutNode1">
+  id="vtkMRMLSelectionNodeSingleton" name="Selection" hideFromEditors="true"
+  activeVolumeID="vtkMRMLScalarVolumeNode1" activeLayoutID="vtkMRMLLayoutNode1"
+  singletonTag="Singleton"
+  >
 </Selection>
 <Interaction
-  id="vtkMRMLInteractionNodeSingleton" name="vtkMRMLInteractionNode1" hideFromEditors="true"
-  currentInteractionMode="ViewTransform" lastInteractionMode="ViewTransform">
+  id="vtkMRMLInteractionNodeSingleton" name="Interaction" hideFromEditors="true"
+  currentInteractionMode="ViewTransform" lastInteractionMode="ViewTransform"
+  singletonTag="Singleton">
 </Interaction>
 
 <Slice

--- a/Libs/MRML/Widgets/qMRMLSceneModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneModel.cxx
@@ -1153,6 +1153,14 @@ void qMRMLSceneModel::onMRMLSceneEvent(vtkObject* vtk_obj, unsigned long event,
   vtkMRMLNode* node = reinterpret_cast<vtkMRMLNode*>(call_data);
   Q_ASSERT(scene);
   Q_ASSERT(sceneModel);
+
+  // we don't care about importing events. we will
+  // repopulate entire scenemodel at EndImportEvent.
+  if (event != vtkMRMLScene::EndImportEvent && scene->IsImporting())
+    {
+    return;
+    }
+
   switch(event)
     {
     case vtkMRMLScene::NodeAboutToBeAddedEvent:
@@ -1499,7 +1507,6 @@ bool qMRMLSceneModel::isANode(const QStandardItem * item)const
 void qMRMLSceneModel::onMRMLSceneAboutToBeImported(vtkMRMLScene* scene)
 {
   Q_UNUSED(scene);
-  //this->beginResetModel();
 }
 
 //------------------------------------------------------------------------------
@@ -1507,11 +1514,8 @@ void qMRMLSceneModel::onMRMLSceneImported(vtkMRMLScene* scene)
 {
   Q_D(qMRMLSceneModel);
   Q_UNUSED(scene);
-  if (d->LazyUpdate)
-    {
-    this->updateScene();
-    }
-  //this->endResetModel();
+  this->updateScene();
+  emit sceneUpdated();
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSceneModel.h
+++ b/Libs/MRML/Widgets/qMRMLSceneModel.h
@@ -124,6 +124,8 @@ public:
   Q_INVOKABLE virtual void setMRMLScene(vtkMRMLScene* scene);
   Q_INVOKABLE vtkMRMLScene* mrmlScene()const;
 
+  virtual void updateScene();
+
   /// 0 until a valid scene is set
   QStandardItem* mrmlSceneItem()const;
 
@@ -266,7 +268,6 @@ protected:
 
   qMRMLSceneModel(qMRMLSceneModelPrivate* pimpl, QObject *parent=0);
 
-  virtual void updateScene();
   virtual void populateScene();
   virtual QStandardItem* insertNode(vtkMRMLNode* node);
   virtual QStandardItem* insertNode(vtkMRMLNode* node, QStandardItem* parent, int row = -1);

--- a/Modules/Loadable/Models/qSlicerModelsModuleWidget.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsModuleWidget.cxx
@@ -547,14 +547,9 @@ void qSlicerModelsModuleWidget::updateWidgetFromSelectionNode()
 
   if (include)
     {
-    // force update mrml widgets
-    std::vector<vtkMRMLNode *> nodes;
-    vtkMRMLScene *scene = this->mrmlScene();
-    scene->GetNodesByClass(displayNodeClass.c_str(), nodes);
-    for (unsigned int i = 0; i < nodes.size(); i++)
-      {
-      nodes[i]->InvokeEvent(vtkCommand::ModifiedEvent);
-      }
+    // invoke batch scenemodel update. triggering modified on each model
+    // node is extremely expensive with larger scenes.
+    d->ModelHierarchyTreeView->sceneModel()->updateScene();
     }
   d->ModelDisplayWidget->setMRMLModelOrHierarchyNode(d->ModelDisplayWidget->mrmlDisplayableNode());
 }


### PR DESCRIPTION
Follow-up to https://github.com/Slicer/Slicer/pull/489
For same large scene (1200 models):
- Reduces scene-loading time to ~4 minutes.
- Reduces delay when switching to Models module from 3 min to ~5s.
- Reduces delay when enabling "Include Fibers" option from 3 min to <5s.
- Reduces delay when changing visibility of all models from "very slow" to "usable" (few seconds)

All the tests pass (locally) except for: `py_BRAINSFitRigidRegistrationCrashIssue4139`, `vtkMRMLNonlinearTransformNodeTest1`, and `qSlicerSslTest`.

The SSL one is known on buildbots, and I believe the other two are ITK linking issues specific to this build toolchain ([mailing list](http://slicer-devel.65872.n3.nabble.com/Empty-deformable-transforms-with-Mac-build-td4036248.html)).

cc @ljod 
