### PR TITLE
Improve startup time

### DIFF
--- a/Applications/SlicerApp/Testing/Python/MeasureStartupTimes.py
+++ b/Applications/SlicerApp/Testing/Python/MeasureStartupTimes.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+import time
+
+"""
+Usage:
+    MeasureStartupTimes.py /path/to/Slicer
+"""
+
+EXIT_FAILURE=1
+EXIT_SUCCESS=0
+
+def run(slicer, command):
+    start = time.time()
+    args = ['--no-splash', '--exit-after-startup']
+    args.extend(command)
+    print("%s %s" % (os.path.basename(slicer), " ".join(args)))
+    args.insert(0, slicer)
+    p = subprocess.Popen(args=args, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+
+    if p.returncode != EXIT_SUCCESS:
+        print('STDOUT: ' + stdout)
+        print('STDERR: ' + stderr)
+
+    print("{:.3f} seconds".format(time.time() - start))
+    print("")
+
+if __name__ == '__main__':
+
+    if len(sys.argv) != 2:
+        print(os.path.basename(sys.argv[0]) +" /path/to/Slicer")
+        exit(EXIT_FAILURE)
+
+    slicer = os.path.expanduser(sys.argv[1])
+
+    tests = [
+        [],
+        ['--disable-builtin-cli-modules'],
+        ['--disable-builtin-loadable-modules'],
+        ['--disable-builtin-scripted-loadable-modules'],
+        ['--disable-builtin-cli-modules', '--disable-builtin-scripted-loadable-modules'],
+        ['--disable-modules']
+    ]
+
+    for test in tests:
+        run(slicer, test)
+
+    for test in tests:
+        test.insert(0, '--disable-python')
+        run(slicer, test)
+

--- a/Base/QTCLI/qSlicerCLIExecutableModuleFactory.cxx
+++ b/Base/QTCLI/qSlicerCLIExecutableModuleFactory.cxx
@@ -49,6 +49,26 @@ qSlicerAbstractCoreModule* qSlicerCLIExecutableModuleFactoryItem::instanciator()
   module->setModuleType("CommandLineModule");
   module->setEntryPoint(this->path());
 
+  QString xmlDescription = this->runCLIWithXmlArgument();
+  if (xmlDescription.isEmpty())
+    {
+    return 0;
+    }
+
+  module->setXmlModuleDescription(xmlDescription.toLatin1());
+  module->setTempDirectory(this->TempDirectory);
+  module->setPath(this->path());
+  module->setInstalled(qSlicerCLIModuleFactoryHelper::isInstalled(this->path()));
+  module->setBuiltIn(qSlicerCLIModuleFactoryHelper::isBuiltIn(this->path()));
+
+  this->CLIModule = module.data();
+
+  return module.take();
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCLIExecutableModuleFactoryItem::runCLIWithXmlArgument()
+{
   ctkScopedCurrentDir scopedCurrentDir(QFileInfo(this->path()).path());
 
   int cliProcessTimeoutInMs = 5000;
@@ -112,7 +132,7 @@ qSlicerAbstractCoreModule* qSlicerCLIExecutableModuleFactoryItem::instanciator()
     {
     this->appendInstantiateErrorString(QString("CLI executable: %1").arg(this->path()));
     this->appendInstantiateErrorString("Failed to retrieve Xml Description");
-    return 0;
+    return QString();
     }
   if (!xmlDescription.startsWith("<?xml"))
     {
@@ -122,16 +142,7 @@ qSlicerAbstractCoreModule* qSlicerCLIExecutableModuleFactoryItem::instanciator()
                                            xmlDescription.mid(0, xmlDescription.indexOf("<?xml"))));
     xmlDescription.remove(0, xmlDescription.indexOf("<?xml"));
     }
-
-  module->setXmlModuleDescription(xmlDescription.toLatin1());
-  module->setTempDirectory(this->TempDirectory);
-  module->setPath(this->path());
-  module->setInstalled(qSlicerCLIModuleFactoryHelper::isInstalled(this->path()));
-  module->setBuiltIn(qSlicerCLIModuleFactoryHelper::isBuiltIn(this->path()));
-
-  this->CLIModule = module.data();
-
-  return module.take();
+  return xmlDescription;
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCLI/qSlicerCLIExecutableModuleFactory.h
+++ b/Base/QTCLI/qSlicerCLIExecutableModuleFactory.h
@@ -39,6 +39,9 @@ public:
   virtual bool load();
   virtual void uninstantiate();
 protected:
+  /// Return path of the expected XML file.
+  QString xmlModuleDescriptionFilePath();
+
   virtual qSlicerAbstractCoreModule* instanciator();
   QString runCLIWithXmlArgument();
 private:

--- a/Base/QTCLI/qSlicerCLIExecutableModuleFactory.h
+++ b/Base/QTCLI/qSlicerCLIExecutableModuleFactory.h
@@ -40,6 +40,7 @@ public:
   virtual void uninstantiate();
 protected:
   virtual qSlicerAbstractCoreModule* instanciator();
+  QString runCLIWithXmlArgument();
 private:
   QString TempDirectory;
   qSlicerCLIModule* CLIModule;

--- a/Base/QTCLI/qSlicerCLILoadableModuleFactory.h
+++ b/Base/QTCLI/qSlicerCLILoadableModuleFactory.h
@@ -41,7 +41,15 @@ class qSlicerCLILoadableModuleFactoryItem
 public:
   typedef ctkFactoryLibraryItem<qSlicerAbstractCoreModule> Superclass;
   qSlicerCLILoadableModuleFactoryItem(const QString& newTempDirectory);
+  virtual bool load();
+
+  static void loadLibraryAndResolveSymbols(
+      void* libraryLoader,  ModuleDescription& desc);
+
 protected:
+  /// Return path of the expected XML file.
+  QString xmlModuleDescriptionFilePath()const;
+
   virtual qSlicerAbstractCoreModule* instanciator();
   QString resolveXMLModuleDescriptionSymbol();
   bool resolveSymbols(ModuleDescription& desc);

--- a/Base/QTCLI/qSlicerCLILoadableModuleFactory.h
+++ b/Base/QTCLI/qSlicerCLILoadableModuleFactory.h
@@ -30,16 +30,21 @@
 #include "qSlicerAbstractModule.h"
 #include "qSlicerBaseQTCLIExport.h"
 
+class ModuleDescription;
 class ModuleLogo;
+class qSlicerCLIModule;
 
 //-----------------------------------------------------------------------------
 class qSlicerCLILoadableModuleFactoryItem
   : public ctkFactoryLibraryItem<qSlicerAbstractCoreModule>
 {
 public:
+  typedef ctkFactoryLibraryItem<qSlicerAbstractCoreModule> Superclass;
   qSlicerCLILoadableModuleFactoryItem(const QString& newTempDirectory);
 protected:
   virtual qSlicerAbstractCoreModule* instanciator();
+  QString resolveXMLModuleDescriptionSymbol();
+  bool resolveSymbols(ModuleDescription& desc);
   static bool updateLogo(qSlicerCLILoadableModuleFactoryItem* item, ModuleLogo& logo);
 private:
   QString TempDirectory;

--- a/Base/QTCLI/qSlicerCLIModule.cxx
+++ b/Base/QTCLI/qSlicerCLIModule.cxx
@@ -44,16 +44,6 @@ public:
   typedef qSlicerCLIModulePrivate Self;
   qSlicerCLIModulePrivate();
 
-  QString           Title;
-  QString           Acknowledgement;
-  QString           Help;
-  QStringList       Categories;
-  QStringList       Contributors;
-  QImage            Logo;
-  int               Index;
-
-  QString           EntryPoint;
-  QString           ModuleType;
   QString           TempDirectory;
 
   ModuleDescription                 Desc;
@@ -65,7 +55,6 @@ public:
 //-----------------------------------------------------------------------------
 qSlicerCLIModulePrivate::qSlicerCLIModulePrivate()
 {
-  this->Index = -1;
 }
 
 //-----------------------------------------------------------------------------
@@ -117,19 +106,94 @@ vtkMRMLAbstractLogic* qSlicerCLIModule::createLogic()
 }
 
 //-----------------------------------------------------------------------------
-CTK_GET_CPP(qSlicerCLIModule, QString, title, Title);
-CTK_GET_CPP(qSlicerCLIModule, QStringList, categories, Categories);
-CTK_GET_CPP(qSlicerCLIModule, QStringList, contributors, Contributors);
-CTK_GET_CPP(qSlicerCLIModule, int, index, Index);
-CTK_GET_CPP(qSlicerCLIModule, QString, acknowledgementText, Acknowledgement);
-CTK_GET_CPP(qSlicerCLIModule, QImage, logo, Logo);
-CTK_GET_CPP(qSlicerCLIModule, QString, helpText, Help);
+QString qSlicerCLIModule::title()const
+{
+  Q_D(const qSlicerCLIModule);
+  return QString::fromStdString(d->Desc.GetTitle());
+}
+
+//-----------------------------------------------------------------------------
+QStringList qSlicerCLIModule::categories()const
+{
+  Q_D(const qSlicerCLIModule);
+  return QString::fromStdString(d->Desc.GetCategory()).split(';');
+}
+
+//-----------------------------------------------------------------------------
+QStringList qSlicerCLIModule::contributors()const
+{
+  Q_D(const qSlicerCLIModule);
+  return QStringList() << QString::fromStdString(d->Desc.GetContributor());
+}
+
+//-----------------------------------------------------------------------------
+int qSlicerCLIModule::index()const
+{
+  Q_D(const qSlicerCLIModule);
+  bool ok = false;
+  int index = QString::fromStdString(d->Desc.GetIndex()).toInt(&ok);
+  return (ok ? index : -1);
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCLIModule::acknowledgementText()const
+{
+  Q_D(const qSlicerCLIModule);
+  return QString::fromStdString(d->Desc.GetAcknowledgements());
+}
+
+//-----------------------------------------------------------------------------
+QImage qSlicerCLIModule::logo()const
+{
+  Q_D(const qSlicerCLIModule);
+  return this->moduleLogoToImage(d->Desc.GetLogo());
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCLIModule::helpText()const
+{
+  Q_D(const qSlicerCLIModule);
+  QString help =
+    "%1<br>"
+    "For more detailed documentation see the online documentation at "
+    "<a href=\"%2\">%2</a>";
+
+  return help.arg(
+    QString::fromStdString(d->Desc.GetDescription())).arg(
+    QString::fromStdString(d->Desc.GetDocumentationURL()));
+}
+
+//-----------------------------------------------------------------------------
 CTK_SET_CPP(qSlicerCLIModule, const QString&, setTempDirectory, TempDirectory);
 CTK_GET_CPP(qSlicerCLIModule, QString, tempDirectory, TempDirectory);
-CTK_SET_CPP(qSlicerCLIModule, const QString&, setEntryPoint, EntryPoint);
-CTK_GET_CPP(qSlicerCLIModule, QString, entryPoint, EntryPoint);
-CTK_SET_CPP(qSlicerCLIModule, const QString&, setModuleType, ModuleType);
-CTK_GET_CPP(qSlicerCLIModule, QString, moduleType, ModuleType);
+
+//-----------------------------------------------------------------------------
+void qSlicerCLIModule::setEntryPoint(const QString& entryPoint)
+{
+  Q_D(qSlicerCLIModule);
+  d->Desc.SetTarget(entryPoint.toStdString());
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCLIModule::entryPoint()const
+{
+  Q_D(const qSlicerCLIModule);
+  return QString::fromStdString(d->Desc.GetTarget());
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerCLIModule::setModuleType(const QString& moduleType)
+{
+  Q_D(qSlicerCLIModule);
+  d->Desc.SetType(moduleType.toStdString());
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCLIModule::moduleType()const
+{
+  Q_D(const qSlicerCLIModule);
+  return QString::fromStdString(d->Desc.GetType());
+}
 
 //-----------------------------------------------------------------------------
 void qSlicerCLIModule::setXmlModuleDescription(const QString& xmlModuleDescription)
@@ -139,9 +203,8 @@ void qSlicerCLIModule::setXmlModuleDescription(const QString& xmlModuleDescripti
   Q_ASSERT(!this->entryPoint().isEmpty());
 
   // Parse module description
-  ModuleDescription desc;
   ModuleDescriptionParser parser;
-  if (parser.Parse(xmlModuleDescription.toStdString(), desc) != 0)
+  if (parser.Parse(xmlModuleDescription.toStdString(), d->Desc) != 0)
     {
     qWarning() << "Failed to parse xml module description:\n"
                << xmlModuleDescription;
@@ -149,37 +212,9 @@ void qSlicerCLIModule::setXmlModuleDescription(const QString& xmlModuleDescripti
     }
 
   // Set properties
-  d->Title = QString::fromStdString(desc.GetTitle());
-  d->Acknowledgement = QString::fromStdString(desc.GetAcknowledgements());
-  d->Contributors = QStringList() << QString::fromStdString(desc.GetContributor());
-  d->Logo = this->moduleLogoToImage(desc.GetLogo());
-  bool ok = false;
-  d->Index = QString::fromStdString(desc.GetIndex()).toInt(&ok);
-  if (!ok)
-    {
-    d->Index = -1;
-    }
-  d->Categories = QStringList() << QString::fromStdString(desc.GetCategory()).split(';');
-
-  QString help =
-    "%1<br>"
-    "For more detailed documentation see the online documentation at "
-    "<a href=\"%2\">%2</a>";
-
-  d->Help = help.arg(
-    QString::fromStdString(desc.GetDescription())).arg(
-    QString::fromStdString(desc.GetDocumentationURL()));
-
-  // Set module type
-  desc.SetType(this->moduleType().toStdString());
-
-  // Set module entry point
-  desc.SetTarget(this->entryPoint().toStdString());
 
   // Register the module description in the master list
-  vtkMRMLCommandLineModuleNode::RegisterModuleDescription(desc);
-
-  d->Desc = desc;
+  vtkMRMLCommandLineModuleNode::RegisterModuleDescription(d->Desc);
 }
 
 //-----------------------------------------------------------------------------
@@ -193,7 +228,7 @@ vtkSlicerCLIModuleLogic* qSlicerCLIModule::cliModuleLogic()
 void qSlicerCLIModule::setLogo(const ModuleLogo& logo)
 {
   Q_D(qSlicerCLIModule);
-  d->Logo = this->moduleLogoToImage(logo);
+  d->Desc.SetLogo(logo);
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCLI/qSlicerCLIModule.cxx
+++ b/Base/QTCLI/qSlicerCLIModule.cxx
@@ -245,6 +245,13 @@ QImage qSlicerCLIModule::moduleLogoToImage(const ModuleLogo& logo)
 }
 
 //-----------------------------------------------------------------------------
+ModuleDescription& qSlicerCLIModule::moduleDescription()
+{
+  Q_D(qSlicerCLIModule);
+  return d->Desc;
+}
+
+//-----------------------------------------------------------------------------
 QStringList qSlicerCLIModule::associatedNodeTypes()const
 {
   return QStringList() << "vtkMRMLCommandLineModuleNode";

--- a/Base/QTCLI/qSlicerCLIModule.cxx
+++ b/Base/QTCLI/qSlicerCLIModule.cxx
@@ -36,7 +36,6 @@
 #include <ModuleDescription.h>
 #include <ModuleDescriptionParser.h>
 #include <ModuleLogo.h>
-#include <ModuleProcessInformation.h>
 
 //-----------------------------------------------------------------------------
 class qSlicerCLIModulePrivate
@@ -58,7 +57,6 @@ public:
   QString           TempDirectory;
 
   ModuleDescription                 Desc;
-  ModuleProcessInformation*         ProcessInformation;
 };
 
 //-----------------------------------------------------------------------------
@@ -67,7 +65,6 @@ public:
 //-----------------------------------------------------------------------------
 qSlicerCLIModulePrivate::qSlicerCLIModulePrivate()
 {
-  this->ProcessInformation = 0;
   this->Index = -1;
 }
 
@@ -163,8 +160,6 @@ void qSlicerCLIModule::setXmlModuleDescription(const QString& xmlModuleDescripti
     d->Index = -1;
     }
   d->Categories = QStringList() << QString::fromStdString(desc.GetCategory()).split(';');
-
-  d->ProcessInformation = desc.GetProcessInformation();
 
   QString help =
     "%1<br>"

--- a/Base/QTCLI/qSlicerCLIModule.h
+++ b/Base/QTCLI/qSlicerCLIModule.h
@@ -27,6 +27,9 @@
 // SlicerQt includes
 #include "qSlicerAbstractModule.h"
 
+// SlicerExecutionModel includes
+#include <ModuleDescription.h>
+
 #include "qSlicerBaseQTCLIExport.h"
 
 class ModuleLogo;
@@ -92,6 +95,11 @@ public:
   /// Convert a ModuleLogo into a QIcon
   /// \todo: Find a better place for this util function
   static QImage moduleLogoToImage(const ModuleLogo& logo);
+
+  /// Return the module description object used to store
+  /// the module properties.
+  ModuleDescription& moduleDescription();
+
 protected:
   ///
   virtual void setup();

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -54,7 +54,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/Slicer/SlicerExecutionModel.git"
-    GIT_TAG "b2c78c74868a1bf8e3abfae831ab31e9d4908c14"
+    GIT_TAG "1b2a454b0337814b36871539ab86e40cbfed6583"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
PERF: Improve startup time delaying execution of shared and executable CLIs
    
This commit **reduces startup time by ~50% (8.6s -> 5.5s)**. Detailed startup
time stats reported below.

More specifically, it updates the loadable and executable CLI factories
so that (1) the XML file is directly loaded from disk if it exists along
side the executable or library and (2) the execution of the executable or
"entry point" for shared library is delayed until needed.

For CLI executable, change consists simply in reading the XML file if it
exists and postpone the execution until it is needed.

For CLI shared library, the ModuleDescription object API has been updated.
It now allows the association of a callback in charge of loading the
library and resolving symbols. The callback is automatically called
when "GetTarget()" method is called and no target has already been set.

Note that the XML file is now copied (and installed if it applies) along
side the CLI executable. There are currently no option to avoid the new
behavior, if it reveals problematic, we could revisit and introduce
an option for "SEMMacroBuildCLI" macro.

Detailed startup time stats without this change are reported in
precedent commit (ENH: Add convenience script to measure the application
startup time).


Detailed startup time stats after this change:

 - Obtained on Ubuntu 15.10, 64GB/M.2 PCIe NVMe SSD/Quad Core 3.80GHz.
 - For a release build

```
Slicer --no-splash --exit-after-startup
5.537 seconds

Slicer --no-splash --exit-after-startup --disable-builtin-cli-modules
5.438 seconds

Slicer --no-splash --exit-after-startup --disable-builtin-loadable-modules
2.863 seconds

Slicer --no-splash --exit-after-startup --disable-builtin-scripted-loadable-modules
3.925 seconds

Slicer --no-splash --exit-after-startup --disable-builtin-cli-modules --disable-builtin-scripted-loadable-modules
3.973 seconds

Slicer --no-splash --exit-after-startup --disable-modules
1.761 seconds

Slicer --no-splash --exit-after-startup --disable-python
3.094 seconds

Slicer --no-splash --exit-after-startup --disable-python --disable-builtin-cli-modules
3.054 seconds

Slicer --no-splash --exit-after-startup --disable-python --disable-builtin-loadable-modules
0.972 seconds

Slicer --no-splash --exit-after-startup --disable-python --disable-builtin-scripted-loadable-modules
3.135 seconds

Slicer --no-splash --exit-after-startup --disable-python --disable-builtin-cli-modules --disable-builtin-scripted-loadable-modules
3.085 seconds

Slicer --no-splash --exit-after-startup --disable-python --disable-modules
0.924 seconds
```


SlicerExecutionModel changes:

```
$ git shortlog b2c78c7..1b2a454 --no-merges
Jean-Christophe Fillion-Robin (9):
      STYLE: ModuleDescription: Move definition to cxx file
      STYLE: Remove obsolete ModuleFactory class
      STYLE: ModuleDescription: Remove unused Alternative Type/Target/Location
      STYLE: Remove obsolete BinaryFileDescriptor support
      STYLE: ModuleDescriptionParser: Add separator comment, small tweaks
      STYLE: Add ModuleDescriptionTesting Macros and Utilities files
      STYLE: ModuleDescription: Add TestDefaults
      ENH: ModuleDescription: Add support for lazily setting the target
      ENH: Update SEMMacroBuildCLI to copy (and optionally install) the XML file
```