### PR TITLE
BUG: Template argument name was modified in template declaration

### DIFF
--- a/Extensions/Testing/CLIExtensionTemplate/CLIModuleTemplate/CLIModuleTemplate.cxx
+++ b/Extensions/Testing/CLIExtensionTemplate/CLIModuleTemplate/CLIModuleTemplate.cxx
@@ -15,7 +15,7 @@ namespace
 {
 
 template <typename TPixel>
-int DoIt( int argc, char * argv[], T )
+int DoIt( int argc, char * argv[], TPixel )
 {
   PARSE_ARGS;
 


### PR DESCRIPTION
Template argument name was modified in template declaration but not
when using it in the templated function.