### PR TITLE
BUG: Attribute does not exist if _haveGit False

### DIFF
--- a/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
@@ -660,15 +660,17 @@ class ExtensionWizard(object):
       self.describe(args)
       acted = True
 
-    # Publish extension if requested
-    if args.publish:
-      self.publish(args)
-      acted = True
+    # The following arguments are only available if _haveGit is True
+    if _haveGit:
+      # Publish extension if requested
+      if args.publish:
+        self.publish(args)
+        acted = True
 
-    # Contribute extension if requested
-    if args.contribute:
-      self.contribute(args)
-      acted = True
+      # Contribute extension if requested
+      if args.contribute:
+        self.contribute(args)
+        acted = True
 
     # Check that we did something
     if not acted:


### PR DESCRIPTION
If Python is not built with SSL support, the variable _haveGit
is set to False. In that case, some command line arguments are
not defined. These arguments should be tested only if _haveGit
is True.
