### PR TITLE
ENH : factorize SliceController + new method for displayStringOrientation

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.cxx
@@ -361,6 +361,45 @@ void vtkMRMLSliceNode::SetOrientation(const char* orientation)
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLSliceNode::SetAxialOrientationDisplayString(const char *displayOrientation)
+{
+  DisplayOrientationStringsMap["Axial"] = displayOrientation;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceNode::SetSagittalOrientationDisplayString(const char *displayOrientation)
+{
+  DisplayOrientationStringsMap["Sagittal"] = displayOrientation;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceNode::SetCoronalOrientationDisplayString(const char *displayOrientation)
+{
+  DisplayOrientationStringsMap["Coronal"] = displayOrientation;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLSliceNode::displayOrientationStringsMap vtkMRMLSliceNode::createdisplayOrientationStringsMap()
+{
+    displayOrientationStringsMap map;
+    map["Axial"] = "Axial";
+    map["Coronal"] = "Coronal";
+    map["Sagittal"] = "Sagittal";
+    return map;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLSliceNode::displayOrientationStringsMap vtkMRMLSliceNode::DisplayOrientationStringsMap =
+    vtkMRMLSliceNode::createdisplayOrientationStringsMap();
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLSliceNode::GetOrientationDisplayString()
+{
+  std::string orientation = this->GetOrientationString();
+  return DisplayOrientationStringsMap[orientation];
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLSliceNode::SetOrientationToReformat()
 {
     // Don't need to do anything.  Leave the matrices where they were

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -30,6 +30,9 @@ class vtkMatrix4x4;
 /// \li FieldOfView tells the size of  slice plane
 class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
 {
+
+  typedef std::map<std::string, std::string> displayOrientationStringsMap ;
+
   public:
   static vtkMRMLSliceNode *New();
   vtkTypeMacro(vtkMRMLSliceNode,vtkMRMLAbstractViewNode);
@@ -132,6 +135,29 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   /// SetOrientationToSagittal(), SetOrientationToCoronal() or
   /// SetOrientationToReformat() depending on the value of the string
   void SetOrientation(const char* orientation);
+
+  ///
+  /// map the Axial plane string with a custom displayOrientation string
+  static void SetAxialOrientationDisplayString(const char* displayOrientation);
+
+  ///
+  /// map the Sagittal plane string with a custom displayOrientation string
+  static void SetSagittalOrientationDisplayString(const char* displayOrientation);
+
+  ///
+  /// map the Coronal plane string with a custom displayOrientation string
+  static void SetCoronalOrientationDisplayString(const char* displayOrientation);
+
+  ///
+  /// A description of the current orientation,
+  /// the method return customized names
+  /// for the planes Axial, Sagittal and Coronal.
+  /// The mapping is set using the static map:
+  /// displayOrientationStringsMap.
+  /// SetAxialOrientationDisplayString
+  /// SetSagittalOrientationDisplayString
+  /// SetCoronalOrientationDisplayString
+  std::string GetOrientationDisplayString();
 
   /// Description
   /// A description of the current orientation
@@ -457,6 +483,9 @@ protected:
   int IsUpdatingMatrices;
 
   std::vector< std::string > ThreeDViewIDs;
+
+  static displayOrientationStringsMap createdisplayOrientationStringsMap();
+  static displayOrientationStringsMap DisplayOrientationStringsMap;
 };
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
@@ -158,7 +158,7 @@ public slots:
 
   /// Set slice orientation.
   /// \note Orientation could be either "Axial, "Sagittal", "Coronal" or "Reformat".
-  void setSliceOrientation(const QString& orientation);
+  virtual void setSliceOrientation(const QString& orientation);
 
   /// Set slice \a offset. Used to set a single value.
   void setSliceOffsetValue(double offset);

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
@@ -109,7 +109,7 @@ public slots:
   void updateFromMRMLScene();
 
   /// Update widget state using the associated MRML slice node
-  void updateWidgetFromMRMLSliceNode();
+  virtual void updateWidgetFromMRMLSliceNode();
 
   /// Update widget state using the associated MRML slice composite node
   void updateWidgetFromMRMLSliceCompositeNode();


### PR DESCRIPTION
@pieper @jcfr 
as discussed this morning for the first point.

The mapping and the methods are static so an estension can do this in its setup method

```
  vtkMRMLSliceNode::SetAxialOrientationDisplayString("XZ");
  vtkMRMLSliceNode::SetSagittalOrientationDisplayString("ZY");
  vtkMRMLSliceNode::SetCoronalOrientationDisplayString("XY");
```

and set up the mapping for all the SliceNodes. 

To get an idea in which situations  this mapping will be useful:

https://github.com/Punzo/SlicerAstro/blob/master/AstroDataProbe/AstroDataProbe.py#L75

https://github.com/Punzo/SlicerAstro/blob/master/AstroVolume/Widgets/qMRMLSliceAstroControllerWidget.cxx#L111