### PR TITLE
ENH: customize ctkAxesWidget

### DIFF
--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -333,6 +333,15 @@ void qMRMLThreeDViewControllerWidget::updateWidgetFromMRML()
     return;
     }
 
+  QStringList axesLabels;
+  axesLabels <<  d->ViewNode->GetAxisLabel(0);
+  axesLabels <<  d->ViewNode->GetAxisLabel(1);
+  axesLabels <<  d->ViewNode->GetAxisLabel(4);
+  axesLabels <<  d->ViewNode->GetAxisLabel(5);
+  axesLabels <<  d->ViewNode->GetAxisLabel(2);
+  axesLabels <<  d->ViewNode->GetAxisLabel(3);
+  d->AxesWidget->setAxesLabels(axesLabels);
+
   d->actionSet3DAxisVisible->setChecked(d->ViewNode->GetBoxVisible());
   d->actionSet3DAxisLabelVisible->setChecked(
     d->ViewNode->GetAxisLabelsVisible());


### PR DESCRIPTION
This is a following up of https://github.com/Slicer/Slicer/pull/464

the Axes Labels stored in the ViewNode will be used to customize automatically also
the ctkAxisWidget.

It will work after the merging of this
https://github.com/commontk/CTK/pull/647