### PR TITLE
PERF: #4191 don't update widgets in batch mode

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
@@ -916,6 +916,7 @@ void vtkMRMLMarkupsFiducialDisplayableManager2D::PropagateMRMLToWidget(vtkMRMLMa
   if (node->GetScene()->IsBatchProcessing())
     {
     // compress events
+    this->SetUpdateFromMRMLRequested(1);
     return;
     }
 

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
@@ -900,6 +900,7 @@ void vtkMRMLMarkupsFiducialDisplayableManager2D::SetNthSeed(int n, vtkMRMLMarkup
 /// Propagate properties of MRML node to widget.
 void vtkMRMLMarkupsFiducialDisplayableManager2D::PropagateMRMLToWidget(vtkMRMLMarkupsNode* node, vtkAbstractWidget * widget)
 {
+
   if (!widget)
     {
     vtkErrorMacro("PropagateMRMLToWidget: Widget was null!")
@@ -909,6 +910,12 @@ void vtkMRMLMarkupsFiducialDisplayableManager2D::PropagateMRMLToWidget(vtkMRMLMa
   if (!node)
     {
     vtkErrorMacro("PropagateMRMLToWidget: MRML node was null!")
+    return;
+    }
+
+  if (node->GetScene()->IsBatchProcessing())
+    {
+    // compress events
     return;
     }
 

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.cxx
@@ -521,6 +521,7 @@ void vtkMRMLMarkupsFiducialDisplayableManager3D::PropagateMRMLToWidget(vtkMRMLMa
   if (node->GetScene()->IsBatchProcessing())
     {
     // compress events
+    this->SetUpdateFromMRMLRequested(1);
     return;
     }
 

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.cxx
@@ -518,6 +518,12 @@ void vtkMRMLMarkupsFiducialDisplayableManager3D::PropagateMRMLToWidget(vtkMRMLMa
     return;
     }
 
+  if (node->GetScene()->IsBatchProcessing())
+    {
+    // compress events
+    return;
+    }
+
   // cast to the specific widget
   vtkSeedWidget* seedWidget = vtkSeedWidget::SafeDownCast(widget);
 

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -297,7 +297,7 @@ list_conditional_append(Slicer_BUILD_CompareVolumes Slicer_REMOTE_DEPENDENCIES C
 
 Slicer_Remote_Add(LandmarkRegistration
   GIT_REPOSITORY "${git_protocol}://github.com/pieper/LandmarkRegistration"
-  GIT_TAG "13d7b32ffc0be030256fd3d1b010a0efc18e3bff"
+  GIT_TAG "e2cc82fea456b2dd71a01f343a02280771b9848e"
   OPTION_NAME Slicer_BUILD_LandmarkRegistration
   OPTION_DEPENDS "Slicer_BUILD_CompareVolumes;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
This really improves the performance of LandmarkRegistration,
particularly when there are large numbers of fiducials
being manipulated.  I haven't seen any side effects.