### PR TITLE
ENH: enable customization of SliceNode and SliceController

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -26,10 +26,12 @@
 #include <vtkMRMLModelHierarchyNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSelectionNode.h>
+#include <vtkMRMLSliceNode.h>
 #include <vtkMRMLTableNode.h>
 #include <vtkMRMLRemoteIOLogic.h>
 
 // VTK includes
+#include <vtkMatrix4x4.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
@@ -295,6 +297,60 @@ void vtkSlicerApplicationLogic::SetMRMLSceneDataIO(vtkMRMLScene* newMRMLScene,
       {
       remoteIOLogic->AddDataIOToScene();
       }
+    }
+
+  // Setting Orientation Matrices presets
+  vtkNew<vtkMatrix4x4> axialSliceToRAS;
+  axialSliceToRAS->SetElement(0, 0, -1.0);
+  axialSliceToRAS->SetElement(1, 0,  0.0);
+  axialSliceToRAS->SetElement(2, 0,  0.0);
+  axialSliceToRAS->SetElement(0, 1,  0.0);
+  axialSliceToRAS->SetElement(1, 1,  1.0);
+  axialSliceToRAS->SetElement(2, 1,  0.0);
+  axialSliceToRAS->SetElement(0, 2,  0.0);
+  axialSliceToRAS->SetElement(1, 2,  0.0);
+  axialSliceToRAS->SetElement(2, 2,  1.0);
+
+  vtkNew<vtkMatrix4x4> sagittalSliceToRAS;
+  sagittalSliceToRAS->SetElement(0, 0,  0.0);
+  sagittalSliceToRAS->SetElement(1, 0,  -1.0);
+  sagittalSliceToRAS->SetElement(2, 0,  0.0);
+  sagittalSliceToRAS->SetElement(0, 1,  0.0);
+  sagittalSliceToRAS->SetElement(1, 1,  0.0);
+  sagittalSliceToRAS->SetElement(2, 1,  1.0);
+  sagittalSliceToRAS->SetElement(0, 2,  1.0);
+  sagittalSliceToRAS->SetElement(1, 2,  0.0);
+  sagittalSliceToRAS->SetElement(2, 2,  0.0);
+
+  vtkNew<vtkMatrix4x4> coronalSliceToRAS;
+  coronalSliceToRAS->SetElement(0, 0, -1.0);
+  coronalSliceToRAS->SetElement(1, 0,  0.0);
+  coronalSliceToRAS->SetElement(2, 0,  0.0);
+  coronalSliceToRAS->SetElement(0, 1,  0.0);
+  coronalSliceToRAS->SetElement(1, 1,  0.0);
+  coronalSliceToRAS->SetElement(2, 1,  1.0);
+  coronalSliceToRAS->SetElement(0, 2,  0.0);
+  coronalSliceToRAS->SetElement(1, 2,  1.0);
+  coronalSliceToRAS->SetElement(2, 2,  0.0);
+
+  // Setting a Slice Default Node
+  vtkSmartPointer<vtkMRMLSliceNode> defaultNode = vtkMRMLSliceNode::SafeDownCast
+      (newMRMLScene->GetDefaultNodeByClass("vtkMRMLSliceNode"));
+  if (defaultNode)
+    {
+    defaultNode->AddSliceOrientationPreset("Axial", axialSliceToRAS.GetPointer());
+    defaultNode->AddSliceOrientationPreset("Sagittal", sagittalSliceToRAS.GetPointer());
+    defaultNode->AddSliceOrientationPreset("Coronal", coronalSliceToRAS.GetPointer());
+    }
+  else
+    {
+    defaultNode = vtkMRMLSliceNode::SafeDownCast
+        (newMRMLScene->CreateNodeByClass("vtkMRMLSliceNode"));
+    defaultNode->AddSliceOrientationPreset("Axial", axialSliceToRAS.GetPointer());
+    defaultNode->AddSliceOrientationPreset("Sagittal", sagittalSliceToRAS.GetPointer());
+    defaultNode->AddSliceOrientationPreset("Coronal", coronalSliceToRAS.GetPointer());
+    newMRMLScene->AddDefaultNode(defaultNode);
+    defaultNode->Delete(); // scene owns it now
     }
 }
 

--- a/Base/Logic/vtkSlicerApplicationLogic.h
+++ b/Base/Logic/vtkSlicerApplicationLogic.h
@@ -26,7 +26,6 @@
 
 // VTK includes
 #include <vtkCollection.h>
-#include <vtkSmartPointer.h>
 
 // ITK includes
 #include <itkMultiThreader.h>

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -61,7 +61,7 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   ///
   /// Mapping from RAS space onto the slice plane
   /// TODO: maybe this should be a quaternion and a translate to avoid shears/scales
-  vtkGetObjectMacro (SliceToRAS, vtkMatrix4x4);
+  vtkMatrix4x4 *GetSliceToRAS();
   virtual void SetSliceToRAS(vtkMatrix4x4* sliceToRAS);
 
   ///
@@ -120,9 +120,9 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   /// 'standard' radiological convention views of patient space
   /// these calls adjust the SliceToRAS matrix to position the slice
   /// cutting plane
-  void SetOrientationToAxial();
-  void SetOrientationToSagittal();
-  void SetOrientationToCoronal();
+  bool SetOrientationToAxial();
+  bool SetOrientationToSagittal();
+  bool SetOrientationToCoronal();
 
   ///
   /// General 'reformat' view that allows for multiplanar reformat
@@ -131,7 +131,7 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   /// Convenient function that calls SetOrientationToAxial(),
   /// SetOrientationToSagittal(), SetOrientationToCoronal() or
   /// SetOrientationToReformat() depending on the value of the string
-  void SetOrientation(const char* orientation);
+  bool SetOrientation(const char* orientation);
 
   /// Description
   /// A description of the current orientation
@@ -148,6 +148,28 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   /// try to match 'Reformat' but would not know what overall orientation to pick).
   vtkGetStringMacro (OrientationReference);
   vtkSetStringMacro (OrientationReference);
+
+
+  /// Return the sliceToRAS matrix
+  vtkMatrix4x4 *GetSliceOrientationPreset(const std::string& name);
+
+  /// Return the orietation string
+  std::string GetSliceOrientationPresetName(vtkMatrix4x4* sliceToRAS);
+
+  /// Return all the orietation strings
+  void GetSliceOrientationPresetNames(vtkStringArray* namedOrientations);
+
+  /// Add an orietaton preset
+  bool AddSliceOrientationPreset(const std::string& name, vtkMatrix4x4* sliceToRAS);
+
+  /// Remove an oritation preset
+  bool RemoveSliceOrientationPreset(const std::string& name);
+
+  /// Rename an oritation preset
+  bool RenameSliceOrientationPreset(const std::string& name, const std::string& updatedName);
+
+  /// Check if an oritation preset is stored
+  bool HasSliceOrientationPreset(const std::string& name);
 
   ///
   /// Size of the slice plane in millimeters
@@ -208,22 +230,22 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   ///
   /// Matrix mapping from XY pixel coordinates on an image window
   /// into slice coordinates in mm
-  vtkGetObjectMacro (XYToSlice, vtkMatrix4x4);
+  vtkMatrix4x4 *GetXYToSlice();
 
   ///
   /// Matrix mapping from XY pixel coordinates on an image window
   /// into RAS world coordinates
-  vtkGetObjectMacro (XYToRAS, vtkMatrix4x4);
+  vtkMatrix4x4 *GetXYToRAS();
 
   ///
   /// Matrix mapping from UVW texture coordinates
   /// into slice coordinates in mm
-  vtkGetObjectMacro (UVWToSlice, vtkMatrix4x4);
+  vtkMatrix4x4 *GetUVWToSlice();
 
   ///
   /// Matrix mapping from UVW texture coordinates
   /// into RAS world coordinates
-  vtkGetObjectMacro (UVWToRAS, vtkMatrix4x4);
+  vtkMatrix4x4 *GetUVWToRAS();
 
   ///
   /// helper for comparing to matrices
@@ -410,14 +432,15 @@ protected:
   vtkMRMLSliceNode(const vtkMRMLSliceNode&);
   void operator=(const vtkMRMLSliceNode&);
 
-  vtkMatrix4x4 *SliceToRAS;
+  vtkSmartPointer<vtkMatrix4x4> SliceToRAS;
 
-  vtkMatrix4x4 *XYToSlice;
-  vtkMatrix4x4 *XYToRAS;
+  vtkSmartPointer<vtkMatrix4x4> XYToSlice;
+  vtkSmartPointer<vtkMatrix4x4> XYToRAS;
 
-  vtkMatrix4x4 *UVWToSlice;
-  vtkMatrix4x4 *UVWToRAS;
+  vtkSmartPointer<vtkMatrix4x4> UVWToSlice;
+  vtkSmartPointer<vtkMatrix4x4> UVWToRAS;
 
+  std::vector< std::pair <std::string, vtkSmartPointer<vtkMatrix4x4> > > OrientationMatrices;
 
   int JumpMode;
 

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -55,7 +55,7 @@ vtkStandardNewMacro(vtkMRMLSliceLayerLogic);
 
 bool AreMatricesEqual(const vtkMatrix4x4* first, const vtkMatrix4x4* second)
 {
-  return vtkAddonMathUtilities::Matrix4x4AreEqual(first, second, /* tolerance= */ 0);
+  return vtkAddonMathUtilities::Matrix4x4AreEqual(first, second);
 }
 
 // Convert a linear transform that is almost exactly a permute transform

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -45,6 +45,7 @@
 #include <vtkPlaneSource.h>
 #include <vtkPolyDataCollection.h>
 #include <vtkSmartPointer.h>
+#include <vtkStringArray.h>
 #include <vtkTransform.h>
 #include <vtkVersion.h>
 
@@ -264,17 +265,26 @@ void vtkMRMLSliceLogic::UpdateSliceNodeFromLayout()
     return;
     }
 
+  vtkNew<vtkStringArray> namedOrientations;
+  this->SliceNode->GetSliceOrientationPresetNames(namedOrientations.GetPointer());
+
+  if (namedOrientations->GetNumberOfValues() < 3)
+    {
+    vtkErrorMacro("UpdateSliceNodeFromLayout: "<< this->GetName() <<
+                  "could not set its orietation.")
+    }
+
   if ( !strcmp( this->GetName(), "Red" ) )
     {
-    this->SliceNode->SetOrientationToAxial();
+    this->SliceNode->SetOrientation(namedOrientations->GetValue(0));
     }
   if ( !strcmp( this->GetName(), "Yellow" ) )
     {
-    this->SliceNode->SetOrientationToSagittal();
+    this->SliceNode->SetOrientation(namedOrientations->GetValue(1));
     }
   if ( !strcmp( this->GetName(), "Green" ) )
     {
-    this->SliceNode->SetOrientationToCoronal();
+    this->SliceNode->SetOrientation(namedOrientations->GetValue(2));
     }
 }
 

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -21,8 +21,12 @@
 // STD includes
 #include <vector>
 
+// VTK includes
+#include <vtkSmartPointer.h>
+
 class vtkMRMLDisplayNode;
 class vtkMRMLLinearTransformNode;
+class vtkMatrix4x4;
 class vtkMRMLModelDisplayNode;
 class vtkMRMLModelNode;
 class vtkMRMLSliceCompositeNode;
@@ -384,7 +388,6 @@ protected:
   vtkMRMLSliceLayerLogic *    BackgroundLayer;
   vtkMRMLSliceLayerLogic *    ForegroundLayer;
   vtkMRMLSliceLayerLogic *    LabelLayer;
-
 
   vtkImageBlend *   Blend;
   vtkImageBlend *   BlendUVW;

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
@@ -94,6 +94,8 @@ public:
   void setupOrientationMarkerMenu();
   void setupRulerMenu();
 
+  qMRMLOrientation mrmlOrientation(const QString& name);
+
   vtkSmartPointer<vtkCollection> saveNodesForUndo(const QString& nodeTypes);
 
   void enableLayerWidgets();
@@ -139,7 +141,7 @@ public slots:
 
 protected:
   virtual void setupPopupUi();
-  void setMRMLSliceNodeInternal(vtkMRMLSliceNode* sliceNode);
+  virtual void setMRMLSliceNodeInternal(vtkMRMLSliceNode* sliceNode);
   void setMRMLSliceCompositeNodeInternal(vtkMRMLSliceCompositeNode* sliceComposite);
 
 public:

--- a/Libs/MRML/Widgets/qMRMLSliceInformationWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceInformationWidget.cxx
@@ -27,6 +27,10 @@
 // MRML includes
 #include <vtkMRMLSliceNode.h>
 
+// VTK includes
+#include <vtkNew.h>
+#include <vtkStringArray.h>
+
 //--------------------------------------------------------------------------
 // qMRMLSliceViewPrivate methods
 
@@ -96,10 +100,61 @@ void qMRMLSliceInformationWidgetPrivate::updateWidgetFromMRMLSliceNode()
   this->LayoutNameLineEdit->setText(QLatin1String(this->MRMLSliceNode->GetLayoutName()));
 
   // Update orientation selector state
+  vtkNew<vtkStringArray> orientationNames;
+  this->MRMLSliceNode->GetSliceOrientationPresetNames(orientationNames.GetPointer());
+
+  bool wasBlocked = this->SliceOrientationSelector->blockSignals(true);
+  int count = this->SliceOrientationSelector->count();
+  // If last item in the combox box is not "Reformat" remove it.
+  // This will exclude that the user can click on "Reformat" orientation
+  // which actually will not change the orientation of sliceToRAS matrix in
+  // vtkMRMLSliceNode::SetOrientation()
+  if(this->SliceOrientationSelector->itemText(count - 1) != "Reformat")
+    {
+    this->SliceOrientationSelector->removeItem(count - 1);
+    count--;
+    }
+  int names = orientationNames->GetNumberOfValues();
+  // The entries of the ctkComboBox will be updated with the names of the orientation presets.
+  if (count < names)
+    {
+    for (int i = 0; i < count; i++)
+      {
+      this->SliceOrientationSelector->setItemText(i, QString::fromStdString(orientationNames->GetValue(i)));
+      }
+    for (int i = count; i < names; i++)
+      {
+      this->SliceOrientationSelector->insertItem(i, QString::fromStdString(orientationNames->GetValue(i)));
+      }
+    }
+  else
+    {
+    for (int i = 0; i < names; i++)
+      {
+      this->SliceOrientationSelector->setItemText(i, QString::fromStdString(orientationNames->GetValue(i)));
+      }
+    for (int i = names; i < count; i++)
+      {
+      this->SliceOrientationSelector->removeItem(i);
+      }
+    }
+  // In case the orientation matrix (sliceToRAS) is different from any preset,
+  // "Reformat" will be displayed on the ctkComboBox.
+  if(!strcmp(this->MRMLSliceNode->GetOrientationString(), "Reformat"))
+    {
+    this->SliceOrientationSelector->insertItem(count, "Reformat");
+    }
+  this->SliceOrientationSelector->blockSignals(wasBlocked);
+
+  // Update orientation selector state
   int index = this->SliceOrientationSelector->findText(
       QString::fromStdString(this->MRMLSliceNode->GetOrientationString()));
-  Q_ASSERT(index>=0 && index <=4);
+  Q_ASSERT(index>=0);
+
+  // We block the signal to avoid calling setSliceOrientation from the MRMLNode
+  wasBlocked = this->SliceOrientationSelector->blockSignals(true);
   this->SliceOrientationSelector->setCurrentIndex(index);
+  this->SliceOrientationSelector->blockSignals(wasBlocked);
 
   // Update slice visibility toggle
   this->SliceVisibilityToggle->setChecked(this->MRMLSliceNode->GetSliceVisible());
@@ -206,12 +261,6 @@ void qMRMLSliceInformationWidget::setMRMLSliceNode(vtkMRMLSliceNode* newSliceNod
 void qMRMLSliceInformationWidget::setSliceOrientation(const QString& orientation)
 {
   Q_D(qMRMLSliceInformationWidget);
-
-#ifndef QT_NO_DEBUG
-  QStringList expectedOrientation;
-  expectedOrientation << "Axial" << "Sagittal" << "Coronal" << "Reformat";
-  Q_ASSERT(expectedOrientation.contains(orientation));
-#endif
 
   if (!d->MRMLSliceNode)
     {


### PR DESCRIPTION
Hi @jcfr . 

I implemented all the API and infrastructure as designed in https://github.com/Slicer/Slicer/pull/499.
I apologize that it is all in one PR. I wanted to test it so I preferred to implement everything. 

Tests:
1) I loaded MRHead, I navigated the datacube using the SliceController and I used several modules.
2) I loaded my extension (which customize the 2-D View with the new API), I navigated the datacube using the SliceController and I used several modules.

@lassoan @pieper may you also kindly have a look?

Thanks,

Davide.
