### PR TITLE
BUG: slicer.util.getNodes() called with no arguments now returns all nodes

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -236,7 +236,7 @@ slicer_add_python_unittest(
 
 slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_util_getNodes.py
-  SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules DATA{${INPUT}/MR-head.nrrd}
+  SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules
   TESTNAME_PREFIX nomainwindow_
   )
 

--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -234,6 +234,12 @@ slicer_add_python_unittest(
   TESTNAME_PREFIX nomainwindow_
   )
 
+slicer_add_python_unittest(
+  SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_util_getNodes.py
+  SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules DATA{${INPUT}/MR-head.nrrd}
+  TESTNAME_PREFIX nomainwindow_
+  )
+
 ## Test reading MGH file format types.
 slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_mgh.py

--- a/Base/Python/slicer/tests/test_slicer_util_getNodes.py
+++ b/Base/Python/slicer/tests/test_slicer_util_getNodes.py
@@ -1,0 +1,10 @@
+import unittest
+import slicer
+import slicer.util
+
+class SlicerUnitTestTest(unittest.TestCase):
+    def test_getNodesNoArg(self):
+        self.assertEqual(slicer.util.getNodes(), slicer.util.getNodes("*"))
+
+    def test_getNodes_MRHead(self):
+        self.assertEqual(slicer.util.getNodes("MR-head").keys(), ["MR-head"])

--- a/Base/Python/slicer/tests/test_slicer_util_getNodes.py
+++ b/Base/Python/slicer/tests/test_slicer_util_getNodes.py
@@ -2,19 +2,19 @@ import unittest
 import slicer
 import slicer.util
 
-class SlicerUnitTestTest(unittest.TestCase):
+class SlicerUtilTest(unittest.TestCase):
     def setUp(self):
         slicer.mrmlScene.AddNode(slicer.vtkMRMLScalarVolumeNode()).SetName("Volume1")
         slicer.mrmlScene.AddNode(slicer.vtkMRMLScalarVolumeNode()).SetName("Volume2")
 
-    def test_getNodesNoArg(self):
+    def test_getNodes(self):
         self.assertEqual(slicer.util.getNodes(), slicer.util.getNodes("*"))
+
         self.assertTrue("Volume1" in slicer.util.getNodes("*"))
         self.assertTrue("Volume2" in slicer.util.getNodes("*"))
         self.assertTrue("Volume1" in slicer.util.getNodes())
         self.assertTrue("Volume2" in slicer.util.getNodes())
 
-    def test_getNodes_MRHead(self):
         self.assertEqual(slicer.util.getNodes("Volume1").keys(), ["Volume1"])
         self.assertEqual(slicer.util.getNodes("Volume2").keys(), ["Volume2"])
         self.assertEqual(slicer.util.getNodes("Volume*").keys(), ["Volume1", "Volume2"])

--- a/Base/Python/slicer/tests/test_slicer_util_getNodes.py
+++ b/Base/Python/slicer/tests/test_slicer_util_getNodes.py
@@ -3,8 +3,18 @@ import slicer
 import slicer.util
 
 class SlicerUnitTestTest(unittest.TestCase):
+    def setUp(self):
+        slicer.mrmlScene.AddNode(slicer.vtkMRMLScalarVolumeNode()).SetName("Volume1")
+        slicer.mrmlScene.AddNode(slicer.vtkMRMLScalarVolumeNode()).SetName("Volume2")
+
     def test_getNodesNoArg(self):
         self.assertEqual(slicer.util.getNodes(), slicer.util.getNodes("*"))
+        self.assertTrue("Volume1" in slicer.util.getNodes("*"))
+        self.assertTrue("Volume2" in slicer.util.getNodes("*"))
+        self.assertTrue("Volume1" in slicer.util.getNodes())
+        self.assertTrue("Volume2" in slicer.util.getNodes())
 
     def test_getNodes_MRHead(self):
-        self.assertEqual(slicer.util.getNodes("MR-head").keys(), ["MR-head"])
+        self.assertEqual(slicer.util.getNodes("Volume1").keys(), ["Volume1"])
+        self.assertEqual(slicer.util.getNodes("Volume2").keys(), ["Volume2"])
+        self.assertEqual(slicer.util.getNodes("Volume*").keys(), ["Volume1", "Volume2"])

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -471,7 +471,9 @@ def getNodes(pattern = "", scene=None):
       node = scene.GetNthNode(idx)
       name = node.GetName()
       id = node.GetID()
-      if fnmatch.fnmatchcase(name, pattern) or fnmatch.fnmatchcase(id, pattern):
+      if (pattern == "" or
+          fnmatch.fnmatchcase(name, pattern) or
+          fnmatch.fnmatchcase(id, pattern):
         nodes[node.GetName()] = node
     return nodes
 

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -473,7 +473,7 @@ def getNodes(pattern = "", scene=None):
       id = node.GetID()
       if (pattern == "" or
           fnmatch.fnmatchcase(name, pattern) or
-          fnmatch.fnmatchcase(id, pattern):
+          fnmatch.fnmatchcase(id, pattern)):
         nodes[node.GetName()] = node
     return nodes
 


### PR DESCRIPTION
Fixed behavior to match docstring and added unit tests