### PR TITLE
ENH: Add configure time check that CMake supports HTTPS

### DIFF
--- a/CMake/SlicerCheckCMakeHTTPS.cmake
+++ b/CMake/SlicerCheckCMakeHTTPS.cmake
@@ -1,0 +1,23 @@
+#
+# slicer_check_cmake_https
+#
+# Check if CMake supports downloading files using the HTTPS protocol. Fail if
+# HTTPS is unsupported.
+#
+# CMake should support HTTPS when compiled with CMAKE_USE_OPENSSL enabled.
+#
+# Based on the script created by Jean-Christophe Fillion-Robin:
+# https://gist.github.com/jcfr/e88a2a7cbc4ddd235186
+#
+
+function(slicer_check_cmake_https)
+  set(url "https://wiki.slicer.org/slicerWiki/images/5/5a/Checkmark.png")
+  set(dest "${CMAKE_CURRENT_BINARY_DIR}/slicer_check_cmake_https_output")
+
+  file(DOWNLOAD ${url} ${dest} STATUS status)
+  list(GET status 0 error_code)
+  file(REMOVE ${dest})
+  if(error_code)
+    message(FATAL_ERROR "error: This CMake does not support the HTTPS protocol. Ensure that CMake is compiled with CMAKE_USE_OPENSSL enabled.")
+  endif()
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,9 @@ if(NOT GIT_FOUND)
 endif()
 mark_as_superbuild(GIT_EXECUTABLE)
 
+include(SlicerCheckCMakeHTTPS)
+slicer_check_cmake_https()
+
 #-----------------------------------------------------------------------------
 # Qt requirements
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Some build targets require downloading files using the HTTPS protocol. Before
this commit, targets such as 'python-source' would fail during the build process
with errors like:

    CMake Error at python-source-prefix/src/python-source-stamp/download-python-source.cmake:27 (message):
      error: downloading
      'https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz' failed

        status_code: 1
        status_string: "Unsupported protocol"
        log: Protocol "https" not supported or disabled in libcurl

This commit adds a configure-time check that CMake supports HTTPS. Now,
developers are made aware of the problem before building.

If CMake doesn't support HTTPS, the configuration step now fails with a
descriptive error message and a suggested solution:

    CMake Error at CMake/SlicerCheckCMakeHTTPS.cmake:21 (message):
      error: This CMake does not support the HTTPS protocol.  Ensure that CMake
      is compiled with CMAKE_USE_OPENSSL enabled.

Fixes http://www.na-mic.org/Bug/view.php?id=4098