### PR TITLE
BUG: Remove invalid assert while populating the scene

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSceneModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneModel.cxx
@@ -778,7 +778,6 @@ void qMRMLSceneModel::populateScene()
        (node = (vtkMRMLNode*)d->MRMLScene->GetNodes()->GetNextItemAsObject(it)) ;)
     {
     index++;
-    Q_ASSERT(index == d->RowCache.count());
     d->insertNode(node, index);
     }
   foreach(vtkMRMLNode* misplacedNode, d->MisplacedNodes)


### PR DESCRIPTION
The assert was checking whether the index of the current node
matches the row count. However, while inserting nodes, the
logic adds a parent node if there isn't one. This insertion of
parent node increments the RowCache size. Next time the assert
was encountered, it would fail.