### PR TITLE
BUG 2763: remove duplicate file browse button for CLI UIs

### DIFF
--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -871,17 +871,12 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createFileTagWidget(const ModuleParame
   QWidget* widget = new QWidget;
   ctkPathLineEdit* pathLineEdit =
     new ctkPathLineEdit(name, QStringList() << QString("*.*"), ctkPathLineEdit::Files, widget);
-  QToolButton* browseButton = new QToolButton(widget);
-  browseButton->setText("...");
-  QObject::connect(browseButton, SIGNAL(clicked()),
-                   pathLineEdit, SLOT(browse()));
 
   INSTANCIATE_WIDGET_VALUE_WRAPPER(File, name, label, pathLineEdit);
 
   QHBoxLayout* hBoxLayout = new QHBoxLayout;
   hBoxLayout->setContentsMargins(0,0,0,0);
   hBoxLayout->addWidget(pathLineEdit);
-  hBoxLayout->addWidget(browseButton);
   widget->setLayout(hBoxLayout);
   return widget;
 }


### PR DESCRIPTION
This PR resolves a bug where the file browse button was duplicated in CLI UIs. The solution was to remove the extra button as ctkPathLineEdit already provides its own browse button.