### PR TITLE
STYLE: Improve documentation of GetFirstNode()

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -197,7 +197,12 @@ public:
   ///
   /// By default, \a byName will be compared using an exact match. If
   /// \a exactNameMatch is set to \a false, the node will be returned if
-  /// its name starts with \a byName.
+  /// its name starts with \a byName. If the pointer \a byHideFromEditors
+  /// is not set, the function will return both the nodes hidden from
+  /// editors as well as the nodes visible in editors. If the pointer
+  /// \a byHideFromEditors is set, the function will only return the
+  /// nodes that are either hidden from editors or the nodes that are
+  /// visible in editors.
   vtkMRMLNode *GetFirstNode(const char* byName = 0, const char* byClass = 0,
                             const int* byHideFromEditors = 0,
                             bool exactNameMatch = true);


### PR DESCRIPTION
GetFirstNode third parameter "byHideFromEditor" was not explained
in the doxygen documentation. It did not seem intuitive to have
a parameter that is a pointer when one might expect to specify a
boolean. The new doxygen string explains that this is a 3-state
variable that is either disregarded if the pointer is set to 0,
or the function only returns a node that matches the given value
(hidden from editor or not).