### PR TITLE
ENH: Update VTK to handle default values for array parameters in python

### DIFF
--- a/SuperBuild/External_VTKv6.cmake
+++ b/SuperBuild/External_VTKv6.cmake
@@ -99,7 +99,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT ${CMAKE_PROJECT_N
   endif()
 
   set(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY "github.com/Slicer/VTK.git" CACHE STRING "Repository from which to get VTK" FORCE)
-  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "1c30cb0fe5270cf0d812a127e5cc6688b287093c" CACHE STRING "VTK git tag to use" FORCE)
+  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "4b9957be64185cb0b80ca58c5e6145dae5c94b2a" CACHE STRING "VTK git tag to use" FORCE)
 
   mark_as_advanced(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG)
 


### PR DESCRIPTION
Without this commit, one must specify parameters like (,int array[3]=0) when
the method is called from python.

$ git shortlog 1c30cb0..4b9957b --no-merges
David Gobbi (2):
      Fix wrapping pointer parameters with default value 0.
      Handle default values for array parameters in python.