### PR TITLE
ENH: Allow modules to detect when the user clicks on a markup fiducial

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -137,6 +137,7 @@ public:
     LockModifiedEvent = 19000,
     LabelFormatModifiedEvent,
     PointModifiedEvent,
+    PointStartInteractionEvent,
     PointEndInteractionEvent,
     NthMarkupModifiedEvent,
     MarkupAddedEvent,

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.cxx
@@ -231,16 +231,18 @@ void vtkMRMLMarkupsDisplayableManagerHelper::UpdateLocked(vtkMRMLMarkupsNode *no
           continue;
           }
         bool isLockedOnNthMarkup = node->GetNthMarkupLocked(i);
-        bool isLockedOnNthSeed = seedWidget->GetSeed(i)->GetProcessEvents() == 0;
+        bool isLockedOnNthSeed = seedWidget->GetSeed(i)->GetEnableTranslation() == 0;
         if (isLockedOnNthMarkup && !isLockedOnNthSeed)
           {
           // lock it
-          seedWidget->GetSeed(i)->ProcessEventsOff();
+          seedWidget->GetSeed(i)->ProcessEventsOn();
+          seedWidget->GetSeed(i)->EnableTranslationOff();
           }
         else if (!isLockedOnNthMarkup && isLockedOnNthSeed)
           {
           // unlock it
           seedWidget->GetSeed(i)->ProcessEventsOn();
+          seedWidget->GetSeed(i)->EnableTranslationOn();
           }
         }
       }

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
@@ -129,6 +129,10 @@ public:
       {
       // std::cout << "Warning: PlacePointEvent not supported" << std::endl;
       }
+    else if (event == vtkCommand::StartInteractionEvent)
+      {
+      this->Node->InvokeEvent(vtkMRMLMarkupsNode::PointStartInteractionEvent, callData);
+      }
     else if (event == vtkCommand::EndInteractionEvent)
       {
       // save the state of the node when done moving
@@ -337,7 +341,8 @@ void vtkMRMLMarkupsFiducialDisplayableManager2D::OnWidgetCreated(vtkAbstractWidg
   myCallback->SetNode(node);
   myCallback->SetWidget(widget);
   myCallback->SetDisplayableManager(this);
-  widget->AddObserver(vtkCommand::EndInteractionEvent,myCallback);
+  widget->AddObserver(vtkCommand::StartInteractionEvent, myCallback);
+  widget->AddObserver(vtkCommand::EndInteractionEvent, myCallback);
   widget->AddObserver(vtkCommand::InteractionEvent,myCallback);
   myCallback->Delete();
 
@@ -865,15 +870,16 @@ void vtkMRMLMarkupsFiducialDisplayableManager2D::SetNthSeed(int n, vtkMRMLMarkup
         (interactionNode->GetCurrentInteractionMode() == vtkMRMLInteractionNode::Place)
         && (interactionNode->GetPlaceModePersistence() == 1);
       }
-    if (listLocked || seedLocked || persistentPlaceMode)
+    vtkHandleWidget *seed = seedWidget->GetSeed(n);
+    if (listLocked || persistentPlaceMode)
       {
-      seedWidget->GetSeed(n)->ProcessEventsOff();
+      seed->ProcessEventsOff();
       }
     else
       {
-      seedWidget->GetSeed(n)->ProcessEventsOn();
+      seed->ProcessEventsOn();
+      seed->SetEnableTranslation(!seedLocked);
       }
-
     }
   else if (pointHandleRep)
     {


### PR DESCRIPTION
*** Do not integrate until https://github.com/lassoan/VTK/tree/seedwidget_point_select is integrated into Slicer's VTK ***

Many times a module need to know when the user selects an existing markup. Often the markup position has to be locked but we still want to be able to detect when the user clicked on it.

VTK allowed locking a seed but then no interaction is possible. VTK handle and seed widgets were improved (see https://github.com/lassoan/VTK/tree/seedwidget_point_select) to allow locking of position but still able to select.

Slicer markups module behavior was changed so that if a markup point is locked then it can still be selected (but not moved). If the entire markup node is locked then markup points cannot be selected or moved (same behavior as before).

How to test the new event:

---

@vtk.calldata_type(vtk.VTK_INT)
def markupCallback(caller, eventId, callData):
  print("PointStartInteractionEvent: {0}".format(callData))

markupsNode = getNode('F')
observerTag = markupsNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointStartInteractionEvent, markupCallback)

---

Markups module may be improved in the future to use this new event, for example select the markup in the markup list if it is selected in a 2D or 3D view. Also, selection state of markups could be changed when the user clicks on a markup (there could be single-select and multi-select modes).