### PR TITLE
ENH: Add support for managing slice orientation presets

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -307,6 +307,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
   slicer_add_python_unittest(SCRIPT RSNAVisTutorial.py)
   slicer_add_python_unittest(SCRIPT RSNAQuantTutorial.py)
   slicer_add_python_unittest(SCRIPT slicerCloseCrashBug2590.py)
+  slicer_add_python_unittest(SCRIPT SlicerOrientationSelectorTest.py)
   slicer_add_python_unittest(SCRIPT ViewControllersSliceInterpolationBug1926.py)
   slicer_add_python_unittest(SCRIPT RSNA2012ProstateDemo.py)
   slicer_add_python_unittest(SCRIPT JRC2013Vis.py)
@@ -332,6 +333,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
     RSNAVisTutorial.py
     RSNAQuantTutorial.py
     slicerCloseCrashBug2590.py
+    SlicerOrientationSelectorTest.py
     ViewControllersSliceInterpolationBug1926.py  
     RSNA2012ProstateDemo.py
     JRC2013Vis.py

--- a/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
@@ -1,0 +1,129 @@
+import os
+import unittest
+import vtk, qt, ctk, slicer
+from slicer.ScriptedLoadableModule import *
+import logging
+
+#
+# SlicerOrientationSelectorTest
+#
+
+class SlicerOrientationSelectorTest(ScriptedLoadableModule):
+  """Uses ScriptedLoadableModule base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "Create ruler crash (Issue 4199)"
+    self.parent.categories = ["Testing.TestCases"]
+    self.parent.dependencies = []
+    self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)",
+      "Davide Punzo (Kapteyn astronomical institute)"] # replace with "Firstname Lastname (Organization)"
+    self.parent.helpText = """This test has been added to check that
+    orientation selector is correctly updated when updating the SliceToRAS matrix.
+    """
+    self.parent.acknowledgementText = """
+    This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
+    and was partially funded by NIH grant 1U24CA194354-01.
+    """ # replace with organization, grant and thanks.
+
+#
+# SlicerOrientationSelectorTestWidget
+#
+
+class SlicerOrientationSelectorTestWidget(ScriptedLoadableModuleWidget):
+  """Uses ScriptedLoadableModuleWidget base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def setup(self):
+    ScriptedLoadableModuleWidget.setup(self)
+
+#
+# SlicerOrientationSelectorTestLogic
+#
+
+class SlicerOrientationSelectorTestLogic(ScriptedLoadableModuleLogic):
+  """This class should implement all the actual
+  computation done by your module.  The interface
+  should be such that other python code can import
+  this class and make use of the functionality without
+  requiring an instance of the Widget.
+  Uses ScriptedLoadableModuleLogic base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def hasImageData(self,volumeNode):
+    """This is an example logic method that
+    returns true if the passed in volume
+    node has valid image data
+    """
+    if not volumeNode:
+      logging.debug('hasImageData failed: no volume node')
+      return False
+    if volumeNode.GetImageData() is None:
+      logging.debug('hasImageData failed: no image data in volume node')
+      return False
+    return True
+
+class SlicerOrientationSelectorTestTest(ScriptedLoadableModuleTest):
+  """
+  This is the test case for your scripted module.
+  Uses ScriptedLoadableModuleTest base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def setUp(self):
+    """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+    """
+    slicer.mrmlScene.Clear(0)
+
+  def runTest(self):
+    """Run as few or as many tests as needed here.
+    """
+    self.setUp()
+    self.test_SlicerOrientationSelectorTest()
+
+  def test_SlicerOrientationSelectorTest(self):
+    """ Ideally you should have several levels of tests.  At the lowest level
+    tests should exercise the functionality of the logic with different inputs
+    (both valid and invalid).  At higher levels your tests should emulate the
+    way the user would interact with your code and confirm that it still works
+    the way you intended.
+    One of the most important features of the tests is that it should alert other
+    developers when their changes will have an impact on the behavior of your
+    module.  For example, if a developer removes a feature that you depend on,
+    your test should break so they know that the feature is needed.
+    """
+
+    logic = SlicerOrientationSelectorTestLogic()
+
+    self.delayDisplay("Starting the test")
+    import SampleData
+    sampleDataLogic = SampleData.SampleDataLogic()
+    mrHeadVolume = sampleDataLogic.downloadMRHead()
+
+    slicer.util.selectModule('Reformat')
+
+    # Select Red slice
+    widget = slicer.modules.reformat.widgetRepresentation()
+    sliceNodeSelector = slicer.util.findChildren(widget, "SliceNodeSelector")[0]
+    sliceNodeSelector.setCurrentNodeID("vtkMRMLSliceNodeRed")
+
+    # Set LR value using Reformat module
+    lrslider = slicer.util.findChildren(widget, "LRSlider")[0]
+    lrslider.value = 1
+
+    # Get reference to the Red slice controller
+    lm = slicer.app.layoutManager()
+    sliceWidget = lm.sliceWidget("Red")
+    sliceOrientationSelector = slicer.util.findChildren(sliceWidget, "SliceOrientationSelector")[0]
+
+    # Check orientations associated with orientations selector
+    orientations = [sliceOrientationSelector.itemText(idx) for idx in range(sliceOrientationSelector.count)]
+    expectedOrientations = ['Axial', 'Sagittal', 'Coronal', 'Reformat']
+    if orientations != expectedOrientations:
+      raise Exception('Problem with orientation selector\norientations: %s\nexpectedOrientations: %s' % (orientations, expectedOrientations))
+
+    self.delayDisplay('Test passed!')

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneTest2.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneTest2.cxx
@@ -14,6 +14,7 @@
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLNode.h"
 #include "vtkMRMLScene.h"
+#include "vtkMRMLSliceNode.h"
 
 // VTK includes
 #include <vtkCallbackCommand.h>
@@ -193,6 +194,9 @@ int vtkMRMLSceneTest2(int argc, char * argv [] )
   vtkSmartPointer<vtkMRMLScene>  scene = vtkSmartPointer<vtkMRMLScene>::New(); // vtkSmartPointer instead of vtkNew to allow SetPointer
   EXERCISE_BASIC_OBJECT_METHODS(scene.GetPointer());
   CHECK_INT(scene->GetNumberOfNodes(), 0);
+
+  // Add default slice orientation presets
+  vtkMRMLSliceNode::AddDefaultSliceOrientationPresets(scene);
 
   // Configure mrml event observer
   vtkNew<vtkMRMLSceneCallback> callback;

--- a/Libs/MRML/Core/Testing/vtkMRMLSliceNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSliceNodeTest1.cxx
@@ -10,12 +10,414 @@
 
 =========================================================================auto=*/
 
+#include "vtkAddonMathUtilities.h"
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLSliceNode.h"
 
+// VTK includes
+#include <vtkMatrix3x3.h>
+#include <vtkMatrix4x4.h>
+#include <vtkStringArray.h>
+
+
+//----------------------------------------------------------------------------
+void AddSliceOrientationPresets(vtkMRMLSliceNode *sliceNode);
+
+//----------------------------------------------------------------------------
+int AddSliceOrientationPresetTest();
+int RemoveSliceOrientationPresetTest();
+int RenameSliceOrientationPresetTest();
+int HasSliceOrientationPresetTest();
+int GetSliceOrientationPresetTest();
+int GetSliceOrientationPresetNameTest();
+int SetOrientationTest();
+int InitializeDefaultMatrixTest();
+
+//----------------------------------------------------------------------------
 int vtkMRMLSliceNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLSliceNode> node1;
+
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+
+  CHECK_INT(AddSliceOrientationPresetTest(), EXIT_SUCCESS);
+  CHECK_INT(RemoveSliceOrientationPresetTest(), EXIT_SUCCESS);
+  CHECK_INT(RenameSliceOrientationPresetTest(), EXIT_SUCCESS);
+  CHECK_INT(HasSliceOrientationPresetTest(), EXIT_SUCCESS);
+  CHECK_INT(GetSliceOrientationPresetTest(), EXIT_SUCCESS);
+  CHECK_INT(GetSliceOrientationPresetNameTest(), EXIT_SUCCESS);
+  CHECK_INT(SetOrientationTest(), EXIT_SUCCESS);
+  CHECK_INT(InitializeDefaultMatrixTest(), EXIT_SUCCESS);
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+void AddSliceOrientationPresets(vtkMRMLSliceNode* sliceNode)
+{
+  {
+    vtkNew<vtkMatrix3x3> preset;
+    vtkMRMLSliceNode::InitializeAxialMatrix(preset.GetPointer());
+
+    sliceNode->AddSliceOrientationPreset("Axial", preset.GetPointer());
+  }
+
+  {
+    vtkNew<vtkMatrix3x3> preset;
+    vtkMRMLSliceNode::InitializeSagittalMatrix(preset.GetPointer());
+
+    sliceNode->AddSliceOrientationPreset("Sagittal", preset.GetPointer());
+  }
+
+  {
+    vtkNew<vtkMatrix3x3> preset;
+    vtkMRMLSliceNode::InitializeCoronalMatrix(preset.GetPointer());
+
+    sliceNode->AddSliceOrientationPreset("Coronal", preset.GetPointer());
+  }
+}
+
+//----------------------------------------------------------------------------
+int CheckOrientationPresetNames(vtkMRMLSliceNode* sliceNode,
+                                std::vector<std::string> names)
+{
+  vtkNew<vtkStringArray> orientationPresetNames;
+  sliceNode->GetSliceOrientationPresetNames(orientationPresetNames.GetPointer());
+
+  CHECK_INT(orientationPresetNames->GetNumberOfValues(), static_cast<int>(names.size()));
+  for (int idx = 0; idx < static_cast<int>(names.size()); ++idx)
+    {
+    CHECK_STD_STRING(orientationPresetNames->GetValue(idx), names.at(idx));
+    }
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int AddSliceOrientationPresetTest()
+{
+  vtkNew<vtkMRMLSliceNode> sliceNode;
+
+  AddSliceOrientationPresets(sliceNode.GetPointer());
+
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  sliceNode->AddSliceOrientationPreset("Reformat", vtkSmartPointer<vtkMatrix3x3>());
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+
+  CHECK_INT(sliceNode->GetNumberOfSliceOrientationPresets(), 3);
+
+  std::vector<std::string> expectedOrientationNames;
+  expectedOrientationNames.push_back("Axial");
+  expectedOrientationNames.push_back("Sagittal");
+  expectedOrientationNames.push_back("Coronal");
+
+  CHECK_INT(CheckOrientationPresetNames(sliceNode.GetPointer(),
+                                        expectedOrientationNames), EXIT_SUCCESS);
+
+  return EXIT_SUCCESS;
+}
+
+namespace
+{
+//----------------------------------------------------------------------------
+void InitializeMatrix(vtkMatrix3x3* matrix, double value)
+{
+  for(int ii = 0; ii < 3; ++ii)
+    {
+    for(int jj = 0; jj < 3; ++jj)
+      {
+      matrix->SetElement(ii, jj, value);
+      }
+    }
+}
+}
+
+//----------------------------------------------------------------------------
+int RemoveSliceOrientationPresetTest()
+{
+  vtkNew<vtkMRMLSliceNode> sliceNode;
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->RemoveSliceOrientationPreset(""), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  vtkNew<vtkMatrix3x3> expectedOnes;
+  InitializeMatrix(expectedOnes.GetPointer(), 1);
+  sliceNode->AddSliceOrientationPreset("Ones", expectedOnes.GetPointer());
+
+  vtkNew<vtkMatrix3x3> expectedTwos;
+  InitializeMatrix(expectedTwos.GetPointer(), 2);
+  sliceNode->AddSliceOrientationPreset("Twos", expectedTwos.GetPointer());
+
+  vtkNew<vtkMatrix3x3> expectedThrees;
+  InitializeMatrix(expectedThrees.GetPointer(), 3);
+  sliceNode->AddSliceOrientationPreset("Threes", expectedThrees.GetPointer());
+
+  CHECK_BOOL(sliceNode->RemoveSliceOrientationPreset("Twos"), true);
+
+  std::vector<std::string> expectedOrientationNames;
+  expectedOrientationNames.push_back("Ones");
+  expectedOrientationNames.push_back("Threes");
+
+  CHECK_INT(CheckOrientationPresetNames(sliceNode.GetPointer(),
+                                        expectedOrientationNames), EXIT_SUCCESS);
+
+  CHECK_INT(sliceNode->GetSliceOrientationPreset("Ones")->GetElement(0, 0), 1);
+  CHECK_INT(sliceNode->GetSliceOrientationPreset("Threes")->GetElement(0, 0), 3);
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int RenameSliceOrientationPresetTest()
+{
+  vtkNew<vtkMRMLSliceNode> sliceNode;
+
+  AddSliceOrientationPresets(sliceNode.GetPointer());
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPreset("", "Axial"), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  {
+    std::vector<std::string> expectedOrientationNames;
+    expectedOrientationNames.push_back("Axial");
+    expectedOrientationNames.push_back("Sagittal");
+    expectedOrientationNames.push_back("Coronal");
+
+    CHECK_INT(CheckOrientationPresetNames(sliceNode.GetPointer(),
+                                          expectedOrientationNames), EXIT_SUCCESS);
+  }
+
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPreset("Axial", "Foo"), true);
+
+  {
+    std::vector<std::string> expectedOrientationNames;
+    expectedOrientationNames.push_back("Foo");
+    expectedOrientationNames.push_back("Sagittal");
+    expectedOrientationNames.push_back("Coronal");
+
+    CHECK_INT(CheckOrientationPresetNames(sliceNode.GetPointer(),
+                                          expectedOrientationNames), EXIT_SUCCESS);
+  }
+
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPreset("Coronal", "Bar"), true);
+
+  {
+    std::vector<std::string> expectedOrientationNames;
+    expectedOrientationNames.push_back("Foo");
+    expectedOrientationNames.push_back("Sagittal");
+    expectedOrientationNames.push_back("Bar");
+
+    CHECK_INT(CheckOrientationPresetNames(sliceNode.GetPointer(),
+                                          expectedOrientationNames), EXIT_SUCCESS);
+  }
+
+  // "Reformat" is a special value and can NOT be used as a preset.
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPreset("Sagittal", "Reformat"), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  {
+    std::vector<std::string> expectedOrientationNames;
+    expectedOrientationNames.push_back("Foo");
+    expectedOrientationNames.push_back("Sagittal");
+    expectedOrientationNames.push_back("Bar");
+
+    CHECK_INT(CheckOrientationPresetNames(sliceNode.GetPointer(),
+                                          expectedOrientationNames), EXIT_SUCCESS);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int HasSliceOrientationPresetTest()
+{
+  vtkNew<vtkMRMLSliceNode> sliceNode;
+
+  AddSliceOrientationPresets(sliceNode.GetPointer());
+
+  CHECK_BOOL(sliceNode->HasSliceOrientationPreset(""), false);
+  TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
+  CHECK_BOOL(sliceNode->HasSliceOrientationPreset("Reformat"), false);
+  TESTING_OUTPUT_ASSERT_WARNINGS_END();
+  CHECK_BOOL(sliceNode->HasSliceOrientationPreset("Coronal"), true);
+  CHECK_BOOL(sliceNode->HasSliceOrientationPreset("Sagittal"), true);
+  CHECK_BOOL(sliceNode->HasSliceOrientationPreset("Axial"), true);
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int GetSliceOrientationPresetTest()
+{
+  vtkNew<vtkMRMLSliceNode> sliceNode;
+
+  vtkNew<vtkMatrix3x3> expectedOnes;
+  InitializeMatrix(expectedOnes.GetPointer(), 1);
+
+  vtkNew<vtkMatrix3x3> expectedTwos;
+  InitializeMatrix(expectedTwos.GetPointer(), 2);
+
+  {
+    vtkNew<vtkMatrix3x3> ones;
+    ones->DeepCopy(expectedOnes.GetPointer());
+    sliceNode->AddSliceOrientationPreset("ones", ones.GetPointer());
+
+    vtkNew<vtkMatrix3x3> twos;
+    twos->DeepCopy(expectedTwos.GetPointer());
+    sliceNode->AddSliceOrientationPreset("twos", twos.GetPointer());
+  }
+
+  {
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    vtkMatrix3x3 * current =
+        sliceNode->GetSliceOrientationPreset("");
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+    CHECK_NULL(current);
+  }
+
+  {
+    vtkMatrix3x3 * current =
+        sliceNode->GetSliceOrientationPreset("ones");
+    CHECK_BOOL(vtkAddonMathUtilities::MatrixAreEqual(
+                 current, expectedOnes.GetPointer()), true);
+  }
+
+  {
+    vtkMatrix3x3 * current =
+        sliceNode->GetSliceOrientationPreset("twos");
+    CHECK_BOOL(vtkAddonMathUtilities::MatrixAreEqual(
+                 current, expectedTwos.GetPointer()), true);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int GetSliceOrientationPresetNameTest()
+{
+  vtkNew<vtkMRMLSliceNode> sliceNode;
+
+  vtkNew<vtkMatrix3x3> originalPreset;
+  vtkMRMLSliceNode::InitializeAxialMatrix(originalPreset.GetPointer());
+
+  vtkNew<vtkMatrix3x3> preset;
+  vtkMRMLSliceNode::InitializeAxialMatrix(preset.GetPointer());
+  sliceNode->AddSliceOrientationPreset("Axial", preset.GetPointer());
+
+
+  originalPreset->SetElement(1, 1,  1.0 + 1e-4);
+
+  CHECK_STD_STRING(sliceNode->GetSliceOrientationPresetName(
+                   originalPreset.GetPointer()), std::string("Axial"));
+
+  originalPreset->SetElement(1, 1,  1.0 + 1e-2);
+
+  CHECK_STD_STRING(sliceNode->GetSliceOrientationPresetName(
+                   originalPreset.GetPointer()), std::string(""));
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int SetOrientationTest()
+{
+  vtkNew<vtkMRMLSliceNode> sliceNode;
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->SetOrientation(0), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->SetOrientation(""), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Reformat"));
+
+  AddSliceOrientationPresets(sliceNode.GetPointer());
+
+  // Set a valid orientation
+  {
+    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    CHECK_BOOL(sliceNode->SetOrientation("Sagittal"), true);
+    CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Sagittal"));
+    CHECK_STRING(sliceNode->GetOrientationString(), "Sagittal");
+    CHECK_BOOL(sliceNode->GetSliceToRAS()->GetMTime() > sliceToRASMTime, true);
+  }
+
+  // Orientation are case sensitive
+  {
+    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_BOOL(sliceNode->SetOrientation("axial"), false);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+    CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Sagittal"));
+    CHECK_STRING(sliceNode->GetOrientationString(), "Sagittal");
+    CHECK_BOOL(sliceNode->GetSliceToRAS()->GetMTime() > sliceToRASMTime, false);
+  }
+
+  // The sliceToRAS matrix define the current orientation
+  {
+    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_BOOL(sliceNode->SetOrientation("Reformat"), false);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+    CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Sagittal"));
+    CHECK_STRING(sliceNode->GetOrientationString(), "Sagittal");
+
+    TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+    CHECK_BOOL(sliceNode->SetOrientation("Foo"), false);
+    TESTING_OUTPUT_ASSERT_ERRORS_END();
+    CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Sagittal"));
+    CHECK_STRING(sliceNode->GetOrientationString(), "Sagittal");
+    CHECK_BOOL(sliceNode->GetSliceToRAS()->GetMTime() > sliceToRASMTime, false);
+  }
+
+  // Check SetOrientationToAxial
+  {
+    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    CHECK_BOOL(sliceNode->SetOrientationToAxial(), true);
+    CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Axial"));
+    CHECK_STRING(sliceNode->GetOrientationString(), "Axial");
+    CHECK_BOOL(sliceNode->GetSliceToRAS()->GetMTime() > sliceToRASMTime, true);
+  }
+
+  // Check SetOrientationToSagittal
+  {
+    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    CHECK_BOOL(sliceNode->SetOrientationToSagittal(), true);
+    CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Sagittal"));
+    CHECK_STRING(sliceNode->GetOrientationString(), "Sagittal");
+    CHECK_BOOL(sliceNode->GetSliceToRAS()->GetMTime() > sliceToRASMTime, true);
+  }
+
+  // Check SetOrientationToCoronal
+  {
+    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    CHECK_BOOL(sliceNode->SetOrientationToCoronal(), true);
+    CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Coronal"));
+    CHECK_STRING(sliceNode->GetOrientationString(), "Coronal");
+    CHECK_BOOL(sliceNode->GetSliceToRAS()->GetMTime() > sliceToRASMTime, true);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int InitializeDefaultMatrixTest()
+{
+  vtkNew<vtkMatrix3x3> axial;
+  vtkMRMLSliceNode::InitializeAxialMatrix(axial.GetPointer());
+  CHECK_NOT_NULL(axial.GetPointer());
+
+  vtkNew<vtkMatrix3x3> coronal;
+  vtkMRMLSliceNode::InitializeCoronalMatrix(coronal.GetPointer());
+  CHECK_NOT_NULL(coronal.GetPointer());
+
+  vtkNew<vtkMatrix3x3> sagittal;
+  vtkMRMLSliceNode::InitializeSagittalMatrix(sagittal.GetPointer());
+  CHECK_NOT_NULL(sagittal.GetPointer());
+
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
@@ -25,6 +25,7 @@
 #include "vtkMRMLDisplayNode.h"
 #include "vtkMRMLNode.h"
 #include "vtkMRMLScene.h"
+#include "vtkMRMLSliceNode.h"
 #include "vtkMRMLStorableNode.h"
 #include "vtkMRMLStorageNode.h"
 #include "vtkMRMLTransformableNode.h"
@@ -579,6 +580,10 @@ int ExerciseSceneLoadingMethods(const char * sceneFilePath, vtkMRMLScene* inputS
     {
       scene = vtkSmartPointer<vtkMRMLScene>::New();
     }
+
+  // Add default slice orientation presets
+  vtkMRMLSliceNode::AddDefaultSliceOrientationPresets(scene);
+
   scene->SetURL(sceneFilePath);
   scene->Connect();
   int numberOfNodes = scene->GetNumberOfNodes();

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -20,6 +20,7 @@
 class vtkMRMLVolumeNode;
 
 // VTK includes
+class vtkMatrix3x3;
 class vtkMatrix4x4;
 
 /// \brief MRML node for storing a slice through RAS space.
@@ -31,6 +32,12 @@ class vtkMatrix4x4;
 class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
 {
   public:
+  /// \brief Instantiate a new Slice node without any orientation presets.
+  ///
+  /// \note To instantiate a vtkMRMLSliceNode with preconfigured
+  /// orientation preset matrices (the default presets are: Axial,
+  /// Sagittal and Coronal in default), it is necessary to use
+  /// vtkMRMLScene::CreateNodeByClass(const char*)
   static vtkMRMLSliceNode *New();
   vtkTypeMacro(vtkMRMLSliceNode,vtkMRMLAbstractViewNode);
   void PrintSelf(ostream& os, vtkIndent indent);
@@ -121,35 +128,106 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   /// If the associated orientation preset has been renamed or removed, calling
   /// these function returns \a False.
   ///
-  /// \sa SetOrientationString(const char*)
-  void SetOrientationToAxial();
-  void SetOrientationToSagittal();
-  void SetOrientationToCoronal();
+  /// \sa SetOrientation(const char*)
+  bool SetOrientationToAxial();
+  bool SetOrientationToSagittal();
+  bool SetOrientationToCoronal();
 
+  /// \brief Get orientation.
   ///
-  /// General 'reformat' view that allows for multiplanar reformat
-  void SetOrientationToReformat();
+  /// It returns a string with a description of the slice orientation
+  ///
+  /// \sa GetOrientation(vtkMatrix4x4* sliceToRAS)
+  /// \sa SetOrientation(const char* orientation)
+  std::string GetOrientation();
 
-  /// Convenient function that calls SetOrientationToAxial(),
-  /// SetOrientationToSagittal(), SetOrientationToCoronal() or
-  /// SetOrientationToReformat() depending on the value of the string
-  void SetOrientation(const char* orientation);
+  /// \brief Return the orientation name associated with \a sliceToRAS.
+  std::string GetOrientation(vtkMatrix4x4* sliceToRAS);
 
-  /// Description
-  /// A description of the current orientation
-  /// Warning, OrientationString doesn't change the matrices, use
-  /// SetOrientation() instead.
-  vtkGetStringMacro (OrientationString);
-  vtkSetStringMacro (OrientationString);
+  /// \brief Set orientation.
+  ///
+  /// It adjusts the SliceToRAS matrix to position the slice
+  /// cutting plane.
+  ///
+  /// Valid \a orientations are known as presets and are easily added,
+  /// removed or renamed.
+  ///
+  /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix4x4* sliceToRAS)
+  /// \sa UpdateMatrices()
+  bool SetOrientation(const char* orientation);
 
-  /// Description
+  /// \brief Get orientation.
+  ///
+  /// \deprecated Prefer GetOrientation()
+  virtual const char* GetOrientationString();
+
+protected:
+
   /// The OrientationReference is a place to store the last orientation
   /// that was explicitly selected.  This way if the RotateToVolumePlane
   /// is called repeatedly it will always return the same plane
   /// (without the hint, it would first try to match, say, Coronal, and then
   /// try to match 'Reformat' but would not know what overall orientation to pick).
+  ///
+  /// \deprecated
   vtkGetStringMacro (OrientationReference);
   vtkSetStringMacro (OrientationReference);
+
+public:
+
+  /// \brief Return the sliceToRAS matrix associated with \a name.
+  vtkMatrix3x3 *GetSliceOrientationPreset(const std::string& name);
+
+  /// \brief Return the preset name corresponding to \a orientationMatrix.
+  ///
+  /// Returns an empty string if \a orientationMatrix is not an existing
+  /// preset.
+  std::string GetSliceOrientationPresetName(vtkMatrix3x3* orientationMatrix);
+
+  /// \brief Return all the orientation preset names.
+  void GetSliceOrientationPresetNames(vtkStringArray* presetOrientationNames);
+
+  /// \brief Return number of orientation presets.
+  /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix3x3* orientationMatrix)
+  int GetNumberOfSliceOrientationPresets() const;
+
+  /// \brief Add an orientation preset.
+  ///
+  /// \sa RenameSliceOrientationPreset(const std::string& name, const std::string& updatedName)
+  /// \sa RemoveSliceOrientationPreset(const std::string& name)
+  bool AddSliceOrientationPreset(const std::string& name, vtkMatrix3x3* orientationMatrix);
+
+  /// \brief Remove an orientation preset.
+  ///
+  /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix4x4* sliceToRAS)
+  bool RemoveSliceOrientationPreset(const std::string& name);
+
+  /// \brief Rename an orientation preset.
+  ///
+  /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix4x4* sliceToRAS)
+  bool RenameSliceOrientationPreset(const std::string& name, const std::string& updatedName);
+
+  /// \brief Return True if an orientation preset is stored.
+  ///
+  /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix4x4* sliceToRAS)
+  bool HasSliceOrientationPreset(const std::string& name);
+
+  /// \brief Initialize \a orientationMatrix as an `Axial` orientation matrix.
+  static void InitializeAxialMatrix(vtkMatrix3x3* orientationMatrix);
+
+  /// \brief Initialize \a orientationMatrix as a `Sagittal` orientation matrix.
+  static void InitializeSagittalMatrix(vtkMatrix3x3* orientationMatrix);
+
+  /// \brief Initialize \a orientationMatrix as a `Coronal` orientation matrix.
+  static void InitializeCoronalMatrix(vtkMatrix3x3* orientationMatrix);
+
+  /// \brief Add default slice orientation presets to \a scene.
+  ///
+  /// \sa vtkMRMLScene::AddDefaultNode(vtkMRMLNode* node)
+  /// \sa InitializeAxialMatrix(vtkMatrix3x3* orientationMatrix)
+  /// \sa InitializeSagittalMatrix(vtkMatrix3x3* orientationMatrix)
+  /// \sa InitializeCoronalMatrix(vtkMatrix3x3* orientationMatrix)
+  static void AddDefaultSliceOrientationPresets(vtkMRMLScene* scene);
 
   ///
   /// Size of the slice plane in millimeters
@@ -229,8 +307,10 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
 
   ///
   /// helper for comparing to matrices
-  bool Matrix4x4AreEqual(const vtkMatrix4x4 *m1, const vtkMatrix4x4 *m2);
+  bool MatrixAreEqual(const vtkMatrix4x4 *m1, const vtkMatrix4x4 *m2);
 
+  bool MatrixAreEqual(const vtkMatrix4x4 *matrix,
+                      const vtkMatrix3x3 *orientationMatrix);
   ///
   /// Recalculate XYToSlice and XYToRAS in terms or fov, dim, SliceToRAS
   /// - called when any of the inputs change
@@ -420,6 +500,8 @@ protected:
   vtkSmartPointer<vtkMatrix4x4> UVWToSlice;
   vtkSmartPointer<vtkMatrix4x4> UVWToRAS;
 
+  typedef std::pair <std::string, vtkSmartPointer<vtkMatrix3x3> > OrientationPresetType;
+  std::vector< OrientationPresetType > OrientationMatrices;
 
   int JumpMode;
 
@@ -438,7 +520,9 @@ protected:
   int UVWDimensions[3];
   int UVWMaximumDimensions[3];
 
-  char *OrientationString;
+  // Hold the string returned by GetOrientationString
+  std::string OrientationString;
+
   char *OrientationReference;
 
   double LayoutColor[3];

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLApplicationLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLApplicationLogicTest1.cxx
@@ -21,6 +21,8 @@
 // MRML includes
 #include "vtkMRMLApplicationLogic.h"
 #include "vtkMRMLCoreTestingMacros.h"
+#include <vtkMRMLScene.h>
+#include <vtkMRMLSliceNode.h>
 
 // VTK includes
 #include <vtkCollection.h>
@@ -32,12 +34,14 @@
 
 //-----------------------------------------------------------------------------
 int SliceLogicsTest();
+int SliceOrientationPresetInitializationTest();
 int TemporaryPathTest();
 
 //-----------------------------------------------------------------------------
 int vtkMRMLApplicationLogicTest1(int , char * [])
 {
   CHECK_INT(SliceLogicsTest(), EXIT_SUCCESS);
+  CHECK_INT(SliceOrientationPresetInitializationTest(), EXIT_SUCCESS);
   CHECK_INT(TemporaryPathTest(), EXIT_SUCCESS);
   return EXIT_SUCCESS;
 }
@@ -95,6 +99,33 @@ int SliceLogicsTest()
     CHECK_NOT_NULL(appLogic->GetSliceLogics());
     CHECK_INT(appLogic->GetSliceLogics()->GetNumberOfItems(), 0);
     CHECK_BOOL(appLogic->GetMTime() > mtime, true);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+//-----------------------------------------------------------------------------
+int SliceOrientationPresetInitializationTest()
+{
+  {
+    vtkNew<vtkMRMLSliceNode> sliceNode;
+    CHECK_INT(sliceNode->GetNumberOfSliceOrientationPresets(), 0);
+  }
+
+  {
+    vtkNew<vtkMRMLScene> scene;
+    vtkMRMLSliceNode * defaultSliceNode =
+        vtkMRMLSliceNode::SafeDownCast(scene->GetDefaultNodeByClass("vtkMRMLSliceNode"));
+    CHECK_NULL(defaultSliceNode);
+  }
+
+  {
+    vtkNew<vtkMRMLScene> scene;
+    vtkNew<vtkMRMLApplicationLogic> appLogic;
+    appLogic->SetMRMLScene(scene.GetPointer());
+    vtkMRMLSliceNode * defaultSliceNode =
+        vtkMRMLSliceNode::SafeDownCast(scene->GetDefaultNodeByClass("vtkMRMLSliceNode"));
+    CHECK_INT(defaultSliceNode->GetNumberOfSliceOrientationPresets(), 3);
   }
 
   return EXIT_SUCCESS;

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -300,6 +300,9 @@ void vtkMRMLApplicationLogic::SetMRMLSceneInternal(vtkMRMLScene *newScene)
     }
   this->SetInteractionNode(vtkMRMLInteractionNode::SafeDownCast(interactionNode));
 
+  // Add default slice orientation presets
+  vtkMRMLSliceNode::AddDefaultSliceOrientationPresets(newScene);
+
   this->Superclass::SetMRMLSceneInternal(newScene);
 
   this->Internal->SliceLinkLogic->SetMRMLScene(newScene);

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -55,7 +55,7 @@ vtkStandardNewMacro(vtkMRMLSliceLayerLogic);
 
 bool AreMatricesEqual(const vtkMatrix4x4* first, const vtkMatrix4x4* second)
 {
-  return vtkAddonMathUtilities::MatrixAreEqual(first, second, /* tolerance= */ 0);
+  return vtkAddonMathUtilities::MatrixAreEqual(first, second);
 }
 
 // Convert a linear transform that is almost exactly a permute transform

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -45,6 +45,7 @@
 #include <vtkPlaneSource.h>
 #include <vtkPolyDataCollection.h>
 #include <vtkSmartPointer.h>
+#include <vtkStringArray.h>
 #include <vtkTransform.h>
 #include <vtkVersion.h>
 
@@ -228,7 +229,8 @@ void vtkMRMLSliceLogic::UpdateSliceNode()
     {
     if ( node == 0 )
       {
-      node = vtkMRMLSliceNode::New();
+      node = vtkMRMLSliceNode::SafeDownCast(
+            this->GetMRMLScene()->CreateNodeByClass("vtkMRMLSliceNode"));
       node->SetName(this->GetName());
       node->SetLayoutName(this->GetName());
       this->SetSliceNode (node);
@@ -264,17 +266,28 @@ void vtkMRMLSliceLogic::UpdateSliceNodeFromLayout()
     return;
     }
 
+  if (this->SliceNode->GetNumberOfSliceOrientationPresets() < 3)
+    {
+    vtkErrorMacro("UpdateSliceNodeFromLayout: " << this->GetName() <<
+                  " could not set its slice node orientation. At least 3"
+                  " orientation preset names are required.")
+    return;
+    }
+
+  vtkNew<vtkStringArray> namedOrientations;
+  this->SliceNode->GetSliceOrientationPresetNames(namedOrientations.GetPointer());
+
   if ( !strcmp( this->GetName(), "Red" ) )
     {
-    this->SliceNode->SetOrientationToAxial();
+    this->SliceNode->SetOrientation(namedOrientations->GetValue(0));
     }
   if ( !strcmp( this->GetName(), "Yellow" ) )
     {
-    this->SliceNode->SetOrientationToSagittal();
+    this->SliceNode->SetOrientation(namedOrientations->GetValue(1));
     }
   if ( !strcmp( this->GetName(), "Green" ) )
     {
-    this->SliceNode->SetOrientationToCoronal();
+    this->SliceNode->SetOrientation(namedOrientations->GetValue(2));
     }
 }
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest2.cxx
@@ -25,11 +25,12 @@
 #include "qMRMLSceneDisplayableModel.h"
 #include "qMRMLSortFilterProxyModel.h"
 
-
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 
-// STD includes
+// VTK includes
+#include <vtkNew.h>
 
 int qMRMLSceneDisplayableModelTest2(int argc, char * argv [] )
 {
@@ -48,6 +49,8 @@ int qMRMLSceneDisplayableModelTest2(int argc, char * argv [] )
     qMRMLSortFilterProxyModel sort;
     sort.setSourceModel(&model);
     vtkMRMLScene* scene = vtkMRMLScene::New();
+    vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+    applicationLogic->SetMRMLScene(scene);
     model.setMRMLScene(scene);
     scene->SetURL(argv[1]);
     scene->Connect();

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest2.cxx
@@ -32,6 +32,7 @@
 #include "qMRMLTreeView.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 
 // VTK includes
@@ -50,6 +51,8 @@ int qMRMLSceneModelHierarchyModelTest2(int argc, char * argv [])
     return EXIT_FAILURE;
     }
   vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(scene.GetPointer());
   scene->SetURL( argv[1] );
   scene->Connect();
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest2.cxx
@@ -26,9 +26,11 @@
 #include "qMRMLSortFilterProxyModel.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 
-// STD includes
+// VTK includes
+#include <vtkNew.h>
 
 int qMRMLSceneTransformModelTest2(int argc, char * argv [] )
 {
@@ -47,6 +49,8 @@ int qMRMLSceneTransformModelTest2(int argc, char * argv [] )
     qMRMLSortFilterProxyModel sort;
     sort.setSourceModel(&model);
     vtkMRMLScene* scene = vtkMRMLScene::New();
+    vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+    applicationLogic->SetMRMLScene(scene);
     model.setMRMLScene(scene);
     scene->SetURL(argv[1]);
     scene->Connect();

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetEventTranslatorPlayerTest1.cxx
@@ -35,6 +35,12 @@
 #include "qMRMLSliceControllerWidget.h"
 #include "qMRMLSceneFactoryWidget.h"
 
+// MRML includes
+#include <vtkMRMLApplicationLogic.h>
+
+// VTK includes
+#include <vtkNew.h>
+
 // STD includes
 #include <cstdlib>
 #include <iostream>
@@ -68,6 +74,9 @@ int qMRMLSliceControllerWidgetEventTranslatorPlayerTest1(int argc, char * argv [
   qMRMLSceneFactoryWidget sceneFactory;
   sceneFactory.generateScene();
   sceneFactory.generateNode("vtkMRMLViewNode");
+
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(sceneFactory.mrmlScene());
 
   widget->setMRMLScene(sceneFactory.mrmlScene());
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
@@ -27,6 +27,7 @@
 #include "qMRMLNodeObject.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLColorTableNode.h>
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLScene.h>
@@ -50,6 +51,8 @@ int qMRMLSliceWidgetTest1(int argc, char * argv [] )
     }
 
   vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(scene.GetPointer());
   scene->SetURL(argv[1]);
   scene->Connect();
   if (scene->GetNumberOfNodes() == 0)

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest2.cxx
@@ -30,10 +30,12 @@
 
 // MRML includes
 #include <vtkMRMLAbstractSliceViewDisplayableManager.h>
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLColorTableNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSliceLogic.h>
 #include <vtkMRMLSliceCompositeNode.h>
+#include <vtkMRMLSliceNode.h>
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLScalarVolumeDisplayNode.h>
 #include <vtkMRMLVolumeArchetypeStorageNode.h>
@@ -88,6 +90,9 @@ int qMRMLSliceWidgetTest2(int argc, char * argv [] )
     }
 
   vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(scene.GetPointer());
+
   vtkMRMLScalarVolumeNode* scalarNode = loadVolume(argv[1], scene.GetPointer());
   if (scalarNode == 0)
     {
@@ -98,6 +103,7 @@ int qMRMLSliceWidgetTest2(int argc, char * argv [] )
   QSize viewSize(256, 256);
   qMRMLSliceWidget sliceWidget;
   sliceWidget.setMRMLScene(scene.GetPointer());
+
   sliceWidget.resize(viewSize.width(), sliceWidget.sliceController()->height() + viewSize.height() );
 
   vtkMRMLSliceCompositeNode* sliceCompositeNode = sliceWidget.sliceLogic()->GetSliceCompositeNode();

--- a/Libs/MRML/Widgets/Testing/qMRMLTreeViewEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTreeViewEventTranslatorPlayerTest1.cxx
@@ -39,6 +39,7 @@
 #include <qMRMLTreeViewEventTranslator.h>
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLModelNode.h>
 #include <vtkMRMLModelDisplayNode.h>
@@ -90,6 +91,8 @@ int qMRMLTreeViewEventTranslatorPlayerTest1(int argc, char * argv [] )
   qMRMLTreeView widget;
 
   vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(scene.GetPointer());
   widget.setMRMLScene(scene.GetPointer());
   scene->SetURL(argv[2]);
   scene->Import();
@@ -107,6 +110,7 @@ int qMRMLTreeViewEventTranslatorPlayerTest1(int argc, char * argv [] )
   vtkNew<vtkMRMLModelDisplayNode> displayModelNode2;
 
   vtkNew<vtkMRMLScene> scene2;
+  applicationLogic->SetMRMLScene(scene2.GetPointer());
   scene2->AddNode(modelNode.GetPointer());
   scene2->AddNode(modelNode2.GetPointer());
   scene2->AddNode(displayModelNode.GetPointer());

--- a/Libs/MRML/Widgets/Testing/qMRMLTreeViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTreeViewTest1.cxx
@@ -22,6 +22,7 @@
 #include <qMRMLTreeView.h>
 #include <qMRMLSceneTransformModel.h>
 
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 
 #include <vtkTimerLog.h>
@@ -41,18 +42,23 @@ int qMRMLTreeViewTest1( int argc, char * argv [] )
   std::cout << std::endl<< "***************************************" << std::endl;
   vtkTimerLog* timer = vtkTimerLog::New();
   vtkMRMLScene* scene = vtkMRMLScene::New();
+  vtkMRMLApplicationLogic* applicationLogic = vtkMRMLApplicationLogic::New();
+  applicationLogic->SetMRMLScene(scene);
   scene->SetURL(argv[1]);
   timer->StartTimer();
   scene->Import();
   timer->StopTimer();
   std::cout << std::endl << "Loaded: " << timer->GetElapsedTime() << std::endl;
   timer->StartTimer();
+  applicationLogic->Delete();
   scene->Delete();
   timer->StopTimer();
   std::cout << std::endl << "Deleted: " << timer->GetElapsedTime() << std::endl;
 
   std::cout << std::endl<< "***************************************" << std::endl;
   scene = vtkMRMLScene::New();
+  applicationLogic = vtkMRMLApplicationLogic::New();
+  applicationLogic->SetMRMLScene(scene);
   qMRMLSceneModel   sceneModel;
   sceneModel.setMRMLScene(scene);
   scene->SetURL(argv[1]);
@@ -61,12 +67,15 @@ int qMRMLTreeViewTest1( int argc, char * argv [] )
   timer->StopTimer();
   std::cout << "qMRMLSceneModel Loaded: " << timer->GetElapsedTime() << std::endl;
   timer->StartTimer();
+  applicationLogic->Delete();
   scene->Delete();
   timer->StopTimer();
   std::cout << "qMRMLSceneModel Deleted: " << timer->GetElapsedTime() << std::endl;
 
   std::cout << std::endl<< "***************************************" << std::endl;
   scene = vtkMRMLScene::New();
+  applicationLogic = vtkMRMLApplicationLogic::New();
+  applicationLogic->SetMRMLScene(scene);
   qMRMLSceneTransformModel   transformModel;
   transformModel.setMRMLScene(scene);
   scene->SetURL(argv[1]);
@@ -75,12 +84,15 @@ int qMRMLTreeViewTest1( int argc, char * argv [] )
   timer->StopTimer();
   std::cout << "qMRMLSceneTransformModel Loaded: " << timer->GetElapsedTime() << std::endl;
   timer->StartTimer();
+  applicationLogic->Delete();
   scene->Delete();
   timer->StopTimer();
   std::cout << "qMRMLSceneTransformModel Deleted: " << timer->GetElapsedTime() << std::endl;
 
   std::cout << std::endl<< "***************************************" << std::endl;
   scene = vtkMRMLScene::New();
+  applicationLogic = vtkMRMLApplicationLogic::New();
+  applicationLogic->SetMRMLScene(scene);
   qMRMLSceneTransformModel   transformModel2;
   transformModel2.setMRMLScene(scene);
   qMRMLSortFilterProxyModel  sortModel;
@@ -91,6 +103,7 @@ int qMRMLTreeViewTest1( int argc, char * argv [] )
   timer->StopTimer();
   std::cout << "qMRMLSceneTransformModel(+qMRMLSortFilterProxyModel) Loaded: " << timer->GetElapsedTime() << std::endl;
   timer->StartTimer();
+  applicationLogic->Delete();
   scene->Delete();
   timer->StopTimer();
   std::cout << "qMRMLSceneTransformModel(+qMRMLSortFilterProxyModel) Deleted: " << timer->GetElapsedTime() << std::endl;
@@ -98,6 +111,8 @@ int qMRMLTreeViewTest1( int argc, char * argv [] )
 
   std::cout << std::endl<< "***************************************" << std::endl;
   scene = vtkMRMLScene::New();
+  applicationLogic = vtkMRMLApplicationLogic::New();
+  applicationLogic->SetMRMLScene(scene);
   qMRMLTreeView   mrmlItem;
   mrmlItem.setMRMLScene(scene);
   scene->SetURL(argv[1]);
@@ -106,12 +121,15 @@ int qMRMLTreeViewTest1( int argc, char * argv [] )
   timer->StopTimer();
   std::cout << "qMRMLTreeView Loaded: " << timer->GetElapsedTime() << std::endl;
   timer->StartTimer();
+  applicationLogic->Delete();
   scene->Delete();
   timer->StopTimer();
   std::cout << "qMRMLTreeView Deleted: " << timer->GetElapsedTime() << std::endl;
 
   std::cout << std::endl<< "***************************************" << std::endl;
   scene = vtkMRMLScene::New();
+  applicationLogic = vtkMRMLApplicationLogic::New();
+  applicationLogic->SetMRMLScene(scene);
   qMRMLTreeView   treeWidget;
   treeWidget.show();
   treeWidget.setMRMLScene(scene);
@@ -121,6 +139,7 @@ int qMRMLTreeViewTest1( int argc, char * argv [] )
   timer->StopTimer();
   std::cout << "qMRMLTreeView visible Loaded: " << timer->GetElapsedTime() << std::endl;
   timer->StartTimer();
+  applicationLogic->Delete();
   scene->Delete();
   timer->StopTimer();
   std::cout << "qMRMLTreeView visible Deleted: " << timer->GetElapsedTime() << std::endl;

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.cxx
@@ -35,6 +35,7 @@
 #include "qMRMLVolumeThresholdWidget.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLColorLogic.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLVolumeNode.h>
@@ -71,6 +72,8 @@ int qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1(int argc, char * argv [
 
   // Test case 1
   vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(scene.GetPointer());
   scene->SetURL(argv[2]);
   scene->Connect();
 

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
@@ -26,6 +26,7 @@
 #include "qMRMLVolumeThresholdWidget.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLVolumeNode.h>
 
@@ -47,6 +48,9 @@ int qMRMLVolumeThresholdWidgetTest1(int argc, char * argv [] )
     }
 
   vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(scene.GetPointer());
+
   scene->SetURL(argv[1]);
   scene->Connect();
   if (scene->GetNumberOfNodes() == 0)

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
@@ -28,6 +28,7 @@
 #include "qMRMLVolumeThresholdWidget.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSliceNode.h>
 #include <vtkMRMLVolumeNode.h>
@@ -53,6 +54,8 @@ int qMRMLVolumeThresholdWidgetTest2(int argc, char * argv [] )
     }
 
   vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(scene.GetPointer());
 
   // Add default color nodes
   vtkNew<vtkMRMLColorLogic> colorLogic;

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.cxx
@@ -35,6 +35,7 @@
 #include "qMRMLWindowLevelWidget.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLVolumeNode.h>
 
@@ -70,6 +71,8 @@ int qMRMLWindowLevelWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 
   // Test case 1
   vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(scene.GetPointer());
   scene->SetURL(argv[2]);
   scene->Connect();
   scene->InitTraversal();

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
@@ -27,6 +27,7 @@
 #include "qMRMLWindowLevelWidget.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLVolumeNode.h>
 
@@ -48,6 +49,9 @@ int qMRMLWindowLevelWidgetTest1(int argc, char * argv [] )
     }
 
   vtkNew<vtkMRMLScene> scene;
+  vtkNew<vtkMRMLApplicationLogic> applicationLogic;
+  applicationLogic->SetMRMLScene(scene.GetPointer());
+
   scene->SetURL(argv[1]);
   scene->Connect();
   if (scene->GetNumberOfNodes() == 0)

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
@@ -76,6 +76,7 @@ class QMRML_WIDGETS_EXPORT qMRMLSliceControllerWidgetPrivate
   Q_DECLARE_PUBLIC(qMRMLSliceControllerWidget);
 
 public:
+  typedef qMRMLSliceControllerWidgetPrivate Self;
   typedef qMRMLViewControllerBarPrivate Superclass;
   qMRMLSliceControllerWidgetPrivate(qMRMLSliceControllerWidget& object);
   virtual ~qMRMLSliceControllerWidgetPrivate();
@@ -105,6 +106,11 @@ public:
 
   void setForegroundInterpolation(vtkMRMLSliceLogic* logic, bool interpolate);
   void setBackgroundInterpolation(vtkMRMLSliceLogic* logic, bool interpolate);
+
+  /// Create a list of orientation containing the regular presets and also
+  /// the "Reformat" string if sliceToRAS is different one of the preset.
+  static void updateSliceOrientationSelector(
+      vtkMRMLSliceNode* sliceNode, QComboBox *sliceOrientationSelector);
 
 public slots:
   /// Update widget state when the scene is modified
@@ -141,7 +147,7 @@ public slots:
 
 protected:
   virtual void setupPopupUi();
-  void setMRMLSliceNodeInternal(vtkMRMLSliceNode* sliceNode);
+  virtual void setMRMLSliceNodeInternal(vtkMRMLSliceNode* sliceNode);
   void setMRMLSliceCompositeNodeInternal(vtkMRMLSliceCompositeNode* sliceComposite);
 
 public:

--- a/Libs/MRML/Widgets/qMRMLSliceInformationWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceInformationWidget.cxx
@@ -22,6 +22,7 @@
 #include <QDebug>
 
 // qMRML includes
+#include "qMRMLSliceControllerWidget_p.h" // For updateSliceOrientationSelector
 #include "qMRMLSliceInformationWidget_p.h"
 
 // MRML includes
@@ -95,11 +96,8 @@ void qMRMLSliceInformationWidgetPrivate::updateWidgetFromMRMLSliceNode()
   // Update layout name
   this->LayoutNameLineEdit->setText(QLatin1String(this->MRMLSliceNode->GetLayoutName()));
 
-  // Update orientation selector state
-  int index = this->SliceOrientationSelector->findText(
-      QString::fromStdString(this->MRMLSliceNode->GetOrientationString()));
-  Q_ASSERT(index>=0 && index <=4);
-  this->SliceOrientationSelector->setCurrentIndex(index);
+  qMRMLSliceControllerWidgetPrivate::updateSliceOrientationSelector(
+        this->MRMLSliceNode, this->SliceOrientationSelector);
 
   // Update slice visibility toggle
   this->SliceVisibilityToggle->setChecked(this->MRMLSliceNode->GetSliceVisible());
@@ -207,18 +205,12 @@ void qMRMLSliceInformationWidget::setSliceOrientation(const QString& orientation
 {
   Q_D(qMRMLSliceInformationWidget);
 
-#ifndef QT_NO_DEBUG
-  QStringList expectedOrientation;
-  expectedOrientation << "Axial" << "Sagittal" << "Coronal" << "Reformat";
-  Q_ASSERT(expectedOrientation.contains(orientation));
-#endif
-
   if (!d->MRMLSliceNode)
     {
     return;
     }
 
-  d->MRMLSliceNode->SetOrientationString(orientation.toLatin1());
+  d->MRMLSliceNode->SetOrientation(orientation.toLatin1());
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
@@ -23,6 +23,7 @@
 #include <QString>
 
 // SlicerQt includes
+#include "qMRMLSliceControllerWidget_p.h" // For updateSliceOrientationSelector
 #include "vtkMRMLSliceNode.h"
 #include "vtkSlicerReformatLogic.h"
 
@@ -259,11 +260,8 @@ void qSlicerReformatModuleWidgetPrivate::updateOrientationGroupBox()
     return;
     }
 
-  // Update the selector
-  int index = this->SliceOrientationSelector->findText(
-      QString::fromStdString(this->MRMLSliceNode->GetOrientationString()));
-  Q_ASSERT(index>=0 && index <=4);
-  this->SliceOrientationSelector->setCurrentIndex(index);
+  qMRMLSliceControllerWidgetPrivate::updateSliceOrientationSelector(
+        this->MRMLSliceNode, this->SliceOrientationSelector);
 
   // Update the normal spinboxes
   bool wasNormalBlocking = this->NormalCoordinatesWidget->blockSignals(true);
@@ -640,15 +638,7 @@ onSliceOrientationChanged(const QString& orientation)
   d->resetSlider(d->PASlider);
   d->resetSlider(d->ISSlider);
 
-#ifndef QT_NO_DEBUG
-  QStringList expectedOrientation;
-  expectedOrientation << tr("Axial") << tr("Sagittal")
-                      << tr("Coronal") << tr("Reformat");
-  Q_ASSERT(expectedOrientation.contains(orientation));
-#endif
-
   d->MRMLSliceNode->SetOrientation(orientation.toLatin1());
-  d->MRMLSliceNode->SetOrientationString(orientation.toLatin1());
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Units/Testing/Cxx/vtkSlicerUnitsLogicTest1.cxx
+++ b/Modules/Loadable/Units/Testing/Cxx/vtkSlicerUnitsLogicTest1.cxx
@@ -22,6 +22,7 @@
 #include "vtkSlicerUnitsLogic.h"
 
 // MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSelectionNode.h>
 #include <vtkMRMLUnitNode.h>
@@ -257,7 +258,9 @@ bool testImportScene(const char* sceneFilePath)
 
   std::cout << "  ...import" << std::endl;
   scene->SetURL(sceneFilePath);
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   scene->Import();
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
 
   // Test scene
   std::vector<vtkMRMLNode*> nodes;


### PR DESCRIPTION
This commit generalizes the concept of slice orientation known as
Axial, Sagittal and Coronal so that it is possible to add, rename and
delete new ones.

Default presets (Axial, Sagittal and Coronal) are associated to a default
slice node in the application logic.

Handle orientation as 3x3 because maintaining sliceOrigin information
in matrices that are orientation presets is not relevant.

Notes:

(1) Mark Get/SetOrientationReference as protected: These methods are only
    used internally and could ultimately be removed by refactoring
    "RotateToVolumePlane()"

(2) Remove unused SetOrientationString: The method is not used in any Slicer
    extensions.

(3) Explicitly setting the orienation string to "Reformat" is
    not not needed anymore because "GetOrientation()" or "GetOrientationString()"
    will return "Reformat" if the SliceToRAS matrix is not one of the preset.

(4) For sake of consistency, in the RenameSliceOrientationPreset, the
    orientation reference is also renamed.

(5) In "Copy()" method, Orientation and OrientationReference are set
    after the presets.

(6) Remove unneeded SetOrientationToReformat() function.

Co-authored-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
Co-authored-by: Andras Lasso <lasso@queensu.ca>