### PR TITLE
BUG: Fix logging warning message when slicer.vtkPVScalarBarActor doesn't exist

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -1,5 +1,6 @@
 from __future__ import division
 import os
+import logging
 import qt
 import vtk
 import slicer
@@ -22,7 +23,7 @@ class SliceAnnotations(VTKObservationMixin):
     VTKObservationMixin.__init__(self)
     self.hasVTKPVScalarBarActor = hasattr(slicer, 'vtkPVScalarBarActor')
     if not self.hasVTKPVScalarBarActor:
-      slicer.logging.warning("SliceAnnotations: Disable features relying on vtkPVScalarBarActor")
+      logging.warning("SliceAnnotations: Disable features relying on vtkPVScalarBarActor")
 
     self.layoutManager = layoutManager
     if self.layoutManager is None:


### PR DESCRIPTION
This commit fixes a bug with logging a warning message. Because 'slicer.logging'
doesn't exist, the call to 'slicer.logging.warning()' failed with an error like:

      File "/path/to/Slicer-build/lib/Slicer-4.5/qt-scripted-modules/DataProbeLib/SliceViewAnnotations.py", line 25, in __init__
	slicer.logging.warning("SliceAnnotations: Disable features relying on vtkPVScalarBarActor")
    AttributeError: 'module' object has no attribute 'logging'

Now the code calls 'logging.warning()'.

This warning was added in r24058. As described in that commit, the warning can
be triggered by starting Slicer with '--disable-builtin-loadable-modules'.