### PR TITLE
BUG: Fix py_nomainwindow_SlicerOptionIgnoreSlicerRCTest

### DIFF
--- a/Applications/SlicerApp/Testing/Python/SlicerOptionIgnoreSlicerRCTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOptionIgnoreSlicerRCTest.py
@@ -43,10 +43,10 @@ if __name__ == '__main__':
   common_args = ['--disable-modules', '--no-main-window']
 
   loadedMsg = "Slicer RC file loaded"
-  slicerrc = tempfile.mkstemp()[1]
+  fd, slicerrc = tempfile.mkstemp()
   assert os.path.isfile(slicerrc)
   try:
-    with open(slicerrc, 'w') as file:
+    with os.fdopen(fd, 'w') as file:
       file.write("print('" + loadedMsg + "')\n")
     os.environ['SLICERRC'] = slicerrc
     if debug:


### PR DESCRIPTION
This commit fixes an error when running py_nomainwindow_SlicerOptionIgnoreSlicerRCTest. On Windows the error message is similar to:

      File "C:/D/N/Slicer-0/Applications/SlicerApp/Testing/Python/SlicerOptionIgnoreSlicerRCTest.py", line 79, in <module>
	os.remove(slicerrc)
    WindowsError: [Error 32] The process cannot access the file because it is being used by another process: 'c:\\users\\slicer~1\\appdata\\local\\temp\\tmpqu7b2u'

The issue is that tempfile.mkstemp() returns an OS-level handle to an open file.
Using Python's open() function on the filename opens the file a second time.
Therefore, an error occurs when attempting to remove the file, because the
handle opened by tempfile.mkstemp() has not been closed.

Replacing open() with os.fdopen() is one way to fix the issue. In that case, the
file is opened only once.