### PR TITLE
BUG: 2087 - Configuration of vtkSlicerVersionConfigure.cmake.in at bu…

### DIFF
--- a/CMake/SlicerConfigurevtkSlicerVersionConfigure.cmake
+++ b/CMake/SlicerConfigurevtkSlicerVersionConfigure.cmake
@@ -1,0 +1,60 @@
+################################################################################
+#
+#  Program: 3D Slicer
+#
+#  Copyright (c) Kitware Inc.
+#
+#  See COPYRIGHT.txt
+#  or http://www.slicer.org/copyright/copyright.txt for details.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
+#  and was partially funded by NIH grant 3P41RR013218-12S1
+#
+################################################################################
+
+
+#-----------------------------------------------------------------------------
+# Slicer version number.
+#-----------------------------------------------------------------------------
+# Releases define a tweak level
+#set(Slicer_VERSION_TWEAK 1)
+#set(Slicer_VERSION_RC 0)
+
+set(CMAKE_MODULE_PATH
+  ${Slicer_MODULE_PATH}
+  ${CMAKE_MODULE_PATH})
+include(${SlicerMacroExtractRepositoryInfo_PATH})
+SlicerMacroExtractRepositoryInfo(VAR_PREFIX Slicer SOURCE_DIR ${Slicer_SOURCE_DIR}) # Used to configure vtkSlicerVersionConfigure.h.in
+string(REGEX REPLACE ".*([0-9][0-9][0-9][0-9]\\-[0-9][0-9]\\-[0-9][0-9]).*" "\\1"
+  Slicer_BUILDDATE "${Slicer_WC_LAST_CHANGED_DATE}")
+
+if(NOT Slicer_FORCED_WC_REVISION STREQUAL "")
+  set(Slicer_WC_REVISION "${Slicer_FORCED_WC_REVISION}")
+endif()
+if("${Slicer_VERSION_TWEAK}" STREQUAL "")
+  set(_version_qualifier "-${Slicer_BUILDDATE}")
+elseif("${Slicer_VERSION_TWEAK}" GREATER 0)
+  set(_version_qualifier "-${Slicer_VERSION_TWEAK}")
+endif()
+
+# XXX This variable should not be set explicitly
+set(Slicer_VERSION      "${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}")
+set(Slicer_VERSION_FULL "${Slicer_VERSION}.${Slicer_VERSION_PATCH}")
+if(Slicer_VERSION_RC)
+  set(Slicer_VERSION_FULL "${Slicer_VERSION_FULL}-rc${Slicer_VERSION_RC}")
+endif()
+set(Slicer_VERSION_FULL "${Slicer_VERSION_FULL}${_version_qualifier}")
+
+message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} version [${Slicer_VERSION_FULL}]")
+message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} revision [${Slicer_WC_REVISION}]")
+
+  configure_file(
+    ${Slicer_SOURCE_DIR}/CMake/vtkSlicerVersionConfigure.h.in
+    ${Slicer_BINARY_DIR}/vtkSlicerVersionConfigure.h
+    )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,7 +359,7 @@ mark_as_advanced(ADDITIONAL_CXX_FLAGS)
 #-----------------------------------------------------------------------------
 include(CMakeParseArguments)
 include(Slicer3PluginsMacros)
-include(SlicerMacroExtractRepositoryInfo)
+include(SlicerMacroExtractRepositoryInfo RESULT_VARIABLE SlicerMacroExtractRepositoryInfo_PATH)
 include(SlicerMacroGetOperatingSystemArchitectureBitness)
 if(Slicer_BUILD_I18N_SUPPORT)
   include(SlicerMacroTranslation)
@@ -1056,7 +1056,6 @@ get_property(Slicer_QM_OUTPUT_DIRS GLOBAL PROPERTY Slicer_QM_OUTPUT_DIRS)
 
 set(files
   vtkSlicerConfigure.h
-  vtkSlicerVersionConfigure.h
   )
 foreach(f ${files})
   configure_file(
@@ -1064,6 +1063,26 @@ foreach(f ${files})
     ${CMAKE_CURRENT_BINARY_DIR}/${f}
     )
 endforeach()
+# Configured at build time
+add_custom_target(ConfigurevtkSlicerVersionConfigure
+                  COMMAND ${CMAKE_COMMAND}
+                  -DSlicer_MODULE_PATH:PATH=${CMAKE_CURRENT_SOURCE_DIR}/CMake
+                  -DSlicer_SOURCE_DIR:PATH=${CMAKE_CURRENT_SOURCE_DIR}
+                  -DSlicer_BINARY_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}
+                  -DSlicer_MAIN_PROJECT_APPLICATION_NAME:STRING=${Slicer_MAIN_PROJECT_APPLICATION_NAME}
+                  -DSlicerMacroExtractRepositoryInfo_PATH:FILEPATH=${SlicerMacroExtractRepositoryInfo_PATH}
+                  -DSlicer_VERSION_MAJOR:STRING=${Slicer_VERSION_MAJOR}
+                  -DSlicer_VERSION_MINOR:STRING=${Slicer_VERSION_MINOR}
+                  -DSlicer_VERSION_PATCH:STRING=${Slicer_VERSION_PATCH}
+                  -DSlicer_OS_LINUX_NAME:STRING=${Slicer_OS_LINUX_NAME}
+                  -DSlicer_OS_MAC_NAME:STRING=${Slicer_OS_MAC_NAME}
+                  -DSlicer_OS_WIN_NAME:STRING=${Slicer_OS_WIN_NAME}
+                  -DSlicer_ARCHITECTURE:STRING=${Slicer_ARCHITECTURE}
+                  -DSlicer_FORCED_WC_REVISION:STRING=${Slicer_FORCED_WC_REVISION}
+                  -DSlicer_OS:STRING=${Slicer_OS}
+                  -P ${CMAKE_CURRENT_SOURCE_DIR}/CMake/SlicerConfigurevtkSlicerVersionConfigure.cmake
+                 )
+list(APPEND files vtkSlicerVersionConfigure.h)
 if(NOT Slicer_INSTALL_NO_DEVELOPMENT)
   install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/vtkSlicerConfigure.h"


### PR DESCRIPTION
…ild time.

vtkSlicerVersionConfigure.cmake was build at configuration time. As
reported in bug report 2087 [1], if one updates the source code of Slicer,
this file main not always be updated. This patch configures
vtkSlicerVersionConfigure.cmake at build time instead.

[1] http://na-mic.org/Mantis/view.php?id=2087