### PR TITLE
Update deprecated VTK usage

### DIFF
--- a/Libs/MRML/Core/vtkITKTransformConverter.h
+++ b/Libs/MRML/Core/vtkITKTransformConverter.h
@@ -190,9 +190,9 @@ bool vtkITKTransformConverter::SetVTKLinearTransformFromITK(
       {
       for (unsigned int j=0; j < D; j++)
         {
-        (*transformVtk_LPS)[i][j] = dlt->GetMatrix()[i][j];
+        transformVtk_LPS->SetElement(i, j, dlt->GetMatrix()[i][j]);
         }
-      (*transformVtk_LPS)[i][D] = dlt->GetOffset()[i];
+      transformVtk_LPS->SetElement(i, D, dlt->GetOffset()[i]);
       }
     }
 
@@ -211,7 +211,7 @@ bool vtkITKTransformConverter::SetVTKLinearTransformFromITK(
     convertedToVtkMatrix=true;
     for (unsigned int i=0; i < D; i++)
       {
-      (*transformVtk_LPS)[i][i] = dst->GetScale()[i];
+      transformVtk_LPS->SetElement(i, i, dst->GetScale()[i]);
       }
     }
 
@@ -223,7 +223,7 @@ bool vtkITKTransformConverter::SetVTKLinearTransformFromITK(
     convertedToVtkMatrix=true;
     for (unsigned int i=0; i < D; i++)
       {
-      (*transformVtk_LPS)[i][D] = dtt->GetOffset()[i];
+      transformVtk_LPS->SetElement(i, D, dtt->GetOffset()[i]);
       }
     }
 
@@ -278,9 +278,9 @@ bool vtkITKTransformConverter::SetITKLinearTransformFromVTK(vtkObject* loggerObj
     {
     for (unsigned int j=0; j < VTKDimension; j++)
       {
-      itkmat[i][j] = (*vtkmat)[i][j];
+      itkmat[i][j] = vtkmat->GetElement(i, j);
       }
-    itkoffset[i] = (*vtkmat)[i][VTKDimension];
+    itkoffset[i] = vtkmat->GetElement(i, VTKDimension);
     }
 
   AffineTransformType::Pointer affine = AffineTransformType::New();

--- a/Libs/vtkTeem/vtkHyperPointandArray.h
+++ b/Libs/vtkTeem/vtkHyperPointandArray.h
@@ -17,7 +17,7 @@
 #include "vtkTeemConfigure.h"
 
 #include "vtkSystemIncludes.h"
-#include "vtkStreamer.h"
+#include "vtkHyperStreamline.h"
 
 
 /// copied directly from vtkHyperStreamline.

--- a/Libs/vtkTeem/vtkTractographyPointAndArray.h
+++ b/Libs/vtkTeem/vtkTractographyPointAndArray.h
@@ -16,7 +16,7 @@
 #define __vtkTractographyPointAndArray_h
 
 #include "vtkSystemIncludes.h"
-#include "vtkStreamer.h"
+#include "vtkHyperStreamline.h"
 #include "vtkTeemConfigure.h"
 
 /// copied directly from vtkTractographyStreamline.

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.h
@@ -20,7 +20,7 @@ class vtkVolumeProperty;
 
 // STD includes
 #include <string>
-#include <vtksys/stl/vector>
+#include <vector>
 
 #define COUNT_CROPPING_REGION_PLANES 6
 


### PR DESCRIPTION
In preparation for upgrading the version of VTK that Slicer uses, update the usage of several deprecated headers and functions.
