### PR TITLE
ENH: Update OpenIGTLinkIF to include compilation fixes for VTK 7.1

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -179,7 +179,7 @@ list(APPEND Slicer_REMOTE_DEPENDENCIES jqPlot)
 
 Slicer_Remote_Add(OpenIGTLinkIF
   GIT_REPOSITORY ${git_protocol}://github.com/openigtlink/OpenIGTLinkIF.git
-  GIT_TAG 9271ec55d4cb0bbeaee4ead84e8c242e9d0ad320
+  GIT_TAG f3ebcbd78f102f832ed037cbc89b08720e329af1
   OPTION_NAME Slicer_BUILD_OpenIGTLinkIF
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_USE_OpenIGTLink"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
OpenIGTLink updates:

    $ git shortlog 9271ec5..f3ebcbd --no-merges
    Max Smolens (1):
	  Fix compilation with VTK 7.1