### PR TITLE
BUG: 3350 correct slice offset when fit to volume is called

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -1640,7 +1640,7 @@ void vtkMRMLSliceLogic::FitSliceToVolume(vtkMRMLVolumeNode *volumeNode, int widt
   //sliceNode->SetSliceOffset(offset);
 
   //TODO Fit UVW space
-
+  this->SnapSliceOffsetToIJK();
   sliceNode->UpdateMatrices( );
 }
 


### PR DESCRIPTION
fixes http://na-mic.org/Mantis/view.php?id=3350 . There are duplicated code paths to call this method, there will be another pull request refactoring to prevent future bugs.