### PR TITLE
Update to VTK 7

### DIFF
--- a/Base/Python/tpycl/tpycl.py
+++ b/Base/Python/tpycl/tpycl.py
@@ -98,13 +98,14 @@ class tpycl(object):
     """ make a unique name for an instance using the classname and
     pointer in hex
     - assumes the string form of the instance will end with hex
-      encoding of the pointer, for example: '(vtkImageData)0x2a9a750'
+      encoding of the pointer, for example:
+      '(vtkCommonDataModelPython.vtkImageData)00000216A218BA08'
+    - name is valid for use as a tcl variable name
     """
-    # used to work with vtk 5.6
-    #return "%s%s" % (instance.GetClassName(), repr(instance).split()[-1][:-1])
-    # now just strip off the parens
-    return repr(instance).replace('(','').replace(')','')
-
+    return ''.join(
+        '_' if c == '.' else c
+        for c in repr(instance)
+        if c not in '()')
 
   def py_del(self,instanceName):
     """ deletes a named instance

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,7 +512,7 @@ if(Slicer_BUILD_CLI_SUPPORT)
 endif()
 
 #-----------------------------------------------------------------------------
-# VTKv6 - Slicer_VTK_COMPONENTS
+# VTKv7 - Slicer_VTK_COMPONENTS
 #-----------------------------------------------------------------------------
 set(Slicer_VTK_RENDERING_BACKEND "OpenGL" CACHE STRING "Choose the rendering backend.")
 set_property(CACHE Slicer_VTK_RENDERING_BACKEND PROPERTY STRINGS "OpenGL" "OpenGL2")
@@ -524,7 +524,6 @@ set(Slicer_VTK_COMPONENTS
   vtkFiltersFlowPaths
   vtkFiltersGeometry
   vtkGUISupportQtOpenGL
-  vtkGUISupportQtWebkit
   vtkGUISupportQtSQL
   vtkIOImage
   vtkIOLegacy
@@ -748,7 +747,7 @@ endif()
 #-----------------------------------------------------------------------------
 # VTK
 #-----------------------------------------------------------------------------
-find_package(VTK 6.1 COMPONENTS ${Slicer_VTK_COMPONENTS} REQUIRED NO_MODULE)
+find_package(VTK 7.1 COMPONENTS ${Slicer_VTK_COMPONENTS} REQUIRED NO_MODULE)
 if(NOT TARGET vtkGUISupportQt)
   message(FATAL_ERROR "error: VTK was not configured to use QT, you probably need "
                     "to recompile it with VTK_USE_GUISUPPORT ON, VTK_Group_Qt ON, "

--- a/Libs/MRML/Core/vtkMRMLDoubleArrayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDoubleArrayNode.cxx
@@ -71,12 +71,12 @@ void vtkMRMLDoubleArrayNode::WriteXML(ostream& of, int nIndent)
     double xy[3];
     for (int i = 0; i < n; i ++)
       {
-      this->Array->GetTupleValue(i, xy);
+      this->Array->GetTypedTuple(i, xy);
       ssX    << xy[0] << ", ";
       ssY    << xy[1] << ", ";
       ssYerr << xy[2] << ", ";
       }
-    this->Array->GetTupleValue(n, xy);
+    this->Array->GetTypedTuple(n, xy);
     // put the last values
     ssX    << xy[0];
     ssY    << xy[1];
@@ -170,7 +170,7 @@ void vtkMRMLDoubleArrayNode::ReadXMLAttributes(const char** atts)
         xy[0] = valueX[i];
         xy[1] = valueY[i];
         xy[2] = valueYErr[i];
-        this->Array->SetTupleValue(i, xy);
+        this->Array->SetTypedTuple(i, xy);
         }
       }
     }
@@ -187,7 +187,7 @@ void vtkMRMLDoubleArrayNode::ReadXMLAttributes(const char** atts)
         xy[0] = valueX[i];
         xy[1] = valueY[i];
         xy[2] = 0.0;
-        this->Array->SetTupleValue(i, xy);
+        this->Array->SetTypedTuple(i, xy);
         }
       }
     }
@@ -267,7 +267,7 @@ int vtkMRMLDoubleArrayNode::GetValues(int index, double* values)
     {
     return 0;
     }
-  this->Array->GetTupleValue(index, values);
+  this->Array->GetTypedTuple(index, values);
   return 1;
 }
 
@@ -351,7 +351,7 @@ int vtkMRMLDoubleArrayNode::SetValues(int index, double* values)
     {
     return 0;
     }
-  this->Array->SetTupleValue(index, values);
+  this->Array->SetTypedTuple(index, values);
   this->Modified();
   return 1;
 }
@@ -501,7 +501,7 @@ void vtkMRMLDoubleArrayNode::GetRange(double* rangeX, double* rangeY, int fInclu
   if (nTuples > 0)
     {
     // Get the first values as an initial value
-    this->Array->GetTupleValue(0, xy);
+    this->Array->GetTypedTuple(0, xy);
     rangeX[0] = xy[0];
     rangeX[1] = xy[0];
     rangeY[0] = xy[1] - c * xy[2];
@@ -510,7 +510,7 @@ void vtkMRMLDoubleArrayNode::GetRange(double* rangeX, double* rangeY, int fInclu
     // Search the array
     for (int i = 1; i < nTuples; i ++)
       {
-      this->Array->GetTupleValue(i, xy);
+      this->Array->GetTypedTuple(i, xy);
 
       // X value
       if (xy[0] < rangeX[0])
@@ -559,14 +559,14 @@ void vtkMRMLDoubleArrayNode::GetXRange(double* range)
     {
 
     // Get the first values as an initial value
-    this->Array->GetTupleValue(0, xy);
+    this->Array->GetTypedTuple(0, xy);
     range[0] = xy[0];
     range[1] = xy[0];
 
     // Search the array
     for (int i = 1; i < nTuples; i ++)
       {
-      this->Array->GetTupleValue(i, xy);
+      this->Array->GetTypedTuple(i, xy);
       if (xy[0] < range[0])
         {
         range[0] = xy[0];
@@ -615,14 +615,14 @@ void vtkMRMLDoubleArrayNode::GetYRange(double* range, int fIncludeError)
     {
 
     // Get the first values as an initial value
-    this->Array->GetTupleValue(0, xy);
+    this->Array->GetTypedTuple(0, xy);
     range[0] = xy[1] - c * xy[2];
     range[1] = xy[1] + c * xy[2];
 
     // Search the array
     for (int i = 1; i < nTuples; i ++)
       {
-      this->Array->GetTupleValue(i, xy);
+      this->Array->GetTypedTuple(i, xy);
       double low  = xy[1] - c * xy[2];
       double high = xy[1] + c * xy[2];
 

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.h
@@ -125,6 +125,7 @@ public:
   /// Get subject hierarchy node belonging to a certain segment
   vtkMRMLSubjectHierarchyNode* GetSegmentSubjectHierarchyNode(std::string segmentID);
 
+#ifndef __VTK_WRAP__
 //BTX
   /// Build merged labelmap of the binary labelmap representations of the specified segments
   /// \param mergedImageData Output image data for the merged labelmap image data
@@ -134,6 +135,7 @@ public:
   /// \return Success flag
   virtual bool GenerateMergedLabelmap(vtkOrientedImageData* mergedImageData, int extentComputationMode, vtkOrientedImageData* mergedLabelmapGeometry = NULL, const std::vector<std::string>& segmentIDs = std::vector<std::string>());
 //ETX
+#endif // __VTK_WRAP__
 
   /// Python-accessible version of the more generic \sa GenerateMergedLabelmap.
   /// The last argument specifying the list of segments to be included is omitted, which means that

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceViewDisplayableManagerFactory.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceViewDisplayableManagerFactory.h
@@ -67,10 +67,12 @@ private:
 
 };
 
+#ifndef __VTK_WRAP__
 //BTX
 VTK_SINGLETON_DECLARE_INITIALIZER(VTK_MRML_DISPLAYABLEMANAGER_EXPORT,
                                   vtkMRMLSliceViewDisplayableManagerFactory);
 //ETX
+#endif // __VTK_WRAP__
 
 #endif
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDReformatDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDReformatDisplayableManager.cxx
@@ -226,7 +226,7 @@ NewImplicitPlaneWidget()
 {
   // Instantiate implcite plane widget and his representation
   vtkNew<vtkImplicitPlaneRepresentation> rep;
-  double defaultBounds[6] = {100, -100, 100, -100, 100, -100};
+  double defaultBounds[6] = {-100, 100, -100, 100, -100, 100};
   rep->PlaceWidget(defaultBounds);
   rep->SetOutlineTranslation(0);
   rep->SetScaleEnabled(0);

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewDisplayableManagerFactory.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewDisplayableManagerFactory.h
@@ -67,9 +67,11 @@ private:
 
 };
 
+#ifndef __VTK_WRAP__
 //BTX
 VTK_SINGLETON_DECLARE_INITIALIZER(VTK_MRML_DISPLAYABLEMANAGER_EXPORT,
                                   vtkMRMLThreeDViewDisplayableManagerFactory);
 //ETX
+#endif // __VTK_WRAP__
 
 #endif

--- a/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
@@ -121,7 +121,7 @@ void vtkITKExecuteDataFromFileDiffusionTensor3D(
         value[i + 3 * j] = float(tensor(i, j));
         }
       }
-    tensors->SetTupleValue(position, value);
+    tensors->SetTypedTuple(position, value);
     }
 }
 

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
@@ -15,9 +15,9 @@
 #include "vtkITKArchetypeImageSeriesScalarReader.h"
 
 // VTK includes
+#include <vtkAOSDataArrayTemplate.h>
 #include <vtkCommand.h>
 #include <vtkDataArray.h>
-#include <vtkDataArrayTemplate.h>
 #include <vtkImageData.h>
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
@@ -35,9 +35,9 @@ vtkStandardNewMacro(vtkITKArchetypeImageSeriesScalarReader);
 namespace {
 
 template <class T>
-vtkDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
+vtkAOSDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
 {
-  return vtkDataArrayTemplate<T>::FastDownCast(a);
+  return vtkAOSDataArrayTemplate<T>::FastDownCast(a);
 }
 
 };
@@ -120,7 +120,7 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
       void *ptr = static_cast<void *> (PixelContainer##typeN->GetBufferPointer());\
       DownCast<type>(data->GetPointData()->GetScalars())                \
         ->SetVoidArray(ptr, PixelContainer##typeN->Size(), 0,\
-                       vtkDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
+                       vtkAOSDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
       PixelContainer##typeN->ContainerManageMemoryOff();\
     }\
     break
@@ -154,7 +154,7 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
       void *ptr = static_cast<void *> (PixelContainer2##typeN->GetBufferPointer());\
       DownCast<type>(data->GetPointData()->GetScalars())                \
         ->SetVoidArray(ptr, PixelContainer2##typeN->Size(), 0,\
-                       vtkDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
+                       vtkAOSDataArrayTemplate<type>::VTK_DATA_ARRAY_DELETE);\
       PixelContainer2##typeN->ContainerManageMemoryOff();\
     }\
     break

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
@@ -16,9 +16,9 @@
 #include "vtkITKArchetypeImageSeriesVectorReaderFile.h"
 
 // VTK includes
+#include <vtkAOSDataArrayTemplate.h>
 #include <vtkCommand.h>
 #include <vtkDataArray.h>
-#include <vtkDataArrayTemplate.h>
 #include <vtkImageData.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
@@ -32,9 +32,9 @@ vtkStandardNewMacro(vtkITKArchetypeImageSeriesVectorReaderFile);
 namespace {
 
 template <class T>
-vtkDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
+vtkAOSDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
 {
-  return vtkDataArrayTemplate<T>::FastDownCast(a);
+  return vtkAOSDataArrayTemplate<T>::FastDownCast(a);
 }
 
 };
@@ -89,7 +89,7 @@ void vtkITKExecuteDataFromFileVector(
   void *ptr = static_cast<void *> (PixelContainer2->GetBufferPointer());
   DownCast<T>(data->GetPointData()->GetScalars())
     ->SetVoidArray(ptr, PixelContainer2->Size(), 0,
-                   vtkDataArrayTemplate<T>::VTK_DATA_ARRAY_DELETE);
+                   vtkAOSDataArrayTemplate<T>::VTK_DATA_ARRAY_DELETE);
   PixelContainer2->ContainerManageMemoryOff();
 }
 

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
@@ -16,9 +16,9 @@
 #include "vtkITKArchetypeImageSeriesVectorReaderSeries.h"
 
 // VTK includes
+#include <vtkAOSDataArrayTemplate.h>
 #include <vtkCommand.h>
 #include <vtkDataArray.h>
-#include <vtkDataArrayTemplate.h>
 #include <vtkImageData.h>
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
@@ -38,9 +38,9 @@ vtkStandardNewMacro(vtkITKArchetypeImageSeriesVectorReaderSeries);
 namespace {
 
 template <class T>
-vtkDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
+vtkAOSDataArrayTemplate<T>* DownCast(vtkAbstractArray* a)
 {
-  return vtkDataArrayTemplate<T>::FastDownCast(a);
+  return vtkAOSDataArrayTemplate<T>::FastDownCast(a);
 }
 
 };
@@ -101,7 +101,7 @@ void vtkITKExecuteDataFromSeriesVector(
   void *ptr = static_cast<void *> (PixelContainer->GetBufferPointer());
   DownCast<T>(data->GetPointData()->GetScalars())
     ->SetVoidArray(ptr, PixelContainer->Size(), 0,
-                   vtkDataArrayTemplate<T>::VTK_DATA_ARRAY_DELETE);
+                   vtkAOSDataArrayTemplate<T>::VTK_DATA_ARRAY_DELETE);
   PixelContainer->ContainerManageMemoryOff();
 }
 

--- a/Libs/vtkITK/vtkITKImageWriter.cxx
+++ b/Libs/vtkITK/vtkITKImageWriter.cxx
@@ -321,8 +321,13 @@ void vtkITKImageWriter::Write()
     }
 
   this->UpdateInformation();
-  this->SetUpdateExtent(this->GetOutputInformation(0)->Get(
-                        vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()));
+  if (this->GetOutputInformation(0))
+    {
+    this->GetOutputInformation(0)->Set(
+      vtkStreamingDemandDrivenPipeline::UPDATE_EXTENT(),
+      this->GetOutputInformation(0)->Get(
+        vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()), 6);
+    }
   int inputDataType =
     pointData->GetScalars() ? pointData->GetScalars()->GetDataType() :
     pointData->GetTensors() ? pointData->GetTensors()->GetDataType() :

--- a/Libs/vtkITK/vtkITKImageWriter.cxx
+++ b/Libs/vtkITK/vtkITKImageWriter.cxx
@@ -483,7 +483,7 @@ void vtkITKImageWriter::Write()
         float outValue[6];
         for(int i=0; i<out->GetNumberOfTuples(); i++)
           {
-          in->GetTupleValue(i, inValue);
+          in->GetTypedTuple(i, inValue);
           //ITK expect tensors saved in upper-triangular format
           outValue[0] = inValue[0];
           outValue[1] = inValue[1];

--- a/Libs/vtkITK/vtkITKLevelTracing3DImageFilter.cxx
+++ b/Libs/vtkITK/vtkITKLevelTracing3DImageFilter.cxx
@@ -186,7 +186,7 @@ int vtkITKLevelTracing3DImageFilter::RequestData(
 
       out = static_cast<unsigned char>((2125.0 * in[0] +  7154.0 * in[1] +  0721.0 * in[2]) / 10000.0);
 
-      grayScalars->SetTupleValue(i, &out);
+      grayScalars->SetTypedTuple(i, &out);
       }
 
     vtkITKLevelTracing3DTrace(this,

--- a/Libs/vtkITK/vtkITKLevelTracingImageFilter.cxx
+++ b/Libs/vtkITK/vtkITKLevelTracingImageFilter.cxx
@@ -292,7 +292,7 @@ int vtkITKLevelTracingImageFilter::RequestData(
 
       out = static_cast<unsigned char>((2125.0 * in[0] +  7154.0 * in[1] +  0721.0 * in[2]) / 10000.0);
 
-      grayScalars->SetTupleValue(i, &out);
+      grayScalars->SetTypedTuple(i, &out);
       }
 
     vtkITKLevelTracingTrace(this,

--- a/Libs/vtkITK/vtkITKTimeSeriesDatabase.cxx
+++ b/Libs/vtkITK/vtkITKTimeSeriesDatabase.cxx
@@ -60,6 +60,6 @@ void vtkITKTimeSeriesDatabase::ExecuteDataWithInformation(vtkDataObject *output,
     vtkUnsignedLongArray::SafeDownCast(
       vtkImageData::SafeDownCast(output)->GetPointData()->GetScalars())
       ->SetVoidArray(ptr, PixelContainerShort->Size(), 0,
-                     vtkDataArrayTemplate<unsigned long>::VTK_DATA_ARRAY_DELETE);
+                     vtkAOSDataArrayTemplate<unsigned long>::VTK_DATA_ARRAY_DELETE);
     PixelContainerShort->ContainerManageMemoryOff();
   };

--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -111,6 +111,7 @@ public:
   /// \sa vtkMRMLStorableNode::GetModifiedSinceRead()
   virtual bool GetModifiedSinceRead();
 
+#ifndef __VTK_WRAP__
 //BTX
   /// Determine common labelmap geometry for whole segmentation.
   /// If the segmentation has reference image geometry conversion parameter, then oversample it to
@@ -128,6 +129,7 @@ public:
   /// \param computeEffectiveExtent Specifies if the extent of a segment is the whole extent or the effective extent (where voxel values >0 found)
   void DetermineCommonLabelmapExtent(int commonGeometryExtent[6], vtkOrientedImageData* commonGeometryImage, const std::vector<std::string>& segmentIDs = std::vector<std::string>(), bool computeEffectiveExtent=false);
 //ETX
+#endif // __VTK_WRAP__
 
 // Segment related methods
 public:

--- a/Libs/vtkTeem/vtkNRRDReader.cxx
+++ b/Libs/vtkTeem/vtkNRRDReader.cxx
@@ -849,7 +849,14 @@ int vtkNRRDReader::tenSpaceDirectionReduce(Nrrd *nout, const Nrrd *nin, double S
 // are assumed to be the same as the file extent/order.
 void vtkNRRDReader::ExecuteDataWithInformation(vtkDataObject *output, vtkInformation* outInfo)
 {
-  this->SetUpdateExtentToWholeExtent();
+  if (this->GetOutputInformation(0))
+    {
+    this->GetOutputInformation(0)->Set(
+      vtkStreamingDemandDrivenPipeline::UPDATE_EXTENT(),
+      this->GetOutputInformation(0)->Get(
+        vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()), 6);
+    }
+
   vtkImageData *imageData = this->AllocateOutputData(output, outInfo);
 
   if (this->GetFileName() == NULL)

--- a/Libs/vtkTeem/vtkSeedTracts.cxx
+++ b/Libs/vtkTeem/vtkSeedTracts.cxx
@@ -856,13 +856,13 @@ void vtkSeedTracts::TransformStreamlinesToRASAndAppendToPolyData(vtkPolyData *ou
       }
     vtkIdTypeArray *cellArrayTransf = transformer->GetOutput()->GetLines()->GetData();
     cellIndex = cellArrayTransf->GetNumberOfTuples()-1;
-    cellArray->SetTupleValue(cellId, &cellIndex);
+    cellArray->SetTypedTuple(cellId, &cellIndex);
     cellId++;
     for (int k=1; k<cellArrayTransf->GetNumberOfTuples(); k++)
       {
       //cellArray->InsertNextValue(ptOffset+cellArrayTransf->GetValue(k));
       cellIndex = ptOffset+cellArrayTransf->GetValue(k);
-      cellArray->SetTupleValue(cellId, &cellIndex);
+      cellArray->SetTypedTuple(cellId, &cellIndex);
       cellId++;
       }
     ptOffset += transformer->GetOutput()->GetNumberOfPoints();

--- a/Modules/Loadable/VolumeRendering/VolumeRenderingReplacements/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/VolumeRenderingReplacements/CMakeLists.txt
@@ -81,7 +81,9 @@ list(APPEND Module_SRCS
   ${CMAKE_CURRENT_BINARY_DIR}/${vtk-module}ObjectFactory.cxx)
 set_source_files_properties(
   ${vtk-module}ObjectFactory.cxx
-  WRAP_EXCLUDE
+  PROPERTIES
+    WRAP_EXCLUDE 1
+    WRAP_EXCLUDE_PYTHON 1
   )
 list(APPEND module_replacements_SRCS ${vtk-module}ObjectFactory.cxx)
 

--- a/Modules/Loadable/VolumeRendering/VolumeRenderingReplacements/vtkSlicerFixedPointVolumeRayCastMapper.cxx
+++ b/Modules/Loadable/VolumeRendering/VolumeRenderingReplacements/vtkSlicerFixedPointVolumeRayCastMapper.cxx
@@ -1197,9 +1197,7 @@ void vtkSlicerFixedPointVolumeRayCastMapper::PerVolumeInitialization( vtkRendere
     }
     else
     {
-        this->UpdateInformation();
-        this->SetUpdateExtentToWholeExtent();
-        this->Update();
+        this->UpdateWholeExtent();
     }
 
     // Compute some matrices from voxels to view and vice versa based

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -91,7 +91,7 @@ mark_as_superbuild(
 
 set(ITK_EXTERNAL_NAME ITKv4)
 
-set(VTK_EXTERNAL_NAME VTKv6)
+set(VTK_EXTERNAL_NAME VTKv7)
 
 set(Slicer_DEPENDENCIES curl teem ${VTK_EXTERNAL_NAME} ${ITK_EXTERNAL_NAME} CTK LibArchive)
 

--- a/SuperBuild/External_VTKv7.cmake
+++ b/SuperBuild/External_VTKv7.cmake
@@ -1,5 +1,5 @@
 
-set(proj VTKv6)
+set(proj VTKv7)
 
 # Set dependency list
 set(${proj}_DEPENDENCIES "zlib")
@@ -99,7 +99,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT ${CMAKE_PROJECT_N
   endif()
 
   set(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY "github.com/Slicer/VTK.git" CACHE STRING "Repository from which to get VTK" FORCE)
-  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "f08b7db25fc76c0c256e040835e9aa8426a18c7c" CACHE STRING "VTK git tag to use" FORCE)
+  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "8f2ca638dfcc0cecf2fb5d42d99d35d46d837dcc" CACHE STRING "VTK git tag to use" FORCE)
 
   mark_as_advanced(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG)
 


### PR DESCRIPTION
This updates Slicer to use VTK 7.

See:
- https://www.slicer.org/slicerWiki/index.php/Documentation/Labs/VTK7.
- http://massmail.spl.harvard.edu/public-archives/slicer-devel/2016/040450.html