### PR TITLE
BUG: the labels on the controller widget were swapped

### DIFF
--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -334,12 +334,12 @@ void qMRMLThreeDViewControllerWidget::updateWidgetFromMRML()
     }
 
   QStringList axesLabels;
-  axesLabels <<  d->ViewNode->GetAxisLabel(0);
   axesLabels <<  d->ViewNode->GetAxisLabel(1);
-  axesLabels <<  d->ViewNode->GetAxisLabel(4);
+  axesLabels <<  d->ViewNode->GetAxisLabel(0);
   axesLabels <<  d->ViewNode->GetAxisLabel(5);
-  axesLabels <<  d->ViewNode->GetAxisLabel(2);
+  axesLabels <<  d->ViewNode->GetAxisLabel(4);
   axesLabels <<  d->ViewNode->GetAxisLabel(3);
+  axesLabels <<  d->ViewNode->GetAxisLabel(2);
   d->AxesWidget->setAxesLabels(axesLabels);
 
   d->actionSet3DAxisVisible->setChecked(d->ViewNode->GetBoxVisible());

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -333,13 +333,15 @@ void qMRMLThreeDViewControllerWidget::updateWidgetFromMRML()
     return;
     }
 
+  // In the axes widget the order of labels is: +X, -X, +Z, -Z, +Y, -Y
+  // and in the view node axis labels order is: -X, +X, -Y, +Y, -Z, +Z.
   QStringList axesLabels;
-  axesLabels <<  d->ViewNode->GetAxisLabel(1);
-  axesLabels <<  d->ViewNode->GetAxisLabel(0);
-  axesLabels <<  d->ViewNode->GetAxisLabel(5);
-  axesLabels <<  d->ViewNode->GetAxisLabel(4);
-  axesLabels <<  d->ViewNode->GetAxisLabel(3);
-  axesLabels <<  d->ViewNode->GetAxisLabel(2);
+  axesLabels <<  d->ViewNode->GetAxisLabel(1); // +X
+  axesLabels <<  d->ViewNode->GetAxisLabel(0); // -X
+  axesLabels <<  d->ViewNode->GetAxisLabel(5); // +Z
+  axesLabels <<  d->ViewNode->GetAxisLabel(4); // -Z
+  axesLabels <<  d->ViewNode->GetAxisLabel(3); // +Y
+  axesLabels <<  d->ViewNode->GetAxisLabel(2); // -Y
   d->AxesWidget->setAxesLabels(axesLabels);
 
   d->actionSet3DAxisVisible->setChecked(d->ViewNode->GetBoxVisible());


### PR DESCRIPTION
The bug has reported during the project week. The label were swapped on the widget controller 
(R <-> L, S <-> I and A <-> P).

The bug was introduced by myself in https://github.com/Slicer/Slicer/pull/500