### PR TITLE
BUG: Fix OpenGL errors in py_RSNA2012ProstateDemo test

### DIFF
--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
@@ -1357,10 +1357,7 @@ bool vtkMRMLAnnotationDisplayableManager::IsWidgetDisplayable(vtkMRMLSliceNode* 
             }
 
           // we need to render again
-          if (currentRenderer)
-            {
-            currentRenderer->Render();
-            }
+          this->RequestRender();
           }
 
         }


### PR DESCRIPTION
Debug builds showed OpenGL errors while running the py_RSNA2012ProstateDemo
test.

The problem is that vtkMRMLAnnotationDisplayableManager could directly call
vtkRenderer::Render() in some cases, but only vtkRenderWindow should call that
method. The errors occur when OpenGL functions are called before an OpenGL
context has been initialized. When the VTK OpenGL2 backend is enabled, running
the py_RSNA2012ProstateDemo test leads to a crash.

See the documentation for vtkRenderer::Render():
https://github.com/Kitware/VTK/blob/5f52c1a91a9e9fbfc1efe0d14b3c11b548c7acb1/Rendering/Core/vtkRenderer.h#L231-L236

<strike>This commit sets the widget representation's NeedToRender flag instead of
attempting to render directly.</strike>
This commit replaces the direct call to vtkRenderer::Render() with a call to the
displayable manager's RequestRender() method. This queues a render request to be
handled by the framework at an appropriate time.