### PR TITLE
ENH: Test for sitkUtils to make sure to push/pull data from Slicer 

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -225,11 +225,11 @@ set_tests_properties(py_nomainwindow_${testname} PROPERTIES
   )
 
 if(Slicer_USE_SimpleITK)
-slicer_add_python_unittest(
-  SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/tests/test_sitkUtils.py
-  SLICER_ARGS --no-main-window
-  TESTNAME_PREFIX nomainwindow_
-  )
+  slicer_add_python_unittest(
+    SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/tests/test_sitkUtils.py
+    SLICER_ARGS --no-main-window
+    TESTNAME_PREFIX nomainwindow_
+    )
 endif()
 
 slicer_add_python_unittest(

--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -224,6 +224,14 @@ set_tests_properties(py_nomainwindow_${testname} PROPERTIES
   WILL_FAIL TRUE
   )
 
+if(Slicer_USE_SimpleITK)
+slicer_add_python_unittest(
+  SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/tests/test_sitkUtils.py
+  SLICER_ARGS --no-main-window
+  TESTNAME_PREFIX nomainwindow_
+  )
+endif()
+
 slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/tests/test_saferef.py
   SLICER_ARGS --no-main-window --disable-modules

--- a/Base/Python/tests/test_sitkUtils.py
+++ b/Base/Python/tests/test_sitkUtils.py
@@ -32,9 +32,62 @@ class SitkUtilsTests(unittest.TestCase):
                          'Error Push Pull: Modify Time are not the same')
 
         """ To perform the test:
-        Try to modified the image with sitk tools (just few sanity checks)
-        Verify the GetMTime are different after a modification of sitkimage
+        DONE : Try to modified the image with sitk tools (just few sanity checks)
+        DONE : Verify the GetMTime are different after a modification of sitkimage
         Try with all the compositeView and overwrite (any possibility)
+        """
+
+        """ Few modification of the image : Direction, Origin """
+        sitkimage.SetDirection((-1.0, 1.0, 0.0, 0.0, -1.0, 1.0, 1.0, 0.0, 1.0))
+        sitkimage.SetOrigin((100.0, 100.0, 100.0))
+
+        """ Few pixel changed """
+        size = sitkimage.GetSize()
+        for x in xrange(0,size[0],(int)(size[0]/10)):
+            for y in xrange(0,size[1],(int)(size[1]/10)):
+                for z in xrange(0,size[2],(int)(size[2]/10)):
+                    sitkimage.SetPixel(x,y,z,0L)
+
+        su.PushToSlicer(sitkimage, 'ImageChanged', compositeView=0, overwrite=False)
+        volumeNode2 = slicer.util.getNode('ImageChanged')
+        self.assertEqual(volumeNode2.GetName(), "ImageChanged",
+                         'Error Push Pull: Node Name are not the same')
+        self.assertNotEqual(self.volumeNode1.GetMTime(), volumeNode2.GetMTime(),
+                            'Error Push Pull: Modify Time are the same')
+
+        """ Test the consistency between sitkimage and volumeNode2
+        """
+        tmp = volumeNode2.GetOrigin()
+        valToCompare = (-tmp[0], -tmp[1], tmp[2])
+        self.assertEqual(valToCompare,sitkimage.GetOrigin(),
+                         'Error Push Pull: Different Origin')
+
+        """ ===========
+        Viewing options
+        ---------------
+        bit 0: Set as background image
+        bit 1: Set as foreground image
+        bit 2: Set as label image
+        """
+        """ TODO : one by one those Push are working but there is an error during the loop
+        caused by the hack in EnsureRegistration() in sitkUtils.py : _DUMMY_DOES_NOT_EXISTS__
+
+        for compositeView in xrange(3):
+            for overwrite in [False, True]:
+                su.PushToSlicer(sitkimage, 'volumeNode'+str(compositeView)+str(overwrite),
+                                compositeView, overwrite)
+                volumeNode = slicer.util.getNode('volumeNode'+str(compositeView)+str(overwrite))
+
+                print("compositeView : %s" %compositeView )
+                print("overwrite : %s " %overwrite )
+
+                #Check if it's a label
+                if compositeView == 2:
+                    self.assertEqual(volumeNode.GetClassName(),'vtkMRMLLabelMapVolumeNode',
+                                     'Error Push Pull: Not a label Class Name')
+                else:
+                    self.assertEqual(volumeNode.GetClassName(), 'vtkMRMLScalarVolumeNode',
+                                     'Error Push Pull: Not a back/foreground Class Name')
         """
 
     def tearDown(self):

--- a/Base/Python/tests/test_sitkUtils.py
+++ b/Base/Python/tests/test_sitkUtils.py
@@ -1,0 +1,49 @@
+import slicer
+#import SimpleITK as sitk
+import sitkUtils as su
+
+import unittest
+
+class SitkUtilsTests(unittest.TestCase):
+
+    def runTest(self):
+        self.setUp()
+        self.test_SimpleITK_SlicerPushPull()
+        self.tearDown()
+
+    def setUp(self):
+        """ Download the MRHead node
+        """
+
+        from SampleData import SampleDataLogic
+        SampleDataLogic().downloadMRHead()
+        myNode1 = slicer.util.getNode('MRHead')
+
+        print("Node Name is %s" % myNode1.GetName())
+        self.assertIsNotNone(myNode1.GetName(),"ERROR: Node Name is None !")
+
+        self.myNode1 = myNode1
+
+    def test_SimpleITK_SlicerPushPull(self):
+        """ Try to pull a slicer MRML image, return the SimpleITK,
+        push it to Slicer, and then compare if the image are the same
+        """
+
+        sitkimage = su.PullFromSlicer(self.myNode1.GetName())
+        su.PushToSlicer(sitkimage, 'MRHead', compositeView=0, overwrite=False)
+        myNode2 = slicer.util.getNode('MRHead')
+
+        self.assertEqual(self.myNode1, myNode2,
+                         'Error Push Pull: Node are not the same')
+        self.assertEqual(self.myNode1.GetID(), myNode2.GetID(),
+                         'Error Push Pull: id are not the same')
+        self.assertEqual(self.myNode1.GetMTime(), myNode2.GetMTime(),
+                         'Error Push Pull: Modify Time are not the same')
+
+        """ To perform the test:
+        Try with a modified sitkimage and verify the GetMTime are diffrents
+        Try with all the compositeView and overwrite (all possiblities)
+        """
+
+    def tearDown(self):
+        del self.myNode1

--- a/Base/Python/tests/test_sitkUtils.py
+++ b/Base/Python/tests/test_sitkUtils.py
@@ -1,15 +1,9 @@
 import slicer
-#import SimpleITK as sitk
 import sitkUtils as su
 
 import unittest
 
 class SitkUtilsTests(unittest.TestCase):
-
-    def runTest(self):
-        self.setUp()
-        self.test_SimpleITK_SlicerPushPull()
-        self.tearDown()
 
     def setUp(self):
         """ Download the MRHead node
@@ -17,33 +11,32 @@ class SitkUtilsTests(unittest.TestCase):
 
         from SampleData import SampleDataLogic
         SampleDataLogic().downloadMRHead()
-        myNode1 = slicer.util.getNode('MRHead')
-
-        print("Node Name is %s" % myNode1.GetName())
-        self.assertIsNotNone(myNode1.GetName(),"ERROR: Node Name is None !")
-
-        self.myNode1 = myNode1
+        volumeNode1 = slicer.util.getNode('MRHead')
+        self.assertEqual(volumeNode1.GetName(), "MRHead")
+        self.volumeNode1 = volumeNode1
 
     def test_SimpleITK_SlicerPushPull(self):
         """ Try to pull a slicer MRML image, return the SimpleITK,
         push it to Slicer, and then compare if the image are the same
         """
 
-        sitkimage = su.PullFromSlicer(self.myNode1.GetName())
+        sitkimage = su.PullFromSlicer(self.volumeNode1.GetName())
         su.PushToSlicer(sitkimage, 'MRHead', compositeView=0, overwrite=False)
-        myNode2 = slicer.util.getNode('MRHead')
+        volumeNode2 = slicer.util.getNode('MRHead')
 
-        self.assertEqual(self.myNode1, myNode2,
-                         'Error Push Pull: Node are not the same')
-        self.assertEqual(self.myNode1.GetID(), myNode2.GetID(),
-                         'Error Push Pull: id are not the same')
-        self.assertEqual(self.myNode1.GetMTime(), myNode2.GetMTime(),
+        self.assertEqual(self.volumeNode1, volumeNode2,
+                         'Error Push Pull: volumeNode are not the same')
+        self.assertEqual(self.volumeNode1.GetID(), volumeNode2.GetID(),
+                         'Error Push Pull: ID are not the same')
+        self.assertEqual(self.volumeNode1.GetMTime(), volumeNode2.GetMTime(),
                          'Error Push Pull: Modify Time are not the same')
 
         """ To perform the test:
-        Try with a modified sitkimage and verify the GetMTime are diffrents
-        Try with all the compositeView and overwrite (all possiblities)
+        Try to modified the image with sitk tools (just few sanity checks)
+        Verify the GetMTime are different after a modification of sitkimage
+        Try with all the compositeView and overwrite (any possibility)
         """
 
     def tearDown(self):
-        del self.myNode1
+        del self.volumeNode1
+        slicer.mrmlScene.Clear(0)


### PR DESCRIPTION
According to the request [ #1693](http://na-mic.org/Mantis/view.php?id=1693) on MantisBugTracker, I added a test for Push/Pull data from Slicer

A minor error linked with the call of PullFromSlicer (a function from sitkUtils) still exist but do not interfere with the test.

The detail of the error can be seen in the file attached [here](https://github.com/Slicer/Slicer/files/364637/error_PullFromSlicer.zip). Otherwise, when running the following terminal command : `ctest -V -R py_nomainwindow_test_sitkUtils`  in the directory `Slicer-SuperBuild/Slicer-build`
