### PR TITLE
ENH: Made Python interactor a docking widget

### DIFF
--- a/Applications/SlicerApp/Main.cxx
+++ b/Applications/SlicerApp/Main.cxx
@@ -134,15 +134,6 @@ int SlicerAppMain(int argc, char* argv[])
   setEnableQtTesting(); // disabled the native menu bar.
 #endif
 
-#ifdef Slicer_USE_PYTHONQT
-  ctkPythonConsole pythonConsole;
-  pythonConsole.setWindowTitle("Slicer Python Interactor");
-  if (!qSlicerApplication::testAttribute(qSlicerApplication::AA_DisablePython))
-    {
-    qSlicerApplicationHelper::initializePythonConsole(&pythonConsole);
-    }
-#endif
-
   bool enableMainWindow = !app.commandOptions()->noMainWindow();
   enableMainWindow = enableMainWindow && !app.commandOptions()->runPythonAndExit();
   bool showSplashScreen = !app.commandOptions()->noSplash() && enableMainWindow;
@@ -202,6 +193,19 @@ int SlicerAppMain(int argc, char* argv[])
     {
     window.reset(new qSlicerAppMainWindow);
     window->setWindowTitle(window->windowTitle()+ " " + Slicer_VERSION_FULL);
+    }
+  else if (app.commandOptions()->showPythonInteractor()
+    && !app.commandOptions()->runPythonAndExit())
+    {
+    // there is no main window but we need to show Python interactor
+#ifdef Slicer_USE_PYTHONQT
+    ctkPythonConsole* pythonConsole = app.pythonConsole();
+    pythonConsole->setWindowTitle("Slicer Python Interactor");
+    pythonConsole->resize(600, 280);
+    pythonConsole->show();
+    pythonConsole->activateWindow();
+    pythonConsole->raise();
+#endif
     }
 
   // Load all available modules

--- a/Applications/SlicerApp/Resources/UI/qSlicerAppMainWindow.ui
+++ b/Applications/SlicerApp/Resources/UI/qSlicerAppMainWindow.ui
@@ -101,7 +101,6 @@
      </property>
      <addaction name="WindowToolbarsResetToDefaultAction"/>
     </widget>
-    <addaction name="WindowPythonInteractorAction"/>
     <addaction name="ViewExtensionsManagerAction"/>
     <addaction name="separator"/>
     <addaction name="WindowToolBarsMenu"/>
@@ -328,7 +327,6 @@
     <bool>false</bool>
    </attribute>
    <addaction name="ViewExtensionsManagerAction"/>
-   <addaction name="WindowPythonInteractorAction"/>
   </widget>
   <action name="FileLoadSceneAction">
    <property name="icon">
@@ -651,21 +649,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+0</string>
-   </property>
-  </action>
-  <action name="WindowPythonInteractorAction">
-   <property name="icon">
-    <iconset>
-     <normaloff>:/python-icon.png</normaloff>:/python-icon.png</iconset>
-   </property>
-   <property name="text">
-    <string>Python Interactor</string>
-   </property>
-   <property name="toolTip">
-    <string>Raise the Python Interactor for controlling the application's data, gui and internals.</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+3</string>
    </property>
   </action>
   <action name="WindowToolbarsResetToDefaultAction">

--- a/Applications/SlicerApp/qSlicerAppMainWindow.h
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.h
@@ -97,8 +97,9 @@ public slots:
   virtual void setLayoutNumberOfCompareViewRows(int);
   virtual void setLayoutNumberOfCompareViewColumns(int);
 
+  virtual void onPythonConsoleToggled(bool);
+
   virtual void on_WindowErrorLogAction_triggered();
-  virtual void on_WindowPythonInteractorAction_triggered();
   virtual void on_WindowToolbarsResetToDefaultAction_triggered();
 
   virtual void on_HelpKeyboardShortcutsAction_triggered();
@@ -132,6 +133,9 @@ protected slots:
 protected:
   /// Connect MainWindow action with slots defined in MainWindowCore
   virtual void setupMenuActions();
+
+  /// Open Python interactor if it was requested
+  virtual void pythonConsoleInitialDisplay();
 
   /// Open a popup to warn the user Slicer is not for clinical use.
   virtual void disclaimer();

--- a/Applications/SlicerApp/qSlicerAppMainWindow_p.h
+++ b/Applications/SlicerApp/qSlicerAppMainWindow_p.h
@@ -67,7 +67,7 @@ public:
   void setErrorLogIconHighlighted(bool);
 
 #ifdef Slicer_USE_PYTHONQT
-  ctkPythonConsole*               PythonConsole;
+  QDockWidget*                    PythonConsoleDockWidget;
 #endif
   ctkErrorLogWidget*              ErrorLogWidget;
   QToolButton*                    ErrorLogToolButton;

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -144,7 +144,10 @@ def mainWindow(verbose = True):
   return lookupTopLevelWidget('qSlicerAppMainWindow', verbose)
 
 def pythonShell(verbose = True):
-  return lookupTopLevelWidget('pythonConsole', verbose)
+  console = slicer.app.pythonConsole()
+  if not console and verbose:
+    print("Failed to obtain reference to python shell", file=sys.stderr)
+  return console
 
 def showStatusMessage(message, duration = 0):
   mw = mainWindow(verbose=False)

--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -50,8 +50,6 @@
 #ifdef Slicer_USE_PYTHONQT
 # include <PythonQtObjectPtr.h>
 # include <PythonQtPythonInclude.h>
-# include "qSlicerPythonManager.h"
-# include "qSlicerSettingsPythonPanel.h"
 #endif
 
 //----------------------------------------------------------------------------
@@ -179,37 +177,4 @@ void qSlicerApplicationHelper::showMRMLEventLoggerWidget()
                    SLOT(setMRMLScene(vtkMRMLScene*)));
 
   logger->show();
-}
-
-//----------------------------------------------------------------------------
-void qSlicerApplicationHelper::initializePythonConsole(ctkPythonConsole* pythonConsole)
-{
-#ifdef Slicer_USE_PYTHONQT
-  Q_ASSERT(pythonConsole);
-  Q_ASSERT(qSlicerApplication::application()->pythonManager());
-  pythonConsole->initialize(qSlicerApplication::application()->pythonManager());
-
-  QStringList autocompletePreferenceList;
-  autocompletePreferenceList
-      << "slicer" << "slicer.mrmlScene"
-      << "qt.QPushButton";
-  pythonConsole->completer()->setAutocompletePreferenceList(autocompletePreferenceList);
-
-  //pythonConsole->setAttribute(Qt::WA_QuitOnClose, false);
-  pythonConsole->resize(600, 280);
-
-  qSlicerApplication::application()->settingsDialog()->addPanel(
-    "Python", new qSlicerSettingsPythonPanel);
-
-  // Show pythonConsole if required
-  qSlicerCommandOptions * options = qSlicerApplication::application()->commandOptions();
-  if(options->showPythonInteractor() && !options->runPythonAndExit())
-    {
-    pythonConsole->show();
-    pythonConsole->activateWindow();
-    pythonConsole->raise();
-    }
-#else
-  Q_UNUSED(pythonConsole);
-#endif
 }

--- a/Base/QTApp/qSlicerApplicationHelper.h
+++ b/Base/QTApp/qSlicerApplicationHelper.h
@@ -26,7 +26,6 @@
 
 #include "qSlicerBaseQTAppExport.h"
 
-class ctkPythonConsole;
 class qSlicerModuleFactoryManager;
 
 class Q_SLICER_BASE_QTAPP_EXPORT qSlicerApplicationHelper : public QObject
@@ -42,8 +41,6 @@ public:
   static void setupModuleFactoryManager(qSlicerModuleFactoryManager * moduleFactoryManager);
 
   static void showMRMLEventLoggerWidget();
-
-  static void initializePythonConsole(ctkPythonConsole* pythonConsole);
 
 private:
   Q_DISABLE_COPY(qSlicerApplicationHelper);

--- a/Base/QTCore/Testing/Cxx/CMakeLists.txt
+++ b/Base/QTCore/Testing/Cxx/CMakeLists.txt
@@ -60,6 +60,12 @@ if(BUILD_TESTING)
     list(APPEND KIT_TEST_TARGET_LIBRARIES Qt4::QtTest)
   endif()
 
+  if(Slicer_USE_PYTHONQT)
+  list(APPEND KIT_TEST_TARGET_LIBRARIES
+    CTKScriptingPythonWidgets
+    )
+  endif()
+
   add_executable(${KIT}CxxTests ${Tests})
   target_link_libraries(${KIT}CxxTests ${KIT_TEST_TARGET_LIBRARIES})
   set_target_properties(${KIT}CxxTests PROPERTIES LABELS ${KIT})

--- a/Base/QTCore/Testing/Cxx/qSlicerCoreApplicationTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerCoreApplicationTest1.cxx
@@ -26,6 +26,7 @@
 #include "qSlicerCoreCommandOptions.h"
 #ifdef Slicer_USE_PYTHONQT
 # include "qSlicerCorePythonManager.h"
+# include "ctkPythonConsole.h"
 #endif
 
 // Slicer includes
@@ -175,6 +176,26 @@ int qSlicerCoreApplicationTest1(int argc, char * argv [] )
   if (pythonManager->getVariable("value").toInt() != 7)
     {
     std::cerr << "Line " << __LINE__ << " - Problem with getVariable()" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  ctkPythonConsole * pythonConsole = app.pythonConsole();
+  if (pythonConsole)
+    {
+    std::cerr << "Line " << __LINE__ << " - Problem with  pythonConsole()"
+              << " - NULL pointer is expected." << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  // Note: qSlicerCoreApplication class takes ownership of the pythonConsole and
+  // will be responsible to delete it
+  app.setPythonConsole(new ctkPythonConsole());
+
+  pythonConsole = app.pythonConsole();
+  if (!pythonConsole)
+    {
+    std::cerr << "Line " << __LINE__ << " - Problem with pythonConsole()"
+              << " - Return a NULL pointer." << std::endl;
     return EXIT_FAILURE;
     }
 

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -64,6 +64,7 @@
 #include "qSlicerCoreIOManager.h"
 #ifdef Slicer_USE_PYTHONQT
 # include "qSlicerCorePythonManager.h"
+# include "ctkPythonConsole.h"
 #endif
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
 # include "qSlicerExtensionsManagerModel.h"
@@ -1290,6 +1291,20 @@ qSlicerCorePythonManager* qSlicerCoreApplication::corePythonManager()const
 {
   Q_D(const qSlicerCoreApplication);
   return d->CorePythonManager.data();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerCoreApplication::setPythonConsole(ctkPythonConsole* console)
+{
+  Q_D(qSlicerCoreApplication);
+  d->PythonConsole = console;
+}
+
+//-----------------------------------------------------------------------------
+ctkPythonConsole* qSlicerCoreApplication::pythonConsole()const
+{
+  Q_D(const qSlicerCoreApplication);
+  return d->PythonConsole.data();
 }
 
 #endif

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -44,6 +44,7 @@ class qSlicerCoreApplicationPrivate;
 class qSlicerModuleManager;
 #ifdef Slicer_USE_PYTHONQT
 class qSlicerCorePythonManager;
+class ctkPythonConsole;
 #endif
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
 class qSlicerExtensionsManagerModel;
@@ -246,6 +247,16 @@ public:
   /// Set the IO manager
   /// \note qSlicerCoreApplication takes ownership of the object
   void setCorePythonManager(qSlicerCorePythonManager* pythonManager);
+
+  /// Get python console
+  ctkPythonConsole* pythonConsole()const;
+
+  /// Set the python console
+  /// \note qSlicerCoreApplication will not take ownership of the object,
+  /// because it will be owned by the widget that it is part of
+  /// (either it is part of the main window or a top-level window).
+  void setPythonConsole(ctkPythonConsole* pythonConsole);
+
 #endif
 
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT

--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -33,6 +33,7 @@
 //
 
 // Qt includes
+#include <QPointer>
 #include <QProcessEnvironment>
 #include <QSettings>
 #include <QSharedPointer>
@@ -154,6 +155,7 @@ public:
 #ifdef Slicer_USE_PYTHONQT
   /// CorePythonManager - It should exist only one instance of the CorePythonManager
   QSharedPointer<qSlicerCorePythonManager>    CorePythonManager;
+  QPointer<ctkPythonConsole> PythonConsole; // it may be owned by a widget, so we cannot refer to it by a strong pointer
 #endif
 
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -34,6 +34,9 @@
 #include <ctkErrorLogStreamMessageHandler.h>
 #include <ctkITKErrorLogMessageHandler.h>
 #include <ctkMessageBox.h>
+#ifdef Slicer_USE_PYTHONQT
+# include "ctkPythonConsole.h"
+#endif
 #include <ctkSettings.h>
 #ifdef Slicer_USE_QtTesting
 #include <ctkQtTestingUtility.h>
@@ -55,6 +58,7 @@
 #include "qSlicerModuleManager.h"
 #ifdef Slicer_USE_PYTHONQT
 # include "qSlicerPythonManager.h"
+# include "qSlicerSettingsPythonPanel.h"
 #endif
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
 # include "qSlicerExtensionsManagerDialog.h"
@@ -172,13 +176,31 @@ void qSlicerApplicationPrivate::init()
 #ifdef Slicer_USE_PYTHONQT
   if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
     {
-    // Note: qSlicerCoreApplication class takes ownership of the pythonManager and
+    // qSlicerCoreApplication class takes ownership of the pythonManager and
     // will be responsible to delete it
     q->setCorePythonManager(new qSlicerPythonManager());
+    // qSlicerCoreApplication does not take ownership of PythonConsole, therefore
+    // we have to delete it in the destructor if it is not deleted already
+    // and not owned by a widget (it is owned and deleted by a widget if it is added
+    // to the GUI)
+    q->setPythonConsole(new ctkPythonConsole());
     }
 #endif
 
   this->Superclass::init();
+
+#ifdef Slicer_USE_PYTHONQT
+  if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
+    {
+    q->pythonConsole()->initialize(q->pythonManager());
+    QStringList autocompletePreferenceList;
+    autocompletePreferenceList
+      << "slicer"
+      << "slicer.mrmlScene"
+      << "qt.QPushButton";
+    q->pythonConsole()->completer()->setAutocompletePreferenceList(autocompletePreferenceList);
+    }
+#endif
 
   this->initStyle();
 
@@ -244,6 +266,13 @@ void qSlicerApplicationPrivate::init()
   qSlicerSettingsInternationalizationPanel* qtInternationalizationPanel =
       new qSlicerSettingsInternationalizationPanel;
   this->SettingsDialog->addPanel("Internationalization", qtInternationalizationPanel);
+#endif
+
+#ifdef Slicer_USE_PYTHONQT
+  if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
+    {
+    q->settingsDialog()->addPanel("Python", new qSlicerSettingsPythonPanel);
+    }
 #endif
 
   qSlicerSettingsDeveloperPanel* developerPanel = new qSlicerSettingsDeveloperPanel;
@@ -325,6 +354,17 @@ qSlicerApplication::qSlicerApplication(int &_argc, char **_argv)
 //-----------------------------------------------------------------------------
 qSlicerApplication::~qSlicerApplication()
 {
+  // We have to delete PythonConsole if it is not deleted already
+  // and not owned by a widget (it is owned and deleted by a widget if it is added
+  // to the GUI).
+  ctkPythonConsole* pythonConsolePtr = this->pythonConsole();
+  if (pythonConsolePtr)
+  {
+    if (pythonConsolePtr->parent() == NULL)
+    {
+      delete pythonConsolePtr;
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -385,14 +425,23 @@ qSlicerIOManager* qSlicerApplication::ioManager()
 //-----------------------------------------------------------------------------
 qSlicerPythonManager* qSlicerApplication::pythonManager()
 {
-  qSlicerPythonManager* _pythonManager = 0;
-  if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
+  if (qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
     {
-    _pythonManager = qobject_cast<qSlicerPythonManager*>(this->corePythonManager());
-    Q_ASSERT(_pythonManager);
+    return 0;
     }
-
+  qSlicerPythonManager* _pythonManager = qobject_cast<qSlicerPythonManager*>(this->corePythonManager());
+  Q_ASSERT(_pythonManager);
   return _pythonManager;
+}
+
+//-----------------------------------------------------------------------------
+ctkPythonConsole* qSlicerApplication::pythonConsole()
+{
+  if (qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
+    {
+    return 0;
+    }
+  return Superclass::pythonConsole();
 }
 #endif
 

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -89,7 +89,8 @@ public:
   #ifdef Slicer_USE_PYTHONQT
   /// Get Python Manager
   Q_INVOKABLE qSlicerPythonManager * pythonManager();
-  #endif
+  Q_INVOKABLE ctkPythonConsole * pythonConsole();
+#endif
 
   #ifdef Slicer_USE_QtTesting
   /// Get test utility


### PR DESCRIPTION
Problem:
It was always necessary to rearrange windows after showing the Python interactor so that both the console and Slicer screen.
This has to be repeated every time Slicer is started, since the Python interactor window's position was not saved.

Implemented solution:

1. Made Python interactor a docking widget (if Slicer starts with main window visible).
For single-screen configuration this allows sharing of the screen between the Python interactor and other Slicer windows.
On multi-screen configurations the interactor can be dragged to the second screen.

2. The position (which screen, where), size, and state (docked/undocked, shown/hidden) of the Python interactor window is now also saved,
so there is no need for any repositioning of the windows between sessions.

3. Ctrl-3 shows/hides the interactor (not just shows as before) and when the interactor is shown it gets keyboard focus.
It allows easy opening of the interactor, typing some text, and closing it, without the need of taking the mouse to reposition
any windows.

Also cleaned up deletion of ctkPythonConsole. As the ctkPythonConsole widget can be owned by a widget (docking window), it is not
possible to create it on the stack anymore. Instead, qSlicerApplication creates the ctkPythonConsole (similarly to qSlicerPythonManager)
and destroys it if it is not owned by a widget.