### PR TITLE
ENH: Make it faster/easier to work with long fiducial lists

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
@@ -395,11 +395,14 @@ void qSlicerSimpleMarkupsWidget::onMarkupsFiducialTableContextMenu(const QPoint&
         deleteFiducials.push_back( i );
         }
       }
+    // Do this in batch mode
+    int wasModifying = currentNode->StartModify();
     //Traversing this way should be more efficient and correct
     for ( int i = deleteFiducials.size() - 1; i >= 0; i-- )
       {
       currentNode->RemoveMarkup( deleteFiducials.at( i ) );
       }
+    currentNode->EndModify(wasModifying);
     }
 
 


### PR DESCRIPTION
Put Start/EndModify calls around removing a list of markups from the current node (speed up is significant when deleting 100 fiducials from a list of 272 fiducials, down to ~4s from ~120s).

Automatically select the last loaded fiducial node when entering the Markups module if there are nodes loaded and none are selected.

Adjust the right click context menu in the table:
Use one line per markup, consolidating the label (use index if no label) and the coordinate (half the rows in the menu).
Put the operations first in the menu in case so many are selected that part of the menu ends up off screen.

Fixes Issue #4239