### PR TITLE
ENH: bump DMRI external module to 0402024

### DIFF
--- a/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.xml
+++ b/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
-  <category>Diffusion.Diffusion Tensor Images</category>
+  <category>Diffusion.Utilities</category>
   <title>Resample DTI Volume</title>
   <description><![CDATA[Resampling an image is a very important task in image analysis. It is especially important in the frame of image registration. This module implements DT image resampling through the use of itk Transforms. The resampling is controlled by the Output Spacing. "Resampling" is performed in space coordinates, not pixel/grid coordinates. It is quite important to ensure that image spacing is properly set on the images involved. The interpolator is required since the mapping from one space to the other will often require evaluation of the intensity of the image at non-grid positions.]]></description>
   <version>1.0.2</version>

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.xml
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Filtering</category>
-  <category>Diffusion.Diffusion Weighted Images</category>
+  <category>Diffusion.Utilities</category>
   <title>Resample Scalar/Vector/DWI Volume</title>
   <description><![CDATA[This module implements image and vector-image resampling through  the use of itk Transforms.It can also handle diffusion weighted MRI image resampling. "Resampling" is performed in space coordinates, not pixel/grid coordinates. It is quite important to ensure that image spacing is properly set on the images involved. The interpolator is required since the mapping from one space to the other will often require evaluation of the intensity of the image at non-grid positions. \n\nWarning: To resample DWMR Images, use nrrd input and output files. \n\nWarning: Do not use to resample Diffusion Tensor Images, tensors would  not be reoriented]]></description>
   <version>0.1</version>

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -314,7 +314,7 @@ Slicer_Remote_Add(SlicerDMRI
   GIT_REPOSITORY "${git_protocol}://github.com/SlicerDMRI/SlicerDMRI"
   # SlicerDMRI Maintainer: If new revision of the extension add or remove modules, consider updating
   #                        the module lists below. Thanks.
-  GIT_TAG "b5c262fc50a5ce113a76c90e37dff1b12643000a"
+  GIT_TAG "b9404cdb7cad91fc3392f79022e29acac03423e5"
   OPTION_NAME Slicer_BUILD_SlicerDMRI
   OPTION_DEPENDS "Slicer_BUILD_DIFFUSION_SUPPORT"
   LABELS REMOTE_EXTENSION


### PR DESCRIPTION
```
Alex Yarmarkovich (4):
      ENH: Added test datasets for DiffusionTensorScalarMeasurements module.
      ENH: Added tests for DiffusionTensorScalarMeasurements CLI
      ENH: Added tests for DWIToDTIEstimation CLI
      BUG: 4238.Right click -> Edit Properties on Fiber Bundle nodes and Fiber Bundle Display nodes in the Data module should go to the Tractography Display module.

Isaiah (2):
      Merge pull request #37 from SlicerDMRI/fbm_stats_option
      Merge pull request #43 from SlicerDMRI/fbm_clamped_msrs

Isaiah Norton (22):
      ENH: FBTractMeasurement: by default, print only specified hierarchy.
      FBTractMsr: Introduce measurement range clamping, and count excluded points
      FBTractMsr: correctly fix #36: by default print top and cluster groups, but not fiberbundles
      FBTractMsr: refactor redundant code
      FBTractMsr: update to pass tests
      FBTractMsr: fix non-C++11 compile, and more refactoring.
      FBMsr: Print NAN when no measurement value exists.
      Remove obsolute DT scalar measures, update docs.
      Update DTMsr contributor list to match wiki
      Update DTMsr contributor institutions.
      More DTScalarMsr interface updates
      Update DWIToDTIEstim module description.
      More updates to DTEstim & ScalarMeasurements desc.
      Update DWMasking module description.
      Update more module description files
      Remove newlines from FBLabelSelect xml
      FBLabelSelect description updates
      FBLabelSelect description more updates
      FBTractMeasurements description update
      TractLMSeeding module description
      COMP: fix and simplify DTScalarMeasure tests
      COMP: fix FBTractMsr tests

Lauren O'Donnell (1):
      Update README.md

zhangfanmark (1):
      EHN: Measure name consistency
```