### PR TITLE
COMP: bump DCMTK version to 3.6.1_20160630

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -33,9 +33,9 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       )
   endif()
 
-  # DCMTK-3.6.1_20160216 + patch to avoid unneeded recompilation
-  set(${proj}_REPOSITORY ${git_protocol}://github.com/commontk/DCMTK)
-  set(${proj}_GIT_TAG "023b8deab3b64bdcf4e40544b40bdbdbbd05e7a3")
+  # DCMTK-3.6.1_20160630
+  set(${proj}_REPOSITORY ${git_protocol}://git.dcmtk.org/dcmtk)
+  set(${proj}_GIT_TAG "271f1e9731cfb29d9451b484ff50a39e32e2c90a")
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}


### PR DESCRIPTION
This has updates needed by us and @fedorov. There was only one patch in the CTK branch, and it is no longer necessary, so I switched back to upstream.