### PR TITLE
COMP: Support building in RelWithDebInfo configuration on Windows

### DIFF
--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -249,10 +249,24 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
       )
 
     set(OpenSSL_DIR ${EP_SOURCE_DIR})
+    set(_openssl_base_dir ${OpenSSL_DIR})
     if(DEFINED CMAKE_CONFIGURATION_TYPES)
       set(OpenSSL_DIR ${OpenSSL_DIR}/${CMAKE_CFG_INTDIR})
+      set(_copy_release_directory 1)
     else()
       set(OpenSSL_DIR ${OpenSSL_DIR}/${CMAKE_BUILD_TYPE})
+      if(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        set(_copy_release_directory 1)
+      endif()
+    endif()
+
+    # Support building in RelWithDebInfo configuration
+    if(_copy_release_directory)
+      ExternalProject_Add_Step(${proj} copy_release_directory
+        COMMAND ${CMAKE_COMMAND} -E copy_directory "${_openssl_base_dir}/Release" "${_openssl_base_dir}/RelWithDebInfo"
+        COMMENT "Copying '${_openssl_base_dir}/Release' to '${_openssl_base_dir}/RelWithDebInfo'"
+        DEPENDEES install
+        )
     endif()
 
     set(OPENSSL_INCLUDE_DIR "${OpenSSL_DIR}/include")


### PR DESCRIPTION
This commit fixes build errors when building in the RelWithDebInfo configuration
on Windows. Previously, projects that use OpenSSL_DIR would fail to find the
OpenSSL headers because only 'Debug' and 'Release' directories--not
'RelWithDebInfo'--are provided by the precompiled OpenSSL binaries.

An example error is:

    10>C:\S\R\Python-2.7.11\Modules\_hashopenssl.c(39): fatal error C1083: Cannot open include file: 'openssl/evp.h': No such file or directory

Fixes http://www.na-mic.org/Mantis/view.php?id=4058.