### PR TITLE
ENH: bump SlicerDMRI remote module to 2775d744a

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -314,7 +314,7 @@ Slicer_Remote_Add(SlicerDMRI
   GIT_REPOSITORY "${git_protocol}://github.com/SlicerDMRI/SlicerDMRI"
   # SlicerDMRI Maintainer: If new revision of the extension add or remove modules, consider updating
   #                        the module lists below. Thanks.
-  GIT_TAG "b9404cdb7cad91fc3392f79022e29acac03423e5"
+  GIT_TAG "2775d744ae92d9c88bd52d6e2ecfa1da662e7cd0"
   OPTION_NAME Slicer_BUILD_SlicerDMRI
   OPTION_DEPENDS "Slicer_BUILD_DIFFUSION_SUPPORT"
   LABELS REMOTE_EXTENSION


### PR DESCRIPTION
```
git shortlog b9404cdb7..2775d744a
Alex Yarmarkovich (1):
      BUG: changed <geometry> tag to use  multiple="true" in order to select hierarchy nodes

Isaiah (1):
      Merge pull request #50 from ihnorton/reassign_cats

Isaiah Norton (3):
      ENH: reassign module categories to reflect workflow
      ENH: more descriptive mask-input label for DWIToDTIEstim
      ENH: CLI region-based seeding/selection categories
```