### PR TITLE
Fix widget size and reference counting tests

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -189,8 +189,8 @@ if(VTK_DEBUG_LEAKS AND Slicer_HAS_CONSOLE_IO_SUPPORT)
     SCRIPT_ARGS --no-main-window --disable-modules
     TESTNAME_PREFIX nomainwindow_
     )
-  set_tests_properties(py_nomainwindow_${testname}
-    PROPERTIES PASS_REGULAR_EXPRESSION "instances? still around"
+  set_tests_properties(py_nomainwindow_${testname} PROPERTIES
+    PASS_REGULAR_EXPRESSION "instances? still around"
     )
 endif()
 
@@ -205,23 +205,6 @@ set(testname MRMLSceneImportAndExport)
 slicer_add_python_test(
   SCRIPT ${testname}.py
   TESTNAME_PREFIX mainwindow_
-  )
-
-set(testname MRMLCreateNodeByClassWithSetReferenceCountToOne)
-slicer_add_python_test(
-  SCRIPT ${testname}.py
-  SCRIPT_ARGS --no-main-window --disable-modules
-  TESTNAME_PREFIX nomainwindow_
-  )
-# The test application is expected to crash. If a test is run from
-# Visual Studio by building RUN_TESTS target and it crashes then an error popup is displayed
-# and test execution is stopped until the user closes the popup - causing delays in the
-# test execution.
-# DASHBOARD_TEST_FROM_CTEST variable is set in order to force CTest to disable debugger
-# and error reporting popups and thus avoiding test execution delays.
-set_tests_properties(py_nomainwindow_${testname} PROPERTIES 
-  ENVIRONMENT "DASHBOARD_TEST_FROM_CTEST=1"
-  WILL_FAIL TRUE
   )
 
 slicer_add_python_unittest(

--- a/Applications/SlicerApp/Testing/Python/MRMLCreateNodeByClassWithSetReferenceCountMinusOne.py
+++ b/Applications/SlicerApp/Testing/Python/MRMLCreateNodeByClassWithSetReferenceCountMinusOne.py
@@ -2,8 +2,8 @@ import slicer
 
 def testMRMLCreateNodeByClassWithSetReferenceCountMinusOne():
   n = slicer.mrmlScene.CreateNodeByClass('vtkMRMLViewNode')
+  n.UnRegister(None) # the node object is now owned by n Python variable therefore we can release the reference that CreateNodeByClass added
   slicer.mrmlScene.AddNode(n)
-  n.SetReferenceCount(n.GetReferenceCount() - 1)
 
 if __name__ == '__main__':
   testMRMLCreateNodeByClassWithSetReferenceCountMinusOne()

--- a/Applications/SlicerApp/Testing/Python/MRMLCreateNodeByClassWithSetReferenceCountToOne.py
+++ b/Applications/SlicerApp/Testing/Python/MRMLCreateNodeByClassWithSetReferenceCountToOne.py
@@ -1,9 +1,0 @@
-import slicer
-
-def testMRMLCreateNodeByClassWithSetReferenceCountToOne():
-  n = slicer.mrmlScene.CreateNodeByClass('vtkMRMLViewNode')
-  slicer.mrmlScene.AddNode(n)
-  n.SetReferenceCount(1)
-
-if __name__ == '__main__':
-  testMRMLCreateNodeByClassWithSetReferenceCountToOne()

--- a/Applications/SlicerApp/Testing/Python/MRMLCreateNodeByClassWithoutSetReferenceCount.py
+++ b/Applications/SlicerApp/Testing/Python/MRMLCreateNodeByClassWithoutSetReferenceCount.py
@@ -12,6 +12,8 @@ def testMRMLCreateNodeByClassWithoutSetReferenceCount():
 
   n = slicer.mrmlScene.CreateNodeByClass('vtkMRMLViewNode')
   slicer.mrmlScene.AddNode(n)
+  # This is expected to leak memory because CreateNodeByClass increments the reference count by one
+  # and nothing decrements it.
 
 if __name__ == '__main__':
   testMRMLCreateNodeByClassWithoutSetReferenceCount()

--- a/Base/QTGUI/Testing/Cxx/qSlicerModuleWidgetGenericTest.cxx.in
+++ b/Base/QTGUI/Testing/Cxx/qSlicerModuleWidgetGenericTest.cxx.in
@@ -21,6 +21,8 @@
 #include "vtkSlicerConfigure.h" // For Slicer_USE_PYTHONQT
 
 // Qt includes
+#include <QApplication>
+#include <QDesktopWidget>
 #include <QDir>
 #include <QTimer>
 #ifdef Slicer_USE_PYTHONQT
@@ -54,7 +56,11 @@
 // VTK includes
 #include <vtkNew.h>
 
-const int minimumWidth = 500;
+// STD includes
+#include <algorithm>
+
+const int allowedWidgetWidthPixel = 500; // no matter how large the screen is, up to 500px widget width is allowed
+const int allowedWidgetWidthScreenPercentage = 30; // about 1/3 of the screen width is allowed
 
 //-----------------------------------------------------------------------------
 int qSlicer@MODULENAME@ModuleWidgetGenericTest( int argc, char * argv[] )
@@ -174,12 +180,25 @@ int qSlicer@MODULENAME@ModuleWidgetGenericTest( int argc, char * argv[] )
   // If the element is in a form layout, QFormLayout::layoutFieldGrowthPolicy
   // might need to be set to AllNonFixedFieldsGrow.
   // All those changes can be set from Qt Designer.
-  if (widget->minimumSizeHint().width() > minimumWidth)
+  const int desktopWidth = QApplication::desktop()->width();
+
+  // Compute actual allowed widget size. Absolute pixel value works for most
+  // legacy systems and provides backward compatibility.
+  // On high-resolution screens widgets may be much larger, therefore
+  // we also allow widgets that have acceptable size relative to the screen size.
+  int maxMinimumSizeHintWidth = std::max(allowedWidgetWidthPixel,
+    int(double(desktopWidth) * double(allowedWidgetWidthScreenPercentage) * 0.01));
+
+  if (widget->minimumSizeHint().width() > maxMinimumSizeHintWidth)
     {
     std::cerr << "Line " << __LINE__
               << " qSlicer@MODULENAME@Module widget has a minimum size hint width"
               << " of " << widget->minimumSizeHint().width() << "px. It is wider"
-              << " than the max width of " << minimumWidth << "px." << std::endl;
+              << " than the maximum allowed width of " << maxMinimumSizeHintWidth << "px."
+              << " (maximum allowed width computed as: " << allowedWidgetWidthPixel << "px or "
+              << allowedWidgetWidthScreenPercentage << "% of screen width of "
+              << desktopWidth << "px)"
+              << std::endl;
     res = false;
     }
 


### PR DESCRIPTION
Fix for two issues that show up on the dashboards:
1. Max allowed widget width hint for HiDPI screens (fix: compute dynamically from screen size)
2. Node reference counting test errors (fix: remove test that tries to check undefined behavior of double-delete)

See details in the two commit comments.