### PR TITLE
ENH: Fractional labelmap display in Segmentations

### DIFF
--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.h
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.h
@@ -34,6 +34,13 @@ class VTK_SLICER_SEGMENTATIONS_MODULE_MRMLDISPLAYABLEMANAGER_EXPORT vtkMRMLSegme
   : public vtkMRMLAbstractSliceViewDisplayableManager
 {
 public:
+
+  /// Field names for 2D display parameters
+  static const char* GetScalarRangeFieldName() {return "ScalarRange";};
+  static const char* GetThresholdValueFieldName() {return "ThresholdValue";};
+  static const char* GetInterpolationTypeFieldName() {return "InterpolationType";};
+
+public:
   static vtkMRMLSegmentationsDisplayableManager2D* New();
   vtkTypeMacro(vtkMRMLSegmentationsDisplayableManager2D, vtkMRMLAbstractSliceViewDisplayableManager);
   void PrintSelf(ostream& os, vtkIndent indent);


### PR DESCRIPTION
This commit modifies the displayable manager in Segmentations to allow an image data containing a range of scalar values to be visualized/interpolated, allowing fractional labelmaps to be displayed correctly.