### PR TITLE
COMP: use proper variable evaluation in SlicerExtensionCPack

### DIFF
--- a/CMake/SlicerExtensionCPack.cmake
+++ b/CMake/SlicerExtensionCPack.cmake
@@ -161,7 +161,7 @@ if(APPLE)
 
   set(msg "Checking if extension type is SuperBuild")
   message(STATUS "${msg}")
-  if(DEFINED ${EXTENSION_NAME}_SUPERBUILD)
+  if(${EXTENSION_NAME}_SUPERBUILD)
     message(STATUS "${msg} - true")
     set(_is_superbuild_extension 1)
   else()


### PR DESCRIPTION
Should fix UKFTractography extension packaging due to using incorrect fixup script. Has been broken since 195c0d55.

See build error: http://slicer.cdash.org/buildSummary.php?buildid=875941