### PR TITLE
BUG: Fix vtkMRMLNonlinearTransformNodeTest1

### DIFF
--- a/Libs/MRML/Core/vtkITKTransformConverter.h
+++ b/Libs/MRML/Core/vtkITKTransformConverter.h
@@ -341,8 +341,17 @@ bool vtkITKTransformConverter::SetVTKBSplineParametersFromITKGeneric(
     return false;
     }
 
-  typename BSplineTransformType::Pointer bsplineItk = dynamic_cast< BSplineTransformType* >( warpTransformItk.GetPointer() );
-  if (!bsplineItk.GetPointer())
+  typename BSplineTransformType::Pointer bsplineItk;
+  std::string warpTransformItkName = warpTransformItk->GetNameOfClass();
+  if (warpTransformItkName == "InverseBSplineTransform" ||
+      warpTransformItkName == "BSplineTransform" ||
+      warpTransformItkName == "BSplineDeformableTransform" ||
+      warpTransformItkName == "InverseBSplineDeformableTransform"
+      )
+    {
+    bsplineItk = static_cast< BSplineTransformType* >( warpTransformItk.GetPointer() );
+    }
+  else
     {
     return false;
     }


### PR DESCRIPTION
This commit fixes the reading of ITKv3 transforms by addressing
a regression introduced in [r24875](https://github.com/Slicer/Slicer/commit/12743c6fcebb67ff9b22319cbe52a322a3738134) (BUG: Fix transform tests by not
using dynamic_cast in vtkITKTransformConverter)

It basically ensures that executable created using compiler (e.g g++4.4.3)
[not supporting the use of dynamic_cast with templated classes instantiated
in a translation unit different than the one where they are defined] still
work as expected.

See #4139