### PR TITLE
Improved node saving and loading

### DIFF
--- a/Base/Python/slicer/tests/test_slicer_mgh.py
+++ b/Base/Python/slicer/tests/test_slicer_mgh.py
@@ -25,11 +25,8 @@ class SlicerUtilLoadSaveMGHTests(unittest.TestCase):
     self.assertTrue(slicer.util.saveNode(node, filename))
     self.assertTrue(os.path.exists(filename))
 
-""" NOT YET SUPPORTED
   def test_saveLongCompressedNode(self):
     node = slicer.util.getNode('T1_longname')
     filename = os.path.join(slicer.app.temporaryPath, 'MGH_T1_longname.mgh.gz')
     self.assertTrue(slicer.util.saveNode(node, filename))
     self.assertTrue(os.path.exists(filename))
-"""
-

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -88,39 +88,27 @@ qSlicerFileReader* qSlicerCoreIOManagerPrivate::reader(const QString& fileName)c
 //-----------------------------------------------------------------------------
 QList<qSlicerFileReader*> qSlicerCoreIOManagerPrivate::readers(const QString& fileName)const
 {
-  QList<qSlicerFileReader*> matchingReaders;
-  // Some readers ("DICOM (*)" or "Scalar Overlay (*.*))" can support any file,
-  // they are called generic readers. They might not be the best choice to read
-  // the file as it might exist a more specific reader to read it.
-  // So let's add generic readers at the end of the reader list.
-  QList<qSlicerFileReader*> genericReaders;
+  // Use a map so that we can access readers sorted by confidence.
+  // The more specific the filter that was matched, the higher confidence
+  // that the reader is more appropriate (e.g., *.seg.nrrd is more specific than *.nrrd;
+  // *.nrrd is more specific than *.*)
+  QMultiMap<int, qSlicerFileReader*> matchingReadersSortedByConfidence;
   foreach(qSlicerFileReader* reader, this->Readers)
     {
-    QStringList matchingNameFilters = reader->supportedNameFilters(fileName);
-    if (matchingNameFilters.count() == 0)
+    int longestExtensionMatch = 0;
+    QStringList matchedNameFilters = reader->supportedNameFilters(fileName, &longestExtensionMatch);
+    if (!matchedNameFilters.empty())
       {
-      continue;
-      }
-    // Generic readers must be added to the end
-    foreach(const QString& nameFilter, matchingNameFilters)
-      {
-      if (nameFilter.contains( "*.*" ) || nameFilter.contains("(*)"))
-        {
-        genericReaders << reader;
-        continue;
-        }
-      if (!matchingReaders.contains(reader))
-        {
-        matchingReaders << reader;
-        }
+      matchingReadersSortedByConfidence.insert(longestExtensionMatch, reader);
       }
     }
-  foreach(qSlicerFileReader* reader, genericReaders)
+  // Put matching readers in a list, with highest confidence readers pushed to the front
+  QList<qSlicerFileReader*> matchingReaders;
+  QMapIterator<int, qSlicerFileReader*> i(matchingReadersSortedByConfidence);
+  while (i.hasNext())
     {
-    if (!matchingReaders.contains(reader))
-      {
-      matchingReaders << reader;
-      }
+    i.next();
+    matchingReaders.push_front(i.value());
     }
   return matchingReaders;
 }
@@ -327,12 +315,12 @@ QStringList qSlicerCoreIOManager::allWritableFileExtensions()const
       vtkMRMLStorageNode* snode = vtkMRMLStorageNode::SafeDownCast(mrmlNode);
       if (snode)
         {
-        const int formatCount = snode->GetSupportedWriteFileTypes()->GetNumberOfValues();
+        vtkNew<vtkStringArray> supportedFileExtensions;
+        snode->GetFileExtensionsFromFileTypes(snode->GetSupportedWriteFileTypes(), supportedFileExtensions.GetPointer());
+        const int formatCount = supportedFileExtensions->GetNumberOfValues();
         for (int formatIt = 0; formatIt < formatCount; ++formatIt)
           {
-          vtkStdString format = snode->GetSupportedWriteFileTypes()->GetValue(formatIt);
-          QString extension = QString::fromStdString(
-                 vtkDataFileFormatHelper::GetFileExtensionFromFormatString(format));
+          QString extension = QString::fromStdString(supportedFileExtensions->GetValue(formatIt));
           extensions << extension;
           }
         }
@@ -364,12 +352,12 @@ QStringList qSlicerCoreIOManager::allReadableFileExtensions()const
       vtkMRMLStorageNode* snode = vtkMRMLStorageNode::SafeDownCast(mrmlNode);
       if (snode)
         {
-        const int formatCount = snode->GetSupportedReadFileTypes()->GetNumberOfValues();
+        vtkNew<vtkStringArray> supportedFileExtensions;
+        snode->GetFileExtensionsFromFileTypes(snode->GetSupportedReadFileTypes(), supportedFileExtensions.GetPointer());
+        const int formatCount = supportedFileExtensions->GetNumberOfValues();
         for (int formatIt = 0; formatIt < formatCount; ++formatIt)
           {
-          vtkStdString format = snode->GetSupportedReadFileTypes()->GetValue(formatIt);
-          QString extension = QString::fromStdString(
-                 vtkDataFileFormatHelper::GetFileExtensionFromFormatString(format));
+          QString extension = QString::fromStdString(supportedFileExtensions->GetValue(formatIt));
           extensions << extension;
           }
         }
@@ -413,32 +401,22 @@ qSlicerIOOptions* qSlicerCoreIOManager::fileWriterOptions(
 }
 
 //-----------------------------------------------------------------------------
-QString qSlicerCoreIOManager::completeSlicerWritableFileNameSuffix(const QString &fileName)const
+QString qSlicerCoreIOManager::completeSlicerWritableFileNameSuffix(vtkMRMLStorableNode *node)const
 {
-  // first get all possible Slicer file extensions
-  QStringList allExtensions = qSlicerCoreIOManager::allWritableFileExtensions();
-  // then iterate through them to find one that matches
-  foreach (QString extension, allExtensions)
+  vtkMRMLStorageNode* storageNode = node->GetStorageNode();
+  if (!storageNode)
     {
-    // check if this extension is at the end of the file name
-    if (fileName.endsWith(extension))
-      {
-      return extension;
-      }
+    qWarning() << Q_FUNC_INFO << " failed: no storage node is available";
+    return QString(".");
     }
-  if (allExtensions.contains(QString(".*")))
+  QString ext = QString::fromStdString(storageNode->GetSupportedFileExtension(NULL, false, true));
+  if (!ext.isEmpty())
     {
-    // if the .* option is in the valid extensions list,
-    // use the QFileInfo complete suffix. That will return
-    // a string of everything following the first '.', then
-    // prepend the dot to match the extensions returned from above
-    QString suffix = QString (".") + QFileInfo(fileName).completeSuffix();
-    qDebug() << "Slicer extension not found in file name " << fileName
-             << ", returning Qt complete suffix as .* case " << suffix;
-    return suffix;
+    // found
+    return ext;
     }
   // otherwise return an empty suffix
-  return QString (".");
+  return QString(".");
 }
 
 //-----------------------------------------------------------------------------
@@ -575,18 +553,17 @@ vtkMRMLNode* qSlicerCoreIOManager::loadNodesAndGetFirst(
 vtkMRMLStorageNode* qSlicerCoreIOManager::createAndAddDefaultStorageNode(
     vtkMRMLStorableNode* node)
 {
-  vtkMRMLStorageNode* snode = node ? node->GetStorageNode() : 0;
-  if (snode == 0 && node != 0)
+  if (!node)
     {
-    snode = node->CreateDefaultStorageNode();
-    if (snode != 0)
-      {
-      node->GetScene()->AddNode(snode);
-      snode->Delete();
-      node->SetAndObserveStorageNodeID(snode->GetID());
-      }
+    qCritical() << Q_FUNC_INFO << " failed: invalid input node";
+    return 0;
     }
-  return snode;
+  if (!node->AddDefaultStorageNode())
+    {
+    qCritical() << Q_FUNC_INFO << " failed: error while adding default storage node";
+    return 0;
+    }
+  return node->GetStorageNode();
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -77,12 +77,12 @@ public:
   qSlicerIOOptions* fileOptions(const QString& fileDescription)const;
   qSlicerIOOptions* fileWriterOptions(vtkObject* object, const QString& extension)const;
 
-  /// Returns a full extension for this file that is recognised by Slicer IO.
-  /// Consults the qSlicerIOCoreManager for a list of known suffixes, if no match
+  /// Returns a full extension for this storable node that is recognised by Slicer IO.
+  /// Consults the storage node for a list of known suffixes, if no match
   /// is found and the .* extension exists, return the Qt completeSuffix string.
   /// If .* is not in the complete list of known suffixes, returns an empty suffix.
   /// Always includes the leading dot.
-  Q_INVOKABLE QString completeSlicerWritableFileNameSuffix(const QString &fileName)const;
+  Q_INVOKABLE QString completeSlicerWritableFileNameSuffix(vtkMRMLStorableNode *node)const;
 
   /// Load a list of nodes corresponding to \a fileType. A given \a fileType corresponds
   /// to a specific reader qSlicerIO.

--- a/Base/QTCore/qSlicerFileReader.cxx
+++ b/Base/QTCore/qSlicerFileReader.cxx
@@ -60,8 +60,12 @@ bool qSlicerFileReader::canLoadFile(const QString& fileName)const
 }
 
 //----------------------------------------------------------------------------
-QStringList qSlicerFileReader::supportedNameFilters(const QString& fileName)const
+QStringList qSlicerFileReader::supportedNameFilters(const QString& fileName, int* longestExtensionMatchPtr /* =NULL */)const
 {
+  if (longestExtensionMatchPtr)
+    {
+    (*longestExtensionMatchPtr) = 0;
+    }
   QStringList matchingNameFilters;
   QFileInfo file(fileName);
   if (!file.isFile() ||
@@ -72,12 +76,18 @@ QStringList qSlicerFileReader::supportedNameFilters(const QString& fileName)cons
     }
   foreach(const QString& nameFilter, this->extensions())
     {
-    foreach(const QString& extension, ctk::nameFilterToExtensions(nameFilter))
+    foreach(QString extension, ctk::nameFilterToExtensions(nameFilter))
       {
       QRegExp regExp(extension, Qt::CaseInsensitive, QRegExp::Wildcard);
       Q_ASSERT(regExp.isValid());
       if (regExp.exactMatch(file.absoluteFilePath()))
         {
+        extension.remove('*'); // wildcard does not count, that's not a specific match
+        int matchedExtensionLength = extension.size();
+        if (longestExtensionMatchPtr && (*longestExtensionMatchPtr) < matchedExtensionLength)
+          {
+          (*longestExtensionMatchPtr) = matchedExtensionLength;
+          }
         matchingNameFilters << nameFilter;
         }
       }

--- a/Base/QTCore/qSlicerFileReader.h
+++ b/Base/QTCore/qSlicerFileReader.h
@@ -51,7 +51,10 @@ public:
   /// and the supported extensions are "Volumes (*.mha *.nrrd *.raw)",
   /// "Images (*.png" *.jpg")", "DICOM (*)" then it returns
   /// "Volumes (*.mha *.nrrd *.raw), DICOM (*)"
-  QStringList supportedNameFilters(const QString& fileName)const;
+  /// \param longestExtensionMatchPtr If non-zero then the method returns
+  /// the length of the longest matched extension length in this argument.
+  /// It can be used to determine how specifically extension matched.
+  QStringList supportedNameFilters(const QString& fileName, int* longestExtensionMatchPtr = NULL)const;
 
   /// Properties availables : fileMode, multipleFiles, fileType.
   virtual bool load(const IOProperties& properties);

--- a/Base/QTGUI/qSlicerNodeWriter.cxx
+++ b/Base/QTGUI/qSlicerNodeWriter.cxx
@@ -150,7 +150,7 @@ bool qSlicerNodeWriter::write(const qSlicerIO::IOProperties& properties)
     qSlicerCoreApplication::application()->coreIOManager();
 
   QString fileFormat =
-    properties.value("fileFormat", coreIOManager->completeSlicerWritableFileNameSuffix(fileName)).toString();
+    properties.value("fileFormat", coreIOManager->completeSlicerWritableFileNameSuffix(node)).toString();
   snode->SetWriteFileFormat(fileFormat.toLatin1());
   snode->SetURI(0);
   if (properties.contains("useCompression"))

--- a/Libs/MRML/Core/Testing/CMakeLists.txt
+++ b/Libs/MRML/Core/Testing/CMakeLists.txt
@@ -66,6 +66,7 @@ create_test_sourcelist(Tests ${KIT}CxxTests.cxx
   vtkMRMLSceneImportTest.cxx
   vtkMRMLSceneTest1.cxx
   vtkMRMLSceneTest2.cxx
+  vtkMRMLSceneDefaultNodeTest.cxx
   vtkMRMLSceneViewNodeImportSceneTest.cxx
   vtkMRMLSceneViewNodeEventsTest.cxx
   vtkMRMLSceneViewNodeRestoreSceneTest.cxx
@@ -179,6 +180,7 @@ simple_test( vtkMRMLSceneImportIDModelHierarchyConflictTest )
 simple_test( vtkMRMLSceneImportIDModelHierarchyParentIDConflictTest )
 simple_test( vtkMRMLSceneIDTest )
 simple_test( vtkMRMLSceneTest1 )
+simple_test( vtkMRMLSceneDefaultNodeTest )
 simple_test( vtkMRMLSceneViewNodeImportSceneTest )
 simple_test( vtkMRMLSceneViewNodeEventsTest )
 simple_test( vtkMRMLSceneViewNodeRestoreSceneTest )

--- a/Libs/MRML/Core/Testing/vtkMRMLNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLNodeTest1.cxx
@@ -122,10 +122,6 @@ public:
   virtual void ReadXMLAttributes(const char** atts);
 
   // Implemented to satisfy the storage node interface
-  virtual const char* GetDefaultWriteFileExtension()
-    {
-    return "noop";
-    }
   virtual bool CanReadInReferenceNode(vtkMRMLNode* refNode)
     {
     return refNode->IsA("vtkMRMLNodeTestHelper1");
@@ -165,6 +161,7 @@ private:
   vtkMRMLStorageNodeTestHelper()
     {
     this->OtherNodeID = NULL;
+    this->DefaultWriteFileExtension = "noop";
     }
   ~vtkMRMLStorageNodeTestHelper()
     {

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneDefaultNodeTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneDefaultNodeTest.cxx
@@ -1,0 +1,51 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2016 Brigham and Women's Hospital (BWH)
+  All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Program:   3D Slicer
+
+=========================================================================auto=*/
+
+#include "vtkMRMLModelNode.h"
+#include "vtkMRMLModelStorageNode.h"
+#include "vtkMRMLScene.h"
+
+#include "vtkMRMLCoreTestingMacros.h"
+
+//------------------------------------------------------------------------------
+int vtkMRMLSceneDefaultNodeTest(int , char * [] )
+{
+  vtkNew<vtkMRMLScene> scene1;
+
+  // Test default node setting in scene
+  vtkNew<vtkMRMLModelStorageNode> defaultStorageNode;
+  defaultStorageNode->SetDefaultWriteFileExtension("stl");
+  scene1->AddDefaultNode(defaultStorageNode.GetPointer());
+  CHECK_POINTER(scene1->GetDefaultNodeByClass("vtkMRMLModelStorageNode"), defaultStorageNode.GetPointer());
+
+  // Test if storage node created by AddDefaultStorage node
+  // is overridden by default storage node set in the scene
+  vtkNew<vtkMRMLModelNode> modelNode;
+  scene1->AddNode(modelNode.GetPointer());
+  CHECK_BOOL(modelNode->AddDefaultStorageNode(), true);
+  vtkMRMLStorageNode* storageNode = modelNode->GetStorageNode();
+  CHECK_NOT_NULL(storageNode);
+  CHECK_STRING(storageNode->GetDefaultWriteFileExtension(), "stl");
+
+  // Test if default node can be modified
+  vtkMRMLModelStorageNode* defaultStorageNode2 = vtkMRMLModelStorageNode::SafeDownCast(scene1->GetDefaultNodeByClass("vtkMRMLModelStorageNode"));
+  CHECK_NOT_NULL(defaultStorageNode2);
+  defaultStorageNode2->SetDefaultWriteFileExtension("vtp");
+  vtkNew<vtkMRMLModelNode> modelNode2;
+  scene1->AddNode(modelNode2.GetPointer());
+  CHECK_BOOL(modelNode2->AddDefaultStorageNode(), true);
+  vtkMRMLStorageNode* storageNode2 = modelNode2->GetStorageNode();
+  CHECK_NOT_NULL(storageNode2);
+  CHECK_STRING(storageNode2->GetDefaultWriteFileExtension(), "vtp");
+
+  return EXIT_SUCCESS;
+}

--- a/Libs/MRML/Core/vtkDataFileFormatHelper.cxx
+++ b/Libs/MRML/Core/vtkDataFileFormatHelper.cxx
@@ -212,6 +212,11 @@ std::string vtkDataFileFormatHelper::GetFileExtensionFromFormatString(
       fileext = fileext.substr(0, pos1);
       }
     std::string lowercaseExtension=vtksys::SystemTools::LowerCase(fileext);
+    // make sure there is a leading . character
+    if (!lowercaseExtension.empty() && lowercaseExtension[0] != '.')
+      {
+      lowercaseExtension = std::string(".") + lowercaseExtension;
+      }
     return lowercaseExtension;
     }
   else

--- a/Libs/MRML/Core/vtkMRMLColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorNode.cxx
@@ -110,18 +110,7 @@ void vtkMRMLColorNode::ReadXMLAttributes(const char** atts)
       if (this->GetStorageNode() == NULL)
         {
         vtkWarningMacro("A color node has a file name, but no storage node, trying to create one");
-        vtkSmartPointer<vtkMRMLStorageNode> snode = this->CreateDefaultStorageNode();
-        if (snode && this->GetScene())
-          {
-          snode->SetFileName(attValue);
-          this->GetScene()->AddNode(snode);
-          this->SetAndObserveStorageNodeID(snode->GetID());
-          }
-        else
-          {
-          vtkErrorMacro("Unable to create or add to scene a new color storage node to read file " << attValue);
-          }
-
+        this->AddDefaultStorageNode(attValue);
         }
       }
     }

--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
@@ -33,6 +33,7 @@ vtkMRMLColorTableStorageNode::vtkMRMLColorTableStorageNode()
 {
   // use 32K as a maximum color id for now
   this->MaximumColorID = 32768;
+  this->DefaultWriteFileExtension = "ctbl";
 }
 
 //----------------------------------------------------------------------------
@@ -316,10 +317,4 @@ void vtkMRMLColorTableStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("Color Table (.ctbl)");
   this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLColorTableStorageNode::GetDefaultWriteFileExtension()
-{
-  return "ctbl";
 }

--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.h
@@ -33,9 +33,6 @@ class VTK_MRML_EXPORT vtkMRMLColorTableStorageNode : public vtkMRMLStorageNode
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "ColorTableStorage";};
 
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode* refNode);
 

--- a/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.cxx
@@ -27,6 +27,7 @@ vtkMRMLNodeNewMacro(vtkMRMLDoubleArrayStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLDoubleArrayStorageNode::vtkMRMLDoubleArrayStorageNode()
 {
+  this->DefaultWriteFileExtension = "mcsv";
 }
 
 //----------------------------------------------------------------------------
@@ -299,10 +300,4 @@ void vtkMRMLDoubleArrayStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("Measurement CSV (.mcsv)");
   this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLDoubleArrayStorageNode::GetDefaultWriteFileExtension()
-{
-  return "mcsv";
 }

--- a/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLDoubleArrayStorageNode.h
@@ -33,9 +33,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "DoubleArrayStorage";};
 
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 

--- a/Libs/MRML/Core/vtkMRMLFiducialListStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFiducialListStorageNode.cxx
@@ -27,6 +27,7 @@ vtkMRMLFiducialListStorageNode::vtkMRMLFiducialListStorageNode()
 {
   // version 2 has the new glyph symbol numbering, which starts at 1
   this->Version = 2;
+  this->DefaultWriteFileExtension = "fcsv";
 }
 
 //----------------------------------------------------------------------------
@@ -515,10 +516,4 @@ void vtkMRMLFiducialListStorageNode::InitializeSupportedReadFileTypes()
 void vtkMRMLFiducialListStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("Fiducial List CSV (.fcsv)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLFiducialListStorageNode::GetDefaultWriteFileExtension()
-{
-  return "fcsv";
 }

--- a/Libs/MRML/Core/vtkMRMLFiducialListStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLFiducialListStorageNode.h
@@ -41,10 +41,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "FiducialListStorage";};
 
-  ///
-  /// Return a default file extension for writing
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Get/Set the storage node version
   vtkGetMacro(Version, int);
   vtkSetMacro(Version, int);

--- a/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.cxx
@@ -25,6 +25,7 @@ vtkMRMLNodeNewMacro(vtkMRMLHierarchyStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLHierarchyStorageNode::vtkMRMLHierarchyStorageNode()
 {
+  this->DefaultWriteFileExtension = "txt";
 }
 
 //----------------------------------------------------------------------------
@@ -152,10 +153,4 @@ void vtkMRMLHierarchyStorageNode::InitializeSupportedReadFileTypes()
 void vtkMRMLHierarchyStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLHierarchyStorageNode::GetDefaultWriteFileExtension()
-{
-  return "txt";
 }

--- a/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLHierarchyStorageNode.h
@@ -35,10 +35,6 @@ public:
   // Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "HierarchyStorage";};
 
-  // Description:
-  // Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if reference node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 protected:

--- a/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.cxx
@@ -34,6 +34,7 @@ vtkMRMLNodeNewMacro(vtkMRMLMarkupsStorageNode);
 vtkMRMLMarkupsStorageNode::vtkMRMLMarkupsStorageNode()
 {
   this->CoordinateSystem = vtkMRMLMarkupsStorageNode::RAS;
+  this->DefaultWriteFileExtension = "mcsv";
 }
 
 //----------------------------------------------------------------------------
@@ -123,12 +124,6 @@ void vtkMRMLMarkupsStorageNode::InitializeSupportedReadFileTypes()
 void vtkMRMLMarkupsStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("Markups CSV (.mcsv)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLMarkupsStorageNode::GetDefaultWriteFileExtension()
-{
-  return "mcsv";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.h
@@ -54,10 +54,6 @@ public:
   /// Copy the node's attributes to this object
   virtual void Copy(vtkMRMLNode *node);
 
-  ///
-  /// Return a default file extension for writing
-  virtual const char* GetDefaultWriteFileExtension();
-
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 
   /// Coordinate system options

--- a/Libs/MRML/Core/vtkMRMLModelNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelNode.cxx
@@ -15,6 +15,8 @@ Version:   $Revision: 1.3 $
 // MRML includes
 #include "vtkEventBroker.h"
 #include "vtkMRMLFreeSurferProceduralColorNode.h"
+#include "vtkMRMLFreeSurferModelOverlayStorageNode.h"
+#include "vtkMRMLFreeSurferModelStorageNode.h"
 #include "vtkMRMLModelNode.h"
 #include "vtkMRMLModelDisplayNode.h"
 #include "vtkMRMLModelStorageNode.h"
@@ -655,6 +657,27 @@ void vtkMRMLModelNode::TransformBoundsToRAS(double inputBounds_Local[6], double 
 vtkMRMLStorageNode* vtkMRMLModelNode::CreateDefaultStorageNode()
 {
   return vtkMRMLStorageNode::SafeDownCast(vtkMRMLModelStorageNode::New());
+}
+
+//---------------------------------------------------------------------------
+std::string vtkMRMLModelNode::GetDefaultStorageNodeClassName(const char* filename /* =NULL */)
+{
+  if (!filename)
+    {
+    return "vtkMRMLModelStorageNode";
+    }
+  // Appropriate storage node depends on the file extension.
+  vtkSmartPointer<vtkMRMLFreeSurferModelStorageNode> fssn = vtkSmartPointer<vtkMRMLFreeSurferModelStorageNode>::New();
+  if (fssn->SupportedFileType(filename))
+    {
+    return "vtkMRMLFreeSurferModelStorageNode";
+    }
+  vtkSmartPointer<vtkMRMLFreeSurferModelOverlayStorageNode> fson = vtkSmartPointer<vtkMRMLFreeSurferModelOverlayStorageNode>::New();
+  if (fson->SupportedFileType(filename))
+    {
+    return "vtkMRMLFreeSurferModelOverlayStorageNode";
+    }
+  return "vtkMRMLModelStorageNode";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLModelNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelNode.h
@@ -181,6 +181,8 @@ public:
 
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 
+  virtual std::string GetDefaultStorageNodeClassName(const char* filename /* =NULL */);
+
   /// Create and observe default display node
   virtual void CreateDefaultDisplayNodes();
 

--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
@@ -79,6 +79,7 @@ vtkMRMLNodeNewMacro(vtkMRMLModelStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLModelStorageNode::vtkMRMLModelStorageNode()
 {
+  this->DefaultWriteFileExtension = "vtk";
 }
 
 //----------------------------------------------------------------------------
@@ -407,10 +408,3 @@ void vtkMRMLModelStorageNode::InitializeSupportedWriteFileTypes()
   this->SupportedWriteFileTypes->InsertNextValue("STL (.stl)");
   this->SupportedWriteFileTypes->InsertNextValue("PLY (.ply)");
 }
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLModelStorageNode::GetDefaultWriteFileExtension()
-{
-  return "vtk";
-}
-

--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.h
@@ -33,9 +33,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "ModelStorage";};
 
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the reference node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 

--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
@@ -39,6 +39,7 @@ vtkMRMLNodeNewMacro(vtkMRMLNRRDStorageNode);
 vtkMRMLNRRDStorageNode::vtkMRMLNRRDStorageNode()
 {
   this->CenterImage = 0;
+  this->DefaultWriteFileExtension = "nhdr";
 }
 
 //----------------------------------------------------------------------------
@@ -515,12 +516,6 @@ void vtkMRMLNRRDStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("NRRD (.nrrd)");
   this->SupportedWriteFileTypes->InsertNextValue("NRRD (.nhdr)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLNRRDStorageNode::GetDefaultWriteFileExtension()
-{
-  return "nhdr";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.h
@@ -57,10 +57,6 @@ class VTK_MRML_EXPORT vtkMRMLNRRDStorageNode : public vtkMRMLStorageNode
   /// Access the nrrd header fields to create a diffusion gradient table
   int ParseDiffusionInformation(vtkNRRDReader *reader,vtkDoubleArray *grad,vtkDoubleArray *bvalues);
 
-  ///
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in.
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 

--- a/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.cxx
@@ -31,6 +31,7 @@ vtkMRMLNodeNewMacro(vtkMRMLProceduralColorStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLProceduralColorStorageNode::vtkMRMLProceduralColorStorageNode()
 {
+  this->DefaultWriteFileExtension = "txt";
 }
 
 //----------------------------------------------------------------------------
@@ -227,10 +228,4 @@ void vtkMRMLProceduralColorStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("Color Function (.cxml)");
   this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLProceduralColorStorageNode::GetDefaultWriteFileExtension()
-{
-  return "txt";
 }

--- a/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorStorageNode.h
@@ -34,9 +34,6 @@ class VTK_MRML_EXPORT vtkMRMLProceduralColorStorageNode : public vtkMRMLStorageN
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "ProceduralColorStorage";};
 
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode* refNode);
 

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -44,6 +44,9 @@ Version:   $Revision: 1.18 $
 #include "vtkMRMLROINode.h"
 #include "vtkMRMLROIListNode.h"
 #include "vtkMRMLScriptedModuleNode.h"
+#include "vtkMRMLSegmentationDisplayNode.h"
+#include "vtkMRMLSegmentationNode.h"
+#include "vtkMRMLSegmentationStorageNode.h"
 #include "vtkMRMLSelectionNode.h"
 #include "vtkMRMLSliceCompositeNode.h"
 #include "vtkMRMLSliceNode.h"
@@ -167,6 +170,9 @@ vtkMRMLScene::vtkMRMLScene()
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLROIListNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSliceCompositeNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLScriptedModuleNode >::New() );
+  this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSegmentationDisplayNode >::New() );
+  this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSegmentationNode >::New() );
+  this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSegmentationStorageNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSelectionNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSliceNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLVolumeArchetypeStorageNode >::New() );

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -173,17 +173,12 @@ void vtkMRMLSceneViewNode::ReadXMLAttributes(const char** atts)
     if (storageNode == NULL)
       {
       // only read the directory if there isn't a storage node already
-      storageNode = this->CreateDefaultStorageNode();
+      this->AddDefaultStorageNode(vtksys::SystemTools::ConvertToOutputPath(screenCaptureFilename.c_str()).c_str());
+      storageNode = this->GetStorageNode();
       if (storageNode)
         {
-        storageNode->SetFileName(vtksys::SystemTools::ConvertToOutputPath(screenCaptureFilename.c_str()).c_str());
-        if (this->GetScene())
-          {
-          this->GetScene()->AddNode(storageNode);
-          }
         vtkWarningMacro("ReadXMLAttributes: found the ScreenCapture directory, creating a storage node to read the image file at\n\t" << storageNode->GetFileName() << "\n\tImage data be overwritten if there is a storage node pointing to another file");
         storageNode->ReadData(this);
-        storageNode->Delete();
         }
       }
     else
@@ -376,22 +371,17 @@ void vtkMRMLSceneViewNode::StoreScene()
       if (this->IncludeNodeInSceneView(storableNode) &&
           storableNode->GetSaveWithScene() )
         {
-        vtkSmartPointer<vtkMRMLStorageNode> storageNode = storableNode->GetStorageNode();
-        if (!storageNode)
+        if (!storableNode->GetStorageNode())
           {
           // No storage node in the main scene, try add one.
-          // If CreateDefaultStorageNode returns NULL it means the node can be stored
-          // in the scene (without using a storage node).
-          storageNode.TakeReference(storableNode->CreateDefaultStorageNode());
+          storableNode->AddDefaultStorageNode();
+          vtkMRMLStorageNode* storageNode = storableNode->GetStorageNode();
           if (storageNode)
             {
             std::string fileBaseName = std::string(storableNode->GetName());
             std::string extension = storageNode->GetDefaultWriteFileExtension();
             std::string storageFileName = fileBaseName + std::string(".") + extension;
             storageNode->SetFileName(storageFileName.c_str());
-            // add to the main scene
-            this->Scene->AddNode(storageNode);
-            storableNode->SetAndObserveStorageNodeID(storageNode->GetID());
             }
           }
         }

--- a/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.cxx
@@ -43,6 +43,7 @@ vtkMRMLNodeNewMacro(vtkMRMLSceneViewStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLSceneViewStorageNode::vtkMRMLSceneViewStorageNode()
 {
+  this->DefaultWriteFileExtension = "png";
 }
 
 //----------------------------------------------------------------------------
@@ -239,10 +240,4 @@ void vtkMRMLSceneViewStorageNode::InitializeSupportedWriteFileTypes()
   this->SupportedWriteFileTypes->InsertNextValue("JPEG (.jpeg)");
   this->SupportedWriteFileTypes->InsertNextValue("TIFF (.tiff)");
   this->SupportedWriteFileTypes->InsertNextValue("BMP (.bmp)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLSceneViewStorageNode::GetDefaultWriteFileExtension()
-{
-  return "png";
 }

--- a/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSceneViewStorageNode.h
@@ -39,9 +39,6 @@ public:
   /// Initialize all the supported write file types
   virtual void InitializeSupportedWriteFileTypes();
 
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -262,20 +262,25 @@ void vtkMRMLSegmentationNode::SegmentationModifiedCallback(vtkObject* vtkNotUsed
       self->InvokeCustomModifiedEvent(eid, callData);
       break;
     case vtkSegmentation::RepresentationModified:
+      self->StorableModifiedTime.Modified();
       self->InvokeCustomModifiedEvent(eid, callData);
       break;
     case vtkSegmentation::ContainedRepresentationNamesModified:
+      self->StorableModifiedTime.Modified();
       self->InvokeCustomModifiedEvent(eid);
       break;
     case vtkSegmentation::SegmentAdded:
+      self->StorableModifiedTime.Modified();
       self->OnSegmentAdded(reinterpret_cast<char*>(callData));
       self->InvokeCustomModifiedEvent(eid, callData);
       break;
     case vtkSegmentation::SegmentRemoved:
+      self->StorableModifiedTime.Modified();
       self->OnSegmentRemoved(reinterpret_cast<char*>(callData));
       self->InvokeCustomModifiedEvent(eid, callData);
       break;
     case vtkSegmentation::SegmentModified:
+      self->StorableModifiedTime.Modified();
       self->OnSegmentModified(reinterpret_cast<char*>(callData));
       self->InvokeCustomModifiedEvent(eid, callData);
       break;
@@ -407,7 +412,6 @@ void vtkMRMLSegmentationNode::OnSubjectHierarchyUIDAdded(vtkMRMLSubjectHierarchy
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLSegmentationNode::CreateDefaultStorageNode()
 {
-  this->StorableModified(); // Workaround to make save dialog check the segmentation node
   return vtkMRMLSegmentationStorageNode::New();
 }
 
@@ -501,9 +505,7 @@ bool vtkMRMLSegmentationNode::GetModifiedSinceRead()
 {
   // Avoid calling vtkMRMLVolumeNode::GetModifiedSinceRead as it calls GetImageData
   // which triggers merge. It is undesirable especially if it's only called when exiting.
-  return this->vtkMRMLStorableNode::GetModifiedSinceRead()
-    || (this->HasMergedLabelmap() && this->GetImageData()->GetMTime() > this->GetStoredTime())
-    || this->Segmentation->GetModifiedSinceRead();
+  return this->vtkMRMLStorableNode::GetModifiedSinceRead();
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -133,8 +133,10 @@ void vtkMRMLSegmentationStorageNode::Copy(vtkMRMLNode *anode)
 //----------------------------------------------------------------------------
 void vtkMRMLSegmentationStorageNode::InitializeSupportedReadFileTypes()
 {
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation 4D NRRD volume (.seg.nrrd)");
-  this->SupportedReadFileTypes->InsertNextValue("Segmentation Multi-block dataset (.seg.vtm)");
+  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.seg.nrrd)");
+  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.seg.vtm)");
+  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.nrrd)");
+  this->SupportedReadFileTypes->InsertNextValue("Segmentation (.vtm)");
 }
 
 //----------------------------------------------------------------------------
@@ -142,17 +144,29 @@ void vtkMRMLSegmentationStorageNode::InitializeSupportedWriteFileTypes()
 {
   Superclass::InitializeSupportedWriteFileTypes();
   vtkMRMLSegmentationNode* segmentationNode = this->GetAssociatedDataNode();
-  if (!segmentationNode)
+  bool masterIsImage = true;
+  bool masterIsPolyData = true;
+  if (segmentationNode)
     {
-    return;
+    // restrict write file types to those that are suitable for current master representaton
+    masterIsImage = segmentationNode->GetSegmentation()->IsMasterRepresentationImageData();
+    masterIsPolyData = segmentationNode->GetSegmentation()->IsMasterRepresentationPolyData();
+    if (!masterIsImage && !masterIsPolyData)
+      {
+      // if contains unknown representation then enable all formats
+      masterIsImage = true;
+      masterIsPolyData = true;
+      }
     }
-  if (segmentationNode->GetSegmentation()->IsMasterRepresentationImageData())
+  if (masterIsImage)
     {
-    this->SupportedWriteFileTypes->InsertNextValue("Segmentation 4D NRRD volume (.seg.nrrd)");
+    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.seg.nrrd)");
+    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.nrrd)");
     }
-  else if (segmentationNode->GetSegmentation()->IsMasterRepresentationPolyData())
+  if (masterIsPolyData)
     {
-    this->SupportedWriteFileTypes->InsertNextValue("Segmentation Multi-block dataset (.seg.vtm)");
+    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.seg.vtm)");
+    this->SupportedWriteFileTypes->InsertNextValue("Segmentation (.vtm)");
     }
 }
 

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
@@ -76,6 +76,8 @@ public:
   virtual const char* GetNodeTagName()  {return "SegmentationStorage";};
 
   /// Return a default file extension for writing
+  /// File write extension is determined dynamically
+  /// from master representation type.
   virtual const char* GetDefaultWriteFileExtension();
 
   /// Return true if the reference node can be read in

--- a/Libs/MRML/Core/vtkMRMLStorableNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorableNode.h
@@ -104,6 +104,12 @@ public:
   /// This must be overwritten by subclasses that use storage nodes.
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 
+  virtual std::string GetDefaultStorageNodeClassName(const char* filename = NULL);
+
+  /// Returns true on success. If storage node is not needed then
+  /// storage node is not created and the method returns with true.
+  virtual bool AddDefaultStorageNode(const char* filename = NULL);
+
   /// Returns true if the node is more recent than the file on disk.
   /// This information can be used by the application to know which node
   /// has been modified since it has been last read or written.

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -184,6 +184,11 @@ void vtkMRMLStorageNode::WriteXML(ostream& of, int nIndent)
   ss << this->UseCompression;
   of << indent << " useCompression=\"" << ss.str() << "\"";
 
+  if (this->GetDefaultWriteFileExtension() != NULL)
+    {
+    of << indent << " defaultWriteFileExtension=\"" << this->GetDefaultWriteFileExtension() << "\"";
+    }
+
   of << indent << " readState=\"" << this->ReadState <<  "\"";
   of << indent << " writeState=\"" << this->WriteState <<  "\"";
 }
@@ -287,6 +292,11 @@ void vtkMRMLStorageNode::ReadXMLAttributes(const char** atts)
       std::string uri = vtkMRMLNode::URLDecodeString(attValue);
       this->AddURI(uri.c_str());
       }
+    else if (!strncmp(attName, "defaultWriteFileExtension", 25))
+      {
+      this->SetDefaultWriteFileExtension(attValue);
+      }
+
     else if (!strcmp(attName, "useCompression"))
       {
       std::stringstream ss;
@@ -330,6 +340,7 @@ void vtkMRMLStorageNode::Copy(vtkMRMLNode *anode)
   this->SetUseCompression(node->UseCompression);
   this->SetReadState(node->ReadState);
   this->SetWriteState(node->WriteState);
+  this->SetDefaultWriteFileExtension(node->GetDefaultWriteFileExtension());
 
   this->EndModify(disabledModify);
 }
@@ -363,6 +374,8 @@ void vtkMRMLStorageNode::PrintSelf(ostream& os, vtkIndent indent)
     }
   os << indent << "WriteFileFormat: " <<
     (this->WriteFileFormat ? this->WriteFileFormat : "(none)") << "\n";
+  os << indent << "DefaultWriteFileExtension: " <<
+    (this->GetDefaultWriteFileExtension() ? this->GetDefaultWriteFileExtension() : "(none)") << "\n";
 
   os << indent << "TempFileName: " << (this->TempFileName ? this->TempFileName : "(none)") << "\n";
 }
@@ -933,6 +946,29 @@ vtkStringArray* vtkMRMLStorageNode::GetSupportedWriteFileTypes()
     }
   return this->SupportedWriteFileTypes;
 }
+
+//------------------------------------------------------------------------------
+const char* vtkMRMLStorageNode::GetDefaultWriteFileExtension()
+{
+  // for backward compatibility, we return NULL by default
+  if (this->DefaultWriteFileExtension.empty())
+    {
+    return NULL;
+    }
+  return this->DefaultWriteFileExtension.c_str();
+};
+
+//------------------------------------------------------------------------------
+void vtkMRMLStorageNode::SetDefaultWriteFileExtension(const char* ext)
+{
+  std::string extStr = (ext ? ext : "");
+  if (extStr == this->DefaultWriteFileExtension)
+    {
+    return;
+    }
+  this->DefaultWriteFileExtension = extStr;
+  this->Modified();
+};
 
 //----------------------------------------------------------------------------
 void vtkMRMLStorageNode::InitializeSupportedReadFileTypes()

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -74,6 +74,13 @@ public:
   vtkSetStringMacro(FileName);
   vtkGetStringMacro(FileName);
 
+  /// Return complete file extension for the specified filename.
+  /// Longest matched extension will be returned (.seg.nrrd will be returned
+  /// if both .nrrd and .seg.nrrd are matched), including dot.
+  /// If filename is not specified then the current FileName will be used
+  /// If there is no match then empty is returned.
+  virtual std::string GetSupportedFileExtension(const char* fileName = NULL, bool includeReadable = true, bool includeWriteable = true);
+
   ///
   /// return the nth file name, null if doesn't exist
   const char *GetNthFileName(int n) const;
@@ -147,7 +154,13 @@ public:
   ///
   /// Check to see if this storage node can handle the file type in the input
   /// string. If input string is null, check URI, then check FileName. Returns
-  /// 1 if is supported, 0 otherwise.
+  /// nonzero if supported, 0 otherwise.
+  /// The higher the value, the higher the confidence that this reader
+  /// is the most suitable for reading the file.
+  /// Typically, the confidence is the length of the file matched file extension
+  /// (including the dot). So, for example for .nrrd file extension the returned
+  /// value is 5, for .seg.nrrd the returned value is 9. If a reader looks into
+  /// the file content then it may return with much higher confidence values.
   /// Subclasses should implement this method.
   virtual int SupportedFileType(const char *fileName);
 
@@ -160,6 +173,13 @@ public:
   /// Get all the supported write file types
   /// Subclasses should overwrite InitializeSupportedWriteFileTypes().
   virtual vtkStringArray* GetSupportedWriteFileTypes();
+
+  ///
+  /// Get all file extensions from file types list
+  /// returned by GetSupportedReadFileTypes() or GetSupportedWriteFileTypes().
+  /// Always includes a dot.
+  /// If extension is not specified for a type or .* is specified then .* will be returned.
+  virtual void GetFileExtensionsFromFileTypes(vtkStringArray* inputFileTypes, vtkStringArray* outputFileExtensions);
 
   ///
   /// Allow to set specific file format that this node will write output.
@@ -277,6 +297,10 @@ public:
   /// Helper function for getting extension from a full filename.
   /// It always returns lowercase extension.
   static std::string GetLowercaseExtensionFromFileName(const std::string& filename);
+
+  /// Remove extension from filename.
+  /// If extension is empty, ".", or ".*"
+  static std::string GetFileNameWithoutExtension(const std::string& filename, const std::string& extension);
 
 protected:
   vtkMRMLStorageNode();

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -212,11 +212,14 @@ public:
   void SetURIPrefix(const char *uriPrefix);
 
   ///
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension()
-    {
-    return NULL;
-    };
+  /// Return default file extension for writing.
+  virtual const char* GetDefaultWriteFileExtension();
+
+  ///
+  /// Set default file extension for writing.
+  /// It is just a hint, the storage node may choose a different
+  /// extension if the provided extension is not suitable.
+  virtual void SetDefaultWriteFileExtension(const char* ext);
 
   ///
   /// Set the nth file in FileNameList, checks that it is already defined
@@ -319,6 +322,7 @@ protected:
   vtkStringArray* SupportedReadFileTypes;
 
   /// List of supported extensions to write in
+  std::string DefaultWriteFileExtension;
   vtkStringArray* SupportedWriteFileTypes;
   char* WriteFileFormat;
 

--- a/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.cxx
@@ -48,6 +48,7 @@ vtkMRMLTableSQLiteStorageNode::vtkMRMLTableSQLiteStorageNode()
 {
   this->TableName = 0;
   this->Password = 0;
+  this->DefaultWriteFileExtension = "sqlite3";
 }
 
 //----------------------------------------------------------------------------
@@ -316,10 +317,4 @@ void vtkMRMLTableSQLiteStorageNode::InitializeSupportedWriteFileTypes()
   this->SupportedWriteFileTypes->InsertNextValue("SQLight database (.db3)");
   this->SupportedWriteFileTypes->InsertNextValue("SQLight database (.sqlite)");
   this->SupportedWriteFileTypes->InsertNextValue("SQLight database (.sqlite3)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLTableSQLiteStorageNode::GetDefaultWriteFileExtension()
-{
-  return "sqlite3";
 }

--- a/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableSQLiteStorageNode.h
@@ -46,9 +46,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "TableSQLightStorage";};
 
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 

--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
@@ -41,6 +41,7 @@ vtkMRMLNodeNewMacro(vtkMRMLTableStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLTableStorageNode::vtkMRMLTableStorageNode()
 {
+  this->DefaultWriteFileExtension = "tsv";
 }
 
 //----------------------------------------------------------------------------
@@ -260,10 +261,4 @@ void vtkMRMLTableStorageNode::InitializeSupportedWriteFileTypes()
   this->SupportedWriteFileTypes->InsertNextValue("Tab-separated values (.tsv)");
   this->SupportedWriteFileTypes->InsertNextValue("Comma-separated values (.csv)");
   this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLTableStorageNode::GetDefaultWriteFileExtension()
-{
-  return "tsv";
 }

--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.h
@@ -50,9 +50,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "TableStorage";};
 
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
@@ -617,30 +617,19 @@ void vtkMRMLTransformStorageNode::InitializeSupportedWriteFileTypes()
 bool vtkMRMLTransformStorageNode::IsImageFile(const std::string &filename)
 {
   // determine file type
-  std::string extension = vtkMRMLStorageNode::GetLowercaseExtensionFromFileName(filename);
+  std::string extension = this->GetSupportedFileExtension(filename.c_str());
   if( extension.empty() )
     {
     vtkErrorMacro("ReadData: no file extension specified: " << filename.c_str());
     return false;
     }
-
   if ( !extension.compare(".nrrd")
       || !extension.compare(".nhdr")
       || !extension.compare(".mha")
       || !extension.compare(".mhd")
-      || !extension.compare(".nii") )
+      || !extension.compare(".nii")
+      || !extension.compare(".nii.gz"))
     {
-    return true;
-    }
-
-  // extension may contain only the last extension, which is not enough if we want to detect .nii.gz,
-  // so handle that case separately here
-  std::string filenameLowercase = vtksys::SystemTools::LowerCase(filename);
-  std::string ending=".nii.gz";
-  if (filenameLowercase.length() > ending.length()
-      && (0 == filenameLowercase.compare (filenameLowercase.length() - ending.length(), ending.length(), ending)) )
-    {
-    // filename ends with .nii.gz
     return true;
     }
 

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
@@ -37,6 +37,7 @@ vtkMRMLNodeNewMacro(vtkMRMLTransformStorageNode);
 vtkMRMLTransformStorageNode::vtkMRMLTransformStorageNode()
 {
   this->PreferITKv3CompatibleTransforms = 0;
+  this->DefaultWriteFileExtension = "h5";
   vtkITKTransformConverter::RegisterInverseTransformTypes();
 }
 
@@ -610,11 +611,6 @@ void vtkMRMLTransformStorageNode::InitializeSupportedWriteFileTypes()
   this->SupportedWriteFileTypes->InsertNextValue("Displacement field (.mhd)");
   this->SupportedWriteFileTypes->InsertNextValue("Displacement field (.nii)");
   this->SupportedWriteFileTypes->InsertNextValue("Displacement field (.nii.gz)");
-}
-//----------------------------------------------------------------------------
-const char* vtkMRMLTransformStorageNode::GetDefaultWriteFileExtension()
-{
-  return "h5";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.h
@@ -52,10 +52,6 @@ class VTK_MRML_EXPORT vtkMRMLTransformStorageNode : public vtkMRMLStorageNode
   /// Initialize all the supported write file types
   virtual void InitializeSupportedWriteFileTypes();
 
-  ///
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Support only transform nodes
   virtual bool CanReadInReferenceNode(vtkMRMLNode* refNode);
 

--- a/Libs/MRML/Core/vtkMRMLUnstructuredGridStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLUnstructuredGridStorageNode.cxx
@@ -30,6 +30,12 @@ Version:   $Revision: 1.2 $
 vtkMRMLNodeNewMacro(vtkMRMLUnstructuredGridStorageNode);
 
 //----------------------------------------------------------------------------
+vtkMRMLUnstructuredGridStorageNode::vtkMRMLUnstructuredGridStorageNode()
+{
+  this->DefaultWriteFileExtension = "vtk";
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLUnstructuredGridStorageNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
@@ -155,10 +161,4 @@ void vtkMRMLUnstructuredGridStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue(
     "Unstructured Grid (.vtk)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLUnstructuredGridStorageNode::GetDefaultWriteFileExtension()
-{
-  return "vtk";
 }

--- a/Libs/MRML/Core/vtkMRMLUnstructuredGridStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLUnstructuredGridStorageNode.h
@@ -34,15 +34,11 @@ public:
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "UnstructuredGridStorage";};
 
-  ///
-  /// Return a defualt file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode* refNode);
 
 protected:
-  vtkMRMLUnstructuredGridStorageNode(){};
+  vtkMRMLUnstructuredGridStorageNode();
   ~vtkMRMLUnstructuredGridStorageNode(){};
   vtkMRMLUnstructuredGridStorageNode(const vtkMRMLUnstructuredGridStorageNode&);
   void operator=(const vtkMRMLUnstructuredGridStorageNode&);

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -55,6 +55,7 @@ vtkMRMLVolumeArchetypeStorageNode::vtkMRMLVolumeArchetypeStorageNode()
   this->CenterImage = 0;
   this->SingleFile  = 0;
   this->UseOrientationFromFile = 1;
+  this->DefaultWriteFileExtension = "nrrd";
 }
 
 //----------------------------------------------------------------------------
@@ -612,12 +613,6 @@ void vtkMRMLVolumeArchetypeStorageNode::InitializeSupportedWriteFileTypes()
                                                      supportedFormats->GetValue(i));
       }
     }
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLVolumeArchetypeStorageNode::GetDefaultWriteFileExtension()
-{
-  return "nrrd";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.h
@@ -72,10 +72,6 @@ public:
   vtkSetMacro(UseOrientationFromFile, int);
   vtkGetMacro(UseOrientationFromFile, int);
 
-  ///
-  /// Return a defualt file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the reference node is supported by the storage node
   virtual bool CanReadInReferenceNode(vtkMRMLNode* refNode);
   virtual bool CanWriteFromReferenceNode(vtkMRMLNode* refNode);

--- a/Libs/vtkSegmentationCore/vtkSegment.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegment.cxx
@@ -109,20 +109,6 @@ void vtkSegment::PrintSelf(ostream& os, vtkIndent indent)
     }
 }
 
-//---------------------------------------------------------------------------
-bool vtkSegment::GetModifiedSinceRead(const vtkTimeStamp& storedTime)
-{
-  RepresentationMap::iterator reprIt;
-  for (reprIt=this->Representations.begin(); reprIt!=this->Representations.end(); ++reprIt)
-    {
-    if (reprIt->second && reprIt->second->GetMTime() > storedTime)
-      {
-      return true;
-      }
-    }
-  return false;
-}
-
 //----------------------------------------------------------------------------
 void vtkSegment::ReadXMLAttributes(const char** vtkNotUsed(atts))
 {

--- a/Libs/vtkSegmentationCore/vtkSegment.h
+++ b/Libs/vtkSegmentationCore/vtkSegment.h
@@ -60,14 +60,6 @@ public:
   /// Get bounding box in global RAS in the form (xmin,xmax, ymin,ymax, zmin,zmax).
   virtual void GetBounds(double bounds[6]);
 
-  /// Returns true if the node (default behavior) or the internal data are modified
-  /// since read/written.
-  /// Note: The MTime of the internal data is used to know if it has been modified.
-  /// So if you invoke one of the data modified events without calling Modified() on the
-  /// internal data, GetModifiedSinceRead() won't return true.
-  /// \sa vtkMRMLStorableNode::GetModifiedSinceRead()
-  bool GetModifiedSinceRead(const vtkTimeStamp& storedTime);
-
   /// Utility function to get extended bounds
   /// \param partialBounds New bounds with which the globalBounds will be extended if necessary
   /// \param globalBounds Global bounds to be extended with partialBounds

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -204,21 +204,6 @@ void vtkSegmentation::GetBounds(double bounds[6])
 }
 
 //---------------------------------------------------------------------------
-bool vtkSegmentation::GetModifiedSinceRead()
-{
-  for (SegmentMap::iterator it = this->Segments.begin(); it != this->Segments.end(); ++it)
-    {
-    vtkSegment* segment = it->second;
-    if (segment->GetModifiedSinceRead(this->MTime))
-      {
-      return true;
-      }
-    }
-
-  return false;
-}
-
-//---------------------------------------------------------------------------
 void vtkSegmentation::SetMasterRepresentationName(const std::string& representationName)
 {
   vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting MasterRepresentationName to " << representationName );

--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -46,9 +46,6 @@ public:
   enum
     {
     /// Fired when the master representation in ANY segment is changed.
-    /// While it is possible for the subclasses to fire the events without modifying the actual data,
-    /// it is not recommended to do so as it doesn't mark the data as modified, which may result in
-    /// an incorrect return value for \sa GetModifiedSinceRead()
     MasterRepresentationModified = 62100,
     /// Fired if any representation (including the master representation) in any segment is modified
     RepresentationModified,
@@ -106,14 +103,6 @@ public:
   /// Apply a non-linear transform on the master representation of the segments. The others will be invalidated
   /// Harden transform both if oriented image data and poly data.
   virtual void ApplyNonLinearTransform(vtkAbstractTransform* transform);
-
-  /// Returns true if the node (default behavior) or the internal data are modified
-  /// since read/written.
-  /// Note: The MTime of the internal data is used to know if it has been modified.
-  /// So if you invoke one of the data modified events without calling Modified() on the
-  /// internal data, GetModifiedSinceRead() won't return true.
-  /// \sa vtkMRMLStorableNode::GetModifiedSinceRead()
-  virtual bool GetModifiedSinceRead();
 
 #ifndef __VTK_WRAP__
 //BTX

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotStorageNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotStorageNode.cxx
@@ -40,6 +40,7 @@ vtkMRMLNodeNewMacro(vtkMRMLAnnotationSnapshotStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLAnnotationSnapshotStorageNode::vtkMRMLAnnotationSnapshotStorageNode()
 {
+  this->DefaultWriteFileExtension = "png";
 }
 
 //----------------------------------------------------------------------------
@@ -252,10 +253,4 @@ void vtkMRMLAnnotationSnapshotStorageNode::InitializeSupportedWriteFileTypes()
   this->SupportedWriteFileTypes->InsertNextValue("JPEG (.jpeg)");
   this->SupportedWriteFileTypes->InsertNextValue("TIFF (.tiff)");
   this->SupportedWriteFileTypes->InsertNextValue("BMP (.bmp)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLAnnotationSnapshotStorageNode::GetDefaultWriteFileExtension()
-{
-  return "png";
 }

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotStorageNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotStorageNode.h
@@ -36,9 +36,6 @@ public:
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "AnnotationSnapshotStorage";};
 
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode* refNode);
 protected:

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationStorageNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationStorageNode.cxx
@@ -15,6 +15,7 @@ vtkMRMLNodeNewMacro(vtkMRMLAnnotationStorageNode);
 vtkMRMLAnnotationStorageNode::vtkMRMLAnnotationStorageNode()
 {
   //this->Debug =1;
+  this->DefaultWriteFileExtension = "acsv";
 }
 
 //----------------------------------------------------------------------------
@@ -659,10 +660,4 @@ void vtkMRMLAnnotationStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("Annotation List CSV (.acsv)");
   this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLAnnotationStorageNode::GetDefaultWriteFileExtension()
-{
-  return "acsv";
 }

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationStorageNode.h
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationStorageNode.h
@@ -27,10 +27,6 @@ public:
   // Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName()  {return "AnnotationStorage";};
 
-  // Description:
-  // Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode* refNode);
 

--- a/Modules/Loadable/Data/qSlicerSceneWriter.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneWriter.cxx
@@ -131,19 +131,14 @@ bool qSlicerSceneWriter::writeToMRML(const qSlicerIO::IOProperties& properties)
     {
     // make a new one
     vtkNew<vtkMRMLSceneViewNode> newSceneViewNode;
-    //newSceneViewNode->SetScene(this->mrmlScene());
     newSceneViewNode->SetName(defaultSceneName);
     newSceneViewNode->SetSceneViewDescription("Scene at MRML file save point");
     this->mrmlScene()->AddNode(newSceneViewNode.GetPointer());
 
     // create a storage node
-    vtkMRMLStorageNode *storageNode = newSceneViewNode->CreateDefaultStorageNode();
     // set the file name from the node name
     std::string fname = std::string(newSceneViewNode->GetName()) + std::string(".png");
-    storageNode->SetFileName(fname.c_str());
-    this->mrmlScene()->AddNode(storageNode);
-    newSceneViewNode->SetAndObserveStorageNodeID(storageNode->GetID());
-    storageNode->Delete();
+    newSceneViewNode->AddDefaultStorageNode(fname.c_str());
 
     // use the new one
     sceneViewNode = newSceneViewNode.GetPointer();
@@ -204,7 +199,7 @@ bool qSlicerSceneWriter::writeToMRB(const qSlicerIO::IOProperties& properties)
 
   // make a subdirectory with the name the user has chosen
   QFileInfo bundle = QFileInfo(QDir(pack.absoluteFilePath()),
-                               fileInfo.baseName());
+                               fileInfo.completeBaseName());
   QString bundlePath = bundle.absoluteFilePath();
   if ( bundle.exists() )
     {

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -34,6 +34,7 @@ vtkMRMLNodeNewMacro(vtkMRMLMarkupsFiducialStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsFiducialStorageNode::vtkMRMLMarkupsFiducialStorageNode()
 {
+  this->DefaultWriteFileExtension = "fcsv";
 }
 
 //----------------------------------------------------------------------------
@@ -573,10 +574,4 @@ void vtkMRMLMarkupsFiducialStorageNode::InitializeSupportedReadFileTypes()
 void vtkMRMLMarkupsFiducialStorageNode::InitializeSupportedWriteFileTypes()
 {
   this->SupportedWriteFileTypes->InsertNextValue("Markups Fiducial CSV (.fcsv)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLMarkupsFiducialStorageNode::GetDefaultWriteFileExtension()
-{
-  return "fcsv";
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.h
@@ -52,10 +52,6 @@ public:
   /// Copy the node's attributes to this object
   virtual void Copy(vtkMRMLNode *node);
 
-  ///
-  /// Return a default file extension for writing
-  virtual const char* GetDefaultWriteFileExtension();
-
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 
 protected:

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -115,9 +115,8 @@ void vtkSlicerSegmentationsModuleLogic::RegisterNodes()
     return;
     }
 
-  this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLSegmentationNode>::New());
-  this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLSegmentationDisplayNode>::New());
-  this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLSegmentationStorageNode>::New());
+  // vtkMRMLSegmentationNode, vtkMRMLSegmentationDisplayNode, and
+  // vtkMRMLSegmentationStorageNode nodes are registered in vtkMRMLScene.
   this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLSegmentEditorNode>::New());
 
   // Register converter rules

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
@@ -85,7 +85,7 @@ qSlicerIO::IOFileType qSlicerSegmentationsReader::fileType()const
 //-----------------------------------------------------------------------------
 QStringList qSlicerSegmentationsReader::extensions()const
 {
-  return QStringList() << "Segmentation (*.seg)" << "4D NRRD volume (*.nrrd)" << "Multi-block dataset (*.vtm)";
+  return QStringList() << "Segmentation (*.seg.nrrd)" << "Segmentation (*.seg.vtm)" << "Segmentation (*.nrrd)" << "Segmentation (*.vtm)";
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.cxx
@@ -30,6 +30,7 @@ vtkMRMLNodeNewMacro(vtkMRMLVolumePropertyStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLVolumePropertyStorageNode::vtkMRMLVolumePropertyStorageNode()
 {
+  this->DefaultWriteFileExtension = "vp";
 }
 
 //----------------------------------------------------------------------------
@@ -225,10 +226,4 @@ void vtkMRMLVolumePropertyStorageNode::InitializeSupportedWriteFileTypes()
   this->SupportedWriteFileTypes->InsertNextValue("VolumeProperty (.vp)");
   this->SupportedWriteFileTypes->InsertNextValue("Text (.txt)");
   this->SupportedWriteFileTypes->InsertNextValue("VolumeProperty (.*)");
-}
-
-//----------------------------------------------------------------------------
-const char* vtkMRMLVolumePropertyStorageNode::GetDefaultWriteFileExtension()
-{
-  return "vp";
 }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyStorageNode.h
@@ -40,10 +40,6 @@ class VTK_SLICER_VOLUMERENDERING_MODULE_MRML_EXPORT vtkMRMLVolumePropertyStorage
   /// Get node XML tag name (like Storage, Transform)
   virtual const char* GetNodeTagName()  {return "VolumePropertyStorage";};
 
-  ///
-  /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension();
-
   /// Return true if the node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
 

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -1305,7 +1305,7 @@ int vtkSlicerVolumesLogic::IsFreeSurferVolume (const char* filename)
     return 0;
     }
 
-  std::string extension = vtksys::SystemTools::LowerCase( vtksys::SystemTools::GetFilenameLastExtension(filename) );
+  std::string extension = vtkMRMLStorageNode::GetLowercaseExtensionFromFileName(filename);
   if (extension == std::string(".mgz") ||
       extension == std::string(".mgh") ||
       extension == std::string(".mgh.gz"))

--- a/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
@@ -97,7 +97,7 @@ QStringList qSlicerVolumesReader::extensions()const
 {
   // pic files are bio-rad images (see itkBioRadImageIO)
   return QStringList()
-    << "Volume (*.hdr *.nhdr *.nrrd *.mhd *.mha *.vti *.nii *.gz *.mgz *.img *.pic)"
+    << "Volume (*.hdr *.nhdr *.nrrd *.mhd *.mha *.vti *.nii *.nii.gz *.mgh *.mgz *.mgh.gz *.img *.pic)"
     << "Dicom (*.dcm *.ima)"
     << "Image (*.png *.tif *.tiff *.jpg *.jpeg)"
     << "All Files (*)";


### PR DESCRIPTION
* Storable node can decide what is the most appropriate storage node, based on the requested file name and storable node content. This allows simplifications and removal of "special case" hacks throughlout the code base.

* Allow overriding default write file extension in storage nodes (instead of hardcoding DefaultWriteFileExtension string, it is now stored in a member variable). For example, changing default model node saving extension can be achieved by this:
```
msn=slicer.vtkMRMLModelStorageNode()
msn.SetDefaultWriteFileExtension('stl')
slicer.mrmlScene.AddDefaultNode(msn)
```
* Improved composite file extension support (.nii.gz, .seg.nrrd, ...). In "Add data dialog" the most specifically matched extension's reader is selected by default (for example, .nrrd is more specific than .*; .seg.nrrd is more specific than .nrrd). File extension matching has been more robust: instead of using heuristics, such as assuming .gz means a composite file extension
and collecting all possible extension from all storage nodes; now extensions are mostly managed by the storage node, which knows exactly what extensions are possible.

In the future, composite extensions could be used for more file formats where we use the same extension for storing different node types (annotations, markups, labelmap/scalar volumes, etc) and there would be no more needs for heuristics or manual user choices for selecting the correct node type.