### PR TITLE
Set default VTK backend to OpenGL2

### DIFF
--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -2859,7 +2859,7 @@ void vtkSlicerCLIModuleLogic
         break;
       case vtkMRMLCommandLineModuleNode::AutoRunEvent:
         {
-        unsigned long requestTime = reinterpret_cast<unsigned long>(callData);
+        vtkMTimeType requestTime = reinterpret_cast<vtkMTimeType>(callData);
         // Make sure the CLI node has its AutoRun flag enabled and its mode is
         // valid.
         bool autoRun = cliNode->GetAutoRun() &&
@@ -2928,7 +2928,7 @@ void vtkSlicerCLIModuleLogic
       extraDelay = 100;
       }
     }
-  unsigned long requestTime = 1; // we don't want 0, so 1 works
+  vtkMTimeType requestTime = 1; // we don't want 0, so 1 works
   if (node->GetAutoRunMode() & vtkMRMLCommandLineModuleNode::AutoRunOnChangedParameter)
     {
     requestTime = std::max(requestTime, node->GetParameterMTime());

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,7 +514,7 @@ endif()
 #-----------------------------------------------------------------------------
 # VTKv7 - Slicer_VTK_COMPONENTS
 #-----------------------------------------------------------------------------
-set(Slicer_VTK_RENDERING_BACKEND "OpenGL" CACHE STRING "Choose the rendering backend.")
+set(Slicer_VTK_RENDERING_BACKEND "OpenGL2" CACHE STRING "Choose the rendering backend.")
 set_property(CACHE Slicer_VTK_RENDERING_BACKEND PROPERTY STRINGS "OpenGL" "OpenGL2")
 mark_as_superbuild(Slicer_VTK_RENDERING_BACKEND)
 set(Slicer_VTK_RENDERING_USE_${Slicer_VTK_RENDERING_BACKEND}_BACKEND 1)

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -610,19 +610,19 @@ unsigned int vtkMRMLCommandLineModuleNode::GetAutoRunDelay() const
 }
 
 //----------------------------------------------------------------------------
-unsigned long vtkMRMLCommandLineModuleNode::GetLastRunTime() const
+vtkMTimeType vtkMRMLCommandLineModuleNode::GetLastRunTime() const
 {
   return this->Internal->LastRunTime.GetMTime();
 }
 
 //----------------------------------------------------------------------------
-unsigned long vtkMRMLCommandLineModuleNode::GetParameterMTime() const
+vtkMTimeType vtkMRMLCommandLineModuleNode::GetParameterMTime() const
 {
   return this->Internal->ParameterMTime.GetMTime();
 }
 
 //----------------------------------------------------------------------------
-unsigned long vtkMRMLCommandLineModuleNode::GetInputMTime() const
+vtkMTimeType vtkMRMLCommandLineModuleNode::GetInputMTime() const
 {
   return this->Internal->InputMTime.GetMTime();
 }

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -189,15 +189,15 @@ public:
 
   /// Return the last time the module was ran.
   /// \sa GetParameterMTime(), GetInputMTime(), GetMTime()
-  unsigned long GetLastRunTime()const;
+  vtkMTimeType GetLastRunTime()const;
 
   /// Return the last time a parameter was modified
   /// \sa GetInputMTime(), GetMTime()
-  unsigned long GetParameterMTime()const;
+  vtkMTimeType GetParameterMTime()const;
 
   /// Return the last time an input parameter was modified.
   /// \sa GetParameterMTime(), GetMTime()
-  unsigned long GetInputMTime()const;
+  vtkMTimeType GetInputMTime()const;
 
   /// Read a parameter file. This will set any parameters that
   /// parameters in this ModuleDescription.

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneEventRecorder.h
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneEventRecorder.h
@@ -45,7 +45,7 @@ public:
                        void *callData);
   // List of node that should be updated when NodeAddedEvent is catched
   std::map<unsigned long, unsigned int> CalledEvents;
-  std::map<unsigned long, unsigned long> LastEventMTime;
+  std::map<unsigned long, vtkMTimeType> LastEventMTime;
 protected:
   vtkMRMLSceneEventRecorder();
   virtual ~vtkMRMLSceneEventRecorder();

--- a/Libs/MRML/Core/Testing/vtkMRMLSliceNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSliceNodeTest1.cxx
@@ -334,7 +334,7 @@ int SetOrientationTest()
 
   // Set a valid orientation
   {
-    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    vtkMTimeType sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
     CHECK_BOOL(sliceNode->SetOrientation("Sagittal"), true);
     CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Sagittal"));
     CHECK_STRING(sliceNode->GetOrientationString(), "Sagittal");
@@ -343,7 +343,7 @@ int SetOrientationTest()
 
   // Orientation are case sensitive
   {
-    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    vtkMTimeType sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
     TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
     CHECK_BOOL(sliceNode->SetOrientation("axial"), false);
     TESTING_OUTPUT_ASSERT_ERRORS_END();
@@ -354,7 +354,7 @@ int SetOrientationTest()
 
   // The sliceToRAS matrix define the current orientation
   {
-    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    vtkMTimeType sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
     TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
     CHECK_BOOL(sliceNode->SetOrientation("Reformat"), false);
     TESTING_OUTPUT_ASSERT_ERRORS_END();
@@ -371,7 +371,7 @@ int SetOrientationTest()
 
   // Check SetOrientationToAxial
   {
-    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    vtkMTimeType sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
     CHECK_BOOL(sliceNode->SetOrientationToAxial(), true);
     CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Axial"));
     CHECK_STRING(sliceNode->GetOrientationString(), "Axial");
@@ -380,7 +380,7 @@ int SetOrientationTest()
 
   // Check SetOrientationToSagittal
   {
-    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    vtkMTimeType sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
     CHECK_BOOL(sliceNode->SetOrientationToSagittal(), true);
     CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Sagittal"));
     CHECK_STRING(sliceNode->GetOrientationString(), "Sagittal");
@@ -389,7 +389,7 @@ int SetOrientationTest()
 
   // Check SetOrientationToCoronal
   {
-    unsigned long sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
+    vtkMTimeType sliceToRASMTime = sliceNode->GetSliceToRAS()->GetMTime();
     CHECK_BOOL(sliceNode->SetOrientationToCoronal(), true);
     CHECK_STD_STRING(sliceNode->GetOrientation(), std::string("Coronal"));
     CHECK_STRING(sliceNode->GetOrientationString(), "Coronal");

--- a/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
@@ -359,7 +359,7 @@ void vtkMRMLFiducialListNode::Copy(vtkMRMLNode *anode)
       {
       vtkMRMLFiducial *fid = vtkMRMLFiducial::SafeDownCast(node->FiducialList->vtkCollection::GetItemAsObject(f));
       vtkMRMLFiducial *fidThis = vtkMRMLFiducial::SafeDownCast(this->FiducialList->vtkCollection::GetItemAsObject(f));
-      unsigned long mtime = fidThis->GetMTime();
+      vtkMTimeType mtime = fidThis->GetMTime();
       fidThis->Copy(fid);
       // Copy doesn't copy the ID, so check to see if the fiducial node in the
       // list to copy has a different id

--- a/Libs/MRML/Core/vtkMRMLHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLHierarchyNode.cxx
@@ -31,7 +31,7 @@ vtkCxxSetReferenceStringMacro(vtkMRMLHierarchyNode, AssociatedNodeIDReference);
 typedef std::map<std::string, std::vector< vtkMRMLHierarchyNode *> > HierarchyChildrenNodesType;
 
 std::map< vtkMRMLScene*, HierarchyChildrenNodesType> vtkMRMLHierarchyNode::SceneHierarchyChildrenNodes = std::map< vtkMRMLScene*, HierarchyChildrenNodesType>();
-std::map< vtkMRMLScene*, unsigned long> vtkMRMLHierarchyNode::SceneHierarchyChildrenNodesMTime = std::map< vtkMRMLScene*, unsigned long>();
+std::map< vtkMRMLScene*, vtkMTimeType> vtkMRMLHierarchyNode::SceneHierarchyChildrenNodesMTime = std::map< vtkMRMLScene*, vtkMTimeType>();
 
 double vtkMRMLHierarchyNode::MaximumSortingValue = 0;
 
@@ -39,7 +39,7 @@ typedef std::map<std::string, vtkMRMLHierarchyNode *> AssociatedHierarchyNodesTy
 
 std::map< vtkMRMLScene*, AssociatedHierarchyNodesType> vtkMRMLHierarchyNode::SceneAssociatedHierarchyNodes = std::map< vtkMRMLScene*, AssociatedHierarchyNodesType>();
 
-std::map< vtkMRMLScene*, unsigned long> vtkMRMLHierarchyNode::SceneAssociatedHierarchyNodesMTime = std::map< vtkMRMLScene*, unsigned long>();;
+std::map< vtkMRMLScene*, vtkMTimeType> vtkMRMLHierarchyNode::SceneAssociatedHierarchyNodesMTime = std::map< vtkMRMLScene*, vtkMTimeType>();;
 
 typedef vtkMRMLHierarchyNode* const vtkMRMLHierarchyNodePointer;
 bool vtkMRMLHierarchyNodeSortPredicate(vtkMRMLHierarchyNodePointer d1, vtkMRMLHierarchyNodePointer d2);
@@ -561,7 +561,7 @@ void vtkMRMLHierarchyNode::UpdateChildrenMap()
     SceneHierarchyChildrenNodesMTime[this->GetScene()] = 0;
     }
 
-  std::map< vtkMRMLScene*, unsigned long>::iterator titer =
+  std::map< vtkMRMLScene*, vtkMTimeType>::iterator titer =
         SceneHierarchyChildrenNodesMTime.find(this->GetScene());
 
   std::map<std::string, std::vector< vtkMRMLHierarchyNode *> >::iterator iter;
@@ -733,7 +733,7 @@ int vtkMRMLHierarchyNode::UpdateAssociatedToHierarchyMap(vtkMRMLScene *scene)
     SceneAssociatedHierarchyNodesMTime[scene] = 0;
     }
 
-  std::map< vtkMRMLScene*, unsigned long>::iterator titer =
+  std::map< vtkMRMLScene*, vtkMTimeType>::iterator titer =
         SceneAssociatedHierarchyNodesMTime.find(scene);
 
   if (scene->GetNodes()->GetMTime() > titer->second)

--- a/Libs/MRML/Core/vtkMRMLHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLHierarchyNode.h
@@ -197,7 +197,7 @@ protected:
   typedef std::map<std::string, std::vector< vtkMRMLHierarchyNode *> > HierarchyChildrenNodesType;
 
   static std::map< vtkMRMLScene*, HierarchyChildrenNodesType> SceneHierarchyChildrenNodes;
-  static std::map< vtkMRMLScene*, unsigned long> SceneHierarchyChildrenNodesMTime;
+  static std::map< vtkMRMLScene*, vtkMTimeType> SceneHierarchyChildrenNodesMTime;
 
   ////////////////////////////
   ///
@@ -209,7 +209,7 @@ protected:
 
   static std::map< vtkMRMLScene*, AssociatedHierarchyNodesType> SceneAssociatedHierarchyNodes;
 
-  static std::map< vtkMRMLScene*, unsigned long> SceneAssociatedHierarchyNodesMTime;
+  static std::map< vtkMRMLScene*, vtkMTimeType> SceneAssociatedHierarchyNodesMTime;
 
   double SortingValue;
 

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -698,7 +698,7 @@ protected:
   NodeReferencesType::iterator FindNodeReference(const char* referencedId, vtkMRMLNode* referencingNode);
 
   vtkCollection*  Nodes;
-  unsigned long   SceneModifiedTime;
+  vtkMTimeType    SceneModifiedTime;
 
   /// data i/o handling members
   vtkCacheManager *  CacheManager;
@@ -744,7 +744,7 @@ protected:
 
   int ReadDataOnLoad;
 
-  unsigned long NodeIDsMTime;
+  vtkMTimeType  NodeIDsMTime;
 
   void RemoveAllNodes(bool removeSingletons);
 

--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
@@ -266,7 +266,7 @@ protected:
   unsigned int NumberOfAddedSegments;
 
   /// For checking if cached segment list in SegmentationDisplayProperties has to be updated
-  unsigned long SegmentListUpdateTime;
+  vtkMTimeType SegmentListUpdateTime;
   vtkSegmentation* SegmentListUpdateSource;
 };
 

--- a/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
@@ -664,7 +664,7 @@ void vtkMRMLSelectionNode::SetUnitNodeID(const char* quantity, const char* id)
   std::string safeQuantity = quantity ? quantity : "";
   std::string referenceRole = this->GetUnitNodeReferenceRole() + safeQuantity;
 
-  unsigned long mTime = this->GetMTime();
+  vtkMTimeType mTime = this->GetMTime();
   this->SetAndObserveNodeReferenceID(referenceRole.c_str(), id);
   // \todo a bit too much hackish...
   if (this->GetMTime() > mTime)

--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -1144,9 +1144,9 @@ void vtkMRMLTransformNode::Inverse()
 }
 
 //----------------------------------------------------------------------------
-unsigned long vtkMRMLTransformNode::GetTransformToWorldMTime()
+vtkMTimeType vtkMRMLTransformNode::GetTransformToWorldMTime()
 {
-  unsigned long latestMTime=0;
+  vtkMTimeType latestMTime=0;
   vtkAbstractTransform* transformToParent=this->GetTransformToParent();
   if (transformToParent!=NULL)
     {
@@ -1156,7 +1156,7 @@ unsigned long vtkMRMLTransformNode::GetTransformToWorldMTime()
   vtkMRMLTransformNode *parent = this->GetParentTransformNode();
   if (parent != NULL)
     {
-    unsigned long parentMTime=parent->GetTransformToWorldMTime();
+    vtkMTimeType parentMTime=parent->GetTransformToWorldMTime();
     if (parentMTime>latestMTime)
       {
       latestMTime=parentMTime;

--- a/Libs/MRML/Core/vtkMRMLTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.h
@@ -339,7 +339,7 @@ public:
   void Inverse();
 
   /// Get the latest modification time of the stored transform
-  unsigned long GetTransformToWorldMTime();
+  vtkMTimeType GetTransformToWorldMTime();
 
   /// Get a human-readable description of the transformation
   /// The returned string is stored in a shared buffer therefore the text has to be copied. This is a

--- a/Libs/MRML/Core/vtkMRMLUnstructuredGridNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLUnstructuredGridNode.cxx
@@ -79,7 +79,7 @@ if (this->UnstructuredGrid != NULL)
       this->UnstructuredGrid, vtkCommand::ModifiedEvent, this, this->MRMLCallbackCommand );
     }
 
-  unsigned long mtime1, mtime2;
+  vtkMTimeType mtime1, mtime2;
   mtime1 = this->GetMTime();
   this->SetUnstructuredGrid(unstructuredGrid);
   mtime2 = this->GetMTime();

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLApplicationLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLApplicationLogicTest1.cxx
@@ -53,14 +53,14 @@ int SliceLogicsTest()
 
   // By default, a null collection is expected
   {
-    unsigned long mtime = appLogic->GetMTime();
+    vtkMTimeType mtime = appLogic->GetMTime();
     CHECK_NULL(appLogic->GetSliceLogics());
     CHECK_BOOL(appLogic->GetMTime() == mtime, true);
   }
 
   // Set a null string
   {
-    unsigned long mtime = appLogic->GetMTime();
+    vtkMTimeType mtime = appLogic->GetMTime();
     appLogic->SetSliceLogics(0);
     CHECK_NULL(appLogic->GetSliceLogics());
     CHECK_BOOL(appLogic->GetMTime() > mtime, false);
@@ -68,7 +68,7 @@ int SliceLogicsTest()
 
   // Set a non-empty collection should work
   {
-    unsigned long mtime = appLogic->GetMTime();
+    vtkMTimeType mtime = appLogic->GetMTime();
     vtkNew<vtkCollection> logics;
     logics->AddItem(vtkSmartPointer<vtkObject>::New());
     appLogic->SetSliceLogics(logics.GetPointer());
@@ -79,7 +79,7 @@ int SliceLogicsTest()
 
   // Set a null collection.
   {
-    unsigned long mtime = appLogic->GetMTime();
+    vtkMTimeType mtime = appLogic->GetMTime();
     appLogic->SetSliceLogics(0);
     CHECK_NULL(appLogic->GetSliceLogics());
     CHECK_BOOL(appLogic->GetMTime() > mtime, true);
@@ -93,7 +93,7 @@ int SliceLogicsTest()
 
   // Set an empty collection.
   {
-    unsigned long mtime = appLogic->GetMTime();
+    vtkMTimeType mtime = appLogic->GetMTime();
     vtkNew<vtkCollection> logics;
     appLogic->SetSliceLogics(logics.GetPointer());
     CHECK_NOT_NULL(appLogic->GetSliceLogics());

--- a/Libs/MRML/Logic/vtkMRMLModelHierarchyLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLModelHierarchyLogic.h
@@ -109,8 +109,8 @@ protected:
   typedef std::map<std::string, std::vector< vtkMRMLModelHierarchyNode *> > HierarchyChildrenNodesType;
   HierarchyChildrenNodesType HierarchyChildrenNodes;
 
-  unsigned long ModelHierarchyNodesMTime;
-  unsigned long HierarchyChildrenNodesMTime;
+  vtkMTimeType ModelHierarchyNodesMTime;
+  vtkMTimeType HierarchyChildrenNodesMTime;
 
   static int ChildrenVisibilitySetBatchUpdateThreshold;
 };

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -646,11 +646,11 @@ void vtkMRMLSliceLayerLogic::UpdateImageDisplay()
     return;
     }
 
-  unsigned long oldReSliceMTime = this->Reslice->GetMTime();
-  unsigned long oldReSliceUVWMTime = this->ResliceUVW->GetMTime();
-  unsigned long oldAssign = this->AssignAttributeTensorsToScalars->GetMTime();
-  unsigned long oldLabel = this->LabelOutline->GetMTime();
-  unsigned long oldLabelUVW = this->LabelOutlineUVW->GetMTime();
+  vtkMTimeType oldReSliceMTime = this->Reslice->GetMTime();
+  vtkMTimeType oldReSliceUVWMTime = this->ResliceUVW->GetMTime();
+  vtkMTimeType oldAssign = this->AssignAttributeTensorsToScalars->GetMTime();
+  vtkMTimeType oldLabel = this->LabelOutline->GetMTime();
+  vtkMTimeType oldLabelUVW = this->LabelOutlineUVW->GetMTime();
 
   if ( (this->VolumeNode->GetImageData() && labelMapVolumeDisplayNode) ||
        (scalarVolumeDisplayNode && scalarVolumeDisplayNode->GetInterpolate() == 0))

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -936,8 +936,8 @@ void vtkMRMLSliceLogic::UpdatePipeline()
         alphaBlending = true;
         }
       }
-    unsigned long int oldBlendMTime = this->Blend->GetMTime();
-    unsigned long int oldBlendUVWMTime = this->BlendUVW->GetMTime();
+    vtkMTimeType oldBlendMTime = this->Blend->GetMTime();
+    vtkMTimeType oldBlendUVWMTime = this->BlendUVW->GetMTime();
 
     int layerIndex = 0;
     int layerIndexUVW = 0;

--- a/Libs/MRML/Widgets/qMRMLSceneColorTableModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneColorTableModel.cxx
@@ -42,7 +42,7 @@ public:
     ColorGradient();
     void updatePixmap(vtkScalarsToColors* scalarsToColors);
 
-    unsigned long MTime;
+    vtkMTimeType  MTime;
     QPixmap       Pixmap;
   };
 

--- a/Libs/vtkITK/vtkITKImageToImageFilter.h
+++ b/Libs/vtkITK/vtkITKImageToImageFilter.h
@@ -71,9 +71,9 @@ public:
   ///
   /// This method considers the sub filters MTimes when computing this objects
   /// modified time.
-  unsigned long int GetMTime()
+  vtkMTimeType GetMTime()
   {
-    unsigned long int t1, t2;
+    vtkMTimeType t1, t2;
 
     t1 = this->Superclass::GetMTime();
     t2 = this->vtkExporter->GetMTime();

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
@@ -937,7 +937,7 @@ bool vtkOrientedImageDataResample::MergeImage(
     vtkGenericWarningMacro("vtkOrientedImageDataResample::MergeImage: Failed to pad segment labelmap");
     return false;
     }
-  unsigned long outputImageMTimeBefore = outputImage->GetMTime();
+  vtkMTimeType outputImageMTimeBefore = outputImage->GetMTime();
   switch (inputImage->GetScalarType())
     {
     vtkTemplateMacro(MergeImageGeneric<VTK_TT>(
@@ -951,7 +951,7 @@ bool vtkOrientedImageDataResample::MergeImage(
     vtkGenericWarningMacro("vtkOrientedImageDataResample::MergeImage: Unknown ScalarType");
     return false;
     }
-  unsigned long outputImageMTimeAfter = outputImage->GetMTime();
+  vtkMTimeType outputImageMTimeAfter = outputImage->GetMTime();
   if (outputModified != NULL)
     {
     (*outputModified) = (outputImageMTimeBefore<outputImageMTimeAfter);

--- a/Libs/vtkTeem/vtkDiffusionTensorGlyph.cxx
+++ b/Libs/vtkTeem/vtkDiffusionTensorGlyph.cxx
@@ -798,10 +798,10 @@ void vtkDiffusionTensorGlyph::PrintSelf(ostream& os, vtkIndent indent)
 //----------------------------------------------------------------------------
 // Account for the MTime of objects we use
 //
-unsigned long int vtkDiffusionTensorGlyph::GetMTime()
+vtkMTimeType vtkDiffusionTensorGlyph::GetMTime()
 {
-  unsigned long mTime=this->vtkObject::GetMTime();
-  unsigned long time;
+  vtkMTimeType mTime=this->vtkObject::GetMTime();
+  vtkMTimeType time;
 
   if ( this->Mask != NULL )
     {

--- a/Libs/vtkTeem/vtkDiffusionTensorGlyph.h
+++ b/Libs/vtkTeem/vtkDiffusionTensorGlyph.h
@@ -165,7 +165,7 @@ public:
   /// When determining the modified time of the filter,
   /// this checks the modified time of the mask input,
   /// if it exists.
-  unsigned long int GetMTime();
+  vtkMTimeType GetMTime();
 
 protected:
   vtkDiffusionTensorGlyph();

--- a/SuperBuild/External_VTKv7.cmake
+++ b/SuperBuild/External_VTKv7.cmake
@@ -99,7 +99,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT ${CMAKE_PROJECT_N
   endif()
 
   set(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY "github.com/Slicer/VTK.git" CACHE STRING "Repository from which to get VTK" FORCE)
-  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "0f8ed32e0b7018d776271dbf5f27968b716a9e10" CACHE STRING "VTK git tag to use" FORCE)
+  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "5f83a54f913d22e49cf30ecb9ae7950fd3d3cdd7" CACHE STRING "VTK git tag to use" FORCE)
 
   mark_as_advanced(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG)
 


### PR DESCRIPTION
Now that upstream VTK includes fixes for OpenGL2 GPU volume renderer issues that affected Slicer, update VTK and set the default VTK backend to OpenGL2.

Note:
Following https://gitlab.kitware.com/vtk/vtk/merge_requests/1790 (ENH: Introduce vtkMTimeType), some extensions will need to be updated using the procedure described in that merge request. Affected extensions include, at least:
* ModelToModelDistance
* SlicerIGT
* SlicerRT
