### PR TITLE
COMP: Fix windows compilation with Slicer_BUILD_PARAMETERSERIALIZER_S…

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CLISerializationTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLISerializationTest.py
@@ -119,17 +119,18 @@ if __name__ == '__main__':
           "files" : [ "1.does", "2.not", "3.matter" ],
           "image1" : "",
           "image2" : "",
-          "outputFile1" : "",
-          "seed" : [[1.0,0.0,-1.0]],
-          "seedsFile" : "",
-          "seedsOutFile" : serializeSeedsOutFile,
-          "transform1" : "%s/ExecutionModelTourTest.mrml#vtkMRMLLinearTransformNode1"%(data_dir),
-          "transform2" : "%s/ExecutionModelTourTest.mrml#vtkMRMLLinearTransformNode2"%(data_dir)
+          "outputFile1" : ""
         },
         "Generic Tables" :
         {
           "inputDT" : "",
           "outputDT" : ""
+        },
+        "Geometry Parameters" :
+        {
+          "InputModel" : "",
+          "ModelSceneFile" : [],
+          "OutputModel" : ""
         },
         "Index Parameters" :
         {
@@ -140,6 +141,12 @@ if __name__ == '__main__':
         {
           "inputFA" : "",
           "outputFA" : ""
+        },
+        "Point Parameters" :
+        {
+          "seed" : [[1.0,0.0,-1.0]],
+          "seedsFile" : "",
+          "seedsOutFile" : serializeSeedsOutFile,
         },
         "Regions of interest" :
         {
@@ -159,6 +166,17 @@ if __name__ == '__main__':
           "anintegervectorreturn" : [],
           "astringchoicereturn" : "Bill",
           "astringreturn" : "Hello"
+        },
+        "Transform Parameters" :
+        {
+          "transform1" : "%s/ExecutionModelTourTest.mrml#vtkMRMLLinearTransformNode1"%(data_dir),
+          "transform2" : "%s/ExecutionModelTourTest.mrml#vtkMRMLLinearTransformNode2"%(data_dir),
+          "transformInput" : "",
+          "transformInputBspline" : "",
+          "transformInputNonlinear" : "",
+          "transformOutput" : "",
+          "transformOutputBspline" : "",
+          "transformOutputNonlinear" : ""
         },
         "Vector Parameters" :
         {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,7 @@ CMAKE_DEPENDENT_OPTION(
   "Slicer_BUILD_ITKPython" OFF)
 mark_as_superbuild(Slicer_INSTALL_ITKPython)
 
-option(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT "Build Slicer with parameter serializer support" OFF)
+option(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT "Build Slicer with parameter serializer support" ON)
 mark_as_superbuild(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT)
 
 #


### PR DESCRIPTION
…UPPORT

The JsonCpp_LIBRARY needs to be passed to SlicerExecutionModel as a
CMAKE_ARGS because it contains the result of the ${CMAKE_CFG_INTDIR}
variable that needs to be evaluated.

cc: @jcfr, @lassoan 