### PR TITLE
BUG: Force image slice actors to be treated as opaque

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -1755,10 +1755,20 @@ void vtkMRMLModelDisplayableManager::SetModelDisplayProperty(vtkMRMLDisplayableN
           actor->GetTexture()->SetInputConnection(modelDisplayNode->GetTextureImageDataConnection());
           actor->GetTexture()->SetInterpolate(modelDisplayNode->GetInterpolateTexture());
           actor->GetProperty()->SetColor(1., 1., 1.);
+
+          // Force actors to be treated as opaque. Otherwise, transparent
+          // elements in the texture cause the actor to be treated as
+          // translucent, i.e. rendered without writing to the depth buffer.
+          // See http://www.na-mic.org/Bug/view.php?id=4253.
+          if (actor->GetProperty()->GetOpacity() == 1.0)
+            {
+            actor->ForceOpaqueOn();
+            }
           }
         else
           {
           actor->SetTexture(0);
+          actor->ForceOpaqueOff();
           }
         }
       else if (imageActor)


### PR DESCRIPTION
This commit fixes rendering of image slices in the 3D view with the VTK
OpenGL2 backend.

The OpenGL2 backend performs more thorough checks than the old backend
when determining whether to treat an actor as opaque or translucent.
Now, in certain cases, VTK determines that the slice texture contains
transparent elements and therefore should treat the actor as
translucent, i.e. rendered without writing to the depth buffer. [1][2]

This commit overrides that transparency-detection logic to force the
image slice actors to be treated as opaque.

Fixes http://www.na-mic.org/Bug/view.php?id=4253

[1] https://github.com/Kitware/VTK/blob/bace0bcf81dd6e8d334b78add2d77da37d71398f/Rendering/Core/vtkActor.cxx#L131-L133

[2] https://github.com/Kitware/VTK/blob/bace0bcf81dd6e8d334b78add2d77da37d71398f/Rendering/OpenGL2/vtkOpenGLActor.cxx#L59