### PR TITLE
BUG: Update VTK to include 2D actor ordering fix for OpenGL2 backend

### DIFF
--- a/SuperBuild/External_VTKv7.cmake
+++ b/SuperBuild/External_VTKv7.cmake
@@ -99,7 +99,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT ${CMAKE_PROJECT_N
   endif()
 
   set(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY "github.com/Slicer/VTK.git" CACHE STRING "Repository from which to get VTK" FORCE)
-  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "5f83a54f913d22e49cf30ecb9ae7950fd3d3cdd7" CACHE STRING "VTK git tag to use" FORCE)
+  set(${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG "a024cefc2acf25350734e6f04d2562f9a6a3b124" CACHE STRING "VTK git tag to use" FORCE)
 
   mark_as_advanced(${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG)
 


### PR DESCRIPTION
Update VTK to include 2D actor ordering fix for OpenGL2 backend. The
relevant merge commit is:
https://github.com/Kitware/VTK/commit/8c39dc64c101a7f23ec9e664be7797244dfdde95

Fixes http://www.na-mic.org/Bug/view.php?id=4251

```
$ git shortlog 5f83a54..3b13ad9f --no-merges
Alvaro Sanchez (6):
      Added vtkValuePass::FLOATING_POINT for point data.
      Made vtkFBO2 derive from vtkFBOBase.
      vtkValuePass::FLOATING_POINT handles viewport size changes.
      vtkValuePass::FLOATING_POINT supports cell data.
      Fixed broken tests and updated documentation.
      Sets the correct input in UseInvertibleColorFor.

Andrew Bauer (4):
      Making vtkPointSetCellIterator have same point data type as the vtkPointSet.
      Reducing output amount from vtkTemporalStatistics filter.
      Making CellIterators have same point data type as the input data set.
      Making DataSetCellIterators have proper point data type.

Armin Wehrfritz (1):
      IO/Xdmf3: Handle Polyhedron cells in unstructured grids with mixed topology

Ben Boeckel (10):
      vtkPResampleFilter: initialize UseInputBounds
      GetMTime: fix some missed mtime type changes
      vtkOSPRayPass: just use const char* up front
      vtkOSPRayPass: avoid variable length stack arrays
      vtkOSPRayPass: avoid needless memory gymnastics
      vtkOSPRayRendererNode: make M_PI available on Windows
      vtkOSPRayRendererNode: include <algorithm> for std::min/max
      vtkOSPRayRendererNode: fix brace initializers
      vtkOSPRayVolumeMapperNode: remove needless parameter
      vtkPointAccumulator: remove unused file

Berk Geveci (1):
      Added test for the FLUENT reader.

Bill Lorensen (2):
      COMP: vtkModelMetaData memory leaks
      COMP: vtkModelMetaData memory leaks

Carson Brownlee (5):
      Adding in OSPRay Volume Rendering Paths
      Reparent OSPVolumeMapper and improve layering
      crash fix
      removing depth buffer realloc.  Adding back conditional composite
      adding ospray init env arg

Chet Nieter (1):
      Clarified documentation of JacobiN method in vtkMath.

Cory Quammen (6):
      16834: Fix warnings in vtkWebGLExporter
      Added test for reading polyhedron from Xdmf file
      Fix dependency that really only needs to be a test dependency
      Removed unneeded private dependencies for IOSQL module
      Added scale factor for distance representation
      Invert the effect of the scale factor

Dan Lipsa (10):
      BUG: n lines of text include (n-1) interline spaces.
      ENH: Add vtkTextProperty::UseTightBoundingBox to center a label to anchor.
      BUG: Ascent, descent are positions from the baseline.
      BUG: Use of double LineSpacing results in one pixel off errors.
      Use NormalizedDisplay as for displaying the text.
      Shift quad position with one pixel to fix multiLineText test.
      BUG: lastPos = firstPos + size - 1.
      Baselines for text labels fixes.
      Additional baselines for text label fixes.
      Additional baseline for text label fixes.

Dave DeMarle (3):
      Fix bug exposed by update test.
      fix compilation warnings
      fix header test

David C. Lonie (6):
      Fix typo in vtkMPIImageReader.
      Add an FXAA implementation.
      Add a vtkFXAAOptions class for storing FXAA config.
      Add vtkOpenGLRenderTimer.
      Exclude vtkOpenGLRenderTimer from wrapping.
      Add FXAA to vtkSynchronizedRenderers.

David DeMarle (17):
      break core's dependence on ospray and begin to flesh out standalone
      miscellaneous fixes and cleanup and flesh out standalone ospvolmap
      attempt to cache ospray state for speed
      A workaround at least that fixes the leak
      misc cleanup and fix ospray layers
      improve benchmark and tests
      bring in Carson's scale fix, fix cell arrays, add the update test
      Fix standalone mapper test.
      remove tests that wont work and add one that should
      update test to allow VTKs own cpu vol renderer
      Protect against a case where volume updates and properties do not.
      upload baseline images
      fix unused var comp warnings
      protect against no input to prevent crash
      Fix new vtk style check
      new baselines for ospray latest
      update comments

David Gobbi (14):
      Simplify template macros in vtkPythonArgs
      Simplify extern template declaration
      16842: Fix reslice SplitMode, Stencil incompatibility
      Simplify extern template declarations for arrays
      Add extern template decls for vtkArrayIterator
      Update the vtkDICOM remote module to 0.7.9.
      Add vtkImageConnectivityFilter
      Update the vtkDICOM remote module to 0.7.10.
      Fix memory leak in TestImageConnectivityFilter
      Use pass-by-reference for assignment operator
      Export the vtkCocoaGLView interface
      Remove double underscore from include guards
      Fix a few doxygen specials for the wrappers
      Check for NaN when using a log scale with vtkLookupTable

Haocheng Liu (5):
      VTk Bug16140: Add one-point line&triangle check for vtkPolyData
      VTK Bug #16736: Add large data support&test for vtkMPIImageReader
      Rewrite all public&private dependency in module.cmake file
      VTK Bug15270: Correct empty condition for vtkGlyph3DMapper
      Fix Wrapping/Tcl => Rendering/Tk dependency direction

Joachim Pouderoux (1):
      Fix QuadRotationalExtrusionFilter bug.

Joseph G. Hennessey (1):
      update the update script

Karsten Tausche (3):
      Pass all available attribute information in vtkAssignAttribute
      Test new vtkAssignAttribute behavior
      Fix cppcheck warning in TestAssignAttribute

Ken Martin (10):
      some tweaks and fixes for VR
      fix incorrect incrment of gl_PrimitiveIDOffset
      fix glyph mapper bounds with composite polydata
      work on better resource management for OpenGL
      Rework the CompositePolyDataMapper2
      Fix a array bounds error and iffy pick
      fix missing newline at end of file
      Try to make the cppcheck happy
      fix an issue with release graphics resources
      fix an OpenGL2 issue impacting slicer and add test

Louis Bergmann (1):
      Added Volume Constraint to QuadricDecimation

Michael Fogleman (7):
      Support parallel project in OSPRay
      add TestOSPRayOrthographic
      Allow selecting scivis vs pathtracer for OSPRay
      Doxygen comments and other cleanup
      Add TestOSPRayRendererType; add 't' command for OSPRay tests
      Add some more kd tree tests
      Add more kd tree tests

Robert Maynard (2):
      Correct inconsistent-missing-override warnings in DataModel.
      VTK_USE_GCC_VISIBILITY has been replaced with CXX_VISIBILITY_PRESET property

Roman Grothausmann (9):
      neighbouring voxel values in vtkDiscreteMarchingCubes
      added documentation of ComputeNeighbours
      ComputeNeighbours now off by default
      renamed ComputeNeighbours to ComputeAdjacentScalars
      renamed newNeighbours to newPointScalars
      taking TestDiscreteMarchingCubes.py as base for *AdjacentScalars.py
      changes needed for successful test with ComputeAdjacentScalarsOn
      changes to test result of ComputeAdjacentScalarsOn
      documentation update

Sankhesh Jhaveri (4):
      [Volume] Support per component light parameters
      [Volume] Added tests for per component light parameters
      Added test baseline
      Fix rendering external configure issues introduced by 6e113ad4

Shawn Waldon (3):
      Use override/final/=delete anytime the compiler supports them
      Add a filter that groups a time series into a multiblock dataset
      gl2ps: add version check for USE_SYSTEM_GL2PS

Steven Hahn (2):
      Improve rendering performance when multiple cell types are present.
      When possible, use direct array access to speed up call to IsCellVisible.

Sujin Philip (1):
      Add vtkExtractTimeSteps filter and test

T.J. Corona (5):
      Turn off anti-aliasing in quadraticIntersection test.
      Update vtkQuadraticWedge documentation to better define point ordering.
      Update vtkPentagonalPrism doc to explicitly state restriction of convexity.
      In vtkGenericCell, add method to expose representative cell.
      Modify vtkHoudiniPolyDataWriter array dispatch to mirror vtkTemplateMacro.

Tiff Upstream (2):
      tiff 2016-09-07 (ecb008f9)
      tiff 2016-09-19 (50a32f50)

Utkarsh Ayachit (5):
      Fix #15909. Avoid double-free to static member.
      Fix #16833. Fix type conversion warning.
      Fix vtkCell3D::GetFacePoints implementations.
      Add support for composite datasets to vtkExtractTemporalFieldData.
      Fix leak in TestExtractTimeSteps.

Will Schroeder (5):
      Added Wendland quintic kernel; unit and plot tests
      Added test
      Better test image thanks Cory
      Move vtkPointCloud remote to Filters/Points
      Point cloud integration issues

XDMF Upstream (1):
      xdmf3 2016-08-24 (fb210b8c)
```