### PR TITLE
ENH: Set default VTK backend to OpenGL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,7 +517,7 @@ endif()
 #-----------------------------------------------------------------------------
 # VTKv7 - Slicer_VTK_COMPONENTS
 #-----------------------------------------------------------------------------
-set(Slicer_VTK_RENDERING_BACKEND "OpenGL" CACHE STRING "Choose the rendering backend.")
+set(Slicer_VTK_RENDERING_BACKEND "OpenGL2" CACHE STRING "Choose the rendering backend.")
 set_property(CACHE Slicer_VTK_RENDERING_BACKEND PROPERTY STRINGS "OpenGL" "OpenGL2")
 mark_as_superbuild(Slicer_VTK_RENDERING_BACKEND)
 set(Slicer_VTK_RENDERING_USE_${Slicer_VTK_RENDERING_BACKEND}_BACKEND 1)


### PR DESCRIPTION
Set the default VTK backend to OpenGL2 now that the following issues
have been fixed:

http://www.na-mic.org/Bug/view.php?id=4251
http://www.na-mic.org/Bug/view.php?id=4253

Other related known issues include:

http://www.na-mic.org/Bug/view.php?id=4252