### PR TITLE
ENH: Update to latest CTK

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -58,7 +58,7 @@ if(NOT DEFINED CTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/commontk/CTK.git"
-    GIT_TAG "e15af4d7c96491c9bc6c5fb4aa3be6088721c8b5"
+    GIT_TAG "4e85deb5c7fd4a18f256d52a2600ca2dca874d6b"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
* Merge pull request #670 from ihnorton/loader_hints

RFC: LibraryFactory: allow setting LoadHints for symbol resolution

* LibraryFactory: allow setting LoadHints for sym resolution

* Merge pull request #669 from lassoan/fine-vtk-render-view-rotation

ENH: Allow automatic view rotation by less than 1 degree

* ENH: Allow automatic view rotation by less than 1 degree

Also improved documentation of a few members of the class.

* Merge branch 'xnat-out-of-bound-fix'

* xnat-out-of-bound-fix:
  XnatTreeModel: Make sure last is at least first when inserting rows

* XnatTreeModel: Make sure last is at least first when inserting rows

Adding a item to a previously empty resource folder would result in first
being 0 and last being -1. This would trigger a Qt assert.

Reviewed-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>

* Merge pull request #667 from lassoan/wrap-pythonmanager-executestring

ENH: Make executeString and executeFile invokable from Python

* ENH: Added test for ctkAbstractPythonManager::executeString wrapping

* ENH: Make executeString and executeFile invokable from Python

This allows creating variables in the Python console's scope.