### PR TITLE
ENH: when using createProgressDialog QProgressDialog needs to be always on top 

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -909,7 +909,7 @@ def messageBox(text, parent=None, **kwargs):
       setattr(mbox, key, value)
   return mbox.exec_()
 
-def createProgressDialog(parent=None, value=0, maximum=100, labelText="", windowTitle="Processing...", **kwargs):
+def createProgressDialog(parent=None, value=0, maximum=100, labelText="", windowTitle="Processing...", windowFlags=None, **kwargs):
   """Display a modal QProgressDialog. Go to QProgressDialog documentation
   http://pyqt.sourceforge.net/Docs/PyQt4/qprogressdialog.html for more keyword arguments, that could be used.
   E.g. progressbar = createProgressIndicator(autoClose=False) if you don't want the progress dialog to automatically
@@ -918,7 +918,8 @@ def createProgressDialog(parent=None, value=0, maximum=100, labelText="", window
   Updating label text with progressbar.labelText = "processing XYZ"
   """
   import qt
-  progressIndicator = qt.QProgressDialog(parent if parent else mainWindow())
+  progressIndicator = qt.QProgressDialog(parent if parent else mainWindow(),
+                                         windowFlags if windowFlags else qt.Qt.WindowStaysOnTopHint)
   progressIndicator.minimumDuration = 0
   progressIndicator.maximum = maximum
   progressIndicator.value = value


### PR DESCRIPTION
- otherwise it would be hidden behind the main window and gives the impression, that the process finished
- also added another keyword argument windowFlags for specifying other flags if needed

fixes https://github.com/SlicerProstate/mpReview/issues/146

TODO: We could also think about some parameter for disabling the mainWindow for the duration of that process
