### PR TITLE
ENH: prefer executable CLIs by default

### DIFF
--- a/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
@@ -119,7 +119,7 @@ void qSlicerSettingsModulesPanelPrivate::init()
   this->FavoritesMoreButton->setChecked(false);
 
   // Default values
-  this->PreferExecutableCLICheckBox->setChecked(false);
+  this->PreferExecutableCLICheckBox->setChecked(true);
   this->TemporaryDirectoryButton->setDirectory(coreApp->defaultTemporaryPath());
   this->DisableModulesListView->setFactoryManager( factoryManager );
   this->FavoritesModulesListView->setFactoryManager( factoryManager );


### PR DESCRIPTION
This resolves a known issue with the application crashing while using modules
as shared libraries under certain circumstances.

Motivated by this thread:

http://slicer-devel.65872.n3.nabble.com/Slicer-crashes-when-running-registration-without-having-settings-set-to-quot-Prefer-Executable-CLIs--td4037245.html