### PR TITLE
BUG: Revert default VTK backend to OpenGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,7 +517,7 @@ endif()
 #-----------------------------------------------------------------------------
 # VTKv7 - Slicer_VTK_COMPONENTS
 #-----------------------------------------------------------------------------
-set(Slicer_VTK_RENDERING_BACKEND "OpenGL2" CACHE STRING "Choose the rendering backend.")
+set(Slicer_VTK_RENDERING_BACKEND "OpenGL" CACHE STRING "Choose the rendering backend.")
 set_property(CACHE Slicer_VTK_RENDERING_BACKEND PROPERTY STRINGS "OpenGL" "OpenGL2")
 mark_as_superbuild(Slicer_VTK_RENDERING_BACKEND)
 set(Slicer_VTK_RENDERING_USE_${Slicer_VTK_RENDERING_BACKEND}_BACKEND 1)


### PR DESCRIPTION
Revert the default VTK backend to OpenGL. Because the OS X factory
machine targets OS X 10.6 (CMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.6), the
Mac nightly builds don't find the required OpenGL version. The error
message seen when running Slicer is:

    vtkCocoaRenderWindow (0x125872400): VTK is designed to work with
    OpenGL version 3.2 but it appears it has been given a context that
    does not support 3.2. VTK will run in a compatibility mode designed
    to work with earlier versions of OpenGL but some features may not
    work.)