### PR TITLE
ENH: update MultiVolumeImporter hash

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -200,7 +200,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeExplorer Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(MultiVolumeImporter
   GIT_REPOSITORY ${git_protocol}://github.com/fedorov/MultiVolumeImporter.git
-  GIT_TAG 669594fb993b34a104795cd0b1e1a3340c4311c2
+  GIT_TAG 2ebb4d2d8135d7d59314dcc6656e2c2b54266d60
   OPTION_NAME Slicer_BUILD_MultiVolumeImporter
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_BUILD_MULTIVOLUME_SUPPORT;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Updated MultiVolumeImporter plugin is improved to handle certain types of 4D
Cardiac CT.

Thanks to @lassoan for identifying the use case and contributing the patch.