### PR TITLE
BUG: Introduce macro to set "Prefer CLI executable" settings default value

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -120,7 +120,7 @@ void qSlicerApplicationHelper::setupModuleFactoryManager(qSlicerModuleFactoryMan
 
     // Option to prefer executable CLIs to limit memory consumption.
     bool preferExecutableCLIs =
-      app->userSettings()->value("Modules/PreferExecutableCLI", false).toBool();
+      app->userSettings()->value("Modules/PreferExecutableCLI", Slicer_CLI_PREFER_EXECUTABLE_DEFAULT).toBool();
 
     qSlicerCLILoadableModuleFactory* cliLoadableFactory = new qSlicerCLILoadableModuleFactory();
     cliLoadableFactory->setTempDirectory(tempDirectory);

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -921,7 +921,7 @@ void qSlicerApplication::logApplicationInformation() const
          developerModeEnabled ? "yes" : "no");
 
   // Prefer executable CLI
-  bool preferExecutableCli = settings.value("Modules/PreferExecutableCLI", false).toBool();
+  bool preferExecutableCli = settings.value("Modules/PreferExecutableCLI", Slicer_CLI_PREFER_EXECUTABLE_DEFAULT).toBool();
   qDebug("%s: %s",
          qPrintable(titles.at(6).leftJustified(titleWidth, '.')),
          preferExecutableCli ? "yes" : "no");

--- a/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
@@ -119,7 +119,7 @@ void qSlicerSettingsModulesPanelPrivate::init()
   this->FavoritesMoreButton->setChecked(false);
 
   // Default values
-  this->PreferExecutableCLICheckBox->setChecked(true);
+  this->PreferExecutableCLICheckBox->setChecked(Slicer_CLI_PREFER_EXECUTABLE_DEFAULT);
   this->TemporaryDirectoryButton->setDirectory(coreApp->defaultTemporaryPath());
   this->DisableModulesListView->setFactoryManager( factoryManager );
   this->FavoritesModulesListView->setFactoryManager( factoryManager );

--- a/CMake/vtkSlicerConfigure.h.in
+++ b/CMake/vtkSlicerConfigure.h.in
@@ -73,6 +73,8 @@
 #define Slicer_CLIMODULES_LIB_DIR "@Slicer_CLIMODULES_LIB_DIR@"
 #define Slicer_CLIMODULES_SHARE_DIR "@Slicer_CLIMODULES_SHARE_DIR@"
 
+#define Slicer_CLI_PREFER_EXECUTABLE_DEFAULT true
+
 #cmakedefine Slicer_USE_PYTHONQT
 #ifdef Slicer_USE_PYTHONQT
 #  define Slicer_PYTHON_VERSION_DOT "@Slicer_PYTHON_VERSION_DOT@"


### PR DESCRIPTION
This commit fixes a regression introduced in r25404 (ENH: prefer executable
CLIs by default) and ensures the settings default value is consistently set.