### PR TITLE
BUG: Update CTK to include vtkLightBoxRendererManager fix.

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -58,7 +58,7 @@ if(NOT DEFINED CTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/commontk/CTK.git"
-    GIT_TAG "4e85deb5c7fd4a18f256d52a2600ca2dca874d6b"
+    GIT_TAG "fefcea4e36c7e1a2bb509a0ea3dd0987a51c5327"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
It fixes problem discussed in [1] and is related to Slicer issue 4251

[1] https://app.assembla.com/spaces/slicerrt/tickets/823-segmentation-disappears-after-deselecting-volume-in-slice-view/details

commit commontk/CTK@6b40e56
Author: Andras Lasso <lasso@queensu.ca>
Date:   Sat Oct 8 12:13:59 2016 -0400

    ENH: Preserve actor order in vtkLightBoxRendererManager

    The order of how 2D actors are added to the renderer greatly
    influences the rendering result. Therefore, for consistent
    rendering results actor ordering in slice viewer has to be preserved
    when just changing the input image data.

    Old behavior: When input to slice viewer was set to NULL (no image
    is selected for display), the image actor was removed from the
    renderer. When an image was selected again, the image actor was
    added again. This changed the actor order.

    Implemented fix: Modified the behavior to only hide the image actor
    when input is set to NULL. This way when image input is later set to
    non-NULL, the image actor does not get promoted to the top of the
    actor list (but keeps its original position).