### PR TITLE
ENH: scripted helper module to suggest SlicerDMRI extension

### DIFF
--- a/Modules/Scripted/CMakeLists.txt
+++ b/Modules/Scripted/CMakeLists.txt
@@ -3,6 +3,7 @@ include(SlicerMacroBuildScriptedModule)
 
 set(modules
   DataProbe
+  DMRIInstall
   Editor
   EditorLib
   LabelStatistics

--- a/Modules/Scripted/DMRIInstall/CMakeLists.txt
+++ b/Modules/Scripted/DMRIInstall/CMakeLists.txt
@@ -1,0 +1,14 @@
+#-----------------------------------------------------------------------------
+set(MODULE_NAME DMRIInstall)
+
+#-----------------------------------------------------------------------------
+set(MODULE_PYTHON_SCRIPTS
+  ${MODULE_NAME}.py
+  )
+
+#-----------------------------------------------------------------------------
+slicerMacroBuildScriptedModule(
+  NAME ${MODULE_NAME}
+  SCRIPTS ${MODULE_PYTHON_SCRIPTS}
+  WITH_GENERIC_TESTS
+  )

--- a/Modules/Scripted/DMRIInstall/DMRIInstall.py
+++ b/Modules/Scripted/DMRIInstall/DMRIInstall.py
@@ -1,0 +1,69 @@
+import os
+import string
+import unittest
+import vtk, qt, ctk, slicer
+from slicer.ScriptedLoadableModule import *
+import logging
+
+#
+# DMRIInstall
+#
+
+class DMRIInstall(ScriptedLoadableModule):
+  """
+  """
+
+  helpText = """
+Please use the Extension Manager to install the "SlicerDMRI" extension for diffusion-related tools including:
+
+    Diffusion Tensor Estimation
+    Tractography Display
+    Tractography Seeding
+    Fiber Tract Measurement
+"""
+
+  def __init__(self, parent):
+
+    # Hide this module if SlicerDMRI is already installed
+    model = slicer.app.extensionsManagerModel()
+    if model.isExtensionInstalled("SlicerDMRI"):
+      return
+
+    ScriptedLoadableModule.__init__(self, parent)
+
+    self.parent.categories = ["Diffusion"]
+    self.parent.title = "Install Slicer Diffusion Tools"
+    self.parent.dependencies = []
+    self.parent.contributors = ["Isaiah Norton"]
+    self.parent.helpText = DMRIInstall.helpText
+    self.parent.helpText += self.getDefaultModuleDocumentationLink()
+    self.parent.acknowledgementText = """
+SlicerDMRI supported by NIH NCI ITCR U01CA199459 (Open Source Diffusion MRI Technology For Brain Cancer Research), and made possible by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.
+"""
+
+class DMRIInstallWidget(ScriptedLoadableModuleWidget):
+  """Uses ScriptedLoadableModuleWidget base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def setup(self):
+    ScriptedLoadableModuleWidget.setup(self)
+
+    self.textBox = qt.QLabel()
+    self.textBox.setWordWrap(1)
+    self.textBox.setText(DMRIInstall.helpText)
+    self.parent.layout().addWidget(self.textBox)
+
+    #
+    # Apply Button
+    #
+    self.applyButton = qt.QPushButton("Open Extension Manager")
+    self.applyButton.toolTip = """Install the "SlicerDMRI" extension from the Diffusion category."""
+    self.applyButton.enabled = True
+    self.applyButton.connect('clicked()', self.onApply)
+    self.parent.layout().addWidget(self.applyButton)
+
+    self.parent.layout().addStretch(1)
+
+  def onApply(self):
+    slicer.app.openExtensionsManagerDialog()


### PR DESCRIPTION
We got a request to make more obvious to users where to find the modules that are now in SlicerDMRI extension. Not sure if this can make it in to release (great if so), but we'd like to have it in the nightly for a few months too.