### PR TITLE
BUG: Fix issue with qMRMLNodeComboBox when removing an attribute filter

### DIFF
--- a/Libs/MRML/Widgets/Testing/CMakeLists.txt
+++ b/Libs/MRML/Widgets/Testing/CMakeLists.txt
@@ -61,6 +61,7 @@ set(TEST_SOURCES
   qMRMLNodeComboBoxTest6.cxx
   qMRMLNodeComboBoxTest7.cxx
   qMRMLNodeComboBoxTest8.cxx
+  qMRMLNodeComboBoxTest9.cxx
   qMRMLNodeComboBoxLazyUpdateTest1.cxx
   qMRMLNodeFactoryTest1.cxx
   qMRMLScalarInvariantComboBoxTest1.cxx
@@ -201,6 +202,7 @@ simple_test( qMRMLNodeComboBoxTest5 )
 simple_test( qMRMLNodeComboBoxTest6 )
 simple_test( qMRMLNodeComboBoxTest7 )
 simple_test( qMRMLNodeComboBoxTest8 )
+simple_test( qMRMLNodeComboBoxTest9 )
 simple_test( qMRMLNodeComboBoxLazyUpdateTest1 )
 simple_test( qMRMLNodeFactoryTest1 )
 simple_test( qMRMLScalarInvariantComboBoxTest1 )

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest9.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest9.cxx
@@ -1,0 +1,115 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Johan Andruejol, Kitware Inc.
+
+==============================================================================*/
+
+// QT includes
+#include <QApplication>
+#include <QTimer>
+
+// CTK includes
+#include <ctkCoreTestingMacros.h>
+
+// qMRML includes
+#include "qMRMLNodeComboBox.h"
+
+// MRML includes
+#include <vtkMRMLNode.h>
+#include <vtkMRMLScene.h>
+#include <vtkMRMLScalarVolumeNode.h>
+
+// VTK includes
+#include <vtkNew.h>
+
+// test the filtering with many cases
+int qMRMLNodeComboBoxTest9( int argc, char * argv [] )
+{
+  QApplication app(argc, argv);
+
+  vtkNew<vtkMRMLScene> scene;
+
+  vtkNew<vtkMRMLScalarVolumeNode> noAttributeNode;
+  scene->AddNode(noAttributeNode.GetPointer());
+
+  const char *testingAttributeName = "testingAttribute";
+  const char *testingAttribute = noAttributeNode->GetAttribute(testingAttributeName);
+  std::cout << "Volume node with no call to SetAttribute, GetAttribute returns " << (testingAttribute ? testingAttribute : "0") << "." << std::endl;
+  CHECK_NULL(testingAttribute);
+
+  vtkNew<vtkMRMLScalarVolumeNode> emptyStringAttributeNode;
+  emptyStringAttributeNode->SetAttribute(testingAttributeName, "");
+  scene->AddNode(emptyStringAttributeNode.GetPointer());
+
+  testingAttribute = emptyStringAttributeNode->GetAttribute(testingAttributeName);
+  CHECK_STRING(testingAttribute, "");
+
+  vtkNew<vtkMRMLScalarVolumeNode> validAttributeNode;
+  validAttributeNode->SetAttribute(testingAttributeName, "a");
+  scene->AddNode(validAttributeNode.GetPointer());
+
+  testingAttribute = validAttributeNode->GetAttribute(testingAttributeName);
+  CHECK_STRING(testingAttribute, "a");
+
+  // a node selector with no filtering attribute, three volumes should be
+  // counted
+  qMRMLNodeComboBox nodeSelector;
+  nodeSelector.setNodeTypes(QStringList("vtkMRMLScalarVolumeNode"));
+  nodeSelector.setMRMLScene(scene.GetPointer());
+
+  CHECK_INT(nodeSelector.nodeCount(), 3);
+  QVariant filter = nodeSelector.sortFilterProxyModel()->attributeFilter("vtkMRMLScalarVolumeNode", testingAttributeName);
+  CHECK_QVARIANT(filter, QVariant());
+  std::cout << "Passed with no filtering\n" << std::endl;
+  nodeSelector.show();
+
+  // a node selector, remove any attribute
+  qMRMLNodeComboBox nodeSelectorA;
+  nodeSelectorA.setNodeTypes(QStringList("vtkMRMLScalarVolumeNode"));
+  nodeSelectorA.removeAttribute("vtkMRMLScalarVolumeNode", testingAttributeName);
+  nodeSelectorA.setMRMLScene(scene.GetPointer());
+
+  CHECK_INT(nodeSelectorA.nodeCount(), 3);
+  filter = nodeSelectorA.sortFilterProxyModel()->attributeFilter("vtkMRMLScalarVolumeNode", testingAttributeName);
+  CHECK_QVARIANT(filter, QVariant());
+  std::cout << "Passed with removing attribute before anything\n" << std::endl;
+  nodeSelectorA.show();
+
+  // a node selector with a defined filtering attribute that doens't match any
+  // volumes, count should be zero
+  qMRMLNodeComboBox nodeSelectorB;
+  nodeSelectorB.setNodeTypes(QStringList("vtkMRMLScalarVolumeNode"));
+  nodeSelectorB.addAttribute("vtkMRMLScalarVolumeNode", testingAttributeName, "a");
+  nodeSelectorB.setMRMLScene(scene.GetPointer());
+
+  CHECK_INT(nodeSelectorB.nodeCount(), 1);
+
+  filter = nodeSelectorB.sortFilterProxyModel()->attributeFilter("vtkMRMLScalarVolumeNode", testingAttributeName);
+  CHECK_QVARIANT(filter, QVariant("a"));
+
+  nodeSelectorB.removeAttribute("vtkMRMLScalarVolumeNode", testingAttributeName);
+  CHECK_INT(nodeSelectorB.nodeCount(), 3);
+
+  filter = nodeSelectorB.sortFilterProxyModel()->attributeFilter("vtkMRMLScalarVolumeNode", testingAttributeName);
+  CHECK_QVARIANT(filter, QVariant());
+  std::cout << "Passed with removing attribute after stuff happened\n" << std::endl;
+  nodeSelectorB.show();
+
+  if (argc < 2 || QString(argv[1]) != "-I")
+    {
+    QTimer::singleShot(200, &app, SLOT(quit()));
+    }
+
+  return app.exec();
+}

--- a/Libs/MRML/Widgets/qMRMLSortFilterProxyModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSortFilterProxyModel.cxx
@@ -130,8 +130,8 @@ void qMRMLSortFilterProxyModel::addAttribute(const QString& nodeType,
 {
   Q_D(qMRMLSortFilterProxyModel);
   if (!d->NodeTypes.contains(nodeType) ||
-      (d->Attributes[nodeType].first == attributeName &&
-       d->Attributes[nodeType].second == attributeValue))
+      (d->Attributes.value(nodeType).first == attributeName &&
+       d->Attributes.value(nodeType).second == attributeValue))
     {
     return;
     }
@@ -146,12 +146,20 @@ void qMRMLSortFilterProxyModel::removeAttribute(const QString& nodeType,
 {
   Q_D(qMRMLSortFilterProxyModel);
   if (!d->NodeTypes.contains(nodeType) ||
-      d->Attributes[nodeType].first != attributeName)
+      d->Attributes.value(nodeType).first != attributeName)
     {
     return;
     }
   d->Attributes.remove(nodeType);
   this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+QVariant qMRMLSortFilterProxyModel::attributeFilter(const QString& nodeType,
+                                                    const QString& attributeName) const
+{
+  Q_D(const qMRMLSortFilterProxyModel);
+  return d->Attributes.value(nodeType).second;
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSortFilterProxyModel.h
+++ b/Libs/MRML/Widgets/qMRMLSortFilterProxyModel.h
@@ -162,6 +162,11 @@ public:
   /// \sa addAttribute
   Q_INVOKABLE void removeAttribute(const QString& nodeType, const QString& attributeName);
 
+  /// Return the current attribute filter for the given node type.
+  /// \sa addAttribute, removeAttribute
+  Q_INVOKABLE QVariant attributeFilter(
+    const QString& nodeType, const QString& attributeName) const;
+
   /// Display or not the nodes that are excluded by
   /// the ExcludedChildNodeTypes list.
   /// true by default.


### PR DESCRIPTION
Because of the use of the [] operator on the `QHash` map used to check
attributes in the `qMRMLComboBox`, removing an attribute filter could lead
the combobox to never show anything.

The bug was as follow in pseudo-code:
```
 combobox = slicer.qMRMLComboBox()
 combobox.removeAttribute('vtkMRMLVolumeNode', 'MyAttribute')
```
-> Because of the [] operator, the map now has an entry for
`vtkMRMLVolumeNode` with nothing in it, i.e. it expects nodes to have that
attribute (and it can be anything).

The fix is to not use the [] operator when accessing values simply for
reading but to use the values() method instead.

Added a test along to make sure everything works properly.