### PR TITLE
BUG: DiffusionTensor3DExtended should not use itkTypeMacro

### DIFF
--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DExtended.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DExtended.h
@@ -36,9 +36,6 @@ public:
   typedef DiffusionTensor3D<DataType> Superclass;
   typedef Matrix<DataType, 3, 3>      MatrixType;
 
-  /** Run-time type information (and related methods). */
-  itkTypeMacro(DiffusionTensor3DExtended, DiffusionTensor3D);
-
   DiffusionTensor3DExtended()
   {
   }


### PR DESCRIPTION
DiffusionTensor3DExtended is not derived from itkLightObject so
it should not use itkTypeMacro.