### PR TITLE
BUG: don't rely on application state in widget ::init

### DIFF
--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -202,8 +202,9 @@ void qSlicerTerminologyNavigatorWidgetPrivate::init()
 //-----------------------------------------------------------------------------
 vtkSlicerTerminologiesModuleLogic* qSlicerTerminologyNavigatorWidgetPrivate::terminologyLogic()
 {
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
   qSlicerAbstractCoreModule* terminologiesModule =
-    qSlicerCoreApplication::application()->moduleManager()->module("Terminologies");
+    app ? app->moduleManager()->module("Terminologies") : NULL;
   if (terminologiesModule)
   {
     vtkSlicerTerminologiesModuleLogic* terminologyLogic =


### PR DESCRIPTION
QtDesigner widget initialization crashes because Terminologies widget `::init` calls a function that requires application state.

ref https://github.com/Slicer/Slicer/commit/4bac13a687b39a69e2648f281bd737bae3eaf08c#commitcomment-19617853