### PR TITLE
ENH: Update SlicerExecutionModel version

### DIFF
--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -76,7 +76,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${git_protocol}://github.com/Slicer/SlicerExecutionModel.git"
-    GIT_TAG "983d2112ec431af20cafa49ca6cf7bd1a777869a"
+    GIT_TAG "62d0121dbb0fb057ebbd7c9ab84520accacec8bc"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BINARY_DIR ${proj}-build
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
```
git shortlog 983d2112ec431af20cafa49ca6cf7bd1a777869a..62d0121dbb0fb057ebbd7c9ab84520accacec8bc --no-merges
Jean-Christophe Fillion-Robin (3):
      gitignore: Add CMakeLists.txt.user
      docker: Associate build-time metadata with the image
      README: Add docker badges

Johan Andruejol (1):
      ENH: GenerateCLP: Include jsoncpp include dirs in UseGenerateCLP.cmake.in

Stephen Aylward (1):
      WARN: Rename isPresent variables to avoid hidden local variable
```