### PR TITLE
ENH: Update to DCMTK-3.6.1_20161102

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -33,9 +33,9 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       )
   endif()
 
-  # DCMTK-3.6.1_20160630
+
   set(${proj}_REPOSITORY ${git_protocol}://git.dcmtk.org/dcmtk)
-  set(${proj}_GIT_TAG "efe1a177eac040b6d41aae0db7714cd970e12bc5")
+  set(${proj}_GIT_TAG "DCMTK-3.6.1_20161102")
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}


### PR DESCRIPTION
```
Suggested-by: Andriy Fedorov <fedorov@bwh.harvard.edu>
Tested-by: Christian Herz <christianherz1985@gmail.com>

$ git shortlog efe1a17..DCMTK-3.6.1_20161102 --no-merges
Jan Schlamelcher (11):
      Fixed wrong usage of checkStringValue() in dcmpmap.
      Several fixes for dcmpstat.
      Fixed 32 vs. 64 bit problem in dcmqrdb.
      Fixed using third party libraries with MinGW.
      Fixed a problem with a previous commit.
      Added OFvariant implementation for C++11.
      Added API documentation for OFvariant etc.
      Updated Makefile dependencies.
      Updated man pages for new development snapshot.
      Updated DCMTK_ABI_VERSION for new development snapshot.
      Updated CHANGES.361 for new development snapshot.

Joerg Riesmeier (3):
      Made clear that options +/-Uo require +Ug.
      Output debug messages when updating attributes.
      Added readXML mode that accepts empty/missing UID.
```