### PR TITLE
CircleCI Error: `CircleCI does not build changes to Slicer dependencies`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,6 @@ dependencies:
 
 test:
   override:
-    - "echo 'Notice: CircleCI does not build changes to Slicer dependencies' && if git diff --name-only master | grep -q SuperBuild > /dev/null; then false; fi"
+    - "echo 'Notice: CircleCI does not build changes to Slicer dependencies' && if git diff --name-only master | grep -q SuperBuild > /dev/null; then echo 'Please create a Pull Request on https://github.com/thewtex/SlicerDocker according to the Update section of the project README.'; false; fi"
     - docker run -e "BUILD_TOOL_FLAGS=-j5" --name slicer -v ~/Slicer:/usr/src/Slicer slicer/slicer-dependencies
     - docker cp slicer:$(docker cp slicer:/usr/src/Slicer-build/Slicer-build/PACKAGE_FILE.txt - | tar xO) $CIRCLE_ARTIFACTS


### PR DESCRIPTION
This error appears when the slicer/slicer-build-deps docker image is not updated with the actual version of slicer.

In order to fix the issue, please create a Pull Request like this one:
  https://github.com/thewtex/SlicerDocker/pull/21

This will build and push all images based on the newer version of Slicer

CC @thewtex 