### PR TITLE
ENH: Improved crosshair usability, added display in 3D view

### DIFF
--- a/Base/QTGUI/qSlicerViewersToolBar_p.h
+++ b/Base/QTGUI/qSlicerViewersToolBar_p.h
@@ -87,7 +87,7 @@ public slots:
   void setCrosshairMode(int);
   void setCrosshairEnabled(bool); // used to toggle between last style and off
   void setCrosshairThickness(int);
-  void setNavigation(bool);
+  void setCrosshairJumpSlices(bool);
   void setSliceIntersectionVisible(bool);
 
 public:
@@ -99,7 +99,7 @@ public:
   QMenu*        CrosshairMenu;
 
   ctkSignalMapper* CrosshairMapper;
-  QAction*      CrosshairNavigationAction;
+  QAction*      CrosshairJumpSlicesAction;
   QAction*      CrosshairNoAction;
   QAction*      CrosshairBasicAction;
   QAction*      CrosshairBasicIntersectionAction;

--- a/Libs/MRML/Core/vtkMRMLCrosshairNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCrosshairNode.cxx
@@ -31,7 +31,7 @@ vtkMRMLCrosshairNode::vtkMRMLCrosshairNode()
   this->HideFromEditors = 1;
 
   this->CrosshairMode = vtkMRMLCrosshairNode::NoCrosshair;
-  this->CrosshairBehavior = vtkMRMLCrosshairNode::Normal;
+  this->CrosshairBehavior = vtkMRMLCrosshairNode::JumpSlice;
   this->CrosshairThickness = vtkMRMLCrosshairNode::Fine;
   this->Navigation = 0;
   this->CrosshairRAS[0] = this->CrosshairRAS[1] = this->CrosshairRAS[2] = 0.0;
@@ -88,13 +88,14 @@ void vtkMRMLCrosshairNode::WriteXML(ostream& of, int nIndent)
 
   of << indent << " navigation=\"" << (this->Navigation ? "true" : "false") << "\"";
 
-  if ( this->CrosshairBehavior == vtkMRMLCrosshairNode::JumpSlice )
+  if ( this->CrosshairBehavior == vtkMRMLCrosshairNode::JumpSlice
+    || this->CrosshairBehavior == vtkMRMLCrosshairNode::Normal )
     {
     of << indent << " crosshairBehavior=\"" << "JumpSlice" << "\"";
     }
-  else if ( this->CrosshairBehavior == vtkMRMLCrosshairNode::Normal )
+  else if (this->CrosshairBehavior == vtkMRMLCrosshairNode::NoAction)
     {
-    of << indent << " crosshairBehavior=\"" << "Normal" << "\"";
+    of << indent << " crosshairBehavior=\"" << "NoAction" << "\"";
     }
 
   if ( this->CrosshairThickness == vtkMRMLCrosshairNode::Fine )
@@ -175,13 +176,14 @@ void vtkMRMLCrosshairNode::ReadXMLAttributes(const char** atts)
       }
     else if (!strcmp (attName, "crosshairBehavior" ))
       {
-      if ( !strcmp (attValue, "JumpSlice"))
+      if ( !strcmp (attValue, "JumpSlice")
+        || !strcmp(attValue, "Normal"))
         {
         this->SetCrosshairBehavior ( vtkMRMLCrosshairNode::JumpSlice);
         }
-      if ( !strcmp (attValue, "Normal"))
+      else if ( !strcmp (attValue, "NoAction"))
         {
-        this->SetCrosshairBehavior ( vtkMRMLCrosshairNode::Normal);
+        this->SetCrosshairBehavior(vtkMRMLCrosshairNode::NoAction);
         }
       }
     else if(!strcmp (attName, "crosshairThickness" ))

--- a/Libs/MRML/Core/vtkMRMLCrosshairNode.h
+++ b/Libs/MRML/Core/vtkMRMLCrosshairNode.h
@@ -110,7 +110,7 @@ class VTK_MRML_EXPORT vtkMRMLCrosshairNode : public vtkMRMLNode
 
 
   ///
-  /// Is the crosshair to be used for navigation or as just a cursor
+  /// Deprecated. This member has no effect anymore and will be removed in the future.
   vtkSetMacro(Navigation, int);
   vtkGetMacro(Navigation, int);
   vtkBooleanMacro(Navigation, int);
@@ -124,7 +124,7 @@ class VTK_MRML_EXPORT vtkMRMLCrosshairNode : public vtkMRMLNode
     return this->GetSingletonTag();
   }
 
-  /// Modes for crosshair display and behavior
+  /// Modes for crosshair display
   enum
     {
       NoCrosshair = 0,
@@ -141,10 +141,13 @@ class VTK_MRML_EXPORT vtkMRMLCrosshairNode : public vtkMRMLNode
       Medium,
       Thick
     };
+  /// Behavior when crosshair position is changed.
+  /// "Normal" mode is deprecated. Use JumpSlice (default) or NoAction instead.
   enum
     {
-      Normal = 0,
-      JumpSlice
+      Normal = 0, // Deprecated
+      JumpSlice = 0,
+      NoAction = 1
     };
 
 protected:

--- a/Libs/MRML/DisplayableManager/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/CMakeLists.txt
@@ -78,6 +78,7 @@ set(DisplayableManager_SRCS
 
   # DisplayableManager associated with SliceView
   vtkMRMLCrosshairDisplayableManager.cxx
+  vtkMRMLCrosshairDisplayableManager3D.cxx
   vtkMRMLModelSliceDisplayableManager.cxx
   vtkMRMLVolumeGlyphSliceDisplayableManager.cxx
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.h
@@ -25,6 +25,9 @@
 #include "vtkMRMLAbstractSliceViewDisplayableManager.h"
 #include "vtkMRMLDisplayableManagerWin32Header.h"
 
+class vtkMRMLCrosshairNode;
+class vtkMRMLScene;
+
 /// \brief Displayable manager for the crosshair on slice (2D) views
 ///
 /// Responsible for any display of the crosshair on Slice views.
@@ -37,6 +40,9 @@ public:
                        vtkMRMLAbstractSliceViewDisplayableManager);
   void PrintSelf(ostream& os, vtkIndent indent);
 
+  // Utility functions (used by 2D and 3D crosshair displayable managers)
+  static vtkMRMLCrosshairNode* FindCrosshairNode(vtkMRMLScene* scene);
+
 protected:
   vtkMRMLCrosshairDisplayableManager();
   virtual ~vtkMRMLCrosshairDisplayableManager();
@@ -44,20 +50,6 @@ protected:
   /// Initialize the displayable manager based on its associated
   /// vtkMRMLSliceNode
   virtual void Create();
-
-  /// Override the default interaction modes under which this
-  /// displayable manager gets events.
-  virtual int ActiveInteractionModes();
-
-  /// Called after interactor style event specified using
-  /// AddInteractorStyleObservableEvent are invoked.
-  /// \sa AddInteractorStyleObservableEvent RemoveInteractorStyleObservableEvent
-  virtual void OnInteractorStyleEvent(int eventid);
-
-  /// Called after interactor event specified using
-  /// AddInteractorObservableEvent are invoked.
-  /// \sa AddInteractorObservableEvent RemoveInteractorObservableEvent
-  virtual void OnInteractorEvent(int eventid);
 
   /// Called when the SliceNode is modified. May cause Crosshair to remap its position on screen.
   virtual void OnMRMLSliceNodeModifiedEvent();

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager3D.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager3D.cxx
@@ -1,0 +1,268 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Andras Lasso (PerkLab, Queen's University).
+
+==============================================================================*/
+
+// MRMLDisplayableManager includes
+#include "vtkMRMLCrosshairDisplayableManager3D.h"
+#include "vtkMRMLCrosshairDisplayableManager.h"
+
+// MRML includes
+#include <vtkMRMLApplicationLogic.h>
+#include <vtkMRMLCrosshairNode.h>
+#include <vtkMRMLScene.h>
+
+// VTK includes
+#include <vtkActor.h>
+#include <vtkCallbackCommand.h>
+#include <vtkHandleWidget.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointHandleRepresentation3D.h>
+#include <vtkProperty.h>
+#include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkSmartPointer.h>
+#include <vtkWeakPointer.h>
+
+// STD includes
+#include <algorithm>
+#include <cassert>
+
+//---------------------------------------------------------------------------
+vtkStandardNewMacro(vtkMRMLCrosshairDisplayableManager3D );
+
+//---------------------------------------------------------------------------
+class vtkMRMLCrosshairDisplayableManager3D::vtkInternal
+{
+public:
+  vtkInternal(vtkMRMLCrosshairDisplayableManager3D * external);
+  ~vtkInternal();
+
+  vtkObserverManager* GetMRMLNodesObserverManager();
+  void Modified();
+
+  // Crosshair
+  void SetCrosshairNode(vtkMRMLCrosshairNode* crosshairNode);
+
+  // Build the crosshair representation
+  void BuildCrosshair();
+
+  vtkMRMLCrosshairDisplayableManager3D* External;
+
+  vtkWeakPointer<vtkRenderWindowInteractor> RenderWindowInteractor;
+  vtkSmartPointer<vtkPointHandleRepresentation3D> CrosshairRepresentation;
+  vtkSmartPointer<vtkHandleWidget> CrosshairWidget;
+
+  vtkWeakPointer<vtkMRMLCrosshairNode> CrosshairNode;
+  int CrosshairMode;
+  int CrosshairThickness;
+  double CrosshairPosition[3];
+};
+
+//---------------------------------------------------------------------------
+// vtkInternal methods
+
+//---------------------------------------------------------------------------
+vtkMRMLCrosshairDisplayableManager3D::vtkInternal
+::vtkInternal(vtkMRMLCrosshairDisplayableManager3D * external)
+{
+  this->External = external;
+  this->CrosshairMode = -1;
+  this->CrosshairThickness = -1;
+  this->CrosshairPosition[0] = 0.0;
+  this->CrosshairPosition[1] = 0.0;
+  this->CrosshairPosition[2] = 0.0;
+
+  this->CrosshairRepresentation = vtkSmartPointer<vtkPointHandleRepresentation3D>::New();
+  this->CrosshairRepresentation->SetPlaceFactor(2.5);
+  this->CrosshairRepresentation->SetHandleSize(30);
+  this->CrosshairRepresentation->GetProperty()->SetColor(1.0, 0.8, 0.1);
+
+  this->CrosshairWidget = vtkSmartPointer<vtkHandleWidget>::New();
+  this->CrosshairWidget->SetRepresentation(this->CrosshairRepresentation);
+  this->CrosshairWidget->EnabledOff();
+  this->CrosshairWidget->ProcessEventsOff();
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLCrosshairDisplayableManager3D::vtkInternal::~vtkInternal()
+{
+  this->SetCrosshairNode(0);
+}
+
+//---------------------------------------------------------------------------
+vtkObserverManager* vtkMRMLCrosshairDisplayableManager3D::vtkInternal::GetMRMLNodesObserverManager()
+{
+  return this->External->GetMRMLNodesObserverManager();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::vtkInternal::Modified()
+{
+  return this->External->Modified();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::vtkInternal
+::SetCrosshairNode(vtkMRMLCrosshairNode* crosshairNode)
+{
+  if (this->CrosshairNode == crosshairNode)
+    {
+    return;
+    }
+  vtkSetAndObserveMRMLNodeMacro(this->CrosshairNode, crosshairNode);
+  this->BuildCrosshair();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::vtkInternal::BuildCrosshair()
+{
+  vtkRenderWindowInteractor* interactor = this->External->GetInteractor();
+  if (!this->CrosshairNode.GetPointer() || !interactor)
+    {
+    this->CrosshairWidget->SetInteractor(NULL);
+    return;
+    }
+
+  this->CrosshairMode = this->CrosshairNode->GetCrosshairMode();
+  if (this->CrosshairNode->GetCrosshairMode() == vtkMRMLCrosshairNode::NoCrosshair)
+    {
+    this->CrosshairWidget->EnabledOff();
+    return;
+    }
+  this->CrosshairWidget->SetInteractor(interactor);
+  this->CrosshairWidget->EnabledOn();
+
+  int *screenSize = interactor->GetRenderWindow()->GetScreenSize();
+
+  // Handle size is defined a percentage of screen size to accommodate high-DPI screens
+  double handleSizeInScreenSizePercent = 5;
+  if (this->CrosshairNode->GetCrosshairMode() == vtkMRMLCrosshairNode::ShowSmallBasic
+    || this->CrosshairNode->GetCrosshairMode() == vtkMRMLCrosshairNode::ShowSmallIntersection)
+    {
+    handleSizeInScreenSizePercent = 2.5;
+    }
+  double handleSizeInPixels = double(screenSize[1])*(0.01*handleSizeInScreenSizePercent);
+  this->CrosshairRepresentation->SetHandleSize(handleSizeInPixels);
+
+  // Line Width
+  // Base width is 1 on a full HD display.
+  double baseWidth = 1 + int(screenSize[1] / 1000);
+  switch (this->CrosshairNode->GetCrosshairThickness())
+    {
+    case vtkMRMLCrosshairNode::Medium:
+      this->CrosshairRepresentation->GetProperty()->SetLineWidth(baseWidth * 2);
+      break;
+    case vtkMRMLCrosshairNode::Thick:
+      this->CrosshairRepresentation->GetProperty()->SetLineWidth(baseWidth * 3);
+      break;
+    case vtkMRMLCrosshairNode::Fine:
+    default:
+      this->CrosshairRepresentation->GetProperty()->SetLineWidth(baseWidth);
+      break;
+    }
+  this->CrosshairThickness = this->CrosshairNode->GetCrosshairThickness();
+}
+
+//---------------------------------------------------------------------------
+// vtkMRMLCrosshairDisplayableManager3D methods
+
+//---------------------------------------------------------------------------
+vtkMRMLCrosshairDisplayableManager3D::vtkMRMLCrosshairDisplayableManager3D()
+{
+  this->Internal = new vtkInternal(this);
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLCrosshairDisplayableManager3D::~vtkMRMLCrosshairDisplayableManager3D()
+{
+  delete this->Internal;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::ObserveMRMLScene()
+{
+  this->Internal->BuildCrosshair();
+  this->Superclass::ObserveMRMLScene();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::UpdateFromMRMLScene()
+{
+  // search for the Crosshair node
+  vtkMRMLCrosshairNode* crosshairNode = vtkMRMLCrosshairDisplayableManager::FindCrosshairNode(this->GetMRMLScene());
+  this->Internal->SetCrosshairNode(crosshairNode);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::UnobserveMRMLScene()
+{
+  this->Internal->SetCrosshairNode(0);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::OnMRMLNodeModified(vtkMRMLNode* node)
+{
+  if (!vtkMRMLCrosshairNode::SafeDownCast(node))
+    {
+    return;
+    }
+
+  // update the properties and style of the crosshair
+  if (this->Internal->CrosshairMode != this->Internal->CrosshairNode->GetCrosshairMode()
+    || this->Internal->CrosshairThickness != this->Internal->CrosshairNode->GetCrosshairThickness())
+    {
+    this->Internal->BuildCrosshair();
+    this->RequestRender();
+    }
+
+  // update the position of the actor
+  double *ras = this->Internal->CrosshairNode->GetCrosshairRAS();
+  double *lastRas = this->Internal->CrosshairPosition;
+  double eps = 1.0e-12;
+  if (fabs(lastRas[0] - ras[0]) > eps
+    || fabs(lastRas[1] - ras[1]) > eps
+    || fabs(lastRas[2] - ras[2]) > eps)
+    {
+    this->Internal->CrosshairRepresentation->SetWorldPosition(ras);
+    lastRas[0] = ras[0];
+    lastRas[1] = ras[1];
+    lastRas[2] = ras[2];
+    this->RequestRender();
+    }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::Create()
+{
+  this->UpdateFromMRMLScene();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager3D::AdditionalInitializeStep()
+{
+  // Build the initial crosshair representation
+  this->Internal->BuildCrosshair();
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager3D.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager3D.h
@@ -1,0 +1,63 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Andras Lasso (PerkLab, Queen's University).
+
+==============================================================================*/
+
+#ifndef __vtkMRMLCrosshairDisplayableManager3D_h
+#define __vtkMRMLCrosshairDisplayableManager3D_h
+
+// MRMLDisplayableManager includes
+#include "vtkMRMLAbstractThreeDViewDisplayableManager.h"
+#include "vtkMRMLDisplayableManagerWin32Header.h"
+
+/// \brief Displayable manager for the crosshair on 3D views
+///
+/// Responsible for any display of the crosshair on 3D views.
+class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLCrosshairDisplayableManager3D :
+  public vtkMRMLAbstractThreeDViewDisplayableManager
+{
+public:
+  static vtkMRMLCrosshairDisplayableManager3D* New();
+  vtkTypeMacro(vtkMRMLCrosshairDisplayableManager3D,
+    vtkMRMLAbstractThreeDViewDisplayableManager);
+  void PrintSelf(ostream& os, vtkIndent indent);
+
+protected:
+  vtkMRMLCrosshairDisplayableManager3D();
+  virtual ~vtkMRMLCrosshairDisplayableManager3D();
+
+  /// Initialize the displayable manager based on its associated
+  /// vtkMRMLSliceNode
+  virtual void Create();
+
+  /// Method to perform additional initialization
+  virtual void AdditionalInitializeStep();
+
+private:
+  vtkMRMLCrosshairDisplayableManager3D(const vtkMRMLCrosshairDisplayableManager3D&);// Not implemented
+  void operator=(const vtkMRMLCrosshairDisplayableManager3D&);                     // Not Implemented
+
+  virtual void UnobserveMRMLScene();
+  virtual void ObserveMRMLScene();
+  virtual void UpdateFromMRMLScene();
+  virtual void OnMRMLNodeModified(vtkMRMLNode* node);
+
+  class vtkInternal;
+  vtkInternal * Internal;
+};
+
+#endif

--- a/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
@@ -64,6 +64,7 @@ public:
   /// Event bindings controlling the effects of pressing mouse buttons
   /// or moving the mouse.
   virtual void OnMouseMove();
+  virtual void OnLeave();
   virtual void OnLeftButtonDown();
   virtual void OnLeftButtonUp();
   virtual void OnMiddleButtonDown();

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -109,6 +109,7 @@ void qMRMLThreeDViewPrivate::initDisplayableManagers()
                       << "vtkMRMLViewDisplayableManager"
                       << "vtkMRMLModelDisplayableManager"
                       << "vtkMRMLThreeDReformatDisplayableManager"
+                      << "vtkMRMLCrosshairDisplayableManager3D"
                       << "vtkMRMLOrientationMarkerDisplayableManager"
                       << "vtkMRMLRulerDisplayableManager";
   foreach(const QString& displayableManager, displayableManagers)


### PR DESCRIPTION
Crosshair had several problems/limitations:
1. Crosshair position was often inconsistent in different slice views (for example: when in navigation view, crosshair was always displayed in all slice views because otherwise the user could not drag the crosshair to a new position; but this way when the user changed slices then the crosshair showed up at different RAS positions in each slice view)
2. Navigation mode was very inconvenient: to jump all slices to a specific RAS position the user had to position the mouse to the previous crosshair and drag it to the new position (it was too easy to miss the small navigation area in the middle and when it was missed, brightness/contrast of the image was accidentally modified)
3. By default (if the user just toggled the crosshair button on the toolbar), crosshair was only visible in the current slice view, which was useless (the crosshair just followed the mouse in the current view)
4. Crosshair position was not visible in 3D view

Solution implemented:
1. Only show crosshair in the correct position in all views. If crosshair position is not in the current slice then hide the crosshair from current slice.
2. Crosshair is now moved by holding down shift + moving mouse. No need to grab the previous crosshair position. Navigation mode is replaced by "jump slices" option (enabled by default), which controls if slice views should jump to current crosshair position. If disabled then shift + moving mouse only moves the crosshair.
3. By default slices jump to current crosshair position, so crosshair is visible in all views. User just has to keep Shift key depressed (added hint to tooltip)
4. Implemented display of crosshair in 3D view.