### PR TITLE
ENH: Added ViewGroup property to view nodes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -37,6 +37,7 @@ static const char* DEFAULT_AXIS_LABELS[vtkMRMLAbstractViewNode::AxisLabelsCount]
 vtkMRMLAbstractViewNode::vtkMRMLAbstractViewNode()
 {
   this->LayoutLabel = NULL;
+  this->ViewGroup = NULL;
   this->Active = 0;
   this->Visibility = 1;
 
@@ -64,11 +65,8 @@ vtkMRMLAbstractViewNode::vtkMRMLAbstractViewNode()
 //----------------------------------------------------------------------------
 vtkMRMLAbstractViewNode::~vtkMRMLAbstractViewNode()
 {
-  if ( this->LayoutLabel )
-    {
-    delete [] this->LayoutLabel;
-    this->LayoutLabel = NULL;
-    }
+  this->SetLayoutLabel(NULL);
+  this->SetViewGroup(NULL);
 }
 
 //----------------------------------------------------------------------------
@@ -88,6 +86,10 @@ void vtkMRMLAbstractViewNode::WriteXML(ostream& of, int nIndent)
     {
     of << indent << " layoutName=\"" << this->GetLayoutName() << "\"";
     }
+  if (this->GetViewGroup())
+  {
+    of << indent << " viewGroup=\"" << this->GetViewGroup() << "\"";
+  }
 
   of << indent << " active=\"" << (this->Active ? "true" : "false") << "\"";
   of << indent << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
@@ -133,13 +135,17 @@ void vtkMRMLAbstractViewNode::ReadXMLAttributes(const char** atts)
     attName = *(atts++);
     attValue = *(atts++);
     if (!strcmp(attName, "layoutLabel"))
-      {
-      this->SetLayoutLabel( attValue );
-      }
+    {
+      this->SetLayoutLabel(attValue);
+    }
     else if (!strcmp(attName, "layoutName"))
       {
       this->SetLayoutName( attValue );
       }
+    else if (!strcmp(attName, "viewGroup"))
+    {
+      this->SetViewGroup(attValue);
+    }
     else if (!strcmp(attName, "backgroundColor"))
       {
       std::stringstream ss;
@@ -295,7 +301,8 @@ void vtkMRMLAbstractViewNode::Copy(vtkMRMLNode *anode)
   vtkMRMLAbstractViewNode *node = (vtkMRMLAbstractViewNode *) anode;
 
   this->SetLayoutLabel(node->GetLayoutLabel());
-  this->SetBackgroundColor ( node->GetBackgroundColor ( ) );
+  this->SetViewGroup(node->GetViewGroup());
+  this->SetBackgroundColor(node->GetBackgroundColor());
   this->SetBackgroundColor2 ( node->GetBackgroundColor2 ( ) );
   // Important: do not use SetActive or RemoveActiveFlagInScene will be called
   this->Active = node->GetActive();
@@ -328,9 +335,11 @@ void vtkMRMLAbstractViewNode::Reset(vtkMRMLNode* defaultNode)
   // automatically.
   // This require a custom behavior implemented here.
   std::string layoutLabel = this->GetLayoutLabel() ? this->GetLayoutLabel() : "";
+  std::string viewGroup = this->GetViewGroup() ? this->GetViewGroup() : "";
   this->Superclass::Reset(defaultNode);
   this->DisableModifiedEventOn();
   this->SetLayoutLabel(layoutLabel.c_str());
+  this->SetViewGroup(viewGroup.empty() ? NULL : viewGroup.c_str());
   this->AxisLabels->Reset();
   for (int i=0; i<vtkMRMLAbstractViewNode::AxisLabelsCount; i++)
     {
@@ -345,6 +354,7 @@ void vtkMRMLAbstractViewNode::PrintSelf(ostream& os, vtkIndent indent)
   Superclass::PrintSelf(os,indent);
 
   os << indent << "LayoutLabel: " << (this->LayoutLabel ? this->LayoutLabel : "(null)") << std::endl;
+  os << indent << "ViewGroup: " << (this->ViewGroup ? this->ViewGroup : "(null)") << std::endl;
   os << indent << "Active:        " << this->Active << "\n";
   os << indent << "Visibility:        " << this->Visibility << "\n";
   os << indent << "BackgroundColor:       " << this->BackgroundColor[0] << " "

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -71,6 +71,16 @@ public:
   inline const char *GetLayoutName();
 
   ///
+  /// An optional identifier to link groups of views. Views that have matching
+  /// ViewGroup value are in the same group.
+  /// By default the value is NULL, which is equivalent with ampty string.
+  /// Empty is a valid value: views that have empty ViewGroup value form a group.
+  /// When changing linked properties in a view then all other views in the group
+  /// are changed accordingly, but other views are not modified.
+  vtkSetStringMacro(ViewGroup);
+  vtkGetStringMacro(ViewGroup);
+
+  ///
   /// Label for the view. Usually a 1 character label, e.g. R, 1, 2, etc.
   /// \sa SetLayoutName()
   vtkSetStringMacro(LayoutLabel);
@@ -218,6 +228,10 @@ protected:
 
   vtkMRMLAbstractViewNode(const vtkMRMLAbstractViewNode&);
   void operator=(const vtkMRMLAbstractViewNode&);
+
+  ///
+  /// Views with the same ViewGroup value are in the same group.
+  char * ViewGroup;
 
   ///
   /// Label to show for the view (shortcut for the name)

--- a/Libs/MRML/Core/vtkMRMLSliceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.cxx
@@ -1606,18 +1606,54 @@ void vtkMRMLSliceNode::JumpSliceByOffsetting(int k, double r, double a, double s
   //this->ActiveSlice = oldActiveSlice;
 }
 
+//----------------------------------------------------------------------------
 void vtkMRMLSliceNode::JumpAllSlices(double r, double a, double s)
 {
-  vtkMRMLSliceNode *node= NULL;
-  vtkMRMLScene *scene = this->GetScene();
+  vtkMRMLSliceNode::JumpAllSlices(this->GetScene(), r, a, s, vtkMRMLSliceNode::DefaultJumpSlice, this->GetViewGroup() ? this->GetViewGroup() : "", this);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceNode::JumpAllSlices(vtkMRMLScene* scene, double r, double a, double s,
+  int jumpMode /* =vtkMRMLSliceNode::DefaultJumpSlice */, const std::string& viewGroup /* ="*" */, vtkMRMLSliceNode* exclude /*=NULL*/)
+{
+  if (!scene)
+    {
+    return;
+    }
+  bool filterByViewGroup = (viewGroup.compare("*") != 0);
+
   int nnodes = scene->GetNumberOfNodesByClass("vtkMRMLSliceNode");
   for (int n=0; n<nnodes; n++)
     {
-    node = vtkMRMLSliceNode::SafeDownCast (
-          scene->GetNthNodeByClass(n, "vtkMRMLSliceNode"));
-    if ( node != NULL && node != this )
+    vtkMRMLSliceNode *node = vtkMRMLSliceNode::SafeDownCast(
+      scene->GetNthNodeByClass(n, "vtkMRMLSliceNode"));
+    if (node == NULL || node == exclude)
+      {
+      continue;
+      }
+    if (filterByViewGroup)
+      {
+      std::string currentViewGroup = node->GetViewGroup() ? node->GetViewGroup() : "";
+      if (currentViewGroup != viewGroup)
+        {
+        continue;
+        }
+      }
+    if (jumpMode == vtkMRMLSliceNode::DefaultJumpSlice)
       {
       node->JumpSlice(r, a, s);
+      }
+    else if (jumpMode == CenteredJumpSlice)
+      {
+      node->JumpSliceByCentering(r, a, s);
+      }
+    else if (jumpMode == OffsetJumpSlice)
+      {
+      node->JumpSliceByOffsetting(r, a, s);
+      }
+    else
+      {
+      vtkGenericWarningMacro("vtkMRMLSliceNode::JumpAllSlices failed: invalid jump mode " << jumpMode);
       }
     }
 }

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -358,12 +358,21 @@ public:
   /// and JumpAllSlices use the JumpMode to determine how to jump.
   void JumpSlice(double r, double a, double s);
   void JumpAllSlices(double r, double a, double s);
+  /// Jump all slices in the scene.
+  /// viewGroup can be used to jump only slice views that are in a specific group.
+  /// If viewGroup is "*" then all slice views are jumped.
+  /// If viewGroup is null then slice views with empty or NULL ViewGroup value are jumped.
+  /// If a non-NULL exclude pointer is specified then position of that slice node will not be changed.
+  /// If jumpMode is set to vtkMRMLSliceNode::DefaultJumpSlice then jump mode set in the slice node will be used.
+  /// specified in the slice node will be used.
+  static void JumpAllSlices(vtkMRMLScene* scene, double r, double a, double s,
+    int jumpMode = vtkMRMLSliceNode::DefaultJumpSlice, const std::string& viewGroup = "*", vtkMRMLSliceNode* exclude = NULL);
   void JumpSliceByOffsetting(double r, double a, double s);
   void JumpSliceByOffsetting(int k, double r, double a, double s);
   void JumpSliceByCentering(double r, double a, double s);
 
   /// Enum to specify the method of jumping slices
-  enum {CenteredJumpSlice=0, OffsetJumpSlice};
+  enum {DefaultJumpSlice=-1, CenteredJumpSlice=0, OffsetJumpSlice};
 
   ///
   /// Control how JumpSlice operates. CenteredJumpMode puts the

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
@@ -19,6 +19,7 @@
 #include "vtkMRMLModelSliceDisplayableManager.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLColorNode.h>
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLDisplayableNode.h>
@@ -171,7 +172,37 @@ bool vtkMRMLModelSliceDisplayableManager::vtkInternal
       visibleOnNode = (displayNode->GetVisibility() == 1 ? true : false);
       }
     }
-  return visibleOnNode && (displayNode->GetSliceIntersectionVisibility() != 0);
+  else
+    {
+    // Only show slice intersection if it is mapped into layout and in the same view group
+    vtkMRMLSliceNode* intersectedSliceNode = NULL;
+    vtkMRMLApplicationLogic *mrmlAppLogic = this->External->GetMRMLApplicationLogic();
+    if (mrmlAppLogic)
+      {
+      vtkMRMLSliceLogic *sliceLogic = mrmlAppLogic->GetSliceLogic(vtkMRMLModelDisplayNode::SafeDownCast(displayNode));
+      if (sliceLogic)
+        {
+        intersectedSliceNode = sliceLogic->GetSliceNode();
+        }
+      }
+    if (intersectedSliceNode)
+      {
+      if (!intersectedSliceNode->IsMappedInLayout())
+        {
+        visibleOnNode = false;
+        }
+      else if (this->SliceNode)
+        {
+        std::string sliceNodeViewGroup = this->SliceNode->GetViewGroup() ? this->SliceNode->GetViewGroup() : "";
+        std::string intersectedSliceNodeViewGroup = intersectedSliceNode->GetViewGroup() ? intersectedSliceNode->GetViewGroup() : "";
+        if (sliceNodeViewGroup != intersectedSliceNodeViewGroup)
+          {
+          visibleOnNode = false;
+          }
+        }
+      }
+    }
+  return visibleOnNode && (displayNode->GetSliceIntersectionVisibility() != 0) ;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.cxx
@@ -240,12 +240,17 @@ void vtkThreeDViewInteractorStyle::OnMouseMove()
             crosshairNode->SetCursorPositionRAS(pickedRAS);
             if (crosshairNode->GetCrosshairBehavior() == vtkMRMLCrosshairNode::JumpSlice)
               {
-              vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(scene->GetNthNodeByClass(0, "vtkMRMLSliceNode"));
-              if (sliceNode)
+              // Try to get view group of the 3D view. If it fails then we'll just use the default (empty) group name.
+              std::string viewGroup;
+              if (this->GetCameraNode() && this->GetCameraNode()->GetActiveTag())
                 {
-                sliceNode->JumpSlice(pickedRAS[0], pickedRAS[1], pickedRAS[2]);
-                sliceNode->JumpAllSlices(pickedRAS[0], pickedRAS[1], pickedRAS[2]);
+                vtkMRMLAbstractViewNode* viewNode = vtkMRMLAbstractViewNode::SafeDownCast(scene->GetNodeByID(this->GetCameraNode()->GetActiveTag()));
+                if (viewNode && viewNode->GetViewGroup())
+                  {
+                  viewGroup = viewNode->GetViewGroup();
+                  }
                 }
+              vtkMRMLSliceNode::JumpAllSlices(scene, pickedRAS[0], pickedRAS[1], pickedRAS[2], -1, viewGroup);
               }
             }
           }

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -272,6 +272,34 @@ GetSliceLogicByLayoutName(const char* layoutName) const
 }
 
 //---------------------------------------------------------------------------
+vtkMRMLSliceLogic* vtkMRMLApplicationLogic::
+GetSliceLogic(vtkMRMLModelDisplayNode* displayNode) const
+{
+  if (!displayNode || !this->Internal->SliceLogics)
+  {
+    return 0;
+  }
+
+  vtkMRMLSliceLogic* logic = 0;
+  vtkCollectionSimpleIterator it;
+  vtkCollection* logics = this->Internal->SliceLogics;
+
+  for (logics->InitTraversal(it);
+    (logic = vtkMRMLSliceLogic::SafeDownCast(logics->GetNextItemAsObject(it)));)
+  {
+    if (logic->GetSliceModelDisplayNode() == displayNode)
+    {
+      break;
+    }
+
+    logic = 0;
+  }
+
+  return logic;
+}
+
+
+//---------------------------------------------------------------------------
 void vtkMRMLApplicationLogic::SetMRMLSceneInternal(vtkMRMLScene *newScene)
 {
   vtkMRMLNode * selectionNode = 0;

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -27,6 +27,7 @@
 #include "vtkMRMLLogicWin32Header.h"
 
 class vtkMRMLColorLogic;
+class vtkMRMLModelDisplayNode;
 class vtkMRMLSliceNode;
 class vtkMRMLSliceLogic;
 class vtkMRMLModelHierarchyLogic;
@@ -62,6 +63,8 @@ public:
   vtkCollection* GetSliceLogics()const;
   vtkMRMLSliceLogic* GetSliceLogic(vtkMRMLSliceNode* sliceNode) const;
   vtkMRMLSliceLogic* GetSliceLogicByLayoutName(const char* layoutName) const;
+  /// Get slice logic from slice model display node
+  vtkMRMLSliceLogic* GetSliceLogic(vtkMRMLModelDisplayNode* displayNode) const;
 
   /// Get ModelHierarchyLogic
   vtkMRMLModelHierarchyLogic* GetModelHierarchyLogic() const;

--- a/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
@@ -322,24 +322,27 @@ const char* threeOverThreeView =
   " <item>"
   "  <layout type=\"horizontal\">"
   "   <item>"
-  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Slice4\">"
+  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Red+\">"
   "     <property name=\"orientation\" action=\"default\">Axial</property>"
-  "     <property name=\"viewlabel\" action=\"default\">4</property>"
-  "     <property name=\"viewcolor\" action=\"default\">#8C8C8C</property>"
+  "     <property name=\"viewlabel\" action=\"default\">R+</property>"
+  "     <property name=\"viewcolor\" action=\"default\">#f9a99f</property>"
+  "     <property name=\"viewgroup\" action=\"default\">+</property>"
   "    </view>"
   "   </item>"
   "   <item>"
-  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Slice5\">"
+  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Yellow+\">"
   "     <property name=\"orientation\" action=\"default\">Sagittal</property>"
-  "     <property name=\"viewlabel\" action=\"default\">5</property>"
-  "     <property name=\"viewcolor\" action=\"default\">#8C8C8C</property>"
+  "     <property name=\"viewlabel\" action=\"default\">Y+</property>"
+  "     <property name=\"viewcolor\" action=\"default\">#f6e9a2</property>"
+  "     <property name=\"viewgroup\" action=\"default\">+</property>"
   "    </view>"
   "   </item>"
   "   <item>"
-  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Slice6\">"
+  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Green+\">"
   "     <property name=\"orientation\" action=\"default\">Coronal</property>"
-  "     <property name=\"viewlabel\" action=\"default\">6</property>"
-  "     <property name=\"viewcolor\" action=\"default\">#8C8C8C</property>"
+  "     <property name=\"viewlabel\" action=\"default\">G+</property>"
+  "     <property name=\"viewcolor\" action=\"default\">#c6e0b8</property>"
+  "     <property name=\"viewgroup\" action=\"default\">+</property>"
   "    </view>"
   "   </item>"
   "  </layout>"
@@ -381,29 +384,33 @@ const char* fourOverFourView =
   " <item>"
   "  <layout type=\"horizontal\">"
   "   <item>"
-  "    <view class=\"vtkMRMLViewNode\" singletontag=\"2\" type=\"secondary\">"
-  "     <property name=\"viewlabel\" action=\"default\">2</property>"
+  "    <view class=\"vtkMRMLViewNode\" singletontag=\"1+\" type=\"secondary\">"
+  "     <property name=\"viewlabel\" action=\"default\">1+</property>"
+  "     <property name=\"viewgroup\" action=\"default\">+</property>"
   "    </view>"
   "   </item>"
   "   <item>"
-  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Slice4\">"
+  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Red+\">"
   "     <property name=\"orientation\" action=\"default\">Axial</property>"
-  "     <property name=\"viewlabel\" action=\"default\">4</property>"
-  "     <property name=\"viewcolor\" action=\"default\">#8C8C8C</property>"
+  "     <property name=\"viewlabel\" action=\"default\">R+</property>"
+  "     <property name=\"viewcolor\" action=\"default\">#f9a99f</property>"
+  "     <property name=\"viewgroup\" action=\"default\">+</property>"
   "    </view>"
   "   </item>"
   "   <item>"
-  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Slice5\">"
+  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Yellow+\">"
   "     <property name=\"orientation\" action=\"default\">Sagittal</property>"
-  "     <property name=\"viewlabel\" action=\"default\">5</property>"
-  "     <property name=\"viewcolor\" action=\"default\">#8C8C8C</property>"
+  "     <property name=\"viewlabel\" action=\"default\">Y+</property>"
+  "     <property name=\"viewcolor\" action=\"default\">#f6e9a2</property>"
+  "     <property name=\"viewgroup\" action=\"default\">+</property>"
   "    </view>"
   "   </item>"
   "   <item>"
-  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Slice6\">"
+  "    <view class=\"vtkMRMLSliceNode\" singletontag=\"Green+\">"
   "     <property name=\"orientation\" action=\"default\">Coronal</property>"
-  "     <property name=\"viewlabel\" action=\"default\">6</property>"
-  "     <property name=\"viewcolor\" action=\"default\">#8C8C8C</property>"
+  "     <property name=\"viewlabel\" action=\"default\">G+</property>"
+  "     <property name=\"viewcolor\" action=\"default\">#c6e0b8</property>"
+  "     <property name=\"viewgroup\" action=\"default\">+</property>"
   "    </view>"
   "   </item>"
   "  </layout>"
@@ -1519,6 +1526,17 @@ void vtkMRMLLayoutLogic::ApplyProperty(const ViewProperty& property, vtkMRMLNode
       }
     sliceNode->SetOrientation(value.c_str());
     }
+  // ViewGroup
+  if (name == std::string("viewgroup"))
+  {
+    vtkMRMLAbstractViewNode* viewNode = vtkMRMLAbstractViewNode::SafeDownCast(view);
+    if (!viewNode)
+    {
+      vtkWarningMacro("Invalid view group property.");
+      return;
+    }
+    viewNode->SetViewGroup(value.c_str());
+  }
   // LayoutLabel
   if (name == std::string("viewlabel"))
     {

--- a/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.cxx
@@ -342,10 +342,15 @@ void vtkMRMLSliceLinkLogic::BroadcastSliceNodeEvent(vtkMRMLSliceNode *sliceNode)
   // std::cout << "BroadcastingEvents: " << this->GetBroadcastingEvents()
   //           << ", Interacting: " << sliceNode->GetInteracting()
   //           << std::endl;
+  if (!sliceNode)
+    {
+    return;
+    }
   if (!this->GetBroadcastingEvents())
     {
     this->BroadcastingEventsOn();
 
+    std::string requiredViewGroup = sliceNode->GetViewGroup() ? sliceNode->GetViewGroup() : "";
     vtkMRMLSliceNode* sNode;
     vtkCollectionSimpleIterator it;
     vtkSmartPointer<vtkCollection> nodes;
@@ -353,145 +358,152 @@ void vtkMRMLSliceLinkLogic::BroadcastSliceNodeEvent(vtkMRMLSliceNode *sliceNode)
     for (nodes->InitTraversal(it);
         (sNode=vtkMRMLSliceNode::SafeDownCast(nodes->GetNextItemAsObject(it)));)
       {
-      if (sNode != sliceNode)
+      if (sNode == sliceNode || !sNode)
         {
-        // Link slice parameters whenever the reformation is consistent
-        if (vtkMRMLSliceLinkLogic::IsOrientationMatching(sliceNode, sNode))
-          {
-          // std::cout << "Orientation match, flags = " << sliceNode->GetInteractionFlags() << std::endl;
-          // std::cout << "Broadcasting SliceToRAS, SliceOrigin, and FieldOfView to "
-          //            << sNode->GetName() << std::endl;
-          //
-
-          // Copy the slice to RAS information
-          if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceNode::SliceToRASFlag)
-            {
-            sNode->GetSliceToRAS()->DeepCopy( sliceNode->GetSliceToRAS() );
-            }
-
-          // Copy the slice origin information
-          if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceNode::XYZOriginFlag)
-            {
-            // Need to copy the SliceOrigin.
-            double *xyzOrigin = sliceNode->GetXYZOrigin();
-            sNode->SetXYZOrigin( xyzOrigin[0], xyzOrigin[1], xyzOrigin[2] );
-            }
-
-          // Copy the field of view information. Use the new
-          // prescribed x fov, aspect corrected y fov, and keep z fov
-          // constant
-          if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceNode::FieldOfViewFlag)
-            {
-            sNode->SetFieldOfView( sliceNode->GetFieldOfView()[0],
-                                   sliceNode->GetFieldOfView()[0]
-                                   * sNode->GetFieldOfView()[1]
-                                   / sNode->GetFieldOfView()[0],
-                                   sNode->GetFieldOfView()[2] );
-            }
-
-          // need to manage prescribed spacing here as well?
-
-          // Forces the internal matrices to be updated which results
-          // in this being modified so a Render can occur
-          sNode->UpdateMatrices();
-          }
-
-        //
-        // Some parameters and commands do not require the
-        // orientations to match. These are handled here.
-        //
-
-        // Setting the orientation of the slice plane does not
-        // require that the orientations initially match.
-        if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
-          & vtkMRMLSliceNode::OrientationFlag)
-          {
-          // We could copy the orientation strings, but we really
-          // want the slice to ras to match, so copy that
-          sNode->GetSliceToRAS()->DeepCopy( sliceNode->GetSliceToRAS() );
-
-          // Forces the internal matrices to be updated which results
-          // in this being modified so a Render can occur
-          sNode->UpdateMatrices();
-          }
-
-        // Reseting the field of view does not require the
-        // orientations to match
-        if ((sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceNode::ResetFieldOfViewFlag)
-            && this->GetMRMLApplicationLogic()->GetSliceLogics())
-          {
-          // need the logic for this slice (sNode)
-          vtkMRMLSliceLogic* logic;
-          vtkCollectionSimpleIterator it;
-          vtkCollection* logics = this->GetMRMLApplicationLogic()->GetSliceLogics();
-          for (logics->InitTraversal(it);
-               (logic=vtkMRMLSliceLogic::SafeDownCast(logics->GetNextItemAsObject(it)));)
-            {
-            if (logic->GetSliceNode() == sNode)
-              {
-              logic->FitSliceToAll();
-              sNode->UpdateMatrices();
-              break;
-              }
-            }
-          }
-
-        // Broadcasting the rotation from a ReformatWidget
-        if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
-          & vtkMRMLSliceNode::MultiplanarReformatFlag)
-          {
-          this->BroadcastLastRotation(sliceNode,sNode);
-          }
-
-        // Setting the label outline mode
-        if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
-          & vtkMRMLSliceNode::LabelOutlineFlag)
-          {
-          sNode->SetUseLabelOutline( sliceNode->GetUseLabelOutline() );
-          }
-
-        // Broadcasting the visibility of slice in 3D
-        if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
-          & vtkMRMLSliceNode::SliceVisibleFlag)
-          {
-          std::string layoutName(sliceNode->GetLayoutName() ? sliceNode->GetLayoutName() : "");
-          std::string lname(sNode->GetLayoutName() ? sNode->GetLayoutName() : "");
-          if (layoutName.find("Compare") == 0)
-            {
-            // Compare view, only broadcast to compare views
-            if (lname.find("Compare") == 0)
-              {
-              // Compare view, broadcast
-              sNode->SetSliceVisible(sliceNode->GetSliceVisible());
-              }
-            }
-          else
-            {
-            // Not a compare view, only broadcast to non compare views
-            if (lname.find("Compare") != 0)
-              {
-              // not a Compare view, broadcast
-              sNode->SetSliceVisible(sliceNode->GetSliceVisible());
-              }
-            }
-          }
-
-          // Setting the slice spacing
-          if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceNode::SliceSpacingFlag)
-            {
-            sNode->SetSliceSpacingMode( sliceNode->GetSliceSpacingMode() );
-            sNode->SetPrescribedSliceSpacing( sliceNode->GetPrescribedSliceSpacing() );
-            }
-        //
-        // End of the block for broadcasting parameters and commands
-        // that do not require the orientation to match
-        //
+        continue;
         }
+      std::string viewGroup = sNode->GetViewGroup() ? sNode->GetViewGroup() : "";
+      if (viewGroup != requiredViewGroup)
+        {
+        continue;
+        }
+
+      // Link slice parameters whenever the reformation is consistent
+      if (vtkMRMLSliceLinkLogic::IsOrientationMatching(sliceNode, sNode))
+        {
+        // std::cout << "Orientation match, flags = " << sliceNode->GetInteractionFlags() << std::endl;
+        // std::cout << "Broadcasting SliceToRAS, SliceOrigin, and FieldOfView to "
+        //            << sNode->GetName() << std::endl;
+        //
+
+        // Copy the slice to RAS information
+        if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceNode::SliceToRASFlag)
+          {
+          sNode->GetSliceToRAS()->DeepCopy( sliceNode->GetSliceToRAS() );
+          }
+
+        // Copy the slice origin information
+        if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceNode::XYZOriginFlag)
+          {
+          // Need to copy the SliceOrigin.
+          double *xyzOrigin = sliceNode->GetXYZOrigin();
+          sNode->SetXYZOrigin( xyzOrigin[0], xyzOrigin[1], xyzOrigin[2] );
+          }
+
+        // Copy the field of view information. Use the new
+        // prescribed x fov, aspect corrected y fov, and keep z fov
+        // constant
+        if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceNode::FieldOfViewFlag)
+          {
+          sNode->SetFieldOfView( sliceNode->GetFieldOfView()[0],
+                                  sliceNode->GetFieldOfView()[0]
+                                  * sNode->GetFieldOfView()[1]
+                                  / sNode->GetFieldOfView()[0],
+                                  sNode->GetFieldOfView()[2] );
+          }
+
+        // need to manage prescribed spacing here as well?
+
+        // Forces the internal matrices to be updated which results
+        // in this being modified so a Render can occur
+        sNode->UpdateMatrices();
+        }
+
+      //
+      // Some parameters and commands do not require the
+      // orientations to match. These are handled here.
+      //
+
+      // Setting the orientation of the slice plane does not
+      // require that the orientations initially match.
+      if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+        & vtkMRMLSliceNode::OrientationFlag)
+        {
+        // We could copy the orientation strings, but we really
+        // want the slice to ras to match, so copy that
+        sNode->GetSliceToRAS()->DeepCopy( sliceNode->GetSliceToRAS() );
+
+        // Forces the internal matrices to be updated which results
+        // in this being modified so a Render can occur
+        sNode->UpdateMatrices();
+        }
+
+      // Reseting the field of view does not require the
+      // orientations to match
+      if ((sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceNode::ResetFieldOfViewFlag)
+          && this->GetMRMLApplicationLogic()->GetSliceLogics())
+        {
+        // need the logic for this slice (sNode)
+        vtkMRMLSliceLogic* logic;
+        vtkCollectionSimpleIterator it;
+        vtkCollection* logics = this->GetMRMLApplicationLogic()->GetSliceLogics();
+        for (logics->InitTraversal(it);
+              (logic=vtkMRMLSliceLogic::SafeDownCast(logics->GetNextItemAsObject(it)));)
+          {
+          if (logic->GetSliceNode() == sNode)
+            {
+            logic->FitSliceToAll();
+            sNode->UpdateMatrices();
+            break;
+            }
+          }
+        }
+
+      // Broadcasting the rotation from a ReformatWidget
+      if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+        & vtkMRMLSliceNode::MultiplanarReformatFlag)
+        {
+        this->BroadcastLastRotation(sliceNode,sNode);
+        }
+
+      // Setting the label outline mode
+      if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+        & vtkMRMLSliceNode::LabelOutlineFlag)
+        {
+        sNode->SetUseLabelOutline( sliceNode->GetUseLabelOutline() );
+        }
+
+      // Broadcasting the visibility of slice in 3D
+      if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+        & vtkMRMLSliceNode::SliceVisibleFlag)
+        {
+        std::string layoutName(sliceNode->GetLayoutName() ? sliceNode->GetLayoutName() : "");
+        std::string lname(sNode->GetLayoutName() ? sNode->GetLayoutName() : "");
+        if (layoutName.find("Compare") == 0)
+          {
+          // Compare view, only broadcast to compare views
+          if (lname.find("Compare") == 0)
+            {
+            // Compare view, broadcast
+            sNode->SetSliceVisible(sliceNode->GetSliceVisible());
+            }
+          }
+        else
+          {
+          // Not a compare view, only broadcast to non compare views
+          if (lname.find("Compare") != 0)
+            {
+            // not a Compare view, broadcast
+            sNode->SetSliceVisible(sliceNode->GetSliceVisible());
+            }
+          }
+        }
+
+        // Setting the slice spacing
+        if (sliceNode->GetInteractionFlags() & sliceNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceNode::SliceSpacingFlag)
+          {
+          sNode->SetSliceSpacingMode( sliceNode->GetSliceSpacingMode() );
+          sNode->SetPrescribedSliceSpacing( sliceNode->GetPrescribedSliceSpacing() );
+          }
+      //
+      // End of the block for broadcasting parameters and commands
+      // that do not require the orientation to match
+      //
       }
 
     // Update SliceNodeInteractionStatus after MultiplanarReformat interaction
@@ -508,10 +520,20 @@ void vtkMRMLSliceLinkLogic::BroadcastSliceCompositeNodeEvent(vtkMRMLSliceComposi
   // std::cout << "BroadcastingEvents: " << this->GetBroadcastingEvents()
   //           << ", Interacting: " << sliceCompositeNode->GetInteracting()
   //           << std::endl;
+  if (!sliceCompositeNode)
+    {
+    return;
+    }
   if (!this->GetBroadcastingEvents() && sliceCompositeNode->GetInteracting())
     {
     this->BroadcastingEventsOn();
 
+    std::string requiredViewGroup;
+    vtkMRMLSliceNode* sliceNode = vtkMRMLSliceLogic::GetSliceNode(sliceCompositeNode);
+    if (sliceNode && sliceNode->GetViewGroup())
+      {
+      requiredViewGroup = sliceNode->GetViewGroup();
+      }
     vtkMRMLSliceCompositeNode* cNode;
     vtkCollectionSimpleIterator it;
     vtkSmartPointer<vtkCollection> nodes;
@@ -520,45 +542,56 @@ void vtkMRMLSliceLinkLogic::BroadcastSliceCompositeNodeEvent(vtkMRMLSliceComposi
     for (nodes->InitTraversal(it);
         (cNode=vtkMRMLSliceCompositeNode::SafeDownCast(nodes->GetNextItemAsObject(it)));)
       {
-      if (cNode != sliceCompositeNode)
+      if (cNode == sliceCompositeNode || !cNode)
         {
-        // Foreground selection
-        if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceCompositeNode::ForegroundVolumeFlag)
-          {
-          //std::cerr << "Broadcasting Foreground Volume " << sliceCompositeNode->GetForegroundVolumeID() << std::endl;
-          cNode->SetForegroundVolumeID(sliceCompositeNode->GetForegroundVolumeID());
-          }
-
-        // Background selection
-        if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceCompositeNode::BackgroundVolumeFlag)
-          {
-          cNode->SetBackgroundVolumeID(sliceCompositeNode->GetBackgroundVolumeID());
-          }
-
-        // Labelmap selection
-        if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceCompositeNode::LabelVolumeFlag)
-          {
-          cNode->SetLabelVolumeID(sliceCompositeNode->GetLabelVolumeID());
-          }
-
-        // Foreground opacity
-        if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceCompositeNode::ForegroundOpacityFlag)
-          {
-          cNode->SetForegroundOpacity(sliceCompositeNode->GetForegroundOpacity());
-          }
-
-        // Labelmap opacity
-        if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
-            & vtkMRMLSliceCompositeNode::LabelOpacityFlag)
-          {
-          cNode->SetLabelOpacity(sliceCompositeNode->GetLabelOpacity());
-          }
-
+        continue;
         }
+      std::string viewGroup;
+      vtkMRMLSliceNode* sNode = vtkMRMLSliceLogic::GetSliceNode(cNode);
+      if (sNode && sNode->GetViewGroup())
+        {
+        viewGroup = sNode->GetViewGroup();
+        }
+      if (viewGroup != requiredViewGroup)
+        {
+        continue;
+        }
+      // Foreground selection
+      if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceCompositeNode::ForegroundVolumeFlag)
+        {
+        //std::cerr << "Broadcasting Foreground Volume " << sliceCompositeNode->GetForegroundVolumeID() << std::endl;
+        cNode->SetForegroundVolumeID(sliceCompositeNode->GetForegroundVolumeID());
+        }
+
+      // Background selection
+      if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceCompositeNode::BackgroundVolumeFlag)
+        {
+        cNode->SetBackgroundVolumeID(sliceCompositeNode->GetBackgroundVolumeID());
+        }
+
+      // Labelmap selection
+      if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceCompositeNode::LabelVolumeFlag)
+        {
+        cNode->SetLabelVolumeID(sliceCompositeNode->GetLabelVolumeID());
+        }
+
+      // Foreground opacity
+      if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceCompositeNode::ForegroundOpacityFlag)
+        {
+        cNode->SetForegroundOpacity(sliceCompositeNode->GetForegroundOpacity());
+        }
+
+      // Labelmap opacity
+      if (sliceCompositeNode->GetInteractionFlags() & sliceCompositeNode->GetInteractionFlagsModifier()
+          & vtkMRMLSliceCompositeNode::LabelOpacityFlag)
+        {
+        cNode->SetLabelOpacity(sliceCompositeNode->GetLabelOpacity());
+        }
+
       }
 
     this->BroadcastingEventsOff();

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceInformationWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceInformationWidget.ui
@@ -37,14 +37,14 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Orientation:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1">
     <widget class="QComboBox" name="SliceOrientationSelector">
      <property name="toolTip">
       <string>Slice orientation (Axial, Sagittal, Coronal, Reformat)</string>
@@ -71,14 +71,14 @@
      </item>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Slice visible:</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QToolButton" name="SliceVisibilityToggle">
      <property name="toolTip">
       <string>Toggle the visibility of the slice in the 3D scene</string>
@@ -105,14 +105,14 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
       <string>Widget visible:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="1">
     <widget class="QToolButton" name="WidgetVisibilityToggle">
      <property name="toolTip">
       <string>Toggle the visibility of the reformat widget in the 3D scene</string>
@@ -139,7 +139,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="label_6">
      <property name="toolTip">
       <string>Dimension of the slice.</string>
@@ -149,7 +149,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="ctkCoordinatesWidget" name="DimensionWidget">
      <property name="enabled">
       <bool>false</bool>
@@ -165,7 +165,27 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="6" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="toolTip">
+      <string>Field of view of slice</string>
+     </property>
+     <property name="text">
+      <string>Field of view:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="ctkCoordinatesWidget" name="FieldOfViewWidget">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
     <widget class="QLabel" name="label_8">
      <property name="toolTip">
       <string>Layout of the lightbox (rows, columns)</string>
@@ -175,7 +195,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
       <widget class="QSpinBox" name="LightboxLayoutRowsSpinBox">
@@ -205,7 +225,7 @@
      </item>
     </layout>
    </item>
-   <item row="8" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="label_9">
      <property name="toolTip">
       <string>Slice spacing may be set automatically or manually by the user or context</string>
@@ -215,7 +235,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <property name="spacing">
       <number>0</number>
@@ -239,14 +259,14 @@
      </item>
     </layout>
    </item>
-   <item row="9" column="0">
+   <item row="10" column="0">
     <widget class="QLabel" name="label_10">
      <property name="text">
       <string>Manual spacing:</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="10" column="1">
     <widget class="ctkDoubleSpinBox" name="PrescribedSpacingSpinBox">
      <property name="enabled">
       <bool>false</bool>
@@ -262,23 +282,20 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="ctkCoordinatesWidget" name="FieldOfViewWidget">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="minimum">
-      <double>0.000000000000000</double>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>View group:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_7">
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="ViewGroupLineEdit">
      <property name="toolTip">
-      <string>Field of view of slice</string>
+      <string>Navigation and linked properties of views in the same group are synchronized</string>
      </property>
-     <property name="text">
-      <string>Field of view:</string>
+     <property name="readOnly">
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/Libs/MRML/Widgets/qMRMLSliceInformationWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceInformationWidget.cxx
@@ -66,6 +66,9 @@ void qMRMLSliceInformationWidgetPrivate::setupUi(qMRMLWidget* widget)
 
   // Dimension and Field of View are readonly
 
+  this->connect(this->ViewGroupLineEdit, SIGNAL(textEdited(QString)),
+    q, SLOT(setViewGroup(QString)));
+
   // Connect LightBox layout
   this->connect(this->LightboxLayoutRowsSpinBox, SIGNAL(valueChanged(int)),
                 q, SLOT(setLightboxLayoutRows(int)));
@@ -121,6 +124,8 @@ void qMRMLSliceInformationWidgetPrivate::updateWidgetFromMRMLSliceNode()
   coordinatesInDouble[1] = fieldOfView[1];
   coordinatesInDouble[2] = fieldOfView[2];
   this->FieldOfViewWidget->setCoordinates(coordinatesInDouble);
+
+  this->ViewGroupLineEdit->setText(this->MRMLSliceNode->GetViewGroup() ? this->MRMLSliceNode->GetViewGroup() : "");
 
   // Update lightbox rows/columns entries
   this->LightboxLayoutRowsSpinBox->setValue(this->MRMLSliceNode->GetLayoutGridRows());
@@ -224,6 +229,26 @@ void qMRMLSliceInformationWidget::setSliceVisible(bool visible)
     }
 
   d->MRMLSliceNode->SetSliceVisible(visible);
+}
+
+//---------------------------------------------------------------------------
+void qMRMLSliceInformationWidget::setViewGroup(const QString& viewGroup)
+{
+  Q_D(qMRMLSliceInformationWidget);
+
+  if (!d->MRMLSliceNode)
+  {
+    return;
+  }
+
+  if (!viewGroup.isEmpty())
+    {
+    d->MRMLSliceNode->SetViewGroup(viewGroup.toLatin1());
+    }
+  else
+    {
+    d->MRMLSliceNode->SetViewGroup(NULL);
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceInformationWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceInformationWidget.h
@@ -71,6 +71,9 @@ public slots:
   /// Set widget visible.
   void setWidgetVisible(bool visible);
 
+  /// Set view group
+  void setViewGroup(const QString& viewGroup);
+
   /// Set lightbox layout row count
   void setLightboxLayoutRows(int rowCount);
 

--- a/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
+++ b/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
@@ -2601,32 +2601,16 @@ void vtkSlicerAnnotationModuleLogic::JumpSlicesToAnnotationCoordinate(const char
     return;
     }
 
-  vtkMRMLNode *mrmlNode = this->GetMRMLScene()->GetNthNodeByClass(0,"vtkMRMLSliceNode");
-  if (!mrmlNode)
+  this->GetMRMLScene()->SaveStateForUndo();
+  // TODO for now only consider the first control point
+  double *rasCoordinates = controlpointsNode->GetControlPointCoordinates(0);
+  if (rasCoordinates)
     {
-    vtkErrorMacro("JumpSlicesToAnnotationCoordinate: could not get first slice node from scene");
-    return;
-    }
-  vtkMRMLSliceNode *sliceNode = vtkMRMLSliceNode::SafeDownCast(mrmlNode);
-  if (sliceNode)
-    {
-    this->GetMRMLScene()->SaveStateForUndo();
-    // TODO for now only consider the first control point
-    double *rasCoordinates = controlpointsNode->GetControlPointCoordinates(0);
-    if (rasCoordinates)
-      {
-      double r = rasCoordinates[0];
-      double a = rasCoordinates[1];
-      double s = rasCoordinates[2];
+    double r = rasCoordinates[0];
+    double a = rasCoordinates[1];
+    double s = rasCoordinates[2];
 
-      sliceNode->JumpAllSlices(r,a,s);
-      // JumpAllSlices jumps all the other slices, not self, so JumpSlice on
-      // this node as well
-      sliceNode->JumpSlice(r,a,s);
-      }
-
-//    annotationNode->RestoreView();
-
+    vtkMRMLSliceNode::JumpAllSlices(this->GetMRMLScene(), NULL, r, a, s);
     }
 }
 

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -516,7 +516,7 @@ int vtkSlicerMarkupsLogic::AddFiducial(double r, double a, double s)
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::JumpSlicesToLocation(double x, double y, double z, bool centered)
+void vtkSlicerMarkupsLogic::JumpSlicesToLocation(double x, double y, double z, bool centered, const std::string& viewGroup /* ="*" */)
 {
   if (!this->GetMRMLScene())
     {
@@ -526,34 +526,12 @@ void vtkSlicerMarkupsLogic::JumpSlicesToLocation(double x, double y, double z, b
 
   // save the whole state as iterating over all slice nodes
   this->GetMRMLScene()->SaveStateForUndo();
-
-  // jump all the slice nodes in the scene
-  int numSliceNodes = this->GetMRMLScene()->GetNumberOfNodesByClass("vtkMRMLSliceNode");
-  for (int n = 0; n < numSliceNodes; ++n)
-    {
-    vtkMRMLNode *mrmlNode = this->GetMRMLScene()->GetNthNodeByClass(n,"vtkMRMLSliceNode");
-    if (!mrmlNode)
-      {
-      vtkErrorMacro("JumpSlicesToLocation: could not get slice node " << n << " from scene");
-      return;
-      }
-    vtkMRMLSliceNode *sliceNode = vtkMRMLSliceNode::SafeDownCast(mrmlNode);
-    if (sliceNode)
-      {
-      if (centered)
-        {
-        sliceNode->JumpSliceByCentering(x,y,z);
-        }
-      else
-        {
-        sliceNode->JumpSliceByOffsetting(x,y,z);
-        }
-      }
-    }
+  int jumpMode = centered ? vtkMRMLSliceNode::CenteredJumpSlice: vtkMRMLSliceNode::OffsetJumpSlice;
+  vtkMRMLSliceNode::JumpAllSlices(this->GetMRMLScene(), x, y, z, jumpMode, viewGroup);
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::JumpSlicesToNthPointInMarkup(const char *id, int n, bool centered)
+void vtkSlicerMarkupsLogic::JumpSlicesToNthPointInMarkup(const char *id, int n, bool centered, const std::string& viewGroup /* ="*" */)
 {
   if (!id)
     {
@@ -576,7 +554,7 @@ void vtkSlicerMarkupsLogic::JumpSlicesToNthPointInMarkup(const char *id, int n, 
     double point[4];
     // get the first point for now
     markup->GetMarkupPointWorld(n, 0, point);
-    this->JumpSlicesToLocation(point[0], point[1], point[2], centered);
+    this->JumpSlicesToLocation(point[0], point[1], point[2], centered, viewGroup);
     }
 }
 

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -89,9 +89,12 @@ public:
   int AddFiducial(double r=0.0, double a=0.0, double s=0.0);
 
   /// jump the slice windows to the given coordinate
-  void JumpSlicesToLocation(double x, double y, double z, bool centered);
+  /// If viewGroup is "*" then all all slice views are updated, otherwise only those views
+  /// that are in the specified group.
+  void JumpSlicesToLocation(double x, double y, double z, bool centered, const std::string& viewGroup = "*");
   /// jump the slice windows to the nth markup with the mrml id id
-  void JumpSlicesToNthPointInMarkup(const char *id, int n, bool centered = false);
+  /// \sa JumpSlicesToLocation
+  void JumpSlicesToNthPointInMarkup(const char *id, int n, bool centered = false, const std::string& viewGroup = "*");
   /// refocus all of the 3D cameras to the nth markup with the mrml id id
   /// \sa FocusCameraOnNthPointInMarkup
   void FocusCamerasOnNthPointInMarkup(const char *id, int n);

--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
@@ -62,6 +62,7 @@ public:
 public:
   bool EnterPlaceModeOnNodeChange;
   bool JumpToSliceEnabled;
+  QString ViewGroup;
 
   vtkWeakPointer<vtkSlicerMarkupsLogic> MarkupsLogic;
   vtkWeakPointer<vtkMRMLMarkupsNode> CurrentMarkupsNode;
@@ -72,6 +73,7 @@ qSlicerSimpleMarkupsWidgetPrivate::qSlicerSimpleMarkupsWidgetPrivate( qSlicerSim
   : q_ptr(&object)
   , EnterPlaceModeOnNodeChange(true)
   , JumpToSliceEnabled(false)
+  , ViewGroup("*")
 {
 }
 
@@ -284,6 +286,20 @@ QColor qSlicerSimpleMarkupsWidget::nodeColor() const
 }
 
 //-----------------------------------------------------------------------------
+void qSlicerSimpleMarkupsWidget::setViewGroup(const QString& newViewGroup)
+{
+  Q_D(qSlicerSimpleMarkupsWidget);
+  d->ViewGroup = newViewGroup;
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerSimpleMarkupsWidget::viewGroup() const
+{
+  Q_D(const qSlicerSimpleMarkupsWidget);
+  return d->ViewGroup;
+}
+
+//-----------------------------------------------------------------------------
 void qSlicerSimpleMarkupsWidget::highlightNthFiducial(int n)
 {
   Q_D(qSlicerSimpleMarkupsWidget);
@@ -424,7 +440,7 @@ void qSlicerSimpleMarkupsWidget::onMarkupsFiducialTableContextMenu(const QPoint&
 
   if ( selectedAction == jumpAction )
     {
-    d->MarkupsLogic->JumpSlicesToNthPointInMarkup( this->currentNode()->GetID(), currentFiducial, true /* centered */ );
+    d->MarkupsLogic->JumpSlicesToNthPointInMarkup(this->currentNode()->GetID(), currentFiducial, true /* centered */, d->ViewGroup.toLatin1().constData());
     }
 
   this->updateWidget();
@@ -448,7 +464,7 @@ void qSlicerSimpleMarkupsWidget::onMarkupsFiducialSelected(int row, int column)
       qCritical("qSlicerSimpleMarkupsWidget::onMarkupsFiducialSelected failed: Cannot jump, markups module logic is invalid");
       return;
       }
-    d->MarkupsLogic->JumpSlicesToNthPointInMarkup(currentMarkupsFiducialNode->GetID(), row, true /* centered */);
+    d->MarkupsLogic->JumpSlicesToNthPointInMarkup(currentMarkupsFiducialNode->GetID(), row, true /* centered */, d->ViewGroup.toLatin1().constData());
     }
 
   emit currentMarkupsFiducialSelectionChanged(row);

--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.h
@@ -44,6 +44,7 @@ qSlicerSimpleMarkupsWidget : public qSlicerWidget
   Q_PROPERTY(bool optionsVisible READ optionsVisible WRITE setOptionsVisible)
   Q_PROPERTY(QColor nodeColor READ nodeColor WRITE setNodeColor)
   Q_PROPERTY(QColor defaultNodeColor READ defaultNodeColor WRITE setDefaultNodeColor)
+  Q_PROPERTY(QString viewGroup READ viewGroup WRITE setViewGroup)
 
 public:
   typedef qSlicerWidget Superclass;
@@ -69,6 +70,7 @@ public:
   bool enterPlaceModeOnNodeChange() const;
 
   /// If enabled then the fiducial will be shown in all slice views when a fiducial is selected
+  /// /sa setViewGroup
   bool jumpToSliceEnabled() const;
 
   /// Show/hide the markup node selector widget.
@@ -82,6 +84,14 @@ public:
 
   /// Get the default node color that is applied to newly created nodes.
   QColor defaultNodeColor() const;
+
+  /// Set views where slice positions will be updated on jump to slice.
+  /// If set to "*" then all slices will be jumped.
+  /// "*" by default.
+  void setViewGroup(const QString& newViewGroup);
+
+  /// Get view group where slice positions will be updated.
+  QString viewGroup()const;
 
 public slots:
 


### PR DESCRIPTION
ViewGroup is used for restricting scope of:
* linked slice view property changes (if slices are linked, a property change will only change views in the same group)
* crosshair jump to slice (if crosshair is moved with shift+mousemove and slice jump is enabled, only those slices will be moved that are in the same group as the view where the mouse was)
* slice intersection display (slice intersections will only shown of those slices that are in the same group)

Implementation:
* Added new ViewGroup member to abstract view node (string, empty by default)
* In default layouts "Three over three" and "Four over four" separated top/bottom rows (view IDs changed to Red+, Yellow+, Green+, 1+; unique node IDs were necessary because on layout change view group is not updated, so we cannot share view nodes between layouts the same group ID for all views)
* Updated vtkMRMLSliceNode::JumpAllSlices to only jump those slices that have matching viewgroup
* Updated vtkMRMLSliceLinkLogic::OnMRMLNodeModified(vtkMRMLNode* node) to make aware of groups
* Updated slice displayable manager to only show slice intersections in the same group (and mapped in layout)
* Updated 2D/3D displayable managers to only jump those slices on crosshair update (shift+mousemove) that are in the same group
* Updated GUI:
** Added View group view/edit to Slice information widget (used in View Controllers module).
** Added viewGroup property to simple markups widget (that can restrict slice jumping to a specific view group)