### PR TITLE
ENH: Implemented DICOMDetailsPopup as window and dialog

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -243,7 +243,7 @@ class DICOMWidget:
     self.dicomFrame.setText("DICOM Database and Networking")
     self.layout.addWidget(self.dicomFrame)
 
-    self.detailsPopup = DICOMLib.DICOMDetailsPopup()
+    self.detailsPopup = DICOMLib.DICOMDetailsWindow()
 
     # XXX Slicer 4.5 - Remove these. Here only for backward compatibility.
     self.dicomBrowser = self.detailsPopup.dicomBrowser

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -313,9 +313,7 @@ class DICOMWidget:
     self.layout.addStretch(1)
 
   def onOpenDetailsPopup(self):
-    print "onOpenDetailsPopup"
     if not isinstance(self.detailsPopup, self.getSavedDICOMDetailsWidgetType()):
-      print "is not instance"
       self.detailsPopup = self.getSavedDICOMDetailsWidgetType()()
     self.detailsPopup.open()
 

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -918,9 +918,6 @@ class DICOMDetailsPopup(DICOMDetailsBase, ctkPopupWidget):
 
 
 class DICOMDetailsDock(DICOMDetailsBase, qt.QFrame):
-  """
-  TODO: this is probably not usable since the dicom browser takes too much space so it wouldn't make sense to dock it
-  """
 
   def __init__(self, dicomBrowser=None):
     DICOMDetailsBase.__init__(self, dicomBrowser)
@@ -931,7 +928,22 @@ class DICOMDetailsDock(DICOMDetailsBase, qt.QFrame):
                           qt.QDockWidget.DockWidgetClosable)
     slicer.util.mainWindow().addDockWidget(qt.Qt.TopDockWidgetArea, self.dock)
     self.dock.setWidget(self)
+    self.dock.visibilityChanged.connect(self.onVisibilityChanged)
     self.setup()
+
+  def __del__(self):
+    self.dock.visibilityChanged.disconnect(self.onVisibilityChanged)
+
+  def open(self):
+    if not self.dock.visible:
+      self.dock.show()
+
+  def close(self):
+    self.dock.hide()
+
+  def onVisibilityChanged(self, visible):
+    if not visible:
+      self.close()
 
 
 class DICOMPluginSelector(qt.QWidget):

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -848,14 +848,15 @@ class DICOMDetailsBase(VTKObservationMixin):
       self.close()
 
 
-class DICOMDetailsModalDialog(DICOMDetailsBase, qt.QDialog):
+class DICOMDetailsDialog(DICOMDetailsBase, qt.QDialog):
 
-  widgetType = "modal_dialog"
+  widgetType = "dialog"
 
   def __init__(self, dicomBrowser=None, parent="mainWindow"):
     DICOMDetailsBase.__init__(self, dicomBrowser)
     qt.QDialog.__init__(self, slicer.util.mainWindow() if parent == "mainWindow" else parent)
     self.modal = True
+    self.setWindowFlags(qt.Qt.WindowMaximizeButtonHint | qt.Qt.Window)
     self.setup()
 
   def open(self):
@@ -865,7 +866,7 @@ class DICOMDetailsModalDialog(DICOMDetailsBase, qt.QDialog):
         self.setGeometry(popupGeometry)
       else:
         self.centerWindow()
-    self.show()
+    self.exec_()
 
   def centerWindow(self):
     mainWindow = slicer.util.mainWindow()
@@ -886,40 +887,13 @@ class DICOMDetailsModalDialog(DICOMDetailsBase, qt.QDialog):
     self.onPopupGeometryChanged()
 
 
-class DICOMDetailsWindow(DICOMDetailsModalDialog):
+class DICOMDetailsWindow(DICOMDetailsDialog):
 
   widgetType = "window"
 
   def __init__(self, dicomBrowser=None, parent="mainWindow"):
     super(DICOMDetailsWindow, self).__init__(dicomBrowser, parent)
     self.modal=False
-
-
-class DICOMDetailsDialog(DICOMDetailsBase, qt.QDialog):
-
-  widgetType = "dialog"
-
-  def __init__(self, dicomBrowser=None, parent="mainWindow"):
-    DICOMDetailsBase.__init__(self, dicomBrowser)
-    qt.QDialog.__init__(self, slicer.util.mainWindow() if parent == "mainWindow" else parent)
-    self.setup()
-
-  def setup(self, showHeader=False, showPreview=False):
-    DICOMDetailsBase.setup(self, showHeader, showPreview)
-
-  def open(self):
-    qt.QDialog.open(self)
-    popupGeometry = settingsValue('DICOM/detailsPopup.geometry', qt.QRect())
-    if popupGeometry.isValid():
-      self.setGeometry(self.x, self.y, self.width, self.height)
-
-  def close(self):
-    qt.QDialog.close(self)
-    self.onPopupGeometryChanged()
-
-  def done(self, result):
-    qt.QDialog.done(self, result)
-    self.onPopupGeometryChanged()
 
 
 class DICOMDetailsDock(DICOMDetailsBase, qt.QFrame):
@@ -961,8 +935,6 @@ class DICOMDetailsWidget(DICOMDetailsBase, qt.QWidget):
     DICOMDetailsBase.__init__(self, dicomBrowser)
     qt.QWidget.__init__(self, parent)
     self.setup()
-    self.browserPersistentButton.visible = False
-    self.browserPersistent = True
 
 
 class DICOMPluginSelector(qt.QWidget):
@@ -1362,6 +1334,7 @@ class DICOMHeaderPopup(qt.QDialog):
 
   def __init__(self, referenceWindow=None):
     qt.QDialog.__init__(self)
+    self.setWindowFlags(qt.Qt.WindowMaximizeButtonHint)
     self.modal = True
     self.referenceWindow = referenceWindow
     self.settings = qt.QSettings()

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -838,17 +838,19 @@ class DICOMDetailsBase(VTKObservationMixin):
     progress.close()
     if loadingResult:
       slicer.util.warningDisplay(loadingResult, windowTitle='DICOM loading')
+
+    self.onLoadingFinished()
+
+  def onLoadingFinished(self):
     if not self.browserPersistent:
       self.close()
-
-    return
 
 
 class DICOMDetailsModalDialog(DICOMDetailsBase, qt.QDialog):
 
-  def __init__(self, dicomBrowser=None):
+  def __init__(self, dicomBrowser=None, parent="mainWindow"):
     DICOMDetailsBase.__init__(self, dicomBrowser)
-    qt.QDialog.__init__(self, slicer.util.mainWindow())
+    qt.QDialog.__init__(self, slicer.util.mainWindow() if parent == "mainWindow" else parent)
     self.modal = True
     self.setup()
 
@@ -882,16 +884,16 @@ class DICOMDetailsModalDialog(DICOMDetailsBase, qt.QDialog):
 
 class DICOMDetailsWindow(DICOMDetailsModalDialog):
 
-  def __init__(self, dicomBrowser=None):
-    super(DICOMDetailsWindow, self).__init__(dicomBrowser)
+  def __init__(self, dicomBrowser=None, parent="mainWindow"):
+    super(DICOMDetailsWindow, self).__init__(dicomBrowser, parent)
     self.modal=False
 
 
 class DICOMDetailsDialog(DICOMDetailsBase, qt.QDialog):
 
-  def __init__(self, dicomBrowser=None):
+  def __init__(self, dicomBrowser=None, parent="mainWindow"):
     DICOMDetailsBase.__init__(self, dicomBrowser)
-    qt.QDialog.__init__(self, slicer.util.mainWindow())
+    qt.QDialog.__init__(self, slicer.util.mainWindow() if parent == "mainWindow" else parent)
     self.setup()
 
   def setup(self, showHeader=False, showPreview=False):
@@ -939,6 +941,16 @@ class DICOMDetailsDock(DICOMDetailsBase, qt.QFrame):
   def onVisibilityChanged(self, visible):
     if not visible:
       self.close()
+
+
+class DICOMDetailsWidget(DICOMDetailsBase, qt.QWidget):
+
+  def __init__(self, dicomBrowser=None, parent=None):
+    DICOMDetailsBase.__init__(self, dicomBrowser)
+    qt.QWidget.__init__(self, parent)
+    self.setup()
+    self.browserPersistentButton.visible = False
+    self.browserPersistent = True
 
 
 class DICOMPluginSelector(qt.QWidget):

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -47,6 +47,8 @@ class DICOMDetailsBase(VTKObservationMixin):
   This is a helper used in the DICOMWidget class.
   """
 
+  widgetType = None
+
   def __init__(self, dicomBrowser=None):
     VTKObservationMixin.__init__(self)
     self.settings = qt.QSettings()
@@ -848,6 +850,8 @@ class DICOMDetailsBase(VTKObservationMixin):
 
 class DICOMDetailsModalDialog(DICOMDetailsBase, qt.QDialog):
 
+  widgetType = "modal_dialog"
+
   def __init__(self, dicomBrowser=None, parent="mainWindow"):
     DICOMDetailsBase.__init__(self, dicomBrowser)
     qt.QDialog.__init__(self, slicer.util.mainWindow() if parent == "mainWindow" else parent)
@@ -884,12 +888,16 @@ class DICOMDetailsModalDialog(DICOMDetailsBase, qt.QDialog):
 
 class DICOMDetailsWindow(DICOMDetailsModalDialog):
 
+  widgetType = "window"
+
   def __init__(self, dicomBrowser=None, parent="mainWindow"):
     super(DICOMDetailsWindow, self).__init__(dicomBrowser, parent)
     self.modal=False
 
 
 class DICOMDetailsDialog(DICOMDetailsBase, qt.QDialog):
+
+  widgetType = "dialog"
 
   def __init__(self, dicomBrowser=None, parent="mainWindow"):
     DICOMDetailsBase.__init__(self, dicomBrowser)
@@ -915,6 +923,8 @@ class DICOMDetailsDialog(DICOMDetailsBase, qt.QDialog):
 
 
 class DICOMDetailsDock(DICOMDetailsBase, qt.QFrame):
+
+  widgetType = "dock"
 
   def __init__(self, dicomBrowser=None):
     DICOMDetailsBase.__init__(self, dicomBrowser)
@@ -944,6 +954,8 @@ class DICOMDetailsDock(DICOMDetailsBase, qt.QFrame):
 
 
 class DICOMDetailsWidget(DICOMDetailsBase, qt.QWidget):
+
+  widgetType = "widget"
 
   def __init__(self, dicomBrowser=None, parent=None):
     DICOMDetailsBase.__init__(self, dicomBrowser)

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -895,6 +895,16 @@ class DICOMDetailsWindow(DICOMDetailsDialog):
     super(DICOMDetailsWindow, self).__init__(dicomBrowser, parent)
     self.modal=False
 
+  def open(self):
+    popupGeometry = settingsValue('DICOM/detailsPopup.geometry', qt.QRect())
+    if not self.isVisible():
+      if popupGeometry.isValid():
+        self.setGeometry(popupGeometry)
+      else:
+        self.centerWindow()
+    self.show()
+    self.activateWindow()
+
 
 class DICOMDetailsDock(DICOMDetailsBase, qt.QFrame):
 

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -850,7 +850,7 @@ class DICOMDetailsWindow(DICOMDetailsBase, qt.QWidget):
     qt.QWidget.__init__(self)
     DICOMDetailsBase.__init__(self, dicomBrowser)
     self.setup()
-    self.setWindowFlags(qt.Qt.WindowStaysOnTopHint)
+    # self.setWindowFlags(qt.Qt.WindowStaysOnTopHint)
 
   def open(self):
     popupGeometry = settingsValue('DICOM/detailsPopup.geometry', qt.QRect())
@@ -1344,7 +1344,7 @@ class DICOMHeaderPopup(qt.QWidget):
   def __init__(self, referenceWindow=None):
     qt.QWidget.__init__(self)
     self.referenceWindow = referenceWindow
-    self.setWindowFlags(qt.Qt.WindowStaysOnTopHint)
+    # self.setWindowFlags(qt.Qt.WindowStaysOnTopHint)
     self.settings = qt.QSettings()
     self.setWindowTitle('DICOM File Metadata')
     self.listWidget = ctkDICOMObjectListWidget()


### PR DESCRIPTION
- default: DICOMDetailsDialog which is bound to the mainWindow and slides in from top
  - closing with esc (which could be improved)
- when using DICOMDetailsWindow, it always says on top
  - resize/move event are overridden called and saves the dimensions to the settings for next call
- old ones like DICOMDetailsPopup and DICOMDetailsDock should be removed since they don't improve any usability

![image](https://cloud.githubusercontent.com/assets/10195822/21067106/3c0d62ee-be37-11e6-818e-f61666dd2fe0.png)
