### PR TITLE
ENH: Update pydicom from 0.9.8 to 0.9.9

### DIFF
--- a/SuperBuild/External_python-pydicom.cmake
+++ b/SuperBuild/External_python-pydicom.cmake
@@ -41,13 +41,10 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/43/62/ba7218b51ebc231863c321dedef54cf97fb29e33832e67db00951a998c50/pydicom-0.9.8.tar.gz"
-    URL_MD5 "b4370f802f0faae7239c8bc9f8a51a18"
+    URL "https://pypi.python.org/packages/5d/1d/dd9716ef3a0ac60c23035a9b333818e34dec2e853733d03f502533af9b84/pydicom-0.9.9.tar.gz"
+    URL_MD5 "a66ca6728e69ba565ab9c8a21740eee8"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR:PATH=${CMAKE_BINARY_DIR}/${proj}
-                                   -DPATCH_${proj}:BOOL=ON
-                                   -P ${CMAKE_CURRENT_LIST_FILE}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install


### PR DESCRIPTION
The main reason is that 0.9.8 fails to load files that have special characters in their name. The problem is fixed in 0.9.9.

0.9.9 doesn't need patching of setup.py anymore (in 0.9.8, first 3 lines of setup.py had to be removed to avoid loading some old dependencies).