### PR TITLE
WIP: TEST: CircleCI Time Kill command

### DIFF
--- a/CMake/CircleCI/kill_time_test.sh
+++ b/CMake/CircleCI/kill_time_test.sh
@@ -1,0 +1,15 @@
+#!bin/bash
+
+min=0
+hour=0
+
+while true
+do
+  echo -n .
+  sleep 1m
+  min=$(($min + 1))
+  if ! (($min % 60)); then
+    hour=$(($hour + 1))
+    echo "Hours elapsed: $hour"
+  fi
+done

--- a/CMake/CircleCI/kill_time_test.sh
+++ b/CMake/CircleCI/kill_time_test.sh
@@ -3,13 +3,17 @@
 min=0
 hour=0
 
-while true
+while (($min < 100))
 do
   echo -n .
   sleep 1m
   min=$(($min + 1))
   if ! (($min % 60)); then
     hour=$(($hour + 1))
-    echo "Hours elapsed: $hour"
+  fi
+  # Time Displayed every 10min
+  if ! (($min % 10)); then
+    min_modulo=$(($min % 60))
+    echo "Time elapsed: $hour:$min_modulo"
   fi
 done

--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,22 @@ machine:
 test:
   override:
     - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh
+    - bash ./CMake/CircleCI/kill_time_test.sh

--- a/circle.yml
+++ b/circle.yml
@@ -6,17 +6,6 @@ machine:
   python:
     version: 2.7.11
 
-dependencies:
-  cache_directories:
-    - "~/docker"
-
-  override:
-    - docker info
-    - pip install scikit-ci-addons==0.11.0
-    - ci_addons docker load-pull-save slicer/slicer-dependencies
-
 test:
   override:
-    - "echo 'Notice: CircleCI does not build changes to Slicer dependencies' && if git diff --name-only master | grep -q SuperBuild > /dev/null; then false; fi"
-    - docker run -e "BUILD_TOOL_FLAGS=-j5" --name slicer -v ~/Slicer:/usr/src/Slicer slicer/slicer-dependencies
-    - docker cp slicer:$(docker cp slicer:/usr/src/Slicer-build/Slicer-build/PACKAGE_FILE.txt - | tar xO) $CIRCLE_ARTIFACTS
+    - bash ./CMake/CircleCI/kill_time_test.sh


### PR DESCRIPTION
Once the Pull Request is done, CircleCI will trigger and launch
kill_time_test.sh which is a simple while true displaying a dot every minutes
and the number of hours elapsed every hour.