### PR TITLE
BUG: fix runtime error related to creation of DICOM database directory

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -491,18 +491,22 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
         But, if the application is in testing mode, just pick a temp directory.
     """
     if slicer.app.commandOptions().testingEnabled:
-      databaseDirectory = os.path.join(slicer.app.temporaryPath, 'tempDICOMDatbase')
+      databaseDirectory = os.path.join(slicer.app.temporaryPath, 'tempDICOMDatabase')
     else:
       databaseDirectory = self.settings.value('DatabaseDirectory')
-      if not databaseDirectory:
-        documentsLocation = qt.QDesktopServices.DocumentsLocation
-        documents = qt.QDesktopServices.storageLocation(documentsLocation)
-        databaseDirectory = os.path.join(documents, "SlicerDICOMDatabase")
-        message = "DICOM Database will be stored in\n\n{}\n\nUse the Local Database button in " \
-                  "the DICOM Browser to pick a different location.".format(databaseDirectory)
-        slicer.util.infoDisplay(message, windowTitle='DICOM')
+      documentsLocation = qt.QDesktopServices.DocumentsLocation
+      documents = qt.QDesktopServices.storageLocation(documentsLocation)
+      defaultDatabaseDirectory = os.path.join(documents, "SlicerDICOMDatabase")
+      message = "DICOM Database will be stored in\n\n{}\n\nUse the Local Database button in " \
+                "the DICOM Browser to pick a different location.".format(defaultDatabaseDirectory)
     if not os.path.exists(databaseDirectory):
-      os.mkdir(databaseDirectory)
+      try:
+        os.mkdir(databaseDirectory)
+      except OSError:
+        databaseDirectory = defaultDatabaseDirectory
+        if not os.path.exists(databaseDirectory):
+          os.mkdir(databaseDirectory)
+        slicer.util.infoDisplay(message, windowTitle='DICOM')
     self.onDatabaseDirectoryChanged(databaseDirectory)
 
   def onTableDensityComboBox(self, state):

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -494,18 +494,17 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
       databaseDirectory = os.path.join(slicer.app.temporaryPath, 'tempDICOMDatabase')
     else:
       databaseDirectory = self.settings.value('DatabaseDirectory')
-      documentsLocation = qt.QDesktopServices.DocumentsLocation
-      documents = qt.QDesktopServices.storageLocation(documentsLocation)
-      defaultDatabaseDirectory = os.path.join(documents, "SlicerDICOMDatabase")
-      message = "DICOM Database will be stored in\n\n{}\n\nUse the Local Database button in " \
-                "the DICOM Browser to pick a different location.".format(defaultDatabaseDirectory)
     if not os.path.exists(databaseDirectory):
       try:
-        os.mkdir(databaseDirectory)
+        os.makedirs(databaseDirectory)
       except OSError:
-        databaseDirectory = defaultDatabaseDirectory
+        documentsLocation = qt.QDesktopServices.DocumentsLocation
+        documents = qt.QDesktopServices.storageLocation(documentsLocation)
+        databaseDirectory = os.path.join(documents, "SlicerDICOMDatabase")
         if not os.path.exists(databaseDirectory):
-          os.mkdir(databaseDirectory)
+          os.makedirs(databaseDirectory)
+        message = "DICOM Database will be stored in\n\n{}\n\nUse the Local Database button in " \
+                "the DICOM Browser to pick a different location.".format(databaseDirectory)
         slicer.util.infoDisplay(message, windowTitle='DICOM')
     self.onDatabaseDirectoryChanged(databaseDirectory)
 


### PR DESCRIPTION
In some situations, user settings may point to a temporary directory with multiple
nesting levels, which cannot be created by os.mkdir().

To solve the issue, when exception occurs, fall back to creating the DICOM DB
directory in the default location.

Also fix a typo for the name of the DICOM DB location in developer mode.

cc: @che85