### PR TITLE
ENH: Add missing python load utility methods

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -299,6 +299,18 @@ def loadAnnotationFiducial(filename, returnNode=False):
   properties['fiducial'] = 1
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
+def loadAnnotationRuler(filename, returnNode=False):
+  filetype = 'AnnotationFile'
+  properties = {}
+  properties['ruler'] = 1
+  return loadNodeFromFile(filename, filetype, properties, returnNode)
+
+def loadAnnotationROI(filename, returnNode=False):
+  filetype = 'AnnotationFile'
+  properties = {}
+  properties['roi'] = 1
+  return loadNodeFromFile(filename, filetype, properties, returnNode)
+
 def loadMarkupsFiducialList(filename, returnNode=False):
   filetype = 'MarkupsFiducials'
   properties = {}


### PR DESCRIPTION
The python utility file was missing methods to load Annotation rulers and ROIs, this change adds:
loadAnnotationRuler('ruler.acsv')
loadAnnotationROI('box.acsv')

Issue #4319