### PR TITLE
COMP: Update smmap to 2.0.1

### DIFF
--- a/SuperBuild/External_python-smmap.cmake
+++ b/SuperBuild/External_python-smmap.cmake
@@ -18,8 +18,8 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/bc/aa/b744b3761fff1b10579df996a2d2e87f124ae07b8336e37edc89cc502f86/smmap-0.9.0.tar.gz"
-    URL_MD5 "d7932d5ace206bf4ae15198cf36fb6ab"
+    URL "https://pypi.python.org/packages/83/ce/e5b3aee7ca420b0ab24d4fcc2aa577f7aa6ea7e9306fafceabee3e8e4703/smmap2-2.0.1.tar.gz"
+    URL_MD5 "71565e9c99ab64718e2a13c489767692"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
After the update of GitPython in r25526, the smmap required version for
pythond-gdb changed to >=2.0.0.