### PR TITLE
ENH: Added CLI output display to module widget

### DIFF
--- a/Base/QTCLI/qSlicerCLIProgressBar.cxx
+++ b/Base/QTCLI/qSlicerCLIProgressBar.cxx
@@ -26,6 +26,10 @@
 #include <QLabel>
 #include <QProgressBar>
 
+// CTK includes
+#include <ctkExpandButton.h>
+#include <ctkFittedTextBrowser.h>
+
 // Slicer includes
 #include "qSlicerCLIProgressBar.h"
 
@@ -59,6 +63,8 @@ private:
   QLabel *       NameLabel;
   QLabel *       StatusLabelLabel;
   QLabel *       StatusLabel;
+  ctkExpandButton * DetailsTextExpandButton;
+  ctkFittedTextBrowser * DetailsTextBrowser;
   QProgressBar * ProgressBar;
   QProgressBar * StageProgressBar;
 
@@ -113,21 +119,37 @@ void qSlicerCLIProgressBarPrivate::init()
 
   this->GridLayout->addWidget(StatusLabel, 1, 1, 1, 1);
 
+  this->DetailsTextExpandButton = new ctkExpandButton();
+  this->DetailsTextExpandButton->setObjectName(QString::fromUtf8("DetailsTextExpandButton"));
+  this->DetailsTextExpandButton->setToolTip(QObject::tr("Show details"));
+  this->DetailsTextExpandButton->setOrientation(Qt::Vertical);
+
+  this->GridLayout->addWidget(DetailsTextExpandButton, 1, 2, 1, 1);
+
+  this->DetailsTextBrowser = new ctkFittedTextBrowser();
+  this->DetailsTextBrowser->setObjectName(QString::fromUtf8("DetailsTextBrowser"));
+  this->DetailsTextBrowser->setVisible(false);
+
+  this->GridLayout->addWidget(DetailsTextBrowser, 2, 0, 1, 3);
+
   this->ProgressBar = new QProgressBar();
   this->ProgressBar->setObjectName(QString::fromUtf8("ProgressBar"));
   this->ProgressBar->setMaximum(100);
   this->ProgressBar->setValue(0);
 
-  this->GridLayout->addWidget(ProgressBar, 2, 0, 1, 2);
+  this->GridLayout->addWidget(ProgressBar, 3, 0, 1, 3);
 
   this->StageProgressBar = new QProgressBar();
   this->StageProgressBar->setObjectName(QString::fromUtf8("StageProgressBar"));
   this->StageProgressBar->setValue(0);
-  this->GridLayout->addWidget(StageProgressBar, 3, 0, 1, 2);
+  this->GridLayout->addWidget(StageProgressBar, 4, 0, 1, 3);
 
   this->NameLabel->setText(QObject::tr(""));
   this->StatusLabelLabel->setText(QObject::tr("Status:"));
   this->StatusLabel->setText(QObject::tr("Idle"));
+
+  QObject::connect(this->DetailsTextExpandButton, SIGNAL(toggled(bool)),
+    this->DetailsTextBrowser, SLOT(setVisible(bool)));
 
   q->updateUiFromCommandLineModuleNode(this->CommandLineModuleNode);
 }
@@ -319,4 +341,25 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
     case vtkMRMLCommandLineModuleNode::Idle:
       break;
     }
+
+  QString detailsText;
+  detailsText = "<pre>";
+  std::string errorText = node->GetErrorText();
+  std::string outputText = node->GetOutputText();
+  if (!errorText.empty())
+    {
+    detailsText += "<span style = \"color:#FF0000;\">";
+    detailsText += errorText.c_str();
+    detailsText += "</span>";
+    }
+  if (!errorText.empty() && !outputText.empty())
+    {
+    detailsText += "\n";
+    }
+  if (!outputText.empty())
+    {
+    detailsText += node->GetOutputText().c_str();
+    }
+  detailsText += "</pre>";
+  d->DetailsTextBrowser->setText(detailsText);
 }

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -831,6 +831,8 @@ void vtkSlicerCLIModuleLogic::Apply ( vtkMRMLCommandLineModuleNode* node, bool u
     }
   else
     {
+    node->SetOutputText("", false);
+    node->SetErrorText("", false);
     node->SetStatus(vtkMRMLCommandLineModuleNode::Scheduled);
     }
 }
@@ -941,6 +943,8 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
   if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Cancelling ||
       node0->GetStatus() == vtkMRMLCommandLineModuleNode::Cancelled)
     {
+    node0->SetOutputText("", false);
+    node0->SetErrorText("", false);
     node0->SetStatus(vtkMRMLCommandLineModuleNode::Cancelled, false);
     this->GetApplicationLogic()->RequestModified( node0 );
     return;
@@ -1818,9 +1822,11 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
         }
       else
         {
-        vtkErrorMacro("No value assigned to \""
-                      << (*iit).second.GetLabel().c_str() << "\"");
-
+        std::string errorText = "No value assigned to \""
+          + (*iit).second.GetLabel() + "\"";
+        vtkErrorMacro(<< errorText.c_str());
+        node0->SetOutputText("", false);
+        node0->SetErrorText(errorText, false);
         node0->SetStatus(vtkMRMLCommandLineModuleNode::Idle, false);
         this->GetApplicationLogic()->RequestModified( node0 );
         return;
@@ -1829,7 +1835,10 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
     else if ((*iit).second.GetTag() == "point"
              || (*iit).second.GetTag() == "region")
       {
-      vtkErrorMacro("Fiducials and ROIs are not currently supported as index arguments to modules.");
+      std::string errorText = "Fiducials and ROIs are not currently supported as index arguments to modules.";
+      vtkErrorMacro(<< errorText.c_str());
+      node0->SetOutputText("", false);
+      node0->SetErrorText(errorText, false);
       node0->SetStatus(vtkMRMLCommandLineModuleNode::Idle, false);
       this->GetApplicationLogic()->RequestModified( node0 );
       return;
@@ -1877,10 +1886,11 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
         }
       else
         {
-        vtkErrorMacro("No " << (*iit).second.GetChannel().c_str()
-                      << " data assigned to \""
-                      << (*iit).second.GetLabel().c_str() << "\"");
-
+        std::string errorText = "No " + (*iit).second.GetChannel()
+          + " data assigned to \"" + (*iit).second.GetLabel() + "\"";
+        vtkErrorMacro(<< errorText.c_str());
+        node0->SetOutputText("", false);
+        node0->SetErrorText(errorText, false);
         node0->SetStatus(vtkMRMLCommandLineModuleNode::Idle, false);
         this->GetApplicationLogic()->RequestModified( node0 );
         return;
@@ -1914,6 +1924,8 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
   //
   //
   node0->GetModuleDescription().GetProcessInformation()->Initialize();
+  node0->SetOutputText("", false);
+  node0->SetErrorText("", false);
   node0->SetStatus(vtkMRMLCommandLineModuleNode::Running, false);
   this->GetApplicationLogic()->RequestModified( node0 );
   if (commandType == CommandLineModule)
@@ -2140,12 +2152,15 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
       // vtkSlicerApplication::GetInstance()->InformationMessage
       qDebug() << stdoutbuffer.c_str();
       }
+    node0->SetOutputText(stdoutbuffer, false);
+
     if (stderrbuffer.size() > 0)
       {
       std::string tmp(" standard error:\n\n");
       stderrbuffer.insert(0, node0->GetModuleDescription().GetTitle()+tmp);
       vtkErrorMacro( << stderrbuffer.c_str() );
       }
+    node0->SetErrorText(stderrbuffer, false);
 
     // check the exit state / error state of the process
     if (node0->GetStatus() == vtkMRMLCommandLineModuleNode::Cancelling)
@@ -2274,6 +2289,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
         // vtkSlicerApplication::GetInstance()->InformationMessage
         qDebug() << (tmp + coutstringstream.str()).c_str();
         }
+      node0->SetOutputText(coutstringstream.str(), false);
       if (cerrstringstream.str().size() > 0)
         {
         std::string tmp(" standard error:\n\n");
@@ -2281,6 +2297,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
 
         vtkErrorMacro( << (tmp + cerrstringstream.str()).c_str() );
         }
+      node0->SetErrorText(cerrstringstream.str(), false);
 
       if (this->Internal->RedirectModuleStreams)
         {

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -62,6 +62,11 @@ public:
 
   /// Flag to trigger or not the StatusModifiedEvent
   mutable bool InvokeStatusModifiedEvent;
+
+  /// Output messages of last execution (printed to stdout)
+  std::string OutputText;
+  /// Error messages of last execution (printed to stderr)
+  std::string ErrorText;
 };
 
 ModuleDescriptionMap vtkMRMLCommandLineModuleNode::vtkInternal::RegisteredModules;
@@ -1018,5 +1023,45 @@ void vtkMRMLCommandLineModuleNode::Modified()
   if (invokeStatusModifiedEvent)
     {
     this->InvokeEvent(vtkMRMLCommandLineModuleNode::StatusModifiedEvent);
+    }
+}
+
+//----------------------------------------------------------------------------
+const std::string vtkMRMLCommandLineModuleNode::GetErrorText() const
+{
+  return this->Internal->ErrorText;
+}
+
+//----------------------------------------------------------------------------
+const std::string vtkMRMLCommandLineModuleNode::GetOutputText() const
+{
+  return this->Internal->OutputText;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLCommandLineModuleNode::SetErrorText(const std::string& text, bool modify)
+{
+  if (this->Internal->ErrorText == text)
+    {
+    return;
+    }
+  this->Internal->ErrorText = text;
+  if (modify)
+    {
+    this->Modified();
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLCommandLineModuleNode::SetOutputText(const std::string& text, bool modify)
+{
+  if (this->Internal->OutputText == text)
+    {
+    return;
+    }
+  this->Internal->OutputText = text;
+  if (modify)
+    {
+    this->Modified();
     }
 }

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -119,6 +119,12 @@ public:
   /// \sa GetStatus(), IsBusy()
   const char* GetStatusString() const;
 
+  void SetOutputText(const std::string& text, bool modify = true);
+  const std::string GetOutputText() const;
+
+  void SetErrorText(const std::string& text, bool modify = true);
+  const std::string GetErrorText() const;
+
   /// Return true if the module is in a busy state: Scheduled, Running,
   /// Cancelling, Completing.
   /// \sa SetStatus(), GetStatus(), BusyMask, Cancel()


### PR DESCRIPTION
Problem:
It is often difficult to find out why a CLI failed or get detailed output.
(user would need to open the log window and find the messages in the log,
but most users don't even know that there is a log window).

Solution:
Expand button is added next to the status message.
User can click there to show/hide all details.
Error output is displayed in red, at the top. Standard output is displayed black.
Window is automatically sized to show all content with minimal need for scrolling.