### PR TITLE
STYLE: Expose utility methods in qMRMLColor

### DIFF
--- a/Libs/MRML/Core/vtkMRMLColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorNode.cxx
@@ -375,6 +375,31 @@ const char *vtkMRMLColorNode::GetColorName(int ind)
 }
 
 //---------------------------------------------------------------------------
+int vtkMRMLColorNode::GetColorIndexByName(const char *name)
+{
+  if (name == NULL)
+    {
+    vtkErrorMacro("vtkMRMLColorNode::GetColorIndexByName: need a non-null name as argument")
+    return -1;
+    }
+
+  if (!this->GetNamesInitialised())
+    {
+    this->SetNamesFromColors();
+    }
+
+  std::string strName = name;
+  for (unsigned int i = 0; i < this->GetNumberOfColors(); ++i)
+    {
+    if (strName == this->GetColorName(i))
+      {
+      return i;
+      }
+    }
+  return -1;
+}
+
+//---------------------------------------------------------------------------
 std::string vtkMRMLColorNode::GetColorNameWithoutSpaces(int ind, const char *subst)
 {
   std::string name = std::string(this->GetColorName(ind));

--- a/Libs/MRML/Core/vtkMRMLColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorNode.h
@@ -110,9 +110,14 @@ public:
       TypeModifiedEvent = 20002
     };
 
-  ///
-  /// Get the 0th based nth name of this colour
+  /// Get name of a color from its index (index is 0-based)
+  /// \sa GetColorIndexByName()
   const char *GetColorName(int ind);
+
+  /// Return the index associated with this color name, which can then be used
+  /// to get the colour. Returns -1 on failure.
+  /// \sa GetColorName()
+  int GetColorIndexByName(const char *name);
 
   /// Get the 0'th based \a colorIndex'th name of this color, replacing all
   /// file name sensitive color name characters with safer character(s).

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
@@ -1418,23 +1418,6 @@ void vtkMRMLColorTableNode::Reset(vtkMRMLNode* defaultNode)
 }
 
 //---------------------------------------------------------------------------
-int vtkMRMLColorTableNode::GetColorIndexByName(const char *name)
-{
-  if (this->GetNamesInitialised() && name != NULL)
-    {
-    std::string strName = name;
-    for (unsigned int i = 0; i < this->Names.size(); i++)
-      {
-      if (strName.compare(this->GetColorName(i)) == 0)
-        {
-        return i;
-        }
-      }
-    }
-    return -1;
-}
-
-//---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLColorTableNode::CreateDefaultStorageNode()
 {
   return vtkMRMLColorTableStorageNode::New();

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.h
@@ -217,11 +217,6 @@ public:
   virtual void Reset(vtkMRMLNode* defaultNode);
 
   ///
-  /// return the index associated with this color name, which can then be used
-  /// to get the colour. Returns -1 on failure.
-  int GetColorIndexByName(const char *name);
-
-  ///
   /// Create default storage node or NULL if does not have one
   virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
 

--- a/Libs/MRML/Widgets/qMRMLColorModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLColorModel.cxx
@@ -204,7 +204,7 @@ QStandardItem* qMRMLColorModel::itemFromColor(int color, int column)const
     {
     return 0;
     }
-  QModelIndexList indexes = this->match(QModelIndex(), qMRMLColorModel::ColorEntryRole,
+  QModelIndexList indexes = this->match(this->index(0,0), qMRMLColorModel::ColorEntryRole,
                                       color, 1,
                                       Qt::MatchExactly | Qt::MatchRecursive);
   while (indexes.size())
@@ -222,7 +222,7 @@ QStandardItem* qMRMLColorModel::itemFromColor(int color, int column)const
 //------------------------------------------------------------------------------
 QModelIndexList qMRMLColorModel::indexes(int color)const
 {
-  return this->match(QModelIndex(), qMRMLColorModel::ColorEntryRole, color, -1,
+  return this->match(this->index(0,0), qMRMLColorModel::ColorEntryRole, color, -1,
                      Qt::MatchExactly | Qt::MatchRecursive);
 }
 
@@ -248,6 +248,17 @@ QString qMRMLColorModel::nameFromColor(int entry)const
     return QString();
     }
   return QString(d->MRMLColorNode->GetColorName(entry));
+}
+
+//------------------------------------------------------------------------------
+int qMRMLColorModel::colorFromName(const QString& name)const
+{
+  Q_D(const qMRMLColorModel);
+  if (d->MRMLColorNode == 0)
+    {
+    return -1;
+    }
+  return d->MRMLColorNode->GetColorIndexByName(name.toLatin1());
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLColorModel.h
+++ b/Libs/MRML/Widgets/qMRMLColorModel.h
@@ -86,10 +86,14 @@ public:
   void setLabelInColorColumn(bool enable);
   bool isLabelInColorColumn()const;
 
-  /// Return the vtkMRMLNode associated to the node index.
-  /// -1 if the node index is not a MRML node (i.e. vtkMRMLScene, extra item...)
-  inline int colorFromIndex(const QModelIndex &nodeIndex)const;
-  int colorFromItem(QStandardItem* nodeItem)const;
+  /// Return the color entry associated to the index.
+  /// -1 if the index is not in the model.
+  /// \sa colorFromItem(), nameFromColor(), colorFromName()
+  inline int colorFromIndex(const QModelIndex &index)const;
+  /// Return the color entry associated to the item.
+  /// -1 if the item is not in the model.
+  /// \sa colorFromIndex(), nameFromColor(), colorFromName()
+  int colorFromItem(QStandardItem* item)const;
 
   QStandardItem* itemFromColor(int color, int column = 0)const;
   QModelIndexList indexes(int color)const;
@@ -99,7 +103,11 @@ public:
   QColor qcolorFromColor(int color)const;
 
   /// Return the name of the color \a colorEntry
+  /// \sa colorFromName(), colorFromIndex(), colorFromItem()
   QString nameFromColor(int colorEntry)const;
+  /// Return the color entry of the first color with name \a name.
+  /// \sa nameFromColor(), colorFromIndex(), colorFromItem()
+  int colorFromName(const QString& name)const;
 
   /// Overload the header data method for the veritical header
   /// so that can return the color index rather than the row

--- a/Libs/MRML/Widgets/qMRMLColorTableView.cxx
+++ b/Libs/MRML/Widgets/qMRMLColorTableView.cxx
@@ -142,3 +142,22 @@ bool qMRMLColorTableView::showOnlyNamedColors()const
 {
   return this->sortFilterProxyModel()->filterRegExp().isEmpty();
 }
+
+//------------------------------------------------------------------------------
+int qMRMLColorTableView::rowFromColorName(const QString& colorName)const
+{
+  int index = this->colorModel()->colorFromName(colorName);
+  return this->rowFromColorIndex(index);
+}
+
+//------------------------------------------------------------------------------
+int qMRMLColorTableView::rowFromColorIndex(int colorIndex)const
+{
+  QModelIndexList indexes = this->colorModel()->indexes(colorIndex);
+  if (indexes.isEmpty())
+    {
+    return -1;
+    }
+  QModelIndex sortedIndex = this->sortFilterProxyModel()->mapFromSource(indexes[0]);
+  return sortedIndex.row();
+}

--- a/Libs/MRML/Widgets/qMRMLColorTableView.h
+++ b/Libs/MRML/Widgets/qMRMLColorTableView.h
@@ -40,6 +40,9 @@ class vtkMRMLNode;
 class QMRML_WIDGETS_EXPORT qMRMLColorTableView : public QTableView
 {
   Q_OBJECT
+  /// This property show/hides the colors whose name are (none).
+  /// false by default.
+  /// \sa showOnlyNamedColors(), setShowOnlyNamedColors()
   Q_PROPERTY(bool showOnlyNamedColors READ showOnlyNamedColors WRITE setShowOnlyNamedColors)
 public:
   qMRMLColorTableView(QWidget *parent=0);
@@ -48,6 +51,13 @@ public:
   vtkMRMLColorNode* mrmlColorNode()const;
   qMRMLColorModel* colorModel()const;
   QSortFilterProxyModel* sortFilterProxyModel()const;
+
+  /// Return the row of the color with name \a colorName.
+  /// \sa rowFromColorIndex()
+  int rowFromColorName(const QString& colorName)const;
+  /// Return the row of the color of index \a colorIndex.
+  /// \sa rowFromColorIndex()
+  int rowFromColorIndex(int colorIndex)const;
 
   bool showOnlyNamedColors()const;
 


### PR DESCRIPTION
Move GetColorIndexByName from vtkMRMLColorTableNode
to vtkMRMLColorNode to expose it in qMRMLColorModel
and qMRMLColorTableView.

by @finetjul 