### PR TITLE
ENH: Expose functions for reproducing 3D view shortcuts

### DIFF
--- a/Libs/MRML/Widgets/qMRMLThreeDView.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.h
@@ -65,6 +65,17 @@ public:
   /// Returns the interactor style of the view
   //vtkInteractorObserver* interactorStyle()const;
 
+  /// Methods to rotate/reset the camera,
+  /// Can defined a view axis by its index (from 0 to 5)
+  /// or its label (defined in vtkMRMLViewNode::AxisLabels)
+  /// to rotate to the axis ranged in that order:
+  /// -X, +X, -Y, +Y, -Z, +Z
+  Q_INVOKABLE void rotateToViewAxis(unsigned int axisId);
+  Q_INVOKABLE void rotateToViewAxis(const std::string& axisLabel);
+  Q_INVOKABLE void resetCamera(bool resetRotation = true,
+                               bool resetTranslation = true,
+                               bool resetDistance = true);
+
 public slots:
 
   /// Set the MRML \a scene that should be listened for events


### PR DESCRIPTION
Before this, there was no simple way to ask programaticaly for the view
to reset the camera like it does when pressing the key pad shortcut keys.
Now the user can do this directly from python. This is potentially useful
for the scripted modules as well.
by @vovythevov 