### PR TITLE
ENH: Improve UpdateDisplayNodeFromVolumeNode

### DIFF
--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -906,40 +906,51 @@ vtkMRMLVolumeRenderingDisplayNode* vtkSlicerVolumeRenderingLogic
 // if needed create vtkMRMLVolumePropertyNode and vtkMRMLAnnotationROINode
 // and initioalize them from VolumeNode
 //----------------------------------------------------------------------------
-void vtkSlicerVolumeRenderingLogic::UpdateDisplayNodeFromVolumeNode(
-                                          vtkMRMLVolumeRenderingDisplayNode *displayNode,
-                                          vtkMRMLVolumeNode *volumeNode,
-                                          vtkMRMLVolumePropertyNode **propNode,
-                                          vtkMRMLAnnotationROINode **roiNode)
+void vtkSlicerVolumeRenderingLogic
+::UpdateDisplayNodeFromVolumeNode(vtkMRMLVolumeRenderingDisplayNode *displayNode,
+                                  vtkMRMLVolumeNode *volumeNode,
+                                  vtkMRMLVolumePropertyNode *propNode /* = NULL */,
+                                  vtkMRMLAnnotationROINode *roiNode /* = NULL */)
 {
+  if (displayNode == NULL)
+    {
+    vtkErrorMacro("vtkSlicerVolumeRenderingLogic::UpdateDisplayNodeFromVolumeNode: "
+                  << "display node pointer is null.")
+    return;
+    }
 
   if (volumeNode == NULL)
     {
     displayNode->SetAndObserveVolumeNodeID(NULL);
     return;
     }
-
   displayNode->SetAndObserveVolumeNodeID(volumeNode->GetID());
 
-  if (*propNode == NULL)
+  if (propNode == NULL && displayNode->GetVolumePropertyNode() == NULL)
     {
-    *propNode = vtkMRMLVolumePropertyNode::New();
-    this->GetMRMLScene()->AddNode(*propNode);
-    (*propNode)->Delete();
+    propNode = vtkMRMLVolumePropertyNode::New();
+    this->GetMRMLScene()->AddNode(propNode);
+    propNode->Delete();
     }
-  displayNode->SetAndObserveVolumePropertyNodeID((*propNode)->GetID());
+  if (propNode != NULL)
+    {
+    displayNode->SetAndObserveVolumePropertyNodeID(propNode->GetID());
+    }
 
-  if (*roiNode == NULL)
+  if (roiNode == NULL && displayNode->GetROINode() == NULL)
     {
-    *roiNode = vtkMRMLAnnotationROINode::New();
+    roiNode = vtkMRMLAnnotationROINode::New();
     // By default, the ROI is interactive. It could be an application setting.
-    (*roiNode)->SetInteractiveMode(1);
-    (*roiNode)->Initialize(this->GetMRMLScene());
+    roiNode->SetInteractiveMode(1);
+    roiNode->Initialize(this->GetMRMLScene());
     // by default, show the ROI only if cropping is enabled
-    (*roiNode)->SetDisplayVisibility(displayNode->GetCroppingEnabled());
-    (*roiNode)->Delete();
+    roiNode->SetDisplayVisibility(displayNode->GetCroppingEnabled());
+    roiNode->Delete();
     }
-  displayNode->SetAndObserveROINodeID((*roiNode)->GetID());
+  if (roiNode != NULL)
+    {
+    displayNode->SetAndObserveROINodeID(roiNode->GetID());
+    }
 
   //this->UpdateVolumePropertyFromImageData(displayNode);
   this->CopyDisplayToVolumeRenderingDisplayNode(displayNode);

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
@@ -211,15 +211,13 @@ public:
     vtkScalarsToColors* lut, vtkVolumeProperty* node);
 
   /// Update DisplayNode from VolumeNode,
-  /// If needed create vtkMRMLVolumePropertyNode and vtkMRMLAnnotationROINode
-  /// and initialize them from VolumeNode
-  void UpdateDisplayNodeFromVolumeNode(vtkMRMLVolumeRenderingDisplayNode *paramNode,
+  /// Can pass a VolumePropertyNode and a AnnotationROINode to be the display node.
+  /// If they are NULL and the display node does not already have any, new ones
+  /// will be created then set and observed to the display node.
+  void UpdateDisplayNodeFromVolumeNode(vtkMRMLVolumeRenderingDisplayNode *displayNode,
                                        vtkMRMLVolumeNode *volumeNode,
-                                       vtkMRMLVolumePropertyNode **propNode,
-                                       vtkMRMLAnnotationROINode **roiNode);
-  /// Utility function that calls UpdateDisplayNodeFromVolumeNode()
-  inline void UpdateDisplayNodeFromVolumeNode(vtkMRMLVolumeRenderingDisplayNode *paramNode,
-                                              vtkMRMLVolumeNode *volumeNode);
+                                       vtkMRMLVolumePropertyNode *propNode = NULL,
+                                       vtkMRMLAnnotationROINode *roiNode = NULL);
 
   /// \deprecated
   /// Create and add into the scene a vtkMRMLVolumeRenderingScenarioNode
@@ -343,15 +341,5 @@ private:
   vtkSlicerVolumeRenderingLogic(const vtkSlicerVolumeRenderingLogic&); // Not implemented
   void operator=(const vtkSlicerVolumeRenderingLogic&);               // Not implemented
 };
-
-//----------------------------------------------------------------------------
-void vtkSlicerVolumeRenderingLogic
-::UpdateDisplayNodeFromVolumeNode(vtkMRMLVolumeRenderingDisplayNode *paramNode,
-                                  vtkMRMLVolumeNode *volumeNode)
-{
-  vtkMRMLVolumePropertyNode *propNode = NULL;
-  vtkMRMLAnnotationROINode *roiNode = NULL;
-  this->UpdateDisplayNodeFromVolumeNode(paramNode, volumeNode, &propNode, &roiNode);
-}
 
 #endif

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -239,15 +239,11 @@ vtkMRMLVolumeRenderingDisplayNode* qSlicerVolumeRenderingModuleWidgetPrivate
   q->mrmlScene()->AddNode(displayNode);
   displayNode->Delete();
 
-  vtkMRMLVolumePropertyNode *propNode = NULL;
-  vtkMRMLAnnotationROINode  *roiNode = NULL;
-
   int wasModifying = displayNode->StartModify();
   // Init the volume rendering without the threshold info
   // of the Volumes module...
   displayNode->SetIgnoreVolumeDisplayNodeThreshold(1);
-  logic->UpdateDisplayNodeFromVolumeNode(displayNode, volumeNode,
-                                         &propNode, &roiNode);
+  logic->UpdateDisplayNodeFromVolumeNode(displayNode, volumeNode);
   // ... but then apply the user settings.
   displayNode->SetIgnoreVolumeDisplayNodeThreshold(
     this->IgnoreVolumesThresholdCheckBox->isChecked());


### PR DESCRIPTION
When using this method, one would think that if the displayNode already
has a volume property node and a region of interest node, no other node
will be created. This change makes the method behave that way and gets
rid of the method overload.