### PR TITLE
ENH: Add optional checkable column in qMRMLColorModel

### DIFF
--- a/Libs/MRML/Widgets/qMRMLCheckableNodeComboBox.h
+++ b/Libs/MRML/Widgets/qMRMLCheckableNodeComboBox.h
@@ -26,7 +26,11 @@
 
 class qMRMLCheckableNodeComboBoxPrivate;
 
+/// This class provides the ability to select(check) multiple nodes at a time
+/// instead of one (qMRMLNodeComboBox). Nodes are left untouched, the selection
+/// information only resides in the combobox.
 /// Nodes are unchecked by default.
+/// \sa qMRMLNodeComboBox
 class QMRML_WIDGETS_EXPORT qMRMLCheckableNodeComboBox
   : public qMRMLNodeComboBox
 {

--- a/Libs/MRML/Widgets/qMRMLColorListView.cxx
+++ b/Libs/MRML/Widgets/qMRMLColorListView.cxx
@@ -51,7 +51,7 @@ void qMRMLColorListViewPrivate::init()
   Q_Q(qMRMLColorListView);
 
   qMRMLColorModel* colorModel = new qMRMLColorModel(q);
-  colorModel->setLabelInColorColumn(true);
+  colorModel->setLabelColumn(0);
   QSortFilterProxyModel* sortFilterModel = new QSortFilterProxyModel(q);
   sortFilterModel->setSourceModel(colorModel);
   q->setModel(sortFilterModel);

--- a/Libs/MRML/Widgets/qMRMLColorModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLColorModel.cxx
@@ -39,7 +39,10 @@ qMRMLColorModelPrivate::qMRMLColorModelPrivate(qMRMLColorModel& object)
 {
   this->CallBack = vtkSmartPointer<vtkCallbackCommand>::New();
   this->NoneEnabled = false;
-  this->LabelInColor = false;
+  this->ColorColumn = 0;
+  this->LabelColumn = 1;
+  this->OpacityColumn = 2;
+  this->CheckableColumn = -1;
 }
 
 //------------------------------------------------------------------------------
@@ -57,18 +60,46 @@ void qMRMLColorModelPrivate::init()
   Q_Q(qMRMLColorModel);
   this->CallBack->SetClientData(q);
   this->CallBack->SetCallback(qMRMLColorModel::onMRMLNodeEvent);
-  q->setColumnCount(3);
-  if (this->LabelInColor)
+  this->updateColumnCount();
+  QStringList headerLabels;
+  for (int i = 0; i <= this->maxColumnId(); ++i)
     {
-    q->setHorizontalHeaderLabels(QStringList() << "Color" << "Label" << "Opacity");
+    headerLabels << "";
     }
-  else
+  if (q->colorColumn() != -1)
     {
-    q->setHorizontalHeaderLabels(QStringList() << "" << "Label" << "Opacity");
+    headerLabels[q->colorColumn()] = "Color";
+    }
+  if (q->labelColumn() != -1)
+    {
+    headerLabels[q->labelColumn()] = "Label";
+    }
+  if (q->opacityColumn() != -1)
+    {
+    headerLabels[q->opacityColumn()] = "Opacity";
     }
   QObject::connect(q, SIGNAL(itemChanged(QStandardItem*)),
                    q, SLOT(onItemChanged(QStandardItem*)),
                    Qt::UniqueConnection);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLColorModelPrivate::updateColumnCount()
+{
+  Q_Q(qMRMLColorModel);
+  const int max = this->maxColumnId();
+  q->setColumnCount(max + 1);
+}
+
+//------------------------------------------------------------------------------
+int qMRMLColorModelPrivate::maxColumnId()const
+{
+  int maxId = 0; // informations (scene, node uid... ) are stored in the 1st column
+  maxId = qMax(maxId, this->ColorColumn);
+  maxId = qMax(maxId, this->LabelColumn);
+  maxId = qMax(maxId, this->OpacityColumn);
+  maxId = qMax(maxId, this->CheckableColumn);
+  return maxId;
 }
 
 //------------------------------------------------------------------------------
@@ -161,23 +192,65 @@ bool qMRMLColorModel::noneEnabled()const
 }
 
 //------------------------------------------------------------------------------
-void qMRMLColorModel::setLabelInColorColumn(bool enable)
+int qMRMLColorModel::colorColumn()const
 {
-  Q_D(qMRMLColorModel);
-  if (d->LabelInColor == enable)
-    {
-    return;
-    }
-  d->LabelInColor = enable;
-  this->updateNode();
+  Q_D(const qMRMLColorModel);
+  return d->ColorColumn;
 }
 
 //------------------------------------------------------------------------------
-bool qMRMLColorModel::isLabelInColorColumn()const
+void qMRMLColorModel::setColorColumn(int column)
+{
+  Q_D(qMRMLColorModel);
+  d->ColorColumn = column;
+  d->updateColumnCount();
+}
+
+//------------------------------------------------------------------------------
+int qMRMLColorModel::labelColumn()const
 {
   Q_D(const qMRMLColorModel);
-  return d->LabelInColor;
+  return d->LabelColumn;
 }
+
+//------------------------------------------------------------------------------
+void qMRMLColorModel::setLabelColumn(int column)
+{
+  Q_D(qMRMLColorModel);
+  d->LabelColumn = column;
+  d->updateColumnCount();
+}
+
+//------------------------------------------------------------------------------
+int qMRMLColorModel::opacityColumn()const
+{
+  Q_D(const qMRMLColorModel);
+  return d->OpacityColumn;
+}
+
+//------------------------------------------------------------------------------
+void qMRMLColorModel::setOpacityColumn(int column)
+{
+  Q_D(qMRMLColorModel);
+  d->OpacityColumn = column;
+  d->updateColumnCount();
+}
+
+//------------------------------------------------------------------------------
+int qMRMLColorModel::checkableColumn()const
+{
+  Q_D(const qMRMLColorModel);
+  return d->CheckableColumn;
+}
+
+//------------------------------------------------------------------------------
+void qMRMLColorModel::setCheckableColumn(int column)
+{
+  Q_D(qMRMLColorModel);
+  d->CheckableColumn = column;
+  d->updateColumnCount();
+}
+
 
 //------------------------------------------------------------------------------
 int qMRMLColorModel::colorFromItem(QStandardItem* colorItem)const
@@ -297,93 +370,87 @@ void qMRMLColorModel::updateItemFromColor(QStandardItem* item, int color, int co
     }
   item->setData(color, qMRMLColorModel::ColorEntryRole);
   double rgba[4] = {0.,0.,0.,1.};
-  bool validColor = d->MRMLColorNode->GetColor(color, rgba);
+
   QString colorName = d->MRMLColorNode->GetNamesInitialised() ?
     d->MRMLColorNode->GetColorName(color) : "";
-  switch (column)
+  if (column == d->ColorColumn)
     {
-    case qMRMLColorModel::ColorColumn:
-    default:
+    QPixmap pixmap;
+    const bool validColor = d->MRMLColorNode->GetColor(color, rgba);
+    if (validColor)
       {
-      QPixmap pixmap;
-      if (validColor)
-        {
-        // It works to set just a QColor but if the model gets into a QComboBox,
-        // the currently selected item doesn't get a decoration.
-        // TODO: Cache the pixmap as it is expensive to compute and it is done
-        // for ALL the colors of the node anytime a color is changed.
-        pixmap = qMRMLUtils::createColorPixmap(
-          qApp->style(), QColor::fromRgbF(rgba[0], rgba[1], rgba[2]));
-        item->setData(pixmap, Qt::DecorationRole);
-        item->setData(QColor::fromRgbF(rgba[0], rgba[1], rgba[2]), qMRMLColorModel::ColorRole);
-        }
-      else
-        {
-        item->setData(QVariant(), Qt::DecorationRole);
-        item->setData(QColor(), qMRMLColorModel::ColorRole);
-        }
-      if (d->LabelInColor)
-        {
-        item->setText(colorName);
-        item->setData(QVariant(),Qt::SizeHintRole);
-        }
-      else
-        {
-        item->setText(QString());
-        item->setData((validColor ? pixmap.size() : QVariant()),Qt::SizeHintRole);
-        }
-      item->setToolTip(colorName);
-      break;
+      // It works to set just a QColor but if the model gets into a QComboBox,
+      // the currently selected item doesn't get a decoration.
+      // TODO: Cache the pixmap as it is expensive to compute and it is done
+      // for ALL the colors of the node anytime a color is changed.
+      pixmap = qMRMLUtils::createColorPixmap(
+        qApp->style(), QColor::fromRgbF(rgba[0], rgba[1], rgba[2]));
+      item->setData(pixmap, Qt::DecorationRole);
+      item->setData(QColor::fromRgbF(rgba[0], rgba[1], rgba[2]), qMRMLColorModel::ColorRole);
       }
-    case qMRMLColorModel::LabelColumn:
-      item->setText(colorName);
-      // check for terminology
-      if (this->mrmlColorLogic() &&
-          this->mrmlColorLogic()->TerminologyExists(d->MRMLColorNode->GetName()))
+    else
+      {
+      item->setData(QVariant(), Qt::DecorationRole);
+      item->setData(QColor(), qMRMLColorModel::ColorRole);
+      }
+    item->setData(validColor && column != d->LabelColumn ?
+      pixmap.size() : QVariant(), Qt::SizeHintRole);
+    item->setToolTip(colorName);
+    }
+  if (column == d->LabelColumn)
+    {
+    item->setText(colorName);
+    // check for terminology
+    if (this->mrmlColorLogic() &&
+        this->mrmlColorLogic()->TerminologyExists(d->MRMLColorNode->GetName()))
+      {
+      const char *lutName = d->MRMLColorNode->GetName();
+      std::string category = this->mrmlColorLogic()->GetSegmentedPropertyCategoryCodeMeaning(color, lutName);
+      std::string type = this->mrmlColorLogic()->GetSegmentedPropertyTypeCodeMeaning(color, lutName);
+      std::string typeMod = this->mrmlColorLogic()->GetSegmentedPropertyTypeModifierCodeMeaning(color, lutName);
+      std::string region = this->mrmlColorLogic()->GetAnatomicRegionCodeMeaning(color, lutName);
+      std::string regionMod = this->mrmlColorLogic()->GetAnatomicRegionModifierCodeMeaning(color, lutName);
+      QString terminology = QString("Terminology:");
+      // only show the not empty terminology terms
+      if (!category.empty())
         {
-        const char *lutName = d->MRMLColorNode->GetName();
-        std::string category = this->mrmlColorLogic()->GetSegmentedPropertyCategoryCodeMeaning(color, lutName);
-        std::string type = this->mrmlColorLogic()->GetSegmentedPropertyTypeCodeMeaning(color, lutName);
-        std::string typeMod = this->mrmlColorLogic()->GetSegmentedPropertyTypeModifierCodeMeaning(color, lutName);
-        std::string region = this->mrmlColorLogic()->GetAnatomicRegionCodeMeaning(color, lutName);
-        std::string regionMod = this->mrmlColorLogic()->GetAnatomicRegionModifierCodeMeaning(color, lutName);
-        QString terminology = QString("Terminology:");
-        // only show the not empty terminology terms
-        if (!category.empty())
-          {
-          terminology = terminology + QString("\nSegmentedPropertyCategory: %1").arg(category.c_str());
-          }
-        if (!type.empty())
-          {
-          terminology = terminology + QString("\nSegmentedPropertyType: %1").arg(type.c_str());
-          }
-        if (!typeMod.empty())
-          {
-          terminology = terminology + QString("\nSegmentedPropertyTypeModifier: %1").arg(typeMod.c_str());
-          }
-        if (!region.empty())
-          {
-          terminology = terminology + QString("\nAnatomicRegion: %1").arg(region.c_str());
-          }
-        if (!regionMod.empty())
-          {
-          terminology = terminology + QString("\nAnatomicRegionModifier: %1").arg(regionMod.c_str());
-          }
-        // check if no terminology was found and use an empty tool tip
-        if (!terminology.compare("Terminology:"))
-          {
-          terminology = QString("");
-          }
-        item->setToolTip(terminology);
+        terminology = terminology + QString("\nSegmentedPropertyCategory: %1").arg(category.c_str());
         }
-      else
+      if (!type.empty())
         {
-        item->setToolTip("");
+        terminology = terminology + QString("\nSegmentedPropertyType: %1").arg(type.c_str());
         }
-      break;
-    case qMRMLColorModel::OpacityColumn:
-      item->setData(QString::number(rgba[3],'f',2), Qt::DisplayRole);
-      break;
+      if (!typeMod.empty())
+        {
+        terminology = terminology + QString("\nSegmentedPropertyTypeModifier: %1").arg(typeMod.c_str());
+        }
+      if (!region.empty())
+        {
+        terminology = terminology + QString("\nAnatomicRegion: %1").arg(region.c_str());
+        }
+      if (!regionMod.empty())
+        {
+        terminology = terminology + QString("\nAnatomicRegionModifier: %1").arg(regionMod.c_str());
+        }
+      // check if no terminology was found and use an empty tool tip
+      if (!terminology.compare("Terminology:"))
+        {
+        terminology = QString("");
+        }
+      item->setToolTip(terminology);
+      }
+    else
+      {
+      item->setToolTip("");
+      }
+    }
+  if (column == d->OpacityColumn)
+    {
+    item->setData(QString::number(rgba[3],'f',2), Qt::DisplayRole);
+    }
+  if (column == d->CheckableColumn)
+    {
+    item->setCheckable(true);
     }
 }
 
@@ -396,22 +463,18 @@ void qMRMLColorModel::updateColorFromItem(int color, QStandardItem* item)
     {
     return;
     }
-  switch(item->column())
+  if (item->column() == d->ColorColumn)
     {
-    case qMRMLColorModel::ColorColumn:
-      {
-      QColor rgba(item->data(qMRMLColorModel::ColorRole).value<QColor>());
-      colorTableNode->SetColor(color, rgba.redF(), rgba.greenF(), rgba.blueF(), rgba.alphaF());
-      break;
-      }
-    case qMRMLColorModel::LabelColumn:
-      colorTableNode->SetColorName(color, item->text().toLatin1());
-      break;
-    case qMRMLColorModel::OpacityColumn:
-      colorTableNode->SetOpacity(color, item->data(Qt::DisplayRole).toDouble());
-      break;
-    default:
-      break;
+    QColor rgba(item->data(qMRMLColorModel::ColorRole).value<QColor>());
+    colorTableNode->SetColor(color, rgba.redF(), rgba.greenF(), rgba.blueF());
+    }
+  else if (item->column() == d->LabelColumn)
+    {
+    colorTableNode->SetColorName(color, item->text().toLatin1());
+    }
+  else if (item->column() == d->OpacityColumn)
+    {
+    colorTableNode->SetOpacity(color, item->data(Qt::DisplayRole).toDouble());
     }
 }
 

--- a/Libs/MRML/Widgets/qMRMLColorModel.h
+++ b/Libs/MRML/Widgets/qMRMLColorModel.h
@@ -46,6 +46,29 @@ class QMRML_WIDGETS_EXPORT qMRMLColorModel : public QStandardItemModel
   Q_ENUMS(ItemDataRole)
   Q_PROPERTY(bool noneEnabled READ noneEnabled WRITE setNoneEnabled)
 
+  /// The color column contains a Qt::DecorationRole with a pixmap of the color,
+  /// the ColorRole with the color QColor, the colorName as Qt::TooltipRole
+  /// 0 by default.
+  /// \sa colorColumn(), setColorColumn(), labelColumn, opacityColumn,
+  /// checkableColumn
+  Q_PROPERTY(int colorColumn READ colorColumn WRITE setColorColumn)
+  /// The label column contains the colorName as Qt::DisplayRole.
+  /// 1 by default.
+  /// \sa labelColumn(), setLabelColumn(), colorColumn, opacityColumn,
+  /// checkableColumn
+  Q_PROPERTY(int labelColumn READ labelColumn WRITE setLabelColumn)
+  /// The opacity column contains the color opacity as Qt::DisplayRole
+  /// 2 by default.
+  /// \sa opacityColumn(), setOpacityColumn(), colorColumn, labelColumn,
+  /// checkableColumn
+  Q_PROPERTY(int opacityColumn READ opacityColumn WRITE setOpacityColumn)
+  /// The checkable column adds a checkbox for each entry.
+  /// Note that the checkboxes are unlinked to the color table node.
+  /// -1 by default
+  /// \sa checkableColumn(), setCheckableColumn(), colorColumn, labelColumn,
+  /// opacityColumn
+  Q_PROPERTY(int checkableColumn READ checkableColumn WRITE setCheckableColumn)
+
 public:
   typedef QAbstractItemModel Superclass;
   qMRMLColorModel(QObject *parent=0);
@@ -60,15 +83,6 @@ public:
   };
 
 
-  /// The color column contains a Qt::DecorationRole with a pixmap of the color,
-  /// the ColorRole with the color QColor, the colorName as Qt::TooltipRole and
-  /// the colorName as Qt::DisplayRole only if LabelInColorColumn is true.
-  enum Columns{
-    ColorColumn = 0,
-    LabelColumn = 1,
-    OpacityColumn = 2
-  };
-
   void setMRMLColorNode(vtkMRMLColorNode* node);
   vtkMRMLColorNode* mrmlColorNode()const;
 
@@ -82,9 +96,17 @@ public:
   void setNoneEnabled(bool enable);
   bool noneEnabled()const;
 
-  /// Control wether or not displaying the label in the color column
-  void setLabelInColorColumn(bool enable);
-  bool isLabelInColorColumn()const;
+  int colorColumn()const;
+  void setColorColumn(int column);
+
+  int labelColumn()const;
+  void setLabelColumn(int column);
+
+  int opacityColumn()const;
+  void setOpacityColumn(int column);
+
+  int checkableColumn()const;
+  void setCheckableColumn(int column);
 
   /// Return the vtkMRMLNode associated to the node index.
   /// -1 if the node index is not a MRML node (i.e. vtkMRMLScene, extra item...)

--- a/Libs/MRML/Widgets/qMRMLColorModel_p.h
+++ b/Libs/MRML/Widgets/qMRMLColorModel_p.h
@@ -58,11 +58,18 @@ public:
   virtual ~qMRMLColorModelPrivate();
   void init();
 
+  void updateColumnCount();
+  virtual int maxColumnId()const;
+
+  vtkSmartPointer<vtkMRMLColorLogic>  ColorLogic;
   vtkSmartPointer<vtkCallbackCommand> CallBack;
   vtkSmartPointer<vtkMRMLColorNode>   MRMLColorNode;
-  bool                                NoneEnabled;
-  bool                                LabelInColor;
-  vtkSmartPointer<vtkMRMLColorLogic>  ColorLogic;
+
+  bool NoneEnabled;
+  int ColorColumn;
+  int LabelColumn;
+  int OpacityColumn;
+  int CheckableColumn;
 };
 
 #endif

--- a/Libs/MRML/Widgets/qMRMLColorTableView.cxx
+++ b/Libs/MRML/Widgets/qMRMLColorTableView.cxx
@@ -57,15 +57,15 @@ void qMRMLColorTableViewPrivate::init()
 
   qMRMLColorModel* colorModel = new qMRMLColorModel(q);
   QSortFilterProxyModel* sortFilterModel = new QSortFilterProxyModel(q);
-  sortFilterModel->setFilterKeyColumn(qMRMLColorModel::LabelColumn);
+  sortFilterModel->setFilterKeyColumn(colorModel->labelColumn());
   sortFilterModel->setSourceModel(colorModel);
   q->setModel(sortFilterModel);
 
   q->setSelectionBehavior(QAbstractItemView::SelectRows);
   q->horizontalHeader()->setStretchLastSection(false);
-  q->horizontalHeader()->setResizeMode(qMRMLColorModel::ColorColumn, QHeaderView::ResizeToContents);
-  q->horizontalHeader()->setResizeMode(qMRMLColorModel::LabelColumn, QHeaderView::Stretch);
-  q->horizontalHeader()->setResizeMode(qMRMLColorModel::OpacityColumn, QHeaderView::ResizeToContents);
+  q->horizontalHeader()->setResizeMode(colorModel->colorColumn(), QHeaderView::ResizeToContents);
+  q->horizontalHeader()->setResizeMode(colorModel->labelColumn(), QHeaderView::Stretch);
+  q->horizontalHeader()->setResizeMode(colorModel->opacityColumn(), QHeaderView::ResizeToContents);
 
   q->setItemDelegate(new qMRMLItemDelegate(q));
 }


### PR DESCRIPTION
* Remove LabelInColorColumn to be more consistent with qMRMLSceneModel
columns.
* Fix updateColorFromItem() that was always forcing the color opacity to be
1.0 because QColor rgba was always opaque.

by @finetjul & @vovythevov 