### PR TITLE
ColumnIndex bug in LabelStatistics.py

### DIFF
--- a/Modules/Scripted/LabelStatistics/LabelStatistics.py
+++ b/Modules/Scripted/LabelStatistics/LabelStatistics.py
@@ -444,8 +444,8 @@ class LabelStatisticsLogic(ScriptedLoadableModuleLogic):
       col.SetName(k)
     for i in self.labelStats["Labels"]:
       rowIndex = table.AddEmptyRow()
+      columnIndex = 0
       if colorNode:
-        columnIndex = 0
         table.SetCellText(rowIndex, columnIndex, colorNode.GetColorName(i))
         columnIndex += 1
       # Add other values


### PR DESCRIPTION
if there is no ```self.colorNode``` defined (it is None) in ```LabelStatisticsLogic```, the columnIndex variable is never initialized