### PR TITLE
TEST: remove obsolete unstructured grid tests

### DIFF
--- a/Libs/MRML/Core/Testing/CMakeLists.txt
+++ b/Libs/MRML/Core/Testing/CMakeLists.txt
@@ -201,9 +201,6 @@ simple_test( vtkMRMLTransformDisplayNodeTest1 )
 simple_test( vtkMRMLTransformNodeTest1 )
 simple_test( vtkMRMLTransformStorageNodeTest1 )
 simple_test( vtkMRMLUnitNodeTest1 )
-simple_test( vtkMRMLUnstructuredGridDisplayNodeTest1 )
-simple_test( vtkMRMLUnstructuredGridNodeTest1 )
-simple_test( vtkMRMLUnstructuredGridStorageNodeTest1 )
 simple_test( vtkMRMLVectorVolumeDisplayNodeTest1 )
 simple_test( vtkMRMLVectorVolumeNodeTest1 )
 simple_test( vtkMRMLViewNodeTest1 )
@@ -233,7 +230,7 @@ set( ScenesToTest
   multi_display.mrml
   name.mrml
   SlicePipeline.mrml
-  unstruct_grid.mrml
+  volumetric_mesh.mrml
   vol_and_cube_camera.mrml
   vol_and_cube.mrml
   vol.mrml

--- a/Libs/MRML/Core/Testing/unstruct_grid.mrml
+++ b/Libs/MRML/Core/Testing/unstruct_grid.mrml
@@ -1,9 +1,0 @@
-<MRML>
-<UnstructuredGrid
- id="vtkMRMLUnstructuredGridNode1" name="PentaHexa.vtk"  hideFromEditors="false" storageNodeRef="vtkMRMLUnstructuredGridStorageNode1" displayNodeRef="vtkMRMLUnstructuredGridDisplayNode1" ></UnstructuredGrid>
-<UnstructuredGridStorage
- id="vtkMRMLUnstructuredGridStorageNode1" name=""  hideFromEditors="true" fileName="TestData/PentaHexa.vtk" ></UnstructuredGridStorage>
-<UnstructuredGridDisplay
- id="vtkMRMLUnstructuredGridDisplayNode1" name=""  hideFromEditors="true"
- shrinkFactor="0.8" color="0.7 0.1 0.7" ambient="0" diffuse="1" specular="0" power="1" opacity="1" visibility="true" clipping="false" backfaceCulling="true" scalarVisibility="false" vectorVisibility="false" tensorVisibility="false" scalarRange="0 100"></UnstructuredGridDisplay>
-</MRML>

--- a/Libs/MRML/Core/Testing/volumetric_mesh.mrml
+++ b/Libs/MRML/Core/Testing/volumetric_mesh.mrml
@@ -1,0 +1,14 @@
+<MRML>
+<Model
+ id="vtkMRMLModelNode1" name="PentaHexa.vtk"  hideFromEditors="false"
+ storageNodeRef="vtkMRMLModelStorageNode1" displayNodeRef="vtkMRMLModelDisplayNode1" ></Model>
+<ModelStorage
+ id="vtkMRMLModelStorageNode1" name=""  hideFromEditors="true"
+ fileName="TestData/PentaHexa.vtk" ></ModelStorage>
+<ModelDisplay
+ id="vtkMRMLModelDisplayNode1" name=""  hideFromEditors="true"
+ color="0.7 0.1 0.7" ambient="0" diffuse="1" specular="0" power="1"
+ opacity="1" visibility="true" clipping="false" backfaceCulling="true"
+ scalarVisibility="false" vectorVisibility="false" tensorVisibility="false"
+ scalarRange="0 100"></ModelDisplay>
+</MRML>


### PR DESCRIPTION
vtkMRMLUnstructuredGridNode and its components were removed in r25666 [1], within the pull request #647, but the tests were not undefined in `Libs/MRML/Core/Testing/CMakeLists.txt`.

[1] http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=25666

Removes the following failing tests from CDash [2]:
* vtkMRMLSceneImportTest_unstruct_grid.mrml
* vtkMRMLSCeneTest2_unstruct_grid.mrml
* vtkMRMLUnstructuredGridDisplayNodeTest1
* vtkMRMLUnstructuredGridNodeTest1
* vtkMRMLUnstructuredGridStorageNodeTest1

[2] http://slicer.cdash.org/viewTest.php?onlydelta&buildid=960672

Replace scene tests using unstructured grid by scene tests using
volumetric mesh.
* vtkMRMLSceneImportTest_volumetric_mesh.mrml
* vtkMRMLSCeneTest2_volumetric_mesh.mrml

Issue reported by @lassoan 