### PR TITLE
ENH: Improved Crop Volume module

### DIFF
--- a/Modules/Loadable/CropVolume/Logic/CMakeLists.txt
+++ b/Modules/Loadable/CropVolume/Logic/CMakeLists.txt
@@ -16,6 +16,7 @@ set(${KIT}_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
   vtkSlicer${MODULE_NAME}ModuleMRML
   vtkSlicerAnnotationsModuleMRML
+  vtkSlicerMarkupsModuleMRML
   vtkSlicerVolumesModuleLogic
   )
 

--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.cxx
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.cxx
@@ -31,6 +31,7 @@
 #include <vtkMRMLDiffusionWeightedVolumeDisplayNode.h>
 #include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLLinearTransformNode.h>
+#include <vtkMRMLMarkupsFiducialNode.h>
 #include <vtkMRMLVectorVolumeNode.h>
 #include <vtkMRMLVectorVolumeDisplayNode.h>
 #include <vtkMRMLTransformNode.h>
@@ -38,13 +39,19 @@
 #include <vtkMRMLAnnotationROINode.h>
 
 // VTK includes
+#include <vtkBoundingBox.h>
+#include <vtkGeneralTransform.h>
 #include <vtkImageData.h>
 #include <vtkImageClip.h>
 #include <vtkNew.h>
 #include <vtkMatrix4x4.h>
+#include <vtkMatrix3x3.h>
 #include <vtkObjectFactory.h>
 #include <vtkSmartPointer.h>
+#include <vtkTransform.h>
 #include <vtkVersion.h>
+
+#include <vtkAddonMathUtilities.h>
 
 // STD includes
 #include <cassert>
@@ -114,563 +121,649 @@ void vtkSlicerCropVolumeLogic::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
+void vtkSlicerCropVolumeLogic::RegisterNodes()
+{
+  if (!this->GetMRMLScene())
+    {
+    return;
+    }
+  this->GetMRMLScene()->RegisterNodeClass(vtkSmartPointer<vtkMRMLCropVolumeParametersNode>::New());
+}
+
+//----------------------------------------------------------------------------
 int vtkSlicerCropVolumeLogic::Apply(vtkMRMLCropVolumeParametersNode* pnode)
 {
   vtkMRMLScene *scene = this->GetMRMLScene();
+  if (!scene)
+    {
+    vtkErrorMacro("CropVolume: Invalid scene");
+    return -1;
+    }
 
+  // Check inputs
+  if (!pnode)
+    {
+    vtkErrorMacro("CropVolume: Invalid parameter node");
+    return -1;
+    }
   vtkMRMLVolumeNode *inputVolume =
     vtkMRMLVolumeNode::SafeDownCast(scene->GetNodeByID(pnode->GetInputVolumeNodeID()));
   vtkMRMLAnnotationROINode *inputROI =
     vtkMRMLAnnotationROINode::SafeDownCast(scene->GetNodeByID(pnode->GetROINodeID()));
-
-  if(!inputVolume || !inputROI)
+  if (!inputVolume || !inputROI)
     {
-    std::cerr << "Failed to look up input volume and/or ROI!" << std::endl;
+    vtkErrorMacro("CropVolume: Invalid input volume or ROI");
     return -1;
     }
-
-  vtkMRMLVolumeNode *outputVolume = NULL;
-
-  // make sure inputs are initialized
-  if(!inputVolume || !inputROI )
+  if (vtkMRMLDiffusionTensorVolumeNode::SafeDownCast(inputVolume))
     {
-    std::cerr << "CropVolume: Inputs are not initialized" << std::endl;
-    return -1;
-    }
-
-  // check the output volume type
-  vtkMRMLDiffusionTensorVolumeNode *dtvnode= vtkMRMLDiffusionTensorVolumeNode::SafeDownCast(inputVolume);
-  vtkMRMLDiffusionWeightedVolumeNode *dwvnode= vtkMRMLDiffusionWeightedVolumeNode::SafeDownCast(inputVolume);
-  vtkMRMLVectorVolumeNode *vvnode= vtkMRMLVectorVolumeNode::SafeDownCast(inputVolume);
-  vtkMRMLScalarVolumeNode *svnode = vtkMRMLScalarVolumeNode::SafeDownCast(inputVolume);
-
-  if(!this->Internal->VolumesLogic)
-    {
-      std::cerr << "CropVolume: ERROR: failed to get hold of Volumes logic" << std::endl;
-      return -2;
-    }
-
-  std::ostringstream outSS;
-  double outputSpacing[3], spacingScaleConst = pnode->GetSpacingScalingConst();
-  outSS << inputVolume->GetName() << "-subvolume-scale_" << spacingScaleConst;
-
-  if(dtvnode)
-    {
-    std::cerr << "CropVolume: ERROR: Diffusion tensor volumes are not supported by this module!" << std::endl;
+    vtkErrorMacro("CropVolume: Diffusion tensor volumes are not supported by this module");
     return -2;
     }
-  // need to create clones and display nodes here, since
-  // VolumesLogic::CloneVolume() handles only ScalarVolumeNode's
-  else if(dwvnode)
+
+  // Check/create output volume
+  vtkMRMLVolumeNode *outputVolume =
+    vtkMRMLVolumeNode::SafeDownCast(scene->GetNodeByID(pnode->GetOutputVolumeNodeID()));
+  if (outputVolume)
     {
-    vtkNew<vtkMRMLDiffusionWeightedVolumeNode> outputDWVNode;
-    outputDWVNode->CopyWithScene(dwvnode);
-    vtkNew<vtkMRMLDiffusionWeightedVolumeDisplayNode> dwiDisplayNode;
-    dwiDisplayNode->CopyWithScene(dwvnode->GetDisplayNode());
-    scene->AddNode(dwiDisplayNode.GetPointer());
-
-    vtkNew<vtkImageData> outputImageData;
-    outputImageData->DeepCopy(dwvnode->GetImageData());
-    outputDWVNode->SetAndObserveImageData(outputImageData.GetPointer());
-
-    outputDWVNode->SetAndObserveDisplayNodeID(dwiDisplayNode->GetID());
-    outputDWVNode->SetAndObserveStorageNodeID(NULL);
-    scene->AddNode(outputDWVNode.GetPointer());
-
-    outputVolume = outputDWVNode.GetPointer();
-    }
-  else if(vvnode)
-    {
-    vtkNew<vtkMRMLVectorVolumeNode> outputVVNode;
-    outputVVNode->CopyWithScene(dwvnode);
-    vtkNew<vtkMRMLVectorVolumeDisplayNode> vvDisplayNode;
-    vvDisplayNode->CopyWithScene(vvnode->GetDisplayNode());
-    scene->AddNode(vvDisplayNode.GetPointer());
-
-    vtkNew<vtkImageData> outputImageData;
-    outputImageData->DeepCopy(vvnode->GetImageData());
-    outputVVNode->SetAndObserveImageData(outputImageData.GetPointer());
-
-    outputVVNode->SetAndObserveDisplayNodeID(vvDisplayNode->GetID());
-    outputVVNode->SetAndObserveStorageNodeID(NULL);
-    scene->AddNode(outputVVNode.GetPointer());
-
-    outputVolume = outputVVNode.GetPointer();
-    }
-  else if(svnode)
-    {
-    outputVolume = this->Internal->VolumesLogic->CloneVolume(this->GetMRMLScene(), inputVolume, outSS.str().c_str());
+    // Output volume is provided, use that (if compatible)
+    if (outputVolume->GetClassName() != inputVolume->GetClassName())
+      {
+      vtkErrorMacro("CropVolume: output volume (" << outputVolume->GetClassName() <<
+        ") is not compatible with input volume (" << inputVolume->GetClassName() << ")");
+      return -1;
+      }
     }
   else
     {
-    std::cerr << "Input volume not recognized!" << std::endl;
-    return -1;
+    // Create compatible output volume
+    if (!this->Internal->VolumesLogic)
+      {
+      vtkErrorMacro("CropVolume: invalid Volumes logic");
+      return -2;
+      }
+    std::ostringstream outSS;
+    outSS << (inputVolume->GetName() ? inputVolume->GetName() : "Volume") << " cropped";
+    outputVolume = this->Internal->VolumesLogic->CloneVolume(this->GetMRMLScene(), inputVolume, outSS.str().c_str());
+    if (!outputVolume)
+      {
+      vtkErrorMacro("CropVolume: failed to create output volume");
+      return -2;
+      }
     }
 
-  outputVolume->SetName(outSS.str().c_str());
-
+  int errorCode = 0;
   if(pnode->GetVoxelBased()) // voxel based cropping selected
     {
-      this->CropVoxelBased(inputROI,inputVolume,outputVolume);
+    errorCode = this->CropVoxelBased(inputROI, inputVolume, outputVolume);
     }
   else  // interpolated cropping selected
     {
-      vtkMRMLScalarVolumeNode *refVolume;
-      vtkMatrix4x4 *inputRASToIJK = vtkMatrix4x4::New();
-      vtkMatrix4x4 *inputIJKToRAS = vtkMatrix4x4::New();
-      vtkMatrix4x4 *outputRASToIJK = vtkMatrix4x4::New();
-      vtkMatrix4x4 *outputIJKToRAS = vtkMatrix4x4::New();
-
-      refVolume = this->Internal->VolumesLogic->CreateAndAddLabelVolume(
-          this->GetMRMLScene(), inputVolume, "CropVolume_ref_volume");
-      refVolume->HideFromEditorsOn();
-
-      refVolume->GetRASToIJKMatrix(inputRASToIJK);
-      refVolume->GetIJKToRASMatrix(inputIJKToRAS);
-      outputRASToIJK->Identity();
-      outputIJKToRAS->Identity();
-
-      // prepare the resampling reference volume
-      double roiRadius[3], roiXYZ[3];
-      inputROI->GetRadiusXYZ(roiRadius);
-      inputROI->GetXYZ(roiXYZ);
-
-      double* inputSpacing = inputVolume->GetSpacing();
-      double minSpacing = inputSpacing[0];
-      if (minSpacing > inputSpacing[1])
-        {
-          minSpacing = inputSpacing[1];
-        }
-      if (minSpacing > inputSpacing[2])
-        {
-          minSpacing = inputSpacing[2];
-        }
-
-      if (pnode->GetIsotropicResampling())
-        {
-          outputSpacing[0] = minSpacing * spacingScaleConst;
-          outputSpacing[1] = minSpacing * spacingScaleConst;
-          outputSpacing[2] = minSpacing * spacingScaleConst;
-        }
-      else
-        {
-          outputSpacing[0] = inputSpacing[0] * spacingScaleConst;
-          outputSpacing[1] = inputSpacing[1] * spacingScaleConst;
-          outputSpacing[2] = inputSpacing[2] * spacingScaleConst;
-        }
-
-      int outputExtent[3];
-
-      outputExtent[0] = roiRadius[0] / outputSpacing[0] * 2.;
-      outputExtent[1] = roiRadius[1] / outputSpacing[1] * 2.;
-      outputExtent[2] = roiRadius[2] / outputSpacing[2] * 2.;
-
-      outputIJKToRAS->SetElement(0, 0, outputSpacing[0]);
-      outputIJKToRAS->SetElement(1, 1, outputSpacing[1]);
-      outputIJKToRAS->SetElement(2, 2, outputSpacing[2]);
-
-      outputIJKToRAS->SetElement(0, 3,
-          roiXYZ[0] - roiRadius[0] + outputSpacing[0] * .5);
-      outputIJKToRAS->SetElement(1, 3,
-          roiXYZ[1] - roiRadius[1] + outputSpacing[1] * .5);
-      outputIJKToRAS->SetElement(2, 3,
-          roiXYZ[2] - roiRadius[2] + outputSpacing[2] * .5);
-
-      // account for the ROI parent transform, if present
-      vtkMRMLTransformNode *roiTransform = inputROI->GetParentTransformNode();
-      if (roiTransform && roiTransform->IsTransformToWorldLinear())
-        {
-          vtkMatrix4x4 *roiMatrix = vtkMatrix4x4::New();
-          roiTransform->GetMatrixTransformToWorld(roiMatrix);
-          outputIJKToRAS->Multiply4x4(roiMatrix, outputIJKToRAS,
-              outputIJKToRAS);
-        }
-
-      outputRASToIJK->DeepCopy(outputIJKToRAS);
-      outputRASToIJK->Invert();
-
-      vtkImageData* outputImageData = vtkImageData::New();
-      outputImageData->SetDimensions(outputExtent[0], outputExtent[1],
-          outputExtent[2]);
-      outputImageData->AllocateScalars(VTK_DOUBLE, 1);
-
-      refVolume->SetAndObserveImageData(outputImageData);
-      outputImageData->Delete();
-
-      refVolume->SetIJKToRASMatrix(outputIJKToRAS);
-      refVolume->SetRASToIJKMatrix(outputRASToIJK);
-
-      inputRASToIJK->Delete();
-      inputIJKToRAS->Delete();
-      outputRASToIJK->Delete();
-      outputIJKToRAS->Delete();
-
-      if (this->Internal->ResampleLogic == 0)
-        {
-          std::cerr << "CropVolume: ERROR: resample logic is not set!";
-          return -3;
-        }
-
-      vtkSmartPointer<vtkMRMLCommandLineModuleNode> cmdNode =
-          this->Internal->ResampleLogic->CreateNodeInScene();
-      assert(cmdNode.GetPointer() != 0);
-
-      cmdNode->SetParameterAsString("inputVolume", inputVolume->GetID());
-      cmdNode->SetParameterAsString("referenceVolume", refVolume->GetID());
-      cmdNode->SetParameterAsString("outputVolume", outputVolume->GetID());
-
-      vtkMRMLTransformNode *movingVolumeTransform = inputVolume->GetParentTransformNode();
-
-      if (movingVolumeTransform != NULL && movingVolumeTransform->IsLinear())
-        {
-        cmdNode->SetParameterAsString("transformationFile",
-            movingVolumeTransform->GetID());
-        }
-
-      std::string interp = "linear";
-      switch (pnode->GetInterpolationMode())
-        {
-      case 1:
-        interp = "nn";
-        break;
-      case 2:
-        interp = "linear";
-        break;
-      case 3:
-        interp = "ws";
-        break;
-      case 4:
-        interp = "bs";
-        break;
-        }
-
-      cmdNode->SetParameterAsString("interpolationType", interp.c_str());
-      this->Internal->ResampleLogic->ApplyAndWait(cmdNode);
-
-      this->GetMRMLScene()->RemoveNode(refVolume);
-      this->GetMRMLScene()->RemoveNode(cmdNode);
-
+    errorCode = this->CropInterpolated(inputROI, inputVolume, outputVolume,
+      pnode->GetIsotropicResampling(), pnode->GetSpacingScalingConst(), pnode->GetInterpolationMode());
     }
-
-  outputVolume->SetAndObserveTransformNodeID(NULL);
+  if (errorCode != 0)
+    {
+    return errorCode;
+    }
+  // no errors
   pnode->SetOutputVolumeNodeID(outputVolume->GetID());
-
   return 0;
 }
 
-
 //----------------------------------------------------------------------------
-void vtkSlicerCropVolumeLogic::CropVoxelBased(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume, vtkMRMLVolumeNode* outputVolume)
+bool vtkSlicerCropVolumeLogic::GetVoxelBasedCropOutputExtent(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume, int outputExtent[6])
 {
-  if(!roi || !inputVolume || !outputVolume)
-    return;
+  outputExtent[0] = outputExtent[2] = outputExtent[4] = 0;
+  outputExtent[1] = outputExtent[3] = outputExtent[5] = -1;
+  if (!roi || !inputVolume || !inputVolume->GetImageData())
+    {
+    return false;
+    }
 
-  vtkNew<vtkImageData> imageDataWorkingCopy;
-  imageDataWorkingCopy->DeepCopy(inputVolume->GetImageData());
+  int originalImageExtents[6] = { 0 };
+  inputVolume->GetImageData()->GetExtent(originalImageExtents);
 
-  vtkNew<vtkMatrix4x4> inputRASToIJK;
-  inputVolume->GetRASToIJKMatrix(inputRASToIJK.GetPointer());
+  vtkMRMLTransformNode* roiTransform = roi->GetParentTransformNode();
+  if (roiTransform && !roiTransform->IsTransformToWorldLinear())
+    {
+    vtkGenericWarningMacro("CropVolume: ROI is transformed using a non-linear transform. The transformation will be ignored");
+    roiTransform = NULL;
+    }
 
-  vtkNew<vtkMatrix4x4> inputIJKToRAS;
-  inputVolume->GetIJKToRASMatrix(inputIJKToRAS.GetPointer());
+  if (inputVolume->GetParentTransformNode() && !inputVolume->GetParentTransformNode()->IsTransformToWorldLinear())
+    {
+    vtkGenericWarningMacro("vtkSlicerCropVolumeLogic::CropVoxelBased: voxel-based cropping of non-linearly transformed input volume is not supported");
+    return -1;
+    }
 
-  double roiXYZ[3];
-  double roiRadius[3];
+  vtkNew<vtkMatrix4x4> roiToVolumeTransformMatrix;
+  vtkMRMLTransformNode::GetMatrixTransformBetweenNodes(roiTransform, inputVolume->GetParentTransformNode(),
+    roiToVolumeTransformMatrix.GetPointer());
 
+  vtkNew<vtkMatrix4x4> rasToIJK;
+  inputVolume->GetRASToIJKMatrix(rasToIJK.GetPointer());
+
+  vtkNew<vtkMatrix4x4> roiToVolumeIJKTransformMatrix;
+  vtkMatrix4x4::Multiply4x4(rasToIJK.GetPointer(), roiToVolumeTransformMatrix.GetPointer(),
+    roiToVolumeIJKTransformMatrix.GetPointer());
+
+  double roiXYZ[3] = { 0 };
   roi->GetXYZ(roiXYZ);
+  double roiRadius[3] = { 0 };
   roi->GetRadiusXYZ(roiRadius);
 
-  double minXYZRAS[] = {roiXYZ[0]-roiRadius[0], roiXYZ[1]-roiRadius[1],roiXYZ[2]-roiRadius[2],1.};
-  double maxXYZRAS[] = {roiXYZ[0]+roiRadius[0], roiXYZ[1]+roiRadius[1],roiXYZ[2]+roiRadius[2],1.};
-
-  vtkMRMLTransformNode* roiTransform  = roi->GetParentTransformNode();
-  // account for the ROI parent transform, if present
-  if (roiTransform && roiTransform->IsTransformToWorldLinear())
+  const int numberOfCorners = 8;
+  double volumeCorners_ROI[numberOfCorners][4] =
     {
-      vtkNew<vtkMatrix4x4> roiTransformMatrix;
-      roiTransform->GetMatrixTransformToWorld(roiTransformMatrix.GetPointer());
-      if (roiTransformMatrix.GetPointer())
+    { roiXYZ[0] - roiRadius[0], roiXYZ[1] - roiRadius[1], roiXYZ[2] - roiRadius[2], 1. },
+    { roiXYZ[0] + roiRadius[0], roiXYZ[1] - roiRadius[1], roiXYZ[2] - roiRadius[2], 1. },
+    { roiXYZ[0] - roiRadius[0], roiXYZ[1] + roiRadius[1], roiXYZ[2] - roiRadius[2], 1. },
+    { roiXYZ[0] + roiRadius[0], roiXYZ[1] + roiRadius[1], roiXYZ[2] - roiRadius[2], 1. },
+    { roiXYZ[0] - roiRadius[0], roiXYZ[1] - roiRadius[1], roiXYZ[2] + roiRadius[2], 1. },
+    { roiXYZ[0] + roiRadius[0], roiXYZ[1] - roiRadius[1], roiXYZ[2] + roiRadius[2], 1. },
+    { roiXYZ[0] - roiRadius[0], roiXYZ[1] + roiRadius[1], roiXYZ[2] + roiRadius[2], 1. },
+    { roiXYZ[0] + roiRadius[0], roiXYZ[1] + roiRadius[1], roiXYZ[2] + roiRadius[2], 1. },
+    };
+
+  // Get ROI extent in IJK coordinate system
+  double outputExtentDouble[6] = { 0 };
+  for (int cornerPointIndex = 0; cornerPointIndex < numberOfCorners; cornerPointIndex++)
+    {
+    double volumeCorner_IJK[4] = { 0, 0, 0, 1 };
+    roiToVolumeIJKTransformMatrix->MultiplyPoint(volumeCorners_ROI[cornerPointIndex], volumeCorner_IJK);
+    for (int axisIndex = 0; axisIndex < 3; ++axisIndex)
+      {
+      if (cornerPointIndex == 0 || volumeCorner_IJK[axisIndex] < outputExtentDouble[axisIndex * 2])
         {
-          // multiply ROI's min and max corners with parent's transform to world to get real RAS position
-          roiTransformMatrix->MultiplyPoint(minXYZRAS, minXYZRAS);
-          roiTransformMatrix->MultiplyPoint(maxXYZRAS, maxXYZRAS);
+        outputExtentDouble[axisIndex * 2] = volumeCorner_IJK[axisIndex];
         }
+      if (cornerPointIndex == 0 || volumeCorner_IJK[axisIndex] > outputExtentDouble[axisIndex * 2 + 1])
+        {
+        outputExtentDouble[axisIndex * 2 + 1] = volumeCorner_IJK[axisIndex];
+        }
+      }
     }
 
-  double minXYZIJK[4], maxXYZIJK[4];
-
-  //transform to ijk
-  inputRASToIJK->MultiplyPoint(minXYZRAS, minXYZIJK);
-  inputRASToIJK->MultiplyPoint(maxXYZRAS, maxXYZIJK);
-
-  double minX = std::min(minXYZIJK[0],maxXYZIJK[0]);
-  double maxX = std::max(minXYZIJK[0],maxXYZIJK[0]) + 0.5; // 0.5 for rounding purposes to make sure everything selected by roi is cropped
-  double minY = std::min(minXYZIJK[1],maxXYZIJK[1]);
-  double maxY = std::max(minXYZIJK[1],maxXYZIJK[1]) + 0.5;
-  double minZ = std::min(minXYZIJK[2],maxXYZIJK[2]);
-  double maxZ = std::max(minXYZIJK[2],maxXYZIJK[2]) + 0.5;
-
-  int originalImageExtents[6];
-  imageDataWorkingCopy->GetExtent(originalImageExtents);
-
-  minX = std::max(minX,0.);
-  maxX = std::min(maxX,static_cast<double>(originalImageExtents[1]));
-  minY = std::max(minY,0.);
-  maxY = std::min(maxY,static_cast<double>(originalImageExtents[3]));
-  minZ = std::max(minZ,0.);
-  maxZ = std::min(maxZ,static_cast<double>(originalImageExtents[5]));
-
-  int outputWholeExtent[6] = {
-    static_cast<int>(minX),
-    static_cast<int>(maxX),
-    static_cast<int>(minY),
-    static_cast<int>(maxY),
-    static_cast<int>(minZ),
-    static_cast<int>(maxZ)};
-
-  const double ijkNewOrigin[] = {
-    static_cast<double>(outputWholeExtent[0]),
-    static_cast<double>(outputWholeExtent[2]),
-    static_cast<double>(outputWholeExtent[4]),
-    static_cast<double>(1.0)};
-
-  double  rasNewOrigin[4];
-  inputIJKToRAS->MultiplyPoint(ijkNewOrigin,rasNewOrigin);
-
-
-  vtkNew<vtkImageClip> imageClip;
-  imageClip->SetInputData(imageDataWorkingCopy.GetPointer());
-  imageClip->SetOutputWholeExtent(outputWholeExtent);
-  imageClip->SetClipData(true);
-
-  imageClip->Update();
-
-
-  vtkNew<vtkMatrix4x4> outputIJKToRAS;
-  outputIJKToRAS->DeepCopy(inputIJKToRAS.GetPointer());
-
-  outputIJKToRAS->SetElement(0,3,rasNewOrigin[0]);
-  outputIJKToRAS->SetElement(1,3,rasNewOrigin[1]);
-  outputIJKToRAS->SetElement(2,3,rasNewOrigin[2]);
-
-  outputVolume->SetOrigin(rasNewOrigin[0],rasNewOrigin[1],rasNewOrigin[2]);
-
-  vtkNew<vtkMatrix4x4> outputRASToIJK;
-  outputRASToIJK->DeepCopy(outputIJKToRAS.GetPointer());
-  outputRASToIJK->Invert();
-
-  vtkNew<vtkImageData> outputImageData;
-  outputImageData->DeepCopy(imageClip->GetOutput());
-
-  int extent[6];
-  imageClip->GetOutput()->GetExtent(extent);
-
-  outputImageData->SetExtent(0, extent[1]-extent[0], 0, extent[3]-extent[2], 0, extent[5]-extent[4]);
-
-  outputVolume->SetAndObserveImageData(outputImageData.GetPointer());
-  outputVolume->SetIJKToRASMatrix(outputIJKToRAS.GetPointer());
-  outputVolume->SetRASToIJKMatrix(outputRASToIJK.GetPointer());
-
-  outputVolume->Modified();
-
-}
-
-//----------------------------------------------------------------------------
-void vtkSlicerCropVolumeLogic::RegisterNodes()
-{
-  if(!this->GetMRMLScene())
+  // Limit output extent to input extent
+  int* inputExtent = inputVolume->GetImageData()->GetExtent();
+  double tolerance = 0.001;
+  for (int axisIndex = 0; axisIndex < 3; ++axisIndex)
     {
-    return;
+    outputExtent[axisIndex * 2] = std::max(inputExtent[axisIndex * 2], int(ceil(outputExtentDouble[axisIndex * 2]+0.5-tolerance)));
+    outputExtent[axisIndex * 2 + 1] = std::min(inputExtent[axisIndex * 2 + 1], int(floor(outputExtentDouble[axisIndex * 2 + 1]-0.5+tolerance)));
     }
-  vtkMRMLCropVolumeParametersNode* pNode = vtkMRMLCropVolumeParametersNode::New();
-  this->GetMRMLScene()->RegisterNodeClass(pNode);
-  pNode->Delete();
-}
-
-
-void vtkSlicerCropVolumeLogic::SnapROIToVoxelGrid(vtkMRMLAnnotationROINode* inputROI, vtkMRMLVolumeNode* inputVolume)
-{
-  if (!inputROI || !inputVolume)
-    {
-      vtkDebugMacro(
-          "vtkSlicerCropVolumeLogic: Snapping ROI to voxel grid failed (input ROI and/or input Volume are invalid)");
-      return;
-    }
-
-  vtkSmartPointer<vtkMRMLScene> scene = this->GetMRMLScene();
-
-  if (!scene)
-    {
-      vtkDebugMacro(
-          "vtkSlicerCropVolumeLogic: Snapping ROI to voxel grid failed (MRML Scene is not available)");
-      return;
-    }
-
-  vtkNew<vtkMatrix4x4> rotationMat;
-
-  bool ok = vtkSlicerCropVolumeLogic::ComputeIJKToRASRotationOnlyMatrix(
-      inputVolume, rotationMat.GetPointer());
-
-
-  if (!ok)
-    {
-      vtkDebugMacro(
-          "vtkSlicerCropVolumeLogic: Snapping ROI to voxel grid failed (IJK to RAS rotation only matrix computation failed)");
-      return;
-    }
-
-  vtkNew<vtkMRMLLinearTransformNode> roiTransformNode;
-  roiTransformNode->ApplyTransformMatrix(rotationMat.GetPointer());
-  roiTransformNode->SetScene(this->GetMRMLScene());
-
-  this->GetMRMLScene()->AddNode(roiTransformNode.GetPointer());
-
-  inputROI->SetAndObserveTransformNodeID(roiTransformNode->GetID());
-}
-
-
-
-//----------------------------------------------------------------------------
-bool vtkSlicerCropVolumeLogic::ComputeIJKToRASRotationOnlyMatrix(vtkMRMLVolumeNode* inputVolume, vtkMatrix4x4* outputMatrix)
-{
-  if(inputVolume == NULL || outputMatrix == NULL)
-    return false;
-
-  vtkNew<vtkMatrix4x4> rotationMat;
-  rotationMat->Identity();
-
-  vtkNew<vtkMatrix4x4> inputIJKToRASMat;
-  inputIJKToRASMat->Identity();
-
-  inputVolume->GetIJKToRASMatrix(inputIJKToRASMat.GetPointer());
-  const char* scanOrder = vtkMRMLVolumeNode::ComputeScanOrderFromIJKToRAS(inputIJKToRASMat.GetPointer());
-
-  vtkNew<vtkMatrix4x4> orientMat;
-  orientMat->Identity();
-
-  bool orientation = vtkSlicerCropVolumeLogic::ComputeOrientationMatrixFromScanOrder(scanOrder,orientMat.GetPointer());
-
-  if(!orientation)
-    return false;
-
-  orientMat->Invert();
-
-  vtkNew<vtkMatrix4x4> directionsMat;
-  directionsMat->Identity();
-
-  inputVolume->GetIJKToRASDirectionMatrix(directionsMat.GetPointer());
-
-  vtkMatrix4x4::Multiply4x4(directionsMat.GetPointer(),orientMat.GetPointer(),rotationMat.GetPointer());
-
-  outputMatrix->DeepCopy(rotationMat.GetPointer());
 
   return true;
 }
 
-
 //----------------------------------------------------------------------------
-bool vtkSlicerCropVolumeLogic::IsVolumeTiltedInRAS( vtkMRMLVolumeNode* inputVolume, vtkMatrix4x4* rotationMatrix)
+int vtkSlicerCropVolumeLogic::CropVoxelBased(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume, vtkMRMLVolumeNode* outputVolume)
 {
-  assert(inputVolume);
-
-  vtkNew<vtkMatrix4x4> iJKToRASMat;
-  vtkNew<vtkMatrix4x4> directionMat;
-
-  inputVolume->GetIJKToRASMatrix(iJKToRASMat.GetPointer());
-  inputVolume->GetIJKToRASDirectionMatrix(directionMat.GetPointer());
-
-  const char* scanOrder = vtkMRMLVolumeNode::ComputeScanOrderFromIJKToRAS(iJKToRASMat.GetPointer());
-
-  vtkNew<vtkMatrix4x4> orientMat;
-  vtkSlicerCropVolumeLogic::ComputeOrientationMatrixFromScanOrder(scanOrder,orientMat.GetPointer());
-
-  bool same = true;
-
-  for(int i=0; i < 4; ++i)
+  if(!roi || !inputVolume || !outputVolume)
     {
-      for(int j=0; j < 4; ++j)
-        {
-          if(directionMat->GetElement(i,j) != orientMat->GetElement(i,j))
-            {
-              same = false;
-              break;
-            }
-        }
-      if(same == false)
-        break;
+    return -1;
+    }
+  if (!inputVolume->GetImageData())
+    {
+    vtkGenericWarningMacro("vtkSlicerCropVolumeLogic::CropVoxelBased: input image is empty")
+    outputVolume->SetAndObserveImageData(NULL);
+    return 0;
     }
 
-  if(!rotationMatrix)
-    rotationMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
-
-  if(same)
+  int outputExtent[6] = { 0, -1, 0, -1, 0, -1 };
+  if (!vtkSlicerCropVolumeLogic::GetVoxelBasedCropOutputExtent(roi, inputVolume, outputExtent))
     {
-      rotationMatrix->Identity();
-    }
-  else
-    {
-      vtkSlicerCropVolumeLogic::ComputeIJKToRASRotationOnlyMatrix(inputVolume,rotationMatrix);
-      return true;
+    vtkGenericWarningMacro("vtkSlicerCropVolumeLogic::CropVoxelBased: failed to get output geometry")
+    return -1;
     }
 
+  vtkNew<vtkMatrix4x4> inputIJKToRAS;
+  inputVolume->GetIJKToRASMatrix(inputIJKToRAS.GetPointer());
 
+  vtkNew<vtkImageClip> imageClip;
+  imageClip->SetInputData(inputVolume->GetImageData());
+  imageClip->SetOutputWholeExtent(outputExtent);
+  imageClip->SetClipData(true);
+  imageClip->Update();
 
-  return false;
+  //int wasModified = outputVolume->StartModify();
+  outputVolume->SetAndObserveImageData(imageClip->GetOutput());
+  outputVolume->SetIJKToRASMatrix(inputIJKToRAS.GetPointer());
+  outputVolume->ShiftImageDataExtentToZeroStart();
+  //outputVolume->EndModify(wasModified);
+
+  outputVolume->SetAndObserveTransformNodeID(inputVolume->GetTransformNodeID());
+
+  return 0;
 }
 
 //----------------------------------------------------------------------------
-bool
-vtkSlicerCropVolumeLogic::ComputeOrientationMatrixFromScanOrder(
-    const char *order, vtkMatrix4x4 *outputMatrix)
+bool vtkSlicerCropVolumeLogic::GetInterpolatedCropOutputGeometry(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume,
+  bool isotropicResampling, double spacingScale, int outputExtent[6], double outputSpacing[3])
 {
-  vtkNew<vtkMatrix4x4> orientMat;
-  orientMat->Identity();
+  if (!roi || !inputVolume)
+    {
+    return false;
+    }
 
-  if (!strcmp(order, "IS") || !strcmp(order, "Axial IS")
-      || !strcmp(order, "Axial"))
+  double* inputSpacing = inputVolume->GetSpacing();
+  if (isotropicResampling)
     {
-      double elems[] =
-        { -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 };
-      orientMat->DeepCopy(elems);
-    }
-  else if (!strcmp(order, "SI") || !strcmp(order, "Axial SI"))
-    {
-      double elems[] =
-        { -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 1 };
-      orientMat->DeepCopy(elems);
-    }
-  else if (!strcmp(order, "RL") || !strcmp(order, "Sagittal RL")
-      || !strcmp(order, "Sagittal"))
-    {
-      double elems[] =
-        { 0, 0, -1, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1 };
-      orientMat->DeepCopy(elems);
-    }
-  else if (!strcmp(order, "LR") || !strcmp(order, "Sagittal LR"))
-    {
-      double elems[] =
-        { 0, 0, 1, 0, -1, 0, 0, 0, 0, -1, 0, 0, 0, 0, 0, 1 };
-      orientMat->DeepCopy(elems);
-    }
-  else if (!strcmp(order, "PA") || !strcmp(order, "Coronal PA")
-      || !strcmp(order, "Coronal"))
-    {
-      double elems[] =
-        { -1, 0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1 };
-      orientMat->DeepCopy(elems);
-    }
-  else if (!strcmp(order, "AP") || !strcmp(order, "Coronal AP"))
-    {
-      double elems[] =
-        { -1, 0, 0, 0, 0, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 1 };
-      orientMat->DeepCopy(elems);
+    double minSpacing = std::min(std::min(inputSpacing[0], inputSpacing[1]), inputSpacing[2]);
+    outputSpacing[0] = minSpacing * spacingScale;
+    outputSpacing[1] = minSpacing * spacingScale;
+    outputSpacing[2] = minSpacing * spacingScale;
     }
   else
     {
-      return false;
+    int inputAxisIndexForROIAxis[3] = { 0, 1, 2 };
+    // Find which image axis corresponds to each ROI axis, to get the correct spacing value for each ROI axis
+    vtkNew<vtkGeneralTransform> volumeToROITransform;
+    vtkNew<vtkTransform> volumeToROITransformLinear;
+    vtkMRMLTransformNode::GetTransformBetweenNodes(inputVolume->GetParentTransformNode(),
+      roi->GetParentTransformNode(), volumeToROITransform.GetPointer());
+    if (vtkMRMLTransformNode::IsGeneralTransformLinear(volumeToROITransform.GetPointer(), volumeToROITransformLinear.GetPointer()))
+      {
+      // Transformation between input volume and ROI is linear, therefore we can find matching axes
+      vtkNew<vtkMatrix4x4> volumeRasToROI;
+      volumeToROITransformLinear->GetMatrix(volumeRasToROI.GetPointer());
+      vtkNew<vtkMatrix4x4> volumeIJKToRAS;
+      inputVolume->GetIJKToRASMatrix(volumeIJKToRAS.GetPointer());
+      vtkNew<vtkMatrix4x4> volumeIJKToROI;
+      vtkMatrix4x4::Multiply4x4(volumeRasToROI.GetPointer(), volumeIJKToRAS.GetPointer(), volumeIJKToROI.GetPointer());
+      double scale[3] = { 1.0 };
+      vtkAddonMathUtilities::NormalizeOrientationMatrixColumns(volumeIJKToROI.GetPointer(), scale);
+      // Find the volumeIJK axis that is best aligned with each ROI azis
+      for (int roiAxisIndex = 0; roiAxisIndex < 3; roiAxisIndex++)
+        {
+        double largestComponentValue = 0;
+        for (int volumeIJKAxisIndex = 0; volumeIJKAxisIndex < 3; volumeIJKAxisIndex++)
+          {
+            double currentComponentValue = fabs(volumeIJKToROI->GetElement(roiAxisIndex, volumeIJKAxisIndex));
+          if (currentComponentValue > largestComponentValue)
+            {
+            largestComponentValue = currentComponentValue;
+            inputAxisIndexForROIAxis[roiAxisIndex] = volumeIJKAxisIndex;
+            }
+          }
+        }
+      }
+    outputSpacing[0] = inputSpacing[inputAxisIndexForROIAxis[0]] * spacingScale;
+    outputSpacing[1] = inputSpacing[inputAxisIndexForROIAxis[1]] * spacingScale;
+    outputSpacing[2] = inputSpacing[inputAxisIndexForROIAxis[2]] * spacingScale;
     }
 
+  // prepare the resampling reference volume
+  double roiRadius[3] = { 0 };
+  roi->GetRadiusXYZ(roiRadius);
 
-  outputMatrix->DeepCopy(orientMat.GetPointer());
+  outputExtent[0] = outputExtent[2] = outputExtent[4] = 0;
+  // add a bit of tolerance in deciding how many voxels the output should contain
+  // to make sure that if the ROI size is set to match the image size exactly then we
+  // output extent contains the whole image
+  double tolerance = 0.001;
+  outputExtent[1] = int(roiRadius[0] / outputSpacing[0] * 2. + tolerance) - 1;
+  outputExtent[3] = int(roiRadius[1] / outputSpacing[1] * 2. + tolerance) - 1;
+  outputExtent[5] = int(roiRadius[2] / outputSpacing[2] * 2. + tolerance) - 1;
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
+int vtkSlicerCropVolumeLogic::CropInterpolated(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume, vtkMRMLVolumeNode* outputVolume,
+  bool isotropicResampling, double spacingScale, int interpolationMode)
+{
+  if (!roi || !inputVolume || !outputVolume)
+    {
+    return -1;
+    }
+
+  if (this->Internal->ResampleLogic == 0)
+    {
+    vtkErrorMacro("CropVolume: resample logic is not set");
+    return -3;
+    }
+
+  int outputExtent[6] = { 0, -1, 0, -1, 0, -1 };
+  double outputSpacing[3] = { 0 };
+  this->GetInterpolatedCropOutputGeometry(roi, inputVolume, isotropicResampling, spacingScale, outputExtent, outputSpacing);
+
+  double roiXYZ[3] = { 0 };
+  roi->GetXYZ(roiXYZ);
+  double roiRadius[3] = { 0 };
+  roi->GetRadiusXYZ(roiRadius);
+
+  vtkNew<vtkMatrix4x4> outputIJKToRAS;
+  outputIJKToRAS->SetElement(0, 0, outputSpacing[0]);
+  outputIJKToRAS->SetElement(1, 1, outputSpacing[1]);
+  outputIJKToRAS->SetElement(2, 2, outputSpacing[2]);
+  outputIJKToRAS->SetElement(0, 3, roiXYZ[0] - roiRadius[0]);
+  outputIJKToRAS->SetElement(1, 3, roiXYZ[1] - roiRadius[1]);
+  outputIJKToRAS->SetElement(2, 3, roiXYZ[2] - roiRadius[2]);
+
+  // account for the ROI parent transform, if present
+  vtkMRMLTransformNode *roiTransform = roi->GetParentTransformNode();
+  vtkMRMLTransformNode *outputTransform = outputVolume->GetParentTransformNode();
+  if (roiTransform && !roiTransform->IsTransformToWorldLinear())
+    {
+    // We can only display a If ROI is transformed with a warping transform then we ignore the transformation because non-linear
+    // transform of ROI node is not supported.
+    vtkErrorMacro("vtkSlicerCropVolumeLogic::CropInterpolated: ROI is under a non-linear transform");
+    return -5;
+    }
+  if (outputTransform && !outputTransform->IsTransformToWorldLinear())
+    {
+    // The resample module can only create a rectangular output.
+    vtkErrorMacro("vtkSlicerCropVolumeLogic::CropInterpolated: output volume is under a non-linear transform");
+    return -6;
+    }
+
+  vtkNew<vtkMatrix4x4> roiMatrix;
+  vtkMRMLTransformNode::GetMatrixTransformBetweenNodes(roiTransform, outputTransform, roiMatrix.GetPointer());
+  outputIJKToRAS->Multiply4x4(roiMatrix.GetPointer(), outputIJKToRAS.GetPointer(),
+    outputIJKToRAS.GetPointer());
+
+  vtkNew<vtkMatrix4x4> rasToLPS;
+  rasToLPS->SetElement(0, 0, -1);
+  rasToLPS->SetElement(1, 1, -1);
+  vtkNew<vtkMatrix4x4> outputIJKToLPS;
+  vtkMatrix4x4::Multiply4x4(rasToLPS.GetPointer(), outputIJKToRAS.GetPointer(), outputIJKToLPS.GetPointer());
+
+  // contains axis directions, in unconventional indexing (column, row)
+  // so that it can be conveniently normalized
+  double outputDirectionColRow[3][3] = { 0 };
+  for (int column = 0; column < 3; column++)
+    {
+    for (int row = 0; row < 3; row++)
+      {
+      outputDirectionColRow[column][row] = outputIJKToLPS->GetElement(row, column);
+      }
+    outputSpacing[column] = vtkMath::Normalize(outputDirectionColRow[column]);
+    }
+
+  vtkMRMLCommandLineModuleNode* cmdNode = this->Internal->ResampleLogic->CreateNodeInScene();
+  if (cmdNode == NULL)
+    {
+    vtkErrorMacro("CropVolume: failed to create resample node");
+    return -4;
+    }
+
+  cmdNode->SetParameterAsString("inputVolume", inputVolume->GetID());
+  cmdNode->SetParameterAsString("outputVolume", outputVolume->GetID());
+
+  std::stringstream sizeStream;
+  sizeStream << (outputExtent[1] - outputExtent[0] + 1)  << ","
+    << (outputExtent[3] - outputExtent[2] + 1) << ","
+    << (outputExtent[5] - outputExtent[4] + 1);
+  cmdNode->SetParameterAsString("outputImageSize", sizeStream.str());
+
+  // Center the output image in the ROI. For that, compute the size difference between
+  // the ROI and the output image.
+  double sizeDifference_IJK[3] =
+    {
+    roiRadius[0] * 2 / outputSpacing[0] - (outputExtent[1] - outputExtent[0] + 1),
+    roiRadius[1] * 2 / outputSpacing[1] - (outputExtent[3] - outputExtent[2] + 1),
+    roiRadius[2] * 2 / outputSpacing[2] - (outputExtent[5] - outputExtent[4] + 1)
+    };
+  // Origin is in the voxel's center. Shift the origin by half voxel
+  // to have the ROI edge at the output image voxel edge.
+  double outputOrigin_IJK[4] =
+    {
+    0.5 + sizeDifference_IJK[0] / 2,
+    0.5 + sizeDifference_IJK[1] / 2,
+    0.5 + sizeDifference_IJK[2] / 2,
+    1.0
+    };
+  double outputOrigin_RAS[4] = { 0.0, 0.0, 0.0, 1.0 };
+  outputIJKToRAS->MultiplyPoint(outputOrigin_IJK, outputOrigin_RAS);
+
+  vtkNew<vtkMRMLMarkupsFiducialNode> originMarkupNode;
+  // Markups are transformed from RAS to LPS by the CLI infrastructure, so we pass them in RAS
+  originMarkupNode->AddFiducial(outputOrigin_RAS[0], outputOrigin_RAS[1], outputOrigin_RAS[2]);
+  this->GetMRMLScene()->AddNode(originMarkupNode.GetPointer());
+  cmdNode->SetParameterAsString("outputImageOrigin", originMarkupNode->GetID());
+
+  std::stringstream spacingStream;
+  spacingStream << std::setprecision(15) << outputSpacing[0] << "," << outputSpacing[1] << "," << outputSpacing[2];
+  cmdNode->SetParameterAsString("outputImageSpacing", spacingStream.str());
+
+  std::stringstream directionStream;
+  directionStream << std::setprecision(15);
+  for (int row = 0; row < 3; row++)
+    {
+    for (int column = 0; column < 3; column++)
+      {
+      if (row > 0 || column > 0)
+        {
+        directionStream << ",";
+        }
+      directionStream << outputDirectionColRow[column][row];
+      }
+    }
+
+  cmdNode->SetParameterAsString("directionMatrix", directionStream.str());
+
+  vtkMRMLTransformNode* inputToRASTransformNodeToRemove = NULL;
+  if (inputVolume->GetParentTransformNode() != NULL)
+    {
+    vtkNew<vtkGeneralTransform> inputToRASTransform;
+    inputVolume->GetParentTransformNode()->GetTransformToNode(outputVolume->GetParentTransformNode(), inputToRASTransform.GetPointer());
+    vtkNew<vtkMRMLTransformNode> inputToRASTransformNode;
+    inputToRASTransformNode->SetAndObserveTransformToParent(inputToRASTransform.GetPointer());
+    this->GetMRMLScene()->AddNode(inputToRASTransformNode.GetPointer());
+    inputToRASTransformNodeToRemove = inputToRASTransformNode.GetPointer();
+    cmdNode->SetParameterAsString("transformationFile", inputToRASTransformNode->GetID());
+    }
+
+  std::string interp = "linear";
+  switch (interpolationMode)
+    {
+    case vtkMRMLCropVolumeParametersNode::InterpolationNearestNeighbor:
+      interp = "nn";
+      break;
+    case vtkMRMLCropVolumeParametersNode::InterpolationLinear:
+      interp = "linear";
+      break;
+    case vtkMRMLCropVolumeParametersNode::InterpolationWindowedSinc:
+      interp = "ws";
+      break;
+    case vtkMRMLCropVolumeParametersNode::InterpolationBSpline:
+      interp = "bs";
+      break;
+    }
+
+  cmdNode->SetParameterAsString("interpolationType", interp.c_str());
+  this->Internal->ResampleLogic->ApplyAndWait(cmdNode, false);
+
+  this->GetMRMLScene()->RemoveNode(cmdNode);
+  this->GetMRMLScene()->RemoveNode(originMarkupNode.GetPointer());
+  if (inputToRASTransformNodeToRemove != NULL)
+    {
+    this->GetMRMLScene()->RemoveNode(inputToRASTransformNodeToRemove);
+    }
+
+  // success
+  return 0;
+}
+
+//-----------------------------------------------------------------------------
+bool vtkSlicerCropVolumeLogic::FitROIToInputVolume(vtkMRMLCropVolumeParametersNode* parametersNode)
+{
+  if (!parametersNode)
+    {
+    return false;
+    }
+  vtkMRMLAnnotationROINode* roiNode = parametersNode->GetROINode();
+  vtkMRMLVolumeNode* volumeNode = parametersNode->GetInputVolumeNode();
+  if (!roiNode || !volumeNode)
+    {
+    return false;
+    }
+
+  vtkMRMLTransformNode* roiTransform = roiNode->GetParentTransformNode();
+  if (roiTransform && !roiTransform->IsTransformToWorldLinear())
+    {
+    roiTransform = NULL;
+    roiNode->SetAndObserveTransformNodeID(NULL);
+    parametersNode->DeleteROIAlignmentTransformNode();
+    }
+  vtkNew<vtkMatrix4x4> worldToROI;
+  vtkMRMLTransformNode::GetMatrixTransformBetweenNodes(NULL, roiTransform, worldToROI.GetPointer());
+
+  double volumeBounds_ROI[6] = { 0 }; // volume bounds in ROI's coordinate system
+  volumeNode->GetSliceBounds(volumeBounds_ROI, worldToROI.GetPointer());
+
+  double roiCenter[3] = { 0 };
+  double roiRadius[3] = { 0 };
+  for (int i = 0; i < 3; i++)
+    {
+    roiCenter[i] = (volumeBounds_ROI[i * 2 + 1] + volumeBounds_ROI[i * 2]) / 2;
+    roiRadius[i] = (volumeBounds_ROI[i * 2 + 1] - volumeBounds_ROI[i * 2]) / 2;
+    }
+  roiNode->SetXYZ(roiCenter);
+  roiNode->SetRadiusXYZ(roiRadius);
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
+void vtkSlicerCropVolumeLogic::SnapROIToVoxelGrid(vtkMRMLCropVolumeParametersNode* parametersNode)
+{
+  if (!parametersNode || !parametersNode->GetInputVolumeNode() || !parametersNode->GetROINode())
+    {
+    // no misalignment (not enough nodes to be misaligned)
+    return;
+    }
+
+  // Is it already aligned?
+  if (IsROIAlignedWithInputVolume(parametersNode))
+    {
+    // already aligned, nothing to do
+    return;
+    }
+
+  double originalBounds_World[6] = { 0, -1, 0, -1, 0, -1 };
+  parametersNode->GetROINode()->GetRASBounds(originalBounds_World);
+
+  // If we don't transform it, is it aligned?
+  if (parametersNode->GetROINode()->GetParentTransformNode() != NULL)
+    {
+    parametersNode->GetROINode()->SetAndObserveTransformNodeID(NULL);
+    if (IsROIAlignedWithInputVolume(parametersNode))
+      {
+      // ROI is aligned if it's not transformed, no need for ROI alignment transform
+      parametersNode->DeleteROIAlignmentTransformNode();
+      // Update ROI to approximately match original region
+      parametersNode->GetROINode()->SetXYZ((originalBounds_World[1] + originalBounds_World[0]) / 2.0,
+        (originalBounds_World[3] + originalBounds_World[2]) / 2.0,
+        (originalBounds_World[5] + originalBounds_World[4]) / 2.0);
+      parametersNode->GetROINode()->SetRadiusXYZ((originalBounds_World[1] - originalBounds_World[0]) / 2.0,
+        (originalBounds_World[3] - originalBounds_World[2]) / 2.0,
+        (originalBounds_World[5] - originalBounds_World[4]) / 2.0);
+      return;
+      }
+    }
+
+  // It's a non-trivial rotation, use the ROI alignment transform node to align
+  vtkNew<vtkMatrix4x4> volumeRasToWorld;
+  vtkMRMLTransformNode::GetMatrixTransformBetweenNodes(parametersNode->GetInputVolumeNode()->GetParentTransformNode(),
+    NULL, volumeRasToWorld.GetPointer());
+  vtkNew<vtkMatrix4x4> volumeIJKToRAS;
+  parametersNode->GetInputVolumeNode()->GetIJKToRASMatrix(volumeIJKToRAS.GetPointer());
+  vtkNew<vtkMatrix4x4> volumeIJKToWorld;
+  vtkMatrix4x4::Multiply4x4(volumeRasToWorld.GetPointer(), volumeIJKToRAS.GetPointer(), volumeIJKToWorld.GetPointer());
+  double scale[3] = { 1.0 };
+  vtkAddonMathUtilities::NormalizeOrientationMatrixColumns(volumeIJKToWorld.GetPointer(), scale);
+
+  // Apply transform to ROI alignment transform
+  if (!parametersNode->GetROIAlignmentTransformNode())
+    {
+    vtkNew<vtkMRMLTransformNode> roiTransformNode;
+    roiTransformNode->SetName("Crop volume ROI alignment");
+    parametersNode->GetScene()->AddNode(roiTransformNode.GetPointer());
+    parametersNode->SetROIAlignmentTransformNodeID(roiTransformNode->GetID());
+    }
+  parametersNode->GetROIAlignmentTransformNode()->SetAndObserveTransformNodeID(NULL);
+  parametersNode->GetROIAlignmentTransformNode()->SetMatrixTransformToParent(volumeIJKToWorld.GetPointer());
+  parametersNode->GetROINode()->SetAndObserveTransformNodeID(parametersNode->GetROIAlignmentTransformNode()->GetID());
+
+  vtkNew<vtkMatrix4x4> worldToROITransformMatrix;
+  parametersNode->GetROIAlignmentTransformNode()->GetMatrixTransformFromWorld(worldToROITransformMatrix.GetPointer());
+
+  // Update ROI to approximately match original region
+  const int numberOfCornerPoints = 8;
+  double cornerPoints_World[numberOfCornerPoints][4] =
+    {
+    { originalBounds_World[0], originalBounds_World[2], originalBounds_World[4], 1 },
+    { originalBounds_World[0], originalBounds_World[2], originalBounds_World[5], 1 },
+    { originalBounds_World[0], originalBounds_World[3], originalBounds_World[4], 1 },
+    { originalBounds_World[0], originalBounds_World[3], originalBounds_World[5], 1 },
+    { originalBounds_World[1], originalBounds_World[2], originalBounds_World[4], 1 },
+    { originalBounds_World[1], originalBounds_World[2], originalBounds_World[5], 1 },
+    { originalBounds_World[1], originalBounds_World[3], originalBounds_World[4], 1 },
+    { originalBounds_World[1], originalBounds_World[3], originalBounds_World[5], 1 }
+    };
+  vtkBoundingBox boundingBox_ROI;
+  for (int i = 0; i < numberOfCornerPoints; i++)
+    {
+    double* cornerPoint_ROI = worldToROITransformMatrix->MultiplyDoublePoint(cornerPoints_World[i]);
+    boundingBox_ROI.AddPoint(cornerPoint_ROI);
+    }
+  double center_ROI[3] = { 0 };
+  boundingBox_ROI.GetCenter(center_ROI);
+  parametersNode->GetROINode()->SetXYZ(center_ROI);
+  double diameters_ROI[3] = { 0 };
+  boundingBox_ROI.GetLengths(diameters_ROI);
+  parametersNode->GetROINode()->SetRadiusXYZ(diameters_ROI[0] / 2, diameters_ROI[1] / 2, diameters_ROI[2] / 2);
+}
+
+//----------------------------------------------------------------------------
+bool vtkSlicerCropVolumeLogic::IsROIAlignedWithInputVolume(vtkMRMLCropVolumeParametersNode* parametersNode)
+{
+  if (!parametersNode || !parametersNode->GetInputVolumeNode() || !parametersNode->GetROINode())
+    {
+    // no misalignment (not enough nodes to be misaligned)
+    return true;
+    }
+
+  if (parametersNode->GetInputVolumeNode()->GetParentTransformNode()
+    && !parametersNode->GetInputVolumeNode()->GetParentTransformNode()->IsTransformToWorldLinear())
+    {
+    // no misalignment, as if input volume is under a non-linear transform then we cannot align a ROI
+    return true;
+    }
+
+  if (parametersNode->GetROINode()->GetParentTransformNode()
+    && !parametersNode->GetROINode()->GetParentTransformNode()->IsTransformToWorldLinear())
+    {
+    // misaligned, as ROI node is under non-linear transform
+    return false;
+    }
+
+  vtkNew<vtkMatrix4x4> volumeRasToROI;
+  vtkMRMLTransformNode::GetMatrixTransformBetweenNodes(parametersNode->GetInputVolumeNode()->GetParentTransformNode(),
+    parametersNode->GetROINode()->GetParentTransformNode(), volumeRasToROI.GetPointer());
+  vtkNew<vtkMatrix4x4> volumeIJKToRAS;
+  parametersNode->GetInputVolumeNode()->GetIJKToRASMatrix(volumeIJKToRAS.GetPointer());
+  vtkNew<vtkMatrix4x4> volumeIJKToROI;
+  vtkMatrix4x4::Multiply4x4(volumeRasToROI.GetPointer(), volumeIJKToRAS.GetPointer(), volumeIJKToROI.GetPointer());
+
+  double scale[3] = { 1.0 };
+  vtkAddonMathUtilities::NormalizeOrientationMatrixColumns(volumeIJKToROI.GetPointer(), scale);
+
+  double tolerance = 0.001;
+  for (int row = 0; row < 3; row++)
+    {
+    for (int column = 0; column < 3; column++)
+      {
+        double elemAbs = fabs(volumeIJKToROI->GetElement(row, column));
+      if (elemAbs > tolerance && elemAbs < 1 - tolerance)
+        {
+        // axes are neither orthogonal nor parallel
+        return false;
+        }
+      }
+    }
   return true;
 }

--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
@@ -33,6 +33,34 @@ class vtkMatrix4x4;
 #include "vtkSlicerCropVolumeModuleLogicExport.h"
 class vtkMRMLCropVolumeParametersNode;
 
+
+/// \class vtkSlicerCropVolumeLogic
+/// \brief Crop a volume to the specified region of interest.
+///
+/// This class implements cropping and resampling of a volume.
+/// Two main use cases:
+///
+/// 1. Reduce size (both extent and resolution) of a large volume.
+/// Size reduction is useful, as it reduces memory need and makes
+/// visualization and processing faster.
+///
+/// 2. Increase resolution of a specific region.
+/// Increasing resolution (decreasing voxel size) is useful for
+/// segmentation and visualization of fine details.
+///
+/// If interpolation is disabled then only the extent of the volume
+/// is decreased. Cropping without resampling is very fast and needs
+/// almost no extra memory.
+///
+/// If interpolation is enabled, then both the size and resolution
+/// of the volume can be changed.
+///
+/// Limitations:
+/// * Region of interes (ROI) node cannot be under non-linear transform
+/// * Cropped output volume node cannot be under non-linear transform
+/// * If interpolation is disabled: input volume node cannot be under non-linear transform
+///   and ROI node must be aligned with the input volume
+///
 /// \ingroup Slicer_QtModules_CropVolume
 class VTK_SLICER_CROPVOLUME_MODULE_LOGIC_EXPORT vtkSlicerCropVolumeLogic
   : public vtkSlicerModuleLogic
@@ -49,23 +77,36 @@ public:
   void SetResampleLogic(vtkSlicerCLIModuleLogic* logic);
   vtkSlicerCLIModuleLogic* GetResampleLogic();
 
+  /// Crop input volume using the specified ROI node.
   int Apply(vtkMRMLCropVolumeParametersNode*);
 
-  void CropVoxelBased(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume, vtkMRMLVolumeNode* outputNode);
+  /// Perform non-interpolated (voxel-based) cropping.
+  static int CropVoxelBased(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume, vtkMRMLVolumeNode* outputNode);
+
+  /// Compute non-interpolated (voxel-based) cropping output volume geometry (without actually cropping the image).
+  static bool GetVoxelBasedCropOutputExtent(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume, int outputExtent[6]);
+
+  /// Perform interpolated cropping.
+  int CropInterpolated(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume, vtkMRMLVolumeNode* outputNode,
+    bool isotropicResampling, double spacingScale, int interpolationMode);
+
+  /// Computes output volume geometry for interpolated cropping (without actually cropping the image).
+  static bool GetInterpolatedCropOutputGeometry(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume,
+    bool isotropicResampling, double spacingScale, int outputExtent[6], double outputSpacing[3]);
+
+  /// Sets ROI to fit to input volume.
+  /// If ROI is under a non-linear transform then the ROI transform will be reset to RAS.
+  static bool FitROIToInputVolume(vtkMRMLCropVolumeParametersNode* parametersNode);
+
+  static void SnapROIToVoxelGrid(vtkMRMLCropVolumeParametersNode* parametersNode);
+
+  static bool IsROIAlignedWithInputVolume(vtkMRMLCropVolumeParametersNode* parametersNode);
 
   virtual void RegisterNodes();
-
-  static bool IsVolumeTiltedInRAS(vtkMRMLVolumeNode* inputVolume, vtkMatrix4x4* rotation);
-  static bool ComputeIJKToRASRotationOnlyMatrix(vtkMRMLVolumeNode* inputVolume, vtkMatrix4x4* outputMatrix);
-
-  void SnapROIToVoxelGrid(vtkMRMLAnnotationROINode* inputROI, vtkMRMLVolumeNode* inputVolume);
-
 
 protected:
   vtkSlicerCropVolumeLogic();
   virtual ~vtkSlicerCropVolumeLogic();
-
-  static bool ComputeOrientationMatrixFromScanOrder(const char *order, vtkMatrix4x4 *outputMatrix);
 
 private:
   vtkSlicerCropVolumeLogic(const vtkSlicerCropVolumeLogic&); // Not implemented

--- a/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.h
+++ b/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.h
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   3D Slicer
-  Module:    $RCSfile: vtkMRMLVolumeRenderingParametersNode.h,v $
-  Date:      $Date: 2006/03/19 17:12:29 $
-  Version:   $Revision: 1.3 $
-
 =========================================================================auto=*/
 // .NAME vtkMRMLVolumeRenderingParametersNode - MRML node for storing a slice through RAS space
 // .SECTION Description
@@ -26,12 +21,20 @@
 #include "vtkSlicerCropVolumeModuleMRMLExport.h"
 
 class vtkMRMLAnnotationROINode;
+class vtkMRMLTransformNode;
 class vtkMRMLVolumeNode;
 
 /// \ingroup Slicer_QtModules_CropVolume
 class VTK_SLICER_CROPVOLUME_MODULE_MRML_EXPORT vtkMRMLCropVolumeParametersNode : public vtkMRMLNode
 {
-  public:
+public:
+  enum
+    {
+    InterpolationNearestNeighbor = 1,
+    InterpolationLinear = 2,
+    InterpolationWindowedSinc = 3,
+    InterpolationBSpline = 4
+    };
 
   static vtkMRMLCropVolumeParametersNode *New();
   vtkTypeMacro(vtkMRMLCropVolumeParametersNode,vtkMRMLNode);
@@ -39,37 +42,46 @@ class VTK_SLICER_CROPVOLUME_MODULE_MRML_EXPORT vtkMRMLCropVolumeParametersNode :
 
   virtual vtkMRMLNode* CreateNodeInstance();
 
-  // Description:
-  // Set node attributes
+  /// Set node attributes from XML attributes
   virtual void ReadXMLAttributes( const char** atts);
 
-  // Description:
-  // Write this node's information to a MRML file in XML format.
+  /// Write this node's information to a MRML file in XML format.
   virtual void WriteXML(ostream& of, int indent);
 
-  // Description:
-  // Copy the node's attributes to this object
+  /// Copy the node's attributes to this object
   virtual void Copy(vtkMRMLNode *node);
 
-  // Description:
-  // Get node XML tag name (like Volume, Model)
+  /// Get node XML tag name (like Volume, Model)
   virtual const char* GetNodeTagName() {return "CropVolumeParameters";};
 
-  // Description:
-  vtkSetStringMacro(InputVolumeNodeID);
-  vtkGetStringMacro (InputVolumeNodeID);
-  vtkSetStringMacro(OutputVolumeNodeID);
-  vtkGetStringMacro (OutputVolumeNodeID);
-  vtkSetStringMacro(ROINodeID);
-  vtkGetStringMacro (ROINodeID);
+  /// Set volume node to be cropped
+  void SetInputVolumeNodeID(const char *nodeID);
+  /// Get volume node to be cropped
+  const char *GetInputVolumeNodeID();
+  vtkMRMLVolumeNode* GetInputVolumeNode();
+
+  /// Set resulting cropped volume node
+  void SetOutputVolumeNodeID(const char *nodeID);
+  /// Get resulting cropped volume node
+  const char* GetOutputVolumeNodeID();
+  vtkMRMLVolumeNode* GetOutputVolumeNode();
+
+  /// Set cropping region of interest
+  void SetROINodeID(const char *nodeID);
+  /// Get cropping region of interest
+  const char* GetROINodeID();
+  vtkMRMLAnnotationROINode* GetROINode();
+
+  /// Set transform node that may be used for aligning
+  /// the ROI with the input volume.
+  void SetROIAlignmentTransformNodeID(const char *nodeID);
+  const char* GetROIAlignmentTransformNodeID();
+  vtkMRMLTransformNode* GetROIAlignmentTransformNode();
+  void DeleteROIAlignmentTransformNode();
 
   vtkSetMacro(IsotropicResampling,bool);
   vtkGetMacro(IsotropicResampling,bool);
   vtkBooleanMacro(IsotropicResampling,bool);
-
-  vtkSetMacro(ROIVisibility,bool);
-  vtkGetMacro(ROIVisibility,bool);
-  vtkBooleanMacro(ROIVisibility,bool);
 
   vtkSetMacro(VoxelBased,bool);
   vtkGetMacro(VoxelBased,bool);
@@ -88,11 +100,6 @@ protected:
   vtkMRMLCropVolumeParametersNode(const vtkMRMLCropVolumeParametersNode&);
   void operator=(const vtkMRMLCropVolumeParametersNode&);
 
-  char *InputVolumeNodeID;
-  char *OutputVolumeNodeID;
-  char *ROINodeID;
-
-  bool ROIVisibility;
   bool VoxelBased;
   int InterpolationMode;
   bool IsotropicResampling;

--- a/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
+++ b/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>670</width>
-    <height>482</height>
+    <width>297</width>
+    <height>451</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,33 +18,33 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="ctkCollapsibleButton" name="ParametersCollapsibleButton">
+    <widget class="ctkCollapsibleButton" name="ParameterSetCollapsibleButton">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+      <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Parameters</string>
+      <string>Crop Volume</string>
      </property>
-     <layout class="QFormLayout" name="parametersFormLayout">
+     <property name="collapsedHeight">
+      <number>6</number>
+     </property>
+     <layout class="QFormLayout" name="parametersFormLayout_3">
       <property name="fieldGrowthPolicy">
        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
       </property>
       <property name="verticalSpacing">
-       <number>12</number>
+       <number>6</number>
       </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
+      <property name="margin">
+       <number>4</number>
       </property>
       <item row="0" column="0">
        <widget class="QLabel" name="ParameterNodeLabel">
         <property name="text">
-         <string>Parameters Node:</string>
+         <string>Parameter set:</string>
         </property>
        </widget>
       </item>
@@ -64,6 +64,9 @@
         <property name="showHidden">
          <bool>true</bool>
         </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
         <property name="addEnabled">
          <bool>true</bool>
         </property>
@@ -72,14 +75,41 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="InputOutputCollapsibleButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>IO</string>
+     </property>
+     <property name="collapsedHeight">
+      <number>6</number>
+     </property>
+     <layout class="QFormLayout" name="parametersFormLayout">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      </property>
+      <property name="verticalSpacing">
+       <number>6</number>
+      </property>
+      <property name="margin">
+       <number>4</number>
+      </property>
+      <item row="0" column="0">
        <widget class="QLabel" name="InputVolumeLabel">
         <property name="text">
          <string>Input volume:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="0" column="1">
        <widget class="qMRMLNodeComboBox" name="InputVolumeComboBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -93,7 +123,7 @@
          </stringlist>
         </property>
         <property name="noneEnabled">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="addEnabled">
          <bool>false</bool>
@@ -103,14 +133,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="InputROILabel">
         <property name="text">
          <string>Input ROI:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="qMRMLNodeComboBox" name="InputROIComboBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -123,8 +153,11 @@
           <string>vtkMRMLAnnotationROINode</string>
          </stringlist>
         </property>
+        <property name="baseName">
+         <string>Crop Volume ROI</string>
+        </property>
         <property name="noneEnabled">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="editEnabled">
          <bool>true</bool>
@@ -134,168 +167,415 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="TechniqueLabel">
-        <property name="text">
-         <string>Technique:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
         <property name="spacing">
-         <number>12</number>
+         <number>6</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
         </property>
         <item>
-         <widget class="QRadioButton" name="InterpolationModeRadioButton">
+         <widget class="ctkCheckBox" name="VisibilityButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="text">
-           <string>Interpolated cropping</string>
+           <string>Display ROI</string>
           </property>
-          <property name="checked">
-           <bool>true</bool>
+          <property name="indicatorIcon">
+           <iconset resource="../../../../../Libs/MRML/Widgets/Resources/qMRMLWidgets.qrc">
+            <normaloff>:/Icons/VisibleOn.png</normaloff>
+            <normalon>:/Icons/VisibleOff.png</normalon>:/Icons/VisibleOn.png</iconset>
           </property>
-          <attribute name="buttonGroup">
-           <string notr="true">TechniqueButtonGroup</string>
-          </attribute>
+          <property name="indicatorIconSize">
+           <size>
+            <width>21</width>
+            <height>21</height>
+           </size>
+          </property>
          </widget>
         </item>
         <item>
-         <widget class="QRadioButton" name="VoxelBasedModeRadioButton">
-          <property name="text">
-           <string>Voxel based cropping</string>
+         <widget class="QPushButton" name="ROIFitPushButton">
+          <property name="enabled">
+           <bool>false</bool>
           </property>
-          <attribute name="buttonGroup">
-           <string notr="true">TechniqueButtonGroup</string>
-          </attribute>
+          <property name="text">
+           <string>Fit to Volume</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../../../../Libs/MRML/Widgets/Resources/qMRMLWidgets.qrc">
+            <normaloff>:/Icons/ViewCenter.png</normaloff>:/Icons/ViewCenter.png</iconset>
+          </property>
          </widget>
         </item>
        </layout>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="ROIVisibilityLabel">
+      <item row="3" column="0">
+       <widget class="QLabel" name="OutputVolumeLabel">
+        <property name="text">
+         <string>Output volume:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="qMRMLNodeComboBox" name="OutputVolumeComboBox">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="text">
-         <string>ROI visibility:</string>
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLScalarVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="baseName">
+         <string>Cropped volume</string>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Create new volume</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
-       <widget class="QToolButton" name="VisibilityButton">
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="InterpolationOptionsCollapsibleButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Interpolation</string>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <property name="collapsedHeight">
+      <number>6</number>
+     </property>
+     <layout class="QFormLayout" name="parametersFormLayout_2">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      </property>
+      <property name="verticalSpacing">
+       <number>6</number>
+      </property>
+      <property name="margin">
+       <number>4</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="IsotropicOutputVoxelLabel_2">
+        <property name="text">
+         <string>Interpolated cropping:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="InterpolationEnabledCheckBox">
+        <property name="toolTip">
+         <string>Interpolate and pad the input volume to make the output image exactly the size of the ROI, with the requested spacing.</string>
+        </property>
         <property name="text">
          <string/>
         </property>
-        <property name="icon">
-         <iconset resource="../../../../../Libs/MRML/Widgets/Resources/qMRMLWidgets.qrc">
-          <normaloff>:/Icons/VisibleOff.png</normaloff>
-          <normalon>:/Icons/VisibleOn.png</normalon>:/Icons/VisibleOff.png</iconset>
-        </property>
-        <property name="checkable">
+        <property name="checked">
          <bool>true</bool>
+        </property>
+        <property name="tristate">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="2">
-       <widget class="ctkCollapsibleGroupBox" name="InterpolationOptionsGroupBox">
-        <property name="title">
-         <string>Interpolation options</string>
+      <item row="1" column="0">
+       <widget class="QLabel" name="InputSpacingScalingConstantLabel">
+        <property name="toolTip">
+         <string>The voxel spacing in the output volume will be scaled by this value. Values larger than 1.0 will make the cropped volume lower resolution than the input volume. Values smaller than 1.0 will make the cropped volume higher resolution than the input volume.</string>
         </property>
-        <layout class="QFormLayout" name="formLayout_2">
-         <property name="fieldGrowthPolicy">
-          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-         </property>
-         <property name="margin">
-          <number>0</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="IsotropicOutputVoxelLabel">
-           <property name="text">
-            <string>Isotropic output voxel:</string>
+        <property name="text">
+         <string>Spacing scale:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ctkDoubleSpinBox" name="SpacingScalingSpinBox">
+        <property name="toolTip">
+         <string>The voxel spacing in the output volume will be scaled by this value. Values larger than 1.0 will make the cropped volume lower resolution than the input volume. Values smaller than 1.0 will make the cropped volume higher resolution than the input volume.</string>
+        </property>
+        <property name="suffix">
+         <string>x</string>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="IsotropicOutputVoxelLabel">
+        <property name="text">
+         <string>Isotropic spacing:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="IsotropicCheckbox">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="tristate">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="InterpolatorLabel">
+        <property name="text">
+         <string>Interpolator:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="1" column="1">
+         <widget class="QRadioButton" name="BSRadioButton">
+          <property name="toolTip">
+           <string>High quality, slow</string>
+          </property>
+          <property name="text">
+           <string>B-spline</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QRadioButton" name="NNRadioButton">
+          <property name="toolTip">
+           <string>Low quality, fastest</string>
+          </property>
+          <property name="text">
+           <string>Nearest Neighbor</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QRadioButton" name="LinearRadioButton">
+          <property name="toolTip">
+           <string>Medium quality, medium speed</string>
+          </property>
+          <property name="text">
+           <string>Linear</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QRadioButton" name="WSRadioButton">
+          <property name="toolTip">
+           <string>High quality, slow</string>
+          </property>
+          <property name="text">
+           <string>Windowed Sinc</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="VolumeInformationCollapsibleButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Volume information</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <property name="collapsedHeight">
+      <number>6</number>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="margin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="QGroupBox" name="InputVolumeInfoGroupBox">
+        <property name="title">
+         <string>Input volume</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="1" column="1">
+          <widget class="qMRMLCoordinatesWidget" name="InputDimensionsWidget">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>Output volume dimension after cropping</string>
+           </property>
+           <property name="decimals">
+            <number>0</number>
+           </property>
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1000000.000000000000000</double>
+           </property>
+           <property name="coordinates" stdset="0">
+            <string>0,0,0</string>
+           </property>
+           <property name="unitAwareProperties">
+            <set>qMRMLCoordinatesWidget::All</set>
            </property>
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QCheckBox" name="IsotropicCheckbox">
-           <property name="text">
-            <string/>
-           </property>
-           <property name="tristate">
+          <widget class="qMRMLCoordinatesWidget" name="InputSpacingWidget">
+           <property name="enabled">
             <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>Output volume spacing after cropping</string>
+           </property>
+           <property name="decimals">
+            <number>4</number>
+           </property>
+           <property name="decimalsOption">
+            <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::DecimalsByValue</set>
+           </property>
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1000000000.000000000000000</double>
+           </property>
+           <property name="coordinates" stdset="0">
+            <string>0,0,0</string>
+           </property>
+           <property name="quantity">
+            <string>length</string>
+           </property>
+           <property name="unitAwareProperties">
+            <set>qMRMLCoordinatesWidget::Precision|qMRMLCoordinatesWidget::Prefix|qMRMLCoordinatesWidget::Scaling|qMRMLCoordinatesWidget::Suffix</set>
            </property>
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QLabel" name="InputSpacingScalingConstantLabel">
-           <property name="toolTip">
-            <string>If not equal to 1, this will result in upsampling (&lt;1) or downsampling (&gt;1) relative to the voxel spacing of the input volume.</string>
-           </property>
+          <widget class="QLabel" name="InputDimensionsLabel">
            <property name="text">
-            <string>Input spacing scaling constant:</string>
+            <string>Dimensions:</string>
            </property>
           </widget>
          </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="InputSpacingLabel">
+           <property name="text">
+            <string>Spacing:</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="OutputVolumeInfoGroupBox">
+        <property name="title">
+         <string>Cropped volume</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
          <item row="1" column="1">
-          <widget class="ctkDoubleSpinBox" name="SpacingScalingSpinBox">
+          <widget class="qMRMLCoordinatesWidget" name="CroppedDimensionsWidget">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
            <property name="toolTip">
-            <string>The voxel spacing in the output volume will be scaled by this value.</string>
+            <string>Output volume dimension after cropping</string>
            </property>
-           <property name="value">
-            <double>1.000000000000000</double>
+           <property name="decimals">
+            <number>0</number>
+           </property>
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1000000.000000000000000</double>
+           </property>
+           <property name="coordinates" stdset="0">
+            <string>0,0,0</string>
+           </property>
+           <property name="unitAwareProperties">
+            <set>qMRMLCoordinatesWidget::All</set>
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="InterpolatorLabel">
+         <item row="0" column="1">
+          <widget class="qMRMLCoordinatesWidget" name="CroppedSpacingWidget">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>Output volume spacing after cropping</string>
+           </property>
+           <property name="decimals">
+            <number>4</number>
+           </property>
+           <property name="decimalsOption">
+            <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::DecimalsByValue</set>
+           </property>
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1000000000.000000000000000</double>
+           </property>
+           <property name="coordinates" stdset="0">
+            <string>0,0,0</string>
+           </property>
+           <property name="quantity">
+            <string>length</string>
+           </property>
+           <property name="unitAwareProperties">
+            <set>qMRMLCoordinatesWidget::Precision|qMRMLCoordinatesWidget::Prefix|qMRMLCoordinatesWidget::Scaling|qMRMLCoordinatesWidget::Suffix</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="CroppedSpacingLabel">
            <property name="text">
-            <string>Interpolator:</string>
+            <string>Spacing:</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <widget class="QWidget" name="InterpolatorWidget" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+         <item row="1" column="0">
+          <widget class="QLabel" name="CroppedDimensionsLabel">
+           <property name="text">
+            <string>Dimensions:</string>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QRadioButton" name="NNRadioButton">
-              <property name="text">
-               <string>Nearest Neighbor</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="LinearRadioButton">
-              <property name="text">
-               <string>Linear</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="WSRadioButton">
-              <property name="text">
-               <string>WindowedSinc</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="BSRadioButton">
-              <property name="text">
-               <string>B-spline</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
           </widget>
          </item>
         </layout>
@@ -303,6 +583,39 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <property name="rightMargin">
+      <number>4</number>
+     </property>
+     <item>
+      <widget class="ctkFittedTextBrowser" name="AlignmentErrorLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QTextEdit::WidgetWidth</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="AlignmentErrorFixButton">
+       <property name="text">
+        <string>Fix</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QPushButton" name="CropButton">
@@ -313,7 +626,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Crop!</string>
+      <string>Apply</string>
      </property>
     </widget>
    </item>
@@ -334,6 +647,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>qMRMLCoordinatesWidget</class>
+   <extends>ctkCoordinatesWidget</extends>
+   <header>qMRMLCoordinatesWidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
@@ -346,21 +664,30 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>ctkCheckBox</class>
+   <extends>QCheckBox</extends>
+   <header>ctkCheckBox.h</header>
+  </customwidget>
+  <customwidget>
    <class>ctkCollapsibleButton</class>
    <extends>QWidget</extends>
    <header>ctkCollapsibleButton.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ctkCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>ctkCollapsibleGroupBox.h</header>
-   <container>1</container>
+   <class>ctkCoordinatesWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkCoordinatesWidget.h</header>
   </customwidget>
   <customwidget>
    <class>ctkDoubleSpinBox</class>
    <extends>QWidget</extends>
    <header>ctkDoubleSpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkFittedTextBrowser</class>
+   <extends>QTextBrowser</extends>
+   <header>ctkFittedTextBrowser.h</header>
   </customwidget>
  </customwidgets>
  <resources>
@@ -379,8 +706,8 @@
      <y>4</y>
     </hint>
     <hint type="destinationlabel">
-     <x>376</x>
-     <y>111</y>
+     <x>279</x>
+     <y>46</y>
     </hint>
    </hints>
   </connection>
@@ -395,8 +722,8 @@
      <y>4</y>
     </hint>
     <hint type="destinationlabel">
-     <x>376</x>
-     <y>111</y>
+     <x>279</x>
+     <y>103</y>
     </hint>
    </hints>
   </connection>
@@ -407,49 +734,254 @@
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>352</x>
+     <x>283</x>
      <y>7</y>
     </hint>
     <hint type="destinationlabel">
-     <x>483</x>
-     <y>148</y>
+     <x>279</x>
+     <y>129</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>InterpolationModeRadioButton</sender>
+   <sender>qSlicerCropVolumeModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>OutputVolumeComboBox</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>283</x>
+     <y>329</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>279</x>
+     <y>187</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerCropVolumeModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>InputSpacingWidget</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>283</x>
+     <y>499</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>269</x>
+     <y>456</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>InterpolationEnabledCheckBox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>InterpolationOptionsGroupBox</receiver>
+   <receiver>IsotropicCheckbox</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>254</x>
-     <y>83</y>
+     <x>279</x>
+     <y>237</y>
     </hint>
     <hint type="destinationlabel">
-     <x>340</x>
-     <y>161</y>
+     <x>279</x>
+     <y>282</y>
     </hint>
    </hints>
   </connection>
   <connection>
-   <sender>InterpolationModeRadioButton</sender>
+   <sender>InterpolationEnabledCheckBox</sender>
    <signal>toggled(bool)</signal>
-   <receiver>InterpolationOptionsGroupBox</receiver>
-   <slot>setChecked(bool)</slot>
+   <receiver>SpacingScalingSpinBox</receiver>
+   <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>199</x>
-     <y>77</y>
+     <x>140</x>
+     <y>232</y>
     </hint>
     <hint type="destinationlabel">
-     <x>340</x>
-     <y>221</y>
+     <x>266</x>
+     <y>263</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>InterpolationEnabledCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>NNRadioButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>139</x>
+     <y>231</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>198</x>
+     <y>303</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>InterpolationEnabledCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>LinearRadioButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>174</x>
+     <y>231</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>167</x>
+     <y>325</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>InterpolationEnabledCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>WSRadioButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>233</x>
+     <y>230</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>132</x>
+     <y>347</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>InterpolationEnabledCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>BSRadioButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>120</x>
+     <y>234</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>130</x>
+     <y>370</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>InputROIComboBox</sender>
+   <signal>currentNodeChanged(bool)</signal>
+   <receiver>VisibilityButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>154</x>
+     <y>123</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>154</x>
+     <y>149</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>InputROIComboBox</sender>
+   <signal>currentNodeChanged(bool)</signal>
+   <receiver>ROIFitPushButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>279</x>
+     <y>129</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>278</x>
+     <y>160</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ParametersNodeComboBox</sender>
+   <signal>currentNodeChanged(bool)</signal>
+   <receiver>InputOutputCollapsibleButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>102</x>
+     <y>38</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>102</x>
+     <y>68</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ParametersNodeComboBox</sender>
+   <signal>currentNodeChanged(bool)</signal>
+   <receiver>InterpolationOptionsCollapsibleButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>129</x>
+     <y>38</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>70</x>
+     <y>209</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ParametersNodeComboBox</sender>
+   <signal>currentNodeChanged(bool)</signal>
+   <receiver>VolumeInformationCollapsibleButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>253</x>
+     <y>37</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>93</x>
+     <y>403</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ParametersNodeComboBox</sender>
+   <signal>currentNodeChanged(bool)</signal>
+   <receiver>CropButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>228</x>
+     <y>37</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>58</x>
+     <y>610</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerCropVolumeModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>CroppedSpacingWidget</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>14</x>
+     <y>55</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>173</x>
+     <y>531</y>
     </hint>
    </hints>
   </connection>
  </connections>
- <buttongroups>
-  <buttongroup name="TechniqueButtonGroup"/>
- </buttongroups>
 </ui>

--- a/Modules/Loadable/CropVolume/Testing/Python/CropVolumeSelfTest.py
+++ b/Modules/Loadable/CropVolume/Testing/Python/CropVolumeSelfTest.py
@@ -173,6 +173,8 @@ class CropVolumeSelfTestTest(unittest.TestCase):
     # test clearing the scene and running a second time
     slicer.mrmlScene.Clear(0)
     # the module will re-add the removed parameters node
+    mainWindow.moduleSelector().selectModule('Transforms')
+    mainWindow.moduleSelector().selectModule('CropVolume')
     cropVolumeNode = slicer.mrmlScene.GetNodeByID('vtkMRMLCropVolumeParametersNode1')
     vol = self.downloadMRHead()
     roi = slicer.vtkMRMLAnnotationROINode()

--- a/Modules/Loadable/CropVolume/Testing/vtkMRMLCropVolumeParametersNodeTest1.cxx
+++ b/Modules/Loadable/CropVolume/Testing/vtkMRMLCropVolumeParametersNodeTest1.cxx
@@ -24,7 +24,6 @@ int vtkMRMLCropVolumeParametersNodeTest1(int , char * [] )
   TEST_SET_GET_STRING(node1.GetPointer(), OutputVolumeNodeID);
   TEST_SET_GET_STRING(node1.GetPointer(), ROINodeID);
 
-  TEST_SET_GET_BOOLEAN(node1.GetPointer(), ROIVisibility);
   TEST_SET_GET_BOOLEAN(node1.GetPointer(), VoxelBased);
   TEST_SET_GET_INT_RANGE(node1.GetPointer(), InterpolationMode, 1, 4);
   TEST_SET_GET_BOOLEAN(node1.GetPointer(), IsotropicResampling);

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.h
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.h
@@ -25,6 +25,7 @@ public:
   virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
 
 public slots:
+  void setParametersNode(vtkMRMLNode* node);
 
 protected:
   QScopedPointer<qSlicerCropVolumeModuleWidgetPrivate> d_ptr;
@@ -33,30 +34,28 @@ protected:
   virtual void enter();
   virtual void setMRMLScene(vtkMRMLScene*);
 
-  void initializeParameterNode(vtkMRMLScene*);
-
-
-
 protected slots:
-  void initializeNode(vtkMRMLNode*);
-  void onInputVolumeChanged();
-  /// when input volumes get added to the node selector, if the selector doesn't
-  /// have a current node, select it
-  void onInputVolumeAdded(vtkMRMLNode*);
-  void onInputROIChanged();
+  void setInputVolume(vtkMRMLNode*);
+  void setOutputVolume(vtkMRMLNode* node);
+  void setInputROI(vtkMRMLNode*);
+  void initializeInputROI(vtkMRMLNode*);
   /// when ROIs get added to the node selector, if the selector doesn't
   /// have a current node, select it
-  void onInputROIAdded(vtkMRMLNode*);
-  void onROIVisibilityChanged();
+  void onInputROIAdded(vtkMRMLNode* node);
+
+  void onROIVisibilityChanged(bool);
+  void onROIFit();
   void onInterpolationModeChanged();
   void onApply();
-  void updateWidget();
-  void updateParameters();
+  void onFixAlignment();
+  void updateWidgetFromMRML();
   void onSpacingScalingValueChanged(double);
-  void onIsotropicModeChanged();
-  void onEndCloseEvent();
-  void onVoxelBasedChecked(bool checked);
+  void onIsotropicModeChanged(bool);
+  void onMRMLSceneEndBatchProcessEvent();
+  void onInterpolationEnabled(bool interpolationEnabled);
+  void onVolumeInformationSectionClicked(bool isOpen);
 
+  void updateVolumeInfo();
 
 private:
   Q_DECLARE_PRIVATE(qSlicerCropVolumeModuleWidget);


### PR DESCRIPTION
While assisting many users in learning segmenting using Segment Editor, it turned out that Crop Volume module is an essential pre-processing tool for segmentation. Either for reducing size of large volumes (cropping/downsampling) or allowing better segmentation of structures that are comparable to the voxel size (cropping/upsampling).

Crop Volume had many limitations, all of them fixed in this pull request:
* Cropping of transformed or non-axis aligned volumes and ROIs was very limited (input volume was not allowed to be transformed, non-linear transforms were not allowed) - now interpolated cropping allows linear transforms of any volumes or ROIs, input volume can even be non-linearly transformed
* No output volume was selectable (this was unlike all other modules in Slicer and it often lead to creating several unneeded output volumes when experimenting with cropping parameters) => now output volume can be specified (if not specified then it is created automatically)
* If inconsistency was found (e.g., misaligned ROI and input volume for voxel-based cropping) then a popup was displayed and users' node selections were reverted, which often disrupted user's workflow (for example, it was not possible to switch input volume and then switch to corresponding ROI because after switching input volume there was a temporary inconsistency that the module wanted to resolve immediately) => now when there is any inconsistency, an error message is displayed and Apply button is disabled; the user can either resolve inconsistencies by selecting different nodes, changing transforms, or clicking the Fix button to automatically resolve all inconsistencies by changing/aligning transforms
* It was tedious to initialize ROI to include the entire volume (e.g., when the goal was to decrease resolution or crop only on one side) => now a ROI auto-fit button is available
* Meaning of "Input spacing scaling constant" parameter was not clear (is it an absolute spacing value or a factor relative to current spacing; what value increases/decreases the resolution) and it was often difficult to predict how large the cropped output volume will be without actually performing the cropping. => now in the Volume information section users can immediately see what the size and resolution of the cropped volume will be
* Cropping of large volumes required lots of memory (voxel-based cropping created extra unnecessary temporary vtkImageData objects; interpolated cropping created an unnecessary reference volume, instead of just specifying output volume geometry using CLI arguments) => no unnecessary images are created now
* Spacing was not computed correctly for volumes where the order of axes were permuted (for example in MRHead sample) => axes between input and output volumes are now correctly matched