### PR TITLE
Dataprobe.py - Check for attribute _text_ on parent

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -284,11 +284,12 @@ class DataProbeInfoWidget(object):
         self.imageLabel.setPixmap(pixmap)
         self.onShowImage(self.showImage)
 
-    sceneName = slicer.mrmlScene.GetURL()
-    if sceneName != "":
-      self.frame.parent().text = "Data Probe: %s" % self.fitName(sceneName,nameSize=2*self.nameSize)
-    else:
-      self.frame.parent().text = "Data Probe"
+    if hasattr(self.frame.parent(), 'text'):
+      sceneName = slicer.mrmlScene.GetURL()
+      if sceneName != "":
+        self.frame.parent().text = "Data Probe: %s" % self.fitName(sceneName,nameSize=2*self.nameSize)
+      else:
+        self.frame.parent().text = "Data Probe"
 
   def generateViewDescription(self, xyz, ras, sliceNode, sliceLogic):
 


### PR DESCRIPTION
We are using the DataProbeWidget on a view on our own. Without the proposed change the processEvents throws errors because there exists not _text_ attribute on the parent. The change checks for the attribute _text_ and executes the code only when the attribute exists. 
It will not break any existing code.

Thanks for considering this change.