### PR TITLE
ENH: Added smooth clipping option for volumetric meshes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLClipModelsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLClipModelsNode.cxx
@@ -99,14 +99,14 @@ void vtkMRMLClipModelsNode::ReadXMLAttributes(const char** atts)
       {
       std::stringstream ss;
       ss << attValue;
-      ClippingMethodType id = this->GetClippingMethodFromString(attValue);
-      if (id == ClippingMethod_Last)
+      int id = this->GetClippingMethodFromString(attValue);
+      if (id < 0)
         {
         vtkWarningMacro("Invalid Clipping Methods: "<<(attValue?attValue:"(none)"));
         }
       else
         {
-        this->ClippingMethod = id;
+        this->ClippingMethod = static_cast<ClippingMethodType>(id);
         }
       }
     }
@@ -148,24 +148,27 @@ void vtkMRMLClipModelsNode::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //-----------------------------------------------------------------------------
-vtkMRMLClipModelsNode::ClippingMethodType vtkMRMLClipModelsNode::GetClippingMethodFromString(const char* name)
+int vtkMRMLClipModelsNode::GetClippingMethodFromString(const char* name)
 {
   if (name == NULL)
     {
     // invalid name
-    return ClippingMethod_Last;
+    return -1;
     }
-  for (int i=0; i<ClippingMethod_Last; i++)
+  if (strcmp(name, "Straight"))
     {
-    ClippingMethodType id = static_cast<ClippingMethodType>(i);
-    if (strcmp(name, GetClippingMethodAsString(id))==0)
-      {
-      // found a matching name
-      return id;
-      }
+    return (int)Straight;
+    }
+  else if (strcmp(name, "Whole Cells"))
+    {
+    return (int)WholeCells;
+    }
+  else if (strcmp(name, "Whole Cells With Boundary"))
+    {
+    return (int)WholeCellsWithBoundary;
     }
   // unknown name
-  return ClippingMethod_Last;
+  return -1;
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLClipModelsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLClipModelsNode.cxx
@@ -33,6 +33,7 @@ vtkMRMLClipModelsNode::vtkMRMLClipModelsNode()
   this->RedSliceClipState = 0;
   this->YellowSliceClipState = 0;
   this->GreenSliceClipState = 0;
+  this->ClippingMethod = vtkMRMLClipModelsNode::Straight;
 }
 
 //----------------------------------------------------------------------------
@@ -54,7 +55,7 @@ void vtkMRMLClipModelsNode::WriteXML(ostream& of, int nIndent)
   of << indent << " redSliceClipState=\"" << this->RedSliceClipState << "\"";
   of << indent << " yellowSliceClipState=\"" << this->YellowSliceClipState << "\"";
   of << indent << " greenSliceClipState=\"" << this->GreenSliceClipState << "\"";
-
+  of << indent << " clippingMethod=\"" << (this->GetClippingMethodAsString(this->ClippingMethod)) << "\n";
 }
 
 //----------------------------------------------------------------------------
@@ -94,6 +95,20 @@ void vtkMRMLClipModelsNode::ReadXMLAttributes(const char** atts)
       ss << attValue;
       ss >> ClipType;
       }
+    else if (!strcmp(attName, "clippingMethod"))
+      {
+      std::stringstream ss;
+      ss << attValue;
+      ClippingMethodType id = this->GetClippingMethodFromString(attValue);
+      if (id == ClippingMethod_Last)
+        {
+        vtkWarningMacro("Invalid Clipping Methods: "<<(attValue?attValue:"(none)"));
+        }
+      else
+        {
+        this->ClippingMethod = id;
+        }
+      }
     }
     this->EndModify(disabledModify);
 
@@ -114,6 +129,7 @@ void vtkMRMLClipModelsNode::Copy(vtkMRMLNode *anode)
   this->SetYellowSliceClipState(node->YellowSliceClipState);
   this->SetGreenSliceClipState(node->GreenSliceClipState);
   this->SetRedSliceClipState(node->RedSliceClipState);
+  this->SetClippingMethod(node->ClippingMethod);
 
   this->EndModify(disabledModify);
 
@@ -128,5 +144,41 @@ void vtkMRMLClipModelsNode::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "YellowSliceClipState: " << this->YellowSliceClipState << "\n";
   os << indent << "GreenSliceClipState:  " << this->GreenSliceClipState << "\n";
   os << indent << "RedSliceClipState:    " << this->RedSliceClipState << "\n";
+  os << indent << " clippingMethod=\"" << (this->GetClippingMethodAsString(this->ClippingMethod)) << "\n";
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLClipModelsNode::ClippingMethodType vtkMRMLClipModelsNode::GetClippingMethodFromString(const char* name)
+{
+  if (name == NULL)
+    {
+    // invalid name
+    return ClippingMethod_Last;
+    }
+  for (int i=0; i<ClippingMethod_Last; i++)
+    {
+    ClippingMethodType id = static_cast<ClippingMethodType>(i);
+    if (strcmp(name, GetClippingMethodAsString(id))==0)
+      {
+      // found a matching name
+      return id;
+      }
+    }
+  // unknown name
+  return ClippingMethod_Last;
+}
+
+//-----------------------------------------------------------------------------
+const char* vtkMRMLClipModelsNode::GetClippingMethodAsString(ClippingMethodType id)
+{
+ switch (id)
+    {
+    case Straight: return "Straight";
+    case WholeCells: return "Whole Cells";
+    case WholeCellsWithBoundary: return "Whole Cells With Boundary";
+    default:
+      // invalid id
+      return "";
+    }
 }
 

--- a/Libs/MRML/Core/vtkMRMLClipModelsNode.h
+++ b/Libs/MRML/Core/vtkMRMLClipModelsNode.h
@@ -90,6 +90,24 @@ public:
       ClipNegativeSpace = 2,
     };
 
+  ///
+  ///Indicates what clipping method should be used
+  ///Straight cut, whole cell extraction, or whole cell extraction with boundary cells
+  typedef enum
+  {
+    Straight = 0,
+    WholeCells,
+    WholeCellsWithBoundary,
+    ClippingMethod_Last,
+  } ClippingMethodType;
+
+  vtkGetMacro(ClippingMethod, ClippingMethodType);
+  vtkSetMacro(ClippingMethod, ClippingMethodType);
+
+  //Convert between enum and string
+  static ClippingMethodType GetClippingMethodFromString(const char* name);
+  static const char* GetClippingMethodAsString(ClippingMethodType id);
+
 protected:
   vtkMRMLClipModelsNode();
   ~vtkMRMLClipModelsNode();
@@ -101,6 +119,8 @@ protected:
   int RedSliceClipState;
   int YellowSliceClipState;
   int GreenSliceClipState;
+
+  ClippingMethodType ClippingMethod;
 
 
 };

--- a/Libs/MRML/Core/vtkMRMLClipModelsNode.h
+++ b/Libs/MRML/Core/vtkMRMLClipModelsNode.h
@@ -98,14 +98,13 @@ public:
     Straight = 0,
     WholeCells,
     WholeCellsWithBoundary,
-    ClippingMethod_Last,
   } ClippingMethodType;
 
   vtkGetMacro(ClippingMethod, ClippingMethodType);
   vtkSetMacro(ClippingMethod, ClippingMethodType);
 
   //Convert between enum and string
-  static ClippingMethodType GetClippingMethodFromString(const char* name);
+  static int GetClippingMethodFromString(const char* name);
   static const char* GetClippingMethodAsString(ClippingMethodType id);
 
 protected:

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -42,6 +42,8 @@
 #include <vtkAssignAttribute.h>
 #include <vtkCellArray.h>
 #include <vtkExtractGeometry.h>
+#include <vtkExtractPolyDataGeometry.h>
+#include <vtkClipDataSet.h>
 #include <vtkClipPolyData.h>
 #include <vtkColorTransferFunction.h>
 #include <vtkDataSetAttributes.h>
@@ -113,6 +115,7 @@ public:
   int                     RedSliceClipState;
   int                     YellowSliceClipState;
   int                     GreenSliceClipState;
+  int                     ClippingMethod;
   bool                    ClippingOn;
 
   bool                         ModelHierarchiesPresent;
@@ -177,6 +180,7 @@ void vtkMRMLModelDisplayableManager::vtkInternal::CreateClipSlices()
   this->RedSliceClipState = vtkMRMLClipModelsNode::ClipOff;
   this->YellowSliceClipState = vtkMRMLClipModelsNode::ClipOff;
   this->GreenSliceClipState = vtkMRMLClipModelsNode::ClipOff;
+  this->ClippingMethod = vtkMRMLClipModelsNode::Straight;
 
   this->ClippingOn = false;
 }
@@ -242,8 +246,8 @@ void vtkMRMLModelDisplayableManager::PrintSelf ( ostream& os, vtkIndent indent )
   os << indent << "RedSliceClipState = " << this->Internal->RedSliceClipState << "\n";
   os << indent << "YellowSliceClipState = " << this->Internal->YellowSliceClipState << "\n";
   os << indent << "GreenSliceClipState = " << this->Internal->GreenSliceClipState << "\n";
+  os << indent << "ClippingMethod = " << this->Internal->ClippingMethod << "\n";
   os << indent << "ClippingOn = " << (this->Internal->ClippingOn ? "true" : "false") << "\n";
-
   os << indent << "ModelHierarchiesPresent = " << this->Internal->ModelHierarchiesPresent << "\n";
 
   os << indent << "PickedNodeID = " << this->Internal->PickedNodeID.c_str() << "\n";
@@ -319,7 +323,7 @@ int vtkMRMLModelDisplayableManager::UpdateClipSlicesFromMRML()
   int nnodes = this->GetMRMLScene()->GetNodesByClass("vtkMRMLSliceNode", snodes);
   for (int n=0; n<nnodes; n++)
     {
-      vtkMRMLSliceNode *node = vtkMRMLSliceNode::SafeDownCast (snodes[n]);
+    vtkMRMLSliceNode *node = vtkMRMLSliceNode::SafeDownCast (snodes[n]);
     // TODO use perhaps SliceLogic to get the name instead of "Red" etc.
     if (!strcmp(node->GetLayoutName(), "Red"))
       {
@@ -417,6 +421,12 @@ int vtkMRMLModelDisplayableManager::UpdateClipSlicesFromMRML()
     this->Internal->YellowSliceClipState = this->Internal->ClipModelsNode->GetYellowSliceClipState();
     }
 
+  if (this->Internal->ClipModelsNode->GetClippingMethod() != this->Internal->ClippingMethod)
+    {
+    modifiedState = 1;
+    this->Internal->ClippingMethod = this->Internal->ClipModelsNode->GetClippingMethod();
+    }
+
   // compute clipping on/off
   if (this->Internal->ClipModelsNode->GetRedSliceClipState() == vtkMRMLClipModelsNode::ClipOff &&
       this->Internal->ClipModelsNode->GetGreenSliceClipState() == vtkMRMLClipModelsNode::ClipOff &&
@@ -492,11 +502,11 @@ void vtkMRMLModelDisplayableManager::ProcessMRMLNodesEvents(vtkObject *caller,
       vtkMRMLDisplayableNode::SafeDownCast(caller);
     switch (event)
       {
-       case vtkMRMLDisplayableNode::DisplayModifiedEvent:
+      case vtkMRMLDisplayableNode::DisplayModifiedEvent:
          // don't go any further if the modified display node is not a model
-         if (!this->IsModelDisplayable(displayableNode) &&
-             !this->IsModelDisplayable(
-               reinterpret_cast<vtkMRMLDisplayNode*>(callData)))
+        if (!this->IsModelDisplayable(displayableNode) &&
+            !this->IsModelDisplayable(
+              reinterpret_cast<vtkMRMLDisplayNode*>(callData)))
           {
           requestRender = false;
           break;
@@ -870,7 +880,7 @@ void vtkMRMLModelDisplayableManager::UpdateModelsFromMRML()
         }
       this->UpdateModifiedModel(model);
       }
-    } // end while
+    }
 }
 
 //---------------------------------------------------------------------------
@@ -1314,8 +1324,8 @@ void vtkMRMLModelDisplayableManager::RemoveModelProps()
         }
       else
         {
-        if ((clipIter->second && !this->Internal->ClippingOn) ||
-            (this->Internal->ClippingOn && clipIter->second != clipModel))
+
+        if (clipIter->second  || (this->Internal->ClippingOn && clipIter->second != clipModel))
           {
           this->GetRenderer()->RemoveViewProp(iter->second);
           removedIDs.push_back(iter->first);
@@ -1655,11 +1665,11 @@ const char* vtkMRMLModelDisplayableManager
     {
     if (modelNode->GetMesh())
       {
-     vtkAlgorithmOutput *meshConnection = modelNode->GetMeshConnection();
-     if (meshConnection != NULL)
-       {
-       meshConnection->GetProducer()->Update();
-       }
+      vtkAlgorithmOutput *meshConnection = modelNode->GetMeshConnection();
+      if (meshConnection != NULL)
+        {
+        meshConnection->GetProducer()->Update();
+        }
       }
     activeScalarName =
       modelNode->GetActiveCellScalarName(vtkDataSetAttributes::SCALARS);
@@ -1985,11 +1995,12 @@ vtkAlgorithm* vtkMRMLModelDisplayableManager
 {
   vtkNew<vtkMatrix4x4> transformToWorld;
   transformToWorld->Identity();
+  vtkSmartPointer<vtkImplicitBoolean> slicePlanes;
   if (tnode != 0 && tnode->IsTransformToWorldLinear())
     {
+    slicePlanes = vtkSmartPointer<vtkImplicitBoolean>::New();
     tnode->GetMatrixTransformToWorld(transformToWorld.GetPointer());
 
-    vtkNew<vtkImplicitBoolean> slicePlanes;
 
     if (this->Internal->ClipType == vtkMRMLClipModelsNode::ClipIntersection)
       {
@@ -2041,36 +2052,49 @@ vtkAlgorithm* vtkMRMLModelDisplayableManager
     vtkMatrix4x4::Multiply4x4(transformToWorld.GetPointer(), sliceMatrix, mat.GetPointer());
     planeDirection = (this->Internal->YellowSliceClipState == vtkMRMLClipModelsNode::ClipNegativeSpace) ? -1 : 1;
     this->SetClipPlaneFromMatrix(mat.GetPointer(), planeDirection, yellowSlicePlane.GetPointer());
-
-    if (type == vtkMRMLModelNode::UnstructuredGridMeshType)
+    }
+  else
+    {
+    slicePlanes = this->Internal->SlicePlanes;
+    }
+  if (type == vtkMRMLModelNode::UnstructuredGridMeshType)
+    {
+    if (this->Internal->ClippingMethod == vtkMRMLClipModelsNode::Straight)
       {
-      vtkExtractGeometry* clipper = vtkExtractGeometry::New();
-      //clipper->SetValue(0.0);
-      clipper->SetImplicitFunction(slicePlanes.GetPointer());
+      vtkClipDataSet* clipper = vtkClipDataSet::New();
+      clipper->SetClipFunction(slicePlanes);
       return clipper;
       }
     else
       {
-      vtkClipPolyData* clipper = vtkClipPolyData::New();
-      clipper->SetValue(0.0);
-      clipper->SetClipFunction(slicePlanes.GetPointer());
+      vtkExtractGeometry* clipper = vtkExtractGeometry::New();
+      clipper->SetImplicitFunction(slicePlanes);
+		  clipper->ExtractInsideOff();
+      if (this->Internal->ClippingMethod == vtkMRMLClipModelsNode::WholeCellsWithBoundary)
+        {
+        clipper->ExtractBoundaryCellsOn();
+        }
       return clipper;
       }
     }
   else
     {
-    if (type == vtkMRMLModelNode::UnstructuredGridMeshType)
+    if (this->Internal->ClippingMethod == vtkMRMLClipModelsNode::Straight)
       {
-      vtkExtractGeometry* clipper = vtkExtractGeometry::New();
-      //clipper->SetValue(0.0);
-      clipper->SetImplicitFunction(this->Internal->SlicePlanes);
+      vtkClipPolyData* clipper = vtkClipPolyData::New();
+      clipper->SetValue(0.0);
+      clipper->SetClipFunction(slicePlanes);
       return clipper;
       }
     else
       {
-      vtkClipPolyData* clipper = vtkClipPolyData::New();
-      clipper->SetValue(0.0);
-      clipper->SetClipFunction(this->Internal->SlicePlanes);
+      vtkExtractPolyDataGeometry* clipper = vtkExtractPolyDataGeometry::New();
+      clipper->SetImplicitFunction(slicePlanes);
+      clipper->ExtractInsideOff();
+      if (this->Internal->ClippingMethod == vtkMRMLClipModelsNode::WholeCellsWithBoundary)
+        {
+        clipper->ExtractBoundaryCellsOn();
+        }
       return clipper;
       }
     }

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLClipNodeWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLClipNodeWidget.ui
@@ -190,6 +190,19 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="WholeCellClippingCheckBox">
+      <property name="checked">
+        <bool>false</bool>
+      </property>
+      <property name="text">
+      <string>Keep only whole cells when clipping</string>
+     </property>
+     <property name="toolTip">
+      <string>Keep only whole cells when clipping</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources>

--- a/Libs/MRML/Widgets/qMRMLClipNodeWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLClipNodeWidget.cxx
@@ -101,6 +101,9 @@ void qMRMLClipNodeWidgetPrivate::init()
   QObject::connect(this->GreenNegativeRadioButton, SIGNAL(toggled(bool)),
                    q, SLOT(updateNodeGreenClipState()));
 
+  QObject::connect(this->WholeCellClippingCheckBox, SIGNAL(toggled(bool)),
+                   q, SLOT(updateNodeClippingMethod()));
+
 
   q->setEnabled(this->MRMLClipNode.GetPointer() != 0);
 }
@@ -229,6 +232,24 @@ int qMRMLClipNodeWidget::greenSliceClipState()const
 }
 
 //------------------------------------------------------------------------------
+void qMRMLClipNodeWidget::setClippingMethod(vtkMRMLClipModelsNode::ClippingMethodType state)
+{
+  Q_D(qMRMLClipNodeWidget);
+  if (!d->MRMLClipNode.GetPointer())
+    {
+    return;
+    }
+  d->MRMLClipNode->SetClippingMethod(state);
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLClipModelsNode::ClippingMethodType qMRMLClipNodeWidget::clippingMethod()const
+{
+  Q_D(const qMRMLClipNodeWidget);
+  return d->WholeCellClippingCheckBox->isChecked() ? vtkMRMLClipModelsNode::WholeCells : vtkMRMLClipModelsNode::Straight;
+}
+
+//------------------------------------------------------------------------------
 void qMRMLClipNodeWidget::updateWidgetFromMRML()
 {
   Q_D(qMRMLClipNodeWidget);
@@ -267,6 +288,9 @@ void qMRMLClipNodeWidget::updateWidgetFromMRML()
     d->MRMLClipNode->GetGreenSliceClipState() == vtkMRMLClipModelsNode::ClipPositiveSpace);
   d->GreenNegativeRadioButton->setChecked(
     d->MRMLClipNode->GetGreenSliceClipState() == vtkMRMLClipModelsNode::ClipNegativeSpace);
+
+  d->WholeCellClippingCheckBox->setChecked(
+    d->MRMLClipNode->GetClippingMethod() != vtkMRMLClipModelsNode::Straight);
 
   d->IsUpdatingWidgetFromMRML = oldUpdating;
 }
@@ -308,4 +332,14 @@ void qMRMLClipNodeWidget::updateNodeGreenClipState()
     return;
     }
   this->setGreenSliceClipState(this->greenSliceClipState());
+}
+
+void qMRMLClipNodeWidget::updateNodeClippingMethod()
+{
+  Q_D(const qMRMLClipNodeWidget);
+  if (d->IsUpdatingWidgetFromMRML)
+    {
+    return;
+    }
+  this->setClippingMethod(this->clippingMethod());
 }

--- a/Libs/MRML/Widgets/qMRMLClipNodeWidget.h
+++ b/Libs/MRML/Widgets/qMRMLClipNodeWidget.h
@@ -29,6 +29,7 @@
 
 // qMRML includes
 #include "qMRMLWidgetsExport.h"
+#include "vtkMRMLClipModelsNode.h"
 
 class qMRMLClipNodeWidgetPrivate;
 class vtkMRMLNode;
@@ -48,11 +49,13 @@ public:
   int redSliceClipState()const;
   int yellowSliceClipState()const;
   int greenSliceClipState()const;
+  vtkMRMLClipModelsNode::ClippingMethodType clippingMethod()const;
 
   void setClipType(int);
   void setRedSliceClipState(int);
   void setYellowSliceClipState(int);
   void setGreenSliceClipState(int);
+  void setClippingMethod(vtkMRMLClipModelsNode::ClippingMethodType);
 
 public slots:
   /// Set the clip node to represent
@@ -67,6 +70,7 @@ protected slots:
   void updateNodeRedClipState();
   void updateNodeYellowClipState();
   void updateNodeGreenClipState();
+  void updateNodeClippingMethod();
 
 protected:
   QScopedPointer<qMRMLClipNodeWidgetPrivate> d_ptr;


### PR DESCRIPTION
Gives option to use vtkClipDataSet to create a smooth surface when clipping volumetric meshes

![screenshot 2017-02-17 17 14 08](https://cloud.githubusercontent.com/assets/25040869/23105431/33ccdf70-f6ad-11e6-9eab-eac4c4c4ef21.png)

See: http://na-mic.org/Mantis/view.php?id=4335