### PR TITLE
Update ITK and SimpleITK Superbuild versions

### DIFF
--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -30,10 +30,9 @@ if(NOT DEFINED ITK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
   endif()
 
   set(ITKv4_REPOSITORY ${git_protocol}://github.com/Slicer/ITK.git)
-  # ITK master (v4.11) of 2016-11-07 with
-  # * cherry-picked ITK commit 2a07831 addressing ITK issue https://issues.itk.org/jira/browse/ITK-3504
-  # * workaround to fix MacOSX/XCode Debug build error
-  set(ITKv4_GIT_TAG bd54ba1b14156a66d8e2d49517392658bb13e2a4)
+  # ITK release v4.11.0 from 2017.01.22 with
+  # * Slicer patches for CMP0042
+  set(ITKv4_GIT_TAG 71e441d7ffe525d022ea6e7e3bc35bcc7877ba0d) # slicer-v4.11.0-2017-01-22
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -34,7 +34,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
 ")
 
   set(SimpleITK_REPOSITORY ${git_protocol}://itk.org/SimpleITK.git)
-  set(SimpleITK_GIT_TAG aeada7ab36535041933f2fa7bfe6209e2205984f ) # 0.11.0.dev110
+  set(SimpleITK_GIT_TAG v1.0rc1)
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
@@ -81,13 +81,8 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
       -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
       -DBUILD_TESTING:BOOL=OFF
       -DBUILD_DOXYGEN:BOOL=OFF
+      -DWRAP_DEFAULT:BOOL=OFF
       -DWRAP_PYTHON:BOOL=ON
-      -DWRAP_TCL:BOOL=OFF
-      -DWRAP_JAVA:BOOL=OFF
-      -DWRAP_RUBY:BOOL=OFF
-      -DWRAP_LUA:BOOL=OFF
-      -DWRAP_CSHARP:BOOL=OFF
-      -DWRAP_R:BOOL=OFF
       -DSimpleITK_BUILD_DISTRIBUTE:BOOL=ON # Shorten version and install path removing -g{GIT-HASH} suffix.
       -DExternalData_OBJECT_STORES:PATH=${ExternalData_OBJECT_STORES}
     #


### PR DESCRIPTION
This updates ITK to the current 4.11.0 release, as well as SimpleITK to 1.0rc1.

This update contains a fix needed for the IASEM module to address the following error:
/home/kitware/Dashboards/Nightly/Slicer-0-build/VTKv7-build/ThirdParty/tiff/vtktiff/libtiff/tif_config.h:293:29: fatal error: vtk_tiff_mangle.h: No such file or directory

Which is done by this commit in ITK: 5f97ceaf85bf2f6b1cc3c0c37eff9ea883347dde