### PR TITLE
ENH: add "build-only" key for extension dependency resolution.

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -116,7 +116,8 @@ public:
     ScreenshotsColumn,
     EnabledColumn,
     ArchiveNameColumn,
-    MD5Column
+    MD5Column,
+    BuildOnlyColumn
     };
 
   enum ItemDataRole{
@@ -272,6 +273,7 @@ void qSlicerExtensionsManagerModelPrivate::init()
   this->initializeColumnIdToNameMap(Self::EnabledColumn, "enabled");
   this->initializeColumnIdToNameMap(Self::ArchiveNameColumn, "archivename");
   this->initializeColumnIdToNameMap(Self::MD5Column, "md5");
+  this->initializeColumnIdToNameMap(Self::BuildOnlyColumn, "build_only");
 
   // See http://www.developer.nokia.com/Community/Wiki/Using_QStandardItemModel_in_QML
   QHash<int, QByteArray> roleNames;
@@ -1343,7 +1345,8 @@ bool qSlicerExtensionsManagerModel::installExtension(
     {
     if (!dependencyName.isEmpty() && dependencyName != "NA")
       {
-      if (this->isExtensionInstalled(dependencyName))
+      if (this->isExtensionInstalled(dependencyName) ||
+          this->extensionMetadata(dependencyName).value("build_only").toBool() == true)
         {
         // Dependency is already installed
         continue;


### PR DESCRIPTION
Extension with the configuration key "build_only" will be ignored by dependency resolution.
This allows us to hide the warning for a compile time-only extension which does not create
any installable build products, such as Eigen.

Fixes:
http://www.na-mic.org/Bug/view.php?id=3704