### PR TITLE
Fix sh warnings

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -845,10 +845,6 @@ void qMRMLSubjectHierarchyTreeView::selectPluginForCurrentItem()
     return;
     }
 
-  // Check if the user is setting the plugin that would otherwise be chosen automatically
-  qSlicerSubjectHierarchyAbstractPlugin* mostSuitablePluginByConfidenceNumbers =
-    qSlicerSubjectHierarchyPluginHandler::instance()->findOwnerPluginForSubjectHierarchyItem(currentItemID);
-
   // Set new owner plugin
   d->SubjectHierarchyNode->SetItemOwnerPluginName(currentItemID, selectedPluginName.toLatin1().constData());
 }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -345,7 +345,8 @@ void qSlicerSubjectHierarchyPluginLogic::addSupportedDataNodesToSubjectHierarchy
 
     // If there is a plugin that can add the data node to subject hierarchy, then add
     QList<qSlicerSubjectHierarchyAbstractPlugin*> foundPlugins =
-      qSlicerSubjectHierarchyPluginHandler::instance()->pluginsForAddingNodeToSubjectHierarchy(node, NULL);
+      qSlicerSubjectHierarchyPluginHandler::instance()->pluginsForAddingNodeToSubjectHierarchy(
+          node, vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID);
     qSlicerSubjectHierarchyAbstractPlugin* selectedPlugin = NULL;
     if (foundPlugins.size() > 0)
       {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -288,13 +288,6 @@ void qSlicerSubjectHierarchyPluginLogic::onSceneImportEnded(vtkObject* sceneObje
     return;
     }
 
-  // Trigger merging the imported subject hierarchy node containing the unresolved items
-  // into the singleton subject hierarchy node in the current scene. This would be done
-  // when first accessing the subject hierarchy node, but it needs to be done so that the
-  // addSupportedDataNodesToSubjectHierarchy call below only adds the nodes that were not
-  // in the hierarchy stored by the imported scene
-  vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
-
   // Add data nodes that are supported (i.e. there is a plugin that can claim it) and were not
   // in the imported subject hierarchy node to subject hierarchy
   this->addSupportedDataNodesToSubjectHierarchy();


### PR DESCRIPTION
This PR fixes the following warnings:

```
/home/jcfr/Projects/Slicer/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx:849:42: warning: unused variable 'mostSuitablePluginByConfidenceNumbers' [-Wunused-variable]
  qSlicerSubjectHierarchyAbstractPlugin* mostSuitablePluginByConfidenceNumbers =
                                         ^
/home/jcfr/Projects/Slicer/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx:296:32: warning: unused variable 'shNode' [-Wunused-variable]
  vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
                               ^
/home/jcfr/Projects/Slicer/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx:355:102: warning: implicit conversion of NULL constant to 'vtkIdType' (aka 'long long')
      [-Wnull-conversion]
      qSlicerSubjectHierarchyPluginHandler::instance()->pluginsForAddingNodeToSubjectHierarchy(node, NULL);
                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~       ^~~~
                                                                                                     0

```

@cpinter Are these benign warnings or do they reveal some other issues ? Thanks for checking