### PR TITLE
COMP: qSlicerTerminologyNavigatorWidget: Fix -Wunused-parameter warnings

### DIFF
--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -1600,6 +1600,7 @@ void qSlicerTerminologyNavigatorWidget::onTypeSearchTextChanged(QString search)
 //-----------------------------------------------------------------------------
 void qSlicerTerminologyNavigatorWidget::onNameChanged(QString name)
 {
+  Q_UNUSED(name);
   Q_D(qSlicerTerminologyNavigatorWidget);
 
   // Set as manual
@@ -1616,6 +1617,7 @@ void qSlicerTerminologyNavigatorWidget::onResetNameClicked()
 //-----------------------------------------------------------------------------
 void qSlicerTerminologyNavigatorWidget::onColorChanged(QColor color)
 {
+  Q_UNUSED(color);
   Q_D(qSlicerTerminologyNavigatorWidget);
 
   // Set as manual


### PR DESCRIPTION
This commit fixes the following warnings:

```
/path/to/Slicer/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx:1601:63: warning: unused parameter 'name' [-Wunused-parameter]
void qSlicerTerminologyNavigatorWidget::onNameChanged(QString name)
                                                              ^
/path/to/Slicer/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx:1617:63: warning: unused parameter 'color' [-Wunused-parameter]
void qSlicerTerminologyNavigatorWidget::onColorChanged(QColor color)
                                                              ^
```

@fedorov Are these warnings benign ? Or do they reveal some real issues ? Thanks for looking into it. 