### PR TITLE
COMP: vtkMRMLCropVolumeParametersNode: Fix -Wunused-variable

### DIFF
--- a/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
+++ b/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
@@ -32,7 +32,6 @@ static const char* OutputVolumeNodeReferenceMRMLAttributeName = "outputVolumeNod
 static const char* ROINodeReferenceRole = "roi";
 static const char* ROINodeReferenceMRMLAttributeName = "ROINodeID";
 static const char* ROIAlignmentTransformNodeReferenceRole = "roiAlignmentTransform";
-static const char* ROIAlignmentTransformNodeReferenceMRMLAttributeName = "ROIAlignmentTransformNodeID";
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLCropVolumeParametersNode);


### PR DESCRIPTION
This commit fixes the following warning:

```
/path/to/Slicer/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx:35:20: warning: unused variable 'ROIAlignmentTransformNodeReferenceMRMLAttributeName' [-Wunused-variable]
static const char* ROIAlignmentTransformNodeReferenceMRMLAttributeName = "ROIAlignmentTransformNodeID";
                   ^
```

@lassoan Is this warning benign ? Or does it reveal some real issues ? Thanks for looking into it. 