### PR TITLE
Fix/clean-up tensor slice glyph issues from model pipeline rework

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorDisplayPropertiesNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorDisplayPropertiesNode.cxx
@@ -36,7 +36,7 @@ vtkMRMLDiffusionTensorDisplayPropertiesNode::vtkMRMLDiffusionTensorDisplayProper
 
   // Default display is FA (often used) and line glyphs (quickest to render)
   this->ScalarInvariant = this->FractionalAnisotropy;
-  this->GlyphGeometry = this->Ellipsoids;
+  this->GlyphGeometry = this->Lines;
   this->ColorGlyphBy = this->FractionalAnisotropy;
 
   // Glyph general parameters

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.cxx
@@ -361,8 +361,8 @@ void vtkMRMLDiffusionTensorVolumeSliceDisplayNode::ProcessMRMLEvents ( vtkObject
                                            unsigned long event,
                                            void *callData )
 {
-  // Calls "UpdatePolyDataPipeline"
   this->Superclass::ProcessMRMLEvents(caller, event, callData);
+  this->UpdateAssignedAttribute();
 
   // Let everyone know that the "display" has changed.
   vtkMRMLDiffusionTensorDisplayPropertiesNode* propertiesNode =

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.cxx
@@ -47,7 +47,7 @@ vtkMRMLDiffusionTensorVolumeSliceDisplayNode::vtkMRMLDiffusionTensorVolumeSliceD
 
   this->ColorMode = this->colorModeScalar;
 
-  this->UpdatePolyDataPipeline();
+  this->UpdateAssignedAttribute();
 }
 
 
@@ -151,27 +151,27 @@ void vtkMRMLDiffusionTensorVolumeSliceDisplayNode::SetSliceImagePort(vtkAlgorith
 
 //----------------------------------------------------------------------------
 vtkAlgorithmOutput* vtkMRMLDiffusionTensorVolumeSliceDisplayNode
-::GetOutputPolyDataConnection()
+::GetOutputMeshConnection()
 {
   return this->DiffusionTensorGlyphFilter->GetOutputPort();
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLDiffusionTensorVolumeSliceDisplayNode::UpdatePolyDataPipeline()
+void vtkMRMLDiffusionTensorVolumeSliceDisplayNode::UpdateAssignedAttribute()
 {
+  this->Superclass::UpdateAssignedAttribute();
+
   // set display properties according to the tensor-specific display properties node for glyphs
-  vtkMRMLDiffusionTensorDisplayPropertiesNode * diffusionTensorDisplayNode =
+  vtkMRMLDiffusionTensorDisplayPropertiesNode * dtDPN =
     this->GetDiffusionTensorDisplayPropertiesNode( );
 
-  this->Superclass::UpdatePolyDataPipeline();
-
   this->DiffusionTensorGlyphFilter->SetSourceConnection(
-    diffusionTensorDisplayNode ?
-    diffusionTensorDisplayNode->GetGlyphConnection() : 0 );
+    dtDPN ?
+    dtDPN->GetGlyphConnection() : 0 );
 
-  if (diffusionTensorDisplayNode == NULL ||
+  if (dtDPN == NULL ||
       this->SliceImagePort == NULL ||
-      diffusionTensorDisplayNode->GetGlyphGeometry( ) == vtkMRMLDiffusionTensorDisplayPropertiesNode::Superquadrics)
+      dtDPN->GetGlyphGeometry( ) == vtkMRMLDiffusionTensorDisplayPropertiesNode::Superquadrics)
     {
     this->ScalarVisibilityOff();
     return;
@@ -186,10 +186,10 @@ void vtkMRMLDiffusionTensorVolumeSliceDisplayNode::UpdatePolyDataPipeline()
 
   // TO DO: implement max # ellipsoids, random sampling features
   this->DiffusionTensorGlyphFilter->SetResolution(1);
-  this->DiffusionTensorGlyphFilter->SetDimensionResolution( diffusionTensorDisplayNode->GetLineGlyphResolution(), diffusionTensorDisplayNode->GetLineGlyphResolution());
-  this->DiffusionTensorGlyphFilter->SetScaleFactor( diffusionTensorDisplayNode->GetGlyphScaleFactor( ) );
+  this->DiffusionTensorGlyphFilter->SetDimensionResolution( dtDPN->GetLineGlyphResolution(), dtDPN->GetLineGlyphResolution());
+  this->DiffusionTensorGlyphFilter->SetScaleFactor( dtDPN->GetGlyphScaleFactor( ) );
 
-  vtkDebugMacro("setting glyph geometry" << diffusionTensorDisplayNode->GetGlyphGeometry( ) );
+  vtkDebugMacro("setting glyph geometry" << dtDPN->GetGlyphGeometry( ) );
 
   // set glyph coloring
   if (this->GetColorMode ( ) == colorModeSolid)
@@ -198,7 +198,7 @@ void vtkMRMLDiffusionTensorVolumeSliceDisplayNode::UpdatePolyDataPipeline()
     }
   else if (this->GetColorMode ( ) == colorModeScalar)
     {
-    switch ( diffusionTensorDisplayNode->GetColorGlyphBy( ))
+    switch ( dtDPN->GetColorGlyphBy( ))
       {
       case vtkMRMLDiffusionTensorDisplayPropertiesNode::FractionalAnisotropy:
         {
@@ -313,9 +313,9 @@ vtkMRMLDiffusionTensorDisplayPropertiesNode* vtkMRMLDiffusionTensorVolumeSliceDi
   vtkMRMLDiffusionTensorDisplayPropertiesNode* node = NULL;
 
   // Find the node corresponding to the ID we have saved.
-  if  ( this->GetScene ( ) && this->GetDiffusionTensorDisplayPropertiesNodeID ( ) )
+  if  ( this->GetScene() && this->GetDiffusionTensorDisplayPropertiesNodeID() )
     {
-    vtkMRMLNode* cnode = this->GetScene ( ) -> GetNodeByID ( this->DiffusionTensorDisplayPropertiesNodeID );
+    vtkMRMLNode* cnode = this->GetScene()->GetNodeByID( this->DiffusionTensorDisplayPropertiesNodeID );
     node = vtkMRMLDiffusionTensorDisplayPropertiesNode::SafeDownCast ( cnode );
     }
 

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.h
@@ -80,11 +80,11 @@ class VTK_MRML_EXPORT vtkMRMLDiffusionTensorVolumeSliceDisplayNode
 
   /// Return the glyph producer output for the input image data.
   /// \sa GetOutputPolyData()
-  virtual vtkAlgorithmOutput* GetOutputPolyDataConnection();
+  virtual vtkAlgorithmOutput* GetOutputMeshConnection();
 
   ///
   /// Update the pipeline based on this node attributes
-  virtual void UpdatePolyDataPipeline();
+  virtual void UpdateAssignedAttribute();
 
   ///
   /// Set ImageData for a volume slice

--- a/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.cxx
@@ -165,29 +165,29 @@ void vtkMRMLGlyphableVolumeSliceDisplayNode
 }
 
 //---------------------------------------------------------------------------
-vtkPolyData* vtkMRMLGlyphableVolumeSliceDisplayNode::GetOutputPolyData()
+vtkPolyData* vtkMRMLGlyphableVolumeSliceDisplayNode::GetOutputMesh()
 {
   // Don't check input polydata as it is not used, but the image data instead.
-  if (!this->GetOutputPolyDataConnection())
+  if (!this->GetOutputMeshConnection())
     {
     return 0;
     }
   return vtkPolyData::SafeDownCast(
-    this->GetOutputPolyDataConnection()->GetProducer()->GetOutputDataObject(
-      this->GetOutputPolyDataConnection()->GetIndex()));
+    this->GetOutputMeshConnection()->GetProducer()->GetOutputDataObject(
+      this->GetOutputMeshConnection()->GetIndex()));
 }
 //----------------------------------------------------------------------------
 vtkAlgorithmOutput* vtkMRMLGlyphableVolumeSliceDisplayNode
-::GetOutputPolyDataConnection()
+::GetOutputMeshConnection()
 {
   return 0;
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLGlyphableVolumeSliceDisplayNode::UpdatePolyDataPipeline()
+void vtkMRMLGlyphableVolumeSliceDisplayNode::UpdateAssignedAttribute()
 {
   this->SliceToXYTransformer->SetInputConnection(
-    this->GetOutputPolyDataConnection());
+    this->GetOutputMeshConnection());
 }
 
 //---------------------------------------------------------------------------
@@ -229,9 +229,3 @@ void vtkMRMLGlyphableVolumeSliceDisplayNode::UpdateReferences()
 {
   Superclass::UpdateReferences();
 }
-
-
-
-
-
-

--- a/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.h
@@ -19,6 +19,7 @@
 
 #include "vtkMRML.h"
 #include "vtkMRMLModelDisplayNode.h"
+#include "vtkPolyData.h"
 
 class vtkTransform;
 class vtkTransformPolyDataFilter;
@@ -85,13 +86,13 @@ class VTK_MRML_EXPORT vtkMRMLGlyphableVolumeSliceDisplayNode : public vtkMRMLMod
   /// The output is connected as the input of the slice transform.
   /// It must be reimplemented in subclasses.
   /// \sa GetOutputPolyData(), GetSliceOutputPort()
-  virtual vtkAlgorithmOutput* GetOutputPolyDataConnection();
+  virtual vtkAlgorithmOutput* GetOutputMeshConnection();
 
   /// Return the glyph polydata for the input slice image.
   /// This is the polydata to use in a 3D view.
   /// Reimplemented to by-pass the check on the input polydata.
   /// \sa GetSliceOutputPolyData(), GetOutputPolyDataConnection()
-  virtual vtkPolyData* GetOutputPolyData();
+  virtual vtkPolyData* GetOutputMesh();
 
   /// Return the glyph polyData transfomed to slice XY.
   /// This is the polydata to use in a 2D slice.
@@ -100,7 +101,7 @@ class VTK_MRML_EXPORT vtkMRMLGlyphableVolumeSliceDisplayNode : public vtkMRMLMod
 
   ///
   /// Update the pipeline based on this node attributes
-  virtual void UpdatePolyDataPipeline();
+  virtual void UpdateAssignedAttribute();
 
   ///
   /// Set imageData of a volume slice. This is used as the input of the display

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -1039,7 +1039,7 @@ void vtkMRMLModelDisplayableManager
     vtkAlgorithm *clipper = 0;
     if(actor)
       {
-      vtkMRMLModelNode::MeshTypeHint meshType = modelNode->GetMeshType();
+      vtkMRMLModelNode::MeshTypeHint meshType = modelNode ? modelNode->GetMeshType() : vtkMRMLModelNode::PolyDataMeshType;
       if (this->Internal->ClippingOn && modelDisplayNode != 0 && clipping)
         {
         clipper = this->CreateTransformedClipper(modelNode->GetParentTransformNode(), meshType);

--- a/Libs/MRML/DisplayableManager/vtkMRMLVolumeGlyphSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLVolumeGlyphSliceDisplayableManager.cxx
@@ -541,7 +541,7 @@ bool vtkMRMLVolumeGlyphSliceDisplayableManager::vtkInternal::IsVisible(
   vtkMRMLDisplayNode* displayNode)
 {
   return displayNode->GetVisibility() &&
-    displayNode->GetScalarVisibility();
+         displayNode->GetScalarVisibility();
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Data/qSlicerDataModuleWidget.cxx
+++ b/Modules/Loadable/Data/qSlicerDataModuleWidget.cxx
@@ -126,7 +126,7 @@ void qSlicerDataModuleWidget::setup()
   // Filter on all the columns
   d->MRMLTreeView->sortFilterProxyModel()->setFilterKeyColumn(-1);
   connect(d->FilterLineEdit, SIGNAL(textChanged(QString)),
-          d->MRMLTreeView->sortFilterProxyModel(), SLOT(setFilterFixedString(QString)));
+          d->MRMLTreeView->sortFilterProxyModel(), SLOT(setFilterWildcard(QString)));
 
   // Hide the IDs by default
   d->DisplayMRMLIDsCheckBox->setChecked(false);


### PR DESCRIPTION
Second commit allows wildcard search in the Data module, which I find useful when looking up nodes because it allows typing a small part of the name.

(cc @ljod)