### PR TITLE
ENH: Add external project step allowing to keep track of project version

### DIFF
--- a/CMake/ExternalProjectGenerateProjectDescription.cmake
+++ b/CMake/ExternalProjectGenerateProjectDescription.cmake
@@ -1,0 +1,92 @@
+################################################################################
+#
+#  Program: 3D Slicer
+#
+#  Copyright (c) Kitware Inc.
+#
+#  See COPYRIGHT.txt
+#  or http://www.slicer.org/copyright/copyright.txt for details.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
+#  and was partially funded by NIH grant 1U24CA194354-01
+#
+################################################################################
+
+#
+#  W A R N I N G
+#  -------------
+#
+# This file is not part of the Slicer API.  It exists purely as an
+# implementation detail.  This CMake module may change from version to
+# version without notice, or even be removed.
+#
+# We mean it.
+#
+
+#!
+#! ExternalProject_GenerateProjectDescription_Step(<projectname>
+#!   [NAME <name>]
+#!   [VERSION <version>]
+#!   [SOURCE_DIR <source_dir>]
+#!   )
+#!
+#! Generate a project description file named 'version-<projectname>.txt'
+#! containing one line of the form '<projectname> <version>'.
+#!
+#! VERSION If no <version> is specified, the version is extracted from the
+#!         <source_dir> running the command '${GIT_EXECUTABLE} describe --always'.
+#!
+#! NAME Specifying <name> parameter allows to override the name used to generate
+#!      the description file.
+#!
+#! SOURCE_DIR Specifying <source_dir> parameter allows to override the default
+#!            source directory set to '${CMAKE_BINARY_DIR}/<projectname>'.
+#!
+function(ExternalProject_GenerateProjectDescription_Step projectname)
+  set(options)
+  set(oneValueArgs NAME SOURCE_DIR VERSION)
+  set(multiValueArgs)
+  cmake_parse_arguments(_epgpd "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  set(name ${projectname})
+  if(_epgpd_NAME)
+    set(name ${_epgpd_NAME})
+  endif()
+
+  set(description_file "version-${name}.txt")
+
+  if(_epgpd_VERSION)
+    file(WRITE ${CMAKE_BINARY_DIR}/${description_file} "${name} ${_epgpd_VERSION}")
+    return()
+  endif()
+
+  set(script "${CMAKE_BINARY_DIR}/CMakeFiles/${projectname}-generate-project-description.cmake")
+
+  file(WRITE "${script}"
+"execute_process(
+  COMMAND \"${GIT_EXECUTABLE}\" describe --always
+  OUTPUT_VARIABLE output
+  )
+file(WRITE \"${CMAKE_BINARY_DIR}/${description_file}\" \"${name} \${output}\")
+")
+
+  set(source_dir ${CMAKE_BINARY_DIR}/${projectname})
+  if(_epgpd_SOURCE_DIR)
+    set(source_dir ${_epgpd_SOURCE_DIR})
+  endif()
+  
+  ExternalProject_Add_Step(${projectname} generate_project_description
+    COMMAND ${CMAKE_COMMAND} -P ${script}
+    COMMENT "Generate ${description_file}"
+    DEPENDEES download
+    BYPRODUCTS ${CMAKE_BINARY_DIR}/${description_file}
+    WORKING_DIRECTORY ${source_dir}
+    )
+
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ endforeach()
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 include(ExternalProject)
 include(ExternalProjectDependency)
+include(ExternalProjectGenerateProjectDescription)
 
 #-----------------------------------------------------------------------------
 if(APPLE)

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -94,6 +94,9 @@ if(NOT DEFINED CTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   set(CTK_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
   #-----------------------------------------------------------------------------

--- a/SuperBuild/External_CTKAPPLAUNCHER.cmake
+++ b/SuperBuild/External_CTKAPPLAUNCHER.cmake
@@ -49,6 +49,11 @@ if(Slicer_USE_CTKAPPLAUNCHER)
       DEPENDS
         ${${proj}_DEPENDENCIES}
       )
+
+    ExternalProject_GenerateProjectDescription_Step(${proj}
+      VERSION ${launcher_version}
+      )
+
     set(CTKAPPLAUNCHER_DIR ${CMAKE_BINARY_DIR}/${proj})
 
   else()

--- a/SuperBuild/External_CTKResEdit.cmake
+++ b/SuperBuild/External_CTKResEdit.cmake
@@ -42,6 +42,11 @@ if(NOT DEFINED CTKResEdit_EXECUTABLE)
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${CTKResEdit_VERSION}
+    )
+
   set(CTKResEdit_EXECUTABLE ${CMAKE_BINARY_DIR}/${proj}/bin/CTKResEdit.exe)
 
 else()

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -65,6 +65,9 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     DEPENDS
       ${${proj}_DEPENDENCIES}
   )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   set(DCMTK_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
   #-----------------------------------------------------------------------------

--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -114,6 +114,9 @@ if(NOT DEFINED ITK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   set(ITK_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
   #-----------------------------------------------------------------------------

--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -72,13 +72,14 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )
-
   if(APPLE)
     ExternalProject_Add_Step(${proj} fix_rpath
       COMMAND install_name_tool -id ${CMAKE_BINARY_DIR}/${proj}-install/lib/libarchive.12.dylib ${CMAKE_BINARY_DIR}/${proj}-install/lib/libarchive.12.dylib
       DEPENDEES install
       )
   endif()
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
 
   set(LibArchive_DIR ${CMAKE_BINARY_DIR}/LibArchive-install)
 

--- a/SuperBuild/External_NUMPY.cmake
+++ b/SuperBuild/External_NUMPY.cmake
@@ -66,10 +66,12 @@ set(${proj}_WORKING_DIR \"${CMAKE_BINARY_DIR}/${proj}\")
 ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py install)
 ")
 
+  set(_version "1.9.2")
+
   #------------------------------------------------------------------------------
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "http://slicer.kitware.com/midas3/download/item/210950/numpy-1.9.2.tar.gz"
+    URL "http://slicer.kitware.com/midas3/download/item/210950/numpy-${_version}.tar.gz"
     URL_MD5 "a1ed53432dbcd256398898d35bc8e645"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
@@ -80,6 +82,10 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
     INSTALL_COMMAND ${CMAKE_COMMAND} -P ${_install_script}
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 
   #-----------------------------------------------------------------------------

--- a/SuperBuild/External_OpenIGTLink.cmake
+++ b/SuperBuild/External_OpenIGTLink.cmake
@@ -46,6 +46,8 @@ if(NOT DEFINED OpenIGTLink_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       ${${proj}_DEPENDENCIES}
     )
 
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   set(OpenIGTLink_DIR ${CMAKE_BINARY_DIR}/OpenIGTLink-build)
 
   #-----------------------------------------------------------------------------

--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -284,6 +284,10 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
     ExternalProject_Message(${proj} "SSL_EAY_RELEASE:${SSL_EAY_RELEASE}")
   endif()
 
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${OPENSSL_DOWNLOAD_VERSION}
+    )
+
   #-----------------------------------------------------------------------------
   # Launcher setting specific to build tree
 

--- a/SuperBuild/External_PCRE.cmake
+++ b/SuperBuild/External_PCRE.cmake
@@ -48,13 +48,19 @@ ExternalProject_Execute(${proj} \"configure\" sh ${pcre_source_dir}/configure
     --prefix=${pcre_install_dir} --disable-shared)
 ")
 
+  set(_version "8.38")
+
   ExternalProject_add(PCRE
     ${${proj}_EP_ARGS}
-    URL http://slicer.kitware.com/midas3/download/item/263369/pcre-8.38.tar.gz
+    URL http://slicer.kitware.com/midas3/download/item/263369/pcre-${_version}.tar.gz
     URL_MD5 8a353fe1450216b6655dfcf3561716d9
     UPDATE_COMMAND "" # Disable update
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -P ${_configure_script}
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 endif()

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -53,6 +53,11 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
     BUILD_COMMAND ""
     )
 
+  ExternalProject_GenerateProjectDescription_Step(SimpleITK-download
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    NAME ${proj}
+    )
+
   ExternalProject_add(SimpleITK
     ${${proj}_EP_ARGS}
     SOURCE_DIR ${EP_SOURCE_DIR}/SuperBuild

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -100,6 +100,9 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   set(SlicerExecutionModel_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
   #-----------------------------------------------------------------------------

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -91,4 +91,8 @@ ExternalProject_Execute(${proj} \"configure\" sh ${swig_source_dir}/configure
     set(SWIG_EXECUTABLE ${swig_install_dir}/bin/swig)
     set(Swig_DEPEND Swig)
   endif()
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${SWIG_TARGET_VERSION}
+    )
 endif()

--- a/SuperBuild/External_VTKv7.cmake
+++ b/SuperBuild/External_VTKv7.cmake
@@ -142,6 +142,9 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT ${CMAKE_PROJECT_N
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   set(VTK_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
   set(VTK_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
 

--- a/SuperBuild/External_curl.cmake
+++ b/SuperBuild/External_curl.cmake
@@ -86,6 +86,8 @@ if((NOT DEFINED CURL_INCLUDE_DIR
       ${${proj}_DEPENDENCIES}
     )
 
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   if(UNIX)
     set(curl_IMPORT_SUFFIX .a)
     if(APPLE)

--- a/SuperBuild/External_python-GitPython.cmake
+++ b/SuperBuild/External_python-GitPython.cmake
@@ -16,9 +16,11 @@ endif()
 
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
+  set(_version "2.1.0")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/d7/16/e914d345d7d4e988f9196b9719a99220bad6a5dbd636162f9b5cc35f3bd6/GitPython-2.1.0.tar.gz"
+    URL "https://pypi.python.org/packages/d7/16/e914d345d7d4e988f9196b9719a99220bad6a5dbd636162f9b5cc35f3bd6/GitPython-${_version}.tar.gz"
     URL_MD5 "29b1fcf504d080dc7a5e630957e829d7"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
@@ -27,6 +29,10 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 
   # See #3749 - Delete test files causing packaging to fail on windows

--- a/SuperBuild/External_python-PyGithub.cmake
+++ b/SuperBuild/External_python-PyGithub.cmake
@@ -16,9 +16,11 @@ endif()
 
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
+  set(_version "1.29")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/1a/2d/7c1ee64a1b477c22eca28a583464172c92403df87ccdf56b34eabf68fce4/PyGithub-1.29.tar.gz"
+    URL "https://pypi.python.org/packages/1a/2d/7c1ee64a1b477c22eca28a583464172c92403df87ccdf56b34eabf68fce4/PyGithub-${_version}.tar.gz"
     URL_MD5 "c921400a5c1acd4b7d7c4fd9ee42650d"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
@@ -27,6 +29,10 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 
   # See #3749 - Delete test files causing packaging to fail on windows

--- a/SuperBuild/External_python-chardet.cmake
+++ b/SuperBuild/External_python-chardet.cmake
@@ -16,9 +16,11 @@ endif()
 
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
+  set(_version "2.3.0")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/7d/87/4e3a3f38b2f5c578ce44f8dc2aa053217de9f0b6d737739b0ddac38ed237/chardet-2.3.0.tar.gz"
+    URL "https://pypi.python.org/packages/7d/87/4e3a3f38b2f5c578ce44f8dc2aa053217de9f0b6d737739b0ddac38ed237/chardet-${_version}.tar.gz"
     URL_MD5 "25274d664ccb5130adae08047416e1a8"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
@@ -27,6 +29,10 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 
 else()

--- a/SuperBuild/External_python-couchdb.cmake
+++ b/SuperBuild/External_python-couchdb.cmake
@@ -16,9 +16,11 @@ endif()
 
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
+  set(_version "1.1")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/9a/e8/c3c8da6d00145aaca07f2b784794917613dad26532068da4e8392dc48d7f/CouchDB-1.1.tar.gz"
+    URL "https://pypi.python.org/packages/9a/e8/c3c8da6d00145aaca07f2b784794917613dad26532068da4e8392dc48d7f/CouchDB-${_version}.tar.gz"
     URL_MD5 "2ed5ad2a477fd3cb472ed6dc5a381ff3"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
@@ -27,6 +29,10 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 
 else()

--- a/SuperBuild/External_python-gitdb.cmake
+++ b/SuperBuild/External_python-gitdb.cmake
@@ -31,9 +31,11 @@ set(${proj}_WORKING_DIR \"${CMAKE_BINARY_DIR}/${proj}\")
 ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py install)
 ")
 
+  set(_version "2.0.0")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/5c/bb/ab74c6914e3b570ab2e960fda17a01aec93474426eecd3b34751ba1c3b38/gitdb2-2.0.0.tar.gz"
+    URL "https://pypi.python.org/packages/5c/bb/ab74c6914e3b570ab2e960fda17a01aec93474426eecd3b34751ba1c3b38/gitdb2-${_version}.tar.gz"
     URL_MD5 "78fdc7645665067862e3ba1e02db6884"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
@@ -42,6 +44,10 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
     INSTALL_COMMAND ${CMAKE_COMMAND} -P ${_install_script}
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 
 else()

--- a/SuperBuild/External_python-nose.cmake
+++ b/SuperBuild/External_python-nose.cmake
@@ -16,9 +16,11 @@ endif()
 
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
+  set(_version "1.3.7")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/source/n/nose/nose-1.3.7.tar.gz"
+    URL "https://pypi.python.org/packages/source/n/nose/nose-${_version}.tar.gz"
     URL_MD5 "4d3ad0ff07b61373d2cefc89c5d0b20b"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
@@ -27,6 +29,10 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 
 else()

--- a/SuperBuild/External_python-pydicom.cmake
+++ b/SuperBuild/External_python-pydicom.cmake
@@ -16,9 +16,11 @@ endif()
 
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
+  set(_version "0.9.9")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/5d/1d/dd9716ef3a0ac60c23035a9b333818e34dec2e853733d03f502533af9b84/pydicom-0.9.9.tar.gz"
+    URL "https://pypi.python.org/packages/5d/1d/dd9716ef3a0ac60c23035a9b333818e34dec2e853733d03f502533af9b84/pydicom-${_version}.tar.gz"
     URL_MD5 "a66ca6728e69ba565ab9c8a21740eee8"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
@@ -27,6 +29,10 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 
 else()

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -48,6 +48,10 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
       ${${proj}_DEPENDENCIES}
     )
 
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
+    )
+
 else()
   ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
 endif()

--- a/SuperBuild/External_python-smmap.cmake
+++ b/SuperBuild/External_python-smmap.cmake
@@ -16,9 +16,11 @@ endif()
 
 if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
+  set(_version "2.0.1")
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://pypi.python.org/packages/83/ce/e5b3aee7ca420b0ab24d4fcc2aa577f7aa6ea7e9306fafceabee3e8e4703/smmap2-2.0.1.tar.gz"
+    URL "https://pypi.python.org/packages/83/ce/e5b3aee7ca420b0ab24d4fcc2aa577f7aa6ea7e9306fafceabee3e8e4703/smmap2-${_version}.tar.gz"
     URL_MD5 "71565e9c99ab64718e2a13c489767692"
     SOURCE_DIR ${proj}
     BUILD_IN_SOURCE 1
@@ -27,6 +29,10 @@ if(NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
     DEPENDS
       ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${_version}
     )
 
 else()

--- a/SuperBuild/External_qRestAPI.cmake
+++ b/SuperBuild/External_qRestAPI.cmake
@@ -41,6 +41,8 @@ if(NOT DEFINED qRestAPI_DIR)
       ${${proj}_DEPENDENCIES}
     )
 
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   set(qRestAPI_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
 else()

--- a/SuperBuild/External_tcl.cmake
+++ b/SuperBuild/External_tcl.cmake
@@ -181,6 +181,10 @@ ExternalProject_Execute(${proj} \"install\" make install)
       ${${proj}_DEPENDENCIES}
     )
 
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    VERSION ${TCL_TK_VERSION_DOT}
+    )
+
   #-----------------------------------------------------------------------------
   # Since fixup_bundle expects the library to be writable, let's add an extra step
   # to make sure it's the case.

--- a/SuperBuild/External_teem.cmake
+++ b/SuperBuild/External_teem.cmake
@@ -76,6 +76,8 @@ if(NOT DEFINED Teem_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       ${${proj}_DEPENDENCIES}
     )
 
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   set(Teem_DIR ${CMAKE_BINARY_DIR}/teem-build)
 
   #-----------------------------------------------------------------------------

--- a/SuperBuild/External_zlib.cmake
+++ b/SuperBuild/External_zlib.cmake
@@ -46,6 +46,9 @@ if(NOT DEFINED zlib_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     DEPENDS
       ${${proj}_DEPENDENCIES}
     )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
   set(zlib_DIR ${EP_INSTALL_DIR})
   set(ZLIB_ROOT ${zlib_DIR})
   set(ZLIB_INCLUDE_DIR ${zlib_DIR}/include)


### PR DESCRIPTION
This commit adds a module named "ExternalProjectGenerateProjectDescription"
providing a convenient function allowing to add a step generating
a project description file containing the name of the project and
its version.

For each project instrumented with this function, a file named
"version-<projectnmame>.txt" is generated in ${CMAKE_BINARY_DIR}.