### PR TITLE
STYLE: Indentation related changes

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLNodeTest1.cxx
@@ -246,7 +246,7 @@ void vtkMRMLNodeTestHelper1::WriteXML(ostream& of, int nIndent)
   vtkIndent indent(nIndent);
   if (this->OtherNodeID != NULL)
     {
-    of << indent << " OtherNodeRef=\"" << this->OtherNodeID << "\"";
+    of << " OtherNodeRef=\"" << this->OtherNodeID << "\"";
     }
 }
 
@@ -290,10 +290,9 @@ void vtkMRMLStorageNodeTestHelper::SetSceneReferences()
 void vtkMRMLStorageNodeTestHelper::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
   if (this->OtherNodeID != NULL)
     {
-    of << indent << " OtherNodeRef=\"" << this->OtherNodeID << "\"";
+    of << " OtherNodeRef=\"" << this->OtherNodeID << "\"";
     }
 }
 

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -75,43 +75,41 @@ void vtkMRMLAbstractViewNode::WriteXML(ostream& of, int nIndent)
 
   this->Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if (this->GetLayoutLabel())
     {
-    of << indent << " layoutLabel=\"" << this->GetLayoutLabel() << "\"";
+    of << " layoutLabel=\"" << this->GetLayoutLabel() << "\"";
     }
   if (this->GetLayoutName())
     {
-    of << indent << " layoutName=\"" << this->GetLayoutName() << "\"";
+    of << " layoutName=\"" << this->GetLayoutName() << "\"";
     }
   if (this->GetViewGroup() > 0)
     {
-    of << indent << " viewGroup=\"" << this->GetViewGroup() << "\"";
+    of << " viewGroup=\"" << this->GetViewGroup() << "\"";
     }
 
-  of << indent << " active=\"" << (this->Active ? "true" : "false") << "\"";
-  of << indent << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
+  of << " active=\"" << (this->Active ? "true" : "false") << "\"";
+  of << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
 
   // background color
-  of << indent << " backgroundColor=\"" << this->BackgroundColor[0] << " "
+  of << " backgroundColor=\"" << this->BackgroundColor[0] << " "
      << this->BackgroundColor[1] << " " << this->BackgroundColor[2] << "\"";
 
-  of << indent << " backgroundColor2=\"" << this->BackgroundColor2[0] << " "
+  of << " backgroundColor2=\"" << this->BackgroundColor2[0] << " "
      << this->BackgroundColor2[1] << " " << this->BackgroundColor2[2] << "\"";
 
   if (this->OrientationMarkerEnabled)
     {
-    of << indent << " orientationMarkerType=\"" << this->GetOrientationMarkerTypeAsString(this->OrientationMarkerType) << "\"";
-    of << indent << " orientationMarkerSize=\"" << this->GetOrientationMarkerSizeAsString(this->OrientationMarkerSize) << "\"";
+    of << " orientationMarkerType=\"" << this->GetOrientationMarkerTypeAsString(this->OrientationMarkerType) << "\"";
+    of << " orientationMarkerSize=\"" << this->GetOrientationMarkerSizeAsString(this->OrientationMarkerSize) << "\"";
     }
 
   if (this->RulerEnabled)
     {
-    of << indent << " rulerType=\"" << this->GetRulerTypeAsString(this->RulerType) << "\"";
+    of << " rulerType=\"" << this->GetRulerTypeAsString(this->RulerType) << "\"";
     }
 
-  of << indent << " AxisLabels=\"";
+  of << " AxisLabels=\"";
   for (int i=0; i<vtkMRMLAbstractViewNode::AxisLabelsCount; i++)
     {
     of << (i>0?";":"") << this->GetAxisLabel(i);

--- a/Libs/MRML/Core/vtkMRMLCameraNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCameraNode.cxx
@@ -79,30 +79,28 @@ void vtkMRMLCameraNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   double *position = this->GetPosition();
-  of << indent << " position=\"" << position[0] << " "
+  of << " position=\"" << position[0] << " "
     << position[1] << " "
     << position[2] << "\"";
 
   double *focalPoint = this->GetFocalPoint();
-  of << indent << " focalPoint=\"" << focalPoint[0] << " "
+  of << " focalPoint=\"" << focalPoint[0] << " "
     << focalPoint[1] << " "
     << focalPoint[2] << "\"";
 
   double *viewUp = this->GetViewUp();
-    of << indent << " viewUp=\"" << viewUp[0] << " "
+    of << " viewUp=\"" << viewUp[0] << " "
       << viewUp[1] << " "
       << viewUp[2] << "\"";
 
-  of << indent << " parallelProjection=\"" << (this->GetParallelProjection() ? "true" : "false") << "\"";
+  of << " parallelProjection=\"" << (this->GetParallelProjection() ? "true" : "false") << "\"";
 
-  of << indent << " parallelScale=\"" << this->GetParallelScale() << "\"";
+  of << " parallelScale=\"" << this->GetParallelScale() << "\"";
 
   if (this->GetActiveTag())
     {
-    of << indent << " activetag=\"" << this->GetActiveTag() << "\"";
+    of << " activetag=\"" << this->GetActiveTag() << "\"";
     }
 
   if (this->GetAppliedTransform())
@@ -123,9 +121,8 @@ void vtkMRMLCameraNode::WriteXML(ostream& of, int nIndent)
         ss << " ";
         }
       }
-    of << indent << " appliedTransform=\"" << ss.str() << "\"";
+    of << " appliedTransform=\"" << ss.str() << "\"";
     }
-
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLChartNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLChartNode.cxx
@@ -76,11 +76,8 @@ vtkMRMLChartNode::~vtkMRMLChartNode()
 //----------------------------------------------------------------------------
 void vtkMRMLChartNode::WriteXML(ostream& of, int nIndent)
 {
-
   // Start by having the superclass write its information
   Superclass::WriteXML(of, nIndent);
-
-  vtkIndent indent(nIndent);
 
   // Write all the IDs
   of << " arrays=\"";
@@ -114,7 +111,6 @@ void vtkMRMLChartNode::WriteXML(ostream& of, int nIndent)
       }
     }
   of << "\"";
-
 }
 
 

--- a/Libs/MRML/Core/vtkMRMLChartViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLChartViewNode.cxx
@@ -53,8 +53,6 @@ void vtkMRMLChartViewNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if (this->ChartNodeID)
     {
     of << " chart=\"" << this->ChartNodeID << "\"";

--- a/Libs/MRML/Core/vtkMRMLClipModelsNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLClipModelsNode.cxx
@@ -48,16 +48,14 @@ void vtkMRMLClipModelsNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
+  of << " clipType=\"" << this->ClipType << "\"";
 
-  of << indent << " clipType=\"" << this->ClipType << "\"";
-
-  of << indent << " redSliceClipState=\"" << this->RedSliceClipState << "\"";
-  of << indent << " yellowSliceClipState=\"" << this->YellowSliceClipState << "\"";
-  of << indent << " greenSliceClipState=\"" << this->GreenSliceClipState << "\"";
+  of << " redSliceClipState=\"" << this->RedSliceClipState << "\"";
+  of << " yellowSliceClipState=\"" << this->YellowSliceClipState << "\"";
+  of << " greenSliceClipState=\"" << this->GreenSliceClipState << "\"";
   if (this->ClippingMethod != vtkMRMLClipModelsNode::Straight)
     {
-    of << indent << " clippingMethod=\"" << (this->GetClippingMethodAsString(this->ClippingMethod)) << "\"";
+    of << " clippingMethod=\"" << (this->GetClippingMethodAsString(this->ClippingMethod)) << "\"";
     }
 }
 

--- a/Libs/MRML/Core/vtkMRMLColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorNode.cxx
@@ -67,8 +67,6 @@ void vtkMRMLColorNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   of << " type=\"" << this->GetType() << "\"";
 
   if (this->FileName != NULL)

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
@@ -54,8 +54,6 @@ void vtkMRMLColorTableNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   // only print out the look up table size so that the table can be
   // initialized properly
   if (this->LookupTable != NULL)

--- a/Libs/MRML/Core/vtkMRMLCrosshairNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCrosshairNode.cxx
@@ -55,63 +55,61 @@ void vtkMRMLCrosshairNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if ( this->CrosshairMode == vtkMRMLCrosshairNode::NoCrosshair )
     {
-    of << indent << " crosshairMode=\"" << "NoCrosshair" << "\"";
+    of << " crosshairMode=\"" << "NoCrosshair" << "\"";
     }
   else if ( this->CrosshairMode == vtkMRMLCrosshairNode::ShowBasic )
     {
-    of << indent << " crosshairMode=\"" << "ShowBasic" << "\"";
+    of << " crosshairMode=\"" << "ShowBasic" << "\"";
     }
   else if ( this->CrosshairMode == vtkMRMLCrosshairNode::ShowIntersection )
     {
-    of << indent << " crosshairMode=\"" << "ShowIntersection" << "\"";
+    of << " crosshairMode=\"" << "ShowIntersection" << "\"";
     }
   else if ( this->CrosshairMode == vtkMRMLCrosshairNode::ShowHashmarks )
     {
-    of << indent << " crosshairMode=\"" << "ShowHashmarks" << "\"";
+    of << " crosshairMode=\"" << "ShowHashmarks" << "\"";
     }
   else if ( this->CrosshairMode == vtkMRMLCrosshairNode::ShowAll )
     {
-    of << indent << " crosshairMode=\"" << "ShowAll" << "\"";
+    of << " crosshairMode=\"" << "ShowAll" << "\"";
     }
   else if ( this->CrosshairMode == vtkMRMLCrosshairNode::ShowSmallBasic )
     {
-    of << indent << " crosshairMode=\"" << "ShowSmallBasic" << "\"";
+    of << " crosshairMode=\"" << "ShowSmallBasic" << "\"";
     }
   else if ( this->CrosshairMode == vtkMRMLCrosshairNode::ShowSmallIntersection )
     {
-    of << indent << " crosshairMode=\"" << "ShowSmallIntersection" << "\"";
+    of << " crosshairMode=\"" << "ShowSmallIntersection" << "\"";
     }
 
-  of << indent << " navigation=\"" << (this->Navigation ? "true" : "false") << "\"";
+  of << " navigation=\"" << (this->Navigation ? "true" : "false") << "\"";
 
   if ( this->CrosshairBehavior == vtkMRMLCrosshairNode::JumpSlice
     || this->CrosshairBehavior == vtkMRMLCrosshairNode::Normal )
     {
-    of << indent << " crosshairBehavior=\"" << "JumpSlice" << "\"";
+    of << " crosshairBehavior=\"" << "JumpSlice" << "\"";
     }
   else if (this->CrosshairBehavior == vtkMRMLCrosshairNode::NoAction)
     {
-    of << indent << " crosshairBehavior=\"" << "NoAction" << "\"";
+    of << " crosshairBehavior=\"" << "NoAction" << "\"";
     }
 
   if ( this->CrosshairThickness == vtkMRMLCrosshairNode::Fine )
     {
-    of << indent << " crosshairThickness=\"" << "Fine" << "\"";
+    of << " crosshairThickness=\"" << "Fine" << "\"";
     }
   else if ( this->CrosshairThickness == vtkMRMLCrosshairNode::Medium )
     {
-    of << indent << " crosshairThickness=\"" << "Medium" << "\"";
+    of << " crosshairThickness=\"" << "Medium" << "\"";
     }
   else if ( this->CrosshairThickness == vtkMRMLCrosshairNode::Thick )
     {
-    of << indent << " crosshairThickness=\"" << "Thick" << "\"";
+    of << " crosshairThickness=\"" << "Thick" << "\"";
     }
 
-  of << indent <<  " crosshairRAS=\"" << this->CrosshairRAS[0] << " "
+  of <<  " crosshairRAS=\"" << this->CrosshairRAS[0] << " "
      << this->CrosshairRAS[1] << " " << this->CrosshairRAS[2] << "\"";
 }
 

--- a/Libs/MRML/Core/vtkMRMLDiffusionImageVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionImageVolumeNode.cxx
@@ -65,19 +65,18 @@ void vtkMRMLDiffusionImageVolumeNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
   std::stringstream ss;
   if (this->BaselineNodeID != NULL)
     {
-    of << indent << " baselineNodeRef=\"" << this->BaselineNodeID << "\"";
+    of << " baselineNodeRef=\"" << this->BaselineNodeID << "\"";
     }
   if (this->DiffusionWeightedNodeID != NULL)
     {
-    of << indent << " diffusionWeightedNodeRef=\"" << this->DiffusionWeightedNodeID << "\"";
+    of << " diffusionWeightedNodeRef=\"" << this->DiffusionWeightedNodeID << "\"";
     }
   if (this->MaskNodeID != NULL)
     {
-    of << indent << " maskNodeRef=\"" << this->MaskNodeID << "\"";
+    of << " maskNodeRef=\"" << this->MaskNodeID << "\"";
     }
 
 }

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorDisplayPropertiesNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorDisplayPropertiesNode.cxx
@@ -85,21 +85,19 @@ void vtkMRMLDiffusionTensorDisplayPropertiesNode::WriteXML(ostream& of, int nInd
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " glyphGeometry=\"" << this->GlyphGeometry << "\"";
-  of << indent << " colorGlyphBy=\"" << this->ColorGlyphBy << "\"";
-  of << indent << " glyphScaleFactor=\"" << this->GlyphScaleFactor << "\"";
-  of << indent << " glyphEigenvector=\"" << this->GlyphEigenvector << "\"";
-  of << indent << " glyphExtractEigenvalues=\"" << this->GlyphExtractEigenvalues << "\"";
-  of << indent << " lineGlyphResolution=\"" << this->LineGlyphResolution << "\"";
-  of << indent << " tubeGlyphRadius=\"" << this->TubeGlyphRadius << "\"";
-  of << indent << " tubeGlyphNumberOfSides=\"" << this->TubeGlyphNumberOfSides << "\"";
-  of << indent << " ellipsoidGlyphThetaResolution=\"" << this->EllipsoidGlyphThetaResolution << "\"";
-  of << indent << " ellipsoidGlyphPhiResolution=\"" << this->EllipsoidGlyphPhiResolution << "\"";
-  of << indent << " superquadricGlyphGamma=\"" << this->SuperquadricGlyphGamma << "\"";
-  of << indent << " superquadricGlyphThetaResolution=\"" << this->SuperquadricGlyphThetaResolution << "\"";
-  of << indent << " superquadricGlyphPhiResolution=\"" << this->SuperquadricGlyphPhiResolution << "\"";
+  of << " glyphGeometry=\"" << this->GlyphGeometry << "\"";
+  of << " colorGlyphBy=\"" << this->ColorGlyphBy << "\"";
+  of << " glyphScaleFactor=\"" << this->GlyphScaleFactor << "\"";
+  of << " glyphEigenvector=\"" << this->GlyphEigenvector << "\"";
+  of << " glyphExtractEigenvalues=\"" << this->GlyphExtractEigenvalues << "\"";
+  of << " lineGlyphResolution=\"" << this->LineGlyphResolution << "\"";
+  of << " tubeGlyphRadius=\"" << this->TubeGlyphRadius << "\"";
+  of << " tubeGlyphNumberOfSides=\"" << this->TubeGlyphNumberOfSides << "\"";
+  of << " ellipsoidGlyphThetaResolution=\"" << this->EllipsoidGlyphThetaResolution << "\"";
+  of << " ellipsoidGlyphPhiResolution=\"" << this->EllipsoidGlyphPhiResolution << "\"";
+  of << " superquadricGlyphGamma=\"" << this->SuperquadricGlyphGamma << "\"";
+  of << " superquadricGlyphThetaResolution=\"" << this->SuperquadricGlyphThetaResolution << "\"";
+  of << " superquadricGlyphPhiResolution=\"" << this->SuperquadricGlyphPhiResolution << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.cxx
@@ -89,10 +89,7 @@ void vtkMRMLDiffusionTensorVolumeDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   this->Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " scalarInvariant=\"" << this->ScalarInvariant << "\"";
-
+  of << " scalarInvariant=\"" << this->ScalarInvariant << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeSliceDisplayNode.cxx
@@ -62,19 +62,14 @@ vtkMRMLDiffusionTensorVolumeSliceDisplayNode::~vtkMRMLDiffusionTensorVolumeSlice
 //----------------------------------------------------------------------------
 void vtkMRMLDiffusionTensorVolumeSliceDisplayNode::WriteXML(ostream& of, int nIndent)
 {
-
   // Write all attributes not equal to their defaults
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if (this->DiffusionTensorDisplayPropertiesNodeID != NULL)
     {
-    of << indent << " DiffusionTensorDisplayPropertiesNodeRef=\"" << this->DiffusionTensorDisplayPropertiesNodeID << "\"";
+    of << " DiffusionTensorDisplayPropertiesNodeRef=\"" << this->DiffusionTensorDisplayPropertiesNodeID << "\"";
     }
-
-
 }
 
 

--- a/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeDisplayNode.cxx
@@ -51,11 +51,9 @@ void vtkMRMLDiffusionWeightedVolumeDisplayNode::WriteXML(ostream& of, int nInden
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   std::stringstream ss;
   ss << this->DiffusionComponent;
-  of << indent << " diffusionComponent=\"" << ss.str() << "\"";
+  of << " diffusionComponent=\"" << ss.str() << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.cxx
@@ -66,7 +66,6 @@ void vtkMRMLDiffusionWeightedVolumeNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
   std::stringstream ss;
   for(int i=0; i<3; i++)
     {
@@ -79,7 +78,7 @@ void vtkMRMLDiffusionWeightedVolumeNode::WriteXML(ostream& of, int nIndent)
         }
       }
     }
-    of << indent << " measurementFrameMatrix=\"" << ss.str() << "\"";
+    of << " measurementFrameMatrix=\"" << ss.str() << "\"";
 
   ss.clear();
 
@@ -91,7 +90,7 @@ void vtkMRMLDiffusionWeightedVolumeNode::WriteXML(ostream& of, int nIndent)
       }
     }
 
-  of << indent << " gradients=\"" << ss.str() << "\"";
+  of << " gradients=\"" << ss.str() << "\"";
 
   ss.clear();
 
@@ -99,8 +98,7 @@ void vtkMRMLDiffusionWeightedVolumeNode::WriteXML(ostream& of, int nIndent)
     {
     ss << this->BValues->GetValue(g) << " ";
     }
-  of << indent << " bValues=\"" << ss.str() << "\"";
-
+  of << " bValues=\"" << ss.str() << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
@@ -111,72 +111,70 @@ void vtkMRMLDisplayNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " color=\"" << this->Color[0] << " "
+  of << " color=\"" << this->Color[0] << " "
     << this->Color[1] << " "
     << this->Color[2] << "\"";
 
-  of << indent << " edgeColor=\"" << this->EdgeColor[0] << " "
+  of << " edgeColor=\"" << this->EdgeColor[0] << " "
     << this->EdgeColor[1] << " " << this->EdgeColor[2] << "\"";
-  of << indent << " selectedColor=\"" << this->SelectedColor[0] << " "
+  of << " selectedColor=\"" << this->SelectedColor[0] << " "
     << this->SelectedColor[1] << " "
     << this->SelectedColor[2] << "\"";
 
-  of << indent << " selectedAmbient=\"" << this->SelectedAmbient << "\"";
+  of << " selectedAmbient=\"" << this->SelectedAmbient << "\"";
 
-  of << indent << " ambient=\"" << this->Ambient << "\"";
+  of << " ambient=\"" << this->Ambient << "\"";
 
-  of << indent << " diffuse=\"" << this->Diffuse << "\"";
+  of << " diffuse=\"" << this->Diffuse << "\"";
 
-  of << indent << " selectedSpecular=\"" << this->SelectedSpecular << "\"";
+  of << " selectedSpecular=\"" << this->SelectedSpecular << "\"";
 
-  of << indent << " specular=\"" << this->Specular << "\"";
+  of << " specular=\"" << this->Specular << "\"";
 
-  of << indent << " power=\"" << this->Power << "\"";
+  of << " power=\"" << this->Power << "\"";
 
-  of << indent << " opacity=\"" << this->Opacity << "\"";
-  of << indent << " sliceIntersectionOpacity=\"" << this->SliceIntersectionOpacity << "\"";
+  of << " opacity=\"" << this->Opacity << "\"";
+  of << " sliceIntersectionOpacity=\"" << this->SliceIntersectionOpacity << "\"";
 
-  of << indent << " pointSize=\"" << this->PointSize << "\"";
-  of << indent << " lineWidth=\"" << this->LineWidth << "\"";
-  of << indent << " representation=\"" << this->Representation << "\"";
-  of << indent << " lighting=\"" << (this->Lighting? "true" : "false") << "\"";
-  of << indent << " interpolation=\"" << this->Interpolation << "\"";
-  of << indent << " shading=\"" << (this->Shading? "true" : "false") << "\"";
+  of << " pointSize=\"" << this->PointSize << "\"";
+  of << " lineWidth=\"" << this->LineWidth << "\"";
+  of << " representation=\"" << this->Representation << "\"";
+  of << " lighting=\"" << (this->Lighting? "true" : "false") << "\"";
+  of << " interpolation=\"" << this->Interpolation << "\"";
+  of << " shading=\"" << (this->Shading? "true" : "false") << "\"";
 
-  of << indent << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
-  of << indent << " edgeVisibility=\"" << (this->EdgeVisibility? "true" : "false") << "\"";
-  of << indent << " clipping=\"" << (this->Clipping ? "true" : "false") << "\"";
+  of << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
+  of << " edgeVisibility=\"" << (this->EdgeVisibility? "true" : "false") << "\"";
+  of << " clipping=\"" << (this->Clipping ? "true" : "false") << "\"";
 
-  of << indent << " sliceIntersectionVisibility=\"" << (this->SliceIntersectionVisibility ? "true" : "false") << "\"";
+  of << " sliceIntersectionVisibility=\"" << (this->SliceIntersectionVisibility ? "true" : "false") << "\"";
 
-  of << indent << " sliceIntersectionThickness=\"" << this->SliceIntersectionThickness << "\"";
+  of << " sliceIntersectionThickness=\"" << this->SliceIntersectionThickness << "\"";
 
-  of << indent << " frontfaceCulling=\"" << (this->FrontfaceCulling ? "true" : "false") << "\"";
-  of << indent << " backfaceCulling=\"" << (this->BackfaceCulling ? "true" : "false") << "\"";
+  of << " frontfaceCulling=\"" << (this->FrontfaceCulling ? "true" : "false") << "\"";
+  of << " backfaceCulling=\"" << (this->BackfaceCulling ? "true" : "false") << "\"";
 
-  of << indent << " scalarVisibility=\"" << (this->ScalarVisibility ? "true" : "false") << "\"";
+  of << " scalarVisibility=\"" << (this->ScalarVisibility ? "true" : "false") << "\"";
 
-  of << indent << " vectorVisibility=\"" << (this->VectorVisibility ? "true" : "false") << "\"";
+  of << " vectorVisibility=\"" << (this->VectorVisibility ? "true" : "false") << "\"";
 
-  of << indent << " tensorVisibility=\"" << (this->TensorVisibility ? "true" : "false") << "\"";
+  of << " tensorVisibility=\"" << (this->TensorVisibility ? "true" : "false") << "\"";
 
-  of << indent << " interpolateTexture=\"" << (this->InterpolateTexture ? "true" : "false") << "\"";
+  of << " interpolateTexture=\"" << (this->InterpolateTexture ? "true" : "false") << "\"";
 
-  of << indent << " scalarRangeFlag=\"" << this->GetScalarRangeFlagTypeAsString(this->ScalarRangeFlag) << "\"";
+  of << " scalarRangeFlag=\"" << this->GetScalarRangeFlagTypeAsString(this->ScalarRangeFlag) << "\"";
 
-  of << indent << " scalarRange=\"" << this->ScalarRange[0] << " "
+  of << " scalarRange=\"" << this->ScalarRange[0] << " "
      << this->ScalarRange[1] << "\"";
 
   if (this->ColorNodeID != NULL)
     {
-    of << indent << " colorNodeID=\"" << this->ColorNodeID << "\"";
+    of << " colorNodeID=\"" << this->ColorNodeID << "\"";
     }
 
   if (this->ActiveScalarName != NULL)
     {
-    of << indent << " activeScalarName=\"" << this->ActiveScalarName << "\"";
+    of << " activeScalarName=\"" << this->ActiveScalarName << "\"";
     }
 
   std::stringstream ss;
@@ -191,7 +189,7 @@ void vtkMRMLDisplayNode::WriteXML(ostream& of, int nIndent)
     }
   if (this->ViewNodeIDs.size() > 0)
     {
-    of << indent << " viewNodeRef=\"" << ss.str().c_str() << "\"";
+    of << " viewNodeRef=\"" << ss.str().c_str() << "\"";
     }
 
   of << " ";

--- a/Libs/MRML/Core/vtkMRMLDisplayableHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayableHierarchyNode.cxx
@@ -52,14 +52,12 @@ void vtkMRMLDisplayableHierarchyNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if (this->DisplayNodeID != NULL)
     {
-    of << indent << " displayNodeID=\"" << this->DisplayNodeID << "\"";
+    of << " displayNodeID=\"" << this->DisplayNodeID << "\"";
     }
 
-  of << indent << " expanded=\"" << (this->Expanded ? "true" : "false") << "\"";
+  of << " expanded=\"" << (this->Expanded ? "true" : "false") << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
@@ -86,7 +86,6 @@ void vtkMRMLFiducialListNode::WriteXML(ostream& of, int nIndent)
 
   // rest is saved in the storage node file, but it needs to be here as well
   // due to the way the scene snapshots are handled (storage nodes are not re-read)
-  vtkIndent indent(nIndent);
 
   of << " symbolScale=\"" << this->SymbolScale << "\"";
   of << " symbolType=\"" << this->GlyphType << "\"";

--- a/Libs/MRML/Core/vtkMRMLFreeSurferProceduralColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFreeSurferProceduralColorNode.cxx
@@ -66,8 +66,6 @@ void vtkMRMLFreeSurferProceduralColorNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   // only print out the look up table if ?
   if (this->LookupTable != NULL)
     {

--- a/Libs/MRML/Core/vtkMRMLGlyphableVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLGlyphableVolumeDisplayNode.cxx
@@ -75,18 +75,14 @@ void vtkMRMLGlyphableVolumeDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if (this->GlyphColorNodeID != NULL)
     {
-    of << indent << " glyphColorNodeRef=\"" << this->GlyphColorNodeID << "\"";
+    of << " glyphColorNodeRef=\"" << this->GlyphColorNodeID << "\"";
     }
 
   std::stringstream ss;
   ss << this->VisualizationMode;
-  of << indent << " visualizationMode=\"" << ss.str() << "\"";
-
-
+  of << " visualizationMode=\"" << ss.str() << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLGlyphableVolumeSliceDisplayNode.cxx
@@ -66,15 +66,11 @@ vtkMRMLGlyphableVolumeSliceDisplayNode::~vtkMRMLGlyphableVolumeSliceDisplayNode(
 //----------------------------------------------------------------------------
 void vtkMRMLGlyphableVolumeSliceDisplayNode::WriteXML(ostream& of, int nIndent)
 {
-
   // Write all attributes not equal to their defaults
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " colorMode =\"" << this->ColorMode << "\"";
-
+  of << " colorMode =\"" << this->ColorMode << "\"";
 }
 
 

--- a/Libs/MRML/Core/vtkMRMLHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLHierarchyNode.cxx
@@ -85,18 +85,16 @@ void vtkMRMLHierarchyNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if (this->ParentNodeIDReference != NULL)
     {
-    of << indent << " parentNodeRef=\"" << this->ParentNodeIDReference << "\"";
+    of << " parentNodeRef=\"" << this->ParentNodeIDReference << "\"";
     }
   if (this->AssociatedNodeIDReference != NULL)
     {
-    of << indent << " associatedNodeRef=\"" << this->AssociatedNodeIDReference << "\"";
+    of << " associatedNodeRef=\"" << this->AssociatedNodeIDReference << "\"";
     }
-  of << indent << " sortingValue=\"" << this->SortingValue << "\"";
-  of << indent << " allowMultipleChildren=\"" << (this->AllowMultipleChildren ? "true" : "false") << "\"";
+  of << " sortingValue=\"" << this->SortingValue << "\"";
+  of << " allowMultipleChildren=\"" << (this->AllowMultipleChildren ? "true" : "false") << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLInteractionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLInteractionNode.cxx
@@ -140,44 +140,41 @@ void vtkMRMLInteractionNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if ( this->GetCurrentInteractionMode() == vtkMRMLInteractionNode::Place )
     {
-    of << indent << " currentInteractionMode=\"" << "Place" << "\"";
+    of << " currentInteractionMode=\"" << "Place" << "\"";
     }
   else if ( this->GetCurrentInteractionMode() == vtkMRMLInteractionNode::ViewTransform )
     {
-    of << indent << " currentInteractionMode=\"" << "ViewTransform" << "\"";
+    of << " currentInteractionMode=\"" << "ViewTransform" << "\"";
     }
 //  else if ( this->GetCurrentInteractionMode() == vtkMRMLInteractionNode::SelectRegion )
 //    {
-//    of << indent << " currentInteractionMode=\"" << "SelectRegion" << "\"";
+//    of << " currentInteractionMode=\"" << "SelectRegion" << "\"";
 //    }
 //  else if ( this->GetCurrentInteractionMode() == vtkMRMLInteractionNode::LassoRegion )
 //    {
-//    of << indent << " currentInteractionMode=\"" << "LassoRegion" << "\"";
+//    of << " currentInteractionMode=\"" << "LassoRegion" << "\"";
 //    }
 
-  of << indent << " placeModePersistence=\"" << (this->PlaceModePersistence ? "true" : "false") << "\"";
+  of << " placeModePersistence=\"" << (this->PlaceModePersistence ? "true" : "false") << "\"";
 
   if ( this->GetLastInteractionMode() == vtkMRMLInteractionNode::Place )
     {
-    of << indent << " lastInteractionMode=\"" << "Place" << "\"";
+    of << " lastInteractionMode=\"" << "Place" << "\"";
     }
   else if ( this->GetLastInteractionMode() == vtkMRMLInteractionNode::ViewTransform )
     {
-    of << indent << " lastInteractionMode=\"" << "ViewTransform" << "\"";
+    of << " lastInteractionMode=\"" << "ViewTransform" << "\"";
     }
 //  else if ( this->GetLastInteractionMode() == vtkMRMLInteractionNode::SelectRegion )
 //    {
-//    of << indent << " lastInteractionMode=\"" << "SelectRegion" << "\"";
+//    of << " lastInteractionMode=\"" << "SelectRegion" << "\"";
 //    }
 //  else if ( this->GetLastInteractionMode() == vtkMRMLInteractionNode::LassoRegion )
 //    {
-//    of << indent << " lastInteractionMode=\"" << "LassoRegion" << "\"";
+//    of << " lastInteractionMode=\"" << "LassoRegion" << "\"";
 //    }
-
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLLayoutNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLayoutNode.cxx
@@ -62,24 +62,23 @@ void vtkMRMLLayoutNode::WriteXML(ostream& of, int nIndent)
   // order here.
 
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
 
-  of << indent << " currentViewArrangement=\"" << this->ViewArrangement << "\"";
-  of << indent << " guiPanelVisibility=\"" << this->GUIPanelVisibility << "\"";
-  of << indent << " bottomPanelVisibility =\"" << this->BottomPanelVisibility << "\"";
-  of << indent << " guiPanelLR=\"" << this->GUIPanelLR << "\"";
-  of << indent << " collapseSliceControllers=\"" << this->CollapseSliceControllers << "\"" << std::endl;
-  of << indent << " numberOfCompareViewRows=\"" << this->NumberOfCompareViewRows << "\"";
-  of << indent << " numberOfCompareViewColumns=\"" << this->NumberOfCompareViewColumns << "\"";
-  of << indent << " numberOfLightboxRows=\"" << this->NumberOfCompareViewLightboxRows << "\"";
-  of << indent << " numberOfLightboxColumns=\"" << this->NumberOfCompareViewLightboxColumns << "\"";
-  of << indent << " mainPanelSize=\"" << this->MainPanelSize << "\"";
-  of << indent << " secondaryPanelSize=\"" << this->SecondaryPanelSize << "\"";
+  of << " currentViewArrangement=\"" << this->ViewArrangement << "\"";
+  of << " guiPanelVisibility=\"" << this->GUIPanelVisibility << "\"";
+  of << " bottomPanelVisibility =\"" << this->BottomPanelVisibility << "\"";
+  of << " guiPanelLR=\"" << this->GUIPanelLR << "\"";
+  of << " collapseSliceControllers=\"" << this->CollapseSliceControllers << "\"" << std::endl;
+  of << " numberOfCompareViewRows=\"" << this->NumberOfCompareViewRows << "\"";
+  of << " numberOfCompareViewColumns=\"" << this->NumberOfCompareViewColumns << "\"";
+  of << " numberOfLightboxRows=\"" << this->NumberOfCompareViewLightboxRows << "\"";
+  of << " numberOfLightboxColumns=\"" << this->NumberOfCompareViewLightboxColumns << "\"";
+  of << " mainPanelSize=\"" << this->MainPanelSize << "\"";
+  of << " secondaryPanelSize=\"" << this->SecondaryPanelSize << "\"";
   if (this->SelectedModule != NULL)
     {
-    of << indent << " selectedModule=\"" << (this->SelectedModule != NULL ? this->SelectedModule : "") << "\"";
+    of << " selectedModule=\"" << (this->SelectedModule != NULL ? this->SelectedModule : "") << "\"";
     }
-  //of << indent << " layout=\"" << this->CurrentLayoutDescription << "\"";
+  //of << " layout=\"" << this->CurrentLayoutDescription << "\"";
 }
 
 

--- a/Libs/MRML/Core/vtkMRMLLinearTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLinearTransformNode.cxx
@@ -43,8 +43,6 @@ void vtkMRMLLinearTransformNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if (this->IsLinear())
     {
     // Only write the matrix to the scene if the object stores a linear transform
@@ -67,7 +65,7 @@ void vtkMRMLLinearTransformNode::WriteXML(ostream& of, int nIndent)
         ss << " ";
         }
       }
-    of << indent << " matrixTransformToParent=\"" << ss.str() << "\"";
+    of << " matrixTransformToParent=\"" << ss.str() << "\"";
     }
 }
 

--- a/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.cxx
@@ -74,9 +74,7 @@ void vtkMRMLMarkupsStorageNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of,nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " coordinateSystem=\"" << this->CoordinateSystem << "\"";
+  of << " coordinateSystem=\"" << this->CoordinateSystem << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
@@ -51,12 +51,10 @@ vtkMRMLNRRDStorageNode::~vtkMRMLNRRDStorageNode()
 void vtkMRMLNRRDStorageNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
 
   std::stringstream ss;
   ss << this->CenterImage;
-  of << indent << " centerImage=\"" << ss.str() << "\"";
-
+  of << " centerImage=\"" << ss.str() << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -35,9 +35,6 @@ vtkMRMLNode::vtkMRMLNode()
 {
   this->ID = NULL;
 
-  // By default nodes have no effect on indentation
-  this->Indent = 0;
-
   // Strings
   this->Description = NULL;
 
@@ -328,7 +325,6 @@ void vtkMRMLNode::PrintSelf(ostream& os, vtkIndent indent)
 
   os << indent << "Selectable: " << this->Selectable << "\n";
   os << indent << "Selected: " << this->Selected << "\n";
-  os << indent << "Indent:      " << this->Indent << "\n";
 
   if (!this->Attributes.empty())
     {
@@ -521,31 +517,32 @@ void vtkMRMLNode::ParseReferencesAttribute(const char *attValue,
 void vtkMRMLNode::WriteXML(ostream& of, int nIndent)
 {
   vtkIndent indent(nIndent);
+  of << indent;
   if (this->ID != NULL)
     {
-    of << indent << " id=\"" << this->ID << "\"";
+    of << " id=\"" << this->ID << "\"";
     }
   if (this->Name != NULL)
     {
-    of << indent << " name=\"" << this->Name << "\"";
+    of << " name=\"" << this->Name << "\"";
     }
   if (this->Description != NULL)
     {
-    of << indent << " description=\"" << this->Description << "\"";
+    of << " description=\"" << this->Description << "\"";
     }
-  of << indent << " hideFromEditors=\"" << (this->HideFromEditors ? "true" : "false") << "\"";
+  of << " hideFromEditors=\"" << (this->HideFromEditors ? "true" : "false") << "\"";
 
-  of << indent << " selectable=\"" << (this->Selectable ? "true" : "false") << "\"";
-  of << indent << " selected=\"" << (this->Selected ? "true" : "false") << "\"";
+  of << " selectable=\"" << (this->Selectable ? "true" : "false") << "\"";
+  of << " selected=\"" << (this->Selected ? "true" : "false") << "\"";
 
   if (this->SingletonTag)
     {
-    of << indent << " singletonTag=\"" << this->SingletonTag << "\"";
+    of << " singletonTag=\"" << this->SingletonTag << "\"";
     }
 
   if (this->Attributes.size())
     {
-    of << indent << " attributes=\"";
+    of << " attributes=\"";
     AttributesType::const_iterator it;
     AttributesType::const_iterator begin = this->Attributes.begin();
     AttributesType::const_iterator end = this->Attributes.end();
@@ -598,15 +595,15 @@ void vtkMRMLNode::WriteXML(ostream& of, int nIndent)
       {
       if (referenceMRMLAttributeName.length() > 0)
         {
-        of << indent << " " << referenceMRMLAttributeName << "=\"" << ss.str().c_str() << "\"";
+        of << " " << referenceMRMLAttributeName << "=\"" << ss.str().c_str() << "\"";
         }
       ssRef << ";";
       }
-    }//for (it = this->NodeReferences.begin(); it != this->NodeReferences.end(); it++)
+    }
 
     if (!(ssRef.str().empty()))
       {
-      of << indent << " " << "references=\"" << ssRef.str().c_str() << "\"";
+      of << " " << "references=\"" << ssRef.str().c_str() << "\"";
       }
 }
 

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -152,7 +152,7 @@ public:
   ///
   /// \note
   /// Subclasses should implement this method.
-  /// Call this method in the subclass impementation.
+  /// Call this method in the subclass implementation.
   virtual void ReadXMLAttributes(const char** atts);
 
   /// \brief The method should remove all pointers and observations to all nodes
@@ -185,6 +185,7 @@ public:
   /// \note
   /// Subclasses should implement this method.
   /// Call this method in the subclass implementation.
+  /// \param indent Deprecated argument that is kept for API backward-compatibility
   virtual void WriteXML(ostream& of, int indent);
 
   /// Write this node's body to a MRML file in XML format.
@@ -334,11 +335,6 @@ public:
   /// Name of this node, to be set by the user
   vtkSetStringMacro(Name);
   vtkGetStringMacro(Name);
-
-
-  /// \brief Node's effect on indentation when displaying the
-  /// contents of a MRML file. (0, +1, -1)
-  vtkGetMacro(Indent, int);
 
   /// ID use by other nodes to reference this node in XML.
   //vtkSetStringMacro(ID);
@@ -781,8 +777,6 @@ protected:
   vtkMRMLNode(const vtkMRMLNode&);
   void operator=(const vtkMRMLNode&);
 
-  vtkSetMacro(Indent, int);
-
   /// a shared set of functions that call the
   /// virtual ProcessMRMLEvents
   static void MRMLCallback( vtkObject *caller,
@@ -881,7 +875,6 @@ protected:
   char *Description;
   char *Name;
   char *ID;
-  int Indent;
   int HideFromEditors;
   int Selectable;
   int Selected;

--- a/Libs/MRML/Core/vtkMRMLROIListNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLROIListNode.cxx
@@ -19,7 +19,6 @@ vtkMRMLNodeNewMacro(vtkMRMLROIListNode);
 vtkMRMLROIListNode::vtkMRMLROIListNode()
 {
   this->ROIList = vtkCollection::New();
-  this->Indent = 1;
   this->TextScale = 4.5;
   this->Visibility = 1;
   this->Color[0]=0.4; this->Color[1]=1.0; this->Color[2]=1.0;
@@ -64,10 +63,9 @@ vtkMRMLROIListNode::~vtkMRMLROIListNode()
 void vtkMRMLROIListNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
 
-  of << indent <<" TextScale=\"" << this->TextScale << "\"";
-  of << indent <<" Visibility=\"" << this->Visibility << "\"";
+  of <<" TextScale=\"" << this->TextScale << "\"";
+  of <<" Visibility=\"" << this->Visibility << "\"";
 
   of << " color=\"" << this->Color[0] << " " <<
     this->Color[1] << " " <<

--- a/Libs/MRML/Core/vtkMRMLROINode.cxx
+++ b/Libs/MRML/Core/vtkMRMLROINode.cxx
@@ -73,29 +73,26 @@ void vtkMRMLROINode::WriteXML(ostream& of, int nIndent)
   // Write all attributes not equal to their defaults
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if (this->VolumeNodeID != NULL)
     {
-    of << indent << " volumeNodeID=\"" << this->VolumeNodeID << "\"";
+    of << " volumeNodeID=\"" << this->VolumeNodeID << "\"";
     }
   if (this->LabelText != NULL)
     {
-    of << indent << " labelText=\"" << this->LabelText << "\"";
+    of << " labelText=\"" << this->LabelText << "\"";
     }
 
-  of << indent << " xyz=\""
+  of << " xyz=\""
     << this->XYZ[0] << " " << this->XYZ[1] << " " << this->XYZ[2] << "\"";
 
-  of << indent << " radiusXYZ=\""
+  of << " radiusXYZ=\""
     << this->RadiusXYZ[0] << " " << this->RadiusXYZ[1] << " " << this->RadiusXYZ[2] << "\"";
 
-  of << indent << " insideOut=\"" << (this->InsideOut ? "true" : "false") << "\"";
+  of << " insideOut=\"" << (this->InsideOut ? "true" : "false") << "\"";
 
-  of << indent << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
+  of << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
 
-  of << indent << " interactiveMode=\"" << (this->InteractiveMode ? "true" : "false") << "\"";
-
+  of << " interactiveMode=\"" << (this->InteractiveMode ? "true" : "false") << "\"";
 
   return;
 }

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -215,47 +215,45 @@ void vtkMRMLScalarVolumeDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   {
   std::stringstream ss;
   ss << this->GetWindow();
-  of << indent << " window=\"" << ss.str() << "\"";
+  of << " window=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->GetLevel();
-  of << indent << " level=\"" << ss.str() << "\"";
+  of << " level=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->GetUpperThreshold();
-  of << indent << " upperThreshold=\"" << ss.str() << "\"";
+  of << " upperThreshold=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->GetLowerThreshold();
-  of << indent << " lowerThreshold=\"" << ss.str() << "\"";
+  of << " lowerThreshold=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->Interpolate;
-  of << indent << " interpolate=\"" << ss.str() << "\"";
+  of << " interpolate=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->AutoWindowLevel;
-  of << indent << " autoWindowLevel=\"" << ss.str() << "\"";
+  of << " autoWindowLevel=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->ApplyThreshold;
-  of << indent << " applyThreshold=\"" << ss.str() << "\"";
+  of << " applyThreshold=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->AutoThreshold;
-  of << indent << " autoThreshold=\"" << ss.str() << "\"";
+  of << " autoThreshold=\"" << ss.str() << "\"";
   }
   if (this->WindowLevelPresets.size() > 0)
     {
@@ -265,7 +263,7 @@ void vtkMRMLScalarVolumeDisplayNode::WriteXML(ostream& of, int nIndent)
       ss << this->WindowLevelPresets[p].Window;
       ss << "|";
       ss << this->WindowLevelPresets[p].Level;
-      of << indent << " windowLevelPreset" << p << "=\"" << ss.str() << "\"";
+      of << " windowLevelPreset" << p << "=\"" << ss.str() << "\"";
       }
     }
 }

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -979,7 +979,7 @@ int vtkMRMLScene::Commit(const char* url)
       }
     }
 
-  int indent=0, deltaIndent;
+  int indent=0;
 
     // this event is being detected by GUI to provide feedback during load
     // of data. But,
@@ -1040,12 +1040,6 @@ int vtkMRMLScene::Commit(const char* url)
       continue;
       }
 
-    deltaIndent = node->GetIndent();
-    if ( deltaIndent < 0 )
-      {
-      indent -=2;
-      }
-
     vtkIndent vindent(indent);
     *os << vindent << "<" << node->GetNodeTagName() << "\n";
 
@@ -1057,11 +1051,6 @@ int vtkMRMLScene::Commit(const char* url)
     *os << vindent << ">";
     node->WriteNodeBodyXML(*os, indent);
     *os << "</" << node->GetNodeTagName() << ">\n";
-
-    if ( deltaIndent > 0 )
-      {
-      indent += 2;
-      }
     }
 
   *os << "</MRML>\n";

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -66,14 +66,12 @@ void vtkMRMLSceneViewNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " screenshotType=\"" << this->GetScreenShotType() << "\"";
+  of << " screenshotType=\"" << this->GetScreenShotType() << "\"";
 
   vtkStdString description = this->GetSceneViewDescription();
   vtksys::SystemTools::ReplaceString(description,"\n","[br]");
 
-  of << indent << " sceneViewDescription=\"" << description << "\"";
+  of << " sceneViewDescription=\"" << description << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLScriptedModuleNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScriptedModuleNode.cxx
@@ -46,8 +46,6 @@ void vtkMRMLScriptedModuleNode::WriteXML(ostream& of, int nIndent)
 
   // Write all MRML node attributes into output stream
 
-  vtkIndent indent(nIndent);
-
   if (this->ModuleName != 0)
     {
     of << " ModuleName =\"" << this->ModuleName << "\"";

--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
@@ -86,23 +86,22 @@ vtkMRMLSegmentationDisplayNode::~vtkMRMLSegmentationDisplayNode()
 void vtkMRMLSegmentationDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
 
-  of << indent << " PreferredDisplayRepresentationName2D=\""
+  of << " PreferredDisplayRepresentationName2D=\""
     << (this->PreferredDisplayRepresentationName2D ? this->PreferredDisplayRepresentationName2D : "NULL") << "\"";
-  of << indent << " PreferredDisplayRepresentationName3D=\""
+  of << " PreferredDisplayRepresentationName3D=\""
     << (this->PreferredDisplayRepresentationName3D ? this->PreferredDisplayRepresentationName3D : "NULL") << "\"";
 
-  of << indent << " Visibility3D=\"" << (this->Visibility3D ? "true" : "false") << "\"";
-  of << indent << " Visibility2DFill=\"" << (this->Visibility2DFill ? "true" : "false") << "\"";
-  of << indent << " Visibility2DOutline=\"" << (this->Visibility2DOutline ? "true" : "false") << "\"";
-  of << indent << " Opacity3D=\"" << this->Opacity3D << "\"";
-  of << indent << " Opacity2DFill=\"" << this->Opacity2DFill << "\"";
-  of << indent << " Opacity2DOutline=\"" << this->Opacity2DOutline << "\"";
+  of << " Visibility3D=\"" << (this->Visibility3D ? "true" : "false") << "\"";
+  of << " Visibility2DFill=\"" << (this->Visibility2DFill ? "true" : "false") << "\"";
+  of << " Visibility2DOutline=\"" << (this->Visibility2DOutline ? "true" : "false") << "\"";
+  of << " Opacity3D=\"" << this->Opacity3D << "\"";
+  of << " Opacity2DFill=\"" << this->Opacity2DFill << "\"";
+  of << " Opacity2DOutline=\"" << this->Opacity2DOutline << "\"";
 
   this->UpdateSegmentList();
 
-  of << indent << " SegmentationDisplayProperties=\"";
+  of << " SegmentationDisplayProperties=\"";
   for (SegmentDisplayPropertiesMap::iterator propIt = this->SegmentationDisplayProperties.begin();
     propIt != this->SegmentationDisplayProperties.end(); ++propIt)
     {

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -115,7 +115,6 @@ void vtkMRMLSegmentationStorageNode::ReadXMLAttributes(const char** atts)
 void vtkMRMLSegmentationStorageNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSelectionNode.cxx
@@ -143,23 +143,21 @@ void vtkMRMLSelectionNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " activeVolumeID=\"" << (this->ActiveVolumeID ? this->ActiveVolumeID : "NULL") << "\"";
-  of << indent << " secondaryVolumeID=\"" << (this->SecondaryVolumeID ? this->SecondaryVolumeID : "NULL") << "\"";
-  of << indent << " activeLabelVolumeID=\"" << (this->ActiveLabelVolumeID ? this->ActiveLabelVolumeID : "NULL") << "\"";
-  of << indent << " activeFiducialListID=\"" << (this->ActiveFiducialListID ? this->ActiveFiducialListID : "NULL") << "\"";
-  of << indent << " activePlaceNodeID=\"" << (this->ActivePlaceNodeID ? this->ActivePlaceNodeID : "NULL") << "\"";
-  of << indent << " activePlaceNodeClassName=\"" << (this->ActivePlaceNodeClassName ? this->ActivePlaceNodeClassName : "NULL") << "\"";
-  of << indent << " activeROIListID=\"" << (this->ActiveROIListID ? this->ActiveROIListID : "NULL") << "\"";
-  of << indent << " activeCameraID=\"" << (this->ActiveCameraID ? this->ActiveCameraID : "NULL") << "\"";
-  of << indent << " activeTableID=\"" << (this->ActiveTableID ? this->ActiveTableID : "NULL") << "\"";
-  of << indent << " activeViewID=\"" << (this->ActiveViewID ? this->ActiveViewID : "NULL") << "\"";
-  of << indent << " activeLayoutID=\"" << (this->ActiveLayoutID ? this->ActiveLayoutID : "NULL") << "\"";
+  of << " activeVolumeID=\"" << (this->ActiveVolumeID ? this->ActiveVolumeID : "NULL") << "\"";
+  of << " secondaryVolumeID=\"" << (this->SecondaryVolumeID ? this->SecondaryVolumeID : "NULL") << "\"";
+  of << " activeLabelVolumeID=\"" << (this->ActiveLabelVolumeID ? this->ActiveLabelVolumeID : "NULL") << "\"";
+  of << " activeFiducialListID=\"" << (this->ActiveFiducialListID ? this->ActiveFiducialListID : "NULL") << "\"";
+  of << " activePlaceNodeID=\"" << (this->ActivePlaceNodeID ? this->ActivePlaceNodeID : "NULL") << "\"";
+  of << " activePlaceNodeClassName=\"" << (this->ActivePlaceNodeClassName ? this->ActivePlaceNodeClassName : "NULL") << "\"";
+  of << " activeROIListID=\"" << (this->ActiveROIListID ? this->ActiveROIListID : "NULL") << "\"";
+  of << " activeCameraID=\"" << (this->ActiveCameraID ? this->ActiveCameraID : "NULL") << "\"";
+  of << " activeTableID=\"" << (this->ActiveTableID ? this->ActiveTableID : "NULL") << "\"";
+  of << " activeViewID=\"" << (this->ActiveViewID ? this->ActiveViewID : "NULL") << "\"";
+  of << " activeLayoutID=\"" << (this->ActiveLayoutID ? this->ActiveLayoutID : "NULL") << "\"";
 
   if (this->ModelHierarchyDisplayNodeClassName.size() > 0)
     {
-    of << indent << " modelHierarchyDisplayableNodeClassName=\"";
+    of << " modelHierarchyDisplayableNodeClassName=\"";
 
     for (std::map<std::string, std::string>::const_iterator it = this->ModelHierarchyDisplayNodeClassName.begin();
          it != this->ModelHierarchyDisplayNodeClassName.end(); it++)
@@ -168,7 +166,7 @@ void vtkMRMLSelectionNode::WriteXML(ostream& of, int nIndent)
       }
     of << "\"";
 
-    of << indent << " modelHierarchyDisplayNodeClassName=\"";
+    of << " modelHierarchyDisplayNodeClassName=\"";
 
     for (std::map<std::string, std::string>::const_iterator it = this->ModelHierarchyDisplayNodeClassName.begin();
          it != this->ModelHierarchyDisplayNodeClassName.end(); it++)

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
@@ -75,61 +75,59 @@ void vtkMRMLSliceCompositeNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " backgroundVolumeID=\"" <<
+  of << " backgroundVolumeID=\"" <<
    (this->BackgroundVolumeID ? this->BackgroundVolumeID : "") << "\"";
-  of << indent << " foregroundVolumeID=\"" <<
+  of << " foregroundVolumeID=\"" <<
    (this->ForegroundVolumeID ? this->ForegroundVolumeID : "") << "\"";
-  of << indent << " labelVolumeID=\"" <<
+  of << " labelVolumeID=\"" <<
    (this->LabelVolumeID ? this->LabelVolumeID : "") << "\"";
 
-  of << indent << " compositing=\"" << this->Compositing << "\"";
-  of << indent << " foregroundOpacity=\"" << this->ForegroundOpacity << "\"";
-  of << indent << " labelOpacity=\"" << this->LabelOpacity << "\"";
-  of << indent << " linkedControl=\"" << this->LinkedControl << "\"";
-  of << indent << " fiducialVisibility=\"" << this->FiducialVisibility << "\"";
-  of << indent << " fiducialLabelVisibility=\"" << this->FiducialLabelVisibility << "\"";
-  of << indent << " sliceIntersectionVisibility=\"" << this->SliceIntersectionVisibility << "\"";
+  of << " compositing=\"" << this->Compositing << "\"";
+  of << " foregroundOpacity=\"" << this->ForegroundOpacity << "\"";
+  of << " labelOpacity=\"" << this->LabelOpacity << "\"";
+  of << " linkedControl=\"" << this->LinkedControl << "\"";
+  of << " fiducialVisibility=\"" << this->FiducialVisibility << "\"";
+  of << " fiducialLabelVisibility=\"" << this->FiducialLabelVisibility << "\"";
+  of << " sliceIntersectionVisibility=\"" << this->SliceIntersectionVisibility << "\"";
   if (this->GetLayoutName() != NULL)
     {
-    of << indent << " layoutName=\"" << this->GetLayoutName() << "\"";
+    of << " layoutName=\"" << this->GetLayoutName() << "\"";
     }
 
   if ( this->AnnotationSpace == vtkMRMLSliceCompositeNode::XYZ)
     {
-    of << indent << " annotationSpace=\"" << "xyz" << "\"";
+    of << " annotationSpace=\"" << "xyz" << "\"";
     }
   else if ( this->AnnotationSpace == vtkMRMLSliceCompositeNode::IJK)
     {
-    of << indent << " annotationSpace=\"" << "ijk" << "\"";
+    of << " annotationSpace=\"" << "ijk" << "\"";
     }
   else if ( this->AnnotationSpace == vtkMRMLSliceCompositeNode::RAS)
     {
-    of << indent << " annotationSpace=\"" << "RAS" << "\"";
+    of << " annotationSpace=\"" << "RAS" << "\"";
     }
   else if ( this->AnnotationSpace == vtkMRMLSliceCompositeNode::IJKAndRAS)
     {
-    of << indent << " annotationSpace=\"" << "IJKAndRAS" << "\"";
+    of << " annotationSpace=\"" << "IJKAndRAS" << "\"";
     }
 
   if ( this->AnnotationMode == vtkMRMLSliceCompositeNode::NoAnnotation )
     {
-    of << indent << " annotationMode=\"" << "NoAnnotation" << "\"";
+    of << " annotationMode=\"" << "NoAnnotation" << "\"";
     }
   else if ( this->AnnotationMode == vtkMRMLSliceCompositeNode::All )
     {
-    of << indent << " annotationMode=\"" << "All" << "\"";
+    of << " annotationMode=\"" << "All" << "\"";
     }
   if ( this->AnnotationMode == vtkMRMLSliceCompositeNode::LabelValuesOnly )
     {
-    of << indent << " annotationMode=\"" << "LabelValuesOnly" << "\"";
+    of << " annotationMode=\"" << "LabelValuesOnly" << "\"";
     }
   if ( this->AnnotationMode == vtkMRMLSliceCompositeNode::LabelAndVoxelValuesOnly )
     {
-    of << indent << " annotationMode=\"" << "LabelAndVoxelValuesOnly" << "\"";
+    of << " annotationMode=\"" << "LabelAndVoxelValuesOnly" << "\"";
     }
-  of << indent << " doPropagateVolumeSelection=\"" << (int)this->DoPropagateVolumeSelection << "\"";
+  of << " doPropagateVolumeSelection=\"" << (int)this->DoPropagateVolumeSelection << "\"";
 }
 
 //-----------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSliceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.cxx
@@ -866,47 +866,45 @@ void vtkMRMLSliceNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " fieldOfView=\"" <<
+  of << " fieldOfView=\"" <<
         this->FieldOfView[0] << " " <<
         this->FieldOfView[1] << " " <<
         this->FieldOfView[2] << "\"";
 
-  of << indent << " dimensions=\"" <<
+  of << " dimensions=\"" <<
         this->Dimensions[0] << " " <<
         this->Dimensions[1] << " " <<
         this->Dimensions[2] << "\"";
 
-  of << indent << " xyzOrigin=\"" <<
+  of << " xyzOrigin=\"" <<
         this->XYZOrigin[0] << " " <<
         this->XYZOrigin[1] << " " <<
         this->XYZOrigin[2] << "\"";
 
-  of << indent << " sliceResolutionMode=\"" << this->SliceResolutionMode << "\"";
+  of << " sliceResolutionMode=\"" << this->SliceResolutionMode << "\"";
 
-  of << indent << " uvwExtents=\"" <<
+  of << " uvwExtents=\"" <<
         this->UVWExtents[0] << " " <<
         this->UVWExtents[1] << " " <<
         this->UVWExtents[2] << "\"";
 
-  of << indent << " uvwDimensions=\"" <<
+  of << " uvwDimensions=\"" <<
         this->UVWDimensions[0] << " " <<
         this->UVWDimensions[1] << " " <<
         this->UVWDimensions[2] << "\"";
 
-  of << indent << " uvwOrigin=\"" <<
+  of << " uvwOrigin=\"" <<
         this->UVWOrigin[0] << " " <<
         this->UVWOrigin[1] << " " <<
         this->UVWOrigin[2] << "\"";
 
 
-  of << indent << " activeSlice=\"" << this->ActiveSlice << "\"";
+  of << " activeSlice=\"" << this->ActiveSlice << "\"";
 
-  of << indent << " layoutGridRows=\"" <<
+  of << " layoutGridRows=\"" <<
         this->LayoutGridRows << "\"";
 
-  of << indent << " layoutGridColumns=\"" <<
+  of << " layoutGridColumns=\"" <<
         this->LayoutGridColumns << "\"";
 
   std::stringstream ss;
@@ -922,7 +920,7 @@ void vtkMRMLSliceNode::WriteXML(ostream& of, int nIndent)
         }
       }
     }
-  of << indent << " sliceToRAS=\"" << ss.str().c_str() << "\"";
+  of << " sliceToRAS=\"" << ss.str().c_str() << "\"";
 
   std::vector< OrientationPresetType >::iterator it;
   for (it = this->OrientationMatrices.begin(); it != this->OrientationMatrices.end(); ++it)
@@ -940,22 +938,22 @@ void vtkMRMLSliceNode::WriteXML(ostream& of, int nIndent)
           }
         }
       }
-      of << indent << " orientationMatrix"<< this->URLEncodeString(it->first.c_str()) <<"=\"" << ss.str().c_str() << "\"";
+      of << " orientationMatrix"<< this->URLEncodeString(it->first.c_str()) <<"=\"" << ss.str().c_str() << "\"";
     }
 
-  of << indent << " layoutColor=\"" << this->LayoutColor[0] << " "
+  of << " layoutColor=\"" << this->LayoutColor[0] << " "
      << this->LayoutColor[1] << " " << this->LayoutColor[2] << "\"";
-  of << indent << " orientation=\"" << this->GetOrientation() << "\"";
+  of << " orientation=\"" << this->GetOrientation() << "\"";
   if (this->OrientationReference)
     {
-    of << indent << " orientationReference=\"" << this->OrientationReference << "\"";
+    of << " orientationReference=\"" << this->OrientationReference << "\"";
     }
-  of << indent << " jumpMode=\"" << this->JumpMode << "\"";
-  of << indent << " sliceVisibility=\"" << (this->SliceVisible ? "true" : "false") << "\"";
-  of << indent << " widgetVisibility=\"" << (this->WidgetVisible ? "true" : "false") << "\"";
-  of << indent << " useLabelOutline=\"" << (this->UseLabelOutline ? "true" : "false") << "\"";
-  of << indent << " sliceSpacingMode=\"" << this->SliceSpacingMode << "\"";
-  of << indent << " prescribedSliceSpacing=\""
+  of << " jumpMode=\"" << this->JumpMode << "\"";
+  of << " sliceVisibility=\"" << (this->SliceVisible ? "true" : "false") << "\"";
+  of << " widgetVisibility=\"" << (this->WidgetVisible ? "true" : "false") << "\"";
+  of << " useLabelOutline=\"" << (this->UseLabelOutline ? "true" : "false") << "\"";
+  of << " sliceSpacingMode=\"" << this->SliceSpacingMode << "\"";
+  of << " prescribedSliceSpacing=\""
      << this->PrescribedSliceSpacing[0] << " "
      << this->PrescribedSliceSpacing[1] << " "
      << this->PrescribedSliceSpacing[2] << "\"";
@@ -971,9 +969,8 @@ void vtkMRMLSliceNode::WriteXML(ostream& of, int nIndent)
     }
   if (this->ThreeDViewIDs.size() > 0)
     {
-    of << indent << " threeDViewNodeRef=\"" << ss.str().c_str() << "\"";
+    of << " threeDViewNodeRef=\"" << ss.str().c_str() << "\"";
     }
-
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSnapshotClipNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSnapshotClipNode.cxx
@@ -51,8 +51,6 @@ void vtkMRMLSnapshotClipNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   vtkMRMLSceneViewNode * node = NULL;
   std::stringstream ss;
   int n;
@@ -65,8 +63,7 @@ void vtkMRMLSnapshotClipNode::WriteXML(ostream& of, int nIndent)
       ss << " ";
       }
     }
-    of << indent << " sceneSnapshotIDs=\"" << ss.str().c_str() << "\"";
-
+    of << " sceneSnapshotIDs=\"" << ss.str().c_str() << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLStorableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorableNode.cxx
@@ -121,8 +121,6 @@ void vtkMRMLStorableNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   std::stringstream ss;
 
   //---write any user tags.
@@ -147,10 +145,9 @@ void vtkMRMLStorableNode::WriteXML(ostream& of, int nIndent)
       }
     if ( ss.str().c_str()!= NULL )
       {
-      of << indent << " userTags=\"" << ss.str().c_str() << "\"";
+      of << " userTags=\"" << ss.str().c_str() << "\"";
       }
     }
-
 }
 
 

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -108,7 +108,6 @@ vtkMRMLStorageNode::~vtkMRMLStorageNode()
 void vtkMRMLStorageNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
 
   if (this->FileName != NULL)
     {
@@ -119,7 +118,7 @@ void vtkMRMLStorageNode::WriteXML(ostream& of, int nIndent)
       name = vtksys::SystemTools::RelativePath(this->GetScene()->GetRootDirectory(), this->FileName);
       }
 
-    of << indent << " fileName=\"" << vtkMRMLNode::URLEncodeString(name.c_str()) << "\"";
+    of << " fileName=\"" << vtkMRMLNode::URLEncodeString(name.c_str()) << "\"";
 
     // if there is a file list, add the archetype to it. add file will check
     // that it's not already there. currently needed for reading in multi
@@ -156,7 +155,7 @@ void vtkMRMLStorageNode::WriteXML(ostream& of, int nIndent)
       name = vtksys::SystemTools::RelativePath(this->GetScene()->GetRootDirectory(), this->GetNthFileName(i));
       }
 
-    of << indent << " fileListMember" << i << "=\"" << vtkMRMLNode::URLEncodeString(name.c_str()) << "\"";
+    of << " fileListMember" << i << "=\"" << vtkMRMLNode::URLEncodeString(name.c_str()) << "\"";
     if (this->GetScene() && this->IsFilePathRelative(this->GetNthFileName(i)))
       {
       // go back to absolute
@@ -175,24 +174,24 @@ void vtkMRMLStorageNode::WriteXML(ostream& of, int nIndent)
 
   if (this->URI != NULL)
     {
-    of << indent << " uri=\"" << vtkMRMLNode::URLEncodeString(this->URI) << "\"";
+    of << " uri=\"" << vtkMRMLNode::URLEncodeString(this->URI) << "\"";
     }
   for (int i = 0; i < this->GetNumberOfURIs(); i++)
     {
-    of << indent << " uriListMember" << i << "=\"" << vtkMRMLNode::URLEncodeString(this->GetNthURI(i)) << "\"";
+    of << " uriListMember" << i << "=\"" << vtkMRMLNode::URLEncodeString(this->GetNthURI(i)) << "\"";
     }
 
   std::stringstream ss;
   ss << this->UseCompression;
-  of << indent << " useCompression=\"" << ss.str() << "\"";
+  of << " useCompression=\"" << ss.str() << "\"";
 
   if (this->GetDefaultWriteFileExtension() != NULL)
     {
-    of << indent << " defaultWriteFileExtension=\"" << this->GetDefaultWriteFileExtension() << "\"";
+    of << " defaultWriteFileExtension=\"" << this->GetDefaultWriteFileExtension() << "\"";
     }
 
-  of << indent << " readState=\"" << this->ReadState <<  "\"";
-  of << indent << " writeState=\"" << this->WriteState <<  "\"";
+  of << " readState=\"" << this->ReadState <<  "\"";
+  of << " writeState=\"" << this->WriteState <<  "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyLegacyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyLegacyNode.cxx
@@ -150,15 +150,12 @@ void vtkMRMLSubjectHierarchyLegacyNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of,nIndent);
 
-  vtkIndent indent(nIndent);
+  of << " Level=\"" << (this->Level ? this->Level : "NULL" ) << "\"";
 
-  of << indent << " Level=\""
-    << (this->Level ? this->Level : "NULL" ) << "\"";
-
-  of << indent << " OwnerPluginName=\""
+  of << " OwnerPluginName=\""
     << (this->OwnerPluginName ? this->OwnerPluginName : "NULL" ) << "\"";
 
-  of << indent << " UIDs=\"";
+  of << " UIDs=\"";
   for (std::map<std::string, std::string>::iterator uidsIt = this->UIDs.begin(); uidsIt != this->UIDs.end(); ++uidsIt)
     {
     of << uidsIt->first << vtkMRMLSubjectHierarchyLegacyNode::SUBJECTHIERARCHY_UID_NAME_VALUE_SEPARATOR

--- a/Libs/MRML/Core/vtkMRMLTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableNode.cxx
@@ -65,10 +65,9 @@ void vtkMRMLTableNode::WriteXML(ostream& of, int nIndent)
 {
   // Start by having the superclass write its information
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
-  of << indent << " locked=\"" << (this->GetLocked() ? "true" : "false") << "\"";
-  of << indent << " useFirstColumnAsRowHeader=\"" << (this->GetUseFirstColumnAsRowHeader() ? "true" : "false") << "\"";
-  of << indent << " useColumnNameAsColumnHeader=\"" << (this->GetUseColumnNameAsColumnHeader() ? "true" : "false") << "\"";
+  of << " locked=\"" << (this->GetLocked() ? "true" : "false") << "\"";
+  of << " useFirstColumnAsRowHeader=\"" << (this->GetUseFirstColumnAsRowHeader() ? "true" : "false") << "\"";
+  of << " useColumnNameAsColumnHeader=\"" << (this->GetUseColumnNameAsColumnHeader() ? "true" : "false") << "\"";
 }
 
 

--- a/Libs/MRML/Core/vtkMRMLTableViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableViewNode.cxx
@@ -63,8 +63,7 @@ const char* vtkMRMLTableViewNode::GetNodeTagName()
 void vtkMRMLTableViewNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
-  of << indent << " doPropagateTableSelection=\"" << (int)this->DoPropagateTableSelection << "\"";
+  of << " doPropagateTableSelection=\"" << (int)this->DoPropagateTableSelection << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTensorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTensorVolumeNode.cxx
@@ -49,7 +49,6 @@ void vtkMRMLTensorVolumeNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
   std::stringstream ss;
   for(int i=0; i<3; i++)
     {
@@ -62,9 +61,9 @@ void vtkMRMLTensorVolumeNode::WriteXML(ostream& of, int nIndent)
         }
       }
     }
-    of << indent << " measurementFrame=\"" << ss.str() << "\"";
+  of << " measurementFrame=\"" << ss.str() << "\"";
 
-   of << indent << " order=\"" << Order << "\"";
+  of << " order=\"" << Order << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformDisplayNode.cxx
@@ -111,35 +111,34 @@ vtkMRMLTransformDisplayNode::~vtkMRMLTransformDisplayNode()
 void vtkMRMLTransformDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
 
-  of << indent << " VisualizationMode=\""<< ConvertVisualizationModeToString(this->VisualizationMode) << "\"";
+  of << " VisualizationMode=\""<< ConvertVisualizationModeToString(this->VisualizationMode) << "\"";
 
-  of << indent << " GlyphSpacingMm=\""<< this->GlyphSpacingMm << "\"";
-  of << indent << " GlyphScalePercent=\""<< this->GlyphScalePercent << "\"";
-  of << indent << " GlyphDisplayRangeMaxMm=\""<< this->GlyphDisplayRangeMaxMm << "\"";
-  of << indent << " GlyphDisplayRangeMinMm=\""<< this->GlyphDisplayRangeMinMm << "\"";
-  of << indent << " GlyphType=\""<< ConvertGlyphTypeToString(this->GlyphType) << "\"";
-  of << indent << " GlyphTipLengthPercent=\"" << this->GlyphTipLengthPercent << "\"";
-  of << indent << " GlyphDiameterMm=\""<< this->GlyphDiameterMm << "\"";
-  of << indent << " GlyphShaftDiameterPercent=\"" << this->GlyphShaftDiameterPercent << "\"";
-  of << indent << " GlyphResolution=\"" << this->GlyphResolution << "\"";
+  of << " GlyphSpacingMm=\""<< this->GlyphSpacingMm << "\"";
+  of << " GlyphScalePercent=\""<< this->GlyphScalePercent << "\"";
+  of << " GlyphDisplayRangeMaxMm=\""<< this->GlyphDisplayRangeMaxMm << "\"";
+  of << " GlyphDisplayRangeMinMm=\""<< this->GlyphDisplayRangeMinMm << "\"";
+  of << " GlyphType=\""<< ConvertGlyphTypeToString(this->GlyphType) << "\"";
+  of << " GlyphTipLengthPercent=\"" << this->GlyphTipLengthPercent << "\"";
+  of << " GlyphDiameterMm=\""<< this->GlyphDiameterMm << "\"";
+  of << " GlyphShaftDiameterPercent=\"" << this->GlyphShaftDiameterPercent << "\"";
+  of << " GlyphResolution=\"" << this->GlyphResolution << "\"";
 
-  of << indent << " GridScalePercent=\""<< this->GridScalePercent << "\"";
-  of << indent << " GridSpacingMm=\""<< this->GridSpacingMm << "\"";
-  of << indent << " GridLineDiameterMm=\""<< this->GridLineDiameterMm << "\"";
-  of << indent << " GridResolutionMm=\""<< this->GridResolutionMm << "\"";
-  of << indent << " GridShowNonWarped=\""<< this->GridShowNonWarped << "\"";
+  of << " GridScalePercent=\""<< this->GridScalePercent << "\"";
+  of << " GridSpacingMm=\""<< this->GridSpacingMm << "\"";
+  of << " GridLineDiameterMm=\""<< this->GridLineDiameterMm << "\"";
+  of << " GridResolutionMm=\""<< this->GridResolutionMm << "\"";
+  of << " GridShowNonWarped=\""<< this->GridShowNonWarped << "\"";
 
-  of << indent << " ContourResolutionMm=\""<< this->ContourResolutionMm << "\"";
-  of << indent << " ContourLevelsMm=\"" << this->GetContourLevelsMmAsString() << "\"";
-  of << indent << " ContourOpacity=\""<< this->ContourOpacity << "\"";
+  of << " ContourResolutionMm=\""<< this->ContourResolutionMm << "\"";
+  of << " ContourLevelsMm=\"" << this->GetContourLevelsMmAsString() << "\"";
+  of << " ContourOpacity=\""<< this->ContourOpacity << "\"";
 
-  of << indent << " EditorVisibility=\""<< this->EditorVisibility << "\"";
-  of << indent << " EditorSliceIntersectionVisibility=\""<< this->EditorSliceIntersectionVisibility << "\"";
-  of << indent << " EditorTranslationEnabled=\""<< this->EditorTranslationEnabled << "\"";
-  of << indent << " EditorRotationEnabled=\"" << this->EditorRotationEnabled << "\"";
-  of << indent << " EditorScalingEnabled=\""<< this->EditorScalingEnabled << "\"";
+  of << " EditorVisibility=\""<< this->EditorVisibility << "\"";
+  of << " EditorSliceIntersectionVisibility=\""<< this->EditorSliceIntersectionVisibility << "\"";
+  of << " EditorTranslationEnabled=\""<< this->EditorTranslationEnabled << "\"";
+  of << " EditorRotationEnabled=\"" << this->EditorRotationEnabled << "\"";
+  of << " EditorScalingEnabled=\""<< this->EditorScalingEnabled << "\"";
 }
 
 

--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -71,7 +71,6 @@ vtkMRMLTransformNode::~vtkMRMLTransformNode()
 //----------------------------------------------------------------------------
 void vtkMRMLTransformNode::WriteXML(ostream& of, int nIndent)
 {
-  vtkIndent indent(nIndent);
   Superclass::WriteXML(of, nIndent);
 }
 
@@ -330,7 +329,6 @@ void vtkMRMLTransformNode::PrintSelf(ostream& os, vtkIndent indent)
       concatenatedTransform->PrintSelf(os, indent.GetNextIndent().GetNextIndent());
       }
     }
-
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
@@ -50,8 +50,8 @@ vtkMRMLTransformStorageNode::~vtkMRMLTransformStorageNode()
 void vtkMRMLTransformStorageNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
-  of << indent << " preferITKv3CompatibleTransforms=\"" << (this->PreferITKv3CompatibleTransforms ? "true" : "false") << "\"";
+
+  of << " preferITKv3CompatibleTransforms=\"" << (this->PreferITKv3CompatibleTransforms ? "true" : "false") << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLUnitNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLUnitNode.cxx
@@ -70,14 +70,13 @@ void vtkMRMLUnitNode::WriteXML(ostream& of, int nIndent)
   // Write all attributes not equal to their defaults
   this->Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-  of << indent << " Quantity=\""
+  of << " Quantity=\""
     << (this->GetQuantity() ? this->GetQuantity() : "") << "\"";
-  of << indent << " Prefix=\"" << (this->Prefix ? this->Prefix : "") << "\"";
-  of << indent << " Suffix=\"" << (this->Suffix ? this->Suffix : "") << "\"";
-  of << indent << " Precision=\"" << this->Precision << "\"";
-  of << indent << " MinimumValue=\"" << this->MinimumValue << "\"";
-  of << indent << " MaximumValue=\"" << this->MaximumValue << "\"";
+  of << " Prefix=\"" << (this->Prefix ? this->Prefix : "") << "\"";
+  of << " Suffix=\"" << (this->Suffix ? this->Suffix : "") << "\"";
+  of << " Precision=\"" << this->Precision << "\"";
+  of << " MinimumValue=\"" << this->MinimumValue << "\"";
+  of << " MaximumValue=\"" << this->MaximumValue << "\"";
 }
 
 namespace

--- a/Libs/MRML/Core/vtkMRMLVectorVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVectorVolumeDisplayNode.cxx
@@ -103,17 +103,15 @@ void vtkMRMLVectorVolumeDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   std::stringstream ss;
 
   ss.clear();
   ss << this->ScalarMode;
-  of << indent << " scalarMode=\"" << ss.str() << "\"";
+  of << " scalarMode=\"" << ss.str() << "\"";
 
   ss.clear();
   ss << this->GlyphMode;
-  of << indent << " glyphMode=\"" << ss.str() << "\"";
+  of << " glyphMode=\"" << ss.str() << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLVectorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVectorVolumeNode.cxx
@@ -39,7 +39,6 @@ vtkMRMLVectorVolumeNode::~vtkMRMLVectorVolumeNode()
 void vtkMRMLVectorVolumeNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLViewNode.cxx
@@ -76,119 +76,116 @@ void vtkMRMLViewNode::WriteXML(ostream& of, int nIndent)
 
   this->Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " fieldOfView=\"" << this->GetFieldOfView() << "\"";
-  of << indent << " letterSize=\"" << this->GetLetterSize() << "\"";
-  of << indent << " boxVisible=\"" << (this->BoxVisible ? "true" : "false") << "\"";
-  of << indent << " fiducialsVisible=\"" << (this->FiducialsVisible ? "true" : "false") << "\"";
-  of << indent << " fiducialLabelsVisible=\"" << (this->FiducialLabelsVisible ? "true" : "false") << "\"";
-  of << indent << " axisLabelsVisible=\"" << (this->AxisLabelsVisible ? "true" : "false") << "\"";
-  of << indent << " axisLabelsCameraDependent=\"" << (this->AxisLabelsCameraDependent ? "true" : "false") << "\"";
+  of << " fieldOfView=\"" << this->GetFieldOfView() << "\"";
+  of << " letterSize=\"" << this->GetLetterSize() << "\"";
+  of << " boxVisible=\"" << (this->BoxVisible ? "true" : "false") << "\"";
+  of << " fiducialsVisible=\"" << (this->FiducialsVisible ? "true" : "false") << "\"";
+  of << " fiducialLabelsVisible=\"" << (this->FiducialLabelsVisible ? "true" : "false") << "\"";
+  of << " axisLabelsVisible=\"" << (this->AxisLabelsVisible ? "true" : "false") << "\"";
+  of << " axisLabelsCameraDependent=\"" << (this->AxisLabelsCameraDependent ? "true" : "false") << "\"";
 
   // spin or rock?
   if ( this->GetAnimationMode() == vtkMRMLViewNode::Off )
     {
-    of << indent << " animationMode=\"" << "Off" << "\"";
+    of << " animationMode=\"" << "Off" << "\"";
     }
   else if ( this->GetAnimationMode() == vtkMRMLViewNode::Spin )
     {
-    of << indent << " animationMode=\"" << "Spin" << "\"";
+    of << " animationMode=\"" << "Spin" << "\"";
     }
   else if ( this->GetAnimationMode() == vtkMRMLViewNode::Rock )
     {
-    of << indent << " animationMode=\"" << "Rock" << "\"";
+    of << " animationMode=\"" << "Rock" << "\"";
     }
 
   if ( this->GetViewAxisMode() == vtkMRMLViewNode::LookFrom )
     {
-    of << indent << " viewAxisMode=\"" << "LookFrom" << "\"";
+    of << " viewAxisMode=\"" << "LookFrom" << "\"";
     }
   else if ( this->GetViewAxisMode() == vtkMRMLViewNode::RotateAround )
     {
-    of << indent << " viewAxisMode=\"" << "RotateAround" << "\"";
+    of << " viewAxisMode=\"" << "RotateAround" << "\"";
     }
 
   // configure spin
-  of << indent << " spinDegrees=\"" << this->GetSpinDegrees() << "\"";
-  of << indent << " spinMs=\"" << this->GetAnimationMs() << "\"";
+  of << " spinDegrees=\"" << this->GetSpinDegrees() << "\"";
+  of << " spinMs=\"" << this->GetAnimationMs() << "\"";
   if ( this->GetSpinDirection() == vtkMRMLViewNode::PitchUp )
     {
-    of << indent << " spinDirection=\"" << "PitchUp" << "\"";
+    of << " spinDirection=\"" << "PitchUp" << "\"";
     }
   else if ( this->GetSpinDirection() == vtkMRMLViewNode::PitchDown )
     {
-    of << indent << " spinDirection=\"" << "PitchDown" << "\"";
+    of << " spinDirection=\"" << "PitchDown" << "\"";
     }
   else if ( this->GetSpinDirection() == vtkMRMLViewNode::RollLeft )
     {
-    of << indent << " spinDirection=\"" << "RollLeft" << "\"";
+    of << " spinDirection=\"" << "RollLeft" << "\"";
     }
   else if ( this->GetSpinDirection() == vtkMRMLViewNode::RollRight )
     {
-    of << indent << " spinDirection=\"" << "RollRight" << "\"";
+    of << " spinDirection=\"" << "RollRight" << "\"";
     }
   else if ( this->GetSpinDirection() == vtkMRMLViewNode::YawLeft )
     {
-    of << indent << " spinDirection=\"" << "YawLeft" << "\"";
+    of << " spinDirection=\"" << "YawLeft" << "\"";
     }
   else if ( this->GetSpinDirection() == vtkMRMLViewNode::YawRight )
     {
-    of << indent << " spinDirection=\"" << "YawRight" << "\"";
+    of << " spinDirection=\"" << "YawRight" << "\"";
     }
 
-  of << indent << " rotateDegrees=\"" << this->GetRotateDegrees() << "\"";
+  of << " rotateDegrees=\"" << this->GetRotateDegrees() << "\"";
 
   // configure rock
-  of << indent << " rockLength=\"" << this->GetRockLength() << "\"";
-  of << indent << " rockCount=\"" << this->GetRockCount() << "\"";
+  of << " rockLength=\"" << this->GetRockLength() << "\"";
+  of << " rockCount=\"" << this->GetRockCount() << "\"";
 
   // configure stereo
   if ( this->GetStereoType() == vtkMRMLViewNode::NoStereo )
     {
-    of << indent << " stereoType=\"" << "NoStereo" << "\"";
+    of << " stereoType=\"" << "NoStereo" << "\"";
     }
   else if ( this->GetStereoType() == vtkMRMLViewNode::RedBlue )
     {
-    of << indent << " stereoType=\"" << "RedBlue" << "\"";
+    of << " stereoType=\"" << "RedBlue" << "\"";
     }
   else if ( this->GetStereoType() == vtkMRMLViewNode::Anaglyph )
     {
-    of << indent << " stereoType=\"" << "Anaglyph" << "\"";
+    of << " stereoType=\"" << "Anaglyph" << "\"";
     }
   else if ( this->GetStereoType() == vtkMRMLViewNode::QuadBuffer )
     {
-    of << indent << " stereoType=\"" << "QuadBuffer" << "\"";
+    of << " stereoType=\"" << "QuadBuffer" << "\"";
     }
   else if ( this->GetStereoType() == vtkMRMLViewNode::Interlaced )
     {
-    of << indent << " stereoType=\"" << "Interlaced" << "\"";
+    of << " stereoType=\"" << "Interlaced" << "\"";
     }
   else if ( this->GetStereoType() == vtkMRMLViewNode::UserDefined_1 )
     {
-    of << indent << " stereoType=\"" << "UserDefined_1" << "\"";
+    of << " stereoType=\"" << "UserDefined_1" << "\"";
     }
   else if ( this->GetStereoType() == vtkMRMLViewNode::UserDefined_2 )
     {
-    of << indent << " stereoType=\"" << "UserDefined_2" << "\"";
+    of << " stereoType=\"" << "UserDefined_2" << "\"";
     }
   else if ( this->GetStereoType() == vtkMRMLViewNode::UserDefined_3 )
     {
-    of << indent << " stereoType=\"" << "UserDefined_3" << "\"";
+    of << " stereoType=\"" << "UserDefined_3" << "\"";
     }
 
   // configure render mode
   if (this->GetRenderMode() == vtkMRMLViewNode::Perspective )
     {
-    of << indent << " renderMode=\"" << "Perspective" << "\"";
+    of << " renderMode=\"" << "Perspective" << "\"";
     }
   else if ( this->GetRenderMode() == vtkMRMLViewNode::Orthographic )
     {
-    of << indent << " renderMode=\"" << "Orthographic" << "\"";
+    of << " renderMode=\"" << "Orthographic" << "\"";
     }
 
-  of << indent << " useDepthPeeling=\"" << this->GetUseDepthPeeling() << "\"";
-
+  of << " useDepthPeeling=\"" << this->GetUseDepthPeeling() << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -67,16 +67,15 @@ vtkMRMLVolumeArchetypeStorageNode::~vtkMRMLVolumeArchetypeStorageNode()
 void vtkMRMLVolumeArchetypeStorageNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
   {
   std::stringstream ss;
   ss << this->CenterImage;
-  of << indent << " centerImage=\"" << ss.str() << "\"";
+  of << " centerImage=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->UseOrientationFromFile;
-  of << indent << " UseOrientationFromFile=\"" << ss.str() << "\"";
+  of << " UseOrientationFromFile=\"" << ss.str() << "\"";
   }
   // SingleFile attribute is not written to file. GetNumberOfFileNames()
   // is used to determine if reader should read from single/multiple files.

--- a/Libs/MRML/Core/vtkMRMLVolumeHeaderlessStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeHeaderlessStorageNode.cxx
@@ -143,41 +143,40 @@ void vtkMRMLVolumeHeaderlessStorageNode::SetFileScalarTypeAsString(const char* t
 void vtkMRMLVolumeHeaderlessStorageNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
-  vtkIndent indent(nIndent);
   {
   std::stringstream ss;
   ss << this->CenterImage;
-  of << indent << " centerImage=\"" << ss.str() << "\"";
+  of << " centerImage=\"" << ss.str() << "\"";
   }
   {
-  of << indent << " fileDimensions=\"" << this->FileDimensions[0] << " "
+  of << " fileDimensions=\"" << this->FileDimensions[0] << " "
     << this->FileDimensions[1] << " "
     << this->FileDimensions[2] << "\"";
   }
   {
-  of << indent << " fileSpacing=\"" << this->FileSpacing[0] << " "
+  of << " fileSpacing=\"" << this->FileSpacing[0] << " "
     << this->FileSpacing[1] << " "
     << this->FileSpacing[2] << "\"";
   }
   {
   std::stringstream ss;
   ss << this->FileLittleEndian;
-  of << indent << " fileLittleEndian=\"" << ss.str() << "\"";
+  of << " fileLittleEndian=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->FileScalarType;
-  of << indent << " fileScalarType=\"" << ss.str() << "\"";
+  of << " fileScalarType=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->FileScanOrder;
-  of << indent << " fileScanOrder=\"" << ss.str() << "\"";
+  of << " fileScanOrder=\"" << ss.str() << "\"";
   }
   {
   std::stringstream ss;
   ss << this->FileNumberOfScalarComponents;
-  of << indent << " fileNumberOfScalarComponents=\"" << ss.str() << "\"";
+  of << " fileNumberOfScalarComponents=\"" << ss.str() << "\"";
   }
 }
 

--- a/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
@@ -83,8 +83,6 @@ void vtkMRMLVolumeNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   std::stringstream ss;
   for(int i=0; i<3; i++)
     {
@@ -97,12 +95,12 @@ void vtkMRMLVolumeNode::WriteXML(ostream& of, int nIndent)
         }
       }
     }
-    of << indent << " ijkToRASDirections=\"" << ss.str() << "\"";
+  of << " ijkToRASDirections=\"" << ss.str() << "\"";
 
-  of << indent << " spacing=\""
+  of << " spacing=\""
     << this->Spacing[0] << " " << this->Spacing[1] << " " << this->Spacing[2] << "\"";
 
-  of << indent << " origin=\""
+  of << " origin=\""
     << this->Origin[0] << " " << this->Origin[1] << " " << this->Origin[2] << "\"";
 }
 

--- a/Libs/vtkSegmentationCore/vtkSegment.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegment.cxx
@@ -129,20 +129,19 @@ void vtkSegment::ReadXMLAttributes(const char** vtkNotUsed(atts))
 void vtkSegment::WriteXML(ostream& of, int nIndent)
 {
   // Note: Segment info is written by the storage node, this function is not called
-  vtkIndent indent(nIndent);
 
-  of << indent << "Name=\"" << (this->Name ? this->Name : "NULL") << "\"";
-  of << indent << "Color:\"(" << this->Color[0] << ", " << this->Color[1] << ", " << this->Color[2] << ")\"";
+  of << "Name=\"" << (this->Name ? this->Name : "NULL") << "\"";
+  of << "Color:\"(" << this->Color[0] << ", " << this->Color[1] << ", " << this->Color[2] << ")\"";
 
   RepresentationMap::iterator reprIt;
-  of << indent << "Representations=\"";
+  of << "Representations=\"";
   for (reprIt=this->Representations.begin(); reprIt!=this->Representations.end(); ++reprIt)
     {
-    of << indent << "  " << reprIt->first << "\"";
+    of << "  " << reprIt->first << "\"";
     }
 
   std::map<std::string,std::string>::iterator tagIt;
-  of << indent << "Tags=\"";
+  of << "Tags=\"";
   for (tagIt=this->Tags.begin(); tagIt!=this->Tags.end(); ++tagIt)
     {
     of << tagIt->first << ":" << tagIt->second << "|";

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -106,9 +106,7 @@ vtkSegmentation::~vtkSegmentation()
 //----------------------------------------------------------------------------
 void vtkSegmentation::WriteXML(ostream& of, int nIndent)
 {
-  vtkIndent indent(nIndent);
-
-  of << indent << " MasterRepresentationName=\"" << this->MasterRepresentationName << "\"";
+  of << " MasterRepresentationName=\"" << this->MasterRepresentationName << "\"";
 
   // Note: Segment info is not written as it is managed by the storage node instead.
 }

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationAngleNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationAngleNode.cxx
@@ -119,32 +119,29 @@ void vtkMRMLAnnotationAngleNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " labelFormat=\"";
+  of << " labelFormat=\"";
   if (this->LabelFormat)
     {
-      of << this->LabelFormat << "\"";
+    of << this->LabelFormat << "\"";
     }
   else
     {
-      of << "\"";
+    of << "\"";
     }
-  of << indent << " angleResolution=\""<< this->Resolution << "\"";
+  of << " angleResolution=\""<< this->Resolution << "\"";
 
   if (this->ModelID1)
     {
-    of << indent << " modelID1=\"" << this->ModelID1 << "\"";
+    of << " modelID1=\"" << this->ModelID1 << "\"";
     }
   if (this->ModelID2)
     {
-    of << indent << " modelID2=\"" << this->ModelID2 << "\"";
+    of << " modelID2=\"" << this->ModelID2 << "\"";
     }
   if (this->ModelIDCenter)
     {
-    of << indent << " modelIDCenter=\"" << this->ModelIDCenter << "\"";
+    of << " modelIDCenter=\"" << this->ModelIDCenter << "\"";
     }
-
 }
 
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationBidimensionalNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationBidimensionalNode.cxx
@@ -75,26 +75,24 @@ void vtkMRMLAnnotationBidimensionalNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << "AnnotationFormat=\"";
+  of << "AnnotationFormat=\"";
   if (this->AnnotationFormat)
     {
-      of << this->AnnotationFormat << "\"";
+    of << this->AnnotationFormat << "\"";
     }
   else
     {
-      of << "\"";
+    of << "\"";
     }
-  of << indent << "Resolution=\""<< this->Resolution << "\"";
+  of << "Resolution=\""<< this->Resolution << "\"";
 
   if (this->measurement1)
     {
-    of << indent << "measurement1=\"" << this->measurement1 << "\"";
+    of << "measurement1=\"" << this->measurement1 << "\"";
     }
   if (this->measurement2)
     {
-    of << indent << "measurement2=\"" << this->measurement2 << "\"";
+    of << "measurement2=\"" << this->measurement2 << "\"";
     }
 }
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.cxx
@@ -38,59 +38,57 @@ void vtkMRMLAnnotationControlPointsNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLHierarchyNode *hnode = vtkMRMLHierarchyNode::GetAssociatedHierarchyNode(this->GetScene(), this->GetID());
 
   if (hnode &&
-      hnode->GetParentNodeID())
-    {
-    vtkWarningMacro("WriteXML: node " << this->GetName() << " is in a hierarchy, " << hnode->GetName() << ", assuming that it wrote it out already");
-    return;
-    }
+  hnode->GetParentNodeID())
+  {
+  vtkWarningMacro("WriteXML: node " << this->GetName() << " is in a hierarchy, " << hnode->GetName() << ", assuming that it wrote it out already");
+  return;
+  }
   */
   // cout << "vtkMRMLAnnotationControlPointsNode::WriteXML start" << endl;
   Superclass::WriteXML(of, nIndent);
-
-  vtkIndent indent(nIndent);
 
   if (this->GetPoints())
     {
     vtkPoints *points = this->GetPoints();
     int n = points->GetNumberOfPoints();
 
-      of << indent << " ctrlPtsCoord=\"";
-      for (int i = 0; i < n; i++ )
-    {
+    of << " ctrlPtsCoord=\"";
+    for (int i = 0; i < n; i++)
+      {
       double* ptr = points->GetPoint(i);
-      of << ptr[0] << " "<<  ptr[1] << " "<<  ptr[2] ;
+      of << ptr[0] << " "<<  ptr[1] << " "<<  ptr[2];
       if (i < n-1)
         {
-          of << "|";
+        of << "|";
         }
-    }
-      of << "\"";
+      }
+    of << "\"";
 
 
-      for (int j = NUM_TEXT_ATTRIBUTE_TYPES ; j < NUM_CP_ATTRIBUTE_TYPES; j ++)
-    {
-      of << indent << " " <<this->GetAttributeTypesEnumAsString(j)<<"=\"";
-      for (int i = 0; i < n-1; i++ )
+    for (int j = NUM_TEXT_ATTRIBUTE_TYPES; j < NUM_CP_ATTRIBUTE_TYPES; j++)
+      {
+      of << " " <<this->GetAttributeTypesEnumAsString(j)<<"=\"";
+      for (int i = 0; i < n-1; i++)
         {
-          of << this->GetAnnotationAttribute(i,j) << " " ;
+        of << this->GetAnnotationAttribute(i, j) << " ";
         }
       if (n)
         {
-          of << this->GetAnnotationAttribute(n-1,j);
+        of << this->GetAnnotationAttribute(n-1, j);
         }
       of << "\"";
-    }
+      }
     }
   else
     {
-      of << indent << " ctrlPtsCoord=\"\"";
-      for (int j = NUM_TEXT_ATTRIBUTE_TYPES ; j < NUM_CP_ATTRIBUTE_TYPES; j ++)
-    {
-      of << indent << " " << this->GetAttributeTypesEnumAsString(j) << "=\"\"";
-    }
+    of << " ctrlPtsCoord=\"\"";
+    for (int j = NUM_TEXT_ATTRIBUTE_TYPES; j < NUM_CP_ATTRIBUTE_TYPES; j++)
+      {
+      of << " " << this->GetAttributeTypesEnumAsString(j) << "=\"\"";
+      }
     }
 
-  of << indent << " ctrlPtsNumberingScheme=\"" << this->NumberingScheme << "\"";
+  of << " ctrlPtsNumberingScheme=\"" << this->NumberingScheme << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLineDisplayNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLineDisplayNode.cxx
@@ -38,7 +38,6 @@ void vtkMRMLAnnotationLineDisplayNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
   of << " lineThickness=\"" << this->LineThickness << "\"";
   of << " labelPosition=\"" << this->LabelPosition << "\"";
   of << " labelVisibility=\"" << (this->LabelVisibility ? "true" : "false") << "\"";
@@ -46,7 +45,7 @@ void vtkMRMLAnnotationLineDisplayNode::WriteXML(ostream& of, int nIndent)
   of << " maxTicks=\"" << this->MaxTicks << "\"";
   of << " sliceProjection=\"" << this->SliceProjection << "\"";
 
-  of << indent << " projectedColor=\"" << this->ProjectedColor[0] << " "
+  of << " projectedColor=\"" << this->ProjectedColor[0] << " "
      << this->ProjectedColor[1] << " "
      << this->ProjectedColor[2] << "\"";
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
@@ -32,57 +32,54 @@ void vtkMRMLAnnotationLinesNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   int n = this->GetNumberOfLines();
   if (n)
     {
     vtkCellArray *lines = this->GetLines();
     lines->InitTraversal();
-    of << indent << "linePtsID=\"" ;
-    for (int i = 0; i < n; i++ )
+    of << "linePtsID=\"";
+    for (int i = 0; i < n; i++)
       {
       vtkIdType npts = 0;
       vtkIdType *pts = NULL;
       lines->GetNextCell(npts, pts);
-      for (int j= 0; j < npts ; j++)
+      for (int j= 0; j < npts; j++)
         {
-          of << pts[j];
-          if (j<  npts -1)
-        {
-          of << " " ;
-        }
+        of << pts[j];
+        if (j<  npts -1)
+          {
+          of << " ";
+          }
         }
       if (i < n-1)
         {
-          of << "|" ;
+        of << "|";
         }
-    }
-      of << "\"";
+      }
+    of << "\"";
 
-
-      for (int j = NUM_CP_ATTRIBUTE_TYPES ; j < NUM_LINE_ATTRIBUTE_TYPES; j ++)
-    {
-      of << indent << " " << this->GetAttributeTypesEnumAsString(j)<<"=\"";
-      for (int i = 0; i < n -1 ; i++ )
+    for (int j = NUM_CP_ATTRIBUTE_TYPES; j < NUM_LINE_ATTRIBUTE_TYPES; j++)
+      {
+      of << " " << this->GetAttributeTypesEnumAsString(j)<<"=\"";
+      for (int i = 0; i < n -1; i++)
         {
-          of << this->GetAnnotationAttribute(i,j) << " " ;
+        of << this->GetAnnotationAttribute(i, j) << " ";
         }
       if (n)
         {
-          of << this->GetAnnotationAttribute(n-1,j) ;
+        of << this->GetAnnotationAttribute(n-1, j);
         }
 
       of << "\"";
-    }
+      }
     }
   else
     {
-      of << indent << "linePtsID=\"\"" ;
-      for (int j = NUM_CP_ATTRIBUTE_TYPES ; j < NUM_LINE_ATTRIBUTE_TYPES; j ++)
-    {
-      of << indent << " " << this->GetAttributeTypesEnumAsString(j) << "=\"\"";
-    }
+    of << "linePtsID=\"\"";
+    for (int j = NUM_CP_ATTRIBUTE_TYPES; j < NUM_LINE_ATTRIBUTE_TYPES; j++)
+      {
+      of << " " << this->GetAttributeTypesEnumAsString(j) << "=\"\"";
+      }
     }
 }
 
@@ -102,44 +99,44 @@ void vtkMRMLAnnotationLinesNode::ReadXMLAttributes(const char** atts)
     std::string attValue(*(atts++));
     if (!strcmp(attName, "linePtsID"))
       {
-    std::string valStr(attValue);
-    std::replace(valStr.begin(), valStr.end(), '|', ' ');
+      std::string valStr(attValue);
+      std::replace(valStr.begin(), valStr.end(), '|', ' ');
 
-    std::stringstream ss;
-    ss << valStr;
-    int d;
-    std::vector<int> tmpVec;
-    while (ss >> d)
+      std::stringstream ss;
+      ss << valStr;
+      int d;
+      std::vector<int> tmpVec;
+      while (ss >> d)
         {
-      tmpVec.push_back(d);
+        tmpVec.push_back(d);
         }
 
-    for (int i = 0; i < int(tmpVec.size()); i += 2)
-      {
-        this->AddLine(tmpVec[i],tmpVec[i + 1],0,0);
-      }
+      for (int i = 0; i < int(tmpVec.size()); i += 2)
+        {
+        this->AddLine(tmpVec[i], tmpVec[i + 1], 0, 0);
+        }
 
       }
     else
       {
-    int j = NUM_CP_ATTRIBUTE_TYPES;
-    while (j <  NUM_LINE_ATTRIBUTE_TYPES)
-      {
+      int j = NUM_CP_ATTRIBUTE_TYPES;
+      while (j <  NUM_LINE_ATTRIBUTE_TYPES)
+        {
         if (!strcmp(attName, this->GetAttributeTypesEnumAsString(j)))
           {
-        std::stringstream ss;
-        ss << attValue;
-        double value;
-        vtkIdType id = 0;
-        while (ss >> value)
-          {
-            this->SetAnnotationAttribute(id,j, value);
-            id ++;
-          }
-        j = NUM_LINE_ATTRIBUTE_TYPES;
+          std::stringstream ss;
+          ss << attValue;
+          double value;
+          vtkIdType id = 0;
+          while (ss >> value)
+            {
+            this->SetAnnotationAttribute(id, j, value);
+            id++;
+            }
+          j = NUM_LINE_ATTRIBUTE_TYPES;
           }
         j++;
-      }
+        }
       }
     }
   this->EndModify(disabledModify);
@@ -152,9 +149,7 @@ void vtkMRMLAnnotationLinesNode::UpdateScene(vtkMRMLScene *scene)
 
   // Nothing to do at this point  bc vtkMRMLAnnotationLineDisplayNode is subclass of vtkMRMLModelDisplayNode
   // => will be taken care of by vtkMRMLModelDisplayNode
-
 }
-
 
 //----------------------------------------------------------------------------
 void vtkMRMLAnnotationLinesNode::Copy(vtkMRMLNode *anode)

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
@@ -60,35 +60,34 @@ void vtkMRMLAnnotationNode::WriteXML(ostream& of, int nIndent)
   // vtkMRMLDisplayableNode::WriteXML(of,nIndent);
   Superclass::WriteXML(of,nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " referenceNodeID=\"" << (this->ReferenceNodeID ? this->GetReferenceNodeID() : "None") << "\"";
-  of << indent << " locked=\"" << this->Locked << "\"";
+  of << " referenceNodeID=\"" << (this->ReferenceNodeID ? this->GetReferenceNodeID() : "None") << "\"";
+  of << " locked=\"" << this->Locked << "\"";
 
   int textLength = this->TextList->GetNumberOfValues();
-  of << indent << " textList=\"";
+  of << " textList=\"";
 
   if (textLength)
     {
-      for (int i = 0 ; i < textLength - 1; i++) {
-    of << this->TextList->GetValue(i) << "|";
+    for (int i = 0 ; i < textLength - 1; i++)
+      {
+      of << this->TextList->GetValue(i) << "|";
       }
-      of <<  this->TextList->GetValue(textLength -1);
+    of <<  this->TextList->GetValue(textLength -1);
     }
   of << "\"";
 
   for (int j = 0 ; j < NUM_TEXT_ATTRIBUTE_TYPES; j ++)
     {
-      of << indent << " " << this->GetAttributeTypesEnumAsString(j) << "=\"";
-      if (textLength && this->GetPolyData() && this->GetPolyData()->GetPointData())
-    {
+    of << " " << this->GetAttributeTypesEnumAsString(j) << "=\"";
+    if (textLength && this->GetPolyData() && this->GetPolyData()->GetPointData())
+      {
       for (int i = 0 ; i < textLength - 1; i++)
         {
-          of << this->GetAnnotationAttribute(i,j) << " " ;
+        of << this->GetAnnotationAttribute(i,j) << " " ;
         }
       of << this->GetAnnotationAttribute(textLength - 1,j);
-    }
-      of << "\"";
+      }
+    of << "\"";
     }
 }
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationPointDisplayNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationPointDisplayNode.cxx
@@ -47,16 +47,15 @@ void vtkMRMLAnnotationPointDisplayNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
   of << " glyphScale=\"" << this->GlyphScale << "\"";
   of << " glyphType=\"" << this->GlyphType << "\"";
   of << " sliceProjection=\"" << this->SliceProjection << "\"";
 
-  of << indent << " projectedColor=\"" << this->ProjectedColor[0] << " "
+  of << " projectedColor=\"" << this->ProjectedColor[0] << " "
      << this->ProjectedColor[1] << " "
      << this->ProjectedColor[2] << "\"";
 
-  of << indent << " projectedOpacity=\"" << this->ProjectedOpacity << "\"";
+  of << " projectedOpacity=\"" << this->ProjectedOpacity << "\"";
  }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationROINode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationROINode.cxx
@@ -86,31 +86,28 @@ void vtkMRMLAnnotationROINode::WriteXML(ostream& of, int nIndent)
   // Write all attributes not equal to their defaults
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   if (this->VolumeNodeID != NULL)
     {
-    of << indent << " volumeNodeID=\"" << this->VolumeNodeID << "\"";
+    of << " volumeNodeID=\"" << this->VolumeNodeID << "\"";
     }
   if (this->LabelText != NULL)
     {
-    of << indent << " labelText=\"" << this->LabelText << "\"";
+    of << " labelText=\"" << this->LabelText << "\"";
     }
 
   // we do not have to write out the coordinates since the controlPointNode does that
-  /*of << indent << " xyz=\""
+  /*of << " xyz=\""
     << XYZ[0] << " " << XYZ[1] << " " << XYZ[2] << "\"";
 
-  of << indent << " radiusXYZ=\""
+  of << " radiusXYZ=\""
     << RadiusXYZ[0] << " " << RadiusXYZ[1] << " " << RadiusXYZ[2] << "\"";
   */
 
-  of << indent << " insideOut=\"" << (this->InsideOut ? "true" : "false") << "\"";
+  of << " insideOut=\"" << (this->InsideOut ? "true" : "false") << "\"";
 
-  //of << indent << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
+  //of << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
 
-  of << indent << " interactiveMode=\"" << (this->InteractiveMode ? "true" : "false") << "\"";
-
+  of << " interactiveMode=\"" << (this->InteractiveMode ? "true" : "false") << "\"";
 }
 
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.cxx
@@ -51,27 +51,25 @@ void vtkMRMLAnnotationRulerNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " rulerDistanceAnnotationFormat=\"";
+  of << " rulerDistanceAnnotationFormat=\"";
   if (this->DistanceAnnotationFormat)
     {
-      of << this->DistanceAnnotationFormat << "\"";
+    of << this->DistanceAnnotationFormat << "\"";
     }
   else
     {
-      of << "\"";
+    of << "\"";
     }
 
   if (this->ModelID1)
     {
-    of << indent << " modelID1=\"" << this->ModelID1 << "\"";
+    of << " modelID1=\"" << this->ModelID1 << "\"";
     }
   if (this->ModelID2)
     {
-    of << indent << " modelID2=\"" << this->ModelID2 << "\"";
+    of << " modelID2=\"" << this->ModelID2 << "\"";
     }
-  of << indent << " distanceMeasurement=\"" << this->GetDistanceMeasurement() << "\"";
+  of << " distanceMeasurement=\"" << this->GetDistanceMeasurement() << "\"";
 }
 
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.cxx
@@ -38,17 +38,14 @@ void vtkMRMLAnnotationSnapshotNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " screenshotType=\"" << this->GetScreenShotType() << "\"";
+  of << " screenshotType=\"" << this->GetScreenShotType() << "\"";
 
   vtkStdString description = this->GetSnapshotDescription();
   vtksys::SystemTools::ReplaceString(description,"\n","[br]");
 
-  of << indent << " snapshotDescription=\"" << description << "\"";
+  of << " snapshotDescription=\"" << description << "\"";
 
-  of << indent << " scaleFactor=\"" << this->GetScaleFactor() << "\"";
-
+  of << " scaleFactor=\"" << this->GetScaleFactor() << "\"";
 }
 
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSplineNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSplineNode.cxx
@@ -80,9 +80,7 @@ void vtkMRMLAnnotationSplineNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " rulerDistanceAnnotationFormat=\"";
+  of << " rulerDistanceAnnotationFormat=\"";
   if (this->DistanceAnnotationFormat)
     {
       of << this->DistanceAnnotationFormat << "\"";
@@ -91,9 +89,7 @@ void vtkMRMLAnnotationSplineNode::WriteXML(ostream& of, int nIndent)
     {
       of << "\"";
     }
-  of << indent << " rulerResolution=\""<< this->Resolution << "\"";
-
-
+  of << " rulerResolution=\""<< this->Resolution << "\"";
 }
 
 

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationTextDisplayNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationTextDisplayNode.cxx
@@ -60,8 +60,6 @@ vtkMRMLAnnotationTextDisplayNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
   of << " textScale=\"" << this->TextScale << "\"";
   of << " useLineWrap=\"" << (this->UseLineWrap ? "true" : "false") << "\"";
   of << " maxCharactersPerLine=\"" << this->MaxCharactersPerLine<< "\"";

--- a/Modules/Loadable/AtlasCreator/Logic/vtkMRMLAtlasCreatorNode.cxx
+++ b/Modules/Loadable/AtlasCreator/Logic/vtkMRMLAtlasCreatorNode.cxx
@@ -154,8 +154,6 @@ void vtkMRMLAtlasCreatorNode::WriteXML(ostream& of, int nIndent)
 
   // Write all MRML node attributes into output stream
 
-  vtkIndent indent(nIndent);
-
   if (this->OriginalImagesFilePathList != 0)
     {
     of << " OriginalImagesFilePathList =\"" << this->OriginalImagesFilePathList << "\"";

--- a/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
+++ b/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
@@ -121,12 +121,10 @@ void vtkMRMLCropVolumeParametersNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " voxelBased=\"" << (this->VoxelBased ? "true" : "false") << "\"";
-  of << indent << " interpolationMode=\"" << this->InterpolationMode << "\"";
-  of << indent << " isotropicResampling=\"" << (this->IsotropicResampling ? "true" : "false") << "\"";
-  of << indent << " spaceScalingConst=\"" << this->SpacingScalingConst << "\"";
+  of << " voxelBased=\"" << (this->VoxelBased ? "true" : "false") << "\"";
+  of << " interpolationMode=\"" << this->InterpolationMode << "\"";
+  of << " isotropicResampling=\"" << (this->IsotropicResampling ? "true" : "false") << "\"";
+  of << " spaceScalingConst=\"" << this->SpacingScalingConst << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -50,9 +50,7 @@ void vtkMRMLMarkupsFiducialNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of,nIndent);
 
-  vtkIndent indent(nIndent);
-
-  //of << indent << " locked=\"" << this->Locked << "\"";
+  //of << " locked=\"" << this->Locked << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -64,10 +64,8 @@ void vtkMRMLMarkupsNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of,nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " locked=\"" << this->Locked << "\"";
-  of << indent << " markupLabelFormat=\"" << this->MarkupLabelFormat.c_str() << "\"";
+  of << " locked=\"" << this->Locked << "\"";
+  of << " markupLabelFormat=\"" << this->MarkupLabelFormat.c_str() << "\"";
 
   int textLength = this->TextList->GetNumberOfValues();
 

--- a/Modules/Loadable/MultiVolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/MultiVolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
@@ -285,35 +285,33 @@ void vtkMRMLMultiVolumeRenderingDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
+  of << " bgVolumeNodeID=\"" << (this->BgVolumeNodeID ? this->BgVolumeNodeID : "NULL") << "\"";
+  of << " fgVolumeNodeID=\"" << (this->FgVolumeNodeID ? this->FgVolumeNodeID : "NULL") << "\"";
+  of << " labelmapVolumeNodeID=\"" << (this->LabelmapVolumeNodeID ? this->LabelmapVolumeNodeID : "NULL") << "\"";
 
-  of << indent << " bgVolumeNodeID=\"" << (this->BgVolumeNodeID ? this->BgVolumeNodeID : "NULL") << "\"";
-  of << indent << " fgVolumeNodeID=\"" << (this->FgVolumeNodeID ? this->FgVolumeNodeID : "NULL") << "\"";
-  of << indent << " labelmapVolumeNodeID=\"" << (this->LabelmapVolumeNodeID ? this->LabelmapVolumeNodeID : "NULL") << "\"";
+  of << " bgCroppingEnabled=\""<< this->BgCroppingEnabled << "\"";
+  of << " fgCroppingEnabled=\""<< this->FgCroppingEnabled << "\"";
+  of << " labelmapCroppingEnabled=\""<< this->LabelmapCroppingEnabled << "\"";
 
-  of << indent << " bgCroppingEnabled=\""<< this->BgCroppingEnabled << "\"";
-  of << indent << " fgCroppingEnabled=\""<< this->FgCroppingEnabled << "\"";
-  of << indent << " labelmapCroppingEnabled=\""<< this->LabelmapCroppingEnabled << "\"";
+  of << " bgROINodeID=\"" << (this->BgROINodeID ? this->BgROINodeID : "NULL") << "\"";
+  of << " fgROINodeID=\"" << (this->FgROINodeID ? this->FgROINodeID : "NULL") << "\"";
+  of << " labelmapROINodeID=\"" << (this->LabelmapROINodeID ? this->LabelmapROINodeID : "NULL") << "\"";
 
-  of << indent << " bgROINodeID=\"" << (this->BgROINodeID ? this->BgROINodeID : "NULL") << "\"";
-  of << indent << " fgROINodeID=\"" << (this->FgROINodeID ? this->FgROINodeID : "NULL") << "\"";
-  of << indent << " labelmapROINodeID=\"" << (this->LabelmapROINodeID ? this->LabelmapROINodeID : "NULL") << "\"";
+  of << " bgVolumePropertyNodeID=\"" << (this->BgVolumePropertyNodeID ? this->BgVolumePropertyNodeID : "NULL") << "\"";
+  of << " fgVolumePropertyNodeID=\"" << (this->FgVolumePropertyNodeID ? this->FgVolumePropertyNodeID : "NULL") << "\"";
 
-  of << indent << " bgVolumePropertyNodeID=\"" << (this->BgVolumePropertyNodeID ? this->BgVolumePropertyNodeID : "NULL") << "\"";
-  of << indent << " fgVolumePropertyNodeID=\"" << (this->FgVolumePropertyNodeID ? this->FgVolumePropertyNodeID : "NULL") << "\"";
+  of << " bgRaycastTechnique=\"" << this->BgRaycastTechnique << "\"";
+  of << " fgRaycastTechnique=\"" << this->FgRaycastTechnique << "\"";
 
-  of << indent << " bgRaycastTechnique=\"" << this->BgRaycastTechnique << "\"";
-  of << indent << " fgRaycastTechnique=\"" << this->FgRaycastTechnique << "\"";
+  of << " multiVolumeFusionMethod=\"" << this->MultiVolumeFusionMethod << "\"";
 
-  of << indent << " multiVolumeFusionMethod=\"" << this->MultiVolumeFusionMethod << "\"";
+  of << " bgFgRatio=\"" << this->BgFgRatio << "\"";
 
-  of << indent << " bgFgRatio=\"" << this->BgFgRatio << "\"";
+  of << " bgFollowVolumeDisplayNode=\"" << this->BgFollowVolumeDisplayNode << "\"";
+  of << " bgIgnoreVolumeDisplayNodeThreshold=\"" << this->BgIgnoreVolumeDisplayNodeThreshold << "\"";
 
-  of << indent << " bgFollowVolumeDisplayNode=\"" << this->BgFollowVolumeDisplayNode << "\"";
-  of << indent << " bgIgnoreVolumeDisplayNodeThreshold=\"" << this->BgIgnoreVolumeDisplayNodeThreshold << "\"";
-
-  of << indent << " fgFollowVolumeDisplayNode=\"" << this->FgFollowVolumeDisplayNode << "\"";
-  of << indent << " fgIgnoreVolumeDisplayNodeThreshold=\"" << this->FgIgnoreVolumeDisplayNodeThreshold << "\"";
+  of << " fgFollowVolumeDisplayNode=\"" << this->FgFollowVolumeDisplayNode << "\"";
+  of << " fgIgnoreVolumeDisplayNodeThreshold=\"" << this->FgIgnoreVolumeDisplayNodeThreshold << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/MRML/vtkMRMLSegmentEditorNode.cxx
+++ b/Modules/Loadable/Segmentations/MRML/vtkMRMLSegmentEditorNode.cxx
@@ -73,15 +73,13 @@ void vtkMRMLSegmentEditorNode::WriteXML(ostream& of, int nIndent)
   Superclass::WriteXML(of, nIndent);
 
   // Write all MRML node attributes into output stream
-  vtkIndent indent(nIndent);
-
-  of << indent << " selectedSegmentID=\"" << (this->SelectedSegmentID?this->SelectedSegmentID:"") << "\"";
-  of << indent << " activeEffectName=\"" << (this->ActiveEffectName?this->ActiveEffectName:"") << "\"";
-  of << indent << " maskMode=\"" << vtkMRMLSegmentEditorNode::ConvertMaskModeToString(this->MaskMode) << "\"";
-  of << indent << " maskSegmentID=\"" << (this->MaskSegmentID?this->MaskSegmentID:"") << "\"";
-  of << indent << " masterVolumeIntensityMask=\"" << (this->MasterVolumeIntensityMask ? "true" : "false") << "\"";
-  of << indent << " masterVolumeIntensityMaskRange=\"" << this->MasterVolumeIntensityMaskRange[0] << " " << this->MasterVolumeIntensityMaskRange[1] << "\"";
-  of << indent << " overwriteMode=\"" << vtkMRMLSegmentEditorNode::ConvertOverwriteModeToString(this->OverwriteMode) << "\"";
+  of << " selectedSegmentID=\"" << (this->SelectedSegmentID?this->SelectedSegmentID:"") << "\"";
+  of << " activeEffectName=\"" << (this->ActiveEffectName?this->ActiveEffectName:"") << "\"";
+  of << " maskMode=\"" << vtkMRMLSegmentEditorNode::ConvertMaskModeToString(this->MaskMode) << "\"";
+  of << " maskSegmentID=\"" << (this->MaskSegmentID?this->MaskSegmentID:"") << "\"";
+  of << " masterVolumeIntensityMask=\"" << (this->MasterVolumeIntensityMask ? "true" : "false") << "\"";
+  of << " masterVolumeIntensityMaskRange=\"" << this->MasterVolumeIntensityMaskRange[0] << " " << this->MasterVolumeIntensityMaskRange[1] << "\"";
+  of << " overwriteMode=\"" << vtkMRMLSegmentEditorNode::ConvertOverwriteModeToString(this->OverwriteMode) << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLCPURayCastVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLCPURayCastVolumeRenderingDisplayNode.cxx
@@ -67,9 +67,7 @@ void vtkMRMLCPURayCastVolumeRenderingDisplayNode::WriteXML(ostream& of, int nInd
 {
   this->Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " raycastTechnique=\"" << this->RaycastTechnique << "\"";
+  of << " raycastTechnique=\"" << this->RaycastTechnique << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
@@ -67,9 +67,7 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::WriteXML(ostream& of, int nInd
 {
   this->Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " raycastTechnique=\"" << this->RaycastTechnique << "\"";
+  of << " raycastTechnique=\"" << this->RaycastTechnique << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
@@ -66,7 +66,6 @@ void vtkMRMLVolumePropertyNode::WriteXML(ostream& of, int nIndent)
   // Write all attributes not equal to their defaults
   this->Superclass::WriteXML(of, nIndent);
 
-  //vtkIndent indent(nIndent);
   of << " interpolation=\"" <<this->VolumeProperty->GetInterpolationType()<< "\"";
   of << " shade=\"" <<this->VolumeProperty->GetShade()<< "\"";
   of << " diffuse=\"" <<this->VolumeProperty->GetDiffuse()<< "\"";

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.cxx
@@ -181,18 +181,15 @@ void vtkMRMLVolumeRenderingDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   this->Superclass::WriteXML(of, nIndent);
 
-  vtkIndent indent(nIndent);
-
-  of << indent << " volumeNodeID=\"" << (this->VolumeNodeID ? this->VolumeNodeID : "NULL") << "\"";
-  of << indent << " croppingEnabled=\""<< this->CroppingEnabled << "\"";
-  of << indent << " ROINodeID=\"" << (this->ROINodeID ? this->ROINodeID : "NULL") << "\"";
-  of << indent << " volumePropertyNodeID=\"" << (this->VolumePropertyNodeID ? this->VolumePropertyNodeID : "NULL") << "\"";
-  of << indent << " threshold=\"" << this->Threshold[0] << " " << this->Threshold[1] << "\"";
-  //of << indent << " useThreshold=\"" << this->UseThreshold << "\"";
-  of << indent << " followVolumeDisplayNode=\"" << this->FollowVolumeDisplayNode << "\"";
-  of << indent << " ignoreVolumeDisplayNodeThreshold=\"" << this->IgnoreVolumeDisplayNodeThreshold << "\"";
-  of << indent << " useSingleVolumeProperty=\"" << this->UseSingleVolumeProperty << "\"";
-  of << indent << " windowLevel=\"" << this->WindowLevel[0] << " " << this->WindowLevel[1] << "\"";
+  of << " volumeNodeID=\"" << (this->VolumeNodeID ? this->VolumeNodeID : "NULL") << "\"";
+  of << " croppingEnabled=\""<< this->CroppingEnabled << "\"";
+  of << " ROINodeID=\"" << (this->ROINodeID ? this->ROINodeID : "NULL") << "\"";
+  of << " volumePropertyNodeID=\"" << (this->VolumePropertyNodeID ? this->VolumePropertyNodeID : "NULL") << "\"";
+  of << " threshold=\"" << this->Threshold[0] << " " << this->Threshold[1] << "\"";
+  of << " followVolumeDisplayNode=\"" << this->FollowVolumeDisplayNode << "\"";
+  of << " ignoreVolumeDisplayNodeThreshold=\"" << this->IgnoreVolumeDisplayNodeThreshold << "\"";
+  of << " useSingleVolumeProperty=\"" << this->UseSingleVolumeProperty << "\"";
+  of << " windowLevel=\"" << this->WindowLevel[0] << " " << this->WindowLevel[1] << "\"";
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingScenarioNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingScenarioNode.cxx
@@ -66,7 +66,7 @@ void vtkMRMLVolumeRenderingScenarioNode::WriteXML(ostream& of, int nIndent)
 
   vtkIndent indent(nIndent);
 
-  of << indent << " parametersNodeID=\"" << (this->ParametersNodeID ? this->ParametersNodeID : "NULL") << "\"";
+  of << " parametersNodeID=\"" << (this->ParametersNodeID ? this->ParametersNodeID : "NULL") << "\"";
 
 }
 


### PR DESCRIPTION
1. vtkMRMLNode::Indent member seemed unused in the core, except from the also unused ROI list node, so the member was removed

2. In WriteXML functions, the increasing indentation was added between the XML attributes, which did not have major effect on the top level, but for example in the scene view section, where indentation was increased, it made the nodes look like this:

```
  <Selection
    id="vtkMRMLSelectionNodeSingleton"    name="Selection"    hideFromEditors="true"    selectable="true"    selected="false"    singletonTag="Singleton"
```

As the purpose of indentation is to add space in front of the _lines_, adding that space between the XML attributes seems unnecessary. With these changes, the same entry now looks like this:

```
  <Selection
    id="vtkMRMLSelectionNodeSingleton" name="Selection" hideFromEditors="true" selectable="true" selected="false"
```