### PR TITLE
Change to Remove Islands Morphology editor button to be able to be imported by other modules.

### DIFF
--- a/Modules/Scripted/EditorLib/RemoveIslandsEffect.py
+++ b/Modules/Scripted/EditorLib/RemoveIslandsEffect.py
@@ -256,7 +256,7 @@ class RemoveIslandsEffectLogic(IslandEffect.IslandEffectLogic):
     labelImage.DeepCopy( self.getScopedLabelInput() )
     label = self.editUtil.getLabel()
 
-    slicer.modules.EditorWidget.toolsBox.undoRedo.saveState()
+    self.undoRedo.saveState()
 
     self.removeIslandsMorphologyDecruft(labelImage,0,label)
     self.getScopedLabelOutput().DeepCopy(labelImage)


### PR DESCRIPTION
Hello!

This is a tiny bug I stumbled upon. I am writing my own Python Slicer module, and imported the Editor widget within the context of my module. This works very well, except for the Remove Islands (Morphology Mode) button, which throws the following error when you call it:

```
Traceback (most recent call last):
  File "C:\Users\azb22\Documents\Software\SlicerNightly\Slicer 4.7.0-2016-10-19\lib\Slicer-4.7\qt-scripted-modules\EditorLib\RemoveIslandsEffect.py", line 76, in onApplyMorphology
    self.logic.removeIslandsMorphology()
  File "C:\Users\azb22\Documents\Software\SlicerNightly\Slicer 4.7.0-2016-10-19\lib\Slicer-4.7\qt-scripted-modules\EditorLib\RemoveIslandsEffect.py", line 259, in removeIslandsMorphology
    slicer.modules.EditorWidget.toolsBox.undoRedo.saveState()
AttributeError: 'module' object has no attribute 'EditorWidget'
```

This happens because RemoveIslands expects to be called from the Editor module, but I'm calling it from my own personal module. It searches for an instance of the EditorWidget and, not finding it, throws an error.

Other editor tools overcome this by instead using the slice self.undoRedo.saveState() ([e.g.](https://github.com/Slicer/Slicer/blob/1a14a65ac5fe5b3615beed701e851293de29fe93/Modules/Scripted/EditorLib/FastMarchingEffect.py#L270)). I've added that change and tested it on the nightly version, and it seems to solve the issue.

Best,
Andrew