### PR TITLE
Support per view visibility of slicer intersection

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
@@ -833,7 +833,7 @@ void vtkMRMLDisplayNode::AddViewNodeID(const char* viewNodeID)
 }
 
 //-------------------------------------------------------
-void vtkMRMLDisplayNode::RemoveViewNodeID(char* viewNodeID)
+void vtkMRMLDisplayNode::RemoveViewNodeID(const char* viewNodeID)
 {
   if (viewNodeID == NULL)
     {

--- a/Libs/MRML/Core/vtkMRMLDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.h
@@ -434,7 +434,7 @@ public:
   void AddViewNodeID(const char* viewNodeID);
   /// Remove View Node ID for the view to display this node in.
   /// \sa ViewNodeIDs, AddViewNodeID(), RemoveAllViewNodeIDs()
-  void RemoveViewNodeID(char* viewNodeID);
+  void RemoveViewNodeID(const char* viewNodeID);
   /// Remove All View Node IDs for the views to display this node in.
   /// \sa ViewNodeIDs, AddViewNodeID(), RemoveViewNodeID()
   void RemoveAllViewNodeIDs();

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
@@ -199,6 +199,14 @@ bool vtkMRMLModelSliceDisplayableManager::vtkInternal
           {
           visibleOnNode = false;
           }
+        else
+          {
+          // Update slice intersection visibility independently of the
+          // Slice visbility in the 3D view.
+          // This is done by directly using "IsDisplayableInView(viewNodeID)"
+          // instead of "GetVisibility(viewNodeID)
+          visibleOnNode = displayNode->IsDisplayableInView(this->SliceNode->GetID());
+          }
         }
       }
     }

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -73,8 +73,40 @@ const std::string vtkMRMLSliceLogic::SLICE_MODEL_NODE_NAME_SUFFIX = std::string(
 vtkStandardNewMacro(vtkMRMLSliceLogic);
 
 //----------------------------------------------------------------------------
+class vtkMRMLSliceLogic::vtkInternal
+{
+public:
+  vtkInternal(vtkMRMLSliceLogic * external);
+  ~vtkInternal();
+
+  vtkMRMLSliceLogic*        External;
+
+};
+
+//----------------------------------------------------------------------------
+// vtkInternal methods
+
+//----------------------------------------------------------------------------
+vtkMRMLSliceLogic::vtkInternal::vtkInternal(vtkMRMLSliceLogic * external)
+{
+  this->External = external;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLSliceLogic::vtkInternal::~vtkInternal()
+{
+}
+
+//----------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------
+// vtkMRMLSliceLogic methods
+
+//----------------------------------------------------------------------------
 vtkMRMLSliceLogic::vtkMRMLSliceLogic()
 {
+  this->Internal = new vtkInternal(this);
+
   this->Initialized = false;
   this->Name = 0;
   this->BackgroundLayer = 0;
@@ -146,6 +178,8 @@ vtkMRMLSliceLogic::~vtkMRMLSliceLogic()
     }
 
   this->DeleteSliceModel();
+
+  delete this->Internal;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -412,6 +412,9 @@ private:
   vtkMRMLSliceLogic(const vtkMRMLSliceLogic&);
   void operator=(const vtkMRMLSliceLogic&);
 
+  class vtkInternal;
+  vtkInternal* Internal;
+
 };
 
 #endif


### PR DESCRIPTION
This commit updates the SliceModel displayable manager to allow hiding part of slice intersection on selected views.

For example, let's consider this scene with:
* 1 model
* slice intersection enabled
* slice views visible in two 3D views

![setting_viewids_start](https://cloud.githubusercontent.com/assets/219043/24574752/5cee146e-1665-11e7-9161-fd100501a3f7.png)

Now, with this change, we can (for example) show the red slice intersection only on the green slice viewer.

The following tweaks have been done:
* model is removed from View1
* "red slice node" is hidden in ThreeD view 2
* only intersection of red slice with  green slice is shown

![setting_viewids_done](https://cloud.githubusercontent.com/assets/219043/24574756/5f713bf8-1665-11e7-8523-771113736362.png)
