### PR TITLE
ENH: quickly reinstall previously installed extensions v2

### DIFF
--- a/Applications/SlicerApp/qSlicerAppMainWindow.cxx
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.cxx
@@ -1165,6 +1165,7 @@ void qSlicerAppMainWindow::showEvent(QShowEvent *event)
     d->WindowInitialShowCompleted = true;
     this->disclaimer();
     this->pythonConsoleInitialDisplay();
+    qSlicerApplication::application()->checkExtensionHistory();
     emit initialWindowShown();
     }
 }

--- a/Applications/SlicerApp/qSlicerAppMainWindow.cxx
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.cxx
@@ -1165,7 +1165,7 @@ void qSlicerAppMainWindow::showEvent(QShowEvent *event)
     d->WindowInitialShowCompleted = true;
     this->disclaimer();
     this->pythonConsoleInitialDisplay();
-    qSlicerApplication::application()->checkExtensionHistory();
+    qSlicerApplication::application()->gatherExtensionsHistoryInformationOnStartup();
     emit initialWindowShown();
     }
 }

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -355,6 +355,7 @@ void qSlicerCoreApplicationPrivate::init()
 
   qSlicerExtensionsManagerModel * model = new qSlicerExtensionsManagerModel(q);
   model->setExtensionsSettingsFilePath(q->slicerRevisionUserSettingsFilePath());
+  model->setExtensionsHistorySettingsFilePath(q->slicerUserSettingsFilePath());
   model->setSlicerRequirements(q->repositoryRevision(), q->os(), q->arch());
   q->setExtensionsManagerModel(model);
 

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1255,9 +1255,9 @@ void qSlicerCoreApplication::setExtensionsInstallPath(const QString& path)
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerCoreApplication::checkExtensionHistory()
+void qSlicerCoreApplication::gatherExtensionsHistoryInformationOnStartup()
 {
-	this->extensionsManagerModel()->checkExtensionHistory();
+  this->extensionsManagerModel()->gatherExtensionsHistoryInformationOnStartup();
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1255,6 +1255,12 @@ void qSlicerCoreApplication::setExtensionsInstallPath(const QString& path)
 }
 
 //-----------------------------------------------------------------------------
+void qSlicerCoreApplication::checkExtensionHistory()
+{
+	this->extensionsManagerModel()->checkExtensionHistory();
+}
+
+//-----------------------------------------------------------------------------
 #ifdef Slicer_USE_PYTHONQT
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -244,7 +244,7 @@ public:
   /// Set slicer extension directory
   void setExtensionsInstallPath(const QString& path);
 
-  void checkExtensionHistory();
+  void gatherExtensionsHistoryInformationOnStartup();
 
   /// If any, this method return the build intermediate directory
   /// See $(IntDir) on http://msdn.microsoft.com/en-us/library/c02as0cs%28VS.71%29.aspx

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -244,6 +244,8 @@ public:
   /// Set slicer extension directory
   void setExtensionsInstallPath(const QString& path);
 
+  void checkExtensionHistory();
+
   /// If any, this method return the build intermediate directory
   /// See $(IntDir) on http://msdn.microsoft.com/en-us/library/c02as0cs%28VS.71%29.aspx
   QString intDir()const;

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -225,8 +225,9 @@ public:
   void addExtensionHistorySetting(const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata, const QString& settingsPath);
   void cancelExtensionHistorySettingRemoval(const QString& extensionsHistorySettingsFile, const QString& extensionName);
   void removeScheduledExtensionHistorySettings(const QString& extensionsHistorySettingsFile);
-  void checkExtensionsHistory();
   QVariantMap getExtensionsInfoFromPreviousInstallations(const QString& extensionsHistorySettingsFile);
+  void gatherExtensionsHistoryInformationOnStartup();
+
 
   qSlicerExtensionsManagerModel::ExtensionMetadataType retrieveExtensionMetadata(
     const qMidasAPI::ParametersType& parameters);
@@ -245,7 +246,6 @@ public:
 
   QString ExtensionsSettingsFilePath;
   QString ExtensionsHistorySettingsFilePath;
-
 
   QString SlicerRevision;
   QString SlicerOs;
@@ -952,35 +952,38 @@ QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousI
 }
 
 // --------------------------------------------------------------------------
-void qSlicerExtensionsManagerModelPrivate::checkExtensionsHistory()
+void qSlicerExtensionsManagerModelPrivate::gatherExtensionsHistoryInformationOnStartup()
 {
 	Q_Q(qSlicerExtensionsManagerModel);
-	QVariantMap extensionInfo = this->getExtensionsInfoFromPreviousInstallations(q->extensionsHistorySettingsFilePath());
-	QStringList candidateIds;
-	for (unsigned int i = 0; i < extensionInfo.size(); i++)
-	{
-		QVariantMap currentInfo = extensionInfo.value(extensionInfo.keys().at(i)).toMap();
-		if (currentInfo.value("WasInstalledInLastRevision").toBool() && currentInfo.value("IsCompatible").toBool() && !currentInfo.value("IsInstalled").toBool())
-		{
-			candidateIds.append(extensionInfo.keys().at(i));
-		}
-	}
-	if (candidateIds.length() > 0)
-	{
-		QMessageBox msgBox;
-		msgBox.setText("Previously installed extensions identified.");
-		QString text = QString("%1 compatible extension(s) from a previous Slicer installation found. Do you want to install?"
-							   "(For details see: Extension Manager > Restore Extensions)").arg(candidateIds.length());
-		msgBox.setInformativeText(text);
-		msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-		if (msgBox.exec() == QMessageBox::Yes)
-		{
-			emit q->extensionRestoreTriggered(candidateIds);
-		}
-	}
+  //q->getExtensionHistoryInformation();
+  //q->extensionsHistoryInformation = this->getExtensionsInfoFromPreviousInstallations(q->extensionsHistorySettingsFilePath());
+  emit q->extensionHistoryGatheredOnStartup(q->getExtensionHistoryInformation());
+  /*
+  QStringList candidateIds;
+  for (unsigned int i = 0; i < extensionInfo.size(); i++)
+  {
+  QVariantMap currentInfo = extensionInfo.value(extensionInfo.keys().at(i)).toMap();
+  if (currentInfo.value("WasInstalledInLastRevision").toBool() && currentInfo.value("IsCompatible").toBool() && !currentInfo.value("IsInstalled").toBool())
+  {
+  candidateIds.append(extensionInfo.keys().at(i));
+  }
+  }
+  if (candidateIds.length() > 0)
+  {
+  QMessageBox msgBox;
+  msgBox.setText("Previously installed extensions identified.");
+  QString text = QString("%1 compatible extension(s) from a previous Slicer installation found. Do you want to install?"
+  "(For details see: Extension Manager > Restore Extensions)").arg(candidateIds.length());
+  msgBox.setInformativeText(text);
+  msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+  if (msgBox.exec() == QMessageBox::Yes)
+  {
+  emit q->extensionRestoreTriggered(candidateIds);
+  }
+  }
+  */
+
 }
-
-
 
 // --------------------------------------------------------------------------
 void qSlicerExtensionsManagerModelPrivate::initializeColumnIdToNameMap(int columnIdx, const char* columnName)
@@ -2201,11 +2204,17 @@ bool qSlicerExtensionsManagerModel::uninstallScheduledExtensions(QStringList& un
 }
 
 // --------------------------------------------------------------------------
-void qSlicerExtensionsManagerModel::checkExtensionHistory()
+void qSlicerExtensionsManagerModel::gatherExtensionsHistoryInformationOnStartup()
 {
 	Q_D(qSlicerExtensionsManagerModel);
-	qDebug() << "Gatering";
-	d->checkExtensionsHistory();
+  d->gatherExtensionsHistoryInformationOnStartup();
+}
+
+// --------------------------------------------------------------------------
+QVariantMap  qSlicerExtensionsManagerModel::getExtensionHistoryInformation()
+{
+  Q_D(qSlicerExtensionsManagerModel);
+  return d->getExtensionsInfoFromPreviousInstallations(extensionsHistorySettingsFilePath());
 }
 
 

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -2027,6 +2027,9 @@ bool qSlicerExtensionsManagerModel::scheduleExtensionForUninstall(const QString&
   // Add to scheduled uninstalls
   scheduled.append(extensionName);
   settings.setValue("Extensions/ScheduledForUninstall", scheduled);
+
+  d->removeExtensionSettings(extensionName);
+
   const ExtensionMetadataType& extensionMetadata = this->extensionMetadata(extensionName);
   d->scheduleExtensionHistorySettingRemoval(this->extensionsHistorySettingsFilePath(), extensionMetadata);
   emit this->extensionScheduledForUninstall(extensionName);

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -842,7 +842,7 @@ void qSlicerExtensionsManagerModelPrivate::addExtensionHistorySetting(
   const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata, const QString& settingsPath)
 {
   QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
-  QStringList& settingsInfoList = settings.value(settingsPath).toStringList();
+  QStringList settingsInfoList = settings.value(settingsPath).toStringList();
   settingsInfoList << extensionMetadata.value("extensionname").toString();
   settingsInfoList.removeDuplicates();
   settings.setValue(settingsPath, settingsInfoList);
@@ -853,7 +853,7 @@ void qSlicerExtensionsManagerModelPrivate::cancelExtensionHistorySettingRemoval(
   const QString& extensionsHistorySettingsFile, const QString& extensionName)
 {
   QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
-  QStringList& settingsInfoList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
+  QStringList settingsInfoList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
   settingsInfoList.removeOne(extensionName);
   settingsInfoList.removeDuplicates();
   settings.setValue("ExtensionsHistory/ScheduledForRemoval", settingsInfoList);
@@ -864,9 +864,9 @@ void qSlicerExtensionsManagerModelPrivate::removeScheduledExtensionHistorySettin
   const QString& extensionsHistorySettingsFile)
 {
   QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
-  QStringList& scheduledForRemovalList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
-  QStringList& historyList = settings.value("ExtensionsHistory/Revisions/" + this->SlicerRevision).toStringList();
-  for (unsigned int i = 0; i < scheduledForRemovalList.length(); i++)
+  QStringList scheduledForRemovalList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
+  QStringList historyList = settings.value("ExtensionsHistory/Revisions/" + this->SlicerRevision).toStringList();
+  for (int i = 0; i < scheduledForRemovalList.length(); i++)
   {
     historyList.removeOne(scheduledForRemovalList.at(i));
   }
@@ -883,7 +883,7 @@ QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousI
   QVariantMap extensionsHistoryInformation;
   QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
   settings.beginGroup("ExtensionsHistory/Revisions");
-  QStringList& revisions = settings.childKeys();
+  QStringList revisions = settings.childKeys();
   revisions.sort();	//revisions sorted ascending
   int lastRevision = -1;
   for (int i = revisions.length() - 1; i >= 0; i--)		//the revision with the highest number not equal the current one is considered to be the last revision
@@ -899,11 +899,11 @@ QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousI
     return extensionsHistoryInformation;
   }
 
-  for (unsigned int i = 0; i < revisions.length(); i++)
+  for (int i = 0; i < revisions.length(); i++)
   {
     QVariantMap curExtensionInfo;
     const QStringList& extensionNames = settings.value(revisions.at(i)).toStringList();
-    for (unsigned int j = 0; j < extensionNames.length(); j++)
+    for (int j = 0; j < extensionNames.length(); j++)
     {
       QString extensionName = extensionNames.at(j);
       QString extensionId = "";
@@ -929,9 +929,7 @@ QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousI
         parameters["arch"] = q->slicerArch();
         const ExtensionMetadataType& metaData = retrieveExtensionMetadata(parameters);
         extensionId = metaData.value("extension_id").toString();     //retrieve updated extension id for not installed extensions
-        const QStringList& reason = this->isExtensionCompatible(metaData, this->SlicerRevision, this->SlicerOs, this->SlicerArch);
-        isCompatible = (this->isExtensionCompatible(metaData,
-          this->SlicerRevision, this->SlicerOs, this->SlicerArch).length() == 0);
+        isCompatible = (this->isExtensionCompatible(metaData, this->SlicerRevision, this->SlicerOs, this->SlicerArch).length() == 0);
       }
       else
       {

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -825,35 +825,35 @@ void qSlicerExtensionsManagerModelPrivate::saveExtensionDescription(
 
 // --------------------------------------------------------------------------
 void qSlicerExtensionsManagerModelPrivate::saveExtensionToHistorySettings(
-	const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata)
+  const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata)
 {
-	this->addExtensionHistorySetting(extensionsHistorySettingsFile, extensionMetadata, "ExtensionsHistory/Revisions/" + this->SlicerRevision);
+  this->addExtensionHistorySetting(extensionsHistorySettingsFile, extensionMetadata, "ExtensionsHistory/Revisions/" + this->SlicerRevision);
 }
 
 // --------------------------------------------------------------------------
 void qSlicerExtensionsManagerModelPrivate::scheduleExtensionHistorySettingRemoval(
-	const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata)
+  const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata)
 {
-	this->addExtensionHistorySetting(extensionsHistorySettingsFile, extensionMetadata, "ExtensionsHistory/ScheduledForRemoval");
+  this->addExtensionHistorySetting(extensionsHistorySettingsFile, extensionMetadata, "ExtensionsHistory/ScheduledForRemoval");
 }
 
 // --------------------------------------------------------------------------
 void qSlicerExtensionsManagerModelPrivate::addExtensionHistorySetting(
-	const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata, const QString& settingsPath)
+  const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata, const QString& settingsPath)
 {
-	QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
-	QStringList& settingsInfoList = settings.value(settingsPath).toStringList();
+  QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
+  QStringList& settingsInfoList = settings.value(settingsPath).toStringList();
   settingsInfoList << extensionMetadata.value("extensionname").toString();
-	settingsInfoList.removeDuplicates();
-	settings.setValue(settingsPath, settingsInfoList);
+  settingsInfoList.removeDuplicates();
+  settings.setValue(settingsPath, settingsInfoList);
 }
 
 // --------------------------------------------------------------------------
 void qSlicerExtensionsManagerModelPrivate::cancelExtensionHistorySettingRemoval(
-	const QString& extensionsHistorySettingsFile, const QString& extensionName)
+  const QString& extensionsHistorySettingsFile, const QString& extensionName)
 {
-	QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
-	QStringList& settingsInfoList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
+  QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
+  QStringList& settingsInfoList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
   settingsInfoList.removeOne(extensionName);
   settingsInfoList.removeDuplicates();
   settings.setValue("ExtensionsHistory/ScheduledForRemoval", settingsInfoList);
@@ -861,65 +861,65 @@ void qSlicerExtensionsManagerModelPrivate::cancelExtensionHistorySettingRemoval(
 
 // --------------------------------------------------------------------------
 void qSlicerExtensionsManagerModelPrivate::removeScheduledExtensionHistorySettings(
-	const QString& extensionsHistorySettingsFile)
+  const QString& extensionsHistorySettingsFile)
 {
-	QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
-	QStringList& scheduledForRemovalList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
-	QStringList& historyList = settings.value("ExtensionsHistory/Revisions/" + this->SlicerRevision).toStringList();
-	for (unsigned int i = 0; i < scheduledForRemovalList.length(); i++)
-	{
-		historyList.removeOne(scheduledForRemovalList.at(i));
-	}
-	historyList.removeDuplicates();
-	settings.setValue("ExtensionsHistory/Revisions/" + this->SlicerRevision, historyList);
-	settings.setValue("ExtensionsHistory/ScheduledForRemoval", "");
+  QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
+  QStringList& scheduledForRemovalList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
+  QStringList& historyList = settings.value("ExtensionsHistory/Revisions/" + this->SlicerRevision).toStringList();
+  for (unsigned int i = 0; i < scheduledForRemovalList.length(); i++)
+  {
+    historyList.removeOne(scheduledForRemovalList.at(i));
+  }
+  historyList.removeDuplicates();
+  settings.setValue("ExtensionsHistory/Revisions/" + this->SlicerRevision, historyList);
+  settings.setValue("ExtensionsHistory/ScheduledForRemoval", "");
 }
 
 // --------------------------------------------------------------------------
 QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousInstallations(
-	const QString& extensionsHistorySettingsFile)
+  const QString& extensionsHistorySettingsFile)
 {
-	Q_Q(qSlicerExtensionsManagerModel);
-	QVariantMap extensionsHistoryInformation;
-	QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
-	settings.beginGroup("ExtensionsHistory/Revisions");
-	QStringList& revisions = settings.childKeys();
-	revisions.sort();	//revisions sorted ascending
-	int lastRevision = -1;
-	for (int i = revisions.length() - 1; i >= 0; i--)		//the revision with the highest number not equal the current one is considered to be the last revision
-	{
-		if (revisions[i] != this->SlicerRevision)
-		{
-			lastRevision = i;
-			break;
-		}
-	}
-	if (lastRevision == -1)
-	{
-		return extensionsHistoryInformation;
-	}
+  Q_Q(qSlicerExtensionsManagerModel);
+  QVariantMap extensionsHistoryInformation;
+  QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
+  settings.beginGroup("ExtensionsHistory/Revisions");
+  QStringList& revisions = settings.childKeys();
+  revisions.sort();	//revisions sorted ascending
+  int lastRevision = -1;
+  for (int i = revisions.length() - 1; i >= 0; i--)		//the revision with the highest number not equal the current one is considered to be the last revision
+  {
+    if (revisions[i] != this->SlicerRevision)
+    {
+      lastRevision = i;
+      break;
+    }
+  }
+  if (lastRevision == -1)
+  {
+    return extensionsHistoryInformation;
+  }
 
-	for (unsigned int i = 0; i < revisions.length(); i++)
-	{
-		QVariantMap curExtensionInfo;
-		const QStringList& extensionNames = settings.value(revisions.at(i)).toStringList();
+  for (unsigned int i = 0; i < revisions.length(); i++)
+  {
+    QVariantMap curExtensionInfo;
+    const QStringList& extensionNames = settings.value(revisions.at(i)).toStringList();
     for (unsigned int j = 0; j < extensionNames.length(); j++)
-		{
+    {
       QString extensionName = extensionNames.at(j);
       QString extensionId = "";
 
-			curExtensionInfo.insert("UsedLastInRevision", revisions.at(i));
-			if (i == lastRevision || (extensionsHistoryInformation.contains(extensionName) &&
+      curExtensionInfo.insert("UsedLastInRevision", revisions.at(i));
+      if (i == lastRevision || (extensionsHistoryInformation.contains(extensionName) &&
         extensionsHistoryInformation.value(extensionName).toMap().value("WasInstalledInLastRevision").toBool()))
-			{
-				curExtensionInfo.insert("WasInstalledInLastRevision", true);
-			}
-			else
-			{
-				curExtensionInfo.insert("WasInstalledInLastRevision", false);
-			}
-			curExtensionInfo.insert("IsInstalled", q->isExtensionInstalled(extensionName));
-			bool isCompatible = true;
+      {
+        curExtensionInfo.insert("WasInstalledInLastRevision", true);
+      }
+      else
+      {
+        curExtensionInfo.insert("WasInstalledInLastRevision", false);
+      }
+      curExtensionInfo.insert("IsInstalled", q->isExtensionInstalled(extensionName));
+      bool isCompatible = true;
 
       if (!q->isExtensionInstalled(extensionName)) {
         qMidasAPI::ParametersType parameters;
@@ -933,24 +933,24 @@ QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousI
         isCompatible = (this->isExtensionCompatible(metaData,
           this->SlicerRevision, this->SlicerOs, this->SlicerArch).length() == 0);
       }
-			else
-			{
+      else
+      {
         const ExtensionMetadataType& metaData = q->extensionMetadata(extensionName);
         extensionId = metaData.value("extension_id").toString();
-				isCompatible = (q->isExtensionCompatible(extensionName).length() == 0);
-			}
+        isCompatible = (q->isExtensionCompatible(extensionName).length() == 0);
+      }
       curExtensionInfo.insert("ExtensionId", extensionId);
-			curExtensionInfo.insert("IsCompatible", isCompatible);
-			extensionsHistoryInformation.insert(extensionName, curExtensionInfo);
-		}
-	}
-	return extensionsHistoryInformation;
+      curExtensionInfo.insert("IsCompatible", isCompatible);
+      extensionsHistoryInformation.insert(extensionName, curExtensionInfo);
+    }
+  }
+  return extensionsHistoryInformation;
 }
 
 // --------------------------------------------------------------------------
 void qSlicerExtensionsManagerModelPrivate::gatherExtensionsHistoryInformationOnStartup()
 {
-	Q_Q(qSlicerExtensionsManagerModel);
+  Q_Q(qSlicerExtensionsManagerModel);
   emit q->extensionHistoryGatheredOnStartup(q->getExtensionHistoryInformation());
 }
 
@@ -2178,7 +2178,7 @@ bool qSlicerExtensionsManagerModel::uninstallScheduledExtensions(QStringList& un
 // --------------------------------------------------------------------------
 void qSlicerExtensionsManagerModel::gatherExtensionsHistoryInformationOnStartup()
 {
-	Q_D(qSlicerExtensionsManagerModel);
+  Q_D(qSlicerExtensionsManagerModel);
   d->gatherExtensionsHistoryInformationOnStartup();
 }
 

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -219,6 +219,8 @@ public:
       const QString& slicerOs, const QString& slicerArch);
 
   void saveExtensionDescription(const QString& extensionDescriptionFile, const ExtensionMetadataType &allExtensionMetadata);
+  void writeExtensionsHistoryToSettingsFile(const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &allExtensionMetadata);
+
 
   qSlicerExtensionsManagerModel::ExtensionMetadataType retrieveExtensionMetadata(
     const qMidasAPI::ParametersType& parameters);
@@ -812,6 +814,17 @@ void qSlicerExtensionsManagerModelPrivate::saveExtensionDescription(
 //    }
 
   qSlicerExtensionsManagerModel::writeExtensionDescriptionFile(extensionDescriptionFile, allExtensionMetadata);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelPrivate::writeExtensionsHistoryToSettingsFile(
+	const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata)
+{
+	QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
+	QStringList extensionIDs = settings.value("ExtensionsHistory/" + this->SlicerRevision).toStringList();
+	extensionIDs << extensionMetadata.value("extension_id").toString();
+	extensionIDs.removeDuplicates();
+	settings.setValue("ExtensionsHistory/" + this->SlicerRevision, extensionIDs);
 }
 
 // --------------------------------------------------------------------------
@@ -1424,6 +1437,7 @@ bool qSlicerExtensionsManagerModel::installExtension(
 
   // Finish installing the extension
   d->saveExtensionDescription(extensionDescriptionFile, extensionMetadata);
+  d->writeExtensionsHistoryToSettingsFile(this->extensionsHistorySettingsFilePath(), extensionMetadata);
   d->addExtensionSettings(extensionName);
   d->addExtensionModelRow(Self::parseExtensionDescriptionFile(extensionDescriptionFile));
 

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -236,6 +236,8 @@ public:
   QHash<QString, UpdateDownloadInformation> AvailableUpdates;
 
   QString ExtensionsSettingsFilePath;
+  QString ExtensionsHistorySettingsFilePath;
+
 
   QString SlicerRevision;
   QString SlicerOs;
@@ -2036,6 +2038,10 @@ void qSlicerExtensionsManagerModel::updateModel()
 // --------------------------------------------------------------------------
 CTK_GET_CPP(qSlicerExtensionsManagerModel, QString, extensionsSettingsFilePath, ExtensionsSettingsFilePath)
 CTK_SET_CPP(qSlicerExtensionsManagerModel, const QString&, setExtensionsSettingsFilePath, ExtensionsSettingsFilePath)
+
+// --------------------------------------------------------------------------
+CTK_GET_CPP(qSlicerExtensionsManagerModel, QString, extensionsHistorySettingsFilePath, ExtensionsHistorySettingsFilePath)
+CTK_SET_CPP(qSlicerExtensionsManagerModel, const QString&, setExtensionsHistorySettingsFilePath, ExtensionsHistorySettingsFilePath)
 
 // --------------------------------------------------------------------------
 CTK_GET_CPP(qSlicerExtensionsManagerModel, QString, slicerRevision, SlicerRevision)

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -908,6 +908,15 @@ QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousI
       QString extensionName = extensionNames.at(j);
       QString extensionId = "";
 
+      //make sure that no invalid white space leads to invalid extension names
+      //also catches empty entries in [ExtensionHistory] in Slicer.ini
+      extensionName = extensionName.simplified();
+      extensionName.replace(" ", "");
+      if (extensionName.length() == 0)
+      {
+        break;
+      }
+
       curExtensionInfo.insert("UsedLastInRevision", revisions.at(i));
       if (i == lastRevision || (extensionsHistoryInformation.contains(extensionName) &&
         extensionsHistoryInformation.value(extensionName).toMap().value("WasInstalledInLastRevision").toBool()))

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -919,7 +919,6 @@ QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousI
 		QStringList extensions = settings.value(revisions.at(i)).toStringList();
 		for (unsigned int j = 0; j < extensions.length(); j++)
 		{
-			qDebug() << extensions.at(j);
 			QStringList extensionIdAndName = extensions.at(j).split(":");
 			const QString extensionId = extensionIdAndName.at(0);
 			const QString extensionName = extensionIdAndName.at(1);
@@ -937,12 +936,9 @@ QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousI
 			curExtensionInfo.insert("IsInstalled", q->isExtensionInstalled(extensionName));
 			bool isCompatible = true;
 			if (!q->isExtensionInstalled(extensionName)) {
-				qDebug() << "retrieve Info";
 				ExtensionMetadataType metaData = q->retrieveExtensionMetadata(extensionId);
-				qDebug() << "have infi";
 				isCompatible = (this->isExtensionCompatible(metaData,
 				this->SlicerRevision, this->SlicerOs, this->SlicerArch).length() == 0);
-				qDebug() << "retrieve: "<<isCompatible;
 			}
 			else
 			{
@@ -979,9 +975,6 @@ void qSlicerExtensionsManagerModelPrivate::checkExtensionsHistory()
 		msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
 		if (msgBox.exec() == QMessageBox::Yes)
 		{
-			qDebug() << "Extension installation triggered";
-			qDebug() << candidateIds;
-			qDebug() << "Emitting event";
 			emit q->extensionRestoreTriggered(candidateIds);
 		}
 	}
@@ -1373,7 +1366,6 @@ void qSlicerExtensionsManagerModel::onInstallDownloadProgress(
 
   // Look up the update information
   const QString& extensionName = task->extensionName();
-  qDebug() << extensionName << received << "," << total;
 
   // Notify observers of download progress
   emit this->installDownloadProgress(extensionName, received, total);

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -350,7 +350,13 @@ signals:
 
   void messageLogged(const QString& text, ctkErrorLogLevel::LogLevels level) const;
 
+  void extensionRestoreTriggered(QStringList& extensions);
+
+  void installDownloadProgress(QString, qint64, qint64);
+
 protected slots:
+
+  void onInstallDownloadProgress(qSlicerExtensionDownloadTask* task, qint64 received, qint64 total);
 
   /// \sa downloadAndInstallExtension
   void onInstallDownloadFinished(qSlicerExtensionDownloadTask* task);

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -148,6 +148,7 @@ public:
   QString extensionsHistorySettingsFilePath()const;
   void setExtensionsHistorySettingsFilePath(const QString& extensionsHistorySettingsFilePath);
 
+
   QString slicerRevision()const;
   void setSlicerRevision(const QString& revision);
 

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -148,6 +148,7 @@ public:
   QString extensionsHistorySettingsFilePath()const;
   void setExtensionsHistorySettingsFilePath(const QString& extensionsHistorySettingsFilePath);
 
+  QVariantMap extensionsHistoryInformation()const;
 
   QString slicerRevision()const;
   void setSlicerRevision(const QString& revision);
@@ -305,7 +306,9 @@ public slots:
   /// \sa scheduleExtensionForUninstall, isExtensionScheduledForUninstall,
   bool uninstallScheduledExtensions();
 
-  void checkExtensionHistory();
+  void gatherExtensionsHistoryInformationOnStartup();
+
+  QVariantMap getExtensionHistoryInformation();
 
   void identifyIncompatibleExtensions();
 
@@ -350,9 +353,9 @@ signals:
 
   void messageLogged(const QString& text, ctkErrorLogLevel::LogLevels level) const;
 
-  void extensionRestoreTriggered(QStringList& extensions);
+  void extensionHistoryGatheredOnStartup(const QVariantMap&);
 
-  void installDownloadProgress(QString, qint64, qint64);
+  void installDownloadProgress(const QString& extensionName, qint64 received, qint64 total);
 
 protected slots:
 

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -52,6 +52,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerExtensionsManagerModel : public QObject
   Q_PROPERTY(QString extensionsInstallPath READ extensionsInstallPath)
   Q_PROPERTY(bool newExtensionEnabledByDefault READ newExtensionEnabledByDefault WRITE setNewExtensionEnabledByDefault)
   Q_PROPERTY(QString extensionsSettingsFilePath READ extensionsSettingsFilePath WRITE setExtensionsSettingsFilePath)
+  Q_PROPERTY(QString extensionsHistorySettingsFilePath READ extensionsHistorySettingsFilePath WRITE setExtensionsHistorySettingsFilePath)
   Q_PROPERTY(QString slicerRevision READ slicerRevision WRITE setSlicerRevision)
   Q_PROPERTY(QString slicerOs READ slicerOs WRITE setSlicerOs)
   Q_PROPERTY(QString slicerArch READ slicerArch WRITE setSlicerArch)
@@ -143,6 +144,9 @@ public:
 
   QString extensionsSettingsFilePath()const;
   void setExtensionsSettingsFilePath(const QString& extensionsSettingsFilePath);
+
+  QString extensionsHistorySettingsFilePath()const;
+  void setExtensionsHistorySettingsFilePath(const QString& extensionsHistorySettingsFilePath);
 
   QString slicerRevision()const;
   void setSlicerRevision(const QString& revision);

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -305,6 +305,8 @@ public slots:
   /// \sa scheduleExtensionForUninstall, isExtensionScheduledForUninstall,
   bool uninstallScheduledExtensions();
 
+  void checkExtensionHistory();
+
   void identifyIncompatibleExtensions();
 
   bool exportExtensionList(QString& exportFilePath);

--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -101,7 +101,7 @@ if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
   list(APPEND KIT_SRCS
     qSlicerExtensionsInstallWidget.cxx
     qSlicerExtensionsInstallWidget.h
-	qSlicerExtensionsRestoreWidget.cxx
+    qSlicerExtensionsRestoreWidget.cxx
     qSlicerExtensionsRestoreWidget.h
     qSlicerExtensionsManageWidget.cxx
     qSlicerExtensionsManageWidget.h

--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -101,6 +101,8 @@ if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
   list(APPEND KIT_SRCS
     qSlicerExtensionsInstallWidget.cxx
     qSlicerExtensionsInstallWidget.h
+	qSlicerExtensionsRestoreWidget.cxx
+    qSlicerExtensionsRestoreWidget.h
     qSlicerExtensionsManageWidget.cxx
     qSlicerExtensionsManageWidget.h
     qSlicerExtensionsManagerDialog.cxx
@@ -199,6 +201,7 @@ set(KIT_MOC_SRCS
 if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
   list(APPEND KIT_MOC_SRCS
     qSlicerExtensionsInstallWidget.h
+    qSlicerExtensionsRestoreWidget.h
     qSlicerExtensionsManageWidget.h
     qSlicerExtensionsManagerDialog.h
     qSlicerExtensionsManagerWidget.h

--- a/Base/QTGUI/Resources/UI/qSlicerExtensionsManagerWidget.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerExtensionsManagerWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>601</width>
-    <height>338</height>
+    <width>933</width>
+    <height>692</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <property name="iconSize">
       <size>
@@ -61,7 +61,25 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="qSlicerExtensionsInstallWidget" name="ExtensionsInstallWidget" native="true"/>
+        <widget class="qSlicerExtensionsInstallWidget" name="ExtensionsInstallWidget" native="true">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="restoreExtensionsTab">
+      <attribute name="icon">
+       <iconset resource="../qSlicerBaseQTGUI.qrc">
+        <normaloff>:/Icons/Medium/SlicerRedo.png</normaloff>:/Icons/Medium/SlicerRedo.png</iconset>
+      </attribute>
+      <attribute name="title">
+       <string>Restore Extensions</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="qSlicerExtensionsRestoreWidget" name="ExtensionsRestoreWidget" native="true"/>
        </item>
       </layout>
      </widget>
@@ -80,6 +98,12 @@
    <class>qSlicerExtensionsInstallWidget</class>
    <extends>QWidget</extends>
    <header>qSlicerExtensionsInstallWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerExtensionsRestoreWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerExtensionsRestoreWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -290,6 +290,7 @@ void qSlicerApplicationPrivate::init()
   //----------------------------------------------------------------------------
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
   this->ExtensionsManagerDialog = new qSlicerExtensionsManagerDialog(0);
+  this->ExtensionsManagerDialog->setExtensionsManagerModel(q->extensionsManagerModel());
 #endif
 
   //----------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
@@ -285,6 +285,7 @@ void qSlicerExtensionsManagerWidget::setExtensionsManagerModel(qSlicerExtensions
   d->ExtensionsManageWidget->setExtensionsManagerModel(model);
   d->ExtensionsManageBrowser->setExtensionsManagerModel(model);
   d->ExtensionsInstallWidget->setExtensionsManagerModel(model);
+  d->ExtensionsRestoreWidget->setExtensionsManagerModel(model);
 
   if (model)
     {

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
@@ -298,11 +298,13 @@ void qSlicerExtensionsRestoreWidgetPrivate
 	  if (headlessMode) {
 		  progressDialog->close();
       headlessMode = false;
-      QMessageBox msgBox;
-      msgBox.setText("Restart required.");
-      msgBox.setInformativeText("All extensions restored. Please restart Slicer.");
-      msgBox.setStandardButtons(QMessageBox::Ok);
-      msgBox.exec();
+
+      ctkMessageBox checkHistoryMessage;
+      checkHistoryMessage.setText("All extensions restored. Please restart Slicer.");
+      checkHistoryMessage.setIcon(QMessageBox::Information);
+      checkHistoryMessage.setStandardButtons(QMessageBox::Ok);
+      checkHistoryMessage.setDontShowAgainVisible(false);
+      checkHistoryMessage.exec();
 	  }
     else
     {

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
@@ -1,0 +1,251 @@
+//QT includes
+#include <QPushButton>
+#include <QProgressBar>
+#include <QLayout>
+#include <iostream>
+#include <QFileInfo>
+#include <QDir>
+#include <QListWidget>
+
+// QtGUI includes
+#include "qSlicerExtensionsRestoreWidget.h"
+#include "qSlicerExtensionsManagerModel.h"
+
+//-----------------------------------------------------------------------------
+class qSlicerExtensionsRestoreWidgetPrivate
+{
+  Q_DECLARE_PUBLIC(qSlicerExtensionsRestoreWidget);
+protected:
+  qSlicerExtensionsRestoreWidget* const q_ptr;
+
+public:
+  qSlicerExtensionsRestoreWidgetPrivate(qSlicerExtensionsRestoreWidget& object);
+  void init();
+  void setupUi();
+  void setupList();
+  QStringList getSelectedExtensions();
+  void startDownloadAndInstallExtensions();
+  void downloadAndInstallNextExtension();
+  void downloadProgress(const QString& extensionName, qint64 received, qint64 total);
+
+  qSlicerExtensionsManagerModel *ExtensionsManagerModel;
+  QProgressBar *progressBar;
+  QListWidget *extensionList;
+  QStringList extensionsToInstall;
+  unsigned int nrOfExtensionsToInstall;
+  int currentExtensionToInstall;
+  unsigned int maxProgress;
+};
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsRestoreWidgetPrivate::qSlicerExtensionsRestoreWidgetPrivate(qSlicerExtensionsRestoreWidget& object)
+:q_ptr(&object)
+{
+
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate::init()
+{
+  nrOfExtensionsToInstall = 0;
+  setupUi();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::setupUi()
+{
+  Q_Q(qSlicerExtensionsRestoreWidget);
+
+  QVBoxLayout *mainLayout = new QVBoxLayout;
+  QHBoxLayout *layoutForProgressAndButton = new QHBoxLayout;
+  QPushButton *installButton = new QPushButton;
+  extensionList = new QListWidget;
+  progressBar = new QProgressBar;
+
+  installButton->setText("Install Selected");
+  maxProgress = 1000;
+  progressBar->setValue(0);
+  progressBar->setMaximum(maxProgress);
+  layoutForProgressAndButton->addWidget(progressBar);
+  layoutForProgressAndButton->addWidget(installButton);
+  mainLayout->addWidget(extensionList);
+  mainLayout->addLayout(layoutForProgressAndButton);
+  q->setLayout(mainLayout);
+
+  //Setup Handling
+  QObject::connect(installButton, SIGNAL(clicked()),
+    q, SLOT(onInstallSelectedExtensionsTriggered()));
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::setupList()
+{
+  Q_Q(qSlicerExtensionsRestoreWidget);
+
+  /*extensionList->clear();
+
+  QMap<QString, QStringList> extensionRestoreInfo = q->extensionsManagerModel()->getExtensionRestoreInformation();
+  foreach(QString extensionId, extensionRestoreInfo.keys())
+  {
+    QListWidgetItem* extensionItem = new QListWidgetItem;
+    extensionItem->setData(Qt::UserRole, extensionId);
+    QString itemText = extensionRestoreInfo[extensionId][0];
+    bool isItemEnabled = (extensionRestoreInfo[extensionId][2] == "0");
+    //&& extensionRestoreInfo[extensionId][3] == "1");
+
+    if (extensionRestoreInfo[extensionId][1] == "1" && isItemEnabled)
+    {
+      extensionItem->setForeground(QBrush(Qt::darkGreen));
+    }
+    extensionItem->setText(extensionRestoreInfo[extensionId][0]);
+    Qt::ItemFlags flags = isItemEnabled ? Qt::ItemIsUserCheckable | Qt::ItemIsEnabled : Qt::ItemIsUserCheckable;
+    extensionItem->setFlags(flags);
+    extensionItem->setCheckState((extensionRestoreInfo[extensionId][1] == "0" || !isItemEnabled) ? Qt::Unchecked : Qt::Checked);
+    extensionList->addItem(extensionItem);
+  }*/
+}
+
+// --------------------------------------------------------------------------
+QStringList qSlicerExtensionsRestoreWidgetPrivate
+::getSelectedExtensions()
+{
+  QStringList selectedExtensions;
+  for (int i = 0; i < extensionList->count(); i++)
+  {
+    QListWidgetItem* currentItem = extensionList->item(i);
+    if (currentItem->checkState() && (currentItem->flags() & Qt::ItemIsEnabled))
+    {
+      selectedExtensions.append(currentItem->data(Qt::UserRole).toString());
+    }
+  }
+  return selectedExtensions;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::startDownloadAndInstallExtensions()
+{
+  extensionsToInstall = getSelectedExtensions();
+  nrOfExtensionsToInstall = extensionsToInstall.size();
+  currentExtensionToInstall = -1;
+  downloadAndInstallNextExtension();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::downloadAndInstallNextExtension()
+{
+  Q_Q(qSlicerExtensionsRestoreWidget);
+  currentExtensionToInstall++;
+  if (currentExtensionToInstall < nrOfExtensionsToInstall)
+  {
+    q->extensionsManagerModel()->downloadAndInstallExtension(extensionsToInstall.at(currentExtensionToInstall));
+  }
+  else {
+    setupList();
+  }
+}
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::downloadProgress(const QString& extensionName, qint64 received, qint64 total)
+{
+  int value = (((float(maxProgress) / float(nrOfExtensionsToInstall))*float(currentExtensionToInstall)) +
+    ((float(received) / float(total)) * (float(maxProgress) / float(nrOfExtensionsToInstall))));
+  progressBar->setValue(value);
+}
+
+// qSlicerExtensionsRestoreWidget methods
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsRestoreWidget
+::qSlicerExtensionsRestoreWidget(QWidget* _parent)
+: Superclass(_parent)
+, d_ptr(new qSlicerExtensionsRestoreWidgetPrivate(*this))
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->init();
+}
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsRestoreWidget
+::~qSlicerExtensionsRestoreWidget()
+{
+}
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsManagerModel* qSlicerExtensionsRestoreWidget
+::extensionsManagerModel()const
+{
+  Q_D(const qSlicerExtensionsRestoreWidget);
+  return d->ExtensionsManagerModel;
+}
+
+
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget
+::setExtensionsManagerModel(qSlicerExtensionsManagerModel* model)
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+
+  if (this->extensionsManagerModel() == model)
+  {
+    return;
+  }
+
+  disconnect(this, SLOT(onProgressChanged(QString, qint64, qint64)));
+  disconnect(this, SLOT(onDownloadFinished(QNetworkReply*)));
+  d->ExtensionsManagerModel = model;
+  d->setupList();
+
+  if (model)
+  {
+    connect(model, SIGNAL(installDownloadProgress(QString, qint64, qint64)),
+      this, SLOT(onProgressChanged(QString, qint64, qint64)));
+    connect(model, SIGNAL(extensionInstalled(QString)),
+      this, SLOT(onInstallationFinished(QString)));
+  }
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget
+::onInstallSelectedExtensionsTriggered()
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->startDownloadAndInstallExtensions();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget::onProgressChanged(const QString& extensionName, qint64 received, qint64 total)
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->downloadProgress(extensionName, received, total);
+};
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget
+::onInstallationFinished(QString extensionName)
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->downloadAndInstallNextExtension();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget::onMessageLogged(const QString& text, ctkErrorLogLevel::LogLevels level)
+{
+  QString delay = "2500";
+  QString state;
+  if (level == ctkErrorLogLevel::Warning)
+  {
+    delay = "10000";
+    state = "warning";
+  }
+  else if (level == ctkErrorLogLevel::Critical || level == ctkErrorLogLevel::Fatal)
+  {
+    delay = "10000";
+    state = "error";
+  }
+
+}

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
@@ -137,13 +137,31 @@ void qSlicerExtensionsRestoreWidgetPrivate
 {
   Q_Q(qSlicerExtensionsRestoreWidget);
 
-  /*extensionList->clear();
+  extensionList->clear();
+  QVariantMap extensionInfo = q->extensionsManagerModel()->getExtensionHistoryInformation();
 
-  QMap<QString, QStringList> extensionRestoreInfo = q->extensionsManagerModel()->getExtensionRestoreInformation();
-  foreach(QString extensionId, extensionRestoreInfo.keys())
+  foreach(QString extensionId, extensionInfo.keys())
   {
     QListWidgetItem* extensionItem = new QListWidgetItem;
     extensionItem->setData(Qt::UserRole, extensionId);
+    QVariantMap currentInfo = extensionInfo.value(extensionId).toMap();
+    QString itemText = currentInfo.value("Name").toString() + "(" + currentInfo.value("UsedLastInRevision").toString() + ")";
+
+    bool isItemEnabled = currentInfo.value("IsCompatible").toBool() && !currentInfo.value("IsInstalled").toBool();
+    if (currentInfo.value("WasInstalledInLastRevision").toBool() && isItemEnabled)
+    {
+      extensionItem->setForeground(QBrush(Qt::darkGreen));
+    }
+    extensionItem->setText(itemText);
+    Qt::ItemFlags flags = isItemEnabled ? Qt::ItemIsUserCheckable | Qt::ItemIsEnabled : Qt::ItemIsUserCheckable;
+    extensionItem->setFlags(flags);
+    extensionItem->setCheckState((!isItemEnabled) ? Qt::Unchecked : Qt::Checked);
+    extensionList->addItem(extensionItem);
+  }
+  /*
+      QListWidgetItem* extensionItem = new QListWidgetItem;
+    extensionItem->setData(Qt::UserRole, extensionId);
+    QVariantMap currentInfo = extensionInfo.value(extensionId).toMap();
     QString itemText = extensionRestoreInfo[extensionId][0];
     bool isItemEnabled = (extensionRestoreInfo[extensionId][2] == "0");
     //&& extensionRestoreInfo[extensionId][3] == "1");
@@ -156,8 +174,7 @@ void qSlicerExtensionsRestoreWidgetPrivate
     Qt::ItemFlags flags = isItemEnabled ? Qt::ItemIsUserCheckable | Qt::ItemIsEnabled : Qt::ItemIsUserCheckable;
     extensionItem->setFlags(flags);
     extensionItem->setCheckState((extensionRestoreInfo[extensionId][1] == "0" || !isItemEnabled) ? Qt::Unchecked : Qt::Checked);
-    extensionList->addItem(extensionItem);
-  }*/
+    extensionList->addItem(extensionItem);*/
 }
 
 // --------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
@@ -150,15 +150,17 @@ void qSlicerExtensionsRestoreWidgetPrivate
   currentExtensionToInstall++;
   if (currentExtensionToInstall < nrOfExtensionsToInstall)
   {
-    if (headlessMode) {
-      progressDialog->setLabelText("Installing Extension (ID):" + extensionsToInstall.at(currentExtensionToInstall));
-    }
     q->extensionsManagerModel()->downloadAndInstallExtension(extensionsToInstall.at(currentExtensionToInstall));
   }
   else {
 	  if (headlessMode) {
 		  progressDialog->close();
       headlessMode = false;
+      QMessageBox msgBox;
+      msgBox.setText("Restart required.");
+      msgBox.setInformativeText("All extensions restored. Please restart Slicer.");
+      msgBox.setStandardButtons(QMessageBox::Ok);
+      msgBox.exec();
 	  }
     else
     {
@@ -172,9 +174,9 @@ void qSlicerExtensionsRestoreWidgetPrivate
 {
   int value = (((float(maxProgress) / float(nrOfExtensionsToInstall))*float(currentExtensionToInstall)) +
     ((float(received) / float(total)) * (float(maxProgress) / float(nrOfExtensionsToInstall))));
-  qDebug() << value;
   if (headlessMode) {
 	  progressDialog->setValue(value);
+    progressDialog->setLabelText("Installing " + extensionName + " (" + QString::number(received) + "/" + QString::number(total) + ")");
   }
   else
   {
@@ -265,7 +267,6 @@ void qSlicerExtensionsRestoreWidget
 ::onExtensionRestoreTriggered(QStringList &extensionIds)
 {
 	Q_D(qSlicerExtensionsRestoreWidget);
-	qDebug() << "Hey, I was triggered with following info: " << extensionIds;
 	d->headlessMode = true;
 	d->extensionsToInstall = extensionIds;
   d->progressDialog->show();

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
@@ -354,7 +354,7 @@ void qSlicerExtensionsRestoreWidgetPrivate
       this->progressDialog->close();
       this->headlessMode = false;
       static_cast<qSlicerApplication*>qApp->confirmRestart("All extensions restored. Please restart Slicer.");
-	  }
+    }
     else
     {
       setupList();
@@ -368,12 +368,12 @@ void qSlicerExtensionsRestoreWidgetPrivate
   int value = (((float(maxProgress) / float(nrOfExtensionsToInstall))*float(currentExtensionToInstall)) +
     ((float(received) / float(total)) * (float(maxProgress) / float(nrOfExtensionsToInstall))));
   if (this->headlessMode) {
-	  this->progressDialog->setValue(value);
+    this->progressDialog->setValue(value);
     this->progressDialog->setLabelText("Installing " + extensionName + " (" + QString::number(received) + "/" + QString::number(total) + ")");
   }
   else
   {
-	  this->progressBar->setValue(value);
+    this->progressBar->setValue(value);
   }
 }
 
@@ -499,7 +499,7 @@ void qSlicerExtensionsRestoreWidget
 void qSlicerExtensionsRestoreWidget
 ::onExtensionHistoryGatheredOnStartup(const QVariantMap& extensionInfo)
 {
-	Q_D(qSlicerExtensionsRestoreWidget);
+  Q_D(qSlicerExtensionsRestoreWidget);
   d->processExtensionsHistoryInformationOnStartup(extensionInfo);
 }
 

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
@@ -7,7 +7,7 @@
 #include <QDir>
 #include <QListWidget>
 #include <QDebug>
-#include <QProgressdialog>
+#include <QProgressDialog>
 #include <ctkMessageBox.h>
 #include <QStyledItemDelegate>
 #include <QPainter>
@@ -86,7 +86,7 @@ public:
 
     QApplication::style()->drawControl(QStyle::CE_CheckBox, &cbOpt, painter);
   }
-  QSize sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const{
+  QSize sizeHint(const QStyleOptionViewItem & /*option*/, const QModelIndex & /*index*/) const{
     return QSize(200, 60);
   }
 
@@ -128,7 +128,7 @@ public:
   QString checkOnStartupSettingsKey;
   QString silentInstallOnStartUpSettingsKey;
   unsigned int nrOfExtensionsToInstall;
-  int currentExtensionToInstall;
+  unsigned int currentExtensionToInstall;
   bool headlessMode;
   unsigned int maxProgress;
 
@@ -309,7 +309,7 @@ QStringList qSlicerExtensionsRestoreWidgetPrivate
 ::getSelectedExtensions()
 {
   QStringList selectedExtensions;
-  for (unsigned int i = 0; i < extensionList->count(); i++)
+  for (int i = 0; i < extensionList->count(); i++)
   {
     QListWidgetItem* currentItem = extensionList->item(i);
     if (currentItem->data(Qt::UserRole + 1).toBool())
@@ -335,7 +335,7 @@ void qSlicerExtensionsRestoreWidgetPrivate
 {
   this->extensionsToInstall = extensionIds;
   this->nrOfExtensionsToInstall = extensionsToInstall.size();
-  this->currentExtensionToInstall = -1;
+  this->currentExtensionToInstall = 0;
   downloadAndInstallNextExtension();
 }
 
@@ -344,7 +344,6 @@ void qSlicerExtensionsRestoreWidgetPrivate
 ::downloadAndInstallNextExtension()
 {
   Q_Q(qSlicerExtensionsRestoreWidget);
-  this->currentExtensionToInstall++;
   if (this->currentExtensionToInstall < this->nrOfExtensionsToInstall)
   {
     q->extensionsManagerModel()->downloadAndInstallExtension(extensionsToInstall.at(currentExtensionToInstall));
@@ -360,6 +359,7 @@ void qSlicerExtensionsRestoreWidgetPrivate
       setupList();
     }
   }
+  this->currentExtensionToInstall++;
 }
 // --------------------------------------------------------------------------
 void qSlicerExtensionsRestoreWidgetPrivate
@@ -490,7 +490,7 @@ void qSlicerExtensionsRestoreWidget::onProgressChanged(const QString& extensionN
 
 // --------------------------------------------------------------------------
 void qSlicerExtensionsRestoreWidget
-::onInstallationFinished(QString extensionName)
+::onInstallationFinished(QString /*extensionName*/)
 {
   Q_D(qSlicerExtensionsRestoreWidget);
   d->downloadAndInstallNextExtension();
@@ -504,7 +504,7 @@ void qSlicerExtensionsRestoreWidget
 }
 
 // --------------------------------------------------------------------------
-void qSlicerExtensionsRestoreWidget::onMessageLogged(const QString& text, ctkErrorLogLevel::LogLevels level)
+void qSlicerExtensionsRestoreWidget::onMessageLogged(const QString& /*text*/, ctkErrorLogLevel::LogLevels level)
 {
   QString delay = "2500";
   QString state;

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
@@ -14,7 +14,7 @@
 #include <QEvent>
 #include <QApplication>
 #include <qSlicerApplication.h>
-#include <QCheckbox>
+#include <QCheckBox>
 
 // QtGUI includes
 #include "qSlicerExtensionsRestoreWidget.h"

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
@@ -1,0 +1,48 @@
+
+#ifndef __qSlicerExtensionsRestoreWidget_h
+#define __qSlicerExtensionsRestoreWidget_h
+
+// CTK includes
+#include <ctkErrorLogLevel.h>
+
+// Qt includes
+#include <QWidget>
+
+// QtGUI includes
+#include "qSlicerBaseQTGUIExport.h"
+
+class qSlicerExtensionsRestoreWidgetPrivate;
+class qSlicerExtensionsManagerModel;
+
+class Q_SLICER_BASE_QTGUI_EXPORT qSlicerExtensionsRestoreWidget
+  : public QWidget
+{
+  Q_OBJECT
+public:
+  /// Superclass typedef
+  typedef QWidget Superclass;
+
+  /// Constructor
+  explicit qSlicerExtensionsRestoreWidget(QWidget* parent = 0);
+
+  /// Destructor
+  virtual ~qSlicerExtensionsRestoreWidget();
+
+  Q_INVOKABLE qSlicerExtensionsManagerModel* extensionsManagerModel()const;
+  Q_INVOKABLE void setExtensionsManagerModel(qSlicerExtensionsManagerModel* model);
+
+  protected slots :
+  void onInstallSelectedExtensionsTriggered();
+  void onProgressChanged(const QString& extensionName, qint64 received, qint64 total);
+  void onInstallationFinished(QString extensionName);
+  void onMessageLogged(const QString& text, ctkErrorLogLevel::LogLevels level);
+
+protected:
+  QScopedPointer<qSlicerExtensionsRestoreWidgetPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerExtensionsRestoreWidget);
+  Q_DISABLE_COPY(qSlicerExtensionsRestoreWidget);
+};
+
+#endif

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
@@ -7,7 +7,7 @@
 
 // Qt includes
 #include <QWidget>
-#include <Qvariant>
+#include <QVariant>
 
 // QtGUI includes
 #include "qSlicerBaseQTGUIExport.h"

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
@@ -32,8 +32,13 @@ public:
   Q_INVOKABLE qSlicerExtensionsManagerModel* extensionsManagerModel()const;
   Q_INVOKABLE void setExtensionsManagerModel(qSlicerExtensionsManagerModel* model);
 
+  // Events
+  void showEvent(QShowEvent* event);
+
   protected slots :
   void onInstallSelectedExtensionsTriggered();
+  void onCheckOnStartupChanged(int state);
+  void onSilentInstallOnStartupChanged(int state);
   void onProgressChanged(const QString& extensionName, qint64 received, qint64 total);
   void onInstallationFinished(QString extensionName);
   void onExtensionHistoryGatheredOnStartup(const QVariantMap&);

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
@@ -35,6 +35,7 @@ public:
   void onInstallSelectedExtensionsTriggered();
   void onProgressChanged(const QString& extensionName, qint64 received, qint64 total);
   void onInstallationFinished(QString extensionName);
+  void onExtensionRestoreTriggered(QStringList &extensionIds);
   void onMessageLogged(const QString& text, ctkErrorLogLevel::LogLevels level);
 
 protected:

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
@@ -7,6 +7,7 @@
 
 // Qt includes
 #include <QWidget>
+#include <Qvariant>
 
 // QtGUI includes
 #include "qSlicerBaseQTGUIExport.h"
@@ -35,7 +36,7 @@ public:
   void onInstallSelectedExtensionsTriggered();
   void onProgressChanged(const QString& extensionName, qint64 received, qint64 total);
   void onInstallationFinished(QString extensionName);
-  void onExtensionRestoreTriggered(QStringList &extensionIds);
+  void onExtensionHistoryGatheredOnStartup(const QVariantMap&);
   void onMessageLogged(const QString& text, ctkErrorLogLevel::LogLevels level);
 
 protected:


### PR DESCRIPTION
This pull request is related to this PR (https://github.com/Slicer/Slicer/pull/632 - could be closed as PR includes all the features). It includes all the feedback from the hangout with JC as well as feedback from Ron from January (check for extensions on startup, allow for completely automatic hands-off installation of extensions if a new slicer build is installed and started for the first time). Details: https://www.slicer.org/wiki/Documentation/Labs/AutomaticUpdateAndInstallationFramework#Adaptations_.28March.29_according_to_input_from_JC_.28December.29_and_Ron_.28January.29

As it relies on tracking previous installations of extensions, the Slicer.ini needs to be adapted to emulate previous tracking.
Example:

[ExtensionsHistory]
Revisions\25844=ChangeTracker, SlicerToKiwiExporter, CleaverExtension
Revisions\25843=AnglePlanesExtension, ABC, CurveMaker, SlicerToKiwiExporter
Revisions\25842=AnglePlanesExtension, CurveMaker, CMFreg
ScheduledForRemoval=

Adding this setting to Slicer.ini would lead to identifying ChangeTracker, SlicerToKiwiExporter, CleaverExtensions as previously installed extensions (prompt on startup, preselection in the qSlicerExtensionRestoreWidget that would also show details about the other extensions installed in older versions of slicer).