### PR TITLE
BUG: load DICOM with referenced loadables popup used first checkbox value only

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -815,6 +815,7 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
           if loadable.selected:
             if children[loadableCnt + 2].checked:
               self.loadablesByPlugin[plugin].append(loadable)
+            loadableCnt += 1
 
       self.referencesDialog.close()
       self.referencesDialog = None


### PR DESCRIPTION
* in case there were three referenced loadables and second and third were unchecked, all loadables were still loaded because only the boolean value of the first checkbox was used for all

* example:
![image](https://cloud.githubusercontent.com/assets/10195822/24711593/6c471172-19ee-11e7-85b7-655bb85950ad.png)
  * all referenced series would still get loaded because the first series is checked

* loadableCnt never got incremented while checking checkboxes