### PR TITLE
Use header metadata to initialize volume scalar range

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -796,7 +796,7 @@ void vtkMRMLScalarVolumeDisplayNode::CalculateAutoLevels()
 
     window = max-min;
     level = 0.5*(max+min);
-    lower = this->GetLevel();
+    lower = level;
     upper = range[1];
     }
   else

--- a/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
@@ -147,6 +147,7 @@ int vtkITKArchetypeDiffusionTensorImageReaderFile::RequestData(
   data->SetOrigin(0, 0, 0);
   data->SetSpacing(1, 1, 1);
   data->SetExtent(extent);
+  this->SetMetaDataScalarRangeToPointDataInfo(data);
   vtkNew<vtkFloatArray> tensors;
   tensors->SetName("ArchetypeReader");
 

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
@@ -23,6 +23,7 @@ Version:   $Revision$
 class vtkMatrix4x4;
 
 // ITK includes
+#include "itkImageIOBase.h"
 #include "itkMetaDataDictionary.h"
 #include "itkSpatialOrientation.h"
 
@@ -792,6 +793,12 @@ protected:
 
   int          OutputScalarType;
   unsigned int NumberOfComponents;
+
+  std::vector<double> MetaDataScalarRangeMinima;
+  std::vector<double> MetaDataScalarRangeMaxima;
+  void GetScalarRangeMetaDataKeys(itk::ImageIOBase::Pointer imageIO,
+                                  std::string range_keys[2]);
+  void SetMetaDataScalarRangeToPointDataInfo(vtkImageData* data);
 
   double DefaultDataSpacing[3];
   double DefaultDataOrigin[3];

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
@@ -84,6 +84,7 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
   data->AllocateScalars(outInfo);
   data->SetExtent(outInfo->Get(
     vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()));
+  this->SetMetaDataScalarRangeToPointDataInfo(data);
 
 /// SCALAR MACRO
 #define vtkITKExecuteDataFromSeries(typeN, type) \

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
@@ -126,6 +126,8 @@ void vtkITKArchetypeImageSeriesVectorReaderFile::ExecuteDataWithInformation(vtkD
     default:
         vtkErrorMacro(<< "UpdateFromFile: Unknown data type " << this->OutputScalarType);
       }
+
+    this->SetMetaDataScalarRangeToPointDataInfo(data);
     }
   else
     {

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
@@ -147,6 +147,8 @@ void vtkITKArchetypeImageSeriesVectorReaderSeries::ExecuteDataWithInformation(vt
       {
       vtkErrorMacro(<< "Exception from vtkITK MegaMacro: " << e << "\n");
       }
+
+    this->SetMetaDataScalarRangeToPointDataInfo(data);
     }
 }
 


### PR DESCRIPTION
Co-Authored with @jcfr 

# Motivation
We're working on a project where we need to speed up the loading of multiple large volumes (Gigabytes) in a custom version of Slicer.
* Our first bottleneck was - _FYI_ - tackled by simply using uncompressed data vs compressed data, where we encountered a 50% to 70% improvement (working with an NVMe SSD where reading from disk is much faster than uncompressing).
* Our second bottleneck was caused by the computation of the volume scalar range, needed to automatically calculate the window/level. The following stack trace obtained during one of our profilings shows a summary of the calls and their cost in CPU time, where `GetDisplayScalarRange` takes around **40%** (in our use case, using uncompressed data, and could go up to **47%**. With uncompressed data, the cost was around **17%**).

> * 97.0% - [qSlicerIOManager::loadNodes](https://github.com/Slicer/Slicer/blob/eefeac9286f48552e8418a11f412b2823a09b407/Base/QTGUI/qSlicerIOManager.cxx#L406-L459)
>   * 86.2% - [qSlicerCoreIOManager::loadNodes](https://github.com/Slicer/Slicer/blob/eefeac9286f48552e8418a11f412b2823a09b407/Base/QTGUI/qSlicerIOManager.cxx#L421)
>     * 82.5% - [vtkSlicerVolumesLogic::AddArchetypeVolume](https://github.com/Slicer/Slicer/blob/683f5016320b4b5769aa6887f2232c294750d9c9/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx#L629-L779)
>       * 74.9% - [vtkMRMLStorageNode::ReadData](https://github.com/Slicer/Slicer/blob/683f5016320b4b5769aa6887f2232c294750d9c9/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx#L700)
>         * 44.7% - vtkMRMLVolumeNode::SetAndObserveImageData
>           * 43.1% - [vtkMRMLScalarVolumeDisplayNode::CalculateAutoLevels](https://github.com/Slicer/Slicer/blob/868c60c58d7c4841462fd15cdb178262a645ce44/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx#L416) 
>             * 39.2% - [vtkMRMLScalarVolumeDisplayNode::GetDisplayScalarRange](https://github.com/Slicer/Slicer/blob/868c60c58d7c4841462fd15cdb178262a645ce44/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx#L792)
>               * 39.2% - [vtkDataSet::GetScalarRange](https://github.com/Slicer/Slicer/blob/868c60c58d7c4841462fd15cdb178262a645ce44/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx#L693)
>             * 3.9% - [vtkStreamingDemandDrivenPipeline::Update](https://github.com/Slicer/Slicer/blob/868c60c58d7c4841462fd15cdb178262a645ce44/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx#L724)
>               * 3.9%- vtkImageAccumulate::RequestData
>         * 29.6% - vtkStreamingDemandDrivenPipeline::Update
>           * 26.0% - itk::ImageFileReader::GenerateData()
>       * 5.8% - vtkMRMLScene::EndState
>     * 2.6% - vtkMRMLApplicationLogic::vtkInternal::PropagateVolumeSelection
>   * 10.7% - [qProgressDialog::setValue](https://github.com/Slicer/Slicer/blob/eefeac9286f48552e8418a11f412b2823a09b407/Base/QTGUI/qSlicerIOManager.cxx#L418)

# Objective
Offer a way to use the metadata min/max information from the volume file headers to speed up the data loading if it exists.

# Current support
Multiple file formats define properties in the header file to store the scalar range, and ITK adds these info to the metadata dictionary that can be retrieved using `itkObject::GetMetaDataDictionary()` :
- nifti: [cal_min, cal_max]
  - [format standard](https://nifti.nimh.nih.gov/nifti-1/documentation/nifti1fields/nifti1fields_pages/cal_maxmin.html)
  - [itk support](https://github.com/InsightSoftwareConsortium/ITK/blob/f9110a0046a9d07a921767ba000443ad006a2c9b/Modules/IO/NIFTI/src/itkNiftiImageIO.cxx#L887-L893)
- nrrd/nhrd: [min, max]
  - [format standard](http://teem.sourceforge.net/nrrd/format.html#min)
  - [itk support](https://github.com/InsightSoftwareConsortium/ITK/blob/f9110a0046a9d07a921767ba000443ad006a2c9b/Modules/ThirdParty/NrrdIO/src/NrrdIO/NrrdIO.h.in#L1238-L1239)
- mha/mhd : [ElementMin, ElementMax]
  - [format standard](https://itk.org/Wiki/MetaIO/Documentation#Tags_Added_by_MetaImage)
  - [itk support](https://github.com/InsightSoftwareConsortium/ITK/blob/f9110a0046a9d07a921767ba000443ad006a2c9b/Modules/IO/Meta/src/itkMetaImageIO.cxx#L393-L401)

Also, the class `vtkITKArchetypeImageSeries[Scalar]Reader` already retrieves the metadata (1) and sets it to the `vtkMRMLVolumeNode` (2):
1. https://github.com/Slicer/Slicer/blob/868c60c58d7c4841462fd15cdb178262a645ce44/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx#L816-L826
2. https://github.com/Slicer/Slicer/blob/eefeac9286f48552e8418a11f412b2823a09b407/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx#L407

