### PR TITLE
ENH: add module to PYTHONPATH during registration

### DIFF
--- a/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
@@ -43,6 +43,24 @@
 //----------------------------------------------------------------------------
 bool ctkFactoryScriptedItem::load()
 {
+#ifdef Slicer_USE_PYTHONQT
+  if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
+    {
+    // By convention, if the module is not embedded, "<MODULEPATH>" will be appended to PYTHONPATH
+    if (!qSlicerCoreApplication::application()->isEmbeddedModule(this->path()))
+      {
+      QDir modulePathWithoutIntDir = QFileInfo(this->path()).dir();
+      QString intDir = qSlicerCoreApplication::application()->intDir();
+      if (intDir ==  modulePathWithoutIntDir.dirName())
+        {
+        modulePathWithoutIntDir.cdUp();
+        }
+      qSlicerCorePythonManager * pythonManager = qSlicerCoreApplication::application()->corePythonManager();
+      pythonManager->appendPythonPaths(QStringList() << modulePathWithoutIntDir.absolutePath());
+      }
+    }
+#endif
+
   return true;
 }
 
@@ -58,24 +76,6 @@ qSlicerAbstractCoreModule* ctkFactoryScriptedItem::instanciator()
   qSlicerCoreApplication * app = qSlicerCoreApplication::application();
   module->setInstalled(qSlicerUtils::isPluginInstalled(this->path(), app->slicerHome()));
   module->setBuiltIn(qSlicerUtils::isPluginBuiltIn(this->path(), app->slicerHome()));
-
-#ifdef Slicer_USE_PYTHONQT
-  if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
-    {
-    // By convention, if the module is not embedded, "<MODULEPATH>" will be appended to PYTHONPATH
-    if (!qSlicerCoreApplication::application()->isEmbeddedModule(module->path()))
-      {
-      QDir modulePathWithoutIntDir = QFileInfo(module->path()).dir();
-      QString intDir = qSlicerCoreApplication::application()->intDir();
-      if (intDir ==  modulePathWithoutIntDir.dirName())
-        {
-        modulePathWithoutIntDir.cdUp();
-        }
-      qSlicerCorePythonManager * pythonManager = qSlicerCoreApplication::application()->corePythonManager();
-      pythonManager->appendPythonPaths(QStringList() << modulePathWithoutIntDir.absolutePath());
-      }
-    }
-#endif
 
   bool ret = module->setPythonSource(this->path());
   if (!ret)


### PR DESCRIPTION
Allows python modules to depend on resources provided by other modules.

There are multiple stages in the module initialization process: registration, instantiation, and loading. Instantiation is when the scripted module is parsed, so any import dependencies must be resolveable at that time. However, instantiation is done alphabetically, with no dependency resolution -- because the module factory does not know anything about dependencies (the module itself supplies the dependencies function). Adding to PYTHONPATH during registration allows to import dependency-provided resources during instantiation.

ref: https://discourse.slicer.org/t/scripted-module-dependency-loaded-too-late-for-one-module-but-for-another-one-not/142