### PR TITLE
ENH: Install SSL dlls into bin folder

### DIFF
--- a/CMake/SlicerBlockInstallOpenSSL.cmake
+++ b/CMake/SlicerBlockInstallOpenSSL.cmake
@@ -11,7 +11,7 @@ foreach(library ${OPENSSL_LIBRARIES})
       if(WIN32)
         get_filename_component(library_without_extension ${library} NAME_WE)
         install(FILES ${OPENSSL_EXPORT_LIBRARY_DIR}/${library_without_extension}.dll
-          DESTINATION ${Slicer_INSTALL_LIB_DIR} COMPONENT Runtime)
+          DESTINATION ${Slicer_INSTALL_BIN_DIR} COMPONENT Runtime)
       elseif(UNIX)
         slicerInstallLibrary(
           FILE ${library}


### PR DESCRIPTION
SSL library loading failure came up on my computer again: SSL libraries failed to load on all installed Slicer releases (even those that worked before). I've confirmed that copying libeay32.dll, ssleay32.dll into SlicerApp-real.exe's folder solves the problem. Interestingly, a system restart solves the problem, too (until the problem comes up again).

This commit makes the SSL libraries installed in SlicerApp-real.exe's folder (c:\Program Files\Slicer 4.7.0-2017-04-20\bin) instead of lib folder (c:\Program Files\Slicer 4.7.0-2017-04-20\lib\Slicer-4.7\ssleay32.dll). This should solve this problem permanently.