### PR TITLE
BUG: Fix ConvertDeviceToXYZ() 1 pixel offset

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractSliceViewDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractSliceViewDisplayableManager.cxx
@@ -96,7 +96,7 @@ void vtkMRMLAbstractSliceViewDisplayableManager::ConvertDeviceToXYZ(
   int numberOfRows = sliceNode->GetLayoutGridRows();
 
   float tempX = x / windowWidth;
-  float tempY = (windowHeight - y) / windowHeight;
+  float tempY = (windowHeight - 1 - y) / windowHeight;
 
   float z = floor(tempY*numberOfRows)*numberOfColumns + floor(tempX*numberOfColumns);
 

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
@@ -1172,17 +1172,6 @@ void vtkMRMLMarkupsDisplayableManager2D::GetDisplayToWorldCoordinates(double x, 
 
   // we will get the transformation matrix to convert display coordinates to RAS
 
-//    double windowWidth = this->GetInteractor()->GetRenderWindow()->GetSize()[0];
-//    double windowHeight = this->GetInteractor()->GetRenderWindow()->GetSize()[1];
-
-//    int numberOfColumns = this->GetMRMLSliceNode()->GetLayoutGridColumns();
-//    int numberOfRows = this->GetMRMLSliceNode()->GetLayoutGridRows();
-
-//    float tempX = x / windowWidth;
-//    float tempY = (windowHeight - y) / windowHeight;
-
-//    float z = floor(tempY*numberOfRows)*numberOfColumns + floor(tempX*numberOfColumns);
-
   vtkRenderer* pokedRenderer = this->GetInteractor()->FindPokedRenderer(x,y);
 
   vtkMatrix4x4 * xyToRasMatrix = this->GetMRMLSliceNode()->GetXYToRAS();
@@ -1260,25 +1249,13 @@ void vtkMRMLMarkupsDisplayableManager2D::GetDisplayToViewportCoordinates(double 
     vtkErrorMacro("GetDisplayToViewportCoordinates: No interactor!");
     return;
     }
-  double windowWidth = this->GetInteractor()->GetRenderWindow()->GetSize()[0];
-  double windowHeight = this->GetInteractor()->GetRenderWindow()->GetSize()[1];
-
-  int numberOfColumns = this->GetMRMLSliceNode()->GetLayoutGridColumns();
-  int numberOfRows = this->GetMRMLSliceNode()->GetLayoutGridRows();
-
-  float tempX = x / windowWidth;
-  float tempY = (windowHeight - y) / windowHeight;
-
-  float z = floor(tempY*numberOfRows)*numberOfColumns + floor(tempX*numberOfColumns);
-
-  vtkRenderer* pokedRenderer = this->GetInteractor()->FindPokedRenderer(x,y);
 
   double displayCoordinates[4];
-  displayCoordinates[0] = x - pokedRenderer->GetOrigin()[0];
-  displayCoordinates[1] = y - pokedRenderer->GetOrigin()[1];
-  displayCoordinates[2] = z;
+  this->ConvertDeviceToXYZ(x, y, displayCoordinates);
   displayCoordinates[3] = 1;
 
+  double windowWidth = this->GetInteractor()->GetRenderWindow()->GetSize()[0];
+  double windowHeight = this->GetInteractor()->GetRenderWindow()->GetSize()[1];
   if (windowWidth != 0.0)
     {
     viewportCoordinates[0] = displayCoordinates[0]/windowWidth;


### PR DESCRIPTION
The issue appeared when using an annotation. When the annotation point is
dragged at the bottom of a slice view, the annotation Z position would
jump 1 pixel higher.
For example in the axial view, the Z coordinate of the annotation would
jump from 0.0 to 1.0 (when no module is loaded).

Here is a small python code exerpt that can be used to showcase the bug:
```Python
def PrintP1(caller, event):
    p1 = [0, 0, 0]
    caller.GetPosition1(p1)
    print(p1)

ruler = slicer.mrmlScene.AddNode(slicer.vtkMRMLAnnotationRulerNode())
ruler.SetPosition1([0, 0, 0])
ruler.SetPosition2([10, 0, 0])
ruler.AddObserver(vtk.vtkCommand.ModifiedEvent, PrintP1)
```

Fixing the computation of Z in ConvertDeviceToXYZ() fixes this.