### PR TITLE
ENH: update DCMTK to d8ed091

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -41,7 +41,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "DCMTK-3.6.1_20161102"
+    "d8ed091cda2b815226eafe41f5b4fe3bd22f8d5d"
     QUIET
     )
 


### PR DESCRIPTION
This update is needed to address a bug that prevented proper handling of character
set while importing attributes into DICOM Segmentation object. This was a critical
bug for the dcmqi library, and in turn for QuantitativeReporting extension. See
detailed discussion at https://github.com/QIICR/dcmqi/issues/233.

```
$ git shortlog DCMTK-3.6.1_20161102..d8ed091 --no-merges
Jan Schlamelcher (82):
      Enhanced C++11 compliance of OFvariant.
      Added macros for controlling compiler diagnostics.
      Suppressed some unnecessary warnings.
      Adjusted a previous commit for older GCC versions.
      Added some missing files to the install steps.
      Added compiler version checks to ofdiag.h etc.
      Suppressed an inappropriate Visual Studio warning.
      Added support for additional compiler diagnostics.
      Several fixes for OFnumeric_limits.
      Suppressed silly Visual Studio warnings in OFvariant.
      Suppressed warnings in OFThread's unit test.
      Fixed an OFnumeric_limits problem regarding C++11.
      Refactored character set conversion classes.
      Several fixes regarding character set conversion.
      Fixed a comment in OFCharacterEncoding.
      Fixed dcm2json when compiling as shared libraries.
      Fixed oflog character set conversion defines.
      Added magic word and version checks to dcmqrdb.
      Added additional information to DcmVR.
      Refactored DcmCharString based classes using DcmVR.
      Added DcmSpecificCharacterSet state checking methods.
      Fixed: ST is also affected by specific character set.
      Refactored dcmqrdb element list to use new/delete.
      Added Specific Character Set to the dcmqrdb index.
      Minor fixes in code comments of yesterdays commits.
      Added missing comment header to several unit tests.
      Added comparison operators for OFDateTime.
      Added string to number helper functions.
      Refactored string to date and time conversion.
      Introduced DcmAttributeMatching.
      Added character set conversion support to dcmqrdb.
      Fixed date time parsing regarding time zones.
      Moved dcmqrdb's trimString() function to OFStandard.
      Added support for additional Matching Keys.
      Added support for Issuer of Patient ID to dcmqrdb.
      Fixed Q/R matching on failed character set conversion.
      Workaround for clang non-type template argument issue.
      Fixed wrong value range check in extractDigits().
      Fixed Visual Studio linker problem with DLLs.
      Fixed digits10 not being a compile time constant.
      Documented dcmqrdb's new character set features.
      Fixed formatting errors in dcmqrscp's man page.
      Updated Makefile dependencies.
      Updated man pages for new development snapshot.
      Updated DCMTK_ABI_VERSION for new development snapshot.
      Updated CHANGES.361 for new development snapshot.
      Fixed dcmqrdb falsely retrying response conversion.
      Fixed previous commit.
      Fixed dcmqrdb falsely retrying response conversion.
      Fixed previous commit.
      Fixed CMake unit tests when BUILD_APPS was disabled.
      Fixed installing manpages with CMake.
      Fixed previous commit support for old CMake versions.
      Fixed inspecting fundamental arithmetic types.
      Fixed build date definition problem regarding Xcode.
      Modified config to prefer CMake's own FindXXX modules.
      Fixed incorrect usage of FindICU.cmake.
      Replaced OFauto_ptr with OFunique_ptr.
      Updated Makefile dependencies.
      Fixed problems regarding Windows include magic.
      Enhanced the way <windows.h> is included.
      Fixed misleading commit introduced by copy and paste.
      Added dcmpstat and dcmwlm test applications to CMake.
      Refactored DSRListOfItems::EmptyItem.
      Suppressed an inappropriate Visual Studio warning.
      Fixed linking some dcmsr unit tests with MSVC.
      Added test-exhaustive target for CMake.
      Added configure tests for some reentrant functions.
      Refactored low level network API usage.
      Added double quotes around paths in CMake files.
      Added CMake config tests for int64_t and uint64_t.
      Modified CMake configuration regarding MinGW.
      Added config tests for including libc.h and math.h.
      Fixed CTest failing tests that did not compile.
      Fixed a mistake in the code generating arith.h.
      Refactored cross compiling support with MinGW/Wine.
      Fixed and refactored cross compiling for Android.
      Fixed and refactored running the unit tests via CTest.
      Refactored getMACAddress() and its use.
      Fixed a misplaced dllexport/dllimport declaration.
      Workaround for Clang regarding OFerror_category.
      Added some CMake config tests and removed a macro.

Joerg Riesmeier (169):
      Added support for InstanceCreatorUID to readXML().
      Added support for missing "ReportType" values.
      Removed check on arrays being not a null pointer.
      Made "ReportType" optional in XML Schema.
      Made getNumberOfVerifyingObservers() const.
      Added new method hasVerifyingObservers().
      Renamed empty() methods to isEmpty().
      Various Doxygen-related fixes to documentation.
      Enabled Doxygen's WARN_NO_PARAMDOC option.
      Fixed Doxygen-related issues in the documentation.
      Added missing documentation for return values.
      Fixed code value for "Pulse Sequence Name" (CP-1578).
      Added four Color Palette SOP Instances (CP-1584).
      Added support for recently approved CPs.
      Added initial support for Supplement 195.
      Added support for CP-1584 to data dictionary.
      Added support for new UID from Supplement 169.
      Added "Simplified Adult Echo SR" to known types.
      Use macro _LIBICONV_VERSION instead of variable.
      Added support for new SR IOD from Supplement 169.
      Replaced non-ASCII characters.
      Replaced tab characters by spaces.
      Fixed wrong identation with tab characters.
      Replaced non-ASCII character in comment header.
      Added note/warning on size of class instance.
      Fixed wrong reference to conventonal JPEG format.
      Fixed warning re. overloaded virtual function.
      Re-added tab characters removed by last commit.
      Rebuilt Makefile dependencies.
      Fixed issue with option "--display-overlay 0".
      Removed additional library dependencies.
      Updated data dictionary for DICOM 2016e.
      Updated code definitions for DICOM 2016e.
      Now use code constant CODE_DCM_PulseSequenceName.
      Added comments on transfer syntax name changes.
      Updated Context Group classes for DICOM 2016e.
      Updated "dcmrt" classes based on DICOM 2016e.
      Check return value of fgets() to avoid warnings.
      Check return value of write() to avoid warning.
      Replaced boolean modes in convertCharacterSet().
      Added missing API documentation for Doxygen.
      Added tests for "new" Chinese characters sets.
      Added missing character sets to XML Schema.
      Added "Simplified Adult Echo SR" to ReportType.
      Added missing API documentation (Doxygen).
      Limit number of entries in optimization LUT.
      Added (missing) comments.
      Changed the way an unused parameter is treated.
      Fixed various documentation issues.
      Updated note on character set conversion options.
      Fixed source code formatting (where appropriate).
      Renamed isAvailable() and getVersionString().
      Added missing period at the end of descriptions.
      Fixed wrong check on GLIBC macro.
      Added comments on ICU conversions flags.
      Avoid compiler warning on unused parameter.
      Various minor fixes to new "dcm2json" tool.
      Further fixes to source code formatting.
      Removed unused configure variable/definition.
      Fixed incomplete renaming of command line options.
      Added a section on the rendering limitations.
      Let git ignore recently introduced dcm2json tool.
      Added Manpage of recently introduced dcm2json tool.
      Removed "dcmwlm/wwwapps" from ".gitignore".
      Added another character set test (for ISO-IR 58).
      Updated documentation regarding HT delimiter.
      Fixed issue with wrong detection of delimiters.
      Added another character set test (for ISO-IR 149).
      Removed DCMTK's implementation of tempnam().
      Do not set TCP send and receive buffer length.
      Updated latest tested CMake version.
      Fixed warnings reported by VisualStudio 2015.
      Replaced binary ("&") by boolean ("&&") AND.
      Fixed maximum number of bytes to read from stdin.
      Do not disable Nagle algorithm by default.
      Do not pass simple const parameters by reference.
      Simplified output of default option values.
      Minor corrections to documentation/comments.
      Added #warning on DONT_DISABLE_NAGLE_ALGORITHM.
      Made send() and recv() timeout configurable.
      Added new option --socket-timeout to storescu/scp.
      Fixed typos in API documentation.
      Added missing header include (without OpenSSL).
      Removed unused variable from writeJsonOpener().
      Included missing standard header "assert".
      Enhanced comments on charset to library mapping.
      Disable exception throwing in destructor.
      Replaced remaining tabs by spaces.
      Minor cleanup in dump output of TLS connections.
      Added missing brackets to "if( || )" statement.
      Pass value of correct type to "size" parameter.
      Changed type for index/number of sequence items.
      Added explicit typecast to function parameter.
      Removed obsolete macro (Windows 95 workaround).
      Removed gethostbyname from compatibility header.
      Added support for recently approved CP-1619.
      Made sure that a value is loaded before modified.
      Minor fixes for reasons of consistency.
      Use DCM_MaxReadLength as the default value.
      Removed useless "option block" for single option.
      Updated credits with regard to the Debian package.
      Removed obsolete command line options.
      Fixed bug introduced with last commit (crash).
      Fixed description of option --prefer-mpeg4-bd.
      Shortened description of MPEG xfer options.
      Added further support for Supplement 195 (HEVC).
      Check returned status of chooseRepresentation().
      Fixed typo in command line option check.
      Added support for unkown VR "??" in dump file.
      Fixed wrong indentation of new options.
      Fixed wrong name of Storage SOP Class.
      Added new sample association negotiation profile.
      Fixes for non-patient DICOM Storage Objects.
      Further fixes regarding non-patient objects.
      Cleanup of comments (retired DICOM SOP Classes).
      Further enhanced support for non-patient objects.
      Allow for sending non-patient DICOM objects.
      Fixed name numberOfAllDcmStorageSOPClassUIDs.
      Added two missing SOP Classes to modality table.
      Fixed crash while processing an invalid DICOMDIR.
      Enhanced logging in case of error.
      Various documentation fixes to newDicomElement().
      Updated copyright date after previous commit.
      Added trailing "." after first sentence (Doxygen).
      Added parentheses around boolean operations.
      Fixed typo, tab character and trailing space.
      Removed documentation of macro STRICT_COMPARE.
      Updated documentation of getOFDateTimeFromString().
      Updated documentation of getOFTimeFromString().
      Further fixes to API documentation.
      Added "Issuer of Patient ID" to documentation.
      Removed outdated comment on DB_FindAttr struct.
      Moved dcm2json tool to the top (alphabetic order).
      Fixed output of network debug information.
      Manual fixes to data dictionary (DICOM 2017a).
      Added comment on "specific character set" options.
      Removed redundant "TransferSyntax" suffix.
      Fixed wrong comment on private GE transfer syntax.
      Updated code definitions for "SRT".
      Updated the code meaning of a "UCUM" code.
      Fixed copyright date.
      Removed trailing spaces.
      Re-added call of endOptionBlock().
      Updated data dictionary for DICOM 2017a.
      Updated code definitions for DICOM 2017a.
      Updated "dcmrt" classes based on DICOM 2017a.
      Fixed indentation and removed trailing spaces.
      Added standard comments to new CMake files.
      Fixed warning reported by gcc 4.8.5 (Linux).
      Fixed warnings reported by gcc with "-Wshadow".
      Removed unused variable "checkAllStrings".
      Fixed warnings on unused parameters.
      Enhanced logging of interface class DSRDocument.
      Replaced spaces by tabs in comment header.
      Documented that --write-ow is now the default.
      Updated Manpage after --write-us has been added.
      Documented new default value of --data-files-path.
      Removed trailing spaces added by last commit.
      Fixed issue reading XML template identification.
      Fixed minor issues in manpage.
      Enhanced XSD definition of "DecimalString".
      Enhanced XSD definition of "UniqueIdentifier".
      Fixed timezone issue with setISOFormattedTime().
      Fixed API documentation of newDicomElement().
      Separated test for dcmGenerateUniqueIdentifier().
      Disabled check of VR for unsupported charsets.
      Added missing object file to Makefile (Autoconf).
      Fixed non-ASCII character (German umlaut).
      Updated latest tested CMake version.

Marco Eichelberg (58):
      Updated dcmsign to correctly compile with OpenSSL 1.1.0.
      Updated dcmtls and dcmpstat to compile with OpenSSL 1.1.0.
      Added code for handling VOI LUT Sequences with OB/OW VR.
      Added code for handling VOI LUT Sequences with OB/OW VR.
      Fixed minor formatting issues.
      Removed unnecessary call to getBaseTag().
      JPEG encoder now writes SOF1 marker in 8-bit ext sequential TS.
      Fixed empty pixel data bug in DcmPixelData::write().
      JPEG decoder now decompresses incomplete bitstreams.
      Improved 8/12/16 bit JPEG code consistency.
      Added legal remark concerning HP's JPEG-LS patents.
      movescu now returns non-zero if c-move was unsuccessful.
      Documented new movescu return codes in man page.
      Fixed signed/unsigned comparison in dcmqrdb module.
      Minor change needed to compile on Cygwin 2.6.0.
      Increased buffer sizes to avoid buffer overflows.
      Use fseek() instead of rewind() on Win32/Cygwin.
      Fixed integer underflow condition.
      Fixed DJDecoderRegistration::registerCodecs().
      Fixed minor integer over/undeflows reported by clang.
      Length check for DICOM implementation version name.
      Fixed responding aetitle in ASC_dumpParameters().
      Delete partially received DICOM objects after error.
      Replaced unlink() with OFStandard::deleteFile().
      Added partial support for GE private transfer syntax.
      Added support for GE private transfer syntax.
      Added support for writing GE private transfer syntax.
      Fixed warnings reported by VS 2017.
      Fixed linker warnings reported by VS 2017.
      OFMutex on Win32 now based on cricital sections.
      Updated macro documentation.
      Parser can now be stopped before a certain tag.
      Updated API documentation.
      Fixed bug introduced with commit f58cfe9.
      JPEG/JPEG-LS padding now uses extended EOI marker.
      Minor API change in dcmjpls.
      Fixed policy CMP0017 warning in CMake 3.7.2.
      Fixed warnings reported by VS 2017 x64.
      Fixed warnings reported by VS 2017 x64.
      Fixed warnings reported by VS 2017 x64.
      Fixed warnings reported by VS 2017 x64.
      Fixed DLL compilation of libcharls.
      Fixed bug in dcmsign certification validation code.
      Changed wlmscpfs default data path to current dir.
      dcmquant now by default generates OW LUT data.
      Fixed server socket options on WIN32.
      Explicitly include <winsock2.h> on Windows.
      DCMTK now uses SOCKET data type on Windows.
      Added timeout handler to DUL FSM state 5.
      Fixed conversion of OF/OD to OB in big endian.
      Updated COPYRIGHT file.
      Now setting LossyImageCompression when decompressing.
      Prevent infinite loop in DUL_AbortAssociation.
      Socket handle now always passed as 64-bit on Win32.
      getMacAddress() on Windows now uses GetAdaptersInfo.
      Fixed private tag issue with dump2dcm and xml2dcm.
      Updated Makefile.
      Updated CREDITS.

Michael Onken (36):
      Renamed min() to min2() (macro name clash).
      Avoid warning regarding hidden virtual method.
      Fixed installation of DCMTKConfigVersion.cmake.
      Better SCP timeouts, test, cleanups and more docs.
      Fixed various documentation issues.
      Avoid warnings about shadowed names.
      Fixed warnings about overloaded virtual functions.
      Fixed warning about unused parameter.
      Print conn. timeout to TRACE instead DEBUG level.
      Avoid another variable shadow warning.
      Fixed (harmless) shadowed variable
      Fixed potential NULL pointer and implicit casts.
      Added hints that memory has to be freed by caller.
      Added missing documentation.
      Fixed User Identification Negotiation ack message.
      Fixed minor documnetation issue.
      Fixed minor documentation issue.
      Report error in case of wrong Pixel Data encoding.
      Fixed parameter type, and docs.
      Fixed dcumentation one more time.
      Moved latest post-read checks to DcmDataset.
      Fixed crash in debug mode (const pointer misuse).
      Remove unused files from build system.
      Rebuilt dependencies.
      Hide public element constructors setting length.
      Fixed missing assignment from last commit.
      Added error message when writing sequences.
      Fixed wrong buffer size for sprintf.
      Allow private tags creation in newDicomElement().
      Fixed module name in documentation.
      Added support for final text CP-1619.
      Fix backslash quoting for Windows --fork mode.
      Check override keys in img2dcm library code.
      Warn if patient name may lead to broken dir name.
      Take over charset on import. Minor changes.
      Ensure SPS/RP Description/Code is never empty.

Nikolas Goldhammer (2):
      Fixed OFStandard::atof() not handling "NaN".
      Introduced OFerror_code and related functionalities.

OFFIS DICOM Team (1):
      Fixed typo in method name and API docs.

Sebastian Grallert (10):
      Fixed suppressing overflow warnings with Clang.
      Added support for the DICOM JSON Model (part 18 F).
      Added MPEG-4 transfer syntax options to several apps.
      Removed unused command line parameters from dcm2json.
      Fixed and enhanced documentation of JSON functions.
      Added command line options for HEVC/H.265.
      Small fix for HEVC/H.265 commit.
      Again, a small fix for HEVC/H.265 commit.
      Added unique section labels in DCMTK man pages.
      Fixed the encoding section in dcm2json man page.

Thorben Hasenpusch (1):
      Fixed OFSemaphore for macOS.