### PR TITLE
STYLE: Fixed dead link in about box

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1376,7 +1376,7 @@ QString qSlicerCoreApplication::acknowledgment()const
     "(NA-MIC), funded by the National Institutes of Health through the NIH "
     "Roadmap for Medical Research, Grant U54 EB005149. Information on the "
     "National Centers for Biomedical Computing can be obtained from "
-    "<a href=\"http://nihroadmap.nih.gov/bioinformatics\">http://nihroadmap.nih.gov/bioinformatics</a>.<br /><br />");
+    "<a href=\"https://commonfund.nih.gov/bioinformatics">https://commonfund.nih.gov/bioinformatics</a>.<br /><br />");
   return acknowledgmentText;
 }
 


### PR DESCRIPTION
Changed link from http://nihroadmap.nih.gov/bioinformatics to https://commonfund.nih.gov/bioinformatics