### PR TITLE
Fix command line extension wizard issues

### DIFF
--- a/Utilities/Scripts/CMakeLists.txt
+++ b/Utilities/Scripts/CMakeLists.txt
@@ -12,12 +12,6 @@ if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT AND Slicer_USE_PYTHONQT)
       )
   endif()
 
-  if(WIN32)
-    set(EXPORT_GIT_PYTHON_GIT_EXECUTABLE_CONFIG
-"\# Export path to git executable provided by Git Bash
-export GIT_PYTHON_GIT_EXECUTABLE=/bin/git")
-  endif()
-
   # Configure and Extension Wizard launcher scripts
   configure_file(
     slicerExtensionWizard.sh.in

--- a/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
@@ -237,9 +237,9 @@ class ExtensionWizard(object):
 
       branch = r.active_branch
       if branch.name != "master":
-        logging.warning("You are currently on the '%s' branch." % branch,
+        logging.warning("You are currently on the '%s' branch. "
                         "It is strongly recommended to publish"
-                        " the 'master' branch.")
+                        " the 'master' branch." % branch)
         if not inquire("Continue anyway"):
           die("canceled at user request")
 


### PR DESCRIPTION
Fix issues using the command line extension wizard on Windows found when checking the status of http://na-mic.org/Mantis/view.php?id=4182.

Note that the AttributeError and path interpretation problems discussed in the bug are no longer issues with the latest Slicer and Git for Windows that reports the following version:

    $ git --version
    git version 2.12.2.windows.2