### PR TITLE
BUG: Update extension buildsystem to handle source dir without vcs

### DIFF
--- a/CMake/SlicerMacroExtractRepositoryInfo.cmake
+++ b/CMake/SlicerMacroExtractRepositoryInfo.cmake
@@ -50,6 +50,10 @@
 #  <var-prefix>_WC_LAST_CHANGED_REV - revision of last commit
 #  <var-prefix>_WC_INFO
 #
+# If source directory is not a SVN, GIT or CVS, the macro will return early
+# displaying an warning message:
+#
+#   -- Skipping repository info extraction: directory [/path/to/src] is not a GIT, SVN or CVS checkout
 
 macro(SlicerMacroExtractRepositoryInfo)
   include(CMakeParseArguments)
@@ -83,6 +87,13 @@ macro(SlicerMacroExtractRepositoryInfo)
   # Clear GIT specific variables
   set(${wc_info_prefix}_WC_REVISION_NAME "NA")
   set(${wc_info_prefix}_WC_REVISION_HASH "NA")
+
+  if(NOT EXISTS ${MY_SOURCE_DIR}/.git
+      AND NOT EXISTS ${MY_SOURCE_DIR}/.svn
+      AND NOT EXISTS ${MY_SOURCE_DIR}/CVS)
+    message(AUTHOR_WARNING "Skipping repository info extraction: directory [${MY_SOURCE_DIR}] is not a GIT, SVN or CVS checkout")
+    return()
+  endif()
 
   find_package(Git REQUIRED)
 

--- a/Extensions/CMake/SlicerBlockUploadExtension.cmake
+++ b/Extensions/CMake/SlicerBlockUploadExtension.cmake
@@ -31,7 +31,9 @@ set(expected_existing_vars
   Slicer_CMAKE_DIR
   Slicer_DIR
   Slicer_EXTENSIONS_CMAKE_DIR
-  Subversion_SVN_EXECUTABLE
+  # Since new extension generated from the SuperBuild template
+  # do not require SVN, we do not require it.
+  # Subversion_SVN_EXECUTABLE
   )
 foreach(var ${expected_existing_vars})
   if(NOT EXISTS "${${var}}")


### PR DESCRIPTION
This commit prevents extension generated using the wizard but not yet
associated with a source control system from failing to build with a
message like:

```
  -- Could NOT find Subversion (missing:  Subversion_SVN_EXECUTABLE)
  CMake Error at /path/to/Slicer/Extensions/CMake/SlicerBlockUploadExtension.cmake:38 (message):
    Variable Subversion_SVN_EXECUTABLE is set to an inexistent directory or
    file ! []
  Call Stack (most recent call first):
    /path/to/Slicer/Extensions/CMake/SlicerEnableExtensionTesting.cmake:23 (include)
    /path/to/Slicer-Release/Slicer-build/UseSlicer.cmake:421 (include)
    CMakeLists.txt:21 (include)
```

If an extension named Foo is not yet associated with a repository is
built, the following author warning is now reported:

```
  -- Configuring Scripted module: bar
  CMake Warning (dev) at /path/to/Slicer/CMake/SlicerMacroExtractRepositoryInfo.cmake:94 (message):
    Skipping repository info extraction: directory [/path/to/Foo] is not a GIT, SVN
    or CVS checkout
  Call Stack (most recent call first):
    /path/to/Slicer/CMake/SlicerExtensionCPack.cmake:55 (SlicerMacroExtractRepositoryInfo)
    CMakeLists.txt:45 (include)
  This warning is for project developers.  Use -Wno-dev to suppress it.

  -- Configuring done
  -- Generating done
  -- Build files have been written to: /path/to/Foo-build/inner-build
```

Reported-by: Matt McCormick <matt.mccormick@kitware.com>