### PR TITLE
ENH: Allow disabling slice view interactions

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.h
@@ -77,15 +77,31 @@ public:
   enum
     {
     None = 0,
-    Translate,
-    Zoom,
-    Rotate, /* Rotate not currently used */
-    Blend, /* fg to bg, labelmap to bg */
-    AdjustWindowLevelBackground,
-    AdjustWindowLevelForeground
+    Translate = 1,
+    Zoom = 2,
+    Rotate = 4, /* Rotate not currently used */
+    Blend = 8, /* fg to bg, labelmap to bg */
+    AdjustWindowLevelBackground = 16,
+    AdjustWindowLevelForeground = 32,
+    BrowseSlice = 64,
+    ShowSlice = 128,
+    AdjustLightbox = 256,
+    SelectVolume = 512,
+    SetCursorPosition = 1024, /* adjust cursor position in crosshair node as mouse is moved */
+    AllActionsMask = Translate | Zoom | Rotate | Blend | AdjustWindowLevelBackground | AdjustWindowLevelForeground
+      | BrowseSlice | ShowSlice | AdjustLightbox | SelectVolume | SetCursorPosition
     };
   vtkGetMacro(ActionState, int);
   vtkSetMacro(ActionState, int);
+
+  /// Enable/disable the specified action (Translate, Zoom, Blend, etc.).
+  /// Multiple actions can be specifed by providing the sum of action ids.
+  /// Set the value to AllActionsMask to enable/disable all actions.
+  /// All actions are enabled by default.
+  void SetActionEnabled(int actionsMask, bool enable = true);
+  /// Returns true if the specified action is allowed.
+  /// If multiple actions are specified, the return value is true if all actions are enabled.
+  bool GetActionEnabled(int actionsMask);
 
   /// Helper routines
 
@@ -153,6 +169,8 @@ protected:
   bool IsMouseInsideVolume(bool background);
 
   int ActionState;
+  int ActionsEnabled;
+
   int StartActionEventPosition[2];
   double StartActionFOV[3];
   double VolumeScalarRange[2];

--- a/Libs/MRML/Widgets/qMRMLSliceView.h
+++ b/Libs/MRML/Widgets/qMRMLSliceView.h
@@ -59,7 +59,7 @@ public:
   /// vtkMRMLVolumeGlyphSliceDisplayableManager and
   /// vtkMRMLCrosshairDisplayableManager are registered.
   /// \sa getDisplayableManagers
-  void addDisplayableManager(const QString& displayableManager);
+  Q_INVOKABLE void addDisplayableManager(const QString& displayableManager);
   /// Get the displayable managers registered in this view
   /// \sa addDisplayableManager
   Q_INVOKABLE void getDisplayableManagers(vtkCollection *displayableManagers);
@@ -68,7 +68,7 @@ public:
   Q_INVOKABLE vtkMRMLSliceNode* mrmlSliceNode()const;
 
   /// Returns the interactor style of the view
-  vtkSliceViewInteractorStyle* sliceViewInteractorStyle()const;
+  Q_INVOKABLE vtkSliceViewInteractorStyle* sliceViewInteractorStyle()const;
 
   /// Convert device coordinates to XYZ coordinates. The x and y
   /// components of the return value are the positions within a


### PR DESCRIPTION
For interventional applications it is often necessary to **prevent the user from manipulating a slice view** (change selected slice, adjust window width/level, etc).

SetActionEnabled/GetActionEnabled methods have been added to specify which actions are allowed in a slice view (default behavior is the same as before: all actions are allowed).

Example:
```
interactorStyle = slicer.app.layoutManager().sliceWidget('Red').sliceView().sliceViewInteractorStyle()
interactorStyle.SetActionEnabled(interactorStyle.BrowseSlice, False)
```