### PR TITLE
BUG: Update Volume loading logic to consider default nodes properties

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1250,7 +1250,8 @@ vtkMRMLNode* vtkMRMLScene::AddNode(vtkMRMLNode *n)
 }
 
 //------------------------------------------------------------------------------
-vtkMRMLNode* vtkMRMLScene::AddNewNodeByClass(std::string className, std::string nodeName)
+vtkMRMLNode* vtkMRMLScene::AddNewNodeByClass(
+    std::string className, std::string nodeBaseName /* = "" */)
 {
   if (className.empty())
     {
@@ -1259,9 +1260,9 @@ vtkMRMLNode* vtkMRMLScene::AddNewNodeByClass(std::string className, std::string 
     }
   vtkSmartPointer<vtkMRMLNode> nodeToAdd =
       vtkSmartPointer<vtkMRMLNode>::Take(this->CreateNodeByClass(className.c_str()));
-  if (!nodeName.empty())
+  if (!nodeBaseName.empty())
     {
-    nodeToAdd->SetName(nodeName.c_str());
+    nodeToAdd->SetName(nodeBaseName.c_str());
     }
   return this->AddNode(nodeToAdd);
 }

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1250,6 +1250,23 @@ vtkMRMLNode* vtkMRMLScene::AddNode(vtkMRMLNode *n)
 }
 
 //------------------------------------------------------------------------------
+vtkMRMLNode* vtkMRMLScene::AddNewNodeByClass(std::string className, std::string nodeName)
+{
+  if (className.empty())
+    {
+    vtkErrorMacro("AddNewNodeByClass: className is an emptry string");
+    return NULL;
+    }
+  vtkSmartPointer<vtkMRMLNode> nodeToAdd =
+      vtkSmartPointer<vtkMRMLNode>::Take(this->CreateNodeByClass(className.c_str()));
+  if (!nodeName.empty())
+    {
+    nodeToAdd->SetName(nodeName.c_str());
+    }
+  return this->AddNode(nodeToAdd);
+}
+
+//------------------------------------------------------------------------------
 void vtkMRMLScene::NodeAdded(vtkMRMLNode *n)
 {
   this->InvokeEvent(this->NodeAddedEvent, n);

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -178,12 +178,16 @@ public:
   /// the scene. It ensures that the new node properties are initialized
   /// considering its default nodes.
   ///
-  /// The method calls CreateNodeByClass(), AddNode() and vtkMRMLNode::SetName().
+  /// The method calls CreateNodeByClass(), vtkMRMLNode::SetName() and AddNode().
   ///
-  /// \sa CreateNodeByClass()
-  /// \sa AddDefaultNode(vtkMRMLNode*)
-  /// \sa AddNode()
-  vtkMRMLNode* AddNewNodeByClass(std::string className, std::string nodeName = "");
+  /// \note Instead of calling SetName() after creating the node, prefer
+  /// passing \a nodeBaseName, indeed the method AddNode() ensures that the
+  /// final node name is unique by appending a suffix.
+  ///
+  /// \sa CreateNodeByClass(), vtkMRMLNode::SetName(), AddNode()
+  /// \sa AddDefaultNode()
+  /// \sa GenerateUniqueName()
+  vtkMRMLNode* AddNewNodeByClass(std::string className, std::string nodeBaseName = "");
 
   /// Add a copy of a node to the scene.
   vtkMRMLNode* CopyNode(vtkMRMLNode *n);

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -99,7 +99,17 @@ public:
   /// Reset all nodes to their constructor's state
   void ResetNodes();
 
-  /// Create node with a given class
+  /// \brief Create node with a given class
+  ///
+  /// This method ensures the new node properties are
+  /// initialized using the associated default node if any.
+  ///
+  /// \note A default node is associated with an other node if
+  /// it belongs to the class hierarchy of that node.
+  ///
+  /// \warning This method does NOT add the new node to the scene.
+  ///
+  /// \sa AddDefaultNode()
   vtkMRMLNode* CreateNodeByClass(const char* className);
 
   /// \brief Register a node class to the scene so that the scene can later
@@ -161,6 +171,19 @@ public:
   /// added but its properties are copied (c.f. vtkMRMLNode::CopyWithScene())
   /// into the already existing singleton node. That node is then returned.
   vtkMRMLNode* AddNode(vtkMRMLNode *nodeToAdd);
+
+  /// \brief Instantiate and add a node to the scene.
+  ///
+  /// This is the preferred way to create and add a new node to
+  /// the scene. It ensures that the new node properties are initialized
+  /// considering its default nodes.
+  ///
+  /// The method calls CreateNodeByClass(), AddNode() and vtkMRMLNode::SetName().
+  ///
+  /// \sa CreateNodeByClass()
+  /// \sa AddDefaultNode(vtkMRMLNode*)
+  /// \sa AddNode()
+  vtkMRMLNode* AddNewNodeByClass(std::string className, std::string nodeName = "");
 
   /// Add a copy of a node to the scene.
   vtkMRMLNode* CopyNode(vtkMRMLNode *n);

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -408,11 +408,11 @@ ArchetypeVolumeNodeSet LabelMapVolumeNodeSetFactory(std::string& volumeName, vtk
   vtkNew<vtkMRMLLabelMapVolumeNode> scalarNode;
   scalarNode->SetName(volumeName.c_str());
   nodeSet.Scene->AddNode(scalarNode.GetPointer());
-
-  vtkNew<vtkMRMLLabelMapVolumeDisplayNode> lmdisplayNode;
-  nodeSet.Scene->AddNode(lmdisplayNode.GetPointer());
+  vtkSmartPointer<vtkMRMLLabelMapVolumeDisplayNode> lmdisplayNode =
+    vtkSmartPointer<vtkMRMLLabelMapVolumeDisplayNode>::Take(
+       vtkMRMLLabelMapVolumeDisplayNode::SafeDownCast(nodeSet.Scene->CreateNodeByClass("vtkMRMLLabelMapVolumeDisplayNode")));
+  nodeSet.Scene->AddNode(lmdisplayNode);
   scalarNode->SetAndObserveDisplayNodeID(lmdisplayNode->GetID());
-
   vtkNew<vtkMRMLVolumeArchetypeStorageNode> storageNode;
   storageNode->SetCenterImage(options & vtkSlicerVolumesLogic::CenterImage);
   storageNode->SetUseOrientationFromFile(!((options & vtkSlicerVolumesLogic::DiscardOrientation) != 0));
@@ -421,7 +421,7 @@ ArchetypeVolumeNodeSet LabelMapVolumeNodeSetFactory(std::string& volumeName, vtk
   scalarNode->SetAndObserveStorageNodeID(storageNode->GetID());
 
   nodeSet.StorageNode = storageNode.GetPointer();
-  nodeSet.DisplayNode = lmdisplayNode.GetPointer();
+  nodeSet.DisplayNode = lmdisplayNode;
   nodeSet.Node = scalarNode.GetPointer();
 
   nodeSet.LabelMap = true;
@@ -658,6 +658,8 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
 
   // set up a mini scene to avoid adding and removing nodes from the main scene
   vtkNew<vtkMRMLScene> testScene;
+  // associate default nodes with mini scene
+  this->GetMRMLScene()->CopyDefaultNodesToScene(testScene.GetPointer());
   // set it up for remote io, the constructor creates a cache and data io manager
   vtkSmartPointer<vtkMRMLRemoteIOLogic> remoteIOLogic;
   remoteIOLogic = vtkSmartPointer<vtkMRMLRemoteIOLogic>::New();

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -291,22 +291,24 @@ ArchetypeVolumeNodeSet DiffusionWeightedVolumeNodeSetFactory(std::string& volume
   ArchetypeVolumeNodeSet nodeSet(scene);
 
   // set up the dwi node's support nodes
-  vtkNew<vtkMRMLDiffusionWeightedVolumeDisplayNode> dwdisplayNode;
-  nodeSet.Scene->AddNode(dwdisplayNode.GetPointer());
+  vtkMRMLDiffusionWeightedVolumeDisplayNode* dwdisplayNode =
+      vtkMRMLDiffusionWeightedVolumeDisplayNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLDiffusionWeightedVolumeDisplayNode"));
 
-  vtkNew<vtkMRMLDiffusionWeightedVolumeNode> dwiNode;
-  dwiNode->SetName(volumeName.c_str());
-  nodeSet.Scene->AddNode(dwiNode.GetPointer());
+  vtkMRMLDiffusionWeightedVolumeNode* dwiNode =
+      vtkMRMLDiffusionWeightedVolumeNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLDiffusionWeightedVolumeNode", volumeName));
   dwiNode->SetAndObserveDisplayNodeID(dwdisplayNode->GetID());
 
-  vtkNew<vtkMRMLNRRDStorageNode> storageNode;
+  vtkMRMLNRRDStorageNode* storageNode =
+      vtkMRMLNRRDStorageNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLNRRDStorageNode"));
   storageNode->SetCenterImage(options & vtkSlicerVolumesLogic::CenterImage);
-  nodeSet.Scene->AddNode(storageNode.GetPointer());
   dwiNode->SetAndObserveStorageNodeID(storageNode->GetID());
 
-  nodeSet.StorageNode = storageNode.GetPointer();
-  nodeSet.DisplayNode = dwdisplayNode.GetPointer();
-  nodeSet.Node = dwiNode.GetPointer();
+  nodeSet.StorageNode = storageNode;
+  nodeSet.DisplayNode = dwdisplayNode;
+  nodeSet.Node = dwiNode;
 
   return nodeSet;
 }
@@ -317,30 +319,37 @@ ArchetypeVolumeNodeSet DiffusionTensorVolumeNodeSetFactory(std::string& volumeNa
   ArchetypeVolumeNodeSet nodeSet(scene);
 
   // set up the tensor node's support nodes
-  vtkNew<vtkMRMLDiffusionTensorVolumeDisplayNode> dtdisplayNode;
+  vtkMRMLDiffusionTensorVolumeDisplayNode* dtdisplayNode =
+      vtkMRMLDiffusionTensorVolumeDisplayNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLDiffusionTensorVolumeDisplayNode"));
   // jvm - are these the default settings anyway?
+  int wasModifying = dtdisplayNode->StartModify();
   dtdisplayNode->SetWindow(0);
   dtdisplayNode->SetLevel(0);
   dtdisplayNode->SetUpperThreshold(0);
   dtdisplayNode->SetLowerThreshold(0);
   dtdisplayNode->SetAutoWindowLevel(1);
-  nodeSet.Scene->AddNode(dtdisplayNode.GetPointer());
+  dtdisplayNode->EndModify(wasModifying);
 
-  vtkNew<vtkMRMLDiffusionTensorVolumeNode> tensorNode;
-  tensorNode->SetName(volumeName.c_str());
-  nodeSet.Scene->AddNode(tensorNode.GetPointer());
+  vtkMRMLDiffusionTensorVolumeNode* tensorNode =
+      vtkMRMLDiffusionTensorVolumeNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLDiffusionTensorVolumeNode", volumeName));
   tensorNode->SetAndObserveDisplayNodeID(dtdisplayNode->GetID());
 
-  vtkNew<vtkMRMLVolumeArchetypeStorageNode> storageNode;
+  vtkMRMLVolumeArchetypeStorageNode* storageNode =
+      vtkMRMLVolumeArchetypeStorageNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLVolumeArchetypeStorageNode"));
+  wasModifying = storageNode->StartModify();
   storageNode->SetCenterImage(options & vtkSlicerVolumesLogic::CenterImage);
   storageNode->SetUseOrientationFromFile(!((options & vtkSlicerVolumesLogic::DiscardOrientation) != 0));
   storageNode->SetSingleFile(options & vtkSlicerVolumesLogic::SingleFile);
-  nodeSet.Scene->AddNode(storageNode.GetPointer());
+  storageNode->EndModify(wasModifying);
+
   tensorNode->SetAndObserveStorageNodeID(storageNode->GetID());
 
-  nodeSet.StorageNode = storageNode.GetPointer();
-  nodeSet.DisplayNode = dtdisplayNode.GetPointer();
-  nodeSet.Node = tensorNode.GetPointer();
+  nodeSet.StorageNode = storageNode;
+  nodeSet.DisplayNode = dtdisplayNode;
+  nodeSet.Node = tensorNode;
 
   return nodeSet;
 }
@@ -351,22 +360,24 @@ ArchetypeVolumeNodeSet NRRDVectorVolumeNodeSetFactory(std::string& volumeName, v
   ArchetypeVolumeNodeSet nodeSet(scene);
 
   // set up the vector node's support nodes
-  vtkNew<vtkMRMLVectorVolumeDisplayNode> vdisplayNode;
-  nodeSet.Scene->AddNode(vdisplayNode.GetPointer());
+  vtkMRMLVectorVolumeDisplayNode* vdisplayNode =
+      vtkMRMLVectorVolumeDisplayNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLVectorVolumeDisplayNode"));
 
-  vtkNew<vtkMRMLVectorVolumeNode> vectorNode;
-  vectorNode->SetName(volumeName.c_str());
-  nodeSet.Scene->AddNode(vectorNode.GetPointer());
+  vtkMRMLVectorVolumeNode* vectorNode =
+      vtkMRMLVectorVolumeNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLVectorVolumeNode", volumeName));
   vectorNode->SetAndObserveDisplayNodeID(vdisplayNode->GetID());
 
-  vtkNew<vtkMRMLNRRDStorageNode> storageNode;
+  vtkMRMLNRRDStorageNode* storageNode =
+      vtkMRMLNRRDStorageNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLNRRDStorageNode"));
   storageNode->SetCenterImage(options & vtkSlicerVolumesLogic::CenterImage);
-  nodeSet.Scene->AddNode(storageNode.GetPointer());
   vectorNode->SetAndObserveStorageNodeID(storageNode->GetID());
 
-  nodeSet.StorageNode = storageNode.GetPointer();
-  nodeSet.DisplayNode = vdisplayNode.GetPointer();
-  nodeSet.Node = vectorNode.GetPointer();
+  nodeSet.StorageNode = storageNode;
+  nodeSet.DisplayNode = vdisplayNode;
+  nodeSet.Node = vectorNode;
 
   return nodeSet;
 }
@@ -377,24 +388,28 @@ ArchetypeVolumeNodeSet ArchetypeVectorVolumeNodeSetFactory(std::string& volumeNa
   ArchetypeVolumeNodeSet nodeSet(scene);
 
   // set up the vector node's support nodes
-  vtkNew<vtkMRMLVectorVolumeDisplayNode> vdisplayNode;
-  nodeSet.Scene->AddNode(vdisplayNode.GetPointer());
+  vtkMRMLVectorVolumeDisplayNode* vdisplayNode =
+      vtkMRMLVectorVolumeDisplayNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLVectorVolumeDisplayNode"));
 
-  vtkNew<vtkMRMLVectorVolumeNode> vectorNode;
-  vectorNode->SetName(volumeName.c_str());
-  nodeSet.Scene->AddNode(vectorNode.GetPointer());
+  vtkMRMLVectorVolumeNode* vectorNode =
+      vtkMRMLVectorVolumeNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLVectorVolumeNode", volumeName));
   vectorNode->SetAndObserveDisplayNodeID(vdisplayNode->GetID());
 
-  vtkNew<vtkMRMLVolumeArchetypeStorageNode> storageNode;
+  vtkMRMLVolumeArchetypeStorageNode* storageNode =
+      vtkMRMLVolumeArchetypeStorageNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLVolumeArchetypeStorageNode"));
+  int wasModifying = storageNode->StartModify();
   storageNode->SetCenterImage(options & vtkSlicerVolumesLogic::CenterImage);
   storageNode->SetUseOrientationFromFile(!((options & vtkSlicerVolumesLogic::DiscardOrientation) != 0));
   storageNode->SetSingleFile(options & vtkSlicerVolumesLogic::SingleFile);
-  nodeSet.Scene->AddNode(storageNode.GetPointer());
+  storageNode->EndModify(wasModifying);
   vectorNode->SetAndObserveStorageNodeID(storageNode->GetID());
 
-  nodeSet.StorageNode = storageNode.GetPointer();
-  nodeSet.DisplayNode = vdisplayNode.GetPointer();
-  nodeSet.Node = vectorNode.GetPointer();
+  nodeSet.StorageNode = storageNode;
+  nodeSet.DisplayNode = vdisplayNode;
+  nodeSet.Node = vectorNode;
 
   return nodeSet;
 }
@@ -405,24 +420,28 @@ ArchetypeVolumeNodeSet LabelMapVolumeNodeSetFactory(std::string& volumeName, vtk
   ArchetypeVolumeNodeSet nodeSet(scene);
 
   // set up the scalar node's support nodes
-  vtkNew<vtkMRMLLabelMapVolumeNode> scalarNode;
-  scalarNode->SetName(volumeName.c_str());
-  nodeSet.Scene->AddNode(scalarNode.GetPointer());
-  vtkSmartPointer<vtkMRMLLabelMapVolumeDisplayNode> lmdisplayNode =
-    vtkSmartPointer<vtkMRMLLabelMapVolumeDisplayNode>::Take(
-       vtkMRMLLabelMapVolumeDisplayNode::SafeDownCast(nodeSet.Scene->CreateNodeByClass("vtkMRMLLabelMapVolumeDisplayNode")));
-  nodeSet.Scene->AddNode(lmdisplayNode);
+  vtkMRMLLabelMapVolumeDisplayNode* lmdisplayNode =
+      vtkMRMLLabelMapVolumeDisplayNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLLabelMapVolumeDisplayNode"));
+
+  vtkMRMLLabelMapVolumeNode* scalarNode =
+      vtkMRMLLabelMapVolumeNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLLabelMapVolumeNode", volumeName));
   scalarNode->SetAndObserveDisplayNodeID(lmdisplayNode->GetID());
-  vtkNew<vtkMRMLVolumeArchetypeStorageNode> storageNode;
+
+  vtkMRMLVolumeArchetypeStorageNode* storageNode =
+      vtkMRMLVolumeArchetypeStorageNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLVolumeArchetypeStorageNode"));
+  int wasModifying = storageNode->StartModify();
   storageNode->SetCenterImage(options & vtkSlicerVolumesLogic::CenterImage);
   storageNode->SetUseOrientationFromFile(!((options & vtkSlicerVolumesLogic::DiscardOrientation) != 0));
   storageNode->SetSingleFile(options & vtkSlicerVolumesLogic::SingleFile);
-  nodeSet.Scene->AddNode(storageNode.GetPointer());
+  storageNode->EndModify(wasModifying);
   scalarNode->SetAndObserveStorageNodeID(storageNode->GetID());
 
-  nodeSet.StorageNode = storageNode.GetPointer();
+  nodeSet.StorageNode = storageNode;
   nodeSet.DisplayNode = lmdisplayNode;
-  nodeSet.Node = scalarNode.GetPointer();
+  nodeSet.Node = scalarNode;
 
   nodeSet.LabelMap = true;
 
@@ -435,24 +454,28 @@ ArchetypeVolumeNodeSet ScalarVolumeNodeSetFactory(std::string& volumeName, vtkMR
   ArchetypeVolumeNodeSet nodeSet(scene);
 
   // set up the scalar node's support nodes
-  vtkNew<vtkMRMLScalarVolumeNode> scalarNode;
-  scalarNode->SetName(volumeName.c_str());
-  nodeSet.Scene->AddNode(scalarNode.GetPointer());
+  vtkMRMLScalarVolumeDisplayNode* sdisplayNode =
+      vtkMRMLScalarVolumeDisplayNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLScalarVolumeDisplayNode"));
 
-  vtkNew<vtkMRMLScalarVolumeDisplayNode> sdisplayNode;
-  nodeSet.Scene->AddNode(sdisplayNode.GetPointer());
+  vtkMRMLScalarVolumeNode* scalarNode =
+      vtkMRMLScalarVolumeNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLScalarVolumeNode", volumeName));
   scalarNode->SetAndObserveDisplayNodeID(sdisplayNode->GetID());
 
-  vtkNew<vtkMRMLVolumeArchetypeStorageNode> storageNode;
+  vtkMRMLVolumeArchetypeStorageNode* storageNode =
+      vtkMRMLVolumeArchetypeStorageNode::SafeDownCast(
+        nodeSet.Scene->AddNewNodeByClass("vtkMRMLVolumeArchetypeStorageNode"));
+  int wasModifying = storageNode->StartModify();
   storageNode->SetCenterImage(options & vtkSlicerVolumesLogic::CenterImage);
   storageNode->SetUseOrientationFromFile(!((options & vtkSlicerVolumesLogic::DiscardOrientation) != 0));
   storageNode->SetSingleFile(options & vtkSlicerVolumesLogic::SingleFile);
-  nodeSet.Scene->AddNode(storageNode.GetPointer());
+  storageNode->EndModify(wasModifying);
   scalarNode->SetAndObserveStorageNodeID(storageNode->GetID());
 
-  nodeSet.StorageNode = storageNode.GetPointer();
-  nodeSet.DisplayNode = sdisplayNode.GetPointer();
-  nodeSet.Node = scalarNode.GetPointer();
+  nodeSet.StorageNode = storageNode;
+  nodeSet.DisplayNode = sdisplayNode;
+  nodeSet.Node = scalarNode;
 
   return nodeSet;
 }

--- a/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
@@ -82,6 +82,18 @@ int vtkSlicerVolumesLogicTest1( int argc, char * argv[] )
 
   vtkMRMLLabelMapVolumeNode * labelMapVolume = TestLabelMapVolumeLoading(volumeName, logic.GetPointer());
   CHECK_NOT_NULL(labelMapVolume);
+  CHECK_INT(labelMapVolume->GetDisplayNode()->GetSliceIntersectionThickness(), 3);
+
+  // Add default node
+  vtkNew<vtkMRMLLabelMapVolumeDisplayNode> defaultDisplayNode;
+  defaultDisplayNode->SetSliceIntersectionThickness(1);
+  scene->AddDefaultNode(defaultDisplayNode.GetPointer());
+
+  // Check that node attribute is initialized considering the default node
+  labelMapVolume = TestLabelMapVolumeLoading(volumeName, logic.GetPointer());
+    CHECK_NOT_NULL(labelMapVolume);
+    CHECK_INT(labelMapVolume->GetDisplayNode()->GetSliceIntersectionThickness(), 1);
+
 
   CHECK_EXIT_SUCCESS(TestCheckForLabelVolumeValidity(scalarVolume, labelMapVolume, logic.GetPointer()));
 


### PR DESCRIPTION
This commit enables customization of the LabelMapVolumeDisplayNode
attributes by ensuring the custom properties set on the corresponding
default node are effectively re-used.