### PR TITLE
ENH: Update ITK to 4.12.0rc1

### DIFF
--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -35,14 +35,11 @@ if(NOT DEFINED ITK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
     QUIET
     )
 
-  # ITK release v4.11.0 from 2017.01.22 with
+  # ITK release v4.12.0rc1 from 2017.05.09 with
   # * Slicer patches for CMP0042
-  # * Revert "BUG: Binary include directory added only if enabled shared" (ITK-3529)
-  # * Revert "BUG: Include installed modules in ITK_MODULES_ENABLED" (ITK-3529)
-  # * COMP: Add missing headers in OpenCVImageBridge
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "1619816e48b327c4c486b76aef0c229af65b92b2" # slicer-v4.11.0-2017-01-22
+    "9c91cb64e76634fe2c58e0b40f316af953fb4e61" # slicer-v4.12.0-2017-05-09-2d63918
     QUIET
     )
 


### PR DESCRIPTION
```
$ git shortlog 1619816..9c91cb6 --no-merges
Ben Boeckel (1):
      ENH: Add a script to help update third-party sources

Brad King (5):
      ENH: Update KWIML import script for new upstream URL
      ENH: Teach update-third-party.bash to add a Change-Id
      ENH: Port KWSys update script to update-third-party.bash
      ENH: KWSys: Filter out unused attributes during import
      ENH: KWSys: Apply attribute changes made upstream

Bradley Lowekamp (19):
      COMP: Enable hidden visibility property with NIFTI static libraries
      COMP: Enable hidden visibility property with GIFTI static libraries
      BUG: Correct variable name used to check CXX version
      BUG: Correct variable name used to check CXX version
      COMP: Enable hidden visibility property with NIFTI static libraries
      COMP: Enable hidden visibility property with GIFTI static libraries
      BUG: Initialize ConvergenceValue in constructor
      BUG: Initialize ConvergenceValue in constructor
      ENH: Update CircleCi script to download latest binary tar-ball
      BUG: Use CMAKE_DL_LIBS instead of explict "dl" library
      COMP: Fix CircleCI ITK data download file name
      ENH: Update CircleCI yaml file
      BUG: Apply changes from MetaIO upstream to remove static variables
      ENH: Update SWIG version to 3.0.12
      ENH: Update PCRE version to 8.40
      ENH: Add OrientedBoudingBox attributes to ShapeLabelMap
      COMP: Use std::abs over vnl_math_abs
      BUG: Initialize image data to 0
      ENH: Fix clearing build tree error

David T. Chen (1):
      BUG: Fixed quote style

Dženan Zukić (3):
      STYLE: Simplify code by using TestingMacros
      BUG: fixing wrong check for argument count
      ENH: Add Strain as a remote module

Floris Berendsen (2):
      COMP: Added missing png_get_uint_31 name mangling
      COMP: Added missing png_get_uint_31 name mangling

Francois Budin (58):
      STYLE: Typo corrections in itk*TopHatImageFilter.h
      ENH: Prefer std::atomic over compiler specific implementation
      BUG: Addresses 'ordered comparison between pointer and zero' error (clang-4)
      BUG: Addresses InDoxygenGroup Test with Python 3.6 failures
      BUG: BSplineScatteredDataPointSetToImageFilter output image is not generated
      BUG: itk::RGBPixel<unsigned short> needs to be wrapped for itkTIFFImageIO
      BUG: Usage of std::atomic was incorrectly used in itk::Detail::AtomicOps
      ENH: Exposing functions to set real and imaginary part of complex numbers
      BUG: ITK_OVERRIDE  keyword for non-overriden funtion
      BUG: 'typename' cannot be used outside of template declaration
      BUG: Missing ITK_OVERRIDE
      BUG: ITK_OVERRIDE  keyword for non-overriden funtion
      BUG: ITK_OVERRIDE  keyword for non-overriden funtion
      BUG: ITK_OVERRIDE  keyword for non-overriden funtion
      BUG: Missing ITK_OVERRIDE
      ENH: Improving usability in IPython
      ENH: Update BridgeNumPy to most recent version (2017.02.24)
      BUG: 3523 Even padding most value representations with space instead of '\0'
      BUG: Remove extra space in chronometer command
      DOC: Make it more explicit that 'push' authorization is not for everybody
      BUG: 3523 Even padding most value representations with space instead of '\0'
      BUG: 3519 KernelTransform WMatrix initialization
      BUG: KWSys symbols should not be exported with WINDOWS_EXPORT_ALL_SYMBOLS
      COMP: Do not expose functions to set real and img part of complex numbers
      BUG: KWSys symbols should not be exported with WINDOWS_EXPORT_ALL_SYMBOLS
      BUG: 3519 KernelTransform WMatrix initialization
      DOC: Typo in itkNumberToString.h
      BUG: Attribute names cannot start with a digit
      BUG: Do not define deprecated function if ITK_LEGACY_REMOVE is selected
      BUG: Wrap EllipseSpatialObject std::list in Python
      ENH: Wrap itkN4BiasFieldCorrectionImageFilter in Python
      BUG: itkStatisticsAlgorithmTest throwing exception on VS2015Update3 and VS2017
      ENH: Skip generating export headers if module does not contain a target
      BUG: Wrapping of itkHessianToObjectnessMeasureImageFilter moved out of Review
      ENH: Update BridgeNumPy to most recent version (2017.03.27)
      BUG: Wrapping of itkHessianToObjectnessMeasureImageFilter moved out of Review
      BUG: Wrap EllipseSpatialObject std::list in Python
      ENH: Improving usability in IPython
      BUG: Attribute names cannot start with a digit
      BUG: Do not export GDCM and Expat symbols with WINDOWS_EXPORT_ALL_SYMBOLS
      BUG: Do not export all symbols from third party libraries on Windows
      ENH: Allows to call ImageFileWriter in Python with Input=Filter
      BUG: Certain third party libraries need to export their symbols on Windows
      BUG: Test if 'issubclass' only if 'isclass' is True
      ENH: Add Python convenience function to read images
      BUG: 3475 AccumulateImageFilter not setting direction cosines of output image
      DOC: Removing typos in itkExtractImageFilter comments
      BUG: ProjectionImageFilter did not copy direction cosine information to output
      BUG: Test if 'issubclass' only if 'isclass' is True
      BUG: 3475 AccumulateImageFilter not setting direction cosines of output image
      BUG: Do not export GDCM and Expat symbols with WINDOWS_EXPORT_ALL_SYMBOLS
      BUG: Do not export all symbols from third party libraries on Windows
      BUG: Certain third party libraries need to export their symbols on Windows
      BUG: ProjectionImageFilter did not copy direction cosine information to output
      ENH: Update BridgeNumPy (2016.04.28) and update itkExtras.py accordingly
      BUG: Template type based input function parameter needs to be deterministic
      ENH: Bump CMakeLists.txt version to 4.11.1
      BUG: Problems due to ComputeOrientedBoundingBox in itkShapeLabelMapFilter

Jean-Baptiste VIMORT (1):
      PERF: Improvement of the itkHistogram class in order to make it faster

Jean-Christophe Fillion-Robin (3):
      ENH: Introduce ITK_WRAP_PYTHON_LEGACY to exclude older Python package layout
      BUG: ITKPython: Do not install *.mdx files required only at generation time
      COMP: Fix Slicer MacOSX extension packaging setting CMP0042 policy to OLD

Johan Andruejol (1):
      ENH: Add wrapping for PathToImageFilter

Jon Haitz Legarreta (131):
      ENH: Improve the itkFileListVideoIO coverage.
      STYLE: Improve the BSplineScatteredDataPointSetToImageFilter style,
      ENH: Improve the itkBSplineScatteredDataPointSetToImageFilter coverage.
      ENH: Add missing ivars in function PrintSelf.
      STYLE: Improve ImageNoise filters' style.
      STYLE: Improve the ImageNoise filters tests' style.
      STYLE: Improve ITKImageSources module filters' style.
      STYLE: Improve the itkLinearInterpolateImageFunction style.
      ENH: Improve the itkLabelOverlapMeasuresImageFilter coverage.
      STYLE: Improve itkAdaptiveHistogramEqualizationImageFilter style.
      ENH: Improve itkAdaptiveHistogramEqualizationImageFilter coverage.
      STYLE: Improve itkKappaStatisticImageToImageMetric style.
      ENH: Improve the itkKappaStatisticImageToImageMetric coverage.
      STYLE: Improve itkBinaryGrindPeakImageFilter style.
      STYLE: Improve the itkCannyEdgeDetectionImageFilter style.
      ENH: Improve itkCannyEdgeDetectionImageFilter coverage.
      ENH: Improve itkBarrier class coverage.
      STYLE: Improve itkFlipImageFilterStyle.
      STYLE: Improve itkSpatialObjectToPointSetFilter style.
      STYLE: Improve itkStretchIntensityImageFilter style.
      ENH: Print all ivars for itkStretchIntensityImageFilter.
      ENH: Improve itkPhysicalPointImageSource class coverage.
      ENH: Add missing ivars to LabelMapMaskImageFilter PrintSelf.
      ENH: Improve itkRealTimeClock coverage.
      STYLE: Improve the itkRealTimeClock style.
      ENH: Improve itkBsplineDecompositionImageFilter coverage.
      ENH: Improve itkTestingStretchIntensityImageFilter coverage.
      STYLE: Improve itkPathToChainCodePathFilter style.
      ENH: Add a Get method for itkPathToChainCodePathFilter ivar.
      ENH: Add specific testing macro for boolean members.
      STYLE: Improve itkLabelMapMaskImageFilter style.
      STYLE: Improve BSplineDecompositionImageFilter style.
      ENH: Finish itkAdaptiveHistogramEqualizationImageFilter PrintSelf.
      COMP: Fix ImageGrid tests compiler warnings.
      ENH: Finish BSplineDecompositionImageFilter PrintSelf.
      BUG: Fix Uninitialized Memory errors reported by Valgrind.
      ENH: Improve itkLabelMapMaskImageFilter coverage.
      ENH: Improve itkBinaryGrindPeakImageFilter coverage.
      ENH: Improve itkPathToChainCodePathFilter coverage.
      ENH: Move LabelMap module test baselines.
      ENH: Move BinaryMathMorphology test baselines out of review.
      ENH: Move ImageFusion test baselines out of review.
      ENH: Improve itkAutoCropLabelMapFilter tests.
      ENH: Improve itkSpatialObjectToPointSetFilter coverage.
      ENH: Move ImageLabel test baselines out of Review.
      ENH: Move ImageGrid test baselines out of review.
      STYLE: Improve itkGaussianSpatialFunction class' style.
      ENH: Improve the ITKPath module classes coverage.
      BUG: Fix BSplineDecompositionImageFilter Valgrind defects.
      STYLE: Improve itkColorTable style.
      ENH: Improve itkHoughTransform2DLinesImageFilter coverage.
      ENH: Improve itkHoughTransform2DCirclesImageFilter coverage.
      BUG: Address uninitialized variable defects.
      STYLE: Improve itk::HistogramThresholdImageFilter style.
      DOC: Fix a typo in the term "threshold".
      STYLE: Imporve itkContourSpatialObjectPoint style.
      ENH: Print all HoughTransform2DLinesImageFilter ivars.
      STYLE: Fix type in Optimizersv4 and Metricsv4 modules.
      ENH: Add PhiLattice regression baseline.
      ENH: Print all itkVoronoiDiagram2DGenerator ivars.
      ENH: Improve itkColorTable coverage.
      ENH: Improve the itk::GradientDescentOptimizerv4 style.
      ENH: Improve the itkImageSources module's filters' coverage.
      ENH: Add PhiLattice regression baseline.
      ENH: Add a new test for itk::ContourSpatialObjectPoint.
      BUG: Fix bug in itkContourSpatialObjectPointTest test.
      STYLE: Improve the itkGaussianSpatialFunctionTest style.
      ENH: Improve itkVotingBinaryHoleFillingImageFilter coverage.
      BUG: Fix precision issues in itkGaborKernelFunctionTest.
      BUG: Relax tolerance in itkGaborKernelFunctionTest.
      DOC: Fix minor typo in itkHistogramThresholdImageFilter doc.
      ENH: Print all ivars in GradientDescentOptimizer base classes.
      STYLE: Improve TIFFImageIO tests.
      ENH: Add Get methods for itk::BSplineDecompositionImageFilter ivars.
      BUG: Fix TimeProbes name in itkLargeTIFFImageWriteReadTest.
      BUG: Fix memory leaks in BMP and PNG tests.
      COMP: Fix signed/unsigned mismatch warning.
      COMP: Fix signed/unsigned mismatch warning.
      BUG: Fix Superclass for ITKThresholding calculators.
      BUG: Make the number of filters be an integer.
      ENH: Honor the itkBooleanMacro for boolean class members.
      ENH: Improve the Watershed module code coverage.
      COMP: Fix double to unsigned int cast warning.
      ENH: Improve coverage for MorphologicalWatersheds filters.
      STYLE: Improve the Denoising module style.
      BUG: Fix the itkPatchBasedDenoisingImageFilter RTTI Superclass name.
      COMP: Fix unsigned char from double conversion warning.
      ENH: Improve itkWatershedMiniPipelineProgressCommand coverage.
      ENH: Improve the itkRegionalMin/Max filters member print types.
      ENH: Improve the itkMorphologicalWatershedFromMarkers coverage.
      ENH: Improve the itkIsolatedWatershedImageFilter coverage.
      STYLE: Improve the Denoisinig module style.
      STYLE: Improve the FEMRegistration module files style.
      DOC: Fix itkOrientImageFilter UseImageDirection method doc typo.
      STYLE: Improve the ITKThresholding module classes style.
      BUG: Fix itkIsolatedWatershedImageFilterTest valgrind errors.
      STYLE: Improve the itkApproximateSignedDistanceMapImageFilter style.
      ENH: Improve Denoising module filters' coverage.
      ENH: Improve the FEMRegistration module coverage.
      STYLE: Improve the itkDisplacementFieldTransform class style.
      STYLE: Limit itkFlipImageFilter methods' loops variables' scope.
      ENH: Improve itkFlipImageFilter coverage.
      COMP: Fix itkPhysicsBasedNonRigidRegistrationMethodTest cast warning.
      STYLE: Improve the HessianToObjectnessMeasureImageFilter style.
      ENH: Improve coverage for HessianToObjectnessMeasureImageFilter.
      ENH: Improve DiscreteGaussianImage operators review classes' coverage.
      ENH: Add test for itk::ConicShellInteriorExteriorSpatialFunction.
      ENH: Print all itkHoughTransform2DCirclesImageFilter ivars.
      ENH: Improve coverage for itk::DisplacementFieldTransform.
      STYLE: Make itkPatchBasedDenoisingBaseImageFilter ivars private.
      STYLE: Improve the itkRobustAutomaticThreshold classes style.
      COMP: Fix itkDisplacementFieldTransformTest compiler warning.
      STYLE: Improve the itkGridForwardWarpImageFilter style.
      ENH: Improve coverage for itkGridForwardWarpImageFilter.
      ENH: Improve coverage for itkRobustAutomaticThreshold classes.
      ENH: Remove duplicate test files in Review.
      DOC: Fix itkDivideByConstantImageFilter doc error.
      STYLE: Improve exception message.
      STYLE: Improve ImageIntensity module image arithm op tests' style.
      STYLE: Improve HConc/Conv HMaxima/HMinima image filters' style.
      ENH: Improve the HConc/HConv HMaxima/HMinima filters' coverage.
      ENH: Improve DiscreteGaussianImage operators review classes' coverage.
      ENH: Change the URL for the PCA remote module repo.
      STYLE: Make flow control variables have a local scope.
      ENH: Add examples and doc build flag support for external modules.
      DOC: Remove wrong group tag for itk::QuadEdgeMeshExtendedTraits.
      BUG: Fix itk::FastMarchingImageFilter RTTI superclass name.
      STYLE: Improve the itk::NodePair class style.
      STYLE: Use the ITK_MANUAL_INSTANTIATION macro consistently.
      STYLE: Delete FastMarching module classes methods consistently.
      DOC: Fix typo in the "implementation" word across the code.

Jon Haitz Legarreta Gorroño (2):
      STYLE: Improve itkWarpHarmonicEnergyCalculator style.
      DOC: Add a notice to let users know about related implementations.

KWIML Upstream (1):
      KWIML 2017-02-27 (aa3a7733)

KWSys Upstream (3):
      KWSys 2016-11-21 (cb55cf5a)
      KWSys 2017-03-28 (34999b6a)
      KWSys 2017-04-20 (8785f84f)

Matthew McCormick (40):
      COMP: Add missing headers in OpenCVImageBridge
      COMP: Use double for gradient calculations in MinMaxCurvatureFlow
      ENH: Bump ITK version to 4.12.0.
      COMP: Add VCL support for GCC 7
      COMP: Define ITK_FALLTHROUGH for GCC 7
      COMP: Add missing ITK_FALLTHROUGH in TiffImageIO
      COMP: Avoid -Warray-bounds in FixedArray with GCC 7
      COMP: Add ProcessObject include in itkLevelSetBase.hxx
      ENH: Exclude Kitware Robot from third party update commit messages
      BUG: Address tab completion with IPython >= 5.0.0
      BUG: Do not use terminal_progress with the Jupyter Notebook
      ENH: Enable BridgeNumPy with Python wrapping
      COMP: Do not require numeric_traits::has_infinity
      BUG: Fix passing _NO_TR1 definition with VS9 and Python
      BUG: Do not tests that require NumPy when it is not available
      ENH: Build Python wrapping with hidden visibility
      ENH: Move morphological watersheds out of ITKReview
      BUG: Do not upload top level folder in ArchiveTestingDataOnGirder.py
      BUG: Remove unused content links from PNG test additions
      ENH: Add .sha512 content links for IO pallette test data
      BUG: Add missing export macros for SpatialObject forward declarations
      BUG: Always wrap basic type RGBUC
      COMP: Do not add Visual Studio numeric_traits workarounds with MinGWPy
      COMP: Increase gold linker requirement to GCC 4.9.0
      COMP: Detect Windows with _WIN32 in socket++/fork.cpp
      BUG: Revert "BUG: Include installed modules in ITK_MODULES_ENABLED"
      BUG: Set ${itk-module}_ENABLE_SHARED in ITKModuleExternal
      BUG: PolyLineParametricPath must be loaded before PathToImageFilter
      COMP: Address Python 2.7 Windows _hypot build errors
      COMP: Undefine Py_hash_t when wrapping VtkGlue
      ENH: Update BridgeNumPy to most recent version (2017.03.05)
      BUG: Improve itkTemplate New compatibility with Python 3
      ENH: Bump CastXML to 2017-04-18
      STYLE: Remove empty or erroreous comments in ImageToImageFilter
      ENH: Use itk.imread and itk.imwrite as standard function names
      BUG: Correct size specification in ImportImageFilter::SetImportPointer
      BUG: Improve large file support in MetaIO
      ENH: Wrap itk::IdentifierType for ScalarToRGBColormapImageFilter
      BUG: LevelSetNeighborhoodExtractor uses spacing
      BUG: Fix PCRE 8.40 download URL

MetaIO Maintainers (1):
      MetaIO 2017-04-08 (dead6687)

Olivier Commowick (1):
      BUG: Correct ITK eigen system (was producing NaN or different values than VNL)

Pablo Hernandez-Cerdan (4):
      ENH: Add SetReferenceImage to GenerateImageSource.
      ENH: Change the metadata of all outputs in GenerateImageSource.
      BUG: Fix Normalization kernel step of ConvolutionImageFilter.
      BUG: Remove call to Superclass::GenerateOutputInformation.

Richard Beare (1):
      DOC: PrincipleComponent flag incorrectly reported by PrintSelf

Sam Horvath (1):
      PERF: reduce memory usage of itkImagePCAShapeModelEstimator

Samuel Gerber (2):
      DOC: Added description to itkLBFGSOptimizerv4.h
      DOC: LBFGSOptimizer doc update

Shusil Dangi (2):
      ENH: Ignores MacOS .DS_Store file
      ENH: Wrap NormalVariateGenerator in the Statistics Module

Simon Rit (2):
      BUG: memory leak in ITK_USE_THREADPOOL
      BUG: Join threads when using thread pool (ITK_USE_THREADPOOL)

Taylor Braun-Jones (1):
      COMP: Only include the headers for required OpenCV modules (fixup)

VXL Maintainers (2):
      VNL 2017-02-01 (ae6eff5e)
      VNL 2017-02-08 (ae8eef13)

Vladimir S. FONOV (3):
      MINC 2017-04-28 (3d79acf3)
      MINC 2017-05-01 (4caf8f4c)
      MINC 2017-05-05 (cc682b52)

Yann Le Poul (4):
      ENH: improvement of palette image support for PNG TIFF and BMP.
      STYLE: Misleading IsReadAsScalarPlusPalette Printing string
      STYLE: ReadAsScalarPlusPalette info already printed in itkImageIOBase
      BUG: ExpandRGBPalette used instead of IsReadAsScalarPlusPalette
```