### PR TITLE
Update SimpleITK version to past 1.0.0

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -41,7 +41,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "v1.0rc1"
+    "643302863821f77429d86c9a1f51a6c1b6e05cbc"
     QUIET
     )
 
@@ -81,10 +81,9 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
       -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
       -DBUILD_SHARED_LIBS:BOOL=${Slicer_USE_SimpleITK_SHARED}
       -DBUILD_EXAMPLES:BOOL=OFF
-      -DSimpleITK_PYTHON_THREADS:BOOL=ON
       -DSimpleITK_INSTALL_ARCHIVE_DIR:PATH=${Slicer_INSTALL_LIB_DIR}
       -DSimpleITK_INSTALL_LIBRARY_DIR:PATH=${Slicer_INSTALL_LIB_DIR}
-      -DSITK_INT64_PIXELIDS:BOOL=OFF
+      -DSimpleITK_INT64_PIXELIDS:BOOL=OFF
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
       -DUSE_SYSTEM_ITK:BOOL=ON
       -DITK_DIR:PATH=${ITK_DIR}


### PR DESCRIPTION
This update to SimpleITK contains the 1.0.0 release, several CMake
related patches on the release branch, plus a patch to enable building
debug SimpleITK against release python for Windows.