### PR TITLE
ENH: update MultiVolumeImporter hash

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -205,7 +205,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeExplorer Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(MultiVolumeImporter
   GIT_REPOSITORY ${git_protocol}://github.com/fedorov/MultiVolumeImporter.git
-  GIT_TAG 2ebb4d2d8135d7d59314dcc6656e2c2b54266d60
+  GIT_TAG 05bc0986507b3a4eb4676bf96311131fd0335ea7
   OPTION_NAME Slicer_BUILD_MultiVolumeImporter
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_BUILD_MULTIVOLUME_SUPPORT;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
The update includes fixes to importing of non-DICOM data, and improves compatibility
of the multivolume DCE data with the PkModeling module (thanks to @drw25 for the
contribution of the MultiVolumeImporter fixes).