### PR TITLE
BUG: Removed all iteratorless traverse of shared collections

### DIFF
--- a/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
@@ -139,7 +139,7 @@ class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModuleTest):
     ioManager.loadFile(filePath)
     ioManager.loadFile(filePath)
 
-    sceneViewNode = slicer.mrmlScene.GetNthNodeByClass(0, 'vtkMRMLSceneViewNode')
+    sceneViewNode = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLSceneViewNode')
     sceneViewNode.RestoreScene()
 
     # If test reach this point without crashing it is a success

--- a/Base/QTCore/qSlicerSlicer2SceneReader.cxx
+++ b/Base/QTCore/qSlicerSlicer2SceneReader.cxx
@@ -1225,16 +1225,13 @@ void qSlicerSlicer2SceneReaderPrivate::importColorNode(NodeType& node)
   //foreach {r g b} $n(diffuseColor) {}
   QStringList rgb = node["diffuseColor"].split(' ');
   //$::slicer3::MRMLScene InitTraversal
-  q->mrmlScene()->InitTraversal();
-  //set ndnodes [$::slicer3::MRMLScene GetNumberOfNodesByClass vtkMRMLModelDisplayNode]
-  int ndnodes = q->mrmlScene()->GetNumberOfNodesByClass("vtkMRMLModelDisplayNode");
-  //for {set i 0} {$i < $ndnodes} {incr i} {
-  for (int i = 0; i < ndnodes; ++i)
+  std::vector<vtkMRMLNode*> nodes;
+  q->mrmlScene()->GetNodesByClass("vtkMRMLModelDisplayNode", nodes);
+  for (std::vector< vtkMRMLNode* >::iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
     {
     //set dnode [$::slicer3::MRMLScene GetNthNodeByClass $i vtkMRMLModelDisplayNode]
     vtkMRMLModelDisplayNode* dnode =
-      vtkMRMLModelDisplayNode::SafeDownCast(
-        q->mrmlScene()->GetNthNodeByClass(i, "vtkMRMLModelDisplayNode"));
+      vtkMRMLModelDisplayNode::SafeDownCast(*nodeIt);
     // set cid [$dnode GetAttribute colorid]
     QString cid = dnode->GetAttribute("colorid");
     //if {$id == $cid} {

--- a/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeDisplayPropertiesTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDisplayableHierarchyNodeDisplayPropertiesTest.cxx
@@ -156,7 +156,6 @@ void PopulateScene(vtkMRMLScene* scene, int numberOfLevels)
 //---------------------------------------------------------------------------
 vtkMRMLModelNode* GetModelNode(vtkMRMLScene* scene, int level)
 {
-  scene->InitTraversal();
   return vtkMRMLModelNode::SafeDownCast(
     scene->GetNthNodeByClass(level, "vtkMRMLModelNode"));
 }
@@ -164,7 +163,6 @@ vtkMRMLModelNode* GetModelNode(vtkMRMLScene* scene, int level)
 //---------------------------------------------------------------------------
 vtkMRMLDisplayableHierarchyNode* GetHierarchyNode(vtkMRMLScene* scene, int level)
 {
-  scene->InitTraversal();
   return vtkMRMLDisplayableHierarchyNode::SafeDownCast(
     scene->GetNthNodeByClass(2*level + 1, "vtkMRMLDisplayableHierarchyNode"));
 }
@@ -172,7 +170,6 @@ vtkMRMLDisplayableHierarchyNode* GetHierarchyNode(vtkMRMLScene* scene, int level
 //---------------------------------------------------------------------------
 vtkMRMLDisplayableHierarchyNode* GetModelHierarchyNode(vtkMRMLScene* scene, int level)
 {
-  scene->InitTraversal();
   return vtkMRMLDisplayableHierarchyNode::SafeDownCast(
     scene->GetNthNodeByClass(2*level, "vtkMRMLDisplayableHierarchyNode"));
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneAddSingletonTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneAddSingletonTest.cxx
@@ -92,11 +92,10 @@ int vtkMRMLSceneAddSingletonTest(int vtkNotUsed(argc), char * vtkNotUsed(argv) [
 
   vtkMRMLSceneViewNode* sceneViewNode = vtkMRMLSceneViewNode::SafeDownCast(
     tempScene->GetFirstNodeByName("sceneView"));
-  sceneViewNode->GetStoredScene()->InitTraversal();
 
   // Test singleton loading/restoring.
   vtkMRMLNode* restoredSingleton1 =
-    sceneViewNode->GetStoredScene()->GetNextNodeByClass("vtkMRMLModelNode");
+    sceneViewNode->GetStoredScene()->GetNthNodeByClass(0, "vtkMRMLModelNode");
   restoredSingleton1->SetSingletonTag("Singleton");
   restoredSingleton1->SetAddToScene(1);
   addedNode = scene->AddNode(restoredSingleton1);
@@ -110,7 +109,7 @@ int vtkMRMLSceneAddSingletonTest(int vtkNotUsed(argc), char * vtkNotUsed(argv) [
   // Test compatibility with Slicer 3 scenes.
   std::string singleton1ID = singleton1->GetID();
   restoredSingleton1 =
-    sceneViewNode->GetStoredScene()->GetNextNodeByClass("vtkMRMLModelNode");
+    sceneViewNode->GetStoredScene()->GetNthNodeByClass(1, "vtkMRMLModelNode");
   restoredSingleton1->SetSingletonTag("Singleton");
   restoredSingleton1->SetAddToScene(1);
   addedNode = scene->AddNode(restoredSingleton1);
@@ -126,7 +125,7 @@ int vtkMRMLSceneAddSingletonTest(int vtkNotUsed(argc), char * vtkNotUsed(argv) [
   // Test odd node ID. There is no reason why it could happen, but there is no
   // reason why it shouldn't be supported.
   restoredSingleton1 =
-    sceneViewNode->GetStoredScene()->GetNextNodeByClass("vtkMRMLModelNode");
+    sceneViewNode->GetStoredScene()->GetNthNodeByClass(2, "vtkMRMLModelNode");
   restoredSingleton1->SetSingletonTag("Singleton");
   restoredSingleton1->SetAddToScene(1);
   addedNode = scene->AddNode(restoredSingleton1);

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneTest2.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneTest2.cxx
@@ -18,6 +18,7 @@
 
 // VTK includes
 #include <vtkCallbackCommand.h>
+#include <vtkCollection.h>
 #include <vtkXMLDataParser.h>
 
 // STD includes
@@ -354,12 +355,13 @@ int vtkMRMLSceneTest2(int argc, char * argv [] )
   std::cout << collection->GetNumberOfItems() << std::endl;
 
   std::cout << "List of Node Names in this Scene" << std::endl;
-  scene->InitTraversal();
-  vtkMRMLNode * nodePtr = scene->GetNextNode();
-  while( nodePtr != 0 )
+  vtkCollectionSimpleIterator it;
+  vtkMRMLNode* node = NULL;
+  vtkCollection *nodes = scene->GetNodes();
+  for (nodes->InitTraversal(it);
+    (node = vtkMRMLNode::SafeDownCast(nodes->GetNextItemAsObject(it)));)
     {
-    std::cout << " " << nodePtr->GetName() << std::endl;
-    nodePtr = scene->GetNextNode();
+    std::cout << " " << node->GetName() << std::endl;
     }
 #endif
 

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeImportSceneTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeImportSceneTest.cxx
@@ -100,10 +100,10 @@ int vtkMRMLSceneViewNodeImportSceneTest(int vtkNotUsed(argc),
 
   // Check scene node IDs
   vtkMRMLNode* displayNode =
-    scene2->GetNthNodeByClass(0, "vtkMRMLScalarVolumeDisplayNode");
+    scene2->GetFirstNodeByClass("vtkMRMLScalarVolumeDisplayNode");
   vtkMRMLNode* displayNode2 = scene2->GetNthNodeByClass(1, "vtkMRMLScalarVolumeDisplayNode");
   vtkMRMLSceneViewNode* sceneViewNode = vtkMRMLSceneViewNode::SafeDownCast(
-    scene2->GetNthNodeByClass(0, "vtkMRMLSceneViewNode"));
+    scene2->GetFirstNodeByClass("vtkMRMLSceneViewNode"));
 
   CHECK_NOT_NULL(displayNode);
   CHECK_NOT_NULL(displayNode2);
@@ -114,10 +114,9 @@ int vtkMRMLSceneViewNodeImportSceneTest(int vtkNotUsed(argc),
 
   // Check sceneViewNode node IDs.
   vtkMRMLNode* sceneViewDisplayNode =
-    sceneViewNode->GetStoredScene()->GetNthNodeByClass(0, "vtkMRMLScalarVolumeDisplayNode");
+    sceneViewNode->GetStoredScene()->GetFirstNodeByClass("vtkMRMLScalarVolumeDisplayNode");
   vtkMRMLDisplayableNode* sceneViewDisplayableNode = vtkMRMLDisplayableNode::SafeDownCast(
-    sceneViewNode->GetStoredScene()->GetNthNodeByClass(
-      0, "vtkMRMLScalarVolumeNode"));
+    sceneViewNode->GetStoredScene()->GetFirstNodeByClass("vtkMRMLScalarVolumeNode"));
 
   CHECK_INT(sceneViewNode->GetStoredScene()->GetNumberOfNodes(), 3);
   CHECK_NOT_NULL(sceneViewDisplayNode);

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeOnNodeReferenceAddTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeOnNodeReferenceAddTest.cxx
@@ -103,20 +103,20 @@ int testScene(vtkMRMLScene* scene)
 {
   // Check transform node IDs
   vtkMRMLNode* transformNode =
-    scene->GetNthNodeByClass(0, "vtkMRMLLinearTransformNode");
+    scene->GetFirstNodeByClass("vtkMRMLLinearTransformNode");
   CHECK_NOT_NULL(transformNode);
   CHECK_STRING(transformNode->GetID(), "vtkMRMLLinearTransformNode1");
 
   // Check references
   vtkMRMLTransformableNode* transformableNode =
-    vtkMRMLTransformableNode::SafeDownCast(scene->GetNthNodeByClass(0, "vtkMRMLScalarVolumeNode"));
+    vtkMRMLTransformableNode::SafeDownCast(scene->GetFirstNodeByClass("vtkMRMLScalarVolumeNode"));
 
   CHECK_NOT_NULL(transformableNode);
   CHECK_STRING(transformableNode->GetTransformNodeID(), transformNode->GetID());
 
   // Test vtkMRMLTransformableNode::OnNodeReferenceAdded()
-  vtkMRMLLinearTransformNode* linearTransformNode = vtkMRMLLinearTransformNode::SafeDownCast(scene->GetNthNodeByClass(0, "vtkMRMLLinearTransformNode"));
-  vtkMRMLScalarVolumeNode* volumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(scene->GetNthNodeByClass(0, "vtkMRMLScalarVolumeNode"));
+  vtkMRMLLinearTransformNode* linearTransformNode = vtkMRMLLinearTransformNode::SafeDownCast(scene->GetFirstNodeByClass("vtkMRMLLinearTransformNode"));
+  vtkMRMLScalarVolumeNode* volumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(scene->GetFirstNodeByClass("vtkMRMLScalarVolumeNode"));
   vtkNew<vtkMRMLCoreTestingUtilities::vtkMRMLNodeCallback> callback;
   volumeNode->AddObserver(vtkCommand::AnyEvent, callback.GetPointer());
 

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeReferenceSaveImportTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformableNodeReferenceSaveImportTest.cxx
@@ -86,7 +86,7 @@ bool import()
 
   // Check transform node IDs
   vtkMRMLNode* trnsformNode =
-    scene2->GetNthNodeByClass(0, "vtkMRMLLinearTransformNode");
+    scene2->GetFirstNodeByClass("vtkMRMLLinearTransformNode");
   if (!trnsformNode || strcmp(trnsformNode->GetID(), "vtkMRMLLinearTransformNode1") != 0
       )
     {
@@ -99,7 +99,7 @@ bool import()
 
   // Check references
   vtkMRMLTransformableNode* trnsformableNode =
-    vtkMRMLTransformableNode::SafeDownCast(scene2->GetNthNodeByClass(0, "vtkMRMLTransformableNode"));
+    vtkMRMLTransformableNode::SafeDownCast(scene2->GetFirstNodeByClass("vtkMRMLTransformableNode"));
 
   if (strcmp(trnsformableNode->GetTransformNodeID(),
              trnsformNode->GetID()) != 0)

--- a/Libs/MRML/Core/vtkMRMLCameraNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCameraNode.cxx
@@ -198,7 +198,7 @@ void vtkMRMLCameraNode::ReadXMLAttributes(const char** atts)
       if (!this->GetActiveTag() && this->Scene)
         {
         vtkMRMLViewNode *vnode = vtkMRMLViewNode::SafeDownCast(
-          this->Scene->GetNthNodeByClass(0, "vtkMRMLViewNode"));
+          this->Scene->GetFirstNodeByClass("vtkMRMLViewNode"));
         if (vnode)
         {
           this->SetActiveTag(vnode->GetID());

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -334,18 +334,19 @@ void vtkMRMLScene::Clear(int removeSingletons)
 //------------------------------------------------------------------------------
 void vtkMRMLScene::RemoveAllNodes(bool removeSingletons)
 {
-  this->InitTraversal();
+
   // Store the node ids because a module may decide to delete some helper nodes
   // when a node is deleted
   std::deque< std::string > removeNodeIds;
-  vtkMRMLNode *node = this->GetNextNode();
-  while(node)
+  vtkMRMLNode *node = NULL;
+  vtkCollectionSimpleIterator it;
+  for (this->Nodes->InitTraversal(it);
+    (node = (vtkMRMLNode*)this->Nodes->GetNextItemAsObject(it));)
     {
     if (removeSingletons || node->GetSingletonTag() == NULL)
       {
       removeNodeIds.push_back(node->GetID());
       }
-    node = this->GetNextNode();
     }
   for(std::deque< std::string >::iterator nodeIt=removeNodeIds.begin(); nodeIt!=removeNodeIds.end(); ++nodeIt)
     {
@@ -361,14 +362,13 @@ void vtkMRMLScene::RemoveAllNodes(bool removeSingletons)
 //------------------------------------------------------------------------------
 void vtkMRMLScene::ResetNodes()
 {
-  vtkMRMLNode *node;
   std::vector <vtkMRMLNode *> nodes;
-  this->InitTraversal();
-  node = this->GetNextNode();
-  while(node)
+  vtkMRMLNode *node = NULL;
+  vtkCollectionSimpleIterator it;
+  for (this->Nodes->InitTraversal(it);
+    (node = (vtkMRMLNode*)this->Nodes->GetNextItemAsObject(it));)
     {
     nodes.push_back(node);
-    node = this->GetNextNode();
     }
   for(unsigned int i=0; i<nodes.size(); i++)
     {
@@ -1484,12 +1484,14 @@ int vtkMRMLScene::IsNodePresent(vtkMRMLNode *n)
 //------------------------------------------------------------------------------
 void vtkMRMLScene::InitTraversal()
 {
+  vtkWarningMacro("Usage of vtkMRMLScene::InitTraversal() is unsafe.")
   this->Nodes->InitTraversal();
 }
 
 //------------------------------------------------------------------------------
 vtkMRMLNode* vtkMRMLScene::GetNextNode()
 {
+  vtkWarningMacro("Usage of vtkMRMLScene::GetNextNode() is unsafe.")
   return vtkMRMLNode::SafeDownCast(this->Nodes->GetNextItemAsObject());
 }
 
@@ -1524,6 +1526,7 @@ int vtkMRMLScene::GetNumberOfNodesByClass(const char *className)
 //------------------------------------------------------------------------------
 int vtkMRMLScene::GetNodesByClass(const char *className, std::vector<vtkMRMLNode *> &nodes)
 {
+  nodes.clear();
   if (className == NULL)
     {
     vtkErrorMacro("GetNodesByClass: class name is null.");
@@ -1584,6 +1587,7 @@ std::list< std::string > vtkMRMLScene::GetNodeClassesList()
 //------------------------------------------------------------------------------
 vtkMRMLNode *vtkMRMLScene::GetNextNodeByClass(const char *className)
 {
+  vtkWarningMacro("Usage of vtkMRMLScene::GetNextNodeByClass(const char *) is unsafe.")
   if (!className)
     {
     vtkErrorMacro("GetNextNodeByClass: class name is null.");
@@ -1711,6 +1715,12 @@ vtkMRMLNode* vtkMRMLScene::GetNthNodeByClass(int n, const char *className)
       }
     }
   return NULL;
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLNode* vtkMRMLScene::GetFirstNodeByClass(const char *className)
+{
+  return this->GetNthNodeByClass(0, className);
 }
 
 //------------------------------------------------------------------------------
@@ -3228,10 +3238,10 @@ void vtkMRMLScene
   //
   // copy over nodes from the current scene to the new scene
   //
-  nodes->InitTraversal();
-  vtkObject* currentObject = NULL;
-  while ((currentObject = nodes->GetNextItemAsObject()) &&
-         (currentObject != NULL))
+  vtkMRMLNode *currentObject = NULL;
+  vtkCollectionSimpleIterator it;
+  for (nodes->InitTraversal(it);
+    (currentObject = (vtkMRMLNode*)nodes->GetNextItemAsObject(it));)
     {
     vtkMRMLNode* n = vtkMRMLNode::SafeDownCast(currentObject);
     if (n == NULL)

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -206,13 +206,31 @@ public:
   /// Returns its position in the list.
   int IsNodePresent(vtkMRMLNode *n);
 
-  /// Initialize a traversal (not reentrant!)
+  /// This method is deprecated, kept for backward compatibility but it will be
+  /// removed in the future.
+  /// The problem is that it changes the node collection's internal iterator,
+  /// which may cause unintended side effects in caller functions that also
+  /// use the node collection's internal iterator.
+  /// Use other methods instead (GetNodes(), GetNodesByClass(), etc.)
+  /// or traverse collection returned by GetNodes() using a collection iterator.
   void InitTraversal();
 
-  /// Get next node in the scene.
+  /// This method is deprecated, kept for backward compatibility but it will be
+  /// removed in the future.
+  /// The problem is that it changes the node collection's internal iterator,
+  /// which may cause unintended side effects in caller functions that also
+  /// use the node collection's internal iterator.
+  /// Use other methods instead (GetNodes(), GetNodesByClass(), etc.)
+  /// or traverse collection returned by GetNodes() using a collection iterator.
   vtkMRMLNode *GetNextNode();
 
-  /// Get next node of the class in the scene.
+  /// This method is deprecated, kept for backward compatibility but it will be
+  /// removed in the future.
+  /// The problem is that it changes the node collection's internal iterator,
+  /// which may cause unintended side effects in caller functions that also
+  /// use the node collection's internal iterator.
+  /// Use other methods instead (GetNodes(), GetNodesByClass(), etc.)
+  /// or traverse collection returned by GetNodes() using a collection iterator.
   vtkMRMLNode *GetNextNodeByClass(const char* className);
 
   /// Get nodes having the specified name
@@ -248,8 +266,10 @@ public:
   /// Get n-th node in the scene
   vtkMRMLNode* GetNthNode(int n);
 
-  /// Get n-th node of a specified class  in the scene
+  /// Get n-th node of a specified class in the scene
   vtkMRMLNode* GetNthNodeByClass(int n, const char* className );
+  /// Convenience function for getting 0-th node of a specified class in the scene
+  vtkMRMLNode* GetFirstNodeByClass(const char* className);
 
   /// Get number of nodes of a specified class in the scene
   int GetNumberOfNodesByClass(const char* className);

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx
@@ -149,7 +149,7 @@ void vtkMRMLCameraDisplayableManager::OnMRMLSceneEndRestore()
   if (!camera_node)
     {
     camera_node = vtkMRMLCameraNode::SafeDownCast(
-        this->GetMRMLScene()->GetNthNodeByClass(0, "vtkMRMLCameraNode"));
+        this->GetMRMLScene()->GetFirstNodeByClass("vtkMRMLCameraNode"));
     if (camera_node)
       {
       camera_node->SetActiveTag(this->GetMRMLViewNode()->GetID());

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -303,7 +303,7 @@ int vtkMRMLModelDisplayableManager::UpdateClipSlicesFromMRML()
     }
 
   // update ClipModels node
-  vtkMRMLClipModelsNode *clipNode = vtkMRMLClipModelsNode::SafeDownCast(this->GetMRMLScene()->GetNthNodeByClass(0, "vtkMRMLClipModelsNode"));
+  vtkMRMLClipModelsNode *clipNode = vtkMRMLClipModelsNode::SafeDownCast(this->GetMRMLScene()->GetFirstNodeByClass("vtkMRMLClipModelsNode"));
   if (clipNode != this->Internal->ClipModelsNode)
     {
     vtkSetAndObserveMRMLNodeMacro(this->Internal->ClipModelsNode, clipNode);

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLColorLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLColorLogicTest1.cxx
@@ -98,12 +98,12 @@ bool TestNodeIDs()
   vtkNew<vtkMRMLColorLogic> colorLogic;
   colorLogic->SetMRMLScene(scene.GetPointer());
 
-  vtkMRMLNode* node= 0;
-  scene->InitTraversal();
-  while ( (node = scene->GetNextNodeByClass("vtkMRMLColorTableNode")) )
+  std::vector<vtkMRMLNode*> nodes;
+  scene->GetNodesByClass("vtkMRMLColorTableNode", nodes);
+  for (std::vector< vtkMRMLNode* >::iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
     {
     vtkMRMLColorTableNode* colorNode =
-      vtkMRMLColorTableNode::SafeDownCast(node);
+      vtkMRMLColorTableNode::SafeDownCast(*nodeIt);
     const char* nodeID =
       vtkMRMLColorLogic::GetColorTableNodeID(colorNode->GetType());
     if (strcmp(colorNode->GetID(), nodeID) != 0)
@@ -114,11 +114,12 @@ bool TestNodeIDs()
       return false;
       }
     }
-  scene->InitTraversal();
-  while ( (node = scene->GetNextNodeByClass("vtkMRMLPETProceduralColorNode")) )
+
+  scene->GetNodesByClass("vtkMRMLPETProceduralColorNode", nodes);
+  for (std::vector< vtkMRMLNode* >::iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
     {
     vtkMRMLPETProceduralColorNode* colorNode =
-      vtkMRMLPETProceduralColorNode::SafeDownCast(node);
+      vtkMRMLPETProceduralColorNode::SafeDownCast(*nodeIt);
     const char* nodeID =
       vtkMRMLColorLogic::GetPETColorNodeID(colorNode->GetType());
     if (strcmp(colorNode->GetID(), nodeID) != 0)
@@ -129,11 +130,12 @@ bool TestNodeIDs()
       return false;
       }
     }
-  scene->InitTraversal();
-  while ( (node = scene->GetNextNodeByClass("vtkMRMLdGEMRICProceduralColorNode")) )
+
+  scene->GetNodesByClass("vtkMRMLdGEMRICProceduralColorNode", nodes);
+  for (std::vector< vtkMRMLNode* >::iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
     {
     vtkMRMLdGEMRICProceduralColorNode* colorNode =
-      vtkMRMLdGEMRICProceduralColorNode::SafeDownCast(node);
+      vtkMRMLdGEMRICProceduralColorNode::SafeDownCast(*nodeIt);
     const char* nodeID =
       vtkMRMLColorLogic::GetdGEMRICColorNodeID(colorNode->GetType());
     if (strcmp(colorNode->GetID(), nodeID) != 0)

--- a/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
@@ -1109,9 +1109,8 @@ void vtkMRMLLayoutLogic::UpdateLayoutNode()
     this->UpdateFromLayoutNode();
     return;
     }
-  this->GetMRMLScene()->InitTraversal();
   vtkMRMLLayoutNode* sceneLayoutNode = vtkMRMLLayoutNode::SafeDownCast(
-    this->GetMRMLScene()->GetNextNodeByClass("vtkMRMLLayoutNode"));
+    this->GetMRMLScene()->GetFirstNodeByClass("vtkMRMLLayoutNode"));
   if (sceneLayoutNode)
     {
     this->SetLayoutNode(sceneLayoutNode);

--- a/Libs/MRML/Widgets/Testing/qMRMLChartViewTest.py
+++ b/Libs/MRML/Widgets/Testing/qMRMLChartViewTest.py
@@ -1,15 +1,11 @@
 import slicer
 import math
 
-lns = slicer.mrmlScene.GetNodesByClass('vtkMRMLLayoutNode')
-lns.InitTraversal()
-ln = lns.GetNextItemAsObject()
+ln = slicer.mrmlScene.GetFirstNodesByClass('vtkMRMLLayoutNode')
 print ln.GetID()
 ln.SetViewArrangement(24)
 
-cvns = slicer.mrmlScene.GetNodesByClass('vtkMRMLChartViewNode')
-cvns.InitTraversal()
-cvn = cvns.GetNextItemAsObject()
+cvn = slicer.mrmlScene.GetFirstNodesByClass('vtkMRMLChartViewNode')
 print cvn.GetID()
 
 dn = slicer.mrmlScene.AddNode(slicer.vtkMRMLDoubleArrayNode())

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
@@ -78,8 +78,7 @@ int qMRMLSliceWidgetTest1(int argc, char * argv [] )
     std::cerr << "Scene must contain a valid vtkMRMLSliceNode:" << redSliceNode << std::endl;
     return EXIT_FAILURE;
     }
-  scene->InitTraversal();
-  vtkMRMLNode* node = scene->GetNextNodeByClass("vtkMRMLScalarVolumeNode");
+  vtkMRMLNode* node = scene->GetFirstNodeByClass("vtkMRMLScalarVolumeNode");
   vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(node);
   if (!volumeNode)
     {

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.cxx
@@ -83,8 +83,7 @@ int qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1(int argc, char * argv [
   // need to set it back to NULL, otherwise the logic removes the nodes that it added when it is destructed
   colorLogic->SetMRMLScene(NULL);
 
-  scene->InitTraversal();
-  vtkMRMLNode* node = scene->GetNextNodeByClass("vtkMRMLScalarVolumeNode");
+  vtkMRMLNode* node = scene->GetFirstNodeByClass("vtkMRMLScalarVolumeNode");
   vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(node);
 
   qMRMLVolumeThresholdWidget volumeThreshold;

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
@@ -58,8 +58,7 @@ int qMRMLVolumeThresholdWidgetTest1(int argc, char * argv [] )
     std::cerr << "Can't load scene:" << argv[1] << " error: " <<scene->GetErrorMessage() << std::endl;
     return EXIT_FAILURE;
     }
-  scene->InitTraversal();
-  vtkMRMLNode* node = scene->GetNextNodeByClass("vtkMRMLScalarVolumeNode");
+  vtkMRMLNode* node = scene->GetFirstNodeByClass("vtkMRMLScalarVolumeNode");
   vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(node);
   if (!volumeNode)
     {

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
@@ -68,8 +68,7 @@ int qMRMLVolumeThresholdWidgetTest2(int argc, char * argv [] )
     std::cerr << "Can't load scene:" << argv[1] << " error: " <<scene->GetErrorMessage() << std::endl;
     return EXIT_FAILURE;
     }
-  scene->InitTraversal();
-  vtkMRMLNode* node = scene->GetNextNodeByClass("vtkMRMLScalarVolumeNode");
+  vtkMRMLNode* node = scene->GetFirstNodeByClass("vtkMRMLScalarVolumeNode");
   vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(node);
   if (!volumeNode)
     {

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.cxx
@@ -75,8 +75,7 @@ int qMRMLWindowLevelWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
   applicationLogic->SetMRMLScene(scene.GetPointer());
   scene->SetURL(argv[2]);
   scene->Connect();
-  scene->InitTraversal();
-  vtkMRMLNode* node = scene->GetNextNodeByClass("vtkMRMLScalarVolumeNode");
+  vtkMRMLNode* node = scene->GetFirstNodeByClass("vtkMRMLScalarVolumeNode");
   vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(node);
 
   qMRMLWindowLevelWidget windowLevel;

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
@@ -59,8 +59,7 @@ int qMRMLWindowLevelWidgetTest1(int argc, char * argv [] )
     std::cerr << "Can't load scene:" << argv[1] << " error: " <<scene->GetErrorMessage() << std::endl;
     return EXIT_FAILURE;
     }
-  scene->InitTraversal();
-  vtkMRMLNode* node = scene->GetNextNodeByClass("vtkMRMLScalarVolumeNode");
+  vtkMRMLNode* node = scene->GetFirstNodeByClass("vtkMRMLScalarVolumeNode");
   vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(node);
   if (!volumeNode)
     {

--- a/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModuleReportDialog.cxx
+++ b/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModuleReportDialog.cxx
@@ -98,11 +98,12 @@ void qSlicerAnnotationModuleReportDialog::setAnnotations(vtkCollection* collecti
 
   this->m_Annotations = vtkCollection::New();
 
-  collection->InitTraversal();
-
-  for(int i=0; i<collection->GetNumberOfItems(); ++i)
+  vtkObject *obj = NULL;
+  vtkCollectionSimpleIterator it;
+  for (collection->InitTraversal(it);
+    (obj = collection->GetNextItemAsObject(it));)
     {
-    this->m_Annotations->AddItem(collection->GetItemAsObject(i));
+    this->m_Annotations->AddItem(obj);
     }
 }
 
@@ -149,9 +150,6 @@ QString qSlicerAnnotationModuleReportDialog::generateReport()
 
   html.append("<tr><td class='heading'><b>Type</b></td><td class='heading'><b>Value</b></td><td class='heading'><b>Text<b></td></tr>\n");
 
-  // now run through the annotations
-  this->m_Annotations->InitTraversal();
-
   this->m_Html = QString("");
 
   vtkMRMLAnnotationHierarchyNode *toplevelNode = NULL;
@@ -176,13 +174,12 @@ QString qSlicerAnnotationModuleReportDialog::generateReport()
 //---------------------------------------------------------------------------
 bool qSlicerAnnotationModuleReportDialog::isAnnotationSelected(const char* mrmlId)
 {
-  this->m_Annotations->InitTraversal();
-
-  for (int i=0; i<this->m_Annotations->GetNumberOfItems(); ++i)
+  vtkMRMLNode *node = NULL;
+  vtkCollectionSimpleIterator it;
+  for (this->m_Annotations->InitTraversal(it);
+    (node = vtkMRMLNode::SafeDownCast(this->m_Annotations->GetNextItemAsObject(it)));)
     {
-    vtkMRMLNode* node = vtkMRMLNode::SafeDownCast(this->m_Annotations->GetItemAsObject(i));
-
-    if (!strcmp(mrmlId,node->GetID()))
+    if (node != NULL && !strcmp(mrmlId, node->GetID()))
       {
       // we found it
       return true;
@@ -198,14 +195,15 @@ void qSlicerAnnotationModuleReportDialog::generateReportRecursive(int level, vtk
   vtkCollection* children = vtkCollection::New();
   currentHierarchy->GetDirectChildren(children);
 
-  children->InitTraversal();
 
-  for(int i=0; i<children->GetNumberOfItems(); ++i)
+  vtkMRMLNode *node = NULL;
+  vtkCollectionSimpleIterator it;
+  for (this->m_Annotations->InitTraversal(it);
+    (node = vtkMRMLNode::SafeDownCast(this->m_Annotations->GetNextItemAsObject(it)));)
     {
     // loop through all children
 
-    vtkMRMLAnnotationNode* annotationNode = vtkMRMLAnnotationNode::SafeDownCast(children->GetItemAsObject(i));
-
+    vtkMRMLAnnotationNode* annotationNode = vtkMRMLAnnotationNode::SafeDownCast(node);
     if (annotationNode)
       {
       // this child is an annotationNode
@@ -221,8 +219,7 @@ void qSlicerAnnotationModuleReportDialog::generateReportRecursive(int level, vtk
 
       } // annotationNode
 
-    vtkMRMLAnnotationHierarchyNode* hierarchyNode = vtkMRMLAnnotationHierarchyNode::SafeDownCast(children->GetItemAsObject(i));
-
+    vtkMRMLAnnotationHierarchyNode* hierarchyNode = vtkMRMLAnnotationHierarchyNode::SafeDownCast(node);
     if (hierarchyNode)
       {
       // this child is a user created hierarchyNode
@@ -336,13 +333,14 @@ bool qSlicerAnnotationModuleReportDialog::saveReport()
     report.replace(QString(":/Icons/"), imgshortdir.append("/"));
     report.replace(tempPath, imgshortdir.append("/"));
 
-    this->m_Annotations->InitTraversal();
-
     // now save all graphics
-    for (int i=0; i<this->m_Annotations->GetNumberOfItems(); ++i)
+    vtkMRMLNode *node = NULL;
+    vtkCollectionSimpleIterator it;
+    for (this->m_Annotations->InitTraversal(it);
+      (node = vtkMRMLNode::SafeDownCast(this->m_Annotations->GetNextItemAsObject(it)));)
       {
-      vtkMRMLAnnotationNode* annotationNode = vtkMRMLAnnotationNode::SafeDownCast(this->m_Annotations->GetItemAsObject(i));
-      vtkMRMLAnnotationHierarchyNode* hierarchyNode = vtkMRMLAnnotationHierarchyNode::SafeDownCast(this->m_Annotations->GetItemAsObject(i));
+      vtkMRMLAnnotationNode* annotationNode = vtkMRMLAnnotationNode::SafeDownCast(node);
+      vtkMRMLAnnotationHierarchyNode* hierarchyNode = vtkMRMLAnnotationHierarchyNode::SafeDownCast(node);
 
       if (annotationNode)
         {

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
@@ -292,16 +292,18 @@ void vtkMRMLAnnotationDisplayableManager::UpdateFromMRML()
     {
     return;
     }
-  // loop over the nodes for which this manager provides widgets
-  this->GetMRMLScene()->InitTraversal();
-  vtkMRMLNode *node = this->GetMRMLScene()->GetNextNodeByClass(this->m_Focus);
+
   // turn off update from mrml requested, as we're doing it now, and create
   // widget requests a render which checks this flag before calling update
   // from mrml again
   this->SetUpdateFromMRMLRequested(0);
-  while (node != NULL)
+
+  // loop over the nodes for which this manager provides widgets
+  std::vector<vtkMRMLNode*> nodes;
+  this->GetMRMLScene()->GetNodesByClass(this->m_Focus, nodes);
+  for (std::vector< vtkMRMLNode* >::iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
     {
-    vtkMRMLAnnotationNode *annotationNode = vtkMRMLAnnotationNode::SafeDownCast(node);
+    vtkMRMLAnnotationNode *annotationNode = vtkMRMLAnnotationNode::SafeDownCast(*nodeIt);
     if (annotationNode)
       {
       // do we  have a widget for it?
@@ -315,7 +317,6 @@ void vtkMRMLAnnotationDisplayableManager::UpdateFromMRML()
           }
         }
       }
-    node = this->GetMRMLScene()->GetNextNodeByClass(this->m_Focus);
     }
   // set up observers on all the nodes
 //  this->SetAndObserveNodes();

--- a/Modules/Loadable/Annotations/Testing/Cxx/qMRMLSceneAnnotationModelAndAnnotationTreeWidgetTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/qMRMLSceneAnnotationModelAndAnnotationTreeWidgetTest1.cxx
@@ -85,7 +85,7 @@ int qMRMLSceneAnnotationModelAndAnnotationTreeViewTest1(int argc, char * argv []
 
   std::cout << "Measurement in rulerNode: " << rulerNode->GetDistanceMeasurement() << std::endl;
 /*
-  QModelIndex index = view->d_func()->SceneModel->indexFromNode(sceneFactory.mrmlScene()->GetNthNodeByClass(0,"vtkMRMLAnnotationRulerNode"));
+  QModelIndex index = view->d_func()->SceneModel->indexFromNode(sceneFactory.mrmlScene()->GetFirstNodeByClass("vtkMRMLAnnotationRulerNode"));
 
   qMRMLAbstractItemHelper* helper = view->d_func()->SceneModel->itemFromIndex(index);
   std::cout << helper->data(Qt::DisplayRole) << std::endl;

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationAngleNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationAngleNodeTest1.cxx
@@ -105,7 +105,7 @@ int vtkMRMLAnnotationAngleNodeTest1(int , char * [] )
     return EXIT_FAILURE;
     }
 
-  vtkMRMLAnnotationAngleNode *node3 = dynamic_cast < vtkMRMLAnnotationAngleNode *> (mrmlScene->GetNthNodeByClass(0,"vtkMRMLAnnotationAngleNode"));
+  vtkMRMLAnnotationAngleNode *node3 = vtkMRMLAnnotationAngleNode::SafeDownCast(mrmlScene->GetFirstNodeByClass("vtkMRMLAnnotationAngleNode"));
   if (!node3)
       {
     std::cerr << "Error in ReadXML() or WriteXML(): could not find vtkMRMLAnnotationAngleNode" << std::endl;

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationControlPointsNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationControlPointsNodeTest1.cxx
@@ -70,7 +70,8 @@ int vtkMRMLAnnotationControlPointsNodeTest1(int , char * [] )
 
   CHECK_INT(mrmlScene2->GetNumberOfNodesByClass("vtkMRMLAnnotationControlPointsNode"),1);
 
-  vtkMRMLAnnotationControlPointsNode *node3 = dynamic_cast < vtkMRMLAnnotationControlPointsNode *> (mrmlScene2->GetNthNodeByClass(0,"vtkMRMLAnnotationControlPointsNode"));
+  vtkMRMLAnnotationControlPointsNode *node3 = vtkMRMLAnnotationControlPointsNode::SafeDownCast(
+    mrmlScene->GetFirstNodeByClass("vtkMRMLAnnotationControlPointsNode"));
   CHECK_NOT_NULL(node3);
 
   vtkIndent ind;

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationFiducialNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationFiducialNodeTest1.cxx
@@ -66,7 +66,7 @@ int vtkMRMLAnnotationFiducialNodeTest1(int , char * [] )
 
   CHECK_INT(mrmlScene2->GetNumberOfNodesByClass("vtkMRMLAnnotationFiducialNode"),1);
 
-  vtkMRMLAnnotationFiducialNode *node3 = dynamic_cast < vtkMRMLAnnotationFiducialNode *> (mrmlScene2->GetNthNodeByClass(0,"vtkMRMLAnnotationFiducialNode"));
+  vtkMRMLAnnotationFiducialNode *node3 = vtkMRMLAnnotationFiducialNode::SafeDownCast(mrmlScene->GetFirstNodeByClass("vtkMRMLAnnotationFiducialNode"));
   CHECK_NOT_NULL(node3);
 
   std::stringstream initialAnnotation, afterAnnotation;

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationLinesNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationLinesNodeTest1.cxx
@@ -89,7 +89,7 @@ int vtkMRMLAnnotationLinesNodeTest1(int , char * [] )
 
   CHECK_INT(mrmlScene2->GetNumberOfNodesByClass("vtkMRMLAnnotationLinesNode"),1);
 
-  vtkMRMLAnnotationLinesNode *node3 = dynamic_cast < vtkMRMLAnnotationLinesNode *> (mrmlScene2->GetNthNodeByClass(0,"vtkMRMLAnnotationLinesNode"));
+  vtkMRMLAnnotationLinesNode *node3 = vtkMRMLAnnotationLinesNode::SafeDownCast(mrmlScene->GetFirstNodeByClass("vtkMRMLAnnotationLinesNode"));
   CHECK_NOT_NULL(node3);
 
   vtkIndent ind;

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationNodeTest1.cxx
@@ -125,12 +125,12 @@ int vtkMRMLAnnotationNodeTest1(int , char * [] )
     return EXIT_FAILURE;
     }
 
-  vtkMRMLAnnotationNode *node3 = dynamic_cast < vtkMRMLAnnotationNode *> (mrmlScene->GetNthNodeByClass(0,"vtkMRMLAnnotationNode"));
+  vtkMRMLAnnotationNode *node3 = vtkMRMLAnnotationNode::SafeDownCast(mrmlScene->GetFirstNodeByClass("vtkMRMLAnnotationNode"));
   if (!node3)
-      {
+    {
     std::cerr << "Error in ReadXML() or WriteXML()" << std::endl;
     return EXIT_FAILURE;
-      }
+    }
 
   vtkIndent ind;
   std::stringstream initialAnnotation, afterAnnotation;

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationRulerNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationRulerNodeTest1.cxx
@@ -101,7 +101,7 @@ int vtkMRMLAnnotationRulerNodeTest1(int , char * [] )
 
   CHECK_INT(mrmlScene2->GetNumberOfNodesByClass("vtkMRMLAnnotationRulerNode"),1);
 
-  vtkMRMLAnnotationRulerNode *node3 = dynamic_cast < vtkMRMLAnnotationRulerNode *> (mrmlScene2->GetNthNodeByClass(0,"vtkMRMLAnnotationRulerNode"));
+  vtkMRMLAnnotationRulerNode *node3 = vtkMRMLAnnotationRulerNode::SafeDownCast(mrmlScene->GetFirstNodeByClass("vtkMRMLAnnotationRulerNode"));
   CHECK_NOT_NULL(node3);
 
   std::stringstream initialAnnotation, afterAnnotation;

--- a/Modules/Loadable/Cameras/Testing/Cxx/vtkSlicerCamerasModuleLogicCopyImportedCamerasTest.cxx
+++ b/Modules/Loadable/Cameras/Testing/Cxx/vtkSlicerCamerasModuleLogicCopyImportedCamerasTest.cxx
@@ -111,7 +111,7 @@ bool TestCopyImportedCameras(bool clear, bool copy)
     expectedFirstCamera = importedCamera1Pos;
     }
   vtkMRMLCameraNode* firstCamera = vtkMRMLCameraNode::SafeDownCast(
-    scene->GetNthNodeByClass(0, "vtkMRMLCameraNode"));
+    scene->GetFirstNodeByClass("vtkMRMLCameraNode"));
   if (camera1->GetPosition()[0] != expectedCamera1Pos[0] ||
       camera2->GetPosition()[0] != expectedCamera2Pos[0] ||
       firstCamera->GetPosition()[0] != expectedFirstCamera[0])

--- a/Modules/Loadable/Colors/Testing/Cxx/qSlicerColorsModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Colors/Testing/Cxx/qSlicerColorsModuleWidgetTest1.cxx
@@ -51,12 +51,12 @@ int qSlicerColorsModuleWidgetTest1(int argc, char * argv [] )
   qSlicerColorsModuleWidget* colorsWidget =
     dynamic_cast<qSlicerColorsModuleWidget*>(colorsModule.widgetRepresentation());
   colorsWidget->show();
-  scene->InitTraversal();
-  vtkMRMLNode* node = scene->GetNextNodeByClass("vtkMRMLColorNode");
-  while (node)
+
+  std::vector< vtkMRMLNode* > nodes;
+  scene->GetNodesByClass("vtkMRMLColorNode", nodes);
+  for (std::vector< vtkMRMLNode* >::iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
     {
-    colorsWidget->setCurrentColorNode(node);
-    node = scene->GetNextNodeByClass("vtkMRMLColorNode");
+    colorsWidget->setCurrentColorNode(*nodeIt);
     }
 
   // colorsWidget->show();

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
@@ -332,7 +332,7 @@ void qSlicerCropVolumeModuleWidget::enter()
     // If none is selected then select the first one.
     if (d->ParametersNodeComboBox->currentNode() == NULL)
       {
-      d->ParametersNodeComboBox->setCurrentNode(scene->GetNthNodeByClass(0, "vtkMRMLCropVolumeParametersNode"));
+      d->ParametersNodeComboBox->setCurrentNode(scene->GetFirstNodeByClass("vtkMRMLCropVolumeParametersNode"));
       }
     }
 

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
@@ -242,21 +242,25 @@ void vtkMRMLMarkupsDisplayableManager2D::UpdateFromMRML()
     {
     return;
     }
+
+  std::vector<vtkMRMLNode*> nodes;
+  this->GetMRMLScene()->GetNodesByClass(this->Focus, nodes);
+
   // check if there are any of these nodes in the scene
-  if (this->GetMRMLScene()->GetNumberOfNodesByClass(this->Focus) < 1)
+  if (nodes.size() < 1)
     {
     return;
     }
-  // loop over the nodes for which this manager provides widgets
-  this->GetMRMLScene()->InitTraversal();
-  vtkMRMLNode *node = this->GetMRMLScene()->GetNextNodeByClass(this->Focus);
+
   // turn off update from mrml requested, as we're doing it now, and create
   // widget requests a render which checks this flag before calling update
   // from mrml again
   this->SetUpdateFromMRMLRequested(0);
-  while (node != NULL)
+
+  // loop over the nodes for which this manager provides widgets
+  for (std::vector< vtkMRMLNode* >::iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
     {
-    vtkMRMLMarkupsNode *markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
+    vtkMRMLMarkupsNode *markupsNode = vtkMRMLMarkupsNode::SafeDownCast(*nodeIt);
     if (markupsNode)
       {
       // do we  have a widget for it?
@@ -275,7 +279,6 @@ void vtkMRMLMarkupsDisplayableManager2D::UpdateFromMRML()
           }
         }
       }
-    node = this->GetMRMLScene()->GetNextNodeByClass(this->Focus);
     }
   // set up observers on all the nodes
 //  this->SetAndObserveNodes();

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager3D.cxx
@@ -235,21 +235,25 @@ void vtkMRMLMarkupsDisplayableManager3D::UpdateFromMRML()
     {
     return;
     }
+
+  std::vector<vtkMRMLNode*> nodes;
+  this->GetMRMLScene()->GetNodesByClass(this->Focus, nodes);
+
   // check if there are any of these nodes in the scene
-  if (this->GetMRMLScene()->GetNumberOfNodesByClass(this->Focus) < 1)
-    {
+  if (nodes.size() < 1)
+  {
     return;
-    }
-  // loop over the nodes for which this manager provides widgets
-  this->GetMRMLScene()->InitTraversal();
-  vtkMRMLNode *node = this->GetMRMLScene()->GetNextNodeByClass(this->Focus);
+  }
+
   // turn off update from mrml requested, as we're doing it now, and create
   // widget requests a render which checks this flag before calling update
   // from mrml again
   this->SetUpdateFromMRMLRequested(0);
-  while (node != NULL)
+
+  // loop over the nodes for which this manager provides widgets
+  for (std::vector< vtkMRMLNode* >::iterator nodeIt = nodes.begin(); nodeIt != nodes.end(); ++nodeIt)
     {
-    vtkMRMLMarkupsNode *markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
+    vtkMRMLMarkupsNode *markupsNode = vtkMRMLMarkupsNode::SafeDownCast(*nodeIt);
     if (markupsNode)
       {
       // do we  have a widget for it?
@@ -268,7 +272,6 @@ void vtkMRMLMarkupsDisplayableManager3D::UpdateFromMRML()
           }
         }
       }
-    node = this->GetMRMLScene()->GetNextNodeByClass(this->Focus);
     }
   // set up observers on all the nodes
 //  this->SetAndObserveNodes();

--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
@@ -76,7 +76,7 @@ void vtkSlicerModelsLogic::SetMRMLSceneInternal(vtkMRMLScene* newScene)
 void vtkSlicerModelsLogic::ObserveMRMLScene()
 {
   if (this->GetMRMLScene() &&
-      this->GetMRMLScene()->GetNthNodeByClass(0, "vtkMRMLClipModelsNode") == 0)
+    this->GetMRMLScene()->GetFirstNodeByClass("vtkMRMLClipModelsNode") == 0)
     {
     // vtkMRMLClipModelsNode is a singleton
     this->GetMRMLScene()->AddNode(vtkSmartPointer<vtkMRMLClipModelsNode>::New());

--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTestScene.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTestScene.cxx
@@ -64,9 +64,8 @@ int qSlicerModelsModuleWidgetTestScene( int argc, char * argv[] )
 
   qMRMLThreeDWidget view;
   view.setMRMLScene(scene.GetPointer());
-  scene->InitTraversal();
   view.setMRMLViewNode(vtkMRMLViewNode::SafeDownCast(
-    scene->GetNextNodeByClass("vtkMRMLViewNode")));
+    scene->GetFirstNodeByClass("vtkMRMLViewNode")));
   view.show();
 
   if (argc < 3 || QString(argv[2]) != "-I")

--- a/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest2.cxx
+++ b/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest2.cxx
@@ -49,9 +49,8 @@ int qMRMLModelDisplayNodeWidgetTest2( int argc, char * argv [] )
   scene->SetURL(argv[1]);
   scene->Connect();
 
-  scene->InitTraversal();
   vtkMRMLModelDisplayNode* modelDisplayNode = vtkMRMLModelDisplayNode::SafeDownCast(
-    scene->GetNextNodeByClass("vtkMRMLModelDisplayNode"));
+    scene->GetFirstNodeByClass("vtkMRMLModelDisplayNode"));
 
   if (!modelDisplayNode)
     {

--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
@@ -554,7 +554,7 @@ void qSlicerReformatModuleWidget::setNormalToCamera()
   // NOTE: We use the first Camera because there is no notion of active scene
   // Code to be changed when methods avaible.
   vtkMRMLCameraNode* cameraNode = vtkMRMLCameraNode::SafeDownCast(
-    reformatLogic->GetMRMLScene()->GetNthNodeByClass(0, "vtkMRMLCameraNode"));
+    reformatLogic->GetMRMLScene()->GetFirstNodeByClass("vtkMRMLCameraNode"));
 
   if (!cameraNode)
     {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyChartsPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyChartsPlugin.cxx
@@ -216,11 +216,7 @@ void qSlicerSubjectHierarchyChartsPlugin::setDisplayVisibility(vtkIdType itemID,
     }
 
   // Get layout node
-  vtkSmartPointer<vtkCollection> layoutNodes =
-    vtkSmartPointer<vtkCollection>::Take( scene->GetNodesByClass("vtkMRMLLayoutNode") );
-  layoutNodes->InitTraversal();
-  vtkObject* layoutNodeVtkObject = layoutNodes->GetNextItemAsObject();
-  vtkMRMLLayoutNode* layoutNode = vtkMRMLLayoutNode::SafeDownCast(layoutNodeVtkObject);
+  vtkMRMLLayoutNode* layoutNode = vtkMRMLLayoutNode::SafeDownCast(scene->GetFirstNodeByClass("vtkMRMLLayoutNode"));
   if (!layoutNode)
     {
     qCritical() << Q_FUNC_INFO << ": Unable to get layout node!";
@@ -328,10 +324,7 @@ vtkMRMLChartViewNode* qSlicerSubjectHierarchyChartsPlugin::getChartViewNode()con
     return NULL;
     }
 
-  vtkSmartPointer<vtkCollection> chartViewNodes =
-    vtkSmartPointer<vtkCollection>::Take( scene->GetNodesByClass("vtkMRMLChartViewNode") );
-  chartViewNodes->InitTraversal();
-  vtkMRMLChartViewNode* chartViewNode = vtkMRMLChartViewNode::SafeDownCast( chartViewNodes->GetNextItemAsObject() );
+  vtkMRMLChartViewNode* chartViewNode = vtkMRMLChartViewNode::SafeDownCast(scene->GetFirstNodeByClass("vtkMRMLChartViewNode"));
   if (!chartViewNode)
     {
     return NULL;

--- a/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.cxx
+++ b/Modules/Loadable/Tables/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTablesPlugin.cxx
@@ -213,11 +213,7 @@ void qSlicerSubjectHierarchyTablesPlugin::setDisplayVisibility(vtkIdType itemID,
     }
 
   // Get layout node
-  vtkSmartPointer<vtkCollection> layoutNodes =
-    vtkSmartPointer<vtkCollection>::Take( scene->GetNodesByClass("vtkMRMLLayoutNode") );
-  layoutNodes->InitTraversal();
-  vtkObject* layoutNodeVtkObject = layoutNodes->GetNextItemAsObject();
-  vtkMRMLLayoutNode* layoutNode = vtkMRMLLayoutNode::SafeDownCast(layoutNodeVtkObject);
+  vtkMRMLLayoutNode* layoutNode = vtkMRMLLayoutNode::SafeDownCast(scene->GetFirstNodeByClass("vtkMRMLLayoutNode"));
   if (!layoutNode)
     {
     qCritical("qSlicerSubjectHierarchyTablesPlugin::getTableViewNode: Unable to get layout node");
@@ -324,10 +320,7 @@ vtkMRMLTableViewNode* qSlicerSubjectHierarchyTablesPlugin::getTableViewNode()con
     return NULL;
     }
 
-  vtkSmartPointer<vtkCollection> tableViewNodes =
-    vtkSmartPointer<vtkCollection>::Take( scene->GetNodesByClass("vtkMRMLTableViewNode") );
-  tableViewNodes->InitTraversal();
-  vtkMRMLTableViewNode* tableViewNode = vtkMRMLTableViewNode::SafeDownCast( tableViewNodes->GetNextItemAsObject() );
+  vtkMRMLTableViewNode* tableViewNode = vtkMRMLTableViewNode::SafeDownCast(scene->GetFirstNodeByClass("vtkMRMLTableViewNode"));
   if (!tableViewNode)
     {
     return NULL;

--- a/Modules/Loadable/Transforms/Widgets/qMRMLTransformInfoWidget.cxx
+++ b/Modules/Loadable/Transforms/Widgets/qMRMLTransformInfoWidget.cxx
@@ -82,7 +82,7 @@ void qMRMLTransformInfoWidgetPrivate::setAndObserveCrosshairNode()
   vtkMRMLCrosshairNode* crosshairNode = 0;
   if (this->MRMLScene.GetPointer())
     {
-    crosshairNode = vtkMRMLCrosshairNode::SafeDownCast(this->MRMLScene->GetNthNodeByClass(0, "vtkMRMLCrosshairNode"));
+    crosshairNode = vtkMRMLCrosshairNode::SafeDownCast(this->MRMLScene->GetFirstNodeByClass("vtkMRMLCrosshairNode"));
     }
 
   q->qvtkReconnect(this->CrosshairNode.GetPointer(), crosshairNode,

--- a/Modules/Loadable/ViewControllers/qSlicerViewControllersModuleWidget.cxx
+++ b/Modules/Loadable/ViewControllers/qSlicerViewControllersModuleWidget.cxx
@@ -222,20 +222,22 @@ void qSlicerViewControllersModuleWidget::setMRMLScene(vtkMRMLScene *newScene)
 
   // Search the scene for the available view nodes and create a
   // Controller and connect it up
-  newScene->InitTraversal();
-  for (vtkMRMLNode *sn = NULL; (sn=newScene->GetNextNodeByClass("vtkMRMLSliceNode"));)
+  std::vector<vtkMRMLNode*> sliceNodes;
+  newScene->GetNodesByClass("vtkMRMLSliceNode", sliceNodes);
+  for (std::vector< vtkMRMLNode* >::iterator sliceNodeIt = sliceNodes.begin(); sliceNodeIt != sliceNodes.end(); ++sliceNodeIt)
     {
-    vtkMRMLSliceNode *snode = vtkMRMLSliceNode::SafeDownCast(sn);
+    vtkMRMLSliceNode *snode = vtkMRMLSliceNode::SafeDownCast(*sliceNodeIt);
     if (snode)
       {
       d->createController(snode, layoutManager);
       }
     }
 
-  newScene->InitTraversal();
-  for (vtkMRMLNode *sn = NULL; (sn=newScene->GetNextNodeByClass("vtkMRMLViewNode"));)
+  std::vector<vtkMRMLNode*> threeDNodes;
+  newScene->GetNodesByClass("vtkMRMLViewNode", threeDNodes);
+  for (std::vector< vtkMRMLNode* >::iterator threeDNodeIt = threeDNodes.begin(); threeDNodeIt != threeDNodes.end(); ++threeDNodeIt)
     {
-    vtkMRMLViewNode *vnode = vtkMRMLViewNode::SafeDownCast(sn);
+    vtkMRMLViewNode *vnode = vtkMRMLViewNode::SafeDownCast(*threeDNodeIt);
     if (vnode)
       {
       d->createController(vnode, layoutManager);
@@ -358,7 +360,6 @@ void qSlicerViewControllersModuleWidget::onLayoutChanged(int)
 
   vtkMRMLLayoutLogic *layoutLogic = layoutManager->layoutLogic();
   vtkCollection *visibleViews = layoutLogic->GetViewNodes();
-  vtkObject *v;
 
   // hide Controllers for Nodes not currently visible in
   // the layout
@@ -375,7 +376,10 @@ void qSlicerViewControllersModuleWidget::onLayoutChanged(int)
 
   // show Controllers for Nodes not currently being managed
   // by this widget
-  for (visibleViews->InitTraversal(); (v = visibleViews->GetNextItemAsObject());)
+  vtkObject *v = NULL;
+  vtkCollectionSimpleIterator it;
+  for (visibleViews->InitTraversal(it);
+    (v = visibleViews->GetNextItemAsObject(it));)
     {
     vtkMRMLNode *vn = vtkMRMLNode::SafeDownCast(v);
     if (vn)

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyNodeTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyNodeTest1.cxx
@@ -109,7 +109,7 @@ int readWrite()
 
   vtkMRMLVolumePropertyNode* propertyNode2 =
     vtkMRMLVolumePropertyNode::SafeDownCast(
-      scene2->GetNthNodeByClass(0, "vtkMRMLVolumePropertyNode"));
+    scene2->GetFirstNodeByClass("vtkMRMLVolumePropertyNode"));
   CHECK_NOT_NULL(propertyNode2);
 
   vtkPiecewiseFunction* scalarOpacity2 = propertyNode2->GetScalarOpacity();

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -98,7 +98,7 @@ class DataProbeInfoWidget(object):
     self.calculateTensorScalars = CalculateTensorScalars()
 
     # Observe the crosshair node to get the current cursor position
-    self.CrosshairNode = slicer.mrmlScene.GetNthNodeByClass(0, 'vtkMRMLCrosshairNode')
+    self.CrosshairNode = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLCrosshairNode')
     if self.CrosshairNode:
       self.CrosshairNodeObserverTag = self.CrosshairNode.AddObserver(slicer.vtkMRMLCrosshairNode.CursorPositionModifiedEvent, self.processEvent)
 

--- a/Modules/Scripted/EditorLib/LabelStructureListWidget.py
+++ b/Modules/Scripted/EditorLib/LabelStructureListWidget.py
@@ -194,16 +194,17 @@ class LabelStructureListWidget(qt.QWidget):
     volumes of the current master"""
     volumeNodes = []
     masterName = self.master.GetName()
-    slicer.mrmlScene.InitTraversal()
-    vNode = slicer.mrmlScene.GetNextNodeByClass( "vtkMRMLScalarVolumeNode" )
     self.row = 0
-    while vNode:
+    nodes = slicer.mrmlScene.GetNodesByClass("vtkMRMLScalarVolumeNode")
+    for index in range(nodes.GetNumberOfItems()):
+      vNode = nodes.GetItemAsObject(index)
+
       vName = vNode.GetName()
       # match something like "CT-lung-label1"
       fnmatchExp = "%s-*%s*" % (masterName, self.mergeVolumePostfix)
       if fnmatch.fnmatchcase(vName,fnmatchExp):
         volumeNodes.append(vNode)
-      vNode = slicer.mrmlScene.GetNextNodeByClass( "vtkMRMLScalarVolumeNode" )
+
     return volumeNodes
 
   #---------------------------------------------------------------------------

--- a/Modules/Scripted/LabelStatistics/LabelStatistics.py
+++ b/Modules/Scripted/LabelStatistics/LabelStatistics.py
@@ -375,16 +375,10 @@ class LabelStatisticsLogic(ScriptedLoadableModuleLogic):
   def createStatsChart(self, labelNode, valueToPlot, ignoreZero=False):
     """Make a MRML chart of the current stats
     """
-    layoutNodes = slicer.mrmlScene.GetNodesByClass('vtkMRMLLayoutNode')
-    layoutNodes.SetReferenceCount(layoutNodes.GetReferenceCount()-1)
-    layoutNodes.InitTraversal()
-    layoutNode = layoutNodes.GetNextItemAsObject()
+    layoutNode = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLLayoutNode')
     layoutNode.SetViewArrangement(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalQuantitativeView)
 
-    chartViewNodes = slicer.mrmlScene.GetNodesByClass('vtkMRMLChartViewNode')
-    chartViewNodes.SetReferenceCount(chartViewNodes.GetReferenceCount()-1)
-    chartViewNodes.InitTraversal()
-    chartViewNode = chartViewNodes.GetNextItemAsObject()
+    chartViewNode = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLChartViewNode')
 
     arrayNode = slicer.mrmlScene.AddNode(slicer.vtkMRMLDoubleArrayNode())
     array = arrayNode.GetArray()

--- a/Modules/Scripted/PerformanceTests/PerformanceTests.py
+++ b/Modules/Scripted/PerformanceTests/PerformanceTests.py
@@ -169,18 +169,14 @@ class PerformanceTestsWidget:
 
   def chartTest(self):
     import math,random
-    lns = slicer.mrmlScene.GetNodesByClass('vtkMRMLLayoutNode')
-    lns.InitTraversal()
-    ln = lns.GetNextItemAsObject()
+    ln = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLLayoutNode')
     ln.SetViewArrangement(24)
 
     chartView = findChildren(className='qMRMLChartView')[0]
     print(chartView.connect("dataMouseOver(const char *,int,double,double)", self.chartMouseOverCallback))
     print(chartView.connect("dataPointClicked(const char *,int,double,double)", self.chartCallback))
 
-    cvns = slicer.mrmlScene.GetNodesByClass('vtkMRMLChartViewNode')
-    cvns.InitTraversal()
-    cvn = cvns.GetNextItemAsObject()
+    cvn = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLChartViewNode')
 
     dn = slicer.mrmlScene.AddNode(slicer.vtkMRMLDoubleArrayNode())
     a = dn.GetArray()


### PR DESCRIPTION
Collections have convenience functions for traversing it without the need for creating an iterator,
using InitTraversal() and GetNextItemAsObject(). These functions use an internal iterator stored in the collection.

Problem:

When a collection is traversed using the internal iterator by multiple functions at the same time, the behavior will be incorrect.

For collections that can be accessed by multiple objects, it is almost impossible to make sure that only one function will use the internal iterator at a time. Therefore, shared collections must be traversed using external iterators.

For example, this error caused a bug in View Controllers module: it only showed the first slice view controller (while there were three). The problem was that View Controllers module iterated through the nodes using the internal iterator and internally a method was called that asked for a list of nodes by classname, which used the same internal iterator.

Solution:

- Made vtkMRMLScene's InitTraversal, GetNextNode, and GetNextNodeByClass methods deprecated (they are still functional, but log a warning when they are called).
- Replaced all instances of shared collection traversal with internal iterator.
- Added vtkMRMLScene::GetFirstNodeByClass convenience function and modified functions that used InitTraversal/GetNextNodeByClass or GetNthNodeByClass(0, ...) to use this function.