### PR TITLE
RFC: "ENH: add 'AllowMemoryTransfer' CLI setting"

### DIFF
--- a/Base/QTCLI/qSlicerCLIModule.cxx
+++ b/Base/QTCLI/qSlicerCLIModule.cxx
@@ -102,6 +102,11 @@ vtkMRMLAbstractLogic* qSlicerCLIModule::createLogic()
     logic->DeleteTemporaryFilesOff();
     }
 
+  if (d->Desc.GetParameterDefaultValue("AllowInMemoryTransfer") == "false")
+    {
+    logic->SetAllowInMemoryTransfer(0);
+    }
+
   return logic;
 }
 

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.h
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.h
@@ -76,6 +76,10 @@ public:
   void SetDeleteTemporaryFiles(int value);
   int GetDeleteTemporaryFiles() const;
 
+  // Control use of in-memory data transfer by this specific CLI.
+  void SetAllowInMemoryTransfer(int value);
+  int GetAllowInMemoryTransfer() const;
+
   /// For debugging, control redirection of cout and cerr
   virtual void RedirectModuleStreamsOn();
   virtual void RedirectModuleStreamsOff();


### PR DESCRIPTION
Request for comment...

This allows a CLI to control whether in-memory (MRMLID) transfer is attempted.
Implemented as a parameter for simplicity. Could be implemented at the execution model level, but
not sure it's worth the churn (etc.) that would cause.