### PR TITLE
BUG: Fixed warping of markup fiducial labels

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.cxx
@@ -196,6 +196,13 @@ void vtkMRMLRulerDisplayableManager::vtkInternal::SetupMarkerRenderer()
     }
   this->MarkerRenderer->SetLayer(RENDERER_LAYER);
   renderWindow->AddRenderer(this->MarkerRenderer);
+  // Parallel projection is needed to prevent actors from warping/tilting
+  // when they are near the edge of the window.
+  vtkCamera* camera = this->MarkerRenderer->GetActiveCamera();
+  if (camera)
+    {
+    camera->ParallelProjectionOn();
+    }
 
   // In 3D viewers we need to follow the renderer and update the orientation marker accordingly
   vtkMRMLViewNode* threeDViewNode = vtkMRMLViewNode::SafeDownCast(this->External->GetMRMLDisplayableNode());

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.cxx
@@ -81,7 +81,7 @@ vtkMRMLAnnotationDisplayableManager::vtkMRMLAnnotationDisplayableManager()
   this->m_Focus = "vtkMRMLAnnotationNode";
 
   // by default, multiply the display node scale by this when setting scale on elements in 2d windows
-  this->ScaleFactor2D = 0.00333;
+  this->ScaleFactor2D = 0.01667;
 
   this->LastClickWorldCoordinates[0]=0;
   this->LastClickWorldCoordinates[1]=0;

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationFiducialDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationFiducialDisplayableManager.cxx
@@ -192,8 +192,8 @@ vtkAbstractWidget * vtkMRMLAnnotationFiducialDisplayableManager::CreateWidget(vt
     return 0;
     }
 
-  // 2d glyphs and text need to be scaled by 1/300 to show up properly in the 2d slice windows
-  this->SetScaleFactor2D(0.0033);
+  // 2d glyphs and text need to be scaled by 1/60 to show up properly in the 2d slice windows
+  this->SetScaleFactor2D(0.01667);
 
   vtkMRMLAnnotationFiducialNode* fiducialNode = vtkMRMLAnnotationFiducialNode::SafeDownCast(node);
 

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
@@ -86,7 +86,7 @@ vtkMRMLMarkupsDisplayableManager2D::vtkMRMLMarkupsDisplayableManager2D()
   this->SliceNode = 0;
 
   // by default, multiply the display node scale by this when setting scale on elements in 2d windows
-  this->ScaleFactor2D = 0.00333;
+  this->ScaleFactor2D = 0.01667;
 
   this->LastClickWorldCoordinates[0]=0.0;
   this->LastClickWorldCoordinates[1]=0.0;

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager2D.cxx
@@ -267,8 +267,8 @@ vtkAbstractWidget * vtkMRMLMarkupsFiducialDisplayableManager2D::CreateWidget(vtk
     return 0;
     }
 
-  // 2d glyphs and text need to be scaled by 1/300 to show up properly in the 2d slice windows
-  this->SetScaleFactor2D(0.0033);
+  // 2d glyphs and text need to be scaled by 1/60 to show up properly in the 2d slice windows
+  this->SetScaleFactor2D(0.01667);
 
   vtkMRMLMarkupsFiducialNode* fiducialNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(node);
 


### PR DESCRIPTION
Warping of markup fiducial labels was caused by using perspective projection in overlay renderer's camera. See details in https://github.com/commontk/CTK/pull/720.

Before the fix:
![image](https://user-images.githubusercontent.com/307929/27387586-1f49c2c4-5667-11e7-960e-d28734220cb7.png)

After the fix:
![image](https://user-images.githubusercontent.com/307929/27387596-23aeb202-5667-11e7-859b-f534de2dd175.png)

By switching to parallel projection, default scaling of widgets have to be adjusted, which is addressed in this pull request.

Merge this exactly at the same time when switching to the fixed CTK version!