### PR TITLE
Updating Slicer to integrate the changes of SEM

### DIFF
--- a/Base/QTCLI/qSlicerCLIModule.cxx
+++ b/Base/QTCLI/qSlicerCLIModule.cxx
@@ -102,7 +102,7 @@ vtkMRMLAbstractLogic* qSlicerCLIModule::createLogic()
     logic->DeleteTemporaryFilesOff();
     }
 
-  if (d->Desc.GetParameterDefaultValue("AllowInMemoryTransfer") == "false")
+  if (d->Desc.GetParameterValue("AllowInMemoryTransfer") == "false")
     {
     logic->SetAllowInMemoryTransfer(0);
     }

--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -293,7 +293,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createIntegerTagWidget(const ModulePar
     return createStringTagWidget(moduleParameter);
   }
 
-  int value = QString::fromStdString(moduleParameter.GetDefault()).toInt();
+  int value = QString::fromStdString(moduleParameter.GetValue()).toInt();
   int step = 1;
   // Since, ctkDoubleSlider checks that MIN_INT < doubleValue / this->SingleStep < MAX_INT
   // Assuming the singlestep won't be smaller than 0.01, the min/max range set from the helper
@@ -346,7 +346,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createBooleanTagWidget(const ModulePar
     return createStringTagWidget(moduleParameter);
   }
 
-  QString valueAsStr = QString::fromStdString(moduleParameter.GetDefault());
+  QString valueAsStr = QString::fromStdString(moduleParameter.GetValue());
   QCheckBox * widget = new QCheckBox;
   QString _label = QString::fromStdString(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
@@ -363,7 +363,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createFloatTagWidget(const ModuleParam
     return createStringTagWidget(moduleParameter);
   }
 
-  QString valueAsStr = QString::fromStdString(moduleParameter.GetDefault());
+  QString valueAsStr = QString::fromStdString(moduleParameter.GetValue());
   float value = valueAsStr.toFloat();
   float step = 0.1;
   // Since, ctkDoubleSlider checks that MIN_INT < doubleValue / this->SingleStep < MAX_INT
@@ -443,7 +443,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createDoubleTagWidget(const ModulePara
     return createStringTagWidget(moduleParameter);
   }
 
-  QString valueAsStr = QString::fromStdString(moduleParameter.GetDefault());
+  QString valueAsStr = QString::fromStdString(moduleParameter.GetValue());
   double value = valueAsStr.toDouble();
   double step = 0.1;
   // Since, ctkDoubleSlider checks that MIN_INT < doubleValue / this->SingleStep < MAX_INT
@@ -517,7 +517,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createDoubleTagWidget(const ModulePara
 //-----------------------------------------------------------------------------
 QWidget* qSlicerCLIModuleUIHelperPrivate::createStringTagWidget(const ModuleParameter& moduleParameter)
 {
-  QString valueAsStr = QString::fromStdString(moduleParameter.GetDefault());
+  QString valueAsStr = QString::fromStdString(moduleParameter.GetValue());
   QLineEdit * widget = new QLineEdit;
   QString _label = QString::fromStdString(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -1065,7 +1065,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
           || (*pit).GetTag() == "transform" || (*pit).GetTag() == "table"
           || (*pit).GetTag() == "measurement" || (*pit).GetTag() == "pointfile")
         {
-        std::string id = (*pit).GetDefault();
+        std::string id = (*pit).GetValue();
 
         // if the parameter is hidden, then deduce its value/id
         if ((*pit).GetHidden() == "true")
@@ -1073,7 +1073,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
           id = this->FindHiddenNodeID(node0->GetModuleDescription(), *pit);
 
           // cache the id so we don't have to look for it later
-          (*pit).SetDefault( id );
+          (*pit).SetValue( id );
           }
 
         // only keep track of objects associated with real nodes
@@ -1457,7 +1457,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
           {
           // simple parameter, write flag and value
           commandLineAsString.push_back(prefix + flag);
-          commandLineAsString.push_back((*pit).GetDefault());
+          commandLineAsString.push_back((*pit).GetValue());
           continue;
           }
         if ((*pit).GetTag() == "boolean")
@@ -1465,7 +1465,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
           // booleans only have a flag (no value) in non-Python modules
           if ( commandType != PythonModule )
             {
-            if ((*pit).GetDefault() == "true")
+            if ((*pit).GetValue() == "true")
               {
               commandLineAsString.push_back(prefix + flag);
               }
@@ -1474,7 +1474,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
             {
             // For Python, if the flag is true or false, specify that
             commandLineAsString.push_back ( prefix + flag );
-            commandLineAsString.push_back ( (*pit).GetDefault() );
+            commandLineAsString.push_back ( (*pit).GetValue() );
             }
           continue;
           }
@@ -1486,10 +1486,10 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
             || (*pit).GetTag() == "string-vector")
           {
           // Only write out the flag if value is not empty
-          if ((*pit).GetDefault() != "")
+          if ((*pit).GetValue() != "")
             {
             commandLineAsString.push_back(prefix + flag);
-            commandLineAsString.push_back((*pit).GetDefault());
+            commandLineAsString.push_back((*pit).GetValue());
             }
           continue;
           }
@@ -1504,13 +1504,13 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
           // established earlier
           MRMLIDToFileNameMap::const_iterator id2fn;
 
-          id2fn  = nodesToWrite.find( (*pit).GetDefault() );
+          id2fn  = nodesToWrite.find( (*pit).GetValue() );
           if ((*pit).GetChannel() == "input" && id2fn != nodesToWrite.end())
             {
             fname = (*id2fn).second;
             }
 
-          id2fn  = nodesToReload.find( (*pit).GetDefault() );
+          id2fn  = nodesToReload.find( (*pit).GetValue() );
           if ((*pit).GetChannel() == "output" && id2fn != nodesToReload.end())
             {
             fname = (*id2fn).second;
@@ -1518,7 +1518,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
 
           // check to see if we need to remap to a scene file and node id
           MRMLIDMap::iterator mit
-            = sceneToMiniSceneMap.find((*pit).GetDefault());
+            = sceneToMiniSceneMap.find((*pit).GetValue());
           if (mit != sceneToMiniSceneMap.end())
             {
             // node is being sent inside of a scene, so use the scene
@@ -1553,7 +1553,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
 
           // get the fiducial list node
           vtkMRMLNode *node
-            = this->GetMRMLScene()->GetNodeByID((*pit).GetDefault().c_str());
+            = this->GetMRMLScene()->GetNodeByID((*pit).GetValue().c_str());
           vtkMRMLFiducialListNode *fiducials
             = vtkMRMLFiducialListNode::SafeDownCast(node);
           vtkMRMLDisplayableHierarchyNode *points = vtkMRMLDisplayableHierarchyNode::SafeDownCast(node);
@@ -1662,7 +1662,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
             }
           // get the fiducial list node
           vtkMRMLNode *node
-            = this->GetMRMLScene()->GetNodeByID((*pit).GetDefault().c_str());
+            = this->GetMRMLScene()->GetNodeByID((*pit).GetValue().c_str());
           vtkMRMLDisplayableNode *markups = vtkMRMLDisplayableNode::SafeDownCast(node);
           if (markups && markups->IsA("vtkMRMLMarkupsFiducialNode"))
             {
@@ -1701,7 +1701,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
 
           // get the region node
           vtkMRMLNode *node
-            = this->GetMRMLScene()->GetNodeByID((*pit).GetDefault().c_str());
+            = this->GetMRMLScene()->GetNodeByID((*pit).GetValue().c_str());
           vtkMRMLROIListNode *regions = vtkMRMLROIListNode::SafeDownCast(node);
 
           vtkMRMLDisplayableHierarchyNode *points = vtkMRMLDisplayableHierarchyNode::SafeDownCast(node);
@@ -1825,7 +1825,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
         && (*iit).second.GetTag() != "double-vector"
         && (*iit).second.GetTag() != "string-vector")
       {
-      commandLineAsString.push_back((*iit).second.GetDefault());
+      commandLineAsString.push_back((*iit).second.GetValue());
       }
     else if ((*iit).second.GetTag() == "file"
              || (*iit).second.GetTag() == "directory"
@@ -1835,9 +1835,9 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
              || (*iit).second.GetTag() == "double-vector"
              || (*iit).second.GetTag() == "string-vector")
       {
-      if ((*iit).second.GetDefault() != "")
+      if ((*iit).second.GetValue() != "")
         {
-        commandLineAsString.push_back((*iit).second.GetDefault());
+        commandLineAsString.push_back((*iit).second.GetValue());
         }
       else
         {
@@ -1873,7 +1873,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
       if ((*iit).second.GetChannel() == "input")
         {
         // Check to make sure the index parameter is set
-        id2fn  = nodesToWrite.find( (*iit).second.GetDefault() );
+        id2fn  = nodesToWrite.find( (*iit).second.GetValue() );
         if (id2fn != nodesToWrite.end())
           {
           fname = (*id2fn).second;
@@ -1882,7 +1882,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
       else if ((*iit).second.GetChannel() == "output")
         {
         // Check to make sure the index parameter is set
-        id2fn  = nodesToReload.find( (*iit).second.GetDefault() );
+        id2fn  = nodesToReload.find( (*iit).second.GetValue() );
         if (id2fn != nodesToReload.end())
           {
           fname = (*id2fn).second;
@@ -1891,7 +1891,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
 
       // check to see if we need to remap to a scene file and node id
       MRMLIDMap::iterator mit
-        = sceneToMiniSceneMap.find((*iit).second.GetDefault());
+        = sceneToMiniSceneMap.find((*iit).second.GetValue());
       if (mit != sceneToMiniSceneMap.end())
         {
         // node is being sent inside of a scene, so use the scene
@@ -2557,7 +2557,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
           if (node0->GetModuleDescription().HasParameter((*pit).GetReference()))
             {
             // get the id stored in the parameter referenced
-            std::string reference = node0->GetModuleDescription().GetParameterDefaultValue((*pit).GetReference());
+            std::string reference = node0->GetModuleDescription().GetParameterValue((*pit).GetReference());
             if (reference.size() > 0)
               {
               // "reference" can mean different things based on the parameter type.
@@ -2575,7 +2575,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
                   vtkMRMLTransformableNode *trefNode = vtkMRMLTransformableNode::SafeDownCast(refNode);
                   if (trefNode)
                     {
-                    if ( (*pit).GetDefault() != "" )
+                    if ( (*pit).GetValue() != "" )
                       {
                       // Invoke an event that will cause the scene to be rewired in the main thread.
                       // Pass a callback that performs the specific edit request. Callback is allocated here and
@@ -2583,7 +2583,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
                       vtkSlicerCLIEditTransformHierarchyCallback *callback = vtkSlicerCLIEditTransformHierarchyCallback::New();
                       callback->SetCLIModuleLogic(this);
                       callback->SetNodeID(reference);
-                      callback->SetTransformNodeID((*pit).GetDefault());
+                      callback->SetTransformNodeID((*pit).GetValue());
 
                       this->GetApplicationLogic()->InvokeEventWithDelay(0, this,
                                                                         vtkSlicerCLIModuleLogic::RequestHierarchyEditEvent,
@@ -2596,7 +2596,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
                 else if (((*pit).GetTag() == "image") || ((*pit).GetTag() == "geometry"))
                   {
                   // Placing an image or model in the same position in a hierarchy as the reference
-                  if ( (*pit).GetDefault() != "" )
+                  if ( (*pit).GetValue() != "" )
                     {
                     // Invoke an event that will cause the scene to be rewired in the main thread.
                     // Pass a callback that performs the specific edit request. Callback is allocated here and
@@ -2604,7 +2604,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
                     vtkSlicerCLIEditSubjectHierarchyCallback *callback = vtkSlicerCLIEditSubjectHierarchyCallback::New();
                     callback->SetCLIModuleLogic(this);
                     callback->SetReferenceNodeID(reference);
-                    callback->SetOutputNodeID((*pit).GetDefault());
+                    callback->SetOutputNodeID((*pit).GetValue());
 
                     this->GetApplicationLogic()->InvokeEventWithDelay(0, this,
                                                                       vtkSlicerCLIModuleLogic::RequestHierarchyEditEvent,
@@ -2620,7 +2620,7 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
                 }
               else
                 {
-                vtkWarningMacro( << "Cannot find referenced node " << (*pit).GetDefault());
+                vtkWarningMacro( << "Cannot find referenced node " << (*pit).GetValue());
                 }
               }
             }
@@ -2735,7 +2735,7 @@ vtkSlicerCLIModuleLogic::FindHiddenNodeID(const ModuleDescription& d,
       std::string reference;
       if (d.HasParameter(p.GetReference()))
         {
-        reference = d.GetParameterDefaultValue(p.GetReference());
+        reference = d.GetParameterValue(p.GetReference());
 
         if (p.GetTag() == "table")
           {
@@ -2810,7 +2810,7 @@ vtkSlicerCLIModuleLogic::FindHiddenNodeID(const ModuleDescription& d,
   else
     {
     // not a hidden node, just return the default
-    id = p.GetDefault();
+    id = p.GetValue();
     }
 
   return id;

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -154,7 +154,7 @@ void vtkMRMLCommandLineModuleNode::WriteXML(ostream& of, int nIndent)
       // variable and it was getting over written when used twice before the
       // buffer was flushed.
       of << " " << this->URLEncodeString ( (*pit).GetName().c_str() );
-      of  << "=\"" << this->URLEncodeString ( (*pit).GetDefault().c_str() ) << "\"";
+      of  << "=\"" << this->URLEncodeString ( (*pit).GetValue().c_str() ) << "\"";
       }
     }
 
@@ -252,7 +252,7 @@ void vtkMRMLCommandLineModuleNode::ReadXMLAttributes(const char** atts)
 
     if (this->Internal->ModuleDescriptionObject.HasParameter(attName))
       {
-      this->Internal->ModuleDescriptionObject.SetParameterDefaultValue(sattName.c_str(),sattValue.c_str());
+      this->Internal->ModuleDescriptionObject.SetParameterValue(sattName.c_str(),sattValue.c_str());
       }
     }
   this->EndModify(wasModifying);
@@ -287,7 +287,7 @@ void vtkMRMLCommandLineModuleNode::PrintSelf(ostream& os, vtkIndent indent)
     std::vector<ModuleParameter>::const_iterator pendit = (*pgit).GetParameters().end();
     for (std::vector<ModuleParameter>::const_iterator pit = pbeginit; pit != pendit; ++pit)
       {
-      os << indent << " " << (*pit).GetName() << " = " << (*pit).GetDefault() << "\n";
+      os << indent << " " << (*pit).GetName() << " = " << (*pit).GetValue() << "\n";
       }
     }
 }
@@ -371,7 +371,7 @@ bool vtkMRMLCommandLineModuleNode
 {
   bool isInput = false;
   std::vector<ModuleParameter> parameters =
-    this->Internal->ModuleDescriptionObject.FindParametersWithDefaultValue(
+    this->Internal->ModuleDescriptionObject.FindParametersWithValue(
       value);
   // It is an input if it is not an output.
   std::vector<ModuleParameter>::const_iterator it;
@@ -404,7 +404,7 @@ bool vtkMRMLCommandLineModuleNode
   // specified
   if (value != oldValue)
     {
-    if (!this->Internal->ModuleDescriptionObject.SetParameterDefaultValue(name, value))
+    if (!this->Internal->ModuleDescriptionObject.SetParameterValue(name, value))
       {
 #ifndef NDEBUG
       if (!this->Internal->ModuleDescriptionObject.HasParameter(name))
@@ -460,7 +460,7 @@ bool vtkMRMLCommandLineModuleNode
   // specified
   if (value != this->GetParameterAsString(name))
     {
-    if (!this->Internal->ModuleDescriptionObject.SetParameterDefaultValue(name, value))
+    if (!this->Internal->ModuleDescriptionObject.SetParameterValue(name, value))
       {
 #ifndef NDEBUG
       if (!this->Internal->ModuleDescriptionObject.HasParameter(name))
@@ -521,7 +521,7 @@ bool vtkMRMLCommandLineModuleNode
 //----------------------------------------------------------------------------
 std::string vtkMRMLCommandLineModuleNode::GetParameterAsString(const char *name) const
 {
-  return this->Internal->ModuleDescriptionObject.GetParameterDefaultValue(name);
+  return this->Internal->ModuleDescriptionObject.GetParameterValue(name);
 }
 
 //----------------------------------------------------------------------------
@@ -937,11 +937,17 @@ std::string vtkMRMLCommandLineModuleNode::GetParameterIndex ( unsigned int group
 //----------------------------------------------------------------------------
 std::string vtkMRMLCommandLineModuleNode::GetParameterDefault ( unsigned int group, unsigned int param ) const
 {
+  return this->GetParameterValue(group, param);
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLCommandLineModuleNode::GetParameterValue ( unsigned int group, unsigned int param ) const
+{
   if (!this->IsValidParamId(group, param))
     {
     return std::string();
     }
-  return this->GetModuleDescription().GetParameterGroups()[group].GetParameters()[param].GetDefault();
+  return this->GetModuleDescription().GetParameterGroups()[group].GetParameters()[param].GetValue();
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -273,7 +273,9 @@ public:
   std::string GetParameterDescription(unsigned int group, unsigned int param) const;
   std::string GetParameterChannel(unsigned int group, unsigned int param) const;
   std::string GetParameterIndex(unsigned int group, unsigned int param) const;
+  // \deprecated you should think about using GetParameterValue
   std::string GetParameterDefault(unsigned int group, unsigned int param) const;
+  std::string GetParameterValue(unsigned int group, unsigned int param) const;
   std::string GetParameterFlag(unsigned int group, unsigned int param) const;
   std::string GetParameterMultiple(unsigned int group, unsigned int param) const;
   std::string GetParameterFileExtensions(unsigned int group, unsigned int param) const;

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -81,7 +81,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "61bb14d57ff45c8de0f506e23b6ec982fcdf0da2"
+    "1d3e9a226bd594f23733993c16c337ba60077bc5"
     QUIET
     )
 


### PR DESCRIPTION
This pull request is following one made on Slicer Execution Model: https://github.com/Slicer/SlicerExecutionModel/pull/91

It is doing 3 distinct things:
- Updating the SEM's version used in Slicer
- Updating Slicer's code in order to use the newly created functions in SEM instead of the deprecated ones
- Updating and depreciating one function of Slicer in order to have a more explicit name (GetParameterValue instead of GetParameterDefault)