### PR TITLE
BUG: Catch improper class names in ExtensionWizard

### DIFF
--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/CreateComponentDialog.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/CreateComponentDialog.py
@@ -1,6 +1,7 @@
 import os
 import slicer
 import qt, ctk
+import re
 
 #=============================================================================
 #
@@ -48,8 +49,19 @@ class CreateComponentDialog(object):
     self._typelc = componenttype.lower()
     self._typetc = componenttype.title()
 
+    self.classNamePattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
   #---------------------------------------------------------------------------
   def accept(self):
+
+    if self._typelc == "module" and not self.classNamePattern.match(self.componentName):
+      slicer.util.errorDisplay("""Internal module names may not contain spaces or other special characters, \
+                                and cannot start with a number. Public-facing module names can be changed \
+                                later in the module code if needed.""",
+                               windowTitle=u"Cannot create %s" % self._typelc, parent=self.dialog)
+      return
+
+
     if not len(self.componentName):
       slicer.util.errorDisplay(u"%s name may not be empty." % self._typetc,
                                windowTitle=u"Cannot create %s" % self._typelc, parent=self.dialog)


### PR DESCRIPTION
Hello!

This is another small bug. When using the ExtensionWizard, one can click the "Add Module to Extension" to generate a module template under a provided module "name." For example, if a module name is provided as "TestModule" in the menu below..

![image](https://user-images.githubusercontent.com/19840621/27445335-5b11d0fe-5747-11e7-8dda-46625348bfd7.png)

Then a file, TestModule.py will be created. That file will contain some pre-built classes, like 

```
class TestModule(ScriptedLoadableModule):

class TestModuleWidget(ScriptedLoadableModuleWidget):
```

The problem is that one can provide ANY string to that menu. Based on the prompt, I would initially assume that I was providing the final module name -- for example, "Extension Wizard". However, this generates bad class names that won't compile, e.g.:

`class Extension WizardWidget(ScriptedLoadableModuleWidget):`

Pressing "OK" with such a name will immediately lead to an error box for hard-to-decipher reasons at a first pass, e.g.

![image](https://user-images.githubusercontent.com/19840621/27445496-f3082764-5747-11e7-8893-792a63434231.png)

While most coders might be able to spot the problem in the console, some probably won't be able to. I know I missed it the first time I tried Extension Wizard, leading me to believe that it was just broken that time around and then I should download a new version later (read: 6 months). There's a bunch of different solutions to this. For example, one could make the prompt box more explicit about what 'Name' means, or automatically convert invalid class names into valid class names. In the interest of simplicity, however, I've just added an error-checker that detects invalid class names and gives users a relevant error message.

![image](https://user-images.githubusercontent.com/19840621/27445626-6769ace0-5748-11e7-9bd2-1de7b3541122.png)

It might be something to think about more in-depth for the templating interface in general, but in the meantime this fix will likely work and perhaps not scare off new potential Slicer developers.

All the best,
Andrew
