### PR TITLE
ENH: Update DCMTK to 3.6.2

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -41,7 +41,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "d8ed091cda2b815226eafe41f5b4fe3bd22f8d5d"
+    "e4df3575fd590bea865e017c84c8f880a9a6c1c0"
     QUIET
     )
 


### PR DESCRIPTION
```
$ git shortlog d8ed091..DCMTK-3.6.2
Jan Schlamelcher (43):
      Fixed CMake check for <png.h> resp. <libpng/png.h>.
      Removed dead code from dcmnet.
      Hid some Visual Studio warnings regarding libxml.
      Moved config/arith.cc to config/tests/arith.cc
      Added configuration options for STL and C++11.
      Fixed segmentation fault in DcmDataDictionary.
      Enhanced recently introduced STL configuration tests.
      Fixed some code relying on C++11 features.
      Updated copyright notice in recently modified file.
      Fixed wrong paths to 'config' dir in CMake scripts.
      Added association negotiation profiles to dcmqrscp.
      Added attribute matching functions to DcmElement etc.
      Fixed combined date time range matching.
      Refactored dcmwlm's attribute matching implementation.
      Added a partial workaround for DCMTK bug #758.
      Added a workaround for a bug in x87 FPUs/GCC.
      Removed broken attributes from dcmqrdb.
      Fixed using wrong build type for configuration test.
      Several fixes for the SunPro compiler (Solaris).
      Fixed configuration test errors.
      Workaround for SunPro C vs. C++ inconsistencies.
      Fixed wrong syntax in previous commit.
      Many workarounds for SunPro.
      Fixed compiler errors on Visual Studio with OpenSSL.
      Fixed compiling with Oracle Developer Studio (SunPro).
      Fixed unexpected iconv behavior on FreeBSD.
      Fixed wrong usage of alignas.
      Silenced output of FIND_PACKAGE(ICU).
      Added a workaround for C++11 compiling errors.
      Added DCMTK_ENABLE_LFS for choosing LFS type (CMake).
      Workaround for strange LFS implementation on Windows.
      Small fixes for a previous commit.
      More fixes for SunPro.
      Added a workaround for inconsistent LFS API under QNX.
      Removed no longer required section from COPYRIGHT.
      Removed several macros from config/docs/macros.txt.
      Added support for suppressing C4307 on Visual Studio.
      Made including third-party libraries version agnostic.
      Updated ANNOUNCE and INSTALL for DCMTK release 3.6.2.
      Updated Makefile dependencies.
      Updated version information for DCMTK release 3.6.2.
      Updated man pages for DCMTK release 3.6.2.
      Created CHANGES.362 for DCMTK release 3.6.2.

Joerg Riesmeier (29):
      Removed unused local variable.
      Fixed inconsistent documentation in man page.
      Fixed documentation and other minor issues.
      Fixed issue with Simplified Adult Echo SR.
      Added unsigned suffix to large decimal constants.
      Fixed various stylistic issues.
      Fixed typo and rewrapped new text paragraphs.
      Changed the way XMLLIBS is set (Autoconf).
      Minor changes for supporting QNX 6.5.
      Added explicit type cast to keep QNX 6.5 quiet.
      Fixed issue with configure test on QNX 6.5.
      Updated Makefile dependencies.
      Updated data dictionary for DICOM 2017b.
      Added definition of new Storage SOP Class UIDs.
      Support new SOP Classes by networking tools.
      Added support for new "SR" and "PR" SOP Classes.
      Initial support for "Patient Radiation Dose SR".
      Added definition of new Presentation States.
      Added new Storage SOP Classes to comment sections.
      Updated latest tested CMake version.
      Enhanced documentation of gotoNamedChildNode().
      Added new method gotoNamedNodeInSubTree().
      Removed 2nd parameter from gotoNamedChildNode().
      Link MATHLIBS to all test programs.
      Moved MATHLIBS to LOCALLIBS.
      Removed useless target "tclabutil" from Makefile.
      Minor fixes in Makefile.
      Fixed typo in Coding Scheme Description.
      Updated copyright date.

Marco Eichelberg (4):
      Removed unused variables.
      Converting large attributes to UN in explicit VR.
      Fixed handling of EINTR in networkDataAvailable().
      Removed support for HAVE_GUSI_H (MacOS classic).

Michael Onken (28):
      Fixed write transfer syntax and support Deflated.
      Suppress error message for missing segm. types.
      Fixed check for transcoding, added documentation.
      First check number of components before value.
      Added OB/OW-related comparison operators.
      Log write errors to error logger.
      Fixed compiler warning on integer casting.
      Fixed wrong copy of SOP class in role selection.
      Made parameter const.
      Fixed possible role selection config. problem.
      Removed dcmStrictRoleSelection config. switch.
      Enhanced role selection documentation.
      Better parameter name and documentation.
      Allow search for role in SCU presentation contexts.
      Added role selection tests.
      Removed leftovers from dcmStrictRoleSelection.
      Fixed doubled space in log output.
      Fixed error message.
      Fixed ASCII art in comment.
      Opt. accept Default role if SCP role expected.
      Test recently introduced role selection option.
      Fixed ASCII art in test.
      Added missing space.
      Fixed typos.
      Removed unused variable.
      Require CMake > 2.8.3. Extended DCMTKConfig.cmake.
      Moved TRY_COMPILE to where it is first needed.
      Export new LFS CMake flag to DCMTKConfig.cmake.

Nikolas Goldhammer (3):
      Replaced 'errno' with OFStandard::getLast*ErrorCode().
      Partially refactored 'errno' usage within dcmnet.
      Fixed OFerror_code's unit test not working on OpenBSD.

Sebastian Grallert (12):
      Enhanced dcm2json application documentation.
      Added an argument conflict check for dcm2json.
      Enhanced value length information in DcmVR.
      Added some Attributes to DcmItem::checkAndUpdateVR().
      Added config test for the feenableexcept function.
      Several fixes for Solaris support.
      Fixed compiling on Solaris.
      Several fixes for NetBSD support.
      Fixed compiling error on Android.
      Added missing compiler flags for NetBSD (Autoconf).
      Modified compiler Flags for Solaris (CMake).
      Fixed configuration test errors on Visual Studio.

Thorben Hasenpusch (2):
      Added feature test files for STL and C++11 support.
      Renamed several HAVE_ macros for better consistency.
```