### PR TITLE
ENH: require Shift key release after translate before slice-follow

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.cxx
@@ -52,6 +52,7 @@ vtkSliceViewInteractorStyle::vtkSliceViewInteractorStyle()
 {
   this->ActionState = vtkSliceViewInteractorStyle::None;
   this->ActionsEnabled = vtkSliceViewInteractorStyle::AllActionsMask;
+  this->ShiftKeyUsedForPreviousAction = false;
 
   this->StartActionEventPosition[0] = 0;
   this->StartActionEventPosition[1] = 0;
@@ -114,6 +115,13 @@ void vtkSliceViewInteractorStyle::OnKeyPress()
 //----------------------------------------------------------------------------
 void vtkSliceViewInteractorStyle::OnKeyRelease()
 {
+
+  std::string key = this->Interactor->GetKeySym();
+
+  if (((key.find("Shift") != std::string::npos)) && this->ShiftKeyUsedForPreviousAction)
+    {
+    this->ShiftKeyUsedForPreviousAction = false;
+    }
   this->Superclass::OnKeyRelease();
 }
 
@@ -375,6 +383,7 @@ void vtkSliceViewInteractorStyle::OnLeftButtonUp()
 {
   if (this->ActionState == this->Translate)
     {
+    this->ShiftKeyUsedForPreviousAction =  true;
     this->EndTranslate();
     }
   else if (this->ActionState == this->Blend)
@@ -541,7 +550,7 @@ void vtkSliceViewInteractorStyle::OnMouseMove()
         double xyz[3];
         vtkMRMLAbstractSliceViewDisplayableManager::ConvertDeviceToXYZ(this->GetInteractor(), sliceNode, pos[0], pos[1], xyz);
         crosshairNode->SetCursorPositionXYZ(xyz, sliceNode);
-        if (this->Interactor->GetShiftKey())
+        if (this->Interactor->GetShiftKey() && (!this->ShiftKeyUsedForPreviousAction))
           {
           performDefaultAction = false;
           double cursorPositionRAS[3];

--- a/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.h
@@ -174,6 +174,7 @@ protected:
 
   int ActionState;
   int ActionsEnabled;
+  bool ShiftKeyUsedForPreviousAction;
 
   int StartActionEventPosition[2];
   double StartActionFOV[3];

--- a/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.h
@@ -174,6 +174,9 @@ protected:
 
   int ActionState;
   int ActionsEnabled;
+
+  /// Indicates whether the shift key was used during the previous action.
+  /// This is used to require shift-up before returning to default mode.
   bool ShiftKeyUsedForPreviousAction;
 
   int StartActionEventPosition[2];

--- a/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.cxx
@@ -39,6 +39,7 @@ vtkStandardNewMacro(vtkThreeDViewInteractorStyle);
 vtkThreeDViewInteractorStyle::vtkThreeDViewInteractorStyle()
 {
   this->MotionFactor = 10.0;
+  this->ShiftKeyUsedForPreviousAction = false;
   this->CameraNode = 0;
   this->NumberOfPlaces= 0;
   this->NumberOfTransientPlaces = 1;
@@ -187,6 +188,18 @@ void vtkThreeDViewInteractorStyle::OnKeyPress()
 }
 
 //----------------------------------------------------------------------------
+ void vtkThreeDViewInteractorStyle::OnKeyRelease()
+{
+  std::string key = this->Interactor->GetKeySym();
+
+  if (((key.find("Shift") != std::string::npos)) && this->ShiftKeyUsedForPreviousAction)
+    {
+    this->ShiftKeyUsedForPreviousAction = false;
+    }
+  this->Superclass::OnKeyRelease();
+}
+
+//----------------------------------------------------------------------------
 void vtkThreeDViewInteractorStyle::OnMouseMove()
 {
   int x = this->Interactor->GetEventPosition()[0];
@@ -224,7 +237,8 @@ void vtkThreeDViewInteractorStyle::OnMouseMove()
       this->InvokeEvent(vtkCommand::InteractionEvent, 0);
       break;
     default:
-      if (this->Interactor->GetShiftKey() && this->GetCameraNode() != 0 && this->GetCameraNode()->GetScene() != 0 )
+      if ( (!this->ShiftKeyUsedForPreviousAction) && this->Interactor->GetShiftKey() &&
+           (this->GetCameraNode() != 0) && (this->GetCameraNode()->GetScene() != 0) )
         {
         double pickedRAS[3]={0,0,0};
         bool picked = this->Pick(this->Interactor->GetEventPosition()[0], this->Interactor->GetEventPosition()[1], pickedRAS);
@@ -331,6 +345,7 @@ void vtkThreeDViewInteractorStyle::OnLeftButtonDown()
 
   if (this->Interactor->GetShiftKey())
     {
+    this->ShiftKeyUsedForPreviousAction = true;
     if (this->Interactor->GetControlKey())
       {
       this->StartDolly();

--- a/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
@@ -59,6 +59,7 @@ public:
   /// Reimplemented for camera orientation
   virtual void OnChar();
   virtual void OnKeyPress();
+  virtual void OnKeyRelease();
 
   ///
   /// Event bindings controlling the effects of pressing mouse buttons
@@ -109,6 +110,7 @@ protected:
   vtkMRMLCameraNode *CameraNode;
 
   double MotionFactor;
+  bool ShiftKeyUsedForPreviousAction;
 
   /// Keep track of the number of picks so for resetting mouse modes when
   /// transient pick or place mode has been selected.

--- a/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
@@ -110,6 +110,9 @@ protected:
   vtkMRMLCameraNode *CameraNode;
 
   double MotionFactor;
+
+  /// Indicates whether the shift key was used during the previous action.
+  /// This is used to require shift-up before returning to default mode.
   bool ShiftKeyUsedForPreviousAction;
 
   /// Keep track of the number of picks so for resetting mouse modes when


### PR DESCRIPTION
This reduces the risk of inadvertently changing all the slice positions when doing something unrelated (with a 1- or 2- button mouse).