### PR TITLE
BUG: Avoid crash during UI buildup if a ButtonGroup has no checked button

### DIFF
--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -141,6 +141,7 @@ QString ButtonGroupWidgetWrapper::checkedValue()
     return button->text();
   }
   else {
+    // Handle case where <string-enumeration> has no <default> element
     return QString("");
   }
 }

--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -137,8 +137,12 @@ QButtonGroup* ButtonGroupWidgetWrapper::buttonGroup()const
 QString ButtonGroupWidgetWrapper::checkedValue()
 {
   QAbstractButton* button = this->ButtonGroup->checkedButton();
-  Q_ASSERT(button);
-  return button->text();
+  if (button) {
+    return button->text();
+  }
+  else {
+    return QString("");
+  }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
I experienced Slicer crashing when loading a module with a `<string-enumeration>` which had no `<default>` element. Reason was that during UI buildup the pointer to the checked button in the ButtonGroup was fetched to get the text of the checked button. However, in this case the pointer to the button was NULL. Returning an empty string in this case seems to solve the issue.