### PR TITLE
ENH: init quantity/units in scalar volume plugin

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -277,3 +277,34 @@ class DICOMPlugin(object):
                               slicer.dicomDatabase.fileValue(firstFile, tags['studyTime']) )
         # Set item name
         shn.SetItemName(studyItemID, studyDescription + ' (' + studyDate + ')')
+
+  def mapSOPClassUIDToDICOMQuantityAndUnits(self, classUID):
+
+    MRname2UID = {
+        "MR Image Storage": "1.2.840.10008.5.1.4.1.1.4",
+        "Enhanced MR Image Storage": "1.2.840.10008.5.1.4.1.1.4.1",
+        "Legacy Converted Enhanced MR Image Storage": "1.2.840.10008.5.1.4.1.1.4.4"
+        }
+
+    CTname2UID = {
+        "CT Image Storage": "1.2.840.10008.5.1.4.1.1.2",
+        "Enhanced CT Image Storage": "1.2.840.10008.5.1.4.1.1.2.1",
+        "Legacy Converted Enhanced CT Image Storage": "1.2.840.10008.5.1.4.1.1.2.2"
+        }
+
+    quantity = None
+    units = None
+
+    # Note more specialized definitions can be specified for MR by more
+    # specialized plugins, see codes 110800 and on in
+    # http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_D.html
+    if classUID in MRname2UID.values():
+      quantity = {"CodingSchemeDesignator": "DCM", "CodeValue": "110852", "CodeMeaning": "MR signal intensity"}
+      units = {"CodingSchemeDesignator": "UCUM", "CodeValue": "1", "CodeMeaning": "no units"}
+
+    if classUID in CTname2UID.values():
+      quantity = {"CodingSchemeDesignator": "DCM", "CodeValue": "110852", "CodeMeaning": "Attenuation Coefficient"}
+      units = {"CodingSchemeDesignator": "UCUM", "CodeValue": "[hnsf'U]", "CodeMeaning": "Hounsfield unit"}
+
+    return (quantity, units)
+      

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -1,5 +1,6 @@
 import numpy
 import os
+import json
 import vtk, qt, ctk, slicer, vtkITK
 from DICOMLib import DICOMPlugin
 from DICOMLib import DICOMLoadable
@@ -37,6 +38,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
     self.tags['instanceUID'] = "0008,0018"
     self.tags['windowCenter'] = "0028,1050"
     self.tags['windowWidth'] = "0028,1051"
+    self.tags['classUID'] = "0008,0016"
 
   @staticmethod
   def readerApproaches():
@@ -447,6 +449,13 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
           logging.info('No display node: cannot use window/level found in DICOM tags')
       except ValueError:
         pass # DICOM tags cannot be parsed to floating point numbers
+
+      # initialize quantity and units codes
+      (quantity,units) = self.mapSOPClassUIDToDICOMQuantityAndUnits(slicer.dicomDatabase.fileValue(file,self.tags['classUID']))
+      if quantity is not None:
+        volumeNode.SetAttribute("DICOM.QuantityCode", json.dumps(quantity))
+      if units is not None:
+        volumeNode.SetAttribute("DICOM.UnitsCode", json.dumps(units))
 
   def loadWithMultipleLoaders(self,loadable):
     """Load using multiple paths (for testing)


### PR DESCRIPTION
Scalar volumes loaded from various various flavors of MR and CT modalities will
be asigned DICOM.QuantityCode and DICOM.UnitsCode to describe the pixel values
stored in the volume. A function mapping SOPClassUID is introduced in the base
DICOM plugin class to perform the mapping.

See related discussion in

https://github.com/QIICR/QuantitativeReporting/issues/127#issuecomment-273925207

A similar approach is implemented in the PET and Parametric Map plugins
provided in the extensions.