### PR TITLE
ENH: Added saving of DICOM scalar volume voxel quantity&unit in volume node

### DIFF
--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -97,15 +97,19 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
         "fileName": "Mouse-MR-example-where-GDCM_fails.zip",
         "name": "Mouse-MR-example-where-GDCM_fails",
         "seriesUID": "1.3.6.1.4.1.9590.100.1.2.366426457713813178933224342280246227461",
-        "expectedFailures": ["GDCM", "Archetype"]
+        "expectedFailures": ["GDCM", "Archetype"],
+        "voxelValueQuantity": "(DCM, 110852, MR signal intensity)",
+        "voxelValueUnit": "(UCUM, [hnsf'U], Hounsfield unit)"
       },
       { "url": "http://slicer.kitware.com/midas3/download/item/294857/deidentifiedMRHead-dcm-one-series.zip",
         "fileName": "deidentifiedMRHead-dcm-one-series.zip",
         "name": "deidentifiedMRHead-dcm-one-series",
         "seriesUID": "1.3.6.1.4.1.5962.99.1.3814087073.479799962.1489872804257.270.0",
-        "expectedFailures": []
+        "expectedFailures": [],
+        "voxelValueQuantity": "(DCM, 110852, MR signal intensity)",
+        "voxelValueUnit": "(UCUM, 1, no units)"
       }
-    ]''') 
+    ]''')
 
     # another dataset that could be added in the future - currently fails for all readers
     # due to invalid format - see https://issues.slicer.org/view.php?id=3569
@@ -113,7 +117,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
         #"fileName": "RIDER_bug.zip",
         #"name": "RIDER_bug",
         #"seriesUID": "1.3.6.1.4.1.9328.50.7.261772317324041365541450388603508531852",
-        #"expectedFailures": []
+        #"expectedFailures": [],
       #}
 
     loadingResult = {}
@@ -159,11 +163,11 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
         loadable = detailsPopup.getAllSelectedLoadables().keys()[0]
 
         #
-        # try loading using each of the selected readers, fail 
+        # try loading using each of the selected readers, fail
         # on enexpected load issue
         #
         scalarVolumePlugin = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin']()
-        readerApproaches = scalarVolumePlugin.readerApproaches()   
+        readerApproaches = scalarVolumePlugin.readerApproaches()
         basename = loadable.name
         volumesByApproach = {}
         for readerApproach in readerApproaches:
@@ -176,6 +180,13 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
             raise Exception("Expected to NOT be able to read with %s, but could!" % readerApproach)
           if volumeNode:
             volumesByApproach[readerApproach] = volumeNode
+
+            # Test quantity and unit
+            if 'voxelValueQuantity' in dataset.keys():
+              self.assertEqual(volumeNode.GetVoxelValueQuantity().GetAsPrintableString(), dataset['voxelValueQuantity'])
+            if 'voxelValueUnit' in dataset.keys():
+              self.assertEqual(volumeNode.GetVoxelValueUnit().GetAsPrintableString(), dataset['voxelValueUnit'])
+
 
         #
         # for each approach that loaded as expected, compare the volumes
@@ -211,5 +222,5 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
     mainWindow.moduleSelector().selectModule('DICOMReaders')
 
     logging.info(loadingResult)
-  
+
     return testPass

--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -98,16 +98,16 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
         "name": "Mouse-MR-example-where-GDCM_fails",
         "seriesUID": "1.3.6.1.4.1.9590.100.1.2.366426457713813178933224342280246227461",
         "expectedFailures": ["GDCM", "Archetype"],
-        "voxelValueQuantity": "(DCM, 110852, MR signal intensity)",
-        "voxelValueUnit": "(UCUM, [hnsf'U], Hounsfield unit)"
+        "voxelValueQuantity": "(DCM, 110852, \\"MR signal intensity\\")",
+        "voxelValueUnits": "(UCUM, 1, \\"no units\\")"
       },
       { "url": "http://slicer.kitware.com/midas3/download/item/294857/deidentifiedMRHead-dcm-one-series.zip",
         "fileName": "deidentifiedMRHead-dcm-one-series.zip",
         "name": "deidentifiedMRHead-dcm-one-series",
         "seriesUID": "1.3.6.1.4.1.5962.99.1.3814087073.479799962.1489872804257.270.0",
         "expectedFailures": [],
-        "voxelValueQuantity": "(DCM, 110852, MR signal intensity)",
-        "voxelValueUnit": "(UCUM, 1, no units)"
+        "voxelValueQuantity": "(DCM, 110852, \\"MR signal intensity\\")",
+        "voxelValueUnits": "(UCUM, 1, \\"no units\\")"
       }
     ]''')
 
@@ -117,7 +117,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
         #"fileName": "RIDER_bug.zip",
         #"name": "RIDER_bug",
         #"seriesUID": "1.3.6.1.4.1.9328.50.7.261772317324041365541450388603508531852",
-        #"expectedFailures": [],
+        #"expectedFailures": []
       #}
 
     loadingResult = {}
@@ -181,11 +181,11 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
           if volumeNode:
             volumesByApproach[readerApproach] = volumeNode
 
-            # Test quantity and unit
+            self.delayDisplay('Test quantity and unit')
             if 'voxelValueQuantity' in dataset.keys():
               self.assertEqual(volumeNode.GetVoxelValueQuantity().GetAsPrintableString(), dataset['voxelValueQuantity'])
-            if 'voxelValueUnit' in dataset.keys():
-              self.assertEqual(volumeNode.GetVoxelValueUnit().GetAsPrintableString(), dataset['voxelValueUnit'])
+            if 'voxelValueUnits' in dataset.keys():
+              self.assertEqual(volumeNode.GetVoxelValueUnits().GetAsPrintableString(), dataset['voxelValueUnits'])
 
 
         #

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -101,6 +101,7 @@ endif()
 # Sources
 # --------------------------------------------------------------------------
 set(MRMLCore_SRCS
+  vtkCodedEntry.cxx
   vtkEventBroker.cxx
   vtkImageBimodalAnalysis.cxx
   vtkDataFileFormatHelper.cxx

--- a/Libs/MRML/Core/vtkCodedEntry.cxx
+++ b/Libs/MRML/Core/vtkCodedEntry.cxx
@@ -1,0 +1,156 @@
+/*=auto=========================================================================
+
+Portions (c) Copyright 2017 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+See COPYRIGHT.txt
+or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+#include "vtkCodedEntry.h"
+
+// VTK include
+#include <vtkObjectFactory.h>
+
+// STD include
+#include <sstream>
+
+vtkStandardNewMacro(vtkCodedEntry);
+
+//----------------------------------------------------------------------------
+vtkCodedEntry::vtkCodedEntry()
+: CodingSchemeDesignator(NULL)
+, CodeValue(NULL)
+, CodeMeaning(NULL)
+{
+}
+
+//----------------------------------------------------------------------------
+vtkCodedEntry::~vtkCodedEntry()
+{
+  this->Initialize();
+}
+
+//----------------------------------------------------------------------------
+void vtkCodedEntry::Initialize()
+{
+  this->SetCodingSchemeDesignator(NULL);
+  this->SetCodeValue(NULL);
+  this->SetCodeMeaning(NULL);
+}
+
+;
+
+//----------------------------------------------------------------------------
+void vtkCodedEntry::SetSchemeValueMeaning(const std::string& scheme,
+  const std::string& value, const std::string& meaning)
+{
+  this->SetCodingSchemeDesignator(scheme.c_str());
+  this->SetCodeValue(value.c_str());
+  this->SetCodeMeaning(meaning.c_str());
+}
+
+//----------------------------------------------------------------------------
+void vtkCodedEntry::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+  os << indent << "CodingSchemeDesignator: " << (this->CodingSchemeDesignator?this->CodingSchemeDesignator:"(none)") << "\n";
+  os << indent << "CodeValue: " << (this->CodeValue?this->CodeValue:"(none)") << "\n";
+  os << indent << "CodeMeaning: " << (this->CodeMeaning?this->CodeMeaning:"(none)") << "\n";
+}
+
+//----------------------------------------------------------------------------
+void vtkCodedEntry::Copy(vtkCodedEntry* aType)
+{
+  if (!aType)
+    {
+    return;
+    }
+  this->SetCodingSchemeDesignator(aType->GetCodingSchemeDesignator());
+  this->SetCodeValue(aType->GetCodeValue());
+  this->SetCodeMeaning(aType->GetCodeMeaning());
+}
+
+//----------------------------------------------------------------------------
+std::string vtkCodedEntry::GetAsPrintableString()
+{
+  std::string printable = std::string("(")
+    + (this->CodingSchemeDesignator ? this->CodingSchemeDesignator : "(none)") + ", "
+    + (this->CodeValue ? this->CodeValue : "(none)") + ", "
+    + (this->CodeMeaning ? this->CodeMeaning : "(none)") + ")";
+  return printable;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkCodedEntry::GetAsString()
+{
+  std::string str;
+  if (this->CodingSchemeDesignator)
+    {
+    str += "CodingSchemeDesignator:";
+    str += this->CodingSchemeDesignator;
+    }
+  if (this->CodeValue)
+    {
+    if (!str.empty())
+      {
+      str += "|";
+      }
+    str += "CodeValue:";
+    str += this->CodeValue;
+    }
+  if (this->CodeMeaning)
+    {
+    if (!str.empty())
+      {
+      str += "|";
+      }
+    str += "CodeMeaning:";
+    str += this->CodeMeaning;
+    }
+  return str;
+}
+
+//----------------------------------------------------------------------------
+bool vtkCodedEntry::SetFromString(const std::string& content)
+{
+  this->Initialize();
+  bool success = true;
+  std::stringstream attributes(content);
+  std::string attribute;
+  while (std::getline(attributes, attribute, '|'))
+    {
+    int colonIndex = attribute.find(':');
+    std::string name = attribute.substr(0, colonIndex);
+    std::string value = attribute.substr(colonIndex + 1);
+    if (name == "CodingSchemeDesignator")
+      {
+      this->SetCodingSchemeDesignator(value.c_str());
+      }
+    else if (name == "CodeValue")
+      {
+      this->SetCodeValue(value.c_str());
+      }
+    else if (name == "CodeMeaning")
+      {
+      this->SetCodeMeaning(value.c_str());
+      }
+    else
+      {
+      vtkWarningMacro("Parsing coded entry string failed: unknown name " << name << " in " + content);
+      success = false;
+      }
+    }
+  if (this->GetCodingSchemeDesignator() == NULL)
+    {
+    vtkWarningMacro("Parsing coded entry string failed: CodingSchemeDesignator is not specified in " + content);
+    success = false;
+    }
+  if (this->GetCodeValue() == NULL)
+    {
+    vtkWarningMacro("Parsing coded entry string failed: CodeValue is not specified in " + content);
+    success = false;
+    }
+  // CodeMeaning is optional
+  return success;
+}

--- a/Libs/MRML/Core/vtkCodedEntry.cxx
+++ b/Libs/MRML/Core/vtkCodedEntry.cxx
@@ -76,8 +76,8 @@ std::string vtkCodedEntry::GetAsPrintableString()
 {
   std::string printable = std::string("(")
     + (this->CodingSchemeDesignator ? this->CodingSchemeDesignator : "(none)") + ", "
-    + (this->CodeValue ? this->CodeValue : "(none)") + ", "
-    + (this->CodeMeaning ? this->CodeMeaning : "(none)") + ")";
+    + (this->CodeValue ? this->CodeValue : "(none)") + ", \""
+    + (this->CodeMeaning ? this->CodeMeaning : "") + "\")";
   return printable;
 }
 

--- a/Libs/MRML/Core/vtkCodedEntry.h
+++ b/Libs/MRML/Core/vtkCodedEntry.h
@@ -1,0 +1,93 @@
+/*=auto=========================================================================
+
+Portions (c) Copyright 2017 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+See COPYRIGHT.txt
+or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+#ifndef __vtkCodedEntry_h
+#define __vtkCodedEntry_h
+
+// MRML includes
+#include "vtkMRML.h"
+
+// VTK includes
+#include <vtkObject.h>
+
+/// \brief Simple class for storing standard coded entries (coding scheme, value, meaning triplets)
+///
+/// vtkCodedEntry is a lightweight class that stores standard coded entries consisting of
+/// CodingSchemeDesignator + CodeValue + CodeMeaning triplets.
+/// This is a commonly used concept in DICOM, see chapter 3: Encoding of Coded Entry Data
+/// (http://dicom.nema.org/dicom/2013/output/chtml/part03/sect_8.3.html).
+///
+class VTK_MRML_EXPORT vtkCodedEntry : public vtkObject
+{
+public:
+
+  static vtkCodedEntry *New();
+  vtkTypeMacro(vtkCodedEntry, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent);
+
+  /// Reset state of object
+  virtual void Initialize();
+
+  /// Convenience function for setting coding scheme, code value, and code meaning with a single method call
+  virtual void SetSchemeValueMeaning(const std::string& scheme, const std::string& value, const std::string& meaning);
+
+  /// Copy one type into another
+  virtual void Copy(vtkCodedEntry* aType);
+
+  ///
+  /// Coding Scheme Designator identifies the coding scheme
+  /// in which the code for a term is defined. Standard coding scheme designators used
+  /// in DICOM information interchange are listed in PS3.16. Other coding scheme designators,
+  /// for both private and public coding schemes, may be used, in accordance with PS3.16.
+  vtkGetStringMacro(CodingSchemeDesignator);
+  vtkSetStringMacro(CodingSchemeDesignator);
+
+  ///
+  /// Code Value (DICOM tag (0008,0100)) is an identifier that is unambiguous within
+  /// the Coding Scheme denoted by Coding Scheme Designator and Coding Scheme Version.
+  vtkGetStringMacro(CodeValue);
+  vtkSetStringMacro(CodeValue);
+
+  ///
+  /// Code Meaning is text that has meaning to a human and conveys
+  /// the meaning of the term defined by the combination of Code Value and Coding Scheme Designator.
+  /// Though such a meaning can be "looked up" in the dictionary for the coding scheme, it is encoded
+  /// for the convenience of applications that do not have access to such a dictionary.
+  vtkGetStringMacro(CodeMeaning);
+  vtkSetStringMacro(CodeMeaning);
+
+  ///
+  /// Get content of the object as a single human-readable string.
+  /// Example: (UCUM, [hnsf'U], Hounsfield unit)
+  std::string GetAsPrintableString();
+
+  ///
+  /// Get content of the object as a single machine-readable string.
+  /// Example: CodingSchemeDesignator:UCUM|CodeValue:[hnsf'U]|CodeMeaning:Hounsfield unit
+  std::string GetAsString();
+
+  ///
+  /// Set content of the object from a single machine-readable string.
+  /// Example input: CodingSchemeDesignator:UCUM|CodeValue:[hnsf'U]|CodeMeaning:Hounsfield unit
+  /// \return true on success
+  bool SetFromString(const std::string& content);
+
+protected:
+  vtkCodedEntry();
+  ~vtkCodedEntry();
+  vtkCodedEntry(const vtkCodedEntry&);
+  void operator=(const vtkCodedEntry&);
+
+protected:
+  char* CodingSchemeDesignator;
+  char* CodeValue;
+  char* CodeMeaning;
+};
+
+#endif

--- a/Libs/MRML/Core/vtkCodedEntry.h
+++ b/Libs/MRML/Core/vtkCodedEntry.h
@@ -21,7 +21,7 @@ or http://www.slicer.org/copyright/copyright.txt for details.
 /// vtkCodedEntry is a lightweight class that stores standard coded entries consisting of
 /// CodingSchemeDesignator + CodeValue + CodeMeaning triplets.
 /// This is a commonly used concept in DICOM, see chapter 3: Encoding of Coded Entry Data
-/// (http://dicom.nema.org/dicom/2013/output/chtml/part03/sect_8.3.html).
+/// (http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_8.3.html).
 ///
 class VTK_MRML_EXPORT vtkCodedEntry : public vtkObject
 {

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -28,12 +28,12 @@ Version:   $Revision: 1.14 $
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLScalarVolumeNode);
 vtkCxxSetObjectMacro(vtkMRMLScalarVolumeNode, VoxelValueQuantity, vtkCodedEntry);
-vtkCxxSetObjectMacro(vtkMRMLScalarVolumeNode, VoxelValueUnit, vtkCodedEntry);
+vtkCxxSetObjectMacro(vtkMRMLScalarVolumeNode, VoxelValueUnits, vtkCodedEntry);
 
 //----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode::vtkMRMLScalarVolumeNode()
 : VoxelValueQuantity(NULL)
-, VoxelValueUnit(NULL)
+, VoxelValueUnits(NULL)
 {
 }
 
@@ -41,7 +41,7 @@ vtkMRMLScalarVolumeNode::vtkMRMLScalarVolumeNode()
 vtkMRMLScalarVolumeNode::~vtkMRMLScalarVolumeNode()
 {
   this->SetVoxelValueQuantity(NULL);
-  this->SetVoxelValueUnit(NULL);
+  this->SetVoxelValueUnits(NULL);
 }
 
 //----------------------------------------------------------------------------
@@ -52,9 +52,9 @@ void vtkMRMLScalarVolumeNode::WriteXML(ostream& of, int nIndent)
     {
     of << " voxelValueQuantity=\"" << vtkMRMLNode::URLEncodeString(this->GetVoxelValueQuantity()->GetAsString().c_str()) << "\"";
     }
-  if (this->GetVoxelValueUnit())
+  if (this->GetVoxelValueUnits())
     {
-    of << " voxelValueUnit=\"" << vtkMRMLNode::URLEncodeString(this->GetVoxelValueUnit()->GetAsString().c_str()) << "\"";
+    of << " voxelValueUnits=\"" << vtkMRMLNode::URLEncodeString(this->GetVoxelValueUnits()->GetAsString().c_str()) << "\"";
     }
 }
 
@@ -90,11 +90,11 @@ void vtkMRMLScalarVolumeNode::ReadXMLAttributes(const char** atts)
       entry->SetFromString(vtkMRMLNode::URLDecodeString(attValue));
       this->SetVoxelValueQuantity(entry.GetPointer());
       }
-    else if (!strcmp(attName, "voxelValueUnit"))
+    else if (!strcmp(attName, "voxelValueUnits"))
       {
       vtkNew<vtkCodedEntry> entry;
       entry->SetFromString(vtkMRMLNode::URLDecodeString(attValue));
-      this->SetVoxelValueUnit(entry.GetPointer());
+      this->SetVoxelValueUnits(entry.GetPointer());
       }
     }
 
@@ -143,9 +143,9 @@ void vtkMRMLScalarVolumeNode::PrintSelf(ostream& os, vtkIndent indent)
     {
     os << indent << "VoxelValueQuantity: " << this->GetVoxelValueQuantity()->GetAsPrintableString() << "\n";
     }
-  if (this->GetVoxelValueUnit())
+  if (this->GetVoxelValueUnits())
     {
-    os << indent << "GetVoxelValueUnit: " << this->GetVoxelValueUnit()->GetAsPrintableString() << "\n";
+    os << indent << "VoxelValueUnits: " << this->GetVoxelValueUnits()->GetAsPrintableString() << "\n";
     }
 }
 

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -12,6 +12,7 @@ Version:   $Revision: 1.14 $
 
 =========================================================================auto=*/
 // MRML includes
+#include "vtkCodedEntry.h"
 #include "vtkMRMLScalarVolumeDisplayNode.h"
 #include "vtkMRMLScalarVolumeNode.h"
 #include "vtkMRMLScene.h"
@@ -26,21 +27,35 @@ Version:   $Revision: 1.14 $
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLScalarVolumeNode);
+vtkCxxSetObjectMacro(vtkMRMLScalarVolumeNode, VoxelValueQuantity, vtkCodedEntry);
+vtkCxxSetObjectMacro(vtkMRMLScalarVolumeNode, VoxelValueUnit, vtkCodedEntry);
 
 //----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode::vtkMRMLScalarVolumeNode()
+: VoxelValueQuantity(NULL)
+, VoxelValueUnit(NULL)
 {
 }
 
 //----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode::~vtkMRMLScalarVolumeNode()
 {
+  this->SetVoxelValueQuantity(NULL);
+  this->SetVoxelValueUnit(NULL);
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLScalarVolumeNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
+  if (this->GetVoxelValueQuantity())
+    {
+    of << " voxelValueQuantity=\"" << vtkMRMLNode::URLEncodeString(this->GetVoxelValueQuantity()->GetAsString().c_str()) << "\"";
+    }
+  if (this->GetVoxelValueUnit())
+    {
+    of << " voxelValueUnit=\"" << vtkMRMLNode::URLEncodeString(this->GetVoxelValueUnit()->GetAsString().c_str()) << "\"";
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -68,6 +83,18 @@ void vtkMRMLScalarVolumeNode::ReadXMLAttributes(const char** atts)
         {
         this->SetAttribute("LabelMap", "1");
         }
+      }
+    else if (!strcmp(attName, "voxelValueQuantity"))
+      {
+      vtkNew<vtkCodedEntry> entry;
+      entry->SetFromString(vtkMRMLNode::URLDecodeString(attValue));
+      this->SetVoxelValueQuantity(entry.GetPointer());
+      }
+    else if (!strcmp(attName, "voxelValueUnit"))
+      {
+      vtkNew<vtkCodedEntry> entry;
+      entry->SetFromString(vtkMRMLNode::URLDecodeString(attValue));
+      this->SetVoxelValueUnit(entry.GetPointer());
       }
     }
 
@@ -112,6 +139,14 @@ vtkMRMLScalarVolumeDisplayNode* vtkMRMLScalarVolumeNode::GetScalarVolumeDisplayN
 void vtkMRMLScalarVolumeNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
+  if (this->GetVoxelValueQuantity())
+    {
+    os << indent << "VoxelValueQuantity: " << this->GetVoxelValueQuantity()->GetAsPrintableString() << "\n";
+    }
+  if (this->GetVoxelValueUnit())
+    {
+    os << indent << "GetVoxelValueUnit: " << this->GetVoxelValueUnit()->GetAsPrintableString() << "\n";
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
@@ -72,11 +72,17 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeNode : public vtkMRMLVolumeNode
   /// Create and observe default display node
   virtual void CreateDefaultDisplayNodes();
 
+  /// Measured quantity of voxel values, specified as a standard coded entry.
+  /// For example: (DCM, 112031, "Attenuation Coefficient")
   void SetVoxelValueQuantity(vtkCodedEntry*);
   vtkGetObjectMacro(VoxelValueQuantity, vtkCodedEntry);
 
-  void SetVoxelValueUnit(vtkCodedEntry*);
-  vtkGetObjectMacro(VoxelValueUnit, vtkCodedEntry);
+  /// Measurement unit of voxel value quantity, specified as a standard coded entry.
+  /// For example: (UCUM, [hnsf'U], "Hounsfield unit")
+  /// It stores a single unit. Plural (units) name is chosen to be consistent
+  /// with nomenclature in the DICOM standard.
+  void SetVoxelValueUnits(vtkCodedEntry*);
+  vtkGetObjectMacro(VoxelValueUnits, vtkCodedEntry);
 
 protected:
   vtkMRMLScalarVolumeNode();
@@ -85,7 +91,7 @@ protected:
   void operator=(const vtkMRMLScalarVolumeNode&);
 
   vtkCodedEntry* VoxelValueQuantity;
-  vtkCodedEntry* VoxelValueUnit;
+  vtkCodedEntry* VoxelValueUnits;
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
@@ -18,6 +18,7 @@
 // MRML includes
 #include "vtkMRMLVolumeNode.h"
 class vtkMRMLScalarVolumeDisplayNode;
+class vtkCodedEntry;
 
 /// \brief MRML node for representing a volume (image stack).
 ///
@@ -71,11 +72,20 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeNode : public vtkMRMLVolumeNode
   /// Create and observe default display node
   virtual void CreateDefaultDisplayNodes();
 
+  void SetVoxelValueQuantity(vtkCodedEntry*);
+  vtkGetObjectMacro(VoxelValueQuantity, vtkCodedEntry);
+
+  void SetVoxelValueUnit(vtkCodedEntry*);
+  vtkGetObjectMacro(VoxelValueUnit, vtkCodedEntry);
+
 protected:
   vtkMRMLScalarVolumeNode();
   ~vtkMRMLScalarVolumeNode();
   vtkMRMLScalarVolumeNode(const vtkMRMLScalarVolumeNode&);
   void operator=(const vtkMRMLScalarVolumeNode&);
+
+  vtkCodedEntry* VoxelValueQuantity;
+  vtkCodedEntry* VoxelValueUnit;
 };
 
 #endif

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -306,7 +306,7 @@ class DICOMPlugin(object):
 
     if classUID in CTname2UID.values():
       quantity = slicer.vtkCodedEntry()
-      quantity.SetSchemeValueMeaning("DCM", "110851", "X-Ray Attenuation Coefficient")
+      quantity.SetSchemeValueMeaning("DCM", "112031", "Attenuation Coefficient")
       units = slicer.vtkCodedEntry()
       units.SetSchemeValueMeaning("UCUM", "[hnsf'U]", "Hounsfield unit")
 

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -277,3 +277,37 @@ class DICOMPlugin(object):
                               slicer.dicomDatabase.fileValue(firstFile, tags['studyTime']) )
         # Set item name
         shn.SetItemName(studyItemID, studyDescription + ' (' + studyDate + ')')
+
+  def mapSOPClassUIDToDICOMQuantityAndUnits(self, classUID):
+
+    MRname2UID = {
+        "MR Image Storage": "1.2.840.10008.5.1.4.1.1.4",
+        "Enhanced MR Image Storage": "1.2.840.10008.5.1.4.1.1.4.1",
+        "Legacy Converted Enhanced MR Image Storage": "1.2.840.10008.5.1.4.1.1.4.4"
+        }
+
+    CTname2UID = {
+        "CT Image Storage": "1.2.840.10008.5.1.4.1.1.2",
+        "Enhanced CT Image Storage": "1.2.840.10008.5.1.4.1.1.2.1",
+        "Legacy Converted Enhanced CT Image Storage": "1.2.840.10008.5.1.4.1.1.2.2"
+        }
+
+    quantity = None
+    units = None
+
+    # Note more specialized definitions can be specified for MR by more
+    # specialized plugins, see codes 110800 and on in
+    # http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_D.html
+    if classUID in MRname2UID.values():
+      quantity = slicer.vtkCodedEntry()
+      quantity.SetSchemeValueMeaning("DCM", "110852", "MR signal intensity")
+      units = slicer.vtkCodedEntry()
+      units.SetSchemeValueMeaning("UCUM", "1", "no units")
+
+    if classUID in CTname2UID.values():
+      quantity = slicer.vtkCodedEntry()
+      quantity.SetSchemeValueMeaning("DCM", "110851", "X-Ray Attenuation Coefficient")
+      units = slicer.vtkCodedEntry()
+      units.SetSchemeValueMeaning("UCUM", "[hnsf'U]", "Hounsfield unit")
+
+    return (quantity, units)

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -37,6 +37,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
     self.tags['instanceUID'] = "0008,0018"
     self.tags['windowCenter'] = "0028,1050"
     self.tags['windowWidth'] = "0028,1051"
+    self.tags['classUID'] = "0008,0016"
 
   @staticmethod
   def readerApproaches():
@@ -447,6 +448,13 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
           logging.info('No display node: cannot use window/level found in DICOM tags')
       except ValueError:
         pass # DICOM tags cannot be parsed to floating point numbers
+
+      # initialize quantity and units codes
+      (quantity,units) = self.mapSOPClassUIDToDICOMQuantityAndUnits(slicer.dicomDatabase.fileValue(file,self.tags['classUID']))
+      if quantity is not None:
+        volumeNode.SetVoxelValueQuantity(quantity)
+      if units is not None:
+        volumeNode.SetVoxelValueUnit(units)
 
   def loadWithMultipleLoaders(self,loadable):
     """Load using multiple paths (for testing)

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -454,7 +454,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
       if quantity is not None:
         volumeNode.SetVoxelValueQuantity(quantity)
       if units is not None:
-        volumeNode.SetVoxelValueUnit(units)
+        volumeNode.SetVoxelValueUnits(units)
 
   def loadWithMultipleLoaders(self,loadable):
     """Load using multiple paths (for testing)


### PR DESCRIPTION
It implements functionality originally implemented in this commit (but later reverted due to regressions):
"ENH: init quantity/units in scalar volume plugin" (4ac23a026eac73f471c53383c9cd73cf30eabc79).

This commit is functionally equivalent (except CT quantity incorrect code value has been fixed in
`mapSOPClassUIDToDICOMQuantityAndUnits`).

Quantity and unit of voxel values of scalar volumes can be accessed in `vtkMRMLScalarVolumeNode` by using these methods:
```
  void SetVoxelValueQuantity(vtkCodedEntry*);
  vtkGetObjectMacro(VoxelValueQuantity, vtkCodedEntry);
  void SetVoxelValueUnit(vtkCodedEntry*);
  vtkGetObjectMacro(VoxelValueUnit, vtkCodedEntry);
```

`vtkCodedEntry` class was added that simplifies storage, printing, serialization of code scheme/value/meaning triplets
so that it can be easily added to other node types in the future.

`DICOMScalarVolumePlugin` sets these values when the data is loaded from DICOM.

Added test of setting quantity and unit in scalar volume node during DICOM import (`py_DICOMReaders test`).