### PR TITLE
BUG: remove false positive warning

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -848,20 +848,16 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
     self.onLoadingFinished()
 
   def warnUserIfLoadableWarningsAndProceed(self):
-    warningsInLoadableWithConfidence = 0.0
-    maximumConfidence = 0.0
+    warningsInSelectedLoadables = False
     for plugin in self.loadablesByPlugin:
       for loadable in self.loadablesByPlugin[plugin]:
-        if loadable.warning != "":
+        if loadable.selected and loadable.warning != "":
+          warningsInSelectedLoadables = True
           logging.warning('Warning in DICOM plugin ' + plugin.loadType + ' when examining loadable ' + loadable.name +
                           ': ' + loadable.warning)
-          if warningsInLoadableWithConfidence < loadable.confidence:
-            warningsInLoadableWithConfidence = loadable.confidence
-        if maximumConfidence < loadable.confidence:
-          maximumConfidence = loadable.confidence
-    if warningsInLoadableWithConfidence == maximumConfidence and not self.advancedView:
+    if warningsInSelectedLoadables:
       warning = "Warnings detected during load.  Examine data in Advanced mode for details.  Load anyway?"
-      if not slicer.util.confirmOkCancelDisplay(warning):
+      if not slicer.util.confirmOkCancelDisplay(warning, parent=self):
         return False
     return True
 


### PR DESCRIPTION
As reported by @fedorov, he was getting warning messages about
bad spacing even for data he thought was correct.  This was
confirmed with data from series 3 of this [1] dataset.

The problem was some faulty logic that to calculate which
loadable has the highest priority [2] but we can remove that
logic because the loadable are already flagged with a
'selected' attribute and we only need to generate the
dialog box when a selected loadable has a warning.

Tested with series 1 (with warning) and 3 of [1].

[1] http://slicer.kitware.com/midas3/folder/2182
[2] https://github.com/Slicer/Slicer/commit/c5a92bcdf471612d41cd41ff5418dca1bf994abb