### PR TITLE
ENH: Print separators on module reload

### DIFF
--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -142,6 +142,8 @@ class ScriptedLoadableModuleWidget:
     ModuleWizard will substitute correct default moduleName.
     Generic reload method for any scripted module.
     """
+    for i in range(10): print('\n')
+    print('------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------')
     slicer.util.reloadScriptedModule(self.moduleName)
 
   def onReloadAndTest(self):

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -142,8 +142,8 @@ class ScriptedLoadableModuleWidget:
     ModuleWizard will substitute correct default moduleName.
     Generic reload method for any scripted module.
     """
-    for i in range(10): print('\n')
-    print('------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------')
+    print('\n' * 10)
+    print('-' * 330)
     slicer.util.reloadScriptedModule(self.moduleName)
 
   def onReloadAndTest(self):


### PR DESCRIPTION
Prints 10 empty lines and a dashed line when user clicks 'Reload', in order to separate error messages and other debugging info