### PR TITLE
COMP: ensure application singletons are available

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/EditorEffects/CMakeLists.txt
@@ -63,6 +63,7 @@ set(${KIT}_TARGET_LIBRARIES
   qMRMLWidgets
   MRMLLogic
   MRMLCore
+  qSlicerBaseQTGUI
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Similar to an issue in the DataStore module [1],
a library that accesses qSlicerApplication::application()
or other singletons needs to be explicitly linked
to qSlicerBaseQTGUI on some platforms
(for example debian 9 with gcc6).

[1] https://github.com/Slicer/Slicer-DataStore/pull/2