### PR TITLE
COMP: vtkSlicerTerminology(Category|Type): Fix -Woverloaded-virtual warnings

### DIFF
--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyCategory.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyCategory.cxx
@@ -70,18 +70,21 @@ void vtkSlicerTerminologyCategory::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
-void vtkSlicerTerminologyCategory::Copy(vtkSlicerTerminologyCategory* aCategory)
+void vtkSlicerTerminologyCategory::Copy(vtkCodedEntry* aCategory)
 {
   if (!aCategory)
     {
     return;
     }
 
-  Superclass::Copy(aCategory);
+  this->Superclass::Copy(aCategory);
 
-  this->SetSNOMEDCTConceptID(aCategory->GetSNOMEDCTConceptID());
-  this->SetUMLSConceptUID(aCategory->GetUMLSConceptUID());
-  this->SetCid(aCategory->GetCid());
-  this->SetContextGroupName(aCategory->GetContextGroupName());
-  this->SetShowAnatomy(aCategory->GetShowAnatomy());
+  vtkSlicerTerminologyCategory *aTerminologyCategory =
+      vtkSlicerTerminologyCategory::SafeDownCast(aCategory);
+
+  this->SetSNOMEDCTConceptID(aTerminologyCategory->GetSNOMEDCTConceptID());
+  this->SetUMLSConceptUID(aTerminologyCategory->GetUMLSConceptUID());
+  this->SetCid(aTerminologyCategory->GetCid());
+  this->SetContextGroupName(aTerminologyCategory->GetContextGroupName());
+  this->SetShowAnatomy(aTerminologyCategory->GetShowAnatomy());
 }

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyCategory.h
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyCategory.h
@@ -47,7 +47,7 @@ public:
   virtual void Initialize();
 
   /// Copy one category into another
-  virtual void Copy(vtkSlicerTerminologyCategory* aCategory);
+  virtual void Copy(vtkCodedEntry* aCategory);
 
 public:
   vtkGetStringMacro(SNOMEDCTConceptID);

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyType.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyType.cxx
@@ -79,20 +79,23 @@ void vtkSlicerTerminologyType::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
-void vtkSlicerTerminologyType::Copy(vtkSlicerTerminologyType* aType)
+void vtkSlicerTerminologyType::Copy(vtkCodedEntry* aType)
 {
   if (!aType)
     {
     return;
     }
 
-  Superclass::Copy(aType);
+  this->Superclass::Copy(aType);
 
-  this->SetRecommendedDisplayRGBValue(aType->GetRecommendedDisplayRGBValue());
-  this->SetSlicerLabel(aType->GetSlicerLabel());
-  this->SetSNOMEDCTConceptID(aType->GetSNOMEDCTConceptID());
-  this->SetUMLSConceptUID(aType->GetUMLSConceptUID());
-  this->SetCid(aType->GetCid());
-  this->SetContextGroupName(aType->GetContextGroupName());
-  this->SetHasModifiers(aType->GetHasModifiers());
+  vtkSlicerTerminologyType *aTerminologyType =
+      vtkSlicerTerminologyType::SafeDownCast(aType);
+
+  this->SetRecommendedDisplayRGBValue(aTerminologyType->GetRecommendedDisplayRGBValue());
+  this->SetSlicerLabel(aTerminologyType->GetSlicerLabel());
+  this->SetSNOMEDCTConceptID(aTerminologyType->GetSNOMEDCTConceptID());
+  this->SetUMLSConceptUID(aTerminologyType->GetUMLSConceptUID());
+  this->SetCid(aTerminologyType->GetCid());
+  this->SetContextGroupName(aTerminologyType->GetContextGroupName());
+  this->SetHasModifiers(aTerminologyType->GetHasModifiers());
 }

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyType.h
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyType.h
@@ -48,7 +48,7 @@ public:
   virtual void Initialize();
 
   /// Copy one type into another
-  virtual void Copy(vtkSlicerTerminologyType* aType);
+  virtual void Copy(vtkCodedEntry* aType);
 
 public:
   vtkGetVector3Macro(RecommendedDisplayRGBValue, unsigned char);


### PR DESCRIPTION
This commit fixes warnings like this one:

```
In file included from /path/to/Slicer/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyCategory.h:27:0,
                 from /path/to/Slicer/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyEntry.h:32,
                 from /path/to/Slicer/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.h:32,
                 from /path/to/Slicer/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx:24:
/path/to/Slicer/Libs/MRML/Core/vtkCodedEntry.h:41:16: warning: ‘virtual void vtkCodedEntry::Copy(vtkCodedEntry*)’ was hidden [-Woverloaded-virtual]
   virtual void Copy(vtkCodedEntry* aType);
                ^
In file included from /path/to/Slicer/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyEntry.h:32:0,
                 from /path/to/Slicer/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.h:32,
                 from /path/to/Slicer/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx:24:
/path/to/Slicer/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologyCategory.h:50:16: warning:   by ‘virtual void vtkSlicerTerminologyCategory::Copy(vtkSlicerTerminologyCategory*)’ [-Woverloaded-virtual]
   virtual void Copy(vtkSlicerTerminologyCategory* aCategory);
                ^
```