### PR TITLE
ENH: Added option to disable DICOM reference check

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -110,6 +110,24 @@ This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. Se
 class _ui_DICOMSettingsPanel(object):
   def __init__(self, parent):
     vBoxLayout = qt.QVBoxLayout(parent)
+    # Add generic settings
+    genericGroupBox = ctk.ctkCollapsibleGroupBox()
+    genericGroupBox.title = "Generic DICOM settings"
+    genericGroupBoxFormLayout = qt.QFormLayout(genericGroupBox)
+    loadReferencesComboBox = ctk.ctkComboBox()
+    loadReferencesComboBox.toolTip = "Determines whether referenced DICOM series are " \
+      "offered when loading DICOM, or the automatic behavior if interaction is disabled. " \
+      "Interactive selection of referenced series is the default selection"
+    loadReferencesComboBox.addItem("Ask user", qt.QMessageBox.InvalidRole)
+    loadReferencesComboBox.addItem("Always", qt.QMessageBox.Yes)
+    loadReferencesComboBox.addItem("Never", qt.QMessageBox.No)
+    loadReferencesComboBox.currentIndex = 0
+    genericGroupBoxFormLayout.addRow("Load referenced series:", loadReferencesComboBox)
+    parent.registerProperty(
+      "DICOM/automaticallyLoadReferences", loadReferencesComboBox, "currentUserDataAsString", qt.SIGNAL("currentIndexChanged (int)"))
+    vBoxLayout.addWidget(genericGroupBox)
+
+    # Add settings panel for the plugins
     plugins = slicer.modules.dicomPlugins
     for pluginName in plugins.keys():
       if hasattr(plugins[pluginName], 'settingsPanelEntry'):

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -30,27 +30,36 @@ class DICOMLoadable(object):
   instead.
   """
 
-  def __init__(self):
-    # the file list of the data to be loaded
-    self.files = []
-    # name exposed to the user for the node
-    self.name = "Unknown"
-    # extra information the user sees on mouse over of the thing
-    self.tooltip = "No further information available"
-    # things the user should know before loading this data
-    self.warning = ""
-    # is the object checked for loading by default
-    self.selected = False
-    # confidence - from 0 to 1 where 0 means low chance
-    # that the user actually wants to load their data this
-    # way up to 1, which means that the plugin is very confident
-    # that this is the best way to load the data.
-    # When more than one plugin marks the same series as
-    # selected, the one with the highest confidence is
-    # actually selected by default.  In the case of a tie,
-    # both series are selected for loading.
-    self.confidence = 0.5
-
+  def __init__(self, qLoadable=None):
+    if qLoadable is None:
+      # the file list of the data to be loaded
+      self.files = []
+      # name exposed to the user for the node
+      self.name = "Unknown"
+      # extra information the user sees on mouse over of the thing
+      self.tooltip = "No further information available"
+      # things the user should know before loading this data
+      self.warning = ""
+      # is the object checked for loading by default
+      self.selected = False
+      # confidence - from 0 to 1 where 0 means low chance
+      # that the user actually wants to load their data this
+      # way up to 1, which means that the plugin is very confident
+      # that this is the best way to load the data.
+      # When more than one plugin marks the same series as
+      # selected, the one with the highest confidence is
+      # actually selected by default.  In the case of a tie,
+      # both series are selected for loading.
+      self.confidence = 0.5
+    else:
+      self.name = qLoadable.name
+      self.tooltip = qLoadable.tooltip
+      self.warning = qLoadable.warning
+      self.files = []
+      for file in qLoadable.files:
+        self.files.append(file)
+      self.selected = qLoadable.selected
+      self.confidence = qLoadable.confidence
 
 #
 # DICOMPlugin

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -768,8 +768,11 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
     if len(referencedFileLists):
       (self.referencedLoadables, loadEnabled) = self.getLoadablesFromFileLists(referencedFileLists)
 
-    if loadEnabled:
+    automaticallyLoadReferences = int(slicer.util.settingsValue('DICOM/automaticallyLoadReferences', qt.QMessageBox.InvalidRole))
+    if loadEnabled and automaticallyLoadReferences == qt.QMessageBox.InvalidRole:
       self.showReferenceDialogAndProceed()
+    elif loadEnabled and automaticallyLoadReferences == qt.QMessageBox.Yes:
+      self.addReferencesAndProceed()
     else:
       self.proceedWithReferencedLoadablesSelection()
 
@@ -777,7 +780,13 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
 
   def showReferenceDialogAndProceed(self):
     referencesDialog = DICOMReferencesDialog(self, loadables=self.referencedLoadables)
-    if referencesDialog.exec_() == qt.QMessageBox.Ok:
+    answer = referencesDialog.exec_()
+    if referencesDialog.rememberChoiceAndStopAskingCheckbox.checked == True:
+      if answer == qt.QMessageBox.Yes:
+        qt.QSettings().setValue('DICOM/automaticallyLoadReferences', qt.QMessageBox.Yes)
+      if answer == qt.QMessageBox.No:
+        qt.QSettings().setValue('DICOM/automaticallyLoadReferences', qt.QMessageBox.No)
+    if answer == qt.QMessageBox.Yes:
       # each check box corresponds to a referenced loadable that was selected by examine;
       # if the user confirmed that reference should be loaded, add it to the self.loadablesByPlugin dictionary
       for plugin in self.referencedLoadables:
@@ -786,6 +795,15 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
             self.loadablesByPlugin[plugin].append(loadable)
         self.loadablesByPlugin[plugin] = list(set(self.loadablesByPlugin[plugin]))
       self.proceedWithReferencedLoadablesSelection()
+    elif answer == qt.QMessageBox.No:
+      self.proceedWithReferencedLoadablesSelection()
+
+  def addReferencesAndProceed(self):
+    for plugin in self.referencedLoadables:
+      for loadable in [l for l in self.referencedLoadables[plugin] if l.selected]:
+        self.loadablesByPlugin[plugin].append(loadable)
+      self.loadablesByPlugin[plugin] = list(set(self.loadablesByPlugin[plugin]))
+    self.proceedWithReferencedLoadablesSelection()
 
   def proceedWithReferencedLoadablesSelection(self):
     if not self.warnUserIfLoadableWarningsAndProceed():
@@ -882,7 +900,8 @@ class DICOMReferencesDialog(qt.QMessageBox):
 
   WINDOW_TITLE = "Referenced datasets found"
   WINDOW_TEXT = "The loaded DICOM objects contain references to other datasets you did not select for loading. Please " \
-                "confirm if you would like to load the following referenced datasets."
+                "select Yes if you would like to load the following referenced datasets, No if you only want to load the " \
+                "originally selected series, or Cancel to abort loading."
 
   def __init__(self, parent, loadables):
     super(DICOMReferencesDialog, self).__init__(parent)
@@ -894,32 +913,42 @@ class DICOMReferencesDialog(qt.QMessageBox):
     self._setBasicProperties()
     self._addTextLabel()
     self._addLoadableCheckboxes()
-    self.okButton = self.addButton(self.Ok)
+    self.rememberChoiceAndStopAskingCheckbox = qt.QCheckBox('Remember choice and stop asking')
+    self.rememberChoiceAndStopAskingCheckbox.toolTip = 'Can be changed later in Application Settings / DICOM'
+    self.yesButton = self.addButton(self.Yes)
+    self.yesButton.setSizePolicy(qt.QSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Preferred))
+    self.noButton = self.addButton(self.No)
+    self.noButton.setSizePolicy(qt.QSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Preferred))
     self.cancelButton = self.addButton(self.Cancel)
-    self.layout().addWidget(self.okButton, 2, 0, 1, 1)
-    self.layout().addWidget(self.cancelButton, 2, 1, 1, 1)
+    self.cancelButton.setSizePolicy(qt.QSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Preferred))
+    self.layout().addWidget(self.yesButton, 3, 0, 1, 1)
+    self.layout().addWidget(self.noButton, 3, 1, 1, 1)
+    self.layout().addWidget(self.cancelButton, 3, 2, 1, 1)
+    self.layout().addWidget(self.rememberChoiceAndStopAskingCheckbox, 2, 0, 1, 3)
 
   def _setBasicProperties(self):
     self.layout().setSpacing(9)
     self.setWindowTitle(self.WINDOW_TITLE)
-    fm = qt.QFontMetrics(qt.QApplication.font(self))
-    self.setStyleSheet("QWidget{min-width: " + str(fm.width(self.WINDOW_TITLE)) + "px;}")
+    self.fontMetrics = qt.QFontMetrics(qt.QApplication.font(self))
+    self.setMinimumWidth(self.fontMetrics.width(self.WINDOW_TITLE))
 
   def _addTextLabel(self):
     label = qt.QLabel(self.WINDOW_TEXT)
     label.wordWrap = True
-    self.layout().addWidget(label, 0, 0, 1, 2)
+    self.layout().addWidget(label, 0, 0, 1, 3)
 
   def _addLoadableCheckboxes(self):
     self.checkBoxGroupBox = qt.QGroupBox("References")
     self.checkBoxGroupBox.setLayout(qt.QFormLayout())
     for plugin in self.loadables:
       for loadable in [l for l in self.loadables[plugin] if l.selected]:
-        cb = qt.QCheckBox(loadable.name, self)
+        checkBoxText = loadable.name + ' (' + plugin.loadType + ') '
+        cb = qt.QCheckBox(checkBoxText, self)
         cb.checked = True
+        cb.setSizePolicy(qt.QSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Preferred))
         self.checkboxes[loadable] = cb
         self.checkBoxGroupBox.layout().addWidget(cb)
-    self.layout().addWidget(self.checkBoxGroupBox, 1, 0, 1, 2)
+    self.layout().addWidget(self.checkBoxGroupBox, 1, 0, 1, 3)
 
 
 class DICOMDetailsDialog(DICOMDetailsBase, qt.QDialog):

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -60,7 +60,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
 
     readersComboBox.toolTip = "Preferred back end.  Archetype was used by default in Slicer before June of 2017.  Change this setting if data that previously loaded stops working (and report an issue)."
 
-    formLayout.addRow("DICOM reader approach", readersComboBox)
+    formLayout.addRow("DICOM reader approach:", readersComboBox)
 
     panel.registerProperty(
       "DICOM/ScalarVolume/ReaderApproach", readersComboBox,


### PR DESCRIPTION
- Added checkbox in the DICOM references dialog to not check for references again. Selection is saved regardless of pressed button
- Added generic options group in Application Settings / DICOM where this setting can be changed
- Added optional constructor argument to DICOMLoadable for easy conversion from qSlicerDICOMLoadable (useful for debugging when the otherwise deprecated python DICOMLoadable class is used internally)