### PR TITLE
ENH: Support Qt5 in dashboard script

### DIFF
--- a/CMake/SlicerDashboardDriverScript.cmake
+++ b/CMake/SlicerDashboardDriverScript.cmake
@@ -28,7 +28,6 @@ set(expected_variables
   CTEST_MEMORYCHECK_COMMAND
   CTEST_SVN_COMMAND
   CTEST_GIT_COMMAND
-  QT_QMAKE_EXECUTABLE
   )
 
 # Update list of expected variables based on build options.
@@ -45,6 +44,19 @@ foreach(var ${expected_variables})
     message(FATAL_ERROR "Variable ${var} should be defined in top-level script !")
   endif()
 endforeach()
+
+# Handle Qt configuration
+if(NOT DEFINED QT_QMAKE_EXECUTABLE AND NOT DEFINED Qt5_DIR)
+  message(FATAL_ERROR "Either QT_QMAKE_EXECUTABLE (for Qt4) or Qt5_DIR (for Qt5) should be defined in top-level script")
+endif()
+if(DEFINED QT_QMAKE_EXECUTABLE)
+  set(QT_CACHE_ENTRY "QT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}")
+  list(APPEND variables QT_QMAKE_EXECUTABLE)
+endif()
+if(DEFINED Qt5_DIR)
+  set(QT_CACHE_ENTRY "Qt5_DIR:PATH=${Qt5_DIR}")
+  list(APPEND variables Qt5_DIR)
+endif()
 
 if(NOT DEFINED CTEST_CONFIGURATION_TYPE AND DEFINED CTEST_BUILD_CONFIGURATION)
   set(CTEST_CONFIGURATION_TYPE ${CTEST_BUILD_CONFIGURATION})
@@ -278,7 +290,7 @@ macro(run_ctest)
     # Write initial cache.
     #-----------------------------------------------------------------------------
     file(WRITE "${CTEST_BINARY_DIRECTORY}/CMakeCache.txt" "
-QT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}
+${QT_CACHE_ENTRY}
 GIT_EXECUTABLE:FILEPATH=${CTEST_GIT_COMMAND}
 Subversion_SVN_EXECUTABLE:FILEPATH=${CTEST_SVN_COMMAND}
 WITH_COVERAGE:BOOL=${WITH_COVERAGE}

--- a/CMake/SlicerDashboardScript.TEMPLATE.cmake
+++ b/CMake/SlicerDashboardScript.TEMPLATE.cmake
@@ -41,8 +41,12 @@ set(SCRIPT_MODE "Nightly") # "Experimental", "Continuous", "Nightly"
 #-----------------------------------------------------------------------------
 set(MY_OPERATING_SYSTEM   "Linux") # Windows, Linux, Darwin...
 set(MY_COMPILER           "g++4.4.3")
+# Qt4:
 set(MY_QT_VERSION         "4.7.4")
 set(QT_QMAKE_EXECUTABLE   "$ENV{HOME}/Dashboards/Support/QtSDK-1.2/Desktop/Qt/474/gcc/bin/qmake")
+# Qt5:
+#set(MY_QT_VERSION         "5.7.1")
+#set(Qt5_DIR               "$ENV{HOME}/Qt5.7.1/5.7/gcc_64/lib/cmake/Qt5")
 set(CTEST_SITE            "karakoram.kitware") # for example: mymachine.kitware, mymachine.bwh.harvard.edu, ...
 set(CTEST_DASHBOARD_ROOT  "$ENV{HOME}/Dashboards/${SCRIPT_MODE}")
 


### PR DESCRIPTION
When building with Qt4, QT_QMAKE_EXECUTABLE is required.
When building with Qt5, Qt5_DIR is required.