### PR TITLE
BUG: Fix module updating mainwindow at load time when using Qt5

### DIFF
--- a/Applications/SlicerApp/Main.cxx
+++ b/Applications/SlicerApp/Main.cxx
@@ -209,6 +209,8 @@ int SlicerAppMain(int argc, char* argv[])
     {
     window.reset(new qSlicerAppMainWindow);
     window->setWindowTitle(window->windowTitle()+ " " + Slicer_VERSION_FULL);
+
+    QObject::connect(window.data(), SIGNAL(windowShown()), &app, SIGNAL(mainWindowShown()));
     }
   else if (app.commandOptions()->showPythonInteractor()
     && !app.commandOptions()->runPythonAndExit())

--- a/Applications/SlicerApp/Main.cxx
+++ b/Applications/SlicerApp/Main.cxx
@@ -209,8 +209,6 @@ int SlicerAppMain(int argc, char* argv[])
     {
     window.reset(new qSlicerAppMainWindow);
     window->setWindowTitle(window->windowTitle()+ " " + Slicer_VERSION_FULL);
-
-    QObject::connect(window.data(), SIGNAL(windowShown()), &app, SIGNAL(mainWindowShown()));
     }
   else if (app.commandOptions()->showPythonInteractor()
     && !app.commandOptions()->runPythonAndExit())
@@ -239,6 +237,15 @@ int SlicerAppMain(int argc, char* argv[])
     }
 
   splashMessage(splashScreen, QString());
+
+  if (window)
+    {
+    QObject::connect(window.data(), SIGNAL(windowShown()), &app, SIGNAL(startupCompleted()));
+    }
+  else
+    {
+    QTimer::singleShot(0, &app, SIGNAL(startupCompleted()));
+    }
 
   if (window)
     {

--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -305,6 +305,39 @@ foreach(stdlib_module IN ITEMS
     )
 endforeach()
 
+# Check that application signal "startupCompleted()" is emitted
+# (1) with mainwindow
+set(_dest "${CMAKE_CURRENT_BINARY_DIR}/StartupCompletedTest")
+file(MAKE_DIRECTORY ${_dest})
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/SlicerStartupCompletedTest.py DESTINATION ${_dest})
+set(_test "py_startupcompleted_signal_emitted_with_mainwindow_test")
+add_test(
+  NAME ${_test}
+  COMMAND ${Slicer_LAUNCHER_EXECUTABLE}
+    --testing --no-splash
+    --disable-builtin-cli-modules
+    --disable-builtin-loadable-modules
+    --disable-builtin-scripted-loadable-modules
+    --additional-module-path ${_dest}
+    --exit-after-startup
+  )
+set_tests_properties(${_test} PROPERTIES PASS_REGULAR_EXPRESSION "StartupCompleted emitted")
+
+# (2) without mainwindow
+set(_test "py_startupcompleted_signal_emitted_without_mainwindow_test")
+add_test(
+  NAME ${_test}
+  COMMAND ${Slicer_LAUNCHER_EXECUTABLE}
+    --testing --no-splash
+    --disable-builtin-cli-modules
+    --disable-builtin-loadable-modules
+    --disable-builtin-scripted-loadable-modules
+    --additional-module-path ${_dest}
+    --no-main-window
+    --exit-after-startup
+  )
+set_tests_properties(${_test} PROPERTIES PASS_REGULAR_EXPRESSION "StartupCompleted emitted")
+
 #
 # SelfTests
 # see http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Developers/Tutorials/SelfTestModule

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedTest.py
@@ -1,0 +1,19 @@
+import slicer
+
+from slicer.ScriptedLoadableModule import *
+
+
+class SlicerStartupCompletedTest(ScriptedLoadableModule):
+
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    self.parent.title = "SlicerStartupCompletedTest"
+    self.parent.categories = ["Testing.TestCases"]
+    self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)"]
+    self.parent.widgetRepresentationCreationEnabled = False
+
+    slicer.app.connect("startupCompleted()", self.onStartupCompleted)
+
+  def onStartupCompleted(self):
+    print("StartupCompleted emitted")
+

--- a/Applications/SlicerApp/qSlicerAppMainWindow.cxx
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.cxx
@@ -1124,6 +1124,7 @@ void qSlicerAppMainWindow::showEvent(QShowEvent *event)
     this->disclaimer();
     this->pythonConsoleInitialDisplay();
     }
+  emit windowShown();
 }
 
 //-----------------------------------------------------------------------------

--- a/Applications/SlicerApp/qSlicerAppMainWindow.h
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.h
@@ -120,7 +120,8 @@ public slots:
   virtual void on_ViewExtensionsManagerAction_triggered();
 
 signals:
-
+  /// Emitted when the window is shown to the user.
+  /// \sa showEvent(QShowEvent *)
   void windowShown();
 
 protected slots:

--- a/Applications/SlicerApp/qSlicerAppMainWindow.h
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.h
@@ -119,6 +119,10 @@ public slots:
   virtual void on_PasteAction_triggered();
   virtual void on_ViewExtensionsManagerAction_triggered();
 
+signals:
+
+  void windowShown();
+
 protected slots:
   virtual void onModuleLoaded(const QString& moduleName);
   virtual void onModuleAboutToBeUnloaded(const QString& moduleName);

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -165,7 +165,16 @@ public slots:
 
 signals:
 
-  void mainWindowShown();
+  /// Emitted when the startup phase has been completed.
+  ///
+  /// Startup is complete when all the modules have been
+  /// initialized and the main window is shown to the user.
+  ///
+  /// \note If the application is started without the mainwindow,
+  /// the signal is emitted after the modules are initialized.
+  ///
+  /// \sa qSlicerAppMainWindow::windowShown()
+  void startupCompleted();
 
 protected:
   /// Reimplemented from qSlicerCoreApplication

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -163,6 +163,10 @@ public slots:
   /// \sa recentLogFiles(), setupFileLogging()
   QString currentLogFile()const;
 
+signals:
+
+  void mainWindowShown();
+
 protected:
   /// Reimplemented from qSlicerCoreApplication
   virtual void handlePreApplicationCommandLineArguments();

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -69,7 +69,7 @@ This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. Se
 
     # Trigger the menu to be added when application has started up
     if not slicer.app.commandOptions().noMainWindow :
-      slicer.app.connect("mainWindowShown()", self.performPostModuleDiscoveryTasks)
+      slicer.app.connect("startupCompleted()", self.performPostModuleDiscoveryTasks)
 
   def setup(self):
     pluginHandlerSingleton = slicer.qSlicerSubjectHierarchyPluginHandler.instance()

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -69,7 +69,7 @@ This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. Se
 
     # Trigger the menu to be added when application has started up
     if not slicer.app.commandOptions().noMainWindow :
-      qt.QTimer.singleShot(0, self.performPostModuleDiscoveryTasks)
+      slicer.app.connect("mainWindowShown()", self.performPostModuleDiscoveryTasks)
 
   def setup(self):
     pluginHandlerSingleton = slicer.qSlicerSubjectHierarchyPluginHandler.instance()

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -67,9 +67,8 @@ This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. Se
         if slicer.dicomDatabase:
           slicer.app.setDICOMDatabase(slicer.dicomDatabase)
 
-    # Trigger the menu to be added when application has started up
-    if not slicer.app.commandOptions().noMainWindow :
-      slicer.app.connect("startupCompleted()", self.performPostModuleDiscoveryTasks)
+    # Tasks to execute after the application has started up
+    slicer.app.connect("startupCompleted()", self.performPostModuleDiscoveryTasks)
 
   def setup(self):
     pluginHandlerSingleton = slicer.qSlicerSubjectHierarchyPluginHandler.instance()
@@ -83,11 +82,13 @@ This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. Se
     """
     # set the dicom pre-cache tags once all plugin classes have been initialized
     DICOMLib.setDatabasePrecacheTags()
-    # add to the main app file menu
-    self.addMenu()
-    # add the settings options
-    self.settingsPanel = DICOMSettingsPanel()
-    slicer.app.settingsDialog().addPanel("DICOM", self.settingsPanel)
+
+    if not slicer.app.commandOptions().noMainWindow:
+      # add to the main app file menu
+      self.addMenu()
+      # add the settings options
+      self.settingsPanel = DICOMSettingsPanel()
+      slicer.app.settingsDialog().addPanel("DICOM", self.settingsPanel)
 
   def addMenu(self):
     """Add an action to the File menu that will go into

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -32,7 +32,7 @@ See <a>http://www.slicer.org</a> for details.  Module implemented by Steve Piepe
 
     # Trigger the menu to be added when application has started up
     if not slicer.app.commandOptions().noMainWindow :
-      qt.QTimer.singleShot(0, self.addView);
+      slicer.app.connect("mainWindowShown()", self.addView)
 
     # Add this test to the SelfTest module's list for discovery when the module
     # is created.  Since this module may be discovered before SelfTests itself,

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -32,7 +32,7 @@ See <a>http://www.slicer.org</a> for details.  Module implemented by Steve Piepe
 
     # Trigger the menu to be added when application has started up
     if not slicer.app.commandOptions().noMainWindow :
-      slicer.app.connect("mainWindowShown()", self.addView)
+      slicer.app.connect("startupCompleted()", self.addView)
 
     # Add this test to the SelfTest module's list for discovery when the module
     # is created.  Since this module may be discovered before SelfTests itself,

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -37,7 +37,7 @@ use it for commercial purposes.</p>
 
     # Trigger the menu to be added when application has started up
     if not slicer.app.commandOptions().noMainWindow :
-      slicer.app.connect("mainWindowShown()", self.addMenu)
+      slicer.app.connect("startupCompleted()", self.addMenu)
 
     # allow other modules to register sample data sources by appending
     # instances or subclasses SampleDataSource objects on this list

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -37,7 +37,7 @@ use it for commercial purposes.</p>
 
     # Trigger the menu to be added when application has started up
     if not slicer.app.commandOptions().noMainWindow :
-      qt.QTimer.singleShot(0, self.addMenu);
+      slicer.app.connect("mainWindowShown()", self.addMenu)
 
     # allow other modules to register sample data sources by appending
     # instances or subclasses SampleDataSource objects on this list


### PR DESCRIPTION
With Qt5, relying on "Qtimer::singleShow" with a time of 0ms is not
sufficient anymore to ensure the associated slot is called after the
main window is shown.

The following errors were reported at startup time:

```
Failed to obtain reference to 'FileMenu'
Failed to obtain reference to 'qSlicerAppMainWindow'
No Data Probe frame - cannot create DataProbe
Failed to obtain reference to 'qSlicerAppMainWindow'
Failed to obtain reference to 'FileMenu'
```

To ensure module can update the main window once it is shown, this
commit introduces the signal "qSlicerApplication::mainWindowShown()" that
can be connected when a scripted or loadable module is initialized.

Once the main window is shown, the signal "mainWindowShown()" ends up being
triggered.