### PR TITLE
BUG: SliceLogic: Fix "Bad plane coordinate system" vtkPlaneSource error

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -549,11 +549,23 @@ void vtkMRMLSliceLogic::ProcessMRMLLogicsEvents()
     plane->SetOrigin(outPt3);
 
     inPt[0] = dims[0];
+    // Force non-zero coordinates to avoid "Bad plane coordinate system"
+    // error from vtkPlaneSource when slice viewers have a width of zero.
+    if (inPt[0] < 1)
+      {
+      inPt[0] = 1;
+      }
     textureToRAS->MultiplyPoint(inPt, outPt);
     plane->SetPoint1(outPt3);
 
     inPt[0] = 0;
     inPt[1] = dims[1];
+    // Force non-zero coordinates to avoid "Bad plane coordinate system"
+    // error from vtkPlaneSource when slice viewers have an height of zero.
+    if (inPt[1] < 1)
+      {
+      inPt[1] = 1;
+      }
     textureToRAS->MultiplyPoint(inPt, outPt);
     plane->SetPoint2(outPt3);
 


### PR DESCRIPTION
The errors can be reproduced using Slicer built against Qt4/VTK7/OpenGL
or Qt5/VTK8/OpenGL2 by:
(1) switching to "Conventional" (or "Conventional Widescreen") layout
(2) and re-sizing the viewers using the "spacer" until their are hidden.

This commit also fixes qMRMLLayoutManagerWithCustomFactoryTest that was
failing with the same error when built using Qt5/VTK8/OpenGL2.

Error similar to the one copied below:

```
Bad plane coordinate system


Algorithm vtkPlaneSource(0x4e5a020) returned failure for request: vtkInformation (0x4e5ca40)
  Debug: Off
  Modified Time: 978985
  Reference Count: 1
  Registered Events: (none)
  Request: REQUEST_DATA
  ALGORITHM_AFTER_FORWARD: 1
  FROM_OUTPUT_PORT: 0
  FORWARD_DIRECTION: 0
```