### PR TITLE
PERF: don't update markups while scene is batch processing

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager2D.cxx
@@ -310,6 +310,11 @@ void vtkMRMLMarkupsDisplayableManager2D
 ::ProcessMRMLNodesEvents(vtkObject *caller,unsigned long event,void *callData)
 {
 
+  if (this->GetMRMLScene()->IsBatchProcessing())
+    {
+    return;
+    }
+
   vtkMRMLMarkupsNode * markupsNode = vtkMRMLMarkupsNode::SafeDownCast(caller);
   vtkMRMLMarkupsDisplayNode *displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(caller);
   vtkMRMLInteractionNode * interactionNode = vtkMRMLInteractionNode::SafeDownCast(caller);

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager3D.cxx
@@ -303,6 +303,11 @@ void vtkMRMLMarkupsDisplayableManager3D
 ::ProcessMRMLNodesEvents(vtkObject *caller,unsigned long event,void *callData)
 {
 
+  if (this->GetMRMLScene()->IsBatchProcessing())
+    {
+    return;
+    }
+
   vtkMRMLMarkupsNode * markupsNode = vtkMRMLMarkupsNode::SafeDownCast(caller);
   vtkMRMLMarkupsDisplayNode *displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(caller);
   vtkMRMLInteractionNode * interactionNode = vtkMRMLInteractionNode::SafeDownCast(caller);


### PR DESCRIPTION
This avoids unacceptable delays when performing batch
operations on fiducial lists.