### PR TITLE
WIP: check for uninitialized DICOM db location

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -79,14 +79,14 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
     VTKObservationMixin.__init__(self)
     self.settings = qt.QSettings()
 
-    # This creates a DICOM database in the current working directory if nothing else
-    # is specified in the settings, therefore promptForDatabaseDirectory must be called before this.
-    self.dicomBrowser = dicomBrowser if dicomBrowser is not None else ctkDICOMBrowser()
-
     # initialize the dicomDatabase
     #   - pick a default and let the user know
     if not slicer.dicomDatabase:
       self.promptForDatabaseDirectory()
+
+    # This creates a DICOM database in the current working directory if nothing else
+    # is specified in the settings, therefore promptForDatabaseDirectory must be called before this.
+    self.dicomBrowser = dicomBrowser if dicomBrowser is not None else ctkDICOMBrowser()
 
     self.browserPersistent = settingsValue('DICOM/BrowserPersistent', False, converter=toBool)
     self.tableDensity = settingsValue('DICOM/tableDensity', 'Compact')
@@ -509,6 +509,8 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
       databaseDirectory = os.path.join(slicer.app.temporaryPath, 'tempDICOMDatabase')
     else:
       databaseDirectory = self.settings.value('DatabaseDirectory')
+      if not databaseDirectory:
+        databaseDirectory = ""
     if not os.path.exists(databaseDirectory):
       try:
         os.makedirs(databaseDirectory)
@@ -521,7 +523,9 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
         message = "DICOM Database will be stored in\n\n{}\n\nUse the Local Database button in " \
                 "the DICOM Browser to pick a different location.".format(databaseDirectory)
         slicer.util.infoDisplay(message, parent=self, windowTitle='DICOM')
-    self.onDatabaseDirectoryChanged(databaseDirectory)
+        self.settings.setValue('DatabaseDirectory', databaseDirectory)
+    if slicer.dicomDatabase:
+      self.onDatabaseDirectoryChanged(databaseDirectory)
 
   def onTableDensityComboBox(self, state):
     self.settings.setValue('DICOM/tableDensity', state)


### PR DESCRIPTION
DatabaseDirectory setting is not available on first start of Slicer. As
described in https://issues.slicer.org/view.php?id=4424, this can lead to the
default location be non-writeable, without user being notified. This commit
aims to fix this problem, but not fully resolves the issue. Current runtime
error:

```
Traceback (most recent call last):
File
"/Applications/Slicer.app/Contents/lib/Slicer-4.7/qt-scripted-modules/DICOM.py",
line 333, in setup
      slicer.dicomDatabase.connect('databaseChanged()', self.onDatabaseChanged)
      AttributeError: 'NoneType' object has no attribute 'connect'
```

I would use help from someone more familiar with this code!