### PR TITLE
ENH: Extend scripted module API adding support for cleanup() method

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -178,10 +178,14 @@ endif()
 # Check if scripted module import works as expected
 #
 
+set(testname ScriptedModuleDiscoveryTest)
 slicer_add_python_test(
-  SCRIPT ScriptedModuleDiscoveryTest.py
+  SCRIPT ${testname}.py
   SLICER_ARGS --no-main-window --disable-builtin-modules --additional-module-path ${CMAKE_CURRENT_SOURCE_DIR}/ScriptedModuleDiscoveryTest
   TESTNAME_PREFIX nomainwindow_
+  )
+set_tests_properties(py_nomainwindow_${testname} PROPERTIES
+  PASS_REGULAR_EXPRESSION "ModuleAWidget finalized"
   )
 
 #

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
@@ -20,5 +20,9 @@ class ModuleA(ScriptedLoadableModule):
     return SOMEVAR
 
 class ModuleAWidget(ScriptedLoadableModuleWidget):
+  def __init__(self, parent=None):
+    ScriptedLoadableModuleWidget.__init__(self, parent)
   def setup(self):
     ScriptedLoadableModuleWidget.setup(self)
+  def cleanup(self):
+    print("ModuleAWidget finalized")

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleB.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleB.py
@@ -20,5 +20,7 @@ class ModuleB(ScriptedLoadableModule):
     return SOMEVAR
 
 class ModuleBWidget(ScriptedLoadableModuleWidget):
+  def __init__(self, parent=None):
+    ScriptedLoadableModuleWidget.__init__(self, parent)
   def setup(self):
     ScriptedLoadableModuleWidget.setup(self)

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -81,6 +81,26 @@ class ScriptedLoadableModuleWidget:
     if not parent:
       self.setup()
       self.parent.show()
+    slicer.app.moduleManager().connect(
+      'moduleAboutToBeUnloaded(QString)', self._onModuleAboutToBeUnloaded)
+
+  def cleanup(self):
+    """Override this function to implement module widget specific cleanup.
+
+    It is invoked when the signal `qSlicerModuleManager::moduleAboutToBeUnloaded(QString)`
+    corresponding to the current module is emitted and just before a module is
+    effectively unloaded.
+    """
+    pass
+
+  def _onModuleAboutToBeUnloaded(self, moduleName):
+    """This slot calls `cleanup()` if the module about to be unloaded is the
+    current one.
+    """
+    if moduleName == self.moduleName:
+      self.cleanup()
+      slicer.app.moduleManager().disconnect(
+        'moduleAboutToBeUnloaded(QString)', self._onModuleAboutToBeUnloaded)
 
   def setupDeveloperSection(self):
     if not self.developerMode:
@@ -133,9 +153,6 @@ class ScriptedLoadableModuleWidget:
   def setup(self):
     # Instantiate and connect default widgets ...
     self.setupDeveloperSection()
-
-  def cleanup(self):
-    pass
 
   def onReload(self):
     """

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -532,8 +532,7 @@ def reloadScriptedModule(moduleName):
   # delete the old widget instance
   if hasattr(slicer.modules, widgetName):
     w = getattr(slicer.modules, widgetName)
-    if hasattr(w, 'cleanup'):
-      w.cleanup()
+    w.cleanup()
 
   # create new widget inside existing parent
   widget = eval('reloaded_module.%s(parent)' % widgetName)


### PR DESCRIPTION
This allows to do some cleanup before a module is effectively unloaded. It
is particularly useful to update objects or widgets and avoid memory leaks
due to complex interdependencies between C++ application and python layer.