### PR TITLE
ENH: Extend application API adding environment()/startupEnvironment()

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -274,6 +274,12 @@ slicer_add_python_unittest(
   TESTNAME_PREFIX nomainwindow_
   )
 
+slicer_add_python_unittest(
+  SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_environment.py
+  SLICER_ARGS --no-main-window --disable-modules
+  TESTNAME_PREFIX nomainwindow_
+  )
+
 # DCMTKPrivateDictionary test
 slicer_add_python_test(
   SCRIPT DCMTKPrivateDictTest.py

--- a/Base/Python/slicer/tests/test_slicer_environment.py
+++ b/Base/Python/slicer/tests/test_slicer_environment.py
@@ -1,0 +1,25 @@
+
+import qt
+import slicer
+import unittest
+
+
+class SlicerEnvironmentTests(unittest.TestCase):
+
+  def setUp(self):
+    pass
+
+  def test_slicer_util_startupEnvironment(self):
+    startupEnv = slicer.util.startupEnvironment()
+    assert type(startupEnv) is dict
+    assert "Slicer-build" not in startupEnv["PATH"]
+
+  def test_slicer_app_startupEnvironment(self):
+    startupEnv = slicer.app.startupEnvironment()
+    assert type(startupEnv) is qt.QProcessEnvironment
+    assert "Slicer-build" not in startupEnv.value("PATH")
+
+  def test_slicer_app_environment(self):
+    env = slicer.app.environment()
+    assert type(env) is qt.QProcessEnvironment
+    assert "Slicer-build" in env.value("PATH")

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -49,6 +49,24 @@ def sourceDir():
   """
   return _readCMakeCache('Slicer_SOURCE_DIR')
 
+def startupEnvironment():
+  """Returns the environment without the Slicer specific values.
+
+  Path environment variables like `PATH`, `LD_LIBRARY_PATH` or `PYTHONPATH`
+  will not contain values found in the launcher settings.
+
+  Similarly `key=value` environment variables also found in the launcher
+  settings are excluded. Note that if a value was associated with a key prior
+  starting Slicer, it will not be set in the environment returned by this
+  function.
+
+  The function excludes both the Slicer launcher settings and the revision
+  specific launcher settings.
+  """
+  import slicer
+  startupEnv = slicer.app.startupEnvironment()
+  return {varname: startupEnv.value(varname) for varname in startupEnv.keys()}
+
 #
 # Custom Import
 #

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -24,6 +24,7 @@
 // Qt includes
 #include <QApplication>
 #include <QMetaType>
+#include <QProcessEnvironment>
 #include <QStringList>
 #include <QVariant>
 
@@ -109,7 +110,38 @@ public:
   /// \sa QCoreApplication::testAttribute
   static bool testAttribute(qSlicerCoreApplication::ApplicationAttribute attribute);
 
-  /// Convenient function to set an environment variable
+  /// \brief Returns the environment without the Slicer specific values.
+  ///
+  /// Path environment variables like `PATH`, `LD_LIBRARY_PATH` or `PYTHONPATH`
+  /// will not contain values found in the launcher settings.
+  ///
+  /// Similarly `key=value` environment variables also found in the launcher
+  /// settings are excluded. Note that if a value was associated with a key prior
+  /// starting Slicer, it will not be set in the environment returned by this
+  /// function.
+  ///
+  /// The function excludes both the Slicer launcher settings and the revision
+  /// specific launcher settings.
+  ///
+  /// \sa launcherSettingsFilePath(), launcherRevisionSpecificUserSettingsFilePath()
+  /// \sa repositoryRevision()
+  /// \sa environment()
+  Q_INVOKABLE QProcessEnvironment startupEnvironment() const;
+
+  /// \brief Returns the current environment.
+  ///
+  /// The returned environment contains all values found in the launcher
+  /// settings.
+  ///
+  /// \note Environment variables set from python updating `os.environ` or
+  /// set from c++ directly calling `putenv()` will **NOT** be found in the
+  /// environment returned by this function.
+  ///
+  /// \sa setEnvironmentVariable(const QString& key, const QString& value);
+  Q_INVOKABLE QProcessEnvironment environment() const;
+
+  /// \brief Convenient function to set an environment variable.
+  ///
   /// \note Using this function will ensure that the environment is up-to-date for
   /// processes started using QProcess or other alternative methods.
   void setEnvironmentVariable(const QString& key, const QString& value);


### PR DESCRIPTION
With the upcoming feature, it will be possible to easily invoke processes by excluding the Slicer environment.:
* from c++ (using `app->startupEnvironment()`), or;
* from python (using `slicer.util.startupEnvironment()` 

Here are two examples:

Without using the `startup` environment, this first example fails (as expected):

```
>>> from subprocess import check_output
>>> check_call(["/usr/bin/python3", "-c", "print('hola')"])
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/jcfr/Projects/Slicer-2-build/python-install/lib/python2.7/subprocess.py", line 186, in check_call
    raise CalledProcessError(retcode, cmd)
CalledProcessError: Command '['/usr/bin/python3', '-c', "print('hola')"]' returned non-zero exit status -6
```

Now, using the sanitized environment, this one succeeds:

```
>>> from subprocess import check_output
>>> check_output(
  ["/usr/bin/python3", "-c", "print('hola')"], 
  env=slicer.util.startupEnvironment())
'hola\n'
```