### PR TITLE
STYLE: prevent __version__.py being marked as modified on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore all dotfiles...
 .*
+!.gitattributes
 
 # Ignore all back-up files...
 *~

--- a/Utilities/Scripts/SlicerWizard/.gitattributes
+++ b/Utilities/Scripts/SlicerWizard/.gitattributes
@@ -1,0 +1,1 @@
+__version__.py text eol=lf


### PR DESCRIPTION
Building Slicer regenerates `__version__.py`, and if the file was checked out with autocrlf it will be marked as modified. This creates an annoyance for many versioning-related operations, such as committing, re-basing, cherry-picking etc.