### PR TITLE
ENH: Update EMSegment removing register

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -289,7 +289,7 @@ endif()
 
 Slicer_Remote_Add(EMSegment
   SVN_REPOSITORY "http://svn.slicer.org/Slicer3/branches/Slicer4-EMSegment"
-  SVN_REVISION -r "17138"
+  SVN_REVISION -r "17139"
   OPTION_NAME Slicer_BUILD_EMSegment
   OPTION_DEPENDS "Slicer_BUILD_BRAINSTOOLS;Slicer_BUILD_QTLOADABLEMODULES;Slicer_USE_PYTHONQT_WITH_TCL"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
The use of the register key word is deprecated:
Slicer-bld/EMSegment/AMF/vtkMinHeap.h:235:5: warning: 'register' storage class specifier is deprecated and incompatible with C++1z
      [-Wdeprecated-register]
    register int  down;
    ^~~~~~~~~