### PR TITLE
BUG: Fixed incorrect value ending up in composite view's volume node IDs

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -278,13 +278,13 @@ def setSliceViewerLayers(background='keep-current', foreground='keep-current', l
   num = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLSliceCompositeNode')
   for i in range(num):
       sliceViewer = slicer.mrmlScene.GetNthNodeByClass(i, 'vtkMRMLSliceCompositeNode')
-      if background is not 'keep-current':
+      if background != 'keep-current':
           sliceViewer.SetBackgroundVolumeID(_nodeID(background))
-      if foreground is not 'keep-current':
+      if foreground != 'keep-current':
           sliceViewer.SetForegroundVolumeID(_nodeID(foreground))
       if foregroundOpacity is not None:
           sliceViewer.SetForegroundOpacity(foregroundOpacity)
-      if label is not 'keep-current':
+      if label != 'keep-current':
           sliceViewer.SetLabelVolumeID(_nodeID(label))
       if labelOpacity is not None:
           sliceViewer.SetLabelOpacity(labelOpacity)

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
@@ -455,15 +455,18 @@ void qSlicerSubjectHierarchyVolumesPlugin::collectShownVolumes( QSet<vtkIdType>&
   for (int i=0; i<numberOfCompositeNodes; i++)
     {
     compositeNode = vtkMRMLSliceCompositeNode::SafeDownCast( scene->GetNthNodeByClass( i, "vtkMRMLSliceCompositeNode" ) );
-    if (layer & vtkMRMLApplicationLogic::BackgroundLayer && compositeNode->GetBackgroundVolumeID())
+    if ( layer & vtkMRMLApplicationLogic::BackgroundLayer
+      && compositeNode->GetBackgroundVolumeID() && strcmp(compositeNode->GetBackgroundVolumeID(),"") && strcmp(compositeNode->GetBackgroundVolumeID(),"NULL") )
       {
       shownVolumeItemIDs.insert(shNode->GetItemByDataNode( scene->GetNodeByID(compositeNode->GetBackgroundVolumeID())) );
       }
-    if (layer & vtkMRMLApplicationLogic::ForegroundLayer && compositeNode->GetForegroundVolumeID())
+    if ( layer & vtkMRMLApplicationLogic::ForegroundLayer
+      && compositeNode->GetForegroundVolumeID() && strcmp(compositeNode->GetForegroundVolumeID(),"") && strcmp(compositeNode->GetForegroundVolumeID(),"NULL") )
       {
       shownVolumeItemIDs.insert(shNode->GetItemByDataNode( scene->GetNodeByID(compositeNode->GetForegroundVolumeID())) );
       }
-    if (layer & vtkMRMLApplicationLogic::LabelLayer && compositeNode->GetLabelVolumeID() && strcmp(compositeNode->GetLabelVolumeID(),""))
+    if ( layer & vtkMRMLApplicationLogic::LabelLayer
+      && compositeNode->GetLabelVolumeID() && strcmp(compositeNode->GetLabelVolumeID(),"") && strcmp(compositeNode->GetLabelVolumeID(),"NULL") )
       {
       shownVolumeItemIDs.insert(shNode->GetItemByDataNode( scene->GetNodeByID(compositeNode->GetLabelVolumeID())) );
       }


### PR DESCRIPTION
By not checking the compared object by contained values, the string 'keep-current' could end up in the volume node IDs (background, foreground, label) stored in vtkMRMLSliceCompositeNode, making it hard to check if a valid volume node in shown in a slice view.

For some reason the string 'NULL' can also end up in these char* members that should only contain valid node ID strings or null pointer, hence the fix in qSlicerSubjectHierarchyVolumesPlugin. The source of the string 'NULL' is still unknown.