### PR TITLE
ENH: Import vtkSegmentationCore to python by default. WIP

### DIFF
--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -12,6 +12,7 @@ set(Slicer_PYTHON_SCRIPTS
   teem
   vtkAddon
   vtkITK
+  vtkSegmentationCore
   )
 
 set(Slicer_PYTHON_MODULES_CONFIG "

--- a/Base/Python/slicer/slicerqt-with-tcl.py
+++ b/Base/Python/slicer/slicerqt-with-tcl.py
@@ -12,7 +12,7 @@ def tcl(cmd):
     import tpycl
     _tpycl = tpycl.tpycl()
 
-    packages = ['freesurfer', 'mrml', 'teem', 'vtk', 'vtkAddon', 'vtkITK']
+    packages = ['freesurfer', 'mrml', 'teem', 'vtk', 'vtkAddon', 'vtkITK', 'vtkSegmentationCore']
     for p in packages:
       _tpycl.py_package(p)
 

--- a/Base/Python/vtkSegmentationCore.py
+++ b/Base/Python/vtkSegmentationCore.py
@@ -1,0 +1,4 @@
+""" This module loads all the classes from the vtkSegmentationCore library into its
+namespace."""
+
+from vtkSegmentationCorePython import *

--- a/CMake/SlicerConfig.cmake.in
+++ b/CMake/SlicerConfig.cmake.in
@@ -268,6 +268,9 @@ set(vtkAddon_INCLUDE_DIRS "@vtkAddon_INCLUDE_DIRS_CONFIG@"
 set(vtkITK_INCLUDE_DIRS "@vtkITK_INCLUDE_DIRS_CONFIG@"
   CACHE INTERNAL "vtkITK includes" FORCE)
 
+set(vtkSegmentationCore_INCLUDE_DIRS "@vtkSegmentationCore_INCLUDE_DIRS_CONFIG@"
+  CACHE INTERNAL "vtkSegmentationCore includes" FORCE)
+
 set(vtkTeem_INCLUDE_DIRS "@vtkTeem_INCLUDE_DIRS_CONFIG@"
   CACHE INTERNAL "vtkTeem includes" FORCE)
 

--- a/CMake/SlicerGenerateSlicerConfig.cmake
+++ b/CMake/SlicerGenerateSlicerConfig.cmake
@@ -108,6 +108,7 @@ set(RemoteIO_INCLUDE_DIRS_CONFIG ${RemoteIO_INCLUDE_DIRS})
 set(vtkTeem_INCLUDE_DIRS_CONFIG ${vtkTeem_INCLUDE_DIRS})
 set(vtkAddon_INCLUDE_DIRS_CONFIG ${vtkAddon_INCLUDE_DIRS})
 set(vtkITK_INCLUDE_DIRS_CONFIG ${vtkITK_INCLUDE_DIRS})
+set(vtkSegmentationCore_INCLUDE_DIRS_CONFIG ${vtkSegmentationCore_INCLUDE_DIRS})
 
 # Note: For sake of simplification, the macro 'slicer_config_set_ep' is not invoked conditionally, if
 # the configured 'value' parameter is an empty string, the macro 'slicer_config_set_ep' is a no-op.

--- a/CMake/SlicerInstallConfig.cmake.in
+++ b/CMake/SlicerInstallConfig.cmake.in
@@ -55,6 +55,7 @@ set(Slicer_Libs_LIBRARY_DIRS
   "${Slicer_HOME}/lib/tclap"
   "${Slicer_HOME}/lib/vtkAddon"
   "${Slicer_HOME}/lib/vtkITK"
+  "${Slicer_HOME}/lib/vtkSegmentationCore"
   "${Slicer_HOME}/lib/vtkTeem"
   "${Slicer_HOME}/lib/TclTk/lib"
   "${Slicer_HOME}/lib/TclTk/lib/itcl@INCR_TCL_VERSION_DOT@"
@@ -75,6 +76,7 @@ set(Slicer_Libs_INCLUDE_DIRS
   "${Slicer_HOME}/include/tclap"
   "${Slicer_HOME}/include/vtkAddon"
   "${Slicer_HOME}/include/vtkITK"
+  "${Slicer_HOME}/include/vtkSegmentationCore"
   "${Slicer_HOME}/include/vtkTeem"
   )
 


### PR DESCRIPTION
Attempt to implicitly import vtkSegmentationCorePython, based on what was in the code for vtkAddon. Unfortunately it does not work, so I'd appreciate any help. Thanks!