### PR TITLE
ENH: Write coordinate system to model files

### DIFF
--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.h
@@ -35,6 +35,9 @@ public:
   /// Get node XML tag name (like Storage, Model)
   virtual const char* GetNodeTagName() VTK_OVERRIDE  {return "ModelStorage";}
 
+  /// Write this node's information to a MRML file in XML format.
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
+
   /// Return true if the reference node can be read in
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode) VTK_OVERRIDE;
 


### PR DESCRIPTION
https://issues.slicer.org/view.php?id=4408

In recent years, LPS coordinate system has become much more widely used than RAS.
When Slicer saves a node to file, it already uses RAS for images and transforms and can use LPS for markups.
However, model node have been still saved as RAS. This caused a problem, because when models and images are
used or created by external software, models and images are not displayed consistently.

Unfortunately, generic mesh file formats have no standard way of storing coordinate system (axis orientation)
information, therefore switching to LPS could not be performed in a single step without breaking backward compatibility.

Proposed solution: Switch to LPS-based model files in multiple steps.

Step 1: Write coordinate system information (SPACE=RAS) to model files. Use comments in STL, PLY, and OBJ files; as field data in VTK files.
Keep writing data as RAS.

Step 2: Allow reading/writing models that use LPS coordinate system (add an option in Add data dialog; add an option in storage node).
Use coordinate system that is stored in the file header. If no coordinate system information is found in the file then assume RAS.

Step 3: Write models to file in LPS coordinate system by default.

Step 4: If no coordinate system information is found in the file then assume LPS.

---

Step 3-4 somewhat break backward compatibility, therefore there should be either sufficient amount of time (1-2 years) has to be
left after Step 1, or these steps should be done in a new major release.

This commit implements Step 1 (with the limitation that coordinate system info cannot be saved into OBJ files and ascii STL files
due to limitation of VTK API - but these formats are rarely used anyway).