### PR TITLE
ENH: Added show option to Add data dialog for volume loading

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -363,6 +363,16 @@ def loadLabelVolume(filename, properties={}, returnNode=False):
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
 def loadVolume(filename, properties={}, returnNode=False):
+  """Properties:
+  - name: this name will be used as node name for the loaded volume
+  - labelmap: interpret volume as labelmap
+  - singleFile: ignore all other files in the directory
+  - center: ignore image position
+  - discardOrientation: ignore image axis directions
+  - autoWindowLevel: compute window/level automatically
+  - show: display volume in slice viewers after loading is completed
+  - fileNames: list of filenames to load the volume from
+  """
   filetype = 'VolumeFile'
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -659,7 +659,6 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
     vtkErrorMacro("AddArchetypeVolume: Failed to add volume - MRMLScene is null");
     return 0;
     }
-  this->GetMRMLScene()->StartState(vtkMRMLScene::BatchProcessState);
 
   bool labelMap = false;
   if ( loadingOptions & 1 )    // labelMap is true
@@ -795,7 +794,6 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
     testScene->SetDataIOManager(0);
     }
 
-  this->GetMRMLScene()->EndState(vtkMRMLScene::BatchProcessState);
   if (modified)
     {
     this->Modified();

--- a/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesIOOptionsWidget.ui
+++ b/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesIOOptionsWidget.ui
@@ -28,9 +28,32 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="LabelMapCheckBox">
+     <property name="text">
+      <string>LabelMap</string>
+     </property>
+     <property name="toolTip">
+      <string>Load the volume as a labelmap (each voxel value representing a segmented structure).</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="SingleFileCheckBox">
+     <property name="text">
+      <string>Single File</string>
+     </property>
+     <property name="toolTip">
+      <string>Only load the selected file. The application will not attempt to look for similar files that can make up the complete volume.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="CenteredCheckBox">
      <property name="text">
       <string>Centered</string>
+     </property>
+     <property name="toolTip">
+      <string>Ignore image position information that is specified in the image header.</string>
      </property>
     </widget>
    </item>
@@ -39,19 +62,21 @@
      <property name="text">
       <string>Ignore Orientation</string>
      </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="LabelMapCheckBox">
-     <property name="text">
-      <string>LabelMap</string>
+     <property name="toolTip">
+      <string>Ignore axis orientation information that is specified in the image header.</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="SingleFileCheckBox">
+    <widget class="QCheckBox" name="ShowCheckBox">
      <property name="text">
-      <string>Single File</string>
+      <string>Show</string>
+     </property>
+     <property name="toolTip">
+      <string>Show volume in slice viewers after loading is completed.</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/Modules/Loadable/Volumes/qSlicerVolumesIOOptionsWidget.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesIOOptionsWidget.cxx
@@ -88,6 +88,8 @@ qSlicerVolumesIOOptionsWidget::qSlicerVolumesIOOptionsWidget(QWidget* parentWidg
           this, SLOT(updateProperties()));
   connect(d->OrientationCheckBox, SIGNAL(toggled(bool)),
           this, SLOT(updateProperties()));
+  connect(d->ShowCheckBox, SIGNAL(toggled(bool)),
+          this, SLOT(updateProperties()));
   connect(d->ColorTableComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
           this, SLOT(updateProperties()));
 
@@ -125,6 +127,7 @@ void qSlicerVolumesIOOptionsWidget::updateProperties()
   d->Properties["center"] = d->CenteredCheckBox->isChecked();
   d->Properties["singleFile"] = d->SingleFileCheckBox->isChecked();
   d->Properties["discardOrientation"] = d->OrientationCheckBox->isChecked();
+  d->Properties["show"] = d->ShowCheckBox->isChecked();
   d->Properties["colorNodeID"] = d->ColorTableComboBox->currentNodeID();
 }
 

--- a/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
@@ -145,6 +145,11 @@ bool qSlicerVolumesReader::load(const IOProperties& properties)
     {
     options |= properties["discardOrientation"].toBool() ? 0x10 : 0x0;
     }
+  bool propagateVolumeSelection = true;
+  if (properties.contains("show"))
+    {
+    propagateVolumeSelection = properties["show"].toBool();
+    }
   vtkSmartPointer<vtkStringArray> fileList;
   if (properties.contains("fileNames"))
     {
@@ -170,23 +175,26 @@ bool qSlicerVolumesReader::load(const IOProperties& properties)
         node->GetDisplayNode()->SetAndObserveColorNodeID(colorNodeID.toLatin1());
         }
       }
-    vtkSlicerApplicationLogic* appLogic =
-      d->Logic->GetApplicationLogic();
-    vtkMRMLSelectionNode* selectionNode =
-      appLogic ? appLogic->GetSelectionNode() : 0;
-    if (selectionNode)
+    if (propagateVolumeSelection)
       {
-      if (vtkMRMLLabelMapVolumeNode::SafeDownCast(node))
+      vtkSlicerApplicationLogic* appLogic =
+        d->Logic->GetApplicationLogic();
+      vtkMRMLSelectionNode* selectionNode =
+        appLogic ? appLogic->GetSelectionNode() : 0;
+      if (selectionNode)
         {
-        selectionNode->SetReferenceActiveLabelVolumeID(node->GetID());
-        }
-      else
-        {
-        selectionNode->SetReferenceActiveVolumeID(node->GetID());
-        }
-      if (appLogic)
-        {
-        appLogic->PropagateVolumeSelection(); // includes FitSliceToAll by default
+        if (vtkMRMLLabelMapVolumeNode::SafeDownCast(node))
+          {
+          selectionNode->SetReferenceActiveLabelVolumeID(node->GetID());
+          }
+        else
+          {
+          selectionNode->SetReferenceActiveVolumeID(node->GetID());
+          }
+        if (appLogic)
+          {
+          appLogic->PropagateVolumeSelection(); // includes FitSliceToAll by default
+          }
         }
       }
     this->setLoadedNodes(QStringList(QString(node->GetID())));


### PR DESCRIPTION
'Show' is enabled by default and so volume that is loaded is displayed.
However, user can disable 'Show' option and then current view settings will be preserved.

Also removed switching to batch processing mode during volume loading, as this is a very expensive operation
(takes time, screen flickers, etc) and it is not necessary anymore.

The option is also accessible from Python:

    slicer.util.loadVolume('fixed.nrrd',{'show':False})