### PR TITLE
COMP: Update LibArchive to fix build error on macOS < 10.13

### DIFF
--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -48,7 +48,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "e8a11f40901212f5d25e2f03938c5410aa9f6a3c" # v3.3.2 + patch disabling LHA (See #4407)
+    "43a14d4a097607d44c8741b24795d9ddc70b9be8" # master (v3.3.3) + patch disabling LHA (See #4407)
     QUIET
     )
 


### PR DESCRIPTION
See https://issues.slicer.org/view.php?id=4438

Suggested-by: Isaiah Norton <inorton@bwh.harvard.edu>
Thanks: Brad King <brad.king@kitware.com>
Reported-by: Steve Pieper <pieper@bwh.harvard.edu>

List of changes:

$ git shortlog e8a11f4..43a14d4 --no-merges
Brad King (1):
      Do not use nanosecond file time APIs on macOS < 10.13

Colin Percival (1):
      Avoid overflow when reading corrupt cpio archive

Ed Maste (1):
      ensure ar strtab is null terminated

Graham Percival (1):
      Spelling fixes

Jean-Christophe Fillion-Robin (1):
      slicer: Disable LHA support

Joerg Sonnenberger (9):
      Don't call wmemmove if size is zero.
      Revert addition of assert.
      Do something sensible for empty strings to make fuzzers happy.
      Match full strings, not just prefixes.
      Don't allow sparse mapping entry to pass beyond 63bit.
      Place a limit on the mtree line length to make fuzzers happy.
      Ensure that the AES extension header is large enough.
      Avoid a read off-by-one error for UTF16 names in RAR archives.
      Fix case in comment.

Martin Matuska (1):
      archive_write_ar_data(): replace strncpy() with memcpy()

Sean Purcell (14):
      Add Zstandard read support
      Add Zstandard write support
      Small zstd fixes
      Add zstd test suite
      Whitespace fixes
      Fix zstd reader and change variable scopes
      Fix compile errors with cmake and when zstd isn't present
      Skip zstd write tests when library not present
      Don't try to use libzstd versions without streaming API
      Build with zstd on TravisCI on OS X
      zstd: Address comments by @terrelln
      zstd: Don't bid on skippable frames
      Fix alphabetical order, other small fixes
      Fix zstd memory allocation and null checks

Tim Kientzle (3):
      Libarchive 3.3.3dev
      Issue #924: fix capitalization of bcrypt.h header
      Issue #947: Reference archive_write_set_options in archive_write.3

Tony Theodore (1):
      libarchive.pc.in: add Cflags.private for static linking

jrmarino (1):
      Recognize ".tzst" extension as ".tar.zst"