### PR TITLE
COMP: fix qt warnings and c++11 errors Plot GUI

### DIFF
--- a/Libs/MRML/Widgets/qMRMLPlotView.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotView.cxx
@@ -194,7 +194,6 @@ void qMRMLPlotViewPrivate::init()
 //---------------------------------------------------------------------------
 void qMRMLPlotViewPrivate::setMRMLScene(vtkMRMLScene* newScene)
 {
-  Q_Q(qMRMLPlotView);
   if (newScene == this->MRMLScene)
     {
     return;
@@ -233,7 +232,6 @@ vtkMRMLScene* qMRMLPlotViewPrivate::mrmlScene()
 // --------------------------------------------------------------------------
 void qMRMLPlotViewPrivate::onPlotChartNodeChanged()
 {
-  Q_Q(qMRMLPlotView);
   vtkMRMLPlotChartNode *newPlotChartNode = NULL;
 
   if (this->MRMLPlotViewNode && this->MRMLPlotViewNode->GetPlotChartNodeID())

--- a/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
@@ -241,8 +241,6 @@ void qMRMLPlotViewControllerWidgetPrivate::onSelectionNodeModified()
 // --------------------------------------------------------------------------
 void qMRMLPlotViewControllerWidgetPrivate::onPlotDataNodesSelected()
 {
-  Q_Q(qMRMLPlotViewControllerWidget);
-
   if (!this->PlotViewNode || !this->PlotChartNode)
     {
     return;
@@ -291,7 +289,7 @@ void qMRMLPlotViewControllerWidgetPrivate::onPlotDataNodeAdded(vtkMRMLNode *node
 {
   Q_Q(qMRMLPlotViewControllerWidget);
 
-  if (!this->PlotChartNode)
+  if (!this->PlotChartNode || !q->mrmlScene())
     {
     return;
     }
@@ -345,8 +343,7 @@ void qMRMLPlotViewControllerWidgetPrivate::onPlotDataNodeEdited(vtkMRMLNode *nod
 // --------------------------------------------------------------------------
 void qMRMLPlotViewControllerWidgetPrivate::onPlotTypeChanged(const QString &Type)
 {
-  Q_Q(qMRMLPlotViewControllerWidget);
-  if (!this->PlotChartNode || !q->mrmlScene())
+  if (!this->PlotChartNode)
     {
     return;
     }
@@ -369,8 +366,6 @@ void qMRMLPlotViewControllerWidgetPrivate::onXAxisChanged(const QString &Column)
 // --------------------------------------------------------------------------
 void qMRMLPlotViewControllerWidgetPrivate::onMarkersChanged(const QString &str)
 {
-  Q_Q(qMRMLPlotViewControllerWidget);
-
   if(!this->PlotChartNode)
     {
     return;
@@ -825,7 +820,7 @@ void qMRMLPlotViewControllerWidget::updateWidgetFromMRML()
       {
       continue;
       }
-    auto plotDataNodesIndex = std::distance(plotDataNodesIDs.begin(), it);
+    int plotDataNodesIndex = std::distance(plotDataNodesIDs.begin(), it);
     plotDataNodesWasModifying[plotDataNodesIndex] = plotDataNode->StartModify();
     }
 
@@ -939,7 +934,7 @@ void qMRMLPlotViewControllerWidget::updateWidgetFromMRML()
       {
       continue;
       }
-    auto plotDataNodesIndex = std::distance(plotDataNodesIDs.begin(), it);
+    int plotDataNodesIndex = std::distance(plotDataNodesIDs.begin(), it);
     plotDataNode->EndModify(plotDataNodesWasModifying[plotDataNodesIndex]);
     }
 

--- a/Libs/MRML/Widgets/qMRMLPlotViewInformationWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotViewInformationWidget.cxx
@@ -39,6 +39,29 @@
 #include <vtkPlot.h>
 #include <vtkPlotLine.h>
 
+// stream includes
+#include <sstream>
+
+namespace
+{
+//----------------------------------------------------------------------------
+template <typename T> std::string NumberToString(T V)
+{
+  std::string stringValue;
+  std::stringstream strstream;
+  strstream << V;
+  strstream >> stringValue;
+  return stringValue;
+}
+
+//----------------------------------------------------------------------------
+std::string DoubleToString(double Value)
+{
+  return NumberToString<double>(Value);
+}
+
+}// end namespace
+
 //--------------------------------------------------------------------------
 // qMRMLPlotViewViewPrivate methods
 
@@ -257,7 +280,7 @@ void qMRMLPlotViewInformationWidgetPrivate::onTitleFontSizeChanged(double size)
     return;
     }
 
-  mrmlPlotChartNode->SetAttribute("TitleFontSize", (std::to_string(size).c_str()));
+  mrmlPlotChartNode->SetAttribute("TitleFontSize", (DoubleToString(size).c_str()));
 }
 
 // --------------------------------------------------------------------------
@@ -269,7 +292,7 @@ void qMRMLPlotViewInformationWidgetPrivate::onAxisTitleFontSizeChanged(double si
     return;
     }
 
-  mrmlPlotChartNode->SetAttribute("AxisTitleFontSize", (std::to_string(size).c_str()));
+  mrmlPlotChartNode->SetAttribute("AxisTitleFontSize", (DoubleToString(size).c_str()));
 }
 
 // --------------------------------------------------------------------------
@@ -281,7 +304,7 @@ void qMRMLPlotViewInformationWidgetPrivate::onAxisLabelFontSizeChanged(double si
     return;
     }
 
-  mrmlPlotChartNode->SetAttribute("AxisLabelFontSize", (std::to_string(size).c_str()));
+  mrmlPlotChartNode->SetAttribute("AxisLabelFontSize", (DoubleToString(size).c_str()));
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
fix as reported by @lassoan  https://github.com/Slicer/Slicer/pull/797#issuecomment-333815222
tested on ubuntu 17.10 gcc6.4 qt5/VTK8 qt4/VTK8 (so this fix is not really tested. it needs to be tested on the build with VTK7).

if the fix can wait I'll try to test qt4/VTK7 version on mac El capitan 