### PR TITLE
ENH: Update SimpleITK

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -41,7 +41,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "534787d1254baa0758676aba10774f4d3b6d35dc"
+    "699ed4bb8934b83ee3bb4a6633b547291f0347ce"
     QUIET
     )
 


### PR DESCRIPTION
List of changes:

```
$ git shortlog  534787d..f6e6bdb --no-merges
Andras Lasso (1):
      Do not create /.git folder when the project is configured

Bradley Lowekamp (212):
      COMP: After rebasing onto master fixed compilation error
      COMP: adding missing files to be compiled
      ENH: moved files into standard src and include directories
      ENH: updated CMake for moved files
      ENH: adding cmake message when code is scanned for tests
      ENH: replaced manual Resample filter with json expand template
      WIP: Refactoring Transforms and Interpolators
      WIP: Created Transform class with pimpl for different transform types
      ENH: Add GetDimension to Transform class
      ENH: added initial support form multiple transform in the xform pimpl
      ENH: adding copy constructor and assignment operator to TX class
      ENH: enabling ToString method to be dispatch into Pimpl
      ENH: added transform and interpolator paramter to Resample filter
      ENH: added default registration test
      WIP: made changed to broked registration test just to get it to compile
      ENH: The sitkImage exposes direction as 1-D matrix
      ENH: adding Direction parameter to Resample filter
      WIP: made registration tests function but incorrect
      ENH: enum for transforms should be prefixed with sitk
      ENH: removed old files after refactoring
      WIP: adding intial metric with pimple implementation
      BUG: by default the direction matric is identity now
      ENH: tweak text output of registration progress reporter
      HACK: disabled failing registration test compares
      ENH: re-enabled the registration resample test to do something useful
      COMP: fix assert which didn't compile in debug mode
      COMP: missing memory header for auto_ptr
      ENH: Ripped out dependencies on ITK headers in header files
      ENH: Move BasicFilters CMakeList to src subdirectory
      ENH: use most general exception
      WIP: hack to get test to pass untill exceptions are reimplemented
      ENH: marking generated code as generated with source file properties
      ENH: removing top level use itk
      only using ITK where explicitly needed
      BUG: added missing include to BasicFilters
      ENH: the generated code now is placed in 2 lists, header and source
      ENH: the itk superbuild is not longer installed
      WIP: added primative attempt to install SimpleITK for C++ development
      ENH: restoring sitkException functionality
      ENH: restoring test
      Revert topic 'SIMPLEITK-121_NoITKInclude'
      ENH: adding intial wrapping of COnvolution and FFTConvolution filters
      ENH: removed additional include from header file to cxx file
      ENH: added numer of inputs as template parameter to ImageFilter, depricating DualImageFilter
      WIP WIP WIP
      Revert "WIP WIP WIP"
      Removed extra dependencies of Java jar onto other libraries
      Broke BasicFilters library into a set of libraries
      Adding all linker, C, and CXX flags to be pushed to external project
      Correcting expected has for series reader of vector images.
      Revert "Correcting expected has for series reader of vector images."
      Reverting SIMPLEITK-251_BreakupBasicFilters topic
      Adding Compose to join a set of Images to a VectorImage
      Revert "Correct R_values in json file."
      Updating ImageBase class to new templated version
      Revert "COMP: Clang requires explicit Disambiguation"
      Removing manually write compose and join series image filters
      breaking up template component ExecuteInternalSetITKFilterInputs
      Adding template for filters which take multiple input images
      Adding Compose filter as multi-input filter
      Adding NaryAdd and Nary Maximum and multi-input Image filters
      WIP WIP WIP
      Revert "Merge topic 'SIMPLEITK-279_AddComposeImageFilter' into next"
      Revert "WIP WIP WIP"
      Revert "Adding NaryAdd and Nary Maximum and multi-input Image filters"
      Revert "Adding Compose filter as multi-input filter"
      Revert "Adding template for filters which take multiple input images"
      Revert "breaking up template component ExecuteInternalSetITKFilterInputs"
      Revert "Removing manually write compose and join series image filters"
      Revert "Updating ImageBase class to new templated version"
      Revert "Adding Compose to join a set of Images to a VectorImage"
      Revert "Revert "Merge topic 'SIMPLEITK-279_AddComposeImageFilter' into next""
      Split the Test driver into several libraries.
      Revert "Split the Test driver into several libraries."
      Remove old RsitkTypes
      Revert "Remove old RsitkTypes"
      Fix warning about converting false to pointer type.
      Updating superbuild SWIG version to 2.0.10
      Revert "Updating superbuild SWIG version to 2.0.10"
      Fix warning about converting false to pointer type.
      Fix Doxygen warning explicit link request to 'ChannelTyperedChannel'
      Fix another warning of conversion false to pointer type
      remove some extra chars in testing print message
      Adding output operator for enum string
      Adding definition of output operator
      Revert "Adding output operator for enum string"
      fix export macro name in comment
      change linkage of functions to match new library
      Still use filter0 link specification for image filter base class
      Revert "fix export macro name in comment"
      BUG: only call RemoveProcessObject once from the process object
      BUG: test using deleted variable, caused segfault
      Revert "BUG: only call RemoveProcessObject once from the process object"
      BUG: Fix linking BasicFiltersLibrary linking to itself
      Revert "BUG: Fix linking BasicFiltersLibrary linking to itself"
      Add '_' prefix to variable not to be propagated to ITK project
      Revert "Add '_' prefix to variable not to be propagated to ITK project"
      Adding initial test for ProcessObject as super for java
      Adding initial test for ProcessObject as super for java
      Revert "Adding initial test for ProcessObject as super for java"
      Revert "Adding initial test for ProcessObject as super for java"
      Revert "Merge branch 'master' into next"
      Add LabelShapeStatisticsImageFilter
      Revert "Add LabelShapeStatisticsImageFilter"
      Adding LabelGeometryImageFilter as a dual image filter
      Add GetNumberOfLabels and HasLabels as custom methods
      Change Volume measurement to return size
      Adding testing of measurements for LabelGeometryImageFilter
      Reduce LabelGeometry instantiation by restricting intensity to real
      STYLE: Ran json through python format script
      Convert test input to instantiated image type
      COMP: Fix CSharp casting in test
      Reduce tolerance for LabelGeometry OBB size from dashboard results
      Increase tolerance of OrientedBoundingBoxVolume for test
      WIP adding stuff
      Renaming CenterTransfromInitializer with filter suffix
      Modifying the generated code for the CenterTransformInitializer
      Adding generated CenteredTransformInitialization filter
      Adding test for centered transform initializer
      Fixing name of Moments and removing leading white space
      copy input to CenteredTransformInitializer
      Revert "WIP adding stuff"
      Don't take address of zero sized std::vector
      Don't take address of zero sized std::vector
      Revert "Don't take address of zero sized std::vector"
      Updating JSON doc string from ITK 4.6 with spacing corrections.
      Revert "Updating JSON doc string from ITK 4.6 with spacing corrections."
      BUG: Propagate Superbuild BUILD_EXAMPLES to SITK and Examples projects
      BUG: Disable SimpleITKExamples Superbuild project with flag
      Revert "BUG: Disable SimpleITKExamples Superbuild project with flag"
      Revert "BUG: Propagate Superbuild BUILD_EXAMPLES to SITK and Examples projects"
      Revert "Increase tolerance of OrientedBoundingBoxVolume for test"
      Revert "Reduce tolerance for LabelGeometry OBB size from dashboard results"
      Revert "COMP: Fix CSharp casting in test"
      Revert "Convert test input to instantiated image type"
      Revert "STYLE: Ran json through python format script"
      Revert "Reduce LabelGeometry instantiation by restricting intensity to real"
      Revert "Adding testing of measurements for LabelGeometryImageFilter"
      Revert "Change Volume measurement to return size"
      Revert "Add GetNumberOfLabels and HasLabels as custom methods"
      Revert "Adding LabelGeometryImageFilter as a dual image filter"
      Ignore SITKDLL since the explicit library is allows static
      Fix shared explicit library
      Reordering explicit headers to reduce gcc attribute warnings
      Revert "Fix shared explicit library"
      Revert "Ignore SITKDLL since the explicit library is allows static"
      Extend Typelist to 30 elements at max.
      Adding Transform constructor which does try casts to determine type
      Refactor ReadTransform method to utilize casting Transform constructor
      Revert "Initial checkin of DicomMetaDataTest"
      Updating superbuild version of Swig to 3.0.6
      Revert "Updating superbuild version of Swig to 3.0.6"
      COMP: Disable attribute warning in Explicit library
      Fix typeo on cmake variable name
      Updating virtualenv version to 14.0.6
      Prefer the use of distutils over setuptools
      Revert "Prefer the use of distutils over setuptools"
      Revert "Updating virtualenv version to 14.0.6"
      Revert "Fix typeo on cmake variable name"
      Enable JSONValidate to work with older pythongs
      Revert "Enable JSONValidate to work with older pythongs"
      Fix GTest Superbuild to consistently use archive path output variable
      Revert "Fix GTest Superbuild to consistently use archive path output variable"
      Revert "Fixed the timeout value for Show on Windows"
      Revert "Suppress a python warning on Windows"
      Update the SimpleITK version searched for in the SimpleITK Examples
      Adding circle.yml for initial testing
      Correct path for ITK bare repository
      Adding randomize to ensure all containers are used.
      Revert "Adding circle.yml for initial testing"
      Adding SimpleITK External Module as external super build project
      Remove ITK filters and functors from SimpleITK
      Adding terminal displace to superbuild script
      Updating SimpleITK ITK Module with bug fix
      Update SimpleITK External ITK module for fix gcc 4.1 compilation
      Update external module with VS11 GTest fix
      Use CMake variable to set version specific TERMINAL options
      Revert "A additional interface to wrapped R to extend SimpleITK in R"
      Update SimpleITK filters module to address CMP0063 warnings
      Revert "Use CMake variable to set version specific TERMINAL options"
      Revert "Updating SimpleITK ITK Module with bug fix"
      Revert "Adding SimpleITK External Module as external super build project"
      Work around CMP0054 warning
      Update ITK superbuild version to 4.12.1
      Move Doxygen download URL to https
      Wrapping IterativeInverseDisplacementFieldImageFilter
      Fix typo in Python version warning
      Relax testing tolerance for N4 to accommodate intel x86
      Fix R package data with SimpleITK_FORBID_DOWNLOADS enabled
      Add missing usage of type property for point_vec
      Print AdaptiveHistogramEqualization radius parameter
      Update to CircleCi2.0
      Replace configuration_file_build_time
      Use ccache and CircleCI cache to expedite re-builds
      Add CircleCI cache for the ExternalData
      Use scikit-builds's juint formatter for juint
      Disable Python version warning when WRAP_PYTHON is disabled.
      Add HelloWorld to the example index
      Update ITK superbuild version to 4.12.2
      Fix typeo for BigIntegerFix class name
      Support ITK's rename README.md file
      Add GetRegion to LabelStatisticsImageFilter
      Fix issue with multiple BigIntegerFix classes causing tests to fail
      Address sign to unsigned comparison warning
      Use named inputs for ConvolutionImageFilter
      Update FAQ url to read the docs
      Fix detection of "std" flag in CMAKE_CXX_FLAGS
      Pass CMake cxx standard variable to try compiles
      Doc try to set "-std" flag when CMake cxx standard flags are present
      Improve error message when configuration fails.
      Fix sign/unsigned comparison warning.
      Add missing parameter and measurements to RelabelComponentImageFilter

Daniel Blezek (4):
      ADD: Added body for RegularStepGradientDescentOptimizer and Resample
      ENH: Modified classes to support registration
      ENH: Small refactor of registration, fixed Optimizer namespace bug
      BUG: Handling case of parameters not being set

Dave Chen (3):
      Initial checkin of DicomMetaDataTest
      Update Documentation.rst
      Initial checkin of smiley face example

David T. Chen (5):
      Fixed the timeout value for Show on Windows
      Suppress a python warning on Windows
      Initial checkin of HelloWorld example
      Changed cmake var to SimpleITK_TESTING_NOSHOW
      Initial check of Documentation.rst for HelloWorld

Hans Johnson (1):
      COMP: Clang requires explicit Disambiguation

Richard Beare (1):
      Correct R_values in json file.

Stefan Schlager (1):
      A additional interface to wrapped R to extend SimpleITK in R
```