### PR TITLE
ENH: macOS: Update Slicer.app to include version information

### DIFF
--- a/Base/Logic/Testing/vtkSlicerApplicationLogicTest1.cxx
+++ b/Base/Logic/Testing/vtkSlicerApplicationLogicTest1.cxx
@@ -165,6 +165,22 @@ int vtkSlicerApplicationLogicTest1(int , char * [])
     }
     {
       TestRowType row;
+      row.push_back("/home/jchris/Projects/Something.app/Contents/lib/Slicer-4.1/qt-loadable-modules/libqSlicerAnnotationsModule.dylib");
+      row.push_back("/home/jchris/Projects/Something.app/Contents");
+      row.push_back("4810");
+      row.push_back("1");
+      data.push_back(row);
+    }
+    {
+      TestRowType row;
+      row.push_back("/home/jchris/Projects/" Slicer_BUNDLE_LOCATION "/lib/Slicer-4.1/qt-loadable-modules/libqSlicerAnnotationsModule.dylib");
+      row.push_back("/home/jchris/Projects/" Slicer_BUNDLE_LOCATION);
+      row.push_back("4810");
+      row.push_back("1");
+      data.push_back(row);
+    }
+    {
+      TestRowType row;
       row.push_back("/home/jchris/Projects/Slicer4-Superbuild-Debug/Slicer-build/bin/Slicer.app/Contents/Extensions-4810/Reporting/lib/Slicer-4.1/qt-loadable-modules/Python/vtkSlicerReportingModuleLogic.py");
       row.push_back("/home/jchris/Projects/Slicer4-Superbuild-Debug/Slicer-build");
       row.push_back("4810");

--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -324,5 +324,5 @@ function(fixup_bundle_with_plugins app)
     )
 endfunction()
 
-fixup_bundle_with_plugins("@Slicer_MAIN_PROJECT_APPLICATION_NAME@.app")
-#verify_app("/Users/partyd/Kitware/Slicer4-trunk/build/Slicer-build/_CPack_Packages/Darwin/DragNDrop/Slicer-4.0.gamma-2011-05-10-Darwin/@Slicer_MAIN_PROJECT_APPLICATION_NAME@.app")
+set(app_name "@Slicer_MAIN_PROJECT_APPLICATION_NAME@-@Slicer_VERSION_FULL@.app")
+fixup_bundle_with_plugins(${app_name})

--- a/CMake/SlicerCPackBundleVerify.cmake
+++ b/CMake/SlicerCPackBundleVerify.cmake
@@ -2,11 +2,16 @@
 include(BundleUtilities)
 
 # Sanity checks
-set(expected_existing_vars Slicer_INSTALL_DIR Slicer_MAIN_PROJECT_APPLICATION_NAME)
+set(expected_existing_vars
+  Slicer_INSTALL_DIR
+  Slicer_MAIN_PROJECT_APPLICATION_NAME
+  Slicer_VERSION_FULL
+  )
 foreach(var ${expected_existing_vars})
   if(NOT EXISTS "${MY_${var}}")
     message(FATAL_ERROR "Variable ${var} is set to an inexistent directory or file ! [${${var}}]")
   endif()
 endforeach()
 
-verify_app("${Slicer_INSTALL_DIR}/${Slicer_MAIN_PROJECT_APPLICATION_NAME}.app")
+set(app_name "${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer_VERSION_FULL}.app")
+verify_app("${Slicer_INSTALL_DIR}/${app_name")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,7 +524,7 @@ endif()
 # Slicer install directories
 #-----------------------------------------------------------------------------
 set(Slicer_INSTALL_ROOT "./")
-set(Slicer_BUNDLE_LOCATION "${Slicer_MAIN_PROJECT_APPLICATION_NAME}.app/Contents")
+set(Slicer_BUNDLE_LOCATION "${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer_VERSION_FULL}.app/Contents")
 # NOTE: Make sure to update vtkSlicerApplicationLogic::IsEmbeddedModule if
 #       the following variables are changed.
 set(Slicer_EXTENSIONS_DIRBASENAME "Extensions")


### PR DESCRIPTION
This commit updates the build system so that the macOS packages
is named like "Slicer-X.Y.Z.app" for a stable build and like
"Slicer-X.Y.Z-YYYY-MM-DD.app" for a nightly or experimental build.

Suggested-by: Andriy Fedorov <fedorov@bwh.harvard.edu>
Suggested-by: Steve Pieper <pieper@bwh.harvard.edu>