### PR TITLE
BUG: fix crush linux/Qt5 when activating segmentation editor effect

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -1450,7 +1450,10 @@ void qMRMLSegmentEditorWidget::updateEffectsSectionFromMRML()
 
     // Perform updates to prevent layout collapse
     d->EffectHelpBrowser->setMinimumHeight(d->EffectHelpBrowser->sizeHint().height());
-    d->EffectHelpBrowser->layout()->update();
+    if (d->EffectHelpBrowser->layout())
+      {
+      d->EffectHelpBrowser->layout()->update();
+      }
     activeEffect->optionsFrame()->setMinimumHeight(activeEffect->optionsFrame()->sizeHint().height());
     activeEffect->optionsLayout()->activate();
     this->setMinimumHeight(this->sizeHint().height());


### PR DESCRIPTION
Fix for Mantis issue: 0004447: Crash Segmentation Editor QT5/VTK8 @cpinter 