### PR TITLE
ENH: model DICOM acquisition geometry (addresses #4409)

### DIFF
--- a/Libs/vtkAddon/vtkOrientedGridTransform.cxx
+++ b/Libs/vtkAddon/vtkOrientedGridTransform.cxx
@@ -24,6 +24,8 @@ vtkOrientedGridTransform::vtkOrientedGridTransform()
   this->GridDirectionMatrix = NULL;
   this->GridIndexToOutputTransformMatrixCached = vtkMatrix4x4::New();
   this->OutputToGridIndexTransformMatrixCached = vtkMatrix4x4::New();
+
+  this->LastWarningMTime = 0;
 }
 
 //----------------------------------------------------------------------------
@@ -322,10 +324,16 @@ void vtkOrientedGridTransform::InverseTransformDerivative(const double inPoint[3
     inverse[1] = lastInverse[1];
     inverse[2] = lastInverse[2];
 
-    vtkWarningMacro("InverseTransformPoint: no convergence (" <<
-                    inPoint[0] << ", " << inPoint[1] << ", " << inPoint[2] <<
-                    ") error = " << sqrt(errorSquared) << " after " <<
-                    i << " iterations.");
+    if (this->MTime > this->LastWarningMTime)
+      {
+      vtkWarningMacro("InverseTransformPoint: no convergence (" <<
+                      inPoint[0] << ", " << inPoint[1] << ", " << inPoint[2] <<
+                      ") error = " << sqrt(errorSquared) << " after " <<
+                      i << " iterations."
+                      "  Further convergence warnings suppressed until transform is modified.");
+      this->LastWarningMTime = this->MTime;
+      }
+    this->InvokeEvent(vtkOrientedGridTransform::ConvergenceFailureEvent);
     }
 
   // convert point

--- a/Libs/vtkAddon/vtkOrientedGridTransform.h
+++ b/Libs/vtkAddon/vtkOrientedGridTransform.h
@@ -18,6 +18,7 @@
 
 #include "vtkAddon.h"
 
+#include "vtkCommand.h"
 #include "vtkGridTransform.h"
 
 class VTK_ADDON_EXPORT vtkOrientedGridTransform : public vtkGridTransform
@@ -38,6 +39,14 @@ public:
   // Description:
   // Make another transform of the same type.
   vtkAbstractTransform *MakeTransform() VTK_OVERRIDE;
+
+  /// List of custom events fired by the class.
+  // ConvergenceFailureEvent is invoked when the gradient cannot be
+  // inverted, probably due to a singular transform or numeric instability.
+  enum Events
+    {
+    ConvergenceFailureEvent = vtkCommand::UserEvent + 1
+    };
 
 protected:
   vtkOrientedGridTransform();
@@ -77,6 +86,11 @@ protected:
   // grid index (IJK) coordinate system.
   vtkMatrix4x4* GridIndexToOutputTransformMatrixCached;
   vtkMatrix4x4* OutputToGridIndexTransformMatrixCached;
+
+  // Description:
+  // Avoid generating hundreds of warning messages for convergence problems
+  // by keeping track of the MTime when the last warning was issued.
+  vtkMTimeType LastWarningMTime;
 
 private:
   vtkOrientedGridTransform(const vtkOrientedGridTransform&);  // Not implemented.


### PR DESCRIPTION
Add a step to the DICOMScalarVolumePlugin to check that the loaded
volume node's slice geometry matches what is expected from
the position and orientation information of the individual
slices in the DICOM headers.

If needed, a grid transform is created to reposition each slice
to the appropriate position in patient space.

The DICOMReaders self test has been extended to test this in the
case where slices are missing from the middle of the volume.  The
grid transform results in an interpolated band of pixels using
information from adjacent slices to 'fill in' for the missing
data.  The test confirms that the last slice of the reconstructed
volume is in the expected location in patient space.  This correction
means that calculations like ruler or segment statistics can be
robust even with missing slices.

Currently the only available testing data is for the case of missing
slices.  However this code should allow proper loading and display of
several not-uncommon imaging scenarios:

1) Missing slices due to network failure or accidental file deletion.

2) Gantry tilted image acquisitons (see #4409) which is
used, for example, to minimize radiation exposure to the retinas
especially in pediatric imaging.

3) Variable table speed during CT acquisition, which is sometimes
used in abdominal or musculoskeletal imaging to provide high resolution
in selected body parts and lower resolution between (e.g. high res
at the ankle, knee and hip, but low res in the shin and thigh).

Consderations:

By creating a transform we preserve the original data and leave it
to the user to resample if desired.  The option of resampling
during load was rejected since it is unclear what sampling grid
would be best in all cases.

Although the transform should correct the geometry, a warning dialog is
still generated during loading since the issue could be correctable
(such as missing slices) or may be triggered by other data issues
not forseen by this code.