### PR TITLE
Improve subject hierarchy combobox

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.h
@@ -88,6 +88,16 @@ public:
   /// \param rootItemID Ancestor item of branch in which the accepted items are counted
   Q_INVOKABLE int acceptedItemCount(vtkIdType rootItemID)const;
 
+  /// Returns true if the item in the row indicated by the given sourceRow and
+  /// sourceParent should be included in the model; otherwise returns false.
+  /// This method test each item via \a filterAcceptsItem
+  virtual bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent)const;
+
+  /// Filters items to decide which to display in the view
+  virtual bool filterAcceptsItem(vtkIdType itemID, bool canAcceptIfAnyChildIsAccepted=true)const;
+
+  virtual Qt::ItemFlags flags(const QModelIndex & index)const;
+
 public slots:
   void setNameFilter(QString filter);
   void setAttributeNameFilter(QString filter);
@@ -95,13 +105,6 @@ public slots:
   void setLevelFilter(QString filter);
 
 protected:
-  /// Returns true if the item in the row indicated by the given sourceRow and
-  /// sourceParent should be included in the model; otherwise returns false.
-  /// This method test each item via \a filterAcceptsItem
-  virtual bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent)const;
-
-  /// Filters items to decide which to display in the view
-  virtual bool filterAcceptsItem(vtkIdType itemID)const;
 
   QStandardItem* sourceItem(const QModelIndex& index)const;
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -96,8 +96,12 @@ void qMRMLSubjectHierarchyComboBoxPrivate::init()
   // Make connections
   QObject::connect(this->TreeView, SIGNAL(currentItemChanged(vtkIdType)),
                    q, SLOT(updateComboBoxTitleAndIcon(vtkIdType)));
+  QObject::connect(this->TreeView, SIGNAL(currentItemModified(vtkIdType)),
+                   q, SLOT(updateComboBoxTitleAndIcon(vtkIdType)));
   QObject::connect(this->TreeView, SIGNAL(currentItemChanged(vtkIdType)),
                    q, SIGNAL(currentItemChanged(vtkIdType)));
+  QObject::connect(this->TreeView, SIGNAL(currentItemModified(vtkIdType)),
+                   q, SIGNAL(currentItemModified(vtkIdType)));
 }
 
 // --------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -155,6 +155,13 @@ void qMRMLSubjectHierarchyComboBox::setMRMLScene(vtkMRMLScene* scene)
 }
 
 //------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::clearSelection()
+{
+  Q_D(const qMRMLSubjectHierarchyComboBox);
+  d->TreeView->clearSelection();
+}
+
+//------------------------------------------------------------------------------
 vtkIdType qMRMLSubjectHierarchyComboBox::currentItem()const
 {
   Q_D(const qMRMLSubjectHierarchyComboBox);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -56,6 +56,7 @@ public:
 
 public:
   int MaximumNumberOfShownItems;
+  bool AlignPopupVertically;
 
   qMRMLSubjectHierarchyTreeView* TreeView;
 };
@@ -64,6 +65,7 @@ public:
 qMRMLSubjectHierarchyComboBoxPrivate::qMRMLSubjectHierarchyComboBoxPrivate(qMRMLSubjectHierarchyComboBox& object)
   : q_ptr(&object)
   , MaximumNumberOfShownItems(20)
+  , AlignPopupVertically(true)
   , TreeView(NULL)
 {
 }
@@ -259,6 +261,20 @@ void qMRMLSubjectHierarchyComboBox::setMaximumNumberOfShownItems(int maxNumberOf
   d->MaximumNumberOfShownItems = maxNumberOfShownItems;
 }
 
+//--------------------------------------------------------------------------
+bool qMRMLSubjectHierarchyComboBox::alignPopupVertically()const
+{
+  Q_D(const qMRMLSubjectHierarchyComboBox);
+  return d->AlignPopupVertically;
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::setAlignPopupVertically(bool align)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  d->AlignPopupVertically = align;
+}
+
 //-----------------------------------------------------------------------------
 void qMRMLSubjectHierarchyComboBox::showPopup()
 {
@@ -289,28 +305,36 @@ void qMRMLSubjectHierarchyComboBox::showPopup()
   listRect.setWidth( listRect.width() + container->frameWidth());
   listRect.setHeight( listRect.height() + marginTop + marginBottom + tvMarginTop + tvMarginBottom);
 
-  // Position horizontally
-  listRect.moveLeft(above.x());
+  if(d->AlignPopupVertically)
+    {
+    // Position horizontally
+    listRect.moveLeft(above.x());
 
-  // Position vertically so the currently selected item lines up with the combo box
-  const QRect currentItemRect = d->TreeView->visualRect(d->TreeView->currentIndex());
-  const int offset = listRect.top() - currentItemRect.top();
-  listRect.moveTop(above.y() + offset - listRect.top());
+    // Position vertically so the currently selected item lines up with the combo box
+    const QRect currentItemRect = d->TreeView->visualRect(d->TreeView->currentIndex());
+    const int offset = listRect.top() - currentItemRect.top();
+    listRect.moveTop(above.y() + offset - listRect.top());
 
-  if (listRect.width() > screen.width() )
-    {
-    listRect.setWidth(screen.width());
+    if (listRect.width() > screen.width() )
+      {
+      listRect.setWidth(screen.width());
+      }
+    if (mapToGlobal(listRect.bottomRight()).x() > screen.right())
+      {
+      below.setX(screen.x() + screen.width() - listRect.width());
+      above.setX(screen.x() + screen.width() - listRect.width());
+      }
+    if (mapToGlobal(listRect.topLeft()).x() < screen.x() )
+      {
+      below.setX(screen.x());
+      above.setX(screen.x());
+      }
     }
-  if (mapToGlobal(listRect.bottomRight()).x() > screen.right())
+  else
     {
-    below.setX(screen.x() + screen.width() - listRect.width());
-    above.setX(screen.x() + screen.width() - listRect.width());
+    listRect.moveTo(below);
     }
-  if (mapToGlobal(listRect.topLeft()).x() < screen.x() )
-    {
-    below.setX(screen.x());
-    above.setX(screen.x());
-    }
+
   container->setGeometry(listRect);
   container->raise();
   container->show();

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -98,8 +98,6 @@ void qMRMLSubjectHierarchyComboBoxPrivate::init()
                    q, SLOT(updateComboBoxTitleAndIcon(vtkIdType)));
   QObject::connect(this->TreeView, SIGNAL(currentItemChanged(vtkIdType)),
                    q, SIGNAL(currentItemChanged(vtkIdType)));
-  QObject::connect(this->TreeView, SIGNAL(currentItemChanged(vtkIdType)),
-                   container, SLOT(hide()));
 }
 
 // --------------------------------------------------------------------------
@@ -378,6 +376,10 @@ void qMRMLSubjectHierarchyComboBox::updateComboBoxTitleAndIcon(vtkIdType selecte
     this->setDefaultIcon(QIcon());
     return;
     }
+
+  // Hide popup
+  QFrame* container = qobject_cast<QFrame*>(this->view()->parentWidget());
+  container->hide();
 
   // Assemble title for selected item
   QString titleText(shNode->GetItemName(selectedShItemID).c_str());

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
@@ -112,6 +112,7 @@ public slots:
 
 signals:
   void currentItemChanged(vtkIdType);
+  void currentItemModified(vtkIdType);
 
 protected slots:
   void updateComboBoxTitleAndIcon(vtkIdType selectedShItemID);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
@@ -52,6 +52,10 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qMRMLSubjectHierarchyCombo
   Q_PROPERTY(bool highlightReferencedItems READ highlightReferencedItems WRITE setHighlightReferencedItems)
   /// Property determining the maximum number of items (rows) shown in the popup tree
   Q_PROPERTY(int maximumNumberOfShownItems READ maximumNumberOfShownItems WRITE setMaximumNumberOfShownItems)
+  /// Property determining the vertical alignement of the popup tree with the combobox.
+  /// If aligned, the popup will shift vertically so that the selected item overlays above the combobox.
+  /// Else, the popup tree appears below the combobox, like for a qMRMLNodeComboBox.
+  Q_PROPERTY(bool alignPopupVertically READ alignPopupVertically WRITE setAlignPopupVertically)
 
 public:
   typedef ctkComboBox Superclass;
@@ -73,6 +77,9 @@ public:
 
   int maximumNumberOfShownItems()const;
   void setMaximumNumberOfShownItems(int maxNumberOfShownItems);
+
+  bool alignPopupVertically()const;
+  void setAlignPopupVertically(bool align);
 
   /// Set attribute filter that allows showing only items that have the specified attribute and their parents.
   /// \param attributeName Name of the attribute by which the items are filtered

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
@@ -66,6 +66,7 @@ public:
   Q_INVOKABLE vtkMRMLScene* mrmlScene()const;
   Q_INVOKABLE vtkMRMLSubjectHierarchyNode* subjectHierarchyNode()const;
 
+  Q_INVOKABLE void clearSelection();
   Q_INVOKABLE vtkIdType currentItem()const;
   Q_INVOKABLE vtkIdType rootItem()const;
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -415,7 +415,7 @@ void qMRMLSubjectHierarchyTreeView::setCurrentItems(QList<vtkIdType> items)
     return;
     }
 
-  this->selectionModel()->clearSelection();
+  this->clearSelection();
 
   foreach (long itemID, items)
     {
@@ -443,7 +443,7 @@ void qMRMLSubjectHierarchyTreeView::setCurrentItems(vtkIdList* items)
     return;
     }
 
-  this->selectionModel()->clearSelection();
+  this->clearSelection();
 
   for (int index=0; index<items->GetNumberOfIds(); ++index)
     {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -160,6 +160,7 @@ public slots:
 
 signals:
   void currentItemChanged(vtkIdType);
+  void currentItemModified(vtkIdType);
 
 protected slots:
   virtual void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
@@ -175,6 +176,10 @@ protected slots:
   /// Update root item to restore view
   /// (e.g. after tree was updated in the model from the subject hierarchy)
   virtual void updateRootItem();
+
+  /// Propagate item modified signal if the item or an item in its branch
+  /// was selected in that treeview
+  virtual void onSubjectHierarchyItemModified(vtkObject *caller, void *callData);
 
   /// Called when scene end is finished. Hierarchy is cleared in that case.
   virtual void onMRMLSceneCloseEnded(vtkObject* sceneObject);
@@ -210,6 +215,10 @@ protected:
   /// Apply highlight for subject hierarchy items referenced by argument items by DICOM
   /// \sa highlightReferencedItems
   void applyReferenceHighlightForItems(QList<vtkIdType> itemIDs);
+
+  /// Return the id of the first subject hierarchy item that is found to be selected
+  /// within the branch that has the input item id as its root
+  vtkIdType firstSelectedSubjectHierarchyItemInBranch(vtkIdType itemID);
 
 protected:
   QScopedPointer<qMRMLSubjectHierarchyTreeViewPrivate> d_ptr;


### PR DESCRIPTION
- [x] Option for new vertical alignment of the popup treeview
- [x] Disable selections of parent items when using attribute filter
- [x] Do not hide popup when no item was selected
- [x] Implement qMRMLSubjectHierarchyComboBox::clearCurrentItem 
- [x] Update combobox label on SubjectHierarchyItemModifiedEvent

In a future pr:
- [ ] Scene item shown when root item != scene and filters returns no item
- [ ] combobox does not stretch in layout like qMRMLNodeComboBox
- [ ] popup wider that combobox due to margins