### PR TITLE
COMP: Support VTK 8.1 updating displayable manager to use vtkObjectFactory

### DIFF
--- a/CMake/SlicerConfigureDisplayableManagerObjectFactory.cmake
+++ b/CMake/SlicerConfigureDisplayableManagerObjectFactory.cmake
@@ -1,0 +1,122 @@
+
+#
+# Configure Slicer displayable manager VTK object factory
+#
+# Given a list of displayable manager source files, this function will
+# generate sources responsible for registering the classes with the
+# vtkObjectFactory.
+#
+# This function set the variable "${TARGET_NAME}_AUTOINIT" to 1 in the parent
+# scope. This tells SlicerMacroBuildModuleLogic to set Slicer_EXPORT_HEADER_CUSTOM_CONTENT
+# and define the associated ${TARGET_NAME}_AUTOINIT compilation flag.
+#
+function(SlicerConfigureDisplayableManagerObjectFactory)
+  set(options
+    NO_EXPORT
+    )
+  set(oneValueArgs
+    TARGET_NAME
+    EXPORT_MACRO
+    EXPORT_HEADER
+    OUTPUT_SRCS_VAR
+    )
+  set(multiValueArgs
+    SRCS
+    )
+  CMAKE_PARSE_ARGUMENTS(DM_OBJECT_FACTORY
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+    )
+
+  # Sanity checks
+  if(DM_OBJECT_FACTORY_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Unknown keywords given to SlicerConfigureDisplayableManagerObjectFactory(): \"${DM_OBJECT_FACTORY_UNPARSED_ARGUMENTS}\"")
+  endif()
+  set(expected_nonempty_vars
+    TARGET_NAME
+    OUTPUT_SRCS_VAR
+    SRCS
+    )
+  if(NOT DM_OBJECT_FACTORY_NO_EXPORT)
+    list(APPEND expected_nonempty_vars
+      EXPORT_MACRO
+      EXPORT_HEADER
+      )
+  endif()
+  foreach(var ${expected_nonempty_vars})
+    if("${DM_OBJECT_FACTORY_${var}}" STREQUAL "")
+      message(FATAL_ERROR "error: ${var} CMake variable is empty !")
+    endif()
+  endforeach()
+
+  # Initialize local variables
+  set(_vtk_override_includes)
+  set(_vtk_override_creates )
+
+  # For each class
+  foreach(FILE ${DM_OBJECT_FACTORY_SRCS})
+
+    # what is the filename without the extension
+    get_filename_component(TMP_FILENAME ${FILE} NAME_WE)
+
+    set(_class ${TMP_FILENAME})
+    set(_override ${_class})
+
+    set(_vtk_override_includes
+      "${_vtk_override_includes}#include \"${_override}.h\"\n")
+
+    set(_vtk_override_creates "${_vtk_override_creates}
+      VTK_CREATE_CREATE_FUNCTION(${_override})")
+
+    set(_vtk_override_do "${_vtk_override_do}
+    this->RegisterOverride(\"${_class}\",
+                           \"${_override}\",
+                           \"Override for ${vtk-module} module\", 1,
+                           vtkObjectFactoryCreate${_override});")
+
+  endforeach()
+
+  set(vtk-module ${DM_OBJECT_FACTORY_TARGET_NAME})
+
+  if(DM_OBJECT_FACTORY_NO_EXPORT)
+    string(TOUPPER ${DM_OBJECT_FACTORY_TARGET_NAME} VTK-MODULE)
+    set(_export_header "#define ${VTK-MODULE}_EXPORT")
+  else()
+    string(REPLACE "_EXPORT" "" VTK-MODULE "${DM_OBJECT_FACTORY_EXPORT_MACRO}")
+    set(_export_header "#include \"${DM_OBJECT_FACTORY_EXPORT_HEADER}\"")
+  endif()
+  set(CMAKE_CONFIGURABLE_FILE_CONTENT "
+#ifndef __${vtk-module}Module_h
+#define __${vtk-module}Module_h
+${_export_header}
+#endif
+")
+  configure_file(
+    ${CMAKE_ROOT}/Modules/CMakeConfigurableFile.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${vtk-module}Module.h
+    )
+  configure_file(
+    ${VTK_CMAKE_DIR}/vtkObjectFactory.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${vtk-module}ObjectFactory.h
+    )
+  configure_file(
+    ${VTK_CMAKE_DIR}/vtkObjectFactory.cxx.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${vtk-module}ObjectFactory.cxx
+    )
+
+  set_source_files_properties(
+    ${CMAKE_CURRENT_BINARY_DIR}/${vtk-module}ObjectFactory.cxx
+    PROPERTIES GENERATED 1 WRAP_EXCLUDE 1 ABSTRACT 0
+    )
+
+  # add the source file to the source list
+  set(${DM_OBJECT_FACTORY_OUTPUT_SRCS_VAR}
+    ${${DM_OBJECT_FACTORY_OUTPUT_SRCS_VAR}}
+    ${CMAKE_CURRENT_BINARY_DIR}/${vtk-module}ObjectFactory.cxx
+    PARENT_SCOPE
+    )
+
+  set(${DM_OBJECT_FACTORY_TARGET_NAME}_AUTOINIT 1 PARENT_SCOPE)
+endfunction()

--- a/CMake/SlicerMacroBuildModuleLogic.cmake
+++ b/CMake/SlicerMacroBuildModuleLogic.cmake
@@ -86,6 +86,20 @@ macro(SlicerMacroBuildModuleLogic)
     set(MODULELOGIC_NO_INSTALL_OPTION "NO_INSTALL")
   endif()
 
+  set(Slicer_EXPORT_HEADER_CUSTOM_CONTENT)
+  if(${MODULELOGIC_NAME}_AUTOINIT)
+    set(Slicer_EXPORT_HEADER_CUSTOM_CONTENT "
+      // ####### Expanded from \@Slicer_EXPORT_HEADER_CUSTOM_CONTENT\@ #######
+      #if defined(${MODULELOGIC_NAME}_AUTOINIT)
+      # include \"${MODULELOGIC_NAME}ObjectFactory.h\"
+      # include \"vtkAutoInit.h\"
+      VTK_AUTOINIT(${MODULELOGIC_NAME})
+      #endif
+      // ##################################################
+      "
+      )
+  endif()
+
   SlicerMacroBuildModuleVTKLibrary(
     NAME ${MODULELOGIC_NAME}
     EXPORT_DIRECTIVE ${MODULELOGIC_EXPORT_DIRECTIVE}
@@ -95,6 +109,13 @@ macro(SlicerMacroBuildModuleLogic)
     TARGET_LIBRARIES ${MODULELOGIC_TARGET_LIBRARIES}
     ${MODULELOGIC_NO_INSTALL_OPTION}
     )
+
+  if(${MODULELOGIC_NAME}_AUTOINIT)
+    set_property(TARGET ${MODULELOGIC_NAME}
+      APPEND PROPERTY COMPILE_DEFINITIONS
+      "${PROJECT_NAME}_AUTOINIT=1(${MODULELOGIC_NAME})"
+      )
+  endif()
 
   set_property(GLOBAL APPEND PROPERTY SLICER_MODULE_LOGIC_TARGETS ${MODULELOGIC_NAME})
 

--- a/CMake/qSlicerExport.h.in
+++ b/CMake/qSlicerExport.h.in
@@ -28,5 +28,5 @@
 #else
  #define @MY_LIBRARY_EXPORT_DIRECTIVE@
 #endif
-
+@Slicer_EXPORT_HEADER_CUSTOM_CONTENT@
 #endif

--- a/Libs/MRML/DisplayableManager/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/CMakeLists.txt
@@ -124,15 +124,20 @@ if(MRMLDisplayableManager_USE_PYTHON)
     )
 endif()
 
-# Create the instantiator for DisplayableManager classes.
-include(${VTK_CMAKE_DIR}/vtkMakeInstantiator.cmake)
-VTK_MAKE_INSTANTIATOR3("${PROJECT_NAME}Instantiator"
-  DisplayableManagerInstantiator_SRCS
-  "${DisplayableManager_SRCS}"
-  "VTK_MRML_DISPLAYABLEMANAGER_EXPORT"
-  ${PROJECT_BINARY_DIR}
-  "vtk${PROJECT_NAME}Export.h")
+# --------------------------------------------------------------------------
+set(lib_name ${PROJECT_NAME})
 
+# --------------------------------------------------------------------------
+# Create the instantiator for DisplayableManager classes.
+# --------------------------------------------------------------------------
+include(SlicerConfigureDisplayableManagerObjectFactory)
+SlicerConfigureDisplayableManagerObjectFactory(
+  TARGET_NAME ${lib_name}
+  SRCS "${DisplayableManager_SRCS}"
+  EXPORT_MACRO "VTK_MRML_DISPLAYABLEMANAGER_EXPORT"
+  EXPORT_HEADER "vtk${PROJECT_NAME}Export.h"
+  OUTPUT_SRCS_VAR DisplayableManagerInstantiator_SRCS
+  )
 set(srcs
   ${KIT_SRCS}
   ${DisplayableManagerInstantiator_SRCS}
@@ -141,7 +146,6 @@ set(srcs
 # --------------------------------------------------------------------------
 # Build library
 # --------------------------------------------------------------------------
-set(lib_name ${PROJECT_NAME})
 add_library(${lib_name} ${srcs})
 
 set(libs
@@ -162,6 +166,13 @@ if(MRMLDisplayableManager_USE_PYTHON)
 endif()
 
 target_link_libraries(${lib_name} ${libs})
+
+if(${lib_name}_AUTOINIT)
+  set_property(TARGET ${lib_name}
+    APPEND PROPERTY COMPILE_DEFINITIONS
+    "${lib_name}_AUTOINIT=1(${lib_name})"
+    )
+endif()
 
 # Apply user-defined properties to the library target.
 if(Slicer_LIBRARY_PROPERTIES)

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/CMakeLists.txt
@@ -26,12 +26,12 @@ set(DisplayableManagerTest_SRCS
   )
 
 # Create the instantiator for DisplayableManager classes.
-VTK_MAKE_INSTANTIATOR3("${PROJECT_NAME}TestInstantiator"
-  DisplayableManagerInstantiatorTest_SRCS
-  "${DisplayableManagerTest_SRCS}"
-  ""
-  ${PROJECT_BINARY_DIR}
-  "")
+SlicerConfigureDisplayableManagerObjectFactory(
+  TARGET_NAME ${KIT}CxxTests
+  SRCS "${DisplayableManagerTest_SRCS}"
+  NO_EXPORT
+  OUTPUT_SRCS_VAR DisplayableManagerInstantiatorTest_SRCS
+  )
 
 add_executable(${KIT}CxxTests
   ${Tests}

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDViewDisplayableManagerFactoryTest1.cxx
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLThreeDViewDisplayableManagerFactoryTest1.cxx
@@ -35,8 +35,6 @@
 #include <vtkRenderer.h>
 #include <vtkSmartPointer.h>
 
-// STD includes
-
 //----------------------------------------------------------------------------
 int vtkMRMLThreeDViewDisplayableManagerFactoryTest1(int vtkNotUsed(argc), char* vtkNotUsed(argv)[])
 {

--- a/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerExport.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerExport.h
@@ -26,4 +26,10 @@
 #define VTK_MRML_DISPLAYABLEMANAGER_EXPORT
 #endif
 
+#if defined(MRMLDisplayableManager_AUTOINIT)
+#include "MRMLDisplayableManagerObjectFactory.h"
+#include "vtkAutoInit.h"
+VTK_AUTOINIT(MRMLDisplayableManager)
+#endif
+
 #endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerGroup.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerGroup.cxx
@@ -33,7 +33,6 @@
 
 // VTK includes
 #include <vtkCallbackCommand.h>
-#include <vtkInstantiator.h>
 #include <vtkObjectFactory.h>
 #include <vtkRenderer.h>
 #include <vtkRenderWindow.h>
@@ -134,7 +133,7 @@ bool vtkMRMLDisplayableManagerGroup
 {
   // Check if displayableManagerName is a valid displayable manager
   vtkSmartPointer<vtkObject> objectSmartPointer;
-  objectSmartPointer.TakeReference(vtkInstantiator::CreateInstance(displayableManagerName));
+  objectSmartPointer.TakeReference(vtkObjectFactory::CreateInstance(displayableManagerName));
   if (objectSmartPointer.GetPointer() &&
       objectSmartPointer->IsA("vtkMRMLAbstractDisplayableManager"))
     {
@@ -171,7 +170,7 @@ vtkMRMLAbstractDisplayableManager* vtkMRMLDisplayableManagerGroup
 #endif
     // Object will be unregistered when the SmartPointer will go out-of-scope
     displayableManager = vtkMRMLAbstractDisplayableManager::SafeDownCast(
-      vtkInstantiator::CreateInstance(displayableManagerName));
+      vtkObjectFactory::CreateInstance(displayableManagerName));
 #ifdef MRMLDisplayableManager_USE_PYTHON
     }
 #endif

--- a/Modules/Loadable/Annotations/MRMLDM/CMakeLists.txt
+++ b/Modules/Loadable/Annotations/MRMLDM/CMakeLists.txt
@@ -25,12 +25,12 @@ set(displayable_manager_SRCS
   vtkMRMLAnnotationROIDisplayableManager.cxx
   )
 
-VTK_MAKE_INSTANTIATOR3("${MODULE_NAME}Instantiator"
-  displayable_manager_instantiator_SRCS
-  "${displayable_manager_SRCS}"
-  "${${KIT}_EXPORT_DIRECTIVE}"
-  ${CMAKE_CURRENT_BINARY_DIR}
-  "${KIT}Export.h"
+SlicerConfigureDisplayableManagerObjectFactory(
+  TARGET_NAME ${KIT}
+  SRCS "${displayable_manager_SRCS}"
+  EXPORT_MACRO "${${KIT}_EXPORT_DIRECTIVE}"
+  EXPORT_HEADER "${KIT}Export.h"
+  OUTPUT_SRCS_VAR displayable_manager_instantiator_SRCS
   )
 
 set(${KIT}_SRCS

--- a/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
+++ b/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
@@ -10,7 +10,6 @@
 #include <qSlicerNodeWriter.h>
 
 // AnnotationModule includes
-#include "AnnotationsInstantiator.h"
 #include "qSlicerAnnotationsModule.h"
 #include "GUI/qSlicerAnnotationModuleWidget.h"
 #include "vtkSlicerAnnotationModuleLogic.h"

--- a/Modules/Loadable/Markups/MRMLDM/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRMLDM/CMakeLists.txt
@@ -20,20 +20,20 @@ set(displayable_manager_SRCS
   vtkMRML${MODULE_NAME}FiducialDisplayableManager2D.cxx
   )
 
-VTK_MAKE_INSTANTIATOR3("${MODULE_NAME}Instantiator"
-  displayable_manager_instantiator_SRCS
-  "${displayable_manager_SRCS}"
-  "${${KIT}_EXPORT_DIRECTIVE}"
-  ${CMAKE_CURRENT_BINARY_DIR}
-  "${KIT}Export.h"
-)
+SlicerConfigureDisplayableManagerObjectFactory(
+  TARGET_NAME ${KIT}
+  SRCS "${displayable_manager_SRCS}"
+  EXPORT_MACRO "${${KIT}_EXPORT_DIRECTIVE}"
+  EXPORT_HEADER "${KIT}Export.h"
+  OUTPUT_SRCS_VAR displayable_manager_instantiator_SRCS
+  )
 
 set(${KIT}_SRCS
   ${displayable_manager_instantiator_SRCS}
   ${displayable_manager_SRCS}
   vtkMRML${MODULE_NAME}DisplayableManagerHelper.cxx
   vtkMRML${MODULE_NAME}ClickCounter.cxx
-)
+  )
 
 set(${KIT}_TARGET_LIBRARIES
   ${MRML_LIBRARIES}

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -36,7 +36,6 @@
 #include "qSlicerSubjectHierarchyMarkupsPlugin.h"
 
 // Markups includes
-#include "MarkupsInstantiator.h"
 #include "qSlicerMarkupsModule.h"
 #include "qSlicerMarkupsModuleWidget.h"
 #include "qSlicerMarkupsReader.h"

--- a/Modules/Loadable/Segmentations/MRMLDM/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/MRMLDM/CMakeLists.txt
@@ -13,12 +13,12 @@ set(displayable_manager_SRCS
   vtkMRML${MODULE_NAME}DisplayableManager2D.cxx
   )
 
-VTK_MAKE_INSTANTIATOR3("${MODULE_NAME}Instantiator"
-  displayable_manager_instantiator_SRCS
-  "${displayable_manager_SRCS}"
-  "${${KIT}_EXPORT_DIRECTIVE}"
-  ${CMAKE_CURRENT_BINARY_DIR}
-  "${KIT}Export.h"
+SlicerConfigureDisplayableManagerObjectFactory(
+  TARGET_NAME ${KIT}
+  SRCS "${displayable_manager_SRCS}"
+  EXPORT_MACRO "${${KIT}_EXPORT_DIRECTIVE}"
+  EXPORT_HEADER "${KIT}Export.h"
+  OUTPUT_SRCS_VAR displayable_manager_instantiator_SRCS
   )
 
 set(${KIT}_SRCS

--- a/Modules/Loadable/Transforms/MRMLDM/CMakeLists.txt
+++ b/Modules/Loadable/Transforms/MRMLDM/CMakeLists.txt
@@ -18,12 +18,12 @@ set(displayable_manager_SRCS
   vtkMRMLLinear${MODULE_NAME}DisplayableManager3D.cxx
   )
 
-VTK_MAKE_INSTANTIATOR3("${MODULE_NAME}Instantiator"
-  displayable_manager_instantiator_SRCS
-  "${displayable_manager_SRCS}"
-  "${${KIT}_EXPORT_DIRECTIVE}"
-  ${CMAKE_CURRENT_BINARY_DIR}
-  "${KIT}Export.h"
+SlicerConfigureDisplayableManagerObjectFactory(
+  TARGET_NAME ${KIT}
+  SRCS "${displayable_manager_SRCS}"
+  EXPORT_MACRO "${${KIT}_EXPORT_DIRECTIVE}"
+  EXPORT_HEADER "${KIT}Export.h"
+  OUTPUT_SRCS_VAR displayable_manager_instantiator_SRCS
   )
 
 set(${KIT}_SRCS

--- a/Modules/Loadable/VolumeRendering/MRMLDM/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/CMakeLists.txt
@@ -15,12 +15,12 @@ set(displayable_manager_SRCS
   vtkMRMLVolumeRenderingDisplayableManager.cxx
   )
 
-VTK_MAKE_INSTANTIATOR3("${MODULE_NAME}Instantiator"
-  displayable_manager_instantiator_SRCS
-  "${displayable_manager_SRCS}"
-  "${${KIT}_EXPORT_DIRECTIVE}"
-  ${CMAKE_CURRENT_BINARY_DIR}
-  "${KIT}Export.h"
+SlicerConfigureDisplayableManagerObjectFactory(
+  TARGET_NAME ${KIT}
+  SRCS "${displayable_manager_SRCS}"
+  EXPORT_MACRO "${${KIT}_EXPORT_DIRECTIVE}"
+  EXPORT_HEADER "${KIT}Export.h"
+  OUTPUT_SRCS_VAR displayable_manager_instantiator_SRCS
   )
 
 set(${KIT}_SRCS

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
@@ -32,7 +32,6 @@
 #include "qSlicerVolumeRenderingModuleWidget.h"
 #include "qSlicerVolumeRenderingReader.h"
 #include "qSlicerVolumeRenderingSettingsPanel.h"
-#include "VolumeRenderingInstantiator.h"
 
 // SubjectHierarchy Plugins includes
 #include "qSlicerSubjectHierarchyPluginHandler.h"


### PR DESCRIPTION
This commit introduces the CMake function "SlicerConfigureDisplayableManagerObjectFactory"
used to configure VTK object factory allowing to instantiate displayable
manager given the class name.

It updates SlicerMacroBuildModuleLogic and qSlicerExport.h.in so that
the generated object factories are properly initialized.

It removes the use of vtkInstantiator that is deprecated following
kitware/VTK@8328eda merged on 2017-09-26.

See https://gitlab.kitware.com/vtk/vtk/merge_requests/3324

Co-authored-by: Jean-Baptiste Vimort <jb.vimort@kitware.com>