### PR TITLE
BUG: Enable high-resolution screenshots of slice views

### DIFF
--- a/Libs/MRML/Widgets/Resources/UI/qMRMLScreenShotDialog.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLScreenShotDialog.ui
@@ -142,7 +142,7 @@
    <item row="2" column="1">
     <widget class="ctkDoubleSpinBox" name="scaleFactorSpinBox">
      <property name="toolTip">
-      <string>Adjust the Magnification factor. Note that only the 3D view is rendered in high resolution, the other views are rescaled after the window is captured.</string>
+      <string>Adjust the Magnification factor.</string>
      </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">


### PR DESCRIPTION
This commit enables rendering high-resolution screenshots of the slice views.
Previously the screenshots were scaled and interpolated after being captured at
screen resolution.

Alternative attempts to render these screenshots, using vtkRenderLargeImage or
vtkWindowToImageFilter without offscreen rendering, resulted in incorrect
rendering of one or more of: the slice image, the annotations (ruler,
orientation marker, etc.), or lightbox mode.

Open issues are:
- Some text doesn't scale in the high-resolution screenshot (corner annotation,
  ruler measurement, orientation marker labels)
- Ruler height is fixed

Fixes #3885

Co-authored-by: Alexis Girault <alexis.girault@kitware.com>