### PR TITLE
COMP: DisplayableManager: Fix windows link error

### DIFF
--- a/CMake/SlicerConfigureDisplayableManagerObjectFactory.cmake
+++ b/CMake/SlicerConfigureDisplayableManagerObjectFactory.cmake
@@ -98,11 +98,11 @@ ${_export_header}
     ${CMAKE_CURRENT_BINARY_DIR}/${vtk-module}Module.h
     )
   configure_file(
-    ${VTK_CMAKE_DIR}/vtkObjectFactory.h.in
+    ${Slicer_CMAKE_DIR}/vtkSlicerObjectFactory.h.in
     ${CMAKE_CURRENT_BINARY_DIR}/${vtk-module}ObjectFactory.h
     )
   configure_file(
-    ${VTK_CMAKE_DIR}/vtkObjectFactory.cxx.in
+    ${Slicer_CMAKE_DIR}/vtkSlicerObjectFactory.cxx.in
     ${CMAKE_CURRENT_BINARY_DIR}/${vtk-module}ObjectFactory.cxx
     )
 

--- a/CMake/SlicerMacroBuildModuleLogic.cmake
+++ b/CMake/SlicerMacroBuildModuleLogic.cmake
@@ -91,7 +91,6 @@ macro(SlicerMacroBuildModuleLogic)
     set(Slicer_EXPORT_HEADER_CUSTOM_CONTENT "
       // ####### Expanded from \@Slicer_EXPORT_HEADER_CUSTOM_CONTENT\@ #######
       #if defined(${MODULELOGIC_NAME}_AUTOINIT)
-      # include \"${MODULELOGIC_NAME}ObjectFactory.h\"
       # include \"vtkAutoInit.h\"
       VTK_AUTOINIT(${MODULELOGIC_NAME})
       #endif

--- a/CMake/vtkSlicerObjectFactory.cxx.in
+++ b/CMake/vtkSlicerObjectFactory.cxx.in
@@ -1,0 +1,67 @@
+/*=========================================================================
+
+  Program:   Visualization Toolkit
+  Module:    @vtk-module@ObjectFactory.cxx
+
+  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+
+#include "@vtk-module@ObjectFactory.h"
+#include "vtkVersion.h"
+
+// Include all of the classes we want to create overrides for.
+@_vtk_override_includes@
+
+vtkStandardNewMacro(@vtk-module@ObjectFactory)
+
+// Now create the functions to create overrides with.
+@_vtk_override_creates@
+
+@vtk-module@ObjectFactory::@vtk-module@ObjectFactory()
+{
+@_vtk_override_do@
+}
+
+const char * @vtk-module@ObjectFactory::GetVTKSourceVersion()
+{
+  return VTK_SOURCE_VERSION;
+}
+
+void @vtk-module@ObjectFactory::PrintSelf(ostream &os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}
+
+// Registration of object factories.
+static unsigned int @vtk-module@Count;
+
+/* @VTK-MODULE@_EXPORT */ void @vtk-module@_AutoInit_Construct()
+{
+  if(++@vtk-module@Count == 1)
+    {
+    @vtk-object-factory-extra-init@
+    @vtk-module@ObjectFactory* factory = @vtk-module@ObjectFactory::New();
+    if (factory)
+      {
+      // vtkObjectFactory keeps a reference to the "factory",
+      vtkObjectFactory::RegisterFactory(factory);
+      factory->Delete();
+      }
+    }
+}
+
+/* @VTK-MODULE@_EXPORT */ void @vtk-module@_AutoInit_Destruct()
+{
+  if(--@vtk-module@Count == 0)
+    {
+    // Do not call vtkObjectFactory::UnRegisterFactory because
+    // vtkObjectFactory.cxx statically unregisters all factories.
+    }
+}

--- a/CMake/vtkSlicerObjectFactory.h.in
+++ b/CMake/vtkSlicerObjectFactory.h.in
@@ -1,0 +1,42 @@
+/*=========================================================================
+
+  Program:   Visualization Toolkit
+  Module:    @vtk-module@ObjectFactory.h
+
+  Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notice for more information.
+
+=========================================================================*/
+
+#ifndef __@vtk-module@ObjectFactory_h
+#define __@vtk-module@ObjectFactory_h
+
+#include "@vtk-module@Module.h" // For export macro
+#include "vtkObjectFactory.h"
+
+class @VTK-MODULE@_EXPORT @vtk-module@ObjectFactory : public vtkObjectFactory
+{
+public:
+  static @vtk-module@ObjectFactory * New();
+  vtkTypeMacro(@vtk-module@ObjectFactory, vtkObjectFactory)
+
+  const char * GetDescription() override { return "@vtk-module@ factory overrides."; }
+
+  const char * GetVTKSourceVersion() override;
+
+  void PrintSelf(ostream &os, vtkIndent indent) override;
+
+protected:
+  @vtk-module@ObjectFactory();
+
+private:
+  @vtk-module@ObjectFactory(const @vtk-module@ObjectFactory&) = delete;
+  void operator=(const @vtk-module@ObjectFactory&) = delete;
+};
+
+#endif // __@vtk-module@ObjectFactory_h

--- a/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerExport.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerExport.h
@@ -16,7 +16,7 @@
 
 #include <vtkMRMLDisplayableManagerConfigure.h>
 
-#if defined(WIN32) && !defined(VTKMRMLDisplayableManager_STATIC)
+#if defined(WIN32) && !defined(MRMLDisplayableManager_STATIC)
 #if defined(MRMLDisplayableManager_EXPORTS)
 #define VTK_MRML_DISPLAYABLEMANAGER_EXPORT __declspec( dllexport )
 #else
@@ -27,7 +27,6 @@
 #endif
 
 #if defined(MRMLDisplayableManager_AUTOINIT)
-#include "MRMLDisplayableManagerObjectFactory.h"
 #include "vtkAutoInit.h"
 VTK_AUTOINIT(MRMLDisplayableManager)
 #endif


### PR DESCRIPTION
This commit fixes "redefinition; different linkage" error reported on
windows. The regression was introduced in r26458 (COMP: Support VTK 8.1
updating displayable manager to use vtkObjectFactory)

It implements the following changes:

* It removes redundant include of ObjectFactory implementation
  from export header. Since it is already part of the translation unit,
  there is no need to add it again here.

* It disables the export of object factory AutoInit_Construct and
  AutoInit_Destruct symbols. Since the factory is initialized in the
  same translation unit using "VTK_AUTOINIT", these symbols do not need
  to be exported.

* It also fixes a typo in vtkMRMLDisplayableManagerExport.h changing
  VTKMRMLDisplayableManager_STATIC into MRMLDisplayableManager_STATIC.


Content of the error:

```
C:\S4R\Slicer-build\Libs\MRML\DisplayableManager\MRMLDisplayableManagerObjectFactory.cxx(106): error C2375: 'MRMLDisplayableManager_AutoInit_Construct' : redefinition; different linkage [C:\S4R\Slicer-build\Libs\MRML\DisplayableManager\MRMLDisplayableManager.vcxproj] [C:\S4R\Slicer.vcxproj]

            C:\S4\Libs\MRML\DisplayableManager\vtkMRMLDisplayableManagerExport.h(32) : see declaration of 'MRMLDisplayableManager_AutoInit_Construct'

C:\S4R\Slicer-build\Libs\MRML\DisplayableManager\MRMLDisplayableManagerObjectFactory.cxx(121): error C2375: 'MRMLDisplayableManager_AutoInit_Destruct' : redefinition; different linkage [C:\S4R\Slicer-build\Libs\MRML\DisplayableManager\MRMLDisplayableManager.vcxproj] [C:\S4R\Slicer.vcxproj]

            C:\S4\Libs\MRML\DisplayableManager\vtkMRMLDisplayableManagerExport.h(32) : see declaration of 'MRMLDisplayableManager_AutoInit_Destruct'
```

Reported-by: Andras Lasso <lasso@queensu.ca>