### PR TITLE
BUG: Improve warning message in vtkMRMLLayoutLogic::GetViewsFromAttributes

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLLayoutLogic.cxx
@@ -1897,7 +1897,7 @@ vtkCollection* vtkMRMLLayoutLogic::GetViewsFromAttributes(const ViewAttributes& 
         }
       if (nodes->GetNumberOfItems() > 1)
         {
-        vtkWarningMacro("Couldn't find node with SingletonTag: " << attributeValue );
+        vtkWarningMacro("Found several nodes with a similar SingletonTag: " << attributeValue );
         // Did not find the node, return an empty list to trigger the
         // calling method, CreateMissingViews(), to create the appropriate node.
         nodes->RemoveAllItems();


### PR DESCRIPTION
This commit updates the warning message to be more explicit and facilitate
debugging when developing custom view and view nodes in Slicer extensions.

Before: Couldn't find node with SingletonTag: ...
 After: Found several nodes with a similar SingletonTag: ...