### PR TITLE
BUG: Fix crash ThresholdSlider in segmentEditor when changing volume

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorThresholdEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorThresholdEffect.py
@@ -109,7 +109,7 @@ class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
     masterImageData = self.scriptedEffect.masterVolumeImageData()
     if masterImageData:
       lo, hi = masterImageData.GetScalarRange()
-      self.thresholdSlider.minimum, self.thresholdSlider.maximum = lo, hi
+      self.thresholdSlider.setRange(lo, hi)
       self.thresholdSlider.singleStep = (hi - lo) / 1000.
       if (self.scriptedEffect.doubleParameter("MinimumThreshold") == self.scriptedEffect.doubleParameter("MaximumThreshold")):
         # has not been initialized yet

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -1380,8 +1380,7 @@ void qMRMLSegmentEditorWidget::onMasterVolumeImageDataModified()
     {
     double range[2] = { 0.0, 0.0 };
     d->MasterVolumeNode->GetImageData()->GetScalarRange(range);
-    d->MasterVolumeIntensityMaskRangeWidget->setMinimum(range[0]);
-    d->MasterVolumeIntensityMaskRangeWidget->setMaximum(range[1]);
+    d->MasterVolumeIntensityMaskRangeWidget->setRange(range[0], range[1]);
     d->MasterVolumeIntensityMaskRangeWidget->setEnabled(true);
     }
   else

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -82,7 +82,7 @@ if(NOT DEFINED CTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "134532b5eda5323d81a0c848b31a21ed19dcc732"
+    "4911acd884b6ccf897fcd116df646b7fd7f7b2bc"
     QUIET
     )
 


### PR DESCRIPTION
Hi @cpinter another fix in the Segmentation editor relative to Qt5.

The crash happens when the minimum of the scalar range is greater then the current maximum of the ctkRangeWidget (at least in linux).

The fix is simply to use ctkRangeWidget::setRange.
P.S.: in the python wrapping setRange is not available.