### PR TITLE
Improve subjecthierarchy combobox (2)

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -303,9 +303,7 @@ void qMRMLSubjectHierarchyComboBox::showPopup()
   // Custom size
   int displayedItemCount = d->TreeView->displayedItemCount();
   const int numberOfRows = qMin(displayedItemCount, d->MaximumNumberOfShownItems);
-  QSize itemSize = QSize(
-    d->TreeView->sizeHintForColumn(d->TreeView->model()->nameColumn()), d->TreeView->sizeHintForRow(0) );
-  listRect.setHeight( numberOfRows * itemSize.height() );
+  int popupHeight = numberOfRows * d->TreeView->sizeHintForRow(0);
 
   // Add margins for the height
   // NB: not needed for the width as the item labels will be cropped
@@ -314,8 +312,9 @@ void qMRMLSubjectHierarchyComboBox::showPopup()
   container->getContentsMargins(&marginLeft, &marginTop, &marginRight, &marginBottom);
   int tvMarginLeft, tvMarginTop, tvMarginRight, tvMarginBottom;
   d->TreeView->getContentsMargins(&tvMarginLeft, &tvMarginTop, &tvMarginRight, &tvMarginBottom);
-  listRect.setHeight( listRect.height() + marginTop + marginBottom + tvMarginTop + tvMarginBottom);
+  popupHeight += marginTop + marginBottom + tvMarginTop + tvMarginBottom;
 
+  // Position of the container
   if(d->AlignPopupVertically)
     {
     // Position horizontally
@@ -343,10 +342,13 @@ void qMRMLSubjectHierarchyComboBox::showPopup()
     }
   else
     {
+    // Position below the combobox
     listRect.moveTo(below);
     }
 
-  container->setGeometry(listRect);
+  container->move(listRect.topLeft());
+  container->setFixedHeight(popupHeight);
+  container->setFixedWidth(this->width());
   container->raise();
   container->show();
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -79,6 +79,7 @@ void qMRMLSubjectHierarchyComboBoxPrivate::init()
 
   q->setDefaultText("Select subject hierarchy item");
   q->setDefaultIcon(QIcon());
+  q->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
 
   // Setup tree view
   this->TreeView = new qMRMLSubjectHierarchyTreeView(q);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -307,12 +307,13 @@ void qMRMLSubjectHierarchyComboBox::showPopup()
     d->TreeView->sizeHintForColumn(d->TreeView->model()->nameColumn()), d->TreeView->sizeHintForRow(0) );
   listRect.setHeight( numberOfRows * itemSize.height() );
 
+  // Add margins for the height
+  // NB: not needed for the width as the item labels will be cropped
+  // without displaying an horizontal scroll bar
   int marginLeft, marginTop, marginRight, marginBottom;
   container->getContentsMargins(&marginLeft, &marginTop, &marginRight, &marginBottom);
   int tvMarginLeft, tvMarginTop, tvMarginRight, tvMarginBottom;
   d->TreeView->getContentsMargins(&tvMarginLeft, &tvMarginTop, &tvMarginRight, &tvMarginBottom);
-  listRect.setWidth( listRect.width() + marginLeft + marginRight + tvMarginLeft + tvMarginRight);
-  listRect.setWidth( listRect.width() + container->frameWidth());
   listRect.setHeight( listRect.height() + marginTop + marginBottom + tvMarginTop + tvMarginBottom);
 
   if(d->AlignPopupVertically)


### PR DESCRIPTION
### 1. Expand subject hierarchy combobox horizontally
Update subject hierarchy combobox size policy to match the layout behavior of the `qMRMLNodeComboBox` (expands [horizontally](https://github.com/Slicer/Slicer/blob/36fe64b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx#L1091), fixed [vertically](https://github.com/Slicer/Slicer/blob/36fe64b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx#L76))

* BEFORE:
<img width="498" alt="screen shot 2017-10-18 at 10 59 57 am" src="https://user-images.githubusercontent.com/4910855/31832480-2af8afe4-b595-11e7-8f1c-1c40f8224ba9.png">

* COMPARED TO `qMRMLNodeComboBox`:
<img width="560" alt="screen shot 2017-10-18 at 1 19 26 pm" src="https://user-images.githubusercontent.com/4910855/31832495-3d322a32-b595-11e7-8952-89a152dc2125.png">

* AFTER:
<img width="449" alt="screen shot 2017-10-20 at 10 53 43 am" src="https://user-images.githubusercontent.com/4910855/31832502-42b10e06-b595-11e7-97cd-05b6cdf881a1.png">

### 2. Fix treeview popup width in subject hierarchy combobox 

The margins from the container and the treeview would make the tree view container wider than the combobox used to select an item (see top right corner). Since the container stretches based on the number of items, the vertical margins are needed to properly embed all items, or else a vertical scrolling bar is needed. However, the combobox/treeview width is fixed and does not vary based on the length of the item labels: therefore, those labels will be cropped (...) at the limit of the container, and a horizontal scroll bar does not appear. Adjusting the width of the container by ignoring the margins of the treeview will therefore not impact how the items are shown.

* BEFORE: 
<img width="394" alt="screen shot 2017-10-20 at 11 53 22 am" src="https://user-images.githubusercontent.com/4910855/31832547-67e6e678-b595-11e7-893a-7616b881c8d8.png">

* NO MARGINS:
<img width="483" alt="screen shot 2017-10-20 at 11 38 31 am" src="https://user-images.githubusercontent.com/4910855/31832557-6dfcd8e2-b595-11e7-9999-98763991f3ca.png">

* NO HORIZONTAL MARGINS ONLY:
<img width="476" alt="screen shot 2017-10-20 at 11 46 34 am" src="https://user-images.githubusercontent.com/4910855/31832566-7760a346-b595-11e7-98ff-db5a9862f5f6.png">

### 3. Fix treeview popup height in subject hierarchy combobox 

The computed height of the treeview container - based on the number of items to display - was ignored when inferior to 98 (4 items or less), resulting in a lot of empty white space. Setting a fixed height and width to the container fixes that issue.

* BEFORE
<img width="263" alt="screen shot 2017-10-18 at 1 01 28 pm" src="https://user-images.githubusercontent.com/4910855/31854522-b8ee6cca-b668-11e7-82c1-a013329954c1.png">

* AFTER
<img width="433" alt="screen shot 2017-10-21 at 2 26 15 pm" src="https://user-images.githubusercontent.com/4910855/31854722-e72b9844-b66b-11e7-8dc9-471336d20681.png">


### 4. Display placeholder label when subject hierarchy tree is empty

Add placeholder message when there are no items to display. Use a QLabel that is shown or hide on top of the TreeView to simplify it (managing a 'None' item in the treeview and its models would have been tricky).

* BEFORE
<img width="200" alt="screen shot 2017-10-18 at 11 04 16 am" src="https://user-images.githubusercontent.com/4910855/31832632-baaf3ca2-b595-11e7-95be-e66eca7ff777.png">

* AFTER
<img width="364" alt="screen shot 2017-10-21 at 1 52 41 pm" src="https://user-images.githubusercontent.com/4910855/31854534-eefd5812-b668-11e7-9b4f-cfdce7953374.png">

<img width="385" alt="screen shot 2017-10-23 at 10 37 54 am" src="https://user-images.githubusercontent.com/4910855/31895113-4e079bbc-b7de-11e7-8296-f65846a35c68.png">

<img width="387" alt="screen shot 2017-10-21 at 1 53 11 pm" src="https://user-images.githubusercontent.com/4910855/31854535-ef170a1e-b668-11e7-994a-010b8e9f9b36.png">
