### PR TITLE
BUG: qMRMLLayoutManager::plotWidget was returning a Table Widget

### DIFF
--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -973,14 +973,14 @@ qMRMLChartWidget* qMRMLLayoutManager::chartWidget(int id)const
 qMRMLTableWidget* qMRMLLayoutManager::tableWidget(int id)const
 {
   return qobject_cast<qMRMLTableWidget*>(
-              this->mrmlViewFactory("vtkMRMLTableViewNode")->viewWidget(id));
+    this->mrmlViewFactory("vtkMRMLTableViewNode")->viewWidget(id));
 }
 
 //------------------------------------------------------------------------------
-qMRMLTableWidget *qMRMLLayoutManager::plotWidget(int id)const
+qMRMLPlotWidget *qMRMLLayoutManager::plotWidget(int id)const
 {
-  return qobject_cast<qMRMLTableWidget*>(
-              this->mrmlViewFactory("vtkMRMLPlotViewNode")->viewWidget(id));
+  return qobject_cast<qMRMLPlotWidget*>(
+    this->mrmlViewFactory("vtkMRMLPlotViewNode")->viewWidget(id));
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.h
@@ -32,6 +32,7 @@ class QWidget;
 #include "qMRMLWidgetsExport.h"
 
 class qMRMLChartWidget;
+class qMRMLPlotWidget;
 class qMRMLTableWidget;
 class qMRMLThreeDWidget;
 class qMRMLSliceWidget;
@@ -149,7 +150,7 @@ public:
   Q_INVOKABLE qMRMLThreeDWidget* threeDWidget(int id)const;
   Q_INVOKABLE qMRMLChartWidget* chartWidget(int id)const;
   Q_INVOKABLE qMRMLTableWidget* tableWidget(int id)const;
-  Q_INVOKABLE qMRMLTableWidget* plotWidget(int id)const;
+  Q_INVOKABLE qMRMLPlotWidget* plotWidget(int id)const;
 
   /// Return the up-to-date list of vtkMRMLSliceLogics associated to the slice views.
   /// The returned collection object is owned by the layout manager.


### PR DESCRIPTION
This fix an error in the Plot infrastructure.  qMRMLLayoutManager::plotWidget should return a PlotWidget.