### PR TITLE
COMP: Fix NUMPY rebuild error ensuring patch are re-applied if needed

### DIFF
--- a/SuperBuild/External_NUMPY.cmake
+++ b/SuperBuild/External_NUMPY.cmake
@@ -71,10 +71,12 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
 
   set(_version "1.13.1")
 
+  set(_download_stamp "${CMAKE_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${proj}-download")
   set(_common_patch_args
     -DPatch_EXECUTABLE:PATH=${Patch_EXECUTABLE}
     -DSOURCE_DIR:PATH=<SOURCE_DIR>
     -DBINARY_DIR:PATH=${CMAKE_BINARY_DIR}
+    -DDOWNLOAD_STAMP:FILEPATH=${_download_stamp}
     )
 
   #------------------------------------------------------------------------------


### PR DESCRIPTION
If DOWNLOAD_STAMP is modified after the patch has been applied, this mean
that the source have been re-downloaded and that the patch must be re-applied.

Fixes https://issues.slicer.org/view.php?id=4452

Reported-by: Andras Lasso <lasso@queensu.ca>
Reported-by: Steve Pieper <pieper@bwh.harvard.edu>