### PR TITLE
RFC: BUG: slicer.util.exit should use first-called exit status

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -31,9 +31,16 @@ add_test(
   --testing --disable-modules --no-main-window
   --python-code "exit(slicer.util.EXIT_FAILURE)"
   )
+add_test(
+  NAME py_nomainwindow_SlicerPythonCodeDoubleExitFailureTest
+  COMMAND ${Slicer_LAUNCH_COMMAND} $<TARGET_FILE:${APP_TARGET_NAME}>
+  --disable-modules --no-main-window
+  --python-code "exit(slicer.util.EXIT_FAILURE); exit(slicer.util.EXIT_SUCCESS)"
+  )
 set_tests_properties(
     py_nomainwindow_SlicerPythonCodeExitFailureTest
     py_nomainwindow_testing_SlicerPythonCodeExitFailureTest
+    py_nomainwindow_SlicerPythonCodeDoubleExitFailureTest
   PROPERTIES WILL_FAIL TRUE
   )
 

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -12,6 +12,11 @@ def quit():
   exit(EXIT_SUCCESS)
 
 def exit(status=EXIT_SUCCESS):
+  # call once because QApplication::exit() from PythonQt
+  # honors only the last-called exit status in a block.
+  if exit.__dict__.get("call_once", False): return
+  exit.__dict__["call_once"] = True
+
   from slicer import app
   app.commandOptions().runPythonAndExit = False
   app.exit(status)


### PR DESCRIPTION
Fixes https://issues.slicer.org/view.php?id=4470

Ref where sys.exit from Python was required to correctly return status:
  https://github.com/pnlbwh/ukftractography/commit/bcd856906d1dbd5eeee608937e62aa3f156c0463

Explanation: QApplication::exit() terminates the event loop and then returns to caller -- so the given PythonQt `eval` runs to completion and multiple calls in a single block/file will only honor the last-called exit status.