### PR TITLE
COMP: Support building with DICOM support disabled

### DIFF
--- a/Libs/CMakeLists.txt
+++ b/Libs/CMakeLists.txt
@@ -75,6 +75,8 @@ set(MRML_APPLICATION_SHARE_SUBDIR ${Slicer_SHARE_DIR})
 # vtkITK contains tests that uses MRML's test data.
 set(MRML_TEST_DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MRML/Core/Testing/TestData)
 
+set(VTKITK_BUILD_DICOM_SUPPORT ${Slicer_BUILD_DICOM_SUPPORT})
+
 #-----------------------------------------------------------------------------
 # Loop over list of directories
 #-----------------------------------------------------------------------------

--- a/Libs/vtkITK/CMakeLists.txt
+++ b/Libs/vtkITK/CMakeLists.txt
@@ -11,6 +11,10 @@ if(NOT DEFINED BUILD_SHARED_LIBS)
   option(BUILD_SHARED_LIBS "Build with shared libraries." ON)
 endif()
 
+if(NOT DEFINED VTKITK_BUILD_DICOM_SUPPORT)
+  option(VTKITK_BUILD_DICOM_SUPPORT "Build with DICOM support" ON)
+endif()
+
 # --------------------------------------------------------------------------
 # Dependencies
 # --------------------------------------------------------------------------

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
@@ -30,8 +30,10 @@
 // ITK includes
 #include <itkOrientImageFilter.h>
 #include <itkImageSeriesReader.h>
+#ifdef VTKITK_BUILD_DICOM_SUPPORT
 #include <itkDCMTKImageIO.h>
 #include <itkGDCMImageIO.h>
+#endif
 
 vtkStandardNewMacro(vtkITKArchetypeImageSeriesScalarReader);
 
@@ -90,6 +92,7 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
     vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT()));
   this->SetMetaDataScalarRangeToPointDataInfo(data);
 
+#ifdef VTKITK_BUILD_DICOM_SUPPORT
 #define vtkITKExecuteDataDeclareDICOMImageIO \
       typedef itk::ImageIOBase ImageIOType; \
       ImageIOType::Pointer imageIO; \
@@ -107,6 +110,11 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
         this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError); \
         return 0; \
         }
+#else
+#define vtkITKExecuteDataDeclareDICOMImageIO \
+  typedef itk::ImageIOBase ImageIOType; \
+  ImageIOType::Pointer imageIO;
+#endif
 
 /// SCALAR MACRO
 #define vtkITKExecuteDataFromSeries(typeN, type) \

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
@@ -28,6 +28,7 @@
 #include <itkImageFileReader.h>
 #include <itkImageSeriesReader.h>
 #include <itkOrientImageFilter.h>
+#ifdef VTKITK_BUILD_DICOM_SUPPORT
 #include <itkDCMTKImageIO.h>
 #include <itkGDCMImageIO.h>
 
@@ -35,6 +36,7 @@
 #include "gdcmDict.h"           /// access to dictionary
 #include "gdcmDictEntry.h"      /// access to dictionary
 #include "gdcmGlobal.h"         /// access to dictionary
+#endif
 
 vtkStandardNewMacro(vtkITKArchetypeImageSeriesVectorReaderSeries);
 
@@ -83,6 +85,7 @@ void vtkITKExecuteDataFromSeriesVector(
   reader->SetFileNames(self->GetFileNames());
   reader->ReleaseDataFlagOn();
   reader->GetOutput()->SetVectorLength(3);
+#ifdef VTKITK_BUILD_DICOM_SUPPORT
   typedef itk::ImageIOBase ImageIOType;
   ImageIOType::Pointer imageIO;
   if (self->GetDICOMImageIOApproach() == vtkITKArchetypeImageSeriesReader::GDCM)
@@ -94,6 +97,7 @@ void vtkITKExecuteDataFromSeriesVector(
     imageIO = itk::DCMTKImageIO::New();
     }
   else
+#endif
     {
     vtkErrorWithObjectMacro(self, <<"vtkITKArchetypeImageSeriesVectorReaderSeries: Unsupported DICOMImageIOApproach: " << self->GetDICOMImageIOApproach());
     itkGenericExceptionMacro("UnrecognizedFileTypeError");

--- a/Libs/vtkITK/vtkITKConfigure.h.in
+++ b/Libs/vtkITK/vtkITKConfigure.h.in
@@ -11,3 +11,5 @@
 #ifndef BUILD_SHARED_LIBS
 #define VTKITK_STATIC
 #endif
+
+#cmakedefine VTKITK_BUILD_DICOM_SUPPORT


### PR DESCRIPTION
This commit update `vtkITK` to support building without DICOM support (`-DSlicer_BUILD_DICOM_SUPPORT:BOOL=OFF`).
Attempting to use "Add Data" dialog, selecting a DICOM file and unchecking
the "single file" option will report an exception like the following:

```
  AssembleVolumeContainingArchetype: index archetype 0 is out of bounds 0-0

  vtkITKArchetypeImageSeriesReader::ExecuteInformation: Failed to read file series
  [...]

  ReadData: This is not a nrrd file
  ReadData: Cannot read file as a volume of type DiffusionTensorVolume[fullName = /path/to/volume0000.dcm]
	  Number of files listed in the node = 0.
	  File reader says it was able to read 0 files.
	  File reader used the archetype file name of/path/to/volume0000.dcm []
  FileNotFoundError

  ReadData: This is not a nrrd file
  ReadData: Failed to instantiate a file reader
  ReadData: Cannot read file as a volume of type Volume[fullName =/path/to/volume0000.dcm]
	  Number of files listed in the node = 0.
	  File reader says it was able to read 0 files.
	  File reader used the archetype file name of/path/to/volume0000.dcm []
  FileNotFoundError
```