### PR TITLE
ENH: add MeanDiffusivity calculation to DTMathematics

### DIFF
--- a/Libs/vtkTeem/Testing/vtkDiffusionTensorMathematicsTest1.cxx
+++ b/Libs/vtkTeem/Testing/vtkDiffusionTensorMathematicsTest1.cxx
@@ -96,7 +96,7 @@ int vtkDiffusionTensorMathematicsTest1(int vtkNotUsed(argc), char* vtkNotUsed(ar
   filter->SetMaskLabelValue(0);  // mask all the labels different from 0
   filter->SetMaskWithScalars(1); // turn on masking
   for (int i = vtkDiffusionTensorMathematics::VTK_TENS_TRACE;
-       i <=vtkDiffusionTensorMathematics::VTK_TENS_PERPENDICULAR_DIFFUSIVITY;
+       i <=vtkDiffusionTensorMathematics::VTK_TENS_MEAN_DIFFUSIVITY;
        ++i)
     {
     filter->SetOperation(i);

--- a/Libs/vtkTeem/vtkDiffusionTensorMathematics.cxx
+++ b/Libs/vtkTeem/vtkDiffusionTensorMathematics.cxx
@@ -622,6 +622,10 @@ static void vtkDiffusionTensorMathematicsExecute1Eigen(vtkDiffusionTensorMathema
             *outPtr = static_cast<T> (vtkDiffusionTensorMathematics::PerpendicularDiffusivity(w));
             break;
 
+          case vtkDiffusionTensorMathematics::VTK_TENS_MEAN_DIFFUSIVITY:
+            *outPtr = static_cast<T> (vtkDiffusionTensorMathematics::MeanDiffusivity(w));
+            break;
+
           case vtkDiffusionTensorMathematics::VTK_TENS_MAX_EIGENVALUE_PROJX:
             *outPtr = static_cast<T> (vtkDiffusionTensorMathematics::MaxEigenvalueProjectionX(v,w));
             break;
@@ -894,6 +898,7 @@ void vtkDiffusionTensorMathematics::ThreadedRequestData(
     case VTK_TENS_COLOR_MODE:
     case VTK_TENS_PARALLEL_DIFFUSIVITY:
     case VTK_TENS_PERPENDICULAR_DIFFUSIVITY:
+    case VTK_TENS_MEAN_DIFFUSIVITY:
       switch (outData[0]->GetScalarType())
       {
         vtkTemplateMacro(vtkDiffusionTensorMathematicsExecute1Eigen(
@@ -1067,6 +1072,15 @@ double vtkDiffusionTensorMathematics::PerpendicularDiffusivity(double w[3])
   return ( ( w[1] + w[2] ) / 2 );
 }
 
+double vtkDiffusionTensorMathematics::MeanDiffusivity(double w[3])
+{
+  if ((w[0] <= VTK_EPS) || (w[1] <= VTK_EPS) || (w[2] <= VTK_EPS))
+  {
+    return DOUBLE_NAN;
+  }
+
+  return ( ( w[0] + w[1] + w[2] ) / 3 );
+}
 
 double vtkDiffusionTensorMathematics::RAIMaxEigenvecX(double **v, double w[3])
 {

--- a/Libs/vtkTeem/vtkDiffusionTensorMathematics.h
+++ b/Libs/vtkTeem/vtkDiffusionTensorMathematics.h
@@ -41,12 +41,6 @@ public:
   vtkTypeMacro(vtkDiffusionTensorMathematics,vtkThreadedImageAlgorithm);
   void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  ///
-  /// Get the Operation to perform.
-  vtkGetMacro(Operation,int);
-  vtkSetClampMacro(Operation,int, VTK_TENS_TRACE, VTK_TENS_PERPENDICULAR_DIFFUSIVITY);
-
-
   /// Operation options.
   enum
   {
@@ -78,9 +72,13 @@ public:
     VTK_TENS_PARALLEL_DIFFUSIVITY = 25,
     VTK_TENS_PERPENDICULAR_DIFFUSIVITY = 26,
     VTK_TENS_COLOR_ORIENTATION_MIDDLE_EIGENVECTOR = 27,
-    VTK_TENS_COLOR_ORIENTATION_MIN_EIGENVECTOR = 28
+    VTK_TENS_COLOR_ORIENTATION_MIN_EIGENVECTOR = 28,
+    VTK_TENS_MEAN_DIFFUSIVITY = 29
   };
-
+  ///
+  /// Get the Operation to perform.
+  vtkGetMacro(Operation,int);
+  vtkSetClampMacro(Operation,int, VTK_TENS_TRACE, VTK_TENS_MEAN_DIFFUSIVITY);
 
   ///
   /// Output the trace (sum of eigenvalues = sum along diagonal)
@@ -112,6 +110,8 @@ public:
     {this->SetOperation(VTK_TENS_PARALLEL_DIFFUSIVITY);};
   void SetOperationToPerpendicularDiffusivity()
     {this->SetOperation(VTK_TENS_PERPENDICULAR_DIFFUSIVITY);};
+  void SetOperationToMeanDiffusivity()
+    {this->SetOperation(VTK_TENS_MEAN_DIFFUSIVITY);};
 
   ///
   /// Output a selected eigenvalue
@@ -251,6 +251,7 @@ public:
   static double MiddleEigenvalue(double w[3]);
   static double ParallelDiffusivity(double w[3]);
   static double PerpendicularDiffusivity(double w[3]);
+  static double MeanDiffusivity(double w[3]);
   static double MinEigenvalue(double w[3]);
   static double RAIMaxEigenvecX(double **v, double w[3]);
   static double RAIMaxEigenvecY(double **v, double w[3]);


### PR DESCRIPTION
Note this is tested in https://github.com/SlicerDMRI/SlicerDMRI/pull/86

(also fixes a bug where the COLOR_ORIENTATION_[middle, min]_EIGENVEC options were not available, because the macro-setter was clamped to an older enum range)