### PR TITLE
ENH: Create user-specific temporary directory on unix systems

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1110,7 +1110,15 @@ bool qSlicerCoreApplication::isEmbeddedModule(const QString& moduleFileName)cons
 //-----------------------------------------------------------------------------
 QString qSlicerCoreApplication::defaultTemporaryPath() const
 {
+#ifdef Q_OS_UNIX
+  // In multi-user Linux environment, a single temporary directory is shared
+  // by all users. We need to create a separate directory for each user,
+  // as users do not have access to another user's directory.
+  QString userName = qgetenv("USER");
+  return QFileInfo(QDir::tempPath(), this->applicationName()+"-"+userName).absoluteFilePath();
+#else
   return QFileInfo(QDir::tempPath(), this->applicationName()).absoluteFilePath();
+#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Slicer temporary directory is owned by the user who started Slicer first and is not writeable. Issue identified by Artem Mamonov.

Fixes https://issues.slicer.org/view.php?id=4340