### PR TITLE
BUG: Added new launcher option for the simplified VisualStudio switch

### DIFF
--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -552,18 +552,24 @@ macro(slicerMacroBuildApplication)
       if(UNIX)
         list(APPEND executables gnome-terminal xterm ddd gdb)
       elseif(WIN32)
-        list(APPEND executables VisualStudio cmd)
+        list(APPEND executables VisualStudio VisualStudioProject cmd)
         set(VisualStudio_EXECUTABLE ${CMAKE_VS_DEVENV_COMMAND})
-        set(VisualStudio_ARGUMENTS ${Slicer_BINARY_DIR}/${Slicer_MAIN_PROJECT_APPLICATION_NAME}.sln)
+        set(VisualStudio_HELP "Open Visual Studio with Slicer's DLL paths set up")
+        set(VisualStudioProject_EXECUTABLE ${CMAKE_VS_DEVENV_COMMAND})
+        set(VisualStudioProject_ARGUMENTS ${Slicer_BINARY_DIR}/${Slicer_MAIN_PROJECT_APPLICATION_NAME}.sln)
+        set(VisualStudioProject_HELP "Open Visual Studio ${Slicer_MAIN_PROJECT_APPLICATION_NAME} project with Slicer's DLL paths set up")
         set(cmd_ARGUMENTS "/c start cmd")
       endif()
       foreach(executable ${executables})
         find_program(${executable}_EXECUTABLE ${executable})
         if(${executable}_EXECUTABLE)
           message(STATUS "Enabling ${SLICERAPP_APPLICATION_NAME} build tree launcher option: --${executable}")
+          if(NOT DEFINED ${executable}_HELP)
+            set(${executable}_HELP "Start ${executable}")
+          endif()
           ctkAppLauncherAppendExtraAppToLaunchToList(
             LONG_ARG ${executable}
-            HELP "Start ${executable}"
+            HELP ${${executable}_HELP}
             PATH ${${executable}_EXECUTABLE}
             ARGUMENTS ${${executable}_ARGUMENTS}
             OUTPUTVAR extraApplicationToLaunchListForBuildTree


### PR DESCRIPTION
Loading the huge (>600) project Slicer.sln by default is convenient, but unexpected for developers. Also the following problems arise:
1. That solution is so heavy it is barely usable in many cases, so instead it is good practice to load smaller solutions (such as the specific module widgets solution where work is needed)
2. If launching with this switch and specifying another solution (see example below), then the huge Slicer.sln is loaded first, taking a few minutes, and only then the specified one
  .\S4D\Slicer-build\Slicer.exe --VisualStudio --launcher-no-splash --launcher-additional-settings ./SlicerRT_D/inner-build/AdditionalLauncherSettings.ini c:\d\SlicerRT_D\inner-build\SlicerRT.sln

A new command line option VisualStudioProject has been added with the recently updated functionality, and the former VisualStudio switch restored to the original state