### PR TITLE
BUG: getLoadablesFromFileLists was expecting a list of tuples only

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -680,8 +680,8 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
     """
     loadablesByPlugin = {}
     loadEnabled = False
-    if not type(fileLists) is list or len(fileLists)==0 or not type(fileLists[0]) is tuple:
-      logging.error('File lists must contain a non-empty list of tuples')
+    if not type(fileLists) is list or len(fileLists) == 0 or not type(fileLists[0]) in [tuple, list]:
+      logging.error('File lists must contain a non-empty list of tuples/lists')
       return loadablesByPlugin, loadEnabled
 
     allFileCount = missingFileCount = 0


### PR DESCRIPTION
* it could also be a list of lists

Here is a list of tuples produced:
https://github.com/Slicer/Slicer/blob/fce63b47161baecc320672e93b879c0e08d3ed9a/Modules/Scripted/DICOMLib/DICOMWidgets.py#L640-L659

Here is a list of lists produced:
https://github.com/Slicer/Slicer/blob/fce63b47161baecc320672e93b879c0e08d3ed9a/Modules/Scripted/DICOMLib/DICOMWidgets.py#L766-L781