### PR TITLE
COMP: Fix Slicer extension VTK wrapping ensuring availability of hierarchy files

### DIFF
--- a/CMake/SlicerConfig.cmake.in
+++ b/CMake/SlicerConfig.cmake.in
@@ -223,6 +223,9 @@ set(Slicer_VTK_VERSION_MAJOR "@Slicer_VTK_VERSION_MAJOR@")
 # Slicer include directories for module Widget
 @Slicer_INCLUDE_MODULE_WIDGET_DIRS_CONFIG@
 
+# Slicer VTK wrap hierarchy files
+@Slicer_WRAP_HIERARCHY_FILES_CONFIG@
+
 # Slicer Libs include file directories.
 set(Slicer_Libs_INCLUDE_DIRS "@Slicer_Libs_INCLUDE_DIRS_CONFIG@")
 

--- a/CMake/SlicerExtensionConfig.cmake.in
+++ b/CMake/SlicerExtensionConfig.cmake.in
@@ -23,6 +23,9 @@
 # Extension include directories for module Widget
 @EXTENSION_INCLUDE_MODULE_WIDGET_DIRS_CONFIG@
 
+# Extension VTK wrap hierarchy files
+@EXTENSION_WRAP_HIERARCHY_FILES_CONFIG@
+
 # Extension Module logic include file directories.
 set(@EXTENSION_NAME@_ModuleLogic_INCLUDE_DIRS "@EXTENSION_ModuleLogic_INCLUDE_DIRS_CONFIG@"
   CACHE INTERNAL "Extension Module logic includes" FORCE)

--- a/CMake/SlicerExtensionGenerateConfig.cmake
+++ b/CMake/SlicerExtensionGenerateConfig.cmake
@@ -83,6 +83,17 @@ set(${target}_INCLUDE_DIRS
   endforeach()
 endif()
 
+get_property(_wrap_hierarchy_targets GLOBAL PROPERTY SLICER_WRAP_HIERARCHY_TARGETS)
+if(_wrap_hierarchy_targets)
+  foreach(target ${_wrap_hierarchy_targets})
+    set(EXTENSION_WRAP_HIERARCHY_FILES_CONFIG
+"${EXTENSION_WRAP_HIERARCHY_FILES_CONFIG}
+set(${target}_WRAP_HIERARCHY_FILE
+  \"${${target}_WRAP_HIERARCHY_FILE}\")"
+)
+  endforeach()
+endif()
+
 set(EXTENSION_SOURCE_DIR_CONFIG "set(${EXTENSION_NAME}_SOURCE_DIR \"${${EXTENSION_NAME}_SOURCE_DIR}\")")
 
 # Variables that will be used for populating AdditionalLauncherSettings.ini.

--- a/CMake/SlicerGenerateSlicerConfig.cmake
+++ b/CMake/SlicerGenerateSlicerConfig.cmake
@@ -95,6 +95,17 @@ set(${target}_INCLUDE_DIRS
   endforeach()
 endif()
 
+get_property(_wrap_hierarchy_targets GLOBAL PROPERTY SLICER_WRAP_HIERARCHY_TARGETS)
+if(_wrap_hierarchy_targets)
+  foreach(target ${_wrap_hierarchy_targets})
+    set(Slicer_WRAP_HIERARCHY_FILES_CONFIG
+"${Slicer_WRAP_HIERARCHY_FILES_CONFIG}
+set(${target}_WRAP_HIERARCHY_FILE
+  \"${${target}_WRAP_HIERARCHY_FILE}\")"
+)
+  endforeach()
+endif()
+
 set(Slicer_Libs_INCLUDE_DIRS_CONFIG ${Slicer_Libs_INCLUDE_DIRS})
 set(Slicer_Base_INCLUDE_DIRS_CONFIG ${Slicer_Base_INCLUDE_DIRS})
 

--- a/CMake/vtkMacroKitPythonWrap.cmake
+++ b/CMake/vtkMacroKitPythonWrap.cmake
@@ -27,7 +27,9 @@
 # Ignores VTK dependencies.
 macro(_get_dependencies_recurse module_name dep)
   string(REGEX REPLACE "(.+)PythonD\$" "\\1" _dep_base ${dep})
-  list(APPEND _${module_name}_wrap_depends ${_dep_base})
+  if(${_dep_base}_WRAP_HIERARCHY_FILE)
+    list(APPEND _${module_name}_wrap_depends ${_dep_base})
+  endif()
 
   set(_wrap_include_dirs ${${_dep_base}_INCLUDE_DIRS})
   if(_wrap_include_dirs)
@@ -125,6 +127,8 @@ macro(vtkMacroKitPythonWrap)
       set(_wrap_hierarchy_file "${Slicer_BINARY_DIR}/${MY_KIT_NAME}Hierarchy.txt")
       set(_wrap_hierarchy_stamp_file ${CMAKE_CURRENT_BINARY_DIR}/${MY_KIT_NAME}Hierarchy.stamp.txt)
       set(${MY_KIT_NAME}_WRAP_HIERARCHY_FILE "${_wrap_hierarchy_file}" CACHE INTERNAL "${MY_KIT_NAME} wrap hierarchy file" FORCE)
+
+      set_property(GLOBAL APPEND PROPERTY SLICER_WRAP_HIERARCHY_TARGETS ${MY_KIT_NAME})
 
       # Set variables for vtk_wrap_python3:
       #   - KIT_HIERARCHY_FILE


### PR DESCRIPTION
This commit updates the configuration of both Slicer application and Slicer
extension config files so that paths to dependent hierarchy files are
available.

See https://issues.slicer.org/view.php?id=4462