### PR TITLE
ENH: Move edited segmentation to the study of the master volume

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
@@ -327,7 +327,16 @@ public:
   std::vector<vtkIdType> GetItemsReferencedFromItemByDICOM(vtkIdType itemID);
   /// Python compatibility method to get items that are referenced from a given item by DICOM.
   /// \sa GetItemsReferencedFromItemByDICOM
-  void GetItemsReferencedFromItemByDICOM(vtkIdType itemID, vtkIdList* referencedIdList);
+  void GetItemsReferencedFromItemByDICOM(vtkIdType itemID, vtkIdList* referencingIdList);
+
+  /// Get subject hierarchy items that reference a given item by DICOM.
+  /// Finds the series items that contain the SOP instance UID of the item among their
+  /// referenced SOP instance UIDs.
+  /// \sa vtkMRMLSubjectHierarchyConstants::GetDICOMReferencedInstanceUIDsAttributeName()
+  std::vector<vtkIdType> GetItemsReferencingItemByDICOM(vtkIdType itemID);
+  /// Python compatibility method to get items that are referenced from a given item by DICOM.
+  /// \sa GetItemsReferencingItemByDICOM
+  void GetItemsReferencingItemByDICOM(vtkIdType itemID, vtkIdList* referencingIdList);
 
   /// Generate unique item name
   std::string GenerateUniqueItemName(std::string name);


### PR DESCRIPTION
In addition, a feature is added to warn the user about issues with DICOM export. Many users have asked why they could not export a segmentation, and the answer always was that because it was not under a patient+study. A check is now done when clicking Export to DICOM in subject hierarchy, and a warning is shown that briefly describes the issue and the solution if the exported node did not have the proper parents.

Fixes https://issues.slicer.org/view.php?id=4313