### PR TITLE
WIP: Add support for conditionally building with ITKFactoryRegistration

### DIFF
--- a/Applications/SlicerApp/Main.cxx
+++ b/Applications/SlicerApp/Main.cxx
@@ -53,7 +53,9 @@
 #include "qSlicerStyle.h"
 
 // ITK includes
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 // VTK includes
 //#include <vtkObject.h>
@@ -95,7 +97,9 @@ void splashMessage(QScopedPointer<QSplashScreen>& splashScreen, const QString& m
 //----------------------------------------------------------------------------
 int SlicerAppMain(int argc, char* argv[])
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
 #if QT_VERSION >= 0x040803
 #ifdef Q_OS_MACX

--- a/Base/CLI/CMakeLists.txt
+++ b/Base/CLI/CMakeLists.txt
@@ -34,12 +34,23 @@ include_directories(${include_dirs})
 # --------------------------------------------------------------------------
 # Update SlicerExecutionModel_EXTRA_INCLUDE_DIRECTORIES
 # --------------------------------------------------------------------------
-set(SlicerExecutionModel_EXTRA_INCLUDE_DIRECTORIES
+set(_include_dirs
   ${SlicerExecutionModel_EXTRA_INCLUDE_DIRECTORIES}
   ${Slicer_BaseCLI_INCLUDE_DIRS}
-  ${ITKFactoryRegistration_INCLUDE_DIRS}
+  )
+if(Slicer_USE_ITKFactoryRegistration)
+  list(APPEND _include_dirs
+    ${ITKFactoryRegistration_INCLUDE_DIRS}
+    )
+endif()
+set(SlicerExecutionModel_EXTRA_INCLUDE_DIRECTORIES
+  ${_include_dirs}
   CACHE INTERNAL "SlicerExecutionModel extra includes" FORCE
   )
+
+# --------------------------------------------------------------------------
+# Update SlicerExecutionModel_CLI_LIBRARY_WRAPPER_CXX
+# --------------------------------------------------------------------------
 set(SlicerExecutionModel_CLI_LIBRARY_WRAPPER_CXX
   ${CMAKE_CURRENT_BINARY_DIR}/SEMCommandLineLibraryWrapper.cxx
   CACHE INTERNAL "SlicerExecutionModel extra includes" FORCE

--- a/Base/CLI/Testing/itkTestMain.h
+++ b/Base/CLI/Testing/itkTestMain.h
@@ -50,7 +50,14 @@
 #include "itksys/SystemTools.hxx"
 #include "itkIntTypes.h"
 #include "itkFloatingPointExceptions.h"
+
+// Slicer includes
+#include <vtkSlicerConfigure.h> //For Slicer_* macros
+
+// ITK includes
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 #define ITK_TEST_DIMENSION_MAX 6
 
@@ -96,7 +103,9 @@ int main(int ac, char *av[])
   typedef std::pair<char *, char *> ComparePairType;
   std::vector<ComparePairType> compareList;
 
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   RegisterTests();
   std::string testToRun;

--- a/Base/Logic/CMakeLists.txt
+++ b/Base/Logic/CMakeLists.txt
@@ -31,11 +31,13 @@ if(Slicer_BUILD_CLI_SUPPORT)
   list(APPEND ${PROJECT_NAME}_ITK_COMPONENTS ${ModuleDescriptionParser_ITK_COMPONENTS})
 endif()
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-list(APPEND ITK_INCLUDE_DIRS
-  ${ITKFactoryRegistration_INCLUDE_DIRS}
-  )
+if(Slicer_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+  list(APPEND ITK_INCLUDE_DIRS
+    ${ITKFactoryRegistration_INCLUDE_DIRS}
+    )
+endif()
 include(${ITK_USE_FILE})
 
 #

--- a/Base/QTCore/CMakeLists.txt
+++ b/Base/QTCore/CMakeLists.txt
@@ -27,7 +27,9 @@ if(Slicer_BUILD_CLI_SUPPORT)
     ITKCommon
     )
   find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  if(Slicer_USE_ITKFactoryRegistration)
+    set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  endif()
   include(${ITK_USE_FILE})
 endif()
 

--- a/Base/QTGUI/Testing/Cxx/CMakeLists.txt
+++ b/Base/QTGUI/Testing/Cxx/CMakeLists.txt
@@ -10,25 +10,34 @@ if(BUILD_TESTING)
     ITKCommon
     )
   find_package(ITK 4.6 COMPONENTS ${${KIT}Testing_ITK_COMPONENTS} REQUIRED)
-  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-  list(APPEND ITK_INCLUDE_DIRS
-    ${ITKFactoryRegistration_INCLUDE_DIRS}
-    )
+  if(Slicer_USE_ITKFactoryRegistration)
+    set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+    list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+    list(APPEND ITK_INCLUDE_DIRS
+      ${ITKFactoryRegistration_INCLUDE_DIRS}
+      )
+  endif()
   include(${ITK_USE_FILE})
 
   #-----------------------------------------------------------------------------
   set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN  "
     DEBUG_LEAKS_ENABLE_EXIT_ERROR();
     TESTING_OUTPUT_INIT();
-    itk::itkFactoryRegistration();
     ")
+  if(Slicer_USE_ITKFactoryRegistration)
+    set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN  "${CMAKE_TESTDRIVER_BEFORE_TESTMAIN}
+      itk::itkFactoryRegistration();
+      ")
+  endif()
 
   set(CMAKE_TESTDRIVER_AFTER_TESTMAIN  "
     TESTING_OUTPUT_ASSERT_WARNINGS_ERRORS(0);
     ")
 
-  set(EXTRA_INCLUDE "vtkMRMLDebugLeaksMacro.h\"\n\#include <itkConfigure.h>\n\#include <itkFactoryRegistration.h>\n\#include \"vtkTestingOutputWindow.h")
+  set(EXTRA_INCLUDE "vtkMRMLDebugLeaksMacro.h\"\n\#include <itkConfigure.h>\n\#include \"vtkTestingOutputWindow.h")
+  if(Slicer_USE_ITKFactoryRegistration)
+    set(EXTRA_INCLUDE "${EXTRA_INCLUDE}\"\n\#include \"itkFactoryRegistration.h")
+  endif()
 
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
   set(KIT_TEST_SRCS

--- a/CMake/SlicerConfig.cmake.in
+++ b/CMake/SlicerConfig.cmake.in
@@ -112,6 +112,7 @@ endif()
 # --------------------------------------------------------------------------
 # Slicer options
 # --------------------------------------------------------------------------
+set(Slicer_USE_ITKFactoryRegistration "@Slicer_USE_ITKFactoryRegistration@")
 set(Slicer_USE_NUMPY "@Slicer_USE_NUMPY@")
 set(Slicer_USE_OpenIGTLink "@Slicer_USE_OpenIGTLink@")
 set(Slicer_USE_PYTHONQT "@Slicer_USE_PYTHONQT@")

--- a/CMake/UseSlicer.cmake.in
+++ b/CMake/UseSlicer.cmake.in
@@ -114,11 +114,13 @@ endif()
 # Prerequisites
 # --------------------------------------------------------------------------
 
-# Expose mechanism allowing extensions to register ITK IOFactories.
-# For details: http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=21592
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-list(APPEND ITK_INCLUDE_DIRS ${ITKFactoryRegistration_INCLUDE_DIRS})
+if(Slicer_USE_ITKFactoryRegistration)
+  # Expose mechanism allowing extensions to register ITK IOFactories.
+  # For details: http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=21592
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+  list(APPEND ITK_INCLUDE_DIRS ${ITKFactoryRegistration_INCLUDE_DIRS})
+endif()
 
 # By default, the "<PROJECT>_USE_FILE" of each slicer external project will be included.
 # This can be changed by setting the variable Slicer_SKIP_EXTERNAL_PROJECTS_USEFILE to TRUE

--- a/CMake/vtkSlicerConfigure.h.in
+++ b/CMake/vtkSlicerConfigure.h.in
@@ -33,6 +33,7 @@
 #endif
 
 #cmakedefine Slicer_USE_IGSTK
+#cmakedefine Slicer_USE_ITKFactoryRegistration
 #cmakedefine Slicer_USE_NAVITRACK
 #cmakedefine Slicer_USE_NUMPY
 #cmakedefine Slicer_USE_PYTHONQT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,11 @@ CMAKE_DEPENDENT_OPTION(
   "Slicer_BUILD_CLI_SUPPORT" OFF
   )
 
+if(NOT DEFINED Slicer_USE_ITKFactoryRegistration)
+  set(Slicer_USE_ITKFactoryRegistration ${Slicer_BUILD_CLI_SUPPORT})
+endif()
+mark_as_superbuild(Slicer_USE_ITKFactoryRegistration:BOOL)
+
 mark_as_superbuild(Slicer_BUILD_CLI)
 CMAKE_DEPENDENT_OPTION(
   Slicer_BUILD_LEGACY_CLI "Build Slicer LEGACY_CLI Plugins" ON

--- a/Libs/CMakeLists.txt
+++ b/Libs/CMakeLists.txt
@@ -11,13 +11,15 @@ set(GENERATECLP_USE_MD5 ON)
 
 set(dirs )
 
-list(APPEND dirs
-  ITKFactoryRegistration
-  )
-set(SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES
-  ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES} ITKFactoryRegistration
-  CACHE INTERNAL "SlicerExecutionModel extra executable target libraries" FORCE
-  )
+if(Slicer_USE_ITKFactoryRegistration)
+  list(APPEND dirs
+    ITKFactoryRegistration
+    )
+  set(SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES
+    ${SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES} ITKFactoryRegistration
+    CACHE INTERNAL "SlicerExecutionModel extra executable target libraries" FORCE
+    )
+endif()
 
 list(APPEND dirs
   vtkAddon

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -46,9 +46,11 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKTransform
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-list(APPEND ITK_INCLUDE_DIRS ${ITKFactoryRegistration_INCLUDE_DIRS})
+if(Slicer_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+  list(APPEND ITK_INCLUDE_DIRS ${ITKFactoryRegistration_INCLUDE_DIRS})
+endif()
 include(${ITK_USE_FILE})
 
 #

--- a/Libs/MRML/Core/Testing/vtkMRMLNonlinearTransformNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLNonlinearTransformNodeTest1.cxx
@@ -10,9 +10,13 @@
 
 =========================================================================auto=*/
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 #include "vtkOrientedBSplineTransform.h"
 #include "vtkOrientedGridTransform.h"
@@ -40,7 +44,9 @@ int TestGetTransform();
 
 int vtkMRMLNonlinearTransformNodeTest1(int argc, char * argv[] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   const char *filename = 0;
   if (argc > 1)

--- a/Libs/MRML/IDImageIO/CMakeLists.txt
+++ b/Libs/MRML/IDImageIO/CMakeLists.txt
@@ -24,9 +24,11 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKIOImageBase
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-list(APPEND ITK_INCLUDE_DIRS ${ITKFactoryRegistration_INCLUDE_DIRS})
+if(Slicer_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+  list(APPEND ITK_INCLUDE_DIRS ${ITKFactoryRegistration_INCLUDE_DIRS})
+endif()
 include(${ITK_USE_FILE})
 
 #

--- a/Libs/MRML/Logic/Testing/Cxx/CMakeLists.txt
+++ b/Libs/MRML/Logic/Testing/Cxx/CMakeLists.txt
@@ -5,11 +5,13 @@ set(${KIT}Testing_ITK_COMPONENTS
   ITKCommon
   )
 find_package(ITK 4.6 COMPONENTS ${${KIT}Testing_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-list(APPEND ITK_INCLUDE_DIRS
-  ${ITKFactoryRegistration_INCLUDE_DIRS}
-  )
+if(Slicer_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+  list(APPEND ITK_INCLUDE_DIRS
+    ${ITKFactoryRegistration_INCLUDE_DIRS}
+    )
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest2.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest2.cxx
@@ -46,14 +46,20 @@
 #include <vtkTimerLog.h>
 #include <vtkVersion.h>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 int vtkMRMLSliceLogicTest2(int argc, char * argv [] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 //  vtkMultiThreader::SetGlobalMaximumNumberOfThreads(1);
 
   if( argc < 2 )

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest3.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest3.cxx
@@ -38,9 +38,13 @@
 #include <vtkTimerLog.h>
 #include <vtkVersion.h>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode* loadVolume(const char* volume, vtkMRMLScene* scene)
@@ -81,7 +85,9 @@ vtkMRMLScalarVolumeNode* loadVolume(const char* volume, vtkMRMLScene* scene)
 //-----------------------------------------------------------------------------
 int vtkMRMLSliceLogicTest3(int argc, char * argv [] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   if( argc < 2 )
     {

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest4.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest4.cxx
@@ -35,9 +35,13 @@
 #include <vtkNew.h>
 #include <vtkVersion.h>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode* loadVolume2(const char* volume, vtkMRMLScene* scene)
@@ -79,7 +83,9 @@ vtkMRMLScalarVolumeNode* loadVolume2(const char* volume, vtkMRMLScene* scene)
 //-----------------------------------------------------------------------------
 int vtkMRMLSliceLogicTest4(int argc, char * argv [] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   if( argc < 2 )
     {

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest5.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLSliceLogicTest5.cxx
@@ -39,9 +39,13 @@
 #include <vtkTimerLog.h>
 #include <vtkVersion.h>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode* vtkMRMLSliceLogicTest5_loadVolume(const char* volume, vtkMRMLScene* scene)
@@ -83,7 +87,9 @@ vtkMRMLScalarVolumeNode* vtkMRMLSliceLogicTest5_loadVolume(const char* volume, v
 //-----------------------------------------------------------------------------
 int vtkMRMLSliceLogicTest5(int argc, char * argv [] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   if( argc < 2 )
     {

--- a/Libs/MRML/Widgets/Testing/CMakeLists.txt
+++ b/Libs/MRML/Widgets/Testing/CMakeLists.txt
@@ -5,18 +5,24 @@ set(${KIT}Testing_ITK_COMPONENTS
   ITKCommon
   )
 find_package(ITK 4.6 COMPONENTS ${${KIT}Testing_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-list(APPEND ITK_INCLUDE_DIRS
-  ${ITKFactoryRegistration_INCLUDE_DIRS}
-  )
+if(Slicer_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+  list(APPEND ITK_INCLUDE_DIRS
+    ${ITKFactoryRegistration_INCLUDE_DIRS}
+    )
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------
 set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN  "
   TESTING_OUTPUT_INIT();
-  itk::itkFactoryRegistration();
   ")
+if(Slicer_USE_ITKFactoryRegistration)
+  set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN  "${CMAKE_TESTDRIVER_BEFORE_TESTMAIN}
+    itk::itkFactoryRegistration();
+    ")
+endif()
 
 set(CMAKE_TESTDRIVER_AFTER_TESTMAIN  "
   TESTING_OUTPUT_ASSERT_WARNINGS_ERRORS(0);

--- a/Libs/MRML/Widgets/Testing/qMRMLWidgetCxxTests.h
+++ b/Libs/MRML/Widgets/Testing/qMRMLWidgetCxxTests.h
@@ -24,8 +24,12 @@
 #include <vtkTestingOutputWindow.h>
 #include <vtkNew.h>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> //For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 #endif

--- a/Libs/vtkITK/CMakeLists.txt
+++ b/Libs/vtkITK/CMakeLists.txt
@@ -45,11 +45,17 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKRegionGrowing
   ITKThresholding
   ITKVTK
+  # IO explicitly used in the project
+  ITKIOMeta
+  ITKIONIFTI
+  ITKIONRRD
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-list(APPEND ITK_INCLUDE_DIRS ${ITKFactoryRegistration_INCLUDE_DIRS})
+if(Slicer_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+  list(APPEND ITK_INCLUDE_DIRS ${ITKFactoryRegistration_INCLUDE_DIRS})
+endif()
 include(${ITK_USE_FILE})
 
 # --------------------------------------------------------------------------

--- a/Libs/vtkITK/Testing/VTKITKVectorReader.cxx
+++ b/Libs/vtkITK/Testing/VTKITKVectorReader.cxx
@@ -4,13 +4,19 @@
 // VTK includes
 #include <vtkImageData.h>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> //For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 int main(int argc, char *argv[])
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   if (argc < 2)
     {

--- a/Modules/CLI/AddScalarVolumes/CMakeLists.txt
+++ b/Modules/CLI/AddScalarVolumes/CMakeLists.txt
@@ -20,7 +20,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageIntensity
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/BlobDetection/CMakeLists.txt
+++ b/Modules/CLI/BlobDetection/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKReview
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/CastScalarVolume/CMakeLists.txt
+++ b/Modules/CLI/CastScalarVolume/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageFilterBase
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/CheckerBoardFilter/CMakeLists.txt
+++ b/Modules/CLI/CheckerBoardFilter/CMakeLists.txt
@@ -19,7 +19,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageGrid
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/ConnectedComponent/CMakeLists.txt
+++ b/Modules/CLI/ConnectedComponent/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKIOImageBase
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/CreateDICOMSeries/CMakeLists.txt
+++ b/Modules/CLI/CreateDICOMSeries/CMakeLists.txt
@@ -20,7 +20,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageIntensity
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/CurvatureAnisotropicDiffusion/CMakeLists.txt
+++ b/Modules/CLI/CurvatureAnisotropicDiffusion/CMakeLists.txt
@@ -19,7 +19,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageFilterBase
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/DiffusionTensorTest/CMakeLists.txt
+++ b/Modules/CLI/DiffusionTensorTest/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKIOImageBase
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/ExpertAutomatedRegistration/CMakeLists.txt
+++ b/Modules/CLI/ExpertAutomatedRegistration/CMakeLists.txt
@@ -28,7 +28,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKTransform
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/ExpertAutomatedRegistration/Testing/CMakeLists.txt
+++ b/Modules/CLI/ExpertAutomatedRegistration/Testing/CMakeLists.txt
@@ -24,7 +24,7 @@ add_test(NAME ${testname} COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:Generate${
   )
 set_property(TEST ${testname} PROPERTY LABELS ${CLP})
 
-
+ 
 set(testname ${CLP}TestDataRigidArgs)
 add_test(NAME ${testname} COMMAND ${SEM_LAUNCH_COMMAND} $<TARGET_FILE:Generate${CLP}TestData>
   ${frequency} ${TEMP}/${CLP}RigidArgs.mha -p 2 4 6 -o 0.02 0.04 0.06

--- a/Modules/CLI/ExpertAutomatedRegistration/Testing/GenerateExpertAutomatedRegistrationTestData.cxx
+++ b/Modules/CLI/ExpertAutomatedRegistration/Testing/GenerateExpertAutomatedRegistrationTestData.cxx
@@ -8,7 +8,14 @@
 #include <itkResampleImageFilter.h>
 #include <itkTransformFactory.h>
 #include <itkTransformFileReader.h>
+
+// SlicerExecutionModel includes
+#include <SEMConfigure.h>
+
+// ITK includes
+#ifdef SlicerExecutionModel_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 // STD includes
 #include <list>
@@ -19,7 +26,9 @@
 
 int main(int argc, char * * argv)
 {
+#ifdef SlicerExecutionModel_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   if( argc < 3 )
     {

--- a/Modules/CLI/ExtractSkeleton/CMakeLists.txt
+++ b/Modules/CLI/ExtractSkeleton/CMakeLists.txt
@@ -17,7 +17,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKIOImageBase
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/FiducialRegistration/CMakeLists.txt
+++ b/Modules/CLI/FiducialRegistration/CMakeLists.txt
@@ -19,7 +19,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKTransform
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/GaussianBlurImageFilter/CMakeLists.txt
+++ b/Modules/CLI/GaussianBlurImageFilter/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKSmoothing
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/GradientAnisotropicDiffusion/CMakeLists.txt
+++ b/Modules/CLI/GradientAnisotropicDiffusion/CMakeLists.txt
@@ -19,7 +19,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageFilterBase
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/GrayscaleFillHoleImageFilter/CMakeLists.txt
+++ b/Modules/CLI/GrayscaleFillHoleImageFilter/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKMathematicalMorphology
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/GrayscaleGrindPeakImageFilter/CMakeLists.txt
+++ b/Modules/CLI/GrayscaleGrindPeakImageFilter/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKMathematicalMorphology
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/HistogramMatching/CMakeLists.txt
+++ b/Modules/CLI/HistogramMatching/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageIntensity
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/ImageLabelCombine/CMakeLists.txt
+++ b/Modules/CLI/ImageLabelCombine/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKIOImageBase
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/LabelMapSmoothing/CMakeLists.txt
+++ b/Modules/CLI/LabelMapSmoothing/CMakeLists.txt
@@ -22,7 +22,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKThresholding
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/MaskScalarVolume/CMakeLists.txt
+++ b/Modules/CLI/MaskScalarVolume/CMakeLists.txt
@@ -21,7 +21,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKThresholding
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/MedianImageFilter/CMakeLists.txt
+++ b/Modules/CLI/MedianImageFilter/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKSmoothing
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/ModelToLabelMap/CMakeLists.txt
+++ b/Modules/CLI/ModelToLabelMap/CMakeLists.txt
@@ -21,7 +21,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKMathematicalMorphology
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/MultiplyScalarVolumes/CMakeLists.txt
+++ b/Modules/CLI/MultiplyScalarVolumes/CMakeLists.txt
@@ -19,7 +19,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageGrid
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/N4ITKBiasFieldCorrection/CMakeLists.txt
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/CMakeLists.txt
@@ -22,7 +22,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKThresholding
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/OrientScalarVolume/CMakeLists.txt
+++ b/Modules/CLI/OrientScalarVolume/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageGrid
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/PETStandardUptakeValueComputation/CMakeLists.txt
+++ b/Modules/CLI/PETStandardUptakeValueComputation/CMakeLists.txt
@@ -26,7 +26,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ${ModuleDescriptionParser_ITK_COMPONENTS}
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/ResampleDTIVolume/CMakeLists.txt
+++ b/Modules/CLI/ResampleDTIVolume/CMakeLists.txt
@@ -29,7 +29,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ${ModuleDescriptionParser_ITK_COMPONENTS}
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 

--- a/Modules/CLI/ResampleDTIVolume/Testing/itkTestMainExtended.h
+++ b/Modules/CLI/ResampleDTIVolume/Testing/itkTestMainExtended.h
@@ -55,7 +55,14 @@
 #include "itkFloatingPointExceptions.h"
 #include <itkTensorFractionalAnisotropyImageFilter.h>
 #include "itkPluginUtilities.h"
+
+// SlicerExecutionModel includes
+#include <SEMConfigure.h>
+
+// ITK includes
+#ifdef SlicerExecutionModel_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 #define ITK_TEST_DIMENSION_MAX 6
 
@@ -101,7 +108,9 @@ int main(int ac, char* av[] )
   typedef std::pair<char *, char *> ComparePairType;
   std::vector<ComparePairType> compareList;
 
+#ifdef SlicerExecutionModel_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   RegisterTests();
   std::string testToRun;

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/CMakeLists.txt
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/CMakeLists.txt
@@ -22,7 +22,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKTransform
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/ResampleScalarVolume/CMakeLists.txt
+++ b/Modules/CLI/ResampleScalarVolume/CMakeLists.txt
@@ -19,7 +19,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageGrid
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/RobustStatisticsSegmenter/CMakeLists.txt
+++ b/Modules/CLI/RobustStatisticsSegmenter/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKIOImageBase
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/RobustStatisticsSegmenter/Testing/SFLSRobustStat3DTestConsole.cxx
+++ b/Modules/CLI/RobustStatisticsSegmenter/Testing/SFLSRobustStat3DTestConsole.cxx
@@ -6,9 +6,13 @@
 #include <itkImageFileReader.h>
 #include <itkImageFileWriter.h>
 
+// SlicerExecutionModel includes
+#include <SEMConfigure.h>
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef SlicerExecutionModel_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 
 #include "labelMapPreprocessor.h"
@@ -19,7 +23,9 @@ getFinalMask(typename itk::Image<TPixel, 3>::Pointer img, unsigned char l, TPixe
 
 int main(int argc, char* * argv)
 {
+#ifdef SlicerExecutionModel_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   if( argc != 7 )
     {

--- a/Modules/CLI/SimpleRegionGrowingSegmentation/CMakeLists.txt
+++ b/Modules/CLI/SimpleRegionGrowingSegmentation/CMakeLists.txt
@@ -20,7 +20,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKRegionGrowing
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/SubtractScalarVolumes/CMakeLists.txt
+++ b/Modules/CLI/SubtractScalarVolumes/CMakeLists.txt
@@ -20,7 +20,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageIntensity
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/TestGridTransformRegistration/CMakeLists.txt
+++ b/Modules/CLI/TestGridTransformRegistration/CMakeLists.txt
@@ -19,7 +19,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKImageGrid
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/ThresholdScalarVolume/CMakeLists.txt
+++ b/Modules/CLI/ThresholdScalarVolume/CMakeLists.txt
@@ -20,7 +20,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKThresholding
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/CLI/VotingBinaryHoleFillingImageFilter/CMakeLists.txt
+++ b/Modules/CLI/VotingBinaryHoleFillingImageFilter/CMakeLists.txt
@@ -18,7 +18,9 @@ set(${PROJECT_NAME}_ITK_COMPONENTS
   ITKLabelVoting
   )
 find_package(ITK 4.6 COMPONENTS ${${PROJECT_NAME}_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+if(SlicerExecutionModel_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/Testing/Cxx/qSlicerMarkupsModuleWidgetsCxxTests.h
+++ b/Modules/Loadable/Markups/Widgets/Testing/Cxx/qSlicerMarkupsModuleWidgetsCxxTests.h
@@ -24,8 +24,12 @@
 #include <vtkTestingOutputWindow.h>
 #include <vtkNew.h>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 #endif

--- a/Modules/Loadable/Tables/Widgets/Testing/Cxx/qSlicerTablesModuleWidgetsCxxTests.h
+++ b/Modules/Loadable/Tables/Widgets/Testing/Cxx/qSlicerTablesModuleWidgetsCxxTests.h
@@ -24,8 +24,12 @@
 #include <vtkTestingOutputWindow.h>
 #include <vtkNew.h>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 #endif

--- a/Modules/Loadable/Transforms/Logic/Testing/Cxx/vtkSlicerTransformLogicTest1.cxx
+++ b/Modules/Loadable/Transforms/Logic/Testing/Cxx/vtkSlicerTransformLogicTest1.cxx
@@ -15,14 +15,20 @@
 // MRML includes
 #include "vtkMRMLScene.h"
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 int vtkSlicerTransformLogicTest1(int argc, char * argv [])
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   if(argc < 2)
     {

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt
@@ -9,11 +9,13 @@ set(${KIT}Testing_ITK_COMPONENTS
   ITKCommon
   )
 find_package(ITK 4.6 COMPONENTS ${${KIT}Testing_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-list(APPEND ITK_INCLUDE_DIRS
-  ${ITKFactoryRegistration_INCLUDE_DIRS}
-  )
+if(Slicer_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+  list(APPEND ITK_INCLUDE_DIRS
+    ${ITKFactoryRegistration_INCLUDE_DIRS}
+    )
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest2.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest2.cxx
@@ -23,7 +23,7 @@
 
 // Slicer includes
 #include <qSlicerApplication.h>
-#include "vtkSlicerConfigure.h"
+#include "vtkSlicerConfigure.h" // For Slicer_* macros
 
 // VolumeRendering includes
 #include "qSlicerVolumeRenderingModule.h"
@@ -42,13 +42,16 @@
 #endif
 
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 int qSlicerVolumeRenderingModuleWidgetTest2( int argc, char * argv[] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
   // Set default surface format for QVTKOpenGLWidget

--- a/Modules/Loadable/Volumes/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/Testing/Cxx/CMakeLists.txt
@@ -9,11 +9,13 @@ set(${KIT}Testing_ITK_COMPONENTS
   ITKCommon
   )
 find_package(ITK 4.6 COMPONENTS ${${KIT}Testing_ITK_COMPONENTS} REQUIRED)
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
-list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
-list(APPEND ITK_INCLUDE_DIRS
-  ${ITKFactoryRegistration_INCLUDE_DIRS}
-  )
+if(Slicer_USE_ITKFactoryRegistration)
+  set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1) # See Libs/ITKFactoryRegistration/CMakeLists.txt
+  list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
+  list(APPEND ITK_INCLUDE_DIRS
+    ${ITKFactoryRegistration_INCLUDE_DIRS}
+    )
+endif()
 include(${ITK_USE_FILE})
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesModuleWidgetTest1.cxx
@@ -23,7 +23,7 @@
 #include <QWidget>
 
 // Slicer includes
-#include "vtkSlicerConfigure.h"
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
 
 // SlicerQt includes
 #include <qSlicerAbstractModuleRepresentation.h>
@@ -40,13 +40,16 @@
 #endif
 
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 int qSlicerVolumesModuleWidgetTest1( int argc, char * argv[] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
   // Set default surface format for QVTKOpenGLWidget

--- a/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
@@ -40,9 +40,13 @@
 #include <vtkNew.h>
 #include <vtkTrivialProducer.h>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 bool isImageDataValid(int line, vtkAlgorithmOutput* imageDataConnection);
@@ -60,7 +64,9 @@ int TestCloneVolume( vtkMRMLScalarVolumeNode* scalarVolume,
 //-----------------------------------------------------------------------------
 int vtkSlicerVolumesLogicTest1( int argc, char * argv[] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   vtkNew<vtkMRMLScene> scene;
   vtkNew<vtkSlicerVolumesLogic> logic;

--- a/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest2.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest2.cxx
@@ -45,9 +45,13 @@
 #include <vector>
 #include <string>
 
+// Slicer includes
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
+
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 bool isImageDataValid(vtkAlgorithmOutput* imageDataConnection)
@@ -79,7 +83,9 @@ bool isImageDataValid(vtkAlgorithmOutput* imageDataConnection)
 //-----------------------------------------------------------------------------
 int main( int argc, char * argv[] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
   if(argc<2)
     {

--- a/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest2.cxx
+++ b/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest2.cxx
@@ -23,7 +23,7 @@
 #include <QTimer>
 
 // Slicer includes
-#include "vtkSlicerConfigure.h"
+#include <vtkSlicerConfigure.h> // For Slicer_* macros
 
 // Volumes includes
 #include "qSlicerDTISliceDisplayWidget.h"
@@ -43,13 +43,16 @@
 #endif
 
 // ITK includes
-#include <itkConfigure.h>
+#ifdef Slicer_USE_ITKFactoryRegistration
 #include <itkFactoryRegistration.h>
+#endif
 
 //-----------------------------------------------------------------------------
 int qSlicerDTISliceDisplayWidgetTest2( int argc, char * argv[] )
 {
+#ifdef Slicer_USE_ITKFactoryRegistration
   itk::itkFactoryRegistration();
+#endif
 
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
   // Set default surface format for QVTKOpenGLWidget

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -81,7 +81,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "1d3e9a226bd594f23733993c16c337ba60077bc5"
+    "edfcb22353cfc5a232b180b5039cb9363e697a49"
     QUIET
     )
 
@@ -104,6 +104,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
       -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
       -DBUILD_TESTING:BOOL=OFF
       -DITK_DIR:PATH=${ITK_DIR}
+      -DSlicerExecutionModel_USE_ITKFactoryRegistration:BOOL=${Slicer_USE_ITKFactoryRegistration}
       -DSlicerExecutionModel_USE_SERIALIZER:BOOL=${Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT}
       -DSlicerExecutionModel_USE_JSONCPP:BOOL=${Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT}
       -DSlicerExecutionModel_LIBRARY_PROPERTIES:STRING=${Slicer_LIBRARY_PROPERTIES}


### PR DESCRIPTION
This commit is **NOT** ready for integration or review.

This commit introduces option  Slicer_USE_ITKFactoryRegistration allowing
to conditionally build with ITKFactoryRegistration. Since latest version
of ITK is expected to address IOFactory issues originally fixed by
introducing ITKFactoryRegistration library, this new option will allow
to easily build Slicer and test that it effectively works without it.

List of SlicerExecutionModel changes:

$ git shortlog 1d3e9a2..edfcb22 --no-merges
Andrey Fedorov (1):
      ENH: add pointer to the wiki documentation

Jean-Christophe Fillion-Robin (1):
      COMP: Add SEMConfigure.h and update config with SlicerExecutionModel_USE_ITKFactoryRegistration