### PR TITLE
BUG: Added Latin1 encoding specification to saved MRML file

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -989,14 +989,18 @@ int vtkMRMLScene::Commit(const char* url)
 
   int indent=0;
 
-    // this event is being detected by GUI to provide feedback during load
-    // of data. But,
-    // commented out for now because CLI modules are using MRML to write
-    // data in another thread, causing GUI to crash.
-//  this->InvokeEvent (vtkMRMLScene::SaveProgressFeedbackEvent );
+  // this event is being detected by GUI to provide feedback during load
+  // of data. But, commented out for now because CLI modules are using MRML
+  // to write data in another thread, causing GUI to crash.
+  //this->InvokeEvent (vtkMRMLScene::SaveProgressFeedbackEvent );
 
   //file << "<?xml version=\"1.0\" standalone='no'?>\n";
   //file << "<!DOCTYPE MRML SYSTEM \"mrml20.dtd\">\n";
+
+  // Add XML encoding specification. Since Slicer uses the Latin1 (ISO-8859-1) character set,
+  // but the MRML file did not specify it, the extra characters made XML loading fail with
+  // characters in the file that are valid for Slicer.
+  *os << "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n";
 
   //--- BEGIN test of user tags
   //file << "<MRML>\n";

--- a/Libs/MRML/DisplayableManager/Testing/Data/vtkMRMLCameraDisplayableManagerTest1.mrml
+++ b/Libs/MRML/DisplayableManager/Testing/Data/vtkMRMLCameraDisplayableManagerTest1.mrml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
 <MRML  version="Slicer4.4.0" >
 <Selection
   id="vtkMRMLSelectionNodeSingleton" name="Selection" hideFromEditors="true" selectable="true" selected="false" singletonTag="Singleton" activeVolumeID="NULL" secondaryVolumeID="NULL" activeLabelVolumeID="NULL" activeFiducialListID="NULL" activePlaceNodeID="NULL" activePlaceNodeClassName="NULL" activeROIListID="NULL" activeCameraID="NULL" activeTableID="NULL" activeViewID="NULL" activeLayoutID="NULL" activePlotChartID="NULL"></Selection>

--- a/Testing/Data/Input/ExecutionModelTourTest.mrml
+++ b/Testing/Data/Input/ExecutionModelTourTest.mrml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
 <MRML  version="Slicer4.4.0" >
 <LinearTransform
   id="vtkMRMLLinearTransformNode1" name="vtkMRMLLinearTransformNode1" hideFromEditors="false" selectable="true" selected="false" userTags="" matrixTransformToParent="1 0 0 0  0 1 0 0  0 0 1 0  0 0 0 1"></LinearTransform>


### PR DESCRIPTION
In case special characters (e.g. in the patient name) ended up being saved in the MRML file, loading the MRML failed due to an XML reading error. These special characters were valid in Slicer, as they were produced by slicer.util.toVTKString. If the character set is specified in the MRML file, then loading is successful.