### PR TITLE
COMP: don't exclude Qt as system library when packaging

### DIFF
--- a/CMake/GetPrerequisitesWithRPath.cmake
+++ b/CMake/GetPrerequisitesWithRPath.cmake
@@ -537,7 +537,9 @@ function(gp_resolved_file_type original_file file exepath dirs type_var)
     endif()
 
     if(APPLE)
-      if(resolved_file MATCHES "^(/System/Library/|/usr/lib/|/opt/X11/)")
+      if(resolved_file MATCHES "^.*Qt.*framework")
+        #pass: we need to package Qt
+      elseif(resolved_file MATCHES "^(/System/Library/|/usr/lib/|/opt/X11/)")
         set(is_system 1)
       endif()
     endif()


### PR DESCRIPTION
This allows to package Qt from e.g. Homebrew in a local build, even though it lives in `/usr/local/lib/...`.