### PR TITLE
BUG: fix crash in CTK on bad scalar range

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -74,7 +74,7 @@ if(NOT DEFINED CTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "1e13d9806ae3dca9603c0d5e6e41181c74fc208e"
+    "71799c27da506c899f2ef04b50cd8d454374870d"
     QUIET
     )
 


### PR DESCRIPTION
This bug fix should be merged into Slicer but it's not urgent.  There are a few other prior commits about color transfer widget have been verified (I haven't looked at those).  If anyone knows those are okay then this update to CTK should be merged.


https://github.com/commontk/CTK/pull/779

https://discourse.slicer.org/t/crash-when-using-volumes-module-on-windows-7-after-4-9-version/1711