### PR TITLE
Add ::retrieveExtensionMetadataByName; update DMRIInstall helper

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -1126,6 +1126,26 @@ qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerMod
 }
 
 // --------------------------------------------------------------------------
+qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerModel
+::retrieveExtensionMetadataByName(const QString& extensionName)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  if (extensionName.isEmpty())
+    {
+    return ExtensionMetadataType();
+    }
+
+  qMidasAPI::ParametersType parameters;
+  parameters["productname"] = extensionName;
+  parameters["slicer_revision"] = this->slicerRevision();
+  parameters["os"] = this->slicerOs();
+  parameters["arch"] = this->slicerArch();
+
+  return d->retrieveExtensionMetadata(parameters);
+}
+
+// --------------------------------------------------------------------------
 qSlicerExtensionDownloadTask*
 qSlicerExtensionsManagerModelPrivate::downloadExtension(
   const QString& extensionId)

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -177,6 +177,10 @@ public:
   /// \sa setServerUrl
   Q_INVOKABLE ExtensionMetadataType retrieveExtensionMetadata(const QString& extensionId);
 
+  /// \brief Query the extension server and retrieve the metadata associated with \a extensionName
+  /// \sa setServerUrl
+  Q_INVOKABLE ExtensionMetadataType retrieveExtensionMetadataByName(const QString& extensionName);
+
   /// Install extension from the specified archive file.
   ///
   /// This attempts to install an extension given only the archive file


### PR DESCRIPTION
- 2e2fcef adds a utility function `qSlicerExtensionsManagerModel::retrieveExtensionMetadataByName`
- dcc57af uses this utility to query metadata, by name, from Python and then run an installer task directly (plus other misc updates).