### PR TITLE
ENH: Add Restore Tab to the extension manager widget

### DIFF
--- a/Applications/SlicerApp/qSlicerAppMainWindow.cxx
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.cxx
@@ -1165,6 +1165,7 @@ void qSlicerAppMainWindow::showEvent(QShowEvent *event)
     d->WindowInitialShowCompleted = true;
     this->disclaimer();
     this->pythonConsoleInitialDisplay();
+    qSlicerApplication::application()->gatherExtensionsHistoryInformationOnStartup();
     emit initialWindowShown();
     }
 }

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -355,6 +355,7 @@ void qSlicerCoreApplicationPrivate::init()
 
   qSlicerExtensionsManagerModel * model = new qSlicerExtensionsManagerModel(q);
   model->setExtensionsSettingsFilePath(q->slicerRevisionUserSettingsFilePath());
+  model->setExtensionsHistorySettingsFilePath(q->slicerUserSettingsFilePath());
   model->setSlicerRequirements(q->repositoryRevision(), q->os(), q->arch());
   q->setExtensionsManagerModel(model);
 
@@ -1251,6 +1252,12 @@ void qSlicerCoreApplication::setExtensionsInstallPath(const QString& path)
   Q_ASSERT(this->extensionsManagerModel());
   this->extensionsManagerModel()->updateModel();
 #endif
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerCoreApplication::gatherExtensionsHistoryInformationOnStartup()
+{
+  this->extensionsManagerModel()->gatherExtensionsHistoryInformationOnStartup();
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -244,6 +244,8 @@ public:
   /// Set slicer extension directory
   void setExtensionsInstallPath(const QString& path);
 
+  void gatherExtensionsHistoryInformationOnStartup();
+
   /// If any, this method return the build intermediate directory
   /// See $(IntDir) on http://msdn.microsoft.com/en-us/library/c02as0cs%28VS.71%29.aspx
   QString intDir()const;

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -30,6 +30,7 @@
 #include <QTemporaryFile>
 #include <QTextStream>
 #include <QUrl>
+
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include <QUrlQuery>
 #endif
@@ -219,6 +220,14 @@ public:
       const QString& slicerOs, const QString& slicerArch);
 
   void saveExtensionDescription(const QString& extensionDescriptionFile, const ExtensionMetadataType &allExtensionMetadata);
+  void saveExtensionToHistorySettings(const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata);
+  void scheduleExtensionHistorySettingRemoval(const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata);
+  void addExtensionHistorySetting(const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata, const QString& settingsPath);
+  void cancelExtensionHistorySettingRemoval(const QString& extensionsHistorySettingsFile, const QString& extensionName);
+  void removeScheduledExtensionHistorySettings(const QString& extensionsHistorySettingsFile);
+  QVariantMap getExtensionsInfoFromPreviousInstallations(const QString& extensionsHistorySettingsFile);
+  void gatherExtensionsHistoryInformationOnStartup();
+
 
   qSlicerExtensionsManagerModel::ExtensionMetadataType retrieveExtensionMetadata(
     const qMidasAPI::ParametersType& parameters);
@@ -236,6 +245,7 @@ public:
   QHash<QString, UpdateDownloadInformation> AvailableUpdates;
 
   QString ExtensionsSettingsFilePath;
+  QString ExtensionsHistorySettingsFilePath;
 
   QString SlicerRevision;
   QString SlicerOs;
@@ -514,7 +524,7 @@ void qSlicerExtensionsManagerModelPrivate::addExtensionPathToLauncherSettings(co
   QSettings settings(this->ExtensionsSettingsFilePath, QSettings::IniFormat);
   if (settings.status() != QSettings::NoError)
     {
-    this->warning(QString("Failed to open extensions settings file %1").arg(this->ExtensionsSettingsFilePath));
+    this->warning(QObject::tr("Failed to open extensions settings file %1").arg(this->ExtensionsSettingsFilePath));
     return;
     }
 
@@ -545,7 +555,7 @@ void qSlicerExtensionsManagerModelPrivate::removeExtensionPathFromLauncherSettin
   QSettings settings(this->ExtensionsSettingsFilePath, QSettings::IniFormat);
   if (settings.status() != QSettings::NoError)
     {
-    this->warning(QString("Failed to open extensions settings file: %1").arg(this->ExtensionsSettingsFilePath));
+    this->warning(QObject::tr("Failed to open extensions settings file: %1").arg(this->ExtensionsSettingsFilePath));
     return;
     }
 
@@ -576,7 +586,7 @@ bool qSlicerExtensionsManagerModelPrivate::checkExtensionsInstallDestinationPath
 {
   if (!QDir(destinationPath).exists())
     {
-    error = QString("Extensions install directory does NOT exist: <strong>%1</strong>").arg(destinationPath);
+    error = QObject::tr("Extensions install directory does NOT exist: <strong>%1</strong>").arg(destinationPath);
     return false;
     }
 
@@ -593,8 +603,8 @@ bool qSlicerExtensionsManagerModelPrivate::checkExtensionsInstallDestinationPath
       || !destinationPathInfo.isWritable()
       || !destinationPathInfo.isExecutable())
     {
-    error = QString("Extensions install directory is expected to be "
-                    "readable/writable/executable: <strong>%1</strong>").arg(destinationPath);
+    error = QObject::tr("Extensions install directory is expected to be "
+                        "readable/writable/executable: <strong>%1</strong>").arg(destinationPath);
     return false;
     }
 
@@ -810,6 +820,137 @@ void qSlicerExtensionsManagerModelPrivate::saveExtensionDescription(
 //    }
 
   qSlicerExtensionsManagerModel::writeExtensionDescriptionFile(extensionDescriptionFile, allExtensionMetadata);
+}
+
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelPrivate::saveExtensionToHistorySettings(
+  const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata)
+{
+  this->addExtensionHistorySetting(extensionsHistorySettingsFile, extensionMetadata, "ExtensionsHistory/Revisions/" + this->SlicerRevision);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelPrivate::scheduleExtensionHistorySettingRemoval(
+  const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata)
+{
+  this->addExtensionHistorySetting(extensionsHistorySettingsFile, extensionMetadata, "ExtensionsHistory/ScheduledForRemoval");
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelPrivate::addExtensionHistorySetting(
+  const QString& extensionsHistorySettingsFile, const ExtensionMetadataType &extensionMetadata, const QString& settingsPath)
+{
+  QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
+  QStringList settingsInfoList = settings.value(settingsPath).toStringList();
+  settingsInfoList << extensionMetadata.value("extensionname").toString();
+  settingsInfoList.removeDuplicates();
+  settings.setValue(settingsPath, settingsInfoList);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelPrivate::cancelExtensionHistorySettingRemoval(
+  const QString& extensionsHistorySettingsFile, const QString& extensionName)
+{
+  QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
+  QStringList settingsInfoList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
+  settingsInfoList.removeOne(extensionName);
+  settingsInfoList.removeDuplicates();
+  settings.setValue("ExtensionsHistory/ScheduledForRemoval", settingsInfoList);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelPrivate::removeScheduledExtensionHistorySettings(
+  const QString& extensionsHistorySettingsFile)
+{
+  QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
+  QStringList scheduledForRemovalList = settings.value("ExtensionsHistory/ScheduledForRemoval").toStringList();
+  QStringList historyList = settings.value("ExtensionsHistory/Revisions/" + this->SlicerRevision).toStringList();
+  for (int i = 0; i < scheduledForRemovalList.length(); i++)
+    {
+    historyList.removeOne(scheduledForRemovalList.at(i));
+    }
+  historyList.removeDuplicates();
+  settings.setValue("ExtensionsHistory/Revisions/" + this->SlicerRevision, historyList);
+  settings.setValue("ExtensionsHistory/ScheduledForRemoval", "");
+}
+
+// --------------------------------------------------------------------------
+QVariantMap qSlicerExtensionsManagerModelPrivate::getExtensionsInfoFromPreviousInstallations(
+  const QString& extensionsHistorySettingsFile)
+{
+  Q_Q(qSlicerExtensionsManagerModel);
+  QVariantMap extensionsHistoryInformation;
+  QSettings settings(extensionsHistorySettingsFile, QSettings::IniFormat);
+  settings.beginGroup("ExtensionsHistory/Revisions");
+  QStringList revisions = settings.childKeys();
+  revisions.sort();	//revisions sorted ascending
+  int lastRevision = -1;
+  for (int i = revisions.length() - 1; i >= 0; i--)		//the revision with the highest number not equal the current one is considered to be the last revision
+    {
+    if (revisions[i] != this->SlicerRevision)
+      {
+      lastRevision = i;
+      break;
+      }
+    }
+  if (lastRevision == -1)
+    {
+    return extensionsHistoryInformation;
+    }
+
+  for (int i = 0; i < revisions.length(); i++)
+    {
+    QVariantMap curExtensionInfo;
+    const QStringList& extensionNames = settings.value(revisions.at(i)).toStringList();
+    for (int j = 0; j < extensionNames.length(); j++)
+      {
+      QString extensionName = extensionNames.at(j);
+      QString extensionId = "";
+
+      curExtensionInfo.insert("UsedLastInRevision", revisions.at(i));
+      if (i == lastRevision || (extensionsHistoryInformation.contains(extensionName) &&
+        extensionsHistoryInformation.value(extensionName).toMap().value("WasInstalledInLastRevision").toBool()))
+        {
+        curExtensionInfo.insert("WasInstalledInLastRevision", true);
+        }
+      else
+        {
+        curExtensionInfo.insert("WasInstalledInLastRevision", false);
+        }
+      curExtensionInfo.insert("IsInstalled", q->isExtensionInstalled(extensionName));
+      bool isCompatible = true;
+
+      if (!q->isExtensionInstalled(extensionName))
+        {
+        qMidasAPI::ParametersType parameters;
+        parameters["productname"] = extensionName;
+        parameters["slicer_revision"] = q->slicerRevision();
+        parameters["os"] = q->slicerOs();
+        parameters["arch"] = q->slicerArch();
+        const ExtensionMetadataType& metaData = retrieveExtensionMetadata(parameters);
+        extensionId = metaData.value("extension_id").toString();     //retrieve updated extension id for not installed extensions
+        isCompatible = (this->isExtensionCompatible(metaData, this->SlicerRevision, this->SlicerOs, this->SlicerArch).length() == 0);
+        }
+      else
+        {
+        const ExtensionMetadataType& metaData = q->extensionMetadata(extensionName);
+        extensionId = metaData.value("extension_id").toString();
+        isCompatible = (q->isExtensionCompatible(extensionName).length() == 0);
+        }
+      curExtensionInfo.insert("ExtensionId", extensionId);
+      curExtensionInfo.insert("IsCompatible", isCompatible);
+      extensionsHistoryInformation.insert(extensionName, curExtensionInfo);
+      }
+    }
+  return extensionsHistoryInformation;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModelPrivate::gatherExtensionsHistoryInformationOnStartup()
+{
+  Q_Q(qSlicerExtensionsManagerModel);
+  emit q->extensionHistoryGatheredOnStartup(q->getExtensionHistoryInformation());
 }
 
 // --------------------------------------------------------------------------
@@ -1203,7 +1344,22 @@ bool qSlicerExtensionsManagerModel::downloadAndInstallExtension(const QString& e
     }
   connect(task, SIGNAL(finished(qSlicerExtensionDownloadTask*)),
           this, SLOT(onInstallDownloadFinished(qSlicerExtensionDownloadTask*)));
+  connect(task, SIGNAL(progress(qSlicerExtensionDownloadTask*, qint64, qint64)),
+          this, SLOT(onInstallDownloadProgress(qSlicerExtensionDownloadTask*, qint64, qint64)));
   return true;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModel::onInstallDownloadProgress(
+  qSlicerExtensionDownloadTask* task, qint64 received, qint64 total)
+{
+  Q_D(qSlicerExtensionsManagerModel);
+
+  // Look up the update information
+  const QString& extensionName = task->extensionName();
+
+  // Notify observers of download progress
+  emit this->installDownloadProgress(extensionName, received, total);
 }
 
 // --------------------------------------------------------------------------
@@ -1444,7 +1600,7 @@ bool qSlicerExtensionsManagerModel::installExtension(
   d->saveExtensionDescription(extensionDescriptionFile, extensionMetadata);
   d->addExtensionSettings(extensionName);
   d->addExtensionModelRow(Self::parseExtensionDescriptionFile(extensionDescriptionFile));
-
+  d->saveExtensionToHistorySettings(this->extensionsHistorySettingsFilePath(), extensionMetadata);
   emit this->extensionInstalled(extensionName);
 
   // Log notice that extension was installed
@@ -1893,6 +2049,8 @@ bool qSlicerExtensionsManagerModel::scheduleExtensionForUninstall(const QString&
 
   d->removeExtensionSettings(extensionName);
 
+  const ExtensionMetadataType& extensionMetadata = this->extensionMetadata(extensionName);
+  d->scheduleExtensionHistorySettingRemoval(this->extensionsHistorySettingsFilePath(), extensionMetadata);
   emit this->extensionScheduledForUninstall(extensionName);
 
   return true;
@@ -1915,7 +2073,7 @@ bool qSlicerExtensionsManagerModel::cancelExtensionScheduledForUninstall(const Q
     }
   d->removeExtensionFromScheduledForUninstallList(extensionName);
   d->addExtensionSettings(extensionName);
-
+  d->cancelExtensionHistorySettingRemoval(this->extensionsHistorySettingsFilePath(), extensionName);
   emit this->extensionCancelledScheduleForUninstall(extensionName);
 
   return true;
@@ -2022,6 +2180,7 @@ bool qSlicerExtensionsManagerModel::uninstallScheduledExtensions()
 bool qSlicerExtensionsManagerModel::uninstallScheduledExtensions(QStringList& uninstalledExtensions)
 {
   Q_D(qSlicerExtensionsManagerModel);
+  d->removeScheduledExtensionHistorySettings(this->extensionsHistorySettingsFilePath());
   bool result = true;
   foreach(const QString& extensionName, this->scheduledForUninstallExtensions())
     {
@@ -2034,6 +2193,21 @@ bool qSlicerExtensionsManagerModel::uninstallScheduledExtensions(QStringList& un
     }
   return result;
 }
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerModel::gatherExtensionsHistoryInformationOnStartup()
+{
+  Q_D(qSlicerExtensionsManagerModel);
+  d->gatherExtensionsHistoryInformationOnStartup();
+}
+
+// --------------------------------------------------------------------------
+QVariantMap  qSlicerExtensionsManagerModel::getExtensionHistoryInformation()
+{
+  Q_D(qSlicerExtensionsManagerModel);
+  return d->getExtensionsInfoFromPreviousInstallations(extensionsHistorySettingsFilePath());
+}
+
 
 // --------------------------------------------------------------------------
 void qSlicerExtensionsManagerModel::updateModel()
@@ -2056,6 +2230,10 @@ void qSlicerExtensionsManagerModel::updateModel()
 // --------------------------------------------------------------------------
 CTK_GET_CPP(qSlicerExtensionsManagerModel, QString, extensionsSettingsFilePath, ExtensionsSettingsFilePath)
 CTK_SET_CPP(qSlicerExtensionsManagerModel, const QString&, setExtensionsSettingsFilePath, ExtensionsSettingsFilePath)
+
+// --------------------------------------------------------------------------
+CTK_GET_CPP(qSlicerExtensionsManagerModel, QString, extensionsHistorySettingsFilePath, ExtensionsHistorySettingsFilePath)
+CTK_SET_CPP(qSlicerExtensionsManagerModel, const QString&, setExtensionsHistorySettingsFilePath, ExtensionsHistorySettingsFilePath)
 
 // --------------------------------------------------------------------------
 CTK_GET_CPP(qSlicerExtensionsManagerModel, QString, slicerRevision, SlicerRevision)

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -52,6 +52,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerExtensionsManagerModel : public QObject
   Q_PROPERTY(QString extensionsInstallPath READ extensionsInstallPath)
   Q_PROPERTY(bool newExtensionEnabledByDefault READ newExtensionEnabledByDefault WRITE setNewExtensionEnabledByDefault)
   Q_PROPERTY(QString extensionsSettingsFilePath READ extensionsSettingsFilePath WRITE setExtensionsSettingsFilePath)
+  Q_PROPERTY(QString extensionsHistorySettingsFilePath READ extensionsHistorySettingsFilePath WRITE setExtensionsHistorySettingsFilePath)
   Q_PROPERTY(QString slicerRevision READ slicerRevision WRITE setSlicerRevision)
   Q_PROPERTY(QString slicerOs READ slicerOs WRITE setSlicerOs)
   Q_PROPERTY(QString slicerArch READ slicerArch WRITE setSlicerArch)
@@ -143,6 +144,11 @@ public:
 
   QString extensionsSettingsFilePath()const;
   void setExtensionsSettingsFilePath(const QString& extensionsSettingsFilePath);
+
+  QString extensionsHistorySettingsFilePath()const;
+  void setExtensionsHistorySettingsFilePath(const QString& extensionsHistorySettingsFilePath);
+
+  QVariantMap extensionsHistoryInformation()const;
 
   QString slicerRevision()const;
   void setSlicerRevision(const QString& revision);
@@ -304,6 +310,10 @@ public slots:
   /// \sa scheduleExtensionForUninstall, isExtensionScheduledForUninstall,
   bool uninstallScheduledExtensions();
 
+  void gatherExtensionsHistoryInformationOnStartup();
+
+  QVariantMap getExtensionHistoryInformation();
+
   void identifyIncompatibleExtensions();
 
   bool exportExtensionList(QString& exportFilePath);
@@ -347,7 +357,13 @@ signals:
 
   void messageLogged(const QString& text, ctkErrorLogLevel::LogLevels level) const;
 
+  void extensionHistoryGatheredOnStartup(const QVariantMap&);
+
+  void installDownloadProgress(const QString& extensionName, qint64 received, qint64 total);
+
 protected slots:
+
+  void onInstallDownloadProgress(qSlicerExtensionDownloadTask* task, qint64 received, qint64 total);
 
   /// \sa downloadAndInstallExtension
   void onInstallDownloadFinished(qSlicerExtensionDownloadTask* task);

--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -101,6 +101,8 @@ if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
   list(APPEND KIT_SRCS
     qSlicerExtensionsInstallWidget.cxx
     qSlicerExtensionsInstallWidget.h
+    qSlicerExtensionsRestoreWidget.cxx
+    qSlicerExtensionsRestoreWidget.h
     qSlicerExtensionsManageWidget.cxx
     qSlicerExtensionsManageWidget.h
     qSlicerExtensionsManagerDialog.cxx
@@ -199,6 +201,7 @@ set(KIT_MOC_SRCS
 if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
   list(APPEND KIT_MOC_SRCS
     qSlicerExtensionsInstallWidget.h
+    qSlicerExtensionsRestoreWidget.h
     qSlicerExtensionsManageWidget.h
     qSlicerExtensionsManagerDialog.h
     qSlicerExtensionsManagerWidget.h

--- a/Base/QTGUI/Resources/UI/qSlicerExtensionsManagerWidget.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerExtensionsManagerWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>601</width>
-    <height>338</height>
+    <width>933</width>
+    <height>692</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <property name="iconSize">
       <size>
@@ -61,7 +61,25 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="qSlicerExtensionsInstallWidget" name="ExtensionsInstallWidget" native="true"/>
+        <widget class="qSlicerExtensionsInstallWidget" name="ExtensionsInstallWidget" native="true">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="restoreExtensionsTab">
+      <attribute name="icon">
+       <iconset resource="../qSlicerBaseQTGUI.qrc">
+        <normaloff>:/Icons/Medium/SlicerRedo.png</normaloff>:/Icons/Medium/SlicerRedo.png</iconset>
+      </attribute>
+      <attribute name="title">
+       <string>Restore Extensions</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="qSlicerExtensionsRestoreWidget" name="ExtensionsRestoreWidget" native="true"/>
        </item>
       </layout>
      </widget>
@@ -80,6 +98,12 @@
    <class>qSlicerExtensionsInstallWidget</class>
    <extends>QWidget</extends>
    <header>qSlicerExtensionsInstallWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerExtensionsRestoreWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerExtensionsRestoreWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -290,6 +290,7 @@ void qSlicerApplicationPrivate::init()
   //----------------------------------------------------------------------------
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
   this->ExtensionsManagerDialog = new qSlicerExtensionsManagerDialog(0);
+  this->ExtensionsManagerDialog->setExtensionsManagerModel(q->extensionsManagerModel());
 #endif
 
   //----------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
@@ -285,6 +285,7 @@ void qSlicerExtensionsManagerWidget::setExtensionsManagerModel(qSlicerExtensions
   d->ExtensionsManageWidget->setExtensionsManagerModel(model);
   d->ExtensionsManageBrowser->setExtensionsManagerModel(model);
   d->ExtensionsInstallWidget->setExtensionsManagerModel(model);
+  d->ExtensionsRestoreWidget->setExtensionsManagerModel(model);
 
   if (model)
     {

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
@@ -1,0 +1,514 @@
+//QT includes
+#include <QPushButton>
+#include <QProgressBar>
+#include <QLayout>
+#include <iostream>
+#include <QFileInfo>
+#include <QDir>
+#include <QListWidget>
+#include <QDebug>
+#include <QProgressDialog>
+#include <ctkMessageBox.h>
+#include <QStyledItemDelegate>
+#include <QPainter>
+#include <QEvent>
+#include <QApplication>
+#include <qSlicerApplication.h>
+#include <QCheckBox>
+
+// QtGUI includes
+#include "qSlicerExtensionsRestoreWidget.h"
+#include "qSlicerExtensionsManagerModel.h"
+
+// --------------------------------------------------------------------------
+class qSlicerRestoreExtensionsItemDelegate : public QStyledItemDelegate
+{
+public:
+  qSlicerRestoreExtensionsItemDelegate(QObject * parent = 0)
+    : QStyledItemDelegate(parent) {};
+
+  bool editorEvent(QEvent *event,
+    QAbstractItemModel *model,
+    const QStyleOptionViewItem &option,
+    const QModelIndex &index)
+  {
+    bool isEnabled = index.data(Qt::UserRole + 3).toBool();
+
+    if (event->type() == QEvent::MouseButtonRelease && isEnabled)
+      {
+      bool value = index.data(Qt::UserRole + 1).toBool();
+      model->setData(index, !value, Qt::UserRole + 1);
+      return true;
+      }
+
+    return QStyledItemDelegate::editorEvent(event, model, option, index);
+  }
+
+  // --------------------------------------------------------------------------
+  void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
+  {
+    QRect r = option.rect;
+
+    QPen enabledPen(QColor::fromRgb(0, 0, 0), 1, Qt::SolidLine);
+    QPen disabledPen(QColor::fromRgb(125, 125, 125), 1, Qt::SolidLine);
+    QPen candidatePen(QColor::fromRgb(0, 200, 50), 1, Qt::SolidLine);
+    QPen installedPen(QColor::fromRgb(0, 50, 200), 1, Qt::SolidLine);
+
+    //GET DATA
+    const QString& title            = index.data(Qt::DisplayRole).toString();
+    const bool isChecked            = index.data(Qt::UserRole + 1).toBool();
+    const QString& description      = index.data(Qt::UserRole + 2).toString();
+    const bool isEnabled            = index.data(Qt::UserRole + 3).toBool();
+    const bool isRestoreCandidate   = index.data(Qt::UserRole + 4).toBool();
+    const bool isInstalled          = index.data(Qt::UserRole + 5).toBool();
+
+    //TITLE
+    painter->setPen((isEnabled ? enabledPen : disabledPen));
+    r = option.rect.adjusted(55, 10, 0, 0);
+    painter->setFont(QFont("Arial", 13, QFont::Bold));
+    painter->drawText(r.left(), r.top(), r.width(), r.height(), Qt::AlignTop | Qt::AlignLeft, title, &r);
+    //DESCRIPTION
+    painter->setPen((isEnabled ? ( isRestoreCandidate ? candidatePen : enabledPen ) : ( isInstalled ? installedPen : disabledPen)));
+    r = option.rect.adjusted(55, 30, -10, 0);
+    painter->setFont(QFont("Arial", 9, QFont::Normal));
+    painter->drawText(r.left(), r.top(), r.width(), r.height(), Qt::AlignLeft, description, &r);
+    //CHECKBOX
+    QStyleOptionButton cbOpt;
+    cbOpt.rect = option.rect.adjusted(20, 0, 0, 0);
+
+    if (isChecked)
+      {
+      cbOpt.state |= QStyle::State_On;
+      }
+    else
+      {
+      cbOpt.state |= QStyle::State_Off;
+      }
+
+    QApplication::style()->drawControl(QStyle::CE_CheckBox, &cbOpt, painter);
+  }
+  QSize sizeHint(const QStyleOptionViewItem & option, const QModelIndex & index) const
+  {
+    return QSize(200, 60);
+  }
+
+};
+
+
+//-----------------------------------------------------------------------------
+class qSlicerExtensionsRestoreWidgetPrivate
+{
+  Q_DECLARE_PUBLIC(qSlicerExtensionsRestoreWidget);
+protected:
+  qSlicerExtensionsRestoreWidget* const q_ptr;
+
+public:
+  qSlicerExtensionsRestoreWidgetPrivate(qSlicerExtensionsRestoreWidget& object);
+  void init();
+  void onShow();
+  void setupUi();
+  void setupList();
+  QStringList getSelectedExtensions();
+  void startDownloadAndInstallExtensions(QStringList extensionIds);
+  void startDownloadAndInstallExtensionsHeadless(QStringList extensionIds);
+
+  void downloadAndInstallNextExtension();
+  void downloadProgress(const QString& extensionName, qint64 received, qint64 total);
+  QStringList extractInstallationCandidates(QVariantMap extensionHistoryInformation);
+  void processExtensionsHistoryInformationOnStartup(QVariantMap extensionHistoryInformation);
+  void setCheckOnStartup(int state);
+  void setSilentInstallOnStartup(int state);
+
+  qSlicerExtensionsManagerModel *ExtensionsManagerModel;
+  QProgressBar *progressBar;
+  QProgressDialog *progressDialog;
+  QCheckBox *checkOnStartup;
+  QCheckBox *silentInstallOnStartup;
+  QListWidget *extensionList;
+  QStringList extensionsToInstall;
+  QVariantMap extensionRestoreInformation;
+  QString checkOnStartupSettingsKey;
+  QString silentInstallOnStartUpSettingsKey;
+  unsigned int nrOfExtensionsToInstall;
+  int currentExtensionToInstall;
+  bool headlessMode;
+
+};
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsRestoreWidgetPrivate::qSlicerExtensionsRestoreWidgetPrivate(qSlicerExtensionsRestoreWidget& object)
+:q_ptr(&object)
+{
+
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate::init()
+{
+  this->nrOfExtensionsToInstall = 0;
+  this->headlessMode = false;
+  setupUi();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate::onShow()
+{
+  QSettings settings; // (this->ExtensionsManagerModel->extensionsSettingsFilePath(), QSettings::IniFormat);
+  checkOnStartup->setChecked(!settings.value(checkOnStartupSettingsKey).toBool());
+  silentInstallOnStartup->setChecked(settings.value(silentInstallOnStartUpSettingsKey).toBool());
+  silentInstallOnStartup->setEnabled(checkOnStartup->isChecked());
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::setupUi()
+{
+  Q_Q(qSlicerExtensionsRestoreWidget);
+
+  QVBoxLayout *mainLayout = new QVBoxLayout;
+  QHBoxLayout *layoutForProgressAndButton = new QHBoxLayout;
+  QHBoxLayout *layoutForSettings= new QHBoxLayout;
+  QPushButton *installButton = new QPushButton;
+  this->checkOnStartup = new QCheckBox;
+  this->silentInstallOnStartup = new QCheckBox;
+  this->progressDialog = new QProgressDialog;
+  this->extensionList = new QListWidget;
+  this->progressBar = new QProgressBar;
+
+  this->extensionList->setAlternatingRowColors(true);
+  this->extensionList->setItemDelegate(new qSlicerRestoreExtensionsItemDelegate(q));
+  this->checkOnStartup->setText(QObject::tr("Check previous extensions on startup"));
+  this->silentInstallOnStartup->setText(QObject::tr("Install previous extensions without request"));
+
+  this->progressDialog->setWindowFlags(Qt::WindowStaysOnTopHint | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
+
+  installButton->setText(QObject::tr("Install Selected"));
+  layoutForProgressAndButton->addWidget(this->progressBar);
+  layoutForProgressAndButton->addWidget(installButton);
+  layoutForSettings->addWidget(this->checkOnStartup);
+  layoutForSettings->addWidget(this->silentInstallOnStartup);
+  mainLayout->addWidget(this->extensionList);
+  mainLayout->addLayout(layoutForProgressAndButton);
+  mainLayout->addLayout(layoutForSettings);
+  q->setLayout(mainLayout);
+  checkOnStartupSettingsKey = "ExtensionCheckOnStartup/dontCheck";
+  silentInstallOnStartUpSettingsKey = "ExtensionCheckOnStartup/ifCheckInstallWithoutDialog";
+
+  QObject::connect(installButton, SIGNAL(clicked()),
+    q, SLOT(onInstallSelectedExtensionsTriggered()));
+  QObject::connect(checkOnStartup, SIGNAL(stateChanged(int)),
+    q, SLOT(onCheckOnStartupChanged(int)));
+  QObject::connect(silentInstallOnStartup, SIGNAL(stateChanged(int)),
+    q, SLOT(onSilentInstallOnStartupChanged(int)));
+
+}
+
+// --------------------------------------------------------------------------
+QStringList qSlicerExtensionsRestoreWidgetPrivate
+::extractInstallationCandidates(QVariantMap extensionHistoryInformation)
+{
+  QStringList candidateIds;
+  foreach(QString extensionName, extensionHistoryInformation.keys())
+    {
+    const QVariantMap& currentInfo = extensionHistoryInformation.value(extensionName).toMap();
+    if (currentInfo.value("WasInstalledInLastRevision").toBool() && currentInfo.value("IsCompatible").toBool() && !currentInfo.value("IsInstalled").toBool())
+      {
+      candidateIds.append(currentInfo.value("ExtensionId").toString());
+      }
+    }
+  return candidateIds;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::processExtensionsHistoryInformationOnStartup(QVariantMap extensionHistoryInformation)
+{
+  QSettings settings;// (this->ExtensionsManagerModel->extensionsSettingsFilePath(), QSettings::IniFormat);
+
+  bool checkOnStartup = !settings.value(this->checkOnStartupSettingsKey).toBool();
+
+  if (checkOnStartup)
+    {
+    const QStringList& candidateIds = extractInstallationCandidates(extensionHistoryInformation);
+
+    if (candidateIds.length() > 0)
+      {
+      bool silentInstall = settings.value(this->silentInstallOnStartUpSettingsKey).toBool();
+      if (silentInstall)
+        {
+        this->startDownloadAndInstallExtensionsHeadless(candidateIds);
+        }
+      else
+        {
+        const QString& text = QObject::tr(
+          "%1 compatible extension(s) from a previous Slicer installation found. Do you want to install? "
+          "(For details see: Extension Manager > Restore Extensions)").arg(candidateIds.length());
+
+        ctkMessageBox checkHistoryMessage;
+        checkHistoryMessage.setText(text);
+        checkHistoryMessage.setIcon(QMessageBox::Information);
+        checkHistoryMessage.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+        checkHistoryMessage.setDontShowAgainVisible(true);
+
+        if (checkHistoryMessage.exec() == QMessageBox::Yes)
+          {
+          this->startDownloadAndInstallExtensionsHeadless(candidateIds);
+          }
+        settings.setValue(checkOnStartupSettingsKey, checkHistoryMessage.dontShowAgain());
+        }
+      }
+    }
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::setupList()
+{
+  Q_Q(qSlicerExtensionsRestoreWidget);
+
+  extensionList->clear();
+  QVariantMap extensionInfo = q->extensionsManagerModel()->getExtensionHistoryInformation();
+
+  foreach(QString extensionName, extensionInfo.keys())
+    {
+    QListWidgetItem* extensionItem = new QListWidgetItem;
+
+    QVariantMap currentInfo = extensionInfo.value(extensionName).toMap();
+
+    const QString& title                  = extensionName;
+    const bool isCompatible               = currentInfo.value("IsCompatible").toBool();
+    const bool isInstalled                = currentInfo.value("IsInstalled").toBool();
+    const QString& usedLastInRevision     = currentInfo.value("UsedLastInRevision").toString();
+    const bool wasInstalledInLastRevision = currentInfo.value("WasInstalledInLastRevision").toBool();
+    const bool isItemEnabled              = isCompatible && !isInstalled;
+    const bool isItemChecked              = isItemEnabled && wasInstalledInLastRevision;
+    const QString& description =
+      (isInstalled
+       ? QObject::tr("currently installed")
+       : (isCompatible
+          ? (wasInstalledInLastRevision
+             ? QObject::tr("was used in previously installed Slicer version (%1)").arg(usedLastInRevision)
+             : QObject::tr("was last used in Slicer version %1").arg(usedLastInRevision))
+          : QObject::tr("not compatible with current Slicer version (was last used in Slicer version %1)").arg(usedLastInRevision)));
+
+    extensionItem->setData(Qt::UserRole, currentInfo.value("ExtensionId").toString());
+    extensionItem->setData(Qt::UserRole + 1, isItemChecked);
+    extensionItem->setData(Qt::UserRole + 2, description);
+    extensionItem->setData(Qt::UserRole + 3, isItemEnabled);
+    extensionItem->setData(Qt::UserRole + 4, wasInstalledInLastRevision); //details added for color coding
+    extensionItem->setData(Qt::UserRole + 5, isInstalled);
+    extensionItem->setText(title);
+
+    extensionList->addItem(extensionItem);
+    }
+}
+
+// --------------------------------------------------------------------------
+QStringList qSlicerExtensionsRestoreWidgetPrivate
+::getSelectedExtensions()
+{
+  QStringList selectedExtensions;
+  for (unsigned int i = 0; i < extensionList->count(); i++)
+    {
+    QListWidgetItem* currentItem = extensionList->item(i);
+    if (currentItem->data(Qt::UserRole + 1).toBool())
+      {
+      selectedExtensions.append(currentItem->data(Qt::UserRole).toString());
+      }
+    }
+  return selectedExtensions;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::startDownloadAndInstallExtensionsHeadless(QStringList extensionIds)
+{
+  this->headlessMode = true;
+  this->progressDialog->show();
+  startDownloadAndInstallExtensions(extensionIds);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::startDownloadAndInstallExtensions(QStringList extensionIds)
+{
+  this->extensionsToInstall = extensionIds;
+  this->nrOfExtensionsToInstall = extensionsToInstall.size();
+  this->currentExtensionToInstall = -1;
+
+  this->progressBar->setMaximum(this->nrOfExtensionsToInstall);
+  this->progressDialog->setMaximum(this->nrOfExtensionsToInstall);
+
+  downloadAndInstallNextExtension();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::downloadAndInstallNextExtension()
+{
+  Q_Q(qSlicerExtensionsRestoreWidget);
+  this->currentExtensionToInstall++;
+  if (this->currentExtensionToInstall < this->nrOfExtensionsToInstall)
+    {
+    q->extensionsManagerModel()->downloadAndInstallExtension(extensionsToInstall.at(currentExtensionToInstall));
+    }
+  else
+    {
+    if (this->headlessMode)
+      {
+      this->progressDialog->close();
+      this->headlessMode = false;
+      static_cast<qSlicerApplication*>qApp->confirmRestart(
+        QObject::tr("All extensions restored. Please restart Slicer."));
+      }
+    else
+      {
+      setupList();
+      }
+    }
+}
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::downloadProgress(const QString& extensionName, qint64 received, qint64 total)
+{
+  int value = float(currentExtensionToInstall) + (float(received) / float(total));
+  if (this->headlessMode)
+    {
+    this->progressDialog->setValue(value);
+    this->progressDialog->setLabelText(
+      QObject::tr("Installing %1 (%2/%3)")
+      .arg(extensionName)
+      .arg(received)
+      .arg(total));
+    }
+  else
+    {
+    this->progressBar->setValue(value);
+    }
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::setCheckOnStartup(int state)
+{
+  QSettings settings;// (this->ExtensionsManagerModel->extensionsSettingsFilePath(), QSettings::IniFormat);
+  settings.setValue(checkOnStartupSettingsKey, !bool(state));
+  this->silentInstallOnStartup->setEnabled(bool(state));
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidgetPrivate
+::setSilentInstallOnStartup(int state)
+{
+  QSettings settings;// (this->ExtensionsManagerModel->extensionsSettingsFilePath(), QSettings::IniFormat);
+  settings.setValue(silentInstallOnStartUpSettingsKey, bool(state));
+}
+
+// --------------------------------------------------------------------------
+// qSlicerExtensionsRestoreWidget methods
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsRestoreWidget
+::qSlicerExtensionsRestoreWidget(QWidget* _parent)
+: Superclass(_parent)
+, d_ptr(new qSlicerExtensionsRestoreWidgetPrivate(*this))
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->init();
+}
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsRestoreWidget
+::~qSlicerExtensionsRestoreWidget()
+{
+}
+
+// --------------------------------------------------------------------------
+qSlicerExtensionsManagerModel* qSlicerExtensionsRestoreWidget
+::extensionsManagerModel()const
+{
+  Q_D(const qSlicerExtensionsRestoreWidget);
+  return d->ExtensionsManagerModel;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget
+::showEvent(QShowEvent* event) {
+  QWidget::showEvent(event);
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->onShow();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget
+::setExtensionsManagerModel(qSlicerExtensionsManagerModel* model)
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+
+  if (this->extensionsManagerModel() == model)
+    {
+    return;
+    }
+
+  disconnect(this, SLOT(onProgressChanged(QString, qint64, qint64)));
+  disconnect(this, SLOT(onInstallationFinished(QString)));
+  disconnect(this, SLOT(onExtensionHistoryGatheredOnStartup(QVariantMap)));
+  d->ExtensionsManagerModel = model;
+  d->setupList();
+
+  if (model)
+    {
+    connect(model, SIGNAL(installDownloadProgress(QString, qint64, qint64)),
+      this, SLOT(onProgressChanged(QString, qint64, qint64)));
+    connect(model, SIGNAL(extensionInstalled(QString)),
+      this, SLOT(onInstallationFinished(QString)));
+    connect(model, SIGNAL(extensionHistoryGatheredOnStartup(QVariantMap)),
+      this, SLOT(onExtensionHistoryGatheredOnStartup(QVariantMap)));
+    }
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget
+::onInstallSelectedExtensionsTriggered()
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->startDownloadAndInstallExtensions(d->getSelectedExtensions());
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget
+::onCheckOnStartupChanged(int state)
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->setCheckOnStartup(state);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget
+::onSilentInstallOnStartupChanged(int state)
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->setSilentInstallOnStartup(state);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget::onProgressChanged(const QString& extensionName, qint64 received, qint64 total)
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->downloadProgress(extensionName, received, total);
+};
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsRestoreWidget
+::onInstallationFinished(QString extensionName)
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->downloadAndInstallNextExtension();
+}
+
+void qSlicerExtensionsRestoreWidget
+::onExtensionHistoryGatheredOnStartup(const QVariantMap& extensionInfo)
+{
+  Q_D(qSlicerExtensionsRestoreWidget);
+  d->processExtensionsHistoryInformationOnStartup(extensionInfo);
+}

--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.h
@@ -1,0 +1,54 @@
+
+#ifndef __qSlicerExtensionsRestoreWidget_h
+#define __qSlicerExtensionsRestoreWidget_h
+
+// CTK includes
+#include <ctkErrorLogLevel.h>
+
+// Qt includes
+#include <QWidget>
+#include <QVariant>
+
+// QtGUI includes
+#include "qSlicerBaseQTGUIExport.h"
+
+class qSlicerExtensionsRestoreWidgetPrivate;
+class qSlicerExtensionsManagerModel;
+
+class Q_SLICER_BASE_QTGUI_EXPORT qSlicerExtensionsRestoreWidget
+  : public QWidget
+{
+  Q_OBJECT
+public:
+  /// Superclass typedef
+  typedef QWidget Superclass;
+
+  /// Constructor
+  explicit qSlicerExtensionsRestoreWidget(QWidget* parent = 0);
+
+  /// Destructor
+  virtual ~qSlicerExtensionsRestoreWidget();
+
+  Q_INVOKABLE qSlicerExtensionsManagerModel* extensionsManagerModel()const;
+  Q_INVOKABLE void setExtensionsManagerModel(qSlicerExtensionsManagerModel* model);
+
+  // Events
+  void showEvent(QShowEvent* event);
+
+  protected slots :
+  void onInstallSelectedExtensionsTriggered();
+  void onCheckOnStartupChanged(int state);
+  void onSilentInstallOnStartupChanged(int state);
+  void onProgressChanged(const QString& extensionName, qint64 received, qint64 total);
+  void onInstallationFinished(QString extensionName);
+  void onExtensionHistoryGatheredOnStartup(const QVariantMap&);
+
+protected:
+  QScopedPointer<qSlicerExtensionsRestoreWidgetPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerExtensionsRestoreWidget);
+  Q_DISABLE_COPY(qSlicerExtensionsRestoreWidget);
+};
+
+#endif


### PR DESCRIPTION
This commit improves the extension manager so that it can keep track of
the installed extensions across version. The goal is to simplify the number
of steps allowing people to reinstall extensions that were used in a previous
installation.

(1) After installing a new version of Slicer, the user can select from all previously
    installed extensions and batch-install them.
(2) Extensions installed in the last (previous) Slicer versions are marked and preselected
    (one click-solution for getting the previous setup)
(3) Extensions that where previously installed but are not compatible for some reason, are
    shown but not selectable
(4) UI: a third tab ("Restore Extensions") is added to the Extension Manager and provide at
    least a list view for selection / a button button for installing the selected extensions.

More specifically, this topic implements the following changes:

- add setter/getter for extension history settings file path
- set path to Slicer.ini as extension model extension history path
- add function to write extension id to settings file after installation
- installed (and scheduled for removal) extensions are reflected in ini file
- add check functionality for previous extensions
- add headless mode to restore widget for initial extension restore
- add messagebox to advice restart after extension restore
- extension check on startup coupled with settings
- user-visible strings are translatable

References:
- https://www.slicer.org/wiki/Documentation/Labs/AutomaticUpdateAndInstallationFramework
- https://github.com/Slicer/Slicer/pull/632
- https://github.com/Slicer/Slicer/pull/865
- https://github.com/Slicer/Slicer/pull/698

Co-authored-by: Hans Meine <hans_meine@gmx.net>

Reviewed-by: Andras Lasso <lasso@queensu.ca>
Reviewed-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
Reviewed-by: Steve Pieper <pieper@bwh.harvard.edu>