### PR TITLE
ENH: Throw an exception if getNode does not find a node

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -596,6 +596,7 @@ def getNodes(pattern="*", scene=None, useLists=False):
   If multiple node share the same name, using ``useLists=False`` (default behavior)
   returns only the last node with that name. If ``useLists=True``, it returns
   a dictionary of lists of nodes.
+  Throws ValueError exception if node is not found that matches the specified pattern.
   """
   import slicer, collections, fnmatch
   nodes = collections.OrderedDict()
@@ -612,6 +613,8 @@ def getNodes(pattern="*", scene=None, useLists=False):
         nodes.setdefault(node.GetName(), []).append(node)
       else:
         nodes[node.GetName()] = node
+  if not nodes:
+    raise ValueError("could not find nodes in the scene by name or id '%s'" % pattern)
   return nodes
 
 def getNode(pattern="*", index=0, scene=None):


### PR DESCRIPTION
Novice developers were often confused by why their Python code did not work when they have a failed MRML node lookup using getNode function.
The problem was that if a node was not found then no errors were reported immediately and the unexpected None value in the variable caused errors later.

Fixed it by throwing a ValueError exception when getNode does not find any nodes.