### PR TITLE
COMP: pass CMAKE_EXPORT_COMPILE_COMMANDS to slicer child build

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -416,6 +416,11 @@ foreach(name IN ITEMS
   endif()
 endforeach()
 
+# Respect top-level setting to request creation of compile_commands.json
+if(DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_ARGS -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=${CMAKE_EXPORT_COMPILE_COMMANDS})
+endif()
+
 #------------------------------------------------------------------------------
 # Slicer_EXTENSION_SOURCE_DIRS
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Allows to work with various tooling that uses `compile_commands.json`.