### PR TITLE
BUG: Fix import of vtk modules when built with Qt5 and VTK9

### DIFF
--- a/CMake/SlicerBlockInstallExternalPythonModules.cmake
+++ b/CMake/SlicerBlockInstallExternalPythonModules.cmake
@@ -9,17 +9,29 @@ if(Slicer_VTK_VERSION_MAJOR VERSION_GREATER "7")
 else()
   set(VTK_PYTHON_MODULE "${VTK_DIR}/Wrapping/Python")
 endif()
-install(DIRECTORY ${VTK_PYTHON_MODULE}/vtk
+set(_vtk_package "vtk")
+if(EXISTS ${VTK_PYTHON_MODULE}/vtkmodules)
+  set(_vtk_package "vtkmodules") # Introduced in VTK9 kitware/vtk@2404228 on 2017.12.15
+endif()
+install(DIRECTORY ${VTK_PYTHON_MODULE}/${_vtk_package}
   DESTINATION ${Slicer_INSTALL_BIN_DIR}/Python
   USE_SOURCE_PERMISSIONS
   COMPONENT Runtime
   # VTK9: Add exclusions to avoid installing VTK's C++ Python modules
   # These have their own install rules (see below).
-  PATTERN "vtk*Python.so" EXCLUDE)
+  PATTERN "vtk*Python.so" EXCLUDE
+  PATTERN "*.pyo" EXCLUDE)
+
+if(EXISTS ${VTK_PYTHON_MODULE}/vtk.py)
+  # Introduced in VTK9 kitware/vtk@2404228 on 2017.12.15
+  install(FILES ${VTK_PYTHON_MODULE}/vtk.py
+    DESTINATION ${Slicer_INSTALL_BIN_DIR}/Python
+    COMPONENT Runtime)
+endif()
 
 # Install external python runtime libraries that we don't link to (fixupbundle won't copy them)
 if(Slicer_VTK_VERSION_MAJOR VERSION_GREATER "7")
-  set(vtk_python_library_subdir "lib/python2.7/site-packages/vtk")
+  set(vtk_python_library_subdir "lib/python2.7/site-packages/${_vtk_package}")
 else()
   set(vtk_python_library_subdir "lib")
 endif()

--- a/SuperBuild/External_VTKv9.cmake
+++ b/SuperBuild/External_VTKv9.cmake
@@ -211,9 +211,23 @@ endif()
 
   # pythonpath
   if(NOT APPLE)
-    set(${proj}_PYTHONPATH_LAUNCHER_INSTALLED
-      <APPLAUNCHER_DIR>/${Slicer_INSTALL_LIB_DIR}/python2.7/site-packages
-      )
+    # This is not required for macOS where VTK python package is installed
+    # in a standard location using CMake/SlicerBlockInstallExternalPythonModules.cmake
+    if(Slicer_VTK_VERSION_MAJOR VERSION_GREATER 8)
+      if(UNIX)
+        set(${proj}_PYTHONPATH_LAUNCHER_INSTALLED
+          <APPLAUNCHER_DIR>/${Slicer_INSTALL_LIB_DIR}/python2.7/site-packages
+          )
+      else()
+        set(${proj}_PYTHONPATH_LAUNCHER_INSTALLED
+          <APPLAUNCHER_DIR>/${Slicer_INSTALL_BIN_DIR}/Lib/site-packages
+          )
+      endif()
+    else()
+      set(${proj}_PYTHONPATH_LAUNCHER_INSTALLED
+        <APPLAUNCHER_DIR>/${Slicer_INSTALL_LIB_DIR}/python2.7/site-packages
+        )
+    endif()
     mark_as_superbuild(
       VARS ${proj}_PYTHONPATH_LAUNCHER_INSTALLED
       LABELS "PYTHONPATH_LAUNCHER_INSTALLED"


### PR DESCRIPTION
Suggested-by: Andras Lasso <lasso@queensu.ca>
Tested-by: Steve Pieper <pieper@bwh.harvard.edu>

See https://discourse.slicer.org/t/vtk-python-does-not-import-on-todays-windows-nightly/1868