### PR TITLE
ENH: Generate license-<projectname>.txt file for each external projects

### DIFF
--- a/CMake/ExternalProjectAddSource.cmake
+++ b/CMake/ExternalProjectAddSource.cmake
@@ -42,12 +42,18 @@
 #!     [PROJECTS <projectname> [<projectname> [...]]]
 #!     [LABELS <label1> [<label2> [...]]]
 #!     [VARS <name1>:<type1>=<value1> [<name2>:<type2>=<value2> [...]]]
+#!     #
+#!     # See ExternalProject_GenerateProjectDescription_Step
+#!     #
+#!     [VERSION <version>]
+#!     [LICENSE_FILES <file> [...]]
 #!   )
 #!
 function(ExternalProject_Add_Source projectname)
   set(options)
   set(_ep_one_args DOWNLOAD_DIR URL URL_MD5 GIT_REPOSITORY GIT_TAG SVN_REPOSITORY SVN_USERNAME SVN_PASSWORD SVN_TRUST_CERT)
-  set(oneValueArgs ${_ep_one_args} SOURCE_DIR_VAR)
+  set(_epgpd_one_args VERSION LICENSE_FILES)
+  set(oneValueArgs ${_ep_one_args} ${_epgpd_one_args} SOURCE_DIR_VAR)
   set(_ep_multi_args SVN_REVISION)
   set(multiValueArgs ${_ep_multi_args} LABELS PROJECTS VARS)
   cmake_parse_arguments(_ep "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -81,6 +87,17 @@ function(ExternalProject_Add_Source projectname)
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""
       INSTALL_COMMAND ""
+      )
+
+    set(_epgpd_args_to_pass)
+    foreach(arg ${_epgpd_one_args})
+      if(_ep_${arg})
+        list(APPEND _epgpd_args_to_pass ${arg} ${_ep_${arg}})
+      endif()
+    endforeach()
+
+    ExternalProject_GenerateProjectDescription_Step(${projectname}
+      ${_epgpd_args_to_pass}
       )
 
     set(${_ep_SOURCE_DIR_VAR} ${CMAKE_BINARY_DIR}/${projectname} PARENT_SCOPE)
@@ -137,6 +154,11 @@ endfunction()
 #!     ]
 #!     [LABELS REMOTE_MODULE]
 #!     [VARS <name1>:<type1>=<value1> [<name2>:<type2>=<value2> [...]]]
+#!     #
+#!     # See ExternalProject_GenerateProjectDescription_Step
+#!     #
+#!     [VERSION <version>]
+#!     [LICENSE_FILES <file> [...]]
 #!   )
 #!
 #! If no <option_name> is specified or if the option is enabled, the variable "Foo_SOURCE_DIR" set
@@ -154,7 +176,9 @@ endfunction()
 macro(Slicer_Remote_Add projectname)
   set(options)
   set(_add_source_args
-    DOWNLOAD_DIR URL URL_MD5 GIT_REPOSITORY GIT_TAG SVN_REPOSITORY SVN_USERNAME SVN_PASSWORD SVN_TRUST_CERT)
+    DOWNLOAD_DIR URL URL_MD5 GIT_REPOSITORY GIT_TAG SVN_REPOSITORY SVN_USERNAME SVN_PASSWORD SVN_TRUST_CERT
+    VERSION LICENSE_FILES
+    )
   set(oneValueArgs OPTION_NAME OPTION_DEFAULT OPTION_FORCE SOURCE_DIR_VAR ${_add_source_args})
   set(_add_source_multi_args SVN_REVISION LABELS PROJECTS VARS)
   set(multiValueArgs OPTION_DEPENDS ${_add_source_multi_args})

--- a/CMake/ExternalProjectGenerateProjectDescription.cmake
+++ b/CMake/ExternalProjectGenerateProjectDescription.cmake
@@ -33,14 +33,29 @@
 #! ExternalProject_GenerateProjectDescription_Step(<projectname>
 #!   [NAME <name>]
 #!   [VERSION <version>]
+#!   [LICENSE_FILES <file> [...]]
 #!   [SOURCE_DIR <source_dir>]
 #!   )
 #!
-#! Generate a project description file named 'version-<projectname>.txt'
-#! containing one line of the form '<projectname> <version>'.
+#! Generate the project description files describing its version
+#! and the license.
+#!
+#! The generate files are:
+#!
+#! * 'version-<projectname>.txt' containing one line of the form '<projectname> <version>'.
+#!
+#! * 'license-<projectname>.txt' containing the project licenses.
 #!
 #! VERSION If no <version> is specified, the version is extracted from the
 #!         <source_dir> running the command '${GIT_EXECUTABLE} describe --always'.
+#!
+#! LICENSE_FILES If no license files is specified, the first file found in this list
+#!               "NOTICE COPYRIGHT Copyright COPYING LICENSE License" is appended to 'license-<projectname>.txt'.
+#!               Files with the following extension are also considered: .md .rst .txt
+#!
+#!               If one or multiple URLs and/or paths relative to the project source
+#!               directory and/or absolute paths are specified, their content is appended
+#!               to 'license-<projectname>.txt'.
 #!
 #! NAME Specifying <name> parameter allows to override the name used to generate
 #!      the description file.
@@ -50,7 +65,7 @@
 #!
 function(ExternalProject_GenerateProjectDescription_Step projectname)
   set(options)
-  set(oneValueArgs NAME SOURCE_DIR VERSION)
+  set(oneValueArgs NAME SOURCE_DIR VERSION LICENSE_FILES)
   set(multiValueArgs)
   cmake_parse_arguments(_epgpd "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
@@ -59,33 +74,110 @@ function(ExternalProject_GenerateProjectDescription_Step projectname)
     set(name ${_epgpd_NAME})
   endif()
 
-  set(description_file "version-${name}.txt")
+  set(generated_version_file "version-${name}.txt")
+  set(generated_license_file "license-${name}.txt")
+
+  set(extract_git_version 1)
 
   if(_epgpd_VERSION)
-    file(WRITE ${CMAKE_BINARY_DIR}/${description_file} "${name} ${_epgpd_VERSION}")
-    return()
+    file(WRITE ${CMAKE_BINARY_DIR}/${generated_version_file} "${name} ${_epgpd_VERSION}")
+    set(extract_git_version 0)
   endif()
 
-  set(script "${CMAKE_BINARY_DIR}/CMakeFiles/${projectname}-generate-project-description.cmake")
+  set(explicit_licenses 1)
 
-  file(WRITE "${script}"
-"execute_process(
-  COMMAND \"${GIT_EXECUTABLE}\" describe --always
-  OUTPUT_VARIABLE output
-  )
-file(WRITE \"${CMAKE_BINARY_DIR}/${description_file}\" \"${name} \${output}\")
-")
+  if(NOT _epgpd_LICENSE_FILES)
+    foreach(filename IN ITEMS NOTICE COPYRIGHT Copyright COPYING LICENSE License)
+      foreach(ext IN ITEMS "" .md .rst .txt)
+        list(APPEND _epgpd_LICENSE_FILES ${filename}${ext})
+      endforeach()
+    endforeach()
+    set(explicit_licenses 0)
+  endif()
 
   ExternalProject_Get_property(${projectname} SOURCE_DIR)
   if(_epgpd_SOURCE_DIR)
     set(SOURCE_DIR ${_epgpd_SOURCE_DIR})
   endif()
+
+  set(script "${CMAKE_BINARY_DIR}/CMakeFiles/${projectname}-generate-project-description.cmake")
+
+  file(WRITE "${script}"
+"# version
+set(extract_git_version \"${extract_git_version}\")
+set(license_files ${_epgpd_LICENSE_FILES})
+set(explicit_licenses ${explicit_licenses})
+set(BINARY_DIR \"${CMAKE_BINARY_DIR}\")
+set(SOURCE_DIR \"${SOURCE_DIR}\")
+if(\${extract_git_version})
+  execute_process(
+    COMMAND \"${GIT_EXECUTABLE}\" describe --always
+    OUTPUT_VARIABLE output
+    WORKING_DIRECTORY \${SOURCE_DIR}
+    )
+  file(WRITE \"\${BINARY_DIR}/${generated_version_file}\" \"${name} \${output}\")
+endif()
+
+# license
+file(REMOVE \"\${BINARY_DIR}/${generated_license_file}\")
+
+set(license_found 0)
+foreach(license_file IN LISTS license_files)
+  if(IS_ABSOLUTE \${license_file})
+    set(filepath \${license_file})
+  else()
+    set(filepath \${SOURCE_DIR}/\${license_file})
+  endif()
+  if(license_file MATCHES \"^http\")
+    set(filepath \${BINARY_DIR}/CMakeFiles/download-license)
+    file(DOWNLOAD \${license_file} \${filepath})
+  endif()
+  if(EXISTS \${filepath})
+    file(READ \${filepath} license_content)
+    file(APPEND \"\${BINARY_DIR}/${generated_license_file}\"
+\"#------------------------------------------------------------------------------
+# \${license_file}
+#------------------------------------------------------------------------------
+\${license_content}
+
+\")
+    set(license_found 1)
+    if(NOT explicit_licenses AND license_found)
+      break()
+    endif()
+  endif()
+endforeach()
+
+if(NOT license_found AND EXISTS \${SOURCE_DIR}/setup.py)
+  # Extract string of the form 'License [:: <text> [...]]:: <license_name>'
+  file(STRINGS \${SOURCE_DIR}/setup.py content REGEX \"License :: (.*)\" LIMIT_COUNT 1)
+  string(STRIP \${content} content)
+  # Extract <license_name>
+  string(REGEX MATCH \".+:: (.+)$\" _match \${content})
+  set(license_name \${CMAKE_MATCH_1})
+  string(REGEX REPLACE \"[\\\",']\" \"\" license_name \${license_name})
+  set(content \"${projectname} is distributed under the terms of \${license_name}\")
+  if(NOT license_name)
+    message(FATAL_ERROR \"${name}: Failed to extract license information from '\${SOURCE_DIR}/setup.py'\")
+  endif()
+  file(APPEND \"\${BINARY_DIR}/${generated_license_file}\" \"\${content}
+\")
+  set(license_found 1)
+endif()
+
+if(NOT license_found)
+  message(FATAL_ERROR \"${name}: Could not find a license file\")
+endif()
+")
   
   ExternalProject_Add_Step(${projectname} generate_project_description
     COMMAND ${CMAKE_COMMAND} -P ${script}
-    COMMENT "Generate ${description_file}"
+    COMMENT "Generate ${generated_version_file} and ${generated_license_file}"
     DEPENDEES download
-    BYPRODUCTS ${CMAKE_BINARY_DIR}/${description_file}
+    DEPENDS ${script}
+    BYPRODUCTS
+      ${CMAKE_BINARY_DIR}/${generated_version_file}
+      ${CMAKE_BINARY_DIR}/${generated_license_file}
     WORKING_DIRECTORY ${SOURCE_DIR}
     )
 

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -212,6 +212,8 @@ endmacro()
 Slicer_Remote_Add(jqPlot
   URL http://slicer.kitware.com/midas3/download?items=15065&dummy=jquery.jqplot.1.0.4r1120.tar.gz
   URL_MD5 5c5d73730145c3963f09e1d3ca355580
+  LICENSE_FILES "MIT-LICENSE.txt"
+  VERSION "1.0.4"
   SOURCE_DIR_VAR jqPlot_DIR
   LABELS FIND_PACKAGE
   )
@@ -220,6 +222,7 @@ list(APPEND Slicer_REMOTE_DEPENDENCIES jqPlot)
 Slicer_Remote_Add(OpenIGTLinkIF
   GIT_REPOSITORY ${git_protocol}://github.com/Slicer/OpenIGTLinkIF.git
   GIT_TAG 0266aa27ad19a00f8d2b1c04736b9f3d3fb25aee
+  LICENSE_FILES "https://www.slicer.org/LICENSE"
   OPTION_NAME Slicer_BUILD_OpenIGTLinkIF
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_USE_OpenIGTLink"
   LABELS REMOTE_MODULE
@@ -250,6 +253,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeImporter Slicer_REMOTE_DEPENDENC
 Slicer_Remote_Add(SimpleFilters
   GIT_REPOSITORY ${git_protocol}://github.com/SimpleITK/SlicerSimpleFilters.git
   GIT_TAG 0e0648faeea0b3cbb8c27a93be0d95253ce13b98
+  LICENSE_FILES "https://www.slicer.org/LICENSE"
   OPTION_NAME Slicer_BUILD_SimpleFilters
   OPTION_DEPENDS "Slicer_BUILD_QTSCRIPTEDMODULES;Slicer_USE_SimpleITK"
   LABELS REMOTE_MODULE
@@ -301,6 +305,7 @@ set(BRAINSTools_options
 Slicer_Remote_Add(BRAINSTools
   GIT_REPOSITORY "${git_protocol}://github.com/Slicer/BRAINSTools.git"
   GIT_TAG "c1289e6686f3fd27db2ce0ea19c36e9792e40d2a" # master (from 2017-11-29, post v4.7.1)
+  LICENSE_FILES "http://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"
   LABELS REMOTE_MODULE
@@ -316,6 +321,8 @@ endif()
 Slicer_Remote_Add(EMSegment
   SVN_REPOSITORY "http://svn.slicer.org/Slicer3/branches/Slicer4-EMSegment"
   SVN_REVISION -r "17145"
+  LICENSE_FILES "https://www.slicer.org/LICENSE"
+  VERSION ${Slicer_VERSION}
   OPTION_NAME Slicer_BUILD_EMSegment
   OPTION_DEPENDS "Slicer_BUILD_BRAINSTOOLS;Slicer_BUILD_QTLOADABLEMODULES;Slicer_USE_PYTHONQT_WITH_TCL"
   LABELS REMOTE_MODULE

--- a/SuperBuild/External_CTKAPPLAUNCHER.cmake
+++ b/SuperBuild/External_CTKAPPLAUNCHER.cmake
@@ -53,6 +53,7 @@ if(Slicer_USE_CTKAPPLAUNCHER)
 
     ExternalProject_GenerateProjectDescription_Step(${proj}
       VERSION ${launcher_version}
+      LICENSE_FILES "https://raw.githubusercontent.com/commontk/AppLauncher/v${launcher_version}/LICENSE_Apache_20"
       )
 
     set(CTKAppLauncher_DIR ${EP_BINARY_DIR})

--- a/SuperBuild/External_CTKAppLauncherLib.cmake
+++ b/SuperBuild/External_CTKAppLauncherLib.cmake
@@ -69,7 +69,9 @@ if(NOT DEFINED CTKAppLauncherLib_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${
       ${${proj}_DEPENDENCIES}
     )
 
-  ExternalProject_GenerateProjectDescription_Step(${proj})
+  ExternalProject_GenerateProjectDescription_Step(${proj}
+    LICENSE_FILES "https://raw.githubusercontent.com/commontk/AppLauncher/v${launcher_version}/LICENSE_Apache_20"
+    )
 
   set(CTKAppLauncherLib_DIR ${EP_BINARY_DIR})
 

--- a/SuperBuild/External_incrTcl.cmake
+++ b/SuperBuild/External_incrTcl.cmake
@@ -65,6 +65,11 @@ ExternalProject_Execute(${proj} \"install\" make install)
         ${${proj}_DEPENDENCIES}
     )
 
+    ExternalProject_GenerateProjectDescription_Step(${proj}
+      VERSION ${INCR_TCL_VERSION_DOT}
+      LICENSE_FILES "https://github.com/tcltk/itcl/blob/master/license.terms"
+      )
+
     #-----------------------------------------------------------------------------
     # Launcher setting specific to build tree
 

--- a/SuperBuild/External_tcl.cmake
+++ b/SuperBuild/External_tcl.cmake
@@ -183,6 +183,7 @@ ExternalProject_Execute(${proj} \"install\" make install)
 
   ExternalProject_GenerateProjectDescription_Step(${proj}
     VERSION ${TCL_TK_VERSION_DOT}
+    LICENSE_FILES "https://github.com/tcltk/tcl/blob/master/license.terms"
     )
 
   #-----------------------------------------------------------------------------


### PR DESCRIPTION
This will help compose the list of open source packages used in a Slicer
based application based on the enables options.