### PR TITLE
BUG: Plotting fixes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLPlotChartNode.h
+++ b/Libs/MRML/Core/vtkMRMLPlotChartNode.h
@@ -79,6 +79,15 @@ class VTK_MRML_EXPORT vtkMRMLPlotChartNode : public vtkMRMLNode
     PlotModifiedEvent = 17000,
     };
 
+  /// Properties used by SetPropertyToAllPlots and GetPropertyFromAllPlots methods.
+  enum PlotDataNodeProperty
+  {
+    PlotType,
+    PlotXColumnName,
+    PlotYColumnName,
+    PlotMarkerStyle
+  };
+
   //----------------------------------------------------------------
   /// Access methods
   //----------------------------------------------------------------
@@ -200,18 +209,15 @@ class VTK_MRML_EXPORT vtkMRMLPlotChartNode : public vtkMRMLNode
   /// \li  "AxisLabelFontSize" - default: "12"
   /// \li  "LookupTable" colorNodeID default: NULL
   ///
-  /// Further attributes of PlotChartNode are connected with
-  /// the PlotDataProperties. If they are have value "Custom"
-  /// then each PlotDataNode has its individual value. If another
-  /// value is chosen, all the PlotDataNodes referenced by the
-  /// PlotChartNode will be updated with the new value.
-  ///
-  /// \li  "Type" - "Custom", "Line", "Scatter", "Bar"
-  /// \li  "XAxis" - Set XAxis "Custom", "..." (list of Columns)
-  /// \li  "Markers" - show markers "Custom", "Cross", "Plus", "Square", "Circle", "Diamond"
-  ///
 
   virtual const char* GetPlotDataNodeReferenceRole();
+
+  /// Helper function to set common properties for all associated plot data nodes
+  void SetPropertyToAllPlots(PlotDataNodeProperty plotProperty, const char* value);
+
+  /// Helper function to get common properties from all associated plot data nodes.
+  /// If property is not the same in all plots then empty string is returned.
+  std::string GetPropertyFromAllPlots(PlotDataNodeProperty plotProperty);
 
  protected:
   //----------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
@@ -76,8 +76,6 @@ qMRMLPlotViewControllerWidgetPrivate::qMRMLPlotViewControllerWidgetPrivate(
   this->PlotChartNode = 0;
   this->PlotViewNode = 0;
   this->PlotView = 0;
-
-  this->SelectionNode = 0;
 }
 
 //---------------------------------------------------------------------------
@@ -207,7 +205,7 @@ void qMRMLPlotViewControllerWidgetPrivate::onPlotChartNodeSelected(vtkMRMLNode *
 
   vtkMRMLPlotChartNode *mrmlPlotChartNode = vtkMRMLPlotChartNode::SafeDownCast(node);
 
-  if (!this->PlotViewNode || !this->SelectionNode || this->PlotChartNode == mrmlPlotChartNode)
+  if (!this->PlotViewNode || this->PlotChartNode == mrmlPlotChartNode)
     {
     return;
     }
@@ -216,27 +214,18 @@ void qMRMLPlotViewControllerWidgetPrivate::onPlotChartNodeSelected(vtkMRMLNode *
                       q, SLOT(updateWidgetFromMRML()));
 
   this->PlotChartNode = mrmlPlotChartNode;
-  this->SelectionNode->SetActivePlotChartID(mrmlPlotChartNode ? mrmlPlotChartNode->GetID() : "");
   this->PlotViewNode->SetPlotChartNodeID(mrmlPlotChartNode ? mrmlPlotChartNode->GetID() : NULL);
+
+  vtkMRMLSelectionNode* selectionNode = vtkMRMLSelectionNode::SafeDownCast(
+    q->mrmlScene() ? q->mrmlScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton") : NULL);
+  if (selectionNode)
+    {
+    selectionNode->SetActivePlotChartID(mrmlPlotChartNode ? mrmlPlotChartNode->GetID() : "");
+    }
 
   q->updateWidgetFromMRML();
 }
 
-// --------------------------------------------------------------------------
-void qMRMLPlotViewControllerWidgetPrivate::onSelectionNodeModified()
-{
-  Q_Q(qMRMLPlotViewControllerWidget);
-
-  if (!this->SelectionNode || !q->mrmlScene())
-    {
-    return;
-    }
-
-  vtkMRMLPlotChartNode *mrmlPlotChartNode = vtkMRMLPlotChartNode::SafeDownCast(
-    q->mrmlScene()->GetNodeByID(this->SelectionNode->GetActivePlotChartID()));
-
-  this->onPlotChartNodeSelected(mrmlPlotChartNode);
-}
 
 // --------------------------------------------------------------------------
 void qMRMLPlotViewControllerWidgetPrivate::onPlotDataNodesSelected()
@@ -962,20 +951,6 @@ void qMRMLPlotViewControllerWidget::setMRMLScene(vtkMRMLScene* newScene)
 
   d->plotChartComboBox->blockSignals(plotChartBlockSignals);
   d->plotDataComboBox->blockSignals(plotBlockSignals);
-
-  vtkMRMLSelectionNode* selectionNode = vtkMRMLSelectionNode::SafeDownCast(
-    this->mrmlScene() ? this->mrmlScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton") : NULL);
-
-  if (!selectionNode)
-    {
-    return;
-    }
-
-  this->qvtkReconnect(d->SelectionNode, selectionNode, vtkCommand::ModifiedEvent,
-                      d, SLOT(onSelectionNodeModified()));
-
-  d->SelectionNode = selectionNode;
-  d->onSelectionNodeModified();
 
   if (this->mrmlScene())
     {

--- a/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget_p.h
@@ -43,7 +43,6 @@ class QAction;
 class qMRMLSceneViewMenu;
 class vtkMRMLPlotViewNode;
 class vtkMRMLPlotChartNode;
-class vtkMRMLSelectionNode;
 class QString;
 
 //-----------------------------------------------------------------------------
@@ -64,7 +63,6 @@ public:
 
   vtkWeakPointer<vtkMRMLPlotChartNode>   PlotChartNode;
   vtkWeakPointer<vtkMRMLPlotViewNode>    PlotViewNode;
-  vtkWeakPointer<vtkMRMLSelectionNode>   SelectionNode;
   qMRMLPlotView*                         PlotView;
 
   QString                                PlotViewLabel;
@@ -76,9 +74,6 @@ public slots:
   /// Called after a PlotChartNode is selected
   /// using the associated qMRMLNodeComboBox.
   void onPlotChartNodeSelected(vtkMRMLNode* node);
-
-  /// Called when the Singleton SelectionNode is modified.
-  void onSelectionNodeModified();
 
   /// Called after an PlotDataNode is selected
   /// using the associated qMRMLNodeComboBox.


### PR DESCRIPTION
1. Prevent changing chart node in all viewers when it is changed in one

When plot chart node selection was changed in one plot widget, it changed plot chart node selection in all other plot widgets.
This prevented showing different charts in different widgets.

Active node in Selection node should not be used for immediately updating all views, but instead it should only be done when vtkMRMLApplicationLogic::PropagatePlotChartSelection is called.

2. Made PlotView input setting more robust: prevent crash when scene is set after plot view node, allow using the view without setting color logic (log warning only if not set).

3. Removed modification of MRML nodes in qMRMLPlotViewControllerWidget::updateWidgetFromMRML

Problem: Common PlotData type, x column name, and marker style was stored in vtkMRMLPlotChartNode. However, this information may get out of sync with actual common properties in associated PlotData nodes. Consolidation of redundant information happened in qMRMLPlotViewControllerWidget::updateWidgetFromMRML, by modifying PlotData nodes. In general, MRML nodes must not be modified in updateWidgetFromMRML calls and data redundancy should be avoided.

Solution: Do not store redundant information in PlotChart node. Common PlotData type, x column name, and marker style is determined when needed, by looking into associated PlotData nodes. When user changes a common property on the GUI, PlotData nodes are updated immediately.