### PR TITLE
RFC: make retrieveExtensionMetadata public, accept QVariantMap?

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -220,9 +220,6 @@ public:
 
   void saveExtensionDescription(const QString& extensionDescriptionFile, const ExtensionMetadataType &allExtensionMetadata);
 
-  qSlicerExtensionsManagerModel::ExtensionMetadataType retrieveExtensionMetadata(
-    const qMidasAPI::ParametersType& parameters);
-
   void initializeColumnIdToNameMap(int columnIdx, const char* columnName);
   QHash<int, QString> ColumnIdToName;
   QStringList ColumnNames;
@@ -820,38 +817,6 @@ void qSlicerExtensionsManagerModelPrivate::initializeColumnIdToNameMap(int colum
 }
 
 // --------------------------------------------------------------------------
-qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerModelPrivate
-::retrieveExtensionMetadata(const qMidasAPI::ParametersType& parameters)
-{
-  Q_Q(const qSlicerExtensionsManagerModel);
-
-  bool ok = false;
-  QList<QVariantMap> results = qMidasAPI::synchronousQuery(
-        ok, q->serverUrl().toString(),
-        "midas.slicerpackages.extension.list", parameters);
-  if (!ok || results.count() != 1)
-    {
-    this->critical(results[0]["queryError"].toString());
-    return ExtensionMetadataType();
-    }
-  ExtensionMetadataType result = results.at(0);
-
-  if (!qSlicerExtensionsManagerModelPrivate::validateExtensionMetadata(result))
-    {
-    return ExtensionMetadataType();
-    }
-
-  ExtensionMetadataType updatedExtensionMetadata;
-  foreach(const QString& key, result.keys())
-    {
-    updatedExtensionMetadata.insert(
-      q->serverToExtensionDescriptionKey().value(key, key), result.value(key));
-    }
-
-  return updatedExtensionMetadata;
-}
-
-// --------------------------------------------------------------------------
 // qSlicerExtensionsManagerModel methods
 
 // --------------------------------------------------------------------------
@@ -1119,30 +1084,55 @@ qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerMod
     return ExtensionMetadataType();
     }
 
-  qMidasAPI::ParametersType parameters;
+  QVariantMap parameters;
   parameters["extension_id"] = extensionId;
 
-  return d->retrieveExtensionMetadata(parameters);
+  return this->retrieveExtensionMetadata(parameters);
 }
 
 // --------------------------------------------------------------------------
 qSlicerExtensionsManagerModel::ExtensionMetadataType qSlicerExtensionsManagerModel
-::retrieveExtensionMetadataByName(const QString& extensionName)
+::retrieveExtensionMetadata(const QVariantMap& paramMap)
 {
-  Q_D(qSlicerExtensionsManagerModel);
+  Q_D(const qSlicerExtensionsManagerModel);
 
-  if (extensionName.isEmpty())
+  qMidasAPI::ParametersType parameters;
+  foreach(const QString& key, paramMap.keys())
+    {
+    QVariant val(paramMap[key]);
+    if (!val.canConvert(QVariant::String))
+      {
+      d->critical("retrieveExtensionMetadata map values must be convertible to QString!");
+      return ExtensionMetadataType();
+      }
+
+    parameters[key] = paramMap.value(key).toString();
+    }
+
+  bool ok = false;
+  QList<QVariantMap> results = qMidasAPI::synchronousQuery(
+        ok, this->serverUrl().toString(),
+        "midas.slicerpackages.extension.list", parameters);
+  if (!ok || results.count() != 1)
+    {
+    d->critical(results[0]["queryError"].toString());
+    return ExtensionMetadataType();
+    }
+  ExtensionMetadataType result = results.at(0);
+
+  if (!qSlicerExtensionsManagerModelPrivate::validateExtensionMetadata(result))
     {
     return ExtensionMetadataType();
     }
 
-  qMidasAPI::ParametersType parameters;
-  parameters["productname"] = extensionName;
-  parameters["slicer_revision"] = this->slicerRevision();
-  parameters["os"] = this->slicerOs();
-  parameters["arch"] = this->slicerArch();
+  ExtensionMetadataType updatedExtensionMetadata;
+  foreach(const QString& key, result.keys())
+    {
+    updatedExtensionMetadata.insert(
+      this->serverToExtensionDescriptionKey().value(key, key), result.value(key));
+    }
 
-  return d->retrieveExtensionMetadata(parameters);
+  return updatedExtensionMetadata;
 }
 
 // --------------------------------------------------------------------------
@@ -1376,14 +1366,14 @@ bool qSlicerExtensionsManagerModel::installExtension(
         continue;
         }
 
-      qMidasAPI::ParametersType parameters;
+      QVariantMap parameters;
       parameters["productname"] = dependencyName;
       parameters["slicer_revision"] = this->slicerRevision();
       parameters["os"] = this->slicerOs();
       parameters["arch"] = this->slicerArch();
 
       const ExtensionMetadataType& dependencyMetadata =
-        d->retrieveExtensionMetadata(parameters);
+        this->retrieveExtensionMetadata(parameters);
       if (dependencyMetadata.contains("extension_id"))
         {
         dependenciesMetadata.insert(dependencyName, dependencyMetadata);

--- a/Base/QTCore/qSlicerExtensionsManagerModel.h
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.h
@@ -177,9 +177,9 @@ public:
   /// \sa setServerUrl
   Q_INVOKABLE ExtensionMetadataType retrieveExtensionMetadata(const QString& extensionId);
 
-  /// \brief Query the extension server and retrieve the metadata associated with \a extensionName
+  /// \brief Query the extension server and retrieve the metadata associated with \a parameter list
   /// \sa setServerUrl
-  Q_INVOKABLE ExtensionMetadataType retrieveExtensionMetadataByName(const QString& extensionName);
+  Q_INVOKABLE ExtensionMetadataType retrieveExtensionMetadata(const QVariantMap& paramMap);
 
   /// Install extension from the specified archive file.
   ///

--- a/Modules/Scripted/DMRIInstall/DMRIInstall.py
+++ b/Modules/Scripted/DMRIInstall/DMRIInstall.py
@@ -116,7 +116,11 @@ class DMRIInstallWidget(ScriptedLoadableModuleWidget):
       self.applyButton.enabled = False
       return
 
-    md = emm.retrieveExtensionMetadataByName("SlicerDMRI")
+    md = emm.retrieveExtensionMetadata(
+                  {'productname': 'SlicerDMRI',
+                   'os': emm.slicerOs,
+                   'slicer_revision': emm.slicerRevision,
+                   'arch': emm.slicerArch})
 
     if not md or not md.has_key('extension_id'):
       return self.onError()


### PR DESCRIPTION
Follow-up to https://github.com/Slicer/Slicer/pull/863#issuecomment-358000228 before I forget:

I noticed that qRestAPI::Parameters is just a QMap<string,string> typedef, so #883 could be reworked for more general use. Then the parameter is automatically wrapped for auto-conversion from a Python dict, and we could use it from Python to query arbitrary metadata combinations instead of only extension-by-name (for example to simplify the Midas query implementation in ExtensionStats).

- [ ] **One question though**: should we add an API to return an array if there are multiple results? Right now there are internal checks whether more than one result was returned from the query, in which case the function just returns an empty dict.