### PR TITLE
BUG: Fixing the empty dialog on startup

### DIFF
--- a/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsRestoreWidget.cxx
@@ -183,6 +183,7 @@ void qSlicerExtensionsRestoreWidgetPrivate
   this->silentInstallOnStartup->setText(QObject::tr("Install previous extensions without request"));
 
   this->progressDialog->setWindowFlags(Qt::WindowStaysOnTopHint | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
+  this->progressDialog->close();
 
   installButton->setText(QObject::tr("Install Selected"));
   layoutForProgressAndButton->addWidget(this->progressBar);


### PR DESCRIPTION
The progress dialog of SlicerExtensionRestoreWidget was enabled at the initialization causing it to show up. Right now closing it during the initialization so that the pop up does not show. Ideally maybe the instance of the ProgressDialog should be created and deleted only when it's needed!