### PR TITLE
ENH: Support passing markups to CLI specifying IJK coordinate

### DIFF
--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
@@ -190,8 +190,22 @@
     <description><![CDATA[Parameters that describe point sets.]]></description>
     <point multiple="true" coordinateSystem="ras">
       <name>seed</name>
-      <label>Seeds</label>
-      <longflag>--seed</longflag>
+      <label>Seeds RAS</label>
+      <longflag>--seed_ras</longflag>
+      <description><![CDATA[Lists of points in the CLI correspond to slicer fiducial lists]]></description>
+      <default>0,0,0</default>
+    </point>
+    <point multiple="true" coordinateSystem="lps">
+      <name>seed_lps</name>
+      <label>Seeds LPS</label>
+      <longflag>--seed_lps</longflag>
+      <description><![CDATA[Lists of points in the CLI correspond to slicer fiducial lists]]></description>
+      <default>0,0,0</default>
+    </point>
+    <point multiple="true" coordinateSystem="ijk">
+      <name>seed_ijk</name>
+      <label>Seeds IJK</label>
+      <longflag>--seed_ijk</longflag>
       <description><![CDATA[Lists of points in the CLI correspond to slicer fiducial lists]]></description>
       <default>0,0,0</default>
     </point>

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -330,11 +330,10 @@ int vtkMRMLMarkupsFiducialStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
               }
             else
               {
-              // IJK not implemented yet, assume RAS
-              markupsNode->SetMarkupPoint(thisMarkupNumber,0,x,y,z);
+              markupsNode->SetMarkupPointIJK(thisMarkupNumber,0,x,y,z);
               }
 
-            // orientatation
+            // orientation
             getline(ss, component, ',');
             ow = atof(component.c_str());
             getline(ss, component, ',');

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -20,6 +20,7 @@
 
 // MRML includes
 #include "vtkMRMLDisplayableNode.h"
+class vtkMRMLVolumeNode;
 
 // Markups includes
 #include "vtkSlicerMarkupsModuleMRMLExport.h"
@@ -94,7 +95,7 @@ public:
 
   /// Write this node's information to a vector of strings for passing to a CLI,
   /// precede each datum with the prefix if not an empty string
-  /// coordinateSystemFlag = 0 for RAS, 1 for LPS
+  /// coordinateSystemFlag = 0 for RAS, 1 for LPS, 2 for IJK
   /// multipleFlag = 1 for the whole list, 1 for the first selected markup
   virtual void WriteCLI(std::vector<std::string>& commandLine,
                         std::string prefix, int coordinateSystem = 0,
@@ -202,6 +203,10 @@ public:
   void GetMarkupPoint(int markupIndex, int pointIndex, double point[3]);
   /// Get points in LPS coordinate system
   void GetMarkupPointLPS(int markupIndex, int pointIndex, double point[3]);
+  /// Get points in IJK coordinate system
+  /// \sa SetAndObserveReferenceImageNodeID
+  void GetMarkupPointIJK(int markupIndex, int pointIndex, double point[3]);
+
   /// Return a three element double giving the world position (any parent
   /// transform on the markup applied to the return of GetMarkupPoint.
   /// Returns 0 on failure, 1 on success.
@@ -234,6 +239,11 @@ public:
   /// Set a point in a markup using LPS coordinate system, converting to RAS
   /// \sa SetMarkupPoint
   void SetMarkupPointLPS(const int markupIndex, const int pointIndex, const double x, const double y, const double z);
+  /// Set a point in a markup using IJK coordinate system, converting to RAS
+  /// \sa SetMarkupPoint
+  /// \sa SetAndObserveReferenceImageNodeID
+  void SetMarkupPointIJK(const int markupIndex, const int pointIndex, const double x, const double y, const double z);
+
   /// Set the markupIndex markup's point pointIndex to xyz transformed
   /// by the inverse of the transform to world for the node.
   /// Calls SetMarkupPoint after transforming the passed in coordinate
@@ -341,11 +351,31 @@ public:
   /// scene. Returns false if n out of bounds, true on success.
   bool ResetNthMarkupID(int n);
 
+  virtual const char* GetReferenceImageNodeReferenceRole();
+
+  /// Get ID of the reference image associated with this markups node.
+  /// \sa SetAndObserveReferenceImageNodeID
+  const char* GetReferenceImageNodeID();
+
+  /// Associate this markups node with a reference image.
+  ///
+  /// This is required to successfully use method converting to/from IJK
+  /// coordinate system.
+  ///
+  /// \sa SetMarkupPointIJK, GetMarkupPointIJK, WriteCLI
+  /// \sa GetReferenceImageNodeID
+  void SetAndObserveReferenceImageNodeID(const char* referenceImageNodeID);
+
 protected:
   vtkMRMLMarkupsNode();
   ~vtkMRMLMarkupsNode();
   vtkMRMLMarkupsNode(const vtkMRMLMarkupsNode&);
   void operator=(const vtkMRMLMarkupsNode&);
+
+  static const char* ReferenceImageNodeReferenceRole;
+  static const char* ReferenceImageNodeReferenceMRMLAttributeName;
+
+  virtual const char* GetReferenceImageNodeReferenceMRMLAttributeName();
 
   vtkStringArray *TextList;
 


### PR DESCRIPTION
This commit allows associating any markupsNode with a reference image. The
association is then used to automatically convert to/from IJK coordinate
using SetMarkupPointIJK()/GetMarkupPointIJK() used in vtkMarkupsNode::WriteCLI().

Co-authored-by: Deepak Chittajallu <deepak.chittajallu@kitware.com>