### PR TITLE
ENH: Added MRML node property macros

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -36,25 +36,25 @@ static const char* DEFAULT_AXIS_LABELS[vtkMRMLAbstractViewNode::AxisLabelsCount]
 
 //----------------------------------------------------------------------------
 vtkMRMLAbstractViewNode::vtkMRMLAbstractViewNode()
+: LayoutLabel(NULL)
+, ViewGroup(0)
+, Active(0)
+, Visibility(1)
+, OrientationMarkerEnabled(false)
+, OrientationMarkerType(OrientationMarkerTypeNone)
+, OrientationMarkerSize(OrientationMarkerSizeMedium)
+, RulerEnabled(false)
+, RulerType(RulerTypeNone)
 {
-  this->LayoutLabel = NULL;
-  this->ViewGroup = 0;
-  this->Active = 0;
-  this->Visibility = 1;
-
-  double black[3] = {0.,0.,0.};
-  memcpy(this->BackgroundColor, black, 3 * sizeof(double));
-  memcpy(this->BackgroundColor2, black, 3 * sizeof(double));
+  this->BackgroundColor[0] = 0.0;
+  this->BackgroundColor[1] = 0.0;
+  this->BackgroundColor[2] = 0.0;
+  this->BackgroundColor2[0] = 0.0;
+  this->BackgroundColor2[1] = 0.0;
+  this->BackgroundColor2[2] = 0.0;
 
   this->SetLayoutLabel("1");
   this->SetHideFromEditors(0);
-
-  this->OrientationMarkerEnabled = false;
-  this->OrientationMarkerType = OrientationMarkerTypeNone;
-  this->OrientationMarkerSize = OrientationMarkerSizeMedium;
-
-  this->RulerEnabled = false;
-  this->RulerType = RulerTypeNone;
 
   this->AxisLabels = vtkSmartPointer<vtkStringArray>::New();
   for (int i=0; i<vtkMRMLAbstractViewNode::AxisLabelsCount; i++)
@@ -76,39 +76,27 @@ void vtkMRMLAbstractViewNode::WriteXML(ostream& of, int nIndent)
 
   this->Superclass::WriteXML(of, nIndent);
 
-  if (this->GetLayoutLabel())
-    {
-    of << " layoutLabel=\"" << this->GetLayoutLabel() << "\"";
-    }
-  if (this->GetLayoutName())
-    {
-    of << " layoutName=\"" << this->GetLayoutName() << "\"";
-    }
+  vtkMRMLWriteXMLBeginMacro(of)
+  vtkMRMLWriteXMLStringMacro(layoutLabel, LayoutLabel)
+  vtkMRMLWriteXMLStringMacro(layoutName, LayoutName)
   if (this->GetViewGroup() > 0)
     {
-    of << " viewGroup=\"" << this->GetViewGroup() << "\"";
+    vtkMRMLWriteXMLBooleanMacro(viewGroup, ViewGroup)
     }
-
-  of << " active=\"" << (this->Active ? "true" : "false") << "\"";
-  of << " visibility=\"" << (this->Visibility ? "true" : "false") << "\"";
-
-  // background color
-  of << " backgroundColor=\"" << this->BackgroundColor[0] << " "
-     << this->BackgroundColor[1] << " " << this->BackgroundColor[2] << "\"";
-
-  of << " backgroundColor2=\"" << this->BackgroundColor2[0] << " "
-     << this->BackgroundColor2[1] << " " << this->BackgroundColor2[2] << "\"";
-
+  vtkMRMLWriteXMLBooleanMacro(active, Active)
+  vtkMRMLWriteXMLBooleanMacro(visibility, Visibility)
+  vtkMRMLWriteXMLVectorMacro(backgroundColor, BackgroundColor, double, 3)
+  vtkMRMLWriteXMLVectorMacro(backgroundColor2, BackgroundColor2, double, 3)
   if (this->OrientationMarkerEnabled)
     {
-    of << " orientationMarkerType=\"" << this->GetOrientationMarkerTypeAsString(this->OrientationMarkerType) << "\"";
-    of << " orientationMarkerSize=\"" << this->GetOrientationMarkerSizeAsString(this->OrientationMarkerSize) << "\"";
+    vtkMRMLWriteXMLEnumMacro(orientationMarkerType, OrientationMarkerType)
+    vtkMRMLWriteXMLEnumMacro(orientationMarkerSize, OrientationMarkerSize)
     }
-
   if (this->RulerEnabled)
     {
-    of << " rulerType=\"" << this->GetRulerTypeAsString(this->RulerType) << "\"";
+    vtkMRMLWriteXMLEnumMacro(rulerType, RulerType)
     }
+  vtkMRMLWriteXMLEndMacro()
 
   of << " AxisLabels=\"";
   for (int i=0; i<vtkMRMLAbstractViewNode::AxisLabelsCount; i++)
@@ -126,105 +114,42 @@ void vtkMRMLAbstractViewNode::ReadXMLAttributes(const char** atts)
 
   this->Superclass::ReadXMLAttributes(atts);
 
+  this->BackgroundColor2[0] = -1; // indicates that it is not set
+
+  vtkMRMLReadXMLBeginMacro(atts)
+  vtkMRMLReadXMLStringMacro(layoutLabel, LayoutLabel)
+  vtkMRMLReadXMLStringMacro(layoutName, LayoutName)
+  vtkMRMLReadXMLBooleanMacro(viewGroup, ViewGroup)
+  vtkMRMLReadXMLBooleanMacro(active, Active)
+
+  // XXX Do not read 'visibility' attribute and default to 1 because:
+  // (1) commit r21034 (STYLE: Add abstract class for all view nodes)
+  // changed the default value for 'visibility' attribute from 1 to 0. This
+  // means there are a lot of already saved scene where visibility attribute
+  // value is saved as 0.
+  // (2) support for visibility attribute by the layout manager has been
+  // added.
+  // XXX Support for 'visibility' attribute could be restored by updating
+  // the mrml version. Scene with a newer version number would consider the
+  // serialized attribute whereas older scene would not.
+  //
+  // vtkMRMLReadXMLBooleanMacro(visibility, Visibility)
+
+  vtkMRMLReadXMLVectorMacro(backgroundColor, BackgroundColor, double, 3)
+  vtkMRMLReadXMLVectorMacro(backgroundColor2, BackgroundColor2, double, 3)
+  vtkMRMLReadXMLEnumMacro(orientationMarkerType, OrientationMarkerType)
+  vtkMRMLReadXMLEnumMacro(orientationMarkerSize, OrientationMarkerSize)
+  vtkMRMLReadXMLEnumMacro(rulerType, RulerType)
+  vtkMRMLReadXMLEndMacro()
+
+
   const char* attName;
   const char* attValue;
   while (*atts != NULL)
     {
     attName = *(atts++);
     attValue = *(atts++);
-    if (!strcmp(attName, "layoutLabel"))
-      {
-      this->SetLayoutLabel( attValue );
-      }
-    else if (!strcmp(attName, "layoutName"))
-      {
-      this->SetLayoutName( attValue );
-      }
-    else if (!strcmp(attName, "viewGroup"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      int val;
-      ss >> val;
-      this->SetViewGroup(val);
-      }
-    else if (!strcmp(attName, "backgroundColor"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      double val;
-      ss >> val;
-      this->BackgroundColor[0] = val;
-      ss << attValue;
-      ss >> val;
-      this->BackgroundColor[1] = val;
-      ss << attValue;
-      ss >> val;
-      this->BackgroundColor[2] = val;
-      }
-    else if (!strcmp(attName, "backgroundColor2"))
-      {
-      isBackgroundColor2Set = true;
-      std::stringstream ss;
-      ss << attValue;
-      double val;
-      ss >> val;
-      this->BackgroundColor2[0] = val;
-      ss << attValue;
-      ss >> val;
-      this->BackgroundColor2[1] = val;
-      ss << attValue;
-      ss >> val;
-      this->BackgroundColor2[2] = val;
-      }
-    else if (!strcmp(attName, "active"))
-      {
-      if (!strcmp(attValue,"true"))
-        {
-        this->Active = 1;
-        }
-      else
-        {
-        this->Active = 0;
-        }
-      }
-    else if (!strcmp(attName, "orientationMarkerType") && this->OrientationMarkerEnabled)
-      {
-      int id = this->GetOrientationMarkerTypeFromString(attValue);
-      if (id<0)
-        {
-        vtkWarningMacro("Invalid orientationMarkerType: "<<(attValue?attValue:"(none)"));
-        }
-      else
-        {
-        this->OrientationMarkerType = id;
-        }
-      }
-    else if (!strcmp(attName, "orientationMarkerSize") && this->OrientationMarkerEnabled)
-      {
-      int id = this->GetOrientationMarkerSizeFromString(attValue);
-      if (id<0)
-        {
-        vtkWarningMacro("Invalid orientationMarkerSize: "<<(attValue?attValue:"(none)"));
-        }
-      else
-        {
-        this->OrientationMarkerSize = id;
-        }
-      }
-    else if (!strcmp(attName, "rulerType") && this->RulerEnabled)
-      {
-      int id = this->GetRulerTypeFromString(attValue);
-      if (id<0)
-        {
-        vtkWarningMacro("Invalid rulerType: "<<(attValue?attValue:"(none)"));
-        }
-      else
-        {
-        this->RulerType = id;
-        }
-      }
-    else if (!strcmp(attName, "AxisLabels"))
+    if (!strcmp(attName, "AxisLabels"))
       {
       std::stringstream labels(attValue);
       std::string label;
@@ -241,32 +166,11 @@ void vtkMRMLAbstractViewNode::ReadXMLAttributes(const char** atts)
         this->SetAxisLabel(labelIndex, "");
         }
       }
-
-    // XXX Do not read 'visibility' attribute and default to 1 because:
-    // (1) commit r21034 (STYLE: Add abstract class for all view nodes)
-    // changed the default value for 'visibility' attribute from 1 to 0. This
-    // means there are a lot of already saved scene where visibility attribute
-    // value is saved as 0.
-    // (2) support for visibility attribute by the layout manager has been
-    // added.
-    // XXX Support for 'visibility' attribute could be restored by updating
-    // the mrml version. Scene with a newer version number would consider the
-    // serialized attribute whereas older scene would not.
-//    else if (!strcmp(attName, "visibility"))
-//      {
-//      if (!strcmp(attValue,"true"))
-//        {
-//        this->Visibility = 1;
-//        }
-//      else
-//        {
-//        this->Visibility = 0;
-//        }
-//      }
     }
 #if MRML_SUPPORT_VERSION < 0x040000
-  if (!isBackgroundColor2Set)
+  if (this->BackgroundColor2[0] < 0)
     {
+    // BackgroundColor2 has not been set
     this->BackgroundColor2[0] = this->BackgroundColor[0];
     this->BackgroundColor2[1] = this->BackgroundColor[1];
     this->BackgroundColor2[2] = this->BackgroundColor[2];
@@ -300,27 +204,26 @@ void vtkMRMLAbstractViewNode::Copy(vtkMRMLNode *anode)
   int disabledModify = this->StartModify();
 
   Superclass::Copy(anode);
-  vtkMRMLAbstractViewNode *node = (vtkMRMLAbstractViewNode *) anode;
 
-  this->SetLayoutLabel(node->GetLayoutLabel());
-  this->SetViewGroup(node->GetViewGroup());
-  this->SetBackgroundColor ( node->GetBackgroundColor ( ) );
-  this->SetBackgroundColor2 ( node->GetBackgroundColor2 ( ) );
-  // Important: do not use SetActive or RemoveActiveFlagInScene will be called
-  this->Active = node->GetActive();
-  this->Visibility = node->GetVisibility();
-
+  vtkMRMLCopyBeginMacro(anode, vtkMRMLAbstractViewNode)
+  vtkMRMLCopyStringMacro(LayoutLabel)
+  vtkMRMLCopyIntMacro(ViewGroup)
+  vtkMRMLCopyIntMacro(Active)
+  vtkMRMLCopyIntMacro(Visibility)
+  vtkMRMLCopyVectorMacro(BackgroundColor, double, 3)
+  vtkMRMLCopyVectorMacro(BackgroundColor2, double, 3)
   if (this->OrientationMarkerEnabled)
     {
-    this->OrientationMarkerType = node->OrientationMarkerType;
-    this->OrientationMarkerSize = node->OrientationMarkerSize;
+    vtkMRMLCopyEnumMacro(OrientationMarkerType)
+    vtkMRMLCopyEnumMacro(OrientationMarkerSize)
     }
-
   if (this->RulerEnabled)
     {
-    this->RulerType = node->RulerType;
+    vtkMRMLCopyEnumMacro(RulerType)
     }
+  vtkMRMLCopyEndMacro()
 
+  vtkMRMLAbstractViewNode *node = (vtkMRMLAbstractViewNode *) anode;
   for (int i=0; i<vtkMRMLAbstractViewNode::AxisLabelsCount; i++)
     {
     this->SetAxisLabel(i,node->GetAxisLabel(i));
@@ -355,27 +258,23 @@ void vtkMRMLAbstractViewNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
 
-  os << indent << "LayoutLabel: " << (this->LayoutLabel ? this->LayoutLabel : "(null)") << std::endl;
-  os << indent << "ViewGroup: " << this->ViewGroup << std::endl;
-  os << indent << "Active:        " << this->Active << "\n";
-  os << indent << "Visibility:        " << this->Visibility << "\n";
-  os << indent << "BackgroundColor:       " << this->BackgroundColor[0] << " "
-     << this->BackgroundColor[1] << " "
-     << this->BackgroundColor[2] <<"\n";
-  os << indent << "BackgroundColor2:       " << this->BackgroundColor2[0] << " "
-     << this->BackgroundColor2[1] << " "
-     << this->BackgroundColor2[2] <<"\n";
-
+  vtkMRMLPrintBeginMacro(os, indent)
+  vtkMRMLPrintStringMacro(LayoutLabel)
+  vtkMRMLPrintIntMacro(ViewGroup)
+  vtkMRMLPrintIntMacro(Active)
+  vtkMRMLPrintIntMacro(Visibility)
+  vtkMRMLPrintVectorMacro(BackgroundColor, double, 3)
+  vtkMRMLPrintVectorMacro(BackgroundColor2, double, 3)
   if (this->OrientationMarkerEnabled)
     {
-    os << indent << "Orientation marker type: " << this->GetOrientationMarkerTypeAsString(this->OrientationMarkerType) << "\n";
-    os << indent << "Orientation marker size: " << this->GetOrientationMarkerSizeAsString(this->OrientationMarkerSize) << "\n";
+    vtkMRMLPrintEnumMacro(OrientationMarkerType)
+    vtkMRMLPrintEnumMacro(OrientationMarkerSize)
     }
-
   if (this->RulerEnabled)
     {
-    os << indent << "Ruler type: " << this->GetRulerTypeAsString(this->RulerType) << "\n";
+    vtkMRMLPrintEnumMacro(RulerType)
     }
+  vtkMRMLPrintEndMacro()
 
   os << indent << " AxisLabels: ";
   for (int i=0; i<vtkMRMLAbstractViewNode::AxisLabelsCount; i++)
@@ -384,27 +283,6 @@ void vtkMRMLAbstractViewNode::PrintSelf(ostream& os, vtkIndent indent)
     }
   os << "\n";
 
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLAbstractViewNode::RemoveActiveFlagInScene()
-{
-  if (this->Scene == NULL)
-    {
-    return;
-    }
-
-  vtkMRMLAbstractViewNode *node = NULL;
-  int nnodes = this->Scene->GetNumberOfNodesByClass("vtkMRMLAbstractViewNode");
-  for (int n=0; n<nnodes; n++)
-    {
-    node = vtkMRMLAbstractViewNode::SafeDownCast (
-       this->Scene->GetNthNodeByClass(n, "vtkMRMLAbstractViewNode"));
-    if (node != this)
-      {
-      node->SetActive(0);
-      }
-    }
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -259,12 +259,8 @@ protected:
 
   ///
   /// Indicates whether or not the View is active.
-  /// Inactive (1) by default.
+  /// Inactive by default.
   int Active;
-
-  ///
-  /// When a view is set Active, make other views inactive.
-  virtual void RemoveActiveFlagInScene();
 
   ///
   /// Background colors

--- a/Libs/MRML/Core/vtkMRMLCameraNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCameraNode.cxx
@@ -41,21 +41,16 @@ vtkMRMLNodeNewMacro(vtkMRMLCameraNode);
 
 //----------------------------------------------------------------------------
 vtkMRMLCameraNode::vtkMRMLCameraNode()
+: InternalActiveTag(NULL)
+, Camera(NULL)
 {
-  //this->SingletonTag = const_cast<char *>("vtkMRMLCameraNode");
-
   this->HideFromEditors = 0;
 
-  this->InternalActiveTag = NULL;
-  this->Camera = NULL;
-  vtkCamera *camera = vtkCamera::New();
-
+  vtkNew<vtkCamera> camera;
   camera->SetPosition(0, 500, 0);
   camera->SetFocalPoint(0, 0, 0);
   camera->SetViewUp(0, 0, 1);
-
-  this->SetAndObserveCamera(camera);
-  camera->Delete();
+  this->SetAndObserveCamera(camera.GetPointer());
 
   this->AppliedTransform = vtkMatrix4x4::New();
  }
@@ -79,29 +74,15 @@ void vtkMRMLCameraNode::WriteXML(ostream& of, int nIndent)
 
   Superclass::WriteXML(of, nIndent);
 
-  double *position = this->GetPosition();
-  of << " position=\"" << position[0] << " "
-    << position[1] << " "
-    << position[2] << "\"";
-
-  double *focalPoint = this->GetFocalPoint();
-  of << " focalPoint=\"" << focalPoint[0] << " "
-    << focalPoint[1] << " "
-    << focalPoint[2] << "\"";
-
-  double *viewUp = this->GetViewUp();
-    of << " viewUp=\"" << viewUp[0] << " "
-      << viewUp[1] << " "
-      << viewUp[2] << "\"";
-
-  of << " parallelProjection=\"" << (this->GetParallelProjection() ? "true" : "false") << "\"";
-
-  of << " parallelScale=\"" << this->GetParallelScale() << "\"";
-
-  if (this->GetActiveTag())
-    {
-    of << " activetag=\"" << this->GetActiveTag() << "\"";
-    }
+  vtkMRMLWriteXMLBeginMacro(of)
+  vtkMRMLWriteXMLVectorMacro(position, Position, double, 3)
+  vtkMRMLWriteXMLVectorMacro(focalPoint, FocalPoint, double, 3)
+  vtkMRMLWriteXMLVectorMacro(viewUp, ViewUp, double, 3)
+  vtkMRMLWriteXMLBooleanMacro(parallelProjection, ParallelProjection)
+  vtkMRMLWriteXMLFloatMacro(parallelScale, ParallelScale)
+  vtkMRMLWriteXMLFloatMacro(viewAngle, ViewAngle)
+  vtkMRMLWriteXMLStringMacro(activetag, ActiveTag)
+  vtkMRMLWriteXMLEndMacro()
 
   if (this->GetAppliedTransform())
     {
@@ -132,66 +113,23 @@ void vtkMRMLCameraNode::ReadXMLAttributes(const char** atts)
 
   Superclass::ReadXMLAttributes(atts);
 
+  vtkMRMLReadXMLBeginMacro(atts)
+  vtkMRMLReadXMLVectorMacro(position, Position, double, 3)
+  vtkMRMLReadXMLVectorMacro(focalPoint, FocalPoint, double, 3)
+  vtkMRMLReadXMLVectorMacro(viewUp, ViewUp, double, 3)
+  vtkMRMLReadXMLBooleanMacro(parallelProjection, ParallelProjection)
+  vtkMRMLReadXMLFloatMacro(parallelScale, ParallelScale)
+  vtkMRMLReadXMLFloatMacro(viewAngle, ViewAngle)
+  vtkMRMLReadXMLStringMacro(activetag, ActiveTag)
+  vtkMRMLReadXMLEndMacro()
+
   const char* attName;
   const char* attValue;
   while (*atts != NULL)
     {
     attName = *(atts++);
     attValue = *(atts++);
-    if (!strcmp(attName, "position"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      double Position[3];
-      ss >> Position[0];
-      ss >> Position[1];
-      ss >> Position[2];
-      this->SetPosition(Position);
-      }
-    else if (!strcmp(attName, "focalPoint"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      double FocalPoint[3];
-      ss >> FocalPoint[0];
-      ss >> FocalPoint[1];
-      ss >> FocalPoint[2];
-      this->SetFocalPoint(FocalPoint);
-      }
-    else if (!strcmp(attName, "viewUp"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      double ViewUp[3];
-      ss >> ViewUp[0];
-      ss >> ViewUp[1];
-      ss >> ViewUp[2];
-      this->SetViewUp(ViewUp);
-      }
-    else if (!strcmp(attName, "parallelProjection"))
-      {
-      if (!strcmp(attValue,"true"))
-        {
-        this->SetParallelProjection(1);
-        }
-      else
-        {
-        this->SetParallelProjection(0);
-        }
-      }
-    else if (!strcmp(attName, "parallelScale"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      double parallelScale;
-      ss >> parallelScale;
-      this->SetParallelScale(parallelScale);
-      }
-    else if (!strcmp(attName, "activetag"))
-      {
-      this->SetActiveTag(attValue);
-      }
-    else if (!strcmp(attName, "active"))
+    if (!strcmp(attName, "active"))
       {
       // Legacy, was replaced by active tag, try to set ActiveTag instead
       // to link to the main viewer
@@ -220,8 +158,8 @@ void vtkMRMLCameraNode::ReadXMLAttributes(const char** atts)
         }
       }
     }
-    this->EndModify(disabledModify);
 
+  this->EndModify(disabledModify);
 }
 
 
@@ -233,21 +171,29 @@ void vtkMRMLCameraNode::Copy(vtkMRMLNode *anode)
   int disabledModify = this->StartModify();
 
   Superclass::Copy(anode);
-  vtkMRMLCameraNode *node = vtkMRMLCameraNode::SafeDownCast(anode);
-  assert(node);
 
-  this->SetPosition(node->GetPosition());
-  this->SetFocalPoint(node->GetFocalPoint());
-  this->SetViewUp(node->GetViewUp());
-  this->SetParallelProjection(node->GetParallelProjection());
-  this->SetParallelScale(node->GetParallelScale());
-  this->AppliedTransform->DeepCopy(node->GetAppliedTransform());
-  // Important, do not call SetActiveTag() or the owner of the current tag
-  // (node) will lose its tag, and the active camera will be untagged, and
-  // a the active camera of the current view will be reset to NULL, and a
-  // new camera will be created on the fly by VTK the next time an active
-  // camera is need, one completely disconnected from Slicer3's MRML/internals
-  this->SetInternalActiveTag(node->GetActiveTag());
+  vtkMRMLCopyBeginMacro(anode, vtkMRMLCameraNode)
+  vtkMRMLCopyVectorMacro(Position, double, 3)
+  vtkMRMLCopyVectorMacro(FocalPoint, double, 3)
+  vtkMRMLCopyVectorMacro(ViewUp, double, 3)
+  vtkMRMLCopyBooleanMacro(ParallelProjection)
+  vtkMRMLCopyFloatMacro(ParallelScale)
+  vtkMRMLCopyFloatMacro(ViewAngle)
+  vtkMRMLCopyEndMacro()
+
+  vtkMRMLCameraNode *node = vtkMRMLCameraNode::SafeDownCast(anode);
+  if (node)
+    {
+    this->AppliedTransform->DeepCopy(node->GetAppliedTransform());
+
+    // Important, do not call SetActiveTag() or the owner of the current tag
+    // (node) will lose its tag, and the active camera will be untagged, and
+    // a the active camera of the current view will be reset to NULL, and a
+    // new camera will be created on the fly by VTK the next time an active
+    // camera is need, one completely disconnected from Slicer3's MRML/internals
+    this->SetInternalActiveTag(node->GetActiveTag());
+    }
+
   // Maybe the new position and focalpoint combo doesn't fit the existing
   // clipping range
   this->ResetClippingRange();
@@ -260,18 +206,16 @@ void vtkMRMLCameraNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
 
-  os << indent << "Parallel projection: " << this->GetParallelProjection() << '\n';
-  os << indent << "Parallel scale: " << this->GetParallelScale() << '\n';
-  os << indent << "ViewAngle:" << this->GetViewAngle() << '\n';
-  double v[3];
-  this->GetPosition(v);
-  os << indent << "Position: " << v[0] << ", " << v[1] << ", " << v[2] << '\n';
-  this->GetFocalPoint(v);
-  os << indent << "FocalPoint: " << v[0] << ", " << v[1] << ", " << v[2] << '\n';
-  this->GetViewUp(v);
-  os << indent << "ViewUp: " << v[0] << ", " << v[1] << ", " << v[2] << '\n';
-  os << indent << "ActiveTag: " <<
-    (this->GetActiveTag() ? this->GetActiveTag() : "(none)") << "\n";
+  vtkMRMLPrintBeginMacro(os, indent)
+  vtkMRMLPrintVectorMacro(Position, double, 3)
+  vtkMRMLPrintVectorMacro(FocalPoint, double, 3)
+  vtkMRMLPrintVectorMacro(ViewUp, double, 3)
+  vtkMRMLPrintBooleanMacro(ParallelProjection)
+  vtkMRMLPrintFloatMacro(ParallelScale)
+  vtkMRMLPrintFloatMacro(ViewAngle)
+  vtkMRMLPrintStringMacro(ActiveTag)
+  vtkMRMLPrintEndMacro();
+
   os << indent << "AppliedTransform: " ;
   this->GetAppliedTransform()->PrintSelf(os, indent.GetNextIndent());
 }

--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -1070,6 +1070,30 @@ const char * vtkMRMLNode::URLDecodeString(const char *inString)
   return (this->GetTempURLString());
 }
 
+//----------------------------------------------------------------------------
+std::string vtkMRMLNode::XMLAttributeEncodeString(const std::string& inString)
+{
+  std::string outString = inString;
+  vtksys::SystemTools::ReplaceString(outString, "&", "&amp;");
+  vtksys::SystemTools::ReplaceString(outString, "\"", "&quot;");
+  vtksys::SystemTools::ReplaceString(outString, "'", "&apos;");
+  vtksys::SystemTools::ReplaceString(outString, "<", "&lt;");
+  vtksys::SystemTools::ReplaceString(outString, ">", "&gt;");
+  return outString;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLNode::XMLAttributeDecodeString(const std::string& inString)
+{
+  std::string outString = inString;
+  vtksys::SystemTools::ReplaceString(outString, "&quot;", "\"");
+  vtksys::SystemTools::ReplaceString(outString, "&apos;", "'");
+  vtksys::SystemTools::ReplaceString(outString, "&lt;", "<");
+  vtksys::SystemTools::ReplaceString(outString, "&gt;", ">");
+  vtksys::SystemTools::ReplaceString(outString, "&amp;", "&");
+  return outString;
+}
+
 //// Reference API
 
 //-----------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -33,6 +33,9 @@ class vtkCallbackCommand;
 // Slicer VTK add-on includes
 #include <vtkLoggingMacros.h>
 
+// Helper macros for simplifying reading, writing, copying, and printing node properties.
+#include "vtkMRMLNodePropertyMacros.h"
+
 // STD includes
 #include <map>
 #include <string>
@@ -567,6 +570,16 @@ public:
   /// \note Currently only works on %, space, ', ", <, >
   /// \sa URLEncodeString()
   const char *URLDecodeString(const char *inString);
+
+  /// \brief Encode an XML attribute string (replaces special characters by .
+  ///
+  /// \sa XMLAttributeDecodeString()
+  std::string XMLAttributeEncodeString(const std::string& inString);
+
+  /// \brief Decode a URL string.
+  ///
+  /// \sa XMLAttributeEncodeString()
+  std::string XMLAttributeDecodeString(const std::string& inString);
 
   /// Get/Set for Selected
   vtkGetMacro(Selected, int);

--- a/Libs/MRML/Core/vtkMRMLNodePropertyMacros.h
+++ b/Libs/MRML/Core/vtkMRMLNodePropertyMacros.h
@@ -1,0 +1,253 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+#ifndef __vtkMRMLNodePropertyMacros_h
+#define __vtkMRMLNodePropertyMacros_h
+
+
+// Macros for writing node properties to XML
+//----------------------------------------------------------------------------
+
+#define vtkMRMLWriteXMLBeginMacro(of) \
+  { \
+  ostream& xmlWriteOutputStream = of;
+
+#define vtkMRMLWriteXMLEndMacro() \
+  }
+
+#define vtkMRMLWriteXMLBooleanMacro(xmlAttributeName, propertyName) \
+  xmlWriteOutputStream << " " #xmlAttributeName "=\"" << (Get##propertyName() ? "true" : "false") << "\"";
+
+#define vtkMRMLWriteXMLStringMacro(xmlAttributeName, propertyName) \
+  if (Get##propertyName() != NULL) \
+    { \
+    xmlWriteOutputStream << " " #xmlAttributeName "=\""; \
+    xmlWriteOutputStream << vtkMRMLNode::XMLAttributeEncodeString(Get##propertyName()); \
+    xmlWriteOutputStream << "\""; \
+    }
+
+#define vtkMRMLWriteXMLStdStringMacro(xmlAttributeName, propertyName) \
+  xmlWriteOutputStream << " " #xmlAttributeName "=\"" << vtkMRMLNode::XMLAttributeEncodeString(Get##propertyName().c_str()) << "\""; \
+
+#define vtkMRMLWriteXMLEnumMacro(xmlAttributeName, propertyName) \
+  xmlWriteOutputStream << " " #xmlAttributeName "=\""; \
+  if (Get##propertyName##AsString(Get##propertyName()) != NULL) \
+    { \
+    xmlWriteOutputStream << vtkMRMLNode::XMLAttributeEncodeString(Get##propertyName##AsString(Get##propertyName())); \
+    } \
+  xmlWriteOutputStream << "\"";
+
+#define vtkMRMLWriteXMLIntMacro(xmlAttributeName, propertyName) \
+  xmlWriteOutputStream << " " #xmlAttributeName "=\"" << Get##propertyName() << "\"";
+
+#define vtkMRMLWriteXMLFloatMacro(xmlAttributeName, propertyName) \
+  xmlWriteOutputStream << " " #xmlAttributeName "=\"" << Get##propertyName() << "\"";
+
+#define vtkMRMLWriteXMLVectorMacro(xmlAttributeName, propertyName, vectorType, vectorSize) \
+  { \
+    xmlWriteOutputStream << " " #xmlAttributeName "=\""; \
+    vectorType* vectorPtr = Get##propertyName(); \
+    if (vectorPtr != NULL) \
+      { \
+      for (int i=0; i<vectorSize; i++) \
+        { \
+        if (i > 0) \
+          { \
+          xmlWriteOutputStream << " "; \
+          } \
+        xmlWriteOutputStream << vectorPtr[i]; \
+        } \
+      } \
+    xmlWriteOutputStream << "\""; \
+  }
+
+// Macros for reading node properties from XML
+//----------------------------------------------------------------------------
+
+#define vtkMRMLReadXMLBeginMacro(atts) \
+  { \
+  const char* xmlReadAttName; \
+  const char* xmlReadAttValue; \
+  while (*atts != NULL) \
+    { \
+    xmlReadAttName = *(atts++); \
+    xmlReadAttValue = *(atts++); \
+    if (xmlReadAttValue == NULL) \
+      { \
+      break; \
+      }
+
+#define vtkMRMLReadXMLEndMacro() \
+  }};
+
+#define vtkMRMLReadXMLBooleanMacro(xmlAttributeName, propertyName) \
+  else if (!strcmp(xmlReadAttName, #xmlAttributeName)) \
+    { \
+    this->Set##propertyName(strcmp(xmlReadAttValue,"true") ? false : true); \
+    }
+
+#define vtkMRMLReadXMLStringMacro(xmlAttributeName, propertyName) \
+  else if (!strcmp(xmlReadAttName, #xmlAttributeName)) \
+    { \
+    this->Set##propertyName(vtkMRMLNode::XMLAttributeDecodeString(xmlReadAttValue).c_str()); \
+    }
+
+#define vtkMRMLReadXMLStdStringMacro(xmlAttributeName, propertyName) \
+  else if (!strcmp(xmlReadAttName, #xmlAttributeName)) \
+    { \
+    this->Set##propertyName(vtkMRMLNode::XMLAttributeDecodeString(xmlReadAttValue)); \
+    }
+
+#define vtkMRMLReadXMLEnumMacro(xmlAttributeName, propertyName) \
+  else if (!strcmp(xmlReadAttName, #xmlAttributeName)) \
+    { \
+    int propertyValue = this->Get##propertyName##FromString(vtkMRMLNode::XMLAttributeDecodeString(xmlReadAttValue).c_str()); \
+    if (propertyValue >= 0) \
+      { \
+      this->Set##propertyName(propertyValue); \
+      } \
+    else \
+      { \
+      vtkErrorMacro("Failed to read #xmlAttributeName attribute value from string '" << xmlReadAttValue << "'"); \
+      } \
+    }
+
+#define vtkMRMLReadXMLIntMacro(xmlAttributeName, propertyName) \
+  else if (!strcmp(xmlReadAttName, #xmlAttributeName)) \
+    { \
+    vtkVariant variantValue(xmlReadAttValue); \
+    bool valid = false; \
+    int intValue =  variantValue.ToInt(&valid); \
+    if (valid) \
+      { \
+      this->Set##propertyName(intValue); \
+      } \
+    else \
+      { \
+      vtkErrorMacro("Failed to read #xmlAttributeName attribute value from string '" << xmlReadAttValue << "': integer expected"); \
+      } \
+    }
+
+#define vtkMRMLReadXMLFloatMacro(xmlAttributeName, propertyName) \
+  else if (!strcmp(xmlReadAttName, #xmlAttributeName)) \
+    { \
+    vtkVariant variantValue(xmlReadAttValue); \
+    bool valid = false; \
+    int scalarValue =  variantValue.ToFloat(&valid); \
+    if (valid) \
+      { \
+      this->Set##propertyName(scalarValue); \
+      } \
+    else \
+      { \
+      vtkErrorMacro("Failed to read #xmlAttributeName attribute value from string '" << xmlReadAttValue << "': float expected"); \
+      } \
+    }
+
+#define vtkMRMLReadXMLVectorMacro(xmlAttributeName, propertyName, vectorType, vectorSize) \
+  else if (!strcmp(xmlReadAttName, #xmlAttributeName)) \
+    { \
+    vectorType vectorValue[vectorSize] = {0}; \
+    std::stringstream ss; \
+    ss << xmlReadAttValue; \
+    for (int i=0; i<vectorSize; i++) \
+      { \
+      vectorType val; \
+      ss >> val; \
+      vectorValue[i] = val; \
+      } \
+    this->Set##propertyName(vectorValue); \
+    }
+
+// Macros for copying node properties
+//----------------------------------------------------------------------------
+
+#define vtkMRMLCopyBeginMacro(sourceNode, nodeClassName) \
+  { \
+  nodeClassName* copySourceNode = nodeClassName::SafeDownCast(sourceNode); \
+  if (copySourceNode != NULL) \
+    {
+
+#define vtkMRMLCopyEndMacro() \
+    } \
+  else \
+    { \
+    vtkErrorMacro("Copy failed: invalid source node"); \
+    } \
+  }
+
+#define vtkMRMLCopyBooleanMacro(propertyName) \
+  this->Set##propertyName(copySourceNode->Get##propertyName());
+
+#define vtkMRMLCopyStringMacro(propertyName) \
+  this->Set##propertyName(copySourceNode->Get##propertyName());
+
+#define vtkMRMLCopyStdStringMacro(propertyName) \
+  this->Set##propertyName(copySourceNode->Get##propertyName());
+
+#define vtkMRMLCopyIntMacro(propertyName) \
+  this->Set##propertyName(copySourceNode->Get##propertyName());
+
+#define vtkMRMLCopyEnumMacro(propertyName) \
+  this->Set##propertyName(copySourceNode->Get##propertyName());
+
+#define vtkMRMLCopyFloatMacro(propertyName) \
+  this->Set##propertyName(copySourceNode->Get##propertyName());
+
+#define vtkMRMLCopyVectorMacro(propertyName, vectorType, vectorSize) \
+  this->Set##propertyName(copySourceNode->Get##propertyName());
+
+// Macros for printing node properties
+//----------------------------------------------------------------------------
+
+#define vtkMRMLPrintBeginMacro(os, indent) \
+  { \
+  ostream& printOutputStream = os; \
+  vtkIndent printOutputIndent = indent;
+
+#define vtkMRMLPrintEndMacro() \
+  }
+
+#define vtkMRMLPrintBooleanMacro(propertyName) \
+  os << indent << #propertyName ": " << (this->Get##propertyName() ? "true" : "false")  << "\n";
+
+#define vtkMRMLPrintStringMacro(propertyName) \
+  os << indent << #propertyName ": " << (this->Get##propertyName() != NULL ? this->Get##propertyName() : "(none)")  << "\n";
+
+#define vtkMRMLPrintStdStringMacro(propertyName) \
+  os << indent << #propertyName ": " << this->Get##propertyName() << "\n";
+
+#define vtkMRMLPrintEnumMacro(propertyName) \
+  os << indent << #propertyName ": " << (Get##propertyName##AsString(Get##propertyName()))  << "\n";
+
+#define vtkMRMLPrintIntMacro(propertyName) \
+  os << indent << #propertyName ": " << this->Get##propertyName() << "\n";
+
+#define vtkMRMLPrintFloatMacro(propertyName) \
+  os << indent << #propertyName ": " << this->Get##propertyName() << "\n";
+
+#define vtkMRMLPrintVectorMacro(propertyName, vectorType, vectorSize) \
+  { \
+  os << indent << #propertyName " : ["; \
+  vectorType* vectorValue = this->Get##propertyName(); \
+  if (vectorValue) \
+    { \
+    for (int i=0; i<vectorSize; i++) \
+      { \
+      if (i > 0) \
+        { \
+        os << ", "; \
+        } \
+      os << vectorValue[i]; \
+      } \
+    os << "]\n"; \
+    } \
+  }
+
+#endif // __vtkMRMLNodePropertyMacros_h


### PR DESCRIPTION
Added macros for reading, writing, copying, and printing MRML node properties.

It reduces amount of copy-pasted code and also allows higher quality implementation. For example, all special characters in strings are now properly encoded and error handling of reading enums or numbers is improved.

Updated vtkMRMLAbstractViewNode and vtkMRMLCameraNode to use these macros. In the future, more nodes should be updated in a similar way.