### PR TITLE
BUG: Fix crash on exit when chart view has been opened

### DIFF
--- a/Base/QTGUI/qSlicerWebWidget.cxx
+++ b/Base/QTGUI/qSlicerWebWidget.cxx
@@ -29,6 +29,7 @@
 #include <QWebFrame>
 #include <QWebView>
 #else
+#include <QCoreApplication>
 #include <QWebEngineView>
 #include <QWebChannel>
 #include <QWebEngineScript>
@@ -93,6 +94,13 @@ void qSlicerWebWidgetPrivate::init()
   this->WebChannel = new QWebChannel(this->WebView->page());
   this->initializeWebChannel(this->WebChannel);
   this->WebView->page()->setWebChannel(this->WebChannel);
+
+  // XXX
+  // The QWebEngineView crashes when the application quits.
+  // Work-around for now seems to be to delete the view before the application
+  // quits.
+  QObject::connect(QCoreApplication::instance(), SIGNAL(aboutToQuit()),
+                   this, SLOT(onAppAboutToQuit()));
 #endif
   this->verticalLayout->insertWidget(0, this->WebView);
 
@@ -143,6 +151,16 @@ QWebFrame* qSlicerWebWidgetPrivate::mainFrame()
   return this->WebView->page()->mainFrame();
 }
 #endif
+
+// --------------------------------------------------------------------------
+void qSlicerWebWidgetPrivate::onAppAboutToQuit()
+{
+  if (this->WebView)
+    {
+    delete this->WebView;
+    this->WebView = 0;
+    }
+}
 
 // --------------------------------------------------------------------------
 void qSlicerWebWidgetPrivate::setDocumentWebkitHidden(bool value)

--- a/Base/QTGUI/qSlicerWebWidget_p.h
+++ b/Base/QTGUI/qSlicerWebWidget_p.h
@@ -59,8 +59,9 @@ protected:
 #endif
 
 //-----------------------------------------------------------------------------
-class qSlicerWebWidgetPrivate: public Ui_qSlicerWebWidget
+class qSlicerWebWidgetPrivate: public QObject, Ui_qSlicerWebWidget
 {
+  Q_OBJECT
   Q_DECLARE_PUBLIC(qSlicerWebWidget);
 protected:
   qSlicerWebWidget* const q_ptr;
@@ -81,6 +82,11 @@ public:
 
   /// Convenient method to set "document.webkitHidden" property
   void setDocumentWebkitHidden(bool value);
+
+public slots:
+  void onAppAboutToQuit();
+
+public:
 
   QTime DownloadTime;
 #if (QT_VERSION < QT_VERSION_CHECK(5, 6, 0))

--- a/Libs/MRML/Widgets/qMRMLChartWidget.h
+++ b/Libs/MRML/Widgets/qMRMLChartWidget.h
@@ -24,6 +24,7 @@ class QResizeEvent;
 
 // qMRMLWidget includes
 #include "qMRMLWidget.h"
+#include "qMRMLWidgetsConfigure.h" // For MRML_WIDGETS_HAVE_WEBKIT_SUPPORT
 class qMRMLChartViewControllerWidget;
 class qMRMLChartView;
 class qMRMLChartWidgetPrivate;
@@ -72,10 +73,14 @@ public:
   void setColorLogic(vtkMRMLColorLogic* colorLogic);
   vtkMRMLColorLogic* colorLogic()const;
 
-
 public slots:
   /// Set the current \a viewNode to observe
   void setMRMLChartViewNode(vtkMRMLChartViewNode* newChartViewNode);
+
+#ifndef MRML_WIDGETS_HAVE_WEBKIT_SUPPORT
+protected slots:
+  void onAppAboutToQuit();
+#endif
 
 protected:
   QScopedPointer<qMRMLChartWidgetPrivate> d_ptr;


### PR DESCRIPTION
The QWebEngineView would crash on exit. This seems related to https://bugreports.qt.io/browse/QTBUG-50160?focusedCommentId=305211&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-305211
The work-around is to delete manually the QWebEngineView (in this case
the qMRMLChartView) before the application has exited.

See issue #4479 - https://issues.slicer.org/view.php?id=4479