### PR TITLE
ENH: Rename CDash project associated with "nightly release" to "SlicerMaster"

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -3,6 +3,6 @@ set(CTEST_NIGHTLY_START_TIME "3:00:00 UTC")
 
 set(CTEST_DROP_METHOD "http")
 set(CTEST_DROP_SITE "slicer.cdash.org")
-set(CTEST_DROP_LOCATION "/submit.php?project=Slicer4")
+set(CTEST_DROP_LOCATION "/submit.php?project=SlicerMaster")
 set(CTEST_DROP_SITE_CDASH TRUE)
 

--- a/Extensions/CMake/CTestConfig.cmake.in
+++ b/Extensions/CMake/CTestConfig.cmake.in
@@ -3,6 +3,6 @@ set(CTEST_NIGHTLY_START_TIME "3:00:00 UTC")
 
 set(CTEST_DROP_METHOD "http")
 set(CTEST_DROP_SITE "@CTEST_DROP_SITE@")
-set(CTEST_DROP_LOCATION "/submit.php?project=Slicer4")
+set(CTEST_DROP_LOCATION "/submit.php?project=SlicerMaster")
 set(CTEST_DROP_SITE_CDASH TRUE)
 

--- a/Extensions/CMake/SlicerBlockBuildPackageAndUploadExtension.cmake
+++ b/Extensions/CMake/SlicerBlockBuildPackageAndUploadExtension.cmake
@@ -113,7 +113,7 @@ set(CTEST_NIGHTLY_START_TIME \"3:00:00 UTC\")
 
 set(CTEST_DROP_METHOD \"http\")
 set(CTEST_DROP_SITE \"${CTEST_DROP_SITE}\")
-set(CTEST_DROP_LOCATION \"/submit.php?project=Slicer4\")
+set(CTEST_DROP_LOCATION \"/submit.php?project=SlicerMaster\")
 set(CTEST_DROP_SITE_CDASH TRUE)")
   endif()
   message(STATUS "CTestCustom.cmake has been written to: ${ctestconfig_dest_dir}")

--- a/Extensions/Testing/SuperBuildExtensionTemplate/CTestConfig.cmake
+++ b/Extensions/Testing/SuperBuildExtensionTemplate/CTestConfig.cmake
@@ -3,5 +3,5 @@ set(CTEST_NIGHTLY_START_TIME "3:00:00 UTC")
 
 set(CTEST_DROP_METHOD "http")
 set(CTEST_DROP_SITE "slicer.cdash.org")
-set(CTEST_DROP_LOCATION "/submit.php?project=Slicer4")
+set(CTEST_DROP_LOCATION "/submit.php?project=SlicerMaster")
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/Utilities/Templates/Extensions/SuperBuild/CTestConfig.cmake
+++ b/Utilities/Templates/Extensions/SuperBuild/CTestConfig.cmake
@@ -3,5 +3,5 @@ set(CTEST_NIGHTLY_START_TIME "3:00:00 UTC")
 
 set(CTEST_DROP_METHOD "http")
 set(CTEST_DROP_SITE "slicer.cdash.org")
-set(CTEST_DROP_LOCATION "/submit.php?project=Slicer4")
+set(CTEST_DROP_LOCATION "/submit.php?project=SlicerMaster")
 set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
See https://discourse.slicer.org/t/different-dashboard-for-master-and-stable-builds/2091

Suggested-by: Andras Lasso <lasso@queensu.ca>

[ci skip]