### PR TITLE
RFC: ENH: allow direct execution of CLI python scripts using Slicer's python

### DIFF
--- a/Base/QTCLI/Testing/CMakeLists.txt
+++ b/Base/QTCLI/Testing/CMakeLists.txt
@@ -19,11 +19,31 @@ SEMMacroBuildCLI(
   )
 
 #-----------------------------------------------------------------------------
+set(pycli_build_dir ${SlicerExecutionModel_DEFAULT_CLI_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR})
+set(pycli_files
+  ${CMAKE_CURRENT_SOURCE_DIR}/PyCLIModule4Test.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/PyCLIModule4Test.xml
+  )
+
+add_custom_target(InstallPyCLITest4 ALL
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${pycli_files} ${pycli_build_dir}
+  )
+
+if(NOT WIN32)
+  add_custom_target(InstallPyCLITest4Chmod ALL
+    COMMAND chmod u+x "${pycli_build_dir}/PyCLIModule4Test.py"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS InstallPyCLITest4
+  )
+endif()
+
+#-----------------------------------------------------------------------------
 set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN "DEBUG_LEAKS_ENABLE_EXIT_ERROR();" )
 create_test_sourcelist(Tests ${KIT}CxxTests.cxx
   qSlicerCLIExecutableModuleFactoryTest1.cxx
   qSlicerCLILoadableModuleFactoryTest1.cxx
   qSlicerCLIModuleTest1.cxx
+  qSlicerPyCLIModuleTest1.cxx
   EXTRA_INCLUDE vtkMRMLDebugLeaksMacro.h
   )
 
@@ -39,3 +59,4 @@ set_target_properties(${KIT}CxxTests PROPERTIES FOLDER "Core-Base")
 simple_test( qSlicerCLIExecutableModuleFactoryTest1 )
 simple_test( qSlicerCLILoadableModuleFactoryTest1 )
 simple_test( qSlicerCLIModuleTest1 )
+simple_test( qSlicerPyCLIModuleTest1 )

--- a/Base/QTCLI/Testing/PyCLIModule4Test.py
+++ b/Base/QTCLI/Testing/PyCLIModule4Test.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import argparse, sys
+import numpy as np
+
+# TODO: would be good to set up test driver so `import slicer, vtk` works,
+#       to make sure we are actually in Slicer's python.
+
+def main():
+    # TODO parse from XML (maybe commontk/ctk-cli)
+
+    parser = argparse.ArgumentParser(description="A test Python CLI")
+    parser.add_argument('outputfile', metavar='<outputfile>', help="Output file",
+                        nargs='?')
+    parser.add_argument('--inputvalue1', metavar='N1', help="Input value 1",
+                        required=True, nargs='?', type=int)
+    parser.add_argument('--inputvalue2', metavar='N2', help="Input value 2",
+                        required=True, nargs='?', type=int)
+    parser.add_argument('--operationtype',
+                        choices=['Addition', 'Multiplication', 'Fail'],
+                        default='Addition')
+
+
+    args = parser.parse_args()
+    operation = args.operationtype
+
+    print args.outputfile
+    if args.outputfile is None:
+        raise Exception("Please specify exactly 1 output file name")
+
+    result = 0
+    if operation == 'Addition':
+        result = args.inputvalue1 + args.inputvalue2
+    elif operation == 'Multiplication':
+        result = args.inputvalue1 * args.inputvalue2
+    else:
+        raise Exception("Unknown OperationType!")
+
+    with open(args.outputfile, "w") as output_f:
+        output_f.write(str(result))
+
+
+if __name__ == '__main__':
+    main()

--- a/Base/QTCLI/Testing/PyCLIModule4Test.xml
+++ b/Base/QTCLI/Testing/PyCLIModule4Test.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<executable>
+  <category>Testing</category>
+  <title>Command Line Module Test</title>
+  <description><![CDATA[Command line module used to test the automatic UI generator.\n]]></description>
+  <version>0.0.1</version>
+  <documentation-url/>
+  <license/>
+  <contributor>Jean-Christophe Fillion-Robin</contributor>
+  <acknowledgements/>
+  <parameters>
+    <label>Test Settings</label>
+    <integer>
+      <name>InputValue1</name>
+      <label>Input Value 1</label>
+      <longflag>--inputvalue1</longflag>
+      <description><![CDATA[Input value 1]]></description>
+      <default>1</default>
+    </integer>
+    <integer>
+      <name>InputValue2</name>
+      <label>Input Value 2</label>
+      <longflag>--inputvalue2</longflag>
+      <description><![CDATA[Input value 2]]></description>
+      <default>1</default>
+    </integer>
+    <string-enumeration>
+      <name>OperationType</name>
+      <label>Operation Type</label>
+      <description><![CDATA[What kind of operation to perform: Addition or multiplication]]></description>
+      <longflag>--operationtype</longflag>
+      <default>Addition</default>
+      <element>Addition</element>
+      <element>Multiplication</element>
+      <element>Fail</element>
+    </string-enumeration>
+    <file fileExtensions="">
+      <name>OutputFile</name>
+      <label>Output File</label>
+      <channel>output</channel>
+      <index>0</index>
+      <description><![CDATA[Output file]]></description>
+    </file>
+  </parameters>
+</executable>

--- a/Base/QTCLI/Testing/qSlicerPyCLIModuleTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerPyCLIModuleTest1.cxx
@@ -1,0 +1,247 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Jean-Christophe Fillion-Robin, Kitware Inc.
+  and was partially funded by NIH grant 3P41RR013218-12S1
+
+==============================================================================*/
+
+// Qt includes
+#include <QPushButton>
+#include <QTemporaryFile>
+#include <QTimer>
+
+// CTK includes
+#include <ctkCallback.h>
+
+// SlicerQt includes
+#include "qSlicerApplication.h"
+#include "qSlicerCLIExecutableModuleFactory.h"
+#include "qSlicerScriptedLoadableModuleFactory.h"
+#include "qSlicerCLIModule.h"
+#include "qSlicerCLIModuleWidget.h"
+#include "qSlicerModuleFactoryManager.h"
+#include "qSlicerModuleManager.h"
+
+// MRMLCLI includes
+#include <vtkMRMLCommandLineModuleNode.h>
+#include <vtkSlicerCLIModuleLogic.h>
+
+// STD includes
+
+namespace
+{
+//-----------------------------------------------------------------------------
+qSlicerCLIModule * CLIModule;
+QString            ErrorString;
+
+//-----------------------------------------------------------------------------
+void runCli(void * data)
+{
+  Q_ASSERT(CLIModule);
+  Q_UNUSED(data);
+
+  QTemporaryFile outputFile("qSlicerCLIModuleTest1-outputFile-XXXXXX");
+  if (!outputFile.open())
+    {
+    ErrorString = "Failed to create temporary file";
+    return;
+    }
+  //outputFile.close();
+
+  // Create node
+  vtkMRMLCommandLineModuleNode * cliModuleNode =
+    CLIModule->cliModuleLogic()->CreateNodeInScene();
+
+  // Values
+  int inputValue1 = 4;
+  int inputValue2 = 3;
+
+  // Set node parameters
+  cliModuleNode->SetParameterAsInt("InputValue1", inputValue1);
+  cliModuleNode->SetParameterAsInt("InputValue2", inputValue2);
+  cliModuleNode->SetParameterAsString("OperationType", "Addition");
+  cliModuleNode->SetParameterAsString("OutputFile", outputFile.fileName().toStdString());
+
+  // Execute synchronously so that we can check the content of the file after the module execution
+  CLIModule->cliModuleLogic()->ApplyAndWait(cliModuleNode);
+
+  // Read outputFile
+  QTextStream stream(&outputFile);
+  QString operationResult = stream.readAll().trimmed();
+
+  QString expectedResult = QString::number(inputValue1 + inputValue2);
+  if (operationResult.compare(expectedResult) != 0)
+    {
+    ErrorString = QString("OutputFile doesn't contain the expected result !\n"
+                          "\tExpected:%1\n"
+                          "\tCurrent:%2").arg(expectedResult).arg(operationResult);
+    return;
+    }
+
+  outputFile.close();
+}
+
+} // end anonymous namespace
+
+//-----------------------------------------------------------------------------
+int qSlicerPyCLIModuleTest1(int argc, char * argv[])
+{
+  // The PyCLI4Test module (PyCLIModule4Test) has already been installed as
+  // a normal Python CLI module.
+  // Slicer-build/lib/Slicer-X.Y/cli-modules[/Debug|Release]
+  QString cliModuleName("PyCLI4Test");
+
+  qSlicerApplication::setAttribute(qSlicerApplication::AA_DisablePython);
+  qSlicerApplication app(argc, argv);
+
+  qSlicerModuleManager * moduleManager = app.moduleManager();
+  if (!moduleManager)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Problem with qSlicerApplication::moduleManager()" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  qSlicerModuleFactoryManager* moduleFactoryManager = moduleManager->factoryManager();
+  if (!moduleFactoryManager)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Problem with qSlicerModuleManager::factoryManager()" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  QString cliPath = app.slicerHome() + "/" + Slicer_CLIMODULES_LIB_DIR + "/";
+  #if __cplusplus >= 201103L
+  QStringList loadPaths = { cliPath, cliPath + app.intDir() };
+  #else
+  QStringList loadPaths;
+  loadPaths.append(cliPath);
+  loadPaths.append(app.intDir());
+  #endif
+
+  //===========================================================================
+  // Ensure that PyCLI is not recognized by the scripted factory.
+  moduleFactoryManager->registerFactory(new qSlicerScriptedLoadableModuleFactory);
+  moduleFactoryManager->addSearchPaths(loadPaths);
+  moduleFactoryManager->registerModules();
+  moduleFactoryManager->instantiateModules();
+
+  QStringList moduleNames = moduleFactoryManager->instantiatedModuleNames();
+  if (moduleNames.contains(cliModuleName))
+    {
+    std::cerr << "Line " << __LINE__ << " - Problem with qSlicerScriptedLoadableModuleFactory"
+              << " - Improperly registered '" << qPrintable(cliModuleName) << "' as scripted module" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  moduleFactoryManager->unregisterFactories();
+
+
+  //===========================================================================
+  // Now test PyCLI for real
+  moduleFactoryManager->registerFactory(new qSlicerCLIExecutableModuleFactory);
+  moduleFactoryManager->addSearchPaths(loadPaths);
+
+  // Register and instantiate modules
+  moduleFactoryManager->registerModules();
+  moduleFactoryManager->instantiateModules();
+
+  moduleNames = moduleFactoryManager->instantiatedModuleNames();
+  if (!moduleNames.contains(cliModuleName))
+    {
+    std::cerr << "Line " << __LINE__ << " - Problem with qSlicerCLIExecutableModuleFactory"
+              << " - Failed to register '" << qPrintable(cliModuleName) << "' module" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  foreach(const QString& name, moduleNames)
+    {
+    moduleFactoryManager->loadModule(name);
+    }
+
+  qSlicerAbstractCoreModule * module = moduleManager->module(cliModuleName);
+  if (!module)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Problem with qSlicerModuleManager::module()"
+              << " - Failed to retrieve module named '" << qPrintable(cliModuleName) << "'" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  qSlicerCLIModule * cliModule = qobject_cast<qSlicerCLIModule*>(module);
+  if (!cliModule)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Failed to cast module named '" << qPrintable(cliModuleName) << "' "
+              << "from [qSlicerAbstractCoreModule*] into [qSlicerCLIModule*]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  qSlicerAbstractModuleRepresentation * widgetRepresentation = cliModule->widgetRepresentation();
+  if (!widgetRepresentation)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Problem with qSlicerCLIModule::widgetRepresentation()"
+              << " - Failed to retrieve representation associated with module named '"
+              << qPrintable(cliModuleName) << "'" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  qSlicerCLIModuleWidget* cliWidget =
+    dynamic_cast<qSlicerCLIModuleWidget*>(widgetRepresentation);
+  if (!cliWidget)
+    {
+    std::cerr << "Line " << __LINE__
+              << " - Failed to cast module '" << qPrintable(cliModuleName) << "' representation "
+              << "from [qSlicerAbstractModuleRepresentation*] into [qSlicerCLIModuleWidget*]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  cliWidget->show();
+
+  QPushButton button("Simulate CLI programmatic start");
+  CLIModule = cliModule;
+  ctkCallback callback(runCli);
+  QObject::connect(&button, SIGNAL(clicked()), &callback, SLOT(invoke()));
+
+  button.show();
+
+  QTimer::singleShot(0, &callback, SLOT(invoke()));
+
+  bool checkResult = false;
+  if (argc < 2 || QString(argv[1]) != "-I" )
+    {
+    QTimer::singleShot(500, &app, SLOT(quit()));
+    checkResult = true;
+    }
+
+  int status = app.exec();
+  if (status == EXIT_FAILURE)
+    {
+    std::cerr << "Line " << __LINE__ << " - Problem with qSlicerApplication::exec()";
+    return EXIT_FAILURE;
+    }
+
+  if (checkResult && !ErrorString.isEmpty())
+    {
+    std::cerr << "Line " << __LINE__ << " - Problem executing command line module - "
+              << qPrintable(ErrorString) << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  return EXIT_SUCCESS;
+
+}

--- a/Base/QTCore/qSlicerUtils.cxx
+++ b/Base/QTCore/qSlicerUtils.cxx
@@ -51,6 +51,22 @@ bool qSlicerUtils::isExecutableName(const QString& name)
 //------------------------------------------------------------------------------
 bool qSlicerUtils::isCLIExecutable(const QString& filePath)
 {
+  if (isCLIScriptedExecutable(filePath))
+    {
+    return true;
+    }
+
+#ifdef _WIN32
+  return ( filePath.endsWith(".exe", Qt::CaseInsensitive) ||
+           filePath.endsWith(".bat", Qt::CaseInsensitive) );
+#else
+  return !QFileInfo(filePath).fileName().contains('.');
+#endif
+}
+
+//------------------------------------------------------------------------------
+bool qSlicerUtils::isCLIScriptedExecutable(const QString& filePath)
+{
   // check if .py file starts with `#!` magic
   //   note: uses QTextStream to avoid issues with BOM.
   QFile scriptFile(filePath);
@@ -62,13 +78,7 @@ bool qSlicerUtils::isCLIExecutable(const QString& filePath)
     {
     return true;
     }
-
-#ifdef _WIN32
-  return ( filePath.endsWith(".exe", Qt::CaseInsensitive) ||
-           filePath.endsWith(".bat", Qt::CaseInsensitive) );
-#else
-  return !QFileInfo(filePath).fileName().contains('.');
-#endif
+  return false;
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerUtils.cxx
+++ b/Base/QTCore/qSlicerUtils.cxx
@@ -51,6 +51,18 @@ bool qSlicerUtils::isExecutableName(const QString& name)
 //------------------------------------------------------------------------------
 bool qSlicerUtils::isCLIExecutable(const QString& filePath)
 {
+  // check if .py file starts with `#!` magic
+  //   note: uses QTextStream to avoid issues with BOM.
+  QFile scriptFile(filePath);
+  QTextStream scriptStream(&scriptFile);
+
+  if ( (filePath.endsWith(".py", Qt::CaseInsensitive)) &&
+       (scriptFile.open(QIODevice::ReadOnly))          &&
+       (scriptStream.readLine(2).startsWith("#!")) )
+    {
+    return true;
+    }
+
 #ifdef _WIN32
   return ( filePath.endsWith(".exe", Qt::CaseInsensitive) ||
            filePath.endsWith(".bat", Qt::CaseInsensitive) );

--- a/Base/QTCore/qSlicerUtils.h
+++ b/Base/QTCore/qSlicerUtils.h
@@ -40,6 +40,9 @@ public:
   /// Returns \a true if the \a filePath matches the CLI executable file name requirements
   static bool isCLIExecutable(const QString& filePath);
 
+  /// Returns \a true if the \a filePath matches scripted CLI requirements
+  static bool isCLIScriptedExecutable(const QString& filePath);
+
   /// Returns \a true if the \a filePath matches the CLI loadable module file name requirements.
   /// \note Associated \a fileName is expected to match the following
   /// regular expression: "(lib)?.+Lib\\.(dll|DLL|so|dylib)"

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
@@ -162,14 +162,7 @@ bool qSlicerScriptedLoadableModuleFactory::isValidFile(const QFileInfo& file)con
     return false;
     }
 
-  // Skip the file if it begins with '#!' -- these are Python CLI scripts
-  //   note: uses QTextStream to avoid issues with BOM.
-  QFile scriptFile(file.filePath());
-  QTextStream scriptStream(&scriptFile);
-
-  if ( (file.filePath().endsWith(".py", Qt::CaseInsensitive)) &&
-       (scriptFile.open(QIODevice::ReadOnly))             &&
-       (scriptStream.readLine(2).startsWith("#!")) )
+  if (qSlicerUtils::isCLIScriptedExecutable(file.filePath()))
     {
     return false;
     }

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
@@ -161,7 +161,20 @@ bool qSlicerScriptedLoadableModuleFactory::isValidFile(const QFileInfo& file)con
     {
     return false;
     }
-  // Accept if current file is a python script
+
+  // Skip the file if it begins with '#!' -- these are Python CLI scripts
+  //   note: uses QTextStream to avoid issues with BOM.
+  QFile scriptFile(file.filePath());
+  QTextStream scriptStream(&scriptFile);
+
+  if ( (file.filePath().endsWith(".py", Qt::CaseInsensitive)) &&
+       (scriptFile.open(QIODevice::ReadOnly))             &&
+       (scriptStream.readLine(2).startsWith("#!")) )
+    {
+    return false;
+    }
+
+  // Otherwise, accept if current file is a python script
   if (file.suffix().compare("py", Qt::CaseInsensitive) == 0)
     {
     return true;


### PR DESCRIPTION
This is a quick hack demonstrating a potential solution to [this issue](https://github.com/Radiomics/SlicerRadiomics/issues/43) and related problems (e.g. running `multiprocessing`). 

tl;dr, this detects a `.pycli` file in a CLI directory (`cli-modules`), and then configures the CLI node to run the script via Slicer's python interpreter. As an example, for SlicerRadiomicsCLI, this gives the following command line:
```
RadiomicsCLI command line:

/opt/bld/s5nj/python-install/bin/python inner-build/lib/Slicer-4.9/cli-modules/SlicerRadiomicsCLI.py --label 1 --out /var/folders/7l/2qsp6sqx4_b5x9kf_yzzm4lc0000gn/T/Slicer/EBACJ_vtkMRMLTableNodeB.csv /var/folders/7l/2qsp6sqx4_b5x9kf_yzzm4lc0000gn/T/Slicer/EBACJ_vtkMRMLScalarVolumeNodeB.nrrd /var/folders/7l/2qsp6sqx4_b5x9kf_yzzm4lc0000gn/T/Slicer/EBACJ_vtkMRMLLabelMapVolumeNodeB.nrrd
```

The command is exec'd via the existing CLI mechanism, runs out-of-process and async as any other CLI would be, but it inherits the full Slicer environment without requiring any launcher/cmake/etc. steps. Running directly also avoids [OS security policy issues](https://discourse.slicer.org/t/tutorial-for-using-pyradiomics-no-module-named-collections/2111/7) caused by [shelling-out to protected interpreters](https://github.com/Radiomics/SlicerRadiomics/blob/master/SlicerRadiomicsCLI/SlicerRadiomicsCLI).

Note that this is *different* from the current scripted CLI module path which runs in-process and blocks on the interpreter for the duration of the call (but should have no effect on that code path).

~~This PR does not handle`python-real` in a factory-packaged Slicer, and other issues, but I wanted to put it up for feedback before spending time on it.~~

cc @fedorov @lassoan @pieper @ljod 