### PR TITLE
BUG: Fix high DPI display on windows with multiple screens

### DIFF
--- a/Applications/SlicerApp/Main.cxx
+++ b/Applications/SlicerApp/Main.cxx
@@ -118,6 +118,14 @@ int SlicerAppMain(int argc, char* argv[])
 #endif
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#ifdef _WIN32
+  // Qt windows defaults to the PROCESS_PER_MONITOR_DPI_AWARE for DPI display
+  // on windows. Unfortunately, this doesn't work well on multi-screens setups.
+  // By calling SetProcessDPIAware(), we force the value to
+  // PROCESS_SYSTEM_DPI_AWARE instead which fixes those issues.
+  SetProcessDPIAware();
+#endif
+
   // Enable automatic scaling based on the pixel density of the monitor
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif


### PR DESCRIPTION
The issue arises when displaying Slicer on multiple high dpi screens. A
transparent bar is displayed below the toolbar and shifts the whole
rendering.
This comes from the Qt windows display plugin (QPA layer) that sets the
windows dpi awarness to PROCESS_PER_MONITOR_DPI_AWARE by default. Although
it is the appropriate value, Qt doesn't handle it properly.
Unfortunately, there is no API to call to change the ProcessDPIAwarness
value. We can however directly call the windows method SetProcessDPIAware()
that will superseed the Qt call and set the ProcessDPIAwarness to
PROCESS_SYSTEM_DPI_AWARE instead which solves the issue.

For reference:
http://doc.qt.io/qt-5/qpa.html
https://msdn.microsoft.com/en-us/library/windows/desktop/dn280512(v=vs.85).aspx

For illustration:
Without the fix on a mirrored display:
![highdpi_bug](https://user-images.githubusercontent.com/426898/36489894-10cfc96a-16f5-11e8-82c3-c41ef600a994.PNG)

With the fix:
![highdpi_fixed](https://user-images.githubusercontent.com/426898/36489898-1226912c-16f5-11e8-989b-0a4c9f5bb2dc.PNG)

The issue in a gif. On the left is one screen and on the right the other:
![highdpi_issue_gif](https://user-images.githubusercontent.com/426898/36490013-53da66fc-16f5-11e8-9d07-486cf32085fa.gif)
