### PR TITLE
BUG: Propagation of the ${additional_project}_SOURCE_DIR variable to the Slicer inner build

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -375,6 +375,8 @@ if(Slicer_ADDITIONAL_PROJECTS)
   foreach(additional_project ${Slicer_ADDITIONAL_PROJECTS})
     # needed to do find_package within Slicer
     mark_as_superbuild(${additional_project}_DIR:PATH)
+    # needed to create the Slicer version
+    mark_as_superbuild(${additional_project}_SOURCE_DIR:PATH)
   endforeach()
   mark_as_superbuild(Slicer_ADDITIONAL_PROJECTS:STRING)
 endif()


### PR DESCRIPTION
The propagation of this variable is needed during the compilation of a Slicer Project Template in order to create the slicer's version: https://github.com/Slicer/Slicer/blob/94a26e017a3aba4a97c17182ffb913d872f897bc/CMake/SlicerVersion.cmake#L29