### PR TITLE
 add lang+region qm file support and simplified/transitional Chinese language in Slicer_LANGUAGES

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1592,7 +1592,6 @@ void qSlicerCoreApplication::loadTranslations(const QString& dir)
 
   QString localeFilter =
       QString( QString("*") + app->settings()->value("language").toString());
-  localeFilter.resize(3);
   localeFilter += QString(".qm");
 
   QDir directory(dir);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ mark_as_superbuild(Slicer_BUILD_DICOM_SUPPORT)
 option(Slicer_BUILD_DIFFUSION_SUPPORT "Build Slicer with diffusion (DWI, DTI) support" ON)
 mark_as_superbuild(Slicer_BUILD_DIFFUSION_SUPPORT)
 
-option(Slicer_BUILD_I18N_SUPPORT "Build Slicer with Internationalization support" OFF)
+option(Slicer_BUILD_I18N_SUPPORT "Build Slicer with Internationalization support" ON)
 
 option(Slicer_BUILD_QTLOADABLEMODULES "Build Slicer QT Loadable Modules" ON)
 mark_as_advanced(Slicer_BUILD_QTLOADABLEMODULES)
@@ -408,6 +408,8 @@ include(SlicerFunctionAddPythonQtResources)
 if(Slicer_BUILD_I18N_SUPPORT)
   set(Slicer_LANGUAGES
     "fr"
+    "zh_tw"
+    "zh_cn"
     )
   set_property(GLOBAL PROPERTY Slicer_LANGUAGES ${Slicer_LANGUAGES})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ mark_as_superbuild(Slicer_BUILD_DICOM_SUPPORT)
 option(Slicer_BUILD_DIFFUSION_SUPPORT "Build Slicer with diffusion (DWI, DTI) support" ON)
 mark_as_superbuild(Slicer_BUILD_DIFFUSION_SUPPORT)
 
-option(Slicer_BUILD_I18N_SUPPORT "Build Slicer with Internationalization support" ON)
+option(Slicer_BUILD_I18N_SUPPORT "Build Slicer with Internationalization support" OFF)
 
 option(Slicer_BUILD_QTLOADABLEMODULES "Build Slicer QT Loadable Modules" ON)
 mark_as_advanced(Slicer_BUILD_QTLOADABLEMODULES)


### PR DESCRIPTION
we remove the qm file filter resizer because Chinese Language have area differences.