### PR TITLE
ENH: Added accessor functions to layout manager and factory

### DIFF
--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -961,6 +961,13 @@ qMRMLThreeDWidget* qMRMLLayoutManager::threeDWidget(int id)const
 }
 
 //------------------------------------------------------------------------------
+qMRMLThreeDWidget* qMRMLLayoutManager::threeDWidget(const QString& name)const
+{
+  return qobject_cast<qMRMLThreeDWidget*>(
+    this->mrmlViewFactory("vtkMRMLViewNode")->viewWidget(name));
+}
+
+//------------------------------------------------------------------------------
 qMRMLChartWidget* qMRMLLayoutManager::chartWidget(int id)const
 {
   return qobject_cast<qMRMLChartWidget*>(

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.h
@@ -117,7 +117,7 @@ public:
   /// Return the view factory that handles the viewClassName view nodes.
   /// This can be used to replace a view factory with another one.
   /// \sa mrmlViewFactories(), registerViewFactory(), unregisterViewFactory()
-  qMRMLLayoutViewFactory* mrmlViewFactory(const QString& viewClassName)const;
+  Q_INVOKABLE qMRMLLayoutViewFactory* mrmlViewFactory(const QString& viewClassName)const;
 
   /// Return the mrml scene of the layout manager. It is the scene that is set
   /// by setMRMLScene().
@@ -129,8 +129,11 @@ public:
   /// qMRMLThreeDWidget respectively).
   Q_INVOKABLE QWidget* viewWidget(vtkMRMLNode *n) const;
 
-  /// Get SliceViewWidget identified by \a name
+  /// Get slice view widget identified by \a name
   Q_INVOKABLE qMRMLSliceWidget* sliceWidget(const QString& name)const;
+
+  /// Get 3D widget identified by \a name
+  Q_INVOKABLE qMRMLThreeDWidget* threeDWidget(const QString& name)const;
 
   /// Get the list of SliceWidgetNames
   /// All slice widget names are returned,

--- a/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
@@ -51,6 +51,7 @@ public:
   virtual void init();
 
   vtkMRMLAbstractViewNode* viewNodeByName(const QString& viewName)const;
+  vtkMRMLAbstractViewNode* viewNodeByLayoutLabel(const QString& layoutLabel)const;
 
   vtkMRMLLayoutLogic::ViewAttributes attributesFromXML(QDomElement viewElement)const;
   vtkMRMLLayoutLogic::ViewProperties propertiesFromXML(QDomElement viewElement)const;
@@ -95,7 +96,21 @@ vtkMRMLAbstractViewNode* qMRMLLayoutViewFactoryPrivate
       return viewNode;
       }
     }
-  return 0;
+  return NULL;
+}
+
+//------------------------------------------------------------------------------
+vtkMRMLAbstractViewNode* qMRMLLayoutViewFactoryPrivate
+::viewNodeByLayoutLabel(const QString& layoutLabel)const
+{
+  foreach(vtkMRMLAbstractViewNode* viewNode, this->Views.keys())
+    {
+    if (layoutLabel == QString(viewNode->GetLayoutLabel()))
+      {
+      return viewNode;
+      }
+    }
+  return NULL;
 }
 
 //------------------------------------------------------------------------------
@@ -281,6 +296,14 @@ QWidget* qMRMLLayoutViewFactory::viewWidget(const QString& name)const
 {
   Q_D(const qMRMLLayoutViewFactory);
   vtkMRMLAbstractViewNode* viewNode = d->viewNodeByName(name);
+  return this->viewWidget(viewNode);
+}
+
+//------------------------------------------------------------------------------
+QWidget* qMRMLLayoutViewFactory::viewWidgetByLayoutLabel(const QString& layoutLabel)const
+{
+  Q_D(const qMRMLLayoutViewFactory);
+  vtkMRMLAbstractViewNode* viewNode = d->viewNodeByLayoutLabel(layoutLabel);
   return this->viewWidget(viewNode);
 }
 

--- a/Libs/MRML/Widgets/qMRMLLayoutViewFactory.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutViewFactory.h
@@ -85,10 +85,11 @@ public:
   /// \sa setMRMLScene()
   Q_INVOKABLE vtkMRMLScene* mrmlScene()const;
 
-  QWidget* viewWidget(int id)const;
-  QWidget* viewWidget(vtkMRMLAbstractViewNode* node)const;
-  QWidget* viewWidget(const QString& name)const;
-  int viewCount()const;
+  Q_INVOKABLE QWidget* viewWidget(int id)const;
+  Q_INVOKABLE QWidget* viewWidget(vtkMRMLAbstractViewNode* node)const;
+  Q_INVOKABLE QWidget* viewWidget(const QString& name)const;
+  Q_INVOKABLE QWidget* viewWidgetByLayoutLabel(const QString& layoutLabel)const;
+  Q_INVOKABLE int viewCount()const;
 
   virtual void beginSetupLayout();
 


### PR DESCRIPTION
- Layout manager factory can be accessed from python
- View widgets can be retrieved by their layout label
- 3D views can be retrieved by name