### PR TITLE
WIP: BUG: Fix toolbuttons size with high dpi display

### DIFF
--- a/Base/QTGUI/qSlicerStyle.cxx
+++ b/Base/QTGUI/qSlicerStyle.cxx
@@ -127,6 +127,11 @@ int qSlicerStyle::pixelMetric(PixelMetric metric, const QStyleOption * option,
     case QStyle::PM_SliderLength:
       return 12; // default to 27
       break;
+#if (QT_VERSION > QT_VERSION_CHECK(5, 0, 0))
+    case QStyle::PM_ButtonIconSize:
+      return 24; // Like with cleanlooks style
+      break;
+#endif
     default:
       return Superclass::pixelMetric(metric, option, widget);
       break;


### PR DESCRIPTION
This commit fixes the tool button size to be consistent with the slicer's
Qt4 sizes when the application is displayed on a high dpi monitor.
Note that this does not affect any toolbutton in a QToolbar as these will
inherit their icon size from the toolbar.

@jcfr: Would you mind testing ?