### PR TITLE
Add tooltip for Reduction in Decimation section of Surface Toolbox module

### DIFF
--- a/Modules/Scripted/SurfaceToolbox/SurfaceToolbox.py
+++ b/Modules/Scripted/SurfaceToolbox/SurfaceToolbox.py
@@ -100,7 +100,9 @@ class SurfaceToolboxWidget(ScriptedLoadableModuleWidget):
     self.layout.addWidget(decimationFrame)
     decimationFormLayout = qt.QFormLayout(decimationFrame)
 
-    reductionFrame, reductionSlider, reductionSpinBox = numericInputFrame(self.parent,"Reduction:","Tooltip",0.0,1.0,0.05,2)
+    reductionFrame, reductionSlider, reductionSpinBox = numericInputFrame(self.parent,"Reduction:",
+      "Specifies the desired reduction in the total number of polygons (e.g., if Reduction is set"
+      +" to 0.9, this filter will try to reduce the data set to 10% of its original size).", 0.0,1.0,0.05,2)
     decimationFormLayout.addWidget(reductionFrame)
 
     boundaryDeletionCheckBox = qt.QCheckBox("Boundary deletion")


### PR DESCRIPTION
It might not be clear if 0.25 means reduce the size to 75% or to 25%. I've adapted the tooltip from VTK docs: https://www.vtk.org/doc/nightly/html/classvtkDecimatePro.html#a2889d06be4ebee23a5c02e69e8b2a946