### PR TITLE
BUG: Fixed hang when volume rendering in one-up 3D view

### DIFF
--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationROIDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationROIDisplayableManager.cxx
@@ -38,6 +38,7 @@
 #include <vtkProperty.h>
 #include <vtkRenderer.h>
 // for picking
+#include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkTransform.h>
 #include <vtkTransformPolyDataFilter.h>
@@ -419,6 +420,11 @@ void vtkMRMLAnnotationROIDisplayableManager::PropagateMRMLToWidget(vtkMRMLAnnota
 /// Propagate properties of MRML node to widget.
 void vtkMRMLAnnotationROIDisplayableManager::PropagateMRMLToWidget2D(vtkMRMLAnnotationNode* node, vtkAbstractWidget * widget)
 {
+  if (!this->GetRenderer() || !this->GetRenderer()->GetRenderWindow() || this->GetRenderer()->GetRenderWindow()->GetNeverRendered())
+    {
+    return;
+    }
+
   vtkMRMLSliceNode *sliceNode = this->GetSliceNode();
   if (!sliceNode)
     {

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation2D.cxx
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation2D.cxx
@@ -37,6 +37,7 @@
 #include <vtkProperty2D.h>
 #include <vtkPropPicker.h>
 #include <vtkRenderer.h>
+#include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkSmartPointer.h>
 #include <vtkSphereSource.h>
@@ -630,7 +631,8 @@ int vtkAnnotationROIRepresentation2D::ComputeInteractionState(int X, int Y, int 
 {
   // Okay, we can process this. Try to pick handles first;
   // if no handles picked, then pick the bounding box.
-  if (!this->Renderer || !this->Renderer->IsInViewport(X, Y))
+  if (!this->Renderer || !this->Renderer->IsInViewport(X, Y)
+    || !this->Renderer->GetRenderWindow() || this->Renderer->GetRenderWindow()->GetNeverRendered())
     {
     this->InteractionState = vtkAnnotationROIRepresentation::Outside;
     return this->InteractionState;


### PR DESCRIPTION
If annotation ROI widget was placed or handle picker was used without initializing the render window then it caused application GUI to stop updating.
Fixed by adding checks to prevent widget use until render window is at least rendered once.

Fixes https://issues.slicer.org/view.php?id=4516.