### PR TITLE
ENH: Speedup by 50% handling of argument expected to display a msg and exit

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -393,6 +393,17 @@ void qSlicerCoreApplicationPrivate::init()
 }
 
 //-----------------------------------------------------------------------------
+void qSlicerCoreApplicationPrivate::quickExit(int exitCode)
+{
+  // XXX When supporting exclusively C++11, replace with std::quick_exit
+#ifdef Q_OS_WIN32
+  ExitProcess(exitCode);
+#else
+  _exit(exitCode);
+#endif
+}
+
+//-----------------------------------------------------------------------------
 void qSlicerCoreApplicationPrivate::initDataIO()
 {
   Q_Q(qSlicerCoreApplication);
@@ -761,44 +772,38 @@ void qSlicerCoreApplication::handlePreApplicationCommandLineArguments()
                 << "Options\n";
       }
     std::cout << qPrintable(options->helpText()) << std::endl;
-    this->terminate(EXIT_SUCCESS);
-    return;
+    d->quickExit(EXIT_SUCCESS);
     }
 
   if (options->displayVersionAndExit())
     {
     std::cout << qPrintable(this->applicationName() + " " +
                             this->applicationVersion()) << std::endl;
-    this->terminate(EXIT_SUCCESS);
-    return;
+    d->quickExit(EXIT_SUCCESS);
     }
 
   if (options->displayProgramPathAndExit())
     {
     std::cout << qPrintable(this->arguments().at(0)) << std::endl;
-    this->terminate(EXIT_SUCCESS);
-    return;
+    d->quickExit(EXIT_SUCCESS);
     }
 
   if (options->displayHomePathAndExit())
     {
     std::cout << qPrintable(this->slicerHome()) << std::endl;
-    this->terminate(EXIT_SUCCESS);
-    return;
+    d->quickExit(EXIT_SUCCESS);
     }
 
   if (options->displaySettingsPathAndExit())
     {
     std::cout << qPrintable(this->userSettings()->fileName()) << std::endl;
-    this->terminate(EXIT_SUCCESS);
-    return;
+    d->quickExit(EXIT_SUCCESS);
     }
 
   if (options->displayTemporaryPathAndExit())
     {
     std::cout << qPrintable(this->temporaryPath()) << std::endl;
-    this->terminate(EXIT_SUCCESS);
-    return;
+    d->quickExit(EXIT_SUCCESS);
     }
 
   if (options->ignoreRest())

--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -65,6 +65,9 @@ public:
 
   virtual void init();
 
+  /// Terminates the calling process "immediately".
+  void quickExit(int exitCode);
+
   /// Set up the local and remote data input/output for this application.
   /// Use this as a template for creating stand alone scenes, then call
   /// vtkSlicerApplicationLogic::SetMRMLSceneDataIO to hook it into a scene.


### PR DESCRIPTION
On my workstation, executing "Slicer --help" or "Slicer --version" went
down from ~1.3s to ~0.6s.

This commit introduces the function quickExit allowing to quickly
terminate the executable.

After supporting exclusively c++11, the corresponding function from
the standard library will be used.
See http://en.cppreference.com/w/cpp/utility/program/quick_exit