### PR TITLE
ENH: Added performance related options to GPU volume rendering

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
@@ -34,6 +34,8 @@ vtkMRMLNodeNewMacro(vtkMRMLGPURayCastVolumeRenderingDisplayNode);
 vtkMRMLGPURayCastVolumeRenderingDisplayNode::vtkMRMLGPURayCastVolumeRenderingDisplayNode()
 {
   this->RaycastTechnique = vtkMRMLGPURayCastVolumeRenderingDisplayNode::Composite;
+  this->UseJittering = 0;
+  this->LockSampleDistanceToInputSpacing = 0;
 }
 
 //----------------------------------------------------------------------------
@@ -46,20 +48,11 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::ReadXMLAttributes(const char**
 {
   this->Superclass::ReadXMLAttributes(atts);
 
-  const char* attName;
-  const char* attValue;
-  while (*atts != NULL)
-    {
-    attName = *(atts++);
-    attValue = *(atts++);
-    if (!strcmp(attName,"raycastTechnique"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->RaycastTechnique;
-      continue;
-      }
-    }
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLIntMacro(raycastTechnique, RaycastTechnique);
+  vtkMRMLReadXMLIntMacro(useJittering, UseJittering);
+  vtkMRMLReadXMLIntMacro(lockSampleDistanceToInputSpacing, LockSampleDistanceToInputSpacing);
+  vtkMRMLReadXMLEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -67,7 +60,11 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::WriteXML(ostream& of, int nInd
 {
   this->Superclass::WriteXML(of, nIndent);
 
-  of << " raycastTechnique=\"" << this->RaycastTechnique << "\"";
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLIntMacro(raycastTechnique, RaycastTechnique);
+  vtkMRMLWriteXMLIntMacro(useJittering, UseJittering);
+  vtkMRMLWriteXMLIntMacro(lockSampleDistanceToInputSpacing, LockSampleDistanceToInputSpacing);
+  vtkMRMLWriteXMLEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -75,9 +72,12 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::Copy(vtkMRMLNode *anode)
 {
   int wasModifying = this->StartModify();
   this->Superclass::Copy(anode);
-  vtkMRMLGPURayCastVolumeRenderingDisplayNode *node = vtkMRMLGPURayCastVolumeRenderingDisplayNode::SafeDownCast(anode);
 
-  this->SetRaycastTechnique(node->GetRaycastTechnique());
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyIntMacro(RaycastTechnique);
+  vtkMRMLCopyIntMacro(UseJittering);
+  vtkMRMLCopyIntMacro(LockSampleDistanceToInputSpacing);
+  vtkMRMLCopyEndMacro();
 
   this->EndModify(wasModifying);
 }
@@ -87,5 +87,9 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::PrintSelf(ostream& os, vtkInde
 {
   this->Superclass::PrintSelf(os,indent);
 
-  os << "RaycastTechnique: " << this->RaycastTechnique << "\n";
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintIntMacro(RaycastTechnique);
+  vtkMRMLPrintIntMacro(UseJittering);
+  vtkMRMLPrintIntMacro(LockSampleDistanceToInputSpacing);
+  vtkMRMLPrintEndMacro();
 }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.h
@@ -55,8 +55,18 @@ public:
 
   // Description:
   // Ray cast technique
-  vtkGetMacro (RaycastTechnique, int);
-  vtkSetMacro (RaycastTechnique, int);
+  vtkGetMacro(RaycastTechnique, int);
+  vtkSetMacro(RaycastTechnique, int);
+
+  // Description:
+  // Jittering
+  vtkGetMacro(UseJittering, int);
+  vtkSetMacro(UseJittering, int);
+
+  // Description:
+  // Lock sample distance to volume spacing
+  vtkGetMacro(LockSampleDistanceToInputSpacing, int);
+  vtkSetMacro(LockSampleDistanceToInputSpacing, int);
 
 protected:
   vtkMRMLGPURayCastVolumeRenderingDisplayNode();
@@ -70,6 +80,15 @@ protected:
    * 3: MINIP
    * */
   int RaycastTechnique;
+
+  /// Use jittering to reduce the wood-grain effect if on. Off by default
+  int UseJittering;
+
+  /// Compute sample distance from volume spacing if on. Off by default
+  /// If turned on, then AutoAdjustSampleDistances and explicit SampleDistance
+  /// will be ignored, and only the internal auto-calculation will determine
+  /// the sampling distance.
+  int LockSampleDistanceToInputSpacing;
 };
 
 #endif

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
@@ -45,48 +45,22 @@ public:
   /// Copy the node's attributes to this object
   virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
-  /// Mark the volume, ROI and volume property nodes as references.
-  virtual void SetSceneReferences() VTK_OVERRIDE;
-
-  /// Update the stored reference to another node in the scene
-  virtual void UpdateReferenceID(const char *oldID, const char *newID) VTK_OVERRIDE;
-
-  /// Updates this node if it depends on other nodes
-  /// when the node is deleted in the scene
-  virtual void UpdateReferences() VTK_OVERRIDE;
-
-  /// Observe the reference transform node
-  virtual void UpdateScene(vtkMRMLScene *scene) VTK_OVERRIDE;
-
-  /// the ID of a MRMLVolumeNode
-  vtkGetStringMacro (VolumeNodeID);
+  const char* GetVolumeNodeID();
   void SetAndObserveVolumeNodeID(const char *volumeNodeID);
-
-  /// Associated transform MRML node
   vtkMRMLVolumeNode* GetVolumeNode();
 
-  /// the ID of a parameter MRMLVolumePropertyNode
-  vtkGetStringMacro (VolumePropertyNodeID);
+  const char* GetVolumePropertyNodeID();
   void SetAndObserveVolumePropertyNodeID(const char *volumePropertyNodeID);
-
-  /// Associated transform MRML node
   vtkMRMLVolumePropertyNode* GetVolumePropertyNode();
 
-  /// the ID of a parameter MRMLROINode
-  vtkGetStringMacro (ROINodeID);
+  const char* GetROINodeID();
   void SetAndObserveROINodeID(const char *roiNodeID);
-
-  /// Associated transform MRML node
   vtkMRMLAnnotationROINode* GetROINode();
 
   /// Is cropping enabled?
   vtkSetMacro(CroppingEnabled,int);
   vtkGetMacro(CroppingEnabled,int);
   vtkBooleanMacro(CroppingEnabled,int);
-
-  //vtkSetMacro(UseThreshold,int);
-  //vtkGetMacro(UseThreshold,int);
-  //vtkBooleanMacro(UseThreshold,int);
 
   /// Estimated Sample Distance
   vtkSetMacro(EstimatedSampleDistance,double);
@@ -139,37 +113,28 @@ protected:
   vtkMRMLVolumeRenderingDisplayNode(const vtkMRMLVolumeRenderingDisplayNode&);
   void operator=(const vtkMRMLVolumeRenderingDisplayNode&);
 
-  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData) VTK_OVERRIDE;
+  virtual void ProcessMRMLEvents(vtkObject *caller, unsigned long event, void *callData) VTK_OVERRIDE;
 
-  vtkIntArray* ObservedEvents;
+  static const char* VolumeNodeReferenceRole;
+  static const char* VolumeNodeReferenceMRMLAttributeName;
+  static const char* VolumePropertyNodeReferenceRole;
+  static const char* VolumePropertyNodeReferenceMRMLAttributeName;
+  static const char* ROINodeReferenceRole;
+  static const char* ROINodeReferenceMRMLAttributeName;
 
-  char *VolumeNodeID;
-  virtual void SetVolumeNodeID(const char* arg);
-  vtkMRMLVolumeNode* VolumeNode;
-
-  char *VolumePropertyNodeID;
-  virtual void SetVolumePropertyNodeID(const char* arg);
-  vtkMRMLVolumePropertyNode* VolumePropertyNode;
-
-  char *ROINodeID;
-  virtual void SetROINodeID(const char* arg);
-  vtkMRMLAnnotationROINode* ROINode;
-
+protected:
   int CroppingEnabled;
 
-  double  EstimatedSampleDistance;
-  double  ExpectedFPS;
+  double EstimatedSampleDistance;
+  double ExpectedFPS;
 
   /// Tracking GPU memory size (in MB), not saved into scene file
   /// because different machines may have different GPU memory
   /// values.
   /// A value of 0 indicates to use the default value in the settings
-  ///
   int GPUMemorySize;
 
   double Threshold[2];
-
-  //int UseThreshold;
 
   /// follow window/level and thresholding setting in volume display node
   int FollowVolumeDisplayNode;

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -359,11 +359,14 @@ double vtkMRMLVolumeRenderingDisplayableManager
 ::GetSampleDistance(vtkMRMLVolumeRenderingDisplayNode* vspNode)
 {
   vtkMRMLVolumeNode* volumeNode = vspNode ? vspNode->GetVolumeNode() : 0;
-  const double minSpacing = volumeNode->GetMinSpacing() > 0 ?
-    volumeNode->GetMinSpacing() : 1.;
+  if (!volumeNode)
+    {
+    vtkErrorMacro("GetSampleDistance: Failed to access volume node:");
+    return vspNode->GetEstimatedSampleDistance();
+    }
+  const double minSpacing = volumeNode->GetMinSpacing() > 0 ? volumeNode->GetMinSpacing() : 1.;
   double sampleDistance = minSpacing / vspNode->GetEstimatedSampleDistance();
-  if (vspNode->GetPerformanceControl() ==
-      vtkMRMLVolumeRenderingDisplayNode::MaximumQuality)
+  if (vspNode->GetPerformanceControl() == vtkMRMLVolumeRenderingDisplayNode::MaximumQuality)
     {
     sampleDistance = minSpacing / 10.; // =10x smaller than pixel is high quality
     }
@@ -386,12 +389,12 @@ void vtkMRMLVolumeRenderingDisplayableManager
   vtkMRMLCPURayCastVolumeRenderingDisplayNode* vspNode)
 {
   this->UpdateMapper(mapper, vspNode);
-  const bool highDef = vspNode->GetPerformanceControl() ==
+  const bool maximumQuality = vspNode->GetPerformanceControl() ==
     vtkMRMLVolumeRenderingDisplayNode::MaximumQuality;
-  mapper->SetAutoAdjustSampleDistances( highDef ? 0 : 1);
+  mapper->SetAutoAdjustSampleDistances(maximumQuality ? 0 : 1);
   mapper->SetSampleDistance(this->GetSampleDistance(vspNode));
   mapper->SetInteractiveSampleDistance(this->GetSampleDistance(vspNode));
-  mapper->SetImageSampleDistance(highDef ? 0.5 : 1.);
+  mapper->SetImageSampleDistance(maximumQuality ? 0.5 : 1.);
 
   switch(vspNode->GetRaycastTechnique())
     {
@@ -414,12 +417,17 @@ void vtkMRMLVolumeRenderingDisplayableManager
   vtkMRMLGPURayCastVolumeRenderingDisplayNode* vspNode)
 {
   this->UpdateMapper(mapper, vspNode);
-  const bool highDef = vspNode->GetPerformanceControl() ==
+  const bool maximumQuality = vspNode->GetPerformanceControl() ==
     vtkMRMLVolumeRenderingDisplayNode::MaximumQuality;
-  mapper->SetAutoAdjustSampleDistances( highDef ? 0 : 1);
+  const bool lockSampleDistance = vspNode->GetLockSampleDistanceToInputSpacing() == 1;
+  // AutoAdjustSampleDistances disables LockSampleDistanceToInputSpacing, so if
+  // LockSampleDistanceToInputSpacing is on then disable AutoAdjustSampleDistances
+  mapper->SetAutoAdjustSampleDistances(maximumQuality || lockSampleDistance ? 0 : 1);
+  mapper->SetLockSampleDistanceToInputSpacing(lockSampleDistance);
   mapper->SetSampleDistance(this->GetSampleDistance(vspNode));
-  mapper->SetImageSampleDistance(highDef ? 1. : 1.);
+  mapper->SetImageSampleDistance(maximumQuality ? 1. : 1.);
   mapper->SetMaxMemoryInBytes(this->GetMaxMemoryInBytes(mapper, vspNode));
+  mapper->SetUseJittering(vspNode->GetUseJittering());
 
   switch(vspNode->GetRaycastTechnique())
     {

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -379,7 +379,7 @@
              <double>1.000000000000000</double>
             </property>
             <property name="maximum">
-             <double>20.000000000000000</double>
+             <double>100.000000000000000</double>
             </property>
             <property name="value">
              <double>8.000000000000000</double>
@@ -506,11 +506,6 @@
            <widget class="qMRMLAnnotationROIWidget" name="ROIWidget"/>
           </item>
          </layout>
-        </widget>
-        <widget class="QWidget" name="MiscTab">
-         <attribute name="title">
-          <string>Misc</string>
-         </attribute>
         </widget>
        </widget>
       </item>

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.cxx
@@ -281,9 +281,9 @@ void qSlicerVolumeRenderingPresetComboBox::updatePresetSliderRange()
   double transferFunctionWidth = effectiveRange[1] - effectiveRange[0];
 
   bool wasBlocking = d->PresetOffsetSlider->blockSignals(true);
+  d->PresetOffsetSlider->setRange(-transferFunctionWidth, transferFunctionWidth);
   d->PresetOffsetSlider->setSingleStep(ctk::closestPowerOfTen(transferFunctionWidth)/500.0);
   d->PresetOffsetSlider->setPageStep(d->PresetOffsetSlider->singleStep());
-  d->PresetOffsetSlider->setRange(-transferFunctionWidth, transferFunctionWidth);
   d->PresetOffsetSlider->blockSignals(wasBlocking);
 }
 


### PR DESCRIPTION
- Added option to use the mapper's feature LockSampleDistanceToInputSpacing to calculate it internally instead of setting sampling distance manually. Off by default. This applies only for GPU rendering. If it's on, then AutoAdjustSampleDistances is disabled, because it prevents using this feature. Because of this, if the flag is on, then the MaximumQuality and AdaptiveQuality setting does not work
- Added UseJittering option to GPU display node. If turned on, then uses random noise to remove the wood-grain artifact. Off by default. Not exposed on the UI yet
- Widened range of FPS slider for adaptive mode to accommodate for new virtual reality use cases (maximum used to be 20, now it is 100)
- Removed empty "Misc" tab from Volume rendering module UI
- Fixed ctkDoubleSlider related warning message
- Modernized vtkMRMLVolumeRenderingDisplayNode to use node references and new property macros. This fixed several bugs as well (e.g. not reading/writing attributes)