### PR TITLE
BUG: Fixed old bug with volume rendering preset selection when changi…

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
@@ -152,11 +152,15 @@ void vtkMRMLVolumePropertyNode::CopyParameterSet(vtkMRMLNode *anode)
     return;
     }
 
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyVectorMacro(EffectiveRange, double, 2);
+  vtkMRMLCopyEndMacro();
+
+  // VolumeProperty
   this->VolumeProperty->SetIndependentComponents(node->VolumeProperty->GetIndependentComponents());
   this->VolumeProperty->SetInterpolationType(node->VolumeProperty->GetInterpolationType());
 
-  //VolumeProperty
-  for (int i=0;i<VTK_MAX_VRCOMP;i++)
+  for (int i=0; i<VTK_MAX_VRCOMP; i++)
     {
     this->VolumeProperty->SetComponentWeight(i,node->GetVolumeProperty()->GetComponentWeight(i));
     //TODO: No set method for GrayTransferFunction, ColorChannels, and DefaultGradientOpacity
@@ -186,8 +190,6 @@ void vtkMRMLVolumePropertyNode::CopyParameterSet(vtkMRMLNode *anode)
     this->VolumeProperty->SetSpecular(i, node->VolumeProperty->GetSpecular(i));
     this->VolumeProperty->SetSpecularPower(i, node->VolumeProperty->GetSpecularPower(i));
     }
-
-  this->SetEffectiveRange(node->GetEffectiveRange());
 }
 
 //----------------------------------------------------------------------------
@@ -195,7 +197,9 @@ void vtkMRMLVolumePropertyNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
 
-  os << indent << "EffectiveRange: (" << this->EffectiveRange[0] << ", " << this->EffectiveRange[1] << ")\n";
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintVectorMacro(EffectiveRange, double, 2);
+  vtkMRMLPrintEndMacro();
 
   os << indent << "VolumeProperty: ";
   this->VolumeProperty->PrintSelf(os,indent.GetNextIndent());

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -287,7 +287,7 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentMRMLVolumeNodeChanged(vtkMRMLN
 
   vtkSlicerVolumeRenderingLogic *logic = vtkSlicerVolumeRenderingLogic::SafeDownCast(this->logic());
 
-  // see if the volume has any display node for a current viewer
+  // See if the volume has any display node for a current viewer
   vtkMRMLVolumeRenderingDisplayNode *dnode = logic->GetFirstVolumeRenderingDisplayNode(volumeNode);
   if (!this->mrmlScene()->IsClosing())
     {
@@ -306,6 +306,16 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentMRMLVolumeNodeChanged(vtkMRMLN
     }
 
   this->setMRMLDisplayNode(dnode);
+
+  // Select preset node that was previously selected for this volume
+  vtkMRMLVolumePropertyNode* volumePropertyNode = this->mrmlVolumePropertyNode();
+  if (volumePropertyNode)
+    {
+    vtkMRMLVolumePropertyNode* presetNode = logic->GetPresetByName(volumePropertyNode->GetName());
+    bool wasBlocking = d->PresetComboBox->blockSignals(true);
+    d->PresetComboBox->setCurrentNode(presetNode);
+    d->PresetComboBox->blockSignals(wasBlocking);
+    }
 
   emit currentVolumeNodeChanged(volumeNode);
 }

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.cxx
@@ -154,6 +154,13 @@ vtkMRMLNode* qSlicerVolumeRenderingPresetComboBox::currentNode()const
 }
 
 // --------------------------------------------------------------------------
+QString qSlicerVolumeRenderingPresetComboBox::currentNodeID()const
+{
+  Q_D(const qSlicerVolumeRenderingPresetComboBox);
+  return d->PresetComboBox->currentNodeID();
+}
+
+// --------------------------------------------------------------------------
 vtkMRMLVolumePropertyNode* qSlicerVolumeRenderingPresetComboBox::mrmlVolumePropertyNode()const
 {
   Q_D(const qSlicerVolumeRenderingPresetComboBox);
@@ -165,6 +172,13 @@ void qSlicerVolumeRenderingPresetComboBox::setCurrentNode(vtkMRMLNode* node)
 {
   Q_D(qSlicerVolumeRenderingPresetComboBox);
   d->PresetComboBox->setCurrentNode(node);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerVolumeRenderingPresetComboBox::setCurrentNodeID(const QString& nodeID)
+{
+  Q_D(qSlicerVolumeRenderingPresetComboBox);
+  d->PresetComboBox->setCurrentNodeID(nodeID);
 }
 
 // --------------------------------------------------------------------------
@@ -291,6 +305,15 @@ void qSlicerVolumeRenderingPresetComboBox::updatePresetSliderRange()
 void qSlicerVolumeRenderingPresetComboBox::applyPreset(vtkMRMLNode* node)
 {
   Q_D(qSlicerVolumeRenderingPresetComboBox);
+
+  if (this->signalsBlocked())
+    {
+    // Prevent the preset node from overwriting the active volume property node (thus reverting
+    // changes in the transfer functions) when the widget's signals are blocked.
+    // Needed to handle here, because if the inner combobox's signals are blocked, then the icon
+    // is not updated.
+    return;
+    }
 
   vtkMRMLVolumePropertyNode* presetNode = vtkMRMLVolumePropertyNode::SafeDownCast(node);
   if (!presetNode || !d->VolumePropertyNode)

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.h
@@ -46,6 +46,9 @@ public:
   /// Get selected preset node in the combobox.
   /// Note: This node is not in the main MRML scene, but from the private presets scene
   Q_INVOKABLE vtkMRMLNode* currentNode()const;
+  /// Return the currently selected node id . "" if no node is selected
+  /// Utility function that is based on currentNode
+  Q_INVOKABLE QString currentNodeID()const;
 
   /// Get volume property node controlling volume rendering transfer functions.
   /// Its content mirrors the currently selected preset node in the combobox.
@@ -54,6 +57,9 @@ public:
 public slots:
   /// Set selected preset node in the combobox. Triggers update of the volume property node
   void setCurrentNode(vtkMRMLNode* node);
+  /// Select the node to be current. If \a nodeID is invalid (or can't be found
+  /// in the scene), the current node becomes 0.
+  void setCurrentNodeID(const QString& nodeID);
 
   /// Set volume property node controlling volume rendering transfer functions.
   /// Its content mirrors the currently selected preset node in the combobox.


### PR DESCRIPTION
…ng volume

When the rendered volume was changed, then the preset combobox selection stayed at the previous selection, but that selection was not applied. Because of this, many times the user had to change selection to something else than back. In addition it was confusing.
Now the selected preset is remembered, and set when the volume changes.