### PR TITLE
BUG: fix #4485 - use of known null

### DIFF
--- a/Libs/MRML/Core/vtkMRMLModelDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelDisplayNode.cxx
@@ -217,10 +217,20 @@ vtkPointSet* vtkMRMLModelDisplayNode::GetOutputMesh()
     }
 
   vtkAlgorithmOutput* outputConnection = this->GetOutputMeshConnection();
-  vtkAlgorithm* producer =  outputConnection? outputConnection->GetProducer() : 0;
+  if (!outputConnection)
+    {
+    return NULL;
+    }
+
+  vtkAlgorithm* producer = outputConnection->GetProducer();
+  if (!producer)
+    {
+    return NULL;
+    }
+
   producer->Update();
   return vtkPointSet::SafeDownCast(
-    producer ? producer->GetOutputDataObject(outputConnection->GetIndex()) : 0);
+           producer->GetOutputDataObject(outputConnection->GetIndex()));
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Ran in to this earlier when I returned null from a subclass `::GetOutputMeshConnection` (temporary testing change in order to short-circuit pipeline).

Also clean up the flow.