### PR TITLE
ENH: Added direct file export from segmentation

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -234,6 +234,17 @@ public:
   static bool ImportModelHierarchyToSegmentationNode(
     vtkMRMLModelHierarchyNode* modelHierarchyNode, vtkMRMLSegmentationNode* segmentationNode, std::string insertBeforeSegmentId = "" );
 
+  /// Export closed surface representation of multiple segments to files. Typically used for writing 3D printable model files.
+  /// \param segmentationNode Segmentation node from which the the segments are exported
+  /// \param destinationFolder Folder name where segments will be exported to
+  /// \param fileFormat Output file format (STL or OBJ).
+  /// \param merge Merge all models into a single mesh. Only applicable to STL format.
+  /// \param lps Save files in LPS coordinate system. If set to false then RAS coordinate system is used.
+  /// \param segmentIds List of segment IDs to export
+  static bool ExportSegmentsClosedSurfaceRepresentationToFiles(std::string destinationFolder,
+    vtkMRMLSegmentationNode* segmentationNode, vtkStringArray* segmentIds = NULL,
+    std::string fileFormat = "STL", bool lps = true, bool merge = false);
+
   /// Create representation of only one segment in a segmentation.
   /// Useful if only one segment is processed, and we do not want to convert all segments to a certain
   /// segmentation to save time.
@@ -338,6 +349,11 @@ protected:
 
   /// Handle MRML node added events
   virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) VTK_OVERRIDE;
+
+  static bool ExportSegmentsClosedSurfaceRepresentationToStlFiles(std::string destinationFolder,
+    vtkMRMLSegmentationNode* segmentationNode, std::vector<std::string>& segmentIDs, bool lps, bool merge);
+  static bool ExportSegmentsClosedSurfaceRepresentationToObjFile(std::string destinationFolder,
+    vtkMRMLSegmentationNode* segmentationNode, std::vector<std::string>& segmentIDs, bool lps);
 
 protected:
   vtkSlicerSegmentationsModuleLogic();

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>357</width>
-    <height>559</height>
+    <height>832</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>4</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
     <number>4</number>
    </property>
    <item>
@@ -72,7 +81,16 @@
       <property name="spacing">
        <number>4</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -139,11 +157,17 @@
      <property name="text">
       <string>Display</string>
      </property>
-     <property name="contentsFrameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
      <layout class="QGridLayout" name="gridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
        <number>4</number>
       </property>
       <property name="spacing">
@@ -163,11 +187,17 @@
      <property name="text">
       <string>Representations</string>
      </property>
-     <property name="contentsFrameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
        <number>4</number>
       </property>
       <property name="spacing">
@@ -190,14 +220,20 @@
      <property name="collapsed">
       <bool>true</bool>
      </property>
-     <property name="contentsFrameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="spacing">
        <number>9</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
        <number>4</number>
       </property>
       <item>
@@ -414,11 +450,17 @@
      <property name="collapsed">
       <bool>true</bool>
      </property>
-     <property name="contentsFrameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
        <number>4</number>
       </property>
       <property name="spacing">
@@ -434,71 +476,6 @@
         </property>
         <property name="noneDisplay">
          <string>Export to new node</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="3">
-       <widget class="ctkPushButton" name="PushButton_ImportExport">
-        <property name="text">
-         <string>Apply</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QRadioButton" name="radioButton_Import">
-        <property name="text">
-         <string>Import</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QRadioButton" name="radioButton_Labelmap">
-        <property name="text">
-         <string>Labelmap</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_ImportExportType">
-        <property name="text">
-         <string>Output type:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QRadioButton" name="radioButton_Model">
-        <property name="text">
-         <string>Models</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QRadioButton" name="radioButton_Export">
-        <property name="text">
-         <string>Export</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_ImportExportNode">
-        <property name="text">
-         <string>Output node:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Operation:</string>
         </property>
        </widget>
       </item>
@@ -520,7 +497,16 @@
          <property name="verticalSpacing">
           <number>4</number>
          </property>
-         <property name="margin">
+         <property name="leftMargin">
+          <number>4</number>
+         </property>
+         <property name="topMargin">
+          <number>4</number>
+         </property>
+         <property name="rightMargin">
+          <number>4</number>
+         </property>
+         <property name="bottomMargin">
           <number>4</number>
          </property>
          <item row="0" column="0">
@@ -598,6 +584,101 @@
         </layout>
        </widget>
       </item>
+      <item row="1" column="2">
+       <widget class="QRadioButton" name="radioButton_Model">
+        <property name="text">
+         <string>Models</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_ImportExportNode">
+        <property name="text">
+         <string>Output node:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QRadioButton" name="radioButton_Import">
+        <property name="text">
+         <string>Import</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="radioButton_Export">
+        <property name="text">
+         <string>Export</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="3">
+       <widget class="ctkPushButton" name="PushButton_ImportExport">
+        <property name="text">
+         <string>Apply</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QRadioButton" name="radioButton_Labelmap">
+        <property name="text">
+         <string>Labelmap</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_ImportExportType">
+        <property name="text">
+         <string>Output type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Operation:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="CollapsibleButton_ExportToFiles">
+     <property name="text">
+      <string>Export to files</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="qMRMLSegmentationFileExportWidget" name="ExportToFilesWidget"/>
+      </item>
      </layout>
     </widget>
    </item>
@@ -649,6 +730,11 @@
    <class>qMRMLSegmentationDisplayNodeWidget</class>
    <extends>qMRMLWidget</extends>
    <header>qMRMLSegmentationDisplayNodeWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSegmentationFileExportWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLSegmentationFileExportWidget.h</header>
   </customwidget>
   <customwidget>
    <class>ctkCollapsibleButton</class>
@@ -760,6 +846,22 @@
     <hint type="destinationlabel">
      <x>398</x>
      <y>1029</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerSegmentationsModule</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>ExportToFilesWidget</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>178</x>
+     <y>415</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>178</x>
+     <y>816</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Segmentations/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/Widgets/CMakeLists.txt
@@ -22,6 +22,8 @@ set(${KIT}_SRCS
   qMRMLSegmentEditorWidget.h
   qMRMLSegmentationDisplayNodeWidget.cxx
   qMRMLSegmentationDisplayNodeWidget.h
+  qMRMLSegmentationFileExportWidget.cxx
+  qMRMLSegmentationFileExportWidget.h
   qMRMLDoubleSpinBoxDelegate.cxx
   qMRMLDoubleSpinBoxDelegate.h
   )
@@ -32,6 +34,7 @@ set(${KIT}_MOC_SRCS
   qMRMLSegmentationConversionParametersWidget.h
   qMRMLSegmentEditorWidget.h
   qMRMLSegmentationDisplayNodeWidget.h
+  qMRMLSegmentationFileExportWidget.h
   qMRMLDoubleSpinBoxDelegate.h
 )
 
@@ -41,6 +44,7 @@ set(${KIT}_UI_SRCS
   Resources/UI/qMRMLSegmentationConversionParametersWidget.ui
   Resources/UI/qMRMLSegmentEditorWidget.ui
   Resources/UI/qMRMLSegmentationDisplayNodeWidget.ui
+  Resources/UI/qMRMLSegmentationFileExportWidget.ui
   )
 
 set(${KIT}_RESOURCES

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/CMakeLists.txt
@@ -19,6 +19,8 @@ set(${KIT}_SRCS
   qMRMLSegmentEditorWidgetPlugin.h
   qMRMLSegmentationDisplayNodeWidgetPlugin.cxx
   qMRMLSegmentationDisplayNodeWidgetPlugin.h
+  qMRMLSegmentationFileExportWidgetPlugin.cxx
+  qMRMLSegmentationFileExportWidgetPlugin.h
   )
 
 set(${KIT}_MOC_SRCS
@@ -29,6 +31,7 @@ set(${KIT}_MOC_SRCS
   qMRMLSegmentSelectorWidgetPlugin.h
   qMRMLSegmentEditorWidgetPlugin.h
   qMRMLSegmentationDisplayNodeWidgetPlugin.h
+  qMRMLSegmentationFileExportWidgetPlugin.h
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationFileExportWidgetPlugin.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationFileExportWidgetPlugin.cxx
@@ -1,0 +1,62 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+
+==============================================================================*/
+
+#include "qMRMLSegmentationFileExportWidgetPlugin.h"
+#include "qMRMLSegmentationFileExportWidget.h"
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationFileExportWidgetPlugin::qMRMLSegmentationFileExportWidgetPlugin(QObject* pluginParent)
+  : QObject(pluginParent)
+{
+}
+
+//-----------------------------------------------------------------------------
+QWidget *qMRMLSegmentationFileExportWidgetPlugin::createWidget(QWidget* parentWidget)
+{
+  qMRMLSegmentationFileExportWidget* pluginWidget =
+    new qMRMLSegmentationFileExportWidget(parentWidget);
+  return pluginWidget;
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSegmentationFileExportWidgetPlugin::domXml() const
+{
+  return "<widget class=\"qMRMLSegmentationFileExportWidget\" \
+          name=\"SegmentationDisplayNodeWidget\">\n"
+          "</widget>\n";
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSegmentationFileExportWidgetPlugin::includeFile() const
+{
+  return "qMRMLSegmentationFileExportWidget.h";
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationFileExportWidgetPlugin::isContainer() const
+{
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSegmentationFileExportWidgetPlugin::name() const
+{
+  return "qMRMLSegmentationFileExportWidget";
+}

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationFileExportWidgetPlugin.h
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationFileExportWidgetPlugin.h
@@ -1,0 +1,43 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+
+==============================================================================*/
+
+#ifndef __qMRMLSegmentationFileExportWidgetPlugin_h
+#define __qMRMLSegmentationFileExportWidgetPlugin_h
+
+#include "qSlicerSegmentationsModuleWidgetsAbstractPlugin.h"
+
+class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_PLUGINS_EXPORT qMRMLSegmentationFileExportWidgetPlugin
+  : public QObject
+  , public qSlicerSegmentationsModuleWidgetsAbstractPlugin
+{
+  Q_OBJECT
+
+public:
+  qMRMLSegmentationFileExportWidgetPlugin(QObject* parent = 0);
+
+  QWidget *createWidget(QWidget* parent);
+  QString  domXml() const;
+  QString  includeFile() const;
+  bool     isContainer() const;
+  QString  name() const;
+
+};
+
+#endif

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qSlicerSegmentationsModuleWidgetsPlugin.h
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qSlicerSegmentationsModuleWidgetsPlugin.h
@@ -37,6 +37,7 @@
 #include "qMRMLSegmentSelectorWidgetPlugin.h"
 #include "qMRMLSegmentEditorWidgetPlugin.h"
 #include "qMRMLSegmentationDisplayNodeWidgetPlugin.h"
+#include "qMRMLSegmentationFileExportWidgetPlugin.h"
 
 // \class Group the plugins in one library
 class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_PLUGINS_EXPORT qSlicerSegmentationsModuleWidgetsPlugin
@@ -53,7 +54,13 @@ public:
   QList<QDesignerCustomWidgetInterface*> customWidgets() const
     {
     QList<QDesignerCustomWidgetInterface *> plugins;
-    plugins << new qMRMLSegmentsTableViewPlugin << new qMRMLSegmentationRepresentationsListViewPlugin << new qMRMLSegmentationConversionParametersWidgetPlugin << new qMRMLSegmentSelectorWidgetPlugin << new qMRMLSegmentEditorWidgetPlugin << new qMRMLSegmentationDisplayNodeWidgetPlugin;
+    plugins << new qMRMLSegmentsTableViewPlugin
+      << new qMRMLSegmentationRepresentationsListViewPlugin
+      << new qMRMLSegmentationConversionParametersWidgetPlugin
+      << new qMRMLSegmentSelectorWidgetPlugin
+      << new qMRMLSegmentEditorWidgetPlugin
+      << new qMRMLSegmentationDisplayNodeWidgetPlugin
+      << new qMRMLSegmentationFileExportWidgetPlugin;
     return plugins;
     }
 };

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationFileExportWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationFileExportWidget.ui
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qMRMLSegmentationFileExportWidget</class>
+ <widget class="qMRMLWidget" name="qMRMLSegmentationFileExportWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>590</width>
+    <height>141</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>qMRMLSegmentationFileExportWidget</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <property name="spacing">
+    <number>4</number>
+   </property>
+   <item row="6" column="1">
+    <widget class="QCheckBox" name="VisibleSegmentsOnlyCheckBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="MergeIntoSingleFileLabel">
+     <property name="text">
+      <string>Merge into single file:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="FileFormatLabel">
+     <property name="text">
+      <string>File format:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QComboBox" name="CoordinateSystemComboBox">
+     <item>
+      <property name="text">
+       <string>LPS</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>RAS</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="VisibleSegmentsOnlyLabel">
+     <property name="text">
+      <string>Visible segments only: </string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="CoordinateSystemLabel">
+     <property name="text">
+      <string>Coordinate system: </string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="MergeIntoSingleFileCheckBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="FileFormatComboBox">
+     <item>
+      <property name="text">
+       <string>STL</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>OBJ</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="HorizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="ctkDirectoryButton" name="DestinationFolderButton"/>
+     </item>
+     <item>
+      <widget class="QToolButton" name="ShowDestinationFolderButton">
+       <property name="toolTip">
+        <string>Browse to destination folder</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
+         <normaloff>:/Icons/Go.png</normaloff>:/Icons/Go.png</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <widget class="QPushButton" name="ExportToFilesButton">
+     <property name="text">
+      <string>Export</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="DestinationFoldeLabel">
+     <property name="text">
+      <string>Destination folder: </string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkDirectoryButton</class>
+   <extends>QWidget</extends>
+   <header>ctkDirectoryButton.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
@@ -353,6 +353,8 @@ protected slots:
   void onSetSurfaceSmoothingClicked();
   /// Switch to Segmentations module and jump to Import/Export section
   void onImportExportActionClicked();
+  /// Open Export to files dialog
+  void onExportToFilesActionClicked();
 
   /// Update masking section on the UI
   void updateMaskingSection();

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.cxx
@@ -1,0 +1,231 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Andras Lasso, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, and Cancer
+  Care Ontario.
+
+==============================================================================*/
+
+// Segmentations includes
+#include "qMRMLSegmentationFileExportWidget.h"
+
+#include "ui_qMRMLSegmentationFileExportWidget.h"
+
+#include "vtkSlicerSegmentationsModuleLogic.h"
+
+#include "vtkMRMLSegmentationDisplayNode.h"
+#include "vtkMRMLSegmentationNode.h"
+
+// VTK includes
+#include <vtkStringArray.h>
+#include <vtkWeakPointer.h>
+
+// Qt includes
+#include <QDebug>
+#include <QDesktopServices>
+#include <QSettings>
+#include <QUrl>
+
+// Slicer includes
+#include <vtkMRMLSliceLogic.h>
+#include <vtkSlicerApplicationLogic.h>
+
+//-----------------------------------------------------------------------------
+class qMRMLSegmentationFileExportWidgetPrivate: public Ui_qMRMLSegmentationFileExportWidget
+{
+  Q_DECLARE_PUBLIC(qMRMLSegmentationFileExportWidget);
+
+protected:
+  qMRMLSegmentationFileExportWidget* const q_ptr;
+public:
+  qMRMLSegmentationFileExportWidgetPrivate(qMRMLSegmentationFileExportWidget& object);
+  void init();
+
+public:
+  vtkWeakPointer<vtkMRMLSegmentationNode> SegmentationNode;
+  QString SettingsKey;
+};
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationFileExportWidgetPrivate::qMRMLSegmentationFileExportWidgetPrivate(qMRMLSegmentationFileExportWidget& object)
+  : q_ptr(&object)
+{
+  this->SegmentationNode = NULL;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationFileExportWidgetPrivate::init()
+{
+  Q_Q(qMRMLSegmentationFileExportWidget);
+  this->setupUi(q);
+  q->setEnabled(false);
+  QObject::connect(this->ExportToFilesButton, SIGNAL(clicked()),
+    q, SLOT(exportToFiles()));
+  QObject::connect(this->ShowDestinationFolderButton, SIGNAL(clicked()),
+    q, SLOT(showDestinationFolder()));
+  QObject::connect(this->FileFormatComboBox, SIGNAL(currentIndexChanged(const QString&)),
+    q, SLOT(setFileFormat(const QString&)));
+}
+
+//-----------------------------------------------------------------------------
+// qMRMLSegmentationFileExportWidget methods
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationFileExportWidget::qMRMLSegmentationFileExportWidget(QWidget* _parent)
+  : qMRMLWidget(_parent)
+  , d_ptr(new qMRMLSegmentationFileExportWidgetPrivate(*this))
+{
+  Q_D(qMRMLSegmentationFileExportWidget);
+  d->init();
+  this->updateWidgetFromSettings();
+}
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationFileExportWidget::~qMRMLSegmentationFileExportWidget()
+{
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLSegmentationNode* qMRMLSegmentationFileExportWidget::segmentationNode() const
+{
+  Q_D(const qMRMLSegmentationFileExportWidget);
+  return d->SegmentationNode;
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSegmentationFileExportWidget::segmentationNodeID()
+{
+  Q_D(qMRMLSegmentationFileExportWidget);
+  return (d->SegmentationNode.GetPointer() ? d->SegmentationNode->GetID() : QString());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationFileExportWidget::setSegmentationNode(vtkMRMLSegmentationNode* node)
+{
+  Q_D(qMRMLSegmentationFileExportWidget);
+  d->SegmentationNode = node;
+  this->setEnabled(d->SegmentationNode.GetPointer() != NULL);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationFileExportWidget::setSegmentationNode(vtkMRMLNode* node)
+{
+  this->setSegmentationNode(vtkMRMLSegmentationNode::SafeDownCast(node));
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationFileExportWidget::updateWidgetFromSettings()
+{
+  Q_D(qMRMLSegmentationFileExportWidget);
+
+  if (d->SettingsKey.isEmpty())
+    {
+    return;
+    }
+
+  QSettings settings;
+
+  QString fileFormat = settings.value(d->SettingsKey + "/FileFormat", "STL").toString();
+  d->FileFormatComboBox->setCurrentIndex(d->FileFormatComboBox->findText(fileFormat));
+
+  d->DestinationFolderButton->setDirectory(settings.value(d->SettingsKey + "/DestinationFolder", ".").toString());
+  d->VisibleSegmentsOnlyCheckBox->setChecked(settings.value(d->SettingsKey + "/VisibleSegmentsOnly", false).toBool());
+  d->MergeIntoSingleFileCheckBox->setChecked(settings.value(d->SettingsKey + "/MergeIntoSingleFile", false).toBool());
+
+  QString coordinateSystem = settings.value(d->SettingsKey + "/CoordinateSystem", "LPS").toString();
+  d->CoordinateSystemComboBox->setCurrentIndex(d->CoordinateSystemComboBox->findText(coordinateSystem));
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationFileExportWidget::updateSettingsFromWidget()
+{
+  Q_D(qMRMLSegmentationFileExportWidget);
+
+  if (d->SettingsKey.isEmpty())
+    {
+    return;
+    }
+
+  QSettings settings;
+
+  settings.setValue(d->SettingsKey + "/FileFormat", d->FileFormatComboBox->currentText());
+  settings.setValue(d->SettingsKey + "/DestinationFolder", d->DestinationFolderButton->directory());
+  settings.setValue(d->SettingsKey + "/VisibleSegmentsOnly", d->VisibleSegmentsOnlyCheckBox->isChecked());
+  settings.setValue(d->SettingsKey + "/MergeIntoSingleFile", d->MergeIntoSingleFileCheckBox->isChecked());
+  settings.setValue(d->SettingsKey + "/CoordinateSystem", d->CoordinateSystemComboBox->currentText());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationFileExportWidget::exportToFiles()
+{
+  Q_D(qMRMLSegmentationFileExportWidget);
+
+  QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
+
+  this->updateSettingsFromWidget();
+
+  vtkSmartPointer<vtkStringArray> segmentIds;
+  if (d->VisibleSegmentsOnlyCheckBox->isChecked()
+    && d->SegmentationNode != NULL
+    && vtkMRMLSegmentationDisplayNode::SafeDownCast(d->SegmentationNode->GetDisplayNode()) != NULL)
+  {
+    segmentIds = vtkSmartPointer<vtkStringArray>::New();
+    vtkMRMLSegmentationDisplayNode* displayNode = vtkMRMLSegmentationDisplayNode::SafeDownCast(d->SegmentationNode->GetDisplayNode());
+    displayNode->GetVisibleSegmentIDs(segmentIds);
+  }
+
+  vtkSlicerSegmentationsModuleLogic::ExportSegmentsClosedSurfaceRepresentationToFiles(
+    d->DestinationFolderButton->directory().toLatin1().constData(),
+    d->SegmentationNode.GetPointer(),
+    segmentIds.GetPointer(),
+    d->FileFormatComboBox->currentText().toLatin1().constData(),
+    d->CoordinateSystemComboBox->currentText() == "LPS",
+    d->MergeIntoSingleFileCheckBox->isChecked());
+
+  QApplication::restoreOverrideCursor();
+
+  emit exportToFilesDone();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationFileExportWidget::showDestinationFolder()
+{
+  Q_D(qMRMLSegmentationFileExportWidget);
+  QDesktopServices::openUrl(QUrl("file:///" + d->DestinationFolderButton->directory(), QUrl::TolerantMode));
+}
+
+//------------------------------------------------------------------------------
+QString qMRMLSegmentationFileExportWidget::settingsKey()const
+{
+  Q_D(const qMRMLSegmentationFileExportWidget);
+  return d->SettingsKey;
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSegmentationFileExportWidget::setSettingsKey(const QString& key)
+{
+  Q_D(qMRMLSegmentationFileExportWidget);
+  d->SettingsKey = key;
+  this->updateWidgetFromSettings();
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSegmentationFileExportWidget::setFileFormat(const QString& formatStr)
+{
+  Q_D(qMRMLSegmentationFileExportWidget);
+  d->MergeIntoSingleFileCheckBox->setEnabled(formatStr == "STL");
+}

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.h
@@ -1,0 +1,97 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Andras Lasso, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, and Cancer
+  Care Ontario.
+
+==============================================================================*/
+
+#ifndef __qMRMLSegmentationFileExportWidget_h
+#define __qMRMLSegmentationFileExportWidget_h
+
+// MRMLWidgets includes
+#include "qMRMLWidget.h"
+
+#include "qSlicerSegmentationsModuleWidgetsExport.h"
+
+// CTK includes
+#include <ctkPimpl.h>
+#include <ctkVTKObject.h>
+
+class qMRMLSegmentationFileExportWidgetPrivate;
+
+class vtkMRMLNode;
+class vtkMRMLSegmentationNode;
+class vtkMRMLSegmentationDisplayNode;
+class QItemSelection;
+
+/// \brief Qt widget for selecting a single segment from a segmentation.
+///   If multiple segments are needed, then use \sa qMRMLSegmentsTableView instead in SimpleListMode
+/// \ingroup SlicerRt_QtModules_Segmentations_Widgets
+class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_EXPORT qMRMLSegmentationFileExportWidget : public qMRMLWidget
+{
+  Q_OBJECT
+  QVTK_OBJECT
+
+    /// Key for storing selected options in application settings.
+    /// If an empty key string is given, then selections are not saved or loaded in settings.
+    /// Empty by default.
+    Q_PROPERTY(QString settingsKey READ settingsKey WRITE setSettingsKey)
+
+public:
+  /// Constructor
+  explicit qMRMLSegmentationFileExportWidget(QWidget* parent = 0);
+  /// Destructor
+  virtual ~qMRMLSegmentationFileExportWidget();
+
+  QString settingsKey()const;
+  void setSettingsKey(const QString& key);
+
+  /// Get current segmentation node
+  Q_INVOKABLE vtkMRMLSegmentationNode* segmentationNode() const;
+  /// Get current segmentation node's ID
+  Q_INVOKABLE QString segmentationNodeID();
+
+signals:
+  /// Emitted when conversion is done
+  void exportToFilesDone();
+
+public slots:
+  /// Set segmentation MRML node
+  void setSegmentationNode(vtkMRMLSegmentationNode* node);
+  void setSegmentationNode(vtkMRMLNode* node);
+
+  void exportToFiles();
+
+  void showDestinationFolder();
+
+  void updateWidgetFromSettings();
+  void updateSettingsFromWidget();
+
+protected slots:
+
+  void setFileFormat(const QString&);
+
+protected:
+  QScopedPointer<qMRMLSegmentationFileExportWidgetPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qMRMLSegmentationFileExportWidget);
+  Q_DISABLE_COPY(qMRMLSegmentationFileExportWidget);
+};
+
+#endif

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -329,6 +329,10 @@ void qSlicerSegmentationsModuleWidget::init()
   connect(d->PushButton_ImportExport, SIGNAL(clicked()),
     this, SLOT(onImportExportApply()));
 
+  d->ExportToFilesWidget->setSettingsKey("ExportSegmentsToFiles");
+  connect(d->MRMLNodeComboBox_Segmentation, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+    d->ExportToFilesWidget, SLOT(setSegmentationNode(vtkMRMLNode*)));
+
   connect(d->toolButton_MoveFromCurrentSegmentation, SIGNAL(clicked()),
     this, SLOT(onMoveFromCurrentSegmentation()) );
   connect(d->toolButton_CopyFromCurrentSegmentation, SIGNAL(clicked()),


### PR DESCRIPTION
Users still find it difficult to create STL files from segmentations (export from segmentation to model nodes, open Save dialog, select model nodes, select output folder, change file type to STL for each model node).

It allows export segments (all or just visible) directly to STL or OBJ files, without the need to export to nodes first.

Segments may be exported to separate STL files or one merged file.
OBJ files contain color and opacity information.

The feature is available both from Segment editor (Segmentations button menu)
and in Segmentations module (new Export to files section).