### PR TITLE
ENH: User information can be saved to application settings - WIP - do not merge yet

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -29,6 +29,9 @@
 #include <vtkMRMLTableNode.h>
 #include <vtkMRMLRemoteIOLogic.h>
 
+// VTKAddon includes
+#include <vtkPersonInformation.h>
+
 // VTK includes
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
@@ -86,6 +89,8 @@ vtkSlicerApplicationLogic::vtkSlicerApplicationLogic()
 
   this->InternalReadDataQueue = new ReadDataQueue;
   this->InternalWriteDataQueue = new WriteDataQueue;
+
+  this->UserInformation = vtkPersonInformation::New();
 }
 
 //----------------------------------------------------------------------------
@@ -120,6 +125,8 @@ vtkSlicerApplicationLogic::~vtkSlicerApplicationLogic()
   delete this->InternalModifiedQueue;
   delete this->InternalReadDataQueue;
   delete this->InternalWriteDataQueue;
+
+  this->UserInformation->Delete();
 }
 
 //----------------------------------------------------------------------------
@@ -956,4 +963,10 @@ std::string vtkSlicerApplicationLogic::GetModuleSlicerXYLibDirectory(const std::
   libDirectory.append("/");
   libDirectory.append(slicerSubDir);
   return libDirectory;
+}
+
+//----------------------------------------------------------------------------
+vtkPersonInformation* vtkSlicerApplicationLogic::GetUserInformation()
+{
+  return this->UserInformation;
 }

--- a/Base/Logic/vtkSlicerApplicationLogic.h
+++ b/Base/Logic/vtkSlicerApplicationLogic.h
@@ -35,6 +35,7 @@ class vtkMRMLSelectionNode;
 class vtkMRMLInteractionNode;
 class vtkMRMLRemoteIOLogic;
 class vtkDataIOManagerLogic;
+class vtkPersonInformation;
 class vtkSlicerTask;
 class ModifiedQueue;
 class ProcessingTaskQueue;
@@ -206,6 +207,10 @@ class VTK_SLICER_BASE_LOGIC_EXPORT vtkSlicerApplicationLogic
   /// Get Slicer-X.Y lib directory associated with module located in \a filePath
   static std::string GetModuleSlicerXYLibDirectory(const std::string& filePath);
 
+  /// Get information about the current user (name, login, email, organization, etc.)
+  /// Values are allowed to be modified.
+  vtkPersonInformation* GetUserInformation();
+
 protected:
 
   vtkSlicerApplicationLogic();
@@ -255,6 +260,8 @@ private:
   ModifiedQueue*       InternalModifiedQueue;
   ReadDataQueue*       InternalReadDataQueue;
   WriteDataQueue*      InternalWriteDataQueue;
+
+  vtkPersonInformation* UserInformation;
 
   /// For use with external tracing tool (such as AQTime)
   int Tracing;

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -105,6 +105,9 @@
 #include <vtkNew.h>
 #include <vtksys/SystemTools.hxx>
 
+// VTKAddon includes
+#include <vtkPersonInformation.h>
+
 // Slicer includes
 #include "vtkSlicerVersionConfigure.h" // For Slicer_VERSION_{MINOR, MAJOR}, Slicer_VERSION_FULL
 
@@ -294,6 +297,12 @@ void qSlicerCoreApplicationPrivate::init()
   // Create the application Logic object,
   this->AppLogic = vtkSmartPointer<vtkSlicerApplicationLogic>::New();
   this->AppLogic->SetTemporaryPath(q->temporaryPath().toLatin1());
+  vtkPersonInformation* userInfo = this->AppLogic->GetUserInformation();
+  if (userInfo)
+    {
+    QString userInfoString = q->userSettings()->value("UserInformation").toString();
+    userInfo->ReadFromString(userInfoString.toLatin1().constData());
+    }
   q->qvtkConnect(this->AppLogic, vtkCommand::ModifiedEvent,
               q, SLOT(onSlicerApplicationLogicModified()));
   q->qvtkConnect(this->AppLogic, vtkSlicerApplicationLogic::RequestInvokeEvent,
@@ -306,6 +315,9 @@ void qSlicerCoreApplicationPrivate::init()
               q, SLOT(onSlicerApplicationLogicRequest(vtkObject*,void*,ulong)));
   q->qvtkConnect(this->AppLogic, vtkSlicerApplicationLogic::RequestWriteDataEvent,
               q, SLOT(onSlicerApplicationLogicRequest(vtkObject*,void*,ulong)));
+  q->qvtkConnect(this->AppLogic->GetUserInformation(), vtkCommand::ModifiedEvent,
+    q, SLOT(onUserInformationModified()));
+
   vtkMRMLThreeDViewDisplayableManagerFactory::GetInstance()->SetMRMLApplicationLogic(
     this->AppLogic.GetPointer());
   vtkMRMLSliceViewDisplayableManagerFactory::GetInstance()->SetMRMLApplicationLogic(
@@ -1476,6 +1488,17 @@ void qSlicerCoreApplication::restart()
 //-----------------------------------------------------------------------------
 void qSlicerCoreApplication::onSlicerApplicationLogicModified()
 {
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerCoreApplication::onUserInformationModified()
+{
+  vtkPersonInformation* userInfo = this->applicationLogic()->GetUserInformation();
+  if (!userInfo)
+    {
+    return;
+    }
+  this->userSettings()->setValue("UserInformation", userInfo->WriteToString().c_str());
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -423,6 +423,7 @@ protected slots:
   virtual void handleCommandLineArguments();
 
   virtual void onSlicerApplicationLogicModified();
+  virtual void onUserInformationModified();
   void onSlicerApplicationLogicRequest(vtkObject*, void* , unsigned long);
   void processAppLogicModified();
   void processAppLogicReadData();

--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -86,6 +86,8 @@ set(KIT_SRCS
   qSlicerSettingsViewsPanel.h
   qSlicerSettingsDeveloperPanel.cxx
   qSlicerSettingsDeveloperPanel.h
+  qSlicerSettingsUserInformationPanel.cxx
+  qSlicerSettingsUserInformationPanel.h
   qSlicerStyle.cxx
   qSlicerStyle.h
   qSlicerViewersToolBar.cxx
@@ -193,6 +195,7 @@ set(KIT_MOC_SRCS
   qSlicerSettingsStylesPanel.h
   qSlicerSettingsViewsPanel.h
   qSlicerSettingsDeveloperPanel.h
+  qSlicerSettingsUserInformationPanel.h
   qSlicerStyle.h
   qSlicerViewersToolBar.h
   qSlicerViewersToolBar_p.h
@@ -249,6 +252,7 @@ set(KIT_UI_SRCS
   Resources/UI/qSlicerSettingsStylesPanel.ui
   Resources/UI/qSlicerSettingsViewsPanel.ui
   Resources/UI/qSlicerSettingsDeveloperPanel.ui
+  Resources/UI/qSlicerSettingsUserInformationPanel.ui
   Resources/UI/qSlicerWebWidget.ui
   )
 if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)

--- a/Base/QTGUI/Resources/UI/qSlicerSettingsUserInformationPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsUserInformationPanel.ui
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qSlicerSettingsUserInformationPanel</class>
+ <widget class="ctkSettingsPanel" name="qSlicerSettingsUserInformationPanel">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>288</width>
+    <height>212</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>General</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMinAndMaxSize</enum>
+     </property>
+     <item row="5" column="1">
+      <widget class="QLineEdit" name="ProcedureRoleLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="OrganizationRoleLabel">
+       <property name="text">
+        <string>OrganizationRole:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="LoginLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="LoginLabel">
+       <property name="text">
+        <string>Login:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="OrganizationRoleLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="NameLabel">
+       <property name="toolTip">
+        <string>Directory where scenes are saved to by default</string>
+       </property>
+       <property name="text">
+        <string>Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="OrganizationLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="ProcedureRoleLabel">
+       <property name="text">
+        <string>ProcedureRole:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="OrganizationLabel">
+       <property name="text">
+        <string>Organization:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="EmailLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="NameLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="EmailLabel">
+       <property name="toolTip">
+        <string>Python script that is executed after the application is started</string>
+       </property>
+       <property name="text">
+        <string>Email:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QLabel" name="EmailValidationLabel">
+       <property name="styleSheet">
+        <string notr="true">color:red</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ctkSettingsPanel</class>
+   <extends>QWidget</extends>
+   <header>ctkSettingsPanel.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -73,6 +73,7 @@
 #include "qSlicerSettingsStylesPanel.h"
 #include "qSlicerSettingsViewsPanel.h"
 #include "qSlicerSettingsDeveloperPanel.h"
+#include "qSlicerSettingsUserInformationPanel.h"
 
 // qMRMLWidget includes
 #include "qMRMLEventBrokerConnection.h"
@@ -263,6 +264,10 @@ void qSlicerApplicationPrivate::init()
   qSlicerSettingsViewsPanel* settingsViewsPanel =
     new qSlicerSettingsViewsPanel(generalPanel);
   this->SettingsDialog->addPanel("Views", settingsViewsPanel);
+
+  qSlicerSettingsUserInformationPanel* settingsUserPanel = new qSlicerSettingsUserInformationPanel;
+  settingsUserPanel->setUserInformation(this->AppLogic->GetUserInformation());
+  this->SettingsDialog->addPanel("User", settingsUserPanel);
 
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
   qSlicerSettingsExtensionsPanel * settingsExtensionsPanel = new qSlicerSettingsExtensionsPanel;

--- a/Base/QTGUI/qSlicerSettingsUserInformationPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsUserInformationPanel.cxx
@@ -1,0 +1,194 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+// QtGUI includes
+#include "qSlicerApplication.h"
+#include "qSlicerSettingsUserInformationPanel.h"
+#include "ui_qSlicerSettingsUserInformationPanel.h"
+
+// VTK includes
+#include "vtkPersonInformation.h"
+
+#include "qsettings.h"
+
+// --------------------------------------------------------------------------
+// qSlicerSettingsUserInformationPanelPrivate
+
+//-----------------------------------------------------------------------------
+class qSlicerSettingsUserInformationPanelPrivate: public Ui_qSlicerSettingsUserInformationPanel
+{
+  Q_DECLARE_PUBLIC(qSlicerSettingsUserInformationPanel);
+protected:
+  qSlicerSettingsUserInformationPanel* const q_ptr;
+
+public:
+  qSlicerSettingsUserInformationPanelPrivate(qSlicerSettingsUserInformationPanel& object);
+  void init();
+
+  vtkPersonInformation* UserInformation;
+};
+
+// --------------------------------------------------------------------------
+// qSlicerSettingsUserInformationPanelPrivate methods
+
+// --------------------------------------------------------------------------
+qSlicerSettingsUserInformationPanelPrivate
+::qSlicerSettingsUserInformationPanelPrivate(qSlicerSettingsUserInformationPanel& object)
+  :q_ptr(&object)
+{
+  this->UserInformation = 0;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanelPrivate::init()
+{
+  Q_Q(qSlicerSettingsUserInformationPanel);
+
+  this->setupUi(q);
+
+  // Actions to propagate to the application when settings are changed
+  QObject::connect(this->NameLineEdit, SIGNAL(editingFinished()),
+                   q, SLOT(onNameChanged()));
+  QObject::connect(this->LoginLineEdit, SIGNAL(editingFinished()),
+                   q, SLOT(onLoginChanged()));
+  QObject::connect(this->EmailLineEdit, SIGNAL(textChanged(QString)),
+                   q, SLOT(onEmailChanged(QString)));
+  QObject::connect(this->OrganizationLineEdit, SIGNAL(editingFinished()),
+                   q, SLOT(onOrganizationChanged()));
+  QObject::connect(this->OrganizationRoleLineEdit, SIGNAL(editingFinished()),
+                   q, SLOT(onOrganizationRoleChanged()));
+  QObject::connect(this->ProcedureRoleLineEdit, SIGNAL(editingFinished()),
+                   q, SLOT(onProcedureRoleChanged()));
+
+  q->qvtkConnect(UserInformation, vtkCommand::ModifiedEvent,
+    q, SLOT(updateFromUserInformation()));
+}
+
+// --------------------------------------------------------------------------
+// qSlicerSettingsUserInformationPanel methods
+
+// --------------------------------------------------------------------------
+qSlicerSettingsUserInformationPanel::qSlicerSettingsUserInformationPanel(QWidget* _parent)
+  : Superclass(_parent)
+  , d_ptr(new qSlicerSettingsUserInformationPanelPrivate(*this))
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  d->init();
+}
+
+// --------------------------------------------------------------------------
+qSlicerSettingsUserInformationPanel::~qSlicerSettingsUserInformationPanel()
+{
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::setUserInformation(vtkPersonInformation* userInfo)
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  if (d->UserInformation == userInfo)
+  {
+    return;
+  }
+
+  d->UserInformation = userInfo;
+
+  // Default values
+  this->updateFromUserInformation();
+  userInformationBackup = userInfo->WriteToString();
+
+  std::cout << "setUserInformation\n" << std::endl;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::updateFromUserInformation()
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+
+  if (d->UserInformation == 0)
+  {
+    return;
+  }
+
+  d->NameLineEdit->setText(d->UserInformation->GetName().c_str());
+  d->LoginLineEdit->setText(d->UserInformation->GetLogin().c_str());
+  d->EmailLineEdit->setText(d->UserInformation->GetEmail().c_str());
+  d->OrganizationLineEdit->setText(d->UserInformation->GetOrganization().c_str());
+  d->OrganizationRoleLineEdit->setText(d->UserInformation->GetOrganizationRole().c_str());
+  d->ProcedureRoleLineEdit->setText(d->UserInformation->GetProcedureRole().c_str());
+
+  resetWarnings();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::applySettings()
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  userInformationBackup = d->UserInformation->WriteToString();
+  updateFromUserInformation();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::resetSettings()
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  d->UserInformation->ReadFromString(userInformationBackup);
+  updateFromUserInformation();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::resetWarnings()
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  d->EmailValidationLabel->setText("");
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::onNameChanged()
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  d->UserInformation->SetName(d->NameLineEdit->text().toStdString().c_str());
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::onLoginChanged()
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  d->UserInformation->SetLogin(d->LoginLineEdit->text().toStdString().c_str());
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::onEmailChanged(const QString& value)
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  if(!d->UserInformation->SetEmail(value.toStdString().c_str()))
+    d->EmailValidationLabel->setText("Invalid format");
+  else
+    d->EmailValidationLabel->setText("");
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::onOrganizationChanged()
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  d->UserInformation->SetOrganization(d->OrganizationLineEdit->text().toStdString().c_str());
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::onOrganizationRoleChanged()
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  d->UserInformation->SetOrganizationRole(d->OrganizationRoleLineEdit->text().toStdString().c_str());
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsUserInformationPanel::onProcedureRoleChanged()
+{
+  Q_D(qSlicerSettingsUserInformationPanel);
+  d->UserInformation->SetProcedureRole(d->ProcedureRoleLineEdit->text().toStdString().c_str());
+}

--- a/Base/QTGUI/qSlicerSettingsUserInformationPanel.h
+++ b/Base/QTGUI/qSlicerSettingsUserInformationPanel.h
@@ -1,0 +1,65 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+#ifndef __qqSlicerSettingsUserInformationPanel_h
+#define __qqSlicerSettingsUserInformationPanel_h
+
+// Qt includes
+#include <QWidget>
+
+// CTK includes
+#include <ctkSettingsPanel.h>
+#include <ctkVTKObject.h>
+
+// QtGUI includes
+#include "qSlicerBaseQTGUIExport.h"
+
+class qSlicerSettingsUserInformationPanelPrivate;
+class vtkPersonInformation;
+
+class Q_SLICER_BASE_QTGUI_EXPORT qSlicerSettingsUserInformationPanel
+  : public ctkSettingsPanel
+{
+  Q_OBJECT
+  QVTK_OBJECT
+public:
+  /// Superclass typedef
+  typedef ctkSettingsPanel Superclass;
+
+  /// Constructor
+  explicit qSlicerSettingsUserInformationPanel(QWidget* parent = 0);
+
+  /// Destructor
+  virtual ~qSlicerSettingsUserInformationPanel();
+
+  virtual void setUserInformation(vtkPersonInformation* userInfo);
+
+public Q_SLOTS:
+  virtual void resetSettings();
+  virtual void applySettings();
+
+  void updateFromUserInformation();
+  void onNameChanged();
+  void onLoginChanged();
+  void onEmailChanged(const QString& value);
+  void onOrganizationChanged();
+  void onOrganizationRoleChanged();
+  void onProcedureRoleChanged();
+
+protected:
+  QScopedPointer<qSlicerSettingsUserInformationPanelPrivate> d_ptr;
+  std::string userInformationBackup;
+  void resetWarnings();
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerSettingsUserInformationPanel);
+  Q_DISABLE_COPY(qSlicerSettingsUserInformationPanel);
+};
+
+#endif

--- a/Libs/vtkAddon/CMakeLists.txt
+++ b/Libs/vtkAddon/CMakeLists.txt
@@ -59,6 +59,8 @@ set(vtkAddon_SRCS
   vtkOrientedBSplineTransform.h
   vtkOrientedGridTransform.cxx
   vtkOrientedGridTransform.h
+  vtkPersonInformation.cxx
+  vtkPersonInformation.h
   vtkAddonMathUtilities.h
   vtkAddonMathUtilities.cxx
   )

--- a/Libs/vtkAddon/Testing/CMakeLists.txt
+++ b/Libs/vtkAddon/Testing/CMakeLists.txt
@@ -4,6 +4,7 @@ create_test_sourcelist(Tests ${KIT}CxxTests.cxx
   vtkAddonMathUtilitiesTest1.cxx
   vtkAddonTestingUtilitiesTest1.cxx
   vtkLoggingMacrosTest1.cxx
+  vtkPersonInformationTest1.cxx
   )
 
 set(LIBRARY_NAME ${PROJECT_NAME})
@@ -24,3 +25,4 @@ endmacro()
 simple_test( vtkAddonMathUtilitiesTest1 )
 simple_test( vtkAddonTestingUtilitiesTest1 )
 simple_test( vtkLoggingMacrosTest1 )
+simple_test( vtkPersonInformationTest1 )

--- a/Libs/vtkAddon/Testing/vtkPersonInformationTest1.cxx
+++ b/Libs/vtkAddon/Testing/vtkPersonInformationTest1.cxx
@@ -1,0 +1,79 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// vtkAddon includes
+#include "vtkPersonInformation.h"
+
+using namespace std;
+
+#define ASSERT_TRUE(returnValue) \
+  if (returnValue == false) { \
+    std::cerr <<  __FILE__ << ":" << __LINE__  << std::endl; \
+    return EXIT_FAILURE; \
+  }
+
+bool isEqual(const std::string& string1, const std::string& string2) {
+  return string1.compare(string2) == 0;
+}
+
+int vtkPersonInformationTest1(int, char**)
+{
+  vtkPersonInformation* UserInformation = vtkPersonInformation::New();
+
+  string name = "John Doe";
+  string login = "foobar";
+  string email = "valid.email@somewhere.com";
+  string organization = "BWH";
+  string organizationRole = "Referring";
+  string procedureRole = "Some Procedure Role";
+
+  ASSERT_TRUE(UserInformation->ReadFromString(""));
+
+  ASSERT_TRUE(UserInformation->SetName(name));
+  ASSERT_TRUE(UserInformation->SetLogin(login));
+  ASSERT_TRUE(UserInformation->SetEmail(email));
+  ASSERT_TRUE(!UserInformation->SetEmail("invalid email"));
+  ASSERT_TRUE(UserInformation->SetOrganization(organization));
+  ASSERT_TRUE(UserInformation->SetOrganizationRole(organizationRole));
+  ASSERT_TRUE(UserInformation->SetProcedureRole(procedureRole));
+
+  ASSERT_TRUE(isEqual(name, UserInformation->GetName()));
+  ASSERT_TRUE(isEqual(login, UserInformation->GetLogin()));
+  ASSERT_TRUE(isEqual(email, UserInformation->GetEmail()));
+  ASSERT_TRUE(isEqual(organization, UserInformation->GetOrganization()));
+  ASSERT_TRUE(isEqual(organizationRole, UserInformation->GetOrganizationRole()));
+  ASSERT_TRUE(isEqual(procedureRole, UserInformation->GetProcedureRole()));
+
+  std::string output = "Email:valid.email@somewhere.com;Login:foobar;"
+                       "Name:John Doe;Organization:BWH;"
+                       "OrganizationRole:Referring;"
+                       "ProcedureRole:Some Procedure Role";
+  ASSERT_TRUE(isEqual(output, UserInformation->WriteToString()))
+
+  ASSERT_TRUE(UserInformation->SetName(""));
+  ASSERT_TRUE(UserInformation->SetLogin(""));
+  ASSERT_TRUE(UserInformation->SetEmail(""));
+  ASSERT_TRUE(UserInformation->SetOrganization(""));
+  ASSERT_TRUE(UserInformation->SetOrganizationRole(""));
+  ASSERT_TRUE(UserInformation->SetProcedureRole(""));
+
+  ASSERT_TRUE(isEqual("", UserInformation->WriteToString()))
+
+  UserInformation->Delete();
+
+  return EXIT_SUCCESS;
+}

--- a/Libs/vtkAddon/vtkPersonInformation.cxx
+++ b/Libs/vtkAddon/vtkPersonInformation.cxx
@@ -116,11 +116,14 @@ std::string vtkPersonInformation::WriteToString()
   for (std::map<std::string, std::string>::iterator it = this->Data.begin();
     it != this->Data.end(); ++it)
     {
-    if (!output.empty())
+    if (!it->second.empty())
       {
-      output += ";";
+       if (!output.empty())
+        {
+        output += ";";
+        }
+      output += this->EncodeString(it->first) + ":" + this->EncodeString(it->second);
       }
-    output += this->EncodeString(it->first) + ":" + this->EncodeString(it->second);
     }
   return output;
 }

--- a/Libs/vtkAddon/vtkPersonInformation.cxx
+++ b/Libs/vtkAddon/vtkPersonInformation.cxx
@@ -1,0 +1,175 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+#include "vtkPersonInformation.h"
+
+#include "vtkInformation.h"
+#include "vtkInformationStringKey.h"
+#include "vtkObjectFactory.h"
+
+#include <vtksys/SystemTools.hxx>
+
+// STD includes
+#include <sstream>
+
+vtkStandardNewMacro(vtkPersonInformation);
+
+#define vtkGetSetStringInformationCxxMacro(key) \
+  bool vtkPersonInformation::Set##key(const std::string& value) \
+  { \
+    this->SetCustomString(#key, value); \
+    return true; \
+  } \
+  std::string vtkPersonInformation::Get##key() \
+  { \
+    return this->GetCustomString(#key); \
+  }
+
+#define vtkGetSetValidatedStringInformationCxxMacro(key) \
+  bool vtkPersonInformation::Set##key(const std::string& value) \
+  { \
+    if (!this->Is##key##Valid(value)) \
+    { \
+      return false; \
+    } \
+    this->SetCustomString(#key, value); \
+    return true; \
+  } \
+  std::string vtkPersonInformation::Get##key() \
+  { \
+    return this->GetCustomString(#key); \
+  }
+
+vtkGetSetStringInformationCxxMacro(Name);
+vtkGetSetValidatedStringInformationCxxMacro(Email);
+vtkGetSetStringInformationCxxMacro(Login);
+vtkGetSetStringInformationCxxMacro(Organization);
+vtkGetSetStringInformationCxxMacro(OrganizationRole);
+vtkGetSetStringInformationCxxMacro(ProcedureRole);
+
+//----------------------------------------------------------------------------
+vtkPersonInformation::vtkPersonInformation()
+{
+}
+
+//----------------------------------------------------------------------------
+vtkPersonInformation::~vtkPersonInformation()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkPersonInformation::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+
+  for (std::map<std::string, std::string>::iterator it = this->Data.begin();
+    it != this->Data.end(); ++it)
+    {
+    os << indent << it->first << ": " << it->second << "\n";
+  }
+}
+
+//----------------------------------------------------------------------------
+void vtkPersonInformation::DeepCopy(vtkPersonInformation* source)
+{
+  if (!source)
+    {
+    return;
+    }
+  this->Data = source->Data;
+}
+
+//----------------------------------------------------------------------------
+void vtkPersonInformation::SetCustomString(const std::string& key, const std::string& value)
+{
+  std::string currentValue = this->Data[key];
+  if (value.compare(currentValue) == 0)
+    {
+    // no change
+    return;
+    }
+  this->Data[key] = value;
+  this->Modified();
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPersonInformation::GetCustomString(const std::string& key)
+{
+  std::map<std::string, std::string>::iterator it = this->Data.find(key);
+  if (it == this->Data.end())
+    {
+    return "";
+    }
+  return it->second;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPersonInformation::WriteToString()
+{
+  std::string output;
+  for (std::map<std::string, std::string>::iterator it = this->Data.begin();
+    it != this->Data.end(); ++it)
+    {
+    if (!output.empty())
+      {
+      output += ";";
+      }
+    output += this->EncodeString(it->first) + ":" + this->EncodeString(it->second);
+    }
+  return output;
+}
+
+//----------------------------------------------------------------------------
+bool vtkPersonInformation::ReadFromString(const std::string& data)
+{
+  this->Data.clear();
+  std::stringstream keyValuePairs(data);
+  std::string keyValuePair;
+  while (std::getline(keyValuePairs, keyValuePair, ';'))
+    {
+    int colonIndex = keyValuePair.find(':');
+    std::string key = this->DecodeString(keyValuePair.substr(0, colonIndex));
+    std::string value = this->DecodeString(keyValuePair.substr(colonIndex + 1));
+    this->SetCustomString(key, value);
+    }
+  return true;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPersonInformation::EncodeString(const std::string& value)
+{
+  std::string output = value;
+  // encode percent sign and semicolon (semicolon is a special character because it separates attributes)
+  vtksys::SystemTools::ReplaceString(output, "%", "%25");
+  vtksys::SystemTools::ReplaceString(output, ":", "%3A");
+  vtksys::SystemTools::ReplaceString(output, ";", "%3B");
+  return output;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkPersonInformation::DecodeString(const std::string& value)
+{
+  std::string output = value;
+  // decode percent sign and semicolon (semicolon is a special character because it separates attributes)
+  vtksys::SystemTools::ReplaceString(output, "%3B", ";");
+  vtksys::SystemTools::ReplaceString(output, "%3A", ":");
+  vtksys::SystemTools::ReplaceString(output, "%25", "%");
+  return output;
+}
+
+//----------------------------------------------------------------------------
+bool vtkPersonInformation::IsEmailValid(const std::string& value)
+{
+  // email is valid if it contains @ character or empty
+  if (value.empty())
+    {
+    return true;
+    }
+  return (value.find("@") != std::string::npos);
+}

--- a/Libs/vtkAddon/vtkPersonInformation.h
+++ b/Libs/vtkAddon/vtkPersonInformation.h
@@ -1,0 +1,101 @@
+/*=auto=========================================================================
+
+  Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+/// \brief vtkPersonInformation - specify name and other information
+/// to identify a person.
+///
+
+#ifndef __vtkPersonInformation_h
+#define __vtkPersonInformation_h
+
+#include "vtkAddon.h"
+
+#include "vtkObject.h"
+
+#include <map>
+
+class VTK_ADDON_EXPORT vtkPersonInformation : public vtkObject
+{
+public:
+  static vtkPersonInformation *New();
+  vtkTypeMacro(vtkPersonInformation,vtkObject);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+
+  // Description:
+  // Set/Get username.
+  // Set method
+  virtual bool SetName(const std::string& value);
+  virtual std::string GetName();
+
+  virtual bool SetLogin(const std::string& value);
+  virtual std::string GetLogin();
+
+  virtual bool SetEmail(const std::string& value);
+  virtual std::string GetEmail();
+
+  virtual bool SetOrganization(const std::string& value);
+  virtual std::string GetOrganization();
+
+  virtual bool SetOrganizationRole(const std::string& value);
+  virtual std::string GetOrganizationRole();
+
+  virtual bool SetProcedureRole(const std::string& value);
+  virtual std::string GetProcedureRole();
+
+  // Description:
+  // Make a full, independent copy of another object into this object.
+  virtual void DeepCopy(vtkPersonInformation* source);
+
+  // Description:
+  // Set a custom string value. Calls Modified() if the value is different from the previous value.
+  // No validation is performed. If a standard string's key is used (Name, Email, ...)
+  // then the standard string is overwritten without validation.
+  virtual void SetCustomString(const std::string& key, const std::string& value);
+
+  // Description:
+  // Get a custom string value.
+  // If a standard string's key is used (Name, Email, ...) then the corresponding value is returned.
+  // Empty string is returned if the key has no associated value.
+  virtual std::string GetCustomString(const std::string& key);
+
+  virtual bool IsEmailValid(const std::string& value);
+
+  // Description:
+  // Information keys.
+  static const char* KeyName() { return "Name"; };
+  static const char* KeyLogin() { return "Login"; };
+  static const char* KeyEmail() { return "Email"; };
+  static const char* KeyOrganization() { return "Organization"; };
+  static const char* KeyOrganizationRole() { return "OrganizationRole"; };
+  static const char* KeyProcedureRole() { return "ProcedureRole"; };
+
+  // Description:
+  // Write all key/value pairs to a string.
+  virtual std::string WriteToString();
+
+  // Description:
+  // Read all key/value pairs from a string.
+  // All previous values are cleared.
+  virtual bool ReadFromString(const std::string& data);
+
+protected:
+  vtkPersonInformation();
+  ~vtkPersonInformation();
+
+  std::string EncodeString(const std::string& value);
+  std::string DecodeString(const std::string& value);
+
+  std::map<std::string, std::string> Data;
+
+private:
+  vtkPersonInformation(const vtkPersonInformation&);  // Not implemented.
+  void operator=(const vtkPersonInformation&);  // Not implemented.
+};
+
+#endif


### PR DESCRIPTION
This PR supersedes https://github.com/Slicer/Slicer/pull/912

User information can be accessed through application logic:

    userInfo = slicer.app.applicationLogic().GetUserInformation()

If the userInfo object is changed, the updated values are automatically written into Slicer.ini.

    userInfo.SetName("John Doe")

Currently, validation is only performed for email address, just to illustrate how validation works.

   userInfo.SetEmail("invalid email")
   userInfo.SetEmail("valid.email@somewhere.com")

Limitations:
- There is no API yet for deleting keys.
- There is no GUI for users to change their user information.
- No tests have been added yet.
