### PR TITLE
BUG: Ensure markup is visible after clicking in 3d in persistent mode

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.cxx
@@ -995,6 +995,7 @@ void vtkMRMLMarkupsFiducialDisplayableManager3D::OnMRMLMarkupsNodeMarkupAddedEve
   vtkSeedRepresentation * seedRepresentation = vtkSeedRepresentation::SafeDownCast(seedWidget->GetRepresentation());
   seedRepresentation->NeedToRenderOn();
   seedWidget->Modified();
+  this->RequestRender();
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
After toggling persistent mode, placing a fiducial in 3D with Slice in the
background caused the fiducial to visible right way but clicking anywhere
else (without any slice in the background) was not causing the fiducial to
appear.

This commit ensures the rendering pipeline is triggered after adding
a fiducial in persistent mode.

Fixes https://issues.slicer.org/view.php?id=4512