### PR TITLE
Improve slice browsing performance from 10fps to 90fps

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -105,6 +105,16 @@ vtkMRMLScalarVolumeDisplayNode::vtkMRMLScalarVolumeDisplayNode()
   this->AppendComponents->AddInputConnection(0, this->ExtractRGB->GetOutputPort() );
   this->AppendComponents->AddInputConnection(0, this->AlphaLogic->GetOutputPort() );
 
+  // Prevent slice rendering pipeline competing with GPU's threaded optimization
+  this->AlphaLogic->SetNumberOfThreads(1);
+  this->MapToColors->SetNumberOfThreads(1);
+  this->Threshold->SetNumberOfThreads(1);
+  this->AppendComponents->SetNumberOfThreads(1);
+  this->ExtractRGB->SetNumberOfThreads(1);
+  this->ExtractAlpha->SetNumberOfThreads(1);
+  this->MultiplyAlpha->SetNumberOfThreads(1);
+  this->MapToWindowLevelColors->SetNumberOfThreads(1);
+
   this->Bimodal = NULL;
   this->Accumulate = NULL;
   this->IsInCalculateAutoLevels = false;

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -145,6 +145,10 @@ vtkMRMLSliceLayerLogic::vtkMRMLSliceLayerLogic()
   this->ResliceUVW->SetOutputDimensionality( 3 );
   this->ResliceUVW->GenerateStencilOutputOn();
 
+  // Prevent slice rendering pipeline competing with GPU's threaded optimization
+  this->Reslice->SetNumberOfThreads(1);
+  this->ResliceUVW->SetNumberOfThreads(1);
+
   this->UpdatingTransforms = 0;
 }
 

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
@@ -230,6 +230,14 @@ public:
       imageFillMapper->SetColorLevel(127.5);
       this->ImageFillActor->SetMapper(imageFillMapper);
       this->ImageFillActor->SetVisibility(0);
+
+      // Prevent slice rendering pipeline competing with GPU's threaded optimization
+      this->Reslice->SetNumberOfThreads(1);
+      this->LabelOutline->SetNumberOfThreads(1);
+      this->ImageThreshold->SetNumberOfThreads(1);
+      outlineColorMapper->SetNumberOfThreads(1);
+      fillColorMapper->SetNumberOfThreads(1);
+
       }
 
     vtkSmartPointer<vtkTransform> WorldToSliceTransform;


### PR DESCRIPTION
Problem: On Intel i7 computers with NVidia GPUs, slice browsing was very slow (10-15fps).

Analysis: If "Threaded optimization" option in NVidia settings was disabled (by default it is enabled) then frame rate went up to 60fps (limited by vsync) to 89fps (without vsync).

Solution: Force image reslicing & mapping filters to use a single thread. It makes slice browsing fast (60-90fps) without disabling "Threaded optimization".