### PR TITLE
ENH: Make model clipping GUI more user friendly

### DIFF
--- a/Modules/Loadable/Models/Resources/UI/qSlicerModelsModuleWidget.ui
+++ b/Modules/Loadable/Models/Resources/UI/qSlicerModelsModuleWidget.ui
@@ -216,6 +216,9 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="clippingConfigurationButtonVisible">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
      </layout>
@@ -247,9 +250,29 @@
      <property name="collapsed" stdset="0">
       <bool>true</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_4">
-      <item>
-       <widget class="qMRMLClipNodeWidget" name="MRMLClipNodeWidget" native="true"/>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="ClipSelectedModelLabel">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Clip selected model:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="ClipSelectedModelCheckBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="qMRMLClipNodeWidget" name="MRMLClipNodeWidget"/>
       </item>
      </layout>
     </widget>

--- a/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
+++ b/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
@@ -252,16 +252,6 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QCheckBox" name="ClippingCheckBox">
-        <property name="toolTip">
-         <string>Hide part of the model according to Clipping Planes settings.</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="ClippingLabel">
         <property name="text">
@@ -297,6 +287,30 @@
          <string>Visible Sides:</string>
         </property>
        </widget>
+      </item>
+      <item row="3" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QCheckBox" name="ClippingCheckBox">
+          <property name="toolTip">
+           <string>Hide part of the model according to Clipping Planes settings.</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="ConfigureClippingPushButton">
+          <property name="toolTip">
+           <string>Configure clipping planes</string>
+          </property>
+          <property name="text">
+           <string>Configure...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.cxx
@@ -87,6 +87,9 @@ void qMRMLModelDisplayNodeWidgetPrivate::init()
     q, SLOT(setVisibility(bool)));
   q->connect(this->ClippingCheckBox, SIGNAL(toggled(bool)),
     q, SLOT(setClipping(bool)));
+  q->connect(this->ConfigureClippingPushButton, SIGNAL(clicked()),
+    q, SIGNAL(clippingConfigurationButtonClicked()));
+  this->ConfigureClippingPushButton->setVisible(false);
 
   q->connect(this->SliceIntersectionVisibilityCheckBox, SIGNAL(toggled(bool)),
     q, SLOT(setSliceIntersectionVisible(bool)));
@@ -237,6 +240,10 @@ void qMRMLModelDisplayNodeWidget::setMRMLModelDisplayNode(vtkMRMLNode* node)
 void qMRMLModelDisplayNodeWidget::setMRMLModelDisplayNode(vtkMRMLModelDisplayNode* ModelDisplayNode)
 {
   Q_D(qMRMLModelDisplayNodeWidget);
+  if (d->MRMLModelDisplayNode == ModelDisplayNode)
+    {
+    return;
+    }
   qvtkReconnect(d->MRMLModelDisplayNode, ModelDisplayNode, vtkCommand::ModifiedEvent,
                 this, SLOT(updateWidgetFromMRML()));
   d->MRMLModelDisplayNode = ModelDisplayNode;
@@ -510,6 +517,7 @@ void qMRMLModelDisplayNodeWidget::updateWidgetFromMRML()
   this->setEnabled(d->MRMLModelDisplayNode.GetPointer() != 0);
   if (!d->MRMLModelDisplayNode.GetPointer())
     {
+    emit displayNodeChanged();
     return;
     }
 
@@ -720,6 +728,7 @@ void qMRMLModelDisplayNodeWidget::updateWidgetFromMRML()
     }
 
   d->ScalarsColorNodeComboBox->blockSignals(wasBlocking);
+  emit displayNodeChanged();
 }
 
 //------------------------------------------------------------------------------
@@ -1021,4 +1030,18 @@ void qMRMLModelDisplayNodeWidget::setDistanceToColorNode(vtkMRMLNode* colorNode)
     }
   d->MRMLModelDisplayNode->SetAndObserveDistanceEncodedProjectionColorNodeID(
     colorNode ? colorNode->GetID() : NULL);
+}
+
+// --------------------------------------------------------------------------
+bool qMRMLModelDisplayNodeWidget::clippingConfigurationButtonVisible()const
+{
+  Q_D(const qMRMLModelDisplayNodeWidget);
+  return d->ConfigureClippingPushButton->isVisible();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLModelDisplayNodeWidget::setClippingConfigurationButtonVisible(bool show)
+{
+  Q_D(qMRMLModelDisplayNodeWidget);
+  d->ConfigureClippingPushButton->setVisible(show);
 }

--- a/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.h
+++ b/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.h
@@ -45,6 +45,7 @@ class Q_SLICER_QTMODULES_MODELS_WIDGETS_EXPORT qMRMLModelDisplayNodeWidget : pub
   Q_PROPERTY(ControlMode scalarRangeMode READ scalarRangeMode WRITE setScalarRangeMode)
   Q_PROPERTY(double minimumValue READ minimumValue WRITE setMinimumValue)
   Q_PROPERTY(double maximumValue READ maximumValue WRITE setMaximumValue)
+  Q_PROPERTY(bool clippingConfigurationButtonVisible READ clippingConfigurationButtonVisible WRITE setClippingConfigurationButtonVisible)
   Q_ENUMS(ControlMode)
 
 public:
@@ -60,6 +61,7 @@ public:
   bool sliceIntersectionVisible()const;
   int sliceIntersectionThickness()const;
   double sliceIntersectionOpacity()const;
+  bool clippingConfigurationButtonVisible()const;
 
   bool scalarsVisibility()const;
   QString activeScalarName()const;
@@ -90,6 +92,12 @@ signals:
   ///
   /// Signal sent if the auto/manual value is updated
   void scalarRangeModeValueChanged(ControlMode value);
+  ///
+  /// Signal sent if the any property in the display node is changed
+  void displayNodeChanged();
+  ///
+  /// Signal sent if clipping configuration button is clicked
+  void clippingConfigurationButtonClicked();
 
 public slots:
   /// Set the volume node to display
@@ -135,6 +143,9 @@ public slots:
   /// Set min/max of scalar range
   void setMinimumValue(double min);
   void setMaximumValue(double max);
+
+  /// Show/hide "Configure..." button for clipping
+  void setClippingConfigurationButtonVisible(bool);
 
 protected slots:
   void updateWidgetFromMRML();

--- a/Modules/Loadable/Models/qSlicerModelsModuleWidget.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsModuleWidget.cxx
@@ -23,6 +23,7 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QModelIndex>
+#include <QScrollArea>
 
 #include <vtkCallbackCommand.h>
 
@@ -145,6 +146,17 @@ void qSlicerModelsModuleWidget::setup()
 
   connect( d->DisplayClassTabWidget, SIGNAL(currentChanged(int)),
            this, SLOT(onDisplayClassChanged(int)) );
+
+  connect(d->ModelDisplayWidget, SIGNAL(clippingConfigurationButtonClicked()),
+    this, SLOT(onClippingConfigurationButtonClicked()));
+
+  // add an add hierarchy right click action on the scene and hierarchy nodes
+  connect(d->ModelDisplayWidget, SIGNAL(displayNodeChanged()),
+    this, SLOT(onDisplayNodeChanged()));
+
+  connect(d->ClipSelectedModelCheckBox, SIGNAL(toggled(bool)),
+    this, SLOT(onClipSelectedModelToggled(bool)));
+
 
   this->updateTreeViewModel();
 
@@ -591,4 +603,61 @@ bool qSlicerModelsModuleWidget::setEditedNode(vtkMRMLNode* node,
     }
 
   return false;
+}
+
+//-----------------------------------------------------------
+void qSlicerModelsModuleWidget::onClippingConfigurationButtonClicked()
+{
+  Q_D(qSlicerModelsModuleWidget);
+  d->ClippingButton->setCollapsed(false);
+  // Make sure import/export is visible
+  if (this->parent() && this->parent()->parent() && this->parent()->parent()->parent())
+    {
+    QScrollArea* scrollArea = qobject_cast<QScrollArea*>(this->parent()->parent()->parent());
+    if (scrollArea)
+      {
+      scrollArea->ensureWidgetVisible(d->ClippingButton);
+      }
+    }
+}
+
+//-----------------------------------------------------------
+void qSlicerModelsModuleWidget::onDisplayNodeChanged()
+{
+  Q_D(qSlicerModelsModuleWidget);
+  vtkMRMLModelDisplayNode* displayNode = d->ModelDisplayWidget->mrmlModelDisplayNode();
+  bool wasBlocked = d->ClipSelectedModelCheckBox->blockSignals(true);
+  d->ClipSelectedModelLabel->setEnabled(displayNode != NULL);
+  d->ClipSelectedModelCheckBox->setEnabled(displayNode != NULL);
+  d->ClipSelectedModelCheckBox->setChecked(displayNode != NULL && displayNode->GetClipping());
+  d->ClipSelectedModelCheckBox->blockSignals(wasBlocked);
+}
+
+//-----------------------------------------------------------
+void qSlicerModelsModuleWidget::onClipSelectedModelToggled(bool toggled)
+{
+  Q_D(qSlicerModelsModuleWidget);
+  vtkMRMLModelDisplayNode* displayNode = d->ModelDisplayWidget->mrmlModelDisplayNode();
+  if (displayNode)
+    {
+    int wasModified = displayNode->StartModify();
+    displayNode->SetClipping(toggled);
+    // By enabling clipping, backfaces may become visible.
+    // Therefore, it is better to render them (not cull them).
+    if (toggled)
+      {
+      displayNode->BackfaceCullingOff();
+      displayNode->FrontfaceCullingOff();
+      if (d->MRMLClipNodeWidget->mrmlClipNode() != NULL
+        && d->MRMLClipNodeWidget->redSliceClipState() == vtkMRMLClipModelsNode::ClipOff
+        && d->MRMLClipNodeWidget->greenSliceClipState() == vtkMRMLClipModelsNode::ClipOff
+        && d->MRMLClipNodeWidget->yellowSliceClipState() == vtkMRMLClipModelsNode::ClipOff)
+        {
+        // All clipping planes are disabled.
+        // Enable the first clipping plane to show a clipped model to the user.
+        d->MRMLClipNodeWidget->setRedSliceClipState(vtkMRMLClipModelsNode::ClipPositiveSpace);
+        }
+      }
+    displayNode->EndModify(wasModified);
+    }
 }

--- a/Modules/Loadable/Models/qSlicerModelsModuleWidget.h
+++ b/Modules/Loadable/Models/qSlicerModelsModuleWidget.h
@@ -56,6 +56,9 @@ public slots:
   void onCurrentNodeChanged(vtkMRMLNode* newCurrentNode);
   void includeFiberBundles(bool include);
   void onDisplayClassChanged(int index);
+  void onClippingConfigurationButtonClicked();
+  void onDisplayNodeChanged();
+  void onClipSelectedModelToggled(bool);
 
   static void onMRMLSceneEvent(vtkObject* vtk_obj, unsigned long event,
                                void* client_data, void* call_data);


### PR DESCRIPTION
Clipping controls (enable clipping for selected model; clipping planes) were shown quite far from each other on Models module GUI. The user had to click enable clipping, disable backface culling, scroll down to clipping planes section, open it, and select clipping planes. Very often users could not figure out that they needed all these steps.

Implemented solution:

Clipping planes are applied globally, to all models, therefore separation from display properties of the selected model is good. But made it easier to get from model-specific clipping enable/disable checkbox to clipping plane definition by adding a "Configure" button next to the clipping enable checkbox, which opens the clipping planes section and scrolls the module widget to ensure the section is visible.

![image](https://user-images.githubusercontent.com/307929/38451964-dbad2896-3a07-11e8-9f48-1228f77c90ab.png)

Added a checkbox to clipping planes section, which allows the user to enable/disable clipping of the selected model at the same place where clipping planes are defined. If user enables clipping then backface culling is automatically disabled and red slice clipping is automatically enabled.

![image](https://user-images.githubusercontent.com/307929/38451970-f4a37bd4-3a07-11e8-997c-276d5a3fe6db.png)
