### PR TITLE
ENH: Use new filters for isosurface extraction and plane cutting

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.h
@@ -26,8 +26,6 @@
 #include "vtkMRMLDisplayableManagerExport.h"
 
 class vtkMRMLDisplayableNode;
-class vtkCutter;
-class vtkProp;
 
 /// \brief Displayable manager for slice (2D) views.
 ///

--- a/Libs/vtkSegmentationCore/vtkFractionalLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkFractionalLabelmapToClosedSurfaceConversionRule.cxx
@@ -25,7 +25,7 @@
 #include <vtkObjectFactory.h>
 #include <vtkPolyData.h>
 #include <vtkVersion.h>
-#include <vtkMarchingCubes.h>
+#include <vtkFlyingEdges3D.h>
 #include <vtkDecimatePro.h>
 #include <vtkSmoothPolyDataFilter.h>
 #include <vtkTransform.h>
@@ -173,7 +173,7 @@ bool vtkFractionalLabelmapToClosedSurfaceConversionRule::Convert(vtkDataObject* 
   imageResize->InterpolateOn();
 
   // Run marching cubes
-  vtkSmartPointer<vtkMarchingCubes> marchingCubes = vtkSmartPointer<vtkMarchingCubes>::New();
+  vtkSmartPointer<vtkFlyingEdges3D> marchingCubes = vtkSmartPointer<vtkFlyingEdges3D>::New();
   marchingCubes->SetInputConnection(imageResize->GetOutputPort());
   marchingCubes->SetNumberOfContours(1);
   marchingCubes->SetValue(0, (fractionalThreshold * (maximumValue - minimumValue)) + minimumValue);

--- a/Modules/CLI/GrayscaleModelMaker/GrayscaleModelMaker.cxx
+++ b/Modules/CLI/GrayscaleModelMaker/GrayscaleModelMaker.cxx
@@ -15,7 +15,7 @@ Version:   $Revision$
 #include "GrayscaleModelMakerCLP.h"
 #include "vtkITKArchetypeImageSeriesScalarReader.h"
 #include "vtkImageData.h"
-#include "vtkMarchingCubes.h"
+#include "vtkFlyingEdges3D.h"
 #include "vtkWindowedSincPolyDataFilter.h"
 #include "vtkTransform.h"
 #include "vtkDecimatePro.h"
@@ -68,7 +68,7 @@ int main(int argc, char * argv[])
   vtkImageData *                    image;
   vtkWindowedSincPolyDataFilter *   smootherSinc = NULL;
   vtkDecimatePro *                  decimator = NULL;
-  vtkMarchingCubes *                mcubes = NULL;
+  vtkFlyingEdges3D *                mcubes = NULL;
   vtkTransform *                    transformIJKtoRAS = NULL;
   vtkReverseSense *                 reverser = NULL;
   vtkTransformPolyDataFilter *      transformer = NULL;
@@ -139,7 +139,7 @@ int main(int argc, char * argv[])
     transformIJKtoRAS->GetMatrix()->Print(std::cout);
     }
   transformIJKtoRAS->Inverse();
-  mcubes = vtkMarchingCubes::New();
+  mcubes = vtkFlyingEdges3D::New();
   vtkPluginFilterWatcher watchMCubes(mcubes,
                                      "Marching Cubes",
                                      CLPProcessInformation,

--- a/Modules/CLI/ModelMaker/ModelMaker.cxx
+++ b/Modules/CLI/ModelMaker/ModelMaker.cxx
@@ -32,7 +32,8 @@ Version:   $Revision$
 // VTK includes
 #include <vtkDebugLeaks.h>
 #include <vtkDecimatePro.h>
-#include <vtkDiscreteMarchingCubes.h>
+#include <vtkDiscreteFlyingEdges3D.h>
+#include <vtkFlyingEdges3D.h>
 #include <vtkGeometryFilter.h>
 #include <vtkImageAccumulate.h>
 #include <vtkImageChangeInformation.h>
@@ -271,7 +272,7 @@ int main(int argc, char * argv[])
   // vtk and helper variables
   vtkSmartPointer<vtkITKArchetypeImageSeriesReader> reader;
   vtkImageData *                                    image;
-  vtkSmartPointer<vtkDiscreteMarchingCubes>         cubes;
+  vtkSmartPointer<vtkDiscreteFlyingEdges3D>         cubes;
   vtkSmartPointer<vtkWindowedSincPolyDataFilter>    smoother;
   bool                                              makeMultiple = false;
   bool                                              useStartEnd = false;
@@ -283,7 +284,7 @@ int main(int argc, char * argv[])
 
   vtkSmartPointer<vtkImageConstantPad>        padder;
   vtkSmartPointer<vtkDecimatePro>             decimator;
-  vtkSmartPointer<vtkMarchingCubes>           mcubes;
+  vtkSmartPointer<vtkFlyingEdges3D>           mcubes;
   vtkSmartPointer<vtkImageThreshold>          imageThreshold;
   vtkSmartPointer<vtkThreshold>               threshold;
   vtkSmartPointer<vtkImageToStructuredPoints> imageToStructuredPoints;
@@ -649,7 +650,7 @@ int main(int argc, char * argv[])
       cubes->SetInputData(NULL);
       cubes = NULL;
       }
-    cubes = vtkSmartPointer<vtkDiscreteMarchingCubes>::New();
+    cubes = vtkSmartPointer<vtkDiscreteFlyingEdges3D>::New();
     std::string            comment1 = "Discrete Marching Cubes";
     vtkPluginFilterWatcher watchDMCubes(cubes,
                                         comment1.c_str(),
@@ -1086,7 +1087,7 @@ int main(int argc, char * argv[])
         mcubes->SetInputData(NULL);
         mcubes = NULL;
         }
-      mcubes = vtkSmartPointer<vtkMarchingCubes>::New();
+      mcubes = vtkSmartPointer<vtkFlyingEdges3D>::New();
       std::string            comment5 = "Marching Cubes " + labelName;
       vtkPluginFilterWatcher watchThreshold(mcubes,
                                             comment5.c_str(),

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
@@ -289,9 +289,12 @@ If segments overlap, segment higher in the segments table will have priority. <b
     ici.SetOutputOrigin(0, 0, 0)
 
     # Convert labelmap to combined polydata
-    convertToPolyData = vtk.vtkDiscreteMarchingCubes()
+    convertToPolyData = vtk.vtkDiscreteFlyingEdges3D()
     convertToPolyData.SetInputConnection(ici.GetOutputPort())
     convertToPolyData.SetNumberOfContours(len(segmentLabelValues))
+    convertToPolyData.ComputeGradientsOff()
+    convertToPolyData.ComputeNormalsOff()
+    convertToPolyData.ComputeScalarsOff()
     contourIndex = 0
     for segmentId, labelValue in segmentLabelValues:
       convertToPolyData.SetValue(contourIndex, labelValue)


### PR DESCRIPTION
Optimized versions of isosurface extraction and plane cutting filters have been introduced a while ago in VTK, but Slicer kept using the existing filters.
Filters updated in this commit:
- vtkDiscreteMarchingCubes => vtkDiscreteFlyingEdges3D
- vtkCutter => vtkPlaneCutter

With default SMP backend (Sequential), performance may be slightly improved. With TBB backend, computation time for complex surfaces (e.g., obtained by thresholding a noisy grayscale volume) is decreased by 30-500%.