### PR TITLE
ENH: Add ability to load custom volume rendering presets

### DIFF
--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -1173,3 +1173,19 @@ void vtkSlicerVolumeRenderingLogic::RemovePreset(vtkMRMLVolumePropertyNode* pres
     }
   presetScene->RemoveNode(preset);
 }
+
+//---------------------------------------------------------------------------
+int vtkSlicerVolumeRenderingLogic::LoadCustomPresetsScene(const char* sceneFilePath)
+{
+  if (!this->PresetsScene)
+    {
+    this->PresetsScene = vtkMRMLScene::New();
+    }
+  else
+    {
+    this->PresetsScene->Clear(1);
+    }
+
+  this->PresetsScene->SetURL(sceneFilePath);
+  return this->PresetsScene->Import();
+}

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
@@ -44,8 +44,6 @@ class vtkVolumeProperty;
 #include <map>
 #include <vector>
 
-class vtkStringArray;
-
 /// \ingroup Slicer_QtModules_VolumeRendering
 /// Collection of utility methods to control the Volume Rendering nodes.
 /// The fastest to volume render of vtkMRMLVolumeNode is to use
@@ -274,6 +272,10 @@ public:
   /// Removes a preset and its associated icon (if specified) from the preset scene.
   /// \sa GetPresetsScene(), GetIconVolumeReferenceRole()
   void RemovePreset(vtkMRMLVolumePropertyNode* preset);
+
+  /// Use custom presets scene
+  /// \return Nonzero if successfully loaded
+  int LoadCustomPresetsScene(const char* sceneFilePath);
   
   /// This node reference role name allows linking from a preset node to a volume
   /// node that contains an icon for the preset node.

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerPresetComboBox.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerPresetComboBox.h
@@ -34,11 +34,16 @@ class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_EXPORT qSlicerPresetComboBox
   : public qMRMLNodeComboBox
 {
   Q_OBJECT
+  Q_PROPERTY(bool showIcons READ showIcons WRITE setShowIcons)
+
 public:
   /// Constructors
   typedef qMRMLNodeComboBox Superclass;
   explicit qSlicerPresetComboBox(QWidget* parent=0);
   virtual ~qSlicerPresetComboBox();
+
+  bool showIcons()const;
+  void setShowIcons(bool show);
 
 public slots:
   void setIconToPreset(vtkMRMLNode* presetNode);

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerPresetComboBox_p.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerPresetComboBox_p.h
@@ -37,6 +37,9 @@ protected:
 public:
   qSlicerPresetComboBoxPrivate(qSlicerPresetComboBox& object);
   void init();
+
+public:
+  bool ShowIcons;
 };
 
 //-----------------------------------------------------------------------------
@@ -49,7 +52,7 @@ public:
   typedef ctkComboBox Superclass;
   explicit qSlicerIconComboBox(QWidget* parent=0);
 
-public :
+public:
   virtual void showPopup();
 
 private:

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.cxx
@@ -333,3 +333,17 @@ void qSlicerVolumeRenderingPresetComboBox::applyPreset(vtkMRMLNode* node)
 
   this->resetOffset();
 }
+
+// --------------------------------------------------------------------------
+bool qSlicerVolumeRenderingPresetComboBox::showIcons()const
+{
+  Q_D(const qSlicerVolumeRenderingPresetComboBox);
+  return d->PresetComboBox->showIcons();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerVolumeRenderingPresetComboBox::setShowIcons(bool show)
+{
+  Q_D(qSlicerVolumeRenderingPresetComboBox);
+  d->PresetComboBox->setShowIcons(show);
+}

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPresetComboBox.h
@@ -36,6 +36,7 @@ class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_EXPORT qSlicerVolumeRenderingPrese
   : public qSlicerWidget
 {
   Q_OBJECT
+  Q_PROPERTY(bool showIcons READ showIcons WRITE setShowIcons)
 
 public:
   /// Constructors
@@ -53,6 +54,9 @@ public:
   /// Get volume property node controlling volume rendering transfer functions.
   /// Its content mirrors the currently selected preset node in the combobox.
   Q_INVOKABLE vtkMRMLVolumePropertyNode* mrmlVolumePropertyNode()const;
+
+  bool showIcons()const;
+  void setShowIcons(bool show);
 
 public slots:
   /// Set selected preset node in the combobox. Triggers update of the volume property node


### PR DESCRIPTION
Added the option to use custom presets scene instead of the default one by calling the LoadCustomPresetsScene function of the volume rendering logic. This might be needed for specific applications when only a subset of the presets need to be shown, or if new presets need to be added.

Added showIcons property to the presets combobox classes. This is useful if new presets in the custom presets scene do not have icons, or simply when showing icons are not desired. Default is showing icons.