### PR TITLE
BUG: Added API to add border around fullscreen app window

### DIFF
--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -24,6 +24,10 @@
 #include <QFile>
 #include <QMainWindow>
 
+#ifdef Q_OS_WIN
+#include <QtPlatformHeaders\QWindowsWindowFunctions>
+#endif
+
 #include "vtkSlicerConfigure.h" // For Slicer_USE_*, Slicer_BUILD_*_SUPPORT
 
 // CTK includes
@@ -666,6 +670,14 @@ ctkSettingsDialog* qSlicerApplication::settingsDialog()const
   Q_D(const qSlicerApplication);
   return d->SettingsDialog;
 }
+
+#ifdef Q_OS_WIN
+// --------------------------------------------------------------------------
+void qSlicerApplication::setHasBorderInFullScreen(bool hasBorder)
+{
+  QWindowsWindowFunctions::setHasBorderInFullScreen(this->mainWindow()->windowHandle(), hasBorder);
+}
+#endif
 
 // --------------------------------------------------------------------------
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -163,6 +163,15 @@ public slots:
   /// \sa recentLogFiles(), setupFileLogging()
   QString currentLogFile()const;
 
+#ifdef Q_OS_WIN
+  /// When turning on OpenGL and using the full screen mode, menus and tooltips
+  /// are no longer visible. By enabling hasBorderInFullScreen, a one-pixel border
+  /// is added around the window, which fixes the problem.
+  /// Border has to be enabled before going to full screen mode.
+  /// See http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows
+  void setHasBorderInFullScreen(bool);
+#endif
+
 signals:
 
   /// Emitted when the startup phase has been completed.


### PR DESCRIPTION
On Windows, when turning on OpenGL and using the full screen mode (mainWindow=slicer.util.mainWindow().showFullScreen()),
menus and tooltips were no longer visible.

By enabling setHasBorderInFullScreen, a one-pixel border is added around the window, which fixes the problem.

See http://doc.qt.io/qt-5/windows-issues.html#fullscreen-opengl-based-windows