### PR TITLE
SegmentEditor used too much space after returning to None effect

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
@@ -217,7 +217,7 @@
    <item>
     <widget class="QGroupBox" name="EffectsGroupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -408,19 +408,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -1544,7 +1544,6 @@ void qMRMLSegmentEditorWidget::updateEffectsSectionFromMRML()
       }
     activeEffect->optionsFrame()->setMinimumHeight(activeEffect->optionsFrame()->sizeHint().height());
     activeEffect->optionsLayout()->activate();
-    this->setMinimumHeight(this->sizeHint().height());
     }
   else
     {

--- a/Modules/Scripted/SegmentEditor/SegmentEditor.py
+++ b/Modules/Scripted/SegmentEditor/SegmentEditor.py
@@ -66,6 +66,9 @@ class SegmentEditorWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
     self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndImportEvent, self.onSceneEndImport)
 
+    if hasattr(self.layout, "addStretch"):
+      self.layout.addStretch()
+
   def selectParameterNode(self):
     # Select parameter set node if one is found in the scene, and create one otherwise
     segmentEditorSingletonTag = "SegmentEditor"


### PR DESCRIPTION
# Before changes

| Paint Effect        | None           | 
| ------------- |:-------------:|
| ![before01](https://user-images.githubusercontent.com/10195822/39368610-05e5aaa6-4a08-11e8-8f4e-989397831360.png)| ![before02](https://user-images.githubusercontent.com/10195822/39368612-05f0d584-4a08-11e8-9171-3c46c32c730b.png)       |

# After changes

| Paint Effect        | None           | 
| ------------- |:-------------:|
| ![after01](https://user-images.githubusercontent.com/10195822/39368792-8cc05706-4a08-11e8-9dcb-2ce3bd7f547e.png) | ![after02](https://user-images.githubusercontent.com/10195822/39368769-7c88341c-4a08-11e8-9f63-8b1e85467d65.png)   |



