### PR TITLE
COMP: remove hard QtPositioning dependency

### DIFF
--- a/CMake/SlicerBlockInstallQt.cmake
+++ b/CMake/SlicerBlockInstallQt.cmake
@@ -37,13 +37,11 @@ else()
   # WebEngine Dependencies
   if("Qt5::WebEngine" IN_LIST QT_LIBRARIES)
     find_package(Qt5 REQUIRED COMPONENTS
-      Positioning
       Qml
       Quick
       QuickWidgets
       )
     list(APPEND QT_LIBRARIES
-      "Qt5::Positioning"
       "Qt5::Qml"
       "Qt5::Quick"
       "Qt5::QuickWidgets"


### PR DESCRIPTION
It is only a soft (Qt) build-time dependency so we don't need to enforce it here:

  https://bugreports.qt.io/browse/QTBUG-57418