### PR TITLE
BUG: fix QtWebEngineProcess for extension manager on linux

### DIFF
--- a/CMake/SlicerBlockInstallQt.cmake
+++ b/CMake/SlicerBlockInstallQt.cmake
@@ -84,6 +84,9 @@ else()
       install(PROGRAMS ${qt_root_dir}/libexec/QtWebEngineProcess
         DESTINATION ${Slicer_INSTALL_ROOT}/libexec COMPONENT Runtime
         )
+      install(
+        CODE "file(WRITE \"\${CMAKE_INSTALL_PREFIX}/libexec/qt.conf\" \"[Paths]\nPrefix=../resources\")"
+        COMPONENT Runtime)
     endif()
 
     set(_qt_version "${Qt5_VERSION_MAJOR}.${Qt5_VERSION_MINOR}.${Qt5_VERSION_PATCH}")


### PR DESCRIPTION
QWebEngineProcess could not find resource paths due to an upstream bug.

The fix is not available until Qt 5.11, so work-around is to include qt.conf
file next to the QtWebEngineProcess executable, setting the relative path
to 'resources/'

  https://issues.slicer.org/view.php?id=4544

upstream
  bug: https://bugreports.qt.io/browse/QTBUG-66346
  fix: https://codereview.qt-project.org/#/c/220734/