### PR TITLE
ENH: skip PythonQt imports in non-embedded Python interpreter

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -325,6 +325,13 @@ add_test(
     ${Slicer_LAUNCHER_EXECUTABLE}
   )
 
+# Check that stand-alone Python interpreter, without PythonQt support, can `import slicer` safely (#945)
+add_test(
+  NAME py_standalonepython_import_slicer
+  COMMAND ${Slicer_LAUNCHER_EXECUTABLE} --launch
+    ${PYTHON} ${CMAKE_CURRENT_SOURCE_DIR}/StandalonePythonImportSlicerTest.py
+  )
+
 #
 # SelfTests
 # see http://wiki.slicer.org/slicerWiki/index.php/Documentation/Nightly/Developers/Tutorials/SelfTestModule

--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -36,11 +36,19 @@ try:
 except ImportError:
   available_kits = []
 
+import string, os, sys
+standalone_python = "python" in string.lower(os.path.split(sys.executable)[-1])
+
 for kit in available_kits:
-   try:
-     exec "from %s import *" % (kit)
-   except ImportError as detail:
-     print detail
+  # skip PythonQt kits if we are running in a regular python interpreter
+  if standalone_python and "PythonQt" in kit:
+    print("Detected non-embedded Python interpreter. Skipping module '{}'".format(kit))
+    continue
+
+  try:
+    exec "from %s import *" % (kit)
+  except ImportError as detail:
+    print detail
 
 #-----------------------------------------------------------------------------
 # Cleanup: Removing things the user shouldn't have to see.
@@ -48,3 +56,4 @@ for kit in available_kits:
 del _createModule
 del available_kits
 del kit
+del standalone_python


### PR DESCRIPTION
This allows to `import slicer` when running Slicer's `python` as a stand-alone executable, by avoiding the segfault while attempting to initialize PythonQt (during Qt library self-registration).

concretely:
> $ source /tmp/s5env # from launcher-dump-env...
> $ /opt/bld/s5nj/python-install/bin/python

> In [1]: import slicer
> Detected non-embedded Python interpreter. Skipping module 'qMRMLWidgetsPythonQt'
> Detected non-embedded Python interpreter. Skipping module 'qSlicerBaseQTCorePythonQt'
> Detected non-embedded Python interpreter. Skipping module 'qSlicerBaseQTGUIPythonQt'
> Detected non-embedded Python interpreter. Skipping module 'qSlicerBaseQTAppPythonQt'
> Detected non-embedded Python interpreter. Skipping module 'qSlicerBaseQTCLIPythonQt'
> 
> In [2]: