### PR TITLE
BUG: Fix PYTHONPATH in installation so that vtk can be imported

### DIFF
--- a/SuperBuild/python_configure_python_launcher.cmake
+++ b/SuperBuild/python_configure_python_launcher.cmake
@@ -126,6 +126,21 @@ set(PYTHONLAUNCHER_PYTHONPATH_INSTALLED
   "<APPLAUNCHER_DIR>/../${Slicer_BIN_DIR}/Python"
   )
 
+# Add paths necessary to import VTK
+if (APPLE)
+  list(APPEND PYTHONLAUNCHER_PYTHONPATH_INSTALLED
+    "${PYTHONHOME}/lib/Slicer-4.9"
+    )
+elseif(MSVC)
+  list(APPEND PYTHONLAUNCHER_PYTHONPATH_INSTALLED
+    "${PYTHONHOME}/${Slicer_BIN_DIR}/Lib/site-packages"
+  )
+else()
+  list(APPEND PYTHONLAUNCHER_PYTHONPATH_INSTALLED
+    "${PYTHONHOME}/lib/Slicer-4.9/python2.7/site-packages"
+  )
+endif()
+
 #
 # Notes:
 #


### PR DESCRIPTION
Add an additional path (different on each OS) so that the vtk
Python package can be found.

Fixes https://issues.slicer.org/view.php?id=4556.