### PR TITLE
ENH: update python commit hash, fixes #4555

### DIFF
--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -128,7 +128,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "16d41fe7aeb24c3e3fada6f888837276e03a7f3a"
+    "c3b8d532242efed85fb3cd77b0e39e424b6db475"
     QUIET
     )
 


### PR DESCRIPTION
Fixes 'import sqlite3' in python.
```
git shortlog 16d41fe7aeb24c..c3b8d532242ef

  Christian Löpke (1):
        PythonApplyPatches: Ensure git found is unused to inialize repo

  Isaiah Norton (1):
        Fix sqlite3 import by matching upstream build option for load_extension

  Jean-Christophe Fillion-Robin (2):
        Merge branch 'fix-PythonApplyPatches'
        Merge pull request #223 from ihnorton/fix_sqlite3
```