### PR TITLE
BUG: Closed slicer.util displays references deleted

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1091,6 +1091,7 @@ def messageBox(text, parent=None, **kwargs):
   for key, value in kwargs.iteritems():
     if hasattr(mbox, key):
       setattr(mbox, key, value)
+  mbox.deleteLater()
   return mbox.exec_()
 
 def createProgressDialog(parent=None, value=0, maximum=100, labelText="", windowTitle="Processing...", **kwargs):


### PR DESCRIPTION
Fixes https://issues.slicer.org/view.php?id=4536

Slicer.util displays (infoDisplay, warningDisplay, errorDisplay, etc) that use `messageBox` were still visible when hovering over Slicer's Windows 10 taskbar preview even though they were closed. This was causing confusion about whether the displays had actually been closed.

References are now scheduled for deletion when the display is closed.