### PR TITLE
BUG: Fix launcher settings generation with system qt.

### DIFF
--- a/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+++ b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
@@ -103,8 +103,12 @@ endforeach()
 #-----------------------------------------------------------------------------
 set(SLICER_PATHS_BUILD
   <APPLAUNCHER_SETTINGS_DIR>/bin/<CMAKE_CFG_INTDIR>
-  ${QT_BINARY_DIR}
   )
+if(NOT Slicer_USE_SYSTEM_QT)
+  list(APPEND SLICER_PATHS_BUILD
+    ${QT_BINARY_DIR}
+    )
+endif()
 
 if(Slicer_BUILD_CLI_SUPPORT AND Slicer_BUILD_CLI)
   list(APPEND SLICER_PATHS_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,29 +624,53 @@ if(Slicer_REQUIRED_QT_VERSION VERSION_GREATER "4.9")
 endif()
 
 #
-# If qmake is found in a system location, explicitly mark Qt as such. Doing so
+# If qmake or Qt5Config are associated with a system location, explicitly mark Qt as such. Doing so
 # will prevent system path from being prepended to PATH or (DY)LD_LIBRARY_PATH
 # when generating the launcher settings and avoid system libraries symbols from
 # conflicting with Slicer version of these libraries.
 #
 # See https://issues.slicer.org/view.php?id=3574
 #
-foreach(_path IN ITEMS
-    "/bin"
-    "/usr/bin/"
-    "/usr/local/bin"
-    "/usr/local/Cellar"
-    "/opt/bin"
-    "/opt/local/bin"
-    )
-  if("${QT_QMAKE_EXECUTABLE}" MATCHES "^${_path}")
-    set(Slicer_USE_SYSTEM_QT ON)
-    message(STATUS "")
-    message(STATUS "Forcing Slicer_USE_SYSTEM_QT to ON (qmake found in a system location: ${_path})")
-    message(STATUS "")
-    break()
-  endif()
-endforeach()
+if(Slicer_HAVE_QT5)
+  foreach(_path IN ITEMS
+      "/usr/lib/"
+      "/usr/lib32/"
+      "/usr/lib64/"
+      "/usr/local/lib/"
+      # homebrew
+      "/usr/local/Cellar/lib/"
+      # macport
+      "/opt/lib"
+      "/opt/local/lib"
+      )
+    if("${Qt5_DIR}" MATCHES "^${_path}")
+      set(Slicer_USE_SYSTEM_QT ON)
+      message(STATUS "")
+      message(STATUS "Forcing Slicer_USE_SYSTEM_QT to ON (Qt5_DIR [${Qt5_DIR}] associated with a system location: ${_path})")
+      message(STATUS "")
+      break()
+    endif()
+  endforeach()
+else()
+  foreach(_path IN ITEMS
+      "/bin"
+      "/usr/bin/"
+      "/usr/local/bin"
+      # homebrew
+      "/usr/local/Cellar"
+      # macport
+      "/opt/bin"
+      "/opt/local/bin"
+      )
+    if("${QT_QMAKE_EXECUTABLE}" MATCHES "^${_path}")
+      set(Slicer_USE_SYSTEM_QT ON)
+      message(STATUS "")
+      message(STATUS "Forcing Slicer_USE_SYSTEM_QT to ON (qmake [${QT_QMAKE_EXECUTABLE}] found in a system location: ${_path})")
+      message(STATUS "")
+      break()
+    endif()
+  endforeach()
+endif()
 
 # Prefer QVTKOpenGLWidget to QVTKWidget when supported
 set(Slicer_VTK_USE_QVTKOPENGLWIDGET 1)


### PR DESCRIPTION
First, it sets Slicer_USE_SYSTEM_QT=ON in the case of Qt5.

And also fix appending QT_BINARY_DIR in the case of
the system qt5.
(this was generating problems with system python and virtualenvs)

Co-authored-by: Jean-Christophe Fillion-Robin <JChris.FillionR@kitware.com>