### PR TITLE
Added setWorldPosition utility method to  qSlicerReformatModuleWidget

### DIFF
--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
@@ -539,6 +539,13 @@ void qSlicerReformatModuleWidget::setWorldPosition(double* worldCoordinates)
 }
 
 //------------------------------------------------------------------------------
+void qSlicerReformatModuleWidget::setWorldPosition(double x, double y, double z)
+{
+  double worldPosition[3] = {x,y,z};
+  this->setWorldPosition(worldPosition);
+}
+
+//------------------------------------------------------------------------------
 void qSlicerReformatModuleWidget::setSliceNormal(double x, double y, double z)
 {
   double sliceNormal[3] = {x,y,z};

--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.h
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.h
@@ -46,6 +46,9 @@ public:
   /// Utility function that sets the normal of the slice plane.
   void setSliceNormal(double x, double y, double z);
 
+  /// Utility function that sets the position of the slice in world coordinates.
+  void setWorldPosition(double x, double y, double z);
+  
   virtual bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString());
 
 protected:


### PR DESCRIPTION
Added a utility method to qSlicerReformatModuleWidget to make it easier to invoke setWorldPosition from Python.