### PR TITLE
ENH: Update ITKv4: Fix compiling with gcc8

### DIFF
--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -33,7 +33,8 @@ if(NOT DEFINED ITK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "f9ae0a051440b674c82dfa41c5054b2c7308417e" # slicer-v4.13.0-2017-12-20-d92873e-2
+    "bc0d1723cb4442be2f74ae4585d6c6be1029e3a4" # slicer-v4.13.0-2018-05-25-32608b68bd
+
     QUIET
     )
 


### PR DESCRIPTION
Among other improvements, it allows building VNL
with gcc8, getting rid of error:
```
"Dunno about this gcc"
```

Complete list of changes
------------------------

$ git shortlog f9ae0a051440b67..bc0d1723cb4442be2f7 --no-merges

Bradley Lowekamp (5):
      COMP: Use anonymous namespace for internal linkage
      COMP: Update SimpleITKFilters for dependency issues
      BUG: Add missing extensions to ImageIO
      BUG: Add specification of OutputImage Type for TobogganImageFilter
      BUG: Prevent concurrent read/write in output image

Francois Budin (1):
      BUG: Initializes CMAKE_DEBUG_POSTFIX to be empty

Jean-Christophe Fillion-Robin (3):
      BUG: Prevent gdcm "missing implementation" error on macOS
      STYLE: Refactor support of itkFloatingPointExceptions implementations
      BUG: Support FPE on macOS without "feenableexcept" function

Jon Haitz Legarreta Gorroño (1):
      ENH: Add Python wrap file to itk::MultiResolutionPDEDeforableRegistration.

Martino Pilia (1):
      BUG: fix itkFormatWarning in Python wrapping

Matthew McCormick (9):
      ENH: Add wrapping for BSplineTransformInitializer
      COMP: Do not use absolute path to TestBigEndian.cmake in GDCM
      COMP: Enable pthreads shim with Emscripten
      BUG: Allow module examples to be enabled when built externally
      ENH: Ensure external module examples get added to current build tree
      COMP: Work around RegionGrow2DTest compiler error on ppc64le
      BUG: Wrap long long instead of long
      COMP: Detect Linux in itkMemoryUsageObserver.h on Alpine Linux
      COMP: Wrap MultiResolutionPDEDeformableRegistration for Pyramid filter types

Niels Dekker (1):
      COMP: Worked around endless VS2015 Release compilation on Math::Floor

Pablo Hernandez-Cerdan (1):
      COMP: Fix VNL to compile with gcc8.

Sean McBride (5):
      STYLE: arranged/alphabetized things to make subsequent changes reviewable
      COMP: Fixed some missing name mangling of libTIFF symbols
      BUG: fixed crash on macOS under guardmalloc from RunOSCheck()
      COMP: Mangle HDF5 symbol names
      COMP: fix warning about implicit double to bool conversion