### PR TITLE
COMP: Fix "was hidden" warning -Woverloaded-virtual

### DIFF
--- a/Libs/vtkITK/vtkITKImageThresholdCalculator.h
+++ b/Libs/vtkITK/vtkITKImageThresholdCalculator.h
@@ -75,9 +75,11 @@ public:
   static const char *GetMethodAsString(int method);
   //@}
 
-  ///
+  /// Bring vtkAlgorithm::Update methods here
+  /// to avoid hiding Update override.
+  using vtkAlgorithm::Update;
   /// The main interface which triggers the writer to start.
-  void Update() VTK_OVERRIDE;
+  virtual void Update() VTK_OVERRIDE;
 
 protected:
   vtkITKImageThresholdCalculator();


### PR DESCRIPTION
Update() function in derived class was hiding methods from
base class: Update(foo), Update(foo, bar), etc.

This is because the way cpp lookup works, more info:
https://stackoverflow.com/questions/6727087/c-virtual-function-being-hidden

```
vtkAlgorithm.h warning: ‘virtual void vtkAlgorithm::Update(int)’ was hidden [-Woverloaded-virtual]

vtkAlgorithm.h:569:15: warning: ‘virtual int vtkAlgorithm::Update(vtkInformation*)’ was hidden [-Woverloaded-virtual]
   virtual int Update(vtkInformation* requests);
               ^~~~~~
vtkITKImageThresholdCalculator.h:80:8: warning:   by ‘virtual void vtkITKImageThresholdCalculator::Update()’ [-Woverloaded-virtual]
   void Update() VTK_OVERRIDE;
        ^~~~~~
```