### PR TITLE
Multi volume rendering

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -44,15 +44,12 @@ public:
   /// MRMLNode methods
   //--------------------------------------------------------------------------
 
-  ///
   /// Read node attributes from XML file
   virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
-  ///
   /// Write this node's information to a MRML file in XML format.
   virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
-  ///
   /// Copy the node's attributes to this object
   virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
@@ -60,7 +57,6 @@ public:
   /// \sa GetLayoutLabel()
   virtual void Reset(vtkMRMLNode* defaultNode) VTK_OVERRIDE;
 
-  ///
   /// Name of the layout. Must be unique between all the view nodes of the
   /// same type because it is used as a singleton tag.
   /// Typical names can be colors "Red", "Green", "Yellow",...
@@ -70,7 +66,6 @@ public:
   inline void SetLayoutName(const char *layoutName);
   inline const char *GetLayoutName();
 
-  ///
   /// An optional identifier to link groups of views. Views that have matching
   /// ViewGroup value are in the same group.
   /// ViewGroup is used for restricting scope of:
@@ -84,13 +79,11 @@ public:
   vtkSetMacro(ViewGroup, int);
   vtkGetMacro(ViewGroup, int);
 
-  ///
   /// Label for the view. Usually a 1 character label, e.g. R, 1, 2, etc.
   /// \sa SetLayoutName()
   vtkSetStringMacro(LayoutLabel);
   vtkGetStringMacro(LayoutLabel);
 
-  ///
   /// Indicates whether or not the view is active
   vtkGetMacro(Active, int );
   vtkSetMacro(Active, int );
@@ -134,21 +127,19 @@ public:
   /// \sa vtkMRMLLayoutNode::SetViewArrangement()
   bool IsViewVisibleInLayout();
 
-  ///
   /// 1st background color of the view.
   /// Black (0,0,0) by default.
   /// \sa SetBackgroundColor2()
   vtkGetVector3Macro(BackgroundColor, double);
   vtkSetVector3Macro(BackgroundColor, double);
 
-  ///
   /// 2nd background color of the view
   /// Black (0,0,0) by default.
   /// \sa SetBackgroundColor2()
   vtkGetVector3Macro(BackgroundColor2, double);
   vtkSetVector3Macro(BackgroundColor2, double);
 
-  ///
+
   /// Color for view header in layout as RGB
   /// Gray by default
   vtkSetVector3Macro(LayoutColor, double);
@@ -165,12 +156,10 @@ public:
   /// It is set statically in each specific view node class and cannot be changed dynamically.
   vtkGetMacro(OrientationMarkerEnabled, bool);
 
-  ///
   /// Get/Set orientation marker type (e.g., not displayed, cube, human, coordinate system axes)
   vtkSetMacro(OrientationMarkerType, int);
   vtkGetMacro(OrientationMarkerType, int);
 
-  ///
   /// Get/Set a custom human orientation marker model.
   /// If NULL or invalid node ID is specified then the default human model will be used.
   /// If the node has point data array with the name "Color" and 3 scalar components then
@@ -180,17 +169,14 @@ public:
   const char* GetOrientationMarkerHumanModelNodeID();
   vtkMRMLModelNode* GetOrientationMarkerHumanModelNode();
 
-  ///
   /// Convert between orientation marker type ID and name
   static const char* GetOrientationMarkerTypeAsString(int id);
   static int GetOrientationMarkerTypeFromString(const char* name);
 
-  ///
   /// Get/Set orientation marker is size. There are a few predefined marker sizes, defined by an enumerated value (e.g., small, medium, large).
   vtkSetMacro(OrientationMarkerSize, int);
   vtkGetMacro(OrientationMarkerSize, int);
 
-  ///
   /// Convert between orientation marker type ID and name
   static const char* GetOrientationMarkerSizeAsString(int id);
   static int GetOrientationMarkerSizeFromString(const char* name);
@@ -217,12 +203,10 @@ public:
   /// It is set statically in each specific view node class and cannot be changed dynamically.
   vtkGetMacro(RulerEnabled, bool);
 
-  ///
   /// Get/Set ruler type (e.g., not displayed, thin, thick)
   vtkSetMacro(RulerType, int);
   vtkGetMacro(RulerType, int);
 
-  ///
   /// Convert between ruler type ID and name
   static const char* GetRulerTypeAsString(int id);
   static int GetRulerTypeFromString(const char* name);
@@ -236,7 +220,6 @@ public:
     RulerType_Last // insert valid types above this line
   };
 
-  ///
   /// Get/Set labels of coordinate system axes.
   /// Order of labels: -X, +X, -Y, +Y, -Z, +Z.
   /// Default: L, R, P, A, I, S
@@ -246,7 +229,6 @@ public:
   const char* GetAxisLabel(int labelIndex);
   void SetAxisLabel(int labelIndex, const char* label);
 
-  ///
   /// Total number of coordinate system axis labels
   static const int AxisLabelsCount;
 
@@ -263,7 +245,7 @@ protected:
 
   ///
   /// Label to show for the view (shortcut for the name)
-  char * LayoutLabel;
+  char* LayoutLabel;
 
   ///
   /// Indicates whether or not the View is visible.

--- a/Libs/MRML/Core/vtkMRMLSliceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.cxx
@@ -250,8 +250,7 @@ bool vtkMRMLSliceNode::IsThreeDViewIDPresent(const char* viewNodeID)const
 }
 
 //----------------------------------------------------------------------------
-bool vtkMRMLSliceNode
-::IsDisplayableInThreeDView(const char* viewNodeID)const
+bool vtkMRMLSliceNode::IsDisplayableInThreeDView(const char* viewNodeID)const
 {
   return this->GetNumberOfThreeDViewIDs() == 0
     || this->IsThreeDViewIDPresent(viewNodeID);
@@ -266,8 +265,7 @@ bool vtkMRMLSliceNode::SetOrientation(const char* orientation)
     return false;
     }
 
-  vtkMatrix3x3 *orientationPreset =
-      this->GetSliceOrientationPreset(orientation);
+  vtkMatrix3x3 *orientationPreset = this->GetSliceOrientationPreset(orientation);
   if (orientationPreset == NULL)
     {
     return false;
@@ -348,8 +346,7 @@ vtkMatrix3x3 *vtkMRMLSliceNode::GetSliceOrientationPreset(const std::string &nam
       }
     }
 
-  vtkErrorMacro("GetSliceOrientationPreset: invalid orientation preset name: "
-                << name);
+  vtkErrorMacro("GetSliceOrientationPreset: invalid orientation preset name: " << name);
   return NULL;
 }
 
@@ -381,8 +378,7 @@ std::string vtkMRMLSliceNode::GetSliceOrientationPresetName(vtkMatrix3x3* orient
 std::string vtkMRMLSliceNode::GetOrientation(vtkMatrix4x4 *sliceToRAS)
 {
   vtkNew<vtkMatrix3x3> orientationMatrix;
-  vtkAddonMathUtilities::GetOrientationMatrix(
-        sliceToRAS, orientationMatrix.GetPointer());
+  vtkAddonMathUtilities::GetOrientationMatrix(sliceToRAS, orientationMatrix.GetPointer());
 
   std::string orientation =
       this->GetSliceOrientationPresetName(orientationMatrix.GetPointer());

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -28,7 +28,7 @@ class vtkMatrix4x4;
 /// This node stores the information about how to map from RAS space to
 /// the desired slice plane.
 /// \li SliceToRAS is the matrix that rotates and translates the slice plane
-/// \li FieldOfView tells the size of  slice plane
+/// \li FieldOfView tells the size of slice plane
 class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
 {
   public:

--- a/Libs/MRML/Core/vtkMRMLViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLViewNode.cxx
@@ -58,7 +58,7 @@ vtkMRMLViewNode::vtkMRMLViewNode()
   this->RulerEnabled = true;
   this->GPUMemorySize = 0; // means application default
   this->ExpectedFPS = 8.;
-  this->VolumeRenderingQuality = vtkMRMLViewNode::AdaptiveQuality;
+  this->VolumeRenderingQuality = vtkMRMLViewNode::Adaptive;
   this->RaycastTechnique = vtkMRMLViewNode::Composite;
   this->VolumeRenderingSurfaceSmoothing = false;
   this->VolumeRenderingOversamplingFactor = 2.0;
@@ -418,9 +418,9 @@ const char* vtkMRMLViewNode::GetVolumeRenderingQualityAsString(int id)
 {
   switch (id)
     {
-    case AdaptiveQuality: return "AdaptiveQuality";
-    case NormalQuality: return "NormalQuality";
-    case MaximumQuality: return "MaximumQuality";
+    case Adaptive: return "Adaptive";
+    case Normal: return "Normal";
+    case Maximum: return "Maximum";
     default:
       // invalid id
       return "";

--- a/Libs/MRML/Core/vtkMRMLViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLViewNode.cxx
@@ -25,7 +25,6 @@ Version:   $Revision: 1.3 $
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLViewNode);
 
-
 //----------------------------------------------------------------------------
 vtkMRMLViewNode::vtkMRMLViewNode()
 {
@@ -56,7 +55,7 @@ vtkMRMLViewNode::vtkMRMLViewNode()
   this->FPSVisible = 0;
   this->OrientationMarkerEnabled = true;
   this->RulerEnabled = true;
-  this->GPUMemorySize = 0; // means application default
+  this->GPUMemorySize = 0; // Means application default
   this->ExpectedFPS = 8.;
   this->VolumeRenderingQuality = vtkMRMLViewNode::Adaptive;
   this->RaycastTechnique = vtkMRMLViewNode::Composite;

--- a/Libs/MRML/Core/vtkMRMLViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLViewNode.h
@@ -136,7 +136,7 @@ public:
   vtkGetMacro(FPSVisible, int);
   vtkSetMacro(FPSVisible, int);
 
-  /// GPU memory size
+  /// GPU memory size in MB
   /// 0 by default (application default)
   vtkGetMacro(GPUMemorySize, int);
   vtkSetMacro(GPUMemorySize, int);
@@ -292,9 +292,8 @@ protected:
   /// Show the Frame per second as text on the lower right part of the view
   int FPSVisible;
 
-  /// Tracking GPU memory size (in MB), not saved into scene file
-  /// because different machines may have different GPU memory
-  /// values.
+  /// Tracking GPU memory size in MB.
+  /// Not saved into scene file because different machines may have different GPU memory values.
   /// A value of 0 indicates to use the default value in the settings
   int GPUMemorySize;
 

--- a/Libs/MRML/Core/vtkMRMLViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLViewNode.h
@@ -81,19 +81,19 @@ public:
   /// Turn on and off animated spinning or rocking.
   vtkGetMacro(AnimationMode, int);
   vtkSetMacro(AnimationMode, int);
-  const char* GetAnimationModeAsString(int id);
-  int GetAnimationModeFromString(const char* name);
+  static const char* GetAnimationModeAsString(int id);
+  static int GetAnimationModeFromString(const char* name);
 
   vtkGetMacro(ViewAxisMode, int);
   vtkSetMacro(ViewAxisMode, int);
-  const char* GetViewAxisModeAsString(int id);
-  int GetViewAxisModeFromString(const char* name);
+  static const char* GetViewAxisModeAsString(int id);
+  static int GetViewAxisModeFromString(const char* name);
 
   /// Direction of animated spinning
   vtkGetMacro(SpinDirection, int);
   vtkSetMacro(SpinDirection, int);
-  const char* GetSpinDirectionAsString(int id);
-  int GetSpinDirectionFromString(const char* name);
+  static const char* GetSpinDirectionAsString(int id);
+  static int GetSpinDirectionFromString(const char* name);
 
   /// Number of degrees in spin increment.
   vtkGetMacro(SpinDegrees, double);
@@ -117,14 +117,14 @@ public:
   /// Stereo mode (including NoStereo)
   vtkGetMacro(StereoType, int);
   vtkSetMacro(StereoType, int);
-  const char* GetStereoTypeAsString(int id);
-  int GetStereoTypeFromString(const char* name);
+  static const char* GetStereoTypeAsString(int id);
+  static int GetStereoTypeFromString(const char* name);
 
   /// Specifies orthographic or perspective rendering
   vtkGetMacro(RenderMode, int);
   vtkSetMacro(RenderMode, int);
-  const char* GetRenderModeAsString(int id);
-  int GetRenderModeFromString(const char* name);
+  static const char* GetRenderModeAsString(int id);
+  static int GetRenderModeFromString(const char* name);
 
   /// Use depth peeling or not.
   /// 0 by default.
@@ -147,14 +147,14 @@ public:
 
   vtkSetMacro(VolumeRenderingQuality, int);
   vtkGetMacro(VolumeRenderingQuality, int);
-  const char* GetVolumeRenderingQualityAsString(int id);
-  int GetVolumeRenderingQualityFromString(const char* name);
+  static const char* GetVolumeRenderingQualityAsString(int id);
+  static int GetVolumeRenderingQualityFromString(const char* name);
 
   /// Rycasting technique for volume rendering
   vtkGetMacro(RaycastTechnique, int);
   vtkSetMacro(RaycastTechnique, int);
-  const char* GetRaycastTechniqueAsString(int id);
-  int GetRaycastTechniqueFromString(const char* name);
+  static const char* GetRaycastTechniqueAsString(int id);
+  static int GetRaycastTechniqueFromString(const char* name);
 
   /// Reduce wood grain artifact to make surfaces appear smoother.
   /// For example, by applying jittering on casted rays.
@@ -166,8 +166,8 @@ public:
   /// GetSampleDistance to be the volume's minimum spacing divided by the oversampling
   /// factor.
   /// If \sa VolumeRenderingQuality is set to maximum quality, then a fix oversampling factor of 10 is used.
-  vtkSetMacro(VolumeRenderingOversamplingFactor,double);
-  vtkGetMacro(VolumeRenderingOversamplingFactor,double);
+  vtkSetMacro(VolumeRenderingOversamplingFactor, double);
+  vtkGetMacro(VolumeRenderingOversamplingFactor, double);
 
   /// Modes for automatically controlling camera
   enum
@@ -221,16 +221,16 @@ public:
     };
 
   /// Quality setting used for \sa VolumeRenderingQuality
-  enum Quality
+  enum
     {
-    AdaptiveQuality = 0, ///< quality determined from desired update rate
-    NormalQuality,       ///< good image quality at reasonable speed
-    MaximumQuality,      ///< high image quality, rendering time is not considered
+    Adaptive = 0, ///< quality determined from desired update rate
+    Normal,       ///< good image quality at reasonable speed
+    Maximum,      ///< high image quality, rendering time is not considered
     VolumeRenderingQuality_Last
     };
 
   /// Ray casting technique for volume rendering
-  enum RayCastType
+  enum
     {
     Composite = 0, // Composite with directional lighting (default)
     CompositeEdgeColoring, // Composite with fake lighting (edge coloring, faster) - Not used
@@ -303,8 +303,8 @@ protected:
 
   /// Volume rendering quality control mode
   /// 0: Adaptive
-  /// 1: Maximum Quality
-  /// 2: Fixed Framerate // unsupported yet
+  /// 1: Normal Quality
+  /// 2: Maximum Quality
   int VolumeRenderingQuality;
 
   /// Techniques for volume rendering ray cast

--- a/Libs/MRML/Core/vtkMRMLViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLViewNode.h
@@ -35,19 +35,15 @@ public:
 
   virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
-  ///
   /// Read node attributes from XML file
   virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
-  ///
   /// Write this node's information to a MRML file in XML format.
   virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
-  ///
   /// Copy the node's attributes to this object
   virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
-  ///
   /// Get node XML tag name (like Volume, Model)
   virtual const char* GetNodeTagName() VTK_OVERRIDE;
 
@@ -55,143 +51,197 @@ public:
   static double* defaultBackgroundColor();
   static double* defaultBackgroundColor2();
 
-  ///
   /// Indicates if the box is visible
   vtkGetMacro(BoxVisible, int);
   vtkSetMacro(BoxVisible, int);
 
-  ///
   /// Indicates if the axis labels are visible
   vtkGetMacro(AxisLabelsVisible, int);
   vtkSetMacro(AxisLabelsVisible, int);
 
-  ///
   /// Indicates if the axis labels visibility controlled by camera orientation
   vtkGetMacro(AxisLabelsCameraDependent, int);
   vtkSetMacro(AxisLabelsCameraDependent, int);
 
-  ///
   /// Toggles visibility of fiducial points in 3D viewer
-  vtkGetMacro(FiducialsVisible, int );
-  vtkSetMacro(FiducialsVisible, int );
+  vtkGetMacro(FiducialsVisible, int);
+  vtkSetMacro(FiducialsVisible, int);
 
-  vtkGetMacro(FiducialLabelsVisible, int );
-  vtkSetMacro(FiducialLabelsVisible, int );
+  vtkGetMacro(FiducialLabelsVisible, int);
+  vtkSetMacro(FiducialLabelsVisible, int);
 
-  ///
   /// Field of view size
   vtkGetMacro(FieldOfView, double);
   vtkSetMacro(FieldOfView, double);
 
-  ///
   /// Axis label size
   vtkGetMacro(LetterSize, double);
   vtkSetMacro(LetterSize, double);
 
-  ///
   /// Turn on and off animated spinning or rocking.
-  vtkGetMacro(AnimationMode, int );
-  vtkSetMacro(AnimationMode, int );
+  vtkGetMacro(AnimationMode, int);
+  vtkSetMacro(AnimationMode, int);
+  const char* GetAnimationModeAsString(int id);
+  int GetAnimationModeFromString(const char* name);
 
-  ///
-  vtkGetMacro(ViewAxisMode, int );
-  vtkSetMacro(ViewAxisMode, int );
+  vtkGetMacro(ViewAxisMode, int);
+  vtkSetMacro(ViewAxisMode, int);
+  const char* GetViewAxisModeAsString(int id);
+  int GetViewAxisModeFromString(const char* name);
 
-  ///
   /// Direction of animated spinning
-  vtkGetMacro(SpinDirection, int );
-  vtkSetMacro(SpinDirection, int );
+  vtkGetMacro(SpinDirection, int);
+  vtkSetMacro(SpinDirection, int);
+  const char* GetSpinDirectionAsString(int id);
+  int GetSpinDirectionFromString(const char* name);
 
-  ///
   /// Number of degrees in spin increment.
-  vtkGetMacro(SpinDegrees, double );
-  vtkSetMacro(SpinDegrees, double );
+  vtkGetMacro(SpinDegrees, double);
+  vtkSetMacro(SpinDegrees, double);
 
-  vtkGetMacro(RotateDegrees, double );
-  vtkSetMacro(RotateDegrees, double );
+  vtkGetMacro(RotateDegrees, double);
+  vtkSetMacro(RotateDegrees, double);
 
-  ///
   /// Amount of wait time between spin increments
-  vtkGetMacro(AnimationMs, int );
-  vtkSetMacro(AnimationMs, int );
+  vtkGetMacro(AnimationMs, int);
+  vtkSetMacro(AnimationMs, int);
 
-  ///
   /// Length of animated rocking
-  vtkGetMacro(RockLength, int );
-  vtkSetMacro(RockLength, int );
+  vtkGetMacro(RockLength, int);
+  vtkSetMacro(RockLength, int);
 
-  ///
   /// Increment of animated rock
-  vtkGetMacro(RockCount, int );
-  vtkSetMacro(RockCount, int );
+  vtkGetMacro(RockCount, int);
+  vtkSetMacro(RockCount, int);
 
-  ///
-  /// stereo mode (including nostereo)
-  vtkGetMacro(StereoType, int );
-  vtkSetMacro(StereoType, int );
+  /// Stereo mode (including NoStereo)
+  vtkGetMacro(StereoType, int);
+  vtkSetMacro(StereoType, int);
+  const char* GetStereoTypeAsString(int id);
+  int GetStereoTypeFromString(const char* name);
 
-  ///
-  /// specifies orthographic or perspective rendering
-  vtkGetMacro(RenderMode, int );
-  vtkSetMacro(RenderMode, int );
+  /// Specifies orthographic or perspective rendering
+  vtkGetMacro(RenderMode, int);
+  vtkSetMacro(RenderMode, int);
+  const char* GetRenderModeAsString(int id);
+  int GetRenderModeFromString(const char* name);
 
   /// Use depth peeling or not.
   /// 0 by default.
-  vtkGetMacro(UseDepthPeeling, int );
-  vtkSetMacro(UseDepthPeeling, int );
+  vtkGetMacro(UseDepthPeeling, int);
+  vtkSetMacro(UseDepthPeeling, int);
 
   /// Show FPS in the lower right side of the screen.
   /// 0 by default.
-  vtkGetMacro(FPSVisible, int );
-  vtkSetMacro(FPSVisible, int );
+  vtkGetMacro(FPSVisible, int);
+  vtkSetMacro(FPSVisible, int);
+
+  /// GPU memory size
+  /// 0 by default (application default)
+  vtkGetMacro(GPUMemorySize, int);
+  vtkSetMacro(GPUMemorySize, int);
+
+  /// Expected FPS
+  vtkSetMacro(ExpectedFPS, double);
+  vtkGetMacro(ExpectedFPS, double);
+
+  vtkSetMacro(VolumeRenderingQuality, int);
+  vtkGetMacro(VolumeRenderingQuality, int);
+  const char* GetVolumeRenderingQualityAsString(int id);
+  int GetVolumeRenderingQualityFromString(const char* name);
+
+  /// Rycasting technique for volume rendering
+  vtkGetMacro(RaycastTechnique, int);
+  vtkSetMacro(RaycastTechnique, int);
+  const char* GetRaycastTechniqueAsString(int id);
+  int GetRaycastTechniqueFromString(const char* name);
+
+  /// Reduce wood grain artifact to make surfaces appear smoother.
+  /// For example, by applying jittering on casted rays.
+  /// Note: Only applies to GPU-based techniques
+  vtkGetMacro(VolumeRenderingSurfaceSmoothing, bool);
+  vtkSetMacro(VolumeRenderingSurfaceSmoothing, bool);
+
+  /// Oversampling factor for sample distance. The sample distance is calculated by \sa
+  /// GetSampleDistance to be the volume's minimum spacing divided by the oversampling
+  /// factor.
+  /// If \sa VolumeRenderingQuality is set to maximum quality, then a fix oversampling factor of 10 is used.
+  vtkSetMacro(VolumeRenderingOversamplingFactor,double);
+  vtkGetMacro(VolumeRenderingOversamplingFactor,double);
 
   /// Modes for automatically controlling camera
   enum
     {
-      RotateAround = 0,
-      LookFrom
+    RotateAround = 0,
+    LookFrom,
+    ViewAxisMode_Last
     };
 
   /// Rotate camera directions
   enum
     {
-      PitchUp = 0,
-      PitchDown,
-      RollLeft,
-      RollRight,
-      YawLeft,
-      YawRight
+    PitchUp = 0,
+    PitchDown,
+    RollLeft,
+    RollRight,
+    YawLeft,
+    YawRight,
+    SpinDirection_Last
     };
 
   /// Stereo modes
   enum
     {
-      NoStereo = 0,
-      RedBlue,
-      Anaglyph,
-      QuadBuffer,
-      Interlaced,
-      UserDefined_1,
-      UserDefined_2,
-      UserDefined_3
+    NoStereo = 0,
+    RedBlue,
+    Anaglyph,
+    QuadBuffer,
+    Interlaced,
+    UserDefined_1,
+    UserDefined_2,
+    UserDefined_3,
+    StereoType_Last
     };
 
-  /// render modes
+  /// Render modes
   enum
     {
-      Perspective = 0,
-      Orthographic
+    Perspective = 0,
+    Orthographic,
+    RenderMode_Last
     };
 
-  /// animation mode
+  /// Animation mode
   enum
     {
-      Off = 0,
-      Spin,
-      Rock
+    Off = 0,
+    Spin,
+    Rock,
+    AnimationMode_Last
     };
 
-  /// events
+  /// Quality setting used for \sa VolumeRenderingQuality
+  enum Quality
+    {
+    AdaptiveQuality = 0, ///< quality determined from desired update rate
+    NormalQuality,       ///< good image quality at reasonable speed
+    MaximumQuality,      ///< high image quality, rendering time is not considered
+    VolumeRenderingQuality_Last
+    };
+
+  /// Ray casting technique for volume rendering
+  enum RayCastType
+    {
+    Composite = 0, // Composite with directional lighting (default)
+    CompositeEdgeColoring, // Composite with fake lighting (edge coloring, faster) - Not used
+    MaximumIntensityProjection,
+    MinimumIntensityProjection,
+    GradiantMagnitudeOpacityModulation, // Not used
+    IllustrativeContextPreservingExploration, // Not used
+    RaycastTechnique_Last
+    };
+
+  /// Events
   enum
     {
     GraphicalResourcesCreatedEvent = 19001,
@@ -212,32 +262,26 @@ protected:
   double FieldOfView;
   double LetterSize;
 
-  ///
-  /// parameters of automatic spin
+  /// Parameters of automatic spin
   int AnimationMode;
   int SpinDirection;
   double SpinDegrees;
   int AnimationMs;
 
-  ///
-  /// parameters of automatic rock
+  /// Parameters of automatic rock
   int RockLength;
   int RockCount;
 
-  ///
   /// Increment used to rotate the view
   /// once about an axis.
   double RotateDegrees;
 
-  ///
-  /// parameters for stereo viewing
+  /// Parameters for stereo viewing
   int StereoType;
 
-  ///
   /// Specifies orthographic or perspective rendering
   int RenderMode;
 
-  ///
   /// Parameters for look-from or rotate-around
   /// automatic view control
   int ViewAxisMode;
@@ -247,6 +291,39 @@ protected:
 
   /// Show the Frame per second as text on the lower right part of the view
   int FPSVisible;
+
+  /// Tracking GPU memory size (in MB), not saved into scene file
+  /// because different machines may have different GPU memory
+  /// values.
+  /// A value of 0 indicates to use the default value in the settings
+  int GPUMemorySize;
+
+  /// Expected frame per second rendered
+  double ExpectedFPS;
+
+  /// Volume rendering quality control mode
+  /// 0: Adaptive
+  /// 1: Maximum Quality
+  /// 2: Fixed Framerate // unsupported yet
+  int VolumeRenderingQuality;
+
+  /// Techniques for volume rendering ray cast
+  /// 0: Composite with directional lighting (default)
+  /// 1: Composite with fake lighting (edge coloring, faster) - Not used
+  /// 2: MIP
+  /// 3: MINIP
+  /// 4: Gradient Magnitude Opacity Modulation - Not used
+  /// 5: Illustrative Context Preserving Exploration - Not used
+  int RaycastTechnique;
+
+  /// Make surface appearance smoother in volume rendering. Off by default
+  bool VolumeRenderingSurfaceSmoothing;
+
+  /// Oversampling factor for sample distance. The sample distance is calculated by \sa
+  /// GetSampleDistance to be the volume's minimum spacing divided by the oversampling
+  /// factor.
+  /// If \sa VolumeRenderingQuality is set to maximum quality, then a fix oversampling factor of 10 is used.
+  double VolumeRenderingOversamplingFactor;
 };
 
 #endif

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -234,6 +234,8 @@ void vtkSlicerVolumeRenderingLogic::ChangeVolumeRenderingMethod(const char* disp
     return;
     }
 
+  this->GetMRMLScene()->StartState(vtkMRMLScene::BatchProcessState);
+
   // Create a display node of the requested type for all existing display nodes
   DisplayNodesType displayNodesCopy(this->DisplayNodes);
   DisplayNodesType::iterator displayIt;
@@ -245,7 +247,7 @@ void vtkSlicerVolumeRenderingLogic::ChangeVolumeRenderingMethod(const char* disp
     if (!newDisplayNode)
       {
       vtkErrorMacro("ChangeVolumeRenderingMethod: Failed to create display node of type " << displayNodeClassName);
-      return;
+      continue;
       }
     this->GetMRMLScene()->AddNode(newDisplayNode);
     newDisplayNode->Delete();
@@ -253,6 +255,8 @@ void vtkSlicerVolumeRenderingLogic::ChangeVolumeRenderingMethod(const char* disp
     this->GetMRMLScene()->RemoveNode(oldDisplayNode);
     displayableNode->AddAndObserveDisplayNodeID(newDisplayNode->GetID());
     }
+
+  this->GetMRMLScene()->EndState(vtkMRMLScene::BatchProcessState);
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -20,6 +20,7 @@
 #include "vtkSlicerVolumeRenderingLogic.h"
 #include "vtkMRMLCPURayCastVolumeRenderingDisplayNode.h"
 #include "vtkMRMLGPURayCastVolumeRenderingDisplayNode.h"
+#include "vtkMRMLMultiVolumeRenderingDisplayNode.h"
 
 // Annotations includes
 #include <vtkMRMLAnnotationROINode.h>
@@ -71,6 +72,8 @@ vtkSlicerVolumeRenderingLogic::vtkSlicerVolumeRenderingLogic()
                                 "vtkMRMLCPURayCastVolumeRenderingDisplayNode");
   this->RegisterRenderingMethod("VTK GPU Ray Casting",
                                 "vtkMRMLGPURayCastVolumeRenderingDisplayNode");
+  this->RegisterRenderingMethod("VTK Multi-Volume (experimental)",
+                                "vtkMRMLMultiVolumeRenderingDisplayNode");
 }
 
 //----------------------------------------------------------------------------
@@ -128,7 +131,11 @@ void vtkSlicerVolumeRenderingLogic::RegisterNodes()
 
   vtkNew<vtkMRMLGPURayCastVolumeRenderingDisplayNode> gpuNode;
   this->GetMRMLScene()->RegisterNodeClass( gpuNode.GetPointer() );
+
+  vtkNew<vtkMRMLMultiVolumeRenderingDisplayNode> multiNode;
+  this->GetMRMLScene()->RegisterNodeClass( multiNode.GetPointer() );
 }
+
 //----------------------------------------------------------------------------
 void vtkSlicerVolumeRenderingLogic::RegisterRenderingMethod(const char* methodName, const char* displayNodeClassName)
 {

--- a/Modules/Loadable/VolumeRendering/MRML/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/MRML/CMakeLists.txt
@@ -12,6 +12,8 @@ set(${KIT}_SRCS
   vtkMRMLCPURayCast${MODULE_NAME}DisplayNode.h
   vtkMRMLGPURayCast${MODULE_NAME}DisplayNode.cxx
   vtkMRMLGPURayCast${MODULE_NAME}DisplayNode.h
+  vtkMRMLMulti${MODULE_NAME}DisplayNode.cxx
+  vtkMRMLMulti${MODULE_NAME}DisplayNode.h
   vtkMRMLVolumePropertyNode.cxx
   vtkMRMLVolumePropertyNode.h
   vtkMRMLVolumePropertyStorageNode.cxx

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
@@ -33,7 +33,6 @@ vtkMRMLNodeNewMacro(vtkMRMLGPURayCastVolumeRenderingDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLGPURayCastVolumeRenderingDisplayNode::vtkMRMLGPURayCastVolumeRenderingDisplayNode()
 {
-  this->SurfaceSmoothing = false;
 }
 
 //----------------------------------------------------------------------------
@@ -47,7 +46,6 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::ReadXMLAttributes(const char**
   this->Superclass::ReadXMLAttributes(atts);
 
   vtkMRMLReadXMLBeginMacro(atts);
-  vtkMRMLReadXMLIntMacro(surfaceSmoothing, SurfaceSmoothing);
   vtkMRMLReadXMLEndMacro();
 }
 
@@ -57,7 +55,6 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::WriteXML(ostream& of, int nInd
   this->Superclass::WriteXML(of, nIndent);
 
   vtkMRMLWriteXMLBeginMacro(of);
-  vtkMRMLWriteXMLIntMacro(surfaceSmoothing, SurfaceSmoothing);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -68,7 +65,6 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::Copy(vtkMRMLNode *anode)
   this->Superclass::Copy(anode);
 
   vtkMRMLCopyBeginMacro(anode);
-  vtkMRMLCopyIntMacro(SurfaceSmoothing);
   vtkMRMLCopyEndMacro();
 
   this->EndModify(wasModifying);
@@ -80,6 +76,5 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::PrintSelf(ostream& os, vtkInde
   this->Superclass::PrintSelf(os,indent);
 
   vtkMRMLPrintBeginMacro(os, indent);
-  vtkMRMLPrintIntMacro(SurfaceSmoothing);
   vtkMRMLPrintEndMacro();
 }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.h
@@ -53,21 +53,11 @@ public:
   // Get node XML tag name (like Volume, Model)
   virtual const char* GetNodeTagName() VTK_OVERRIDE {return "GPURayCastVolumeRendering";}
 
-  // Description:
-  // Reduce wood grain artifact to make surfaces appear smoother.
-  // For example, by applying jittering on casted rays.
-  vtkGetMacro(SurfaceSmoothing, bool);
-  vtkSetMacro(SurfaceSmoothing, bool);
-
 protected:
   vtkMRMLGPURayCastVolumeRenderingDisplayNode();
   ~vtkMRMLGPURayCastVolumeRenderingDisplayNode();
   vtkMRMLGPURayCastVolumeRenderingDisplayNode(const vtkMRMLGPURayCastVolumeRenderingDisplayNode&);
   void operator=(const vtkMRMLGPURayCastVolumeRenderingDisplayNode&);
-
-  /// Make surface appearance smoother. Off by default
-  bool SurfaceSmoothing;
 };
 
 #endif
-

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
@@ -1,0 +1,91 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and CANARIE.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLMultiVolumeRenderingDisplayNode.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+
+// STL includes
+#include <sstream>
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLMultiVolumeRenderingDisplayNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLMultiVolumeRenderingDisplayNode::vtkMRMLMultiVolumeRenderingDisplayNode()
+{
+  this->RaycastTechnique = vtkMRMLMultiVolumeRenderingDisplayNode::Composite;
+  this->SurfaceSmoothing = false;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMultiVolumeRenderingDisplayNode::~vtkMRMLMultiVolumeRenderingDisplayNode()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMultiVolumeRenderingDisplayNode::ReadXMLAttributes(const char** atts)
+{
+  this->Superclass::ReadXMLAttributes(atts);
+
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLIntMacro(raycastTechnique, RaycastTechnique);
+  vtkMRMLReadXMLIntMacro(surfaceSmoothing, SurfaceSmoothing);
+  vtkMRMLReadXMLEndMacro();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMultiVolumeRenderingDisplayNode::WriteXML(ostream& of, int nIndent)
+{
+  this->Superclass::WriteXML(of, nIndent);
+
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLIntMacro(raycastTechnique, RaycastTechnique);
+  vtkMRMLWriteXMLIntMacro(surfaceSmoothing, SurfaceSmoothing);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMultiVolumeRenderingDisplayNode::Copy(vtkMRMLNode *anode)
+{
+  int wasModifying = this->StartModify();
+  this->Superclass::Copy(anode);
+
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyIntMacro(RaycastTechnique);
+  vtkMRMLCopyIntMacro(SurfaceSmoothing);
+  vtkMRMLCopyEndMacro();
+
+  this->EndModify(wasModifying);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMultiVolumeRenderingDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintIntMacro(RaycastTechnique);
+  vtkMRMLPrintIntMacro(SurfaceSmoothing);
+  vtkMRMLPrintEndMacro();
+}

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
@@ -34,8 +34,6 @@ vtkMRMLNodeNewMacro(vtkMRMLMultiVolumeRenderingDisplayNode);
 //----------------------------------------------------------------------------
 vtkMRMLMultiVolumeRenderingDisplayNode::vtkMRMLMultiVolumeRenderingDisplayNode()
 {
-  this->RaycastTechnique = vtkMRMLMultiVolumeRenderingDisplayNode::Composite;
-  this->SurfaceSmoothing = false;
 }
 
 //----------------------------------------------------------------------------
@@ -49,8 +47,6 @@ void vtkMRMLMultiVolumeRenderingDisplayNode::ReadXMLAttributes(const char** atts
   this->Superclass::ReadXMLAttributes(atts);
 
   vtkMRMLReadXMLBeginMacro(atts);
-  vtkMRMLReadXMLIntMacro(raycastTechnique, RaycastTechnique);
-  vtkMRMLReadXMLIntMacro(surfaceSmoothing, SurfaceSmoothing);
   vtkMRMLReadXMLEndMacro();
 }
 
@@ -60,8 +56,6 @@ void vtkMRMLMultiVolumeRenderingDisplayNode::WriteXML(ostream& of, int nIndent)
   this->Superclass::WriteXML(of, nIndent);
 
   vtkMRMLWriteXMLBeginMacro(of);
-  vtkMRMLWriteXMLIntMacro(raycastTechnique, RaycastTechnique);
-  vtkMRMLWriteXMLIntMacro(surfaceSmoothing, SurfaceSmoothing);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -72,8 +66,6 @@ void vtkMRMLMultiVolumeRenderingDisplayNode::Copy(vtkMRMLNode *anode)
   this->Superclass::Copy(anode);
 
   vtkMRMLCopyBeginMacro(anode);
-  vtkMRMLCopyIntMacro(RaycastTechnique);
-  vtkMRMLCopyIntMacro(SurfaceSmoothing);
   vtkMRMLCopyEndMacro();
 
   this->EndModify(wasModifying);
@@ -85,7 +77,5 @@ void vtkMRMLMultiVolumeRenderingDisplayNode::PrintSelf(ostream& os, vtkIndent in
   this->Superclass::PrintSelf(os,indent);
 
   vtkMRMLPrintBeginMacro(os, indent);
-  vtkMRMLPrintIntMacro(RaycastTechnique);
-  vtkMRMLPrintIntMacro(SurfaceSmoothing);
   vtkMRMLPrintEndMacro();
 }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.h
@@ -1,0 +1,85 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and CANARIE.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLMultiVolumeRenderingDisplayNode_h
+#define __vtkMRMLMultiVolumeRenderingDisplayNode_h
+
+// Volume Rendering includes
+#include "vtkMRMLVolumeRenderingDisplayNode.h"
+
+/// \ingroup Slicer_QtModules_VolumeRendering
+/// \name vtkMRMLGPURayCastGPURayCastVolumeRenderingDisplayNode
+/// \brief MRML node for storing information for GPU Raycast Volume Rendering
+class VTK_SLICER_VOLUMERENDERING_MODULE_MRML_EXPORT vtkMRMLMultiVolumeRenderingDisplayNode
+  : public vtkMRMLVolumeRenderingDisplayNode
+{
+public:
+  static vtkMRMLMultiVolumeRenderingDisplayNode *New();
+  vtkTypeMacro(vtkMRMLMultiVolumeRenderingDisplayNode,vtkMRMLVolumeRenderingDisplayNode);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+
+  // Description:
+  // Set node attributes
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
+
+  // Description:
+  // Write this node's information to a MRML file in XML format.
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
+
+  // Description:
+  // Copy the node's attributes to this object
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
+
+  // Description:
+  // Get node XML tag name (like Volume, Model)
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "MultiVolumeRendering";}
+
+  // Description:
+  // Ray cast technique
+  vtkGetMacro(RaycastTechnique, int);
+  vtkSetMacro(RaycastTechnique, int);
+
+  // Description:
+  // Reduce wood grain artifact to make surfaces appear smoother.
+  // For example, by applying jittering on casted rays.
+  vtkGetMacro(SurfaceSmoothing, bool);
+  vtkSetMacro(SurfaceSmoothing, bool);
+
+protected:
+  vtkMRMLMultiVolumeRenderingDisplayNode();
+  ~vtkMRMLMultiVolumeRenderingDisplayNode();
+  vtkMRMLMultiVolumeRenderingDisplayNode(const vtkMRMLMultiVolumeRenderingDisplayNode&);
+  void operator=(const vtkMRMLMultiVolumeRenderingDisplayNode&);
+
+  /* techniques in GPU ray cast
+   * 0: composite with directional lighting (default)
+   * 2: MIP
+   * 3: MINIP
+   * */
+  int RaycastTechnique;
+
+  /// Make surface appearance smoother. Off by default
+  bool SurfaceSmoothing;
+};
+
+#endif

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.h
@@ -38,48 +38,23 @@ public:
 
   virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
-  // Description:
-  // Set node attributes
+  /// Set node attributes
   virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
-  // Description:
-  // Write this node's information to a MRML file in XML format.
+  /// Write this node's information to a MRML file in XML format.
   virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
-  // Description:
-  // Copy the node's attributes to this object
+  /// Copy the node's attributes to this object
   virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
-  // Description:
-  // Get node XML tag name (like Volume, Model)
+  /// Get node XML tag name (like Volume, Model)
   virtual const char* GetNodeTagName() VTK_OVERRIDE {return "MultiVolumeRendering";}
-
-  // Description:
-  // Ray cast technique
-  vtkGetMacro(RaycastTechnique, int);
-  vtkSetMacro(RaycastTechnique, int);
-
-  // Description:
-  // Reduce wood grain artifact to make surfaces appear smoother.
-  // For example, by applying jittering on casted rays.
-  vtkGetMacro(SurfaceSmoothing, bool);
-  vtkSetMacro(SurfaceSmoothing, bool);
 
 protected:
   vtkMRMLMultiVolumeRenderingDisplayNode();
   ~vtkMRMLMultiVolumeRenderingDisplayNode();
   vtkMRMLMultiVolumeRenderingDisplayNode(const vtkMRMLMultiVolumeRenderingDisplayNode&);
   void operator=(const vtkMRMLMultiVolumeRenderingDisplayNode&);
-
-  /* techniques in GPU ray cast
-   * 0: composite with directional lighting (default)
-   * 2: MIP
-   * 3: MINIP
-   * */
-  int RaycastTechnique;
-
-  /// Make surface appearance smoother. Off by default
-  bool SurfaceSmoothing;
 };
 
 #endif

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.cxx
@@ -241,7 +241,7 @@ double vtkMRMLVolumeRenderingDisplayNode::GetSampleDistance()
   const double minSpacing = volumeNode->GetMinSpacing() > 0 ? volumeNode->GetMinSpacing() : 1.;
   double sampleDistance = minSpacing / firstViewNode->GetVolumeRenderingOversamplingFactor();
   if ( firstViewNode
-    && firstViewNode->GetVolumeRenderingQuality() == vtkMRMLViewNode::MaximumQuality)
+    && firstViewNode->GetVolumeRenderingQuality() == vtkMRMLViewNode::Maximum)
     {
     sampleDistance = minSpacing / 10.; // =10x smaller than pixel is high quality
     }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
@@ -23,6 +23,7 @@
 class vtkMRMLAnnotationROINode;
 class vtkMRMLVolumeNode;
 class vtkMRMLVolumePropertyNode;
+class vtkMRMLViewNode;
 
 class vtkIntArray;
 
@@ -57,42 +58,13 @@ public:
   void SetAndObserveROINodeID(const char *roiNodeID);
   vtkMRMLAnnotationROINode* GetROINode();
 
-  /// Is cropping enabled?
+  vtkMRMLViewNode* GetFirstViewNode();
+
+  double GetSampleDistance();
+
   vtkSetMacro(CroppingEnabled,int);
   vtkGetMacro(CroppingEnabled,int);
   vtkBooleanMacro(CroppingEnabled,int);
-
-  /// Estimated Sample Distance
-  vtkSetMacro(EstimatedSampleDistance,double);
-  vtkGetMacro(EstimatedSampleDistance,double);
-
-  /// Expected FPS
-  vtkSetMacro(ExpectedFPS,double);
-  vtkGetMacro(ExpectedFPS,double);
-
-  /// Quality used for PerformanceControl
-  enum Quality
-  {
-    AdaptiveQuality = 0, ///< quality determined from desired update rate
-    NormalQuality = 1,   ///< good image quality at reasonable speed
-    MaximumQuality = 2,  ///< high image quality, rendering time is not considered
-    Adaptative = 0       ///< deprecated (kept for backward compatibility only, same as AdaptiveQuality)
-  };
-  vtkSetMacro(PerformanceControl,int);
-  vtkGetMacro(PerformanceControl,int);
-
-  vtkGetMacro(GPUMemorySize, int);
-  vtkSetMacro(GPUMemorySize, int);
-
-  enum RayCastType
-  {
-    Composite = 0, // Composite with directional lighting (default)
-    CompositeEdgeColoring, // Composite with fake lighting (edge coloring, faster) - Not used
-    MaximumIntensityProjection,
-    MinimumIntensityProjection,
-    GradiantMagnitudeOpacityModulation, // Not used
-    IllustrativeContextPreservingExploration // Not used
-  };
 
   vtkSetVector2Macro(Threshold, double);
   vtkGetVectorMacro(Threshold, double, 2);
@@ -108,9 +80,6 @@ public:
 
   vtkSetVector2Macro(WindowLevel, double);
   vtkGetVectorMacro(WindowLevel, double, 2);
-
-  vtkGetMacro(RaycastTechnique, int);
-  vtkSetMacro(RaycastTechnique, int);
 
 protected:
   vtkMRMLVolumeRenderingDisplayNode();
@@ -128,20 +97,12 @@ protected:
   static const char* ROINodeReferenceMRMLAttributeName;
 
 protected:
+  /// Flag indicating whether cropping is enabled
   int CroppingEnabled;
-
-  double EstimatedSampleDistance;
-  double ExpectedFPS;
-
-  /// Tracking GPU memory size (in MB), not saved into scene file
-  /// because different machines may have different GPU memory
-  /// values.
-  /// A value of 0 indicates to use the default value in the settings
-  int GPUMemorySize;
 
   double Threshold[2];
 
-  /// follow window/level and thresholding setting in volume display node
+  /// Follow window/level and thresholding setting in volume display node
   int FollowVolumeDisplayNode;
   int IgnoreVolumeDisplayNodeThreshold;
 
@@ -149,21 +110,6 @@ protected:
 
   /// Volume window & level
   double WindowLevel[2];
-
-  /// Performance Control method
-  /// 0: Adaptive
-  /// 1: Maximum Quality
-  /// 2: Fixed Framerate // unsupported yet
-  int PerformanceControl;
-
-  /// Techniques for ray cast
-  /// 0: Composite with directional lighting (default)
-  /// 1: Composite with fake lighting (edge coloring, faster) - Not used
-  /// 2: MIP
-  /// 3: MINIP
-  /// 4: Gradient Magnitude Opacity Modulation - Not used
-  /// 5: Illustrative Context Preserving Exploration - Not used
-  int RaycastTechnique;
 };
 
 #endif

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -626,17 +626,17 @@ void vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::UpdateDisplayNodePip
 
     switch (viewNode->GetRaycastTechnique())
       {
-      case vtkMRMLViewNode::AdaptiveQuality:
+      case vtkMRMLViewNode::Adaptive:
         cpuMapper->SetAutoAdjustSampleDistances(true);
         cpuMapper->SetLockSampleDistanceToInputSpacing(false);
         cpuMapper->SetImageSampleDistance(1.0);
         break;
-      case vtkMRMLViewNode::NormalQuality:
+      case vtkMRMLViewNode::Normal:
         cpuMapper->SetAutoAdjustSampleDistances(false);
         cpuMapper->SetLockSampleDistanceToInputSpacing(true);
         cpuMapper->SetImageSampleDistance(1.0);
         break;
-      case vtkMRMLViewNode::MaximumQuality:
+      case vtkMRMLViewNode::Maximum:
         cpuMapper->SetAutoAdjustSampleDistances(false);
         cpuMapper->SetLockSampleDistanceToInputSpacing(false);
         cpuMapper->SetImageSampleDistance(0.5);
@@ -659,17 +659,17 @@ void vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::UpdateDisplayNodePip
 
     switch (viewNode->GetVolumeRenderingQuality())
       {
-      case vtkMRMLViewNode::AdaptiveQuality:
+      case vtkMRMLViewNode::Adaptive:
         gpuMapper->SetAutoAdjustSampleDistances(true);
         gpuMapper->SetLockSampleDistanceToInputSpacing(false);
         gpuMapper->SetUseJittering(viewNode->GetVolumeRenderingSurfaceSmoothing());
         break;
-      case vtkMRMLViewNode::NormalQuality:
+      case vtkMRMLViewNode::Normal:
         gpuMapper->SetAutoAdjustSampleDistances(false);
         gpuMapper->SetLockSampleDistanceToInputSpacing(true);
         gpuMapper->SetUseJittering(viewNode->GetVolumeRenderingSurfaceSmoothing());
         break;
-      case vtkMRMLViewNode::MaximumQuality:
+      case vtkMRMLViewNode::Maximum:
         gpuMapper->SetAutoAdjustSampleDistances(false);
         gpuMapper->SetLockSampleDistanceToInputSpacing(false);
         gpuMapper->SetUseJittering(viewNode->GetVolumeRenderingSurfaceSmoothing());
@@ -690,20 +690,19 @@ void vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::UpdateDisplayNodePip
       vtkMRMLMultiVolumeRenderingDisplayNode::SafeDownCast(displayNode);
     vtkGPUVolumeRayCastMapper* gpuMultiMapper = vtkGPUVolumeRayCastMapper::SafeDownCast(mapper);
 
-    //TODO: All the multi-volume display nodes must have the same settings that concern the mapper
     switch (viewNode->GetRaycastTechnique())
       {
-      case vtkMRMLViewNode::AdaptiveQuality:
+      case vtkMRMLViewNode::Adaptive:
         gpuMultiMapper->SetAutoAdjustSampleDistances(true);
         gpuMultiMapper->SetLockSampleDistanceToInputSpacing(false);
         gpuMultiMapper->SetUseJittering(viewNode->GetVolumeRenderingSurfaceSmoothing());
         break;
-      case vtkMRMLViewNode::NormalQuality:
+      case vtkMRMLViewNode::Normal:
         gpuMultiMapper->SetAutoAdjustSampleDistances(false);
         gpuMultiMapper->SetLockSampleDistanceToInputSpacing(true);
         gpuMultiMapper->SetUseJittering(viewNode->GetVolumeRenderingSurfaceSmoothing());
         break;
-      case vtkMRMLViewNode::MaximumQuality:
+      case vtkMRMLViewNode::Maximum:
         gpuMultiMapper->SetAutoAdjustSampleDistances(false);
         gpuMultiMapper->SetLockSampleDistanceToInputSpacing(false);
         gpuMultiMapper->SetUseJittering(viewNode->GetVolumeRenderingSurfaceSmoothing());
@@ -782,7 +781,7 @@ double vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::GetFramerate()
     return 15.;
     }
 
-  return ( viewNode->GetVolumeRenderingQuality() == vtkMRMLViewNode::MaximumQuality ?
+  return ( viewNode->GetVolumeRenderingQuality() == vtkMRMLViewNode::Maximum ?
            0.0 : // special value meaning full quality
            std::max(viewNode->GetExpectedFPS(), 0.0001) );
 }

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
@@ -27,6 +27,11 @@
 // MRML DisplayableManager includes
 #include <vtkMRMLAbstractThreeDViewDisplayableManager.h>
 
+//TODO: For testing, remove
+#include <vtkGPUVolumeRayCastMapper.h>
+#include <vtkVolume.h>
+#include "vtkMRMLVolumeNode.h"
+
 class vtkSlicerVolumeRenderingLogic;
 
 #define VTKIS_VOLUME_PROPS 100
@@ -70,13 +75,6 @@ protected:
   virtual void ProcessMRMLNodesEvents(vtkObject * caller, unsigned long event, void * callData) VTK_OVERRIDE;
 
   virtual void OnInteractorStyleEvent(int eventID) VTK_OVERRIDE;
-
-  /// Return true if the volume wasn't in the view.
-  //bool AddVolumeToView();
-  //void RemoveVolumeFromView();
-  //void RemoveVolumeFromView(vtkVolume* volume);
-  //bool IsVolumeInView();
-  //bool IsVolumeInView(vtkVolume* volume);
 
 protected:
   vtkSlicerVolumeRenderingLogic *VolumeRenderingLogic;

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
@@ -57,6 +57,10 @@ public:
   /// Update actors based on volumes in the scene
   virtual void UpdateFromMRML() VTK_OVERRIDE;
 
+  /// Utility functions mainly used for testing
+  vtkVolumeMapper* GetVolumeMapper(vtkMRMLVolumeNode* volumeNode);
+  vtkVolume* GetVolumeActor(vtkMRMLVolumeNode* volumeNode);
+
 public:
   static int DefaultGPUMemorySize;
 

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.h
@@ -27,12 +27,10 @@
 // MRML DisplayableManager includes
 #include <vtkMRMLAbstractThreeDViewDisplayableManager.h>
 
-//TODO: For testing, remove
-#include <vtkGPUVolumeRayCastMapper.h>
-#include <vtkVolume.h>
-#include "vtkMRMLVolumeNode.h"
-
 class vtkSlicerVolumeRenderingLogic;
+class vtkMRMLVolumeNode;
+class vtkVolumeMapper;
+class vtkVolume;
 
 #define VTKIS_VOLUME_PROPS 100
 

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerCPURayCastVolumeRenderingPropertiesWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerCPURayCastVolumeRenderingPropertiesWidget.ui
@@ -14,20 +14,29 @@
    <string>GPU RayCast</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item row="0" column="0">
     <widget class="QLabel" name="RenderingTechniqueLabel">
      <property name="text">
-      <string>Technique (bg):</string>
+      <string>Technique:</string>
      </property>
     </widget>
    </item>
    <item row="0" column="1">
     <widget class="QComboBox" name="RenderingTechniqueComboBox">
      <property name="toolTip">
-      <string>Select Ray casting technique for the background (default) volume.</string>
+      <string>Select ray casting technique for the views where the current volume is visible</string>
      </property>
     </widget>
    </item>

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerGPURayCastVolumeRenderingPropertiesWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerGPURayCastVolumeRenderingPropertiesWidget.ui
@@ -29,14 +29,14 @@
    <item row="0" column="0">
     <widget class="QLabel" name="RenderingTechniqueLabel">
      <property name="text">
-      <string>Technique (bg):</string>
+      <string>Technique:</string>
      </property>
     </widget>
    </item>
    <item row="0" column="1">
     <widget class="QComboBox" name="RenderingTechniqueComboBox">
      <property name="toolTip">
-      <string>Select Ray casting technique for the background (default) volume.</string>
+      <string>Select ray casting technique for the views where the current volume is visible</string>
      </property>
     </widget>
    </item>

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerMultiVolumeRenderingPropertiesWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerMultiVolumeRenderingPropertiesWidget.ui
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qSlicerMultiVolumeRenderingPropertiesWidget</class>
+ <widget class="QWidget" name="qSlicerMultiVolumeRenderingPropertiesWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>236</width>
+    <height>44</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MultiVolume GPU RayCast</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="RenderingTechniqueLabel">
+     <property name="text">
+      <string>Technique (bg):</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="RenderingTechniqueComboBox">
+     <property name="toolTip">
+      <string>Select Ray casting technique for the background (default) volume.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="SurfaceSmoothingLabel">
+     <property name="toolTip">
+      <string>Option for removing wood-grain artifacts by applying random noise to raycasting</string>
+     </property>
+     <property name="text">
+      <string>Surface smoothing:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="SurfaceSmoothingCheckBox">
+     <property name="toolTip">
+      <string>Option for removing wood-grain artifacts by applying random noise to raycasting</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerMultiVolumeRenderingPropertiesWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerMultiVolumeRenderingPropertiesWidget.ui
@@ -29,14 +29,14 @@
    <item row="0" column="0">
     <widget class="QLabel" name="RenderingTechniqueLabel">
      <property name="text">
-      <string>Technique (bg):</string>
+      <string>Technique:</string>
      </property>
     </widget>
    </item>
    <item row="0" column="1">
     <widget class="QComboBox" name="RenderingTechniqueComboBox">
      <property name="toolTip">
-      <string>Select Ray casting technique for the background (default) volume.</string>
+      <string>Select ray casting technique for the views where the current volume is visible</string>
      </property>
     </widget>
    </item>

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -311,9 +311,9 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QComboBox" name="MemorySizeComboBox">
+           <widget class="qSlicerGPUMemoryComboBox" name="MemorySizeComboBox">
             <property name="toolTip">
-             <string>Amount of memory in MB available on the GPU for rendering. &quot;Default&quot; can be modified in the settings.</string>
+             <string>Amount of memory allocated for volume rendering on the graphic card. &quot;Default&quot; can be modified in the settings.</string>
             </property>
             <property name="currentIndex">
              <number>-1</number>
@@ -555,6 +555,12 @@
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerGPUMemoryComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qSlicerGPUMemoryComboBox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -330,25 +330,10 @@
           <item row="2" column="1">
            <widget class="QComboBox" name="QualityControlComboBox">
             <property name="currentIndex">
-             <number>0</number>
+             <number>-1</number>
             </property>
-            <item>
-             <property name="text">
-              <string>Adaptive</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Normal Quality</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Maximum Quality</string>
-             </property>
-            </item>
            </widget>
-           </item>
+          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="FramerateLabel">
             <property name="text">

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingSettingsPanel.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingSettingsPanel.ui
@@ -46,73 +46,13 @@
     </widget>
    </item>
    <item row="4" column="1">
-    <widget class="QComboBox" name="GPUMemoryComboBox">
+    <widget class="qSlicerGPUMemoryComboBox" name="GPUMemoryComboBox">
      <property name="toolTip">
-      <string>Amount of memory available on the graphic card</string>
+      <string>Amount of memory allocated for volume rendering on the graphic card</string>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>-1</number>
      </property>
-     <item>
-      <property name="text">
-       <string>128 MB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>256 MB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>512 MB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>1024 MB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>1.5 GB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>2 GB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>3 GB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>4 GB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>6 GB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>8 GB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>12 GB</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>16 GB</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="1" column="1">
@@ -178,6 +118,12 @@
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerGPUMemoryComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qSlicerGPUMemoryComboBox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingSettingsPanel.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingSettingsPanel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>345</width>
-    <height>107</height>
+    <height>155</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,16 +18,40 @@
     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
    </property>
    <item row="0" column="0">
+    <widget class="QLabel" name="RenderingMethodLabel">
+     <property name="text">
+      <string>Default rendering method:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="RenderingMethodComboBox">
+     <property name="toolTip">
+      <string>Default rendering method</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="QualityControlLabel">
+     <property name="text">
+      <string>Default quality:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <widget class="QLabel" name="GPUMemoryLabel">
      <property name="text">
       <string>GPU memory size:</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="4" column="1">
     <widget class="QComboBox" name="GPUMemoryComboBox">
      <property name="toolTip">
       <string>Amount of memory available on the graphic card</string>
+     </property>
+     <property name="currentIndex">
+      <number>1</number>
      </property>
      <item>
       <property name="text">
@@ -91,17 +115,53 @@
      </item>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="RenderingMethodLabel">
-     <property name="text">
-      <string>Default rendering method:</string>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="QualityControlComboBox">
+     <property name="toolTip">
+      <string>Quality control method to def</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="RenderingMethodComboBox">
+   <item row="2" column="0">
+    <widget class="QLabel" name="InteractiveSpeedLabel">
+     <property name="text">
+      <string>Default interactive speed:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="ctkSliderWidget" name="InteractiveSpeedSlider">
+     <property name="decimals">
+      <number>0</number>
+     </property>
+     <property name="minimum">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>100.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>8.000000000000000</double>
+     </property>
+     <property name="suffix">
+      <string> fps</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="SurfaceSmoothingLabel">
+     <property name="text">
+      <string>Default surface smoothing:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="SurfaceSmoothingCheckBox">
      <property name="toolTip">
-      <string>Default rendering method</string>
+      <string>Reduce wood grain artifact to make surfaces appear smoother.</string>
+     </property>
+     <property name="text">
+      <string/>
      </property>
     </widget>
    </item>
@@ -113,6 +173,11 @@
    <extends>QWidget</extends>
    <header>ctkSettingsPanel.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
@@ -141,8 +141,7 @@ int vtkMRMLVolumeRenderingDisplayableManagerTest1(int argc, char* argv[])
   vtkNew<vtkSlicerVolumeRenderingLogic> vrLogic;
   vrLogic->SetMRMLScene(scene);
 
-  vrLogic->CopyScalarDisplayToVolumeRenderingDisplayNode(
-    vrDisplayNode.GetPointer());
+  vrLogic->CopyScalarDisplayToVolumeRenderingDisplayNode(vrDisplayNode.GetPointer());
 
   vrDisplayNode->SetFollowVolumeDisplayNode(1);
   volumeDisplayNode->SetThreshold(128, 245);
@@ -213,28 +212,27 @@ int vtkMRMLVolumeRenderingDisplayableManagerTest1(int argc, char* argv[])
     std::cout << "Saved screenshot: " << screenshootFilename << std::endl;
     }
 
-//TODO:
-  vtkGPUVolumeRayCastMapper* mapper = NULL;//vtkGPUVolumeRayCastMapper::SafeDownCast(vrDisplayableManager->GetVolumeMapper(vrDisplayNode.GetPointer()));
+  vtkGPUVolumeRayCastMapper* mapper = vtkGPUVolumeRayCastMapper::SafeDownCast(vrDisplayableManager->GetVolumeMapper(volumeNode));
   if (mapper)
     {
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 256);
-    vrDisplayNode->SetGPUMemorySize(250);
+    viewNode->SetGPUMemorySize(250);
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 256);
-    vrDisplayNode->SetGPUMemorySize(1024);
+    viewNode->SetGPUMemorySize(1024);
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 1024);
-    vrDisplayNode->SetGPUMemorySize(256);
+    viewNode->SetGPUMemorySize(256);
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 256);
-    vrDisplayNode->SetGPUMemorySize(520);
+    viewNode->SetGPUMemorySize(520);
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 640);
-    vrDisplayNode->SetGPUMemorySize(0);
+    viewNode->SetGPUMemorySize(0);
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 256);
-    vrDisplayNode->SetGPUMemorySize(2048);
+    viewNode->SetGPUMemorySize(2048);
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 2048);
-    vrDisplayNode->SetGPUMemorySize(4096);
+    viewNode->SetGPUMemorySize(4096);
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 4096);
-    vrDisplayNode->SetGPUMemorySize(8192);
+    viewNode->SetGPUMemorySize(8192);
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 8192);
-    vrDisplayNode->SetGPUMemorySize(16384);
+    viewNode->SetGPUMemorySize(16384);
     CHECK_INT(mapper->GetMaxMemoryInBytes() / 1024 / 1024, 16384);
    }
 

--- a/Modules/Loadable/VolumeRendering/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Widgets/CMakeLists.txt
@@ -27,6 +27,8 @@ set(${KIT}_SRCS
   qSlicer${MODULE_NAME}PresetComboBox.h
   qMRMLVolumePropertyNodeWidget.cxx
   qMRMLVolumePropertyNodeWidget.h
+  qSlicerGPUMemoryComboBox.cxx
+  qSlicerGPUMemoryComboBox.h
   )
 
 set(${KIT}_MOC_SRCS
@@ -39,6 +41,7 @@ set(${KIT}_MOC_SRCS
   qSlicer${MODULE_NAME}PropertiesWidget.h
   qSlicer${MODULE_NAME}PresetComboBox.h
   qMRMLVolumePropertyNodeWidget.h
+  qSlicerGPUMemoryComboBox.h
   )
 
 set(${KIT}_UI_SRCS

--- a/Modules/Loadable/VolumeRendering/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Widgets/CMakeLists.txt
@@ -14,6 +14,8 @@ set(${KIT}_SRCS
   qSlicerCPURayCast${MODULE_NAME}PropertiesWidget.h
   qSlicerGPURayCast${MODULE_NAME}PropertiesWidget.cxx
   qSlicerGPURayCast${MODULE_NAME}PropertiesWidget.h
+  qSlicerMulti${MODULE_NAME}PropertiesWidget.cxx
+  qSlicerMulti${MODULE_NAME}PropertiesWidget.h
   qSlicerPresetComboBox.cxx
   qSlicerPresetComboBox.h
   qSlicerPresetComboBox_p.h
@@ -30,6 +32,7 @@ set(${KIT}_SRCS
 set(${KIT}_MOC_SRCS
   qSlicerCPURayCast${MODULE_NAME}PropertiesWidget.h
   qSlicerGPURayCast${MODULE_NAME}PropertiesWidget.h
+  qSlicerMulti${MODULE_NAME}PropertiesWidget.h
   qSlicerPresetComboBox.h
   qSlicerPresetComboBox_p.h
   qSlicer${MODULE_NAME}ModuleWidget.h
@@ -42,6 +45,7 @@ set(${KIT}_UI_SRCS
   ../Resources/UI/qMRMLVolumePropertyNodeWidget.ui
   ../Resources/UI/qSlicerCPURayCast${MODULE_NAME}PropertiesWidget.ui
   ../Resources/UI/qSlicerGPURayCast${MODULE_NAME}PropertiesWidget.ui
+  ../Resources/UI/qSlicerMulti${MODULE_NAME}PropertiesWidget.ui
   ../Resources/UI/qSlicer${MODULE_NAME}ModuleWidget.ui
   ../Resources/UI/qSlicer${MODULE_NAME}PresetComboBox.ui
   )

--- a/Modules/Loadable/VolumeRendering/Widgets/DesignerPlugins/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Widgets/DesignerPlugins/CMakeLists.txt
@@ -15,6 +15,8 @@ set(${KIT}_SRCS
   qSlicerPresetComboBoxPlugin.h
   qSlicerVolumeRenderingPresetComboBoxPlugin.cxx
   qSlicerVolumeRenderingPresetComboBoxPlugin.h
+  qSlicerGPUMemoryComboBoxPlugin.cxx
+  qSlicerGPUMemoryComboBoxPlugin.h
   )
 
 set(${KIT}_MOC_SRCS
@@ -23,6 +25,7 @@ set(${KIT}_MOC_SRCS
   qMRMLVolumePropertyNodeWidgetPlugin.h
   qSlicerPresetComboBoxPlugin.h
   qSlicerVolumeRenderingPresetComboBoxPlugin.h
+  qSlicerGPUMemoryComboBoxPlugin.h
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/Modules/Loadable/VolumeRendering/Widgets/DesignerPlugins/qSlicerGPUMemoryComboBoxPlugin.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/DesignerPlugins/qSlicerGPUMemoryComboBoxPlugin.cxx
@@ -1,0 +1,61 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through CANARIE’s Research Software Program, and Cancer
+  Care Ontario.
+
+==============================================================================*/
+
+#include "qSlicerGPUMemoryComboBoxPlugin.h"
+#include "qSlicerGPUMemoryComboBox.h"
+
+//-----------------------------------------------------------------------------
+qSlicerGPUMemoryComboBoxPlugin::qSlicerGPUMemoryComboBoxPlugin(QObject *objectParent)
+  : QObject(objectParent)
+{
+}
+
+//-----------------------------------------------------------------------------
+QWidget *qSlicerGPUMemoryComboBoxPlugin::createWidget(QWidget *widgetParent)
+{
+  qSlicerGPUMemoryComboBox* newWidget = new qSlicerGPUMemoryComboBox(widgetParent);
+  return newWidget;
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerGPUMemoryComboBoxPlugin::domXml() const
+{
+  return "<widget class=\"qSlicerGPUMemoryComboBox\" \
+          name=\"GPUMemoryComboBox\">\n"
+          "</widget>\n";
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerGPUMemoryComboBoxPlugin::includeFile() const
+{
+  return "qSlicerGPUMemoryComboBox.h";
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerGPUMemoryComboBoxPlugin::isContainer() const
+{
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerGPUMemoryComboBoxPlugin::name() const
+{
+  return "qSlicerGPUMemoryComboBox";
+}

--- a/Modules/Loadable/VolumeRendering/Widgets/DesignerPlugins/qSlicerGPUMemoryComboBoxPlugin.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/DesignerPlugins/qSlicerGPUMemoryComboBoxPlugin.h
@@ -1,0 +1,42 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through CANARIE’s Research Software Program, and Cancer
+  Care Ontario.
+
+==============================================================================*/
+
+#ifndef __qSlicerGPUMemoryComboBoxPlugin_h
+#define __qSlicerGPUMemoryComboBoxPlugin_h
+
+#include "qSlicerVolumeRenderingModuleWidgetsAbstractPlugin.h"
+
+class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_PLUGINS_EXPORT qSlicerGPUMemoryComboBoxPlugin
+  : public QObject
+  , public qSlicerVolumeRenderingModuleWidgetsAbstractPlugin
+{
+  Q_OBJECT
+
+public:
+  qSlicerGPUMemoryComboBoxPlugin(QObject *_parent = 0);
+
+  QWidget *createWidget(QWidget *_parent);
+  QString  domXml() const;
+  QString  includeFile() const;
+  bool     isContainer() const;
+  QString  name() const;
+};
+
+#endif

--- a/Modules/Loadable/VolumeRendering/Widgets/DesignerPlugins/qSlicerVolumeRenderingModuleWidgetsPlugin.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/DesignerPlugins/qSlicerVolumeRenderingModuleWidgetsPlugin.h
@@ -34,6 +34,7 @@
 #include "qMRMLVolumePropertyNodeWidgetPlugin.h"
 #include "qSlicerPresetComboBoxPlugin.h"
 #include "qSlicerVolumeRenderingPresetComboBoxPlugin.h"
+#include "qSlicerGPUMemoryComboBoxPlugin.h"
 
 // \class Group the plugins in one library
 class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_PLUGINS_EXPORT qSlicerVolumeRenderingModuleWidgetsPlugin
@@ -52,7 +53,8 @@ public:
     QList<QDesignerCustomWidgetInterface *> plugins;
     plugins << new qMRMLVolumePropertyNodeWidgetPlugin
             << new qSlicerPresetComboBoxPlugin
-            << new qSlicerVolumeRenderingPresetComboBoxPlugin;
+            << new qSlicerVolumeRenderingPresetComboBoxPlugin
+            << new qSlicerGPUMemoryComboBoxPlugin;
     return plugins;
     }
 };

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerGPUMemoryComboBox.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerGPUMemoryComboBox.cxx
@@ -1,0 +1,246 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through CANARIE’s Research Software Program, and Cancer
+  Care Ontario.
+
+==============================================================================*/
+
+// qSlicerVolumeRendering includes
+#include "qSlicerGPUMemoryComboBox.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkGPUInfo.h>
+#include <vtkGPUInfoList.h>
+
+// Qt includes
+#include <QDebug>
+#include <QLineEdit>
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_VolumeRendering
+class qSlicerGPUMemoryComboBoxPrivate
+{
+  Q_DECLARE_PUBLIC(qSlicerGPUMemoryComboBox);
+protected:
+  qSlicerGPUMemoryComboBox* const q_ptr;
+
+public:
+  qSlicerGPUMemoryComboBoxPrivate(qSlicerGPUMemoryComboBox& object);
+  virtual ~qSlicerGPUMemoryComboBoxPrivate();
+
+  void init();
+
+  double memoryFromString(const QString& memory)const;
+  QString memoryToString(double memory)const;
+
+  QRegExp MemoryRegExp;
+  QString DefaultText;
+};
+
+//-----------------------------------------------------------------------------
+// qSlicerGPUMemoryComboBoxPrivate methods
+
+//-----------------------------------------------------------------------------
+qSlicerGPUMemoryComboBoxPrivate::qSlicerGPUMemoryComboBoxPrivate(
+  qSlicerGPUMemoryComboBox& object)
+  : q_ptr(&object)
+  , DefaultText("0 MB (Default)")
+{
+  this->MemoryRegExp = QRegExp("^(\\d+(?:\\.\\d*)?)\\s?(MB|GB|\\%)$");
+}
+
+//-----------------------------------------------------------------------------
+qSlicerGPUMemoryComboBoxPrivate::~qSlicerGPUMemoryComboBoxPrivate()
+{
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerGPUMemoryComboBoxPrivate::init()
+{
+  Q_Q(qSlicerGPUMemoryComboBox);
+
+  q->setEditable(true);
+  q->lineEdit()->setValidator( new QRegExpValidator(this->MemoryRegExp, q));
+  q->addItem(DefaultText);
+  //q->addItem(q->tr("25 %")); //TODO: Uncomment when totalGPUMemoryInMB works
+  //q->addItem(q->tr("50 %"));
+  //q->addItem(q->tr("75 %"));
+  //q->addItem(q->tr("90 %"));
+  q->addItem(q->tr("128 MB"));
+  q->addItem(q->tr("256 MB"));
+  q->addItem(q->tr("512 MB"));
+  q->addItem(q->tr("1024 MB"));
+  q->addItem(q->tr("1.5 GB"));
+  q->addItem(q->tr("2 GB"));
+  q->addItem(q->tr("3 GB"));
+  q->addItem(q->tr("4 GB"));
+  q->addItem(q->tr("6 GB"));
+  q->addItem(q->tr("8 GB"));
+  q->addItem(q->tr("12 GB"));
+  q->addItem(q->tr("16 GB"));
+  q->insertSeparator(1);
+
+  // Detect the amount of memory in the graphic card and set it as default
+  int gpuMemoryInMB = q->totalGPUMemoryInMB();
+  if (gpuMemoryInMB > 0)
+    {
+    q->setCurrentGPUMemory(gpuMemoryInMB);
+    }
+}
+
+// --------------------------------------------------------------------------
+double qSlicerGPUMemoryComboBoxPrivate::memoryFromString(const QString& memory)const
+{
+  if (memory == this->DefaultText)
+    {
+    return 0.0;
+    }
+
+  int pos = this->MemoryRegExp.indexIn(memory);
+  if (pos < 0)
+    {
+    return 0.0;
+    }
+
+  QString memoryValue = this->MemoryRegExp.cap(1);
+  double value = memoryValue.toDouble();
+  QString memoryUnit = this->MemoryRegExp.cap(2);
+
+  if (memoryUnit == "%")
+    {
+    return value / 100.0;
+    }
+  else if (memoryUnit == "GB")
+    {
+    return value * 1024.0;
+    }
+  return value;
+}
+
+// --------------------------------------------------------------------------
+QString qSlicerGPUMemoryComboBoxPrivate::memoryToString(double memory)const
+{
+  if (memory == 0.0)
+    {
+    return this->DefaultText;
+    }
+  if (memory < 1.0)
+    {
+    return QString::number(static_cast<int>(memory * 100)) + " %";
+    }
+  if (memory > 1024.0)
+    {
+    return QString::number(static_cast<float>(memory) / 1024) + " GB";
+    }
+  return QString::number(static_cast<int>(memory)) + " MB";
+}
+
+
+//-----------------------------------------------------------------------------
+// qSlicerGPUMemoryComboBox methods
+
+// --------------------------------------------------------------------------
+qSlicerGPUMemoryComboBox::qSlicerGPUMemoryComboBox(QWidget* parentWidget)
+  : Superclass(parentWidget)
+  , d_ptr(new qSlicerGPUMemoryComboBoxPrivate(*this))
+{
+  Q_D(qSlicerGPUMemoryComboBox);
+  d->init();
+}
+
+// --------------------------------------------------------------------------
+qSlicerGPUMemoryComboBox::~qSlicerGPUMemoryComboBox()
+{
+}
+
+//-----------------------------------------------------------------------------
+int qSlicerGPUMemoryComboBox::totalGPUMemoryInMB()const
+{
+  // Detect the amount of memory in the graphic card
+  vtkNew<vtkGPUInfoList> gpuInfoList;
+  gpuInfoList->Probe();
+
+  if (gpuInfoList->GetNumberOfGPUs() > 0)
+    {
+    int gpuMemoryInBytes = gpuInfoList->GetGPUInfo(0)->GetDedicatedVideoMemory();
+    int gpuMemoryInKB = gpuMemoryInBytes / 1024;
+    int gpuMemoryInMB = gpuMemoryInKB / 1024;
+    return gpuMemoryInMB;
+    }
+
+  return 0;
+}
+
+// --------------------------------------------------------------------------
+double qSlicerGPUMemoryComboBox::currentGPUMemory()const
+{
+  Q_D(const qSlicerGPUMemoryComboBox);
+
+  QString memoryString = this->currentText();
+  return d->memoryFromString(memoryString);
+}
+
+// --------------------------------------------------------------------------
+int qSlicerGPUMemoryComboBox::currentGPUMemoryInMB()const
+{
+  Q_D(const qSlicerGPUMemoryComboBox);
+
+  QString memoryString = this->currentText();
+  if (memoryString == d->DefaultText)
+    {
+    return 0;
+    }
+  double memory = d->memoryFromString(memoryString);
+  if (memory < 1.0)
+    {
+    int gpuMemoryInMB = this->totalGPUMemoryInMB();
+    if (gpuMemoryInMB == 0)
+      {
+      return 0;
+      }
+    return static_cast<int>(memory * gpuMemoryInMB);
+    }
+  return static_cast<int>(memory);
+}
+
+// --------------------------------------------------------------------------
+QString qSlicerGPUMemoryComboBox::currentGPUMemoryAsString()const
+{
+  return this->currentText();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerGPUMemoryComboBox::setCurrentGPUMemory(double memory)
+{
+  Q_D(qSlicerGPUMemoryComboBox);
+
+  QString memoryString = d->memoryToString(memory);
+  this->setCurrentGPUMemoryFromString(memoryString);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerGPUMemoryComboBox::setCurrentGPUMemoryFromString(const QString& memoryString)
+{
+  int index = this->findText(memoryString);
+  if (index == -1)
+    {
+    int customIndex = 0;
+    this->setItemText(customIndex, memoryString);
+    index = customIndex;
+    }
+  this->setCurrentIndex(index);
+}

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerGPUMemoryComboBox.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerGPUMemoryComboBox.h
@@ -1,0 +1,69 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through CANARIE’s Research Software Program, and Cancer
+  Care Ontario.
+
+==============================================================================*/
+
+#ifndef __qSlicerGPUMemoryComboBox_h
+#define __qSlicerGPUMemoryComboBox_h
+
+// Qt includes
+#include <QComboBox>
+
+// SlicerQt includes
+#include "qSlicerVolumeRenderingModuleWidgetsExport.h"
+
+class qSlicerGPUMemoryComboBoxPrivate;
+
+class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_EXPORT qSlicerGPUMemoryComboBox
+  : public QComboBox
+{
+  Q_OBJECT
+  Q_PROPERTY(double currentGPUMemory READ currentGPUMemory WRITE setCurrentGPUMemory)
+  Q_PROPERTY(QString currentGPUMemoryString READ currentGPUMemoryAsString WRITE setCurrentGPUMemoryFromString)
+
+public:
+  /// Constructors
+  typedef QComboBox Superclass;
+  explicit qSlicerGPUMemoryComboBox(QWidget* parent=0);
+  virtual ~qSlicerGPUMemoryComboBox();
+
+  /// Return total memory available in the GPU
+  Q_INVOKABLE int totalGPUMemoryInMB()const;
+  /// Return currently selected GPU memory in MB or percentage (% value between 0-1)
+  Q_INVOKABLE double currentGPUMemory()const;
+  /// Return currently selected GPU memory in MB
+  Q_INVOKABLE int currentGPUMemoryInMB()const;
+  /// Return currently selected GPU memory as string
+  Q_INVOKABLE QString currentGPUMemoryAsString()const;
+
+public slots:
+  /// Set currently selected GPU memory in MB or percentage (% value between 0-1)
+  void setCurrentGPUMemory(double memory);
+  /// Set currently selected GPU memory from string
+  /// (\sa qSlicerGPUMemoryComboBoxPrivate::memoryFromString)
+  void setCurrentGPUMemoryFromString(const QString& memoryString);
+
+protected:
+  QScopedPointer<qSlicerGPUMemoryComboBoxPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerGPUMemoryComboBox);
+  Q_DISABLE_COPY(qSlicerGPUMemoryComboBox);
+};
+
+#endif

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerMultiVolumeRenderingPropertiesWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerMultiVolumeRenderingPropertiesWidget.cxx
@@ -24,6 +24,10 @@
 #include "vtkMRMLMultiVolumeRenderingDisplayNode.h"
 #include "ui_qSlicerMultiVolumeRenderingPropertiesWidget.h"
 
+// MRML includes
+#include "vtkMRMLScene.h"
+#include "vtkMRMLViewNode.h"
+
 //-----------------------------------------------------------------------------
 /// \ingroup Slicer_QtModules_VolumeRendering
 class qSlicerMultiVolumeRenderingPropertiesWidgetPrivate
@@ -73,13 +77,11 @@ void qSlicerMultiVolumeRenderingPropertiesWidgetPrivate::populateRenderingTechni
 {
   this->RenderingTechniqueComboBox->clear();
   this->RenderingTechniqueComboBox->addItem(
-    "Composite With Shading", vtkMRMLVolumeRenderingDisplayNode::Composite);
+    "Composite With Shading", vtkMRMLViewNode::Composite);
   this->RenderingTechniqueComboBox->addItem(
-    "Maximum Intensity Projection",
-    vtkMRMLVolumeRenderingDisplayNode::MaximumIntensityProjection);
+    "Maximum Intensity Projection", vtkMRMLViewNode::MaximumIntensityProjection);
   this->RenderingTechniqueComboBox->addItem(
-    "Minimum Intensity Projection",
-    vtkMRMLVolumeRenderingDisplayNode::MinimumIntensityProjection);
+    "Minimum Intensity Projection", vtkMRMLViewNode::MinimumIntensityProjection);
 }
 
 //-----------------------------------------------------------------------------
@@ -118,8 +120,13 @@ void qSlicerMultiVolumeRenderingPropertiesWidget::updateWidgetFromMRML()
     {
     return;
     }
+  vtkMRMLViewNode* firstViewNode = displayNode->GetFirstViewNode();
+  if (!firstViewNode)
+    {
+    return;
+    }
 
-  int technique = displayNode->GetRaycastTechnique();
+  int technique = firstViewNode->GetRaycastTechnique();
   int index = d->RenderingTechniqueComboBox->findData(QVariant(technique));
   if (index == -1)
     {
@@ -130,7 +137,7 @@ void qSlicerMultiVolumeRenderingPropertiesWidget::updateWidgetFromMRML()
   d->RenderingTechniqueComboBox->blockSignals(wasBlocked);
 
   wasBlocked = d->SurfaceSmoothingCheckBox->blockSignals(true);
-  d->SurfaceSmoothingCheckBox->setChecked(displayNode->GetSurfaceSmoothing());
+  d->SurfaceSmoothingCheckBox->setChecked(firstViewNode->GetVolumeRenderingSurfaceSmoothing());
   d->SurfaceSmoothingCheckBox->blockSignals(wasBlocked);
 }
 
@@ -144,7 +151,17 @@ void qSlicerMultiVolumeRenderingPropertiesWidget::setRenderingTechnique(int inde
     return;
     }
   int technique = d->RenderingTechniqueComboBox->itemData(index).toInt();
-  displayNode->SetRaycastTechnique(technique);
+
+  std::vector<vtkMRMLNode*> viewNodes;
+  displayNode->GetScene()->GetNodesByClass("vtkMRMLViewNode", viewNodes);
+  for (std::vector<vtkMRMLNode*>::iterator it=viewNodes.begin(); it!=viewNodes.end(); ++it)
+    {
+    vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(*it);
+    if (displayNode->IsDisplayableInView(viewNode->GetID()))
+      {
+      viewNode->SetRaycastTechnique(technique);
+      }
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -156,5 +173,15 @@ void qSlicerMultiVolumeRenderingPropertiesWidget::setSurfaceSmoothing(bool on)
     {
     return;
     }
-  displayNode->SetSurfaceSmoothing(on);
+
+  std::vector<vtkMRMLNode*> viewNodes;
+  displayNode->GetScene()->GetNodesByClass("vtkMRMLViewNode", viewNodes);
+  for (std::vector<vtkMRMLNode*>::iterator it=viewNodes.begin(); it!=viewNodes.end(); ++it)
+    {
+    vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(*it);
+    if (displayNode->IsDisplayableInView(viewNode->GetID()))
+      {
+      viewNode->SetVolumeRenderingSurfaceSmoothing(on);
+      }
+    }
 }

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerMultiVolumeRenderingPropertiesWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerMultiVolumeRenderingPropertiesWidget.cxx
@@ -1,0 +1,160 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and CANARIE.
+
+==============================================================================*/
+
+// qSlicerGPURayCastVolumeRendering includes
+#include "qSlicerMultiVolumeRenderingPropertiesWidget.h"
+#include "vtkMRMLMultiVolumeRenderingDisplayNode.h"
+#include "ui_qSlicerMultiVolumeRenderingPropertiesWidget.h"
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_VolumeRendering
+class qSlicerMultiVolumeRenderingPropertiesWidgetPrivate
+  : public Ui_qSlicerMultiVolumeRenderingPropertiesWidget
+{
+  Q_DECLARE_PUBLIC(qSlicerMultiVolumeRenderingPropertiesWidget);
+protected:
+  qSlicerMultiVolumeRenderingPropertiesWidget* const q_ptr;
+
+public:
+  qSlicerMultiVolumeRenderingPropertiesWidgetPrivate(
+    qSlicerMultiVolumeRenderingPropertiesWidget& object);
+  virtual ~qSlicerMultiVolumeRenderingPropertiesWidgetPrivate();
+
+  virtual void setupUi(qSlicerMultiVolumeRenderingPropertiesWidget*);
+  void populateRenderingTechniqueComboBox();
+};
+
+// --------------------------------------------------------------------------
+qSlicerMultiVolumeRenderingPropertiesWidgetPrivate
+::qSlicerMultiVolumeRenderingPropertiesWidgetPrivate(
+  qSlicerMultiVolumeRenderingPropertiesWidget& object)
+  : q_ptr(&object)
+{
+}
+
+// --------------------------------------------------------------------------
+qSlicerMultiVolumeRenderingPropertiesWidgetPrivate::
+~qSlicerMultiVolumeRenderingPropertiesWidgetPrivate()
+{
+}
+
+// --------------------------------------------------------------------------
+void qSlicerMultiVolumeRenderingPropertiesWidgetPrivate
+::setupUi(qSlicerMultiVolumeRenderingPropertiesWidget* widget)
+{
+  this->Ui_qSlicerMultiVolumeRenderingPropertiesWidget::setupUi(widget);
+  this->populateRenderingTechniqueComboBox();
+  QObject::connect(this->RenderingTechniqueComboBox, SIGNAL(currentIndexChanged(int)),
+                   widget, SLOT(setRenderingTechnique(int)));
+  QObject::connect(this->SurfaceSmoothingCheckBox, SIGNAL(toggled(bool)),
+                   widget, SLOT(setSurfaceSmoothing(bool)));
+}
+
+// --------------------------------------------------------------------------
+void qSlicerMultiVolumeRenderingPropertiesWidgetPrivate::populateRenderingTechniqueComboBox()
+{
+  this->RenderingTechniqueComboBox->clear();
+  this->RenderingTechniqueComboBox->addItem(
+    "Composite With Shading", vtkMRMLVolumeRenderingDisplayNode::Composite);
+  this->RenderingTechniqueComboBox->addItem(
+    "Maximum Intensity Projection",
+    vtkMRMLVolumeRenderingDisplayNode::MaximumIntensityProjection);
+  this->RenderingTechniqueComboBox->addItem(
+    "Minimum Intensity Projection",
+    vtkMRMLVolumeRenderingDisplayNode::MinimumIntensityProjection);
+}
+
+//-----------------------------------------------------------------------------
+// qSlicerMultiVolumeRenderingPropertiesWidget methods
+
+//-----------------------------------------------------------------------------
+qSlicerMultiVolumeRenderingPropertiesWidget
+::qSlicerMultiVolumeRenderingPropertiesWidget(QWidget* parentWidget)
+  : Superclass( parentWidget )
+  , d_ptr( new qSlicerMultiVolumeRenderingPropertiesWidgetPrivate(*this) )
+{
+  Q_D(qSlicerMultiVolumeRenderingPropertiesWidget);
+  d->setupUi(this);
+}
+
+//-----------------------------------------------------------------------------
+qSlicerMultiVolumeRenderingPropertiesWidget::~qSlicerMultiVolumeRenderingPropertiesWidget()
+{
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLMultiVolumeRenderingDisplayNode* qSlicerMultiVolumeRenderingPropertiesWidget
+::mrmlDisplayNode()
+{
+  return vtkMRMLMultiVolumeRenderingDisplayNode::SafeDownCast(
+    this->mrmlVolumeRenderingDisplayNode());
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMultiVolumeRenderingPropertiesWidget::updateWidgetFromMRML()
+{
+  Q_D(qSlicerMultiVolumeRenderingPropertiesWidget);
+
+  vtkMRMLMultiVolumeRenderingDisplayNode* displayNode = this->mrmlDisplayNode();
+  if (!displayNode)
+    {
+    return;
+    }
+
+  int technique = displayNode->GetRaycastTechnique();
+  int index = d->RenderingTechniqueComboBox->findData(QVariant(technique));
+  if (index == -1)
+    {
+    index = 0;
+    }
+  bool wasBlocked = d->RenderingTechniqueComboBox->blockSignals(true);
+  d->RenderingTechniqueComboBox->setCurrentIndex(index);
+  d->RenderingTechniqueComboBox->blockSignals(wasBlocked);
+
+  wasBlocked = d->SurfaceSmoothingCheckBox->blockSignals(true);
+  d->SurfaceSmoothingCheckBox->setChecked(displayNode->GetSurfaceSmoothing());
+  d->SurfaceSmoothingCheckBox->blockSignals(wasBlocked);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMultiVolumeRenderingPropertiesWidget::setRenderingTechnique(int index)
+{
+  Q_D(qSlicerMultiVolumeRenderingPropertiesWidget);
+  vtkMRMLMultiVolumeRenderingDisplayNode* displayNode = this->mrmlDisplayNode();
+  if (!displayNode)
+    {
+    return;
+    }
+  int technique = d->RenderingTechniqueComboBox->itemData(index).toInt();
+  displayNode->SetRaycastTechnique(technique);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMultiVolumeRenderingPropertiesWidget::setSurfaceSmoothing(bool on)
+{
+  Q_D(qSlicerMultiVolumeRenderingPropertiesWidget);
+  vtkMRMLMultiVolumeRenderingDisplayNode* displayNode = this->mrmlDisplayNode();
+  if (!displayNode)
+    {
+    return;
+    }
+  displayNode->SetSurfaceSmoothing(on);
+}

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerMultiVolumeRenderingPropertiesWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerMultiVolumeRenderingPropertiesWidget.h
@@ -1,0 +1,57 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and CANARIE.
+
+==============================================================================*/
+
+#ifndef __qSlicerMultiVolumeRenderingPropertiesWidget_h
+#define __qSlicerMultiVolumeRenderingPropertiesWidget_h
+
+// SlicerQt includes
+#include "qSlicerVolumeRenderingPropertiesWidget.h"
+class qSlicerMultiVolumeRenderingPropertiesWidgetPrivate;
+class vtkMRMLMultiVolumeRenderingDisplayNode;
+
+/// \ingroup Slicer_QtModules_VolumeRendering
+class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_EXPORT qSlicerMultiVolumeRenderingPropertiesWidget
+  : public qSlicerVolumeRenderingPropertiesWidget
+{
+  Q_OBJECT
+public:
+  typedef qSlicerVolumeRenderingPropertiesWidget Superclass;
+  qSlicerMultiVolumeRenderingPropertiesWidget(QWidget *parent=0);
+  virtual ~qSlicerMultiVolumeRenderingPropertiesWidget();
+
+  vtkMRMLMultiVolumeRenderingDisplayNode* mrmlDisplayNode();
+
+public slots:
+  void setRenderingTechnique(int index);
+  void setSurfaceSmoothing(bool on);
+
+protected slots:
+  virtual void updateWidgetFromMRML();
+
+protected:
+  QScopedPointer<qSlicerMultiVolumeRenderingPropertiesWidgetPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerMultiVolumeRenderingPropertiesWidget);
+  Q_DISABLE_COPY(qSlicerMultiVolumeRenderingPropertiesWidget);
+};
+
+#endif

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -141,12 +141,16 @@ void qSlicerVolumeRenderingModuleWidgetPrivate::setupUi(qSlicerVolumeRenderingMo
   this->MemorySizeComboBox->addItem("8 GB", 8192);
   this->MemorySizeComboBox->addItem("12 GB", 12288);
   this->MemorySizeComboBox->addItem("16 GB", 16384);
-
   QObject::connect(this->MemorySizeComboBox, SIGNAL(currentIndexChanged(int)),
                    q, SLOT(onCurrentMemorySizeChanged(int)));
 
+  for (int qualityIndex=0; qualityIndex<vtkMRMLViewNode::VolumeRenderingQuality_Last; qualityIndex++)
+    {
+    this->QualityControlComboBox->addItem(vtkMRMLViewNode::GetVolumeRenderingQualityAsString(qualityIndex));
+    }
   QObject::connect(this->QualityControlComboBox, SIGNAL(currentIndexChanged(int)),
                    q, SLOT(onCurrentQualityControlChanged(int)));
+
   QObject::connect(this->FramerateSliderWidget, SIGNAL(valueChanged(double)),
                    q, SLOT(onCurrentFramerateChanged(double)));
 
@@ -420,7 +424,7 @@ void qSlicerVolumeRenderingModuleWidget::updateWidgetFromDisplayNode()
     d->FramerateSliderWidget->setValue(firstViewNode->GetExpectedFPS());
     }
   d->FramerateSliderWidget->setEnabled(
-    firstViewNode && firstViewNode->GetVolumeRenderingQuality() == vtkMRMLViewNode::AdaptiveQuality );
+    firstViewNode && firstViewNode->GetVolumeRenderingQuality() == vtkMRMLViewNode::Adaptive );
   // Advanced rendering properties
   if (d->RenderingMethodWidgets[currentRenderingMethod])
     {

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -27,6 +27,7 @@
 
 #include "qSlicerCPURayCastVolumeRenderingPropertiesWidget.h"
 #include "qSlicerGPURayCastVolumeRenderingPropertiesWidget.h"
+#include "qSlicerMultiVolumeRenderingPropertiesWidget.h"
 #include "qSlicerVolumeRenderingPresetComboBox.h"
 
 // MRML includes
@@ -122,6 +123,8 @@ void qSlicerVolumeRenderingModuleWidgetPrivate::setupUi(qSlicerVolumeRenderingMo
                               new qSlicerCPURayCastVolumeRenderingPropertiesWidget);
   q->addRenderingMethodWidget("vtkMRMLGPURayCastVolumeRenderingDisplayNode",
                               new qSlicerGPURayCastVolumeRenderingPropertiesWidget);
+  q->addRenderingMethodWidget("vtkMRMLGPURayCastMultiVolumeRenderingDisplayNode",
+                              new qSlicerMultiVolumeRenderingPropertiesWidget);
   QSettings settings;
   int defaultGPUMemorySize = settings.value("VolumeRendering/GPUMemorySize").toInt();
   this->MemorySizeComboBox->addItem(QString("Default (%1 MB)").arg(defaultGPUMemorySize), 0);

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
@@ -75,11 +75,11 @@ protected slots:
   void onCurrentMRMLVolumePropertyNodeChanged(vtkMRMLNode* node);
 
   void onCurrentRenderingMethodChanged(int index);
-  void onCurrentMemorySizeChanged(int index);
+  void onCurrentMemorySizeChanged();
   void onCurrentQualityControlChanged(int index);
   void onCurrentFramerateChanged(double fps);
 
-  void updateWidgetFromDisplayNode();
+  void updateWidgetFromMRML();
   void updateWidgetFromROINode();
 
   void synchronizeScalarDisplayNode();

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPropertiesWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingPropertiesWidget.cxx
@@ -113,12 +113,11 @@ void qSlicerVolumeRenderingPropertiesWidget
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerVolumeRenderingPropertiesWidget
-::updateWidgetFromMRML()
+void qSlicerVolumeRenderingPropertiesWidget::updateWidgetFromMRML()
 {
   Q_D(qSlicerVolumeRenderingPropertiesWidget);
   vtkMRMLVolumeNode* newVolumeNode =
-    d->VolumeRenderingDisplayNode ?d->VolumeRenderingDisplayNode->GetVolumeNode() : 0;
+    d->VolumeRenderingDisplayNode ? d->VolumeRenderingDisplayNode->GetVolumeNode() : 0;
   qvtkReconnect(d->VolumeNode, newVolumeNode, vtkCommand::ModifiedEvent,
                 this, SLOT(updateWidgetFromMRMLVolumeNode()));
   d->VolumeNode = newVolumeNode;
@@ -126,7 +125,6 @@ void qSlicerVolumeRenderingPropertiesWidget
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerVolumeRenderingPropertiesWidget
-::updateWidgetFromMRMLVolumeNode()
+void qSlicerVolumeRenderingPropertiesWidget::updateWidgetFromMRMLVolumeNode()
 {
 }

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
@@ -141,25 +141,20 @@ QStringList qSlicerVolumeRenderingModule::categories() const
 void qSlicerVolumeRenderingModule::setup()
 {
   this->Superclass::setup();
-  vtkMRMLThreeDViewDisplayableManagerFactory::GetInstance()->
-    RegisterDisplayableManager("vtkMRMLVolumeRenderingDisplayableManager");
+  vtkMRMLThreeDViewDisplayableManagerFactory::GetInstance()->RegisterDisplayableManager(
+    "vtkMRMLVolumeRenderingDisplayableManager");
 
   vtkSlicerVolumeRenderingLogic* volumeRenderingLogic =
     vtkSlicerVolumeRenderingLogic::SafeDownCast(this->logic());
   if (qSlicerApplication::application())
     {
-    qSlicerVolumeRenderingSettingsPanel* panel =
-      new qSlicerVolumeRenderingSettingsPanel;
-    qSlicerApplication::application()->settingsDialog()->addPanel(
-      "Volume rendering", panel);
+    qSlicerVolumeRenderingSettingsPanel* panel = new qSlicerVolumeRenderingSettingsPanel;
+    qSlicerApplication::application()->settingsDialog()->addPanel("Volume rendering", panel);
     panel->setVolumeRenderingLogic(volumeRenderingLogic);
     }
-  qSlicerCoreIOManager* coreIOManager =
-    qSlicerCoreApplication::application()->coreIOManager();
-  coreIOManager->registerIO(
-    new qSlicerVolumeRenderingReader(volumeRenderingLogic, this));
-  coreIOManager->registerIO(new qSlicerNodeWriter(
-    "Transfer Function", QString("TransferFunctionFile"),
+  qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
+  coreIOManager->registerIO(new qSlicerVolumeRenderingReader(volumeRenderingLogic, this));
+  coreIOManager->registerIO(new qSlicerNodeWriter("Transfer Function", QString("TransferFunctionFile"),
     QStringList() << "vtkMRMLVolumePropertyNode", true, this));
 
   // Register Subject Hierarchy core plugins

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.cxx
@@ -19,6 +19,7 @@
 ==============================================================================*/
 
 // Qt includes
+#include <QDebug>
 #include <QLineEdit>
 
 // QtGUI includes
@@ -38,6 +39,10 @@
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
+// MRML includes
+#include <vtkMRMLScene.h>
+#include <vtkMRMLViewNode.h>
+
 // --------------------------------------------------------------------------
 // qSlicerVolumeRenderingSettingsPanelPrivate
 
@@ -56,6 +61,9 @@ public:
   QString memoryToString(int memory)const;
 
   void addRenderingMethod(const QString& methodName, const QString& methodClassName);
+
+  vtkMRMLScene* mrmlScene();
+  vtkMRMLViewNode* defaultMrmlViewNode();
 
   QRegExp MemoryRegExp;
   vtkSmartPointer<vtkSlicerVolumeRenderingLogic> VolumeRenderingLogic;
@@ -79,9 +87,39 @@ void qSlicerVolumeRenderingSettingsPanelPrivate::init()
 
   this->setupUi(q);
 
+  //
+  // Quality
+  //
+  for (int qualityIndex=0; qualityIndex<vtkMRMLViewNode::VolumeRenderingQuality_Last; qualityIndex++)
+    {
+    this->QualityControlComboBox->addItem(vtkMRMLViewNode::GetVolumeRenderingQualityAsString(qualityIndex));
+    }
+  QObject::connect(this->QualityControlComboBox, SIGNAL(currentIndexChanged(int)),
+                   q, SLOT(onDefaultQualityChanged(int)));
+  q->registerProperty("VolumeRendering/DefaultQuality", q,
+                      "defaultQuality", SIGNAL(defaultQualityChanged(QString)));
+
+  //
+  // Interactive speed
+  //
+  QObject::connect(this->InteractiveSpeedSlider, SIGNAL(valueChanged(double)),
+                   q, SLOT(onDefaultInteractiveSpeedChanged(double)));
+  q->registerProperty("VolumeRendering/DefaultInteractiveSpeed", q,
+                      "defaultInteractiveSpeed", SIGNAL(defaultInteractiveSpeedChanged(int)));
+
+  //
+  // Surface smoothing
+  //
+  QObject::connect(this->SurfaceSmoothingCheckBox, SIGNAL(toggled(bool)),
+                   q, SLOT(onDefaultSurfaceSmoothingChanged(bool)));
+  q->registerProperty("VolumeRendering/DefaultSurfaceSmoothing", q,
+                      "defaultSurfaceSmoothing", SIGNAL(defaultSurfaceSmoothingChanged(bool)));
+
+  //
+  // GPU memory
+  //
   this->GPUMemoryComboBox->setEditable(true);
-  this->GPUMemoryComboBox->lineEdit()->setValidator(
-    new QRegExpValidator(this->MemoryRegExp, q));
+  this->GPUMemoryComboBox->lineEdit()->setValidator( new QRegExpValidator(this->MemoryRegExp, q));
   this->GPUMemoryComboBox->insertItem(0, q->tr("0 MB"));
   this->GPUMemoryComboBox->insertSeparator(1);
 
@@ -103,8 +141,8 @@ void qSlicerVolumeRenderingSettingsPanelPrivate::init()
     q->setGPUMemory(gpuMemoryInMo);
     }
 
-  q->registerProperty("VolumeRendering/GPUMemorySize", q, "gpuMemory",
-                      SIGNAL(gpuMemoryChanged(int)));
+  q->registerProperty("VolumeRendering/GPUMemorySize", q,
+                      "gpuMemory", SIGNAL(gpuMemoryChanged(int)));
 }
 
 // --------------------------------------------------------------------------
@@ -120,7 +158,7 @@ int qSlicerVolumeRenderingSettingsPanelPrivate::memoryFromString(const QString& 
   QString memoryUnit = this->MemoryRegExp.cap(2);
 
   double value = memoryValue.toDouble();
-  double unit = memoryUnit == "MB" ? 1. : 1024;
+  double unit = memoryUnit == "MB" ? 1. : 1024.;
 
   return static_cast<int>(value * unit);
 }
@@ -137,11 +175,42 @@ QString qSlicerVolumeRenderingSettingsPanelPrivate::memoryToString(int memory)co
 }
 
 // --------------------------------------------------------------------------
-void qSlicerVolumeRenderingSettingsPanelPrivate
-::addRenderingMethod(const QString& methodName, const QString& methodClassName)
+void qSlicerVolumeRenderingSettingsPanelPrivate::addRenderingMethod(
+  const QString& methodName, const QString& methodClassName )
 {
-  this->RenderingMethodComboBox->addItem(
-    methodName, methodClassName);
+  this->RenderingMethodComboBox->addItem(methodName, methodClassName);
+}
+
+// --------------------------------------------------------------------------
+vtkMRMLScene* qSlicerVolumeRenderingSettingsPanelPrivate::mrmlScene()
+{
+  Q_Q(qSlicerVolumeRenderingSettingsPanel);
+
+  vtkSlicerVolumeRenderingLogic* logic = q->volumeRenderingLogic();
+  if (!logic)
+    {
+    return NULL;
+    }
+  return logic->GetMRMLScene();
+}
+
+// --------------------------------------------------------------------------
+vtkMRMLViewNode* qSlicerVolumeRenderingSettingsPanelPrivate::defaultMrmlViewNode()
+{
+  vtkMRMLScene* scene = this->mrmlScene();
+  if (!scene)
+    {
+    return NULL;
+    }
+
+  // Setup a default 3D view node so that the default settings are propagated to all new 3D views
+  vtkSmartPointer<vtkMRMLNode> defaultNode = scene->GetDefaultNodeByClass("vtkMRMLViewNode");
+  if (!defaultNode)
+    {
+    defaultNode.TakeReference(scene->CreateNodeByClass("vtkMRMLViewNode"));
+    scene->AddDefaultNode(defaultNode);
+    }
+  return vtkMRMLViewNode::SafeDownCast(defaultNode.GetPointer());
 }
 
 // --------------------------------------------------------------------------
@@ -162,16 +231,14 @@ qSlicerVolumeRenderingSettingsPanel::~qSlicerVolumeRenderingSettingsPanel()
 }
 
 // --------------------------------------------------------------------------
-vtkSlicerVolumeRenderingLogic* qSlicerVolumeRenderingSettingsPanel
-::volumeRenderingLogic()const
+vtkSlicerVolumeRenderingLogic* qSlicerVolumeRenderingSettingsPanel::volumeRenderingLogic()const
 {
   Q_D(const qSlicerVolumeRenderingSettingsPanel);
   return d->VolumeRenderingLogic;
 }
 
 // --------------------------------------------------------------------------
-void qSlicerVolumeRenderingSettingsPanel
-::setVolumeRenderingLogic(vtkSlicerVolumeRenderingLogic* logic)
+void qSlicerVolumeRenderingSettingsPanel::setVolumeRenderingLogic(vtkSlicerVolumeRenderingLogic* logic)
 {
   Q_D(qSlicerVolumeRenderingSettingsPanel);
 
@@ -186,10 +253,11 @@ void qSlicerVolumeRenderingSettingsPanel
 }
 
 // --------------------------------------------------------------------------
-void qSlicerVolumeRenderingSettingsPanel
-::onVolumeRenderingLogicModified()
+void qSlicerVolumeRenderingSettingsPanel::onVolumeRenderingLogicModified()
 {
   Q_D(qSlicerVolumeRenderingSettingsPanel);
+
+  // Update default rendering method
   const std::map<std::string, std::string>& renderingMethods =
     d->VolumeRenderingLogic->GetRenderingMethods();
   /// \todo not the best test to make sure the list is different
@@ -212,6 +280,13 @@ void qSlicerVolumeRenderingSettingsPanel
   int defaultRenderingMethodIndex = d->RenderingMethodComboBox->findData(
     QString(defaultRenderingMethod));
   d->RenderingMethodComboBox->setCurrentIndex(defaultRenderingMethodIndex);
+
+  // MRML scene is not accessible yet from the logic when it is set, so cannot access default view node
+  // either. Need to setup default node and set defaults to 3D views when the scene is available.
+  this->onDefaultQualityChanged(d->QualityControlComboBox->currentIndex());
+  this->onDefaultInteractiveSpeedChanged(d->InteractiveSpeedSlider->value());
+  this->onDefaultSurfaceSmoothingChanged(d->SurfaceSmoothingCheckBox->isChecked());
+  this->onGPUMemoryChanged();
 }
 
 // --------------------------------------------------------------------------
@@ -249,31 +324,45 @@ void qSlicerVolumeRenderingSettingsPanel::setGPUMemory(int gpuMemory)
 // --------------------------------------------------------------------------
 void qSlicerVolumeRenderingSettingsPanel::onGPUMemoryChanged()
 {
-  vtkMRMLVolumeRenderingDisplayableManager::DefaultGPUMemorySize =
-    this->gpuMemory();
+  Q_D(qSlicerVolumeRenderingSettingsPanel);
+  if (!d->mrmlScene())
+    {
+    return;
+    }
 
-  emit gpuMemoryChanged(this->gpuMemory());
-  // Todo:
-  // update all the VolumeRendering displayable manager to take the new memory
-  // into account.
-  //vtkMRMLThreeDViewDisplayableManagerFactory* factory
-  //  = vtkMRMLThreeDViewDisplayableManagerFactory::GetInstance();
+  int memory = this->gpuMemory();
+  vtkMRMLVolumeRenderingDisplayableManager::DefaultGPUMemorySize = memory;
+
+  // Set to default view node
+  vtkMRMLViewNode* defaultViewNode = d->defaultMrmlViewNode();
+  if (defaultViewNode)
+    {
+    defaultViewNode->SetGPUMemorySize(memory);
+    }
+
+  // Set to all existing view nodes
+  std::vector<vtkMRMLNode*> viewNodes;
+  d->mrmlScene()->GetNodesByClass("vtkMRMLViewNode", viewNodes);
+  for (std::vector<vtkMRMLNode*>::iterator it=viewNodes.begin(); it!=viewNodes.end(); ++it)
+    {
+    vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(*it);
+    viewNode->SetGPUMemorySize(memory);
+    }
+
+  emit gpuMemoryChanged(memory);
 }
 
 // --------------------------------------------------------------------------
-QString qSlicerVolumeRenderingSettingsPanel
-::defaultRenderingMethod()const
+QString qSlicerVolumeRenderingSettingsPanel::defaultRenderingMethod()const
 {
   Q_D(const qSlicerVolumeRenderingSettingsPanel);
   QString renderingClassName =
-    d->RenderingMethodComboBox->itemData(
-      d->RenderingMethodComboBox->currentIndex()).toString();
+    d->RenderingMethodComboBox->itemData(d->RenderingMethodComboBox->currentIndex()).toString();
   return renderingClassName;
 }
 
 // --------------------------------------------------------------------------
-void qSlicerVolumeRenderingSettingsPanel
-::setDefaultRenderingMethod(const QString& method)
+void qSlicerVolumeRenderingSettingsPanel::setDefaultRenderingMethod(const QString& method)
 {
   Q_D(qSlicerVolumeRenderingSettingsPanel);
   int methodIndex = d->RenderingMethodComboBox->findData(method);
@@ -281,8 +370,7 @@ void qSlicerVolumeRenderingSettingsPanel
 }
 
 // --------------------------------------------------------------------------
-void qSlicerVolumeRenderingSettingsPanel
-::onDefaultRenderingMethodChanged(int index)
+void qSlicerVolumeRenderingSettingsPanel::onDefaultRenderingMethodChanged(int index)
 {
   Q_UNUSED(index);
   this->updateVolumeRenderingLogicDefaultRenderingMethod();
@@ -290,14 +378,144 @@ void qSlicerVolumeRenderingSettingsPanel
 }
 
 // --------------------------------------------------------------------------
-void qSlicerVolumeRenderingSettingsPanel
-::updateVolumeRenderingLogicDefaultRenderingMethod()
+void qSlicerVolumeRenderingSettingsPanel::updateVolumeRenderingLogicDefaultRenderingMethod()
 {
   Q_D(qSlicerVolumeRenderingSettingsPanel);
-  if (d->VolumeRenderingLogic == 0)
+  if (d->VolumeRenderingLogic == NULL)
     {
     return;
     }
-  d->VolumeRenderingLogic->SetDefaultRenderingMethod(
-    this->defaultRenderingMethod().toLatin1());
+  d->VolumeRenderingLogic->SetDefaultRenderingMethod(this->defaultRenderingMethod().toLatin1());
+}
+
+// --------------------------------------------------------------------------
+QString qSlicerVolumeRenderingSettingsPanel::defaultQuality()const
+{
+  Q_D(const qSlicerVolumeRenderingSettingsPanel);
+  int qualityIndex = d->QualityControlComboBox->currentIndex();
+  QString quality(vtkMRMLViewNode::GetVolumeRenderingQualityAsString(qualityIndex));
+  return quality;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerVolumeRenderingSettingsPanel::setDefaultQuality(const QString& quality)
+{
+  Q_D(qSlicerVolumeRenderingSettingsPanel);
+  int qualityIndex = d->QualityControlComboBox->findText(quality);
+  d->QualityControlComboBox->setCurrentIndex(qualityIndex);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerVolumeRenderingSettingsPanel::onDefaultQualityChanged(int qualityIndex)
+{
+  Q_D(qSlicerVolumeRenderingSettingsPanel);
+  if (!d->mrmlScene())
+    {
+    return;
+    }
+
+  // Set to default view node
+  vtkMRMLViewNode* defaultViewNode = d->defaultMrmlViewNode();
+  if (defaultViewNode)
+    {
+    defaultViewNode->SetVolumeRenderingQuality(qualityIndex);
+    }
+
+  // Set to all existing view nodes
+  std::vector<vtkMRMLNode*> viewNodes;
+  d->mrmlScene()->GetNodesByClass("vtkMRMLViewNode", viewNodes);
+  for (std::vector<vtkMRMLNode*>::iterator it=viewNodes.begin(); it!=viewNodes.end(); ++it)
+    {
+    vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(*it);
+    viewNode->SetVolumeRenderingQuality(qualityIndex);
+    }
+
+  QString quality(vtkMRMLViewNode::GetVolumeRenderingQualityAsString(qualityIndex));
+  emit defaultQualityChanged(quality);
+}
+
+// --------------------------------------------------------------------------
+int qSlicerVolumeRenderingSettingsPanel::defaultInteractiveSpeed()const
+{
+  Q_D(const qSlicerVolumeRenderingSettingsPanel);
+  int interactiveSpeed = d->InteractiveSpeedSlider->value();
+  return interactiveSpeed;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerVolumeRenderingSettingsPanel::setDefaultInteractiveSpeed(int interactiveSpeed)
+{
+  Q_D(qSlicerVolumeRenderingSettingsPanel);
+  d->InteractiveSpeedSlider->setValue(interactiveSpeed);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerVolumeRenderingSettingsPanel::onDefaultInteractiveSpeedChanged(double interactiveSpeed)
+{
+  Q_D(qSlicerVolumeRenderingSettingsPanel);
+  if (!d->mrmlScene())
+    {
+    return;
+    }
+
+  // Set to default view node
+  vtkMRMLViewNode* defaultViewNode = d->defaultMrmlViewNode();
+  if (defaultViewNode)
+    {
+    defaultViewNode->SetExpectedFPS((int)interactiveSpeed);
+    }
+
+  // Set to all existing view nodes
+  std::vector<vtkMRMLNode*> viewNodes;
+  d->mrmlScene()->GetNodesByClass("vtkMRMLViewNode", viewNodes);
+  for (std::vector<vtkMRMLNode*>::iterator it=viewNodes.begin(); it!=viewNodes.end(); ++it)
+    {
+    vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(*it);
+    viewNode->SetExpectedFPS((int)interactiveSpeed);
+    }
+
+  emit defaultInteractiveSpeedChanged((int)interactiveSpeed);
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerVolumeRenderingSettingsPanel::defaultSurfaceSmoothing()const
+{
+  Q_D(const qSlicerVolumeRenderingSettingsPanel);
+  bool smoothing = d->SurfaceSmoothingCheckBox->isChecked();
+  return smoothing;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerVolumeRenderingSettingsPanel::setDefaultSurfaceSmoothing(bool surfaceSmoothing)
+{
+  Q_D(qSlicerVolumeRenderingSettingsPanel);
+  d->SurfaceSmoothingCheckBox->setChecked(surfaceSmoothing);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerVolumeRenderingSettingsPanel::onDefaultSurfaceSmoothingChanged(bool smoothing)
+{
+  Q_D(qSlicerVolumeRenderingSettingsPanel);
+  if (!d->mrmlScene())
+    {
+    return;
+    }
+
+  // Set to default view node
+  vtkMRMLViewNode* defaultViewNode = d->defaultMrmlViewNode();
+  if (defaultViewNode)
+    {
+    defaultViewNode->SetVolumeRenderingSurfaceSmoothing(smoothing);
+    }
+
+  // Set to all existing view nodes
+  std::vector<vtkMRMLNode*> viewNodes;
+  d->mrmlScene()->GetNodesByClass("vtkMRMLViewNode", viewNodes);
+  for (std::vector<vtkMRMLNode*>::iterator it=viewNodes.begin(); it!=viewNodes.end(); ++it)
+    {
+    vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(*it);
+    viewNode->SetVolumeRenderingSurfaceSmoothing(smoothing);
+    }
+
+  emit defaultSurfaceSmoothingChanged(smoothing);
 }

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.cxx
@@ -34,8 +34,6 @@
 #include <vtkSlicerVolumeRenderingLogic.h>
 
 // VTK includes
-#include <vtkGPUInfo.h>
-#include <vtkGPUInfoList.h>
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 
@@ -57,15 +55,11 @@ public:
   qSlicerVolumeRenderingSettingsPanelPrivate(qSlicerVolumeRenderingSettingsPanel& object);
   void init();
 
-  int memoryFromString(const QString& memory)const;
-  QString memoryToString(int memory)const;
-
   void addRenderingMethod(const QString& methodName, const QString& methodClassName);
 
   vtkMRMLScene* mrmlScene();
   vtkMRMLViewNode* defaultMrmlViewNode();
 
-  QRegExp MemoryRegExp;
   vtkSmartPointer<vtkSlicerVolumeRenderingLogic> VolumeRenderingLogic;
 };
 
@@ -77,7 +71,6 @@ qSlicerVolumeRenderingSettingsPanelPrivate
 ::qSlicerVolumeRenderingSettingsPanelPrivate(qSlicerVolumeRenderingSettingsPanel& object)
   :q_ptr(&object)
 {
-  this->MemoryRegExp = QRegExp("^(\\d+(?:\\.\\d*)?)\\s?(MB|GB)$");
 }
 
 // --------------------------------------------------------------------------
@@ -118,60 +111,13 @@ void qSlicerVolumeRenderingSettingsPanelPrivate::init()
   //
   // GPU memory
   //
-  this->GPUMemoryComboBox->setEditable(true);
-  this->GPUMemoryComboBox->lineEdit()->setValidator( new QRegExpValidator(this->MemoryRegExp, q));
-  this->GPUMemoryComboBox->insertItem(0, q->tr("0 MB"));
-  this->GPUMemoryComboBox->insertSeparator(1);
-
   QObject::connect(this->GPUMemoryComboBox, SIGNAL(editTextChanged(QString)),
                    q, SLOT(onGPUMemoryChanged()));
-  QObject::connect(this->GPUMemoryComboBox, SIGNAL(currentIndexChanged(QString)),
+  QObject::connect(this->GPUMemoryComboBox, SIGNAL(currentTextChanged(QString)),
                    q, SLOT(onGPUMemoryChanged()));
 
-  // Detect the amount of memory in the graphic card
-  vtkNew<vtkGPUInfoList> gpuInfoList;
-  gpuInfoList->Probe();
-
-  if (gpuInfoList->GetNumberOfGPUs() > 0)
-    {
-    int gpuMemoryInBytes = gpuInfoList->GetGPUInfo(0)->GetDedicatedVideoMemory();
-    int gpuMemoryInKo = gpuMemoryInBytes / 1024;
-    int gpuMemoryInMo = gpuMemoryInKo / 1024;
-    // Set it as the default amount of memory
-    q->setGPUMemory(gpuMemoryInMo);
-    }
-
   q->registerProperty("VolumeRendering/GPUMemorySize", q,
-                      "gpuMemory", SIGNAL(gpuMemoryChanged(int)));
-}
-
-// --------------------------------------------------------------------------
-int qSlicerVolumeRenderingSettingsPanelPrivate::memoryFromString(const QString& memory)const
-{
-  int pos = this->MemoryRegExp.indexIn(memory);
-  if (pos < 0)
-    {
-    return 0;
-    }
-
-  QString memoryValue = this->MemoryRegExp.cap(1);
-  QString memoryUnit = this->MemoryRegExp.cap(2);
-
-  double value = memoryValue.toDouble();
-  double unit = memoryUnit == "MB" ? 1. : 1024.;
-
-  return static_cast<int>(value * unit);
-}
-
-// --------------------------------------------------------------------------
-QString qSlicerVolumeRenderingSettingsPanelPrivate::memoryToString(int memory)const
-{
-  QString value = QString::number(memory) + " MB";
-  if (memory > 1024)
-    {
-    value = QString::number(static_cast<float>(memory) / 1024) + " GB";
-    }
-  return value;
+                      "gpuMemory", SIGNAL(gpuMemoryChanged(QString)));
 }
 
 // --------------------------------------------------------------------------
@@ -290,35 +236,18 @@ void qSlicerVolumeRenderingSettingsPanel::onVolumeRenderingLogicModified()
 }
 
 // --------------------------------------------------------------------------
-int qSlicerVolumeRenderingSettingsPanel::gpuMemory()const
+QString qSlicerVolumeRenderingSettingsPanel::gpuMemory()const
 {
   Q_D(const qSlicerVolumeRenderingSettingsPanel);
-  QString memory = d->GPUMemoryComboBox->currentText();
-  return d->memoryFromString(memory);
+  return d->GPUMemoryComboBox->currentGPUMemoryAsString();
 }
 
 // --------------------------------------------------------------------------
-void qSlicerVolumeRenderingSettingsPanel::setGPUMemory(int gpuMemory)
+void qSlicerVolumeRenderingSettingsPanel::setGPUMemory(const QString& gpuMemoryString)
 {
   Q_D(qSlicerVolumeRenderingSettingsPanel);
-  QString value = d->memoryToString(gpuMemory);
-  int index = d->GPUMemoryComboBox->findText(value);
-  bool currentIndexModified = false;
-  if (index == -1)
-    {
-    int customIndex = 0;
-    d->GPUMemoryComboBox->setItemText(customIndex, value);
-    index = customIndex;
-    if (index == d->GPUMemoryComboBox->currentIndex())
-      {
-      currentIndexModified = true;
-      }
-    }
-  d->GPUMemoryComboBox->setCurrentIndex(index);
-  if (currentIndexModified)
-    {
-    this->onGPUMemoryChanged();
-    }
+  d->GPUMemoryComboBox->setCurrentGPUMemoryFromString(gpuMemoryString);
+  this->onGPUMemoryChanged();
 }
 
 // --------------------------------------------------------------------------
@@ -330,8 +259,7 @@ void qSlicerVolumeRenderingSettingsPanel::onGPUMemoryChanged()
     return;
     }
 
-  int memory = this->gpuMemory();
-  vtkMRMLVolumeRenderingDisplayableManager::DefaultGPUMemorySize = memory;
+  int memory = d->GPUMemoryComboBox->currentGPUMemoryInMB();
 
   // Set to default view node
   vtkMRMLViewNode* defaultViewNode = d->defaultMrmlViewNode();
@@ -349,7 +277,7 @@ void qSlicerVolumeRenderingSettingsPanel::onGPUMemoryChanged()
     viewNode->SetGPUMemorySize(memory);
     }
 
-  emit gpuMemoryChanged(memory);
+  emit gpuMemoryChanged(this->gpuMemory());
 }
 
 // --------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.h
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.h
@@ -39,7 +39,7 @@ class Q_SLICER_QTMODULES_VOLUMERENDERING_EXPORT qSlicerVolumeRenderingSettingsPa
   Q_PROPERTY(QString defaultQuality READ defaultQuality WRITE setDefaultQuality NOTIFY defaultQualityChanged)
   Q_PROPERTY(int defaultInteractiveSpeed READ defaultInteractiveSpeed WRITE setDefaultInteractiveSpeed NOTIFY defaultInteractiveSpeedChanged)
   Q_PROPERTY(bool defaultSurfaceSmoothing READ defaultSurfaceSmoothing WRITE setDefaultSurfaceSmoothing NOTIFY defaultSurfaceSmoothingChanged)
-  Q_PROPERTY(int gpuMemory READ gpuMemory WRITE setGPUMemory NOTIFY gpuMemoryChanged)
+  Q_PROPERTY(QString gpuMemory READ gpuMemory WRITE setGPUMemory NOTIFY gpuMemoryChanged)
 
 public:
   /// Superclass typedef
@@ -60,21 +60,21 @@ public:
   QString defaultQuality()const;
   int defaultInteractiveSpeed()const;
   bool defaultSurfaceSmoothing()const;
-  int gpuMemory()const;
+  QString gpuMemory()const;
 
 public slots:
   void setDefaultRenderingMethod(const QString& method);
   void setDefaultQuality(const QString& quality);
   void setDefaultInteractiveSpeed(int interactiveSpeed);
   void setDefaultSurfaceSmoothing(bool surfaceSmoothing);
-  void setGPUMemory(int gpuMemory);
+  void setGPUMemory(const QString& gpuMemory);
 
 signals:
   void defaultRenderingMethodChanged(const QString&);
   void defaultQualityChanged(const QString&);
   void defaultInteractiveSpeedChanged(int);
   void defaultSurfaceSmoothingChanged(bool);
-  void gpuMemoryChanged(int);
+  void gpuMemoryChanged(QString);
 
 protected slots:
   void onVolumeRenderingLogicModified();

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.h
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.h
@@ -35,8 +35,12 @@ class Q_SLICER_QTMODULES_VOLUMERENDERING_EXPORT qSlicerVolumeRenderingSettingsPa
 {
   Q_OBJECT
   QVTK_OBJECT
-  Q_PROPERTY(int gpuMemory READ gpuMemory WRITE setGPUMemory NOTIFY gpuMemoryChanged)
   Q_PROPERTY(QString defaultRenderingMethod READ defaultRenderingMethod WRITE setDefaultRenderingMethod NOTIFY defaultRenderingMethodChanged)
+  Q_PROPERTY(QString defaultQuality READ defaultQuality WRITE setDefaultQuality NOTIFY defaultQualityChanged)
+  Q_PROPERTY(int defaultInteractiveSpeed READ defaultInteractiveSpeed WRITE setDefaultInteractiveSpeed NOTIFY defaultInteractiveSpeedChanged)
+  Q_PROPERTY(bool defaultSurfaceSmoothing READ defaultSurfaceSmoothing WRITE setDefaultSurfaceSmoothing NOTIFY defaultSurfaceSmoothingChanged)
+  Q_PROPERTY(int gpuMemory READ gpuMemory WRITE setGPUMemory NOTIFY gpuMemoryChanged)
+
 public:
   /// Superclass typedef
   typedef ctkSettingsPanel Superclass;
@@ -52,22 +56,34 @@ public:
   void setVolumeRenderingLogic(vtkSlicerVolumeRenderingLogic* logic);
   vtkSlicerVolumeRenderingLogic* volumeRenderingLogic()const;
 
-  int gpuMemory()const;
-  void setGPUMemory(int gpuMemory);
-
   QString defaultRenderingMethod()const;
+  QString defaultQuality()const;
+  int defaultInteractiveSpeed()const;
+  bool defaultSurfaceSmoothing()const;
+  int gpuMemory()const;
+
 public slots:
   void setDefaultRenderingMethod(const QString& method);
+  void setDefaultQuality(const QString& quality);
+  void setDefaultInteractiveSpeed(int interactiveSpeed);
+  void setDefaultSurfaceSmoothing(bool surfaceSmoothing);
+  void setGPUMemory(int gpuMemory);
 
 signals:
-  void gpuMemoryChanged(int);
   void defaultRenderingMethodChanged(const QString&);
+  void defaultQualityChanged(const QString&);
+  void defaultInteractiveSpeedChanged(int);
+  void defaultSurfaceSmoothingChanged(bool);
+  void gpuMemoryChanged(int);
 
 protected slots:
   void onVolumeRenderingLogicModified();
-  void onGPUMemoryChanged();
   void onDefaultRenderingMethodChanged(int);
   void updateVolumeRenderingLogicDefaultRenderingMethod();
+  void onDefaultQualityChanged(int);
+  void onDefaultInteractiveSpeedChanged(double);
+  void onDefaultSurfaceSmoothingChanged(bool);
+  void onGPUMemoryChanged();
 
 protected:
   QScopedPointer<qSlicerVolumeRenderingSettingsPanelPrivate> d_ptr;


### PR DESCRIPTION
This PR implements real multi-volume support in Slicer, using the vtkMultiVolume actor. The actor is not fully implemented, so it has limitations, such as no shading, no cropping by ROI, no per-volume visibility. For a few of these, workarounds have been implemented. Hence, the options is currently marked experimental in the drop-down list.

Additionally, I refactored the volume rendering options so that many of them now are in the view node instead of the display node, and added those to Application Settings.

The PR contains four commits for easier review, and I think it makes sense to keep them separate when integrating.