### PR TITLE
BUG: Load python dependent widget during module instantiation

### DIFF
--- a/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
@@ -192,28 +192,6 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& newPythonSour
 void qSlicerScriptedLoadableModule::setup()
 {
   Q_D(qSlicerScriptedLoadableModule);
-
-  qSlicerCoreApplication * app = qSlicerCoreApplication::application();
-  if (app)
-    {
-    // Set to /path/to/lib/Slicer-X.Y/qt-scripted-modules
-    QString modulePath = QFileInfo(this->path()).absolutePath();
-    // Set to /path/to/lib/Slicer-X.Y
-    modulePath = QFileInfo(modulePath).absolutePath();
-    // Set to /path/to/lib/Slicer-X.Y/qt-loadable-modules
-    modulePath = modulePath + "/" Slicer_QTLOADABLEMODULES_SUBDIR;
-
-    bool isEmbedded = app->isEmbeddedModule(this->path());
-    if (!isEmbedded)
-      {
-      if (!qSlicerLoadableModule::importModulePythonExtensions(
-            app->corePythonManager(), app->intDir(), modulePath, isEmbedded))
-        {
-        qWarning() << "qSlicerLoadableModule::setup - Failed to import module" << this->name() << "python extensions";
-        }
-      }
-    }
-
   this->registerFileDialog();
   this->registerIO();
   d->PythonCppAPI.callMethod(Pimpl::SetupMethod);

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
@@ -77,6 +77,18 @@ qSlicerAbstractCoreModule* ctkFactoryScriptedItem::instanciator()
   module->setInstalled(qSlicerUtils::isPluginInstalled(this->path(), app->slicerHome()));
   module->setBuiltIn(qSlicerUtils::isPluginBuiltIn(this->path(), app->slicerHome()));
 
+  // Set to /path/to/lib/Slicer-X.Y/qt-scripted-modules
+  QString modulePath = QFileInfo(this->path()).absolutePath();
+  // Set to /path/to/lib/Slicer-X.Y
+  modulePath = QFileInfo(modulePath).absolutePath();
+  // Set to /path/to/lib/Slicer-X.Y/qt-loadable-modules/Release|(...)|Debug
+  modulePath = modulePath + "/" Slicer_QTLOADABLEMODULES_SUBDIR + "/" + app->intDir();
+  if (!qSlicerLoadableModule::importModulePythonExtensions(
+        app->corePythonManager(), app->intDir(), modulePath, app->isEmbeddedModule(this->path())))
+    {
+    return 0;
+    }
+
   bool ret = module->setPythonSource(this->path());
   if (!ret)
     {


### PR DESCRIPTION
This let python module access widget/logic or any C++ classes they may
have as soon as they are instantiated. This let users do the following:
"var = slicer.qMyClassWidget.MyEnumValue" for example.