### PR TITLE
ENH: Update LibArchive. Fix gcc8 warnings.

### DIFF
--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -38,7 +38,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/Slicer/LibArchive.git"
+    "${EP_GIT_PROTOCOL}://github.com/phcerdan/libarchive"
     QUIET
     )
 
@@ -47,7 +47,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
   # - fixing GCC7 build errors
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    "ebec58f7698ed04712e885aa2c354547fc8c596d"
+    "944ab1d06a4e190068aadc34e2a10381312412b2"
     QUIET
     )
 


### PR DESCRIPTION
The gcc8 warnings were generating build errors at Debug mode,
because the aggressive Werror flag in LibArchive.

git shortlog 98a695399e8e7420635a5448aecde8b0a82fb83a..d7dea508

Arshan Khanifar (7):
      flush pending chdirs prior to processing mtree files
      Test case for using -C in conjunction with an @mtree format file
      corrected licensing, removed unnecessary variables
      build fail fix, simplified logic
      absolute path fix
      alphabetical order
      put the absolute path in quotes in case user's directory has spaces in it

BenjaminTrapani (9):
      Fix bsdtar test compilation on windows with platform toolset 141
      Fix missing hardlink source test windows
      Fix version format to match unit test
      Copy reference resource to binary directory to make it possible to debug tests via visual studio cmake
      Add space after version to fix all unit tests besides sparse tests
      Fix sparse tests windows
      Revert "Copy reference resource to binary directory to make it possible to debug"
      Fix indentation to match rest of file
      Fix warnings treated as errors during x64 build

Bernard Spil (1):
      fix build with LibreSSL 2.7

Brad King (1):
      Do not use nanosecond file time APIs on macOS < 10.13

Chris Roberts (1):
      Check libgnu for xattr functions on Haiku

Colin Percival (1):
      Avoid overflow when reading corrupt cpio archive

Ed Maste (1):
      ensure ar strtab is null terminated

Graham Percival (1):
      Spelling fixes

Joerg Sonnenberger (12):
      Don't call wmemmove if size is zero.
      Revert addition of assert.
      Do something sensible for empty strings to make fuzzers happy.
      Match full strings, not just prefixes.
      Don't allow sparse mapping entry to pass beyond 63bit.
      Place a limit on the mtree line length to make fuzzers happy.
      Ensure that the AES extension header is large enough.
      Avoid a read off-by-one error for UTF16 names in RAR archives.
      Fix case in comment.
      Match archive.h for la_int64_t vs int64_t
      Fix archive freeing bug in bsdcat.
      Check size of the extended time field in zip archives

John Starks (2):
      Windows: set errno on CreateFileW failure
      zip: Allow backslash as path separator

Martin Matuska (8):
      Merge pull request #926 from emaste/libarchive
      archive_write_ar_data(): replace strncpy() with memcpy()
      bsdtar manpage: unify descriptions of compression options
      Fix build on FreeBSD with NFS4 ACLs without ACL_ENTRY_INHERITED
      Remove lzop package from Darwin testing
      Unbreak write test for libzstd 1.3.4
      Merge pull request #973 from o3dwade:master
      Add some gzip header tests including RFC 1952 compression level flag

Martin Matuška (1):
      Merge pull request #968 from trollixx/cmake-lz4-option

Mike Frysinger (1):
      delete dead ppmd7 alloc callbacks (#893)

Oleg Shparber (2):
      cmake: Add ENABLE_LZ4 option
      cmake: Fix missing override for LZO2_FOUND

Omar Farooq (1):
      Adding compression level support for gzip

Pablo Hernandez-Cerdan (1):
      Fix gcc 8 warning about strncpy

Paul Spangler (2):
      archive_write_disk_{posix,windows}.c: Don't modify attributes for existing directories when ARCHIVE_EXTRACT_NO_OVERWRITE is set
      Simplify test case per PR comments

Sean Purcell (14):
      Add Zstandard read support
      Add Zstandard write support
      Small zstd fixes
      Add zstd test suite
      Whitespace fixes
      Fix zstd reader and change variable scopes
      Fix compile errors with cmake and when zstd isn't present
      Skip zstd write tests when library not present
      Don't try to use libzstd versions without streaming API
      Build with zstd on TravisCI on OS X
      zstd: Address comments by @terrelln
      zstd: Don't bid on skippable frames
      Fix alphabetical order, other small fixes
      Fix zstd memory allocation and null checks

Tim Kientzle (19):
      Libarchive 3.3.3dev
      Issue #924: fix capitalization of bcrypt.h header
      Merge pull request #929 from cperciva/master
      Merge pull request #930 from Tarsnap/spelling-upload
      Merge pull request #934 from tonytheodore/cflags-private
      Merge pull request #905 from iburinoc/zstd
      Merge pull request #943 from jrmarino/master
      Issue #947: Reference archive_write_set_options in archive_write.3
      Merge pull request #912 from korli/libnetwork
      Merge pull request #961 from zweger/master
      Merge pull request #964 from legnaleurc/fix_fallthrough
      Merge pull request #970 from jstarks/zip_path_separator
      Merge pull request #966 from jstarks/windows_disk_read_error
      Merge pull request #962 from spanglerco/existing-dir-owner
      Merge pull request #986 from BenjaminTrapani/windows-fixes
      Merge pull request #989 from trollixx/cmake-fix-lzo2
      Merge pull request #993 from ArshanKhanifar/issue-991
      Merge pull request #1005 from Sp1l/master
      Merge pull request #1024 from phcerdan/fix_strncpy_warning

Tony Theodore (1):
      libarchive.pc.in: add Cflags.private for static linking

Wei-Cheng Pan (1):
      Fix -Werror=implicit-fallthrough= for GCC 7.

Zack Weger (1):
      Clear the ZIP format name before constructing a new one, so it isn't appended to the format name of the previous entry

jrmarino (1):
      Recognize ".tzst" extension as ".tar.zst"

ngie (1):
      Fix a potential NULL pointer dereference of `tar` in archive_read_support_format_tar when HAVE_COPYFILE_H is defined (#959)