### PR TITLE
COMP: Fix minor warnings generated with gcc8

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -80,6 +80,7 @@ struct BlendPipeline
 {
   BlendPipeline()
   {
+    /*
     // AlphaBlending, ReverseAlphaBlending:
     //
     //   foreground \
@@ -103,6 +104,7 @@ struct BlendPipeline
     //     ... AddSubOutputCast > AddSubExtractRGB \
     //                                              > AddSubAppendRGBA > Blend
     //             background > AddSubExtractAlpha /
+    */
 
     this->AddSubForegroundCast->SetOutputScalarTypeToShort();
     this->AddSubBackgroundCast->SetOutputScalarTypeToShort();

--- a/Libs/vtkITK/vtkITKImageThresholdCalculator.cxx
+++ b/Libs/vtkITK/vtkITKImageThresholdCalculator.cxx
@@ -102,7 +102,7 @@ void ITKComputeThresholdFromVTKImage(vtkITKImageThresholdCalculator *self, vtkIm
     {
     calculator->Update();
     }
-  catch (itk::ExceptionObject err)
+  catch (itk::ExceptionObject &err)
     {
     vtkErrorWithObjectMacro(self, "Failed to compute threshold value using method " << self->GetMethodAsString(self->GetMethod())
       << ". Details: " << err);


### PR DESCRIPTION
- Catch by value instead of reference.
- Multi-line comment without /* */ notation.

```
[77/796] Building CXX object Libs/MRML/Core/CM...LCore.dir/vtkMRMLSegmentationStorageNode.cxx.o
/Software/Slicer/Slicer-src/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx:85:5: warning: multi-line comment [-Wcomment]
     //   foreground \
     ^
/Software/Slicer/Slicer-src/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx:98:5: warning: multi-line comment [-Wcomment]
     //   foreground > AddSubForegroundCast \
     ^
/Software/Slicer/Slicer-src/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx:103:5: warning: multi-line comment [-Wcomment]
     //     ... AddSubOutputCast > AddSubExtractRGB \
     ^
```