### PR TITLE
ENH: Add widget to specify labelmap geometry in segmentations

### DIFF
--- a/Libs/vtkSegmentationCore/vtkCalculateOversamplingFactor.cxx
+++ b/Libs/vtkSegmentationCore/vtkCalculateOversamplingFactor.cxx
@@ -463,7 +463,7 @@ void vtkCalculateOversamplingFactor::ApplyOversamplingOnImageGeometry(vtkOriente
       {
       int dimension = extent[axis*2+1] - extent[axis*2] + 1;
       int extentMin = static_cast<int>(ceil(oversamplingFactor * extent[axis * 2]));
-      int extentMax = extentMin + static_cast<int>(floor(oversamplingFactor*dimension)) - 1;
+      int extentMax = std::max(extentMin + static_cast<int>(floor(oversamplingFactor*dimension)) - 1, 0);
       newExtent[axis*2] = extentMin;
       newExtent[axis*2+1] = extentMax;
       newSpacing[axis] = spacing[axis]

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
@@ -458,14 +458,6 @@ bool vtkOrientedImageDataResample::ResampleOrientedImageToReferenceGeometry(vtkO
   vtkAbstractTransform* inputImageToReferenceImageTransform = referenceImageToInputImageTransform->GetInverse();
   inputImageToReferenceImageTransform->Update();
 
-  // Determine output origin and spacing using vtkOrientedImageData function
-  vtkSmartPointer<vtkOrientedImageData> utilityImageData = vtkSmartPointer<vtkOrientedImageData>::New();
-  utilityImageData->SetGeometryFromImageToWorldMatrix(referenceToWorldMatrix);
-  double outputOrigin[3] = {0.0, 0.0, 0.0};
-  utilityImageData->GetOrigin(outputOrigin);
-  double outputSpacing[3] = {0.0, 0.0, 0.0};
-  utilityImageData->GetSpacing(outputSpacing);
-
   // Calculate output extent in reference frame. Use all bounding box corners
   int outputExtent[6] = {0,-1,0,-1,0,-1};
   vtkOrientedImageDataResample::TransformExtent(effectiveInputExtent, referenceImageToInputImageTransform.GetPointer(), outputExtent);

--- a/Libs/vtkSegmentationCore/vtkSegmentationConverter.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConverter.h
@@ -55,10 +55,14 @@ public:
 
   /// Default representation types
   /// In binary and fractional labelmaps values <=0 are considered background voxels (outside), values>0 are foreground (inside).
-  static const char* GetSegmentationBinaryLabelmapRepresentationName() { return "Binary labelmap"; };
+  static const char* GetSegmentationBinaryLabelmapRepresentationName()     { return "Binary labelmap"; };
   static const char* GetSegmentationFractionalLabelmapRepresentationName() { return "Fractional labelmap"; };
-  static const char* GetSegmentationPlanarContourRepresentationName() { return "Planar contour"; };
-  static const char* GetSegmentationClosedSurfaceRepresentationName() { return "Closed surface"; };
+  static const char* GetSegmentationPlanarContourRepresentationName()      { return "Planar contour"; };
+  static const char* GetSegmentationClosedSurfaceRepresentationName()      { return "Closed surface"; };
+  static const char* GetBinaryLabelmapRepresentationName()     { return GetSegmentationBinaryLabelmapRepresentationName(); };
+  static const char* GetFractionalLabelmapRepresentationName() { return GetSegmentationFractionalLabelmapRepresentationName(); };
+  static const char* GetPlanarContourRepresentationName()      { return GetSegmentationPlanarContourRepresentationName(); };
+  static const char* GetClosedSurfaceRepresentationName()      { return GetSegmentationClosedSurfaceRepresentationName(); };
 
   // Common conversion parameters
   // ----------------------------

--- a/Modules/Loadable/Segmentations/Logic/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/Logic/CMakeLists.txt
@@ -12,6 +12,8 @@ set(${KIT}_INCLUDE_DIRECTORIES
 set(${KIT}_SRCS
   vtkSlicer${MODULE_NAME}ModuleLogic.cxx
   vtkSlicer${MODULE_NAME}ModuleLogic.h
+  vtkSlicerSegmentationGeometryLogic.cxx
+  vtkSlicerSegmentationGeometryLogic.h
   vtkImageGrowCutSegment.cxx
   vtkImageGrowCutSegment.h
   FibHeap.cxx
@@ -20,6 +22,7 @@ set(${KIT}_SRCS
 set(${KIT}_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleMRML
   vtkSlicerTerminologiesModuleLogic
+  vtkSlicerAnnotationsModuleMRML
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.cxx
@@ -1,0 +1,438 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through CANARIE and the Applied Cancer Research Unit program
+  of Cancer Care Ontario with funds provided by the Ontario Ministry of Health and
+  Long-Term Care
+
+==============================================================================*/
+
+// Segmentations includes
+#include "vtkSlicerSegmentationGeometryLogic.h"
+
+// SegmentationCore includes
+#include "vtkSegmentation.h"
+#include "vtkSegmentationConverter.h"
+#include "vtkOrientedImageDataResample.h"
+#include "vtkCalculateOversamplingFactor.h"
+
+// MRML includes
+#include "vtkMRMLScalarVolumeNode.h"
+#include "vtkMRMLTransformNode.h"
+#include "vtkMRMLAnnotationROINode.h"
+#include "vtkMRMLModelNode.h"
+#include "vtkMRMLNodePropertyMacros.h"
+
+
+// VTK includes
+#include <vtkMatrix4x4.h>
+#include <vtkTransform.h>
+#include <vtkGeneralTransform.h>
+#include <vtkAddonMathUtilities.h>
+
+// STD includes
+#include <sstream>
+
+//----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkSlicerSegmentationGeometryLogic);
+
+//----------------------------------------------------------------------------
+vtkSlicerSegmentationGeometryLogic::vtkSlicerSegmentationGeometryLogic()
+: InputAxisIndexForSourceAxis{ 0, 1, 2 }
+, SourceAxisIndexForInputAxis{ 0, 1, 2 }
+, UserSpacing{ 1.0, 1.0, 1.0 }
+
+{
+  this->InputSegmentationNode = nullptr;
+  this->SourceGeometryNode = nullptr;
+  this->OversamplingFactor = 1.0;
+  this->IsotropicSpacing = false;
+
+  this->OutputGeometryImageData = vtkOrientedImageData::New();
+}
+
+//----------------------------------------------------------------------------
+vtkSlicerSegmentationGeometryLogic::~vtkSlicerSegmentationGeometryLogic()
+{
+  this->SetInputSegmentationNode(NULL);
+
+  if (this->OutputGeometryImageData)
+    {
+    this->OutputGeometryImageData->Delete();
+    this->OutputGeometryImageData = nullptr;
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkSlicerSegmentationGeometryLogic::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintBooleanMacro(IsotropicSpacing);
+  vtkMRMLPrintFloatMacro(OversamplingFactor);
+  vtkMRMLPrintVectorMacro(UserSpacing, double, 3);
+  vtkMRMLPrintVectorMacro(InputAxisIndexForSourceAxis, int, 3);
+  vtkMRMLPrintVectorMacro(SourceAxisIndexForInputAxis, int, 3);
+  vtkMRMLPrintEndMacro();
+
+  if (this->InputSegmentationNode)
+    {
+    os << indent << "InputSegmentationNode: " ;
+    this->InputSegmentationNode->PrintSelf(os, indent.GetNextIndent());
+    }
+
+  if (this->SourceGeometryNode)
+    {
+    os << indent << "SourceGeometryNode: " ;
+    this->SourceGeometryNode->PrintSelf(os, indent.GetNextIndent());
+    }
+
+  os << indent << "OutputGeometryImageData: " ;
+  this->OutputGeometryImageData->PrintSelf(os, indent.GetNextIndent());
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerSegmentationGeometryLogic::SetSourceGeometryNode(vtkMRMLDisplayableNode* node)
+{
+  vtkSetObjectBodyMacro(SourceGeometryNode, vtkMRMLDisplayableNode, node);
+
+  // Calculate axis permutation if necessary
+  if (this->SourceGeometryNode && this->InputSegmentationNode)
+    {
+    this->ComputeSourceAxisIndexForInputAxis();
+    }
+}
+
+//-----------------------------------------------------------------------------
+std::string vtkSlicerSegmentationGeometryLogic::CalculateOutputGeometry()
+{
+  // Reset geometry
+  this->ResetGeometryImageData();
+
+  if (!this->InputSegmentationNode)
+    {
+    return "No input segmentation specified";
+    }
+
+  // Determine source type
+  vtkMRMLScalarVolumeNode* sourceVolumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(this->SourceGeometryNode);
+  vtkMRMLAnnotationROINode* sourceROINode = vtkMRMLAnnotationROINode::SafeDownCast(this->SourceGeometryNode);
+  vtkMRMLModelNode* sourceModelNode = vtkMRMLModelNode::SafeDownCast(this->SourceGeometryNode);
+
+  vtkMRMLSegmentationNode* sourceSegmentationNode = vtkMRMLSegmentationNode::SafeDownCast(this->SourceGeometryNode);
+  vtkSmartPointer<vtkOrientedImageData> sourceBinaryLabelmap;
+  if (this->IsSourceSegmentationWithBinaryLabelmapMaster())
+    {
+    //TODO: Fractional labelmaps cannot be used yet as source, as DetermineCommonLabelmapGeometry only supports binary labelmaps
+    sourceBinaryLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
+    std::string geometryString = sourceSegmentationNode->GetSegmentation()->DetermineCommonLabelmapGeometry();
+    vtkSegmentationConverter::DeserializeImageGeometry(geometryString, sourceBinaryLabelmap, false);
+    }
+
+  //
+  // Source type is volume (volume node or segmentation with non-empty binary labelmap master)
+  //
+  if (sourceVolumeNode || sourceBinaryLabelmap.GetPointer())
+    {
+    // Set initial geometry from source volume
+    vtkNew<vtkMatrix4x4> labelmapIJKToSegmentationMatrix;
+    if (sourceVolumeNode && sourceVolumeNode->GetImageData())
+      {
+      sourceVolumeNode->GetIJKToRASMatrix(labelmapIJKToSegmentationMatrix);
+      this->OutputGeometryImageData->SetExtent(sourceVolumeNode->GetImageData()->GetExtent());
+      }
+    else if (sourceBinaryLabelmap)
+      {
+      sourceBinaryLabelmap->GetImageToWorldMatrix(labelmapIJKToSegmentationMatrix);
+      this->OutputGeometryImageData->SetExtent(sourceBinaryLabelmap->GetExtent());
+      }
+    else
+      {
+      return "Invalid source volume";
+      }
+
+    // Apply parent transforms
+    vtkNew<vtkGeneralTransform> inputSegmentationToSourceTransform;
+    vtkNew<vtkTransform> inputSegmentationToSourceTransformLinear;
+    vtkMRMLTransformNode::GetTransformBetweenNodes(this->InputSegmentationNode->GetParentTransformNode(),
+      this->SourceGeometryNode->GetParentTransformNode(), inputSegmentationToSourceTransform);
+    if (vtkMRMLTransformNode::IsGeneralTransformLinear(inputSegmentationToSourceTransform, inputSegmentationToSourceTransformLinear))
+      {
+      // Transformation between segmentation and source is linear
+      vtkNew<vtkMatrix4x4> labelmapIJKToSourceMatrix;
+      vtkNew<vtkMatrix4x4> inputSegmentationToSourceMatrix;
+      inputSegmentationToSourceTransformLinear->GetMatrix(inputSegmentationToSourceMatrix);
+      vtkMatrix4x4::Multiply4x4(inputSegmentationToSourceMatrix, labelmapIJKToSegmentationMatrix, labelmapIJKToSourceMatrix);
+      this->OutputGeometryImageData->SetImageToWorldMatrix(labelmapIJKToSourceMatrix);
+      }
+    else
+      {
+      vtkWarningMacro("CalculateOutputGeometry: Ignoring parent transforms because non-linear components have been found");
+      this->OutputGeometryImageData->SetImageToWorldMatrix(labelmapIJKToSegmentationMatrix);
+      }
+
+    // Apply optional settings
+    if (this->IsotropicSpacing)
+      {
+      double* spacing = this->OutputGeometryImageData->GetSpacing();
+      double minSpacing = this->OutputGeometryImageData->GetMinSpacing();
+
+      int newExtent[6] = {0,-1,0,-1,0,-1};
+      int extent[6] = {0,-1,0,-1,0,-1};
+      this->OutputGeometryImageData->GetExtent(extent);
+      for (unsigned int axis=0; axis<3; ++axis)
+        {
+        double oversamplingForAxis = spacing[this->SourceAxisIndexForInputAxis[axis]] / minSpacing;
+        int dimension = extent[axis*2+1] - extent[axis*2] + 1;
+        int extentMin = static_cast<int>(ceil(oversamplingForAxis * extent[axis * 2]));
+        int extentMax = extentMin + static_cast<int>(floor(oversamplingForAxis*dimension)) - 1;
+        newExtent[axis*2] = extentMin;
+        newExtent[axis*2+1] = extentMax;
+        }
+      this->OutputGeometryImageData->SetSpacing(minSpacing, minSpacing, minSpacing);
+      this->OutputGeometryImageData->SetExtent(newExtent);
+      }
+
+    if (this->OversamplingFactor != 1.0)
+      {
+      vtkCalculateOversamplingFactor::ApplyOversamplingOnImageGeometry(this->OutputGeometryImageData, this->OversamplingFactor);
+      }
+    }
+  //
+  // Source is ROI, model, or segmentation with poly data master
+  //
+  else
+    {
+    // Get initial spacing
+    double outputSpacing[3] = { 0 };
+    outputSpacing[0] = this->UserSpacing[0];
+    outputSpacing[1] = this->UserSpacing[1];
+    outputSpacing[2] = this->UserSpacing[2];
+
+    // Get source bounds
+    double sourceBounds[6] = {0, -1, 0, -1, 0, -1};
+    this->SourceGeometryNode->GetBounds(sourceBounds);
+
+    // Determine transform between source node and input segmentation
+    vtkNew<vtkGeneralTransform> segmentationToSourceTransform;
+    vtkNew<vtkTransform> segmentationToSourceTransformLinear;
+    vtkMRMLTransformNode::GetTransformBetweenNodes(this->InputSegmentationNode->GetParentTransformNode(),
+      this->SourceGeometryNode->GetParentTransformNode(), segmentationToSourceTransform);
+    vtkNew<vtkMatrix4x4> segmentationToSourceMatrix;
+    if (vtkMRMLTransformNode::IsGeneralTransformLinear(segmentationToSourceTransform, segmentationToSourceTransformLinear))
+      {
+      // Transformation between segmentation and source is linear
+      segmentationToSourceTransformLinear->GetMatrix(segmentationToSourceMatrix);
+      }
+    else
+      {
+      vtkWarningMacro("CalculateOutputGeometry: Ignoring parent transforms because non-linear components have been found");
+      segmentationToSourceMatrix->Identity();
+      }
+
+    // If input segmentation has non-empty binary labelmap master that need to be resampled,
+    // then match the axes of the labelmap to the axes of the transformed source node, and
+    // determine directions and spacing according to that.
+    // In this case, origin is also given by the input segmentation's labelmap
+    if (this->InputSegmentationCanBeResampled())
+      {
+      vtkNew<vtkOrientedImageData> inputBinaryLabelmap;
+      std::string geometryString = this->InputSegmentationNode->GetSegmentation()->DetermineCommonLabelmapGeometry();
+      vtkSegmentationConverter::DeserializeImageGeometry(geometryString, inputBinaryLabelmap, false);
+
+      // Find which labelmap axis corresponds to each source axis, to get the correct spacing value for each source axis
+      vtkNew<vtkMatrix4x4> inputLabelmapIJKToInputSegmentation;
+      inputBinaryLabelmap->GetImageToWorldMatrix(inputLabelmapIJKToInputSegmentation);
+      vtkNew<vtkMatrix4x4> inputLabelmapIJKToSource;
+      vtkMatrix4x4::Multiply4x4(segmentationToSourceMatrix, inputLabelmapIJKToInputSegmentation, inputLabelmapIJKToSource);
+      this->OutputGeometryImageData->SetImageToWorldMatrix(inputLabelmapIJKToSource);
+
+      outputSpacing[0] = this->UserSpacing[this->InputAxisIndexForSourceAxis[0]];
+      outputSpacing[1] = this->UserSpacing[this->InputAxisIndexForSourceAxis[1]];
+      outputSpacing[2] = this->UserSpacing[this->InputAxisIndexForSourceAxis[2]];
+      this->OutputGeometryImageData->SetSpacing(outputSpacing);
+      }
+    else
+      {
+      // Directions according to segmentation to source transformation
+      this->OutputGeometryImageData->SetImageToWorldMatrix(segmentationToSourceMatrix);
+      // Spacing as specified on the UI
+      this->OutputGeometryImageData->SetSpacing(outputSpacing);
+      }
+
+    // Calculate origin according to the bounds
+    const double origin_Source[4] = { sourceBounds[0], sourceBounds[2], sourceBounds[4], 1.0 };
+    vtkNew<vtkMatrix4x4> sourceToSegmentationMatrix;
+    sourceToSegmentationMatrix->DeepCopy(segmentationToSourceMatrix);
+    sourceToSegmentationMatrix->Invert();
+    double origin_Segmentation[4] = { 0.0, 0.0, 0.0, 0.0 };
+    sourceToSegmentationMatrix->MultiplyPoint(origin_Source, origin_Segmentation);
+
+    vtkNew<vtkMatrix4x4> labelmapIJKToSegmentationMatrix;
+    this->OutputGeometryImageData->GetImageToWorldMatrix(labelmapIJKToSegmentationMatrix);
+    const double voxelCenter_IJK[4] = { 0.5, 0.5, 0.5, 1.0 };
+    vtkNew<vtkMatrix4x4> labelmapIJKToSegmentationDirectionMatrix;
+    labelmapIJKToSegmentationDirectionMatrix->DeepCopy(labelmapIJKToSegmentationMatrix);
+    labelmapIJKToSegmentationDirectionMatrix->SetElement(0,3,0.0);
+    labelmapIJKToSegmentationDirectionMatrix->SetElement(1,3,0.0);
+    labelmapIJKToSegmentationDirectionMatrix->SetElement(2,3,0.0);
+    double voxelCenter_Segmentation[4] = { 0.0, 0.0, 0.0, 0.0 };
+    labelmapIJKToSegmentationDirectionMatrix->MultiplyPoint(voxelCenter_IJK, voxelCenter_Segmentation);
+    origin_Segmentation[0] = origin_Segmentation[0] + voxelCenter_Segmentation[0];
+    origin_Segmentation[1] = origin_Segmentation[1] + voxelCenter_Segmentation[1];
+    origin_Segmentation[2] = origin_Segmentation[2] + voxelCenter_Segmentation[2];
+    this->OutputGeometryImageData->SetOrigin(origin_Segmentation);
+
+    // Calculate extent
+    int outputExtent[6] = { 0, -1, 0, -1, 0, -1 };
+    const double farCorner_Source[4] = { sourceBounds[1], sourceBounds[3], sourceBounds[5], 1.0 };
+    double farCorner_Segmentation[4] = { 0.0, 0.0, 0.0, 0.0 };
+    sourceToSegmentationMatrix->MultiplyPoint(farCorner_Source, farCorner_Segmentation);
+    // Add a bit of tolerance in deciding how many voxels the output should contain
+    // to make sure that if the ROI size is set to match the image size exactly then we
+    // output extent contains the whole image
+    double tolerance = 0.001;
+    outputExtent[1] = ceil((farCorner_Segmentation[0] - origin_Segmentation[0]) / outputSpacing[0] + tolerance) - 1;
+    outputExtent[3] = ceil((farCorner_Segmentation[1] - origin_Segmentation[1]) / outputSpacing[1] + tolerance) - 1;
+    outputExtent[5] = ceil((farCorner_Segmentation[2] - origin_Segmentation[2]) / outputSpacing[2] + tolerance) - 1;
+    this->OutputGeometryImageData->SetExtent(outputExtent);
+    }
+
+    return "";
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerSegmentationGeometryLogic::ResetGeometryImageData()
+{
+  vtkNew<vtkMatrix4x4> identityMatrix;
+  identityMatrix->Identity();
+  this->OutputGeometryImageData->SetImageToWorldMatrix(identityMatrix);
+  this->OutputGeometryImageData->SetDimensions(0, 0, 0);
+}
+
+//-----------------------------------------------------------------------------
+bool vtkSlicerSegmentationGeometryLogic::IsSourceSegmentationWithBinaryLabelmapMaster()
+{
+  vtkMRMLSegmentationNode* sourceSegmentationNode = vtkMRMLSegmentationNode::SafeDownCast(this->SourceGeometryNode);
+  std::string binaryLabelmapName = vtkSegmentationConverter::GetBinaryLabelmapRepresentationName();
+  vtkSmartPointer<vtkOrientedImageData> sourceBinaryLabelmap;
+  if ( sourceSegmentationNode
+    && sourceSegmentationNode->GetSegmentation()
+    && sourceSegmentationNode->GetSegmentation()->GetNumberOfSegments() > 0
+    && sourceSegmentationNode->GetSegmentation()->ContainsRepresentation(binaryLabelmapName)
+    && sourceSegmentationNode->GetSegmentation()->GetMasterRepresentationName() == binaryLabelmapName )
+    {
+    return true;
+    }
+
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+bool vtkSlicerSegmentationGeometryLogic::InputSegmentationCanBeResampled()
+{
+  if ( this->InputSegmentationNode != nullptr
+    &&  this->InputSegmentationNode->GetSegmentation()->GetNumberOfSegments() > 0
+    && this->InputSegmentationNode->GetSegmentation()->ContainsRepresentation(
+        vtkSegmentationConverter::GetBinaryLabelmapRepresentationName())
+    && this->InputSegmentationNode->GetSegmentation()->GetMasterRepresentationName()
+        == vtkSegmentationConverter::GetBinaryLabelmapRepresentationName() )
+    {
+    return true;
+    }
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerSegmentationGeometryLogic::ComputeSourceAxisIndexForInputAxis()
+{
+  // Initialize source axis permutation and inverse
+  this->InputAxisIndexForSourceAxis[0] = 0;
+  this->InputAxisIndexForSourceAxis[1] = 1;
+  this->InputAxisIndexForSourceAxis[2] = 2;
+  this->SourceAxisIndexForInputAxis[0] = 0;
+  this->SourceAxisIndexForInputAxis[1] = 1;
+  this->SourceAxisIndexForInputAxis[2] = 2;
+
+  vtkMRMLTransformableNode* transformableSourceNode = vtkMRMLTransformableNode::SafeDownCast(this->SourceGeometryNode);
+  if (!transformableSourceNode || !this->InputSegmentationNode)
+    {
+    vtkErrorMacro("ComputeSourceAxisIndexForInputAxis: Invalid input nodes");
+    return;
+    }
+  if (transformableSourceNode->GetScene() != this->InputSegmentationNode->GetScene())
+    {
+    vtkErrorMacro("ComputeSourceAxisIndexForInputAxis: MRML scene of the given source node and the widget are different, cannot set node");
+    return;
+    }
+
+  // If source is volume type and input segmentation has non-empty binary labelmap master that need to be resampled,
+  // then match the axes of the input labelmap to the axes of the transformed source node.
+  // Use this calculated permutation for updating spacing widget from geometry and interpreting spacing input
+  if ( (transformableSourceNode->IsA("vtkMRMLScalarVolumeNode") || this->IsSourceSegmentationWithBinaryLabelmapMaster())
+    && this->InputSegmentationCanBeResampled() )
+    {
+    // Determine transform between source node and input segmentation
+    vtkNew<vtkGeneralTransform> segmentationToSourceTransform;
+    vtkNew<vtkTransform> segmentationToSourceTransformLinear;
+    vtkMRMLTransformNode::GetTransformBetweenNodes(this->InputSegmentationNode->GetParentTransformNode(),
+      transformableSourceNode->GetParentTransformNode(), segmentationToSourceTransform);
+    vtkNew<vtkMatrix4x4> segmentationToSourceMatrix;
+    if (vtkMRMLTransformNode::IsGeneralTransformLinear(segmentationToSourceTransform, segmentationToSourceTransformLinear))
+      {
+      // Transformation between segmentation and source is linear
+      segmentationToSourceTransformLinear->GetMatrix(segmentationToSourceMatrix);
+      }
+    else
+      {
+      vtkWarningMacro("ComputeSourceAxisIndexForInputAxis: Ignoring parent transforms because non-linear components have been found");
+      segmentationToSourceMatrix->Identity();
+      }
+
+    vtkNew<vtkOrientedImageData> inputBinaryLabelmap;
+    std::string geometryString = this->InputSegmentationNode->GetSegmentation()->DetermineCommonLabelmapGeometry();
+    vtkSegmentationConverter::DeserializeImageGeometry(geometryString, inputBinaryLabelmap, false);
+
+    // Find which labelmap axis corresponds to each source axis, to get the correct spacing value for each source axis
+    vtkNew<vtkMatrix4x4> inputLabelmapIJKToInputSegmentation;
+    inputBinaryLabelmap->GetImageToWorldMatrix(inputLabelmapIJKToInputSegmentation);
+    vtkNew<vtkMatrix4x4> inputLabelmapIJKToSource;
+    vtkMatrix4x4::Multiply4x4(segmentationToSourceMatrix, inputLabelmapIJKToInputSegmentation, inputLabelmapIJKToSource);
+
+    // Find the axis that is best aligned with each source axis
+    double scale[3] = { 1.0 };
+    vtkAddonMathUtilities::NormalizeOrientationMatrixColumns(inputLabelmapIJKToSource, scale);
+    for (int sourceAxisIndex=0; sourceAxisIndex<3; sourceAxisIndex++)
+      {
+      double largestComponentValue = 0.0;
+      for (int labelmapIJKAxisIndex=0; labelmapIJKAxisIndex<3; labelmapIJKAxisIndex++)
+        {
+        double currentComponentValue = fabs(inputLabelmapIJKToSource->GetElement(sourceAxisIndex, labelmapIJKAxisIndex));
+        if (currentComponentValue > largestComponentValue)
+          {
+          largestComponentValue = currentComponentValue;
+          this->InputAxisIndexForSourceAxis[sourceAxisIndex] = labelmapIJKAxisIndex;
+          }
+        }
+      }
+    }
+
+  // Calculate inverse permutation
+  for (int i=0; i<3; ++i)
+    {
+    this->SourceAxisIndexForInputAxis[this->InputAxisIndexForSourceAxis[i]] = i;
+    }
+}

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
@@ -1,0 +1,123 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through CANARIE and the Applied Cancer Research Unit program
+  of Cancer Care Ontario with funds provided by the Ontario Ministry of Health and
+  Long-Term Care
+
+==============================================================================*/
+
+// .NAME vtkSlicerSegmentationGeometryLogic
+// .SECTION Description
+// This class manages the logic associated with converting and handling
+// segmentation node objects.
+
+#ifndef __vtkSlicerSegmentationGeometryLogic_h
+#define __vtkSlicerSegmentationGeometryLogic_h
+
+// Slicer includes
+#include "vtkSlicerSegmentationsModuleLogicExport.h"
+
+// Segmentations includes
+#include "vtkMRMLSegmentationNode.h"
+
+// vtkSegmentationCore includes
+#include "vtkOrientedImageData.h"
+
+/// \ingroup Slicer_QtModules_Segmentations
+class VTK_SLICER_SEGMENTATIONS_LOGIC_EXPORT vtkSlicerSegmentationGeometryLogic : public vtkObject
+{
+public:
+  static vtkSlicerSegmentationGeometryLogic* New();
+  vtkTypeMacro(vtkSlicerSegmentationGeometryLogic, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+
+  /// Calculate output geometry into \sa GeometryImageData with current options
+  /// \return Error message. Empty when successful
+  std::string CalculateOutputGeometry();
+
+  /// Determine if source node is a non-empty segmentation with a labelmap master
+  bool IsSourceSegmentationWithBinaryLabelmapMaster();
+
+  /// Determine if input segmentation is non-empty, and with binary labelmap master
+  bool InputSegmentationCanBeResampled();
+
+  /// Match the axes of the input labelmap to the axes of the transformed source node.
+  /// Use this calculated permutation for updating spacing widget from geometry and interpreting spacing input
+  void ComputeSourceAxisIndexForInputAxis();
+
+  vtkGetObjectMacro(OutputGeometryImageData, vtkOrientedImageData);
+
+  /// Reset geometry image data \sa GeometryImageData
+  void ResetGeometryImageData();
+
+  vtkGetObjectMacro(InputSegmentationNode, vtkMRMLSegmentationNode);
+  vtkSetObjectMacro(InputSegmentationNode, vtkMRMLSegmentationNode);
+
+  vtkGetObjectMacro(SourceGeometryNode, vtkMRMLDisplayableNode);
+  virtual void SetSourceGeometryNode(vtkMRMLDisplayableNode* node);
+
+  vtkGetMacro(IsotropicSpacing, bool);
+  vtkSetMacro(IsotropicSpacing, bool);
+  vtkBooleanMacro(IsotropicSpacing, bool);
+
+  vtkGetMacro(OversamplingFactor, double);
+  vtkSetMacro(OversamplingFactor, double);
+
+  vtkGetVectorMacro(UserSpacing, double, 3);
+  vtkSetVectorMacro(UserSpacing, double, 3);
+
+  vtkGetVectorMacro(InputAxisIndexForSourceAxis, int, 3);
+
+  vtkGetVectorMacro(SourceAxisIndexForInputAxis, int, 3);
+
+protected:
+  vtkSlicerSegmentationGeometryLogic();
+  virtual ~vtkSlicerSegmentationGeometryLogic();
+
+protected:
+  /// Input segmentation MRML node to modify the labelmap geometry of
+  vtkMRMLSegmentationNode* InputSegmentationNode;
+
+  /// MRML node specifying the source geometry
+  vtkMRMLDisplayableNode* SourceGeometryNode;
+
+  /// Flag indicating whether isotropic spacing is requested. Off by default
+  /// Resample the volume so that every voxel is a box. Use smallest spacing. Useful if the volume has elongated voxels.
+  bool IsotropicSpacing;
+
+  /// Oversampling factor:
+  /// Split each voxel of the volume to this many voxels along each direction. Useful when increasing the resolution is needed
+  /// 1 by default.
+  double OversamplingFactor;
+
+  /// Explicitly specified spacing. Only applied if \sa SourceGeometryNode does not contain volume data
+  /// (i.e. not a volume node nor a segmentation node with labelmap master, but an ROI, model, or segmentation with poly data master)
+  double UserSpacing[3];
+
+  /// Oriented image data containing output geometry. This is what the class calculates from the inputs
+  vtkOrientedImageData* OutputGeometryImageData;
+
+  /// Source to input axes mapping \sa matchInputAndSourceAxes
+  int InputAxisIndexForSourceAxis[3];
+  /// Inverse permutation of \sa InputAxisIndexForSourceAxis
+  int SourceAxisIndexForInputAxis[3];
+
+private:
+  vtkSlicerSegmentationGeometryLogic(const vtkSlicerSegmentationGeometryLogic&); // Not implemented
+  void operator=(const vtkSlicerSegmentationGeometryLogic&);               // Not implemented
+};
+
+#endif

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -815,12 +815,12 @@ bool vtkSlicerSegmentationsModuleLogic::ExportSegmentToRepresentationNode(vtkSeg
 bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsToModelHierarchy(vtkMRMLSegmentationNode* segmentationNode,
   std::vector<std::string>& segmentIDs, vtkMRMLModelHierarchyNode* modelHierarchyNode)
 {
-  if (!segmentationNode)
+  if (!segmentationNode || !segmentationNode->GetScene())
     {
     vtkGenericWarningMacro("vtkSlicerSegmentationsModuleLogic::ExportSegmentsToModelHierarchy: Invalid segmentation node");
     return false;
     }
-  if (!modelHierarchyNode)
+  if (!modelHierarchyNode || !modelHierarchyNode->GetScene() || modelHierarchyNode->GetScene() != segmentationNode->GetScene())
     {
     vtkErrorWithObjectMacro(segmentationNode, "ExportSegmentsToModelHierarchy: Invalid model hierarchy node");
     return false;

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -47,7 +47,7 @@ class vtkMRMLModelNode;
 class vtkMRMLModelHierarchyNode;
 class vtkSlicerTerminologiesModuleLogic;
 
-/// \ingroup SlicerRt_QtModules_Segmentations
+/// \ingroup Slicer_QtModules_Segmentations
 class VTK_SLICER_SEGMENTATIONS_LOGIC_EXPORT vtkSlicerSegmentationsModuleLogic :
   public vtkSlicerModuleLogic
 {

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
@@ -25,12 +25,12 @@ class SegmentationWidgetsTest1(unittest.TestCase):
     self.TestSection_00_SetupPathsAndNames()
     self.TestSection_01_GenerateInputData()
     self.TestSection_1_qMRMLSegmentsTableView()
+    self.TestSection_2_qMRMLSegmentationGeometryWidget()
 
     logging.info('Test finished')
 
   #------------------------------------------------------------------------------
   def TestSection_00_SetupPathsAndNames(self):
-
     self.inputSegmentationNode = None
 
   #------------------------------------------------------------------------------
@@ -42,7 +42,6 @@ class SegmentationWidgetsTest1(unittest.TestCase):
     # Create new segments
     import random
     for segmentName in ['first', 'second', 'third']:
-
       sphereSegment = vtkSegmentationCore.vtkSegment()
       sphereSegment.SetName(segmentName)
       sphereSegment.SetColor(random.uniform(0.0,1.0), random.uniform(0.0,1.0), random.uniform(0.0,1.0))
@@ -77,3 +76,217 @@ class SegmentationWidgetsTest1(unittest.TestCase):
     self.assertEqual(len(segmentsTableView.displayedSegmentIDs()), 2)
     slicer.app.processEvents()
     slicer.util.delayDisplay("Hidden 'second'")
+
+  #------------------------------------------------------------------------------
+  def compareOutputGeometry(self, orientedImageData, spacing, origin, directions):
+    if orientedImageData is None:
+      logging.error('Invalid input oriented image data')
+      return False
+    if (not isinstance(spacing, list) and not isinstance(spacing, tuple)) \
+        or (not isinstance(origin, list) and not isinstance(origin, tuple)) \
+        or not isinstance(directions, list):
+      logging.error('Invalid baseline object types - need lists')
+      return False
+    if len(spacing) != 3 or len(origin) != 3 or len(directions) != 3 \
+        or len(directions[0]) != 3 or len(directions[1]) != 3 or len(directions[2]) != 3:
+      logging.error('Baseline lists need to contain 3 elements each, the directions 3 lists of 3')
+      return False
+    import numpy
+    tolerance = 0.0001
+    actualSpacing = orientedImageData.GetSpacing()
+    actualOrigin = orientedImageData.GetOrigin()
+    actualDirections = [[0]*3]*3
+    orientedImageData.GetDirections(actualDirections)
+    for i in [0,1,2]:
+      if not numpy.isclose(spacing[i], actualSpacing[i], tolerance):
+        logging.warning('Spacing discrepancy: ' + str(spacing) + ' != ' + str(actualSpacing))
+        return False
+      if not numpy.isclose(origin[i], actualOrigin[i], tolerance):
+        logging.warning('Origin discrepancy: ' + str(origin) + ' != ' + str(actualOrigin))
+        return False
+      for j in [0,1,2]:
+        if not numpy.isclose(directions[i][j], actualDirections[i][j], tolerance):
+          logging.warning('Directions discrepancy: ' + str(directions) + ' != ' + str(actualDirections))
+          return False
+    return True
+
+  #------------------------------------------------------------------------------
+  def imageDataContainsData(self, imageData):
+    if imageData is None:
+      logging.error('Invalid input image data')
+      return False
+    acc = vtk.vtkImageAccumulate()
+    acc.SetInputData(imageData)
+    acc.SetIgnoreZero(1)
+    acc.Update()
+    if acc.GetVoxelCount() > 0:
+      return True
+    return False
+
+  #------------------------------------------------------------------------------
+  def TestSection_2_qMRMLSegmentationGeometryWidget(self):
+    logging.info('Test section 2: qMRMLSegmentationGeometryWidget')
+
+    import vtkSegmentationCore
+    binaryLabelmapReprName = vtkSegmentationCore.vtkSegmentationConverter.GetBinaryLabelmapRepresentationName()
+    closedSurfaceReprName = vtkSegmentationCore.vtkSegmentationConverter.GetClosedSurfaceRepresentationName()
+
+    # Use MRHead and Tinypatient for testing
+    import SampleData
+    sampleDataLogic = SampleData.SampleDataLogic()
+    mrVolumeNode = sampleDataLogic.downloadMRHead()
+    [tinyVolumeNode, tinySegmentationNode] = sampleDataLogic.downloadSample('TinyPatient')
+
+    # Convert MRHead to oriented image data
+    import vtkSlicerSegmentationsModuleLogicPython as vtkSlicerSegmentationsModuleLogic
+    mrOrientedImageData = vtkSlicerSegmentationsModuleLogic.vtkSlicerSegmentationsModuleLogic.CreateOrientedImageDataFromVolumeNode(mrVolumeNode)
+    mrOrientedImageData.UnRegister(None)
+
+    # Create segmentation node with binary labelmap master and one segment with MRHead geometry
+    segmentationNode = slicer.vtkMRMLSegmentationNode()
+    segmentationNode.GetSegmentation().SetMasterRepresentationName(binaryLabelmapReprName)
+    geometryStr = vtkSegmentationCore.vtkSegmentationConverter.SerializeImageGeometry(mrOrientedImageData)
+    segmentationNode.GetSegmentation().SetConversionParameter(
+      vtkSegmentationCore.vtkSegmentationConverter.GetReferenceImageGeometryParameterName(), geometryStr)
+    slicer.mrmlScene.AddNode(segmentationNode)
+    threshold = vtk.vtkImageThreshold()
+    threshold.SetInputData(mrOrientedImageData)
+    threshold.ThresholdByUpper(16.0)
+    threshold.SetInValue(1)
+    threshold.SetOutValue(0)
+    threshold.SetOutputScalarType(vtk.VTK_UNSIGNED_CHAR)
+    threshold.Update()
+    segmentOrientedImageData = vtkSegmentationCore.vtkOrientedImageData()
+    segmentOrientedImageData.DeepCopy(threshold.GetOutput())
+    mrImageToWorldMatrix = vtk.vtkMatrix4x4()
+    mrOrientedImageData.GetImageToWorldMatrix(mrImageToWorldMatrix)
+    segmentOrientedImageData.SetImageToWorldMatrix(mrImageToWorldMatrix)
+    segment = vtkSegmentationCore.vtkSegment()
+    segment.SetName('Brain')
+    segment.SetColor(0.0,0.0,1.0)
+    segment.AddRepresentation(binaryLabelmapReprName, segmentOrientedImageData)
+    segmentationNode.GetSegmentation().AddSegment(segment)
+
+    # Create geometry widget
+    geometryWidget = slicer.qMRMLSegmentationGeometryWidget()
+    geometryWidget.setSegmentationNode(segmentationNode)
+    geometryWidget.editEnabled = True
+    geometryImageData = vtkSegmentationCore.vtkOrientedImageData() # To contain the output later
+
+    # Volume source with no transforms
+    geometryWidget.setSourceNode(tinyVolumeNode)
+    geometryWidget.geometryImageData(geometryImageData)
+    self.assertTrue(self.compareOutputGeometry(geometryImageData,
+        (49,49,23), (248.8439, 248.2890, -123.75),
+        [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]))
+    slicer.util.delayDisplay('Volume source with no transforms - OK')
+
+    # Transformed volume source
+    translationTransformMatrix = vtk.vtkMatrix4x4()
+    translationTransformMatrix.SetElement(0,3,24.5)
+    translationTransformMatrix.SetElement(1,3,24.5)
+    translationTransformMatrix.SetElement(2,3,11.5)
+    translationTransformNode = slicer.vtkMRMLLinearTransformNode()
+    translationTransformNode.SetName('TestTranslation')
+    slicer.mrmlScene.AddNode(translationTransformNode)
+    translationTransformNode.SetMatrixTransformToParent(translationTransformMatrix)
+
+    tinyVolumeNode.SetAndObserveTransformNodeID(translationTransformNode.GetID())
+    geometryWidget.geometryImageData(geometryImageData)
+    self.assertTrue(self.compareOutputGeometry(geometryImageData,
+        (49,49,23), (224.3439, 223.7890, -135.25),
+        [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]))
+    slicer.util.delayDisplay('Transformed volume source - OK')
+
+    # Volume source with isotropic spacing
+    tinyVolumeNode.SetAndObserveTransformNodeID(None)
+    geometryWidget.setIsotropicSpacing(True)
+    geometryWidget.geometryImageData(geometryImageData)
+    self.assertTrue(self.compareOutputGeometry(geometryImageData,
+        (23,23,23), (248.8439, 248.2890, -123.75),
+        [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]))
+    slicer.util.delayDisplay('Volume source with isotropic spacing - OK')
+
+    # Volume source with oversampling
+    geometryWidget.setIsotropicSpacing(False)
+    geometryWidget.setOversamplingFactor(2.0)
+    geometryWidget.geometryImageData(geometryImageData)
+    self.assertTrue(self.compareOutputGeometry(geometryImageData,
+        (24.5, 24.5, 11.5), (261.0939, 260.5390, -129.5),
+        [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]))
+    slicer.util.delayDisplay('Volume source with oversampling - OK')
+
+    # Segmentation source with binary labelmap master
+    geometryWidget.setOversamplingFactor(1.0)
+    geometryWidget.setSourceNode(tinySegmentationNode)
+    geometryWidget.geometryImageData(geometryImageData)
+    self.assertTrue(self.compareOutputGeometry(geometryImageData,
+        (49,49,23), (248.8439, 248.2890, -123.75),
+        [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]))
+    slicer.util.delayDisplay('Segmentation source with binary labelmap master - OK')
+
+    # Segmentation source with closed surface master
+    tinySegmentationNode.GetSegmentation().SetConversionParameter('Smoothing factor', '0.0')
+    self.assertTrue(tinySegmentationNode.GetSegmentation().CreateRepresentation(closedSurfaceReprName))
+    tinySegmentationNode.GetSegmentation().SetMasterRepresentationName(closedSurfaceReprName)
+    tinySegmentationNode.Modified() # Trigger re-calculation of geometry (only generic Modified event is observed)
+    geometryWidget.geometryImageData(geometryImageData)
+    # Manually resample and check if the output is non-empty
+    # Note: This is done for all poly data based geometry calculations below
+    #TODO: Come up with proper geometry baselines for these too
+    vtkSegmentationCore.vtkOrientedImageDataResample.ResampleOrientedImageToReferenceOrientedImage(
+      segmentOrientedImageData, geometryImageData, geometryImageData, False, True)
+    self.assertTrue(self.imageDataContainsData(geometryImageData))
+    slicer.util.delayDisplay('Segmentation source with closed surface master - OK')
+
+    # Model source with no transform
+    outputModelHierarchy = slicer.vtkMRMLModelHierarchyNode()
+    slicer.mrmlScene.AddNode(outputModelHierarchy)
+    success = vtkSlicerSegmentationsModuleLogic.vtkSlicerSegmentationsModuleLogic.ExportVisibleSegmentsToModelHierarchy(
+      tinySegmentationNode, outputModelHierarchy )
+    self.assertTrue(success)
+    modelNode = slicer.util.getNode('Body_Contour')
+    geometryWidget.setSourceNode(modelNode)
+    geometryWidget.geometryImageData(geometryImageData)
+    vtkSegmentationCore.vtkOrientedImageDataResample.ResampleOrientedImageToReferenceOrientedImage(
+      segmentOrientedImageData, geometryImageData, geometryImageData, False, True)
+    self.assertTrue(self.imageDataContainsData(geometryImageData))
+    slicer.util.delayDisplay('Model source with no transform - OK')
+
+    # Transformed model source
+    rotationTransform = vtk.vtkTransform()
+    rotationTransform.RotateX(45)
+    rotationTransformMatrix = vtk.vtkMatrix4x4()
+    rotationTransform.GetMatrix(rotationTransformMatrix)
+    rotationTransformNode = slicer.vtkMRMLLinearTransformNode()
+    rotationTransformNode.SetName('TestRotation')
+    slicer.mrmlScene.AddNode(rotationTransformNode)
+    rotationTransformNode.SetMatrixTransformToParent(rotationTransformMatrix)
+
+    modelNode.SetAndObserveTransformNodeID(rotationTransformNode.GetID())
+    modelNode.Modified()
+    geometryWidget.geometryImageData(geometryImageData)
+    vtkSegmentationCore.vtkOrientedImageDataResample.ResampleOrientedImageToReferenceOrientedImage(
+      segmentOrientedImageData, geometryImageData, geometryImageData, False, True)
+    self.assertTrue(self.imageDataContainsData(geometryImageData))
+    slicer.util.delayDisplay('Transformed model source - OK')
+
+    # ROI source
+    roiNode = slicer.vtkMRMLAnnotationROINode()
+    roiNode.SetName('SourceROI')
+    slicer.mrmlScene.AddNode(roiNode)
+    roiNode.UnRegister(None)
+    xyz = [0]*3
+    center = [0]*3
+    slicer.vtkMRMLSliceLogic.GetVolumeRASBox(tinyVolumeNode, xyz, center)
+    radius = map(lambda x: x/2.0, xyz)
+    roiNode.SetXYZ(center)
+    roiNode.SetRadiusXYZ(radius)
+    geometryWidget.setSourceNode(roiNode)
+    geometryWidget.geometryImageData(geometryImageData)
+    vtkSegmentationCore.vtkOrientedImageDataResample.ResampleOrientedImageToReferenceOrientedImage(
+      segmentOrientedImageData, geometryImageData, geometryImageData, False, True)
+    self.assertTrue(self.imageDataContainsData(geometryImageData))
+    slicer.util.delayDisplay('ROI source - OK')
+
+    slicer.util.delayDisplay('Segmentation geometry widget test passed')

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
@@ -3,7 +3,7 @@ import unittest
 import vtk, qt, ctk, slicer
 import logging
 
-import vtkSegmentationCorePython as vtkSegmentationCore
+import vtkSegmentationCore
 
 class SegmentationsModuleTest1(unittest.TestCase):
   def setUp(self):

--- a/Modules/Loadable/Segmentations/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/Widgets/CMakeLists.txt
@@ -24,8 +24,12 @@ set(${KIT}_SRCS
   qMRMLSegmentationDisplayNodeWidget.h
   qMRMLSegmentationFileExportWidget.cxx
   qMRMLSegmentationFileExportWidget.h
-  qMRMLDoubleSpinBoxDelegate.cxx
+  qMRMLSegmentationGeometryWidget.cxx
+  qMRMLSegmentationGeometryWidget.h
+  qMRMLSegmentationGeometryDialog.cxx
+  qMRMLSegmentationGeometryDialog.h
   qMRMLDoubleSpinBoxDelegate.h
+  qMRMLDoubleSpinBoxDelegate.cxx
   )
 
 set(${KIT}_MOC_SRCS
@@ -35,6 +39,8 @@ set(${KIT}_MOC_SRCS
   qMRMLSegmentEditorWidget.h
   qMRMLSegmentationDisplayNodeWidget.h
   qMRMLSegmentationFileExportWidget.h
+  qMRMLSegmentationGeometryWidget.h
+  qMRMLSegmentationGeometryDialog.h
   qMRMLDoubleSpinBoxDelegate.h
 )
 
@@ -45,6 +51,7 @@ set(${KIT}_UI_SRCS
   Resources/UI/qMRMLSegmentEditorWidget.ui
   Resources/UI/qMRMLSegmentationDisplayNodeWidget.ui
   Resources/UI/qMRMLSegmentationFileExportWidget.ui
+  Resources/UI/qMRMLSegmentationGeometryWidget.ui
   )
 
 set(${KIT}_RESOURCES

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
@@ -38,26 +38,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="SegmentationNodeLabel">
-       <property name="text">
-        <string>Segmentation:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="qMRMLNodeComboBox" name="SegmentationNodeComboBox">
-       <property name="nodeTypes">
-        <stringlist>
-         <string>vtkMRMLSegmentationNode</string>
-        </stringlist>
-       </property>
-       <property name="renameEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1" colspan="2">
+     <item row="1" column="1">
       <widget class="qMRMLNodeComboBox" name="MasterVolumeNodeComboBox">
        <property name="nodeTypes">
         <stringlist>
@@ -83,19 +64,56 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QToolButton" name="SliceRotateWarningButton">
-       <property name="toolTip">
-        <string>Slice views orientation are not aligned with segmentation. Striping artifacts may appear. Click to align slice views to segmentation.</string>
-       </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="SegmentationNodeLabel">
        <property name="text">
-        <string>Slice rotated</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../qSlicerSegmentationsModuleWidgets.qrc">
-         <normaloff>:/Icons/SlicerRotateWarning.png</normaloff>:/Icons/SlicerRotateWarning.png</iconset>
+        <string>Segmentation:</string>
        </property>
       </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QToolButton" name="SpecifyGeometryButton">
+       <property name="toolTip">
+        <string>Specify geometry (or grid) of the edited labelmap volume</string>
+       </property>
+       <property name="text">
+        <string>Specify geometry of the edited labelmap volume</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../Annotations/Resources/qSlicerAnnotationModule.qrc">
+         <normaloff>:/Icons/AnnotationROI.png</normaloff>:/Icons/AnnotationROI.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1" colspan="2">
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item>
+        <widget class="qMRMLNodeComboBox" name="SegmentationNodeComboBox">
+         <property name="nodeTypes">
+          <stringlist>
+           <string>vtkMRMLSegmentationNode</string>
+          </stringlist>
+         </property>
+         <property name="renameEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="SliceRotateWarningButton">
+         <property name="toolTip">
+          <string>Slice views orientation are not aligned with segmentation. Striping artifacts may appear. Click to align slice views to segmentation.</string>
+         </property>
+         <property name="text">
+          <string>Slice rotated</string>
+         </property>
+         <property name="icon">
+          <iconset resource="../qSlicerSegmentationsModuleWidgets.qrc">
+           <normaloff>:/Icons/SlicerRotateWarning.png</normaloff>:/Icons/SlicerRotateWarning.png</iconset>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
@@ -519,6 +537,7 @@
  </customwidgets>
  <resources>
   <include location="../qSlicerSegmentationsModuleWidgets.qrc"/>
+  <include location="../../../../Annotations/Resources/qSlicerAnnotationModule.qrc"/>
   <include location="../../../Resources/qSlicerSegmentationsModule.qrc"/>
   <include location="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc"/>
  </resources>
@@ -578,12 +597,12 @@
    <slot>setVisible(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>374</x>
-     <y>454</y>
+     <x>400</x>
+     <y>362</y>
     </hint>
     <hint type="destinationlabel">
-     <x>179</x>
-     <y>506</y>
+     <x>184</x>
+     <y>388</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationGeometryWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationGeometryWidget.ui
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qMRMLSegmentationGeometryWidget</class>
+ <widget class="qMRMLWidget" name="qMRMLSegmentationGeometryWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>490</width>
+    <height>317</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>SegmentationGeometryWidget</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>9</number>
+   </property>
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="frame_SourceGeometry">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>9</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_SourceGeometryNode">
+        <property name="text">
+         <string>Source geometry:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_SourceGeometryNode">
+        <property name="nodeTypes">
+         <stringlist>
+          <string>vtkMRMLScalarVolumeNode</string>
+          <string>vtkMRMLSegmentationNode</string>
+          <string>vtkMRMLModelNode</string>
+          <string>vtkMRMLAnnotationROINode</string>
+         </stringlist>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="noneDisplay">
+         <string>Showing current segmentation labelmap geometry. Click here to change</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QGroupBox" name="groupBox_VolumeSpacingOptions">
+        <property name="title">
+         <string>Volume spacing options</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <property name="leftMargin">
+          <number>4</number>
+         </property>
+         <property name="topMargin">
+          <number>6</number>
+         </property>
+         <property name="rightMargin">
+          <number>4</number>
+         </property>
+         <property name="bottomMargin">
+          <number>4</number>
+         </property>
+         <property name="horizontalSpacing">
+          <number>4</number>
+         </property>
+         <property name="verticalSpacing">
+          <number>6</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_OversamplingFactor">
+           <property name="toolTip">
+            <string>Split each voxel of the volume to this many voxels along each direction. Useful when increasing the resolution is needed</string>
+           </property>
+           <property name="text">
+            <string>Oversampling factor:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="ctkDoubleSpinBox" name="DoubleSpinBox_OversamplingFactor">
+           <property name="toolTip">
+            <string>Split each voxel of the volume to this many voxels along each direction. Useful when increasing the resolution is needed</string>
+           </property>
+           <property name="minimum">
+            <double>0.050000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_IsotropicSpacing">
+           <property name="toolTip">
+            <string>Resample the volume so that every voxel is a box. Use smallest spacing. Useful if the volume has elongated voxels.</string>
+           </property>
+           <property name="text">
+            <string>Isotropic spacing:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="checkBox_IsotropicSpacing">
+           <property name="toolTip">
+            <string>Resample the volume so that every voxel is a box. Use smallest spacing. Useful if the volume has elongated voxels.</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_SegmentationLabelmapGeometry">
+     <property name="title">
+      <string>Segmentation labelmap geometry</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <property name="horizontalSpacing">
+       <number>4</number>
+      </property>
+      <property name="verticalSpacing">
+       <number>6</number>
+      </property>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_Directions">
+        <property name="text">
+         <string>Directions:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_Origin">
+        <property name="text">
+         <string>Origin:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_Spacing">
+        <property name="text">
+         <string>Spacing:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="ctkMatrixWidget" name="MatrixWidget_Directions">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="columnCount">
+         <number>3</number>
+        </property>
+        <property name="rowCount">
+         <number>3</number>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="qMRMLCoordinatesWidget" name="MRMLCoordinatesWidget_Origin">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="quantity">
+         <string>length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_Dimensions">
+        <property name="text">
+         <string>Dimensions:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="qMRMLCoordinatesWidget" name="MRMLCoordinatesWidget_Spacing">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="quantity">
+         <string>length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLCoordinatesWidget" name="MRMLCoordinatesWidget_Dimensions">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
+       <widget class="QLabel" name="label_Error">
+        <property name="palette">
+         <palette>
+          <active>
+           <colorrole role="WindowText">
+            <brush brushstyle="SolidPattern">
+             <color alpha="255">
+              <red>255</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </brush>
+           </colorrole>
+          </active>
+          <inactive>
+           <colorrole role="WindowText">
+            <brush brushstyle="SolidPattern">
+             <color alpha="255">
+              <red>255</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </brush>
+           </colorrole>
+          </inactive>
+          <disabled>
+           <colorrole role="WindowText">
+            <brush brushstyle="SolidPattern">
+             <color alpha="255">
+              <red>120</red>
+              <green>120</green>
+              <blue>120</blue>
+             </color>
+            </brush>
+           </colorrole>
+          </disabled>
+         </palette>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string>Error message</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLCoordinatesWidget</class>
+   <extends>ctkCoordinatesWidget</extends>
+   <header>qMRMLCoordinatesWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkCoordinatesWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkCoordinatesWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkDoubleSpinBox</class>
+   <extends>QWidget</extends>
+   <header>ctkDoubleSpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkMatrixWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkMatrixWidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>qMRMLSegmentationGeometryWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>MRMLNodeComboBox_SourceGeometryNode</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>103</x>
+     <y>3</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>297</x>
+     <y>28</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qMRMLSegmentationGeometryWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>MRMLCoordinatesWidget_Dimensions</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>436</x>
+     <y>3</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>364</x>
+     <y>203</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qMRMLSegmentationGeometryWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>MRMLCoordinatesWidget_Spacing</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>479</x>
+     <y>5</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>481</x>
+     <y>251</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qMRMLSegmentationGeometryWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>MRMLCoordinatesWidget_Origin</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>556</x>
+     <y>7</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>543</x>
+     <y>291</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -28,6 +28,9 @@
 #include "vtkMRMLSegmentationNode.h"
 #include "vtkMRMLSegmentationDisplayNode.h"
 #include "vtkMRMLSegmentEditorNode.h"
+#include "qMRMLSegmentationGeometryDialog.h"
+
+// vtkSegmentationCore Includes
 #include "vtkSegmentation.h"
 #include "vtkSegmentationHistory.h"
 #include "vtkSegment.h"
@@ -355,6 +358,11 @@ void qMRMLSegmentEditorWidgetPrivate::init()
   Q_Q(qMRMLSegmentEditorWidget);
   this->setupUi(q);
 
+  this->SliceRotateWarningButton->setMaximumHeight(this->SegmentationNodeComboBox->sizeHint().height());
+  this->SliceRotateWarningButton->setMaximumWidth(this->SegmentationNodeComboBox->sizeHint().height());
+  this->SpecifyGeometryButton->setMaximumHeight(this->MasterVolumeNodeComboBox->sizeHint().height());
+  this->SpecifyGeometryButton->setMaximumWidth(this->MasterVolumeNodeComboBox->sizeHint().height());
+
   this->MaskModeComboBox->addItem(QObject::tr("Everywhere"), vtkMRMLSegmentEditorNode::PaintAllowedEverywhere);
   this->MaskModeComboBox->addItem(QObject::tr("Inside all segments"), vtkMRMLSegmentEditorNode::PaintAllowedInsideAllSegments);
   this->MaskModeComboBox->addItem(QObject::tr("Inside all visible segments"), vtkMRMLSegmentEditorNode::PaintAllowedInsideVisibleSegments);
@@ -393,6 +401,8 @@ void qMRMLSegmentEditorWidgetPrivate::init()
     q, SLOT(rotateSliceViewsToSegmentation()));
   QObject::connect( this->MasterVolumeNodeComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
     q, SLOT(onMasterVolumeNodeChanged(vtkMRMLNode*)) );
+  QObject::connect( this->SpecifyGeometryButton, SIGNAL(clicked()),
+    q, SLOT(showSegmentationGeometryDialog()));
   QObject::connect( this->SegmentsTableView, SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
     q, SLOT(onSegmentSelectionChanged(QItemSelection,QItemSelection)) );
   QObject::connect( this->SegmentsTableView, SIGNAL(segmentAboutToBeModified(QString)),
@@ -1391,6 +1401,7 @@ void qMRMLSegmentEditorWidget::updateWidgetFromSegmentationNode()
     qvtkReconnect(d->SegmentationNode, segmentationNode, vtkSegmentation::SegmentRemoved, this, SLOT(onSegmentAddedRemoved()));
     qvtkReconnect(d->SegmentationNode, segmentationNode, vtkSegmentation::SegmentModified, this, SLOT(updateMaskingSection()));
     qvtkReconnect(d->SegmentationNode, segmentationNode, vtkMRMLDisplayableNode::DisplayModifiedEvent, this, SLOT(onSegmentationDisplayModified()));
+    qvtkReconnect(d->SegmentationNode, segmentationNode, vtkSegmentation::MasterRepresentationModified, this, SLOT(updateSliceRotateWarningButtonVisibility()));
     d->SegmentationNode = segmentationNode;
 
     bool wasBlocked = d->SegmentationNodeComboBox->blockSignals(true);
@@ -3523,4 +3534,20 @@ void qMRMLSegmentEditorWidget::rotateSliceViewsToSegmentation()
     sliceNode->RotateToAxes(segmentationIJKToRAS.GetPointer());
     }
   this->updateSliceRotateWarningButtonVisibility();
+}
+
+//---------------------------------------------------------------------------
+void qMRMLSegmentEditorWidget::showSegmentationGeometryDialog()
+{
+  Q_D(qMRMLSegmentEditorWidget);
+  if (!d->SegmentationNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Invalid segmentation node";
+    return;
+    }
+
+  qMRMLSegmentationGeometryDialog geometryDialog(d->SegmentationNode, this);
+  geometryDialog.setEditEnabled(true);
+  geometryDialog.setResampleLabelmaps(true);
+  bool result = geometryDialog.exec();
 }

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
@@ -50,7 +50,7 @@ class qSlicerSegmentEditorAbstractEffect;
 class qSlicerAbstractModuleWidget;
 
 /// \brief Qt widget for editing a segment from a segmentation using Editor effects.
-/// \ingroup SlicerRt_QtModules_Segmentations_Widgets
+/// \ingroup Slicer_QtModules_Segmentations_Widgets
 ///
 /// Widget for editing segmentations that can be re-used in any module.
 ///
@@ -368,8 +368,11 @@ protected slots:
   /// Update masking section on the UI
   void updateMaskingSection();
 
-  /// Shows slice rotation warning button if slice views are rotated, hide otherwise
+  /// Show slice rotation warning button if slice views are rotated, hide otherwise
   void updateSliceRotateWarningButtonVisibility();
+
+  /// Show segmentation geometry dialog to specify labelmap geometry
+  void showSegmentationGeometryDialog();
 
 protected:
   /// Callback function invoked when interaction happens

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationConversionParametersWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationConversionParametersWidget.h
@@ -66,9 +66,6 @@ public:
   /// Return chosen conversion parameters
   vtkSegmentationConverterRule::ConversionParameterListType conversionParameters();
 
-  /// Set reference image geometry conversion parameter from the selected volume node \sa onGetReferenceImageGeometryFromVolumeClicked
-  void setReferenceImageGeometryParameterFromVolumeNode(vtkMRMLNode* node);
-
 signals:
   /// Emitted when conversion is done
   void conversionDone();
@@ -90,10 +87,9 @@ protected slots:
   /// Handle editing of generic conversation parameters
   void onParameterChanged(QTableWidgetItem* changedItem);
 
-  /// Handles button click for setting reference image geometry from volume node.
+  /// Show segmentation geometry dialog to specify reference image geometry
   /// The button appears in the row of the reference image geometry conversion parameter, which is a special case.
-  /// Pops up a dialog in which the user can select a volume node. The geometry is set when apply is clicked, sa setReferenceImageGeometryParameterFromVolumeNode
-  void onSetReferenceImageGeometryFromVolumeClicked();
+  void onSpecifyGeometryButtonClicked();
 
   /// Create selected representation
   void applyConversion();

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationDisplayNodeWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationDisplayNodeWidget.h
@@ -40,7 +40,7 @@ class QItemSelection;
 
 /// \brief Qt widget for selecting a single segment from a segmentation.
 ///   If multiple segments are needed, then use \sa qMRMLSegmentsTableView instead in SimpleListMode
-/// \ingroup SlicerRt_QtModules_Segmentations_Widgets
+/// \ingroup Slicer_QtModules_Segmentations_Widgets
 class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_EXPORT qMRMLSegmentationDisplayNodeWidget : public qMRMLWidget
 {
   Q_OBJECT

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.h
@@ -41,7 +41,7 @@ class QItemSelection;
 
 /// \brief Qt widget for selecting a single segment from a segmentation.
 ///   If multiple segments are needed, then use \sa qMRMLSegmentsTableView instead in SimpleListMode
-/// \ingroup SlicerRt_QtModules_Segmentations_Widgets
+/// \ingroup Slicer_QtModules_Segmentations_Widgets
 class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_EXPORT qMRMLSegmentationFileExportWidget : public qMRMLWidget
 {
   Q_OBJECT

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryDialog.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryDialog.cxx
@@ -1,0 +1,183 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and CANARIE.
+
+==============================================================================*/
+// Segmentations includes
+#include "qMRMLSegmentationGeometryDialog.h"
+
+#include "vtkMRMLSegmentationNode.h"
+
+// Qt includes
+#include <QDialog>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QDebug>
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_Segmentations_Widgets
+class qMRMLSegmentationGeometryDialogPrivate : public QDialog
+{
+  Q_DECLARE_PUBLIC(qMRMLSegmentationGeometryDialog);
+protected:
+  qMRMLSegmentationGeometryDialog* const q_ptr;
+public:
+  qMRMLSegmentationGeometryDialogPrivate(qMRMLSegmentationGeometryDialog& object);
+  virtual ~qMRMLSegmentationGeometryDialogPrivate();
+public:
+  void init();
+private:
+  vtkMRMLSegmentationNode* SegmentationNode;
+  bool ResampleLabelmaps;
+
+  qMRMLSegmentationGeometryWidget* GeometryWidget;
+  QPushButton* OKButton;
+  QPushButton* CancelButton;
+};
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationGeometryDialogPrivate::qMRMLSegmentationGeometryDialogPrivate(qMRMLSegmentationGeometryDialog& object)
+  : q_ptr(&object)
+  , ResampleLabelmaps(false)
+{
+}
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationGeometryDialogPrivate::~qMRMLSegmentationGeometryDialogPrivate()
+{
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryDialogPrivate::init()
+{
+  Q_Q(qMRMLSegmentationGeometryDialog);
+
+  // Set up UI
+  this->setWindowTitle("Segmentation geometry");
+
+  QVBoxLayout* layout = new QVBoxLayout(this);
+  layout->setSpacing(4);
+  layout->setContentsMargins(4, 4, 4, 6);
+
+  this->GeometryWidget = new qMRMLSegmentationGeometryWidget();
+  this->GeometryWidget->setSegmentationNode(this->SegmentationNode);
+  layout->addWidget(this->GeometryWidget);
+
+  //layout->addStretch(1);
+
+  QHBoxLayout* buttonsLayout = new QHBoxLayout();
+  buttonsLayout->setSpacing(4);
+  buttonsLayout->setContentsMargins(4, 0, 4, 0);
+
+  this->OKButton = new QPushButton("OK");
+  buttonsLayout->addWidget(this->OKButton);
+
+  this->CancelButton = new QPushButton("Cancel");
+  buttonsLayout->addWidget(this->CancelButton);
+  this->CancelButton->setVisible(this->GeometryWidget->editEnabled());
+
+  layout->addLayout(buttonsLayout);
+
+  // Make connections
+  connect(this->OKButton, SIGNAL(clicked()), this, SLOT(accept()));
+  connect(this->CancelButton, SIGNAL(clicked()), this, SLOT(reject()));
+}
+
+//-----------------------------------------------------------------------------
+// qMRMLSegmentationGeometryDialog methods
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationGeometryDialog::qMRMLSegmentationGeometryDialog(vtkMRMLSegmentationNode* segmentationNode, QObject* parent)
+  : QObject(parent)
+  , d_ptr(new qMRMLSegmentationGeometryDialogPrivate(*this))
+{
+  Q_D(qMRMLSegmentationGeometryDialog);
+  d->SegmentationNode = segmentationNode;
+
+  d->init();
+}
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationGeometryDialog::~qMRMLSegmentationGeometryDialog()
+{
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationGeometryDialog::editEnabled()const
+{
+  Q_D(const qMRMLSegmentationGeometryDialog);
+  return d->GeometryWidget->editEnabled();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryDialog::setEditEnabled(bool aEditEnabled)
+{
+  Q_D(qMRMLSegmentationGeometryDialog);
+  d->GeometryWidget->setEditEnabled(aEditEnabled);
+  d->CancelButton->setVisible(aEditEnabled);
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationGeometryDialog::resampleLabelmaps()const
+{
+  Q_D(const qMRMLSegmentationGeometryDialog);
+  return d->ResampleLabelmaps;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryDialog::setResampleLabelmaps(bool aResampleLabelmaps)
+{
+  Q_D(qMRMLSegmentationGeometryDialog);
+  d->ResampleLabelmaps = aResampleLabelmaps;
+  if (aResampleLabelmaps)
+    {
+    d->OKButton->setToolTip("Set reference image geometry and resample all segment labelmaps");
+    }
+  else
+    {
+    d->OKButton->setToolTip("Set reference image geometry (do not resample)");
+    }
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationGeometryDialog::exec()
+{
+  Q_D(qMRMLSegmentationGeometryDialog);
+
+  // Initialize dialog
+  d->GeometryWidget->setSegmentationNode(d->SegmentationNode);
+
+  // Show dialog
+  bool result = false;
+  if (d->exec() != QDialog::Accepted)
+    {
+    return result;
+    }
+
+  // Apply geometry after clean exit
+  if (d->GeometryWidget->editEnabled())
+    {
+    d->GeometryWidget->setReferenceImageGeometryForSegmentationNode();
+    if (d->ResampleLabelmaps)
+      {
+      d->GeometryWidget->resampleLabelmapsInSegmentationNode();
+      }
+    }
+  return true;
+}

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryDialog.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryDialog.h
@@ -1,0 +1,81 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and CANARIE.
+
+==============================================================================*/
+
+#ifndef __qMRMLSegmentationGeometryDialog_h
+#define __qMRMLSegmentationGeometryDialog_h
+
+// Qt includes
+#include <QObject>
+
+// Segmentations includes
+#include "qSlicerSegmentationsModuleWidgetsExport.h"
+
+#include "qMRMLSegmentationGeometryWidget.h"
+
+class vtkMRMLSegmentationNode;
+class qMRMLSegmentationGeometryDialogPrivate;
+
+/// \brief Qt dialog for changing segmentation labelmap geometry
+/// \ingroup Slicer_QtModules_Segmentations_Widgets
+class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_EXPORT qMRMLSegmentationGeometryDialog : public QObject
+{
+public:
+  Q_OBJECT
+
+  /// Controls for editing (source geometry selector and spacing options box) only appear if editing is enabled
+  /// Off by default
+  Q_PROPERTY(bool editEnabled READ editEnabled WRITE setEditEnabled)
+  /// If turned on, the existing labelmaps in the segmentation are resampled in addition to setting reference
+  /// image geometry conversion parameter
+  /// Otherwise only the reference image geometry parameter is set
+  /// Off by default
+  Q_PROPERTY(bool resampleLabelmaps READ resampleLabelmaps WRITE setResampleLabelmaps)
+
+public:
+  typedef QObject Superclass;
+  qMRMLSegmentationGeometryDialog(vtkMRMLSegmentationNode* segmentationNode, QObject* parent=NULL);
+  virtual ~qMRMLSegmentationGeometryDialog();
+
+public:
+  /// Show dialog
+  /// \param nodeToSelect Node is selected in the tree if given
+  /// \return Success flag (if dialog result is not Accepted then false)
+  virtual bool exec();
+
+  /// Python compatibility function for showing dialog (calls \a exec)
+  Q_INVOKABLE bool execDialog() { return this->exec(); };
+
+  bool editEnabled()const;
+  bool resampleLabelmaps()const;
+
+public slots:
+  void setEditEnabled(bool aEditEnabled);
+  void setResampleLabelmaps(bool aResampleLabelmaps);
+
+protected:
+  QScopedPointer<qMRMLSegmentationGeometryDialogPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qMRMLSegmentationGeometryDialog);
+  Q_DISABLE_COPY(qMRMLSegmentationGeometryDialog);
+};
+
+#endif

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryWidget.cxx
@@ -1,0 +1,493 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and CANARIE.
+
+==============================================================================*/
+
+// Segmentations includes
+#include "qMRMLSegmentationGeometryWidget.h"
+
+#include "ui_qMRMLSegmentationGeometryWidget.h"
+
+#include "vtkSlicerSegmentationGeometryLogic.h"
+#include "vtkMRMLSegmentationNode.h"
+
+// SegmentationCore includes
+#include "vtkSegmentation.h"
+#include "vtkSegmentationConverter.h"
+#include "vtkOrientedImageData.h"
+#include "vtkOrientedImageDataResample.h"
+#include "vtkCalculateOversamplingFactor.h"
+
+// MRML includes
+#include "vtkMRMLScalarVolumeNode.h"
+#include "vtkMRMLTransformNode.h"
+#include "vtkMRMLAnnotationROINode.h"
+#include "vtkMRMLModelNode.h"
+
+// VTK includes
+#include <vtkWeakPointer.h>
+#include <vtkMatrix4x4.h>
+#include <vtkTransform.h>
+#include <vtkGeneralTransform.h>
+#include <vtkAddonMathUtilities.h>
+
+// Qt includes
+#include <QDebug>
+
+//-----------------------------------------------------------------------------
+class qMRMLSegmentationGeometryWidgetPrivate: public Ui_qMRMLSegmentationGeometryWidget
+{
+  Q_DECLARE_PUBLIC(qMRMLSegmentationGeometryWidget);
+
+protected:
+  qMRMLSegmentationGeometryWidget* const q_ptr;
+public:
+  qMRMLSegmentationGeometryWidgetPrivate(qMRMLSegmentationGeometryWidget& object);
+  virtual ~qMRMLSegmentationGeometryWidgetPrivate();
+  void init();
+
+  /// Fill geometry info section from geometry image data containing geometry information \sa GeometryImageData
+  void updateGeometryWidgets();
+
+public:
+  /// Segmentation MRML node
+  vtkWeakPointer<vtkMRMLSegmentationNode> SegmentationNode;
+
+  /// Segmentation geometry logic
+  vtkSlicerSegmentationGeometryLogic* Logic;
+
+  /// Flag indicating whether editing is enabled in the widget
+  bool EditEnabled;
+};
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationGeometryWidgetPrivate::qMRMLSegmentationGeometryWidgetPrivate(qMRMLSegmentationGeometryWidget& object)
+  : q_ptr(&object)
+  , EditEnabled(false)
+{
+  this->Logic = vtkSlicerSegmentationGeometryLogic::New();
+}
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationGeometryWidgetPrivate::~qMRMLSegmentationGeometryWidgetPrivate()
+{
+  if (this->Logic)
+    {
+    this->Logic->Delete();
+    this->Logic = nullptr;
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidgetPrivate::init()
+{
+  Q_Q(qMRMLSegmentationGeometryWidget);
+  this->setupUi(q);
+
+  // Make connections
+  QObject::connect(this->MRMLNodeComboBox_SourceGeometryNode, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+    q, SLOT(onSourceNodeChanged(vtkMRMLNode*)) );
+  QObject::connect(this->DoubleSpinBox_OversamplingFactor, SIGNAL(valueChanged(double)),
+    q, SLOT(onOversamplingFactorChanged(double)) );
+  QObject::connect(this->checkBox_IsotropicSpacing, SIGNAL(toggled(bool)),
+    q, SLOT(onIsotropicSpacingChanged(bool)) );
+  QObject::connect(this->MRMLCoordinatesWidget_Spacing, SIGNAL(coordinatesChanged(double*)),
+    q, SLOT(onUserSpacingChanged(double*)) );
+
+  q->setEnabled(this->SegmentationNode.GetPointer());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidgetPrivate::updateGeometryWidgets()
+{
+  vtkOrientedImageData* geometryImageData = this->Logic->GetOutputGeometryImageData();
+  if (!geometryImageData)
+    {
+    qCritical() << Q_FUNC_INFO << ": Invalid geometry image data";
+    return;
+    }
+
+  int dims[3] = { 0 };
+  geometryImageData->GetDimensions(dims);
+  double dimsDouble[3] = { (double)dims[0], (double)dims[1], (double)dims[2] };
+  this->MRMLCoordinatesWidget_Dimensions->setCoordinates(dimsDouble);
+
+  // Apply inverse source axis permutation
+  int sourceAxisIndexForInputAxis[3] = { 0 };
+  this->Logic->GetSourceAxisIndexForInputAxis(sourceAxisIndexForInputAxis);
+  double spacing[3] = { 0.0 };
+  geometryImageData->GetSpacing(spacing);
+  double outputSpacing[3]  = {
+    spacing[sourceAxisIndexForInputAxis[0]],
+    spacing[sourceAxisIndexForInputAxis[1]],
+    spacing[sourceAxisIndexForInputAxis[2]] };
+
+  bool blocked = this->MRMLCoordinatesWidget_Spacing->blockSignals(true);
+  this->MRMLCoordinatesWidget_Spacing->setCoordinates(outputSpacing);
+  this->MRMLCoordinatesWidget_Spacing->blockSignals(blocked);
+
+  double origin[3] = { 0.0 };
+  geometryImageData->GetOrigin(origin);
+  this->MRMLCoordinatesWidget_Origin->setCoordinates(origin);
+
+  vtkNew<vtkMatrix4x4> directions;
+  geometryImageData->GetDirectionMatrix(directions);
+  for (int i=0; i<3; ++i)
+    {
+    for (int j=0; j<3; ++j)
+      {
+      this->MatrixWidget_Directions->setValue(i, j, directions->GetElement(i,j));
+      }
+    }
+}
+
+
+//-----------------------------------------------------------------------------
+// qMRMLSegmentationGeometryWidget methods
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationGeometryWidget::qMRMLSegmentationGeometryWidget(QWidget* _parent)
+  : qMRMLWidget(_parent)
+  , d_ptr(new qMRMLSegmentationGeometryWidgetPrivate(*this))
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+  d->init();
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationGeometryWidget::~qMRMLSegmentationGeometryWidget()
+{
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLSegmentationNode* qMRMLSegmentationGeometryWidget::segmentationNode()const
+{
+  Q_D(const qMRMLSegmentationGeometryWidget);
+  return d->SegmentationNode;
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSegmentationGeometryWidget::segmentationNodeID()const
+{
+  Q_D(const qMRMLSegmentationGeometryWidget);
+  return (d->SegmentationNode.GetPointer() ? d->SegmentationNode->GetID() : QString());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::setSegmentationNode(vtkMRMLSegmentationNode* node)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+
+  if (d->SegmentationNode == node)
+    {
+    return;
+    }
+
+  if (node)
+    {
+    this->setMRMLScene(node->GetScene());
+    }
+
+  qvtkReconnect(d->SegmentationNode, node, vtkCommand::ModifiedEvent, this, SLOT(updateWidgetFromMRML()));
+
+  vtkMRMLSegmentationNode* segmentationNode = vtkMRMLSegmentationNode::SafeDownCast(node);
+  d->SegmentationNode = segmentationNode;
+
+  d->Logic->SetInputSegmentationNode(segmentationNode);
+
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationGeometryWidget::editEnabled()const
+{
+  Q_D(const qMRMLSegmentationGeometryWidget);
+  return d->EditEnabled;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::setEditEnabled(bool aEditEnabled)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+  d->EditEnabled = aEditEnabled;
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLNode* qMRMLSegmentationGeometryWidget::sourceNode()const
+{
+  Q_D(const qMRMLSegmentationGeometryWidget);
+  return d->MRMLNodeComboBox_SourceGeometryNode->currentNode();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::setSourceNode(vtkMRMLNode* sourceNode)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+  if (sourceNode && sourceNode->GetScene() != this->mrmlScene())
+    {
+    qCritical() << Q_FUNC_INFO << ": MRML scene of the given source node and the widget are different, cannot set node";
+    return;
+    }
+
+  qvtkReconnect(this->sourceNode(), sourceNode, vtkCommand::ModifiedEvent, this, SLOT(updateWidgetFromMRML()));
+
+  d->MRMLNodeComboBox_SourceGeometryNode->setCurrentNode(sourceNode);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::onSourceNodeChanged(vtkMRMLNode* sourceNode)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+
+  d->Logic->SetSourceGeometryNode(vtkMRMLDisplayableNode::SafeDownCast(sourceNode));
+
+  // Calculate output geometry and update UI
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::onOversamplingFactorChanged(double oversamplingFactor)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+
+  d->Logic->SetOversamplingFactor(oversamplingFactor);
+
+  // Calculate output geometry and update UI
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::onIsotropicSpacingChanged(bool isotropicSpacing)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+
+  d->Logic->SetIsotropicSpacing(isotropicSpacing);
+
+  // Calculate output geometry and update UI
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::onUserSpacingChanged(double* userSpacing)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+
+  d->Logic->SetUserSpacing(userSpacing);
+
+  // Calculate output geometry and update UI
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+double qMRMLSegmentationGeometryWidget::oversamplingFactor()const
+{
+  Q_D(const qMRMLSegmentationGeometryWidget);
+  return d->DoubleSpinBox_OversamplingFactor->value();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::setOversamplingFactor(double aOversamplingFactor)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+  d->DoubleSpinBox_OversamplingFactor->setValue(aOversamplingFactor);
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationGeometryWidget::isotropicSpacing()const
+{
+  Q_D(const qMRMLSegmentationGeometryWidget);
+  return d->checkBox_IsotropicSpacing->isChecked();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::setIsotropicSpacing(bool aIsotropicSpacing)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+  d->checkBox_IsotropicSpacing->setChecked(aIsotropicSpacing);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::setSpacing(double aSpacing[3])
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+  d->MRMLCoordinatesWidget_Spacing->setCoordinates(aSpacing);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::updateWidgetFromMRML()
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+
+  // Reset geometry
+  d->Logic->ResetGeometryImageData();
+
+  // Sanity check
+  d->label_Error->setVisible(false);
+  this->setEnabled(d->SegmentationNode.GetPointer());
+  if (!d->SegmentationNode.GetPointer())
+    {
+    d->frame_SourceGeometry->setVisible(false);
+    d->groupBox_VolumeSpacingOptions->setVisible(false);
+    d->MRMLCoordinatesWidget_Spacing->setEnabled(false);
+    d->label_Error->setText("No segmentation node specified!");
+    d->label_Error->setVisible(true);
+    d->updateGeometryWidgets();
+    return;
+    }
+
+  // Get source node
+  vtkMRMLTransformableNode* sourceNode = vtkMRMLTransformableNode::SafeDownCast(
+    d->MRMLNodeComboBox_SourceGeometryNode->currentNode() );
+  // Get possible source volumes
+  vtkMRMLScalarVolumeNode* sourceVolumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(sourceNode);
+  bool sourceIsVolume = (sourceVolumeNode != nullptr) || d->Logic->IsSourceSegmentationWithBinaryLabelmapMaster();
+
+  // If editing is disabled, then hide source node selector and use no source node even if was previously selected
+  if (d->EditEnabled)
+    {
+    d->frame_SourceGeometry->setVisible(true);
+    }
+  else
+    {
+    d->frame_SourceGeometry->setVisible(false);
+    sourceNode = nullptr;
+    }
+
+  // If no source node is selected, then show the current labelmap geometry
+  if (!sourceNode)
+    {
+    d->groupBox_VolumeSpacingOptions->setVisible(false);
+    std::string geometryString = d->SegmentationNode->GetSegmentation()->GetConversionParameter(
+      vtkSegmentationConverter::GetReferenceImageGeometryParameterName());
+    if (geometryString.empty())
+      {
+      d->updateGeometryWidgets();
+      return;
+      }
+    vtkOrientedImageData* geometryImageData = d->Logic->GetOutputGeometryImageData();
+    vtkSegmentationConverter::DeserializeImageGeometry(geometryString, geometryImageData, false);
+    d->updateGeometryWidgets();
+    return;
+    }
+
+  // If volume node is selected, then show volume spacing options box
+  d->groupBox_VolumeSpacingOptions->setVisible(sourceNode != nullptr && sourceIsVolume);
+  // Otherwise enable spacing widget to allow editing if it's allowed
+  d->MRMLCoordinatesWidget_Spacing->setEnabled(sourceNode != nullptr && !sourceIsVolume && d->EditEnabled);
+
+  // Calculate output geometry based on selection
+  std::string errorMessage = d->Logic->CalculateOutputGeometry();
+  if (!errorMessage.empty())
+    {
+    d->label_Error->setText(errorMessage.c_str());
+    d->label_Error->setVisible(true);
+    qCritical() << Q_FUNC_INFO << ": " << errorMessage.c_str();
+    }
+
+  // Fill output geometry in the widget
+  d->updateGeometryWidgets();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::setReferenceImageGeometryForSegmentationNode()
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+  if (!d->SegmentationNode.GetPointer())
+    {
+    qCritical() << Q_FUNC_INFO << "No input segmentation specified";
+    return;
+    }
+
+  vtkOrientedImageData* geometryImageData = d->Logic->GetOutputGeometryImageData();
+  std::string geometryString = vtkSegmentationConverter::SerializeImageGeometry(geometryImageData);
+  d->SegmentationNode->GetSegmentation()->SetConversionParameter(
+    vtkSegmentationConverter::GetReferenceImageGeometryParameterName(), geometryString );
+  qDebug() << Q_FUNC_INFO << "Reference image geometry of " << d->SegmentationNode->GetName()
+    << " has been set to '" << geometryString.c_str() << "'";
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::resampleLabelmapsInSegmentationNode()
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+  if (!d->SegmentationNode.GetPointer())
+    {
+    qCritical() << Q_FUNC_INFO << "No input segmentation specified";
+    return;
+    }
+  bool success = true;
+
+  // Check if master representation is binary or fractional labelmap (those are the only supported representations in segment editor)
+  std::string masterRepresentationName = d->SegmentationNode->GetSegmentation()->GetMasterRepresentationName();
+  if ( masterRepresentationName != vtkSegmentationConverter::GetBinaryLabelmapRepresentationName()
+    && masterRepresentationName != vtkSegmentationConverter::GetFractionalLabelmapRepresentationName() )
+    {
+    qCritical() << Q_FUNC_INFO << "Master representation needs to be a labelmap type, but '"
+      << masterRepresentationName.c_str() << "' found";
+    return;
+    }
+
+  std::vector< std::string > segmentIDs;
+  d->SegmentationNode->GetSegmentation()->GetSegmentIDs(segmentIDs);
+  for (std::vector< std::string >::const_iterator segmentIdIt = segmentIDs.begin(); segmentIdIt != segmentIDs.end(); ++segmentIdIt)
+    {
+    std::string currentSegmentID = *segmentIdIt;
+    vtkSegment* currentSegment = d->SegmentationNode->GetSegmentation()->GetSegment(*segmentIdIt);
+
+    // Get master labelmap from segment
+    vtkOrientedImageData* currentLabelmap = vtkOrientedImageData::SafeDownCast(
+      currentSegment->GetRepresentation(masterRepresentationName) );
+    if (!currentLabelmap)
+      {
+      qCritical() << Q_FUNC_INFO << "Failed to retrieve master representation from segment " << currentSegmentID.c_str();
+      continue;
+      }
+
+    // Resample
+    vtkOrientedImageData* geometryImageData = d->Logic->GetOutputGeometryImageData();
+    if (!vtkOrientedImageDataResample::ResampleOrientedImageToReferenceOrientedImage(currentLabelmap, geometryImageData, currentLabelmap, false, true))
+      {
+      qCritical() << Q_FUNC_INFO << "Segment " << d->SegmentationNode->GetName() << "/" << currentSegmentID.c_str() << " failed to be resampled";
+      success = false;
+      continue;
+      }
+    }
+
+  if (success)
+    {
+    qDebug() << Q_FUNC_INFO << "Master representation '" << masterRepresentationName.c_str() << "' in each segment of segmentation "
+      << d->SegmentationNode->GetName() << " has been resampled to specified geometry";
+    }
+
+  // Trigger display update
+  d->SegmentationNode->Modified();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationGeometryWidget::geometryImageData(vtkOrientedImageData* outputGeometry)
+{
+  Q_D(qMRMLSegmentationGeometryWidget);
+  if (!outputGeometry)
+    {
+    return;
+    }
+  outputGeometry->ShallowCopy(d->Logic->GetOutputGeometryImageData());
+}

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryWidget.h
@@ -1,0 +1,105 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+  and CANARIE.
+
+==============================================================================*/
+
+#ifndef __qMRMLSegmentationGeometryWidget_h
+#define __qMRMLSegmentationGeometryWidget_h
+
+// Segmentations includes
+#include "qSlicerSegmentationsModuleWidgetsExport.h"
+
+// MRMLWidgets includes
+#include "qMRMLWidget.h"
+
+// CTK includes
+#include <ctkPimpl.h>
+#include <ctkVTKObject.h>
+
+class vtkOrientedImageData;
+class vtkMRMLNode;
+class vtkMRMLSegmentationNode;
+class qMRMLSegmentationGeometryWidgetPrivate;
+
+/// \ingroup Slicer_QtModules_Segmentations_Widgets
+class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_EXPORT qMRMLSegmentationGeometryWidget : public qMRMLWidget
+{
+  Q_OBJECT
+  QVTK_OBJECT
+
+  Q_PROPERTY(bool editEnabled READ editEnabled WRITE setEditEnabled)
+  Q_PROPERTY(double oversamplingFactor READ oversamplingFactor WRITE setOversamplingFactor)
+  Q_PROPERTY(bool isotropicSpacing READ isotropicSpacing WRITE setIsotropicSpacing)
+
+public:
+  typedef qMRMLWidget Superclass;
+  /// Constructor
+  explicit qMRMLSegmentationGeometryWidget(QWidget* parent = 0);
+  /// Destructor
+  virtual ~qMRMLSegmentationGeometryWidget();
+
+  /// Get segmentation MRML node
+  Q_INVOKABLE vtkMRMLSegmentationNode* segmentationNode()const;
+  Q_INVOKABLE QString segmentationNodeID()const;
+
+  bool editEnabled()const;
+  vtkMRMLNode* sourceNode()const;
+  double oversamplingFactor()const;
+  bool isotropicSpacing()const;
+
+  void setSpacing(double aSpacing[3]);
+
+  /// Get calculated geometry image data
+  Q_INVOKABLE void geometryImageData(vtkOrientedImageData* outputGeometry);
+
+public slots:
+  /// Set segmentation MRML node
+  void setSegmentationNode(vtkMRMLSegmentationNode* node);
+
+  void setEditEnabled(bool aEditEnabled);
+  void setSourceNode(vtkMRMLNode* sourceNode);
+  void setOversamplingFactor(double aOversamplingFactor);
+  void setIsotropicSpacing(bool aIsotropicSpacing);
+
+  /// Set reference geometry conversion parameter to the one specified
+  void setReferenceImageGeometryForSegmentationNode();
+
+  /// Resample existing labelmaps in segmentation node with specified geometry
+  void resampleLabelmapsInSegmentationNode();
+
+protected slots:
+  /// Calculate output geometry from input segmentation and source node and update UI
+  void updateWidgetFromMRML();
+
+  /// Calculate source axis permutation and then output geometry.
+  void onSourceNodeChanged(vtkMRMLNode*);
+
+  void onOversamplingFactorChanged(double);
+  void onIsotropicSpacingChanged(bool);
+  void onUserSpacingChanged(double*);
+
+protected:
+  QScopedPointer<qMRMLSegmentationGeometryWidgetPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qMRMLSegmentationGeometryWidget);
+  Q_DISABLE_COPY(qMRMLSegmentationGeometryWidget);
+};
+
+#endif

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -33,7 +33,6 @@
 
 // Terminologies includes
 #include "qSlicerTerminologyItemDelegate.h"
-#include "qSlicerTerminologyNavigatorWidget.h"
 #include "vtkSlicerTerminologiesModuleLogic.h"
 #include "vtkSlicerTerminologyEntry.h"
 #include "vtkSlicerTerminologyCategory.h"
@@ -1195,7 +1194,7 @@ QString qMRMLSegmentsTableView::terminologyTooltipForSegment(vtkSegment* segment
     {
     qCritical() << Q_FUNC_INFO << ": Terminologies module is not found";
     return QString();
-    } 
+    }
 
   std::string serializedTerminology("");
   if (!segment->GetTag(vtkSegment::GetTerminologyEntryTagName(), serializedTerminology))

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
@@ -42,7 +42,7 @@ class QTableWidgetItem;
 class QItemSelection;
 class QContextMenuEvent;
 
-/// \ingroup SlicerRt_QtModules_Segmentations_Widgets
+/// \ingroup Slicer_QtModules_Segmentations_Widgets
 class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_EXPORT qMRMLSegmentsTableView : public qMRMLWidget
 {
   Q_OBJECT

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologySelectorDialog.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologySelectorDialog.cxx
@@ -33,7 +33,7 @@
 #include <QDebug>
 
 //-----------------------------------------------------------------------------
-/// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
+/// \ingroup Slicer_QtModules_Terminologies_Widgets
 class qSlicerTerminologySelectorDialogPrivate : public QDialog
 {
   Q_DECLARE_PUBLIC(qSlicerTerminologySelectorDialog);


### PR DESCRIPTION
- Add qMRMLSegmentationGeometryWidget that allows the user to specify a volume/segmentation/model/ROI as source, and set geometry details
  - For segmentation with labelmap master it is possible to set isotropic spacing and oversampling factor. Spacing cannot be set manually in these cases
  - For model, ROI, or segmentation with poly data master the parent transform is used for orientation, user input for spacing, and the bounding box for origin and extent
- Add qMRMLSegmentationGeometryDialog that has a geometry widget in it, and OK and Cancel buttons if editing is enabled, and an OK button otherwise. If resampling is requested, then besides setting the reference image geometry conversion parameter, the existing segments are resampled to the specified geometry
- Add button in row of master volume in Segment Editor widget that opens the geometry dialog
- Replace button in conversion parameters dialog for specifying reference image geometry. Before it was a simple dialog that allowed selecting a volume, now the new geometry dialog shows up
- Add python test for testing all kinds of scenarios for segmentation labelmap geometry calculation
- Crash fixed in vtkCalculateOversamplingFactor: when factor was very low, invalid extent was calculated and then crashed when calculating spacing based on that