### PR TITLE
ENH: update DCMTK

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -60,11 +60,11 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${CMAKE_PROJECT_NAME}_${proj}_GIT_TAG
-    # Include patches for:
-    # * DCMTK_ENABLE_CXX11 support on Linux
+    # Official DCMTK master as of 20180621
+    # http://git.dcmtk.org/?p=dcmtk.git;a=commit;h=29f9de10c2e8576147f16475b156bba98d14ba7d
+    # plus the following patch:
     # * Set CMP0067 to ensure try_compile work as expected
-    # * Fix template parameter in dcmiod/iodimage
-    "54004ba20077c626ff4e3042b1d4a5b36eda5e0e" # v3.6.3_20180205
+    "e79118cd2f40b77654630a56bbb17fe0bccc354c" # v3.6.3_20180621
     QUIET
     )
 


### PR DESCRIPTION
The updated version includes some patches that were earlier in the CTK fork, and an important bug fix that prevented output for DICOM Segmentation objects with the number of pixels in the frame not divisible by 8.

List of changes:
```
$ git shortlog DCMTK-3.6.3..29f9de10c
Jan Schlamelcher (13):
      Updated version information for 3.6.3+ development.
      Enhanced combined date time range matching.
      Added a missing test for universal matching.
      Minor language and coding style fixes in dcmwlm.
      Fixed an issue in dcmwlm / universal matching.
      Introduced a subset of std::filesystem for ofstd.
      Minor fixes for previous commit.
      More fixes for ofstd filesystem.
      Enhanced Doxygen documentation.
      Introduced support for compile time assertions.
      Enhanced ofstd filesystem's unit test.
      Simplified and enhanced dcmwlm's code.
      Fixed C++11 incompatibility in yesterday's commit.

Joerg Riesmeier (70):
      Enhanced verboseness of getDecompressedColorModel.
      Fixed typos.
      Added comment on missing timer start.
      Added comment on unhandled attributes.
      Use default timeout for first PDU to be read.
      Fixed name of retired Storage SOP Class.
      Removed all references to "CVS".
      Updated copyright date.
      Fixed issue with DSRTree<T>::swap().
      Added support for TID 4019 to TID 1419.
      Increased buffer size to avoid possible overflow.
      Added reference to documentation of TID 4019.
      Fixed double declaration of local variable.
      Increased buffer size to avoid possible overflow.
      Added PatientRadiationDoseSRStorage to man page.
      Moved assignment operator to source file.
      Added check for self-assignment.
      Added constructors and assignment operator.
      Fixed inaccurate name specifier of nested class.
      Enhanced code examples for module "dcmsr".
      Fixed partly wrong API documentation.
      Minor fix to API documentation.
      Fixed typos and removed trailing spaces.
      Removed space character at beginning of a line.
      Updated data dictionary for DICOM 2018a.
      Updated mapping of Body Part Examined to codes.
      Fixed classification of command line options.
      Fixed reference to outdated macro name.
      Removed double declaration of local variable.
      Made log output more consistent.
      Fixed outdated log message.
      Enhanced API documentation of DcmObject::getVM().
      Reverted to version before last commit.
      Next try to keep SunPro Studio 12.x quiet.
      Fixed wrong use of preprocessor directive #elif.
      Initialize struct with ={} instead of ={0}.
      Fixed typo in preprocessor directive.
      Fixed typo.
      Made mapping between VR name and enum more robust.
      Added new method getNumberOfValues().
      Made use of new method getNumberOfValues().
      Updated documentation on CP-1704 (Final Text).
      Made clear that an empty code is not valid.
      Added tree node filter "has Concept Name".
      Set observation date/time for all content items.
      Fixed invalid patient's birthdate in demo data.
      Report warning on missing file meta information.
      Added quotation marks around "isinf/isnan(0.)".
      Avoided "double typecast" in comparison operators.
      Added missing comparison operators "==" and "!=".
      Added support for recently approved CPs.
      Updated data dictionary for DICOM 2018b.
      Updated code definitions for DICOM 2018b.
      Updated Context Group classes for DICOM 2018b.
      Added support for Encapsulated STL Storage SOP.
      Fixed possible "use after scope" issue.
      Fixed typos, tab characters, trailing spaces, etc.
      Removed addOption() flag AF_NoWarning.
      Fixed possible issue with scaled overlays.
      Introduced header file for common exit codes.
      Fixed wrong reference to "dcmsend" tool.
      Fixed "unused result warning" on fwrite() calls.
      Fixed bug introduced with last commit.
      Adapted code for recent API change (DEBUG mode).
      Fixed issue with undefined CMAKE_SYSTEM_VERSION.
      Fixed typos in API documentation of new classes.
      Fixed typos in comments.
      Added support for recently approved CPs.
      CP-1765 retired DICOMDIR reference to CDA/XML.
      Fixed issue with incorrect rendering of overlays.

Marco Eichelberg (61):
      Fixed heap buffer overflow in dcmpschk.
      Changed OFSockAddr::size() return type to socklen_t.
      Fixed MSVC x64 type conversion warning.
      Fixed MSVC x64 type conversion warning.
      Fixed undefined behavior warning on 32-bit platforms.
      DcmTagKey comparison operators now return OFBool.
      Added line feed at EOF to fix Sun C++ warning.
      Fixed use of operator delete[], reported by clang.
      Include <sys/timeb.h> only if really needed.
      Fixed minor warnings reported by SunPro Studio
      Fixed heap buffer overflow in dcmpstat module.
      Minor changes to fix warnings on MacOS.
      Fixed include path for OpenSSL
      Fixed two bugs in DNS lookup code.
      Fixed heap overflow issue caused by invalid datasets.
      Fixed minor warning on MacOS
      Regenerated vrscan code with flex-2.6.4.
      Fixed warning introduced by flex-2.6.4 on Win32.
      Fixed compile error on current version of MinGW.
      Fixed compile error on current version of MinGW.
      Use readdir() instead of readdir_r() if safe.
      Removed default clause in DcmItem::newDicomElement().
      Permit external access to byte offsets in DICOM file.
      Added OpenSSL version check to configure/CMake.
      Updated OpenSSL version test to 1.0.2 as minimum.
      Reverted to OpenSSL version test to 1.0.1 as minimum.
      Link OpenSSL against libdl if available.
      Fixed OpenSSL version test on Windows.
      Another fix for the OpenSSL version test on Windows.
      Major revision of TLS code implementing Suppl. 204.
      Enabled NULL ciphers on OpenSSL 1.1.0 and newer.
      Fixed description regarding OpenSSL 1.1.0 and newer.
      Fixed read mode for certificate files to binary.
      Added Perl script that generates test files.
      Added Perl script with dcmtls test suite.
      Minor cleanup in echoscu.
      Implemented cryptographically secure ISAAC PRNG.
      Modified code to use OFRandom instead of srand/rand.
      Completed conversion to OFRandom.
      Replaced strcpy by OFStandard::strlcpy.
      Added DLL export symbols.
      Replaced strcat by OFStandard::strlcat.
      Added export declaration for deny_/allow_severity.
      Changes for OpenSSL without ECDH support.
      Replaced strcpy by OFStandard::strlcpy.
      Replaced strcpy by OFStandard::strlcpy.
      Fixed minor bug introduced with last commit.
      Moved declaration of global variables for libwrap.
      Added logger to module dcmsign.
      Changed DVPSIPCMessage::resizePayload parameter type.
      Undefine isinf() macro if defined.
      Fixed minor warnings.
      Added missing include statement.
      Fixed missing end of comment.
      Fixed incorrect strlcpy buffer size.
      Added OFStandard::snprintf() and vsnprintf().
      Changes to permit compilation with LibreSSL.
      Fixed gcc 8 warning.
      Fixed typo in comment.
      Introduced upper size limit for A-ASSOCIATE PDUs.
      Improved poll() code in module dcmnet.

Michael Onken (33):
      Fix cmake error on Linux with DCMTK_ENABLE_CXX11.
      Ensure isnan/isinf macro is only defined once.
      Renamed VM variables for clarity.
      Fixed integer overflow in pixel buffer allocation.
      Print error details if conversion fails.
      Fixed uninitialized variable.
      Updated importHierarchy() method API.
      Again, fix API for importHierarchy() (see c8fdfb).
      Fixed C++11 template specialization.
      Added virtual destructors to potent. base classes.
      Initialize members.
      Fixed some compare() methods.
      Fixed missing initializers and old-style casts.
      Fixed usage of getVM() versus getNumberOfValues().
      Added member initializations and copy/assignment.
      Enhanced documentation.
      Added import() method for FoR and FoR checks.
      Removed debug output.
      Fixed compare() methods.
      Make sure compare() works on valid objects.
      Simplified cast.
      Added support for CP-1650 (support JWT User ID).
      Fix posible crash if network data is malformed.
      Fix possible crash if network data is malformed.
      Fix underflow in networking code.
      Fix possible bypass of length check.
      Updated copyright for last commits.
      Use POLLOUT if connect() returns EINPROGRESS.
      Make some parameters const in ASC_ methods.
      Fixed RGB to DICOM Lab color conversion.
      Fixed binary segmentations with rows*cols%8 != 0.
      Fix dcmseg test for all compilers.
      Enabled doxygen docs potentially hidden by macros.

Pedro (1):
      Fixed wrong return status from echoscu.

Pedro F. Arizpe-Gomez (4):
      Fixed wrong return status and exit codes for echoscu.
      Documented exit codes in echoscu manpage.
      Made const pointers for interface of core.
      CMake-language style improvements.
```