### PR TITLE
BUG: Generate unique name in AddNewNodeByClass

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -1279,7 +1279,7 @@ vtkMRMLNode* vtkMRMLScene::AddNewNodeByClass(
     }
   if (!nodeBaseName.empty())
     {
-    nodeToAdd->SetName(nodeBaseName.c_str());
+    nodeToAdd->SetName(this->GenerateUniqueName(nodeBaseName).c_str());
     }
   return this->AddNode(nodeToAdd);
 }


### PR DESCRIPTION
Even though the documentation mentioned it, the implementation
wasn't generating unique names. Fix it.