### PR TITLE
COMP: Fixed packaging of bundled superbuild extensions

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -67,6 +67,12 @@ include(${Slicer_CMAKE_DIR}/SlicerBlockInstallExtensionPackages.cmake)
 
 set(CPACK_INSTALL_CMAKE_PROJECTS)
 
+foreach(extension_name ${Slicer_BUNDLED_EXTENSION_NAMES})
+  if(DEFINED "${extension_name}_CPACK_INSTALL_CMAKE_PROJECTS")
+    set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${${extension_name}_CPACK_INSTALL_CMAKE_PROJECTS}")
+  endif()
+endforeach()
+
 # Install CTK Apps and Plugins (PythonQt modules, QtDesigner plugins ...)
 if(NOT "${CTK_DIR}" STREQUAL "" AND EXISTS "${CTK_DIR}/CTK-build/CMakeCache.txt")
   set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${CTK_DIR}/CTK-build;CTK;RuntimeApplications;/")

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -342,6 +342,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 set(_extension_depends )
 
 # Build only inner-build for superbuild-type extensions
+set(Slicer_BUNDLED_EXTENSION_NAMES)
 foreach(extension_dir ${Slicer_EXTENSION_SOURCE_DIRS})
   get_filename_component(extension_dir ${extension_dir} ABSOLUTE)
   get_filename_component(extension_name ${extension_dir} NAME) # The assumption is that source directories are named after the extension project
@@ -367,12 +368,17 @@ foreach(extension_dir ${Slicer_EXTENSION_SOURCE_DIRS})
       set(_additional_project_name "${CMAKE_MATCH_1}")
       list(APPEND _extension_depends ${_additional_project_name})
     endforeach()
+
+    list(APPEND Slicer_BUNDLED_EXTENSION_NAMES ${extension_name})
+
     message(STATUS "SuperBuild - ${extension_name} extension => ${_extension_depends}")
 
   endif()
 endforeach()
 
 list(APPEND Slicer_DEPENDENCIES ${_extension_depends})
+
+mark_as_superbuild(Slicer_BUNDLED_EXTENSION_NAMES:STRING)
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Allows packaging superbuild extensions bundled with the Slicer installer. Tested with SlicerVirtualReality

Thanks, @jcfr, I owe you one!