### PR TITLE
ENH: Allow cut, copy, and paste of fiducials in markups module

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.cxx
@@ -136,10 +136,6 @@ std::string vtkMRMLMarkupsStorageNode::GetCoordinateSystemAsString()
     {
     coordString = std::string("LPS");
     }
-  else if (this->CoordinateSystem == vtkMRMLMarkupsStorageNode::IJK)
-    {
-    coordString = std::string("IJK");
-    }
   return coordString;
 }
 
@@ -172,25 +168,6 @@ void vtkMRMLMarkupsStorageNode::UseLPSOn()
 bool vtkMRMLMarkupsStorageNode::GetUseLPS()
 {
   if (this->GetCoordinateSystem() == vtkMRMLMarkupsStorageNode::LPS)
-    {
-    return true;
-    }
-  else
-    {
-    return false;
-    }
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsStorageNode::UseIJKOn()
-{
-  this->SetCoordinateSystem(vtkMRMLMarkupsStorageNode::IJK);
-}
-
-//----------------------------------------------------------------------------
-bool vtkMRMLMarkupsStorageNode::GetUseIJK()
-{
-  if (this->GetCoordinateSystem() == vtkMRMLMarkupsStorageNode::IJK)
     {
     return true;
     }

--- a/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.h
@@ -60,12 +60,11 @@ public:
   enum
   {
     RAS = 0,
-    LPS,
-    IJK
+    LPS
   };
 
   /// Get/Set flag that controls if points are to be written in various coordinate systems
-  vtkSetClampMacro(CoordinateSystem, int, vtkMRMLMarkupsStorageNode::RAS, vtkMRMLMarkupsStorageNode::IJK);
+  vtkSetClampMacro(CoordinateSystem, int, vtkMRMLMarkupsStorageNode::RAS, vtkMRMLMarkupsStorageNode::LPS);
   vtkGetMacro(CoordinateSystem, int);
   std::string GetCoordinateSystemAsString();
   /// Convenience methods to get/set various coordinate system values
@@ -74,8 +73,6 @@ public:
   bool GetUseRAS();
   void UseLPSOn();
   bool GetUseLPS();
-  void UseIJKOn();
-  bool GetUseIJK();
 
   /// Convert between user input strings and strings safe to be
   /// written to the storage file. Since the current storage node

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.h
@@ -56,6 +56,18 @@ public:
 
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode) VTK_OVERRIDE;
 
+  // If markupIndex >= number of existing markups then a new markup node is appended.
+  // Returns true on success.
+  virtual bool SetMarkupFromString(vtkMRMLMarkupsNode *markupsNode, int markupIndex, const char* str);
+
+  virtual std::string GetMarkupAsString(vtkMRMLMarkupsNode *markupsNode, int markupIndex);
+
+  /// Characters that separate between fields in the written file.
+  /// Comma by default.
+  /// Currently, only the first character of the string is used.
+  vtkSetMacro(FieldDelimiterCharacters, std::string);
+  vtkGetMacro(FieldDelimiterCharacters, std::string);
+
 protected:
   vtkMRMLMarkupsFiducialStorageNode();
   ~vtkMRMLMarkupsFiducialStorageNode();
@@ -81,6 +93,7 @@ protected:
   /// necessary, same with the description
   virtual int WriteDataInternal(vtkMRMLNode *refNode) VTK_OVERRIDE;
 
+  std::string FieldDelimiterCharacters;
 };
 
 #endif

--- a/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
+++ b/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>490</width>
-    <height>649</height>
+    <width>593</width>
+    <height>587</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -346,6 +346,36 @@
        <property name="icon">
         <iconset>
          <normaloff>:/Icons/MarkupsDeleteAllRows.png</normaloff>:/Icons/MarkupsDeleteAllRows.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="CutMarkupsToolButton">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Cut</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="CopyMarkupsToolButton">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Copy</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="PasteMarkupsToolButton">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Paste</string>
        </property>
       </widget>
      </item>
@@ -763,6 +793,7 @@
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest1.cxx
@@ -62,17 +62,6 @@ int vtkMRMLMarkupsStorageNodeTest1(int vtkNotUsed(argc), char * vtkNotUsed(argv)
     return EXIT_FAILURE;
     }
 
-  node1->UseIJKOn();
-  if (node1->GetCoordinateSystemAsString().compare("IJK") != 0)
-    {
-    std::cerr << "Failed to set coordinate system to IJK "
-              << vtkMRMLMarkupsStorageNode::IJK
-              << ", int flag = " << node1->GetCoordinateSystem()
-              << ", string = " << node1->GetCoordinateSystemAsString().c_str()
-              << std::endl;
-    return EXIT_FAILURE;
-    }
-
   // reset coordinate system flag to RAS
   node1->UseRASOn();
  if (node1->GetCoordinateSystemAsString().compare("RAS") != 0)

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
@@ -148,7 +148,7 @@ public slots:
   void onAddMarkupPushButtonClicked();
   void onMoveMarkupUpPushButtonClicked();
   void onMoveMarkupDownPushButtonClicked();
-  void onDeleteMarkupPushButtonClicked();
+  void onDeleteMarkupPushButtonClicked(bool confirm=true);
   void onDeleteAllMarkupsInListPushButtonClicked();
 
   /// Update the selection node from the combo box
@@ -209,6 +209,10 @@ public slots:
   /// the named list, calls logic method to do the move if it can find both
   /// markups nodes in the scene
   void moveSelectedToNamedList(QString listName);
+
+  void cutSelectedToClipboard();
+  void copySelectedToClipboard();
+  void pasteSelectedFromClipboard();
 
   /// Enable/disable editing the table if the markups node is un/locked
   void onActiveMarkupsNodeLockModifiedEvent();


### PR DESCRIPTION
Selected markups can be cut or copied to clipboard.
Markups can be pasted to an Excel spreadsheet or pasted into the same or another markup list node Slicer.
