### PR TITLE
ENH: remove import warning for non-embedded interpreter

### DIFF
--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -42,7 +42,6 @@ standalone_python = "python" in string.lower(os.path.split(sys.executable)[-1])
 for kit in available_kits:
   # skip PythonQt kits if we are running in a regular python interpreter
   if standalone_python and "PythonQt" in kit:
-    print("Detected non-embedded Python interpreter. Skipping module '{}'".format(kit))
     continue
 
   try:


### PR DESCRIPTION
Having used this for a while, the (repeated) warnings are annoying, especially when writing tests. Any objection to removing the warning?