### PR TITLE
COMP: Add missing headers.

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -56,6 +56,7 @@
 // VTK includes
 #include <vtksys/SystemTools.hxx>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/qMRMLSliceView.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceView.cxx
@@ -51,6 +51,7 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkSmartPointer.h>
 
 //--------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -49,6 +49,7 @@
 #include <vtkCollection.h>
 #include <vtkNew.h>
 #include <vtkRenderer.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkSmartPointer.h>
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
Solve incomplete type errors when using latest VTKv9:
982ec1c561868f3e2442d11df0c44eaea1e56834

```
Software/Slicer/Slicer-src/Base/QTApp/qSlicerApplicationHelper.cxx: In static member function ‘static void qSlicerApplicationHelper::preInitializeApplication(const char*, ctkProxyStyle*)’:
Software/Slicer/Slicer-src/Base/QTApp/qSlicerApplicationHelper.cxx:98:18: error: variable ‘QSurfaceFormat format’ has initializer but incomplete type
   QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
                  ^~~~~~
Software/Slicer/Slicer-src/Base/QTApp/qSlicerApplicationHelper.cxx:98:59: error: invalid use of incomplete type ‘class QSurfaceFormat’
   QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
                                                           ^
In file included from Software/Slicer/Slicer-src/Base/QTApp/qSlicerApplicationHelper.cxx:59:
Software/Slicer/build-relwithdebinfo/VTKv9/GUISupport/Qt/QVTKOpenGLWidget.h:23:7: note: forward declaration of ‘class QSurfaceFormat’
 class QSurfaceFormat;
       ^~~~~~~~~~~~~~
Software/Slicer/Slicer-src/Base/QTApp/qSlicerApplicationHelper.cxx:100:19: error: incomplete type ‘QSurfaceFormat’ used in nested name specifier
   QSurfaceFormat::setDefaultFormat(format);
```