### PR TITLE
Unlink range widgets in model scalar visualization

### DIFF
--- a/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.cxx
@@ -436,8 +436,6 @@ void qMRMLModelDisplayNodeWidget::setScalarsDisplayRange(double min, double max)
     qvtkBlock(d->MRMLModelDisplayNode, vtkCommand::ModifiedEvent, this);
     d->MRMLModelDisplayNode->SetScalarRange(min, max);
     qvtkUnblock(d->MRMLModelDisplayNode, vtkCommand::ModifiedEvent, this);
-    d->ThresholdRangeWidget->setRange(min,max);
-    d->ThresholdRangeWidget->setValues(min,max);
     }
 }
 


### PR DESCRIPTION
When the Displayed Range widget is modified, the Threshold range widget
is updated with the same values. This is not necessary, as proved by the
equivalent widgets in the Volumes module.

Also, maybe the names of the widgets should be changed as well. The Threshold widget modify the "displayed range", which is the name of the widget to control the "window" of the mapped colors.

For example, I have a model with point data from 0 to 100, with a gray colormap. I want values under 30 to be black and over 70 to be white, so I set the "Displayed Range" between 30 and 70. When I click on the threshold checkbox, my white and black parts of the model disappear, but maybe I want to hide only the values over 90.