### PR TITLE
COMP: Add missing header when using QVTKOpenGLWidget

### DIFF
--- a/Applications/SlicerApp/Testing/Cpp/qSlicerAppMainWindowTest1.cxx
+++ b/Applications/SlicerApp/Testing/Cpp/qSlicerAppMainWindowTest1.cxx
@@ -31,6 +31,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerDirectoryListViewTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerDirectoryListViewTest1.cxx
@@ -31,6 +31,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerLayoutManagerTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerLayoutManagerTest1.cxx
@@ -31,6 +31,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
@@ -18,6 +18,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest1.cxx
@@ -32,6 +32,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
@@ -50,6 +50,7 @@
 #include <vtkActor2D.h>
 #include <vtkVersion.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #else
 #include <QVTKWidget.h>

--- a/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxEventTranslatorPlayerTest1.cxx
@@ -41,6 +41,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxTest1.cxx
@@ -33,6 +33,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetEventTranslatorPlayerTest1.cxx
@@ -43,6 +43,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetTest1.cxx
@@ -34,6 +34,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLCollapsibleButtonEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLCollapsibleButtonEventTranslatorPlayerTest1.cxx
@@ -39,6 +39,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorListViewEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorListViewEventTranslatorPlayerTest1.cxx
@@ -46,6 +46,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorListViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorListViewTest1.cxx
@@ -37,6 +37,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorModelTest1.cxx
@@ -39,6 +39,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetEventTranslatorPlayerTest1.cxx
@@ -50,6 +50,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest1.cxx
@@ -35,6 +35,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest2.cxx
@@ -40,6 +40,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest3.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest3.cxx
@@ -37,6 +37,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxEventTranslatorPlayerTest1.cxx
@@ -44,6 +44,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxTest1.cxx
@@ -32,6 +32,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorTableViewEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorTableViewEventTranslatorPlayerTest1.cxx
@@ -46,6 +46,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorTableViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorTableViewTest1.cxx
@@ -41,6 +41,7 @@
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetEventTranslatorPlayerTest1.cxx
@@ -43,6 +43,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetTest1.cxx
@@ -34,6 +34,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLabelComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLabelComboBoxEventTranslatorPlayerTest1.cxx
@@ -43,6 +43,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
@@ -46,6 +46,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest2.cxx
@@ -35,6 +35,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest3.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest3.cxx
@@ -40,6 +40,7 @@
 #include <vtkCollection.h>
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest4.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest4.cxx
@@ -35,6 +35,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
@@ -43,6 +43,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
@@ -49,6 +49,7 @@
 #include <vtkObjectFactory.h>
 #include <vtkWeakPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLinearTransformSliderEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLinearTransformSliderEventTranslatorPlayerTest1.cxx
@@ -39,6 +39,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLinearTransformSliderTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLinearTransformSliderTest1.cxx
@@ -6,6 +6,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLListWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLListWidgetEventTranslatorPlayerTest1.cxx
@@ -40,6 +40,7 @@
 
 // VTK
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLListWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLListWidgetTest1.cxx
@@ -26,6 +26,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetEventTranslatorPlayerTest1.cxx
@@ -39,6 +39,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetTest1.cxx
@@ -12,6 +12,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLModelInfoWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLModelInfoWidgetTest1.cxx
@@ -35,6 +35,7 @@
 #include <vtkSmartPointer.h>
 #include <vtkPolyData.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLModelTest1.cxx
@@ -33,6 +33,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLModelTreeViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLModelTreeViewTest1.cxx
@@ -34,6 +34,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNavigationViewEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNavigationViewEventTranslatorPlayerTest1.cxx
@@ -48,6 +48,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNavigationViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNavigationViewTest1.cxx
@@ -38,6 +38,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxEventTranslatorPlayerTest1.cxx
@@ -46,6 +46,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxLazyUpdateTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxLazyUpdateTest1.cxx
@@ -39,6 +39,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest1.cxx
@@ -34,6 +34,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest2.cxx
@@ -34,6 +34,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest3.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest3.cxx
@@ -34,6 +34,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest4.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest4.cxx
@@ -35,6 +35,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest5.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest5.cxx
@@ -36,6 +36,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest6.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest6.cxx
@@ -36,6 +36,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest7.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest7.cxx
@@ -32,6 +32,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
@@ -35,6 +35,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest9.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest9.cxx
@@ -36,6 +36,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeFactoryTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeFactoryTest1.cxx
@@ -34,6 +34,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLPlotViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLPlotViewTest1.cxx
@@ -44,6 +44,7 @@
 #include <vtkNew.h>
 #include <vtkTable.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLROIWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLROIWidgetEventTranslatorPlayerTest1.cxx
@@ -43,6 +43,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLRangeWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLRangeWidgetEventTranslatorPlayerTest1.cxx
@@ -38,6 +38,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxEventTranslatorPlayerTest1.cxx
@@ -43,6 +43,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxTest1.cxx
@@ -34,6 +34,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneCategoryModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneCategoryModelTest1.cxx
@@ -38,6 +38,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneColorTableModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneColorTableModelTest1.cxx
@@ -39,6 +39,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest1.cxx
@@ -35,6 +35,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest2.cxx
@@ -35,6 +35,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneFactoryWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneFactoryWidgetTest1.cxx
@@ -32,6 +32,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneHierarchyModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneHierarchyModelTest1.cxx
@@ -39,6 +39,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest1.cxx
@@ -35,6 +35,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest2.cxx
@@ -41,6 +41,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneModelTest1.cxx
@@ -34,6 +34,7 @@
 //
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest1.cxx
@@ -35,6 +35,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest2.cxx
@@ -35,6 +35,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetEventTranslatorPlayerTest1.cxx
@@ -44,6 +44,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetEventTranslatorPlayerTest1.cxx
@@ -50,6 +50,7 @@
 #include <vtkMultiThreader.h>
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
@@ -41,6 +41,7 @@
 #include <vtkMultiThreader.h>
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest2.cxx
@@ -47,6 +47,7 @@
 #include <vtkCollection.h>
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLTableViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTableViewTest1.cxx
@@ -42,6 +42,7 @@
 #include <vtkNew.h>
 #include <vtkTable.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDViewControllerWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDViewControllerWidgetEventTranslatorPlayerTest1.cxx
@@ -39,6 +39,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDViewTest1.cxx
@@ -34,6 +34,7 @@
 #include <vtkCollection.h>
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDWidgetEventTranslatorPlayerTest1.cxx
@@ -46,6 +46,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDWidgetTest1.cxx
@@ -37,6 +37,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersEventTranslatorPlayerTest1.cxx
@@ -39,6 +39,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersTest1.cxx
@@ -9,6 +9,7 @@
 #include <vtkMRMLTransformNode.h>
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLTreeViewEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTreeViewEventTranslatorPlayerTest1.cxx
@@ -50,6 +50,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLTreeViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTreeViewTest1.cxx
@@ -29,6 +29,7 @@
 #include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLUtf8Test1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLUtf8Test1.cxx
@@ -39,6 +39,7 @@
 // VTK includes
 #include "vtkNew.h"
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLUtilsTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLUtilsTest1.cxx
@@ -30,6 +30,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeInfoWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeInfoWidgetEventTranslatorPlayerTest1.cxx
@@ -48,6 +48,7 @@
 #include <vtkNew.h>
 #include <vtkVersion.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeInfoWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeInfoWidgetTest1.cxx
@@ -39,6 +39,7 @@
 #include <vtkNew.h>
 #include <vtkVersion.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.cxx
@@ -46,6 +46,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
@@ -36,6 +36,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
@@ -42,6 +42,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLWidgetsExportTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWidgetsExportTest1.cxx
@@ -5,6 +5,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.cxx
@@ -45,6 +45,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
@@ -37,6 +37,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Annotations/Testing/Cxx/qMRMLAnnotationROIWidgetTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/qMRMLAnnotationROIWidgetTest1.cxx
@@ -17,6 +17,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Annotations/Testing/Cxx/qMRMLSceneAnnotationModelAndAnnotationTreeWidgetTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/qMRMLSceneAnnotationModelAndAnnotationTreeWidgetTest1.cxx
@@ -22,6 +22,7 @@
 #include "vtkMRMLCoreTestingMacros.h"
 #include <vtkEventBroker.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Colors/Testing/Cxx/qSlicerColorsModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Colors/Testing/Cxx/qSlicerColorsModuleWidgetTest1.cxx
@@ -37,6 +37,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest1.cxx
@@ -41,6 +41,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTestScene.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTestScene.cxx
@@ -42,6 +42,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest1.cxx
+++ b/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest1.cxx
@@ -34,6 +34,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest2.cxx
+++ b/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest2.cxx
@@ -36,6 +36,7 @@
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Plots/Widgets/Testing/Cxx/qMRMLPlotPropertiesWidgetTest1.cxx
+++ b/Modules/Loadable/Plots/Widgets/Testing/Cxx/qMRMLPlotPropertiesWidgetTest1.cxx
@@ -48,6 +48,7 @@
 #include <vtkNew.h>
 #include <vtkTable.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Tables/Widgets/Testing/Cxx/qSlicerTableColumnPropertiesWidgetTest1.cxx
+++ b/Modules/Loadable/Tables/Widgets/Testing/Cxx/qSlicerTableColumnPropertiesWidgetTest1.cxx
@@ -41,6 +41,7 @@
 #include <vtkNew.h>
 #include <vtkTable.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Transforms/Widgets/Testing/qMRMLTransformDisplayNodeWidgetTest1.cxx
+++ b/Modules/Loadable/Transforms/Widgets/Testing/qMRMLTransformDisplayNodeWidgetTest1.cxx
@@ -38,6 +38,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Transforms/Widgets/Testing/qMRMLTransformInfoWidgetTest1.cxx
+++ b/Modules/Loadable/Transforms/Widgets/Testing/qMRMLTransformInfoWidgetTest1.cxx
@@ -37,6 +37,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/qMRMLVolumePropertyNodeWidgetTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/qMRMLVolumePropertyNodeWidgetTest1.cxx
@@ -33,6 +33,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest1.cxx
@@ -33,6 +33,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest2.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest2.cxx
@@ -38,6 +38,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesIOOptionsWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesIOOptionsWidgetTest1.cxx
@@ -37,6 +37,7 @@
 
 // VTK includes
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesModuleWidgetTest1.cxx
@@ -36,6 +36,7 @@
 // VTK includes
 #include <vtkNew.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest1.cxx
@@ -36,6 +36,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest2.cxx
+++ b/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest2.cxx
@@ -39,6 +39,7 @@
 #include <vtkNew.h>
 #include <vtkTrivialProducer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 

--- a/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDiffusionTensorVolumeDisplayWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDiffusionTensorVolumeDisplayWidgetTest1.cxx
@@ -36,6 +36,7 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
+#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #endif
 


### PR DESCRIPTION
Same fix than #987 but for all tests.

Missing header when `Slicer_VTK_USE_QVTKOPENGLWIDGET` is defined.

Tested using VTKv9 from this branch:
https://github.com/phcerdan/VTK/tree/slicer-v9.0.0-2018-07-06-982ec1c561

Solve error:
```bash
In file included from
/Software/Shape/SALT/build/slicersources-src/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetTest1.cxx:37:
/Software/Shape/SALT/build/VTKv9/GUISupport/Qt/QVTKOpenGLWidget.h:23:7:
note: forward declaration of ‘class QSurfaceFormat’
 class QSurfaceFormat;
        ^~~~~~~~~~~~~~
        /Software/Shape/SALT/build/slicersources-src/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetTest1.cxx:48:19:
        error: incomplete type ‘QSurfaceFormat’ used in nested name
        specifier
           QSurfaceFormat::setDefaultFormat(format);
```