### PR TITLE
ENH: Changed Slicer's Python executable to PythonSlicer

### DIFF
--- a/CMake/SlicerBlockInstallPython.cmake
+++ b/CMake/SlicerBlockInstallPython.cmake
@@ -75,24 +75,32 @@ if(Slicer_USE_PYTHONQT)
   endif()
 
   # Install Slicer python launcher settings
-  install(
-    FILES ${python_bin_dir}/SlicerPythonLauncherSettingsToInstall.ini
-    DESTINATION ${Slicer_INSTALL_BIN_DIR}
-    RENAME SlicerPythonLauncherSettings.ini
-    COMPONENT Runtime
-    )
 
-  # Install Slicer python launcher
-  set(_launcher CTKAppLauncher)
-  if(Slicer_BUILD_WIN32_CONSOLE)
-    set(_launcher CTKAppLauncherW)
-  endif()
-  install(
-    PROGRAMS ${CTKAppLauncher_DIR}/bin/${_launcher}${CMAKE_EXECUTABLE_SUFFIX}
-    DESTINATION ${Slicer_INSTALL_BIN_DIR}
-    RENAME SlicerPython${CMAKE_EXECUTABLE_SUFFIX}
-    COMPONENT Runtime
-    )
+  macro(_install_python_launcher executablename)
+    # Install Slicer python launcher settings
+    install(
+      FILES ${python_bin_dir}/${executablename}LauncherSettingsToInstall.ini
+      DESTINATION ${Slicer_INSTALL_BIN_DIR}
+      RENAME ${executablename}LauncherSettings.ini
+      COMPONENT Runtime
+      )
+    # Install Slicer python launcher
+    set(_launcher CTKAppLauncher)
+    if(Slicer_BUILD_WIN32_CONSOLE)
+      set(_launcher CTKAppLauncherW)
+    endif()
+    install(
+      PROGRAMS ${CTKAppLauncher_DIR}/bin/${_launcher}${CMAKE_EXECUTABLE_SUFFIX}
+      DESTINATION ${Slicer_INSTALL_BIN_DIR}
+      RENAME ${executablename}${CMAKE_EXECUTABLE_SUFFIX}
+      COMPONENT Runtime
+      )
+  endmacro()
+
+  _install_python_launcher(PythonSlicer)
+
+  # SlicerPython executable is deprecated, see details in External_python.cmake
+  _install_python_launcher(SlicerPython)
 
   # Install headers
   set(python_include_subdir /Include/)

--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -185,13 +185,13 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
     set(slicer_PYTHON_SHARED_LIBRARY_DIR ${python_DIR}/lib)
     set(PYTHON_INCLUDE_DIR ${python_DIR}/include/python2.7)
     set(PYTHON_LIBRARY ${python_DIR}/lib/libpython2.7.${python_IMPORT_SUFFIX})
-    set(PYTHON_EXECUTABLE ${python_DIR}/bin/SlicerPython)
+    set(PYTHON_EXECUTABLE ${python_DIR}/bin/PythonSlicer)
     set(slicer_PYTHON_REAL_EXECUTABLE ${python_DIR}/bin/python)
   elseif(WIN32)
     set(slicer_PYTHON_SHARED_LIBRARY_DIR ${python_DIR}/bin)
     set(PYTHON_INCLUDE_DIR ${python_DIR}/include)
     set(PYTHON_LIBRARY ${python_DIR}/libs/python27.lib)
-    set(PYTHON_EXECUTABLE ${python_DIR}/bin/SlicerPython.exe)
+    set(PYTHON_EXECUTABLE ${python_DIR}/bin/PythonSlicer.exe)
     set(slicer_PYTHON_REAL_EXECUTABLE ${python_DIR}/bin/python.exe)
   else()
     message(FATAL_ERROR "Unknown system !")
@@ -221,7 +221,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
       DEPENDEES install
       )
 
-    # Note: Install rules for SlicerPythonLauncherSettingsToInstall.ini and SlicerPython executable
+    # Note: Install rules for PythonSlicerLauncherSettingsToInstall.ini and PythonSlicer executable
     #       are specified in SlicerBlockInstallPython.cmake
 
     if(UNIX AND NOT APPLE)

--- a/SuperBuild/python_configure_python_launcher.cmake
+++ b/SuperBuild/python_configure_python_launcher.cmake
@@ -129,12 +129,11 @@ set(PYTHONLAUNCHER_PYTHONPATH_INSTALLED
 #
 # Notes:
 #
-#  * Install rules for SlicerPythonLauncherSettingsToInstall.ini and SlicerPython executable
+#  * Install rules for PythonSlicerLauncherSettingsToInstall.ini and PythonSlicer executable
 #  are specified in SlicerBlockInstallPython.cmake
 #
 
-ctkAppLauncherConfigureForExecutable(
-  APPLICATION_NAME SlicerPython
+set(_python_launcher_config_params
   SPLASHSCREEN_DISABLED
 
   # Additional settings exclude groups
@@ -160,4 +159,18 @@ ctkAppLauncherConfigureForExecutable(
   ENVVARS_INSTALLED "${PYTHONLAUNCHER_ENVVARS_INSTALLED}"
   ADDITIONAL_PATH_ENVVARS_INSTALLED "${PYTHONLAUNCHER_ADDITIONAL_PATH_ENVVARS_INSTALLED}"
   ADDITIONAL_SETTINGS_FILEPATH_INSTALLED "<APPLAUNCHER_SETTINGS_DIR>/SlicerLauncherSettings.ini"
+  )
+
+# Custom Python executable name must start with Python for compatibility with
+# development tools, such as PyCharm.
+ctkAppLauncherConfigureForExecutable(
+  APPLICATION_NAME PythonSlicer
+  ${_python_launcher_config_params}
+  )
+
+# SlicerPython executable name is deprecated and will be removed in the future
+# (name is not compatible with some development environments - see the comment above).
+ctkAppLauncherConfigureForExecutable(
+  APPLICATION_NAME SlicerPython
+  ${_python_launcher_config_params}
   )

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 if(Slicer_USE_NUMPY AND PYTHON_EXECUTABLE)
 
-  add_test(SlicerPythonSimpleNUMPYTest ${Slicer_LAUNCH_COMMAND} ${PYTHON_EXECUTABLE} ${Slicer_SOURCE_DIR}/Testing/SimpleNUMPYTest.py)
+  add_test(PythonSlicerSimpleNUMPYTest ${Slicer_LAUNCH_COMMAND} ${PYTHON_EXECUTABLE} ${Slicer_SOURCE_DIR}/Testing/SimpleNUMPYTest.py)
 
 endif()

--- a/Utilities/Scripts/slicerExtensionWizard-install.sh.in
+++ b/Utilities/Scripts/slicerExtensionWizard-install.sh.in
@@ -8,7 +8,7 @@ python="$bin/python-real"
 [ -x "$python" ] || python=python
 
 # Set up environment
-eval $("$bin/SlicerPython" --launcher-show-set-environment-commands)
+eval $("$bin/PythonSlicer" --launcher-show-set-environment-commands)
 
 @EXPORT_GIT_PYTHON_GIT_EXECUTABLE_CONFIG@
 


### PR DESCRIPTION
PythonSlicer is recognized as Python executable by developer tools such as PyCharm, while SlicerPython is not recognized.

SlicerPython is kept for now for backward compatibility but will be removed in the future.