### PR TITLE
COMP: Fail early building script with PythonQt disabled

### DIFF
--- a/CMake/SlicerMacroBuildScriptedModule.cmake
+++ b/CMake/SlicerMacroBuildScriptedModule.cmake
@@ -37,9 +37,9 @@ macro(slicerMacroBuildScriptedModule)
     "${multiValueArgs}"
     ${ARGN}
     )
-    
+
   message(STATUS "Configuring Scripted module: ${MY_SLICER_NAME}")
-  
+
   # --------------------------------------------------------------------------
   # Print information helpful for debugging checks
   # --------------------------------------------------------------------------
@@ -82,6 +82,12 @@ macro(slicerMacroBuildScriptedModule)
       endif()
     endforeach()
   endforeach()
+
+  if(NOT Slicer_USE_PYTHONQT)
+      message(FATAL_ERROR
+        "Attempting to build the Python scripted module '${MY_SLICER_NAME}'"
+        " when Slicer_USE_PYTHONQT is OFF")
+  endif()
 
   set(_no_install_subdir_option NO_INSTALL_SUBDIR)
   set(_destination_subdir "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,7 @@ mark_as_advanced(ADDITIONAL_CXX_FLAGS)
 # CMake Function(s) and Macro(s)
 #-----------------------------------------------------------------------------
 include(CMakeParseArguments)
+include(SlicerMacroBuildScriptedModule)
 include(SlicerMacroGetOperatingSystemArchitectureBitness)
 if(Slicer_BUILD_I18N_SUPPORT)
   include(SlicerMacroTranslation)

--- a/Modules/Scripted/CMakeLists.txt
+++ b/Modules/Scripted/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-include(SlicerMacroBuildScriptedModule)
-
 set(modules
   DataProbe
   DMRIInstall


### PR DESCRIPTION
```bash
CMake Error at Software/Slicer/SlicerCustomAppTemplate/build-SlicerSALT/slicersources-src/CMake/SlicerMacroBuildScriptedModule.cmake:94 (ctkMacroCompilePythonScript):
  Unknown CMake command "ctkMacroCompilePythonScript".
Call Stack (most recent call first):
  Software/Slicer/SlicerCustomAppTemplate/build-SlicerSALT/Sequences/SequenceSampleData/CMakeLists.txt:17 (slicerMacroBuildScriptedModule)
```

This is caused because the cmake macro `ctkMacroCompilePythonScript` is only included when PythonQt is on.