### PR TITLE
COMP: Add header QStyle to qSlicerAppMainWindow.

### DIFF
--- a/Applications/SlicerApp/qSlicerAppMainWindow.cxx
+++ b/Applications/SlicerApp/qSlicerAppMainWindow.cxx
@@ -24,6 +24,7 @@
 // Qt includes
 #include <QDesktopServices>
 #include <QPixmap>
+#include <QStyle>
 #include <QUrl>
 
 // Slicer includes


### PR DESCRIPTION
Solves the following incomplete type class QStyle error:

```
Software/Slicer/Slicer-src/Applications/SlicerApp/qSlicerAppMainWindow.cxx: In member function ‘virtual void qSlicerAppMainWindowPrivate::setupUi(QMainWindow*)’:
Software/Slicer/Slicer-src/Applications/SlicerApp/qSlicerAppMainWindow.cxx:138:42: error: invalid use of incomplete type ‘class QStyle’
   QIcon networkIcon = mainWindow->style()->standardIcon(QStyle::SP_DriveNetIcon);
```