### PR TITLE
ENH: Move Editor module to Legacy category

### DIFF
--- a/CMake/SlicerApplicationOptions.cmake
+++ b/CMake/SlicerApplicationOptions.cmake
@@ -65,7 +65,7 @@ mark_as_superbuild(Slicer_DEFAULT_HOME_MODULE)
 message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} default home module [${Slicer_DEFAULT_HOME_MODULE}]")
 
 if(NOT DEFINED Slicer_DEFAULT_FAVORITE_MODULES)
-  set(Slicer_DEFAULT_FAVORITE_MODULES "Data, Volumes, Models, Transforms, Markups, Editor, SegmentEditor"
+  set(Slicer_DEFAULT_FAVORITE_MODULES "Data, Volumes, Models, Transforms, Markups, SegmentEditor"
       CACHE STRING "Name of the modules shown on the toolbar by default (comma-separated list)")
   mark_as_advanced(Slicer_DEFAULT_FAVORITE_MODULES)
 endif()

--- a/Modules/Scripted/Editor/Editor.py
+++ b/Modules/Scripted/Editor/Editor.py
@@ -16,7 +16,7 @@ class Editor(ScriptedLoadableModule):
     ScriptedLoadableModule.__init__(self, parent)
     import string
     parent.title = "Editor"
-    parent.categories = ["", "Segmentation"]
+    parent.categories = ["Legacy"]
     parent.contributors = ["Steve Pieper (Isomics)"]
     parent.helpText = string.Template("""
 The Editor allows label maps to be created and edited. The active label map will be modified by the Editor.


### PR DESCRIPTION
Now Segment Editor should be used instead of Editor module.
To reduce user confusion, moved Editor module to Legacy category and removed Editor module from default Favorite module list.