### PR TITLE
COMP: Update CTK, solves missing header gcc8-VTKv9

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "f0386cba0dd62d728bca9a00a2c89bc0528ff768"
+    "26478d25fba7596d185ee70e2c6d451de57d99c3"
     QUIET
     )
 


### PR DESCRIPTION
Mainly to solve compilation error with gcc8, vtk9, solved here:
https://github.com/commontk/CTK/pull/817

```
$ git shortlog --no-merges f0386cba0dd62d728bca9a00a2c89bc0528ff768..26478d25fba7596d185ee70e2c6d451de57d99c3

Andras Lasso (1):
      ENH: Enabled Python wrapping for ctkColorDialog

Jean-Christophe Fillion-Robin (4):
      COMP: Remove obsolete use of remaining "qt5_use_modules"
      COMP: Fix missing ctkCompilerDetections_p.h when building configadmin tests
      ci: Switch to CircleCI 2.0
      ci: Remove obsolete script and dockerfiles

Pablo Hernandez-Cerdan (1):
      COMP: Missing header

jamesobutler (1):
      BUG: Fix incorrect changed settings indicator
```