### PR TITLE
BUG: Get MacOSX bundle version from Slicer_MAIN_PROJECT_VERSION_FULL

### DIFF
--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -446,8 +446,8 @@ macro(slicerMacroBuildApplication)
     set(link_flags "-Wl,-rpath,@loader_path/../")
     set_target_properties(${slicerapp_target}
       PROPERTIES
-        MACOSX_BUNDLE_BUNDLE_NAME "${SLICERAPP_APPLICATION_NAME} ${Slicer_VERSION_FULL}"
-        MACOSX_BUNDLE_BUNDLE_VERSION "${Slicer_VERSION_FULL}"
+        MACOSX_BUNDLE_BUNDLE_NAME "${SLICERAPP_APPLICATION_NAME} ${Slicer_MAIN_PROJECT_VERSION_FULL}"
+        MACOSX_BUNDLE_BUNDLE_VERSION "${Slicer_MAIN_PROJECT_VERSION_FULL}"
         MACOSX_BUNDLE_INFO_PLIST "${Slicer_CMAKE_DIR}/MacOSXBundleInfo.plist.in"
         LINK_FLAGS ${link_flags}
       )


### PR DESCRIPTION
Set MACOSX_BUNDLE_BUNDLE_NAME using Slicer_MAIN_PROJECT_VERSION_FULL, not Slicer_VERSION_FULL. Needed for custom applications.