### PR TITLE
ENH: set sys.executable in python to 'PythonSlicer'

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -902,7 +902,12 @@ void qSlicerCoreApplication::handleCommandLineArguments()
 
     // Set 'sys.executable' so that Slicer can be used as a "regular" python interpreter
     this->corePythonManager()->executeString(
-          QString("import sys; sys.executable = '%1'; del sys").arg(QStandardPaths::findExecutable("PythonSlicer")));
+          #if (QT_VERSION > QT_VERSION_CHECK(5, 0, 0))
+          QString("import sys; sys.executable = '%1'; del sys").arg(QStandardPaths::findExecutable("PythonSlicer"))
+          #else
+          QString("import sys, distutils.spawn; sys.executable = distutils.spawn.find_executable('PythonSlicer'); del sys, distutils")
+          #endif
+          );
 
     // Clean memory
     for(int i = 0; i < pythonArgc; ++i){ delete[] pythonArgv[i];}

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -902,7 +902,7 @@ void qSlicerCoreApplication::handleCommandLineArguments()
 
     // Set 'sys.executable' so that Slicer can be used as a "regular" python interpreter
     this->corePythonManager()->executeString(
-          QString("import sys; sys.executable = '%1'; del sys").arg(this->applicationFilePath()));
+          QString("import sys; sys.executable = '%1'; del sys").arg(QStandardPaths::findExecutable("PythonSlicer")));
 
     // Clean memory
     for(int i = 0; i < pythonArgc; ++i){ delete[] pythonArgv[i];}


### PR DESCRIPTION
Allows sys.executable to be used to find a functioning interpreter.

ref: https://github.com/Slicer/Slicer/pull/993#issuecomment-408999954 and comments below.