### PR TITLE
ENH: add Ext. Wizard paths by default

### DIFF
--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/LoadModulesDialog.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/LoadModulesDialog.py
@@ -33,6 +33,7 @@ class _ui_LoadModulesDialog(object):
 
     self.addToSearchPaths = qt.QCheckBox()
     vLayout.addWidget(self.addToSearchPaths)
+    self.addToSearchPaths.checked = True
 
     self.enableDeveloperMode = qt.QCheckBox()
     self.enableDeveloperMode.text = "Enable developer mode"


### PR DESCRIPTION
This sets the "Add selected modules to search path" button to checked by default (this is probably what people want most of the time):

![image](https://user-images.githubusercontent.com/327706/45122785-e0a21580-b132-11e8-9981-0ac2012a8d9f.png)

Suggested by @ljod 