### PR TITLE
BUG: Report error if --python-script associated with non-existent file

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -89,6 +89,13 @@ slicer_add_python_test(SCRIPT SlicerTestingExitSuccessTest.py)
 slicer_add_python_test(SCRIPT SlicerTestingExitFailureTest.py)
 set_tests_properties(py_SlicerTestingExitFailureTest PROPERTIES WILL_FAIL TRUE)
 
+slicer_add_python_test(
+  SCRIPT SlicerTestingWithNonExistentScriptTest.py
+  SLICER_ARGS --no-main-window --disable-modules --exit-after-startup
+  TESTNAME_PREFIX nomainwindow_
+  )
+set_tests_properties(py_nomainwindow_SlicerTestingWithNonExistentScriptTest PROPERTIES WILL_FAIL TRUE)
+
 #
 # Check if 'slicer.testing.runUnitTest()' works as expected
 #

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -928,14 +928,15 @@ void qSlicerCoreApplication::handleCommandLineArguments()
     // Execute python script
     if(!pythonScript.isEmpty())
       {
+      qApp->processEvents();
       if (QFile::exists(pythonScript))
         {
-        qApp->processEvents();
         this->corePythonManager()->executeFile(pythonScript);
         }
       else
         {
-        qWarning() << "Specified python script doesn't exist:" << pythonScript;
+        this->corePythonManager()->executeString(
+              QString("raise RuntimeError(\"Specified python script doesn't exist: %1\")").arg(pythonScript));
         }
       }
     QString pythonCode = options->pythonCode();


### PR DESCRIPTION
This commit ensures an exception is raised when the python script does not
exist. When associated with the --exit-after-startup option, a non-zero status
code is now returned when Slicer exit.