### PR TITLE
Improve macos packaging for Slicer extension

### DIFF
--- a/CMake/SlicerExtensionCPack.cmake
+++ b/CMake/SlicerExtensionCPack.cmake
@@ -160,9 +160,20 @@ else()
   set(_is_superbuild_extension 0)
 endif()
 
+set(_has_cpack_cmake_install_projects 0)
 if(_is_superbuild_extension)
+  set(_has_cpack_cmake_install_projects 1)
   if("${CPACK_INSTALL_CMAKE_PROJECTS}" STREQUAL "")
     message(FATAL_ERROR "${EXTENSION_NAME}: Variable CPACK_INSTALL_CMAKE_PROJECTS is expected to be set.")
+  endif()
+else()
+  set(msg "Checking if CPACK_INSTALL_CMAKE_PROJECTS is defined")
+  message(STATUS "${msg}")
+  if(DEFINED CPACK_INSTALL_CMAKE_PROJECTS)
+    message(STATUS "${msg} - yes")
+    set(_has_cpack_cmake_install_projects 1)
+  else()
+    message(STATUS "${msg} - no")
   endif()
 endif()
 
@@ -212,7 +223,7 @@ if(APPLE)
   #------------------------------------------------------------------------------
   # Add install rule ensuring the "fix-up" script is executed at packaging time
   #------------------------------------------------------------------------------
-  if(NOT _is_superbuild_extension)
+  if(NOT _has_cpack_cmake_install_projects)
 
     message(STATUS "Extension fixup mode: adding <cpack_bundle_fixup_directory>")
     # HACK - For a given directory, "install(SCRIPT ...)" rule will be evaluated first,

--- a/CMake/SlicerExtensionCPackBundleFixup.cmake.in
+++ b/CMake/SlicerExtensionCPackBundleFixup.cmake.in
@@ -174,6 +174,12 @@ function(fixup_extension ext libs dirs)
   message(STATUS "  libs='${libs}'")
   message(STATUS "  dirs='${dirs}'")
 
+  set(extension_build_dir "@CMAKE_BINARY_DIR@")
+  set(_is_superbuild_extension @_is_superbuild_extension@)
+  if(_is_superbuild_extension)
+    get_filename_component(extension_build_dir ${extension_build_dir}/.. ABSOLUTE)
+  endif()
+
   #get_bundle_and_executable("${ext}" bundle executable valid)
   set(bundle "${ext}")
   message(STATUS "  bundle='${bundle}'")
@@ -211,9 +217,24 @@ function(fixup_extension ext libs dirs)
         message(STATUS "")
       endif()
 
-      string(FIND "${${key}_ITEM}" "@Slicer_SUPERBUILD_DIR@" pos)
       set(key_skip 0)
+
+      # Check if the item belong to an extension package itself built within a
+      # "Slicer" build tree. This may be done in custom application (e.g SlicerSALT)
+      # where bundling a specific extension (through -DSlicer_EXTENSION_SOURCE_DIRS=...)
+      # is not possible and instead the extension is packaged first and its content
+      # is then copied into the custom application package.
+      set(in_extension_build_dir_within_slicer_build_dir 0)
+      string(FIND "${extension_build_dir}" "@Slicer_SUPERBUILD_DIR@" pos)
       if(${pos} EQUAL 0)
+        string(FIND "${${key}_ITEM}" "${extension_build_dir}" pos)
+        if(${pos} EQUAL 0)
+          set(in_extension_build_dir_within_slicer_build_dir 1)
+        endif()
+      endif()
+
+      string(FIND "${${key}_ITEM}" "@Slicer_SUPERBUILD_DIR@" pos)
+      if(${pos} EQUAL 0 AND NOT in_extension_build_dir_within_slicer_build_dir)
         message(STATUS "${i}/${n}: skipping '${${key}_ITEM}'")
         set(key_skip 1)
       endif()

--- a/CMake/SlicerExtensionCPackBundleFixup.cmake.in
+++ b/CMake/SlicerExtensionCPackBundleFixup.cmake.in
@@ -92,6 +92,21 @@ function(gp_item_default_embedded_path_override item default_embedded_path_var)
     set(path "@fixup_path@/@Slicer_BUNDLE_EXTENSIONS_LOCATION@@Slicer_THIRDPARTY_LIB_DIR@")
   endif()
 
+  set(extension_build_dir "@CMAKE_BINARY_DIR@")
+  set(_is_superbuild_extension @_is_superbuild_extension@)
+  if(_is_superbuild_extension)
+    get_filename_component(extension_build_dir ${extension_build_dir}/.. ABSOLUTE)
+  endif()
+
+  # Libraries that are not part of the Slicer build tree and not part of the extension
+  # build tree are considered as third-party libraries.
+  if(NOT item MATCHES "@Slicer_SUPERBUILD_DIR@"
+      AND NOT item MATCHES "${extension_build_dir}"
+      AND item MATCHES "\\.(so|dylib)$"
+      )
+    set(path "@fixup_path@/@Slicer_BUNDLE_EXTENSIONS_LOCATION@@Slicer_THIRDPARTY_LIB_DIR@")
+  endif()
+
   math(EXPR lib_current $ENV{FIXUP_LIB_CURRENT}+1)
   set(ENV{FIXUP_LIB_CURRENT} ${lib_current})
   #gp_log_message("${lib_current}/$ENV{FIXUP_LIBS_COUNT} - fixing item ${item} with ${path}")


### PR DESCRIPTION
This PR is here for review. More testing will be performed after I am back of traveling two weeks.

These changes were originally motivated to support packaging of SlicerSALT (a custom Slicer application used to disseminate powerful shape analysis methodology based on 3D Slicer open-source software). See http://salt.slicer.org/