### PR TITLE
COMP: Fix warning catching exception by value

### DIFF
--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx
@@ -121,7 +121,7 @@ DiffusionTensor3DWrite<TData>
     writer->Update();
     return 0;
     }
-  catch( itk::ExceptionObject excep )
+  catch( itk::ExceptionObject &excep )
     {
     std::cerr
     << "DiffusionTensor3DWrite::Write: exception caught !" << std::endl;


### PR DESCRIPTION
```
[1378/4728] Building CXX object Modules/CLI/CastScalarVolume/CMakeFiles/CastScalarVolumeLib.dir/CastScalarVolume.cxx.o
In file included from Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.h:99,
                 from Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx:28:
Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx: In instantiation of ‘int itk::DiffusionTensor3DWrite<TData>::Update(const char*) [with TData = float]’:
Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx:1075:5:   required from ‘int {anonymous}::Do({anonymous}::parameters) [with PixelType = float]’
Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx:1141:30:   required from here
Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx:124:3: warning: catching polymorphic type ‘class itk::ExceptionObject’ by value [-Wcatch-value=]
   catch( itk::ExceptionObject excep )
   ^~~~~
Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx: In instantiation of ‘int itk::DiffusionTensor3DWrite<TData>::Update(const char*) [with TData = double]’:
Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx:1075:5:   required from ‘int {anonymous}::Do({anonymous}::parameters) [with PixelType = double]’
Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx:1144:31:   required from here
Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWrite.txx:124:3: warning: catching polymorphic type ‘class itk::ExceptionObject’ by value [-Wcatch-value=]
```