### PR TITLE
ENH: Disable TCL Bridge by default  See #4625

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ CMAKE_DEPENDENT_OPTION(
 mark_as_superbuild(Slicer_USE_PYTHONQT_WITH_OPENSSL)
 
 CMAKE_DEPENDENT_OPTION(
-  Slicer_USE_PYTHONQT_WITH_TCL "Enable PythonQt Tcl adapter layer" ON
+  Slicer_USE_PYTHONQT_WITH_TCL "Enable PythonQt Tcl adapter layer" OFF
   "Slicer_USE_PYTHONQT" OFF)
 mark_as_superbuild(Slicer_USE_PYTHONQT_WITH_TCL)
 


### PR DESCRIPTION
Disabling TCL since it is only used by EMSegment, which is
non-functional.  Disabling the TCL option will also disable
EMSegment