### PR TITLE
BUG: Fix default display and storage node creation

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLBSplineTransformNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLBSplineTransformNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLBSplineTransformNode.h"
 #include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLBSplineTransformNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLBSplineTransformNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLColorTableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLColorTableNodeTest1.cxx
@@ -27,7 +27,11 @@ using namespace vtkMRMLCoreTestingUtilities;
 int vtkMRMLColorTableNodeTest1(int argc, char * argv[])
 {
   vtkNew<vtkMRMLColorTableNode> node1;
-  EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+  {
+    vtkNew<vtkMRMLScene> scene;
+    scene->AddNode(node1);
+    EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+  }
 
   if (argc != 2)
     {
@@ -57,15 +61,15 @@ int vtkMRMLColorTableNodeTest1(int argc, char * argv[])
     colorNode->SetColor(2, "two", 0.0, 1.0, 0.0, 1.0);
     colorNode->NamesInitialisedOn();
 
-    vtkSmartPointer<vtkMRMLStorageNode> colorStorageNode =
-        vtkSmartPointer<vtkMRMLStorageNode>::Take(colorNode->CreateDefaultStorageNode());
-
     // add node to the scene
     vtkNew<vtkMRMLScene> scene;
     scene->SetRootDirectory(tempDir);
     CHECK_NOT_NULL(scene->AddNode(colorNode.GetPointer()));
 
     // add storage node to the scene
+    vtkSmartPointer<vtkMRMLStorageNode> colorStorageNode =
+        vtkSmartPointer<vtkMRMLStorageNode>::Take(colorNode->CreateDefaultStorageNode());
+
     scene->AddNode(colorStorageNode);
     colorNode->SetAndObserveStorageNodeID(colorStorageNode->GetID());
 

--- a/Libs/MRML/Core/Testing/vtkMRMLDiffusionImageVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDiffusionImageVolumeNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLDiffusionImageVolumeNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLDiffusionImageVolumeNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLDiffusionImageVolumeNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLDiffusionTensorVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDiffusionTensorVolumeNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLDiffusionTensorVolumeNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLDiffusionTensorVolumeNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLDiffusionTensorVolumeNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLDiffusionWeightedVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDiffusionWeightedVolumeNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLDiffusionWeightedVolumeNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLDiffusionWeightedVolumeNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLDiffusionWeightedVolumeNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDoubleArrayNodeTest1.cxx
@@ -14,6 +14,7 @@
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLDoubleArrayNode.h"
 #include "vtkMRMLDoubleArrayStorageNode.h"
+#include "vtkMRMLScene.h"
 
 // VTK includes
 #include <vtkNew.h>
@@ -39,6 +40,8 @@ bool TestReadOldFile(std::string filepath);
 int vtkMRMLDoubleArrayNodeTest1(int argc, char * argv[])
 {
   vtkNew<vtkMRMLDoubleArrayNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
 
   if (argc != 3)

--- a/Libs/MRML/Core/Testing/vtkMRMLFiducialListNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLFiducialListNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLFiducialListNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLFiducialListNodeTest1(int , char * [] )
 {
   vtkNew< vtkMRMLFiducialListNode > node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLFreeSurferProceduralColorNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLFreeSurferProceduralColorNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLFreeSurferProceduralColorNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLFreeSurferProceduralColorNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLFreeSurferProceduralColorNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   node1->SetTypeToBlueRed();
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;

--- a/Libs/MRML/Core/Testing/vtkMRMLGridTransformNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLGridTransformNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLGridTransformNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLGridTransformNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLGridTransformNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLLinearTransformNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLLinearTransformNodeTest1.cxx
@@ -12,11 +12,14 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLLinearTransformNode.h"
+#include "vtkMRMLScene.h"
 
 //---------------------------------------------------------------------------
 int vtkMRMLLinearTransformNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLLinearTransformNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLModelNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLModelNodeTest1.cxx
@@ -13,6 +13,7 @@
 // MRML includes
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLModelNode.h"
+#include "vtkMRMLScene.h"
 
 // VTK includes
 #include <vtkDataSetAttributes.h>
@@ -38,6 +39,8 @@ int vtkMRMLModelNodeTest1(int , char * [] )
 int ExerciseBasicMethods()
 {
   vtkNew<vtkMRMLModelNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLPETProceduralColorNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLPETProceduralColorNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLPETProceduralColorNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLPETProceduralColorNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLPETProceduralColorNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLProceduralColorNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLProceduralColorNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLProceduralColorNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLProceduralColorNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLProceduralColorNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLScalarVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLScalarVolumeNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLScalarVolumeNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLScalarVolumeNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLScalarVolumeNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneViewNodeTest1.cxx
@@ -23,19 +23,17 @@
 int vtkMRMLSceneViewNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLSceneViewNode> node1;
-  EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
 
   // test with null scene
   node1->StoreScene();
   node1->SetAbsentStorageFileNames();
-  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   vtkCollection *col = node1->GetNodesByClass(NULL);
-  TESTING_OUTPUT_ASSERT_ERRORS_END();
   CHECK_NULL(col);
 
   // make a scene and test again
   vtkNew<vtkMRMLScene> scene;
-  node1->SetScene(scene.GetPointer());
+  scene->AddNode(node1);
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   node1->StoreScene();
 
   vtkMRMLScene *storedScene = node1->GetStoredScene();

--- a/Libs/MRML/Core/Testing/vtkMRMLTableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTableNodeTest1.cxx
@@ -20,6 +20,7 @@
 
 ==============================================================================*/
 
+#include "vtkMRMLScene.h"
 #include "vtkMRMLTableNode.h"
 #include "vtkMRMLTableStorageNode.h"
 
@@ -31,10 +32,14 @@
 
 int vtkMRMLTableNodeTest1(int , char * [] )
 {
+  vtkNew<vtkMRMLScene> scene;
+
   vtkNew<vtkMRMLTableNode> node1;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
 
   vtkNew<vtkMRMLTableNode> node2;
+  scene->AddNode(node2);
 
   vtkTable* table = node2->GetTable();
   CHECK_NOT_NULL(table);

--- a/Libs/MRML/Core/Testing/vtkMRMLTensorVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTensorVolumeNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLTensorVolumeNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLTensorVolumeNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLTensorVolumeNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLTransformNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTransformNodeTest1.cxx
@@ -38,6 +38,8 @@ vtkMatrix4x4* CreateTransformMatrix(double translateX, double translateY, double
 int vtkMRMLTransformNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLTransformNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   vtkNew<vtkMatrix4x4> linearTransform;
   node1->SetMatrixTransformToParent(linearTransform.GetPointer());
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
@@ -64,7 +66,7 @@ int vtkMRMLTransformNodeTest1(int , char * [] )
   qTransform->SetMatrixTransformToParent(b_from_q_mx.GetPointer());
   rTransform->SetMatrixTransformToParent(q_from_r_mx.GetPointer());
 
-  // Create transfor hierarchy in the scene
+  // Create transform hierarchy in the scene
   //
   // WORLD -> w coordinate system
   //  |-- bTransform
@@ -74,7 +76,6 @@ int vtkMRMLTransformNodeTest1(int , char * [] )
   //         |-- qTransform
   //                |-- rTransform
   //
-  vtkNew<vtkMRMLScene> scene;
   scene->AddNode(bTransform.GetPointer());
   scene->AddNode(cTransform.GetPointer());
   scene->AddNode(dTransform.GetPointer());

--- a/Libs/MRML/Core/Testing/vtkMRMLVectorVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLVectorVolumeNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLVectorVolumeNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLVectorVolumeNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLVectorVolumeNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/Testing/vtkMRMLdGEMRICProceduralColorNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLdGEMRICProceduralColorNodeTest1.cxx
@@ -12,10 +12,13 @@
 
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLdGEMRICProceduralColorNode.h"
+#include "vtkMRMLScene.h"
 
 int vtkMRMLdGEMRICProceduralColorNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLdGEMRICProceduralColorNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
@@ -1429,7 +1429,13 @@ void vtkMRMLColorTableNode::Reset(vtkMRMLNode* defaultNode)
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLColorTableNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLColorTableStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(scene->CreateNodeByClass("vtkMRMLColorTableStorageNode"));
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
+++ b/Libs/MRML/Core/vtkMRMLCoreTestingUtilities.cxx
@@ -188,9 +188,6 @@ int ExerciseBasicMRMLMethods(vtkMRMLNode* node)
   node1->SetName("copywithscenewithsinglemodified");
   node->CopyWithSceneWithSingleModifiedEvent(node1);
 
-  //  Test GetScene()
-  CHECK_NULL(node->GetScene());
-
   //  Test UpdateReferences()
   node->UpdateReferences();
   node->UpdateReferenceID("oldID", "newID");
@@ -201,7 +198,6 @@ int ExerciseBasicMRMLMethods(vtkMRMLNode* node)
 
   //  Test ReadXMLAttributes()
   const char *atts[] = {
-            "id", "vtkMRMLNodeTest1",
             "name", "MyName",
             "description", "Testing a mrml node",
             "hideFromEditors", "false",
@@ -209,8 +205,6 @@ int ExerciseBasicMRMLMethods(vtkMRMLNode* node)
             "selected", "true",
             NULL};
   node->ReadXMLAttributes(atts);
-
-  CHECK_STRING(node->GetID(), "vtkMRMLNodeTest1");
 
   //  Test WriteXML
   std::cout << "WriteXML output:" << std::endl << "------------------" << std::endl;

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeNode.cxx
@@ -66,7 +66,14 @@ vtkMRMLDiffusionTensorVolumeDisplayNode* vtkMRMLDiffusionTensorVolumeNode
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLDiffusionTensorVolumeNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLNRRDStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLNRRDStorageNode"));
 }
 
 //----------------------------------------------------------------------------
@@ -82,8 +89,8 @@ void vtkMRMLDiffusionTensorVolumeNode::CreateDefaultDisplayNodes()
     vtkErrorMacro("vtkMRMLDiffusionTensorVolumeNode::CreateDefaultDisplayNodes failed: scene is invalid");
     return;
     }
-  vtkNew<vtkMRMLDiffusionTensorVolumeDisplayNode> dispNode;
-  this->GetScene()->AddNode(dispNode.GetPointer());
+  vtkMRMLDiffusionTensorVolumeDisplayNode* dispNode = vtkMRMLDiffusionTensorVolumeDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLDiffusionTensorVolumeDisplayNode") );
   dispNode->SetDefaultColorMap();
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
   // add slice display nodes

--- a/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.cxx
@@ -446,7 +446,14 @@ vtkMRMLDiffusionWeightedVolumeDisplayNode* vtkMRMLDiffusionWeightedVolumeNode::G
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLDiffusionWeightedVolumeNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLNRRDStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLNRRDStorageNode"));
 }
 
 //----------------------------------------------------------------------------
@@ -462,8 +469,8 @@ void vtkMRMLDiffusionWeightedVolumeNode::CreateDefaultDisplayNodes()
     vtkErrorMacro("vtkMRMLDiffusionWeightedVolumeNode::CreateDefaultDisplayNodes failed: scene is invalid");
     return;
     }
-  vtkNew<vtkMRMLDiffusionWeightedVolumeDisplayNode> dispNode;
-  this->GetScene()->AddNode(dispNode.GetPointer());
+  vtkMRMLDiffusionWeightedVolumeDisplayNode* dispNode = vtkMRMLDiffusionWeightedVolumeDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLDiffusionWeightedVolumeDisplayNode") );
   dispNode->SetDefaultColorMap();
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }

--- a/Libs/MRML/Core/vtkMRMLDoubleArrayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDoubleArrayNode.cxx
@@ -15,6 +15,7 @@ Version:   $Revision: 1.2 $
 // MRML includes
 #include "vtkMRMLDoubleArrayNode.h"
 #include "vtkMRMLDoubleArrayStorageNode.h"
+#include "vtkMRMLScene.h"
 
 // VTK includes
 #include <vtkDoubleArray.h>
@@ -298,10 +299,10 @@ int vtkMRMLDoubleArrayNode::GetXYValue(int index, double* x, double* y)
 
   std::vector<double> tuple(this->Array->GetNumberOfComponents());
   int success = this->GetValues(index, &tuple[0]);
-  
+
   *x = tuple[0];
   *y = tuple[1];
-  
+
   return success;
 }
 
@@ -624,11 +625,13 @@ void vtkMRMLDoubleArrayNode::GetYRange(double* range, int fIncludeError)
 
 }
 
+//---------------------------------------------------------------------------
 void vtkMRMLDoubleArrayNode::SetLabels(const LabelsVectorType &labels)
 {
    this->Labels = labels;
 }
 
+//---------------------------------------------------------------------------
 const vtkMRMLDoubleArrayNode::LabelsVectorType & vtkMRMLDoubleArrayNode::GetLabels() const
 {
     return this->Labels;
@@ -638,5 +641,12 @@ const vtkMRMLDoubleArrayNode::LabelsVectorType & vtkMRMLDoubleArrayNode::GetLabe
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLDoubleArrayNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLDoubleArrayStorageNode::New();
-};
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLDoubleArrayStorageNode"));
+}

--- a/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
@@ -1666,7 +1666,14 @@ void vtkMRMLFiducialListNode::ApplyTransform(vtkAbstractTransform* transform)
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLFiducialListNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLFiducialListStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLFiducialListStorageNode"));
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.cxx
@@ -71,8 +71,8 @@ void vtkMRMLLabelMapVolumeNode::CreateDefaultDisplayNodes()
     vtkErrorMacro("vtkMRMLLabelMapVolumeNode::CreateDefaultDisplayNodes failed: scene is invalid");
     return;
     }
-  vtkNew<vtkMRMLLabelMapVolumeDisplayNode> dispNode;
-  this->GetScene()->AddNode(dispNode.GetPointer());
+  vtkMRMLLabelMapVolumeDisplayNode* dispNode = vtkMRMLLabelMapVolumeDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLLabelMapVolumeDisplayNode") );
   dispNode->SetDefaultColorMap();
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }

--- a/Libs/MRML/Core/vtkMRMLModelNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelNode.cxx
@@ -803,7 +803,14 @@ void vtkMRMLModelNode::TransformBoundsToRAS(double inputBounds_Local[6], double 
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLModelNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLModelStorageNode::New());
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLModelStorageNode"));
 }
 
 //---------------------------------------------------------------------------
@@ -835,12 +842,14 @@ void vtkMRMLModelNode::CreateDefaultDisplayNodes()
     // display node already exists
     return;
     }
-  if (this->GetScene()==NULL)
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
     {
     vtkErrorMacro("vtkMRMLModelNode::CreateDefaultDisplayNodes failed: scene is invalid");
     return;
     }
-  vtkNew<vtkMRMLModelDisplayNode> dispNode;
+  vtkMRMLModelDisplayNode* dispNode = vtkMRMLModelDisplayNode::SafeDownCast(
+    scene->AddNewNodeByClass("vtkMRMLModelDisplayNode") );
 
   if (this->GetMesh())
     {
@@ -859,7 +868,6 @@ void vtkMRMLModelNode::CreateDefaultDisplayNodes()
     dispNode->SetAndObserveColorNodeID("vtkMRMLFreeSurferProceduralColorNodeRedGreen");
     }
 
-  this->GetScene()->AddNode( dispNode.GetPointer() );
   this->SetAndObserveDisplayNodeID( dispNode->GetID() );
 }
 

--- a/Libs/MRML/Core/vtkMRMLProceduralColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLProceduralColorNode.cxx
@@ -15,6 +15,7 @@ Version:   $Revision: 1.0 $
 // MRML includes
 #include "vtkMRMLProceduralColorNode.h"
 #include "vtkMRMLProceduralColorStorageNode.h"
+#include "vtkMRMLScene.h"
 
 // VTK includes
 #include <vtkColorTransferFunction.h>
@@ -262,7 +263,14 @@ bool vtkMRMLProceduralColorNode::GetColor(int entry, double color[4])
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode * vtkMRMLProceduralColorNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLProceduralColorStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLProceduralColorStorageNode"));
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -152,7 +152,14 @@ void vtkMRMLScalarVolumeNode::PrintSelf(ostream& os, vtkIndent indent)
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLScalarVolumeNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLVolumeArchetypeStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLVolumeArchetypeStorageNode"));
 }
 
 //----------------------------------------------------------------------------
@@ -168,8 +175,8 @@ void vtkMRMLScalarVolumeNode::CreateDefaultDisplayNodes()
     vtkErrorMacro("vtkMRMLScalarVolumeNode::CreateDefaultDisplayNodes failed: scene is invalid");
     return;
     }
-  vtkNew<vtkMRMLScalarVolumeDisplayNode> dispNode;
-  this->GetScene()->AddNode(dispNode.GetPointer());
+  vtkMRMLScalarVolumeDisplayNode* dispNode = vtkMRMLScalarVolumeDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLScalarVolumeDisplayNode") );
   dispNode->SetDefaultColorMap();
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }

--- a/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSceneViewNode.cxx
@@ -707,7 +707,14 @@ void vtkMRMLSceneViewNode::SetAbsentStorageFileNames()
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLSceneViewNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLSceneViewStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLSceneViewStorageNode"));
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -377,7 +377,14 @@ void vtkMRMLSegmentationNode::OnSubjectHierarchyUIDAdded(
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLSegmentationNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLSegmentationStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLSegmentationStorageNode"));
 }
 
 //----------------------------------------------------------------------------
@@ -393,8 +400,8 @@ void vtkMRMLSegmentationNode::CreateDefaultDisplayNodes()
     vtkErrorMacro("vtkMRMLSegmentationNode::CreateDefaultDisplayNodes failed: Scene is invalid");
     return;
     }
-  vtkNew<vtkMRMLSegmentationDisplayNode> displayNode;
-  this->GetScene()->AddNode(displayNode.GetPointer());
+  vtkMRMLSegmentationDisplayNode* displayNode = vtkMRMLSegmentationDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLSegmentationDisplayNode") );
   this->SetAndObserveDisplayNodeID(displayNode->GetID());
 }
 

--- a/Libs/MRML/Core/vtkMRMLTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableNode.cxx
@@ -21,6 +21,7 @@
 ==============================================================================*/
 
 // MRML includes
+#include "vtkMRMLScene.h"
 #include "vtkMRMLTableNode.h"
 #include "vtkMRMLTableStorageNode.h"
 
@@ -238,7 +239,14 @@ void vtkMRMLTableNode::PrintSelf(ostream& os, vtkIndent indent)
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLTableNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLTableStorageNode::New());
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLTableStorageNode"));
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTensorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTensorVolumeNode.cxx
@@ -14,8 +14,9 @@ Version:   $Revision: 1.14 $
 
 // MRML includes
 #include "vtkMRMLDiffusionTensorVolumeDisplayNode.h"
-#include "vtkMRMLTensorVolumeNode.h"
 #include "vtkMRMLNRRDStorageNode.h"
+#include "vtkMRMLScene.h"
+#include "vtkMRMLTensorVolumeNode.h"
 
 // VTK includes
 #include <vtkImageData.h>
@@ -217,6 +218,12 @@ void vtkMRMLTensorVolumeNode::PrintSelf(ostream& os, vtkIndent indent)
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLTensorVolumeNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLNRRDStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLNRRDStorageNode"));
 }
-

--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -782,7 +782,14 @@ bool vtkMRMLTransformNode::IsAbstractTransformComputedFromInverse(vtkAbstractTra
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLTransformNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLTransformStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLTransformStorageNode"));
 }
 
 //----------------------------------------------------------------------------
@@ -798,8 +805,8 @@ void vtkMRMLTransformNode::CreateDefaultDisplayNodes()
     vtkErrorMacro("vtkMRMLTransformNode::CreateDefaultDisplayNodes failed: scene is invalid");
     return;
     }
-  vtkNew<vtkMRMLTransformDisplayNode> dispNode;
-  this->GetScene()->AddNode(dispNode.GetPointer());
+  vtkMRMLTransformDisplayNode* dispNode = vtkMRMLTransformDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLTransformDisplayNode") );
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }
 

--- a/Libs/MRML/Core/vtkMRMLVectorVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVectorVolumeNode.cxx
@@ -72,7 +72,14 @@ vtkMRMLVectorVolumeDisplayNode* vtkMRMLVectorVolumeNode::GetVectorVolumeDisplayN
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLVectorVolumeNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLVolumeArchetypeStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLVolumeArchetypeStorageNode"));
 }
 
 //----------------------------------------------------------------------------
@@ -88,8 +95,8 @@ void vtkMRMLVectorVolumeNode::CreateDefaultDisplayNodes()
     vtkErrorMacro("vtkMRMLVectorVolumeNode::CreateDefaultDisplayNodes failed: scene is invalid");
     return;
     }
-  vtkNew<vtkMRMLVectorVolumeDisplayNode> dispNode;
-  this->GetScene()->AddNode(dispNode.GetPointer());
+  vtkMRMLVectorVolumeDisplayNode* dispNode = vtkMRMLVectorVolumeDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLVectorVolumeDisplayNode") );
   dispNode->SetDefaultColorMap();
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationAngleNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationAngleNode.cxx
@@ -1,14 +1,18 @@
-#include <sstream>
-
+//MRML includes
 #include "vtkMRMLAnnotationAngleNode.h"
 #include "vtkMRMLAnnotationTextDisplayNode.h"
 #include "vtkMRMLAnnotationPointDisplayNode.h"
 #include "vtkMRMLAnnotationLineDisplayNode.h"
 #include "vtkMRMLAnnotationAngleStorageNode.h"
+#include "vtkMRMLScene.h"
 
+// VTK includes
 #include <vtkAbstractTransform.h>
 #include <vtkObjectFactory.h>
 #include <vtkMatrix4x4.h>
+
+// STD includes
+#include <sstream>
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLAnnotationAngleNode);
@@ -492,7 +496,14 @@ void vtkMRMLAnnotationAngleNode::ApplyTransform(vtkAbstractTransform* transform)
 //-------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLAnnotationAngleNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLAnnotationAngleStorageNode::New());
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLAnnotationAngleStorageNode"));
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationControlPointsNode.cxx
@@ -482,7 +482,14 @@ const char *vtkMRMLAnnotationControlPointsNode::GetAttributeTypesEnumAsString(in
 //-------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLAnnotationControlPointsNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLAnnotationControlPointsStorageNode::New());
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLAnnotationControlPointsStorageNode"));
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
@@ -437,9 +437,15 @@ const char *vtkMRMLAnnotationLinesNode::GetAttributeTypesEnumAsString(int val)
 //-------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLAnnotationLinesNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLAnnotationLinesStorageNode::New());
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLAnnotationLinesStorageNode"));
 }
-
 
 //---------------------------------------------------------------------------
 int  vtkMRMLAnnotationLinesNode::SetLine(int id, int ctrlPtIdStart, int ctrlPtIdEnd,int selectedFlag, int visibleFlag)

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationNode.cxx
@@ -584,7 +584,14 @@ std::string vtkMRMLAnnotationNode::GetDefaultStorageNodeClassName(const char* fi
 //-------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLAnnotationNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLAnnotationStorageNode::New());
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLAnnotationStorageNode"));
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationRulerNode.cxx
@@ -1,15 +1,19 @@
-#include <sstream>
-
+// MRML includes
 #include "vtkMRMLAnnotationRulerNode.h"
 #include "vtkMRMLAnnotationTextDisplayNode.h"
 #include "vtkMRMLAnnotationPointDisplayNode.h"
 #include "vtkMRMLAnnotationLineDisplayNode.h"
 #include "vtkMRMLAnnotationRulerStorageNode.h"
+#include "vtkMRMLScene.h"
 
+// VTK includes
 #include <vtkAbstractTransform.h>
 #include <vtkObjectFactory.h>
 #include <vtkMath.h>
 #include <vtkMatrix4x4.h>
+
+// STD includes
+#include <sstream>
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLAnnotationRulerNode);
@@ -365,7 +369,14 @@ void vtkMRMLAnnotationRulerNode::ApplyTransform(vtkAbstractTransform* transform)
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLAnnotationRulerNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLAnnotationRulerStorageNode::New());
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLAnnotationRulerStorageNode"));
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationSnapshotNode.cxx
@@ -1,6 +1,7 @@
 // MRML includes
 #include "vtkMRMLAnnotationSnapshotNode.h"
 #include "vtkMRMLAnnotationSnapshotStorageNode.h"
+#include "vtkMRMLScene.h"
 
 // VTKsys includes
 #include <vtksys/SystemTools.hxx>
@@ -97,7 +98,14 @@ void vtkMRMLAnnotationSnapshotNode::ReadXMLAttributes(const char** atts)
 //----------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLAnnotationSnapshotNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLAnnotationSnapshotStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLAnnotationSnapshotStorageNode"));
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationAngleNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationAngleNodeTest1.cxx
@@ -8,33 +8,33 @@
 
 int vtkMRMLAnnotationAngleNodeTest1(int , char * [] )
 {
-
   // ======================
   // Basic Setup
   // ======================
 
-  vtkSmartPointer< vtkMRMLAnnotationAngleNode > node2 = vtkSmartPointer< vtkMRMLAnnotationAngleNode >::New();
-  vtkSmartPointer<vtkMRMLScene> mrmlScene = vtkSmartPointer<vtkMRMLScene>::New();
-  // node2->Initialize(mrmlScene);
+  vtkNew<vtkMRMLAnnotationAngleNode> node2;
+  vtkNew<vtkMRMLScene> mrmlScene;
+  vtkNew<vtkMRMLAnnotationAngleNode> node1;
+  mrmlScene->AddNode(node1);
 
-  {
+  node1->UpdateReferences();
+  node2->Copy( node1 );
 
-    vtkSmartPointer< vtkMRMLAnnotationAngleNode > node1 = vtkSmartPointer< vtkMRMLAnnotationAngleNode >::New();
-    // node1->Initialize(mrmlScene);
-    EXERCISE_ALL_BASIC_MRML_METHODS(node1);
+  mrmlScene->RegisterNodeClass(node1);
+  mrmlScene->AddNode(node2);
 
-    node1->UpdateReferences();
-    node2->Copy( node1 );
+  vtkNew<vtkMRMLAnnotationAngleStorageNode> prototypeStorageNode;
+  mrmlScene->RegisterNodeClass(prototypeStorageNode);
+  vtkMRMLAnnotationAngleStorageNode *storNode = vtkMRMLAnnotationAngleStorageNode::SafeDownCast(
+    node2->CreateDefaultStorageNode());
 
-    mrmlScene->RegisterNodeClass(node1);
-    mrmlScene->AddNode(node2);
-  }
-  vtkMRMLAnnotationAngleStorageNode *storNode = dynamic_cast <vtkMRMLAnnotationAngleStorageNode *> (node2->CreateDefaultStorageNode());
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1);
+  mrmlScene->RemoveNode(node1);
 
   if( !storNode )
     {
-      std::cerr << "Error in CreateDefaultStorageNode()" << std::endl;
-      return EXIT_FAILURE;
+    std::cerr << "Error in CreateDefaultStorageNode()" << std::endl;
+    return EXIT_FAILURE;
     }
   storNode->Delete();
 
@@ -45,8 +45,6 @@ int vtkMRMLAnnotationAngleNodeTest1(int , char * [] )
   // ======================
   node2->Reset(NULL);
   node2->StartModify();
-  // node2->Initialize(mrmlScene);
-
 
   node2->SetName("AnnotationAngleNodeTest") ;
 
@@ -66,23 +64,20 @@ int vtkMRMLAnnotationAngleNodeTest1(int , char * [] )
     node2->SetPositionCenter(ctp);
   }
 
-
   int vis = 1;
   node2->SetRay1Visibility(vis);
-
 
   double *ctrlPointID = node2->GetPositionCenter();
 
   if (ctrlPointID[0]!= 1 || (ctrlPointID[1] != 2) || (ctrlPointID[2] != 3) ||  node2->GetRay1Visibility() != vis)
     {
-      std::cerr << "Error in Array Attributes: "  << ctrlPointID[0] << "!=1, " << ctrlPointID[1]<< "!=2" << ctrlPointID[2]<< "!=3, "
-        << node2->GetRay1Visibility() <<"!="<< vis << std::endl;
-      return EXIT_FAILURE;
+    std::cerr << "Error in Array Attributes: "  << ctrlPointID[0] << "!=1, " << ctrlPointID[1]<< "!=2" << ctrlPointID[2]<< "!=3, "
+      << node2->GetRay1Visibility() <<"!="<< vis << std::endl;
+    return EXIT_FAILURE;
     }
 
   vtkIndent ind;
   node2->PrintAnnotationInfo(cout,ind);
-
 
   cout << "Passed Adding and Deleting Data" << endl;
 
@@ -101,21 +96,18 @@ int vtkMRMLAnnotationAngleNodeTest1(int , char * [] )
 
   if (mrmlScene->GetNumberOfNodesByClass("vtkMRMLAnnotationAngleNode") != 1)
     {
-        std::cerr << "Error in ReadXML() or WriteXML() - Did not create a class called vtkMRMLAnnotationAngleNode" << std::endl;
+    std::cerr << "Error in ReadXML() or WriteXML() - Did not create a class called vtkMRMLAnnotationAngleNode" << std::endl;
     return EXIT_FAILURE;
     }
 
   vtkMRMLAnnotationAngleNode *node3 = vtkMRMLAnnotationAngleNode::SafeDownCast(mrmlScene->GetFirstNodeByClass("vtkMRMLAnnotationAngleNode"));
   if (!node3)
-      {
+    {
     std::cerr << "Error in ReadXML() or WriteXML(): could not find vtkMRMLAnnotationAngleNode" << std::endl;
     return EXIT_FAILURE;
-      }
+    }
 
   std::stringstream initialAnnotation, afterAnnotation;
-
-
-  // node2->PrintSelf(cout,ind);
 
   node2->PrintAnnotationInfo(initialAnnotation,ind);
 
@@ -130,7 +122,4 @@ int vtkMRMLAnnotationAngleNodeTest1(int , char * [] )
   cout << "Passed XML" << endl;
 
   return EXIT_SUCCESS;
-
 }
-
-

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationControlPointsNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationControlPointsNodeTest1.cxx
@@ -10,12 +10,14 @@
 int vtkMRMLAnnotationControlPointsNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLAnnotationControlPointsNode> node1;
-  EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+  vtkNew<vtkMRMLScene> mrmlScene;
+  mrmlScene->AddNode(node1);
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1);
+  mrmlScene->RemoveNode(node1);
 
   // ======================
   // Basic Setup
   // ======================
-  vtkNew<vtkMRMLScene> mrmlScene;
   mrmlScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLAnnotationControlPointsNode>::New());
   mrmlScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLAnnotationPointDisplayNode>::New());
 

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationFiducialNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationFiducialNodeTest1.cxx
@@ -9,12 +9,14 @@
 int vtkMRMLAnnotationFiducialNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLAnnotationFiducialNode> node1;
+  vtkNew<vtkMRMLScene> mrmlScene;
+  mrmlScene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+  mrmlScene->RemoveNode(node1);
 
   // ======================
   // Basic Setup
   // ======================
-  vtkNew<vtkMRMLScene> mrmlScene;
   mrmlScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLAnnotationFiducialNode>::New());
   mrmlScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLAnnotationPointDisplayNode>::New());
 

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationLinesNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationLinesNodeTest1.cxx
@@ -29,12 +29,14 @@ void SetControlPointsAndText(vtkMRMLAnnotationLinesNode* node2)
 int vtkMRMLAnnotationLinesNodeTest1(int , char * [] )
 {
   vtkNew< vtkMRMLAnnotationLinesNode > node1;
-  EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+  vtkNew<vtkMRMLScene> mrmlScene;
+  mrmlScene->AddNode(node1);
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1);
+  mrmlScene->RemoveNode(node1);
 
   // ======================
   // Basic Setup
   // ======================
-  vtkNew<vtkMRMLScene> mrmlScene;
   mrmlScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLAnnotationLinesNode>::New());
   mrmlScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLAnnotationLineDisplayNode>::New());
 

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationNodeTest1.cxx
@@ -13,44 +13,47 @@ int vtkMRMLAnnotationNodeTest1(int , char * [] )
   // ======================
   // Basic Setup
   // ======================
-  vtkSmartPointer< vtkMRMLAnnotationNode > node2 = vtkSmartPointer< vtkMRMLAnnotationNode >::New();
+  vtkNew<vtkMRMLAnnotationNode> node2;
   // This was a bug - used to crash
   node2->GetText(0);
 
-  vtkSmartPointer<vtkMRMLScene> mrmlScene = vtkSmartPointer<vtkMRMLScene>::New();
-  {
-    vtkNew<vtkMRMLAnnotationNode> node1;
-    EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+  vtkNew<vtkMRMLScene> mrmlScene;
+  vtkNew<vtkMRMLAnnotationNode> node1;
+  mrmlScene->AddNode(node1);
 
-    node1->UpdateReferences();
-    node2->Copy( node1.GetPointer() );
+  node1->UpdateReferences();
+  node2->Copy(node1);
 
-    mrmlScene->RegisterNodeClass( node1.GetPointer() );
-    mrmlScene->AddNode(node2);
-  }
+  mrmlScene->RegisterNodeClass(node1);
+  mrmlScene->AddNode(node2);
 
-  vtkMRMLAnnotationStorageNode *storNode = dynamic_cast <vtkMRMLAnnotationStorageNode *> (node2->CreateDefaultStorageNode());
+  vtkNew<vtkMRMLAnnotationStorageNode> prototypeStorageNode;
+  mrmlScene->RegisterNodeClass(prototypeStorageNode);
+  vtkMRMLAnnotationStorageNode *storNode = vtkMRMLAnnotationStorageNode::SafeDownCast(
+    node2->CreateDefaultStorageNode());
+
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1);
+  mrmlScene->RemoveNode(node1);
 
   if( !storNode )
     {
-      std::cerr << "Error in CreateDefaultStorageNode()" << std::endl;
-      return EXIT_FAILURE;
+    std::cerr << "Error in CreateDefaultStorageNode()" << std::endl;
+    return EXIT_FAILURE;
     }
   storNode->Delete();
 
   std::cout << "Passed StorageNode" << std::endl;
 
-
   node2->CreateAnnotationTextDisplayNode();
   vtkMRMLAnnotationTextDisplayNode *textDisplayNode = node2->GetAnnotationTextDisplayNode();
   if (!textDisplayNode)
     {
-       std::cerr << "Error in AnnotationTextDisplayNode() " << std::endl;
-       return EXIT_FAILURE;
+    std::cerr << "Error in AnnotationTextDisplayNode() " << std::endl;
+    return EXIT_FAILURE;
     }
   else
     {
-    // register the node type to the sceen
+    // register the node type to the scene
     mrmlScene->RegisterNodeClass(textDisplayNode);
     }
   std::cout << "Passed DisplayNode" << std::endl;
@@ -149,44 +152,3 @@ int vtkMRMLAnnotationNodeTest1(int , char * [] )
   return EXIT_SUCCESS;
 
 }
-
-
-  // std::stringstream ss;
-  // node2->WriteXML(ss,5);
-  // std::string writeXML = ss.str();
-  // std::vector<std::string> tmpVec;
-  //
-  // size_t pos = writeXML.find("     ");
-  // while (pos != std::string::npos)
-  //   {
-  //     pos += 6;
-  //     size_t fix = writeXML.find('=',pos);
-  //     tmpVec.push_back(writeXML.substr(pos,fix - pos));
-  //     fix +=2;
-  //     pos = writeXML.find("\"     ",fix);
-  //
-  //     if (pos == std::string::npos)
-  //     {
-  //       std::string tmp = writeXML.substr(fix);
-  //       std::replace(tmp.begin(), tmp.end(), '\"', ' ');
-  //       // tmp.erase(remove_if(tmp.begin(), tmp.end(), isspace), tmp.end());
-  //       tmpVec.push_back(tmp);
-  //     }
-  //     else
-  //     {
-  //       tmpVec.push_back(writeXML.substr(fix,pos-fix));
-  //       pos ++;
-  //     }
-  //   }
-  //
-  //
-  // const char **readXML = new const char*[tmpVec.size()+1];
-  // for (int i= 0 ; i < int(tmpVec.size()); i++)
-  //   {
-  //     readXML[i] =  tmpVec[i].c_str();
-  //   }
-  // readXML[tmpVec.size()]= NULL;
-  // node2->ReadXMLAttributes(readXML);
-  // delete[] readXML;
-
-

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationROINodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationROINodeTest1.cxx
@@ -24,26 +24,24 @@ int TestGetTransformedPlanes(vtkMRMLScene* scene, vtkMRMLAnnotationROINode* node
 //----------------------------------------------------------------------------
 int vtkMRMLAnnotationROINodeTest1(int , char * [] )
 {
-
   // ======================
   // Basic Setup
   // ======================
 
-  vtkSmartPointer<vtkMRMLAnnotationROINode > node2 = vtkSmartPointer< vtkMRMLAnnotationROINode >::New();
-  vtkSmartPointer<vtkMRMLScene> mrmlScene = vtkSmartPointer<vtkMRMLScene>::New();
+  vtkNew<vtkMRMLAnnotationROINode> node2;
+  vtkNew<vtkMRMLScene> mrmlScene;
 
-  {
+  vtkNew<vtkMRMLAnnotationROINode> node1;
+  mrmlScene->AddNode(node1);
 
-    vtkNew<vtkMRMLAnnotationROINode> node1;
+  node1->UpdateReferences();
+  node2->Copy(node1.GetPointer());
 
-    EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+  mrmlScene->RegisterNodeClass(node1.GetPointer());
+  mrmlScene->AddNode(node2);
 
-    node1->UpdateReferences();
-    node2->Copy(node1.GetPointer());
-
-    mrmlScene->RegisterNodeClass(node1.GetPointer());
-    mrmlScene->AddNode(node2);
-  }
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1);
+  mrmlScene->RemoveNode(node1);
 
   // ======================
   // Modify Properties

--- a/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationRulerNodeTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/vtkMRMLAnnotationRulerNodeTest1.cxx
@@ -12,15 +12,17 @@
 int vtkMRMLAnnotationRulerNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLAnnotationRulerNode> node1;
+  vtkNew<vtkMRMLScene> mrmlScene;
+  mrmlScene->AddNode(node1);
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   TESTING_OUTPUT_ASSERT_ERRORS(4); // write XML fails for a ruler without points defined
   TESTING_OUTPUT_ASSERT_ERRORS_END();
+  mrmlScene->RemoveNode(node1);
 
   // ======================
   // Basic Setup
   // ======================
-  vtkNew<vtkMRMLScene> mrmlScene;
   mrmlScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLAnnotationRulerNode>::New());
   mrmlScene->RegisterNodeClass(vtkSmartPointer<vtkMRMLAnnotationPointDisplayNode>::New());
 
@@ -114,5 +116,3 @@ int vtkMRMLAnnotationRulerNodeTest1(int , char * [] )
 
   return EXIT_SUCCESS;
 }
-
-

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -134,7 +134,14 @@ void vtkMRMLMarkupsFiducialNode::PrintSelf(ostream& os, vtkIndent indent)
 //-------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLMarkupsFiducialNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLMarkupsFiducialStorageNode::New());
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLMarkupsFiducialStorageNode"));
 }
 
 //-------------------------------------------------------------------------
@@ -151,8 +158,8 @@ void vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes()
     vtkErrorMacro("vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes failed: scene is invalid");
     return;
     }
-  vtkNew<vtkMRMLMarkupsDisplayNode> dispNode;
-  this->GetScene()->AddNode(dispNode.GetPointer());
+  vtkMRMLMarkupsDisplayNode* dispNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLMarkupsDisplayNode") );
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -345,7 +345,14 @@ void vtkMRMLMarkupsNode::RemoveAllTexts()
 //-------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLMarkupsNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLStorageNode::SafeDownCast(vtkMRMLMarkupsStorageNode::New());
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLMarkupsStorageNode"));
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialNodeTest1.cxx
@@ -19,6 +19,7 @@
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkMRMLMarkupsFiducialNode.h"
+#include "vtkMRMLScene.h"
 #include "vtkURIHandler.h"
 
 // VTK includes
@@ -28,7 +29,9 @@
 int vtkMRMLMarkupsFiducialNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLMarkupsFiducialNode> node1;
-  EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1);
 
   vtkMRMLMarkupsDisplayNode *dispNode = node1->GetMarkupsDisplayNode();
   std::cout << "Get MarkupsDisplayNode returned " << (dispNode ? "valid" : "null") << " pointer" << std::endl;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
@@ -18,6 +18,7 @@
 // MRML includes
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLMarkupsNode.h"
+#include "vtkMRMLScene.h"
 
 // VTK includes
 #include <vtkIndent.h>
@@ -32,6 +33,8 @@
 int vtkMRMLMarkupsNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLMarkupsNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
 
   TEST_SET_GET_BOOLEAN(node1, Locked);

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
@@ -1,5 +1,5 @@
-
 // MRML includes
+#include "vtkMRMLScene.h"
 #include "vtkMRMLVolumePropertyNode.h"
 #include "vtkMRMLVolumePropertyStorageNode.h"
 
@@ -364,7 +364,14 @@ double vtkMRMLVolumePropertyNode::HigherAndUnique(double value, double &previous
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLVolumePropertyNode::CreateDefaultStorageNode()
 {
-  return vtkMRMLVolumePropertyStorageNode::New();
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == NULL)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return NULL;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLVolumePropertyStorageNode"));
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyNodeTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumePropertyNodeTest1.cxx
@@ -46,12 +46,13 @@ int vtkMRMLVolumePropertyNodeTest1(int argc, char *[] )
     }
 
   vtkNew<vtkMRMLVolumePropertyNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
 
   CHECK_EXIT_SUCCESS(readWrite());
   CHECK_EXIT_SUCCESS(piecewiseFunctionFromString());
 
-  vtkNew<vtkMRMLScene> scene;
   vtkNew<vtkMRMLApplicationLogic> applicationLogic;
   applicationLogic->SetMRMLScene(scene.GetPointer()); // register custom nodes
   vtkNew<vtkSlicerVolumeRenderingLogic> vrLogic;


### PR DESCRIPTION
The CreateDefaultDisplayNodes and CreateDefaultStorageNode functions did not use the CreateNewNodeByClass infrastructure so default nodes were not considered. This has been fixed in all node classes using such functions.