### PR TITLE
BUG: Fix typo in qSlicerVolumeRenderingModuleWidget

### DIFF
--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -400,7 +400,7 @@ void qSlicerVolumeRenderingModuleWidget::updateWidgetFromMRML()
   // Techniques tab
   QSettings settings;
   QString defaultRenderingMethod =
-    settings.value("VolumeRendering/RenderingMethod", QString("vtkMRMLCPURayCastVolumeRenderinDisplayNode")).toString();
+    settings.value("VolumeRendering/RenderingMethod", QString("vtkMRMLCPURayCastVolumeRenderingDisplayNode")).toString();
   QString currentRenderingMethod = displayNode ? QString(displayNode->GetClassName()) : defaultRenderingMethod;
   d->RenderingMethodComboBox->setCurrentIndex(d->RenderingMethodComboBox->findData(currentRenderingMethod) );
   d->MemorySizeComboBox->setCurrentGPUMemory(firstViewNode ? firstViewNode->GetGPUMemorySize() : 0);


### PR DESCRIPTION
This fixes a minor typo I found in qSlicerVolumeRenderingModuleWidget which caused a message in my console window.