### PR TITLE
BUG: Fix failing vtkMRMLStreamingVolumeNode test and memory leak

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLStreamingVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLStreamingVolumeNodeTest1.cxx
@@ -20,11 +20,14 @@ Care Ontario.
 
 // MRML includes
 #include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
 #include "vtkMRMLStreamingVolumeNode.h"
 
 int vtkMRMLStreamingVolumeNodeTest1(int , char * [] )
 {
   vtkNew<vtkMRMLStreamingVolumeNode> node1;
+  vtkNew<vtkMRMLScene> scene;
+  scene->AddNode(node1);
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
 
   int width = 10;

--- a/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStreamingVolumeNode.cxx
@@ -155,7 +155,7 @@ vtkStreamingVolumeCodec* vtkMRMLStreamingVolumeNode::GetCodec()
       (this->Codec &&
        this->Codec->GetFourCC() != this->GetCodecFourCC()))
     {
-    this->Codec = vtkStreamingVolumeCodecFactory::GetInstance()->CreateCodecByFourCC(this->GetCodecFourCC());
+    this->Codec = vtkSmartPointer<vtkStreamingVolumeCodec>::Take(vtkStreamingVolumeCodecFactory::GetInstance()->CreateCodecByFourCC(this->GetCodecFourCC()));
     }
   return this->Codec;
 }

--- a/Libs/vtkAddon/vtkRawRGBVolumeCodec.h
+++ b/Libs/vtkAddon/vtkRawRGBVolumeCodec.h
@@ -51,6 +51,10 @@ protected:
   /// There are no parameters to update within this codec
   virtual bool UpdateParameterInternal(std::string vtkNotUsed(parameterValue), std::string vtkNotUsed(parameterName)) { return false; };
 
+  /// Return the codec parameter description
+  /// There are no parameters to update within this codec
+  virtual std::string GetParameterDescription(std::string vtkNotUsed(parameterName)) { return ""; };
+
 private:
   vtkRawRGBVolumeCodec(const vtkRawRGBVolumeCodec&);
   void operator=(const vtkRawRGBVolumeCodec&);

--- a/Libs/vtkAddon/vtkStreamingVolumeCodec.h
+++ b/Libs/vtkAddon/vtkStreamingVolumeCodec.h
@@ -93,7 +93,7 @@ public:
   /// Get parameter description as a string
   /// \param parameterName String containing the name of the parameter
   /// Returns the description of the parameter as a string, and returns an empty string if the parameter name is invalid
-  virtual std::string GetParameterDescription(std::string parameterName) { return ""; };
+  virtual std::string GetParameterDescription(std::string parameterName) = 0;
 
   /// Set a parameter for the codec
   /// \param parameterName String containing the name of the parameter


### PR DESCRIPTION
- vtkMRMLStreamingVolumeNodeTest1.cxx was previously failing due to missing scene
- Fixed Memory leak vtkStreamingVolumeCodec within vtkMRMLStreamingVolumeNode where vtkSmartPointer::Take was not used with the codec factory method.
- Fix compile warning for unused parameter in vtkRawRGBVolumeCodec