### PR TITLE
ENH: Allow observing color name change

### DIFF
--- a/Libs/MRML/Core/vtkMRMLColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorNode.cxx
@@ -450,7 +450,7 @@ int vtkMRMLColorNode::SetColorName(int ind, const char *name)
     {
     this->Names[ind] = newName;
     this->StorableModifiedTime.Modified();
-    // TBD: fire Modified?
+    this->Modified();
     }
   return 1;
 }


### PR DESCRIPTION
This change makes it possible to update the scalar bar when the isodose level is changed. Isodose level is stored as the color name, and it can be changed in a color table view. Related issue: https://github.com/SlicerRt/SlicerRT/issues/8

I'm issueing a PR because there was a TBD there but also because I'm not sure what are the cases where color names might be changed in bulk, causing potential issues with lots of Modified events.