### PR TITLE
BUG: Fixed volume rendering ROI reset

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -1254,15 +1254,7 @@ void vtkMRMLVolumeRenderingDisplayableManager::ProcessMRMLNodesEvents(vtkObject*
            || (event == vtkMRMLTransformableNode::TransformModifiedEvent) )
       {
       this->Internal->UpdatePipelineTransforms(volumeNode);
-
-      // Reset ROI
-      std::set< vtkMRMLVolumeRenderingDisplayNode* > displayNodes = this->Internal->VolumeToDisplayNodes[volumeNode];
-      std::set< vtkMRMLVolumeRenderingDisplayNode* >::iterator displayNodeIt;
-      for (displayNodeIt = displayNodes.begin(); displayNodeIt != displayNodes.end(); displayNodeIt++)
-        {
-        this->VolumeRenderingLogic->FitROIToVolume(*displayNodeIt);
-        }
-
+      // ROI must not be reset, as it would make it impossible to replay clipped volume sequences
       this->RequestRender();
       }
     else if (event == vtkMRMLScalarVolumeNode::ImageDataModifiedEvent)


### PR DESCRIPTION
When volume rendered node's transform was changed, ROI was reset. This made it impossible to review clipped volume sequences or transform clipped volumes.

ROI reset is not needed anyway, because if user would like to keep the volume fully displayed when it is transformed, then it can be achieved by setting the same parent transform for the ROI node as for the volume node.