### PR TITLE
BUG: Update SimpleFilters remote to fix errors on close

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -213,7 +213,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeImporter Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(SimpleFilters
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/SimpleITK/SlicerSimpleFilters.git
-  GIT_TAG 35e3f0118247ea47f6ff4440cae69690fa3a337f
+  GIT_TAG dd1e8be506381e1a7c5407a46195243961ea0622
   OPTION_NAME Slicer_BUILD_SimpleFilters
   OPTION_DEPENDS "Slicer_BUILD_QTSCRIPTEDMODULES;Slicer_USE_SimpleITK"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Update SimpleFilters remote module

Fix calling disconnect on destroyed object when Slicer is closing.