### PR TITLE
BUG: Fixed virtual reality picking error

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDisplayableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayableNode.cxx
@@ -329,3 +329,14 @@ void vtkMRMLDisplayableNode::GetBounds(double bounds[6])
 {
   vtkMath::UninitializeBounds(bounds);
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLDisplayableNode::SetSelectable(int selectable)
+{
+  bool modified = (selectable != this->Selectable);
+  Superclass::SetSelectable(selectable);
+  if (modified)
+    {
+    this->InvokeEvent(vtkMRMLDisplayableNode::DisplayModifiedEvent, this);
+    }
+}

--- a/Libs/MRML/Core/vtkMRMLDisplayableNode.h
+++ b/Libs/MRML/Core/vtkMRMLDisplayableNode.h
@@ -206,6 +206,11 @@ public:
 
   virtual const char* GetDisplayNodeReferenceRole();
 
+  ///
+  /// Override default selectable setting to notify display node
+  /// about the change.
+  virtual void SetSelectable(int) VTK_OVERRIDE;
+
  protected:
   vtkMRMLDisplayableNode();
   ~vtkMRMLDisplayableNode();

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -1713,6 +1713,7 @@ void vtkMRMLModelDisplayableManager::SetModelDisplayProperty(vtkMRMLDisplayableN
         actorProperties->SetFrontfaceCulling(modelDisplayNode->GetFrontfaceCulling());
         actorProperties->SetBackfaceCulling(modelDisplayNode->GetBackfaceCulling());
 
+        actor->SetPickable(model->GetSelectable());
         if (modelDisplayNode->GetSelected())
           {
           vtkDebugMacro("Model display node " << modelDisplayNode->GetName() << " is selected...");

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
@@ -525,6 +525,7 @@ void vtkMRMLSegmentationsDisplayableManager3D::vtkInternal::UpdateDisplayNodePip
     pipeline->Actor->GetProperty()->SetColor(color[0], color[1], color[2]);
     pipeline->Actor->GetProperty()->SetOpacity(properties.Opacity3D * displayNode->GetOpacity3D());
 
+    pipeline->Actor->SetPickable(segmentationNode->GetSelectable());
     if (displayNode->GetSelected())
       {
       pipeline->Actor->GetProperty()->SetAmbient(displayNode->GetSelectedAmbient());

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -804,6 +804,8 @@ void vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::UpdateDisplayNodePip
   vtkVolumeProperty* volumeProperty = displayNode->GetVolumePropertyNode() ? displayNode->GetVolumePropertyNode()->GetVolumeProperty() : NULL;
   pipeline->VolumeActor->SetProperty(volumeProperty);
 
+  pipeline->VolumeActor->SetPickable(volumeNode->GetSelectable());
+
   this->UpdateDesiredUpdateRate(displayNode);
 }
 


### PR DESCRIPTION
When the pick position was close or inside non-selectable object, picking often failed because VTK's cell picker found that actor.

Now if a model, segmentation, or volume rendering node is not selectable then it is completely excluded from picking.
