### PR TITLE
BUG: Fix cutoff in DICOM browser toolbar

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -181,7 +181,7 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
     # tool row at top, with commands and database
     self.toolFrame = qt.QWidget()
     self.toolFrame.setMaximumHeight(40)
-    self.toolFrame.setContentsMargins(-5, -5, -5, -5)
+    self.toolFrame.setContentsMargins(0,0,0,0)
     self.toolLayout = qt.QHBoxLayout(self.toolFrame)
     self.layout().addWidget(self.toolFrame)
     self.toolLayout.addWidget(self.toolBar)


### PR DESCRIPTION
The DICOM browser's toolbar looks like this on Windows in 4.10:
![image](https://user-images.githubusercontent.com/1325980/49537703-a104da00-f897-11e8-87a9-91eb548ba49d.png)

It is not a good idea to set fixed number of pixels for anything in Qt5, and this negative margin does not seem to be safe any more.