### PR TITLE
ENH: Allow for custom presets prefix and tooltips

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLSliceNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSliceNodeTest1.cxx
@@ -32,6 +32,8 @@ int GetSliceOrientationPresetTest();
 int GetSliceOrientationPresetNameTest();
 int SetOrientationTest();
 int InitializeDefaultMatrixTest();
+int SliceOrientationPresetPrefixTest();
+int SliceOrientationPresetTooltipTest();
 
 //----------------------------------------------------------------------------
 int vtkMRMLSliceNodeTest1(int , char * [] )
@@ -48,6 +50,8 @@ int vtkMRMLSliceNodeTest1(int , char * [] )
   CHECK_EXIT_SUCCESS(GetSliceOrientationPresetNameTest());
   CHECK_EXIT_SUCCESS(SetOrientationTest());
   CHECK_EXIT_SUCCESS(InitializeDefaultMatrixTest());
+  CHECK_EXIT_SUCCESS(SliceOrientationPresetPrefixTest());
+  CHECK_EXIT_SUCCESS(SliceOrientationPresetTooltipTest());
 
   return EXIT_SUCCESS;
 }
@@ -423,6 +427,62 @@ int InitializeDefaultMatrixTest()
   vtkNew<vtkMatrix3x3> sagittal;
   vtkMRMLSliceNode::InitializeSagittalMatrix(sagittal.GetPointer());
   CHECK_NOT_NULL(sagittal.GetPointer());
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int SliceOrientationPresetPrefixTest()
+{
+  vtkNew<vtkMRMLSliceNode> sliceNode;
+
+  vtkNew<vtkMatrix3x3> testMatrix;
+  sliceNode->AddSliceOrientationPreset("test_prefix", testMatrix.GetPointer());
+  CHECK_STD_STRING(sliceNode->GetSliceOrientationPresetPrefix("test_prefix"), "");
+  CHECK_STD_STRING(sliceNode->GetSliceOrientationPresetPrefix("Reformat"), "");
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPresetPrefix("", "t:"), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPresetPrefix("wrong name", "t:"), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPresetPrefix("Reformat", "t:"), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPresetPrefix("test_prefix", "t:"), true);
+  CHECK_STD_STRING(sliceNode->GetSliceOrientationPresetPrefix("test_prefix"), "t:");
+
+  return EXIT_SUCCESS;
+}
+
+//----------------------------------------------------------------------------
+int SliceOrientationPresetTooltipTest()
+{
+  vtkNew<vtkMRMLSliceNode> sliceNode;
+
+  vtkNew<vtkMatrix3x3> testMatrix;
+  sliceNode->AddSliceOrientationPreset("test_tooltip", testMatrix.GetPointer());
+  CHECK_STD_STRING(sliceNode->GetSliceOrientationPresetTooltip("test_tooltip"), "Oblique");
+  CHECK_STD_STRING(sliceNode->GetSliceOrientationPresetTooltip("Reformat"), "Oblique");
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPresetTooltip("", "this is a tip"), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPresetTooltip("wrong name", "this is a tip"), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPresetTooltip("Reformat", "this is a tip"), false);
+  TESTING_OUTPUT_ASSERT_ERRORS_END();
+
+  CHECK_BOOL(sliceNode->RenameSliceOrientationPresetTooltip("test_tooltip", "this is a tip"), true);
+  CHECK_STD_STRING(sliceNode->GetSliceOrientationPresetTooltip("test_tooltip"), "this is a tip");
 
   return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -23,6 +23,15 @@ class vtkMRMLVolumeNode;
 class vtkMatrix3x3;
 class vtkMatrix4x4;
 
+/// \brief Structure to store preset orientation information.
+struct OrientationPresetType
+{
+  std::string Name;
+  vtkSmartPointer<vtkMatrix3x3> Orientation;
+  std::string Prefix;
+  std::string Tooltip;
+};
+
 /// \brief MRML node for storing a slice through RAS space.
 ///
 /// This node stores the information about how to map from RAS space to
@@ -157,7 +166,9 @@ class VTK_MRML_EXPORT vtkMRMLSliceNode : public vtkMRMLAbstractViewNode
   /// Valid \a orientations are known as presets and are easily added,
   /// removed or renamed.
   ///
-  /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix4x4* sliceToRAS)
+  /// \sa AddSliceOrientationPreset(
+  ///    const std::string& name, vtkMatrix3x3* sliceToRAS,
+  ///    const std::string& prefix, const std::string& tooltip)
   /// \sa UpdateMatrices()
   bool SetOrientation(const char* orientation);
 
@@ -186,6 +197,16 @@ public:
   /// preset.
   std::string GetSliceOrientationPresetName(vtkMatrix3x3* orientationMatrix);
 
+  /// \brief Return the preset prefix corresponding to a preset \a name.
+  ///
+  /// Returns an empty string if the preset with the given \a name doesn't exist.
+  std::string GetSliceOrientationPresetPrefix(const std::string& name);
+
+  /// \brief Return the preset tooltip corresponding to a preset \a name.
+  ///
+  /// Returns an empty string if the tooltip with the given \a name doesn't exist.
+  std::string GetSliceOrientationPresetTooltip(const std::string& name);
+
   /// \brief Return all the orientation preset names.
   void GetSliceOrientationPresetNames(vtkStringArray* presetOrientationNames);
 
@@ -197,21 +218,46 @@ public:
   ///
   /// \sa RenameSliceOrientationPreset(const std::string& name, const std::string& updatedName)
   /// \sa RemoveSliceOrientationPreset(const std::string& name)
-  bool AddSliceOrientationPreset(const std::string& name, vtkMatrix3x3* orientationMatrix);
+  /// \sa RenameSliceOrientationPresetPrefix(const std::string& name, const std::string& prefix)
+  /// \sa RenameSliceOrientationPresetTooltip(const std::string& name, const std::string& tip)
+  bool AddSliceOrientationPreset(const std::string& name,
+    vtkMatrix3x3* orientationMatrix,
+    const std::string& prefix="",
+    const std::string& tooltip = "Oblique");
 
   /// \brief Remove an orientation preset.
   ///
-  /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix4x4* sliceToRAS)
+  /// \sa AddSliceOrientationPreset(
+  ///    const std::string& name, vtkMatrix3x3* sliceToRAS,
+  ///    const std::string& prefix, const std::string& tooltip)
   bool RemoveSliceOrientationPreset(const std::string& name);
 
   /// \brief Rename an orientation preset.
   ///
-  /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix4x4* sliceToRAS)
+  /// \sa AddSliceOrientationPreset(
+  ///    const std::string& name, vtkMatrix3x3* sliceToRAS,
+  ///    const std::string& prefix, const std::string& tooltip)
   bool RenameSliceOrientationPreset(const std::string& name, const std::string& updatedName);
+
+  /// \brief Rename an orientation prefix.
+  ///
+  /// \sa AddSliceOrientationPreset(
+  ///    const std::string& name, vtkMatrix3x3* sliceToRAS,
+  ///    const std::string& prefix, const std::string& tooltip)
+  bool RenameSliceOrientationPresetPrefix(const std::string& name, const std::string& prefix);
+
+  /// \brief Rename an orientation prefix.
+  ///
+  /// \sa AddSliceOrientationPreset(
+  ///    const std::string& name, vtkMatrix3x3* sliceToRAS,
+  ///    const std::string& prefix, const std::string& tooltip)
+  bool RenameSliceOrientationPresetTooltip(const std::string& name, const std::string& tip);
 
   /// \brief Return True if an orientation preset is stored.
   ///
-  /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix4x4* sliceToRAS)
+  /// \sa AddSliceOrientationPreset(
+  ///    const std::string& name, vtkMatrix3x3* sliceToRAS,
+  ///    const std::string& prefix, const std::string& tooltip)
   bool HasSliceOrientationPreset(const std::string& name);
 
   /// \brief Initialize \a orientationMatrix as an `Axial` orientation matrix.
@@ -509,8 +555,8 @@ protected:
   vtkSmartPointer<vtkMatrix4x4> UVWToSlice;
   vtkSmartPointer<vtkMatrix4x4> UVWToRAS;
 
-  typedef std::pair <std::string, vtkSmartPointer<vtkMatrix3x3> > OrientationPresetType;
   std::vector< OrientationPresetType > OrientationMatrices;
+  OrientationPresetType* GetOrientationPreset(const std::string& name, bool error=true);
 
   int JumpMode;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetTest.cxx
@@ -28,6 +28,7 @@
 // MRML includes
 #include "qMRMLNodeComboBox.h"
 #include "qMRMLSliceControllerWidget.h"
+#include "qMRMLSliderWidget.h"
 #include <vtkMRMLColorLogic.h>
 #include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLScalarVolumeNode.h>
@@ -71,6 +72,9 @@ private slots:
   void testSetLabelVolumeWithNoLinkedControl();
 
   void testUpdateSliceOrientationSelector();
+
+  void testPrefix();
+  void testTooltip();
 };
 
 // ----------------------------------------------------------------------------
@@ -349,6 +353,48 @@ void qMRMLSliceControllerWidgetTester::testUpdateSliceOrientationSelector()
   sliceControllerWidget.mrmlSliceNode()->SetOrientation("Axial");
   QCOMPARE(sliceControllerWidget.sliceOrientation(), QString("Axial"));
 
+}
+
+// ----------------------------------------------------------------------------
+void qMRMLSliceControllerWidgetTester::testPrefix()
+{
+  qMRMLSliceControllerWidget sliceControllerWidget;
+  vtkNew<vtkMatrix3x3> testMatrix;
+  this->MRMLSliceNode->AddSliceOrientationPreset(
+    "Test", testMatrix.GetPointer(), "Prefix_test");
+
+  sliceControllerWidget.setMRMLScene(this->MRMLScene);
+  sliceControllerWidget.setMRMLSliceNode(this->MRMLSliceNode);
+  this->MRMLSliceNode->SetOrientation("Test");
+  QCOMPARE(sliceControllerWidget.sliceOrientation(), QString("Test"));
+
+  qMRMLSliderWidget* sliderWidget =
+    sliceControllerWidget.findChild<qMRMLSliderWidget*>();
+  Q_ASSERT(sliderWidget);
+
+  QCOMPARE(sliderWidget->prefix(), QString("Prefix_test"));
+  QCOMPARE(sliderWidget->toolTip(), QString("Oblique"));
+}
+
+// ----------------------------------------------------------------------------
+void qMRMLSliceControllerWidgetTester::testTooltip()
+{
+  qMRMLSliceControllerWidget sliceControllerWidget;
+  vtkNew<vtkMatrix3x3> testMatrix;
+  this->MRMLSliceNode->AddSliceOrientationPreset(
+    "Test", testMatrix.GetPointer(), "t:", "This is a tooltip test");
+
+  sliceControllerWidget.setMRMLScene(this->MRMLScene);
+  sliceControllerWidget.setMRMLSliceNode(this->MRMLSliceNode);
+  this->MRMLSliceNode->SetOrientation("Test");
+  QCOMPARE(sliceControllerWidget.sliceOrientation(), QString("Test"));
+
+  qMRMLSliderWidget* sliderWidget =
+    sliceControllerWidget.findChild<qMRMLSliderWidget*>();
+  Q_ASSERT(sliderWidget);
+
+  QCOMPARE(sliderWidget->prefix(), QString("t:"));
+  QCOMPARE(sliderWidget->toolTip(), QString("This is a tooltip test"));
 }
 
 // ----------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -71,16 +71,6 @@ qMRMLSliceControllerWidgetPrivate::qMRMLSliceControllerWidgetPrivate(qMRMLSliceC
 
   this->ControllerButtonGroup = 0;
 
-  qMRMLOrientation axialOrientation = {qMRMLSliceControllerWidget::tr("S: "), qMRMLSliceControllerWidget::tr("I <-----> S")};
-  qMRMLOrientation sagittalOrientation = {qMRMLSliceControllerWidget::tr("R: "), qMRMLSliceControllerWidget::tr("L <-----> R")};
-  qMRMLOrientation coronalOrientation = {qMRMLSliceControllerWidget::tr("A: "), qMRMLSliceControllerWidget::tr("P <-----> A")};
-  qMRMLOrientation obliqueOrientation = {qMRMLSliceControllerWidget::tr(""), qMRMLSliceControllerWidget::tr("Oblique")};
-
-  this->SliceOrientationToDescription["Axial"] = axialOrientation;
-  this->SliceOrientationToDescription["Sagittal"] = sagittalOrientation;
-  this->SliceOrientationToDescription["Coronal"] = coronalOrientation;
-  this->SliceOrientationToDescription["Reformat"] = obliqueOrientation;
-
   this->LastLabelMapOpacity = 1.;
   this->LastForegroundOpacity = 1.;
   this->LastBackgroundOpacity = 1.;
@@ -873,10 +863,11 @@ void qMRMLSliceControllerWidgetPrivate::updateWidgetFromMRMLSliceNode()
   Self::updateSliceOrientationSelector(this->MRMLSliceNode, this->SliceOrientationSelector);
 
   // Update slice offset slider tooltip
-  qMRMLOrientation orientation = this->mrmlOrientation(
-      QString::fromStdString(this->MRMLSliceNode->GetOrientation().c_str()));
-  this->SliceOffsetSlider->setToolTip(orientation.ToolTip);
-  this->SliceOffsetSlider->setPrefix(orientation.Prefix);
+  std::string orientation = this->MRMLSliceNode->GetOrientation();
+  this->SliceOffsetSlider->setToolTip(
+    qMRMLSliceControllerWidget::tr(this->MRMLSliceNode->GetSliceOrientationPresetTooltip(orientation).c_str()));
+  this->SliceOffsetSlider->setPrefix(
+    qMRMLSliceControllerWidget::tr(this->MRMLSliceNode->GetSliceOrientationPresetPrefix(orientation).c_str()));
 
   // Update slice visibility toggle
   this->actionShow_in_3D->setChecked(this->MRMLSliceNode->GetSliceVisible());
@@ -1510,18 +1501,6 @@ void qMRMLSliceControllerWidgetPrivate::setupRulerMenu()
   rulerMenu->setObjectName("rulerMenu");
   this->RulerButton->setMenu(rulerMenu);
   rulerMenu->addActions(rulerTypesActions->actions());
-}
-
-// --------------------------------------------------------------------------
-qMRMLOrientation qMRMLSliceControllerWidgetPrivate::mrmlOrientation(const QString &name)
-{
-  QHash<QString, qMRMLOrientation>::iterator it = this->SliceOrientationToDescription.find(name);
-  if (it != this->SliceOrientationToDescription.end())
-    {
-    return it.value();
-    }
-  qMRMLOrientation obliqueOrientation = {qMRMLSliceControllerWidget::tr(""), qMRMLSliceControllerWidget::tr("Oblique")};
-  return obliqueOrientation;
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
@@ -61,13 +61,6 @@ class vtkObject;
 class vtkMRMLSegmentationDisplayNode;
 
 //-----------------------------------------------------------------------------
-struct QMRML_WIDGETS_EXPORT qMRMLOrientation
-{
-  QString Prefix;
-  QString ToolTip;
-};
-
-//-----------------------------------------------------------------------------
 class QMRML_WIDGETS_EXPORT qMRMLSliceControllerWidgetPrivate
   : public qMRMLViewControllerBarPrivate
   , public Ui_qMRMLSliceControllerWidget
@@ -96,8 +89,6 @@ public:
   void setupMoreOptionsMenu();
   void setupOrientationMarkerMenu();
   void setupRulerMenu();
-
-  qMRMLOrientation mrmlOrientation(const QString& name);
 
   vtkSmartPointer<vtkCollection> saveNodesForUndo(const QString& nodeTypes);
 
@@ -171,7 +162,6 @@ public:
   vtkSmartPointer<vtkMRMLSliceLogic>  SliceLogic;
   vtkCollection*                      SliceLogics;
   vtkWeakPointer<vtkAlgorithmOutput>  ImageDataConnection;
-  QHash<QString, qMRMLOrientation>    SliceOrientationToDescription;
   QString                             SliceViewName;
   QButtonGroup*                       ControllerButtonGroup;
 


### PR DESCRIPTION
Although Slicer allowed to create custom presets for the Slice views, it
did not allow the user to customize the tooltip nor the prefix that would
show in the view.
It is now possible to customize each of the slice views preset to have
a custom prefix and/or tooltip.