### PR TITLE
ENH: Future proof null pointer behavior for ITKv5

### DIFF
--- a/Libs/MRML/Core/vtkITKTransformConverter.h
+++ b/Libs/MRML/Core/vtkITKTransformConverter.h
@@ -248,7 +248,7 @@ bool vtkITKTransformConverter::SetITKLinearTransformFromVTK(vtkObject* loggerObj
 {
   typedef itk::AffineTransform<double, VTKDimension> AffineTransformType;
 
-  if (transformVtk_RAS==NULL)
+  if (transformVtk_RAS==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject,"vtkITKTransformConverter::SetITKLinearTransformFromVTK failed: invalid input transform");
     return false;
@@ -321,7 +321,7 @@ bool vtkITKTransformConverter::SetVTKBSplineParametersFromITKGeneric(
   // this version uses the itk::BSplineTransform not the itk::BSplineDeformableTransform
   //
   typedef typename BSplineTransformType::ScalarType T;
-  if (bsplineVtk==NULL)
+  if (bsplineVtk==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "vtkMRMLTransformStorageNode::SetVTKBSplineFromITKv4 failed: bsplineVtk is invalid");
     return false;
@@ -456,7 +456,7 @@ template <typename T> bool vtkITKTransformConverter::SetVTKBSplineFromITKv3Gener
   vtkOrientedBSplineTransform* bsplineVtk,
   typename itk::TransformBaseTemplate<T>::Pointer warpTransformItk, typename itk::TransformBaseTemplate<T>::Pointer bulkTransformItk)
 {
-  if (bsplineVtk==NULL)
+  if (bsplineVtk==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "vtkMRMLTransformStorageNode::SetVTKBSplineFromITK failed: bsplineVtk is invalid");
     return false;
@@ -559,13 +559,13 @@ template <typename BSplineTransformType> bool vtkITKTransformConverter::SetITKBS
   typename itk::Transform< typename BSplineTransformType::ScalarType,VTKDimension,VTKDimension>::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk)
 {
   typedef typename BSplineTransformType::ScalarType T;
-  if (bsplineVtk==NULL)
+  if (bsplineVtk==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "vtkMRMLTransformStorageNode::SetITKBSplineFromVTK failed: bsplineVtk is invalid");
     return false;
     }
   vtkImageData* bsplineCoefficients_RAS=bsplineVtk->GetCoefficientData();
-  if (bsplineCoefficients_RAS==NULL)
+  if (bsplineCoefficients_RAS==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot write BSpline transform to file: coefficients are not specified");
     return false;
@@ -601,7 +601,7 @@ template <typename BSplineTransformType> bool vtkITKTransformConverter::SetITKBS
   transformFixedParamsItk[8]=gridSpacing[2];
 
   vtkNew<vtkMatrix4x4> gridDirectionMatrix_RAS;
-  if (bsplineVtk->GetGridDirectionMatrix()!=NULL)
+  if (bsplineVtk->GetGridDirectionMatrix()!=ITK_NULLPTR)
     {
     gridDirectionMatrix_RAS->DeepCopy(bsplineVtk->GetGridDirectionMatrix());
     }
@@ -656,7 +656,7 @@ template <typename T> bool vtkITKTransformConverter::SetITKv3BSplineFromVTKGener
   typename itk::Transform<T,VTKDimension,VTKDimension>::Pointer& bulkTransformItk,
   vtkOrientedBSplineTransform* bsplineVtk, bool alwaysAddBulkTransform)
 {
-  if (bsplineVtk==NULL)
+  if (bsplineVtk==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "vtkMRMLTransformStorageNode::SetITKBSplineFromVTK failed: bsplineVtk is invalid");
     return false;
@@ -690,7 +690,7 @@ template <typename T> bool vtkITKTransformConverter::SetITKv3BSplineFromVTKGener
     vtkNew<vtkMatrix4x4> bulkMatrix_LPS; // bulk_LPS = rasToLps * bulk_RAS * lpsToRas
     // If bulk transform is available then use it, otherwise just write an identity matrix (we just write it because
     // alwaysAddBulkTransform was requested, due to backward compatibility reasons)
-    if (bulkMatrix_RAS!=NULL)
+    if (bulkMatrix_RAS!=ITK_NULLPTR)
       {
       vtkMatrix4x4::Multiply4x4(rasToLps.GetPointer(), bulkMatrix_RAS, bulkMatrix_LPS.GetPointer());
       vtkMatrix4x4::Multiply4x4(bulkMatrix_LPS.GetPointer(), lpsToRas.GetPointer(), bulkMatrix_LPS.GetPointer());
@@ -715,7 +715,7 @@ template <typename T> bool vtkITKTransformConverter::SetITKv3BSplineFromVTKGener
     }
   else
     {
-    bulkTransformItk=NULL;
+    bulkTransformItk=ITK_NULLPTR;
     }
 
   return true;
@@ -749,7 +749,7 @@ template <typename T> bool vtkITKTransformConverter::SetITKv4BSplineFromVTKGener
 bool vtkITKTransformConverter::SetITKv3BSplineFromVTK(vtkObject* loggerObject, itk::Object::Pointer& warpTransformItk,
   itk::Object::Pointer& bulkTransformItk, vtkOrientedBSplineTransform* bsplineVtk, bool alwaysAddBulkTransform)
 {
-  if (bsplineVtk==NULL)
+  if (bsplineVtk==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot retrieve BSpline transform from node");
     return false;
@@ -757,7 +757,7 @@ bool vtkITKTransformConverter::SetITKv3BSplineFromVTK(vtkObject* loggerObject, i
 
   vtkImageData* bsplineCoefficients=bsplineVtk->GetCoefficientData();
 
-  if (bsplineCoefficients==NULL)
+  if (bsplineCoefficients==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot write BSpline transform to file: coefficients are not specified");
     return false;
@@ -801,7 +801,7 @@ bool vtkITKTransformConverter::SetITKv3BSplineFromVTK(vtkObject* loggerObject, i
 //----------------------------------------------------------------------------
 bool vtkITKTransformConverter::SetITKv4BSplineFromVTK(vtkObject* loggerObject, itk::Object::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk)
 {
-  if (bsplineVtk==NULL)
+  if (bsplineVtk==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot retrieve BSpline transform from node");
     return false;
@@ -809,7 +809,7 @@ bool vtkITKTransformConverter::SetITKv4BSplineFromVTK(vtkObject* loggerObject, i
 
   vtkImageData* bsplineCoefficients=bsplineVtk->GetCoefficientData();
 
-  if (bsplineCoefficients==NULL)
+  if (bsplineCoefficients==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot write BSpline transform to file: coefficients are not specified");
     return false;
@@ -855,7 +855,7 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITK(vtkObject* log
 
   if (!transformItk_LPS)
     {
-    vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK oriented grid transform from ITK: the input transform is NULL");
+    vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK oriented grid transform from ITK: the input transform is ITK_NULLPTR");
     return false;
     }
   if (transformItk_LPS->GetOutputSpaceDimension() != VTKDimension)
@@ -868,7 +868,7 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITK(vtkObject* log
   std::string transformItkClassName = transformItk_LPS->GetNameOfClass();
 
   bool inverse = false;
-  typename DisplacementFieldTransformType::DisplacementFieldType* gridImageItk_Lps = NULL;
+  typename DisplacementFieldTransformType::DisplacementFieldType* gridImageItk_Lps = ITK_NULLPTR;
   if (transformItkClassName == "InverseDisplacementFieldTransform") // inverse class is derived from forward class, so it has to be checked first
     {
     DisplacementFieldTransformType* inverseDisplacementFieldTransform = static_cast<InverseDisplacementFieldTransformType*>( transformItk_LPS.GetPointer() );
@@ -989,7 +989,7 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITKImage(vtkObject
 //----------------------------------------------------------------------------
 bool vtkITKTransformConverter::SetITKImageFromVTKOrientedGridTransform(vtkObject* loggerObject, GridImageDoubleType::Pointer &gridImage_Lps, vtkOrientedGridTransform* grid_Ras)
 {
-  if (grid_Ras==NULL)
+  if (grid_Ras==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot save grid transform: the input vtkOrientedGridTransform is invalid");
     return false;
@@ -999,7 +999,7 @@ bool vtkITKTransformConverter::SetITKImageFromVTKOrientedGridTransform(vtkObject
   grid_Ras->Update();
 
   vtkImageData* gridImage_Ras = grid_Ras->GetDisplacementGrid();
-  if (gridImage_Ras==NULL)
+  if (gridImage_Ras==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot save grid transform: the input vtkOrientedGridTransform does not contain a valid displacement grid");
     return false;
@@ -1025,7 +1025,7 @@ bool vtkITKTransformConverter::SetITKImageFromVTKOrientedGridTransform(vtkObject
 
   // Direction
   vtkNew<vtkMatrix4x4> gridDirectionMatrix_Ras;
-  if (grid_Ras->GetGridDirectionMatrix()!=NULL)
+  if (grid_Ras->GetGridDirectionMatrix()!=ITK_NULLPTR)
     {
     gridDirectionMatrix_Ras->DeepCopy(grid_Ras->GetGridDirectionMatrix());
     }
@@ -1100,7 +1100,7 @@ bool vtkITKTransformConverter::SetVTKThinPlateSplineTransformFromITK(vtkObject* 
   typedef itk::ThinPlateSplineKernelTransform<T,3> ThinPlateSplineTransformType;
   typedef itk::InverseThinPlateSplineKernelTransform< T, 3 > InverseThinPlateSplineTransformType;
 
-  if (transformVtk_RAS==NULL)
+  if (transformVtk_RAS==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK thin-plate spline transform from ITK: the output vtkThinPlateSplineTransform is invalid");
     return false;
@@ -1108,7 +1108,7 @@ bool vtkITKTransformConverter::SetVTKThinPlateSplineTransformFromITK(vtkObject* 
 
   if (!transformItk_LPS)
     {
-    vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK thin-plate spline transform from ITK: the input transform is NULL");
+    vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK thin-plate spline transform from ITK: the input transform is ITK_NULLPTR");
     return false;
     }
 
@@ -1193,7 +1193,7 @@ bool vtkITKTransformConverter::SetVTKThinPlateSplineTransformFromITK(vtkObject* 
 bool vtkITKTransformConverter::SetITKThinPlateSplineTransformFromVTK(vtkObject* loggerObject,
   itk::Object::Pointer& transformItk_LPS, vtkThinPlateSplineTransform* transformVtk_RAS, bool initialize /*= true*/)
 {
-  if (transformVtk_RAS==NULL)
+  if (transformVtk_RAS==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot set ITK thin-plate spline transform from VTK: the intput vtkThinPlateSplineTransform is invalid");
     return false;
@@ -1211,7 +1211,7 @@ bool vtkITKTransformConverter::SetITKThinPlateSplineTransformFromVTK(vtkObject* 
 
   ThinPlateSplineTransformDoubleType::PointSetType::Pointer sourceLandmarksItk_Lps = ThinPlateSplineTransformDoubleType::PointSetType::New();
   vtkPoints* sourceLandmarksVtk_Ras=transformVtk_RAS->GetSourceLandmarks();
-  if (sourceLandmarksVtk_Ras!=NULL)
+  if (sourceLandmarksVtk_Ras!=ITK_NULLPTR)
     {
     for (int i=0; i<sourceLandmarksVtk_Ras->GetNumberOfPoints(); i++)
       {
@@ -1226,7 +1226,7 @@ bool vtkITKTransformConverter::SetITKThinPlateSplineTransformFromVTK(vtkObject* 
     }
   ThinPlateSplineTransformDoubleType::PointSetType::Pointer targetLandmarksItk_Lps = ThinPlateSplineTransformDoubleType::PointSetType::New();
   vtkPoints* targetLandmarksVtk_Ras=transformVtk_RAS->GetTargetLandmarks();
-  if (targetLandmarksVtk_Ras!=NULL)
+  if (targetLandmarksVtk_Ras!=ITK_NULLPTR)
     {
     for (int i=0; i<targetLandmarksVtk_Ras->GetNumberOfPoints(); i++)
       {
@@ -1282,7 +1282,7 @@ vtkAbstractTransform* vtkITKTransformConverter::CreateVTKTransformFromITK(
     {
     vtkNew<vtkTransform> linearTransformVtk;
     linearTransformVtk->SetMatrix(transformMatrixVtk.GetPointer());
-    linearTransformVtk->Register(NULL);
+    linearTransformVtk->Register(ITK_NULLPTR);
     return linearTransformVtk.GetPointer();
     }
   // Grid
@@ -1290,7 +1290,7 @@ vtkAbstractTransform* vtkITKTransformConverter::CreateVTKTransformFromITK(
   conversionSuccess = SetVTKOrientedGridTransformFromITK<T>(loggerObject, gridTransformVtk.GetPointer(), transformItk);
   if (conversionSuccess)
     {
-    gridTransformVtk->Register(NULL);
+    gridTransformVtk->Register(ITK_NULLPTR);
     return gridTransformVtk.GetPointer();
     }
   // BSpline
@@ -1298,7 +1298,7 @@ vtkAbstractTransform* vtkITKTransformConverter::CreateVTKTransformFromITK(
   conversionSuccess = SetVTKBSplineFromITKv4Generic<T>(loggerObject, bsplineTransformVtk.GetPointer(), transformItk);
   if (conversionSuccess)
     {
-    bsplineTransformVtk->Register(NULL);
+    bsplineTransformVtk->Register(ITK_NULLPTR);
     return bsplineTransformVtk.GetPointer();
     }
   // ThinPlateSpline
@@ -1306,11 +1306,11 @@ vtkAbstractTransform* vtkITKTransformConverter::CreateVTKTransformFromITK(
   conversionSuccess = SetVTKThinPlateSplineTransformFromITK<T>(loggerObject, tpsTransformVtk.GetPointer(), transformItk);
   if (conversionSuccess)
     {
-    tpsTransformVtk->Register(NULL);
+    tpsTransformVtk->Register(ITK_NULLPTR);
     return tpsTransformVtk.GetPointer();
     }
 
-  return 0;
+  return ITK_NULLPTR;
 }
 
 //----------------------------------------------------------------------------
@@ -1319,10 +1319,10 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
 {
   typedef itk::CompositeTransform< double > CompositeTransformType;
 
-  if (transformVtk==NULL)
+  if (transformVtk==ITK_NULLPTR)
     {
     vtkErrorWithObjectMacro(loggerObject, "CreateITKTransformFromVTK failed: invalid VTK transform");
-    return 0;
+    return ITK_NULLPTR;
     }
   vtkNew<vtkCollection> transformList;
   vtkMRMLTransformNode::FlattenGeneralTransform(transformList.GetPointer(), transformVtk);
@@ -1346,7 +1346,7 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       if (!SetITKLinearTransformFromVTK(loggerObject, primaryTransformItk, transformMatrix))
         {
         // conversion failed
-        return 0;
+        return ITK_NULLPTR;
         }
       return primaryTransformItk;
       }
@@ -1355,12 +1355,12 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       {
       vtkOrientedBSplineTransform* bsplineTransformVtk = vtkOrientedBSplineTransform::SafeDownCast(singleTransformVtk);
       vtkMatrix4x4* bulkMatrix = bsplineTransformVtk->GetBulkTransformMatrix(); // non-zero for ITKv3 bspline transform only
-      if (preferITKv3CompatibleTransforms || (bulkMatrix!=NULL && !IsIdentityMatrix(bulkMatrix)))
+      if (preferITKv3CompatibleTransforms || (bulkMatrix!=ITK_NULLPTR && !IsIdentityMatrix(bulkMatrix)))
         {
         if (!SetITKv3BSplineFromVTK(loggerObject, primaryTransformItk, secondaryTransformItk, bsplineTransformVtk, preferITKv3CompatibleTransforms))
           {
           // conversion failed
-          return 0;
+          return ITK_NULLPTR;
           }
         return primaryTransformItk;
         }
@@ -1369,7 +1369,7 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
         if (!SetITKv4BSplineFromVTK(loggerObject, primaryTransformItk, bsplineTransformVtk))
           {
           // conversion failed
-          return 0;
+          return ITK_NULLPTR;
           }
         return primaryTransformItk;
         }
@@ -1381,7 +1381,7 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       if (!SetITKOrientedGridTransformFromVTK(loggerObject, primaryTransformItk, gridTransformVtk))
         {
         // conversion failed
-        return 0;
+        return ITK_NULLPTR;
         }
       return primaryTransformItk;
       }
@@ -1392,19 +1392,19 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       if (!SetITKThinPlateSplineTransformFromVTK(loggerObject, primaryTransformItk, tpsTransformVtk, initialize))
         {
         // conversion failed
-        return 0;
+        return ITK_NULLPTR;
         }
       return primaryTransformItk;
       }
     else
       {
-      if (singleTransformVtk==NULL)
+      if (singleTransformVtk==ITK_NULLPTR)
         {
         vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: invalid input transform");
-        return 0;
+        return ITK_NULLPTR;
         }
       vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: conversion of transform type "<<singleTransformVtk->GetClassName()<<" is not supported");
-      return 0;
+      return ITK_NULLPTR;
       }
     }
   else
@@ -1425,21 +1425,21 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       if (secondaryTransformItk.IsNotNull())
         {
         vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: composite transforms cannot contain legacy transforms (that contains secondary transforms). Do not harden transforms on legacy ITK transforms to avoid this error.");
-        return 0;
+        return ITK_NULLPTR;
         }
 
       if (singleTransformItk.IsNull()
           || std::string(singleTransformItk->GetNameOfClass()).find("Transform") == std::string::npos)
         {
         vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: invalid element found while trying to create a composite transform");
-        return 0;
+        return ITK_NULLPTR;
         }
       CompositeTransformType::TransformType::Pointer singleTransformItkTypeChecked = static_cast< CompositeTransformType::TransformType* >( singleTransformItk.GetPointer() );
       compositeTransformItk->AddTransform(singleTransformItkTypeChecked.GetPointer());
       }
     return primaryTransformItk;
     }
-  return 0;
+  return ITK_NULLPTR;
 }
 
 #endif // __vtkITKTransformConverter_h

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
@@ -182,7 +182,7 @@ int vtkMRMLTransformStorageNode::ReadFromITKv3BSplineTransformFile(vtkMRMLNode *
     return 0;
     }
   ++it;
-  TransformType::Pointer transform2=0;
+  TransformType::Pointer transform2=ITK_NULLPTR;
   if( it != (*transforms).end() )
     {
     transform2 = (*it);
@@ -226,7 +226,7 @@ int vtkMRMLTransformStorageNode::ReadFromImageFile(vtkMRMLNode *refNode)
     return 0;
     }
 
-  GridImageDoubleType::Pointer gridImage_Lps = 0;
+  GridImageDoubleType::Pointer gridImage_Lps = ITK_NULLPTR;
 
   typedef itk::ImageFileReader< GridImageDoubleType >  ReaderType;
   std::string fullName =  this->GetFullNameFromFileName();

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
@@ -55,11 +55,11 @@ vtkStandardNewMacro(vtkITKArchetypeImageSeriesReader);
 //----------------------------------------------------------------------------
 vtkITKArchetypeImageSeriesReader::vtkITKArchetypeImageSeriesReader()
 {
-  this->Archetype  = NULL;
+  this->Archetype  = ITK_NULLPTR;
   this->IndexArchetype = 0;
   this->SingleFile = 1;
   this->UseOrientationFromFile = 1;
-  this->RasToIjkMatrix = NULL;
+  this->RasToIjkMatrix = ITK_NULLPTR;
   this->MeasurementFrameMatrix = vtkMatrix4x4::New();
   this->MeasurementFrameMatrix->Identity();
   this->SetDesiredCoordinateOrientationToAxial();
@@ -114,17 +114,17 @@ vtkITKArchetypeImageSeriesReader::~vtkITKArchetypeImageSeriesReader()
   if (this->Archetype)
     {
     delete [] this->Archetype;
-    this->Archetype = NULL;
+    this->Archetype = ITK_NULLPTR;
     }
  if (RasToIjkMatrix)
    {
    RasToIjkMatrix->Delete();
-   RasToIjkMatrix = NULL;
+   RasToIjkMatrix = ITK_NULLPTR;
    }
   if (MeasurementFrameMatrix)
    {
    MeasurementFrameMatrix->Delete();
-   MeasurementFrameMatrix = NULL;
+   MeasurementFrameMatrix = ITK_NULLPTR;
    }
 
 }
@@ -184,7 +184,7 @@ void vtkITKArchetypeImageSeriesReader::PrintSelf(ostream& os, vtkIndent indent)
 //----------------------------------------------------------------------------
 int vtkITKArchetypeImageSeriesReader::CanReadFile(const char* vtkNotUsed(filename))
 {
-  if (this->Archetype == NULL)
+  if (this->Archetype == ITK_NULLPTR)
     {
     return false;
     }
@@ -462,7 +462,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
   double origin[3];
 
 
-  itk::ImageIOBase::Pointer imageIO = NULL;
+  itk::ImageIOBase::Pointer imageIO = ITK_NULLPTR;
 
   try
     {
@@ -548,7 +548,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
 
 
       imageIO = imageReader->GetImageIO();
-      if (imageIO.GetPointer() == NULL)
+      if (imageIO.GetPointer() == ITK_NULLPTR)
         {
           vtkErrorMacro( "vtkITKArchetypeImageSeriesReader::ExecuteInformation: ImageIO for file " << fileNameCollapsed.c_str() << " does not exist.");
           this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError);
@@ -692,7 +692,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
     // If there is only one file in the series
     if (this->FileNames.size() == 1)
       {
-      if (imageIO.GetPointer() == NULL)
+      if (imageIO.GetPointer() == ITK_NULLPTR)
         {
         scalarType = VTK_SHORT; // TODO - figure out why multi-file series doesn't have an imageIO
         }
@@ -872,7 +872,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
     }
 
   int numberOfComponents = 1;
-  if (imageIO.GetPointer() != NULL)
+  if (imageIO.GetPointer() != ITK_NULLPTR)
     {
     numberOfComponents = imageIO->GetNumberOfComponents();
     }
@@ -885,7 +885,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
                                               numberOfComponents);
 
   // Copy the MetaDataDictionary from the ITK layer to the VTK layer
-  if (imageIO.GetPointer() != NULL)
+  if (imageIO.GetPointer() != ITK_NULLPTR)
     {
     this->Dictionary = imageIO->GetMetaDataDictionary();
     }
@@ -949,7 +949,7 @@ void vtkITKArchetypeImageSeriesReader::GetScalarRangeMetaDataKeys(itk::ImageIOBa
 //----------------------------------------------------------------------------
 void vtkITKArchetypeImageSeriesReader::SetMetaDataScalarRangeToPointDataInfo( vtkImageData* data )
 {
-    if (data == NULL)
+    if (data == ITK_NULLPTR)
       {
       vtkWarningMacro("No image data specified, can't set scalar range information.")
       return;
@@ -973,8 +973,8 @@ void vtkITKArchetypeImageSeriesReader::SetMetaDataScalarRangeToPointDataInfo( vt
 
     // Check that scalar info exists
     vtkDataArray* scalars = data->GetPointData()->GetScalars();
-    vtkInformation* scalarInfo = scalars ? scalars->GetInformation() : NULL;
-    if (scalarInfo == NULL)
+    vtkInformation* scalarInfo = scalars ? scalars->GetInformation() : ITK_NULLPTR;
+    if (scalarInfo == ITK_NULLPTR)
       {
       return;
       }
@@ -1012,7 +1012,7 @@ void vtkITKArchetypeImageSeriesReader::AssembleNthVolume ( int n )
   for (unsigned int k = 0; k < nSlices; k++)
   {
     const char* name = GetNthFileName( 0, -1, -1, -1, 0, k, 0, n );
-    if (name == NULL)
+    if (name == ITK_NULLPTR)
     {
       continue;
     }
@@ -1076,7 +1076,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetNthFileName ( int idxSeriesInst
       }
     }
   }
-  return NULL;
+  return ITK_NULLPTR;
 }
 
 //----------------------------------------------------------------------------
@@ -1395,7 +1395,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetNthKey( unsigned int n )
 {
   if (n >= this->Tags.size())
   {
-    return NULL;
+    return ITK_NULLPTR;
   }
   return this->Tags[n].c_str();
 }
@@ -1405,7 +1405,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetNthValue( unsigned int n )
 {
   if (n >= this->TagValues.size())
   {
-    return NULL;
+    return ITK_NULLPTR;
   }
   return this->TagValues[n].c_str();
 }
@@ -1421,7 +1421,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetTagValue( char* tag )
       return this->TagValues[k].c_str();
     }
   }
-  return NULL;
+  return ITK_NULLPTR;
 }
 
 //----------------------------------------------------------------------------
@@ -1429,7 +1429,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetFileName( unsigned int n )
 {
   if ( n >= this->GetNumberOfFileNames() )
   {
-    return NULL;
+    return ITK_NULLPTR;
   }
 
   return this->FileNames[n].c_str();

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationHelper.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationHelper.txx
@@ -753,7 +753,7 @@ ImageToImageRegistrationHelper<TImage>
   typedef ResampleImageFilter<TImage, TImage, double>
   ResampleImageFilterType;
 
-  typename InterpolatorType::Pointer interpolator = 0;
+  typename InterpolatorType::Pointer interpolator = ITK_NULLPTR;
 
   switch( interpolationMethod )
     {

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationMethod.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationMethod.txx
@@ -29,7 +29,7 @@ ImageToImageRegistrationMethod<TImage>
 {
   this->SetNumberOfRequiredOutputs( 1 ); // the transform
 
-  this->m_Transform = 0;
+  this->m_Transform = ITK_NULLPTR;
   typename TransformOutputType::Pointer transformDecorator =
     static_cast<TransformOutputType *>
     ( this->MakeOutput(static_cast<DataObjectPointerArraySizeType>(0)).GetPointer() );
@@ -39,13 +39,13 @@ ImageToImageRegistrationMethod<TImage>
   this->m_RegistrationNumberOfThreads = this->GetNumberOfThreads();
   this->GetMultiThreader()->SetNumberOfThreads( this->m_RegistrationNumberOfThreads );
 
-  this->m_FixedImage = 0;
-  this->m_MovingImage = 0;
+  this->m_FixedImage = ITK_NULLPTR;
+  this->m_MovingImage = ITK_NULLPTR;
   this->m_UseFixedImageMaskObject = false;
-  this->m_FixedImageMaskObject = 0;
+  this->m_FixedImageMaskObject = ITK_NULLPTR;
   this->m_UseMovingImageMaskObject = false;
-  this->m_MovingImageMaskObject = 0;
-  this->m_Observer = 0;
+  this->m_MovingImageMaskObject = ITK_NULLPTR;
+  this->m_Observer = ITK_NULLPTR;
   this->m_ReportProgress = false;
 
   this->m_UseRegionOfInterest = false;
@@ -164,7 +164,7 @@ ImageToImageRegistrationMethod<TImage>
     default:
       itkExceptionMacro(
         "MakeOutput request for an output number larger than the expected number of outputs" );
-      return 0;
+      return ITK_NULLPTR;
     }
 }
 

--- a/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
@@ -67,10 +67,10 @@ int main(int argc, char* * argv)
 
   PARSE_ARGS;
 
-  ImageType::Pointer inputImage = NULL;
+  ImageType::Pointer inputImage = ITK_NULLPTR;
 
   typedef itk::Image<unsigned char, ImageDimension> MaskImageType;
-  MaskImageType::Pointer maskImage = NULL;
+  MaskImageType::Pointer maskImage = ITK_NULLPTR;
 
   typedef    itk::N4BiasFieldCorrectionImageFilter<ImageType, MaskImageType, ImageType> CorrecterType;
   CorrecterType::Pointer correcter = CorrecterType::New();
@@ -126,7 +126,7 @@ int main(int argc, char* * argv)
     maskImage = otsu->GetOutput();
     }
 
-  ImageType::Pointer weightImage = NULL;
+  ImageType::Pointer weightImage = ITK_NULLPTR;
 
   if( weightImageName != "" )
     {

--- a/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
+++ b/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
@@ -326,7 +326,7 @@ ComputeTransformMatrix( const parameters & list,
 
 template <class PixelType>
 typename itk::DiffusionTensor3DAffineTransform<PixelType>::Pointer
-FSOrPPD( const std::string & ppd, itk::Matrix<double, 4, 4> *matrix = NULL )
+FSOrPPD( const std::string & ppd, itk::Matrix<double, 4, 4> *matrix = ITK_NULLPTR )
 {
   typedef itk::DiffusionTensor3DFSAffineTransform<PixelType>
   FSAffineTransformType;
@@ -466,7 +466,7 @@ SetTransformAndOrder( parameters & list,
             {
             std::cerr << "Transformation type not yet implemented for tensors"
                       << std::endl;
-            return NULL;
+            return ITK_NULLPTR;
             }
           }
       }
@@ -477,7 +477,7 @@ SetTransformAndOrder( parameters & list,
         {
         std::cerr << "Error in the file containing the transformation"
                   << std::endl;
-        return NULL;
+        return ITK_NULLPTR;
         }
       }
     }

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
@@ -247,7 +247,7 @@ SetUpTransform( parameters & list,
           }
         else
           {
-          return NULL;
+          return ITK_NULLPTR;
           }
         }
       }
@@ -340,7 +340,7 @@ SetTransformAndOrder( parameters & list,
             {
             std::cerr << "Transformation type not yet implemented"
                       << std::endl;
-            return NULL;
+            return ITK_NULLPTR;
             }
           }
       }
@@ -351,7 +351,7 @@ SetTransformAndOrder( parameters & list,
         {
         std::cerr << "Error in the file containing the matrix transformation"
                   << std::endl;
-        return NULL;
+        return ITK_NULLPTR;
         }
       }
     }
@@ -368,7 +368,7 @@ SetTransform( parameters & list,
               )
 {
   typedef itk::Transform<double, 3, 3> TransformType;
-  typename TransformType::Pointer transform = 0;
+  typename TransformType::Pointer transform = ITK_NULLPTR;
   if( list.transformationFile.compare( "" ) ) // Get transformation matrix from command line if no file given
     {
     if( !list.transformsOrder.compare( "input-to-output" ) )
@@ -500,7 +500,7 @@ SetAllTransform( parameters & list,
   if( nonRigidTransforms < 0 ) // The transform file contains a transform that is not handled by ResampleVolume2, it
                                // exits.
     {
-    return NULL;
+    return ITK_NULLPTR;
     }
   if( list.deffield.compare( "" ) )
     {
@@ -642,7 +642,7 @@ SetAllTransform( parameters & list,
         std::cerr
         << "An affine or rigid transform was not convertible to itk::MatrixOffsetTransformBase< double , 3 , 3 >"
         << std::endl;
-        return NULL;
+        return ITK_NULLPTR;
         }
       typename MatrixTransformType::Pointer localTransform;
       localTransform = static_cast<MatrixTransformType *>(transform.GetPointer() );
@@ -952,19 +952,19 @@ Transform3DPointer InverseTransform( const Transform3DPointer & transform )
         }
       else
         {
-        inverseTransform = NULL;
+        inverseTransform = ITK_NULLPTR;
         }
       }
     }
   catch( ... )
     {
     std::cerr << "Exception Detected" << std::endl;
-    inverseTransform = NULL;
+    inverseTransform = ITK_NULLPTR;
     }
   return inverseTransform;
 }
 
-// Read Measurement Frame and set it to identity if inverseTransform is not NULL
+// Read Measurement Frame and set it to identity if inverseTransform is not ITK_NULLPTR
 itk::Matrix<double, 3, 3>
 ReadMeasurementFrame( itk::MetaDataDictionary & dico, const Transform3DPointer & inverseTransform )
 {


### PR DESCRIPTION
Enhancements in nullptr behavior in ITKv5 provide more clear
type checking and respect the nullptr identifier.  The 'long 0' value
known as NULL causes an abiguity for overload compilations of the ITKv5 smartpointers.

Using ITK_NULLPTR is both backwards and forwards compatible.