### PR TITLE
COMP: Require C++11 support for building Slicer

### DIFF
--- a/CMake/SlicerTestCXX11Features.cmake
+++ b/CMake/SlicerTestCXX11Features.cmake
@@ -1,0 +1,79 @@
+#
+# This cmake file creates a small target to compile and assignes
+# target_compile_features that are needed by the supporting
+# libraries.  The intent is to fail early and report the
+# missing compiler feature before the long compliation process
+# is started.
+#
+
+message(STATUS "-- Testing C++ features")
+set(CXX11_TEST_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cxx11_test_build.cxx )
+file(WRITE ${CXX11_TEST_FILENAME}
+    "int main(int, char *[]) { return 0; }"
+)
+
+add_executable(unused_cxx11_test EXCLUDE_FROM_ALL ${CXX11_TEST_FILENAME})
+target_compile_features(unused_cxx11_test PUBLIC
+  #-- cxx_std_98 # Compiler mode is aware of C++ 98.
+  cxx_std_11 # Compiler mode is aware of C++ 11.
+  #-- cxx_std_14 # Compiler mode is aware of C++ 14.
+  #-- cxx_std_17 # Compiler mode is aware of C++ 17.
+  #-- cxx_std_20 # Compiler mode is aware of C++ 20.
+  #-- cxx_aggregate_default_initializers # Aggregate default initializers, as defined in N3605.
+  cxx_alias_templates # Template aliases, as defined in N2258.
+  cxx_alignas # Alignment control alignas, as defined in N2341.
+  cxx_alignof # Alignment control alignof, as defined in N2341.
+  cxx_attributes # Generic attributes, as defined in N2761.
+  #-- cxx_attribute_deprecated # [[deprecated]] attribute, as defined in N3760.
+  cxx_auto_type # Automatic type deduction, as defined in N1984.
+  #-- cxx_binary_literals # Binary literals, as defined in N3472.
+  cxx_constexpr # Constant expressions, as defined in N2235.
+  #-- cxx_contextual_conversions # Contextual conversions, as defined in N3323.
+  #-- cxx_decltype_incomplete_return_types # Decltype on incomplete return types, as defined in N3276.
+  cxx_decltype # Decltype, as defined in N2343.
+  #-- cxx_decltype_auto # decltype(auto) semantics, as defined in N3638.
+  cxx_default_function_template_args # Default template arguments for function templates, as defined in DR226
+  cxx_defaulted_functions # Defaulted functions, as defined in N2346.
+  cxx_defaulted_move_initializers # Defaulted move initializers, as defined in N3053.
+  cxx_delegating_constructors # Delegating constructors, as defined in N1986.
+  cxx_deleted_functions # Deleted functions, as defined in N2346.
+  #-- cxx_digit_separators # Digit separators, as defined in N3781.
+  cxx_enum_forward_declarations # Enum forward declarations, as defined in N2764.
+  cxx_explicit_conversions # Explicit conversion operators, as defined in N2437.
+  cxx_extended_friend_declarations # Extended friend declarations, as defined in N1791.
+  cxx_extern_templates # Extern templates, as defined in N1987.
+  cxx_final # Override control final keyword, as defined in N2928, N3206 and N3272.
+  cxx_func_identifier # Predefined __func__ identifier, as defined in N2340.
+  cxx_generalized_initializers # Initializer lists, as defined in N2672.
+  #-- cxx_generic_lambdas # Generic lambdas, as defined in N3649.
+  cxx_inheriting_constructors # Inheriting constructors, as defined in N2540.
+  cxx_inline_namespaces # Inline namespaces, as defined in N2535.
+  cxx_lambdas # Lambda functions, as defined in N2927.
+  #-- cxx_lambda_init_captures # Initialized lambda captures, as defined in N3648.
+  cxx_local_type_template_args # Local and unnamed types as template arguments, as defined in N2657.
+  cxx_long_long_type # long long type, as defined in N1811.
+  cxx_noexcept # Exception specifications, as defined in N3050.
+  cxx_nonstatic_member_init # Non-static data member initialization, as defined in N2756.
+  cxx_nullptr # Null pointer, as defined in N2431.
+  cxx_override # Override control override keyword, as defined in N2928, N3206 and N3272.
+  cxx_range_for # Range-based for, as defined in N2930.
+  cxx_raw_string_literals # Raw string literals, as defined in N2442.
+  cxx_reference_qualified_functions # Reference qualified functions, as defined in N2439.
+  #-- cxx_relaxed_constexpr # Relaxed constexpr, as defined in N3652.
+  #--cxx_return_type_deduction # Return type deduction on normal functions, as defined in N3386.
+  cxx_right_angle_brackets # Right angle bracket parsing, as defined in N1757.
+  cxx_rvalue_references # R-value references, as defined in N2118.
+  cxx_sizeof_member # Size of non-static data members, as defined in N2253.
+  cxx_static_assert # Static assert, as defined in N1720.
+  cxx_strong_enums # Strongly typed enums, as defined in N2347.
+  cxx_thread_local # Thread-local variables, as defined in N2659.
+  cxx_trailing_return_types # Automatic function return type, as defined in N2541.
+  cxx_unicode_literals # Unicode string literals, as defined in N2442.
+  cxx_uniform_initialization # Uniform initialization, as defined in N2640.
+  cxx_unrestricted_unions # Unrestricted unions, as defined in N2544.
+  cxx_user_literals # User-defined literals, as defined in N2765.
+  #-- cxx_variable_templates # Variable templates, as defined in N3651.
+  cxx_variadic_macros # Variadic macros, as defined in N1653.
+  cxx_variadic_templates # Variadic templates, as defined in N2242.
+  #-- cxx_template_template_parameters # Template template parameters, as defined in ISO/IEC 14882:1998.
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,56 @@
-cmake_minimum_required(VERSION 3.5)
-
-#-----------------------------------------------------------------------------
-# Enable C++11
-#-----------------------------------------------------------------------------
-set(_msg "Setting C++ standard")
-message(STATUS "${_msg}")
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-  if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "8" OR DEFINED Qt5_DIR)
-    set(CMAKE_CXX_STANDARD 11)
-  else()
-    set(CMAKE_CXX_STANDARD 98)
-  endif()
+# ==== Define cmake build policies that affect compilation and linkage default behaviors
+#
+# Set the SLICER_NEWEST_VALIDATED_POLICIES_VERSION string to the newest cmake version
+# policies that provide successful builds. By setting SLICER_NEWEST_VALIDATED_POLICIES_VERSION
+# to a value greater than the oldest policies, all policies between
+# SLICER_OLDEST_VALIDATED_POLICIES_VERSION and CMAKE_VERSION (used for this build)
+# are set to their NEW behaivor, thereby suppressing policy warnings related to policies
+# between the SLICER_OLDEST_VALIDATED_POLICIES_VERSION and CMAKE_VERSION.
+#
+# CMake versions greater than the SLICER_NEWEST_VALIDATED_POLICIES_VERSION policies will
+# continue to generate policy warnings "CMake Warning (dev)...Policy CMP0XXX is not set:"
+#
+set(SLICER_OLDEST_VALIDATED_POLICIES_VERSION "3.5")
+set(SLICER_NEWEST_VALIDATED_POLICIES_VERSION "3.13.1")
+cmake_minimum_required(VERSION ${SLICER_OLDEST_VALIDATED_POLICIES_VERSION} FATAL_ERROR)
+if("${CMAKE_VERSION}" VERSION_LESS_EQUAL "${SLICER_NEWEST_VALIDATED_POLICIES_VERSION}")
+  #Set and use the newest available cmake policies that are validated to work
+  set(SLICER_CMAKE_POLICY_VERSION "${CMAKE_VERSION}")
+else()
+  set(SLICER_CMAKE_POLICY_VERSION "${SLICER_NEWEST_VALIDATED_POLICIES_VERSION}")
 endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+cmake_policy(VERSION ${SLICER_CMAKE_POLICY_VERSION})
+#
+# Now enumerate specific policies newer than SLICER_NEWEST_VALIDATED_POLICIES_VERSION
+# that may need to be individually set to NEW/OLD
+#
+foreach(pnew "") # Currently Empty
+  if(POLICY ${pnew})
+    cmake_policy(SET ${pnew} NEW)
+  endif()
+endforeach()
+foreach(pold "") # Currently Empty
+  if(POLICY ${pold})
+    cmake_policy(SET ${pold} OLD)
+  endif()
+endforeach()
+
+# ==== Define language standard configurations requiring at least c++11 standard
+if(CMAKE_CXX_STANDARD EQUAL "98" )
+   message(FATAL_ERROR "CMAKE_CXX_STANDARD:STRING=98 is not supported in Slicer 4.11 and greater.")
+endif()
+
+#####
+##  Set the default target properties for ITK
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11) # Supported values are ``11``, ``14``, and ``17``.
+endif()
+if(NOT CMAKE_CXX_STANDARD_REQUIRED)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+if(NOT CMAKE_CXX_EXTENSIONS)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
 message(STATUS "${_msg} - C++${CMAKE_CXX_STANDARD}")
 
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,6 +776,7 @@ message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} for [${Slice
 #-----------------------------------------------------------------------------
 if(Slicer_SUPERBUILD)
   include("${CMAKE_CURRENT_SOURCE_DIR}/SuperBuild.cmake")
+  include(SlicerTestCXX11Features)  #Test necessary cmake features upfront
   return()
 endif()
 


### PR DESCRIPTION
By requiring compiler support for C++11 we can greatly simplify the code
updates necessary support ITKv5 updates.

As development of the next phase of Slicer is begining, changing
to require C++11 will greatly reduce the number of compile
time conditionals in the code.  In many cases supporting
ITKv5 involves using c++11 features directly without
needing conditional wrappers.