### PR TITLE
STYLE: Add SampleData.downloadSample

### DIFF
--- a/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139.py
+++ b/Applications/SlicerApp/Testing/Python/BRAINSFitRigidRegistrationCrashIssue4139.py
@@ -103,12 +103,12 @@ class BRAINSFitRigidRegistrationCrashIssue4139Test(ScriptedLoadableModuleTest):
 
     logic = BRAINSFitRigidRegistrationCrashIssue4139Logic()
 
-    from SampleData import SampleDataLogic
+    import SampleData
 
-    fixed = SampleDataLogic().downloadMRBrainTumor1()
+    fixed = SampleData.downloadSample('MRBrainTumor1')[0]
     self.assertIsNotNone(logic.hasImageData(fixed))
 
-    moving = SampleDataLogic().downloadMRBrainTumor2()
+    moving = SampleData.downloadSample('MRBrainTumor2')[0]
     self.assertIsNotNone(logic.hasImageData(moving))
 
     self.delayDisplay('Finished with download and loading')

--- a/Applications/SlicerApp/Testing/Python/CLIEventTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLIEventTest.py
@@ -219,8 +219,8 @@ class CLIEventTestTest(ScriptedLoadableModuleTest):
     self.delayDisplay('Test that output node moved to referenced node location in subject hierarchy')
 
     self.delayDisplay('Load input volume')
-    from SampleData import SampleDataLogic
-    inputVolume = SampleDataLogic().downloadMRHead()
+    import SampleData
+    inputVolume = SampleData.downloadSample("MRHead")[0]
 
     self.delayDisplay('Create subject hierarchy of input volume')
     shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)

--- a/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
+++ b/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
@@ -135,8 +135,8 @@ class FiducialLayoutSwitchBug1914Logic(ScriptedLoadableModuleLogic):
     self.delayDisplay("Conventional view")
 
     # Download MRHead from sample data
-    from SampleData import SampleDataLogic
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    import SampleData
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
 
     # Place a fiducial on the red slice
     markupsLogic = slicer.modules.markups.logic()

--- a/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
@@ -158,8 +158,8 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
     #
     # first, get some data
     #
-    from SampleData import SampleDataLogic
-    tumor = SampleDataLogic().downloadMRBrainTumor1()
+    import SampleData
+    tumor = SampleData.downloadSample('MRBrainTumor1')[0]
 
     try:
       # four up view

--- a/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
@@ -71,8 +71,8 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
     """ Test the GetRASBounds & GetBounds method on a volume.
     """
     #self.delayDisplay("Starting test_Volume")
-    from SampleData import SampleDataLogic
-    volumeNode = SampleDataLogic().downloadAbdominalCTVolume()
+    import SampleData
+    volumeNode = SampleData.downloadSample('CTA abdomen\n(Panoramix)')[0]
 
     bounds = range(6)
     volumeNode.GetRASBounds(bounds)

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
@@ -89,8 +89,8 @@ class SlicerMRBMultipleSaveRestoreLoop(ScriptedLoadableModuleTest):
     # first, get the data
     #
     print("Getting MR Head Volume")
-    from SampleData import SampleDataLogic
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    import SampleData
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
 
     # Place a fiducial
     markupsLogic = slicer.modules.markups.logic()

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
@@ -86,8 +86,8 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
     # first, get the data
     #
     print("Getting MR Head Volume")
-    from SampleData import SampleDataLogic
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    import SampleData
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
 
     # Place a fiducial
     markupsLogic = slicer.modules.markups.logic()

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
@@ -154,8 +154,8 @@ class SlicerMRBSaveRestoreCheckPaths(ScriptedLoadableModuleTest):
     # first, get the volume data
     #
     print("Getting MR Head Volume")
-    from SampleData import SampleDataLogic
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    import SampleData
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
 
     slicer.util.delayDisplay('Finished with download of volume')
 

--- a/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
@@ -100,8 +100,8 @@ class SlicerOrientationSelectorTestTest(ScriptedLoadableModuleTest):
     logic = SlicerOrientationSelectorTestLogic()
 
     self.delayDisplay("Starting the test")
-    from SampleData import SampleDataLogic
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    import SampleData
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
 
     slicer.util.selectModule('Reformat')
 

--- a/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
@@ -135,8 +135,8 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
     """
     logic = SlicerTransformInteractionTest1Logic()
 
-    from SampleData import SampleDataLogic
-    volume = SampleDataLogic().downloadAbdominalCTVolume()
+    import SampleData
+    volume = SampleData.downloadSample('CTA abdomen\n(Panoramix)')[0]
 
     #self.delayDisplay("Starting test_3D_interactionVolume")
     logic = SlicerTransformInteractionTest1Logic()

--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -96,11 +96,11 @@ class UtilTestTest(ScriptedLoadableModuleTest):
     self.assertIsNone(redSliceCompositeNode.GetForegroundVolumeID())
     self.assertIsNone(redSliceCompositeNode.GetLabelVolumeID())
 
-    from SampleData import SampleDataLogic
+    import SampleData
 
-    backgroundNode = SampleDataLogic().downloadMRHead()
+    backgroundNode = SampleData.downloadSample("MRHead")[0]
     backgroundNode.SetName('Background')
-    foregroundNode = SampleDataLogic().downloadMRHead()
+    foregroundNode = SampleData.downloadSample("MRHead")[0]
     foregroundNode.SetName('Foreground')
 
     volumesLogic = slicer.modules.volumes.logic()
@@ -133,9 +133,9 @@ class UtilTestTest(ScriptedLoadableModuleTest):
     self.assertEqual(redSliceCompositeNode.GetLabelOpacity(), 0.1)
 
     # Try to reset
-    otherBackgroundNode = SampleDataLogic().downloadMRHead()
+    otherBackgroundNode = SampleData.downloadSample("MRHead")[0]
     otherBackgroundNode.SetName('OtherBackground')
-    otherForegroundNode = SampleDataLogic().downloadMRHead()
+    otherForegroundNode = SampleData.downloadSample("MRHead")[0]
     otherForegroundNode.SetName('OtherForeground')
     otherLabelmapNode = volumesLogic.CreateAndAddLabelVolume( slicer.mrmlScene, backgroundNode, 'OtherLabelmap' )
 
@@ -199,8 +199,8 @@ class UtilTestTest(ScriptedLoadableModuleTest):
     # Test if retrieving voxels as a numpy array works
 
     self.delayDisplay('Download sample data')
-    from SampleData import SampleDataLogic
-    volumeNode = SampleDataLogic().downloadMRHead()
+    import SampleData
+    volumeNode = SampleData.downloadSample("MRHead")[0]
 
     self.delayDisplay('Test voxel value read')
     voxelPos = [120,135,89]
@@ -221,8 +221,8 @@ class UtilTestTest(ScriptedLoadableModuleTest):
     # Test if updating voxels from a numpy array works
 
     self.delayDisplay('Download sample data')
-    from SampleData import SampleDataLogic
-    volumeNode = SampleDataLogic().downloadMRHead()
+    import SampleData
+    volumeNode = SampleData.downloadSample("MRHead")[0]
 
     import numpy as np
     import math
@@ -254,8 +254,8 @@ class UtilTestTest(ScriptedLoadableModuleTest):
     self.assertEqual(tableNode1.GetNumberOfRows(), 3)
 
     self.delayDisplay('Download sample data')
-    from SampleData import SampleDataLogic
-    volumeNode = SampleDataLogic().downloadMRHead()
+    import SampleData
+    volumeNode = SampleData.downloadSample("MRHead")[0]
 
     self.delayDisplay('Compute histogram')
     histogram = np.histogram(slicer.util.arrayFromVolume(volumeNode))
@@ -290,8 +290,8 @@ class UtilTestTest(ScriptedLoadableModuleTest):
     # Test if convenience function of getting numpy array from various nodes works
 
     self.delayDisplay('Test array with scalar image')
-    from SampleData import SampleDataLogic
-    volumeNode = SampleDataLogic().downloadMRHead()
+    import SampleData
+    volumeNode = SampleData.downloadSample("MRHead")[0]
     voxelPos = [120,135,89]
     voxelValueVtk = volumeNode.GetImageData().GetScalarComponentAsDouble(voxelPos[0], voxelPos[1], voxelPos[2], 0)
     narray = slicer.util.arrayFromVolume(volumeNode)
@@ -299,7 +299,7 @@ class UtilTestTest(ScriptedLoadableModuleTest):
     self.assertEqual(voxelValueVtk, voxelValueNumpy)
 
     self.delayDisplay('Test array with tensor image')
-    tensorVolumeNode = SampleDataLogic().downloadDTIBrain()
+    tensorVolumeNode = SampleData.downloadSample('DTIBrain')[0]
     narray = slicer.util.array(tensorVolumeNode.GetName())
     self.assertEqual(narray.shape, (85, 144, 144, 3, 3))
 

--- a/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926.py
+++ b/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926.py
@@ -96,9 +96,9 @@ class ViewControllersSliceInterpolationBug1926Test(ScriptedLoadableModuleTest):
     # first, get some data
     #
     self.delayDisplay("Getting Data")
-    from SampleData import SampleDataLogic
-    head = SampleDataLogic().downloadMRHead()
-    tumor = SampleDataLogic().downloadMRBrainTumor1()
+    import SampleData
+    head = SampleData.downloadSample("MRHead")[0]
+    tumor = SampleData.downloadSample('MRBrainTumor1')[0]
 
     # Change to a CompareView
     ln = slicer.util.getNode(pattern='vtkMRMLLayoutNode*')

--- a/Applications/SlicerApp/Testing/Python/sceneImport2428.py
+++ b/Applications/SlicerApp/Testing/Python/sceneImport2428.py
@@ -97,8 +97,8 @@ class sceneImport2428Test(ScriptedLoadableModuleTest):
     # first, get some data
     #
     self.delayDisplay("Getting Data")
-    from SampleData import SampleDataLogic
-    head = SampleDataLogic().downloadMRHead()
+    import SampleData
+    head = SampleData.downloadSample("MRHead")[0]
 
     #
     # create a label map and set it for editing

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1366,7 +1366,7 @@ def plot(narray, xColumnIndex = -1, columnNames = None, title = None, show = Tru
     # Get sample data
     import numpy as np
     import SampleData
-    volumeNode = SampleData.SampleDataLogic().downloadMRHead()
+    volumeNode = SampleData.downloadSample("MRHead")[0]
 
     # Create new plot
     histogram = np.histogram(arrayFromVolume(volumeNode), bins=50)
@@ -1383,7 +1383,7 @@ def plot(narray, xColumnIndex = -1, columnNames = None, title = None, show = Tru
     # Get sample data
     import numpy as np
     import SampleData
-    volumeNode = SampleData.SampleDataLogic().downloadMRHead()
+    volumeNode = SampleData.downloadSample("MRHead")[0]
 
     # Create variable that will store plot nodes (chart, table, series)
     plotNodes = {}

--- a/Base/Python/tests/test_sitkUtils.py
+++ b/Base/Python/tests/test_sitkUtils.py
@@ -13,8 +13,8 @@ class SitkUtilsTests(unittest.TestCase):
 
         """ Download the MRHead node
         """
-        from SampleData import SampleDataLogic
-        SampleDataLogic().downloadMRHead()
+        import SampleData
+        SampleData.downloadSample("MRHead")[0]
         volumeNode1 = slicer.util.getNode('MRHead')
         self.assertEqual(volumeNode1.GetName(), "MRHead")
 
@@ -86,8 +86,8 @@ class SitkUtilsTests(unittest.TestCase):
 
         """ Download the MRHead node
         """
-        from SampleData import SampleDataLogic
-        SampleDataLogic().downloadMRHead()
+        import SampleData
+        SampleData.downloadSample("MRHead")[0]
         volumeNode1 = slicer.util.getNode('MRHead')
         self.assertEqual(volumeNode1.GetName(), "MRHead")
 

--- a/Extensions/Testing/ScriptedSegmentEditorEffectExtensionTemplate/ScriptedSegmentEditorEffectModuleTemplate/SegmentEditorScriptedSegmentEditorEffectModuleTemplate.py
+++ b/Extensions/Testing/ScriptedSegmentEditorEffectExtensionTemplate/ScriptedSegmentEditorEffectModuleTemplate/SegmentEditorScriptedSegmentEditorEffectModuleTemplate.py
@@ -66,8 +66,8 @@ class SegmentEditorScriptedSegmentEditorEffectModuleTemplateTest(ScriptedLoadabl
     ##################################
     self.delayDisplay("Load master volume")
 
-    from SampleData import SampleDataLogic
-    masterVolumeNode = SampleDataLogic().downloadMRBrainTumor1()
+    import SampleData
+    masterVolumeNode = SampleData.downloadSample('MRBrainTumor1')[0]
 
     ##################################
     self.delayDisplay("Create segmentation containing a few spheres")

--- a/Modules/Loadable/CropVolume/Testing/Python/CropVolumeSelfTest.py
+++ b/Modules/Loadable/CropVolume/Testing/Python/CropVolumeSelfTest.py
@@ -58,9 +58,9 @@ class CropVolumeSelfTestTest(ScriptedLoadableModuleTest):
 
     print("Running CropVolumeSelfTest Test case:")
 
-    from SampleData import SampleDataLogic
+    import SampleData
 
-    vol = SampleDataLogic().downloadMRHead()
+    vol = SampleData.downloadSample("MRHead")[0]
     roi = slicer.vtkMRMLAnnotationROINode()
     roi.Initialize(slicer.mrmlScene)
 
@@ -87,7 +87,7 @@ class CropVolumeSelfTestTest(ScriptedLoadableModuleTest):
     mainWindow.moduleSelector().selectModule('Transforms')
     mainWindow.moduleSelector().selectModule('CropVolume')
     cropVolumeNode = slicer.mrmlScene.GetNodeByID('vtkMRMLCropVolumeParametersNode1')
-    vol = SampleDataLogic().downloadMRHead()
+    vol = SampleData.downloadSample("MRHead")[0]
     roi = slicer.vtkMRMLAnnotationROINode()
     roi.Initialize(slicer.mrmlScene)
     cropVolumeNode.SetInputVolumeNodeID(vol.GetID())

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
@@ -80,8 +80,8 @@ class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
     # first load the data
     #
     print("Getting MR Head Volume")
-    from SampleData import SampleDataLogic
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    import SampleData
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
 
     #
     # link the viewers

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
@@ -135,8 +135,8 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     # first load the data
     #
     print("Getting MR Head Volume")
-    from SampleData import SampleDataLogic
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    import SampleData
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
 
     #
     # link the viewers

--- a/Modules/Loadable/Markups/Testing/Python/NeurosurgicalPlanningTutorialMarkupsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/NeurosurgicalPlanningTutorialMarkupsSelfTest.py
@@ -143,8 +143,8 @@ class NeurosurgicalPlanningTutorialMarkupsSelfTestLogic(ScriptedLoadableModuleLo
 
     # use the sample data module logic to load data for the self test
     self.delayDisplay("Getting Baseline volume")
-    from SampleData import SampleDataLogic
-    baselineVolume = SampleDataLogic().downloadWhiteMatterExplorationBaselineVolume()
+    import SampleData
+    baselineVolume = SampleData.downloadSample('BaselineVolume')[0]
 
     self.takeScreenshot('NeurosurgicalPlanning-Loaded','Data loaded')
 

--- a/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
+++ b/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
@@ -156,8 +156,8 @@ class AddStorableDataAfterSceneViewTestTest(ScriptedLoadableModuleTest):
     # add another storable node, a volume
     #
     slicer.util.delayDisplay("Adding a new storable node, after creating a scene view")
-    from SampleData import SampleDataLogic
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    import SampleData
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
     mrHeadID = mrHeadVolume.GetID()
 
     #
@@ -178,7 +178,7 @@ class AddStorableDataAfterSceneViewTestTest(ScriptedLoadableModuleTest):
 
     #
     # add new storable again
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
     mrHeadID = mrHeadVolume.GetID()
 
     #

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
@@ -132,9 +132,9 @@ class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
     closedSurfaceReprName = vtkSegmentationCore.vtkSegmentationConverter.GetClosedSurfaceRepresentationName()
 
     # Use MRHead and Tinypatient for testing
-    from SampleData import SampleDataLogic
-    mrVolumeNode = SampleDataLogic().downloadMRHead()
-    [tinyVolumeNode, tinySegmentationNode] = SampleDataLogic().downloadSample('TinyPatient')
+    import SampleData
+    mrVolumeNode = SampleData.downloadSample("MRHead")[0]
+    [tinyVolumeNode, tinySegmentationNode] = SampleData.downloadSample('TinyPatient')
 
     # Convert MRHead to oriented image data
     import vtkSlicerSegmentationsModuleLogicPython as vtkSlicerSegmentationsModuleLogic

--- a/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
@@ -97,8 +97,8 @@ class VolumeRenderingSceneCloseLogic(ScriptedLoadableModuleLogic):
 
     self.delayDisplay('Running the aglorithm')
 
-    from SampleData import SampleDataLogic
-    ctVolume = SampleDataLogic().downloadCTChest()
+    import SampleData
+    ctVolume = SampleData.downloadSample('CTChest')[0]
     self.delayDisplay('Downloaded CT sample data')
 
     # go to the volume rendering module

--- a/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingThreeDOnlyLayout.py
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingThreeDOnlyLayout.py
@@ -34,8 +34,8 @@ class VolumeRenderingThreeDOnlyLayout(ScriptedLoadableModuleTest):
         layoutManager.setMRMLScene(mrmlScene)
 
         # Load MRHead volume
-        from SampleData import SampleDataLogic
-        SampleDataLogic().downloadMRHead()
+        import SampleData
+        SampleData.downloadSample("MRHead")[0]
 
         # Enter the volume rendering module
         slicer.util.mainWindow().moduleSelector().selectModule('VolumeRendering')

--- a/Modules/Loadable/Volumes/Testing/Python/LoadVolumeDisplaybleSceneModelClose.py
+++ b/Modules/Loadable/Volumes/Testing/Python/LoadVolumeDisplaybleSceneModelClose.py
@@ -17,8 +17,8 @@ class VolumesLoadSceneCloseTesting(ScriptedLoadableModuleTest):
     #
     # first, get some sample data
     #
-    from SampleData import SampleDataLogic
-    SampleDataLogic().downloadMRHead()
+    import SampleData
+    SampleData.downloadSample("MRHead")[0]
 
     #
     # enter the models module

--- a/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
+++ b/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
@@ -18,8 +18,8 @@ class VolumesLogicCompareVolumeGeometryTesting(ScriptedLoadableModuleTest):
     #
     # first, get some sample data
     #
-    from SampleData import SampleDataLogic
-    head = SampleDataLogic().downloadMRHead()
+    import SampleData
+    head = SampleData.downloadSample("MRHead")[0]
 
     #
     # get the volumes logic and print out default epsilon and precision

--- a/Modules/Scripted/EditorLib/Testing/StandaloneEditorWidgetTest.py
+++ b/Modules/Scripted/EditorLib/Testing/StandaloneEditorWidgetTest.py
@@ -30,8 +30,8 @@ class EditorLibTesting(ScriptedLoadableModuleTest):
     #
     # first, get some sample data
     #
-    from SampleData import SampleDataLogic
-    head = SampleDataLogic().downloadMRHead()
+    import SampleData
+    head = SampleData.downloadSample("MRHead")[0]
 
     #
     # create a label map and set it for editing

--- a/Modules/Scripted/EditorLib/Testing/ThresholdThreadingTest.py
+++ b/Modules/Scripted/EditorLib/Testing/ThresholdThreadingTest.py
@@ -58,8 +58,8 @@ class ThresholdThreadingTestTest(ScriptedLoadableModuleTest):
     # first, get some sample data
     #
     self.delayDisplay("Get some data")
-    from SampleData import SampleDataLogic
-    head = SampleDataLogic().downloadMRHead()
+    import SampleData
+    head = SampleData.downloadSample("MRHead")[0]
 
     #
     # now, define an ROI in it

--- a/Modules/Scripted/LabelStatistics/LabelStatistics.py
+++ b/Modules/Scripted/LabelStatistics/LabelStatistics.py
@@ -517,9 +517,9 @@ class LabelStatisticsTest(ScriptedLoadableModuleTest):
     #
     # first, get some data
     #
-    from SampleData import SampleDataLogic
-    mrHead = SampleDataLogic().downloadMRHead()
-    ctChest = SampleDataLogic().downloadCTChest()
+    import SampleData
+    mrHead = SampleData.downloadSample("MRHead")[0]
+    ctChest = SampleData.downloadSample('CTChest')[0]
     self.delayDisplay('Two data sets loaded')
 
     volumesLogic = slicer.modules.volumes.logic()

--- a/Modules/Scripted/PerformanceTests/PerformanceTests.py
+++ b/Modules/Scripted/PerformanceTests/PerformanceTests.py
@@ -54,10 +54,10 @@ class PerformanceTestsWidget(ScriptedLoadableModuleWidget):
     self.layout.addStretch(1)
 
   def downloadMRHead(self):
-    from SampleData import SampleDataLogic
+    import SampleData
     self.log.insertHtml('<b>Requesting downloading MRHead')
     self.log.repaint()
-    mrHeadVolume = SampleDataLogic().downloadMRHead()
+    mrHeadVolume = SampleData.downloadSample("MRHead")[0]
     if mrHeadVolume:
       self.log.insertHtml('<i>finished.</i>\n')
       self.log.insertPlainText('\n')

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -37,6 +37,11 @@ def downloadFromURL(uris, fileNames, nodeNames=None,
     uris, fileNames, nodeNames, customDownloader, loadFileTypes, loadFileProperties)
 
 
+def downloadSample(sampleName):
+  """For a given sample name this will search the available sources
+  and load it if it is available.  Returns the loaded nodes."""
+  return SampleDataLogic().downloadSample(sampleName)
+
 #
 # SampleData
 #

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -1130,9 +1130,9 @@ class ScreenCaptureTest(ScriptedLoadableModuleTest):
     """ Do whatever is needed to reset the state - typically a scene clear will be enough.
     """
     slicer.mrmlScene.Clear(0)
-    from SampleData import SampleDataLogic
-    self.image1 = SampleDataLogic().downloadMRBrainTumor1()
-    self.image2 = SampleDataLogic().downloadMRBrainTumor2()
+    import SampleData
+    self.image1 = SampleData.downloadSample('MRBrainTumor1')[0]
+    self.image2 = SampleData.downloadSample('MRBrainTumor2')[0]
 
     # make the output volume appear in all the slice views
     selectionNode = slicer.app.applicationLogic().GetSelectionNode()

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -645,12 +645,12 @@ class SegmentStatisticsTest(ScriptedLoadableModuleTest):
     self.delayDisplay("Starting test_SegmentStatisticsBasic")
 
     import vtkSegmentationCorePython as vtkSegmentationCore
-    from SampleData import SampleDataLogic
+    import SampleData
     from SegmentStatistics import SegmentStatisticsLogic
 
     self.delayDisplay("Load master volume")
 
-    masterVolumeNode = SampleDataLogic().downloadMRBrainTumor1()
+    masterVolumeNode = SampleData.downloadSample('MRBrainTumor1')[0]
 
     self.delayDisplay("Create segmentation containing a few spheres")
 
@@ -703,12 +703,12 @@ class SegmentStatisticsTest(ScriptedLoadableModuleTest):
     self.delayDisplay("Starting test_SegmentStatisticsPlugins")
 
     import vtkSegmentationCorePython as vtkSegmentationCore
-    from SampleData import SampleDataLogic
+    import SampleData
     from SegmentStatistics import SegmentStatisticsLogic
 
     self.delayDisplay("Load master volume")
 
-    masterVolumeNode = SampleDataLogic().downloadMRBrainTumor1()
+    masterVolumeNode = SampleData.downloadSample('MRBrainTumor1')[0]
 
     self.delayDisplay("Create segmentation containing a few spheres")
 

--- a/Utilities/Templates/Modules/ScriptedSegmentEditorEffect/SegmentEditorTemplateKey.py
+++ b/Utilities/Templates/Modules/ScriptedSegmentEditorEffect/SegmentEditorTemplateKey.py
@@ -60,13 +60,13 @@ class SegmentEditorTemplateKeyTest(ScriptedLoadableModuleTest):
 
     import vtkSegmentationCorePython as vtkSegmentationCore
     import vtkSlicerSegmentationsModuleLogicPython as vtkSlicerSegmentationsModuleLogic
-    from SampleData import SampleDataLogic
+    import SampleData
     from SegmentStatistics import SegmentStatisticsLogic
 
     ##################################
     self.delayDisplay("Load master volume")
 
-    masterVolumeNode = SampleDataLogic().downloadMRBrainTumor1()
+    masterVolumeNode = SampleData.downloadSample('MRBrainTumor1')[0]
 
     ##################################
     self.delayDisplay("Create segmentation containing a few spheres")


### PR DESCRIPTION
This is a follow of https://github.com/Slicer/Slicer/pull/1062

Other possible improvement:
* decouple downloading and loading by having `loadFromURL` and `downloadFromURL`
* rename `downloadSample` into `loadSample`. Since this may break existing code .. may be we should keep this for Slicer 5.0 ? 