### PR TITLE
ENH: Added option to load MRB files from Sample Data module

### DIFF
--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -333,7 +333,7 @@ class SampleDataLogic(object):
   def registerCustomSampleDataSource(category='Custom',
     sampleName=None, uris=None, fileNames=None, nodeNames=None,
     customDownloader=None, thumbnailFileName=None,
-    loadFileType='VolumeFile', loadFileProperties={}):
+    loadFileType='VolumeFile', loadFiles=None, loadFileProperties={}):
     """Adds custom data sets to SampleData.
     :param category: Section title of data set in SampleData module GUI.
     :param sampleName: Displayed name of data set in SampleData module GUI.
@@ -361,6 +361,7 @@ class SampleDataLogic(object):
       nodeNames=nodeNames,
       thumbnailFileName=thumbnailFileName,
       loadFileType=loadFileType,
+      loadFiles=loadFiles,
       loadFileProperties=loadFileProperties
       ))
 


### PR DESCRIPTION
In the Sample Data module, scene files (.mrb or .mrml) are not loaded into Slicer by default. This default could not be changed when registering a custom data set. Now a parameter has been added to specify if the files should be loaded for a custom data set. 