### PR TITLE
ENH: Initialize revisionUserSettings using default settings

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -291,6 +291,10 @@ void qSlicerCoreApplicationPrivate::init()
         {
         q->userSettings()->setValue(key, q->defaultSettings()->value(key));
         }
+      if (!q->revisionUserSettings()->contains(key))
+        {
+        q->revisionUserSettings()->setValue(key, q->defaultSettings()->value(key));
+        }
       }
     }
 


### PR DESCRIPTION
This commit ensures that default settings are used to initialize both
userSettings and revisionUserSettings. This is particularly useful when
creating slicer custom application.