### PR TITLE
ENH: Update SimpleITK to v1.2.0 release

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -41,7 +41,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v1.1.0"
+    "v1.2.0"
     QUIET
     )
 


### PR DESCRIPTION
Release Notes:
https://github.com/SimpleITK/SimpleITK/releases/tag/v1.2.0

> - ITKv5 compatibility enables SimpleITK to be compiled against ITKv5 betas.
> - The default and binaries are built against the proven ITK 4.13.1 release branch. Comprehensive SimpleITK testing has lead to improvements in upstream ITK. (https://github.com/InsightSoftwareConsortium/ITK/releases/tag/v4.13.1)

Built and ran tests with the following results that don't seem related. It was a Windows7-VS2015-64bits-QT5.10.1 configuration.  Could be good to include in Slicer 4.10.1 release.

> 99% tests passed, 3 tests failed out of 664
> .
> .
> .
> 1>The following tests FAILED:
> 1>	  6 - cmake_slicer_generate_extension_description_test (Failed)
> 1>	512 - MergeModelsTestCompare (Failed)
> 1>	663 - py_LandmarkRegistration (Failed)