### PR TITLE
Constrain fiducials (WIP, do not merge)

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
@@ -312,6 +312,34 @@ p, li { white-space: pre-wrap; }
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="threeDHorizontalLayout">
+         <item>
+          <widget class="QLabel" name="ThreeDViewLabel">
+           <property name="text">
+            <string>Constrain fiducials to 3D surface:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="ThreeDConstrainMarkupsCheckBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Keep fiducials on the surfaces of visible objects in the 3D view.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/Base/QTGUI/qSlicerSettingsViewsPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsViewsPanel.cxx
@@ -132,6 +132,11 @@ void qSlicerSettingsViewsPanelPrivate::init()
                       "checked", SIGNAL(toggled(bool)),
                       "Orthographic projection");
 
+  q->registerProperty("ThreeDView/ConstrainFiducials", this->ThreeDConstrainMarkupsCheckBox,
+                      "checked", SIGNAL(toggled(bool)),
+                      "Orthographic projection",
+                      ctkSettingsPanel::OptionRequireRestart);
+
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
@@ -22,13 +22,13 @@
 
 // VTK includes
 #include "vtkObject.h"
+#include "vtkCellPicker.h"
 #include "vtkInteractorStyle.h"
 #include "vtkSmartPointer.h"
 
 #include "vtkMRMLDisplayableManagerExport.h"
 
 class vtkMRMLModelDisplayableManager;
-class vtkCellPicker;
 
 /// \brief Interactive manipulation of the camera.
 ///
@@ -102,11 +102,13 @@ public:
   vtkGetObjectMacro(ModelDisplayableManager, vtkMRMLModelDisplayableManager);
   virtual void SetModelDisplayableManager(vtkMRMLModelDisplayableManager *modelDisplayableManager);
 
+  /// Use the internal picker to find closest intersected point
+  /// along ray from camera through x, y in display coordinates
+  bool Pick(int x, int y, double pickPoint[3]);
+
 protected:
   vtkThreeDViewInteractorStyle();
   ~vtkThreeDViewInteractorStyle();
-
-  bool Pick(int x, int y, double pickPoint[3]);
 
   vtkMRMLCameraNode *CameraNode;
 

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.cxx
@@ -644,7 +644,6 @@ void vtkMRMLMarkupsFiducialDisplayableManager3D::ConstrainMovement(vtkMRMLMarkup
 
   vtkThreeDViewInteractorStyle* interactorStyle = vtkThreeDViewInteractorStyle::SafeDownCast(
               this->GetInteractor()->GetInteractorStyle());
-  vtkCellPicker *cellPicker = interactorStyle->GetCellPicker();
 
   double pickPoint[3];
   if (interactorStyle->Pick(displayCoordinates[0], displayCoordinates[1], pickPoint))

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.h
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsFiducialDisplayableManager3D.h
@@ -66,6 +66,14 @@ protected:
   /// Propagate properties of widget to MRML node.
   virtual void PropagateWidgetToMRML(vtkAbstractWidget * widget, vtkMRMLMarkupsNode* node) VTK_OVERRIDE;
 
+  /// Constrain movement along surface of displayables in the scene
+  /// NOTE: this method is added to the Markups infrastructure to address a common use
+  /// case of dragging a fiducial on a 3D surface.  Since their is an active development
+  /// process in place to create a new design, this feature is not added as a general
+  /// purpose virtual method.
+  /// See: https://na-mic.github.io/ProjectWeek/PW30_2019_GranCanaria/Projects/MarkupsRedesign/
+  void ConstrainMovement(vtkMRMLMarkupsFiducialNode *fiducialNode, double coords[3]);
+
   /// Set up an observer on the interactor style to watch for key press events
   virtual void AdditionnalInitializeStep();
   /// Respond to the interactor style event


### PR DESCRIPTION
This works pretty well, and can be a placeholder until the more comprehensive markup overhaul is ready.

You might want to try it and see if we can figure out how to make the fiducial 'stick' to the mouse, but if not I think okay as-is and better than the default behavior.  I'd be tempted to include it as-is in the 4.10.2 patch release.

Note that I looked into making it possible to toggle this behavior, but didn't see how to get access to state from a QSetting into a vtkMRMLDisplayableManager (some options discussed in the commit message).  @jcfr or @lassoan any thoughts?