### PR TITLE
Webwidget streamline python use

### DIFF
--- a/Base/QTGUI/qSlicerExtensionsInstallWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsInstallWidget.cxx
@@ -152,18 +152,16 @@ void qSlicerExtensionsInstallWidgetPrivate::setFailurePage(const QStringList& er
 }
 
 // --------------------------------------------------------------------------
-void qSlicerExtensionsInstallWidgetPrivate::updateWebChannelScript(QByteArray& webChannelScript)
+void qSlicerExtensionsInstallWidgetPrivate::initializeWebChannelTransport(QByteArray& webChannelScript)
 {
 #if (QT_VERSION < QT_VERSION_CHECK(5, 6, 0))
   Q_UNUSED(webChannelScript);
 #else
+  this->Superclass::initializeWebChannelTransport(webChannelScript);
   webChannelScript.append(
-      "\n"
-      "new QWebChannel(qt.webChannelTransport, function(channel) {"
-      " window.extensions_manager_model = channel.objects.extensions_manager_model;"
+      " window.extensions_manager_model = channel.objects.extensions_manager_model;\n"
       // See ExtensionInstallWidgetWebChannelProxy
-      " window.extensions_install_widget = channel.objects.extensions_install_widget;"
-      "});"
+      " window.extensions_install_widget = channel.objects.extensions_install_widget;\n"
       );
 #endif
 }

--- a/Base/QTGUI/qSlicerExtensionsInstallWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsInstallWidget.cxx
@@ -175,6 +175,7 @@ void qSlicerExtensionsInstallWidgetPrivate::initializeWebChannel(QWebChannel* we
   Q_UNUSED(webChannel);
   // This is done in qSlicerExtensionsInstallWidget::initJavascript()
 #else
+  this->Superclass::initializeWebChannel(webChannel);
   webChannel->registerObject(
         "extensions_install_widget", this->InstallWidgetForWebChannel);
 #endif

--- a/Base/QTGUI/qSlicerExtensionsInstallWidget_p.h
+++ b/Base/QTGUI/qSlicerExtensionsInstallWidget_p.h
@@ -66,8 +66,8 @@ public:
 
   void setFailurePage(const QStringList &errors);
 
-  virtual void updateWebChannelScript(QByteArray& webChannelScript);
   virtual void initializeWebChannel(QWebChannel* webChannel);
+  virtual void initializeWebChannelTransport(QByteArray& webChannelScript);
   void registerExtensionsManagerModel(qSlicerExtensionsManagerModel* oldModel, qSlicerExtensionsManagerModel* newModel);
 
   qSlicerExtensionsManagerModel * ExtensionsManagerModel;

--- a/Base/QTGUI/qSlicerExtensionsInstallWidget_p.h
+++ b/Base/QTGUI/qSlicerExtensionsInstallWidget_p.h
@@ -56,6 +56,7 @@ protected:
   qSlicerExtensionsInstallWidget* const q_ptr;
 
 public:
+  typedef qSlicerWebWidgetPrivate Superclass;
   qSlicerExtensionsInstallWidgetPrivate(qSlicerExtensionsInstallWidget& object);
   virtual ~qSlicerExtensionsInstallWidgetPrivate();
 

--- a/Base/QTGUI/qSlicerWebWidget.cxx
+++ b/Base/QTGUI/qSlicerWebWidget.cxx
@@ -214,6 +214,29 @@ void qSlicerWebWidgetPrivate::onAppAboutToQuit()
 
 // --------------------------------------------------------------------------
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+void qSlicerWebWidgetPrivate::updateWebChannelScript(QByteArray& webChannelScript)
+{
+  webChannelScript.append(
+        "\n"
+        "new QWebChannel(qt.webChannelTransport, function(channel) {\n"
+        );
+  this->initializeWebChannelTransport(webChannelScript);
+  webChannelScript.append(
+        "});\n"
+        );
+}
+#endif
+
+// --------------------------------------------------------------------------
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+void qSlicerWebWidgetPrivate::initializeWebChannelTransport(QByteArray& webChannelScript)
+{
+  webChannelScript.append(" window.slicerPython = channel.objects.slicerPython;\n");
+}
+#endif
+
+// --------------------------------------------------------------------------
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
 void qSlicerWebWidgetPrivate::initializeWebEngineProfile(QWebEngineProfile* profile)
 {
   if (!profile)

--- a/Base/QTGUI/qSlicerWebWidget_p.h
+++ b/Base/QTGUI/qSlicerWebWidget_p.h
@@ -114,8 +114,21 @@ public:
   /// script content.
   virtual void initializeWebEngineProfile(QWebEngineProfile* profile);
 
+  /// \brief Append additional script content to ``qwebchannel_appended.js``.
+  ///
+  /// The default implementation instantiates a ``QWebChannel`` JS object and
+  /// call initializeWebChannelTransport() to provide derived classes with an
+  /// opportunity to further customize the WebChannelTransport initialization
+  /// callback code.
+  ///
   /// \sa initializeWebEngineProfile(QWebEngineProfile*)
-  virtual void updateWebChannelScript(QByteArray& /* webChannelScript */){}
+  virtual void updateWebChannelScript(QByteArray& /* webChannelScript */);
+
+  /// \brief Append additional script content to the WebChannelTransport initialization
+  /// callback associated with the default QWebChannel.
+  ///
+  /// \sa updateWebChannelScript()
+  virtual void initializeWebChannelTransport(QByteArray& /* webChannelScript */);
 
   virtual void initializeWebChannel(QWebChannel* /* webChannel */);
 

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -301,7 +301,7 @@ list_conditional_append(Slicer_BUILD_OtsuThresholdImageFilter Slicer_REMOTE_DEPE
 
 Slicer_Remote_Add(DataStore
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/Slicer-DataStore"
-  GIT_TAG "e6278c07610d0a8719bfa65b24f2aa7c28332d68"
+  GIT_TAG "8053b0283583d93b223c43bbf4678cb9adf7b0c7"
   OPTION_NAME Slicer_BUILD_DataStore
   LABELS REMOTE_MODULE
   )

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -301,7 +301,7 @@ list_conditional_append(Slicer_BUILD_OtsuThresholdImageFilter Slicer_REMOTE_DEPE
 
 Slicer_Remote_Add(DataStore
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/Slicer-DataStore"
-  GIT_TAG "fb679171ca9722e8f716902a582e45495331f801"
+  GIT_TAG "e6278c07610d0a8719bfa65b24f2aa7c28332d68"
   OPTION_NAME Slicer_BUILD_DataStore
   LABELS REMOTE_MODULE
   )


### PR DESCRIPTION
Improve use of python from javascript.

@pieper Instead of a systematically re-initialization the `QWebChannel`, this PR re-refactor the code introducing `qSlicerExtensionsInstallWidgetPrivate::initializeWebChannelTransport(QByteArray& webChannelScript)` allowing both the base and derives classes to customize the WebChannelTransport initialization call back.

See also this documentation mentioning that only one WebChannel can be initialized only once per page. See http://doc.qt.io/qt-5/qwebenginepage.html#setWebChannel

This means that to evaluate python from a webpage loaded through a `qSlicerWebWidget`, it is now as simple as doing `window.slicerPython.evalPython("print('hello from JS through python')")`