### PR TITLE
Extension widgets re-usable from QFormBuilder (slicer.util.loadUI)

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -198,6 +198,7 @@ public:
   bool uninstallExtension(const QString& extensionName);
 
   QStringList extensionLibraryPaths(const QString& extensionName)const;
+  QStringList extensionQtPluginPaths(const QString& extensionName)const;
   QStringList extensionPaths(const QString& extensionName)const;
 
 #ifdef Slicer_USE_PYTHONQT
@@ -520,12 +521,25 @@ void qSlicerExtensionsManagerModelPrivate::addExtensionPathToLauncherSettings(co
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
                          appendToPathList(paths, this->extensionPaths(extensionName)),
                          "Paths", "path");
+
 #ifdef Slicer_USE_PYTHONQT
   QStringList pythonPaths = qSlicerExtensionsManagerModel::readArrayValues(settings, "PYTHONPATH", "path");
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
                          appendToPathList(pythonPaths, this->extensionPythonPaths(extensionName)),
                          "PYTHONPATH", "path");
 #endif
+
+  QStringList envVars = settings.value("General/additionalPathVariables").toStringList();
+  if (!envVars.contains("QT_PLUGIN_PATH"))
+    {
+    envVars << "QT_PLUGIN_PATH";
+    }
+  settings.setValue("General/additionalPathVariables", envVars);
+
+  QStringList qtPluginPaths = qSlicerExtensionsManagerModel::readArrayValues(settings, "QT_PLUGIN_PATH", "path");
+  qSlicerExtensionsManagerModel::writeArrayValues(settings,
+                         appendToPathList(qtPluginPaths, this->extensionQtPluginPaths(extensionName)),
+                         "QT_PLUGIN_PATH", "path");
 }
 
 // --------------------------------------------------------------------------
@@ -551,12 +565,18 @@ void qSlicerExtensionsManagerModelPrivate::removeExtensionPathFromLauncherSettin
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
                          removeFromPathList(paths, this->extensionPaths(extensionName)),
                          "Paths", "path");
+
 #ifdef Slicer_USE_PYTHONQT
   QStringList pythonPaths = qSlicerExtensionsManagerModel::readArrayValues(settings, "PYTHONPATH", "path");
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
                          removeFromPathList(pythonPaths, this->extensionPythonPaths(extensionName)),
                          "PYTHONPATH", "path");
 #endif
+
+  QStringList qtPluginPaths = qSlicerExtensionsManagerModel::readArrayValues(settings, "QT_PLUGIN_PATH", "path");
+  qSlicerExtensionsManagerModel::writeArrayValues(settings,
+                         removeFromPathList(qtPluginPaths, this->extensionQtPluginPaths(extensionName)),
+                         "QT_PLUGIN_PATH", "path");
 }
 
 #ifdef Q_OS_WIN
@@ -698,6 +718,20 @@ QStringList qSlicerExtensionsManagerModelPrivate::extensionLibraryPaths(const QS
                    << path + "/" + QString(Slicer_QTLOADABLEMODULES_LIB_DIR).replace(Slicer_VERSION, this->SlicerVersion)
                    << path + "/" + QString(Slicer_THIRDPARTY_LIB_DIR)
                    );
+}
+
+// --------------------------------------------------------------------------
+QStringList qSlicerExtensionsManagerModelPrivate::extensionQtPluginPaths(const QString& extensionName)const
+{
+  Q_Q(const qSlicerExtensionsManagerModel);
+  if (this->SlicerVersion.isEmpty())
+  {
+    return QStringList();
+  }
+  QString path = q->extensionInstallPath(extensionName);
+  return appendToPathList(QStringList(), QStringList()
+                   << path + "/" + QString(Slicer_QtPlugins_DIR).replace(Slicer_VERSION, this->SlicerVersion)
+  );
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #4670

Extension plugin path is installed into Slicer-XYZ.ini configuration file when extension is installed, removed when extension is removed.

Build tree fixes are not required as plugin library is installed into Slicer root plugin folder