### PR TITLE
BUG: DicomWidgets - Do not assume that the extensions manager exists

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -412,6 +412,9 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
     """The dicom browser will emit multiple directoryImported
     signals during the same operation, so we collapse them
     into a single check for compatible extensions."""
+    if not hasattr(slicer.app, 'extensionsManagerModel'):
+      # Slicer may not be built with extension manager support
+      return
     if not self.extensionCheckPending:
       self.extensionCheckPending = True
       def timerCallback():


### PR DESCRIPTION
Since Slicer may not be built with the extension manager enabled,
qSlicerCoreApplication::extentionsManagerModel may not exists (it's
surrounded by #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT).