### PR TITLE
BUG: Fix mouse cursor in Segment Editor

### DIFF
--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -472,10 +472,7 @@ void qSlicerMouseModeToolBar::changeCursorTo(QCursor cursor)
       {
       continue;
       }
-    threeDView->setCursor(cursor);
-#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
-    threeDView->VTKWidget()->setQVTKCursor(cursor);
-#endif
+    threeDView->setViewCursor(cursor);
     }
 
   // Updated all mapped slicer viewers

--- a/Libs/MRML/Widgets/qMRMLSliceView.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceView.cxx
@@ -418,3 +418,15 @@ QList<double> qMRMLSliceView::convertXYZToRAS(const QList<double>& xyz)const
   ret << 0. << 0. << 0.;
   return ret;
 }
+
+// --------------------------------------------------------------------------
+void qMRMLSliceView::setViewCursor(const QCursor &cursor)
+{
+  this->setCursor(cursor);
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
+  if (this->VTKWidget() != NULL)
+    {
+    this->VTKWidget()->setQVTKCursor(cursor);
+    }
+#endif
+}

--- a/Libs/MRML/Widgets/qMRMLSliceView.h
+++ b/Libs/MRML/Widgets/qMRMLSliceView.h
@@ -87,6 +87,8 @@ public:
   /// in the LightBox pane.
   Q_INVOKABLE QList<double> convertXYZToRAS(const QList<double> &xyz)const;
 
+  /// Set cursor in the view area
+  Q_INVOKABLE void setViewCursor(const QCursor &);
 
 public slots:
 

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -523,3 +523,15 @@ void qMRMLThreeDView::getDisplayableManagers(vtkCollection *displayableManagers)
     displayableManagers->AddItem(d->DisplayableManagerGroup->GetNthDisplayableManager(n));
     }
 }
+
+// --------------------------------------------------------------------------
+void qMRMLThreeDView::setViewCursor(const QCursor &cursor)
+{
+  this->setCursor(cursor);
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
+  if (this->VTKWidget() != NULL)
+   {
+    this->VTKWidget()->setQVTKCursor(cursor);
+    }
+#endif
+}

--- a/Libs/MRML/Widgets/qMRMLThreeDView.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.h
@@ -76,6 +76,9 @@ public:
                                bool resetTranslation = true,
                                bool resetDistance = true);
 
+  /// Set cursor in the view area
+  Q_INVOKABLE void setViewCursor(const QCursor &);
+
 public slots:
 
   /// Set the MRML \a scene that should be listened for events

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
@@ -515,7 +515,16 @@ void qSlicerSegmentEditorAbstractEffect::cursorOff(qMRMLWidget* viewWidget)
   Q_D(qSlicerSegmentEditorAbstractEffect);
 
   d->SavedCursor = QCursor(viewWidget->cursor());
-  viewWidget->setCursor(QCursor(Qt::BlankCursor));
+  qMRMLSliceWidget* sliceWidget = qobject_cast<qMRMLSliceWidget*>(viewWidget);
+  qMRMLThreeDWidget* threeDWidget = qobject_cast<qMRMLThreeDWidget*>(viewWidget);
+  if (sliceWidget && sliceWidget->sliceView())
+    {
+    sliceWidget->sliceView()->setViewCursor(QCursor(Qt::BlankCursor));
+    }
+  else if (threeDWidget && threeDWidget->threeDView())
+    {
+    threeDWidget->threeDView()->setViewCursor(QCursor(Qt::BlankCursor));
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -523,7 +532,16 @@ void qSlicerSegmentEditorAbstractEffect::cursorOn(qMRMLWidget* viewWidget)
 {
   Q_D(qSlicerSegmentEditorAbstractEffect);
 
-  viewWidget->setCursor(d->SavedCursor);
+  qMRMLSliceWidget* sliceWidget = qobject_cast<qMRMLSliceWidget*>(viewWidget);
+  qMRMLThreeDWidget* threeDWidget = qobject_cast<qMRMLThreeDWidget*>(viewWidget);
+  if (sliceWidget && sliceWidget->sliceView())
+    {
+    sliceWidget->sliceView()->setViewCursor(d->SavedCursor);
+    }
+  else if (threeDWidget && threeDWidget->threeDView())
+    {
+    threeDWidget->threeDView()->setViewCursor(d->SavedCursor);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -805,7 +805,7 @@ void qMRMLSegmentEditorWidgetPrivate::setEffectCursor(qSlicerSegmentEditorAbstra
       }
     if (effect && effect->showEffectCursorInSliceView())
       {
-      sliceWidget->sliceView()->setCursor(effect->createCursor(sliceWidget));
+      sliceWidget->sliceView()->setViewCursor(effect->createCursor(sliceWidget));
       }
     else
       {
@@ -821,7 +821,7 @@ void qMRMLSegmentEditorWidgetPrivate::setEffectCursor(qSlicerSegmentEditorAbstra
       }
     if (effect && effect->showEffectCursorInThreeDView())
       {
-      threeDWidget->threeDView()->setCursor(effect->createCursor(threeDWidget));
+      threeDWidget->threeDView()->setViewCursor(effect->createCursor(threeDWidget));
       }
     else
       {


### PR DESCRIPTION
Since recent updates in VTK Qt widget, when a Segment Editor effect was active the mouse cursor remained the default arrow cursor.
Fixed by adding setViewCursor() method that calls appropriate method to change the cursor shape, and calling this method from Segment Editor.