### PR TITLE
ENH: Added new node types to support custom volume rendering shader code

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -438,6 +438,10 @@ def loadLabelVolume(filename, properties={}, returnNode=False):
   properties['labelmap'] = True
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
+def loadShaderProperty(filename, returnNode=False):
+  filetype = 'ShaderPropertyFile'
+  return loadNodeFromFile(filename, filetype, {}, returnNode)
+
 def loadVolume(filename, properties={}, returnNode=False):
   """Properties:
   - name: this name will be used as node name for the loaded volume
@@ -495,6 +499,10 @@ def openAddMarkupsDialog():
 def openAddFiberBundleDialog():
   from slicer import app
   return app.coreIOManager().openAddFiberBundleDialog()
+
+def openAddShaderPropertyDialog():
+  from slicer import app, qSlicerFileDialog
+  return app.coreIOManager().openDialog('ShaderPropertyFile', qSlicerFileDialog.Read)
 
 def openSaveDataDialog():
   from slicer import app

--- a/Modules/Loadable/VolumeRendering/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/CMakeLists.txt
@@ -35,6 +35,8 @@ set(MODULE_SRCS
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}Reader.cxx
   qSlicer${MODULE_NAME}Reader.h
+  qSlicerShaderPropertyReader.cxx
+  qSlicerShaderPropertyReader.h
   qSlicer${MODULE_NAME}SettingsPanel.cxx
   qSlicer${MODULE_NAME}SettingsPanel.h
   )
@@ -42,6 +44,7 @@ set(MODULE_SRCS
 set(MODULE_MOC_SRCS
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}Reader.h
+  qSlicerShaderPropertyReader.h
   qSlicer${MODULE_NAME}SettingsPanel.h
   )
 

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
@@ -32,6 +32,7 @@ class vtkMRMLViewNode;
 class vtkMRMLVolumeDisplayNode;
 class vtkMRMLVolumeNode;
 class vtkMRMLVolumePropertyNode;
+class vtkMRMLShaderPropertyNode;
 
 // VTK includes
 class vtkColorTransferFunction;
@@ -264,6 +265,10 @@ public:
   /// Load from file and add into the scene a transfer function.
   /// \sa vtkMRMLVolumePropertyStorageNode
   vtkMRMLVolumePropertyNode* AddVolumePropertyFromFile (const char* filename);
+
+  /// Load from file and add into the scene a shader property.
+  /// \sa vtkMRMLShaderPropertyStorageNode
+  vtkMRMLShaderPropertyNode* AddShaderPropertyFromFile (const char* filename);
 
   /// Return the scene containing the volume rendering presets.
   /// If there is no presets scene, a scene is created and presets are loaded

--- a/Modules/Loadable/VolumeRendering/MRML/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/MRML/CMakeLists.txt
@@ -4,7 +4,10 @@ set(KIT ${PROJECT_NAME})
 
 set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_MODULE_MRML_EXPORT")
 
+find_package(JsonCpp REQUIRED)
+
 set(${KIT}_INCLUDE_DIRECTORIES
+  ${JsonCpp_INCLUDE_DIR}
   )
 
 set(${KIT}_SRCS
@@ -14,6 +17,10 @@ set(${KIT}_SRCS
   vtkMRMLGPURayCast${MODULE_NAME}DisplayNode.h
   vtkMRMLMulti${MODULE_NAME}DisplayNode.cxx
   vtkMRMLMulti${MODULE_NAME}DisplayNode.h
+  vtkMRMLShaderPropertyNode.cxx
+  vtkMRMLShaderPropertyNode.h
+  vtkMRMLShaderPropertyStorageNode.cxx
+  vtkMRMLShaderPropertyStorageNode.h
   vtkMRMLVolumePropertyNode.cxx
   vtkMRMLVolumePropertyNode.h
   vtkMRMLVolumePropertyStorageNode.cxx

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
@@ -1,0 +1,171 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Simon Drouin, Brigham and Women's
+  Hospital, Boston, MA.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLScene.h"
+#include "vtkMRMLShaderPropertyNode.h"
+#include "vtkMRMLVolumePropertyStorageNode.h"
+
+// VTK includes
+#include <vtkCommand.h>
+#include <vtkIntArray.h>
+#include <vtkObjectFactory.h>
+#include <vtkShaderProperty.h>
+#include <vtkUniforms.h>
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLShaderPropertyNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLShaderPropertyNode::vtkMRMLShaderPropertyNode()
+  : ShaderProperty(nullptr)
+  , DisabledModify(0)
+{
+  this->ObservedEvents = vtkIntArray::New();
+  this->ObservedEvents->InsertNextValue(vtkCommand::ModifiedEvent);
+
+  vtkShaderProperty* property = vtkShaderProperty::New();
+  vtkSetAndObserveMRMLObjectEventsMacro(this->ShaderProperty, property, this->ObservedEvents);
+  property->Delete();
+
+  // Observe uniform variables
+  vtkObserveMRMLObjectEventsMacro(this->ShaderProperty->GetVertexCustomUniforms(), this->ObservedEvents);
+  vtkObserveMRMLObjectEventsMacro(this->ShaderProperty->GetFragmentCustomUniforms(), this->ObservedEvents);
+
+  this->SetHideFromEditors(0);
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLShaderPropertyNode::~vtkMRMLShaderPropertyNode(void)
+{
+  if(this->ShaderProperty)
+    {
+    vtkUnObserveMRMLObjectMacro(this->ShaderProperty->GetVertexCustomUniforms());
+    vtkUnObserveMRMLObjectMacro(this->ShaderProperty->GetFragmentCustomUniforms());
+    vtkSetAndObserveMRMLObjectMacro(this->ShaderProperty, nullptr);
+    }
+  this->ObservedEvents->Delete();
+}
+
+//----------------------------------------------------------------------------
+vtkUniforms * vtkMRMLShaderPropertyNode::GetVertexUniforms()
+{
+  return this->ShaderProperty->GetVertexCustomUniforms();
+}
+
+//----------------------------------------------------------------------------
+vtkUniforms * vtkMRMLShaderPropertyNode::GetFragmentUniforms()
+{
+  return this->ShaderProperty->GetFragmentCustomUniforms();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLShaderPropertyNode::WriteXML(ostream& of, int nIndent)
+{
+  // Write all attributes not equal to their defaults
+  this->Superclass::WriteXML(of, nIndent);
+
+//  vtkMRMLWriteXMLBeginMacro(of);
+//  vtkMRMLWriteXMLEndMacro();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLShaderPropertyNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+
+  this->Superclass::ReadXMLAttributes(atts);
+
+//  vtkMRMLReadXMLBeginMacro(atts);
+//  vtkMRMLReadXMLEndMacro();
+
+  this->EndModify(disabledModify);
+}
+
+//----------------------------------------------------------------------------
+// Copy the node's attributes to this object.
+// Does NOT copy: ID, FilePrefix, Name, ID
+void vtkMRMLShaderPropertyNode::Copy(vtkMRMLNode *anode)
+{
+  int disabledModify = this->StartModify();
+
+  this->Superclass::Copy(anode);
+
+  this->CopyParameterSet(anode);
+
+  this->EndModify(disabledModify);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLShaderPropertyNode::CopyParameterSet(vtkMRMLNode *anode)
+{
+  vtkMRMLShaderPropertyNode *node = vtkMRMLShaderPropertyNode::SafeDownCast(anode);
+  if (!node)
+    {
+    vtkErrorMacro("CopyParameterSet: Invalid input MRML node");
+    return;
+    }
+
+  this->ShaderProperty->DeepCopy( node->ShaderProperty);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLShaderPropertyNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+
+  os << indent << "ShaderProperty: ";
+  this->ShaderProperty->PrintSelf(os,indent.GetNextIndent());
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLShaderPropertyNode::ProcessMRMLEvents( vtkObject *caller,
+                                                   unsigned long event,
+                                                   void *callData)
+{
+  this->Superclass::ProcessMRMLEvents(caller, event, callData);
+  switch (event)
+    {
+    case vtkCommand::ModifiedEvent:
+      this->Modified();
+      break;
+    }
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLStorageNode* vtkMRMLShaderPropertyNode::CreateDefaultStorageNode()
+{
+  vtkMRMLScene* scene = this->GetScene();
+  if (scene == nullptr)
+    {
+    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
+    return nullptr;
+    }
+  return vtkMRMLStorageNode::SafeDownCast(
+    scene->CreateNodeByClass("vtkMRMLShaderPropertyStorageNode"));
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLShaderPropertyNode::GetModifiedSinceRead()
+{
+  return this->Superclass::GetModifiedSinceRead() ||
+    (this->ShaderProperty &&
+     this->ShaderProperty->GetMTime() > this->GetStoredTime());
+}

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
@@ -76,6 +76,12 @@ vtkUniforms * vtkMRMLShaderPropertyNode::GetFragmentUniforms()
 }
 
 //----------------------------------------------------------------------------
+vtkUniforms * vtkMRMLShaderPropertyNode::GetGeometryUniforms()
+{
+  return this->ShaderProperty->GetGeometryCustomUniforms();
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLShaderPropertyNode::WriteXML(ostream& of, int nIndent)
 {
   // Write all attributes not equal to their defaults

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.cxx
@@ -36,7 +36,6 @@ vtkMRMLNodeNewMacro(vtkMRMLShaderPropertyNode);
 //----------------------------------------------------------------------------
 vtkMRMLShaderPropertyNode::vtkMRMLShaderPropertyNode()
   : ShaderProperty(nullptr)
-  , DisabledModify(0)
 {
   this->ObservedEvents = vtkIntArray::New();
   this->ObservedEvents->InsertNextValue(vtkCommand::ModifiedEvent);
@@ -108,22 +107,16 @@ void vtkMRMLShaderPropertyNode::Copy(vtkMRMLNode *anode)
 
   this->Superclass::Copy(anode);
 
-  this->CopyParameterSet(anode);
-
-  this->EndModify(disabledModify);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLShaderPropertyNode::CopyParameterSet(vtkMRMLNode *anode)
-{
   vtkMRMLShaderPropertyNode *node = vtkMRMLShaderPropertyNode::SafeDownCast(anode);
   if (!node)
     {
     vtkErrorMacro("CopyParameterSet: Invalid input MRML node");
-    return;
     }
+  else {
+    this->ShaderProperty->DeepCopy( node->ShaderProperty);
+  }
 
-  this->ShaderProperty->DeepCopy( node->ShaderProperty);
+  this->EndModify(disabledModify);
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.h
@@ -1,0 +1,107 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Simon Drouin, Brigham and Women's
+  Hospital, Boston, MA.
+
+==============================================================================*/
+/// vtkMRMLShaderPropertyNode - MRML node to represent custom volume shader
+/// variables and replacement code
+
+#ifndef __vtkMRMLShaderPropertyNode_h
+#define __vtkMRMLShaderPropertyNode_h
+
+// VolumeRendering includes
+#include "vtkSlicerVolumeRenderingModuleMRMLExport.h"
+
+// MRML includes
+#include "vtkMRMLStorableNode.h"
+
+// VTK includes
+class vtkShaderProperty;
+class vtkUniforms;
+
+/// \brief vtkMRMLShaderPropertyNode volume shader custom code and
+/// custom uniform variables defined by users or specialized rendering
+/// modules.
+class VTK_SLICER_VOLUMERENDERING_MODULE_MRML_EXPORT vtkMRMLShaderPropertyNode
+  : public vtkMRMLStorableNode
+{
+public:
+
+  /// Create a new vtkMRMLShaderPropertyNode
+  static vtkMRMLShaderPropertyNode *New();
+  vtkTypeMacro(vtkMRMLShaderPropertyNode,vtkMRMLStorableNode);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+
+  /// Don't change its scalarOpacity, gradientOpacity or color on the volume property
+  /// but use the methods below. It wouldn't observe them.
+  vtkGetObjectMacro(ShaderProperty, vtkShaderProperty);
+
+  /// Get the list of user-defined uniform variables.
+  vtkUniforms * GetVertexUniforms();
+  vtkUniforms * GetFragmentUniforms();
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+
+  /// Set node attributes
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
+
+  /// Write this node's information to a MRML file in XML format.
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
+
+  /// Copy the node's attributes to this object
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
+
+  /// Copy only the parameter set (like volume properties, piecewise functions
+  /// etc. as deep copy, but no references etc.)
+  void CopyParameterSet(vtkMRMLNode *node);
+
+  /// Get node XML tag name (like Volume, Model)
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "ShaderProperty";}
+
+  /// Reimplemented for internal reasons.
+  virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData) VTK_OVERRIDE;
+
+  /// Create default storage node or NULL if does not have one
+  virtual vtkMRMLStorageNode* CreateDefaultStorageNode() VTK_OVERRIDE;
+
+  /// \sa vtkMRMLStorableNode::GetModifiedSinceRead()
+  virtual bool GetModifiedSinceRead() VTK_OVERRIDE;
+
+protected:
+  vtkMRMLShaderPropertyNode(void);
+  ~vtkMRMLShaderPropertyNode(void) override;
+
+protected:
+  /// Events observed on the transfer functions
+  vtkIntArray* ObservedEvents;
+
+  /// Main parameters for visualization
+  vtkShaderProperty* ShaderProperty;
+
+  /// Keep track of state of disable modified events
+  int DisabledModify;
+
+private:
+  vtkMRMLShaderPropertyNode(const vtkMRMLShaderPropertyNode&) = delete;
+  void operator=(const vtkMRMLShaderPropertyNode&) = delete;
+
+};
+
+#endif

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.h
@@ -53,6 +53,7 @@ public:
   /// Get the list of user-defined uniform variables.
   vtkUniforms * GetVertexUniforms();
   vtkUniforms * GetFragmentUniforms();
+  vtkUniforms * GetGeometryUniforms();
 
   //--------------------------------------------------------------------------
   // MRMLNode methods

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyNode.h
@@ -68,10 +68,6 @@ public:
   /// Copy the node's attributes to this object
   virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
-  /// Copy only the parameter set (like volume properties, piecewise functions
-  /// etc. as deep copy, but no references etc.)
-  void CopyParameterSet(vtkMRMLNode *node);
-
   /// Get node XML tag name (like Volume, Model)
   virtual const char* GetNodeTagName() VTK_OVERRIDE {return "ShaderProperty";}
 
@@ -94,9 +90,6 @@ protected:
 
   /// Main parameters for visualization
   vtkShaderProperty* ShaderProperty;
-
-  /// Keep track of state of disable modified events
-  int DisabledModify;
 
 private:
   vtkMRMLShaderPropertyNode(const vtkMRMLShaderPropertyNode&) = delete;

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
@@ -114,7 +114,7 @@ void DecodeMatrix(const Json::Value & json, std::vector<ScalarType> & values)
 
 //----------------------------------------------------------------------------
 template< typename ScalarType >
-void DecodeValues(const Json::Value & json, vtkUniforms::TupleType tupleType, int nbComponents, int nbTuples, std::vector<ScalarType> & values)
+void DecodeValues(const Json::Value & json, vtkUniforms::TupleType tupleType, int vtkNotUsed(nbComponents), int nbTuples, std::vector<ScalarType> & values)
 {
   if(nbTuples == 1)
     {

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
@@ -106,7 +106,7 @@ void DecodeMatrix(const Json::Value & json, std::vector<ScalarType> & values)
     for(Json::ArrayIndex columnIndex = 0; columnIndex < nbCols; ++columnIndex)
       {
       ScalarType value;
-      DecodeValue(row[rowIndex], value);
+      DecodeValue(row[columnIndex], value);
       values.push_back(value);
       }
     }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.cxx
@@ -1,0 +1,446 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Simon Drouin, Brigham and Women's
+  Hospital, Boston, MA.
+
+==============================================================================*/
+
+// VolumeRendering includes
+#include "vtkMRMLShaderPropertyNode.h"
+#include "vtkMRMLShaderPropertyStorageNode.h"
+
+// MRML includes
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkMatrix3x3.h>
+#include <vtkMatrix4x4.h>
+#include <vtkObjectFactory.h>
+#include <vtkShaderProperty.h>
+#include <vtkStringArray.h>
+#include <vtkUniforms.h>
+
+// Json includes
+#include <json/json.h>
+
+// STD includes
+#include <sstream>
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLShaderPropertyStorageNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLShaderPropertyStorageNode::vtkMRMLShaderPropertyStorageNode()
+{
+  this->DefaultWriteFileExtension = "sp";
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLShaderPropertyStorageNode::~vtkMRMLShaderPropertyStorageNode()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLShaderPropertyStorageNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLShaderPropertyStorageNode::CanReadInReferenceNode(vtkMRMLNode *refNode)
+{
+  return refNode->IsA("vtkMRMLShaderPropertyNode");
+}
+
+namespace
+{
+
+//----------------------------------------------------------------------------
+void DecodeValue(Json::Value & val, int & dec)
+{
+  dec = val.asInt();
+}
+
+//----------------------------------------------------------------------------
+void DecodeValue(Json::Value & val, float & dec)
+{
+  dec = val.asFloat();
+}
+
+//----------------------------------------------------------------------------
+template< typename scalarT >
+void DecodeTuple(Json::Value & val, std::vector<scalarT> & tuple)
+{
+  tuple.resize(val.size());
+  for(unsigned i = 0; i < val.size(); ++i)
+    {
+    scalarT vi;
+    DecodeValue(val[i], vi);
+    tuple[i] = vi;
+    }
+}
+
+//----------------------------------------------------------------------------
+template< typename scalarT >
+void DecodeMatrix(Json::Value & val, std::vector<scalarT> & mat)
+{
+  int nbRows = val.size();
+  for(int i = 0; i < nbRows; ++i)
+    {
+    Json::Value & row = val[i];
+    int nbCols = row.size();
+    for(int j = 0; j < nbCols; ++j)
+      {
+      scalarT vi;
+      DecodeValue(row[i], vi);
+      mat.push_back(vi);
+      }
+    }
+}
+
+//----------------------------------------------------------------------------
+template< typename scalarT >
+void DecodeValue(Json::Value & val, vtkUniforms::TupleType tupleType, int nbComponents, int nbTuples, std::vector<scalarT> & dec)
+{
+  if(nbTuples == 1)
+    {
+    if(tupleType == vtkUniforms::TupleTypeScalar)
+      {
+      scalarT v;
+      DecodeValue(val["value"], v);
+      dec.resize(1,v);
+      }
+    else if(tupleType == vtkUniforms::TupleTypeVector)
+      {
+      DecodeTuple(val["value"], dec);
+      }
+    else if(tupleType == vtkUniforms::TupleTypeMatrix)
+      {
+      DecodeMatrix(val["value"], dec);
+      }
+    }
+  else
+    {
+    if(tupleType == vtkUniforms::TupleTypeScalar)
+      {
+      DecodeTuple(val["value"], dec);
+      }
+    else if(tupleType == vtkUniforms::TupleTypeVector)
+      {
+      for(int i = 0; i < val.size(); ++i)
+        {
+        std::vector<scalarT> tup;
+        DecodeTuple(val[i], tup);
+        dec.insert(dec.end(), tup.begin(), tup.end());
+        }
+      }
+    else if(tupleType == vtkUniforms::TupleTypeMatrix)
+      {
+      for(int i = 0; i < val.size(); ++i)
+        {
+        std::vector<scalarT> mat;
+        DecodeMatrix(val[i], mat);
+        dec.insert(dec.end(), mat.begin(), mat.end());
+        }
+      }
+    }
+}
+
+} // end of anonymous namespace
+
+//----------------------------------------------------------------------------
+void ReadUniforms(Json::Value & juni, vtkUniforms * uni)
+{
+  for(int i = 0; i < juni.size(); ++i)
+    {
+    Json::Value jvar = juni[i];
+    std::string uName = jvar["name"].asString();
+    int scalarType = vtkUniforms::StringToScalarType(jvar["scalarType"].asString());
+    vtkUniforms::TupleType tupleType =  vtkUniforms::StringToTupleType(jvar["tupleType"].asString());
+    int nbComponents = jvar["numberOfComponents"].asInt();
+    int nbTuples = jvar["numberOfTuples"].asInt();
+
+    if(scalarType == VTK_INT)
+      {
+      std::vector<int> decValues;
+      DecodeValue(jvar, tupleType, nbComponents, nbTuples, decValues);
+      uni->SetUniform(uName.c_str(), tupleType, nbComponents, decValues);
+      }
+    else if(scalarType == VTK_FLOAT)
+      {
+      std::vector<float> decValues;
+      DecodeValue(jvar, tupleType, nbComponents, nbTuples, decValues);
+      uni->SetUniform(uName.c_str(), tupleType, nbComponents, decValues);
+      }
+    }
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLShaderPropertyStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
+{
+  vtkMRMLShaderPropertyNode *spNode =
+    vtkMRMLShaderPropertyNode::SafeDownCast(refNode);
+
+  std::string fullName = this->GetFullNameFromFileName();
+  if (fullName.empty())
+    {
+    vtkErrorMacro("ReadData: File name not specified");
+    return 0;
+    }
+
+  std::ifstream ifs;
+  ifs.open(fullName.c_str(), ios::in);
+  if (!ifs)
+    {
+    vtkErrorMacro("Cannot open shader property file: " << fullName);
+    return 0;
+    }
+
+  // Read json file
+  Json::Reader reader;
+  Json::Value root;
+  reader.parse(ifs, root, false);
+  ifs.close();
+
+  // Read vertex shader uniform variables
+  Json::Value vertexUniforms = root["VertexUniforms"];
+  ReadUniforms(vertexUniforms, spNode->GetVertexUniforms());
+
+  // Read fragment shader uniform variables
+  Json::Value fragmentUniforms = root["FragmentUniforms"];
+  ReadUniforms(fragmentUniforms, spNode->GetFragmentUniforms());
+
+  // Read shader replacements
+  vtkShaderProperty * sp = spNode->GetShaderProperty();
+  Json::Value shaderReplacement = root["ShaderReplacements"];
+  for(int i = 0; i < shaderReplacement.size(); ++i)
+    {
+    Json::Value spv = shaderReplacement[i];
+    std::string shaderType = spv["ShaderType"].asString();
+    std::string replacementSpec = spv["ReplacementSpec"].asString();
+    bool replaceFirst = spv["replaceFirst"].asBool();
+    std::string replacementValue = spv["ReplacementValue"].asString();
+    bool replaceAll = spv["replaceAll"].asBool();
+    if(shaderType == std::string("Vertex"))
+      {
+      sp->AddVertexShaderReplacement(replacementSpec, replaceFirst, replacementValue, replaceAll);
+      }
+    else if(shaderType == std::string("Fragment"))
+      {
+      sp->AddFragmentShaderReplacement(replacementSpec, replaceFirst, replacementValue, replaceAll);
+      }
+    }
+
+  return 1;
+}
+
+namespace
+{
+
+//----------------------------------------------------------------------------
+template< typename T >
+Json::Value EncodeMatrix(const std::vector<T> & mat, int n)
+{
+  Json::Value val;
+  for(int i = 0; i < n; ++i)
+    {
+    Json::Value row;
+    for(int j = 0; j < n; ++j)
+      {
+      row[j] = mat[i*n+j];
+      }
+    val[i] = row;
+    }
+  return val;
+}
+
+//----------------------------------------------------------------------------
+template< typename T >
+Json::Value EncodeTuple(const std::vector<T> & tuple, int n )
+{
+  Json::Value val;
+  val.resize(n);
+  for(int i = 0; i < n; ++i)
+    {
+    val[i] = tuple[i];
+    }
+  return val;
+}
+
+//----------------------------------------------------------------------------
+template< typename scalarT >
+void EncodeVar(int nbComponents, int nbTuples, vtkUniforms::TupleType tt, Json::Value & val, const std::vector<scalarT> & values)
+{
+  if(nbTuples == 1)
+    {
+    if(tt == vtkUniforms::TupleTypeScalar)
+      {
+      val["value"] = values[0];
+      }
+    else if(tt == vtkUniforms::TupleTypeVector)
+      {
+      val["value"] = EncodeTuple(values,nbComponents);
+      }
+    else if(tt == vtkUniforms::TupleTypeMatrix)
+      {
+      int matWidth = static_cast<int>(sqrt(nbComponents));
+      val["value"] = EncodeMatrix(values, matWidth);
+      }
+    }
+  else
+    {
+    if(tt == vtkUniforms::TupleTypeScalar)
+      {
+      val["value"] = EncodeTuple(values,nbTuples);
+      }
+    else if(tt == vtkUniforms::TupleTypeVector)
+      {
+      val["value"].resize(nbTuples);
+      for(int i = 0; i < nbTuples; ++i)
+        {
+        val["value"][i] = EncodeTuple(values,nbComponents);
+        }
+      }
+    else if(tt == vtkUniforms::TupleTypeMatrix)
+    {
+      int matWidth = static_cast<int>(sqrt(nbComponents));
+      val["value"].resize(nbTuples);
+      for(int i = 0; i < nbTuples; ++i)
+        {
+        val["value"][i] = EncodeMatrix(values, matWidth);
+        }
+      }
+    }
+}
+
+//----------------------------------------------------------------------------
+void WriteUniforms(vtkUniforms * vu, Json::Value & root)
+{
+  root.resize(vu->GetNumberOfUniforms());
+  for(int i = 0; i < vu->GetNumberOfUniforms(); ++i)
+    {
+    std::string uName = vu->GetNthUniformName(i);
+    Json::Value u;
+
+    vtkUniforms::TupleType tupleType = vu->GetUniformTupleType(uName.c_str());
+    vtkIdType nbTuples = vu->GetUniformNumberOfTuples(uName.c_str());
+    vtkIdType nbComponents = vu->GetUniformNumberOfComponents(uName.c_str());
+    int scalarType = vu->GetUniformScalarType(uName.c_str());
+
+    u["name"] = uName;
+    u["scalarType"] = vtkUniforms::ScalarTypeToString(scalarType);
+    u["tupleType"] = vtkUniforms::TupleTypeToString(tupleType);
+    u["numberOfComponents"] = nbComponents;
+    u["numberOfTuples"] = nbTuples;
+
+    if(scalarType == VTK_INT)
+      {
+      std::vector<int> uv;
+      if(vu->GetUniform(uName.c_str(), uv))
+        {
+        EncodeVar(nbComponents, nbTuples, tupleType, u, uv);
+        }
+      }
+    else if(scalarType == VTK_FLOAT)
+      {
+      std::vector<float> uv;
+      if(vu->GetUniform(uName.c_str(), uv))
+        {
+        EncodeVar(nbComponents, nbTuples, tupleType, u, uv);
+        }
+      }
+    root[i] = u;
+    }
+}
+
+} // end of anonymous namespace
+
+//----------------------------------------------------------------------------
+int vtkMRMLShaderPropertyStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
+{
+  vtkMRMLShaderPropertyNode *spNode = vtkMRMLShaderPropertyNode::SafeDownCast(refNode);
+
+  std::string fullName =  this->GetFullNameFromFileName();
+  if (fullName.empty())
+    {
+    vtkErrorMacro("vtkMRMLShaderPropertyStorageNode: File name not specified");
+    return 0;
+    }
+
+  std::ofstream ofs;
+  ofs.open(fullName.c_str(), ios::out);
+
+  if (!ofs)
+    {
+    vtkErrorMacro("Cannot open shader property file: " << fullName);
+    return 0;
+    }
+
+  Json::Value root;
+
+  // Collect vertex uniforms json structures
+  Json::Value vertexUniforms;
+  WriteUniforms(spNode->GetVertexUniforms(), vertexUniforms);
+  root["VertexUniforms"] = vertexUniforms;
+
+  // Collect fragment uniforms json structures
+  Json::Value fragmentUniforms;
+  WriteUniforms(spNode->GetFragmentUniforms(), fragmentUniforms);
+  root["FragmentUniforms"] = fragmentUniforms;
+
+  // Collect shader replacements in json structures
+  vtkShaderProperty * sp = spNode->GetShaderProperty();
+  int nbRep = sp->GetNumberOfShaderReplacements();
+  Json::Value rep;
+  rep.resize(nbRep);
+  for(int i = 0; i < nbRep; ++i)
+    {
+    Json::Value spv;
+    spv["ShaderType"] = sp->GetNthShaderReplacementTypeAsString(i);
+    std::string replacementSpec;
+    bool replaceFirst = false;
+    std::string replacementValue;
+    bool replaceAll = false;
+    sp->GetNthShaderReplacement(i, replacementSpec, replaceFirst, replacementValue, replaceAll);
+    spv["ReplacementSpec"] = replacementSpec;
+    spv["replaceFirst"] = replaceFirst;
+    spv["ReplacementValue"] = replacementValue;
+    spv["replaceAll"] = replaceAll;
+    rep[i] = spv;
+    }
+  root["ShaderReplacements"] = rep;
+
+  // Write the file
+  Json::StyledStreamWriter writer;
+  writer.write(ofs, root);
+
+  ofs.close();
+
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLShaderPropertyStorageNode::InitializeSupportedReadFileTypes()
+{
+  this->SupportedReadFileTypes->InsertNextValue("Shader Property (.sp)");
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLShaderPropertyStorageNode::InitializeSupportedWriteFileTypes()
+{
+  this->SupportedWriteFileTypes->InsertNextValue("Shader Property (.sp)");
+  this->SupportedWriteFileTypes->InsertNextValue("Shader Property (.*)");
+}

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLShaderPropertyStorageNode.h
@@ -1,0 +1,72 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Simon Drouin, Brigham and Women's
+  Hospital, Boston, MA.
+
+==============================================================================*/
+///  vtkMRMLShaderPropertyStorageNode - MRML node for transform storage on disk
+///
+/// Storage nodes has methods to read/write transforms to/from disk
+
+#ifndef __vtkMRMLShaderPropertyStorageNode_h
+#define __vtkMRMLShaderPropertyStorageNode_h
+
+// VolumeRendering includes
+#include "vtkSlicerVolumeRenderingModuleMRMLExport.h"
+
+// MRML includes
+#include "vtkMRMLStorageNode.h"
+
+class vtkImageData;
+
+class VTK_SLICER_VOLUMERENDERING_MODULE_MRML_EXPORT vtkMRMLShaderPropertyStorageNode
+  : public vtkMRMLStorageNode
+{
+public:
+  static vtkMRMLShaderPropertyStorageNode *New();
+  vtkTypeMacro(vtkMRMLShaderPropertyStorageNode,vtkMRMLStorageNode);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+
+  ///
+  /// Get node XML tag name (like Storage, Transform)
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "ShaderPropertyStorage";}
+
+  /// Return true if the node can be read in
+  virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode) VTK_OVERRIDE;
+
+protected:
+  vtkMRMLShaderPropertyStorageNode();
+  ~vtkMRMLShaderPropertyStorageNode() VTK_OVERRIDE;
+  vtkMRMLShaderPropertyStorageNode(const vtkMRMLShaderPropertyStorageNode&);
+  void operator=(const vtkMRMLShaderPropertyStorageNode&);
+
+  /// Initialize all the supported read file types
+  virtual void InitializeSupportedReadFileTypes() VTK_OVERRIDE;
+
+  /// Initialize all the supported write file types
+  virtual void InitializeSupportedWriteFileTypes() VTK_OVERRIDE;
+
+  /// Read data and set it in the referenced node
+  virtual int ReadDataInternal(vtkMRMLNode *refNode) VTK_OVERRIDE;
+
+  /// Write data from a  referenced node
+  virtual int WriteDataInternal(vtkMRMLNode *refNode) VTK_OVERRIDE;
+
+};
+
+#endif

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
@@ -23,6 +23,7 @@
 class vtkMRMLAnnotationROINode;
 class vtkMRMLVolumeNode;
 class vtkMRMLVolumePropertyNode;
+class vtkMRMLShaderPropertyNode;
 class vtkMRMLViewNode;
 
 class vtkIntArray;
@@ -53,6 +54,11 @@ public:
   const char* GetVolumePropertyNodeID();
   void SetAndObserveVolumePropertyNodeID(const char *volumePropertyNodeID);
   vtkMRMLVolumePropertyNode* GetVolumePropertyNode();
+
+  const char* GetShaderPropertyNodeID();
+  void SetAndObserveShaderPropertyNodeID(const char *shaderPropertyNodeID);
+  vtkMRMLShaderPropertyNode* GetShaderPropertyNode();
+  vtkMRMLShaderPropertyNode* GetOrCreateShaderPropertyNode( vtkMRMLScene * mrmlScene );
 
   const char* GetROINodeID();
   void SetAndObserveROINodeID(const char *roiNodeID);
@@ -95,6 +101,8 @@ protected:
   static const char* VolumePropertyNodeReferenceMRMLAttributeName;
   static const char* ROINodeReferenceRole;
   static const char* ROINodeReferenceMRMLAttributeName;
+  static const char* ShaderPropertyNodeReferenceRole;
+  static const char* ShaderPropertyNodeReferenceMRMLAttributeName;
 
 protected:
   /// Flag indicating whether cropping is enabled

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -34,6 +34,7 @@
 #include "vtkMRMLTransformNode.h"
 #include "vtkMRMLViewNode.h"
 #include "vtkMRMLVolumePropertyNode.h"
+#include "vtkMRMLShaderPropertyNode.h"
 #include "vtkEventBroker.h"
 
 // VTK includes
@@ -803,6 +804,10 @@ void vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::UpdateDisplayNodePip
   // Set volume property
   vtkVolumeProperty* volumeProperty = displayNode->GetVolumePropertyNode() ? displayNode->GetVolumePropertyNode()->GetVolumeProperty() : nullptr;
   pipeline->VolumeActor->SetProperty(volumeProperty);
+
+  // Set shader property
+  vtkShaderProperty* shaderProperty = displayNode->GetShaderPropertyNode() ? displayNode->GetShaderPropertyNode()->GetShaderProperty() : nullptr;
+  pipeline->VolumeActor->SetShaderProperty(shaderProperty);
 
   pipeline->VolumeActor->SetPickable(volumeNode->GetSelectable());
 

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt
@@ -19,6 +19,8 @@ include(${ITK_USE_FILE})
 #-----------------------------------------------------------------------------
 set(MRML_CORE_INPUT "${MRMLCore_SOURCE_DIR}/Testing/TestData/")
 set(INPUT ${CMAKE_CURRENT_SOURCE_DIR}/../Data/Input)
+set(TEMP "${CMAKE_BINARY_DIR}/Testing/Temporary")
+message("VolumeRendering CXX tests: TEMP var: ${TEMP}")
 
 #-----------------------------------------------------------------------------
 set(KIT_TEST_SRCS
@@ -26,6 +28,7 @@ set(KIT_TEST_SRCS
   qSlicerPresetComboBoxTest.cxx
   qSlicer${MODULE_NAME}ModuleWidgetTest1.cxx
   qSlicer${MODULE_NAME}ModuleWidgetTest2.cxx
+  vtkMRMLShaderPropertyStorageNodeTest1.cxx
   vtkMRMLVolumePropertyNodeTest1.cxx
   vtkMRMLVolumePropertyStorageNodeTest1.cxx
   vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
@@ -53,6 +56,7 @@ simple_test(qMRMLVolumePropertyNodeWidgetTest1)
 simple_test(qSlicerPresetComboBoxTest)
 simple_test(qSlicer${MODULE_NAME}ModuleWidgetTest1)
 simple_test(qSlicer${MODULE_NAME}ModuleWidgetTest2 ${MRML_CORE_INPUT}/fixed.nrrd)
+simple_test(vtkMRMLShaderPropertyStorageNodeTest1 ${TEMP})
 simple_test(vtkMRMLVolumePropertyNodeTest1 ${INPUT}/volRender.mrml)
 simple_test(vtkMRMLVolumePropertyStorageNodeTest1)
 simple_test(vtkMRMLVolumeRenderingDisplayableManagerTest1)

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLShaderPropertyStorageNodeTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLShaderPropertyStorageNodeTest1.cxx
@@ -1,0 +1,223 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright 2015 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Andras Lasso (PerkLab, Queen's
+  University) and Kevin Wang (Princess Margaret Hospital, Toronto) and was
+  supported through OCAIRO and the Applied Cancer Research Unit program of
+  Cancer Care Ontario.
+
+==============================================================================*/
+
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLScene.h"
+#include "vtkMRMLShaderPropertyNode.h"
+#include "vtkMRMLShaderPropertyStorageNode.h"
+#include "vtkShaderProperty.h"
+#include "vtkUniforms.h"
+
+#include <vtksys/SystemTools.hxx>
+
+//---------------------------------------------------------------------------
+void BuildShaderProperty( vtkMRMLShaderPropertyNode * psNode );
+int TestReadWriteData(vtkMRMLScene* scene, const char *extension, vtkMRMLShaderPropertyNode* sp );
+
+int vtkMRMLShaderPropertyStorageNodeTest1(int argc, char * argv[])
+{
+  if (argc != 2)
+    {
+    std::cerr << "Usage: " << argv[0] << " /path/to/temp" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  // Test basic methods
+  vtkNew<vtkMRMLShaderPropertyStorageNode> node1;
+  EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
+
+  // Create scene
+  vtkNew<vtkMRMLScene> scene;
+  const char* tempDir = argv[1];
+  scene->SetRootDirectory(tempDir);
+
+  // Create shader property node
+  vtkNew<vtkMRMLShaderPropertyNode> spNode;
+  BuildShaderProperty(spNode.GetPointer());
+
+  CHECK_NOT_NULL(spNode->GetShaderProperty());
+  CHECK_NOT_NULL(scene->AddNode(spNode.GetPointer()));
+  CHECK_EXIT_SUCCESS(TestReadWriteData(scene, ".sp", spNode.GetPointer()));
+
+  std::cout << "Test passed." << std::endl;
+  return EXIT_SUCCESS;
+}
+
+//---------------------------------------------------------------------------
+void BuildShaderProperty( vtkMRMLShaderPropertyNode * spNode )
+{
+  vtkShaderProperty * sp = spNode->GetShaderProperty();
+
+  // Exercise shader replacement code - this is not actually usable code,
+  // it is only for the purpose of testing round trip read/write
+  sp->AddVertexShaderReplacement( "VTK::Clipping::Impl", true, "var1 = 1.0;", true );
+  sp->AddFragmentShaderReplacement( "VTK::Clipping::Impl", true, "var2 = 2;", true );
+  sp->AddGeometryShaderReplacement( "VTK::Clipping::Impl", true, "var3 = 3.0;", true );
+  sp->SetVertexShaderCode("int main() { float var1 = 3.0; }");
+  sp->SetFragmentShaderCode("int main() { int var2 = 4; }");
+  sp->SetGeometryShaderCode("int main() { float var3 = 5.0; }");
+
+  // Exercise all combinations of uniforms types:
+  // number of tuples{1,many(2)}, tupleType{scalar,vector,matrix}, scalarType{int,float}
+  vtkUniforms * vertexUniforms = sp->GetVertexCustomUniforms();
+
+  // 1 tuple, scalar
+  vertexUniforms->SetUniformf( "var1-1t-sf", 1.2f );
+  vertexUniforms->SetUniformi( "var2-1t-si", 2 );
+
+  // 1 tuple, vector
+  int var3[2] = { 3, 4 };
+  vertexUniforms->SetUniform2i("var3-1t-vi", var3);
+  float var4[2] = { 3.0f, 4.0f };
+  vertexUniforms->SetUniform2f("var4-1t-vf",var4);
+
+  // We put the next cases in the fragment uniforms
+  vtkUniforms * fragmentUniforms = sp->GetFragmentCustomUniforms();
+
+  // 1 tuple matrix
+  float var5[9] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 };
+  vertexUniforms->SetUniformMatrix3x3("var5-1t-matf",var5);
+
+  // 2 tuples, scalar
+  int var7[2] = { 1, 2 };
+  fragmentUniforms->SetUniform1iv("var7-2t-si",2,var7);
+  float var8[2] = {1.0f,2.0f};
+  fragmentUniforms->SetUniform1fv("var8-2t-sf",2,var8);
+
+  // We put the next cases in the fragment uniforms
+  vtkUniforms * geometryUniforms = sp->GetGeometryCustomUniforms();
+
+  // 2 tuples, vector
+  float var9[2][2] = {{1.0f, 2.0f},{3.0f, 4.0f}};
+  geometryUniforms->SetUniform2fv("var9-2t-vf",2,var9);
+
+  // 2 tuples, matrix
+  float var10[32];
+  std::fill(var10,var10+16,5.0f);
+  std::fill(var10+16,var10+32,8.0f);
+  geometryUniforms->SetUniformMatrix4x4v("var10-2t-mat4x4f",2,var10);
+}
+
+//---------------------------------------------------------------------------
+int CompareUniforms( vtkUniforms * u1, vtkUniforms * u2 )
+{
+  CHECK_BOOL(u1->GetNumberOfUniforms()==u2->GetNumberOfUniforms(),true);
+  for( int i = 0; i < u1->GetNumberOfUniforms(); ++i )
+  {
+    const char * name = u1->GetNthUniformName(i);
+    CHECK_BOOL(u1->GetUniformScalarType(name)==VTK_INT || u1->GetUniformScalarType(name)==VTK_FLOAT,true);
+    CHECK_BOOL(u1->GetUniformScalarType(name)==u2->GetUniformScalarType(name),true);
+    if( u1->GetUniformScalarType(name) == VTK_INT )
+    {
+      std::vector<int> u1Val;
+      u1->GetUniform(name,u1Val);
+      std::vector<int> u2Val;
+      u2->GetUniform(name,u2Val);
+      CHECK_BOOL(u1Val == u2Val,true);
+    }
+    else if( u1->GetUniformScalarType(name) == VTK_FLOAT )
+    {
+      std::vector<float> u1Val;
+      u1->GetUniform(name,u1Val);
+      std::vector<float> u2Val;
+      u2->GetUniform(name,u2Val);
+      CHECK_BOOL(u1Val == u2Val,true);
+    }
+  }
+  return EXIT_SUCCESS;
+}
+
+//---------------------------------------------------------------------------
+int CompareShaderProperty( vtkMRMLShaderPropertyNode * n1, vtkMRMLShaderPropertyNode * n2 )
+{
+  vtkShaderProperty * sp1 = n1->GetShaderProperty();
+  CHECK_NOT_NULL(sp1);
+  vtkShaderProperty * sp2 = n2->GetShaderProperty();
+  CHECK_NOT_NULL(sp2);
+
+  // Compare whole shader code
+  CHECK_STRING(sp1->GetVertexShaderCode(),sp2->GetVertexShaderCode());
+  CHECK_STRING(sp1->GetFragmentShaderCode(),sp2->GetFragmentShaderCode());
+  CHECK_STRING(sp1->GetGeometryShaderCode(),sp2->GetGeometryShaderCode());
+
+  // Compare partial shader replacements
+  CHECK_BOOL(sp1->GetNumberOfShaderReplacements() == sp2->GetNumberOfShaderReplacements(),true);
+  for( int i = 0; i < sp1->GetNumberOfShaderReplacements(); ++i)
+  {
+    std::string name1;
+    bool replaceFirst1 = false;
+    std::string replacementValue1;
+    bool replaceAll1 = false;
+    sp1->GetNthShaderReplacement(i,name1,replaceFirst1,replacementValue1,replaceAll1);
+    std::string name2;
+    bool replaceFirst2 = false;
+    std::string replacementValue2;
+    bool replaceAll2 = false;
+    sp2->GetNthShaderReplacement(i,name2,replaceFirst2,replacementValue2,replaceAll2);
+    CHECK_BOOL(sp1->GetNthShaderReplacementTypeAsString(i) == sp2->GetNthShaderReplacementTypeAsString(i),true);
+    CHECK_BOOL(name1 == name2,true);
+    CHECK_BOOL(replaceFirst1 == replaceFirst2,true);
+    CHECK_BOOL(replacementValue1 == replacementValue2,true);
+    CHECK_BOOL(replaceAll1 == replaceAll2,true);
+  }
+
+  // Compare uniform variables
+  vtkUniforms * uv1 = sp1->GetVertexCustomUniforms();
+  vtkUniforms * uv2 = sp2->GetVertexCustomUniforms();
+  CHECK_EXIT_SUCCESS(CompareUniforms( uv1, uv2 ));
+
+  vtkUniforms * uf1 = sp1->GetFragmentCustomUniforms();
+  vtkUniforms * uf2 = sp2->GetFragmentCustomUniforms();
+  CHECK_EXIT_SUCCESS(CompareUniforms( uf1, uf2 ));
+
+  vtkUniforms * ug1 = sp1->GetGeometryCustomUniforms();
+  vtkUniforms * ug2 = sp2->GetGeometryCustomUniforms();
+  CHECK_EXIT_SUCCESS(CompareUniforms( ug1, ug2 ));
+
+  return EXIT_SUCCESS;
+}
+
+//---------------------------------------------------------------------------
+int TestReadWriteData(vtkMRMLScene* scene, const char *extension, vtkMRMLShaderPropertyNode* spNode )
+{
+  std::string fileName = std::string(scene->GetRootDirectory()) +
+    std::string("/vtkMRMLShaderPropertyStorageNodeTest1") +
+    std::string(extension);
+
+  vtksys::SystemTools::RemoveFile(fileName);
+
+  // Add storage node
+  vtkNew<vtkMRMLShaderPropertyStorageNode> storageNode;
+  storageNode->SetFileName(fileName.c_str());
+
+  // Test writing
+  CHECK_BOOL(storageNode->WriteData(spNode), true);
+
+  // Test reading
+  vtkNew<vtkMRMLShaderPropertyNode> spNodeRead;
+  CHECK_BOOL(storageNode->ReadData(spNodeRead), true);
+
+  // Compare read/write nodes
+  CHECK_EXIT_SUCCESS(CompareShaderProperty(spNode,spNodeRead));
+
+  return EXIT_SUCCESS;
+}

--- a/Modules/Loadable/VolumeRendering/qSlicerShaderPropertyReader.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerShaderPropertyReader.cxx
@@ -13,8 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 
-  This file was originally developed by Julien Finet, Kitware Inc.
-  and was partially funded by NIH grant 3P41RR013218-12S1
+  This file was originally developed by Simon Drouin, Brigham and Women's
+  Hospital, Boston, MA.
 
 ==============================================================================*/
 
@@ -22,7 +22,7 @@
 #include <QFileInfo>
 
 // SlicerQt includes
-#include "qSlicerVolumeRenderingReader.h"
+#include "qSlicerShaderPropertyReader.h"
 
 // Logic includes
 #include "vtkSlicerVolumeRenderingLogic.h"
@@ -33,83 +33,88 @@
 // MRML includes
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLSelectionNode.h>
-#include "vtkMRMLVolumePropertyNode.h"
+#include "vtkMRMLShaderPropertyNode.h"
 
 // VTK includes
 #include <vtkSmartPointer.h>
 
 //-----------------------------------------------------------------------------
-class qSlicerVolumeRenderingReaderPrivate
+class qSlicerShaderPropertyReaderPrivate
 {
   public:
   vtkSmartPointer<vtkSlicerVolumeRenderingLogic> VolumeRenderingLogic;
 };
 
 //-----------------------------------------------------------------------------
-qSlicerVolumeRenderingReader::qSlicerVolumeRenderingReader(QObject* _parent)
+qSlicerShaderPropertyReader::qSlicerShaderPropertyReader(QObject* _parent)
   : Superclass(_parent)
-  , d_ptr(new qSlicerVolumeRenderingReaderPrivate)
+  , d_ptr(new qSlicerShaderPropertyReaderPrivate)
 {
 }
 
 //-----------------------------------------------------------------------------
-qSlicerVolumeRenderingReader::qSlicerVolumeRenderingReader(vtkSlicerVolumeRenderingLogic* logic, QObject* _parent)
+qSlicerShaderPropertyReader::qSlicerShaderPropertyReader(vtkSlicerVolumeRenderingLogic* logic, QObject* _parent)
   : Superclass(_parent)
-  , d_ptr(new qSlicerVolumeRenderingReaderPrivate)
+  , d_ptr(new qSlicerShaderPropertyReaderPrivate)
 {
   this->setVolumeRenderingLogic(logic);
 }
 
 //-----------------------------------------------------------------------------
-qSlicerVolumeRenderingReader::~qSlicerVolumeRenderingReader()
+qSlicerShaderPropertyReader::~qSlicerShaderPropertyReader()
 = default;
 
 //-----------------------------------------------------------------------------
-void qSlicerVolumeRenderingReader::setVolumeRenderingLogic(vtkSlicerVolumeRenderingLogic* logic)
+void qSlicerShaderPropertyReader::setVolumeRenderingLogic(vtkSlicerVolumeRenderingLogic* logic)
 {
-  Q_D(qSlicerVolumeRenderingReader);
+  Q_D(qSlicerShaderPropertyReader);
   d->VolumeRenderingLogic = logic;
 }
 
 //-----------------------------------------------------------------------------
-vtkSlicerVolumeRenderingLogic* qSlicerVolumeRenderingReader::volumeRenderingLogic()const
+vtkSlicerVolumeRenderingLogic* qSlicerShaderPropertyReader::volumeRenderingLogic()const
 {
-  Q_D(const qSlicerVolumeRenderingReader);
+  Q_D(const qSlicerShaderPropertyReader);
   return d->VolumeRenderingLogic.GetPointer();
 }
 
 //-----------------------------------------------------------------------------
-QString qSlicerVolumeRenderingReader::description()const
+QString qSlicerShaderPropertyReader::description()const
 {
-  return "Transfer Function";
+  return "GPU Shader Property";
 }
 
 //-----------------------------------------------------------------------------
-qSlicerIO::IOFileType qSlicerVolumeRenderingReader::fileType()const
+qSlicerIO::IOFileType qSlicerShaderPropertyReader::fileType()const
 {
-  return QString("TransferFunctionFile");
+  return QString("ShaderPropertyFile");
 }
 
 //-----------------------------------------------------------------------------
-QStringList qSlicerVolumeRenderingReader::extensions()const
+QStringList qSlicerShaderPropertyReader::extensions()const
 {
-  // pic files are bio-rad images (see itkBioRadImageIO)
   return QStringList()
-    << "Transfer Function (*.vp)";
+    << "Shader Property (*.sp)";
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerVolumeRenderingReader::load(const IOProperties& properties)
+bool qSlicerShaderPropertyReader::load(const IOProperties& properties)
 {
-  Q_D(qSlicerVolumeRenderingReader);
+  Q_D(qSlicerShaderPropertyReader);
   Q_ASSERT(properties.contains("fileName"));
   QString fileName = properties["fileName"].toString();
+  // Name is ignored
+  //QString name = QFileInfo(fileName).baseName();
+  //if (properties.contains("name"))
+  //  {
+  //  name = properties["name"].toString();
+  //  }
   if (d->VolumeRenderingLogic.GetPointer() == nullptr)
     {
     return false;
     }
-  vtkMRMLVolumePropertyNode* node =
-    d->VolumeRenderingLogic->AddVolumePropertyFromFile(fileName.toLatin1());
+  vtkMRMLShaderPropertyNode* node =
+    d->VolumeRenderingLogic->AddShaderPropertyFromFile(fileName.toLatin1());
   QStringList loadedNodes;
   if (node)
     {

--- a/Modules/Loadable/VolumeRendering/qSlicerShaderPropertyReader.h
+++ b/Modules/Loadable/VolumeRendering/qSlicerShaderPropertyReader.h
@@ -1,0 +1,61 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Simon Drouin, Brigham and Women's
+  Hospital, Boston, MA.
+
+==============================================================================*/
+
+#ifndef __qSlicerShaderPropertyReader_h
+#define __qSlicerShaderPropertyReader_h
+
+// SlicerQT includes
+#include <qSlicerFileReader.h>
+
+// Volume Rendering includes
+class qSlicerShaderPropertyReaderPrivate;
+class vtkSlicerVolumeRenderingLogic;
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_VolumeRendering
+class qSlicerShaderPropertyReader
+  : public qSlicerFileReader
+{
+  Q_OBJECT
+public:
+  typedef qSlicerFileReader Superclass;
+  qSlicerShaderPropertyReader(QObject* parent = nullptr);
+  qSlicerShaderPropertyReader(vtkSlicerVolumeRenderingLogic* logic, QObject* parent = nullptr);
+  virtual ~qSlicerShaderPropertyReader();
+
+  void setVolumeRenderingLogic(vtkSlicerVolumeRenderingLogic* logic);
+  vtkSlicerVolumeRenderingLogic* volumeRenderingLogic()const;
+
+  // Reimplemented for IO specific description
+  virtual QString description()const;
+  virtual IOFileType fileType()const;
+  virtual QStringList extensions()const;
+
+  virtual bool load(const IOProperties& properties);
+
+protected:
+  QScopedPointer<qSlicerShaderPropertyReaderPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerShaderPropertyReader);
+  Q_DISABLE_COPY(qSlicerShaderPropertyReader);
+};
+
+#endif

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
@@ -31,6 +31,7 @@
 #include "qSlicerVolumeRenderingModule.h"
 #include "qSlicerVolumeRenderingModuleWidget.h"
 #include "qSlicerVolumeRenderingReader.h"
+#include "qSlicerShaderPropertyReader.h"
 #include "qSlicerVolumeRenderingSettingsPanel.h"
 
 // SubjectHierarchy Plugins includes
@@ -144,10 +145,17 @@ void qSlicerVolumeRenderingModule::setup()
     qSlicerApplication::application()->settingsDialog()->addPanel("Volume rendering", panel);
     panel->setVolumeRenderingLogic(volumeRenderingLogic);
     }
+
+  // Register VolumeProperty reader/writer
   qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
   coreIOManager->registerIO(new qSlicerVolumeRenderingReader(volumeRenderingLogic, this));
   coreIOManager->registerIO(new qSlicerNodeWriter("Transfer Function", QString("TransferFunctionFile"),
     QStringList() << "vtkMRMLVolumePropertyNode", true, this));
+
+  // Register ShaderProperty reader/writer
+  coreIOManager->registerIO(new qSlicerShaderPropertyReader(volumeRenderingLogic,this));
+  coreIOManager->registerIO(new qSlicerNodeWriter("Shader Property", QString("ShaderPropertyFile"),
+    QStringList() << "vtkMRMLShaderPropertyNode", true, this ));
 
   // Register Subject Hierarchy core plugins
   vtkSlicerVolumeRenderingLogic* logic = vtkSlicerVolumeRenderingLogic::SafeDownCast(this->logic());
@@ -173,6 +181,7 @@ QStringList qSlicerVolumeRenderingModule::associatedNodeTypes() const
 {
   return QStringList()
     << "vtkMRMLVolumePropertyNode"
+    << "vtkMRMLShaderPropertyNode"
     << "vtkMRMLVolumeRenderingDisplayNode"
     << "vtkMRMLAnnotationROINode"; // volume rendering clipping box
 }


### PR DESCRIPTION
With this PR, we introduce a mechanism to manage and store custom modifications and variables of volume rendering shaders. This pull request requires changes to VTK contained in this other pull request:

https://github.com/Slicer/VTK/pull/22

This change in VTK separates the management of vtkUniforms and shader replacements from the volume mapper and stores all these properties in a new class (vtkShaderProperty), which is stored in vtkVolume. On the Slicer side, I have created wrappers classes to manage vtkShaderProperty:

* vtkMRMLShaderPropertyNode
* vtkMRMLShaderPropertyStorageNode
* qSlicerShaderPropertyReader 

The advantages of the new system are twofold:
* Custom shader modifications are contained in a class that is shared by all displayable managers, i.e. your custom shader effect is visible in both the 3D view and the VR view.
* Custom modifications to the shaders are now saved with the mrml scene (in a json file with extension .sp), which means that GLSL experts can modify the shader code and variables, send the scene to non-programmers (e.g. clinicians) who will be able to load and visualize the new rendering effect by simply loading the scene. 

@lassoan @pieper @cpinter @jcfr please let me know what you think. 