### PR TITLE
BUG: Fix deprecated use of QPixmap::grabWidget

### DIFF
--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -851,7 +851,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
       # no view is specified, capture the entire view layout
 
       # Simply using grabwidget on the view layout frame would grab the screen without background:
-      # img = qt.QPixmap.grabWidget(slicer.app.layoutManager().viewport())
+      # img = ctk.ctkWidgetsUtils.grabWidget(slicer.app.layoutManager().viewport())
 
       # Grab the main window and use only the viewport's area
       allViews = slicer.app.layoutManager().viewport()
@@ -869,7 +869,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
       if (imageSize.y() & 1 == 1):
         imageSize.setY(imageSize.y()-1)
 
-      img = qt.QPixmap.grabWidget(slicer.util.mainWindow(), topLeft.x(), topLeft.y(), imageSize.x(), imageSize.y())
+      img = ctk.ctkWidgetsUtils.grabWidget(slicer.util.mainWindow(), qt.QRect(topLeft.x(), topLeft.y(), imageSize.x(), imageSize.y()))
       img.save(filename)
       return
 
@@ -970,7 +970,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
                         outputFilenamePattern, captureAllViews = None, transparentBackground = False):
 
     self.cancelRequested = False
-    
+
     if not captureAllViews and not sliceNode.IsMappedInLayout():
       raise ValueError('Selected slice view is not visible in the current layout.')
 


### PR DESCRIPTION
This fixes a deprecation warning `QPixmap::grabWidget is deprecated, use QWidget::grab() instead`.
To replicate the warning, use ScreenCapture module to capture a single image of all views.

This use case was accidentally overlooked when https://github.com/Slicer/Slicer/commit/70c23d09a3fa6e970b6ae1c24e055b123e015e11 was committed which fixed other instances.  

Once Slicer is no longer trying to support both Qt4 and Qt5, then QWidget::grab() can be used directly.  Currently [ctkWidgetUtils.grabWidget](https://github.com/commontk/CTK/blob/cccef11c938cc946789ddb25ccc613287a33c56e/Libs/Widgets/ctkWidgetsUtils.cpp#L54-L57) is used which uses QPixmap::grabWidget if Qt4 and QWidget::grab if Qt5.