### PR TITLE
COMP: Update CMake minimum required version from 3.5 to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13.0)
 
 #-----------------------------------------------------------------------------
 # Enable C++11

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -197,7 +197,7 @@ mark_as_advanced(Slicer_BUILD_MULTIVOLUME_SUPPORT)
 
 Slicer_Remote_Add(MultiVolumeExplorer
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/fedorov/MultiVolumeExplorer.git
-  GIT_TAG 0bca789aae8e096e2a24cb6b984e4f5eae565d96
+  GIT_TAG 1618048725c37d1c36b1cdbd51c562f14479b1e9
   OPTION_NAME Slicer_BUILD_MultiVolumeExplorer
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_BUILD_MULTIVOLUME_SUPPORT;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE
@@ -206,7 +206,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeExplorer Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(MultiVolumeImporter
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/fedorov/MultiVolumeImporter.git
-  GIT_TAG e1c1cd845427298f3825ae208074f579626b3698
+  GIT_TAG ce324adb909b366454dab61b184bfda18b38a1f4
   OPTION_NAME Slicer_BUILD_MultiVolumeImporter
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_BUILD_MULTIVOLUME_SUPPORT;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE
@@ -215,7 +215,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeImporter Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(SimpleFilters
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/SimpleITK/SlicerSimpleFilters.git
-  GIT_TAG dd1e8be506381e1a7c5407a46195243961ea0622
+  GIT_TAG 8c27c74be153ebe83834b6e49ba0d5b387a0c264
   OPTION_NAME Slicer_BUILD_SimpleFilters
   OPTION_DEPENDS "Slicer_BUILD_QTSCRIPTEDMODULES;Slicer_USE_SimpleITK"
   LABELS REMOTE_MODULE
@@ -294,7 +294,7 @@ list_conditional_append(Slicer_BUILD_EMSegment Slicer_REMOTE_DEPENDENCIES EMSegm
 
 Slicer_Remote_Add(OtsuThresholdImageFilter
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/Slicer-OtsuThresholdImageFilter"
-  GIT_TAG "cf39e5064472af31809ec1fa2f93fb97dc9a606e"
+  GIT_TAG c14d5b8ee7a39bcdcc026d6a83957551a47a62bf
   OPTION_NAME Slicer_BUILD_OtsuThresholdImageFilter
   OPTION_DEPENDS "Slicer_BUILD_EMSegment"
   LABELS REMOTE_MODULE
@@ -303,7 +303,7 @@ list_conditional_append(Slicer_BUILD_OtsuThresholdImageFilter Slicer_REMOTE_DEPE
 
 Slicer_Remote_Add(DataStore
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/Slicer-DataStore"
-  GIT_TAG "8053b0283583d93b223c43bbf4678cb9adf7b0c7"
+  GIT_TAG 5fcf3b6457c378f5b2987d7d7430416001c364b8
   OPTION_NAME Slicer_BUILD_DataStore
   LABELS REMOTE_MODULE
   )
@@ -311,7 +311,7 @@ list_conditional_append(Slicer_BUILD_DataStore Slicer_REMOTE_DEPENDENCIES DataSt
 
 Slicer_Remote_Add(CompareVolumes
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/pieper/CompareVolumes"
-  GIT_TAG "b2a9a0d9045f3bc819504ad25a20409047e61694"
+  GIT_TAG 34f1b3da761f25227d6785b13b5700b8d446992d
   OPTION_NAME Slicer_BUILD_CompareVolumes
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE
@@ -320,7 +320,7 @@ list_conditional_append(Slicer_BUILD_CompareVolumes Slicer_REMOTE_DEPENDENCIES C
 
 Slicer_Remote_Add(LandmarkRegistration
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/pieper/LandmarkRegistration"
-  GIT_TAG "837e5edfb3b69844f2f06bf152a6edc6e7af1e8d"
+  GIT_TAG 6569f69ecb5c6d766ca02845e02ab5962eaab971
   OPTION_NAME Slicer_BUILD_LandmarkRegistration
   OPTION_DEPENDS "Slicer_BUILD_CompareVolumes;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -83,12 +83,6 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
     # More details here: https://discourse.slicer.org/t/cannot-compile-slicer-on-mac-macos-sierra-clang-9-cmake-3-9-1/1104/9
     #
 
-    if(CMAKE_VERSION VERSION_LESS "3.8.2")
-      message(FATAL_ERROR "Since SimpleITK requires CMP0067 to properly support C++11, "
-                          "CMake >= 3.8.2 is required to configure ${PROJECT_NAME}: "
-                          "Current CMake version is [${CMAKE_VERSION}]")
-    endif()
-
     list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
       -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
       -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}

--- a/SuperBuild/External_teem.cmake
+++ b/SuperBuild/External_teem.cmake
@@ -30,19 +30,13 @@ if(NOT DEFINED Teem_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       "-DCMAKE_PROJECT_Teem_INCLUDE:FILEPATH=${CMAKE_ROOT}/Modules/CTestUseLaunchers.cmake")
   endif()
 
-  if(${CMAKE_VERSION} VERSION_GREATER "2.8.11.2")
-    # Following CMake commit 2a7975398, the FindPNG.cmake module
-    # supports detection of release and debug libraries. Specifying only
-    # the release variable is enough to ensure the variable PNG_LIBRARY
-    # is internally set if the project is built either in Debug or Release.
-    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
-      -DPNG_LIBRARY_RELEASE:FILEPATH=${PNG_LIBRARY}
-      )
-  else()
-    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
-      -DPNG_LIBRARY:FILEPATH=${PNG_LIBRARY}
-      )
-  endif()
+  # Following CMake commit 2a7975398, the FindPNG.cmake module
+  # supports detection of release and debug libraries. Specifying only
+  # the release variable is enough to ensure the variable PNG_LIBRARY
+  # is internally set if the project is built either in Debug or Release.
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+    -DPNG_LIBRARY_RELEASE:FILEPATH=${PNG_LIBRARY}
+    )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY


### PR DESCRIPTION
Discourse post:
https://discourse.slicer.org/t/updating-minimum-required-version-of-cmake-to-3-13/6012

// ----------
Update MultiVolumeExplorer:

```
git shortlog --no-merges 0bca789..16180487
Pablo Hernandez-Cerdan (1):
      Update cmake_minimum_required to 3.13
```
// ----------
Update MultiVolumeImporter:

```
git shortlog --no-merges   e1c1cd8..ce324adb
Pablo Hernandez-Cerdan (1):
      Update cmake_minimum_required to 3.13
```
// ----------
Update SimpleFilters

```
git shortlog --no-merges   dd1e8be5..8c27c74b
Pablo Hernandez-Cerdan (1):
      Update cmake_minimum_required to 3.13
```
// ----------
Update OtsuThresholdImageFilter

```
git shortlog --no-merges  cf39e506..c14d5b8e
Pablo Hernandez-Cerdan (1):
      Update cmake_minimum_required to 3.13
```
// ----------
Update DataStore

```
git shortlog --no-merges  8053b028..5fcf3b64
Pablo Hernandez-Cerdan (1):
      Update cmake_minimum_required to 3.13
```
// ----------
Update CompareVolumes

```
git shortlog --no-merges b2a9a0d9..34f1b3da
Pablo Hernandez-Cerdan (1):
      Update cmake_minimum_required to 3.13
```

// ----------
Update LandmarkRegistration

```
git shortlog --no-merges 837e5edf..6569f69e
Pablo Hernandez-Cerdan (1):
      Update cmake_minimum_required to 3.13
```

Co-authored-by: Hans Johnson <hans-johnson@uiowa.edu>