### PR TITLE
COMP: Fix minor warnings

### DIFF
--- a/Libs/vtkAddon/vtkOpenGLShaderComputation.cxx
+++ b/Libs/vtkAddon/vtkOpenGLShaderComputation.cxx
@@ -420,7 +420,6 @@ void vtkOpenGLShaderComputation::Compute(float slice)
   //
   // Does the GPU support current Framebuffer configuration?
   //
-  GLenum status;
   if (!this->FramebufferComplete())
     {
     vtkErrorMacro("Framebuffer is not complete.");

--- a/Libs/vtkITK/Testing/VTKITKVectorReader.cxx
+++ b/Libs/vtkITK/Testing/VTKITKVectorReader.cxx
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
     {
     vectorReader->Update();
     }
-  catch (itk::ExceptionObject err)
+  catch (itk::ExceptionObject &err)
     {
     std::cout << "Unable to read file '" << argv[1] << "', err = \n" << err << std::endl;
     vectorReader->Delete();


### PR DESCRIPTION
- Catch by value exception in `Testing/VTKITKVectorReader.cxx`

```cpp
warning: catching polymorphic type ‘class itk::ExceptionObject’ by value [-Wcatch-value=]
```

- unused variable in vtkAddon/vtkOpenGLShaderComputation.cxx

```cpp
/Libs/vtkAddon/vtkOpenGLShaderComputation.cxx:423:10: warning: unused variable ‘status’ [-Wunused-variable]
   GLenum status;
          ^~~~~~
```