### PR TITLE
COMP: Fix unused warning related to vtkMRMLWriteXML and vtkMRMLPrint

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx
@@ -53,9 +53,6 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::ReadXMLAttributes(const char**
 void vtkMRMLGPURayCastVolumeRenderingDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   this->Superclass::WriteXML(of, nIndent);
-
-  vtkMRMLWriteXMLBeginMacro(of);
-  vtkMRMLWriteXMLEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -74,7 +71,4 @@ void vtkMRMLGPURayCastVolumeRenderingDisplayNode::Copy(vtkMRMLNode *anode)
 void vtkMRMLGPURayCastVolumeRenderingDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
-
-  vtkMRMLPrintBeginMacro(os, indent);
-  vtkMRMLPrintEndMacro();
 }

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLMultiVolumeRenderingDisplayNode.cxx
@@ -54,9 +54,6 @@ void vtkMRMLMultiVolumeRenderingDisplayNode::ReadXMLAttributes(const char** atts
 void vtkMRMLMultiVolumeRenderingDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   this->Superclass::WriteXML(of, nIndent);
-
-  vtkMRMLWriteXMLBeginMacro(of);
-  vtkMRMLWriteXMLEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -75,7 +72,4 @@ void vtkMRMLMultiVolumeRenderingDisplayNode::Copy(vtkMRMLNode *anode)
 void vtkMRMLMultiVolumeRenderingDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os,indent);
-
-  vtkMRMLPrintBeginMacro(os, indent);
-  vtkMRMLPrintEndMacro();
 }


### PR DESCRIPTION
in `vtkMRMLGPURayCastVolumeRenderingDisplayNode` and
`vtkMRMLMultiVolumeRenderingDisplayNode`.

These classes where starting and end the macros, but without any content
printed or written between those calls.

Warning:

```cpp
[335/2622] Building CXX object Libs/vtkITK/CMakeFiles/vtkITK.dir/vtkITKGrowCutSegmentationImageFilter.cxx.o
In file included from Libs/MRML/Core/vtkMRMLNode.h:37,
                 from Libs/MRML/Core/vtkMRMLDisplayNode.h:19,
                 from Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h:22,
                 from Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.h:25,
                 from Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx:22:
Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx: In member function ‘virtual void vtkMRMLGPURayCastVolumeRenderingDisplayNode::ReadXMLAttributes(const char**)’:
Libs/MRML/Core/vtkMRMLNodePropertyMacros.h:148:15: warning: variable ‘xmlReadAttName’ set but not used [-Wunused-but-set-variable]
   const char* xmlReadAttName; \
               ^~~~~~~~~~~~~~
Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx:48:3: note: in expansion of macro ‘vtkMRMLReadXMLBeginMacro’
   vtkMRMLReadXMLBeginMacro(atts);
   ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from Libs/MRML/Core/vtkMRMLNode.h:37,
                 from Libs/MRML/Core/vtkMRMLDisplayNode.h:19,
                 from Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h:22,
                 from Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.h:25,
                 from Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx:22:
Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx: In member function ‘virtual void vtkMRMLGPURayCastVolumeRenderingDisplayNode::WriteXML(std::ostream&, int)’:
Libs/MRML/Core/vtkMRMLNodePropertyMacros.h:30:12: warning: unused variable ‘xmlWriteOutputStream’ [-Wunused-variable]
   ostream& xmlWriteOutputStream = of;
            ^~~~~~~~~~~~~~~~~~~~
Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx:57:3: note: in expansion of macro ‘vtkMRMLWriteXMLBeginMacro’
   vtkMRMLWriteXMLBeginMacro(of);
   ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from Libs/MRML/Core/vtkMRMLNode.h:37,
                 from Libs/MRML/Core/vtkMRMLDisplayNode.h:19,
                 from Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h:22,
                 from Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.h:25,
                 from Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx:22:
Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx: In member function ‘virtual void vtkMRMLGPURayCastVolumeRenderingDisplayNode::PrintSelf(std::ostream&, vtkIndent)’:
Libs/MRML/Core/vtkMRMLNodePropertyMacros.h:417:12: warning: unused variable ‘printOutputStream’ [-Wunused-variable]
   ostream& printOutputStream = os; \
            ^~~~~~~~~~~~~~~~~
Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx:78:3: note: in expansion of macro ‘vtkMRMLPrintBeginMacro’
   vtkMRMLPrintBeginMacro(os, indent);
   ^~~~~~~~~~~~~~~~~~~~~~
Libs/MRML/Core/vtkMRMLNodePropertyMacros.h:418:13: warning: variable ‘printOutputIndent’ set but not used [-Wunused-but-set-variable]
   vtkIndent printOutputIndent = indent;
             ^~~~~~~~~~~~~~~~~
Modules/Loadable/VolumeRendering/MRML/vtkMRMLGPURayCastVolumeRenderingDisplayNode.cxx:78:3: note: in expansion of macro ‘vtkMRMLPrintBeginMacro’
   vtkMRMLPrintBeginMacro(os, indent);
```