### PR TITLE
STYLE: Replace ITK_OVERRIDE with override

### DIFF
--- a/Libs/MRML/Core/vtkITKTransformInverse.h
+++ b/Libs/MRML/Core/vtkITKTransformInverse.h
@@ -52,39 +52,39 @@ namespace itk
     (the inherited implementations are for the forward transform, so they would not give correct results) */
     using Superclass::TransformPoint;
     virtual typename Superclass::OutputPointType TransformPoint(
-        const typename Superclass::InputPointType&) const ITK_OVERRIDE
+        const typename Superclass::InputPointType&) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     virtual void ComputeJacobianWithRespectToParameters(
         const typename Superclass::InputPointType &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     // Deprecated in ITKv5. It should be removed when ITK_LEGACY_REMOVE is set to ON.
     virtual void ComputeJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     virtual void ComputeJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianPositionType &) const ITK_OVERRIDE
+        typename Superclass::JacobianPositionType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     // Deprecated in ITKv5. It should be removed when ITK_LEGACY_REMOVE is set to ON.
     virtual void ComputeInverseJacobianWithRespectToPosition(
         const typename Superclass::InputPointType &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     virtual void ComputeInverseJacobianWithRespectToPosition(
         const typename Superclass::InputPointType &,
-        typename Superclass::InverseJacobianPositionType &) const ITK_OVERRIDE
+        typename Superclass::InverseJacobianPositionType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
@@ -119,38 +119,38 @@ namespace itk
     (the inherited implementations are for the forward transform, so they would not give correct results) */
     using Superclass::TransformPoint;
     virtual typename Superclass::OutputPointType TransformPoint(
-        const typename Superclass::InputPointType&) const ITK_OVERRIDE
+        const typename Superclass::InputPointType&) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     virtual void ComputeJacobianWithRespectToParameters(
         const typename Superclass::InputPointType &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     // Deprecated in ITKv5. It should be removed when ITK_LEGACY_REMOVE is set to ON.
     virtual void ComputeJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     virtual void ComputeJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianPositionType &) const ITK_OVERRIDE
+        typename Superclass::JacobianPositionType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     virtual void ComputeInverseJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
     virtual void ComputeInverseJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::InverseJacobianPositionType &) const ITK_OVERRIDE
+        typename Superclass::InverseJacobianPositionType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseBSplineTransform" );
       }
@@ -178,57 +178,57 @@ namespace itk
     /** Define all computation methods as unimplemented to make sure they are not used
     (the inherited implementations are for the forward transform, so they would not give correct results) */
     virtual typename Superclass::OutputPointType TransformPoint(
-        const typename Superclass::InputPointType&) const ITK_OVERRIDE
+        const typename Superclass::InputPointType&) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
       }
     virtual void ComputeJacobianWithRespectToParameters(
         const typename Superclass::InputPointType &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
       }
     virtual void ComputeJacobianWithRespectToParameters(
         const typename Superclass::IndexType &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
       }
     // Deprecated in ITKv5. It should be removed when ITK_LEGACY_REMOVE is set to ON.
     virtual void ComputeJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
       }
     virtual void ComputeJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianPositionType &) const ITK_OVERRIDE
+        typename Superclass::JacobianPositionType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
       }
     virtual void ComputeJacobianWithRespectToPosition(
         const typename Superclass::IndexType  &,
-        typename Superclass::JacobianPositionType &) const ITK_OVERRIDE
+        typename Superclass::JacobianPositionType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
       }
     virtual void ComputeInverseJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
       }
     virtual void ComputeInverseJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::InverseJacobianPositionType &) const ITK_OVERRIDE
+        typename Superclass::InverseJacobianPositionType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
       }
     virtual void GetInverseJacobianOfForwardFieldWithRespectToPosition(
         const typename Superclass::InputPointType &,
         typename Superclass::JacobianPositionType &,
-        bool useSVD = false ) const ITK_OVERRIDE
+        bool useSVD = false ) const override
       {
       (void)useSVD; // unused
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
@@ -236,7 +236,7 @@ namespace itk
     virtual void GetInverseJacobianOfForwardFieldWithRespectToPosition(
         const typename Superclass::IndexType &,
         typename Superclass::JacobianPositionType &,
-        bool useSVD = false ) const ITK_OVERRIDE
+        bool useSVD = false ) const override
       {
       (void)useSVD; // unused
       itkExceptionMacro( "Only storage methods are implemented for InverseDisplacementFieldTransform" );
@@ -264,44 +264,44 @@ namespace itk
     /** Define all computation methods as unimplemented to make sure they are not used
     (the inherited implementations are for the forward transform, so they would not give correct results) */
     virtual typename Superclass::OutputPointType TransformPoint(
-        const typename Superclass::InputPointType&) const ITK_OVERRIDE
+        const typename Superclass::InputPointType&) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseThinPlateSplineKernelTransform" );
       }
     virtual void ComputeDeformationContribution(const typename Superclass::InputPointType &,
-                                              typename Superclass::OutputPointType &) const ITK_OVERRIDE
+                                              typename Superclass::OutputPointType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseThinPlateSplineKernelTransform" );
       }
     virtual void ComputeJacobianWithRespectToParameters(
         const typename Superclass::InputPointType &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseThinPlateSplineKernelTransform" );
       }
     // Deprecated in ITKv5. It should be removed when ITK_LEGACY_REMOVE is set to ON.
     virtual void ComputeJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseThinPlateSplineKernelTransform" );
       }
     virtual void ComputeJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianPositionType &) const ITK_OVERRIDE
+        typename Superclass::JacobianPositionType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseThinPlateSplineKernelTransform" );
       }
     // Deprecated in ITKv5. It should be removed when ITK_LEGACY_REMOVE is set to ON.
     virtual void ComputeInverseJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::JacobianType &) const ITK_OVERRIDE
+        typename Superclass::JacobianType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseThinPlateSplineKernelTransform" );
       }
     virtual void ComputeInverseJacobianWithRespectToPosition(
         const typename Superclass::InputPointType  &,
-        typename Superclass::InverseJacobianPositionType &) const ITK_OVERRIDE
+        typename Superclass::InverseJacobianPositionType &) const override
       {
       itkExceptionMacro( "Only storage methods are implemented for InverseThinPlateSplineKernelTransform" );
       }

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIO.h
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIO.h
@@ -66,36 +66,36 @@ public:
 
   /** Determine the file type. Returns true if this ImageIO can read the
    * file specified. */
-  virtual bool CanReadFile(const char*) ITK_OVERRIDE;
+  virtual bool CanReadFile(const char*) override;
 
   virtual bool CanUseOwnBuffer();
   virtual void ReadUsingOwnBuffer();
   virtual void * GetOwnBuffer();
 
   /** Set the spacing and dimension information for the set filename. */
-  virtual void ReadImageInformation() ITK_OVERRIDE;
+  virtual void ReadImageInformation() override;
 
   /** Reads the data from disk into the memory buffer provided. */
-  virtual void Read(void* buffer) ITK_OVERRIDE;
+  virtual void Read(void* buffer) override;
 
   /*-------- This part of the interfaces deals with writing data. ----- */
 
   /** Determine the file type. Returns true if this ImageIO can read the
    * file specified. */
-  virtual bool CanWriteFile(const char*) ITK_OVERRIDE;
+  virtual bool CanWriteFile(const char*) override;
 
   /** Writes the header of the image.
    * Assumes SetFileName has been called with a valid file name. */
-  virtual void WriteImageInformation() ITK_OVERRIDE;
+  virtual void WriteImageInformation() override;
 
   /** Writes the data to disk from the memory buffer provided. Make sure
    * that the IORegion has been set properly. */
-  virtual void Write(const void* buffer) ITK_OVERRIDE;
+  virtual void Write(const void* buffer) override;
 
 protected:
   MRMLIDImageIO();
   ~MRMLIDImageIO();
-  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Write the image information to the node and specified image */
   virtual void WriteImageInformation(vtkMRMLVolumeNode *, vtkImageData*,

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIOFactory.h
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIOFactory.h
@@ -39,8 +39,8 @@ public:
   typedef SmartPointer<const Self>  ConstPointer;
 
   /** Class methods used to interface with the registered factories. */
-  virtual const char* GetITKSourceVersion(void) const ITK_OVERRIDE;
-  virtual const char* GetDescription(void) const ITK_OVERRIDE;
+  virtual const char* GetITKSourceVersion(void) const override;
+  virtual const char* GetDescription(void) const override;
 
   /** Method for class instantiation. */
   itkFactorylessNewMacro(Self);

--- a/Libs/vtkITK/itkGrowCutSegmentationImageFilter.h
+++ b/Libs/vtkITK/itkGrowCutSegmentationImageFilter.h
@@ -266,21 +266,21 @@ template<class TInputImage,
   ~GrowCutSegmentationImageFilter() {};
 
    // Override since the filter needs all the data for the algorithm
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  void GenerateInputRequestedRegion() override;
 
    // Override since the filter produces the entire dataset
-  void EnlargeOutputRequestedRegion(DataObject *output) ITK_OVERRIDE;
+  void EnlargeOutputRequestedRegion(DataObject *output) override;
 
-  void GenerateData() ITK_OVERRIDE;
+  void GenerateData() override;
 
   void ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread ,
-                             ThreadIdType threadId ) ITK_OVERRIDE;
+                             ThreadIdType threadId ) override;
 
-  void AfterThreadedGenerateData() ITK_OVERRIDE;
+  void AfterThreadedGenerateData() override;
 
   void Initialize(OutputImageType* output);
 
-  void PrintSelf ( std::ostream& os, Indent indent ) const ITK_OVERRIDE;
+  void PrintSelf ( std::ostream& os, Indent indent ) const override;
 
   void GrowCutSlowROI( TOutputImage *);
 

--- a/Libs/vtkITK/itkLevelTracingImageFilter.h
+++ b/Libs/vtkITK/itkLevelTracingImageFilter.h
@@ -74,7 +74,7 @@ public:
   itkStaticConstMacro(OutputImageDimension, unsigned int,
                       TOutputImage::ImageDimension);
 
-  void PrintSelf ( std::ostream& os, Indent indent ) const ITK_OVERRIDE;
+  void PrintSelf ( std::ostream& os, Indent indent ) const override;
 
   /// Set/Get the seed
   itkSetMacro(Seed, IndexType);
@@ -95,12 +95,12 @@ protected:
   ~LevelTracingImageFilter(){}
 
   /// Override since the filter needs all the data for the algorithm
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  void GenerateInputRequestedRegion() override;
 
   /// Override since the filter produces the entire dataset
-  void EnlargeOutputRequestedRegion(DataObject *output) ITK_OVERRIDE;
+  void EnlargeOutputRequestedRegion(DataObject *output) override;
 
-  void GenerateData() ITK_OVERRIDE;
+  void GenerateData() override;
 
   using Superclass::MakeOutput;
   DataObjectPointer MakeOutput(unsigned int output);

--- a/Libs/vtkITK/itkLevelTracingImageFilter.txx
+++ b/Libs/vtkITK/itkLevelTracingImageFilter.txx
@@ -63,7 +63,7 @@ public:
    *
    * ImageFunction::IsInsideBuffer() can be used to check bounds before
    * calling the method. */
-  virtual bool Evaluate( const PointType& point ) const ITK_OVERRIDE
+  virtual bool Evaluate( const PointType& point ) const override
     {
       IndexType index;
       this->ConvertPointToNearestIndex( point, index );
@@ -79,7 +79,7 @@ public:
    * ImageFunction::IsInsideBuffer() can be used to check bounds before
    * calling the method. */
   virtual bool EvaluateAtContinuousIndex(
-    const ContinuousIndexType & index ) const ITK_OVERRIDE
+    const ContinuousIndexType & index ) const override
     {
       IndexType nindex;
 
@@ -95,7 +95,7 @@ public:
    *
    * ImageFunction::IsInsideBuffer() can be used to check bounds before
    * calling the method. */
-  virtual bool EvaluateAtIndex( const IndexType & index ) const ITK_OVERRIDE
+  virtual bool EvaluateAtIndex( const IndexType & index ) const override
     {
       // Create an N-d neighborhood kernel, using a zeroflux boundary condition
       ConstNeighborhoodIterator<InputImageType>

--- a/Libs/vtkITK/itkMorphologicalContourInterpolator.h
+++ b/Libs/vtkITK/itkMorphologicalContourInterpolator.h
@@ -238,7 +238,7 @@ protected:
 
   /** Does the real work. */
   virtual void
-  GenerateData() ITK_OVERRIDE;
+  GenerateData() override;
 
   /** Determines correspondances between two slices and calls appropriate methods. */
   void
@@ -339,7 +339,7 @@ protected:
 
   /** Copied from ImageSource and changed to allocate a cleared buffer. */
   virtual void
-  AllocateOutputs() ITK_OVERRIDE;
+  AllocateOutputs() override;
 
   /** Returns the centroid of given regions */
   typename SliceType::IndexType

--- a/Libs/vtkITK/itkMorphologicalContourInterpolator.hxx
+++ b/Libs/vtkITK/itkMorphologicalContourInterpolator.hxx
@@ -90,7 +90,7 @@ protected:
 
 private:
   virtual void
-  ThreadedExecution( const DomainType& subDomain, const ThreadIdType threadId ) ITK_OVERRIDE
+  ThreadedExecution( const DomainType& subDomain, const ThreadIdType threadId ) override
   {
     // Look only at the range of cells by the set of indices in the subDomain.
     for ( itk::IndexValueType ii = subDomain[0]; ii <= subDomain[1] && ii < IndexValueType( m_WorkArray.size() ); ++ii )

--- a/Libs/vtkITK/itkNewOtsuThresholdImageCalculator.h
+++ b/Libs/vtkITK/itkNewOtsuThresholdImageCalculator.h
@@ -72,7 +72,7 @@ public:
 protected:
   NewOtsuThresholdImageCalculator();
   virtual ~NewOtsuThresholdImageCalculator() {};
-  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
   NewOtsuThresholdImageCalculator(const Self&); //purposely not implemented

--- a/Libs/vtkITK/itkNewOtsuThresholdImageFilter.h
+++ b/Libs/vtkITK/itkNewOtsuThresholdImageFilter.h
@@ -106,10 +106,10 @@ public:
 protected:
   NewOtsuThresholdImageFilter();
   ~NewOtsuThresholdImageFilter(){}
-  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
-  void GenerateData () ITK_OVERRIDE;
+  void GenerateInputRequestedRegion() override;
+  void GenerateData () override;
 
 private:
   NewOtsuThresholdImageFilter(const Self&); //purposely not implemented

--- a/Libs/vtkITK/itkTimeSeriesDatabase.h
+++ b/Libs/vtkITK/itkTimeSeriesDatabase.h
@@ -85,8 +85,8 @@ public:
   itkGetMacro ( OutputDirection, typename OutputImageType::DirectionType );
 
   /** Standard method for a ImageSource object */
-  virtual void GenerateOutputInformation(void) ITK_OVERRIDE;
-  virtual void GenerateData(void) ITK_OVERRIDE;
+  virtual void GenerateOutputInformation(void) override;
+  virtual void GenerateData(void) override;
 
   /** A convenience method for reading a voxel's time course
    * Subsequent calls to voxels in the immediate region of this will be
@@ -105,7 +105,7 @@ public:
 protected:
   TimeSeriesDatabase();
   ~TimeSeriesDatabase();
-  virtual void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  virtual void PrintSelf(std::ostream& os, Indent indent) const override;
 
   Array<unsigned int> m_Dimensions;
   Array<unsigned int> m_BlocksPerImage;

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAffineImageToImageRegistrationMethod.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAffineImageToImageRegistrationMethod.h
@@ -60,7 +60,7 @@ public:
   // Superclass Methods
   //
 
-  void GenerateData( void ) ITK_OVERRIDE;
+  void GenerateData( void ) override;
 
   //
   // Custom Methods
@@ -100,7 +100,7 @@ protected:
   AffineImageToImageRegistrationMethod( void );
   virtual ~AffineImageToImageRegistrationMethod( void );
 
-  void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
 private:
 

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarity3DTransform.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarity3DTransform.h
@@ -107,15 +107,15 @@ public:
    *
    * \sa MatrixOffsetTransformBase::SetMatrix() */
   using itk::Rigid3DTransform<TScalarType>::SetMatrix;
-  virtual void SetMatrix(const MatrixType & matrix) ITK_OVERRIDE;
+  virtual void SetMatrix(const MatrixType & matrix) override;
 
   /** Set the transformation from a container of parameters This is typically
    * used by optimizers.  There are 7 parameters. The first three represent the
    * versor, the next three represent the translation and the last one
    * represents the scaling factor. */
-  void SetParameters( const ParametersType & parameters ) ITK_OVERRIDE;
+  void SetParameters( const ParametersType & parameters ) override;
 
-  virtual const ParametersType & GetParameters(void) const ITK_OVERRIDE;
+  virtual const ParametersType & GetParameters(void) const override;
 
   /** Set/Get the value of the isotropic scaling factor */
   void SetScale( ScaleType scale );
@@ -128,7 +128,7 @@ public:
    * given point or vector, returning the transformed point or
    * vector. The rank of the Jacobian will also indicate if the
    * transform is invertible at this point. */
-  virtual void ComputeJacobianWithRespectToParameters(const InputPointType & p, JacobianType & jacobian) const ITK_OVERRIDE;
+  virtual void ComputeJacobianWithRespectToParameters(const InputPointType & p, JacobianType & jacobian) const override;
 
 protected:
   AnisotropicSimilarity3DTransform(const MatrixType & matrix, const OutputVectorType & offset);
@@ -138,14 +138,14 @@ protected:
   {
   };
 
-  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream & os, Indent indent) const override;
 
   /** Recomputes the matrix by calling the Superclass::ComputeMatrix() and then
    * applying the scale factor. */
-  void ComputeMatrix() ITK_OVERRIDE;
+  void ComputeMatrix() override;
 
   /** Computes the parameters from an input matrix. */
-  void ComputeMatrixParameters() ITK_OVERRIDE;
+  void ComputeMatrixParameters() override;
 
 private:
   AnisotropicSimilarity3DTransform(const Self &); // purposely not implemented

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkAnisotropicSimilarityLandmarkBasedTransformInitializer.h
@@ -154,7 +154,7 @@ protected:
   {
   }
 
-  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream & os, Indent indent) const override;
 
   // Supported Transform types
   typedef enum

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkBSplineImageToImageRegistrationMethod.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkBSplineImageToImageRegistrationMethod.h
@@ -66,7 +66,7 @@ public:
   // Methods from Superclass
   //
 
-  virtual void GenerateData( void ) ITK_OVERRIDE;
+  virtual void GenerateData( void ) override;
 
   //
   // Custom Methods
@@ -111,13 +111,13 @@ protected:
   typedef InterpolateImageFunction<TImage, double> InterpolatorType;
   typedef ImageToImageMetric<TImage, TImage>       MetricType;
 
-  virtual void Optimize( MetricType * metric, InterpolatorType * interpolator ) ITK_OVERRIDE;
+  virtual void Optimize( MetricType * metric, InterpolatorType * interpolator ) override;
 
   virtual void GradientOptimize( MetricType * metric, InterpolatorType * interpolator );
 
   virtual void MultiResolutionOptimize( MetricType * metric, InterpolatorType * interpolator );
 
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
 
 private:
 

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkBSplineImageToImageRegistrationMethod.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkBSplineImageToImageRegistrationMethod.txx
@@ -53,12 +53,12 @@ public:
   itkSetMacro(DontShowParameters, bool);
   itkSetMacro(UpdateInterval, int);
 
-  void Execute( Object * caller, const EventObject & event ) ITK_OVERRIDE
+  void Execute( Object * caller, const EventObject & event ) override
   {
     Execute( (const Object *)caller, event );
   }
 
-  void Execute( const Object * object, const EventObject & event ) ITK_OVERRIDE
+  void Execute( const Object * object, const EventObject & event ) override
   {
     if( typeid( event ) != typeid( IterationEvent ) || object == NULL )
       {

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.h
@@ -222,7 +222,7 @@ public:
 protected:
   ImageRegionMomentsCalculator();
   virtual ~ImageRegionMomentsCalculator();
-  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
   ImageRegionMomentsCalculator(const Self &); // purposely not implemented

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationHelper.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationHelper.h
@@ -428,7 +428,7 @@ protected:
   void PrintSelfHelper( std::ostream & os, Indent indent, const std::string basename, MetricMethodEnumType metric,
                         InterpolationMethodEnumType interpolation ) const;
 
-  void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
 private:
 

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationMethod.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationMethod.h
@@ -132,9 +132,9 @@ protected:
   /** Method that actually computes the registration. This method is intended
    * to be overloaded by derived classes. Those overload, however, must
    * invoke this method in the base class. */
-  void GenerateData( void ) ITK_OVERRIDE;
+  void GenerateData( void ) override;
 
-  void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   /** Provide derived classes with access to the Transform member variable. */
   itkSetObjectMacro( Transform, TransformType );
@@ -142,9 +142,9 @@ protected:
   itkGetConstObjectMacro( Transform, TransformType );
 
   using Superclass::MakeOutput;
-  virtual DataObjectPointer   MakeOutput( DataObjectPointerArraySizeType idx ) ITK_OVERRIDE;
+  virtual DataObjectPointer   MakeOutput( DataObjectPointerArraySizeType idx ) override;
 
-  unsigned long               GetMTime( void ) const ITK_OVERRIDE;
+  unsigned long               GetMTime( void ) const override;
 
 protected:
 

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkInitialImageToImageRegistrationMethod.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkInitialImageToImageRegistrationMethod.h
@@ -105,13 +105,13 @@ protected:
   InitialImageToImageRegistrationMethod( void );
   virtual ~InitialImageToImageRegistrationMethod( void );
 
-  void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
   //
   //  Methods from Superclass. Only the GenerateData() method should be
   //  overloaded. The Update() method must not be overloaded.
   //
-  void    GenerateData() ITK_OVERRIDE;
+  void    GenerateData() override;
 
 private:
 

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkOptimizedImageToImageRegistrationMethod.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkOptimizedImageToImageRegistrationMethod.h
@@ -77,7 +77,7 @@ public:
   //
   // Methods from Superclass
   //
-  virtual void GenerateData( void ) ITK_OVERRIDE;
+  virtual void GenerateData( void ) override;
 
   //
   // Custom Methods
@@ -144,7 +144,7 @@ protected:
 
   virtual void Optimize( MetricType * metric, InterpolatorType * interpolator );
 
-  virtual void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+  virtual void PrintSelf( std::ostream & os, Indent indent ) const override;
 
 private:
 

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkOptimizedImageToImageRegistrationMethod.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkOptimizedImageToImageRegistrationMethod.txx
@@ -68,12 +68,12 @@ public:
   itkSetMacro(DontShowParameters, bool);
   itkSetMacro(UpdateInterval, int);
 
-  void Execute( Object * caller, const EventObject & event ) ITK_OVERRIDE
+  void Execute( Object * caller, const EventObject & event ) override
   {
     Execute( (const Object *)caller, event );
   }
 
-  void Execute( const Object * object, const EventObject & event ) ITK_OVERRIDE
+  void Execute( const Object * object, const EventObject & event ) override
   {
     if( typeid( event ) != typeid( IterationEvent ) || object == NULL )
       {

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkRigidImageToImageRegistrationMethod.h
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkRigidImageToImageRegistrationMethod.h
@@ -76,7 +76,7 @@ public:
   //
   //  Superclass Methods
   //
-  void GenerateData( void ) ITK_OVERRIDE;
+  void GenerateData( void ) override;
 
   //
   // Custom Methods
@@ -120,7 +120,7 @@ protected:
   RigidImageToImageRegistrationMethod( void );
   virtual ~RigidImageToImageRegistrationMethod( void );
 
-  void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+  void PrintSelf( std::ostream & os, Indent indent ) const override;
 
 private:
 

--- a/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
@@ -29,12 +29,12 @@ protected:
   };
 public:
 
-  void Execute(itk::Object *caller, const itk::EventObject & event) ITK_OVERRIDE
+  void Execute(itk::Object *caller, const itk::EventObject & event) override
   {
     Execute( (const itk::Object *) caller, event);
   }
 
-  void Execute(const itk::Object * object, const itk::EventObject & event) ITK_OVERRIDE
+  void Execute(const itk::Object * object, const itk::EventObject & event) override
   {
     const TFilter * filter =
       dynamic_cast<const TFilter *>( object );

--- a/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
+++ b/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
@@ -103,7 +103,7 @@ protected:
   {
   }
 
-  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** DifferenceImageFilter can be implemented as a multithreaded
    * filter.  Therefore, this implementation provides a
@@ -116,11 +116,11 @@ protected:
    *
    * \sa ImageToImageFilter::ThreadedGenerateData(),
    *     ImageToImageFilter::GenerateData()  */
-  void ThreadedGenerateData(const OutputImageRegionType& threadRegion, ThreadIdType threadId) ITK_OVERRIDE;
+  void ThreadedGenerateData(const OutputImageRegionType& threadRegion, ThreadIdType threadId) override;
 
-  void BeforeThreadedGenerateData() ITK_OVERRIDE;
+  void BeforeThreadedGenerateData() override;
 
-  void AfterThreadedGenerateData() ITK_OVERRIDE;
+  void AfterThreadedGenerateData() override;
 
   InputPixelType ApplyMeasurementFrameToTensor( InputPixelType tensor, const MatrixType & measurementFrame );
 

--- a/Modules/CLI/ResampleDTIVolume/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
+++ b/Modules/CLI/ResampleDTIVolume/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
@@ -68,13 +68,13 @@ public:
   itkNewMacro(Self);
 
   /** Print internal ivars */
-  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE
+  void PrintSelf(std::ostream& os, Indent indent) const override
   {
     this->Superclass::PrintSelf( os, indent );
   }
 
   // need to override GenerateData (This should be threaded)
-  void GenerateData() ITK_OVERRIDE;
+  void GenerateData() override;
 
   OutputPixelType ComputeDisplacement(typename InputImageType::ConstPointer input,
                                       typename InputImageType::IndexType ind,

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DBSplineInterpolateImageFunction.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DBSplineInterpolateImageFunction.h
@@ -48,7 +48,7 @@ public:
   // /Set the Spline Order, supports 0th - 5th order splines. The default is a 1st order spline.
   itkSetMacro( SplineOrder, unsigned int );
 protected:
-  void AllocateInterpolator() ITK_OVERRIDE;
+  void AllocateInterpolator() override;
 
   DiffusionTensor3DBSplineInterpolateImageFunction();
   unsigned int m_SplineOrder;

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DFSAffineTransform.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DFSAffineTransform.h
@@ -57,7 +57,7 @@ public:
   itkTypeMacro(DiffusionTensor3DFSAffineTransform, DiffusionTensor3DAffineTransform);
 
 protected:
-  void PreCompute() ITK_OVERRIDE;
+  void PreCompute() override;
 
 private:
   MatrixTransformType ComputeMatrixSquareRoot( MatrixTransformType matrix );

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunction.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunction.h
@@ -67,7 +67,7 @@ public:
    *
    * ImageFunction::IsInsideBuffer() can be used to check bounds before
    * calling the method. */
-  virtual TensorDataType Evaluate( const PointType& point ) const ITK_OVERRIDE
+  virtual TensorDataType Evaluate( const PointType& point ) const override
   {
     ContinuousIndexType index;
 
@@ -85,7 +85,7 @@ public:
    *
    * ImageFunction::IsInsideBuffer() can be used to check bounds before
    * calling the method. */
-  virtual TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const ITK_OVERRIDE = 0;
+  virtual TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const override = 0;
 
   /** Interpolate the image at an index position.
    *
@@ -96,7 +96,7 @@ public:
    * ImageFunction::IsInsideBuffer() can be used to check bounds before
    * calling the method. */
 
-  virtual TensorDataType EvaluateAtIndex( const IndexType & index ) const ITK_OVERRIDE
+  virtual TensorDataType EvaluateAtIndex( const IndexType & index ) const override
   {
     return this->GetInputImage()->GetPixel( index );
   }

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DInterpolateImageFunctionReimplementation.h
@@ -67,9 +67,9 @@ public:
   /** Evaluate the interpolated tensor at a position
    */
   // TensorDataType Evaluate( const PointType &point ) ;
-  TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const ITK_OVERRIDE;
+  TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const override;
 
-  virtual void SetInputImage( const DiffusionImageType *inputImage ) ITK_OVERRIDE;
+  virtual void SetInputImage( const DiffusionImageType *inputImage ) override;
 
   itkSetMacro( NumberOfThreads, int );
 protected:

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DLinearInterpolateFunction.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DLinearInterpolateFunction.h
@@ -42,7 +42,7 @@ public:
 
   itkNewMacro(Self);
 protected:
-  void AllocateInterpolator() ITK_OVERRIDE;
+  void AllocateInterpolator() override;
 
   typename LinearInterpolateImageFunctionType::Pointer linearInterpolator[6];
 };

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DMatrix3x3Transform.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DMatrix3x3Transform.h
@@ -61,7 +61,7 @@ public:
   void SetCenter( PointType center );
 
   // /Evaluate the position of the transformed tensor in the output image
-  PointType EvaluateTensorPosition( const PointType & point ) ITK_OVERRIDE;
+  PointType EvaluateTensorPosition( const PointType & point ) override;
 
   // /Set the 3x3 transform matrix
   virtual void SetMatrix3x3( MatrixTransformType & matrix );
@@ -72,7 +72,7 @@ public:
   // /Evaluate the transformed tensor
   virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor );
 
-  virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor, PointType & outputPosition ) ITK_OVERRIDE; // dummy
+  virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor, PointType & outputPosition ) override; // dummy
                                                                                                            // output
                                                                                                            // position;
                                                                                                            // to be
@@ -81,7 +81,7 @@ public:
                                                                                                            // non-rigid
                                                                                                            // transforms
 
-  virtual typename Transform<double, 3, 3>::Pointer GetTransform() ITK_OVERRIDE;
+  virtual typename Transform<double, 3, 3>::Pointer GetTransform() override;
 
 protected:
   void ComputeOffset();

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DNearestNeighborInterpolateFunction.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DNearestNeighborInterpolateFunction.h
@@ -46,7 +46,7 @@ public:
   itkNewMacro( Self );
   // /Evaluate the value of a tensor at a given position
 //  TensorDataType Evaluate( const PointType &point ) ;
-  TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const ITK_OVERRIDE;
+  TensorDataType EvaluateAtContinuousIndex( const ContinuousIndexType & index ) const override;
 
 protected:
 };

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DNonRigidTransform.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DNonRigidTransform.h
@@ -47,13 +47,13 @@ public:
   itkNewMacro( Self );
   // /Set the transform
   itkSetObjectMacro( Transform, TransformType );
-  TransformType::Pointer GetTransform() ITK_OVERRIDE;
+  TransformType::Pointer GetTransform() override;
 
   // /Evaluate the position of the transformed tensor in the output image
-  PointType EvaluateTensorPosition( const PointType & point ) ITK_OVERRIDE;
+  PointType EvaluateTensorPosition( const PointType & point ) override;
 
   // /Evaluate the transformed tensor
-  virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor, PointType & outputPosition ) ITK_OVERRIDE;
+  virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor, PointType & outputPosition ) override;
 
   void SetAffineTransformType(typename AffineTransform::Pointer transform);
 protected:

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DPPDAffineTransform.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DPPDAffineTransform.h
@@ -56,12 +56,12 @@ public:
 
   itkNewMacro( Self );
   using Superclass::EvaluateTransformedTensor;
-  virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor ) ITK_OVERRIDE;
+  virtual TensorDataType EvaluateTransformedTensor( TensorDataType & tensor ) override;
 
   void SetMatrix( MatrixTransformType & matrix );
 
 protected:
-  void PreCompute() ITK_OVERRIDE;
+  void PreCompute() override;
 
   InternalMatrixTransformType ComputeMatrixFromAxisAndAngle( VectorType axis, double cosangle );
 

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.h
@@ -75,7 +75,7 @@ public:
   void SetOutputParametersFromImage( InputImagePointerType Image );
 
 // /Get the time of the last modification of the object
-  unsigned long GetMTime() const ITK_OVERRIDE;
+  unsigned long GetMTime() const override;
 
   itkSetMacro( DefaultPixelValue, OutputDataType );
   itkGetMacro( DefaultPixelValue, OutputDataType );
@@ -93,15 +93,15 @@ public:
 protected:
   DiffusionTensor3DResample();
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) ITK_OVERRIDE;
+  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) override;
 
-  void BeforeThreadedGenerateData() ITK_OVERRIDE;
+  void BeforeThreadedGenerateData() override;
 
-  void GenerateOutputInformation() ITK_OVERRIDE;
+  void GenerateOutputInformation() override;
 
-  void AfterThreadedGenerateData() ITK_OVERRIDE;
+  void AfterThreadedGenerateData() override;
 
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  void GenerateInputRequestedRegion() override;
 
 private:
   typename InterpolatorType::Pointer      m_Interpolator;

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRigidTransform.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DRigidTransform.h
@@ -52,7 +52,7 @@ public:
 
   itkNewMacro( Self );
   // /Set the 3x3 rotation matrix
-  void SetMatrix3x3( MatrixTransformType & matrix ) ITK_OVERRIDE;
+  void SetMatrix3x3( MatrixTransformType & matrix ) override;
 
   void DisablePrecision();
 
@@ -62,7 +62,7 @@ protected:
   bool m_PrecisionChecking;
   double GetDet( MatrixTransformType & matrix );
 
-  void PreCompute() ITK_OVERRIDE;
+  void PreCompute() override;
 
 };
 

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DWindowedSincInterpolateImageFunction.h
@@ -51,7 +51,7 @@ public:
 
   itkNewMacro(Self);
 protected:
-  void AllocateInterpolator() ITK_OVERRIDE;
+  void AllocateInterpolator() override;
 
   typename WindowedSincInterpolateImageFunctionType::Pointer windowedSincInterpolator[6];
 };

--- a/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.h
+++ b/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.h
@@ -61,11 +61,11 @@ public:
 protected:
   SeparateComponentsOfADiffusionTensorImage();
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) ITK_OVERRIDE;
+  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) override;
 
-  void GenerateOutputInformation() ITK_OVERRIDE;
+  void GenerateOutputInformation() override;
 
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  void GenerateInputRequestedRegion() override;
 
 private:
 

--- a/Modules/CLI/ResampleDTIVolume/itkTransformDeformationFieldFilter.h
+++ b/Modules/CLI/ResampleDTIVolume/itkTransformDeformationFieldFilter.h
@@ -55,7 +55,7 @@ public:
   itkSetObjectMacro( Transform, TransformType );
 
 // /Get the time of the last modification of the object
-  unsigned long GetMTime() const ITK_OVERRIDE;
+  unsigned long GetMTime() const override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
@@ -68,13 +68,13 @@ public:
 protected:
   TransformDeformationFieldFilter();
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) ITK_OVERRIDE;
+  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) override;
 
-  void BeforeThreadedGenerateData() ITK_OVERRIDE;
+  void BeforeThreadedGenerateData() override;
 
-  void GenerateOutputInformation() ITK_OVERRIDE;
+  void GenerateOutputInformation() override;
 
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  void GenerateInputRequestedRegion() override;
 
 private:
   typename TransformType::Pointer m_Transform;

--- a/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.h
+++ b/Modules/CLI/ResampleDTIVolume/itkWarpTransform3D.h
@@ -43,26 +43,26 @@ public:
 
   /** CreateAnother method will clone the existing instance of this type,
    * including its internal member variables. */
-  virtual::itk::LightObject::Pointer CreateAnother(void) const ITK_OVERRIDE;
+  virtual::itk::LightObject::Pointer CreateAnother(void) const override;
 
   /** Run-time type information (and related methods). */
   itkTypeMacro(WarpTransform3D, Transform);
 
-  OutputPointType TransformPoint( const InputPointType & inputPoint ) const ITK_OVERRIDE;
+  OutputPointType TransformPoint( const InputPointType & inputPoint ) const override;
 
   virtual void ComputeJacobianWithRespectToParameters(const InputPointType  & p,
-      JacobianType & jacobian ) const ITK_OVERRIDE;
+      JacobianType & jacobian ) const override;
 
   virtual void ComputeJacobianWithRespectToPosition(
     const InputPointType & itkNotUsed(x),
-    JacobianType & itkNotUsed(j) ) const ITK_OVERRIDE
+    JacobianType & itkNotUsed(j) ) const override
   {
     itkExceptionMacro("ComputeJacobianWithRespectToPosition is not implemented for WarpTransform3D");
   }
 
   virtual void ComputeJacobianWithRespectToPosition(
     const InputPointType & itkNotUsed(x),
-    JacobianPositionType & itkNotUsed(j) ) const ITK_OVERRIDE
+    JacobianPositionType & itkNotUsed(j) ) const override
   {
     itkExceptionMacro("ComputeJacobianWithRespectToPosition is not implemented for WarpTransform3D");
   }
@@ -76,20 +76,20 @@ public:
 
   using Superclass::TransformVector;
   /**  Method to transform a vector. */
-  virtual OutputVectorType    TransformVector(const InputVectorType &) const ITK_OVERRIDE
+  virtual OutputVectorType    TransformVector(const InputVectorType &) const override
   {
     itkExceptionMacro("TransformVector(const InputVectorType &) is not implemented for WarpTransform3D");
   }
 
   /**  Method to transform a vnl_vector. */
-  virtual OutputVnlVectorType TransformVector(const InputVnlVectorType &) const ITK_OVERRIDE
+  virtual OutputVnlVectorType TransformVector(const InputVnlVectorType &) const override
   {
     itkExceptionMacro("TransformVector(const InputVnlVectorType &) is not implemented for WarpTransform3D");
   }
 
   using Superclass::TransformCovariantVector;
   /**  Method to transform a CovariantVector. */
-  virtual OutputCovariantVectorType TransformCovariantVector(const InputCovariantVectorType &) const  ITK_OVERRIDE
+  virtual OutputCovariantVectorType TransformCovariantVector(const InputCovariantVectorType &) const  override
   {
     itkExceptionMacro(
       "TransformCovariantVector(const InputCovariantVectorType & is not implemented for WarpTransform3D");
@@ -103,13 +103,13 @@ protected:
   /**This is a dummy function. This class does not allow to set the
    * transform parameters through this function. Use
    * SetDeformationField() to set the transform.*/
-  virtual void  SetParameters(const ParametersType &) ITK_OVERRIDE
+  virtual void  SetParameters(const ParametersType &) override
   {
   }
   /**This is a dummy function. This class does not allow to set the
    * transform fixed parameters through this function. Use
    * SetDeformationField() to set the transform */
-  virtual void  SetFixedParameters(const ParametersType &) ITK_OVERRIDE
+  virtual void  SetFixedParameters(const ParametersType &) override
   {
   }
 


### PR DESCRIPTION
This commit replaces occurences of the ITK_OVERRIDE macro with override. This one-liner
was used to perform the update:

```
git grep -l "ITK_OVERRIDE"  | fgrep -v CMakeLists.txt |fgrep -v .cmake | xargs sed -i '' -e "s/ITK_OVERRIDE/override/g"
```

It was adapted from https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/ITKv5Preparation/ReplaceITK_OVERRIDEMacroNames.sh