### PR TITLE
STYLE: Replace ITK_NULLPTR with nullptr

### DIFF
--- a/Libs/MRML/Core/vtkITKTransformConverter.h
+++ b/Libs/MRML/Core/vtkITKTransformConverter.h
@@ -248,7 +248,7 @@ bool vtkITKTransformConverter::SetITKLinearTransformFromVTK(vtkObject* loggerObj
 {
   typedef itk::AffineTransform<double, VTKDimension> AffineTransformType;
 
-  if (transformVtk_RAS==ITK_NULLPTR)
+  if (transformVtk_RAS==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject,"vtkITKTransformConverter::SetITKLinearTransformFromVTK failed: invalid input transform");
     return false;
@@ -321,7 +321,7 @@ bool vtkITKTransformConverter::SetVTKBSplineParametersFromITKGeneric(
   // this version uses the itk::BSplineTransform not the itk::BSplineDeformableTransform
   //
   typedef typename BSplineTransformType::ScalarType T;
-  if (bsplineVtk==ITK_NULLPTR)
+  if (bsplineVtk==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "vtkMRMLTransformStorageNode::SetVTKBSplineFromITKv4 failed: bsplineVtk is invalid");
     return false;
@@ -456,7 +456,7 @@ template <typename T> bool vtkITKTransformConverter::SetVTKBSplineFromITKv3Gener
   vtkOrientedBSplineTransform* bsplineVtk,
   typename itk::TransformBaseTemplate<T>::Pointer warpTransformItk, typename itk::TransformBaseTemplate<T>::Pointer bulkTransformItk)
 {
-  if (bsplineVtk==ITK_NULLPTR)
+  if (bsplineVtk==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "vtkMRMLTransformStorageNode::SetVTKBSplineFromITK failed: bsplineVtk is invalid");
     return false;
@@ -559,13 +559,13 @@ template <typename BSplineTransformType> bool vtkITKTransformConverter::SetITKBS
   typename itk::Transform< typename BSplineTransformType::ScalarType,VTKDimension,VTKDimension>::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk)
 {
   typedef typename BSplineTransformType::ScalarType T;
-  if (bsplineVtk==ITK_NULLPTR)
+  if (bsplineVtk==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "vtkMRMLTransformStorageNode::SetITKBSplineFromVTK failed: bsplineVtk is invalid");
     return false;
     }
   vtkImageData* bsplineCoefficients_RAS=bsplineVtk->GetCoefficientData();
-  if (bsplineCoefficients_RAS==ITK_NULLPTR)
+  if (bsplineCoefficients_RAS==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot write BSpline transform to file: coefficients are not specified");
     return false;
@@ -601,7 +601,7 @@ template <typename BSplineTransformType> bool vtkITKTransformConverter::SetITKBS
   transformFixedParamsItk[8]=gridSpacing[2];
 
   vtkNew<vtkMatrix4x4> gridDirectionMatrix_RAS;
-  if (bsplineVtk->GetGridDirectionMatrix()!=ITK_NULLPTR)
+  if (bsplineVtk->GetGridDirectionMatrix()!=nullptr)
     {
     gridDirectionMatrix_RAS->DeepCopy(bsplineVtk->GetGridDirectionMatrix());
     }
@@ -656,7 +656,7 @@ template <typename T> bool vtkITKTransformConverter::SetITKv3BSplineFromVTKGener
   typename itk::Transform<T,VTKDimension,VTKDimension>::Pointer& bulkTransformItk,
   vtkOrientedBSplineTransform* bsplineVtk, bool alwaysAddBulkTransform)
 {
-  if (bsplineVtk==ITK_NULLPTR)
+  if (bsplineVtk==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "vtkMRMLTransformStorageNode::SetITKBSplineFromVTK failed: bsplineVtk is invalid");
     return false;
@@ -690,7 +690,7 @@ template <typename T> bool vtkITKTransformConverter::SetITKv3BSplineFromVTKGener
     vtkNew<vtkMatrix4x4> bulkMatrix_LPS; // bulk_LPS = rasToLps * bulk_RAS * lpsToRas
     // If bulk transform is available then use it, otherwise just write an identity matrix (we just write it because
     // alwaysAddBulkTransform was requested, due to backward compatibility reasons)
-    if (bulkMatrix_RAS!=ITK_NULLPTR)
+    if (bulkMatrix_RAS!=nullptr)
       {
       vtkMatrix4x4::Multiply4x4(rasToLps.GetPointer(), bulkMatrix_RAS, bulkMatrix_LPS.GetPointer());
       vtkMatrix4x4::Multiply4x4(bulkMatrix_LPS.GetPointer(), lpsToRas.GetPointer(), bulkMatrix_LPS.GetPointer());
@@ -715,7 +715,7 @@ template <typename T> bool vtkITKTransformConverter::SetITKv3BSplineFromVTKGener
     }
   else
     {
-    bulkTransformItk=ITK_NULLPTR;
+    bulkTransformItk=nullptr;
     }
 
   return true;
@@ -749,7 +749,7 @@ template <typename T> bool vtkITKTransformConverter::SetITKv4BSplineFromVTKGener
 bool vtkITKTransformConverter::SetITKv3BSplineFromVTK(vtkObject* loggerObject, itk::Object::Pointer& warpTransformItk,
   itk::Object::Pointer& bulkTransformItk, vtkOrientedBSplineTransform* bsplineVtk, bool alwaysAddBulkTransform)
 {
-  if (bsplineVtk==ITK_NULLPTR)
+  if (bsplineVtk==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot retrieve BSpline transform from node");
     return false;
@@ -757,7 +757,7 @@ bool vtkITKTransformConverter::SetITKv3BSplineFromVTK(vtkObject* loggerObject, i
 
   vtkImageData* bsplineCoefficients=bsplineVtk->GetCoefficientData();
 
-  if (bsplineCoefficients==ITK_NULLPTR)
+  if (bsplineCoefficients==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot write BSpline transform to file: coefficients are not specified");
     return false;
@@ -801,7 +801,7 @@ bool vtkITKTransformConverter::SetITKv3BSplineFromVTK(vtkObject* loggerObject, i
 //----------------------------------------------------------------------------
 bool vtkITKTransformConverter::SetITKv4BSplineFromVTK(vtkObject* loggerObject, itk::Object::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk)
 {
-  if (bsplineVtk==ITK_NULLPTR)
+  if (bsplineVtk==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot retrieve BSpline transform from node");
     return false;
@@ -809,7 +809,7 @@ bool vtkITKTransformConverter::SetITKv4BSplineFromVTK(vtkObject* loggerObject, i
 
   vtkImageData* bsplineCoefficients=bsplineVtk->GetCoefficientData();
 
-  if (bsplineCoefficients==ITK_NULLPTR)
+  if (bsplineCoefficients==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot write BSpline transform to file: coefficients are not specified");
     return false;
@@ -855,7 +855,7 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITK(vtkObject* log
 
   if (!transformItk_LPS)
     {
-    vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK oriented grid transform from ITK: the input transform is ITK_NULLPTR");
+    vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK oriented grid transform from ITK: the input transform is nullptr");
     return false;
     }
   if (transformItk_LPS->GetOutputSpaceDimension() != VTKDimension)
@@ -868,7 +868,7 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITK(vtkObject* log
   std::string transformItkClassName = transformItk_LPS->GetNameOfClass();
 
   bool inverse = false;
-  typename DisplacementFieldTransformType::DisplacementFieldType* gridImageItk_Lps = ITK_NULLPTR;
+  typename DisplacementFieldTransformType::DisplacementFieldType* gridImageItk_Lps = nullptr;
   if (transformItkClassName == "InverseDisplacementFieldTransform") // inverse class is derived from forward class, so it has to be checked first
     {
     DisplacementFieldTransformType* inverseDisplacementFieldTransform = static_cast<InverseDisplacementFieldTransformType*>( transformItk_LPS.GetPointer() );
@@ -989,7 +989,7 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITKImage(vtkObject
 //----------------------------------------------------------------------------
 bool vtkITKTransformConverter::SetITKImageFromVTKOrientedGridTransform(vtkObject* loggerObject, GridImageDoubleType::Pointer &gridImage_Lps, vtkOrientedGridTransform* grid_Ras)
 {
-  if (grid_Ras==ITK_NULLPTR)
+  if (grid_Ras==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot save grid transform: the input vtkOrientedGridTransform is invalid");
     return false;
@@ -999,7 +999,7 @@ bool vtkITKTransformConverter::SetITKImageFromVTKOrientedGridTransform(vtkObject
   grid_Ras->Update();
 
   vtkImageData* gridImage_Ras = grid_Ras->GetDisplacementGrid();
-  if (gridImage_Ras==ITK_NULLPTR)
+  if (gridImage_Ras==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot save grid transform: the input vtkOrientedGridTransform does not contain a valid displacement grid");
     return false;
@@ -1025,7 +1025,7 @@ bool vtkITKTransformConverter::SetITKImageFromVTKOrientedGridTransform(vtkObject
 
   // Direction
   vtkNew<vtkMatrix4x4> gridDirectionMatrix_Ras;
-  if (grid_Ras->GetGridDirectionMatrix()!=ITK_NULLPTR)
+  if (grid_Ras->GetGridDirectionMatrix()!=nullptr)
     {
     gridDirectionMatrix_Ras->DeepCopy(grid_Ras->GetGridDirectionMatrix());
     }
@@ -1100,7 +1100,7 @@ bool vtkITKTransformConverter::SetVTKThinPlateSplineTransformFromITK(vtkObject* 
   typedef itk::ThinPlateSplineKernelTransform<T,3> ThinPlateSplineTransformType;
   typedef itk::InverseThinPlateSplineKernelTransform< T, 3 > InverseThinPlateSplineTransformType;
 
-  if (transformVtk_RAS==ITK_NULLPTR)
+  if (transformVtk_RAS==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK thin-plate spline transform from ITK: the output vtkThinPlateSplineTransform is invalid");
     return false;
@@ -1108,7 +1108,7 @@ bool vtkITKTransformConverter::SetVTKThinPlateSplineTransformFromITK(vtkObject* 
 
   if (!transformItk_LPS)
     {
-    vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK thin-plate spline transform from ITK: the input transform is ITK_NULLPTR");
+    vtkErrorWithObjectMacro(loggerObject, "Cannot set VTK thin-plate spline transform from ITK: the input transform is nullptr");
     return false;
     }
 
@@ -1193,7 +1193,7 @@ bool vtkITKTransformConverter::SetVTKThinPlateSplineTransformFromITK(vtkObject* 
 bool vtkITKTransformConverter::SetITKThinPlateSplineTransformFromVTK(vtkObject* loggerObject,
   itk::Object::Pointer& transformItk_LPS, vtkThinPlateSplineTransform* transformVtk_RAS, bool initialize /*= true*/)
 {
-  if (transformVtk_RAS==ITK_NULLPTR)
+  if (transformVtk_RAS==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "Cannot set ITK thin-plate spline transform from VTK: the intput vtkThinPlateSplineTransform is invalid");
     return false;
@@ -1211,7 +1211,7 @@ bool vtkITKTransformConverter::SetITKThinPlateSplineTransformFromVTK(vtkObject* 
 
   ThinPlateSplineTransformDoubleType::PointSetType::Pointer sourceLandmarksItk_Lps = ThinPlateSplineTransformDoubleType::PointSetType::New();
   vtkPoints* sourceLandmarksVtk_Ras=transformVtk_RAS->GetSourceLandmarks();
-  if (sourceLandmarksVtk_Ras!=ITK_NULLPTR)
+  if (sourceLandmarksVtk_Ras!=nullptr)
     {
     for (int i=0; i<sourceLandmarksVtk_Ras->GetNumberOfPoints(); i++)
       {
@@ -1226,7 +1226,7 @@ bool vtkITKTransformConverter::SetITKThinPlateSplineTransformFromVTK(vtkObject* 
     }
   ThinPlateSplineTransformDoubleType::PointSetType::Pointer targetLandmarksItk_Lps = ThinPlateSplineTransformDoubleType::PointSetType::New();
   vtkPoints* targetLandmarksVtk_Ras=transformVtk_RAS->GetTargetLandmarks();
-  if (targetLandmarksVtk_Ras!=ITK_NULLPTR)
+  if (targetLandmarksVtk_Ras!=nullptr)
     {
     for (int i=0; i<targetLandmarksVtk_Ras->GetNumberOfPoints(); i++)
       {
@@ -1282,7 +1282,7 @@ vtkAbstractTransform* vtkITKTransformConverter::CreateVTKTransformFromITK(
     {
     vtkNew<vtkTransform> linearTransformVtk;
     linearTransformVtk->SetMatrix(transformMatrixVtk.GetPointer());
-    linearTransformVtk->Register(ITK_NULLPTR);
+    linearTransformVtk->Register(nullptr);
     return linearTransformVtk.GetPointer();
     }
   // Grid
@@ -1290,7 +1290,7 @@ vtkAbstractTransform* vtkITKTransformConverter::CreateVTKTransformFromITK(
   conversionSuccess = SetVTKOrientedGridTransformFromITK<T>(loggerObject, gridTransformVtk.GetPointer(), transformItk);
   if (conversionSuccess)
     {
-    gridTransformVtk->Register(ITK_NULLPTR);
+    gridTransformVtk->Register(nullptr);
     return gridTransformVtk.GetPointer();
     }
   // BSpline
@@ -1298,7 +1298,7 @@ vtkAbstractTransform* vtkITKTransformConverter::CreateVTKTransformFromITK(
   conversionSuccess = SetVTKBSplineFromITKv4Generic<T>(loggerObject, bsplineTransformVtk.GetPointer(), transformItk);
   if (conversionSuccess)
     {
-    bsplineTransformVtk->Register(ITK_NULLPTR);
+    bsplineTransformVtk->Register(nullptr);
     return bsplineTransformVtk.GetPointer();
     }
   // ThinPlateSpline
@@ -1306,11 +1306,11 @@ vtkAbstractTransform* vtkITKTransformConverter::CreateVTKTransformFromITK(
   conversionSuccess = SetVTKThinPlateSplineTransformFromITK<T>(loggerObject, tpsTransformVtk.GetPointer(), transformItk);
   if (conversionSuccess)
     {
-    tpsTransformVtk->Register(ITK_NULLPTR);
+    tpsTransformVtk->Register(nullptr);
     return tpsTransformVtk.GetPointer();
     }
 
-  return ITK_NULLPTR;
+  return nullptr;
 }
 
 //----------------------------------------------------------------------------
@@ -1319,10 +1319,10 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
 {
   typedef itk::CompositeTransform< double > CompositeTransformType;
 
-  if (transformVtk==ITK_NULLPTR)
+  if (transformVtk==nullptr)
     {
     vtkErrorWithObjectMacro(loggerObject, "CreateITKTransformFromVTK failed: invalid VTK transform");
-    return ITK_NULLPTR;
+    return nullptr;
     }
   vtkNew<vtkCollection> transformList;
   vtkMRMLTransformNode::FlattenGeneralTransform(transformList.GetPointer(), transformVtk);
@@ -1346,7 +1346,7 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       if (!SetITKLinearTransformFromVTK(loggerObject, primaryTransformItk, transformMatrix))
         {
         // conversion failed
-        return ITK_NULLPTR;
+        return nullptr;
         }
       return primaryTransformItk;
       }
@@ -1355,12 +1355,12 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       {
       vtkOrientedBSplineTransform* bsplineTransformVtk = vtkOrientedBSplineTransform::SafeDownCast(singleTransformVtk);
       vtkMatrix4x4* bulkMatrix = bsplineTransformVtk->GetBulkTransformMatrix(); // non-zero for ITKv3 bspline transform only
-      if (preferITKv3CompatibleTransforms || (bulkMatrix!=ITK_NULLPTR && !IsIdentityMatrix(bulkMatrix)))
+      if (preferITKv3CompatibleTransforms || (bulkMatrix!=nullptr && !IsIdentityMatrix(bulkMatrix)))
         {
         if (!SetITKv3BSplineFromVTK(loggerObject, primaryTransformItk, secondaryTransformItk, bsplineTransformVtk, preferITKv3CompatibleTransforms))
           {
           // conversion failed
-          return ITK_NULLPTR;
+          return nullptr;
           }
         return primaryTransformItk;
         }
@@ -1369,7 +1369,7 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
         if (!SetITKv4BSplineFromVTK(loggerObject, primaryTransformItk, bsplineTransformVtk))
           {
           // conversion failed
-          return ITK_NULLPTR;
+          return nullptr;
           }
         return primaryTransformItk;
         }
@@ -1381,7 +1381,7 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       if (!SetITKOrientedGridTransformFromVTK(loggerObject, primaryTransformItk, gridTransformVtk))
         {
         // conversion failed
-        return ITK_NULLPTR;
+        return nullptr;
         }
       return primaryTransformItk;
       }
@@ -1392,19 +1392,19 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       if (!SetITKThinPlateSplineTransformFromVTK(loggerObject, primaryTransformItk, tpsTransformVtk, initialize))
         {
         // conversion failed
-        return ITK_NULLPTR;
+        return nullptr;
         }
       return primaryTransformItk;
       }
     else
       {
-      if (singleTransformVtk==ITK_NULLPTR)
+      if (singleTransformVtk==nullptr)
         {
         vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: invalid input transform");
-        return ITK_NULLPTR;
+        return nullptr;
         }
       vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: conversion of transform type "<<singleTransformVtk->GetClassName()<<" is not supported");
-      return ITK_NULLPTR;
+      return nullptr;
       }
     }
   else
@@ -1425,21 +1425,21 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       if (secondaryTransformItk.IsNotNull())
         {
         vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: composite transforms cannot contain legacy transforms (that contains secondary transforms). Do not harden transforms on legacy ITK transforms to avoid this error.");
-        return ITK_NULLPTR;
+        return nullptr;
         }
 
       if (singleTransformItk.IsNull()
           || std::string(singleTransformItk->GetNameOfClass()).find("Transform") == std::string::npos)
         {
         vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: invalid element found while trying to create a composite transform");
-        return ITK_NULLPTR;
+        return nullptr;
         }
       CompositeTransformType::TransformType::Pointer singleTransformItkTypeChecked = static_cast< CompositeTransformType::TransformType* >( singleTransformItk.GetPointer() );
       compositeTransformItk->AddTransform(singleTransformItkTypeChecked.GetPointer());
       }
     return primaryTransformItk;
     }
-  return ITK_NULLPTR;
+  return nullptr;
 }
 
 #endif // __vtkITKTransformConverter_h

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
@@ -182,7 +182,7 @@ int vtkMRMLTransformStorageNode::ReadFromITKv3BSplineTransformFile(vtkMRMLNode *
     return 0;
     }
   ++it;
-  TransformType::Pointer transform2=ITK_NULLPTR;
+  TransformType::Pointer transform2=nullptr;
   if( it != (*transforms).end() )
     {
     transform2 = (*it);
@@ -226,7 +226,7 @@ int vtkMRMLTransformStorageNode::ReadFromImageFile(vtkMRMLNode *refNode)
     return 0;
     }
 
-  GridImageDoubleType::Pointer gridImage_Lps = ITK_NULLPTR;
+  GridImageDoubleType::Pointer gridImage_Lps = nullptr;
 
   typedef itk::ImageFileReader< GridImageDoubleType >  ReaderType;
   std::string fullName =  this->GetFullNameFromFileName();

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
@@ -55,11 +55,11 @@ vtkStandardNewMacro(vtkITKArchetypeImageSeriesReader);
 //----------------------------------------------------------------------------
 vtkITKArchetypeImageSeriesReader::vtkITKArchetypeImageSeriesReader()
 {
-  this->Archetype  = ITK_NULLPTR;
+  this->Archetype  = nullptr;
   this->IndexArchetype = 0;
   this->SingleFile = 1;
   this->UseOrientationFromFile = 1;
-  this->RasToIjkMatrix = ITK_NULLPTR;
+  this->RasToIjkMatrix = nullptr;
   this->MeasurementFrameMatrix = vtkMatrix4x4::New();
   this->MeasurementFrameMatrix->Identity();
   this->SetDesiredCoordinateOrientationToAxial();
@@ -114,17 +114,17 @@ vtkITKArchetypeImageSeriesReader::~vtkITKArchetypeImageSeriesReader()
   if (this->Archetype)
     {
     delete [] this->Archetype;
-    this->Archetype = ITK_NULLPTR;
+    this->Archetype = nullptr;
     }
  if (RasToIjkMatrix)
    {
    RasToIjkMatrix->Delete();
-   RasToIjkMatrix = ITK_NULLPTR;
+   RasToIjkMatrix = nullptr;
    }
   if (MeasurementFrameMatrix)
    {
    MeasurementFrameMatrix->Delete();
-   MeasurementFrameMatrix = ITK_NULLPTR;
+   MeasurementFrameMatrix = nullptr;
    }
 
 }
@@ -184,7 +184,7 @@ void vtkITKArchetypeImageSeriesReader::PrintSelf(ostream& os, vtkIndent indent)
 //----------------------------------------------------------------------------
 int vtkITKArchetypeImageSeriesReader::CanReadFile(const char* vtkNotUsed(filename))
 {
-  if (this->Archetype == ITK_NULLPTR)
+  if (this->Archetype == nullptr)
     {
     return false;
     }
@@ -462,7 +462,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
   double origin[3];
 
 
-  itk::ImageIOBase::Pointer imageIO = ITK_NULLPTR;
+  itk::ImageIOBase::Pointer imageIO = nullptr;
 
   try
     {
@@ -548,7 +548,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
 
 
       imageIO = imageReader->GetImageIO();
-      if (imageIO.GetPointer() == ITK_NULLPTR)
+      if (imageIO.GetPointer() == nullptr)
         {
           vtkErrorMacro( "vtkITKArchetypeImageSeriesReader::ExecuteInformation: ImageIO for file " << fileNameCollapsed.c_str() << " does not exist.");
           this->SetErrorCode(vtkErrorCode::UnrecognizedFileTypeError);
@@ -696,7 +696,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
     // If there is only one file in the series
     if (this->FileNames.size() == 1)
       {
-      if (imageIO.GetPointer() == ITK_NULLPTR)
+      if (imageIO.GetPointer() == nullptr)
         {
         scalarType = VTK_SHORT; // TODO - figure out why multi-file series doesn't have an imageIO
         }
@@ -876,7 +876,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
     }
 
   int numberOfComponents = 1;
-  if (imageIO.GetPointer() != ITK_NULLPTR)
+  if (imageIO.GetPointer() != nullptr)
     {
     numberOfComponents = imageIO->GetNumberOfComponents();
     }
@@ -889,7 +889,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
                                               numberOfComponents);
 
   // Copy the MetaDataDictionary from the ITK layer to the VTK layer
-  if (imageIO.GetPointer() != ITK_NULLPTR)
+  if (imageIO.GetPointer() != nullptr)
     {
     this->Dictionary = imageIO->GetMetaDataDictionary();
     }
@@ -953,7 +953,7 @@ void vtkITKArchetypeImageSeriesReader::GetScalarRangeMetaDataKeys(itk::ImageIOBa
 //----------------------------------------------------------------------------
 void vtkITKArchetypeImageSeriesReader::SetMetaDataScalarRangeToPointDataInfo( vtkImageData* data )
 {
-    if (data == ITK_NULLPTR)
+    if (data == nullptr)
       {
       vtkWarningMacro("No image data specified, can't set scalar range information.")
       return;
@@ -977,8 +977,8 @@ void vtkITKArchetypeImageSeriesReader::SetMetaDataScalarRangeToPointDataInfo( vt
 
     // Check that scalar info exists
     vtkDataArray* scalars = data->GetPointData()->GetScalars();
-    vtkInformation* scalarInfo = scalars ? scalars->GetInformation() : ITK_NULLPTR;
-    if (scalarInfo == ITK_NULLPTR)
+    vtkInformation* scalarInfo = scalars ? scalars->GetInformation() : nullptr;
+    if (scalarInfo == nullptr)
       {
       return;
       }
@@ -1016,7 +1016,7 @@ void vtkITKArchetypeImageSeriesReader::AssembleNthVolume ( int n )
   for (unsigned int k = 0; k < nSlices; k++)
   {
     const char* name = GetNthFileName( 0, -1, -1, -1, 0, k, 0, n );
-    if (name == ITK_NULLPTR)
+    if (name == nullptr)
     {
       continue;
     }
@@ -1080,7 +1080,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetNthFileName ( int idxSeriesInst
       }
     }
   }
-  return ITK_NULLPTR;
+  return nullptr;
 }
 
 //----------------------------------------------------------------------------
@@ -1399,7 +1399,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetNthKey( unsigned int n )
 {
   if (n >= this->Tags.size())
   {
-    return ITK_NULLPTR;
+    return nullptr;
   }
   return this->Tags[n].c_str();
 }
@@ -1409,7 +1409,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetNthValue( unsigned int n )
 {
   if (n >= this->TagValues.size())
   {
-    return ITK_NULLPTR;
+    return nullptr;
   }
   return this->TagValues[n].c_str();
 }
@@ -1425,7 +1425,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetTagValue( char* tag )
       return this->TagValues[k].c_str();
     }
   }
-  return ITK_NULLPTR;
+  return nullptr;
 }
 
 //----------------------------------------------------------------------------
@@ -1433,7 +1433,7 @@ const char* vtkITKArchetypeImageSeriesReader::GetFileName( unsigned int n )
 {
   if ( n >= this->GetNumberOfFileNames() )
   {
-    return ITK_NULLPTR;
+    return nullptr;
   }
 
   return this->FileNames[n].c_str();

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationHelper.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationHelper.txx
@@ -753,7 +753,7 @@ ImageToImageRegistrationHelper<TImage>
   typedef ResampleImageFilter<TImage, TImage, double>
   ResampleImageFilterType;
 
-  typename InterpolatorType::Pointer interpolator = ITK_NULLPTR;
+  typename InterpolatorType::Pointer interpolator = nullptr;
 
   switch( interpolationMethod )
     {

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationMethod.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageToImageRegistrationMethod.txx
@@ -29,7 +29,7 @@ ImageToImageRegistrationMethod<TImage>
 {
   this->SetNumberOfRequiredOutputs( 1 ); // the transform
 
-  this->m_Transform = ITK_NULLPTR;
+  this->m_Transform = nullptr;
   typename TransformOutputType::Pointer transformDecorator =
     static_cast<TransformOutputType *>
     ( this->MakeOutput(static_cast<DataObjectPointerArraySizeType>(0)).GetPointer() );
@@ -39,13 +39,13 @@ ImageToImageRegistrationMethod<TImage>
   this->m_RegistrationNumberOfThreads = this->GetNumberOfThreads();
   this->GetMultiThreader()->SetNumberOfThreads( this->m_RegistrationNumberOfThreads );
 
-  this->m_FixedImage = ITK_NULLPTR;
-  this->m_MovingImage = ITK_NULLPTR;
+  this->m_FixedImage = nullptr;
+  this->m_MovingImage = nullptr;
   this->m_UseFixedImageMaskObject = false;
-  this->m_FixedImageMaskObject = ITK_NULLPTR;
+  this->m_FixedImageMaskObject = nullptr;
   this->m_UseMovingImageMaskObject = false;
-  this->m_MovingImageMaskObject = ITK_NULLPTR;
-  this->m_Observer = ITK_NULLPTR;
+  this->m_MovingImageMaskObject = nullptr;
+  this->m_Observer = nullptr;
   this->m_ReportProgress = false;
 
   this->m_UseRegionOfInterest = false;
@@ -164,7 +164,7 @@ ImageToImageRegistrationMethod<TImage>
     default:
       itkExceptionMacro(
         "MakeOutput request for an output number larger than the expected number of outputs" );
-      return ITK_NULLPTR;
+      return nullptr;
     }
 }
 

--- a/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
+++ b/Modules/CLI/N4ITKBiasFieldCorrection/N4ITKBiasFieldCorrection.cxx
@@ -67,10 +67,10 @@ int main(int argc, char* * argv)
 
   PARSE_ARGS;
 
-  ImageType::Pointer inputImage = ITK_NULLPTR;
+  ImageType::Pointer inputImage = nullptr;
 
   typedef itk::Image<unsigned char, ImageDimension> MaskImageType;
-  MaskImageType::Pointer maskImage = ITK_NULLPTR;
+  MaskImageType::Pointer maskImage = nullptr;
 
   typedef    itk::N4BiasFieldCorrectionImageFilter<ImageType, MaskImageType, ImageType> CorrecterType;
   CorrecterType::Pointer correcter = CorrecterType::New();
@@ -126,7 +126,7 @@ int main(int argc, char* * argv)
     maskImage = otsu->GetOutput();
     }
 
-  ImageType::Pointer weightImage = ITK_NULLPTR;
+  ImageType::Pointer weightImage = nullptr;
 
   if( weightImageName != "" )
     {

--- a/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
+++ b/Modules/CLI/ResampleDTIVolume/ResampleDTIVolume.cxx
@@ -326,7 +326,7 @@ ComputeTransformMatrix( const parameters & list,
 
 template <class PixelType>
 typename itk::DiffusionTensor3DAffineTransform<PixelType>::Pointer
-FSOrPPD( const std::string & ppd, itk::Matrix<double, 4, 4> *matrix = ITK_NULLPTR )
+FSOrPPD( const std::string & ppd, itk::Matrix<double, 4, 4> *matrix = nullptr )
 {
   typedef itk::DiffusionTensor3DFSAffineTransform<PixelType>
   FSAffineTransformType;
@@ -466,7 +466,7 @@ SetTransformAndOrder( parameters & list,
             {
             std::cerr << "Transformation type not yet implemented for tensors"
                       << std::endl;
-            return ITK_NULLPTR;
+            return nullptr;
             }
           }
       }
@@ -477,7 +477,7 @@ SetTransformAndOrder( parameters & list,
         {
         std::cerr << "Error in the file containing the transformation"
                   << std::endl;
-        return ITK_NULLPTR;
+        return nullptr;
         }
       }
     }

--- a/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
+++ b/Modules/CLI/ResampleScalarVectorDWIVolume/ResampleScalarVectorDWIVolume.cxx
@@ -247,7 +247,7 @@ SetUpTransform( parameters & list,
           }
         else
           {
-          return ITK_NULLPTR;
+          return nullptr;
           }
         }
       }
@@ -340,7 +340,7 @@ SetTransformAndOrder( parameters & list,
             {
             std::cerr << "Transformation type not yet implemented"
                       << std::endl;
-            return ITK_NULLPTR;
+            return nullptr;
             }
           }
       }
@@ -351,7 +351,7 @@ SetTransformAndOrder( parameters & list,
         {
         std::cerr << "Error in the file containing the matrix transformation"
                   << std::endl;
-        return ITK_NULLPTR;
+        return nullptr;
         }
       }
     }
@@ -368,7 +368,7 @@ SetTransform( parameters & list,
               )
 {
   typedef itk::Transform<double, 3, 3> TransformType;
-  typename TransformType::Pointer transform = ITK_NULLPTR;
+  typename TransformType::Pointer transform = nullptr;
   if( list.transformationFile.compare( "" ) ) // Get transformation matrix from command line if no file given
     {
     if( !list.transformsOrder.compare( "input-to-output" ) )
@@ -500,7 +500,7 @@ SetAllTransform( parameters & list,
   if( nonRigidTransforms < 0 ) // The transform file contains a transform that is not handled by ResampleVolume2, it
                                // exits.
     {
-    return ITK_NULLPTR;
+    return nullptr;
     }
   if( list.deffield.compare( "" ) )
     {
@@ -642,7 +642,7 @@ SetAllTransform( parameters & list,
         std::cerr
         << "An affine or rigid transform was not convertible to itk::MatrixOffsetTransformBase< double , 3 , 3 >"
         << std::endl;
-        return ITK_NULLPTR;
+        return nullptr;
         }
       typename MatrixTransformType::Pointer localTransform;
       localTransform = static_cast<MatrixTransformType *>(transform.GetPointer() );
@@ -952,19 +952,19 @@ Transform3DPointer InverseTransform( const Transform3DPointer & transform )
         }
       else
         {
-        inverseTransform = ITK_NULLPTR;
+        inverseTransform = nullptr;
         }
       }
     }
   catch( ... )
     {
     std::cerr << "Exception Detected" << std::endl;
-    inverseTransform = ITK_NULLPTR;
+    inverseTransform = nullptr;
     }
   return inverseTransform;
 }
 
-// Read Measurement Frame and set it to identity if inverseTransform is not ITK_NULLPTR
+// Read Measurement Frame and set it to identity if inverseTransform is not nullptr
 itk::Matrix<double, 3, 3>
 ReadMeasurementFrame( itk::MetaDataDictionary & dico, const Transform3DPointer & inverseTransform )
 {


### PR DESCRIPTION
This commit replaces occurences of the ITK_NULLPTR macro with nullptr. This one-liner 
was used to perform the update:

```
git grep -l "ITK_NULLPTR" | fgrep -v CMakeLists.txt |fgrep -v .cmake | xargs sed -i '' -e "s/ITK_NULLPTR/nullptr/g"
```
It was adapted from https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/ITKv5Preparation/ReplaceITK_NULLPTRMacroNames.sh

Updated information can be found in the wiki:
 https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide/ObsoleteCodeRemoval#C.2B.2B11:_Update_source_code_to_use_nullptr