### PR TITLE
BUG: Fix MRML scene undo/redo mechanism

### DIFF
--- a/Base/Logic/vtkSlicerFiducialsLogic.cxx
+++ b/Base/Logic/vtkSlicerFiducialsLogic.cxx
@@ -87,7 +87,6 @@ void vtkSlicerFiducialsLogic::AddFiducialListSelected()
             this->GetMRMLScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton"));
   if (selnode && node)
     {
-    this->GetMRMLScene()->SaveStateForUndo(selnode);
     selnode->SetActiveFiducialListID(node->GetID());
     }
   else
@@ -99,8 +98,6 @@ void vtkSlicerFiducialsLogic::AddFiducialListSelected()
 //----------------------------------------------------------------------------
 vtkMRMLFiducialListNode *vtkSlicerFiducialsLogic::AddFiducialList()
 {
-  this->GetMRMLScene()->SaveStateForUndo();
-
   vtkSmartPointer<vtkMRMLNode> node = vtkSmartPointer<vtkMRMLNode>::Take(
     this->GetMRMLScene()->CreateNodeByClass("vtkMRMLFiducialListNode"));
   vtkMRMLFiducialListNode* fiducialListNode = vtkMRMLFiducialListNode::SafeDownCast(node);
@@ -144,7 +141,6 @@ int vtkSlicerFiducialsLogic::AddFiducialSelected (float x, float y, float z, int
     }
 
   // add a fiducial to the selected list
-  this->GetMRMLScene()->SaveStateForUndo(flist);
   vtkDebugMacro("AddFiducialSelected: calling add fiducial on list " << flist->GetName());
   index = flist->AddFiducialWithXYZ(x, y, z, selected);
   if (index < 0)
@@ -198,8 +194,6 @@ int vtkSlicerFiducialsLogic::AddFiducialPicked (float x, float y, float z, int s
 //----------------------------------------------------------------------------
 vtkMRMLFiducialListNode *vtkSlicerFiducialsLogic::LoadFiducialList(const char* path)
 {
-  this->GetMRMLScene()->SaveStateForUndo();
-
   vtkSmartPointer<vtkMRMLNode> node = vtkSmartPointer<vtkMRMLNode>::Take(
     this->GetMRMLScene()->CreateNodeByClass("vtkMRMLFiducialListNode"));
   vtkMRMLFiducialListNode *listNode = vtkMRMLFiducialListNode::SafeDownCast(node);

--- a/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFiducialListNode.cxx
@@ -1812,11 +1812,6 @@ void vtkMRMLFiducialListNode::RenumberFiducials(int startFrom)
     return;
     }
 
-  // save state for undo
-  if (this->GetScene())
-    {
-    this->GetScene()->SaveStateForUndo(this);
-    }
   for (int p = 0, n = startFrom; p < this->GetNumberOfFiducials(); p++, n++)
     {
     std::string oldName = this->GetNthFiducialLabelText(p);
@@ -1843,11 +1838,6 @@ void vtkMRMLFiducialListNode::RenameFiducials(const char *newName)
     return;
     }
 
-  // save state for undo
-  if (this->GetScene())
-    {
-    this->GetScene()->SaveStateForUndo(this);
-    }
   for (int p = 0; p < this->GetNumberOfFiducials(); p++)
     {
     std::string oldName = this->GetNthFiducialLabelText(p);

--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -48,7 +48,7 @@ vtkMRMLNode::vtkMRMLNode()
   , SingletonTag(NULL)
   , DisableModifiedEvent(0)
   , ModifiedEventPending(0)
-
+  , UndoEnabled(false)
 {
   // Set up callbacks
   this->MRMLCallbackCommand = vtkCallbackCommand::New();
@@ -133,7 +133,7 @@ void vtkMRMLNode::Copy(vtkMRMLNode *node)
     {
     vtkMRMLCopyStringMacro(SingletonTag);
     }
-
+  vtkMRMLCopyBooleanMacro(UndoEnabled);
   vtkMRMLCopyEndMacro();
 
   this->Attributes = node->Attributes;
@@ -303,6 +303,7 @@ void vtkMRMLNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(HideFromEditors);
   vtkMRMLPrintBooleanMacro(Selectable);
   vtkMRMLPrintBooleanMacro(Selected);
+  vtkMRMLPrintBooleanMacro(UndoEnabled)
   vtkMRMLPrintEndMacro();
 
   if (!this->Attributes.empty())
@@ -363,6 +364,7 @@ void vtkMRMLNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(selectable, Selectable);
   vtkMRMLReadXMLBooleanMacro(selected, Selected);
   vtkMRMLReadXMLStringMacro(singletonTag, SingletonTag);
+  vtkMRMLReadXMLBooleanMacro(undoEnabled, UndoEnabled)
   vtkMRMLReadXMLEndMacro();
 
   std::map<std::string, std::string> references;
@@ -469,6 +471,12 @@ void vtkMRMLNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(selectable, Selectable);
   vtkMRMLWriteXMLBooleanMacro(selected, Selected);
   vtkMRMLWriteXMLStringMacro(singletonTag, SingletonTag);
+  if (this->UndoEnabled)
+    {
+    // Only write out UndoEnabled flag in case of non-default value is used,
+    // to keep the written XML file cleaner.
+    vtkMRMLWriteXMLBooleanMacro(undoEnabled, UndoEnabled);
+    }
   vtkMRMLWriteXMLEndMacro();
 
   if (this->Attributes.size())

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -319,6 +319,14 @@ public:
   vtkSetMacro(Selectable, int);
   vtkBooleanMacro(Selectable, int);
 
+  /// Specifies if the state of this node stored in the scene's undo buffer.
+  /// False by default to make sure that undo can be enabled selectively,
+  /// only for nodes that are prepared to work correctly when saved/restored.
+  /// Nodes with different UndoEnabled value must not reference to each other,
+  /// because restoring states could lead to unresolved node references.
+  vtkGetMacro(UndoEnabled, bool);
+  vtkSetMacro(UndoEnabled, bool);
+  vtkBooleanMacro(UndoEnabled, bool);
 
   /// Propagate events generated in mrml.
   virtual void ProcessMRMLEvents ( vtkObject *caller, unsigned long event, void *callData );
@@ -893,6 +901,7 @@ protected:
   int Selectable;
   int Selected;
   int AddToScene;
+  bool UndoEnabled;
 
   int  SaveWithScene;
 

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -117,9 +117,8 @@ vtkMRMLScene::vtkMRMLScene()
   this->UniqueNames.clear();
 
   this->Nodes =  vtkCollection::New();
-  this->UndoStackSize = 100;
+  this->MaximumNumberOfSavedUndoStates = 20;
   this->UndoFlag = false;
-  this->InUndo = false;
 
   this->NodeReferences.clear();
   this->ReferencedIDChanges.clear();
@@ -1286,13 +1285,60 @@ vtkMRMLNode* vtkMRMLScene::AddNewNodeByClass(
 }
 
 //------------------------------------------------------------------------------
+vtkMRMLNode* vtkMRMLScene::AddNewNodeByClassWithID(std::string className, std::string nodeBaseName, std::string nodeID)
+{
+  if (className.empty())
+    {
+    vtkErrorMacro("AddNewNodeByClassWithID: className is an emptry string");
+    return NULL;
+    }
+
+  if (nodeID.empty())
+    {
+    vtkErrorMacro("AddNewNodeByClassWithID: nodeID is an emptry string");
+    return NULL;
+    }
+
+  bool isUnique = ((this->GetNodeByID(nodeID) == 0) &&
+                   (!this->IsReservedID(nodeID)) &&
+                   (!this->IsNodeIDReservedByUndo(nodeID)));
+  if (!isUnique)
+    {
+    vtkErrorMacro("AddNewNodeByClassWithID: nodeID is already in use");
+    return NULL;
+    }
+
+  if (this->NodeIDs.find(nodeID) != this->NodeIDs.end())
+    {
+    vtkErrorMacro("AddNewNodeByClassWithID: node already exists with ID - " << nodeID);
+    return NULL;
+    }
+
+  vtkSmartPointer<vtkMRMLNode> nodeToAdd =
+    vtkSmartPointer<vtkMRMLNode>::Take(this->CreateNodeByClass(className.c_str()));
+  if (nodeToAdd == NULL)
+    {
+    vtkErrorMacro("AddNewNodeByClassWithID: failed to create node by class " << className);
+    return NULL;
+    }
+
+  nodeToAdd->SetID(nodeID.c_str());
+  if (!nodeBaseName.empty())
+    {
+    nodeToAdd->SetName(nodeBaseName.c_str());
+    }
+
+  return this->AddNode(nodeToAdd);
+}
+
+//------------------------------------------------------------------------------
 void vtkMRMLScene::NodeAdded(vtkMRMLNode *n)
 {
   this->InvokeEvent(this->NodeAddedEvent, n);
 }
 
 //------------------------------------------------------------------------------
-vtkMRMLNode*  vtkMRMLScene::CopyNode(vtkMRMLNode *n)
+vtkMRMLNode* vtkMRMLScene::CopyNode(vtkMRMLNode *n)
 {
    if (!n)
     {
@@ -2211,9 +2257,70 @@ int vtkMRMLScene::GetUniqueIDIndex(const std::string& baseID)
     std::string candidateID = this->BuildID(baseID, index);
     isUnique =
       (this->GetNodeByID(candidateID) == 0) &&
-      (!this->IsReservedID(candidateID));
+      (!this->IsReservedID(candidateID)) &&
+      (!this->IsNodeIDReservedByUndo(candidateID));
     }
   return index;
+}
+
+//------------------------------------------------------------------------------
+bool vtkMRMLScene::IsNodeIDReservedByUndo(const std::string id) const
+{
+  NodeReferencesType::const_iterator referenceIt = this->NodeReferences.find(id);
+  if (referenceIt != this->NodeReferences.end())
+    {
+    // ID is referenced by a node in the scene.
+    // It cannot be reserved by undo.
+    return false;
+    }
+
+  std::set<std::string> undoReferenceIDs;
+  this->GetNodeReferenceIDsFromUndoStack(undoReferenceIDs);
+  if (undoReferenceIDs.find(id) != undoReferenceIDs.end())
+    {
+    return true;
+    }
+
+  return false;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLScene::GetNodeReferenceIDsFromUndoStack(std::set<std::string>& referenceIDs) const
+{
+  referenceIDs.clear();
+
+  std::list<vtkCollection*>::const_iterator undoStackIt;
+  for (undoStackIt = this->UndoStack.begin(); undoStackIt != this->UndoStack.end(); ++undoStackIt)
+    {
+    vtkCollection* nodes = *undoStackIt;
+    for (int i = 0; i < nodes->GetNumberOfItems(); ++i)
+      {
+      vtkMRMLNode* node = vtkMRMLNode::SafeDownCast(nodes->GetItemAsObject(i));
+      if (!node)
+        {
+        continue;
+        }
+
+      std::vector<std::string> roles;
+      node->GetNodeReferenceRoles(roles);
+      std::vector<std::string>::iterator roleIt;
+      for (roleIt = roles.begin(); roleIt != roles.end(); ++roleIt)
+        {
+        std::string role = *roleIt;
+        std::vector<const char*> currentReferenceIDs;
+        node->GetNodeReferenceIDs(role.c_str(), currentReferenceIDs);
+        std::vector<const char*>::iterator referenceIDIt;
+        for (referenceIDIt = currentReferenceIDs.begin(); referenceIDIt != currentReferenceIDs.end(); ++referenceIDIt)
+          {
+          if (!(*referenceIDIt))
+            {
+            continue;
+            }
+          referenceIDs.insert(*referenceIDIt);
+          }
+        }
+      }
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -2332,7 +2439,7 @@ void vtkMRMLScene::SaveStateForUndo (vtkMRMLNode *node)
     return;
     }
 
-  if (this->InUndo)
+  if (this->IsUndoing())
     {
     return;
     }
@@ -2342,10 +2449,15 @@ void vtkMRMLScene::SaveStateForUndo (vtkMRMLNode *node)
     return;
     }
 
+  if (!node->GetUndoEnabled())
+    {
+    return;
+    }
+
   this->ClearRedoStack();
   //this->SetUndoOn();
   this->PushIntoUndoStack();
-  if ( node && !node->IsA("vtkMRMLSceneViewNode"))
+  if (node)
     {
     this->CopyNodeInUndoStack(node);
     }
@@ -2359,7 +2471,7 @@ void vtkMRMLScene::SaveStateForUndo (std::vector<vtkMRMLNode *> nodes)
     return;
     }
 
-  if (this->InUndo )
+  if (this->IsUndoing())
     {
     return;
     }
@@ -2375,7 +2487,7 @@ void vtkMRMLScene::SaveStateForUndo (std::vector<vtkMRMLNode *> nodes)
   for (n=0; n<nodes.size(); n++)
     {
     vtkMRMLNode *node = nodes[n];
-    if (node && !node->IsA("vtkMRMLSceneViewNode"))
+    if (node && node->GetUndoEnabled())
       {
       this->CopyNodeInUndoStack(node);
       }
@@ -2390,7 +2502,7 @@ void vtkMRMLScene::SaveStateForUndo (vtkCollection* nodes)
     return;
     }
 
-  if (this->InUndo)
+  if (this->IsUndoing())
     {
     return;
     }
@@ -2413,8 +2525,8 @@ void vtkMRMLScene::SaveStateForUndo (vtkCollection* nodes)
 
   for (int n=0; n<nnodes; n++)
     {
-    vtkMRMLNode *node  = dynamic_cast < vtkMRMLNode *>(nodes->GetItemAsObject(n));
-    if (node && !node->IsA("vtkMRMLSceneViewNode"))
+    vtkMRMLNode *node  = vtkMRMLNode::SafeDownCast(nodes->GetItemAsObject(n));
+    if (node && node->GetUndoEnabled())
       {
       this->CopyNodeInUndoStack(node);
       }
@@ -2456,15 +2568,15 @@ void vtkMRMLScene::PushIntoUndoStack()
 
   for (int n=0; n<nnodes; n++)
     {
-    vtkMRMLNode *node  = dynamic_cast < vtkMRMLNode *>(currentScene->GetItemAsObject(n));
-    if (node && !node->IsA("vtkMRMLSceneViewNode"))
+    vtkMRMLNode *node  = vtkMRMLNode::SafeDownCast(currentScene->GetItemAsObject(n));
+    if (node && node->GetUndoEnabled())
       {
       newScene->AddItem(node);
       }
     }
 
-  //TODO check max stack size
   this->UndoStack.push_back(newScene);
+  this->TrimUndoStack();
 }
 
 //------------------------------------------------------------------------------
@@ -2484,14 +2596,13 @@ void vtkMRMLScene::PushIntoRedoStack()
 
   for (int n=0; n<nnodes; n++)
     {
-    vtkMRMLNode *node  = dynamic_cast < vtkMRMLNode *>(currentScene->GetItemAsObject(n));
-    if (node && !node->IsA("vtkMRMLSceneViewNode"))
+    vtkMRMLNode *node  = vtkMRMLNode::SafeDownCast(currentScene->GetItemAsObject(n));
+    if (node && node->GetUndoEnabled())
       {
       newScene->AddItem(node);
       }
     }
 
-  //TODO check max stack size
   this->RedoStack.push_back(newScene);
 }
 
@@ -2511,11 +2622,12 @@ void vtkMRMLScene::CopyNodeInUndoStack(vtkMRMLNode *copyNode)
     {
     snode->CopyWithScene(copyNode);
     }
-  vtkCollection* undoScene = dynamic_cast < vtkCollection *>( this->UndoStack.back() );
+
+  vtkCollection* undoScene = this->UndoStack.back();
   int nnodes = undoScene->GetNumberOfItems();
   for (int n=0; n<nnodes; n++)
     {
-    vtkMRMLNode *node  = dynamic_cast < vtkMRMLNode *>(undoScene->GetItemAsObject(n));
+    vtkMRMLNode *node  = vtkMRMLNode::SafeDownCast(undoScene->GetItemAsObject(n));
     if (node == copyNode)
       {
       undoScene->ReplaceItem (n, snode);
@@ -2540,11 +2652,11 @@ void vtkMRMLScene::CopyNodeInRedoStack(vtkMRMLNode *copyNode)
     {
     snode->CopyWithSceneWithSingleModifiedEvent(copyNode);
     }
-  vtkCollection* undoScene = dynamic_cast < vtkCollection *>( this->RedoStack.back() );
+  vtkCollection* undoScene = this->RedoStack.back();
   int nnodes = undoScene->GetNumberOfItems();
   for (int n=0; n<nnodes; n++)
     {
-    vtkMRMLNode *node  = dynamic_cast < vtkMRMLNode *>(undoScene->GetItemAsObject(n));
+    vtkMRMLNode *node  = vtkMRMLNode::SafeDownCast(undoScene->GetItemAsObject(n));
     if (node == copyNode)
       {
       undoScene->ReplaceItem (n, snode);
@@ -2569,15 +2681,14 @@ void vtkMRMLScene::Undo()
     return;
     }
 
+  this->StartState(vtkMRMLScene::UndoState);
   this->RemoveUnusedNodeReferences();
-
-  this->InUndo = true;
 
   int nnodes;
   int n;
   unsigned int nn;
 
-  PushIntoRedoStack();
+  this->PushIntoRedoStack();
 
   vtkCollection* currentScene = this->Nodes;
   // We use 2 vectors instead of a map in order to keep the ordering of the
@@ -2587,8 +2698,8 @@ void vtkMRMLScene::Undo()
   nnodes = currentScene->GetNumberOfItems();
   for (n=0; n<nnodes; n++)
     {
-    vtkMRMLNode *node  = dynamic_cast < vtkMRMLNode *>(currentScene->GetItemAsObject(n));
-    if (node && !node->IsA("vtkMRMLSceneViewNode"))
+    vtkMRMLNode *node  = vtkMRMLNode::SafeDownCast(currentScene->GetItemAsObject(n));
+    if (node && node->GetUndoEnabled())
       {
       currentIDs.push_back(node->GetID());
       currentNodes.push_back(node);
@@ -2601,12 +2712,12 @@ void vtkMRMLScene::Undo()
 
   if (!this->UndoStack.empty())
     {
-    undoScene = dynamic_cast < vtkCollection *>( this->UndoStack.back() );
+    undoScene = this->UndoStack.back();
     nnodes = undoScene->GetNumberOfItems();
     for (n=0; n<nnodes; n++)
       {
-      vtkMRMLNode *node  = dynamic_cast < vtkMRMLNode *>(undoScene->GetItemAsObject(n));
-      if (node && !node->IsA("vtkMRMLSceneViewNode"))
+      vtkMRMLNode *node  = vtkMRMLNode::SafeDownCast(undoScene->GetItemAsObject(n));
+      if (node && node->GetUndoEnabled())
         {
         undoIDs.push_back(node->GetID());
         undoNodes.push_back(node);
@@ -2628,7 +2739,7 @@ void vtkMRMLScene::Undo()
     curIterNode = currentNodes.begin() + std::distance(currentIDs.begin(), curIterID);
     if ( curIterID == currentIDs.end() )
       {
-      // the node was deleted, add Node back to the curreent scene
+      // the node was deleted, add Node back to the current scene
       addNodes.push_back(*iterNode);
       }
     else if (*iterNode != *curIterNode)
@@ -2655,6 +2766,7 @@ void vtkMRMLScene::Undo()
   for (nn=0; nn<addNodes.size(); nn++)
     {
     this->AddNode(addNodes[nn]);
+    addNodes[nn]->SetSceneReferences();
     }
   for (nn=0; nn<removeNodes.size(); nn++)
     {
@@ -2673,15 +2785,17 @@ void vtkMRMLScene::Undo()
     undoScene->Delete();
     }
 
-  this->RemoveUnusedNodeReferences();
-
   if (!this->UndoStack.empty())
    {
-   UndoStack.pop_back();
+   this->UndoStack.pop_back();
    }
   this->Modified();
 
-  this->InUndo = false;
+  this->EndState(vtkMRMLScene::UndoState);
+
+  // Some untracked nodes may need to be restored to the scene after undo has completed
+  // Do not remove unused node references until these nodes have been added
+  this->RemoveUnusedNodeReferences();
 }
 
 //------------------------------------------------------------------------------
@@ -2701,56 +2815,66 @@ void vtkMRMLScene::Redo()
   int n;
   unsigned int nn;
 
+  this->StartState(vtkMRMLScene::RedoState);
+
   this->RemoveUnusedNodeReferences();
 
-  PushIntoUndoStack();
+  this->PushIntoUndoStack();
+
 
   vtkCollection* currentScene = this->Nodes;
   //std::hash_map<std::string, vtkMRMLNode*> currentMap;
-  std::map<std::string, vtkMRMLNode*> currentMap;
+  std::map<std::string, vtkWeakPointer<vtkMRMLNode> > currentMap;
   nnodes = currentScene->GetNumberOfItems();
   for (n=0; n<nnodes; n++)
     {
-    vtkMRMLNode *node  = dynamic_cast < vtkMRMLNode *>(currentScene->GetItemAsObject(n));
-    if (node && !node->IsA("vtkMRMLSceneViewNode"))
+    vtkMRMLNode *node  = vtkMRMLNode::SafeDownCast(currentScene->GetItemAsObject(n));
+    if (node && node->GetUndoEnabled())
       {
       currentMap[node->GetID()] = node;
       }
     }
 
   //std::hash_map<std::string, vtkMRMLNode*> undoMap;
-  std::map<std::string, vtkMRMLNode*> undoMap;
+  std::map<std::string, vtkWeakPointer<vtkMRMLNode> > undoMap;
 
   vtkCollection* undoScene = NULL;
 
   if (!this->RedoStack.empty())
     {
-    undoScene = dynamic_cast < vtkCollection *>( this->RedoStack.back() );;
-    nnodes = undoScene->GetNumberOfItems();
-    for (n=0; n<nnodes; n++)
+    undoScene = this->RedoStack.back();
+    if (undoScene)
       {
-      vtkMRMLNode *node  = dynamic_cast < vtkMRMLNode *>(undoScene->GetItemAsObject(n));
-      if (node && !node->IsA("vtkMRMLSceneViewNode"))
+      nnodes = undoScene->GetNumberOfItems();
+      for (n = 0; n < nnodes; n++)
         {
-        undoMap[node->GetID()] = node;
+        vtkMRMLNode *node = vtkMRMLNode::SafeDownCast(undoScene->GetItemAsObject(n));
+        if (node && node->GetUndoEnabled())
+          {
+          undoMap[node->GetID()] = node;
+          }
         }
       }
     }
 
   //std::hash_map<std::string, vtkMRMLNode*>::iterator iter;
   //std::hash_map<std::string, vtkMRMLNode*>::iterator curIter;
-  std::map<std::string, vtkMRMLNode*>::iterator iter;
-  std::map<std::string, vtkMRMLNode*>::iterator curIter;
+  std::map<std::string, vtkWeakPointer<vtkMRMLNode> >::iterator iter;
+  std::map<std::string, vtkWeakPointer<vtkMRMLNode> >::iterator curIter;
 
   // copy back changes and add deleted nodes to the current scene
-  std::vector<vtkMRMLNode*> addNodes;
-
+  std::vector<vtkWeakPointer<vtkMRMLNode> > addNodes;
   for(iter=undoMap.begin(); iter != undoMap.end(); iter++)
     {
     curIter = currentMap.find(iter->first);
+    if (!curIter->second || !iter->second)
+      {
+      continue;
+      }
+
     if ( curIter == currentMap.end() )
       {
-      // the node was deleted, add Node back to the curreent scene
+      // the node was deleted, add Node back to the current scene
       addNodes.push_back(iter->second);
       }
     else if (iter->second != curIter->second)
@@ -2763,12 +2887,18 @@ void vtkMRMLScene::Redo()
     }
 
   // remove new nodes created before Undo
-  std::vector<vtkMRMLNode*> removeNodes;
+  std::vector<vtkWeakPointer<vtkMRMLNode> > removeNodes;
   for(curIter=currentMap.begin(); curIter != currentMap.end(); curIter++)
     {
+    if (!curIter->second)
+      {
+      continue;
+      }
+
     iter = undoMap.find(curIter->first);
     if ( iter == undoMap.end() )
       {
+      this->CopyNodeInUndoStack(curIter->second);
       removeNodes.push_back(curIter->second);
       }
     }
@@ -2787,10 +2917,10 @@ void vtkMRMLScene::Redo()
     undoScene->RemoveAllItems();
     undoScene->Delete();
     }
-
-  RedoStack.pop_back();
-
+  this->RedoStack.pop_back();
   this->Modified();
+
+  this->EndState(vtkMRMLScene::RedoState);
 }
 
 //------------------------------------------------------------------------------
@@ -3475,4 +3605,33 @@ const char* vtkMRMLScene::GetNthReferencedID(int n)
     n-=referenceIt->second.size();
     }
   return NULL;
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLScene::SetMaximumNumberOfSavedUndoStates(int stackSize)
+{
+  if (stackSize == this->MaximumNumberOfSavedUndoStates)
+    {
+    return;
+    }
+
+  if (stackSize < 0)
+    {
+    vtkErrorMacro("Cannot set maximum stack size to be a value less than 0");
+    }
+
+  this->MaximumNumberOfSavedUndoStates = stackSize;
+  this->TrimUndoStack();
+  this->Modified();
+}
+
+//-----------------------------------------------------------------------------
+void vtkMRMLScene::TrimUndoStack()
+{
+  std::list<vtkSmartPointer<vtkCollection> > removedStacks;
+  while(this->UndoStack.size() > this->MaximumNumberOfSavedUndoStates)
+    {
+    removedStacks.push_back(this->UndoStack.front());
+    this->UndoStack.pop_front();
+    }
 }

--- a/Libs/MRML/DisplayableManager/vtkSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkSliceIntersectionWidget.cxx
@@ -267,19 +267,26 @@ bool vtkSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionEvent
       processedEvent = this->ProcessMouseMove(eventData);
       break;
     case WidgetEventTouchpadRotateSliceIntersection:
+      // TODO: save state when the gesture starts. Need to get an event from Qt via VTK.
       this->Rotate(-1.0*vtkMath::RadiansFromDegrees(eventData->GetRotation() - eventData->GetLastRotation()));
       break;
     case WidgetEventTranslateStart:
       this->SetWidgetState(WidgetStateTranslate);
-      this->SliceLogic->GetMRMLScene()->SaveStateForUndo(this->GetSliceNode());
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       processedEvent = this->ProcessStartMouseDrag(eventData);
       break;
+    case WidgetEventTranslateEnd:
+      processedEvent = this->ProcessEndMouseDrag(eventData);
+      break;
     case WidgetEventRotateStart:
-      this->SliceLogic->GetMRMLScene()->SaveStateForUndo(this->GetSliceNode());
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       processedEvent = this->ProcessRotateStart(eventData);
       break;
+    case WidgetEventRotateEnd:
+      processedEvent = this->ProcessEndMouseDrag(eventData);
+      break;
     case WidgetEventTranslateSliceStart:
-      this->SliceLogic->GetMRMLScene()->SaveStateForUndo(this->GetSliceNode());
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->SliceLogic->StartSliceNodeInteraction(vtkMRMLSliceNode::XYZOriginFlag);
       this->SetWidgetState(WidgetStateTranslateSlice);
       processedEvent = this->ProcessStartMouseDrag(eventData);
@@ -289,7 +296,7 @@ bool vtkSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionEvent
       this->SliceLogic->EndSliceNodeInteraction();
       break;
     case WidgetEventZoomSliceStart:
-      this->SliceLogic->GetMRMLScene()->SaveStateForUndo(this->SliceLogic->GetSliceNode());
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->SetWidgetState(WidgetStateZoomSlice);
       this->SliceLogic->StartSliceNodeInteraction(vtkMRMLSliceNode::FieldOfViewFlag);
       this->SliceLogic->GetSliceNode()->GetFieldOfView(this->StartActionFOV);
@@ -300,24 +307,24 @@ bool vtkSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionEvent
       this->SliceLogic->EndSliceNodeInteraction();
       break;
     case WidgetEventAdjustWindowLevelStart:
-      this->SliceLogic->GetMRMLScene()->SaveStateForUndo(this->SliceLogic->GetSliceNode());
       this->SetWidgetState(WidgetStateAdjustWindowLevel);
       processedEvent = this->ProcessAdjustWindowLevelStart(eventData);
+      break;
+    case WidgetEventAdjustWindowLevelEnd:
+      processedEvent = this->ProcessEndMouseDrag(eventData);
       break;
     case WidgetEventBlendStart:
       {
       this->SetWidgetState(WidgetStateBlend);
       vtkMRMLSliceCompositeNode *sliceCompositeNode = this->SliceLogic->GetSliceCompositeNode();
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->LastForegroundOpacity = sliceCompositeNode->GetForegroundOpacity();
       this->LastLabelOpacity = this->GetLabelOpacity();
       this->StartActionSegmentationDisplayNode = this->GetVisibleSegmentationDisplayNode();
       processedEvent = this->ProcessStartMouseDrag(eventData);
       }
       break;
-    case WidgetEventTranslateEnd:
-    case WidgetEventRotateEnd:
     case WidgetEventBlendEnd:
-    case WidgetEventAdjustWindowLevelEnd:
       processedEvent = this->ProcessEndMouseDrag(eventData);
       break;
     case WidgetEventSetCrosshairPosition:
@@ -325,6 +332,7 @@ bool vtkSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionEvent
       break;
     case WidgetEventToggleLabelOpacity:
       {
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->StartActionSegmentationDisplayNode = NULL;
       double opacity = this->GetLabelOpacity();
       if (opacity != 0.0)
@@ -341,6 +349,7 @@ bool vtkSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionEvent
     case WidgetEventToggleForegroundOpacity:
       {
       vtkMRMLSliceCompositeNode *sliceCompositeNode = this->SliceLogic->GetSliceCompositeNode();
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       double opacity = sliceCompositeNode->GetForegroundOpacity();
       if (opacity != 0.0)
         {
@@ -360,14 +369,17 @@ bool vtkSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionEvent
       this->DecrementSlice();
       break;
     case WidgetEventToggleSliceVisibility:
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->GetSliceNode()->SetSliceVisible(!this->GetSliceNode()->GetSliceVisible());
       break;
     case WidgetEventToggleAllSlicesVisibility:
       // TODO: need to set all slices visible
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->GetSliceNode()->SetSliceVisible(!this->GetSliceNode()->GetSliceVisible());
       break;
     case WidgetEventResetFieldOfView:
       {
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->SliceLogic->StartSliceNodeInteraction(vtkMRMLSliceNode::ResetFieldOfViewFlag);
       this->SliceLogic->FitSliceToAll();
       this->GetSliceNode()->UpdateMatrices();
@@ -382,15 +394,19 @@ bool vtkSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionEvent
       break;
     break;
     case WidgetEventShowPreviousBackgroundVolume:
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->CycleVolumeLayer(LayerBackground, -1);
       break;
     case WidgetEventShowNextBackgroundVolume:
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->CycleVolumeLayer(LayerBackground, 1);
       break;
     case WidgetEventShowPreviousForegroundVolume:
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->CycleVolumeLayer(LayerForeground, -1);
       break;
     case WidgetEventShowNextForegroundVolume:
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
       this->CycleVolumeLayer(LayerForeground, 1);
       break;
 
@@ -1007,6 +1023,8 @@ bool vtkSliceIntersectionWidget::ProcessAdjustWindowLevelStart(vtkMRMLInteractio
 
   if (adjustForeground)
     {
+    vtkMRMLNode* volumeNode = this->SliceLogic->GetMRMLScene()->GetNodeByID(sliceCompositeNode->GetForegroundVolumeID());
+    this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
     this->WindowLevelAdjustedLayer = LayerForeground;
     this->SliceLogic->GetForegroundWindowLevelAndRange(
       this->LastVolumeWindowLevel[0], this->LastVolumeWindowLevel[1],
@@ -1014,6 +1032,8 @@ bool vtkSliceIntersectionWidget::ProcessAdjustWindowLevelStart(vtkMRMLInteractio
     }
   else
     {
+    vtkMRMLNode* volumeNode = this->SliceLogic->GetMRMLScene()->GetNodeByID(sliceCompositeNode->GetBackgroundVolumeID());
+    this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
     this->WindowLevelAdjustedLayer = LayerBackground;
     this->SliceLogic->GetBackgroundWindowLevelAndRange(
       this->LastVolumeWindowLevel[0], this->LastVolumeWindowLevel[1],

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -771,10 +771,7 @@ vtkSmartPointer<vtkCollection> qMRMLSliceControllerWidgetPrivate::saveNodesForUn
     nodes.TakeReference(
       q->mrmlScene()->GetNodesByClass(nodeTypes.toLatin1()));
     }
-  if (nodes.GetPointer())
-    {
-    q->mrmlScene()->SaveStateForUndo(nodes);
-    }
+  q->mrmlScene()->SaveStateForUndo();
   return nodes;
 }
 
@@ -1382,7 +1379,7 @@ void qMRMLSliceControllerWidgetPrivate::setForegroundInterpolation(vtkMRMLSliceL
     volumeNode->GetVolumeDisplayNode()) : 0;
   if (displayNode)
     {
-    q->mrmlScene()->SaveStateForUndo(displayNode);
+    q->mrmlScene()->SaveStateForUndo();
     displayNode->SetInterpolate(linear);
     }
   // historic code that doesn't seem to work
@@ -1390,7 +1387,7 @@ void qMRMLSliceControllerWidgetPrivate::setForegroundInterpolation(vtkMRMLSliceL
   //   sliceLogic->GetForegroundLayer()->GetVolumeDisplayNode());
   // if (displayNode)
   //   {
-  //   q->mrmlScene()->SaveStateForUndo(displayNode);
+  //   q->mrmlScene()->SaveStateForUndo();
   //   displayNode->SetInterpolate(interpolate);
   //   vtkMRMLVolumeNode* volumeNode = sliceLogic->GetForegroundLayer()->GetVolumeNode();
   //   if (volumeNode)
@@ -1410,7 +1407,7 @@ void qMRMLSliceControllerWidgetPrivate::setBackgroundInterpolation(vtkMRMLSliceL
     volumeNode->GetVolumeDisplayNode()) : 0;
   if (displayNode)
     {
-    q->mrmlScene()->SaveStateForUndo(displayNode);
+    q->mrmlScene()->SaveStateForUndo();
     displayNode->SetInterpolate(linear);
     }
   // historic code that doesn't seem to work
@@ -1418,7 +1415,7 @@ void qMRMLSliceControllerWidgetPrivate::setBackgroundInterpolation(vtkMRMLSliceL
   //   sliceLogic->GetBackgroundLayer()->GetVolumeDisplayNode());
   // if (displayNode)
   //   {
-  //   q->mrmlScene()->SaveStateForUndo(displayNode);
+  //   q->mrmlScene()->SaveStateForUndo();
   //   displayNode->SetInterpolate(interpolate);
   //   vtkMRMLVolumeNode* volumeNode = sliceLogic->GetBackgroundLayer()->GetVolumeNode();
   //   if (volumeNode)

--- a/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModulePropertyDialog.cxx
+++ b/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModulePropertyDialog.cxx
@@ -937,7 +937,7 @@ void qSlicerAnnotationModulePropertyDialog::onTextOpacityChanged(double value)
     }
   if (textDisplayNode->GetScene())
     {
-    textDisplayNode->GetScene()->SaveStateForUndo(textDisplayNode);
+    textDisplayNode->GetScene()->SaveStateForUndo();
     }
   textDisplayNode->SetOpacity(value);
 }
@@ -953,7 +953,7 @@ void qSlicerAnnotationModulePropertyDialog::onTextVisibilityChanged(bool value)
     }
   if (textDisplayNode->GetScene())
     {
-    textDisplayNode->GetScene()->SaveStateForUndo(textDisplayNode);
+    textDisplayNode->GetScene()->SaveStateForUndo();
     }
   textDisplayNode->SetVisibility(value);
 }
@@ -1065,7 +1065,7 @@ void qSlicerAnnotationModulePropertyDialog::onPointsTableWidgetChanged(QTableWid
     //std::cout << "Setting control point for point " << row << ", to " << newCoords[0] << ", " << newCoords[1] << ", " << newCoords[2] << std::endl;
     if (pointsNode->GetScene())
       {
-      pointsNode->GetScene()->SaveStateForUndo(pointsNode);
+      pointsNode->GetScene()->SaveStateForUndo();
       }
     pointsNode->SetControlPoint(row, newCoords);
     }
@@ -1109,7 +1109,7 @@ void qSlicerAnnotationModulePropertyDialog::onPointSizeChanged(double value)
     }
   if (pointDisplayNode->GetScene())
     {
-    pointDisplayNode->GetScene()->SaveStateForUndo(pointDisplayNode);
+    pointDisplayNode->GetScene()->SaveStateForUndo();
     }
   pointDisplayNode->SetGlyphScale(value);
 }
@@ -1125,7 +1125,7 @@ void qSlicerAnnotationModulePropertyDialog::onPointOpacityChanged(double value)
     }
   if (pointDisplayNode->GetScene())
     {
-    pointDisplayNode->GetScene()->SaveStateForUndo(pointDisplayNode);
+    pointDisplayNode->GetScene()->SaveStateForUndo();
     }
   pointDisplayNode->SetOpacity(value);
 }
@@ -1141,7 +1141,7 @@ void qSlicerAnnotationModulePropertyDialog::onPointAmbientChanged(double value)
     }
   if (pointDisplayNode->GetScene())
     {
-    pointDisplayNode->GetScene()->SaveStateForUndo(pointDisplayNode);
+    pointDisplayNode->GetScene()->SaveStateForUndo();
     }
   pointDisplayNode->SetAmbient(value);
 }
@@ -1157,7 +1157,7 @@ void qSlicerAnnotationModulePropertyDialog::onPointDiffuseChanged(double value)
     }
   if (pointDisplayNode->GetScene())
     {
-    pointDisplayNode->GetScene()->SaveStateForUndo(pointDisplayNode);
+    pointDisplayNode->GetScene()->SaveStateForUndo();
     }
   pointDisplayNode->SetDiffuse(value);
 }
@@ -1173,7 +1173,7 @@ void qSlicerAnnotationModulePropertyDialog::onPointSpecularChanged(double value)
     }
   if (pointDisplayNode->GetScene())
     {
-    pointDisplayNode->GetScene()->SaveStateForUndo(pointDisplayNode);
+    pointDisplayNode->GetScene()->SaveStateForUndo();
     }
   pointDisplayNode->SetSpecular(value);
 }
@@ -1214,7 +1214,7 @@ void qSlicerAnnotationModulePropertyDialog::onLineWidthChanged(double value)
     }
   if (lineDisplayNode->GetScene())
     {
-    lineDisplayNode->GetScene()->SaveStateForUndo(lineDisplayNode);
+    lineDisplayNode->GetScene()->SaveStateForUndo();
     }
   lineDisplayNode->SetLineThickness(value);
 }
@@ -1230,7 +1230,7 @@ void qSlicerAnnotationModulePropertyDialog::onLineLabelPositionChanged(double va
     }
   if (lineDisplayNode->GetScene())
     {
-    lineDisplayNode->GetScene()->SaveStateForUndo(lineDisplayNode);
+    lineDisplayNode->GetScene()->SaveStateForUndo();
     }
   lineDisplayNode->SetLabelPosition(value);
 }
@@ -1246,7 +1246,7 @@ void qSlicerAnnotationModulePropertyDialog::onLineLabelVisibilityStateChanged(in
     }
   if (lineDisplayNode->GetScene())
     {
-    lineDisplayNode->GetScene()->SaveStateForUndo(lineDisplayNode);
+    lineDisplayNode->GetScene()->SaveStateForUndo();
     }
   if (state)
     {
@@ -1270,7 +1270,7 @@ void qSlicerAnnotationModulePropertyDialog::onLineTickSpacingChanged()
   double value = ui.lineTickSpacingSlider->value();
   if (lineDisplayNode->GetScene())
     {
-    lineDisplayNode->GetScene()->SaveStateForUndo(lineDisplayNode);
+    lineDisplayNode->GetScene()->SaveStateForUndo();
     }
   lineDisplayNode->SetTickSpacing(value);
 }
@@ -1286,7 +1286,7 @@ void qSlicerAnnotationModulePropertyDialog::onLineMaxTicksChanged(double value)
     }
   if (lineDisplayNode->GetScene())
     {
-    lineDisplayNode->GetScene()->SaveStateForUndo(lineDisplayNode);
+    lineDisplayNode->GetScene()->SaveStateForUndo();
     }
   lineDisplayNode->SetMaxTicks(int(value));
 }
@@ -1302,7 +1302,7 @@ void qSlicerAnnotationModulePropertyDialog::onLineOpacityChanged(double value)
     }
   if (lineDisplayNode->GetScene())
     {
-    lineDisplayNode->GetScene()->SaveStateForUndo(lineDisplayNode);
+    lineDisplayNode->GetScene()->SaveStateForUndo();
     }
   lineDisplayNode->SetOpacity(value);
 }
@@ -1318,7 +1318,7 @@ void qSlicerAnnotationModulePropertyDialog::onLineAmbientChanged(double value)
     }
   if (lineDisplayNode->GetScene())
     {
-    lineDisplayNode->GetScene()->SaveStateForUndo(lineDisplayNode);
+    lineDisplayNode->GetScene()->SaveStateForUndo();
     }
   lineDisplayNode->SetAmbient(value);
 }
@@ -1334,7 +1334,7 @@ void qSlicerAnnotationModulePropertyDialog::onLineDiffuseChanged(double value)
     }
   if (lineDisplayNode->GetScene())
     {
-    lineDisplayNode->GetScene()->SaveStateForUndo(lineDisplayNode);
+    lineDisplayNode->GetScene()->SaveStateForUndo();
     }
   lineDisplayNode->SetDiffuse(value);
 }
@@ -1350,7 +1350,7 @@ void qSlicerAnnotationModulePropertyDialog::onLineSpecularChanged(double value)
     }
   if (lineDisplayNode->GetScene())
     {
-    lineDisplayNode->GetScene()->SaveStateForUndo(lineDisplayNode);
+    lineDisplayNode->GetScene()->SaveStateForUndo();
     }
   lineDisplayNode->SetSpecular(value);
 }

--- a/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModulePropertyDialogWIP.cxx
+++ b/Modules/Loadable/Annotations/GUI/qSlicerAnnotationModulePropertyDialogWIP.cxx
@@ -340,8 +340,7 @@ void qSlicerAnnotationModulePropertyDialog::initialize()
     /*
    this->setWindowTitle(
    "Annotation Properties");
-   this->SaveStateForUndo(
-   node);
+   this->SaveStateForUndo();
 
    // COORDINATES
    QDoubleValidator *doubleVal = new QDoubleValidator(
@@ -1080,11 +1079,7 @@ void qSlicerAnnotationModulePropertyDialog::SaveStateForUndo(vtkMRMLNode* node)
    vtkMRMLAnnotationFiducialNode::SafeDownCast(node);
    fiducialNode->CreateAnnotationTextDisplayNode();
    fiducialNode->CreateAnnotationPointDisplayNode();
-   fiducialNode->GetScene()->SaveStateForUndo(fiducialNode);
-   fiducialNode->GetAnnotationTextDisplayNode()->GetScene()->SaveStateForUndo(
-   fiducialNode->GetAnnotationTextDisplayNode());
-   fiducialNode->GetAnnotationPointDisplayNode()->GetScene()->SaveStateForUndo(
-   fiducialNode->GetAnnotationPointDisplayNode());
+   fiducialNode->GetScene()->SaveStateForUndo();
    }
    */
 }

--- a/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
+++ b/Modules/Loadable/Annotations/Logic/vtkSlicerAnnotationModuleLogic.cxx
@@ -2533,7 +2533,6 @@ void vtkSlicerAnnotationModuleLogic::JumpSlicesToAnnotationCoordinate(const char
     return;
     }
 
-  this->GetMRMLScene()->SaveStateForUndo();
   // TODO for now only consider the first control point
   double *rasCoordinates = controlpointsNode->GetControlPointCoordinates(0);
   if (rasCoordinates)

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationFiducialDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationFiducialDisplayableManager.cxx
@@ -144,7 +144,7 @@ public:
         // PropagateWidgetToMRML to update the node one last time
         if (this->m_Node->GetScene())
           {
-          this->m_Node->GetScene()->SaveStateForUndo(this->m_Node);
+          this->m_Node->GetScene()->SaveStateForUndo();
           }
         }
 

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationRulerDisplayableManager.cxx
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationRulerDisplayableManager.cxx
@@ -128,7 +128,7 @@ public:
         // PropagateWidgetToMRML to update the node one last time
         if (this->m_Node->GetScene())
           {
-          this->m_Node->GetScene()->SaveStateForUndo(this->m_Node);
+          this->m_Node->GetScene()->SaveStateForUndo();
           }
         }
       // the interaction with the widget ended, now propagate the changes to MRML

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -91,6 +91,7 @@ public:
 //----------------------------------------------------------------------------
 vtkSlicerMarkupsLogic::vtkSlicerMarkupsLogic()
 {
+  this->AutoCreateDisplayNodes = true;
   this->DefaultMarkupsDisplayNode = vtkMRMLMarkupsDisplayNode::New();
   // link an observation of the modified event on the display node to trigger
   // a modified event on the logic so any settings panel can get updated
@@ -270,7 +271,7 @@ void vtkSlicerMarkupsLogic::OnMRMLSceneNodeAdded(vtkMRMLNode* node)
     return;
     }
 
-  if (markupsNode->GetDisplayNode() == nullptr)
+  if (markupsNode->GetDisplayNode() == nullptr && this->AutoCreateDisplayNodes)
     {
     // add a display node
     int modifyFlag = markupsNode->StartModify();
@@ -436,7 +437,8 @@ std::string vtkSlicerMarkupsLogic::AddNewDisplayNodeForMarkupsNode(vtkMRMLNode *
     }
 
   // create the display node
-  vtkMRMLMarkupsDisplayNode *displayNode = vtkMRMLMarkupsDisplayNode::New();
+  vtkMRMLMarkupsDisplayNode *displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(
+    mrmlNode->GetScene()->AddNewNodeByClass("vtkMRMLMarkupsDisplayNode"));
   // set it from the defaults
   this->SetDisplayNodeToDefaults(displayNode);
   vtkDebugMacro("AddNewDisplayNodeForMarkupsNode: set display node to defaults");
@@ -579,7 +581,6 @@ void vtkSlicerMarkupsLogic::JumpSlicesToLocation(double x, double y, double z, b
     }
 
   // save the whole state as iterating over all slice nodes
-  this->GetMRMLScene()->SaveStateForUndo();
   int jumpMode = centered ? vtkMRMLSliceNode::CenteredJumpSlice: vtkMRMLSliceNode::OffsetJumpSlice;
   vtkMRMLSliceNode::JumpAllSlices(this->GetMRMLScene(), x, y, z, jumpMode, viewGroup, exclude);
 }

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -214,6 +214,10 @@ public:
   /// Get the index of teh closest control point to the world coordinates
   int GetClosestControlPointIndexToPositionWorld(vtkMRMLMarkupsNode *markupsNode, double pos[3]);
 
+  vtkSetMacro(AutoCreateDisplayNodes, bool);
+  vtkGetMacro(AutoCreateDisplayNodes, bool);
+  vtkBooleanMacro(AutoCreateDisplayNodes, bool);
+
 protected:
   vtkSlicerMarkupsLogic();
   virtual ~vtkSlicerMarkupsLogic();
@@ -236,6 +240,8 @@ private:
   /// keep a markups display node with default values that can be updated from
   /// the application settings
   vtkMRMLMarkupsDisplayNode *DefaultMarkupsDisplayNode;
+
+  bool AutoCreateDisplayNodes;
 };
 
 #endif

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveWidget.cxx
@@ -19,6 +19,7 @@
 #include "vtkSlicerCurveWidget.h"
 #include "vtkMRMLInteractionEventData.h"
 #include "vtkMRMLMarkupsCurveNode.h"
+#include "vtkMRMLScene.h"
 #include "vtkMRMLSliceNode.h"
 #include "vtkSlicerCurveRepresentation2D.h"
 #include "vtkSlicerCurveRepresentation3D.h"
@@ -113,6 +114,8 @@ bool vtkSlicerCurveWidget::ProcessControlPointInsert(vtkMRMLInteractionEventData
     double doubleDisplayPos[3] = { static_cast<double>(displayPos[0]), static_cast<double>(displayPos[1]), 0.0 };
     rep2d->GetSliceToWorldCoordinates(doubleDisplayPos, worldPos);
     }
+
+  markupsNode->GetScene()->SaveStateForUndo();
 
   // Create new control point and insert
   vtkMRMLMarkupsNode::ControlPoint* controlPoint = new vtkMRMLMarkupsNode::ControlPoint;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -249,6 +249,7 @@ bool vtkSlicerMarkupsWidget::ProcessWidgetReset(vtkMRMLInteractionEventData* vtk
     {
     return false;
     }
+  markupsNode->GetScene()->SaveStateForUndo();
   markupsNode->RemoveAllControlPoints();
   return true;
 }
@@ -282,6 +283,7 @@ bool vtkSlicerMarkupsWidget::ProcessControlPointDelete(vtkMRMLInteractionEventDa
     return false;
     }
 
+  markupsNode->GetScene()->SaveStateForUndo();
   markupsNode->RemoveNthControlPoint(controlPointToDelete);
   return true;
 }
@@ -304,6 +306,7 @@ bool vtkSlicerMarkupsWidget::ProcessWidgetJumpCursor(vtkMRMLInteractionEventData
     {
     return false;
     }
+  markupsNode->GetScene()->SaveStateForUndo();
   vtkNew<vtkMRMLInteractionEventData> jumpToPointEventData;
   jumpToPointEventData->SetType(vtkMRMLMarkupsDisplayNode::JumpToPointEvent);
   jumpToPointEventData->SetComponentType(vtkMRMLMarkupsDisplayNode::ComponentControlPoint);
@@ -550,6 +553,8 @@ void vtkSlicerMarkupsWidget::StartWidgetInteraction(vtkMRMLInteractionEventData*
     {
     return;
     }
+
+  markupsNode->GetScene()->SaveStateForUndo();
 
   //this->GrabFocus(this->EventCallbackCommand);
   //this->StartInteraction();

--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
@@ -226,8 +226,6 @@ vtkMRMLModelNode* vtkSlicerModelsLogic::AddModel (const char* filename)
     std::string uname( this->GetMRMLScene()->GetUniqueNameByString(baseName.c_str()));
     modelNode->SetName(uname.c_str());
 
-    this->GetMRMLScene()->SaveStateForUndo();
-
     this->GetMRMLScene()->AddNode(storageNode.GetPointer());
     this->GetMRMLScene()->AddNode(displayNode.GetPointer());
 
@@ -356,8 +354,6 @@ bool vtkSlicerModelsLogic::AddScalar(const char* filename, vtkMRMLModelNode *mod
     {
     return false;
     }
-
-  this->GetMRMLScene()->SaveStateForUndo();
 
   this->GetMRMLScene()->AddNode(storageNode.GetPointer());
 

--- a/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
+++ b/Modules/Loadable/SceneViews/Logic/vtkSlicerSceneViewsModuleLogic.cxx
@@ -298,8 +298,6 @@ void vtkSlicerSceneViewsModuleLogic::RestoreSceneView(const char* id, bool remov
     return;
     }
 
-  this->GetMRMLScene()->SaveStateForUndo();
-
   viewNode->RestoreScene(removeNodes);
 }
 

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -267,7 +267,6 @@ vtkMRMLSegmentationNode* vtkSlicerSegmentationsModuleLogic::LoadSegmentationFrom
   segmentationNode->SetName(uname.c_str());
   std::string storageUName = uname + "_Storage";
   storageNode->SetName(storageUName.c_str());
-  this->GetMRMLScene()->SaveStateForUndo();
   this->GetMRMLScene()->AddNode(storageNode.GetPointer());
 
   segmentationNode->SetScene(this->GetMRMLScene());

--- a/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.cxx
+++ b/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.cxx
@@ -145,7 +145,6 @@ vtkMRMLTransformNode* vtkSlicerTransformLogic::AddTransform(const char* filename
   // check to see which node can read this type of file
   vtkSmartPointer<vtkMRMLTransformNode> tnode;
 
-  scene->SaveStateForUndo();
   storageNode->SetScene(scene);
 
   vtkNew<vtkMRMLTransformNode> generalTransform;

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -1036,8 +1036,6 @@ vtkMRMLVolumePropertyNode* vtkSlicerVolumeRenderingLogic::AddVolumePropertyFromF
 
     vpNode->SetName(uname.c_str());
 
-    this->GetMRMLScene()->SaveStateForUndo();
-
     vpNode->SetScene(this->GetMRMLScene());
     vpStorageNode->SetScene(this->GetMRMLScene());
 

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -648,8 +648,6 @@ vtkMRMLVolumeNode* vtkSlicerVolumesLogic::AddArchetypeVolume (
     labelMap = true;
     }
 
-  this->GetMRMLScene()->SaveStateForUndo();
-
   vtkSmartPointer<vtkMRMLVolumeNode> volumeNode;
   vtkSmartPointer<vtkMRMLVolumeDisplayNode> displayNode;
   vtkSmartPointer<vtkMRMLStorageNode> storageNode;


### PR DESCRIPTION
MRML scene undo/redo mechanism has been disabled for a long time and this commit keeps it that way. However, this commit contain a number of fixes for problems that initial testing of the undo/redo mechanism revealed. While the undo/redo infrastructure is still not ready for general use, these fixes allow enabling it for selected nodes in custom applications.

- Add flag to enable/disable undo/redo tracking for nodes. This allows enabling undo/redo only for selected nodes, that are implemented carefully to work well with undo/redo.
- Enforce maximum stack size on undo and redo stacks.
- Node IDs that are referenced within the node stack and are not within the scene are considered to be in use for the purpose of generating unique node ids (this makes sure no node ID conflicts can occur between new nodes and nodes that were restored from the undo stack).
- Add missing SaveStateForUndo calls into Markups widgets.
- Always save the full scene state - saving only state of selected nodes can break node references and make the state of the scene inconsistent. Even if a Slice core module would think that as a result of a user action only specific nodes are updated, due to behavior of custom modules, it is possible that a simple node change triggers events that change state of other nodes, which would not be possible to revert without saving the state of all nodes.
- Add flag to be able to disable automatic display node creation for Markups.
- Removed SaveStateForUndo calls from logic and MRML classes. Undo/Redo should be handled at the application/GUI level and not at MRML library level (at the library level it is not known when is a good time to save a new state).

Co-authored-by: Kyle Sunderland <sunderlandkyl@gmail.com>