### PR TITLE
STYLE: Remove outdated Qt4 code in CMake and python code.

### DIFF
--- a/CMake/SlicerBlockFindQtAndCheckVersion.cmake
+++ b/CMake/SlicerBlockFindQtAndCheckVersion.cmake
@@ -18,11 +18,6 @@
 #
 ################################################################################
 
-#
-# The CMake code used to find Qt4 has been factored out into this CMake script so that
-# it can be used in both Slicer/CMakelists.txt and Slicer/UseSlicer.cmake
-#
-
 macro(__SlicerBlockFindQtAndCheckVersion_find_qt)
     find_package(Qt5 COMPONENTS ${Slicer_REQUIRED_QT_MODULES})
     set(_found_var Qt5_FOUND)
@@ -63,7 +58,7 @@ foreach(v ${expected_defined_vars})
   endif()
 endforeach()
 
-# Check QT_QMAKE_EXECUTABLE provided by VTK
+# Check Qt5_DIR provided by CTK
 set(extra_error_message)
   if(DEFINED CTK_Qt5_DIR AND NOT EXISTS "${CTK_Qt5_DIR}")
     message(FATAL_ERROR "error: You should probably re-configure CTK. CTK_Qt5_DIR points to a nonexistent directory: ${CTK_Qt5_DIR}")

--- a/CMake/SlicerConfig.cmake.in
+++ b/CMake/SlicerConfig.cmake.in
@@ -516,7 +516,7 @@ endforeach()
 @Slicer_EP_USE_SYSTEM_VARS_CONFIG@
 
 # This block should be added after VTK and CTK are found.
-# Indeed, it will check if both VTK_QT_QMAKE_EXECUTABLE and CTK_QT_QMAKE_EXECUTABLE are valid.
+# It will check if CTK_Qt5_DIR is valid.
 include(${Slicer_CMAKE_DIR}/SlicerBlockFindQtAndCheckVersion.cmake)
 
 # --------------------------------------------------------------------------

--- a/CMake/SlicerDashboardDriverScript.cmake
+++ b/CMake/SlicerDashboardDriverScript.cmake
@@ -168,12 +168,8 @@ set(variables ${expected_variables})
 #-----------------------------------------------------------------------------
 # Handle Qt configuration
 #-----------------------------------------------------------------------------
-if(NOT DEFINED QT_QMAKE_EXECUTABLE AND NOT DEFINED Qt5_DIR)
-  message(FATAL_ERROR "Either QT_QMAKE_EXECUTABLE (for Qt4) or Qt5_DIR (for Qt5) should be defined in top-level script")
-endif()
-if(DEFINED QT_QMAKE_EXECUTABLE)
-  set(QT_CACHE_ENTRY "QT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}")
-  list(APPEND variables QT_QMAKE_EXECUTABLE)
+if(NOT DEFINED Qt5_DIR)
+  message(FATAL_ERROR "Qt5_DIR should be defined in top-level script")
 endif()
 if(DEFINED Qt5_DIR)
   set(QT_CACHE_ENTRY "Qt5_DIR:PATH=${Qt5_DIR}")

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTestHelper.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTestHelper.cxx
@@ -38,10 +38,7 @@ bool checkViewArrangement(int line, qMRMLLayoutManager* layoutManager,
 // --------------------------------------------------------------------------
 
 // Note:
-// (1) Qt4 reports leaks in debug mode (LEAK: 88 WebCoreNode) on exit.
-//     This seems to be harmless and will be fixed in future Qt releases.
-//     More info: https://bugreports.qt.io/browse/QTBUG-29390
-// (2) Because of Qt5 issue #50160, we need to explicitly call the quit function.
+// (1) Because of Qt5 issue #50160, we need to explicitly call the quit function.
 //     This ensures that the workaround associated with qSlicerWebWidget,
 //     qMRMLChartWidget, ... is applied.
 //     See https://bugreports.qt.io/browse/QTBUG-50160#comment-305211

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -525,14 +525,9 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
       try:
         os.makedirs(databaseDirectory)
       except OSError:
-        try:
-          # Qt4
-          documentsLocation = qt.QDesktopServices.DocumentsLocation
-          documents = qt.QDesktopServices.storageLocation(documentsLocation)
-        except AttributeError:
-          # Qt5
-          documentsLocation = qt.QStandardPaths.DocumentsLocation
-          documents = qt.QStandardPaths.writableLocation(documentsLocation)
+        # Qt5
+        documentsLocation = qt.QStandardPaths.DocumentsLocation
+        documents = qt.QStandardPaths.writableLocation(documentsLocation)
         databaseDirectory = os.path.join(documents, slicer.app.applicationName+"DICOMDatabase")
         if not os.path.exists(databaseDirectory):
           os.makedirs(databaseDirectory)


### PR DESCRIPTION
Removed code was never executed since Qt5 is now required
or contained outdated documentation.