### PR TITLE
BUG: Fix ITK filters to use ITKv5 dynamic multi threading

### DIFF
--- a/Libs/vtkITK/itkGrowCutSegmentationImageFilter.txx
+++ b/Libs/vtkITK/itkGrowCutSegmentationImageFilter.txx
@@ -69,6 +69,12 @@ GrowCutSegmentationImageFilter<TInputImage, TOutputImage, TWeightPixelType>
   m_UnknownLabel = static_cast<OutputPixelType>( NumericTraits<OutputPixelType>::ZeroValue() );
 
   m_Radius.Fill(1);
+
+  // Keep using the ITKv4 threading system.
+  // This class could be updated to use the ITKv5 dynamic threading system in the future
+  // Check the ITK migration guide:
+  // https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/ITK5MigrationGuide.md
+  this->DynamicMultiThreadingOff();
 }
 
 
@@ -478,6 +484,9 @@ MaskSegmentedImageByWeight( float confThresh)
 }
 
 
+// TODO: The class overrides both: GenerateData and ThreadedGenerateData
+// This is wrong. See Issue in Mantis for details:
+// https://issues.slicer.org/view.php?id=4679
 template <class TInputImage, class TOutputImage, class TWeightPixelType>
 void
 GrowCutSegmentationImageFilter<TInputImage, TOutputImage, TWeightPixelType>
@@ -491,6 +500,12 @@ GrowCutSegmentationImageFilter<TInputImage, TOutputImage, TWeightPixelType>
   typename OutputImageType::Pointer output = this->GetOutput();
   this->Initialize(output);
 
+  // TODO: RunOneIteration does the opposite of what is intended.
+  // Superclass::GenerateData will call this class ThreadedGenerateData, so it will run multi-threaded.
+  // If m_RunOneIteration is false, ThreadedGenerateData is NOT called.
+  // To update to ITKv5, remove GenerateData, change the name of ThreadedGenerateData to
+  // DynamicThreadedGenerateData and that's it.
+  // Test if both implementations, GenerateData and ThreadedGenerateData and equivalent.
   if(m_RunOneIteration)
     {
     Superclass::GenerateData();

--- a/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
+++ b/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.txx
@@ -49,6 +49,14 @@ DifferenceDiffusionTensor3DImageFilter<TInputImage, TOutputImage>
   m_IgnoreBoundaryPixels = false;
   m_MeasurementFrameValid.SetIdentity();
   m_MeasurementFrameTest.SetIdentity();
+
+  // Keep using the ITKv4 threading system.
+  // This class could be updated to use the ITKv5 dynamic threading system in the future
+  // Check the ITK migration guide:
+  // https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/ITK5MigrationGuide.md
+  // This class in particular does use threadId, so a more complex solution is needed
+  // Check the example of using std::atomic in the migration guide.
+  this->DynamicMultiThreadingOff();
 }
 
 // ----------------------------------------------------------------------------

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.h
@@ -75,7 +75,7 @@ public:
   void SetOutputParametersFromImage( InputImagePointerType Image );
 
 // /Get the time of the last modification of the object
-  unsigned long GetMTime() const ITK_OVERRIDE;
+  unsigned long GetMTime() const override;
 
   itkSetMacro( DefaultPixelValue, OutputDataType );
   itkGetMacro( DefaultPixelValue, OutputDataType );
@@ -95,13 +95,13 @@ protected:
 
   void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread) override;
 
-  void BeforeThreadedGenerateData() ITK_OVERRIDE;
+  void BeforeThreadedGenerateData() override;
 
-  void GenerateOutputInformation() ITK_OVERRIDE;
+  void GenerateOutputInformation() override;
 
-  void AfterThreadedGenerateData() ITK_OVERRIDE;
+  void AfterThreadedGenerateData() override;
 
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  void GenerateInputRequestedRegion() override;
 
 private:
   typename InterpolatorType::Pointer      m_Interpolator;

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.h
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.h
@@ -93,7 +93,7 @@ public:
 protected:
   DiffusionTensor3DResample();
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) ITK_OVERRIDE;
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread) override;
 
   void BeforeThreadedGenerateData() ITK_OVERRIDE;
 

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.txx
@@ -165,7 +165,7 @@ void
 DiffusionTensor3DResample<TInput, TOutput>
 ::AfterThreadedGenerateData()
 {
-  m_Interpolator->SetInputImage( NULL );
+  m_Interpolator->SetInputImage( nullptr );
 }
 
 /**

--- a/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkDiffusionTensor3DResample.txx
@@ -83,10 +83,9 @@ DiffusionTensor3DResample<TInput, TOutput>
 template <class TInput, class TOutput>
 void
 DiffusionTensor3DResample<TInput, TOutput>
-::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
-                        ThreadIdType itkNotUsed(threadId) )
+::DynamicThreadedGenerateData( const OutputImageRegionType &outputRegionForThread)
   {
-  OutputImagePointerType outputImagePtr = this->GetOutput( 0 );
+  OutputImageType*       outputImagePtr = this->GetOutput( 0 );
   IteratorType           it( outputImagePtr, outputRegionForThread );
   InputTensorDataType    inputTensor;
   OutputTensorDataType   outputTensor;

--- a/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.h
+++ b/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.h
@@ -61,7 +61,7 @@ public:
 protected:
   SeparateComponentsOfADiffusionTensorImage();
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) ITK_OVERRIDE;
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread) override;
 
   void GenerateOutputInformation() ITK_OVERRIDE;
 

--- a/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.h
+++ b/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.h
@@ -63,12 +63,9 @@ protected:
 
   void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread) override;
 
-  void GenerateOutputInformation() ITK_OVERRIDE;
+  void GenerateOutputInformation() override;
 
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
-
-private:
-
+  void GenerateInputRequestedRegion() override;
 };
 
 } // end namespace itk

--- a/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.txx
@@ -38,8 +38,7 @@ SeparateComponentsOfADiffusionTensorImage<TInput, TOutput>
 template <class TInput, class TOutput>
 void
 SeparateComponentsOfADiffusionTensorImage<TInput, TOutput>
-::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
-                        ThreadIdType itkNotUsed(threadId) )
+::DynamicThreadedGenerateData( const OutputImageRegionType &outputRegionForThread)
   {
   InputIteratorType it( this->GetInput(), outputRegionForThread );
 

--- a/Modules/CLI/ResampleDTIVolume/itkTransformDeformationFieldFilter.h
+++ b/Modules/CLI/ResampleDTIVolume/itkTransformDeformationFieldFilter.h
@@ -55,7 +55,7 @@ public:
   itkSetObjectMacro( Transform, TransformType );
 
 // /Get the time of the last modification of the object
-  unsigned long GetMTime() const ITK_OVERRIDE;
+  unsigned long GetMTime() const override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
@@ -70,11 +70,11 @@ protected:
 
   void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread) override;
 
-  void BeforeThreadedGenerateData() ITK_OVERRIDE;
+  void BeforeThreadedGenerateData() override;
 
-  void GenerateOutputInformation() ITK_OVERRIDE;
+  void GenerateOutputInformation() override;
 
-  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+  void GenerateInputRequestedRegion() override;
 
 private:
   typename TransformType::Pointer m_Transform;

--- a/Modules/CLI/ResampleDTIVolume/itkTransformDeformationFieldFilter.h
+++ b/Modules/CLI/ResampleDTIVolume/itkTransformDeformationFieldFilter.h
@@ -68,7 +68,7 @@ public:
 protected:
   TransformDeformationFieldFilter();
 
-  void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) ITK_OVERRIDE;
+  void DynamicThreadedGenerateData( const OutputImageRegionType & outputRegionForThread) override;
 
   void BeforeThreadedGenerateData() ITK_OVERRIDE;
 

--- a/Modules/CLI/ResampleDTIVolume/itkTransformDeformationFieldFilter.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkTransformDeformationFieldFilter.txx
@@ -48,8 +48,7 @@ TransformDeformationFieldFilter<TInput, TOutput, NDimensions>
 template <class TInput, class TOutput, int NDimensions>
 void
 TransformDeformationFieldFilter<TInput, TOutput, NDimensions>
-::ThreadedGenerateData( const OutputImageRegionType &outputRegionForThread,
-                        ThreadIdType itkNotUsed(threadId) )
+::DynamicThreadedGenerateData( const OutputImageRegionType &outputRegionForThread)
   {
   OutputDeformationFieldPointerType outputImagePtr = this->GetOutput( 0 );
   InputIteratorType                 it( this->GetInput( 0 ), outputRegionForThread );


### PR DESCRIPTION
Fix failing tests with errors similar to:
```
Description: itk::ERROR: TransformDeformationFieldFilter(0x7faf052005c0): Subclass should override this method!!!
If old behavior is desired invoke this->DynamicMultiThreadingOff(); before Update() is called. The best place is in class constructor.
```

We have two options:
 - Keep using the old ITKv4 system, this just requires adding `this->DynamicMultiThreadingOff()` to the constructor.
 - Update to the dynamic multi threading system.

Check the ITK migration guide:
https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/ITK5MigrationGuide.md

If the ThreadedGenerateData function does not use `threadId` (such
as in this case), we could just change the name of the function:
`ThreadedGenerateData` to: `DynamicThreadedGenerateData`
and delete the unused `threadId` argument.

This will allow a dynamic thread usage.

Note that a bug in itkGrowCutSegmentationImageFilter was discovered.
Issue opened in Mantis: https://issues.slicer.org/view.php?id=4679
And some inline comments about it. This should be tackled in another PR.

