### PR TITLE
ENH: add slice distance color mapping in 2d view for markups widgets

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -29,6 +29,8 @@
 #include "vtkMRMLDisplayNode.h"
 #include "vtkMRMLMarkupsNode.h"
 
+class vtkMRMLProceduralColorNode;
+
 /// \ingroup Slicer_QtModules_Markups
 class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsDisplayNode : public vtkMRMLDisplayNode
 {
@@ -165,14 +167,21 @@ public:
   /// not visible.
   /// Off by default
   /// \sa SliceIntersectionVisibilty, SliceProjectionColor
-  vtkSetMacro(SliceProjection, int);
-  vtkGetMacro(SliceProjection, int);
+  vtkSetMacro(SliceProjection, bool);
+  vtkGetMacro(SliceProjection, bool);
+  vtkBooleanMacro(SliceProjection, bool);
 
-  /// Set SliceProjection to On
-  inline void SliceProjectionOn();
+  /// Set projection color to be the same as the fiducial color
+  /// On by default
+  vtkSetMacro(SliceProjectionUseFiducialColor, bool);
+  vtkGetMacro(SliceProjectionUseFiducialColor, bool);
+  vtkBooleanMacro(SliceProjectionUseFiducialColor, bool);
 
-  /// Set SliceProjection to Off
-  inline void SliceProjectionOff();
+  /// Set projection's view different if under/over/in the plane
+  /// Off by default
+  vtkSetMacro(SliceProjectionOutlinedBehindSlicePlane, bool);
+  vtkGetMacro(SliceProjectionOutlinedBehindSlicePlane, bool);
+  vtkBooleanMacro(SliceProjectionOutlinedBehindSlicePlane, bool);
 
   /// Set color of the projection on the 2D viewers
   /// White (1.0, 1.0, 1.0) by default.
@@ -184,43 +193,38 @@ public:
   vtkSetClampMacro(SliceProjectionOpacity, double, 0.0, 1.0);
   vtkGetMacro(SliceProjectionOpacity, double);
 
-  /// Set projection color to be the same as the fiducial color
-  ///\sa SetSliceProjectionColor
-  inline void SliceProjectionUseFiducialColorOn();
+  /// Configures the line color fading appearance
+  /// Default value = 1.0
+  vtkGetMacro (LineColorFadingStart, double);
+  vtkSetMacro (LineColorFadingStart, double);
 
-  /// Manually set projection color
-  ///\sa SetSliceProjectionColor
-  inline void SliceProjectionUseFiducialColorOff();
+  /// Configures the line color fading appearance
+  /// Default value = 10.0
+  vtkGetMacro (LineColorFadingEnd, double);
+  vtkSetMacro (LineColorFadingEnd, double);
 
-  /// Return true if the slice projection use fiducial color option
-  /// is on, false otherwise
-  inline bool GetSliceProjectionUseFiducialColor();
+  /// Configures the line color fading appearance
+  /// Default value = 1.0
+  vtkSetClampMacro (LineColorFadingSaturation, double, 0.0, 1.0);
+  vtkGetMacro (LineColorFadingSaturation, double);
 
-  /// Set projection's view different if under/over/in the plane
-  ///\sa SetSliceProjectionColor
-  inline void SliceProjectionOutlinedBehindSlicePlaneOn();
+  /// Configures the line color fading appearance
+  /// Default value = 0.0
+  vtkSetClampMacro (LineColorFadingHueOffset, double, 0.0, 1.0);
+  vtkGetMacro (LineColorFadingHueOffset, double);
 
-  /// Set projection's view the same if under/over/in the plane
-  ///\sa SetSliceProjectionColor
-  inline void SliceProjectionOutlinedBehindSlicePlaneOff();
+  /// Set the line color node ID used for the projection on the line actors on the 2D viewers.
+  /// Setting a line color node allows to define any arbitrary color mapping.
+  /// Setting a line color node will overwrite the settings given by the
+  /// color, opacity and LineColorFading variables of the displayNode.
+  virtual void SetLineColorNodeID(const char *lineColorNodeID);
 
-  /// Return true if the outline behind slice plane setting is turned
-  /// on, false otherwise
-  inline bool GetSliceProjectionOutlinedBehindSlicePlane();
+  /// Get the line color node ID used for the projection on the line actors on the 2D viewers.
+  const char* GetLineColorNodeID();
 
-  /// ProjectionUseFiducialColor : Set projection color the same as the
-  /// markup color
-  /// ProjectionOutlinedBehindSlicePlane : Different shape and opacity when
-  /// markup is on top of the slice plane, or under
-  /// Projection Off, UseFiducialColor, OutlinedBehindSlicePlane by default
-  ///\enum SliceProjectionFlag
-  enum SliceProjectionFlag
-  {
-    ProjectionOff = 0x00,
-    ProjectionOn = 0x01,
-    ProjectionUseFiducialColor = 0x02,
-    ProjectionOutlinedBehindSlicePlane = 0x04
-  };
+  /// Get the line color node used for the projection on the line actors on the 2D viewers.
+  vtkMRMLProceduralColorNode* GetLineColorNode();
+  virtual const char* GetLineColorNodeReferenceRole();
 
 protected:
   vtkMRMLMarkupsDisplayNode();
@@ -238,79 +242,20 @@ protected:
   double GlyphScale;
   static const char* GlyphTypesNames[GlyphMax+2];
 
-  int SliceProjection;
+  bool SliceProjection;
+  bool SliceProjectionUseFiducialColor;
+  bool SliceProjectionOutlinedBehindSlicePlane;
   double SliceProjectionColor[3];
   double SliceProjectionOpacity;
+
+  virtual const char* GetLineColorNodeReferenceMRMLAttributeName();
+
+  static const char* LineColorNodeReferenceRole;
+  static const char* LineColorNodeReferenceMRMLAttributeName;
+
+  double LineColorFadingStart;
+  double LineColorFadingEnd;
+  double LineColorFadingSaturation;
+  double LineColorFadingHueOffset;
 };
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsDisplayNode::SliceProjectionOn()
-{
-  this->SetSliceProjection( this->GetSliceProjection() |
-                            vtkMRMLMarkupsDisplayNode::ProjectionOn);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsDisplayNode::SliceProjectionOff()
-{
-  this->SetSliceProjection( this->GetSliceProjection() &
-                            ~vtkMRMLMarkupsDisplayNode::ProjectionOn);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsDisplayNode::SliceProjectionUseFiducialColorOn()
-{
-  this->SetSliceProjection( this->GetSliceProjection() |
-                            vtkMRMLMarkupsDisplayNode::ProjectionUseFiducialColor);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsDisplayNode::SliceProjectionUseFiducialColorOff()
-{
-  this->SetSliceProjection( this->GetSliceProjection() &
-                            ~vtkMRMLMarkupsDisplayNode::ProjectionUseFiducialColor);
-}
-
-//----------------------------------------------------------------------------
-bool vtkMRMLMarkupsDisplayNode::GetSliceProjectionUseFiducialColor()
-{
-  if (this->GetSliceProjection() &
-      this->ProjectionUseFiducialColor)
-    {
-    return true;
-    }
-  else
-    {
-    return false;
-    }
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsDisplayNode::SliceProjectionOutlinedBehindSlicePlaneOn()
-{
-  this->SetSliceProjection( this->GetSliceProjection() |
-                            vtkMRMLMarkupsDisplayNode::ProjectionOutlinedBehindSlicePlane);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsDisplayNode::SliceProjectionOutlinedBehindSlicePlaneOff()
-{
-  this->SetSliceProjection( this->GetSliceProjection() &
-                            ~vtkMRMLMarkupsDisplayNode::ProjectionOutlinedBehindSlicePlane);
-}
-
-//----------------------------------------------------------------------------
-bool vtkMRMLMarkupsDisplayNode::GetSliceProjectionOutlinedBehindSlicePlane()
-{
-  if (this->GetSliceProjection() &
-      this->ProjectionOutlinedBehindSlicePlane)
-    {
-    return true;
-    }
-  else
-    {
-    return false;
-    }
-}
-
 #endif

--- a/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.cxx
@@ -634,6 +634,7 @@ void vtkMarkupsGlyphSource2D::PrintSelf(ostream& os, vtkIndent indent)
     }
 }
 
+//----------------------------------------------------------------------------
 void vtkMarkupsGlyphSource2D::SetGlyphTypeAsString(const char *type)
 {
   if (type == nullptr)
@@ -691,5 +692,18 @@ void vtkMarkupsGlyphSource2D::SetGlyphTypeAsString(const char *type)
   else if (!strcmp(type, markupsDisplayNode->GetGlyphTypeAsString(vtkMRMLMarkupsDisplayNode::HookedArrow2D)))
     {
     this->SetGlyphTypeToHookedArrow();
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMarkupsGlyphSource2D::SetNextGlyphType()
+{
+  if (this->GlyphType == VTK_STARBURST_GLYPH)
+    {
+    this->SetGlyphTypeToVertex();
+    }
+  else
+    {
+    this->GlyphType++;
     }
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.h
@@ -119,6 +119,7 @@ public:
   void SetGlyphTypeToStarBurst() {this->SetGlyphType(VTK_STARBURST_GLYPH);}
 
   void SetGlyphTypeAsString(const char* type);
+  void SetNextGlyphType();
 
 protected:
   vtkMarkupsGlyphSource2D();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
@@ -33,15 +33,11 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation2D.h"
 
-class vtkActor2D;
-class vtkAppendPolyData;
-class vtkPolyDataMapper2D;
-class vtkPolyData;
-class vtkProperty2D;
-class vtkTubeFilter;
 class vtkArcSource;
+class vtkDiscretizableColorTransferFunction;
+class vtkSampleImplicitFunctionFilter;
 class vtkTextActor;
-class vtkVectorText;
+class vtkTubeFilter;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerAngleRepresentation2D : public vtkSlicerMarkupsWidgetRepresentation2D
 {
@@ -78,22 +74,31 @@ protected:
   vtkSlicerAngleRepresentation2D();
   ~vtkSlicerAngleRepresentation2D() override;
 
-  vtkSmartPointer<vtkPolyData>                  Line;
-  vtkSmartPointer<vtkPolyDataMapper2D>    LineMapper;
-  vtkSmartPointer<vtkActor2D>                   LineActor;
+  void SetMarkupsNode(vtkMRMLMarkupsNode *markupsNode) override;
 
-  vtkSmartPointer<vtkArcSource>                 Arc;
-  vtkSmartPointer<vtkPolyDataMapper2D>    ArcMapper;
-  vtkSmartPointer<vtkActor2D>                   ArcActor;
-
-  vtkSmartPointer<vtkTextActor>           TextActor;
-
-  vtkSmartPointer<vtkTubeFilter>                TubeFilter;
-  vtkSmartPointer<vtkTubeFilter>                ArcTubeFilter;
-
-  std::string LabelFormat;
 
   void BuildArc();
+
+  vtkSmartPointer<vtkPolyData> Line;
+  vtkSmartPointer<vtkPolyDataMapper2D> LineMapper;
+  vtkSmartPointer<vtkActor2D> LineActor;
+  vtkSmartPointer<vtkArcSource> Arc;
+  vtkSmartPointer<vtkPolyDataMapper2D> ArcMapper;
+  vtkSmartPointer<vtkActor2D> ArcActor;
+  vtkSmartPointer<vtkDiscretizableColorTransferFunction> ColorMap;
+
+  vtkSmartPointer<vtkTextActor> TextActor;
+
+  vtkSmartPointer<vtkTubeFilter> TubeFilter;
+  vtkSmartPointer<vtkTubeFilter> ArcTubeFilter;
+
+  vtkSmartPointer<vtkTransformPolyDataFilter> LineWorldToSliceTransformer;
+  vtkSmartPointer<vtkTransformPolyDataFilter> ArcWorldToSliceTransformer;
+
+  vtkSmartPointer<vtkSampleImplicitFunctionFilter> LineSliceDistance;
+  vtkSmartPointer<vtkSampleImplicitFunctionFilter> ArcSliceDistance;
+
+  std::string LabelFormat;
 
 private:
   vtkSlicerAngleRepresentation2D(const vtkSlicerAngleRepresentation2D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
@@ -33,14 +33,12 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation3D.h"
 
-class vtkAppendPolyData;
 class vtkActor;
+class vtkArcSource;
 class vtkPolyDataMapper;
 class vtkPolyData;
-class vtkTubeFilter;
-class vtkPropPicker;
 class vtkTextActor;
-class vtkArcSource;
+class vtkTubeFilter;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerAngleRepresentation3D : public vtkSlicerMarkupsWidgetRepresentation3D
 {
@@ -93,9 +91,6 @@ protected:
   std::string LabelFormat;
 
   void BuildArc();
-
-  // Support picking
-  vtkSmartPointer<vtkPropPicker> LinePicker;
 
 private:
   vtkSlicerAngleRepresentation3D(const vtkSlicerAngleRepresentation3D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerClosedCurveWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerClosedCurveWidget.cxx
@@ -47,13 +47,13 @@ void vtkSlicerClosedCurveWidget::CreateDefaultRepresentation(
 {
   vtkSmartPointer<vtkSlicerMarkupsWidgetRepresentation> rep = nullptr;
   if (vtkMRMLSliceNode::SafeDownCast(viewNode))
-  {
+    {
     rep = vtkSmartPointer<vtkSlicerCurveRepresentation2D>::New();
-  }
+    }
   else
-  {
+    {
     rep = vtkSmartPointer<vtkSlicerCurveRepresentation3D>::New();
-  }
+    }
   this->SetRenderer(renderer);
   this->SetRepresentation(rep);
   rep->SetViewNode(viewNode);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
@@ -16,45 +16,30 @@
 
 =========================================================================*/
 
-#include "vtkSlicerCurveRepresentation2D.h"
-
+// VTK includes
 #include "vtkCellLocator.h"
-#include "vtkCleanPolyData.h"
 #include "vtkDiscretizableColorTransferFunction.h"
-#include "vtkPolyDataMapper2D.h"
-#include "vtkPiecewiseFunction.h"
-#include "vtkActor2D.h"
-#include "vtkAssemblyPath.h"
-#include "vtkRenderer.h"
-#include "vtkRenderWindow.h"
-#include "vtkObjectFactory.h"
-#include "vtkProperty2D.h"
-#include "vtkMath.h"
-#include "vtkInteractorObserver.h"
 #include "vtkLine.h"
-#include "vtkCoordinate.h"
-#include "vtkGlyph2D.h"
-#include "vtkCursor2D.h"
-#include "vtkCylinderSource.h"
-#include "vtkPolyData.h"
-#include "vtkPoints.h"
-#include "vtkDoubleArray.h"
-#include "vtkPointData.h"
-#include "vtkTransformPolyDataFilter.h"
-#include "vtkTransform.h"
-#include "vtkCamera.h"
-#include "vtkPoints.h"
-#include "vtkCellArray.h"
-#include "vtkSphereSource.h"
-#include "vtkAppendPolyData.h"
-#include "vtkTubeFilter.h"
-#include "vtkStringArray.h"
+#include "vtkMath.h"
+#include "vtkObjectFactory.h"
 #include "vtkPlane.h"
-#include "vtkVectorText.h"
-#include "vtkTextActor.h"
-#include "cmath"
-#include "vtkMRMLMarkupsDisplayNode.h"
+#include "vtkPoints.h"
+#include "vtkPointData.h"
+#include "vtkPolyData.h"
+#include "vtkPolyDataMapper2D.h"
+#include "vtkProperty2D.h"
+#include "vtkRenderer.h"
 #include "vtkSampleImplicitFunctionFilter.h"
+#include "vtkSlicerCurveRepresentation2D.h"
+#include "vtkTextActor.h"
+#include "vtkTextProperty.h"
+#include "vtkTransform.h"
+#include "vtkTransformPolyDataFilter.h"
+#include "vtkTubeFilter.h"
+
+// MRML includes
+#include "vtkMRMLMarkupsDisplayNode.h"
+#include "vtkMRMLProceduralColorNode.h"
 
 vtkStandardNewMacro(vtkSlicerCurveRepresentation2D);
 
@@ -64,11 +49,9 @@ vtkSlicerCurveRepresentation2D::vtkSlicerCurveRepresentation2D()
   this->Line = vtkSmartPointer<vtkPolyData>::New();
 
   this->SliceDistance = vtkSmartPointer<vtkSampleImplicitFunctionFilter>::New();
-  this->SlicePlane = vtkSmartPointer<vtkPlane>::New();
   this->SliceDistance->SetImplicitFunction(this->SlicePlane);
 
   this->WorldToSliceTransformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
-  this->WorldToSliceTransform = vtkSmartPointer<vtkTransform>::New();
   this->WorldToSliceTransformer->SetTransform(this->WorldToSliceTransform);
   this->WorldToSliceTransformer->SetInputConnection(this->SliceDistance->GetOutputPort());
 
@@ -77,9 +60,10 @@ vtkSlicerCurveRepresentation2D::vtkSlicerCurveRepresentation2D()
   this->TubeFilter->SetNumberOfSides(6);
   this->TubeFilter->SetRadius(1);
 
+  this->LineColorMap = vtkSmartPointer<vtkDiscretizableColorTransferFunction>::New();
+
   this->LineMapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
   this->LineMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
-  this->LineColorMap = vtkSmartPointer<vtkDiscretizableColorTransferFunction>::New();
   this->LineMapper->SetLookupTable(this->LineColorMap);
   this->LineMapper->SetScalarVisibility(true);
 
@@ -106,40 +90,11 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
     || !this->MarkupsDisplayNode->GetVisibility()
     || !this->MarkupsDisplayNode->IsDisplayableInView(this->ViewNode->GetID())
     )
-  {
+    {
     this->VisibilityOff();
     return;
-  }
-  this->VisibilityOn();
-
-  // Update from slice node
-  if (!caller || caller == this->ViewNode.GetPointer())
-    {
-    vtkMatrix4x4* sliceXYToRAS = this->GetSliceNode()->GetXYToRAS();
-
-    // Update transformation to slice
-    vtkNew<vtkMatrix4x4> rasToSliceXY;
-    vtkMatrix4x4::Invert(sliceXYToRAS, rasToSliceXY.GetPointer());
-    // Project all points to the slice plane (slice Z coordinate = 0)
-    rasToSliceXY->SetElement(2, 0, 0);
-    rasToSliceXY->SetElement(2, 1, 0);
-    rasToSliceXY->SetElement(2, 2, 0);
-    this->WorldToSliceTransform->SetMatrix(rasToSliceXY.GetPointer());
-
-    // Update slice plane (for distance computation)
-    double normal[3];
-    double origin[3];
-    const int planeOrientation = 1; // +/-1: orientation of the normal
-    for (int i = 0; i < 3; i++)
-      {
-      normal[i] = planeOrientation * sliceXYToRAS->GetElement(i, 2);
-      origin[i] = sliceXYToRAS->GetElement(i, 3);
-      }
-    vtkMath::Normalize(normal);
-    this->SlicePlane->SetNormal(normal);
-    this->SlicePlane->SetOrigin(origin);
-    this->SlicePlane->Modified();
     }
+  this->VisibilityOn();
 
   // Line display
 
@@ -150,61 +105,49 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   bool allControlPointsSelected = this->GetAllControlPointsSelected();
   int controlPointType = Active;
   if (this->MarkupsDisplayNode->GetActiveComponentType() != vtkMRMLMarkupsDisplayNode::ComponentLine)
-  {
+    {
     controlPointType = allControlPointsSelected ? Selected : Unselected;
-  }
+    }
   this->LineActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
 
-  // TODO: use color node or display node properties to set up colormap
-  double limit = 10.0;
-  double tolerance = 1.0;
-  vtkPiecewiseFunction* opacityFunction = this->LineColorMap->GetScalarOpacityFunction();
-  if (!opacityFunction)
+  if (this->MarkupsDisplayNode->GetLineColorNode() && this->MarkupsDisplayNode->GetLineColorNode()->GetColorTransferFunction())
     {
-    opacityFunction = vtkPiecewiseFunction::New();
-    this->LineColorMap->SetScalarOpacityFunction(opacityFunction);
-    opacityFunction->Delete();
+    // Update the line color mapping from the colorNode stored in the markups display node
+    this->LineMapper->SetLookupTable(this->MarkupsDisplayNode->GetLineColorNode()->GetColorTransferFunction());
     }
-  opacityFunction->RemoveAllPoints();
-  opacityFunction->AddPoint(-limit, 0.0);
-  opacityFunction->AddPoint(-tolerance, 1.0);
-  opacityFunction->AddPoint(tolerance, 1.0);
-  opacityFunction->AddPoint(limit, 0.0);
-  vtkColorTransferFunction* colorFunction = this->LineColorMap;
-  colorFunction->RemoveAllPoints();
-  double* lineColorRGB = this->GetControlPointsPipeline(controlPointType)->Property->GetColor();
-  colorFunction->AddRGBPoint(-tolerance*2.0, std::min(lineColorRGB[0]*0.5, 1.0), std::min(lineColorRGB[1] * 0.5, 1.0), std::min(lineColorRGB[2] * 2.0, 1.0));
-  colorFunction->AddRGBPoint(-tolerance, lineColorRGB[0], lineColorRGB[1], lineColorRGB[2]);
-  colorFunction->AddRGBPoint( tolerance, lineColorRGB[0], lineColorRGB[1], lineColorRGB[2]);
-  colorFunction->AddRGBPoint( tolerance*2.0, std::min(lineColorRGB[0] * 2.0, 1.0), std::min(lineColorRGB[1] * 0.5, 1.0), std::min(lineColorRGB[2] * 0.5, 1.0));
-  this->LineColorMap->SetEnableOpacityMapping(true);
-  this->LineColorMap->SetClamping(true);
+  else
+    {
+    // if there is no line color node, build the color mapping from few varibales
+    // (color, opacity, distance fading, saturation and hue offset) stored in the display node
+    this->UpdateDistanceColorMap(this->LineColorMap, this->LineActor->GetProperty()->GetColor());
+    this->LineMapper->SetLookupTable(this->LineColorMap);
+    }
 
   bool allNodesHidden = true;
   for (int controlPointIndex = 0; controlPointIndex < markupsNode->GetNumberOfControlPoints(); controlPointIndex++)
-  {
-    if (markupsNode->GetNthControlPointVisibility(controlPointIndex))
     {
+    if (markupsNode->GetNthControlPointVisibility(controlPointIndex))
+      {
       allNodesHidden = false;
       break;
+      }
     }
-  }
 
   // Display center position
   // It would be cleaner to use a dedicated actor for this instead of using the control points actors
   // as it would give flexibility in what glyph we use, it would not interfere with active control point display, etc.
   if (this->ClosedLoop && markupsNode->GetNumberOfControlPoints() > 2 && this->CenterVisibilityOnSlice && !allNodesHidden)
-  {
+    {
     double centerPosWorld[3], centerPosDisplay[3], orient[3] = { 0 };
     markupsNode->GetCenterPosition(centerPosWorld);
     this->GetWorldToSliceCoordinates(centerPosWorld, centerPosDisplay);
     int centerControlPointType = allControlPointsSelected ? Selected : Unselected;
     if (this->MarkupsDisplayNode->GetActiveComponentType() == vtkMRMLMarkupsDisplayNode::ComponentCenterPoint)
-    {
+      {
       centerControlPointType = Active;
       this->GetControlPointsPipeline(centerControlPointType)->ControlPoints->SetNumberOfPoints(0);
       this->GetControlPointsPipeline(centerControlPointType)->ControlPointsPolyData->GetPointData()->GetNormals()->SetNumberOfTuples(0);
-    }
+      }
     this->GetControlPointsPipeline(centerControlPointType)->ControlPoints->InsertNextPoint(centerPosDisplay);
     this->GetControlPointsPipeline(centerControlPointType)->ControlPointsPolyData->GetPointData()->GetNormals()->InsertNextTuple(orient);
 
@@ -212,11 +155,11 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
     this->GetControlPointsPipeline(centerControlPointType)->ControlPointsPolyData->GetPointData()->GetNormals()->Modified();
     this->GetControlPointsPipeline(centerControlPointType)->ControlPointsPolyData->Modified();
     if (centerControlPointType == Active)
-    {
+      {
       this->GetControlPointsPipeline(centerControlPointType)->Actor->VisibilityOn();
       this->GetControlPointsPipeline(centerControlPointType)->LabelsActor->VisibilityOff();
+      }
     }
-  }
 }
 
 //----------------------------------------------------------------------
@@ -227,15 +170,15 @@ void vtkSlicerCurveRepresentation2D::CanInteract(
   foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentNone;
   vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
   if (!markupsNode || markupsNode->GetLocked() || markupsNode->GetNumberOfControlPoints() < 1)
-  {
+    {
     return;
-  }
+    }
   Superclass::CanInteract(displayPosition, worldPosition, foundComponentType, foundComponentIndex, closestDistance2);
   if (foundComponentType != vtkMRMLMarkupsDisplayNode::ComponentNone)
-  {
+    {
     // if mouse is near a control point then select that (ignore the line)
     return;
-  }
+    }
 
   this->CanInteractWithCurve(displayPosition, worldPosition, foundComponentType, foundComponentIndex, closestDistance2);
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.h
@@ -33,20 +33,10 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation2D.h"
 
-class vtkActor2D;
-class vtkArcSource;
-class vtkAppendPolyData;
 class vtkCellLocator;
 class vtkDiscretizableColorTransferFunction;
-class vtkPolyDataMapper2D;
-class vtkTextActor;
-class vtkPlane;
-class vtkPolyData;
-class vtkProperty2D;
-class vtkPropPicker;
 class vtkSampleImplicitFunctionFilter;
 class vtkTubeFilter;
-class vtkVectorText;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerCurveRepresentation2D : public vtkSlicerMarkupsWidgetRepresentation2D
 {
@@ -85,19 +75,18 @@ protected:
 
   void SetMarkupsNode(vtkMRMLMarkupsNode *markupsNode) override;
 
-  vtkSmartPointer<vtkPolyData>                  Line;
-  vtkSmartPointer<vtkPolyDataMapper2D>    LineMapper;
-  vtkSmartPointer<vtkActor2D>                   LineActor;
+  void UpdateLineColorMap();
+
+  vtkSmartPointer<vtkPolyData> Line;
+  vtkSmartPointer<vtkPolyDataMapper2D> LineMapper;
+  vtkSmartPointer<vtkActor2D> LineActor;
   vtkSmartPointer<vtkDiscretizableColorTransferFunction> LineColorMap;
 
-  vtkSmartPointer<vtkTubeFilter>                TubeFilter;
+  vtkSmartPointer<vtkTubeFilter> TubeFilter;
 
-  vtkSmartPointer<vtkTransform> WorldToSliceTransform;
   vtkSmartPointer<vtkTransformPolyDataFilter> WorldToSliceTransformer;
   vtkSmartPointer<vtkCellLocator> SliceCurvePointLocator;
 
-
-  vtkSmartPointer<vtkPlane> SlicePlane;
   vtkSmartPointer<vtkSampleImplicitFunctionFilter> SliceDistance;
 
 private:

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
@@ -16,43 +16,18 @@
 
 =========================================================================*/
 
-#include "vtkSlicerCurveRepresentation3D.h"
-
-#include "vtkCellLocator.h"
-#include "vtkCleanPolyData.h"
-#include "vtkPolyDataMapper.h"
-#include "vtkActor.h"
+// VTK includes
 #include "vtkActor2D.h"
-#include "vtkAssemblyPath.h"
-#include "vtkRenderer.h"
-#include "vtkRenderWindow.h"
-#include "vtkObjectFactory.h"
-#include "vtkProperty.h"
-#include "vtkAssemblyPath.h"
-#include "vtkMath.h"
-#include "vtkInteractorObserver.h"
-#include "vtkLine.h"
-#include "vtkCoordinate.h"
+#include "vtkCellLocator.h"
 #include "vtkGlyph3D.h"
-#include "vtkCursor2D.h"
-#include "vtkCylinderSource.h"
-#include "vtkPolyData.h"
-#include "vtkPoints.h"
-#include "vtkDoubleArray.h"
+#include "vtkPolyDataMapper.h"
 #include "vtkPointData.h"
-#include "vtkTransformPolyDataFilter.h"
-#include "vtkTransform.h"
-#include "vtkCamera.h"
-#include "vtkPoints.h"
-#include "vtkCellArray.h"
-#include "vtkSphereSource.h"
-#include "vtkPropPicker.h"
-#include "vtkAppendPolyData.h"
-#include "vtkStringArray.h"
+#include "vtkProperty.h"
+#include "vtkRenderer.h"
+#include "vtkSlicerCurveRepresentation3D.h"
 #include "vtkTubeFilter.h"
-#include "vtkTextActor.h"
-#include "cmath"
-#include "vtkTextProperty.h"
+
+// MRML includes
 #include "vtkMRMLMarkupsDisplayNode.h"
 
 vtkStandardNewMacro(vtkSlicerCurveRepresentation3D);
@@ -91,23 +66,23 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   if (!markupsNode || !this->MarkupsDisplayNode
     || !this->MarkupsDisplayNode->GetVisibility()
     || !this->MarkupsDisplayNode->IsDisplayableInView(this->ViewNode->GetID()))
-  {
+    {
     this->VisibilityOff();
     return;
-  }
+    }
 
   this->VisibilityOn();
 
   // Line display
 
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
-  {
+    {
     ControlPointsPipeline3D* controlPoints = this->GetControlPointsPipeline(controlPointType);
     controlPoints->LabelsActor->SetVisibility(this->MarkupsDisplayNode->GetTextVisibility());
     controlPoints->Glypher->SetScaleFactor(this->ControlPointSize);
 
     this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->Mapper);
-  }
+    }
 
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
 
@@ -118,32 +93,32 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   bool allControlPointsSelected = this->GetAllControlPointsSelected();
   int controlPointType = Active;
   if (this->MarkupsDisplayNode->GetActiveComponentType() != vtkMRMLMarkupsDisplayNode::ComponentLine)
-  {
+    {
     controlPointType = allControlPointsSelected ? Selected : Unselected;
-  }
+    }
   this->LineActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
 
   bool allNodesHidden = true;
   for (int controlPointIndex = 0; controlPointIndex < markupsNode->GetNumberOfControlPoints(); controlPointIndex++)
-  {
-    if (markupsNode->GetNthControlPointVisibility(controlPointIndex))
     {
+    if (markupsNode->GetNthControlPointVisibility(controlPointIndex))
+      {
       allNodesHidden = false;
       break;
+      }
     }
-  }
 
   if (this->ClosedLoop && markupsNode->GetNumberOfControlPoints() > 2 && !allNodesHidden)
-  {
+    {
     double centerPosWorld[3], orient[3] = { 0 };
     markupsNode->GetCenterPosition(centerPosWorld);
     int centerControlPointType = allControlPointsSelected ? Selected : Unselected;
     if (this->MarkupsDisplayNode->GetActiveComponentType() == vtkMRMLMarkupsDisplayNode::ComponentCenterPoint)
-    {
+      {
       centerControlPointType = Active;
       this->GetControlPointsPipeline(centerControlPointType)->ControlPoints->SetNumberOfPoints(0);
       this->GetControlPointsPipeline(centerControlPointType)->ControlPointsPolyData->GetPointData()->GetNormals()->SetNumberOfTuples(0);
-    }
+      }
     this->GetControlPointsPipeline(centerControlPointType)->ControlPoints->InsertNextPoint(centerPosWorld);
     this->GetControlPointsPipeline(centerControlPointType)->ControlPointsPolyData->GetPointData()->GetNormals()->InsertNextTuple(orient);
 
@@ -151,11 +126,11 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
     this->GetControlPointsPipeline(centerControlPointType)->ControlPointsPolyData->GetPointData()->GetNormals()->Modified();
     this->GetControlPointsPipeline(centerControlPointType)->ControlPointsPolyData->Modified();
     if (centerControlPointType == Active)
-    {
+      {
       this->GetControlPointsPipeline(centerControlPointType)->Actor->VisibilityOn();
       this->GetControlPointsPipeline(centerControlPointType)->LabelsActor->VisibilityOff();
+      }
     }
-  }
 }
 
 //----------------------------------------------------------------------
@@ -243,14 +218,14 @@ void vtkSlicerCurveRepresentation3D::CanInteract(
   foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentNone;
   vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
   if (!markupsNode || markupsNode->GetLocked() || markupsNode->GetNumberOfControlPoints() < 1)
-  {
+    {
     return;
-  }
+    }
   Superclass::CanInteract(displayPosition, worldPosition, foundComponentType, foundComponentIndex, closestDistance2);
   if (foundComponentType != vtkMRMLMarkupsDisplayNode::ComponentNone)
-  {
+    {
     return;
-  }
+    }
 
   this->CanInteractWithCurve(displayPosition, worldPosition, foundComponentType, foundComponentIndex, closestDistance2);
 }
@@ -275,7 +250,7 @@ void vtkSlicerCurveRepresentation3D::PrintSelf(ostream& os, vtkIndent indent)
 void vtkSlicerCurveRepresentation3D::SetMarkupsNode(vtkMRMLMarkupsNode *markupsNode)
 {
   if (this->MarkupsNode != markupsNode)
-    {
+  {
     if (markupsNode)
       {
       this->TubeFilter->SetInputConnection(markupsNode->GetCurveWorldConnection());
@@ -284,7 +259,7 @@ void vtkSlicerCurveRepresentation3D::SetMarkupsNode(vtkMRMLMarkupsNode *markupsN
       {
       this->TubeFilter->SetInputData(this->Line);
       }
-    }
+  }
   this->Superclass::SetMarkupsNode(markupsNode);
 }
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.h
@@ -34,14 +34,11 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation3D.h"
 
-class vtkAppendPolyData;
-class vtkCellLocator;
 class vtkActor;
+class vtkCellLocator;
 class vtkPolyDataMapper;
 class vtkPolyData;
 class vtkTubeFilter;
-class vtkTextActor;
-class vtkArcSource;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerCurveRepresentation3D : public vtkSlicerMarkupsWidgetRepresentation3D
 {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.h
@@ -33,13 +33,8 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation2D.h"
 
-class vtkActor2D;
-class vtkAppendPolyData;
-class vtkPolyDataMapper2D;
-class vtkPolyData;
-class vtkProperty2D;
 class vtkTubeFilter;
-class vtkPropPicker;
+class vtkSampleImplicitFunctionFilter;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerLineRepresentation2D : public vtkSlicerMarkupsWidgetRepresentation2D
 {
@@ -75,11 +70,17 @@ protected:
   vtkSlicerLineRepresentation2D();
   ~vtkSlicerLineRepresentation2D() override;
 
+  void SetMarkupsNode(vtkMRMLMarkupsNode *markupsNode) override;
+
   vtkSmartPointer<vtkPolyData> Line;
   vtkSmartPointer<vtkPolyDataMapper2D> LineMapper;
   vtkSmartPointer<vtkActor2D> LineActor;
+  vtkSmartPointer<vtkDiscretizableColorTransferFunction> LineColorMap;
 
   vtkSmartPointer<vtkTubeFilter> TubeFilter;
+
+  vtkSmartPointer<vtkTransformPolyDataFilter> WorldToSliceTransformer;
+  vtkSmartPointer<vtkSampleImplicitFunctionFilter> SliceDistance;
 
 private:
   vtkSlicerLineRepresentation2D(const vtkSlicerLineRepresentation2D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -16,38 +16,16 @@
 
 =========================================================================*/
 
-#include "vtkSlicerLineRepresentation3D.h"
-#include "vtkCleanPolyData.h"
-#include "vtkPolyDataMapper.h"
-#include "vtkActor.h"
+// VTK includes
 #include "vtkActor2D.h"
-#include "vtkAssemblyPath.h"
-#include "vtkRenderer.h"
-#include "vtkRenderWindow.h"
-#include "vtkObjectFactory.h"
-#include "vtkProperty.h"
-#include "vtkAssemblyPath.h"
-#include "vtkMath.h"
-#include "vtkInteractorObserver.h"
-#include "vtkLine.h"
-#include "vtkCoordinate.h"
 #include "vtkGlyph3D.h"
-#include "vtkCursor2D.h"
-#include "vtkCylinderSource.h"
-#include "vtkPolyData.h"
-#include "vtkPoints.h"
-#include "vtkDoubleArray.h"
-#include "vtkPointData.h"
-#include "vtkTransformPolyDataFilter.h"
-#include "vtkTransform.h"
-#include "vtkCamera.h"
-#include "vtkPoints.h"
-#include "vtkCellArray.h"
-#include "vtkSphereSource.h"
-#include "vtkPropPicker.h"
-#include "vtkAppendPolyData.h"
-#include "vtkStringArray.h"
+#include "vtkPolyDataMapper.h"
+#include "vtkProperty.h"
+#include "vtkRenderer.h"
+#include "vtkSlicerLineRepresentation3D.h"
 #include "vtkTubeFilter.h"
+
+// MRML includes
 #include "vtkMRMLMarkupsDisplayNode.h"
 
 vtkStandardNewMacro(vtkSlicerLineRepresentation3D);
@@ -94,9 +72,9 @@ int vtkSlicerLineRepresentation3D::RenderOverlay(vtkViewport *viewport)
   int count=0;
   count = this->Superclass::RenderOverlay(viewport);
   if (this->LineActor->GetVisibility())
-  {
+    {
     count +=  this->LineActor->RenderOverlay(viewport);
-  }
+    }
   return count;
 }
 
@@ -107,9 +85,9 @@ int vtkSlicerLineRepresentation3D::RenderOpaqueGeometry(
   int count=0;
   count = this->Superclass::RenderOpaqueGeometry(viewport);
   if (this->LineActor->GetVisibility())
-  {
+    {
     count += this->LineActor->RenderOpaqueGeometry(viewport);
-  }
+    }
   return count;
 }
 
@@ -120,9 +98,9 @@ int vtkSlicerLineRepresentation3D::RenderTranslucentPolygonalGeometry(
   int count=0;
   count = this->Superclass::RenderTranslucentPolygonalGeometry(viewport);
   if (this->LineActor->GetVisibility())
-  {
+    {
     count += this->LineActor->RenderTranslucentPolygonalGeometry(viewport);
-  }
+    }
   return count;
 }
 
@@ -161,10 +139,10 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
   if (!markupsNode || !this->MarkupsDisplayNode
     || !this->MarkupsDisplayNode->GetVisibility()
     || !this->MarkupsDisplayNode->IsDisplayableInView(this->ViewNode->GetID()))
-  {
+    {
     this->VisibilityOff();
     return;
-  }
+    }
 
   this->VisibilityOn();
 
@@ -175,12 +153,12 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
   // Line display
 
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
-  {
+    {
     ControlPointsPipeline3D* controlPoints = this->GetControlPointsPipeline(controlPointType);
     controlPoints->LabelsActor->SetVisibility(this->MarkupsDisplayNode->GetTextVisibility());
     controlPoints->Glypher->SetScaleFactor(this->ControlPointSize);
     this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->Mapper);
-  }
+    }
 
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
 
@@ -203,15 +181,15 @@ void vtkSlicerLineRepresentation3D::CanInteract(
   foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentNone;
   vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
   if (!markupsNode || markupsNode->GetLocked() || markupsNode->GetNumberOfControlPoints() < 1)
-  {
+    {
     return;
-  }
+    }
   Superclass::CanInteract(displayPosition, worldPosition, foundComponentType, foundComponentIndex, closestDistance2);
   if (foundComponentType != vtkMRMLMarkupsDisplayNode::ComponentNone)
-  {
+    {
     // if mouse is near a control point then select that (ignore the line)
     return;
-  }
+    }
 
   this->CanInteractWithLine(displayPosition, worldPosition, foundComponentType, foundComponentIndex, closestDistance2);
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
@@ -33,7 +33,6 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation3D.h"
 
-class vtkAppendPolyData;
 class vtkActor;
 class vtkPolyDataMapper;
 class vtkPolyData;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
@@ -67,7 +67,8 @@ public:
     WidgetEventControlPointMoveStart,
     WidgetEventControlPointMoveEnd,
     WidgetEventControlPointDelete,
-    WidgetEventControlPointInsert
+    WidgetEventControlPointInsert,
+    WidgetEventControlPointSnapToSlice
   };
 
   // Returns true if one of the markup points are just being previewed and not placed yet.
@@ -117,7 +118,7 @@ protected:
   void StartWidgetInteraction(vtkMRMLInteractionEventData* eventData);
   void EndWidgetInteraction();
 
-  virtual void TranslatePoint(double eventPos[2]);
+  virtual void TranslatePoint(double eventPos[2], bool snapToSlice = false);
   virtual void TranslateWidget(double eventPos[2]);
   virtual void ScaleWidget(double eventPos[2]);
   virtual void RotateWidget(double eventPos[2]);
@@ -140,6 +141,7 @@ protected:
   // placing the widget.
   // Return true if the event is processed.
   virtual bool ProcessMouseMove(vtkMRMLInteractionEventData* eventData);
+  virtual bool ProcessControlPointSnapToSlice(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessControlPointDelete(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessControlPointInsert(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessControlPointMoveStart(vtkMRMLInteractionEventData* eventData);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -47,23 +47,11 @@
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkMRMLMarkupsNode.h"
 
-class vtkMapper;
 class vtkMarkupsGlyphSource2D;
-class vtkPolyData;
-class vtkPoints;
-
 class vtkPointPlacer;
-class vtkPolyData;
-class vtkIdList;
 class vtkPointSetToLabelHierarchy;
 class vtkSphereSource;
-class vtkStringArray;
 class vtkTextProperty;
-
-#include "vtkBoundingBox.h"
-
-class ControlPointsPipeline;
-class vtkMRMLAbstractViewNode;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerMarkupsWidgetRepresentation : public vtkMRMLAbstractWidgetRepresentation
 {
@@ -164,12 +152,14 @@ protected:
     Unselected,
     Selected,
     Active,
+    Project,
+    ProjectBack,
     NumberOfControlPointTypes
   };
 
   double* GetWidgetColor(int controlPointType);
 
-  ControlPointsPipeline* ControlPoints[3]; // Unselected, Selected, Active
+  ControlPointsPipeline* ControlPoints[5]; // Unselected, Selected, Active, Project, ProjectBehind
 
 private:
   vtkSlicerMarkupsWidgetRepresentation(const vtkSlicerMarkupsWidgetRepresentation&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
@@ -36,9 +36,11 @@
 #include "vtkMRMLSliceNode.h"
 
 class vtkActor2D;
+class vtkDiscretizableColorTransferFunction;
 class vtkGlyph2D;
 class vtkLabelPlacementMapper;
 class vtkMarkupsGlyphSource2D;
+class vtkPlane;
 class vtkPolyDataMapper2D;
 class vtkProperty2D;
 
@@ -96,10 +98,21 @@ protected:
     /// Get MRML view node as slice view node
   vtkMRMLSliceNode *GetSliceNode();
 
+  void UpdatePlaneFromSliceNode();
+
   bool GetAllControlPointsVisible() override;
 
   /// Check, if the point is displayable in the current slice geometry
   virtual bool IsPointDisplayableOnSlice(vtkMRMLMarkupsNode* node, int pointIndex = 0);
+
+  // Update colormap based on provided base color (modulated with settings stored in the display node)
+  void UpdateDistanceColorMap(vtkDiscretizableColorTransferFunction* colormap, double color[3]);
+
+  /// Check, if the point is behind in the current slice geometry
+  virtual bool IsPointBehindSlice(vtkMRMLMarkupsNode* node, int pointIndex = 0);
+
+  /// Check, if the point is in front in the current slice geometry
+  virtual bool IsPointInFrontSlice(vtkMRMLMarkupsNode* node, int pointIndex = 0);
 
   /// Check, if the point is displayable in the current slice geometry
   virtual bool IsCenterDisplayableOnSlice(vtkMRMLMarkupsNode* node);
@@ -127,12 +140,17 @@ protected:
   ControlPointsPipeline2D* GetControlPointsPipeline(int controlPointType);
 
   vtkSmartPointer<vtkIntArray> PointsVisibilityOnSlice;
-  bool                        CenterVisibilityOnSlice;
+  bool                         CenterVisibilityOnSlice;
+
+  vtkSmartPointer<vtkTransform> WorldToSliceTransform;
+  vtkSmartPointer<vtkPlane> SlicePlane;
 
   /// Scale factor for 2d windows
   double ScaleFactor2D;
 
   virtual void UpdateAllPointsAndLabelsFromMRML(double labelsOffset);
+
+  double GetWidgetOpacity(int controlPointType);
 
 private:
   vtkSlicerMarkupsWidgetRepresentation2D(const vtkSlicerMarkupsWidgetRepresentation2D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -16,51 +16,27 @@
 
 =========================================================================*/
 
-#include "vtkSlicerMarkupsWidgetRepresentation3D.h"
-#include "vtkCellPicker.h"
-#include "vtkCleanPolyData.h"
-#include "vtkPolyDataMapper.h"
-#include "vtkActor.h"
-#include "vtkAssemblyPath.h"
-#include "vtkRenderer.h"
-#include "vtkRenderWindow.h"
-#include "vtkObjectFactory.h"
-#include "vtkAssemblyPath.h"
-#include "vtkMath.h"
-#include "vtkInteractorObserver.h"
-#include "vtkIncrementalOctreePointLocator.h"
-#include "vtkLine.h"
-#include "vtkCoordinate.h"
-#include "vtkGlyph3D.h"
-#include "vtkCursor2D.h"
-#include "vtkCylinderSource.h"
-#include "vtkPolyData.h"
-#include "vtkPoints.h"
-#include "vtkDoubleArray.h"
-#include "vtkPointData.h"
-#include "vtkTransformPolyDataFilter.h"
-#include "vtkTransform.h"
+// VTK includes
 #include "vtkCamera.h"
-#include "vtkPoints.h"
-#include "vtkCellArray.h"
-#include "vtkSphereSource.h"
-#include "vtkBox.h"
-#include "vtkIntArray.h"
+#include "vtkCellPicker.h"
+#include "vtkLabelPlacementMapper.h"
+#include "vtkLine.h"
+#include "vtkGlyph3D.h"
+#include "vtkMarkupsGlyphSource2D.h"
+#include "vtkMath.h"
 #include "vtkMatrix4x4.h"
 #include "vtkObjectFactory.h"
-#include "vtkRenderer.h"
-#include "vtkRenderWindow.h"
-#include "vtkWindow.h"
-#include "vtkProperty.h"
-#include "vtkTextProperty.h"
-#include "vtkActor2D.h"
-#include "vtkLabelPlacementMapper.h"
+#include "vtkPointData.h"
 #include "vtkPointSetToLabelHierarchy.h"
-#include "vtkStringArray.h"
-#include "vtkLabelHierarchy.h"
-#include "vtkMRMLMarkupsDisplayNode.h"
+#include "vtkPolyDataMapper.h"
+#include "vtkProperty.h"
+#include "vtkRenderer.h"
 #include "vtkSelectVisiblePoints.h"
-#include "vtkMarkupsGlyphSource2D.h"
+#include "vtkSlicerMarkupsWidgetRepresentation3D.h"
+#include "vtkSphereSource.h"
+#include "vtkStringArray.h"
+#include "vtkTextActor.h"
+#include "vtkTextProperty.h"
 
 vtkSlicerMarkupsWidgetRepresentation3D::ControlPointsPipeline3D::ControlPointsPipeline3D()
 {
@@ -160,13 +136,13 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateNthPointAndLabelFromMRML(int 
   /*
   TODO: implement this for better performance
   if (markupsNode->GetNumberOfControlPoints() - 1 >= this->PointsVisibilityOnSlice->GetNumberOfValues())
-  {
+    {
     this->PointsVisibilityOnSlice->InsertValue(markupsNode->GetNumberOfControlPoints() - 1, 1);
-  }
+    }
   else
-  {
+    {
     this->PointsVisibilityOnSlice->InsertNextValue(1);
-  }
+    }
   this->UpdateInterpolatedPoints(markupsNode->GetNumberOfControlPoints() - 1);
   */
 }
@@ -194,7 +170,6 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
     this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->Mapper);
     controlPoints->Glypher->SetScaleFactor(this->ControlPointSize);
     }
-
 
   int activeControlPointIndex = this->MarkupsDisplayNode->GetActiveControlPoint();
 
@@ -272,7 +247,6 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
     controlPoints->LabelControlPoints->Modified();
     controlPoints->LabelControlPointsPolyData->GetPointData()->GetNormals()->Modified();
     controlPoints->LabelControlPointsPolyData->Modified();
-
     }
 }
 
@@ -402,8 +376,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller,
   vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
   if (!this->ViewNode || !markupsNode || !this->MarkupsDisplayNode
     || !this->MarkupsDisplayNode->GetVisibility()
-    || !this->MarkupsDisplayNode->IsDisplayableInView(this->ViewNode->GetID())
-    )
+    || !this->MarkupsDisplayNode->IsDisplayableInView(this->ViewNode->GetID()))
     {
     this->VisibilityOff();
     return;
@@ -461,7 +434,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller,
 void vtkSlicerMarkupsWidgetRepresentation3D::GetActors(vtkPropCollection *pc)
 {
   for (int i = 0; i < NumberOfControlPointTypes; i++)
-    {
+   {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
     controlPoints->Actor->GetActors(pc);
     controlPoints->LabelsActor->GetActors(pc);
@@ -569,11 +542,11 @@ double *vtkSlicerMarkupsWidgetRepresentation3D::GetBounds()
 {
   vtkBoundingBox boundingBox;
   const std::vector<vtkProp*> actors(
-    {
+  {
     reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[Unselected])->Actor,
     reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[Selected])->Actor,
     reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[Active])->Actor
-    });
+  });
   this->AddActorsBounds(boundingBox, actors, Superclass::GetBounds());
   boundingBox.GetBounds(this->Bounds);
   return this->Bounds;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -30,21 +30,14 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation.h"
 
-#include "vtkMRMLMarkupsNode.h"
-
-#include <vector> // STL Header; Required for vector
-
+class vtkActor;
 class vtkActor2D;
 class vtkCellPicker;
 class vtkGlyph3D;
 class vtkLabelPlacementMapper;
-class vtkActor;
 class vtkPolyDataMapper;
-class vtkPointSetToLabelHierarchy;
 class vtkProperty;
 class vtkSelectVisiblePoints;
-class vtkStringArray;
-class vtkTextProperty;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerMarkupsWidgetRepresentation3D : public vtkSlicerMarkupsWidgetRepresentation
 {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPointsRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPointsRepresentation2D.h
@@ -33,8 +33,6 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation2D.h"
 
-class vtkAppendPolyData;
-
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerPointsRepresentation2D : public vtkSlicerMarkupsWidgetRepresentation2D
 {
 public:

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPointsRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPointsRepresentation3D.h
@@ -33,8 +33,6 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation3D.h"
 
-class vtkAppendPolyData;
-
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerPointsRepresentation3D : public vtkSlicerMarkupsWidgetRepresentation3D
 {
 public:

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsFiducialProjectionPropertyWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsFiducialProjectionPropertyWidget.cxx
@@ -94,11 +94,11 @@ qMRMLMarkupsFiducialProjectionPropertyWidget
 
 //-----------------------------------------------------------------------------
 void qMRMLMarkupsFiducialProjectionPropertyWidget
-::setMRMLFiducialNode(vtkMRMLMarkupsFiducialNode* fiducialNode)
+::setMRMLMarkupsNode(vtkMRMLMarkupsNode* markupsNode)
 {
   Q_D(qMRMLMarkupsFiducialProjectionPropertyWidget);
   vtkMRMLMarkupsDisplayNode* displayNode
-    = fiducialNode ? fiducialNode->GetMarkupsDisplayNode() : nullptr;
+    = markupsNode ? markupsNode->GetMarkupsDisplayNode() : nullptr;
 
   qvtkReconnect(d->FiducialDisplayNode, displayNode, vtkCommand::ModifiedEvent,
                 this, SLOT(updateWidgetFromDisplayNode()));
@@ -209,8 +209,7 @@ void qMRMLMarkupsFiducialProjectionPropertyWidget
   // Update widget if different from MRML node
   // -- 2D Projection Visibility
   d->point2DProjectionCheckBox->setChecked(
-    d->FiducialDisplayNode->GetSliceProjection() &
-    vtkMRMLMarkupsDisplayNode::ProjectionOn);
+    d->FiducialDisplayNode->GetSliceProjection());
 
   // -- Projection Color
   double pColor[3];

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsFiducialProjectionPropertyWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsFiducialProjectionPropertyWidget.h
@@ -34,7 +34,7 @@
 #include "qSlicerMarkupsModuleWidgetsExport.h"
 
 class qMRMLMarkupsFiducialProjectionPropertyWidgetPrivate;
-class vtkMRMLMarkupsFiducialNode;
+class vtkMRMLMarkupsNode;
 
 /// \ingroup Slicer_QtModules_Markups
 class Q_SLICER_MODULE_MARKUPS_WIDGETS_EXPORT
@@ -50,7 +50,7 @@ public:
   ~qMRMLMarkupsFiducialProjectionPropertyWidget() override;
 
 public slots:
-  void setMRMLFiducialNode(vtkMRMLMarkupsFiducialNode* fiducialNode);
+  void setMRMLMarkupsNode(vtkMRMLMarkupsNode* markupsNode);
   void setProjectionVisibility(bool showProjection);
   void setProjectionColor(QColor newColor);
   void setUseFiducialColor(bool useFiducialColor);

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -768,16 +768,7 @@ void qSlicerMarkupsModuleWidget::updateWidgetFromMRML()
   d->sliceIntersectionsVisibilityCheckBox->setChecked(this->sliceIntersectionsVisible());
 
   // update the point projections
-  // To DO: update to use also other markups nodes
-  if (markupsNode->IsA("vtkMRMLMarkupsFiducialNode"))
-    {
-    d->pointFiducialProjectionWidget->setMRMLFiducialNode(
-        vtkMRMLMarkupsFiducialNode::SafeDownCast(markupsNode));
-    }
-  else
-    {
-    d->pointFiducialProjectionWidget->setMRMLFiducialNode(nullptr);
-    }
+  d->pointFiducialProjectionWidget->setMRMLMarkupsNode(markupsNode);
 
   // update the list name format
   QString nameFormat = QString(markupsNode->GetMarkupLabelFormat().c_str());


### PR DESCRIPTION
This adds the slice distance color mapping for all the line actors of the new markups widgets. 

It is possible to create the color mapping in two ways: 1) giving a procedural color node (by setting the reference in the display node of the markups); 2) using a default mapping which is possible to modify by changing the parameters of the display node: color, opacity, distance fading, saturation and hue offset. If the line color mapping node is set, it will overwrite the "default" one (i.e. 1 overwrites 2).

The PR fix also some style issues: removed many unnecessary includes and added parenthesis double spaces (it was not uniform). 

Still TO DO:
- [x] 1) Projection of the point for all the widget (project behind slice and in front of slice);
- [ ] 2) highlight widget-slice intersection with a thick circle or X where the contour intersects the slice exactly . 

Update: (2) will not be done in this PR.
Please @lassoan review anytime. Thanks!