### PR TITLE
ENH: Modernize: use delete for not implemented functions

### DIFF
--- a/Base/Logic/vtkImageFillROI.h
+++ b/Base/Logic/vtkImageFillROI.h
@@ -95,8 +95,8 @@ protected:
                           vtkInformationVector* outputVector) override;
 
 private:
-  vtkImageFillROI(const vtkImageFillROI&);
-  void operator=(const vtkImageFillROI&);
+  vtkImageFillROI(const vtkImageFillROI&) = delete;
+  void operator=(const vtkImageFillROI&) = delete;
 };
 
 #endif

--- a/Base/Logic/vtkImageRectangularSource.h
+++ b/Base/Logic/vtkImageRectangularSource.h
@@ -96,8 +96,8 @@ protected:
   int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
   void ExecuteDataWithInformation(vtkDataObject *output, vtkInformation* outInfo) override;
 private:
-  vtkImageRectangularSource(const vtkImageRectangularSource&);  /// Not implemented.
-  void operator=(const vtkImageRectangularSource&);  /// Not implemented.
+  vtkImageRectangularSource(const vtkImageRectangularSource&) = delete;
+  void operator=(const vtkImageRectangularSource&) = delete;
 };
 
 

--- a/Base/Logic/vtkSlicerGlyphSource2D.h
+++ b/Base/Logic/vtkSlicerGlyphSource2D.h
@@ -179,8 +179,8 @@ protected:
                        vtkCellArray *polys, vtkUnsignedCharArray *colors, double scale);
 
 private:
-  vtkSlicerGlyphSource2D(const vtkSlicerGlyphSource2D&);  /// Not implemented.
-  void operator=(const vtkSlicerGlyphSource2D&);  /// Not implemented.
+  vtkSlicerGlyphSource2D(const vtkSlicerGlyphSource2D&) = delete;
+  void operator=(const vtkSlicerGlyphSource2D&) = delete;
 };
 
 #endif

--- a/Base/Logic/vtkSlicerModuleLogic.h
+++ b/Base/Logic/vtkSlicerModuleLogic.h
@@ -43,8 +43,8 @@ protected:
 
 private:
 
-  vtkSlicerModuleLogic(const vtkSlicerModuleLogic&); // Not implemented
-  void operator=(const vtkSlicerModuleLogic&);       // Not implemented
+  vtkSlicerModuleLogic(const vtkSlicerModuleLogic&) = delete;
+  void operator=(const vtkSlicerModuleLogic&) = delete;
 
   std::string ModuleShareDirectory;
 };

--- a/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.h
+++ b/Base/Logic/vtkSlicerScriptedLoadableModuleLogic.h
@@ -49,8 +49,8 @@ protected:
 
 private:
 
-  vtkSlicerScriptedLoadableModuleLogic(const vtkSlicerScriptedLoadableModuleLogic&); // Not implemented
-  void operator=(const vtkSlicerScriptedLoadableModuleLogic&);       // Not implemented
+  vtkSlicerScriptedLoadableModuleLogic(const vtkSlicerScriptedLoadableModuleLogic&) = delete;
+  void operator=(const vtkSlicerScriptedLoadableModuleLogic&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Base/Logic/vtkTransformVisualizerGlyph3D.h
+++ b/Base/Logic/vtkTransformVisualizerGlyph3D.h
@@ -91,8 +91,8 @@ protected:
   int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
 private:
-  vtkTransformVisualizerGlyph3D(const vtkTransformVisualizerGlyph3D&);  // Not implemented.
-  void operator=(const vtkTransformVisualizerGlyph3D&);  // Not implemented.
+  vtkTransformVisualizerGlyph3D(const vtkTransformVisualizerGlyph3D&) = delete;
+  void operator=(const vtkTransformVisualizerGlyph3D&) = delete;
 };
 
 #endif

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.h
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.h
@@ -159,8 +159,8 @@ protected:
 private:
   vtkSlicerCLIModuleLogic();
   ~vtkSlicerCLIModuleLogic() override;
-  vtkSlicerCLIModuleLogic(const vtkSlicerCLIModuleLogic&);
-  void operator=(const vtkSlicerCLIModuleLogic&);
+  vtkSlicerCLIModuleLogic(const vtkSlicerCLIModuleLogic&) = delete;
+  void operator=(const vtkSlicerCLIModuleLogic&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/FreeSurfer/vtkFSSurfaceAnnotationReader.h
+++ b/Libs/FreeSurfer/vtkFSSurfaceAnnotationReader.h
@@ -95,8 +95,8 @@ protected:
 
 
 private:
-  vtkFSSurfaceAnnotationReader(const vtkFSSurfaceAnnotationReader&);  /// Not implemented.
-  void operator=(const vtkFSSurfaceAnnotationReader&);  /// Not implemented.
+  vtkFSSurfaceAnnotationReader(const vtkFSSurfaceAnnotationReader&) = delete;
+  void operator=(const vtkFSSurfaceAnnotationReader&) = delete;
 };
 
 #endif

--- a/Libs/FreeSurfer/vtkFSSurfaceLabelReader.h
+++ b/Libs/FreeSurfer/vtkFSSurfaceLabelReader.h
@@ -100,8 +100,8 @@ protected:
   int ReadFloat (FILE* iFile, float& oInt);
 */
 private:
-  vtkFSSurfaceLabelReader(const vtkFSSurfaceLabelReader&);  /// Not implemented.
-  void operator=(const vtkFSSurfaceLabelReader&);  /// Not implemented.
+  vtkFSSurfaceLabelReader(const vtkFSSurfaceLabelReader&) = delete;
+  void operator=(const vtkFSSurfaceLabelReader&) = delete;
 };
 
 #endif

--- a/Libs/FreeSurfer/vtkFSSurfaceReader.h
+++ b/Libs/FreeSurfer/vtkFSSurfaceReader.h
@@ -59,8 +59,8 @@ protected:
     vtkInformationVector *outputVector) override;
 
 private:
-  vtkFSSurfaceReader(const vtkFSSurfaceReader&);  /// Not implemented.
-  void operator=(const vtkFSSurfaceReader&);  /// Not implemented.
+  vtkFSSurfaceReader(const vtkFSSurfaceReader&) = delete;
+  void operator=(const vtkFSSurfaceReader&) = delete;
 };
 
 

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -298,8 +298,8 @@ protected:
 private:
   vtkMRMLCommandLineModuleNode();
   ~vtkMRMLCommandLineModuleNode() override;
-  vtkMRMLCommandLineModuleNode(const vtkMRMLCommandLineModuleNode&);
-  void operator=(const vtkMRMLCommandLineModuleNode&);
+  vtkMRMLCommandLineModuleNode(const vtkMRMLCommandLineModuleNode&) = delete;
+  void operator=(const vtkMRMLCommandLineModuleNode&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/Core/vtkDataFileFormatHelper.h
+++ b/Libs/MRML/Core/vtkDataFileFormatHelper.h
@@ -58,8 +58,8 @@ class VTK_MRML_EXPORT vtkDataFileFormatHelper : public vtkObject
      ITKImageFileFormat& structFileFormat);
 
 private:
-  vtkDataFileFormatHelper(const vtkDataFileFormatHelper&);
-  void operator=(const vtkDataFileFormatHelper&);
+  vtkDataFileFormatHelper(const vtkDataFileFormatHelper&) = delete;
+  void operator=(const vtkDataFileFormatHelper&) = delete;
 };
 
 #endif

--- a/Libs/MRML/Core/vtkImageBimodalAnalysis.h
+++ b/Libs/MRML/Core/vtkImageBimodalAnalysis.h
@@ -88,8 +88,8 @@ protected:
   void ExecuteDataWithInformation(vtkDataObject *, vtkInformation*) override;
 
 private:
-  vtkImageBimodalAnalysis(const vtkImageBimodalAnalysis&);
-  void operator=(const vtkImageBimodalAnalysis&);
+  vtkImageBimodalAnalysis(const vtkImageBimodalAnalysis&) = delete;
+  void operator=(const vtkImageBimodalAnalysis&) = delete;
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
@@ -148,8 +148,8 @@ protected:
   ~vtkMRMLSegmentationStorageNode() override;
 
 private:
-  vtkMRMLSegmentationStorageNode(const vtkMRMLSegmentationStorageNode&);  /// Not implemented.
-  void operator=(const vtkMRMLSegmentationStorageNode&);  /// Not implemented.
+  vtkMRMLSegmentationStorageNode(const vtkMRMLSegmentationStorageNode&) = delete;
+  void operator=(const vtkMRMLSegmentationStorageNode&) = delete;
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
@@ -238,8 +238,8 @@ private:
   /// Incremental ID used to uniquely identify subject hierarchy items
   static vtkIdType NextSubjectHierarchyItemID;
 
-  vtkSubjectHierarchyItem(const vtkSubjectHierarchyItem&); // Not implemented
-  void operator=(const vtkSubjectHierarchyItem&);          // Not implemented
+  vtkSubjectHierarchyItem(const vtkSubjectHierarchyItem&) = delete;
+  void operator=(const vtkSubjectHierarchyItem&) = delete;
 };
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestCustomDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestCustomDisplayableManager.h
@@ -53,8 +53,8 @@ protected:
 
 private:
 
-  vtkMRMLTestCustomDisplayableManager(const vtkMRMLTestCustomDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLTestCustomDisplayableManager&);                     // Not Implemented
+  vtkMRMLTestCustomDisplayableManager(const vtkMRMLTestCustomDisplayableManager&) = delete;
+  void operator=(const vtkMRMLTestCustomDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestSliceViewDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestSliceViewDisplayableManager.h
@@ -57,8 +57,8 @@ protected:
 
 private:
 
-  vtkMRMLTestSliceViewDisplayableManager(const vtkMRMLTestSliceViewDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLTestSliceViewDisplayableManager&);                     // Not Implemented
+  vtkMRMLTestSliceViewDisplayableManager(const vtkMRMLTestSliceViewDisplayableManager&) = delete;
+  void operator=(const vtkMRMLTestSliceViewDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestThreeDViewDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/Testing/Cxx/vtkMRMLTestThreeDViewDisplayableManager.h
@@ -57,8 +57,8 @@ protected:
 
 private:
 
-  vtkMRMLTestThreeDViewDisplayableManager(const vtkMRMLTestThreeDViewDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLTestThreeDViewDisplayableManager&);                     // Not Implemented
+  vtkMRMLTestThreeDViewDisplayableManager(const vtkMRMLTestThreeDViewDisplayableManager&) = delete;
+  void operator=(const vtkMRMLTestThreeDViewDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.h
@@ -272,8 +272,8 @@ protected:
 
 private:
 
-  vtkMRMLAbstractDisplayableManager(const vtkMRMLAbstractDisplayableManager&); // Not implemented
-  void operator=(const vtkMRMLAbstractDisplayableManager&);                    // Not implemented
+  vtkMRMLAbstractDisplayableManager(const vtkMRMLAbstractDisplayableManager&) = delete;
+  void operator=(const vtkMRMLAbstractDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal* Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractSliceViewDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractSliceViewDisplayableManager.h
@@ -93,8 +93,8 @@ protected:
 
 private:
 
-  vtkMRMLAbstractSliceViewDisplayableManager(const vtkMRMLAbstractSliceViewDisplayableManager&); // Not implemented
-  void operator=(const vtkMRMLAbstractSliceViewDisplayableManager&);                    // Not implemented
+  vtkMRMLAbstractSliceViewDisplayableManager(const vtkMRMLAbstractSliceViewDisplayableManager&) = delete;
+  void operator=(const vtkMRMLAbstractSliceViewDisplayableManager&) = delete;
 };
 
 #endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractThreeDViewDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractThreeDViewDisplayableManager.h
@@ -66,8 +66,8 @@ protected:
 
 private:
 
-  vtkMRMLAbstractThreeDViewDisplayableManager(const vtkMRMLAbstractThreeDViewDisplayableManager&); // Not implemented
-  void operator=(const vtkMRMLAbstractThreeDViewDisplayableManager&);                    // Not implemented
+  vtkMRMLAbstractThreeDViewDisplayableManager(const vtkMRMLAbstractThreeDViewDisplayableManager&) = delete;
+  void operator=(const vtkMRMLAbstractThreeDViewDisplayableManager&) = delete;
 };
 
 #endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.h
@@ -79,8 +79,8 @@ protected:
 
 private:
 
-  vtkMRMLCameraDisplayableManager(const vtkMRMLCameraDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLCameraDisplayableManager&);                     // Not Implemented
+  vtkMRMLCameraDisplayableManager(const vtkMRMLCameraDisplayableManager&) = delete;
+  void operator=(const vtkMRMLCameraDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.h
@@ -64,8 +64,8 @@ protected:
   void AdditionalInitializeStep() override;
 
 private:
-  vtkMRMLCrosshairDisplayableManager(const vtkMRMLCrosshairDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLCrosshairDisplayableManager&);                     // Not Implemented
+  vtkMRMLCrosshairDisplayableManager(const vtkMRMLCrosshairDisplayableManager&) = delete;
+  void operator=(const vtkMRMLCrosshairDisplayableManager&) = delete;
 
   void UnobserveMRMLScene() override;
   void ObserveMRMLScene() override;

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager3D.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager3D.h
@@ -48,8 +48,8 @@ protected:
   void AdditionalInitializeStep() override;
 
 private:
-  vtkMRMLCrosshairDisplayableManager3D(const vtkMRMLCrosshairDisplayableManager3D&);// Not implemented
-  void operator=(const vtkMRMLCrosshairDisplayableManager3D&);                     // Not Implemented
+  vtkMRMLCrosshairDisplayableManager3D(const vtkMRMLCrosshairDisplayableManager3D&) = delete;
+  void operator=(const vtkMRMLCrosshairDisplayableManager3D&) = delete;
 
   void UnobserveMRMLScene() override;
   void ObserveMRMLScene() override;

--- a/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerFactory.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerFactory.h
@@ -95,8 +95,8 @@ protected:
 
 private:
 
-  vtkMRMLDisplayableManagerFactory(const vtkMRMLDisplayableManagerFactory&);
-  void operator=(const vtkMRMLDisplayableManagerFactory&);
+  vtkMRMLDisplayableManagerFactory(const vtkMRMLDisplayableManagerFactory&) = delete;
+  void operator=(const vtkMRMLDisplayableManagerFactory&) = delete;
 
 };
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerGroup.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLDisplayableManagerGroup.h
@@ -135,8 +135,8 @@ protected:
 
 private:
 
-  vtkMRMLDisplayableManagerGroup(const vtkMRMLDisplayableManagerGroup&);
-  void operator=(const vtkMRMLDisplayableManagerGroup&);
+  vtkMRMLDisplayableManagerGroup(const vtkMRMLDisplayableManagerGroup&) = delete;
+  void operator=(const vtkMRMLDisplayableManagerGroup&) = delete;
 
 };
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLLightBoxRendererManagerProxy.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLLightBoxRendererManagerProxy.h
@@ -46,8 +46,8 @@ protected:
   ~vtkMRMLLightBoxRendererManagerProxy() override ;
 
 private:
-  vtkMRMLLightBoxRendererManagerProxy(const vtkMRMLLightBoxRendererManagerProxy&); // Not implemented
-  void operator=(const vtkMRMLLightBoxRendererManagerProxy&);                    // Not implemented
+  vtkMRMLLightBoxRendererManagerProxy(const vtkMRMLLightBoxRendererManagerProxy&) = delete;
+  void operator=(const vtkMRMLLightBoxRendererManagerProxy&) = delete;
 
 
 };

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
@@ -219,8 +219,8 @@ protected:
 
 private:
 
-  vtkMRMLModelDisplayableManager(const vtkMRMLModelDisplayableManager&); // Not implemented
-  void operator=(const vtkMRMLModelDisplayableManager&);                 // Not Implemented
+  vtkMRMLModelDisplayableManager(const vtkMRMLModelDisplayableManager&) = delete;
+  void operator=(const vtkMRMLModelDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal* Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.h
@@ -68,8 +68,8 @@ protected:
 
 private:
 
-  vtkMRMLModelSliceDisplayableManager(const vtkMRMLModelSliceDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLModelSliceDisplayableManager&);                     // Not Implemented
+  vtkMRMLModelSliceDisplayableManager(const vtkMRMLModelSliceDisplayableManager&) = delete;
+  void operator=(const vtkMRMLModelSliceDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLOrientationMarkerDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLOrientationMarkerDisplayableManager.h
@@ -59,8 +59,8 @@ protected:
 
 private:
 
-  vtkMRMLOrientationMarkerDisplayableManager(const vtkMRMLOrientationMarkerDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLOrientationMarkerDisplayableManager&); // Not Implemented
+  vtkMRMLOrientationMarkerDisplayableManager(const vtkMRMLOrientationMarkerDisplayableManager&) = delete;
+  void operator=(const vtkMRMLOrientationMarkerDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.h
@@ -86,8 +86,8 @@ protected:
 
 private:
 
-  vtkMRMLRulerDisplayableManager(const vtkMRMLRulerDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLRulerDisplayableManager&); // Not Implemented
+  vtkMRMLRulerDisplayableManager(const vtkMRMLRulerDisplayableManager&) = delete;
+  void operator=(const vtkMRMLRulerDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.h
@@ -57,8 +57,8 @@ protected:
   void OnMRMLDisplayableNodeModifiedEvent(vtkObject* caller) override;
 
 private:
-  vtkMRMLScriptedDisplayableManager(const vtkMRMLScriptedDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLScriptedDisplayableManager&);                   // Not Implemented
+  vtkMRMLScriptedDisplayableManager(const vtkMRMLScriptedDisplayableManager&) = delete;
+  void operator=(const vtkMRMLScriptedDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceViewDisplayableManagerFactory.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceViewDisplayableManagerFactory.h
@@ -62,8 +62,8 @@ protected:
 
 private:
 
-  vtkMRMLSliceViewDisplayableManagerFactory(const vtkMRMLSliceViewDisplayableManagerFactory&);
-  void operator=(const vtkMRMLSliceViewDisplayableManagerFactory&);
+  vtkMRMLSliceViewDisplayableManagerFactory(const vtkMRMLSliceViewDisplayableManagerFactory&) = delete;
+  void operator=(const vtkMRMLSliceViewDisplayableManagerFactory&) = delete;
 
 };
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDReformatDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDReformatDisplayableManager.h
@@ -56,8 +56,8 @@ protected:
   void OnMRMLNodeModified(vtkMRMLNode* node) override;
 
 private:
-  vtkMRMLThreeDReformatDisplayableManager(const vtkMRMLThreeDReformatDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLThreeDReformatDisplayableManager&);                         // Not Implemented
+  vtkMRMLThreeDReformatDisplayableManager(const vtkMRMLThreeDReformatDisplayableManager&) = delete;
+  void operator=(const vtkMRMLThreeDReformatDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal* Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewDisplayableManagerFactory.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewDisplayableManagerFactory.h
@@ -62,8 +62,8 @@ protected:
 
 private:
 
-  vtkMRMLThreeDViewDisplayableManagerFactory(const vtkMRMLThreeDViewDisplayableManagerFactory&);
-  void operator=(const vtkMRMLThreeDViewDisplayableManagerFactory&);
+  vtkMRMLThreeDViewDisplayableManagerFactory(const vtkMRMLThreeDViewDisplayableManagerFactory&) = delete;
+  void operator=(const vtkMRMLThreeDViewDisplayableManagerFactory&) = delete;
 
 };
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewDisplayableManager.h
@@ -77,8 +77,8 @@ protected:
 
 private:
 
-  vtkMRMLViewDisplayableManager(const vtkMRMLViewDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLViewDisplayableManager&); // Not Implemented
+  vtkMRMLViewDisplayableManager(const vtkMRMLViewDisplayableManager&) = delete;
+  void operator=(const vtkMRMLViewDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/vtkMRMLVolumeGlyphSliceDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLVolumeGlyphSliceDisplayableManager.h
@@ -55,8 +55,8 @@ protected:
 
 private:
 
-  vtkMRMLVolumeGlyphSliceDisplayableManager(const vtkMRMLVolumeGlyphSliceDisplayableManager&);// Not implemented
-  void operator=(const vtkMRMLVolumeGlyphSliceDisplayableManager&);                     // Not Implemented
+  vtkMRMLVolumeGlyphSliceDisplayableManager(const vtkMRMLVolumeGlyphSliceDisplayableManager&) = delete;
+  void operator=(const vtkMRMLVolumeGlyphSliceDisplayableManager&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkSliceViewInteractorStyle.h
@@ -133,8 +133,8 @@ protected:
   vtkMRMLAbstractDisplayableManager* FocusedDisplayableManager;
 
 private:
-  vtkSliceViewInteractorStyle(const vtkSliceViewInteractorStyle&);  /// Not implemented.
-  void operator=(const vtkSliceViewInteractorStyle&);  /// Not implemented.
+  vtkSliceViewInteractorStyle(const vtkSliceViewInteractorStyle&) = delete;
+  void operator=(const vtkSliceViewInteractorStyle&) = delete;
 };
 
 #endif

--- a/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkThreeDViewInteractorStyle.h
@@ -142,8 +142,8 @@ protected:
   vtkMRMLAbstractDisplayableManager* FocusedDisplayableManager;
 
 private:
-  vtkThreeDViewInteractorStyle(const vtkThreeDViewInteractorStyle&);  /// Not implemented.
-  void operator=(const vtkThreeDViewInteractorStyle&);  /// Not implemented.
+  vtkThreeDViewInteractorStyle(const vtkThreeDViewInteractorStyle&) = delete;
+  void operator=(const vtkThreeDViewInteractorStyle&) = delete;
 };
 
 #endif

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIO.h
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIO.h
@@ -122,8 +122,8 @@ protected:
                        MetaDataDictionary &dict);
 
 private:
-  MRMLIDImageIO(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  MRMLIDImageIO(const Self&) = delete;
+  void operator=(const Self&) = delete;
 
   bool IsAVolumeNode(const char*);
   vtkMRMLVolumeNode* FileNameToVolumeNodePtr(const char*);

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIOFactory.h
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIOFactory.h
@@ -61,8 +61,8 @@ protected:
   ~MRMLIDImageIOFactory() override;
 
 private:
-  MRMLIDImageIOFactory(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  MRMLIDImageIOFactory(const Self&) = delete;
+  void operator=(const Self&) = delete;
 
 };
 

--- a/Libs/MRML/Logic/vtkMRMLAbstractLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLAbstractLogic.h
@@ -437,8 +437,8 @@ protected:
 
 private:
 
-  vtkMRMLAbstractLogic(const vtkMRMLAbstractLogic&); // Not implemented
-  void operator=(const vtkMRMLAbstractLogic&);       // Not implemented
+  vtkMRMLAbstractLogic(const vtkMRMLAbstractLogic&) = delete;
+  void operator=(const vtkMRMLAbstractLogic&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -239,8 +239,8 @@ private:
   /// from GetNthFileName(n)
   std::map<vtkMRMLStorageNode*, std::vector<std::string> > OriginalStorageNodeFileNames;
 
-  vtkMRMLApplicationLogic(const vtkMRMLApplicationLogic&);
-  void operator=(const vtkMRMLApplicationLogic&);
+  vtkMRMLApplicationLogic(const vtkMRMLApplicationLogic&) = delete;
+  void operator=(const vtkMRMLApplicationLogic&) = delete;
 
   class vtkInternal;
   vtkInternal* Internal;

--- a/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLinkLogic.h
@@ -80,8 +80,8 @@ protected:
 
 private:
 
-  vtkMRMLSliceLinkLogic(const vtkMRMLSliceLinkLogic&);
-  void operator=(const vtkMRMLSliceLinkLogic&);
+  vtkMRMLSliceLinkLogic(const vtkMRMLSliceLinkLogic&) = delete;
+  void operator=(const vtkMRMLSliceLinkLogic&) = delete;
 
   vtkMRMLSliceCompositeNode* GetCompositeNode(vtkMRMLSliceNode*);
   void BroadcastLastRotation(vtkMRMLSliceNode*, vtkMRMLSliceNode*);

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -408,8 +408,8 @@ protected:
 
 private:
 
-  vtkMRMLSliceLogic(const vtkMRMLSliceLogic&);
-  void operator=(const vtkMRMLSliceLogic&);
+  vtkMRMLSliceLogic(const vtkMRMLSliceLogic&) = delete;
+  void operator=(const vtkMRMLSliceLogic&) = delete;
 
 };
 

--- a/Libs/MRML/Logic/vtkMRMLViewLinkLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLViewLinkLogic.h
@@ -67,8 +67,8 @@ protected:
   void BroadcastCameraNodeEvent(vtkMRMLCameraNode* cameraNode);
 
 private:
-  vtkMRMLViewLinkLogic(const vtkMRMLViewLinkLogic&);
-  void operator=(const vtkMRMLViewLinkLogic&);
+  vtkMRMLViewLinkLogic(const vtkMRMLViewLinkLogic&) = delete;
+  void operator=(const vtkMRMLViewLinkLogic&) = delete;
 
 };
 

--- a/Libs/MRML/Logic/vtkMRMLViewLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLViewLogic.h
@@ -121,8 +121,8 @@ protected:
   vtkMRMLCameraNode* CameraNode;
 
 private:
-  vtkMRMLViewLogic(const vtkMRMLViewLogic&);
-  void operator=(const vtkMRMLViewLogic&);
+  vtkMRMLViewLogic(const vtkMRMLViewLogic&) = delete;
+  void operator=(const vtkMRMLViewLogic&) = delete;
 
 };
 

--- a/Libs/MRML/Widgets/qMRMLSliceView_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceView_p.h
@@ -111,8 +111,8 @@ protected:
   ~vtkInternalLightBoxRendererManagerProxy() override;
 
 private:
-  vtkInternalLightBoxRendererManagerProxy(const vtkInternalLightBoxRendererManagerProxy&); // Not implemented
-  void operator=(const vtkInternalLightBoxRendererManagerProxy&);                    // Not implemented
+  vtkInternalLightBoxRendererManagerProxy(const vtkInternalLightBoxRendererManagerProxy&) = delete;
+  void operator=(const vtkInternalLightBoxRendererManagerProxy&) = delete;
 
   vtkWeakPointer<vtkLightBoxRendererManager> LightBoxRendererManager;
 

--- a/Libs/vtkAddon/vtkAddonMathUtilities.h
+++ b/Libs/vtkAddon/vtkAddonMathUtilities.h
@@ -80,8 +80,8 @@ protected:
   ~vtkAddonMathUtilities() override;
 
 private:
-  vtkAddonMathUtilities(const vtkAddonMathUtilities&);  // Not implemented.
-  void operator=(const vtkAddonMathUtilities&);  // Not implemented.
+  vtkAddonMathUtilities(const vtkAddonMathUtilities&) = delete;
+  void operator=(const vtkAddonMathUtilities&) = delete;
 };
 
 #endif

--- a/Libs/vtkAddon/vtkOpenGLShaderComputation.h
+++ b/Libs/vtkAddon/vtkOpenGLShaderComputation.h
@@ -113,8 +113,8 @@ protected:
   ~vtkOpenGLShaderComputation() override;
 
 private:
-  vtkOpenGLShaderComputation(const vtkOpenGLShaderComputation&);  // Not implemented.
-  void operator=(const vtkOpenGLShaderComputation&);  // Not implemented.
+  vtkOpenGLShaderComputation(const vtkOpenGLShaderComputation&) = delete;
+  void operator=(const vtkOpenGLShaderComputation&) = delete;
 
   bool Initialized;
   bool ErrorOccurred;

--- a/Libs/vtkAddon/vtkOpenGLTextureImage.h
+++ b/Libs/vtkAddon/vtkOpenGLTextureImage.h
@@ -152,8 +152,8 @@ protected:
   ~vtkOpenGLTextureImage() override;
 
 private:
-  vtkOpenGLTextureImage(const vtkOpenGLTextureImage&);  // Not implemented.
-  void operator=(const vtkOpenGLTextureImage&);  // Not implemented.
+  vtkOpenGLTextureImage(const vtkOpenGLTextureImage&) = delete;
+  void operator=(const vtkOpenGLTextureImage&) = delete;
 
   vtkOpenGLShaderComputation *ShaderComputation;
   vtkImageData *ImageData;

--- a/Libs/vtkAddon/vtkOrientedBSplineTransform.h
+++ b/Libs/vtkAddon/vtkOrientedBSplineTransform.h
@@ -94,8 +94,8 @@ protected:
   vtkMatrix4x4* InverseBulkTransformMatrixCached;
 
 private:
-  vtkOrientedBSplineTransform(const vtkOrientedBSplineTransform&);  // Not implemented.
-  void operator=(const vtkOrientedBSplineTransform&);  // Not implemented.
+  vtkOrientedBSplineTransform(const vtkOrientedBSplineTransform&) = delete;
+  void operator=(const vtkOrientedBSplineTransform&) = delete;
 };
 
 #endif

--- a/Libs/vtkAddon/vtkOrientedGridTransform.h
+++ b/Libs/vtkAddon/vtkOrientedGridTransform.h
@@ -93,8 +93,8 @@ protected:
   vtkMTimeType LastWarningMTime;
 
 private:
-  vtkOrientedGridTransform(const vtkOrientedGridTransform&);  // Not implemented.
-  void operator=(const vtkOrientedGridTransform&);  // Not implemented.
+  vtkOrientedGridTransform(const vtkOrientedGridTransform&) = delete;
+  void operator=(const vtkOrientedGridTransform&) = delete;
 };
 
 #endif

--- a/Libs/vtkAddon/vtkPersonInformation.h
+++ b/Libs/vtkAddon/vtkPersonInformation.h
@@ -100,8 +100,8 @@ protected:
   std::map<std::string, std::string> Data;
 
 private:
-  vtkPersonInformation(const vtkPersonInformation&);  // Not implemented.
-  void operator=(const vtkPersonInformation&);  // Not implemented.
+  vtkPersonInformation(const vtkPersonInformation&) = delete;
+  void operator=(const vtkPersonInformation&) = delete;
 };
 
 #endif

--- a/Libs/vtkAddon/vtkRawRGBVolumeCodec.h
+++ b/Libs/vtkAddon/vtkRawRGBVolumeCodec.h
@@ -56,8 +56,8 @@ protected:
   std::string GetParameterDescription(std::string vtkNotUsed(parameterName)) override { return ""; };
 
 private:
-  vtkRawRGBVolumeCodec(const vtkRawRGBVolumeCodec&);
-  void operator=(const vtkRawRGBVolumeCodec&);
+  vtkRawRGBVolumeCodec(const vtkRawRGBVolumeCodec&) = delete;
+  void operator=(const vtkRawRGBVolumeCodec&) = delete;
 };
 
 #endif

--- a/Libs/vtkAddon/vtkStreamingVolumeCodec.h
+++ b/Libs/vtkAddon/vtkStreamingVolumeCodec.h
@@ -179,8 +179,8 @@ protected:
   ~vtkStreamingVolumeCodec() override;
 
 private:
-  vtkStreamingVolumeCodec(const vtkStreamingVolumeCodec&);
-  void operator=(const vtkStreamingVolumeCodec&);
+  vtkStreamingVolumeCodec(const vtkStreamingVolumeCodec&) = delete;
+  void operator=(const vtkStreamingVolumeCodec&) = delete;
 
 protected:
   std::vector<std::string>                  AvailiableParameterNames;

--- a/Libs/vtkAddon/vtkStreamingVolumeFrame.h
+++ b/Libs/vtkAddon/vtkStreamingVolumeFrame.h
@@ -95,8 +95,8 @@ protected:
   ~vtkStreamingVolumeFrame() override;
 
 private:
-  vtkStreamingVolumeFrame(const vtkStreamingVolumeFrame&);
-  void operator=(const vtkStreamingVolumeFrame&);
+  vtkStreamingVolumeFrame(const vtkStreamingVolumeFrame&) = delete;
+  void operator=(const vtkStreamingVolumeFrame&) = delete;
 
 };
 #endif

--- a/Libs/vtkAddon/vtkTestingOutputWindow.h
+++ b/Libs/vtkAddon/vtkTestingOutputWindow.h
@@ -88,8 +88,8 @@ protected:
   int NumberOfLoggedMessages;
 
 private:
-  vtkTestingOutputWindow(const vtkTestingOutputWindow&);  // Not implemented.
-  void operator=(const vtkTestingOutputWindow&);  // Not implemented.
+  vtkTestingOutputWindow(const vtkTestingOutputWindow&) = delete;
+  void operator=(const vtkTestingOutputWindow&) = delete;
 };
 
 

--- a/Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h
+++ b/Libs/vtkITK/itkConstrainedValueMultiplicationImageFilter.h
@@ -128,8 +128,8 @@ protected:
   ~ConstrainedValueMultiplicationImageFilter() override {}
 
 private:
-  ConstrainedValueMultiplicationImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  ConstrainedValueMultiplicationImageFilter(const Self&) = delete;
+  void operator=(const Self&) = delete;
 
 };
 

--- a/Libs/vtkITK/itkLevelTracingImageFilter.h
+++ b/Libs/vtkITK/itkLevelTracingImageFilter.h
@@ -115,8 +115,8 @@ protected:
   virtual void Trace( const DispatchBase &);
 
 private:
-  LevelTracingImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  LevelTracingImageFilter(const Self&) = delete;
+  void operator=(const Self&) = delete;
 
   IndexType           m_Seed;
   InputImagePixelType m_Max;

--- a/Libs/vtkITK/itkLevelTracingImageFilter.txx
+++ b/Libs/vtkITK/itkLevelTracingImageFilter.txx
@@ -154,8 +154,8 @@ protected:
   ~LevelTracingImageFunction() override{}
 
 private:
-  LevelTracingImageFunction( const Self& ); //purposely not implemented
-  void operator=( const Self& ); //purposely not implemented
+  LevelTracingImageFunction( const Self& ) = delete;
+  void operator=( const Self& ) = delete;
 
   PixelType     m_Threshold;
   InputSizeType m_Radius;

--- a/Libs/vtkITK/itkMorphologicalContourInterpolator.h
+++ b/Libs/vtkITK/itkMorphologicalContourInterpolator.h
@@ -401,9 +401,9 @@ protected:
   typename ConnectedComponentsType::Pointer m_ConnectedComponents;
 
 private:
-  MorphologicalContourInterpolator( const Self & ) ITK_DELETED_FUNCTION;
+  MorphologicalContourInterpolator( const Self & ) = delete;
   void
-  operator=( const Self & ) ITK_DELETED_FUNCTION;
+  operator=( const Self & ) = delete;
 };
 } // namespace itk
 

--- a/Libs/vtkITK/itkNewOtsuThresholdImageCalculator.h
+++ b/Libs/vtkITK/itkNewOtsuThresholdImageCalculator.h
@@ -75,8 +75,8 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
-  NewOtsuThresholdImageCalculator(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  NewOtsuThresholdImageCalculator(const Self&) = delete;
+  void operator=(const Self&) = delete;
 
   PixelType            m_Threshold;
   unsigned long        m_NumberOfHistogramBins;

--- a/Libs/vtkITK/itkNewOtsuThresholdImageFilter.h
+++ b/Libs/vtkITK/itkNewOtsuThresholdImageFilter.h
@@ -112,8 +112,8 @@ protected:
   void GenerateData () override;
 
 private:
-  NewOtsuThresholdImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  NewOtsuThresholdImageFilter(const Self&) = delete;
+  void operator=(const Self&) = delete;
 
   InputPixelType      m_Threshold;
   OutputPixelType     m_InsideValue;

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
@@ -895,8 +895,8 @@ protected:
   std::vector<long int> IndexImagePositionPatient;
 
 private:
-  vtkITKArchetypeImageSeriesReader(const vtkITKArchetypeImageSeriesReader&);  /// Not implemented.
-  void operator=(const vtkITKArchetypeImageSeriesReader&);  /// Not implemented.
+  vtkITKArchetypeImageSeriesReader(const vtkITKArchetypeImageSeriesReader&) = delete;
+  void operator=(const vtkITKArchetypeImageSeriesReader&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKDistanceTransform.h
+++ b/Libs/vtkITK/vtkITKDistanceTransform.h
@@ -50,8 +50,8 @@ protected:
   double BackgroundValue;
 
 private:
-  vtkITKDistanceTransform(const vtkITKDistanceTransform&);  /// Not implemented.
-  void operator=(const vtkITKDistanceTransform&);  /// Not implemented.
+  vtkITKDistanceTransform(const vtkITKDistanceTransform&) = delete;
+  void operator=(const vtkITKDistanceTransform&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKGradientAnisotropicDiffusionImageFilter.h
+++ b/Libs/vtkITK/vtkITKGradientAnisotropicDiffusionImageFilter.h
@@ -65,8 +65,8 @@ protected:
 
 
 private:
-  vtkITKGradientAnisotropicDiffusionImageFilter(const vtkITKGradientAnisotropicDiffusionImageFilter&);  /// Not implemented.
-  void operator=(const vtkITKGradientAnisotropicDiffusionImageFilter&);  /// Not implemented.
+  vtkITKGradientAnisotropicDiffusionImageFilter(const vtkITKGradientAnisotropicDiffusionImageFilter&) = delete;
+  void operator=(const vtkITKGradientAnisotropicDiffusionImageFilter&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKGrowCutSegmentationImageFilter.h
+++ b/Libs/vtkITK/vtkITKGrowCutSegmentationImageFilter.h
@@ -58,8 +58,8 @@ protected:
   int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
 private:
-  vtkITKGrowCutSegmentationImageFilter(const vtkITKGrowCutSegmentationImageFilter&);  // Not implemented.
-  void operator=(const vtkITKGrowCutSegmentationImageFilter&);  // Not implemented.
+  vtkITKGrowCutSegmentationImageFilter(const vtkITKGrowCutSegmentationImageFilter&) = delete;
+  void operator=(const vtkITKGrowCutSegmentationImageFilter&) = delete;
 
 };
 

--- a/Libs/vtkITK/vtkITKImageThresholdCalculator.h
+++ b/Libs/vtkITK/vtkITKImageThresholdCalculator.h
@@ -89,8 +89,8 @@ protected:
   double Threshold;
 
 private:
-  vtkITKImageThresholdCalculator(const vtkITKImageThresholdCalculator&);  /// Not implemented.
-  void operator=(const vtkITKImageThresholdCalculator&);  /// Not implemented.
+  vtkITKImageThresholdCalculator(const vtkITKImageThresholdCalculator&) = delete;
+  void operator=(const vtkITKImageThresholdCalculator&) = delete;
 };
 
 //vtkStandardNewMacro(vtkITKImageThresholdCalculator)

--- a/Libs/vtkITK/vtkITKImageToImageFilter.h
+++ b/Libs/vtkITK/vtkITKImageToImageFilter.h
@@ -256,8 +256,8 @@ public:
   vtkImageExport* vtkExporter;
 
 private:
-  vtkITKImageToImageFilter(const vtkITKImageToImageFilter&);  /// Not implemented.
-  void operator=(const vtkITKImageToImageFilter&);  /// Not implemented.
+  vtkITKImageToImageFilter(const vtkITKImageToImageFilter&) = delete;
+  void operator=(const vtkITKImageToImageFilter&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKImageToImageFilterFF.h
+++ b/Libs/vtkITK/vtkITKImageToImageFilterFF.h
@@ -70,8 +70,8 @@ protected:
   };
 
 private:
-  vtkITKImageToImageFilterFF(const vtkITKImageToImageFilterFF&);  /// Not implemented.
-  void operator=(const vtkITKImageToImageFilterFF&);  /// Not implemented.
+  vtkITKImageToImageFilterFF(const vtkITKImageToImageFilterFF&) = delete;
+  void operator=(const vtkITKImageToImageFilterFF&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKImageToImageFilterSS.h
+++ b/Libs/vtkITK/vtkITKImageToImageFilterSS.h
@@ -79,8 +79,8 @@ protected:
   };
 
 private:
-  vtkITKImageToImageFilterSS(const vtkITKImageToImageFilterSS&);  /// Not implemented.
-  void operator=(const vtkITKImageToImageFilterSS&);  /// Not implemented.
+  vtkITKImageToImageFilterSS(const vtkITKImageToImageFilterSS&) = delete;
+  void operator=(const vtkITKImageToImageFilterSS&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKImageWriter.h
+++ b/Libs/vtkITK/vtkITKImageWriter.h
@@ -78,8 +78,8 @@ protected:
   char* ImageIOClassName;
 
 private:
-  vtkITKImageWriter(const vtkITKImageWriter&);  /// Not implemented.
-  void operator=(const vtkITKImageWriter&);  /// Not implemented.
+  vtkITKImageWriter(const vtkITKImageWriter&) = delete;
+  void operator=(const vtkITKImageWriter&) = delete;
 };
 
 //vtkStandardNewMacro(vtkITKImageWriter)

--- a/Libs/vtkITK/vtkITKIslandMath.h
+++ b/Libs/vtkITK/vtkITKIslandMath.h
@@ -74,8 +74,8 @@ protected:
   unsigned long OriginalNumberOfIslands;
 
 private:
-  vtkITKIslandMath(const vtkITKIslandMath&);  /// Not implemented.
-  void operator=(const vtkITKIslandMath&);  /// Not implemented.
+  vtkITKIslandMath(const vtkITKIslandMath&) = delete;
+  void operator=(const vtkITKIslandMath&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKLevelTracing3DImageFilter.h
+++ b/Libs/vtkITK/vtkITKLevelTracing3DImageFilter.h
@@ -38,8 +38,8 @@ protected:
   int Seed[3];
 
 private:
-  vtkITKLevelTracing3DImageFilter(const vtkITKLevelTracing3DImageFilter&);  /// Not implemented.
-  void operator=(const vtkITKLevelTracing3DImageFilter&);  /// Not implemented.
+  vtkITKLevelTracing3DImageFilter(const vtkITKLevelTracing3DImageFilter&) = delete;
+  void operator=(const vtkITKLevelTracing3DImageFilter&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKLevelTracingImageFilter.h
+++ b/Libs/vtkITK/vtkITKLevelTracingImageFilter.h
@@ -46,8 +46,8 @@ protected:
   int Plane;
 
 private:
-  vtkITKLevelTracingImageFilter(const vtkITKLevelTracingImageFilter&);  /// Not implemented.
-  void operator=(const vtkITKLevelTracingImageFilter&);  /// Not implemented.
+  vtkITKLevelTracingImageFilter(const vtkITKLevelTracingImageFilter&) = delete;
+  void operator=(const vtkITKLevelTracingImageFilter&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKMorphologicalContourInterpolator.h
+++ b/Libs/vtkITK/vtkITKMorphologicalContourInterpolator.h
@@ -57,8 +57,8 @@ protected:
   bool UseBallStructuringElement;
 
 private:
-  vtkITKMorphologicalContourInterpolator(const vtkITKMorphologicalContourInterpolator&);  /// Not implemented.
-  void operator=(const vtkITKMorphologicalContourInterpolator&);  /// Not implemented.
+  vtkITKMorphologicalContourInterpolator(const vtkITKMorphologicalContourInterpolator&) = delete;
+  void operator=(const vtkITKMorphologicalContourInterpolator&) = delete;
 };
 
 #endif

--- a/Libs/vtkITK/vtkITKNewOtsuThresholdImageFilter.h
+++ b/Libs/vtkITK/vtkITKNewOtsuThresholdImageFilter.h
@@ -74,8 +74,8 @@ protected:
   ImageFilterType* GetImageFilterPointer() { return dynamic_cast<ImageFilterType*> ( m_Filter.GetPointer() ); }
 
 private:
-  vtkITKNewOtsuThresholdImageFilter(const vtkITKNewOtsuThresholdImageFilter&);  /// Not implemented.
-  void operator=(const vtkITKNewOtsuThresholdImageFilter&);  /// Not implemented.
+  vtkITKNewOtsuThresholdImageFilter(const vtkITKNewOtsuThresholdImageFilter&) = delete;
+  void operator=(const vtkITKNewOtsuThresholdImageFilter&) = delete;
 };
 
 //vtkStandardNewMacro(vtkITKNewOtsuThresholdImageFilter);

--- a/Libs/vtkITK/vtkITKTimeSeriesDatabase.h
+++ b/Libs/vtkITK/vtkITKTimeSeriesDatabase.h
@@ -95,8 +95,8 @@ protected:
   void ExecuteDataWithInformation(vtkDataObject *output, vtkInformation *outInfo) override;
 
 private:
-  vtkITKTimeSeriesDatabase(const vtkITKTimeSeriesDatabase&);  /// Not implemented.
-  void operator=(const vtkITKTimeSeriesDatabase&);  /// Not implemented.
+  vtkITKTimeSeriesDatabase(const vtkITKTimeSeriesDatabase&) = delete;
+  void operator=(const vtkITKTimeSeriesDatabase&) = delete;
 
 };
 

--- a/Libs/vtkITK/vtkITKWandImageFilter.h
+++ b/Libs/vtkITK/vtkITKWandImageFilter.h
@@ -36,8 +36,8 @@ protected:
   double DynamicRangePercentage;
 
 private:
-  vtkITKWandImageFilter(const vtkITKWandImageFilter&);  /// Not implemented.
-  void operator=(const vtkITKWandImageFilter&);  /// Not implemented.
+  vtkITKWandImageFilter(const vtkITKWandImageFilter&) = delete;
+  void operator=(const vtkITKWandImageFilter&) = delete;
 };
 
 #endif

--- a/Libs/vtkSegmentationCore/vtkCalculateOversamplingFactor.h
+++ b/Libs/vtkSegmentationCore/vtkCalculateOversamplingFactor.h
@@ -126,8 +126,8 @@ protected:
   ~vtkCalculateOversamplingFactor() override;
 
 private:
-  vtkCalculateOversamplingFactor(const vtkCalculateOversamplingFactor&); // Not implemented
-  void operator=(const vtkCalculateOversamplingFactor&);               // Not implemented
+  vtkCalculateOversamplingFactor(const vtkCalculateOversamplingFactor&) = delete;
+  void operator=(const vtkCalculateOversamplingFactor&) = delete;
   //ETX
 };
 

--- a/Libs/vtkSegmentationCore/vtkOrientedImageData.h
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageData.h
@@ -94,8 +94,8 @@ protected:
   double Directions[3][3];
 
 private:
-  vtkOrientedImageData(const vtkOrientedImageData&);  // Not implemented.
-  void operator=(const vtkOrientedImageData&);  // Not implemented.
+  vtkOrientedImageData(const vtkOrientedImageData&) = delete;
+  void operator=(const vtkOrientedImageData&) = delete;
 };
 
 #endif

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
@@ -165,8 +165,8 @@ protected:
   ~vtkOrientedImageDataResample() override;
 
 private:
-  vtkOrientedImageDataResample(const vtkOrientedImageDataResample&);  // Not implemented.
-  void operator=(const vtkOrientedImageDataResample&);  // Not implemented.
+  vtkOrientedImageDataResample(const vtkOrientedImageDataResample&) = delete;
+  void operator=(const vtkOrientedImageDataResample&) = delete;
 };
 
 #endif

--- a/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.h
+++ b/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.h
@@ -136,8 +136,8 @@ protected:
                              double z);
 
 private:
-  vtkPolyDataToFractionalLabelmapFilter(const vtkPolyDataToFractionalLabelmapFilter&);  // Not implemented.
-  void operator=(const vtkPolyDataToFractionalLabelmapFilter&);  // Not implemented.
+  vtkPolyDataToFractionalLabelmapFilter(const vtkPolyDataToFractionalLabelmapFilter&) = delete;
+  void operator=(const vtkPolyDataToFractionalLabelmapFilter&) = delete;
 };
 
 #endif

--- a/Libs/vtkSegmentationCore/vtkTopologicalHierarchy.h
+++ b/Libs/vtkSegmentationCore/vtkTopologicalHierarchy.h
@@ -102,8 +102,8 @@ protected:
   ~vtkTopologicalHierarchy() override;
 
 private:
-  vtkTopologicalHierarchy(const vtkTopologicalHierarchy&); // Not implemented
-  void operator=(const vtkTopologicalHierarchy&);               // Not implemented
+  vtkTopologicalHierarchy(const vtkTopologicalHierarchy&) = delete;
+  void operator=(const vtkTopologicalHierarchy&) = delete;
 };
 
 #endif

--- a/Libs/vtkTeem/vtkDiffusionTensorGlyph.h
+++ b/Libs/vtkTeem/vtkDiffusionTensorGlyph.h
@@ -187,8 +187,8 @@ protected:
   vtkImageData *Mask;  /// display glyphs at points where mask is nonzero
 
 private:
-  vtkDiffusionTensorGlyph(const vtkDiffusionTensorGlyph&);  /// Not implemented.
-  void operator=(const vtkDiffusionTensorGlyph&);  /// Not implemented.
+  vtkDiffusionTensorGlyph(const vtkDiffusionTensorGlyph&) = delete;
+  void operator=(const vtkDiffusionTensorGlyph&) = delete;
 };
 
 #endif

--- a/Libs/vtkTeem/vtkDiffusionTensorMathematics.h
+++ b/Libs/vtkTeem/vtkDiffusionTensorMathematics.h
@@ -303,8 +303,8 @@ protected:
                           vtkInformationVector** inputVector,
                           vtkInformationVector* outputVector) override;
 private:
-  vtkDiffusionTensorMathematics(const vtkDiffusionTensorMathematics&);
-  void operator=(const vtkDiffusionTensorMathematics&);
+  vtkDiffusionTensorMathematics(const vtkDiffusionTensorMathematics&) = delete;
+  void operator=(const vtkDiffusionTensorMathematics&) = delete;
 };
 
 #endif

--- a/Libs/vtkTeem/vtkImageLabelCombine.h
+++ b/Libs/vtkTeem/vtkImageLabelCombine.h
@@ -70,8 +70,8 @@ protected:
   int FillInputPortInformation(int port, vtkInformation* info) override;
 
 private:
-  vtkImageLabelCombine(const vtkImageLabelCombine&);  /// Not implemented.
-  void operator=(const vtkImageLabelCombine&);  /// Not implemented.
+  vtkImageLabelCombine(const vtkImageLabelCombine&) = delete;
+  void operator=(const vtkImageLabelCombine&) = delete;
 };
 
 #endif

--- a/Libs/vtkTeem/vtkTeemNRRDReader.h
+++ b/Libs/vtkTeem/vtkTeemNRRDReader.h
@@ -269,8 +269,8 @@ protected:
   int tenSpaceDirectionReduce(Nrrd *nout, const Nrrd *nin, double SD[9]);
 
 private:
-  vtkTeemNRRDReader(const vtkTeemNRRDReader&);  /// Not implemented.
-  void operator=(const vtkTeemNRRDReader&);  /// Not implemented.
+  vtkTeemNRRDReader(const vtkTeemNRRDReader&) = delete;
+  void operator=(const vtkTeemNRRDReader&) = delete;
 
 };
 

--- a/Libs/vtkTeem/vtkTeemNRRDWriter.h
+++ b/Libs/vtkTeem/vtkTeemNRRDWriter.h
@@ -117,8 +117,8 @@ protected:
   int VectorAxisKind;
 
 private:
-  vtkTeemNRRDWriter(const vtkTeemNRRDWriter&);  /// Not implemented.
-  void operator=(const vtkTeemNRRDWriter&);  /// Not implemented.
+  vtkTeemNRRDWriter(const vtkTeemNRRDWriter&) = delete;
+  void operator=(const vtkTeemNRRDWriter&) = delete;
   void vtkImageDataInfoToNrrdInfo(vtkImageData *in, int &nrrdKind, size_t &numComp, int &vtkType, void **buffer);
   int VTKToNrrdPixelType( const int vtkPixelType );
   int DiffusionWeightedData;

--- a/Modules/CLI/ACPCTransform/vtkPrincipalAxesAlign.h
+++ b/Modules/CLI/ACPCTransform/vtkPrincipalAxesAlign.h
@@ -42,8 +42,8 @@ protected:
   vtkPrincipalAxesAlign();
   ~vtkPrincipalAxesAlign() override;
 private:
-  vtkPrincipalAxesAlign(vtkPrincipalAxesAlign &);
-  void operator=(const vtkPrincipalAxesAlign &);
+  vtkPrincipalAxesAlign(vtkPrincipalAxesAlign &) = delete;
+  void operator=(const vtkPrincipalAxesAlign &) = delete;
 
   double* Center;
   double* XAxis;

--- a/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
+++ b/Modules/CLI/ResampleDTIVolume/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
@@ -135,8 +135,8 @@ protected:
   MatrixType            m_MeasurementFrameValid;
   MatrixType            m_MeasurementFrameTest;
 private:
-  DifferenceDiffusionTensor3DImageFilter(const Self &); // purposely not implemented
-  void operator=(const Self &);                         // purposely not implemented
+  DifferenceDiffusionTensor3DImageFilter(const Self &) = delete;
+  void operator=(const Self &) = delete;
 
   bool m_IgnoreBoundaryPixels;
 };

--- a/Modules/CLI/ResampleDTIVolume/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
+++ b/Modules/CLI/ResampleDTIVolume/dtiprocessFiles/itkHFieldToDeformationFieldImageFilter.h
@@ -87,8 +87,8 @@ protected:
   {
   }
 private:
-  HFieldToDeformationFieldImageFilter(const Self &); // purposely not implemented
-  void operator=(const Self &);                      // purposely not implemented
+  HFieldToDeformationFieldImageFilter(const Self &) = delete;
+  void operator=(const Self &) = delete;
 
 };
 

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationBidimensionalDisplayableManager.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationBidimensionalDisplayableManager.h
@@ -62,8 +62,8 @@ protected:
 
 private:
 
-  vtkMRMLAnnotationBidimensionalDisplayableManager(const vtkMRMLAnnotationBidimensionalDisplayableManager&); /// Not implemented
-  void operator=(const vtkMRMLAnnotationBidimensionalDisplayableManager&); /// Not Implemented
+  vtkMRMLAnnotationBidimensionalDisplayableManager(const vtkMRMLAnnotationBidimensionalDisplayableManager&) = delete;
+  void operator=(const vtkMRMLAnnotationBidimensionalDisplayableManager&) = delete;
 
 };
 

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationClickCounter.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationClickCounter.h
@@ -51,8 +51,8 @@ protected:
 
 private:
 
-  vtkMRMLAnnotationClickCounter(const vtkMRMLAnnotationClickCounter&); /// Not implemented
-  void operator=(const vtkMRMLAnnotationClickCounter&); /// Not Implemented
+  vtkMRMLAnnotationClickCounter(const vtkMRMLAnnotationClickCounter&) = delete;
+  void operator=(const vtkMRMLAnnotationClickCounter&) = delete;
 
   int m_Clicks;
 

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManager.h
@@ -243,8 +243,8 @@ protected:
 
 private:
 
-  vtkMRMLAnnotationDisplayableManager(const vtkMRMLAnnotationDisplayableManager&); /// Not implemented
-  void operator=(const vtkMRMLAnnotationDisplayableManager&); /// Not Implemented
+  vtkMRMLAnnotationDisplayableManager(const vtkMRMLAnnotationDisplayableManager&) = delete;
+  void operator=(const vtkMRMLAnnotationDisplayableManager&) = delete;
 
 
   int DisableInteractorStyleEventsProcessing;

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.h
@@ -146,8 +146,8 @@ protected:
 
 private:
 
-  vtkMRMLAnnotationDisplayableManagerHelper(const vtkMRMLAnnotationDisplayableManagerHelper&); /// Not implemented
-  void operator=(const vtkMRMLAnnotationDisplayableManagerHelper&); /// Not Implemented
+  vtkMRMLAnnotationDisplayableManagerHelper(const vtkMRMLAnnotationDisplayableManagerHelper&) = delete;
+  void operator=(const vtkMRMLAnnotationDisplayableManagerHelper&) = delete;
 
   /// SeedWidget for point placement
   vtkSmartPointer<vtkSeedWidget> SeedWidget;

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationFiducialDisplayableManager.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationFiducialDisplayableManager.h
@@ -71,8 +71,8 @@ protected:
 
 private:
 
-  vtkMRMLAnnotationFiducialDisplayableManager(const vtkMRMLAnnotationFiducialDisplayableManager&); /// Not implemented
-  void operator=(const vtkMRMLAnnotationFiducialDisplayableManager&); /// Not Implemented
+  vtkMRMLAnnotationFiducialDisplayableManager(const vtkMRMLAnnotationFiducialDisplayableManager&) = delete;
+  void operator=(const vtkMRMLAnnotationFiducialDisplayableManager&) = delete;
 
 };
 

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationROIDisplayableManager.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationROIDisplayableManager.h
@@ -74,8 +74,8 @@ protected:
 
 private:
 
-  vtkMRMLAnnotationROIDisplayableManager(const vtkMRMLAnnotationROIDisplayableManager&); /// Not implemented
-  void operator=(const vtkMRMLAnnotationROIDisplayableManager&); /// Not Implemented
+  vtkMRMLAnnotationROIDisplayableManager(const vtkMRMLAnnotationROIDisplayableManager&) = delete;
+  void operator=(const vtkMRMLAnnotationROIDisplayableManager&) = delete;
 
 };
 

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationRulerDisplayableManager.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationRulerDisplayableManager.h
@@ -76,8 +76,8 @@ protected:
 
 private:
 
-  vtkMRMLAnnotationRulerDisplayableManager(const vtkMRMLAnnotationRulerDisplayableManager&); /// Not implemented
-  void operator=(const vtkMRMLAnnotationRulerDisplayableManager&); /// Not Implemented
+  vtkMRMLAnnotationRulerDisplayableManager(const vtkMRMLAnnotationRulerDisplayableManager&) = delete;
+  void operator=(const vtkMRMLAnnotationRulerDisplayableManager&) = delete;
 
 };
 

--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationTextDisplayableManager.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationTextDisplayableManager.h
@@ -64,8 +64,8 @@ protected:
   void BestGuessForNewCaptionCoordinates(double bestGuess[2]);
 private:
 
-  vtkMRMLAnnotationTextDisplayableManager(const vtkMRMLAnnotationTextDisplayableManager&); /// Not implemented
-  void operator=(const vtkMRMLAnnotationTextDisplayableManager&); /// Not Implemented
+  vtkMRMLAnnotationTextDisplayableManager(const vtkMRMLAnnotationTextDisplayableManager&) = delete;
+  void operator=(const vtkMRMLAnnotationTextDisplayableManager&) = delete;
 
 };
 

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationBidimensionalRepresentation.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationBidimensionalRepresentation.h
@@ -44,8 +44,8 @@ protected:
 
 private:
 
-  vtkAnnotationBidimensionalRepresentation(const vtkAnnotationBidimensionalRepresentation&); /// Not implemented
-  void operator=(const vtkAnnotationBidimensionalRepresentation&); /// Not Implemented
+  vtkAnnotationBidimensionalRepresentation(const vtkAnnotationBidimensionalRepresentation&) = delete;
+  void operator=(const vtkAnnotationBidimensionalRepresentation&) = delete;
 
   double m_Distance1;
   double m_Distance2;

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationBidimensionalWidget.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationBidimensionalWidget.h
@@ -41,8 +41,8 @@ protected:
 
 private:
 
-  vtkAnnotationBidimensionalWidget(const vtkAnnotationBidimensionalWidget&); /// Not implemented
-  void operator=(const vtkAnnotationBidimensionalWidget&); /// Not Implemented
+  vtkAnnotationBidimensionalWidget(const vtkAnnotationBidimensionalWidget&) = delete;
+  void operator=(const vtkAnnotationBidimensionalWidget&) = delete;
 
 };
 

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationGlyphSource2D.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationGlyphSource2D.h
@@ -188,8 +188,8 @@ protected:
                        vtkCellArray *polys, vtkUnsignedCharArray *colors, double scale);
 
 private:
-  vtkAnnotationGlyphSource2D(const vtkAnnotationGlyphSource2D&);  /// Not implemented.
-  void operator=(const vtkAnnotationGlyphSource2D&);  /// Not implemented.
+  vtkAnnotationGlyphSource2D(const vtkAnnotationGlyphSource2D&) = delete;
+  void operator=(const vtkAnnotationGlyphSource2D&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation.h
@@ -298,8 +298,8 @@ protected:
 
 
 private:
-  vtkAnnotationROIRepresentation(const vtkAnnotationROIRepresentation&);  //Not implemented
-  void operator=(const vtkAnnotationROIRepresentation&);  //Not implemented
+  vtkAnnotationROIRepresentation(const vtkAnnotationROIRepresentation&) = delete;
+  void operator=(const vtkAnnotationROIRepresentation&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation2D.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation2D.h
@@ -162,8 +162,8 @@ protected:
   int HandlesVisibility;
 
 private:
-  vtkAnnotationROIRepresentation2D(const vtkAnnotationROIRepresentation2D&);  //Not implemented
-  void operator=(const vtkAnnotationROIRepresentation2D&);  //Not implemented
+  vtkAnnotationROIRepresentation2D(const vtkAnnotationROIRepresentation2D&) = delete;
+  void operator=(const vtkAnnotationROIRepresentation2D&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIWidget.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIWidget.h
@@ -160,8 +160,8 @@ protected:
   int RotationEnabled;
 
 private:
-  vtkAnnotationROIWidget(const vtkAnnotationROIWidget&);  //Not implemented
-  void operator=(const vtkAnnotationROIWidget&);  //Not implemented
+  vtkAnnotationROIWidget(const vtkAnnotationROIWidget&) = delete;
+  void operator=(const vtkAnnotationROIWidget&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIWidget2D.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIWidget2D.h
@@ -130,8 +130,8 @@ protected:
   ~vtkAnnotationROIWidget2D() override;
 
 private:
-  vtkAnnotationROIWidget2D(const vtkAnnotationROIWidget2D&);  //Not implemented
-  void operator=(const vtkAnnotationROIWidget2D&);  //Not implemented
+  vtkAnnotationROIWidget2D(const vtkAnnotationROIWidget2D&) = delete;
+  void operator=(const vtkAnnotationROIWidget2D&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationRulerRepresentation.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationRulerRepresentation.h
@@ -47,8 +47,8 @@ protected:
 
 private:
 
-  vtkAnnotationRulerRepresentation(const vtkAnnotationRulerRepresentation&); /// Not implemented
-  void operator=(const vtkAnnotationRulerRepresentation&); /// Not Implemented
+  vtkAnnotationRulerRepresentation(const vtkAnnotationRulerRepresentation&) = delete;
+  void operator=(const vtkAnnotationRulerRepresentation&) = delete;
 
   double m_Distance;
 

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationRulerRepresentation3D.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationRulerRepresentation3D.h
@@ -72,8 +72,8 @@ protected:
 
 private:
 
-  vtkAnnotationRulerRepresentation3D(const vtkAnnotationRulerRepresentation3D&); /// Not implemented
-  void operator=(const vtkAnnotationRulerRepresentation3D&); /// Not Implemented
+  vtkAnnotationRulerRepresentation3D(const vtkAnnotationRulerRepresentation3D&) = delete;
+  void operator=(const vtkAnnotationRulerRepresentation3D&) = delete;
 
   double m_Distance;
 

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationRulerWidget.h
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationRulerWidget.h
@@ -48,8 +48,8 @@ protected:
 
 private:
 
-  vtkAnnotationRulerWidget(const vtkAnnotationRulerWidget&); /// Not implemented
-  void operator=(const vtkAnnotationRulerWidget&); /// Not Implemented
+  vtkAnnotationRulerWidget(const vtkAnnotationRulerWidget&) = delete;
+  void operator=(const vtkAnnotationRulerWidget&) = delete;
 
 };
 

--- a/Modules/Loadable/Cameras/Logic/vtkSlicerCamerasModuleLogic.h
+++ b/Modules/Loadable/Cameras/Logic/vtkSlicerCamerasModuleLogic.h
@@ -63,8 +63,8 @@ protected:
   bool CopyImportedCameras;
 
 private:
-  vtkSlicerCamerasModuleLogic(const vtkSlicerCamerasModuleLogic&); // Not implemented
-  void operator=(const vtkSlicerCamerasModuleLogic&);              // Not implemented
+  vtkSlicerCamerasModuleLogic(const vtkSlicerCamerasModuleLogic&) = delete;
+  void operator=(const vtkSlicerCamerasModuleLogic&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.h
+++ b/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.h
@@ -90,8 +90,8 @@ protected:
   bool CenterLabel;
 
 private:
-  vtkSlicerScalarBarActor(const vtkSlicerScalarBarActor&);  // Not implemented.
-  void operator=(const vtkSlicerScalarBarActor&);  // Not implemented.
+  vtkSlicerScalarBarActor(const vtkSlicerScalarBarActor&) = delete;
+  void operator=(const vtkSlicerScalarBarActor&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
@@ -109,8 +109,8 @@ protected:
   ~vtkSlicerCropVolumeLogic() override;
 
 private:
-  vtkSlicerCropVolumeLogic(const vtkSlicerCropVolumeLogic&); // Not implemented
-  void operator=(const vtkSlicerCropVolumeLogic&);           // Not implemented
+  vtkSlicerCropVolumeLogic(const vtkSlicerCropVolumeLogic&) = delete;
+  void operator=(const vtkSlicerCropVolumeLogic&) = delete;
 
   class vtkInternal;
   vtkInternal* Internal;

--- a/Modules/Loadable/Data/Logic/vtkSlicerDataModuleLogic.h
+++ b/Modules/Loadable/Data/Logic/vtkSlicerDataModuleLogic.h
@@ -71,8 +71,8 @@ protected:
   bool AutoRemoveDisplayAndStorageNodes;
 
 private:
-  vtkSlicerDataModuleLogic(const vtkSlicerDataModuleLogic&); // Not implemented
-  void operator=(const vtkSlicerDataModuleLogic&);               // Not implemented
+  vtkSlicerDataModuleLogic(const vtkSlicerDataModuleLogic&) = delete;
+  void operator=(const vtkSlicerDataModuleLogic&) = delete;
 
 protected:
   /// Flag indicating if the scene has recently changed (update of the module GUI if needed)

--- a/Modules/Loadable/DoubleArrays/Logic/vtkSlicerDoubleArraysLogic.h
+++ b/Modules/Loadable/DoubleArrays/Logic/vtkSlicerDoubleArraysLogic.h
@@ -50,8 +50,8 @@ protected:
   ~vtkSlicerDoubleArraysLogic() override;
 
 private:
-  vtkSlicerDoubleArraysLogic(const vtkSlicerDoubleArraysLogic&); // Not implemented
-  void operator=(const vtkSlicerDoubleArraysLogic&);               // Not implemented
+  vtkSlicerDoubleArraysLogic(const vtkSlicerDoubleArraysLogic&) = delete;
+  void operator=(const vtkSlicerDoubleArraysLogic&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -230,8 +230,8 @@ protected:
 
 private:
 
-  vtkSlicerMarkupsLogic(const vtkSlicerMarkupsLogic&); // Not implemented
-  void operator=(const vtkSlicerMarkupsLogic&);               // Not implemented
+  vtkSlicerMarkupsLogic(const vtkSlicerMarkupsLogic&) = delete;
+  void operator=(const vtkSlicerMarkupsLogic&) = delete;
 
   /// keep a markups display node with default values that can be updated from
   /// the application settings

--- a/Modules/Loadable/Markups/MRML/vtkCurveGenerator.h
+++ b/Modules/Loadable/Markups/MRML/vtkCurveGenerator.h
@@ -207,8 +207,8 @@ private:
   static void SortByIndex(vtkPoints*, vtkDoubleArray*);
   static void SortByMinimumSpanningTreePosition(vtkPoints*, vtkDoubleArray*);
 
-  vtkCurveGenerator(const vtkCurveGenerator&); // Not implemented.
-  void operator=(const vtkCurveGenerator&); // Not implemented.
+  vtkCurveGenerator(const vtkCurveGenerator&) = delete;
+  void operator=(const vtkCurveGenerator&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
@@ -155,8 +155,8 @@ protected:
   vtkWeakPointer<vtkSlicerMarkupsWidget> LastActiveWidget;
 
 private:
-  vtkMRMLMarkupsDisplayableManager(const vtkMRMLMarkupsDisplayableManager&); /// Not implemented
-  void operator=(const vtkMRMLMarkupsDisplayableManager&); /// Not Implemented
+  vtkMRMLMarkupsDisplayableManager(const vtkMRMLMarkupsDisplayableManager&) = delete;
+  void operator=(const vtkMRMLMarkupsDisplayableManager&) = delete;
 
   int DisableInteractorStyleEventsProcessing;
 

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.h
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.h
@@ -97,8 +97,8 @@ protected:
 
 private:
 
-  vtkMRMLMarkupsDisplayableManagerHelper(const vtkMRMLMarkupsDisplayableManagerHelper&); /// Not implemented
-  void operator=(const vtkMRMLMarkupsDisplayableManagerHelper&); /// Not Implemented
+  vtkMRMLMarkupsDisplayableManagerHelper(const vtkMRMLMarkupsDisplayableManagerHelper&) = delete;
+  void operator=(const vtkMRMLMarkupsDisplayableManagerHelper&) = delete;
 
   /// Keep a record of the current glyph type for the handles in the widget
   /// associated with this node, prevents changing them unnecessarily

--- a/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkMarkupsGlyphSource2D.h
@@ -166,8 +166,8 @@ protected:
                        vtkCellArray *polys, vtkUnsignedCharArray *colors);
 
 private:
-  vtkMarkupsGlyphSource2D(const vtkMarkupsGlyphSource2D&);  /// Not implemented.
-  void operator=(const vtkMarkupsGlyphSource2D&);  /// Not implemented.
+  vtkMarkupsGlyphSource2D(const vtkMarkupsGlyphSource2D&) = delete;
+  void operator=(const vtkMarkupsGlyphSource2D&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Plots/Logic/vtkSlicerPlotsLogic.h
+++ b/Modules/Loadable/Plots/Logic/vtkSlicerPlotsLogic.h
@@ -68,8 +68,8 @@ protected:
   ~vtkSlicerPlotsLogic() override;
 
 private:
-  vtkSlicerPlotsLogic(const vtkSlicerPlotsLogic&); // Not implemented
-  void operator=(const vtkSlicerPlotsLogic&);               // Not implemented
+  vtkSlicerPlotsLogic(const vtkSlicerPlotsLogic&) = delete;
+  void operator=(const vtkSlicerPlotsLogic&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.h
+++ b/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.h
@@ -68,8 +68,8 @@ protected:
 
 private:
 
-  vtkSlicerReformatLogic(const vtkSlicerReformatLogic&);  // Not implemented
-  void operator=(const vtkSlicerReformatLogic&);                    // Not implemented
+  vtkSlicerReformatLogic(const vtkSlicerReformatLogic&) = delete;
+  void operator=(const vtkSlicerReformatLogic&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.h
@@ -117,8 +117,8 @@ protected:
   int SourceAxisIndexForInputAxis[3];
 
 private:
-  vtkSlicerSegmentationGeometryLogic(const vtkSlicerSegmentationGeometryLogic&); // Not implemented
-  void operator=(const vtkSlicerSegmentationGeometryLogic&);               // Not implemented
+  vtkSlicerSegmentationGeometryLogic(const vtkSlicerSegmentationGeometryLogic&) = delete;
+  void operator=(const vtkSlicerSegmentationGeometryLogic&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -378,8 +378,8 @@ protected:
   vtkSlicerTerminologiesModuleLogic* TerminologiesLogic;
 
 private:
-  vtkSlicerSegmentationsModuleLogic(const vtkSlicerSegmentationsModuleLogic&); // Not implemented
-  void operator=(const vtkSlicerSegmentationsModuleLogic&);               // Not implemented
+  vtkSlicerSegmentationsModuleLogic(const vtkSlicerSegmentationsModuleLogic&) = delete;
+  void operator=(const vtkSlicerSegmentationsModuleLogic&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.h
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.h
@@ -74,8 +74,8 @@ protected:
   ~vtkMRMLSegmentationsDisplayableManager2D() override;
 
 private:
-  vtkMRMLSegmentationsDisplayableManager2D(const vtkMRMLSegmentationsDisplayableManager2D&);// Not implemented
-  void operator=(const vtkMRMLSegmentationsDisplayableManager2D&);                     // Not Implemented
+  vtkMRMLSegmentationsDisplayableManager2D(const vtkMRMLSegmentationsDisplayableManager2D&) = delete;
+  void operator=(const vtkMRMLSegmentationsDisplayableManager2D&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.h
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.h
@@ -75,8 +75,8 @@ protected:
 
 private:
 
-  vtkMRMLSegmentationsDisplayableManager3D(const vtkMRMLSegmentationsDisplayableManager3D&); // Not implemented
-  void operator=(const vtkMRMLSegmentationsDisplayableManager3D&);                 // Not Implemented
+  vtkMRMLSegmentationsDisplayableManager3D(const vtkMRMLSegmentationsDisplayableManager3D&) = delete;
+  void operator=(const vtkMRMLSegmentationsDisplayableManager3D&) = delete;
 
   class vtkInternal;
   vtkInternal* Internal;

--- a/Modules/Loadable/SubjectHierarchy/Logic/vtkSlicerSubjectHierarchyModuleLogic.h
+++ b/Modules/Loadable/SubjectHierarchy/Logic/vtkSlicerSubjectHierarchyModuleLogic.h
@@ -115,8 +115,8 @@ protected:
   ~vtkSlicerSubjectHierarchyModuleLogic() override;
 
 private:
-  vtkSlicerSubjectHierarchyModuleLogic(const vtkSlicerSubjectHierarchyModuleLogic&); // Not implemented
-  void operator=(const vtkSlicerSubjectHierarchyModuleLogic&); // Not implemented
+  vtkSlicerSubjectHierarchyModuleLogic(const vtkSlicerSubjectHierarchyModuleLogic&) = delete;
+  void operator=(const vtkSlicerSubjectHierarchyModuleLogic&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Tables/Logic/vtkSlicerTablesLogic.h
+++ b/Modules/Loadable/Tables/Logic/vtkSlicerTablesLogic.h
@@ -60,8 +60,8 @@ protected:
   ~vtkSlicerTablesLogic() override;
 
 private:
-  vtkSlicerTablesLogic(const vtkSlicerTablesLogic&); // Not implemented
-  void operator=(const vtkSlicerTablesLogic&);               // Not implemented
+  vtkSlicerTablesLogic(const vtkSlicerTablesLogic&) = delete;
+  void operator=(const vtkSlicerTablesLogic&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.h
@@ -229,8 +229,8 @@ protected:
   char* UserContextsPath;
 
 private:
-  vtkSlicerTerminologiesModuleLogic(const vtkSlicerTerminologiesModuleLogic&); // Not implemented
-  void operator=(const vtkSlicerTerminologiesModuleLogic&);              // Not implemented
+  vtkSlicerTerminologiesModuleLogic(const vtkSlicerTerminologiesModuleLogic&) = delete;
+  void operator=(const vtkSlicerTerminologiesModuleLogic&) = delete;
 
   class vtkInternal;
   vtkInternal* Internal;

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager3D.h
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager3D.h
@@ -76,8 +76,8 @@ protected:
 
 private:
 
-  vtkMRMLLinearTransformsDisplayableManager3D(const vtkMRMLLinearTransformsDisplayableManager3D&); // Not implemented
-  void operator=(const vtkMRMLLinearTransformsDisplayableManager3D&);                 // Not Implemented
+  vtkMRMLLinearTransformsDisplayableManager3D(const vtkMRMLLinearTransformsDisplayableManager3D&) = delete;
+  void operator=(const vtkMRMLLinearTransformsDisplayableManager3D&) = delete;
 
   class vtkInternal;
   vtkInternal* Internal;

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager2D.h
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager2D.h
@@ -66,8 +66,8 @@ protected:
 
 private:
 
-  vtkMRMLTransformsDisplayableManager2D(const vtkMRMLTransformsDisplayableManager2D&);// Not implemented
-  void operator=(const vtkMRMLTransformsDisplayableManager2D&);                     // Not Implemented
+  vtkMRMLTransformsDisplayableManager2D(const vtkMRMLTransformsDisplayableManager2D&) = delete;
+  void operator=(const vtkMRMLTransformsDisplayableManager2D&) = delete;
 
   class vtkInternal;
   vtkInternal * Internal;

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager3D.h
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager3D.h
@@ -65,8 +65,8 @@ protected:
 
 private:
 
-  vtkMRMLTransformsDisplayableManager3D(const vtkMRMLTransformsDisplayableManager3D&); // Not implemented
-  void operator=(const vtkMRMLTransformsDisplayableManager3D&);                 // Not Implemented
+  vtkMRMLTransformsDisplayableManager3D(const vtkMRMLTransformsDisplayableManager3D&) = delete;
+  void operator=(const vtkMRMLTransformsDisplayableManager3D&) = delete;
 
   class vtkInternal;
   vtkInternal* Internal;

--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.h
@@ -205,8 +205,8 @@ protected:
   // Variables
   vtkMRMLScene* UnitsScene;
 private:
-  vtkSlicerUnitsLogic(const vtkSlicerUnitsLogic&); // Not implemented
-  void operator=(const vtkSlicerUnitsLogic&); // Not implemented
+  vtkSlicerUnitsLogic(const vtkSlicerUnitsLogic&) = delete;
+  void operator=(const vtkSlicerUnitsLogic&) = delete;
 
   /// This variable contains the units of the singleton before the last scene
   /// batch process.

--- a/Modules/Loadable/ViewControllers/Logic/vtkSlicerViewControllersLogic.h
+++ b/Modules/Loadable/ViewControllers/Logic/vtkSlicerViewControllersLogic.h
@@ -76,8 +76,8 @@ protected:
   void RegisterNodes() override;
 
 private:
-  vtkSlicerViewControllersLogic(const vtkSlicerViewControllersLogic&); // Not implemented
-  void operator=(const vtkSlicerViewControllersLogic&);               // Not implemented
+  vtkSlicerViewControllersLogic(const vtkSlicerViewControllersLogic&) = delete;
+  void operator=(const vtkSlicerViewControllersLogic&) = delete;
 
 };
 

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
@@ -345,8 +345,8 @@ protected:
   vtkMRMLScene* PresetsScene;
 
 private:
-  vtkSlicerVolumeRenderingLogic(const vtkSlicerVolumeRenderingLogic&); // Not implemented
-  void operator=(const vtkSlicerVolumeRenderingLogic&);               // Not implemented
+  vtkSlicerVolumeRenderingLogic(const vtkSlicerVolumeRenderingLogic&) = delete;
+  void operator=(const vtkSlicerVolumeRenderingLogic&) = delete;
 };
 
 #endif

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.h
@@ -211,8 +211,8 @@ protected:
 
 private:
   /// Caution: Not implemented
-  vtkMRMLVolumePropertyNode(const vtkMRMLVolumePropertyNode&);//Not implemented
-  void operator=(const vtkMRMLVolumePropertyNode&);// Not implemented
+  vtkMRMLVolumePropertyNode(const vtkMRMLVolumePropertyNode&) = delete;
+  void operator=(const vtkMRMLVolumePropertyNode&) = delete;
 
 };
 

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -207,8 +207,8 @@ private:
   std::vector<std::string> ErrorList;
 
 private:
-  vtkSlicerErrorSink(const vtkSlicerErrorSink&); // Not implemented
-  void operator=(const vtkSlicerErrorSink&);     // Not implemented
+  vtkSlicerErrorSink(const vtkSlicerErrorSink&) = delete;
+  void operator=(const vtkSlicerErrorSink&) = delete;
 };
 
 //----------------------------------------------------------------------------

--- a/Modules/Scripted/DataProbe/Logic/vtkPVScalarBarActor.h
+++ b/Modules/Scripted/DataProbe/Logic/vtkPVScalarBarActor.h
@@ -175,8 +175,8 @@ protected:
   int AddRangeAnnotations;
 
 private:
-  vtkPVScalarBarActor(const vtkPVScalarBarActor &);     // Not implemented.
-  void operator=(const vtkPVScalarBarActor &);          // Not implemented.
+  vtkPVScalarBarActor(const vtkPVScalarBarActor &) = delete;
+  void operator=(const vtkPVScalarBarActor &) = delete;
 };
 
 #endif //__vtkPVScalarBarActor_h

--- a/Modules/Scripted/EditorLib/Logic/vtkImageConnectivity.h
+++ b/Modules/Scripted/EditorLib/Logic/vtkImageConnectivity.h
@@ -93,8 +93,8 @@ protected:
   void ExecuteDataWithInformation(vtkDataObject *, vtkInformation *) override;
 
 private:
-  vtkImageConnectivity(const vtkImageConnectivity&);
-  void operator=(const vtkImageConnectivity&);
+  vtkImageConnectivity(const vtkImageConnectivity&) = delete;
+  void operator=(const vtkImageConnectivity&) = delete;
 };
 
 #endif

--- a/Modules/Scripted/EditorLib/Logic/vtkImageSlicePaint.h
+++ b/Modules/Scripted/EditorLib/Logic/vtkImageSlicePaint.h
@@ -168,8 +168,8 @@ protected:
   int PaintOver;
 
 private:
-  vtkImageSlicePaint(const vtkImageSlicePaint&);  /// Not implemented.
-  void operator=(const vtkImageSlicePaint&);  /// Not implemented.
+  vtkImageSlicePaint(const vtkImageSlicePaint&) = delete;
+  void operator=(const vtkImageSlicePaint&) = delete;
 };
 
 #endif

--- a/Modules/Scripted/EditorLib/Logic/vtkImageStash.h
+++ b/Modules/Scripted/EditorLib/Logic/vtkImageStash.h
@@ -107,8 +107,8 @@ protected:
 private:
   int StashingThreadID;
 
-  vtkImageStash(const vtkImageStash&);  /// Not implemented.
-  void operator=(const vtkImageStash&);  /// Not implemented.
+  vtkImageStash(const vtkImageStash&) = delete;
+  void operator=(const vtkImageStash&) = delete;
 };
 
 


### PR DESCRIPTION
Check the Slicer Wiki for an updated version of the documentation on
how to run clang-tidy.
https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide/ObsoleteCodeRemoval#C.2B.2B11:_Update_source_code_to_use_.3D_delete

```
run-clang-tidy.py -checks=-*,modernize-use-equals-delete -header-filter=.* -fix
```

Plus manual deletion of comments // Not implemented and similar.

```
 ack "delete" -l --print0 | xargs -0 -n 1 sed -E -i 's@delete;\s*\/*\s*[nN]ot [iI]mplemented\.?@delete;@g'
 ack "delete" -l --print0 | xargs -0 -n 1 sed -E -i 's@delete;\s*\/*\s*purposely [nN]ot [iI]mplemented\.?@delete;@g'
 ack "delete" -l --print0 | xargs -0 -n 1 sed -E -i 's@delete ITK\_DELETED\_FUNCTION;@delete;@g'
```

Next step would be to move the declaration to the public interface
instead of the current private.