### PR TITLE
Cli node references

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.h
@@ -353,6 +353,11 @@ public:
   /// \param inputTransform The transform for which information is obtained
   const char* GetTransformInfo(vtkAbstractTransform* inputTransform);
 
+  /// Reference role name from the transform node to the moving volume or fiducial node that participated in registration.
+  static const char* GetMovingNodeReferenceRole() { return "spatialRegistrationMoving"; };
+  /// Reference role name from the transform node to the moving volume or fiducial node that participated in registration
+  static const char* GetFixedNodeReferenceRole() { return "spatialRegistrationFixed"; };
+
 protected:
   vtkMRMLTransformNode();
   ~vtkMRMLTransformNode() override;

--- a/Modules/CLI/ExpertAutomatedRegistration/ExpertAutomatedRegistration.xml
+++ b/Modules/CLI/ExpertAutomatedRegistration/ExpertAutomatedRegistration.xml
@@ -52,6 +52,8 @@
       <description><![CDATA[Save the transform that results from registration]]></description>
       <longflag>saveTransform</longflag>
       <channel>output</channel>
+      <reference role="spatialRegistrationMoving" parameter="movingImage"/>
+      <reference role="spatialRegistrationFixed" parameter="fixedimage"/>
       <default/>
     </transform>
     <string-enumeration>

--- a/Modules/CLI/FiducialRegistration/FiducialRegistration.xml
+++ b/Modules/CLI/FiducialRegistration/FiducialRegistration.xml
@@ -31,6 +31,8 @@
       <description><![CDATA[Save the transform that results from registration]]></description>
       <longflag>saveTransform</longflag>
       <channel>output</channel>
+      <reference role="spatialRegistrationMoving" parameter="movingLandmarks"/>
+      <reference role="spatialRegistrationFixed" parameter="fixedLandmarks"/>
     </transform>
     <string-enumeration>
       <name>transformType</name>

--- a/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.xml
+++ b/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.xml
@@ -35,6 +35,8 @@
       <description><![CDATA[The grid transform (deformation vector field).]]></description>
       <label>Output transform</label>
       <channel>output</channel>
+      <reference role="spatialRegistrationMoving" parameter="MovingImageFileName"/>
+      <reference role="spatialRegistrationFixed" parameter="FixedImageFileName"/>
     </transform>
     <image>
       <name>FixedImageFileName</name>


### PR DESCRIPTION
It was possible to define references in CLIs before, but they had special meaning (set parent transform, set subject hierarchy parent), and they were defined "in reverse", i.e. in the referenced object.
This change adds support for generic, forward references, which allow specifying any type of reference between two nodes. For example in a registration module, the output transform can specify node references to the moving and fixed images.

Registration modules have been updated to use this reference feature to reference the input images from the output transformations. This change is needed for proper DICOM spatial registration export (https://github.com/SlicerRt/SlicerRT/issues/42)

The following PR is needed before this can be integrated: https://github.com/Slicer/SlicerExecutionModel/pull/109