### PR TITLE
ENH: Enable gesture interactions in Slice and 3D views

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
@@ -21,9 +21,11 @@
 #include "vtkCamera.h"
 #include "vtkEvent.h"
 #include "vtkInteractorStyle.h"
+#include "vtkPlane.h"
 #include "vtkRenderer.h"
 #include "vtkRenderWindow.h"
 #include "vtkRenderWindowInteractor.h"
+#include "vtkTransform.h"
 
 /// MRML includes
 #include "vtkMRMLCrosshairDisplayableManager.h"
@@ -50,56 +52,56 @@ vtkMRMLCameraWidget::vtkMRMLCameraWidget()
 
   // Rotate camera to anatomic directions
 
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_1", WidgetCameraRotateToAnterior);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "End", WidgetCameraRotateToAnterior);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_1", WidgetCameraRotateToPosterior);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "End", WidgetCameraRotateToPosterior);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_1", WidgetEventCameraRotateToAnterior);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "End", WidgetEventCameraRotateToAnterior);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_1", WidgetEventCameraRotateToPosterior);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "End", WidgetEventCameraRotateToPosterior);
 
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_3", WidgetCameraRotateToLeft);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Next", WidgetCameraRotateToLeft); //= PageDown
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_3", WidgetCameraRotateToRight);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Next", WidgetCameraRotateToRight);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_3", WidgetEventCameraRotateToLeft);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Next", WidgetEventCameraRotateToLeft); //= PageDown
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_3", WidgetEventCameraRotateToRight);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Next", WidgetEventCameraRotateToRight);
 
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_7", WidgetCameraRotateToSuperior);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Home", WidgetCameraRotateToSuperior);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_7", WidgetCameraRotateToInferior);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Home", WidgetCameraRotateToInferior);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_7", WidgetEventCameraRotateToSuperior);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Home", WidgetEventCameraRotateToSuperior);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_7", WidgetEventCameraRotateToInferior);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Home", WidgetEventCameraRotateToInferior);
 
   // Rotate camera by small increments
 
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_2", WidgetCameraRotateCwX);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Down", WidgetCameraRotateCwX);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_8", WidgetCameraRotateCcwX);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Up", WidgetCameraRotateCcwX);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_4", WidgetCameraRotateCwZ);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Left", WidgetCameraRotateCwZ);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_6", WidgetCameraRotateCcwZ);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Right", WidgetCameraRotateCcwZ);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_2", WidgetEventCameraRotateCwX);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Down", WidgetEventCameraRotateCwX);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_8", WidgetEventCameraRotateCcwX);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Up", WidgetEventCameraRotateCcwX);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_4", WidgetEventCameraRotateCwZ);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Left", WidgetEventCameraRotateCwZ);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_6", WidgetEventCameraRotateCcwZ);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Right", WidgetEventCameraRotateCcwZ);
 
   // Translate camera by small increments
 
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_2", WidgetCameraTranslateBackwardY);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Down", WidgetCameraTranslateBackwardY);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_8", WidgetCameraTranslateForwardY);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Up", WidgetCameraTranslateForwardY);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_4", WidgetCameraTranslateBackwardX);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Left", WidgetCameraTranslateBackwardX);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_6", WidgetCameraTranslateForwardX);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Right", WidgetCameraTranslateForwardX);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_2", WidgetEventCameraTranslateBackwardY);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Down", WidgetEventCameraTranslateBackwardY);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_8", WidgetEventCameraTranslateForwardY);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Up", WidgetEventCameraTranslateForwardY);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_4", WidgetEventCameraTranslateBackwardX);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Left", WidgetEventCameraTranslateBackwardX);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_6", WidgetEventCameraTranslateForwardX);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Right", WidgetEventCameraTranslateForwardX);
 
   // Camera zoom
 
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "plus", WidgetCameraZoomIn);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "minus", WidgetCameraZoomOut);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "plus", WidgetEventCameraZoomIn);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "minus", WidgetEventCameraZoomOut);
 
   // Reset camera
 
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_0", WidgetCameraReset);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Insert", WidgetCameraReset);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_5", WidgetCameraResetRotation);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Clear", WidgetCameraResetRotation);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_5", WidgetCameraResetTranslation);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Clear", WidgetCameraResetTranslation);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_0", WidgetEventCameraReset);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Insert", WidgetEventCameraReset);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "KP_5", WidgetEventCameraResetRotation);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Clear", WidgetEventCameraResetRotation);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_5", WidgetEventCameraResetTranslation);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Clear", WidgetEventCameraResetTranslation);
 
   // Rotate
   this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::LeftButtonPressEvent, vtkEvent::NoModifier,
@@ -110,18 +112,30 @@ vtkMRMLCameraWidget::vtkMRMLCameraWidget()
     WidgetStateTranslate, WidgetEventTranslateStart, WidgetEventTranslateEnd);
   this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::MiddleButtonPressEvent, vtkEvent::NoModifier,
     WidgetStateTranslate, WidgetEventTranslateStart, WidgetEventTranslateEnd);
+  // Touch translate
+  this->SetEventTranslation(WidgetStateIdle, vtkCommand::StartPanEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureStart);
+  this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::PanEvent, vtkEvent::AnyModifier, WidgetEventTouchPanTranslate);
+  this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::EndPanEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureEnd);
 
   // Dolly
   this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::LeftButtonPressEvent, vtkEvent::ShiftModifier + vtkEvent::ControlModifier,
     WidgetStateScale, WidgetEventScaleStart, WidgetEventScaleEnd);
   this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::RightButtonPressEvent, vtkEvent::NoModifier,
     WidgetStateScale, WidgetEventScaleStart, WidgetEventScaleEnd);
-  this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseWheelForwardEvent, vtkEvent::NoModifier, WidgetCameraWheelZoomIn);
-  this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseWheelBackwardEvent, vtkEvent::NoModifier, WidgetCameraWheelZoomOut);
+  this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseWheelForwardEvent, vtkEvent::NoModifier, WidgetEventCameraWheelZoomIn);
+  this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseWheelBackwardEvent, vtkEvent::NoModifier, WidgetEventCameraWheelZoomOut);
+  // Touch zoom
+  this->SetEventTranslation(WidgetStateIdle, vtkCommand::StartPinchEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureStart);
+  this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::PinchEvent, vtkEvent::AnyModifier, WidgetEventTouchPinchZoom);
+  this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::EndPinchEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureEnd);
 
   // Spin
   this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::LeftButtonPressEvent, vtkEvent::ControlModifier,
     WidgetStateSpin, WidgetEventSpinStart, WidgetEventSpinEnd);
+  // Touch rotate
+  this->SetEventTranslation(WidgetStateIdle, vtkCommand::StartRotateEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureStart);
+  this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::RotateEvent, vtkEvent::AnyModifier, WidgetEventTouchSpinCamera);
+  this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::EndRotateEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureEnd);
 
   // Set cursor position
   this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseMoveEvent, vtkEvent::ShiftModifier, WidgetEventSetCrosshairPosition);
@@ -190,123 +204,123 @@ bool vtkMRMLCameraWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* e
   if (!this->CameraNode)
     {
     return false;
-   }
+    }
   unsigned long widgetEvent = this->TranslateInteractionEventToWidgetEvent(eventData);
 
   bool processedEvent = true;
 
   switch (widgetEvent)
     {
-    case WidgetCameraRotateToAnterior:
+    case WidgetEventCameraRotateToAnterior:
       this->SaveStateForUndo();
       this->CameraNode->RotateTo(vtkMRMLCameraNode::Anterior);
       break;
-    case WidgetCameraRotateToPosterior:
+    case WidgetEventCameraRotateToPosterior:
       this->SaveStateForUndo();
       this->CameraNode->RotateTo(vtkMRMLCameraNode::Posterior);
       break;
-    case WidgetCameraRotateToRight:
+    case WidgetEventCameraRotateToRight:
       this->SaveStateForUndo();
       this->CameraNode->RotateTo(vtkMRMLCameraNode::Right);
       break;
-    case WidgetCameraRotateToLeft:
+    case WidgetEventCameraRotateToLeft:
       this->SaveStateForUndo();
       this->CameraNode->RotateTo(vtkMRMLCameraNode::Left);
       break;
-    case WidgetCameraRotateToSuperior:
+    case WidgetEventCameraRotateToSuperior:
       this->SaveStateForUndo();
       this->CameraNode->RotateTo(vtkMRMLCameraNode::Superior);
       break;
-    case WidgetCameraRotateToInferior:
+    case WidgetEventCameraRotateToInferior:
       this->SaveStateForUndo();
       this->CameraNode->RotateTo(vtkMRMLCameraNode::Inferior);
       break;
 
-    case WidgetCameraTranslateBackwardX:
+    case WidgetEventCameraTranslateBackwardX:
       this->SaveStateForUndo();
       this->CameraNode->TranslateAlong(vtkMRMLCameraNode::X, true); // screen X is towards left
       break;
-    case WidgetCameraTranslateForwardX:
+    case WidgetEventCameraTranslateForwardX:
       this->SaveStateForUndo();
       this->CameraNode->TranslateAlong(vtkMRMLCameraNode::X, false); // screen X is towards left
       break;
-    case WidgetCameraTranslateBackwardY:
+    case WidgetEventCameraTranslateBackwardY:
       this->SaveStateForUndo();
       this->CameraNode->TranslateAlong(vtkMRMLCameraNode::Y, false);
       break;
-    case WidgetCameraTranslateForwardY:
+    case WidgetEventCameraTranslateForwardY:
       this->SaveStateForUndo();
       this->CameraNode->TranslateAlong(vtkMRMLCameraNode::Y, true);
       break;
-    case WidgetCameraTranslateBackwardZ:
+    case WidgetEventCameraTranslateBackwardZ:
       this->SaveStateForUndo();
       this->CameraNode->TranslateAlong(vtkMRMLCameraNode::Z, false);
       break;
-    case WidgetCameraTranslateForwardZ:
+    case WidgetEventCameraTranslateForwardZ:
       this->SaveStateForUndo();
       this->CameraNode->TranslateAlong(vtkMRMLCameraNode::Z, true);
       break;
 
-    case WidgetCameraRotateCcwX:
+    case WidgetEventCameraRotateCcwX:
       this->SaveStateForUndo();
       this->CameraNode->RotateAround(vtkMRMLCameraNode::R, false);
       break;
-    case WidgetCameraRotateCwX:
+    case WidgetEventCameraRotateCwX:
       this->SaveStateForUndo();
       this->CameraNode->RotateAround(vtkMRMLCameraNode::R, true);
       break;
-    case WidgetCameraRotateCcwY:
+    case WidgetEventCameraRotateCcwY:
       this->SaveStateForUndo();
       this->CameraNode->RotateAround(vtkMRMLCameraNode::A, false);
       break;
-    case WidgetCameraRotateCwY:
+    case WidgetEventCameraRotateCwY:
       this->SaveStateForUndo();
       this->CameraNode->RotateAround(vtkMRMLCameraNode::A, true);
       break;
-    case WidgetCameraRotateCcwZ:
+    case WidgetEventCameraRotateCcwZ:
       this->SaveStateForUndo();
       this->CameraNode->RotateAround(vtkMRMLCameraNode::S, false);
       break;
-    case WidgetCameraRotateCwZ:
+    case WidgetEventCameraRotateCwZ:
       this->SaveStateForUndo();
       this->CameraNode->RotateAround(vtkMRMLCameraNode::S, true);
       break;
 
-    case WidgetCameraReset:
+    case WidgetEventCameraReset:
       this->SaveStateForUndo();
       this->CameraNode->Reset(true, true, true, this->Renderer);
       break;
-    case WidgetCameraResetRotation:
+    case WidgetEventCameraResetRotation:
       this->SaveStateForUndo();
       this->CameraNode->Reset(true, false, false, this->Renderer);
       break;
-    case WidgetCameraResetTranslation:
+    case WidgetEventCameraResetTranslation:
       this->SaveStateForUndo();
       this->CameraNode->Reset(false, true, false, this->Renderer);
       break;
 
-    case WidgetCameraZoomIn:
+    case WidgetEventCameraZoomIn:
       this->SaveStateForUndo();
       this->Dolly(1.2);
       break;
-    case WidgetCameraZoomOut:
+    case WidgetEventCameraZoomOut:
       this->SaveStateForUndo();
       this->Dolly(0.8);
       break;
 
-    case WidgetCameraWheelZoomIn:
+    case WidgetEventCameraWheelZoomIn:
       this->SaveStateForUndo();
       // Slicer; invert direction to match right button drag
       this->Dolly(pow((double)1.1, -0.2 * this->MotionFactor * this->MouseWheelMotionFactor));
       break;
-    case WidgetCameraWheelZoomOut:
+    case WidgetEventCameraWheelZoomOut:
       this->SaveStateForUndo();
       // Slicer; invert direction to match right button drag
       this->Dolly(pow((double)1.1, 0.2 * this->MotionFactor * this->MouseWheelMotionFactor));
       break;
 
     case WidgetEventMouseMove:
-    // click-and-dragging the mouse cursor
+      // click-and-dragging the mouse cursor
       processedEvent = this->ProcessMouseMove(eventData);
       break;
 
@@ -337,6 +351,21 @@ bool vtkMRMLCameraWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* e
       break;
     case WidgetEventSpinEnd:
       processedEvent = this->ProcessEndMouseDrag(eventData);
+      break;
+    case WidgetEventTouchGestureStart:
+      this->ProcessTouchGestureStart(eventData);
+      break;
+    case WidgetEventTouchGestureEnd:
+      this->ProcessTouchGestureEnd(eventData);
+      break;
+    case WidgetEventTouchSpinCamera:
+      this->ProcessTouchCameraSpin(eventData);
+      break;
+    case WidgetEventTouchPinchZoom:
+      this->ProcessTouchCameraZoom(eventData);
+      break;
+    case WidgetEventTouchPanTranslate:
+      this->ProcessTouchCameraTranslate(eventData);
       break;
 
     case WidgetEventSetCrosshairPosition:
@@ -379,7 +408,7 @@ bool vtkMRMLCameraWidget::ProcessMouseMove(vtkMRMLInteractionEventData* eventDat
     default:
       // not processed
       return false;
-  }
+    }
   return true;
 }
 
@@ -704,6 +733,150 @@ bool vtkMRMLCameraWidget::ProcessScale(vtkMRMLInteractionEventData* eventData)
 
   this->PreviousEventPosition[0] = eventPosition[0];
   this->PreviousEventPosition[1] = eventPosition[1];
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLCameraWidget::ProcessTouchGestureStart(vtkMRMLInteractionEventData* eventData)
+{
+  this->SetWidgetState(WidgetStateTouchGesture);
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLCameraWidget::ProcessTouchGestureEnd(vtkMRMLInteractionEventData* eventData)
+{
+  this->SetWidgetState(WidgetStateIdle);
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLCameraWidget::ProcessTouchCameraSpin(vtkMRMLInteractionEventData* eventData)
+{
+  vtkCamera* camera = this->GetCamera();
+  if (!camera)
+    {
+    return false;
+    }
+
+  bool wasCameraNodeModified = this->CameraModifyStart();
+
+  int pinchPostionDisplay[2] = { 0,0 };
+  eventData->GetDisplayPosition(pinchPostionDisplay);
+
+  double oldWorldPosition[4] = { 0,0,0,0 };
+  vtkInteractorObserver::ComputeDisplayToWorld(this->Renderer, pinchPostionDisplay[0], pinchPostionDisplay[1], 0, oldWorldPosition);
+
+  camera->Roll(eventData->GetRotation() - eventData->GetLastRotation());
+  camera->OrthogonalizeViewUp();
+
+  double newWorldPosition[4] = { 0,0,0,0 };
+  vtkInteractorObserver::ComputeDisplayToWorld(this->Renderer, pinchPostionDisplay[0], pinchPostionDisplay[1], 0, newWorldPosition);
+
+  vtkNew<vtkPlane> plane;
+  plane->SetOrigin(camera->GetFocalPoint());
+  plane->SetNormal(camera->GetViewPlaneNormal());
+  plane->ProjectPoint(newWorldPosition, newWorldPosition);
+  plane->ProjectPoint(oldWorldPosition, oldWorldPosition);
+
+  double deltaWorld[3] = { 0,0,0 };
+  vtkMath::Subtract(oldWorldPosition, newWorldPosition, deltaWorld);
+
+  vtkNew<vtkTransform> deltaWorldTransform;
+  deltaWorldTransform->Identity();
+  deltaWorldTransform->Translate(deltaWorld);
+  camera->ApplyTransform(deltaWorldTransform);
+
+  this->CameraModifyEnd(wasCameraNodeModified, false, true);
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLCameraWidget::ProcessTouchCameraZoom(vtkMRMLInteractionEventData* eventData)
+{
+  vtkCamera* camera = this->GetCamera();
+  if (!camera)
+    {
+    return false;
+    }
+  if (!eventData)
+    {
+    return false;
+    }
+
+  bool wasCameraNodeModified = this->CameraModifyStart();
+
+  int pinchPostionDisplay[3] = { 0,0,0 };
+  eventData->GetDisplayPosition(pinchPostionDisplay);
+
+  // Remember the position of the center of the pinch in world coordinates
+  // This position should stay in the same location on the screen after the dolly has been performed
+  double oldWorldPosition[4] = { 0,0,0,0 };
+  vtkInteractorObserver::ComputeDisplayToWorld(this->Renderer, pinchPostionDisplay[0], pinchPostionDisplay[1], pinchPostionDisplay[2], oldWorldPosition);
+
+  // Perform the zoom
+  this->Dolly(eventData->GetScale() / eventData->GetLastScale());
+
+  // New position at the center of the pinch gesture
+  double newWorldPosition[4] = { 0,0,0,0 };
+  vtkInteractorObserver::ComputeDisplayToWorld(this->Renderer, pinchPostionDisplay[0], pinchPostionDisplay[1], pinchPostionDisplay[2], newWorldPosition);
+
+  vtkNew<vtkPlane> plane;
+  plane->SetOrigin(camera->GetFocalPoint());
+  plane->SetNormal(camera->GetViewPlaneNormal());
+  plane->ProjectPoint(newWorldPosition, newWorldPosition);
+  plane->ProjectPoint(oldWorldPosition, oldWorldPosition);
+
+  // Determine how far the pinch center has been shifted from it's original location
+  double deltaWorld[3] = { 0,0,0 };
+  vtkMath::Subtract(oldWorldPosition, newWorldPosition, deltaWorld);
+
+  // Translate the camera to compensate for the shift of the pinch center
+  vtkNew<vtkTransform> deltaWorldTransform;
+  deltaWorldTransform->Identity();
+  deltaWorldTransform->Translate(deltaWorld);
+  camera->ApplyTransform(deltaWorldTransform);
+
+  this->CameraModifyEnd(wasCameraNodeModified, false, true);
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLCameraWidget::ProcessTouchCameraTranslate(vtkMRMLInteractionEventData* eventData)
+{
+  vtkCamera* camera = this->GetCamera();
+  if (!this->Renderer || !eventData || !camera)
+    {
+    return false;
+    }
+
+  const double* translation = eventData->GetTranslation();
+  double deltaView[3] = {-translation[0], -translation[1], 0.0};
+
+  double worldFocus[4];
+  camera->GetFocalPoint(worldFocus);
+  double viewFocus[4];
+  vtkInteractorObserver::ComputeWorldToDisplay(this->Renderer,
+                                               worldFocus[0],
+                                               worldFocus[1],
+                                               worldFocus[2],
+                                               viewFocus);
+
+  double newWorldFocus[4];
+  vtkInteractorObserver::ComputeDisplayToWorld(this->Renderer,
+                                               viewFocus[0] + deltaView[0],
+                                               viewFocus[1] + deltaView[1],
+                                               viewFocus[2] + deltaView[2],
+                                               newWorldFocus);
+
+  double deltaWorld[4];
+  vtkMath::Subtract(newWorldFocus, worldFocus, deltaWorld);
+
+  vtkNew<vtkTransform> deltaWorldTransform;
+  deltaWorldTransform->Identity();
+  deltaWorldTransform->Translate(deltaWorld);
+  camera->ApplyTransform(deltaWorldTransform);
+
   return true;
 }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
@@ -73,45 +73,53 @@ public:
     {
     WidgetStateFollowCursor = WidgetStateUser,
     WidgetStateSpin,
-    WidgetEventSpinStart,
-    WidgetEventSpinEnd,
+    WidgetStateTouchGesture,
     };
 
   /// Widget events
   enum
     {
-    WidgetCameraRotateToRight = WidgetEventUser,
-    WidgetCameraRotateToLeft,
-    WidgetCameraRotateToAnterior,
-    WidgetCameraRotateToPosterior,
-    WidgetCameraRotateToSuperior,
-    WidgetCameraRotateToInferior,
+    WidgetEventSpinStart = WidgetEventUser,
+    WidgetEventSpinEnd,
 
-    WidgetCameraTranslateForwardX,
-    WidgetCameraTranslateBackwardX,
-    WidgetCameraTranslateForwardY,
-    WidgetCameraTranslateBackwardY,
-    WidgetCameraTranslateForwardZ,
-    WidgetCameraTranslateBackwardZ,
+    WidgetEventCameraRotateToRight,
+    WidgetEventCameraRotateToLeft,
+    WidgetEventCameraRotateToAnterior,
+    WidgetEventCameraRotateToPosterior,
+    WidgetEventCameraRotateToSuperior,
+    WidgetEventCameraRotateToInferior,
 
-    WidgetCameraRotateCcwX,
-    WidgetCameraRotateCwX,
-    WidgetCameraRotateCcwY,
-    WidgetCameraRotateCwY,
-    WidgetCameraRotateCcwZ,
-    WidgetCameraRotateCwZ,
+    WidgetEventCameraTranslateForwardX,
+    WidgetEventCameraTranslateBackwardX,
+    WidgetEventCameraTranslateForwardY,
+    WidgetEventCameraTranslateBackwardY,
+    WidgetEventCameraTranslateForwardZ,
+    WidgetEventCameraTranslateBackwardZ,
 
-    WidgetCameraZoomIn,
-    WidgetCameraZoomOut,
-    WidgetCameraWheelZoomIn, // same as WidgetCameraZoomIn but with using wheel scaling factor
-    WidgetCameraWheelZoomOut,
+    WidgetEventCameraRotateCcwX,
+    WidgetEventCameraRotateCwX,
+    WidgetEventCameraRotateCcwY,
+    WidgetEventCameraRotateCwY,
+    WidgetEventCameraRotateCcwZ,
+    WidgetEventCameraRotateCwZ,
 
-    WidgetCameraReset,
-    WidgetCameraResetTranslation,
-    WidgetCameraResetRotation,
+    WidgetEventCameraZoomIn,
+    WidgetEventCameraZoomOut,
+    WidgetEventCameraWheelZoomIn, // same as WidgetEventCameraZoomIn but with using wheel scaling factor
+    WidgetEventCameraWheelZoomOut,
 
-    WidgetCameraRotate,
-    WidgetCameraPan,
+    WidgetEventCameraReset,
+    WidgetEventCameraResetTranslation,
+    WidgetEventCameraResetRotation,
+
+    WidgetEventCameraRotate,
+    WidgetEventCameraPan,
+
+    WidgetEventTouchGestureStart,
+    WidgetEventTouchGestureEnd,
+    WidgetEventTouchSpinCamera,
+    WidgetEventTouchPinchZoom,
+    WidgetEventTouchPanTranslate,
 
     WidgetEventSetCrosshairPosition,
     };
@@ -137,6 +145,12 @@ protected:
   bool ProcessScale(vtkMRMLInteractionEventData* eventData);
   bool ProcessSpin(vtkMRMLInteractionEventData* eventData);
   bool ProcessSetCrosshair(vtkMRMLInteractionEventData* eventData);
+
+  bool ProcessTouchGestureStart(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTouchGestureEnd(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTouchCameraSpin(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTouchCameraZoom(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTouchCameraTranslate(vtkMRMLInteractionEventData* eventData);
 
   bool Dolly(double factor);
   vtkCamera* GetCamera();

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.cxx
@@ -263,6 +263,10 @@ void vtkMRMLInteractionEventData::SetAttributesFromInteractor(vtkRenderWindowInt
 
   this->Rotation = interactor->GetRotation();
   this->LastRotation = interactor->GetLastRotation();
+  this->Scale = interactor->GetScale();
+  this->LastScale = interactor->GetLastScale();
+  this->SetTranslation(interactor->GetTranslation());
+  this->SetLastTranslation(interactor->GetLastTranslation());
 }
 
 //---------------------------------------------------------------------------
@@ -350,3 +354,53 @@ bool vtkMRMLInteractionEventData::Equivalent(const vtkEventData *e) const
     }
   return true;
 };
+
+//---------------------------------------------------------------------------
+void vtkMRMLInteractionEventData::SetScale(double scale)
+{
+  this->Scale = scale;
+}
+
+//---------------------------------------------------------------------------
+double vtkMRMLInteractionEventData::GetScale() const
+{
+  return this->Scale;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLInteractionEventData::SetLastScale(double lastScale)
+{
+  this->LastScale = lastScale;
+}
+
+//---------------------------------------------------------------------------
+double vtkMRMLInteractionEventData::GetLastScale() const
+{
+  return this->LastScale;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLInteractionEventData::SetTranslation(const double translation[2])
+{
+  this->Translation[0] = translation[0];
+  this->Translation[1] = translation[1];
+}
+
+//---------------------------------------------------------------------------
+const double* vtkMRMLInteractionEventData::GetTranslation() const
+{
+  return this->Translation;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLInteractionEventData::SetLastTranslation(const double lastTranslation[2])
+{
+  this->LastTranslation[0] = lastTranslation[0];
+  this->LastTranslation[1] = lastTranslation[1];
+}
+
+//---------------------------------------------------------------------------
+const double* vtkMRMLInteractionEventData::GetLastTranslation() const
+{
+  return this->LastTranslation;
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
@@ -89,7 +89,14 @@ public:
   double GetRotation() const;
   void SetLastRotation(double v);
   double GetLastRotation() const;
-
+  void SetScale(double scale);
+  double GetScale() const;
+  void SetLastScale(double scale);
+  double GetLastScale() const;
+  void SetTranslation(const double translation[2]);
+  const double *GetTranslation() const;
+  void SetLastTranslation(const double translation[2]);
+  const double* GetLastTranslation() const;
   void SetWorldToPhysicalScale(double v);
   double GetWorldToPhysicalScale() const;
 
@@ -122,10 +129,15 @@ protected:
   std::string KeySym;
   //@}
 
+  // Gesture events
   //@{
   /// MacOSX touchpad events
   double Rotation;
   double LastRotation;
+  double Scale;
+  double LastScale;
+  double Translation[2];
+  double LastTranslation[2];
   //@}
 
   /// For VR events

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -74,6 +74,17 @@ vtkMRMLSliceIntersectionWidget::vtkMRMLSliceIntersectionWidget()
 
   this->ModifierKeyPressedSinceLastMouseButtonRelease = true;
 
+  this->TouchRotationThreshold = 10.0;
+  this->TouchZoomThreshold = 0.1;
+  this->TouchTranslationThreshold = 25.0;
+
+  this->TotalTouchRotation = 0.0;
+  this->TouchRotateEnabled = false;
+  this->TotalTouchZoom = 0.0;
+  this->TouchZoomEnabled = false;
+  this->TotalTouchTranslation = 0.0;
+  this->TouchTranslationEnabled = false;
+
   this->SliceLogicsModifiedCommand->SetClientData(this);
   this->SliceLogicsModifiedCommand->SetCallback(vtkMRMLSliceIntersectionWidget::SliceLogicsModifiedCallback);
 
@@ -94,8 +105,10 @@ void vtkMRMLSliceIntersectionWidget::UpdateInteractionEventMapping()
 
   if (this->GetActionEnabled(ActionRotateSliceIntersection))
     {
-    // MacOSX touchpad slice rotate
-    this->SetEventTranslation(WidgetStateIdle, vtkCommand::RotateEvent, vtkEvent::AnyModifier, WidgetEventTouchpadRotateSliceIntersection);
+    // Touch gesture slice rotate
+    this->SetEventTranslation(WidgetStateIdle, vtkCommand::StartRotateEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureStart);
+    this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::RotateEvent, vtkEvent::AnyModifier, WidgetEventTouchRotateSliceIntersection);
+    this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::EndRotateEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureEnd);
 
     this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::LeftButtonPressEvent,
       vtkEvent::AltModifier+vtkEvent::ControlModifier, WidgetStateRotate, WidgetEventRotateStart, WidgetEventRotateEnd);
@@ -149,6 +162,10 @@ void vtkMRMLSliceIntersectionWidget::UpdateInteractionEventMapping()
       WidgetStateZoomSlice, WidgetEventZoomSliceStart, WidgetEventZoomSliceEnd);
     this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseWheelForwardEvent, vtkEvent::ControlModifier, WidgetEventZoomOutSlice);
     this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseWheelBackwardEvent, vtkEvent::ControlModifier, WidgetEventZoomInSlice);
+    // Touch slice zoom
+    this->SetEventTranslation(WidgetStateIdle, vtkCommand::StartPinchEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureStart);
+    this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::PinchEvent, vtkEvent::AnyModifier, WidgetEventTouchZoomSlice);
+    this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::EndPinchEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureEnd);
     }
 
   if (this->GetActionEnabled(ActionTranslate))
@@ -157,6 +174,10 @@ void vtkMRMLSliceIntersectionWidget::UpdateInteractionEventMapping()
       WidgetStateTranslateSlice, WidgetEventTranslateSliceStart, WidgetEventTranslateSliceEnd);
     this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::MiddleButtonPressEvent, vtkEvent::NoModifier,
       WidgetStateTranslateSlice, WidgetEventTranslateSliceStart, WidgetEventTranslateSliceEnd);
+    // Touch slice translate
+    this->SetEventTranslation(WidgetStateIdle, vtkCommand::StartPanEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureStart);
+    this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::PanEvent, vtkEvent::AnyModifier, WidgetEventTouchTranslateSlice);
+    this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::EndPanEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureEnd);
     }
 }
 
@@ -252,9 +273,20 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
       // click-and-dragging the mouse cursor
       processedEvent = this->ProcessMouseMove(eventData);
       break;
-    case WidgetEventTouchpadRotateSliceIntersection:
-      // TODO: save state when the gesture starts. Need to get an event from Qt via VTK.
-      this->Rotate(-1.0*vtkMath::RadiansFromDegrees(eventData->GetRotation() - eventData->GetLastRotation()));
+    case  WidgetEventTouchGestureStart:
+      this->ProcessTouchGestureStart(eventData);
+      break;
+    case WidgetEventTouchGestureEnd:
+      this->ProcessTouchGestureEnd(eventData);
+      break;
+    case WidgetEventTouchRotateSliceIntersection:
+      this->ProcessTouchRotate(eventData);
+      break;
+    case WidgetEventTouchZoomSlice:
+      this->ProcessTouchZoom(eventData);
+      break;
+    case WidgetEventTouchTranslateSlice:
+      this->ProcessTouchTranslate(eventData);
       break;
     case WidgetEventTranslateStart:
       this->SetWidgetState(WidgetStateTranslate);
@@ -473,6 +505,76 @@ bool vtkMRMLSliceIntersectionWidget::ProcessEndMouseDrag(vtkMRMLInteractionEvent
     return false;
     }
   this->SetWidgetState(WidgetStateIdle);
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessTouchGestureStart(vtkMRMLInteractionEventData* eventData)
+{
+  this->SetWidgetState(WidgetStateTouchGesture);
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessTouchGestureEnd(vtkMRMLInteractionEventData* eventData)
+{
+  this->TotalTouchRotation = 0.0;
+  this->TouchRotateEnabled = false;
+  this->TotalTouchZoom = 0.0;
+  this->TouchZoomEnabled = false;
+  this->TotalTouchTranslation = 0.0;
+  this->TouchTranslationEnabled = false;
+  this->SetWidgetState(WidgetStateIdle);
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessTouchRotate(vtkMRMLInteractionEventData* eventData)
+{
+  this->TotalTouchRotation += eventData->GetRotation() - eventData->GetLastRotation();
+  if (this->TouchRotateEnabled || std::abs(this->TotalTouchRotation) >= this->TouchRotationThreshold)
+    {
+    this->Rotate(vtkMath::RadiansFromDegrees(eventData->GetRotation() - eventData->GetLastRotation()));
+    this->TouchRotateEnabled = true;
+    }
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessTouchZoom(vtkMRMLInteractionEventData* eventData)
+{
+  this->TotalTouchZoom += eventData->GetLastScale() / eventData->GetScale();
+  if (this->TouchZoomEnabled || std::abs(this->TotalTouchZoom - 1.0) > this->TouchZoomThreshold)
+    {
+    this->ScaleZoom(eventData->GetLastScale() / eventData->GetScale(), eventData);
+    this->TouchZoomEnabled = true;
+    }
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessTouchTranslate(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLSliceNode* sliceNode = this->SliceLogic->GetSliceNode();
+
+  vtkMatrix4x4* xyToSlice = sliceNode->GetXYToSlice();
+  const double* translate = eventData->GetTranslation();
+  double translation[2] = {
+    xyToSlice->GetElement(0, 0) * translate[0],
+    xyToSlice->GetElement(1, 1) * translate[1]
+  };
+
+
+  this->TotalTouchTranslation += vtkMath::Norm2D(translate);
+
+  if (this->TouchTranslationEnabled || this->TotalTouchTranslation >= this->TouchTranslationThreshold)
+    {
+    double sliceOrigin[3];
+    sliceNode->GetXYZOrigin(sliceOrigin);
+    sliceNode->SetSliceOrigin(sliceOrigin[0] - translation[0], sliceOrigin[1] - translation[1], 0);
+    this->TouchTranslationEnabled = true;
+    }
+
   return true;
 }
 
@@ -902,6 +1004,7 @@ void vtkMRMLSliceIntersectionWidget::ScaleZoom(double zoomScaleFactor, vtkMRMLIn
     return;
     }
   vtkMRMLSliceNode *sliceNode = this->SliceLogic->GetSliceNode();
+  int wasModifying = sliceNode->StartModify();
 
   // Get distance of event position from slice center
   const int* eventPosition = eventData->GetDisplayPosition();
@@ -929,6 +1032,7 @@ void vtkMRMLSliceIntersectionWidget::ScaleZoom(double zoomScaleFactor, vtkMRMLIn
     sliceOrigin[2]);
 
   sliceNode->UpdateMatrices();
+  sliceNode->EndModify(wasModifying);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
@@ -82,12 +82,17 @@ public:
     WidgetStateBlend,
     WidgetStateTranslateSlice,
     WidgetStateZoomSlice,
+    WidgetStateTouchGesture,
     };
 
   /// Widget events
   enum
     {
-    WidgetEventTouchpadRotateSliceIntersection = WidgetEventUser,
+    WidgetEventTouchGestureStart = WidgetEventUser,
+    WidgetEventTouchGestureEnd,
+    WidgetEventTouchRotateSliceIntersection,
+    WidgetEventTouchZoomSlice,
+    WidgetEventTouchTranslateSlice,
     WidgetEventBlendStart,
     WidgetEventBlendEnd,
     WidgetEventToggleLabelOpacity,
@@ -168,6 +173,12 @@ protected:
 
   bool ProcessZoomSlice(vtkMRMLInteractionEventData* eventData);
 
+  bool ProcessTouchGestureStart(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTouchGestureEnd(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTouchRotate(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTouchZoom(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTouchTranslate(vtkMRMLInteractionEventData* eventData);
+
   /// Rotate the message by the specified amount. Used for touchpad events.
   bool Rotate(double sliceRotationAngleRad);
 
@@ -236,6 +247,16 @@ protected:
   bool ModifierKeyPressedSinceLastMouseButtonRelease;
 
   int ActionsEnabled;
+
+  double TouchRotationThreshold;
+  double TouchTranslationThreshold;
+  double TouchZoomThreshold;
+  double TotalTouchRotation;
+  bool TouchRotateEnabled;
+  double TotalTouchTranslation;
+  bool TouchTranslationEnabled;
+  double TotalTouchZoom;
+  bool TouchZoomEnabled;
 
 private:
   vtkMRMLSliceIntersectionWidget(const vtkMRMLSliceIntersectionWidget&) = delete;

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -237,6 +237,56 @@ void vtkMRMLViewInteractorStyle::OnConfigure()
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnPinch()
+{
+  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::PinchEvent))
+    {
+    return;
+    }
+  this->Superclass::OnPinch();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnRotate()
+{
+  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::RotateEvent))
+    {
+    return;
+    }
+  this->Superclass::OnRotate();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnPan()
+{
+  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::PanEvent))
+    {
+    return;
+    }
+  this->Superclass::OnPan();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnTap()
+{
+  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::TapEvent))
+    {
+    return;
+    }
+  this->Superclass::OnTap();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLViewInteractorStyle::OnLongTap()
+{
+  if (this->DelegateInteractionEventToDisplayableManagers(vtkCommand::LongTapEvent))
+    {
+    return;
+    }
+  this->Superclass::OnLongTap();
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLViewInteractorStyle::SetDisplayableManagers(vtkMRMLDisplayableManagerGroup* displayableManagerGroup)
 {
   this->DisplayableManagers = displayableManagerGroup;
@@ -430,5 +480,11 @@ void vtkMRMLViewInteractorStyle::SetInteractor(vtkRenderWindowInteractor *intera
     this->Interactor->AddObserver(vtkCommand::LeftButtonDoubleClickEvent, this->EventCallbackCommand, this->Priority);
     this->Interactor->AddObserver(vtkCommand::MiddleButtonDoubleClickEvent, this->EventCallbackCommand, this->Priority);
     this->Interactor->AddObserver(vtkCommand::RightButtonDoubleClickEvent, this->EventCallbackCommand, this->Priority);
+    this->Interactor->AddObserver(vtkCommand::StartPinchEvent, this->EventCallbackCommand, this->Priority);
+    this->Interactor->AddObserver(vtkCommand::EndPinchEvent, this->EventCallbackCommand, this->Priority);
+    this->Interactor->AddObserver(vtkCommand::StartRotateEvent, this->EventCallbackCommand, this->Priority);
+    this->Interactor->AddObserver(vtkCommand::EndRotateEvent, this->EventCallbackCommand, this->Priority);
+    this->Interactor->AddObserver(vtkCommand::StartPanEvent, this->EventCallbackCommand, this->Priority);
+    this->Interactor->AddObserver(vtkCommand::EndPanEvent, this->EventCallbackCommand, this->Priority);
     }
 }

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.h
@@ -57,6 +57,13 @@ public:
   void OnMouseWheelForward() override;
   void OnMouseWheelBackward() override;
 
+  // Touch gesture interaction events
+  void OnPinch() override;
+  void OnRotate() override;
+  void OnPan() override;
+  void OnTap() override;
+  void OnLongTap() override;
+
   /// Keyboard functions
   void OnChar() override;
   void OnKeyPress() override;


### PR DESCRIPTION
Adds Qt gesture interactions for pinch, rotate and pan gestures

Pinch:
- Slice view: Zoom in and out at mouse location
- 3D view: Zoom in and out at focal point

Rotate:
- Slice view: If slice intersection is visible, rotate parallel slices around current slice
- 3D view: Roll camera around current forward direction

Pan:
- Slice view: Translate slice plane
- 3D view: Translate camera position and focal point

___

Supersedes: https://github.com/Slicer/Slicer/pull/970

Requires a few changes in VTK to ensure that gestures are correctly captured:
https://github.com/Sunderlandkyl/VTK/commit/3ed40faaf3c785084f6eb13d562b30087d3010d6

Example video here:
https://www.dropbox.com/s/3zif5a4kvrad8xj/gesture_demo_2.mp4?dl=0

___

TODO:
- [x] Test gestures on touchscreen