### PR TITLE
ENH: Pause rendering in views while user interactions are processed

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -314,6 +314,10 @@ void qSlicerCoreApplicationPrivate::init()
               q, SLOT(onSlicerApplicationLogicRequest(vtkObject*,void*,ulong)));
   q->qvtkConnect(this->AppLogic, vtkSlicerApplicationLogic::RequestWriteDataEvent,
               q, SLOT(onSlicerApplicationLogicRequest(vtkObject*,void*,ulong)));
+  q->qvtkConnect(this->AppLogic, vtkMRMLApplicationLogic::PauseRenderEvent,
+              q, SLOT(pauseRender()));
+  q->qvtkConnect(this->AppLogic, vtkMRMLApplicationLogic::ResumeRenderEvent,
+              q, SLOT(resumeRender()));
   q->qvtkConnect(this->AppLogic->GetUserInformation(), vtkCommand::ModifiedEvent,
     q, SLOT(onUserInformationModified()));
 

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -445,6 +445,20 @@ public slots:
 
   bool unregisterResource(int handle);
 
+  /// Calls setRenderPaused(pause) on the current layout manager.
+  /// Emits pauseRenderRequested() if pause is true and resumeRenderRequested() if pause is false.
+  /// The caller is responsible for making sure that each setRenderPaused(true) is paired with
+  /// setRenderPaused(false).
+  /// Implemented in qSlicerApplication
+  /// \sa qSlicerApplication::setRenderPaused()
+  virtual void setRenderPaused(bool pause) {};
+  /// Equivalent to setRenderPaused(true)
+  /// \sa setRenderPaused
+  virtual void pauseRender() {};
+  /// Equivalent to setRenderPaused(false)
+  /// \sa setRenderPaused
+  virtual void resumeRender() {};
+
 protected:
 
   /// Process command line arguments **before** the applicaton event loop is started.

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -176,15 +176,15 @@ public slots:
   /// The caller is responsible for making sure that each setRenderPaused(true) is paired with
   /// setRenderPaused(false).
   /// \sa qMRMLLayoutManager::setRenderPaused()
-  void setRenderPaused(bool pause);
+  void setRenderPaused(bool pause) override;
 
   /// Equivalent to setRenderPaused(true)
   /// \sa setRenderPaused
-  void pauseRender();
+  void pauseRender() override;
 
   /// Equivalent to setRenderPaused(false)
   /// \sa setRenderPaused
-  void resumeRender();
+  void resumeRender() override;
 
 signals:
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -19,6 +19,7 @@
 
 // MRML includes
 #include "vtkMRMLAbstractSliceViewDisplayableManager.h"
+#include "vtkMRMLApplicationLogic.h"
 #include "vtkMRMLDisplayableManagerGroup.h"
 #include "vtkMRMLInteractionEventData.h"
 
@@ -303,6 +304,8 @@ bool vtkMRMLViewInteractorStyle::DelegateInteractionEventDataToDisplayableManage
     return false;
     }
 
+  // This prevents desynchronized update of displayable managers during user interaction
+  // (ie. slice intersection widget or segmentations laggingbehind during slice translation)
   bool processed = this->FocusedDisplayableManager->ProcessInteractionEvent(eventData);
   int cursor = VTK_CURSOR_DEFAULT;
   if (processed)
@@ -310,6 +313,7 @@ bool vtkMRMLViewInteractorStyle::DelegateInteractionEventDataToDisplayableManage
     cursor = this->FocusedDisplayableManager->GetMouseCursor();
     }
   this->FocusedDisplayableManager->SetMouseCursor(cursor);
+  this->FocusedDisplayableManager->GetMRMLApplicationLogic()->ResumeRender();
   return processed;
 }
 

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -1244,3 +1244,19 @@ void vtkMRMLApplicationLogic::SaveSceneScreenshot(vtkImageData* screenshot)
   screenShotWriter->SetFileName(screenshotFilePath.c_str());
   screenShotWriter->Write();
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::PauseRender()
+{
+  // Observers in qSlicerCoreApplication listen for PauseRenderEvent and call pauseRender
+  // to temporarily stop rendering in all views in the current layout
+  this->InvokeEvent(PauseRenderEvent);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::ResumeRender()
+{
+  // Observers in qSlicerCoreApplication listen for ResumeRenderEvent and call resumeRender
+  // to resume rendering in all views in the current layout
+  this->InvokeEvent(ResumeRenderEvent);
+}

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -189,7 +189,9 @@ public:
 
   /// List of custom events fired by the class.
   enum Events{
-    RequestInvokeEvent = vtkCommand::UserEvent + 1
+    RequestInvokeEvent = vtkCommand::UserEvent + 1,
+    PauseRenderEvent = vtkCommand::UserEvent + 101,
+    ResumeRenderEvent
   };
   /// Structure passed as calldata pointer in the RequestEvent invoked event.
   struct InvokeRequest{
@@ -218,6 +220,20 @@ public:
   /// Saves the provided image as screenshot of the scene (same filepath as the scene URL but extension is .png instead of .mrml).
   /// Uses current scene's URL property, so the URL must be up-to-date when calling this method.
   void SaveSceneScreenshot(vtkImageData* screenshot);
+
+  /// Pauses rendering for all views in the current layout.
+  /// It should be used in situations where multiple nodes are modified, and it is undesirable to display an intermediate
+  /// state.
+  /// The caller is responsible for making sure that each PauseRender() is paired with
+  /// ResumeRender().
+  /// \sa vtkMRMLApplicationLogic::ResumeRender()
+  /// \sa qSlicerApplication::setRenderPaused()
+  virtual void PauseRender();
+
+  /// Resumes rendering for all views in the current layout.
+  /// \sa vtkMRMLApplicationLogic::PauseRender()
+  /// \sa qSlicerApplication::setRenderPaused()
+  virtual void ResumeRender();
 
 protected:
 

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -1361,5 +1361,5 @@ void qMRMLLayoutManager::pauseRender()
 //------------------------------------------------------------------------------
 void qMRMLLayoutManager::resumeRender()
 {
-  this->setRenderPaused(true);
+  this->setRenderPaused(false);
 }


### PR DESCRIPTION
This prevents desynchronized update of displayable managers during user interaction (ie. slice intersection widget or segmentations lagging behind during slice translation)

When the user interacts with a view, PauseRenderEvent is invoked on the instance of vtkMRMLApplicationLogic.
Observers in qSlicerCoreApplication call pauseRender to temporarily stop rendering in all views.
When the user interaction has been processed ResumeRenderEvent is invoked, allowing rendering to continue.