### PR TITLE
BUG: Fix loading of DICOM series removing unneeded "slicer.util.unicodeify"

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1053,16 +1053,6 @@ def tempDirectory(key='__SlicerTemp__',tempDir=None,includeDateTime=True):
   qt.QDir().mkpath(dirPath)
   return dirPath
 
-#
-# Misc. Utility methods
-#
-def unicodeify(s):
-  """
-  Avoid UnicodeEncodeErrors using the technique described here:
-  http://stackoverflow.com/questions/9942594/unicodeencodeerror-ascii-codec-cant-encode-character-u-xa0-in-position-20
-  """
-  return s.encode('utf-8')
-
 def delayDisplay(message,autoCloseMsec=1000):
   """Display an information message in a popup window for a short time.
   If autoCloseMsec<400, then only slicer.app.processEvents() is called.

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -262,8 +262,8 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
     """
     if not (hasattr(x,'name') and hasattr(y,'name')):
         return 0
-    xName = slicer.util.unicodeify(x.name)
-    yName = slicer.util.unicodeify(y.name)
+    xName = x.name
+    yName = y.name
     try:
       xNumber = int(xName[:xName.index(':')])
       yNumber = int(yName[:yName.index(':')])


### PR DESCRIPTION
BUG: Fix loading of DICOM series removing unneeded "slicer.util.unicodeify"

It fixes the following error reported when loading RTImage dataset while
having the SlicerRT modules loaded:

```pytb
  Traceback (most recent call last):
    File "/path/to/Slicer-SuperBuild/Slicer-build/lib/Slicer-4.11/qt-scripted-modules/DICOMLib/DICOMWidgets.py", line 730, in getLoadablesFromFileLists
      loadablesByPlugin[plugin] = plugin.examineForImport(fileLists)
    File "/path/to/Slicer-SuperBuild/Slicer-build/lib/Slicer-4.11/qt-scripted-modules/DICOMScalarVolumePlugin.py", line 147, in examineForImport
      loadables.sort(key=cmp_to_key(lambda x,y: self.seriesSorter(x,y)))
    File "/path/to/Slicer-SuperBuild/Slicer-build/lib/Slicer-4.11/qt-scripted-modules/DICOMScalarVolumePlugin.py", line 147, in <lambda>
      loadables.sort(key=cmp_to_key(lambda x,y: self.seriesSorter(x,y)))
    File "/path/to/Slicer-SuperBuild/Slicer-build/lib/Slicer-4.11/qt-scripted-modules/DICOMScalarVolumePlugin.py", line 268, in seriesSorter
      xNumber = int(xName[:xName.index(':')])
  TypeError: a bytes-like object is required, not 'str'
  Warning: Plugin failed: DICOMScalarVolumePlugin
```

Since Python3 handle all strings as unicode, this commit removes the
unicodeify function originally introduced in these commits:
* r23472 (BUG: 3688 unicode characters from dicom)
* r23473 (BUG: unicodeify date to fix subject hierarchy)
* r23483 (BUG: Fixed accented character display of series and studies in subject)
* r23484 (STYLE: Removed testing code from previous commit)

Dataset originally associated with issue 3688 is loading as expected.