### PR TITLE
ENH: BuildSystem: Add Slicer_BUILD_WEBENGINE_SUPPORT option

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -121,6 +121,9 @@ void qSlicerApplicationHelper::preInitializeApplication(
   // Enable automatic scaling based on the pixel density of the monitor
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
+  // Enables resource sharing between the OpenGL contexts used by classes like QOpenGLWidget and QQuickWidget
+  QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+
   // Allow a custom application name so that the settings
   // can be distinct for differently named applications
   QString applicationName("Slicer");

--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -93,13 +93,6 @@ set(KIT_SRCS
   qSlicerViewersToolBar.cxx
   qSlicerViewersToolBar.h
   qSlicerViewersToolBar_p.h
-  qSlicerWebPythonProxy.cxx
-  qSlicerWebPythonProxy.h
-  qSlicerWebDownloadWidget.cxx
-  qSlicerWebDownloadWidget.h
-  qSlicerWebWidget.cxx
-  qSlicerWebWidget.h
-  qSlicerWebWidget_p.h
   qSlicerWidget.cxx
   qSlicerWidget.h
 
@@ -109,9 +102,6 @@ set(KIT_SRCS
 
 if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
   list(APPEND KIT_SRCS
-    qSlicerExtensionsInstallWidget.cxx
-    qSlicerExtensionsInstallWidget.h
-    qSlicerExtensionsInstallWidget_p.h
     qSlicerExtensionsRestoreWidget.cxx
     qSlicerExtensionsRestoreWidget.h
     qSlicerExtensionsManageWidget.cxx
@@ -123,12 +113,31 @@ if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
     qSlicerSettingsExtensionsPanel.cxx
     qSlicerSettingsExtensionsPanel.h
     )
+  if(Slicer_BUILD_WEBENGINE_SUPPORT)
+    list(APPEND KIT_SRCS
+      qSlicerExtensionsInstallWidget.cxx
+      qSlicerExtensionsInstallWidget.h
+      qSlicerExtensionsInstallWidget_p.h
+      )
+  endif()
 endif()
 
 if(Slicer_BUILD_I18N_SUPPORT)
   list(APPEND KIT_SRCS
     qSlicerSettingsInternationalizationPanel.cxx
     qSlicerSettingsInternationalizationPanel.h
+    )
+endif()
+
+if(Slicer_BUILD_WEBENGINE_SUPPORT)
+  list(APPEND KIT_SRCS
+    qSlicerWebPythonProxy.cxx
+    qSlicerWebPythonProxy.h
+    qSlicerWebDownloadWidget.cxx
+    qSlicerWebDownloadWidget.h
+    qSlicerWebWidget.cxx
+    qSlicerWebWidget.h
+    qSlicerWebWidget_p.h
     )
 endif()
 
@@ -206,10 +215,6 @@ set(KIT_MOC_SRCS
   qSlicerStyle.h
   qSlicerViewersToolBar.h
   qSlicerViewersToolBar_p.h
-  qSlicerWebDownloadWidget.h
-  qSlicerWebPythonProxy.h
-  qSlicerWebWidget.h
-  qSlicerWebWidget_p.h
   qSlicerWidget.h
 
   qSlicerSingletonViewFactory.h
@@ -217,19 +222,32 @@ set(KIT_MOC_SRCS
 
 if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
   list(APPEND KIT_MOC_SRCS
-    qSlicerExtensionsInstallWidget.h
-    qSlicerExtensionsInstallWidget_p.h
     qSlicerExtensionsRestoreWidget.h
     qSlicerExtensionsManageWidget.h
     qSlicerExtensionsManagerDialog.h
     qSlicerExtensionsManagerWidget.h
     qSlicerSettingsExtensionsPanel.h
     )
+  if(Slicer_BUILD_WEBENGINE_SUPPORT)
+    list(APPEND KIT_MOC_SRCS
+      qSlicerExtensionsInstallWidget.h
+      qSlicerExtensionsInstallWidget_p.h
+      )
+  endif()
 endif()
 
 if(Slicer_BUILD_I18N_SUPPORT)
   list(APPEND KIT_MOC_SRCS
     qSlicerSettingsInternationalizationPanel.h
+    )
+endif()
+
+if(Slicer_BUILD_WEBENGINE_SUPPORT)
+  list(APPEND KIT_MOC_SRCS
+    qSlicerWebDownloadWidget.h
+    qSlicerWebPythonProxy.h
+    qSlicerWebWidget.h
+    qSlicerWebWidget_p.h
     )
 endif()
 

--- a/Base/QTGUI/Resources/UI/qSlicerExtensionsManagerWidget.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerExtensionsManagerWidget.ui
@@ -43,7 +43,6 @@
        <item>
         <widget class="QStackedWidget" name="ManageExtensionsPager">
          <widget class="qSlicerExtensionsManageWidget" name="ExtensionsManageWidget"/>
-         <widget class="qSlicerExtensionsInstallWidget" name="ExtensionsManageBrowser"/>
         </widget>
        </item>
       </layout>
@@ -56,17 +55,10 @@
       <attribute name="title">
        <string>Install Extensions</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <layout class="QVBoxLayout" name="InstallExtensionsTabLayout">
        <property name="margin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="qSlicerExtensionsInstallWidget" name="ExtensionsInstallWidget" native="true">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="restoreExtensionsTab">
@@ -92,12 +84,6 @@
    <class>qSlicerExtensionsManageWidget</class>
    <extends>QWidget</extends>
    <header>qSlicerExtensionsManageWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerExtensionsInstallWidget</class>
-   <extends>QWidget</extends>
-   <header>qSlicerExtensionsInstallWidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
@@ -11,6 +11,9 @@
 
 // this is a test of the slicer slice logic resampling pipeline
 
+// Slicer includes
+#include "vtkSlicerConfigure.h" // For Slicer_VTK_USE_QVTKOPENGLWIDGET, Slicer_BUILD_WEBENGINE_SUPPORT
+
 // Qt includes
 #include <QApplication>
 #include <QProcessEnvironment>
@@ -18,10 +21,9 @@
 #include <QString>
 #include <QTimer>
 #include <QVBoxLayout>
+#ifdef Slicer_BUILD_WEBENGINE_SUPPORT
 #include <QWebEngineView>
-
-// Slicer includes
-#include "vtkSlicerConfigure.h"
+#endif
 
 // SlicerQt includes
 #include "qSlicerWidget.h"
@@ -186,10 +188,12 @@ int qSlicerWidgetTest2(int argc, char * argv[] )
   vbox.addWidget(vtkWidget);
   vtkWidget->GetRenderWindow()->Render();
 
+#ifdef Slicer_BUILD_WEBENGINE_SUPPORT
   QWebEngineView webView;
   webView.setParent(&parentWidget);
   webView.setUrl(QUrl("http://pyjs.org/examples"));
   vbox.addWidget(&webView);
+#endif
 
   vtkMRMLScene* scene = vtkMRMLScene::New();
   widget->setMRMLScene(scene);

--- a/Base/QTGUI/qSlicerActionsDialog.cxx
+++ b/Base/QTGUI/qSlicerActionsDialog.cxx
@@ -18,10 +18,14 @@
 
 ==============================================================================*/
 
+#include "vtkSlicerConfigure.h" // For Slicer_BUILD_WEBENGINE_SUPPORT
+
 // Qt includes
 #include <QGridLayout>
 #include <QtGlobal>
+#ifdef Slicer_BUILD_WEBENGINE_SUPPORT
 #include <QWebEngineView>
+#endif
 
 // SlicerQt includes
 #include "qSlicerActionsDialog.h"
@@ -40,7 +44,9 @@ public:
   qSlicerActionsDialogPrivate(qSlicerActionsDialog& object);
   void init();
 
+#ifdef Slicer_BUILD_WEBENGINE_SUPPORT
   QWebEngineView* WebView;
+#endif
 
 };
 
@@ -56,6 +62,7 @@ void qSlicerActionsDialogPrivate::init()
   Q_Q(qSlicerActionsDialog);
 
   this->setupUi(q);
+#ifdef Slicer_BUILD_WEBENGINE_SUPPORT
   this->WebView = new QWebEngineView();
   this->WebView->setObjectName("WebView");
   this->gridLayout->addWidget(this->WebView, 0, 0);
@@ -69,6 +76,9 @@ void qSlicerActionsDialogPrivate::init()
     QString("http://wiki.slicer.org/slicerWiki/index.php/Documentation/%1/").arg(wikiVersion);
   shortcutsUrl += "SlicerApplication/MouseandKeyboardShortcuts";
   this->WebView->setUrl( shortcutsUrl );
+#else
+  this->tabWidget->setTabEnabled(this->tabWidget->indexOf(this->WikiTab), false);
+#endif
 }
 
 //------------------------------------------------------------------------------

--- a/CMake/SlicerBlockInstallQt.cmake
+++ b/CMake/SlicerBlockInstallQt.cmake
@@ -110,10 +110,12 @@ set(QT_INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR})
       )
 
     # Install webengine translations
-    set(translations_dir "${qt_root_dir}/translations/qtwebengine_locales")
-    install(DIRECTORY ${translations_dir}
-      DESTINATION ${Slicer_INSTALL_ROOT}/share/QtTranslations/ COMPONENT Runtime
-      )
+    if("Qt5::WebEngine" IN_LIST QT_LIBRARIES)
+      set(translations_dir "${qt_root_dir}/translations/qtwebengine_locales")
+      install(DIRECTORY ${translations_dir}
+        DESTINATION ${Slicer_INSTALL_ROOT}/share/QtTranslations/ COMPONENT Runtime
+        )
+    endif()
 
     # Configure and install qt.conf
     set(qt_conf_contents "[Paths]\nPrefix = ..\nPlugins = ${Slicer_INSTALL_QtPlugins_DIR}\nTranslations = share/QtTranslations")

--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -36,9 +36,11 @@ if(NOT Slicer_USE_SYSTEM_QT)
     imageformats
     sqldrivers
     )
-    list(APPEND SlicerBlockInstallQtPlugins_subdirectories
-      designer:webengineview
-      )
+    if(Slicer_BUILD_WEBENGINE_SUPPORT)
+      list(APPEND SlicerBlockInstallQtPlugins_subdirectories
+        designer:webengineview
+        )
+    endif()
     if(APPLE)
       list(APPEND SlicerBlockInstallQtPlugins_subdirectories
         platforms:cocoa

--- a/CMake/vtkSlicerConfigure.h.in
+++ b/CMake/vtkSlicerConfigure.h.in
@@ -68,6 +68,7 @@
 #cmakedefine Slicer_BUILD_DIFFUSION_SUPPORT
 #cmakedefine Slicer_BUILD_I18N_SUPPORT
 #cmakedefine Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT
+#cmakedefine Slicer_BUILD_WEBENGINE_SUPPORT
 
 #cmakedefine Slicer_BUILD_CLI_SUPPORT
 #cmakedefine Slicer_BUILD_CLI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,9 @@ mark_as_superbuild(Slicer_BUILD_DIFFUSION_SUPPORT)
 option(Slicer_BUILD_I18N_SUPPORT "Build Slicer with Internationalization support" OFF)
 mark_as_superbuild(Slicer_BUILD_I18N_SUPPORT)
 
+option(Slicer_BUILD_WEBENGINE_SUPPORT "Build Slicer with Qt WebEngine support" OFF)
+mark_as_superbuild(Slicer_BUILD_WEBENGINE_SUPPORT)
+
 option(Slicer_BUILD_QTLOADABLEMODULES "Build Slicer QT Loadable Modules" ON)
 mark_as_advanced(Slicer_BUILD_QTLOADABLEMODULES)
 mark_as_superbuild(Slicer_BUILD_QTLOADABLEMODULES)
@@ -552,11 +555,13 @@ endif()
     Svg Sql
     )
   find_package(Qt5 COMPONENTS Core QUIET)
+  if(Slicer_BUILD_WEBENGINE_SUPPORT)
     list(APPEND Slicer_REQUIRED_QT_MODULES
       WebEngine
       WebEngineWidgets
       WebChannel
       )
+  endif()
   if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
     list(APPEND Slicer_REQUIRED_QT_MODULES Script)
   endif()

--- a/Libs/CMakeLists.txt
+++ b/Libs/CMakeLists.txt
@@ -72,6 +72,8 @@ set(MRML_TEST_DATA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/MRML/Core/Testing/TestData)
 
 set(VTKITK_BUILD_DICOM_SUPPORT ${Slicer_BUILD_DICOM_SUPPORT})
 
+set(MRML_WIDGETS_HAVE_WEBGINE_SUPPORT ${Slicer_BUILD_WEBENGINE_SUPPORT})
+
 #-----------------------------------------------------------------------------
 # Loop over list of directories
 #-----------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/CMakeLists.txt
+++ b/Libs/MRML/Widgets/CMakeLists.txt
@@ -46,6 +46,9 @@ endif()
 # Configure headers
 # --------------------------------------------------------------------------
 set(MRML_WIDGETS_HAVE_QT5 1)
+if(NOT DEFINED MRML_WIDGETS_HAVE_WEBGINE_SUPPORT)
+  set(MRML_WIDGETS_HAVE_WEBGINE_SUPPORT 1)
+endif()
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/qMRMLWidgetsConfigure.h.in
@@ -58,14 +61,6 @@ configure_file(
 set(MRMLWidgets_SRCS
   qMRMLCaptureToolBar.cxx
   qMRMLCaptureToolBar.h
-  qMRMLChartView.cxx
-  qMRMLChartView.h
-  qMRMLChartView_p.h
-  qMRMLChartViewControllerWidget.cxx
-  qMRMLChartViewControllerWidget.h
-  qMRMLChartViewControllerWidget_p.h
-  qMRMLChartWidget.cxx
-  qMRMLChartWidget.h
   qMRMLCheckableNodeComboBox.cxx
   qMRMLCheckableNodeComboBox.h
   qMRMLClipNodeWidget.cxx
@@ -226,23 +221,31 @@ set(MRMLWidgets_SRCS
   qMRMLVolumeThresholdWidget.h
   qMRMLVolumeWidget.cxx
   qMRMLVolumeWidget.h
-  qMRMLExpandingWebView.cxx
-  qMRMLExpandingWebView.h
-  qMRMLExpandingWebView_p.h
   qMRMLWidget.cxx
   qMRMLWidget.h
   qMRMLWindowLevelWidget.cxx
   qMRMLWindowLevelWidget.h
   )
 
+if(MRML_WIDGETS_HAVE_WEBGINE_SUPPORT)
+  list(APPEND MRMLWidgets_SRCS
+    qMRMLChartView.cxx
+    qMRMLChartView.h
+    qMRMLChartView_p.h
+    qMRMLChartViewControllerWidget.cxx
+    qMRMLChartViewControllerWidget.h
+    qMRMLChartViewControllerWidget_p.h
+    qMRMLChartWidget.cxx
+    qMRMLChartWidget.h
+    qMRMLExpandingWebView.cxx
+    qMRMLExpandingWebView.h
+    qMRMLExpandingWebView_p.h
+    )
+endif()
+
 # Headers that should run through moc
 set(MRMLWidgets_MOC_SRCS
   qMRMLCaptureToolBar.h
-  qMRMLChartView.h
-  qMRMLChartView_p.h
-  qMRMLChartViewControllerWidget.h
-  qMRMLChartViewControllerWidget_p.h
-  qMRMLChartWidget.h
   qMRMLCheckableNodeComboBox.h
   qMRMLClipNodeWidget.h
   qMRMLCollapsibleButton.h
@@ -328,15 +331,24 @@ set(MRMLWidgets_MOC_SRCS
   qMRMLVolumeThresholdWidget.h
   qMRMLVolumeWidget.h
   qMRMLVolumeWidget_p.h
-  qMRMLExpandingWebView.h
-  qMRMLExpandingWebView_p.h
   qMRMLWidget.h
   qMRMLWindowLevelWidget.h
   )
 
+if(MRML_WIDGETS_HAVE_WEBGINE_SUPPORT)
+  list(APPEND MRMLWidgets_MOC_SRCS
+    qMRMLChartView.h
+    qMRMLChartView_p.h
+    qMRMLChartViewControllerWidget.h
+    qMRMLChartViewControllerWidget_p.h
+    qMRMLChartWidget.h
+    qMRMLExpandingWebView.h
+    qMRMLExpandingWebView_p.h
+    )
+endif()
+
 # UI files
 set(MRMLWidgets_UI_SRCS
-  Resources/UI/qMRMLChartViewControllerWidget.ui
   Resources/UI/qMRMLClipNodeWidget.ui
   Resources/UI/qMRMLColorPickerWidget.ui
   Resources/UI/qMRMLDisplayNodeWidget.ui
@@ -361,11 +373,22 @@ set(MRMLWidgets_UI_SRCS
   Resources/UI/qMRMLWindowLevelWidget.ui
   )
 
-configure_file(Resources/jqPlot.qrc.in ${qMRMLWidgets_BINARY_DIR}/Resources/jqPlot.qrc)
+if(MRML_WIDGETS_HAVE_WEBGINE_SUPPORT)
+  list(APPEND MRMLWidgets_UI_SRCS
+    Resources/UI/qMRMLChartViewControllerWidget.ui
+    )
+endif()
+
 set(MRMLWidgets_QRC_SRCS
   Resources/qMRMLWidgets.qrc
-  ${qMRMLWidgets_BINARY_DIR}/Resources/jqPlot.qrc
   )
+
+if(MRML_WIDGETS_HAVE_WEBGINE_SUPPORT)
+  configure_file(Resources/jqPlot.qrc.in ${qMRMLWidgets_BINARY_DIR}/Resources/jqPlot.qrc)
+  list(APPEND MRMLWidgets_QRC_SRCS
+    ${qMRMLWidgets_BINARY_DIR}/Resources/jqPlot.qrc
+    )
+endif()
 
 if(Slicer_USE_QtTesting)
   list(APPEND MRMLWidgets_SRCS

--- a/Libs/MRML/Widgets/DesignerPlugins/CMakeLists.txt
+++ b/Libs/MRML/Widgets/DesignerPlugins/CMakeLists.txt
@@ -37,8 +37,6 @@ set(${KIT}_SRCS
   qMRMLDisplayNodeWidgetPlugin.h
   qMRMLEventBrokerWidgetPlugin.cxx
   qMRMLEventBrokerWidgetPlugin.h
-  qMRMLExpandingWebViewPlugin.cxx
-  qMRMLExpandingWebViewPlugin.h
   qMRMLLabelComboBoxPlugin.cxx
   qMRMLLabelComboBoxPlugin.h
   qMRMLLayoutWidgetPlugin.cxx
@@ -101,6 +99,13 @@ set(${KIT}_SRCS
   qMRMLWindowLevelWidgetPlugin.h
   )
 
+if(MRML_WIDGETS_HAVE_WEBGINE_SUPPORT)
+  list(APPEND ${KIT}_SRCS
+    qMRMLExpandingWebViewPlugin.cxx
+    qMRMLExpandingWebViewPlugin.h
+    )
+endif()
+
 # Headers that should run through moc
 set(${KIT}_MOC_SRCS
   qMRMLWidgetsPlugin.h
@@ -116,7 +121,6 @@ set(${KIT}_MOC_SRCS
   qMRMLDisplayNodeViewComboBoxPlugin.h
   qMRMLDisplayNodeWidgetPlugin.h
   qMRMLEventBrokerWidgetPlugin.h
-  qMRMLExpandingWebViewPlugin.h
   qMRMLLabelComboBoxPlugin.h
   qMRMLLayoutWidgetPlugin.h
   qMRMLLinearTransformSliderPlugin.h
@@ -148,6 +152,12 @@ set(${KIT}_MOC_SRCS
   qMRMLWidgetPlugin.h
   qMRMLWindowLevelWidgetPlugin.h
   )
+
+if(MRML_WIDGETS_HAVE_WEBGINE_SUPPORT)
+  list(APPEND ${KIT}_MOC_SRCS
+    qMRMLExpandingWebViewPlugin.h
+    )
+endif()
 
 set(${KIT}_TARGET_LIBRARIES
   qMRMLWidgets

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLWidgetsPlugin.h
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLWidgetsPlugin.h
@@ -21,7 +21,7 @@
 #ifndef __qMRMLWidgetsPlugin_h
 #define __qMRMLWidgetsPlugin_h
 
-#include "qMRMLWidgetsConfigure.h" // For MRML_WIDGETS_HAVE_QT5
+#include "qMRMLWidgetsConfigure.h" // For MRML_WIDGETS_HAVE_QT5, MRML_WIDGETS_HAVE_WEBGINE_SUPPORT
 
 // Qt includes
 #ifdef MRML_WIDGETS_HAVE_QT5
@@ -41,7 +41,9 @@
 #include "qMRMLDisplayNodeViewComboBoxPlugin.h"
 #include "qMRMLDisplayNodeWidgetPlugin.h"
 #include "qMRMLEventBrokerWidgetPlugin.h"
+#ifdef MRML_WIDGETS_HAVE_WEBGINE_SUPPORT
 #include "qMRMLExpandingWebViewPlugin.h"
+#endif
 #include "qMRMLLabelComboBoxPlugin.h"
 #include "qMRMLLayoutWidgetPlugin.h"
 #include "qMRMLLinearTransformSliderPlugin.h"
@@ -99,7 +101,9 @@ public:
             << new qMRMLDisplayNodeViewComboBoxPlugin
             << new qMRMLDisplayNodeWidgetPlugin
             << new qMRMLEventBrokerWidgetPlugin
+#ifdef MRML_WIDGETS_HAVE_WEBGINE_SUPPORT
             << new qMRMLExpandingWebViewPlugin
+#endif
             << new qMRMLLabelComboBoxPlugin
             << new qMRMLLayoutWidgetPlugin
             << new qMRMLLinearTransformSliderPlugin

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
@@ -27,7 +27,10 @@
 #include <QWidget>
 
 // Slicer includes
+#include <qMRMLWidgetsConfigure.h> // For MRML_WIDGETS_HAVE_WEBGINE_SUPPORT
+#ifdef MRML_WIDGETS_HAVE_WEBGINE_SUPPORT
 #include "qMRMLChartWidget.h"
+#endif
 #include "qMRMLLayoutManager.h"
 #include "qMRMLSliceWidget.h"
 #include "qMRMLTableWidget.h"
@@ -57,6 +60,7 @@ namespace
 //------------------------------------------------------------------------------
 bool testLayoutManagerViewWidgetForChart(int line, qMRMLLayoutManager* layoutManager, int viewId)
 {
+#ifdef MRML_WIDGETS_HAVE_WEBGINE_SUPPORT
   qMRMLChartWidget* widget = layoutManager->chartWidget(viewId);
   vtkMRMLChartViewNode* node = widget ? widget->mrmlChartViewNode() : nullptr;
   if (!widget || !node)
@@ -69,6 +73,11 @@ bool testLayoutManagerViewWidgetForChart(int line, qMRMLLayoutManager* layoutMan
     std::cerr << "Line " << line << " - Problem with qMRMLLayoutManager::viewWidget()" << std::endl;
     return false;
     }
+#else
+  Q_UNUSED(line);
+  Q_UNUSED(layoutManager);
+  Q_UNUSED(viewId);
+#endif
   return true;
 }
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLLayoutManager_p.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager_p.h
@@ -41,6 +41,7 @@
 #include <ctkLayoutManager_p.h>
 
 // qMRML includes
+#include "qMRMLWidgetsConfigure.h" // For MRML_WIDGETS_HAVE_WEBGINE_SUPPORT
 #include "qMRMLLayoutManager.h"
 #include "qMRMLLayoutViewFactory.h"
 
@@ -177,6 +178,7 @@ protected:
 };
 
 //------------------------------------------------------------------------------
+#ifdef MRML_WIDGETS_HAVE_WEBGINE_SUPPORT
 class QMRML_WIDGETS_EXPORT qMRMLLayoutChartViewFactory
   : public qMRMLLayoutViewFactory
 {
@@ -194,6 +196,7 @@ protected:
   QWidget* createViewFromNode(vtkMRMLAbstractViewNode* viewNode) override;
   vtkMRMLColorLogic* ColorLogic;
 };
+#endif
 
 //------------------------------------------------------------------------------
 class QMRML_WIDGETS_EXPORT qMRMLLayoutTableViewFactory

--- a/Libs/MRML/Widgets/qMRMLWidgetsConfigure.h.in
+++ b/Libs/MRML/Widgets/qMRMLWidgetsConfigure.h.in
@@ -26,6 +26,7 @@
 #endif
 
 #cmakedefine MRML_WIDGETS_HAVE_QT5
+#cmakedefine MRML_WIDGETS_HAVE_WEBGINE_SUPPORT
 
 #endif
 

--- a/Modules/Scripted/CMakeLists.txt
+++ b/Modules/Scripted/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(modules
   DataProbe
-  DMRIInstall
   Editor
   EditorLib
   LabelStatistics
@@ -15,6 +14,7 @@ set(modules
   )
 if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
   list(APPEND modules
+    DMRIInstall
     ExtensionWizard
     )
 endif()

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -182,15 +182,17 @@ macro(list_conditional_append cond list)
   endif()
 endmacro()
 
-Slicer_Remote_Add(jqPlot
-  URL https://github.com/Slicer/SlicerBinaryDependencies/releases/download/jqplot/jquery.jqplot.1.0.4r1115.tar.gz
-  URL_MD5 5c5d73730145c3963f09e1d3ca355580
-  LICENSE_FILES "MIT-LICENSE.txt"
-  VERSION "1.0.4"
-  SOURCE_DIR_VAR jqPlot_DIR
-  LABELS FIND_PACKAGE
-  )
-list(APPEND Slicer_REMOTE_DEPENDENCIES jqPlot)
+if(Slicer_BUILD_WEBENGINE_SUPPORT)
+  Slicer_Remote_Add(jqPlot
+    URL https://github.com/Slicer/SlicerBinaryDependencies/releases/download/jqplot/jquery.jqplot.1.0.4r1115.tar.gz
+    URL_MD5 5c5d73730145c3963f09e1d3ca355580
+    LICENSE_FILES "MIT-LICENSE.txt"
+    VERSION "1.0.4"
+    SOURCE_DIR_VAR jqPlot_DIR
+    LABELS FIND_PACKAGE
+    )
+  list(APPEND Slicer_REMOTE_DEPENDENCIES jqPlot)
+endif()
 
 option(Slicer_BUILD_MULTIVOLUME_SUPPORT "Build MultiVolume support." ON)
 mark_as_advanced(Slicer_BUILD_MULTIVOLUME_SUPPORT)
@@ -306,6 +308,7 @@ Slicer_Remote_Add(DataStore
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/Slicer-DataStore"
   GIT_TAG 5fcf3b6457c378f5b2987d7d7430416001c364b8
   OPTION_NAME Slicer_BUILD_DataStore
+  OPTION_DEPENDS "Slicer_BUILD_WEBENGINE_SUPPORT"
   LABELS REMOTE_MODULE
   )
 list_conditional_append(Slicer_BUILD_DataStore Slicer_REMOTE_DEPENDENCIES DataStore)

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -57,7 +57,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "6d9fb092e9a112b6a088da76bb74f0a7afe76e0d"
+    "ac0ff495ceee73ded5ee4508c1226472c39a730e"
     QUIET
     )
 


### PR DESCRIPTION
This new option allows to build custom Slicer applications without
WebEngine libraries. It reduces the install size by ~120MB

If Slicer_BUILD_WEBENGINE_SUPPORT option is OFF, the following happens:

  - exclude the following classes:

    - qSlicerWebWidget, qSlicerWebDownloadWidget and qSlicerWebPythonProxy
    - qMRMLExpandingWebView and qMRMLExpandingWebViewPlugin
    - qMRMLChartView, qMRMLChartWidget and qMRMLChartViewControllerWidget

  - views:

    - skip registration of qMRMLLayoutChartViewFactory in layout manager
       and return sensible values for method like viewNode(), viewWidget()

    - skip download of jqPlot only used in qMRMLChartView class

    - vtkMRMLChart nodes are still available and registered.

  - disable tab showing shortcuts in  qSlicerActionsDialog

  - datastore module is not available

  - extension manager:

    - enabling Slicer_BUILD_EXTENSIONMANAGER_SUPPORT while having
      Slicer_BUILD_WEBENGINE_SUPPORT off is supported.

    - installing from file is still supported.

    - in "Manage Extensons" tab, clicking on an extension link will NOT
      show a web-browser inside the manager.

    - in "Install Extensions" tab, nothing will be shown.