### PR TITLE
ENH: Display node description in subject hierarchy tree view

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -62,6 +62,7 @@ qMRMLSubjectHierarchyModelPrivate::qMRMLSubjectHierarchyModelPrivate(qMRMLSubjec
   , VisibilityColumn(-1)
   , ColorColumn(-1)
   , TransformColumn(-1)
+  , DescriptionColumn(-1)
   , SubjectHierarchyNode(nullptr)
   , MRMLScene(nullptr)
   , TerminologiesModuleLogic(nullptr)
@@ -107,15 +108,17 @@ void qMRMLSubjectHierarchyModelPrivate::init()
   QObject::connect(q, SIGNAL(itemChanged(QStandardItem*)), q, SLOT(onItemChanged(QStandardItem*)));
 
   q->setNameColumn(0);
-  q->setVisibilityColumn(1);
-  q->setColorColumn(2);
-  q->setTransformColumn(3);
-  q->setIDColumn(4);
+  q->setDescriptionColumn(1);
+  q->setVisibilityColumn(2);
+  q->setColorColumn(3);
+  q->setTransformColumn(4);
+  q->setIDColumn(5);
 
   q->setHorizontalHeaderLabels(
-    QStringList() << "Node" << "" << "" << "" << "IDs" );
+    QStringList() << "Node" << "Description" << "" /*visibility*/ << "" /*color*/ << "" /*transform*/ << "IDs" );
 
   q->horizontalHeaderItem(q->nameColumn())->setToolTip(QObject::tr("Node name and type"));
+  q->horizontalHeaderItem(q->descriptionColumn())->setToolTip(QObject::tr("Node description"));
   q->horizontalHeaderItem(q->visibilityColumn())->setToolTip(QObject::tr("Show/hide branch or node"));
   q->horizontalHeaderItem(q->colorColumn())->setToolTip(QObject::tr("Node color"));
   q->horizontalHeaderItem(q->transformColumn())->setToolTip(QObject::tr("Applied transform"));
@@ -805,7 +808,8 @@ QFlags<Qt::ItemFlag> qMRMLSubjectHierarchyModel::subjectHierarchyItemFlags(vtkId
     }
 
   // Name and transform columns are editable
-  if (column == this->nameColumn() || column == this->colorColumn() || column == this->transformColumn())
+  if (column == this->nameColumn() || column == this->colorColumn() || column == this->transformColumn()
+    || column == this->descriptionColumn())
     {
     flags |= Qt::ItemIsEditable;
     }
@@ -967,6 +971,15 @@ void qMRMLSubjectHierarchyModel::updateItemDataFromSubjectHierarchyItem(QStandar
     else
       {
       emit requestCollapseItem(shItemID);
+      }
+    }
+  // Description column
+  if (column == this->descriptionColumn())
+    {
+    vtkMRMLNode* dataNode = d->SubjectHierarchyNode->GetItemDataNode(shItemID);
+    if (dataNode)
+      {
+      item->setText(QString(dataNode->GetDescription()));
       }
     }
   // ID column
@@ -1162,6 +1175,17 @@ void qMRMLSubjectHierarchyModel::updateSubjectHierarchyItemFromItemData(vtkIdTyp
     {
     // This call renames associated data node if any
     d->SubjectHierarchyNode->SetItemName(shItemID, item->text().toLatin1().constData());
+    }
+  // Description column
+  if (item->column() == this->descriptionColumn())
+    {
+    std::string newDescriptionStr = item->text().toLatin1().constData();
+    vtkMRMLNode* dataNode = vtkMRMLNode::SafeDownCast(d->SubjectHierarchyNode->GetItemDataNode(shItemID));
+    if (!dataNode)
+      {
+      return;
+      }
+    dataNode->SetDescription(newDescriptionStr.c_str());
     }
   // Visibility column
   if (item->column() == this->visibilityColumn() && !item->data(VisibilityRole).isNull())
@@ -1617,6 +1641,21 @@ void qMRMLSubjectHierarchyModel::setTransformColumn(int column)
 }
 
 //------------------------------------------------------------------------------
+int qMRMLSubjectHierarchyModel::descriptionColumn()const
+{
+  Q_D(const qMRMLSubjectHierarchyModel);
+  return d->DescriptionColumn;
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyModel::setDescriptionColumn(int column)
+{
+  Q_D(qMRMLSubjectHierarchyModel);
+  d->DescriptionColumn = column;
+  this->updateColumnCount();
+}
+
+//------------------------------------------------------------------------------
 void qMRMLSubjectHierarchyModel::updateColumnCount()
 {
   Q_D(const qMRMLSubjectHierarchyModel);
@@ -1648,8 +1687,9 @@ void qMRMLSubjectHierarchyModel::updateColumnCount()
 int qMRMLSubjectHierarchyModel::maxColumnId()const
 {
   Q_D(const qMRMLSubjectHierarchyModel);
-  int maxId = 0;
+  int maxId = -1;
   maxId = qMax(maxId, d->NameColumn);
+  maxId = qMax(maxId, d->DescriptionColumn);
   maxId = qMax(maxId, d->IDColumn);
   maxId = qMax(maxId, d->VisibilityColumn);
   maxId = qMax(maxId, d->ColorColumn);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
@@ -59,13 +59,19 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qMRMLSubjectHierarchyModel
   /// If no property is set in a column, nothing is displayed.
   Q_PROPERTY (int nameColumn READ nameColumn WRITE setNameColumn)
   /// Control in which column data MRML node visibility are displayed (Qt::DecorationRole).
-  /// A value of -1 hides it. Hidden by default (value of -1).
+  /// A value of -1 (default) hides the column
   Q_PROPERTY (int visibilityColumn READ visibilityColumn WRITE setVisibilityColumn)
-  /// Control in which column the parent transforms are displayed
+  /// Control in which column data MRML node color is displayed.
+  /// A value of -1 (default) hides the column
+  Q_PROPERTY(int colorColumn READ colorColumn WRITE setColorColumn)
+    /// Control in which column the parent transforms are displayed
   /// A MRML node combobox is displayed in the row of the transformable nodes, in which
   /// the current transform is selected. The user can change the transform using the combobox.
   /// A value of -1 (default) hides the column
   Q_PROPERTY (int transformColumn READ transformColumn WRITE setTransformColumn)
+  /// Control in which column the node descriptions are displayed
+  /// A value of -1 (default) hides the column
+  Q_PROPERTY (int descriptionColumn READ descriptionColumn WRITE setDescriptionColumn)
   /// Control in which column the data MRML node IDs are displayed (Qt::DisplayRole).
   /// A value of -1 hides it. Hidden by default (value of -1)
   Q_PROPERTY (int idColumn READ idColumn WRITE setIDColumn)
@@ -99,6 +105,9 @@ public:
 
   int transformColumn()const;
   void setTransformColumn(int column);
+
+  int descriptionColumn()const;
+  void setDescriptionColumn(int column);
 
   int idColumn()const;
   void setIDColumn(int column);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel_p.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel_p.h
@@ -88,6 +88,7 @@ public:
   int VisibilityColumn;
   int ColorColumn;
   int TransformColumn;
+  int DescriptionColumn;
 
   QIcon VisibleIcon;
   QIcon HiddenIcon;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -169,12 +169,11 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
   this->SortFilterModel->setSourceModel(this->Model);
 
   // Set up headers
-  q->header()->setStretchLastSection(false);
-  q->header()->setSectionResizeMode(this->Model->nameColumn(), QHeaderView::Stretch);
-  q->header()->setSectionResizeMode(this->Model->visibilityColumn(), QHeaderView::ResizeToContents);
-  q->header()->setSectionResizeMode(this->Model->colorColumn(), QHeaderView::ResizeToContents);
-  q->header()->setSectionResizeMode(this->Model->transformColumn(), QHeaderView::ResizeToContents);
-  q->header()->setSectionResizeMode(this->Model->idColumn(), QHeaderView::ResizeToContents);
+  q->resetColumnSizesToDefault();
+  if (this->Model->descriptionColumn()>=0)
+    {
+    q->setColumnHidden(this->Model->descriptionColumn(), true);
+    }
 
   // Set generic MRML item delegate
   q->setItemDelegate(new qMRMLItemDelegate(q));
@@ -224,6 +223,43 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
 
   // Set up scene and node actions for the tree view
   this->setupActions();
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::resetColumnSizesToDefault()
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+
+  // Set up headers
+  this->header()->setStretchLastSection(false);
+  if (this->header()->count() <= 0)
+    {
+    return;
+    }
+  if (d->Model->nameColumn() >= 0)
+    {
+    this->header()->setSectionResizeMode(d->Model->nameColumn(), QHeaderView::Stretch);
+    }
+  if (d->Model->descriptionColumn() >= 0)
+    {
+    this->header()->setSectionResizeMode(d->Model->descriptionColumn(), QHeaderView::Interactive);
+    }
+  if (d->Model->visibilityColumn() >= 0)
+    {
+  this->header()->setSectionResizeMode(d->Model->visibilityColumn(), QHeaderView::ResizeToContents);
+    }
+  if (d->Model->colorColumn() >= 0)
+    {
+    this->header()->setSectionResizeMode(d->Model->colorColumn(), QHeaderView::ResizeToContents);
+    }
+  if (d->Model->transformColumn() >= 0)
+    {
+    this->header()->setSectionResizeMode(d->Model->transformColumn(), QHeaderView::ResizeToContents);
+    }
+  if (d->Model->idColumn() >= 0)
+    {
+    this->header()->setSectionResizeMode(d->Model->idColumn(), QHeaderView::ResizeToContents);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -184,6 +184,9 @@ public slots:
   void setEditMenuActionVisible(bool visible);
   void setSelectRoleSubMenuVisible(bool visible);
 
+  /// Resets column sizes and size policies to default.
+  void resetColumnSizesToDefault();
+
 signals:
   void currentItemChanged(vtkIdType);
   void currentItemModified(vtkIdType);


### PR DESCRIPTION
Added option to show node description in subject hierarchy tree.

The new column is hidden by default to preserve current behavior.
To show the description column, call:

    shTreeView.setColumnHidden(shTreeView.model().descriptionColumn, False)