### PR TITLE
ENH: Added Frenet-Serret frame and spline driven image slicer

### DIFF
--- a/Libs/vtkAddon/CMakeLists.txt
+++ b/Libs/vtkAddon/CMakeLists.txt
@@ -72,6 +72,11 @@ set(vtkAddon_SRCS
   vtkStreamingVolumeCodecFactory.h
   vtkRawRGBVolumeCodec.cxx
   vtkRawRGBVolumeCodec.h
+  # From https://github.com/lorensen/midas-journal-838:
+  vtkFrenetSerretFrame.cxx
+  vtkFrenetSerretFrame.h
+  vtkSplineDrivenImageSlicer.cxx
+  vtkSplineDrivenImageSlicer.h
 )
 
 if(Slicer_VTK_RENDERING_USE_OpenGL2_BACKEND)

--- a/Libs/vtkAddon/vtkFrenetSerretFrame.cxx
+++ b/Libs/vtkAddon/vtkFrenetSerretFrame.cxx
@@ -1,0 +1,239 @@
+// Copyright (c) 2010, Jerome Velut
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT OWNER ``AS IS'' AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+// NO EVENT SHALL THE COPYRIGHT OWNER BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "vtkFrenetSerretFrame.h"
+
+#include "vtkDoubleArray.h"
+#include "vtkPointData.h"
+#include "vtkMath.h"
+#include "vtkInformation.h"
+#include "vtkInformationVector.h"
+#include "vtkObjectFactory.h"
+
+vtkStandardNewMacro(vtkFrenetSerretFrame);
+
+vtkFrenetSerretFrame::vtkFrenetSerretFrame( )
+{
+  this->ConsistentNormals = 1;
+  this->ComputeBinormal = 1;
+  this->ViewUp = 0;
+}
+
+vtkFrenetSerretFrame::~vtkFrenetSerretFrame( )
+{
+
+}
+//---------------------------------------------------------------------------
+int vtkFrenetSerretFrame::FillInputPortInformation(int port, vtkInformation *info)
+{
+  if( port == 0 )
+  {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
+  }
+  return 1;
+}
+
+int vtkFrenetSerretFrame::RequestData(
+  vtkInformation *vtkNotUsed(request),
+  vtkInformationVector **inputVector,
+  vtkInformationVector *outputVector)
+{
+  // get the info objects
+  vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
+  vtkInformation *outInfo = outputVector->GetInformationObject(0);
+
+  // get the input and ouptut
+  vtkPolyData *input = vtkPolyData::SafeDownCast(
+    inInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkPolyData *output = vtkPolyData::SafeDownCast(
+    outInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  output->DeepCopy( input );
+
+  vtkDoubleArray* tangents = vtkDoubleArray::New( );
+  tangents->SetNumberOfComponents( 3 );
+  tangents->SetNumberOfTuples( input->GetNumberOfPoints( ) );
+  tangents->SetName("FSTangents");
+
+  vtkDoubleArray* normals = vtkDoubleArray::New( );
+  normals->SetNumberOfComponents( 3 );
+  normals->SetNumberOfTuples( input->GetNumberOfPoints( ) );
+  normals->SetName("FSNormals");
+
+  vtkDoubleArray* binormals = vtkDoubleArray::New( );
+  binormals->SetNumberOfComponents( 3 );
+  binormals->SetNumberOfTuples( input->GetNumberOfPoints( ) );
+  binormals->SetName("FSBinormals");
+
+
+  vtkCellArray* lines = output->GetLines( );
+  lines->InitTraversal();
+  vtkIdType nbPoints;
+  vtkIdType* points;
+
+  int cellIdx;
+  for( cellIdx = 0; cellIdx < lines->GetNumberOfCells( ); cellIdx++ )
+  {
+    lines->GetNextCell( nbPoints, points);
+    for( int i = 0 ; i<nbPoints; i++)
+    {
+      double tangent[3];
+      if( i == 0 )
+      {
+        this->ComputeTangentVectors( points[0],points[1],tangent );
+      }
+      else if( i == nbPoints-1 )
+      {
+        this->ComputeTangentVectors( points[nbPoints-2],points[nbPoints-1],tangent );
+      }
+      else
+      {
+        this->ComputeTangentVectors( points[i-1],points[i+1],tangent );
+      }
+      vtkMath::Normalize( tangent );
+      tangents->SetTuple(points[i],tangent);
+    }
+
+
+    for( int i = 0 ; i<nbPoints; i++)
+    {
+      double normal[3];
+      if( !this->ConsistentNormals || i == 0)
+      {
+        double tangentLast[3], tangentNext[3];
+        if( i == 0 )
+        {
+          tangents->GetTuple( points[i], tangentLast);
+        }
+        else
+        {
+          tangents->GetTuple( points[i-1], tangentLast);
+        }
+        if( i == nbPoints-1 )
+        {
+          tangents->GetTuple( points[i], tangentNext);
+        }
+        else
+        {
+          tangents->GetTuple( points[i+1], tangentNext);
+        }
+        this->ComputeNormalVectors( tangentLast, tangentNext, normal );
+
+        if( this->ConsistentNormals )
+        {
+          this->RotateVector( normal, tangentLast, this->ViewUp );
+        }
+      }
+
+      if( this->ConsistentNormals && i != 0)
+      {
+
+        double tangent[3], lastNormal[3];
+        normals->GetTuple(points[i-1],lastNormal);
+        tangents->GetTuple(points[i],tangent);
+
+        this->ComputeConsistentNormalVectors( tangent,
+                                              lastNormal,
+                                              normal );
+
+      }
+      vtkMath::Normalize( normal );
+      normals->SetTuple(points[i],normal);
+
+      if( this->ComputeBinormal == 1 )
+      {
+        double tangent[3], binormal[3];
+        tangents->GetTuple( points[i], tangent );
+        vtkMath::Cross( tangent, normal, binormal );
+        binormals->SetTuple( points[i], binormal );
+      }
+    }
+  }
+
+  output->GetPointData( )->AddArray( normals );
+  output->GetPointData( )->AddArray( tangents );
+  if( this->ComputeBinormal == 1 )
+  {
+    output->GetPointData( )->AddArray( binormals );
+  }
+  normals->Delete( );
+  tangents->Delete( );
+  binormals->Delete( );
+  return 1;
+}
+
+void vtkFrenetSerretFrame::ComputeTangentVectors( vtkIdType pointIdNext, vtkIdType pointIdLast, double* tangent )
+{
+
+  vtkPolyData* input = static_cast<vtkPolyData*>(this->GetInput( 0 ));
+  double ptNext[3];
+  double ptLast[3];
+
+  input->GetPoint( pointIdNext, ptNext);
+  input->GetPoint( pointIdLast, ptLast);
+
+  int comp;
+  for( comp = 0; comp < 3; comp++ )
+  {
+    tangent[comp] = ( ptLast[comp] - ptNext[comp] )/2;
+  }
+}
+
+void vtkFrenetSerretFrame::ComputeConsistentNormalVectors( double* tangent,
+                                                           double* normalLast,
+                                                           double* normal )
+{
+  double temp[3];
+  vtkMath::Cross( normalLast, tangent, temp);
+  vtkMath::Cross( tangent, temp, normal );
+}
+
+void vtkFrenetSerretFrame::ComputeNormalVectors( double* tgNext,
+                                                 double* tgLast,
+                                                 double* normal )
+{
+  int comp;
+  for( comp = 0; comp < 3; comp++ )
+  {
+    normal[comp] = ( tgNext[comp] - tgLast[comp] );
+  }
+  if( vtkMath::Norm(normal) == 0 ) // tgNext == tgLast
+  {
+    double unit[3] = {1,0,0};
+    vtkMath::Cross( tgLast, unit, normal );
+  }
+
+}
+
+void vtkFrenetSerretFrame::RotateVector( double* vector, const double* axis, double angle )
+{
+  double UdotN = vtkMath::Dot(vector,axis);
+  double NvectU[3];
+  vtkMath::Cross(axis, vector, NvectU);
+
+  for( int comp = 0; comp < 3 ; comp++)
+  {
+    vector[comp] =  cos( angle )*vector[comp]
+      + (1-cos( angle ))*UdotN*axis[comp]
+      + sin( angle )*NvectU[comp];
+  }
+}

--- a/Libs/vtkAddon/vtkFrenetSerretFrame.h
+++ b/Libs/vtkAddon/vtkFrenetSerretFrame.h
@@ -1,0 +1,122 @@
+// Copyright (c) 2010, Jerome Velut
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT OWNER ``AS IS'' AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+// NO EVENT SHALL THE COPYRIGHT OWNER BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! \class vtkFrenetSerretFrame
+//! \brief Compute tangent and normal vectors to a polyline
+//!
+//! Given a polyline as input, this filter computes the Frenet-Serret frame
+//! at each point. The output contains the tangent and normal vectors to the
+//! curve. These vectors are appended, so that input array are not overwrited
+//! \see vtkImagePathReslice for a use-case.
+//!
+//! \todo Comment this class. (cxx)
+//! \todo [ENH] compute the whole chart (B=N^T) and put it in the
+//! PointData as a tensor.
+//!
+//! \author Jerome Velut
+//! \date 21 jan 2010
+
+#ifndef vtkFrenetSerretFrame_h
+#define vtkFrenetSerretFrame_h
+
+// vtkAddon includes
+#include "vtkAddon.h"
+
+#include "vtkPolyDataAlgorithm.h"
+
+class VTK_ADDON_EXPORT vtkFrenetSerretFrame : public vtkPolyDataAlgorithm
+{
+public:
+  vtkTypeMacro(vtkFrenetSerretFrame,vtkPolyDataAlgorithm);
+  static vtkFrenetSerretFrame* New();
+
+  //! Set ConsistentNormals to 1 if you want your frames to be 'smooth'.
+  //! Note that in this case, the normal to the curve will not represent the
+  //! acceleration, ie this is no more Frenet-Serret chart.
+  vtkBooleanMacro( ConsistentNormals, int );
+  vtkSetMacro( ConsistentNormals, int );
+  vtkGetMacro( ConsistentNormals, int );
+
+  //! If yes, computes the cross product between Tangent and Normal to get
+  //! the binormal vector.
+  vtkBooleanMacro( ComputeBinormal, int );
+  vtkSetMacro( ComputeBinormal, int );
+  vtkGetMacro( ComputeBinormal, int );
+
+  //! Define the inclination of the consistent normals. Radian value.
+  vtkSetMacro( ViewUp, double );
+  vtkGetMacro( ViewUp, double );
+
+  //! Rotate a vector around an axis
+  //! \param [in] axis {Vector defining the axis to turn around.}
+  //! \param [in] angle {Rotation angle in radian.}
+  //! \param [out] vector {Vector to rotate. In place modification.}
+  static void RotateVector( double* vector, const double* axis, double angle );
+
+
+protected:
+  vtkFrenetSerretFrame();
+  ~vtkFrenetSerretFrame();
+
+  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
+  virtual int FillInputPortInformation(int port, vtkInformation *info) override;
+
+  //! Computes the derivative between 2 points (Next - Last).
+  //! \param [in] pointIdNext {give first point Id}
+  //! \param [in] pointIdLast {give second point Id}
+  //! \param [out] tangent {fill a 3-array with the derivative value}
+  //! \note If Next is [i+1], Last is [i-1], your are computing the
+  //! centered tangent at [i].
+  void ComputeTangentVectors( vtkIdType pointIdNext,
+                              vtkIdType pointIdLast,
+                              double* tangent );
+
+  //! Computes the second derivative between 2 points (Next - Last).
+  //! \param [in] nextTg {give a first derivative}
+  //! \param [in] lastTg {give a first derivative}
+  //! \param [out] normal {fill a 3-array with the second derivative value}
+  void ComputeNormalVectors( double *tgNext,
+                             double *tgLast,
+                             double* normal );
+
+  //! ConsistentNormal depends on the local tangent and the last computed
+  //! normal. This is a projection of lastNormal on the plan defined
+  //! by tangent.
+  //! \param [in] tangent {give the tangent}
+  //! \param [in] lastNormal {give the reference normal}
+  //! \param [out] normal {fill a 3-array with the normal vector}
+  void ComputeConsistentNormalVectors( double *tangent,
+                                       double *lastNormal,
+                                       double* normal );
+private:
+  vtkFrenetSerretFrame(const vtkFrenetSerretFrame&) = delete;
+  void operator=(const vtkFrenetSerretFrame&) = delete;
+
+  int ComputeBinormal; //!< If 1, a Binormal array is added to the output
+  int ConsistentNormals; //!< Boolean. If 1, successive normals are computed
+  //!< in smooth manner.
+  //!< \see ComputeConsistentNormalVectors
+  double ViewUp; //!< Define the inclination of the normal vectors in case of
+  //!< ConsistentNormals is On
+};
+
+#endif //__VTKFRENETSERRETFRAME_H__

--- a/Libs/vtkAddon/vtkSplineDrivenImageSlicer.cxx
+++ b/Libs/vtkAddon/vtkSplineDrivenImageSlicer.cxx
@@ -1,0 +1,326 @@
+// Copyright (c) 2010, Jerome Velut
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT OWNER ``AS IS'' AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+// NO EVENT SHALL THE COPYRIGHT OWNER BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "vtkSplineDrivenImageSlicer.h"
+
+#include"vtkPoints.h"
+#include"vtkPolyData.h"
+#include"vtkCellArray.h"
+#include "vtkImageReslice.h"
+
+#include "vtkFrenetSerretFrame.h"
+#include "vtkPlaneSource.h"
+#include "vtkImageData.h"
+#include "vtkProbeFilter.h"
+#include "vtkMatrix4x4.h"
+#include "vtkImageAppend.h"
+#include "vtkDoubleArray.h"
+#include "vtkPointData.h"
+#include "vtkMath.h"
+#include "vtkInformation.h"
+#include "vtkInformationVector.h"
+#include "vtkObjectFactory.h"
+#include "vtkSmartPointer.h"
+#include "vtkStreamingDemandDrivenPipeline.h"
+
+
+vtkStandardNewMacro(vtkSplineDrivenImageSlicer);
+
+vtkSplineDrivenImageSlicer::vtkSplineDrivenImageSlicer( )
+{
+  this->localFrenetFrames = vtkFrenetSerretFrame::New( );
+  this->reslicer = vtkImageReslice::New();
+  this->SliceExtent[0] = 15;
+  this->SliceExtent[1] = 15;
+  this->SliceSpacing[0] = 1;
+  this->SliceSpacing[1] = 1;
+  this->SliceThickness = 1;
+  this->OffsetPoint = 0;
+  this->OffsetLine = 0;
+  this->ProbeInput = 0;
+
+  this->SetNumberOfInputPorts( 2 );
+  this->SetNumberOfOutputPorts( 2 );
+
+  // by default process active point scalars
+  this->SetInputArrayToProcess(0,0,0,vtkDataObject::FIELD_ASSOCIATION_POINTS,
+                               vtkDataSetAttributes::SCALARS);
+}
+
+vtkSplineDrivenImageSlicer::~vtkSplineDrivenImageSlicer( )
+{
+  this->localFrenetFrames->Delete( );
+  this->reslicer->Delete( );
+}
+
+//----------------------------------------------------------------------------
+// Specify a source object at a specified table location.
+void vtkSplineDrivenImageSlicer::SetPathConnection(int id, vtkAlgorithmOutput* algOutput)
+{
+  if (id < 0)
+  {
+    vtkErrorMacro("Bad index " << id << " for source.");
+    return;
+  }
+
+  int numConnections = this->GetNumberOfInputConnections(1);
+  if (id < numConnections)
+  {
+    this->SetNthInputConnection(1, id, algOutput);
+  }
+  else if (id == numConnections && algOutput)
+  {
+    this->AddInputConnection(1, algOutput);
+  }
+  else if (algOutput)
+  {
+    vtkWarningMacro("The source id provided is larger than the maximum "
+                    "source id, using " << numConnections << " instead.");
+    this->AddInputConnection(1, algOutput);
+  }
+}
+
+//---------------------------------------------------------------------------
+int vtkSplineDrivenImageSlicer::FillInputPortInformation(int port, vtkInformation *info)
+{
+  if( port == 0 )
+  {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkImageData");
+  }
+  else
+  {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
+  }
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+int vtkSplineDrivenImageSlicer::FillOutputPortInformation(
+  int port, vtkInformation* info)
+{
+  if (port == 0)
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkImageData");
+  if (port == 1)
+    info->Set(vtkDataObject::DATA_TYPE_NAME(), "vtkPolyData");
+  return 1;
+}
+
+
+int vtkSplineDrivenImageSlicer::RequestInformation (
+  vtkInformation * vtkNotUsed(request),
+  vtkInformationVector**,
+  vtkInformationVector *outputVector)
+{
+
+  // get the info objects
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+
+  int extent[6] = {0, this->SliceExtent[0] - 1,
+                   0, this->SliceExtent[1] - 1,
+                   0, 1};
+  double spacing[3] = {this->SliceSpacing[0],this->SliceSpacing[1],this->SliceThickness};
+
+
+  outInfo->Set(vtkDataObject::SPACING(), spacing, 3);
+  outInfo->Set(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(),
+               extent,6);
+
+  return 1;
+}
+
+//! RequestData is called by the pipeline process.
+int vtkSplineDrivenImageSlicer::RequestData(
+  vtkInformation *vtkNotUsed(request),
+  vtkInformationVector **inputVector,
+  vtkInformationVector *outputVector)
+{
+  // get the info objects
+  vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
+  vtkInformation *pathInfo = inputVector[1]->GetInformationObject(0);
+  vtkInformation *outImageInfo = outputVector->GetInformationObject(0);
+  vtkInformation *outPlaneInfo = outputVector->GetInformationObject(1);
+
+  // get the input and ouptut
+  vtkImageData *input = vtkImageData::SafeDownCast(
+    inInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkSmartPointer<vtkImageData> inputCopy = vtkSmartPointer<vtkImageData>::New( );
+  inputCopy->ShallowCopy( input );
+  vtkPolyData *inputPath = vtkPolyData::SafeDownCast(
+    pathInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  vtkImageData *outputImage = vtkImageData::SafeDownCast(
+    outImageInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkPolyData *outputPlane = vtkPolyData::SafeDownCast(
+    outPlaneInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  vtkSmartPointer<vtkPolyData> pathCopy = vtkSmartPointer<vtkPolyData>::New( );
+  pathCopy->ShallowCopy( inputPath );
+
+
+  // Compute the local normal and tangent to the path
+  this->localFrenetFrames->SetInputData( pathCopy );
+  this->localFrenetFrames->SetViewUp( this->Incidence );
+  this->localFrenetFrames->ComputeBinormalOn();
+  this->localFrenetFrames->Update( );
+
+  // path will contain PointData array "Tangents" and "Vectors"
+  vtkPolyData* path = static_cast<vtkPolyData*>
+    (this->localFrenetFrames->GetOutputDataObject( 0 ));
+  // Count how many points are used in the cells
+  // In case of loop, points may be used several times
+  // (note: not using NumberOfPoints because we want only LINES points...)
+  vtkCellArray* lines = path->GetLines( );
+  lines->InitTraversal( );
+
+  vtkIdType nbCellPoints;
+  vtkIdType* points;
+
+  vtkIdType cellId = -1;
+  do{
+    lines->GetNextCell( nbCellPoints, points);
+    cellId++;
+  }
+  while( cellId != this->OffsetLine );
+
+  int ptId = this->OffsetPoint;
+  if( ptId >= nbCellPoints )
+  {
+    ptId = nbCellPoints - 1;
+  }
+  // Build a new reslicer with image input as input too.
+  this->reslicer->SetInputData( inputCopy );
+
+  // Get the Frenet-Serret chart at point ptId:
+  // - position (center)
+  // - tangent T
+  // - normal N
+  double center[3];
+  path->GetPoints( )->GetPoint( ptId, center );
+  vtkDoubleArray* pathTangents = static_cast<vtkDoubleArray*>
+    (path->GetPointData( )->GetArray( "FSTangents" ));
+  double tangent[3];
+  pathTangents->GetTuple( ptId, tangent );
+
+  vtkDoubleArray* pathNormals = static_cast<vtkDoubleArray*>
+    (path->GetPointData( )->GetArray( "FSNormals" ));
+  double normal[3];
+  pathNormals->GetTuple( ptId, normal );
+
+  vtkDoubleArray* pathBinormals = static_cast<vtkDoubleArray*>
+    (path->GetPointData( )->GetArray( "FSBinormals" ));
+  double binormal[3];
+  pathBinormals->GetTuple( ptId, binormal );
+
+  // Build the plane output that will represent the slice location in 3D view
+  vtkSmartPointer<vtkPlaneSource> plane = vtkSmartPointer<vtkPlaneSource>::New( );
+
+  double planeOrigin[3];
+  double planePoint1[3];
+  double planePoint2[3];
+  for( int comp = 0; comp < 3; comp ++)
+  {
+    planeOrigin[comp] = center[comp] - normal[comp]*this->SliceExtent[1]*this->SliceSpacing[1]/2.0
+      - binormal[comp]*this->SliceExtent[0]*this->SliceSpacing[0]/2.0;
+    planePoint1[comp] = planeOrigin[comp] + binormal[comp]*this->SliceExtent[0]*this->SliceSpacing[0];
+    planePoint2[comp] = planeOrigin[comp] + normal[comp]*this->SliceExtent[1]*this->SliceSpacing[1];
+  }
+  plane->SetOrigin(planeOrigin);
+  plane->SetPoint1(planePoint1);
+  plane->SetPoint2(planePoint2);
+  plane->SetResolution(this->SliceExtent[0],
+                       this->SliceExtent[1]);
+  plane->Update();
+
+  if( this->ProbeInput == 1 )
+  {
+    vtkSmartPointer<vtkProbeFilter> probe = vtkSmartPointer<vtkProbeFilter>::New( );
+    probe->SetInputConnection( plane->GetOutputPort( ) );
+    probe->SetSourceData( inputCopy );
+    probe->Update( );
+    outputPlane->DeepCopy(probe->GetOutputDataObject(0));
+  }
+  else
+  {
+    outputPlane->DeepCopy(plane->GetOutputDataObject(0));
+  }
+
+  // Build the transformation matrix (inspired from vtkImagePlaneWidget)
+  vtkMatrix4x4* resliceAxes = vtkMatrix4x4::New( );
+  resliceAxes->Identity();
+  double origin[4];
+  // According to vtkImageReslice API:
+  // - 1st column contains the resliced image x-axis
+  // - 2nd column contains the resliced image y-axis
+  // - 3rd column contains the normal of the resliced image plane
+  // -> 1st column is normal to the path
+  // -> 3nd column is tangent to the path
+  // -> 2nd column is B = T^N
+  for ( int comp = 0; comp < 3; comp++ )
+  {
+    resliceAxes->SetElement(0,comp,binormal[comp]);
+    resliceAxes->SetElement(1,comp,normal[comp]);
+    resliceAxes->SetElement(2,comp,tangent[comp]);
+
+    origin[comp] = center[comp] - normal[comp]*this->SliceExtent[1]*this->SliceSpacing[1]/2.0
+      - binormal[comp]*this->SliceExtent[0]*this->SliceSpacing[0]/2.0;
+  }
+
+  //! Transform the origin in the homogeneous coordinate space.
+  //! \todo See why !
+  origin[3] = 1.0;
+  double originXYZW[4];
+  resliceAxes->MultiplyPoint(origin, originXYZW);
+
+  //! Get the new origin from the transposed matrix.
+  //! \todo See why !
+  resliceAxes->Transpose();
+  double neworiginXYZW[4];
+  resliceAxes->MultiplyPoint(originXYZW, neworiginXYZW);
+
+  resliceAxes->SetElement(0,3,neworiginXYZW[0]);
+  resliceAxes->SetElement(1,3,neworiginXYZW[1]);
+  resliceAxes->SetElement(2,3,neworiginXYZW[2]);
+
+
+  this->reslicer->SetResliceAxes( resliceAxes );
+  this->reslicer->SetInformationInput( input );
+  this->reslicer->SetInterpolationModeToCubic( );
+
+  this->reslicer->SetOutputDimensionality( 2 );
+  this->reslicer->SetOutputOrigin(0,0,0);
+  this->reslicer->SetOutputExtent( 0, this->SliceExtent[0] - 1,
+                                   0, this->SliceExtent[1] - 1,
+                                   0, 1);
+  this->reslicer->SetOutputSpacing(this->SliceSpacing[0],
+                                   this->SliceSpacing[1],
+                                   this->SliceThickness);
+  this->reslicer->Update( );
+
+  resliceAxes->Delete( );
+
+
+  outputImage->DeepCopy( this->reslicer->GetOutputDataObject( 0 ) );
+  outputImage->GetPointData( )->GetScalars( )->SetName( "ReslicedImage" );
+
+  return 1;
+
+}

--- a/Libs/vtkAddon/vtkSplineDrivenImageSlicer.h
+++ b/Libs/vtkAddon/vtkSplineDrivenImageSlicer.h
@@ -1,0 +1,118 @@
+// Copyright (c) 2010, Jerome Velut
+// All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT OWNER ``AS IS'' AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN
+// NO EVENT SHALL THE COPYRIGHT OWNER BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! \class vtkSplineDrivenImageSlicer
+//! \brief Reslicing of a volume along a path
+//!
+//! Straightened Curved Planar Reformation (Stretched-CPR) builds a 2D image
+//! from an input path and an input volume. Each point of the path is
+//! considered as the center of a 2D vtkImageReslicer. Reslicers axes are set
+//! orthogonal to the path. Reslicers output are appended on the z axis. Thus
+//! the output of this filter is a volume with central XZ- and YZ-slices
+//! corresponding to the Straightened-CPR.
+//!
+//! Input: vtkImageData (InputConnection) and vtkPolyData (PathConnection)
+//! one polyline representing the path. Typically, the output of vtkSpline can
+//! be used as path input.
+//!
+//! \see Kanitsar et al. "CPR - Curved Planar Reformation", Proc. IEEE  Visualization, 2002, 37-44
+//! \author Jerome Velut
+//! \date 6 february 2011
+
+#ifndef vtkSplineDrivenImageSlicer_h
+#define vtkSplineDrivenImageSlicer_h
+
+#include"vtkImageAlgorithm.h"
+
+class vtkFrenetSerretFrame;
+class vtkImageReslice;
+
+// vtkAddon includes
+#include "vtkAddon.h"
+
+class VTK_ADDON_EXPORT vtkSplineDrivenImageSlicer : public vtkImageAlgorithm
+{
+public:
+  vtkTypeMacro(vtkSplineDrivenImageSlicer,vtkImageAlgorithm);
+  static vtkSplineDrivenImageSlicer* New();
+
+  //! Specify the path represented by a vtkPolyData wich contains PolyLines
+  void SetPathConnection(int id, vtkAlgorithmOutput* algOutput);
+  void SetPathConnection(vtkAlgorithmOutput* algOutput)
+  {
+    this->SetPathConnection(0, algOutput);
+  };
+  vtkAlgorithmOutput* GetPathConnection( )
+  {return( this->GetInputConnection( 1, 0 ) );};
+
+  vtkSetVector2Macro( SliceExtent, int );
+  vtkGetVector2Macro( SliceExtent, int );
+
+  vtkSetVector2Macro( SliceSpacing, double );
+  vtkGetVector2Macro( SliceSpacing, double );
+
+  vtkSetMacro( SliceThickness, double );
+  vtkGetMacro( SliceThickness, double );
+
+  vtkSetMacro( OffsetPoint, vtkIdType );
+  vtkGetMacro( OffsetPoint, vtkIdType );
+
+  vtkSetMacro( OffsetLine, vtkIdType );
+  vtkGetMacro( OffsetLine, vtkIdType );
+
+  vtkSetMacro( ProbeInput, vtkIdType );
+  vtkGetMacro( ProbeInput, vtkIdType );
+  vtkBooleanMacro( ProbeInput, vtkIdType );
+
+  vtkSetMacro( Incidence, double );
+  vtkGetMacro( Incidence, double );
+
+
+protected:
+  vtkSplineDrivenImageSlicer();
+  ~vtkSplineDrivenImageSlicer();
+
+  virtual int RequestData(vtkInformation *, vtkInformationVector **,
+                          vtkInformationVector *) override;
+
+  virtual int FillInputPortInformation(int port, vtkInformation *info) override;
+  virtual int FillOutputPortInformation( int, vtkInformation*) override;
+  virtual int RequestInformation(vtkInformation*, vtkInformationVector**,
+                                 vtkInformationVector*) override;
+private:
+  vtkSplineDrivenImageSlicer(const vtkSplineDrivenImageSlicer&) = delete;
+  void operator=(const vtkSplineDrivenImageSlicer&) = delete;
+
+  vtkFrenetSerretFrame* localFrenetFrames; //!< computes local tangent along path input
+  vtkImageReslice* reslicer; //!< Reslicers array
+
+  int     SliceExtent[2]; //!< Number of pixels nx, ny in the slice space around the center points
+  double SliceSpacing[2]; //!< Pixel size sx, sy of the output slice
+  double SliceThickness; //!< Slice thickness (useful for volumic reconstruction)
+  double Incidence; //!< Rotation of the initial normal vector.
+
+  vtkIdType OffsetPoint; //!< Id of the point where the reslicer proceed
+  vtkIdType OffsetLine; //!< Id of the line cell where to get the reslice center
+  vtkIdType ProbeInput; //!< If true, the output plane (2nd output probes the input image)
+};
+
+#endif //__vtkSplineDrivenImageSlicer_h__


### PR DESCRIPTION
These classes will be used by Markups.

Source is at https://github.com/midas-journal/midas-journal-838/tree/master/Filters, which is a VTK remote module. I've tried to enable this remote module in Slicer's VTK but nothing happened (maybe I did it incorrectly) and thought that it could be useful if we can easily modify the files, so I went ahead and just copied the source files. But if it's easy to enable it as a VTK remote module then we may consider that instead of merging this pull request.