### PR TITLE
ENH: Add segment name to exported labelmap in case of a single segment

### DIFF
--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
@@ -916,13 +916,23 @@ void qSlicerSubjectHierarchySegmentationsPlugin::exportToBinaryLabelmap()
     return;
     }
 
+  // Get exported (visible) segment IDs
+  std::vector<std::string> segmentIDs;
+  vtkMRMLSegmentationDisplayNode* displayNode = vtkMRMLSegmentationDisplayNode::SafeDownCast(segmentationNode->GetDisplayNode());
+  displayNode->GetVisibleSegmentIDs(segmentIDs);
+
   // Create new labelmap node
   vtkSmartPointer<vtkMRMLNode> newNode = vtkSmartPointer<vtkMRMLNode>::Take(
     segmentationNode->GetScene()->CreateNodeByClass("vtkMRMLLabelMapVolumeNode"));
   vtkMRMLLabelMapVolumeNode* newLabelmapNode = vtkMRMLLabelMapVolumeNode::SafeDownCast(
     segmentationNode->GetScene()->AddNode(newNode));
   newLabelmapNode->CreateDefaultDisplayNodes();
-  std::string exportedNodeName = std::string(segmentationNode->GetName()) + "-label";
+  std::string exportedNodeName = std::string(segmentationNode->GetName());
+  if (segmentIDs.size() == 1)
+    {
+    exportedNodeName += "-" + std::string(segmentationNode->GetSegmentation()->GetSegment(segmentIDs[0])->GetName());
+    }
+  exportedNodeName += "-label";
   exportedNodeName = segmentationNode->GetScene()->GetUniqueNameByString(exportedNodeName.c_str());
   newLabelmapNode->SetName(exportedNodeName.c_str());
 

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -745,11 +745,25 @@ bool qSlicerSegmentationsModuleWidget::exportFromCurrentSegmentation()
     return false;
     }
 
+  // Get IDs of segments to be exported
+  std::vector<std::string> segmentIDs;
+  if (d->ComboBox_ExportedSegments->currentIndex() == 0)
+    {
+    // All segments
+    currentSegmentationNode->GetSegmentation()->GetSegmentIDs(segmentIDs);
+    }
+  else
+    {
+    // Visible segments
+    vtkMRMLSegmentationDisplayNode* displayNode = vtkMRMLSegmentationDisplayNode::SafeDownCast(currentSegmentationNode->GetDisplayNode());
+    displayNode->GetVisibleSegmentIDs(segmentIDs);
+    }
+
   // If existing node was not selected then create a new one that we will export into
   vtkMRMLNode* otherRepresentationNode = d->MRMLNodeComboBox_ImportExportNode->currentNode();
   if (!otherRepresentationNode)
     {
-    std::string namePostfix;
+    std::string namePostfix("");
     if (d->radioButton_Labelmap->isChecked())
       {
       vtkSmartPointer<vtkMRMLNode> newNode = vtkSmartPointer<vtkMRMLNode>::Take(
@@ -758,7 +772,12 @@ bool qSlicerSegmentationsModuleWidget::exportFromCurrentSegmentation()
         currentSegmentationNode->GetScene()->AddNode(newNode));
       newLabelmapNode->CreateDefaultDisplayNodes();
       otherRepresentationNode = newLabelmapNode;
-      namePostfix = "-label";
+      // Add segment name if only one segment is exported
+      if (segmentIDs.size() == 1)
+        {
+        namePostfix += "-" + std::string(currentSegmentationNode->GetSegmentation()->GetSegment(segmentIDs[0])->GetName());
+        }
+      namePostfix += "-label";
       }
     else
       {
@@ -773,20 +792,6 @@ bool qSlicerSegmentationsModuleWidget::exportFromCurrentSegmentation()
     exportedNodeName = currentSegmentationNode->GetScene()->GetUniqueNameByString(exportedNodeName.c_str());
     otherRepresentationNode->SetName(exportedNodeName.c_str());
     d->MRMLNodeComboBox_ImportExportNode->setCurrentNode(otherRepresentationNode);
-    }
-
-  // Get IDs of segments to be exported
-  std::vector<std::string> segmentIDs;
-  if (d->ComboBox_ExportedSegments->currentIndex() == 0)
-    {
-    // All segments
-    currentSegmentationNode->GetSegmentation()->GetSegmentIDs(segmentIDs);
-    }
-  else
-    {
-    // Visible segments
-    vtkMRMLSegmentationDisplayNode* displayNode = vtkMRMLSegmentationDisplayNode::SafeDownCast(currentSegmentationNode->GetDisplayNode());
-    displayNode->GetVisibleSegmentIDs(segmentIDs);
     }
 
   vtkMRMLLabelMapVolumeNode* labelmapNode = vtkMRMLLabelMapVolumeNode::SafeDownCast(otherRepresentationNode);


### PR DESCRIPTION
When the user exports segmentations to labelmaps, it is more indicative to include the segment name in the name of the labelmap if there is only one segment in the segmentation:
- Quickly make sense of a selected labelmap in the node dropdown
- Save the exported labelmap into a file with a meaningful name