### PR TITLE
ENH: Added quantification features to markups and fixed display scaling

### DIFF
--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -105,6 +105,7 @@ set(MRMLCore_SRCS
   vtkEventBroker.cxx
   vtkImageBimodalAnalysis.cxx
   vtkDataFileFormatHelper.cxx
+  vtkMRMLMeasurement.cxx
   vtkMRMLLogic.cxx
   vtkMRMLAbstractLayoutNode.cxx
   vtkMRMLAbstractViewNode.cxx

--- a/Libs/MRML/Core/vtkMRMLMeasurement.cxx
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.cxx
@@ -1,0 +1,265 @@
+/*=auto=========================================================================
+
+Portions (c) Copyright 2017 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+See COPYRIGHT.txt
+or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+#include "vtkMRMLMeasurement.h"
+
+// VTK include
+#include <vtkObjectFactory.h>
+
+// STD include
+#include <sstream>
+
+vtkStandardNewMacro(vtkMRMLMeasurement);
+
+//----------------------------------------------------------------------------
+vtkMRMLMeasurement::vtkMRMLMeasurement()
+: Name(nullptr)
+, Value(0.0)
+, Units(nullptr)
+, PrintFormat(nullptr)
+, Description(nullptr)
+, QuantityCode(nullptr)
+, DerivationCode(nullptr)
+, UnitsCode(nullptr)
+, MethodCode(nullptr)
+{
+  this->SetPrintFormat("%5.3f %s");
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMeasurement::~vtkMRMLMeasurement()
+{
+  this->Initialize();
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLMeasurement::GetValueWithUnitsAsPrintableString()
+{
+  if (!this->PrintFormat)
+    {
+    return  "";
+    }
+  char buf[80] = { 0 };
+  snprintf(buf, sizeof(buf) - 1, this->PrintFormat, this->Value, this->Units);
+  return buf;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::Initialize()
+{
+  this->SetName(nullptr);
+  this->SetValue(0.0);
+  this->SetUnits(nullptr);
+  this->SetPrintFormat("%5.3f %s");
+  this->SetDescription(nullptr);
+  this->SetQuantityCode(nullptr);
+  this->SetDerivationCode(nullptr);
+  this->SetUnitsCode(nullptr);
+  this->SetMethodCode(nullptr);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+  os << indent << "Name: " << (this->Name ? this->Name : "(none)") << "\n";
+  os << indent << "PrintableValue: " << this->GetValueWithUnitsAsPrintableString();
+  os << indent << "Value: " << this->Value << "\n";
+  os << indent << "Units: " << (this->Units ? this->Units : "(none)") << "\n";
+  os << indent << "PrintFormat: " << (this->PrintFormat ? this->PrintFormat : "(none)") << "\n";
+  os << indent << "Description: " << (this->Description ? this->Description : "(none)") << "\n";
+  if (this->QuantityCode)
+    {
+    os << indent << "Quantity: " << this->QuantityCode->GetAsPrintableString() << std::endl;
+    }
+  if (this->DerivationCode)
+    {
+    os << indent << "Derivation: " << this->DerivationCode->GetAsPrintableString() << std::endl;
+    }
+  if (this->UnitsCode)
+    {
+    os << indent << "Units: " << this->UnitsCode->GetAsPrintableString() << std::endl;
+    }
+  if (this->MethodCode)
+    {
+    os << indent << "Method: " << this->MethodCode->GetAsPrintableString() << std::endl;
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::Copy(vtkMRMLMeasurement* src)
+{
+  if (!src)
+    {
+    return;
+    }
+  this->SetName(src->GetName());
+  this->SetValue(src->GetValue());
+  this->SetUnits(src->GetUnits());
+  this->SetPrintFormat(src->GetPrintFormat());
+  this->SetDescription(src->GetDescription());
+  this->SetQuantityCode(src->QuantityCode);
+  this->SetDerivationCode(src->DerivationCode);
+  this->SetUnitsCode(src->UnitsCode);
+  this->SetMethodCode(src->MethodCode);
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLMeasurement::GetAsString()
+{
+  std::string str;
+  /* TODO: implement
+  if (this->CodeValue)
+    {
+    str += "CodeValue:";
+    str += this->CodeValue;
+    }
+  if (this->CodingSchemeDesignator)
+    {
+    if (!str.empty())
+      {
+      str += "|";
+      }
+    str += "CodingSchemeDesignator:";
+    str += this->CodingSchemeDesignator;
+    }
+  if (this->CodeMeaning)
+    {
+    if (!str.empty())
+      {
+      str += "|";
+      }
+    str += "CodeMeaning:";
+    str += this->CodeMeaning;
+    }
+    */
+  return str;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLMeasurement::SetFromString(const std::string& content)
+{
+  this->Initialize();
+  bool success = true;
+  /* TODO: implement
+  std::stringstream attributes(content);
+  std::string attribute;
+  while (std::getline(attributes, attribute, '|'))
+    {
+    int colonIndex = attribute.find(':');
+    std::string name = attribute.substr(0, colonIndex);
+    std::string value = attribute.substr(colonIndex + 1);
+    if (name == "CodeValue")
+      {
+      this->SetCodeValue(value.c_str());
+      }
+    else if (name == "CodingSchemeDesignator")
+      {
+      this->SetCodingSchemeDesignator(value.c_str());
+      }
+    else if (name == "CodeMeaning")
+      {
+      this->SetCodeMeaning(value.c_str());
+      }
+    else
+      {
+      vtkWarningMacro("Parsing coded entry string failed: unknown name " << name << " in " + content);
+      success = false;
+      }
+    }
+  if (this->GetCodeValue() == nullptr)
+    {
+    vtkWarningMacro("Parsing coded entry string failed: CodeValue is not specified in " + content);
+    success = false;
+    }
+  if (this->GetCodingSchemeDesignator() == nullptr)
+    {
+    vtkWarningMacro("Parsing coded entry string failed: CodingSchemeDesignator is not specified in " + content);
+    success = false;
+    }
+  // CodeMeaning is optional
+  */
+  return success;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::SetQuantityCode(vtkCodedEntry* entry)
+{
+  if (!entry)
+    {
+    if (this->QuantityCode)
+      {
+      this->QuantityCode->Delete();
+      this->QuantityCode = nullptr;
+      }
+    return;
+    }
+  if (!this->QuantityCode)
+    {
+    this->QuantityCode = vtkCodedEntry::New();
+    }
+  this->QuantityCode->Copy(entry);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::SetDerivationCode(vtkCodedEntry* entry)
+{
+  if (!entry)
+    {
+    if (this->DerivationCode)
+      {
+      this->DerivationCode->Delete();
+      this->DerivationCode = nullptr;
+      }
+    return;
+    }
+  if (!this->DerivationCode)
+    {
+    this->DerivationCode = vtkCodedEntry::New();
+    }
+  this->DerivationCode->Copy(entry);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::SetUnitsCode(vtkCodedEntry* entry)
+{
+  if (!entry)
+    {
+    if (this->UnitsCode)
+      {
+      this->UnitsCode->Delete();
+      this->UnitsCode = nullptr;
+      }
+    return;
+    }
+  if (!this->UnitsCode)
+    {
+    this->UnitsCode = vtkCodedEntry::New();
+    }
+  this->UnitsCode->Copy(entry);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::SetMethodCode(vtkCodedEntry* entry)
+{
+  if (!entry)
+    {
+    if (this->MethodCode)
+      {
+      this->MethodCode->Delete();
+      this->MethodCode = nullptr;
+      }
+    return;
+    }
+  if (!this->MethodCode)
+    {
+    this->MethodCode = vtkCodedEntry::New();
+    }
+  this->MethodCode->Copy(entry);
+}

--- a/Libs/MRML/Core/vtkMRMLMeasurement.h
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.h
@@ -1,0 +1,110 @@
+/*=auto=========================================================================
+
+Portions (c) Copyright 2017 Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+See COPYRIGHT.txt
+or http://www.slicer.org/copyright/copyright.txt for details.
+
+=========================================================================auto=*/
+
+#ifndef __vtkMRMLMeasurement_h
+#define __vtkMRMLMeasurement_h
+
+// MRML includes
+#include <vtkCodedEntry.h>
+#include "vtkMRML.h"
+
+// VTK includes
+#include <vtkObject.h>
+#include <vtkSmartPointer.h>
+
+/// \brief Class for storing well-defined measurement results, using coded entries.
+///
+/// This stores all important information about a measurement using standard coded entries.
+/// Measurement method, derivation, quantity value, units, etc, can be specified.
+/// This is a commonly used concept in DICOM structured reports.
+///
+/// \sa vtkCodedEntry
+///
+class VTK_MRML_EXPORT vtkMRMLMeasurement : public vtkObject
+{
+public:
+
+  static vtkMRMLMeasurement *New();
+  vtkTypeMacro(vtkMRMLMeasurement, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Reset state of object
+  virtual void Initialize();
+
+  /// Copy one type into another (deep copy)
+  virtual void Copy(vtkMRMLMeasurement* aEntry);
+
+  /// Measurement name
+  vtkGetStringMacro(Name);
+  vtkSetStringMacro(Name);
+
+  /// Measured quantity value
+  vtkGetMacro(Value, double);
+  vtkSetMacro(Value, double);
+
+  /// Measurement unit
+  vtkGetStringMacro(Units);
+  vtkSetStringMacro(Units);
+
+  /// Informal description of the measurement
+  vtkGetStringMacro(Description);
+  vtkSetStringMacro(Description);
+
+  /// Formatting string for displaying measurement value and units
+  vtkGetStringMacro(PrintFormat);
+  vtkSetStringMacro(PrintFormat);
+
+  // Copies content of coded entry
+  void SetQuantityCode(vtkCodedEntry* entry);
+  vtkGetObjectMacro(QuantityCode, vtkCodedEntry);
+
+  // Copies content of coded entry
+  void SetDerivationCode(vtkCodedEntry* entry);
+  vtkGetObjectMacro(DerivationCode, vtkCodedEntry);
+
+  // Copies content of coded entry
+  void SetUnitsCode(vtkCodedEntry* entry);
+  vtkGetObjectMacro(UnitsCode, vtkCodedEntry);
+
+  // Copies content of coded entry
+  void SetMethodCode(vtkCodedEntry* entry);
+  vtkGetObjectMacro(MethodCode, vtkCodedEntry);
+
+  ///
+  /// Get measurement value and units as a single human-readable string.
+  std::string GetValueWithUnitsAsPrintableString();
+
+  ///
+  /// Get content of the object as a single machine-readable string.
+  std::string GetAsString();
+
+  ///
+  /// Set content of the object from a single machine-readable string.
+  /// \return true on success
+  bool SetFromString(const std::string& content);
+
+protected:
+  vtkMRMLMeasurement();
+  ~vtkMRMLMeasurement() override;
+  vtkMRMLMeasurement(const vtkMRMLMeasurement&);
+  void operator=(const vtkMRMLMeasurement&);
+
+protected:
+  char* Name;
+  double Value;
+  char* Units;
+  char* Description;
+  char* PrintFormat; // for value (double), unit (string)
+  vtkCodedEntry* QuantityCode;   // volume
+  vtkCodedEntry* DerivationCode; // min/max/mean
+  vtkCodedEntry* UnitsCode;      // cubic millimeter
+  vtkCodedEntry* MethodCode;     // Sum of segmented voxel volumes
+};
+
+#endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.cxx
@@ -25,9 +25,11 @@
 //----------------------------------------------------------------------
 vtkMRMLAbstractWidgetRepresentation::vtkMRMLAbstractWidgetRepresentation()
 {
-  this->ViewScaleFactor = 1.0;
+  // Default glyph scale used to be 3.0 (in Slicer-4.10 and earlier).
+  // This display scale factor value produces similar appearance of markup points.
+  this->ScreenScaleFactor = 0.2;
 
-  this->Tolerance = 2.0;
+  this->Tolerance = 0.2;
   this->PixelTolerance = 1;
   this->NeedToRender = false;
 
@@ -37,56 +39,6 @@ vtkMRMLAbstractWidgetRepresentation::vtkMRMLAbstractWidgetRepresentation()
 //----------------------------------------------------------------------
 vtkMRMLAbstractWidgetRepresentation::~vtkMRMLAbstractWidgetRepresentation()
 = default;
-
-//----------------------------------------------------------------------
-void vtkMRMLAbstractWidgetRepresentation::UpdateViewScaleFactor()
-{
-  if (!this->Renderer || !this->Renderer->GetActiveCamera())
-    {
-    this->ViewScaleFactor = 1.0;
-    }
-
-  double p1[4], p2[4];
-  this->Renderer->GetActiveCamera()->GetFocalPoint(p1);
-  p1[3] = 1.0;
-  this->Renderer->SetWorldPoint(p1);
-  this->Renderer->WorldToView();
-  this->Renderer->GetViewPoint(p1);
-
-  double depth = p1[2];
-  double aspect[2];
-  this->Renderer->ComputeAspect();
-  this->Renderer->GetAspect(aspect);
-
-  p1[0] = -aspect[0];
-  p1[1] = -aspect[1];
-  this->Renderer->SetViewPoint(p1);
-  this->Renderer->ViewToWorld();
-  this->Renderer->GetWorldPoint(p1);
-
-  p2[0] = aspect[0];
-  p2[1] = aspect[1];
-  p2[2] = depth;
-  p2[3] = 1.0;
-  this->Renderer->SetViewPoint(p2);
-  this->Renderer->ViewToWorld();
-  this->Renderer->GetWorldPoint(p2);
-
-  double distance = sqrt(vtkMath::Distance2BetweenPoints(p1, p2));
-
-  int *size = this->Renderer->GetRenderWindow()->GetSize();
-  double viewport[4];
-  this->Renderer->GetViewport(viewport);
-
-  double x, y, distance2;
-
-  x = size[0] * (viewport[2] - viewport[0]);
-  y = size[1] * (viewport[3] - viewport[1]);
-
-  distance2 = sqrt(x * x + y * y);
-  this->ViewScaleFactor = distance2 / distance;
-}
-
 
 //----------------------------------------------------------------------
 void vtkMRMLAbstractWidgetRepresentation

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
@@ -112,7 +112,7 @@ public:
   /// Specify tolerance for performing pick operations of points
   /// (see ActivateNode).
   /// Tolerance is defined in terms of percentage of the handle size.
-  /// Default value is 0.5
+  /// Default value is 0.2
   vtkSetMacro(Tolerance, double);
   vtkGetMacro(Tolerance, double);
 
@@ -146,9 +146,6 @@ public:
   // using the renderer of this class.
   void GetRendererComputedDisplayPositionFromWorldPosition(const double worldPos[3], double displayPos[2]);
 
-  // Calculate view scale factor
-  void UpdateViewScaleFactor();
-
   void UpdateRelativeCoincidentTopologyOffsets(vtkMapper* mapper);
 
   // The renderer in which this widget is placed
@@ -160,11 +157,12 @@ public:
   double Tolerance;
   double PixelTolerance;
 
+  // Allows global rescaling of all widgets (to compensate for larger or smaller physical screen size)
+  double ScreenScaleFactor;
+
   vtkWeakPointer<vtkMRMLAbstractViewNode> ViewNode;
 
   bool AlwaysOnTop;
-
-  double ViewScaleFactor;
 
   // Temporary variable to store GetBounds() result
   double Bounds[6];

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -35,7 +35,11 @@
 #include "vtkSlicerMarkupsModuleLogicExport.h"
 
 class vtkMRMLMarkupsNode;
+class vtkMRMLMarkupsClosedCurveNode;
 class vtkMRMLMarkupsDisplayNode;
+class vtkPlane;
+class vtkPoints;
+class vtkPolyData;
 
 /// \ingroup Slicer_QtModules_Markups
 class VTK_SLICER_MARKUPS_MODULE_LOGIC_EXPORT vtkSlicerMarkupsLogic :
@@ -181,9 +185,6 @@ public:
   /// in the scene
   void SetSliceIntersectionsVisibility(bool flag);
 
-  /// Get the index of teh closest control point to the world coordinates
-  int GetClosestControlPointIndexToPositionWorld(vtkMRMLMarkupsNode *markupsNode, double pos[3]);
-
   vtkSetMacro(AutoCreateDisplayNodes, bool);
   vtkGetMacro(AutoCreateDisplayNodes, bool);
   vtkBooleanMacro(AutoCreateDisplayNodes, bool);
@@ -193,6 +194,24 @@ public:
   /// Copies basic display properties between markups display nodes. This is used
   /// for updating a display node to defaults.
   void CopyBasicDisplayProperties(vtkMRMLMarkupsDisplayNode *sourceDisplayNode, vtkMRMLMarkupsDisplayNode *targetDisplayNode);
+
+  /// Measure surface area of the smooth surface that fits on the closed curve in world coordinate system.
+  /// \param curveNode points to fit the surface to
+  /// \param surface if not nullptr then the generated surface is saved into that
+  static double GetClosedCurveSurfaceArea(vtkMRMLMarkupsClosedCurveNode* curveNode, vtkPolyData* surface = nullptr);
+
+  /// Create a "soap bubble" surface that fits on the provided point list
+  /// \param curvePoints: points to fit the surface to
+  /// \param radiusScalingFactor size of the surface.Value of 1.0 (default) means the surface edge fits on the points.
+  /// Larger values increase the generated soap bubble outer radius, which may be useful to avoid coincident points
+  /// when using this surface for cutting another surface.
+  static bool CreateSoapBubblePolyDataFromCircumferencePoints(vtkPoints* curvePoints, vtkPolyData* surface, double radiusScalingFactor = 1.0);
+
+  /// Get best fit plane for a markup
+  static bool GetBestFitPlane(vtkMRMLMarkupsNode* curveNode, vtkPlane* plane);
+
+  /// Compute least squares best fit plane
+  static bool FitPlaneToPoints(vtkPoints* curvePoints, vtkPlane* plane);
 
 protected:
   vtkSlicerMarkupsLogic();

--- a/Modules/Loadable/Markups/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRML/CMakeLists.txt
@@ -9,6 +9,7 @@ set(${KIT}_INCLUDE_DIRECTORIES
 
 set(${KIT}_SRCS
   vtkMRML${MODULE_NAME}DisplayNode.cxx
+  vtkMRML${MODULE_NAME}FiducialDisplayNode.cxx
   vtkMRML${MODULE_NAME}FiducialNode.cxx
   vtkMRML${MODULE_NAME}LineNode.cxx
   vtkMRML${MODULE_NAME}AngleNode.cxx

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.cxx
@@ -66,3 +66,40 @@ void vtkMRMLMarkupsAngleNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
 }
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsAngleNode::UpdateMeasurements()
+{
+  Superclass::UpdateMeasurements();
+  if (this->GetNumberOfControlPoints() < 3)
+    {
+    return;
+    }
+
+  double p1[3] = { 0.0 };
+  double c[3] = { 0.0 };
+  double p2[3] = { 0.0 };
+  this->GetNthControlPointPositionWorld(0, p1);
+  this->GetNthControlPointPositionWorld(1, c);
+  this->GetNthControlPointPositionWorld(2, p2);
+
+  // Compute the angle (only if necessary since we don't want
+  // fluctuations in angle value as the camera moves, etc.)
+  if (((fabs(p1[0] - c[0]) <= VTK_DBL_EPSILON) &&
+    (fabs(p1[1] - c[1]) <= VTK_DBL_EPSILON) &&
+    (fabs(p1[2] - c[2]) <= VTK_DBL_EPSILON)) ||
+    ((fabs(p2[0] - c[0]) <= VTK_DBL_EPSILON) &&
+    (fabs(p2[1] - c[1]) <= VTK_DBL_EPSILON) &&
+      (fabs(p2[2] - c[2]) <= VTK_DBL_EPSILON)))
+    {
+    return;
+    }
+
+  double vector1[3] = { p1[0] - c[0], p1[1] - c[1], p1[2] - c[2] };
+  double vector2[3] = { p2[0] - c[0], p2[1] - c[1], p2[2] - c[2] };
+  double l1 = vtkMath::Normalize(vector1);
+  double l2 = vtkMath::Normalize(vector2);
+  double angle = vtkMath::DegreesFromRadians(acos(vtkMath::Dot(vector1, vector2)));
+
+  this->SetNthMeasurement(0, "angle", angle, "deg");
+}

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.h
@@ -66,6 +66,7 @@ protected:
   vtkMRMLMarkupsAngleNode(const vtkMRMLMarkupsAngleNode&);
   void operator=(const vtkMRMLMarkupsAngleNode&);
 
+  void UpdateMeasurements() override;
 };
 
 #endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -24,8 +24,16 @@
 #include "vtkMRMLScene.h"
 
 // VTK includes
+#include <vtkCutter.h>
+#include <vtkDoubleArray.h>
+#include <vtkFrenetSerretFrame.h>
+#include <vtkMatrix4x4.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
+#include <vtkPlane.h>
+#include <vtkPointData.h>
+#include <vtkPolyData.h>
+#include <vtkStringArray.h>
 
 // STD includes
 #include <sstream>
@@ -70,4 +78,471 @@ void vtkMRMLMarkupsCurveNode::Copy(vtkMRMLNode *anode)
 void vtkMRMLMarkupsCurveNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
+}
+
+//---------------------------------------------------------------------------
+vtkPoints* vtkMRMLMarkupsCurveNode::GetCurvePointsWorld()
+{
+  this->CurveGenerator->Update();
+  vtkPolyData* curvePoly = this->GetCurveWorld();
+  if (!curvePoly)
+    {
+    return nullptr;
+    }
+  return curvePoly->GetPoints();
+}
+
+//---------------------------------------------------------------------------
+double vtkMRMLMarkupsCurveNode::GetCurveLengthWorld(vtkIdType startCurvePointIndex /*=0*/, vtkIdType numberOfCurvePoints /*=-1*/)
+{
+  vtkPoints* points = this->GetCurvePointsWorld();
+  if (!points || points->GetNumberOfPoints() < 2)
+    {
+    return 0.0;
+    }
+  if (startCurvePointIndex < 0)
+    {
+    vtkWarningMacro("Invalid startCurvePointIndex=" << startCurvePointIndex << ", using 0 instead");
+    startCurvePointIndex = 0;
+    }
+  vtkIdType lastCurvePointIndex = points->GetNumberOfPoints()-1;
+  if (numberOfCurvePoints >= 0 && startCurvePointIndex + numberOfCurvePoints - 1 < lastCurvePointIndex)
+    {
+    lastCurvePointIndex = startCurvePointIndex + numberOfCurvePoints - 1;
+    }
+
+  double length = 0.0;
+  double previousPoint[3] = { 0.0 };
+  points->GetPoint(startCurvePointIndex, previousPoint);
+  for (vtkIdType curvePointIndex = startCurvePointIndex + 1; curvePointIndex <= lastCurvePointIndex; curvePointIndex++)
+    {
+    double nextPoint[3];
+    points->GetPoint(curvePointIndex, nextPoint);
+    length += sqrt(vtkMath::Distance2BetweenPoints(previousPoint, nextPoint));
+    previousPoint[0] = nextPoint[0];
+    previousPoint[1] = nextPoint[1];
+    previousPoint[2] = nextPoint[2];
+    }
+  return length;
+}
+
+//---------------------------------------------------------------------------
+double vtkMRMLMarkupsCurveNode::GetCurveLengthBetweenStartEndPointsWorld(vtkIdType startCurvePointIndex, vtkIdType endCurvePointIndex)
+{
+  if (startCurvePointIndex <= endCurvePointIndex)
+  {
+    return this->GetCurveLengthWorld(startCurvePointIndex, endCurvePointIndex - startCurvePointIndex + 1);
+  }
+  else
+  {
+    // wrap around
+    return this->GetCurveLengthWorld(0, endCurvePointIndex + 1) + this->GetCurveLengthWorld(startCurvePointIndex, -1);
+  }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::ResampleCurveWorld(double controlPointDistance)
+{
+  vtkPoints* points = this->GetCurvePointsWorld();
+  if (!points || points->GetNumberOfPoints() < 2)
+    {
+    return;
+    }
+
+  vtkNew<vtkPoints> interpolatedPoints;
+  vtkMRMLMarkupsCurveNode::ResamplePoints(points, interpolatedPoints, controlPointDistance, this->CurveClosed);
+
+  vtkNew<vtkPoints> originalPoints;
+  originalPoints->DeepCopy(points);
+  vtkNew<vtkStringArray> originalLabels;
+  this->GetControlPointLabels(originalLabels);
+
+  this->SetControlPointPositionsWorld(interpolatedPoints);
+  this->SetControlPointLabelsWorld(originalLabels, originalPoints);
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsCurveNode::ResamplePoints(vtkPoints* originalPoints, vtkPoints* sampledPoints,
+  double samplingDistance, bool closedCurve)
+{
+  if (!originalPoints || !sampledPoints || samplingDistance <= 0)
+    {
+    vtkGenericWarningMacro("vtkMRMLMarkupsCurveNode::ResamplePoints failed: invalid inputs");
+    return false;
+    }
+
+  if (originalPoints->GetNumberOfPoints() < 2)
+    {
+    sampledPoints->DeepCopy(originalPoints);
+    return true;
+    }
+
+  double distanceFromLastSampledPoint = 0;
+  double previousCurvePoint[3] = { 0.0 };
+  originalPoints->GetPoint(0, previousCurvePoint);
+  sampledPoints->Reset();
+  sampledPoints->InsertNextPoint(previousCurvePoint);
+  vtkIdType numberOfOriginalPoints = originalPoints->GetNumberOfPoints();
+  for (vtkIdType originalPointIndex = 0; originalPointIndex < numberOfOriginalPoints; originalPointIndex++)
+    {
+    double* currentCurvePoint = originalPoints->GetPoint(originalPointIndex);
+    double segmentLength = sqrt(vtkMath::Distance2BetweenPoints(currentCurvePoint, previousCurvePoint));
+    if (segmentLength <= 0.0)
+      {
+      continue;
+      }
+    double remainingSegmentLength = distanceFromLastSampledPoint + segmentLength;
+    if (remainingSegmentLength >= samplingDistance)
+      {
+      double segmentDirectionVector[3] =
+        {
+        (currentCurvePoint[0] - previousCurvePoint[0]) / segmentLength,
+        (currentCurvePoint[1] - previousCurvePoint[1]) / segmentLength,
+        (currentCurvePoint[2] - previousCurvePoint[2]) / segmentLength
+        };
+      // distance of new sampled point from previous curve point
+      double distanceFromLastInterpolatedPoint = samplingDistance - distanceFromLastSampledPoint;
+      while (remainingSegmentLength >= samplingDistance)
+        {
+        double newSampledPoint[3] =
+          {
+          previousCurvePoint[0] + segmentDirectionVector[0] * distanceFromLastInterpolatedPoint,
+          previousCurvePoint[1] + segmentDirectionVector[1] * distanceFromLastInterpolatedPoint,
+          previousCurvePoint[2] + segmentDirectionVector[2] * distanceFromLastInterpolatedPoint
+          };
+        sampledPoints->InsertNextPoint(newSampledPoint);
+        distanceFromLastSampledPoint = 0;
+        distanceFromLastInterpolatedPoint += samplingDistance;
+        remainingSegmentLength -= samplingDistance;
+        }
+      distanceFromLastSampledPoint = remainingSegmentLength;
+      }
+    else
+      {
+      distanceFromLastSampledPoint += segmentLength;
+      }
+    previousCurvePoint[0] = currentCurvePoint[0];
+    previousCurvePoint[1] = currentCurvePoint[1];
+    previousCurvePoint[2] = currentCurvePoint[2];
+    }
+
+  // The last segment may be much shorter than all the others, which may introduce artifact in spline fitting.
+  // To fix that, move the last point to have two equal segments at the end.
+  if (closedCurve && sampledPoints->GetNumberOfPoints() > 3)
+    {
+    double firstPoint[3] = { 0.0 };
+    double secondLastPoint[3] = { 0.0 };
+    double lastPoint[3] = { 0.0 };
+    sampledPoints->GetPoint(0, firstPoint);
+    sampledPoints->GetPoint(sampledPoints->GetNumberOfPoints()-2, secondLastPoint);
+    sampledPoints->GetPoint(sampledPoints->GetNumberOfPoints() - 1, lastPoint);
+    double lastSegmentLength = sqrt(vtkMath::Distance2BetweenPoints(secondLastPoint, lastPoint));
+    double lastTwoSegmentLengthAverage = (lastSegmentLength + sqrt(vtkMath::Distance2BetweenPoints(lastPoint, firstPoint)))/2.0;
+    double lastTwoSegmentRatio = lastTwoSegmentLengthAverage / lastSegmentLength;
+    double adjustedLastPoint[3] =
+      {
+      secondLastPoint[0] + (lastPoint[0] - secondLastPoint[0]) * lastTwoSegmentRatio,
+      secondLastPoint[1] + (lastPoint[1] - secondLastPoint[1]) * lastTwoSegmentRatio,
+      secondLastPoint[2] + (lastPoint[2] - secondLastPoint[2]) * lastTwoSegmentRatio
+      };
+    sampledPoints->SetPoint(sampledPoints->GetNumberOfPoints() - 1, adjustedLastPoint);
+    }
+
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsCurveNode::GetSampledCurvePointsBetweenStartEndPointsWorld(vtkPoints* sampledPoints,
+  double samplingDistance, vtkIdType startCurvePointIndex, vtkIdType endCurvePointIndex)
+{
+  if (!sampledPoints || samplingDistance <= 0)
+    {
+    vtkGenericWarningMacro("vtkMRMLMarkupsCurveNode::GetSampledCurvePointsBetweenStartEndPoints failed: invalid inputs");
+    return false;
+    }
+  vtkPoints* allPoints = this->GetCurvePointsWorld();
+  if (!allPoints)
+    {
+    return false;
+    }
+  if (startCurvePointIndex < 0 || endCurvePointIndex >= allPoints->GetNumberOfPoints())
+    {
+    vtkGenericWarningMacro("vtkMRMLMarkupsCurveNode::GetSampledCurvePointsBetweenStartEndPoints failed: invalid inputs ("
+    << "requested " << startCurvePointIndex << ".." << endCurvePointIndex << " range, but there are "
+    << allPoints->GetNumberOfPoints() << " curve points)");
+    return false;
+    }
+  vtkNew<vtkPoints> points;
+  if (startCurvePointIndex <= endCurvePointIndex)
+    {
+    points->InsertPoints(0, endCurvePointIndex - startCurvePointIndex + 1, startCurvePointIndex, allPoints);
+    }
+  else
+    {
+    // wrap around
+    vtkNew<vtkPoints> points;
+    points->InsertPoints(0, allPoints->GetNumberOfPoints() - startCurvePointIndex, startCurvePointIndex, allPoints);
+    points->InsertPoints(points->GetNumberOfPoints(), endCurvePointIndex + 1, 0, allPoints);
+    }
+  return vtkMRMLMarkupsCurveNode::ResamplePoints(points, sampledPoints, samplingDistance, this->CurveClosed);
+}
+
+//---------------------------------------------------------------------------
+vtkIdType vtkMRMLMarkupsCurveNode::GetClosestCurvePointIndexToPositionWorld(double posWorld[3])
+{
+  vtkPoints* points = this->GetCurvePointsWorld();
+  if (!points)
+    {
+    return -1;
+    }
+  this->TransformedCurvePolyLocator->Update(); // or ->BuildLocator()?
+  return this->TransformedCurvePolyLocator->FindClosestPoint(posWorld);
+}
+
+//---------------------------------------------------------------------------
+vtkIdType vtkMRMLMarkupsCurveNode::GetCurvePointIndexFromControlPointIndex(int controlPointIndex)
+{
+  if (this->CurveGenerator->IsInterpolatingCurve())
+    {
+    return controlPointIndex * this->CurveGenerator->GetNumberOfPointsPerInterpolatingSegment() + 1;
+    }
+  else
+    {
+    double controlPointPositionWorld[3] = { 0.0 };
+    this->GetNthControlPointPositionWorld(controlPointIndex, controlPointPositionWorld);
+    return GetClosestCurvePointIndexToPositionWorld(controlPointPositionWorld);
+    }
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsCurveNode::GetCurveDirectionAtPointIndexWorld(vtkIdType curvePointIndex, double directionVectorWorld[3])
+{
+  vtkPoints* points = this->GetCurvePointsWorld();
+  if (!points)
+    {
+    return false;
+    }
+  vtkIdType numberOfPoints = points->GetNumberOfPoints();
+  if (numberOfPoints<2 || curvePointIndex < 0 || curvePointIndex >= numberOfPoints)
+    {
+    return false;
+    }
+
+  if (curvePointIndex == 0 || curvePointIndex == numberOfPoints - 1 || numberOfPoints < 3)
+    {
+    // Point is at the start or end of the line
+    double pointPos[3] = { 0.0 };
+    double pointPosAfter[3] = { 0.0 };
+    points->GetPoint(curvePointIndex == 0 ? 0 : numberOfPoints - 2, pointPos);
+    points->GetPoint(curvePointIndex == 0 ? 1 : numberOfPoints - 1, pointPosAfter);
+    directionVectorWorld[0] = pointPosAfter[0] - pointPos[0];
+    directionVectorWorld[1] = pointPosAfter[1] - pointPos[1];
+    directionVectorWorld[2] = pointPosAfter[2] - pointPos[2];
+    }
+  else
+    {
+    // point is along the line, compute direction as the average of
+    // direction before and after the line
+    double pointPosBefore[3] = { 0.0 };
+    double pointPos[3] = { 0.0 };
+    double pointPosAfter[3] = { 0.0 };
+    points->GetPoint(curvePointIndex - 1, pointPosBefore);
+    points->GetPoint(curvePointIndex, pointPos);
+    points->GetPoint(curvePointIndex + 1, pointPosAfter);
+    double directionVectorBefore[3] = { pointPos[0] - pointPosBefore[0], pointPos[1] - pointPosBefore[1], pointPos[2] - pointPosBefore[2] };
+    double directionVectorAfter[3] = { pointPosAfter[0] - pointPos[0], pointPosAfter[1] - pointPos[1], pointPosAfter[2] - pointPos[2] };
+    vtkMath::Normalize(directionVectorBefore);
+    vtkMath::Normalize(directionVectorAfter);
+    directionVectorWorld[0] = directionVectorBefore[0] - directionVectorAfter[0];
+    directionVectorWorld[1] = directionVectorBefore[1] - directionVectorAfter[1];
+    directionVectorWorld[2] = directionVectorBefore[2] - directionVectorAfter[2];
+    }
+  vtkMath::Normalize(directionVectorWorld);
+  return true;
+}
+
+//---------------------------------------------------------------------------
+vtkIdType vtkMRMLMarkupsCurveNode::GetFarthestCurvePointIndexToPositionWorld(double posWorld[3])
+{
+  vtkPoints* points = this->GetCurvePointsWorld();
+  if (!points || points->GetNumberOfPoints()<1)
+    {
+    return false;
+    }
+
+  double farthestPoint[3] = { 0.0 };
+  points->GetPoint(0, farthestPoint);
+  double farthestPointDistance2 = vtkMath::Distance2BetweenPoints(posWorld, farthestPoint);
+  vtkIdType farthestPointId = 0;
+
+  vtkIdType numberOfPoints = points->GetNumberOfPoints();
+  for (vtkIdType pointIndex = 1; pointIndex < numberOfPoints; pointIndex++)
+    {
+    double* nextPoint = points->GetPoint(pointIndex);
+    double nextPointDistance2 = vtkMath::Distance2BetweenPoints(posWorld, nextPoint);
+    if (nextPointDistance2 > farthestPointDistance2)
+      {
+      farthestPoint[0] = nextPoint[0];
+      farthestPoint[1] = nextPoint[1];
+      farthestPoint[2] = nextPoint[2];
+      farthestPointDistance2 = nextPointDistance2;
+      farthestPointId = pointIndex;
+      }
+    }
+
+  return farthestPointId;
+}
+
+//---------------------------------------------------------------------------
+vtkIdType vtkMRMLMarkupsCurveNode::GetCurvePointIndexAlongCurveWorld(vtkIdType startCurvePointId, double distanceFromStartPoint)
+{
+  vtkPoints* points = this->GetCurvePointsWorld();
+  if (!points)
+    {
+    return -1;
+    }
+  vtkIdType n = points->GetNumberOfPoints();
+  if (startCurvePointId < 0 || startCurvePointId >= n)
+    {
+    return -1;
+    }
+
+  vtkIdType idIncrement = (distanceFromStartPoint >= 0 ? 1 : -1);
+  double remainingDistanceFromStartPoint = abs(distanceFromStartPoint);
+  double previousPoint[3] = { 0.0 };
+  points->GetPoint(startCurvePointId, previousPoint);
+  vtkIdType pointId = startCurvePointId;
+  bool curveConfirmedToBeNonZeroLength = false;
+  double lastSegmentLength = 0;
+  while (remainingDistanceFromStartPoint>0)
+    {
+    pointId += idIncrement;
+
+    // if reach the end then wrap around for closed curve, terminate search for open curve
+    if (pointId < 0 || pointId >= n)
+      {
+      if (this->CurveClosed)
+        {
+        if (!curveConfirmedToBeNonZeroLength)
+          {
+          if (this->GetCurveLengthWorld() == 0.0)
+            {
+            return -1;
+            }
+          curveConfirmedToBeNonZeroLength = true;
+          }
+        pointId = (pointId < 0 ? n : -1);
+        continue;
+        }
+      else
+        {
+        // reached end of curve before getting at the requested distance
+        // return closest
+        return (pointId < 0 ? 0 : n - 1);
+        }
+      }
+
+    // determine how much closer we are now
+    double* nextPoint = points->GetPoint(pointId);
+    lastSegmentLength = sqrt(vtkMath::Distance2BetweenPoints(nextPoint, previousPoint));
+    remainingDistanceFromStartPoint -= lastSegmentLength;
+    previousPoint[0] = nextPoint[0];
+    previousPoint[1] = nextPoint[1];
+    previousPoint[2] = nextPoint[2];
+    }
+
+  if (fabs(remainingDistanceFromStartPoint) <= fabs(remainingDistanceFromStartPoint + lastSegmentLength))
+    {
+    return pointId;
+    }
+  else
+    {
+    return pointId-1;
+    }
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsCurveNode::GetPointsOnPlaneWorld(vtkPlane* plane, vtkPoints* intersectionPoints)
+{
+  if (!intersectionPoints)
+    {
+    return false;
+    }
+  intersectionPoints->Reset();
+  if (!plane)
+    {
+    return false;
+    }
+  this->CurveGenerator->Update();
+  vtkPolyData* curvePoly = this->GetCurveWorld();
+  if (!curvePoly)
+    {
+    return true;
+    }
+
+  vtkNew<vtkCutter> cutEdges;
+  cutEdges->SetInputData(curvePoly);
+  cutEdges->SetCutFunction(plane);
+  cutEdges->GenerateCutScalarsOff();
+  cutEdges->SetValue(0, 0);
+  cutEdges->Update();
+  if (!cutEdges->GetOutput())
+    {
+    return true;
+    }
+  vtkPoints* points = cutEdges->GetOutput()->GetPoints();
+  if (!points)
+    {
+    return true;
+    }
+  intersectionPoints->DeepCopy(points);
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsCurveNode::GetCurvePointToWorldTransformAtPointIndex(vtkIdType curvePointIndex, vtkMatrix4x4* curvePointToWorld)
+{
+  if (!curvePointToWorld)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsCurveNode::GetCurvePointToWorldTransformAtPointIndex failed: Invalid curvePointToWorld");
+    return false;
+    }
+  this->CurveGenerator->Update();
+  this->CurveCoordinateSystemGeneratorWorld->Update();
+  vtkPolyData* curvePoly = this->CurveCoordinateSystemGeneratorWorld->GetOutput();
+  if (!curvePoly)
+    {
+    return false;
+    }
+  vtkIdType n = curvePoly->GetNumberOfPoints();
+  if (curvePointIndex < 0 || curvePointIndex >= n)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsCurveNode::GetCurvePointToWorldTransformAtPointIndex failed: Invalid curvePointIndex");
+    return false;
+    }
+  curvePointToWorld->Identity();
+  vtkPointData* pointData = curvePoly->GetPointData();
+  if (!pointData)
+    {
+    return false;
+    }
+  vtkDoubleArray* normals = vtkDoubleArray::SafeDownCast(pointData->GetAbstractArray("FSNormals"));
+  vtkDoubleArray* binormals = vtkDoubleArray::SafeDownCast(pointData->GetArray("FSBinormals"));
+  vtkDoubleArray* tangents = vtkDoubleArray::SafeDownCast(pointData->GetArray("FSTangents"));
+  if (!tangents || !normals || !binormals)
+    {
+    return false;
+    }
+  double* normal = normals->GetTuple3(curvePointIndex);
+  double* binormal = binormals->GetTuple3(curvePointIndex);
+  double* tangent = tangents->GetTuple3(curvePointIndex);
+  double* position = curvePoly->GetPoint(curvePointIndex);
+  for (int row=0; row<3; row++)
+    {
+    curvePointToWorld->SetElement(row, 0, normal[row]);
+    curvePointToWorld->SetElement(row, 1, binormal[row]);
+    curvePointToWorld->SetElement(row, 2, tangent[row]);
+    curvePointToWorld->SetElement(row, 3, position[row]);
+    }
+  return true;
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -26,6 +26,8 @@
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkMRMLMarkupsNode.h"
 
+class vtkPlane;
+
 /// \brief MRML node to represent a curve markup
 /// Curve Markups nodes contain N control points.
 /// Visualization parameters are set in the vtkMRMLMarkupsDisplayNode class.
@@ -59,6 +61,63 @@ public:
 
   /// Copy the node's attributes to this object
   void Copy(vtkMRMLNode *node) override;
+
+  /// Get curve points positions in world coordinate system.
+  vtkPoints* GetCurvePointsWorld();
+
+  /// Get length of the curve or a section of the curve.
+  /// \param startCurvePointIndex length computation starts from this curve point index
+  /// \param numberOfCurvePoints if specified then distances up to the first n points are computed
+  /// \return sum of distances between the curve points, returns 0 in case of an error
+  double GetCurveLengthWorld(vtkIdType startCurvePointIndex=0, vtkIdType numberOfCurvePoints=-1);
+
+  /// Get length of a section of the curve between startPointIndex and endPointIndex.
+  /// If endPointIndex < startPointIndex then length outside of the section is computed.
+  /// \param startCurvePointIndex length computation starts from this curve point index
+  /// \param endCurvePointIndex length computation starts from this curve point index
+  /// \return sum of distances between the curve points, returns 0 in case of an error
+  double GetCurveLengthBetweenStartEndPointsWorld(vtkIdType startCurvePointIndex, vtkIdType endCurvePointIndex);
+
+  void ResampleCurveWorld(double controlPointDistance);
+
+  static bool ResamplePoints(vtkPoints* originalPoints, vtkPoints* interpolatedPoints, double samplingDistance, bool closedCurve);
+
+  /// Samples points along the curve at equal distances.
+  /// If endPointIndex < startPointIndex then after the last point, the curve is assumed to continue at the first point.
+  bool GetSampledCurvePointsBetweenStartEndPointsWorld(vtkPoints* sampledPoints,
+    double samplingDistance, vtkIdType startCurvePointIndex, vtkIdType endCurvePointIndex);
+
+  /// Get the index of the closest curve point to the world coordinates
+  vtkIdType GetClosestCurvePointIndexToPositionWorld(double posWorld[3]);
+
+  /// Get index of the farthest curve point from the specified reference point.
+  /// Distance is Euclidean distance, not distance along the curve.
+  /// \param posWorld Reference point position in world coordinate system
+  /// \return index of the farthest curve point from refPoint, -1 in case of error
+  vtkIdType GetFarthestCurvePointIndexToPositionWorld(double posWorld[3]);
+
+  vtkIdType GetCurvePointIndexFromControlPointIndex(int controlPointIndex);
+
+  /// Get position of a curve point along the curve relative to the specified start point index.
+  /// \param startCurvePointId index of the curve point to start the distance measurement from
+  /// \param distanceFromStartPoint distance from the start point
+  /// \return founod point index, -1 in case of an error
+  vtkIdType GetCurvePointIndexAlongCurveWorld(vtkIdType startCurvePointId, double distanceFromStartPoint);
+
+  /// Get direction vector at specified curve point index, in World coordinate system.
+  /// \return true on success.
+  bool GetCurveDirectionAtPointIndexWorld(vtkIdType curvePointIndex, double directionVectorWorld[3]);
+
+  /// Get transformation from CurvePoint to World coordinate system at the specified curve point index.
+  /// CurvePoint coordinate system:
+  /// - Origin: position of the curve point.
+  /// - X axis: curve normal direction.
+  /// - Y axis: binormal direction (tangent x normal).
+  /// - Z axis: curve tangent direction.
+  /// \return true on success.
+  bool GetCurvePointToWorldTransformAtPointIndex(vtkIdType curvePointIndex, vtkMatrix4x4* curvePointToWorld);
+
+  bool GetPointsOnPlaneWorld(vtkPlane* plane, vtkPoints* intersectionPoints);
 
 protected:
   vtkMRMLMarkupsCurveNode();

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -64,7 +64,9 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   // markup display node settings
   this->TextScale = 3;
   this->GlyphType = vtkMRMLMarkupsDisplayNode::Sphere3D;
-  this->GlyphScale = 3;
+  this->GlyphScale = 1.0; // size as percent in screen size
+  this->GlyphSize = 5.0;  // size in world coordinate system (mm)
+  this->UseGlyphScale = true; // relative size by default
 
   // projection settings
   this->SliceProjection = false;
@@ -75,7 +77,8 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->SliceProjectionColor[2] = 1.0;
   this->SliceProjectionOpacity = 0.6;
 
-  this->TextVisibility = true;
+  this->PropertiesLabelVisibility = true;
+  this->PointLabelsVisibility = false;
 
   this->ActiveComponentType = ComponentNone;
   this->ActiveComponentIndex = -1;
@@ -104,19 +107,20 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of, nIndent);
 
-  of << " textScale=\"" << this->TextScale << "\"";
-  of << " glyphScale=\"" << this->GlyphScale << "\"";
-  of << " glyphType=\"" << this->GlyphType << "\"";
-
-  of << " sliceProjection=\"" << this->SliceProjection << "\"";
-  of << " SliceProjectionUseFiducialColor=\"" << this->SliceProjectionUseFiducialColor << "\"";
-  of << " SliceProjectionOutlinedBehindSlicePlane=\"" << this->SliceProjectionOutlinedBehindSlicePlane << "\"";
-
-  of << " sliceProjectionColor=\"" << this->SliceProjectionColor[0] << " "
-     << this->SliceProjectionColor[1] << " "
-     << this->SliceProjectionColor[2] << "\"";
-
-  of << " sliceProjectionOpacity=\"" << this->SliceProjectionOpacity << "\"";
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLBooleanMacro(propertiesLabelVisibility, PropertiesLabelVisibility);
+  vtkMRMLWriteXMLBooleanMacro(pointLabelsVisibility, PointLabelsVisibility);
+  vtkMRMLWriteXMLFloatMacro(textScale, TextScale);
+  vtkMRMLWriteXMLFloatMacro(glyphScale, GlyphScale);
+  vtkMRMLWriteXMLFloatMacro(glyphSize, GlyphSize);
+  vtkMRMLWriteXMLBooleanMacro(useGlyphScale, UseGlyphScale);
+  vtkMRMLWriteXMLEnumMacro(glyphType, GlyphType);
+  vtkMRMLWriteXMLBooleanMacro(sliceProjection, SliceProjection);
+  vtkMRMLWriteXMLBooleanMacro(sliceProjectionUseFiducialColor, SliceProjectionUseFiducialColor);
+  vtkMRMLWriteXMLBooleanMacro(sliceProjectionOutlinedBehindSlicePlane, SliceProjectionOutlinedBehindSlicePlane);
+  vtkMRMLWriteXMLVectorMacro(sliceProjectionColor, SliceProjectionColor, double, 3);
+  vtkMRMLWriteXMLFloatMacro(sliceProjectionOpacity, SliceProjectionOpacity);
+  vtkMRMLWriteXMLEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -126,66 +130,20 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
 
   Superclass::ReadXMLAttributes(atts);
 
-  const char* attName;
-  const char* attValue;
-  while (*atts != nullptr)
-    {
-    attName = *(atts++);
-    attValue = *(atts++);
-
-    if (!strcmp(attName, "textScale"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->TextScale;
-      }
-    else if (!strcmp(attName, "glyphType"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->GlyphType;
-      }
-    else if (!strcmp(attName, "glyphScale"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->GlyphScale;
-      }
-    else if (!strcmp(attName, "sliceProjection"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->SliceProjection;
-      }
-    else if (!strcmp(attName, "SliceProjectionUseFiducialColor"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->SliceProjectionUseFiducialColor;
-      }
-    else if (!strcmp(attName, "SliceProjectionOutlinedBehindSlicePlane"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->SliceProjectionOutlinedBehindSlicePlane;
-      }
-    else if (!strcmp(attName, "sliceProjectionColor") ||
-         !strcmp(attName, "projectedColor"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->SliceProjectionColor[0];
-      ss >> this->SliceProjectionColor[1];
-      ss >> this->SliceProjectionColor[2];
-      }
-    else if (!strcmp(attName, "sliceProjectionOpacity") ||
-         !strcmp(attName, "projectedOpacity"))
-      {
-      std::stringstream ss;
-      ss << attValue;
-      ss >> this->SliceProjectionOpacity;
-      }
-    }
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLBooleanMacro(propertiesLabelVisibility, PropertiesLabelVisibility);
+  vtkMRMLReadXMLBooleanMacro(pointLabelsVisibility, PointLabelsVisibility);
+  vtkMRMLReadXMLFloatMacro(textScale, TextScale);
+  vtkMRMLReadXMLFloatMacro(glyphScale, GlyphScale);
+  vtkMRMLReadXMLFloatMacro(glyphSize, GlyphSize);
+  vtkMRMLReadXMLBooleanMacro(useGlyphScale, UseGlyphScale);
+  vtkMRMLReadXMLEnumMacro(glyphType, GlyphType);
+  vtkMRMLReadXMLBooleanMacro(sliceProjection, SliceProjection);
+  vtkMRMLReadXMLBooleanMacro(sliceProjectionUseFiducialColor, SliceProjectionUseFiducialColor);
+  vtkMRMLReadXMLBooleanMacro(sliceProjectionOutlinedBehindSlicePlane, SliceProjectionOutlinedBehindSlicePlane);
+  vtkMRMLReadXMLVectorMacro(sliceProjectionColor, SliceProjectionColor, double, 3);
+  vtkMRMLReadXMLFloatMacro(sliceProjectionOpacity, SliceProjectionOpacity);
+  vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
 }
@@ -202,14 +160,20 @@ void vtkMRMLMarkupsDisplayNode::Copy(vtkMRMLNode *anode)
 
   vtkMRMLMarkupsDisplayNode *node = vtkMRMLMarkupsDisplayNode::SafeDownCast(anode);
 
-  this->SetTextScale(node->GetTextScale());
-  this->SetGlyphType(node->GetGlyphType());
-  this->SetGlyphScale(node->GetGlyphScale());
-  this->SetSliceProjection(node->GetSliceProjection());
-  this->SetSliceProjectionUseFiducialColor(node->GetSliceProjectionUseFiducialColor());
-  this->SetSliceProjectionOutlinedBehindSlicePlane(node->GetSliceProjectionOutlinedBehindSlicePlane());
-  this->SetSliceProjectionColor(node->GetSliceProjectionColor());
-  this->SetSliceProjectionOpacity(node->GetSliceProjectionOpacity());
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyBooleanMacro(PropertiesLabelVisibility);
+  vtkMRMLCopyBooleanMacro(PointLabelsVisibility);
+  vtkMRMLCopyFloatMacro(TextScale);
+  vtkMRMLCopyFloatMacro(GlyphScale);
+  vtkMRMLCopyFloatMacro(GlyphSize);
+  vtkMRMLCopyBooleanMacro(UseGlyphScale);
+  vtkMRMLCopyEnumMacro(GlyphType);
+  vtkMRMLCopyBooleanMacro(SliceProjection);
+  vtkMRMLCopyBooleanMacro(SliceProjectionUseFiducialColor);
+  vtkMRMLCopyBooleanMacro(SliceProjectionOutlinedBehindSlicePlane);
+  vtkMRMLCopyVectorMacro(SliceProjectionColor, double, 3);
+  vtkMRMLCopyFloatMacro(SliceProjectionOpacity);
+  vtkMRMLCopyEndMacro();
 
   this->EndModify(disabledModify);
 }
@@ -277,25 +241,22 @@ const char* vtkMRMLMarkupsDisplayNode::GetGlyphTypeAsString(int id)
 void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
-
-  os << indent << "Text scale: " << this->TextScale << "\n";
-  os << indent << "Glyph scale: (";
-  os << this->GlyphScale << ")\n";
-  os << indent << "Glyph type: ";
-  os << this->GetGlyphTypeAsString() << " (" << this->GlyphType << ")\n";
-  os << indent << "Slice projection: " << this->SliceProjection << "\n";
-  os << indent << "Slice projection use fiducial color: "
-    << this->SliceProjectionUseFiducialColor << "\n";
-  os << indent << "Slice projection outline behind plane: "
-    << this->SliceProjectionOutlinedBehindSlicePlane << "\n";
-  os << indent << "Slice projection Color: (";
-  os << this->SliceProjectionColor[0] << ","
-     << this->SliceProjectionColor[1] << ","
-     << this->SliceProjectionColor[2] << ")" << "\n";
-  os << indent << "Slice projection Opacity: " << this->SliceProjectionOpacity << "\n";
-
-  os << indent << "Active component type: " << this->ActiveComponentType << "\n";
-  os << indent << "Active component index: " << this->ActiveComponentIndex << "\n";
+  vtkMRMLPrintBeginMacro(os,indent);
+  vtkMRMLPrintBooleanMacro(PropertiesLabelVisibility);
+  vtkMRMLPrintBooleanMacro(PointLabelsVisibility);
+  vtkMRMLPrintFloatMacro(TextScale);
+  vtkMRMLPrintFloatMacro(GlyphScale);
+  vtkMRMLPrintFloatMacro(GlyphSize);
+  vtkMRMLPrintBooleanMacro(UseGlyphScale);
+  vtkMRMLPrintEnumMacro(GlyphType);
+  vtkMRMLPrintBooleanMacro(SliceProjection);
+  vtkMRMLPrintBooleanMacro(SliceProjectionUseFiducialColor);
+  vtkMRMLPrintBooleanMacro(SliceProjectionOutlinedBehindSlicePlane);
+  vtkMRMLPrintVectorMacro(SliceProjectionColor, double, 3);
+  vtkMRMLPrintFloatMacro(SliceProjectionOpacity);
+  vtkMRMLPrintFloatMacro(ActiveComponentType);
+  vtkMRMLPrintFloatMacro(ActiveComponentIndex);
+  vtkMRMLPrintEndMacro();
 }
 
 //---------------------------------------------------------------------------
@@ -324,31 +285,6 @@ int  vtkMRMLMarkupsDisplayNode::GlyphTypeIs3D(int glyphType)
     {
     return 0;
     }
-}
-
-//---------------------------------------------------------------------------
-void  vtkMRMLMarkupsDisplayNode::SetGlyphType(int type)
-{
-  if (this->GlyphType == type)
-    {
-    return;
-    }
-  vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting GlyphType to " << type);
-  this->GlyphType = type;
-
-  this->Modified();
-}
-
-//---------------------------------------------------------------------------
-void vtkMRMLMarkupsDisplayNode::SetGlyphScale(double scale)
-{
-  if (this->GlyphScale == scale)
-    {
-    return;
-    }
-  vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting GlyphScale to " << scale);
-  this->GlyphScale = scale;
-  this->Modified();
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -106,12 +106,24 @@ public:
   vtkGetMacro(TextScale,double);
   vtkSetMacro(TextScale,double);
 
-  /// Set the text visibility of the display node.
-  vtkSetMacro(TextVisibility, bool);
-  /// Get the text visibility of the display node.
-  vtkGetMacro(TextVisibility, bool);
-  /// Set the text visibility of the display node.
-  vtkBooleanMacro(TextVisibility, bool);
+  //@{
+  /**
+   * Control visibility of control point labels.
+   */
+  vtkSetMacro(PointLabelsVisibility, bool);
+  vtkGetMacro(PointLabelsVisibility, bool);
+  vtkBooleanMacro(PointLabelsVisibility, bool);
+  //@}
+
+  //@{
+  /**
+   * Control visibility of information box.
+   */
+  vtkSetMacro(PropertiesLabelVisibility, bool);
+  vtkGetMacro(PropertiesLabelVisibility, bool);
+  vtkBooleanMacro(PropertiesLabelVisibility, bool);
+  //@}
+
 
   /// Which kind of glyph should be used to display this markup?
   /// Vertex2D is supposed to start at 1
@@ -139,7 +151,7 @@ public:
   static int GetMaximumGlyphType() { return vtkMRMLMarkupsDisplayNode::GlyphType_Last-1; };
 
   /// The glyph type used to display this fiducial
-  void SetGlyphType(int type);
+  vtkSetMacro(GlyphType, int);
   vtkGetMacro(GlyphType, int);
   /// Returns 1 if the type is a 3d one, 0 else
   int GlyphTypeIs3D(int glyphType);
@@ -152,9 +164,25 @@ public:
   static const char* GetGlyphTypeAsString(int g);
   static int GetGlyphTypeFromString(const char*);
 
-  /// Get/Set for Symbol scale
-  void SetGlyphScale(double scale);
+  /// Get/Set markup point size relative to the window size.
+  /// This value is only used in slice views and only if SliceUseGlyphScale is set to true.
+  /// Diameter of the point is defined as "scale" percentage of diagonal size of the window.
+  vtkSetMacro(GlyphScale,double);
   vtkGetMacro(GlyphScale,double);
+
+  /// Get/Set absolute markup point size.
+  /// This value is used in 3D views. This value is used in slice views if SliceUseGlyphScale is set to false.
+  /// Diameter of the point is defined as "scale" percentage of diagonal size of the window.
+  vtkSetMacro(GlyphSize,double);
+  vtkGetMacro(GlyphSize,double);
+
+  /// This flag controls if GlyphScale relative or GlyphSize absolute size is used
+  /// to determine size of point glyphs.
+  /// On by default (GlyphScale is used for point sizing in 2D views).
+  /// \sa SetGlyphScale, SetGlyphSize
+  vtkSetMacro(UseGlyphScale, bool);
+  vtkGetMacro(UseGlyphScale, bool);
+  vtkBooleanMacro(UseGlyphScale, bool);
 
   enum
     {
@@ -241,10 +269,13 @@ protected:
   int ActiveComponentType;
   int ActiveComponentIndex;
 
-  bool TextVisibility;
+  bool PropertiesLabelVisibility;
+  bool PointLabelsVisibility;
   double TextScale;
   int GlyphType;
   double GlyphScale;
+  double GlyphSize;
+  bool UseGlyphScale;
 
   bool SliceProjection;
   bool SliceProjectionUseFiducialColor;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialDisplayNode.cxx
@@ -1,0 +1,41 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLMarkupsFiducialDisplayNode.h"
+
+// VTK includes
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+
+// STL includes
+#include <sstream>
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLMarkupsFiducialDisplayNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsFiducialDisplayNode::vtkMRMLMarkupsFiducialDisplayNode()
+{
+  // Markups display node settings
+  this->PropertiesLabelVisibility = false;
+  this->PointLabelsVisibility = true;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsFiducialDisplayNode::~vtkMRMLMarkupsFiducialDisplayNode()
+= default;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialDisplayNode.h
@@ -1,0 +1,55 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// .NAME vtkMRMLMarkupsFiducialDisplayNode - MRML node to represent display properties for markups fiducials
+// .SECTION Description
+// Currently, the only difference compared to the generic markups display node is that point labels
+// are displayed by default.
+//
+
+#ifndef __vtkMRMLMarkupsFiducialDisplayNode_h
+#define __vtkMRMLMarkupsFiducialDisplayNode_h
+
+#include "vtkSlicerMarkupsModuleMRMLExport.h"
+
+#include "vtkMRMLMarkupsDisplayNode.h"
+
+class vtkMRMLProceduralColorNode;
+
+/// \ingroup Slicer_QtModules_Markups
+class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsFiducialDisplayNode : public vtkMRMLMarkupsDisplayNode
+{
+public:
+  static vtkMRMLMarkupsFiducialDisplayNode *New();
+  vtkTypeMacro ( vtkMRMLMarkupsFiducialDisplayNode,vtkMRMLMarkupsDisplayNode );
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+
+  vtkMRMLNode* CreateNodeInstance (  ) override;
+
+  // Get node XML tag name (like Volume, Markups)
+  const char* GetNodeTagName() override {return "MarkupsFiducialDisplay";};
+
+protected:
+  vtkMRMLMarkupsFiducialDisplayNode();
+  ~vtkMRMLMarkupsFiducialDisplayNode() override;
+  vtkMRMLMarkupsFiducialDisplayNode( const vtkMRMLMarkupsFiducialDisplayNode& );
+  void operator= ( const vtkMRMLMarkupsFiducialDisplayNode& );
+};
+#endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -16,7 +16,7 @@
 ==============================================================================*/
 
 // MRML includes
-#include "vtkMRMLMarkupsDisplayNode.h"
+#include "vtkMRMLMarkupsFiducialDisplayNode.h"
 #include "vtkMRMLMarkupsFiducialNode.h"
 #include "vtkMRMLMarkupsFiducialStorageNode.h"
 #include "vtkMRMLScene.h"
@@ -208,4 +208,23 @@ void vtkMRMLMarkupsFiducialNode::GetNthFiducialWorldCoordinates(int n, double co
 void vtkMRMLMarkupsFiducialNode::UpdateCurvePolyFromCurveInputPoly()
 {
   // No need for curve generation for markup points
+}
+
+//-------------------------------------------------------------------------
+void vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes()
+{
+  if (this->GetDisplayNode() != nullptr &&
+    vtkMRMLMarkupsDisplayNode::SafeDownCast(this->GetDisplayNode()) != nullptr)
+    {
+    // display node already exists
+    return;
+    }
+  if (this->GetScene() == nullptr)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes failed: scene is invalid");
+    return;
+    }
+  vtkMRMLMarkupsFiducialDisplayNode* dispNode = vtkMRMLMarkupsFiducialDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLMarkupsFiducialDisplayNode"));
+  this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -123,6 +123,9 @@ public:
 
   void UpdateCurvePolyFromCurveInputPoly() override;
 
+  /// Create and observe default display node(s)
+  void CreateDefaultDisplayNodes() override;
+
 protected:
   vtkMRMLMarkupsFiducialNode();
   ~vtkMRMLMarkupsFiducialNode() override;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
@@ -44,25 +44,29 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
   std::string formatTest = node1->ReplaceListNameInMarkupLabelFormat();
   CHECK_STD_STRING(formatTest, "testingname-%d");
 
-  node1->AddText("testing");
-  CHECK_INT(node1->GetNumberOfTexts(), 1);
-  CHECK_STD_STRING(node1->GetText(0), "testing");
+  vtkNew<vtkMRMLMeasurement> measurement1;
+  measurement1->SetName("Diameter");
+  measurement1->SetValue(15.0);
+  measurement1->SetUnits("mm2");
+  node1->AddMeasurement(measurement1);
+  CHECK_INT(node1->GetNumberOfMeasurements(), 1);
+  CHECK_STRING(node1->GetNthMeasurement(0)->GetName(), "Diameter");
 
-  node1->SetText(0, "New string");
-  CHECK_STD_STRING(node1->GetText(0), "New string");
+  node1->SetNthMeasurement(0, "Radius", 11.1, "cm");
+  CHECK_STRING(node1->GetNthMeasurement(0)->GetName(), "Radius");
 
-  node1->DeleteText(0);
-  CHECK_INT(node1->GetNumberOfTexts(), 0);
+  node1->RemoveNthMeasurement(0);
+  CHECK_INT(node1->GetNumberOfMeasurements(), 0);
 
-  node1->SetText(0, "string a");
-  node1->SetText(1, "string b");
-  node1->SetText(2, "string c");
-  CHECK_INT(node1->GetNumberOfTexts(), 3);
+  node1->SetNthMeasurement(0, "Cross-section area", 15.2, "mm2");
+  node1->SetNthMeasurement(1, "Volume", 1.3, "mm3");
+  node1->SetNthMeasurement(2, "Length", 25.4, "mm");
+  CHECK_INT(node1->GetNumberOfMeasurements(), 3);
 
-  node1->DeleteText(0);
-  CHECK_INT(node1->GetNumberOfTexts(), 2);
-  CHECK_STD_STRING(node1->GetText(0), "string b");
-  CHECK_STD_STRING(node1->GetText(1), "string c");
+  node1->RemoveNthMeasurement(0);
+  CHECK_INT(node1->GetNumberOfMeasurements(), 2);
+  CHECK_STRING(node1->GetNthMeasurement(0)->GetName(), "Volume");
+  CHECK_STRING(node1->GetNthMeasurement(1)->GetName(), "Length");
 
   //
   // test methods with no markups

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
@@ -36,7 +36,6 @@
 class vtkArcSource;
 class vtkDiscretizableColorTransferFunction;
 class vtkSampleImplicitFunctionFilter;
-class vtkTextActor;
 class vtkTubeFilter;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerAngleRepresentation2D : public vtkSlicerMarkupsWidgetRepresentation2D
@@ -86,8 +85,6 @@ protected:
   vtkSmartPointer<vtkPolyDataMapper2D> ArcMapper;
   vtkSmartPointer<vtkActor2D> ArcActor;
   vtkSmartPointer<vtkDiscretizableColorTransferFunction> ColorMap;
-
-  vtkSmartPointer<vtkTextActor> TextActor;
 
   vtkSmartPointer<vtkTubeFilter> TubeFilter;
   vtkSmartPointer<vtkTubeFilter> ArcTubeFilter;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
@@ -196,12 +196,12 @@ void vtkSlicerAngleRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
     {
     ControlPointsPipeline3D* controlPoints = this->GetControlPointsPipeline(controlPointType);
-    controlPoints->LabelsActor->SetVisibility(this->MarkupsDisplayNode->GetTextVisibility());
+    controlPoints->LabelsActor->SetVisibility(this->MarkupsDisplayNode->GetPointLabelsVisibility());
     controlPoints->Glypher->SetScaleFactor(this->ControlPointSize);
     this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->Mapper);
     }
 
-  this->TextActor->SetVisibility(this->MarkupsDisplayNode->GetTextVisibility());
+  this->TextActor->SetVisibility(this->MarkupsDisplayNode->GetPropertiesLabelVisibility());
 
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
   this->UpdateRelativeCoincidentTopologyOffsets(this->ArcMapper);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
@@ -98,7 +98,7 @@ void vtkSlicerLineRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
 
   // Line display
 
-  this->TubeFilter->SetRadius(this->ViewScaleFactor * this->ControlPointSize * 0.125);
+  this->TubeFilter->SetRadius(this->ControlPointSize * 0.125);
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() == 2);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -155,7 +155,7 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
     {
     ControlPointsPipeline3D* controlPoints = this->GetControlPointsPipeline(controlPointType);
-    controlPoints->LabelsActor->SetVisibility(this->MarkupsDisplayNode->GetTextVisibility());
+    controlPoints->LabelsActor->SetVisibility(this->MarkupsDisplayNode->GetPointLabelsVisibility());
     controlPoints->Glypher->SetScaleFactor(this->ControlPointSize);
     this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->Mapper);
     }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -28,6 +28,7 @@
 #include "vtkRenderer.h"
 #include "vtkSphereSource.h"
 #include "vtkStringArray.h"
+#include "vtkTextActor.h"
 #include "vtkTextProperty.h"
 
 vtkSlicerMarkupsWidgetRepresentation::ControlPointsPipeline::ControlPointsPipeline()
@@ -91,7 +92,6 @@ vtkSlicerMarkupsWidgetRepresentation::ControlPointsPipeline::ControlPointsPipeli
 
   this->GlyphSourceSphere = vtkSmartPointer<vtkSphereSource>::New();
   this->GlyphSourceSphere->SetRadius(0.5);
-
 };
 
 vtkSlicerMarkupsWidgetRepresentation::ControlPointsPipeline::~ControlPointsPipeline()
@@ -100,13 +100,15 @@ vtkSlicerMarkupsWidgetRepresentation::ControlPointsPipeline::~ControlPointsPipel
 //----------------------------------------------------------------------
 vtkSlicerMarkupsWidgetRepresentation::vtkSlicerMarkupsWidgetRepresentation()
 {
-  this->ViewScaleFactor = 1.0;
+  this->ViewScaleFactorMmPerPixel = 1.0;
+  this->ScreenSizePixel = 1000;
 
   this->ControlPointSize = 3.0;
-  this->Tolerance                = 2.0;
-  this->PixelTolerance           = 1;
   this->NeedToRender             = false;
   this->ClosedLoop               = 0;
+
+  this->TextActor = vtkSmartPointer<vtkTextActor>::New();
+  this->TextActor->SetInput("");
 
   this->PointPlacer = vtkSmartPointer<vtkFocalPlanePointPlacer>::New();
 
@@ -487,6 +489,8 @@ void vtkSlicerMarkupsWidgetRepresentation::UpdateFromMRML(
       }
     this->SetMarkupsNode(markupsNode);
     }
+
+  this->TextActor->SetVisibility(this->MarkupsDisplayNode->GetPropertiesLabelVisibility());
 
   this->NeedToRenderOn(); // TODO: to improve performance, call this only if it is actually needed
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -51,6 +51,7 @@ class vtkMarkupsGlyphSource2D;
 class vtkPointPlacer;
 class vtkPointSetToLabelHierarchy;
 class vtkSphereSource;
+class vtkTextActor;
 class vtkTextProperty;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerMarkupsWidgetRepresentation : public vtkMRMLAbstractWidgetRepresentation
@@ -122,6 +123,14 @@ protected:
     vtkSmartPointer<vtkTextProperty> TextProperty;
   };
 
+  // Calculate view size and scale factor
+  virtual void UpdateViewScaleFactor() = 0;
+
+  virtual void UpdatePixelTolerance() = 0;
+
+  double ViewScaleFactorMmPerPixel;
+  double ScreenSizePixel; // diagonal size of the screen
+
   double ControlPointSize;
 
   virtual void SetMarkupsNode(vtkMRMLMarkupsNode *markupsNode);
@@ -130,6 +139,8 @@ protected:
   vtkWeakPointer<vtkMRMLMarkupsNode> MarkupsNode;
 
   vtkSmartPointer<vtkPointPlacer> PointPlacer;
+
+  vtkSmartPointer<vtkTextActor> TextActor;
 
   vtkTypeBool ClosedLoop;
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
@@ -87,10 +87,6 @@ public:
   void GetSliceToWorldCoordinates(const double[2], double[3]);
   void GetWorldToSliceCoordinates(const double worldPos[3], double slicePos[2]);
 
-  /// Set/Get the 2d scale factor to divide 3D scale by to show 2D elements appropriately (usually set to 300)
-  vtkSetMacro(ScaleFactor2D, double);
-  vtkGetMacro(ScaleFactor2D, double);
-
 protected:
   vtkSlicerMarkupsWidgetRepresentation2D();
   ~vtkSlicerMarkupsWidgetRepresentation2D() override;
@@ -99,6 +95,9 @@ protected:
   vtkMRMLSliceNode *GetSliceNode();
 
   void UpdatePlaneFromSliceNode();
+
+  void UpdateViewScaleFactor() override;
+  void UpdatePixelTolerance() override;
 
   bool GetAllControlPointsVisible() override;
 
@@ -144,9 +143,6 @@ protected:
 
   vtkSmartPointer<vtkTransform> WorldToSliceTransform;
   vtkSmartPointer<vtkPlane> SlicePlane;
-
-  /// Scale factor for 2d windows
-  double ScaleFactor2D;
 
   virtual void UpdateAllPointsAndLabelsFromMRML(double labelsOffset);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -31,6 +31,7 @@
 #include "vtkPolyDataMapper.h"
 #include "vtkProperty.h"
 #include "vtkRenderer.h"
+#include "vtkRenderWindow.h"
 #include "vtkSelectVisiblePoints.h"
 #include "vtkSlicerMarkupsWidgetRepresentation3D.h"
 #include "vtkSphereSource.h"
@@ -119,8 +120,9 @@ vtkSlicerMarkupsWidgetRepresentation3D::vtkSlicerMarkupsWidgetRepresentation3D()
   reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[Active])->Actor->PickableOff();
   reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[Active])->Actor->DragableOff();
 
+  this->TextActor->SetTextProperty(this->GetControlPointsPipeline(Unselected)->TextProperty);
+
   this->ControlPointSize = 10; // will be set from the markup's GlyphScale
-  this->Tolerance = 5.0;
 
   this->AccuratePicker = vtkSmartPointer<vtkCellPicker>::New();
   this->AccuratePicker->SetTolerance(.005);
@@ -160,8 +162,6 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
     return;
     }
 
-  this->ControlPointSize = this->MarkupsDisplayNode->GetGlyphScale();
-
   int numPoints = markupsNode->GetNumberOfControlPoints();
 
   for (int i = 0; i<NumberOfControlPointTypes; i++)
@@ -196,7 +196,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
         startIndex = activeControlPointIndex;
         stopIndex = startIndex;
         controlPoints->Actor->VisibilityOn();
-        controlPoints->LabelsActor->SetVisibility(display->GetTextVisibility());
+        controlPoints->LabelsActor->SetVisibility(display->GetPointLabelsVisibility());
         }
       else
         {
@@ -207,7 +207,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
       }
     else
       {
-      controlPoints->LabelsActor->SetVisibility(display->GetTextVisibility());
+      controlPoints->LabelsActor->SetVisibility(display->GetPointLabelsVisibility());
       }
 
     for (int pointIndex = startIndex; pointIndex <= stopIndex; pointIndex++)
@@ -265,8 +265,6 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
 
   double displayPosition3[3] = { static_cast<double>(displayPosition[0]), static_cast<double>(displayPosition[1]), 0.0 };
 
-  double pixelTolerance2 = this->PixelTolerance * this->PixelTolerance;
-
   closestDistance2 = VTK_DOUBLE_MAX; // in display coordinate system
   foundComponentIndex = -1;
   if (markupsNode->GetNumberOfControlPoints() > 2 && this->ClosedLoop && markupsNode)
@@ -274,11 +272,13 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
     // Check if center is selected
     double centerPosWorld[3], centerPosDisplay[3];
     markupsNode->GetCenterPosition(centerPosWorld);
+    double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(centerPosWorld)
+      + this->ScreenSizePixel * this->ScreenScaleFactor * this->Tolerance / 100.0;
     this->Renderer->SetWorldPoint(centerPosWorld);
     this->Renderer->WorldToDisplay();
     this->Renderer->GetDisplayPoint(centerPosDisplay);
     double dist2 = vtkMath::Distance2BetweenPoints(centerPosDisplay, displayPosition3);
-    if (dist2 < pixelTolerance2)
+    if (dist2 < pixelTolerance * pixelTolerance)
       {
       closestDistance2 = dist2;
       foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentCenterPoint;
@@ -295,11 +295,13 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
       }
     double centerPosWorld[3], centerPosDisplay[3];
     markupsNode->GetNthControlPointPositionWorld(i, centerPosWorld);
+    double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(centerPosWorld)
+      + this->ScreenSizePixel * this->ScreenScaleFactor * this->Tolerance / 100.0;
     this->Renderer->SetWorldPoint(centerPosWorld);
     this->Renderer->WorldToDisplay();
     this->Renderer->GetDisplayPoint(centerPosDisplay);
     double dist2 = vtkMath::Distance2BetweenPoints(centerPosDisplay, displayPosition3);
-    if (dist2 < pixelTolerance2 && dist2 < closestDistance2)
+    if (dist2 < pixelTolerance * pixelTolerance && dist2 < closestDistance2)
       {
       closestDistance2 = dist2;
       foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentControlPoint;
@@ -362,14 +364,18 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteractWithLine(
 //----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned long event, void *callData /*=nullptr*/)
 {
-  // Update from slice node
-  if (!caller || caller == this->ViewNode.GetPointer())
+  this->UpdateViewScaleFactor();
+  if (this->MarkupsDisplayNode->GetUseGlyphScale())
     {
-    this->UpdateViewScaleFactor();
+    this->ControlPointSize = this->ScreenSizePixel * this->ScreenScaleFactor
+      * this->MarkupsDisplayNode->GetGlyphScale() / 100.0 * this->ViewScaleFactorMmPerPixel;
+    }
+  else
+    {
+    this->ControlPointSize = this->MarkupsDisplayNode->GetGlyphSize();
     }
 
-  this->ControlPointSize = this->MarkupsDisplayNode->GetGlyphScale();
-  this->PixelTolerance = this->ControlPointSize * (1.0 + this->Tolerance) * this->ViewScaleFactor;
+  this->UpdatePixelTolerance();
 
   Superclass::UpdateFromMRML(caller, event, callData);
 
@@ -641,4 +647,80 @@ bool vtkSlicerMarkupsWidgetRepresentation3D::AccuratePick(int x, int y, double p
       }
     }
   return true;
+}
+
+//----------------------------------------------------------------------
+double vtkSlicerMarkupsWidgetRepresentation3D::GetViewScaleFactorAtPosition(double positionWorld[3])
+{
+  double viewScaleFactorMmPerPixel = 1.0;
+  if (!this->Renderer || !this->Renderer->GetActiveCamera())
+    {
+    return viewScaleFactorMmPerPixel;
+    }
+
+  vtkCamera * cam = this->Renderer->GetActiveCamera();
+  if (cam->GetParallelProjection())
+    {
+    // Viewport: xmin, ymin, xmax, ymax; range: 0.0-1.0; origin is bottom left
+    // Determine the available renderer size in pixels
+    double minX = 0;
+    double minY = 0;
+    this->Renderer->NormalizedDisplayToDisplay(minX, minY);
+    double maxX = 1;
+    double maxY = 1;
+    this->Renderer->NormalizedDisplayToDisplay(maxX, maxY);
+    int rendererSizeInPixels[2] = { static_cast<int>(maxX - minX), static_cast<int>(maxY - minY) };
+    // Parallel scale: height of the viewport in world-coordinate distances.
+    // Larger numbers produce smaller images.
+    viewScaleFactorMmPerPixel = (cam->GetParallelScale() * 2.0) / double(rendererSizeInPixels[1]);
+    }
+  else
+    {
+    double cameraFP[4] = { positionWorld[0], positionWorld[1], positionWorld[2], 1.0 };
+
+    double cameraViewUp[3] = { 0 };
+    cam->GetViewUp(cameraViewUp);
+    vtkMath::Normalize(cameraViewUp);
+
+    // Get distance in pixels between two points at unit distance above and below the focal point
+    this->Renderer->SetWorldPoint(cameraFP[0] + cameraViewUp[0], cameraFP[1] + cameraViewUp[1], cameraFP[2] + cameraViewUp[2], cameraFP[3]);
+    this->Renderer->WorldToDisplay();
+    double topCenter[3] = { 0 };
+    this->Renderer->GetDisplayPoint(topCenter);
+    this->Renderer->SetWorldPoint(cameraFP[0] - cameraViewUp[0], cameraFP[1] - cameraViewUp[1], cameraFP[2] - cameraViewUp[2], cameraFP[3]);
+    this->Renderer->WorldToDisplay();
+    double bottomCenter[3] = { 0 };
+    this->Renderer->GetDisplayPoint(bottomCenter);
+    double distInPixels = sqrt(vtkMath::Distance2BetweenPoints(topCenter, bottomCenter));
+
+    // 2.0 = 2x length of viewUp vector in mm (because viewUp is unit vector)
+    viewScaleFactorMmPerPixel = 2.0 / distInPixels;
+    }
+  return viewScaleFactorMmPerPixel;
+}
+
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation3D::UpdateViewScaleFactor()
+{
+  this->ViewScaleFactorMmPerPixel = 1.0;
+  this->ScreenSizePixel = 1000.0;
+  if (!this->Renderer || !this->Renderer->GetActiveCamera())
+    {
+    return;
+    }
+
+  int* screenSize = this->Renderer->GetRenderWindow()->GetScreenSize();
+  this->ScreenSizePixel = sqrt(screenSize[0] * screenSize[0] + screenSize[1] * screenSize[1]);
+
+  double cameraFP[3] = { 0.0 };
+  this->Renderer->GetActiveCamera()->GetFocalPoint(cameraFP);
+  this->ViewScaleFactorMmPerPixel = this->GetViewScaleFactorAtPosition(cameraFP);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation3D::UpdatePixelTolerance()
+{
+  this->PixelTolerance = this->ControlPointSize / 2.0 / this->ViewScaleFactorMmPerPixel
+    + this->ScreenSizePixel * this->ScreenScaleFactor * this->Tolerance / 100.0;
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -78,6 +78,12 @@ protected:
   vtkSlicerMarkupsWidgetRepresentation3D();
   ~vtkSlicerMarkupsWidgetRepresentation3D() override;
 
+  double GetViewScaleFactorAtPosition(double positionWorld[3]);
+
+  void UpdateViewScaleFactor() override;
+
+  void UpdatePixelTolerance() override;
+
   class ControlPointsPipeline3D : public ControlPointsPipeline
   {
   public:

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>258</width>
-    <height>259</height>
+    <width>348</width>
+    <height>278</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,6 +26,20 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="VisibilityLabel">
+     <property name="text">
+      <string>Visible:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QCheckBox" name="VisibilityCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="DisplayNodeViewLabel">
      <property name="text">
@@ -105,7 +119,7 @@
    <item row="9" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QPushButton" name="pushButton">
+      <widget class="QPushButton" name="glyphSizeIsAbsoluteButton">
        <property name="text">
         <string>absolute</string>
        </property>
@@ -122,18 +136,41 @@
        <property name="maximum">
         <double>20.000000000000000</double>
        </property>
+       <property name="suffix">
+        <string> %</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="qMRMLSliderWidget" name="glyphSizeSliderWidget">
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="pageStep">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>5.000000000000000</double>
+       </property>
       </widget>
      </item>
     </layout>
    </item>
    <item row="10" column="0">
+    <widget class="QLabel" name="PointLabelsVisibilityLabel">
+     <property name="text">
+      <string>Point Labels:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
     <widget class="QLabel" name="textScaleLabel">
      <property name="text">
       <string>Text Size:</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
+   <item row="11" column="1">
     <widget class="ctkSliderWidget" name="textScaleSliderWidget">
      <property name="singleStep">
       <double>0.100000000000000</double>
@@ -146,7 +183,7 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="0" colspan="2">
+   <item row="12" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="SliceDisplayCollapsibleGroupBox">
      <property name="title">
       <string>Advanced</string>
@@ -173,15 +210,8 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="VisibilityLabel">
-     <property name="text">
-      <string>Visible:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QCheckBox" name="VisibilityCheckBox">
+   <item row="10" column="1">
+    <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
      <property name="text">
       <string/>
      </property>
@@ -207,6 +237,11 @@
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSliderWidget</class>
+   <extends>ctkSliderWidget</extends>
+   <header>qMRMLSliderWidget.h</header>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>
@@ -238,5 +273,38 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>glyphSizeIsAbsoluteButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>glyphScaleSliderWidget</receiver>
+   <slot>setHidden(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>129</x>
+     <y>186</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>174</x>
+     <y>186</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>glyphSizeIsAbsoluteButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>glyphSizeSliderWidget</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>114</x>
+     <y>188</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>300</x>
+     <y>188</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -73,7 +73,7 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
   this->unselectedColorPickerButton->setDialogOptions(ctkColorPickerButton::UseCTKColorDialog);
 
   // set up the display properties
-  q->connect(this->VisibilityCheckBox, SIGNAL(toggled(bool)),
+  QObject::connect(this->VisibilityCheckBox, SIGNAL(toggled(bool)),
     q, SLOT(setVisibility(bool)));
   QObject::connect(this->selectedColorPickerButton, SIGNAL(colorChanged(QColor)),
     q, SLOT(onSelectedColorPickerButtonChanged(QColor)));
@@ -81,8 +81,14 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
     q, SLOT(onUnselectedColorPickerButtonChanged(QColor)));
   QObject::connect(this->glyphTypeComboBox, SIGNAL(currentIndexChanged(QString)),
     q, SLOT(onGlyphTypeComboBoxChanged(QString)));
+  QObject::connect(this->glyphSizeIsAbsoluteButton, SIGNAL(toggled(bool)),
+    q, SLOT(setGlyphSizeIsAbsolute(bool)));
   QObject::connect(this->glyphScaleSliderWidget, SIGNAL(valueChanged(double)),
     q, SLOT(onGlyphScaleSliderWidgetChanged(double)));
+  QObject::connect(this->glyphSizeSliderWidget, SIGNAL(valueChanged(double)),
+    q, SLOT(onGlyphSizeSliderWidgetChanged(double)));
+  QObject::connect(this->PointLabelsVisibilityCheckBox, SIGNAL(toggled(bool)),
+	  q, SLOT(setPointLabelsVisibility(bool)));
   QObject::connect(this->textScaleSliderWidget, SIGNAL(valueChanged(double)),
     q, SLOT(onTextScaleSliderWidgetChanged(double)));
 
@@ -126,6 +132,9 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
     q->setEnabled(true);
     q->setMRMLMarkupsDisplayNode(this->MarkupsDisplayNode);
     }
+
+  this->glyphSizeSliderWidget->setVisible(this->glyphSizeIsAbsoluteButton->isChecked());
+  this->glyphScaleSliderWidget->setHidden(this->glyphSizeIsAbsoluteButton->isChecked());
 
   // Disable until a valid display node is set
   this->setEnabled(false);
@@ -218,6 +227,8 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
     d->glyphTypeComboBox->setCurrentIndex(glyphTypeIndex);
     }
 
+  d->glyphSizeIsAbsoluteButton->setChecked(d->MarkupsDisplayNode ? !d->MarkupsDisplayNode->GetUseGlyphScale() : false);
+
   // glyph scale
   double glyphScale = markupsDisplayNode->GetGlyphScale();
   // make sure that the slider can accommodate this scale
@@ -226,6 +237,17 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
     d->glyphScaleSliderWidget->setMaximum(glyphScale);
     }
   d->glyphScaleSliderWidget->setValue(glyphScale);
+
+  // glyph size
+  double glyphSize = markupsDisplayNode->GetGlyphSize();
+  // make sure that the slider can accommodate this scale
+  if (glyphSize > d->glyphSizeSliderWidget->maximum())
+    {
+    d->glyphSizeSliderWidget->setMaximum(glyphSize);
+    }
+  d->glyphSizeSliderWidget->setValue(glyphSize);
+
+  d->PointLabelsVisibilityCheckBox->setChecked(d->MarkupsDisplayNode ? d->MarkupsDisplayNode->GetPointLabelsVisibility() : false);
 
   // text scale
   double textScale = markupsDisplayNode->GetTextScale();
@@ -267,6 +289,42 @@ bool qMRMLMarkupsDisplayNodeWidget::visibility()const
 {
   Q_D(const qMRMLMarkupsDisplayNodeWidget);
   return d->VisibilityCheckBox->isChecked();
+}
+
+//------------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setPointLabelsVisibility(bool visible)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode.GetPointer())
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetPointLabelsVisibility(visible);
+}
+
+//------------------------------------------------------------------------------
+bool qMRMLMarkupsDisplayNodeWidget::pointLabelsVisibility()const
+{
+  Q_D(const qMRMLMarkupsDisplayNodeWidget);
+  return d->PointLabelsVisibilityCheckBox->isChecked();
+}
+
+//------------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setGlyphSizeIsAbsolute(bool absolute)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode.GetPointer())
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetUseGlyphScale(!absolute);
+}
+
+//------------------------------------------------------------------------------
+bool qMRMLMarkupsDisplayNodeWidget::glyphSizeIsAbsolute()const
+{
+  Q_D(const qMRMLMarkupsDisplayNodeWidget);
+  return d->glyphSizeIsAbsoluteButton->isChecked();
 }
 
 //-----------------------------------------------------------------------------
@@ -318,6 +376,17 @@ void qMRMLMarkupsDisplayNodeWidget::onGlyphScaleSliderWidgetChanged(double value
 }
 
 //-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::onGlyphSizeSliderWidgetChanged(double value)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetGlyphSize(value);
+}
+
+//-----------------------------------------------------------------------------
 void qMRMLMarkupsDisplayNodeWidget::onTextScaleSliderWidgetChanged(double value)
 {
   Q_D(qMRMLMarkupsDisplayNodeWidget);
@@ -351,5 +420,16 @@ void qMRMLMarkupsDisplayNodeWidget::setMaximumMarkupsScale(double maxScale)
   if (maxScale > d->textScaleSliderWidget->maximum())
     {
     d->textScaleSliderWidget->setMaximum(maxScale);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setMaximumMarkupsSize(double maxSize)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+
+  if (maxSize > d->glyphSizeSliderWidget->maximum())
+    {
+    d->glyphSizeSliderWidget->setMaximum(maxSize);
     }
 }

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
@@ -55,6 +55,10 @@ public:
 
   bool visibility()const;
 
+  bool glyphSizeIsAbsolute()const;
+
+  bool pointLabelsVisibility()const;
+
 signals:
   ///
   /// Signal sent if the any property in the display node is changed
@@ -74,7 +78,12 @@ public slots:
 
   void setVisibility(bool);
 
+  void setGlyphSizeIsAbsolute(bool absolute);
+
+  void setPointLabelsVisibility(bool);
+
   void setMaximumMarkupsScale(double maxScale);
+  void setMaximumMarkupsSize(double maxScale);
 
 protected slots:
   void updateWidgetFromMRML();
@@ -84,6 +93,7 @@ protected slots:
   void onUnselectedColorPickerButtonChanged(QColor qcolor);
   void onGlyphTypeComboBoxChanged(QString value);
   void onGlyphScaleSliderWidgetChanged(double value);
+  void onGlyphSizeSliderWidgetChanged(double value);
   void onTextScaleSliderWidgetChanged(double value);
   void onOpacitySliderWidgetChanged(double value);
 

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.h
@@ -34,6 +34,7 @@
 class qSlicerMarkupsPlaceWidgetPrivate;
 class vtkMRMLInteractionNode;
 class vtkMRMLMarkupsFiducialNode;
+class vtkMRMLMarkupsNode;
 
 /// \ingroup Slicer_QtModules_CreateModels
 class Q_SLICER_MODULE_MARKUPS_WIDGETS_EXPORT
@@ -50,7 +51,6 @@ qSlicerMarkupsPlaceWidget : public qSlicerWidget
   Q_PROPERTY(bool placeModeEnabled READ placeModeEnabled WRITE setPlaceModeEnabled)
   Q_PROPERTY(bool placeModePersistency READ placeModePersistency WRITE setPlaceModePersistency)
 
-
 public:
   typedef qSlicerWidget Superclass;
   qSlicerMarkupsPlaceWidget(QWidget *parent=nullptr);
@@ -58,7 +58,7 @@ public:
 
   enum PlaceMultipleMarkupsType
   {
-    ShowPlaceMultipleMarkupsOption, // show a menu on the place button to place multiple fiducials
+    ShowPlaceMultipleMarkupsOption, // show a menu on the place button to place multiple markup points
     HidePlaceMultipleMarkupsOption, // don't allow to change persistency of place mode, just use current
     ForcePlaceSingleMarkup, // always disable persistency when enabling place mode
     ForcePlaceMultipleMarkups // always enable persistency when enabling place mode
@@ -66,8 +66,8 @@ public:
 
   /// Get the currently selected markups node.
   Q_INVOKABLE vtkMRMLNode* currentNode() const;
-
   Q_INVOKABLE vtkMRMLMarkupsFiducialNode* currentMarkupsFiducialNode() const;
+  Q_INVOKABLE vtkMRMLMarkupsNode* currentMarkupsNode() const;
 
   /// Get interaction node.
   /// \sa setInteractionNode()
@@ -134,10 +134,10 @@ public slots:
   /// Set place mode to persistent (remains active until deactivated). Does not enable or disable placement mode.
   void setPlaceModePersistency(bool);
 
-  /// Delete a point from fiducial from the list.
+  /// Delete last placed markup point.
   void deleteLastPoint();
 
-  /// Delete all points from the current fiducial markups node.
+  /// Delete all points from the markups node.
   void deleteAllPoints();
 
   /// \deprecated Use deleteLastPoint instead.
@@ -165,6 +165,9 @@ signals:
   /// This signal is emitted when place mode for the active markup is changed to enabled or disabled.
   /// The argument \a enabled is true if the currently selected markups node is active and in place mode.
   /// The argument \a enabled is false if the currently selected markups node is not active or not in place mode.
+  void activeMarkupsPlaceModeChanged(bool enabled);
+
+  /// \deprecated Use activeMarkupsPlaceModeChanged instead.
   void activeMarkupsFiducialPlaceModeChanged(bool enabled);
 
 protected:


### PR DESCRIPTION
First step towards implementing markup measurements, and some fixes.

Store measurements in markups in vtkMRMLMeasurement class instead of plain text fields. vtkMRMLMeasurement can also store measurements computed by other modules (such as Segment Statistics).

Fixed scaling of markups. Size can be set relatively to screen size or setting an absolute markup size.

Improve GUI:
- Make markup point labels hidden by default for all nodes except fiducials.
- Make qSlicerMarkupsPlaceWidget compatible with all markups