### PR TITLE
BUG: Use OpenGL compatibility profile on Windows by default

### DIFF
--- a/Applications/SlicerApp/Testing/Cpp/qSlicerAppMainWindowTest1.cxx
+++ b/Applications/SlicerApp/Testing/Cpp/qSlicerAppMainWindowTest1.cxx
@@ -29,13 +29,7 @@
 # include <ctkPythonConsole.h>
 #endif
 
-// VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
-
-// SlicerApp includes
+#include "qMRMLWidget.h"// SlicerApp includes
 #include "qSlicerApplication.h"
 #include "qSlicerAppMainWindow.h"
 #ifdef Slicer_USE_PYTHONQT
@@ -46,17 +40,9 @@
 
 int qSlicerAppMainWindowTest1(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  // Enables resource sharing between the OpenGL contexts used by classes like QOpenGLWidget and QQuickWidget
-  QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-
-  qSlicerApplication app(argc, argv);
+  qMRMLWidget::preInitializeApplication();
+  QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qSlicerAppMainWindow mainWindow;
   mainWindow.show();

--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -56,16 +56,13 @@
 
 // MRMLWidgets includes
 #include <qMRMLEventLoggerWidget.h>
+#include <qMRMLWidget.h>
 
 // ITK includes
 #include <itkFactoryRegistration.h>
 
 // VTK includes
 #include <vtksys/SystemTools.hxx>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
 #include <vtkNew.h>
 
 // PythonQt includes
@@ -75,7 +72,7 @@
 #endif
 
 #ifdef _WIN32
-#include <Windows.h> //for SetProcessDPIAware
+#include <Windows.h> //for SHELLEXECUTEINFO
 #endif
 
 //----------------------------------------------------------------------------
@@ -92,37 +89,7 @@ void qSlicerApplicationHelper::preInitializeApplication(
     const char* argv0, ctkProxyStyle* style)
 {
   itk::itkFactoryRegistration();
-#ifdef Q_OS_MACX
-  if (QSysInfo::MacintoshVersion > QSysInfo::MV_10_8)
-    {
-    // Fix Mac OS X 10.9 (mavericks) font issue
-    // https://bugreports.qt-project.org/browse/QTBUG-32789
-    QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
-    }
-#endif
-
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget. Disable multisampling to
-  // support volume rendering and other VTK functionality that reads from the
-  // framebuffer; see https://gitlab.kitware.com/vtk/vtk/issues/17095.
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-#ifdef _WIN32
-  // Qt windows defaults to the PROCESS_PER_MONITOR_DPI_AWARE for DPI display
-  // on windows. Unfortunately, this doesn't work well on multi-screens setups.
-  // By calling SetProcessDPIAware(), we force the value to
-  // PROCESS_SYSTEM_DPI_AWARE instead which fixes those issues.
-  SetProcessDPIAware();
-#endif
-
-  // Enable automatic scaling based on the pixel density of the monitor
-  QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-
-  // Enables resource sharing between the OpenGL contexts used by classes like QOpenGLWidget and QQuickWidget
-  QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+  qMRMLWidget::preInitializeApplication();
 
   // Allow a custom application name so that the settings
   // can be distinct for differently named applications

--- a/Base/QTGUI/Testing/Cxx/qSlicerDirectoryListViewTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerDirectoryListViewTest1.cxx
@@ -28,26 +28,17 @@
 
 // SlicerQt includes
 #include "qSlicerDirectoryListView.h"
-
-// VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <iostream>
 
 int qSlicerDirectoryListViewTest1(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
+
   qSlicerDirectoryListView widget;
 
   QSignalSpy spy(&widget, SIGNAL(directoryListChanged()));

--- a/Base/QTGUI/Testing/Cxx/qSlicerLayoutManagerTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerLayoutManagerTest1.cxx
@@ -30,24 +30,16 @@
 // MRML includes
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
 
 int qSlicerLayoutManagerTest1(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   qSlicerLayoutManager* layoutManager = new qSlicerLayoutManager(nullptr);
   delete layoutManager;
   return EXIT_SUCCESS;

--- a/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
@@ -17,10 +17,7 @@
 #include <vtkSlicerApplicationLogic.h>
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
@@ -39,14 +36,6 @@ QString activePlaceActionText(qSlicerMouseModeToolBar& mouseModeToolBar)
 
 int qSlicerMouseModeToolBarTest1(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  //QApplication app(argc, argv);
   qSlicerApplication app(argc, argv);
   qSlicerMouseModeToolBar mouseToolBar;
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest1.cxx
@@ -31,23 +31,15 @@
 #include <vtkMRMLScene.h>
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qSlicerWidgetTest1(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   qSlicerWidget widget;
   if (widget.mrmlScene() != nullptr)
     {

--- a/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
@@ -27,6 +27,7 @@
 
 // SlicerQt includes
 #include "qSlicerWidget.h"
+#include "qMRMLWidget.h"
 
 // Slicer includes
 #include <vtkMRMLSliceLogic.h>
@@ -48,7 +49,6 @@
 #include <vtkActor2D.h>
 #include <vtkVersion.h>
 #ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
 #include <QVTKOpenGLWidget.h>
 #else
 #include <QVTKWidget.h>
@@ -151,17 +151,13 @@ int qSlicerWidgetTest2(int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
   //
   // Create a simple gui with a quit button and render window
   //
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
+
   QWidget parentWidget;
   parentWidget.setWindowTitle("qSlicerWidgetTest2");
   QVBoxLayout vbox;

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -81,6 +81,7 @@
 
 // qMRMLWidget includes
 #include "qMRMLEventBrokerConnection.h"
+#include "qMRMLWidget.h"
 
 // qMRML includes
 #ifdef Slicer_USE_QtTesting
@@ -178,6 +179,19 @@ qSlicerApplicationPrivate::~qSlicerApplicationPrivate()
 void qSlicerApplicationPrivate::init()
 {
   Q_Q(qSlicerApplication);
+
+  qMRMLWidget::OpenGLProfileType openGLProfile = qMRMLWidget::OpenGLProfileDefault;
+  QString useOpenGLCompatibilityProfileApplicationSetting =
+    qSlicerApplication::application()->userSettings()->value("OpenGLProfile").toString().toLower();
+  if (useOpenGLCompatibilityProfileApplicationSetting == "compatibility")
+    {
+    openGLProfile = qMRMLWidget::OpenGLProfileCompatibility;
+    }
+  else if (useOpenGLCompatibilityProfileApplicationSetting == "core")
+    {
+    openGLProfile = qMRMLWidget::OpenGLProfileCore;
+    }
+  qMRMLWidget::postInitializeApplication(openGLProfile);
 
   ctkVTKConnectionFactory::setInstance(new qMRMLConnectionFactory);
 

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -56,7 +56,6 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerApplication : public qSlicerCoreApplicat
 {
   Q_OBJECT
 public:
-
   typedef qSlicerCoreApplication Superclass;
   qSlicerApplication(int &argc, char **argv);
   ~qSlicerApplication() override;

--- a/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxEventTranslatorPlayerTest1.cxx
@@ -38,12 +38,7 @@
 #include "qMRMLCheckableNodeComboBox.h"
 #include "qMRMLCheckableNodeComboBoxEventPlayer.h"
 #include "qMRMLSceneFactoryWidget.h"
-
-// VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -63,15 +58,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLCheckableNodeComboBoxEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
-
+  qMRMLWidget::postInitializeApplication();
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
   // ------------------------
   ctkEventTranslatorPlayerWidget etpWidget;

--- a/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLCheckableNodeComboBoxTest1.cxx
@@ -32,23 +32,15 @@
 // MRML includes
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLCheckableNodeComboBoxTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLCheckableNodeComboBox nodeSelector;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetEventTranslatorPlayerTest1.cxx
@@ -42,10 +42,7 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -68,14 +65,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLClipNodeWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLClipNodeWidgetTest1.cxx
@@ -33,23 +33,15 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLClipNodeWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkSmartPointer< vtkMRMLClipModelsNode > clipNode =
     vtkSmartPointer< vtkMRMLClipModelsNode >::New();

--- a/Libs/MRML/Widgets/Testing/qMRMLCollapsibleButtonEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLCollapsibleButtonEventTranslatorPlayerTest1.cxx
@@ -38,10 +38,7 @@
 #include "qMRMLCollapsibleButton.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -61,14 +58,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLCollapsibleButtonEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorListViewEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorListViewEventTranslatorPlayerTest1.cxx
@@ -45,10 +45,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -68,14 +65,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLColorListViewEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorListViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorListViewTest1.cxx
@@ -36,23 +36,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLColorListViewTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QWidget topLevel;
   qMRMLColorListView ColorListView;

--- a/Libs/MRML/Widgets/Testing/qMRMLColorModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorModelTest1.cxx
@@ -38,21 +38,13 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLColorModelTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLColorModel model;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetEventTranslatorPlayerTest1.cxx
@@ -49,10 +49,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -72,14 +69,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLColorPickerWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest1.cxx
@@ -34,23 +34,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLColorPickerWidgetTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLColorPickerWidget colorPickerWidget;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest2.cxx
@@ -39,21 +39,13 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLColorPickerWidgetTest2(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLColorPickerWidget colorPickerWidget;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest3.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorPickerWidgetTest3.cxx
@@ -36,23 +36,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLColorPickerWidgetTest3(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLColorPickerWidget colorPickerWidget;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxEventTranslatorPlayerTest1.cxx
@@ -43,10 +43,7 @@
 #include <vtkMRMLScene.h>
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -66,14 +63,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLColorTableComboBoxEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorTableComboBoxTest1.cxx
@@ -31,23 +31,15 @@
 // MRML includes
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLColorTableComboBoxTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLColorTableComboBox nodeSelector;
   qMRMLSceneFactoryWidget sceneFactory;

--- a/Libs/MRML/Widgets/Testing/qMRMLColorTableViewEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorTableViewEventTranslatorPlayerTest1.cxx
@@ -45,10 +45,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -68,14 +65,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLColorTableViewEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLColorTableViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLColorTableViewTest1.cxx
@@ -40,21 +40,13 @@
 // VTK includes
 #include <vtkNew.h>
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLColorTableViewTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QWidget topLevel;
   qMRMLColorTableView ColorTableView;

--- a/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetEventTranslatorPlayerTest1.cxx
@@ -42,10 +42,7 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -68,14 +65,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLDisplayNodeWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLDisplayNodeWidgetTest1.cxx
@@ -33,23 +33,15 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLDisplayNodeWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkSmartPointer< vtkMRMLModelDisplayNode > displayNode =
     vtkSmartPointer< vtkMRMLModelDisplayNode >::New();

--- a/Libs/MRML/Widgets/Testing/qMRMLLabelComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLabelComboBoxEventTranslatorPlayerTest1.cxx
@@ -42,10 +42,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -65,14 +62,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLLabelComboBoxEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
@@ -50,10 +50,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 namespace
 {
@@ -136,14 +133,9 @@ bool testLayoutManagerViewWidgetForThreeD(int line, qMRMLLayoutManager* layoutMa
 //------------------------------------------------------------------------------
 int qMRMLLayoutManagerTest1(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   qMRMLLayoutManager * layoutManager = new qMRMLLayoutManager();
 
   vtkNew<vtkMRMLApplicationLogic> applicationLogic;

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest2.cxx
@@ -35,10 +35,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // Common test driver includes
 #include "qMRMLWidgetCxxTests.h"
@@ -47,17 +44,10 @@
 // --------------------------------------------------------------------------
 int qMRMLLayoutManagerTest2(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  // Enables resource sharing between the OpenGL contexts used by classes like QOpenGLWidget and QQuickWidget
-  QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
+
   QWidget w;
   w.show();
   qMRMLLayoutManager* layoutManager = new qMRMLLayoutManager(&w, &w);

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest3.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest3.cxx
@@ -40,10 +40,7 @@
 // VTK includes
 #include <vtkCollection.h>
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // Common test driver includes
 #include "qMRMLWidgetCxxTests.h"
@@ -71,17 +68,10 @@ bool checkNumberOfItems(int line, qMRMLLayoutManager* layoutManager, int expecte
 // --------------------------------------------------------------------------
 int qMRMLLayoutManagerTest3(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  // Enables resource sharing between the OpenGL contexts used by classes like QOpenGLWidget and QQuickWidget
-  QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
+
   QWidget w;
   w.show();
   qMRMLLayoutManager* layoutManager = new qMRMLLayoutManager(&w, &w);

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest4.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest4.cxx
@@ -35,27 +35,16 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // Common test driver includes
 #include "qMRMLLayoutManagerTestHelper.cxx"
 
 int qMRMLLayoutManagerTest4(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  // Enables resource sharing between the OpenGL contexts used by classes like QOpenGLWidget and QQuickWidget
-  QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QWidget w;
   w.show();

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
@@ -43,10 +43,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // --------------------------------------------------------------------------
 bool checkNodeVisibility(int line,
@@ -370,17 +367,9 @@ bool runTests(vtkMRMLScene* scene,
 // --------------------------------------------------------------------------
 int qMRMLLayoutManagerVisibilityTest(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  // Enables resource sharing between the OpenGL contexts used by classes like QOpenGLWidget and QQuickWidget
-  QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QWidget w;
   w.show();

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
@@ -49,10 +49,7 @@
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>
 #include <vtkWeakPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 //------------------------------------------------------------------------------
 class qSlicerLayoutCustomSliceViewFactory
@@ -200,17 +197,9 @@ protected:
 //------------------------------------------------------------------------------
 int qMRMLLayoutManagerWithCustomFactoryTest(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  // Enables resource sharing between the OpenGL contexts used by classes like QOpenGLWidget and QQuickWidget
-  QApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QWidget w;
   w.show();

--- a/Libs/MRML/Widgets/Testing/qMRMLLinearTransformSliderEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLinearTransformSliderEventTranslatorPlayerTest1.cxx
@@ -38,10 +38,7 @@
 #include "qMRMLLinearTransformSlider.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -61,14 +58,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLLinearTransformSliderEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLinearTransformSliderTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLinearTransformSliderTest1.cxx
@@ -5,23 +5,15 @@
 #include "vtkSlicerConfigure.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLLinearTransformSliderTest1( int argc , char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  QApplication app( argc, argv );
+  qMRMLWidget::preInitializeApplication();
+  QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QWidget widget;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLListWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLListWidgetEventTranslatorPlayerTest1.cxx
@@ -39,10 +39,7 @@
 #include "qMRMLSceneFactoryWidget.h"
 
 // VTK
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -62,14 +59,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLListWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLListWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLListWidgetTest1.cxx
@@ -25,23 +25,15 @@
 #include "vtkSlicerConfigure.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLListWidgetTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLListWidget   mrmlItem;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetEventTranslatorPlayerTest1.cxx
@@ -38,10 +38,7 @@
 #include "qMRMLMatrixWidget.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -64,14 +61,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLMatrixWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLMatrixWidgetTest1.cxx
@@ -11,21 +11,13 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLMatrixWidgetTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QWidget widget;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLModelInfoWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLModelInfoWidgetTest1.cxx
@@ -34,23 +34,15 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 #include <vtkPolyData.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLModelInfoWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkSmartPointer< vtkMRMLModelNode > modelNode = vtkSmartPointer< vtkMRMLModelNode >::New();
 

--- a/Libs/MRML/Widgets/Testing/qMRMLModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLModelTest1.cxx
@@ -32,24 +32,16 @@
 #include "qMRMLSceneModel.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 
 // STD includes
 
 int qMRMLModelTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   try
     {

--- a/Libs/MRML/Widgets/Testing/qMRMLModelTreeViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLModelTreeViewTest1.cxx
@@ -33,23 +33,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLModelTreeViewTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew<vtkMRMLModelNode> modelNode;
   vtkNew<vtkMRMLModelDisplayNode> displayModelNode;

--- a/Libs/MRML/Widgets/Testing/qMRMLNavigationViewEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNavigationViewEventTranslatorPlayerTest1.cxx
@@ -47,10 +47,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -70,14 +67,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLNavigationViewEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNavigationViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNavigationViewTest1.cxx
@@ -37,23 +37,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLNavigationViewTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLNavigationView navigationView;
   navigationView.setWindowTitle("Navigation view");

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxEventTranslatorPlayerTest1.cxx
@@ -45,10 +45,7 @@
 #include <vtkMRMLScene.h>
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -68,14 +65,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLNodeComboBoxEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxLazyUpdateTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxLazyUpdateTest1.cxx
@@ -38,23 +38,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLNodeComboBoxLazyUpdateTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLNodeComboBox nodeSelector;
   qMRMLColorTableComboBox treeNodeSelector;

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest1.cxx
@@ -33,23 +33,15 @@
 #include <vtkMRMLScene.h>
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLNodeComboBoxTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLNodeComboBox nodeSelector;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest2.cxx
@@ -33,23 +33,15 @@
 #include <vtkMRMLScene.h>
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLNodeComboBoxTest2( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLNodeComboBox nodeSelector;
   qMRMLSceneFactoryWidget sceneFactory;

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest3.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest3.cxx
@@ -33,10 +33,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 
 // Common test driver includes
@@ -50,14 +47,9 @@ int qMRMLNodeComboBoxTest3( int argc, char * argv [] )
     return EXIT_FAILURE;
     }
 
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLNodeComboBox nodeSelector;
   nodeSelector.show();

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest4.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest4.cxx
@@ -34,22 +34,14 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 
 int qMRMLNodeComboBoxTest4( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLNodeComboBox nodeSelector;
   nodeSelector.setNodeTypes(QStringList() << "vtkMRMLScalarVolumeNode" << "vtkMRMLLabelMapVolumeNode");

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest5.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest5.cxx
@@ -35,21 +35,13 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLNodeComboBoxTest5( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLNodeComboBox nodeSelector;
   nodeSelector.setNodeTypes(QStringList("vtkMRMLCameraNode"));

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest6.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest6.cxx
@@ -35,22 +35,14 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 
 int qMRMLNodeComboBoxTest6( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLNodeComboBox nodeSelector;
   nodeSelector.setNodeTypes(QStringList("vtkMRMLModelNode"));

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest7.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest7.cxx
@@ -31,23 +31,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 
 // test the filtering with many cases
 int qMRMLNodeComboBoxTest7( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew<vtkMRMLScene> scene;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest8.cxx
@@ -34,10 +34,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 namespace
 {
@@ -62,14 +59,9 @@ bool checkActionCount(int line, qMRMLSceneModel* sceneModel, int expected)
 // test the adding of user menu actions
 int qMRMLNodeComboBoxTest8( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew<vtkMRMLScene> scene;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest9.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeComboBoxTest9.cxx
@@ -35,22 +35,14 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // test the filtering with many cases
 int qMRMLNodeComboBoxTest9( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew<vtkMRMLScene> scene;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLNodeFactoryTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLNodeFactoryTest1.cxx
@@ -33,24 +33,16 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
 
 int qMRMLNodeFactoryTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLNodeFactory nodeFactory;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLPlotViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLPlotViewTest1.cxx
@@ -43,21 +43,13 @@
 #include <vtkFloatArray.h>
 #include <vtkNew.h>
 #include <vtkTable.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLPlotViewTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew<vtkMRMLScene> scene;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLROIWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLROIWidgetEventTranslatorPlayerTest1.cxx
@@ -42,10 +42,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -65,14 +62,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLROIWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLRangeWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLRangeWidgetEventTranslatorPlayerTest1.cxx
@@ -37,10 +37,7 @@
 #include "qMRMLRangeWidget.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -61,14 +58,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLRangeWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxEventTranslatorPlayerTest1.cxx
@@ -42,10 +42,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -65,14 +62,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLScalarInvariantComboBoxEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLScalarInvariantComboBoxTest1.cxx
@@ -33,23 +33,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLScalarInvariantComboBoxTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew<vtkMRMLDiffusionTensorDisplayPropertiesNode> displayPropertiesNode;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneCategoryModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneCategoryModelTest1.cxx
@@ -37,23 +37,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLSceneCategoryModelTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLSceneCategoryModel model;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneColorTableModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneColorTableModelTest1.cxx
@@ -38,23 +38,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLSceneColorTableModelTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLSceneColorTableModel model;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest1.cxx
@@ -34,10 +34,7 @@
 #include "qMRMLSceneDisplayableModel.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
@@ -46,14 +43,9 @@
 
 int qMRMLSceneDisplayableModelTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLSceneDisplayableModel model;
   qMRMLSceneFactoryWidget sceneFactory(nullptr);

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneDisplayableModelTest2.cxx
@@ -34,21 +34,13 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLSceneDisplayableModelTest2(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   if( argc < 2 )
     {
     std::cerr << "Error: missing arguments" << std::endl;

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneFactoryWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneFactoryWidgetTest1.cxx
@@ -31,23 +31,15 @@
 #include <vtkMRMLScene.h>
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLSceneFactoryWidgetTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLSceneFactoryWidget   sceneFactory;
   sceneFactory.generateScene();

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneHierarchyModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneHierarchyModelTest1.cxx
@@ -38,23 +38,15 @@
 #include "vtkMRMLHierarchyNode.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLSceneHierarchyModelTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLSceneHierarchyModel model;
   qMRMLSceneFactoryWidget sceneFactory(nullptr);

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest1.cxx
@@ -34,24 +34,16 @@
 #include "qMRMLSceneModelHierarchyModel.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 
 // STD includes
 
 int qMRMLSceneModelHierarchyModelTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLSceneModelHierarchyModel model;
   qMRMLSceneFactoryWidget sceneFactory(nullptr);

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneModelHierarchyModelTest2.cxx
@@ -40,23 +40,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLSceneModelHierarchyModelTest2(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   if (argc < 2)
     {

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneModelTest1.cxx
@@ -33,23 +33,15 @@
 // MRML includes
 //
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLSceneModelTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLSceneModel   sceneModel;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest1.cxx
@@ -34,23 +34,15 @@
 #include "qMRMLTreeView.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLSceneTransformModelTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLSceneTransformModel model;
   qMRMLSceneFactoryWidget sceneFactory(nullptr);

--- a/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSceneTransformModelTest2.cxx
@@ -34,21 +34,13 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLSceneTransformModelTest2(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   if( argc < 2 )
     {
     std::cerr << "Error: missing arguments" << std::endl;

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetEventTranslatorPlayerTest1.cxx
@@ -43,10 +43,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -66,14 +63,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLSliceControllerWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetEventTranslatorPlayerTest1.cxx
@@ -50,10 +50,7 @@
 // VTK includes
 #include <vtkMultiThreader.h>
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -73,14 +70,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLSliceWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest1.cxx
@@ -41,21 +41,13 @@
 // VTK includes
 #include <vtkMultiThreader.h>
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLSliceWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   vtkMultiThreader::SetGlobalMaximumNumberOfThreads(1);
   if( argc < 2 )
     {

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceWidgetTest2.cxx
@@ -46,10 +46,7 @@
 // VTK includes
 #include <vtkCollection.h>
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 vtkMRMLScalarVolumeNode* loadVolume(const char* volume, vtkMRMLScene* scene)
 {
@@ -87,14 +84,9 @@ vtkMRMLScalarVolumeNode* loadVolume(const char* volume, vtkMRMLScene* scene)
 
 int qMRMLSliceWidgetTest2(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   if( argc < 2 )
     {
     std::cerr << "Error: missing arguments" << std::endl;

--- a/Libs/MRML/Widgets/Testing/qMRMLTableViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTableViewTest1.cxx
@@ -41,21 +41,13 @@
 #include <vtkDoubleArray.h>
 #include <vtkNew.h>
 #include <vtkTable.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLTableViewTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   // Create a table with some points in it...
   vtkNew<vtkTable> table;

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDViewControllerWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDViewControllerWidgetEventTranslatorPlayerTest1.cxx
@@ -38,10 +38,7 @@
 #include "qMRMLThreeDViewControllerWidget.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -61,14 +58,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLThreeDViewControllerWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDViewTest1.cxx
@@ -33,23 +33,15 @@
 // VTK includes
 #include <vtkCollection.h>
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLThreeDViewTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   qMRMLThreeDView view;
   view.show();
 

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDWidgetEventTranslatorPlayerTest1.cxx
@@ -46,10 +46,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -69,14 +66,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLThreeDWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLThreeDWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLThreeDWidgetTest1.cxx
@@ -37,10 +37,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -48,14 +45,9 @@
 
 int qMRMLThreeDWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   qMRMLThreeDWidget widget;
   widget.show();
 

--- a/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersEventTranslatorPlayerTest1.cxx
@@ -38,10 +38,7 @@
 #include "qMRMLTransformSliders.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -61,14 +58,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLTransformSlidersEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTransformSlidersTest1.cxx
@@ -8,23 +8,15 @@
 #include <vtkMatrix4x4.h>
 #include <vtkMRMLTransformNode.h>
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLTransformSlidersTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QWidget widget;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLTreeViewEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTreeViewEventTranslatorPlayerTest1.cxx
@@ -49,10 +49,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -83,14 +80,9 @@ void checkFinalWidgetState2(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLTreeViewEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLTreeViewTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLTreeViewTest1.cxx
@@ -28,10 +28,7 @@
 // VTK includes
 #include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLScene.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 #include <vtkTimerLog.h>
 
@@ -39,14 +36,9 @@
 
 int qMRMLTreeViewTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
   if( argc < 2 )
     {
     std::cerr << "Error: missing arguments" << std::endl;

--- a/Libs/MRML/Widgets/Testing/qMRMLUtf8Test1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLUtf8Test1.cxx
@@ -38,10 +38,7 @@
 
 // VTK includes
 #include "vtkNew.h"
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -69,14 +66,9 @@ void saveScene(void* vtkNotUsed(data))
 //------------------------------------------------------------------------------
 int qMRMLUtf8Test1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew<vtkMRMLScene> scene;
   myScene = scene.GetPointer();

--- a/Libs/MRML/Widgets/Testing/qMRMLUtilsTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLUtilsTest1.cxx
@@ -29,10 +29,7 @@
 #include <qMRMLUtils.h>
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -40,14 +37,9 @@
 
 int qMRMLUtilsTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   // Test color conversions
   QColor qcolor1 = QColor(255, 127, 0);

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeInfoWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeInfoWidgetEventTranslatorPlayerTest1.cxx
@@ -47,10 +47,7 @@
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkVersion.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -70,14 +67,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLVolumeInfoWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeInfoWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeInfoWidgetTest1.cxx
@@ -38,21 +38,13 @@
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkVersion.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLVolumeInfoWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew< vtkMRMLScalarVolumeNode > volumeNode;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.cxx
@@ -45,10 +45,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -68,14 +65,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest1.cxx
@@ -36,23 +36,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLVolumeThresholdWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   if( argc < 2 )
     {

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetTest2.cxx
@@ -42,23 +42,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLVolumeThresholdWidgetTest2(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   if( argc < 2 )
     {

--- a/Libs/MRML/Widgets/Testing/qMRMLWidgetsExportTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWidgetsExportTest1.cxx
@@ -4,24 +4,16 @@
 #include "vtkSlicerConfigure.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
 
 int qMRMLWidgetsExportTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   // qMRMLWidgetsExport   mrmlItem;
 

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.cxx
@@ -44,10 +44,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 #include <cstdlib>
@@ -67,14 +64,9 @@ void checkFinalWidgetState(void* data)
 //-----------------------------------------------------------------------------
 int qMRMLWindowLevelWidgetEventTranslatorPlayerTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   QString xmlDirectory = QString(argv[1]) + "/Libs/MRML/Widgets/Testing/";
 

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetTest1.cxx
@@ -36,23 +36,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLWindowLevelWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   if( argc < 2 )
     {

--- a/Libs/MRML/Widgets/qMRMLUtils.h
+++ b/Libs/MRML/Widgets/qMRMLUtils.h
@@ -43,6 +43,7 @@ class QMRML_WIDGETS_EXPORT qMRMLUtils : public QObject
 {
   Q_OBJECT;
 public:
+
   typedef qMRMLUtils Self;
   qMRMLUtils(QObject* parent = nullptr);
   ~qMRMLUtils() override;

--- a/Libs/MRML/Widgets/qMRMLWidget.h
+++ b/Libs/MRML/Widgets/qMRMLWidget.h
@@ -37,12 +37,28 @@ class QMRML_WIDGETS_EXPORT qMRMLWidget : public QWidget
   Q_OBJECT
 
 public:
+  enum OpenGLProfileType
+    {
+    OpenGLProfileDefault,
+    OpenGLProfileCore,
+    OpenGLProfileCompatibility
+    };
+
   typedef QWidget Superclass;
   explicit qMRMLWidget(QWidget *parent=nullptr, Qt::WindowFlags f=nullptr);
   ~qMRMLWidget() override;
 
   /// Return a pointer on the current MRML scene
   Q_INVOKABLE vtkMRMLScene* mrmlScene() const;
+
+  /// Initialization that needs to be performed before creating the Qt application object.
+  Q_INVOKABLE static void preInitializeApplication();
+
+  /// Initialization that needs to be performed after initializing the application but
+  /// _before_ creating any GUI widget.
+  /// It sets up OpenGL surface format and it is performed after initialization of the application
+  /// to allow the surface format to be set based on application settings.
+  Q_INVOKABLE static void postInitializeApplication(OpenGLProfileType openGLProfile = OpenGLProfileDefault);
 
 public slots:
   /// Set the MRML \a scene associated with the widget

--- a/Modules/Loadable/Annotations/Testing/Cxx/qMRMLAnnotationROIWidgetTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/qMRMLAnnotationROIWidgetTest1.cxx
@@ -14,24 +14,14 @@
 // MRML includes
 #include <vtkMRMLScene.h>
 
-// VTK includes
-#include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 //-----------------------------------------------------------------------------
 int qMRMLAnnotationROIWidgetTest1(int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkSmartPointer<vtkMRMLScene> scene =
     vtkSmartPointer<vtkMRMLScene>::New();

--- a/Modules/Loadable/Annotations/Testing/Cxx/qMRMLSceneAnnotationModelAndAnnotationTreeWidgetTest1.cxx
+++ b/Modules/Loadable/Annotations/Testing/Cxx/qMRMLSceneAnnotationModelAndAnnotationTreeWidgetTest1.cxx
@@ -21,10 +21,7 @@
 // VTK includes
 #include "vtkMRMLCoreTestingMacros.h"
 #include <vtkEventBroker.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 #include "GUI/qMRMLAnnotationTreeView.h"
 #include "Logic/vtkSlicerAnnotationModuleLogic.h"
@@ -40,14 +37,9 @@
 
 int qMRMLSceneAnnotationModelAndAnnotationTreeViewTest1(int argc, char * argv [])
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   qMRMLSceneFactoryWidget sceneFactory(0);
 

--- a/Modules/Loadable/Colors/Testing/Cxx/qSlicerColorsModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Colors/Testing/Cxx/qSlicerColorsModuleWidgetTest1.cxx
@@ -36,10 +36,7 @@
 #include <vtkMRMLScene.h>
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
@@ -47,14 +44,9 @@
 
 int qSlicerColorsModuleWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  qSlicerApplication app(argc, argv);
+  qMRMLWidget::preInitializeApplication();
+  QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkSmartPointer<vtkMRMLScene> scene = vtkSmartPointer<vtkMRMLScene>::New();
   vtkSmartPointer<vtkMRMLColorLogic> colorLogic = vtkSmartPointer<vtkMRMLColorLogic>::New();

--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest1.cxx
@@ -40,22 +40,14 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 //-----------------------------------------------------------------------------
 int qSlicerModelsModuleWidgetTest1( int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  qSlicerApplication app(argc, argv);
+  qMRMLWidget::preInitializeApplication();
+  QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   if (argc < 2)
     {

--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTestScene.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTestScene.cxx
@@ -41,22 +41,14 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 //-----------------------------------------------------------------------------
 int qSlicerModelsModuleWidgetTestScene( int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  qSlicerApplication app(argc, argv);
+  qMRMLWidget::preInitializeApplication();
+  QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   if (argc < 2)
     {

--- a/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest1.cxx
+++ b/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest1.cxx
@@ -33,23 +33,15 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLModelDisplayNodeWidgetTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkSmartPointer<vtkMRMLModelDisplayNode> modelDisplayNode =
     vtkSmartPointer<vtkMRMLModelDisplayNode>::New();

--- a/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest2.cxx
+++ b/Modules/Loadable/Models/Widgets/Testing/Cxx/qMRMLModelDisplayNodeWidgetTest2.cxx
@@ -35,23 +35,15 @@
 // VTK includes
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLModelDisplayNodeWidgetTest2( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   if (argc < 2)
     {

--- a/Modules/Loadable/Plots/Widgets/Testing/Cxx/qMRMLPlotPropertiesWidgetTest1.cxx
+++ b/Modules/Loadable/Plots/Widgets/Testing/Cxx/qMRMLPlotPropertiesWidgetTest1.cxx
@@ -47,21 +47,13 @@
 // VTK includes
 #include <vtkNew.h>
 #include <vtkTable.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qMRMLPlotPropertiesWidgetTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew<vtkMRMLScene> scene;
   vtkNew<vtkMRMLColorLogic> colorLogic;

--- a/Modules/Loadable/Tables/Widgets/Testing/Cxx/qSlicerTableColumnPropertiesWidgetTest1.cxx
+++ b/Modules/Loadable/Tables/Widgets/Testing/Cxx/qSlicerTableColumnPropertiesWidgetTest1.cxx
@@ -40,21 +40,13 @@
 // VTK includes
 #include <vtkNew.h>
 #include <vtkTable.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 int qSlicerTableColumnPropertiesWidgetTest1( int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   // Create a table with some points in it...
   vtkNew<vtkTable> table;

--- a/Modules/Loadable/Transforms/Widgets/Testing/qMRMLTransformDisplayNodeWidgetTest1.cxx
+++ b/Modules/Loadable/Transforms/Widgets/Testing/qMRMLTransformDisplayNodeWidgetTest1.cxx
@@ -37,23 +37,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLTransformDisplayNodeWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew<vtkMRMLScene> scene;
   vtkNew< vtkMRMLTransformNode > transformNode;

--- a/Modules/Loadable/Transforms/Widgets/Testing/qMRMLTransformInfoWidgetTest1.cxx
+++ b/Modules/Loadable/Transforms/Widgets/Testing/qMRMLTransformInfoWidgetTest1.cxx
@@ -36,23 +36,15 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // STD includes
 
 int qMRMLTransformInfoWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkNew< vtkMRMLTransformNode > transformNode;
 

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/qMRMLVolumePropertyNodeWidgetTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/qMRMLVolumePropertyNodeWidgetTest1.cxx
@@ -32,10 +32,7 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // this test only works on VTKv6 and later
 
@@ -50,14 +47,9 @@ VTK_MODULE_INIT(vtkRenderingContextOpenGL);
 
 int qMRMLVolumePropertyNodeWidgetTest1(int argc, char * argv [] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkSmartPointer<vtkMRMLVolumePropertyNode> volumePropertyNode =
     vtkSmartPointer<vtkMRMLVolumePropertyNode>::New();

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest1.cxx
@@ -32,21 +32,11 @@
 // MRML includes
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 //-----------------------------------------------------------------------------
 int qSlicerVolumeRenderingModuleWidgetTest1( int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
   qSlicerApplication app(argc, argv);
 
   qSlicerVolumeRenderingModule module;

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest2.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/qSlicerVolumeRenderingModuleWidgetTest2.cxx
@@ -37,10 +37,7 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // ITK includes
 #include <itkConfigure.h>
@@ -50,13 +47,6 @@
 int qSlicerVolumeRenderingModuleWidgetTest2( int argc, char * argv[] )
 {
   itk::itkFactoryRegistration();
-
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
 
   qSlicerApplication app(argc, argv);
 

--- a/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesIOOptionsWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesIOOptionsWidgetTest1.cxx
@@ -36,22 +36,14 @@
 #include "vtkMRMLScene.h"
 
 // VTK includes
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 //-----------------------------------------------------------------------------
 int qSlicerVolumesIOOptionsWidgetTest1( int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  qSlicerApplication app(argc, argv);
+  qMRMLWidget::preInitializeApplication();
+  QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   // set up the color nodes for access from the widget
   vtkSlicerApplicationLogic* appLogic = qSlicerCoreApplication::application()->applicationLogic();

--- a/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/qSlicerVolumesModuleWidgetTest1.cxx
@@ -35,10 +35,7 @@
 
 // VTK includes
 #include <vtkNew.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 // ITK includes
 #include <itkConfigure.h>
@@ -49,14 +46,9 @@ int qSlicerVolumesModuleWidgetTest1( int argc, char * argv[] )
 {
   itk::itkFactoryRegistration();
 
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
-  qSlicerApplication app(argc, argv);
+  qMRMLWidget::preInitializeApplication();
+  QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   if (argc < 2)
     {

--- a/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest1.cxx
@@ -35,22 +35,14 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 //-----------------------------------------------------------------------------
 int qSlicerDTISliceDisplayWidgetTest1( int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkSmartPointer<vtkMRMLScene> scene = vtkSmartPointer<vtkMRMLScene>::New();
   vtkSmartPointer<vtkMRMLDiffusionTensorDisplayPropertiesNode> propertiesNode =

--- a/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest2.cxx
+++ b/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDTISliceDisplayWidgetTest2.cxx
@@ -32,16 +32,13 @@
 // MRML includes
 #include <vtkMRMLDiffusionTensorVolumeSliceDisplayNode.h>
 #include <vtkMRMLDiffusionTensorDisplayPropertiesNode.h>
+#include <qMRMLWidget.h>
 
 // VTK includes
 #include <vtkSmartPointer.h>
 #include <vtkImageData.h>
 #include <vtkNew.h>
 #include <vtkTrivialProducer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
 
 // ITK includes
 #include <itkConfigure.h>
@@ -52,14 +49,9 @@ int qSlicerDTISliceDisplayWidgetTest2( int argc, char * argv[] )
 {
   itk::itkFactoryRegistration();
 
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   if (argc < 2)
     {

--- a/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDiffusionTensorVolumeDisplayWidgetTest1.cxx
+++ b/Modules/Loadable/Volumes/Widgets/Testing/Cxx/qSlicerDiffusionTensorVolumeDisplayWidgetTest1.cxx
@@ -35,22 +35,14 @@
 
 // VTK includes
 #include <vtkSmartPointer.h>
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-#include <QSurfaceFormat>
-#include <QVTKOpenGLWidget.h>
-#endif
+#include "qMRMLWidget.h"
 
 //-----------------------------------------------------------------------------
 int qSlicerDiffusionTensorVolumeDisplayWidgetTest1( int argc, char * argv[] )
 {
-#ifdef Slicer_VTK_USE_QVTKOPENGLWIDGET
-  // Set default surface format for QVTKOpenGLWidget
-  QSurfaceFormat format = QVTKOpenGLWidget::defaultFormat();
-  format.setSamples(0);
-  QSurfaceFormat::setDefaultFormat(format);
-#endif
-
+  qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
+  qMRMLWidget::postInitializeApplication();
 
   vtkSmartPointer<vtkMRMLScene> scene = vtkSmartPointer<vtkMRMLScene>::New();
   vtkSmartPointer<vtkMRMLDiffusionTensorVolumeDisplayNode> displayNode =


### PR DESCRIPTION
On Windows, OpenGL compatibility profile is used by default.
For troubleshooting purposes, compatibility/core profile can be explicitly selected by modifying General/OpenGLProfile application settings key (valid values: default, compatibility, core).

Implemented OpenGL profile mode setting in qMRMLWidget so that it can be accessed easily from all tests. It is in postInitializeApplication() method to allow configuring the surface format based on application settings (which are not available before the application object is created).