### PR TITLE
BUG: fix linking of threeD views

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
@@ -345,6 +345,16 @@ bool vtkMRMLCameraWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* e
       processedEvent = false;
     }
 
+  if (processedEvent)
+    {
+    // invoke interaction event for compatibility with pre-camera-widget
+    // behavior of vtk event processing.  This enables events to pass
+    // through the qMRMLThreeDView to the cameraNode
+    // for broadcast to other cameras
+    vtkRenderWindowInteractor* interactor = this->Renderer->GetRenderWindow()->GetInteractor();
+    interactor->InvokeEvent(vtkCommand::InteractionEvent);
+    }
+
   return processedEvent;
 }
 


### PR DESCRIPTION
The new vtkMRMLCameraWidget captures the InteractionEvents
and so the qMRMLThreeDView never invoked the
CameraInteractionEvents that cause the views to be linked.

With this change the camera widget invokes an interaction
event on the render window interactor when it has been
processed so that the ViewLinkLogic knows to broadcast
the camera view.