### PR TITLE
ENH: add option for black or white ruler

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -446,10 +446,10 @@ const char* vtkMRMLAbstractViewNode::GetRulerTypeAsString(int id)
 int vtkMRMLAbstractViewNode::GetRulerTypeFromString(const char* name)
 {
   if (name == nullptr)
-  {
+    {
     // invalid name
     return -1;
-  }
+    }
   for (int i=0; i<RulerType_Last; i++)
     {
     if (strcmp(name, GetRulerTypeAsString(i))==0)
@@ -479,10 +479,10 @@ const char* vtkMRMLAbstractViewNode::GetRulerColorAsString(int id)
 int vtkMRMLAbstractViewNode::GetRulerColorFromString(const char* name)
 {
   if (name == nullptr)
-  {
+    {
     // invalid name
     return -1;
-  }
+    }
   for (int i=0; i<RulerColor_Last; i++)
     {
     if (strcmp(name, GetRulerColorAsString(i))==0)

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -469,6 +469,7 @@ const char* vtkMRMLAbstractViewNode::GetRulerColorAsString(int id)
     {
     case RulerColorWhite: return "white";
     case RulerColorBlack: return "black";
+    case RulerColorYellow: return "yellow";
     default:
       // invalid id
       return "";

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -47,6 +47,7 @@ vtkMRMLAbstractViewNode::vtkMRMLAbstractViewNode()
 , OrientationMarkerSize(OrientationMarkerSizeMedium)
 , RulerEnabled(false)
 , RulerType(RulerTypeNone)
+, RulerColor(RulerColorWhite)
 {
   this->BackgroundColor[0] = 0.0;
   this->BackgroundColor[1] = 0.0;
@@ -103,6 +104,7 @@ void vtkMRMLAbstractViewNode::WriteXML(ostream& of, int nIndent)
     {
     vtkMRMLWriteXMLEnumMacro(rulerType, RulerType);
     }
+  vtkMRMLWriteXMLEnumMacro(rulerColor, RulerColor);
   vtkMRMLWriteXMLEndMacro();
 
   of << " AxisLabels=\"";
@@ -148,6 +150,7 @@ void vtkMRMLAbstractViewNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLEnumMacro(orientationMarkerType, OrientationMarkerType);
   vtkMRMLReadXMLEnumMacro(orientationMarkerSize, OrientationMarkerSize);
   vtkMRMLReadXMLEnumMacro(rulerType, RulerType);
+  vtkMRMLReadXMLEnumMacro(rulerColor, RulerColor);
   vtkMRMLReadXMLEndMacro();
 
   const char* attName;
@@ -229,6 +232,7 @@ void vtkMRMLAbstractViewNode::Copy(vtkMRMLNode *anode)
     {
     vtkMRMLCopyEnumMacro(RulerType);
     }
+  vtkMRMLCopyEnumMacro(RulerColor);
   vtkMRMLCopyEndMacro();
 
   vtkMRMLAbstractViewNode *node = (vtkMRMLAbstractViewNode *) anode;
@@ -283,6 +287,7 @@ void vtkMRMLAbstractViewNode::PrintSelf(ostream& os, vtkIndent indent)
     {
     vtkMRMLPrintEnumMacro(RulerType);
     }
+  vtkMRMLPrintEnumMacro(RulerColor);
   vtkMRMLPrintEndMacro();
 
   os << indent << " AxisLabels: ";
@@ -448,6 +453,39 @@ int vtkMRMLAbstractViewNode::GetRulerTypeFromString(const char* name)
   for (int i=0; i<RulerType_Last; i++)
     {
     if (strcmp(name, GetRulerTypeAsString(i))==0)
+      {
+      // found a matching name
+      return i;
+      }
+    }
+  // unknown name
+  return -1;
+}
+
+//-----------------------------------------------------------
+const char* vtkMRMLAbstractViewNode::GetRulerColorAsString(int id)
+{
+  switch (id)
+    {
+    case RulerColorWhite: return "white";
+    case RulerColorBlack: return "black";
+    default:
+      // invalid id
+      return "";
+    }
+}
+
+//-----------------------------------------------------------
+int vtkMRMLAbstractViewNode::GetRulerColorFromString(const char* name)
+{
+  if (name == nullptr)
+  {
+    // invalid name
+    return -1;
+  }
+  for (int i=0; i<RulerColor_Last; i++)
+    {
+    if (strcmp(name, GetRulerColorAsString(i))==0)
       {
       // found a matching name
       return i;

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -260,6 +260,7 @@ public:
   {
     RulerColorWhite=0,
     RulerColorBlack,
+    RulerColorYellow,
     RulerColor_Last // insert valid types above this line
   };
 

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -238,13 +238,29 @@ public:
   static const char* GetRulerTypeAsString(int id);
   static int GetRulerTypeFromString(const char* name);
 
-  /// Enum to specify orientation marker types
+  /// Enum to specify ruler types
   enum RulerTypeType
   {
     RulerTypeNone=0,
     RulerTypeThin,
     RulerTypeThick,
     RulerType_Last // insert valid types above this line
+  };
+
+  /// Get/Set ruler color (e.g., white or black)
+  vtkSetMacro(RulerColor, int);
+  vtkGetMacro(RulerColor, int);
+
+  /// Convert between ruler color ID and name
+  static const char* GetRulerColorAsString(int id);
+  static int GetRulerColorFromString(const char* name);
+
+  /// Enum to specify ruler colors
+  enum RulerColorType
+  {
+    RulerColorWhite=0,
+    RulerColorBlack,
+    RulerColor_Last // insert valid types above this line
   };
 
   /// Get/Set labels of coordinate system axes.
@@ -307,6 +323,7 @@ protected:
   /// these parameters define how to display the ruler.
   bool RulerEnabled;
   int RulerType;
+  int RulerColor;
 
   ///
   /// Labels of coordinate system axes

--- a/Libs/MRML/Core/vtkMRMLViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLViewNode.h
@@ -275,6 +275,7 @@ public:
     OrientationMarkerTypeFlag,
     OrientationMarkerSizeFlag,
     RulerTypeFlag,
+    RulerColorFlag,
     UseDepthPeelingFlag,
     FPSVisibleFlag,
   };

--- a/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.cxx
@@ -375,6 +375,21 @@ void vtkMRMLRulerDisplayableManager::vtkInternal::UpdateRuler()
     break;
   }
 
+  int color = viewNode->GetRulerColor();
+  switch (color)
+  {
+  case vtkMRMLAbstractViewNode::RulerColorWhite:
+    lineProperty->SetColor(1,1,1);
+    textProperty->SetColor(1,1,1);
+    break;
+  case vtkMRMLAbstractViewNode::RulerColorBlack:
+    lineProperty->SetColor(0,0,0);
+    textProperty->SetColor(0,0,0);
+    break;
+  default:
+    break;
+  }
+
   this->ShowActors(true);
 }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.cxx
@@ -386,6 +386,10 @@ void vtkMRMLRulerDisplayableManager::vtkInternal::UpdateRuler()
     lineProperty->SetColor(0,0,0);
     textProperty->SetColor(0,0,0);
     break;
+  case vtkMRMLAbstractViewNode::RulerColorYellow:
+    lineProperty->SetColor(1,1,0);
+    textProperty->SetColor(1,1,0);
+    break;
   default:
     break;
   }

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
@@ -1135,6 +1135,22 @@
     <string>Show thick ruler</string>
    </property>
   </action>
+  <action name="actionRulerColorWhite">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>White ruler</string>
+   </property>
+  </action>
+  <action name="actionRulerColorBlack">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Black ruler</string>
+   </property>
+  </action>
   <action name="actionSegmentationOutlineFill">
    <property name="icon">
     <iconset resource="../qMRMLWidgets.qrc">

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
@@ -1151,6 +1151,14 @@
     <string>Black ruler</string>
    </property>
   </action>
+  <action name="actionRulerColorYellow">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Yellow ruler</string>
+   </property>
+  </action>
   <action name="actionSegmentationOutlineFill">
    <property name="icon">
     <iconset resource="../qMRMLWidgets.qrc">

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLThreeDViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLThreeDViewControllerWidget.ui
@@ -567,6 +567,22 @@
     <string>Show thick ruler</string>
    </property>
   </action>
+  <action name="actionRulerColorWhite">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>White ruler</string>
+   </property>
+  </action>
+  <action name="actionRulerColorBlack">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Black ruler</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLThreeDViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLThreeDViewControllerWidget.ui
@@ -583,6 +583,14 @@
     <string>Black ruler</string>
    </property>
   </action>
+  <action name="actionRulerColorYellow">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Yellow ruler</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -1506,6 +1506,7 @@ void qMRMLSliceControllerWidgetPrivate::setupRulerMenu()
   this->RulerColorMapper = new ctkSignalMapper(this->PopupWidget);
   this->RulerColorMapper->setMapping(this->actionRulerColorBlack, vtkMRMLAbstractViewNode::RulerColorBlack);
   this->RulerColorMapper->setMapping(this->actionRulerColorWhite, vtkMRMLAbstractViewNode::RulerColorWhite);
+  this->RulerColorMapper->setMapping(this->actionRulerColorYellow, vtkMRMLAbstractViewNode::RulerColorYellow);
   QActionGroup* rulerTypesActions = new QActionGroup(this->PopupWidget);
   rulerTypesActions->setExclusive(true);
   rulerTypesActions->addAction(this->actionRulerTypeNone);
@@ -1516,6 +1517,7 @@ void qMRMLSliceControllerWidgetPrivate::setupRulerMenu()
   QActionGroup* rulerColorActions = new QActionGroup(this->PopupWidget);
   rulerColorActions->addAction(this->actionRulerColorWhite);
   rulerColorActions->addAction(this->actionRulerColorBlack);
+  rulerColorActions->addAction(this->actionRulerColorYellow);
   QObject::connect(this->RulerColorMapper, SIGNAL(mapped(int)),q, SLOT(setRulerColor(int)));
   QObject::connect(rulerColorActions, SIGNAL(triggered(QAction*)),this->RulerColorMapper, SLOT(map(QAction*)));
   // Menu

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -982,6 +982,13 @@ void qMRMLSliceControllerWidgetPrivate::updateWidgetFromMRMLSliceNode()
     {
     action->setChecked(true);
     }
+
+  // Ruler Color (check the selected option)
+  action = qobject_cast<QAction*>(this->RulerColorMapper->mapping(this->MRMLSliceNode->GetRulerColor()));
+  if (action)
+    {
+    action->setChecked(true);
+    }
 }
 
 // --------------------------------------------------------------------------
@@ -1496,6 +1503,9 @@ void qMRMLSliceControllerWidgetPrivate::setupRulerMenu()
   this->RulerTypesMapper->setMapping(this->actionRulerTypeNone, vtkMRMLAbstractViewNode::RulerTypeNone);
   this->RulerTypesMapper->setMapping(this->actionRulerTypeThin, vtkMRMLAbstractViewNode::RulerTypeThin);
   this->RulerTypesMapper->setMapping(this->actionRulerTypeThick, vtkMRMLAbstractViewNode::RulerTypeThick);
+  this->RulerColorMapper = new ctkSignalMapper(this->PopupWidget);
+  this->RulerColorMapper->setMapping(this->actionRulerColorBlack, vtkMRMLAbstractViewNode::RulerColorBlack);
+  this->RulerColorMapper->setMapping(this->actionRulerColorWhite, vtkMRMLAbstractViewNode::RulerColorWhite);
   QActionGroup* rulerTypesActions = new QActionGroup(this->PopupWidget);
   rulerTypesActions->setExclusive(true);
   rulerTypesActions->addAction(this->actionRulerTypeNone);
@@ -1503,11 +1513,18 @@ void qMRMLSliceControllerWidgetPrivate::setupRulerMenu()
   rulerTypesActions->addAction(this->actionRulerTypeThick);
   QObject::connect(this->RulerTypesMapper, SIGNAL(mapped(int)),q, SLOT(setRulerType(int)));
   QObject::connect(rulerTypesActions, SIGNAL(triggered(QAction*)),this->RulerTypesMapper, SLOT(map(QAction*)));
+  QActionGroup* rulerColorActions = new QActionGroup(this->PopupWidget);
+  rulerColorActions->addAction(this->actionRulerColorWhite);
+  rulerColorActions->addAction(this->actionRulerColorBlack);
+  QObject::connect(this->RulerColorMapper, SIGNAL(mapped(int)),q, SLOT(setRulerColor(int)));
+  QObject::connect(rulerColorActions, SIGNAL(triggered(QAction*)),this->RulerColorMapper, SLOT(map(QAction*)));
   // Menu
   QMenu* rulerMenu = new QMenu(tr("Ruler"), this->PopupWidget);
   rulerMenu->setObjectName("rulerMenu");
   this->RulerButton->setMenu(rulerMenu);
   rulerMenu->addActions(rulerTypesActions->actions());
+  rulerMenu->addSeparator();
+  rulerMenu->addActions(rulerColorActions->actions());
 }
 
 // --------------------------------------------------------------------------
@@ -2780,6 +2797,26 @@ void qMRMLSliceControllerWidget::setRulerType(int newRulerType)
     if (node == d->MRMLSliceNode || this->isLinked())
       {
       node->SetRulerType(newRulerType);
+      }
+    }
+}
+
+// --------------------------------------------------------------------------
+void qMRMLSliceControllerWidget::setRulerColor(int newRulerColor)
+{
+  Q_D(qMRMLSliceControllerWidget);
+  vtkSmartPointer<vtkCollection> nodes = d->saveNodesForUndo("vtkMRMLSliceNode");
+  if (!nodes.GetPointer())
+    {
+    return;
+    }
+  vtkMRMLSliceNode* node = nullptr;
+  vtkCollectionSimpleIterator it;
+  for (nodes->InitTraversal(it);(node = static_cast<vtkMRMLSliceNode*>(nodes->GetNextItemAsObject(it)));)
+    {
+    if (node == d->MRMLSliceNode || this->isLinked())
+      {
+      node->SetRulerColor(newRulerColor);
       }
     }
 }

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
@@ -265,6 +265,7 @@ public slots:
 
   // Ruler
   void setRulerType(int type);
+  void setRulerColor(int color);
 
   // Lightbox
   void setLightbox(int rows, int columns);

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
@@ -210,6 +210,7 @@ public:
   ctkSignalMapper*                    OrientationMarkerSizesMapper;
 
   ctkSignalMapper*                    RulerTypesMapper;
+  ctkSignalMapper*                    RulerColorMapper;
 };
 
 #endif

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -203,10 +203,12 @@ void qMRMLThreeDViewControllerWidgetPrivate::setupPopupUi()
   this->RulerColorMapper = new ctkSignalMapper(this->PopupWidget);
   this->RulerColorMapper->setMapping(this->actionRulerColorWhite, vtkMRMLAbstractViewNode::RulerColorWhite);
   this->RulerColorMapper->setMapping(this->actionRulerColorBlack, vtkMRMLAbstractViewNode::RulerColorBlack);
+  this->RulerColorMapper->setMapping(this->actionRulerColorYellow, vtkMRMLAbstractViewNode::RulerColorYellow);
   QActionGroup* rulerColorActions = new QActionGroup(this->PopupWidget);
   rulerColorActions->setExclusive(true);
   rulerColorActions->addAction(this->actionRulerColorWhite);
   rulerColorActions->addAction(this->actionRulerColorBlack);
+  rulerColorActions->addAction(this->actionRulerColorYellow);
   QObject::connect(this->RulerColorMapper, SIGNAL(mapped(int)),q, SLOT(setRulerColor(int)));
   QObject::connect(rulerColorActions, SIGNAL(triggered(QAction*)),this->RulerColorMapper, SLOT(map(QAction*)));
 

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -199,11 +199,24 @@ void qMRMLThreeDViewControllerWidgetPrivate::setupPopupUi()
   rulerTypesActions->addAction(this->actionRulerTypeThick);
   QObject::connect(this->RulerTypesMapper, SIGNAL(mapped(int)),q, SLOT(setRulerType(int)));
   QObject::connect(rulerTypesActions, SIGNAL(triggered(QAction*)),this->RulerTypesMapper, SLOT(map(QAction*)));
+  // Color
+  this->RulerColorMapper = new ctkSignalMapper(this->PopupWidget);
+  this->RulerColorMapper->setMapping(this->actionRulerColorWhite, vtkMRMLAbstractViewNode::RulerColorWhite);
+  this->RulerColorMapper->setMapping(this->actionRulerColorBlack, vtkMRMLAbstractViewNode::RulerColorBlack);
+  QActionGroup* rulerColorActions = new QActionGroup(this->PopupWidget);
+  rulerColorActions->setExclusive(true);
+  rulerColorActions->addAction(this->actionRulerColorWhite);
+  rulerColorActions->addAction(this->actionRulerColorBlack);
+  QObject::connect(this->RulerColorMapper, SIGNAL(mapped(int)),q, SLOT(setRulerColor(int)));
+  QObject::connect(rulerColorActions, SIGNAL(triggered(QAction*)),this->RulerColorMapper, SLOT(map(QAction*)));
+
   // Menu
   QMenu* rulerMenu = new QMenu(tr("Ruler"), this->PopupWidget);
   rulerMenu->setObjectName("rulerMenu");
   this->RulerButton->setMenu(rulerMenu);
   rulerMenu->addActions(rulerTypesActions->actions());
+  rulerMenu->addSeparator();
+  rulerMenu->addActions(rulerColorActions->actions());
 
   // More controls
   QMenu* moreMenu = new QMenu("More", this->PopupWidget);
@@ -839,6 +852,20 @@ void qMRMLThreeDViewControllerWidget::setRulerType(int newRulerType)
     d->ViewNode->SetRenderMode(vtkMRMLViewNode::Orthographic);
     d->ViewLogic->EndViewNodeInteraction();
     }
+}
+
+// --------------------------------------------------------------------------
+void qMRMLThreeDViewControllerWidget::setRulerColor(int newRulerColor)
+{
+  Q_D(qMRMLThreeDViewControllerWidget);
+  if (!d->ViewNode)
+    {
+    return;
+    }
+
+  d->ViewLogic->StartViewNodeInteraction(vtkMRMLViewNode::RulerColorFlag);
+  d->ViewNode->SetRulerColor(newRulerColor);
+  d->ViewLogic->EndViewNodeInteraction();
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
@@ -129,6 +129,7 @@ public slots:
   void setOrientationMarkerType(int type);
   void setOrientationMarkerSize(int size);
   void setRulerType(int type);
+  void setRulerColor(int color);
 
 protected slots:
   void updateWidgetFromMRMLView();

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget_p.h
@@ -79,6 +79,7 @@ public:
   ctkSignalMapper*                    OrientationMarkerTypesMapper;
   ctkSignalMapper*                    OrientationMarkerSizesMapper;
   ctkSignalMapper*                    RulerTypesMapper;
+  ctkSignalMapper*                    RulerColorMapper;
 
   QString                             ThreeDViewLabel;
   QToolButton*                        CenterToolButton;


### PR DESCRIPTION
Works for both slice and threeD views.

Saves and restores with mrml scene.

Is propagated with other attributes when views are linked.