### PR TITLE
Cherry-pick missed bug fix into master-410

### DIFF
--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -269,6 +269,7 @@ class ScriptedLoadableModuleLogic():
       return
 
     node = slicer.mrmlScene.CreateNodeByClass("vtkMRMLScriptedModuleNode")
+    node.UnRegister(None) # object is owned by the Python variable now
     if self.isSingletonParameterNode:
       node.SetSingletonTag( self.moduleName )
     # Add module name in an attribute to allow filtering in node selector widgets


### PR DESCRIPTION
d9e3d6b was backported into the master-410 branch as part of the Slicer 4.10.2 release, but this memory leak bug fix for that commit was accidentally not included in the backport.

I guess for anyone who builds this branch from source it is a bug fix, though I'm not really expecting there to be a 4.10.3 release.