### PR TITLE
Enabling PUBLIC/PRIVATE/INTERFACE keyword

### DIFF
--- a/CMake/SlicerMacroBuildLoadableModule.cmake
+++ b/CMake/SlicerMacroBuildLoadableModule.cmake
@@ -218,8 +218,9 @@ macro(slicerMacroBuildLoadableModule)
   set_target_properties(${lib_name} PROPERTIES LABELS ${lib_name})
 
   target_link_libraries(${lib_name}
-    ${Slicer_GUI_LIBRARY}
     ${LOADABLEMODULE_TARGET_LIBRARIES}
+    PUBLIC
+      ${Slicer_GUI_LIBRARY}
     )
 
   # Apply user-defined properties to the library target.

--- a/CMake/SlicerMacroBuildLoadableModule.cmake
+++ b/CMake/SlicerMacroBuildLoadableModule.cmake
@@ -218,6 +218,8 @@ macro(slicerMacroBuildLoadableModule)
   set_target_properties(${lib_name} PROPERTIES LABELS ${lib_name})
 
   target_link_libraries(${lib_name}
+    # The two PUBLIC keywords are not a duplication, they allow developers to 
+    # include PRIVATE/INTERFACE keywords in their library list
     PUBLIC
       ${LOADABLEMODULE_TARGET_LIBRARIES}
     PUBLIC

--- a/CMake/SlicerMacroBuildLoadableModule.cmake
+++ b/CMake/SlicerMacroBuildLoadableModule.cmake
@@ -218,7 +218,8 @@ macro(slicerMacroBuildLoadableModule)
   set_target_properties(${lib_name} PROPERTIES LABELS ${lib_name})
 
   target_link_libraries(${lib_name}
-    ${LOADABLEMODULE_TARGET_LIBRARIES}
+    PUBLIC
+      ${LOADABLEMODULE_TARGET_LIBRARIES}
     PUBLIC
       ${Slicer_GUI_LIBRARY}
     )


### PR DESCRIPTION
Macro slicerMacroBuildLoadableModule now supports PUBLIC/PRIVATE/INTERFACE keyword for target_link_libraries