### PR TITLE
ENH: Allow Slicer install on Windows for non-admin users

### DIFF
--- a/CMake/SlicerApplicationOptions.cmake
+++ b/CMake/SlicerApplicationOptions.cmake
@@ -114,3 +114,29 @@ if(NOT DEFINED ${Slicer_MAIN_PROJECT_APPLICATION_NAME}_SOURCE_DIR)
   set(${Slicer_MAIN_PROJECT_APPLICATION_NAME}_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 endif()
 mark_as_superbuild(${Slicer_MAIN_PROJECT_APPLICATION_NAME}_SOURCE_DIR)
+
+#-----------------------------------------------------------------------------
+# Set default installation folder and admin account requirement for Windows
+#-----------------------------------------------------------------------------
+if(WIN32)
+
+  if(NOT DEFINED Slicer_CPACK_NSIS_INSTALL_ROOT)
+    # Set root install directory (displayed to end user at installer-run time)
+    # to C:\Users\<username>\AppData\Local by default to allow installation
+    # without having administrative privileges.
+    set(Slicer_CPACK_NSIS_INSTALL_ROOT "$LOCALAPPDATA" CACHE STRING
+      "Default installation location. Accepted values include $LOCALAPPDATA, $APPDATA, $PROGRAMFILES, $PROGRAMFILES64.")
+    mark_as_advanced(Slicer_CPACK_NSIS_INSTALL_ROOT)
+  endif()
+  mark_as_superbuild(Slicer_CPACK_NSIS_INSTALL_ROOT)
+  message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} install root [${Slicer_CPACK_NSIS_INSTALL_ROOT}]")
+
+  if(NOT DEFINED Slicer_CPACK_NSIS_INSTALL_REQUIRES_ADMIN_ACCOUNT)
+    set(Slicer_CPACK_NSIS_INSTALL_REQUIRES_ADMIN_ACCOUNT OFF CACHE STRING
+      "Require administrator account to install the application. Must be enabled if Slicer_CPACK_NSIS_INSTALL_ROOT is only writable by administrators.")
+    mark_as_advanced(Slicer_CPACK_NSIS_INSTALL_REQUIRES_ADMIN_ACCOUNT)
+  endif()
+  mark_as_superbuild(Slicer_CPACK_NSIS_INSTALL_REQUIRES_ADMIN_ACCOUNT)
+  message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} requires admin account [${Slicer_CPACK_NSIS_INSTALL_REQUIRES_ADMIN_ACCOUNT}]")
+
+endif()

--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -350,16 +350,21 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
   set(Slicer_CPACK_NSIS_INSTALL_SUBDIRECTORY "")
   slicer_cpack_set("CPACK_NSIS_INSTALL_SUBDIRECTORY")
 
+  set(_nsis_install_root "${Slicer_CPACK_NSIS_INSTALL_ROOT}")
+
+  if (NOT Slicer_CPACK_NSIS_INSTALL_REQUIRES_ADMIN_ACCOUNT)
+    # Install as regular user (UAC dialog will not be shown).
+    SET(CPACK_NSIS_DEFINES ${CPACK_NSIS_DEFINES} "RequestExecutionLevel user")
+  endif()
+
   # Installers for 32- vs. 64-bit CMake:
-  #  - Root install directory (displayed to end user at installer-run time)
   #  - "NSIS package/display name" (text used in the installer GUI)
   #  - Registry key used to store info about the installation
+
   if(CMAKE_CL_64)
-    set(_nsis_install_root "$PROGRAMFILES64")
     slicer_verbose_set(CPACK_NSIS_PACKAGE_NAME "${CPACK_PACKAGE_INSTALL_DIRECTORY}")
     slicer_verbose_set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "${CPACK_PACKAGE_INSTALL_DIRECTORY} (Win64)")
   else()
-    set(_nsis_install_root "$PROGRAMFILES")
     slicer_verbose_set(CPACK_NSIS_PACKAGE_NAME "${CPACK_PACKAGE_INSTALL_DIRECTORY} (Win32)")
     slicer_verbose_set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "${CPACK_PACKAGE_INSTALL_DIRECTORY}")
   endif()


### PR DESCRIPTION
This makes it easier to install Slicer for users that do not have administrator access.
Default install location is changed accordingly to C:\Users\<username>\AppData\Local (which is writable by regular users).

See this discussion for background: https://discourse.slicer.org/t/automatic-install-of-python-packages/7078/8