### PR TITLE
ENH: Simplify node loading methods API in slicer.util

### DIFF
--- a/Applications/SlicerApp/Testing/Python/ShaderProperties.py
+++ b/Applications/SlicerApp/Testing/Python/ShaderProperties.py
@@ -76,7 +76,7 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
     fileURL = 'http://slicer.kitware.com/midas3/download/item/426450/MRRobot-Shoulder-MR.nrrd'
     filePath = os.path.join(slicer.util.tempDirectory(), 'MRRobot-Shoulder-MR.nrrd')
     slicer.util.downloadFile(fileURL, filePath)
-    success, shoulder = slicer.util.loadVolume(filePath, returnNode=True)
+    shoulder = slicer.util.loadVolume(filePath)
 
     self.delayDisplay("Shoulder downloaded...")
 

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -370,80 +370,197 @@ def setSliceViewerLayers(background='keep-current', foreground='keep-current', l
 #
 
 def loadNodeFromFile(filename, filetype, properties={}, returnNode=False):
+  """Load node into the scene from a file.
+  :param filename: full path of the file to load.
+  :param filetype: specifies the file type, which determines which IO class will load the file.
+  :param properties: map containing additional parameters for the loading.
+  :param returnNode: Deprecated. If set to true then the method returns status flag and node
+    instead of signalling error by throwing an exception.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   from slicer import app
   from vtk import vtkCollection
   properties['fileName'] = filename
 
+  loadedNodesCollection = vtkCollection()
+  success = app.coreIOManager().loadNodes(filetype, properties, loadedNodesCollection)
+  loadedNode = loadedNodesCollection.GetItemAsObject(0) if loadedNodesCollection.GetNumberOfItems() > 0 else None
+
+  # Deprecated way of returning status and node
   if returnNode:
-      loadedNodes = vtkCollection()
-      success = app.coreIOManager().loadNodes(filetype, properties, loadedNodes)
-      return success, loadedNodes.GetItemAsObject(0)
-  else:
-      success = app.coreIOManager().loadNodes(filetype, properties)
-      return success
+    import logging
+    logging.warning("loadNodeFromFile `returnNode` argument is deprecated. Loaded node is now returned directly if `returnNode` is not specified.")
+    return success, loadedNode
+
+  if not success:
+    errorMessage = "Failed to load node from file: " + str(filename)
+    raise RuntimeError(errorMessage)
+
+  return loadedNode
+
+def loadNodesFromFile(filename, filetype, properties={}, returnNode=False):
+  """Load nodes into the scene from a file. It differs from `loadNodeFromFile` in that
+  it returns loaded node(s) in an iterator.
+  :param filename: full path of the file to load.
+  :param filetype: specifies the file type, which determines which IO class will load the file.
+  :param properties: map containing additional parameters for the loading.
+  :return: loaded node(s) in an iterator object.
+  """
+  from slicer import app
+  from vtk import vtkCollection
+  properties['fileName'] = filename
+
+  loadedNodesCollection = vtkCollection()
+  success = app.coreIOManager().loadNodes(filetype, properties, loadedNodesCollection)
+  if not success:
+    errorMessage = "Failed to load nodes from file: " + str(filename)
+    raise RuntimeError(errorMessage)
+
+  return iter(loadedNodesCollection)
 
 def loadColorTable(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'ColorTableFile'
   return loadNodeFromFile(filename, filetype, {}, returnNode)
 
 def loadFiberBundle(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'FiberBundleFile'
   return loadNodeFromFile(filename, filetype, {}, returnNode)
 
 def loadFiducialList(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'FiducialListFile'
   return loadNodeFromFile(filename, filetype, {}, returnNode)
 
 def loadAnnotationFiducial(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'AnnotationFile'
   properties = {}
   properties['fiducial'] = 1
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
 def loadAnnotationRuler(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'AnnotationFile'
   properties = {}
   properties['ruler'] = 1
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
 def loadAnnotationROI(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'AnnotationFile'
   properties = {}
   properties['roi'] = 1
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
 def loadMarkupsFiducialList(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'MarkupsFiducials'
   properties = {}
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
 def loadModel(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'ModelFile'
   return loadNodeFromFile(filename, filetype, {}, returnNode)
 
 def loadScalarOverlay(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'ScalarOverlayFile'
   return loadNodeFromFile(filename, filetype, {}, returnNode)
 
 def loadSegmentation(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'SegmentationFile'
   return loadNodeFromFile(filename, filetype, {}, returnNode)
 
 def loadTransform(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'TransformFile'
   return loadNodeFromFile(filename, filetype, {}, returnNode)
 
 def loadLabelVolume(filename, properties={}, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'VolumeFile'
   properties['labelmap'] = True
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
 def loadShaderProperty(filename, returnNode=False):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'ShaderPropertyFile'
   return loadNodeFromFile(filename, filetype, {}, returnNode)
 
 def loadVolume(filename, properties={}, returnNode=False):
-  """Properties:
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param properties:
   - name: this name will be used as node name for the loaded volume
   - labelmap: interpret volume as labelmap
   - singleFile: ignore all other files in the directory
@@ -452,11 +569,20 @@ def loadVolume(filename, properties={}, returnNode=False):
   - autoWindowLevel: compute window/level automatically
   - show: display volume in slice viewers after loading is completed
   - fileNames: list of filenames to load the volume from
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
   """
   filetype = 'VolumeFile'
   return loadNodeFromFile(filename, filetype, properties, returnNode)
 
 def loadScene(filename, properties={}):
+  """Load node from file.
+  :param filename: full path of the file to load.
+  :param returnNode: Deprecated.
+  :return: loaded node (if multiple nodes are loaded then a list of nodes).
+    If returnNode is True then a status flag and loaded node are returned.
+  """
   filetype = 'SceneFile'
   return loadNodeFromFile(filename, filetype, properties, returnNode=False)
 

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
@@ -82,10 +82,8 @@ class SegmentationsModuleTest1(unittest.TestCase):
   #------------------------------------------------------------------------------
   def TestSection_LoadInputData(self):
     # Load into Slicer
-    ctLoadSuccess = slicer.util.loadVolume(self.dataDir + '/TinyPatient_CT.nrrd')
-    self.assertTrue( ctLoadSuccess )
-    segLoadSuccess = slicer.util.loadNodeFromFile(self.dataDir + '/TinyPatient_Structures.seg.vtm', "SegmentationFile", {})
-    self.assertTrue( segLoadSuccess )
+    slicer.util.loadVolume(self.dataDir + '/TinyPatient_CT.nrrd')
+    slicer.util.loadNodeFromFile(self.dataDir + '/TinyPatient_Structures.seg.vtm', "SegmentationFile", {})
 
     # Change master representation to closed surface (so that conversion is possible when adding segment)
     self.inputSegmentationNode = slicer.util.getNode('vtkMRMLSegmentationNode1')


### PR DESCRIPTION
Previously, returnNode=True argument had to be set to retrieve the loaded node:

  volumeNode = slicer.util.loadVolume('path/to/volume.nrrd', returnNode=True)[1]

Now the node is returned by default:

  volumeNode = slicer.util.loadVolume('path/to/volume.nrrd')

Also added loadNodesFromFile function that can return multiple loaded nodes.