### PR TITLE
BUG: Fix regex matching for SimpleITK Python library fixup

### DIFF
--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -76,7 +76,7 @@ function(gp_item_default_embedded_path_override item default_embedded_path_var)
 
   set(Slicer_USE_SimpleITK "@Slicer_USE_SimpleITK@")
   if(Slicer_USE_SimpleITK)
-    if (item MATCHES  "site-packages/(SimpleITK.*)/_SimpleITK\\.so" )
+    if (item MATCHES  "site-packages/(SimpleITK.*)/_SimpleITK[^/]*\\.(so|dylib)$" )
       # CMAKE_MATCH_1 is the over complicated egg path
       set(python_sys_site_path "@fixup_path@/lib/Python/${PYTHON_SITE_PACKAGES_SUBDIR}")
       set(path "${python_sys_site_path}/${CMAKE_MATCH_1}/")


### PR DESCRIPTION
The SimpleITK Python library now is named
"_SimpleITK.cpython-36m-darwin.so", where the ".cpython-36m-darwin" is
new. The regular expression has been updated so that the library will
be corretly matched and fixed up.