### PR TITLE
BUG: Fix Qt sound replay

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -33,6 +33,7 @@ endif()
 
 if(NOT Slicer_USE_SYSTEM_QT)
   set(SlicerBlockInstallQtPlugins_subdirectories
+    audio
     imageformats
     sqldrivers
     )

--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -87,7 +87,7 @@ function(gp_item_default_embedded_path_override item default_embedded_path_var)
     set(path "@fixup_path@/@Slicer_ITKFACTORIES_DIR@")
   endif()
 
-  foreach(qt_plugin_dir designer iconengines styles imageformats sqldrivers platforms)
+  foreach(qt_plugin_dir designer iconengines styles audio imageformats sqldrivers platforms)
     if(item MATCHES "@Slicer_QtPlugins_DIR@/${qt_plugin_dir}/[^/]+\\.(so|dylib)$")
       set(path "@fixup_path@/@Slicer_QtPlugins_DIR@/${qt_plugin_dir}")
     endif()
@@ -145,6 +145,7 @@ function(fixup_bundle_with_plugins app)
     "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/designer/*.dylib"
     "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/iconengines/*Plugin.so"
     "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/styles/*Plugins.so"
+    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/audio/*${suffix}"
     "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/imageformats/*${suffix}"
     "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/sqldrivers/*${suffix}"
     "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/platforms/*${suffix}"
@@ -263,6 +264,7 @@ function(fixup_bundle_with_plugins app)
   _fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/designer")
   _fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/iconengines")
   _fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/styles")
+  #_fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/audio")
   #_fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/imageformats")
   #_fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/sqldrivers")
   #_fixup_paths_append(libs_path "${Slicer_BUILD_DIR}/@Slicer_BIN_DIR@/platforms")


### PR DESCRIPTION
When attempting to play sound using QSound or QSoundEffect, installed Slicer logged "using null output device, none available" warning and sound did not play.
There was no problem in the build tree.

The root cause of the problem turned out to be that Qt audio plugins are not bundled with the installer.

Solved by adding "audio" plugin to the installer package (the same way as it is done for "imageformats" and "sqldrivers" plugins).