### PR TITLE
Remove harden question from sh

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
@@ -2827,7 +2827,8 @@ vtkIdType vtkMRMLSubjectHierarchyNode::GetItemAncestorAtLevel(vtkIdType itemID, 
 }
 
 //---------------------------------------------------------------------------
-bool vtkMRMLSubjectHierarchyNode::IsAnyNodeInBranchTransformed(vtkIdType itemID, vtkMRMLTransformNode* exceptionNode/*=nullptr*/)
+bool vtkMRMLSubjectHierarchyNode::IsAnyNodeInBranchTransformed(
+  vtkIdType itemID, bool includeParentItem/*=true*/, vtkMRMLTransformNode* exceptionNode/*=nullptr*/)
 {
   // Check transformable node from the item itself if any
   vtkSubjectHierarchyItem* item = this->Internal->SceneItem->FindChildByID(itemID);
@@ -2836,11 +2837,13 @@ bool vtkMRMLSubjectHierarchyNode::IsAnyNodeInBranchTransformed(vtkIdType itemID,
     vtkErrorMacro("IsAnyNodeInBranchTransformed: Failed to find non-scene subject hierarchy item by ID " << itemID);
     return false;
     }
+  vtkMRMLTransformableNode* parentTransformableNode = nullptr;
   if (item->DataNode)
     {
-    vtkMRMLTransformableNode* transformableDataNode = vtkMRMLTransformableNode::SafeDownCast(item->DataNode);
-    if ( transformableDataNode && transformableDataNode->GetParentTransformNode()
-      && transformableDataNode->GetParentTransformNode() != exceptionNode)
+    parentTransformableNode = vtkMRMLTransformableNode::SafeDownCast(item->DataNode);
+    if ( parentTransformableNode && parentTransformableNode->GetParentTransformNode()
+      && parentTransformableNode->GetParentTransformNode() != exceptionNode
+      && includeParentItem )
       {
       return true;
       }
@@ -2858,6 +2861,10 @@ bool vtkMRMLSubjectHierarchyNode::IsAnyNodeInBranchTransformed(vtkIdType itemID,
     vtkMRMLTransformNode* parentTransformNode = nullptr;
     if (transformableNode && (parentTransformNode = transformableNode->GetParentTransformNode()))
       {
+      if (!includeParentItem && transformableNode == parentTransformableNode)
+        {
+        continue;
+        }
       if (parentTransformNode != exceptionNode)
         {
         return true;

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
@@ -318,8 +318,9 @@ public:
   vtkIdType GetItemAncestorAtLevel(vtkIdType itemID, std::string level);
 
   /// Determine if any of the children of this item is transformed (has a parent transform applied), except for an optionally given node
-  /// \param exceptionNode The function still returns true if the only applied transform found is this specified node
-  bool IsAnyNodeInBranchTransformed(vtkIdType itemID, vtkMRMLTransformNode* exceptionNode=nullptr);
+  /// \param includeParentItem Determine whether the given item (the parent of the branch) should be included in the search. True by default
+  /// \param exceptionNode The function returns false if the only applied transform found is this specified node.
+  bool IsAnyNodeInBranchTransformed(vtkIdType itemID, bool includeParentItem=true, vtkMRMLTransformNode* exceptionNode=nullptr);
 
   /// Deserialize a UID list string (stored in the UID map) into a vector of UID strings
   static void DeserializeUIDList(std::string uidListString, std::vector<std::string>& deserializedUIDList);

--- a/Modules/Loadable/SubjectHierarchy/Testing/Cxx/vtkSlicerSubjectHierarchyModuleLogicTest.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Cxx/vtkSlicerSubjectHierarchyModuleLogicTest.cxx
@@ -795,7 +795,7 @@ namespace
       std::cerr << "Wrong inquiry about transformed items in study2" << std::endl;
       return false;
       }
-    if (shNode->IsAnyNodeInBranchTransformed(study2ShItemID, transformNode1.GetPointer()))
+    if (shNode->IsAnyNodeInBranchTransformed(study2ShItemID, true, transformNode1.GetPointer()))
       {
       std::cerr << "Wrong inquiry about transformed items in study2 with exception transform set" << std::endl;
       return false;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -1249,7 +1249,7 @@ void qMRMLSubjectHierarchyModel::updateSubjectHierarchyItemFromItemData(vtkIdTyp
 
     // Ask the user if any child node in the branch is transformed with a transform different from the chosen one
     bool hardenExistingTransforms = true;
-    if (d->SubjectHierarchyNode->IsAnyNodeInBranchTransformed(shItemID))
+    if (d->SubjectHierarchyNode->IsAnyNodeInBranchTransformed(shItemID, false))
       {
       QMessageBox::StandardButton answer =
         QMessageBox::question(nullptr, tr("Some nodes in the branch are already transformed"),
@@ -1263,7 +1263,6 @@ void qMRMLSubjectHierarchyModel::updateSubjectHierarchyItemFromItemData(vtkIdTyp
         }
       else if (answer == QMessageBox::Cancel)
         {
-        //qDebug() << Q_FUNC_INFO << ": Transform branch cancelled";
         return;
         }
       }


### PR DESCRIPTION
BUG: Remove SH harden transform question if changing transform on single item

When a subject hierarchy item had a transform and the user wanted to replace it with another transform, a message popped up asking if the user wants to harden it and then apply, or simply replace. Since hardening hardly ever seem to be needed, this question was removed.
The question, however, still pops up if the parent item of a branch in which there is at least one transformed item is to be transformed.


BUG: Fix crash when closing application after certain operations in SH

When a volume was cloned and moved in the tree (not sure if both are needed), then Slicer crashed on exit.