### PR TITLE
ENH: Allow handling events by interaction context

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
@@ -268,7 +268,7 @@ bool vtkMRMLAbstractWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData*
 }
 
 //-----------------------------------------------------------------------------
-void vtkMRMLAbstractWidget::Leave()
+void vtkMRMLAbstractWidget::Leave(vtkMRMLInteractionEventData* eventData)
 {
   this->SetWidgetState(WidgetStateIdle);
 }

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.h
@@ -153,7 +153,7 @@ public:
   virtual unsigned long TranslateInteractionEventToWidgetEvent(vtkMRMLInteractionEventData* eventData);
 
   /// Called when the the widget loses the focus.
-  virtual void Leave();
+  virtual void Leave(vtkMRMLInteractionEventData* eventData);
 
   void SetRenderer(vtkRenderer* renderer);
   vtkGetMacro(Renderer, vtkRenderer*);

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.cxx
@@ -47,6 +47,7 @@ vtkMRMLInteractionEventData::vtkMRMLInteractionEventData()
   this->Rotation = 0.0;
   this->LastRotation = 0.0;
   this->WorldToPhysicalScale = 1.0;
+  this->InteractionContextName = "";
 }
 
 //---------------------------------------------------------------------------
@@ -287,6 +288,18 @@ vtkCellPicker* vtkMRMLInteractionEventData::GetAccuratePicker() const
 void vtkMRMLInteractionEventData::SetAccuratePicker(vtkCellPicker* picker)
 {
   this->AccuratePicker = picker;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLInteractionEventData::SetInteractionContextName(const std::string& contextName)
+{
+  this->InteractionContextName = contextName;
+}
+
+//---------------------------------------------------------------------------
+const std::string& vtkMRMLInteractionEventData::GetInteractionContextName()
+{
+  return this->InteractionContextName;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
@@ -102,6 +102,9 @@ public:
   void SetAccuratePicker(vtkCellPicker* picker);
   vtkCellPicker* GetAccuratePicker() const;
 
+  void SetInteractionContextName(const std::string& v);
+  const std::string& GetInteractionContextName();
+
 protected:
   int Modifiers;
   int DisplayPosition[2];
@@ -131,6 +134,9 @@ protected:
   /// For VR events
   /// World to physical scale: Value greater than 1 means that objects appear larger in VR than their real world size.
   double WorldToPhysicalScale;
+
+  /// Name of interaction context. In case of the mouse, it is empty string
+  std::string InteractionContextName;
 
   bool Equivalent(const vtkEventData *e) const override;
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLScalarBarDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScalarBarDisplayableManager.cxx
@@ -199,7 +199,7 @@ bool vtkMRMLScalarBarDisplayableManager::CanProcessInteractionEvent(vtkMRMLInter
   int eventid = eventData->GetType();
   if (eventid == vtkCommand::LeaveEvent)
     {
-    this->Internal->WindowLevelWidget->Leave();
+    this->Internal->WindowLevelWidget->Leave(eventData);
     }
 
   // Find/create active widget

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -398,9 +398,9 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
 }
 
 //-------------------------------------------------------------------------
-void vtkMRMLSliceIntersectionWidget::Leave()
+void vtkMRMLSliceIntersectionWidget::Leave(vtkMRMLInteractionEventData* eventData)
 {
-  this->Superclass::Leave();
+  this->Superclass::Leave(eventData);
 }
 
 //-------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
@@ -73,7 +73,7 @@ public:
   bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
 
   /// Called when the the widget loses the focus.
-  void Leave() override;
+  void Leave(vtkMRMLInteractionEventData* eventData) override;
 
   /// Widget states
   enum

--- a/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
@@ -186,14 +186,14 @@ bool vtkMRMLWindowLevelWidget::ProcessInteractionEvent(vtkMRMLInteractionEventDa
 }
 
 //-------------------------------------------------------------------------
-void vtkMRMLWindowLevelWidget::Leave()
+void vtkMRMLWindowLevelWidget::Leave(vtkMRMLInteractionEventData* eventData)
 {
   this->SetWidgetState(WidgetStateIdle);
   if (this->WidgetRep)
     {
     this->WidgetRep->SetVisibility(false);
     }
-  this->Superclass::Leave();
+  this->Superclass::Leave(eventData);
 }
 
 //-------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.h
@@ -86,7 +86,7 @@ public:
   bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
 
   /// Called when the the widget loses the focus.
-  void Leave() override;
+  void Leave(vtkMRMLInteractionEventData* eventData) override;
 
   /// Widget states
   enum

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -101,7 +101,7 @@ public:
   /// Get position of a curve point along the curve relative to the specified start point index.
   /// \param startCurvePointId index of the curve point to start the distance measurement from
   /// \param distanceFromStartPoint distance from the start point
-  /// \return founod point index, -1 in case of an error
+  /// \return found point index, -1 in case of an error
   vtkIdType GetCurvePointIndexAlongCurveWorld(vtkIdType startCurvePointId, double distanceFromStartPoint);
 
   /// Get direction vector at specified curve point index, in World coordinate system.

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
@@ -75,7 +75,7 @@ public:
   bool IsPointPreviewed();
 
   /// Add/update a point preview to the current active Markup at the specified position.
-  void UpdatePreviewPoint(const int displayPos[2], const double worldPos[3], const char* associatedNodeID, int positionStatus);
+  void UpdatePreviewPoint(vtkMRMLInteractionEventData* eventData, const char* associatedNodeID, int positionStatus);
 
   /// Remove the point preview to the current active Markup.
   /// Returns true is preview point existed and now it is removed.
@@ -86,7 +86,7 @@ public:
   // Returns true if the event is processed.
   bool PlacePoint(vtkMRMLInteractionEventData* eventData);
 
-  /// Add a point to the current active Markup at input World coordiantes.
+  /// Add a point to the current active Markup at input World coordinates.
   virtual int AddPointFromWorldCoordinate(const double worldCoordinates[3]);
 
   /// Given a specific X, Y pixel location, add a new node
@@ -100,7 +100,7 @@ public:
   bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
 
   /// Called when the the widget loses the focus.
-  void Leave() override;
+  void Leave(vtkMRMLInteractionEventData* eventData) override;
 
   // Allows the widget to request interactive mode (faster updates)
   bool GetInteractive() override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -176,7 +176,7 @@ protected:
 
   double* GetWidgetColor(int controlPointType);
 
-  ControlPointsPipeline* ControlPoints[5]; // Unselected, Selected, Active, Project, ProjectBehind
+  ControlPointsPipeline* ControlPoints[NumberOfControlPointTypes]; // Unselected, Selected, Active, Project, ProjectBehind
 
 private:
   vtkSlicerMarkupsWidgetRepresentation(const vtkSlicerMarkupsWidgetRepresentation&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -189,7 +189,15 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(do
     {
     return;
     }
-  int activeControlPointIndex = this->MarkupsDisplayNode->GetActiveControlPoint();
+
+  // Use first active control point for jumping //TODO: Have an 'even more active' point concept
+  std::vector<int> activeControlPointIndices;
+  this->MarkupsDisplayNode->GetActiveControlPoints(activeControlPointIndices);
+  int activeControlPointIndex = -1;
+  if (!activeControlPointIndices.empty())
+    {
+    activeControlPointIndex = activeControlPointIndices[0];
+    }
 
   int numPoints = markupsNode->GetNumberOfControlPoints();
 


### PR DESCRIPTION
The goal was to fix the issue where the active component is decided based on what's the last device whose event is processed. E.g. a VR controller is in a markup which is supposed to be highlighted, but the other controller is not, and its move event overwrites the active component.

To solve this issue, it was needed to store the interaction context (mouse, VR left, etc.) in the interaction event data, and process accordingly.