### PR TITLE
ReformatLogic: Fix crash and improve GetVolumeBounds()

### DIFF
--- a/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.cxx
+++ b/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.cxx
@@ -182,14 +182,13 @@ void vtkSlicerReformatLogic::GetVolumeBounds(vtkMRMLSliceNode* node,
     volumeNodeID = sliceCompositeNode ? sliceCompositeNode->GetLabelVolumeID() : nullptr;
     }
 
-  if (!this->GetMRMLScene())
+  if (!node->GetScene())
     {
-    vtkWarningMacro("vtkSlicerReformatLogic::GetVolumeBounds: logic must be associated with a scene");
+    vtkWarningMacro("vtkSlicerReformatLogic::GetVolumeBounds: slice node must be associated with a scene");
     return;
     }
 
-  vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(
-   this->GetMRMLScene()->GetNodeByID(volumeNodeID));
+  vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(node->GetScene()->GetNodeByID(volumeNodeID));
 
   if (volumeNode)
     {

--- a/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.cxx
+++ b/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.cxx
@@ -182,6 +182,12 @@ void vtkSlicerReformatLogic::GetVolumeBounds(vtkMRMLSliceNode* node,
     volumeNodeID = sliceCompositeNode ? sliceCompositeNode->GetLabelVolumeID() : nullptr;
     }
 
+  if (!this->GetMRMLScene())
+    {
+    vtkWarningMacro("vtkSlicerReformatLogic::GetVolumeBounds: logic must be associated with a scene");
+    return;
+    }
+
   vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(
    this->GetMRMLScene()->GetNodeByID(volumeNodeID));
 

--- a/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.cxx
+++ b/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.cxx
@@ -67,7 +67,7 @@ SetSliceOrigin(vtkMRMLSliceNode* node, double x, double y, double z)
 
   // Clamp the position given the volume
   double bounds[6];
-  this->GetVolumeBounds(node, bounds);
+  Self::GetVolumeBounds(node, bounds);
 
   x = std::max(bounds[0], std::min(x, bounds[1]));
   y = std::max(bounds[2], std::min(y, bounds[3]));
@@ -88,7 +88,7 @@ SetSliceOrigin(vtkMRMLSliceNode* node, double position[3])
   double y = position[1];
   double z = position[2];
 
-  this->SetSliceOrigin(node, x, y, z);
+  Self::SetSliceOrigin(node, x, y, z);
 }
 
 //------------------------------------------------------------------------------
@@ -153,7 +153,7 @@ SetSliceNormal(vtkMRMLSliceNode* node, double normal[3])
   double y = normal[1];
   double z = normal[2];
 
-  this->SetSliceNormal(node, x, y, z);
+  Self::SetSliceNormal(node, x, y, z);
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.cxx
+++ b/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.cxx
@@ -184,12 +184,11 @@ void vtkSlicerReformatLogic::GetVolumeBounds(vtkMRMLSliceNode* node,
 
   if (!node->GetScene())
     {
-    vtkWarningMacro("vtkSlicerReformatLogic::GetVolumeBounds: slice node must be associated with a scene");
+    vtkWarningWithObjectMacro(node, "vtkSlicerReformatLogic::GetVolumeBounds: slice node must be associated with a scene");
     return;
     }
 
   vtkMRMLVolumeNode* volumeNode = vtkMRMLVolumeNode::SafeDownCast(node->GetScene()->GetNodeByID(volumeNodeID));
-
   if (volumeNode)
     {
     double dimensions[3], center[3];

--- a/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.h
+++ b/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.h
@@ -57,7 +57,7 @@ public:
   void SetSliceNormal(vtkMRMLSliceNode* node, double normal[3]);
 
   /// Compute and return the volume bounding box
-  void GetVolumeBounds(vtkMRMLSliceNode* node, double bounds[6]);
+  static void GetVolumeBounds(vtkMRMLSliceNode* node, double bounds[6]);
 
   /// Compute the center from a bounds
   static void GetCenterFromBounds(double bounds[6], double center[3]);

--- a/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.h
+++ b/Modules/Loadable/Reformat/Logic/vtkSlicerReformatLogic.h
@@ -43,18 +43,18 @@ class VTK_SLICER_REFORMAT_MODULE_LOGIC_EXPORT
 vtkSlicerReformatLogic : public vtkSlicerModuleLogic
 {
 public:
-
   static vtkSlicerReformatLogic *New();
+  typedef vtkSlicerReformatLogic Self;
   vtkTypeMacro(vtkSlicerReformatLogic,vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Set the world coordinate origin position
-  void SetSliceOrigin(vtkMRMLSliceNode* node, double x, double y, double z);
-  void SetSliceOrigin(vtkMRMLSliceNode* node, double position[3]);
+  static void SetSliceOrigin(vtkMRMLSliceNode* node, double x, double y, double z);
+  static void SetSliceOrigin(vtkMRMLSliceNode* node, double position[3]);
 
   /// Set the normal to the plane of the slice node.
-  void SetSliceNormal(vtkMRMLSliceNode* node, double x, double y, double z);
-  void SetSliceNormal(vtkMRMLSliceNode* node, double normal[3]);
+  static void SetSliceNormal(vtkMRMLSliceNode* node, double x, double y, double z);
+  static void SetSliceNormal(vtkMRMLSliceNode* node, double normal[3]);
 
   /// Compute and return the volume bounding box
   static void GetVolumeBounds(vtkMRMLSliceNode* node, double bounds[6]);

--- a/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModuleWidget.cxx
@@ -219,7 +219,7 @@ void qSlicerReformatModuleWidgetPrivate::updateOriginCoordinates()
 
   // Update volumes extremums
   double volumeBounds[6] = {0, 0, 0, 0, 0, 0};
-  reformatLogic->GetVolumeBounds(this->MRMLSliceNode, volumeBounds);
+  vtkSlicerReformatLogic::GetVolumeBounds(this->MRMLSliceNode, volumeBounds);
 
   /// TODO: set min/max per element
   double minimum = qMin(volumeBounds[0], qMin(volumeBounds[2], volumeBounds[4]));
@@ -535,7 +535,7 @@ void qSlicerReformatModuleWidget::setWorldPosition(double* worldCoordinates)
     }
 
   // Insert the widget translation
-  reformatLogic->SetSliceOrigin(d->MRMLSliceNode, worldCoordinates);
+  vtkSlicerReformatLogic::SetSliceOrigin(d->MRMLSliceNode, worldCoordinates);
 }
 
 //------------------------------------------------------------------------------
@@ -634,7 +634,7 @@ void qSlicerReformatModuleWidget::setSliceNormal(double* sliceNormal)
   vtkMath::Normalize(normalizedSliceNormal);
 
   // Insert the widget rotation
-  reformatLogic->SetSliceNormal(d->MRMLSliceNode, normalizedSliceNormal);
+  vtkSlicerReformatLogic::SetSliceNormal(d->MRMLSliceNode, normalizedSliceNormal);
 }
 
 //------------------------------------------------------------------------------
@@ -724,11 +724,11 @@ void qSlicerReformatModuleWidget::centerSliceNode()
 
   // Retrieve the center given the volume bounds
   double bounds[6], center[3];
-  reformatLogic->GetVolumeBounds(d->MRMLSliceNode, bounds);
+  vtkSlicerReformatLogic::GetVolumeBounds(d->MRMLSliceNode, bounds);
   vtkSlicerReformatLogic::GetCenterFromBounds(bounds, center);
 
   // Apply the center
-  reformatLogic->SetSliceOrigin(d->MRMLSliceNode, center);
+  vtkSlicerReformatLogic::SetSliceOrigin(d->MRMLSliceNode, center);
 }
 
 //-----------------------------------------------------------


### PR DESCRIPTION
See https://discourse.slicer.org/t/reproducible-slicer-crash-on-use-of-slicer-vtkslicerreformatlogic-setsliceorigin/7539