### PR TITLE
ENH: Swig executable path passed to downstream projects

### DIFF
--- a/CMake/SlicerConfig.cmake.in
+++ b/CMake/SlicerConfig.cmake.in
@@ -212,6 +212,9 @@ set(Slicer_Libs_VTK_WRAPPED_LIBRARIES "@Slicer_Libs_VTK_WRAPPED_LIBRARIES@")
 # Slicer VTK version
 set(Slicer_VTK_VERSION_MAJOR "@Slicer_VTK_VERSION_MAJOR@")
 
+# Slicer SWIG utility
+set(Slicer_SWIG_EXECUTABLE "@SWIG_EXECUTABLE@")
+
 # Slicer include directories for module
 @Slicer_INCLUDE_MODULE_DIRS_CONFIG@
 


### PR DESCRIPTION
Downloading correct CTKAPPLAUNCHER binary for aarch64 platform