### PR TITLE
Update to itk5

### DIFF
--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.cxx
@@ -238,10 +238,10 @@ int vtkMRMLModelStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
         {
         readerSH->SetFileName(fullName.c_str());
         readerSH->Update();
-        MeshReaderType::SceneType::Pointer scene = readerSH->GetScene();
-        MeshReaderType::SceneType::ObjectListType * objList =  scene->GetObjects(1,nullptr);
+        MeshReaderType::GroupType::Pointer group = readerSH->GetGroup();
+        MeshReaderType::GroupType::ObjectListType * objList =  group->GetChildren(1,nullptr);
 
-        MeshReaderType::SceneType::ObjectListType::iterator it = objList->begin();
+        MeshReaderType::GroupType::ObjectListType::iterator it = objList->begin();
         itk::SpatialObject<3> * curObj = *it;
         MeshSpatialObjectType::Pointer  SOMesh = dynamic_cast<MeshSpatialObjectType*> (curObj);
         surfaceMesh = SOMesh->GetMesh();

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkOptimizedImageToImageRegistrationMethod.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkOptimizedImageToImageRegistrationMethod.txx
@@ -292,7 +292,7 @@ OptimizedImageToImageRegistrationMethod<TImage>
       if( this->GetUseFixedImageMaskObject() )
         {
         double val;
-        if( this->GetFixedImageMaskObject()->ValueAt( fixedPoint, val ) )
+        if( this->GetFixedImageMaskObject()->ValueAtInWorldSpace( fixedPoint, val ) )
           {
           if( val == 0 )
             {
@@ -360,7 +360,7 @@ OptimizedImageToImageRegistrationMethod<TImage>
       if( this->GetUseFixedImageMaskObject() )
         {
         double val;
-        if( this->GetFixedImageMaskObject()->ValueAt( fixedPoint, val ) )
+        if( this->GetFixedImageMaskObject()->ValueAtInWorldSpace( fixedPoint, val ) )
           {
           if( val == 0 )
             {

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -244,8 +244,8 @@ set(BRAINSTools_options
   USE_BRAINSFit:BOOL=ON
   USE_BRAINSROIAuto:BOOL=ON
   USE_BRAINSResample:BOOL=ON
-  USE_BRAINSDemonWarp:BOOL=ON
   # BRAINSTools comes with some extra tool that should not be compiled by default
+  USE_BRAINSDemonWarp:BOOL=OFF
   USE_AutoWorkup:BOOL=OFF
   USE_ReferenceAtlas:BOOL=OFF
   USE_ANTS:BOOL=OFF
@@ -271,7 +271,6 @@ set(BRAINSTools_options
   BRAINS_DEBUG_IMAGE_WRITE:BOOL=OFF
   USE_BRAINSTransformConvert:BOOL=ON
   USE_DWIConvert:BOOL=${Slicer_BUILD_DICOM_SUPPORT} ## Need to figure out library linking
-  USE_BRAINSDemonWarp:BOOL=ON
   USE_BRAINSRefacer:BOOL=OFF
   )
 

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -275,8 +275,8 @@ set(BRAINSTools_options
   )
 
 Slicer_Remote_Add(BRAINSTools
-  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/Slicer/BRAINSTools.git
-  GIT_TAG 53c15d6beac5b8d65689054da89deb69e61c7d32 # slicer-2019-03-07-v5.0.0-2af1e31
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/BRAINSIA/BRAINSTools.git
+  GIT_TAG b75f58ada5456e75f068ecdc640d5da30c7703de # master corresponding to ITKv5
   LICENSE_FILES "http://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -27,14 +27,12 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    # "${EP_GIT_PROTOCOL}://github.com/Slicer/ITK"
     "${EP_GIT_PROTOCOL}://github.com/Kitware/ITK"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    # "4f7f4bf295e7a34a7bac8474ca2fc26bccc53c12" # 5.0.rc01 (2019-01-30) + backports: DCMTK + ITKDeprecated
     "v5.0.0"
     QUIET
     )

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -27,13 +27,15 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/Slicer/ITK"
+    # "${EP_GIT_PROTOCOL}://github.com/Slicer/ITK"
+    "${EP_GIT_PROTOCOL}://github.com/Kitware/ITK"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "4f7f4bf295e7a34a7bac8474ca2fc26bccc53c12" # 5.0.rc01 (2019-01-30) + backports: DCMTK + ITKDeprecated
+    # "4f7f4bf295e7a34a7bac8474ca2fc26bccc53c12" # 5.0.rc01 (2019-01-30) + backports: DCMTK + ITKDeprecated
+    "v5.0.0"
     QUIET
     )
 


### PR DESCRIPTION
@jcfr for this I referenced upstream repos and not our Slicer org forks.  Were there any patches still outstanding that aren't in the upstream?  If you agree, I think we should change the Welcome branches of to say that they are for legacy use (e.g. for 4.10) but won't be used in the future unless specific needs arise.

p.s. there's no particular rush, but [this extension](https://github.com/SNRLab/LineMarkerRegistration/pull/3) needs a fix from itk5 to build on mac.