### PR TITLE
Update qSlicerScalarVolumeDisplayWidget.cxx

### DIFF
--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
@@ -202,8 +202,8 @@ void qSlicerScalarVolumeDisplayWidget::updateWidgetFromMRML()
     {
     d->ColorTableComboBox->setCurrentNode(displayNode->GetColorNode());
     d->InterpolateCheckbox->setChecked(displayNode->GetInterpolate());
-    d->LockWindowLevelButton->setChecked(displayNode->GetInterpolate());
     bool lockedWindowLevel = displayNode->GetWindowLevelLocked();
+    d->LockWindowLevelButton->setChecked(lockedWindowLevel);
     if (lockedWindowLevel)
       {
       d->LockWindowLevelButton->setIcon(QIcon(":Icons/Medium/SlicerLock.png"));


### PR DESCRIPTION
Corrected setting the state of LockWindowLevelButton according to the correct property of the displayNode. The bug had no consequences, so just a formality.