### PR TITLE
BUG: Fix segment previous/next shortcut and move segment up/down

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -71,6 +71,8 @@ vtkMRMLSegmentationNode::vtkMRMLSegmentationNode()
   this->SegmentCenterTmp[2] = 0.0;
   this->SegmentCenterTmp[3] = 1.0;
 
+  this->SegmentListFilterEnabled = false;
+
   // Create empty segmentations object
   this->Segmentation = nullptr;
   vtkSmartPointer<vtkSegmentation> segmentation = vtkSmartPointer<vtkSegmentation>::New();
@@ -94,6 +96,10 @@ void vtkMRMLSegmentationNode::WriteXML(ostream& of, int nIndent)
     {
     this->Segmentation->WriteXML(of, nIndent);
     }
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLBooleanMacro(segmentListFilterEnabled, SegmentListFilterEnabled);
+  vtkMRMLWriteXMLStdStringMacro(segmentListFilterOptions, SegmentListFilterOptions);
+  vtkMRMLWriteXMLEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -110,6 +116,10 @@ void vtkMRMLSegmentationNode::ReadXMLAttributes(const char** atts)
     this->SetAndObserveSegmentation(segmentation);
     }
   this->Segmentation->ReadXMLAttributes(atts);
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLBooleanMacro(segmentListFilterEnabled, SegmentListFilterEnabled);
+  vtkMRMLReadXMLStdStringMacro(segmentListFilterOptions, SegmentListFilterOptions);
+  vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
 }
@@ -143,6 +153,11 @@ void vtkMRMLSegmentationNode::Copy(vtkMRMLNode *anode)
     this->SetAndObserveSegmentation(nullptr);
     }
 
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyBooleanMacro(SegmentListFilterEnabled);
+  vtkMRMLCopyStdStringMacro(SegmentListFilterOptions);
+  vtkMRMLCopyEndMacro();
+
   this->EndModify(wasModified);
 }
 
@@ -166,6 +181,10 @@ void vtkMRMLSegmentationNode::PrintSelf(ostream& os, vtkIndent indent)
     {
     os << " (invalid)\n";
     }
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintBooleanMacro(SegmentListFilterEnabled);
+  vtkMRMLPrintStdStringMacro(SegmentListFilterOptions);
+  vtkMRMLPrintEndMacro();
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.h
@@ -249,6 +249,15 @@ public:
   /// Get position of the segment's center in world coordinate system.
   void GetSegmentCenterRAS(const std::string& segmentID, double centerRAS[3]);
 
+  /// Indicates whether or not the segment filter is visible in the segments view
+  vtkSetMacro(SegmentListFilterEnabled, bool);
+  vtkGetMacro(SegmentListFilterEnabled, bool);
+  vtkBooleanMacro(SegmentListFilterEnabled, bool);
+
+  /// Contains a serialized representation of the filtering options used by the segments view
+  vtkSetMacro(SegmentListFilterOptions, std::string);
+  vtkGetMacro(SegmentListFilterOptions, std::string);
+
 protected:
   /// Set segmentation object
   vtkSetObjectMacro(Segmentation, vtkSegmentation);
@@ -287,6 +296,9 @@ protected:
   /// Temporary buffer that holds value returned by GetSegmentCenter(...) and GetSegmentCenterRAS(...)
   /// Has 4 components to allow usage in homogeneous transformations
   double SegmentCenterTmp[4];
+
+  bool SegmentListFilterEnabled;
+  std::string SegmentListFilterOptions;
 };
 
 #endif // __vtkMRMLSegmentationNode_h

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -695,7 +695,8 @@ bool vtkSegmentation::SetSegmentIndex(const std::string& segmentId, unsigned int
     vtkErrorMacro("vtkSegmentation::SetSegmentIndex failed: segment " << segmentId << " not found");
     return false;
     }
-  std::swap(*foundIt, this->SegmentIds[newIndex]);
+  this->SegmentIds.erase(foundIt);
+  this->SegmentIds.insert(this->SegmentIds.begin() + newIndex, segmentId);
   this->Modified();
   this->InvokeEvent(vtkSegmentation::SegmentsOrderModified);
   return true;

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -345,9 +345,12 @@ public:
     Flagged,
     LastStatus
   };
-
   /// Get the human readable segment status from the SegmentStatus enum value
-  static const char* GetSegmentStatusEnumAsString(int val);
+  static const char* GetSegmentStatusAsHumanReadableString(int segmentStatus);
+  /// Get the machine readable segment status from the SegmentStatus enum value
+  static const char* GetSegmentStatusAsMachineReadableString(int segmentStatus);
+  /// Get the enum segment status from a machine string
+  static int GetSegmentStatusFromMachineReadableString(std::string statusString);
 
   /// Returns the name of the status tag
   static const char* GetStatusTagName();
@@ -355,6 +358,9 @@ public:
   static int GetSegmentStatus(vtkSegment* segment);
   /// Returns the value of the status tag for the given segment
   static void SetSegmentStatus(vtkSegment* segment, int status);
+
+  static bool ClearSegment(vtkMRMLSegmentationNode* segmentationNode, std::string segmentID);
+  static bool ClearSegment(vtkSegmentation* segmentation, std::string segmentID);
 
 public:
   /// Set Terminologies module logic

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
@@ -827,7 +827,7 @@ void qMRMLSegmentsModel::reorderItems()
     }
 
   vtkSegmentation* segmentation = d->SegmentationNode->GetSegmentation();
-  if (segmentation)
+  if (!segmentation)
     {
     return;
     }

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
@@ -59,6 +59,7 @@ public:
   Q_PROPERTY(bool opacityColumnVisible READ opacityColumnVisible WRITE setOpacityColumnVisible)
   Q_PROPERTY(bool readOnly READ readOnly WRITE setReadOnly)
   Q_PROPERTY(bool filterBarVisible READ filterBarVisible WRITE setFilterBarVisible)
+  Q_PROPERTY(QString textFilter READ textFilter WRITE setTextFilter)
 
   typedef qMRMLWidget Superclass;
   /// Constructor
@@ -105,6 +106,13 @@ public:
   Q_INVOKABLE qMRMLSortFilterSegmentsProxyModel* sortFilterProxyModel()const;
   Q_INVOKABLE qMRMLSegmentsModel* model()const;
 
+  /// The text used to filter the segments in the table
+  /// \sa setTextFilter
+  QString textFilter();
+  // If the specified status should be shown in the table
+  /// \sa setStatusShown
+  Q_INVOKABLE bool statusShown(int status);
+
 public slots:
   /// Set segmentation MRML node
   void setSegmentationNode(vtkMRMLNode* node);
@@ -142,6 +150,13 @@ public slots:
   /// Move selected segments down in the list
   void moveSelectedSegmentsDown();
 
+  /// Set the text used to filter the segments in the table
+  /// \sa textFilter
+  void setTextFilter(QString);
+  /// Set if the specified status should be shown in the table
+  /// \sa statusShown
+  void setStatusShown(int status, bool shown);
+
 signals:
   /// Emitted if selection changes
   void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
@@ -159,6 +174,11 @@ protected slots:
   void onVisibility2DFillActionToggled(bool visible);
   void onVisibility2DOutlineActionToggled(bool visible);
 
+  /// Handles when the filters on underlying sort model are modified
+  void onSegmentsFilterModified();
+  /// Handles clicks on the show status buttons
+  void onShowStatusButtonClicked();
+
   /// Handles clicks on a table cell (visibility + state)
   void onSegmentsTableClicked(const QModelIndex& modelIndex);
 
@@ -166,6 +186,10 @@ protected slots:
   void endProcessing();
 
   void onSegmentAddedOrRemoved();
+
+  /// Update the widget form the MRML node
+  /// Called when the segmentation node is modified
+  void updateWidgetFromMRML();
 
 protected:
   /// Convenience function to set segment visibility options from event handlers

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSortFilterSegmentsProxyModel.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSortFilterSegmentsProxyModel.h
@@ -42,26 +42,12 @@ class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_EXPORT qMRMLSortFilterSegmentsProxyM
   Q_OBJECT
   QVTK_OBJECT
 
+  /// Whether the filter should be applied
+  Q_PROPERTY(bool filterEnabled READ filterEnabled WRITE setFilterEnabled)
   /// Filter to show only items that contain the string in their names. Empty by default
   Q_PROPERTY(QString nameFilter READ nameFilter WRITE setNameFilter)
   /// Filter to show only items that contain the string in their names or within tag values. Empty by default
   Q_PROPERTY(QString textFilter READ textFilter WRITE setTextFilter)
-  /// Filter to show segments with the state NotStarted
-  /// If all four boolean flags are false, than no filtering is performed
-  /// \sa showInProgress showCompleted showFlagged
-  Q_PROPERTY(bool showNotStarted READ showNotStarted WRITE setShowNotStarted)
-  /// Filter to show segments with the state InProgress
-  /// If all four boolean flags are false, than no filtering is performed
-  /// \sa showNotStarted showCompleted showFlagged
-  Q_PROPERTY(bool showInProgress READ showInProgress WRITE setShowInProgress)
-  ///Filter to show segments with the state Completed
-  /// If all four boolean flags are false, than no filtering is performed
-  /// \sa showNotStarted showInProgress showFlagged
-  Q_PROPERTY(bool showCompleted READ showCompleted WRITE setShowCompleted)
-  /// Filter to show segments with the state Flagged
-  /// If all four boolean flags are false, than no filtering is performed
-  /// \sa showNotStarted showInProgress showCompleted
-  Q_PROPERTY(bool showFlagged READ showFlagged WRITE setShowFlagged)
 
 public:
   typedef QSortFilterProxyModel Superclass;
@@ -76,18 +62,21 @@ public:
   Q_INVOKABLE void setHideSegments(const QStringList& segmentIDs);
   Q_INVOKABLE QStringList hideSegments()const;
 
+  bool filterEnabled()const;
   QString nameFilter()const;
   QString textFilter()const;
-  bool showNotStarted()const;
-  bool showInProgress()const;
-  bool showCompleted()const;
-  bool showFlagged()const;
+
+  /// Filter to show segments with the specified state
+  /// If the flags for all states are false, than no filtering is performed
+  /// The list of availiable status is in vtkSlicerSegmentationsModuleLogic::SegmentStatus
+  /// \sa setShowStatus
+  Q_INVOKABLE bool showStatus(int status) const;
 
   /// Retrieve the associated segment ID from a model index
   Q_INVOKABLE QString segmentIDFromIndex(const QModelIndex& index)const;
 
   /// Retrieve an index for a given a segment ID
-  Q_INVOKABLE QModelIndex indexFromSegmentID(QString itemID, int column=0)const;
+  Q_INVOKABLE QModelIndex indexFromSegmentID(QString segmentID, int column=0)const;
 
   /// Returns true if the item in the row indicated by the given sourceRow and
   /// sourceParent should be included in the model; otherwise returns false.
@@ -100,13 +89,21 @@ public:
   /// Returns the flags for the current index
   Qt::ItemFlags flags(const QModelIndex & index)const override;
 
+  /// Set filter to show segments with the specified state
+  /// If the flags for all states are false, than no filtering is performed
+  /// The list of availiable status is in vtkSlicerSegmentationsModuleLogic::SegmentStatus
+  /// \sa showStatus
+  void setShowStatus(int status, bool shown);
+
 public slots:
+  void setFilterEnabled(bool filterEnabled);
   void setNameFilter(QString filter);
   void setTextFilter(QString filter);
-  void setShowNotStarted(bool show);
-  void setShowInProgress(bool show);
-  void setShowCompleted(bool show);
-  void setShowFlagged(bool show);
+
+signals:
+  /// Emitted when one of the filter parameters are modified
+  /// \sa setShowStatus setTextFilter setNameFilter
+  void filterModified();
 
 protected:
   QStandardItem* sourceItem(const QModelIndex& index)const;

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -19,6 +19,7 @@
 ==============================================================================*/
 
 // Segmentations includes
+#include "qMRMLSortFilterSegmentsProxyModel.h"
 #include "qSlicerSegmentationsModuleWidget.h"
 #include "ui_qSlicerSegmentationsModule.h"
 
@@ -428,7 +429,17 @@ void qSlicerSegmentationsModuleWidget::onAddSegment()
     }
 
   // Create empty segment in current segmentation
-  std::string addedSegmentID = currentSegmentationNode->GetSegmentation()->AddEmptySegment();
+  std::string addedSegmentID = currentSegmentationNode->GetSegmentation()->AddEmptySegment(d->SegmentsTableView->textFilter().toStdString());
+  int status = 0;
+  for (int i = 0; i < vtkSlicerSegmentationsModuleLogic::LastStatus; ++i)
+    {
+    if (d->SegmentsTableView->sortFilterProxyModel()->showStatus(i))
+      {
+      status = i;
+      break;
+      }
+    }
+  vtkSlicerSegmentationsModuleLogic::SetSegmentStatus(currentSegmentationNode->GetSegmentation()->GetSegment(addedSegmentID), status);
 
   // Select the new segment
   if (!addedSegmentID.empty())


### PR DESCRIPTION
* The prev/next shortcuts in the segment editor now move the table selection up and down the list of visible segments, skipping all filtered segments
* The move segment up/down will move segments up/down, skipping all filtered segments

Filtering parameters are now stored in two new vtkMRMLSegmentationNode attributes:
* SegmentListFilterEnabled - Determines if the filter bar should be shown or not
* SegmentListFilterOptions - Serialized string containing the parameters used to filter the segments (text, status, etc)

Other changes:
* Cleaned up handling of segment status, made it more expandable in the future
* Moved ClearSegment methods to vtkSlicerSegmentationsModuleLogic to allow access in Python
* New segments will now set their id based on the text filter. This allows prevents created segments from being hidden by the filter (only applies to text filtering, not status filtering).