### PR TITLE
BUG: Fix crash in Segment table prev/next shortcut

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
@@ -295,6 +295,17 @@ public slots:
   /// \sa interactionNode()
   void setInteractionNode(vtkMRMLInteractionNode* interactionNode);
 
+  /// Select the segment above the currently selected one in the table (skipping segments that are not visible)
+  void selectPreviousSegment();
+
+  /// Select the segment below the currently selected one in the table (skipping segments that are not visible)
+  void selectNextSegment();
+
+  /// Select the segment offset from the currently selected one in the table (skipping segments that are not visible)
+  /// Positive offset will move down the table
+  /// Negative offset will move up the table
+  void selectSegmentAtOffset (int offset);
+
 signals:
   /// Emitted if different segment is selected in the segment list.
   void currentSegmentIDChanged(const QString&);

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
@@ -113,6 +113,11 @@ public:
   /// \sa setStatusShown
   Q_INVOKABLE bool statusShown(int status);
 
+  /// Get the row for the specified segment ID
+  int rowForSegmentID(QString segmentID);
+  /// Get the segment ID for the specified row
+  QString segmentIDForRow(int row);
+
 public slots:
   /// Set segmentation MRML node
   void setSegmentationNode(vtkMRMLNode* node);
@@ -152,7 +157,7 @@ public slots:
 
   /// Set the text used to filter the segments in the table
   /// \sa textFilter
-  void setTextFilter(QString);
+  void setTextFilter(QString textFilter);
   /// Set if the specified status should be shown in the table
   /// \sa statusShown
   void setStatusShown(int status, bool shown);

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSortFilterSegmentsProxyModel.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSortFilterSegmentsProxyModel.cxx
@@ -348,6 +348,8 @@ void qMRMLSortFilterSegmentsProxyModel::setHideSegments(const QStringList& segme
 {
   Q_D(qMRMLSortFilterSegmentsProxyModel);
   d->HideSegments = segmentIDs;
+  this->invalidateFilter();
+  emit filterModified();
 }
 
 // --------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSortFilterSegmentsProxyModel.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSortFilterSegmentsProxyModel.h
@@ -93,7 +93,7 @@ public:
   /// If the flags for all states are false, than no filtering is performed
   /// The list of availiable status is in vtkSlicerSegmentationsModuleLogic::SegmentStatus
   /// \sa showStatus
-  void setShowStatus(int status, bool shown);
+  Q_INVOKABLE void setShowStatus(int status, bool shown);
 
 public slots:
   void setFilterEnabled(bool filterEnabled);


### PR DESCRIPTION
Crash introduced in cb6b36b. Previously negative indices were handled through cast to unsigned int.
New implementation should correctly iterate through visible segment IDs in the table without crashing.