### PR TITLE
ENH: Rename overwrite-related masking options in Segment Editor

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
@@ -454,7 +454,7 @@
          <string/>
         </property>
         <property name="text">
-         <string>Overwrite other segments:</string>
+         <string>Modify other segments:</string>
         </property>
        </widget>
       </item>

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -387,9 +387,9 @@ void qMRMLSegmentEditorWidgetPrivate::init()
   this->MaskModeComboBox->insertSeparator(this->MaskModeComboBox->count());
   this->MaskModeComboBoxFixedItemsCount = this->MaskModeComboBox->count();
 
-  this->OverwriteModeComboBox->addItem(qMRMLSegmentEditorWidget::tr("All segments"), vtkMRMLSegmentEditorNode::OverwriteAllSegments);
-  this->OverwriteModeComboBox->addItem(qMRMLSegmentEditorWidget::tr("Visible segments"), vtkMRMLSegmentEditorNode::OverwriteVisibleSegments);
-  this->OverwriteModeComboBox->addItem(qMRMLSegmentEditorWidget::tr("None"), vtkMRMLSegmentEditorNode::OverwriteNone);
+  this->OverwriteModeComboBox->addItem(qMRMLSegmentEditorWidget::tr("Overwrite all"), vtkMRMLSegmentEditorNode::OverwriteAllSegments);
+  this->OverwriteModeComboBox->addItem(qMRMLSegmentEditorWidget::tr("Overwrite visible"), vtkMRMLSegmentEditorNode::OverwriteVisibleSegments);
+  this->OverwriteModeComboBox->addItem(qMRMLSegmentEditorWidget::tr("Allow overlap"), vtkMRMLSegmentEditorNode::OverwriteNone);
 
   this->SwitchToSegmentationsButton->setIcon(q->style()->standardIcon(QStyle::SP_ArrowRight));
 


### PR DESCRIPTION
Instead of
  Overwrite other segments: All segments / Visible segments / None
now it says
  Modify other segments: Overwrite all / Overwrite visible / Overlap
The intention is to reduce confusion and make the consequence of the selection clearer.