### PR TITLE
BUG: Set defaults specific to testing related to DICOM loading

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -141,6 +141,8 @@ class _ui_DICOMSettingsPanel(object):
     schemaUpdateComboBox.addItem("Never update", "NeverUpdate")
     schemaUpdateComboBox.addItem("Ask user", "AskUser")
     schemaUpdateComboBox.currentIndex = 2 # Make 'AskUser' the default as opposed to the CTK default 'AlwaysUpdate'
+    if slicer.app.commandOptions().testingEnabled:
+      schemaUpdateComboBox.currentIndex = 0 # Update database for automatic tests
     genericGroupBoxFormLayout.addRow("Schema update behavior:", schemaUpdateComboBox)
     parent.registerProperty(
       "DICOM/SchemaUpdateOption", schemaUpdateComboBox,

--- a/Modules/Scripted/DICOMLib/DICOMWidgets.py
+++ b/Modules/Scripted/DICOMLib/DICOMWidgets.py
@@ -795,6 +795,8 @@ class DICOMDetailsBase(VTKObservationMixin, SizePositionSettingsMixin):
       (self.referencedLoadables, loadEnabled) = self.getLoadablesFromFileLists(referencedFileLists)
 
     automaticallyLoadReferences = int(slicer.util.settingsValue('DICOM/automaticallyLoadReferences', qt.QMessageBox.InvalidRole))
+    if slicer.app.commandOptions().testingEnabled:
+      automaticallyLoadReferences = qt.QMessageBox.No
     if loadEnabled and automaticallyLoadReferences == qt.QMessageBox.InvalidRole:
       self.showReferenceDialogAndProceed()
     elif loadEnabled and automaticallyLoadReferences == qt.QMessageBox.Yes:


### PR DESCRIPTION
Tests failed due to dialogs popping up leading to timeout. Two defaults have been introduced that apply only when running automated tests:
- Update DICOM database schema: always
- Load DICOM references: no

Related to https://github.com/Slicer/Slicer/commit/75fceb26fb40397eac1b06fb2030c7b040f861ad