### PR TITLE
BUG: Fix show only selected segments option in segment table

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -3658,13 +3658,13 @@ void qMRMLSegmentEditorWidget::showSegmentationGeometryDialog()
 //---------------------------------------------------------------------------
 void qMRMLSegmentEditorWidget::selectPreviousSegment()
 {
-  this->selectSegmentAtOffset (-1);
+  this->selectSegmentAtOffset(-1);
 }
 
 //---------------------------------------------------------------------------
 void qMRMLSegmentEditorWidget::selectNextSegment()
 {
-  this->selectSegmentAtOffset (1);
+  this->selectSegmentAtOffset(1);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Show only selected segments was previous applied to only the displayed segments in the table.
Fixed by applying the desired visibility to the total list of segments, excluding those that are specifically hidden in the table (through setHideSegments()).
Updated SegmentationWidgetsTest1 to test showOnlySelectedSegments().