### PR TITLE
ENH: Improve segment table filtering performance

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
@@ -196,6 +196,9 @@ protected slots:
   /// Called when the segmentation node is modified
   void updateWidgetFromMRML();
 
+  /// Update the filter parameters in the vtkMRMLSegmentationNode
+  void updateMRMLFromFilterParameters();
+
 protected:
   /// Convenience function to set segment visibility options from event handlers
   /// \sa onVisibilityButtonToggled \sa onVisibility3DActionToggled \sa onVisibility2DFillActionToggled \sa onVisibility2DOutlineActionToggled


### PR DESCRIPTION
Previously, each time the filter parameters were changed, the
segmentation node would be modified, triggering other expensive
operations (rendering, etc).

Now changing filter parameters will restart a 500ms one-shot timer that
will cause the node to only be updated once it has elapsed. Continuous
updates such as typing will not be saved until there is a 500ms gap in
the changes.