### PR TITLE
COMP: Ensure designer launcher directory exists at configuration time

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -76,6 +76,9 @@ if(Slicer_BUILD_QT_DESIGNER_PLUGINS)
     set(installed_designer_executable "Designer")
     set(installed_designer_subdir "Designer.app/Contents/MacOS")
   endif()
+  # Ensure directory exists at configuration time
+  file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${Slicer_BIN_DIR})
+  # Configure designer launcher
   find_package(CTKAppLauncher REQUIRED)
   ctkAppLauncherConfigureForExecutable(
     APPLICATION_NAME ${executablename}


### PR DESCRIPTION
This commit fixes the following error reported when configuring the SlicerSALT
custom application:

```
  CMake Error at /work/Stable/SSALT-200-build/CTKAPPLAUNCHER/CMake/ctkAppLauncher.cmake:278 (message):
   DESTINATION_DIR [/work/Stable/SSALT-200-build/Slicer-build/bin] doesn't
   seem to exist !
  Call Stack (most recent call first):
   /work/Stable/SSALT-200-build/CTKAPPLAUNCHER/CMake/ctkAppLauncher.cmake:520 (_check_variables_exists)
   /work/Stable/SSALT-200-build/CTKAPPLAUNCHER/CMake/ctkAppLauncher.cmake:411 (ctk_applauncher_configure)
   CMake/SlicerCPack.cmake:80 (ctkAppLauncherConfigureForExecutable)
   CMake/LastConfigureStep/CMakeLists.txt:44 (include)
```

See https://github.com/KitwareMedical/SlicerCustomAppTemplate/issues/10

Reported-by: Sam Horvath <sam.horvath@kitware.com>