### PR TITLE
COMP: Package JsonCpp if VolumeRendering module is enabled

### DIFF
--- a/CMake/SlicerBlockInstallCMakeProjects.cmake
+++ b/CMake/SlicerBlockInstallCMakeProjects.cmake
@@ -43,7 +43,11 @@ endif()
 # -------------------------------------------------------------------------
 # Install JsonCpp
 # -------------------------------------------------------------------------
-if(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT
+
+# JsonCpp is required to build VolumeRendering module
+slicer_is_loadable_builtin_module_enabled("VolumeRendering" _build_volume_rendering_module)
+
+if((Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT OR _build_volume_rendering_module)
   AND NOT "${JsonCpp_DIR}" STREQUAL "" AND EXISTS "${JsonCpp_DIR}/CMakeCache.txt")
   set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${JsonCpp_DIR};JsonCpp;Unspecified;/")
 endif()


### PR DESCRIPTION
Following r28285 (ENH: Add new node types to support custom
shader code for volume rendering), JsonCpp is a requirement
for VolumeRendering module.

This commit is a follow-up of r28301 (COMP: Build JsonCpp if
VolumeRendering module is enabled)

Reported-by: Csaba Pinter <csaba.pinter@queensu.ca>