### PR TITLE
COMP: allow compiling with all versions of VS2017 and VS2019

### DIFF
--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -198,15 +198,11 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
       # VS2013
       set(OpenSSL_1.0.1h_1800_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1800-32.tar.gz)
       set(OpenSSL_1.0.1h_1800_MD5 f10ceb422ab37f2b0bd5e225c74fd1d4)
-      # VS2015
-      set(OpenSSL_1.0.1h_1900_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-32.tar.gz)
-      set(OpenSSL_1.0.1h_1900_MD5 e0e26ae6ac5693d266c804e738d7aa14)
-      # VS2017 (expected to be binary compatible with VS2015)
-      set(OpenSSL_1.0.1h_1916_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-32.tar.gz)
-      set(OpenSSL_1.0.1h_1916_MD5 e0e26ae6ac5693d266c804e738d7aa14)
-      # VS2019 (expected to be binary compatible with VS2015)
-      set(OpenSSL_1.0.1h_1921_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-32.tar.gz)
-      set(OpenSSL_1.0.1h_1921_MD5 e0e26ae6ac5693d266c804e738d7aa14)
+      # VS2015, VS2017 and VS2019
+      if(${MSVC_VERSION} VERSION_GREATER_EQUAL 1900)
+        set(OpenSSL_1.0.1h_${MSVC_VERSION}_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-32.tar.gz)
+        set(OpenSSL_1.0.1h_${MSVC_VERSION}_MD5 e0e26ae6ac5693d266c804e738d7aa14)
+      endif()
 
       # OpenSSL 1.0.1l
       # VS2008
@@ -229,15 +225,11 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
       # VS2013
       set(OpenSSL_1.0.1h_1800_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1800-64.tar.gz)
       set(OpenSSL_1.0.1h_1800_MD5 7aefdd94babefbe603cca48ff86da768)
-      # VS2015
-      set(OpenSSL_1.0.1h_1900_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-64.tar.gz)
-      set(OpenSSL_1.0.1h_1900_MD5 f93d266def384926015550452573e824)
-      # VS2017
-      set(OpenSSL_1.0.1h_1916_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-64.tar.gz)
-      set(OpenSSL_1.0.1h_1916_MD5 f93d266def384926015550452573e824)
-      # VS2019
-      set(OpenSSL_1.0.1h_1921_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-64.tar.gz)
-      set(OpenSSL_1.0.1h_1921_MD5 f93d266def384926015550452573e824)
+      # VS2015, VS2017 and VS2019
+      if(${MSVC_VERSION} VERSION_GREATER_EQUAL 1900)
+        set(OpenSSL_1.0.1h_${MSVC_VERSION}_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-64.tar.gz)
+        set(OpenSSL_1.0.1h_${MSVC_VERSION}_MD5 f93d266def384926015550452573e824)
+      endif()
 
       # OpenSSL 1.0.1l
       # VS2008

--- a/SuperBuild/External_tbb.cmake
+++ b/SuperBuild/External_tbb.cmake
@@ -50,10 +50,10 @@ if (WIN32)
     set(tbb_vsdir vc12)
   elseif (NOT MSVC_VERSION VERSION_GREATER 1900)
     set(tbb_vsdir vc14)
-  elseif (NOT MSVC_VERSION VERSION_GREATER 1916)
+  elseif (NOT MSVC_VERSION VERSION_GREATER 1919)
     # VS2017 is expected to be binary compatible with VS2015
     set(tbb_vsdir vc14)
-  elseif (NOT MSVC_VERSION VERSION_GREATER 1921)
+  elseif (NOT MSVC_VERSION VERSION_GREATER 1929)
     # VS2019 is expected to be binary compatible with VS2015
     set(tbb_vsdir vc14)
   elseif (tbb_enabled)


### PR DESCRIPTION
Fixes:

CMake Error at SuperBuild/External_OpenSSL.cmake:253 (message):
  There is no pre-compiled version of OpenSSL 1.0.1h available for

  this version of visual studio [1922].