### PR TITLE
BUG: Fix issues with DICOM browser widget

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -176,6 +176,9 @@ This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. Se
 
 
   def onLayoutChanged(self, viewArrangement):
+    if viewArrangement == self.currentViewArrangement:
+      return
+
     self.previousViewArrangement = self.currentViewArrangement
     self.currentViewArrangement = viewArrangement
 
@@ -431,7 +434,8 @@ class DICOMWidget(object):
     self.tables = self.detailsPopup.tables
 
     layoutManager = slicer.app.layoutManager()
-    layoutManager.layoutChanged.connect(self.onLayoutChanged)
+    if layoutManager is not None:
+      layoutManager.layoutChanged.connect(self.onLayoutChanged)
 
     # connect to the 'Show DICOM Browser' button
     self.showBrowserButton = qt.QPushButton('Show DICOM database browser')
@@ -457,7 +461,6 @@ class DICOMWidget(object):
     self.subjectHierarchyTree.currentItemModified.connect(self.onCurrentItemModified)
     self.subjectHierarchyCurrentVisibility = False
     self.subjectHierarchyTree.setColumnHidden(self.subjectHierarchyTree.model().idColumn, True)
-
 
     self.browserSettingsWidget = ctk.ctkCollapsibleGroupBox()
     self.browserSettingsWidget.title = "Browser settings"
@@ -553,9 +556,6 @@ class DICOMWidget(object):
     self.recentActivity = DICOMLib.DICOMRecentActivityWidget(self.activityFrame,detailsPopup=self.detailsPopup)
     self.activityFrame.layout().addWidget(self.recentActivity)
     self.requestUpdateRecentActivity()
-
-    # Add spacer to layout
-    self.layout.addStretch(1)
 
   def onLayoutChanged(self, viewArrangement):
     if viewArrangement == slicer.vtkMRMLLayoutNode.SlicerLayoutDicomBrowserView:


### PR DESCRIPTION
Fix qSlicerDICOMModuleGenericTest failure
* qSlicerDICOMModuleGenericTest is run without the main window, so layout manager does not not exist.
* Now checks to make sure the layout manager exists before creating the connection

Fix issue where data is loaded and the widget closes, yet the layout remains the same
* See https://issues.slicer.org/view.php?id=4705
* Certain datasets invoke start/end batch processing
* This caused an unnecessary update of the previous/current layout within the DICOM module
* Solved by only changing the previous/current layout if it is different from the current layout

Allow the subject hierarchy tree to expand within the module layout
* Remove the extra spacer from the module layout, allowing the tree widget to expand