### PR TITLE
ENH: Close DICOM browser when switching modules

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -419,8 +419,7 @@ class DICOMWidget(object):
     self.onOpenDetailsPopup()
 
   def exit(self):
-    if not self.detailsPopup.browserPersistent:
-      self.detailsPopup.close()
+    self.detailsPopup.close()
 
   def updateGUIFromMRML(self, caller, event):
     pass


### PR DESCRIPTION
With the previous behavior, the DICOM browser will remain open when switching modules as long as "Browser persistent" is enabled.
This commit causes the DICOM browser to be closed when switching modules, regardless of the "Browser persistent" setting.

"Browser persistent" only affects whether or not the DICOM browser is closed after loading data from the database.