### PR TITLE
BUG: Remove creation of DICOM browser widget before module is opened

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -112,7 +112,6 @@ This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. Se
     self.detailsPopup = None
     self.viewWidget = None
     self.browserSettingsWidget = None
-    self.setDetailsPopup(DICOMWidget.getSavedDICOMDetailsWidgetType()())
 
   def startListener(self):
     # the dicom listener is also global, but only started on app start if


### PR DESCRIPTION
Previously the details popup was incorrectly created when the module was loaded, and again when it was opened.
Early creation of the was unnecessary and caused issues with the automated tests.

This commit removes the instantiation of the DICOM popup widget until the DICOM module is opened.