### PR TITLE
Update qSlicerMouseModeToolBar.cxx

### DIFF
--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -539,7 +539,7 @@ void qSlicerMouseModeToolBar::changeCursorTo(QCursor cursor)
     qMRMLThreeDView* threeDView = layoutManager->threeDWidget(i)->threeDView();
     if (!threeDView->mrmlViewNode()->IsMappedInLayout())
       {
-      return;
+      continue;
       }
     // Update cursor only if view interaction node corresponds to the one associated with the mouse toolbar
     if (threeDView->mrmlViewNode()->GetInteractionNode() != this->interactionNode())
@@ -556,7 +556,7 @@ void qSlicerMouseModeToolBar::changeCursorTo(QCursor cursor)
     qMRMLSliceView* sliceView = layoutManager->sliceWidget(viewerName)->sliceView();
     if (!sliceView->mrmlSliceNode()->IsMappedInLayout())
       {
-      return;
+      continue;
       }
     // Update cursor only if view interaction node corresponds to the one associated with the mouse toolbar
     if (sliceView->mrmlSliceNode()->GetInteractionNode() != this->interactionNode())


### PR DESCRIPTION
BUG: updating of cursor for 3d views was broken and did not continue when an unmapped view was encountered

Relates to [this](https://discourse.slicer.org/t/update-of-slicer-issue-tracker/437/18?u=rprueckl) forum post.