### PR TITLE
ENH: Refactoring the MRML scene to contain a SH node as a member vari…

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -19,7 +19,6 @@ Version:   $Revision: 1.18 $
 #include "vtkDataIOManager.h"
 #include "vtkTagTable.h"
 
-#include "vtkMRMLTransformNode.h"
 #include "vtkMRMLBSplineTransformNode.h"
 #include "vtkMRMLCameraNode.h"
 #include "vtkMRMLChartNode.h"
@@ -36,16 +35,17 @@ Version:   $Revision: 1.18 $
 #include "vtkMRMLHierarchyStorageNode.h"
 #include "vtkMRMLLabelMapVolumeDisplayNode.h"
 #include "vtkMRMLLabelMapVolumeNode.h"
+#include "vtkMRMLLayoutNode.h"
 #include "vtkMRMLLinearTransformNode.h"
-#include "vtkMRMLModelNode.h"
 #include "vtkMRMLModelHierarchyNode.h"
-#include "vtkMRMLPlotSeriesNode.h"
+#include "vtkMRMLModelNode.h"
 #include "vtkMRMLPlotChartNode.h"
+#include "vtkMRMLPlotSeriesNode.h"
 #include "vtkMRMLPlotViewNode.h"
 #include "vtkMRMLProceduralColorNode.h"
 #include "vtkMRMLProceduralColorStorageNode.h"
-#include "vtkMRMLROINode.h"
 #include "vtkMRMLROIListNode.h"
+#include "vtkMRMLROINode.h"
 #include "vtkMRMLScriptedModuleNode.h"
 #include "vtkMRMLSegmentationDisplayNode.h"
 #include "vtkMRMLSegmentationNode.h"
@@ -55,22 +55,23 @@ Version:   $Revision: 1.18 $
 #include "vtkMRMLSliceNode.h"
 #include "vtkMRMLSnapshotClipNode.h"
 #include "vtkMRMLSubjectHierarchyNode.h"
+#include "vtkMRMLSubjectHierarchyNode.h"
 #include "vtkMRMLTableNode.h"
 #include "vtkMRMLTableStorageNode.h"
 #include "vtkMRMLTableViewNode.h"
 #include "vtkMRMLTextNode.h"
 #include "vtkMRMLTextStorageNode.h"
 #include "vtkMRMLTransformDisplayNode.h"
+#include "vtkMRMLTransformNode.h"
 #include "vtkMRMLTransformStorageNode.h"
 #include "vtkMRMLVectorVolumeDisplayNode.h"
 #include "vtkMRMLViewNode.h"
 #include "vtkMRMLVolumeArchetypeStorageNode.h"
 #include "vtkURIHandler.h"
-#include "vtkMRMLLayoutNode.h"
 
+#include "vtkMRMLCrosshairNode.h"
 #include "vtkMRMLDoubleArrayNode.h"
 #include "vtkMRMLDoubleArrayStorageNode.h"
-#include "vtkMRMLCrosshairNode.h"
 #include "vtkMRMLInteractionNode.h"
 
 #ifdef MRML_USE_vtkTeem
@@ -104,6 +105,7 @@ Version:   $Revision: 1.18 $
 # include <vtkTimerLog.h>
 #endif
 
+vtkCxxSetObjectMacro(vtkMRMLScene, SubjectHierarchyNode, vtkMRMLSubjectHierarchyNode);
 vtkCxxSetObjectMacro(vtkMRMLScene, CacheManager, vtkCacheManager)
 vtkCxxSetObjectMacro(vtkMRMLScene, DataIOManager, vtkDataIOManager)
 vtkCxxSetObjectMacro(vtkMRMLScene, UserTagTable, vtkTagTable)
@@ -124,6 +126,8 @@ vtkMRMLScene::vtkMRMLScene()
 
   this->NodeReferences.clear();
   this->ReferencedIDChanges.clear();
+
+  this->SubjectHierarchyNode = nullptr;
 
   this->CacheManager = nullptr;
   this->DataIOManager = nullptr;
@@ -248,6 +252,11 @@ vtkMRMLScene::~vtkMRMLScene()
   for (unsigned int n=0; n<this->RegisteredNodeClasses.size(); n++)
     {
     this->RegisteredNodeClasses[n]->Delete();
+    }
+
+  if ( this->SubjectHierarchyNode != nullptr )
+    {
+    this->SubjectHierarchyNode = nullptr;
     }
 
   if ( this->CacheManager != nullptr )
@@ -868,6 +877,10 @@ int vtkMRMLScene::Import()
   timer->Delete();
 #endif
   this->StoredTime.Modified();
+
+  // Once the import is finished, give the SH a chance to ensure consistency
+  this->SetSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(this));
+
   return returnCode;
 }
 
@@ -1189,10 +1202,16 @@ vtkMRMLNode* vtkMRMLScene::AddNodeNoNotify(vtkMRMLNode *n)
   n->SetScene( this );
   this->Nodes->vtkCollection::AddItem((vtkObject *)n);
 
-  // cache the node so the whole scene cache stays up-todate
+  // cache the node so the whole scene cache stays up-to date
   this->AddNodeID(n);
 
-  //n->OnNodeAddedToScene();
+  // Keep the SH up-to-date
+  if (vtkMRMLSubjectHierarchyNode::SafeDownCast(n) != nullptr &&
+    !(this->IsImporting() || this->IsRestoring()) )
+  {
+    // This should rarely ever be called, but just in case someone added a SH node manually, let's make sure it works
+    this->SetSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(this));
+  }
 
   n->EndModify(wasModifying);
   return n;
@@ -3501,6 +3520,20 @@ const char * vtkMRMLScene::GetErrorMessagePointer()
   {
   return (this->GetErrorMessage().c_str());
   }
+
+//----------------------------------------------------------------------------
+vtkMRMLSubjectHierarchyNode* vtkMRMLScene::GetSubjectHierarchyNode()
+{
+  if (this->SubjectHierarchyNode == nullptr)
+  {
+    this->SetSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(this));
+    if (this->SubjectHierarchyNode == nullptr)
+    {
+      vtkErrorMacro("Unable to resolve subject hierarchy. No node available.");
+    }
+  }
+  return this->SubjectHierarchyNode;
+}
 
 //-----------------------------------------------------------------------------
 bool vtkMRMLScene::GetModifiedSinceRead()

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -25,6 +25,7 @@ Version:   $Revision: 1.18 $
 // VTK includes
 #include <vtkObject.h>
 #include <vtkSmartPointer.h>
+#include <vtkWeakPointer.h>
 
 // STD includes
 #include <list>
@@ -43,6 +44,7 @@ class vtkGeneralTransform;
 class vtkURIHandler;
 class vtkMRMLNode;
 class vtkMRMLSceneViewNode;
+class vtkMRMLSubjectHierarchyNode;
 
 /// \brief A set of MRML Nodes that supports serialization and undo/redo.
 ///
@@ -510,14 +512,16 @@ public:
   void SetErrorMessage(const char * message);
   const char *GetErrorMessagePointer();
 
-  vtkGetObjectMacro ( CacheManager, vtkCacheManager );
-  virtual void SetCacheManager(vtkCacheManager* );
-  vtkGetObjectMacro ( DataIOManager, vtkDataIOManager );
-  virtual void SetDataIOManager(vtkDataIOManager* );
-  vtkGetObjectMacro ( URIHandlerCollection, vtkCollection );
-  virtual void SetURIHandlerCollection(vtkCollection* );
-  vtkGetObjectMacro ( UserTagTable, vtkTagTable);
-  virtual void SetUserTagTable(vtkTagTable* );
+  vtkMRMLSubjectHierarchyNode* GetSubjectHierarchyNode();
+
+  vtkGetObjectMacro(CacheManager, vtkCacheManager);
+  virtual void SetCacheManager(vtkCacheManager*);
+  vtkGetObjectMacro(DataIOManager, vtkDataIOManager);
+  virtual void SetDataIOManager(vtkDataIOManager*);
+  vtkGetObjectMacro(URIHandlerCollection, vtkCollection);
+  virtual void SetURIHandlerCollection(vtkCollection*);
+  vtkGetObjectMacro(UserTagTable, vtkTagTable);
+  virtual void SetUserTagTable(vtkTagTable*);
 
   /// \brief Find a URI handler in the collection that can work on the
   /// passed URI.
@@ -814,7 +818,12 @@ protected:
   /// Returns true if a node is not referenced within the scene, but is referenced within the Undo stack.
   bool IsNodeIDReservedByUndo(const std::string id) const;
 
+  virtual void SetSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode*);
+
   vtkCollection*  Nodes;
+
+  /// subject hierarchy node
+  vtkWeakPointer<vtkMRMLSubjectHierarchyNode> SubjectHierarchyNode;
 
   /// data i/o handling members
   vtkCacheManager *  CacheManager;

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
@@ -356,6 +356,9 @@ public:
   /// Print subject hierarchy item info on stream
   void PrintItem(vtkIdType itemID, ostream& os, vtkIndent indent);
 
+  /// Ensure the consistency and validity of the SH node in the scene
+  static vtkMRMLSubjectHierarchyNode* ResolveSubjectHierarchy(vtkMRMLScene* scene);
+
 protected:
   /// Callback function for all events from the subject hierarchy items
   static void ItemEventCallback(vtkObject* caller, unsigned long eid, void* clientData, void* callData);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
@@ -85,8 +85,6 @@ public:
   /// Allows cleanup of the singleton at application exit
   static void setInstance(qSlicerSubjectHierarchyPluginHandler* instance);
 
-  /// Set subject hierarchy node
-  void setSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode* shNode);
   /// Get subject hierarchy node
   Q_INVOKABLE vtkMRMLSubjectHierarchyNode* subjectHierarchyNode()const;
   /// Set MRML scene
@@ -208,8 +206,6 @@ protected:
   /// (selected items in the tree view e.g. for context menu request)
   QList<vtkIdType> m_CurrentItems;
 
-  /// Subject hierarchy node
-  vtkWeakPointer<vtkMRMLSubjectHierarchyNode> m_SubjectHierarchyNode;
   /// MRML scene (to get new subject hierarchy node if the stored one is deleted)
   vtkWeakPointer<vtkMRMLScene> m_MRMLScene;
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -329,15 +329,12 @@ void qSlicerSubjectHierarchyPluginLogic::onSceneCloseEnded(vtkObject* sceneObjec
 
   // Trigger creating new subject hierarchy node
   // (scene close removed the pseudo-singleton subject hierarchy node)
-  vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
+  vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(scene);
   if (!shNode)
     {
     qCritical() << Q_FUNC_INFO << ": There must be a subject hierarchy node in the scene";
     return;
     }
-
-  // Set subject hierarchy node to plugin handler
-  qSlicerSubjectHierarchyPluginHandler::instance()->setSubjectHierarchyNode(shNode);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Moving consistency logic from vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode to a new function vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy and calling from end of scene import, node added, and SH plugin handler

Subject hierarchy plugin handler no longer cache's the SH node, but requests it from the scene instead