### PR TITLE
BUG: Fix failure in SegmentationWidgetsTest1

### DIFF
--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationWidgetsTest1.py
@@ -119,6 +119,11 @@ class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
     displayNode.SetSegmentVisibility("third", True)
     segmentsTableView.filterBarVisible = False
 
+    # Reset the filtering parameters in the segmentation node to avoid interference with other tests that
+    # use this segmentation node
+    self.inputSegmentationNode.SetSegmentListFilterEnabled(False)
+    self.inputSegmentationNode.SetSegmentListFilterOptions("")
+
   #------------------------------------------------------------------------------
   def compareOutputGeometry(self, orientedImageData, spacing, origin, directions):
     if orientedImageData is None:
@@ -354,6 +359,9 @@ class SegmentationWidgetsTest1(ScriptedLoadableModuleTest):
 
     self.segmentEditorNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLSegmentEditorNode')
     self.assertIsNotNone(self.segmentEditorNode)
+
+    self.inputSegmentationNode.SetSegmentListFilterEnabled(False)
+    self.inputSegmentationNode.SetSegmentListFilterOptions("")
 
     displayNode = self.inputSegmentationNode.GetDisplayNode()
     self.assertIsNotNone(displayNode)


### PR DESCRIPTION
Changes in segment filtering parameters are written to the segmentation node after a short delay in order to prevent unnecessary rendering while typing in the filter bar.
This caused the section 4 of the test to fail because the table widget was deleted before the delay had elapsed and the changes to the segmentation filter could be written to the node.

This commit fixes the test by specifically setting the segmentation node filter parameters both once the test has completed (to avoid interfering with other test sections), and at the start of section 4 (to ensure that changes in the filtering parameters from other tests do not cause a failure in this part of the test again)