### PR TITLE
BUG: Fix traceback in SegmentEditorHollowEffect medial surface

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorHollowEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorHollowEffect.py
@@ -154,7 +154,7 @@ class SegmentEditorHollowEffect(AbstractScriptedSegmentEditorEffect):
     kernelSizePixel = self.getKernelSizePixel()
     if shellMode == MEDIAL_SURFACE:
       # both erosion and dilation will be applied, so kernel size must be half on each side
-      kernelSizePixel = [int(kernelSizePixel[0],2), int(kernelSizePixel[1],2), int(kernelSizePixel[2],2)]
+      kernelSizePixel = [int(kernelSizePixel[0]/2), int(kernelSizePixel[1]/2), int(kernelSizePixel[2]/2)]
 
     # We need to know exactly the value of the segment voxels, apply threshold to make force the selected label value
     labelValue = 1


### PR DESCRIPTION
During the migration to Python 3 (a7f519bd884a2e30cc340d0abf24a9a7013b5b0f), kernelSizePixel[x]/2 was changed to int(kernelSizePixel[x],2).
This commit changes it to the call to: int(kernelSizePixel[x]/2, which prevents the error and matches the original implementation.