### PR TITLE
BUG: Duplicate subject hierarchy items no longer appearing

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
@@ -1815,7 +1815,7 @@ vtkMRMLSubjectHierarchyNode* vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarch
     newShNode->SetName("SubjectHierarchy");
     scene->AddNode(newShNode);
 
-    vtkDebugWithObjectMacro(newShNode.GetPointer(), "vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode: "
+    vtkDebugWithObjectMacro(newShNode.GetPointer(), "vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy: "
       "New subject hierarchy node created as none was found in the scene");
     return newShNode;
     }
@@ -1826,7 +1826,7 @@ vtkMRMLSubjectHierarchyNode* vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarch
   if (!firstShNode)
     {
     vtkErrorWithObjectMacro( scene,
-      "vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode: Invalid first subject hierarchy node" );
+      "vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy: Invalid first subject hierarchy node" );
     return firstShNode;
     }
   if (shNodesInScene.size() == 1)
@@ -1840,7 +1840,7 @@ vtkMRMLSubjectHierarchyNode* vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarch
       // Remove invalid subject hierarchy node so that it can be rebuilt from scratch
       scene->RemoveNode(firstShNode);
       vtkErrorWithObjectMacro( scene,
-        "vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode: Failed to resolve unresolved subject "
+        "vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy: Failed to resolve unresolved subject "
         "hierarchy items, re-building subject hierarchy from scratch" );
       return nullptr;
       }
@@ -1916,8 +1916,8 @@ vtkMRMLSubjectHierarchyNode* vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarch
         }
 
       vtkErrorWithObjectMacro( scene,
-        "vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode: Failed to merge subject hierarchy nodes, re-building subject hierarchy from scratch" );
-      return vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
+        "vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy: Failed to merge subject hierarchy nodes, re-building subject hierarchy from scratch" );
+      return vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(scene);
       }
     }
   // Remove merged subject hierarchy nodes from the scene

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
@@ -44,7 +44,8 @@ class vtkMRMLTransformNode;
 ///   It is not singleton in either the common or the MRML sense, instead, the subject hierarchy logic
 ///   makes sure that any added subject hierarchy nodes are merged in the first one, and if the last one
 ///   is removed, a new one is created. The used subject hierarchy node can be accessed using the static
-///   function \sa GetSubjectHierarchyNode().
+///   function \sa GetSubjectHierarchyNode(). Resolution of multiple SH nodes or stale nodes can be
+///   performed via \sa ResolveSubjectHierarchy()
 ///
 ///   The node entries are encapsulated in SubjectHierarchyItem classes, which contain the hierarchy
 ///   information for the contained nodes, and represent the non-leaf nodes of the tree. Accessor functions

--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
@@ -90,7 +90,7 @@ void vtkSlicerModelsLogic::OnMRMLSceneEndImport()
     vtkErrorMacro("OnMRMLSceneEndImport: Unable to access MRML scene");
     return;
     }
-  vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
+  vtkMRMLSubjectHierarchyNode* shNode = vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(scene);
   if (!shNode)
     {
     vtkErrorMacro("OnMRMLSceneEndImport: Unable to access subject hierarchy node");

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -1473,7 +1473,7 @@ void qMRMLSubjectHierarchyModel::onMRMLSceneImported(vtkMRMLScene* scene)
 void qMRMLSubjectHierarchyModel::onMRMLSceneClosed(vtkMRMLScene* scene)
 {
   // Make sure there is one subject hierarchy node in the scene, and it is used by the model
-  vtkMRMLSubjectHierarchyNode* newSubjectHierarchyNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
+  vtkMRMLSubjectHierarchyNode* newSubjectHierarchyNode = vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(scene);
   if (!newSubjectHierarchyNode)
     {
     qCritical() << Q_FUNC_INFO << ": No subject hierarchy node could be retrieved from the scene";
@@ -1508,7 +1508,7 @@ void qMRMLSubjectHierarchyModel::onMRMLNodeRemoved(vtkMRMLNode* node)
   if (node->IsA("vtkMRMLSubjectHierarchyNode"))
     {
     // Make sure there is one subject hierarchy node in the scene, and it is used by the model
-    vtkMRMLSubjectHierarchyNode* newSubjectHierarchyNode = vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(d->MRMLScene);
+    vtkMRMLSubjectHierarchyNode* newSubjectHierarchyNode = vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(d->MRMLScene);
     if (!newSubjectHierarchyNode)
       {
       qCritical() << Q_FUNC_INFO << ": No subject hierarchy node could be retrieved from the scene";

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -1716,7 +1716,7 @@ void qMRMLSubjectHierarchyTreeView::onMRMLSceneCloseEnded(vtkObject* sceneObject
 
   // Get new subject hierarchy node (or if not created yet then trigger creating it, because
   // scene close removed the pseudo-singleton subject hierarchy node), and set it to the tree view
-  this->setSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene));
+  this->setSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(scene));
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -166,7 +166,7 @@ void qSlicerSubjectHierarchyPluginLogic::onNodeAdded(vtkObject* sceneObject, vtk
   if (subjectHierarchyNode)
     {
     // Calling this function makes sure that there is exactly one subject hierarchy node in the scene (performs the merge if more found)
-    vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
+    vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(scene);
     }
   // If data node, then add it to subject hierarchy
   else
@@ -272,7 +272,7 @@ void qSlicerSubjectHierarchyPluginLogic::onNodeRemoved(vtkObject* sceneObject, v
   if (shNode)
     {
     // Make sure a new quasi-singleton subject hierarchy node is created
-    vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
+    vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(scene);
 
     // Add data nodes that are supported (i.e. there is a plugin that can claim it) and were not
     // in the imported subject hierarchy node to subject hierarchy
@@ -294,7 +294,7 @@ void qSlicerSubjectHierarchyPluginLogic::onSceneImportEnded(vtkObject* sceneObje
   // be done when first accessing the subject hierarchy node, but it needs to be done so that
   // the addSupportedDataNodesToSubjectHierarchy call below only adds the nodes that were not
   // in the hierarchy stored by the imported scene
-  vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
+  vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(scene);
 
   // Add data nodes that are supported (i.e. there is a plugin that can claim it) and were not
   // in the imported subject hierarchy node to subject hierarchy
@@ -312,7 +312,7 @@ void qSlicerSubjectHierarchyPluginLogic::onSceneRestoreEnded(vtkObject* sceneObj
 
   // This call is needed to resolve unresolved items that were copied into the hierarchy
   // when restoring the scene view
-  vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode(scene);
+  vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy(scene);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Contract for vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNode was broken and references that relied on the old behaviour were not updated. This commit analyzed the existing usages and changed them to vtkMRMLSubjectHierarchyNode::ResolveSubjectHierarchy as needed.