### PR TITLE
COMP: Introducing conditional searching of CTKAppLauncherLib

### DIFF
--- a/Base/QTCore/CMakeLists.txt
+++ b/Base/QTCore/CMakeLists.txt
@@ -42,7 +42,9 @@ endif()
 #
 # CTKAppLauncherLib
 #
-find_package(CTKAppLauncherLib REQUIRED)
+if(Slicer_USE_CTKAPPLAUNCHER)
+  find_package(CTKAppLauncherLib REQUIRED)
+endif()
 
 #
 # See CMake/SlicerMacroBuildBaseQtLibrary.cmake for details


### PR DESCRIPTION
Since Slicer_USE_CTKAPPLAUNCHER option exists, it makes sense that,
when Slicer_USE_CTKAPPLAUNCHER=OFF, CTKAppLauncherLib is not
searched. Currently, find_package(CTKAppLauncherLib REQUIRED) is
called regardless of the state of Slicer_USE_CTKAPPLAUNCHER. This can
cause configuration issues when configuring Slicer.

With the following configuration:

		-DSlicer_SUPERBUILD=OFF
		-DBUILD_TESTING=OFF
		-DSlicer_BUILD_EXTENSIONMANAGER_SUPPORT=OFF
		-DSlicer_BUILD_CLI_SUPPORT=OFF
		-DSlicer_BUILD_CLI=OFF
		-DCMAKE_CXX_STANDARD=11
		-DSlicer_REQUIRED_QT_VERSION=5
		-DSlicer_BUILD_DICOM_SUPPORT=OFF
		-DSlicer_BUILD_ITKPython=OFF
		-DSlicer_BUILD_QTLOADABLEMODULES=OFF
		-DSlicer_BUILD_QT_DESIGNER_PLUGINS=OFF
		-DSlicer_USE_CTKAPPLAUNCHER=OFF
		-DSlicer_USE_PYTHONQT=OFF
		-DSlicer_USE_QtTesting=OFF
		-DSlicer_USE_SimpleITK=OFF
		-DSlicer_VTK_RENDERING_BACKEND=OpenGL2
		-DSlicer_VTK_VERSION_MAJOR=8
		-DSlicer_INSTALL_DEVELOPMENT=ON
		-DCMAKE_INSTALL_RPATH=/usr/lib64/Slicer-4.11:/usr/lib64/ctk-0.1:/usr/lib64/Slicer-4.11/qt-loadable-modules:/usr/lib64/ITK-5.1.0
		-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
		-DSlicer_USE_SYSTEM_LibArchive=ON
		-DTeem_DIR=/usr/lib64
		-DjqPlot_DIR=/usr/share/jqPlot

the following error raises:

CMake Error at Base/QTCore/CMakeLists.txt:45 (find_package):
  By not providing "FindCTKAppLauncherLib.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "CTKAppLauncherLib", but CMake did not find one.

  Could not find a package configuration file provided by "CTKAppLauncherLib"
  with any of the following names:

    CTKAppLauncherLibConfig.cmake
    ctkapplauncherlib-config.cmake

  Add the installation prefix of "CTKAppLauncherLib" to CMAKE_PREFIX_PATH or
  set "CTKAppLauncherLib_DIR" to a directory containing one of the above
  files.  If "CTKAppLauncherLib" provides a separate development package or
  SDK, be sure it has been installed.