### PR TITLE
COMP: Find ITK components in vtkTeem

### DIFF
--- a/Libs/vtkTeem/CMakeLists.txt
+++ b/Libs/vtkTeem/CMakeLists.txt
@@ -22,6 +22,11 @@ endif()
 #include(${VTK_USE_FILE})
 
 #
+# ITK
+#
+find_package(ITK COMPONENTS ITKCommon ITKVNL REQUIRED)
+
+#
 # Teem
 #
 find_package(Teem REQUIRED NO_MODULE)


### PR DESCRIPTION
With the following configuration:

		-DSlicer_SUPERBUILD=OFF
		-DBUILD_TESTING=OFF
		-DSlicer_BUILD_EXTENSIONMANAGER_SUPPORT=OFF
		-DSlicer_BUILD_CLI_SUPPORT=OFF
		-DSlicer_BUILD_CLI=OFF
		-DCMAKE_CXX_STANDARD=11
		-DSlicer_REQUIRED_QT_VERSION=5
		-DSlicer_BUILD_DICOM_SUPPORT=OFF
		-DSlicer_BUILD_ITKPython=OFF
		-DSlicer_BUILD_QTLOADABLEMODULES=OFF
		-DSlicer_BUILD_QT_DESIGNER_PLUGINS=OFF
		-DSlicer_USE_CTKAPPLAUNCHER=OFF
		-DSlicer_USE_PYTHONQT=OFF
		-DSlicer_USE_QtTesting=OFF
		-DSlicer_USE_SimpleITK=OFF
		-DSlicer_VTK_RENDERING_BACKEND=OpenGL2
		-DSlicer_VTK_VERSION_MAJOR=8
		-DSlicer_INSTALL_DEVELOPMENT=ON
		-DCMAKE_INSTALL_RPATH=/usr/lib64/Slicer-4.11:/usr/lib64/ctk-0.1:/usr/lib64/Slicer-4.11/qt-loadable-modules:/usr/lib64/ITK-5.1.0
		-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
		-DSlicer_USE_SYSTEM_LibArchive=ON
		-DTeem_DIR=/usr/lib64
		-DjqPlot_DIR=/usr/share/jqPlot

The following error raises:

	[  2%] Building CXX object Libs/vtkTeem/CMakeFiles/vtkTeem.dir/vtkTeemNRRDWriter.cxx.o
	In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/x86_64-pc-linux-gnu/bits/os_defines.h:39,
			 from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/x86_64-pc-linux-gnu/bits/c++config.h:508,
			 from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/bits/stl_algobase.h:59,
			 from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/bits/stl_tree.h:63,
			 from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/map:60,
			 from /home/aure/src/Slicer/Slicer/Libs/vtkTeem/vtkTeemNRRDWriter.cxx:1:
	/usr/include/features.h:382:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
	 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
	    ^~~~~~~
	/home/aure/src/Slicer/Slicer/Libs/vtkTeem/vtkTeemNRRDWriter.cxx:12:10: fatal error: vnl/vnl_math.h: No such file or directory
	 #include <vnl/vnl_math.h>

This problem can be solved by finding ITKVNL from ITK in vtkTeem