### PR TITLE
COMP: Conditional CTKAppLauncher code in qSlicerCoreApplication

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -93,8 +93,10 @@
 #include <vtkMRMLScene.h>
 
 // CTKLauncherLib includes
+#ifdef Slicer_USE_CTKAPPLAUNCHER
 #include <ctkAppLauncherEnvironment.h>
 #include <ctkAppLauncherSettings.h>
+#endif
 
 // VTK includes
 #include <vtkNew.h>
@@ -213,6 +215,7 @@ void qSlicerCoreApplicationPrivate::init()
 
   this->SlicerHome = this->discoverSlicerHomeDirectory();
 
+#ifdef Slicer_Use_CTKAPPLAUNCHER
   // Save the environment if no launcher is used (this is for example the case
   // on MacOSX when slicer is started from an install tree)
   if (ctkAppLauncherEnvironment::currentLevel() == 0)
@@ -260,6 +263,8 @@ void qSlicerCoreApplicationPrivate::init()
       q->setEnvironmentVariable(key, value);
       }
     }
+
+#endif
 
 #ifdef Slicer_USE_PYTHONQT_WITH_OPENSSL
   if (!QSslSocket::supportsSsl())
@@ -706,7 +711,11 @@ bool qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::ApplicationAt
 //-----------------------------------------------------------------------------
 QProcessEnvironment qSlicerCoreApplication::startupEnvironment() const
 {
+#ifdef Slicer_Use_CTKAPPLAUNCHER
   return ctkAppLauncherEnvironment::environment(0);
+#else
+  return QProcessEnvironment();
+#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Using the following configuration:

		-DSlicer_SUPERBUILD=OFF
		-DBUILD_TESTING=OFF
		-DSlicer_BUILD_EXTENSIONMANAGER_SUPPORT=OFF
		-DSlicer_BUILD_CLI_SUPPORT=OFF
		-DSlicer_BUILD_CLI=OFF
		-DCMAKE_CXX_STANDARD=11
		-DSlicer_REQUIRED_QT_VERSION=5
		-DSlicer_BUILD_DICOM_SUPPORT=OFF
		-DSlicer_BUILD_ITKPython=OFF
		-DSlicer_BUILD_QTLOADABLEMODULES=OFF
		-DSlicer_BUILD_QT_DESIGNER_PLUGINS=OFF
		-DSlicer_USE_CTKAPPLAUNCHER=OFF
		-DSlicer_USE_PYTHONQT=OFF
		-DSlicer_USE_QtTesting=OFF
		-DSlicer_USE_SimpleITK=OFF
		-DSlicer_VTK_RENDERING_BACKEND=OpenGL2
		-DSlicer_VTK_VERSION_MAJOR=8
		-DSlicer_INSTALL_DEVELOPMENT=ON
		-DCMAKE_INSTALL_RPATH=/usr/lib64/Slicer-4.11:/usr/lib64/ctk-0.1:/usr/lib64/Slicer-4.11/qt-loadable-modules:/usr/lib64/ITK-5.1.0
		-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
		-DSlicer_USE_SYSTEM_LibArchive=ON
		-DTeem_DIR=/usr/lib64
		-DjqPlot_DIR=/usr/share/jqPlot

The following error is raised:

	[ 70%] Building CXX object Base/QTCore/CMakeFiles/qSlicerBaseQTCore.dir/qSlicerCoreApplication.cxx.o
	In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/x86_64-pc-linux-gnu/bits/os_defines.h:39,
			 from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/x86_64-pc-linux-gnu/bits/c++config.h:508,
			 from /usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/include/g++-v8/clocale:41,
			 from /home/aure/src/Slicer/Slicer/Base/QTCore/qSlicerCoreApplication.cxx:22:
	/usr/include/features.h:382:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
	 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
	    ^~~~~~~
	/home/aure/src/Slicer/Slicer/Base/QTCore/qSlicerCoreApplication.cxx:96:10: fatal error: ctkAppLauncherEnvironment.h: No such file or directory
	 #include <ctkAppLauncherEnvironment.h>

Since the Slicer_USE_CTKAPPLAUNCHER option exists, it makes sense to
add conditional pre-processing directives to include/exclude code
related to the CTKAppLauncher.