### PR TITLE
BUG: Fix bugs and performance issues in Segmentations

### DIFF
--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
@@ -169,12 +169,14 @@ public:
   /// \param maskLabelmap Mask image to get values under
   /// \param Threshold value for the mask. Values above this threshold are considered to be under the mask
   /// \param values The values found in the binary labelmap underneath the mask
-  static void GetLabelValuesInMask(vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask, int maskThreshold, std::vector<int> &labelValues);
+  static void GetLabelValuesInMask(vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask,
+    const int extent[6], std::vector<int> &labelValues, int maskThreshold=0);
 
   /// Determine if there is a non-zero value in the labelmap under the mask
   /// \param binaryLabelmap Input image to get values from
   /// \param maskLabelmap Mask image to get values under
-  static bool IsLabelInMask(vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask, int maskThreshold);
+  static bool IsLabelInMask(vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask,
+    int extent[6], int maskThreshold=0);
 
   /// Cast the data type of the image to be able to contain the specified value
   /// \param image Image to convert

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -291,9 +291,9 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
     previewNode.GetSegmentation().GetSegmentIDs(segmentIDs)
     for index in range(segmentIDs.GetNumberOfValues()):
       segmentID = segmentIDs.GetValue(index)
-      previewSegment = previewNode.GetSegmentation().GetSegment(segmentID)
-      previewSegmentLabelmap = previewSegment.GetRepresentation(vtkSegmentationCore.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName())
-      self.scriptedEffect.modifySegmentByLabelmap(segmentationNode, segmentID,previewSegmentLabelmap,
+      previewSegmentLabelmap = slicer.vtkOrientedImageData()
+      previewNode.GetBinaryLabelmapRepresentation(segmentID, previewSegmentLabelmap)
+      self.scriptedEffect.modifySegmentByLabelmap(segmentationNode, segmentID, previewSegmentLabelmap,
         slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeSet)
       if segmentationDisplayNode is not None and self.isBackgroundLabelmap(previewSegmentLabelmap):
         # Automatically hide result segments that are background (all eight corners are non-zero)

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLogicalEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLogicalEffect.py
@@ -247,7 +247,7 @@ class SegmentEditorLogicalEffect(AbstractScriptedSegmentEditorEffect):
           max(selectedSegmentLabelmapExtent[4], modifierSegmentLabelmapExtent[4]),
           min(selectedSegmentLabelmapExtent[5], modifierSegmentLabelmapExtent[5])]
         self.scriptedEffect.modifySelectedSegmentByLabelmap(
-          intersectionLabelmap, slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeSet, commonExtent)
+          intersectionLabelmap, slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeSet, commonExtent, bypassMasking)
 
     elif operation == LOGICAL_INVERT:
       selectedSegmentLabelmap = self.scriptedEffect.selectedSegmentLabelmap()

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
@@ -335,15 +335,20 @@ If segments overlap, segment higher in the segments table will have priority. <b
     imageToWorldMatrix = vtk.vtkMatrix4x4()
     mergedImage.GetImageToWorldMatrix(imageToWorldMatrix)
 
+    # TODO: Temporarily setting the overwite mode to OverwriteVisibleSegments is an approach that should be change once additional
+    # layer control options have been implemented. Users may wish to keep segments on separate layers, and not allow them to be separated/merged automatically.
+    # This effect could leverage those options once they have been implemented.
+    oldOverwriteMode = self.scriptedEffect.parameterSetNode().GetOverwriteMode()
+    self.scriptedEffect.parameterSetNode().SetOverwriteMode(slicer.vtkMRMLSegmentEditorNode.OverwriteVisibleSegments)
     for segmentId, labelValue in segmentLabelValues:
       threshold.ThresholdBetween(labelValue, labelValue)
       stencil.Update()
       smoothedBinaryLabelMap = slicer.vtkOrientedImageData()
       smoothedBinaryLabelMap.ShallowCopy(stencil.GetOutput())
       smoothedBinaryLabelMap.SetImageToWorldMatrix(imageToWorldMatrix)
-      # Write results to segments directly, bypassing masking
-      slicer.vtkSlicerSegmentationsModuleLogic.SetBinaryLabelmapToSegment(smoothedBinaryLabelMap,
-        segmentationNode, segmentId, slicer.vtkSlicerSegmentationsModuleLogic.MODE_REPLACE, smoothedBinaryLabelMap.GetExtent())
+      self.scriptedEffect.modifySegmentByLabelmap(segmentationNode, segmentId, smoothedBinaryLabelMap,
+        slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeSet, False)
+    self.scriptedEffect.parameterSetNode().SetOverwriteMode(oldOverwriteMode)
 
 MEDIAN = 'MEDIAN'
 GAUSSIAN = 'GAUSSIAN'

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -369,7 +369,7 @@ public:
   /// \param mask Mask labelmap
   /// \param segmentIDs Output list of segment IDs under the mask
   /// \param includeInputSharedSegmentID If false, sharedSegmentID will not be added to the list of output segment IDs even if it is within the mask
-  static bool GetSharedSegmentIDsInMask(vtkMRMLSegmentationNode* segmentationNode, std::string sharedSegmentID, vtkOrientedImageData* mask,
+  static bool GetSharedSegmentIDsInMask(vtkMRMLSegmentationNode* segmentationNode, std::string sharedSegmentID, vtkOrientedImageData* mask, const int extent[6],
     std::vector<std::string>& segmentIDs, int maskThreshold = 0.0, bool includeInputSharedSegmentID = false);
 
 public:

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>348</width>
-    <height>719</height>
+    <width>340</width>
+    <height>756</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -446,58 +446,6 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="CollapsibleButton_BinaryLabelmapLayers">
-     <property name="text">
-      <string>Binary labelmap layers</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_LayerCount">
-        <property name="text">
-         <string>Layer count:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QPushButton" name="pushButton_CollapseLayers">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Collapse labelmap layers</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="checkBox_OverwriteSegments">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Overwrite segments</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="label_LayerCountValue">
-        <property name="text">
-         <string>0</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="ctkCollapsibleButton" name="CollapsibleButton_ImportExportSegment">
      <property name="text">
       <string>Export/import models and labelmaps</string>
@@ -524,12 +472,26 @@
       <property name="spacing">
        <number>4</number>
       </property>
-      <item row="0" column="1">
-       <widget class="QRadioButton" name="radioButton_Export">
-        <property name="text">
-         <string>Export</string>
-        </property>
-       </widget>
+      <item row="3" column="1" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="qMRMLSubjectHierarchyComboBox" name="SubjectHierarchyComboBox_ImportExport"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_ClearSelection">
+          <property name="toolTip">
+           <string>Clear selection indicating that a new node should be created</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="../../Widgets/Resources/qSlicerSegmentationsModuleWidgets.qrc">
+            <normaloff>:/Icons/ClearSelection.png</normaloff>:/Icons/ClearSelection.png</iconset>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label">
@@ -555,13 +517,6 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="3">
-       <widget class="ctkPushButton" name="PushButton_ImportExport">
-        <property name="text">
-         <string>Apply</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_ImportExportType">
         <property name="text">
@@ -573,6 +528,20 @@
        <widget class="QLabel" name="label_ImportExportNode">
         <property name="text">
          <string>Output:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="3">
+       <widget class="ctkPushButton" name="PushButton_ImportExport">
+        <property name="text">
+         <string>Apply</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="radioButton_Export">
+        <property name="text">
+         <string>Export</string>
         </property>
        </widget>
       </item>
@@ -688,27 +657,6 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="1" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="qMRMLSubjectHierarchyComboBox" name="SubjectHierarchyComboBox_ImportExport"/>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_ClearSelection">
-          <property name="toolTip">
-           <string>Clear selection indicating that a new node should be created</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset resource="../../Widgets/Resources/qSlicerSegmentationsModuleWidgets.qrc">
-            <normaloff>:/Icons/ClearSelection.png</normaloff>:/Icons/ClearSelection.png</iconset>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
      </layout>
     </widget>
    </item>
@@ -754,6 +702,88 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="CollapsibleButton_BinaryLabelmapLayers">
+     <property name="text">
+      <string>Binary labelmap layers</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_LayerCountText">
+        <property name="text">
+         <string>Layer count:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="label_LayerCountValue">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_OverwriteSegmentsText">
+        <property name="text">
+         <string>Overwrite segments:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_SegmentCountText">
+        <property name="text">
+         <string>Number of segments:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="3">
+       <widget class="QPushButton" name="pushButton_CollapseLayers">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Collapse labelmap layers</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="label_SegmentCountValue">
+        <property name="text">
+         <string>0</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="checkBox_OverwriteSegments">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -324,9 +324,6 @@ void qSlicerSegmentationsModuleWidget::init()
   connect(d->MRMLNodeComboBox_OtherSegmentationOrRepresentationNode, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
     this, SLOT(setOtherSegmentationOrRepresentationNode(vtkMRMLNode*)) );
 
-  connect(d->pushButton_CollapseLayers, SIGNAL(clicked()),
-    this, SLOT(collapseLabelmapLayers()));
-
   connect(d->ImportExportOperationButtonGroup, SIGNAL(buttonClicked(QAbstractButton*)),
     this, SLOT(updateImportExportWidgets()));
 
@@ -350,6 +347,11 @@ void qSlicerSegmentationsModuleWidget::init()
     this, SLOT(onCopyToCurrentSegmentation()) );
   connect(d->toolButton_MoveToCurrentSegmentation, SIGNAL(clicked()),
     this, SLOT(onMoveToCurrentSegmentation()) );
+
+  connect(d->CollapsibleButton_BinaryLabelmapLayers, SIGNAL(contentsCollapsed(bool)),
+    this, SLOT(updateLayerWidgets()));
+  connect(d->pushButton_CollapseLayers, SIGNAL(clicked()),
+    this, SLOT(collapseLabelmapLayers()));
 
   // Show only segment names in copy/view segment list and make it non-editable
   d->SegmentsTableView_Current->setSelectionMode(QAbstractItemView::ExtendedSelection);
@@ -573,16 +575,32 @@ void qSlicerSegmentationsModuleWidget::updateLayerWidgets()
 {
   Q_D(qSlicerSegmentationsModuleWidget);
 
-  std::stringstream ss;
+  if (d->CollapsibleButton_BinaryLabelmapLayers->collapsed())
+    {
+    return;
+    }
+
+  std::stringstream segmentCountSS;
   if (!d->SegmentationNode)
     {
-    ss << "0";
+    segmentCountSS << "0";
     }
   else
     {
-    ss << d->SegmentationNode->GetSegmentation()->GetNumberOfLayers(vtkSegmentationConverter::GetBinaryLabelmapRepresentationName());
+    segmentCountSS << d->SegmentationNode->GetSegmentation()->GetNumberOfSegments();
     }
-  d->label_LayerCountValue->setText(QString::fromStdString(ss.str()));
+  d->label_SegmentCountValue->setText(QString::fromStdString(segmentCountSS.str()));
+
+  std::stringstream layerCountSS;
+  if (!d->SegmentationNode)
+    {
+    layerCountSS << "0";
+    }
+  else
+    {
+    layerCountSS << d->SegmentationNode->GetSegmentation()->GetNumberOfLayers(vtkSegmentationConverter::GetBinaryLabelmapRepresentationName());
+    }
+  d->label_LayerCountValue->setText(QString::fromStdString(layerCountSS.str()));
 }
 
 //-----------------------------------------------------------------------------
@@ -650,6 +668,7 @@ void qSlicerSegmentationsModuleWidget::updateImportExportWidgets()
 void qSlicerSegmentationsModuleWidget::onImportExportApply()
 {
   Q_D(qSlicerSegmentationsModuleWidget);
+  QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
   if (d->radioButton_Export->isChecked())
     {
     this->exportFromCurrentSegmentation();
@@ -658,6 +677,7 @@ void qSlicerSegmentationsModuleWidget::onImportExportApply()
     {
     this->importToCurrentSegmentation();
     }
+  QApplication::restoreOverrideCursor();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
* Move and reformat "Binary labelmap layers" section of Segmentations module
* Only update layer section in Segmentations while it is open
* Add total segment count to layer section
* Show wait cursor while importing labelmap nodes to segmentation
* Improve performance when modifying segments through segment editor
* Fix bugs in Joint Smoothing and AutoComplete editor effects that allowed resulting segments to exist on multiple layers
* Improve 3D segment pipeline to improve speed when segment visibility is changed
* Preferred display representation is no longer set to be closed surface by default
* Fix bug that allowed segments to be added to the subject hierarchy twice