### PR TITLE
ENH: expose module load/unload API

### DIFF
--- a/Base/QTCore/qSlicerAbstractModuleFactoryManager.h
+++ b/Base/QTCore/qSlicerAbstractModuleFactoryManager.h
@@ -183,6 +183,12 @@ public:
   /// Uninstantiate all instantiated modules
   void uninstantiateModules();
 
+  /// Instantiate a module given its \a name
+  Q_INVOKABLE qSlicerAbstractCoreModule* instantiateModule(const QString& name);
+
+  /// Uninstantiate a module given its \a moduleName
+  Q_INVOKABLE virtual void uninstantiateModule(const QString& moduleName);
+
   /// Enable/Disable verbose output during module discovery process
   void setVerboseModuleDiscovery(bool value);
 
@@ -226,12 +232,6 @@ protected:
   QScopedPointer<qSlicerAbstractModuleFactoryManagerPrivate> d_ptr;
 
   void registerModules(const QString& directoryPath);
-
-  /// Instantiate a module given its \a name
-  qSlicerAbstractCoreModule* instantiateModule(const QString& name);
-
-  /// Uninstantiate a module given its \a moduleName
-  virtual void uninstantiateModule(const QString& moduleName);
 
 private:
   Q_DECLARE_PRIVATE(qSlicerAbstractModuleFactoryManager);

--- a/Base/QTCore/qSlicerModuleFactoryManager.h
+++ b/Base/QTCore/qSlicerModuleFactoryManager.h
@@ -86,7 +86,11 @@ public:
 
   /// Load module identified by \a name
   /// \todo move it as protected
-  bool loadModule(const QString& name);
+  Q_INVOKABLE bool loadModule(const QString& name);
+
+  /// Unload module identified by \a name
+  Q_INVOKABLE void unloadModule(const QString& name);
+
 
   /// Return all module paths that are direct child of \a basePath.
   QStringList modulePaths(const QString& basePath);
@@ -111,9 +115,6 @@ protected:
   QScopedPointer<qSlicerModuleFactoryManagerPrivate> d_ptr;
 
   bool loadModule(const QString& name, const QString& dependee);
-
-  /// Unload module identified by \a name
-  void unloadModule(const QString& name);
 
   /// Uninstantiate a module given its \a moduleName
   void uninstantiateModule(const QString& moduleName) override;


### PR DESCRIPTION
Exposing these methods allows programmatic control over
module loading and unloading, which can be useful for giving
users access to experimental modules, like with the following
script:

```
import os
import shutil

archiveFilePath = os.path.join(slicer.app.temporaryPath, "master.zip")
outputDir = os.path.join(slicer.app.temporaryPath, "SlicerAnimator")

try:
    os.remove(archiveFilePath)
except FileNotFoundError:
    pass

try:
    shutil.rmtree(outputDir)
except FileNotFoundError:
    pass

os.mkdir(outputDir)

slicer.util.downloadAndExtractArchive(
    url = "https://github.com/pieper/SlicerAnimator/archive/master.zip",
    archiveFilePath = archiveFilePath,
    outputDir = outputDir)

modulePath = os.path.join(outputDir, "SlicerAnimator-master", "Animator", "Animator.py")
factoryManager = slicer.app.moduleManager().factoryManager()
factoryManager.registerModule(qt.QFileInfo(modulePath))

factoryManager.instantiateModule("Animator")
factoryManager.loadModule("Animator")

slicer.util.selectModule("Animator")
slicer.util.delayDisplay("Waiting")

factoryManager.unloadModule("Animator")

```