### PR TITLE
ENH: Add insert control point xyz function

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -689,6 +689,27 @@ bool vtkMRMLMarkupsNode::InsertControlPoint(ControlPoint *controlPoint, int targ
 }
 
 //-----------------------------------------------------------
+bool vtkMRMLMarkupsNode::InsertControlPointWorld(int n, vtkVector3d pointWorld, std::string label)
+{
+  vtkVector3d point;
+  this->TransformPointFromWorld(pointWorld, point);
+  return this->InsertControlPoint(n, point, label);
+}
+
+
+//-----------------------------------------------------------
+bool vtkMRMLMarkupsNode::InsertControlPoint(int n, vtkVector3d point, std::string label)
+{
+  ControlPoint *controlPoint = new ControlPoint;
+  controlPoint->Label = label;
+  controlPoint->Position[0] = point.GetX();
+  controlPoint->Position[1] = point.GetY();
+  controlPoint->Position[2] = point.GetZ();
+  controlPoint->PositionStatus = PositionDefined;
+  return this->InsertControlPoint(controlPoint, n);
+}
+
+//-----------------------------------------------------------
 void vtkMRMLMarkupsNode::UpdateCurvePolyFromControlPoints()
 {
   // Add points

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -1435,7 +1435,9 @@ bool vtkMRMLMarkupsNode::ResetNthControlPointID(int n)
     {
     return false;
     }
+
   this->SetNthControlPointID(n, this->GenerateUniqueControlPointID());
+  this->LastUsedControlPointNumber++;
   return true;
 }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -311,6 +311,14 @@ public:
   /// Returns true on success, false on failure.
   bool InsertControlPoint(ControlPoint* controlPoint, int targetIndex);
 
+  //Add and insert control point at index, defined in the world coordinate system.
+  //\sa InsertControlPoint
+  bool InsertControlPointWorld(int n, vtkVector3d pointWorld, std::string label = std::string());
+
+  //Add and insert control point at index
+  //\sa InsertControlPoint
+  bool InsertControlPoint(int n, vtkVector3d point, std::string label = std::string());
+
   /// Swap the position of two control points
   void SwapControlPoints(int m1, int m2);
 


### PR DESCRIPTION
Adds functions to insert a control point using a vector (previously only available using ControlPoint structure)

Also has a bugfix for resetting the ID on a control point.  Previously, LastUsedControlPointNumber was no incremented fro each reset, and so if you reset multiple points that would each gave the same ID. 