### PR TITLE
BUG: Fix segments model update when multiple segments are removed

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
@@ -810,16 +810,18 @@ void qMRMLSegmentsModel::onSegmentAdded(QString segmentID)
 void qMRMLSegmentsModel::onSegmentRemoved(QString removedSegmentID)
 {
   Q_D(qMRMLSegmentsModel);
-  QModelIndex index = this->indexFromSegmentID(removedSegmentID);
   if (!removedSegmentID.isEmpty())
     {
+    QModelIndex index = this->indexFromSegmentID(removedSegmentID);
     this->removeRow(index.row());
     return;
     }
 
   std::vector<std::string> segmentIDs;
   d->SegmentationNode->GetSegmentation()->GetSegmentIDs(segmentIDs);
-  for (int i = 0; i < this->rowCount(); ++i)
+
+  // Iterate in reverse so the index remains valid
+  for (int i = this->rowCount()-1; i >= 0; --i)
     {
     QModelIndex index = this->index(i, 0);
     std::string currentSegmentID = this->segmentIDFromIndex(index).toStdString();


### PR DESCRIPTION
When multiple segments are removed within a StartModify/EndModify, not all removed segments were removed from the table.
This was because the onSegmentRemoved iterated over the rows from 0 to rowCount. The index would be invalidated if any rows were removed.
Fixed by iterating through the rows in reverse.