### PR TITLE
BUG: Fix missing labels in closed surface to binary labelmap conversion

### DIFF
--- a/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.cxx
@@ -46,6 +46,8 @@
 // STD includes
 #include <sstream>
 
+int DEFAULT_LABEL_VALUE = 1;
+
 //----------------------------------------------------------------------------
 vtkSegmentationConverterRuleNewMacro(vtkClosedSurfaceToBinaryLabelmapConversionRule);
 
@@ -224,7 +226,9 @@ bool vtkClosedSurfaceToBinaryLabelmapConversionRule::Convert(vtkSegment* segment
   stencil->SetInputData(binaryLabelmap);
   stencil->SetStencilConnection(polyDataToImageStencil->GetOutputPort());
   stencil->ReverseStencilOn();
-  stencil->SetBackgroundValue(segment->GetLabelValue()); // General foreground value is 1 (background value because of reverse stencil)
+  // If the output labelmap was to required to be unsigned char, we could use the segment label value.
+  // To ensure that the label value is < 255, we set it to 1. Collapsing the labelmaps during post-conversion may assign new a value regardless.
+  stencil->SetBackgroundValue(DEFAULT_LABEL_VALUE); // General foreground value is 1 (background value because of reverse stencil)
 
   // Save result to output
   vtkNew<vtkImageCast> imageCast;
@@ -236,6 +240,9 @@ bool vtkClosedSurfaceToBinaryLabelmapConversionRule::Convert(vtkSegment* segment
   // Restore geometry of the labelmap that we set to identity before conversion
   // (so that we can perform the stencil operations in IJK space)
   binaryLabelmap->SetGeometryFromImageToWorldMatrix(outputLabelmapImageToWorldMatrix);
+
+  // Set segment value to 1
+  segment->SetLabelValue(DEFAULT_LABEL_VALUE);
 
   return true;
 }

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
@@ -55,7 +55,7 @@ void MergeImageGeneric2(
     vtkImageData *baseImage,
     vtkImageData *modifierImage,
     int operation,
-    const int extent[6],
+    const int extent[6]/*=nullptr*/,
     double maskThreshold,
     double fillValue)
 {
@@ -234,7 +234,7 @@ void MergeImageGeneric(
     vtkImageData *baseImage,
     vtkImageData *modifierImage,
     int operation,
-    const int extent[6],
+    const int extent[6]/*=nullptr*/,
     double maskThreshold,
     double fillValue)
 {
@@ -1071,7 +1071,7 @@ bool vtkOrientedImageDataResample::MergeImage(
     vtkOrientedImageData* imageToAppend,
     vtkOrientedImageData* outputImage,
     int operation,
-    const int extent[6]/*=0*/,
+    const int extent[6]/*=nullptr*/,
     double maskThreshold /*=0*/,
     double fillValue /*=1*/,
     bool *outputModified /*=nullptr*/)
@@ -1428,10 +1428,10 @@ bool vtkOrientedImageDataResample::ApplyImageMask(vtkOrientedImageData* input, v
 //----------------------------------------------------------------------------
 template <class ImageScalarType, class MaskScalarType>
 void GetLabelValuesInMaskGeneric2(
+  std::vector<int>& foundValues,
   vtkOrientedImageData* binaryLabelmap,
   vtkOrientedImageData* mask,
-  const int extent[6],
-  std::vector<int> &foundValues,
+  const int extent[6]/*=nullptr*/,
   int maskThreshold)
 {
   // Compute update extent as intersection of base and mask image extents (extent can be further reduced by specifying a smaller extent)
@@ -1568,19 +1568,19 @@ void GetLabelValuesInMaskGeneric2(
 //----------------------------------------------------------------------------
 template <class ImageScalarType>
 void GetLabelValuesInMaskGeneric(
+  std::vector<int>& foundValues,
   vtkOrientedImageData* binaryLabelmap,
   vtkOrientedImageData* resampledMask,
-  const int extent[6],
-  std::vector<int> &foundValues,
+  const int extent[6]/*=nullptr*/,
   int maskThreshold)
 {
   switch (resampledMask->GetScalarType())
     {
     vtkTemplateMacro((GetLabelValuesInMaskGeneric2<ImageScalarType, VTK_TT>(
+      foundValues,
       binaryLabelmap,
       resampledMask,
       extent,
-      foundValues,
       maskThreshold)));
     default:
       vtkGenericWarningMacro("vtkOrientedImageDataResample::GetLabelValuesInMaskGeneric: Unknown ScalarType");
@@ -1588,8 +1588,8 @@ void GetLabelValuesInMaskGeneric(
 }
 
 //-----------------------------------------------------------------------------
-void vtkOrientedImageDataResample::GetLabelValuesInMask(
-  vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask, const int extent[6], std::vector<int>& labelValues, int maskThreshold/*=0*/)
+void vtkOrientedImageDataResample::GetLabelValuesInMask(std::vector<int>& labelValues,
+  vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask, const int extent[6]/*=nullptr*/, int maskThreshold/*=0*/)
 {
   labelValues.clear();
 
@@ -1642,10 +1642,10 @@ void vtkOrientedImageDataResample::GetLabelValuesInMask(
   switch (binaryLabelmap->GetScalarType())
     {
     vtkTemplateMacro((GetLabelValuesInMaskGeneric<VTK_TT>(
+      foundValues,
       resampledBinaryLabelmap,
       resampledMask,
       extent,
-      foundValues,
       maskThreshold)));
     default:
       vtkGenericWarningMacro("vtkOrientedImageDataResample::GetLabelValuesInMask: Unknown ScalarType");
@@ -1661,7 +1661,7 @@ void vtkOrientedImageDataResample::GetLabelValuesInMask(
 //----------------------------------------------------------------------------
 template <class ImageScalarType, class MaskScalarType>
 void IsLabelInMaskGeneric2(vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask,
-  int extent[6], int maskThreshold, bool &inMask)
+  int extent[6]/*=nullptr*/, int maskThreshold, bool &inMask)
 {
   // Compute update extent as intersection of base and mask image extents (extent can be further reduced by specifying a smaller extent)
   int updateExt[6] = { 0, -1, 0, -1, 0, -1 };
@@ -1733,7 +1733,7 @@ void IsLabelInMaskGeneric2(vtkOrientedImageData* binaryLabelmap, vtkOrientedImag
 //----------------------------------------------------------------------------
 template <class ImageScalarType>
 void IsLabelInMaskGeneric(vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask,
-  int extent[6], int maskThreshold, bool &inMask)
+  int extent[6]/*=nullptr*/, int maskThreshold, bool &inMask)
 {
   switch (mask->GetScalarType())
     {
@@ -1750,7 +1750,7 @@ void IsLabelInMaskGeneric(vtkOrientedImageData* binaryLabelmap, vtkOrientedImage
 
 //-----------------------------------------------------------------------------
 bool vtkOrientedImageDataResample::IsLabelInMask(
-  vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask, int extent[6], int maskThreshold/*=0*/)
+  vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask, int extent[6]/*=nullptr*/, int maskThreshold/*=0*/)
 {
   int binaryExtent[6] = { 0 };
   binaryLabelmap->GetExtent(binaryExtent);

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
@@ -85,7 +85,7 @@ public:
   /// Extent can be specified to restrict imageToAppend's extent to a smaller region.
   /// inputImage and imageToAppend must have the same geometry, but they may have different extents.
   static bool MergeImage(vtkOrientedImageData* inputImage, vtkOrientedImageData* imageToAppend, vtkOrientedImageData* outputImage, int operation,
-    const int extent[6] = nullptr, double maskThreshold = 0, double fillValue = 1, bool *outputModified=nullptr);
+    const int extent[6]=nullptr, double maskThreshold = 0, double fillValue = 1, bool *outputModified=nullptr);
 
   /// Modifies inputImage in-place by combining with modifierImage using max/min operation.
   /// The extent will remain unchanged.
@@ -166,17 +166,22 @@ public:
 
   /// Get the values contained in the labelmap under the mask
   /// \param binaryLabelmap Input image to get values from
-  /// \param maskLabelmap Mask image to get values under
-  /// \param Threshold value for the mask. Values above this threshold are considered to be under the mask
-  /// \param values The values found in the binary labelmap underneath the mask
-  static void GetLabelValuesInMask(vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask,
-    const int extent[6], std::vector<int> &labelValues, int maskThreshold=0);
+  /// \param mask Mask image to get values under
+  /// \param extent Can be set to restrict the examined extent to a smaller region.
+  ///  If nullptr, the extent will be the overlapping extent between the label and mask.
+  /// \param labelValues The values found in the binary labelmap underneath the mask
+  /// \param maskThreshold Threshold value for the mask. Values above this threshold are considered to be under the mask
+  static void GetLabelValuesInMask(std::vector<int>& labelValues, vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask,
+    const int extent[6]=nullptr, int maskThreshold = 0);
 
   /// Determine if there is a non-zero value in the labelmap under the mask
   /// \param binaryLabelmap Input image to get values from
-  /// \param maskLabelmap Mask image to get values under
+  /// \param mask Mask image to get values under
+  /// \param extent Can be set to restrict the examined extent to a smaller region.
+  ///  If nullptr, the extent will be the overlapping extent between the label and mask.
+  /// \param maskThreshold Threshold value for the mask. Values above this threshold are considered to be under the mask
   static bool IsLabelInMask(vtkOrientedImageData* binaryLabelmap, vtkOrientedImageData* mask,
-    int extent[6], int maskThreshold=0);
+    int extent[6]=nullptr, int maskThreshold=0);
 
   /// Cast the data type of the image to be able to contain the specified value
   /// \param image Image to convert

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -2292,7 +2292,7 @@ void vtkSegmentation::CollapseBinaryLabelmaps(bool forceToSingleLayer/*=false*/)
 
   if (forceToSingleLayer)
     {
-    // If the merge is unsafe, segments can be overwritten.
+    // If the merge is forced to a single layer, segments can be overwritten.
     std::vector<std::string> segmentIds;
     this->GetSegmentIDs(segmentIds);
     this->MergeSegmentLabelmaps(segmentIds);
@@ -2357,7 +2357,7 @@ void vtkSegmentation::CollapseBinaryLabelmaps(bool forceToSingleLayer/*=false*/)
         bool safeToMerge = true;
         if (currentLabelmap)
           {
-          safeToMerge = !vtkOrientedImageDataResample::IsLabelInMask(newLayerLabelmap, thresholdedLabelmap, 0);
+          safeToMerge = !vtkOrientedImageDataResample::IsLabelInMask(newLayerLabelmap, thresholdedLabelmap, nullptr);
           }
 
         if (safeToMerge)
@@ -2368,7 +2368,7 @@ void vtkSegmentation::CollapseBinaryLabelmaps(bool forceToSingleLayer/*=false*/)
             {
             // GetUniqueLabelValueForSharedLabelmap(vtkOrientedImageData) only checks the existing scalars in the labelmap.
             // If there are shared labelmaps in the new layer that do not have filled voxels in the labelmap, then the result of
-            // GetUniqueLabelValueForSharedLabelmap may not be unique. Compare the label value of all of the segments in the
+            // GetUniqueLabelValueForSharedLabelmap may not be unique. Instead, we compare the label value of all of the segments in the
             // new layer to make sure the value is unique.
             int existingValue = newLabelmapValues[layerSegmentID];
             labelValue = std::max(labelValue, existingValue + 1);

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -2622,7 +2622,7 @@ bool vtkSlicerSegmentationsModuleLogic::GetSharedSegmentIDsInMask(
     segmentation->GetSegment(sharedSegmentID)->GetRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()));
 
   std::vector<int> labelValuesInMask;
-  vtkOrientedImageDataResample::GetLabelValuesInMask(binaryLabelmap, maskLabelmap, extent, labelValuesInMask, maskThreshold);
+  vtkOrientedImageDataResample::GetLabelValuesInMask(labelValuesInMask, binaryLabelmap, maskLabelmap, extent, maskThreshold);
 
   for (int labelValue : labelValuesInMask)
     {


### PR DESCRIPTION
When converting closed surface segments that have a label value > 255, the segments would not be in the labelmaps representations post-conversion.
This was because the labelmaps generated by vtkClosedSurfaceToBinaryLabelmapConversionRule are of type UNSIGNED_CHAR, and the segment label value was used for the stencil background value.
In the case where the label value exceeded 255, this meant that the labelmap would be missing from the output.

Fixed by setting the label value for binary labelmap created from closed surface to 1.
This is fine, since the PostConvert step will collapse the labelmaps and assign new label values anyway.