### PR TITLE
ENH: Ignore Segment Editor interactor events during touchscreen gesture

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx
@@ -599,3 +599,9 @@ bool vtkMRMLCameraDisplayableManager::ProcessInteractionEvent(vtkMRMLInteraction
   return processed;
 */
 }
+
+//---------------------------------------------------------------------------
+vtkMRMLCameraWidget* vtkMRMLCameraDisplayableManager::GetCameraWidget()
+{
+  return this->Internal->CameraWidget;
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.h
@@ -28,6 +28,7 @@
 #include "vtkMRMLDisplayableManagerExport.h"
 
 class vtkMRMLCameraNode;
+class vtkMRMLCameraWidget;
 
 class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLCameraDisplayableManager :
   public vtkMRMLAbstractThreeDViewDisplayableManager
@@ -55,6 +56,8 @@ public:
 
   bool CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double &closestDistance2) override;
   bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
+
+  vtkMRMLCameraWidget* GetCameraWidget();
 
 protected:
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.cxx
@@ -588,3 +588,9 @@ int vtkMRMLCrosshairDisplayableManager::GetActionsEnabled()
 {
   return this->Internal->SliceIntersectionWidget->GetActionsEnabled();
 }
+
+//---------------------------------------------------------------------------
+vtkMRMLSliceIntersectionWidget* vtkMRMLCrosshairDisplayableManager::GetSliceIntersectionWidget()
+{
+  return this->Internal->SliceIntersectionWidget;
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.h
@@ -27,6 +27,7 @@
 
 class vtkMRMLCrosshairNode;
 class vtkMRMLScene;
+class vtkMRMLSliceIntersectionWidget;
 
 /// \brief Displayable manager for the crosshair on slice (2D) views
 ///
@@ -48,6 +49,8 @@ public:
 
   void SetActionsEnabled(int actions);
   int GetActionsEnabled();
+
+  vtkMRMLSliceIntersectionWidget* GetSliceIntersectionWidget();
 
 protected:
   vtkMRMLCrosshairDisplayableManager();


### PR DESCRIPTION
Pinch/Pan/Rotate can have unwanted effects when used while an editor effect is active.
This commit changes qMRMLSegmentEditorWidget to only react to interaction events while a gesture is not currently active.