### PR TITLE
COMP: Install pip, setuptools, wheel using whl files

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -117,35 +117,6 @@ if(Slicer_BUILD_DICOM_SUPPORT)
   list(APPEND Slicer_DEPENDENCIES DCMTK)
 endif()
 
-if(Slicer_BUILD_DICOM_SUPPORT AND Slicer_USE_PYTHONQT_WITH_OPENSSL)
-  list(APPEND Slicer_DEPENDENCIES python-dicom-requirements)
-endif()
-
-if(Slicer_USE_PYTHONQT)
-  list(APPEND Slicer_DEPENDENCIES
-    python-pythonqt-requirements  # This provides the "packaging.version.parse()" function
-    python-pip
-    )
-endif()
-
-if(Slicer_USE_PYTHONQT AND Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
-  list(APPEND Slicer_DEPENDENCIES
-    python-extension-manager-requirements
-    )
-  if(Slicer_USE_PYTHONQT_WITH_OPENSSL OR Slicer_USE_SYSTEM_python)
-    # python-PyGithub requires SSL support in Python
-    list(APPEND Slicer_DEPENDENCIES
-      python-extension-manager-ssl-requirements
-      )
-  else()
-    message(STATUS "--------------------------------------------------")
-    message(STATUS "Python was built without SSL support; "
-                   "github integration will not be available. "
-                   "Set Slicer_USE_PYTHONQT_WITH_OPENSSL=ON to enable this feature.")
-    message(STATUS "--------------------------------------------------")
-  endif()
-endif()
-
 if(Slicer_USE_CTKAPPLAUNCHER)
   list(APPEND Slicer_DEPENDENCIES CTKAPPLAUNCHER)
 endif()
@@ -153,14 +124,35 @@ endif()
 if(Slicer_USE_PYTHONQT)
   set(PYTHON_ENABLE_SSL ${Slicer_USE_PYTHONQT_WITH_OPENSSL})
   list(APPEND Slicer_DEPENDENCIES python)
-endif()
-
-if(Slicer_USE_NUMPY)
-  list(APPEND Slicer_DEPENDENCIES python-numpy)
-endif()
-
-if(Slicer_USE_PYTHONQT_WITH_TCL AND UNIX)
-  list(APPEND Slicer_DEPENDENCIES incrTcl)
+  list(APPEND Slicer_DEPENDENCIES
+    python-pythonqt-requirements  # This provides the "packaging.version.parse()" function
+    )
+  if(Slicer_USE_NUMPY)
+    list(APPEND Slicer_DEPENDENCIES python-numpy)
+  endif()
+  if(Slicer_BUILD_DICOM_SUPPORT AND Slicer_USE_PYTHONQT_WITH_OPENSSL)
+    list(APPEND Slicer_DEPENDENCIES python-dicom-requirements)
+  endif()
+  if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
+    list(APPEND Slicer_DEPENDENCIES
+      python-extension-manager-requirements
+      )
+    if(Slicer_USE_PYTHONQT_WITH_OPENSSL OR Slicer_USE_SYSTEM_python)
+      # python-PyGithub requires SSL support in Python
+      list(APPEND Slicer_DEPENDENCIES
+        python-extension-manager-ssl-requirements
+        )
+    else()
+      message(STATUS "--------------------------------------------------")
+      message(STATUS "Python was built without SSL support; "
+                    "github integration will not be available. "
+                    "Set Slicer_USE_PYTHONQT_WITH_OPENSSL=ON to enable this feature.")
+      message(STATUS "--------------------------------------------------")
+    endif()
+  endif()
+  if(Slicer_USE_PYTHONQT_WITH_TCL AND UNIX)
+    list(APPEND Slicer_DEPENDENCIES incrTcl)
+  endif()
 endif()
 
 if(Slicer_USE_TBB)

--- a/SuperBuild/External_python-ensurepip.cmake
+++ b/SuperBuild/External_python-ensurepip.cmake
@@ -1,14 +1,7 @@
-set(proj python-pythonqt-requirements)
+set(proj python-ensurepip)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES python python-ensurepip python-pip python-setuptools python-wheel)
-
-set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
-file(WRITE ${requirements_file} [===[
-packaging==19.0 --hash=sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3
-pyparsing==2.3.1 --hash=sha256:f6c5ef0d7480ad048c054c37632c67fca55299990fff127850181659eea33fc3
-six==1.12.0 --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c
-]===])
+set(${proj}_DEPENDENCIES python)
 
 if(NOT DEFINED Slicer_USE_SYSTEM_${proj})
   set(Slicer_USE_SYSTEM_${proj} ${Slicer_USE_SYSTEM_python})
@@ -18,7 +11,7 @@ endif()
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
 if(Slicer_USE_SYSTEM_${proj})
-  foreach(module_name IN ITEMS pyparsing packaging)
+  foreach(module_name IN ITEMS ensurepip pip setuptools)
     ExternalProject_FindPythonPackage(
       MODULE_NAME "${module_name}"
       REQUIRED
@@ -35,7 +28,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
-    INSTALL_COMMAND ${PYTHON_EXECUTABLE} -m pip install --require-hashes -r ${requirements_file}
+    INSTALL_COMMAND ${PYTHON_EXECUTABLE} -m ensurepip --default-pip
     LOG_INSTALL 1
     DEPENDS
       ${${proj}_DEPENDENCIES}

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -1,7 +1,12 @@
 set(proj python-pip)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES python python-wheel)
+set(${proj}_DEPENDENCIES python python-ensurepip python-setuptools)
+
+set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
+file(WRITE ${requirements_file} [===[
+pip==19.0.3 --hash=sha256:bd812612bbd8ba84159d9ddc0266b7fbce712fc9bc98c82dee5750546ec8ec64
+]===])
 
 if(NOT DEFINED Slicer_USE_SYSTEM_${proj})
   set(Slicer_USE_SYSTEM_${proj} ${Slicer_USE_SYSTEM_python})
@@ -11,26 +16,24 @@ endif()
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
 if(Slicer_USE_SYSTEM_${proj})
-  ExternalProject_FindPythonPackage(
-    MODULE_NAME "pip"
-    REQUIRED
-    )
+  foreach(module_name IN ITEMS pip)
+    ExternalProject_FindPythonPackage(
+      MODULE_NAME "${module_name}"
+      REQUIRED
+      )
+  endforeach()
 endif()
 
 if(NOT Slicer_USE_SYSTEM_${proj})
 
-  set(_version "19.0.3")
-
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://files.pythonhosted.org/packages/36/fa/51ca4d57392e2f69397cd6e5af23da2a8d37884a605f9e3f2d3bfdc48397/pip-${_version}.tar.gz"
-    URL_HASH "SHA256=6e6f197a1abfb45118dbb878b5c859a0edbdd33fd250100bc015b67fded4b9f2"
-    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
+    DOWNLOAD_COMMAND ""
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
-    INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
+    INSTALL_COMMAND ${PYTHON_EXECUTABLE} -m pip install --require-hashes -r ${requirements_file}
     LOG_INSTALL 1
     DEPENDS
       ${${proj}_DEPENDENCIES}

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -1,7 +1,12 @@
 set(proj python-wheel)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES python python-setuptools)
+set(${proj}_DEPENDENCIES python python-setuptools python-pip)
+
+set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
+file(WRITE ${requirements_file} [===[
+wheel==0.33.1 --hash=sha256:8eb4a788b3aec8abf5ff68d4165441bc57420c9f64ca5f471f58c3969fe08668
+]===])
 
 if(NOT DEFINED Slicer_USE_SYSTEM_${proj})
   set(Slicer_USE_SYSTEM_${proj} ${Slicer_USE_SYSTEM_python})
@@ -11,26 +16,24 @@ endif()
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
 if(Slicer_USE_SYSTEM_${proj})
-  ExternalProject_FindPythonPackage(
-    MODULE_NAME "wheel"
-    REQUIRED
-    )
+  foreach(module_name IN ITEMS wheel)
+    ExternalProject_FindPythonPackage(
+      MODULE_NAME "${module_name}"
+      REQUIRED
+      )
+  endforeach()
 endif()
 
 if(NOT Slicer_USE_SYSTEM_${proj})
 
-  set(_version "0.33.1")
-
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
-    URL "https://files.pythonhosted.org/packages/b7/cf/1ea0f5b3ce55cacde1e84cdde6cee1ebaff51bd9a3e6c7ba4082199af6f6/wheel-${_version}.tar.gz"
-    URL_HASH "SHA256=66a8fd76f28977bb664b098372daef2b27f60dc4d1688cfab7b37a09448f0e9d"
-    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
+    DOWNLOAD_COMMAND ""
     SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
-    INSTALL_COMMAND ${PYTHON_EXECUTABLE} setup.py install
+    INSTALL_COMMAND ${PYTHON_EXECUTABLE} -m pip install --require-hashes -r ${requirements_file}
     LOG_INSTALL 1
     DEPENDS
       ${${proj}_DEPENDENCIES}


### PR DESCRIPTION
This reverts 9cd8cb4de2b99c752be49c19be310f2034047e14 and adds back 26ecf484d51e4c298a76b80b3a0dec7e9c157a1d with changes to Superbuild.cmake to make sure that python-dicom-requirements remains building successfully.

Tested by removing the main Python build project and all other "python-XXX" package projects to rebuild these from scratch.

Images of site-packages inside the python-install directory:
![python-packages](https://user-images.githubusercontent.com/15837524/68092485-b0025c80-fe59-11e9-86e0-4e958ecf641a.PNG)
![python-packages2](https://user-images.githubusercontent.com/15837524/68092488-b4c71080-fe59-11e9-8042-271330c1093e.PNG)