### PR TITLE
ENH: Improve observer management in vtkSegmentation

### DIFF
--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -501,6 +501,10 @@ protected:
   /// It fires a \sa MasterRepresentationModifiedEvent if master representation is changed in ANY segment
   static void OnMasterRepresentationModified(vtkObject* caller, unsigned long eid, void* clientData, void* callData);
 
+  /// Check to ensure that all master representations are being observed, and observers on master representations that
+  /// are no longer in the segmentation are removed
+  void UpdateMasterRepresentationObservers();
+
 protected:
   vtkSegmentation();
   ~vtkSegmentation() override;
@@ -539,6 +543,8 @@ protected:
   /// (we could retrieve segment IDs from SegmentMap too, but that always contains segments in
   /// alphabetical order)
   std::deque< std::string > SegmentIds;
+
+  std::set<vtkSmartPointer<vtkDataObject> > MasterRepresentationCache;
 
   friend class vtkMRMLSegmentationNode;
   friend class vtkSlicerSegmentationsModuleLogic;

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -74,7 +74,7 @@ public:
   /// \param filename Path and name of file containing segmentation (nrrd, vtm, etc.)
   /// \param autoOpacities Optional flag determining whether segment opacities are calculated automatically based on containment. True by default
   /// \return Loaded segmentation node
-  vtkMRMLSegmentationNode* LoadSegmentationFromFile(const char* filename, bool autoOpacities=true);
+  vtkMRMLSegmentationNode* LoadSegmentationFromFile(const char* filename, bool autoOpacities = true);
 
   /// Create labelmap volume MRML node from oriented image data.
   /// Creates a display node if a display node does not exist. Shifts image extent to start from zero.
@@ -359,9 +359,8 @@ public:
   static int GetSegmentStatus(vtkSegment* segment);
   /// Returns the value of the status tag for the given segment
   static void SetSegmentStatus(vtkSegment* segment, int status);
-
+  /// Clear the contents of a single segment
   static bool ClearSegment(vtkMRMLSegmentationNode* segmentationNode, std::string segmentID);
-  static bool ClearSegment(vtkSegmentation* segmentation, std::string segmentID);
 
   /// Get the list of segment IDs in the same shared labelmap that are contained within the mask
   /// \param segmentationNode Node containing the segmentation
@@ -371,6 +370,20 @@ public:
   /// \param includeInputSharedSegmentID If false, sharedSegmentID will not be added to the list of output segment IDs even if it is within the mask
   static bool GetSharedSegmentIDsInMask(vtkMRMLSegmentationNode* segmentationNode, std::string sharedSegmentID, vtkOrientedImageData* mask, const int extent[6],
     std::vector<std::string>& segmentIDs, int maskThreshold = 0.0, bool includeInputSharedSegmentID = false);
+
+  /// Reconvert all representations in the segmentation from the master representation
+  /// \param segmentationNode Node containing the segmentation
+  /// \param sharedSegmentID Segment IDs to be converted. If empty, all segments will be converted.
+  /// \return True if the representation was created, False otherwise
+  static bool ReconvertAllRepresentations(vtkMRMLSegmentationNode* segmentationNode,
+    const std::vector<std::string>& segmentIDs={});
+
+  /// Collapse all segments into fewer shared labelmap layers
+  /// \param segmentationNode Node containing the segmentation
+  /// \param forceToSingleLayer If false, then the layers will not be overwritten by each other, if true then the layers can
+  ///   overwrite each other, but the result is guaranteed to have one layer
+  /// \return True if the representation was created, False otherwise
+  static void CollapseBinaryLabelmaps(vtkMRMLSegmentationNode* segmentationNode, bool forceToSingleLayer);
 
 public:
   /// Set Terminologies module logic

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -1159,7 +1159,7 @@ void qMRMLSegmentsTableView::clearSelectedSegments()
   QStringList selectedSegmentIDs = this->selectedSegmentIDs();
   for (QString segmentID : selectedSegmentIDs)
     {
-    vtkSlicerSegmentationsModuleLogic::ClearSegment(segmentation, segmentID.toStdString());
+    vtkSlicerSegmentationsModuleLogic::ClearSegment(d->SegmentationNode, segmentID.toStdString());
     }
 }
 

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -565,9 +565,8 @@ void qSlicerSegmentationsModuleWidget::collapseLabelmapLayers()
     return;
     }
 
-  MRMLNodeModifyBlocker blocker(d->SegmentationNode);
   bool forceToSingleLayer = d->checkBox_OverwriteSegments->isChecked();
-  d->SegmentationNode->GetSegmentation()->CollapseBinaryLabelmaps(forceToSingleLayer);
+  vtkSlicerSegmentationsModuleLogic::CollapseBinaryLabelmaps(d->SegmentationNode, forceToSingleLayer);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Previously observers were only added or removed from master representations when AddSegment, RemoveSegment or SetMasterRepresentationModifiedEnabled was called.
This meant that observers were not handled if vtkSegment::AddRepresentation was called, resulting in orphaned or missing observers.

This commit collects all of the AddObserver/RemoveObserver calls for the master representation in a single function UpdateMasterRepresentationObservers.
UpdateMasterRepresentationObservers caches a list of the master representations data objects that are monitored and compares against the list of master representations in the segmentation, and then adds or removes observers as needed.