### PR TITLE
BUG: Fix a set of failing tests due to new SH node as a member variable of MRML scene

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLNodeTest1.cxx
@@ -2531,11 +2531,11 @@ bool TestNodeReferenceSerialization()
   scene2->RegisterNodeClass(vtkSmartPointer<vtkMRMLNodeTestHelper1>::New());
   scene2->SetLoadFromXMLString(1);
   scene2->SetSceneXMLString(sceneXMLString);
-  scene2->Import();
+  scene2->Import();  // adds Subject Hierarchy Node
 
   if (!CheckInt(__LINE__,
                 "Scene2-GetNumberOfNodes",
-                scene2->GetNumberOfNodes(), 4))
+                scene2->GetNumberOfNodes(), 5))
     {
     return false;
     }

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneAddSingletonTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneAddSingletonTest.cxx
@@ -159,9 +159,9 @@ int vtkMRMLSceneAddSingletonTest(int vtkNotUsed(argc), char * vtkNotUsed(argv) [
 
   scene->SetLoadFromXMLString(1);
   scene->SetSceneXMLString(scene1XML);
-  scene->Import();
+  scene->Import();  // adds Subject Hierarchy Node
 
-  CHECK_INT(scene->GetNumberOfNodes(), 4);
+  CHECK_INT(scene->GetNumberOfNodes(), 5);
 
   vtkMRMLNode* scene1SingletonA = scene->GetNodeByID("vtkMRMLScriptedModuleNodeSingletonA");
   vtkMRMLNode* scene1SingletonB = scene->GetNodeByID("vtkMRMLScriptedModuleNodeSingletonB");
@@ -201,9 +201,9 @@ int vtkMRMLSceneAddSingletonTest(int vtkNotUsed(argc), char * vtkNotUsed(argv) [
 
   scene->SetLoadFromXMLString(1);
   scene->SetSceneXMLString(scene2XML);
-  scene->Import();
+  scene->Import();  // adds Subject Hierarchy Node
 
-  CHECK_INT(scene->GetNumberOfNodes(), 6);
+  CHECK_INT(scene->GetNumberOfNodes(), 7);
 
   vtkMRMLNode* scene2SingletonA = scene->GetNodeByID("vtkMRMLScriptedModuleNodeSingletonA");
   vtkMRMLNode* scene2SingletonB = scene->GetNodeByID("vtkMRMLScriptedModuleNodeSingletonB"); // ID changed (singleton is matched based on singleton tag)

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDConflictTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDConflictTest.cxx
@@ -92,7 +92,7 @@ int vtkMRMLSceneImportIDConflictTest(int vtkNotUsed(argc), char * vtkNotUsed(arg
 
   scene->SetSceneXMLString(scene1XML);
   scene->SetLoadFromXMLString(1);
-  scene->Import();
+  scene->Import();  // adds Subject Hierarchy Node
 
   // When importing the scene, there is conflict between the existing nodes
   // and added nodes. New IDs are set by Import to the added nodes.
@@ -100,6 +100,7 @@ int vtkMRMLSceneImportIDConflictTest(int vtkNotUsed(argc), char * vtkNotUsed(arg
   // At this point the scene should be:
   //
   //  Scene
+  //    |---- vtkMRMLSubjectHierarchyNode1
   //    |---- vtkMRMLModelNode1  (valid polydata)
   //    |          |-- ref [displayNodeRef] to vtkMRMLModelDisplayNode1
   //    |
@@ -119,7 +120,7 @@ int vtkMRMLSceneImportIDConflictTest(int vtkNotUsed(argc), char * vtkNotUsed(arg
   // Check scene contains original nodes
   //
 
-  CHECK_INT(scene->GetNumberOfNodes(), 6);
+  CHECK_INT(scene->GetNumberOfNodes(), 7);
   CHECK_NODE_IN_SCENE_BY_ID(scene.GetPointer(),"vtkMRMLModelNode1", modelNode.GetPointer());
   CHECK_NODE_IN_SCENE_BY_ID(scene.GetPointer(),"vtkMRMLModelDisplayNode1", modelDisplayNode.GetPointer());
   CHECK_POINTER(modelNode->GetDisplayNode(), modelDisplayNode.GetPointer());

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDModelHierarchyConflictTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDModelHierarchyConflictTest.cxx
@@ -139,11 +139,12 @@ int ImportIDModelHierarchyConflictTest()
   // and added nodes. New IDs are set by Import to the added nodes.
   // The node ids in the scene after a proper import should be
 
-  scene->Import();
+  scene->Import();  // adds Subject Hierarchy Node
 
   // At this point the scene should be:
   //
   //  Scene
+  //    |---- vtkMRMLSubjectHierarchyNode1
   //    |---- vtkMRMLModelNode1  (valid polydata)
   //    |          |-- ref [displayNodeRef] to vtkMRMLModelDisplayNode1
   //    |
@@ -166,7 +167,7 @@ int ImportIDModelHierarchyConflictTest()
   //               |-- ref [displayNodeID] to vtkMRMLModelDisplayNode4
   //               |-- ref [associatedNodeRef] to vtkMRMLModelNode2
 
-  CHECK_INT(scene->GetNumberOfNodes(), 8);
+  CHECK_INT(scene->GetNumberOfNodes(), 9);
   CHECK_NODE_IN_SCENE_BY_ID(scene.GetPointer(),"vtkMRMLModelNode1", modelNode.GetPointer());
   CHECK_NODE_IN_SCENE_BY_ID(scene.GetPointer(),"vtkMRMLModelDisplayNode1", modelDisplayNode.GetPointer());
   CHECK_POINTER(modelNode->GetDisplayNode(), modelDisplayNode.GetPointer());
@@ -254,11 +255,12 @@ int ImportModelHierarchyTwiceTest()
   // Load same scene into scene
   scene->SetSceneXMLString(xmlScene);
   scene->SetLoadFromXMLString(1);
-  scene->Import();
+  scene->Import();  // adds Subject Hierarchy Node
 
   // At this point the scene should be:
   //
   //  Scene
+  //    |---- vtkMRMLSubjectHierarchyNode1
   //    |---- vtkMRMLModelNode1
   //    |
   //    |---- vtkMRMLModelDisplayNode1
@@ -281,7 +283,7 @@ int ImportModelHierarchyTwiceTest()
   //    |
   //    |---- vtkMRMLHierarchyNode2                                     [was vtkMRMLHierarchyNode1]
 
-  CHECK_INT(scene->GetNumberOfNodes(), 8);
+  CHECK_INT(scene->GetNumberOfNodes(), 9);
   CHECK_NODE_IN_SCENE_BY_ID(scene.GetPointer(),"vtkMRMLModelNode1", modelNode.GetPointer());
   CHECK_NODE_IN_SCENE_BY_ID(scene.GetPointer(),"vtkMRMLModelDisplayNode1", hierachyDisplayNode.GetPointer());
   CHECK_NODE_IN_SCENE_BY_ID(scene.GetPointer(),"vtkMRMLModelHierarchyNode1", modelHierarchyNode.GetPointer());

--- a/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDModelHierarchyParentIDConflictTest.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSceneImportIDModelHierarchyParentIDConflictTest.cxx
@@ -167,12 +167,13 @@ int ImportIDModelHierarchyParentIDConflictTestXMLString()
   // and added nodes. New IDs are set by Import to the added nodes and the
   // parent node refs should be updated
 
-  scene->Import();
+  scene->Import();  // adds Subject Hierarchy Node
 
 
   // At this point the scene should be:
   //
   //  Scene
+  //    |---- vtkMRMLSubjectHierarchyNode1
   //    |---- vtkMRMLModelHierarchyNode1 (name: 0)
   //    |          |-- ref [parentNodeRef] to <null>
   //    |
@@ -204,7 +205,7 @@ int ImportIDModelHierarchyParentIDConflictTestXMLString()
   //    |          |-- ref [parentNodeRef] to vtkMRMLModelHierarchyNode9
 
 
-  CHECK_INT_ADD_REPORT(scene->GetNumberOfNodes(), 10, PrintModelHierarchyNodes(__LINE__, scene.GetPointer()));
+  CHECK_INT_ADD_REPORT(scene->GetNumberOfNodes(), 11, PrintModelHierarchyNodes(__LINE__, scene.GetPointer()));
   CHECK_INT_ADD_REPORT(scene->GetNumberOfNodesByClass("vtkMRMLModelHierarchyNode"), 10, PrintModelHierarchyNodes(__LINE__, scene.GetPointer()));
 
   for (int index = 0; index < 10; ++index)
@@ -279,15 +280,16 @@ int ImportIDModelHierarchyParentIDConflictTestFile()
   vtkNew<vtkMRMLScene> scene3;
 
   scene3->SetURL(filename1.c_str());
-  scene3->Import();
+  scene3->Import();  // adds Subject Hierarchy Node
 
   // At this point the scene3 should be:
   //
   //  Scene
+  //    |---- vtkMRMLSubjectHierarchyNode1
   //    |---- vtkMRMLModelHierarchyNode1 (name: 0)
   //    |          |-- ref [parentNodeRef] to <null>
 
-  CHECK_INT(scene3->GetNumberOfNodes(), 1);
+  CHECK_INT(scene3->GetNumberOfNodes(), 2);
 
   std::cerr << "After first import, new scene has " << scene3->GetNumberOfNodes() << " nodes" << std::endl;
   PrintModelHierarchyNodes(__LINE__, scene3.GetPointer());
@@ -299,6 +301,7 @@ int ImportIDModelHierarchyParentIDConflictTestFile()
   // At this point the scene3 should be:
   //
   //  Scene
+  //    |---- vtkMRMLSubjectHierarchyNode1
   //    |---- vtkMRMLModelHierarchyNode1 (name: 0)
   //    |          |-- ref [parentNodeRef] to <null>
   //    |
@@ -325,7 +328,7 @@ int ImportIDModelHierarchyParentIDConflictTestFile()
   // vtkMRMLModelHierarchyNode4 has parent node id of vtkMRMLModelHierarchyNode3
   // vtkMRMLModelHierarchyNode5 has parent node id of vtkMRMLModelHierarchyNode4
 
-  CHECK_INT(scene3->GetNumberOfNodes(), 6);
+  CHECK_INT(scene3->GetNumberOfNodes(), 7);
 
   vtkMRMLModelHierarchyNode *hierarchyNode2 =
       vtkMRMLModelHierarchyNode::SafeDownCast(scene3->GetNodeByID("vtkMRMLModelHierarchyNode2"));


### PR DESCRIPTION
This PR aims to fix a set of 5 failing tests that began to fail on Sept. 16th due to changes made in aa94228a125cac9e2e128020c08d9a63f2d9bebb. In that commit a subject hierarchy node was added as a member variable of the scene which caused a set of tests to fail all the in the same way of expecting one less node than actual.

The set of tests are:
- vtkMRMLNodeTest1
- vtkMRMLSceneAddSingletonTest
- vtkMRMLSceneImportIDConflictTest
- vtkMRMLSceneImportIDModelHierarchyConflictTest
- vtkMRMLSceneImportIDModelHierarchyParentIDConflictTest

@adamrankin it appears @cpinter alerted you of these failing tests in https://github.com/Slicer/Slicer/pull/1210#issuecomment-532265182, but it looks like this was something that was accidentally forgotten about. Can you take a look and confirm these changes to these tests match the changes you committed?