### PR TITLE
COMP: Update to latest SimpleFilters

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -213,7 +213,7 @@ list_conditional_append(Slicer_BUILD_MultiVolumeImporter Slicer_REMOTE_DEPENDENC
 
 Slicer_Remote_Add(SimpleFilters
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/SimpleITK/SlicerSimpleFilters.git
-  GIT_TAG 69ef9f277832d80305ab690b1df1941851b09aad
+  GIT_TAG 8686bf5722c642cca0b765cb3f8e5b24b0a25422
   OPTION_NAME Slicer_BUILD_SimpleFilters
   OPTION_DEPENDS "Slicer_BUILD_QTSCRIPTEDMODULES;Slicer_USE_SimpleITK"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
>git shortlog --no-merges 69ef9f27..8686bf57
James Butler (1):
      BUG: Fix overflow errors due to uint64 and int64 values

@jcfr Here is the corresponding PR for the Slicer repo.

This updates SimpleFilters to include a bug fix for a [failing test](http://slicer.cdash.org/testDetails.php?test=9823818&build=1743836).