### PR TITLE
Improved view right-click menu

### DIFF
--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -39,7 +39,7 @@
 // MRML includes
 #include <vtkMRMLDisplayableNode.h>
 #include <vtkMRMLDisplayNode.h>
-#include <vtkMRMLMarkupsFiducialNode.h>
+#include <vtkMRMLMarkupsNode.h>
 #include <vtkMRMLScene.h>
 
 // vtkSegmentationCore includes
@@ -71,7 +71,9 @@ public:
   void init();
 
 public:
-  QAction* RenameFiducialAction;
+  QAction* RenamePointAction;
+  QAction* DeletePointAction;
+  QAction* ToggleSelectPointAction;
 
   QVariantMap ViewMenuEventData;
 };
@@ -83,7 +85,7 @@ public:
 qSlicerSubjectHierarchyMarkupsPluginPrivate::qSlicerSubjectHierarchyMarkupsPluginPrivate(qSlicerSubjectHierarchyMarkupsPlugin& object)
 : q_ptr(&object)
 {
-  this->RenameFiducialAction = nullptr;
+  this->RenamePointAction = nullptr;
 }
 
 //------------------------------------------------------------------------------
@@ -91,8 +93,17 @@ void qSlicerSubjectHierarchyMarkupsPluginPrivate::init()
 {
   Q_Q(qSlicerSubjectHierarchyMarkupsPlugin);
 
-  this->RenameFiducialAction = new QAction("Rename fiducial...", q);
-  QObject::connect(this->RenameFiducialAction, SIGNAL(triggered()), q, SLOT(renameFiducial()));
+  this->RenamePointAction = new QAction("Rename point...", q);
+  this->RenamePointAction->setObjectName("RenamePointAction");
+  QObject::connect(this->RenamePointAction, SIGNAL(triggered()), q, SLOT(renamePoint()));
+
+  this->DeletePointAction = new QAction("Delete point", q);
+  this->DeletePointAction->setObjectName("DeletePointAction");
+  QObject::connect(this->DeletePointAction, SIGNAL(triggered()), q, SLOT(deletePoint()));
+
+  this->ToggleSelectPointAction = new QAction("Toggle select point", q);
+  this->ToggleSelectPointAction->setObjectName("ToggleSelectPointAction");
+  QObject::connect(this->ToggleSelectPointAction, SIGNAL(triggered()), q, SLOT(toggleSelectPoint()));
 }
 
 //-----------------------------------------------------------------------------
@@ -370,7 +381,7 @@ QList<QAction*> qSlicerSubjectHierarchyMarkupsPlugin::viewContextMenuActions()co
   Q_D(const qSlicerSubjectHierarchyMarkupsPlugin);
 
   QList<QAction*> actions;
-  actions << d->RenameFiducialAction;
+  actions << d->RenamePointAction << d->DeletePointAction << d->ToggleSelectPointAction;
   return actions;
 }
 
@@ -393,17 +404,19 @@ void qSlicerSubjectHierarchyMarkupsPlugin::showViewContextMenuActionsForItem(vtk
 
   // Markup
   vtkMRMLNode* associatedNode = shNode->GetItemDataNode(itemID);
-  if (associatedNode && associatedNode->IsA("vtkMRMLMarkupsFiducialNode"))
+  if (associatedNode && associatedNode->IsA("vtkMRMLMarkupsNode"))
     {
     d->ViewMenuEventData = eventData;
     d->ViewMenuEventData["NodeID"] = QVariant(associatedNode->GetID());
 
-    d->RenameFiducialAction->setVisible(true);
+    d->RenamePointAction->setVisible(true);
+    d->DeletePointAction->setVisible(true);
+    d->ToggleSelectPointAction->setVisible(true);
     }
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerSubjectHierarchyMarkupsPlugin::renameFiducial()
+void qSlicerSubjectHierarchyMarkupsPlugin::renamePoint()
 {
   Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
 
@@ -419,21 +432,21 @@ void qSlicerSubjectHierarchyMarkupsPlugin::renameFiducial()
     return;
     }
 
-  // Get fiducial markups node
+  // Get markups node
   QString nodeID = d->ViewMenuEventData["NodeID"].toString();
   vtkMRMLNode* node = scene->GetNodeByID(nodeID.toLatin1().constData());
-  vtkMRMLMarkupsFiducialNode* fiducialNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(node);
-  if (!fiducialNode)
+  vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
+  if (!markupsNode)
     {
-    qCritical() << Q_FUNC_INFO << ": Failed to get fiducial markups node by ID " << nodeID;
+    qCritical() << Q_FUNC_INFO << ": Failed to get markups node by ID " << nodeID;
     return;
     }
 
-  // Get fiducial index
+  // Get point index
   int componentIndex = d->ViewMenuEventData["ComponentIndex"].toInt();
 
   // Pop up an entry box for the new name, with the old name as default
-  QString oldName(fiducialNode->GetNthFiducialLabel(componentIndex).c_str());
+  QString oldName(markupsNode->GetNthControlPointLabel(componentIndex).c_str());
 
   bool ok = false;
   QString newName = QInputDialog::getText(nullptr, QString("Rename ") + oldName, "New name:", QLineEdit::Normal, oldName, &ok);
@@ -442,5 +455,71 @@ void qSlicerSubjectHierarchyMarkupsPlugin::renameFiducial()
     return;
     }
 
-  fiducialNode->SetNthFiducialLabel(componentIndex, newName.toLatin1().constData());
+  markupsNode->SetNthControlPointLabel(componentIndex, newName.toLatin1().constData());
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyMarkupsPlugin::deletePoint()
+{
+  Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
+
+  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+    {
+    qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
+    return;
+    }
+  vtkMRMLScene* scene = qSlicerSubjectHierarchyPluginHandler::instance()->mrmlScene();
+  if (!scene)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access MRML scene";
+    return;
+    }
+
+  // Get markups node
+  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  vtkMRMLNode* node = scene->GetNodeByID(nodeID.toLatin1().constData());
+  vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
+  if (!markupsNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to get markups node by ID " << nodeID;
+    return;
+    }
+
+  // Get point index
+  int componentIndex = d->ViewMenuEventData["ComponentIndex"].toInt();
+
+  markupsNode->RemoveNthControlPoint(componentIndex);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyMarkupsPlugin::toggleSelectPoint()
+{
+  Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
+
+  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+    {
+    qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
+    return;
+    }
+  vtkMRMLScene* scene = qSlicerSubjectHierarchyPluginHandler::instance()->mrmlScene();
+  if (!scene)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access MRML scene";
+    return;
+    }
+
+  // Get markups node
+  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  vtkMRMLNode* node = scene->GetNodeByID(nodeID.toLatin1().constData());
+  vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
+  if (!markupsNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to get markups node by ID " << nodeID;
+    return;
+    }
+
+  // Get point index
+  int componentIndex = d->ViewMenuEventData["ComponentIndex"].toInt();
+
+  markupsNode->SetNthControlPointSelected(componentIndex, !markupsNode->GetNthControlPointSelected(componentIndex));
 }

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -99,8 +99,12 @@ public:
   void showViewContextMenuActionsForItem(vtkIdType itemID, QVariantMap eventData) override;
 
 protected slots:
-  /// Called when clicking on rename fiducial function
-  void renameFiducial();
+  /// Called when clicking on rename point action
+  void renamePoint();
+  /// Called when clicking on delete point action
+  void deletePoint();
+  /// Called when clicking on toggle select point action
+  void toggleSelectPoint();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyMarkupsPluginPrivate> d_ptr;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -1260,7 +1260,7 @@ void qMRMLSubjectHierarchyTreeView::selectPluginForCurrentItem()
   vtkIdType currentItemID = this->currentItem();
   if (!currentItemID)
     {
-    qCritical() << Q_FUNC_INFO << ": Invalid current item for manually selecting role!";
+    qCritical() << Q_FUNC_INFO << ": Invalid current item for manually selecting role";
     return;
     }
   QString selectedPluginName = d->SelectPluginActionGroup->checkedAction()->data().toString();
@@ -1291,7 +1291,7 @@ void qMRMLSubjectHierarchyTreeView::updateSelectPluginActions()
   vtkIdType currentItemID = this->currentItem();
   if (!currentItemID)
     {
-    qCritical() << Q_FUNC_INFO << ": Invalid current item!";
+    qCritical() << Q_FUNC_INFO << ": Invalid current item";
     return;
     }
   QString ownerPluginName = QString(d->SubjectHierarchyNode->GetItemOwnerPluginName(currentItemID).c_str());
@@ -1342,7 +1342,7 @@ void qMRMLSubjectHierarchyTreeView::renameCurrentItem()
   vtkIdType currentItemID = this->currentItem();
   if (!currentItemID)
     {
-    qCritical() << Q_FUNC_INFO << ": Invalid current item!";
+    qCritical() << Q_FUNC_INFO << ": Invalid current item";
     return;
     }
 
@@ -1371,7 +1371,7 @@ void qMRMLSubjectHierarchyTreeView::editCurrentItem()
   vtkIdType currentItemID = this->currentItem();
   if (!currentItemID)
     {
-    qCritical() << Q_FUNC_INFO << ": Invalid current item!";
+    qCritical() << Q_FUNC_INFO << ": Invalid current item";
     return;
     }
 
@@ -1480,7 +1480,7 @@ void qMRMLSubjectHierarchyTreeView::expandToDepthFromContextMenu()
   QAction* senderAction = qobject_cast<QAction*>(this->sender());
   if (!senderAction)
     {
-    qCritical() << Q_FUNC_INFO << ": Unable to get sender action!";
+    qCritical() << Q_FUNC_INFO << ": Unable to get sender action";
     return;
     }
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
@@ -160,6 +160,7 @@ public:
 
   /// Get view context menu item actions that are available when right-clicking an object in the views.
   /// These item context menu actions can be shown in the implementations of \sa showViewContextMenuActionsForItem
+  /// Note: The actions need object names set so that they can be included in the white list
   Q_INVOKABLE virtual QList<QAction*> viewContextMenuActions()const;
 
   /// Show context menu actions valid for a given subject hierarchy item to be shown in the view.

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
@@ -135,12 +135,12 @@ bool qSlicerSubjectHierarchyPluginHandler::registerPlugin(qSlicerSubjectHierarch
 {
   if (pluginToRegister == nullptr)
     {
-    qCritical() << Q_FUNC_INFO << ": Invalid plugin to register!";
+    qCritical() << Q_FUNC_INFO << ": Invalid plugin to register";
     return false;
     }
   if (pluginToRegister->name().isEmpty())
     {
-    qCritical() << Q_FUNC_INFO << ": SubjectHierarchy plugin cannot be registered with empty name!";
+    qCritical() << Q_FUNC_INFO << ": SubjectHierarchy plugin cannot be registered with empty name";
     return false;
     }
 
@@ -204,7 +204,7 @@ qSlicerSubjectHierarchyAbstractPlugin* qSlicerSubjectHierarchyPluginHandler::plu
       }
     }
 
-  qWarning() << Q_FUNC_INFO << ": Plugin named '" << name << "' cannot be found!";
+  qWarning() << Q_FUNC_INFO << ": Plugin named '" << name << "' cannot be found";
   return nullptr;
 }
 
@@ -348,7 +348,7 @@ qSlicerSubjectHierarchyAbstractPlugin* qSlicerSubjectHierarchyPluginHandler::get
     {
     if (itemID != this->m_MRMLScene->GetSubjectHierarchyNode()->GetSceneItemID())
       {
-      qCritical() << Q_FUNC_INFO << ": Item '" << this->m_MRMLScene->GetSubjectHierarchyNode()->GetItemName(itemID).c_str() << "' is not owned by any plugin!";
+      qCritical() << Q_FUNC_INFO << ": Item '" << this->m_MRMLScene->GetSubjectHierarchyNode()->GetItemName(itemID).c_str() << "' is not owned by any plugin";
       }
     return nullptr;
     }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -42,6 +42,9 @@
 #include "vtkMRMLDisplayNode.h"
 #include "vtkMRMLInteractionEventData.h"
 
+// SlicerQt includes
+#include "qSlicerApplication.h"
+
 // Qt includes
 #include <QAction>
 #include <QDebug>
@@ -63,6 +66,12 @@ public:
 
   /// Menu shown when right-clicking a supported object in the views
   QMenu* ViewMenu;
+  /// Edit properties action
+  QAction* EditPropertiesAction;
+  /// Actions from the registered plugins
+  QList<QAction*> AllPluginActions;
+  /// Item ID for the currently displayed View menu
+  vtkIdType CurrentItemID;
 };
 
 //-----------------------------------------------------------------------------
@@ -71,12 +80,17 @@ public:
 //-----------------------------------------------------------------------------
 qSlicerSubjectHierarchyPluginLogicPrivate::qSlicerSubjectHierarchyPluginLogicPrivate(qSlicerSubjectHierarchyPluginLogic& object)
   : q_ptr(&object)
+  , CurrentItemID(0)
 {
   // Register vtkIdType for use in python for subject hierarchy item IDs
   qRegisterMetaType<vtkIdType>("vtkIdType");
   //qRegisterMetaType<QList<vtkIdType> >("QList<vtkIdType>"); //TODO: Allows returning it but cannot be used (e.g. pluginHandler->currentItems())
 
   this->ViewMenu = new QMenu();
+
+  this->EditPropertiesAction = new QAction("Edit properties...");
+  this->EditPropertiesAction->setObjectName("EditPropertiesAction");
+  QObject::connect(this->EditPropertiesAction, SIGNAL(triggered()), q_ptr, SLOT(editProperties()));
 }
 
 //-----------------------------------------------------------------------------
@@ -84,6 +98,9 @@ qSlicerSubjectHierarchyPluginLogicPrivate::~qSlicerSubjectHierarchyPluginLogicPr
 {
   this->ViewMenu->deleteLater();
   this->ViewMenu = nullptr;
+
+  this->EditPropertiesAction->deleteLater();
+  this->EditPropertiesAction = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -462,9 +479,20 @@ void qSlicerSubjectHierarchyPluginLogic::onDisplayMenuEvent(vtkObject* displayNo
   vtkIdType itemID = shNode->GetItemByDataNode(displayableNode);
   if (!itemID)
     {
-    qCritical() << Q_FUNC_INFO<< ": Failed to find displayable node " << (displayableNode->GetName() ? displayableNode->GetName() : "Unnamed")
+    qCritical() << Q_FUNC_INFO << ": Failed to find displayable node " << (displayableNode->GetName() ? displayableNode->GetName() : "Unnamed")
       << " in subject hierarchy";
     return;
+    }
+
+  // If menu is empty (when no white-list was set manually), then construct the full menu
+  if (d->ViewMenu->isEmpty())
+    {
+    d->ViewMenu->clear(); // isEmpty may return true if there are actions in the menu with visibility off
+    foreach (QAction* action, d->AllPluginActions)
+      {
+      d->ViewMenu->addAction(action);
+      }
+    d->ViewMenu->addAction(d->EditPropertiesAction);
     }
 
   // Have all plugins show context view menu actions for current item
@@ -473,6 +501,9 @@ void qSlicerSubjectHierarchyPluginLogic::onDisplayMenuEvent(vtkObject* displayNo
     plugin->hideAllContextMenuActions();
     plugin->showViewContextMenuActionsForItem(itemID, eventDataMap);
     }
+
+  // Set current item ID for Edit properties action
+  d->CurrentItemID = itemID;
 
   // Show menu
   d->ViewMenu->move(QCursor::pos());
@@ -543,6 +574,68 @@ void qSlicerSubjectHierarchyPluginLogic::addViewMenuAction(QAction* action)
 
   if (action)
     {
-    d->ViewMenu->addAction(action);
+    d->AllPluginActions << action;
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyPluginLogic::editProperties()
+{
+  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
+  if (!shNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
+    return;
+    }
+
+  Q_D(qSlicerSubjectHierarchyPluginLogic);
+  qSlicerApplication::application()->openNodeModule(shNode->GetItemDataNode(d->CurrentItemID));
+}
+
+//-----------------------------------------------------------------------------
+QStringList qSlicerSubjectHierarchyPluginLogic::allViewMenuActions()
+{
+  Q_D(qSlicerSubjectHierarchyPluginLogic);
+
+  QStringList allActions;
+  foreach (QAction* action, d->AllPluginActions)
+    {
+    allActions << action->objectName();
+    }
+  allActions << d->EditPropertiesAction->objectName();
+
+  return allActions;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyPluginLogic::setViewMenuActionWhitelist(QStringList actionObjectNames)
+{
+  Q_D(qSlicerSubjectHierarchyPluginLogic);
+
+  // Add white-listed actions to menu
+  d->ViewMenu->clear();
+  foreach (QString currentActionObjectName, actionObjectNames)
+    {
+    QAction* foundAction = nullptr;
+    foreach (QAction* action, d->AllPluginActions)
+      {
+      if (currentActionObjectName == action->objectName())
+        {
+        foundAction = action;
+        break;
+        }
+      }
+    if (!foundAction && currentActionObjectName == d->EditPropertiesAction->objectName())
+      {
+      foundAction = d->EditPropertiesAction;
+      }
+    if (foundAction)
+      {
+      d->ViewMenu->addAction(foundAction);
+      }
+    else
+      {
+      qWarning() << Q_FUNC_INFO << ": Failed to find subject hierarchy view menu action by object name " << currentActionObjectName;
+      }
     }
 }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
@@ -71,8 +71,16 @@ public:
 
   /// Register subject hierarchy core plugins
   /// Note: Registering plugins provided by other modules is the responsibility
-  ///   of the module!
+  ///       of the module!
   void registerCorePlugins();
+
+  /// Get all view menu actions available
+  /// \return List of object names of the view menu actions
+  Q_INVOKABLE QStringList allViewMenuActions();
+  /// Set desired set of view menu actions
+  /// \param actionObjectNames List of view menu actions to consider. Only actions included here by object name
+  ///        are shown in the menu if they are accepted by the owner plugin. The order set here is used.
+  Q_INVOKABLE void setViewMenuActionWhitelist(QStringList actionObjectNames);
 
 protected:
   /// Add observations for node that was added to subject hierarchy
@@ -113,6 +121,8 @@ protected slots:
   void onDisplayNodeModified(vtkObject*, vtkObject*);
   /// Called when menu event is invoked on a display node of an owned displayable node
   void onDisplayMenuEvent(vtkObject*, vtkObject*);
+  /// Called when the user clicks the Edit properties View menu action
+  void editProperties();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyPluginLogicPrivate> d_ptr; 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.cxx
@@ -60,8 +60,10 @@ public:
     SetDisplayVisibilityMethod,
     GetDisplayVisibilityMethod,
     ItemContextMenuActionsMethod,
+    ViewContextMenuActionsMethod,
     SceneContextMenuActionsMethod,
     ShowContextMenuActionsForItemMethod,
+    ShowViewContextMenuActionsForItemMethod,
     CanAddNodeToSubjectHierarchyMethod,
     CanReparentItemInsideSubjectHierarchyMethod,
     ReparentItemInsideSubjectHierarchyMethod
@@ -91,8 +93,10 @@ qSlicerSubjectHierarchyScriptedPluginPrivate::qSlicerSubjectHierarchyScriptedPlu
   this->PythonCppAPI.declareMethod(Self::GetDisplayVisibilityMethod, "getDisplayVisibility");
   // Function related methods
   this->PythonCppAPI.declareMethod(Self::ItemContextMenuActionsMethod, "itemContextMenuActions");
+  this->PythonCppAPI.declareMethod(Self::ViewContextMenuActionsMethod, "viewContextMenuActions");
   this->PythonCppAPI.declareMethod(Self::SceneContextMenuActionsMethod, "sceneContextMenuActions");
   this->PythonCppAPI.declareMethod(Self::ShowContextMenuActionsForItemMethod, "showContextMenuActionsForItem");
+  this->PythonCppAPI.declareMethod(Self::ShowViewContextMenuActionsForItemMethod, "showViewContextMenuActionsForItem");
   // Parenting related methods (with default implementation)
   this->PythonCppAPI.declareMethod(Self::CanAddNodeToSubjectHierarchyMethod, "canAddNodeToSubjectHierarchy");
   this->PythonCppAPI.declareMethod(Self::CanReparentItemInsideSubjectHierarchyMethod, "canReparentItemInsideSubjectHierarchy");
@@ -377,6 +381,33 @@ QList<QAction*> qSlicerSubjectHierarchyScriptedPlugin::itemContextMenuActions()c
 }
 
 //-----------------------------------------------------------------------------
+QList<QAction*> qSlicerSubjectHierarchyScriptedPlugin::viewContextMenuActions()const
+{
+  Q_D(const qSlicerSubjectHierarchyScriptedPlugin);
+  PyObject* result = d->PythonCppAPI.callMethod(d->ViewContextMenuActionsMethod);
+  if (!result)
+    {
+    // Method call failed (probably an omitted function), call default implementation
+    return this->Superclass::viewContextMenuActions();
+    }
+
+  // Parse result
+  QVariant resultVariant = PythonQtConv::PyObjToQVariant(result, QVariant::List);
+  if (resultVariant.isNull())
+    {
+    return this->Superclass::viewContextMenuActions();
+    }
+  QList<QVariant> resultVariantList = resultVariant.toList();
+  QList<QAction*> actionList;
+  foreach(QVariant actionVariant, resultVariantList)
+    {
+    QAction* action = qobject_cast<QAction*>( actionVariant.value<QObject*>() );
+    actionList << action;
+    }
+  return actionList;
+}
+
+//-----------------------------------------------------------------------------
 QList<QAction*> qSlicerSubjectHierarchyScriptedPlugin::sceneContextMenuActions()const
 {
   Q_D(const qSlicerSubjectHierarchyScriptedPlugin);
@@ -410,6 +441,23 @@ void qSlicerSubjectHierarchyScriptedPlugin::showContextMenuActionsForItem(vtkIdT
 
   PyObject* arguments = PyTuple_New(1);
   PyTuple_SET_ITEM(arguments, 0, PyLong_FromLongLong(itemID));
+  PyObject* result = d->PythonCppAPI.callMethod(d->ShowContextMenuActionsForItemMethod, arguments);
+  Py_DECREF(arguments);
+  if (!result)
+    {
+    // Method call failed (probably an omitted function), call default implementation
+    this->Superclass::showContextMenuActionsForItem(itemID);
+    }
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyScriptedPlugin::showViewContextMenuActionsForItem(vtkIdType itemID, QVariantMap eventData)
+{
+  Q_D(qSlicerSubjectHierarchyScriptedPlugin);
+
+  PyObject* arguments = PyTuple_New(1);
+  PyTuple_SET_ITEM(arguments, 0, PyLong_FromLongLong(itemID));
+  PyTuple_SET_ITEM(arguments, 1, PythonQtConv::QVariantMapToPyObject(eventData));
   PyObject* result = d->PythonCppAPI.callMethod(d->ShowContextMenuActionsForItemMethod, arguments);
   Py_DECREF(arguments);
   if (!result)

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyScriptedPlugin.h
@@ -128,6 +128,9 @@ public:
   /// Get item context menu item actions to add to tree view
   QList<QAction*> itemContextMenuActions()const override;
 
+  /// Get view item context menu item actions to add to views
+  QList<QAction*> viewContextMenuActions()const override;
+
   /// Get scene context menu item actions to add to tree view
   /// Separate method is needed for the scene, as its actions are set to the
   /// tree by a different method \sa itemContextMenuActions
@@ -137,7 +140,12 @@ public:
   /// \param itemID Subject Hierarchy item to show the context menu items for
   void showContextMenuActionsForItem(vtkIdType itemID) override;
 
-// Parenting related virtual methods with default implementation
+  /// Show view context menu actions valid for a given subject hierarchy item.
+  /// \param itemID Subject Hierarchy item to show the context menu items for
+  /// \param eventData Supplementary data for the item that may be considered for the menu (sub-item ID, attribute, etc.)
+  void showViewContextMenuActionsForItem(vtkIdType itemID, QVariantMap eventData) override;
+
+  // Parenting related virtual methods with default implementation
 public:
   /// Determines if a data node can be placed in the hierarchy using the actual plugin,
   /// and gets a confidence value for a certain MRML node (usually the type and possibly attributes are checked).


### PR DESCRIPTION
- More actions for markpus (and not just for fiducial types): Rename point, Delete point, Toggle select point, Edit properties...
- A whitelist in plugin logic for the actions so that it can be easily customized
