### PR TITLE
BUG: Fixes normal vector weight bug and update search radius range

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -206,7 +206,7 @@ bool vtkMRMLMarkupsCurveNode::ResampleCurveSurface(double controlPointDistance, 
     vtkErrorMacro("vtkMRMLMarkupsCurveNode::ResampleCurveSurface failed: Constraint surface is not valid");
     return false;
     }
-  if (maximumSearchRadiusTolerance <= 0 || maximumSearchRadiusTolerance >= 1)
+  if (maximumSearchRadiusTolerance <= 0 || maximumSearchRadiusTolerance > 1)
     {
     vtkErrorMacro("vtkMRMLMarkupsCurveNode::ResampleCurveSurface failed: Invalid search radius");
     return false;
@@ -285,17 +285,16 @@ bool vtkMRMLMarkupsCurveNode::ResampleCurveSurface(double controlPointDistance, 
     originalControlPoints->GetPoint(segmentStartIndex, segmentStartPoint);
     // get projection of point to curve
     this->GetClosestPointPositionAlongCurveWorld(interpolatedPoint, projectedPoint);
+	distanceToStart = vtkMath::Distance2BetweenPoints(segmentStartPoint, projectedPoint);
     if (segmentStartIndex == 0)
       {
       originalControlPoints->GetPoint(segmentStartIndex + 1, segmentEndPoint);
-      distanceToStart = 0;
       distanceToEnd = vtkMath::Distance2BetweenPoints(segmentEndPoint, projectedPoint);
       }
     else if (segmentStartIndex == (originalControlPoints->GetNumberOfPoints() - 1))
       {
       originalControlPoints->GetPoint(segmentStartIndex - 1, segmentEndPoint);
-      distanceToStart = vtkMath::Distance2BetweenPoints(segmentStartPoint, projectedPoint);
-      distanceToEnd = 0;
+      distanceToEnd = vtkMath::Distance2BetweenPoints(segmentEndPoint, projectedPoint);
       }
     else
       {
@@ -303,7 +302,7 @@ bool vtkMRMLMarkupsCurveNode::ResampleCurveSurface(double controlPointDistance, 
       double dist1 = vtkMath::Distance2BetweenPoints(segmentEndPoint1, projectedPoint);
       double* segmentEndPoint2 = originalControlPoints->GetPoint(segmentStartIndex + 1);
       double dist2 = vtkMath::Distance2BetweenPoints(segmentEndPoint2, projectedPoint);
-      distanceToStart = vtkMath::Distance2BetweenPoints(segmentStartPoint, projectedPoint);
+      
       if ((dist1 < dist2) && dist1 < vtkMath::Distance2BetweenPoints(segmentEndPoint1, segmentStartPoint))
         {
         segmentEndPoint[0] = segmentEndPoint1[0];
@@ -328,8 +327,8 @@ bool vtkMRMLMarkupsCurveNode::ResampleCurveSurface(double controlPointDistance, 
     double endNormal[3] = { 0.0 };
     normalVectorArray->GetTuple(pointIdEnd, endNormal);
 
-    double startWeight = distanceToStart / (distanceToStart + distanceToEnd);
-    double endWeight = distanceToEnd / (distanceToStart + distanceToEnd);
+    double startWeight = distanceToEnd / (distanceToStart + distanceToEnd);
+    double endWeight = distanceToStart / (distanceToStart + distanceToEnd);
     double rayDirection[3] = { 0.0 };
     rayDirection[0] = (startWeight*startNormal[0]) + (endWeight*endNormal[0]);
     rayDirection[1] = (startWeight*startNormal[1]) + (endWeight*endNormal[1]);
@@ -355,7 +354,7 @@ bool vtkMRMLMarkupsCurveNode::ConstrainPointsToSurface(vtkPoints* originalPoints
     vtkGenericWarningMacro("vtkMRMLMarkupsCurveNode::ConstrainPointsToSurface failed: invalid inputs");
     return false;
     }
-  if (maximumSearchRadiusTolerance <= 0 || maximumSearchRadiusTolerance >= 1)
+  if (maximumSearchRadiusTolerance <= 0 || maximumSearchRadiusTolerance > 1)
     {
     vtkGenericWarningMacro("vtkMRMLMarkupsCurveNode::ConstrainPointsToSurface failed: Invalid search radius");
     return false;


### PR DESCRIPTION
This commit fixes a bug in the resample curves function of the Markups Module. The bug in the estimation of the normal vectors used to project curve points onto a surface resulted in a NAN weight for the final curve point. The weights of the normal points on either side of the projected point needed to be reversed.

The range of allowed the allowed search radius is expanded to include 100% to align with the GUI.