### PR TITLE
BUG: Fix crash when loading and editing empty segments

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -788,6 +788,11 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
           else
             {
             // empty segment
+            for (int i = 0; i < 3; ++i)
+              {
+              currentSegmentExtent[2 * i] = 0;
+              currentSegmentExtent[2 * i + 1] = -1;
+              }
             currentBinaryLabelmap->SetExtent(currentSegmentExtent);
             currentBinaryLabelmap->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
             }


### PR DESCRIPTION
When loading a segmentation file that contained a segment with an empty segment that was not {0, -1, 0, -1, 0, -1}, there would be a crash when trying to copy or use the image data.
Fixed by setting the segment extent to {0, -1, 0, -1, 0, -1} if it is empty.