### PR TITLE
BUG: Fix clearing of segments in ImportLabelmapToSegmentationNode

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -1415,7 +1415,7 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(
     }
 
   // Get oriented image data from labelmap volume node
-  vtkOrientedImageData* labelOrientedImageData = vtkOrientedImageData::New();
+  vtkNew<vtkOrientedImageData> labelOrientedImageData;
   labelOrientedImageData->vtkImageData::ShallowCopy(labelmapNode->GetImageData());
   vtkNew<vtkMatrix4x4> ijkToRasMatrix;
   labelmapNode->GetIJKToRASMatrix(ijkToRasMatrix.GetPointer());
@@ -1501,8 +1501,8 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(
       }
 
     int label = segmentIndex + 1;
-    segment->SetLabelValue(label);
     segmentationNode->GetSegmentation()->ClearSegment(segmentId);
+    segment->SetLabelValue(label);
     segment->AddRepresentation(vtkSegmentationConverter::GetBinaryLabelmapRepresentationName(), labelOrientedImageData);
 
     } // for each label


### PR DESCRIPTION
During ImportLabelmapToSegmentationNode, segments should be cleared if they already exist, however the wrong label value was being cleared for the updated segment.
Fixed by clearing the segment before updating the label value (was previously the opposite).
Added a test to SegmentationsModuleTest1 to detect this issue.