### PR TITLE
BUG: Fix vtkITKArchetypeImageSeriesReader::CanReadFile()

### DIFF
--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h
@@ -806,6 +806,9 @@ protected:
   /// Get MetaData from dictionary, removing all whitespaces from the string.
   static std::string GetMetaDataWithoutSpaces(const itk::MetaDataDictionary &dict, const std::string& tag);
 
+  /// Get the image IO for the specified filename
+  itk::ImageIOBase::Pointer GetImageIO(const char* filename);
+
   char *Archetype;
   int SingleFile;
   int UseOrientationFromFile;

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
@@ -82,7 +82,7 @@ void vtkITKExecuteDataFromFileVector(
       self->GetDesiredCoordinateOrientation());
     filter = orient2;
     }
-   filter->UpdateLargestPossibleRegion();
+  filter->UpdateLargestPossibleRegion();
   typename itk::ImportImageContainer<itk::SizeValueType, T>::Pointer PixelContainer2;
   PixelContainer2 = filter->GetOutput()->GetPixelContainer();
   void *ptr = static_cast<void *> (PixelContainer2->GetBufferPointer());


### PR DESCRIPTION
vtkITKArchetypeImageSeriesReader::CanReadFile previously returned true as long as the Archetype was set, and the file exists.
Now, CanReadFile will return true if, in addition to the archetype being set and the file existing, an itk::ImageFileReader can be instantiated for the specified file.