### PR TITLE
ENH: Add option to set space attribute in vtkTeemNRRDWriter

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -1150,6 +1150,8 @@ int vtkMRMLSegmentationStorageNode::WriteBinaryLabelmapRepresentation(vtkMRMLSeg
   vtkNew<vtkTeemNRRDWriter> writer;
   writer->SetFileName(fullName.c_str());
   writer->SetUseCompression(this->GetUseCompression());
+  writer->SetSpace(nrrdSpaceLeftPosteriorSuperior);
+  writer->SetMeasurementFrameMatrix(nullptr);
 
   // Create metadata dictionary
 

--- a/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
+++ b/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
@@ -38,6 +38,7 @@ vtkTeemNRRDWriter::vtkTeemNRRDWriter()
   this->AxisLabels = new AxisInfoMapType;
   this->AxisUnits = new AxisInfoMapType;
   this->VectorAxisKind = nrrdKindUnknown;
+  this->Space = nrrdSpaceRightAnteriorSuperior;
 }
 
 //----------------------------------------------------------------------------
@@ -197,9 +198,23 @@ void* vtkTeemNRRDWriter::MakeNRRD()
   void *buffer;
   int vtkType;
 
-    // Fill in image information.
+  // Fill in image information.
 
   //vtkImageData *input = this->GetInput();
+
+  if (this->Space != nrrdSpaceRightAnteriorSuperior || this->Space != nrrdSpaceRightAnteriorSuperiorTime)
+    {
+    if (this->GetInput()->GetPointData()->GetTensors())
+      {
+      vtkErrorMacro("Write: Can only NRRD with tensors in RAS space");
+      return nullptr;
+      }
+    if (this->MeasurementFrameMatrix)
+      {
+      vtkErrorMacro("Write: Can only NRRD with a measurement frame in RAS space");
+      return nullptr;
+      }
+    }
 
   // Find Pixel type from data and select a buffer.
   this->vtkImageDataInfoToNrrdInfo(this->GetInput(),kind[0],size[0],vtkType, &buffer);
@@ -220,16 +235,36 @@ void* vtkTeemNRRDWriter::MakeNRRD()
     }
   nrrdDim = baseDim + spaceDim;
 
+  vtkNew<vtkMatrix4x4> rasToSpace;
+  rasToSpace->Identity();
+  switch (this->Space)
+    {
+    case nrrdSpaceRightAnteriorSuperior:
+    case nrrdSpaceRightAnteriorSuperiorTime:
+      break;
+    case nrrdSpaceLeftPosteriorSuperior:
+    case nrrdSpaceLeftPosteriorSuperiorTime:
+      rasToSpace->SetElement(0, 0, -1);
+      rasToSpace->SetElement(1, 1, -1);
+      break;
+    default:
+      vtkErrorMacro("Write: Unsupported space " << this->Space << " for " << this->GetFileName());
+      return nullptr;
+    }
+  vtkNew<vtkMatrix4x4> ijkToSpaceMatrix;
+  vtkMatrix4x4::Multiply4x4(rasToSpace, this->IJKToRASMatrix, ijkToSpaceMatrix);
+
   unsigned int axi;
   for (axi=0; axi < spaceDim; axi++)
     {
     size[axi+baseDim] = this->GetInput()->GetDimensions()[axi];
     kind[axi+baseDim] = nrrdKindDomain;
-    origin[axi] = this->IJKToRASMatrix->GetElement((int) axi,3);
+    origin[axi] = ijkToSpaceMatrix->GetElement((int) axi,3);
+
     //double spacing = this->GetInput()->GetSpacing()[axi];
     for (unsigned int saxi=0; saxi < spaceDim; saxi++)
       {
-      spaceDir[axi+baseDim][saxi] = this->IJKToRASMatrix->GetElement(saxi,axi);
+      spaceDir[axi+baseDim][saxi] = ijkToSpaceMatrix->GetElement(saxi,axi);
       }
     }
 
@@ -249,7 +284,7 @@ void* vtkTeemNRRDWriter::MakeNRRD()
     }
   nrrdAxisInfoSet_nva(nrrd, nrrdAxisInfoKind, kind);
   nrrdAxisInfoSet_nva(nrrd, nrrdAxisInfoSpaceDirection, spaceDir);
-  nrrd->space = nrrdSpaceRightAnteriorSuperior;
+  nrrd->space = this->Space;
 
   if (!this->AxisLabels->empty())
     {

--- a/Libs/vtkTeem/vtkTeemNRRDWriter.h
+++ b/Libs/vtkTeem/vtkTeemNRRDWriter.h
@@ -82,6 +82,19 @@ public:
   /// from the number of components and scalar type.
   void SetVectorAxisKind(int kind);
 
+  /// Method to set the coordinate system written to the NRRD file.
+  /// Currently the only valid coordinate systems are: RAS, RAST, LPS, and LPST.
+  vtkSetMacro(Space, int);
+  vtkGetMacro(Space, int);
+
+  /// Set coordinate system to RAS
+  void vtkSetSpaceToRAS()  { this->SetSpace(nrrdSpaceRightAnteriorSuperior);  };
+  void vtkSetSpaceToRAST() { this->SetSpace(nrrdSpaceRightAnteriorSuperiorTime);  };
+
+  /// Set coordinate system to LPS
+  void vtkSetSpaceToLPS()  { this->SetSpace(nrrdSpaceLeftPosteriorSuperior); };
+  void vtkSetSpaceToLPST() { this->SetSpace(nrrdSpaceLeftPosteriorSuperiorTime); };
+
   /// Utility function to return image as a Nrrd*
   void* MakeNRRD();
 
@@ -115,6 +128,7 @@ protected:
   AxisInfoMapType *AxisLabels;
   AxisInfoMapType *AxisUnits;
   int VectorAxisKind;
+  int Space;
 
 private:
   vtkTeemNRRDWriter(const vtkTeemNRRDWriter&) = delete;


### PR DESCRIPTION
Previously all NRRD files written using vtkTeemNRRDWriter were written in RAS.
This commit offers the options to write NRRD files in RAS, RAST, LPS, or LPST space.

Attempting to write a NRRD with tensors, or with a measurement frame, in any space except RAS/RAST will report an error and fail to write.
NRRD Segmentations are now saved in LPS coordinates.