### PR TITLE
BUG: Fix incorrect logical operation in vtkTeemNRRDWriter

### DIFF
--- a/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
+++ b/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
@@ -202,7 +202,7 @@ void* vtkTeemNRRDWriter::MakeNRRD()
 
   //vtkImageData *input = this->GetInput();
 
-  if (this->Space != nrrdSpaceRightAnteriorSuperior || this->Space != nrrdSpaceRightAnteriorSuperiorTime)
+  if (this->Space != nrrdSpaceRightAnteriorSuperior && this->Space != nrrdSpaceRightAnteriorSuperiorTime)
     {
     if (this->GetInput()->GetPointData()->GetTensors())
       {


### PR DESCRIPTION
Check for RAS/RAST space used '||' instead of '&&'.
Fixes failing py_nomainwindow_DWMRIMultishellIOTests.