### PR TITLE
COMP: Fix names of modules to compile with USE_SYSTEM_python

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -38,12 +38,21 @@ endif()
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
 if(Slicer_USE_SYSTEM_${proj})
-  foreach(module_name IN ITEMS pydicom numpy pillow six certifi idna chardet urllib3 requests dicomweb_client)
+  foreach(module_name IN ITEMS pydicom numpy six certifi idna chardet urllib3 requests)
     ExternalProject_FindPythonPackage(
       MODULE_NAME "${module_name}"
       REQUIRED
       )
   endforeach()
+  ExternalProject_FindPythonPackage(
+    MODULE_NAME PIL #pillow
+    REQUIRED
+    )
+  ExternalProject_FindPythonPackage(
+    MODULE_NAME dicomweb_client
+    NO_VERSION_PROPERTY
+    REQUIRED
+    )
 endif()
 
 if(NOT Slicer_USE_SYSTEM_${proj})

--- a/SuperBuild/External_python-ensurepip.cmake
+++ b/SuperBuild/External_python-ensurepip.cmake
@@ -11,12 +11,17 @@ endif()
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
 if(Slicer_USE_SYSTEM_${proj})
-  foreach(module_name IN ITEMS ensurepip pip setuptools)
+  foreach(module_name IN ITEMS pip setuptools)
     ExternalProject_FindPythonPackage(
       MODULE_NAME "${module_name}"
       REQUIRED
       )
   endforeach()
+  ExternalProject_FindPythonPackage(
+    MODULE_NAME ensurepip
+    VERSION_PROPERTY "version()"
+    REQUIRED
+    )
 endif()
 
 if(NOT Slicer_USE_SYSTEM_${proj})

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -21,7 +21,7 @@ endif()
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
 if(Slicer_USE_SYSTEM_${proj})
-  foreach(module_name IN ITEMS chardet couchdb gitdb2 smmap2 GitPython six)
+  foreach(module_name IN ITEMS chardet couchdb gitdb smmap git six)
     ExternalProject_FindPythonPackage(
       MODULE_NAME "${module_name}"
       REQUIRED

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -25,12 +25,17 @@ endif()
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 
 if(Slicer_USE_SYSTEM_${proj})
-  foreach(module_name IN ITEMS PyJWT PyGithub)
+  foreach(module_name IN ITEMS jwt)
     ExternalProject_FindPythonPackage(
       MODULE_NAME "${module_name}"
       REQUIRED
       )
   endforeach()
+  ExternalProject_FindPythonPackage(
+    MODULE_NAME github
+    NO_VERSION_PROPERTY
+    REQUIRED
+    )
 endif()
 
 if(NOT Slicer_USE_SYSTEM_${proj})


### PR DESCRIPTION
The name of the modules are sometimes not the same used for the
import command.  For example, for the package pillow, have to use `import PIL`

This made the command `ExternalProject_FindPythonPackage` to fail when
checking version.
Also some modules do not implement `__version__`, but `version()` or
even nothing. Changes have been made accordingly for these cases.

Tested in ArchLinux with command:

```bash
cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo -DSlicer_USE_SYSTEM_curl:BOOL=ON -DSlicer_USE_SYSTEM_python:BOOL=ON -DQt5_DIR:PATH=/usr/lib/cmake/Qt5 ../Slicer-src
```

And installing with `pacman`, from the AUR, or with `pip --user` the required
python packages.

As a side-note, Arch also requires the VTK fix for Python3.8:
https://gitlab.kitware.com/vtk/vtk/merge_requests/5883/commits