### PR TITLE
COMP: Make EditorEffects base classes available for extensions

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/EditorEffects/CMakeLists.txt
@@ -78,10 +78,9 @@ set(${KIT}_TARGET_LIBRARIES
   )
 
 #-----------------------------------------------------------------------------
-SlicerMacroBuildModuleQtLibrary(
+SlicerMacroBuildModuleWidgets(
   NAME ${KIT}
   EXPORT_DIRECTIVE ${${KIT}_EXPORT_DIRECTIVE}
-  FOLDER "Module-${MODULE_NAME}"
   INCLUDE_DIRECTORIES ${${KIT}_INCLUDE_DIRECTORIES}
   SRCS ${${KIT}_SRCS}
   MOC_SRCS ${${KIT}_MOC_SRCS}


### PR DESCRIPTION
SlicerMacroBuildModuleQtLibrary macro does not add module include directories to CMake variables that are exposed to extensions. However, we need Segmentations/EditorEffects classes to be available for extensions to allow creating editor effects in C++.

See background in https://discourse.slicer.org/t/unable-to-include-qslicersegmentationseditoreffects-when-building-extension/9371/5