### PR TITLE
ENH: Add CropToMinimumExtent to vtkMRMLSegmentationStorageNode

### DIFF
--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -71,6 +71,7 @@ set(KIT_SRCS
   qSlicerNodeWriter.h
   qSlicerNodeWriterOptionsWidget.cxx
   qSlicerNodeWriterOptionsWidget.h
+  qSlicerNodeWriterOptionsWidget_p.h
   qSlicerQListQVariantMapMetaType.h
   qSlicerSaveDataDialog.cxx
   qSlicerSaveDataDialog.h
@@ -203,6 +204,7 @@ set(KIT_MOC_SRCS
   qSlicerMouseModeToolBar_p.h
   qSlicerNodeWriter.h
   qSlicerNodeWriterOptionsWidget.h
+  qSlicerNodeWriterOptionsWidget_p.h
   qSlicerSaveDataDialog.h
   qSlicerSaveDataDialog_p.h
   qSlicerSettingsCachePanel.h

--- a/Base/QTGUI/qSlicerNodeWriterOptionsWidget.cxx
+++ b/Base/QTGUI/qSlicerNodeWriterOptionsWidget.cxx
@@ -18,26 +18,13 @@
 
 ==============================================================================*/
 
-// Qt includes
-
 // qSlicer includes
-#include "qSlicerIOOptions_p.h"
 #include "qSlicerNodeWriterOptionsWidget.h"
-#include "ui_qSlicerNodeWriterOptionsWidget.h"
+#include "qSlicerNodeWriterOptionsWidget_p.h"
 
 // MRML includes
 #include <vtkMRMLStorableNode.h>
 #include <vtkMRMLStorageNode.h>
-
-//------------------------------------------------------------------------------
-class qSlicerNodeWriterOptionsWidgetPrivate
-  : public qSlicerIOOptionsPrivate
-  , public Ui_qSlicerNodeWriterOptionsWidget
-{
-public:
-  ~qSlicerNodeWriterOptionsWidgetPrivate() override;
-  virtual void setupUi(QWidget* widget);
-};
 
 //------------------------------------------------------------------------------
 qSlicerNodeWriterOptionsWidgetPrivate::~qSlicerNodeWriterOptionsWidgetPrivate()
@@ -51,6 +38,14 @@ void qSlicerNodeWriterOptionsWidgetPrivate::setupUi(QWidget* widget)
                    widget, SLOT(setUseCompression(bool)));
   QObject::connect(this->CompressionParameterSelector, SIGNAL(currentIndexChanged(int)),
                    widget, SLOT(setCompressionParameter(int)));
+}
+
+//------------------------------------------------------------------------------
+qSlicerNodeWriterOptionsWidget
+::qSlicerNodeWriterOptionsWidget(qSlicerNodeWriterOptionsWidgetPrivate* pimpl,
+                                   QWidget* parentWidget)
+  : Superclass(pimpl, parentWidget)
+{
 }
 
 //------------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerNodeWriterOptionsWidget.h
+++ b/Base/QTGUI/qSlicerNodeWriterOptionsWidget.h
@@ -37,7 +37,7 @@ public:
   explicit qSlicerNodeWriterOptionsWidget(QWidget* parent = nullptr);
   ~qSlicerNodeWriterOptionsWidget() override;
 
-  bool showUseCompression()const;
+  bool showUseCompression() const;
   void setShowUseCompression(bool show);
 
   bool isValid()const override;
@@ -49,6 +49,10 @@ protected slots:
   virtual void setUseCompression(bool use);
   virtual void setCompressionParameter(int index);
   virtual void setCompressionParameter(QString parameter);
+
+protected:
+  qSlicerNodeWriterOptionsWidget(qSlicerNodeWriterOptionsWidgetPrivate* pimpl,
+    QWidget* parent);
 
 private:
   Q_DECLARE_PRIVATE_D(qGetPtrHelper(qSlicerIOOptions::d_ptr), qSlicerNodeWriterOptionsWidget);

--- a/Base/QTGUI/qSlicerNodeWriterOptionsWidget_p.h
+++ b/Base/QTGUI/qSlicerNodeWriterOptionsWidget_p.h
@@ -1,0 +1,49 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Julien Finet, Kitware Inc.
+  and was partially funded by NIH grant 3P41RR013218-12S1
+
+==============================================================================*/
+
+#ifndef __qSlicerNodeWriterOptionsWidget_p_h
+#define __qSlicerNodeWriterOptionsWidget_p_h
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Slicer API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include "qSlicerBaseQTGUIExport.h"
+#include "qSlicerIOOptions_p.h"
+#include "ui_qSlicerNodeWriterOptionsWidget.h"
+
+//------------------------------------------------------------------------------
+class Q_SLICER_BASE_QTGUI_EXPORT qSlicerNodeWriterOptionsWidgetPrivate
+  : public qSlicerIOOptionsPrivate
+  , public Ui_qSlicerNodeWriterOptionsWidget
+{
+public:
+  ~qSlicerNodeWriterOptionsWidgetPrivate() override;
+  virtual void setupUi(QWidget* widget);
+};
+
+#endif

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.h
@@ -162,6 +162,13 @@ public:
   /// Reset supported write file types. Called when master representation is changed
   void ResetSupportedWriteFileTypes();
 
+  /// Save segmentation using the reference geometry.
+  /// If true, the segmentation will be saved using the same extent as the reference image.
+  /// If false, the segmentation will be saved using the effective extent.
+  vtkSetMacro(CropToMinimumExtent, bool);
+  vtkGetMacro(CropToMinimumExtent, bool);
+  vtkBooleanMacro(CropToMinimumExtent, bool);
+
 protected:
   /// Initialize all the supported read file types
   void InitializeSupportedReadFileTypes() override;
@@ -224,6 +231,9 @@ protected:
 
   static std::string GetSegmentColorAsString(vtkMRMLSegmentationNode* segmentationNode, const std::string& segmentId);
   static void GetSegmentColorFromString(double color[3], std::string colorString);
+
+protected:
+  bool CropToMinimumExtent;
 
 protected:
   vtkMRMLSegmentationStorageNode();

--- a/Modules/Loadable/Segmentations/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/CMakeLists.txt
@@ -33,6 +33,10 @@ set(MODULE_SRCS
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}ModuleWidget.cxx
   qSlicer${MODULE_NAME}ModuleWidget.h
+  qSlicer${MODULE_NAME}NodeWriter.cxx
+  qSlicer${MODULE_NAME}NodeWriter.h
+  qSlicer${MODULE_NAME}NodeWriterOptionsWidget.cxx
+  qSlicer${MODULE_NAME}NodeWriterOptionsWidget.h
   qSlicer${MODULE_NAME}Reader.cxx
   qSlicer${MODULE_NAME}Reader.h
   qSlicer${MODULE_NAME}SettingsPanel.cxx
@@ -43,6 +47,8 @@ set(MODULE_MOC_SRCS
   qSlicer${MODULE_NAME}IOOptionsWidget.h
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}ModuleWidget.h
+  qSlicer${MODULE_NAME}NodeWriter.h
+  qSlicer${MODULE_NAME}NodeWriterOptionsWidget.h
   qSlicer${MODULE_NAME}Reader.h
   qSlicer${MODULE_NAME}SettingsPanel.h
   )
@@ -62,6 +68,7 @@ set(MODULE_TARGET_LIBRARIES
   qSlicer${MODULE_NAME}EditorEffects
   qSlicerSubjectHierarchyModuleWidgets
   vtkSlicerTerminologiesModuleLogic
+  qSlicerBaseQTGUI
   )
 
 set(MODULE_RESOURCES

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
@@ -28,6 +28,7 @@
 #include "vtkSlicerSegmentationsModuleLogic.h"
 #include "vtkMRMLSegmentationsDisplayableManager3D.h"
 #include "vtkMRMLSegmentationsDisplayableManager2D.h"
+#include "qSlicerSegmentationsNodeWriter.h"
 
 // Segment editor effects includes
 #include "qSlicerSegmentEditorEffectFactory.h"
@@ -167,7 +168,7 @@ void qSlicerSegmentationsModule::setup()
 
   // Register IOs
   qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
-  ioManager->registerIO(new qSlicerNodeWriter("Segmentation", QString("SegmentationFile"), QStringList() << "vtkMRMLSegmentationNode", true, this));
+  ioManager->registerIO(new qSlicerSegmentationsNodeWriter(this));
   ioManager->registerIO(new qSlicerSegmentationsReader(segmentationsLogic, this));
 
   // Register settings panel

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
@@ -1,0 +1,96 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women’s Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+// Qt includes
+#include <QDebug>
+#include <QFileInfo>
+
+// QtGUI includes
+#include "qSlicerSegmentationsNodeWriter.h"
+#include "qSlicerSegmentationsNodeWriterOptionsWidget.h"
+
+// QTCore includes
+#include "qSlicerCoreApplication.h"
+#include "qSlicerCoreIOManager.h"
+
+// MRML includes
+#include <vtkMRMLScene.h>
+#include <vtkMRMLSceneViewNode.h>
+#include <vtkMRMLSegmentationStorageNode.h>
+#include <vtkMRMLStorableNode.h>
+#include <vtkMRMLStorageNode.h>
+
+// VTK includes
+#include <vtkStdString.h>
+#include <vtkStringArray.h>
+
+//-----------------------------------------------------------------------------
+class qSlicerSegmentationsNodeWriterPrivate
+{
+public:
+  QString Description;
+  qSlicerIO::IOFileType FileType;
+  QStringList NodeClassNames;
+  bool SupportUseCompression;
+};
+
+//----------------------------------------------------------------------------
+qSlicerSegmentationsNodeWriter::qSlicerSegmentationsNodeWriter(QObject* parentObject)
+  : qSlicerNodeWriter("Segmentation", QString("SegmentationFile"), QStringList() << "vtkMRMLSegmentationNode", true, parentObject)
+  , d_ptr(new qSlicerSegmentationsNodeWriterPrivate)
+{
+  Q_D(qSlicerSegmentationsNodeWriter);
+}
+
+//----------------------------------------------------------------------------
+qSlicerSegmentationsNodeWriter::~qSlicerSegmentationsNodeWriter()
+= default;
+
+//----------------------------------------------------------------------------
+bool qSlicerSegmentationsNodeWriter::write(const qSlicerIO::IOProperties& properties)
+{
+  Q_ASSERT(!properties["nodeID"].toString().isEmpty());
+
+  vtkMRMLStorableNode* node = vtkMRMLStorableNode::SafeDownCast(
+    this->getNodeByID(properties["nodeID"].toString().toLatin1().data()));
+  if (!this->canWriteObject(node))
+    {
+    return false;
+    }
+  vtkMRMLSegmentationStorageNode* snode = vtkMRMLSegmentationStorageNode::SafeDownCast(
+    qSlicerCoreIOManager::createAndAddDefaultStorageNode(node));
+  if (snode == nullptr)
+    {
+    qDebug() << "No storage node for node" << properties["nodeID"].toString();
+    return false;
+    }
+  snode->SetCropToMinimumExtent(properties["cropToMinimumExtent"].toBool());
+
+  return Superclass::write(properties);
+}
+
+//-----------------------------------------------------------------------------
+qSlicerIOOptions* qSlicerSegmentationsNodeWriter::options() const
+{
+  Q_D(const qSlicerSegmentationsNodeWriter);
+  qSlicerSegmentationsNodeWriterOptionsWidget* options = new qSlicerSegmentationsNodeWriterOptionsWidget;
+  options->setShowUseCompression(d->SupportUseCompression);
+  return options;
+}

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.h
@@ -1,0 +1,58 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women’s Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#ifndef __qSlicerSegmentationsNodeWriter_h
+#define __qSlicerSegmentationsNodeWriter_h
+
+// QtCore includes
+#include "qSlicerSegmentationsModuleExport.h"
+#include "qSlicerNodeWriter.h"
+
+class qSlicerSegmentationsNodeWriterPrivate;
+class vtkMRMLNode;
+
+/// Utility class that is ready to use for most of the nodes.
+class Q_SLICER_QTMODULES_SEGMENTATIONS_EXPORT qSlicerSegmentationsNodeWriter
+  : public qSlicerNodeWriter
+{
+  Q_OBJECT
+public:
+  typedef qSlicerNodeWriter Superclass;
+  qSlicerSegmentationsNodeWriter(QObject* parent);
+  ~qSlicerSegmentationsNodeWriter() override;
+
+  /// Return a qSlicerIOSegmentationNodeWriterOptionsWidget
+  qSlicerIOOptions* options()const override;
+
+  /// Write the node referenced by "nodeID" into the "fileName" file.
+  /// Optionally, "useCompression" and "useReferenceGeometry" can be specified.
+  /// Return true on success, false otherwise.
+  /// Create a storage node if the storable node doesn't have any.
+  bool write(const qSlicerIO::IOProperties& properties) override;
+
+protected:
+  QScopedPointer<qSlicerSegmentationsNodeWriterPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerSegmentationsNodeWriter);
+  Q_DISABLE_COPY(qSlicerSegmentationsNodeWriter);
+};
+
+#endif

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriterOptionsWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriterOptionsWidget.cxx
@@ -1,0 +1,86 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women’s Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+// Qt includes
+
+// qSlicer includes
+#include "qSlicerNodeWriterOptionsWidget_p.h"
+#include "qSlicerSegmentationsNodeWriterOptionsWidget.h"
+
+// MRML includes
+#include <vtkMRMLStorableNode.h>
+#include <vtkMRMLSegmentationStorageNode.h>
+
+//------------------------------------------------------------------------------
+class qSlicerSegmentationsNodeWriterOptionsWidgetPrivate
+  : public qSlicerNodeWriterOptionsWidgetPrivate
+{
+public:
+  virtual void setupUi(QWidget* widget) override;
+  QCheckBox* UseReferenceGeometryCheckBox;
+};
+
+//------------------------------------------------------------------------------
+void qSlicerSegmentationsNodeWriterOptionsWidgetPrivate::setupUi(QWidget* widget)
+{
+  this->qSlicerNodeWriterOptionsWidgetPrivate::setupUi(widget);
+  this->UseReferenceGeometryCheckBox = new QCheckBox(widget);
+  this->UseReferenceGeometryCheckBox->setObjectName(QStringLiteral("CropToMinimumExtentCheckBox"));
+  this->UseReferenceGeometryCheckBox->setText("Crop to minimum extent");
+  horizontalLayout->addWidget(UseReferenceGeometryCheckBox);
+  QObject::connect(this->UseReferenceGeometryCheckBox, SIGNAL(toggled(bool)),
+    widget, SLOT(setCropToMinimumExtent(bool)));
+}
+
+//------------------------------------------------------------------------------
+qSlicerSegmentationsNodeWriterOptionsWidget::qSlicerSegmentationsNodeWriterOptionsWidget(QWidget* parentWidget)
+  : Superclass(new qSlicerSegmentationsNodeWriterOptionsWidgetPrivate, parentWidget)
+{
+  Q_D(qSlicerSegmentationsNodeWriterOptionsWidget);
+  d->setupUi(this);
+}
+
+//------------------------------------------------------------------------------
+qSlicerSegmentationsNodeWriterOptionsWidget::~qSlicerSegmentationsNodeWriterOptionsWidget()
+= default;
+
+//------------------------------------------------------------------------------
+void qSlicerSegmentationsNodeWriterOptionsWidget::setObject(vtkObject* object)
+{
+  Q_D(qSlicerSegmentationsNodeWriterOptionsWidget);
+  vtkMRMLStorableNode* storableNode = vtkMRMLStorableNode::SafeDownCast(object);
+  if (storableNode)
+    {
+    vtkMRMLSegmentationStorageNode* storageNode = vtkMRMLSegmentationStorageNode::SafeDownCast(
+      storableNode->GetStorageNode());
+    if (storageNode)
+      {
+      d->UseReferenceGeometryCheckBox->setChecked(storageNode->GetCropToMinimumExtent());
+      }
+    }
+  Superclass::setObject(object);
+}
+
+//------------------------------------------------------------------------------
+void qSlicerSegmentationsNodeWriterOptionsWidget::setCropToMinimumExtent(bool crop)
+{
+  Q_D(qSlicerSegmentationsNodeWriterOptionsWidget);
+  d->Properties["cropToMinimumExtent"] = crop;
+}

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriterOptionsWidget.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriterOptionsWidget.h
@@ -1,0 +1,50 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women’s Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#ifndef __qSlicerSegmentationsNodeWriterOptionsWidget_h
+#define __qSlicerSegmentationsNodeWriterOptionsWidget_h
+
+/// QtCore includes
+#include "qSlicerSegmentationsModuleExport.h"
+#include "qSlicerNodeWriterOptionsWidget.h"
+
+class qSlicerSegmentationsNodeWriterOptionsWidgetPrivate;
+
+class Q_SLICER_QTMODULES_SEGMENTATIONS_EXPORT qSlicerSegmentationsNodeWriterOptionsWidget
+  : public qSlicerNodeWriterOptionsWidget
+{
+  Q_OBJECT
+
+public:
+  typedef qSlicerNodeWriterOptionsWidget Superclass;
+  explicit qSlicerSegmentationsNodeWriterOptionsWidget(QWidget* parent = nullptr);
+  ~qSlicerSegmentationsNodeWriterOptionsWidget() override;
+
+public slots:
+  void setObject(vtkObject* object) override;
+
+protected slots:
+  virtual void setCropToMinimumExtent(bool crop);
+
+private:
+  Q_DECLARE_PRIVATE_D(qGetPtrHelper(qSlicerIOOptions::d_ptr), qSlicerSegmentationsNodeWriterOptionsWidget);
+};
+
+#endif


### PR DESCRIPTION
If CropToMinimumExtent is false, the segmentation will be saved using the same extent as the reference image.
If CropToMinimumExtent is true, the segmentation will be saved using the effective extent.

The option can be changed using the options widget in the save dialog.
This required moving qSlicerNodeWriterOptionsWidgetPrivate to a private header so that it could be inherited.