### PR TITLE
BUG: Fix display and derived representations of cleared segments

### DIFF
--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
@@ -258,7 +258,7 @@ bool vtkBinaryLabelmapToClosedSurfaceConversionRule::CreateClosedSurface(vtkOrie
     {
     // empty labelmap
     vtkDebugMacro("Convert: No polygons can be created, input image extent is empty");
-    closedSurfacePolyData->Reset();
+    closedSurfacePolyData->Initialize();
     return true;
     }
 

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -2532,7 +2532,7 @@ bool vtkSlicerSegmentationsModuleLogic::ClearSegment(vtkMRMLSegmentationNode* se
   vtkSlicerSegmentationsModuleLogic::ReconvertAllRepresentations(segmentationNode, segmentIDVector);
 
   vtkSlicerSegmentationsModuleLogic::SetSegmentStatus(segment, vtkSlicerSegmentationsModuleLogic::NotStarted);
-  segment->Modified();
+  segmentation->InvokeEvent(vtkSegmentation::RepresentationModified, (void*)segmentId.c_str());
   return true;
 }
 

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
@@ -1156,6 +1156,15 @@ void vtkMRMLSegmentationsDisplayableManager2D::vtkInternal::UpdateDisplayNodePip
           }
         }
       }
+    else
+      {
+      // Display representation object is not available.
+      pipeline->PolyDataOutlineActor->SetVisibility(false);
+      pipeline->PolyDataFillActor->SetVisibility(false);
+      pipeline->ImageOutlineActor->SetVisibility(false);
+      pipeline->ImageFillActor->SetVisibility(false);
+      continue;
+      }
     }
 }
 
@@ -1272,6 +1281,12 @@ bool vtkMRMLSegmentationsDisplayableManager2D::vtkInternal::IsSegmentVisibleInCu
     {
     vtkPolyData* polyData = vtkPolyData::SafeDownCast(segment->GetRepresentation(displayNode->GetDisplayRepresentationName2D()));
     polyData->GetBounds(segmentBounds_Segment);
+    }
+  else if (displayNode->GetDisplayRepresentationName2D() == vtkSegmentationConverter::GetBinaryLabelmapRepresentationName() ||
+    displayNode->GetDisplayRepresentationName2D() == vtkSegmentationConverter::GetFractionalLabelmapRepresentationName())
+    {
+    vtkOrientedImageData* imageData = vtkOrientedImageData::SafeDownCast(segment->GetRepresentation(displayNode->GetDisplayRepresentationName2D()));
+    imageData->GetBounds(segmentBounds_Segment);
     }
   else
     {

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.cxx
@@ -1148,10 +1148,11 @@ void qMRMLSegmentsTableView::clearSelectedSegments()
     }
 
   QMessageBox messageBox;
-  messageBox.setStandardButtons(QMessageBox::StandardButton::Discard | QMessageBox::StandardButton::Cancel);
-  messageBox.setDefaultButton(QMessageBox::Cancel);
-  messageBox.setText("Are you sure you want to discard the contents of the selected segments?");
-  if (messageBox.exec() == QMessageBox::Cancel)
+  messageBox.addButton("Clear", QMessageBox::ButtonRole::AcceptRole);
+  QPushButton* cancelButton = messageBox.addButton("Cancel", QMessageBox::ButtonRole::RejectRole);
+  messageBox.setDefaultButton(cancelButton);
+  messageBox.setText("Are you sure you want to clear the contents of the selected segments?");
+  if (messageBox.exec() == QMessageBox::ButtonRole::RejectRole)
     {
     return;
     }


### PR DESCRIPTION
Clearing the last labelmap segment in segmentation would not correctly update the display pipeline, or the derived representations.
This commit ensures that the segments are displayed correctly if cleared using vtkDataObject::Initialize().