### PR TITLE
ENH: Save and load empty nodes without error

### DIFF
--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -517,6 +517,10 @@ void vtkMRMLStorageNode::StageWriteData ( vtkMRMLNode *refNode )
 //    this->Scene->InvokeEvent (vtkMRMLScene::SaveProgressFeedbackEvent );
     }
 
+  if (this->WriteState == Cancelled || this->WriteState == SkippedNoData)
+    {
+    return;
+    }
   if (this->URI == nullptr)
     {
     this->SetWriteStateTransferDone();
@@ -600,6 +604,10 @@ const char * vtkMRMLStorageNode::GetStateAsString(int state)
   if (state == this->Cancelled)
     {
     return "Cancelled";
+    }
+  if (state == this->SkippedNoData)
+    {
+    return "SkippedNoData";
     }
   return "(undefined)";
 }

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -117,6 +117,9 @@ public:
   /// Transferring: data is remote, and the transfer is working to completion
   /// TransferDone: the data is on disk and ready to be read
   /// Cancelled: the user cancelled the remote data transfer
+  /// SkippedNoData: writing or reading was skipped due to data not present.
+  ///                This is a valid state used if and only if the data node
+  ///                is empty and there is nothing to be written or read.
   enum
   {
     Idle,
@@ -124,7 +127,8 @@ public:
     Scheduled,
     Transferring,
     TransferDone,
-    Cancelled
+    Cancelled,
+    SkippedNoData
   };
 
   /// Get/Set the state of reading
@@ -136,6 +140,7 @@ public:
   void SetReadStateTransferring() { this->SetReadState(this->Transferring); };
   void SetReadStateTransferDone() { this->SetReadState(this->TransferDone); };
   void SetReadStateCancelled() { this->SetReadState(this->Cancelled); };
+  void SetReadStateSkippedNoData() { this->SetReadState(this->SkippedNoData); };
   const char *GetStateAsString(int state);
   const char *GetReadStateAsString() { return this->GetStateAsString(this->ReadState); };
 
@@ -149,6 +154,7 @@ public:
   void SetWriteStateTransferring() { this->SetWriteState(this->Transferring); };
   void SetWriteStateTransferDone() { this->SetWriteState(this->TransferDone); };
   void SetWriteStateCancelled() { this->SetWriteState(this->Cancelled); };
+  void SetWriteStateSkippedNoData() { this->SetWriteState(this->SkippedNoData); };
   const char *GetWriteStateAsString() { return this->GetStateAsString(this->WriteState); };
 
   ///

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
@@ -444,7 +444,15 @@ int vtkMRMLTransformStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
     vtkErrorMacro("ReadData: File name not specified");
     return 0;
     }
-  // check that the file exists
+
+  // Skip reading if write state indicates that no file has been saved due to empty dataset
+  if (this->GetWriteState() == SkippedNoData)
+    {
+    vtkDebugMacro("ReadDataInternal: empty transform file was not saved, ignore loading");
+    return 1;
+    }
+
+  // Check that the file exists
   if (vtksys::SystemTools::FileExists(fullName.c_str()) == false)
     {
     vtkErrorMacro("ReadDataInternal: transform file '" << fullName.c_str() << "' not found.");
@@ -481,8 +489,8 @@ int vtkMRMLTransformStorageNode::WriteToTransformFile(vtkMRMLNode *refNode)
   vtkAbstractTransform* transformVtk = transformNode->GetTransformFromParent();
   if (transformVtk==nullptr)
     {
-    vtkErrorMacro("WriteTransform failed: cannot get VTK transform");
-    return 0;
+    this->SetWriteStateSkippedNoData();
+    return 1;
     }
 
   // Convert VTK transform to ITK transform


### PR DESCRIPTION
When a node had no data in it, for example a transform node had no matrix object set, then WriteDataInternal returned with an error, but also the storage node contained a valid file name and the write state was TransferDone. When loading such a scene, an error was thrown because the file specified did not exist. Thus, this valid behavior could be incorrectly detected as a scene load failure.

This commit introduces the new state CancelledNoData in the storage nodes, allowing the above described situation to be handled in a way that does not indicate error. When loading such a scene, no file is attempted to be loaded, and scene load ends with success.

The supported node types are
- Volume
- Model
- Transform