### PR TITLE
COMP: Fix misc -Wunused-* warnings

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
@@ -220,6 +220,8 @@ void vtkMRMLDisplayNode::ReadXMLAttributes(const char** atts)
       }
     }
   vtkMRMLReadXMLEndMacro();
+
+  this->EndModify(disabledModify);
 }
 
 //----------------------------------------------------------------------------
@@ -277,8 +279,6 @@ void vtkMRMLDisplayNode::Copy(vtkMRMLNode *anode)
 //----------------------------------------------------------------------------
 void vtkMRMLDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 {
-  int idx;
-
   Superclass::PrintSelf(os,indent);
 
   vtkMRMLPrintBeginMacro(os, indent);

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -1049,7 +1049,6 @@ void vtkMRMLModelDisplayableManager::UpdateModelMesh(vtkMRMLDisplayableNode *dis
     vtkProp3D* prop = nullptr;
 
     int clipping = displayNode->GetClipping();
-    int visibility = (displayNode->GetVisibility() == 1 && displayNode->GetVisibility3D() == 1 ? 1 : 0);
     vtkAlgorithmOutput *meshConnection = nullptr;
     if (this->IsModelDisplayable(modelDisplayNode))
       {

--- a/Libs/MRML/Widgets/qMRMLTreeView.cxx
+++ b/Libs/MRML/Widgets/qMRMLTreeView.cxx
@@ -845,24 +845,11 @@ void qMRMLTreeView::toggleVisibility(const QModelIndex& index)
   vtkMRMLNode* node = this->sortFilterProxyModel()->mrmlNodeFromIndex(index);
   vtkMRMLDisplayNode* displayNode =
     vtkMRMLDisplayNode::SafeDownCast(node);
-  vtkMRMLDisplayableNode* displayableNode =
-    vtkMRMLDisplayableNode::SafeDownCast(node);
-  vtkMRMLDisplayableHierarchyNode* displayableHierarchyNode =
-      vtkMRMLDisplayableHierarchyNode::SafeDownCast(node);
 
   vtkMRMLSelectionNode* selectionNode = vtkMRMLSelectionNode::SafeDownCast(
     this->mrmlScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton"));
 
-  if (selectionNode && displayableHierarchyNode)
-    {
-    vtkMRMLDisplayNode *hierDisplayNode = displayableHierarchyNode->GetDisplayNode();
-    int visibility = 1;
-    if (hierDisplayNode)
-      {
-      visibility = (hierDisplayNode->GetVisibility() ? 0 : 1);
-      }
-    }
-  else if (selectionNode && displayNode)
+  if (selectionNode && displayNode)
     {
     displayNode->SetVisibility(displayNode->GetVisibility() ? 0 : 1);
     }

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -1392,7 +1392,7 @@ double vtkSlicerMarkupsLogic::GetClosedCurveSurfaceArea(vtkMRMLMarkupsClosedCurv
 }
 
 //---------------------------------------------------------------------------
-bool vtkSlicerMarkupsLogic::FitSurfaceProjectWarp(vtkPoints* curvePoints, vtkPolyData* surface, double radiusScalingFactor/*=1.0*/)
+bool vtkSlicerMarkupsLogic::FitSurfaceProjectWarp(vtkPoints* curvePoints, vtkPolyData* surface, double vtkNotUsed(radiusScalingFactor)/*=1.0*/)
 {
   if (!curvePoints || !surface)
     {
@@ -1679,7 +1679,6 @@ bool vtkSlicerMarkupsLogic::FitPlaneToPoints(vtkPoints* curvePoints, vtkMatrix4x
   pointCoords.row(1).array() -= centroid(1);
   pointCoords.row(2).array() -= centroid(2);
   Eigen::BDCSVD<Eigen::MatrixXd> svd(pointCoords, Eigen::ComputeFullU);
-  const Eigen::MatrixXd& u = svd.matrixU();
 
   transformToBestFitPlane->Identity();
   for (int row = 0; row < 3; row++)

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -393,7 +393,6 @@ bool vtkMRMLMarkupsCurveNode::ConstrainPointsToSurface(vtkPoints* originalPoints
     rayEndPoint[2] = originalPoint[2] + rayDirection[2] * rayLength;
 
     double t = 0.0;
-    double firstIntersectionPoint[3] = { 0.0 };
     double pcoords[3] = { 0.0 };
     int subId = 0;
     vtkIdType cellId = 0;
@@ -596,19 +595,16 @@ bool vtkMRMLMarkupsCurveNode::GetPositionAndClosestPointIndexAlongCurve(double f
   if (numberOfCurvePoints == 0)
     {
     vtkGenericWarningMacro("vtkMRMLMarkupsCurveNode::GetPositionAlongCurve failed: invalid input points");
-    foundClosestPointIndex = -1;
     return false;
     }
   if (startCurvePointId < 0 || startCurvePointId >= numberOfCurvePoints)
     {
     vtkGenericWarningMacro("vtkMRMLMarkupsCurveNode::GetPositionAlongCurve failed: startCurvePointId is out of range");
-    foundClosestPointIndex = -1;
     return false;
     }
   if (numberOfCurvePoints == 1 || distanceFromStartPoint == 0)
     {
     curvePoints->GetPoint(startCurvePointId, foundCurvePosition);
-    foundClosestPointIndex = startCurvePointId;
     if (distanceFromStartPoint > 0.0)
       {
       vtkGenericWarningMacro("vtkMRMLMarkupsCurveNode::GetPositionAlongCurve failed: non-zero distance"
@@ -640,7 +636,6 @@ bool vtkMRMLMarkupsCurveNode::GetPositionAndClosestPointIndexAlongCurve(double f
           {
           if (vtkMRMLMarkupsCurveNode::GetCurveLength(curvePoints, closedCurve) == 0.0)
             {
-            foundClosestPointIndex = -1;
             return false;
             }
           curveConfirmedToBeNonZeroLength = true;
@@ -652,7 +647,6 @@ bool vtkMRMLMarkupsCurveNode::GetPositionAndClosestPointIndexAlongCurve(double f
         {
         // reached end of curve before getting at the requested distance
         // return closest
-        foundClosestPointIndex = (pointId < 0 ? 0 : numberOfCurvePoints - 1);
         curvePoints->GetPoint(startCurvePointId, foundCurvePosition);
         return false;
         }
@@ -670,14 +664,6 @@ bool vtkMRMLMarkupsCurveNode::GetPositionAndClosestPointIndexAlongCurve(double f
         {
         foundCurvePosition[i] = nextPoint[i] +
           remainingDistanceFromStartPoint * (nextPoint[i] - previousPoint[i]) / lastSegmentLength;
-        }
-      if (fabs(remainingDistanceFromStartPoint) <= fabs(remainingDistanceFromStartPoint + lastSegmentLength))
-        {
-        foundClosestPointIndex = pointId;
-        }
-      else
-        {
-        foundClosestPointIndex = pointId-1;
         }
       break;
       }
@@ -1014,7 +1000,6 @@ vtkIdType vtkMRMLMarkupsCurveNode::GetClosestPointPositionAlongCurveWorld(const 
   closestPosWorld[0] = closestCurvePoint[0];
   closestPosWorld[1] = closestCurvePoint[1];
   closestPosWorld[2] = closestCurvePoint[2];
-  vtkIdType lineIndex = closestCurvePointIndex;
 
   // See if we can find any points closer along the curve
   double relativePositionAlongLine = -1.0; // between 0.0-1.0 if between the endpoints of the line segment
@@ -1030,7 +1015,6 @@ vtkIdType vtkMRMLMarkupsCurveNode::GetClosestPointPositionAlongCurveWorld(const 
       closestPosWorld[0] = closestPointOnLine[0];
       closestPosWorld[1] = closestPointOnLine[1];
       closestPosWorld[2] = closestPointOnLine[2];
-      lineIndex = closestCurvePointIndex - 1;
       }
     }
   if (closestCurvePointIndex + 1 < points->GetNumberOfPoints())
@@ -1043,7 +1027,6 @@ vtkIdType vtkMRMLMarkupsCurveNode::GetClosestPointPositionAlongCurveWorld(const 
       closestPosWorld[0] = closestPointOnLine[0];
       closestPosWorld[1] = closestPointOnLine[1];
       closestPosWorld[2] = closestPointOnLine[2];
-      lineIndex = closestCurvePointIndex;
       }
     }
   return true;

--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
@@ -545,13 +545,6 @@ void vtkSlicerModelsLogic::SetAllModelsVisibility(int flag)
     return;
     }
 
-  vtkMRMLSelectionNode *selectionNode = nullptr;
-  if (this->GetMRMLScene())
-    {
-    selectionNode = vtkMRMLSelectionNode::SafeDownCast(
-      this->GetMRMLScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton"));
-    }
-
   int numModels = this->GetMRMLScene()->GetNumberOfNodesByClass("vtkMRMLModelNode");
 
   // go into batch processing mode


### PR DESCRIPTION
Referenced below are the commits were the warnings were originally
introduced:

--------

* vtkMRMLDisplayNode:
  - r28511 / 747cab119c (ENH: Add folder display property override to more displayable managers) from @cpinter 

--------

* vtkMRMLModelDisplayableManager:
  - r28509 / 3813e8d2765bea (ENH: Refactor visibility of displayable nodes in hierarchies) from @cpinter

--------

* vtkSlicerMarkupsLogic:
  - r28390 / 68173fa5a839d (BUG: Fixed markups curve surface computation for concave surfaces) frmo @lassoan 

--------

* vtkMRMLMarkupsCurveNode:
  - r28508 / f4f510600a023120d5483a2310b609181cce4f72 (BUG: Fix markups curve interpolation) from @lassoan 
  - r28585 / 56e460280183103ee8ce8834e0d9f0aa660a13e1 (ENH: Add markups curve resample feature with optional snap to model surface) from @smrolfe @lassoan 

--------

* qMRMLTreeView, vtkSlicerModelsLogic:
  - r28510 / 637cf7c7ebfafbe098dfcc529b70a89bdccf99bc (ENH: Remove model hierarchy nodes) from @cpinter 

## Summary

* [x] vtkMRMLDisplayNode.cxx:
  * Better warning fix explicitly introduced in [r28673](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=28673)
  * Original fix inadvertently introduced in [r28674](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=28674) and later reverted in [r28676](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=28676)
* [x] vtkMRMLModelDisplayableManager.cxx: Warning fix integrated in [r28674](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=28674)
* [x] qMRMLTreeView.cxx: Warning fix integrated in [r28674](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=28674)
* [x] vtkSlicerMarkupsLogic.cxx : 
  * Warning fix integrated in [r28674](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=28674).
  * Comment indicating that `radiusScalingFactor` is not implemented added in [r28677](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=28677)
* [x] vtkSlicerModelsLogic.cxx: Warning fix integrated in [r28674](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=28674)
* [x] vtkMRMLMarkupsCurveNode.cxx:
  * Suggested fix integrated in [r28678](http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=28678)