### PR TITLE
Fix failing py_UtilTest and py_MarkupsWidgetsSelfTest

### DIFF
--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -416,19 +416,19 @@ class UtilTestTest(ScriptedLoadableModuleTest):
     self.assertEqual(narray[1,2], 31+translation[2])
     self.assertEqual(narray[4,2], 59+translation[2])
 
-    self.delayDisplay('Test updateMarkupControlPointsFromArray')
+    self.delayDisplay('Test updateMarkupsControlPointsFromArray')
 
     narray = np.array([[2,3,4],[6,7,8]])
-    slicer.util.updateMarkupControlPointsFromArray(markupsNode, narray)
+    slicer.util.updateMarkupsControlPointsFromArray(markupsNode, narray)
     self.assertEqual(markupsNode.GetNumberOfControlPoints(), 2)
     position = [0]*3
     markupsNode.GetNthControlPointPosition(1,position)
     np.testing.assert_array_equal(position,narray[1,:])
 
-    self.delayDisplay('Test updateMarkupControlPointsFromArray with world=True')
+    self.delayDisplay('Test updateMarkupsControlPointsFromArray with world=True')
 
     narray = np.array([[2,3,4],[6,7,8]])
-    slicer.util.updateMarkupControlPointsFromArray(markupsNode, narray, world=True)
+    slicer.util.updateMarkupsControlPointsFromArray(markupsNode, narray, world=True)
     self.assertEqual(markupsNode.GetNumberOfControlPoints(), 2)
     markupsNode.GetNthControlPointPositionWorld(1,position)
     np.testing.assert_array_equal(position,narray[1,:])

--- a/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
+++ b/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
@@ -93,7 +93,7 @@ class MarkupsWidgetsSelfTestTest(ScriptedLoadableModuleTest):
     self.delayDisplay("Test SimpleMarkupsWidget",self.delayMs)
 
     simpleMarkupsWidget = slicer.qSlicerSimpleMarkupsWidget()
-    nodeSelector = slicer.util.findChildren(simpleMarkupsWidget,"MarkupsFiducialNodeComboBox")[0]
+    nodeSelector = slicer.util.findChildren(simpleMarkupsWidget,"MarkupsNodeComboBox")[0]
     self.assertIsNone(simpleMarkupsWidget.interactionNode())
     simpleMarkupsWidget.setMRMLScene(slicer.mrmlScene)
     simpleMarkupsWidget.show()


### PR DESCRIPTION
The first commit should fix the following failing [py_UtilTest](http://slicer.cdash.org/testDetails.php?test=9849661&build=1773258). The test began to fail when a function was renamed in https://github.com/Slicer/Slicer/commit/a3308548ca4dd5c0ccd44924449abd55fa9d2f01. 

The second commit should fix the following failing [py_MarkupsWidgetsSelfTest ](http://slicer.cdash.org/testDetails.php?test=9849654&build=1773258). The test began to fail when a qMRMLNodeComboBox was renamed in https://github.com/Slicer/Slicer/commit/2a8a518dbb0fce256c3fb094a4e39ae3213ea6ce.