### PR TITLE
BUG: Change vtkSegmentation::DeepCopy to use CopySegment

### DIFF
--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -461,6 +461,11 @@ public:
   /// the segmentation! Use \sa CreateRepresentation for that.
   virtual void SetMasterRepresentationName(const std::string& representationName);
 
+  /// Deep copies source segment to destination segment. If the same representation is found in baseline
+  /// with up-to-date timestamp then the representation is reused from baseline.
+  static void CopySegment(vtkSegment* destination, vtkSegment* source, vtkSegment* baseline,
+    std::map<vtkDataObject*, vtkDataObject*>& cachedRepresentations);
+
 protected:
   bool ConvertSegmentsUsingPath(std::vector<std::string> segmentIDs, vtkSegmentationConverter::ConversionPathType path, bool overwriteExisting = false);
   bool ConvertSegments(std::vector<std::string> segmentIDs, bool overwriteExisting = false);

--- a/Libs/vtkSegmentationCore/vtkSegmentationHistory.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationHistory.h
@@ -105,11 +105,6 @@ protected:
   ~vtkSegmentationHistory() override;
   void operator=(const vtkSegmentationHistory&);
 
-  /// Deep copies source segment to destination segment. If the same representation is found in baseline
-  /// with up-to-date timestamp then the representation is reused from baseline.
-  void CopySegment(vtkSegment* destination, vtkSegment* source, vtkSegment* baseline,
-    std::map<vtkDataObject*, vtkDataObject*> &cachedRepresentations);
-
   typedef std::map<std::string, vtkSmartPointer<vtkSegment> > SegmentsMap;
 
   struct SegmentationState


### PR DESCRIPTION
Due to changes in the way vtkSegment::DeepCopy is performed, it is no longer suitable for preserving shared labelmap layers when copying entire segmentations.
This commit fixes the behavior of vtkSegmentation::DeepCopy by utilizing vtkSegmentation::CopySegment (migrated from vtkSegmentationHistory).