### PR TITLE
Update ITK 5.1rc01 and SimpleITK

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -265,8 +265,8 @@ set(BRAINSTools_options
   )
 
 Slicer_Remote_Add(BRAINSTools
-  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/BRAINSIA/BRAINSTools.git
-  GIT_TAG d0e6c01c712e73f47b7e99c3194514a888a1b4a7 # post ITK 5.0.1
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/Slicer/BRAINSTools.git
+  GIT_TAG f8e5ed125623fea783e3adedcedffb1f114f619a # slicer-2020-01-08-d0e6c01
   LICENSE_FILES "http://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ff48670261e3bd16ee1c6f5494834f65183a98dd" # pre-v5.1b01 (2019-08-26)
+    "v5.1rc01"
     QUIET
     )
 

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -35,13 +35,13 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/Slicer/SimpleITK.git"
+    "${EP_GIT_PROTOCOL}://github.com/SimpleITK/SimpleITK.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "3ad12467ba44d2f831305ef645ae181a381e60ab" # slicer-v1.2.0-2019-08-16-3ad12467
+    "16a62269c25fef83b739f8ae8640cf796a6f44f1"  # pre-v2.0 (ITK 5 as default)
     QUIET
     )
 


### PR DESCRIPTION
This PR updates ITK to 5.1rc01 and updates SimpleITK so that it is compatible with ITK 5.1rc01.  Building of SimpleITK is also now using the upstream repo as I noticed the previous used git hash in the Slicer fork had no additional changes so instead of creating a new branch that is a mirror up to a certain hash I'm just specifying the upstream repo.

I have had a successful build on Windows 10 and with only seemingly already failing tests continuing to fail.
![ITK-5 1rc01-update](https://user-images.githubusercontent.com/15837524/71524588-35bfe880-289c-11ea-9476-1e6c40acba0f.PNG)
