### PR TITLE
BUG: Fix setModuleHelpSectionVisible always setting false

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2215,7 +2215,7 @@ def setApplicationLogoVisible(visible):
 def setModuleHelpSectionVisible(visible):
   """Show/hide Help section at the top of module panel."""
   modulePanel = findChild(mainWindow(), "ModulePanel")
-  modulePanel.helpAndAcknowledgmentVisible=False
+  modulePanel.helpAndAcknowledgmentVisible = visible
 
 def setDataProbeVisible(visible):
   """Show/hide Data probe at the bottom of module panel."""


### PR DESCRIPTION
@lassoan This fixes a minor bug that was included when `setModuleHelpSectionVisible` was originally introduced as part of https://github.com/Slicer/Slicer/commit/21dc780a216f077bdd080fdc64073ccf6b5356e0.