### PR TITLE
ENH: Add vtkITKLabelShapeStatistics for binary labelmap statistics

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableNode.cxx
@@ -40,8 +40,9 @@
 #include <vtksys/SystemTools.hxx>
 
 // STD includes
-#include <sstream>
 #include <deque>
+#include <sstream>
+#include <string>
 
 // Reserved property names
 static const char SCHEMA_COLUMN_NAME[] = "columnName";

--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.h
@@ -26,6 +26,7 @@
 #include "vtkMRMLStorageNode.h"
 
 class vtkMRMLTableNode;
+class vtkTable;
 
 /// \brief MRML node for handling Table node storage
 ///
@@ -89,6 +90,28 @@ protected:
   std::string GenerateSchemaFileName(const char* fileName);
 
   virtual std::string GetFieldDelimiterCharacters(std::string filename);
+
+  // Struct for managing column information
+  typedef struct
+  {
+    std::string ColumnName;
+    std::vector<vtkAbstractArray*> RawComponentArrays;
+    int ScalarType = VTK_STRING;
+    std::vector<std::string> ComponentNames;
+    std::string NullValueString;
+  } ColumnInfo;
+
+  /// Determines information about the columns in the table, including column name,
+  /// The raw components that should be includeded in the table, the scalar type,
+  /// and the names of the components.
+  std::vector<ColumnInfo> GetColumnInfo(vtkMRMLTableNode* tableNode, vtkTable* rawTable);
+
+  /// Casts the data in the string array to the correct type and stores it in the data array
+  void FillDataFromStringArray(vtkStringArray* stringComponentArray, vtkDataArray* dataArray, std::string nullValueString="");
+
+  /// Adds the column specified by the given columnInfo to the table.
+  /// Handles both single and multi-component columns
+  void AddColumnToTable(vtkTable* table, ColumnInfo columnInfo);
 
   bool ReadSchema(std::string filename, vtkMRMLTableNode* tableNode);
   bool ReadTable(std::string filename, vtkMRMLTableNode* tableNode);

--- a/Libs/vtkITK/CMakeLists.txt
+++ b/Libs/vtkITK/CMakeLists.txt
@@ -105,6 +105,7 @@ set(vtkITK_SRCS
   vtkITKImageToImageFilterSS.h
   vtkITKGradientAnisotropicDiffusionImageFilter.cxx
   vtkITKDistanceTransform.cxx
+  vtkITKLabelShapeStatistics.cxx
   vtkITKLevelTracingImageFilter.cxx
   vtkITKLevelTracing3DImageFilter.cxx
   vtkITKWandImageFilter.cxx

--- a/Libs/vtkITK/vtkITKLabelShapeStatistics.cxx
+++ b/Libs/vtkITK/vtkITKLabelShapeStatistics.cxx
@@ -1,0 +1,393 @@
+/*=========================================================================
+
+  Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Program:   vtkITK
+  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKLabelShapeStatistics.cxx $
+  Date:      $Date: 2006-12-21 07:21:52 -0500 (Thu, 21 Dec 2006) $
+  Version:   $Revision: 1900 $
+
+==========================================================================*/
+
+#include "vtkITKLabelShapeStatistics.h"
+
+// VTK includes
+#include <vtkDataArray.h>
+#include <vtkDoubleArray.h>
+#include <vtkImageData.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
+#include <vtkLongArray.h>
+#include <vtkObjectFactory.h>
+#include <vtkPoints.h>
+#include <vtkPointData.h>
+
+// ITK includes
+#include <itkLabelImageToShapeLabelMapFilter.h>
+#include <itkShapeLabelObject.h>
+#include <itkVTKImageToImageFilter.h>
+
+vtkStandardNewMacro(vtkITKLabelShapeStatistics);
+
+//----------------------------------------------------------------------------
+vtkITKLabelShapeStatistics::vtkITKLabelShapeStatistics()
+{
+  this->Directions = nullptr;
+
+  this->ComputedStatistics.push_back(this->GetShapeStatisticAsString(Centroid));
+  this->ComputedStatistics.push_back(this->GetShapeStatisticAsString(Flatness));
+}
+
+//----------------------------------------------------------------------------
+vtkITKLabelShapeStatistics::~vtkITKLabelShapeStatistics()
+{
+  this->SetDirections(nullptr);
+}
+
+//----------------------------------------------------------------------------
+void vtkITKLabelShapeStatistics::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os,indent);
+}
+
+//----------------------------------------------------------------------------
+int vtkITKLabelShapeStatistics::FillInputPortInformation(
+  int vtkNotUsed(port), vtkInformation* info)
+{
+  info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkImageData");
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkITKLabelShapeStatistics::GetShapeStatisticAsString(ShapeStatistic statistic)
+{
+  switch (statistic)
+    {
+    case Centroid:
+      return "Centroid";
+    case OrientedBoundingBox:
+      return "OrientedBoundingBox";
+    case FeretDiameter:
+      return "FeretDiameter";
+    case Perimeter:
+      return "Perimeter";
+    case Roundness:
+      return "Roundness";
+    case Flatness:
+      return "Flatness";
+    default:
+      vtkErrorWithObjectMacro(nullptr, "GetShapeStatisticFromString: Cannot determine string for statistic: " << statistic);
+      return "";
+    }
+}
+
+//----------------------------------------------------------------------------
+vtkITKLabelShapeStatistics::ShapeStatistic vtkITKLabelShapeStatistics::GetShapeStatisticFromString(std::string statisticName)
+{
+  for (int i = 0; i < ShapeStatistic_Last; ++i)
+    {
+    ShapeStatistic statistic = static_cast<ShapeStatistic>(i);
+    if (statisticName == vtkITKLabelShapeStatistics::GetShapeStatisticAsString(statistic))
+      {
+      return statistic;
+      }
+    }
+  vtkErrorWithObjectMacro(nullptr, "GetShapeStatisticFromString: Cannot determine statistic from string: " << statisticName);
+  return ShapeStatistic_Last;
+}
+
+//----------------------------------------------------------------------------
+void vtkITKLabelShapeStatistics::ComputeShapeStatisticOn(std::string statisticName)
+{
+  this->SetComputeShapeStatistic(statisticName, true);
+}
+
+//----------------------------------------------------------------------------
+void vtkITKLabelShapeStatistics::ComputeShapeStatisticOff(std::string statisticName)
+{
+  this->SetComputeShapeStatistic(statisticName, false);
+}
+
+//----------------------------------------------------------------------------
+void vtkITKLabelShapeStatistics::SetComputeShapeStatistic(std::string statisticName, bool state)
+{
+  std::vector<std::string>::iterator statIt = std::find(this->ComputedStatistics.begin(), this->ComputedStatistics.end(), statisticName);
+  if (!state)
+    {
+    if (statIt != this->ComputedStatistics.end())
+      {
+      this->ComputedStatistics.erase(statIt);
+      }
+    }
+  else
+    {
+    if (statIt == this->ComputedStatistics.end())
+      {
+      this->ComputedStatistics.push_back(statisticName);
+      }
+    }
+}
+
+//----------------------------------------------------------------------------
+bool vtkITKLabelShapeStatistics::GetComputeShapeStatistic(std::string statisticName)
+{
+  std::vector<std::string>::iterator statIt = std::find(this->ComputedStatistics.begin(), this->ComputedStatistics.end(), statisticName);
+  if (statIt != this->ComputedStatistics.end())
+    {
+    return true;
+    }
+  return false;
+}
+
+//----------------------------------------------------------------------------
+// Note: local function not method - conforms to signature in itkCommand.h
+void vtkITKLabelShapeStatisticsHandleProgressEvent (itk::Object *caller,
+                                          const itk::EventObject& vtkNotUsed(eventObject),
+                                          void *clientdata)
+{
+  itk::ProcessObject *itkFilter = dynamic_cast<itk::ProcessObject*>(caller);
+  vtkAlgorithm *vtkFilter = reinterpret_cast<vtkAlgorithm*>(clientdata);
+  if ( itkFilter && vtkFilter )
+    {
+    vtkFilter->UpdateProgress ( itkFilter->GetProgress() );
+    }
+};
+
+//----------------------------------------------------------------------------
+template <class T>
+T* GetArray(vtkTable* table, std::string name, int numberOfComponents, std::vector<std::string>* componentNames = nullptr)
+{
+  vtkSmartPointer<T> array = T::SafeDownCast(table->GetColumnByName(name.c_str()));
+  if (!array)
+    {
+    array = vtkSmartPointer<T>::New();
+    array->SetName(name.c_str());
+    array->SetNumberOfComponents(numberOfComponents);
+    array->SetNumberOfTuples(table->GetNumberOfRows());
+    table->AddColumn(array);
+    int componentIndex = 0;
+    if (componentNames)
+      {
+      if (numberOfComponents != componentNames->size())
+        {
+        vtkErrorWithObjectMacro(nullptr, "vtkITKLAbelSHapeStatistics: GetArray - Number of components and component names do not match!");
+        }
+      else
+        {
+        for (std::string componentName : *componentNames)
+          {
+          array->SetComponentName(componentIndex, componentName.c_str());
+          }
+        }
+      }
+    }
+  return array.GetPointer();
+}
+
+//----------------------------------------------------------------------------
+template <class T>
+void vtkITKLabelShapeStatisticsExecute(vtkITKLabelShapeStatistics* self, vtkImageData* input, vtkTable* output,
+  vtkMatrix4x4* directionMatrix, T* vtkNotUsed(inPtr))
+{
+  if (!self || !input || !output)
+    {
+    return;
+    }
+
+  // Clear current results
+  output->Initialize();
+
+  // Wrap VTK image into an ITK image
+  using ImageType = itk::Image<T, 3> ;
+  using VTKToITKFilterType = itk::VTKImageToImageFilter<ImageType>;
+  typename VTKToITKFilterType::Pointer vtkToITKFilter = VTKToITKFilterType::New();
+  vtkToITKFilter->SetInput(input);
+  vtkToITKFilter->Update();
+  ImageType* inImage = vtkToITKFilter->GetOutput();
+
+  // TODO: When vtkImageData is updated to include direction, this should be updated
+  if (directionMatrix)
+    {
+    typename ImageType::DirectionType gridDirectionMatrix;
+    for (unsigned int row = 0; row < 3; row++)
+      {
+      for (unsigned int column = 0; column < 3; column++)
+        {
+        gridDirectionMatrix(row, column) = directionMatrix->GetElement(row, column);
+        }
+      }
+    inImage->SetDirection(gridDirectionMatrix);
+    }
+
+  // Set up the progress callback
+  itk::CStyleCommand::Pointer progressCommand = itk::CStyleCommand::New();
+  progressCommand->SetClientData(static_cast<void*>(self));
+  progressCommand->SetCallback(vtkITKLabelShapeStatisticsHandleProgressEvent);
+
+  using ShapeLabelObjectType = itk::ShapeLabelObject<T, 3>;
+  using LabelMapType = itk::LabelMap<ShapeLabelObjectType>;
+  using LableShapeFilterType = itk::LabelImageToShapeLabelMapFilter<ImageType, LabelMapType>;
+
+  bool computeFeretDiameter = self->GetComputeShapeStatistic(self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::ShapeStatistic::FeretDiameter));
+  bool computePerimeter = self->GetComputeShapeStatistic(self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::ShapeStatistic::Perimeter)) ||
+    self->GetComputeShapeStatistic(self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::ShapeStatistic::Roundness));
+  bool computeOrientedBoundingBox =
+  self->GetComputeShapeStatistic(self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::ShapeStatistic::OrientedBoundingBox));
+
+  typename LableShapeFilterType::Pointer labelFilter = LableShapeFilterType::New();
+  labelFilter->AddObserver(itk::ProgressEvent(), progressCommand);
+  labelFilter->SetInput(inImage);
+  labelFilter->SetComputeFeretDiameter(computeFeretDiameter);
+  labelFilter->SetComputePerimeter(computePerimeter);
+  labelFilter->SetComputeOrientedBoundingBox(computeOrientedBoundingBox);
+  labelFilter->Update();
+
+  typename LabelMapType::Pointer labelmapObject = labelFilter->GetOutput();
+  const std::vector<typename ShapeLabelObjectType::LabelType> labelValues = labelmapObject->GetLabels();
+
+  // Number of rows in the table is equal to the number of label values
+  output->SetNumberOfRows(labelValues.size());
+
+  int rowIndex = -1;
+  for (unsigned int i = 0; i < labelValues.size(); ++i)
+    {
+    rowIndex++;
+    int labelValue = labelValues[i];
+
+    typename ShapeLabelObjectType::ShapeLabelObject::Pointer shapeObject = labelmapObject->GetLabelObject(labelValue);
+    if (!shapeObject)
+      {
+      continue;
+      }
+
+    vtkLongArray* array = GetArray<vtkLongArray>(output, "LabelValue", 1);
+    array->InsertTuple1(rowIndex, labelValue);
+
+    for (std::string statisticName : self->GetComputedStatistics())
+      {
+      if (statisticName == self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::Centroid))
+        {
+        typename ShapeLabelObjectType::CentroidType centroidObject = shapeObject->GetCentroid();
+        vtkDoubleArray* array = GetArray<vtkDoubleArray>(output, statisticName, 3);
+        array->InsertTuple3(rowIndex, centroidObject[0], centroidObject[1], centroidObject[2]);
+        }
+      else if (statisticName == self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::Roundness))
+        {
+        double roundness = shapeObject->GetRoundness();
+        vtkDoubleArray* array = GetArray<vtkDoubleArray>(output, statisticName, 1);
+        array->InsertTuple1(rowIndex, roundness);
+        }
+      else if (statisticName == self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::Flatness))
+        {
+        double flatness = shapeObject->GetFlatness();
+        vtkDoubleArray* array = GetArray<vtkDoubleArray>(output, statisticName, 1);
+        array->InsertTuple1(rowIndex, flatness);
+        }
+      else if (statisticName == self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::FeretDiameter))
+        {
+        double feretDiameter = shapeObject->GetFeretDiameter();
+        vtkDoubleArray* array = GetArray<vtkDoubleArray>(output, statisticName, 1);
+        array->InsertTuple1(rowIndex, feretDiameter);
+        }
+      else if (statisticName == self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::Perimeter))
+        {
+        double perimeter = shapeObject->GetPerimeter();
+        vtkDoubleArray* array = GetArray<vtkDoubleArray>(output, statisticName, 1);
+        array->InsertTuple1(rowIndex, perimeter);
+        }
+      else if (statisticName == self->GetShapeStatisticAsString(vtkITKLabelShapeStatistics::OrientedBoundingBox))
+        {
+        typename ShapeLabelObjectType::OrientedBoundingBoxPointType boundingBoxOrigin = shapeObject->GetOrientedBoundingBoxOrigin();
+        vtkDoubleArray* obbOriginArray = GetArray<vtkDoubleArray>(output, "OrientedBoundingBoxOrigin", 3);
+        obbOriginArray->InsertTuple3(rowIndex, boundingBoxOrigin[0], boundingBoxOrigin[1], boundingBoxOrigin[2]);
+
+        typename ShapeLabelObjectType::OrientedBoundingBoxPointType boundingBoxSize = shapeObject->GetOrientedBoundingBoxSize();
+        std::vector<std::string> componentNames = { "x", "y", "z" };
+        vtkDoubleArray* obbSizeArray = GetArray<vtkDoubleArray>(output, "OrientedBoundingBoxSize", 3, &componentNames);
+        obbSizeArray->InsertTuple3(rowIndex, boundingBoxSize[0], boundingBoxSize[1], boundingBoxSize[2]);
+
+        typename ShapeLabelObjectType::OrientedBoundingBoxDirectionType boundingBoxDirections = shapeObject->GetOrientedBoundingBoxDirection();
+        vtkDoubleArray* obbDirectionXArray = GetArray<vtkDoubleArray>(output, "OrientedBoundingBoxDirectionX", 3);
+        obbDirectionXArray->InsertTuple3(rowIndex, boundingBoxDirections(0, 0), boundingBoxDirections(0, 1), boundingBoxDirections(0, 2));
+        vtkDoubleArray* obbDirectionYArray = GetArray<vtkDoubleArray>(output, "OrientedBoundingBoxDirectionY", 3);
+        obbDirectionYArray->InsertTuple3(rowIndex, boundingBoxDirections(1, 0), boundingBoxDirections(1, 1), boundingBoxDirections(1, 2));
+        vtkDoubleArray* obbDirectionZArray = GetArray<vtkDoubleArray>(output, "OrientedBoundingBoxDirectionZ", 3);
+        obbDirectionZArray->InsertTuple3(rowIndex, boundingBoxDirections(2, 0), boundingBoxDirections(2, 1), boundingBoxDirections(2, 2));
+        }
+      }
+    }
+}
+
+//----------------------------------------------------------------------------
+// This is the superclasses style of Execute method.  Convert it into
+// an imaging style Execute method.
+int vtkITKLabelShapeStatistics::RequestData(
+  vtkInformation* vtkNotUsed(request),
+  vtkInformationVector** inputVector,
+  vtkInformationVector* outputVector)
+{
+  // get the data object
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+  vtkTable* output = vtkTable::SafeDownCast(
+    outInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  vtkInformation* inInfo = inputVector[0]->GetInformationObject(0);
+  vtkImageData* input = vtkImageData::SafeDownCast(
+    inInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  vtkDebugMacro(<< "Executing label shape statistics");
+
+  //
+  // Initialize and check input
+  //
+  vtkPointData *pd = input->GetPointData();
+  if (pd ==nullptr)
+    {
+    vtkErrorMacro(<<"PointData is NULL");
+    return 0;
+    }
+  vtkDataArray *inScalars=pd->GetScalars();
+  if ( inScalars == nullptr )
+    {
+    vtkErrorMacro(<<"Scalars must be defined for island math");
+    return 0;
+    }
+
+  if (inScalars->GetNumberOfComponents() == 1 )
+    {
+
+////////// These types are not defined in itk ////////////
+#undef VTK_TYPE_USE_LONG_LONG
+#undef VTK_TYPE_USE___INT64
+
+#define CALL  vtkITKLabelShapeStatisticsExecute(this, input, output, this->Directions, static_cast<VTK_TT *>(inPtr));
+
+    void* inPtr = input->GetScalarPointer();
+    switch (inScalars->GetDataType())
+      {
+      vtkTemplateMacroCase(VTK_LONG, long, CALL);                               \
+      vtkTemplateMacroCase(VTK_UNSIGNED_LONG, unsigned long, CALL);             \
+      vtkTemplateMacroCase(VTK_INT, int, CALL);                                 \
+      vtkTemplateMacroCase(VTK_UNSIGNED_INT, unsigned int, CALL);               \
+      vtkTemplateMacroCase(VTK_SHORT, short, CALL);                             \
+      vtkTemplateMacroCase(VTK_UNSIGNED_SHORT, unsigned short, CALL);           \
+      vtkTemplateMacroCase(VTK_CHAR, char, CALL);                               \
+      vtkTemplateMacroCase(VTK_SIGNED_CHAR, signed char, CALL);                 \
+      vtkTemplateMacroCase(VTK_UNSIGNED_CHAR, unsigned char, CALL);             \
+      default:
+        {
+        vtkErrorMacro(<< "Incompatible data type for this version of ITK.");
+        return 0;
+        }
+      } //switch
+    }
+  else
+    {
+    vtkErrorMacro(<< "Only single component images supported.");
+    return 0;
+    }
+  return 1;
+}

--- a/Libs/vtkITK/vtkITKLabelShapeStatistics.h
+++ b/Libs/vtkITK/vtkITKLabelShapeStatistics.h
@@ -1,0 +1,85 @@
+/*=========================================================================
+
+  Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+==========================================================================*/
+
+#ifndef __vtkITKLabelShapeStatistics_h
+#define __vtkITKLabelShapeStatistics_h
+
+#include "vtkITK.h"
+
+// VTK includes
+#include <vtkMatrix4x4.h>
+#include <vtkSmartPointer.h>
+#include <vtkTable.h>
+#include <vtkTableAlgorithm.h>
+#include <vtkVector.h>
+
+// std includes
+#include <vector>
+
+class vtkPoints;
+
+/// \brief ITK-based utilities for calculating label statistics.
+/// Utilizes itk::LabelImageToShapeLabelMapFilter to calcualte label shape statistics
+/// (https://itk.org/Doxygen/html/classitk_1_1LabelImageToShapeLabelMapFilter.html)
+/// Label centroid and flatness are the only statistics calculated by default.
+/// Other availiable statistics are: Oriented bounding box (origin, size, direction), feret diameter, perimeter, roundness.
+/// Calculated statistics can be changed using the SetComputeShapeStatistic/ComputeShapeStatisticOn/ComputeShapeStatisticOff methods.
+/// Output statistics are represented in a vtkTable where each column represents a statistic and each row is a different label value.
+class VTK_ITK_EXPORT vtkITKLabelShapeStatistics : public vtkTableAlgorithm
+{
+public:
+  static vtkITKLabelShapeStatistics *New();
+  vtkTypeMacro(vtkITKLabelShapeStatistics, vtkTableAlgorithm);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  enum ShapeStatistic
+  {
+    Centroid,
+    OrientedBoundingBox,
+    FeretDiameter,
+    Perimeter,
+    Roundness,
+    Flatness,
+    ShapeStatistic_Last,
+  };
+
+  static std::string GetShapeStatisticAsString(ShapeStatistic statistic);
+  static ShapeStatistic GetShapeStatisticFromString(std::string statisticName);
+
+  vtkSetObjectMacro(Directions, vtkMatrix4x4);
+  vtkSetMacro(ComputedStatistics, std::vector<std::string>);
+  vtkGetMacro(ComputedStatistics, std::vector<std::string>);
+
+  /// Set/Get if the the specified statistic should be computed.
+  /// Label centroid and flatness are computed by default.
+  /// Other statistics are listed in the ShapeStatistic enum.
+  void SetComputeShapeStatistic(std::string statisticName, bool state);
+  bool GetComputeShapeStatistic(std::string statisticName);
+  void ComputeShapeStatisticOn(std::string statisticName);
+  void ComputeShapeStatisticOff(std::string statisticName);
+
+protected:
+  vtkITKLabelShapeStatistics();
+  ~vtkITKLabelShapeStatistics() override;
+
+  int FillInputPortInformation(int vtkNotUsed(port), vtkInformation* info) override;
+  virtual int RequestData(vtkInformation* request,
+    vtkInformationVector** inputVector,
+    vtkInformationVector* outputVector) override;
+
+protected:
+  std::vector<std::string> ComputedStatistics;
+  vtkMatrix4x4* Directions;
+
+private:
+  vtkITKLabelShapeStatistics(const vtkITKLabelShapeStatistics&) = delete;
+  void operator=(const vtkITKLabelShapeStatistics&) = delete;
+};
+
+#endif

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/LabelmapSegmentStatisticsPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/LabelmapSegmentStatisticsPlugin.py
@@ -1,5 +1,6 @@
 import vtk
 import slicer
+import vtkITK
 from SegmentStatisticsPlugins import SegmentStatisticsPluginBase
 from functools import reduce
 
@@ -9,8 +10,26 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
   def __init__(self):
     super(LabelmapSegmentStatisticsPlugin,self).__init__()
     self.name = "Labelmap"
-    self.keys = ["voxel_count", "volume_mm3", "volume_cm3"]
-    self.defaultKeys = self.keys # calculate all measurements by default
+    self.obbKeys = ["obb_origin_ras", "obb_diameter_mm", "obb_direction_ras_x", "obb_direction_ras_y", "obb_direction_ras_z"]
+    self.shapeKeys = [
+      "centroid_ras", "feret_diameter_mm", "surface_area_mm2", "roundness", "flatness",
+      ] + self.obbKeys
+
+    self.defaultKeys = ["voxel_count", "volume_mm3", "volume_cm3"] # Don't calculate label shape statistics by default since they take longer to compute
+    self.keys = self.defaultKeys + self.shapeKeys
+    self.keyToShapeStatisticNames = {
+      "centroid_ras" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.Centroid),
+      "feret_diameter_mm": vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.FeretDiameter),
+      "surface_area_mm2" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.Perimeter),
+      "roundness" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.Roundness),
+      "flatness" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.Flatness),
+      "oriented_bounding_box" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.OrientedBoundingBox),
+      "obb_origin_ras" : "OrientedBoundingBoxOrigin",
+      "obb_diameter_mm" : "OrientedBoundingBoxSize",
+      "obb_direction_ras_x" : "OrientedBoundingBoxDirectionX",
+      "obb_direction_ras_y" : "OrientedBoundingBoxDirectionY",
+      "obb_direction_ras_z" : "OrientedBoundingBoxDirectionZ",
+      }
     #... developer may add extra options to configure other parameters
 
   def computeStatistics(self, segmentID):
@@ -67,6 +86,118 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
       stats["volume_mm3"] = stat.GetVoxelCount() * cubicMMPerVoxel
     if "volume_cm3" in requestedKeys:
       stats["volume_cm3"] = stat.GetVoxelCount() * cubicMMPerVoxel * ccPerCubicMM
+
+    calculateShapeStats = False
+    for shapeKey in self.shapeKeys:
+      if shapeKey in requestedKeys:
+        calculateShapeStats = True
+        break
+
+    if calculateShapeStats:
+      directions = vtk.vtkMatrix4x4()
+      segmentLabelmap.GetDirectionMatrix(directions)
+
+      # Remove oriented bounding box from requested keys and replace with individual keys
+      requestedOptions = requestedKeys
+      statFilterOptions = self.shapeKeys
+      calculateOBB = (
+        "obb_diameter_mm" in requestedKeys or
+        "obb_origin_ras" in requestedKeys or
+        "obb_direction_ras_x" in requestedKeys or
+        "obb_direction_ras_y" in requestedKeys or
+        "obb_direction_ras_z" in requestedKeys
+        )
+
+      if calculateOBB:
+        temp = statFilterOptions
+        statFilterOptions = []
+        for option in temp:
+          if not option in self.obbKeys:
+            statFilterOptions.append(option)
+        statFilterOptions.append("oriented_bounding_box")
+
+        temp = requestedOptions
+        requestedOptions = []
+        for option in temp:
+          if not option in self.obbKeys:
+            requestedOptions.append(option)
+        requestedOptions.append("oriented_bounding_box")
+
+      shapeStat = vtkITK.vtkITKLabelShapeStatistics()
+      shapeStat.SetInputData(thresh.GetOutput())
+      shapeStat.SetDirections(directions)
+      for shapeKey in statFilterOptions:
+        shapeStat.SetComputeShapeStatistic(self.keyToShapeStatisticNames[shapeKey], shapeKey in requestedOptions)
+      shapeStat.Update()
+
+      # If segmentation node is transformed, apply that transform to get RAS coordinates
+      transformSegmentToRas = vtk.vtkGeneralTransform()
+      slicer.vtkMRMLTransformNode.GetTransformBetweenNodes(segmentationNode.GetParentTransformNode(), None, transformSegmentToRas)
+
+      statTable = shapeStat.GetOutput()
+      if "centroid_ras" in requestedKeys:
+        centroidRAS = [0,0,0]
+        centroidArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["centroid_ras"])
+        centroid = centroidArray.GetTuple(0)
+        transformSegmentToRas.TransformPoint(centroid, centroidRAS)
+        stats["centroid_ras"] = centroidRAS
+
+      if "roundness" in requestedKeys:
+        roundnessArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["roundness"])
+        roundness = roundnessArray.GetTuple(0)[0]
+        stats["roundness"] = roundness
+
+      if "flatness" in requestedKeys:
+        flatnessArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["flatness"])
+        flatness = flatnessArray.GetTuple(0)[0]
+        stats["flatness"] = flatness
+
+      if "feret_diameter_mm" in requestedKeys:
+        feretDiameterArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["feret_diameter_mm"])
+        feretDiameter = feretDiameterArray.GetTuple(0)[0]
+        stats["feret_diameter_mm"] = feretDiameter
+
+      if "surface_area_mm2" in requestedKeys:
+        perimeterArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["surface_area_mm2"])
+        perimeter = perimeterArray.GetTuple(0)[0]
+        stats["surface_area_mm2"] = perimeter
+
+      if "obb_origin_ras" in requestedKeys:
+        obbOriginRAS = [0,0,0]
+        obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
+        obbOrigin = obbOriginArray.GetTuple(0)
+        transformSegmentToRas.TransformPoint(obbOrigin, obbOriginRAS)
+        stats["obb_origin_ras"] = obbOriginRAS
+
+      if "obb_diameter_mm" in requestedKeys:
+        obbDiameterArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_diameter_mm"])
+        obbDiameterMM = list(obbDiameterArray.GetTuple(0))
+        stats["obb_diameter_mm"] = obbDiameterMM
+
+      if "obb_direction_ras_x" in requestedKeys:
+        obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
+        obbOrigin = obbOriginArray.GetTuple(0)
+        obbDirectionXArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_direction_ras_x"])
+        obbDirectionX = list(obbDirectionXArray.GetTuple(0))
+        transformSegmentToRas.TransformVectorAtPoint(obbOrigin, obbDirectionX, obbDirectionX)
+        stats["obb_direction_ras_x"] = obbDirectionX
+
+      if "obb_direction_ras_y" in requestedKeys:
+        obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
+        obbOrigin = obbOriginArray.GetTuple(0)
+        obbDirectionYArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_direction_ras_y"])
+        obbDirectionY = list(obbDirectionYArray.GetTuple(0))
+        transformSegmentToRas.TransformVectorAtPoint(obbOrigin, obbDirectionY, obbDirectionY)
+        stats["obb_direction_ras_y"] = obbDirectionY
+
+      if "obb_direction_ras_z" in requestedKeys:
+        obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
+        obbOrigin = obbOriginArray.GetTuple(0)
+        obbDirectionZArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_direction_ras_z"])
+        obbDirectionZ = list(obbDirectionZArray.GetTuple(0))
+        transformSegmentToRas.TransformVectorAtPoint(obbOrigin, obbDirectionZ, obbDirectionZ)
+        stats["obb_direction_ras_z"] = obbDirectionZ
+
     return stats
 
   def getMeasurementInfo(self, key):
@@ -93,5 +224,40 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
                                    unitsDicomCode=self.createCodedEntry("cm3", "UCUM", "cubic centimeter", True),
                                    measurementMethodDicomCode=self.createCodedEntry("126030", "DCM",
                                                                              "Sum of segmented voxel volumes", True))
+
+    info["centroid_ras"] = \
+      self.createMeasurementInfo(name="Centroid (RAS)", description="Location of the centroid in RAS", units="", componentNames=["r", "a", "s"])
+
+    info["feret_diameter_mm"] = \
+      self.createMeasurementInfo(name="Feret Diameter mm", description="Feret diameter in mm", units="mm")
+
+    info["surface_area_mm2"] = \
+      self.createMeasurementInfo(name="Surface mm2", description="Surface area in mm2", units="mm2",
+                                   quantityDicomCode=self.createCodedEntry("000247", "99CHEMINF", "Surface area", True),
+                                   unitsDicomCode=self.createCodedEntry("mm2", "UCUM", "squared millimeters", True))
+
+    info["roundness"] = \
+      self.createMeasurementInfo(name="Roundness", description="Roundness", units="")
+
+    info["flatness"] = \
+      self.createMeasurementInfo(name="Flatness", description="Flatness", units="")
+
+    info["oriented_bounding_box"] = \
+      self.createMeasurementInfo(name="Oriented bounding box", description="Oriented bounding box", units="")
+
+    info["obb_origin_ras"] = \
+      self.createMeasurementInfo(name="OBB origin (RAS)", description="Oriented bounding box origin", units="", componentNames=["r", "a", "s"])
+
+    info["obb_diameter_mm"] = \
+      self.createMeasurementInfo(name="OBB diameter", description="Oriented bounding box diameter", units="mm", componentNames=["x", "y", "z"])
+
+    info["obb_direction_ras_x"] = \
+      self.createMeasurementInfo(name="OBB X direction (RAS)", description="Oriented bounding box X direction", units="", componentNames=["r", "a", "s"])
+
+    info["obb_direction_ras_y"] = \
+      self.createMeasurementInfo(name="OBB Y direction (RAS)", description="Oriented bounding box Y direction", units="", componentNames=["r", "a", "s"])
+
+    info["obb_direction_ras_z"] = \
+      self.createMeasurementInfo(name="OBB Z direction (RAS)", description="Oriented bounding box Z direction", units="", componentNames=["r", "a", "s"])
 
     return info[key] if key in info else None

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/SegmentStatisticsPluginBase.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/SegmentStatisticsPluginBase.py
@@ -17,13 +17,15 @@ class SegmentStatisticsPluginBase(object):
 
   @staticmethod
   def createMeasurementInfo(name, description, units, quantityDicomCode=None, unitsDicomCode=None,
-                            measurementMethodDicomCode=None, derivationDicomCode=None):
+                            measurementMethodDicomCode=None, derivationDicomCode=None, componentNames=None):
     """Utility method to create measurement information"""
     info = {
       "name": name,
       "description": description,
       "units": units
       }
+    if componentNames:
+      info["componentNames"] = componentNames
     if quantityDicomCode:
       info["DICOM.QuantityCode"] = quantityDicomCode
     if unitsDicomCode:
@@ -50,7 +52,7 @@ class SegmentStatisticsPluginBase(object):
       self.parameterNode.RemoveObserver(self.parameterNodeObserver)
 
   def computeStatistics(self, segmentID):
-    """Compute measurements for requested keys on the given segment and return 
+    """Compute measurements for requested keys on the given segment and return
     as dictionary mapping key's to measurement results
     """
     pass
@@ -82,12 +84,12 @@ class SegmentStatisticsPluginBase(object):
       return ()
     requestedKeys = [key for key in self.keys if self.parameterNode.GetParameter(self.toLongKey(key)+'.enabled')=='True']
     return requestedKeys
-  
+
   def toLongKey(self, key):
     # add name of plugin as a prefix for use outside of plugin
     pluginName = self.__class__.__name__
     return pluginName+'.'+key
-  
+
   def toShortKey(self, key):
     # remove prefix used outside of plugin
     pluginName = self.__class__.__name__


### PR DESCRIPTION
This commit adds the new vtkITKLabelShapeStatistics class to vtkITK that calculates various statics on binary labelmaps.
Additional statisics provided by the filter have been added to the LabelmapSegmentStatisticsPlugin as optional, non-default statistics.

Current statistics provided by vtkITKLabelShapeStatistics are:
- Centroid coordinates
- Feret diameter
- Perimeter
- Roundness
- Flatness
- Oriented bounding box