### PR TITLE
BUG: Fix handling of legacy node reference attributes in scene files

### DIFF
--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -38,6 +38,7 @@ class vtkCallbackCommand;
 
 // STD includes
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -896,7 +897,7 @@ protected:
 
   /// Parse references in the form "role1:id1 id2;role2:id3;"
   /// map contains existing role-id pairs, so we don't repeat them
-  void ParseReferencesAttribute(const char *attValue, std::map<std::string, std::string> &references);
+  void ParseReferencesAttribute(const char *attValue, std::set<std::string> &references);
 
   /// Holders for MRML callbacks
   vtkCallbackCommand *MRMLCallbackCommand;


### PR DESCRIPTION
Previously, if both legacy and current node reference attributes existed with the XML tag for a MRMLNode, both reference IDs would be added to the node.
This commit removes the writing of the legacy node reference attributes to the XML tag, and ensures that for scenes that contain both types of attributes, the legacy format is ignored if the same node reference is found in the "references" attribute.