### PR TITLE
ENH: Use TBB for threading in ITK

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -9,6 +9,9 @@ endif()
 if(Slicer_BUILD_ITKPython)
   list(APPEND ${proj}_DEPENDENCIES Swig python)
 endif()
+if(Slicer_USE_TBB)
+  list(APPEND ${proj}_DEPENDENCIES tbb)
+endif()
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
@@ -38,6 +41,13 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     )
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+
+  if(Slicer_USE_TBB)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DModule_ITKTBB:BOOL=ON
+      -DTBB_DIR:PATH=${TBB_INSTALL_DIR}/cmake
+      )
+  endif()
 
   if(Slicer_USE_PYTHONQT OR Slicer_BUILD_ITKPython)
     # XXX Ensure python executable used for ITKModuleHeaderTest
@@ -87,7 +97,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
 
   #Add additional user specified modules from this variable
-  #Slicer_ITK_ADDITIONAL_MOUDLES
+  #Slicer_ITK_ADDITIONAL_MODULES
   #Add -DModule_${module} for each listed module
   #Names in list must match the expected module names in the ITK build system
   if(DEFINED Slicer_ITK_ADDITIONAL_MODULES)


### PR DESCRIPTION
TBB offers better load balancing for unevenly complex work distribution and plays better with non-ITK load on the CPU.

As a side effect, it also improves granularity of filter progress reporting (https://discourse.slicer.org/t/bilateral-filter-not-working/9797/13).

Let's NOT INTEGRATE this until a Windows factory machine is down. Once a new nightly build is available then we can integrate this and have the same Slicer version with/without TBB for clean performance comparison.