### PR TITLE
COMP: Fix compile error in vtkITKLabelShapeStatistics

### DIFF
--- a/Libs/vtkITK/CMakeLists.txt
+++ b/Libs/vtkITK/CMakeLists.txt
@@ -63,6 +63,7 @@ include(${ITK_USE_FILE})
 set(include_dirs
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
+  ${vtkAddon_INCLUDE_DIRS}
   )
 include_directories(${include_dirs})
 

--- a/Libs/vtkITK/vtkITKLabelShapeStatistics.h
+++ b/Libs/vtkITK/vtkITKLabelShapeStatistics.h
@@ -19,6 +19,9 @@
 #include <vtkTableAlgorithm.h>
 #include <vtkVector.h>
 
+// vtkAddon includes
+#include <vtkAddonSetGet.h>
+
 // std includes
 #include <vector>
 
@@ -53,8 +56,8 @@ public:
   static ShapeStatistic GetShapeStatisticFromString(std::string statisticName);
 
   vtkSetObjectMacro(Directions, vtkMatrix4x4);
-  vtkSetMacro(ComputedStatistics, std::vector<std::string>);
-  vtkGetMacro(ComputedStatistics, std::vector<std::string>);
+  vtkSetStdVectorMacro(ComputedStatistics, std::vector<std::string>);
+  vtkGetStdVectorMacro(ComputedStatistics, std::vector<std::string>);
 
   /// Set/Get if the the specified statistic should be computed.
   /// Label centroid and flatness are computed by default.


### PR DESCRIPTION
vtkSetMacro and vtkGetMacro do not work with std::vector.
This commit fixes vtkITKLabelShapeStatistics by using vtkSetStdVectorMacro from vtkAddon instead.