### PR TITLE
ENH: update DCMTK to version 3.6.5

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -50,18 +50,15 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/commontk/dcmtk"
+    "${EP_GIT_PROTOCOL}://git.dcmtk.org/dcmtk"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    # Official DCMTK master as of 20180621
-    # http://git.dcmtk.org/?p=dcmtk.git;a=commit;h=29f9de10c2e8576147f16475b156bba98d14ba7d
-    # plus the following patch:
-    # * Set CMP0067 to ensure try_compile work as expected
-    # * Backport fix for DICOM TR support for along-track measurements
-    "22f253424f70d6c6d8ea91a11fcc07231e6ac2bf" # v3.6.3_20180621
+    # Official DCMTK release DCMTK-3.6.5
+    # http://git.dcmtk.org/?p=dcmtk.git;a=commit;h=0f2de2313a00f9360bdf33399a2f37ee5e65c429
+    "DCMTK-3.6.5"
     QUIET
     )
 


### PR DESCRIPTION
This update already includes [the patch](https://github.com/commontk/DCMTK/commit/e79118cd2f40b77654630a56bbb17fe0bccc354c) that previously required a separate repository under commontk: http://git.dcmtk.org/?p=dcmtk.git;a=commit;h=09d352dd240f36451107665ddece85f9809f4d01.

Also see discussion in https://discourse.slicer.org/t/updating-dcmtk-to-3-6-5/9888.

List of changes specific to 3.6.5:

$ git shortlog 29f9de10..DCMTK-3.6.5 --no-merges
Jan Schlamelcher (54):
      Fixed a compile time type conversion issue on clang.
      Re-fixed the clang conversion issue from yesterday.
      Fixes and enhancements for OFpath.
      Made DcmAttributeMatchings's range separator public.
      Updated copyright date in files from previous commit.
      Various enhancements for VR checking code.
      Added additional DA, DT and TM check functions.
      Added functions to validate range queries.
      Fixed initially bad naming sense in previous commit.
      Fixed a bug in yesterday's commit.
      Added a configure test for stdlibc iconv behavior.
      Added forgotten configure test source file.
      Fixed a missing return statement by refactoring.
      Fixed another iconv related issue.
      More fixes for iconv stuff.
      Fixed argument order for iconv_open() in config test.
      Enhanced recently introduced iconv configure test.
      Added handy overload for OFStandard::trimString().
      Fixed Worklist SCP not accepting some time queries.
      More fixes for iconv configure test.
      Added configure test to workaround an Android issue.
      Fixed generated CMake exports install destination.
      Fixed not detecting some functions on 32 bit Windows.
      Fixed wrong documentation of calcElementLength().
      Added missing includes for configuration tests.
      Added another iconv configuration test.
      Added a missing include.
      Updated DIMSE compatibility flag.
      Updated Autoconf config for upcoming release 3.6.4.
      Updated ANNOUNCE and INSTALL for DCMTK release 3.6.4.
      Updated version information for DCMTK release 3.6.4.
      Updated man pages for DCMTK release 3.6.4.
      Created CHANGES.364 for DCMTK release 3.6.4.
      Updated version information for 3.6.4+ development.
      Fixed inconsistent use of USE_STD_CXX_INCLUDES.
      Fixed incorrect assumption in OVector's unit test.
      Enhanced top level CMakeLists.txt.
      Changes to use newer CMake policies when available.
      Added support for CMAKE_CXX_STANDARD et al.
      Fixes for a previous commit.
      Workaround to silence some clang warnings.
      Hopefully fixed rare issues regarding <utility>.
      As expected, MSVC gets the #ifdef it deserves.
      Fixed OFin_place again.
      Include <tuple> on HAVE_STL_TUPLE, easy, right?
      Added missing member typedefs to OFIterator.
      Made building/installing of manpages configurable.
      Made patching manpages platform independent.
      Updated DIMSE compatibility flag.
      Updated Autoconf config for upcoming release 3.6.5.
      Updated ANNOUNCE and INSTALL for DCMTK release 3.6.5.
      Updated version information for DCMTK release 3.6.5.
      Updated man pages for DCMTK release 3.6.5.
      Created CHANGES.365 for DCMTK release 3.6.5.

Joerg Riesmeier (141):
      Use correct data type for type casts.
      Fixes for recent API change.
      Updated data dictionary for DICOM 2018c.
      Updated code definitions for DICOM 2018c.
      Updated Context Group classes for DICOM 2018c.
      Fixed wrong MAC size returned for SHA384.
      Added warning on Modality LUT transformation.
      Added private undefined copy constructor.
      Fixed inconsistencies in recent commits.
      Fixed manpage title of new tool "stl2dcm".
      Added missing "." to API documentation (Doxygen).
      Further fixes for cda2dcm syntax usage / manpage.
      Fixed various typos and formatting issues.
      Added default manpage for new tool "dcmicmp".
      Made use of OFExplicitBool for OFBool parameters.
      Updated Makefile dependencies.
      Avoid type mismatch warnings (sprintf and sscanf).
      Fixed typo in comment.
      Include missing files in Doxygen's HTML output.
      Added new dcmimage tool "dcmicmp".
      Updated data dictionary for DICOM 2018d.
      Updated code definitions for DICOM 2018d.
      Updated Context Group classes for DICOM 2018d.
      Updated latest tested CMake version.
      Option --output-directory requires --port.
      Increased precision of floating point output.
      Added configure test for HAVE_STREAMBUF_H.
      Fixed wrong initialization order of members.
      Updated data dictionary for approved changes.
      Added sentence on compression of icon images.
      Removed useless for-loop (since VM is always 1).
      Fixed bug introduced with last commit (0f80c07).
      Fixed various issues with syntax usage.
      Updated data dictionary for DICOM 2018e.
      Updated code definitions for DICOM 2018e.
      Reverted changes from last commit.
      Fixed coding style of last commit.
      Added definition of new Storage SOP Class UIDs.
      Added support for directory record "RADIOTHERAPY".
      Added support for new "SR" SOP Classes.
      Initial support for new SR types (Supplement 164).
      Fixed CMake error if "FindPkgConfig" is missing.
      Minor fixes to text formatting.
      Only include directories that exist (CMake).
      Fixed wrong parameter names (only affects BEOS).
      Added quotation marks around filesystem paths.
      Added new method getNamedChildNode().
      Made use of new getNamedChildNode() method.
      Added support for Synchronization Module.
      Removed unused local variable.
      Fixed broken CMake configuration (older versions).
      Fixed inconsistent names of two SR classes.
      Added full support for SR IODs from Suppl. 164.
      Added new DIMSE status code category to summary.
      Minor fixes to INSTALL file.
      Removed explicit type cast from size_t parameter.
      Fixed warnings reported by VisualStudio.
      Updated internal XML parser to version 2.44.
      Added configure test for atoll() function.
      Fixed text formatting such as line indentation.
      Partly removed workaround for SunPro compiler.
      Avoid unused function warning reported by gcc.
      Updated data dictionary for DICOM 2019a.
      Updated code definitions for DICOM 2019a.
      Updated Context Group classes for DICOM 2019a.
      Updated copyright date.
      Added support for Issuer of Patient ID to "dcmsr".
      Replaced undefined length by explicit value.
      Added minimal support for new 64-bit VRs.
      Fixed incorrect man and HTML page title.
      Added new SR SOP Classes also to documentation.
      Added check on VR support for undefined length.
      Added DCMVR_PROP_UNDEFINEDLENGTH to EVR_UNKNOWN.
      Handle new VRs SV/UV/OV separately.
      Fixed typos and replaced tabs by spaces.
      Fixed incorrect sprintf() format pattern.
      Added missing attributes to checkMetaHeaderValue.
      Enhanced documentation of setEncodingHandler().
      Fixed wrong type of coding scheme designator.
      Removed double class specifier DSRTypes::DSRTypes.
      Added Markdown version of README file.
      Always respect option --ignore-missing-tags.
      Fixed issue with verify() method for certain VRs.
      Replaced tabs by spaces and fixed typos.
      Minor fixes to source code formatting.
      Minor fixes to recently added documentation.
      Fixed incompatible types in assignment.
      Fixed issue with OFStringUtil::replace_all().
      Added initial support for "SCT" code definitions.
      Fixed outdated "purpose" text in file header.
      Fixed API documentation of recently added method.
      Updated data dictionary for DICOM 2019b.
      Updated code definitions for DICOM 2019b.
      Updated Context Group classes for DICOM 2019b.
      Updated SR Template classes for DICOM 2019b.
      Fixed issue with .cc file listed for "make clean".
      Fixed wrong DIMSE status codes (A8xx/A800).
      Separate DIMSE status strings for C-MOVE and C-GET.
      Fixed typo in log message.
      Removed old STATUS_STORE_xxx constant.
      Fixed minor formatting issues.
      Only use PTRDIFF_MAX if defined.
      Added full support for new 64-bit VRs.
      Minor fixes to API documentation and formatting.
      Fixed issue with loop check (by-reference).
      Updated code definitions for DICOM 2019c.
      Fixed minor issues in API documentation.
      Added createXXXArray() method for OD, OF, OL, OV.
      Added new print flag PF_printEmptyCodes.
      Added wide char support to XML parser (Windows).
      Added missing prefix "DCMTK_" to CMake variable.
      Fixed issue with empty OverlayActivationLayer.
      Minor fixes after previous commit.
      Added missing full stop to end of sentence.
      Updated data dictionary for Supplement 175.
      Updated keyword of attribute (0018,100B).
      Updated latest tested CMake version.
      Fixed declaration order of member variables.
      Added wlmsetup.txt to module page and install it.
      Added new well-known Frame of Reference UID.
      Added support for new Storage SOP Classes.
      Added "const" specifier to writeSequenceItem().
      Added support for detecting a URL in code value.
      Fixed various HTML issues in API documentation.
      Fixed crash when "tag" attribute is missing.
      Fixed another issue with wrong VR for sequences.
      Made "Define if..." comments more consistent.
      Get rid of unwanted HAVE_ITERATOR define.
      Fixed issue with loading external entities (XML).
      Use non-zero exit code in case of error (findscu).
      Fixed unused parameter warning in test program.
      Removed unused local variables from test program.
      Fixed wrong VR for attribute RetrieveURL.
      Fixed double declaration of local variable.
      Added comment on missing VRs for this test.
      Updated latest tested CMake version.
      Fixed "defined but not used function" warning.
      Added missing space character to log messages.
      Fixed wrong return type of clone() method.
      Added new VR "OV" to list of bulk data VRs.
      Added explaining text on invalid XML entities.

Marco Eichelberg (90):
      Class OFReadWriteLock now uses SRW locks on Windows.
      Added CMake test for availability of SRW functions.
      Added UL modifier to constants to avoid warnings.
      Fixed detection of SRW locks on MinGW.
      Fixed typo and changed SRW detection (again).
      Removed extra semicolon.
      Check chooseRepresentation() return code.
      Check special cases before compressing/decompressing.
      Fixed segmentation fault caused by invalid datasets.
      Changes that permit inclusion from private modules.
      Check minimum bit depth in lossless encoders.
      Added workaround for Cornell bug to JPEG decoder.
      Enabled JPEG decoder workaround options.
      Fixed buffer overflows during assoc negotiation.
      Fixed incorrect Doxygen comments.
      Added enum EW_WindowType.
      Initial release of dcmicmp, an image comparison tool.
      Various fixes for dcmicmp.
      Added workaround for decoding incomplete RLE stripes.
      Fixed minor gcc warning.
      Fixed minor gcc warning.
      Various improvements for dcmicmp.
      Fixed warnings about out of bounds array access.
      Changed version numbering of shared objects.
      Fixed a warning reported by gcc 8.
      Implemented DICOM CP 1653 in the JPEG codec.
      Fixed warning about unused parameter (gcc -Wextra).
      Fixed buffer overflow in DcmRLEDecoder::decompress().
      Added configure tests for getrusage, gettimeofday.
      Added configure test to detect the OpenJPEG library.
      Updated the names of some private GE tags.
      Improved compilation instructions for Linux/Unix.
      Fixed OpenJPEG detection on Win32.
      Removed configure test for LZW support in libtiff.
      Fixed typo in error message.
      Reintroduced DcmTLSTransportLayer::setCipherSuites().
      Removed top-level configure script and added instructions to INSTALL how users who wish to use the Autoconf toolchain can recreate it.
      Cleaned up the set of included header files.
      Enable RSA-PSS signatures when using OpenSSL 1.1.1+.
      Minor code cleanup in RLE decoder.
      Added explicit typecasts to avoid integer overflows.
      Create list of elliptic curves for TLS dynamically.
      Fixed compilation with OpenSSL 1.0.1.
      Fixed memory leak in multithreaded apps on Win32.
      Fixed compilation error on 32-bit Windows.
      Disable TLS 1.3 for the historic security profiles.
      Added module constant.
      Removed duplicate text.
      Improved documentation.
      Fix dcm2pdf pad byte removal code.
      Improved lossless predictor overflow workaround.
      Fixed --accept-acr-nema option in dcmcjpeg.
      Define Uint32 as uint32_t if possible.
      Replaced strncpy with strlcpy.
      Fixed type conversion warning.
      Fixed warning on Win64 about socket type conversion.
      Implemented Extended BCP 195 TLS Profile.
      Implemented Extended BCP 195 TLS Profile.
      Fixed warning in OFBitmanipTemplate::moveMem().
      Define Uint32 as uint32_t if possible.
      Fixed previous commit.
      Fixed tabs and space characters.
      Do not use the ios::nocreate flag in C++11 mode.
      Fixed IBM xlC warnings in libxml headers.
      Added compiler flags to suppress some xlC warnings.
      Fixed compilation of arith.cc on CygWin.
      Fixed CMake OpenSSL version check.
      Fixed bug in JPEG-LS decoder.
      Minor correction to previous commit.
      Enable setting of individual JPEG-LS encoding parameters.
      Added text file explaining the Worklist SCP setup.
      Added --workaround-incpl option to dcmdjpls.
      Fixed custom RESET value issue in JPEG-LS encoder.
      Avoid passing default JPEG-LS parameters to encoder.
      Fixed bug in the near-lossless JPEG-LS encoder.
      CMake option DCMTK_COMPILE_WIN32_MULTITHREADED_DLL.
      Changed DJLSCodecParameter constructor parameters.
      Added bitstream padding command line options.
      Cleanup of dcmtk/oflog/oflog.h dependencies.
      Added better logger output to RLE decoder.
      Use DICOM_WARNING_STATUS to check for DIMSE warnings.
      Fixed compilation of arith.cc on Cygwin.
      Use OFnullptr as sentinel parameter for execl calls.
      Use null pointer as sentinel for execl calls.
      Removed <sys/errno.h> include statements.
      Added new macro OFopenmode_in_nocreate.
      JPEG-LS encoder now sets PlanarConfiguration to 0.
      Fixed memory leak in DiPNGPlugin::write().
      Fixed DcmTLSOptions::getTransportLayer() signature.
      Clarified documentation of dcmdjpeg --conv-never.

Michael Onken (42):
      Fix possible pixel data size int overflows.
      Fixed doxygen warnings.
      Allow 32 bit value for Number of Frames.
      Set maximum number of frames to 2147483647.
      Fixed algorithm identification substructure.
      Make Number of Frames 32 bit.
      Set error_flag when returning from method.
      Fixed compiler warning.
      Set error_flag when returning from method, again.
      Set error_flag when returning from method.
      Load external dictionaries on Windows per default.
      Load dicitionaries from DCMDICTPATH in any case.
      Adapt dictionary test for commit 52b3b7.
      Fixed dictionary test under Windows.
      Fixed index check.
      Fixed indexing bugs and parameter constness.
      Make checkValuesComplete() public.
      Fix index checking if no measurem. are available.
      Added replace_all() methods.
      New wlmscpfs options (dumping requests, sleeping).
      New class OFStringUtil to stay STL-compatible.
      Fixed typo.
      Fixed wlmscpfs bug rejecting all Called AE Titles.
      Make option --request-file-path optional.
      Fixed minor inconsistencies.
      Use 16 bit for Bits Alloc. for 12 bit JPEG input.
      Check for multiplication overflow.
      Permit skipping of functional group checks.
      Fixed access to Referenced Frame Number.
      Added first test for dcmfg module.
      Clean up after test.
      Add new dcmfg test to autoconf build.
      Added test for Frame Content Functional Group.
      Minor formatting fixes.
      Added missing file for commit f2fd2d.
      Enhanced img2dcm documentation (no multi-frame).
      Notify about association termination.
      Option to rename file after processing.
      Correct error message if  ass. negotiation fails.
      Copy frame data when adding fractional frames.
      Fixed issue with test crashing without dictionary.
      Fixed skipping too much characters after replace.

Nikolas Goldhammer (5):
      Fixed incompatibility between FindIconv versions.
      Fixed FindIconv problems on OpenBSD.
      Fixed a minor typo in a comment.
      Workaround for ICU on the IBM XL C/C++ compiler.
      Workaround for libxml on the IBM XL C/C++ compiler.

Pedro ArizpeGomez (33):
      Added new class dcencdoc (DCM encapsulated Document).
      Added new tool cda2dcm.
      Added new tool stl2dcm.
      Added --key option to pdf2dcm.
      Improved dcencdoc with the typical output options.
      Included stl2dcm and cda2dcm in CMAKE and man1.
      Fixed new inconsistencies in recent commits.
      Improved tabulation in encapsulation applications.
      Fixed bug on responseCounter of findSCU.
      Fixed option issues of dcencdoc.
      Fixed encapsulation apps log output discrepancies.
      Fixed document encapsulation modality and MIME-type settings.
      Fixed a problem introduced by last commits.
      Improved dcencdoc doxygen documentation.
      Improved STL file verification.
      Fixed missing attribute on CDA encapsulation.
      Fixed wrong method call on pdf2dcm.
      Fixed undeclared identifier error in STL verification.
      Improved STL validation with casting.
      Improved log output for encapsulation apps.
      Fixed unused parameters and options in dcencdoc.
      Fixed missing modules for STL encapsulation.
      Updated stl2dcm manpage with required module options.
      Updated manpages of encapsulation apps.
      Fixed manpage formatting inconsistencies in encapsulation apps.
      Fixed formatting inconsistencies in stl2dcm --help.
      Removed stl2dcm support for ASCII STL files.
      Included patch to remove -Wunused-result warnings.
      Included patch to remove -Wunused-result warnings.
      Included addGeneralOptions in ofstd.
      Minor fixes to remove Doxygen warnings.
      Included dummy values for stl2dcm.
      Fix some spacing inconsistencies from last commit.