### PR TITLE
Model and markups save in LPS by default

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsStorageNode.h
@@ -56,17 +56,12 @@ public:
 
   bool CanReadInReferenceNode(vtkMRMLNode *refNode) override;
 
-  /// Coordinate system options
-  enum
-  {
-    RAS = 0,
-    LPS
-  };
-
   /// Get/Set flag that controls if points are to be written in various coordinate systems
-  vtkSetClampMacro(CoordinateSystem, int, vtkMRMLMarkupsStorageNode::RAS, vtkMRMLMarkupsStorageNode::LPS);
+  vtkSetClampMacro(CoordinateSystem, int, 0, vtkMRMLStorageNode::CoordinateSystemType_Last-1);
   vtkGetMacro(CoordinateSystem, int);
   std::string GetCoordinateSystemAsString();
+  static const char* GetCoordinateSystemAsString(int id);
+  static int GetCoordinateSystemFromString(const char* name);
   /// Convenience methods to get/set various coordinate system values
   /// \sa SetCoordinateSystem, GetCoordinateSystem
   void UseRASOn();

--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.h
@@ -18,6 +18,7 @@
 #include "vtkMRMLStorageNode.h"
 
 class vtkMRMLModelNode;
+class vtkPointSet;
 
 /// \brief MRML node for model storage on disk.
 ///
@@ -35,11 +36,20 @@ public:
   /// Get node XML tag name (like Storage, Model)
   const char* GetNodeTagName() override  {return "ModelStorage";}
 
+  /// Read node attributes from XML file
+  void ReadXMLAttributes(const char** atts) override;
+
   /// Write this node's information to a MRML file in XML format.
   void WriteXML(ostream& of, int indent) override;
 
   /// Return true if the reference node can be read in
   bool CanReadInReferenceNode(vtkMRMLNode *refNode) override;
+
+  /// Get/Set flag that controls if points are to be written in various coordinate systems
+  vtkSetClampMacro(CoordinateSystem, int, 0, vtkMRMLStorageNode::CoordinateSystemType_Last-1);
+  vtkGetMacro(CoordinateSystem, int);
+  static const char* GetCoordinateSystemAsString(int id);
+  static int GetCoordinateSystemFromString(const char* name);
 
 protected:
   vtkMRMLModelStorageNode();
@@ -62,6 +72,13 @@ protected:
   /// Write data from a  referenced node
   int WriteDataInternal(vtkMRMLNode *refNode) override;
 
+  static void ConvertBetweenRASAndLPS(vtkPointSet* inputMesh, vtkPointSet* outputMesh);
+
+  static int GetCoordinateSystemFromFileHeader(const char* header);
+
+  static int GetCoordinateSystemFromFieldData(vtkPointSet* mesh);
+
+  int CoordinateSystem;
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -1404,3 +1404,36 @@ vtkMRMLStorableNode* vtkMRMLStorageNode::GetStorableNode()
   this->LastFoundStorableNode = nullptr;
   return nullptr;
 }
+
+//-----------------------------------------------------------
+const char* vtkMRMLStorageNode::GetCoordinateSystemTypeAsString(int id)
+{
+  switch (id)
+    {
+    case CoordinateSystemRAS: return "RAS";
+    case CoordinateSystemLPS: return "LPS";
+    default:
+      // invalid id
+      return "";
+    }
+}
+
+//-----------------------------------------------------------
+int vtkMRMLStorageNode::GetCoordinateSystemTypeFromString(const char* name)
+{
+  if (name == nullptr)
+    {
+    // invalid name
+    return -1;
+    }
+  for (int ii = 0; ii < CoordinateSystemType_Last; ii++)
+    {
+    if (strcmp(name, GetCoordinateSystemTypeAsString(ii)) == 0)
+      {
+      // found a matching name
+      return ii;
+      }
+    }
+  // unknown name
+  return -1;
+}

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -350,6 +350,26 @@ public:
   /// Get a list of all supported compression presets
   virtual const std::vector<CompressionPreset> GetCompressionPresets();
 
+  /// Coordinate system options
+  /// LPS coordinate system is used the most commonly in medical image computing.
+  ///   Slicer is moving towards using this coordinate system in all files by default
+  ///   (while keep using RAS coordinate system internally).
+  /// RAS coordinate system is used in Slicer internally. For many years, Slicer used
+  ///   this coordinate system in files that it created, too.
+  enum
+  {
+    CoordinateSystemRAS = 0,
+    RAS = 0, ///< for backward compatibility
+    CoordinateSystemLPS = 1,
+    LPS = 1, ///< for backward compatibility
+    CoordinateSystemType_Last
+  };
+
+  ///
+  /// Convert between coordinate system ID and name
+  static const char *GetCoordinateSystemTypeAsString(int id);
+  static int GetCoordinateSystemTypeFromString(const char *name);
+
 protected:
   vtkMRMLStorageNode();
   ~vtkMRMLStorageNode() override;

--- a/Libs/MRML/Core/vtkMRMLViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLViewNode.cxx
@@ -143,7 +143,7 @@ void vtkMRMLViewNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLEnumMacro(raycastTechnique, RaycastTechnique);
   vtkMRMLReadXMLIntMacro(volumeRenderingSurfaceSmoothing, VolumeRenderingSurfaceSmoothing);
   vtkMRMLReadXMLFloatMacro(volumeRenderingOversamplingFactor, VolumeRenderingOversamplingFactor);
-  vtkMRMLReadXMLIntMacro(linkedControl, LinkedControl)
+  vtkMRMLReadXMLIntMacro(linkedControl, LinkedControl);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -275,8 +275,8 @@ bool vtkMRMLMarkupsFiducialStorageNode::SetPointFromString(vtkMRMLMarkupsNode *m
     return false;
     }
 
-  if (this->GetCoordinateSystem() != vtkMRMLMarkupsFiducialStorageNode::RAS
-    && this->GetCoordinateSystem() != vtkMRMLMarkupsFiducialStorageNode::LPS)
+  if (this->GetCoordinateSystem() != vtkMRMLStorageNode::CoordinateSystemRAS
+    && this->GetCoordinateSystem() != vtkMRMLStorageNode::CoordinateSystemLPS)
     {
     vtkGenericWarningMacro("vtkMRMLMarkupsFiducialStorageNode::SetMarkupFromString failed: invalid coordinate system");
     return false;
@@ -366,11 +366,11 @@ bool vtkMRMLMarkupsFiducialStorageNode::SetPointFromString(vtkMRMLMarkupsNode *m
 
   markupsNode->SetNthControlPointID(pointIndex, id);
 
-  if (this->GetCoordinateSystem() == vtkMRMLMarkupsFiducialStorageNode::RAS)
+  if (this->GetCoordinateSystem() == vtkMRMLStorageNode::CoordinateSystemRAS)
     {
     markupsNode->SetNthControlPointPosition(pointIndex, xyz[0], xyz[1], xyz[2]);
     }
-  else if (this->GetCoordinateSystem() == vtkMRMLMarkupsFiducialStorageNode::LPS)
+  else if (this->GetCoordinateSystem() == vtkMRMLStorageNode::CoordinateSystemLPS)
     {
     markupsNode->SetNthControlPointPosition(pointIndex, -xyz[0], -xyz[1], xyz[2]);
     }
@@ -407,12 +407,12 @@ std::string vtkMRMLMarkupsFiducialStorageNode::GetPointAsString(vtkMRMLMarkupsNo
 
   double xyz[3] = { 0.0, 0.0, 0.0 };
   markupsNode->GetNthControlPointPosition(pointIndex, xyz);
-  if (this->GetCoordinateSystem() == vtkMRMLMarkupsFiducialStorageNode::LPS)
+  if (this->GetCoordinateSystem() == vtkMRMLStorageNode::CoordinateSystemLPS)
     {
     xyz[0] = -xyz[0];
     xyz[1] = -xyz[1];
     }
-  else if (this->GetCoordinateSystem() != vtkMRMLMarkupsFiducialStorageNode::RAS)
+  else if (this->GetCoordinateSystem() != vtkMRMLStorageNode::CoordinateSystemRAS)
     {
     vtkErrorMacro("WriteData: invalid coordinate system index " << this->GetCoordinateSystem());
     return "";
@@ -503,9 +503,6 @@ int vtkMRMLMarkupsFiducialStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
     // only print out the warning once
     bool printedVersionWarning = false;
 
-    // coordinate system
-    int coordinateSystemFlag = 0;
-
     while (fstr.good())
       {
       fstr.getline(line, MARKUPS_BUFFER_SIZE);
@@ -528,7 +525,7 @@ int vtkMRMLMarkupsFiducialStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
           else if (lineString.find("# CoordinateSystem = ") != std::string::npos)
             {
             std::string str = lineString.substr(21,std::string::npos);
-            coordinateSystemFlag = atoi(str.c_str());
+            int coordinateSystemFlag = vtkMRMLMarkupsStorageNode::GetCoordinateSystemFromString(str.c_str());
             vtkDebugMacro("CoordinateSystem = " << coordinateSystemFlag);
             this->SetCoordinateSystem(coordinateSystemFlag);
             }
@@ -696,7 +693,7 @@ int vtkMRMLMarkupsFiducialStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
 
   // put down a header
   of << "# Markups fiducial file version = " << Slicer_VERSION << endl;
-  of << "# CoordinateSystem = " << this->GetCoordinateSystem() << endl;
+  of << "# CoordinateSystem = " << vtkMRMLMarkupsStorageNode::GetCoordinateSystemAsString(this->GetCoordinateSystem()) << endl;
 
   // label the columns
   // id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,associatedNodeID

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest1.cxx
@@ -157,41 +157,34 @@ int vtkMRMLMarkupsFiducialStorageNodeTest1(int argc, char * argv[] )
   CHECK_BOOL(retval, true);
 
   //
-  // test with use LPS flag on
-  node1->UseLPSOn();
-  std::cout << "Writing file with use LPS flag set:\n"
+  // test with RAS coordinate system
+  node1->UseRASOn();
+  std::cout << "Writing file in RAS coordinate system:\n"
             << node1->GetFileName() << std::endl;
   retval = node1->WriteData(markupsNode.GetPointer());
   CHECK_BOOL(retval, true);
 
   // read it in after clearing out the test data
+  // Set to use LPS to verify that not this hint but the coordinate system that
+  // is specified in the file is taken into account.
   snode2->UseLPSOn();
   markupsNode2->RemoveAllControlPoints();
-  std::cout << "Reading with LPS from " << snode2->GetFileName() << std::endl;
+  std::cout << "Reading file that uses RAS coordinate system from " << snode2->GetFileName() << std::endl;
 
   retval = snode2->ReadData(markupsNode2.GetPointer());
   CHECK_BOOL(retval, true);
+  CHECK_BOOL(snode2->GetUseRAS(), true);
 
-  std::cout << "\nMarkups with LPS read from file = " << std::endl;
+  std::cout << "\nMarkups specified in RAS read from file = " << std::endl;
   markupsNode2->PrintSelf(std::cout, indent);
 
-  // check the point so that it's been converted back to be the same
-  double outputPointAfterLPS[3];
+  // check the point coordinates are correct when stored in files in RAS coordinate system
+  double outputPointLoadedFromRASFile[3];
   index = 0;
-  markupsNode2->GetNthControlPointPosition(index, outputPointAfterLPS);
-  CHECK_DOUBLE_TOLERANCE(outputPointAfterLPS[0], inputPoint[0], 0.1);
-  CHECK_DOUBLE_TOLERANCE(outputPointAfterLPS[1], inputPoint[1], 0.1);
-  CHECK_DOUBLE_TOLERANCE(outputPointAfterLPS[2], inputPoint[2], 0.1);
-
-  double lpsPoint[3];
-  markupsNode2->GetNthControlPointPosition(index, lpsPoint);
-  lpsPoint[0] = -lpsPoint[0];
-  lpsPoint[1] = -lpsPoint[1];
-  std::cout << "Successfully wrote out point as lps "
-            << lpsPoint[0] << "," << lpsPoint[1] << "," << lpsPoint[2]
-            << " and read it back in as RAS "
-            << outputPointAfterLPS[0] << "," << outputPointAfterLPS[1] << ","
-            << outputPointAfterLPS[2] << std::endl;
+  markupsNode2->GetNthControlPointPosition(index, outputPointLoadedFromRASFile);
+  CHECK_DOUBLE_TOLERANCE(outputPointLoadedFromRASFile[0], inputPoint[0], 0.1);
+  CHECK_DOUBLE_TOLERANCE(outputPointLoadedFromRASFile[1], inputPoint[1], 0.1);
+  CHECK_DOUBLE_TOLERANCE(outputPointLoadedFromRASFile[2], inputPoint[2], 0.1);
 
   // check for commas in the markup label and description
   std::string labelWithCommas = markupsNode2->GetNthControlPointLabel(commaIndex);

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
@@ -87,6 +87,5 @@ int vtkMRMLMarkupsFiducialStorageNodeTest2(int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-
   return EXIT_SUCCESS;
 }

--- a/Modules/Loadable/Models/CMakeLists.txt
+++ b/Modules/Loadable/Models/CMakeLists.txt
@@ -32,6 +32,8 @@ set(MODULE_SRCS
   qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicer${MODULE_NAME}Reader.cxx
   qSlicer${MODULE_NAME}Reader.h
+  qSlicer${MODULE_NAME}IOOptionsWidget.cxx
+  qSlicer${MODULE_NAME}IOOptionsWidget.h
   qSlicerScalarOverlayIOOptionsWidget.cxx
   qSlicerScalarOverlayIOOptionsWidget.h
   qSlicerScalarOverlayReader.cxx
@@ -42,12 +44,14 @@ set(MODULE_MOC_SRCS
   qSlicer${MODULE_NAME}Module.h
   qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicer${MODULE_NAME}Reader.h
+  qSlicer${MODULE_NAME}IOOptionsWidget.h
   qSlicerScalarOverlayIOOptionsWidget.h
   qSlicerScalarOverlayReader.h
   )
 
 set(MODULE_UI_SRCS
   Resources/UI/qSlicer${MODULE_NAME}ModuleWidget.ui
+  Resources/UI/qSlicer${MODULE_NAME}IOOptionsWidget.ui
   Resources/UI/qSlicerScalarOverlayIOOptionsWidget.ui
   )
 

--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.h
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.h
@@ -19,6 +19,9 @@
 #include "vtkSlicerModuleLogic.h"
 #include "vtkSlicerModelsModuleLogicExport.h"
 
+// MRML includes
+#include "vtkMRMLStorageNode.h"
+
 // VTK includes
 #include <vtkVersion.h>
 
@@ -45,25 +48,32 @@ class VTK_SLICER_MODELS_MODULE_LOGIC_EXPORT vtkSlicerModelsLogic
 
   /// Add into the scene a new mrml model node with an existing polydata
   /// A display node is also added into the scene.
-  /// \todo Should the function AddModel also add a storage node ?
+  ///param polyData surface mesh in RAS coordinate system.
   vtkMRMLModelNode* AddModel(vtkPolyData* polyData = nullptr);
 
   /// Add into the scene a new mrml model node with an existing polydata
   /// A display node is also added into the scene.
-  /// \todo Should the function AddModel also add a storage node ?
+  ///param polyData surface mesh algorithm output in RAS coordinate system.
   vtkMRMLModelNode* AddModel(vtkAlgorithmOutput* polyData = nullptr);
 
   /// Add into the scene a new mrml model node and
   /// read it's polydata from a specified file
   /// A display node and a storage node are also added into the scene
-  vtkMRMLModelNode* AddModel(const char* filename);
+  /// \param coordinateSystem If coordinate system is not specified
+  ///   in the file then this coordinate system is used. Default is LPS.
+  vtkMRMLModelNode* AddModel(const char* filename, int coordinateSystem = vtkMRMLStorageNode::CoordinateSystemLPS);
 
   /// Create model nodes and
   /// read their polydata from a specified directory
-  int AddModels(const char* dirname, const char* suffix);
+  /// \param coordinateSystem If coordinate system is not specified
+  ///   in the file then this coordinate system is used. Default is LPS.
+  int AddModels(const char* dirname, const char* suffix, int coordinateSystem = vtkMRMLStorageNode::CoordinateSystemLPS);
 
   /// Write model's polydata  to a specified file
-  int SaveModel(const char* filename, vtkMRMLModelNode *modelNode);
+  /// \param coordinateSystem If coordinate system is not specified
+  ///   in the file then this coordinate system is used. Default is -1, which means that
+  ///   the coordinate system specified in the storage node will be used.
+  int SaveModel(const char* filename, vtkMRMLModelNode *modelNode, int coordinateSystem = vtkMRMLStorageNode::CoordinateSystemLPS);
 
   /// Read in a scalar overlay and add it to the model node
   /// \return True on success
@@ -95,9 +105,9 @@ protected:
 
   void OnMRMLSceneEndImport() override;
 
-private:
   /// Color logic
   vtkMRMLColorLogic* ColorLogic;
+
 };
 
 #endif

--- a/Modules/Loadable/Models/Resources/UI/qSlicerModelsIOOptionsWidget.ui
+++ b/Modules/Loadable/Models/Resources/UI/qSlicerModelsIOOptionsWidget.ui
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qSlicerModelsIOOptionsWidget</class>
+ <widget class="qSlicerWidget" name="qSlicerModelsIOOptionsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>151</width>
+    <height>19</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Models options</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Coordinate system:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="coordinateSystemComboBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>Use LPS (left-posterior-superior) for better compatibility with most software. Use RAS (right-anterior-superior) for better compatibility with earlier Slicer versions.</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>Default</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>LPS</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>RAS</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qSlicerWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Modules/Loadable/Models/qSlicerModelsIOOptionsWidget.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsIOOptionsWidget.cxx
@@ -1,0 +1,62 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Julien Finet, Kitware Inc.
+  and was partially funded by NIH grant 3P41RR013218-12S1
+
+==============================================================================*/
+
+/// Qt includes
+#include <QDebug>
+
+/// Models includes
+#include "qSlicerIOOptions_p.h"
+#include "qSlicerModelsIOOptionsWidget.h"
+#include "ui_qSlicerModelsIOOptionsWidget.h"
+
+// MRML includes
+#include <vtkMRMLNode.h>
+#include <vtkMRMLStorageNode.h>
+
+//-----------------------------------------------------------------------------
+class qSlicerModelsIOOptionsWidgetPrivate
+  : public qSlicerIOOptionsPrivate
+  , public Ui_qSlicerModelsIOOptionsWidget
+{
+public:
+};
+
+//-----------------------------------------------------------------------------
+qSlicerModelsIOOptionsWidget::qSlicerModelsIOOptionsWidget(QWidget* parentWidget)
+  : Superclass(new qSlicerModelsIOOptionsWidgetPrivate, parentWidget)
+{
+  Q_D(qSlicerModelsIOOptionsWidget);
+  d->setupUi(this);
+
+  connect(d->coordinateSystemComboBox, SIGNAL(currentIndexChanged(int)),
+          this, SLOT(updateProperties()));
+}
+
+//-----------------------------------------------------------------------------
+qSlicerModelsIOOptionsWidget::~qSlicerModelsIOOptionsWidget()
+= default;
+
+//-----------------------------------------------------------------------------
+void qSlicerModelsIOOptionsWidget::updateProperties()
+{
+  Q_D(qSlicerModelsIOOptionsWidget);
+  d->Properties["coordinateSystem"] = vtkMRMLStorageNode::GetCoordinateSystemTypeFromString(
+    d->coordinateSystemComboBox->currentText().toLatin1().constData());
+}

--- a/Modules/Loadable/Models/qSlicerModelsIOOptionsWidget.h
+++ b/Modules/Loadable/Models/qSlicerModelsIOOptionsWidget.h
@@ -1,0 +1,50 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Julien Finet, Kitware Inc.
+  and was partially funded by NIH grant 3P41RR013218-12S1
+
+==============================================================================*/
+
+#ifndef __qSlicerModelsIOOptionsWidget_h
+#define __qSlicerModelsIOOptionsWidget_h
+
+// CTK includes
+#include <ctkPimpl.h>
+
+// SlicerQt includes
+#include "qSlicerIOOptionsWidget.h"
+#include "qSlicerModelsModuleExport.h"
+
+class qSlicerModelsIOOptionsWidgetPrivate;
+
+class Q_SLICER_QTMODULES_MODELS_EXPORT qSlicerModelsIOOptionsWidget
+  : public qSlicerIOOptionsWidget
+{
+  Q_OBJECT
+public:
+  typedef qSlicerIOOptionsWidget Superclass;
+  qSlicerModelsIOOptionsWidget(QWidget *parent=nullptr);
+  ~qSlicerModelsIOOptionsWidget() override;
+
+protected slots:
+  void updateProperties();
+
+private:
+  Q_DECLARE_PRIVATE_D(qGetPtrHelper(qSlicerIOOptions::d_ptr), qSlicerModelsIOOptionsWidget);
+  Q_DISABLE_COPY(qSlicerModelsIOOptionsWidget);
+};
+
+#endif

--- a/Modules/Loadable/Models/qSlicerModelsReader.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsReader.cxx
@@ -22,6 +22,7 @@
 #include <QFileInfo>
 
 // SlicerQt includes
+#include "qSlicerModelsIOOptionsWidget.h"
 #include "qSlicerModelsReader.h"
 
 // Logic includes
@@ -89,6 +90,14 @@ QStringList qSlicerModelsReader::extensions()const
 }
 
 //-----------------------------------------------------------------------------
+qSlicerIOOptions* qSlicerModelsReader::options()const
+{
+  qSlicerIOOptionsWidget* options = new qSlicerModelsIOOptionsWidget;
+  options->setMRMLScene(this->mrmlScene());
+  return options;
+}
+
+//-----------------------------------------------------------------------------
 bool qSlicerModelsReader::load(const IOProperties& properties)
 {
   Q_D(qSlicerModelsReader);
@@ -99,6 +108,11 @@ bool qSlicerModelsReader::load(const IOProperties& properties)
   if (d->ModelsLogic.GetPointer() == nullptr)
     {
     return false;
+    }
+  int coordinateSystem = -1; // default
+  if (properties.contains("coordinateSystem"))
+    {
+    coordinateSystem = properties["coordinateSystem"].toInt();
     }
   vtkMRMLModelNode* node = d->ModelsLogic->AddModel(
     fileName.toLatin1());

--- a/Modules/Loadable/Models/qSlicerModelsReader.h
+++ b/Modules/Loadable/Models/qSlicerModelsReader.h
@@ -45,6 +45,7 @@ public:
   QString description()const override;
   IOFileType fileType()const override;
   QStringList extensions()const override;
+  qSlicerIOOptions* options()const override;
 
   bool load(const IOProperties& properties) override;
 


### PR DESCRIPTION
Slicer has been using LPS coordinate system when storing images, transforms, and markups. All medical image computing software (maybe except a few very old ones) uses LPS coordinate system, too. Slicer started writing coordinate system name in mesh files (STL, VTK, VTP, OBJ, PLY) but still used RAS by default for saving models. This caused inconsistencies when Slicer-exported data was used in third-party software. See https://issues.slicer.org/view.php?id=4445 for details.

This commit changes default coordinate system in saved models to LPS. When loading a model that has coordinate system information embedded in the file then that coordinate system is used. If the model does not contain coordinate system information then the CoordinateSystem property of model storage node is used. CoordinateSystem is set to LPS by default but the user can change it in "Add data" dialog (in option column)

Backward compatibility:
- all old Slicer scenes are loaded correctly (if model coordinate system is not specified in the mrml file then it is assumed to be RAS)
- all standalone model files that Slicer created since 2017-09-27 (Slicer-4.8.0) are read correctly (except obj files created by Slicer-4.6 and Slicer-4.8)
- all files created by external software that use LPS coordinate system are read correctly
- files that require manual selection of RAS coordinate system when loading without a scene: model files created by Slicer-4.6 (2017-09-27) and earlier; and obj files created by Slicer-4.6 and Slicer-4.8 (between 2016-10-11 and 2018-03-26).

Also cleaned up markups node coordinate system writing (use LPS/RAS string instead of magic numbers, similar style as model nodes, added tests).