### PR TITLE
BUG: Fix failing extension build test due to documentation URL update

### DIFF
--- a/Extensions/CMake/Testing/CheckGeneratedDescriptionFiles.cmake
+++ b/Extensions/CMake/Testing/CheckGeneratedDescriptionFiles.cmake
@@ -37,7 +37,7 @@ endfunction()
 
 check_extension_metadata(
   "HOMEPAGE"
-  "http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/TestExtC"
+  "https://www.slicer.org/wiki/Documentation/Nightly/Extensions/TestExtC"
   )
 check_extension_metadata(
   "CATEGORY"

--- a/Extensions/CMake/Testing/SlicerExtensionBuildSystemTest.py
+++ b/Extensions/CMake/Testing/SlicerExtensionBuildSystemTest.py
@@ -701,7 +701,7 @@ include({slicer_source_dir}/Extensions/CMake/SlicerExtensionsDashboardDriverScri
             'contributors': ['John Doe (AnyWare Corp.)'],
             'description': ['This is an example of a simple extension'],
             'enabled': ['1'],
-            'homepage': ['http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Extensions/%s' % extensionName],
+            'homepage': ['https://www.slicer.org/wiki/Documentation/Nightly/Extensions/%s' % extensionName],
             'icon_url': ['http://www.example.com/Slicer/Extensions/%s.png' % extensionName],
             'screenshots': ['http://www.example.com/Slicer/Extensions/%s/Screenshots/1.png' % extensionName],
           })

--- a/Modules/CLI/AddScalarVolumes/AddScalarVolumes.xml
+++ b/Modules/CLI/AddScalarVolumes/AddScalarVolumes.xml
@@ -4,7 +4,7 @@
   <title>Add Scalar Volumes</title>
   <description><![CDATA[Adds two images. Although all image types are supported on input, only signed types are produced. The two images do not have to have the same dimensions.]]></description>
   <version>0.1.0.$Revision$(alpha)</version>
-  <documentation-url>http://slicer.org/slicerWiki/index.php/Documentation/Nightly/Modules/Add</documentation-url>
+  <documentation-url>https://www.slicer.org/wiki/Documentation/Nightly/Modules/Add</documentation-url>
   <license/>
   <contributor>Bill Lorensen (GE)</contributor>
   <acknowledgements><![CDATA[This work is part of the National Alliance for Medical Image Computing (NAMIC), funded by the National Institutes of Health through the NIH Roadmap for Medical Research, Grant U54 EB005149.]]></acknowledgements>


### PR DESCRIPTION
Test failures caused by change in bd9e2c0b4d2855cb4e24b5331f994e064d1f21e2.

See [failed tests](http://slicer.cdash.org/viewTest.php?onlyfailed&buildid=1804946) on CDash.