### PR TITLE
ENH: Add more segment label statistics and display table component info

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableNode.cxx
@@ -51,6 +51,9 @@ static const char SCHEMA_COLUMN_NULL_VALUE[] = "nullValue";
 static const char SCHEMA_COLUMN_LONG_NAME[] = "longName";
 static const char SCHEMA_COLUMN_DESCRIPTION[] = "description";
 static const char SCHEMA_COLUMN_UNIT_LABEL[] = "unitLabel";
+static const char SCHEMA_COMPONENT_NAMES[] = "componentNames";
+
+static const char COMPONENT_COUNT_PROPERTY[] = "componentCount";
 
 static const char SCHEMA_DEFAULT_COLUMN_NAME[] = "<default>";
 
@@ -752,6 +755,19 @@ std::string vtkMRMLTableNode::GetColumnProperty(const std::string& columnName, c
     {
     return vtkMRMLTableNode::GetValueTypeAsString(this->GetColumnType(columnName));
     }
+  if (propertyName == SCHEMA_COMPONENT_NAMES)
+    {
+    return vtkMRMLTableNode::GetComponentNamesAsString(this->GetComponentNames(columnName));
+    }
+  if (propertyName == COMPONENT_COUNT_PROPERTY)
+    {
+    int numberOfComponents = 0;
+    if (this->Table && this->Table->GetColumnByName(columnName.c_str()))
+      {
+      numberOfComponents = this->Table->GetColumnByName(columnName.c_str())->GetNumberOfComponents();
+      }
+    return vtkVariant(numberOfComponents).ToString();
+    }
 
   return this->GetColumnPropertyInternal(columnName, propertyName);
 }
@@ -808,6 +824,16 @@ void vtkMRMLTableNode::SetColumnProperty(const std::string& columnName, const st
     this->SetColumnType(columnName, vtkMRMLTableNode::GetValueTypeFromString(propertyValue));
     return;
     }
+  if (propertyName == SCHEMA_COMPONENT_NAMES)
+    {
+    this->SetComponentNames(columnName, this->GetComponentNamesFromString(propertyValue));
+    }
+  if (propertyName == COMPONENT_COUNT_PROPERTY)
+    {
+    vtkErrorMacro("vtkMRMLTableNode::SetColumnProperty failed : property is read-only " << COMPONENT_COUNT_PROPERTY);
+    return;
+    }
+
   if (propertyName.empty())
     {
     vtkErrorMacro("vtkMRMLTableNode::SetColumnProperty failed: property name is invalid");
@@ -876,7 +902,8 @@ void vtkMRMLTableNode::SetColumnPropertyInternal(const std::string& columnName, 
 //----------------------------------------------------------------------------
 void vtkMRMLTableNode::RemoveColumnProperty(const std::string& propertyName)
 {
-  if (propertyName == SCHEMA_COLUMN_NAME || propertyName == SCHEMA_COLUMN_TYPE)
+  if (propertyName == SCHEMA_COLUMN_NAME || propertyName == SCHEMA_COLUMN_TYPE
+    || propertyName == SCHEMA_COMPONENT_NAMES || propertyName == COMPONENT_COUNT_PROPERTY)
     {
     vtkErrorMacro("vtkMRMLTableNode::RemoveColumnProperty failed: reserved propertyName: " << propertyName);
     return;
@@ -1185,4 +1212,105 @@ int vtkMRMLTableNode::GetColumnType(const std::string& columnName)
     }
   int valueTypeId = this->Table->GetColumn(columnIndex)->GetDataType();
   return valueTypeId;
+}
+
+//----------------------------------------------------------------------------
+const std::vector<std::string> vtkMRMLTableNode::GetComponentNamesFromString(const std::string& componentNamesString)
+{
+  std::stringstream ss(componentNamesString);
+  std::string componentName;
+  std::vector<std::string> componentNames;
+  while (std::getline(ss, componentName, '|'))
+    {
+    componentNames.push_back(componentName);
+    }
+  return componentNames;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkMRMLTableNode::GetComponentNamesAsString(const std::vector<std::string>& componentNames)
+{
+  std::stringstream ss;
+  for (size_t componentCount = 0; componentCount != componentNames.size(); ++componentCount)
+    {
+    if (componentCount != 0)
+      {
+      ss << "|";
+      }
+    ss << componentNames[componentCount];
+    }
+  return ss.str();
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLTableNode::SetComponentNames(const std::string& columnName, const std::vector<std::string>& componentNames)
+{
+  vtkAbstractArray* column = nullptr;
+  if (this->Table && columnName != SCHEMA_DEFAULT_COLUMN_NAME)
+    {
+    column = this->Table->GetColumnByName(columnName.c_str());
+    }
+
+  if (column == nullptr)
+    {
+    return false;
+    }
+
+  if (column->GetNumberOfComponents() != static_cast<int>(componentNames.size()))
+    {
+    return false;
+    }
+
+  int componentIndex = 0;
+  for (std::string componentName : componentNames)
+    {
+    column->SetComponentName(componentIndex, componentName.c_str());
+    ++componentIndex;
+    }
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
+std::vector<std::string> vtkMRMLTableNode::GetComponentNames(const std::string& columnName)
+{
+  vtkAbstractArray* column = nullptr;
+  if (this->Table && columnName != SCHEMA_DEFAULT_COLUMN_NAME)
+    {
+    column = this->Table->GetColumnByName(columnName.c_str());
+    }
+  return vtkMRMLTableNode::GetComponentNamesFromArray(column);
+}
+
+//----------------------------------------------------------------------------
+std::vector<std::string> vtkMRMLTableNode::GetComponentNamesFromSchema(const std::string& columnName)
+{
+  return this->GetComponentNamesFromString(this->GetColumnPropertyInternal(columnName, SCHEMA_COLUMN_TYPE));
+}
+
+//----------------------------------------------------------------------------
+std::vector<std::string> vtkMRMLTableNode::GetComponentNamesFromArray(vtkAbstractArray* array)
+{
+  std::vector<std::string> componentNames;
+  if (!array)
+    {
+    return componentNames;
+    }
+
+  for (int componentIndex = 0; componentIndex < array->GetNumberOfComponents(); ++componentIndex)
+    {
+    const char* componentName = array->GetComponentName(componentIndex);
+    if (componentName != nullptr)
+      {
+      componentNames.push_back(componentName);
+      }
+    else
+      {
+      // Default to colum integer name 0, 1, 2, etc.
+      std::stringstream ss;
+      ss << componentIndex;
+      componentNames.push_back(ss.str());
+      }
+    }
+  return componentNames;
 }

--- a/Libs/MRML/Core/vtkMRMLTableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableNode.h
@@ -147,7 +147,7 @@ public:
   /// Remove all columns from the table (including associated properties).
   /// Returns with true on success.
   bool RemoveAllColumns();
-  
+
   ///
   /// Add an empty row at the end of the table
   /// Returns the index of the inserted row or -1 on failure.
@@ -290,6 +290,25 @@ public:
 
   /// Get value type id from string (uses vtkImageScalarTypeNameMacro)
   static std::string GetValueTypeAsString(int valueType);
+
+  /// Set the component names for the specified column
+  bool SetComponentNames(const std::string& columnName, const std::vector<std::string>& componentNames);
+
+  /// Get the vector of component names from the
+  std::vector<std::string> GetComponentNames(const std::string& columnName);
+
+  /// Get component names stored in the schema. It should only be used during reading/writing of the node,
+  /// because once the table column is created, the actual column names are stored in the data array.
+  std::vector<std::string> GetComponentNamesFromSchema(const std::string& columnName);
+
+  /// Get component names from a vtkAbstractArray as a vector of string
+  static std::vector<std::string> GetComponentNamesFromArray(vtkAbstractArray* array);
+
+  /// Convert the vector of component names from a string of component names separated with the '|' character
+  static const std::vector<std::string> GetComponentNamesFromString(const std::string& componentNameString);
+
+  /// Convert the component names as a string of component names separated with the '|' character
+  static std::string GetComponentNamesAsString(const std::vector<std::string>& componentNames);
 
   //----------------------------------------------------------------
   /// Constructor and destructor

--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
@@ -469,7 +469,7 @@ void vtkMRMLTableStorageNode::AddColumnToTable(vtkTable* table, vtkMRMLTableStor
       }
     typedColumn->SetNumberOfTuples(numberOfTuples);
 
-    int componentIndex = 0;
+    vtkIdType componentIndex = 0;
     for (vtkAbstractArray* componentArray : rawComponentArrays)
       {
       vtkSmartPointer<vtkStringArray> rawComponentArray = vtkStringArray::SafeDownCast(componentArray);
@@ -502,7 +502,7 @@ void vtkMRMLTableStorageNode::AddColumnToTable(vtkTable* table, vtkMRMLTableStor
         typedColumn = typedComponentArray;
         }
 
-      if (componentIndex < columnInfo.ComponentNames.size())
+      if (componentIndex < static_cast<vtkIdType>(columnInfo.ComponentNames.size()))
         {
         std::string componentName = columnInfo.ComponentNames[componentIndex];
         typedColumn->SetComponentName(componentIndex, componentName.c_str());
@@ -771,28 +771,9 @@ bool vtkMRMLTableStorageNode::WriteSchema(std::string filename, vtkMRMLTableNode
         columnNameArray->SetValue(schemaRowIndex, column->GetName());
         }
 
-      std::stringstream componentNamesSS;
-      if (column->GetNumberOfComponents() > 1)
-        {
-        for (int componentIndex = 0; componentIndex < column->GetNumberOfComponents(); ++componentIndex)
-          {
-          if (componentIndex != 0)
-            {
-            componentNamesSS << "|";
-            }
-
-          if (column->GetComponentName(componentIndex))
-            {
-            componentNamesSS << column->GetComponentName(componentIndex);
-            }
-          else
-            {
-            componentNamesSS << componentIndex;
-            }
-          }
-        }
-      std::string componentNames = componentNamesSS.str();
-      componentNamesArray->SetValue(schemaRowIndex, componentNames.c_str());
+      std::vector<std::string> componentNames = vtkMRMLTableNode::GetComponentNamesFromArray(column);
+      std::string componentNamesStr = vtkMRMLTableNode::GetComponentNamesAsString(componentNames);
+      componentNamesArray->SetValue(schemaRowIndex, componentNamesStr.c_str());
       }
     }
 

--- a/Libs/vtkITK/vtkITKLabelShapeStatistics.h
+++ b/Libs/vtkITK/vtkITKLabelShapeStatistics.h
@@ -1,11 +1,22 @@
-/*=========================================================================
+/*==============================================================================
 
-  Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
 
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-==========================================================================*/
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women’s Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
 
 #ifndef __vtkITKLabelShapeStatistics_h
 #define __vtkITKLabelShapeStatistics_h
@@ -31,7 +42,7 @@ class vtkPoints;
 /// Utilizes itk::LabelImageToShapeLabelMapFilter to calcualte label shape statistics
 /// (https://itk.org/Doxygen/html/classitk_1_1LabelImageToShapeLabelMapFilter.html)
 /// Label centroid and flatness are the only statistics calculated by default.
-/// Other availiable statistics are: Oriented bounding box (origin, size, direction), feret diameter, perimeter, roundness.
+/// For a list of availiable parameters, see: vtkITKLabelShapeStatistics::ShapeStatistic
 /// Calculated statistics can be changed using the SetComputeShapeStatistic/ComputeShapeStatisticOn/ComputeShapeStatisticOff methods.
 /// Output statistics are represented in a vtkTable where each column represents a statistic and each row is a different label value.
 class VTK_ITK_EXPORT vtkITKLabelShapeStatistics : public vtkTableAlgorithm
@@ -41,14 +52,28 @@ public:
   vtkTypeMacro(vtkITKLabelShapeStatistics, vtkTableAlgorithm);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
+  /// Shape statistic parameters
+  /// See parameter definitions and formulas here: http://hdl.handle.net/1926/584
   enum ShapeStatistic
   {
+    /// Location of the center of mass of the label
     Centroid,
+    /// Oriented bounding box of the label
     OrientedBoundingBox,
+    /// Diameter of the sphere that contains the label
     FeretDiameter,
+    /// Surface area of the label
     Perimeter,
+    /// Ratio of the area of the hypersphere by the actual area. A value of 1 represents a spherical structure
     Roundness,
+    /// Square root of the ratio of the second smallest principal moment by the smallest. A value of 0 represents a flat structure
     Flatness,
+    /// Square root of the ratio of the second largest principal moment by the second smallest
+    Elongation,
+    /// Principal moments of inertia for the principal axes
+    PrincipalMoments,
+    // Principal axes of rotation
+    PrincipalAxes,
     ShapeStatistic_Last,
   };
 

--- a/Modules/Loadable/Tables/Widgets/Resources/UI/qSlicerTableColumnPropertiesWidget.ui
+++ b/Modules/Loadable/Tables/Widgets/Resources/UI/qSlicerTableColumnPropertiesWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>768</width>
+    <width>384</width>
     <height>285</height>
    </rect>
   </property>
@@ -23,7 +23,16 @@
    <property name="fieldGrowthPolicy">
     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item row="1" column="0">
@@ -96,6 +105,11 @@
        </item>
        <item>
         <property name="text">
+         <string>long</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>long long</string>
         </property>
        </item>
@@ -157,45 +171,73 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="NullValueLabel">
      <property name="text">
       <string>Null value:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="5" column="1">
     <widget class="QLineEdit" name="NullValueLineEdit"/>
    </item>
-   <item row="4" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="LongNameLabel">
      <property name="text">
       <string>Long name:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="6" column="1">
     <widget class="QLineEdit" name="LongNameLineEdit"/>
    </item>
-   <item row="5" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="DescriptionLabel">
      <property name="text">
       <string>Description:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="7" column="1">
     <widget class="QLineEdit" name="DescriptionLineEdit"/>
    </item>
-   <item row="6" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="UnitLabelLabel">
      <property name="text">
       <string>Unit label:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="8" column="1">
     <widget class="QLineEdit" name="UnitLabelLineEdit"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="ComponentCountLabel">
+     <property name="text">
+      <string>Component count:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="ComponentCountLineEdit">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="ComponentNamesLineEdit">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="ComponentNamesLabel">
+     <property name="text">
+      <string>Component names:</string>
+     </property>
+    </widget>
    </item>
   </layout>
   <action name="ActionPersistent">

--- a/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.cxx
+++ b/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.cxx
@@ -117,11 +117,15 @@ void qSlicerTableColumnPropertiesWidget::setup()
   d->LongNameLineEdit->setProperty(SCHEMA_PROPERTY_NAME, QString("longName"));
   d->DescriptionLineEdit->setProperty(SCHEMA_PROPERTY_NAME, QString("description"));
   d->UnitLabelLineEdit->setProperty(SCHEMA_PROPERTY_NAME, QString("unitLabel"));
+  d->ComponentCountLineEdit->setProperty(SCHEMA_PROPERTY_NAME, QString("componentCount"));
+  d->ComponentNamesLineEdit->setProperty(SCHEMA_PROPERTY_NAME, QString("componentNames"));
 
   d->PropertyEditWidgets << d->NullValueLineEdit;
   d->PropertyEditWidgets << d->LongNameLineEdit;
   d->PropertyEditWidgets << d->DescriptionLineEdit;
   d->PropertyEditWidgets << d->UnitLabelLineEdit;
+  d->PropertyEditWidgets << d->ComponentCountLineEdit;
+  d->PropertyEditWidgets << d->ComponentNamesLineEdit;
 
   connect(d->DataTypeComboBox, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(onDataTypeChanged(const QString&)));
   foreach(QLineEdit* widget, d->PropertyEditWidgets)
@@ -180,7 +184,7 @@ void qSlicerTableColumnPropertiesWidget::setColumnProperty(QString propertyName,
     }
   foreach(const QString& columnName, d->ColumnNames)
     {
-      d->CurrentTableNode->SetColumnProperty(columnName.toLatin1().constData(), propertyName.toLatin1().constData(), propertyValue.toLatin1().constData());
+    d->CurrentTableNode->SetColumnProperty(columnName.toLatin1().constData(), propertyName.toLatin1().constData(), propertyValue.toLatin1().constData());
     }
 }
 
@@ -189,14 +193,14 @@ QString qSlicerTableColumnPropertiesWidget::columnProperty(QString propertyName)
 {
   Q_D(const qSlicerTableColumnPropertiesWidget);
   if (d->CurrentTableNode == nullptr)
-  {
+    {
     qWarning() << Q_FUNC_INFO << " failed: table node is not selected";
     return "";
-  }
+    }
   if (d->ColumnNames.empty())
-  {
+    {
     return "";
-  }
+    }
   std::string commonPropertyValue = d->CurrentTableNode->GetColumnProperty(d->ColumnNames[0].toLatin1().constData(), propertyName.toLatin1().constData());
   foreach(const QString& columnName, d->ColumnNames)
     {
@@ -224,6 +228,12 @@ void qSlicerTableColumnPropertiesWidget::updateWidget()
     return;
     }
 
+  bool componentRowsVisible = vtkVariant(this->columnProperty("componentCount").toStdString()) > 1;
+  d->ComponentCountLabel->setVisible(componentRowsVisible);
+  d->ComponentCountLineEdit->setVisible(componentRowsVisible);
+  d->ComponentNamesLabel->setVisible(componentRowsVisible);
+  d->ComponentNamesLineEdit->setVisible(componentRowsVisible);
+
   d->NameLineEdit->setText(d->ColumnNames.join(", "));
 
   QString columnType = this->columnProperty("type");
@@ -232,7 +242,6 @@ void qSlicerTableColumnPropertiesWidget::updateWidget()
 
   foreach(QLineEdit* widget, d->PropertyEditWidgets)
     {
-    connect(widget, SIGNAL(textEdited(const QString&)), this, SLOT(onPropertyChanged(const QString&)));
     widget->setText(this->columnProperty(widget->property(SCHEMA_PROPERTY_NAME).toString()));
     }
 

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/LabelmapSegmentStatisticsPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/LabelmapSegmentStatisticsPlugin.py
@@ -11,9 +11,11 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
     super(LabelmapSegmentStatisticsPlugin,self).__init__()
     self.name = "Labelmap"
     self.obbKeys = ["obb_origin_ras", "obb_diameter_mm", "obb_direction_ras_x", "obb_direction_ras_y", "obb_direction_ras_z"]
+    self.principalAxisKeys = ["principal_axis_x", "principal_axis_y", "principal_axis_z"]
     self.shapeKeys = [
-      "centroid_ras", "feret_diameter_mm", "surface_area_mm2", "roundness", "flatness",
-      ] + self.obbKeys
+      "centroid_ras", "feret_diameter_mm", "surface_area_mm2", "roundness", "flatness", "elongation",
+      "principal_moments",
+      ] + self.principalAxisKeys + self.obbKeys
 
     self.defaultKeys = ["voxel_count", "volume_mm3", "volume_cm3"] # Don't calculate label shape statistics by default since they take longer to compute
     self.keys = self.defaultKeys + self.shapeKeys
@@ -23,12 +25,18 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
       "surface_area_mm2" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.Perimeter),
       "roundness" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.Roundness),
       "flatness" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.Flatness),
+      "elongation" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.Elongation),
       "oriented_bounding_box" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.OrientedBoundingBox),
       "obb_origin_ras" : "OrientedBoundingBoxOrigin",
       "obb_diameter_mm" : "OrientedBoundingBoxSize",
       "obb_direction_ras_x" : "OrientedBoundingBoxDirectionX",
       "obb_direction_ras_y" : "OrientedBoundingBoxDirectionY",
       "obb_direction_ras_z" : "OrientedBoundingBoxDirectionZ",
+      "principal_moments" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.PrincipalMoments),
+      "principal_axes" : vtkITK.vtkITKLabelShapeStatistics.GetShapeStatisticAsString(vtkITK.vtkITKLabelShapeStatistics.PrincipalAxes),
+      "principal_axis_x" : "PrincipalAxisX",
+      "principal_axis_y" : "PrincipalAxisY",
+      "principal_axis_z" : "PrincipalAxisZ",
       }
     #... developer may add extra options to configure other parameters
 
@@ -123,6 +131,26 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
             requestedOptions.append(option)
         requestedOptions.append("oriented_bounding_box")
 
+      calculatePrincipalAxis = (
+        "principal_axis_x" in requestedKeys or
+        "principal_axis_y" in requestedKeys or
+        "principal_axis_z" in requestedKeys
+        )
+      if calculatePrincipalAxis:
+        temp = statFilterOptions
+        statFilterOptions = []
+        for option in temp:
+          if not option in self.principalAxisKeys:
+            statFilterOptions.append(option)
+        statFilterOptions.append("principal_axes")
+
+        temp = requestedOptions
+        requestedOptions = []
+        for option in temp:
+          if not option in self.principalAxisKeys:
+            requestedOptions.append(option)
+        requestedOptions.append("principal_axes")
+
       shapeStat = vtkITK.vtkITKLabelShapeStatistics()
       shapeStat.SetInputData(thresh.GetOutput())
       shapeStat.SetDirections(directions)
@@ -138,65 +166,135 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
       if "centroid_ras" in requestedKeys:
         centroidRAS = [0,0,0]
         centroidArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["centroid_ras"])
-        centroid = centroidArray.GetTuple(0)
-        transformSegmentToRas.TransformPoint(centroid, centroidRAS)
-        stats["centroid_ras"] = centroidRAS
+        centroidTuple = centroidArray.GetTuple(0)
+        if centroidTuple is not None:
+          transformSegmentToRas.TransformPoint(centroidTuple, centroidRAS)
+          stats["centroid_ras"] = centroidRAS
 
       if "roundness" in requestedKeys:
         roundnessArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["roundness"])
-        roundness = roundnessArray.GetTuple(0)[0]
-        stats["roundness"] = roundness
+        roundnessTuple = roundnessArray.GetTuple(0)
+        if roundnessTuple is not None:
+          roundness = roundnessTuple[0]
+          stats["roundness"] = roundness
 
       if "flatness" in requestedKeys:
         flatnessArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["flatness"])
-        flatness = flatnessArray.GetTuple(0)[0]
-        stats["flatness"] = flatness
+        flatnessTuple = flatnessArray.GetTuple(0)
+        if flatnessTuple is not None:
+          flatness = flatnessTuple[0]
+          stats["flatness"] = flatness
+
+      if "elongation" in requestedKeys:
+        elongationArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["elongation"])
+        elongationTuple = elongationArray.GetTuple(0)
+        if elongationTuple is not None:
+          elongation = elongationTuple[0]
+          stats["elongation"] = elongation
 
       if "feret_diameter_mm" in requestedKeys:
         feretDiameterArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["feret_diameter_mm"])
-        feretDiameter = feretDiameterArray.GetTuple(0)[0]
-        stats["feret_diameter_mm"] = feretDiameter
+        feretDiameterTuple = feretDiameterArray.GetTuple(0)
+        if feretDiameterTuple is not None:
+          feretDiameter = feretDiameterTuple[0]
+          stats["feret_diameter_mm"] = feretDiameter
 
       if "surface_area_mm2" in requestedKeys:
         perimeterArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["surface_area_mm2"])
-        perimeter = perimeterArray.GetTuple(0)[0]
-        stats["surface_area_mm2"] = perimeter
+        perimeterTuple = perimeterArray.GetTuple(0)
+        if perimeterTuple is not None:
+          perimeter = perimeterTuple[0]
+          stats["surface_area_mm2"] = perimeter
 
       if "obb_origin_ras" in requestedKeys:
         obbOriginRAS = [0,0,0]
         obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
-        obbOrigin = obbOriginArray.GetTuple(0)
-        transformSegmentToRas.TransformPoint(obbOrigin, obbOriginRAS)
-        stats["obb_origin_ras"] = obbOriginRAS
+        obbOriginTuple = obbOriginArray.GetTuple(0)
+        if obbOriginTuple is not None:
+          transformSegmentToRas.TransformPoint(obbOriginTuple, obbOriginRAS)
+          stats["obb_origin_ras"] = obbOriginRAS
 
       if "obb_diameter_mm" in requestedKeys:
         obbDiameterArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_diameter_mm"])
-        obbDiameterMM = list(obbDiameterArray.GetTuple(0))
-        stats["obb_diameter_mm"] = obbDiameterMM
+        obbDiameterMMTuple = obbDiameterArray.GetTuple(0)
+        if obbDiameterMMTuple is not None:
+          obbDiameterMM = list(obbDiameterMMTuple)
+          stats["obb_diameter_mm"] = obbDiameterMM
 
       if "obb_direction_ras_x" in requestedKeys:
         obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
-        obbOrigin = obbOriginArray.GetTuple(0)
+        obbOriginTuple = obbOriginArray.GetTuple(0)
         obbDirectionXArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_direction_ras_x"])
-        obbDirectionX = list(obbDirectionXArray.GetTuple(0))
-        transformSegmentToRas.TransformVectorAtPoint(obbOrigin, obbDirectionX, obbDirectionX)
-        stats["obb_direction_ras_x"] = obbDirectionX
+        obbDirectionXTuple = obbDirectionXArray.GetTuple(0)
+        if obbOriginTuple is not None and obbDirectionXTuple is not None:
+          obbDirectionX = list(obbDirectionXTuple)
+          transformSegmentToRas.TransformVectorAtPoint(obbOriginTuple, obbDirectionX, obbDirectionX)
+          stats["obb_direction_ras_x"] = obbDirectionX
 
       if "obb_direction_ras_y" in requestedKeys:
         obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
-        obbOrigin = obbOriginArray.GetTuple(0)
+        obbOriginTuple = obbOriginArray.GetTuple(0)
         obbDirectionYArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_direction_ras_y"])
-        obbDirectionY = list(obbDirectionYArray.GetTuple(0))
-        transformSegmentToRas.TransformVectorAtPoint(obbOrigin, obbDirectionY, obbDirectionY)
-        stats["obb_direction_ras_y"] = obbDirectionY
+        obbDirectionYTuple = obbDirectionYArray.GetTuple(0)
+        if obbOriginTuple is not None and obbDirectionYTuple is not None:
+          obbDirectionY = list(obbDirectionYTuple)
+          transformSegmentToRas.TransformVectorAtPoint(obbOriginTuple, obbDirectionY, obbDirectionY)
+          stats["obb_direction_ras_y"] = obbDirectionY
 
       if "obb_direction_ras_z" in requestedKeys:
         obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
-        obbOrigin = obbOriginArray.GetTuple(0)
+        obbOriginTuple = obbOriginArray.GetTuple(0)
         obbDirectionZArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_direction_ras_z"])
-        obbDirectionZ = list(obbDirectionZArray.GetTuple(0))
-        transformSegmentToRas.TransformVectorAtPoint(obbOrigin, obbDirectionZ, obbDirectionZ)
-        stats["obb_direction_ras_z"] = obbDirectionZ
+        obbDirectionZTuple = obbDirectionZArray.GetTuple(0)
+        if obbOriginTuple is not None and obbDirectionZTuple is not None:
+          obbDirectionZ = list(obbDirectionZTuple)
+          transformSegmentToRas.TransformVectorAtPoint(obbOriginTuple, obbDirectionZ, obbDirectionZ)
+          stats["obb_direction_ras_z"] = obbDirectionZ
+
+      if "obb_diameter_mm" in requestedKeys:
+        obbDiameterArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_diameter_mm"])
+        obbDiameterMMTuple = obbDiameterArray.GetTuple(0)
+        if obbDiameterMMTuple is not None:
+          obbDiameterMM = list(obbDiameterMMTuple)
+          stats["obb_diameter_mm"] = obbDiameterMM
+
+      if "principal_moments" in requestedKeys:
+        principalMomentsArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["principal_moments"])
+        principalMomentsTuple = principalMomentsArray.GetTuple(0)
+        if principalMomentsTuple is not None:
+          principalMoments = list(principalMomentsTuple)
+          stats["principal_moments"] = principalMoments
+
+      if "principal_axis_x" in requestedKeys:
+        obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
+        obbOriginTuple = obbOriginArray.GetTuple(0)
+        principalAxisXArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["principal_axis_x"])
+        principalAxisXTuple = principalAxisXArray.GetTuple(0)
+        if obbOriginTuple is not None and principalAxisXTuple is not None:
+          principalAxisX = list(principalAxisXTuple)
+          transformSegmentToRas.TransformVectorAtPoint(obbOriginTuple, principalAxisX, principalAxisX)
+          stats["principal_axis_x"] = principalAxisX
+
+      if "principal_axis_y" in requestedKeys:
+        obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
+        obbOriginTuple = obbOriginArray.GetTuple(0)
+        principalAxisYArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["principal_axis_y"])
+        principalAxisYTuple = principalAxisYArray.GetTuple(0)
+        if obbOriginTuple is not None and principalAxisYTuple is not None:
+          principalAxisY = list(principalAxisYTuple)
+          transformSegmentToRas.TransformVectorAtPoint(obbOriginTuple, principalAxisY, principalAxisY)
+          stats["principal_axis_y"] = principalAxisY
+
+      if "principal_axis_z" in requestedKeys:
+        obbOriginArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["obb_origin_ras"])
+        obbOriginTuple = obbOriginArray.GetTuple(0)
+        principalAxisZArray = statTable.GetColumnByName(self.keyToShapeStatisticNames["principal_axis_z"])
+        principalAxisZTuple = principalAxisZArray.GetTuple(0)
+        if obbOriginTuple is not None and principalAxisZTuple is not None:
+          principalAxisZ = list(principalAxisZTuple)
+          transformSegmentToRas.TransformVectorAtPoint(obbOriginTuple, principalAxisZ, principalAxisZ)
+          stats["principal_axis_z"] = principalAxisZ
+
 
     return stats
 
@@ -237,10 +335,19 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
                                    unitsDicomCode=self.createCodedEntry("mm2", "UCUM", "squared millimeters", True))
 
     info["roundness"] = \
-      self.createMeasurementInfo(name="Roundness", description="Roundness", units="")
+      self.createMeasurementInfo(name="Roundness",
+      description="Segment roundness. Calculated from ratio of the area of the hypersphere by the actual area. Value of 1 represents a spherical structure", units="")
 
     info["flatness"] = \
-      self.createMeasurementInfo(name="Flatness", description="Flatness", units="")
+      self.createMeasurementInfo(name="Flatness",
+      description="Segment flatness. Calculated from square root of the ratio of the second smallest principal moment by the smallest. Value of 0 represents a flat structure." +
+        " ( http://hdl.handle.net/1926/584 )",
+      units="")
+
+    info["elongation"] = \
+      self.createMeasurementInfo(name="Elongation",
+      description="Segment elongation. Calculated from square root of the ratio of the second largest principal moment by the second smallest. ( http://hdl.handle.net/1926/584 )",
+      units="")
 
     info["oriented_bounding_box"] = \
       self.createMeasurementInfo(name="Oriented bounding box", description="Oriented bounding box", units="")
@@ -259,5 +366,18 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
 
     info["obb_direction_ras_z"] = \
       self.createMeasurementInfo(name="OBB Z direction (RAS)", description="Oriented bounding box Z direction", units="", componentNames=["r", "a", "s"])
+
+    info["principal_moments"] = \
+      self.createMeasurementInfo(name="Principal moments", description="Principal moments of inertia for x, y and z axes",
+      units="", componentNames=["x", "y", "z"])
+
+    info["principal_axis_x"] = \
+      self.createMeasurementInfo(name="Principal X axis", description="Principal X axis of rotation", units="", componentNames=["r", "a", "s"])
+
+    info["principal_axis_y"] = \
+      self.createMeasurementInfo(name="Principal Y axis", description="Principal Y axis of rotation", units="", componentNames=["r", "a", "s"])
+
+    info["principal_axis_z"] = \
+      self.createMeasurementInfo(name="Principal Z axis", description="Principal Z axis of rotation", units="", componentNames=["r", "a", "s"])
 
     return info[key] if key in info else None


### PR DESCRIPTION
New label shape statics:
- Elongation
- Principal moments
- Principal axes

Adds component information (component count and component names) within qSlicerTableColumnPropertiesWidget. Additional information is only shown if there is more than one component.

![image](https://user-images.githubusercontent.com/9222709/73691819-19844800-46a1-11ea-9755-5589e44795e1.png)

Also:
- Fixes a bug in qSlicerTableCOlumnPropertiesWidget that caused many connections to be added to the QLineEdit textEdited() signal.