### PR TITLE
ENH: Add the vtkSegmentationModifier helper class

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -807,7 +807,7 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
     }
 
   // Add the created segments to the segmentation
-  for (int segmentIndex = 0; segmentIndex < segments.size(); ++segmentIndex)
+  for (int segmentIndex = 0; segmentIndex < static_cast<int>(segments.size()); ++segmentIndex)
     {
     vtkSegment* currentSegment = segments[segmentIndex];
     if (!currentSegment)

--- a/Libs/vtkSegmentationCore/CMakeLists.txt
+++ b/Libs/vtkSegmentationCore/CMakeLists.txt
@@ -47,6 +47,8 @@ set(vtkSegmentationCore_SRCS
   vtkSegmentationConverterRule.h
   vtkSegmentationHistory.cxx
   vtkSegmentationHistory.h
+  vtkSegmentationModifier.cxx
+  vtkSegmentationModifier.h
   vtkTopologicalHierarchy.cxx
   vtkTopologicalHierarchy.h
   vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx

--- a/Libs/vtkSegmentationCore/Testing/vtkSegmentationTest2.cxx
+++ b/Libs/vtkSegmentationCore/Testing/vtkSegmentationTest2.cxx
@@ -199,7 +199,7 @@ bool TestSharedLabelmapCollapse()
     imageCount3,
     imageCount4,
     };
-  for (int i = 0; i < segments.size(); ++i)
+  for (size_t i = 0; i < segments.size(); ++i)
     {
     vtkSegment* segment = segments[i];
     int expectedFrequency = expectedResults[i];
@@ -235,7 +235,7 @@ bool TestSharedLabelmapCollapse()
     imageCount3,
     imageCount4,
     };
-  for (int i = 0; i < segments.size(); ++i)
+  for (size_t i = 0; i < segments.size(); ++i)
     {
     vtkSegment* segment = segments[i];
     int expectedFrequency = expectedResults[i];

--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
@@ -174,8 +174,6 @@ bool vtkBinaryLabelmapToClosedSurfaceConversionRule::Convert(vtkSegment* segment
       imageAccumulate->SetComponentSpacing(1, 1, 1);
       imageAccumulate->SetComponentExtent(lowLabel, highLabel, 0, 0, 0, 0);
       imageAccumulate->Update();
-      int minimum = (int)imageAccumulate->GetMin()[0];
-      int maximum = (int)imageAccumulate->GetMax()[0];
 
       std::vector<int> labelValues;
       for (int labelValue = lowLabel; labelValue <= highLabel; ++labelValue)
@@ -288,7 +286,6 @@ bool vtkBinaryLabelmapToClosedSurfaceConversionRule::CreateClosedSurface(vtkOrie
   double decimationFactor = vtkVariant(this->ConversionParameters[GetDecimationFactorParameterName()].first).ToDouble();
   double smoothingFactor = vtkVariant(this->ConversionParameters[GetSmoothingFactorParameterName()].first).ToDouble();
   int computeSurfaceNormals = vtkVariant(this->ConversionParameters[GetComputeSurfaceNormalsParameterName()].first).ToInt();
-  int jointSmoothing = vtkVariant(this->ConversionParameters[GetJointSmoothingParameterName()].first).ToInt();
 
 #if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
   vtkNew<vtkDiscreteFlyingEdges3D> marchingCubes;

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
@@ -1740,7 +1740,7 @@ void IsLabelInMaskGeneric2(vtkOrientedImageData* binaryLabelmap, vtkOrientedImag
       {
       for (vtkIdType idxX = 0; idxX <= maxX; idxX++)
         {
-        if (static_cast<MaskScalarType>(*maskPointer) > maskThreshold && *binaryLabelmapPointer != (ImageScalarType)0)
+        if (*maskPointer > static_cast<MaskScalarType>(maskThreshold) && *binaryLabelmapPointer != (ImageScalarType)0)
           {
           inMask = true;
           return;

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -361,8 +361,6 @@ bool vtkSegmentation::AddSegment(vtkSegment* segment, std::string segmentId/*=""
       reprIt != requiredRepresentationNames.end(); ++reprIt)
       {
       vtkSmartPointer<vtkDataObject> emptyRepresentation;
-      bool isSharedLabelmap = false;
-      int sharedLabelmapValue = -1;
       if (this->GetMasterRepresentationName() == vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName())
         {
         for (std::deque<std::string>::iterator segmentIDIt = this->SegmentIds.begin(); segmentIDIt != this->SegmentIds.end(); ++segmentIDIt)
@@ -370,8 +368,6 @@ bool vtkSegmentation::AddSegment(vtkSegment* segment, std::string segmentId/*=""
           emptyRepresentation = segment->GetRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName());
           if (emptyRepresentation)
             {
-            isSharedLabelmap = true;
-            sharedLabelmapValue = 1;
             break;
             }
           }
@@ -1063,12 +1059,6 @@ bool vtkSegmentation::ConvertSegmentsUsingPath(std::vector<std::string> segmentI
 }
 
 //-----------------------------------------------------------------------------
-bool vtkSegmentation::ConvertSegments(std::vector<std::string> segmentIDs, bool overwriteExisting)
-{
-  return true;
-}
-
-//-----------------------------------------------------------------------------
 bool vtkSegmentation::ConvertSegmentUsingPath(vtkSegment* segment, vtkSegmentationConverter::ConversionPathType path, bool overwriteExisting/*=false*/)
 {
   // Execute each conversion step in the selected path
@@ -1179,7 +1169,6 @@ bool vtkSegmentation::CreateRepresentation(const std::string& targetRepresentati
   std::map<std::string, vtkDataObject*> representationsBefore;
   for (SegmentMap::iterator segmentIt = this->Segments.begin(); segmentIt != this->Segments.end(); ++segmentIt)
     {
-    vtkSegment* segment = segmentIt->second;
     representationsBefore[segmentIt->first] = segmentIt->second->GetRepresentation(targetRepresentationName);
     }
 
@@ -1193,7 +1182,6 @@ bool vtkSegmentation::CreateRepresentation(const std::string& targetRepresentati
 
   for (SegmentMap::iterator segmentIt = this->Segments.begin(); segmentIt != this->Segments.end(); ++segmentIt)
     {
-    vtkSegment* segment = segmentIt->second;
     vtkDataObject* representationBefore = representationsBefore[segmentIt->first];
     vtkDataObject* representationAfter = segmentIt->second->GetRepresentation(targetRepresentationName);
     if (representationBefore != representationAfter
@@ -1797,7 +1785,6 @@ std::string vtkSegmentation::AddEmptySegment(std::string segmentId/*=""*/, std::
   if (this->MasterRepresentationName == vtkSegmentationConverter::GetBinaryLabelmapRepresentationName())
     {
     std::string sharedSegmentId;
-    int numberOfSharedSegments = 0;
     if (this->SegmentIds.size() > 0)
       {
       // Add the empty segment to the first shared labelmap.

--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -468,7 +468,6 @@ public:
 
 protected:
   bool ConvertSegmentsUsingPath(std::vector<std::string> segmentIDs, vtkSegmentationConverter::ConversionPathType path, bool overwriteExisting = false);
-  bool ConvertSegments(std::vector<std::string> segmentIDs, bool overwriteExisting = false);
 
   /// Convert given segment along a specified path
   /// \param segment Segment to convert
@@ -553,6 +552,7 @@ protected:
 
   friend class vtkMRMLSegmentationNode;
   friend class vtkSlicerSegmentationsModuleLogic;
+  friend class vtkSegmentationModifier;
   friend class qMRMLSegmentEditorWidgetPrivate;
 };
 

--- a/Libs/vtkSegmentationCore/vtkSegmentationModifier.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentationModifier.cxx
@@ -1,0 +1,395 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women’s Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+// SegmentationCore includes
+#include "vtkOrientedImageData.h"
+#include "vtkOrientedImageDataResample.h"
+#include "vtkSegmentation.h"
+#include "vtkSegmentationConverter.h"
+#include "vtkSegmentationModifier.h"
+
+// VTK includes
+#include <vtkImageConstantPad.h>
+#include <vtkImageThreshold.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
+
+// STD includes
+#include <algorithm>
+
+vtkStandardNewMacro(vtkSegmentationModifier);
+
+//-----------------------------------------------------------------------------
+vtkSegmentationModifier::vtkSegmentationModifier() = default;
+
+//-----------------------------------------------------------------------------
+vtkSegmentationModifier::~vtkSegmentationModifier() = default;
+
+//-----------------------------------------------------------------------------
+bool vtkSegmentationModifier::ModifyBinaryLabelmap(
+  vtkOrientedImageData* labelmap, vtkSegmentation* segmentation, std::string segmentID, int mergeMode/*=MODE_REPLACE*/, const int extent[6]/*=0*/,
+  bool minimumOfAllSegments/*=false*/, bool masterRepresentationModifiedEnabled/*=false*/, std::vector<std::string> segmentIDsToOverwrite/*={}*/,
+  std::vector<std::string>* modifiedSegmentIDs/*=nullptr*/)
+{
+  if (!segmentation || segmentID.empty() || !labelmap)
+    {
+    vtkGenericWarningMacro("vtkSegmentationModifier::SetBinaryLabelmapToSegment: Invalid inputs");
+    return false;
+    }
+  if (labelmap->GetPointData()->GetScalars() == nullptr)
+    {
+    vtkErrorWithObjectMacro(segmentation, "vtkSegmentationModifier::SetBinaryLabelmapToSegment: Invalid input labelmap");
+    return false;
+    }
+
+  // If there are segments on the same layer that we should not overwrite, determine if there are any under the modifier labelmap
+  if (vtkSegmentationModifier::SharedLabelmapShouldOverlap(segmentation, segmentID, segmentIDsToOverwrite))
+    {
+    vtkSegmentationModifier::SeparateModifiedSegmentFromSharedLabelmap(labelmap, segmentation, segmentID, extent, segmentIDsToOverwrite);
+    }
+
+  if (modifiedSegmentIDs)
+    {
+    modifiedSegmentIDs->clear();
+    }
+
+  // Get binary labelmap representation of selected segment
+  vtkSegment* selectedSegment = segmentation->GetSegment(segmentID);
+  if (!selectedSegment)
+    {
+    vtkGenericWarningMacro("vtkSegmentationModifier::SetBinaryLabelmapToSegment: Invalid selected segment");
+    return false;
+    }
+
+  vtkOrientedImageData* segmentLabelmap = vtkOrientedImageData::SafeDownCast(
+    selectedSegment->GetRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()) );
+  if (!segmentLabelmap)
+    {
+    vtkErrorWithObjectMacro(segmentation, "vtkSegmentationModifier::SetBinaryLabelmapToSegment: Failed to get binary labelmap representation in "
+      << "segmentation");
+    return false;
+    }
+
+  bool wasMasterRepresentationModifiedEnabled = segmentation->SetMasterRepresentationModifiedEnabled(masterRepresentationModifiedEnabled);
+
+  bool segmentLabelmapModified = true;
+  if (!vtkSegmentationModifier::AppendLabelmapToSegment(labelmap, segmentation, segmentID, mergeMode, extent, minimumOfAllSegments, modifiedSegmentIDs,
+    segmentLabelmapModified))
+    {
+    segmentation->SetMasterRepresentationModifiedEnabled(wasMasterRepresentationModifiedEnabled);
+    return false;
+    }
+
+  // Shrink the image data extent to only contain the effective data (extent of non-zero voxels)
+  vtkSegmentationModifier::ShrinkSegmentToEffectiveExtent(segmentLabelmap);
+
+  // Re-enable master representation modified event
+  segmentation->SetMasterRepresentationModifiedEnabled(wasMasterRepresentationModifiedEnabled);
+  if (segmentLabelmapModified)
+    {
+    const char* segmentIdChar = segmentID.c_str();
+    segmentation->InvokeEvent(vtkSegmentation::MasterRepresentationModified, (void*)segmentIdChar);
+    segmentation->InvokeEvent(vtkSegmentation::RepresentationModified, (void*)segmentIdChar);
+    }
+
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+bool vtkSegmentationModifier::GetSharedSegmentIDsInMask(
+  vtkSegmentation* segmentation, std::string sharedSegmentID, vtkOrientedImageData* maskLabelmap, const int extent[6],
+  std::vector<std::string>& segmentIDs, int maskThreshold/*=0*/, bool includeInputSegmentID/*=false*/)
+{
+  segmentIDs.clear();
+  if (!segmentation)
+    {
+    vtkErrorWithObjectMacro(nullptr, "Invalid segmentation!");
+    return false;
+    }
+
+  std::vector<std::string> sharedSegmentIDs;
+  segmentation->GetSegmentIDsSharingBinaryLabelmapRepresentation(sharedSegmentID, sharedSegmentIDs, includeInputSegmentID);
+  if (sharedSegmentIDs.empty())
+    {
+    // No shared segments to compare against, so there are no relevant IDs in the mask
+    return true;
+    }
+
+  std::map<int, std::string> segmentValues;
+  for (std::string currentSegmentID : sharedSegmentIDs)
+    {
+    vtkSegment* segment = segmentation->GetSegment(currentSegmentID);
+    segmentValues[segment->GetLabelValue()] = currentSegmentID;
+    }
+
+  vtkOrientedImageData* binaryLabelmap = vtkOrientedImageData::SafeDownCast(
+    segmentation->GetSegment(sharedSegmentID)->GetRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()));
+
+  std::vector<int> labelValuesInMask;
+  vtkOrientedImageDataResample::GetLabelValuesInMask(labelValuesInMask, binaryLabelmap, maskLabelmap, extent, maskThreshold);
+
+  for (int labelValue : labelValuesInMask)
+    {
+    if (labelValue == 0 || segmentValues.find(labelValue) == segmentValues.end())
+      {
+      continue;
+      }
+    segmentIDs.push_back(segmentValues[labelValue]);
+    }
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+bool vtkSegmentationModifier::SharedLabelmapShouldOverlap(vtkSegmentation* segmentation, std::string segmentID, std::vector<std::string>& segmentIDsToOverwrite)
+{
+  std::vector<std::string> sharedSegmentIDs;
+  segmentation->GetSegmentIDsSharingBinaryLabelmapRepresentation(segmentID, sharedSegmentIDs, false);
+
+  // Determine if there are any segments on the same layer that we should not overwrite
+  bool segmentsOnLayerShouldOverlap = false;
+  for (std::string sharedID : sharedSegmentIDs)
+    {
+    if (std::find(segmentIDsToOverwrite.begin(), segmentIDsToOverwrite.end(), sharedID) == segmentIDsToOverwrite.end())
+      {
+      segmentsOnLayerShouldOverlap = true;
+      break;
+      }
+    }
+  return segmentsOnLayerShouldOverlap;
+}
+
+//-----------------------------------------------------------------------------
+void vtkSegmentationModifier::SeparateModifiedSegmentFromSharedLabelmap(vtkOrientedImageData* labelmap, vtkSegmentation* segmentation, std::string segmentID,
+  const int extent[6], const std::vector<std::string>& segmentIDsToOverwrite)
+{
+  std::vector<std::string> sharedSegmentsUnderModifier;
+  vtkSegmentationModifier::GetSharedSegmentIDsInMask(segmentation, segmentID, labelmap,
+    extent, sharedSegmentsUnderModifier, 0.0, false);
+
+  for (std::string sharedSegmentID : sharedSegmentsUnderModifier)
+    {
+    std::vector<std::string>::const_iterator foundOverwriteIDIt = std::find(segmentIDsToOverwrite.begin(), segmentIDsToOverwrite.end(), sharedSegmentID);
+    if (foundOverwriteIDIt == segmentIDsToOverwrite.end())
+      {
+      // TODO: Implement more robust handling of segment separation and layers.
+      //       ex. Rather than a completely new layer, we could move the segment to the next availiable layer
+
+      // We would overwrite a segment that should not be overwritten. Separate the modifier segment to a new layer
+      segmentation->SeparateSegmentLabelmap(segmentID);
+      break;
+      }
+    }
+}
+
+//-----------------------------------------------------------------------------
+bool vtkSegmentationModifier::AppendLabelmapToSegment(vtkOrientedImageData* labelmap, vtkSegmentation* segmentation, std::string segmentID, int mergeMode,
+  const int extent[6], bool minimumOfAllSegments, std::vector<std::string>* modifiedSegmentIDs, bool& segmentLabelmapModified)
+{
+  // Get binary labelmap representation of selected segment
+  vtkSegment* selectedSegment = segmentation->GetSegment(segmentID);
+  if (!selectedSegment)
+    {
+    vtkGenericWarningMacro("vtkSegmentationModifier::SetBinaryLabelmapToSegment: Invalid selected segment");
+    return false;
+    }
+
+  vtkOrientedImageData* segmentLabelmap = vtkOrientedImageData::SafeDownCast(
+    selectedSegment->GetRepresentation(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()));
+  if (!segmentLabelmap)
+    {
+    vtkErrorWithObjectMacro(segmentation, "vtkSegmentationModifier::SetBinaryLabelmapToSegment: Failed to get binary labelmap representation in "
+      << "segmentation");
+    return false;
+    }
+
+  int* segmentLabelmapExtent = segmentLabelmap->GetExtent();
+  bool segmentLabelmapEmpty = (segmentLabelmapExtent[0] > segmentLabelmapExtent[1] ||
+    segmentLabelmapExtent[2] > segmentLabelmapExtent[3] ||
+    segmentLabelmapExtent[4] > segmentLabelmapExtent[5]);
+  if (segmentLabelmapEmpty)
+    {
+    if (mergeMode == MODE_MERGE_MIN)
+      {
+      // empty image is assumed to have minimum value everywhere, combining it with MAX operation
+      // results an empty image, so we don't need to do anything.
+      return true;
+      }
+    // Replace the empty image with the modifier image
+    mergeMode = MODE_REPLACE;
+    }
+
+  int labelValue = selectedSegment->GetLabelValue();
+  // Ensure that the value for the segment can be contained in the labelmap.
+  vtkOrientedImageDataResample::CastImageForValue(segmentLabelmap, labelValue);
+
+  if (mergeMode == MODE_REPLACE)
+    {
+    std::vector<std::string> sharedSegmentIDs;
+    segmentation->GetSegmentIDsSharingBinaryLabelmapRepresentation(segmentID, sharedSegmentIDs, false);
+    if (sharedSegmentIDs.size() != 0)
+      {
+      // There are other labelmaps that share the same representation.
+      // Clear the representation and use mask mode.
+      mergeMode = MODE_MERGE_MASK;
+      segmentation->ClearSegment(segmentID);
+      }
+    else
+      {
+      vtkSmartPointer<vtkOrientedImageData> modifierLabelmap = labelmap;
+      if (labelValue != 1)
+        {
+        // If the label value is not the same as the modifier (which should be 1), change the label value of the modifier labelmap to be
+        // the same as the segment label value.
+        vtkNew<vtkImageThreshold> threshold;
+        threshold->SetInputData(labelmap);
+        threshold->ThresholdByLower(0);
+        threshold->SetInValue(0);
+        threshold->SetOutValue(labelValue);
+        threshold->Update();
+        modifierLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
+        modifierLabelmap->ShallowCopy(threshold->GetOutput());
+        modifierLabelmap->CopyDirections(labelmap);
+        }
+
+      if (modifiedSegmentIDs)
+        {
+        modifiedSegmentIDs->push_back(segmentID);
+        }
+
+      if (!vtkOrientedImageDataResample::CopyImage(modifierLabelmap, segmentLabelmap, extent))
+        {
+        vtkErrorWithObjectMacro(segmentation, "vtkSegmentationModifier::AppendLabelmapToSegment: Failed to copy labelmap");
+        return false;
+        }
+      }
+    }
+
+  if (mergeMode != MODE_REPLACE)
+    {
+    int operation = vtkOrientedImageDataResample::OPERATION_MINIMUM;
+    switch (mergeMode)
+      {
+      case MODE_MERGE_MAX:
+        operation = vtkOrientedImageDataResample::OPERATION_MAXIMUM;
+        break;
+      case MODE_MERGE_MASK:
+        operation = vtkOrientedImageDataResample::OPERATION_MASKING;
+        break;
+      default:
+        operation = vtkOrientedImageDataResample::OPERATION_MINIMUM;
+      }
+
+    vtkSmartPointer<vtkOrientedImageData> modifierLabelmap = labelmap;
+    if (operation == vtkOrientedImageDataResample::OPERATION_MINIMUM)
+      {
+      vtkNew<vtkImageThreshold> threshold;
+      threshold->SetInputData(labelmap);
+      threshold->ThresholdByLower(0);
+      threshold->SetInValue(0);
+      threshold->SetOutValue(segmentLabelmap->GetScalarTypeMax());
+      threshold->SetOutputScalarType(segmentLabelmap->GetScalarType());
+      threshold->Update();
+      modifierLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
+      modifierLabelmap->ShallowCopy(threshold->GetOutput());
+      modifierLabelmap->CopyDirections(labelmap);
+      }
+    else
+      {
+      if (modifiedSegmentIDs)
+        {
+        vtkSegmentationModifier::GetSharedSegmentIDsInMask(segmentation, segmentID, labelmap, extent, *modifiedSegmentIDs);
+        }
+      }
+    if (modifiedSegmentIDs)
+      {
+      modifiedSegmentIDs->push_back(segmentID);
+      }
+
+    vtkSmartPointer<vtkOrientedImageData> resampledSegmentLabelmap;
+    if (!vtkOrientedImageDataResample::DoGeometriesMatch(segmentLabelmap, modifierLabelmap))
+      {
+      // Make sure appended image has the same lattice as the input image
+      resampledSegmentLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
+      vtkOrientedImageDataResample::ResampleOrientedImageToReferenceOrientedImage(
+        segmentLabelmap, modifierLabelmap, resampledSegmentLabelmap, false /*interpolate*/, true /*pad*/);
+      }
+    else
+      {
+      resampledSegmentLabelmap = segmentLabelmap;
+      }
+
+    if (operation == vtkOrientedImageDataResample::OPERATION_MINIMUM && !minimumOfAllSegments)
+      {
+      vtkNew<vtkOrientedImageData> segmentMask;
+      vtkNew<vtkImageThreshold> thresholdSegment;
+      thresholdSegment->SetInputData(resampledSegmentLabelmap);
+      thresholdSegment->ThresholdBetween(labelValue, labelValue);
+      thresholdSegment->SetInValue(1);
+      thresholdSegment->SetOutValue(0);
+      thresholdSegment->SetOutputScalarTypeToUnsignedChar();
+      thresholdSegment->Update();
+      segmentMask->ShallowCopy(thresholdSegment->GetOutput());
+      segmentMask->CopyDirections(resampledSegmentLabelmap);
+      vtkOrientedImageDataResample::ApplyImageMask(modifierLabelmap, segmentMask, modifierLabelmap->GetScalarTypeMax());
+      }
+
+    if (!vtkOrientedImageDataResample::MergeImage(
+      resampledSegmentLabelmap, modifierLabelmap, segmentLabelmap, operation, extent, 0, labelValue, &segmentLabelmapModified))
+      {
+      vtkErrorWithObjectMacro(segmentation, "vtkSegmentationModifier::SetBinaryLabelmapToSegment: Failed to merge labelmap (max)");
+      return false;
+      }
+    }
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+void vtkSegmentationModifier::ShrinkSegmentToEffectiveExtent(vtkOrientedImageData* segmentLabelmap)
+{
+  int effectiveExtent[6] = {0,-1,0,-1,0,-1};
+  vtkOrientedImageDataResample::CalculateEffectiveExtent(segmentLabelmap, effectiveExtent); // TODO: use the update extent? maybe crop when changing segment?
+  if (effectiveExtent[0] > effectiveExtent[1] || effectiveExtent[2] > effectiveExtent[3] || effectiveExtent[4] > effectiveExtent[5])
+    {
+    vtkDebugWithObjectMacro(segmentLabelmap,
+      "vtkSegmentationModifier::SetBinaryLabelmapToSegment: effective extent of the labelmap to set is invalid (labelmap is empty)");
+    }
+  else
+    {
+    bool isPaddingRequired = false;
+    int segmentExtent[6] = { 0 };
+    segmentLabelmap->GetExtent(segmentExtent);
+    for (int i = 0; i < 3; ++i)
+      {
+      if (effectiveExtent[2 * i] != segmentExtent[2 * i] || effectiveExtent[2 * i + 1] != segmentExtent[2 * i + 1])
+        {
+        isPaddingRequired = true;
+        break;
+        }
+      }
+    if (isPaddingRequired)
+      {
+      vtkSmartPointer<vtkImageConstantPad> padder = vtkSmartPointer<vtkImageConstantPad>::New();
+      padder->SetInputData(segmentLabelmap);
+      padder->SetOutputWholeExtent(effectiveExtent);
+      padder->Update();
+      segmentLabelmap->ShallowCopy(padder->GetOutput());
+      }
+    }
+}

--- a/Libs/vtkSegmentationCore/vtkSegmentationModifier.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationModifier.h
@@ -1,0 +1,91 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women’s Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#ifndef __vtkSegmentationModifier_h
+#define __vtkSegmentationModifier_h
+
+// Segmentation includes
+#include "vtkSegmentationCoreConfigure.h"
+
+// VTK includes
+#include "vtkObject.h"
+
+// STD includes
+#include <vector>
+
+class vtkOrientedImageData;
+class vtkSegmentation;
+
+/// \ingroup SegmentationCore
+/// \brief Utility functions for resampling oriented image data
+class vtkSegmentationCore_EXPORT vtkSegmentationModifier : public vtkObject
+{
+public:
+  static vtkSegmentationModifier* New();
+  vtkTypeMacro(vtkSegmentationModifier, vtkObject);
+
+public:
+  /// Set a labelmap image as binary labelmap representation into the segment defined by the segmentation node and segment ID.
+  /// Master representation must be binary labelmap! Master representation changed event is disabled to prevent deletion of all
+  /// other representation in all segments. The other representations in the given segment are re-converted. The extent of the
+  /// segment binary labelmap is shrunk to the effective extent. Display update is triggered.
+  /// \param mergeMode Determines if the labelmap should replace the segment, combined with a maximum or minimum operation, or set under the mask.
+  /// \param extent If extent is specified then only that extent of the labelmap is used.
+  enum
+  {
+    MODE_REPLACE = 0,
+    MODE_MERGE_MAX,
+    MODE_MERGE_MIN,
+    MODE_MERGE_MASK
+  };
+  static bool ModifyBinaryLabelmap(vtkOrientedImageData* labelmap, vtkSegmentation* segmentation, std::string segmentID,
+    int mergeMode = MODE_REPLACE, const int extent[6] = nullptr, bool minimumOfAllSegments = false, bool masterRepresentationModifiedEnabled = false,
+    const std::vector<std::string> segmentIdsToOverwrite = {}, std::vector<std::string>* modifiedSegmentIDs = nullptr);
+
+  /// Get the list of segment IDs in the same shared labelmap that are contained within the mask
+  /// \param segmentationNode Node containing the segmentation
+  /// \param sharedSegmentID Segment ID of the segment that contains the shared labelmap to be checked
+  /// \param mask Mask labelmap
+  /// \param segmentIDs Output list of segment IDs under the mask
+  /// \param includeInputSharedSegmentID If false, sharedSegmentID will not be added to the list of output segment IDs even if it is within the mask
+  static bool GetSharedSegmentIDsInMask(vtkSegmentation* segmentation, std::string sharedSegmentID, vtkOrientedImageData* mask, const int extent[6],
+    std::vector<std::string>& segmentIDs, int maskThreshold = 0.0, bool includeInputSharedSegmentID = false);
+
+protected:
+  static bool AppendLabelmapToSegment(vtkOrientedImageData* labelmap, vtkSegmentation* segmentation, std::string segmentID, int mergeMode, const int extent[6],
+    bool minimumOfAllSegments, std::vector<std::string>* modifiedSegmentIDs, bool& segmentLabelmapModified);
+
+  static void ShrinkSegmentToEffectiveExtent(vtkOrientedImageData* segmentLabelmap);
+
+  static bool SharedLabelmapShouldOverlap(vtkSegmentation* segmentation, std::string segmentID, std::vector<std::string>& segmentIDsToOverwrite);
+
+  static void SeparateModifiedSegmentFromSharedLabelmap(vtkOrientedImageData* labelmap, vtkSegmentation* segmentation, std::string segmentID,
+    const int extent[6], const std::vector<std::string>& segmentIDsToOverwrite);
+
+protected:
+  vtkSegmentationModifier();
+  ~vtkSegmentationModifier() override;
+
+private:
+  vtkSegmentationModifier(const vtkSegmentationModifier&) = delete;
+  void operator=(const vtkSegmentationModifier&) = delete;
+};
+
+#endif

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -323,7 +323,7 @@ public:
     MODE_MERGE_MASK
     };
   static bool SetBinaryLabelmapToSegment(vtkOrientedImageData* labelmap, vtkMRMLSegmentationNode* segmentationNode, std::string segmentID,
-    int mergeMode=MODE_REPLACE, const int extent[6]=nullptr, bool minimumOfAllSegments=false);
+    int mergeMode=MODE_REPLACE, const int extent[6]=nullptr, bool minimumOfAllSegments=false, std::vector<std::string> segmentIdsToOverwrite={});
 
   /// Assign terminology to segments in a segmentation node based on the labels of a labelmap node. Match is made based on the
   /// 3dSlicerLabel terminology type attribute. If the terminology context does not contain that attribute, match cannot be made.


### PR DESCRIPTION
Previously handling of shared layers took place in qSlicerSegmentEditorAbstractEffect::modifySegmentByLabelmap.
This process now takes place in vtkSegmentationModifier::ModifyBinaryLabelmap(), which provides access to labelmap modification and layer management at the PolySeg level.
This commit also fixes a number of compiler warnings in Segmentations.