### PR TITLE
ENH: Improve performance of segment island effect

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
@@ -928,6 +928,8 @@ void vtkMRMLSegmentationDisplayNode::GenerateSegmentColor(double color[3], int c
     {
     colorNumber = this->NumberOfGeneratedColors;
     }
+  // Contain the color index to the valid range of colors
+  colorNumber = colorNumber % genericAnatomyColorNode->GetNumberOfColors();
 
   // Get color corresponding to the number of added segments (which is incremented in
   // vtkMRMLSegmentationNode::AddSegmentDisplayProperties every time a new segment display


### PR DESCRIPTION
Adds a NodeModify context to the split segments function to reduce the number of modified events.
Also wraps the color generated from vtkMRMLSegmentationDisplayNode::GenerateSegmentColor() around if it goes out of bounds of the generic anatomy color table node. This prevents a large number of errors from being printed to the console if the number of segments exceeds the number of colors in the table.