### PR TITLE
BUG: Patch SimpleITK  explicitly set sitk default visibility

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -24,6 +24,17 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(_env_script ${CMAKE_BINARY_DIR}/${proj}_Env.cmake)
   ExternalProject_Write_SetPythonSetupEnv_Commands(${_env_script})
 
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+
+  set(SimpleITK_ADDITONAL_CMAKE_CACHE_ARGS)
+  if(APPLE)
+    # To ensure dynamic_cast for ITK symbols works across libraries,
+    # and with the Slicer runtime, make all implicit symbols visible
+    # on OSX.
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS  "-DCMAKE_CXX_VISIBILITY_PRESET:BOOL=default")
+  endif()
+
   # install step - the working path must be set to the location of the SimpleITK.py
   # file so that it will be picked up by distuils setup, and installed
   set(_install_script ${CMAKE_BINARY_DIR}/${proj}_install_step.cmake)
@@ -35,13 +46,13 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/SimpleITK/SimpleITK.git"
+    "${EP_GIT_PROTOCOL}://github.com/Slicer/SimpleITK.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "16a62269c25fef83b739f8ae8640cf796a6f44f1"  # pre-v2.0 (ITK 5 as default)
+    "slicer-v1.2.4-2020-02-07-777520bd"  # pre-v2.0 (ITK 5 as default)
     QUIET
     )
 
@@ -82,13 +93,14 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
       -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
       -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
       -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
+      -DCMAKE_CXX_VISIBILITY_PRESET:BOOL=default
       -DBUILD_SHARED_LIBS:BOOL=${Slicer_USE_SimpleITK_SHARED}
       -DBUILD_EXAMPLES:BOOL=OFF
+      -DSimpleITK_BUILD_STRIP:BOOL=1
       -DSimpleITK_PYTHON_THREADS:BOOL=ON
       -DSimpleITK_INSTALL_ARCHIVE_DIR:PATH=${Slicer_INSTALL_LIB_DIR}
       -DSimpleITK_INSTALL_LIBRARY_DIR:PATH=${Slicer_INSTALL_LIB_DIR}
       -DSimpleITK_INT64_PIXELIDS:BOOL=OFF
-      -DSimpleITK_EXPLICIT_INSTATIATION_DEFAULT:BOOL=ON
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
       -DSimpleITK_USE_SYSTEM_ITK:BOOL=ON
       -DITK_DIR:PATH=${ITK_DIR}
@@ -103,6 +115,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
       -DWRAP_PYTHON:BOOL=ON
       -DSimpleITK_BUILD_DISTRIBUTE:BOOL=ON # Shorten version and install path removing -g{GIT-HASH} suffix.
       -DExternalData_OBJECT_STORES:PATH=${ExternalData_OBJECT_STORES}
+      ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
     #
     INSTALL_COMMAND ${CMAKE_COMMAND} -P ${_install_script}
     #


### PR DESCRIPTION
Change SimpleITK to export ITK symbols with the default visibility on
OSX. This resolves run-time duplication of symbols causing
dynamic_cast failures.

Update ITK to da0e39
--------------------

List of changes:

$ git shortlog v5.1rc01..da0e39 --no-merges
Antoine Robert (1):
      ENH: Add boundary condition getters and setters

Brad King (1):
      BUG: Update URL for GitSetup hooks checkout

Brad T. Moore (1):
      ENH: Added explicit test of VectorImage with ExpandImageFilter

Bradley Lowekamp (14):
      BUG: Use unique_ptr::reset() to delete held pointer
      COMP: Remove unused region parameter in default copy constructor
      ENH: Update to latest GoogleTest release tag
      COMP: Disable GTest using threads
      ENH: Enable CircleCI to retrieve ccache on pull requests
      BUG: Set ConnectedComponentImageFilter's initial background
      value to zero.
      STYLE: Move constructor to hxx, use inline initialization for
      ivars
      COMP: Fix DCMTK unused CMake variable warning
      Revert "BUG: SetScale() and SetSkew() did not recompute offset:
      ScaleSkewVersorT (#1523)"
      BUG: Prevent integer underflow in CropImageFilter
      ENH: Add VectorImage support to MeanImageFilter
      ENH: Add test for sorting and size  in
      RelabelComponentImageFilter
      BUG: Fix RelabelComponentImageFilter with sorting off, size on
      PERF: Refactor RelabelComponentImageFilter

Davis Vigneault (5):
      BUG: Bump Cuberille Git Hash
      ENH: Bump Cuberille Commit Hash
      BUG: Delaunay Cell Data
      BUG: Handle CellData in Decimation Filter
      BUG: Bump Cuberille Commit Hash

Dženan Zukić (11):
      BUG: fix null pointer dereference in
      itkInOrderTreeIterator.h:102
      Update Release.md
      ENH: updating remote modules
      ENH: Deprecate TreeContainer group of classes
      BUG: Baseline and test image order was reversed in GDCM tests
      ENH: adding JPEG2000 ICT and RCT encoding compliance tests
      STYLE: ivar initialization into the header file in
      GDCMSeriesFileNames
      COMP: expose TransformCategoryType under LEGACY
      STYLE: cleaning up excessive white space in example
      ENH: update example to support non-overlapping images
      BUG: incorrect neighbor determination in scan-line derived
      filters

Eigen Upstream (1):
      Eigen3 2019-12-09 (c5d991ff)

Flavien Bridault (1):
      COMP: Fix compiling an app with Clang when ITK is built with GCC

GoogleTest Upstream (1):
      GoogleTest 2019-10-03 (703bd9ca)

Hans J. Johnson (3):
      ENH: When using cmake > 3.12 use FindPython3 module
      COMP: Remove searching for python interpreter
      COMP: Allow building basic ITK on computer without python3.5

Hans Johnson (5):
      COMP: Exceptions should be caught by constant reference
      BUG: Second argument to stream `operator<<` as const
      BUG: Print function should be const
      BUG: Add missing const 'GetDataObject' function signature
      BUG: Set 'GetDataObject' function signature to const

Jared Vicory (1):
      ENH: Wrap ComposeImageFilter for complex types

Matt McCormick (34):
      ENH: Update SCIFIO remote module to 2019-12-11 Git master
      ENH: Update stale-bot comment about issue closure
      ENH: Update content links
      DOC: Update ExternalData kitware rsync command
      DOC: Document how to re-run tests with a PR comment
      ENH: Use curl instead of wget in SourceTarball script
      ENH: Add script to identify release authors
      ENH: Use a script to generate the release changelog
      DOC: Update .mailmap to consolidate author identification
      DOC: Add Stephen R. Aylward to .mailmap
      DOC: Set lang attribute for Doxygen docs
      DOC: Add version-specific Doxygen links to the download page
      DOC: .mailmap entry for Hans J. Johnson
      DOC: Update README links
      STYLE: Updates for ImageIORegionGTest,
      DiscreteGaussianImageFilter
      ENH: clang-format.bash detects clang-format-8 executable
      DOC: Update clang-format.bash path
      ENH: Add clang-format linter GitHub Action
      ENH: Apply clang-format to PR with action:ApplyClangFormat
      DOC: Add clang-format check docs in CONTRIBUTING.md
      DOC: Add Zenodo DOI badge
      ENH: Also run clang-format linter on PRs
      DOC: Remove CONTRIBUTING note about ApplyClangFormat action
      DOC: CONTRIBUTING.md link to ITK Software Guide Development
      Guidelines
      COMP: PYTHON_LIBRARY is missing for Windows configuration
      BUG: Workaround Python3 CMake module bugs
      STYLE: Do not use id as variable in igenerator.py
      ENH: Bump macOS Azure CI images to 10.14
      COMP: Quote Python3_LIBRARY argument
      COMP: Get Input const in CastSpatialObjectFilter
      BUG: Address CastSpatialObjectFilter argument to itkTypeMacro
      BUG: Call itk.down_cast on ProcessObject outputs in functional
      call
      DOC: Add Citation section to README
      DOC: Request updates ITKBibliography.bib

Niels Dekker (3):
      STYLE: Make RecursiveSeparableImageFilter MathEMAMAMAM/SMAMAMAM
      static
      STYLE: Make RecursiveSeparableImageFilter::FilterDataArray const
      STYLE: Locally use unique_ptr within
      RecursiveSeparableImageFilter

Niklas Johansson (1):
      STYLE: Remove unused import inspect

Pradeep Garigipati (1):
      BUG: Remove debug console prints from GPU kernels

Sean McBride (2):
      BUG: fixed off-by-one error found by ASan
      COMP: reformulate a self-assignment to fix
      -Wself-assign-overloaded warning

Simon Rit (1):
      ENH: latest version of remote module RTK

Stephen R. Aylward (5):
      BUG: SetScale() and SetSkew() did not recompute offset:
      ScaleSkewVersorT (#1523)
      BUG: itkMetaImageIO.cxx supports more MetaDataDictionary field
      types
      ENH: Adding function to SOToImageFilter simplify output
      definition (#1531)
      ENH: Adding ComposeScaleSkewVersor 3D Transform (#1539)
      ENH: Adding filter and wrapping for casting within SO hierarchy
      (#1576)

Taylor Braun-Jones (1):
      COMP: Fix unit tests for OpenCV 4

VXL Maintainers (1):
      VNL 2019-12-13 (8af77376)

Vladimir S. FONOV (5):
      ENH: Updated script for Eigen third party update
      ENH: Simplification of the ImageSeriesReader nonuniform sampling
      detection
      BUG: fixes issue# 1498
      ENH: Changed NIFTI IO to support different flavors of Analyze
      readers
      COMP: Fixes error "error: no member named 'cend' in
      'std::__1::__map_const..."

Ziv Yaniv (1):
      BUG: SetLabelForUndecidedPixels value ignored.

Update to SimpleITK to 777520
-----------------------------

List of changes:

$ git shortlog 16a622..777520 --no-merges
Boo Irizarry (3):
      update workflow contrubiting.md file
      update contributing file
      update contributing file again

Bradley Lowekamp (23):
      Load SimpleITK version used in SimpleITKExamples sub-project
      Set SimpleITK version to 2.0.0
      Set more restrictive test template globs
      Update ITK Superbuild version along the 5.1 development branch
      Suppress self assignment warning in Image tests.
      For external project add required flags to preprocessor
      Update Superbuild ITK version along ITKv5.1 development
      Update ITK along 5.1 development
      Update ITK along 5.1 development
      Update MeanImageFilter wrapping to directly use VectorImage
      Add docker to build the SimpleITK doxygen
      AZP add Doxygen build and archive creating to packing build
      Add displacement field test case
      Fix double free from buffer ownership change in
      ImageFromVectorImage
      Update the SimpleITK S3 URL to virtual-host style
      Set ReturnBinMidpoint to match default ITKv5 value
      Update Doxygen version to 1.8.17
      Update superbuild version of ITK
      Update testing results of Otsu changed behavior
      Add more testing for RelabelComponentImageFilter
      Fix AZP package find command path
      Add rename const buffer access methods to C# interface.
      Propagate CMake visibility variables in external projects.

Dave Chen (4):
      Fixed grammer and changed ImageJ to Fiji.
      Added CMake/C++ setup documentation
      Added CMake/C++ setup documentation
      Removed 1st and 2nd person usage

Ziv Yaniv (1):
      Adding license and link to license.