### PR TITLE
BUG: Allow reading of FreeSurfer models saved with vtk extension

### DIFF
--- a/Libs/MRML/Core/vtkMRMLFreeSurferModelStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFreeSurferModelStorageNode.cxx
@@ -120,6 +120,13 @@ int vtkMRMLFreeSurferModelStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
   std::string extension = vtkMRMLStorageNode::GetLowercaseExtensionFromFileName(fullName);
   vtkDebugMacro("ReadDataInternal: extension = " << extension.c_str());
 
+  // Node was saved with vtk extension.
+  // Should be handled by vtkMRMLModelStorageNode.
+  if (extension == ".vtk")
+    {
+    return Superclass::ReadDataInternal(refNode);
+    }
+
   int result = 1;
   try
     {


### PR DESCRIPTION
When imported into Slicer, FreeSurfer models are read using a vtkMRMLFreeSurferModelStorageNode.
When saving, the storage node has no write methods, resulting in it falling back on the parent implementation and saving as a vtk (or other vtkMRMLModelNode format).
Trying to read the saved vtk files will cause an error, since vtkMRMLFreeSurferModelStorageNode does not handle non-FreeSurfer file types.

This fixes the issue by adding a workaround to revert to the parent implementation if the file extension is vtk.