### PR TITLE
COMP: removing unused include from vtkImageGrowCutSegment.cxx

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.cxx
@@ -5,7 +5,6 @@
 
 #include <vtkInformation.h>
 #include <vtkInformationVector.h>
-#include <vtkLoggingMacros.h>
 #include <vtkMath.h>
 #include <vtkNew.h>
 #include <vtkObjectFactory.h>


### PR DESCRIPTION
This makes reusing this file outside of Slicer easier.