### PR TITLE
ENH: Add surface based curve interpolation to markups

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
@@ -17,17 +17,26 @@
 
 ==============================================================================*/
 
+// Markups MRML includes
 #include "vtkCurveGenerator.h"
 #include "vtkLinearSpline.h"
 
+// VTK includes
 #include <vtkCardinalSpline.h>
+#include <vtkDijkstraGraphGeodesicPath.h>
 #include <vtkDoubleArray.h>
+#include <vtkInformation.h>
+#include <vtkInformationVector.h>
 #include <vtkKochanekSpline.h>
 #include <vtkParametricSpline.h>
 #include <vtkParametricFunction.h>
 #include "vtkParametricPolynomialApproximation.h"
 #include <vtkPoints.h>
+#include <vtkPointData.h>
+#include <vtkPointLocator.h>
+#include <vtkPolyData.h>
 
+// std includes
 #include <list>
 
 //------------------------------------------------------------------------------
@@ -36,8 +45,8 @@ vtkStandardNewMacro(vtkCurveGenerator);
 //------------------------------------------------------------------------------
 vtkCurveGenerator::vtkCurveGenerator()
 {
-  this->InputPoints = nullptr;
-  this->InputParameters = nullptr;
+  this->SetNumberOfInputPorts(2);
+
   this->SetCurveTypeToLinearSpline();
   this->CurveIsLoop = false;
   this->NumberOfPointsPerInterpolatingSegment = 5;
@@ -50,13 +59,17 @@ vtkCurveGenerator::vtkCurveGenerator()
   this->PolynomialFitMethod = vtkCurveGenerator::POLYNOMIAL_FIT_METHOD_GLOBAL_LEAST_SQUARES;
   this->PolynomialWeightFunction = vtkCurveGenerator::POLYNOMIAL_WEIGHT_FUNCTION_GAUSSIAN;
   this->PolynomialSampleWidth = 0.5;
-  this->OutputPoints = nullptr;
+  this->UseSurfaceScalarWeights = true;
   this->OutputCurveLength = 0.0;
 
   // timestamps for input and output are the same, initially
   this->Modified();
 
   // local storage variables
+  this->PointLocator = vtkSmartPointer<vtkPointLocator>::New();
+  this->PathFilter = vtkSmartPointer<vtkDijkstraGraphGeodesicPath>::New();
+  this->PathFilter->StopWhenEndReachedOn();
+  this->InputParameters = nullptr;
   this->ParametricFunction = nullptr;
 }
 
@@ -68,7 +81,6 @@ vtkCurveGenerator::~vtkCurveGenerator()
 void vtkCurveGenerator::PrintSelf(std::ostream &os, vtkIndent indent)
 {
   Superclass::PrintSelf(os, indent);
-  os << indent << "InputPoints size: " << (this->InputPoints != nullptr ? this->InputPoints->GetNumberOfPoints() : 0) << std::endl;
   os << indent << "InputParameters size: " << (this->InputParameters != nullptr ? this->InputParameters->GetNumberOfTuples() : 0) << std::endl;
   os << indent << "CurveType: " << this->GetCurveTypeAsString(this->CurveType) << std::endl;
   os << indent << "CurveIsLoop: " << this->CurveIsLoop << std::endl;
@@ -77,7 +89,29 @@ void vtkCurveGenerator::PrintSelf(std::ostream &os, vtkIndent indent)
   os << indent << "KochanekTension: " << this->KochanekTension << std::endl;
   os << indent << "KochanekEndsCopyNearestDerivatives: " << this->KochanekEndsCopyNearestDerivatives << std::endl;
   os << indent << "PolynomialOrder: " << this->PolynomialOrder << std::endl;
-  os << indent << "OutputPoints size: " << (this->OutputPoints != nullptr ? this->OutputPoints->GetNumberOfPoints() : 0) << std::endl;
+  os << indent << "UseSurfaceScalarWeights: " << this->UseSurfaceScalarWeights << std::endl;
+}
+
+//----------------------------------------------------------------------------
+int vtkCurveGenerator::FillInputPortInformation(
+  int port, vtkInformation* info)
+{
+  if (port == 0)
+    {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
+    }
+  else if (port == 1)
+    {
+    info->Set(vtkAlgorithm::INPUT_REQUIRED_DATA_TYPE(), "vtkPolyData");
+    info->Set(vtkAlgorithm::INPUT_IS_OPTIONAL(), 1);
+    }
+  else
+    {
+    vtkErrorMacro("Cannot set input info for port " << port);
+    return 0;
+    }
+
+  return 1;
 }
 
 //------------------------------------------------------------------------------
@@ -102,6 +136,10 @@ const char* vtkCurveGenerator::GetCurveTypeAsString(int curveType)
     case vtkCurveGenerator::CURVE_TYPE_POLYNOMIAL:
       {
       return "polynomial";
+      }
+    case vtkCurveGenerator::CURVE_TYPE_SHORTEST_SURFACE_DISTANCE:
+      {
+      return "shortestSurfaceDistance";
       }
     default:
       {
@@ -271,156 +309,92 @@ int vtkCurveGenerator::GetPolynomialWeightFunctionFromString(const char* name)
   return -1;
 }
 
-
-//------------------------------------------------------------------------------
-vtkPoints* vtkCurveGenerator::GetInputPoints()
-{
-  return this->InputPoints;
-}
-
-//------------------------------------------------------------------------------
-void vtkCurveGenerator::SetInputPoints(vtkPoints* points)
-{
-  this->InputPoints = points;
-  this->Modified();
-}
-
-//------------------------------------------------------------------------------
-vtkPoints* vtkCurveGenerator::GetOutputPoints()
-{
-  if (this->UpdateNeeded())
-    {
-    this->Update();
-    }
-  return this->OutputPoints;
-}
-
 //------------------------------------------------------------------------------
 double vtkCurveGenerator::GetOutputCurveLength()
 {
-  if (this->UpdateNeeded())
-    {
-    this->Update();
-    }
   return this->OutputCurveLength;
 }
 
 //------------------------------------------------------------------------------
-void vtkCurveGenerator::SetOutputPoints(vtkPoints* points)
+int vtkCurveGenerator::RequestData(
+  vtkInformation* vtkNotUsed(request),
+  vtkInformationVector** inputVector,
+  vtkInformationVector* outputVector)
 {
-  this->OutputPoints = points;
-  this->Modified();
+  vtkInformation* inInfo = inputVector[0]->GetInformationObject(0);
+  vtkPolyData* inputPolyData = vtkPolyData::SafeDownCast(
+    inInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  if (!inputPolyData)
+    {
+    return 1;
+    }
+
+  vtkPoints* inputPoints = inputPolyData->GetPoints();
+  if (!inputPoints)
+    {
+    return 1;
+    }
+
+  vtkPolyData* inputSurfaceMesh = nullptr;
+  vtkInformation* inInfo2 = inputVector[1]->GetInformationObject(0);
+  if (inInfo2)
+    {
+    inputSurfaceMesh = vtkPolyData::SafeDownCast(
+      inInfo2->Get(vtkDataObject::DATA_OBJECT()));
+    }
+
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+  vtkPolyData* outputPolyData = vtkPolyData::SafeDownCast(
+    outInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  if (!this->GeneratePoints(inputPoints, inputSurfaceMesh, outputPolyData))
+    {
+    return 0;
+    }
+
+  if (!this->GenerateLines(outputPolyData))
+    {
+    return 0;
+    }
+
+  outputPolyData->Squeeze();
+  return 1;
 }
 
 //------------------------------------------------------------------------------
-// LOGIC
-//------------------------------------------------------------------------------
-void vtkCurveGenerator::Update()
-{
-  if (this->InputPoints == nullptr)
-    {
-    vtkWarningMacro("No input points. No curve generation possible.");
-    return;
-    }
-
-  if (!this->UpdateNeeded())
-    {
-    return;
-    }
-
-  switch (this->CurveType)
-    {
-    case vtkCurveGenerator::CURVE_TYPE_LINEAR_SPLINE:
-      {
-      this->SetParametricFunctionToLinearSpline();
-      break;
-      }
-    case vtkCurveGenerator::CURVE_TYPE_CARDINAL_SPLINE:
-      {
-      this->SetParametricFunctionToCardinalSpline();
-      break;
-      }
-    case vtkCurveGenerator::CURVE_TYPE_KOCHANEK_SPLINE:
-      {
-      this->SetParametricFunctionToKochanekSpline();
-      break;
-      }
-    case vtkCurveGenerator::CURVE_TYPE_POLYNOMIAL:
-      {
-      this->SetParametricFunctionToPolynomial();
-      break;
-      }
-    default:
-      {
-      vtkErrorMacro("Error: Unrecognized curve type: " << this->CurveType << ".");
-      break;
-      }
-    }
-  this->GeneratePoints();
-}
-
-//------------------------------------------------------------------------------
-bool vtkCurveGenerator::UpdateNeeded()
-{
-  // assume that if any of these is null, then the user intends for everything to be computed
-  // in normal use, none of these should be null
-  if (this->OutputPoints == nullptr || this->InputPoints == nullptr)
-    {
-    return true;
-    }
-
-  // If this->InputParameters ever become modifiable by the user,
-  // then that modified time will need to be checked here too.
-
-  vtkMTimeType outputModifiedTime = this->OutputPoints->GetMTime();
-  vtkMTimeType curveGeneratorModifiedTime = this->GetMTime();
-  if (curveGeneratorModifiedTime > outputModifiedTime)
-    {
-    return true;
-    }
-
-  vtkMTimeType inputPointsModifiedTime = this->InputPoints->GetMTime();
-  if (inputPointsModifiedTime > outputModifiedTime)
-    {
-    return true;
-    }
-
-  return false;
-}
-
-//------------------------------------------------------------------------------
-void vtkCurveGenerator::SetParametricFunctionToSpline(vtkSpline* xSpline, vtkSpline* ySpline, vtkSpline* zSpline)
+void vtkCurveGenerator::SetParametricFunctionToSpline(vtkPoints* inputPoints, vtkSpline* xSpline, vtkSpline* ySpline, vtkSpline* zSpline)
 {
   vtkSmartPointer<vtkParametricSpline> parametricSpline = vtkSmartPointer<vtkParametricSpline>::New();
   parametricSpline->SetXSpline(xSpline);
   parametricSpline->SetYSpline(ySpline);
   parametricSpline->SetZSpline(zSpline);
-  parametricSpline->SetPoints(this->InputPoints);
+  parametricSpline->SetPoints(inputPoints);
   parametricSpline->SetClosed(this->CurveIsLoop);
   parametricSpline->SetParameterizeByLength(false);
   this->ParametricFunction = parametricSpline;
 }
 
 //------------------------------------------------------------------------------
-void vtkCurveGenerator::SetParametricFunctionToLinearSpline()
+void vtkCurveGenerator::SetParametricFunctionToLinearSpline(vtkPoints* inputPoints)
 {
   vtkSmartPointer<vtkLinearSpline> xSpline = vtkSmartPointer<vtkLinearSpline>::New();
   vtkSmartPointer<vtkLinearSpline> ySpline = vtkSmartPointer<vtkLinearSpline>::New();
   vtkSmartPointer<vtkLinearSpline> zSpline = vtkSmartPointer<vtkLinearSpline>::New();
-  this->SetParametricFunctionToSpline(xSpline, ySpline, zSpline);
+  this->SetParametricFunctionToSpline(inputPoints, xSpline, ySpline, zSpline);
 }
 
 //------------------------------------------------------------------------------
-void vtkCurveGenerator::SetParametricFunctionToCardinalSpline()
+void vtkCurveGenerator::SetParametricFunctionToCardinalSpline(vtkPoints* inputPoints)
 {
   vtkSmartPointer<vtkCardinalSpline> xSpline = vtkSmartPointer<vtkCardinalSpline>::New();
   vtkSmartPointer<vtkCardinalSpline> ySpline = vtkSmartPointer<vtkCardinalSpline>::New();
   vtkSmartPointer<vtkCardinalSpline> zSpline = vtkSmartPointer<vtkCardinalSpline>::New();
-  this->SetParametricFunctionToSpline(xSpline, ySpline, zSpline);
+  this->SetParametricFunctionToSpline(inputPoints, xSpline, ySpline, zSpline);
 }
 
 //------------------------------------------------------------------------------
-void vtkCurveGenerator::SetParametricFunctionToKochanekSpline()
+void vtkCurveGenerator::SetParametricFunctionToKochanekSpline(vtkPoints* inputPoints)
 {
   vtkSmartPointer<vtkKochanekSpline> xSpline = vtkSmartPointer<vtkKochanekSpline>::New();
   xSpline->SetDefaultBias(this->KochanekBias);
@@ -449,9 +423,9 @@ void vtkCurveGenerator::SetParametricFunctionToKochanekSpline()
     zSpline->SetLeftConstraint(1);
     // we assume there are at least 2 points, this is already checked in the Update() functions
     double point0[3];
-    this->InputPoints->GetPoint(0, point0);
+    inputPoints->GetPoint(0, point0);
     double point1[3];
-    this->InputPoints->GetPoint(1, point1);
+    inputPoints->GetPoint(1, point1);
     xSpline->SetLeftValue(point1[0] - point0[0]);
     ySpline->SetLeftValue(point1[1] - point0[1]);
     zSpline->SetLeftValue(point1[2] - point0[2]);
@@ -459,11 +433,11 @@ void vtkCurveGenerator::SetParametricFunctionToKochanekSpline()
     xSpline->SetRightConstraint(1);
     ySpline->SetRightConstraint(1);
     zSpline->SetRightConstraint(1);
-    int numberOfInputPoints = this->InputPoints->GetNumberOfPoints();
+    int numberOfInputPoints = inputPoints->GetNumberOfPoints();
     double pointNMinus2[3];
-    this->InputPoints->GetPoint(numberOfInputPoints - 2, pointNMinus2);
+    inputPoints->GetPoint(numberOfInputPoints - 2, pointNMinus2);
     double pointNMinus1[3];
-    this->InputPoints->GetPoint(numberOfInputPoints - 1, pointNMinus1);
+    inputPoints->GetPoint(numberOfInputPoints - 1, pointNMinus1);
     xSpline->SetRightValue(pointNMinus1[0] - pointNMinus2[0]);
     ySpline->SetRightValue(pointNMinus1[1] - pointNMinus2[1]);
     zSpline->SetRightValue(pointNMinus1[2] - pointNMinus2[2]);
@@ -482,14 +456,14 @@ void vtkCurveGenerator::SetParametricFunctionToKochanekSpline()
     zSpline->SetRightConstraint(0);
     }
 
-  this->SetParametricFunctionToSpline(xSpline, ySpline, zSpline);
+  this->SetParametricFunctionToSpline(inputPoints, xSpline, ySpline, zSpline);
 }
 
 //------------------------------------------------------------------------------
-void vtkCurveGenerator::SetParametricFunctionToPolynomial()
+void vtkCurveGenerator::SetParametricFunctionToPolynomial(vtkPoints* inputPoints)
 {
   vtkSmartPointer< vtkParametricPolynomialApproximation > polynomial = vtkSmartPointer< vtkParametricPolynomialApproximation >::New();
-  polynomial->SetPoints(this->InputPoints);
+  polynomial->SetPoints(inputPoints);
   polynomial->SetPolynomialOrder(this->PolynomialOrder);
 
   if (this->InputParameters == nullptr)
@@ -499,11 +473,11 @@ void vtkCurveGenerator::SetParametricFunctionToPolynomial()
 
   if (this->PolynomialPointSortingMethod == vtkCurveGenerator::SORTING_METHOD_INDEX)
     {
-    vtkCurveGenerator::SortByIndex(this->InputPoints, this->InputParameters);
+    vtkCurveGenerator::SortByIndex(inputPoints, this->InputParameters);
     }
   else if (this->PolynomialPointSortingMethod == vtkCurveGenerator::SORTING_METHOD_MINIMUM_SPANNING_TREE_POSITION)
     {
-    vtkCurveGenerator::SortByMinimumSpanningTreePosition(this->InputPoints, this->InputParameters);
+    vtkCurveGenerator::SortByMinimumSpanningTreePosition(inputPoints, this->InputParameters);
     }
   else
     {
@@ -553,33 +527,78 @@ void vtkCurveGenerator::SetParametricFunctionToPolynomial()
 }
 
 //------------------------------------------------------------------------------
-void vtkCurveGenerator::GeneratePoints()
+int vtkCurveGenerator::GeneratePoints(vtkPoints* inputPoints, vtkPolyData* inputSurface, vtkPolyData* outputPolyData)
 {
-  if (this->InputPoints == nullptr)
-    {
-    vtkErrorMacro("Input points are null, so curve points cannot be generated.");
-    return;
-    }
-  if (this->ParametricFunction == nullptr)
-    {
-    vtkErrorMacro("Parametric function is null, so curve points cannot be generated.");
-    return;
-    }
-
-  if (this->OutputPoints == nullptr)
-    {
-    this->OutputPoints = vtkSmartPointer< vtkPoints >::New();
-    }
-  else
-    {
-    this->OutputPoints->Reset();
-    }
+  vtkNew<vtkPoints> outputPoints;
   this->OutputCurveLength = 0.0;
+  this->CorrespondingControlPointIds.clear();
 
-  int numberOfInputPoints = this->InputPoints->GetNumberOfPoints();
+  switch (this->CurveType)
+  {
+  case vtkCurveGenerator::CURVE_TYPE_LINEAR_SPLINE:
+  case vtkCurveGenerator::CURVE_TYPE_CARDINAL_SPLINE:
+  case vtkCurveGenerator::CURVE_TYPE_KOCHANEK_SPLINE:
+  case vtkCurveGenerator::CURVE_TYPE_POLYNOMIAL:
+    {
+    if (!this->GeneratePointsFromFunction(inputPoints, outputPoints))
+      {
+      return 0;
+      }
+    break;
+    }
+  case vtkCurveGenerator::CURVE_TYPE_SHORTEST_SURFACE_DISTANCE:
+    if (!this->GeneratePointsFromSurface(inputPoints, inputSurface, outputPoints))
+      {
+      return 0;
+      }
+    break;
+  default:
+    {
+    vtkErrorMacro("Error: Unrecognized curve type: " << this->CurveType << ".");
+    return 0;
+    }
+  }
+
+  outputPolyData->SetPoints(outputPoints);
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+int vtkCurveGenerator::GeneratePointsFromFunction(vtkPoints* inputPoints, vtkPoints* outputPoints)
+{
+  int numberOfInputPoints = inputPoints->GetNumberOfPoints();
   if (numberOfInputPoints <= 1)
     {
-    return;
+    return 0;
+    }
+
+  switch (this->CurveType)
+    {
+    case vtkCurveGenerator::CURVE_TYPE_LINEAR_SPLINE:
+      {
+      this->SetParametricFunctionToLinearSpline(inputPoints);
+      break;
+      }
+    case vtkCurveGenerator::CURVE_TYPE_CARDINAL_SPLINE:
+      {
+      this->SetParametricFunctionToCardinalSpline(inputPoints);
+      break;
+      }
+    case vtkCurveGenerator::CURVE_TYPE_KOCHANEK_SPLINE:
+      {
+      this->SetParametricFunctionToKochanekSpline(inputPoints);
+      break;
+      }
+    case vtkCurveGenerator::CURVE_TYPE_POLYNOMIAL:
+      {
+      this->SetParametricFunctionToPolynomial(inputPoints);
+      break;
+      }
+    default:
+      {
+      vtkErrorMacro("Error: Unrecognized curve type: " << this->CurveType << ".");
+      break;
+      }
     }
 
   int numberOfSegments = 0; // temporary value
@@ -599,7 +618,7 @@ void vtkCurveGenerator::GeneratePoints()
     double sampleParameter = pointIndex / (double)(totalNumberOfPoints - 1);
     double curvePoint[3];
     this->ParametricFunction->Evaluate(&sampleParameter, curvePoint, nullptr);
-    this->OutputPoints->InsertNextPoint(curvePoint);
+    outputPoints->InsertNextPoint(curvePoint);
     if (pointIndex > 0)
       {
       double segmentLength = sqrt(vtkMath::Distance2BetweenPoints(previousPoint, curvePoint));
@@ -608,7 +627,143 @@ void vtkCurveGenerator::GeneratePoints()
     previousPoint[0] = curvePoint[0];
     previousPoint[1] = curvePoint[1];
     previousPoint[2] = curvePoint[2];
+  }
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+int vtkCurveGenerator::GeneratePointsFromSurface(vtkPoints* inputPoints, vtkPolyData* inputSurface, vtkPoints* outputPoints)
+{
+  // If there is no surface, there are no points. Don't report as an error.
+  if (!inputSurface)
+    {
+    return 1;
     }
+
+  // If there are no input points, there are output points. Don't report as an error.
+  vtkIdType numberOfInputPoints = inputPoints->GetNumberOfPoints();
+  if (numberOfInputPoints <= 1)
+    {
+    return 1;
+    }
+
+  vtkIdType numberOfSegments = 0;
+  if (this->CurveIsLoop)
+    {
+    numberOfSegments = numberOfInputPoints;
+    }
+  else
+    {
+    numberOfSegments = (numberOfInputPoints - 1);
+    }
+
+  this->PathFilter->SetInputData(inputSurface);
+  this->PointLocator->SetDataSet(inputSurface);
+  this->PointLocator->BuildLocator();
+
+  for (vtkIdType controlPointIndex = 0; controlPointIndex < numberOfSegments; ++controlPointIndex)
+    {
+    double controlPoint1[3] = { 0 };
+    inputPoints->GetPoint(controlPointIndex, controlPoint1);
+    vtkIdType id1 = this->PointLocator->FindClosestPoint(controlPoint1);
+
+    double controlPoint2[3] = { 0 };
+    inputPoints->GetPoint((controlPointIndex + 1) % numberOfInputPoints, controlPoint2);
+    vtkIdType id2 = this->PointLocator->FindClosestPoint(controlPoint2);
+
+    // If no scalar array is active on the points, and UseScalarWeights is enabled, the dijkstra filter will crash.
+    // To avoid this, UseScalarWeights is temporarily disabled.
+    bool useSurfaceScalarWeightsTemp = this->UseSurfaceScalarWeights;
+    if (!inputSurface->GetPointData() || !inputSurface->GetPointData()->GetScalars())
+      {
+      this->UseSurfaceScalarWeights = false;
+      }
+
+    // Path is traced backward, so start vertex should be point2, and end should be point1.
+    this->PathFilter->SetStartVertex(id2);
+    this->PathFilter->SetEndVertex(id1);
+    if (static_cast<bool>(this->PathFilter->GetUseScalarWeights()) != this->UseSurfaceScalarWeights)
+      {
+      this->PathFilter->SetUseScalarWeights(this->UseSurfaceScalarWeights);
+      // Edge weights are not recalculated unless the input surface is modified.
+      inputSurface->Modified();
+      }
+
+    this->PathFilter->Update();
+    this->UseSurfaceScalarWeights = useSurfaceScalarWeightsTemp;
+
+    vtkPolyData* outputPath = this->PathFilter->GetOutput();
+    double previousPoint[3];
+    for (vtkIdType pointIndex = 0; pointIndex < outputPath->GetNumberOfPoints(); ++pointIndex)
+      {
+      double curvePoint[3] = { 0 };
+      outputPath->GetPoint(pointIndex, curvePoint);
+
+      if (controlPointIndex == 0 || pointIndex > 0)
+        {
+        vtkIdType outputPointId = outputPoints->InsertNextPoint(curvePoint);
+        if (this->CorrespondingControlPointIds.size() <= controlPointIndex)
+          {
+          this->CorrespondingControlPointIds.push_back(outputPointId);
+          }
+
+        if (pointIndex > 0)
+          {
+          double segmentLength = sqrt(vtkMath::Distance2BetweenPoints(previousPoint, curvePoint));
+          this->OutputCurveLength += segmentLength;
+          }
+        }
+      previousPoint[0] = curvePoint[0];
+      previousPoint[1] = curvePoint[1];
+      previousPoint[2] = curvePoint[2];
+      }
+    }
+  return 1;
+}
+
+//------------------------------------------------------------------------------
+int vtkCurveGenerator::GenerateLines(vtkPolyData* polyData)
+{
+  // Update lines: a single cell containing a line with point
+  // indices: 0, 1, ..., last point (and an extra 0 if closed curve).
+  vtkIdType numberOfPoints = polyData->GetNumberOfPoints();
+  vtkNew<vtkCellArray> lines;
+  if (numberOfPoints > 1)
+    {
+    bool loop = (numberOfPoints > 2 && this->CurveIsLoop);
+    vtkIdType numberOfCellPoints = (loop ? numberOfPoints + 1 : numberOfPoints);
+
+    // Only regenerate indices if necessary
+    bool needToUpdateLines = true;
+    if (lines->GetNumberOfCells() == 1)
+      {
+      vtkIdType currentNumberOfCellPoints = 0;
+      vtkIdType* currentCellPoints = nullptr;
+      lines->GetCell(0, currentNumberOfCellPoints, currentCellPoints);
+
+      if (currentNumberOfCellPoints == numberOfCellPoints)
+        {
+        needToUpdateLines = false;
+        }
+      }
+
+    if (needToUpdateLines)
+      {
+      lines->Reset();
+      lines->InsertNextCell(numberOfCellPoints);
+      for (int i = 0; i < numberOfPoints; i++)
+        {
+        lines->InsertCellPoint(i);
+        }
+      if (loop)
+        {
+        lines->InsertCellPoint(0);
+        }
+      lines->Modified();
+      }
+    }
+  polyData->SetLines(lines);
+  return 1;
 }
 
 //------------------------------------------------------------------------------
@@ -838,4 +993,25 @@ bool vtkCurveGenerator::IsInterpolatingCurve()
   return (this->CurveType == CURVE_TYPE_LINEAR_SPLINE
     || this->CurveType == CURVE_TYPE_CARDINAL_SPLINE
     || this->CurveType == CURVE_TYPE_KOCHANEK_SPLINE);
+}
+
+//------------------------------------------------------------------------------
+vtkIdList* vtkCurveGenerator::GetSurfacePointIds()
+{
+  return this->PathFilter->GetIdList();
+}
+
+//------------------------------------------------------------------------------
+vtkIdType vtkCurveGenerator::GetControlPointIdFromInterpolatedPointId(vtkIdType outputPointId)
+{
+  int controlId = -1;
+  for (vtkIdType id : this->CorrespondingControlPointIds)
+    {
+    if (outputPointId < id)
+      {
+      return controlId;
+      }
+    ++controlId;
+    }
+  return controlId;
 }

--- a/Modules/Loadable/Markups/MRML/vtkCurveGenerator.h
+++ b/Modules/Loadable/Markups/MRML/vtkCurveGenerator.h
@@ -21,11 +21,13 @@
 #define __vtkCurveGenerator_h
 
 // vtk includes
-#include <vtkObject.h>
 #include <vtkParametricFunction.h>
+#include <vtkPolyData.h>
+#include <vtkPolyDataAlgorithm.h>
 #include <vtkSetGet.h>
 #include <vtkSmartPointer.h>
 
+class vtkDijkstraGraphGeodesicPath;
 class vtkDoubleArray;
 class vtkPoints;
 class vtkSpline;
@@ -33,28 +35,29 @@ class vtkSpline;
 // export
 #include "vtkSlicerMarkupsModuleMRMLExport.h"
 
-// A class to generate curves from input polydata
-class VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkCurveGenerator : public vtkObject
+/// Filter that generates curves between points of an input polydata
+class VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkCurveGenerator : public vtkPolyDataAlgorithm
 {
 public:
-  vtkTypeMacro(vtkCurveGenerator, vtkObject);
+  vtkTypeMacro(vtkCurveGenerator, vtkPolyDataAlgorithm);
   static vtkCurveGenerator* New();
 
-  void PrintSelf(ostream &os, vtkIndent indent) override;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  // This indicates whether the curve should loop back in on itself,
-  // connecting the last point back to the first point (disabled by default).
+  /// This indicates whether the curve should loop back in on itself,
+  /// connecting the last point back to the first point (disabled by default).
   vtkSetMacro(CurveIsLoop, bool);
   vtkGetMacro(CurveIsLoop, bool);
   vtkBooleanMacro(CurveIsLoop, bool);
 
-  // type of curve to generate
+  /// Type of curve to generate
   enum
     {
     CURVE_TYPE_LINEAR_SPLINE = 0, // Curve interpolates between input points with straight lines
     CURVE_TYPE_CARDINAL_SPLINE, // Curve interpolates between input points smoothly
     CURVE_TYPE_KOCHANEK_SPLINE, // Curve interpolates between input points smoothly, generalized
     CURVE_TYPE_POLYNOMIAL, // Curve approximates the input points with a polynomial fit
+    CURVE_TYPE_SHORTEST_SURFACE_DISTANCE, // Curve finds the closest path along a the edges of a surface mesh
     CURVE_TYPE_LAST // Valid types go above this line
     };
   vtkGetMacro(CurveType, int);
@@ -65,30 +68,31 @@ public:
   void SetCurveTypeToCardinalSpline() { this->SetCurveType(CURVE_TYPE_CARDINAL_SPLINE); }
   void SetCurveTypeToKochanekSpline() { this->SetCurveType(CURVE_TYPE_KOCHANEK_SPLINE); }
   void SetCurveTypeToPolynomial() { this->SetCurveType(CURVE_TYPE_POLYNOMIAL); }
+  void SetCurveTypeToShortestSurfaceDistance() { this->SetCurveType(CURVE_TYPE_SHORTEST_SURFACE_DISTANCE); }
 
   virtual bool IsInterpolatingCurve();
 
-  // Sample an *interpolating* curve this many times per segment (pair of points in sequence). Range 1 and up. Default 5.
+  /// Sample an *interpolating* curve this many times per segment (pair of points in sequence). Range 1 and up. Default 5.
   vtkSetMacro(NumberOfPointsPerInterpolatingSegment, int);
   vtkGetMacro(NumberOfPointsPerInterpolatingSegment, int);
 
-  // Bias of derivative toward previous point (negative value) or next point. Range -1 to 1. Default 0.
+  /// Bias of derivative toward previous point (negative value) or next point. Range -1 to 1. Default 0.
   vtkGetMacro(KochanekBias, double);
   vtkSetMacro(KochanekBias, double);
 
-  // Make the curve sharper( negative value) or smoother (positive value). Range -1 to 1. Default 0.
+  /// Make the curve sharper( negative value) or smoother (positive value). Range -1 to 1. Default 0.
   vtkGetMacro(KochanekContinuity, double);
   vtkSetMacro(KochanekContinuity, double);
 
-  // How quickly the curve turns, higher values like tightening an elastic. Range -1 to 1. Default 0.
+  /// How quickly the curve turns, higher values like tightening an elastic. Range -1 to 1. Default 0.
   vtkGetMacro(KochanekTension, double);
   vtkSetMacro(KochanekTension, double);
 
-  // Make the ends of the curve 'straighter' by copying derivative of the nearest point. Default false.
+  /// Make the ends of the curve 'straighter' by copying derivative of the nearest point. Default false.
   vtkGetMacro(KochanekEndsCopyNearestDerivatives, bool);
   vtkSetMacro(KochanekEndsCopyNearestDerivatives, bool);
 
-  // Set the order of the polynomials for fitting. Range 1 to 9 (equation becomes unstable from 9 upward). Default 1.
+  /// Set the order of the polynomials for fitting. Range 1 to 9 (equation becomes unstable from 9 upward). Default 1.
   vtkGetMacro(PolynomialOrder, int);
   vtkSetMacro(PolynomialOrder, int);
 
@@ -102,23 +106,25 @@ public:
   //virtual void SetInputParameters( vtkDoubleArray* );
   //virtual vtkDoubleArray* GetInputParameters();
 
-  // Set the sorting method for points in a polynomial.
-  enum {
+  /// Set the sorting method for points in a polynomial.
+  enum
+    {
     SORTING_METHOD_INDEX = 0,
     SORTING_METHOD_MINIMUM_SPANNING_TREE_POSITION,
     SORTING_METHOD_LAST // valid types should be written above this line
-  };
+    };
   vtkGetMacro(PolynomialPointSortingMethod, int);
   vtkSetMacro(PolynomialPointSortingMethod, int);
   static const char* GetPolynomialPointSortingMethodAsString(int id);
   static int GetPolynomialPointSortingMethodFromString(const char* name);
   void SetPolynomialPointSortingMethodToIndex() { this->SetPolynomialPointSortingMethod(vtkCurveGenerator::SORTING_METHOD_INDEX); }
-  void SetPolynomialPointSortingMethodToMinimumSpanningTreePosition() {
+  void SetPolynomialPointSortingMethodToMinimumSpanningTreePosition()
+    {
     this->SetPolynomialPointSortingMethod(vtkCurveGenerator::SORTING_METHOD_MINIMUM_SPANNING_TREE_POSITION);
-  }
+    }
 
-  // Set the type of fit for polynomials
-  // see corresponding entries in vtkParametricPolynomialApproximation.h for more information
+  /// Set the type of fit for polynomials
+  /// see corresponding entries in vtkParametricPolynomialApproximation.h for more information
   enum
     {
     POLYNOMIAL_FIT_METHOD_GLOBAL_LEAST_SQUARES = 0,
@@ -132,12 +138,12 @@ public:
   void SetPolynomialFitMethodToGlobalLeastSquares() { this->SetPolynomialFitMethod(vtkCurveGenerator::POLYNOMIAL_FIT_METHOD_GLOBAL_LEAST_SQUARES); }
   void SetPolynomialFitMethodToMovingLeastSquares() { this->SetPolynomialFitMethod(vtkCurveGenerator::POLYNOMIAL_FIT_METHOD_MOVING_LEAST_SQUARES); }
 
-  // Set the sampling distance (in parameter space) for moving least squares sampling
+  /// Set the sampling distance (in parameter space) for moving least squares sampling
   vtkGetMacro(PolynomialSampleWidth, double);
   vtkSetMacro(PolynomialSampleWidth, double);
 
-  // Set the weight function for moving least squares polynomial fits
-  // see corresponding entries in vtkParametricPolynomialApproximation.h for more information
+  /// Set the weight function for moving least squares polynomial fits
+  /// see corresponding entries in vtkParametricPolynomialApproximation.h for more information
   enum
     {
     POLYNOMIAL_WEIGHT_FUNCTION_RECTANGULAR = 0,
@@ -155,31 +161,25 @@ public:
   void SetPolynomialWeightFunctionToCosine() { this->SetPolynomialWeightFunction(vtkCurveGenerator::POLYNOMIAL_WEIGHT_FUNCTION_COSINE); }
   void SetPolynomialWeightFunctionToGaussian() { this->SetPolynomialWeightFunction(vtkCurveGenerator::POLYNOMIAL_WEIGHT_FUNCTION_GAUSSIAN); }
 
-  // Set the points that the curve should be based on
-  vtkPoints* GetInputPoints();
-  void SetInputPoints(vtkPoints*);
+  /// If the surface scalars should be used to weight the distances in the pathfinding algorithm
+  vtkGetMacro(UseSurfaceScalarWeights, bool);
+  vtkSetMacro(UseSurfaceScalarWeights, bool);
+  vtkBooleanMacro(UseSurfaceScalarWeights, bool);
 
-  // output sampled points
-  vtkPoints* GetOutputPoints();
-  void SetOutputPoints(vtkPoints*);
+  /// Get the control point id from the interpolated point id
+  /// Currently only works for shortest surface distance
+  vtkIdType GetControlPointIdFromInterpolatedPointId(vtkIdType interpolatedPointId);
 
+  /// Get the list of curve point ids on the surface mesh
+  vtkIdList* GetSurfacePointIds();
+
+  /// Get the length of the curve
   double GetOutputCurveLength();
 
-  /// The internal instance of the current parametric function
-  /// use of the curve for other computations.
+  /// The internal instance of the current parametric function use of the curve for other computations.
   vtkParametricFunction* GetParametricFunction() { return this->ParametricFunction.GetPointer(); };
 
-  // logic
-  void Update();
-
 protected:
-  vtkCurveGenerator();
-  ~vtkCurveGenerator() override;
-
-private:
-  // inputs
-  vtkSmartPointer< vtkPoints > InputPoints;
-
   // input parameters
   int NumberOfPointsPerInterpolatingSegment;
   int CurveType;
@@ -193,27 +193,38 @@ private:
   int PolynomialFitMethod;
   double PolynomialSampleWidth;
   int PolynomialWeightFunction;
+  bool UseSurfaceScalarWeights;
+  std::vector<vtkIdType> CorrespondingControlPointIds;
 
   // internal storage
-  vtkSmartPointer< vtkDoubleArray > InputParameters;
-  vtkSmartPointer< vtkParametricFunction > ParametricFunction;
+  vtkSmartPointer<vtkPointLocator> PointLocator;
+  vtkSmartPointer<vtkDijkstraGraphGeodesicPath> PathFilter;
+  vtkSmartPointer<vtkDoubleArray> InputParameters;
+  vtkSmartPointer<vtkParametricFunction> ParametricFunction;
 
   // output
-  vtkSmartPointer< vtkPoints > OutputPoints;
   double OutputCurveLength;
 
   // logic
-  void SetParametricFunctionToSpline(vtkSpline* xSpline, vtkSpline* ySpline, vtkSpline* zSpline);
-  void SetParametricFunctionToLinearSpline();
-  void SetParametricFunctionToCardinalSpline();
-  void SetParametricFunctionToKochanekSpline();
-  void SetParametricFunctionToPolynomial();
-  bool UpdateNeeded();
-  void GeneratePoints();
+  void SetParametricFunctionToSpline(vtkPoints* inputPoints, vtkSpline* xSpline, vtkSpline* ySpline, vtkSpline* zSpline);
+  void SetParametricFunctionToLinearSpline(vtkPoints* inputPoints);
+  void SetParametricFunctionToCardinalSpline(vtkPoints* inputPoints);
+  void SetParametricFunctionToKochanekSpline(vtkPoints* inputPoints);
+  void SetParametricFunctionToPolynomial(vtkPoints* inputPoints);
+  int GeneratePoints(vtkPoints* inputPoints, vtkPolyData* inputSurface, vtkPolyData* outputPolyData);
+  int GeneratePointsFromFunction(vtkPoints* inputPoints, vtkPoints* outputPoints);
+  int GeneratePointsFromSurface(vtkPoints* inputPoints, vtkPolyData* inputSurface, vtkPoints* outputPoints);
+  int GenerateLines(vtkPolyData* polyData);
 
   static void SortByIndex(vtkPoints*, vtkDoubleArray*);
   static void SortByMinimumSpanningTreePosition(vtkPoints*, vtkDoubleArray*);
 
+  int FillInputPortInformation(int port, vtkInformation* info) override;
+  int RequestData(vtkInformation* request, vtkInformationVector** inputVector, vtkInformationVector* outputVector) override;
+
+protected:
+  vtkCurveGenerator();
+  ~vtkCurveGenerator() override;
   vtkCurveGenerator(const vtkCurveGenerator&) = delete;
   void operator=(const vtkCurveGenerator&) = delete;
 };

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -26,18 +26,22 @@
 #include "vtkMRMLUnitNode.h"
 
 // VTK includes
+#include <vtkArrayCalculator.h>
 #include <vtkBoundingBox.h>
+#include <vtkCallbackCommand.h>
+#include <vtkCellLocator.h>
+#include <vtkCommand.h>
 #include <vtkCutter.h>
 #include <vtkDoubleArray.h>
 #include <vtkFrenetSerretFrame.h>
 #include <vtkGeneralTransform.h>
 #include <vtkGenericCell.h>
-
 #include <vtkLine.h>
 #include <vtkMatrix4x4.h>
 #include <vtkNew.h>
 #include <vtkOBBTree.h>
 #include <vtkObjectFactory.h>
+#include <vtkPassArrays.h>
 #include <vtkPlane.h>
 #include <vtkPointData.h>
 #include <vtkPointLocator.h>
@@ -48,8 +52,6 @@
 
 // STD includes
 #include <sstream>
-
-class vtkMRMLModelNode;
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLMarkupsCurveNode);
@@ -63,6 +65,25 @@ vtkMRMLMarkupsCurveNode::vtkMRMLMarkupsCurveNode()
   this->RequiredNumberOfControlPoints = 1e6;
   this->CurveGenerator->SetCurveTypeToCardinalSpline();
   this->CurveGenerator->SetNumberOfPointsPerInterpolatingSegment(10);
+  this->CurveGenerator->SetUseSurfaceScalarWeights(false);
+
+  this->PolyDataToWorldTransformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+  this->PolyDataToWorldTransformer->SetTransform(vtkNew<vtkGeneralTransform>());
+
+  this->ScalarCalculator = vtkSmartPointer<vtkArrayCalculator>::New();
+  this->ScalarCalculator->AddObserver(vtkCommand::ModifiedEvent, this->MRMLCallbackCommand);
+  this->SetSurfaceScalarWeightFunction("activeScalar");
+
+  this->PassArray = vtkSmartPointer<vtkPassArrays>::New();
+  this->PassArray->AddObserver(vtkCommand::ModifiedEvent, this->MRMLCallbackCommand);
+
+  vtkNew<vtkIntArray> events;
+  events->InsertNextTuple1(vtkCommand::ModifiedEvent);
+  events->InsertNextTuple1(vtkMRMLModelNode::MeshModifiedEvent);
+  events->InsertNextTuple1(vtkMRMLTransformableNode::TransformModifiedEvent);
+  this->AddNodeReferenceRole(this->GetSurfaceMeshNodeReferenceRole(), this->GetSurfaceMeshNodeReferenceMRMLAttributeName(), events);
+
+  this->ActiveScalar = "";
 }
 
 //----------------------------------------------------------------------------
@@ -77,6 +98,8 @@ void vtkMRMLMarkupsCurveNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBeginMacro(of);
   vtkMRMLWriteXMLEnumMacro(curveType, CurveType);
   vtkMRMLWriteXMLIntMacro(numberOfPointsPerInterpolatingSegment, NumberOfPointsPerInterpolatingSegment);
+  vtkMRMLWriteXMLBooleanMacro(useSurfaceScalarWeights, UseSurfaceScalarWeights);
+  vtkMRMLWriteXMLStringMacro(surfaceScalarWeightFunction, SurfaceScalarWeightFunction);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -89,6 +112,8 @@ void vtkMRMLMarkupsCurveNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBeginMacro(atts);
   vtkMRMLReadXMLEnumMacro(curveType, CurveType);
   vtkMRMLReadXMLIntMacro(numberOfPointsPerInterpolatingSegment, NumberOfPointsPerInterpolatingSegment);
+  vtkMRMLReadXMLBooleanMacro(useSurfaceScalarWeights, UseSurfaceScalarWeights);
+  vtkMRMLReadXMLStringMacro(surfaceScalarWeightFunction, SurfaceScalarWeightFunction);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
@@ -104,6 +129,8 @@ void vtkMRMLMarkupsCurveNode::Copy(vtkMRMLNode *anode)
   vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyEnumMacro(CurveType);
   vtkMRMLCopyIntMacro(NumberOfPointsPerInterpolatingSegment);
+  vtkMRMLCopyBooleanMacro(UseSurfaceScalarWeights);
+  vtkMRMLCopyStringMacro(SurfaceScalarWeightFunction);
   vtkMRMLCopyEndMacro();
 
   this->EndModify(disabledModify);
@@ -117,6 +144,8 @@ void vtkMRMLMarkupsCurveNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintEnumMacro(CurveType);
   vtkMRMLPrintIntMacro(NumberOfPointsPerInterpolatingSegment);
+  vtkMRMLPrintBooleanMacro(UseSurfaceScalarWeights);
+  vtkMRMLPrintStringMacro(SurfaceScalarWeightFunction);
   vtkMRMLPrintEndMacro();
 }
 
@@ -199,6 +228,7 @@ bool vtkMRMLMarkupsCurveNode::SetControlPointLabels(vtkStringArray* labels, vtkP
 {
   return this->SetControlPointLabelsWorld(labels, points);
 }
+
 //---------------------------------------------------------------------------
 bool vtkMRMLMarkupsCurveNode::ResampleCurveSurface(double controlPointDistance, vtkMRMLModelNode* modelNode, double maximumSearchRadiusTolerance)
 {
@@ -346,6 +376,7 @@ bool vtkMRMLMarkupsCurveNode::ResampleCurveSurface(double controlPointDistance, 
   this->SetControlPointLabelsWorld(originalLabels, originalControlPoints);
   return true;
 }
+
 //---------------------------------------------------------------------------
 bool vtkMRMLMarkupsCurveNode::ConstrainPointsToSurface(vtkPoints* originalPoints, vtkPoints* normalVectors, vtkPolyData* surfacePolydata,
   vtkPoints* surfacePoints, double maximumSearchRadiusTolerance)
@@ -977,6 +1008,16 @@ void vtkMRMLMarkupsCurveNode::SetCurveTypeToPolynomial()
 }
 
 //---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::SetCurveTypeToShortestSurfaceDistance(vtkMRMLModelNode* modelNode)
+{
+  this->CurveGenerator->SetCurveTypeToShortestSurfaceDistance();
+  if (modelNode)
+    {
+    this->SetAndObserveModelNode(modelNode);
+    }
+}
+
+//---------------------------------------------------------------------------
 int vtkMRMLMarkupsCurveNode::GetNumberOfPointsPerInterpolatingSegment()
 {
   return this->CurveGenerator->GetNumberOfPointsPerInterpolatingSegment();
@@ -1071,4 +1112,217 @@ void vtkMRMLMarkupsCurveNode::UpdateMeasurements()
     this->SetNthMeasurement(0, "length", length, unit, printFormat);
     }
   this->WriteMeasurementsToDescription();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::ProcessMRMLEvents(vtkObject* caller,
+                                             unsigned long event,
+                                             void* callData)
+{
+  if (caller == this->GetNodeReference(this->GetSurfaceMeshNodeReferenceRole()))
+    {
+    this->UpdateScalarVariables();
+    if (event == vtkMRMLTransformableNode::TransformModifiedEvent)
+      {
+      vtkMRMLTransformableNode* meshNode = vtkMRMLTransformableNode::SafeDownCast(caller);
+      if (meshNode)
+        {
+        vtkMRMLTransformNode* parentTransformNode = meshNode->GetParentTransformNode();
+        if (parentTransformNode)
+          {
+          vtkNew<vtkGeneralTransform> modelToWorldTransform;
+          modelToWorldTransform->Identity();
+          parentTransformNode->GetTransformToWorld(modelToWorldTransform);
+          this->PolyDataToWorldTransformer->SetTransform(modelToWorldTransform);
+          }
+        }
+      }
+    }
+  else if (caller == this->ScalarCalculator.GetPointer())
+    {
+    int n = -1;
+    this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointModifiedEvent, static_cast<void*>(&n));
+    }
+
+  Superclass::ProcessMRMLEvents(caller, event, callData);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::OnNodeReferenceAdded(vtkMRMLNodeReference* reference)
+{
+  if (strcmp(reference->GetReferenceRole(), this->GetSurfaceMeshNodeReferenceRole()) == 0)
+    {
+    this->UpdateModelNode();
+    }
+
+  Superclass::OnNodeReferenceAdded(reference);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::OnNodeReferenceModified(vtkMRMLNodeReference* reference)
+{
+  if (strcmp(reference->GetReferenceRole(), this->GetSurfaceMeshNodeReferenceRole()) == 0)
+    {
+    this->UpdateModelNode();
+    }
+
+  Superclass::OnNodeReferenceModified(reference);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::OnNodeReferenceRemoved(vtkMRMLNodeReference* reference)
+{
+  if (strcmp(reference->GetReferenceRole(), this->GetSurfaceMeshNodeReferenceRole()) == 0)
+    {
+    this->UpdateModelNode();
+    }
+  Superclass::OnNodeReferenceRemoved(reference);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::SetAndObserveModelNode(vtkMRMLModelNode* modelNode)
+{
+  this->SetAndObserveNodeReferenceID(this->GetSurfaceMeshNodeReferenceRole(), modelNode ? modelNode->GetID() : nullptr);
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLModelNode* vtkMRMLMarkupsCurveNode::GetModelNode()
+{
+  return vtkMRMLModelNode::SafeDownCast(this->GetNodeReference(this->GetSurfaceMeshNodeReferenceRole()));
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsCurveNode::GetUseSurfaceScalarWeights()
+{
+  return this->CurveGenerator->GetUseSurfaceScalarWeights();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::SetUseSurfaceScalarWeights(bool useSurfaceScalarWeights)
+{
+  this->CurveGenerator->SetUseSurfaceScalarWeights(useSurfaceScalarWeights);
+}
+
+//---------------------------------------------------------------------------
+const char* vtkMRMLMarkupsCurveNode::GetSurfaceScalarWeightFunction()
+{
+  return this->ScalarCalculator->GetFunction();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::SetSurfaceScalarWeightFunction(const char* function)
+{
+  this->ScalarCalculator->SetFunction(function);
+  this->UpdateScalarVariables();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::UpdateModelNode()
+{
+  this->UpdateScalarVariables();
+
+  vtkMRMLModelNode* modelNode = this->GetModelNode();
+  if (modelNode)
+    {
+    this->PolyDataToWorldTransformer->SetInputConnection(modelNode->GetPolyDataConnection());
+
+    this->ScalarCalculator->SetInputConnection(this->PolyDataToWorldTransformer->GetOutputPort());
+    this->ScalarCalculator->SetAttributeTypeToPointData();
+    this->ScalarCalculator->SetResultArrayName("weights");
+    this->ScalarCalculator->SetResultArrayType(VTK_FLOAT);
+
+    this->PassArray->SetInputConnection(this->ScalarCalculator->GetOutputPort());
+    this->PassArray->AddArray(vtkDataObject::POINT, "weights");
+    this->PassArray->UseFieldTypesOn();
+    this->PassArray->AddFieldType(vtkDataObject::POINT);
+    this->PassArray->AddFieldType(vtkDataObject::CELL);
+
+    this->CurveGenerator->SetInputConnection(1, this->ScalarCalculator->GetOutputPort());
+    }
+  else
+    {
+    this->ScalarCalculator->RemoveAllInputConnections(0);
+    this->CurveGenerator->RemoveInputConnection(1, this->ScalarCalculator->GetOutputPort());
+    }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsCurveNode::UpdateScalarVariables()
+{
+  vtkMRMLModelNode* modelNode = this->GetModelNode();
+  if (!modelNode)
+    {
+    return;
+    }
+
+  vtkPolyData* polyData = modelNode->GetPolyData();
+  if (!polyData)
+    {
+    return;
+    }
+
+  vtkPointData* pointData = polyData->GetPointData();
+  if (!pointData)
+    {
+    return;
+    }
+
+  const char* activeScalarName = modelNode->GetActivePointScalarName(vtkDataSetAttributes::SCALARS);
+  bool activeScalarChanged = false;
+  if ((activeScalarName == nullptr && this->ActiveScalar != nullptr) ||
+      (activeScalarName != nullptr && this->ActiveScalar == nullptr))
+    {
+    activeScalarChanged = true;
+    }
+  else if (activeScalarName && this->ActiveScalar && strcmp(activeScalarName, this->ActiveScalar) != 0)
+    {
+    activeScalarChanged = true;
+    }
+  this->ActiveScalar = activeScalarName;
+
+  int numberOfArraysInMesh = pointData->GetNumberOfArrays();
+  int numberOfArraysInCalculator = this->ScalarCalculator->GetNumberOfScalarArrays() + this->ScalarCalculator->GetNumberOfVectorArrays();
+  if (!activeScalarChanged && numberOfArraysInMesh + 1 == numberOfArraysInCalculator)
+    {
+    return;
+    }
+
+  this->ScalarCalculator->RemoveAllVariables();
+  for (int i = -1; i < numberOfArraysInMesh; ++i)
+    {
+    const char* variableName = "activeScalar";
+    vtkDataArray* array = nullptr;
+    if (i >= 0)
+      {
+      array = pointData->GetArray(i);
+      variableName = array->GetName();
+      }
+    else
+      {
+      if (!activeScalarName)
+        {
+        continue;
+        }
+      array = pointData->GetArray(activeScalarName);
+      }
+
+    if (!array)
+      {
+      vtkWarningMacro("UpdateScalarVariables: Could not get array " << i);
+      continue;
+      }
+
+    if (array->GetNumberOfComponents() == 1)
+      {
+      this->ScalarCalculator->AddScalarVariable(variableName, array->GetName());
+      }
+    else
+      {
+      this->ScalarCalculator->AddVectorVariable(variableName, array->GetName());
+      }
+    }
+
+  // Changing the variables doesn't invoke modified, so we need to invoke it here.
+  this->ScalarCalculator->Modified();
+  this->Modified();
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -205,12 +205,6 @@ void vtkMRMLMarkupsFiducialNode::GetNthFiducialWorldCoordinates(int n, double co
 }
 
 //-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::UpdateCurvePolyFromCurveInputPoly()
-{
-  // No need for curve generation for markup points
-}
-
-//-------------------------------------------------------------------------
 void vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes()
 {
   if (this->GetDisplayNode() != nullptr &&

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -121,8 +121,6 @@ public:
   /// Get world coordinates on nth fiducial
   void GetNthFiducialWorldCoordinates(int n, double coords[4]);
 
-  void UpdateCurvePolyFromCurveInputPoly() override;
-
   /// Create and observe default display node(s)
   void CreateDefaultDisplayNodes() override;
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -598,8 +598,6 @@ protected:
 
   virtual void UpdateCurvePolyFromControlPoints();
 
-  virtual void UpdateCurvePolyFromCurveInputPoly();
-
   void OnTransformNodeReferenceChanged(vtkMRMLTransformNode* transformNode) override;
 
   virtual void UpdateMeasurements();
@@ -630,9 +628,8 @@ protected:
   // Line cells connect all points into a curve.
   vtkSmartPointer<vtkPolyData> CurveInputPoly;
 
-  // Points store interpolated/approximated point positions (in local coordinate system).
-  // Line cells connect all points into a curve.
-  vtkSmartPointer<vtkPolyData> CurvePoly;
+  vtkSmartPointer<vtkTransformPolyDataFilter> CurveInputPolyToWorldTransformer;
+  vtkSmartPointer<vtkGeneralTransform> CurveInputPolyToWorldTransform;
 
   vtkSmartPointer<vtkTransformPolyDataFilter> CurvePolyToWorldTransformer;
   vtkSmartPointer<vtkGeneralTransform> CurvePolyToWorldTransform;

--- a/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
+++ b/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
@@ -186,6 +186,45 @@
       <bool>true</bool>
      </property>
      <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Interaction in Views:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="listLockedUnlockedPushButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>30</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>32</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Enable/disable all interactions in slice and 3D views.</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:Icons/Medium/SlicerUnlock.png</normaloff>:Icons/Medium/SlicerUnlock.png</iconset>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
@@ -504,45 +543,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="listLockedUnlockedPushButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>30</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>32</width>
-          <height>32</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Enable/disable all interactions in slice and 3D views.</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="icon">
-         <iconset>
-          <normaloff>:Icons/Medium/SlicerUnlock.png</normaloff>:Icons/Medium/SlicerUnlock.png</iconset>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Interaction in Views:</string>
-        </property>
-       </widget>
-      </item>
       <item row="6" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="advancedCollapsibleButton">
         <property name="toolTip">
@@ -707,6 +707,84 @@
             <string>Convert Annotation Fiducials</string>
            </property>
           </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="curveSettingsCollapseButton">
+     <property name="text">
+      <string>Curve Settings</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <item>
+       <layout class="QFormLayout" name="formLayout_3">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Curve Type:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="curveTypeComboBox"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="ctkCollapsibleGroupBox" name="surfaceCurveCollapsibleButton">
+        <property name="title">
+         <string>Surface</string>
+        </property>
+        <property name="collapsed">
+         <bool>false</bool>
+        </property>
+        <layout class="QFormLayout" name="formLayout_2">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Model Node:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="qMRMLNodeComboBox" name="modelNodeSelector">
+           <property name="nodeTypes">
+            <stringlist>
+             <string>vtkMRMLModelNode</string>
+            </stringlist>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="useScalarsCheckBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Use Scalars:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Scalar Function:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="scalarFunctionLineEdit"/>
          </item>
         </layout>
        </widget>
@@ -902,6 +980,7 @@
    <class>qMRMLNodeComboBox</class>
    <extends>QWidget</extends>
    <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qSlicerWidget</class>
@@ -1007,6 +1086,22 @@
     <hint type="destinationlabel">
      <x>290</x>
      <y>774</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerMarkupsModule</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>modelNodeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>219</x>
+     <y>285</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>260</x>
+     <y>553</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
@@ -313,6 +313,13 @@ void vtkSlicerCurveRepresentation2D::CanInteractWithCurve(
     return;
     }
 
+  // No curve points to find. Trying to run the locator would result in a crash.
+  vtkPoints* curvePoints = this->MarkupsNode->GetCurvePoints();
+  if (!curvePoints || curvePoints->GetNumberOfPoints() == 0)
+    {
+    return;
+    }
+
   this->SliceDistance->Update();
   this->SliceCurvePointLocator->SetDataSet(this->SliceDistance->GetOutput());
   this->SliceCurvePointLocator->Update();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveWidget.cxx
@@ -124,7 +124,15 @@ bool vtkSlicerCurveWidget::ProcessControlPointInsert(vtkMRMLInteractionEventData
 
   // Create new control point and insert
   vtkMRMLMarkupsNode::ControlPoint* controlPoint = new vtkMRMLMarkupsNode::ControlPoint;
-  (*controlPoint) = (*markupsNode->GetNthControlPoint(foundComponentIndex));
+  vtkMRMLMarkupsNode::ControlPoint* foundControlPoint = markupsNode->GetNthControlPoint(foundComponentIndex);
+  if (foundControlPoint)
+    {
+    (*controlPoint) = (*foundControlPoint);
+    }
+  else
+    {
+    vtkWarningMacro("ProcessControlPointInsert: Found control point is out of bounds");
+    }
   markupsNode->TransformPointFromWorld(worldPos, controlPoint->Position);
   if (!markupsNode->InsertControlPoint(controlPoint, foundComponentIndex + 1))
     {

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -29,6 +29,7 @@
 #include <QSignalMapper>
 #include <QStringList>
 #include <QTableWidgetItem>
+#include <QTimer>
 
 // CTK includes
 #include "ctkMessageBox.h"
@@ -124,6 +125,8 @@ private:
   QAction*    cutAction;
   QAction*    copyAction;
   QAction*    pasteAction;
+
+  QTimer*     editScalarFunctionDelay;
 };
 
 //-----------------------------------------------------------------------------
@@ -151,6 +154,8 @@ qSlicerMarkupsModuleWidgetPrivate::qSlicerMarkupsModuleWidgetPrivate(qSlicerMark
   this->cutAction = nullptr;
   this->copyAction = nullptr;
   this->pasteAction = nullptr;
+
+  this->editScalarFunctionDelay = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -436,6 +441,27 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
   this->resampleCurveCollapsibleButton->setVisible(false);
   QObject::connect(this->resampleCurveButton, SIGNAL(clicked()),
     q, SLOT(onApplyCurveResamplingPushButtonClicked()));
+
+
+  this->curveTypeComboBox->clear();
+  for (int curveType = 0; curveType < vtkCurveGenerator::CURVE_TYPE_LAST; ++curveType)
+    {
+    this->curveTypeComboBox->addItem(vtkCurveGenerator::GetCurveTypeAsString(curveType), curveType);
+    }
+
+  this->editScalarFunctionDelay = new QTimer(q);
+  this->editScalarFunctionDelay->setInterval(500);
+  this->editScalarFunctionDelay->setSingleShot(true);
+  QObject::connect(this->editScalarFunctionDelay, SIGNAL(timeout()),
+    q, SLOT(onCurveTypeParameterChanged()));
+  QObject::connect(this->curveTypeComboBox, SIGNAL(currentIndexChanged(int)),
+    q, SLOT(onCurveTypeParameterChanged()));
+  QObject::connect(this->modelNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+    q, SLOT(onCurveTypeParameterChanged()));
+  QObject::connect(this->useScalarsCheckBox, SIGNAL(stateChanged(int)),
+    q, SLOT(onCurveTypeParameterChanged()));
+  QObject::connect(this->scalarFunctionLineEdit, SIGNAL(textChanged(QString)),
+    this->editScalarFunctionDelay, SLOT(start()));
 }
 
 //-----------------------------------------------------------------------------
@@ -837,6 +863,34 @@ void qSlicerMarkupsModuleWidget::updateWidgetFromMRML()
       {
       d->resampleCurveOutputNodeSelector->setCurrentNode(nullptr);
       }
+
+    wasBlocked = d->curveTypeComboBox->blockSignals(true);
+    d->curveTypeComboBox->setCurrentIndex(d->curveTypeComboBox->findData(markupsCurveNode->GetCurveType()));
+    d->curveTypeComboBox->blockSignals(wasBlocked);
+
+    vtkMRMLModelNode* modelNode = markupsCurveNode->GetModelNode();
+    wasBlocked = d->modelNodeSelector->blockSignals(true);
+    d->modelNodeSelector->setCurrentNode(modelNode);
+    d->modelNodeSelector->blockSignals(wasBlocked);
+
+    wasBlocked = d->useScalarsCheckBox->blockSignals(true);
+    d->useScalarsCheckBox->setChecked(markupsCurveNode->GetUseSurfaceScalarWeights());
+    d->useScalarsCheckBox->blockSignals(wasBlocked);
+
+    wasBlocked = d->scalarFunctionLineEdit->blockSignals(true);
+    int currentCursorPosition = d->scalarFunctionLineEdit->cursorPosition();
+    d->scalarFunctionLineEdit->setText(markupsCurveNode->GetSurfaceScalarWeightFunction());
+    d->scalarFunctionLineEdit->setCursorPosition(currentCursorPosition);
+    d->scalarFunctionLineEdit->blockSignals(wasBlocked);
+    }
+
+  if (markupsCurveNode && markupsCurveNode->GetCurveType() == vtkCurveGenerator::CURVE_TYPE_SHORTEST_SURFACE_DISTANCE)
+    {
+    d->surfaceCurveCollapsibleButton->setVisible(true);
+    }
+  else
+    {
+    d->surfaceCurveCollapsibleButton->setVisible(false);
     }
 }
 
@@ -2463,4 +2517,22 @@ void qSlicerMarkupsModuleWidget::onSaveToDefaultDisplayPropertiesPushButtonClick
 
   // also save the settings permanently
   qSlicerMarkupsModule::writeDefaultMarkupsDisplaySettings(this->markupsLogic()->GetDefaultMarkupsDisplayNode());
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMarkupsModuleWidget::onCurveTypeParameterChanged()
+{
+  Q_D(qSlicerMarkupsModuleWidget);
+  vtkMRMLMarkupsCurveNode* curveNode = vtkMRMLMarkupsCurveNode::SafeDownCast(d->MarkupsNode);
+  if (!curveNode)
+    {
+    return;
+    }
+
+  MRMLNodeModifyBlocker blocker(curveNode);
+  curveNode->SetCurveType(d->curveTypeComboBox->currentData().toInt());
+  curveNode->SetAndObserveModelNode(vtkMRMLModelNode::SafeDownCast(d->modelNodeSelector->currentNode()));
+  curveNode->SetUseSurfaceScalarWeights(d->useScalarsCheckBox->isChecked());
+  std::string functionString = d->scalarFunctionLineEdit->text().toStdString();
+  curveNode->SetSurfaceScalarWeightFunction(functionString.c_str());
 }

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
@@ -228,6 +228,9 @@ public slots:
   /// update the coordinates shown in the table to be either the transformed coordiantes (checked) or the untransformed coordiantes (unchecked)
   void onTransformedCoordinatesToggled(bool checked);
 
+  /// Change in a widget related to a surface curve type parameter
+  void onCurveTypeParameterChanged();
+
 protected:
   QScopedPointer<qSlicerMarkupsModuleWidgetPrivate> d_ptr;
 


### PR DESCRIPTION
Adds a Dijkstra's algorithm based pathfinding to generate an interpolated curve for open and closed curve markup types.
By default, the only metric used is the distance between each vertex, however scalar values can also optionally be used (see below).

- Add a combobox to select curve interpolation type to the markups module
- Convert vtkCurveGenerator to a vtkPolyDataAlgorithm
- Scalar weighted pathfinding:
  - The pathfinding edge cost can be weighted using the point scalars of the mesh (currently weight = distance / scalar^2)
  - The formula used for generating the scalar values can be specified with vtkMRMLMarkupsCurveNode::SetSurfaceScalarWeightFunction() using vtkFunctionParser syntax
  - All point scalars can be used in the function (ex. "scalar1 + scalar2").

![image](https://user-images.githubusercontent.com/9222709/74771283-db1f8900-525b-11ea-8b8d-e203a1395a90.png)
