### PR TITLE
BUG: Fix crash when running island effects on empty segment

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -445,6 +445,16 @@ void vtkSlicerSegmentationsModuleLogic::GetAllLabelValues(vtkIntArray* labels, v
     vtkGenericWarningMacro("vtkSlicerSegmentationsModuleLogic::GetAllLabelValues: Invalid labelmap");
     return;
    }
+
+  int dimensions[3] = { 0 };
+  labelmap->GetDimensions(dimensions);
+  if (dimensions[0] == 0 || dimensions[1] == 0 || dimensions[2] == 0)
+    {
+    // Labelmap is empty, there are no label values.
+    // Running vtkImageAccumulate would cause a crash.
+    return;
+    }
+
   double* scalarRange = labelmap->GetScalarRange();
   int lowLabel = (int)(floor(scalarRange[0]));
   int highLabel = (int)(ceil(scalarRange[1]));


### PR DESCRIPTION
If the segment labelmap had a dimension of {0, 0, 0}, the vtkSlicerSegmentationsModuleLogic::GetAllLabelValues() would cause a crash by trying to run the empty image through vtkImageAccumulate.
Fixed by returning from the function if the dimensions of the image are 0.