### PR TITLE
COMP: Fix CircleCI build by completely disabling LandmarkRegistration module

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -318,15 +318,15 @@ Slicer_Remote_Add(CompareVolumes
   )
 list_conditional_append(Slicer_BUILD_CompareVolumes Slicer_REMOTE_DEPENDENCIES CompareVolumes)
 
-Slicer_Remote_Add(LandmarkRegistration
-  GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/pieper/LandmarkRegistration"
-  GIT_TAG 1e1c706a3c9445cb32116ff899201b445d041c4a
-  OPTION_NAME Slicer_BUILD_LandmarkRegistration
-  OPTION_DEPENDS "Slicer_BUILD_CompareVolumes;Slicer_USE_PYTHONQT"
-  LABELS REMOTE_MODULE
-  )
-# disable this module until it can be ported to the new markups code
-# tracked at https://github.com/pieper/LandmarkRegistration/issues/29
+# Disable this module until it can be ported to the new markups code
+# Tracked at https://github.com/pieper/LandmarkRegistration/issues/29
+#Slicer_Remote_Add(LandmarkRegistration
+#  GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/pieper/LandmarkRegistration"
+#  GIT_TAG 1e1c706a3c9445cb32116ff899201b445d041c4a
+#  OPTION_NAME Slicer_BUILD_LandmarkRegistration
+#  OPTION_DEPENDS "Slicer_BUILD_CompareVolumes;Slicer_USE_PYTHONQT"
+#  LABELS REMOTE_MODULE
+#  )
 #list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDENCIES LandmarkRegistration)
 
 Slicer_Remote_Add(SurfaceToolbox


### PR DESCRIPTION
This commit fixes a regression introduced in r28766 (COMP: disable LandmarkRegistration)