### PR TITLE
ENH: making the mask image optional (to match documentation)

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.cxx
@@ -141,7 +141,7 @@ bool vtkImageGrowCutSegment::vtkInternal::InitializationAHP(
     seedLabelVolumePtr = static_cast<LabelPixelType*>(seedLabelVolume->GetScalarPointer());
     }
   MaskPixelType* maskLabelVolumePtr = nullptr;
-  if (seedLabelVolume != nullptr)
+  if (maskLabelVolume != nullptr)
     {
     maskLabelVolumePtr = static_cast<MaskPixelType*>(maskLabelVolume->GetScalarPointer());
     }

--- a/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.cxx
@@ -191,7 +191,7 @@ bool vtkImageGrowCutSegment::vtkInternal::InitializationAHP(
     // The neighborhood size is everywhere the same (size of m_NeighborIndexOffsets)
     // except at the edges of the volume, where the neighborhood size is 0.
     m_NumberOfNeighbors.resize(dimXYZ);
-    const unsigned char numberOfNeighbors = m_NeighborIndexOffsets.size();
+    const unsigned char numberOfNeighbors = static_cast<unsigned char>(m_NeighborIndexOffsets.size());
     unsigned char* nbSizePtr = &(m_NumberOfNeighbors[0]);
     for (NodeIndexType z = 0; z < m_DimZ; z++)
       {

--- a/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkImageGrowCutSegment.h
@@ -5,6 +5,7 @@
 
 #include <vtkImageAlgorithm.h>
 #include <vtkImageData.h>
+#include <vtkInformation.h>
 
 class VTK_SLICER_SEGMENTATIONS_LOGIC_EXPORT vtkImageGrowCutSegment : public vtkImageAlgorithm
 {
@@ -41,6 +42,17 @@ protected:
 
   void ExecuteDataWithInformation(vtkDataObject *outData, vtkInformation *outInfo) override;
   int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
+
+  int
+  FillInputPortInformation(int port, vtkInformation * info) override
+  {
+    vtkImageAlgorithm::FillInputPortInformation(port, info);
+    if (port == 2)
+    {
+      info->Set(vtkAlgorithm::INPUT_IS_OPTIONAL(), 1);
+    }
+    return 1;
+  }
 
 private:
   class vtkInternal;


### PR DESCRIPTION
The input is required, otherwise the class produces all-zero output.

Side note: this mask has the opposite semantics from usual (a separate issue).