### PR TITLE
COMP: Update DCMTK library install rules to fix packaging using Ninja generator

### DIFF
--- a/CMake/SlicerBlockInstallDCMTKLibs.cmake
+++ b/CMake/SlicerBlockInstallDCMTKLibs.cmake
@@ -5,7 +5,10 @@
 find_package(DCMTK REQUIRED)
 foreach(dcmtk_Lib ${DCMTK_LIBRARIES})
   if(WIN32)
-    install(FILES ${DCMTK_DIR}/bin/Release/${dcmtk_Lib}.dll
+    if(CMAKE_CONFIGURATION_TYPES)
+      set(int_dir "Release/")
+    endif()
+    install(FILES ${DCMTK_DIR}/bin/${int_dir}${dcmtk_Lib}.dll
       DESTINATION ${Slicer_INSTALL_LIB_DIR} COMPONENT Runtime)
   elseif(UNIX)
     install(DIRECTORY ${DCMTK_DIR}/lib/


### PR DESCRIPTION
This commit fixes errors like the following reported when building "package"
target using ninja on windows:

```
  CMake Error at D:/P/s-r/Slicer-build/CMake/LastConfigureStep/cmake_install.cmake:263 (file):
    file INSTALL cannot find "D:/P/s-r/DCMTK-build/bin/Release/ofstd.dll".
  Call Stack (most recent call first):
    D:/P/s-r/Slicer-build/cmake_install.cmake:47 (include)


  CMake Error at D:/P/s-r/Slicer-build/CMake/LastConfigureStep/cmake_install.cmake:267 (file):
    file INSTALL cannot find "D:/P/s-r/DCMTK-build/bin/Release/oflog.dll".
  Call Stack (most recent call first):
    D:/P/s-r/Slicer-build/cmake_install.cmake:47 (include)
```