### PR TITLE
ENH: Add back vtkCurveGenerator SetInputPoints and GetOutputPoints

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
@@ -1021,3 +1021,22 @@ void vtkCurveGenerator::SetSurfaceCostFunctionType(int setSurfaceCostFunctionTyp
   this->SurfacePathFilter->SetCostFunctionType(setSurfaceCostFunctionType);
   this->Modified();
 }
+
+//------------------------------------------------------------------------------
+void vtkCurveGenerator::SetInputPoints(vtkPoints* points)
+{
+  vtkNew<vtkPolyData> polyData;
+  polyData->SetPoints(points);
+  this->SetInputData(polyData);
+}
+
+//------------------------------------------------------------------------------
+vtkPoints* vtkCurveGenerator::GetOutputPoints()
+{
+  vtkPolyData* polyData = this->GetOutput();
+  if (!polyData)
+    {
+    return nullptr;
+    }
+  return polyData->GetPoints();
+}

--- a/Modules/Loadable/Markups/MRML/vtkCurveGenerator.h
+++ b/Modules/Loadable/Markups/MRML/vtkCurveGenerator.h
@@ -178,6 +178,12 @@ public:
   /// The internal instance of the current parametric function use of the curve for other computations.
   vtkParametricFunction* GetParametricFunction() { return this->ParametricFunction.GetPointer(); };
 
+  /// Set the input control points
+  void SetInputPoints(vtkPoints* points);
+
+  /// Get the output sampled points
+  vtkPoints* GetOutputPoints();
+
 protected:
   // input parameters
   int NumberOfPointsPerInterpolatingSegment;


### PR DESCRIPTION
Restore removed methods from vtkCurveGenerator. Allows setting of input and retrieval of output as viewpoints.