### PR TITLE
BUG: Fix markup curve surface interpolation with incompatible mesh

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -34,9 +34,11 @@
 #include <vector>
 
 class vtkArrayCalculator;
-class vtkPassArrays;
+class vtkCleanPolyData;
+class vtkPassThroughFilter;
 class vtkPlane;
 class vtkTransformPolyDataFilter;
+class vtkTriangleFilter;
 
 /// \brief MRML node to represent a curve markup
 /// Curve Markups nodes contain N control points.
@@ -205,9 +207,11 @@ public:
   //@}
 
 protected:
+  vtkSmartPointer<vtkCleanPolyData> CleanFilter;
+  vtkSmartPointer<vtkTriangleFilter> TriangleFilter;
   vtkSmartPointer<vtkTransformPolyDataFilter> SurfaceToWorldTransformer;
   vtkSmartPointer<vtkArrayCalculator> SurfaceScalarCalculator;
-  vtkSmartPointer<vtkPassArrays> SurfacePassArray;
+  vtkSmartPointer<vtkPassThroughFilter> PassThroughFilter;
   const char* ActiveScalar;
 
 protected:


### PR DESCRIPTION
Some mesh required a cleanup and/or conversion to a triangular mesh before vtkSlicerDijkstraGraphGeodesicPath could generate a path.
Input mesh are now run through vtkCleanPolyData and vtkTriangleFilter before being used for pathfinding.
Also reduce errors for mesh with no active scalars by routing the input through a vtkPassThroughFilter to avoid scalar calculation when it is not needed.