### PR TITLE
BUG: Disable default interaction of ffmpeg with stdin

### DIFF
--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -1268,6 +1268,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
     filePathPattern = os.path.join(outputDir, imageFileNamePattern)
     outputVideoFilePath = os.path.join(outputDir, videoFileName)
     ffmpegParams = [ffmpegPath,
+                    "-nostdin",
                     "-y", # overwrite without asking
                     "-r", str(frameRate),
                     "-start_number", "0",


### PR DESCRIPTION
If Slicer is run in the background process group, it hangs when calling ffmpeg with subprocess.Popen().
This commit disables interaction with stdin to prevent this from happenning on Linux and macOS.

See discussion on Slicer forum: https://discourse.slicer.org/t/screen-capture-module-makes-slicer-hang/10456.
Solution found on SO: https://stackoverflow.com/q/47115191/3956024.