### PR TITLE
ENH: Add patient birth date and sex to exported DICOM scalar volume

### DIFF
--- a/Modules/CLI/CreateDICOMSeries/CreateDICOMSeries.cxx
+++ b/Modules/CLI/CreateDICOMSeries/CreateDICOMSeries.cxx
@@ -159,12 +159,8 @@ int DoIt( int argc, char * argv[])
 
     // Image type
     itk::EncapsulateMetaData<std::string>(dictionary, "0008|0008", std::string("ORIGINAL\\PRIMARY\\AXIAL") );
-    // Patient's Birthdate
-    itk::EncapsulateMetaData<std::string>(dictionary, "0010|0030", std::string("20060101") );
     // Patient's Birth Time
     itk::EncapsulateMetaData<std::string>(dictionary, "0010|0032", std::string("010100.000000") );
-    // Patient's Sex
-    itk::EncapsulateMetaData<std::string>(dictionary, "0010|0040", std::string("M") );
     // Study Date
     itk::EncapsulateMetaData<std::string>(dictionary, "0008|0020", std::string("20050101") );
     // Study Time
@@ -186,6 +182,14 @@ int DoIt( int argc, char * argv[])
     if (!patientID.empty())
       {
       itk::EncapsulateMetaData<std::string>(dictionary, "0010|0020", patientID);
+      }
+    if (!patientBirthDate.empty())
+      {
+      itk::EncapsulateMetaData<std::string>(dictionary, "0010|0030", patientBirthDate);
+      }
+    if (!patientSex.empty())
+      {
+      itk::EncapsulateMetaData<std::string>(dictionary, "0010|0040", patientSex);
       }
     if (!patientComments.empty())
       {

--- a/Modules/CLI/CreateDICOMSeries/CreateDICOMSeries.xml
+++ b/Modules/CLI/CreateDICOMSeries/CreateDICOMSeries.xml
@@ -26,6 +26,20 @@
       <default>123456</default>
     </string>
     <string>
+      <name>patientBirthDate</name>
+      <longflag>--patientBirthDate</longflag>
+      <description><![CDATA[Patient birth date (0010,0030)]]></description>
+      <label>Patient Birth Date</label>
+      <default>20060101</default>
+    </string>
+    <string>
+      <name>patientSex</name>
+      <longflag>--patientSex</longflag>
+      <description><![CDATA[Patient sex (0010,0040)]]></description>
+      <label>Patient Sex</label>
+      <default>M</default>
+    </string>
+    <string>
       <name>patientComments</name>
       <longflag>--patientComments</longflag>
       <description><![CDATA[Patient comments (0010,4000)]]></description>

--- a/Modules/Scripted/DICOMLib/DICOMExportScalarVolume.py
+++ b/Modules/Scripted/DICOMLib/DICOMExportScalarVolume.py
@@ -109,6 +109,8 @@ class DICOMExportScalarVolume(object):
     # Patient
     cliparameters['patientName'] = self.tags['Patient Name']
     cliparameters['patientID'] = self.tags['Patient ID']
+    cliparameters['patientBirthDate'] = self.tags['Patient Birth Date']
+    cliparameters['patientSex'] = self.tags['Patient Sex']
     cliparameters['patientComments'] = self.tags['Patient Comments']
     # Study
     cliparameters['studyID'] = self.tags['Study ID']

--- a/Modules/Scripted/DICOMLib/DICOMExportScene.py
+++ b/Modules/Scripted/DICOMLib/DICOMExportScene.py
@@ -31,7 +31,6 @@ for elements like slicer.dicomDatatabase and slicer.mrmlScene
 
 class DICOMExportScene(object):
   """Export slicer scene to dicom database
-  TODO: delete temp directories and files
   """
 
   def __init__(self,referenceFile=None):

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -522,6 +522,8 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
       tags = {}
       tags['Patient Name'] = exportable.tag(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMPatientNameTagName())
       tags['Patient ID'] = exportable.tag(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMPatientIDTagName())
+      tags['Patient Birth Date'] = exportable.tag(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMPatientBirthDateTagName())
+      tags['Patient Sex'] = exportable.tag(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMPatientSexTagName())
       tags['Patient Comments'] = exportable.tag(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMPatientCommentsTagName())
       tags['Study ID'] = self.defaultStudyID
       tags['Study Date'] = exportable.tag(slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMStudyDateTagName())


### PR DESCRIPTION
Patient birth date and sex were not exported in the series by the scalar volume plugin (and CreateDICOMSeries module), even if the fields were filled. These two tags are now also supported.