### PR TITLE
COMP: Large 64 bit integers loose precision in double

### DIFF
--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx
@@ -860,18 +860,18 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
           }
         if ( imageIO->GetComponentType() == itk::ImageIOBase::INT )
           {
-          min = std::numeric_limits<int32_t>::min() < min ? std::numeric_limits<int32_t>::min() : min;
-          max = std::numeric_limits<int32_t>::max() > max ? std::numeric_limits<int32_t>::max() : max;
+          min = static_cast<double>(std::numeric_limits<int32_t>::min() < min ? std::numeric_limits<int32_t>::min() : min);
+          max = static_cast<double>(std::numeric_limits<int32_t>::max() > max ? std::numeric_limits<int32_t>::max() : max);
           }
         if ( imageIO->GetComponentType() == itk::ImageIOBase::ULONG )
           { // note that on windows ULONG is only 32 bit
-          min = std::numeric_limits<uint64_t>::min() < min ? std::numeric_limits<uint64_t>::min() : min;
-          max = std::numeric_limits<uint64_t>::max() > max ? std::numeric_limits<uint64_t>::max() : max;
+          min = static_cast<double>(std::numeric_limits<uint64_t>::min() < min ? std::numeric_limits<uint64_t>::min() : min);
+          max = static_cast<double>(std::numeric_limits<uint64_t>::max() > max ? std::numeric_limits<uint64_t>::max() : max);
           }
         if ( imageIO->GetComponentType() == itk::ImageIOBase::LONG )
           { // note that on windows LONG is only 32 bit
-          min = std::numeric_limits<int64_t>::min() < min ? std::numeric_limits<int64_t>::min() : min;
-          max = std::numeric_limits<int64_t>::max() > max ? std::numeric_limits<int64_t>::max() : max;
+          min = static_cast<double>(std::numeric_limits<int64_t>::min() < min ? std::numeric_limits<int64_t>::min() : min);
+          max = static_cast<double>(std::numeric_limits<int64_t>::max() > max ? std::numeric_limits<int64_t>::max() : max);
           }
         if ( imageIO->GetComponentType() == itk::ImageIOBase::FLOAT )
           {
@@ -901,7 +901,7 @@ int vtkITKArchetypeImageSeriesReader::RequestInformation(
           {
           scalarType = VTK_UNSIGNED_INT;
           }
-        else if( max <= std::numeric_limits<uint64_t>::max() )
+        else if( max <= static_cast<double>(std::numeric_limits<uint64_t>::max()) )
           {
           scalarType = VTK_UNSIGNED_LONG;
           }

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
@@ -1886,7 +1886,7 @@ void vtkOrientedImageDataResample::CastImageForValue(vtkOrientedImageData* image
       {
       scalarType = VTK_DOUBLE;
       }
-    else if (value > VTK_UNSIGNED_LONG_MAX)
+    else if (value > static_cast<double>(VTK_UNSIGNED_LONG_MAX))
       {
       scalarType = VTK_FLOAT;
       }

--- a/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.txx
+++ b/Modules/CLI/ExpertAutomatedRegistration/ITKRegistrationHelper/itkImageRegionMomentsCalculator.txx
@@ -200,7 +200,7 @@ ImageRegionMomentsCalculator<TImage>::Compute()
     }
 
   // Compute principal moments and axes
-  vnl_symmetric_eigensystem<double> eigen( m_Cm.GetVnlMatrix() );
+  vnl_symmetric_eigensystem<double> eigen( m_Cm.GetVnlMatrix().as_ref() );
   vnl_diag_matrix<double>           pm = eigen.D;
   for( unsigned int i = 0; i < ImageDimension; i++ )
     {
@@ -210,7 +210,7 @@ ImageRegionMomentsCalculator<TImage>::Compute()
 
   // Add a final reflection if needed for a proper rotation,
   // by multiplying the last row by the determinant
-  vnl_real_eigensystem                  eigenrot( m_Pa.GetVnlMatrix() );
+  vnl_real_eigensystem                  eigenrot( m_Pa.GetVnlMatrix().as_ref() );
   vnl_diag_matrix<std::complex<double> > eigenval = eigenrot.D;
   std::complex<double>                   det( 1.0, 0.0 );
   for( unsigned int i = 0; i < ImageDimension; i++ )


### PR DESCRIPTION
warning: implicit conversion from 'unsigned long' to 'double'
changes value from 18446744073709551615 to 18446744073709551616 [-Wimplicit-int-float-conversion]