### PR TITLE
Finalize svn to GitHub transition

### DIFF
--- a/CMake/SlicerDashboardDriverScript.cmake
+++ b/CMake/SlicerDashboardDriverScript.cmake
@@ -267,28 +267,12 @@ list(APPEND variables CDASH_PROJECT_NAME)
 
 #-----------------------------------------------------------------------------
 if(NOT DEFINED GIT_REPOSITORY)
-  if(NOT DEFINED SVN_REPOSITORY)
-    set(SVN_REPOSITORY "http://svn.slicer.org/Slicer4")
-  endif()
-  if(NOT DEFINED SVN_BRANCH)
-    set(SVN_BRANCH "trunk")
-  endif()
-  set(SVN_URL ${SVN_REPOSITORY}/${SVN_BRANCH})
-  set(svn_checkout_option "")
-  if(NOT "${SVN_REVISION}" STREQUAL "")
-    set(SVN_URL "${SVN_URL}@${SVN_REVISION}")
-    set(run_ctest_with_update FALSE)
-  endif()
-  set(repository ${SVN_URL})
-  list(APPEND variables SVN_REPOSITORY SVN_BRANCH SVN_REVISION SVN_URL)
-else()
-  set(repository ${GIT_REPOSITORY})
-  set(git_branch_option "")
-  if(NOT "${GIT_TAG}" STREQUAL "")
-    set(git_branch_option "-b ${GIT_TAG}")
-  endif()
-  list(APPEND variables GIT_REPOSITORY GIT_TAG)
+  set(GIT_REPOSITORY "https://github.com/Slicer/Slicer")
 endif()
+if(NOT DEFINED GIT_TAG)
+  set(GIT_TAG "master")
+endif()
+list(APPEND variables GIT_REPOSITORY GIT_TAG)
 
 #-----------------------------------------------------------------------------
 # Required executables
@@ -300,14 +284,6 @@ if(NOT EXISTS "${CTEST_GIT_COMMAND}")
   message(FATAL_ERROR "CTEST_GIT_COMMAND is set to a non-existent path [${CTEST_GIT_COMMAND}]")
 endif()
 message(STATUS "CTEST_GIT_COMMAND: ${CTEST_GIT_COMMAND}")
-
-if(NOT DEFINED CTEST_SVN_COMMAND)
-  find_program(CTEST_SVN_COMMAND NAMES svn)
-endif()
-if(NOT EXISTS "${CTEST_SVN_COMMAND}")
-  message(FATAL_ERROR "CTEST_SVN_COMMAND is set to a non-existent path [${CTEST_SVN_COMMAND}]")
-endif()
-message(STATUS "CTEST_SVN_COMMAND: ${CTEST_SVN_COMMAND}")
 
 #-----------------------------------------------------------------------------
 # Should binary directory be cleaned?
@@ -447,18 +423,9 @@ endif()
 # Source code checkout and update commands
 #-----------------------------------------------------------------------------
 if(NOT EXISTS "${CTEST_SOURCE_DIRECTORY}")
-  if(NOT DEFINED GIT_REPOSITORY)
-    set(CTEST_CHECKOUT_COMMAND "${CTEST_SVN_COMMAND} checkout ${repository} ${CTEST_SOURCE_DIRECTORY}")
-  else()
-    set(CTEST_CHECKOUT_COMMAND "${CTEST_GIT_COMMAND} clone ${git_branch_option} ${repository} ${CTEST_SOURCE_DIRECTORY}")
-  endif()
+  set(CTEST_CHECKOUT_COMMAND "${CTEST_GIT_COMMAND} clone -b ${GIT_TAG} ${GIT_REPOSITORY} ${CTEST_SOURCE_DIRECTORY}")
 endif()
-
-if(NOT DEFINED GIT_REPOSITORY)
-  set(CTEST_UPDATE_COMMAND "${CTEST_SVN_COMMAND}")
-else()
-  set(CTEST_UPDATE_COMMAND "${CTEST_GIT_COMMAND}")
-endif()
+set(CTEST_UPDATE_COMMAND "${CTEST_GIT_COMMAND}")
 
 #-----------------------------------------------------------------------------
 # run_ctest macro
@@ -493,11 +460,6 @@ CMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}")
     if(DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
       set(OPTIONAL_CACHE_CONTENT "${OPTIONAL_CACHE_CONTENT}
 CMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}")
-    endif()
-
-    if(DEFINED CTEST_SVN_COMMAND)
-      set(OPTIONAL_CACHE_CONTENT "${OPTIONAL_CACHE_CONTENT}
-Subversion_SVN_EXECUTABLE:FILEPATH=${CTEST_SVN_COMMAND}")
     endif()
 
     if(DEFINED Slicer_BUILD_WIN32_CONSOLE)

--- a/CMake/SlicerDashboardScript.TEMPLATE.cmake
+++ b/CMake/SlicerDashboardScript.TEMPLATE.cmake
@@ -17,7 +17,7 @@ dashboard_set(OPERATING_SYSTEM      "Linux")
 dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous or Nightly
 dashboard_set(Slicer_RELEASE_TYPE   "Experimental")   # (E)xperimental, (P)review or (S)table
 dashboard_set(WITH_PACKAGES         FALSE)            # Enable to generate packages
-dashboard_set(SVN_REVISION          "")               # Specify a revision for Stable release
+dashboard_set(GIT_TAG               "master")         # Specify a tag for Stable release
 if(APPLE)
   dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
 endif()
@@ -56,7 +56,7 @@ set(ADDITIONAL_CMAKECACHE_OPTION "
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
 ##########################################
 if(NOT DEFINED DRIVER_SCRIPT)
-  set(url http://svn.slicer.org/Slicer4/trunk/CMake/SlicerDashboardDriverScript.cmake)
+  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/CMake/SlicerDashboardDriverScript.cmake)
   set(dest ${DASHBOARDS_DIR}/${EXTENSION_DASHBOARD_SUBDIR}/${CTEST_SCRIPT_NAME}.driver)
   file(DOWNLOAD ${url} ${dest} STATUS status)
   if(NOT status MATCHES "0.*")

--- a/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
+++ b/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
@@ -59,7 +59,7 @@ set(ADDITIONAL_CMAKECACHE_OPTION "
 ##########################################
 set(EXTENSIONS_TRACK_QUALIFIER ${EXTENSIONS_INDEX_BRANCH})
 if(NOT DEFINED DRIVER_SCRIPT)
-  set(url http://svn.slicer.org/Slicer4/trunk/Extensions/CMake/SlicerExtensionsDashboardDriverScript.cmake)
+  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/Extensions/CMake/SlicerExtensionsDashboardDriverScript.cmake)
   set(dest ${DASHBOARDS_DIR}/${EXTENSION_DASHBOARD_SUBDIR}/${CTEST_SCRIPT_NAME}.driver)
   file(DOWNLOAD ${url} ${dest} STATUS status)
   if(NOT status MATCHES "0.*")

--- a/Libs/MRML/Core/vtkMRMLParser.h
+++ b/Libs/MRML/Core/vtkMRMLParser.h
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Slicer
-  Language:  C++
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Applications/GUI/Slicer3.cxx $
-  Date:      $Date: 2009-04-15 06:29:13 -0400 (Wed, 15 Apr 2009) $
-  Version:   $Revision: 9206 $
-
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   3D Slicer
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Base/GUI/vtkMRMLModelDisplayableManager.cxx $
-  Date:      $Date: 2010-05-27 14:32:23 -0400 (Thu, 27 May 2010) $
-  Version:   $Revision: 13525 $
-
 ==========================================================================*/
 
 // MRMLDisplayableManager includes

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   SlicerViewerWidget
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Base/GUI/vtkMRMLModelDisplayableManager.h $
-  Date:      $Date: 2010-05-12 08:34:19 -0400 (Wed, 12 May 2010) $
-  Version:   $Revision: 13332 $
-
 ==========================================================================*/
 
 #ifndef __vtkMRMLModelDisplayableManager_h

--- a/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx $
-  Date:      $Date: 2007-08-15 17:04:27 -0400 (Wed, 15 Aug 2007) $
-  Version:   $Revision: 4068 $
-
 ==========================================================================*/
 
 // vtkITK includes

--- a/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.h
+++ b/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.h
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.h $
-  Date:      $Date: 2007-01-19 13:21:56 -0500 (Fri, 19 Jan 2007) $
-  Version:   $Revision: 2267 $
-
 ==========================================================================*/
 
 #ifndef __vtkITKArchetypeDiffusionTensorImageReaderFile_h

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx $
-  Date:      $Date: 2007-08-15 17:04:27 -0400 (Wed, 15 Aug 2007) $
-  Version:   $Revision: 4068 $
-
 ==========================================================================*/
 
 // VTKITK includes

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.h
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.h $
-  Date:      $Date: 2007-01-19 13:21:56 -0500 (Fri, 19 Jan 2007) $
-  Version:   $Revision: 2267 $
-
 ==========================================================================*/
 
 #ifndef __vtkITKArchetypeImageSeriesVectorReaderFile_h

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx $
-  Date:      $Date: 2007-08-15 17:04:27 -0400 (Wed, 15 Aug 2007) $
-  Version:   $Revision: 4068 $
-
 ==========================================================================*/
 
 // VTKITK includes

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.h
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.h $
-  Date:      $Date: 2007-01-19 13:21:56 -0500 (Fri, 19 Jan 2007) $
-  Version:   $Revision: 2267 $
-
 ==========================================================================*/
 
 #ifndef __vtkITKArchetypeImageSeriesVectorReaderSeries_h

--- a/Libs/vtkITK/vtkITKDistanceTransform.cxx
+++ b/Libs/vtkITK/vtkITKDistanceTransform.cxx
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKDistanceTransform.cxx $
-  Date:      $Date: 2006-12-21 07:21:52 -0500 (Thu, 21 Dec 2006) $
-  Version:   $Revision: 1900 $
-
 ==========================================================================*/
 
 #include "vtkITKDistanceTransform.h"

--- a/Libs/vtkITK/vtkITKImageToImageFilterUSF.h
+++ b/Libs/vtkITK/vtkITKImageToImageFilterUSF.h
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKImageToImageFilterUSF.h $
-  Date:      $Date: 2006-12-21 07:21:52 -0500 (Thu, 21 Dec 2006) $
-  Version:   $Revision: 1900 $
-
 ==========================================================================*/
 
 #ifndef __vtkITKImageToImageFilterUSF

--- a/Libs/vtkITK/vtkITKIslandMath.cxx
+++ b/Libs/vtkITK/vtkITKIslandMath.cxx
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKIslandMath.cxx $
-  Date:      $Date: 2006-12-21 07:21:52 -0500 (Thu, 21 Dec 2006) $
-  Version:   $Revision: 1900 $
-
 ==========================================================================*/
 
 #include "vtkITKIslandMath.h"

--- a/Libs/vtkITK/vtkITKMorphologicalContourInterpolator.cxx
+++ b/Libs/vtkITK/vtkITKMorphologicalContourInterpolator.cxx
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKMorphologicalContourInterpolator.cxx $
-  Date:      $Date: 2006-12-21 07:21:52 -0500 (Thu, 21 Dec 2006) $
-  Version:   $Revision: 1900 $
-
 ==========================================================================*/
 
 #include "vtkITKMorphologicalContourInterpolator.h"

--- a/Libs/vtkITK/vtkITKTimeSeriesDatabase.cxx
+++ b/Libs/vtkITK/vtkITKTimeSeriesDatabase.cxx
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.cxx $
-  Date:      $Date: 2008-04-03 07:35:41 -0500 (Thu, 03 Apr 2008) $
-  Version:   $Revision: 6383 $
-
 ==========================================================================*/
 #include "vtkITKTimeSeriesDatabase.h"
 

--- a/Libs/vtkITK/vtkITKTimeSeriesDatabase.h
+++ b/Libs/vtkITK/vtkITKTimeSeriesDatabase.h
@@ -5,11 +5,6 @@
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
 
-  Program:   vtkITK
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Libs/vtkITK/vtkITKArchetypeImageSeriesReader.h $
-  Date:      $Date: 2008-03-11 13:22:52 -0500 (Tue, 11 Mar 2008) $
-  Version:   $Revision: 6159 $
-
 ==========================================================================*/
 
 #ifndef __vtkITKTimeSeriesDatabase_h

--- a/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
+++ b/Modules/CLI/CastScalarVolume/CastScalarVolume.cxx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Insight Segmentation & Registration Toolkit
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/Cast.cxx $
-  Language:  C++
-  Date:      $Date: 2006-12-20 16:00:24 -0500 (Wed, 20 Dec 2006) $
-  Version:   $Revision: 1892 $
-
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 

--- a/Modules/CLI/ImageLabelCombine/ImageLabelCombine.cxx
+++ b/Modules/CLI/ImageLabelCombine/ImageLabelCombine.cxx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Slicer
-  Language:  C++
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ConfidenceConnected.cxx $
-  Date:      $Date: 2008-11-24 14:36:19 -0500 (Mon, 24 Nov 2008) $
-  Version:   $Revision: 7965 $
-
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.

--- a/Modules/CLI/LabelMapSmoothing/LabelMapSmoothing.cxx
+++ b/Modules/CLI/LabelMapSmoothing/LabelMapSmoothing.cxx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Slicer
-  Language:  C++
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ConfidenceConnected.cxx $
-  Date:      $Date: 2008-11-24 14:36:19 -0500 (Mon, 24 Nov 2008) $
-  Version:   $Revision: 7965 $
-
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.

--- a/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
+++ b/Modules/CLI/MaskScalarVolume/MaskScalarVolume.cxx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Insight Segmentation & Registration Toolkit
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/Mask.cxx $
-  Language:  C++
-  Date:      $Date: 2009-04-10 13:33:12 -0400 (Fri, 10 Apr 2009) $
-  Version:   $Revision: 9136 $
-
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 

--- a/Modules/CLI/MergeModels/MergeModels.cxx
+++ b/Modules/CLI/MergeModels/MergeModels.cxx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Insight Segmentation & Registration Toolkit
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/OrientImage.cxx $
-  Language:  C++
-  Date:      $Date: 2007-12-20 18:30:38 -0500 (Thu, 20 Dec 2007) $
-  Version:   $Revision: 5310 $
-
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 

--- a/Modules/CLI/ModelToLabelMap/ModelToLabelMap.cxx
+++ b/Modules/CLI/ModelToLabelMap/ModelToLabelMap.cxx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Insight Segmentation & Registration Toolkit
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/OrientImage.cxx $
-  Language:  C++
-  Date:      $Date: 2007-12-20 18:30:38 -0500 (Thu, 20 Dec 2007) $
-  Version:   $Revision: 5310 $
-
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 

--- a/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
+++ b/Modules/CLI/MultiplyScalarVolumes/MultiplyScalarVolumes.cxx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Insight Segmentation & Registration Toolkit
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/Multiply.cxx $
-  Language:  C++
-  Date:      $Date: 2009-05-13 17:16:00 -0400 (Wed, 13 May 2009) $
-  Version:   $Revision: 9478 $
-
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 

--- a/Modules/CLI/ROITest/CLIROITest.cxx
+++ b/Modules/CLI/ROITest/CLIROITest.cxx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Realign Volumes
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/ROI_InTransform/ROI_InTransform.cxx $
-  Language:  C++
-  Date:      $Date: 2012-03-06 19:15:36 -0500 (Tue, 06 Mar 2012) $
-  Version:   $Revision: 19530 $
-
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.

--- a/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.h
+++ b/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.h
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/DiffusionApplications/ResampleDTI/itkDiffusionTensor3DResample.h $
-  Language:  C++
-  Date:      $Date: 2010/04/05 10:04:59 $
-  Version:   $Revision: 1.1 $
-
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.

--- a/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.txx
+++ b/Modules/CLI/ResampleDTIVolume/itkSeparateComponentsOfADiffusionTensorImage.txx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Diffusion Applications
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/DiffusionApplications/ResampleDTI/itkDiffusionTensor3DResample.txx $
-  Language:  C++
-  Date:      $Date: 2010/04/05 10:04:59 $
-  Version:   $Revision: 1.1 $
-
   Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
 
   See License.txt or http://www.slicer.org/copyright/copyright.txt for details.

--- a/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
+++ b/Modules/CLI/ThresholdScalarVolume/ThresholdScalarVolume.cxx
@@ -1,11 +1,5 @@
 /*=========================================================================
 
-  Program:   Insight Segmentation & Registration Toolkit
-  Module:    $HeadURL: http://svn.slicer.org/Slicer4/trunk/Modules/CLI/Threshold.cxx $
-  Language:  C++
-  Date:      $Date: 2006-12-20 16:00:24 -0500 (Wed, 20 Dec 2006) $
-  Version:   $Revision: 1892 $
-
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 


### PR DESCRIPTION
Locally tested applying this patch:

```diff
diff --git a/CMake/SlicerDashboardScript.TEMPLATE.cmake b/CMake/SlicerDashboardScript.TEMPLATE.cmake
index df38c564d..2d7443cd5 100644
--- a/CMake/SlicerDashboardScript.TEMPLATE.cmake
+++ b/CMake/SlicerDashboardScript.TEMPLATE.cmake
@@ -56,7 +56,7 @@ set(ADDITIONAL_CMAKECACHE_OPTION "
 # WARNING: DO NOT EDIT BEYOND THIS POINT #
 ##########################################
 if(NOT DEFINED DRIVER_SCRIPT)
-  set(url https://raw.githubusercontent.com/Slicer/Slicer/master/CMake/SlicerDashboardDriverScript.cmake)
+  set(url https://raw.githubusercontent.com/jcfr/Slicer/finalize-svn-to-github-transition/CMake/SlicerDashboardDriverScript.cmake)
   set(dest ${DASHBOARDS_DIR}/${EXTENSION_DASHBOARD_SUBDIR}/${CTEST_SCRIPT_NAME}.driver)
   file(DOWNLOAD ${url} ${dest} STATUS status)
   if(NOT status MATCHES "0.*")
```

and running the following commands:

```bash
git clone git://github.com/jcfr/Slicer -b finalize-svn-to-github-transition Slicer-jcfr
cd Slicer-jcfr
~/Software/cmake-3.16.0-rc4-Linux-x86_64/bin/ctest \
  -DHOSTNAME:STRING=CerroTorre \
  -DOPERATING_SYSTEM:STRING=Ubuntu-15.10 \
  -DCOMPILER:STRING=gcc-5.2.1 \
  -DQt5_DIR:PATH=/home/jcfr/Software/Qt5.10.0/5.10.0/gcc_64/lib/cmake/Qt5 \
  -S ./CMake/SlicerDashboardScript.TEMPLATE.cmake
```