### PR TITLE
ENH: Add command line url handling and DICOM import from DICOMweb url

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -872,6 +872,13 @@ void qSlicerCoreApplication::handleCommandLineArguments()
     {
     foreach(QString fileName, unparsedArguments)
       {
+      QUrl url = QUrl(fileName);
+      if (url.scheme().toLower() == this->applicationName().toLower()) // Scheme is case insensitive
+        {
+        emit urlReceived(fileName);
+        continue;
+        }
+
       QFileInfo file(fileName);
       if (file.exists())
         {

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -536,6 +536,11 @@ protected slots:
 signals:
   void mrmlSceneChanged(vtkMRMLScene* mrmlScene);
 
+  /// Signal is emmited when a url argument is processed with the slicer:// protocol
+  /// The url string is emitted with the signal.
+  /// Modules can connect to this signal to handle url arguments.
+  void urlReceived(QString url);
+
   /// Internal method used to move an invocation from a thread to the main thread.
   /// \sa requestInvokeEvent(), scheduleInvokeEvent()
   void invokeEventRequested(unsigned int delay, void* caller,

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -721,17 +721,19 @@ def importFromDICOMWeb(dicomWebEndpoint, studyInstanceUID, seriesInstanceUID=Non
       study_instance_uid=studyInstanceUID,
       series_instance_uid=currentSeriesInstanceUID)
 
-    outputDirectoryBase = slicer.dicomDatabase.databaseDirectory + "/DICOMweb/" + qt.QDateTime.currentDateTime().toString("yyyyMMdd-hhmmss")
-    outputDirectory = qt.QTemporaryDir(outputDirectoryBase) # Add unique substring to directory
+    outputDirectoryBase = slicer.dicomDatabase.databaseDirectory + "/DICOMweb"
+    if not os.access(outputDirectoryBase, os.F_OK):
+      os.makedirs(outputDirectoryBase)
+    outputDirectoryBase += "/" + qt.QDateTime.currentDateTime().toString("yyyyMMdd-hhmmss")
+    outputDirectory = qt.QTemporaryDir(outputDirectoryBase)  # Add unique substring to directory
     outputDirectory.setAutoRemove(False)
     outputDirectoryPath = outputDirectory.path()
-    if not os.access(outputDirectoryPath, os.F_OK):
-      os.makedirs(outputDirectoryPath)
 
     for instance in instances:
       filename = outputDirectoryPath + "/" + str(fileNumber) + ".dcm"
       instance.save_as(filename)
       fileNumber += 1
+      slicer.app.processEvents()
     importDicom(outputDirectoryPath)
 
   return seriesInstanceUIDs


### PR DESCRIPTION
Adds the urlReceived signal to qSlicerCoreApplication that is emitted when a url beginning with the "slicer://" protocol is processed from the command line.
This also adds handling for "slicer://viewer/..." urls, which will import the specified dataset using DICOMweb.