### PR TITLE
COMP: Remove unused function from Tcl wrapping

### DIFF
--- a/Base/QTCore/qSlicerSlicer2SceneReader.cxx
+++ b/Base/QTCore/qSlicerSlicer2SceneReader.cxx
@@ -240,14 +240,6 @@ void qSlicerSlicer2SceneReaderPrivate::importNode(vtkXMLDataElement* element)
     node[attName] = element->GetAttributeValue(i);
   }
 
-  //set nodeType [$element GetName]
-  //set handler ImportNode$nodeType
-  //if { [info command $handler] == "" } {
-  //  set err [$::slicer3::MRMLScene GetErrorMessagePointer]
-  //  $::slicer3::MRMLScene SetErrorMessage "$err\nno handler for $nodeType"
-  //  $::slicer3::MRMLScene SetErrorCode 1
-  //}
-
   // call the handler for this element
   //$handler node
   QString name = element->GetName();

--- a/Base/QTCore/qSlicerXcedeCatalogReader.cxx
+++ b/Base/QTCore/qSlicerXcedeCatalogReader.cxx
@@ -541,12 +541,6 @@ void qSlicerXcedeCatalogReaderPrivate::importEntry(vtkXMLDataElement* element)
   // //--- finally, create the node
   // set handler XcedeCatalogImportEntry$nodeType
 
-  // if { [info command $handler] == "" } {
-  //     set err [$::slicer3::MRMLScene GetErrorMessagePointer]
-  //     $::slicer3::MRMLScene SetErrorMessage "$err\nno handler for $nodeType"
-  //     $::slicer3::MRMLScene SetErrorCode 1
-  // }
-
   // // call the handler for this element
   // puts "Importing $nodeType"
   // $handler node

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -3504,12 +3504,6 @@ void vtkMRMLScene::SetErrorMessage(const char * message)
   this->SetErrorMessage(std::string(message));
   }
 
-//-----------------------------------------------------------------------------
-const char * vtkMRMLScene::GetErrorMessagePointer()
-  {
-  return (this->GetErrorMessage().c_str());
-  }
-
 //----------------------------------------------------------------------------
 vtkMRMLSubjectHierarchyNode* vtkMRMLScene::GetSubjectHierarchyNode()
 {

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -510,7 +510,6 @@ public:
   const std::string& GetSceneXMLString();
 
   void SetErrorMessage(const char * message);
-  const char *GetErrorMessagePointer();
 
   vtkMRMLSubjectHierarchyNode* GetSubjectHierarchyNode();
 


### PR DESCRIPTION
```
Building CXX object Libs/MRML/Core/CMakeFiles/MRMLCore.dir/vtkMRMLScene.cxx.o
Slicer/Libs/MRML/Core/vtkMRMLScene.cxx:3510:11: warning: returning address of local temporary object [-Wreturn-stack-address]
  return (this->GetErrorMessage().c_str());
          ^~~~~~~~~~~~~~~~~~~~~~~
```

Resolves: #4729