### PR TITLE
BUG: Fix mrml and mrb file association on Windows

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -397,21 +397,32 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
 
     set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS)
     set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS)
+
+    if (Slicer_CPACK_NSIS_INSTALL_REQUIRES_ADMIN_ACCOUNT)
+      # Save file association information directly in HKEY_CLASSES_ROOT
+      # when installed as an admin.
+      SET(CR "HKCR \\\"")
+    else()
+      # Save file association information directly in HKEY_CURRENT_USER
+      # when installed without admin rights.
+      SET(CR "HKCU \\\"SOFTWARE\\Classes\\")
+    endif()
+
     foreach(ext ${FILE_EXTENSIONS})
       string(LENGTH "${ext}" len)
       math(EXPR len_m1 "${len} - 1")
       string(SUBSTRING "${ext}" 1 ${len_m1} ext_wo_dot)
       set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
         "${CPACK_NSIS_EXTRA_INSTALL_COMMANDS}
-            WriteRegStr HKCR \\\"${APPLICATION_NAME}\\\" \\\"\\\" \\\"${APPLICATION_NAME} supported file\\\"
-            WriteRegStr HKCR \\\"${APPLICATION_NAME}\\\\shell\\\\open\\\\command\\\" \\\"\\\" \\\"$\\\\\\\"$INSTDIR\\\\${EXECUTABLE_NAME}.exe$\\\\\\\" $\\\\\\\"%1$\\\\\\\"\\\"
-            WriteRegStr HKCR \\\"${ext}\\\" \\\"\\\" \\\"${APPLICATION_NAME}\\\"
-            WriteRegStr HKCR \\\"${ext}\\\" \\\"Content Type\\\" \\\"application/x-${ext_wo_dot}\\\"
-          ")
+WriteRegStr ${CR}${APPLICATION_NAME}\\\" \\\"\\\" \\\"${APPLICATION_NAME} supported file\\\"
+WriteRegStr ${CR}${APPLICATION_NAME}\\\\shell\\\\open\\\\command\\\" \\\"\\\" \\\"$\\\\\\\"$INSTDIR\\\\${EXECUTABLE_NAME}.exe$\\\\\\\" $\\\\\\\"%1$\\\\\\\"\\\"
+WriteRegStr ${CR}${ext}\\\" \\\"\\\" \\\"${APPLICATION_NAME}\\\"
+WriteRegStr ${CR}${ext}\\\" \\\"Content Type\\\" \\\"application/x-${ext_wo_dot}\\\"
+")
       set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "${CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS}
-            DeleteRegKey HKCR \\\" ${APPLICATION_NAME}\\\"
-            DeleteRegKey HKCR \\\"${ext}\\\"
-          ")
+DeleteRegKey ${CR}${APPLICATION_NAME}\\\"
+DeleteRegKey ${CR}${ext}\\\"
+")
     endforeach()
   endif()
 


### PR DESCRIPTION
File associations has not been registered since admin access requirement was removed from installer, as a regular user cannot write HKEY_CLASSES_ROOT registry section.

Updated installer so that if installation is done without admin access, file association is saved in HKEY_CURRENT_USER section of registry.