### PR TITLE
Updating Python Packages to latest - March 2020 

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -40,16 +40,16 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  pydicom==1.3.0 --hash=sha256:ee3a94de180c6337e1443ce346730a784f9027f56175f61ba4dfda632693b843
+  pydicom==1.4.2 --hash=sha256:f315ba2296346f4f9913c269618201e170b9326362e2ada6041ca91b7cb2117b
   # Hashes correspond to the following packages:
-  #  - Pillow-6.2.1-cp36-cp36m-win_amd64.whl
-  #  - Pillow-6.2.1-cp36-cp36m-macosx_10_6_intel.whl
-  #  - Pillow-6.2.1-cp36-cp36m-manylinux1_x86_64.whl
-  pillow==6.2.1 --hash=sha256:83792cb4e0b5af480588601467c0764242b9a483caea71ef12d22a0d0d6bdce2 \
-                --hash=sha256:846fa202bd7ee0f6215c897a1d33238ef071b50766339186687bd9b7a6d26ac5 \
-                --hash=sha256:e0697b826da6c2472bb6488db4c0a7fa8af0d52fa08833ceb3681358914b14e5
-  six==1.12.0 --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c
-  dicomweb_client==0.14.0 --hash=sha256:6391a8a8be33919c2aa869f6538eeeb3d00f2546cb5abd29c8e03bc30cf90e44
+  #  - Pillow-7.0.0-cp36-cp36m-win_amd64.whl
+  #  - Pillow-7.0.0-cp36-cp36m-macosx_10_6_intel.whl
+  #  - Pillow-7.0.0-cp36-cp36m-manylinux1_x86_64.whl
+  pillow==7.0.0 --hash=sha256:bf598d2e37cf8edb1a2f26ed3fb255191f5232badea4003c16301cb94ac5bdd0 \
+                --hash=sha256:ab76e5580b0ed647a8d8d2d2daee170e8e9f8aad225ede314f684e297e3643c2 \
+                --hash=sha256:8ac6ce7ff3892e5deaab7abaec763538ffd011f74dc1801d93d3c5fc541feee2
+  six==1.14.0 --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
+  dicomweb-client==0.21.0 --hash=sha256:e8b46e517a5399b85b2f4e724e54bfe3a934bc22c9c2ba3d0e92eb3e87846228
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -35,10 +35,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
-  gitdb2==2.0.6 --hash=sha256:96bbb507d765a7f51eb802554a9cfe194a174582f772e0d89f4e87288c288b7b
-  smmap2==2.0.5 --hash=sha256:0555a7bf4df71d1ef4218e4807bbf9b201f910174e6e08af2e138d4e517b4dde
-  GitPython==3.0.4 --hash=sha256:a7d6bef0775f66ba47f25911d285bcd692ce9053837ff48a120c2b8cf3a71389
-  six==1.12.0 --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c
+  gitdb==4.0.2 --hash=sha256:284a6a4554f954d6e737cddcff946404393e030b76a282c6640df8efd6b3da5e
+  smmap==3.0.1 --hash=sha256:5fead614cf2de17ee0707a8c6a5f2aa5a2fc6c698c70993ba42f515485ffda78
+  GitPython==3.1.0 --hash=sha256:43da89427bdf18bf07f1164c6d415750693b4d50e28fc9b68de706245147b9dd
+  six==1.14.0 --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -33,10 +33,9 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   PyJWT==1.7.1 --hash=sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e
-  six==1.12.0 --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c
-  wrapt==1.11.2 --hash=sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1
-  Deprecated==1.2.6 --hash=sha256:b07b414c8aac88f60c1d837d21def7e83ba711052e03b3cbaff27972567a8f8d
-  PyGithub==1.44 --hash=sha256:fd10fc9006fd54080b190c5c863384381905160c8ea8e830c4a3d8219f23193d
+  wrapt==1.12.1 --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
+  Deprecated==1.2.7 --hash=sha256:8b6a5aa50e482d8244a62e5582b96c372e87e3a28e8b49c316e46b95c76a611d
+  PyGithub==1.47 --hash=sha256:2638ea9a2070d995197dca2ac521c207f8de000cc3aa5e912e264932886781ba
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -31,12 +31,12 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   nose==1.3.7 --hash=sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac  # needed for NumPy unit tests
   # Hashes correspond to the following packages:
-  # - numpy-1.17.3-cp36-cp36m-win_amd64.whl
-  # - numpy-1.17.3-cp36-cp36m-macosx_10_9_x86_64.whl
-  # - numpy-1.17.3-cp36-cp36m-manylinux1_x86_64.whl
-  numpy==1.17.3 --hash=sha256:2e418f0a59473dac424f888dd57e85f77502a593b207809211c76e5396ae4f5c \
-                --hash=sha256:669795516d62f38845c7033679c648903200980d68935baaa17ac5c7ae03ae0c \
-                --hash=sha256:4f2a2b279efde194877aff1f76cf61c68e840db242a5c7169f1ff0fd59a2b1e2
+  # - numpy-1.18.1-cp36-cp36m-win_amd64.whl
+  # - numpy-1.18.1-cp36-cp36m-macosx_10_9_x86_64.whl
+  # - numpy-1.18.1-cp36-cp36m-manylinux1_x86_64.whl
+  numpy==1.18.1 --hash=sha256:9acdf933c1fd263c513a2df3dceecea6f3ff4419d80bf238510976bf9bcb26cd \
+                --hash=sha256:ae0975f42ab1f28364dcda3dde3cf6c1ddab3e1d4b2909da0cb0191fa9ca0480 \
+                --hash=sha256:b765ed3930b92812aa698a455847141869ef755a87e099fddd4ccf9d81fffb57
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -26,7 +26,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  pip==19.3.1 --hash=sha256:6917c65fc3769ecdc61405d3dfd97afdedd75808d200b2838d7d961cebc0c2c7
+  pip==20.0.2 --hash=sha256:4ae14a42d8adba3205ebeb38aa68cfc0b6c346e1ae2e699a0b3bad4da19cef5c
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -31,9 +31,9 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  packaging==19.2 --hash=sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108
-  pyparsing==2.4.2 --hash=sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4
-  six==1.12.0 --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c
+  packaging==20.3 --hash=sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752
+  pyparsing==2.4.6 --hash=sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec
+  six==1.14.0 --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -26,11 +26,11 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  certifi==2019.9.11 --hash=sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef
-  idna==2.8 --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c
+  certifi==2019.11.28 --hash=sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3
+  idna==2.9 --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa
   chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-  urllib3==1.25.6 --hash=sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398
-  requests==2.22.0 --hash=sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31
+  urllib3==1.25.8 --hash=sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc
+  requests==2.23.0 --hash=sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -30,12 +30,12 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # Hashes correspond to the following packages:
-  # - scipy-1.3.1-cp36-cp36m-win_amd64.whl
-  # - scipy-1.3.1-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-  # - scipy-1.3.1-cp36-cp36m-manylinux1_x86_64.whl
-  scipy==1.3.1 --hash=sha256:a81da2fe32f4eab8b60d56ad43e44d93d392da228a77e229e59b51508a00299c \
-              --hash=sha256:46a5e55850cfe02332998b3aef481d33f1efee1960fe6cfee0202c7dd6fc21ab \
-              --hash=sha256:75b513c462e58eeca82b22fc00f0d1875a37b12913eee9d979233349fce5c8b2
+  # - scipy-1.4.1-cp36-cp36m-win_amd64.whl
+  # - scipy-1.4.1-cp36-cp36m-macosx_10_6_intel.whl
+  # - scipy-1.4.1-cp36-cp36m-manylinux1_x86_64.whl
+  scipy==1.4.1 --hash=sha256:dc60bb302f48acf6da8ca4444cfa17d52c63c5415302a9ee77b3b21618090521 \
+              --hash=sha256:bb517872058a1f087c4528e7429b4a44533a902644987e7b2fe35ecc223bc408 \
+              --hash=sha256:386086e2972ed2db17cebf88610aab7d7f6e2c0ca30042dc9a89cf18dcc363fa
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -25,7 +25,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  setuptools==41.6.0 --hash=sha256:3e8e8505e563631e7cb110d9ad82d135ee866b8146d5efe06e42be07a72db20a
+  setuptools==46.0.0 --hash=sha256:693e0504490ed8420522bf6bc3aa4b0da6a9f1c80c68acfb4e959275fd04cd82
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -26,7 +26,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  wheel==0.33.6 --hash=sha256:f4da1763d3becf2e2cd92a14a7c920f0f00eca30fdde9ea992c836685b9faf28
+  wheel==0.34.2 --hash=sha256:df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e
   ]===])
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
Python packages were last updated November 10th, 2019. Outdated python packages were discovered using the below code snippet and then versions, hashes and dependencies were determined and updated.
```powershell
./SlicerPython.exe -m pip list --outdated
```

Tests were run locally on Windows with the same currently failing tests on the dashboard also only being the ones to fail.

@pieper  This includes updating the pydicom version as you indicated you wanted in https://github.com/Slicer/SlicerGitSVNArchive/pull/1254#issuecomment-597660126.