### PR TITLE
ENH: Set imported segmentation names from label value

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -857,7 +857,9 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
       }
     else
       {
-      currentSegmentID = segmentation->GenerateUniqueSegmentID("Segment");
+      std::stringstream segmentNameSS;
+      segmentNameSS << "Segment_" << currentSegment->GetLabelValue();
+      currentSegmentID = segmentation->GenerateUniqueSegmentID(segmentNameSS.str());
       currentSegment->SetName(currentSegmentID.c_str());
       }
     segmentation->AddSegment(currentSegment, currentSegmentID);


### PR DESCRIPTION
Previously imported segmentations used linearly increasing identifiers when importing (Segment, Segment_1, Segment_2, etc.). Now names are generated using the label value of the segment (Segment_1, Segment_4, Segment_5, etc for label values 1, 4, and 5).

Fixes #4733