### PR TITLE
ENH: Improve Slicer Data Bundle DICOM export and import

### DIFF
--- a/Modules/CLI/CreateDICOMSeries/CreateDICOMSeries.cxx
+++ b/Modules/CLI/CreateDICOMSeries/CreateDICOMSeries.cxx
@@ -150,6 +150,7 @@ int DoIt( int argc, char * argv[])
     else if (modality=="CR")  { sopClassUID = "1.2.840.10008.5.1.4.1.1.1"; }
     else if (modality=="NM")  { sopClassUID = "1.2.840.10008.5.1.4.1.1.20"; }
     else if (modality=="US")  { sopClassUID = "1.2.840.10008.5.1.4.1.1.6.1"; }
+    else if (modality=="SC")  { sopClassUID = "1.2.840.10008.5.1.4.1.1.7"; }
     else
       {
       std::cerr << "Unknown modality: " << modality << ". Using CT Image Storage SOP class UID." << std::endl;


### PR DESCRIPTION
- Slicer Data Bundle exporter can save to user defined path
- Slicer Data Bundle exporter can use custom tags: study description and series description as separate member variables (because they have defaults in the exporter), and an optional tags map to specify any tag
- Allow Slicer Data Bundle exporter to export custom image to the Secondary Capture series
- Add option to Slicer Data Bundle exporter for copying SDB DICOM file to database or not when importing
- Slicer Data Bundle DICOM plugin now sets up subject hierarchy as all other DICOM plugins when importing. Important so that patient/study/series data are stored somewhere in the scene. The series node is the first volume or (non-slice) model or markup
- Allow CreateDICOMSeries module to export Secondary Capture