### PR TITLE
ENH: Add JPG support to Screen Capture

### DIFF
--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -1022,7 +1022,14 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
       imageClipper.Update()
       capturedImage = imageClipper.GetOutput()
 
-    writer = vtk.vtkPNGWriter()
+    name, extension = os.path.splitext(filename)
+    if extension.lower() == '.png':
+      writer = vtk.vtkPNGWriter()
+    elif extension.lower() == '.jpg' or extension.lower() == '.jpeg':
+      writer = vtk.vtkJPEGWriter()
+    else:
+      logging.error('Unsupported image format based on file name ' + filename)
+      return
     writer.SetInputData(self.addWatermark(capturedImage))
     writer.SetFileName(filename)
     writer.Write()


### PR DESCRIPTION
DCMTK Secondary Capture only supports JPG files, so instead of converting within the application, JPG support has been added to the Screen Capture module