### PR TITLE
BUG: Fix failed loading of model nodes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -1225,6 +1225,7 @@ int vtkMRMLStorageNode::ReadData(vtkMRMLNode* refNode, bool temporary)
 //------------------------------------------------------------------------------
 int vtkMRMLStorageNode::WriteData(vtkMRMLNode* refNode)
 {
+  this->WriteState = this->Idle;
   if (refNode == nullptr)
     {
     vtkErrorMacro("WriteData: can't write, input node is null");


### PR DESCRIPTION
If a model node was empty when the scene was saved then write state of its storage node was set SkippedNoData.
This write state was never updated to Idle, even when later the model was saved successfully.