### PR TITLE
ENH: Added Python scripted CLI module template

### DIFF
--- a/Utilities/Templates/Modules/ScriptedCLI/CMakeLists.txt
+++ b/Utilities/Templates/Modules/ScriptedCLI/CMakeLists.txt
@@ -1,0 +1,29 @@
+#-----------------------------------------------------------------------------
+set(MODULE_NAME TemplateKey)
+
+#-----------------------------------------------------------------------------
+# If the module only consists of ${MODULE_NAME}.py and ${MODULE_NAME}.xml
+# then no changes are needed in the lines below.
+
+set(CLI_DEST "${CMAKE_BINARY_DIR}/${Slicer_CLIMODULES_BIN_DIR}")
+set(CLI_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_custom_command(
+  OUTPUT "${CLI_DEST}/${MODULE_NAME}.py" "${CLI_DEST}/${MODULE_NAME}.xml"
+  COMMAND "${CMAKE_COMMAND}" -E make_directory "${CLI_DEST}"
+  COMMAND "${CMAKE_COMMAND}" -E copy "${CLI_SOURCE}/${MODULE_NAME}.py" "${CLI_DEST}"
+  COMMAND "${CMAKE_COMMAND}" -E copy "${CLI_SOURCE}/${MODULE_NAME}.xml" "${CLI_DEST}"
+  DEPENDS "${CLI_SOURCE}/${MODULE_NAME}.xml" "${CLI_SOURCE}/${MODULE_NAME}.py"
+  )
+
+add_custom_target(${MODULE_NAME} ALL
+  SOURCES "${CLI_SOURCE}/${MODULE_NAME}.py" "${CLI_SOURCE}/${MODULE_NAME}.xml"
+  DEPENDS "${CLI_DEST}/${MODULE_NAME}.py" "${CLI_DEST}/${MODULE_NAME}.xml"
+  COMMENT "Copying ${MODULE_NAME} files to  ${CLI_DEST}"
+  )
+
+install(FILES ${MODULE_NAME}.py ${MODULE_NAME}.xml
+  DESTINATION "${Slicer_INSTALL_CLIMODULES_BIN_DIR}"
+  COMPONENT Runtime
+  USE_SOURCE_PERMISSIONS
+  )

--- a/Utilities/Templates/Modules/ScriptedCLI/TemplateKey.py
+++ b/Utilities/Templates/Modules/ScriptedCLI/TemplateKey.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python-real
+
+import os
+import sys
+
+def main(input, sigma, output):
+
+    import SimpleITK as sitk
+
+    reader = sitk.ImageFileReader()
+    reader.SetFileName(input)
+    image = reader.Execute()
+
+    pixelID = image.GetPixelID()
+
+    gaussian = sitk.SmoothingRecursiveGaussianImageFilter()
+    gaussian.SetSigma(sigma)
+    image = gaussian.Execute(image)
+
+    caster = sitk.CastImageFilter()
+    caster.SetOutputPixelType(pixelID)
+    image = caster.Execute(image)
+
+    writer = sitk.ImageFileWriter()
+    writer.SetFileName (output)
+    writer.Execute (image)
+
+
+if __name__ == "__main__":
+    if len (sys.argv) < 4:
+        print("Usage: TemplateKey <input> <sigma> <output>")
+        sys.exit (1)
+    main(sys.argv[1], float(sys.argv[2]), sys.argv[3])

--- a/Utilities/Templates/Modules/ScriptedCLI/TemplateKey.xml
+++ b/Utilities/Templates/Modules/ScriptedCLI/TemplateKey.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<executable>
+  <category>Examples</category>
+  <index>0</index>
+  <title>TemplateKey</title>
+  <description><![CDATA[Apply a Gaussian blur to an image]]></description>
+  <version>0.1.0.</version>
+  <documentation-url>https://github.com/lassoan/SlicerPythonCLIExample</documentation-url>
+  <license/>
+  <contributor>Andras Lasso (PerkLab)</contributor>
+  <acknowledgements><![CDATA[This work is part of the National Alliance for Medical Image Computing (NAMIC), funded by the National Institutes of Health through the NIH Roadmap for Medical Research, Grant U54 EB005149.]]></acknowledgements>
+  <parameters>
+    <double>
+      <name>sigma</name>
+      <label>Sigma</label>
+      <index>1</index>
+      <description><![CDATA[Sigma value in physical units (e.g., mm) of the Gaussian kernel]]></description>
+      <default>1.0</default>
+    </double>
+    <label>IO</label>
+    <description><![CDATA[Input/output parameters]]></description>
+    <image>
+      <name>inputVolume</name>
+      <label>Input Volume</label>
+      <channel>input</channel>
+      <index>0</index>
+      <description><![CDATA[Input volume]]></description>
+    </image>
+    <image reference="inputVolume">
+      <name>outputVolume</name>
+      <label>Output Volume</label>
+      <channel>output</channel>
+      <index>2</index>
+      <description><![CDATA[Blurred Volume]]></description>
+    </image>
+  </parameters>
+</executable>


### PR DESCRIPTION
Python scripted CLI modules are Python scripts that are made possible to run in Slicer simply by providing an XML file that describe the interface.

"Python scripted CLI" module .py file's first line must start with shebang (#!), to distinguish it from a "Python scripted loadable" module.