### PR TITLE
ENH: Add option to build Slicer using system vtkAddon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,9 @@ option(Slicer_USE_FOLDERS "Organize build targets into folders" ON)
 mark_as_superbuild(Slicer_USE_FOLDERS)
 mark_as_advanced(Slicer_USE_FOLDERS)
 
+option(Slicer_USE_SYSTEM_vtkAddon "Build Slicer using system vtkAddon" OFF)
+mark_as_superbuild(Slicer_USE_SYSTEM_vtkAddon:BOOL)
+
 #-----------------------------------------------------------------------------
 # External projects related options
 #-----------------------------------------------------------------------------
@@ -859,8 +862,10 @@ set(SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES "" CACHE INTERNAL "Sl
 # Set Slicer builtin libraries *_DIR variables
 #-----------------------------------------------------------------------------
 set(GenerateLM_DIR ${Slicer_BINARY_DIR}/Libs/GenerateLM)
-set(vtkAddon_DIR ${Slicer_BINARY_DIR}/Libs/vtkAddon)
 set(vtkITK_DIR ${Slicer_BINARY_DIR}/Libs/vtkITK)
+if (NOT Slicer_USE_SYSTEM_vtkAddon)
+  set(vtkAddon_DIR ${Slicer_BINARY_DIR}/Libs/vtkAddon)
+endif()
 
 #-----------------------------------------------------------------------------
 # Set COVERAGE_{C,CXX}_FLAGS variables

--- a/Libs/CMakeLists.txt
+++ b/Libs/CMakeLists.txt
@@ -19,8 +19,13 @@ set(SlicerExecutionModel_EXTRA_EXECUTABLE_TARGET_LIBRARIES
   CACHE INTERNAL "SlicerExecutionModel extra executable target libraries" FORCE
   )
 
+if (NOT Slicer_USE_SYSTEM_vtkAddon)
+  list(APPEND dirs
+    vtkAddon
+    )
+endif()
+
 list(APPEND dirs
-  vtkAddon
   vtkTeem
   vtkITK
   vtkSegmentationCore
@@ -128,7 +133,6 @@ set(MRML_LIBRARIES ${_mrml_libraries} CACHE INTERNAL "MRML libraries" FORCE)
 # Set variable Slicer_Libs_VTK_WRAPPED_LIBRARIES
 #-----------------------------------------------------------------------------
 set(_vtk_wrapped_libraries
-  vtkAddon
   vtkSegmentationCore
   vtkTeem
   vtkITK
@@ -136,6 +140,12 @@ set(_vtk_wrapped_libraries
   MRMLCore
   MRMLLogic
   )
+
+if (NOT Slicer_USE_SYSTEM_vtkAddon)
+  list(APPEND _vtk_wrapped_libraries
+    vtkAddon
+    )
+endif()
 if(Slicer_USE_PYTHONQT AND VTK_WRAP_PYTHON)
   list(APPEND _vtk_wrapped_libraries MRMLDisplayableManager)
 endif()

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -60,6 +60,13 @@ if(MRML_USE_vtkTeem)
   include(${Teem_USE_FILE})
 endif()
 
+#
+# vtkAddon
+#
+if (Slicer_USE_SYSTEM_vtkAddon)
+  find_package(vtkAddon REQUIRED)
+endif()
+
 # --------------------------------------------------------------------------
 # Include dirs
 # --------------------------------------------------------------------------

--- a/Libs/vtkSegmentationCore/CMakeLists.txt
+++ b/Libs/vtkSegmentationCore/CMakeLists.txt
@@ -69,6 +69,13 @@ set(vtkSegmentationCore_SRCS
 #  ABSTRACT
 #  )
 
+#
+# vtkAddon
+#
+if (Slicer_USE_SYSTEM_vtkAddon)
+  find_package(vtkAddon REQUIRED)
+endif()
+
 set(vtkSegmentationCore_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -473,6 +473,10 @@ if(WIN32)
   list(APPEND EXTERNAL_PROJECT_OPTIONAL_ARGS -DSlicer_SKIP_ROOT_DIR_MAX_LENGTH_CHECK:BOOL=ON)
 endif()
 
+if (Slicer_USE_SYSTEM_vtkAddon)
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_ARGS -DvtkAddon_DIR:PATH=${vtkAddon_DIR})
+endif()
+
 #------------------------------------------------------------------------------
 # Customizing SlicerApp metadata
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Adds the Slicer_USE_SYSTEM_vtkAddon option, which is OFF by default.
This allows extensions with dependencies that rely on vtkAddon to be built in custom apps.