### PR TITLE
COMP: Fix compilation when Slicer_BUILD_vtkAddon is OFF

### DIFF
--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 #
 # vtkAddon
 #
-if (Slicer_USE_SYSTEM_vtkAddon)
+if(NOT Slicer_BUILD_vtkAddon)
   find_package(vtkAddon REQUIRED)
 endif()
 

--- a/Libs/vtkITK/CMakeLists.txt
+++ b/Libs/vtkITK/CMakeLists.txt
@@ -57,6 +57,13 @@ list(APPEND ITK_LIBRARIES ITKFactoryRegistration)
 list(APPEND ITK_INCLUDE_DIRS ${ITKFactoryRegistration_INCLUDE_DIRS})
 include(${ITK_USE_FILE})
 
+#
+# vtkAddon
+#
+if(NOT Slicer_BUILD_vtkAddon)
+  find_package(vtkAddon REQUIRED)
+endif()
+
 # --------------------------------------------------------------------------
 # Include dirs
 # --------------------------------------------------------------------------

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -205,7 +205,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 183e5197d0eb9b5f6a353fbf126bf3347cbdeece
+  GIT_TAG af1d32d4bad5d2fab96b8eef0d7504ee27a07199
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_MultiVolumeExplorer Slicer_REMOTE_DEPENDENCIES MultiVolumeExplorer)


### PR DESCRIPTION
vtkAddonTargets.cmake is not generated when building Slicer_BUILD_vtkAddon is on.
When built externally, vtkAddonTargets.cmake needs to be included manually, since it is not included in vtkAddonConfig.cmake.