### PR TITLE
ENH: Remove redundant reference to volume node in volume rendering display node

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.cxx
@@ -33,8 +33,6 @@ Version:   $Revision: 1.2 $
 #include <sstream>
 
 //----------------------------------------------------------------------------
-const char* vtkMRMLVolumeRenderingDisplayNode::VolumeNodeReferenceRole = "volume";
-const char* vtkMRMLVolumeRenderingDisplayNode::VolumeNodeReferenceMRMLAttributeName = "volumeNodeID";
 const char* vtkMRMLVolumeRenderingDisplayNode::VolumePropertyNodeReferenceRole = "volumeProperty";
 const char* vtkMRMLVolumeRenderingDisplayNode::VolumePropertyNodeReferenceMRMLAttributeName = "volumePropertyNodeID";
 const char* vtkMRMLVolumeRenderingDisplayNode::ROINodeReferenceRole = "roi";
@@ -45,9 +43,6 @@ const char* vtkMRMLVolumeRenderingDisplayNode::ShaderPropertyNodeReferenceMRMLAt
 //----------------------------------------------------------------------------
 vtkMRMLVolumeRenderingDisplayNode::vtkMRMLVolumeRenderingDisplayNode()
 {
-  this->AddNodeReferenceRole(VolumeNodeReferenceRole,
-                             VolumeNodeReferenceMRMLAttributeName);
-
   vtkNew<vtkIntArray> volumePropertyEvents;
   volumePropertyEvents->InsertNextValue(vtkCommand::StartEvent);
   volumePropertyEvents->InsertNextValue(vtkCommand::EndEvent);
@@ -154,21 +149,16 @@ void vtkMRMLVolumeRenderingDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLVolumeRenderingDisplayNode::SetAndObserveVolumeNodeID(const char* volumeNodeID)
-{
-  this->SetAndObserveNodeReferenceID(VolumeNodeReferenceRole, volumeNodeID);
-}
-
-//----------------------------------------------------------------------------
 const char* vtkMRMLVolumeRenderingDisplayNode::GetVolumeNodeID()
 {
-  return this->GetNodeReferenceID(VolumeNodeReferenceRole);
+  vtkMRMLDisplayableNode* volumeNode = this->GetDisplayableNode();
+  return (volumeNode ? volumeNode->GetID() : nullptr);
 }
 
 //----------------------------------------------------------------------------
 vtkMRMLVolumeNode* vtkMRMLVolumeRenderingDisplayNode::GetVolumeNode()
 {
-  return vtkMRMLVolumeNode::SafeDownCast(this->GetNodeReference(VolumeNodeReferenceRole));
+  return vtkMRMLVolumeNode::SafeDownCast(this->GetDisplayableNode());
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumeRenderingDisplayNode.h
@@ -48,7 +48,6 @@ public:
   void Copy(vtkMRMLNode *node) override;
 
   const char* GetVolumeNodeID();
-  void SetAndObserveVolumeNodeID(const char *volumeNodeID);
   vtkMRMLVolumeNode* GetVolumeNode();
 
   const char* GetVolumePropertyNodeID();
@@ -95,8 +94,6 @@ protected:
 
   void ProcessMRMLEvents(vtkObject *caller, unsigned long event, void *callData) override;
 
-  static const char* VolumeNodeReferenceRole;
-  static const char* VolumeNodeReferenceMRMLAttributeName;
   static const char* VolumePropertyNodeReferenceRole;
   static const char* VolumePropertyNodeReferenceMRMLAttributeName;
   static const char* ROINodeReferenceRole;

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingMultiVolumeTest.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingMultiVolumeTest.cxx
@@ -121,9 +121,9 @@ void SetupVolumeNode(vtkMRMLScene* scene, vtkMRMLScalarVolumeNode* volumeNode)
   scene->AddNode(volumePropertyNode.GetPointer());
 
   vtkNew<vtkMRMLCPURayCastVolumeRenderingDisplayNode> vrDisplayNode;
-  vrDisplayNode->SetAndObserveVolumeNodeID(volumeNode->GetID());
   vrDisplayNode->SetAndObserveVolumePropertyNodeID(volumePropertyNode->GetID());
   scene->AddNode(vrDisplayNode.GetPointer());
+  volumeNode->AddAndObserveDisplayNodeID(vrDisplayNode->GetID());
 }
 
 char TestCopyImageDataEventLog[] =

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -211,9 +211,15 @@ vtkMRMLVolumeRenderingDisplayNode* qSlicerVolumeRenderingModuleWidgetPrivate::cr
     return nullptr;
     }
 
-  vtkMRMLVolumeRenderingDisplayNode* displayNode = logic->CreateVolumeRenderingDisplayNode();
+  vtkSmartPointer<vtkMRMLVolumeRenderingDisplayNode> displayNode =
+    vtkSmartPointer<vtkMRMLVolumeRenderingDisplayNode>::Take(logic->CreateVolumeRenderingDisplayNode());
+  displayNode->SetVisibility(0);
   q->mrmlScene()->AddNode(displayNode);
-  displayNode->Delete();
+
+  if (volumeNode)
+    {
+    volumeNode->AddAndObserveDisplayNodeID(displayNode->GetID());
+    }
 
   int wasModifying = displayNode->StartModify();
   // Initialize volume rendering without the threshold info of the Volumes module
@@ -223,17 +229,12 @@ vtkMRMLVolumeRenderingDisplayNode* qSlicerVolumeRenderingModuleWidgetPrivate::cr
   displayNode->SetIgnoreVolumeDisplayNodeThreshold(this->IgnoreVolumesThresholdCheckBox->isChecked());
   // Do not show newly selected volume (because it would be triggered by simply selecting it in the combobox,
   // and it would not adhere to the customary Slicer behavior)
-  displayNode->SetVisibility(0);
   // Set selected views to the display node
   foreach (vtkMRMLAbstractViewNode* viewNode, this->ViewCheckableNodeComboBox->checkedViewNodes())
     {
     displayNode->AddViewNodeID(viewNode ? viewNode->GetID() : nullptr);
     }
   displayNode->EndModify(wasModifying);
-  if (volumeNode)
-    {
-    volumeNode->AddAndObserveDisplayNodeID(displayNode->GetID());
-    }
   return displayNode;
 }
 


### PR DESCRIPTION
vtkMRMLVolumeRenderingDisplayNode::SetAndObserveVolumeNodeID method was removed, as display node base class already maintains a pointer to the displayed (volume) node.

Updated migration guide (https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide/Slicer#Volume_rendering).

Fixes #2628.