### PR TITLE
BUG: Apply segmentation parent transform to draw effect

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorDrawEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorDrawEffect.py
@@ -221,7 +221,8 @@ class DrawPipeline(object):
       modifierLabelmap = self.scriptedEffect.defaultModifierLabelmap()
 
       # Apply poly data on modifier labelmap
-      self.scriptedEffect.appendPolyMask(modifierLabelmap, self.polyData, self.sliceWidget)
+      segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
+      self.scriptedEffect.appendPolyMask(modifierLabelmap, self.polyData, self.sliceWidget, segmentationNode)
 
     self.resetPolyData()
     if lineExists:

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractLabelEffect.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractLabelEffect.h
@@ -77,7 +77,7 @@ public slots:
 public:
 
   /// Rasterize a poly data onto the input image into the slice view
-  Q_INVOKABLE static void appendPolyMask(vtkOrientedImageData* input, vtkPolyData* polyData, qMRMLSliceWidget* sliceWidget);
+  Q_INVOKABLE static void appendPolyMask(vtkOrientedImageData* input, vtkPolyData* polyData, qMRMLSliceWidget* sliceWidget, vtkMRMLSegmentationNode* segmentationNode=nullptr);
 
   /// Create a slice view screen space (2D) mask image for the given polydata
   Q_INVOKABLE static void createMaskImageFromPolyData(vtkPolyData* polyData, vtkOrientedImageData* outputMask, qMRMLSliceWidget* sliceWidget);


### PR DESCRIPTION
The polydata for the draw effect was rasterized in the world coordinate system.
If the segmentation node was under a transform node, the transform would not be taken into account when modifying the segment.

This commit transforms the rasterized image to the same coordinate system as the segmentation before appending it to the modifier labelmap.

re #4685