### PR TITLE
BUG: Apply segmentation parent transform to level-tracing effect

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorEffect.py
@@ -68,16 +68,16 @@ class AbstractScriptedSegmentEditorEffect(object):
     rasVector = self.scriptedEffect.xyToRas(xyPoint, viewWidget)
     return [rasVector.x(), rasVector.y(), rasVector.z()]
 
-  def xyzToIjk(self, xyz, viewWidget, image):
+  def xyzToIjk(self, xyz, viewWidget, image, parentTransformNode=None):
     import vtkSegmentationCorePython as vtkSegmentationCore
     xyzVector = qt.QVector3D(xyz[0], xyz[1], xyz[2])
-    ijkVector = self.scriptedEffect.xyzToIjk(xyzVector, viewWidget, image)
+    ijkVector = self.scriptedEffect.xyzToIjk(xyzVector, viewWidget, image, parentTransformNode)
     return [int(ijkVector.x()), int(ijkVector.y()), int(ijkVector.z())]
 
-  def xyToIjk(self, xy, viewWidget, image):
+  def xyToIjk(self, xy, viewWidget, image, parentTransformNode=None):
     import vtkSegmentationCorePython as vtkSegmentationCore
     xyPoint = qt.QPoint(xy[0], xy[1])
-    ijkVector = self.scriptedEffect.xyToIjk(xyPoint, viewWidget, image)
+    ijkVector = self.scriptedEffect.xyToIjk(xyPoint, viewWidget, image, parentTransformNode)
     return [int(ijkVector.x()), int(ijkVector.y()), int(ijkVector.z())]
 
   def setWidgetMinMaxStepFromImageSpacing(self, spinbox, imageData):

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
@@ -39,6 +39,7 @@ class vtkMRMLScene;
 class vtkMRMLSegmentEditorNode;
 class vtkMRMLAbstractViewNode;
 class vtkMRMLSegmentationNode;
+class vtkMRMLTransformNode;
 class vtkSegment;
 class vtkRenderer;
 class vtkRenderWindow;
@@ -374,15 +375,15 @@ public:
   /// Convert XY in-slice position to RAS position, python accessor method
   Q_INVOKABLE static QVector3D xyToRas(QPoint xy, qMRMLSliceWidget* sliceWidget);
   /// Convert XYZ slice view position to image IJK position, \sa xyzToRas
-  static void xyzToIjk(double inputXyz[3], int outputIjk[3], qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image);
+  static void xyzToIjk(double inputXyz[3], int outputIjk[3], qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image, vtkMRMLTransformNode* parentTransform = nullptr);
   /// Convert XYZ slice view position to image IJK position, python accessor method, \sa xyzToRas
-  Q_INVOKABLE static QVector3D xyzToIjk(QVector3D inputXyz, qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image);
+  Q_INVOKABLE static QVector3D xyzToIjk(QVector3D inputXyz, qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image, vtkMRMLTransformNode* parentTransform = nullptr);
   /// Convert XY in-slice position to image IJK position
-  static void xyToIjk(QPoint xy, int outputIjk[3], qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image);
+  static void xyToIjk(QPoint xy, int outputIjk[3], qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image, vtkMRMLTransformNode* parentTransform = nullptr);
   /// Convert XY in-slice position to image IJK position
-  static void xyToIjk(double xy[2], int outputIjk[3], qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image);
+  static void xyToIjk(double xy[2], int outputIjk[3], qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image, vtkMRMLTransformNode* parentTransform = nullptr);
   /// Convert XY in-slice position to image IJK position, python accessor method
-  Q_INVOKABLE static QVector3D xyToIjk(QPoint xy, qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image);
+  Q_INVOKABLE static QVector3D xyToIjk(QPoint xy, qMRMLSliceWidget* sliceWidget, vtkOrientedImageData* image, vtkMRMLTransformNode* parentTransform = nullptr);
 
   Q_INVOKABLE static void forceRender(qMRMLWidget* viewWidget);
   Q_INVOKABLE static void scheduleRender(qMRMLWidget* viewWidget);


### PR DESCRIPTION
The position of the mouse in IJK coordinates, as well as the position of the polydata did not previously take into account the parent transform of the segmentation.

re #4685