### PR TITLE
BUG: Apply segmentation parent transform to island effect

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorIslandsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorIslandsEffect.py
@@ -286,7 +286,7 @@ class SegmentEditorIslandsEffect(AbstractScriptedSegmentEditorEffect):
       inputLabelImage.SetImageToWorldMatrix(selectedSegmentLabelmapImageToWorldMatrix)
 
     xy = callerInteractor.GetEventPosition()
-    ijk = self.xyToIjk(xy, viewWidget, inputLabelImage)
+    ijk = self.xyToIjk(xy, viewWidget, inputLabelImage, segmentationNode.GetParentTransformNode())
     pixelValue = inputLabelImage.GetScalarComponentAsFloat(ijk[0], ijk[1], ijk[2], 0)
 
     try:


### PR DESCRIPTION
The position of the mouse in IJK coordinates did not previously take into account the parent transform of the segmentation.

re #4685