### PR TITLE
Various updates to contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ If you are new to Slicer development and you don't have push access to the Slice
 repository, here are the steps:
 
 1. [Fork and clone](https://help.github.com/articles/fork-a-repo/) the repository.
+2. Run the developer setup script [`SetupForDevelopment.sh`](Utilities/SetupForDevelopment.sh).
 3. Create a branch.
 4. [Push](https://help.github.com/articles/pushing-to-a-remote/) the branch to your GitHub fork.
 5. Create a [Pull Request](https://github.com/Slicer/Slicer/pulls).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,9 @@ blog post.
 #### Nightly tests
 
 After changes are integrated, every evening at 10pm EST (3am UTC), Slicer build bots (aka factories)
-will build, test and package Slicer application and all its extensions on Linux, MacOSX
-and Windows. Results are published daily on [CDash](http://slicer.cdash.org/index.php?project=Slicer4)
-and developers introducing changes introducing build or test failures are notified by
+will build, test and package the Slicer application and all its extensions on Linux, MacOSX
+and Windows. Results are published daily on CDash ([Stable](http://slicer.cdash.org/index.php?project=Slicer4) & [Preview](http://slicer.cdash.org/index.php?project=SlicerPreview))
+and developers that introduced changes resulting in build or test failures are notified by
 email.
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ We encourage all developers to:
   also resourceful.
 
 * consider potential backward compatibility breakage and discuss these on the
-  mailing list. For example, update of ITK, Python, Qt or VTK version, change to
+  [Slicer forum](https://discourse.slicer.org). For example, update of ITK, Python, Qt or VTK version, change to
   core functionality, should be carefully reviewed and integrated. Ideally, several
   developers would test that the changes don't break extensions.
 
@@ -112,12 +112,9 @@ is the checklist:
 * To accommodate developers explicitly asking for more time to test the
   proposed changes, integration time can be delayed by few more days.
 
-Next, there are two scenarios:
-* You do NOT have push access: A Slicer core developer will integrate your PR. If
+* If you do NOT have push access, a Slicer core developer will integrate your PR. If
   you would like to speed up the integration, do not hesitate to send a note on
-  the mailing list.
-* You have push access: Follow [Integrating topic from external contributor](https://www.slicer.org/wiki/Slicer:git-svn#Integrating_topic_from_external_contributor)
-  instructions on the wiki.
+  the [Slicer forum](https://discourse.slicer.org).
 
 
 #### Automatic testing of pull requests
@@ -152,7 +149,7 @@ email.
    alternatives, summarize findings on the wiki or similar. [Labs](https://www.slicer.org/wiki/Documentation/Labs)
    page are usually a good ground for such summary.
 
-4. Announce on the mailing list the in-depth discussion of the topic for the
+4. Announce on the [Slicer forum](https://discourse.slicer.org) the in-depth discussion of the topic for the
    [Slicer Community hangout](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Meetings),
    encourage anyone that is interested in weighing in on the topic to join the
    discussion. If there is someone who is interested to participate in the discussion,
@@ -180,6 +177,6 @@ These currently include:
 
 *Alphabetically ordered by last name.*
 
-The Slicer community is inclusive and welcome anyone to work to become a core
+The Slicer community is inclusive and welcomes anyone to work to become a core
 developer and then a BDFL. This happens with hard work and approval of the existing
 BDFL.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ look through the [documentation](https://www.slicer.org/wiki/Documentation/Night
 do better.
 
   * Ask a question on the [Slicer forum](https://discourse.slicer.org)
-  * Submit a feature request or bug, or add to the discussion on the [Slicer issue tracker](https://issues.slicer.org/)
+  * Use Slicer [Issues](https://github.com/Slicer/Slicer/issues) to submit a feature request or bug, or add to the discussion on an existing issue
   * Submit a [Pull Request](https://github.com/Slicer/Slicer/pulls) to improve Slicer or its documentation
 
 We encourage a range of Pull Requests, from patches that include passing tests and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,6 @@ Based on the comments posted by the reviewers, you may have to revisit your patc
 
 We encourage all developers to:
 
-* review and follow the style guidelines described
-[on the wiki](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Style_Guide#Commits).
-
 * add or update tests. There are plenty of existing tests to inspire from. The
   testing [how-tos](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/Testing) are
   also resourceful.
@@ -49,6 +46,51 @@ We encourage all developers to:
   mailing list. For example, update of ITK, Python, Qt or VTK version, change to
   core functionality, should be carefully reviewed and integrated. Ideally, several
   developers would test that the changes don't break extensions.
+
+#### How to write commit messages ?
+
+Write your commit messages using the standard prefixes for Slicer commit
+messages:
+
+  * `BUG:` Fix for runtime crash or incorrect result
+  * `COMP:` Compiler error or warning fix
+  * `DOC:` Documentation change
+  * `ENH:` New functionality
+  * `PERF:` Performance improvement
+  * `STYLE:` No logic impact (indentation, comments)
+  * `WIP:` Work In Progress not ready for merge
+
+The body of the message should clearly describe the motivation of the commit
+(**what**, **why**, and **how**). In order to ease the task of reviewing
+commits, the message body should follow the following guidelines:
+
+  1. Leave a blank line between the subject and the body.
+  This helps `git log` and `git rebase` work nicely, and allows to smooth
+  generation of release notes.
+  2. Try to keep the subject line below 72 characters, ideally 50.
+  3. Capitalize the subject line.
+  4. Do not end the subject line with a period.
+  5. Use the imperative mood in the subject line (e.g. `BUG: Fix spacing
+  not being considered.`).
+  6. Wrap the body at 80 characters.
+  7. Use semantic line feeds to separate different ideas, which improves the
+  readability.
+  8. Be concise, but honor the change: if significant alternative solutions
+  were available, explain why they were discarded.
+  9. If the commit refers to a topic discussed on the [Slicer forum](https://discourse.slicer.org), or fixes
+  a regression test, provide the link. If it fixes a compiler error, provide a
+  minimal verbatim message of the compiler error. If the commit closes an
+  issue, use the [GitHub issue closing
+  keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
+
+Keep in mind that the significant time is invested in reviewing commits and
+*pull requests*, so following these guidelines will greatly help the people
+doing reviews.
+
+These guidelines are largely inspired by Chris Beam's
+[How to Write a Commit Message](https://chris.beams.io/posts/git-commit/)
+post.
+
 
 #### How to integrate a PR ?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,14 @@ These guidelines are largely inspired by Chris Beam's
 [How to Write a Commit Message](https://chris.beams.io/posts/git-commit/)
 post.
 
+Examples:
+  - Bad: `BUG: Check pointer validity before dereferencing` -> implementation detail, self-explanatory (by looking at the code)
+  - Good: `BUG: Fix crash in Module X when clicking Apply button`
+  - Bad: `ENH: More work in qSlicerXModuleWidget` -> more work is too vague, qSlicerXModuleWidget is too low level
+  - Good: `ENH: Add float image outputs in module X`
+  - Bad: `COMP: Typo in cmake variable` -> implementation detail, self-explanatory
+  - Good: `COMP: Fix compilation error with Numpy on Visual Studio`
+
 
 #### How to integrate a PR ?
 


### PR DESCRIPTION
This updates the contributing doc with some additional changes about the usage of the Slicer forum instead of the mailing list, using github issues, and the transition of information about commit messages from the Slicer wiki to a github hosted document.

I don't believe this work has any duplication of work in #4771 as the contributing doc there is just being converted from MD to RST.