### PR TITLE
ENH: Update sample data URLs to use GitHub instead of Midas

### DIFF
--- a/Applications/SlicerApp/Testing/Python/AtlasTests.py
+++ b/Applications/SlicerApp/Testing/Python/AtlasTests.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 #
 # AtlasTests
@@ -154,7 +155,7 @@ class AtlasTestsTest(ScriptedLoadableModuleTest):
     downloads = {
       'fileNames': 'Abdominal_Atlas_2012.mrb',
       'loadFiles': True,
-      'uris': 'http://slicer.kitware.com/midas3/download?items=8301',
+      'uris': TESTING_DATA_URL + 'SHA256/5d315abf7d303326669c6075f9eea927eeda2e531a5b1662cfa505806cb498ea',
       'checksums': 'SHA256:5d315abf7d303326669c6075f9eea927eeda2e531a5b1662cfa505806cb498ea',
       }
     self.perform_AtlasTest(downloads,'I')
@@ -164,7 +165,7 @@ class AtlasTestsTest(ScriptedLoadableModuleTest):
     downloads = {
       'fileNames': 'BrainAtlas2012.mrb',
       'loadFiles': True,
-      'uris': 'http://slicer.kitware.com/midas3/download?items=10937',
+      'uris': TESTING_DATA_URL + 'SHA256/688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1',
       'checksums': 'SHA256:688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1',
       }
     self.perform_AtlasTest(downloads,'A1_grayT1')
@@ -174,7 +175,7 @@ class AtlasTestsTest(ScriptedLoadableModuleTest):
     downloads = {
       'fileNames': 'KneeAtlas2012.mrb',
       'loadFiles': True,
-      'uris': 'http://slicer.kitware.com/midas3/download?items=9912',
+      'uris': TESTING_DATA_URL + 'SHA256/5d5506c07c238918d0c892e7b04c26ad7f43684d89580780bb207d1d860b0b33',
       'checksums': 'SHA256:5d5506c07c238918d0c892e7b04c26ad7f43684d89580780bb207d1d860b0b33',
       }
     self.perform_AtlasTest(downloads,'I')

--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -6,6 +6,7 @@ import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 from DICOMLib import DICOMUtils
+from slicer.util import TESTING_DATA_URL
 
 #
 # DICOMReaders
@@ -67,7 +68,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
     self.delayDisplay("Starting the DICOM test")
 
     referenceData = [
-      { "url": "http://slicer.kitware.com/midas3/download?items=292839",
+      { "url": TESTING_DATA_URL + "SHA256/3450ef9372a3460a2f181c8d3bb35a74b4f0acb10c6e18cfcf7804e1d99bf843",
         "checksum": "SHA256:3450ef9372a3460a2f181c8d3bb35a74b4f0acb10c6e18cfcf7804e1d99bf843",
         "fileName": "Mouse-MR-example-where-GDCM_fails.zip",
         "name": "Mouse-MR-example-where-GDCM_fails",
@@ -78,7 +79,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
         "voxelValueQuantity": "(110852, DCM, \"MR signal intensity\")",
         "voxelValueUnits": "(1, UCUM, \"no units\")"
       },
-      { "url": "http://slicer.kitware.com/midas3/download?items=294857",
+      { "url": TESTING_DATA_URL + "SHA256/899f3f8617ca53bad7dca0b2908478319e708b48ff41dfa64b6bac1d76529928",
         "checksum": "SHA256:899f3f8617ca53bad7dca0b2908478319e708b48ff41dfa64b6bac1d76529928",
         "fileName": "deidentifiedMRHead-dcm-one-series.zip",
         "name": "deidentifiedMRHead-dcm-one-series",
@@ -91,7 +92,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
 
     # another dataset that could be added in the future - currently fails for all readers
     # due to invalid format - see https://issues.slicer.org/view.php?id=3569
-      #{ "url": "http://slicer.kitware.com/midas3/download/item/293587/RIDER_bug.zip",
+      #{ "url": TESTING_DATA_URL + "SHA256/4cbd051dc249ea47d0f7b4147ea8340ba11a4a18a1771d37c387e40538374cab",
         #"fileName": "RIDER_bug.zip",
         #"name": "RIDER_bug",
         #"seriesUID": "1.3.6.1.4.1.9328.50.7.261772317324041365541450388603508531852",
@@ -214,7 +215,7 @@ reloadScriptedModule('DICOMReaders'); import DICOMReaders; tester = DICOMReaders
     import SampleData
     dicomFilesDirectory = SampleData.downloadFromURL(
       fileNames='deidentifiedMRHead-dcm-one-series.zip',
-      uris='http://slicer.kitware.com/midas3/download?items=294857',
+      uris=TESTING_DATA_URL + 'SHA256/899f3f8617ca53bad7dca0b2908478319e708b48ff41dfa64b6bac1d76529928',
       checksums='SHA256:899f3f8617ca53bad7dca0b2908478319e708b48ff41dfa64b6bac1d76529928')[0]
     self.delayDisplay('Finished with download\n')
 

--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -4,6 +4,7 @@ import unittest
 import vtk, qt, ctk, slicer
 from DICOMLib import DICOMUtils
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 #
 # JRC2013Vis
@@ -59,22 +60,22 @@ class JRC2013VisWidget(ScriptedLoadableModuleWidget):
     self.layout.addStretch(1)
 
   def onPart1DICOM(self):
-    tester = JRC2013VisTestTest()
+    tester = JRC2013VisTest()
     tester.setUp()
     tester.test_Part1DICOM()
 
   def onPart2Head(self):
-    tester = JRC2013VisTestTest()
+    tester = JRC2013VisTest()
     tester.setUp()
     tester.test_Part2Head()
 
   def onPart3Liver(self):
-    tester = JRC2013VisTestTest()
+    tester = JRC2013VisTest()
     tester.setUp()
     tester.test_Part3Liver()
 
   def onPart4Lung(self):
-    tester = JRC2013VisTestTest()
+    tester = JRC2013VisTest()
     tester.setUp()
     tester.test_Part4Lung()
 
@@ -95,7 +96,7 @@ class JRC2013VisWidget(ScriptedLoadableModuleWidget):
         import SampleData
         SampleData.downloadFromURL(
           fileNames='Dcmtk-db.zip',
-          uris='http://slicer.kitware.com/midas3/download?items=18822',
+          uris=TESTING_DATA_URL + 'MD5/6bfb01cf5ffb8e3af9b1c0c9556f0c6b45f0ec40305a9539ed7a9f0dcfe378e3',
           checksums='SHA256:6bfb01cf5ffb8e3af9b1c0c9556f0c6b45f0ec40305a9539ed7a9f0dcfe378e3')[0]
 
       import subprocess
@@ -144,7 +145,7 @@ class JRC2013VisLogic(ScriptedLoadableModuleLogic):
   pass
 
 
-class JRC2013VisTestTest(ScriptedLoadableModuleTest):
+class JRC2013VisTest(ScriptedLoadableModuleTest):
   """
   This is the test case for your scripted module.
   """
@@ -180,7 +181,7 @@ class JRC2013VisTestTest(ScriptedLoadableModuleTest):
     import SampleData
     dicomFilesDirectory = SampleData.downloadFromURL(
       fileNames='Dcmtk-db.zip',
-      uris='https://github.com/Slicer/SlicerTestingData/releases/download/MD5/7a43d121a51a631ab0df02071e5ba6ed',
+      uris=TESTING_DATA_URL + 'MD5/7a43d121a51a631ab0df02071e5ba6ed',
       checksums='MD5:7a43d121a51a631ab0df02071e5ba6ed')[0]
 
     try:
@@ -313,7 +314,7 @@ class JRC2013VisTestTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       fileNames='3DHeadData.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=8609',
+      uris=TESTING_DATA_URL + 'SHA256/e2c7944095dd92be7961bed37f3c8f49e6f40c7f31d4fe865753b6efddae7993',
       checksums='SHA256:e2c7944095dd92be7961bed37f3c8f49e6f40c7f31d4fe865753b6efddae7993')
     self.delayDisplay('Finished with download and loading\n')
 
@@ -387,7 +388,7 @@ class JRC2013VisTestTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       fileNames='LiverData.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=8611',
+      uris=TESTING_DATA_URL + 'SHA256/a39075d3e87f80bbf8eba1e0222ee68c60036e57c3db830db08f3022f424e221',
       checksums='SHA256:a39075d3e87f80bbf8eba1e0222ee68c60036e57c3db830db08f3022f424e221')
     self.delayDisplay('Finished with download and loading\n')
 
@@ -456,7 +457,7 @@ class JRC2013VisTestTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       fileNames='LungData.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=8612',
+      uris=TESTING_DATA_URL + 'SHA256/9da091065aa42edbba2d436a2ef21a093792e8a76455c28e5b80590b04f5a73e',
       checksums='SHA256:9da091065aa42edbba2d436a2ef21a093792e8a76455c28e5b80590b04f5a73e')
     self.delayDisplay('Finished with download and loading\n')
 

--- a/Applications/SlicerApp/Testing/Python/RSNA2012ProstateDemo.py
+++ b/Applications/SlicerApp/Testing/Python/RSNA2012ProstateDemo.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 #
 # RSNA2012ProstateDemo
@@ -69,7 +70,7 @@ class RSNA2012ProstateDemoTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       fileNames='RSNA2012ProstateDemo.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=10697',
+      uris=TESTING_DATA_URL + 'SHA256/2627388ee213564f8783d0242993212ba01189f4c6640d57c4cde4e28fc5f97b',
       checksums='SHA256:2627388ee213564f8783d0242993212ba01189f4c6640d57c4cde4e28fc5f97b')
 
     # get all scene view nodes and test switching

--- a/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
@@ -2,7 +2,7 @@ import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
-
+from slicer.util import TESTING_DATA_URL
 #
 # RSNAQuantTutorial
 #
@@ -220,7 +220,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
     import SampleData
     extractPath = SampleData.downloadFromURL(
       fileNames='dataset3_PETCT.zip',
-      uris='http://slicer.kitware.com/midas3/download?items=124185',
+      uris=TESTING_DATA_URL + 'SHA256/11e81af3462076f4ca371b632e03ed435240042915c2daf07f80059b3f78f88d',
       checksums='SHA256:11e81af3462076f4ca371b632e03ed435240042915c2daf07f80059b3f78f88d')[0]
 
     self.delayDisplay("Loading PET_CT_pre-treatment.mrb")
@@ -324,7 +324,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       fileNames='ChangeTrackerScene.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=124184',
+      uris=TESTING_DATA_URL + 'SHA256/64734cbbf8ebafe4a52f551d1510a8f6f3d0625eb5b6c1e328be117c48e2c653',
       checksums='SHA256:64734cbbf8ebafe4a52f551d1510a8f6f3d0625eb5b6c1e328be117c48e2c653')
     logic.takeScreenshot('ChangeTracker-Loaded','Finished with download and loading',-1)
 

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
@@ -3,6 +3,7 @@ import unittest
 import vtk, qt, ctk, slicer
 from DICOMLib import DICOMUtils
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 #
 # RSNAVisTutorial
@@ -186,7 +187,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
     import SampleData
     dicomFilesDirectory = SampleData.downloadFromURL(
       fileNames='dataset1_Thorax_Abdomen.zip',
-      uris='http://slicer.kitware.com/midas3/download?items=124183',
+      uris=TESTING_DATA_URL + 'SHA256/17a4199aad03a373dab27dc17e5bfcf84fc194d0a30975b4073e5b595d43a56a',
       checksums='SHA256:17a4199aad03a373dab27dc17e5bfcf84fc194d0a30975b4073e5b595d43a56a')[0]
 
     try:
@@ -306,7 +307,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       fileNames='Head_Scene.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=124180',
+      uris=TESTING_DATA_URL + 'SHA256/6785e481925c912a5a3940e9c9b71935df93a78a871e10f66ab71f8478229e68',
       checksums='SHA256:6785e481925c912a5a3940e9c9b71935df93a78a871e10f66ab71f8478229e68')
 
     logic.takeScreenshot('Head-Downloaded','Finished with download and loading',-1)
@@ -407,7 +408,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       fileNames='LiverSegments_Scene.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=124181',
+      uris=TESTING_DATA_URL + 'SHA256/ff797140c13a5988a7b72920adf0d2dab390a9babeab9161d5c52613328249f7',
       checksums='SHA256:ff797140c13a5988a7b72920adf0d2dab390a9babeab9161d5c52613328249f7')
 
     logic.takeScreenshot('Liver-Loaded','Loaded Liver scene',-1)
@@ -481,7 +482,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       fileNames='LungSegments_Scene.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=124182',
+      uris=TESTING_DATA_URL + 'SHA256/89ffc6cabd76a17dfa6beb404a5901a4b4e4b4f2f4ee46c2d5f4d34459f554a1',
       checksums='SHA256:89ffc6cabd76a17dfa6beb404a5901a4b4e4b4f2f4ee46c2d5f4d34459f554a1')
 
     logic.takeScreenshot('Lung-Loaded','Finished with download and loading',-1)

--- a/Applications/SlicerApp/Testing/Python/ScenePerformance.py
+++ b/Applications/SlicerApp/Testing/Python/ScenePerformance.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 #
 # ScenePerformance
@@ -144,7 +145,8 @@ class ScenePerformanceTest(ScriptedLoadableModuleTest):
   def testAll(self):
     self.setUp()
 
-    self.addURLData('http://slicer.kitware.com/midas3/download?items=10937', 'BrainAtlas2012.mrb', 'SHA256:688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1')
+    self.addURLData(TESTING_DATA_URL + 'SHA256/688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1',
+      'BrainAtlas2012.mrb', 'SHA256:688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1')
     self.modifyNodeByID('vtkMRMLScalarVolumeNode1')
     self.modifyNodeByID('vtkMRMLScalarVolumeNode2')
     self.modifyNodeByID('vtkMRMLScalarVolumeNode3')

--- a/Applications/SlicerApp/Testing/Python/ShaderProperties.py
+++ b/Applications/SlicerApp/Testing/Python/ShaderProperties.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 #
 # ShaderProperties
@@ -73,7 +74,7 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
     self.delayDisplay("Starting...")
     self.setUp()
 
-    fileURL = 'http://slicer.kitware.com/midas3/download/item/426450/MRRobot-Shoulder-MR.nrrd'
+    fileURL = TESTING_DATA_URL + 'SHA256/19ad4f794de8dcdabbe3290c40fa18072cf5e05b6b2466fcc508ea7a42aae71e'
     filePath = os.path.join(slicer.util.tempDirectory(), 'MRRobot-Shoulder-MR.nrrd')
     slicer.util.downloadFile(fileURL, filePath)
     shoulder = slicer.util.loadVolume(filePath)

--- a/Applications/SlicerApp/Testing/Python/SliceLinkLogic.py
+++ b/Applications/SlicerApp/Testing/Python/SliceLinkLogic.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 #
 # SliceLinkLogic
@@ -127,7 +128,7 @@ class SliceLinkLogicTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       nodeNames='FA',
       fileNames='FA.nrrd',
-      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      uris=TESTING_DATA_URL + 'SHA256/12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560',
       checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
     print('')

--- a/Applications/SlicerApp/Testing/Python/Slicer4Minute.py
+++ b/Applications/SlicerApp/Testing/Python/Slicer4Minute.py
@@ -3,6 +3,7 @@ import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 #
 # Slicer4Minute
@@ -124,7 +125,7 @@ class Slicer4MinuteTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       fileNames='slicer4minute.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=8466',
+      uris=TESTING_DATA_URL + 'SHA256/5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8',
       checksums='SHA256:5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8')
     self.delayDisplay('Finished with download and loading')
 

--- a/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerRestoreSceneViewCrashIssue3445.py
@@ -1,8 +1,9 @@
+import logging
 import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
-import logging
+from slicer.util import TESTING_DATA_URL
 
 #
 # SlicerRestoreSceneViewCrashIssue3445
@@ -97,7 +98,7 @@ class SlicerRestoreSceneViewCrashIssue3445Test(ScriptedLoadableModuleTest):
     filePath = SampleData.downloadFromURL(
       fileNames='BrainAtlas2012.mrb',
       loadFiles=True,
-      uris='http://slicer.kitware.com/midas3/download?items=10937',
+      uris=TESTING_DATA_URL + 'SHA256/688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1',
       checksums='SHA256:688ebcc6f45989795be2bcdc6b8b5bfc461f1656d677ed3ddef8c313532687f1')[0]
 
     self.delayDisplay('Finished with download')

--- a/Applications/SlicerApp/Testing/Python/slicerCloseCrashBug2590.py
+++ b/Applications/SlicerApp/Testing/Python/slicerCloseCrashBug2590.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 #
 # slicerCloseCrashBug2590
@@ -91,7 +92,7 @@ class slicerCloseCrashBug2590Test(ScriptedLoadableModuleTest):
     import SampleData
     SampleData.downloadFromURL(
       fileNames='RSNA2011_ChangeTracker_data.zip',
-      uris='http://slicer.kitware.com/midas3/download?items=8986',
+      uris=TESTING_DATA_URL + 'SHA256/256bf00a83884fab173edc9f83c028f654bd5eb44aeed28d2203ec76fab941ce',
       checksums='SHA256:256bf00a83884fab173edc9f83c028f654bd5eb44aeed28d2203ec76fab941ce')
 
     try:

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -8,6 +8,20 @@ from __future__ import print_function
 EXIT_SUCCESS = 0
 EXIT_FAILURE = 1
 
+TESTING_DATA_URL = "https://github.com/Slicer/SlicerTestingData/releases/download/"
+"""Base URL for downloading testing data.
+
+Datasets can be downloaded using URL of the form ``TESTING_DATA_URL + "SHA256/" + sha256ofDataSet``
+"""
+
+DATA_STORE_URL = "https://github.com/Slicer/SlicerDataStore/releases/download/"
+"""Base URL for downloading data from Slicer Data Store. Data store contains atlases,
+registration case library images, and various sample data sets.
+
+Datasets can be downloaded using URL of the form ``DATA_STORE_URL + "SHA256/" + sha256ofDataSet``
+"""
+
+
 def quit():
   exit(EXIT_SUCCESS)
 

--- a/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
+++ b/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
@@ -1,8 +1,9 @@
+import logging
 import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
-import logging
+from slicer.util import TESTING_DATA_URL
 
 #
 # ScriptedLoadableModuleTemplate
@@ -233,14 +234,13 @@ class ScriptedLoadableModuleTemplateTest(ScriptedLoadableModuleTest):
     # first, get some data
     #
     import SampleData
-    SampleData.downloadFromURL(
-      nodeNames='FA',
-      fileNames='FA.nrrd',
-      uris='http://slicer.kitware.com/midas3/download?items=5767',
-      checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
+    volumeNode = SampleData.downloadFromURL(
+      nodeNames='MRHead',
+      fileNames='MR-head.nrrd',
+      uris=TESTING_DATA_URL + 'SHA256/cc211f0dfd9a05ca3841ce1141b292898b2dd2d3f08286affadf823a7e58df93',
+      checksums='SHA256:cc211f0dfd9a05ca3841ce1141b292898b2dd2d3f08286affadf823a7e58df93')
     self.delayDisplay('Finished with download and loading')
 
-    volumeNode = slicer.util.getNode(pattern="FA")
     logic = ScriptedLoadableModuleTemplateLogic()
     self.assertIsNotNone( logic.hasImageData(volumeNode) )
     self.delayDisplay('Test passed!')

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
@@ -3,7 +3,7 @@ import unittest
 import vtk, qt, ctk, slicer
 import logging
 from slicer.ScriptedLoadableModule import *
-
+from slicer.util import TESTING_DATA_URL
 import vtkSegmentationCore
 
 
@@ -66,7 +66,8 @@ class SegmentationsModuleTest1(unittest.TestCase):
   def TestSection_RetrieveInputData(self):
     try:
       slicer.util.downloadAndExtractArchive(
-        'http://slicer.kitware.com/midas3/download/folder/3763/TinyPatient_Seg.zip', self.dataZipFilePath, self.segmentationsModuleTestDir,
+        TESTING_DATA_URL + 'SHA256/b902f635ef2059cd3b4ba854c000b388e4a9e817a651f28be05c22511a317ec7',
+        self.dataZipFilePath, self.segmentationsModuleTestDir,
         checksum='SHA256:b902f635ef2059cd3b4ba854c000b388e4a9e817a651f28be05c22511a317ec7')
 
       numOfFilesInDataDirTest = len([name for name in os.listdir(self.dataDir) if os.path.isfile(self.dataDir + '/' + name)])

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
@@ -3,6 +3,7 @@ import unittest
 import vtk, qt, ctk, slicer
 import logging
 from slicer.ScriptedLoadableModule import *
+from slicer.util import TESTING_DATA_URL
 
 import vtkSegmentationCore
 
@@ -66,7 +67,8 @@ class SegmentationsModuleTest2(unittest.TestCase):
   def TestSection_RetrieveInputData(self):
     try:
       slicer.util.downloadAndExtractArchive(
-        'http://slicer.kitware.com/midas3/download/folder/3763/TinyPatient_Seg.zip', self.dataZipFilePath, self.segmentationsModuleTestDir,
+        TESTING_DATA_URL + 'SHA256/b902f635ef2059cd3b4ba854c000b388e4a9e817a651f28be05c22511a317ec7',
+        self.dataZipFilePath, self.segmentationsModuleTestDir,
         checksum='SHA256:b902f635ef2059cd3b4ba854c000b388e4a9e817a651f28be05c22511a317ec7')
 
       numOfFilesInDataDirTest = len([name for name in os.listdir(self.dataDir) if os.path.isfile(self.dataDir + '/' + name)])

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyFoldersTest1.py
@@ -3,6 +3,7 @@ import unittest
 import vtk, qt, ctk, slicer
 import logging
 from slicer.ScriptedLoadableModule import *
+from slicer.util import DATA_STORE_URL
 
 class SubjectHierarchyFoldersTest1(unittest.TestCase):
 
@@ -81,7 +82,8 @@ class SubjectHierarchyFoldersTest1(unittest.TestCase):
     import SampleData
     sceneFile = SampleData.downloadFromURL(
       fileNames='NACBrainAtlas2015.mrb',
-      uris='https://slicer.kitware.com/midas3/download/bitstream/462380/nac-hncma-atlas-2015April-Slicer4-4Version.mrb',
+      # Note: this data set is from SlicerDataStore (not from SlicerTestingData) repository
+      uris=DATA_STORE_URL + 'SHA256/d69d0331d4fd2574be1459b7734921f64f5872d3cb9589ec01b2f53dadc7112f',
       checksums='SHA256:d69d0331d4fd2574be1459b7734921f64f5872d3cb9589ec01b2f53dadc7112f')[0]
 
     ioManager = slicer.app.ioManager()

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
@@ -1,10 +1,11 @@
 from __future__ import print_function
+import logging
 import os
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 from DICOMLib import DICOMUtils
-import logging
+from slicer.util import TESTING_DATA_URL
 
 #
 # SubjectHierarchyGenericSelfTest
@@ -121,7 +122,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
       os.mkdir(self.dicomDataDir)
 
     self.dicomDatabaseDir = subjectHierarchyGenericSelfTestDir + '/CtkDicomDatabase'
-    self.dicomZipFileUrl = 'http://slicer.kitware.com/midas3/download/item/137843/TestDicomCT.zip'
+    self.dicomZipFileUrl = TESTING_DATA_URL + 'SHA256/1aa0bb177bbf6471ca5f2192340a6cecdedb81b33506b03ff316c6b5f624e863'
     self.dicomZipChecksum = 'SHA256:1aa0bb177bbf6471ca5f2192340a6cecdedb81b33506b03ff316c6b5f624e863'
     self.dicomZipFilePath = subjectHierarchyGenericSelfTestDir + '/TestDicomCT.zip'
     self.expectedNumOfFilesInDicomDataDir = 10

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -1,11 +1,12 @@
 from __future__ import print_function
+import logging
 import os
 import unittest
 import vtk, qt, ctk, slicer
 import vtkTeem
 import DataProbeLib
 from slicer.ScriptedLoadableModule import *
-import logging
+from slicer.util import TESTING_DATA_URL
 
 #
 # DataProbe
@@ -588,7 +589,7 @@ class DataProbeTest(ScriptedLoadableModuleTest):
     SampleData.downloadFromURL(
       nodeNames='FA',
       fileNames='FA.nrrd',
-      uris='http://slicer.kitware.com/midas3/download?items=5767',
+      uris=TESTING_DATA_URL + 'SHA256/12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560',
       checksums='SHA256:12d17fba4f2e1f1a843f0757366f28c3f3e1a8bb38836f0de2a32bb1cd476560')
     self.delayDisplay('Finished with download and loading')
 

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
+import logging
 import os
+import textwrap
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
-from slicer.util import computeChecksum, extractAlgoAndDigest
-import logging
-import textwrap
+from slicer.util import computeChecksum, extractAlgoAndDigest, TESTING_DATA_URL
 
 #
 # SampleData methods
@@ -122,10 +122,11 @@ class SampleDataSource(object):
   Example::
 
     import SampleData
+    from slicer.util import TESTING_DATA_URL
     dataSource = SampleData.SampleDataSource(
       nodeNames='fixed',
       fileNames='fixed.nrrd',
-      uris='http://slicer.kitware.com/midas3/download/item/157188/small-mr-eye-fixed.nrrd')
+      uris=TESTING_DATA_URL + 'SHA256/b757f9c61c1b939f104e5d7861130bb28d90f33267a012eb8bb763a435f29d37')
     loadedNode = SampleData.SampleDataLogic().downloadFromSource(dataSource)[0]
   """
 
@@ -497,37 +498,50 @@ class SampleDataLogic(object):
   def registerBuiltInSampleDataSources(self):
     """Fills in the pre-define sample data sources"""
     sourceArguments = (
-        ('MRHead', None, 'http://slicer.kitware.com/midas3/download/item/292308/MR-head.nrrd', 'MR-head.nrrd', 'MRHead', 'SHA256:cc211f0dfd9a05ca3841ce1141b292898b2dd2d3f08286affadf823a7e58df93'),
-        ('CTChest', None, 'http://slicer.kitware.com/midas3/download/item/292307/CT-chest.nrrd', 'CT-chest.nrrd', 'CTChest', 'SHA256:4507b664690840abb6cb9af2d919377ffc4ef75b167cb6fd0f747befdb12e38e'),
-        ('CTACardio', None, 'http://slicer.kitware.com/midas3/download/item/292309/CTA-cardio.nrrd', 'CTA-cardio.nrrd', 'CTACardio', 'SHA256:3b0d4eb1a7d8ebb0c5a89cc0504640f76a030b4e869e33ff34c564c3d3b88ad2'),
-        ('DTIBrain', None, 'http://slicer.kitware.com/midas3/download/item/292310/DTI-brain.nrrd', 'DTI-Brain.nrrd', 'DTIBrain', 'SHA256:5c78d00c86ae8d968caa7a49b870ef8e1c04525b1abc53845751d8bce1f0b91a'),
-        ('MRBrainTumor1', None, 'http://slicer.kitware.com/midas3/download/item/292312/RegLib_C01_1.nrrd', 'RegLib_C01_1.nrrd', 'MRBrainTumor1', 'SHA256:998cb522173839c78657f4bc0ea907cea09fd04e44601f17c82ea27927937b95'),
-        ('MRBrainTumor2', None, 'http://slicer.kitware.com/midas3/download/item/292313/RegLib_C01_2.nrrd', 'RegLib_C01_2.nrrd', 'MRBrainTumor2', 'SHA256:1a64f3f422eb3d1c9b093d1a18da354b13bcf307907c66317e2463ee530b7a97'),
-        ('BaselineVolume', None, 'http://slicer.kitware.com/midas3/download/?items=2009,1', 'BaselineVolume.nrrd', 'BaselineVolume', 'SHA256:dff28a7711d20b6e16d5416535f6010eb99fd0c8468aaa39be4e39da78e93ec2'),
+        ('MRHead', None, TESTING_DATA_URL + 'SHA256/cc211f0dfd9a05ca3841ce1141b292898b2dd2d3f08286affadf823a7e58df93',
+          'MR-head.nrrd', 'MRHead', 'SHA256:cc211f0dfd9a05ca3841ce1141b292898b2dd2d3f08286affadf823a7e58df93'),
+        ('CTChest', None, TESTING_DATA_URL + 'SHA256/4507b664690840abb6cb9af2d919377ffc4ef75b167cb6fd0f747befdb12e38e',
+          'CT-chest.nrrd', 'CTChest', 'SHA256:4507b664690840abb6cb9af2d919377ffc4ef75b167cb6fd0f747befdb12e38e'),
+        ('CTACardio', None, TESTING_DATA_URL + 'SHA256/3b0d4eb1a7d8ebb0c5a89cc0504640f76a030b4e869e33ff34c564c3d3b88ad2',
+          'CTA-cardio.nrrd', 'CTACardio', 'SHA256:3b0d4eb1a7d8ebb0c5a89cc0504640f76a030b4e869e33ff34c564c3d3b88ad2'),
+        ('DTIBrain', None, TESTING_DATA_URL + 'SHA256/5c78d00c86ae8d968caa7a49b870ef8e1c04525b1abc53845751d8bce1f0b91a',
+          'DTI-Brain.nrrd', 'DTIBrain', 'SHA256:5c78d00c86ae8d968caa7a49b870ef8e1c04525b1abc53845751d8bce1f0b91a'),
+        ('MRBrainTumor1', None, TESTING_DATA_URL + 'SHA256/998cb522173839c78657f4bc0ea907cea09fd04e44601f17c82ea27927937b95',
+          'RegLib_C01_1.nrrd', 'MRBrainTumor1', 'SHA256:998cb522173839c78657f4bc0ea907cea09fd04e44601f17c82ea27927937b95'),
+        ('MRBrainTumor2', None, TESTING_DATA_URL + 'SHA256/1a64f3f422eb3d1c9b093d1a18da354b13bcf307907c66317e2463ee530b7a97',
+          'RegLib_C01_2.nrrd', 'MRBrainTumor2', 'SHA256:1a64f3f422eb3d1c9b093d1a18da354b13bcf307907c66317e2463ee530b7a97'),
+        ('BaselineVolume', None, TESTING_DATA_URL + 'SHA256/dff28a7711d20b6e16d5416535f6010eb99fd0c8468aaa39be4e39da78e93ec2',
+          'BaselineVolume.nrrd', 'BaselineVolume', 'SHA256:dff28a7711d20b6e16d5416535f6010eb99fd0c8468aaa39be4e39da78e93ec2'),
         ('DTIVolume', None,
-          ('http://slicer.kitware.com/midas3/download/?items=2011,1',
-            'http://slicer.kitware.com/midas3/download/?items=2010,1', ),
+          (TESTING_DATA_URL + 'SHA256/d785837276758ddd9d21d76a3694e7fd866505a05bc305793517774c117cb38d',
+            TESTING_DATA_URL + 'SHA256/67564aa42c7e2eec5c3fd68afb5a910e9eab837b61da780933716a3b922e50fe', ),
           ('DTIVolume.raw.gz', 'DTIVolume.nhdr'), (None, 'DTIVolume'),
-          ('SHA256:d785837276758ddd9d21d76a3694e7fd866505a05bc305793517774c117cb38d', 'SHA256:67564aa42c7e2eec5c3fd68afb5a910e9eab837b61da780933716a3b922e50fe')),
+          ('SHA256:d785837276758ddd9d21d76a3694e7fd866505a05bc305793517774c117cb38d',
+            'SHA256:67564aa42c7e2eec5c3fd68afb5a910e9eab837b61da780933716a3b922e50fe')),
         ('DWIVolume', None,
-          ('http://slicer.kitware.com/midas3/download/?items=2142,1', 'http://slicer.kitware.com/midas3/download/?items=2141,1'),
+          (TESTING_DATA_URL + 'SHA256/cf03fd53583dc05120d3314d0a82bdf5946799b1f72f2a7f08963f3fd24ca692',
+           TESTING_DATA_URL + 'SHA256/7666d83bc205382e418444ea60ab7df6dba6a0bd684933df8809da6b476b0fed'),
           ('dwi.raw.gz', 'dwi.nhdr'), (None, 'dwi'),
-          ('SHA256:cf03fd53583dc05120d3314d0a82bdf5946799b1f72f2a7f08963f3fd24ca692', 'SHA256:7666d83bc205382e418444ea60ab7df6dba6a0bd684933df8809da6b476b0fed')),
-        ('CTAAbdomenPanoramix', 'CTA abdomen\n(Panoramix)', 'http://slicer.kitware.com/midas3/download/?items=9073,1', 'Panoramix-cropped.nrrd', 'Panoramix-cropped', 'SHA256:146af87511520c500a3706b7b2bfb545f40d5d04dd180be3a7a2c6940e447433'),
+          ('SHA256:cf03fd53583dc05120d3314d0a82bdf5946799b1f72f2a7f08963f3fd24ca692',
+            'SHA256:7666d83bc205382e418444ea60ab7df6dba6a0bd684933df8809da6b476b0fed')),
+        ('CTAAbdomenPanoramix', 'CTA abdomen\n(Panoramix)', TESTING_DATA_URL + 'SHA256/146af87511520c500a3706b7b2bfb545f40d5d04dd180be3a7a2c6940e447433',
+          'Panoramix-cropped.nrrd', 'Panoramix-cropped', 'SHA256:146af87511520c500a3706b7b2bfb545f40d5d04dd180be3a7a2c6940e447433'),
         ('CBCTDentalSurgery', None,
-          ('http://slicer.kitware.com/midas3/download/item/94510/Greyscale_presurg.gipl.gz',
-            'http://slicer.kitware.com/midas3/download/item/94509/Greyscale_postsurg.gipl.gz',),
+          (TESTING_DATA_URL + 'SHA256/7bfa16945629c319a439f414cfb7edddd2a97ba97753e12eede3b56a0eb09968',
+            TESTING_DATA_URL + 'SHA256/4cdc3dc35519bb57daeef4e5df89c00849750e778809e94971d3876f95cc7bbd',),
           ('PreDentalSurgery.gipl.gz', 'PostDentalSurgery.gipl.gz'), ('PreDentalSurgery', 'PostDentalSurgery'),
-          ('SHA256:7bfa16945629c319a439f414cfb7edddd2a97ba97753e12eede3b56a0eb09968', 'SHA256:4cdc3dc35519bb57daeef4e5df89c00849750e778809e94971d3876f95cc7bbd')),
+          ('SHA256:7bfa16945629c319a439f414cfb7edddd2a97ba97753e12eede3b56a0eb09968',
+            'SHA256:4cdc3dc35519bb57daeef4e5df89c00849750e778809e94971d3876f95cc7bbd')),
         ('MRUSProstate', 'MR-US Prostate',
-          ('http://slicer.kitware.com/midas3/download/item/142475/Case10-MR.nrrd',
-            'http://slicer.kitware.com/midas3/download/item/142476/case10_US_resampled.nrrd',),
+          (TESTING_DATA_URL + 'SHA256/4843cdc9ea5d7bcce61650d1492ce01035727c892019339dca726380496896aa',
+            TESTING_DATA_URL + 'SHA256/34decf58b1e6794069acbe947b460252262fe95b6858c5e320aeab03bc82ebb2',),
           ('Case10-MR.nrrd', 'case10_US_resampled.nrrd'), ('MRProstate', 'USProstate'),
-          ('SHA256:4843cdc9ea5d7bcce61650d1492ce01035727c892019339dca726380496896aa', 'SHA256:34decf58b1e6794069acbe947b460252262fe95b6858c5e320aeab03bc82ebb2')),
+          ('SHA256:4843cdc9ea5d7bcce61650d1492ce01035727c892019339dca726380496896aa',
+            'SHA256:34decf58b1e6794069acbe947b460252262fe95b6858c5e320aeab03bc82ebb2')),
         ('CTMRBrain', 'CT-MR Brain',
-          ('http://slicer.kitware.com/midas3/download/item/284192/CTBrain.nrrd',
-           'http://slicer.kitware.com/midas3/download/item/330508/MRBrainT1.nrrd',
-           'http://slicer.kitware.com/midas3/download/item/330509/MRBrainT2.nrrd',),
+          (TESTING_DATA_URL + 'SHA256/6a5b6caccb76576a863beb095e3bfb910c50ca78f4c9bf043aa42f976cfa53d1',
+           TESTING_DATA_URL + 'SHA256/2da3f655ed20356ee8cdf32aa0f8f9420385de4b6e407d28e67f9974d7ce1593',
+           TESTING_DATA_URL + 'SHA256/fa1fe5910a69182f2b03c0150d8151ac6c75df986449fb5a6c5ae67141e0f5e7',),
           ('CT-brain.nrrd', 'MR-brain-T1.nrrd', 'MR-brain-T2.nrrd'),
           ('CTBrain', 'MRBrainT1', 'MRBrainT2'),
           ('SHA256:6a5b6caccb76576a863beb095e3bfb910c50ca78f4c9bf043aa42f976cfa53d1',
@@ -548,8 +562,8 @@ class SampleDataLogic(object):
     iconPath = os.path.join(os.path.dirname(__file__).replace('\\','/'), 'Resources','Icons')
     self.registerCustomSampleDataSource(
       category=self.developmentCategoryName, sampleName='TinyPatient',
-      uris=['http://slicer.kitware.com/midas3/download/item/245205/TinyPatient_CT.nrrd',
-            'http://slicer.kitware.com/midas3/download/item/367020/TinyPatient_Structures.seg.nrrd'],
+      uris=[TESTING_DATA_URL + 'SHA256/c0743772587e2dd4c97d4e894f5486f7a9a202049c8575e032114c0a5c935c3b',
+            TESTING_DATA_URL + 'SHA256/3243b62bde36b1db1cdbfe204785bd4bc1fbb772558d5f8cac964cda8385d470'],
       fileNames=['TinyPatient_CT.nrrd', 'TinyPatient_Structures.seg.nrrd'],
       nodeNames=['TinyPatient_CT', 'TinyPatient_Segments'],
       thumbnailFileName=os.path.join(iconPath, 'TinyPatient.png'),
@@ -583,7 +597,7 @@ class SampleDataLogic(object):
       filePaths.append(self.downloadFileIntoCache(uri, fileName, checksum))
     return filePaths
 
-  def downloadFromSource(self,source,attemptCount=0):
+  def downloadFromSource(self, source, maximumAttemptsCount=3):
     """Given an instance of SampleDataSource, downloads the associated data and
     load them into Slicer if it applies.
 
@@ -599,76 +613,71 @@ class SampleDataLogic(object):
     If no ``nodeNames`` and no ``fileTypes`` are specified or if ``loadFiles`` are all False,
     returns the list of all downloaded filepaths.
     """
-    nodes = []
-    filePaths = []
+
+    # Input may contain urls without associated node names, which correspond to additional data files
+    # (e.g., .raw file for a .nhdr header file). Therefore we collect nodes and file paths separately
+    # and we only return file paths if no node names have been provided.
+    resultNodes = []
+    resultFilePaths = []
 
     for uri,fileName,nodeName,checksum,loadFile,loadFileType in zip(source.uris,source.fileNames,source.nodeNames,source.checksums,source.loadFiles,source.loadFileType):
 
       current_source = SampleDataSource(uris=uri, fileNames=fileName, nodeNames=nodeName, checksums=checksum, loadFiles=loadFile, loadFileType=loadFileType, loadFileProperties=source.loadFileProperties)
-      try:
-        filePath = self.downloadFileIntoCache(uri, fileName, checksum)
-      except ValueError:
-        if attemptCount < 5:
-          attemptCount += 1
-          self.logMessage('<b>Load failed! Trying to download again (%d of 5 attempts)...</b>' % (attemptCount), logging.ERROR)
+
+      for attemptsCount in range(maximumAttemptsCount):
+
+        # Download
+        try:
           filePath = self.downloadFileIntoCache(uri, fileName, checksum)
-
-      filePaths.append(filePath)
-
-      if loadFileType == 'ZipFile':
-        if loadFile == False:
-          nodes.append(filePath)
+        except ValueError:
+          self.logMessage('<b>Download failed (attempt %d of %d)...</b>' % (attemptsCount+1, maximumAttemptsCount), logging.ERROR)
           continue
-        outputDir = slicer.mrmlScene.GetCacheManager().GetRemoteCacheDirectory() + "/" + os.path.splitext(os.path.basename(filePath))[0]
-        qt.QDir().mkpath(outputDir)
-        success = slicer.util.extractArchive(filePath, outputDir)
-        if not success and attemptCount < 5:
-          file = qt.QFile(filePath)
-          if not file.remove():
-            self.logMessage('<b>Load failed! Unable to delete and try again loading %s!</b>' % filePath, logging.ERROR)
-            nodes.append(None)
-            break
-          attemptCount += 1
-          self.logMessage('<b>Load failed! Trying to download again (%d of 5 attempts)...</b>' % (attemptCount), logging.ERROR)
-          outputDir = self.downloadFromSource(current_source,attemptCount)[0]
-        nodes.append(outputDir)
+        resultFilePaths.append(filePath)
 
-      elif loadFileType == 'SceneFile':
-        if not loadFile:
-          nodes.append(filePath)
-          continue
-        success = self.loadScene(filePath, source.loadFileProperties.copy())
-        if not success and attemptCount < 5:
-          file = qt.QFile(filePath)
-          if not file.remove():
-            self.logMessage('<b>Load failed! Unable to delete and try again loading %s!</b>' % filePath, logging.ERROR)
-            nodes.append(None)
+        if loadFileType == 'ZipFile':
+          if loadFile == False:
+            resultNodes.append(filePath)
             break
-          attemptCount += 1
-          self.logMessage('<b>Load failed! Trying to download again (%d of 5 attempts)...</b>' % (attemptCount), logging.ERROR)
-          filePath = self.downloadFromSource(current_source,attemptCount)[0]
-        nodes.append(filePath)
-
-      elif nodeName:
-        if loadFile == False:
-          nodes.append(filePath)
-          continue
-        loadedNode = self.loadNode(filePath, nodeName, loadFileType, source.loadFileProperties.copy())
-        if loadedNode is None and attemptCount < 5:
-          file = qt.QFile(filePath)
-          if not file.remove():
-            self.logMessage('<b>Load failed! Unable to delete and try again loading %s!</b>' % filePath, logging.ERROR)
-            nodes.append(None)
+          outputDir = slicer.mrmlScene.GetCacheManager().GetRemoteCacheDirectory() + "/" + os.path.splitext(os.path.basename(filePath))[0]
+          qt.QDir().mkpath(outputDir)
+          if slicer.util.extractArchive(filePath, outputDir):
+            # Success
+            resultNodes.append(outputDir)
             break
-          attemptCount += 1
-          self.logMessage('<b>Load failed! Trying to download again (%d of 5 attempts)...</b>' % (attemptCount), logging.ERROR)
-          loadedNode = self.downloadFromSource(current_source,attemptCount)[0]
-        nodes.append(loadedNode)
+        elif loadFileType == 'SceneFile':
+          if not loadFile:
+            resultNodes.append(filePath)
+            break
+          if self.loadScene(filePath, source.loadFileProperties.copy()):
+            # Success
+            resultNodes.append(filePath)
+            break
+        elif nodeName:
+          if loadFile == False:
+            resultNodes.append(filePath)
+            break
+          loadedNode = self.loadNode(filePath, nodeName, loadFileType, source.loadFileProperties.copy())
+          if loadedNode:
+            # Success
+            resultNodes.append(loadedNode)
+            break
+        else:
+          # no need to load node
+          break
 
-    if nodes:
-      return nodes
+        # Failed. Clean up downloaded file (it might have been a partial download)
+        file = qt.QFile(filePath)
+        if not file.remove():
+          self.logMessage('<b>Load failed (attempt %d of %d). Unable to delete and try again loading %s</b>'
+            % (attemptsCount+1, maximumAttemptsCount, filePath), logging.ERROR)
+          resultNodes.append(loadedNode)
+          break
+        self.logMessage('<b>Load failed (attempt %d of %d)...</b>' % (attemptsCount+1, maximumAttemptsCount), logging.ERROR)
+
+    if resultNodes:
+      return resultNodes
     else:
-      return filePaths
+      return resultFilePaths
 
   def sourceForSampleName(self,sampleName):
     """For a given sample name this will search the available sources.
@@ -927,7 +936,8 @@ class SampleDataTest(ScriptedLoadableModuleTest):
 
     sceneMTime = slicer.mrmlScene.GetMTime()
     filePaths = logic.downloadFromSource(SampleDataSource(
-      uris='http://slicer.kitware.com/midas3/download/item/292308/MR-head.nrrd', fileNames='MR-head.nrrd'))
+      uris=TESTING_DATA_URL + 'SHA256/cc211f0dfd9a05ca3841ce1141b292898b2dd2d3f08286affadf823a7e58df93',
+      fileNames='MR-head.nrrd'))
     self.assertEqual(len(filePaths), 1)
     self.assertTrue(os.path.exists(filePaths[0]))
     self.assertTrue(os.path.isfile(filePaths[0]))
@@ -935,7 +945,8 @@ class SampleDataTest(ScriptedLoadableModuleTest):
 
     sceneMTime = slicer.mrmlScene.GetMTime()
     filePaths = logic.downloadFromSource(SampleDataSource(
-      uris=['http://slicer.kitware.com/midas3/download/item/292308/MR-head.nrrd', 'http://slicer.kitware.com/midas3/download/item/292307/CT-chest.nrrd'],
+      uris=[TESTING_DATA_URL + 'SHA256/cc211f0dfd9a05ca3841ce1141b292898b2dd2d3f08286affadf823a7e58df93',
+            TESTING_DATA_URL + 'SHA256/4507b664690840abb6cb9af2d919377ffc4ef75b167cb6fd0f747befdb12e38e'],
       fileNames=['MR-head.nrrd', 'CT-chest.nrrd']))
     self.assertEqual(len(filePaths), 2)
     self.assertTrue(os.path.exists(filePaths[0]))
@@ -948,7 +959,8 @@ class SampleDataTest(ScriptedLoadableModuleTest):
     logic = SampleDataLogic()
     sceneMTime = slicer.mrmlScene.GetMTime()
     filePaths = logic.downloadFromSource(SampleDataSource(
-      uris='http://slicer.kitware.com/midas3/download/folder/3763/TinyPatient_Seg.zip', fileNames='TinyPatient_Seg.zip'))
+      uris=TESTING_DATA_URL + 'SHA256/b902f635ef2059cd3b4ba854c000b388e4a9e817a651f28be05c22511a317ec7',
+      fileNames='TinyPatient_Seg.zip'))
     self.assertEqual(len(filePaths), 1)
     self.assertTrue(os.path.exists(filePaths[0]))
     self.assertTrue(os.path.isdir(filePaths[0]))
@@ -958,7 +970,8 @@ class SampleDataTest(ScriptedLoadableModuleTest):
     logic = SampleDataLogic()
     sceneMTime = slicer.mrmlScene.GetMTime()
     filePaths = logic.downloadFromSource(SampleDataSource(
-      uris='http://slicer.kitware.com/midas3/download?items=8466', loadFiles=True, fileNames='slicer4minute.mrb'))
+      uris=TESTING_DATA_URL + 'SHA256/5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8',
+      loadFiles=True, fileNames='slicer4minute.mrb'))
     self.assertEqual(len(filePaths), 1)
     self.assertTrue(os.path.exists(filePaths[0]))
     self.assertTrue(os.path.isfile(filePaths[0]))
@@ -986,7 +999,8 @@ class SampleDataTest(ScriptedLoadableModuleTest):
     logic = SampleDataLogic()
     sceneMTime = slicer.mrmlScene.GetMTime()
     filePaths = logic.downloadFromSource(SampleDataSource(
-      uris='http://slicer.kitware.com/midas3/download?items=8466', fileNames='slicer4minute.mrb'))
+      uris=TESTING_DATA_URL + 'SHA256/5a1c78c3347f77970b1a29e718bfa10e5376214692d55a7320af94b9d8d592b8',
+      fileNames='slicer4minute.mrb'))
     self.assertEqual(len(filePaths), 1)
     self.assertTrue(os.path.exists(filePaths[0]))
     self.assertTrue(os.path.isfile(filePaths[0]))
@@ -1013,14 +1027,16 @@ class SampleDataTest(ScriptedLoadableModuleTest):
   def test_downloadFromSource_loadNode(self):
     logic = SampleDataLogic()
     nodes = logic.downloadFromSource(SampleDataSource(
-      uris='http://slicer.kitware.com/midas3/download/item/292308/MR-head.nrrd', fileNames='MR-head.nrrd', nodeNames='MRHead'))
+      uris=TESTING_DATA_URL + 'MD5/39b01631b7b38232a220007230624c8e',
+      fileNames='MR-head.nrrd', nodeNames='MRHead'))
     self.assertEqual(len(nodes), 1)
     self.assertEqual(nodes[0], slicer.mrmlScene.GetFirstNodeByName("MRHead"))
 
   def test_downloadFromSource_loadNodeFromMultipleFiles(self):
     logic = SampleDataLogic()
     nodes = logic.downloadFromSource(SampleDataSource(
-      uris=['http://slicer.kitware.com/midas3/download/?items=2011,1', 'http://slicer.kitware.com/midas3/download/?items=2010,1'],
+      uris=[TESTING_DATA_URL + 'SHA256/d785837276758ddd9d21d76a3694e7fd866505a05bc305793517774c117cb38d',
+            TESTING_DATA_URL + 'SHA256/67564aa42c7e2eec5c3fd68afb5a910e9eab837b61da780933716a3b922e50fe'],
       fileNames=['DTIVolume.raw.gz', 'DTIVolume.nhdr'],
       nodeNames=[None, 'DTIVolume']))
     self.assertEqual(len(nodes), 1)
@@ -1029,7 +1045,8 @@ class SampleDataTest(ScriptedLoadableModuleTest):
   def test_downloadFromSource_loadNodesWithLoadFileFalse(self):
     logic = SampleDataLogic()
     nodes = logic.downloadFromSource(SampleDataSource(
-      uris=['http://slicer.kitware.com/midas3/download/item/292308/MR-head.nrrd', 'http://slicer.kitware.com/midas3/download/item/292307/CT-chest.nrrd'],
+      uris=[TESTING_DATA_URL + 'SHA256/cc211f0dfd9a05ca3841ce1141b292898b2dd2d3f08286affadf823a7e58df93',
+            TESTING_DATA_URL + 'SHA256/4507b664690840abb6cb9af2d919377ffc4ef75b167cb6fd0f747befdb12e38e'],
       fileNames=['MR-head.nrrd', 'CT-chest.nrrd'],
       nodeNames=['MRHead', 'CTChest'],
       loadFiles=[False, True]))
@@ -1041,7 +1058,8 @@ class SampleDataTest(ScriptedLoadableModuleTest):
   def test_downloadFromSource_loadNodes(self):
     logic = SampleDataLogic()
     nodes = logic.downloadFromSource(SampleDataSource(
-      uris=['http://slicer.kitware.com/midas3/download/item/292308/MR-head.nrrd', 'http://slicer.kitware.com/midas3/download/item/292307/CT-chest.nrrd'],
+      uris=[TESTING_DATA_URL + 'SHA256/cc211f0dfd9a05ca3841ce1141b292898b2dd2d3f08286affadf823a7e58df93',
+            TESTING_DATA_URL + 'SHA256/4507b664690840abb6cb9af2d919377ffc4ef75b167cb6fd0f747befdb12e38e'],
       fileNames=['MR-head.nrrd', 'CT-chest.nrrd'],
       nodeNames=['MRHead', 'CTChest']))
     self.assertEqual(len(nodes), 2)


### PR DESCRIPTION
Also improved SampleData.downloadFromSource to not load scenes many times if download or loading fails (by default, download and load is only attempted up to 3 times).

re #4602