### PR TITLE
BUG: Prevent segment editor error messages on scene close

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -175,7 +175,16 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
 
   def observeSegmentation(self, observationEnabled):
     import vtkSegmentationCorePython as vtkSegmentationCore
-    segmentation = self.scriptedEffect.parameterSetNode().GetSegmentationNode().GetSegmentation()
+
+    parameterSetNode = self.scriptedEffect.parameterSetNode()
+    segmentationNode = None
+    if parameterSetNode:
+      segmentationNode = parameterSetNode.GetSegmentationNode()
+
+    segmentation = None
+    if segmentationNode:
+      segmentation = segmentationNode.GetSegmentation()
+
     if observationEnabled and self.observedSegmentation == segmentation:
       return
     if not observationEnabled and not self.observedSegmentation:


### PR DESCRIPTION
- Modified events are now blocked during parameter node initialization
- Error message is not displayed if no parameter node is found during updateWidgetFromMRML
- More thorough error checking for parameter and segmentation nodes in autocomplete effect

fixes #4662, #4664