### PR TITLE
ENH: Update ITK version from v5.1rc01 to v5.1rc03

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v5.1rc01"
+    "v5.1rc03"
     QUIET
     )
 


### PR DESCRIPTION
List of changes:

```
$ git shortlog v5.1rc01..v5.1rc03 --no-merges
Adam Rankin (1):
      COMP: Fixing compilation of ITK/OpenCV video bridge

Antoine Robert (1):
      ENH: Add boundary condition getters and setters

Brad King (1):
      BUG: Update URL for GitSetup hooks checkout

Brad T. Moore (1):
      ENH: Added explicit test of VectorImage with ExpandImageFilter

Bradley Lowekamp (32):
      BUG: Use unique_ptr::reset() to delete held pointer
      COMP: Remove unused region parameter in default copy constructor
      ENH: Update to latest GoogleTest release tag
      COMP: Disable GTest using threads
      ENH: Enable CircleCI to retrieve ccache on pull requests
      BUG: Set ConnectedComponentImageFilter's initial background value to zero.
      STYLE: Move constructor to hxx, use inline initialization for ivars
      COMP: Fix DCMTK unused CMake variable warning
      Revert "BUG: SetScale() and SetSkew() did not recompute offset: ScaleSkewVersorT (#1523)"
      BUG: Prevent integer underflow in CropImageFilter
      ENH: Add VectorImage support to MeanImageFilter
      ENH: Add test for sorting and size  in RelabelComponentImageFilter
      BUG: Fix RelabelComponentImageFilter with sorting off, size on
      PERF: Refactor RelabelComponentImageFilter
      BUG: Restore enum typedef name Convolution and Deconvolution filters
      ENH: ignore GDCM whitespace issues
      COMP: Fix suggested brace around initialization warnings
   `   BUG: set BinaryNot operator to const method
      ENH: Add a modular and unified interface for multi-threaded progress
      ENH: Update TBBMultiThreader to use ProgressReporters
      ENH: Restore progress reporting to many filters
      BUG: PoolMultiThreader catch and re-throw exceptions from progress
      BUG: Explicitly check abort flag in TBB multi-threader
      ENH: Update SimpleITKFilters remote module
      COMP: fix Doxygen Illegal command in title section
      ENH: Add name mangling for libpng update
      DOC: Add brief description to image filters
      BUG: Use function call to change access of superclass methods
      ENH: When REMOTE_GIT_TAG_{name} is empty do not update remote
      ENH: Rename REMOTE_GIT_TAG_${_name} to Module_${_name}_GIT_TAG
      ENH: Update SimpleITKFilters remote module
      COMP: Fix typo with Doxygen sphinx macro

Davis Vigneault (6):
      BUG: Bump Cuberille Git Hash
      ENH: Bump Cuberille Commit Hash
      BUG: Delaunay Cell Data
      BUG: Handle CellData in Decimation Filter
      BUG: Bump Cuberille Commit Hash
      DOC: Add ORCID for Davis Vigneault

Dženan Zukić (22):
      BUG: fix null pointer dereference in itkInOrderTreeIterator.h:102
      Update Release.md
      ENH: updating remote modules
      ENH: Deprecate TreeContainer group of classes
      BUG: Baseline and test image order was reversed in GDCM tests
      ENH: adding JPEG2000 ICT and RCT encoding compliance tests
      STYLE: ivar initialization into the header file in GDCMSeriesFileNames
      COMP: expose TransformCategoryType under LEGACY
      STYLE: cleaning up excessive white space in example
      ENH: update example to support non-overlapping images
      BUG: incorrect neighbor determination in scan-line derived filters
      BUG: remove assertion which frequently fails
      DOC: Update SupportedCompilers.md
      DOC: update example links in ImageToVTKImageFilter
      DOC: updating zenodo authors' ORCIDs and affiliations
      DOC: Update pull request template
      COMP: fix type conversion error in GPUPDEDeformableRegistrationFilter
      BUG: fix crash with multiple update in LabelStatisticsImageFilter
      BUG: restoring libPNG branch name for UpdateFromUpstream.sh
      ENH: update remote modules
      DOC: update compliance worksheet for 6 remote modules
      ENH: updating TubeTK and SphinxExamples remote modules

Eigen Upstream (2):
      Eigen3 2019-12-09 (c5d991ff)
      Eigen3 2020-02-06 (0a5604a9)

Flavien Bridault (1):
      COMP: Fix compiling an app with Clang when ITK is built with GCC

GDCM Upstream (3):
      GDCM 2020-02-12 (f1797c61)
      GDCM 2020-02-13 (5f191ecb)
      GDCM 2020-03-16 (cbb4c75c)

GoogleTest Upstream (1):
      GoogleTest 2019-10-03 (703bd9ca)

Hans J. Johnson (14):
      ENH: When using cmake > 3.12 use FindPython3 module
      COMP: Remove searching for python interpreter
      COMP: Allow building basic ITK on computer without python3.5
      ENH: Consistently use strongly typed enums
      STYLE: Fix style conformance with include file
      COMP: Named exception not passed along to next exception
      ENH: Provide rating scale for ITK Remote modules
      DOC: Fix copyright notice for NumFOCUS.
      BUG: Module COMPLIANCE level processing improved
      ENH: Default ITK_MINIMUM_COMPLIANCE_LEVEL=3
      COMP: Conditional python3 package finding
      ENH: Update hook-max-size for large GDCM files.
      COMP: Fix extra semi-colon compiler warning
      ENH: Fix anonymous exception passing for intel

Hans Johnson (43):
      COMP: Exceptions should be caught by constant reference
      BUG: Second argument to stream `operator<<` as const
      BUG: Print function should be const
      BUG: Add missing const 'GetDataObject' function signature
      BUG: Set 'GetDataObject' function signature to const
      BUG: operator() can not be const
      COMP: Need to explicitly define std::min<> template values
      ENH: Update RTK for future proofing.
      STYLE: clang-format style updates.
      COMP: Implicit conversion warnings
      BUG: Missing backward compatible enumeration name
      ENH: Update DCMTK to master branch of upstream DCMTK
      ENH: Update FFTW to latest release
      COMP: Use separate build path for fftw versions
      COMP: Fix fftw library ordering
      BUG: Incorrect type specified for enumeration
      ENH: Add all commit authors for ITK
      STYLE: Move deprecated remote modules into subdirectory.
      COMP: VXL > 2.0.2 is the default
      STYLE: Remove redundant void argument lists
      STYLE: Use override statements for C++11
      STYLE: Replace integer literals which are cast to bool.
      PERF: emplace_back method results in potentially more efficient code
      STYLE: Prefer c++11 'using' to 'typedef'
      STYLE: Use default member initialization
      STYLE: Prefer = default to explicitly trivial implementations
      STYLE: Prefer = delete to explicitly trivial implementations
      PERF: Allow compiler to choose best way to construct a copy
      PERF: readability container size empty
      STYLE: Use range-based loops from C++11
      STYLE: Use auto for variable type matches the type of the initializer expression
      COMP: Prefer const member functions
      BUG: Wrapping the GPUImageOps in python
      STYLE: Capture stderr/stdout for eigen3 config
      STYLE: Hide options for unused wrapping features
      STYLE: Hide options for unused remote modules.
      STYLE: ITK_MINIMUM_COMPLIANCE_LEVEL is an advanced feature
      STYLE: ITK_NIFTI_IO_ANALYZE_FLAVOR is an advanced feature
      STYLE: CLANGFORMAT_EXECUTABLE is an advanced feature
      COMP: Improve logic of hiding low grade modules
      STYLE: Rename AnalyzeObjectLabelMap to match conventions.
      ENH: Add compliance criteria worksheet
      COMP: non-C-compatible type given name for linkage

Hastings Greer (1):
      DOC: Document python snakecase filters' kwargs

Jared Vicory (1):
      ENH: Wrap ComposeImageFilter for complex types

Jon Haitz Legarreta Gorroño (1):
      DOC: Fix typos in progress reporter classes

KWSys Upstream (1):
      KWSys 2020-03-04 (6af2e592)

LIBPNG Upstream (1):
      PNG 2019-04-25 (301f7a14)

Mathew Seng (1):
      STYLE: Prefer making deleted functions public

Matt McCormick (68):
      ENH: Update SCIFIO remote module to 2019-12-11 Git master
      ENH: Update stale-bot comment about issue closure
      ENH: Update content links
      DOC: Update ExternalData kitware rsync command
      DOC: Document how to re-run tests with a PR comment
      ENH: Use curl instead of wget in SourceTarball script
      ENH: Add script to identify release authors
      ENH: Use a script to generate the release changelog
      DOC: Update .mailmap to consolidate author identification
      DOC: Add Stephen R. Aylward to .mailmap
      DOC: Set lang attribute for Doxygen docs
      DOC: Add version-specific Doxygen links to the download page
      DOC: .mailmap entry for Hans J. Johnson
      DOC: Update README links
      STYLE: Updates for ImageIORegionGTest, DiscreteGaussianImageFilter
      ENH: clang-format.bash detects clang-format-8 executable
      DOC: Update clang-format.bash path
      ENH: Add clang-format linter GitHub Action
      ENH: Apply clang-format to PR with action:ApplyClangFormat
      DOC: Add clang-format check docs in CONTRIBUTING.md
      DOC: Add Zenodo DOI badge
      ENH: Also run clang-format linter on PRs
      DOC: Remove CONTRIBUTING note about ApplyClangFormat action
      DOC: CONTRIBUTING.md link to ITK Software Guide Development Guidelines
      COMP: PYTHON_LIBRARY is missing for Windows configuration
      BUG: Workaround Python3 CMake module bugs
      STYLE: Do not use id as variable in igenerator.py
      ENH: Bump macOS Azure CI images to 10.14
      COMP: Quote Python3_LIBRARY argument
      COMP: Get Input const in CastSpatialObjectFilter
      BUG: Address CastSpatialObjectFilter argument to itkTypeMacro
      BUG: Call itk.down_cast on ProcessObject outputs in functional call
      DOC: Add Citation section to README
      DOC: Request updates ITKBibliography.bib
      DOC: Update copyright assignment to NumFOCUS
      DOC: Update NOTICE and README.md copyright remarks
      DOC: Add welcome message to CONTRIBUTING.md
      COMP: Exclude inconsistently failing Linux Python CI tests
      DOC: Add .zenodo.json for author association
      ENH: Add script to update .zenodo.json
      DOC: Suggest adding ORCID iD in CONTRIBUTING.md
      ENH: Require 10 or more commits for .zenodo.json
      DOC: .mailmap entry for ntustison@wustl.edu
      ENH: Add itk.xarray_from_image and itk.image_from_xarray
      BUG: Remove duplicate wrapping of itk.MeshEnums
      ENH: Support xarray.DataArray's in Pythonic filters
      BUG: Remove Python 2 code from igenerator.py
      BUG: Re-enable NumPy bridge tests in PythonExtrasTest
      COMP: Add missing brackets to RelabelComponentsImageFilterGTest
      BUG: Use Python3_EXECUTABLE when specified
      BUG: Specify CMAKE_GENERATOR for Eigen external project build
      BUG: Set Python3_EXECUTABLE on Windows
      STYLE: Remove Python 2 compatibility code in site-packages detection
      ENH: New testing data content links for ITK 5.1RC2
      BUG: Wrap TriangleMeshToBinaryImageFilter for float types
      COMP: Unused exception object in SmapsFileParser::ReadFile
      BUG: Add Python3 CMake module workarounds to ITKModuleExternal
      DOC: Add Lydia Ng's ORCID iD and affiliation
      DOC: Windows Python package builds now require CMake 3.16
      ENH: StopConditionRegularStepGradientDescentBaseOptimizer -> StopCondition
      ENH: Wrap ExhaustiveOptimizerv4
      BUG: Implement __eq__ for sequence objects, e.g. itk.Size
      BUG: Exclude Modules/Remote/CMakeLists.txt from remote module changes
      ENH: Format the release changelog in Markdown
      DOC: Remove FindPython3 robust remark
      COMP: Add ITK patches for DCMTK
      COMP: Do not add -mcorei7 with Emscripten
      DOC: Update .zenodo

MetaIO Maintainers (1):
      MetaIO 2020-02-29 (4828268c)

Niels Dekker (4):
      STYLE: Make RecursiveSeparableImageFilter MathEMAMAMAM/SMAMAMAM static
      STYLE: Make RecursiveSeparableImageFilter::FilterDataArray const
      STYLE: Locally use unique_ptr within RecursiveSeparableImageFilter
      COMP: Use nullptr rather than 0 in IOFactoryRegisterRegisterList (3x)

Niklas Johansson (1):
      STYLE: Remove unused import inspect

Pablo Hernandez-Cerdan (5):
      COMP: Use always find_package for Eigen3
      COMP: Eigen: Remove itkeigen folder (unrelated histories)
      DOC: Update .zenodo.json
      COMP: Update remote module: TotalVariation
      BUG: Pass CMAKE_<lang>_COMPILER to Eigen configuration

Pradeep Garigipati (1):
      BUG: Remove debug console prints from GPU kernels

Roman Grothausmann (1):
      ENH: updating remote module PolarTransform

Sean McBride (3):
      BUG: fixed off-by-one error found by ASan
      COMP: reformulate a self-assignment to fix -Wself-assign-overloaded warning
      COMP: fixed -Wfloat-conversion warning in public header

Simon Rit (5):
      COMP: remove Eigen3 shadow warnings with GCC 4.8.5
      ENH: latest version of remote module RTK
      ENH: update RTK and set MODULE_COMPLIANCE_LEVEL to 3
      DOC: add affiliation and orcid for Simon Rit
      BUG: fix manual definition of git tag for remote modules

Stephen R. Aylward (10):
      BUG: SetScale() and SetSkew() did not recompute offset: ScaleSkewVersorT (#1523)
      BUG: itkMetaImageIO.cxx supports more MetaDataDictionary field types
      ENH: Adding function to SOToImageFilter simplify output definition (#1531)
      ENH: Adding ComposeScaleSkewVersor 3D Transform (#1539)
      ENH: Adding filter and wrapping for casting within SO hierarchy (#1576)
      ENH: Update TubeSpatialObjects I/O methods for recent MetaIO changes.
      ENH: Add TubeTK as a remote module for ITK
      ENH: Bump TubeTK to support internal and extern remote module
      ENH: Update TubeTK to github/InsightSoftwareConsortium/ITKTubeTK
      BUG: Bump TubeTK to fix use of ArrayFire and installation command

Tabish Syed (1):
      ENH: Allow Transform with different Input and Output Dimensions.

Taylor Braun-Jones (1):
      COMP: Fix unit tests for OpenCV 4

VXL Maintainers (2):
      VNL 2019-12-13 (8af77376)
      VNL 2020-02-14 (be6c1433)

Vladimir S. FONOV (8):
      ENH: Updated script for Eigen third party update
      ENH: Simplification of the ImageSeriesReader nonuniform sampling detection
      BUG: fixes issue# 1498
      ENH: Changed NIFTI IO to support different flavors of Analyze readers
      COMP: Fixes error "error: no member named 'cend' in 'std::__1::__map_const..."
      DOC: updated ITK5MigrationGuide on Analyze format support
      BUG: reduced number of warnings for non-uniform sampling
      BUG: accessing array out of bounds in ImageSeriesReader

Ziv Yaniv (2):
      BUG: SetLabelForUndecidedPixels value ignored.
      DOC: Adding ORCID for Ziv Yaniv.
```