### PR TITLE
COMP: Update SimpleITK to build error related to ITK version update

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -51,7 +51,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" Packaging/s
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "slicer-v1.2.4-2020-02-07-777520bd"  # pre-v2.0 (ITK 5 as default), with patch "Propagate CMake visibility variables in external projects"
+    "7ce1f1867eaa419d0ef0f9aeb074363e85b633c4"  # slicer-v2.0rc1-2020-03-09-7ce1f1867
     QUIET
     )
 


### PR DESCRIPTION
This commit fixes regression introduced in 0a8f06c62 (ENH: Update ITK
version from v5.1rc01 to v5.1rc03)

List of changes:

```
$ git shortlog 9fbcf2e9b..7ce1f1867 --no-merges
Boo Irizarry (3):
      update workflow contrubiting.md file
      update contributing file
      update contributing file again

Bradley Lowekamp (69):
      Load SimpleITK version used in SimpleITKExamples sub-project
      Set SimpleITK version to 2.0.0
      Set more restrictive test template globs
      Update ITK Superbuild version along the 5.1 development branch
      Suppress self assignment warning in Image tests.
      For external project add required flags to preprocessor
      Update Superbuild ITK version along ITKv5.1 development
      Update ITK along 5.1 development
      Update ITK along 5.1 development
      Update MeanImageFilter wrapping to directly use VectorImage
      Add docker to build the SimpleITK doxygen
      AZP add Doxygen build and archive creating to packing build
      Add displacement field test case
      Fix double free from buffer ownership change in ImageFromVectorImage
      Update the SimpleITK S3 URL to virtual-host style
      Remove ITK legacy code in Superbuild
      Set ReturnBinMidpoint to match default ITKv5 value
      Update Doxygen version to 1.8.17
      Update superbuild version of ITK
      Update testing results of Otsu changed behavior
      Add more testing for RelabelComponentImageFilter
      Fix AZP package find command path
      Add rename const buffer access methods to C# interface.
      Add GetIndexes and GetRLEIndexes to LabelShapStatistics filter.
      Propagate CMake visibility variables in external projects.
      Remove references to git on itk.org
      Fix spelling in error message
      Fix pipeline update in per component filters
      Fix finding correct lua interpreter version
      Correct variables reported in Lua and VirtualEnv find package
      Update ITK superbuild version along ITKv5.1rc01 development
      Explicitly cast int to ITK strongly typed enums
      Use python 3 executable
      Remove auto_ptr wrapper with std::unique_ptr
      Update ITK along the 5.1 RC development
      Replace nsstd fuctional with C++ functional
      Explicitly delete methods
      Replace sitkStaticAssert with standard static_assert
      Remove unused CXX_ALIAS_TEMPLATE
      Replace SITK_NULLPTR with standard nullptr
      Replace nsstd::unordered_map with std::unordered_map
      Include map in BasicFilters header
      Add CTest suppression for CircleCI adding host key to known hosts
      Use catch by reference to address compiler warning
      Replace nsstd type_traits with C++ type_traits
      Remove unused namespace alias of nsstd in tests
      Replace custom class with std::enable_if
      Use std::conditional
      Remove remnants of nsstd files
      Update ITK Superbuild version to v5.1rc02
      Add GetBufferAsVoid to Image
      Pass GDCM_ CMake variables to the ITK Superbuild
      Use lambda over using nested std::bind
      Add move operations to the Image class
      Increase max blob size for ghostflow-check-master
      Directly use C++11 noexcept keyword
      Replace SITK_OVERRIDE with C++11 override keyword
      CircleCI do not use old KWStyle
      Skip wrapping sitk::Image move methods
      Add Decay parameter to the MirrorPadImageFilter
      Add direct support for C++ lambda to ProcessObject commands
      Add testing for lambda commands
      Add C++ lambda command example
      Update copyright assignment to NumFOCUS
      Correct usage of cmake to create zip archive for CSharp
      Update JSON doxygen strings from ITK
      Move AZP package scripts to scripts directory
      AZP add Java package for Apple OSX
      Update AZP mac package image to 10.14

Dave Chen (5):
      Fixed grammer and changed ImageJ to Fiji.
      Added CMake/C++ setup documentation
      Added CMake/C++ setup documentation
      Removed 1st and 2nd person usage
      Fixed a couple spelling bugs

Ziv Yaniv (1):
      Adding license and link to license.
```