### PR TITLE
COMP: Fix configuration with CMake >= 3.17. CMAKE_DEFAULT_BUILD_TYPE can not be specified

### DIFF
--- a/CMake/SlicerConfig.cmake.in
+++ b/CMake/SlicerConfig.cmake.in
@@ -112,7 +112,7 @@ endif()
 # --------------------------------------------------------------------------
 # Slicer options
 # --------------------------------------------------------------------------
-set(CMAKE_DEFAULT_BUILD_TYPE "@CMAKE_DEFAULT_BUILD_TYPE@")
+set(Slicer_DEFAULT_BUILD_TYPE "@Slicer_DEFAULT_BUILD_TYPE@")
 set(Slicer_USE_NUMPY "@Slicer_USE_NUMPY@")
 set(Slicer_USE_SCIPY "@Slicer_USE_SCIPY@")
 set(Slicer_USE_PYTHONQT "@Slicer_USE_PYTHONQT@")

--- a/CMake/SlicerInitializeBuildType.cmake
+++ b/CMake/SlicerInitializeBuildType.cmake
@@ -1,15 +1,15 @@
 
 # Default build type to use if none was specified
-if(NOT DEFINED CMAKE_DEFAULT_BUILD_TYPE)
-  set(CMAKE_DEFAULT_BUILD_TYPE "Debug")
+if(NOT DEFINED Slicer_DEFAULT_BUILD_TYPE)
+  set(Slicer_DEFAULT_BUILD_TYPE "Debug")
 endif()
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 
-  message(STATUS "Setting build type to '${CMAKE_DEFAULT_BUILD_TYPE}' as none was specified.")
+  message(STATUS "Setting build type to '${Slicer_DEFAULT_BUILD_TYPE}' as none was specified.")
 
-  set(CMAKE_BUILD_TYPE ${CMAKE_DEFAULT_BUILD_TYPE} CACHE STRING "Choose the type of build." FORCE)
+  set(CMAKE_BUILD_TYPE ${Slicer_DEFAULT_BUILD_TYPE} CACHE STRING "Choose the type of build." FORCE)
   mark_as_advanced(CMAKE_BUILD_TYPE)
 
   # Set the possible values of build type for cmake-gui
@@ -29,4 +29,3 @@ if(COMMAND mark_as_superbuild)
     mark_as_superbuild(VARS CMAKE_CONFIGURATION_TYPES ALL_PROJECTS)
   endif()
 endif()
-


### PR DESCRIPTION
This commit conditionally sets CMAKE_DEFAULT_BUILD_TYPE variable to fix
configuration error <s>on Windows</s> using CMake >= 3.17.

This change is required because Slicer build-system introduced the
variable CMAKE_DEFAULT_BUILD_TYPE in Nov 2017 (see c808da1) and it triggers
a configuration error following the introduction of the same variable in
CMake 3.17.
See https://cmake.org/cmake/help/latest/variable/CMAKE_DEFAULT_BUILD_TYPE.html

Error fixed by this commit:

```
  CMake Error:
     Generator

       Visual Studio 15 2017

     does not support variable

       CMAKE_DEFAULT_BUILD_TYPE

     but it has been specified.
```

Custom Slicer application may have to be updated to conditionally set
CMAKE_DEFAULT_BUILD_TYPE based on the value of the GENERATOR_IS_MULTI_CONFIG
global property.

Fixes #4798