### PR TITLE
ENH: Add interaction handles for transforming markup positions

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -237,12 +237,6 @@ public:
   /// Get best fit plane for a markup
   static bool GetBestFitPlane(vtkMRMLMarkupsNode* curveNode, vtkPlane* plane);
 
-  /// Compute least squares best fit plane
-  static bool FitPlaneToPoints(vtkPoints* curvePoints, vtkPlane* plane);
-
-  /// Compute transform that best transforms the XY plane to the best fit plane
-  static bool FitPlaneToPoints(vtkPoints* curvePoints, vtkMatrix4x4* transformToBestFitPlane);
-
 protected:
   vtkSlicerMarkupsLogic();
   ~vtkSlicerMarkupsLogic() override;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.h
@@ -66,6 +66,9 @@ protected:
   vtkMRMLMarkupsAngleNode(const vtkMRMLMarkupsAngleNode&);
   void operator=(const vtkMRMLMarkupsAngleNode&);
 
+  /// Calculates the handle to world matrix based on the current control points
+  void UpdateInteractionHandleToWorldMatrix() override;
+
   void UpdateMeasurements() override;
 };
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -96,6 +96,8 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->LineColorFadingSaturation = 1.;
   this->LineColorFadingHueOffset = 0.;
 
+  this->HandlesInteractive = false;
+
   // Line color node
   vtkNew<vtkIntArray> events;
   events->InsertNextValue(vtkCommand::ModifiedEvent);
@@ -133,6 +135,7 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingHueOffset, LineColorFadingHueOffset);
+  vtkMRMLWriteXMLBooleanMacro(handlesInteractive, HandlesInteractive);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -162,6 +165,7 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLReadXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
   vtkMRMLReadXMLFloatMacro(lineColorFadingHueOffset, LineColorFadingHueOffset);
+  vtkMRMLReadXMLBooleanMacro(handlesInteractive, HandlesInteractive);
   vtkMRMLReadXMLEndMacro();
 
   // Fix up legacy markups fiducial nodes
@@ -222,6 +226,7 @@ void vtkMRMLMarkupsDisplayNode::Copy(vtkMRMLNode *anode)
   vtkMRMLCopyFloatMacro(LineColorFadingEnd);
   vtkMRMLCopyFloatMacro(LineColorFadingSaturation);
   vtkMRMLCopyFloatMacro(LineColorFadingHueOffset);
+  vtkMRMLCopyBooleanMacro(HandlesInteractive);
   vtkMRMLCopyEndMacro();
 
   this->EndModify(disabledModify);
@@ -350,6 +355,7 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(LineColorFadingEnd);
   vtkMRMLPrintFloatMacro(LineColorFadingSaturation);
   vtkMRMLPrintFloatMacro(LineColorFadingHueOffset);
+  vtkMRMLPrintBooleanMacro(HandlesInteractive);
   vtkMRMLPrintEndMacro();
 }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -88,7 +88,9 @@ public:
     ComponentControlPoint,
     ComponentCenterPoint,
     ComponentLine,
-    ComponentPlane
+    ComponentPlane,
+    ComponentRotationHandle,
+    ComponentTranslationHandle,
     };
   struct ComponentInfo
     {
@@ -313,6 +315,11 @@ public:
   vtkMRMLProceduralColorNode* GetLineColorNode();
   virtual const char* GetLineColorNodeReferenceRole();
 
+  /// The visibility and interactability of the interaction handles
+  vtkGetMacro(HandlesInteractive, bool);
+  vtkSetMacro(HandlesInteractive, bool);
+  vtkBooleanMacro(HandlesInteractive, bool);
+
 protected:
   vtkMRMLMarkupsDisplayNode();
   ~vtkMRMLMarkupsDisplayNode() override;
@@ -349,5 +356,7 @@ protected:
   double LineColorFadingEnd;
   double LineColorFadingSaturation;
   double LineColorFadingHueOffset;
+
+  bool HandlesInteractive;
 };
 #endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.h
@@ -67,6 +67,9 @@ protected:
   void operator=(const vtkMRMLMarkupsLineNode&);
 
   void UpdateMeasurements() override;
+
+  /// Calculates the handle to world matrix based on the current control points
+  void UpdateInteractionHandleToWorldMatrix() override;
 };
 
 #endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -52,7 +52,9 @@ class vtkMRMLUnitNode;
 /// Each ControlPoint can also be individually un/selected, un/locked, in/visible,
 /// and have a label (short, shown in the viewers) and description (longer,
 /// shown in the GUI).
-///
+/// Coordinate systems used:
+///   - Local: Local coordinates
+///   - World: All parent transforms on node applied to local.
 /// \sa vtkMRMLMarkupsDisplayNode
 /// \ingroup Slicer_QtModules_Markups
 
@@ -561,6 +563,9 @@ public:
   /// Get a copy of all control point positions in world coordinate system
   void GetControlPointPositionsWorld(vtkPoints* points);
 
+  /// 4x4 matrix detailing the orientation and position in world coordinates of the interaction handles.
+  virtual vtkMatrix4x4* GetInteractionHandleToWorldMatrix();
+
 protected:
   vtkMRMLMarkupsNode();
   ~vtkMRMLMarkupsNode() override;
@@ -605,6 +610,9 @@ protected:
   /// Helper function to write measurements to node Description property.
   /// This is a short-term solution until measurements display is properly implemented.
   virtual void WriteMeasurementsToDescription();
+
+  /// Calculates the handle to world matrix based on the current control points
+  virtual void UpdateInteractionHandleToWorldMatrix();
 
   // Used for limiting number of markups that may be placed.
   int MaximumNumberOfControlPoints;
@@ -653,6 +661,10 @@ protected:
   vtkVector3d CenterPos;
 
   std::vector< vtkSmartPointer<vtkMRMLMeasurement> > Measurements;
+
+  // Transform that moves the xyz unit vectors and origin of the interaction handles to local coordinates
+  vtkSmartPointer<vtkMatrix4x4> InteractionHandleToWorldMatrix;
+
 };
 
 #endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.cxx
@@ -46,7 +46,11 @@ vtkMRMLMarkupsPlaneNode::vtkMRMLMarkupsPlaneNode()
   this->RequiredNumberOfControlPoints = 3;
   this->SizeMode = SizeModeAuto;
   this->AutoSizeScalingFactor = 1.0;
-  this->LocalToPlaneTransform = vtkSmartPointer<vtkMatrix4x4>::New();
+  for (int i = 0; i < 6; ++i)
+    {
+    this->PlaneBounds[i] = 0.0;
+    }
+  this->PlaneToPlaneOffsetMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
 }
 
 //----------------------------------------------------------------------------
@@ -60,7 +64,7 @@ void vtkMRMLMarkupsPlaneNode::WriteXML(ostream& of, int nIndent)
   Superclass::WriteXML(of,nIndent);
   vtkMRMLWriteXMLBeginMacro(of);
   vtkMRMLWriteXMLEnumMacro(sizeMode, SizeMode);
-  vtkMRMLWriteXMLMatrix4x4Macro(localToPlaneTransform, LocalToPlaneTransform);
+  vtkMRMLWriteXMLMatrix4x4Macro(planeToPlaneOffsetMatrix, PlaneToPlaneOffsetMatrix);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -71,7 +75,7 @@ void vtkMRMLMarkupsPlaneNode::ReadXMLAttributes(const char** atts)
   Superclass::ReadXMLAttributes(atts);
   vtkMRMLReadXMLBeginMacro(atts);
   vtkMRMLReadXMLEnumMacro(sizeMode, SizeMode);
-  vtkMRMLReadXMLOwnedMatrix4x4Macro(localToPlaneTransform, LocalToPlaneTransform);
+  vtkMRMLReadXMLOwnedMatrix4x4Macro(planeToPlaneOffsetMatrix, PlaneToPlaneOffsetMatrix);
   vtkMRMLReadXMLEndMacro();
 }
 
@@ -82,7 +86,7 @@ void vtkMRMLMarkupsPlaneNode::Copy(vtkMRMLNode *anode)
   Superclass::Copy(anode);
   vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyEnumMacro(SizeMode);
-  vtkMRMLCopyOwnedMatrix4x4Macro(LocalToPlaneTransform);
+  vtkMRMLCopyOwnedMatrix4x4Macro(PlaneToPlaneOffsetMatrix);
   vtkMRMLCopyEndMacro();
 }
 
@@ -92,7 +96,7 @@ void vtkMRMLMarkupsPlaneNode::PrintSelf(ostream& os, vtkIndent indent)
   Superclass::PrintSelf(os,indent);
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintEnumMacro(SizeMode);
-  vtkMRMLPrintMatrix4x4Macro(LocalToPlaneTransform);
+  vtkMRMLPrintMatrix4x4Macro(PlaneToPlaneOffsetMatrix);
   vtkMRMLPrintEndMacro();
 }
 
@@ -144,7 +148,7 @@ void vtkMRMLMarkupsPlaneNode::GetNormal(double normal[3])
 
   double x[3] = { 0 };
   double y[3] = { 0 };
-  this->GetPlaneAxes(x, y, normal);
+  this->GetAxes(x, y, normal);
 }
 
 //----------------------------------------------------------------------------
@@ -167,7 +171,7 @@ void vtkMRMLMarkupsPlaneNode::GetNormalWorld(double normalWorld[3])
 
   double x[3] = { 0 };
   double y[3] = { 0 };
-  this->GetPlaneAxesWorld(x, y, normalWorld);
+  this->GetAxesWorld(x, y, normalWorld);
 }
 
 //----------------------------------------------------------------------------
@@ -196,7 +200,7 @@ void vtkMRMLMarkupsPlaneNode::SetNormal(const double normal[3])
     }
 
   vtkNew<vtkTransform> planeToLocalTransform;
-  planeToLocalTransform->Concatenate(this->LocalToPlaneTransform);
+  //planeToLocalTransform->Concatenate(this->LocalToPlaneTransform); //TODO
   planeToLocalTransform->Inverse();
 
   double currentNormalLocal[3] = { 0 };
@@ -258,62 +262,67 @@ void vtkMRMLMarkupsPlaneNode::SetNormalWorld(const double inNormal[3])
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::GetOrigin(double outOrigin[3])
+void vtkMRMLMarkupsPlaneNode::GetOrigin(double origin_Local[3])
 {
-  if (!outOrigin)
+  if (!origin_Local)
     {
     vtkErrorMacro("GetOrigin: Invalid origin argument");
     return;
     }
 
+  origin_Local[0] = 0.0;
+  origin_Local[1] = 0.0;
+  origin_Local[2] = 0.0;
+
   if (this->GetNumberOfControlPoints() < 1)
     {
-    outOrigin[0] = 0;
-    outOrigin[1] = 0;
-    outOrigin[2] = 0;
     vtkWarningMacro("GetOrigin: Not enough points to define plane origin");
     return;
     }
 
-  outOrigin[0] = 0;
-  outOrigin[1] = 0;
-  outOrigin[2] = 0;
+  double origin_Plane[3] = { 0.0, 0.0, 0.0 };
 
-  vtkNew<vtkTransform> localToPlaneTransform;
-  localToPlaneTransform->SetMatrix(this->LocalToPlaneTransform);
-  localToPlaneTransform->TransformPoint(outOrigin, outOrigin);
+  vtkNew<vtkMatrix4x4> planeToLocalMatrix;
+  this->GetPlaneToLocalMatrix(planeToLocalMatrix);
 
-  double origin[3] = { 0 };
-  this->GetNthControlPointPosition(0, origin);
-  vtkMath::Add(origin, outOrigin, outOrigin);
+  vtkNew<vtkTransform> planeToLocalTransform;
+  planeToLocalTransform->SetMatrix(planeToLocalMatrix);
+  planeToLocalTransform->TransformPoint(origin_Plane, origin_Local);
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::GetOriginWorld(double originWorld[3])
+void vtkMRMLMarkupsPlaneNode::GetOriginWorld(double origin_World[3])
 {
-  if (!originWorld)
+  if (!origin_World)
     {
     vtkErrorMacro("GetOriginWorld: Invalid origin argument");
     return;
     }
 
+  origin_World[0] = 0.0;
+  origin_World[1] = 0.0;
+  origin_World[2] = 0.0;
+
   if (this->GetNumberOfControlPoints() < 1)
     {
-    originWorld[0] = 0;
-    originWorld[1] = 0;
-    originWorld[2] = 0;
     vtkWarningMacro("GetOriginWorld: Not enough points to define plane origin");
     return;
     }
 
-  this->GetOrigin(originWorld);
-  this->TransformPointToWorld(originWorld, originWorld);
+  double origin_Plane[3] = { 0.0, 0.0, 0.0 };
+
+  vtkNew<vtkMatrix4x4> planeToWorldMatrix;
+  this->GetPlaneToWorldMatrix(planeToWorldMatrix);
+
+  vtkNew<vtkTransform> planeToWorldTransform;
+  planeToWorldTransform->SetMatrix(planeToWorldMatrix);
+  planeToWorldTransform->TransformPoint(origin_Plane, origin_World);
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::SetOrigin(const double origin[3])
+void vtkMRMLMarkupsPlaneNode::SetOrigin(const double origin_Local[3])
 {
-  if (!origin)
+  if (!origin_Local)
     {
     vtkWarningMacro("SetOrigin: Invalid origin argument");
     return;
@@ -325,42 +334,27 @@ void vtkMRMLMarkupsPlaneNode::SetOrigin(const double origin[3])
     this->AddNControlPoints(1);
     }
 
-  double newControlPointPos[3] = { 0, 0, 0 };
-  vtkNew<vtkTransform> planeToLocalTransform;
-  planeToLocalTransform->SetMatrix(this->LocalToPlaneTransform);
-  planeToLocalTransform->Inverse();
-  planeToLocalTransform->TransformPoint(origin, newControlPointPos);
+  double previousOrigin_Local[3] = { 0.0, 0.0, 0.0 };
+  this->GetOrigin(previousOrigin_Local);
 
-  double previousControlPointPos[3] = { 0.0 };
-  this->GetNthControlPointPosition(0, previousControlPointPos);
+  double displacementVector_Local[3] = { 0.0 };
+  vtkMath::Subtract(origin_Local, previousOrigin_Local, displacementVector_Local);
 
-  this->SetNthControlPointPosition(0,
-    newControlPointPos[0], newControlPointPos[1], newControlPointPos[2]);
-
-  if (this->GetNumberOfControlPoints() < 3)
+  for (int i = 0; i < this->GetNumberOfControlPoints(); ++i)
     {
-    return;
-    }
-
-  double displacementVector[3] = { 0.0 };
-  vtkMath::Subtract(newControlPointPos, previousControlPointPos, displacementVector);
-
-  for (int i = 1; i < this->GetNumberOfControlPoints(); ++i)
-    {
-    double currentControlPointPos[3] = { 0.0 };
-    this->GetNthControlPointPosition(i, currentControlPointPos);
-    vtkMath::Add(currentControlPointPos, displacementVector, currentControlPointPos);
-    this->SetNthControlPointPosition(i,
-      currentControlPointPos[0], currentControlPointPos[1], currentControlPointPos[2]);
+    double position_Local[3] = { 0.0 };
+    this->GetNthControlPointPosition(i, position_Local);
+    vtkMath::Add(position_Local, displacementVector_Local, position_Local);
+    this->SetNthControlPointPosition(i, position_Local[0], position_Local[1], position_Local[2]);
     }
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::SetOriginWorld(const double originWorld[3])
+void vtkMRMLMarkupsPlaneNode::SetOriginWorld(const double origin_World[3])
 {
-  double originLocal[3] = { 0 };
-  this->TransformPointFromWorld(originWorld, originLocal);
-  this->SetOrigin(originLocal);
+  double origin_Local[3] = { 0.0 };
+  this->TransformPointFromWorld(origin_World, origin_Local);
+  this->SetOrigin(origin_Local);
 }
 
 //----------------------------------------------------------------------------
@@ -370,7 +364,7 @@ void vtkMRMLMarkupsPlaneNode::CalculateAxesFromPoints(const double point0[3], co
   vtkMath::Subtract(point1, point0, x);
   vtkMath::Normalize(x);
 
-  double tempVector[3] = { 0 };
+  double tempVector[3] = { 0.0 };
   vtkMath::Subtract(point2, point0, tempVector);
   vtkMath::Cross(x, tempVector, z);
   vtkMath::Normalize(z);
@@ -380,231 +374,353 @@ void vtkMRMLMarkupsPlaneNode::CalculateAxesFromPoints(const double point0[3], co
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::GetPlaneAxes(double x[3], double y[3], double z[3])
+void vtkMRMLMarkupsPlaneNode::GetPlaneToLocalMatrix(vtkMatrix4x4* planeToLocalMatrix)
 {
-  if (!x || !y || !z)
+  if (!planeToLocalMatrix)
     {
-    vtkErrorMacro("GetPlaneAxes: Invalid input argument");
+    return;
+    }
+
+  if (this->GetNumberOfControlPoints() < 1)
+    {
+    return;
+    }
+
+  double point0_Local[3] = { 0.0 };
+  this->GetNthControlPointPosition(0, point0_Local);
+
+  vtkNew<vtkMatrix4x4> planeOffsetToLocalMatrix;
+  for (int i = 0; i < 3; ++i)
+    {
+    planeOffsetToLocalMatrix->SetElement(i, 3, point0_Local[i]);
+    }
+
+  if (this->GetNumberOfControlPoints() >= 3)
+    {
+    double point1_Local[3] = { 0.0 };
+    double point2_Local[3] = { 0.0 };
+
+    this->GetNthControlPointPosition(1, point1_Local);
+    this->GetNthControlPointPosition(2, point2_Local);
+
+    double xAxis_Local[3] = { 0.0 };
+    double yAxis_Local[3] = { 0.0 };
+    double zAxis_Local[3] = { 0.0 };
+    this->CalculateAxesFromPoints(point0_Local, point1_Local, point2_Local, xAxis_Local, yAxis_Local, zAxis_Local);
+    for (int i = 0; i < 3; ++i)
+      {
+      planeOffsetToLocalMatrix->SetElement(i, 0, xAxis_Local[i]);
+      planeOffsetToLocalMatrix->SetElement(i, 1, yAxis_Local[i]);
+      planeOffsetToLocalMatrix->SetElement(i, 2, zAxis_Local[i]);
+      }
+    }
+
+  vtkNew<vtkTransform> planeToLocalTransform;
+  planeToLocalTransform->PostMultiply();
+  planeToLocalTransform->Concatenate(this->PlaneToPlaneOffsetMatrix);
+  planeToLocalTransform->Concatenate(planeOffsetToLocalMatrix);
+  planeToLocalMatrix->DeepCopy(planeToLocalTransform->GetMatrix());
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::GetPlaneToWorldMatrix(vtkMatrix4x4* planeToWorldMatrix)
+{
+  if (!planeToWorldMatrix)
+    {
+    return;
+    }
+
+  if (this->GetNumberOfControlPoints() < 1)
+    {
+    return;
+    }
+
+  double point0_World[3] = { 0.0 };
+  this->GetNthControlPointPositionWorld(0, point0_World);
+
+  vtkNew<vtkMatrix4x4> planeOffsetToWorldMatrix;
+  for (int i = 0; i < 3; ++i)
+    {
+    planeOffsetToWorldMatrix->SetElement(i, 3, point0_World[i]);
+    }
+
+  if (this->GetNumberOfControlPoints() >= 3)
+    {
+    double point1_World[3] = { 0.0 };
+    double point2_World[3] = { 0.0 };
+
+    this->GetNthControlPointPositionWorld(1, point1_World);
+    this->GetNthControlPointPositionWorld(2, point2_World);
+
+    double xAxis_World[3] = { 0.0 };
+    double yAxis_World[3] = { 0.0 };
+    double zAxis_World[3] = { 0.0 };
+    this->CalculateAxesFromPoints(point0_World, point1_World, point2_World, xAxis_World, yAxis_World, zAxis_World);
+    for (int i = 0; i < 3; ++i)
+      {
+      planeOffsetToWorldMatrix->SetElement(i, 0, xAxis_World[i]);
+      planeOffsetToWorldMatrix->SetElement(i, 1, yAxis_World[i]);
+      planeOffsetToWorldMatrix->SetElement(i, 2, zAxis_World[i]);
+      }
+    }
+
+  vtkNew<vtkTransform> planeToLocalTransform;
+  planeToLocalTransform->PostMultiply();
+  planeToLocalTransform->Concatenate(this->PlaneToPlaneOffsetMatrix);
+  planeToLocalTransform->Concatenate(planeOffsetToWorldMatrix);
+  planeToWorldMatrix->DeepCopy(planeToLocalTransform->GetMatrix());
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::GetAxes(double xAxis_Local[3], double yAxis_Local[3], double zAxis_Local[3])
+{
+  if (!xAxis_Local || !yAxis_Local || !zAxis_Local)
+    {
+    vtkErrorMacro("GetAxes: Invalid input argument");
     return;
     }
 
   if (this->GetNumberOfControlPoints() < 3)
     {
-    vtkWarningMacro("GetPlaneAxes: Not enough points to define plane axis");
+    vtkWarningMacro("GetAxes: Not enough points to define plane axis");
     return;
     }
 
-  double point0[3] = { 0 };
-  this->GetNthControlPointPosition(0, point0);
-  double point1[3] = { 0 };
-  this->GetNthControlPointPosition(1, point1);
-  double point2[3] = { 0 };
-  this->GetNthControlPointPosition(2, point2);
-
-  vtkNew<vtkTransform> localToPlaneTransform;
-  localToPlaneTransform->SetMatrix(this->LocalToPlaneTransform);
-  localToPlaneTransform->TransformPoint(point0, point0);
-  localToPlaneTransform->TransformPoint(point1, point1);
-  localToPlaneTransform->TransformPoint(point2, point2);
-
-  this->CalculateAxesFromPoints(point0, point1, point2, x, y, z);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::GetPlaneAxesWorld(double x[3], double y[3], double z[3])
-{
-  if (!x || !y || !z)
+  for (int i = 0; i < 3; ++i)
     {
-    vtkErrorMacro("GetPlaneAxesWorld: Invalid input argument");
-    return;
+    xAxis_Local[i] = 0.0;
+    yAxis_Local[i] = 0.0;
+    zAxis_Local[i] = 0.0;
     }
+  xAxis_Local[0] = 1.0;
+  yAxis_Local[1] = 1.0;
+  zAxis_Local[2] = 1.0;
 
-  vtkMRMLTransformNode* transformNode = this->GetParentTransformNode();
+  double xAxis_Plane[3] = { 1.0, 0.0, 0.0 };
+  double yAxis_Plane[3] = { 0.0, 1.0, 0.0 };
+  double zAxis_Plane[3] = { 0.0, 0.0, 1.0 };
 
-  double point0[3] = { 0 };
-  this->GetNthControlPointPosition(0, point0);
-  double point1[3] = { 0 };
-  this->GetNthControlPointPosition(1, point1);
-  double point2[3] = { 0 };
-  this->GetNthControlPointPosition(2, point2);
+  vtkNew<vtkMatrix4x4> planeToLocalMatrix;
+  this->GetPlaneToLocalMatrix(planeToLocalMatrix);
 
-  vtkNew<vtkTransform> localToPlaneTransform;
-  localToPlaneTransform->SetMatrix(this->LocalToPlaneTransform);
-  localToPlaneTransform->TransformPoint(point0, point0);
-  localToPlaneTransform->TransformPoint(point1, point1);
-  localToPlaneTransform->TransformPoint(point2, point2);
-
-  if (transformNode)
-    {
-    // Get transform
-    vtkNew<vtkGeneralTransform> transformToWorld;
-    transformNode->GetTransformToWorld(transformToWorld.GetPointer());
-    transformToWorld->TransformPoint(point0, point0);
-    transformToWorld->TransformPoint(point1, point1);
-    transformToWorld->TransformPoint(point2, point2);
-    }
-
-  this->CalculateAxesFromPoints(point0, point1, point2, x, y, z);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::SetPlaneAxes(const double inX[3], const double inY[3], const double inZ[3])
-{
-  if (!inX || !inY || !inZ)
-    {
-    vtkErrorMacro("SetPlaneAxes: Invalid input axes");
-    return;
-    }
-
-  double x[3], y[3], z[3] = { 0 };
   vtkNew<vtkTransform> planeToLocalTransform;
-  planeToLocalTransform->SetMatrix(this->LocalToPlaneTransform);
-  planeToLocalTransform->Inverse();
-  planeToLocalTransform->TransformPoint(inX, x);
-  planeToLocalTransform->TransformPoint(inY, y);
-  planeToLocalTransform->TransformPoint(inZ, z);
+  planeToLocalTransform->SetMatrix(planeToLocalMatrix);
+  planeToLocalTransform->TransformVector(xAxis_Plane, xAxis_Local);
+  planeToLocalTransform->TransformVector(yAxis_Plane, yAxis_Local);
+  planeToLocalTransform->TransformVector(zAxis_Plane, zAxis_Local);
+}
 
-  double epsilon = 0.0001;
-
-  double tempX[3], tempY[3], tempZ[3] = { 0 };
-  vtkMath::Cross(y, z, tempX);
-  vtkMath::Cross(z, x, tempY);
-  vtkMath::Cross(x, y, tempZ);
-  if (vtkMath::Dot(tempX, x) <= 1 - epsilon ||
-      vtkMath::Dot(tempY, y) <= 1 - epsilon ||
-      vtkMath::Dot(tempZ, z) <= 1 - epsilon)
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::GetAxesWorld(double xAxis_World[3], double yAxis_World[3], double zAxis_World[3])
+{
+  if (!xAxis_World || !yAxis_World || !zAxis_World)
     {
-    vtkErrorMacro("SetPlaneAxes: Invalid direction vectors!");
+    vtkErrorMacro("GetAxesWorld: Invalid input argument");
     return;
     }
 
-  if (vtkMath::Dot(x, y) >= epsilon || vtkMath::Dot(y, z) >= epsilon || vtkMath::Dot(z, x) >= epsilon)
+  if (this->GetNumberOfControlPoints() < 3)
     {
-    vtkErrorMacro("SetPlaneAxes: Invalid vectors");
+    vtkWarningMacro("GetAxes: Not enough points to define plane axis");
+    return;
+    }
+
+  for (int i = 0; i < 3; ++i)
+    {
+    xAxis_World[i] = 0.0;
+    yAxis_World[i] = 0.0;
+    zAxis_World[i] = 0.0;
+    }
+  xAxis_World[0] = 1.0;
+  yAxis_World[1] = 1.0;
+  zAxis_World[2] = 1.0;
+
+  double xAxis_Plane[3] = { 1.0, 0.0, 0.0 };
+  double yAxis_Plane[3] = { 0.0, 1.0, 0.0 };
+  double zAxis_Plane[3] = { 0.0, 0.0, 1.0 };
+
+  vtkNew<vtkMatrix4x4> planeToWorldMatrix;
+  this->GetPlaneToWorldMatrix(planeToWorldMatrix);
+
+  vtkNew<vtkTransform> planeToWorldTransform;
+  planeToWorldTransform->SetMatrix(planeToWorldMatrix);
+  planeToWorldTransform->TransformVector(xAxis_Plane, xAxis_World);
+  planeToWorldTransform->TransformVector(yAxis_Plane, yAxis_World);
+  planeToWorldTransform->TransformVector(zAxis_Plane, zAxis_World);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::SetAxes(const double xAxis_Local[3], const double yAxis_Local[3], const double zAxis_Local[3])
+{
+  if (!xAxis_Local || !yAxis_Local || !zAxis_Local)
+    {
+    vtkErrorMacro("SetAxes: Invalid input axes");
+    return;
+    }
+
+  double epsilon = 1e-5;
+  double tempX[3] = { 0.0 };
+  double tempY[3] = { 0.0 };
+  double tempZ[3] = { 0.0 };
+  vtkMath::Cross(yAxis_Local, zAxis_Local, tempX);
+  vtkMath::Cross(zAxis_Local, xAxis_Local, tempY);
+  vtkMath::Cross(xAxis_Local, yAxis_Local, tempZ);
+  if (vtkMath::Dot(tempX, xAxis_Local) <= 1.0 - epsilon ||
+      vtkMath::Dot(tempY, yAxis_Local) <= 1.0 - epsilon ||
+      vtkMath::Dot(tempZ, zAxis_Local) <= 1.0 - epsilon)
+    {
+    vtkErrorMacro("SetAxes: Invalid direction vectors!");
+    return;
+    }
+
+  if (vtkMath::Dot(xAxis_Local, yAxis_Local) >= epsilon ||
+      vtkMath::Dot(yAxis_Local, zAxis_Local) >= epsilon ||
+      vtkMath::Dot(zAxis_Local, xAxis_Local) >= epsilon)
+    {
+    vtkErrorMacro("SetAxes: Invalid vectors");
     }
 
   MRMLNodeModifyBlocker blocker(this);
   this->CreatePlane();
 
-  double oldX[3], oldY[3], oldZ[3] = { 0 };
-  this->GetPlaneAxes(oldX, oldY, oldZ);
+  double previousXAxis_Local[3] = { 0.0 };
+  double previousYAxis_Local[3] = { 0.0 };
+  double previousZAxis_Local[3] = { 0.0 };
+  this->GetAxes(previousXAxis_Local, previousYAxis_Local, previousZAxis_Local);
 
-  vtkNew<vtkMatrix4x4> oldVectorsToIdentity;
+  vtkNew<vtkMatrix4x4> previousAxisToIdentity;
   for (int i = 0; i < 3; ++i)
     {
-    oldVectorsToIdentity->SetElement(i, 0, oldX[i]);
-    oldVectorsToIdentity->SetElement(i, 1, oldY[i]);
-    oldVectorsToIdentity->SetElement(i, 2, oldZ[i]);
+    previousAxisToIdentity->SetElement(i, 0, previousXAxis_Local[i]);
+    previousAxisToIdentity->SetElement(i, 1, previousYAxis_Local[i]);
+    previousAxisToIdentity->SetElement(i, 2, previousZAxis_Local[i]);
     }
-  oldVectorsToIdentity->Invert();
+  previousAxisToIdentity->Invert();
 
-  vtkNew<vtkMatrix4x4> identityToNewVectors;
+  vtkNew<vtkMatrix4x4> identityToNewAxis;
   for (int i = 0; i < 3; ++i)
     {
-    identityToNewVectors->SetElement(i, 0, x[i]);
-    identityToNewVectors->SetElement(i, 1, y[i]);
-    identityToNewVectors->SetElement(i, 2, z[i]);
+    identityToNewAxis->SetElement(i, 0, xAxis_Local[i]);
+    identityToNewAxis->SetElement(i, 1, yAxis_Local[i]);
+    identityToNewAxis->SetElement(i, 2, zAxis_Local[i]);
     }
 
-  double point0[3] = { 0 };
-  this->GetNthControlPointPosition(0, point0);
+  double point0_Local[3] = { 0 };
+  this->GetNthControlPointPosition(0, point0_Local);
 
   vtkNew<vtkTransform> transform;
-  transform->Translate(point0);
-  transform->Concatenate(oldVectorsToIdentity);
-  transform->Concatenate(identityToNewVectors);
+  transform->PostMultiply();
   for (int i = 0; i < 3; ++i)
     {
-    point0[i] = -1 * point0[i];
+    point0_Local[i] = -1 * point0_Local[i];
     }
-  transform->Translate(point0);
+  transform->Translate(point0_Local);
+  transform->Concatenate(previousAxisToIdentity);
+  transform->Concatenate(identityToNewAxis);
+  for (int i = 0; i < 3; ++i)
+    {
+    point0_Local[i] = -1 * point0_Local[i];
+    }
+  transform->Translate(point0_Local);
 
   for (int i = 0; i < 3; ++i)
     {
-    double controlPoint[4] = { 0, 0, 0, 1 };
-    this->GetNthControlPointPosition(i, controlPoint);
-    transform->MultiplyPoint(controlPoint, controlPoint);
-    this->SetNthControlPointPosition(i, controlPoint[0], controlPoint[1], controlPoint[2]);
+    double point_Local[4] = { 0, 0, 0, 1 };
+    this->GetNthControlPointPosition(i, point_Local);
+    transform->MultiplyPoint(point_Local, point_Local);
+    this->SetNthControlPointPosition(i, point_Local[0], point_Local[1], point_Local[2]);
     }
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::SetPlaneAxesWorld(const double inX[3], const double inY[3], const double inZ[3])
+void vtkMRMLMarkupsPlaneNode::SetAxesWorld(const double xAxis_World[3], const double yAxis_World[3], const double zAxis_World[3])
 {
-  double x[3] = { inX[0], inX[1], inX[2] };
-  double y[3] = { inY[0], inY[1], inY[2] };
-  double z[3] = { inZ[0], inZ[1], inZ[2] };
+  double xAxis_Local[3] = { xAxis_World[0], xAxis_World[1], xAxis_World[2] };
+  double yAxis_Local[3] = { yAxis_World[0], yAxis_World[1], yAxis_World[2] };
+  double zAxis_Local[3] = { zAxis_World[0], zAxis_World[1], zAxis_World[2] };
+
+  MRMLNodeModifyBlocker blocker(this);
+  this->CreatePlane();
 
   vtkMRMLTransformNode* transformNode = this->GetParentTransformNode();
   if (transformNode)
     {
     // Get transform
-    vtkNew<vtkGeneralTransform> transformToWorld;
-    transformNode->GetTransformFromWorld(transformToWorld.GetPointer());
+    vtkNew<vtkGeneralTransform> worldToLocalTransform;
+    transformNode->GetTransformFromWorld(worldToLocalTransform.GetPointer());
 
     // Convert coordinates
-    double origin[3] = { 0 };
-    this->GetOriginWorld(origin);
-    transformToWorld->TransformVectorAtPoint(origin, x, x);
-    transformToWorld->TransformVectorAtPoint(origin, y, y);
-    transformToWorld->TransformVectorAtPoint(origin, z, z);
+    double origin_World[3] = { 0 };
+    this->GetOriginWorld(origin_World);
+    worldToLocalTransform->TransformVectorAtPoint(origin_World, xAxis_World, xAxis_Local);
+    worldToLocalTransform->TransformVectorAtPoint(origin_World, yAxis_World, yAxis_Local);
+    worldToLocalTransform->TransformVectorAtPoint(origin_World, zAxis_World, zAxis_Local);
     }
-  this->SetPlaneAxes(x, y, z);
+  this->SetAxes(xAxis_Local, yAxis_Local, zAxis_Local);
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::GetSize(double size[3])
+void vtkMRMLMarkupsPlaneNode::GetPlaneBounds(double PlaneBounds[6])
 {
   if (this->GetNumberOfControlPoints() < 3)
     {
-    size[0] = 0.0;
-    size[1] = 0.0;
-    size[2] = 0.0;
+    for (int i = 0; i < 6; ++i)
+      {
+      PlaneBounds[i] = 0.0;
+      }
     return;
     }
 
   // Size mode auto means we need to recalculate the diameter of the plane from the control points.
   if (this->SizeMode == vtkMRMLMarkupsPlaneNode::SizeModeAuto)
     {
-    double point0[3] = { 0.0 };
-    double point1[3] = { 0.0 };
-    double point2[3] = { 0.0 };
-    this->GetNthControlPointPosition(0, point0);
-    this->GetNthControlPointPosition(1, point1);
-    this->GetNthControlPointPosition(2, point2);
+    double point0_Local[3] = { 0.0 };
+    double point1_Local[3] = { 0.0 };
+    double point2_Local[3] = { 0.0 };
+    this->GetNthControlPointPosition(0, point0_Local);
+    this->GetNthControlPointPosition(1, point1_Local);
+    this->GetNthControlPointPosition(2, point2_Local);
 
+    double point0_Plane[3] = { 0.0 };
+    double point1_Plane[3] = { 0.0 };
+    double point2_Plane[3] = { 0.0 };
     vtkNew<vtkTransform> localToPlaneTransform;
-    localToPlaneTransform->SetMatrix(this->LocalToPlaneTransform);
-    localToPlaneTransform->TransformPoint(point0, point0);
-    localToPlaneTransform->TransformPoint(point1, point1);
-    localToPlaneTransform->TransformPoint(point2, point2);
+    localToPlaneTransform->SetMatrix(this->PlaneToPlaneOffsetMatrix); // TODO
+    localToPlaneTransform->TransformPoint(point0_Local, point0_Plane);
+    localToPlaneTransform->TransformPoint(point1_Local, point1_Plane);
+    localToPlaneTransform->TransformPoint(point2_Local, point2_Plane);
 
-    double x[3], y[3], z[3] = { 0 };
-    this->GetPlaneAxes(x, y, z);
+    double xAxis_Local[3] = { 0.0 };
+    double yAxis_Local[3] = { 0.0 };
+    double zAxis_Local[3] = { 0.0 };
+    this->GetAxes(xAxis_Local, yAxis_Local, zAxis_Local);
 
     // Update the plane
-    double vector1[3] = { 0 };
-    vtkMath::Subtract(point1, point0, vector1);
+    double vectorPoint0ToPoint1_Plane[3] = { 0 };
+    vtkMath::Subtract(point1_Plane, point0_Plane, vectorPoint0ToPoint1_Plane);
 
-    double vector2[3] = { 0 };
-    vtkMath::Subtract(point2, point0, vector2);
+    double vectorPoint0ToPoint2_Plane[3] = { 0 };
+    vtkMath::Subtract(point2_Plane, point0_Plane, vectorPoint0ToPoint2_Plane);
 
-    double point1X = std::abs(vtkMath::Dot(vector1, x));
-    double point2X = std::abs(vtkMath::Dot(vector2, x));
+    double point1X = std::abs(vtkMath::Dot(vectorPoint0ToPoint1_Plane, xAxis_Local));
+    double point2X = std::abs(vtkMath::Dot(vectorPoint0ToPoint2_Plane, xAxis_Local));
     double xMax = std::max({ 0.0, point1X, point2X });
 
-    double point1Y = std::abs(vtkMath::Dot(vector1, y));
-    double point2Y = std::abs(vtkMath::Dot(vector2, y));
+    double point1Y = std::abs(vtkMath::Dot(vectorPoint0ToPoint1_Plane, yAxis_Local));
+    double point2Y = std::abs(vtkMath::Dot(vectorPoint0ToPoint2_Plane, yAxis_Local));
     double yMax = std::max({ 0.0, point1Y, point2Y });
 
-    this->Size[0] = 2 * xMax * this->AutoSizeScalingFactor;
-    this->Size[1] = 2 * yMax * this->AutoSizeScalingFactor;
-    this->Size[2] = 0.0;
+    this->PlaneBounds[0] = xMax * this->AutoSizeScalingFactor * -1.0;
+    this->PlaneBounds[1] = xMax * this->AutoSizeScalingFactor;
+    this->PlaneBounds[2] = yMax * this->AutoSizeScalingFactor * -1.0;
+    this->PlaneBounds[3] = yMax * this->AutoSizeScalingFactor;
+    this->PlaneBounds[4] = 0.0;
+    this->PlaneBounds[5] = 0.0;
     }
 
-  for (int i = 0; i < 3; ++i)
+  for (int i = 0; i < 6; ++i)
     {
-    size[i] = this->Size[i];
+    PlaneBounds[i] = this->PlaneBounds[i];
     }
 }
 
@@ -616,56 +732,86 @@ void vtkMRMLMarkupsPlaneNode::CreatePlane()
     this->AddNControlPoints(3 - this->GetNumberOfControlPoints());
     }
 
-  double point0[3], point1[3], point2[3] = { 0 };
-  this->GetNthControlPointPosition(0, point0);
-  this->GetNthControlPointPosition(1, point1);
-  this->GetNthControlPointPosition(2, point2);
+  double point0_Local[3] = { 0.0 };
+  double point1_Local[3] = { 0.0 };
+  double point2_Local[3] = { 0.0 };
+  this->GetNthControlPointPosition(0, point0_Local);
+  this->GetNthControlPointPosition(1, point1_Local);
+  this->GetNthControlPointPosition(2, point2_Local);
 
   // Check if existing vectors are unique.
-  double vector1[3], vector2[3] = { 0 };
-  vtkMath::Subtract(point1, point0, vector1);
-  vtkMath::Subtract(point2, point0, vector2);
+  double vectorPoint0ToPoint1_Local[3] = { 0.0 };
+  double vectorPoint0ToPoint2_Local[3] = { 0.0 };
+  vtkMath::Subtract(point1_Local, point0_Local, vectorPoint0ToPoint1_Local);
+  vtkMath::Subtract(point2_Local, point0_Local, vectorPoint0ToPoint2_Local);
 
   bool pointChanged = false;
-  double epsilon = 0.0001;
-  if (vtkMath::Norm(vector1) <= epsilon)
+  double epsilon = 1e-5;
+  if (vtkMath::Norm(vectorPoint0ToPoint1_Local) <= epsilon)
     {
     // Point1 is at same position as point0.
     // Move point1 away in x axis.
     double xVector[3] = { 1,0,0 };
-    vtkMath::Add(point1, xVector, point1);
+    vtkMath::Add(point1_Local, xVector, point1_Local);
     pointChanged = true;
     }
 
-  if (vtkMath::Norm(vector2) <= epsilon)
+  if (vtkMath::Norm(vectorPoint0ToPoint2_Local) <= epsilon)
     {
     // Point2 is at same position as point0.
     // Move point2 away in y axis.
     double yVector[3] = { 0,1,0 };
-    vtkMath::Add(point2, yVector, point2);
+    vtkMath::Add(point2_Local, yVector, point2_Local);
     pointChanged = true;
     }
 
-  vtkMath::Subtract(point1, point0, vector1);
-  vtkMath::Subtract(point2, point0, vector2);
-  if (vtkMath::Dot(vector1, vector2) >= 1 - epsilon)
+  vtkMath::Subtract(point1_Local, point0_Local, vectorPoint0ToPoint1_Local);
+  vtkMath::Subtract(point2_Local, point0_Local, vectorPoint0ToPoint2_Local);
+  if (vtkMath::Dot(vectorPoint0ToPoint1_Local, vectorPoint0ToPoint2_Local) >= 1.0 - epsilon)
     {
     // Point1 and point2 are along the same vector from point0.
     // Find a perpendicular vector and move point2.
-    double vector[3] = { 0,0,0 };
-    vtkMath::Perpendiculars(vector2, vector, nullptr, 0.0);
-    vtkMath::Add(point0, vector, point2);
+    double perpendicular_Local[3] = { 0.0 };
+    vtkMath::Perpendiculars(vectorPoint0ToPoint2_Local, perpendicular_Local, nullptr, 0.0);
+    vtkMath::Add(point0_Local, perpendicular_Local, point2_Local);
     }
 
   if (pointChanged)
     {
-    this->SetNthControlPointPosition(1, point1[0], point1[1], point1[2]);
-    this->SetNthControlPointPosition(2, point2[0], point2[1], point2[2]);
+    this->SetNthControlPointPosition(1, point1_Local[0], point1_Local[1], point1_Local[2]);
+    this->SetNthControlPointPosition(2, point2_Local[0], point2_Local[1], point2_Local[2]);
     }
 }
 
 //----------------------------------------------------------------------------
-vtkMatrix4x4* vtkMRMLMarkupsPlaneNode::GetLocalToPlaneTransform()
+vtkMatrix4x4* vtkMRMLMarkupsPlaneNode::GetPlaneToPlaneOffsetMatrix()
 {
-  return this->LocalToPlaneTransform;
+  return this->PlaneToPlaneOffsetMatrix;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdateInteractionHandleToWorldMatrix()
+{
+  double handleX_World[3] = { 0.0 };
+  double handleY_World[3] = { 0.0 };
+  double handleZ_World[3] = { 0.0 };
+  if (this->GetNumberOfControlPoints() < 3)
+    {
+    return;
+    }
+
+  this->GetAxesWorld(handleX_World, handleY_World, handleZ_World);
+
+  double origin_Local[3] = { 0 };
+  this->GetOrigin(origin_Local);
+
+  vtkNew<vtkMatrix4x4> handleToWorldMatrix;
+  for (int i = 0; i < 3; ++i)
+    {
+    handleToWorldMatrix->SetElement(i, 0, handleX_World[i]);
+    handleToWorldMatrix->SetElement(i, 1, handleY_World[i]);
+    handleToWorldMatrix->SetElement(i, 2, handleZ_World[i]);
+    handleToWorldMatrix->SetElement(i, 3, origin_Local[i]);
+    }
+  this->InteractionHandleToWorldMatrix->DeepCopy(handleToWorldMatrix);
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
@@ -14,7 +14,7 @@
 
   This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
   and was supported through CANARIE's Research Software Program, Cancer
-  Care Ontario, OpenAnatomy, and Brigham and Women’s Hospital through NIH grant R01MH112748.
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
 
 ==============================================================================*/
 
@@ -38,6 +38,11 @@
 ///
 /// Markups is intended to be used for manual marking/editing of point positions.
 ///
+/// Coordinate systems used:
+///   - Local: Local coordinates
+///   - World: All parent transforms on node applied to local.
+///   - Plane: Plane coordinate space (Origin of plane at 0,0,0, XYZ axis aligned to XYZ unit vectors).
+///            Can have additional offset/rotation compared to local.
 /// \ingroup Slicer_QtModules_Markups
 class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsPlaneNode : public vtkMRMLMarkupsNode
 {
@@ -88,20 +93,21 @@ public:
   vtkGetMacro(AutoSizeScalingFactor, double);
   vtkSetMacro(AutoSizeScalingFactor, double);
 
-  /// The diameter of the plane along each of the direction vectors.
+  /// The bounds of the plane in the plane coordinate system.
+  /// When the size mode is absolute, SetPlaneBounds can be used to specify the size of the plane.
   /// This is only used when the size mode is absolute.
-  void GetSize(double size[3]);
-  vtkSetVector3Macro(Size, double);
+  void GetPlaneBounds(double bounds[6]);
+  vtkSetVector6Macro(PlaneBounds, double);
 
   /// The normal vector for the plane.
-  /// Calculated as the vector perpendicular to the plane containing the 3 markup points, and transformed by the LocalToPlaneTransform.
+  /// Calculated as the vector perpendicular to the plane containing the 3 markup points, and transformed by the PlaneToPlaneOffsetMatrix.
   void GetNormal(double normal[3]);
   void SetNormal(const double normal[3]);
   void GetNormalWorld(double normal[3]);
   void SetNormalWorld(const double normal[3]);
 
   /// The normal vector of the plane.
-  /// Calculated as the location of the 0th markup point, and translated by the LocalToPlaneTransform.
+  /// Calculated as the location of the 0th markup point, and translated by the PlaneToPlaneOffsetMatrix.
   void GetOrigin(double origin[3]);
   void SetOrigin(const double origin[3]);
   void GetOriginWorld(double origin[3]);
@@ -112,14 +118,19 @@ public:
   /// X: Vector from 1st to 0th point.
   /// Y: Cross product of the Z vector and X vectors.
   /// Z: Cross product of the X vector and the vector from the 2nd to 0th point.
-  void GetPlaneAxes(double x[3], double y[3], double z[3]);
-  void SetPlaneAxes(const double x[3], const double y[3], const double z[3]);
-  void GetPlaneAxesWorld(double x[3], double y[3], double z[3]);
-  void SetPlaneAxesWorld(const double x[3], const double y[3], const double z[3]);
+  void GetAxes(double x[3], double y[3], double z[3]);
+  void SetAxes(const double x[3], const double y[3], const double z[3]);
+  void GetAxesWorld(double x[3], double y[3], double z[3]);
+  void SetAxesWorld(const double x[3], const double y[3], const double z[3]);
+
+  // Mapping from XYZ plane coordinates to local coordinates
+  virtual void GetPlaneToLocalMatrix(vtkMatrix4x4* planeToLocalMatrix);
+  // Mapping from XYZ plane coordinates to world coordinates
+  virtual void GetPlaneToWorldMatrix(vtkMatrix4x4* planeToWorldMatrix);
 
   /// 4x4 matrix detailing the offset (rotation/translation) of the plane from the plane defined by the markup points.
   /// Default is the identity matrix.
-  virtual vtkMatrix4x4* GetLocalToPlaneTransform();
+  virtual vtkMatrix4x4* GetPlaneToPlaneOffsetMatrix();
 
 protected:
 
@@ -128,13 +139,16 @@ protected:
 
   int SizeMode;
   double AutoSizeScalingFactor;
-  double Size[3];
-  vtkSmartPointer<vtkMatrix4x4> LocalToPlaneTransform;
+  double PlaneBounds[6];
+  vtkSmartPointer<vtkMatrix4x4> PlaneToPlaneOffsetMatrix;
 
   /// Helper method for ensuring that the plane has enough points and that the points/vectors are not coincident.
   /// Used when calling SetNormal(), SetVectors() to ensure that the plane is valid before transforming to the new
   /// orientation.
   void CreatePlane();
+
+  /// Calculates the handle to world matrix based on the current control points
+  void UpdateInteractionHandleToWorldMatrix() override;
 
   vtkMRMLMarkupsPlaneNode();
   ~vtkMRMLMarkupsPlaneNode() override;

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -105,6 +105,8 @@ protected slots:
   void deletePoint();
   /// Called when clicking on toggle select point action
   void toggleSelectPoint();
+  /// Called when clicking on handle interactive action
+  void toggleHandleInteractive();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyMarkupsPluginPrivate> d_ptr;

--- a/Modules/Loadable/Markups/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Testing/Cxx/CMakeLists.txt
@@ -11,6 +11,7 @@ set(KIT_TEST_SRCS
   vtkMRMLMarkupsNodeTest1.cxx
   vtkMRMLMarkupsNodeTest2.cxx
   vtkMRMLMarkupsNodeTest3.cxx
+  vtkMRMLMarkupsNodeTest4.cxx
   vtkMRMLMarkupsFiducialStorageNodeTest1.cxx
   vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
   vtkMRMLMarkupsFiducialStorageNodeTest3.cxx
@@ -36,6 +37,7 @@ SIMPLE_TEST( vtkMRMLMarkupsFiducialNodeTest1 )
 SIMPLE_TEST( vtkMRMLMarkupsNodeTest1 )
 SIMPLE_TEST( vtkMRMLMarkupsNodeTest2 )
 SIMPLE_TEST( vtkMRMLMarkupsNodeTest3 )
+SIMPLE_TEST( vtkMRMLMarkupsNodeTest4 )
 
 SIMPLE_TEST( vtkMRMLMarkupsFiducialStorageNodeTest1 ${TEMP}/markupsFiducialStorageNode.fcsv )
 

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
@@ -1,0 +1,145 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLLinearTransformNode.h"
+#include "vtkMRMLMarkupsPlaneNode.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkIndent.h>
+#include <vtkMath.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkRegularPolygonSource.h>
+#include <vtkTestingOutputWindow.h>
+#include <vtkTransform.h>
+
+// STL includes
+#include <sstream>
+
+static const double EPSILON = 1e-5;
+
+bool ComparePlane(double xAxisExpected_World[3], double yAxisExpected_World[3], double zAxisExpected_World[3],
+  double originExpected_World[3], vtkMRMLMarkupsPlaneNode* planeNode, double epsilon)
+{
+  double xAxisActual_World[3] = { 0.0 };
+  double yAxisActual_World[3] = { 0.0 };
+  double zAxisActual_World[3] = { 0.0 };
+  planeNode->GetAxesWorld(xAxisActual_World, yAxisActual_World, zAxisActual_World);
+
+  if (vtkMath::Dot(xAxisExpected_World, xAxisActual_World) < 1.0 - epsilon)
+    {
+    return false;
+    }
+  if (vtkMath::Dot(yAxisExpected_World, yAxisActual_World) < 1.0 - epsilon)
+    {
+    return false;
+    }
+  if (vtkMath::Dot(zAxisExpected_World, zAxisActual_World) < 1.0 - epsilon)
+    {
+    return false;
+    }
+
+  double originActual_World[3] = { 0.0 };
+  planeNode->GetOriginWorld(originActual_World);
+  double originDifference_World[3] = { 0.0 };
+  vtkMath::Subtract(originExpected_World, originActual_World, originDifference_World);
+
+  if (vtkMath::Norm(originDifference_World) > epsilon)
+    {
+    return false;
+    }
+
+  return true;
+}
+
+int vtkMRMLMarkupsNodeTest4(int , char * [] )
+{
+  std::cout << "Testing vtkMRMLMarkupsPlaneNode" << std::endl;
+  vtkNew<vtkMRMLScene> scene;
+
+  vtkNew<vtkMRMLMarkupsPlaneNode> planeNode;
+  scene->AddNode(planeNode);
+
+  double xAxis_World[3] = { 0.0, 0.0, 1.0 };
+  double yAxis_World[3] = { -1.0, 0.0, 0.0 };
+  double zAxis_World[3] = { 0.0, -1.0, 0.0 };
+  double origin_World[3] = { 50.0, 150.0, 200.0 };
+
+  /////////////
+  std::cout << "Test set axes/origin" << std::endl;
+  planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+  planeNode->SetOriginWorld(origin_World);
+  CHECK_BOOL(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON), true);
+
+  /////////////
+  std::cout << "Test set axes/origin with plane offset" << std::endl;
+  vtkNew<vtkTransform> planeToPlaneOffset;
+  planeToPlaneOffset->Translate(1.0, 2.0, 3.0);
+  planeToPlaneOffset->RotateX(50.0);
+  planeToPlaneOffset->RotateY(12.0);
+  planeToPlaneOffset->RotateZ(5.0);
+  planeToPlaneOffset->Translate(5.0, 3.0, 10.0);
+  planeNode->GetPlaneToPlaneOffsetMatrix()->DeepCopy(planeToPlaneOffset->GetMatrix());
+  planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+  planeNode->SetOriginWorld(origin_World);
+  CHECK_BOOL(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON), true);
+
+  /////////////
+  std::cout << "Test set axes/origin with plane offset and transform node" << std::endl;
+  vtkNew<vtkMRMLLinearTransformNode> transformNode;
+  scene->AddNode(transformNode);
+  planeNode->SetAndObserveTransformNodeID(transformNode->GetID());
+
+  vtkNew<vtkTransform> localToWorldTransform;
+  localToWorldTransform->Translate(30.0, 60.0, 90.0);
+  localToWorldTransform->RotateZ(30.0);
+  localToWorldTransform->RotateY(60.0);
+  localToWorldTransform->RotateX(90.0);
+  localToWorldTransform->Translate(90.0, 60.0, 30.0);
+  transformNode->SetMatrixTransformToParent(localToWorldTransform->GetMatrix());
+  planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+  planeNode->SetOriginWorld(origin_World);
+  CHECK_BOOL(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON), true);
+
+  /////////////
+  std::cout << "Test set norm with plane offset and transform node" << std::endl;
+  double expectedNormal_World[3] = { 1.0, -3.0, 5.0 };
+  vtkMath::Normalize(expectedNormal_World);
+  planeNode->SetNormalWorld(expectedNormal_World);
+  double actualNormal_World[3] = { 0.0 };
+  planeNode->GetNormalWorld(actualNormal_World);
+  double normalDifference_World[3] = { 0.0 };
+  vtkMath::Subtract(actualNormal_World, expectedNormal_World, normalDifference_World);
+  CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(normalDifference_World), 0.0, EPSILON);
+
+  /////////////
+  std::cout << "Test set origin with plane offset and transform node" << std::endl;
+  double expectedOrigin_World[3] = { -123.0, 456.0, -789.0 };
+  planeNode->SetOriginWorld(expectedOrigin_World);
+  double actualOrigin_World[3] = { 0.0 };
+  planeNode->GetOriginWorld(actualOrigin_World);
+  double originDifference_World[3] = { 0.0 };
+  vtkMath::Subtract(actualOrigin_World, expectedOrigin_World, originDifference_World);
+  CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(originDifference_World), 0.0, EPSILON);
+
+  std::cout << "Success." << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.cxx
@@ -455,3 +455,16 @@ void vtkSlicerAngleRepresentation2D::SetMarkupsNode(vtkMRMLMarkupsNode *markupsN
     }
   this->Superclass::SetMarkupsNode(markupsNode);
 }
+
+//-----------------------------------------------------------------------------
+void vtkSlicerAngleRepresentation2D::UpdateInteractionPipeline()
+{
+  vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
+  if (!markupsNode || markupsNode->GetNumberOfControlPoints() < 3)
+    {
+    this->InteractionPipeline->Actor->SetVisibility(false);
+    return;
+    }
+
+  Superclass::UpdateInteractionPipeline();
+}

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
@@ -77,8 +77,10 @@ protected:
 
   void SetMarkupsNode(vtkMRMLMarkupsNode *markupsNode) override;
 
-
   void BuildArc();
+
+  // Update visibility of interaction handles for representation
+  void UpdateInteractionPipeline() override;
 
   vtkSmartPointer<vtkPolyData> Line;
   vtkSmartPointer<vtkPolyDataMapper2D> LineMapper;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
@@ -394,3 +394,16 @@ void vtkSlicerAngleRepresentation3D::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "Label Format: ";
   os << this->LabelFormat << "\n";
 }
+
+//-----------------------------------------------------------------------------
+void vtkSlicerAngleRepresentation3D::UpdateInteractionPipeline()
+{
+  vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
+  if (!markupsNode || markupsNode->GetNumberOfControlPoints() < 3)
+    {
+    this->InteractionPipeline->Actor->SetVisibility(false);
+    return;
+    }
+  // Final visibility handled by superclass in vtkSlicerMarkupsWidgetRepresentation
+  Superclass::UpdateInteractionPipeline();
+}

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
@@ -94,6 +94,9 @@ protected:
 
   void BuildArc();
 
+  // Update visibility of interaction handles for representation
+  void UpdateInteractionPipeline() override;
+
 private:
   vtkSlicerAngleRepresentation3D(const vtkSlicerAngleRepresentation3D&) = delete;
   void operator=(const vtkSlicerAngleRepresentation3D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
@@ -245,3 +245,15 @@ void vtkSlicerLineRepresentation2D::SetMarkupsNode(vtkMRMLMarkupsNode *markupsNo
     }
   this->Superclass::SetMarkupsNode(markupsNode);
 }
+
+//-----------------------------------------------------------------------------
+void vtkSlicerLineRepresentation2D::UpdateInteractionPipeline()
+{
+  if (!this->LineActor->GetVisibility())
+    {
+    this->InteractionPipeline->Actor->SetVisibility(false);
+    return;
+    }
+  // Final visibility handled by superclass in vtkSlicerMarkupsWidgetRepresentation
+  Superclass::UpdateInteractionPipeline();
+}

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.h
@@ -74,6 +74,9 @@ protected:
 
   void SetMarkupsNode(vtkMRMLMarkupsNode *markupsNode) override;
 
+  /// Update interaction handle visibility for representation
+  void UpdateInteractionPipeline() override;
+
   vtkSmartPointer<vtkPolyData> Line;
   vtkSmartPointer<vtkPolyDataMapper2D> LineMapper;
   vtkSmartPointer<vtkActor2D> LineActor;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -19,10 +19,12 @@
 // VTK includes
 #include "vtkActor2D.h"
 #include "vtkGlyph3D.h"
+#include "vtkMatrix4x4.h"
 #include "vtkPolyDataMapper.h"
 #include "vtkProperty.h"
 #include "vtkRenderer.h"
 #include "vtkSlicerLineRepresentation3D.h"
+#include "vtkTransform.h"
 #include "vtkTubeFilter.h"
 
 // MRML includes
@@ -204,4 +206,16 @@ void vtkSlicerLineRepresentation3D::PrintSelf(ostream& os, vtkIndent indent)
     {
     os << indent << "Line Visibility: (none)\n";
     }
+}
+
+//-----------------------------------------------------------------------------
+void vtkSlicerLineRepresentation3D::UpdateInteractionPipeline()
+{
+  if (this->MarkupsNode->GetNumberOfControlPoints() < 2)
+    {
+    this->InteractionPipeline->Actor->SetVisibility(false);
+    return;
+    }
+  // Final visibility handled by superclass in vtkSlicerMarkupsWidgetRepresentation
+  Superclass::UpdateInteractionPipeline();
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
@@ -73,6 +73,9 @@ protected:
   vtkSlicerLineRepresentation3D();
   ~vtkSlicerLineRepresentation3D() override;
 
+  /// Update interaction handle visibility for representation
+  virtual void UpdateInteractionPipeline() override;
+
   vtkSmartPointer<vtkPolyData> Line;
   vtkSmartPointer<vtkPolyDataMapper> LineMapper;
   vtkSmartPointer<vtkActor> LineActor;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
@@ -57,12 +57,16 @@ public:
   {
     WidgetStateDefine = WidgetStateUser, // click in empty area will place a new point
     WidgetStateTranslateControlPoint, // translating the active point by mouse move
+    WidgetStateOnTranslationHandle, // hovering over a translation interaction handle
+    WidgetStateOnRotationHandle, // hovering over a rotation interaction handle
   };
 
   /// Widget events
   enum
   {
     WidgetEventControlPointPlace = WidgetEventUser,
+    WidgetEventClickAndDragStart,
+    WidgetEventClickAndDragEnd,
     WidgetEventStopPlace,
     WidgetEventControlPointMoveStart,
     WidgetEventControlPointMoveEnd,
@@ -113,6 +117,9 @@ public:
 
   vtkSlicerMarkupsWidgetRepresentation* GetMarkupsRepresentation();
 
+  int GetActiveComponentType();
+  int GetActiveComponentIndex();
+
 protected:
   vtkSlicerMarkupsWidget();
   ~vtkSlicerMarkupsWidget() override;
@@ -155,6 +162,14 @@ protected:
   virtual bool ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessWidgetReset(vtkMRMLInteractionEventData* eventData);
   virtual bool ProcessWidgetJumpCursor(vtkMRMLInteractionEventData* eventData);
+
+  // Get the closest point on the line defined by the interaction handle axis.
+  // Input coordinates are in display coordinates, while output are in world coordinates.
+  virtual bool GetClosestPointOnInteractionAxis(int type, int index, const double inputDisplay[2], double outputIntersectionWorld[3]);
+
+  // Get the closest point on the plane defined using the interaction handle axis as the plane normal.
+  // Input coordinates are in display coordinates, while output are in world coordinates
+  virtual bool GetIntersectionOnAxisPlane(int type, int index, const double inputDisplay[2], double outputIntersectionWorld[3]);
 
   // Variables for translate/rotate/scale
   double LastEventPosition[2];

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -17,26 +17,48 @@
 =========================================================================*/
 
 // VTK includes
+#include "vtkAppendPolyData.h"
+#include "vtkArcSource.h"
+#include "vtkArrowSource.h"
 #include "vtkSlicerMarkupsWidgetRepresentation.h"
 #include "vtkCamera.h"
 #include "vtkDoubleArray.h"
+#include "vtkFloatArray.h"
 #include "vtkFocalPlanePointPlacer.h"
+#include "vtkGlyph3D.h"
 #include "vtkLine.h"
+#include "vtkLineSource.h"
+#include "vtkLookupTable.h"
 #include "vtkMarkupsGlyphSource2D.h"
 #include "vtkMRMLSliceNode.h"
 #include "vtkMRMLViewNode.h"
 #include "vtkPointData.h"
 #include "vtkPointSetToLabelHierarchy.h"
+#include "vtkPolyDataMapper2D.h"
+#include "vtkProperty2D.h"
 #include "vtkRenderer.h"
 #include "vtkSphereSource.h"
 #include "vtkStringArray.h"
 #include "vtkTextActor.h"
 #include "vtkTextProperty.h"
+#include "vtkTensorGlyph.h"
+#include "vtkTransform.h"
+#include "vtkTransformPolyDataFilter.h"
+#include "vtkTubeFilter.h"
 
 // MRML includes
 #include <vtkMRMLFolderDisplayNode.h>
 #include <vtkMRMLInteractionEventData.h>
+#include <vtkMRMLTransformNode.h>
 
+//----------------------------------------------------------------------
+static const double INTERACTION_HANDLE_RADIUS = 0.125;
+static const double INTERACTION_HANDLE_DIAMETER = INTERACTION_HANDLE_RADIUS * 2.0;
+static const double INTERACTION_HANDLE_ROTATION_ARC_TUBE_RADIUS = INTERACTION_HANDLE_RADIUS * 0.4;
+static const double INTERACTION_HANDLE_ROTATION_ARC_RADIUS = 0.80;
+static const double INTERACTION_HANDLE_SCALE_FACTOR = 7.0;
+
+//----------------------------------------------------------------------
 vtkSlicerMarkupsWidgetRepresentation::ControlPointsPipeline::ControlPointsPipeline()
 {
   this->TextProperty = vtkSmartPointer<vtkTextProperty>::New();
@@ -100,6 +122,7 @@ vtkSlicerMarkupsWidgetRepresentation::ControlPointsPipeline::ControlPointsPipeli
   this->GlyphSourceSphere->SetRadius(0.5);
 };
 
+//----------------------------------------------------------------------
 vtkSlicerMarkupsWidgetRepresentation::ControlPointsPipeline::~ControlPointsPipeline()
 = default;
 
@@ -125,6 +148,14 @@ vtkSlicerMarkupsWidgetRepresentation::vtkSlicerMarkupsWidgetRepresentation()
 
   this->AlwaysOnTop = false;
 
+  this->InteractionPipeline = nullptr;
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::SetupInteractionPipeline()
+{
+  this->InteractionPipeline = new MarkupsInteractionPipeline(this);
+  this->InteractionPipeline->InitializePipeline();
 }
 
 //----------------------------------------------------------------------
@@ -137,8 +168,15 @@ vtkSlicerMarkupsWidgetRepresentation::~vtkSlicerMarkupsWidgetRepresentation()
     }
   // Force deleting variables to prevent circular dependency keeping objects alive
   this->PointPlacer = nullptr;
+
+  if (this->InteractionPipeline != nullptr)
+    {
+    delete this->InteractionPipeline;
+    this->InteractionPipeline = nullptr;
+    }
 }
 
+//----------------------------------------------------------------------
 int vtkSlicerMarkupsWidgetRepresentation::GetNumberOfControlPoints()
 {
   vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
@@ -482,6 +520,11 @@ void vtkSlicerMarkupsWidgetRepresentation::BuildLine(vtkPolyData* linePolyData, 
 void vtkSlicerMarkupsWidgetRepresentation::UpdateFromMRML(
     vtkMRMLNode* vtkNotUsed(caller), unsigned long event, void *vtkNotUsed(callData))
 {
+  if (!this->InteractionPipeline)
+    {
+    this->SetupInteractionPipeline();
+    }
+
   if (!event || event == vtkMRMLTransformableNode::TransformModifiedEvent)
     {
     this->MarkupsTransformModifiedTime.Modified();
@@ -501,6 +544,34 @@ void vtkSlicerMarkupsWidgetRepresentation::UpdateFromMRML(
   this->TextActor->SetVisibility(this->MarkupsDisplayNode->GetPropertiesLabelVisibility());
 
   this->NeedToRenderOn(); // TODO: to improve performance, call this only if it is actually needed
+
+  if (this->InteractionPipeline)
+    {
+    this->UpdateInteractionPipeline();
+    }
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::UpdateInteractionPipeline()
+{
+  vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
+  if (!markupsNode || markupsNode->GetNumberOfControlPoints() < 1)
+    {
+    this->InteractionPipeline->Actor->SetVisibility(false);
+    return;
+    }
+
+  if (!this->MarkupsDisplayNode)
+    {
+    this->InteractionPipeline->Actor->SetVisibility(false);
+    return;
+    }
+
+  this->InteractionPipeline->Actor->SetVisibility(this->MarkupsDisplayNode->GetHandlesInteractive());
+
+  vtkNew<vtkTransform> handleToWorldTransform;
+  handleToWorldTransform->SetMatrix(markupsNode->GetInteractionHandleToWorldMatrix());
+  this->InteractionPipeline->HandleToWorldTransform->DeepCopy(handleToWorldTransform);
 }
 
 //----------------------------------------------------------------------
@@ -720,4 +791,589 @@ bool vtkSlicerMarkupsWidgetRepresentation::IsDisplayable()
       }
     }
   return true;
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::GetActors(vtkPropCollection* pc)
+{
+  if (this->InteractionPipeline)
+    {
+    this->InteractionPipeline->Actor->GetActors(pc);
+    }
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::ReleaseGraphicsResources(vtkWindow* window)
+{
+  if (this->InteractionPipeline)
+    {
+    this->InteractionPipeline->Actor->ReleaseGraphicsResources(window);
+    }
+}
+
+//----------------------------------------------------------------------
+int vtkSlicerMarkupsWidgetRepresentation::RenderOverlay(vtkViewport* viewport)
+{
+  int count = 0;
+  if (this->InteractionPipeline && this->InteractionPipeline->Actor->GetVisibility())
+    {
+    count += this->InteractionPipeline->Actor->RenderOverlay(viewport);
+    }
+  return count;
+}
+
+//----------------------------------------------------------------------
+int vtkSlicerMarkupsWidgetRepresentation::RenderOpaqueGeometry(vtkViewport* viewport)
+{
+  int count = 0;
+  if (this->InteractionPipeline && this->InteractionPipeline->Actor->GetVisibility())
+    {
+    this->InteractionPipeline->UpdateHandleColors();
+    double interactionWidgetScale = INTERACTION_HANDLE_SCALE_FACTOR * this->ControlPointSize;
+    this->InteractionPipeline->SetWidgetScale(interactionWidgetScale);
+    count += this->InteractionPipeline->Actor->RenderOpaqueGeometry(viewport);
+    }
+  return count;
+}
+
+//----------------------------------------------------------------------
+int vtkSlicerMarkupsWidgetRepresentation::RenderTranslucentPolygonalGeometry(vtkViewport* viewport)
+{
+  int count = 0;
+  if (this->InteractionPipeline && this->InteractionPipeline->Actor->GetVisibility())
+    {
+    count += this->InteractionPipeline->Actor->RenderTranslucentPolygonalGeometry(viewport);
+    }
+  return count;
+}
+
+//----------------------------------------------------------------------
+vtkTypeBool vtkSlicerMarkupsWidgetRepresentation::HasTranslucentPolygonalGeometry()
+{
+  if (this->InteractionPipeline && this->InteractionPipeline->Actor->GetVisibility() &&
+    this->InteractionPipeline->Actor->HasTranslucentPolygonalGeometry())
+    {
+    return true;
+    }
+  return false;
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::GetInteractionHandleAxisWorld(int index, double axis[3])
+{
+  this->InteractionPipeline->GetInteractionHandleAxisWorld(index, axis);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::GetInteractionHandleOriginWorld(double origin[3])
+{
+  this->InteractionPipeline->GetInteractionHandleOriginWorld(origin);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::GetInteractionHandleVector(int type, int index, double axis[3])
+{
+  vtkPolyData* handles = nullptr;
+  if (type == vtkMRMLMarkupsDisplayNode::ComponentRotationHandle)
+    {
+    handles = this->InteractionPipeline->RotationHandlePoints;
+    }
+  else if (type == vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle)
+    {
+    handles = this->InteractionPipeline->TranslationHandlePoints;
+    }
+
+  if (!handles)
+    {
+    vtkErrorMacro("GetInteractionHandleVector: Could not find interaction handles!");
+    return;
+    }
+
+  if (index  < 0 || index >= handles->GetNumberOfPoints())
+    {
+    vtkErrorMacro("GetInteractionHandleVector: Handle index out of range!");
+    return;
+    }
+
+  handles->GetPoint(index, axis);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::GetInteractionHandleVectorWorld(int type, int index, double axisWorld[3])
+{
+  if (!axisWorld)
+    {
+    vtkErrorMacro("GetInteractionHandleVectorWorld: Invalid axis argument!");
+    }
+
+  this->GetInteractionHandleVector(type, index, axisWorld);
+  double origin[3] = { 0 };
+  this->InteractionPipeline->HandleToWorldTransform->TransformVectorAtPoint(origin, axisWorld, axisWorld);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::GetInteractionHandlePositionWorld(int type, int index, double positionWorld[3])
+{
+  if (!positionWorld)
+    {
+    vtkErrorMacro("GetInteractionHandlePositionWorld: Invalid position argument!");
+    }
+
+  if (type == vtkMRMLMarkupsDisplayNode::ComponentRotationHandle)
+    {
+    this->InteractionPipeline->RotationHandlePoints->GetPoint(index, positionWorld);
+    this->InteractionPipeline->RotationScaleTransform->GetTransform()->TransformPoint(positionWorld, positionWorld);
+    this->InteractionPipeline->HandleToWorldTransform->TransformPoint(positionWorld, positionWorld);
+    }
+  else if (type == vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle)
+    {
+    this->InteractionPipeline->TranslationHandlePoints->GetPoint(index, positionWorld);
+    this->InteractionPipeline->TranslationScaleTransform->GetTransform()->TransformPoint(positionWorld, positionWorld);
+    this->InteractionPipeline->HandleToWorldTransform->TransformPoint(positionWorld, positionWorld);
+    }
+}
+
+//----------------------------------------------------------------------
+vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::MarkupsInteractionPipeline(vtkMRMLAbstractWidgetRepresentation* representation)
+{
+  this->Representation = representation;
+
+  this->AxisRotationHandleSource = vtkSmartPointer<vtkSphereSource>::New();
+  this->AxisRotationHandleSource->SetRadius(INTERACTION_HANDLE_RADIUS);
+
+  this->AxisRotationArcSource = vtkSmartPointer<vtkArcSource>::New();
+  this->AxisRotationArcSource->SetAngle(90);
+  this->AxisRotationArcSource->SetCenter(-INTERACTION_HANDLE_ROTATION_ARC_RADIUS, 0, 0);
+  this->AxisRotationArcSource->SetPoint1(
+    INTERACTION_HANDLE_ROTATION_ARC_RADIUS / sqrt(2) - INTERACTION_HANDLE_ROTATION_ARC_RADIUS,
+   -INTERACTION_HANDLE_ROTATION_ARC_RADIUS/sqrt(2), 0);
+  this->AxisRotationArcSource->SetPoint2(
+    INTERACTION_HANDLE_ROTATION_ARC_RADIUS / sqrt(2) - INTERACTION_HANDLE_ROTATION_ARC_RADIUS,
+    INTERACTION_HANDLE_ROTATION_ARC_RADIUS/sqrt(2), 0);
+  this->AxisRotationArcSource->SetResolution(6);
+
+  this->AxisRotationTubeFilter = vtkSmartPointer<vtkTubeFilter>::New();
+  this->AxisRotationTubeFilter->SetInputConnection(this->AxisRotationArcSource->GetOutputPort());
+  this->AxisRotationTubeFilter->SetRadius(INTERACTION_HANDLE_ROTATION_ARC_TUBE_RADIUS);
+
+  this->AxisRotationGlyphSource = vtkSmartPointer <vtkAppendPolyData>::New();
+  this->AxisRotationGlyphSource->AddInputConnection(this->AxisRotationHandleSource->GetOutputPort());
+  this->AxisRotationGlyphSource->AddInputConnection(this->AxisRotationTubeFilter->GetOutputPort());
+
+  this->AxisTranslationGlyphSource = vtkSmartPointer<vtkArrowSource>::New();
+  this->AxisTranslationGlyphSource->SetTipRadius(INTERACTION_HANDLE_RADIUS);
+  this->AxisTranslationGlyphSource->SetTipLength(INTERACTION_HANDLE_DIAMETER);
+  this->AxisTranslationGlyphSource->InvertOn();
+
+  vtkNew<vtkTransform> translationGlyphTransformer;
+  translationGlyphTransformer->Translate(INTERACTION_HANDLE_RADIUS, 0, 0);
+  translationGlyphTransformer->RotateY(180);
+
+  this->AxisTranslationGlyphTransformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+  this->AxisTranslationGlyphTransformer->SetTransform(translationGlyphTransformer);
+  this->AxisTranslationGlyphTransformer->SetInputConnection(this->AxisTranslationGlyphSource->GetOutputPort());
+
+  this->RotationHandlePoints = vtkSmartPointer<vtkPolyData>::New();
+  this->TranslationHandlePoints = vtkSmartPointer<vtkPolyData>::New();
+
+  this->RotationScaleTransform = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+  this->RotationScaleTransform->SetInputData(this->RotationHandlePoints);
+  this->RotationScaleTransform->SetTransform(vtkNew<vtkTransform>());
+
+  this->TranslationScaleTransform = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+  this->TranslationScaleTransform->SetInputData(this->TranslationHandlePoints);
+  this->TranslationScaleTransform->SetTransform(vtkNew<vtkTransform>());
+
+  this->AxisRotationGlypher = vtkSmartPointer<vtkTensorGlyph>::New();
+  this->AxisRotationGlypher->SetInputConnection(this->RotationScaleTransform->GetOutputPort());
+  this->AxisRotationGlypher->SetSourceConnection(this->AxisRotationGlyphSource->GetOutputPort());
+  this->AxisRotationGlypher->ScalingOff();
+  this->AxisRotationGlypher->ExtractEigenvaluesOff();
+  this->AxisRotationGlypher->SetInputArrayToProcess(0, 0, 0, 0, "orientation"); // Orientation direction array
+
+  this->AxisTranslationGlypher = vtkSmartPointer<vtkGlyph3D>::New();
+  this->AxisTranslationGlypher->SetInputConnection(this->TranslationScaleTransform->GetOutputPort());
+  this->AxisTranslationGlypher->SetSourceConnection(0, this->AxisTranslationGlyphTransformer->GetOutputPort());
+  this->AxisTranslationGlypher->SetSourceConnection(1, this->AxisRotationHandleSource->GetOutputPort());
+  this->AxisTranslationGlypher->ScalingOn();
+  this->AxisTranslationGlypher->SetScaleModeToDataScalingOff();
+  this->AxisTranslationGlypher->SetIndexModeToScalar();
+  this->AxisTranslationGlypher->SetColorModeToColorByScalar();
+  this->AxisTranslationGlypher->OrientOn();
+  this->AxisTranslationGlypher->SetInputArrayToProcess(0, 0, 0, 0, "glyphIndex"); // Glyph shape
+  this->AxisTranslationGlypher->SetInputArrayToProcess(1, 0, 0, 0, "orientation"); // Orientation direction array
+
+  this->Append = vtkSmartPointer<vtkAppendPolyData>::New();
+  this->Append->AddInputConnection(this->AxisRotationGlypher->GetOutputPort());
+  this->Append->AddInputConnection(this->AxisTranslationGlypher->GetOutputPort());
+
+  this->HandleToWorldTransform = vtkSmartPointer<vtkTransform>::New();
+  this->HandleToWorldTransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+  this->HandleToWorldTransformFilter->SetInputConnection(this->Append->GetOutputPort());
+  this->HandleToWorldTransformFilter->SetTransform(this->HandleToWorldTransform);
+
+  this->ColorTable = vtkSmartPointer<vtkLookupTable>::New();
+
+  vtkNew<vtkCoordinate> coordinate;
+  coordinate->SetCoordinateSystemToWorld();
+
+  this->Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+  this->Mapper->SetInputConnection(this->HandleToWorldTransformFilter->GetOutputPort());
+  this->Mapper->SetColorModeToMapScalars();
+  this->Mapper->ColorByArrayComponent("colorIndex", 0);
+  this->Mapper->SetLookupTable(this->ColorTable);
+  this->Mapper->ScalarVisibilityOn();
+  this->Mapper->UseLookupTableScalarRangeOn();
+  this->Mapper->SetTransformCoordinate(coordinate);
+
+  this->Property = vtkSmartPointer<vtkProperty2D>::New();
+  this->Property->SetPointSize(0.0);
+  this->Property->SetLineWidth(0.0);
+
+  this->Actor = vtkSmartPointer<vtkActor2D>::New();
+  this->Actor->SetProperty(this->Property);
+  this->Actor->SetMapper(this->Mapper);
+
+  this->StartFadeAngle = 30;
+  this->EndFadeAngle = 20;
+}
+
+//----------------------------------------------------------------------
+vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::~MarkupsInteractionPipeline()
+= default;
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::InitializePipeline()
+{
+  this->CreateRotationHandles();
+  this->CreateTranslationHandles();
+  this->UpdateHandleColors();
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateRotationHandles()
+{
+  vtkNew<vtkPoints> points;
+
+  double xRotationHandle[3] = { 0, 1, 1 }; // X-axis
+  vtkMath::Normalize(xRotationHandle);
+  points->InsertNextPoint(xRotationHandle);
+  double yRotationHandle[3] = { 1, 0, 1 }; // Y-axis
+  vtkMath::Normalize(yRotationHandle);
+  points->InsertNextPoint(yRotationHandle);
+  double zRotationHandle[3] = { 1, 1, 0 }; // Z-axis
+  vtkMath::Normalize(zRotationHandle);
+  points->InsertNextPoint(zRotationHandle);
+  this->RotationHandlePoints->SetPoints(points);
+
+  vtkNew<vtkDoubleArray> orientationArray;
+  orientationArray->SetName("orientation");
+  orientationArray->SetNumberOfComponents(9);
+  vtkNew<vtkTransform> xRotationOrientation;
+  xRotationOrientation->RotateX(90);
+  xRotationOrientation->RotateY(90);
+  xRotationOrientation->RotateZ(45);
+  vtkMatrix4x4* xRotationMatrix = xRotationOrientation->GetMatrix();
+  orientationArray->InsertNextTuple9(xRotationMatrix->GetElement(0, 0), xRotationMatrix->GetElement(1, 0), xRotationMatrix->GetElement(2, 0),
+                                     xRotationMatrix->GetElement(0, 1), xRotationMatrix->GetElement(1, 1), xRotationMatrix->GetElement(2, 1),
+                                     xRotationMatrix->GetElement(0, 2), xRotationMatrix->GetElement(1, 2), xRotationMatrix->GetElement(2, 2));
+  vtkNew<vtkTransform> yRotationOrientation;
+  yRotationOrientation->RotateX(90);
+  yRotationOrientation->RotateZ(45);
+  vtkMatrix4x4* yRotationMatrix = yRotationOrientation->GetMatrix();
+  orientationArray->InsertNextTuple9(yRotationMatrix->GetElement(0, 0), yRotationMatrix->GetElement(1, 0), yRotationMatrix->GetElement(2, 0),
+                                     yRotationMatrix->GetElement(0, 1), yRotationMatrix->GetElement(1, 1), yRotationMatrix->GetElement(2, 1),
+                                     yRotationMatrix->GetElement(0, 2), yRotationMatrix->GetElement(1, 2), yRotationMatrix->GetElement(2, 2));
+  vtkNew<vtkTransform> zRotationOrientation;
+  zRotationOrientation->RotateZ(45);
+  vtkMatrix4x4* zRotationMatrix = zRotationOrientation->GetMatrix();
+  orientationArray->InsertNextTuple9(zRotationMatrix->GetElement(0, 0), zRotationMatrix->GetElement(1, 0), zRotationMatrix->GetElement(2, 0),
+                                     zRotationMatrix->GetElement(0, 1), zRotationMatrix->GetElement(1, 1), zRotationMatrix->GetElement(2, 1),
+                                     zRotationMatrix->GetElement(0, 2), zRotationMatrix->GetElement(1, 2), zRotationMatrix->GetElement(2, 2));
+  this->RotationHandlePoints->GetPointData()->AddArray(orientationArray);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateTranslationHandles()
+{
+  vtkNew<vtkPoints> points;
+  points->InsertNextPoint(1, 0, 0); // X-axis
+  points->InsertNextPoint(0, 1, 0); // Y-axis
+  points->InsertNextPoint(0, 0, 1); // Z-axis
+  points->InsertNextPoint(0, 0, 0); // Free translation
+  this->TranslationHandlePoints->SetPoints(points);
+
+  vtkNew<vtkDoubleArray> orientationArray;
+  orientationArray->SetName("orientation");
+  orientationArray->SetNumberOfComponents(3);
+  orientationArray->InsertNextTuple3(1, 0, 0);
+  orientationArray->InsertNextTuple3(0, 1, 0);
+  orientationArray->InsertNextTuple3(0, 0, 1);
+  orientationArray->InsertNextTuple3(1, 0, 0); // Free translation
+  this->TranslationHandlePoints->GetPointData()->AddArray(orientationArray);
+
+  vtkNew<vtkDoubleArray> glyphIndexArray;
+  glyphIndexArray->SetName("glyphIndex");
+  glyphIndexArray->SetNumberOfComponents(1);
+  glyphIndexArray->InsertNextTuple1(0);
+  glyphIndexArray->InsertNextTuple1(0);
+  glyphIndexArray->InsertNextTuple1(0);
+  glyphIndexArray->InsertNextTuple1(1);
+  this->TranslationHandlePoints->GetPointData()->AddArray(glyphIndexArray);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::UpdateHandleColors()
+{
+  if (!this->ColorTable)
+    {
+    return;
+    }
+
+  int numberOfHandles = this->RotationHandlePoints->GetNumberOfPoints() + this->TranslationHandlePoints->GetNumberOfPoints();
+  this->ColorTable->SetNumberOfTableValues(numberOfHandles);
+  this->ColorTable->SetTableRange(0, numberOfHandles - 1);
+
+  int colorIndex = 0;
+  double color[4] = { 0 };
+
+  // Rotation handles
+  vtkSmartPointer<vtkFloatArray> rotationColorArray = vtkFloatArray::SafeDownCast(
+    this->RotationHandlePoints->GetPointData()->GetAbstractArray("colorIndex"));
+  if (!rotationColorArray)
+    {
+    rotationColorArray = vtkSmartPointer<vtkFloatArray>::New();
+    rotationColorArray->SetName("colorIndex");
+    rotationColorArray->SetNumberOfComponents(1);
+    this->RotationHandlePoints->GetPointData()->AddArray(rotationColorArray);
+    this->RotationHandlePoints->GetPointData()->SetActiveScalars("colorIndex");
+    }
+  rotationColorArray->Initialize();
+  rotationColorArray->SetNumberOfTuples(this->RotationHandlePoints->GetNumberOfPoints());
+  for (int i = 0; i < this->RotationHandlePoints->GetNumberOfPoints(); ++i)
+    {
+    this->GetHandleColor(vtkMRMLMarkupsDisplayNode::ComponentRotationHandle, i, color);
+    this->ColorTable->SetTableValue(colorIndex, color);
+    rotationColorArray->SetTuple1(i, colorIndex);
+    ++colorIndex;
+    }
+
+  // Translation handles
+  vtkSmartPointer<vtkFloatArray> translationColorArray = vtkFloatArray::SafeDownCast(
+    this->TranslationHandlePoints->GetPointData()->GetAbstractArray("colorIndex"));
+  if (!translationColorArray)
+    {
+    translationColorArray = vtkSmartPointer<vtkFloatArray>::New();
+    translationColorArray->SetName("colorIndex");
+    translationColorArray->SetNumberOfComponents(1);
+    this->TranslationHandlePoints->GetPointData()->AddArray(translationColorArray);
+    this->TranslationHandlePoints->GetPointData()->SetActiveScalars("colorIndex");
+    }
+  translationColorArray->Initialize();
+  translationColorArray->SetNumberOfTuples(this->TranslationHandlePoints->GetNumberOfPoints());
+  for (int i = 0; i < this->TranslationHandlePoints->GetNumberOfPoints(); ++i)
+    {
+    this->GetHandleColor(vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle, i, color);
+    this->ColorTable->SetTableValue(colorIndex, color);
+    translationColorArray->SetTuple1(i, colorIndex);
+    ++colorIndex;
+    }
+
+  this->ColorTable->Build();
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::GetHandleColor(int type, int index, double color[4])
+{
+  if (!color)
+    {
+    return;
+    }
+
+  double red[4]    = { 1.00, 0.00, 0.00, 1.00 };
+  double green[4]  = { 0.00, 1.00, 0.00, 1.00 };
+  double blue[4]   = { 0.00, 0.00, 1.00, 1.00 };
+  double orange[4] = { 1.00, 0.50, 0.00, 1.00 };
+  double white[4]  = { 1.00, 1.00, 1.00, 1.00 };
+  double yellow[4] = { 1.00, 1.00, 0.00, 1.00 };
+
+  double* currentColor = red;
+  switch (index)
+    {
+    case 0:
+      currentColor = red;
+      break;
+    case 1:
+      currentColor = green;
+      break;
+    case 2:
+      currentColor = blue;
+      break;
+    case 3:
+      currentColor = orange;
+      break;
+    default:
+      currentColor = white;
+      break;
+    }
+
+  bool highlighted = false;
+  // Highlighted
+  vtkSlicerMarkupsWidgetRepresentation* markupsRepresentation = vtkSlicerMarkupsWidgetRepresentation::SafeDownCast(this->Representation);
+  vtkMRMLMarkupsDisplayNode* displayNode = nullptr;
+  if (markupsRepresentation)
+    {
+    displayNode = markupsRepresentation->GetMarkupsDisplayNode();
+    }
+  if (displayNode && displayNode->GetActiveComponentType() == type && displayNode->GetActiveComponentIndex() == index)
+    {
+    highlighted = true;
+    currentColor = yellow;
+    }
+
+  for (int i = 0; i < 3; ++i)
+    {
+    color[i] = currentColor[i];
+    }
+
+  double opacity = 1.0;
+  if (!highlighted)
+    {
+    opacity = this->GetOpacity(type, index);
+    }
+  color[3] = opacity;
+}
+
+//----------------------------------------------------------------------
+double vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::GetOpacity(int type, int index)
+{
+  double viewNormal[3] = { 0 };
+  this->GetViewPlaneNormal(viewNormal);
+
+  double opacity = 1.0;
+  if (type == vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle && index == 3)
+    {
+    // Free transform handle
+    return opacity;
+    }
+
+  double axis[3] = { 0 };
+  this->GetInteractionHandleAxisWorld(index, axis);
+  if (vtkMath::Dot(viewNormal, axis) < 0)
+    {
+    vtkMath::MultiplyScalar(axis, -1);
+    }
+
+  double fadeAngleRange = this->StartFadeAngle - this->EndFadeAngle;
+  double angle = vtkMath::DegreesFromRadians(vtkMath::AngleBetweenVectors(viewNormal, axis));
+  if (type == vtkMRMLMarkupsDisplayNode::ComponentRotationHandle)
+    {
+    // Fade for rotation handles happens when the rotation axis is approaching 90 degrees from the view normal
+    if (angle > 90 - this->EndFadeAngle)
+      {
+      opacity = 0.0;
+      }
+    else if (angle > 90 - this->StartFadeAngle)
+      {
+      double difference = angle - (90 - this->StartFadeAngle);
+      opacity = 1.0 - (difference / fadeAngleRange);
+      }
+    }
+  else if (type == vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle)
+    {
+    // Fade for translation handles happens when the rotation axis is approaching 0 degrees from the view normal
+    if (angle < this->EndFadeAngle)
+      {
+      opacity = 0.0;
+      }
+    else if (angle < this->StartFadeAngle)
+      {
+      double difference = angle - this->EndFadeAngle;
+      opacity = (difference / fadeAngleRange);
+      }
+    }
+  return opacity;
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::GetViewPlaneNormal(double normal[3])
+{
+  if (!normal)
+    {
+    return;
+    }
+  if (this->Representation && this->Representation->GetRenderer() && this->Representation->GetRenderer()->GetActiveCamera())
+    {
+    vtkCamera* camera = this->Representation->GetRenderer()->GetActiveCamera();
+    camera->GetViewPlaneNormal(normal);
+    }
+}
+
+//----------------------------------------------------------------------
+vtkSlicerMarkupsWidgetRepresentation::HandleInfoList vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::GetHandleInfoList()
+{
+  vtkSlicerMarkupsWidgetRepresentation::HandleInfoList handleInfoList;
+  for (int i = 0; i < this->RotationHandlePoints->GetNumberOfPoints(); ++i)
+    {
+    double handlePositionLocal[3] = { 0 };
+    double handlePositionWorld[3] = { 0 };
+    this->RotationHandlePoints->GetPoint(i, handlePositionLocal);
+    this->RotationScaleTransform->GetTransform()->TransformPoint(handlePositionLocal, handlePositionWorld);
+    this->HandleToWorldTransform->TransformPoint(handlePositionWorld, handlePositionWorld);
+    double color[4] = { 0 };
+    this->GetHandleColor(vtkMRMLMarkupsDisplayNode::ComponentRotationHandle, i, color);
+    HandleInfo info(i, vtkMRMLMarkupsDisplayNode::ComponentRotationHandle, handlePositionWorld, handlePositionLocal, color);
+    handleInfoList.push_back(info);
+    }
+
+  for (int i = 0; i < this->TranslationHandlePoints->GetNumberOfPoints(); ++i)
+    {
+    double handlePositionLocal[3] = { 0 };
+    double handlePositionWorld[3] = { 0 };
+    this->TranslationHandlePoints->GetPoint(i, handlePositionLocal);
+    this->TranslationScaleTransform->GetTransform()->TransformPoint(handlePositionLocal, handlePositionWorld);
+    this->HandleToWorldTransform->TransformPoint(handlePositionWorld, handlePositionWorld);
+    double color[4] = { 0 };
+    this->GetHandleColor(vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle, i, color);
+    HandleInfo info(i, vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle, handlePositionWorld, handlePositionLocal, color);
+    handleInfoList.push_back(info);
+    }
+  return handleInfoList;
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::SetWidgetScale(double scale)
+{
+  vtkNew<vtkTransform> scaleTransform;
+  scaleTransform->Scale(scale, scale, scale);
+  this->RotationScaleTransform->SetTransform(scaleTransform);
+  this->TranslationScaleTransform->SetTransform(scaleTransform);
+  this->AxisRotationGlypher->SetScaleFactor(scale);
+  this->AxisTranslationGlypher->SetScaleFactor(scale);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::GetInteractionHandleAxisWorld(int index, double axisWorld[3])
+{
+  if (!axisWorld || index < 0 || index > 2)
+    {
+    return;
+    }
+
+  double handleAxis[3] = { 0 };
+  handleAxis[index] = 1;
+  double origin[3] = { 0,0,0 };
+  this->HandleToWorldTransform->TransformVectorAtPoint(origin, handleAxis, axisWorld);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::GetInteractionHandleOriginWorld(double originWorld[3])
+{
+  if (!originWorld)
+    {
+    return;
+    }
+
+  double handleOrigin[3] = { 0,0,0 };
+  this->HandleToWorldTransform->TransformPoint(handleOrigin, originWorld);
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
@@ -57,6 +57,10 @@ public:
   void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
     int &foundComponentType, int &foundComponentIndex, double &closestDistance2) override;
 
+  /// Check if interaction with the transformation handles is possible
+  virtual void CanInteractWithHandles(vtkMRMLInteractionEventData* interactionEventData,
+    int& foundComponentType, int& foundComponentIndex, double& closestDistance2);
+
   /// Checks if interaction with straight line between visible points is possible.
   /// Can be used on the output of CanInteract, as if no better component is found then the input is returned.
   void CanInteractWithLine(vtkMRMLInteractionEventData* interactionEventData,
@@ -94,9 +98,14 @@ public:
   void GetSliceToWorldCoordinates(const double[2], double[3]);
   void GetWorldToSliceCoordinates(const double worldPos[3], double slicePos[2]);
 
+  void UpdateInteractionPipeline() override;
+
 protected:
   vtkSlicerMarkupsWidgetRepresentation2D();
   ~vtkSlicerMarkupsWidgetRepresentation2D() override;
+
+  /// Reimplemented for 2D specific mapper/actor settings
+  virtual void SetupInteractionPipeline() override;
 
     /// Get MRML view node as slice view node
   vtkMRMLSliceNode *GetSliceNode();
@@ -158,6 +167,17 @@ protected:
   virtual void UpdateAllPointsAndLabelsFromMRML(double labelsOffset);
 
   double GetWidgetOpacity(int controlPointType);
+
+  class MarkupsInteractionPipeline2D : public MarkupsInteractionPipeline
+  {
+  public:
+    MarkupsInteractionPipeline2D(vtkSlicerMarkupsWidgetRepresentation* representation);
+    virtual ~MarkupsInteractionPipeline2D() {};
+
+    virtual void GetViewPlaneNormal(double viewPlaneNormal[3]) override;
+
+    vtkSmartPointer<vtkTransformPolyDataFilter> WorldToSliceTransformFilter;
+  };
 
 private:
   vtkSlicerMarkupsWidgetRepresentation2D(const vtkSlicerMarkupsWidgetRepresentation2D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -38,10 +38,13 @@
 #include "vtkStringArray.h"
 #include "vtkTextActor.h"
 #include "vtkTextProperty.h"
+#include "vtkTransform.h"
+#include "vtkTransformPolyDataFilter.h"
 
 // MRML includes
 #include <vtkMRMLFolderDisplayNode.h>
 #include <vtkMRMLInteractionEventData.h>
+#include <vtkMRMLViewNode.h>
 
 vtkSlicerMarkupsWidgetRepresentation3D::ControlPointsPipeline3D::ControlPointsPipeline3D()
 {
@@ -274,7 +277,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
 
   double displayPosition3[3] = { 0.0, 0.0, 0.0 };
   // Display position is valid in case of desktop interactions. Otherwise it is a 3D only context such as
-  // virtual reality, and then we expect a valid world position in tha absence of display position.
+  // virtual reality, and then we expect a valid world position in the absence of display position.
   if (interactionEventData->IsDisplayPositionValid())
     {
     const int* displayPosition = interactionEventData->GetDisplayPosition();
@@ -288,6 +291,16 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
 
   closestDistance2 = VTK_DOUBLE_MAX; // in display coordinate system (phyisical in case of virtual reality renderer)
   foundComponentIndex = -1;
+
+  // We can interact with the handle if the mouse is hovering over one of the handles (translation or rotation), in display coordinates.
+  // If display coordinates for the interaction event are not valid, world coordinates will be checked instead.
+  this->CanInteractWithHandles(interactionEventData, foundComponentType, foundComponentIndex, closestDistance2);
+  if (foundComponentType != vtkMRMLMarkupsDisplayNode::ComponentNone)
+    {
+    // if mouse is near a handle then select that (ignore the line + control points)
+    return;
+    }
+
   if (markupsNode->GetNumberOfControlPoints() > 2 && this->ClosedLoop)
     {
     // Check if center is selected
@@ -416,6 +429,132 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
 }
 
 //----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation3D::CanInteractWithHandles(
+  vtkMRMLInteractionEventData* interactionEventData,
+  int& foundComponentType, int& foundComponentIndex, double& closestDistance2)
+{
+  if (!this->InteractionPipeline || !this->InteractionPipeline->Actor->GetVisibility())
+    {
+    return;
+    }
+
+  double displayPosition3[3] = { 0.0, 0.0, 0.0 };
+  // Display position is valid in case of desktop interactions. Otherwise it is a 3D only context such as
+  // virtual reality, and then we expect a valid world position in the absence of display position.
+  if (interactionEventData->IsDisplayPositionValid())
+    {
+    const int* displayPosition = interactionEventData->GetDisplayPosition();
+    displayPosition3[0] = static_cast<double>(displayPosition[0]);
+    displayPosition3[1] = static_cast<double>(displayPosition[1]);
+    }
+  else if (!interactionEventData->IsWorldPositionValid())
+    {
+    return;
+    }
+
+  bool handlePicked = false;
+  vtkSlicerMarkupsWidgetRepresentation::HandleInfoList handleInfoList = this->InteractionPipeline->GetHandleInfoList();
+  for (vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::HandleInfo handleInfo : handleInfoList)
+    {
+    if (!handleInfo.IsVisible())
+      {
+      continue;
+      }
+
+    double* handleWorldPos = handleInfo.PositionWorld;
+    double handleDisplayPos[3] = { 0 };
+
+    if (interactionEventData->IsDisplayPositionValid())
+      {
+      double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(handleWorldPos)
+        + this->PickingTolerance * this->ScreenScaleFactor;
+      this->Renderer->SetWorldPoint(handleWorldPos);
+      this->Renderer->WorldToDisplay();
+      this->Renderer->GetDisplayPoint(handleDisplayPos);
+      handleDisplayPos[2] = 0.0;
+      double dist2 = vtkMath::Distance2BetweenPoints(handleDisplayPos, displayPosition3);
+      if (dist2 < pixelTolerance * pixelTolerance && dist2 < closestDistance2)
+        {
+        closestDistance2 = dist2;
+        foundComponentType = handleInfo.ComponentType;
+        foundComponentIndex = handleInfo.Index;
+        handlePicked = true;
+        }
+      }
+    else
+      {
+      const double* worldPosition = interactionEventData->GetWorldPosition();
+      double worldTolerance = this->ControlPointSize / 2.0 +
+        this->PickingTolerance / interactionEventData->GetWorldToPhysicalScale();
+      double dist2 = vtkMath::Distance2BetweenPoints(handleWorldPos, worldPosition);
+      if (dist2 < worldTolerance * worldTolerance && dist2 < closestDistance2)
+        {
+        closestDistance2 = dist2;
+        foundComponentType = handleInfo.ComponentType;
+        foundComponentIndex = handleInfo.Index;
+        }
+      }
+    }
+
+  if (!handlePicked)
+    {
+    // Detect translation handle shaft
+    for (vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::HandleInfo handleInfo : handleInfoList)
+      {
+      if (!handleInfo.IsVisible() || handleInfo.ComponentType != vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle)
+        {
+        continue;
+        }
+      double* handleWorldPos = handleInfo.PositionWorld;
+      double handleDisplayPos[3] = { 0 };
+
+      if (interactionEventData->IsDisplayPositionValid())
+        {
+        double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(handleWorldPos)
+          + this->PickingTolerance * this->ScreenScaleFactor;
+        this->Renderer->SetWorldPoint(handleWorldPos);
+        this->Renderer->WorldToDisplay();
+        this->Renderer->GetDisplayPoint(handleDisplayPos);
+        handleDisplayPos[2] = 0.0;
+
+        double originWorldPos[4] = { 0.0, 0.0, 0.0, 1.0 };
+        this->InteractionPipeline->GetInteractionHandleOriginWorld(originWorldPos);
+        double originDisplayPos[4] = { 0.0 };
+        this->Renderer->SetWorldPoint(originWorldPos);
+        this->Renderer->WorldToDisplay();
+        this->Renderer->GetDisplayPoint(originDisplayPos);
+        originDisplayPos[2] = displayPosition3[2]; // Handles are always projected
+        double t = 0;
+        double lineDistance = vtkLine::DistanceToLine(displayPosition3, originDisplayPos, handleDisplayPos, t);
+        double lineDistance2 = lineDistance * lineDistance;
+        if (lineDistance < pixelTolerance && lineDistance2 < closestDistance2)
+          {
+          closestDistance2 = lineDistance2;
+          foundComponentType = handleInfo.ComponentType;
+          foundComponentIndex = handleInfo.Index;
+          }
+        }
+      else
+        {
+        const double* worldPosition = interactionEventData->GetWorldPosition();
+        double worldTolerance = this->ControlPointSize / 2.0 +
+          this->PickingTolerance / interactionEventData->GetWorldToPhysicalScale();
+        double originWorldPos[4] = { 0.0, 0.0, 0.0, 1.0 };
+        this->InteractionPipeline->GetInteractionHandleOriginWorld(originWorldPos);
+        double t;
+        double lineDistance = vtkLine::DistanceToLine(worldPosition, originWorldPos, handleWorldPos, t);
+        if (lineDistance < worldTolerance && lineDistance < closestDistance2)
+          {
+          closestDistance2 = lineDistance;
+          foundComponentType = handleInfo.ComponentType;
+          foundComponentIndex = handleInfo.Index;
+          }
+        }
+      }
+    }
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation3D::CanInteractWithLine(
   vtkMRMLInteractionEventData* interactionEventData,
   int &foundComponentType, int &foundComponentIndex, double &closestDistance2)
@@ -526,6 +665,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller,
 //----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation3D::GetActors(vtkPropCollection *pc)
 {
+  Superclass::GetActors(pc);
   for (int i = 0; i < NumberOfControlPointTypes; i++)
    {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
@@ -538,6 +678,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::GetActors(vtkPropCollection *pc)
 void vtkSlicerMarkupsWidgetRepresentation3D::ReleaseGraphicsResources(
   vtkWindow *win)
 {
+  Superclass::ReleaseGraphicsResources(win);
   for (int i = 0; i < NumberOfControlPointTypes; i++)
     {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
@@ -549,7 +690,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::ReleaseGraphicsResources(
 //----------------------------------------------------------------------
 int vtkSlicerMarkupsWidgetRepresentation3D::RenderOverlay(vtkViewport *viewport)
 {
-  int count=0;
+  int count = Superclass::RenderOverlay(viewport);
   for (int i = 0; i < NumberOfControlPointTypes; i++)
     {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
@@ -569,7 +710,6 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderOverlay(vtkViewport *viewport)
 int vtkSlicerMarkupsWidgetRepresentation3D::RenderOpaqueGeometry(
   vtkViewport *viewport)
 {
-
   // Recompute glyph size if it is relative to the screen size
   // (it gets smaller/larger as the camera is moved or zoomed)
   bool updateControlPointSize = false;
@@ -593,7 +733,7 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderOpaqueGeometry(
       }
     }
 
-  int count=0;
+  int count = Superclass::RenderOpaqueGeometry(viewport);
   vtkCamera* cam = this->Renderer->GetActiveCamera();
   double cameraPosition[3] = { 0.0, 0.0, 0.0 };
   double viewUp[3] = { 0.0, 1.0, 0.0 };
@@ -633,7 +773,7 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderOpaqueGeometry(
 int vtkSlicerMarkupsWidgetRepresentation3D::RenderTranslucentPolygonalGeometry(
   vtkViewport *viewport)
 {
-  int count=0;
+  int count = Superclass::RenderTranslucentPolygonalGeometry(viewport);
   for (int i = 0; i < NumberOfControlPointTypes; i++)
     {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
@@ -919,4 +1059,17 @@ bool vtkSlicerMarkupsWidgetRepresentation3D::GetNthControlPointViewVisibility(in
       }
     }
   return false;
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation3D::UpdateInteractionPipeline()
+{
+  vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(this->ViewNode);
+  if (!viewNode)
+    {
+    this->InteractionPipeline->Actor->SetVisibility(false);
+    return;
+    }
+  // Final visibility handled by superclass in vtkSlicerMarkupsWidgetRepresentation
+  Superclass::UpdateInteractionPipeline();
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -69,6 +69,10 @@ public:
   void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
     int &foundComponentType, int &foundComponentIndex, double &closestDistance2) override;
 
+  /// Check if interaction with the transformation handles is possible
+  virtual void CanInteractWithHandles(vtkMRMLInteractionEventData* interactionEventData,
+    int& foundComponentType, int& foundComponentIndex, double& closestDistance2);
+
   /// Checks if interaction with straight line between visible points is possible.
   /// Can be used on the output of CanInteract, as if no better component is found then the input is returned.
   void CanInteractWithLine(vtkMRMLInteractionEventData* interactionEventData,
@@ -90,6 +94,8 @@ protected:
   void UpdateViewScaleFactor() override;
 
   void UpdateControlPointSize() override;
+
+  void UpdateInteractionPipeline() override;
 
   class ControlPointsPipeline3D : public ControlPointsPipeline
   {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
@@ -81,6 +81,9 @@ public:
 
   void BuildPlane();
 
+  // Update visibility of interaction handles for representation
+  void UpdateInteractionPipeline() override;
+
 protected:
   vtkSlicerPlaneRepresentation2D();
   ~vtkSlicerPlaneRepresentation2D() override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
@@ -94,7 +94,11 @@ protected:
 
   std::string LabelFormat;
 
+  // Setup the pipeline for plane display
   void BuildPlane();
+
+  // Update visibility of interaction handles for representation
+  virtual void UpdateInteractionPipeline() override;
 
 private:
   vtkSlicerPlaneRepresentation3D(const vtkSlicerPlaneRepresentation3D&) = delete;

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>477</width>
-    <height>121</height>
+    <height>137</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -73,13 +73,6 @@
      </item>
     </layout>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="textScaleLabel">
-     <property name="text">
-      <string>Text Size:</string>
-     </property>
-    </widget>
-   </item>
    <item row="7" column="1">
     <widget class="ctkSliderWidget" name="textScaleSliderWidget">
      <property name="singleStep">
@@ -93,7 +86,49 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="7" column="0">
+    <widget class="QLabel" name="textScaleLabel">
+     <property name="text">
+      <string>Text Size:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="VisibilityCheckBox">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="opacityLabel">
+       <property name="text">
+        <string>Opacity:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ctkSliderWidget" name="opacitySliderWidget">
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="VisibilityLabel">
+     <property name="text">
+      <string>Visibility:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="SliceDisplayCollapsibleGroupBox">
      <property name="title">
       <string>Advanced</string>
@@ -186,39 +221,30 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="VisibilityCheckBox">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="opacityLabel">
-       <property name="text">
-        <string>Opacity:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="ctkSliderWidget" name="opacitySliderWidget">
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="VisibilityLabel">
-     <property name="text">
-      <string>Visibility:</string>
+   <item row="8" column="0" colspan="2">
+    <widget class="ctkCollapsibleGroupBox" name="InteractionGroupBox">
+     <property name="title">
+      <string>Interaction</string>
      </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="interactionLabel">
+        <property name="text">
+         <string>Visible:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="interactionCheckBox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -95,6 +95,9 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
   QObject::connect(this->opacitySliderWidget, SIGNAL(valueChanged(double)),
     q, SLOT(onOpacitySliderWidgetChanged(double)));
 
+  QObject::connect(this->interactionCheckBox, SIGNAL(stateChanged(int)),
+    q, SLOT(onInteractionCheckBoxChanged(int)));
+
     // populate the glyph type combo box
   if (this->glyphTypeComboBox->count() == 0)
     {
@@ -257,6 +260,9 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
     d->textScaleSliderWidget->setMaximum(textScale);
     }
   d->textScaleSliderWidget->setValue(textScale);
+
+  bool handlesInteractive = markupsDisplayNode->GetHandlesInteractive();
+  d->interactionCheckBox->setChecked(handlesInteractive);
 
   emit displayNodeChanged();
 }
@@ -432,4 +438,15 @@ void qMRMLMarkupsDisplayNodeWidget::setMaximumMarkupsSize(double maxSize)
     {
     d->glyphSizeSliderWidget->setMaximum(maxSize);
     }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::onInteractionCheckBoxChanged(int state)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetHandlesInteractive(state);
 }

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
@@ -96,6 +96,7 @@ protected slots:
   void onGlyphSizeSliderWidgetChanged(double value);
   void onTextScaleSliderWidgetChanged(double value);
   void onOpacitySliderWidgetChanged(double value);
+  void onInteractionCheckBoxChanged(int state);
 
 protected:
   QScopedPointer<qMRMLMarkupsDisplayNodeWidgetPrivate> d_ptr;


### PR DESCRIPTION
Adds 6 interaction handles to rotate and translate markup control points.
Each of the handles allows constrained motion of the markup control points constrained around/on a single axis.

Handles are only visible if the node is selected (via the vtkMRMLNode::Selected attribute).
This commit also adds some additional helper functions to vtkMRMLSelectionNode for getting the currently selected nodes, detecting if only one node is selected, and deselecting all nodes.

![image](https://user-images.githubusercontent.com/9222709/78164770-44c4b280-7418-11ea-900f-a11f09635a54.png)

Demo video:
https://www.dropbox.com/s/rycp6hxoh1i17rf/markup_handle_demo_1.mp4?dl=0