### PR TITLE
ENH: Allow splitting image subseries using acquisition number tag

### DIFF
--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -33,6 +33,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
     self.tags['orientation'] = "0020,0037"
     self.tags['pixelData'] = "7fe0,0010"
     self.tags['seriesInstanceUID'] = "0020,000E"
+    self.tags['acquisitionNumber'] = "0020,0012"
     self.tags['imageType'] = "0008,0008"
     self.tags['contentTime'] = "0008,0033"
     self.tags['triggerTime'] = "0018,1060"
@@ -169,6 +170,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
     # make subseries volumes based on tag differences
     subseriesTags = [
         "seriesInstanceUID",
+        "acquisitionNumber",
         # GE volume viewer puts an overview slice and reconstructed slices in one series, using two different image types.
         # Splitting based on image type allows loading of these volumes.
         "imageType",


### PR DESCRIPTION
Some CT images contain multiple acquisitions in the same series, distinguished by Acquisition Number (0020,0012) DICOM tag.
Adding this tag to the list of subseries tags in DICOMScalarVolumePlugin allows loading frames corresponding to specific acquisition numbers.