### PR TITLE
ENH: Set Help tab as the default instead of Acknowledgement

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerModulePanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerModulePanel.ui
@@ -86,7 +86,7 @@
           <item>
            <widget class="QTabWidget" name="HelpAcknowledgementTabWidget">
             <property name="currentIndex">
-             <number>1</number>
+             <number>0</number>
             </property>
             <widget class="QWidget" name="HelpTab">
              <attribute name="title">


### PR DESCRIPTION
Based on the discussion at https://discourse.slicer.org/t/making-the-help-tab-as-the-default-tab-to-open/10944

This PR sets the "Help" tab to be the default instead of the "Acknowledgement" tab. It was set to "Acknowledgement" in https://github.com/Slicer/Slicer/commit/aa4d34d33b2904033a3400ba0ea4a9d525085d9c which added that tab, but it was probably the original intent to maintain "Help" as the default since it is also the first tab.