### PR TITLE
BUG: Return all data nodes loaded by DICOMUtils.loadLoadables

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -637,7 +637,7 @@ def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
   @vtk.calldata_type(vtk.VTK_OBJECT)
   def onNodeAdded(caller, event, calldata):
     node = calldata
-    if isinstance(node, slicer.vtkMRMLVolumeNode):
+    if not isinstance(node, slicer.vtkMRMLStorageNode) and not isinstance(node, slicer.vtkMRMLDisplayNode):
       loadedNodeIDs.append(node.GetID())
 
   sceneObserverTag = slicer.mrmlScene.AddObserver(slicer.vtkMRMLScene.NodeAddedEvent, onNodeAdded)


### PR DESCRIPTION
Only the volume nodes were returned by the DICOMUtils.loadLoadables, which was confusing given the documentation and variable names, and also incorrect because many other types of nodes can be loaded from DICOM (fiducials, segmentations, beams, etc.). This fix allows any non-storage and non-display type node to be included in the returned list.