### PR TITLE
BUG: Change GUI instructions in error message

### DIFF
--- a/Modules/Loadable/Colors/Logic/vtkSlicerColorLogic.cxx
+++ b/Modules/Loadable/Colors/Logic/vtkSlicerColorLogic.cxx
@@ -161,7 +161,7 @@ std::vector<std::string> vtkSlicerColorLogic::FindColorFiles(const std::vector<s
     struct dirent *dirp;
     if ((dp  = opendir(dirString.c_str())) == nullptr)
       {
-      vtkErrorMacro("\nError(" << errno << ") opening user specified color path: " << dirString.c_str() << ", no color files will be loaded from that directory\n(check View -> Application Settings -> Module Settings to adjust your User defined color file paths)");
+      vtkErrorMacro("\nError(" << errno << ") opening user specified color path: " << dirString.c_str() << ", no color files will be loaded from that directory\n(check Edit -> Application Settings -> Module Settings to adjust your User defined color file paths)");
       }
     else
       {


### PR DESCRIPTION
The "Application Settings" menu is under "Edit", not "View". This directs the user to the right part of the UI.

I do not know when this code runs. I do not know if "Application Settings" menu is _always_ under "Edit". This patch is completely untested. It fails the pre-commit hook (line length).