### PR TITLE
BUG: Fix failing generate extension description test

### DIFF
--- a/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
+++ b/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
@@ -108,7 +108,6 @@ function(slicerFunctionGenerateExtensionDescription)
   configure_file(
     ${Slicer_EXTENSIONS_CMAKE_DIR}/../../Utilities/Templates/Extensions/extension_description.s4ext.in
     ${filename}
-    NEWLINE_STYLE LF
     )
 
   message(STATUS "Extension description has been written to: ${filename}")


### PR DESCRIPTION
This fixes the failing [cmake_slicer_generate_extension_description_test](http://slicer.cdash.org/testDetails.php?test=9961228&build=1881141). The test was failing because of different line endings between the files.

Since the test was passing as of March 10th and then failing as of March 13th, this corresponds exactly with the transition from SVN to Git.  I believe during this transition `extension_description_with_depends.s4ext` and `extension_description_without_depends.s4ext` went from having `LF` line endings with SVN to having `CRLF` line endings with git.

@lassoan This will essentially revert your commit https://github.com/Slicer/Slicer/commit/1c469b3a121fe977755a613a40eb067e5da53d43.  I'm not really sure of the purpose of that commit, but if you would like to maintain it then I could instead switch the two s4ext files to have LF line endings.
