### PR TITLE
BUG: Fix failing slicer_util_without_modules test

### DIFF
--- a/Base/Python/slicer/tests/compute-checksum.txt
+++ b/Base/Python/slicer/tests/compute-checksum.txt
@@ -1,1 +1,0 @@
-This is a text file!

--- a/Base/Python/slicer/tests/test_slicer_util_without_modules.py
+++ b/Base/Python/slicer/tests/test_slicer_util_without_modules.py
@@ -1,4 +1,6 @@
+import io
 import os
+import tempfile
 import unittest
 import slicer.util
 
@@ -12,12 +14,19 @@ class SlicerUtilWithoutModulesTest(unittest.TestCase):
     with self.assertRaises(IOError):
       slicer.util.computeChecksum('SHA256', 'compute-checksum-nonexistent.txt')
 
-    input_file = os.path.join(os.path.dirname(__file__), 'compute-checksum.txt')
-    self.assertEqual(slicer.util.computeChecksum('SHA256', input_file), '4a57f3207b97f26a6061f86948483c00b03893ddfef9e82b639ebe66e3aba338')
-    self.assertEqual(slicer.util.computeChecksum('SHA512', input_file), '5080ee92e951c5f8336053f11d278c23f5d26b5eb78805c952960eac0194f357f98b0e350611ce081d4a1e28dd8ea182d3a276c99b1752e0def2de0f47b8b27b')
+    with tempfile.TemporaryDirectory() as tmpdirname:
 
-    with self.assertRaises(ValueError):
-      slicer.util.computeChecksum('SHAINVALID', input_file)
+      input_file = os.path.join(tmpdirname, 'compute-checksum.txt')
+      with io.open(input_file, 'w', newline='\n') as content:
+        content.write('This is a text file!\n')
+
+      self.assertTrue(os.path.exists(input_file))
+
+      self.assertEqual(slicer.util.computeChecksum('SHA256', input_file), '4a57f3207b97f26a6061f86948483c00b03893ddfef9e82b639ebe66e3aba338')
+      self.assertEqual(slicer.util.computeChecksum('SHA512', input_file), '5080ee92e951c5f8336053f11d278c23f5d26b5eb78805c952960eac0194f357f98b0e350611ce081d4a1e28dd8ea182d3a276c99b1752e0def2de0f47b8b27b')
+
+      with self.assertRaises(ValueError):
+        slicer.util.computeChecksum('SHAINVALID', input_file)
 
   def test_extractAlgoAndDigest(self):
     with self.assertRaises(ValueError):


### PR DESCRIPTION
This fixes the failing [py_nomainwindow_test_slicer_util_without_modules](http://slicer.cdash.org/testDetails.php?test=9961479&build=1881141).  The test was failing due to an invalid expected checksum for the `compute-checksum.txt` file.

Since the test was passing as of March 10th and then failing as of March 13th, this corresponds exactly with the transition from SVN to Git.  I believe during this transition `compute-checksum.txt` went from having `LF` line endings with SVN to having `CRLF` line endings with git.

This is similar to #4814 as it is a fix for a test that started to fail due to a change in a file's line endings.
