### PR TITLE
ENH: Use ManifestDPIAware to improve the look of the Windows installer

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -356,6 +356,10 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
 
   set(_nsis_install_root "${Slicer_CPACK_NSIS_INSTALL_ROOT}")
 
+  # Use ManifestDPIAware to improve appearance of installer
+  string(APPEND CPACK_NSIS_DEFINES "\n  ;Use ManifestDPIAware to improve appearance of installer")
+  string(APPEND CPACK_NSIS_DEFINES "\n  ManifestDPIAware true\n")
+
   if (NOT Slicer_CPACK_NSIS_INSTALL_REQUIRES_ADMIN_ACCOUNT)
     # Install as regular user (UAC dialog will not be shown).
     string(APPEND CPACK_NSIS_DEFINES "\n  ;Install as regular user (UAC dialog will not be shown).")

--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -358,7 +358,8 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
 
   if (NOT Slicer_CPACK_NSIS_INSTALL_REQUIRES_ADMIN_ACCOUNT)
     # Install as regular user (UAC dialog will not be shown).
-    set(CPACK_NSIS_DEFINES ${CPACK_NSIS_DEFINES} "RequestExecutionLevel user")
+    string(APPEND CPACK_NSIS_DEFINES "\n  ;Install as regular user (UAC dialog will not be shown).")
+    string(APPEND CPACK_NSIS_DEFINES "\n  RequestExecutionLevel user")
   endif()
 
   # Installers for 32- vs. 64-bit CMake:


### PR DESCRIPTION
Fixes #4279 

Adds "ManifestDPIAware true" to CPACK_NSIS_DEFINES.  The variable value
must be as a single string to avoid inserting semicolons into the scripts

Before:
<img width="371" alt="Screenshot 2020-04-13 13 54 37" src="https://user-images.githubusercontent.com/25040869/79148581-b515f100-7d93-11ea-8903-dc5552cda521.png">

After:
<img width="372" alt="Screenshot 2020-04-13 13 54 25" src="https://user-images.githubusercontent.com/25040869/79148598-bba46880-7d93-11ea-8b93-b73c61300375.png">

["Before" installer](https://data.kitware.com/#item/5e94a71a2660cbefbab464c2)
["After" installer](https://data.kitware.com/#item/5e94a68c2660cbefbab4625b)