### PR TITLE
BUG: Update curve path when mesh is changed

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -1149,7 +1149,7 @@ void vtkMRMLMarkupsCurveNode::ProcessMRMLEvents(vtkObject* caller,
       }
     else
       {
-      this->UpdateSurfaceScalarVariables();
+      this->OnSurfaceModelNodeChanged();
       }
     }
   else if (caller == this->SurfaceScalarCalculator.GetPointer())


### PR DESCRIPTION
The underlying mesh used for pathfinding wasn't updated when the mesh used in the model node was changed.
Fixed by calling OnSurfaceModelNodeChanged instead of UpdateSurfaceScalarVariables when the ShortestDistanceSurfaceNode, or the underlying mesh is modified.

fixes #4817