### PR TITLE
COMP: Fix macOS extension packaging warning

### DIFF
--- a/CMake/SlicerExtensionCPack.cmake
+++ b/CMake/SlicerExtensionCPack.cmake
@@ -244,6 +244,7 @@ if(APPLE)
 
     file(WRITE ${slicer_extension_cpack_bundle_fixup_directory}/CMakeLists.txt
     "cmake_minimum_required(VERSION 3.13.4)
+project(SlicerExtensionCPackBundleFixup)
 install(SCRIPT \"${slicer_extension_cpack_bundle_fixup_directory}/SlicerExtensionCPackBundleFixup.cmake\")")
     set(source_dir "${slicer_extension_cpack_bundle_fixup_directory}")
     set(build_dir "${slicer_extension_cpack_bundle_fixup_directory}-binary")


### PR DESCRIPTION
This commit fixes warning like the following:

```
  -- Checking if extension type is SuperBuild
  -- Checking if extension type is SuperBuild - true
  -- Extension fixup mode: updating CPACK_INSTALL_CMAKE_PROJECTS with <cpack_bundle_fixup_directory>
  CMake Warning (dev) in CMakeLists.txt:
    No project() command is present.  The top-level CMakeLists.txt file must
    contain a literal, direct call to the project() command.  Add a line of
    code such as

      project(ProjectName)

    near the top of the file, but after cmake_minimum_required().

    CMake is pretending there is a "project(Project)" command on the first
    line.
```