### PR TITLE
ENH: Update BRAINSTools to version 5.2.0

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -277,7 +277,6 @@ set(BRAINSTools_options
   USE_BRAINSROIAuto:BOOL=ON
   USE_BRAINSResample:BOOL=ON
   # BRAINSTools comes with some extra tool that should not be compiled by default
-  USE_BRAINSDemonWarp:BOOL=OFF
   USE_AutoWorkup:BOOL=OFF
   USE_ReferenceAtlas:BOOL=OFF
   USE_ANTS:BOOL=OFF
@@ -288,16 +287,13 @@ set(BRAINSTools_options
   USE_BRAINSMush:BOOL=OFF
   USE_BRAINSInitializedControlPoints:BOOL=OFF
   USE_BRAINSMultiModeSegment:BOOL=OFF
-  USE_BRAINSCut:BOOL=OFF
   USE_BRAINSLandmarkInitializer:BOOL=OFF
   USE_ImageCalculator:BOOL=OFF
-  USE_BRAINSSurfaceTools:BOOL=OFF
   USE_BRAINSSnapShotWriter:BOOL=OFF
   USE_ConvertBetweenFileFormats:BOOL=OFF
   USE_BRAINSMultiSTAPLE:BOOL=OFF
   USE_BRAINSCreateLabelMapFromProbabilityMaps:BOOL=OFF
   USE_BRAINSContinuousClass:BOOL=OFF
-  USE_ICCDEF:BOOL=OFF
   USE_BRAINSPosteriorToContinuousClass:BOOL=OFF
   USE_DebugImageViewer:BOOL=OFF
   BRAINS_DEBUG_IMAGE_WRITE:BOOL=OFF
@@ -308,7 +304,7 @@ set(BRAINSTools_options
 
 Slicer_Remote_Add(BRAINSTools
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/Slicer/BRAINSTools.git
-  GIT_TAG d87ea8f357622c27abc6a2162b4623abe782b995 # slicer-2020-01-08-d0e6c01
+  GIT_TAG da5d1e9dab95d786f503379bd1278f52c2fef39d # slicer-2020-04-24-v5.2.0
   LICENSE_FILES "http://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"


### PR DESCRIPTION
Summary:
* BRAINSTools v5.2.0 now uses C++11, and ITKv5.
* This version compiles and passes all Slicer regression tests.
* Several outdated programs have been removed from the build tree.

List of changes:

```
$ git shortlog d87ea8f35..da5d1e9da --no-merges
Ali Ghayoor (1):
      BUG: three landmarks are enough for rigid transformation in BRAINSLandmarkInitializer

Andras Lasso (1):
      COMP: Fix build errors with current ITK master

Hans J. Johnson (132):
      ENH: ARCHIVE BRAINSDemonWarp as not needed.
      COMP: Updated `enum` to `enum class` for c++11
      STYLE: Enforce ITK style defined by .clang-format
      COMP: ANTs git has was invalid pre-merge value
      ENH: ITKv5 changes for ResampleImage.
      ENH: Make verbosity of BRAINSFit much less by default
      COMP: BRAINSDemonWarp is in the ARCHIVE build
      STYLE: Use range-based loops from C++11
      PERF: Improve build performance on dashboards
      ENH: Diagnostics for cache.
      ENH: Improve script robustness by quoting variables
      ENH: Fix verbose messages identified incorrectly as errors by cdash.
      ENH: Update external project dependancies.
      ENH: Update to ITKv5.1rc0
      STYLE: Remove redundant code.
      DOC: Fix diagnostic error message.
      STYLE: Remove redundant void argument lists
      STYLE: Make prototype match definition names
      ENH: remove redundant control fllow
      STYLE: Use auto for variable type matches the type of the initializer expression
      PERF: readability container size empty
      STYLE: Use range-based loops from C++11
      STYLE: Assign initial values to variables
      STYLE: Pefer = default to explicitly trivial implementations
      STYLE: One declaration per line for readability
      PERF: Replace explicit return calls of constructor
      STYLE: Replace integer literals which are cast to bool.
      PERF: emplace_back method results in potentially more efficient code
      STYLE: Prefer c++11 'using' to 'typedef'
      ENH: Turn legacy mode off for ITK support.
      COMP: Set default value for enumeration.
      ENH: Update ITK/ANTS/SlicerExecutionModel.
      COMP: Building TBB with with cmake ninja generator
      COMP: implicit conversion from int to float
      COMP: Add project line for build script testing tbb.
      ENH: Teem is no longer needed as an external package.
      COMP: Fix implicit vnl conversion warnings.
      ENH: Improve overriding ITK TAG temporarily.
      COMP: Remove vnl implicit conversion warnings.
      COMP: Remove unused variables.
      ENH: Synchronize external project with Slicer upstream.
      ENH: Update travis to include newer cmake version.
      ENH: Improve azure dashboard script.
      ENH: Remove zlib warnings outside scope of BRAINSTools concern.
      STYLE: Enforce clang-format.
      ENH: Improve support for coverage testing.
      ENH: Update VTK version.
      ENH: Match cmake version to SEM
      COMP: Remove VTK configure warning
      STYLE: Remove reference to DART_TESTING_TIMEOUT.
      ENH: Remove testing that used deprecated function
      COMP: Use One Definition Rule for mark_as_superbuild
      DOC: Make message match test.
      ENH: Fix debug build failures.
      COMP: VXL explicit matrix/vector conversion.
      ENH: Remove unused variable that does not have ctest effects.
      STYLE: Slight modernization of cmake variable setting.
      ENH: Update ITK and fix VTK to 8.2.0.
      ENH: Use ITK remote module RTK.
      ENH: Separate BRAINSTools from EP support options.
      COMP: Allow building of the BRAINSSuperResolution code
      COMP: Cleanup CMAKE_MODULE_PATH settings.
      COMP: Cleanup argument passing for BRAINSTools superbuild step.
      ENH: Update SlicerExecutionModel for suppressing warnings.
      ENH: Remove BRAINSDemonWarm and BRAINSCut.
      STYLE: Remove dead code BRAINSContinuousClass
      COMP: Fix compilation error.
      STYLE: Remove dead BRAINSSurfaceTools
      ENH: Almost make ICCDEF compile.
      STYLE: Remove ICCDEF from codebase.
      WIP: SEM TEMP UPDATE.
      STYLE: Remove redundant void argument lists
      STYLE: Replace integer literals which are cast to bool.
      PERF: readability container size empty
      STYLE: Make prototype match definition names
      STYLE: Prefer c++11 'using' to 'typedef'
      COMP: Prefer const member functions
      STYLE: Use default member initialization
      STYLE: Prefer = default to explicitly trivial implementations
      STYLE: Prefer = delete to explicitly trivial implementations
      STYLE: Use override statements for C++11
      PERF: Allow compiler to choose best way to construct a copy
      PERF: emplace_back method results in potentially more efficient code
      STYLE: Use auto for variable type matches the type of the initializer expression
      STYLE: Use range-based loops from C++11
      STYLE: Prefer raw-string-literal over escapes
      ENH: remove redundant control fllow
      STYLE: One declaration per line for readability
      COMP: Error in definition of annonymous enumeration.
      COMP: Write 'mark_as_superbuild' vars to cache
      ENH: Fix explicit setting of build type directory names.
      ENH: Adding clean build of BRAINSTools directory.
      COMP: Add missing dependancies for building test
      ENH: Fix GTRACT test dependency.
      STYLE: Remove debugging comments.
      ENH: Remove DicomSignature code.
      STYLE: Remove dead project BRAINSRefacer
      BUG: Finding the largest connected region bug when noisy mask given
      STYLE: Status warnings should print to std::cout not std::cerr
      COMP: Remove unused typedef warnings.
      DOC: Improve warning diagnostic so that it is not interpreted as an error.
      ENH: Fix shadow variable warning due to range based loop
      ENH: Update ITK to remove compiler warning double->longint
      COMP: Ensure that CMAKE_BUILD_TYPE is recorded in the CACHE
      COMP: Add floating point exception failure catching to build
      ENH: Add mac build support for catalina and TBB.
      STYLE: Remove unused functions, and protect macro do {} while(0) construcgt
      COMP: Remove conflicts of setting archetecture version supported.
      DOC: Improve comment formating and content.
      ENH: Expand compound statements for debugging.
      ENH: Use offset to avoid log of 0.
      BUG: Revert definiton of LOGP and EXPP to avoid problem at zero.
      ENH: Small shift to avoid problems with log conversions.
      ENH: Make tolerances smaller for floating point stability.
      ENH: Fix function signature to return outputs.
      COMP: Remove unused ivar & associated support structure.
      STYLE: Remove always true statement.
      ENH: Improve setting of -march and -mtune for superbuild.
      ENH: Add common build starting points
      BUG:  Improve stability of code by avoiding log( 0 ) multiplied by probability  of 0.
      ENH: Merge changes from working codebase.
      BUG: Diagnostic message was wrong for floating point types.
      STYLE: Use compile time constexpr when possible
      BUG: Debug fallthrough speedup mechanism make debugging very difficult
      ENH: Add another build configuration setting.
      ENH: Mac 10.15 standard build options for BRAINSTTools added
      ENH: Adding bug fix for TBB build
      ENH: Update to avoid using deprecated redundant features of TBB
      ENH: ITK updates and TBB updates that are note yet finalized
      ENH: Fix vxl version for ITK.
      ENH: Fix error in GTRACT building requirements.
      ENH: Update to version 5.2.0 of BRAINSTools

Tien Tong (1):
      Update README add note about unique session
```