### PR TITLE
STYLE: Remove conditional code for CXX< 201103L

### DIFF
--- a/Base/QTCLI/Testing/qSlicerPyCLIModuleTest1.cxx
+++ b/Base/QTCLI/Testing/qSlicerPyCLIModuleTest1.cxx
@@ -124,13 +124,7 @@ int qSlicerPyCLIModuleTest1(int argc, char * argv[])
     }
 
   QString cliPath = app.slicerHome() + "/" + Slicer_CLIMODULES_LIB_DIR + "/";
-  #if __cplusplus >= 201103L
   QStringList loadPaths = { cliPath, cliPath + app.intDir() };
-  #else
-  QStringList loadPaths;
-  loadPaths.append(cliPath);
-  loadPaths.append(cliPath + app.intDir());
-  #endif
 
   //===========================================================================
   // Ensure that PyCLI is not recognized by the scripted factory.

--- a/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
+++ b/Modules/Loadable/VolumeRendering/MRML/vtkMRMLVolumePropertyNode.cxx
@@ -24,15 +24,9 @@ vtkMRMLNodeNewMacro(vtkMRMLVolumePropertyNode);
 //----------------------------------------------------------------------------
 vtkMRMLVolumePropertyNode::vtkMRMLVolumePropertyNode()
   : VolumeProperty(nullptr)
-#if __cplusplus >= 201103L
   , EffectiveRange{0.0,-1.0}
-#endif
   , DisabledModify(0)
 {
-#if __cplusplus < 201103L
-  this->EffectiveRange[0] = 0.0;
-  this->EffectiveRange[1] = -1.0;
-#endif
   this->ObservedEvents = vtkIntArray::New();
   this->ObservedEvents->InsertNextValue(vtkCommand::StartEvent);
   this->ObservedEvents->InsertNextValue(vtkCommand::ModifiedEvent);


### PR DESCRIPTION
Now that C++11 is mandatory, remove conditional code
for older language support.