### PR TITLE
COMP: Update ITK to include -Wstrict-overflow warning fix

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v5.1rc03"
+    "35704a458d1ad9a4a2f2634d38032216ab280823"  # v5.1rc03 with ITK PR#1727 fixing -Wstrict-overflow warning
     QUIET
     )
 


### PR DESCRIPTION
Fix was contributed in upstream ITK in InsightSoftwareConsortium/ITK#1727

List of changes:

```
$ git shortlog v5.1rc03..35704a458d --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix -Wstrict-overflow warning in itkImageRegionConstIteratorWithIndex
```