### PR TITLE
BUG: Fix curve node surface interpolation when loading scene

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -222,6 +222,7 @@ protected:
 
   virtual void UpdateSurfaceScalarVariables();
   virtual void OnSurfaceModelNodeChanged();
+  virtual void OnSurfaceModelTransformChanged();
 
   vtkMRMLMarkupsCurveNode();
   ~vtkMRMLMarkupsCurveNode() override;


### PR DESCRIPTION
When loading a scene, the parent transform of the model node wasn't used unless it was modified.
Fixed by moving the code for updating the polydata transform to a new function (OnSurfaceModelTransformChanged).
The function is called when a node reference for the surface node is added or modified, which fixes the behavior on scene load.