### PR TITLE
STYLE: Use override statements for C++11

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
@@ -86,7 +86,7 @@ protected:
   ~vtkSlicerPlaneRepresentation2D() override;
 
   /// Re-implemented to adjust plane opacity
-  virtual void UpdateDistanceColorMap(vtkDiscretizableColorTransferFunction* colormap, double color[3]);
+  void UpdateDistanceColorMap(vtkDiscretizableColorTransferFunction* colormap, double color[3]) override;
 
   vtkNew<vtkPlaneSource> PlaneFilter;
   vtkNew<vtkPlaneCutter> PlaneCutter;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.h
@@ -71,7 +71,7 @@ protected:
   bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
   bool ProcessPlaneMoveStart(vtkMRMLInteractionEventData* event);
   bool ProcessPlaneMoveEnd(vtkMRMLInteractionEventData* event);
-  bool ProcessMouseMove(vtkMRMLInteractionEventData* eventData);
+  bool ProcessMouseMove(vtkMRMLInteractionEventData* eventData) override;
   bool ProcessPlaneTranslate(vtkMRMLInteractionEventData* event);
 
 private:


### PR DESCRIPTION
Describe function overrides using the override
keyword from C++11.

cd ${BLDDIR}
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-override  -header-filter=.* -fix