### PR TITLE
COMP: Fix setting of Slicer_MAIN_PROJECT_COMMIT_COUNT in vtkSlicerVersionConfigure.h

### DIFF
--- a/CMake/SlicerVersion.cmake
+++ b/CMake/SlicerVersion.cmake
@@ -50,52 +50,6 @@ set(CMAKE_MODULE_PATH
 include(SlicerMacroExtractRepositoryInfo)
 
 #-----------------------------------------------------------------------------
-# Slicer main application version number
-#-----------------------------------------------------------------------------
-SlicerMacroExtractRepositoryInfo(
-  VAR_PREFIX Slicer_MAIN_PROJECT
-  SOURCE_DIR ${${Slicer_MAIN_PROJECT_APPLICATION_NAME}_SOURCE_DIR}
-  )
-
-if(NOT "${Slicer_MAIN_PROJECT_FORCED_WC_LAST_CHANGED_DATE}" STREQUAL "")
-  set(Slicer_MAIN_PROJECT_WC_LAST_CHANGED_DATE "${Slicer_MAIN_PROJECT_FORCED_WC_LAST_CHANGED_DATE}")
-endif()
-string(REGEX REPLACE ".*([0-9][0-9][0-9][0-9]\\-[0-9][0-9]\\-[0-9][0-9]).*" "\\1"
-  Slicer_MAIN_PROJECT_BUILDDATE "${Slicer_MAIN_PROJECT_WC_LAST_CHANGED_DATE}")
-
-# Set Slicer_MAIN_PROJECT_COMMIT_COUNT from working copy commit count adjusted by a custom offset.
-if("${Slicer_MAIN_PROJECT_WC_COMMIT_COUNT_OFFSET}" STREQUAL "")
-  set(Slicer_MAIN_PROJECT_WC_COMMIT_COUNT_OFFSET "0")
-endif()
-math(EXPR Slicer_MAIN_PROJECT_COMMIT_COUNT "${Slicer_MAIN_PROJECT_WC_COMMIT_COUNT}+${Slicer_MAIN_PROJECT_WC_COMMIT_COUNT_OFFSET}")
-
-if("${Slicer_MAIN_PROJECT_REVISION_TYPE}" STREQUAL "")
-  set(Slicer_MAIN_PROJECT_REVISION_TYPE "CommitCount")
-endif()
-
-if(NOT "${Slicer_MAIN_PROJECT_FORCED_REVISION}" STREQUAL "")
-  set(Slicer_MAIN_PROJECT_REVISION "${Slicer_FORCED_REVISION}")
-elseif(Slicer_MAIN_PROJECT_REVISION_TYPE STREQUAL "CommitCount")
-  set(Slicer_MAIN_PROJECT_REVISION "${Slicer_MAIN_PROJECT_COMMIT_COUNT}")
-elseif(Slicer_MAIN_PROJECT_REVISION_TYPE STREQUAL "Hash")
-  set(Slicer_MAIN_PROJECT_REVISION "${Slicer_MAIN_PROJECT_WC_REVISION_HASH}")
-else()
-  message(FATAL_ERROR "Invalid Slicer_MAIN_PROJECT_REVISION_TYPE value: ${Slicer_MAIN_PROJECT_REVISION_TYPE}")
-endif()
-
-set(Slicer_MAIN_PROJECT_VERSION      "${Slicer_MAIN_PROJECT_VERSION_MAJOR}.${Slicer_MAIN_PROJECT_VERSION_MINOR}")
-set(Slicer_MAIN_PROJECT_VERSION_FULL "${Slicer_MAIN_PROJECT_VERSION}.${Slicer_MAIN_PROJECT_VERSION_PATCH}")
-
-if(NOT "${Slicer_RELEASE_TYPE}" STREQUAL "Stable")
-  set(Slicer_MAIN_PROJECT_VERSION_FULL "${Slicer_MAIN_PROJECT_VERSION_FULL}-${Slicer_MAIN_PROJECT_BUILDDATE}")
-endif()
-
-if(NOT "${Slicer_MAIN_PROJECT_APPLICATION_NAME}" STREQUAL "Slicer")
-  message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} version [${Slicer_MAIN_PROJECT_VERSION_FULL}]")
-  message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} revision [${Slicer_MAIN_PROJECT_REVISION}]")
-endif()
-
-#-----------------------------------------------------------------------------
 # Slicer version number
 #-----------------------------------------------------------------------------
 SlicerMacroExtractRepositoryInfo(
@@ -138,3 +92,61 @@ endif()
 
 message(STATUS "Configuring Slicer version [${Slicer_VERSION_FULL}]")
 message(STATUS "Configuring Slicer revision [${Slicer_REVISION}]")
+
+#-----------------------------------------------------------------------------
+# Slicer main application version number
+#-----------------------------------------------------------------------------
+SlicerMacroExtractRepositoryInfo(
+  VAR_PREFIX Slicer_MAIN_PROJECT
+  SOURCE_DIR ${${Slicer_MAIN_PROJECT_APPLICATION_NAME}_SOURCE_DIR}
+  )
+
+if(NOT "${Slicer_MAIN_PROJECT_FORCED_WC_LAST_CHANGED_DATE}" STREQUAL "")
+  set(Slicer_MAIN_PROJECT_WC_LAST_CHANGED_DATE "${Slicer_MAIN_PROJECT_FORCED_WC_LAST_CHANGED_DATE}")
+endif()
+string(REGEX REPLACE ".*([0-9][0-9][0-9][0-9]\\-[0-9][0-9]\\-[0-9][0-9]).*" "\\1"
+  Slicer_MAIN_PROJECT_BUILDDATE "${Slicer_MAIN_PROJECT_WC_LAST_CHANGED_DATE}")
+
+# Set Slicer_MAIN_PROJECT_COMMIT_COUNT from working copy commit count adjusted by a custom offset.
+if("${Slicer_MAIN_PROJECT_WC_COMMIT_COUNT_OFFSET}" STREQUAL "")
+  if ("${Slicer_MAIN_PROJECT_APPLICATION_NAME}" STREQUAL "Slicer")
+    # Force SlicerApp's commit count offset to be the same as Slicer_WC_COMMIT_COUNT_OFFSET to make
+    # Slicer_MAIN_PROJECT_REVISION the same as Slicer_REVISION if the default Slicer application is built.
+    set(Slicer_MAIN_PROJECT_WC_COMMIT_COUNT_OFFSET "${Slicer_WC_COMMIT_COUNT_OFFSET}")
+  else()
+    set(Slicer_MAIN_PROJECT_WC_COMMIT_COUNT_OFFSET "0")
+  endif()
+endif()
+math(EXPR Slicer_MAIN_PROJECT_COMMIT_COUNT "${Slicer_MAIN_PROJECT_WC_COMMIT_COUNT}+${Slicer_MAIN_PROJECT_WC_COMMIT_COUNT_OFFSET}")
+
+if("${Slicer_MAIN_PROJECT_REVISION_TYPE}" STREQUAL "")
+  if ("${Slicer_MAIN_PROJECT_APPLICATION_NAME}" STREQUAL "Slicer")
+    # Force SlicerApp's revision type to be the same as Slicer_REVISION_TYPE to make
+    # Slicer_MAIN_PROJECT_REVISION the same as Slicer_REVISION if the default Slicer application is built.
+    set(Slicer_MAIN_PROJECT_REVISION_TYPE "${Slicer_REVISION_TYPE}")
+  else()
+    set(Slicer_MAIN_PROJECT_REVISION_TYPE "CommitCount")
+  endif()
+endif()
+
+if(NOT "${Slicer_MAIN_PROJECT_FORCED_REVISION}" STREQUAL "")
+  set(Slicer_MAIN_PROJECT_REVISION "${Slicer_FORCED_REVISION}")
+elseif(Slicer_MAIN_PROJECT_REVISION_TYPE STREQUAL "CommitCount")
+  set(Slicer_MAIN_PROJECT_REVISION "${Slicer_MAIN_PROJECT_COMMIT_COUNT}")
+elseif(Slicer_MAIN_PROJECT_REVISION_TYPE STREQUAL "Hash")
+  set(Slicer_MAIN_PROJECT_REVISION "${Slicer_MAIN_PROJECT_WC_REVISION_HASH}")
+else()
+  message(FATAL_ERROR "Invalid Slicer_MAIN_PROJECT_REVISION_TYPE value: ${Slicer_MAIN_PROJECT_REVISION_TYPE}")
+endif()
+
+set(Slicer_MAIN_PROJECT_VERSION      "${Slicer_MAIN_PROJECT_VERSION_MAJOR}.${Slicer_MAIN_PROJECT_VERSION_MINOR}")
+set(Slicer_MAIN_PROJECT_VERSION_FULL "${Slicer_MAIN_PROJECT_VERSION}.${Slicer_MAIN_PROJECT_VERSION_PATCH}")
+
+if(NOT "${Slicer_RELEASE_TYPE}" STREQUAL "Stable")
+  set(Slicer_MAIN_PROJECT_VERSION_FULL "${Slicer_MAIN_PROJECT_VERSION_FULL}-${Slicer_MAIN_PROJECT_BUILDDATE}")
+endif()
+
+if(NOT "${Slicer_MAIN_PROJECT_APPLICATION_NAME}" STREQUAL "Slicer")
+  message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} version [${Slicer_MAIN_PROJECT_VERSION_FULL}]")
+  message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} revision [${Slicer_MAIN_PROJECT_REVISION}]")
+endif()


### PR DESCRIPTION
This commit updates SlicerVersion module to fix setting of commit offset variables
and ensures the variable Slicer_MAIN_PROJECT_COMMIT_COUNT defined in
vtkSlicerVersionConfigure.h is correct.

Indeed, if the main application is "Slicer" then we copy Slicer_WC_COMMIT_COUNT_OFFSET
and Slicer_REVISION_TYPE values from Slicer to the main application, so Slicer
values need to be set first.

See https://github.com/Slicer/Slicer/pull/4784#discussion_r400621292