### PR TITLE
ENH: Update MRML node API to allow listing of node content modification events

### DIFF
--- a/Libs/MRML/Core/vtkMRMLModelNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelNode.cxx
@@ -59,6 +59,8 @@ vtkMRMLModelNode::vtkMRMLModelNode()
   // for backward compatibility, we assume that if no
   // mesh were set, it is a polydata.
   this->MeshType = vtkMRMLModelNode::PolyDataMeshType;
+
+  this->ContentModifiedEvents->InsertNextValue(vtkMRMLModelNode::PolyDataModifiedEvent);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNode.cxx
@@ -33,6 +33,9 @@ Version:   $Revision: 1.11 $
 //------------------------------------------------------------------------------
 vtkMRMLNode::vtkMRMLNode()
 {
+  this->ContentModifiedEvents = vtkIntArray::New();
+  this->ContentModifiedEvents->InsertNextValue(vtkCommand::ModifiedEvent);
+
   // Set up callbacks
   this->MRMLCallbackCommand = vtkCallbackCommand::New();
   this->MRMLCallbackCommand->SetClientData( reinterpret_cast<void *>(this) );
@@ -74,6 +77,12 @@ vtkMRMLNode::~vtkMRMLNode()
     this->MRMLCallbackCommand->SetClientData( nullptr );
     this->MRMLCallbackCommand->Delete ( );
     this->MRMLCallbackCommand = nullptr;
+    }
+
+  if (this->ContentModifiedEvents)
+    {
+    this->ContentModifiedEvents->Delete();
+    this->ContentModifiedEvents = nullptr;
     }
 
   this->SetTempURLString(nullptr);

--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -572,6 +572,12 @@ public:
   /// Update the stored reference to another node in the scene.
   virtual void UpdateReferenceID(const char *oldID, const char *newID);
 
+  /// Return list of events that indicate that content of the node is modified.
+  /// For example, it is not enough to observe vtkCommand::ModifiedEvent to get
+  /// notified when a transform stored in a transform node is modified, but
+  /// vtkMRMLTransformableNode::TransformModifiedEvent must be observed as well.
+  vtkGetObjectMacro(ContentModifiedEvents, vtkIntArray);
+
   /// \brief Encode a URL string.
   ///
   /// Returns the string (null) if the input is null.
@@ -924,6 +930,8 @@ protected:
 
   typedef std::map< std::string, std::string > AttributesType;
   AttributesType Attributes;
+
+  vtkIntArray* ContentModifiedEvents;
 
   vtkObserverManager *MRMLObserverManager;
 

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -80,6 +80,13 @@ vtkMRMLSegmentationNode::vtkMRMLSegmentationNode()
   this->Segmentation = nullptr;
   vtkSmartPointer<vtkSegmentation> segmentation = vtkSmartPointer<vtkSegmentation>::New();
   this->SetAndObserveSegmentation(segmentation);
+
+  this->ContentModifiedEvents->InsertNextValue(vtkSegmentation::MasterRepresentationModified);
+  this->ContentModifiedEvents->InsertNextValue(vtkSegmentation::ContainedRepresentationNamesModified);
+  this->ContentModifiedEvents->InsertNextValue(vtkSegmentation::SegmentAdded);
+  this->ContentModifiedEvents->InsertNextValue(vtkSegmentation::SegmentRemoved);
+  this->ContentModifiedEvents->InsertNextValue(vtkSegmentation::SegmentModified);
+  this->ContentModifiedEvents->InsertNextValue(vtkSegmentation::SegmentsOrderModified);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTextNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTextNode.cxx
@@ -32,6 +32,7 @@ vtkMRMLNodeNewMacro(vtkMRMLTextNode);
 vtkMRMLTextNode::vtkMRMLTextNode()
   : Text("")
 {
+  this->ContentModifiedEvents->InsertNextValue(vtkMRMLTextNode::TextModifiedEvent);
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -54,6 +54,8 @@ vtkMRMLTransformNode::vtkMRMLTransformNode()
 
   this->CachedMatrixTransformToParent=vtkMatrix4x4::New();
   this->CachedMatrixTransformFromParent=vtkMatrix4x4::New();
+
+  this->ContentModifiedEvents->InsertNextValue(vtkMRMLTransformableNode::TransformModifiedEvent);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.cxx
@@ -67,6 +67,8 @@ vtkMRMLVolumeNode::vtkMRMLVolumeNode()
 
   this->ImageDataConnection = nullptr;
   this->DataEventForwarder = nullptr;
+
+  this->ContentModifiedEvents->InsertNextValue(vtkMRMLVolumeNode::ImageDataModifiedEvent);
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -101,8 +101,8 @@ vtkMRMLMarkupsNode::vtkMRMLMarkupsNode()
   this->CurveCoordinateSystemGeneratorWorld->SetInputConnection(this->CurvePolyToWorldTransformer->GetOutputPort());
 
   this->TransformedCurvePolyLocator = vtkSmartPointer<vtkPointLocator>::New();
-
   this->InteractionHandleToWorldMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+  this->ContentModifiedEvents->InsertNextValue(vtkMRMLMarkupsNode::PointModifiedEvent);
 }
 
 //----------------------------------------------------------------------------
@@ -429,8 +429,8 @@ vtkMRMLMarkupsNode::ControlPoint* vtkMRMLMarkupsNode::GetNthControlPointCustomLo
 {
   if (n < 0 || n >= this->GetNumberOfControlPoints())
     {
-    vtkErrorMacro("vtkMRMLMarkupsNode::" << failedMethodName << " failed: control point " <<
-      n << " does not exist");
+      vtkErrorMacro("vtkMRMLMarkupsNode::" << failedMethodName << " failed: control point " <<
+        n << " does not exist");
     return nullptr;
     }
 


### PR DESCRIPTION
For example, for transform node, it is not enough to observe vtkCommand::ModifiedEvent.
In that case, the list will contain both vtkCommand::ModifiedEvent
and vtkMRMLTransformableNode::TransformModifiedEvent.