### PR TITLE
ENH: Update MRML scene API adding support for read/write of MRML bundle

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -241,15 +241,7 @@ protected:
   void SetSelectionNode(vtkMRMLSelectionNode* );
   void SetInteractionNode(vtkMRMLInteractionNode* );
 
-  void SaveStorableNodeToSlicerDataBundleDirectory(vtkMRMLStorableNode* storableNode,
-                                                 std::string &dataDir);
-
 private:
-
-  /// use a map to store the file names from a storage node, the 0th one is by
-  /// definition the GetFileName returned value, then the rest are at index n+1
-  /// from GetNthFileName(n)
-  std::map<vtkMRMLStorageNode*, std::vector<std::string> > OriginalStorageNodeFileNames;
 
   vtkMRMLApplicationLogic(const vtkMRMLApplicationLogic&) = delete;
   void operator=(const vtkMRMLApplicationLogic&) = delete;


### PR DESCRIPTION
Local build successful and MRB tests pass:

```
$ ctest -R MRB -V
[...]
The following tests passed:
	py_SlicerMRBMultipleSaveRestoreLoopTest
	py_SlicerMRBMultipleSaveRestoreTest
	py_SlicerMRBSaveRestoreCheckPathsTest

100% tests passed, 0 tests failed out of 3

Total Test time (real) =  63.90 sec

```