### PR TITLE
COMP: Update BRAINSTools and VTK to fix windows CMake configuration error

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -304,7 +304,7 @@ set(BRAINSTools_options
 
 Slicer_Remote_Add(BRAINSTools
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/Slicer/BRAINSTools.git
-  GIT_TAG da5d1e9dab95d786f503379bd1278f52c2fef39d # slicer-2020-04-24-v5.2.0
+  GIT_TAG 3fe08e96be8967945cab79451ffb21c0c5a83bf8 # slicer-2020-04-24-v5.2.0
   LICENSE_FILES "http://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -122,7 +122,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
 set(_git_tag)
 if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "8")
-  set(_git_tag "9853cac9f934a6e68635c23b37d1c8cc74d51670") # slicer-v8.2.0-2020-03-16-16f7bbd
+  set(_git_tag "8b29c955d8b73cc26f6616ee734d8c501ff79dcd") # slicer-v8.2.0-2018-10-02-74d9488523
 else()
   message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
 endif()


### PR DESCRIPTION
This commit fixes a regression introduced in 39054218c3 (ENH: Update
BRAINSTools from v5.0.0 to v5.2.0)


List of BRAINSTools changes:

```
$ git shortlog da5d1e9d..3fe08e96 --no-merges
Jean-Christophe Fillion-Robin (1):
      [backport BRAINSia/BRAINSTools#473] COMP: Fix windows compilation adding missing check_avx_flags function
```

List of VTK changes:

```
$ git shortlog 9853cac9f9..8b29c955d8 --no-merges
Jean-Christophe Fillion-Robin (2):
      [backport MR-6754] COMP: Rename CheckCXXSourceRuns CMake module bundled in VTK
      [backport MR-6754] COMP: Rename CHECK_CXX_SOURCE_RUNS to avoid conflict with CMake implementation
```