### PR TITLE
ENH: Generate unique name for markups created by displayable manager

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
@@ -600,6 +600,7 @@ vtkMRMLMarkupsNode* vtkMRMLMarkupsDisplayableManager::CreateNewMarkupsNode(
     {
     nodeName = "P";
     }
+  nodeName = this->GetMRMLScene()->GenerateUniqueName(nodeName);
 
   vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(
     this->GetMRMLScene()->AddNewNodeByClass(markupsNodeClassName, nodeName));


### PR DESCRIPTION
Previously markup nodes created using vtkMRMLMarkupsDisplayableManager::CreateNewMarkupsNode would use the same name for all nodes.
Now, vtkMRMLScene::GenerateUniqueName is used to give the markups names like: P, P_1, P_2, etc.