### PR TITLE
COMP: Fix -Wunused-but-set-variable warning in vtkSlicerMarkupsWidgetRepresentation2D

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -419,14 +419,6 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller,
     this->UpdatePlaneFromSliceNode();
     }
 
-  // Use hierarchy information if any, and if overriding is allowed for the current display node
-  bool hierarchyVisibility = true;
-  if (this->MarkupsDisplayNode->GetFolderDisplayOverrideAllowed())
-    {
-    vtkMRMLDisplayableNode* displayableNode = this->MarkupsDisplayNode->GetDisplayableNode();
-    hierarchyVisibility = vtkMRMLFolderDisplayNode::GetHierarchyVisibility(displayableNode);
-    }
-
   vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
   if (!markupsNode || !this->IsDisplayable())
     {
@@ -1037,7 +1029,6 @@ bool vtkSlicerMarkupsWidgetRepresentation2D::IsCenterDisplayableOnSlice(vtkMRMLM
   bool showPoint = true;
 
   // allow annotations to appear only in designated viewers
-  vtkMRMLDisplayNode *displayNode = markupsNode->GetDisplayNode();
   if (!markupsNode || !this->IsDisplayable())
     {
     return false;


### PR DESCRIPTION
This commit fixes warning introduced in b39762c4e (BUG: Fixed adjustment
of markups visibility and color in subject hierarchy)