### PR TITLE
COMP: Fix -Wunused-variable warning in vtkSlicerMarkupsWidgetRepresentation2D

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -630,7 +630,6 @@ void vtkSlicerMarkupsWidgetRepresentation2D::CanInteractWithHandles(
       double* handleWorldPos = handleInfo.PositionWorld;
       rasToxyMatrix->MultiplyPoint(handleWorldPos, handleDisplayPos);
       handleDisplayPos[2] = displayPosition3[2]; // Handles are always projected
-      double dist2 = vtkMath::Distance2BetweenPoints(handleDisplayPos, displayPosition3);
 
       double originWorldPos[4] = { 0.0, 0.0, 0.0, 1.0 };
       this->InteractionPipeline->GetInteractionHandleOriginWorld(originWorldPos);


### PR DESCRIPTION
This commit fix warning introduced in ceaddc05b (ENH: Add interaction
handles for transforming markup positions)