### PR TITLE
BUG: Fix git hooks for git 2.18 and greater

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -19,10 +19,14 @@
 
 # Based on hook scripts from Git, VTK and ParaView.
 
+# As of git 2.18
+# https://stackoverflow.com/questions/53121208/git-dir-no-longer-set-in-pre-commit-hooks
+export HOOK_GIT_DIR=${HOOK_GIT_DIR-`git rev-parse --git-dir`}
+
 # Prepare a copy of the message:
 #  - strip comment lines
 #  - stop at "diff --git" (git commit -v)
-commit_msg="$GIT_DIR/COMMIT_MSG"
+commit_msg="$HOOK_GIT_DIR/COMMIT_MSG"
 sed -n -e '/^#/d' -e '/^diff --git/q' -e 'p;d' "$1" > "$commit_msg"
 
 advice='
@@ -43,7 +47,7 @@ printErrorAndExit() {
 # Check the commit message layout with a simple state machine.
 
 msg_is_merge() {
-  test -f "$GIT_DIR/MERGE_HEAD" &&
+  test -f "$HOOK_GIT_DIR/MERGE_HEAD" &&
     echo "$line" | grep "^Merge " >/dev/null 2>&1
 }
 

--- a/pre-commit
+++ b/pre-commit
@@ -19,6 +19,10 @@
 
 # Based on hook scripts from Git, VTK and ParaView.
 
+# As of git 2.18
+# https://stackoverflow.com/questions/53121208/git-dir-no-longer-set-in-pre-commit-hooks
+export HOOK_GIT_DIR=${HOOK_GIT_DIR-`git rev-parse --git-dir`}
+
 printErrorAndExit() {
   echo 'pre-commit hook failure' 1>&2
   echo '-----------------------' 1>&2
@@ -54,7 +58,7 @@ git config --get user.email | grep '^[^@]*@[^@]*$' > /dev/null ||
 # Check that developer setup is up-to-date.
 lastSetupForDevelopment=$(git config --get hooks.SetupForDevelopment || echo 0)
 eval $(grep '^SetupForDevelopment_VERSION=' \
-  "$GIT_DIR/../Utilities/SetupForDevelopment.sh")
+  "$HOOK_GIT_DIR/../Utilities/SetupForDevelopment.sh")
 test -n "$SetupForDevelopment_VERSION" || SetupForDevelopment_VERSION=0
 if test $lastSetupForDevelopment -lt $SetupForDevelopment_VERSION; then
   printErrorAndExit '


### PR DESCRIPTION
https://stackoverflow.com/questions/53121208/git-dir-no-longer-set-in-pre-commit-hooks

Using $GIT_DIR, when it has not been explicity set, in pre-commit hooks
did work pre Git 2.18, however this was an unexpected side effect and
not intended behavior.

A change in GIT 2.18 caused this to stop working. In the link a
contributor mentions that the correct way to get the location of the
.git directory in a pre-commit hook (or any hook for that matter) is to
use this git command

```bash
git rev-parse --git-dir
```