### PR TITLE
Fix OpenSSL build issues on Mac 10.15 XCode 11 clean OS

### DIFF
--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -108,6 +108,16 @@ ExternalProject_Execute(${proj} \"configure\" sh config --with-zlib-lib=${_zlib_
 ")
 
     #------------------------------------------------------------------------------
+    set(BUILD_COMMAND_MAKE_ENV)
+    if(APPLE)
+       # Allow the SDKROOT to be found on mac when
+       # building OpenSSL. This is needed to find
+       # standard header files and avoid errors like
+       # | ./cryptlib.h:62:11: fatal error: 'stdlib.h' file not found
+       # | # include <stdlib.h>
+       # |
+       set(BUILD_COMMAND_MAKE_ENV "SDKROOT=${CMAKE_OSX_SYSROOT}")
+    endif()
     ExternalProject_Add(${proj}
       ${${proj}_EP_ARGS}
       URL ${OpenSSL_${OPENSSL_DOWNLOAD_VERSION}_URL}
@@ -117,7 +127,7 @@ ExternalProject_Execute(${proj} \"configure\" sh config --with-zlib-lib=${_zlib_
       BUILD_IN_SOURCE 1
       PATCH_COMMAND ${CMAKE_COMMAND} -P ${_configure_script}
       CONFIGURE_COMMAND ""
-      BUILD_COMMAND make -j1 build_libs
+      BUILD_COMMAND ${BUILD_COMMAND_MAKE_ENV} make -j1 build_libs
       INSTALL_COMMAND ""
       DEPENDS
         ${${proj}_DEPENDENCIES}


### PR DESCRIPTION
The SDK must be provided in the environment for OpenSSL to compile.

OpenSSL include directory name is 'openssl' all lower case letters.  Use that to avoid 100's of compiler warnings about case mis-match.