### PR TITLE
STYLE: Use override statements for C++11

### DIFF
--- a/Base/QTGUI/qSlicerSettingsInternationalizationPanel.h
+++ b/Base/QTGUI/qSlicerSettingsInternationalizationPanel.h
@@ -45,7 +45,7 @@ public:
   explicit qSlicerSettingsInternationalizationPanel(QWidget* parent = 0);
 
   /// Destructor
-  virtual ~qSlicerSettingsInternationalizationPanel();
+  ~qSlicerSettingsInternationalizationPanel() override;
 
 public slots:
 

--- a/Libs/MRML/Core/vtkMRMLLinearTransformSequenceStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLLinearTransformSequenceStorageNode.h
@@ -35,22 +35,22 @@ class VTK_MRML_EXPORT vtkMRMLLinearTransformSequenceStorageNode : public vtkMRML
   static vtkMRMLLinearTransformSequenceStorageNode *New();
   vtkTypeMacro(vtkMRMLLinearTransformSequenceStorageNode,vtkMRMLNRRDStorageNode);
 
-  virtual vtkMRMLNode* CreateNodeInstance() override;
+  vtkMRMLNode* CreateNodeInstance() override;
 
   ///
   /// Get node XML tag name (like Storage, Model)
-  virtual const char* GetNodeTagName() override {return "LinearTransformSequenceStorage";};
+  const char* GetNodeTagName() override {return "LinearTransformSequenceStorage";};
 
   /// Return true if the node can be read in.
-  virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode) override;
+  bool CanReadInReferenceNode(vtkMRMLNode *refNode) override;
 
   /// Return true if the node can be written by using thie writer.
-  virtual bool CanWriteFromReferenceNode(vtkMRMLNode* refNode) override;
-  virtual int WriteDataInternal(vtkMRMLNode *refNode) override;
+  bool CanWriteFromReferenceNode(vtkMRMLNode* refNode) override;
+  int WriteDataInternal(vtkMRMLNode *refNode) override;
 
   ///
   /// Return a default file extension for writting
-  virtual const char* GetDefaultWriteFileExtension() override;
+  const char* GetDefaultWriteFileExtension() override;
 
   /// Read all the fields in the metaimage file header.
   /// If sequence nodes are passed in createdNodes then they will be reused. New sequence nodes will be created if there are more transforms
@@ -66,7 +66,7 @@ class VTK_MRML_EXPORT vtkMRMLLinearTransformSequenceStorageNode : public vtkMRML
 
 protected:
   vtkMRMLLinearTransformSequenceStorageNode();
-  ~vtkMRMLLinearTransformSequenceStorageNode();
+  ~vtkMRMLLinearTransformSequenceStorageNode() override;
   vtkMRMLLinearTransformSequenceStorageNode(const vtkMRMLLinearTransformSequenceStorageNode&);
   void operator=(const vtkMRMLLinearTransformSequenceStorageNode&);
 
@@ -74,13 +74,13 @@ protected:
   /// Returns 0 by default (read not supported).
   /// This implementation delegates most everything to the superclass
   /// but it has an early exit if the file to be read is incompatible.
-  virtual int ReadDataInternal(vtkMRMLNode* refNode) override;
+  int ReadDataInternal(vtkMRMLNode* refNode) override;
 
   /// Initialize all the supported write file types
-  virtual void InitializeSupportedReadFileTypes() override;
+  void InitializeSupportedReadFileTypes() override;
 
   /// Initialize all the supported write file types
-  virtual void InitializeSupportedWriteFileTypes() override;
+  void InitializeSupportedWriteFileTypes() override;
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLSequenceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSequenceNode.h
@@ -165,7 +165,7 @@ public:
 
 protected:
   vtkMRMLSequenceNode();
-  ~vtkMRMLSequenceNode();
+  ~vtkMRMLSequenceNode() override;
   vtkMRMLSequenceNode(const vtkMRMLSequenceNode&);
   void operator=(const vtkMRMLSequenceNode&);
 

--- a/Libs/MRML/Core/vtkMRMLSequenceStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLSequenceStorageNode.h
@@ -56,7 +56,7 @@ public:
 
 protected:
   vtkMRMLSequenceStorageNode();
-  ~vtkMRMLSequenceStorageNode();
+  ~vtkMRMLSequenceStorageNode() override;
   vtkMRMLSequenceStorageNode(const vtkMRMLSequenceStorageNode&);
   void operator=(const vtkMRMLSequenceStorageNode&);
 

--- a/Libs/MRML/Core/vtkMRMLTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.h
@@ -251,7 +251,7 @@ public:
   vtkMRMLStorageNode* CreateDefaultStorageNode() override;
 
   /// Creates the most appropriate storage node class for storing a sequence of these nodes.
-  virtual vtkMRMLStorageNode* CreateDefaultSequenceStorageNode();
+  vtkMRMLStorageNode* CreateDefaultSequenceStorageNode() override;
 
   ///
   /// Create and observe default display node

--- a/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.h
@@ -57,7 +57,7 @@ class VTK_MRML_EXPORT vtkMRMLVolumeSequenceStorageNode : public vtkMRMLNRRDStora
 
 protected:
   vtkMRMLVolumeSequenceStorageNode();
-  ~vtkMRMLVolumeSequenceStorageNode();
+  ~vtkMRMLVolumeSequenceStorageNode() override;
   vtkMRMLVolumeSequenceStorageNode(const vtkMRMLVolumeSequenceStorageNode&);
   void operator=(const vtkMRMLVolumeSequenceStorageNode&);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
@@ -74,7 +74,7 @@ protected:
   ~vtkSlicerLineRepresentation3D() override;
 
   /// Update interaction handle visibility for representation
-  virtual void UpdateInteractionPipeline() override;
+  void UpdateInteractionPipeline() override;
 
   vtkSmartPointer<vtkPolyData> Line;
   vtkSmartPointer<vtkPolyDataMapper> LineMapper;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
@@ -105,7 +105,7 @@ protected:
   ~vtkSlicerMarkupsWidgetRepresentation2D() override;
 
   /// Reimplemented for 2D specific mapper/actor settings
-  virtual void SetupInteractionPipeline() override;
+  void SetupInteractionPipeline() override;
 
     /// Get MRML view node as slice view node
   vtkMRMLSliceNode *GetSliceNode();
@@ -172,9 +172,9 @@ protected:
   {
   public:
     MarkupsInteractionPipeline2D(vtkSlicerMarkupsWidgetRepresentation* representation);
-    virtual ~MarkupsInteractionPipeline2D() {};
+    ~MarkupsInteractionPipeline2D() override {};
 
-    virtual void GetViewPlaneNormal(double viewPlaneNormal[3]) override;
+    void GetViewPlaneNormal(double viewPlaneNormal[3]) override;
 
     vtkSmartPointer<vtkTransformPolyDataFilter> WorldToSliceTransformFilter;
   };

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
@@ -98,7 +98,7 @@ protected:
   void BuildPlane();
 
   // Update visibility of interaction handles for representation
-  virtual void UpdateInteractionPipeline() override;
+  void UpdateInteractionPipeline() override;
 
 private:
   vtkSlicerPlaneRepresentation3D(const vtkSlicerPlaneRepresentation3D&) = delete;

--- a/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.h
+++ b/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.h
@@ -96,7 +96,7 @@ public:
 
 protected:
   vtkSlicerSequencesLogic();
-  virtual ~vtkSlicerSequencesLogic();
+  ~vtkSlicerSequencesLogic() override;
 
   void SetMRMLSceneInternal(vtkMRMLScene* newScene) override;
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
@@ -304,7 +304,7 @@ public:
 
 protected:
   vtkMRMLSequenceBrowserNode();
-  ~vtkMRMLSequenceBrowserNode();
+  ~vtkMRMLSequenceBrowserNode() override;
   vtkMRMLSequenceBrowserNode(const vtkMRMLSequenceBrowserNode&);
   void operator=(const vtkMRMLSequenceBrowserNode&);
 

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceBrowserPlayWidgetPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceBrowserPlayWidgetPlugin.h
@@ -29,11 +29,11 @@ qMRMLSequenceBrowserPlayWidgetPlugin
 public:
   qMRMLSequenceBrowserPlayWidgetPlugin(QObject *_parent = 0);
 
-  QWidget *createWidget(QWidget *_parent);
-  QString domXml() const;
-  QString includeFile() const;
-  bool isContainer() const;
-  QString name() const;
+  QWidget *createWidget(QWidget *_parent) override;
+  QString domXml() const override;
+  QString includeFile() const override;
+  bool isContainer() const override;
+  QString name() const override;
 
 };
 

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceBrowserSeekWidgetPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceBrowserSeekWidgetPlugin.h
@@ -29,11 +29,11 @@ qMRMLSequenceBrowserSeekWidgetPlugin
 public:
   qMRMLSequenceBrowserSeekWidgetPlugin(QObject *_parent = 0);
 
-  QWidget *createWidget(QWidget *_parent);
-  QString domXml() const;
-  QString includeFile() const;
-  bool isContainer() const;
-  QString name() const;
+  QWidget *createWidget(QWidget *_parent) override;
+  QString domXml() const override;
+  QString includeFile() const override;
+  bool isContainer() const override;
+  QString name() const override;
 
 };
 

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceBrowserToolBarPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceBrowserToolBarPlugin.h
@@ -29,12 +29,12 @@ qMRMLSequenceBrowserToolBarPlugin
 public:
   qMRMLSequenceBrowserToolBarPlugin(QObject *_parent = 0);
 
-  QWidget *createWidget(QWidget *_parent);
-  QString  domXml() const;
-  QIcon    icon() const;
-  QString  includeFile() const;
-  bool     isContainer() const;
-  QString  name() const;
+  QWidget *createWidget(QWidget *_parent) override;
+  QString  domXml() const override;
+  QIcon    icon() const override;
+  QString  includeFile() const override;
+  bool     isContainer() const override;
+  QString  name() const override;
 
 };
 

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsAbstractPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsAbstractPlugin.h
@@ -38,11 +38,11 @@ public:
 
   qSlicerSequencesModuleWidgetsAbstractPlugin();
   // Don't reimplement this method.
-  QString group() const;
+  QString group() const override;
   // You can reimplement these methods
-  virtual QIcon icon() const;
-  virtual QString toolTip() const;
-  virtual QString whatsThis() const;
+  QIcon icon() const override;
+  QString toolTip() const override;
+  QString whatsThis() const override;
 
 };
 

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsPlugin.h
@@ -46,7 +46,7 @@ class Q_SLICER_MODULE_SEQUENCES_WIDGETS_PLUGINS_EXPORT qSlicerSequenceBrowserMod
   Q_INTERFACES(QDesignerCustomWidgetCollectionInterface);
 
 public:
-  QList<QDesignerCustomWidgetInterface*> customWidgets() const
+  QList<QDesignerCustomWidgetInterface*> customWidgets() const override
     {
     QList<QDesignerCustomWidgetInterface *> plugins;
     plugins << new qMRMLSequenceBrowserPlayWidgetPlugin;

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.h
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.h
@@ -47,7 +47,7 @@ class Q_SLICER_MODULE_SEQUENCES_WIDGETS_EXPORT qMRMLSequenceBrowserPlayWidget
 public:
   typedef qMRMLWidget Superclass;
   qMRMLSequenceBrowserPlayWidget(QWidget *newParent = 0);
-  virtual ~qMRMLSequenceBrowserPlayWidget();
+  ~qMRMLSequenceBrowserPlayWidget() override;
 
   /// Add a keyboard shortcut for play/pause button
   void setPlayPauseShortcut(QString keySequence);

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserSeekWidget.h
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserSeekWidget.h
@@ -42,7 +42,7 @@ class Q_SLICER_MODULE_SEQUENCES_WIDGETS_EXPORT qMRMLSequenceBrowserSeekWidget
 public:
   typedef qMRMLWidget Superclass;
   qMRMLSequenceBrowserSeekWidget(QWidget *newParent = 0);
-  virtual ~qMRMLSequenceBrowserSeekWidget();
+  ~qMRMLSequenceBrowserSeekWidget() override;
 
   /// Get access to the internal slider widget.
   /// This allows fine-tuning of parameters such as page step.

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserToolBar.h
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserToolBar.h
@@ -49,7 +49,7 @@ public:
   /// Title is the name of the toolbar (can appear using right click on the toolbar area)
   qMRMLSequenceBrowserToolBar(const QString& title, QWidget* parent = 0);
   qMRMLSequenceBrowserToolBar(QWidget* parent = 0);
-  virtual ~qMRMLSequenceBrowserToolBar();
+  ~qMRMLSequenceBrowserToolBar() override;
 
 public slots:
   virtual void setMRMLScene(vtkMRMLScene* newScene);

--- a/Modules/Loadable/Sequences/qSlicerSequencesModule.h
+++ b/Modules/Loadable/Sequences/qSlicerSequencesModule.h
@@ -56,7 +56,7 @@ public:
 
   typedef qSlicerLoadableModule Superclass;
   explicit qSlicerSequencesModule(QObject *parent=0);
-  virtual ~qSlicerSequencesModule();
+  ~qSlicerSequencesModule() override;
 
   qSlicerGetTitleMacro(QTMODULE_TITLE);
 

--- a/Modules/Loadable/Sequences/qSlicerSequencesModuleWidget.h
+++ b/Modules/Loadable/Sequences/qSlicerSequencesModuleWidget.h
@@ -40,7 +40,7 @@ public:
 
   typedef qSlicerAbstractModuleWidget Superclass;
   qSlicerSequencesModuleWidget(QWidget *parent=0);
-  virtual ~qSlicerSequencesModuleWidget();
+  ~qSlicerSequencesModuleWidget() override;
 
   /// Set up the GUI from mrml when entering
   void enter() override;
@@ -88,7 +88,7 @@ protected:
   void setEnableWidgets(bool enable);
 
 public slots:
-  void setMRMLScene(vtkMRMLScene* scene);
+  void setMRMLScene(vtkMRMLScene* scene) override;
 
 protected slots:
   void activeBrowserNodeChanged(vtkMRMLNode* node);

--- a/Modules/Loadable/Sequences/qSlicerSequencesReader.h
+++ b/Modules/Loadable/Sequences/qSlicerSequencesReader.h
@@ -37,7 +37,7 @@ class qSlicerSequencesReader
 public:
   typedef qSlicerFileReader Superclass;
   qSlicerSequencesReader(vtkSlicerSequencesLogic* sequencesLogic = 0, QObject* parent = 0);
-  virtual ~qSlicerSequencesReader();
+  ~qSlicerSequencesReader() override;
 
   void setSequencesLogic(vtkSlicerSequencesLogic* sequencesLogic);
   vtkSlicerSequencesLogic* sequencesLogic()const;


### PR DESCRIPTION
Describe function overrides using the override keyword from C++11.

-----
https://stackoverflow.com/questions/39932391/virtual-override-or-both-c
When you override a function you don't technically need to write either virtual
or override.

The original base class declaration needs the keyword virtual to mark it as
virtual.

In the derived class the function is virtual by way of having the ¹same type as
the base class function.

However, an override can help avoid bugs by producing a compilation error when
the intended override isn't technically an override. For instance, the function
type isn't exactly like the base class function. Or that a maintenance of the
base class changes that function's type, e.g. adding a defaulted argument.

In the same way, a virtual keyword in the derived class can make such a bug
more subtle by ensuring that the function is still virtual in the further
derived classes.

So the general advice is,

Use virtual for the base class function declaration.  This is technically
necessary.

Use override (only) for a derived class' override.  This helps maintenance.
-----

Remove 'virtual' is implied when 'override' is specified, so remove the
redundant specification.

cd ${BLDDIR}
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-override  -header-filter=.* -fix