### PR TITLE
WIP: This workaround for old linux breaks new linux.

### DIFF
--- a/SuperBuild/python_configure_lsb_release_wrapper.cmake
+++ b/SuperBuild/python_configure_lsb_release_wrapper.cmake
@@ -1,3 +1,7 @@
+# This code causes Ubuntu 18.04 builds to fail
+# The lsb_release binary in the slicer tree
+# fails to build!
+if(OLD_LINUX_RELEASE_FIXUP)
 cmake_minimum_required(VERSION 3.13.4)
 
 foreach(varname IN ITEMS
@@ -25,3 +29,4 @@ ctkAppLauncherConfigureForExecutable(
   APPLICATION_EXECUTABLE ${LSB_RELEASE_EXECUTABLE}
   DESTINATION_DIR ${python_bin_dir}
   )
+endif()


### PR DESCRIPTION
This is a hack to fix problems building on Ubuntu 18.04.

I don't understand what the code is trying to do, but removing this "work-around" fixes builds on new ubuntu 18.04.

The `/usr/bin/lsb_release` uses python 3.6.9 by default in the standard unix prompt.  

```
head /usr/bin/lsb_release 
#!/usr/bin/python3 -Es
```

I think the problem is that the "work-around" uses `/usr/bin/python` which is 2.7

Hans
