### PR TITLE
COMP: Fix BRAINSTools compiler warning of deprecated feature

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -311,7 +311,7 @@ set(BRAINSTools_slicer_options
 
 Slicer_Remote_Add(BRAINSTools
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/Slicer/BRAINSTools.git
-  GIT_TAG 3fe08e96be8967945cab79451ffb21c0c5a83bf8 # slicer-2020-04-24-v5.2.0
+  GIT_TAG de71a695f605c7f17c52a168b35dce0231b62dd7 # slicer-2020-04-14-v5.2.0
   LICENSE_FILES "http://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"


### PR DESCRIPTION
Minor compiler warning addressed related to
implicit conversion of vnl_matrix.