### PR TITLE
ENH: Make qMRMLNodeComboBox node editing easier

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -326,8 +326,6 @@ void qSlicerMainWindowPrivate::setupUi(QMainWindow * mainWindow)
                    SLOT(setMRMLScene(vtkMRMLScene*)));
   QObject::connect(this->LayoutManager, SIGNAL(layoutChanged(int)),
                    q, SLOT(onLayoutChanged(int)));
-  QObject::connect(this->LayoutManager, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)),
-                   qSlicerApplication::application(), SLOT(openNodeModule(vtkMRMLNode*)));
 
   // TODO: When module will be managed by the layoutManager, this should be
   //       revisited.

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -317,6 +317,8 @@ void qSlicerCoreApplicationPrivate::init()
               q, SLOT(pauseRender()));
   q->qvtkConnect(this->AppLogic, vtkMRMLApplicationLogic::ResumeRenderEvent,
               q, SLOT(resumeRender()));
+  q->qvtkConnect(this->AppLogic, vtkSlicerApplicationLogic::EditNodeEvent,
+              q, SLOT(editNode(vtkObject*, void*, ulong)));
   q->qvtkConnect(this->AppLogic->GetUserInformation(), vtkCommand::ModifiedEvent,
     q, SLOT(onUserInformationModified()));
 

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -518,6 +518,10 @@ protected slots:
   void processAppLogicReadData();
   void processAppLogicWriteData();
 
+  /// Editing of a MRML node has been requested.
+  /// Implemented in qSlicerApplication.
+  virtual void editNode(vtkObject*, void*, unsigned long) {};
+
   /// Set the ReturnCode flag and call QCoreApplication::exit()
   void terminate(int exitCode = qSlicerCoreApplication::ExitSuccess);
 

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -1135,3 +1135,13 @@ bool qSlicerApplication::isCodePageUtf8()
   return true;
 #endif
 }
+
+//------------------------------------------------------------------------------
+void qSlicerApplication::editNode(vtkObject*, void* callData, unsigned long)
+{
+  vtkMRMLNode* node = reinterpret_cast<vtkMRMLNode*>(callData);
+  if (node)
+    {
+    this->openNodeModule(node);
+    }
+}

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -228,6 +228,11 @@ signals:
   /// \sa setRenderPaused
   void renderPaused(bool);
 
+protected slots:
+
+  /// Request editing of a MRML node
+  void editNode(vtkObject*, void*, unsigned long) override;
+
 protected:
   /// Reimplemented from qSlicerCoreApplication
   void handlePreApplicationCommandLineArguments() override;

--- a/Libs/MRML/Core/vtkMRMLInteractionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLInteractionNode.cxx
@@ -333,3 +333,10 @@ void vtkMRMLInteractionNode::SwitchToViewTransformMode()
   this->SetCurrentInteractionMode(vtkMRMLInteractionNode::ViewTransform);
   this->EndModify(disabledModify);
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLInteractionNode::EditNode(vtkMRMLNode* node)
+{
+  // Observers in qSlicerCoreApplication listen for this event
+  this->InvokeEvent(EditNodeEvent, node);
+}

--- a/Libs/MRML/Core/vtkMRMLInteractionNode.h
+++ b/Libs/MRML/Core/vtkMRMLInteractionNode.h
@@ -60,6 +60,7 @@ public:
       InteractionModeChangedEvent = 19001,
       InteractionModePersistenceChangedEvent,
       EndPlacementEvent,
+      EditNodeEvent,
     };
 
   /// Return a text string describing the mode
@@ -77,6 +78,10 @@ public:
 /// Enable/Disable Editing of Fibers
   vtkGetMacro(EnableFiberEdit, int);
   vtkSetMacro(EnableFiberEdit, int);
+
+  /// Request the application to display user interface
+  /// that allows editing of the node.
+  void EditNode(vtkMRMLNode* node);
 
 protected:
   vtkMRMLInteractionNode();

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -187,7 +187,8 @@ public:
   enum Events{
     RequestInvokeEvent = vtkCommand::UserEvent + 1,
     PauseRenderEvent = vtkCommand::UserEvent + 101,
-    ResumeRenderEvent
+    ResumeRenderEvent,
+    EditNodeEvent
   };
   /// Structure passed as calldata pointer in the RequestEvent invoked event.
   struct InvokeRequest{
@@ -231,6 +232,9 @@ public:
   /// \sa qSlicerApplication::setRenderPaused()
   virtual void ResumeRender();
 
+  /// Requests the application to show user interface for editing a node.
+  virtual void EditNode(vtkMRMLNode* node);
+
 protected:
 
   vtkMRMLApplicationLogic();
@@ -240,6 +244,8 @@ protected:
 
   void SetSelectionNode(vtkMRMLSelectionNode* );
   void SetInteractionNode(vtkMRMLInteractionNode* );
+
+  void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void* callData) override;
 
 private:
 

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLChartViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLChartViewControllerWidget.ui
@@ -45,7 +45,10 @@
         <bool>true</bool>
        </property>
        <property name="removeEnabled">
-        <bool>false</bool>
+        <bool>true</bool>
+       </property>
+       <property name="editEnabled">
+        <bool>true</bool>
        </property>
        <property name="renameEnabled">
         <bool>true</bool>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLPlotViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLPlotViewControllerWidget.ui
@@ -40,6 +40,9 @@
            <property name="renameEnabled">
             <bool>true</bool>
            </property>
+           <property name="editEnabled">
+            <bool>true</bool>
+           </property>
           </widget>
         </item>
         <item>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
@@ -64,6 +64,9 @@
      <property name="removeEnabled">
       <bool>false</bool>
      </property>
+     <property name="editEnabled">
+      <bool>true</bool>
+     </property>
      <property name="renameEnabled">
       <bool>true</bool>
      </property>
@@ -188,6 +191,9 @@
      </property>
      <property name="removeEnabled">
       <bool>false</bool>
+     </property>
+     <property name="editEnabled">
+      <bool>true</bool>
      </property>
      <property name="renameEnabled">
       <bool>true</bool>
@@ -325,6 +331,9 @@
      </property>
      <property name="removeEnabled">
       <bool>false</bool>
+     </property>
+     <property name="editEnabled">
+      <bool>true</bool>
      </property>
      <property name="renameEnabled">
       <bool>true</bool>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLTableViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLTableViewControllerWidget.ui
@@ -38,6 +38,9 @@
        <property name="removeEnabled">
         <bool>true</bool>
        </property>
+       <property name="editEnabled">
+        <bool>true</bool>
+       </property>
        <property name="renameEnabled">
         <bool>true</bool>
        </property>

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -381,9 +381,6 @@ QWidget* qMRMLLayoutSliceViewFactory::createViewFromNode(vtkMRMLAbstractViewNode
 
   this->sliceLogics()->AddItem(sliceWidget->sliceLogic());
 
-  QObject::connect(sliceWidget, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)),
-                   this->layoutManager(), SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)));
-
   return sliceWidget;
 }
 

--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.h
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.h
@@ -76,6 +76,14 @@ class QMRML_WIDGETS_EXPORT qMRMLNodeComboBox
   Q_PROPERTY(bool editEnabled READ editEnabled WRITE setEditEnabled)
   Q_PROPERTY(bool renameEnabled READ renameEnabled WRITE setRenameEnabled)
 
+  /// Node editing is requested via an interaction node in the scene.
+  /// This singleton tag identifies which interaction node should be used.
+  /// In most cases, it is not necessary to change the default value.
+  /// If the value is set to empty then only nodeAboutToBeEdited signal is invoked
+  /// but node editing is not requested via interaction node.
+  /// \sa nodeAboutToBeEdited
+  Q_PROPERTY(QString interactionNodeSingletonTag READ interactionNodeSingletonTag WRITE setInteractionNodeSingletonTag)
+
   Q_PROPERTY(bool selectNodeUponCreation READ selectNodeUponCreation WRITE setSelectNodeUponCreation)
   /// This property controls the name that is displayed for the None item.
   /// "None" by default.
@@ -157,12 +165,12 @@ public:
 
   /// return the number of nodes. it can be different from count()
   /// as count includes the "AddNode", "Remove Node"... items
-  int nodeCount()const;
+  Q_INVOKABLE int nodeCount()const;
 
   /// return the vtkMRMLNode* at the corresponding index. 0 if the index is
   /// invalid
   /// \sa nodeCount(), setCurrentNode(int)
-  vtkMRMLNode* nodeFromIndex(int index)const;
+  Q_INVOKABLE vtkMRMLNode* nodeFromIndex(int index)const;
 
   /// Return the currently selected node. 0 if no node is selected
   Q_INVOKABLE vtkMRMLNode* currentNode()const;
@@ -257,6 +265,9 @@ public:
   /// Also checks for action text that will be hidden by the default action
   /// texts and doesn't add it.
   Q_INVOKABLE virtual void addMenuAction(QAction *newAction);
+
+  virtual QString interactionNodeSingletonTag()const;
+  virtual void setInteractionNodeSingletonTag(const QString& tag);
 
 public slots:
   /// Set the scene the combobox listens to. The scene is observed and when new

--- a/Libs/MRML/Widgets/qMRMLNodeComboBox_p.h
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox_p.h
@@ -74,6 +74,7 @@ public:
   bool              RemoveEnabled;
   bool              EditEnabled;
   bool              RenameEnabled;
+  QString           InteractionNodeSingletonTag;
 
   QHash<QString, QString> NodeTypeLabels;
 

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -284,8 +284,6 @@ void qMRMLSliceControllerWidgetPrivate::setupPopupUi()
   //              this->actionSegmentationVisibility, SLOT(setEnabled(bool)));
   this->connect(this->SegmentSelectorWidget, SIGNAL(currentNodeChanged(bool)),
                 this->actionSegmentationOutlineFill, SLOT(setEnabled(bool)));
-  this->connect(this->SegmentSelectorWidget, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)),
-                q, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)));
   this->connect(this->SegmentSelectorWidget, SIGNAL(segmentSelectionChanged(QStringList)),
                 this, SLOT(onSegmentVisibilitySelectionChanged(QStringList)));
 
@@ -300,8 +298,6 @@ void qMRMLSliceControllerWidgetPrivate::setupPopupUi()
   //              this->actionLabelMapVisibility, SLOT(setEnabled(bool)));
   this->connect(this->LabelMapComboBox, SIGNAL(currentNodeChanged(bool)),
                 this->actionLabelMapOutline, SLOT(setEnabled(bool)));
-  this->connect(this->LabelMapComboBox, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)),
-                q, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)));
 
   // Connect Foreground layer selector
   this->connect(this->ForegroundComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
@@ -314,8 +310,6 @@ void qMRMLSliceControllerWidgetPrivate::setupPopupUi()
   //              this->actionForegroundVisibility, SLOT(setEnabled(bool)));
   this->connect(this->ForegroundComboBox, SIGNAL(currentNodeChanged(bool)),
                 this->actionForegroundInterpolation, SLOT(setEnabled(bool)));
-  this->connect(this->ForegroundComboBox, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)),
-                q, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)));
 
   // Connect Background layer selector
   this->connect(this->BackgroundComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
@@ -328,8 +322,6 @@ void qMRMLSliceControllerWidgetPrivate::setupPopupUi()
   //              this->actionBackgroundVisibility, SLOT(setEnabled(bool)));
   this->connect(this->BackgroundComboBox, SIGNAL(currentNodeChanged(bool)),
                 this->actionBackgroundInterpolation, SLOT(setEnabled(bool)));
-  this->connect(this->BackgroundComboBox, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)),
-                   q, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)));
 
   QObject::connect(q, SIGNAL(mrmlSceneChanged(vtkMRMLScene*)),
                    this->SegmentSelectorWidget, SLOT(setMRMLScene(vtkMRMLScene*)));

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
@@ -70,8 +70,6 @@ void qMRMLSliceWidgetPrivate::init()
           this, SLOT(setImageDataConnection(vtkAlgorithmOutput*)));
   connect(this->SliceController, SIGNAL(renderRequested()),
           this->SliceView, SLOT(scheduleRender()), Qt::QueuedConnection);
-  connect(this->SliceController, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)),
-          q, SIGNAL(nodeAboutToBeEdited(vtkMRMLNode*)));
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
This pull request makes "Edit current X" menu in MRML node selectors work, without the need for developers to implement a custom event handler.

Now it is enough to enable "editEnabled" property on the node selector to get a working "edit" menu item.