### PR TITLE
COMP: Fix OpenSSL -Wnonportable-include-path warning

### DIFF
--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -133,6 +133,17 @@ ExternalProject_Execute(${proj} \"configure\" sh config --with-zlib-lib=${_zlib_
         ${${proj}_DEPENDENCIES}
       )
 
+    # To address "-Wnonportable-include-path" warning, resolve "e_os2.h" symlink found
+    # in ${EP_SOURCE_DIR}/include/openssl.
+    # See https://github.com/Slicer/Slicer/issues/4875
+    ExternalProject_Add_Step(${proj} resolve_e_os2_symlink
+      COMMAND ${CMAKE_COMMAND}
+        -DOPENSSL_SOURCE_DIR:PATH=${EP_SOURCE_DIR}
+        -P ${Slicer_SOURCE_DIR}/SuperBuild/OpenSSL_resolve_e_os2_symlink.cmake
+      DEPENDEES configure
+      DEPENDERS build
+      )
+
     if(APPLE)
       ExternalProject_Add_Step(${proj} fix_rpath
         COMMAND install_name_tool -id ${EP_SOURCE_DIR}/libcrypto.dylib ${EP_SOURCE_DIR}/libcrypto.dylib

--- a/SuperBuild/OpenSSL_resolve_e_os2_symlink.cmake
+++ b/SuperBuild/OpenSSL_resolve_e_os2_symlink.cmake
@@ -1,0 +1,25 @@
+
+cmake_minimum_required(VERSION 3.13.4)
+
+foreach(varname IN ITEMS
+  OPENSSL_SOURCE_DIR
+  )
+  if("${${varname}}" STREQUAL "")
+    message(FATAL_ERROR "${varname} is empty")
+  endif()
+endforeach()
+
+set(include_dir "${OPENSSL_SOURCE_DIR}/include/openssl")
+
+if(NOT IS_SYMLINK "${include_dir}/e_os2.h")
+  return()
+endif()
+
+# Remove symlink
+file(REMOVE ${include_dir}/e_os2.h)
+
+# Copy real file into include directory
+file(COPY ${OPENSSL_SOURCE_DIR}/e_os2.h DESTINATION ${include_dir})
+
+# Remove original file
+file(REMOVE ${OPENSSL_SOURCE_DIR}/e_os2.h)


### PR DESCRIPTION
This commit resolves the symlink to e_os2.h header to address
the following compiler warning:

```
   In file included from /Users/johnsonhj/src/Slicer-build/curl/lib/urldata.h:79:
  Slicer-build/OpenSSL/include/openssl/pem.h:62:11: warning: non-portable path to file '<OpenSSL/e_os2.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
            ^~~~~~~~~~~~~~~~~
            <OpenSSL/e_os2.h>     <- What Slicer/Superbuild provided
```

See #4875

Co-authored-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>