### PR TITLE
WIP: Detect and prohibit symbolic links in build path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,15 @@ if(NOT DEFINED Slicer_VERSION_PATCH)
 endif()
 project(Slicer VERSION "${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}.${Slicer_VERSION_PATCH}")
 
+
+#-----------------------------------------------------------------------------
+# Slicer builds fail when build directory is a simlink
+get_filename_component(Slicer_BINARY_DIR_realdir "${Slicer_BINARY_DIR}" REALPATH)
+if( NOT "${Slicer_BINARY_DIR_realdir}" STREQUAL "${Slicer_BINARY_DIR}")
+  message(FATAL_ERROR "${Slicer_BINARY_DIR} must not be a symlinked path, configure with Slicer_BINARY_DIR:PATH=${Slicer_BINARY_DIR_realdir}")
+endif()
+
+
 #-----------------------------------------------------------------------------
 # Update CMake module path
 #------------------------------------------------------------------------------

--- a/SuperBuild/python_configure_lsb_release_wrapper.cmake
+++ b/SuperBuild/python_configure_lsb_release_wrapper.cmake
@@ -13,6 +13,11 @@ endforeach()
 find_package(CTKAppLauncher REQUIRED)
 
 get_filename_component(python_bin_dir "${PYTHON_REAL_EXECUTABLE}" PATH)
+get_filename_component(python_bin_realdir "${python_bin_dir}" REALPATH)
+if( NOT "${python_bin_dir}" STREQUAL "${python_bin_realdir}")
+  message(STATUS "${python_bin_dir}!=${python_bin_realdir}")
+  message(FATAL_ERROR "${PYTHON_REAL_EXECUTABLE} must not be a symlinked path, use PYTHON_REAL_EXECUTABLE:PATH=${python_bin_realdir}")
+endif()
 
 # Configure wrapper for lsb_release to support pip installation
 # of packages on system where "lsb_release" is it self implemented


### PR DESCRIPTION
Symbolic links in the build path are not supported
due to incorrect build-time relative path resolution
that is needed.  The relative paths are not stable
across the symlinks.