### PR TITLE
BUG: Fix crash in qMRMLSubjectHierarchyModel

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -1219,6 +1219,11 @@ void qMRMLSubjectHierarchyModel::updateSubjectHierarchyItemFromItemData(vtkIdTyp
     qCritical() << Q_FUNC_INFO << ": Invalid subject hierarchy";
     return;
     }
+  if (!item)
+    {
+    qCritical() << Q_FUNC_INFO << ": Invalid item";
+    return;
+    }
 
   qSlicerSubjectHierarchyAbstractPlugin* ownerPlugin =
     qSlicerSubjectHierarchyPluginHandler::instance()->getOwnerPluginForSubjectHierarchyItem(shItemID);


### PR DESCRIPTION
If a null QStandardItem* was passed to updateSubjectHierarchyItemFromItemData, it would cause a crash.
Fixed by adding a null-pointer check and an error message.