### PR TITLE
BUG: Add nullptr check to updateSubjectHierarchyItemFromItem

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -1156,6 +1156,12 @@ void qMRMLSubjectHierarchyModel::updateItemDataFromSubjectHierarchyItem(QStandar
 //------------------------------------------------------------------------------
 void qMRMLSubjectHierarchyModel::updateSubjectHierarchyItemFromItem(vtkIdType shItemID, QStandardItem* item)
 {
+  if (!item)
+    {
+    qCritical() << Q_FUNC_INFO << ": Invalid item";
+    return;
+    }
+
   //int wasModifying = node->StartModify(); //TODO: Add feature to item if there are performance issues
   this->updateSubjectHierarchyItemFromItemData(shItemID, item);
   //node->EndModify(wasModifying);


### PR DESCRIPTION
qMRMLSubjectHierarchyModel::updateSubjectHierarchyItemFromItem could cause a crash if it was called with a nullptr item argument.

Fixed by adding a nullptr check to the start of the function.