### PR TITLE
COMP: Update SurfaceToolbox to fix build error on MacOS

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -353,7 +353,7 @@ list_conditional_append(Slicer_BUILD_CompareVolumes Slicer_REMOTE_DEPENDENCIES C
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG f4ac8329d3e25fd36837499603d5170d63d985ab
+  GIT_TAG 4e0a9f96155eb510a5df2efe0923672e12762626
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Changes included:

```
$ git shortlog  f4ac832..4e0a9f9
Kyle Sunderland (1):
      COMP: Fix -Winconsistent-missing-override

Steve Pieper (1):
      COMP: return nullptr not false
```