### PR TITLE
COMP: Update SurfaceToolbox to fix warnings

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -353,7 +353,7 @@ list_conditional_append(Slicer_BUILD_CompareVolumes Slicer_REMOTE_DEPENDENCIES C
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG 4e0a9f96155eb510a5df2efe0923672e12762626
+  GIT_TAG ec6fe416b0db39d266b256bd9a2f735df2b006fa
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
List of changes:

```
$ git shortlog 4e0a9f961..ec6fe416b --no-merges
Jean-Christophe Fillion-Robin (8):
      STYLE: Update Simplify.h converting tabs to spaces
      COMP: Fix -Wsign-compare warnings in Simplify.h and Decimation.cxx
      COMP: Fix -Wunused-* warnings in Simplify.h
      COMP: Fix -Wparentheses warning in Simplify.h
      STYLE: Remove use of "loopi" macro in Simplify.h
      STYLE: Remove use of "loopk" macro in Simplify.h
      STYLE: Remove use of "static_cast" in Simplify.h
      STYLE: Remove use of "loopj" macro in Simplify.h
```