### PR TITLE
STYLE: Rename "ScalarBar" to "Color Scalar Bar" in the GUI

### DIFF
--- a/Modules/Loadable/Colors/Resources/UI/qSlicerColorsModuleWidget.ui
+++ b/Modules/Loadable/Colors/Resources/UI/qSlicerColorsModuleWidget.ui
@@ -195,7 +195,7 @@
    <item>
     <widget class="ctkCollapsibleButton" name="ScalarBarCollapsibleButton">
      <property name="text">
-      <string>Scalar Bar</string>
+      <string>Color Scalar Bar</string>
      </property>
      <property name="collapsed">
       <bool>true</bool>

--- a/Modules/Scripted/DataProbe/DataProbeLib/Resources/UI/settings.ui
+++ b/Modules/Scripted/DataProbe/DataProbeLib/Resources/UI/settings.ui
@@ -257,7 +257,7 @@
      <item>
       <widget class="ctkCollapsibleButton" name="scalarBarCollapsibleButton">
        <property name="text">
-        <string>ScalarBar</string>
+        <string>Color Scalar Bar</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_6">
         <item>


### PR DESCRIPTION
From https://discourse.slicer.org/t/renaming-scalar-bar-to-color-bar/11274

| DataProbe module Before | DataProbe module After |
|------------------------------|----------------------------|
|![dataprobe-module-scalar-bar](https://user-images.githubusercontent.com/15837524/80286687-d9aa8b00-86fa-11ea-959c-c572f06b2016.png)|![dataprobe-module-scalar-bar-2](https://user-images.githubusercontent.com/15837524/80286692-e0390280-86fa-11ea-95a2-f9585c522d57.png)|



| Colors module Before | Colors module After |
|-------------------------|------------------------|
|![color-module-scalar-bar](https://user-images.githubusercontent.com/15837524/80286696-ec24c480-86fa-11ea-82ad-3e86bc404b66.png)|![color-module-scalar-bar-2](https://user-images.githubusercontent.com/15837524/80286700-f050e200-86fa-11ea-8fdd-1bcd8514b396.png)|

