### PR TITLE
ENH: Always use filenames that user typed in save data dialog

### DIFF
--- a/Base/QTGUI/qSlicerSaveDataDialog_p.h
+++ b/Base/QTGUI/qSlicerSaveDataDialog_p.h
@@ -48,6 +48,8 @@ public:
   /// node IDs in the internal scene view scenes as well.
   static vtkMRMLNode* getNodeByID(char *id, vtkMRMLScene* scene);
 
+  void formatChanged(int row);
+
 public slots:
   void setDirectory(const QString& newDirectory);
   void selectModifiedSceneData();
@@ -67,6 +69,7 @@ protected slots:
   void onSceneFormatChanged();
   void enableNodes(bool);
   void saveSceneAsDataBundle();
+  void onItemChanged(QTableWidgetItem*);
 
 protected:
   enum ColumnType
@@ -132,14 +135,10 @@ class qSlicerFileNameItemDelegate : public QStyledItemDelegate
 public:
   typedef QStyledItemDelegate Superclass;
   qSlicerFileNameItemDelegate( QObject * parent = nullptr );
-  QWidget* createEditor( QWidget * parent,
-                                 const QStyleOptionViewItem & option,
-                                 const QModelIndex & index ) const override;
-  void setModelData(QWidget *editor,
-                            QAbstractItemModel *model,
-                            const QModelIndex &index) const override;
-  static QString fixupFileName(const QString& fileName, const QString& extension,
+  static QString forceFileNameExtension(const QString& fileName, const QString& extension,
                                vtkMRMLScene *mrmlScene, const QString &nodeID);
+  static QString forceFileNameValidCharacters(const QString& filename);
+
   /// Generate a regular expression that can ensure a filename has a valid
   /// extension.
   /// Example of supported extensions:


### PR DESCRIPTION
When user typed an invalid filename in save data dialog (such as just a filename base without extension or with an invalid extension) then the validator rejected it and user had to either forced to type the extension or revert to the original value. When user clicked on save after entering an invalid filename (without pressing enter or escape) then the filename was reverted to the original without warning to the user.

It was also not possible to choose a different file extension just by typing a filename with a different extension.

This commit fixes these problems and makes consistent with other software (Notepad, Word, Visual Studio Code, Gimp, Camtasia, Snagit):
- If a known file extension is entered but not the one that is selected in the listbox then the entered filename is used as is.
- If an unknown file extension is entered then the file extension selected in the listbox is appended to the entered filename.

See https://discourse.slicer.org/t/confusing-save-dialog-behavior/11251/15 for discussion.