### PR TITLE
BUG: Rename MainWindow File menu entry from "Exit" to "Quit"

### DIFF
--- a/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
+++ b/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
@@ -501,7 +501,10 @@
   </action>
   <action name="FileExitAction">
    <property name="text">
-    <string>E&amp;xit</string>
+    <string>Quit</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
    </property>
    <property name="toolTip">
     <string>Quit the application</string>


### PR DESCRIPTION
The menu entry allowing to exit the application is now consistently
named on all platforms.

Shortcut Ctrl+Q (or Command+Q) is also consistent across platforms.

Fixes #3517