### PR TITLE
BUG: Return GetCurvePoints in the correct coordinate system

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -46,6 +46,12 @@ class vtkTriangleFilter;
 ///
 /// Markups is intended to be used for manual marking/editing of point positions.
 ///
+/// Coordinate systems used:
+///   - Local: Current node's coordinate system where the position of the control and curve points are defined.
+///            Local coordinates can be converted to world by concatenating all parent transforms on the current node.
+///   - Surface: Model node's coordinate system where the polydata used for ShortestDistanceOnSurface pathfinding is defined.
+///            Surface coordinates can be converted to world by concatenating all parent transforms on the surface node.
+///   - World: Patient coordinate system (RAS)
 /// \ingroup Slicer_QtModules_Markups
 class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsCurveNode : public vtkMRMLMarkupsNode
 {
@@ -210,7 +216,7 @@ public:
 protected:
   vtkSmartPointer<vtkCleanPolyData> CleanFilter;
   vtkSmartPointer<vtkTriangleFilter> TriangleFilter;
-  vtkSmartPointer<vtkTransformPolyDataFilter> SurfaceToWorldTransformer;
+  vtkSmartPointer<vtkTransformPolyDataFilter> SurfaceToLocalTransformer;
   vtkSmartPointer<vtkArrayCalculator> SurfaceScalarCalculator;
   vtkSmartPointer<vtkPassThroughFilter> PassThroughFilter;
   const char* ActiveScalar;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -78,13 +78,8 @@ vtkMRMLMarkupsNode::vtkMRMLMarkupsNode()
   vtkNew<vtkPoints> curveInputPoints;
   this->CurveInputPoly->SetPoints(curveInputPoints);
 
-  this->CurveInputPolyToWorldTransform = vtkSmartPointer<vtkGeneralTransform>::New();
-  this->CurveInputPolyToWorldTransformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
-  this->CurveInputPolyToWorldTransformer->SetInputData(this->CurveInputPoly);
-  this->CurveInputPolyToWorldTransformer->SetTransform(this->CurveInputPolyToWorldTransform);
-
   this->CurveGenerator = vtkSmartPointer<vtkCurveGenerator>::New();
-  this->CurveGenerator->SetInputConnection(this->CurveInputPolyToWorldTransformer->GetOutputPort());
+  this->CurveGenerator->SetInputData(this->CurveInputPoly);
   this->CurveGenerator->SetCurveTypeToLinearSpline();
   this->CurveGenerator->SetNumberOfPointsPerInterpolatingSegment(1);
   this->CurveGenerator->AddObserver(vtkCommand::ModifiedEvent, this->MRMLCallbackCommand);
@@ -92,8 +87,7 @@ vtkMRMLMarkupsNode::vtkMRMLMarkupsNode()
   this->CurvePolyToWorldTransform = vtkSmartPointer<vtkGeneralTransform>::New();
   this->CurvePolyToWorldTransformer = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
   this->CurvePolyToWorldTransformer->SetInputConnection(this->CurveGenerator->GetOutputPort());
-  //this->CurvePolyToWorldTransformer->SetTransform(this->CurvePolyToWorldTransform);
-  this->CurvePolyToWorldTransformer->SetTransform(vtkSmartPointer<vtkGeneralTransform>::New());
+  this->CurvePolyToWorldTransformer->SetTransform(this->CurvePolyToWorldTransform);
 
   this->CurveCoordinateSystemGeneratorWorld = vtkSmartPointer<vtkFrenetSerretFrame>::New();
   // Curve coordinate system is computed at the very end of the pipeline so that it is only computed
@@ -229,7 +223,6 @@ void vtkMRMLMarkupsNode::ProcessMRMLEvents(vtkObject *caller,
 {
   if (caller != nullptr && event == vtkMRMLTransformableNode::TransformModifiedEvent)
     {
-    vtkMRMLTransformNode::GetTransformBetweenNodes(this->GetParentTransformNode(), nullptr, this->CurveInputPolyToWorldTransform);
     vtkMRMLTransformNode::GetTransformBetweenNodes(this->GetParentTransformNode(), nullptr, this->CurvePolyToWorldTransform);
     this->UpdateInteractionHandleToWorldMatrix();
     this->UpdateMeasurements();
@@ -617,11 +610,6 @@ int vtkMRMLMarkupsNode::GetNthControlPointPositionWorld(int pointIndex, double w
     {
     return 0;
     }
-/*
-  this->CurvePolyToWorldTransformer->Update();
-  vtkPoints* pointsWorld = this->CurvePolyToWorldTransformer->GetOutput()->GetPoints();
-  pointsWorld->GetPoint(pointIndex, worldxyz);
-*/
   this->TransformPointToWorld(controlPoint->Position, worldxyz);
   return 1;
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -637,9 +637,6 @@ protected:
   // Line cells connect all points into a curve.
   vtkSmartPointer<vtkPolyData> CurveInputPoly;
 
-  vtkSmartPointer<vtkTransformPolyDataFilter> CurveInputPolyToWorldTransformer;
-  vtkSmartPointer<vtkGeneralTransform> CurveInputPolyToWorldTransform;
-
   vtkSmartPointer<vtkTransformPolyDataFilter> CurvePolyToWorldTransformer;
   vtkSmartPointer<vtkGeneralTransform> CurvePolyToWorldTransform;
 


### PR DESCRIPTION
Due to changes in the input of the curve generator, curve points were being returned in the world coordinate system. Fixed by passing the input points in the local coordinate system.
This also ensures that the output curve transform is up-to-date if the parent transform node changes.