### PR TITLE
ENH: Texts module with monospaced font

### DIFF
--- a/Modules/Loadable/Texts/Widgets/Resources/UI/qMRMLTextWidget.ui
+++ b/Modules/Loadable/Texts/Widgets/Resources/UI/qMRMLTextWidget.ui
@@ -15,7 +15,13 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTextEdit" name="TextEdit"/>
+    <widget class="QTextEdit" name="TextEdit">
+     <property name="font">
+      <font>
+       <family>Courier</family>
+      </font>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="ButtonLayout">


### PR DESCRIPTION
Monospaced font for `qMRMLTextEditWidget` as suggested in #4925. This is done by [setting the font family to _Courier_](https://forum.qt.io/topic/35999/solved-qplaintextedit-how-to-change-the-font-to-be-monospaced/5).

**Question:** `QTextEdit` has a property `acceptRichText` which defaults to _true_. Therefore, if you paste formatted text into our widget, the content will have formatting too. Should we set `acceptRichText` to _false_ to make clear that the data is plain text? (The function `void qMRMLTextWidget::updateMRMLFromWidget()` converts content to plain text).
