### PR TITLE
ENH: Add absolute way to specify markups curve and line thickness

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -88,7 +88,9 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   // Set active component defaults for mouse (identified by empty string)
   this->ActiveComponents[GetDefaultContextName()] = ComponentInfo();
 
+  this->CurveLineSizeMode = vtkMRMLMarkupsDisplayNode::UseLineThickness;
   this->LineThickness = 0.2;
+  this->LineDiameter = 1.0;
 
   // Line color variables
   this->LineColorFadingStart = 1.;
@@ -130,7 +132,9 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(sliceProjectionOutlinedBehindSlicePlane, SliceProjectionOutlinedBehindSlicePlane);
   vtkMRMLWriteXMLVectorMacro(sliceProjectionColor, SliceProjectionColor, double, 3);
   vtkMRMLWriteXMLFloatMacro(sliceProjectionOpacity, SliceProjectionOpacity);
+  vtkMRMLWriteXMLEnumMacro(curveLineSizeMode, CurveLineSizeMode);
   vtkMRMLWriteXMLFloatMacro(lineThickness, LineThickness);
+  vtkMRMLWriteXMLFloatMacro(lineDiameter, LineDiameter);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingStart, LineColorFadingStart);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
@@ -160,7 +164,9 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(sliceProjectionOutlinedBehindSlicePlane, SliceProjectionOutlinedBehindSlicePlane);
   vtkMRMLReadXMLVectorMacro(sliceProjectionColor, SliceProjectionColor, double, 3);
   vtkMRMLReadXMLFloatMacro(sliceProjectionOpacity, SliceProjectionOpacity);
+  vtkMRMLReadXMLEnumMacro(curveLineSizeMode, CurveLineSizeMode);
   vtkMRMLReadXMLFloatMacro(lineThickness, LineThickness);
+  vtkMRMLReadXMLFloatMacro(lineDiameter, LineDiameter);
   vtkMRMLReadXMLFloatMacro(lineColorFadingStart, LineColorFadingStart);
   vtkMRMLReadXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLReadXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
@@ -218,7 +224,9 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   vtkMRMLCopyBooleanMacro(SliceProjectionOutlinedBehindSlicePlane);
   vtkMRMLCopyVectorMacro(SliceProjectionColor, double, 3);
   vtkMRMLCopyFloatMacro(SliceProjectionOpacity);
+  vtkMRMLCopyEnumMacro(CurveLineSizeMode);
   vtkMRMLCopyFloatMacro(LineThickness);
+  vtkMRMLCopyFloatMacro(LineDiameter);
   vtkMRMLCopyFloatMacro(LineColorFadingStart);
   vtkMRMLCopyFloatMacro(LineColorFadingEnd);
   vtkMRMLCopyFloatMacro(LineColorFadingSaturation);
@@ -320,6 +328,51 @@ const char* vtkMRMLMarkupsDisplayNode::GetSnapModeAsString(int id)
 }
 
 //----------------------------------------------------------------------------
+const char* vtkMRMLMarkupsDisplayNode::GetCurveLineSizeModeAsString()
+{
+  return vtkMRMLMarkupsDisplayNode::GetCurveLineSizeModeAsString(this->CurveLineSizeMode);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsDisplayNode::SetCurveLineSizeModeFromString(const char* modeString)
+{
+  this->SetCurveLineSizeMode(vtkMRMLMarkupsDisplayNode::GetCurveLineSizeModeFromString(modeString));
+}
+
+//-----------------------------------------------------------
+int vtkMRMLMarkupsDisplayNode::GetCurveLineSizeModeFromString(const char* name)
+{
+  if (name == nullptr)
+    {
+    // invalid name
+    return 0;
+    }
+  for (int ii = 0; ii < CurveLineSizeMode_Last; ii++)
+    {
+    if (strcmp(name, GetCurveLineSizeModeAsString(ii)) == 0)
+      {
+      // found a matching name
+      return ii;
+      }
+    }
+  // unknown name
+  return -1;
+}
+
+//---------------------------------------------------------------------------
+const char* vtkMRMLMarkupsDisplayNode::GetCurveLineSizeModeAsString(int id)
+{
+  switch (id)
+  {
+  case UseLineThickness: return "UseLineThickness";
+  case UseLineDiameter: return "UseLineDiameter";
+  default:
+    // invalid id
+    return "Invalid";
+  }
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
@@ -345,7 +398,9 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
     }
   os << "\n";
   }
+  vtkMRMLPrintEnumMacro(CurveLineSizeMode);
   vtkMRMLPrintFloatMacro(LineThickness);
+  vtkMRMLPrintFloatMacro(LineDiameter);
   vtkMRMLPrintFloatMacro(LineColorFadingStart);
   vtkMRMLPrintFloatMacro(LineColorFadingEnd);
   vtkMRMLPrintFloatMacro(LineColorFadingSaturation);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -40,8 +40,8 @@ class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsDisplayNode : public 
 {
 public:
   static vtkMRMLMarkupsDisplayNode *New();
-  vtkTypeMacro ( vtkMRMLMarkupsDisplayNode,vtkMRMLDisplayNode );
-  void PrintSelf ( ostream& os, vtkIndent indent ) override;
+  vtkTypeMacro(vtkMRMLMarkupsDisplayNode,vtkMRMLDisplayNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   //--------------------------------------------------------------------------
   // MRMLNode methods
@@ -60,14 +60,13 @@ public:
   vtkMRMLCopyContentMacro(vtkMRMLMarkupsDisplayNode);
 
   /// Get node XML tag name (like Volume, Markups)
-  const char* GetNodeTagName() override {return "MarkupsDisplay";};
+  const char* GetNodeTagName() override { return "MarkupsDisplay"; };
 
   /// Finds the storage node and read the data
-  void UpdateScene(vtkMRMLScene *scene) override;
+  void UpdateScene(vtkMRMLScene* scene) override;
 
   /// Alternative method to propagate events generated in Display nodes
-  void ProcessMRMLEvents(vtkObject * /*caller*/,
-                         unsigned long /*event*/, void * /*callData*/ ) override;
+  void ProcessMRMLEvents(vtkObject* /*caller*/, unsigned long /*event*/, void* /*callData*/ ) override;
 
   /// Convenience function for getting the displayable markups node
   vtkMRMLMarkupsNode* GetMarkupsNode();
@@ -160,7 +159,7 @@ public:
   vtkBooleanMacro(PropertiesLabelVisibility, bool);
   //@}
 
-  /// Defines how points are placed and moved in views
+  /// Define how points are placed and moved in views
   enum SnapModes
     {
     SnapModeUnconstrained, //< point is moved independently from displayed objects in 3D views (e.g., in parallel with camera plane)
@@ -203,7 +202,7 @@ public:
 
   /// Return a string representing the glyph type, set it from a string
   const char* GetGlyphTypeAsString();
-  void SetGlyphTypeFromString(const char *glyphString);
+  void SetGlyphTypeFromString(const char* glyphString);
 
   static const char* GetGlyphTypeAsString(int g);
   static int GetGlyphTypeFromString(const char*);
@@ -276,31 +275,58 @@ public:
   vtkSetClampMacro(SliceProjectionOpacity, double, 0.0, 1.0);
   vtkGetMacro(SliceProjectionOpacity, double);
 
-  /// Configures line thickness.
+  /// Way of determining line radius of markup curves. Default is relative thickness
+  /// Current mode is stored in \sa CurveLineSizeMode
+  enum CurveLineSizeModes
+    {
+    UseLineThickness = 0,
+    UseLineDiameter,
+    CurveLineSizeMode_Last // insert new types above this line
+    };
+
+  /// Configure mode of determining line radius of markup curves.
+  /// Default is relative thickness. Available modes in \sa CurveLineSizeModes
+  vtkSetMacro(CurveLineSizeMode, int);
+  vtkGetMacro(CurveLineSizeMode, int);
+  const char* GetCurveLineSizeModeAsString();
+  void SetCurveLineSizeModeFromString(const char* modeString);
+  static const char* GetCurveLineSizeModeAsString(int mode);
+  static int GetCurveLineSizeModeFromString(const char*);
+
+  /// Configure line thickness
   /// Thickness is specified relative to markup point size
   /// (1.0 means line diameter is the same as diameter of point glyphs).
+  /// This relative value is used if \sa CurveLineSizeMode is UseLineThickness
+  /// For absolute control of thickness, \sa LineDiameter should be used.
   vtkGetMacro(LineThickness, double);
   vtkSetMacro(LineThickness, double);
 
-  /// Configures the line color fading appearance
-  /// Default value = 1.0
-  vtkGetMacro (LineColorFadingStart, double);
-  vtkSetMacro (LineColorFadingStart, double);
+  /// Configure line diameter
+  /// Diameter is specified in absolute mm value
+  /// This absolute value is used if \sa CurveLineSizeMode is UseLineDiameter
+  /// For relative control of diameter, \sa LineThickness should be used.
+  vtkGetMacro(LineDiameter, double);
+  vtkSetMacro(LineDiameter, double);
 
-  /// Configures the line color fading appearance
+  /// Configure the line color fading appearance
+  /// Default value = 1.0
+  vtkGetMacro(LineColorFadingStart, double);
+  vtkSetMacro(LineColorFadingStart, double);
+
+  /// Configure the line color fading appearance
   /// Default value = 10.0
-  vtkGetMacro (LineColorFadingEnd, double);
-  vtkSetMacro (LineColorFadingEnd, double);
+  vtkGetMacro(LineColorFadingEnd, double);
+  vtkSetMacro(LineColorFadingEnd, double);
 
   /// Configures the line color fading appearance
   /// Default value = 1.0
-  vtkSetClampMacro (LineColorFadingSaturation, double, 0.0, 1.0);
-  vtkGetMacro (LineColorFadingSaturation, double);
+  vtkSetClampMacro(LineColorFadingSaturation, double, 0.0, 1.0);
+  vtkGetMacro(LineColorFadingSaturation, double);
 
   /// Configures the line color fading appearance
   /// Default value = 0.0
-  vtkSetClampMacro (LineColorFadingHueOffset, double, 0.0, 1.0);
-  vtkGetMacro (LineColorFadingHueOffset, double);
+  vtkSetClampMacro(LineColorFadingHueOffset, double, 0.0, 1.0);
+  vtkGetMacro(LineColorFadingHueOffset, double);
 
   /// Set the line color node ID used for the projection on the line actors on the 2D viewers.
   /// Setting a line color node allows to define any arbitrary color mapping.
@@ -351,7 +377,10 @@ protected:
   static const char* LineColorNodeReferenceRole;
   static const char* LineColorNodeReferenceMRMLAttributeName;
 
+  int CurveLineSizeMode;
   double LineThickness;
+  double LineDiameter;
+
   double LineColorFadingStart;
   double LineColorFadingEnd;
   double LineColorFadingSaturation;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.cxx
@@ -213,8 +213,10 @@ void vtkSlicerAngleRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
 
   // Update lines display properties
 
-  this->TubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
-  this->ArcTubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+  double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
+    this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
+  this->TubeFilter->SetRadius(diameter * 0.5);
+  this->ArcTubeFilter->SetRadius(diameter * 0.5);
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() >= 2);
   this->ArcActor->SetVisibility(markupsNode->GetNumberOfControlPoints() == 3);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
@@ -196,8 +196,10 @@ void vtkSlicerAngleRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
   this->UpdateRelativeCoincidentTopologyOffsets(this->ArcMapper);
 
-  this->TubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
-  this->ArcTubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+  double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
+    this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
+  this->TubeFilter->SetRadius(diameter * 0.5);
+  this->ArcTubeFilter->SetRadius(diameter * 0.5);
 
   bool lineVisibility = this->GetAllControlPointsVisible();
 
@@ -260,14 +262,16 @@ int vtkSlicerAngleRepresentation3D::RenderOpaqueGeometry(
 {
   int count=0;
   count = this->Superclass::RenderOpaqueGeometry(viewport);
+  double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
+    this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
   if (this->LineActor->GetVisibility())
     {
-    this->TubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+    this->TubeFilter->SetRadius(diameter * 0.5);
     count += this->LineActor->RenderOpaqueGeometry(viewport);
     }
   if (this->ArcActor->GetVisibility())
     {
-    this->ArcTubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+    this->ArcTubeFilter->SetRadius(diameter * 0.5);
     count += this->ArcActor->RenderOpaqueGeometry(viewport);
     }
   if (this->TextActor->GetVisibility())

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
@@ -101,7 +101,9 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
 
   // Line display
 
-  this->TubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+  double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
+    this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
+  this->TubeFilter->SetRadius(diameter * 0.5);
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() >= 2);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
@@ -88,7 +88,9 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
 
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
 
-  this->TubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+  double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
+    this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
+  this->TubeFilter->SetRadius(diameter * 0.5);
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() >= 2);
 
@@ -170,7 +172,9 @@ int vtkSlicerCurveRepresentation3D::RenderOpaqueGeometry(
   count = this->Superclass::RenderOpaqueGeometry(viewport);
   if (this->LineActor->GetVisibility())
     {
-    this->TubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+    double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
+      this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
+    this->TubeFilter->SetRadius(diameter * 0.5);
     count += this->LineActor->RenderOpaqueGeometry(viewport);
     }
   return count;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
@@ -96,7 +96,9 @@ void vtkSlicerLineRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
 
   // Line display
 
-  this->TubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+  double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
+    this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
+  this->TubeFilter->SetRadius(diameter * 0.5);
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() == 2);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -89,7 +89,9 @@ int vtkSlicerLineRepresentation3D::RenderOpaqueGeometry(
   count = this->Superclass::RenderOpaqueGeometry(viewport);
   if (this->LineActor->GetVisibility())
     {
-    this->TubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+    double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
+      this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
+    this->TubeFilter->SetRadius(diameter * 0.5);
     count += this->LineActor->RenderOpaqueGeometry(viewport);
     }
   return count;
@@ -159,7 +161,9 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
 
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
 
-  this->TubeFilter->SetRadius(this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() * 0.5);
+  double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
+    this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
+  this->TubeFilter->SetRadius(diameter * 0.5);
 
   this->LineActor->SetVisibility(this->GetAllControlPointsVisible());
   int controlPointType = Active;


### PR DESCRIPTION
Curve diameter so far could not be set independently form markup control point diameter, but to use curves to show e.g. intravascular catheter with specific diameter, we need the ability to set the displayed curve diameter to an absolute value.

We also need to keep the ability to specify the size relative to the markups size, because for some other use cases that is the preferable option, so we have similar options for this as for glyph sizing:
- LineThickness (already existed, size relative to glyph)
- LineDiameter (new double value, absolute value in length unit, such as mm)
- CurveLineRadiusMode (enum: UseLineThickness and UseLineDiameter for now, but later we may add more options, such as vary radius according to scalar value associated with control points)