### PR TITLE
COMP: Update VTK to fix build with Qt 5.15.0

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -126,7 +126,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
 set(_git_tag)
 if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "8")
-  set(_git_tag "dd7e051af68cfbf3675e411494af7169fc7d5618") # slicer-v9.0.0-2020-05-05-987ae267
+  set(_git_tag "a81d1af0825b26946f05f0af9451e993489e801b") # slicer-v9.0.0-2020-05-05-987ae267
 else()
   message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
 endif()


### PR DESCRIPTION
List of VTK changes:

$ git shortlog --no-merges dd7e051..a81d1af
Andrew J. P. Maclean (1):
      [backport MR-6943] Qt 5.15 needs the include file QPainterPath