### PR TITLE
COMP: Update minimum required CMAKE_OSX_DEPLOYMENT_TARGET to 10.13

### DIFF
--- a/CMake/SlicerDashboardScript.TEMPLATE.cmake
+++ b/CMake/SlicerDashboardScript.TEMPLATE.cmake
@@ -34,7 +34,7 @@ dashboard_set(WITH_DOCUMENTATION  FALSE)
 dashboard_set(Slicer_BUILD_CLI    ON)
 dashboard_set(Slicer_USE_PYTHONQT ON)
 
-dashboard_set(QT_VERSION          "5.10.0")
+dashboard_set(QT_VERSION          "5.15.0")
 dashboard_set(Qt5_DIR             "${DASHBOARDS_DIR}/Support/Qt${QT_VERSION}/${QT_VERSION}/gcc_64/lib/cmake/Qt5")
 
 #   Source directory : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>

--- a/CMake/SlicerDashboardScript.TEMPLATE.cmake
+++ b/CMake/SlicerDashboardScript.TEMPLATE.cmake
@@ -19,7 +19,7 @@ dashboard_set(Slicer_RELEASE_TYPE   "Experimental")   # (E)xperimental, (P)revie
 dashboard_set(WITH_PACKAGES         FALSE)            # Enable to generate packages
 dashboard_set(GIT_TAG               "master")         # Specify a tag for Stable release
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "g++-X.Y.Z")      # Used only to set the build name

--- a/CMake/SlicerInitializeOSXVariables.cmake
+++ b/CMake/SlicerInitializeOSXVariables.cmake
@@ -64,7 +64,7 @@ if(APPLE)
   endif()
 
   # Starting with 10.9, libc++ replaces libstdc++ as the default runtime.
-  set(required_deployment_target "10.11")
+  set(required_deployment_target "10.13")
 
   if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS ${required_deployment_target})
     message(FATAL_ERROR "CMAKE_OSX_DEPLOYMENT_TARGET ${CMAKE_OSX_DEPLOYMENT_TARGET} must be ${required_deployment_target} or greater.")

--- a/Docs/user_guide/getting_started.md
+++ b/Docs/user_guide/getting_started.md
@@ -17,8 +17,7 @@ GPU: Graphics must support minimum OpenGL 3.2. Integrated graphics card is suffi
 
 ### Recommended operating system versions
 - Windows 10, 64-bit
-- Mac OS X Lion
-  - On Mac OS X Maverick - Make sure to install this update: http://support.apple.com/kb/DL1754
+- macOS Catalina
 - Linux: recent versions of popular distributions should work. Ubuntu and Fedora are the most widely used distribution among the developers. The SlicerPreview nightly build system runs CentOS 7.
 
 32 bit versus 64 bit: Many clinical research tasks, such as processing of large CT or MR volumetric datasets, require more memory than can be accommodated with a 32 bit program. Therefore, we only make 64-bit Slicer versions available. Developers can build 32-bit version on their own if they need to run Slicer on a 32-bit operating system.

--- a/Docs/user_guide/getting_started.md
+++ b/Docs/user_guide/getting_started.md
@@ -17,7 +17,7 @@ GPU: Graphics must support minimum OpenGL 3.2. Integrated graphics card is suffi
 
 ### Recommended operating system versions
 - Windows 10, 64-bit
-- macOS Catalina
+- macOS Catalina (MacOS High Sierra or later required)
 - Linux: recent versions of popular distributions should work. Ubuntu and Fedora are the most widely used distribution among the developers. The SlicerPreview nightly build system runs CentOS 7.
 
 32 bit versus 64 bit: Many clinical research tasks, such as processing of large CT or MR volumetric datasets, require more memory than can be accommodated with a 32 bit program. Therefore, we only make 64-bit Slicer versions available. Developers can build 32-bit version on their own if they need to run Slicer on a 32-bit operating system.

--- a/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
+++ b/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
@@ -29,7 +29,7 @@ dashboard_set(CTEST_BUILD_FLAGS     "")               # Use multiple CPU cores t
 dashboard_set(CTEST_BUILD_CONFIGURATION "Release")
 dashboard_set(EXTENSIONS_BUILDSYSTEM_TESTING FALSE)   # If enabled, build <Slicer_SOURCE_DIR>/Extensions/*.s4ext
 
-dashboard_set(QT_VERSION            "5.10.0")         # Used only to set the build name
+dashboard_set(QT_VERSION            "5.15.0")         # Used only to set the build name
 
 #   Slicer_SOURCE_DIR: <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>
 #   Slicer_DIR       : <DASHBOARDS_DIR>/<Slicer_DASHBOARD_SUBDIR>/<Slicer_DIRECTORY_BASENAME>-<Slicer_DIRECTORY_IDENTIFIER>-build

--- a/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
+++ b/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake
@@ -18,7 +18,7 @@ dashboard_set(SCRIPT_MODE           "Experimental")   # Experimental, Continuous
 dashboard_set(Slicer_RELEASE_TYPE   "Experimental")   # (E)xperimental, (P)review or (S)table
 dashboard_set(EXTENSIONS_INDEX_BRANCH "master")       # "master", X.Y, ...
 if(APPLE)
-  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.11")
+  dashboard_set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13")
 endif()
 dashboard_set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 dashboard_set(COMPILER              "g++-X.Y.Z")      # Used only to set the build name


### PR DESCRIPTION
This is for work https://github.com/Slicer/DashboardScripts/pull/27 which updates the factory macOS build to use Qt 5.15.0.

Deployment target >= 10.13 is the one officially supported by Qt 5.15. See [Qt 5.15 supported platforms](https://doc-snapshots.qt.io/qt5-5.15/supported-platforms.html).

This will support the following macOS versions:
- 10.15: Catalina (2019)
- 10.14: Mojave (2018)
- 10.13: High Sierra (2017)

The last forum discussion about updating minimum osx deployment target can be found [here](https://discourse.slicer.org/t/poll-which-version-of-macos-do-you-use-to-run-slicer/6055).

---------------------------
macOS 10.13 High Sierra is compatible with the following hardware ([source](https://support.apple.com/en-us/HT208969)):
- MacBook introduced in late 2009 or later
- MacBook Air introduced in late 2010 or later
- MacBook Pro introduced in mid 2010 or later
- Mac mini introduced in mid 2010 or later
- iMac introduced in late 2009 or later
- Mac Pro introduced in mid 2010 or later

According to https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide as of April 2020 this would mean there would be support for 84.23% of Mac devices worldwide.