### PR TITLE
ENH: Add FolderDisplayOverrideAllowed support for volume rendering

### DIFF
--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -29,6 +29,7 @@
 
 // MRML includes
 #include "vtkMRMLAnnotationROINode.h"
+#include "vtkMRMLFolderDisplayNode.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLScalarVolumeNode.h"
 #include "vtkMRMLTransformNode.h"
@@ -331,6 +332,15 @@ bool vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::UseDisplayNode(vtkMR
 //---------------------------------------------------------------------------
 bool vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::IsVisible(vtkMRMLVolumeRenderingDisplayNode* displayNode)
 {
+  if (displayNode && displayNode->GetFolderDisplayOverrideAllowed())
+    {
+    vtkMRMLDisplayableNode* displayableNode = displayNode->GetDisplayableNode();
+    if (!vtkMRMLFolderDisplayNode::GetHierarchyVisibility(displayableNode))
+      {
+      return false;
+      }
+    }
+
   return displayNode && displayNode->GetVisibility() && displayNode->GetVisibility3D()
     && displayNode->GetVisibility(this->External->GetMRMLViewNode()->GetID())
     && displayNode->GetOpacity() > 0;


### PR DESCRIPTION
Volume rendering display nodes did not check subject hierarchy visibility if FolderDisplayOverrideAllowed was enabled.

This changes the vtkMRMLVolumeRenderingDisplayableManager to show/hide the volume rendering display node based on subject hierarchy when FolderDisplayOverrideAllowed is true.