### PR TITLE
BUG: unset cursor on scene close in slice views

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
@@ -94,6 +94,12 @@ void qMRMLSliceWidgetPrivate::endProcessing()
 }
 
 // --------------------------------------------------------------------------
+void qMRMLSliceWidgetPrivate::endCloseScene()
+{
+    this->SliceView->unsetViewCursor();
+}
+
+// --------------------------------------------------------------------------
 void qMRMLSliceWidgetPrivate::setImageDataConnection(vtkAlgorithmOutput * imageDataConnection)
 {
   //qDebug() << "qMRMLSliceWidgetPrivate::setImageDataConnection";
@@ -134,6 +140,10 @@ void qMRMLSliceWidget::setMRMLScene(vtkMRMLScene* newScene)
   d->qvtkReconnect(
     this->mrmlScene(), newScene,
     vtkMRMLScene::EndBatchProcessEvent, d, SLOT(endProcessing()));
+
+  d->qvtkReconnect(
+      this->mrmlScene(), newScene,
+      vtkMRMLScene::EndCloseEvent, d, SLOT(endCloseScene()));
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget_p.h
@@ -66,6 +66,7 @@ public slots:
   void setSliceViewSize(const QSize& size);
   void resetSliceViewSize();
   void endProcessing();
+  void endCloseScene();
   /// Set the image data to the slice view
   void setImageDataConnection(vtkAlgorithmOutput * imageDataConnection);
 


### PR DESCRIPTION
This fixes the following issue:
 - Start to edit a segmentation by painting in a slice
 - Close the scene
 -> The cursor in the Slice view is still showing the Paint cursor even though you're not painting anymore.

Note: This fix should probably be propagated to the 3D view and any other view that may have cursor change (maybe Chart view ?).
