### PR TITLE
ENH: Update SurfaceToolbox

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -353,7 +353,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG 8030089352a92b61327bc121516e3bdaa7cd54e1
+  GIT_TAG 090223059af483faec8fc235c89ad0014045d1b9
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
List of changes:

$ git shortlog 8030089..0902230
Kyle Sunderland (8):
      BUG: Fix incorrect casting of Dynamic modeler Mirror rule input plane
      BUG: Fix incorrect end-cap position
      ENH: Move PlaneCut input model to top of inputs
      BUG: Preserve surface normals when cutting planes in dynamic modeler
      ENH: Manually specify end-cap normals when cutting with planes
      ENH: Rename DynamicModeler *Rule classes to *Tool
      COMP: Fix warning 'not all control paths return a value'
      STYLE: Add additional comments to vtkSlicerDynamicModelerPlaneCutTool