### PR TITLE
COMP: Fix warnings in SurfaceToolbox

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -353,7 +353,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG 090223059af483faec8fc235c89ad0014045d1b9
+  GIT_TAG 86827c575efe77fe56c757029917387673ee7afd
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
```
$ git shortlog 0902230..86827c5
Jean-Christophe Fillion-Robin (2):
      COMP: Fix -Wunused-* warnings
      COMP: Fix -Wsign-compare in vtkSlicerDynamicModelerTool

Co-authored-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
```