### PR TITLE
COMP: Update CTKAppLauncherLib

### DIFF
--- a/SuperBuild/External_CTKAppLauncherLib.cmake
+++ b/SuperBuild/External_CTKAppLauncherLib.cmake
@@ -26,7 +26,7 @@ if(NOT DEFINED CTKAppLauncherLib_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ec98a50327644f6607b1a21bf016eba1027134d5"
+    "b1d6dad48b11c2770a72ad879812995213ccfc6e"
     QUIET
     )
 


### PR DESCRIPTION
```
$ git shortlog --no-merges ec98a50..b1d6dad
James Butler (1):
      COMP: Fix deprecation warning C4996

Jean-Christophe Fillion-Robin (7):
      ENH: Reduce launcher executable size on Linux by stripping symbols
      .travis: Fix build installing installing latest rvm keys
      CTKAppLauncher v0.1.26
      Begin post-v0.1.26 development [ci skip]
      BUG: Fix stripping of packaged launcher executable on Linux
      CTKAppLauncher v0.1.27
      Begin post-v0.1.27 development [ci skip]
```