### PR TITLE
ENH: Set default display precision of length unit to 4

### DIFF
--- a/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
+++ b/Modules/Loadable/Units/Logic/vtkSlicerUnitsLogic.cxx
@@ -163,7 +163,7 @@ void vtkSlicerUnitsLogic::ObserveMRMLScene()
 void vtkSlicerUnitsLogic::AddDefaultsUnits()
 {
   vtkMRMLUnitNode* node =
-    this->AddUnitNode("ApplicationLength", "length", "", "mm", 3);
+    this->AddUnitNode("ApplicationLength", "length", "", "mm", 4);
   node->SetSaveWithScene(false);
   this->SetDefaultUnit(node->GetQuantity(), node->GetID());
 


### PR DESCRIPTION
By default, length values over 100mm were displayed without decimal digits by default (precision=3), which may be insufficient for some medical applications, since measurement of such lengths is no uncommon and image resolution is usually in the magnitude of 0.1mm.

Example: 104.123mm distance was displayed as "104.mm" before this change and it is displayed as "104.2mm" after this change.