### PR TITLE
BUG: Fix converted labelmap geometry with UseOutputImageDataGeometry

### DIFF
--- a/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.cxx
@@ -123,6 +123,8 @@ vtkDataObject* vtkClosedSurfaceToBinaryLabelmapConversionRule::ConstructRepresen
 //----------------------------------------------------------------------------
 bool vtkClosedSurfaceToBinaryLabelmapConversionRule::Convert(vtkSegment* segment)
 {
+  vtkSmartPointer<vtkOrientedImageData> outputGeometryLabelmap = vtkOrientedImageData::SafeDownCast(
+    segment->GetRepresentation(this->GetTargetRepresentationName()));
   this->CreateTargetRepresentation(segment);
 
   // Check validity of source and target representation objects
@@ -158,6 +160,11 @@ bool vtkClosedSurfaceToBinaryLabelmapConversionRule::Convert(vtkSegment* segment
       vtkErrorMacro("Convert: Failed to calculate output image geometry!");
       return false;
       }
+    }
+  else if (outputGeometryLabelmap)
+    {
+    std::string geometryString = vtkSegmentationConverter::SerializeImageGeometry(outputGeometryLabelmap);
+    vtkSegmentationConverter::DeserializeImageGeometry(geometryString, binaryLabelmap, false);
     }
 
   // Allocate output image data


### PR DESCRIPTION
Binary labelmaps generated from vtkClosedSurfaceToBinaryLabelmapConversionRule create a new data object representation rather than using the existing data object.
The newly created labelmaps did not copy the existing geometry, so labelmaps created with UseOutputImageDataGeometry enabled would be empty.

Fixed by copying the geometry of the existing output labelmap into the new output.