### PR TITLE
COMP: Update VTK to remove vtk-m dependency

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -126,7 +126,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
 set(_git_tag)
 if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "8")
-  set(_git_tag "a81d1af0825b26946f05f0af9451e993489e801b") # slicer-v9.0.0-2020-05-05-987ae267
+  set(_git_tag "a44e00db0dd000d41268fa77c1d86d4d5977aeaa") # slicer-v9.0.0-2020-05-05-987ae267
 else()
   message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
 endif()


### PR DESCRIPTION
List of changes:

```
$ git shortlog a81d1af082..a44e00db0d --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Remove vtk-m submodule
```

To remove vtkm from existing VTK source checkout:

```
git submodule deinit -f -- ThirdParty/vtkm
rm -rf .git/modules/VTK-m/
git rm -rf ThirdParty/vtkm/
```