### PR TITLE
BUG: Update qMRMLTreeView to fix visibility toggle

### DIFF
--- a/Libs/MRML/Widgets/qMRMLTreeView.cxx
+++ b/Libs/MRML/Widgets/qMRMLTreeView.cxx
@@ -827,8 +827,13 @@ bool qMRMLTreeView::clickDecoration(const QModelIndex& index)
 void qMRMLTreeView::toggleVisibility(const QModelIndex& index)
 {
   vtkMRMLNode* node = this->sortFilterProxyModel()->mrmlNodeFromIndex(index);
-  vtkMRMLDisplayNode* displayNode =
-    vtkMRMLDisplayNode::SafeDownCast(node);
+  vtkMRMLDisplayNode* displayNode = vtkMRMLDisplayNode::SafeDownCast(node);
+  vtkMRMLDisplayableNode* displayableNode = vtkMRMLDisplayableNode::SafeDownCast(node);
+
+  if (displayableNode && displayableNode->GetDisplayNode())
+    {
+    displayNode = displayableNode->GetDisplayNode();
+    }
 
   vtkMRMLSelectionNode* selectionNode = vtkMRMLSelectionNode::SafeDownCast(
     this->mrmlScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton"));


### PR DESCRIPTION
This commit fixes a regression introduced in 2f932d8 / r28510 (ENH: Remove
model hierarchy nodes) and ensures visibility of both display and displayable
nodes can be toggled using a qMRMLTreeView associated with a "Displayable"
scene model (qMRMLSceneDisplayableModel)