### PR TITLE
COMP: Fix -Wunused-function warnings in qMRMLLayoutManager tests

### DIFF
--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTest1.cxx
@@ -133,6 +133,8 @@ bool testLayoutManagerViewWidgetForThreeD(int line, qMRMLLayoutManager* layoutMa
 //------------------------------------------------------------------------------
 int qMRMLLayoutManagerTest1(int argc, char * argv[] )
 {
+  (void)checkViewArrangement; // Fix -Wunused-function warning
+
   qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
   qMRMLWidget::postInitializeApplication();

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
@@ -367,6 +367,8 @@ bool runTests(vtkMRMLScene* scene,
 // --------------------------------------------------------------------------
 int qMRMLLayoutManagerVisibilityTest(int argc, char * argv[] )
 {
+  (void)checkViewArrangement; // Fix -Wunused-function warning
+
   qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
   qMRMLWidget::postInitializeApplication();

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
@@ -196,6 +196,8 @@ protected:
 //------------------------------------------------------------------------------
 int qMRMLLayoutManagerWithCustomFactoryTest(int argc, char * argv[] )
 {
+  (void)checkViewArrangement; // Fix -Wunused-function warning
+
   qMRMLWidget::preInitializeApplication();
   QApplication app(argc, argv);
   qMRMLWidget::postInitializeApplication();


### PR DESCRIPTION
This commit fixes warnings like the following:


```
  /path/to/Slicer/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerTestHelper.cxx:13:6: warning: ‘bool {anonymous}::checkViewArrangement(int, qMRMLLayoutManager*, vtkMRMLLayoutNode*, int)’ defined but not used [-Wunused-function]
   bool checkViewArrangement(int line, qMRMLLayoutManager* layoutManager,
        ^
```