### PR TITLE
COMP: Remove Slicer_ITK_VERSION_MAJOR configure option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,11 +327,6 @@ mark_as_superbuild(Slicer_INSTALL_ITKPython)
 option(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT "Build Slicer with parameter serializer support" ON)
 mark_as_superbuild(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT)
 
-set(_default_itk "5")
-set(Slicer_ITK_VERSION_MAJOR ${_default_itk} CACHE STRING "The ITK major version (5).")
-set_property(CACHE Slicer_ITK_VERSION_MAJOR PROPERTY STRINGS "5")
-mark_as_superbuild(Slicer_ITK_VERSION_MAJOR)
-
 set(_default_vtk "8")
 set(Slicer_VTK_VERSION_MAJOR ${_default_vtk} CACHE STRING "VTK major version")
 set_property(CACHE Slicer_VTK_VERSION_MAJOR PROPERTY STRINGS "8")

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -18,7 +18,7 @@ ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj
 
 if(Slicer_USE_SYSTEM_${proj})
   unset(ITK_DIR CACHE)
-  find_package(ITK 4.13.1 REQUIRED NO_MODULE)
+  find_package(ITK 5.1 REQUIRED NO_MODULE)
 endif()
 
 # Sanity checks


### PR DESCRIPTION
This closes #4866.

There is really no option except for ITK v5.  This can be brought back sometime in the future if there is ever a need to support multiple versions during a ITK v5/v6 transition

Also included minor commit to update version of ITK to find when using system ITK as part of build process.