### PR TITLE
ENH: Control volume rendering synchronize scalar button with check box

### DIFF
--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -429,6 +429,9 @@
               <property name="flat">
                <bool>false</bool>
               </property>
+              <property name="checkBoxControlsButtonToggleState">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item>


### PR DESCRIPTION
Clicking the check box on the SynchronizeScalarDisplayNodeButton now changes the toggle state of the button. Checked causes the button to be toggled "On" and unchecked causes it to be toggled "Off".

Fixes #4717