### PR TITLE
COMP: Update VTK to fix build with gcc 10.1 on Arch Linux

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -126,7 +126,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
 set(_git_tag)
 if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "8")
-  set(_git_tag "e1be324636d835558ff220326d16a721b852f17f") # slicer-v8.2.0-2018-10-02-74d9488523
+  set(_git_tag "b4a181566f8510103333d32d19a567cd5a455a34") # slicer-v8.2.0-2018-10-02-74d9488523
 else()
   message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
 endif()


### PR DESCRIPTION
See https://discourse.slicer.org/t/build-fails-in-vtkexodus-on-linux/12018

List of changes:

```
$ git shortlog e1be324..b4a1815 --no-merges
SET (1):
      [Backport] Exodus gcc 10 support
```

Co-authored-by: SET <chir.set@free.fr>