### PR TITLE
Update OpenSSL from 1.0.2n  to 1.1.1g

### DIFF
--- a/CMake/SlicerBlockInstallOpenSSL.cmake
+++ b/CMake/SlicerBlockInstallOpenSSL.cmake
@@ -2,6 +2,23 @@
 # Find and install OpenSSL Libs
 # -------------------------------------------------------------------------
 
+find_package(OpenSSL REQUIRED) # Needed to set OPENSSL_VERSION
+set(library_suffix "")
+if(WIN32 AND OPENSSL_VERSION VERSION_GREATER_EQUAL "1.1.0")
+  # Starting with OpenSSL 1.1.0, shared libraries are named
+  # * libcrypto-1_1.dll and libssl-1_1.dll for 32-bit
+  # * libcrypto-1_1-x64.dll and libssl-1_1-x64.dll for 64-bit
+
+  string(REGEX MATCHALL "[0-9]+" openssl_versions "${OPENSSL_VERSION}")
+  list(GET openssl_versions 0 openssl_version_major)
+  list(GET openssl_versions 1 openssl_version_minor)
+
+  set(library_suffix "-${openssl_version_major}_${openssl_version_minor}")
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit
+    string(APPEND library_suffix "-x64")
+  endif()
+endif()
+
 set(library_config "general")
 foreach(library ${OPENSSL_LIBRARIES})
   if(library MATCHES "debug|general|optimized")
@@ -10,7 +27,7 @@ foreach(library ${OPENSSL_LIBRARIES})
     if(library_config MATCHES "general|optimized")
       if(WIN32)
         get_filename_component(library_without_extension ${library} NAME_WE)
-        install(FILES ${OPENSSL_EXPORT_LIBRARY_DIR}/${library_without_extension}.dll
+        install(FILES ${OPENSSL_EXPORT_LIBRARY_DIR}/${library_without_extension}${library_suffix}.dll
           DESTINATION ${Slicer_INSTALL_BIN_DIR} COMPONENT Runtime)
       elseif(UNIX)
         slicerInstallLibrary(

--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -45,9 +45,16 @@ if(NOT DEFINED OPENSSL_LIBRARIES
 
   #------------------------------------------------------------------------------
   if(UNIX)
+    # Starting with Qt 5.12.4, official Qt binaries are build against OpenSSL 1.1.1
+    # See https://www.qt.io/blog/2019/06/17/qt-5-12-4-released-support-openssl-1-1-1
+    if("${Qt5_VERSION_MAJOR}.${Qt5_VERSION_MINOR}.${Qt5_VERSION_PATCH}" VERSION_GREATER_EQUAL "5.12.4")
+      set(_default_version "1.1.1g")
+    else()
+      set(_default_version "1.0.2n")
+    endif()
 
-    set(OPENSSL_DOWNLOAD_VERSION "1.0.2n" CACHE STRING "Version of OpenSSL source package to download")
-    set_property(CACHE OPENSSL_DOWNLOAD_VERSION PROPERTY STRINGS "1.0.1e" "1.0.1l" "1.0.2n")
+    set(OPENSSL_DOWNLOAD_VERSION "${_default_version}" CACHE STRING "Version of OpenSSL source package to download")
+    set_property(CACHE OPENSSL_DOWNLOAD_VERSION PROPERTY STRINGS "1.0.1e" "1.0.1l" "1.0.2n" "1.1.1g")
 
     set(OpenSSL_1.0.1e_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/sources/openssl-1.0.1e.tar.gz)
     set(OpenSSL_1.0.1e_MD5 66bf6f10f060d561929de96f9dfe5b8c)
@@ -57,6 +64,11 @@ if(NOT DEFINED OPENSSL_LIBRARIES
 
     set(OpenSSL_1.0.2n_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/sources/openssl-1.0.2n.tar.gz)
     set(OpenSSL_1.0.2n_MD5 13bdc1b1d1ff39b6fd42a255e74676a4)
+
+    # Workaround linking error when building against non-system zlib on macOS
+    # See https://github.com/openssl/openssl/pull/12238
+    set(OpenSSL_1.1.1g_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/sources/openssl-1.1.1g-pr12238.tar.gz)
+    set(OpenSSL_1.1.1g_MD5 4765dcd60bcbed784c59ad7c2ca2b841)
 
     if(NOT DEFINED OpenSSL_${OPENSSL_DOWNLOAD_VERSION}_URL)
       message(FATAL_ERROR "There is no source version of OpenSSL ${OPENSSL_DOWNLOAD_VERSION} available.
@@ -122,10 +134,15 @@ ExternalProject_Execute(${proj} \"configure\" sh config --prefix=${EP_SOURCE_DIR
     set(_build_script ${CMAKE_BINARY_DIR}/${proj}_build_step.cmake)
     file(WRITE ${_build_script}
 "include(\"${_env_script}\")
-# Unset MAKEFLAGS to avoid \"warning: -jN forced in submake: disabling jobserver mode.\"
-unset(ENV{MAKEFLAGS})
+set(OPENSSL_DOWNLOAD_VERSION \"${OPENSSL_DOWNLOAD_VERSION}\")
+set(jflag \"\")
+if(OPENSSL_DOWNLOAD_VERSION VERSION_LESS \"1.1.0\")
+  # Unset MAKEFLAGS to avoid \"warning: -jN forced in submake: disabling jobserver mode.\"
+  unset(ENV{MAKEFLAGS})
+  set(jflag \"-j1\")
+endif()
 set(${proj}_WORKING_DIR \"${EP_SOURCE_DIR}\")
-ExternalProject_Execute(${proj} \"build\" make -j1 build_libs)
+ExternalProject_Execute(${proj} \"build\" make \${jflag} build_libs)
 ")
 
     #------------------------------------------------------------------------------
@@ -169,10 +186,15 @@ ExternalProject_Execute(${proj} \"build\" make -j1 build_libs)
   #------------------------------------------------------------------------------
   elseif(WIN32)
 
-    set(OPENSSL_DOWNLOAD_VERSION "1.0.1h" CACHE STRING "Version of OpenSSL pre-compiled package to download.")
-    set_property(CACHE OPENSSL_DOWNLOAD_VERSION PROPERTY STRINGS "1.0.1h" "1.0.1l")
-
-    set(_qt_version "${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}.${QT_VERSION_PATCH}")
+    # Starting with Qt 5.12.4, official Qt binaries are build against OpenSSL 1.1.1
+    # See https://www.qt.io/blog/2019/06/17/qt-5-12-4-released-support-openssl-1-1-1
+    if("${Qt5_VERSION_MAJOR}.${Qt5_VERSION_MINOR}.${Qt5_VERSION_PATCH}" VERSION_GREATER_EQUAL "5.12.4")
+      set(_default_version "1.1.1g")
+    else()
+      set(_default_version "1.0.1h")
+    endif()
+    set(OPENSSL_DOWNLOAD_VERSION "${_default_version}" CACHE STRING "Version of OpenSSL pre-compiled package to download.")
+    set_property(CACHE OPENSSL_DOWNLOAD_VERSION PROPERTY STRINGS "1.0.1h" "1.0.1l" "1.1.1g")
 
     # Starting with Qt 4.8.6, we compiled [1] OpenSSL binaries specifically for each
     # version of Microsoft Visual Studio. To understand the motivation, read below.
@@ -236,6 +258,13 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
 
     #--------------------
     elseif(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit
+
+      # OpenSSL 1.1.1g
+      # VS2015, VS2017 and VS2019
+      if(${MSVC_VERSION} VERSION_GREATER_EQUAL 1900)
+        set(OpenSSL_1.1.1g_${MSVC_VERSION}_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.1.1g/OpenSSL_1_1_1g-install-msvc1900-64.tar.gz)
+        set(OpenSSL_1.1.1g_${MSVC_VERSION}_MD5 f89ea6a4fcfb279af30cbe01c1d7f879)
+      endif()
 
       # OpenSSL 1.0.1h
       # VS2008
@@ -308,10 +337,17 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
     set(OPENSSL_LIBRARY_DIR "${OpenSSL_DIR}/lib")
     set(OPENSSL_EXPORT_LIBRARY_DIR "${OpenSSL_DIR}/bin")
 
-    set(LIB_EAY_DEBUG "${EP_SOURCE_DIR}/Debug/lib/libeay32.lib")
-    set(LIB_EAY_RELEASE "${EP_SOURCE_DIR}/Release/lib/libeay32.lib")
-    set(SSL_EAY_DEBUG "${EP_SOURCE_DIR}/Debug/lib/ssleay32.lib")
-    set(SSL_EAY_RELEASE "${EP_SOURCE_DIR}/Release/lib/ssleay32.lib")
+    if(OPENSSL_DOWNLOAD_VERSION VERSION_GREATER_EQUAL "1.1.0")
+      set(LIB_EAY_DEBUG "${EP_SOURCE_DIR}/Debug/lib/libcrypto.lib")
+      set(LIB_EAY_RELEASE "${EP_SOURCE_DIR}/Release/lib/libcrypto.lib")
+      set(SSL_EAY_DEBUG "${EP_SOURCE_DIR}/Debug/lib/libssl.lib")
+      set(SSL_EAY_RELEASE "${EP_SOURCE_DIR}/Release/lib/libssl.lib")
+    else()
+      set(LIB_EAY_DEBUG "${EP_SOURCE_DIR}/Debug/lib/libeay32.lib")
+      set(LIB_EAY_RELEASE "${EP_SOURCE_DIR}/Release/lib/libeay32.lib")
+      set(SSL_EAY_DEBUG "${EP_SOURCE_DIR}/Debug/lib/ssleay32.lib")
+      set(SSL_EAY_RELEASE "${EP_SOURCE_DIR}/Release/lib/ssleay32.lib")
+    endif()
 
     ExternalProject_Message(${proj} "LIB_EAY_DEBUG:${LIB_EAY_DEBUG}")
     ExternalProject_Message(${proj} "LIB_EAY_RELEASE:${LIB_EAY_RELEASE}")

--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -114,7 +114,7 @@ set(ENV{VS_UNICODE_OUTPUT} \"\")
 set(${proj}_WORKING_DIR \"${EP_SOURCE_DIR}\")
 ExternalProject_Execute(${proj} \"configure-zlib\" cp ${ZLIB_LIBRARY} ${_zlib_library_dir}/libz.a
   )
-ExternalProject_Execute(${proj} \"configure\" sh config --with-zlib-lib=${_zlib_library_dir} --with-zlib-include=${ZLIB_INCLUDE_DIR} threads zlib shared
+ExternalProject_Execute(${proj} \"configure\" sh config --prefix=${EP_SOURCE_DIR} --openssldir=${EP_SOURCE_DIR} --libdir=${EP_SOURCE_DIR} --with-zlib-lib=${_zlib_library_dir} --with-zlib-include=${ZLIB_INCLUDE_DIR} threads zlib shared
   )
 ")
 
@@ -154,16 +154,6 @@ ExternalProject_Execute(${proj} \"build\" make -j1 build_libs)
       DEPENDEES configure
       DEPENDERS build
       )
-
-    if(APPLE)
-      ExternalProject_Add_Step(${proj} fix_rpath
-        COMMAND install_name_tool -id ${EP_SOURCE_DIR}/libcrypto.dylib ${EP_SOURCE_DIR}/libcrypto.dylib
-        COMMAND install_name_tool
-          -change /usr/local/ssl/lib/libcrypto.1.0.0.dylib ${EP_SOURCE_DIR}/libcrypto.dylib
-          -id ${EP_SOURCE_DIR}/libssl.dylib ${EP_SOURCE_DIR}/libssl.dylib
-        DEPENDEES build
-        )
-    endif()
 
     set(OpenSSL_DIR ${EP_SOURCE_DIR})
     set(OPENSSL_INCLUDE_DIR ${OpenSSL_DIR}/include)


### PR DESCRIPTION
Related to #4859 Tested on Ubuntu 18.04 Linux with Qt 5.15.0, and both debug and release builds work now, where previously they segfaulted almost immediately.

