### PR TITLE
BUG: Add missing import to ScriptedLoadableModule

### DIFF
--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import os, string
 import unittest
-import qt, ctk, slicer
+import vtk, qt, ctk, slicer
 import logging
 import importlib
 


### PR DESCRIPTION
This commit fixes the following error when using takeScreenshot from a
ScriptedLoadableModuleLogic subclass:
```
  File "path\to\slicer\Python\slicer\ScriptedLoadableModule.py", line
  344, in takeScreenshot
      imageData = vtk.vtkImageData()
      NameError: name 'vtk' is not defined
```