### PR TITLE
COMP: Fix linux build ensuring curl library is install in "lib" directory

### DIFF
--- a/SuperBuild/External_curl.cmake
+++ b/SuperBuild/External_curl.cmake
@@ -86,6 +86,7 @@ if((NOT DEFINED CURL_INCLUDE_DIR
       -DCMAKE_C_FLAGS:STRING=${${proj}_CMAKE_C_FLAGS}
       -DCMAKE_DEBUG_POSTFIX:STRING=
       -DCMAKE_INSTALL_PREFIX:PATH=${EP_INSTALL_DIR}
+      -DCMAKE_INSTALL_LIBDIR:STRING=lib  # Override value set in GNUInstallDirs CMake module
       -DBUILD_TESTING:BOOL=OFF
       -DBUILD_CURL_EXE:BOOL=OFF
       -DBUILD_SHARED_LIBS:BOOL=OFF  # Before enabling this option, see https://github.com/Slicer/curl/commit/ca5fe8e63df7faea0bfb988ef3fe58f538e6950b


### PR DESCRIPTION
This commit fixes the following error:

  error: '/work/Preview/Slicer-0-build/curl-install/lib/libcurl.a', needed by 'bin/libRemoteIO.so', missing and no known rule to make it

It fixes a regression originally introduced in 128fb86dd1 (ENH: Update
curl from 7.34 to 7.70)

See #5000 and #4992