### PR TITLE
ENH: Update transform node name when the transform is inverted

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -39,6 +39,7 @@ Version:   $Revision: 1.14 $
 #include <vtkPoints.h>
 #include <vtkThinPlateSplineTransform.h>
 #include <vtkTransform.h>
+#include <vtksys/SystemTools.hxx>
 
 // STD includes
 #include <sstream>
@@ -1191,6 +1192,22 @@ void vtkMRMLTransformNode::Inverse()
   this->StorableModifiedTime.Modified();
   this->Modified();
   this->TransformModified();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLTransformNode::InverseName()
+{
+  std::string nodeName = (this->GetName() ? this->GetName() : "");
+  const std::string inverseSuffix(" (-)"); // this could be moved to a member variable
+  if (vtksys::SystemTools::StringEndsWith(nodeName, inverseSuffix.c_str()))
+    {
+    nodeName.erase(nodeName.size() - inverseSuffix.size(), inverseSuffix.size());
+    }
+  else
+    {
+    nodeName += inverseSuffix;
+    }
+  this->SetName(nodeName.c_str());
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.h
@@ -349,6 +349,10 @@ public:
   /// Internally it does not perform any actual computation just switches ToParent and FromParent.
   void Inverse();
 
+  /// Update the node's name to reflect that the node content is inverted.
+  /// Inversion is implemented by adding/removing " (-)" suffix.
+  virtual void InverseName();
+
   /// Get the latest modification time of the stored transform
   vtkMTimeType GetTransformToWorldMTime();
 

--- a/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
+++ b/Modules/Loadable/Transforms/SubjectHierarchyPlugins/qSlicerSubjectHierarchyTransformsPlugin.cxx
@@ -408,7 +408,9 @@ void qSlicerSubjectHierarchyTransformsPlugin::invert()
     shNode->GetItemDataNode(currentItemID) );
   if (transformNode)
     {
+    MRMLNodeModifyBlocker blocker(transformNode);
     transformNode->Inverse();
+    transformNode->InverseName();
     }
 }
 

--- a/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModuleWidget.cxx
@@ -398,7 +398,9 @@ void qSlicerTransformsModuleWidget::invert()
   d->TranslationSliders->resetUnactiveSliders();
   d->RotationSliders->resetUnactiveSliders();
 
+  MRMLNodeModifyBlocker blocker(d->MRMLTransformNode);
   d->MRMLTransformNode->Inverse();
+  d->MRMLTransformNode->InverseName();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
When inverting a transform by clicking "Invert" button, it is easy to lose track how many times invert was clicked and the user does not know if the transform ends up being the same as the original or inverted.

We change the behavior so that a (-) suffix as appended to or removed from the transform's name each time "Invert" is clicked.

![image](https://user-images.githubusercontent.com/307929/85903138-a015ff00-b7d3-11ea-8573-4c21c5dd1767.png)

![image](https://user-images.githubusercontent.com/307929/85903144-a3a98600-b7d3-11ea-9c1d-2e786e03a0b1.png)
