### PR TITLE
BUG: Fix vtkMRMLMarkupsCurveNode crash when removing surface reference

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -1259,7 +1259,7 @@ void vtkMRMLMarkupsCurveNode::OnSurfaceModelNodeChanged()
     }
   else
     {
-    this->CleanFilter->RemoveInputConnection(0, modelNode->GetPolyDataConnection());
+    this->CleanFilter->RemoveAllInputs();
     this->CurveGenerator->RemoveInputConnection(1, this->PassThroughFilter->GetOutputPort());
     }
 }


### PR DESCRIPTION
When the shortest distance surface node reference was removed, it caused a crash when trying to access null pointer. Fixed by calling RemoveAllInputs rather than RemoveInputConnection.