### PR TITLE
ENH: Improve logic searching translation files for custom app

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -126,6 +126,17 @@ public:
   /// Parse arguments
   void parseArguments();
 
+  /// \brief Returns list of translation files contained in given \a dir for the input \a settingsLanguage
+  ///
+  /// If \a settingsLanguage is empty returns an empty list (application default language)
+  /// If \a settingsLanguage is not empty try to find the translation files from specific extension to generic extension
+  /// For example when \a settingsLanguage = "en_US", translation files ending with "en_US.qm" will be searched first
+  /// if no files are found then files ending with "en.qm" will be searched.
+  static QStringList findTranslationFiles(const QString& dir, const QString& settingsLanguage);
+
+  /// \brief Returns list of translation files contained in given \a dir for the input \a languageExtension
+  static QStringList findTranslationFilesWithLanguageExtension(const QString& dir, const QString& languageExtension);
+
 public:
   /// MRMLScene and AppLogic pointers
   vtkSmartPointer<vtkMRMLScene>               MRMLScene;

--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -178,7 +178,6 @@ macro(slicerMacroBuildAppLibrary)
     set(TS_DIR
       "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/"
     )
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(

--- a/CMake/SlicerMacroBuildBaseQtLibrary.cmake
+++ b/CMake/SlicerMacroBuildBaseQtLibrary.cmake
@@ -177,7 +177,6 @@ macro(SlicerMacroBuildBaseQtLibrary)
     set(TS_DIR
       "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/"
     )
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(

--- a/CMake/SlicerMacroBuildLoadableModule.cmake
+++ b/CMake/SlicerMacroBuildLoadableModule.cmake
@@ -168,7 +168,6 @@ macro(slicerMacroBuildLoadableModule)
   # --------------------------------------------------------------------------
   if(Slicer_BUILD_I18N_SUPPORT)
     set(TS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/")
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(

--- a/CMake/SlicerMacroBuildModuleWidgets.cmake
+++ b/CMake/SlicerMacroBuildModuleWidgets.cmake
@@ -84,7 +84,6 @@ macro(SlicerMacroBuildModuleWidgets)
   #-----------------------------------------------------------------------------
   if(Slicer_BUILD_I18N_SUPPORT)
     set(TS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/")
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(

--- a/CMake/SlicerMacroTranslation.cmake
+++ b/CMake/SlicerMacroTranslation.cmake
@@ -85,7 +85,19 @@ function(SlicerMacroTranslation)
     if(Slicer_UPDATE_TRANSLATION)
       QT5_CREATE_TRANSLATION(QM_OUTPUT_FILES ${FILES_TO_TRANSLATE} ${TS_FILES})
     else()
-      QT5_ADD_TRANSLATION(QM_OUTPUT_FILES ${TS_FILES})
+      # Find existing TS files and only add translation if at least one translation file exist to avoid error
+      # (Case may exist if Slicer_UPDATE_TRANSLATION is disabled and translation files were never
+      # generated for the input language)
+      set(EXISTING_TS_FILES)
+      foreach(TS_FILE ${TS_FILES})
+        if(EXISTS ${TS_FILE})
+          list(APPEND EXISTING_TS_FILES ${TS_FILE})
+        endif()
+      endforeach()
+
+      if(EXISTING_TS_FILES)
+        QT5_ADD_TRANSLATION(QM_OUTPUT_FILES ${EXISTING_TS_FILES})
+      endif()
     endif()
 
   # ---------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,8 +436,10 @@ include(SlicerFunctionAddPythonQtResources)
 if(Slicer_BUILD_I18N_SUPPORT)
   set(Slicer_LANGUAGES
     "fr"
+    CACHE STRING "Semicolon separated list of supported Slicer languages. Expected format : language[_country] (both en and en_US are supported)."
     )
-  set_property(GLOBAL PROPERTY Slicer_LANGUAGES ${Slicer_LANGUAGES})
+  mark_as_advanced(Slicer_LANGUAGES)
+  mark_as_superbuild(Slicer_LANGUAGES)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/CMakeLists.txt
+++ b/Libs/MRML/Widgets/CMakeLists.txt
@@ -439,7 +439,6 @@ endif()
     set(TS_DIR
       "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/"
     )
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(


### PR DESCRIPTION
* Change `Slicer_LANGUAGES` from a `GLOBAL` property to a `CACHE` variable
  allowing language generation to be modified in the context of custom
  applications.

* Change behavior for missing translation files when disabling translation
  updates to allow custom applications to translate subparts of the
  application only.

* Fix `qSlicerCoreApplication::loadTranslations` to find generic forms of TS
  files when present.
