### PR TITLE
New module finder dialog

### DIFF
--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -48,7 +48,7 @@ This work is partially supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colon
     """
     if not docPage:
       docPage = "Modules/"+self.moduleName
-    linkText = 'See <a href="{0}/Documentation/{1}.{2}/{3}">the documentation</a> for more information.'.format(
+    linkText = '<p>For more information see the <a href="{0}/Documentation/{1}.{2}/{3}">online documentation</a>.</p>'.format(
       self.parent.slicerWikiUrl, slicer.app.majorVersion, slicer.app.minorVersion, docPage)
     return linkText
 

--- a/Base/QTCLI/qSlicerCLIModule.cxx
+++ b/Base/QTCLI/qSlicerCLIModule.cxx
@@ -154,14 +154,13 @@ QImage qSlicerCLIModule::logo()const
 QString qSlicerCLIModule::helpText()const
 {
   Q_D(const qSlicerCLIModule);
-  QString help =
-    "%1<br>"
-    "For more detailed documentation see the online documentation at "
-    "<a href=\"%2\">%2</a>";
-
-  return help.arg(
-    QString::fromStdString(d->Desc.GetDescription())).arg(
-    QString::fromStdString(d->Desc.GetDocumentationURL()));
+  QString help = QString::fromStdString(d->Desc.GetDescription());
+  if (!d->Desc.GetDocumentationURL().empty())
+    {
+    help += QString("<p>For more information see the <a href=\"%1\">online documentation</a>.</p>")
+      .arg(QString::fromStdString(d->Desc.GetDocumentationURL()));
+    }
+  return help;
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerAbstractCoreModule.cxx
+++ b/Base/QTCore/qSlicerAbstractCoreModule.cxx
@@ -63,7 +63,7 @@ qSlicerAbstractCoreModulePrivate::qSlicerAbstractCoreModulePrivate()
   this->Name = "NA";
   this->WidgetRepresentation = nullptr;
   this->Installed = false;
-  this->BuiltIn = false;
+  this->BuiltIn = true;
   this->WidgetRepresentationCreationEnabled = true;
 }
 

--- a/Base/QTCore/qSlicerAbstractCoreModule.cxx
+++ b/Base/QTCore/qSlicerAbstractCoreModule.cxx
@@ -25,6 +25,7 @@
 // Slicer includes
 #include "qSlicerAbstractCoreModule.h"
 #include "qSlicerAbstractModuleRepresentation.h"
+#include "qSlicerCoreApplication.h"
 
 // SlicerLogic includes
 #include "vtkSlicerModuleLogic.h"
@@ -318,4 +319,21 @@ void qSlicerAbstractCoreModule::representationDeleted(qSlicerAbstractModuleRepre
 QStringList qSlicerAbstractCoreModule::associatedNodeTypes()const
 {
   return QStringList();
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerAbstractCoreModule::defaultDocumentationLink()const
+{
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
+
+  // Use "latest" version for Preview (installed preview release) and Experimental (developer build),
+  // and use "majorVersion.minorVersion" for Stable release.
+  QString version = QLatin1String("latest");
+  if (app->releaseType() == "Stable")
+    {
+    version = QString("%1.%2").arg(app->majorVersion()).arg(app->minorVersion());
+    }
+  QString url = QString("https://slicer.readthedocs.io/en/%1/user_guide/modules/%2.html").arg(version).arg(this->name().toLower());
+  QString linkText = QString("<p>For more information see the <a href=\"%1\">online documentation</a>.</p>").arg(url);
+  return linkText;
 }

--- a/Base/QTCore/qSlicerAbstractCoreModule.h
+++ b/Base/QTCore/qSlicerAbstractCoreModule.h
@@ -141,9 +141,15 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerAbstractCoreModule : public QObject
   Q_PROPERTY(QStringList contributors READ contributors)
 
   /// This property holds the URL of the module for the Slicer wiki.
-  /// It can be used in the help/ackknowledgement.
-  /// \todo Is the slicerWikiUrl module property obsolete ? should it be static ?
+  /// It can be used in the help/acknowledgement.
+  /// This method is being phased out, as module documentations is moving to ReadTheDocs.
+  /// Modules that already documented on ReadTheDocs can use defaultDocumentationLink property instead.
   Q_PROPERTY(QString slicerWikiUrl READ slicerWikiUrl)
+
+  /// Auto-generated string that contains a paragraph that links to the
+  /// default module documentation location on ReadTheDocs.
+  /// It can be used in the help/acknowledgement.
+  Q_PROPERTY(QString defaultDocumentationLink READ defaultDocumentationLink);
 
   /// This property holds the module name list of the module dependencies.
   /// It is used to order the loading of the modules. When setup() is called
@@ -197,8 +203,14 @@ public:
 
   virtual void printAdditionalInfo();
 
-  /// Convenient method to return slicer wiki URL
+  /// Convenience method to return slicer wiki URL
   QString slicerWikiUrl()const{ return "http://www.slicer.org/slicerWiki/index.php"; }
+
+  /// Convenience method that returns a string that can be inserted into the application help text that contains
+  /// link to the module's documentation in current Slicer version's documentation on ReadTheDocs.
+  /// The text is "For more information, see the online documentation."
+  /// and it points to https://slicer.readthedocs.io/en/(version)/user_guide/modules/(modulename).html
+  QString defaultDocumentationLink()const;
 
   /// Initialize the module, an appLogic must be given to
   /// initialize the module

--- a/Base/QTCore/qSlicerUtils.cxx
+++ b/Base/QTCore/qSlicerUtils.cxx
@@ -27,6 +27,7 @@
 
 // Slicer includes
 #include "qSlicerUtils.h"
+#include "qSlicerAbstractCoreModule.h"
 
 // SlicerLogic includes
 #include "vtkSlicerApplicationLogic.h"
@@ -95,6 +96,20 @@ bool qSlicerUtils::isLoadableModule(const QString& filePath)
   // See http://stackoverflow.com/questions/899422/regular-expression-for-a-string-that-does-not-start-with-a-sequence
   QRegExp regex("(libqSlicer.+Module\\.(so|dylib))|((?!lib)qSlicer.+Module\\.(dll|DLL))");
   return regex.exactMatch(QFileInfo(filePath).fileName());
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerUtils::isTestingModule(qSlicerAbstractCoreModule* module)
+{
+  const QStringList& categories = module->categories();
+  foreach(const QString & category, categories)
+    {
+    if (category.split('.').takeFirst() != "Testing")
+      {
+      return false;
+      }
+    }
+  return true;
 }
 
 //------------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerUtils.h
+++ b/Base/QTCore/qSlicerUtils.h
@@ -26,6 +26,8 @@
 
 #include "qSlicerBaseQTCoreExport.h"
 
+class qSlicerAbstractCoreModule;
+
 class Q_SLICER_BASE_QTCORE_EXPORT qSlicerUtils
 {
 
@@ -52,6 +54,11 @@ public:
   /// \note Associated \a fileName is expected to match the following
   /// regular expression: "(lib)?qSlicer.+Module\\.(so, dll, dylib)"
   static bool isLoadableModule(const QString& filePath);
+
+  /// Return \a true is the module is for testing purposes.
+  /// These modules are for testing and for troubleshooting and normally should not be displayed
+  /// to end users.
+  static bool isTestingModule(qSlicerAbstractCoreModule* module);
 
   /// Look for target file in build intermediate directory.
   /// On windows, the intermediate directory includes: . Debug RelWithDebInfo Release MinSizeRel

--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -54,6 +54,8 @@ set(KIT_SRCS
 
   qSlicerModuleFactoryFilterModel.cxx
   qSlicerModuleFactoryFilterModel.h
+  qSlicerModuleFinderDialog.cxx
+  qSlicerModuleFinderDialog.h
   qSlicerModulesListView.cxx
   qSlicerModulesListView.h
   qSlicerModulesMenu.cxx
@@ -196,6 +198,7 @@ set(KIT_MOC_SRCS
   qSlicerModelsDialog_p.h
 
   qSlicerModuleFactoryFilterModel.h
+  qSlicerModuleFinderDialog.h
   qSlicerModulesListView.h
   qSlicerModulesMenu.h
   qSlicerModulePanel.h
@@ -273,6 +276,7 @@ set(KIT_UI_SRCS
   Resources/UI/qSlicerActionsDialog.ui
   Resources/UI/qSlicerDataDialog.ui
   Resources/UI/qSlicerModelsDialog.ui
+  Resources/UI/qSlicerModuleFinderDialog.ui
   Resources/UI/qSlicerModulePanel.ui
   Resources/UI/qSlicerNodeWriterOptionsWidget.ui
   Resources/UI/qSlicerSaveDataDialog.ui

--- a/Base/QTGUI/Resources/UI/qSlicerModuleFinderDialog.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerModuleFinderDialog.ui
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qSlicerModuleFinderDialog</class>
+ <widget class="QDialog" name="qSlicerModuleFinderDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>674</width>
+    <height>413</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Module finder</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="ctkSearchBox" name="FilterTitleSearchBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
+       <property name="showSearchIcon">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="SearchInAllTextCheckBox">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Search in full text (module name and description). If unchecked then only module names are searched.</string>
+       </property>
+       <property name="text">
+        <string>&amp;Full text</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="ShowBuiltInCheckBox">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Show built-in modules. Unchecking makes it easier to find modules provided by extensions.</string>
+       </property>
+       <property name="text">
+        <string>&amp;Built-in</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="ShowTestingCheckBox">
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Show testing modules. Useful for software testing and troubleshooting.</string>
+       </property>
+       <property name="text">
+        <string>&amp;Testing</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="qSlicerModulesListView" name="ModuleListView">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>2</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="ButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QTextBrowser" name="ModuleDescriptionBrowser">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>3</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qSlicerModulesListView</class>
+   <extends>QListView</extends>
+   <header>qSlicerModulesListView.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkSearchBox</class>
+   <extends>QLineEdit</extends>
+   <header>ctkSearchBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>ModuleListView</tabstop>
+  <tabstop>ButtonBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>ButtonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>qSlicerModuleFinderDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>184</x>
+     <y>402</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>204</x>
+     <y>410</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ButtonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>qSlicerModuleFinderDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>252</x>
+     <y>396</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>272</x>
+     <y>410</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
+++ b/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
@@ -47,6 +47,9 @@ public:
   bool ShowLoaded;
   bool ShowIgnored;
   bool ShowFailed;
+  bool ShowBuiltIn;
+  bool ShowTesting;
+  bool ShowHidden;
 
   QStringList ShowModules;
   bool HideAllWhenShowModulesIsEmpty;
@@ -82,6 +85,9 @@ qSlicerModuleFactoryFilterModelPrivate::qSlicerModuleFactoryFilterModelPrivate(q
   this->ShowToIgnore = true;
   this->ShowIgnored = true;
   this->ShowFailed = true;
+  this->ShowBuiltIn = true;
+  this->ShowTesting = true;
+  this->ShowHidden = true;
   this->HideAllWhenShowModulesIsEmpty = false;
 }
 
@@ -172,6 +178,50 @@ void qSlicerModuleFactoryFilterModel::setShowFailed(bool show)
   this->invalidateFilter();
 }
 
+// --------------------------------------------------------------------------
+bool qSlicerModuleFactoryFilterModel::showBuiltIn()const
+{
+  Q_D(const qSlicerModuleFactoryFilterModel);
+  return d->ShowBuiltIn;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerModuleFactoryFilterModel::setShowBuiltIn(bool show)
+{
+  Q_D(qSlicerModuleFactoryFilterModel);
+  d->ShowBuiltIn = show;
+  this->invalidateFilter();
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerModuleFactoryFilterModel::showHidden()const
+{
+  Q_D(const qSlicerModuleFactoryFilterModel);
+  return d->ShowHidden;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerModuleFactoryFilterModel::setShowHidden(bool show)
+{
+  Q_D(qSlicerModuleFactoryFilterModel);
+  d->ShowHidden = show;
+  this->invalidateFilter();
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerModuleFactoryFilterModel::showTesting()const
+{
+  Q_D(const qSlicerModuleFactoryFilterModel);
+  return d->ShowTesting;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerModuleFactoryFilterModel::setShowTesting(bool show)
+{
+  Q_D(qSlicerModuleFactoryFilterModel);
+  d->ShowTesting = show;
+  this->invalidateFilter();
+}
 
 // --------------------------------------------------------------------------
 QStringList qSlicerModuleFactoryFilterModel::showModules()const
@@ -268,6 +318,30 @@ bool qSlicerModuleFactoryFilterModel::filterAcceptsRow(int sourceRow, const QMod
   if (!d->ShowFailed)
     {
     if (this->sourceModel()->data(sourceIndex, Qt::ForegroundRole).value<QBrush>() == QBrush(Qt::red))
+      {
+      return false;
+      }
+    }
+  if (!d->ShowBuiltIn)
+    {
+    // qSlicerModulesListViewPrivate::IsBuiltInRole = Qt::UserRole+1
+    if (this->sourceModel()->data(sourceIndex, Qt::UserRole+1).toBool())
+      {
+      return false;
+      }
+    }
+  if (!d->ShowTesting)
+    {
+    // qSlicerModulesListViewPrivate::IsTestingRole = Qt::UserRole+2
+    if (this->sourceModel()->data(sourceIndex, Qt::UserRole+2).toBool())
+      {
+      return false;
+      }
+    }
+  if (!d->ShowHidden)
+    {
+    // qSlicerModulesListViewPrivate::IsHiddenRole = Qt::UserRole+3
+    if (this->sourceModel()->data(sourceIndex, Qt::UserRole+3).toBool())
       {
       return false;
       }

--- a/Base/QTGUI/qSlicerModuleFactoryFilterModel.h
+++ b/Base/QTGUI/qSlicerModuleFactoryFilterModel.h
@@ -43,6 +43,12 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerModuleFactoryFilterModel
   Q_PROPERTY(bool showIgnored READ showIgnored WRITE setShowIgnored)
   /// True by default
   Q_PROPERTY(bool showFailed READ showFailed WRITE setShowFailed)
+  /// True by default
+  Q_PROPERTY(bool showBuiltIn READ showBuiltIn WRITE setShowBuiltIn)
+  /// True by default
+  Q_PROPERTY(bool showTesting READ showTesting WRITE setShowTesting)
+  /// True by default
+  Q_PROPERTY(bool showHidden READ showHidden WRITE setShowHidden)
 
   /// Don't use in conjunction of setFilter*()
   /// Empty by default
@@ -64,6 +70,9 @@ public:
   bool showLoaded()const;
   bool showIgnored()const;
   bool showFailed()const;
+  bool showBuiltIn()const;
+  bool showTesting()const;
+  bool showHidden()const;
 
   QStringList showModules()const;
 
@@ -79,6 +88,9 @@ public slots:
   void setShowLoaded(bool show);
   void setShowIgnored(bool show);
   void setShowFailed(bool show);
+  void setShowBuiltIn(bool show);
+  void setShowTesting(bool show);
+  void setShowHidden(bool show);
 
   void setShowModules(const QStringList& modules);
 

--- a/Base/QTGUI/qSlicerModuleFinderDialog.cxx
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.cxx
@@ -1,0 +1,404 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// STD includes
+#include <algorithm>
+
+// Qt includes
+#include <QKeyEvent>
+#include <QPushButton>
+
+// Slicer includes
+#include "qSlicerAbstractCoreModule.h"
+#include "qSlicerAbstractModule.h"
+#include "qSlicerApplication.h"
+#include "qSlicerModuleFactoryFilterModel.h"
+#include "qSlicerModuleFactoryManager.h"
+#include "qSlicerModuleManager.h"
+#include "qSlicerModuleFinderDialog.h"
+#include "qSlicerUtils.h"
+#include "ui_qSlicerModuleFinderDialog.h"
+
+// --------------------------------------------------------------------------
+// qSlicerModuleFinderDialogPrivate
+
+//-----------------------------------------------------------------------------
+class qSlicerModuleFinderDialogPrivate: public Ui_qSlicerModuleFinderDialog
+{
+  Q_DECLARE_PUBLIC(qSlicerModuleFinderDialog);
+protected:
+  qSlicerModuleFinderDialog* const q_ptr;
+
+public:
+  qSlicerModuleFinderDialogPrivate(qSlicerModuleFinderDialog& object);
+
+  /// Convenient method regrouping all initialization code
+  void init();
+
+  void makeSelectedItemVisible();
+
+  QString CurrentModuleName;
+};
+
+// --------------------------------------------------------------------------
+// qSlicerModuleFinderDialogPrivate methods
+
+// --------------------------------------------------------------------------
+qSlicerModuleFinderDialogPrivate::qSlicerModuleFinderDialogPrivate(qSlicerModuleFinderDialog& object)
+  :q_ptr(&object)
+{
+}
+
+// --------------------------------------------------------------------------
+void qSlicerModuleFinderDialogPrivate::init()
+{
+  Q_Q(qSlicerModuleFinderDialog);
+
+  this->setupUi(q);
+
+  qSlicerCoreApplication * coreApp = qSlicerCoreApplication::application();
+  qSlicerAbstractModuleFactoryManager* factoryManager = coreApp->moduleManager()->factoryManager();
+
+  qSlicerModuleFactoryFilterModel* filterModel = this->ModuleListView->filterModel();
+
+  // Hide modules that do not have GUI (user cannot switch to them)
+  filterModel->setShowHidden(false);
+  // Hide testing modules by default
+  filterModel->setShowTesting(false);
+
+  QObject::connect(this->SearchInAllTextCheckBox, SIGNAL(toggled(bool)),
+    q, SLOT(setSearchInAllText(bool)));
+  QObject::connect(this->ShowBuiltInCheckBox, SIGNAL(toggled(bool)),
+    q, SLOT(setShowBuiltInModules(bool)));
+  QObject::connect(this->ShowTestingCheckBox, SIGNAL(toggled(bool)),
+    q, SLOT(setShowTestingModules(bool)));
+  QObject::connect(this->FilterTitleSearchBox, SIGNAL(textChanged(QString)),
+    q, SLOT(setModuleTitleFilterText(QString)));
+
+  QObject::connect(this->ModuleListView->selectionModel(), SIGNAL(selectionChanged(QItemSelection, QItemSelection)),
+    q, SLOT(onSelectionChanged(QItemSelection, QItemSelection)));
+
+  this->FilterTitleSearchBox->installEventFilter(q);
+
+  QPushButton* okButton = this->ButtonBox->button(QDialogButtonBox::Ok);
+  okButton->setText(q->tr("Switch to module"));
+
+  if (filterModel->rowCount() > 0)
+    {
+    // select first item
+    this->ModuleListView->setCurrentIndex(filterModel->index(0, 0));
+    }
+}
+
+// --------------------------------------------------------------------------
+void qSlicerModuleFinderDialogPrivate::makeSelectedItemVisible()
+{
+  Q_Q(qSlicerModuleFinderDialog);
+  qSlicerModuleFactoryFilterModel* filterModel = this->ModuleListView->filterModel();
+
+  // Make sure that an item is selected
+  if (!this->ModuleListView->currentIndex().isValid())
+    {
+    if (filterModel->rowCount() > 0)
+      {
+      // select first item
+      this->ModuleListView->setCurrentIndex(filterModel->index(0, 0));
+      }
+    }
+  // Make sure that the selected item is visible
+  if (this->ModuleListView->currentIndex().isValid())
+    {
+    this->ModuleListView->scrollTo(this->ModuleListView->currentIndex());
+    }
+}
+
+// --------------------------------------------------------------------------
+// qSlicerModuleFinderDialog methods
+
+// --------------------------------------------------------------------------
+qSlicerModuleFinderDialog::qSlicerModuleFinderDialog(QWidget* _parent)
+  : Superclass(_parent)
+  , d_ptr(new qSlicerModuleFinderDialogPrivate(*this))
+{
+  Q_D(qSlicerModuleFinderDialog);
+  d->init();
+}
+
+// --------------------------------------------------------------------------
+qSlicerModuleFinderDialog::~qSlicerModuleFinderDialog() = default;
+
+void qSlicerModuleFinderDialog::setFactoryManager(qSlicerAbstractModuleFactoryManager* factoryManager)
+{
+  Q_D(qSlicerModuleFinderDialog);
+  d->ModuleListView->setFactoryManager(factoryManager);
+}
+
+//------------------------------------------------------------------------------
+void qSlicerModuleFinderDialog::onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)
+{
+  Q_UNUSED(deselected);
+  Q_D(qSlicerModuleFinderDialog);
+
+  QString moduleName;
+  qSlicerAbstractCoreModule* module = nullptr;
+  if (!selected.indexes().empty())
+    {
+    moduleName = selected.indexes().first().data(Qt::UserRole).toString();
+    qSlicerCoreApplication* coreApp = qSlicerCoreApplication::application();
+    qSlicerModuleManager* moduleManager = coreApp->moduleManager();
+    qSlicerModuleFactoryManager* factoryManager = moduleManager->factoryManager();
+    if (factoryManager->isLoaded(moduleName))
+      {
+      module = moduleManager->module(moduleName);
+      }
+    }
+
+  d->CurrentModuleName = moduleName;
+
+  if (module)
+    {
+    d->ModuleDescriptionBrowser->clear();
+    QString html;
+
+    // Title
+    html.append(QString("<h2>%1</h2>").arg(module->title()));
+
+    // Categories
+    QStringList categories = module->categories();
+    QStringList filteredCategories;
+    foreach(QString category, categories)
+      {
+      if (category.isEmpty())
+        {
+        category = QLatin1String("[main]");
+        }
+      else
+        {
+        category.replace(".", "->");
+        }
+      filteredCategories << category;
+      }
+    html.append(QString("<p><b>Category:</b> %1</p>").arg(filteredCategories.join(", ")));
+
+    // Help
+    QString help = module->helpText();
+    qSlicerCoreApplication* app = qSlicerCoreApplication::application();
+    if (app)
+      {
+      QString wikiVersion = "Nightly";
+      if (app->releaseType() == "Stable")
+        {
+        wikiVersion = QString("%1.%2").arg(app->majorVersion()).arg(app->minorVersion());
+        }
+      help = qSlicerUtils::replaceWikiUrlVersion(module->helpText(), wikiVersion);
+      }
+    help.replace("\\n", "<br>");
+    help = help.trimmed();
+    if (!help.isEmpty())
+      {
+      html.append(help.trimmed());
+      }
+
+    // Acknowledgments
+    qSlicerAbstractModule* guiModule = qobject_cast<qSlicerAbstractModule*>(module);
+    if (guiModule && !guiModule->logo().isNull())
+      {
+      d->ModuleDescriptionBrowser->document()->addResource(QTextDocument::ImageResource,
+        QUrl("module://logo.png"), QVariant(guiModule->logo()));
+      html.append(
+        QString("<center><img src=\"module://logo.png\"/></center><br>"));
+      }
+    QString acknowledgement = module->acknowledgementText();
+    if (!acknowledgement.isEmpty())
+      {
+      acknowledgement.replace("\\n", "<br>");
+      acknowledgement = acknowledgement.trimmed();
+      html.append("<p>");
+      html.append(acknowledgement.trimmed());
+      }
+
+    // Contributors
+    if (!module->contributors().isEmpty())
+      {
+      QString contributors = module->contributors().join(", ");
+      QString contributorsText = QString("<p><b>Contributors:</b> ") + contributors + "</p>";
+      html.append(contributorsText);
+      }
+
+    // Internal name
+    if (module->name() != module->title())
+      {
+      html.append(QString("<p><b>Internal name:</b> %1</p>").arg(module->name()));
+      }
+
+    // Type
+    QString type = QLatin1String("Core");
+    // Use "inherits" instead of "qobject_cast" because "qSlicerBaseQTCLI" depends on "qSlicerQTGUI"
+    if (module->inherits("qSlicerScriptedLoadableModule"))
+      {
+      type = QLatin1String("Python Scripted Loadable");
+      }
+    else if (module->inherits("qSlicerLoadableModule"))
+      {
+      type = QLatin1String("C++ Loadable");
+      }
+    else if (module->inherits("qSlicerCLIModule"))
+      {
+      type = QLatin1String("Command-Line Interface (CLI)");
+      }
+    if (module->isBuiltIn())
+      {
+      type += QLatin1String(", built-in");
+      }
+    html.append(QString("<p><b>Type:</b> %1</p>").arg(type));
+
+    // Dependencies
+    if (!module->dependencies().empty())
+      {
+      html.append(QString("<p><b>Require:</b> %1</p>").arg(module->dependencies().join(", ")));
+      }
+
+    // Location
+    html.append(QString("<p><b>Location:</b> %1</p>").arg(module->path()));
+
+    d->ModuleDescriptionBrowser->setHtml(html);
+    }
+  else
+    {
+    d->ModuleDescriptionBrowser->clear();
+    if (!moduleName.isEmpty())
+      {
+      d->ModuleDescriptionBrowser->setText(QString("%1 module is not loaded").arg(moduleName));
+      }
+    }
+
+  // scroll to the top
+  QTextCursor cursor = d->ModuleDescriptionBrowser->textCursor();
+  //cursor.setPosition(0);
+  cursor.movePosition(QTextCursor::Start);
+  d->ModuleDescriptionBrowser->setTextCursor(cursor);
+}
+
+//---------------------------------------------------------------------------
+bool qSlicerModuleFinderDialog::eventFilter(QObject* target, QEvent* event)
+{
+  Q_D(qSlicerModuleFinderDialog);
+  if (target == d->FilterTitleSearchBox)
+    {
+    // Prevent giving the focus to the previous/next widget if arrow keys are used
+    // at the edge of the table (without this: if the current cell is in the top
+    // row and user press the Up key, the focus goes from the table to the previous
+    // widget in the tab order)
+    if (event->type() == QEvent::KeyPress)
+      {
+      QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+      qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();
+      if (keyEvent != nullptr && filterModel->rowCount() > 0)
+        {
+        int currentRow = d->ModuleListView->currentIndex().row();
+        int stepSize = 1;
+        if (keyEvent->key() == Qt::Key_PageUp || keyEvent->key() == Qt::Key_PageDown)
+          {
+          stepSize = 5;
+          }
+        else if (keyEvent->key() == Qt::Key_Home || keyEvent->key() == Qt::Key_End)
+          {
+          stepSize = 10000;
+          }
+        if (keyEvent->key() == Qt::Key_Up || keyEvent->key() == Qt::Key_PageUp || keyEvent->key() == Qt::Key_Home)
+          {
+          if (currentRow > 0)
+            {
+            d->ModuleListView->setCurrentIndex(filterModel->index(std::max(0, currentRow - stepSize), 0));
+            d->ModuleListView->scrollTo(d->ModuleListView->currentIndex());
+            }
+          return true;
+          }
+        else if (keyEvent->key() == Qt::Key_Down || keyEvent->key() == Qt::Key_PageDown || keyEvent->key() == Qt::Key_End)
+          {
+          if (currentRow + 1 < filterModel->rowCount())
+            {
+            d->ModuleListView->setCurrentIndex(filterModel->index(std::min(currentRow + stepSize, filterModel->rowCount()-1), 0));
+            d->ModuleListView->scrollTo(d->ModuleListView->currentIndex());
+            }
+          return true;
+          }
+        }
+      }
+    }
+  return this->Superclass::eventFilter(target, event);
+}
+
+//---------------------------------------------------------------------------
+QString qSlicerModuleFinderDialog::currentModuleName()const
+{
+  Q_D(const qSlicerModuleFinderDialog);
+  return d->CurrentModuleName;
+}
+
+//---------------------------------------------------------------------------
+void qSlicerModuleFinderDialog::setFocusToModuleTitleFilter()
+{
+  Q_D(qSlicerModuleFinderDialog);
+  d->FilterTitleSearchBox->setFocus();
+  d->makeSelectedItemVisible();
+}
+
+//---------------------------------------------------------------------------
+void qSlicerModuleFinderDialog::setModuleTitleFilterText(const QString& text)
+{
+  Q_D(qSlicerModuleFinderDialog);
+  qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();
+  filterModel->setFilterFixedString(d->FilterTitleSearchBox->text());
+  d->makeSelectedItemVisible();
+}
+
+//---------------------------------------------------------------------------
+void qSlicerModuleFinderDialog::setSearchInAllText(bool searchAll)
+{
+  Q_D(qSlicerModuleFinderDialog);
+  qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();
+  if (searchAll)
+    {
+    // qModuleListViewPrivate::FullTextSearchRole = Qt::UserRole + 4
+    filterModel->setFilterRole(Qt::UserRole + 4);
+    }
+  else
+    {
+    // search in displayed module title
+    filterModel->setFilterRole(Qt::DisplayRole);
+    }
+  d->makeSelectedItemVisible();
+}
+
+//---------------------------------------------------------------------------
+void qSlicerModuleFinderDialog::setShowBuiltInModules(bool show)
+{
+  Q_D(qSlicerModuleFinderDialog);
+  qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();
+  filterModel->setShowBuiltIn(show);
+  d->makeSelectedItemVisible();
+}
+
+//---------------------------------------------------------------------------
+void qSlicerModuleFinderDialog::setShowTestingModules(bool show)
+{
+  Q_D(qSlicerModuleFinderDialog);
+  qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();
+  filterModel->setShowTesting(show);
+  d->makeSelectedItemVisible();
+}

--- a/Base/QTGUI/qSlicerModuleFinderDialog.h
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.h
@@ -1,0 +1,69 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __qSlicerModuleFinderDialog_h
+#define __qSlicerModuleFinderDialog_h
+
+// Qt includes
+#include <QDialog>
+
+// CTK includes
+#include <ctkPimpl.h>
+
+// Slicer includes
+#include "qSlicerBaseQTGUIExport.h"
+
+/// Forward declarations
+class QItemSelection;
+class qSlicerAbstractModuleFactoryManager;
+class qSlicerModuleFinderDialogPrivate;
+
+//------------------------------------------------------------------------------
+class Q_SLICER_BASE_QTGUI_EXPORT qSlicerModuleFinderDialog : public QDialog
+{
+  Q_OBJECT
+  Q_PROPERTY(QString currentModuleName READ currentModuleName)
+public:
+  typedef QDialog Superclass;
+  qSlicerModuleFinderDialog(QWidget* parent=nullptr);
+  ~qSlicerModuleFinderDialog() override;
+
+  QString currentModuleName() const;
+
+  Q_INVOKABLE void setFocusToModuleTitleFilter();
+
+public Q_SLOTS:
+  /// Set the module factory manager that contains the list of modules
+  void setFactoryManager(qSlicerAbstractModuleFactoryManager* manager);
+  void setModuleTitleFilterText(const QString& text);
+  void setSearchInAllText(bool searchAll);
+  void setShowBuiltInModules(bool show);
+  void setShowTestingModules(bool show);
+
+protected Q_SLOTS:
+  void onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
+
+protected:
+  QScopedPointer<qSlicerModuleFinderDialogPrivate> d_ptr;
+  bool eventFilter(QObject* target, QEvent* event) override;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerModuleFinderDialog);
+  Q_DISABLE_COPY(qSlicerModuleFinderDialog);
+};
+
+#endif

--- a/Base/QTGUI/qSlicerModulePanel.cxx
+++ b/Base/QTGUI/qSlicerModulePanel.cxx
@@ -179,6 +179,7 @@ void qSlicerModulePanel::addModule(qSlicerAbstractCoreModule* module)
       }
     help = qSlicerUtils::replaceWikiUrlVersion(module->helpText(), wikiVersion);
     }
+  help.replace("\\n", "<br>");
 
   d->HelpCollapsibleButton->setVisible(this->isHelpAndAcknowledgmentVisible() && !help.isEmpty());
   d->HelpLabel->setHtml(help);

--- a/Base/QTGUI/qSlicerModulePanel.cxx
+++ b/Base/QTGUI/qSlicerModulePanel.cxx
@@ -197,7 +197,6 @@ void qSlicerModulePanel::addModule(qSlicerAbstractCoreModule* module)
   if (!module->contributors().isEmpty())
     {
     QString contributors = module->contributors().join(", ");
-    contributors.replace(contributors.lastIndexOf(","), 1, " and");
     QString contributorsText = QString("<br/><u>Contributors:</u> <i>") + contributors + "</i><br/>";
     d->AcknowledgementLabel->append(contributorsText);
     }

--- a/Base/QTGUI/qSlicerModuleSelectorToolBar.h
+++ b/Base/QTGUI/qSlicerModuleSelectorToolBar.h
@@ -74,6 +74,8 @@ public slots:
   void selectNextModule();
   void selectPreviousModule();
 
+  void showModuleFinder();
+
 signals:
   /// The signal is fired every time a module is selected. The QAction of the
   /// module is triggered.

--- a/Base/QTGUI/qSlicerModulesListView.h
+++ b/Base/QTGUI/qSlicerModulesListView.h
@@ -37,6 +37,7 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerModulesListView : public QListView
   Q_OBJECT
   /// False by default
   Q_PROPERTY(bool checkBoxVisible READ isCheckBoxVisible WRITE setCheckBoxVisible )
+  Q_PROPERTY(QStringList modules READ modules)
   Q_PROPERTY(QStringList checkedModules READ checkedModules
              WRITE setCheckedModules NOTIFY checkedModulesChanged
              DESIGNABLE false)
@@ -53,12 +54,11 @@ public:
   /// Destructor
   ~qSlicerModulesListView() override;
 
-  /// Set the module factory manager that contains the list of modules
+  /// Get the module factory manager that contains the list of modules
   /// and modules to ignore
-  void setFactoryManager(qSlicerAbstractModuleFactoryManager* manager);
-  qSlicerAbstractModuleFactoryManager* factoryManager()const;
+  Q_INVOKABLE qSlicerAbstractModuleFactoryManager* factoryManager()const;
 
-  qSlicerModuleFactoryFilterModel* filterModel()const;
+  Q_INVOKABLE qSlicerModuleFactoryFilterModel* filterModel()const;
 
   /// Return the list of all loaded, ignored and toIgnore modules.
   QStringList modules()const;
@@ -73,7 +73,12 @@ public:
   QStringList uncheckedModules()const;
 
 public slots:
+  /// Set the module factory manager that contains the list of modules
+  /// and modules to ignore
+  void setFactoryManager(qSlicerAbstractModuleFactoryManager* manager);
+
   void setCheckBoxVisible(bool show);
+
   /// Check the modules in the \a moduleNames list. Uncheck the modules
   /// not in the \a moduleNames list.
   void setCheckedModules(const QStringList& moduleNames);

--- a/Base/QTGUI/qSlicerModulesMenu.h
+++ b/Base/QTGUI/qSlicerModulesMenu.h
@@ -55,10 +55,6 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerModulesMenu: public QMenu
   /// only the future added modules
   Q_PROPERTY(bool showHiddenModules READ showHiddenModules WRITE setShowHiddenModules)
 
-  /// By default (isAllModulesCategoryVisible = true), setting this property controls
-  /// the visibility of the "All Modules" category.
-  Q_PROPERTY(bool allModulesCategoryVisible READ isAllModulesCategoryVisible WRITE setAllModulesCategoryVisible)
-
   Q_PROPERTY(QStringList topLevelCategoryOrder READ topLevelCategoryOrder WRITE setTopLevelCategoryOrder)
 public:
   typedef QMenu Superclass;
@@ -94,12 +90,6 @@ public:
   void setShowHiddenModules(bool show);
   bool showHiddenModules()const;
 
-  /// Return menu associated with the special "All Modules" category.
-  Q_INVOKABLE QMenu* allModulesCategory()const;
-
-  void setAllModulesCategoryVisible(bool visible);
-  bool isAllModulesCategoryVisible()const;
-
   void setTopLevelCategoryOrder(const QStringList& categories);
   QStringList topLevelCategoryOrder()const;
 
@@ -107,10 +97,7 @@ public:
   ///
   /// Sub-category can be specified using a "dot" separator (i.e. "CategoryName.SubCategoryName")
   ///
-  /// \note The special catergory "All Modules" can not be removed with this function. Instead
-  /// consider setting \a allModulesCategoryVisible property.
-  ///
-  /// \sa removeModule(), setAllModulesCategoryVisible()
+  /// \sa removeModule()
   Q_INVOKABLE bool removeCategory(const QString& categoryName);
 
 public slots:
@@ -130,11 +117,10 @@ public slots:
   /// Return true if the module was found and removed.
   ///
   /// By default, matching module entries are removed from the top-level category,
-  /// the custom and pre-defined categories as well as the "All Modules" special
-  /// category. Setting \a removeFromAllModules to false allows to change this.
+  /// the custom and pre-defined categories.
   ///
   /// \a removeFromAllModules to false allows to change this.
-  bool removeModule(const QString& moduleName, bool removeFromAllModules=true);
+  bool removeModule(const QString& moduleName);
 
   /// Select a module by title. It looks for the module action and triggers it.
   /// \sa setCurrentModule()
@@ -154,7 +140,7 @@ public slots:
   /// category. Setting \a removeFromAllModules to false allows to change this.
   ///
   /// Return true if the module was found and removed.
-  bool removeModule(qSlicerAbstractCoreModule*, bool removeFromAllModules=true);
+  bool removeModule(qSlicerAbstractCoreModule*);
 
 signals:
   /// The signal is fired every time a module is selected. The QAction of the

--- a/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModule.cxx
@@ -119,6 +119,7 @@ bool qSlicerScriptedLoadableModule::setPythonSource(const QString& newPythonSour
 
   // Extract moduleName from the provided filename
   QString moduleName = QFileInfo(newPythonSource).baseName();
+  this->setName(moduleName);
   QString className = moduleName;
 
   // Get a reference to the main module and global dictionary

--- a/Modules/CLI/DiffusionTensorTest/DiffusionTensorTest.xml
+++ b/Modules/CLI/DiffusionTensorTest/DiffusionTensorTest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <executable>
-  <category>Legacy.Work in Progress.Diffusion Tensor.Test</category>
+  <category>Testing.Legacy</category>
   <title>Simple IO Test</title>
   <description><![CDATA[Simple test of tensor IO]]></description>
   <version>0.1.0.$Revision$(alpha)</version>

--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <executable>
-  <category>Developer Tools</category>
+  <category>Testing</category>
   <title>Execution Model Tour</title>
   <description><![CDATA[Shows one of each type of parameter.]]></description>
   <version>0.1.0.$Revision$(alpha)</version>

--- a/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.xml
+++ b/Modules/CLI/TestGridTransformRegistration/TestGridTransformRegistration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <executable>
-  <category>Legacy.Registration</category>
+  <category>Testing.Legacy</category>
   <title>Test GridTransform registration</title>
   <index>9</index>
   <description><![CDATA[Generates a GridTransform to test the communication facilities]]></description>

--- a/Modules/Core/EventBroker/qSlicerEventBrokerModule.cxx
+++ b/Modules/Core/EventBroker/qSlicerEventBrokerModule.cxx
@@ -59,8 +59,8 @@ QStringList qSlicerEventBrokerModule::categories()const
 //-----------------------------------------------------------------------------
 QString qSlicerEventBrokerModule::helpText()const
 {
-  QString help = "<a href=\"%1/Documentation/%2.%3/Modules/EventBroker\">"
-    "%1/Documentation/%2.%3/Modules/EventBroker</a>\n";
+  QString help = "For more information see the <a href=\"%1/Documentation/%2.%3/Modules/EventBroker\">"
+    "online documentation</a>\n";
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 

--- a/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
+++ b/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
@@ -123,11 +123,12 @@ vtkMRMLAbstractLogic* qSlicerAnnotationsModule::createLogic()
 //-----------------------------------------------------------------------------
 QString qSlicerAnnotationsModule::helpText() const
 {
-  QString help = QString("The Annotations module, create and edit supplementary information associated with a scene.<br>"
-                         "Currently supported annotations are fiducial points, rulers, and regions of interest (ROIs).<br>"
-                         "<a href=\"%1/Documentation/%2.%3/Modules/Annotations\">"
-                         "%1/Documentation/%2.%3/Modules/Annotations</a><br>");
-
+  QString help = QString(
+  "Annotations module, create and edit supplementary information associated with a scene.<br>"
+  "The module will soon be replaced by Markups module."
+  "Currently supported annotations are fiducial points, rulers, and regions of interest (ROIs).<br>"
+  "For more information see the <a href=\"%1/Documentation/%2.%3/Modules/Annotations\">"
+  "online documentation</a><br>");
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 

--- a/Modules/Loadable/Cameras/qSlicerCamerasModule.cxx
+++ b/Modules/Loadable/Cameras/qSlicerCamerasModule.cxx
@@ -76,8 +76,8 @@ QString qSlicerCamerasModule::helpText()const
     "active camera for the selected view.<br>"
     "WARNING: this is rather experimental at the moment (fiducials, IO/data, "
     "closing the scene are probably broken for new views).<br>"
-    "<a href=\"%1/Documentation/%2.%3/Modules/Cameras\">"
-    "%1/Documentation/%2.%3/Modules/Cameras</a>\n");
+    "For more information see the <a href=\"%1/Documentation/%2.%3/Modules/Cameras\">"
+    "online documentation</a>\n");
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 
@@ -92,8 +92,7 @@ QString qSlicerCamerasModule::acknowledgementText()const
     "<td><img src=\":Logos/BIRN-NoText.png\" alt\"BIRN\"></td>"
     "<td><img src=\":Logos/NCIGT.png\" alt\"NCIGT\"></td>"
     "</tr></table></center>"
-    "This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. "
-    "See <a href=\"http://www.slicer.org\">slicer.org</a> for details.");
+    "This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.");
   return acknowledgement;
 }
 

--- a/Modules/Loadable/Colors/qSlicerColorsModule.cxx
+++ b/Modules/Loadable/Colors/qSlicerColorsModule.cxx
@@ -143,8 +143,8 @@ QString qSlicerColorsModule::helpText()const
 {
   QString help =
     "The <b>Colors Module</b> manages color look up tables.<br>"
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/Colors\">"
-    "%1/Documentation/%2.%3/Modules/Colors</a><br>"
+    "For more information see the <a href=\"%1/Documentation/%2.%3/Modules/Colors\">"
+    "online documentation</a><br>"
     "Tables are used by mappers to translate between an integer and a colour "
     "value for display of models and volumes.<br>Slicer supports three kinds "
     "of tables:<br>"
@@ -165,10 +165,7 @@ QString qSlicerColorsModule::helpText()const
 QString qSlicerColorsModule::acknowledgementText()const
 {
   QString about =
-    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer "
-    "Community.<br>"
-    "See <a href=\"http://www.slicer.org\">www.slicer.org</a> for details."
-    "This Color module was developed by Nicole Aucoin, SPL, BWH (Ron Kikinis).";
+    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.";
   return about;
 }
 
@@ -178,6 +175,7 @@ QStringList qSlicerColorsModule::contributors()const
   QStringList moduleContributors;
   moduleContributors << QString("Nicole Aucoin (SPL, BWH)");
   moduleContributors << QString("Julien Finet (Kitware)");
+  moduleContributors << QString("Ron Kikinis (SPL, BWH)");
   return moduleContributors;
 }
 

--- a/Modules/Loadable/Data/qSlicerDataModule.cxx
+++ b/Modules/Loadable/Data/qSlicerDataModule.cxx
@@ -128,10 +128,9 @@ QString qSlicerDataModule::helpText()const
     "presented for access and manipulation is the Data module. It allows organizing "
     "the data in folders or patient/study trees (automatically done for DICOM), "
     "visualizing any displayable data, transformation of whole branches, and a "
-    "multitude of data type specific features.<br>"
-    "<a href=\"%1/Documentation/%2.%3/Modules/Data\">"
-    "%1/Documentation/%2.%3/Modules/Data</a>");
-  return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
+    "multitude of data type specific features.");
+  help += this->defaultDocumentationLink();
+  return help;
 }
 
 //-----------------------------------------------------------------------------
@@ -146,8 +145,7 @@ QString qSlicerDataModule::acknowledgementText()const
     "<td><img src=\":Logos/NCIGT.png\" alt\"NCIGT\"></td>"
     "</tr></table></center>"
     "This work was supported by NA-MIC, NAC, BIRN, NCIGT, CTSC, and the Slicer "
-    "Community.<br>"
-    "See <a href=\"http://www.slicer.org\">www.slicer.org</a> for details.<br>";
+    "Community.";
   return about;
 }
 

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -86,10 +86,9 @@ QString qSlicerMarkupsModule::helpText()const
 {
   QString help =
     "A module to create and manage markups in 2D and 3D."
-    " Replaces the Annotations module for fiducials.\n"
-    "<a href=\"%1/Documentation/%2.%3/Modules/Markups\">"
-    "%1/Documentation/%2.%3/Modules/Markups</a>\n";
-  return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
+    " Replaces the Annotations module for fiducials.";
+  help += this->defaultDocumentationLink();
+  return help;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Plots/qSlicerPlotsModule.cxx
+++ b/Modules/Loadable/Plots/qSlicerPlotsModule.cxx
@@ -70,7 +70,7 @@ QString qSlicerPlotsModule::helpText()const
 {
   QString help =
     "The Plots module allows editing properties of plots.<br>"
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/Plots\">%1/Documentation/%2.%3/Modules/Plots</a><br>";
+    "For more information see the <a href=\"%1/Documentation/%2.%3/Developers/Plots\">oneline documentation</a>.<br>";
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 

--- a/Modules/Loadable/Reformat/qSlicerReformatModule.cxx
+++ b/Modules/Loadable/Reformat/qSlicerReformatModule.cxx
@@ -61,8 +61,8 @@ QString qSlicerReformatModule::helpText()const
   QString help =
       "The Transforms Reformat Widget Module creates "
       "and edits the Slice Node transforms.<br>"
-      "<a href=\"%1/Documentation/%2.%3/Modules/Reformat\">"
-      "%1/Documentation/%2.%3/Modules/Reformat</a>\n";
+      "For more information see the <a href=\"%1/Documentation/%2.%3/Modules/Reformat\">"
+      "online documentation</a>.\n";
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 
@@ -70,11 +70,7 @@ QString qSlicerReformatModule::helpText()const
 QString qSlicerReformatModule::acknowledgementText()const
 {
   QString acknowledgement =
-    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer "
-    "Community.<br>"
-    "See <a href=\"http://www.slicer.org\">www.slicer.org</a> for details.<br>"
-    "The Slice Node Transform module was contributed by "
-    "Michael Jeulin-Lagarrigue, Kitware Inc.";
+    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.";
   return acknowledgement;
 }
 

--- a/Modules/Loadable/SceneViews/qSlicerSceneViewsModule.cxx
+++ b/Modules/Loadable/SceneViews/qSlicerSceneViewsModule.cxx
@@ -68,8 +68,8 @@ QString qSlicerSceneViewsModule::helpText() const
     "visibility of the elements and capture interesting scene views. "
     "Unexpected behavior may occur if you add or delete data from the scene "
     "while saving and restoring scene views.\n"
-    "<a href=\"%1/Documentation/%2.%3/Modules/SceneViews\">"
-    "%1/Documentation/%2.%3/Modules/SceneViews</a>\n";
+    "For more information see the <a href=\"%1/Documentation/%2.%3/Modules/SceneViews\">"
+    "online documentation</a>.\n";
 
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
@@ -98,9 +98,13 @@ qSlicerSegmentationsModule::~qSlicerSegmentationsModule() = default;
 QString qSlicerSegmentationsModule::helpText()const
 {
   QString help =
-    "The Segmentations module manages segmentations. "
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/Segmentations\">%1/Documentation/%2.%3/Modules/Segmentations</a><br>";
-  return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
+    "Segmentations module manages segmentations. Each segmentation can contain"
+    " multiple segments, which correspond to one structure or ROI. Each segment"
+    " can contain multiple data representations for the same structure, and the"
+    " module supports automatic conversion between these representations"
+    " as well as advanced display settings and import/export features.";
+  help += this->defaultDocumentationLink();
+  return help;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SlicerWelcome/qSlicerWelcomeModule.cxx
+++ b/Modules/Loadable/SlicerWelcome/qSlicerWelcomeModule.cxx
@@ -61,7 +61,7 @@ QString qSlicerWelcomeModule::helpText()const
 QString qSlicerWelcomeModule::acknowledgementText()const
 {
   return "This work was supported by NA-MIC, NAC, BIRN, NCIGT, CTSC and the Slicer Community. "
-      "See <a>http://www.slicer.org</a> for details. We would also like to express our sincere "
+      "See <a href=\"http://www.slicer.org\">http://www.slicer.org</a> for details. We would also like to express our sincere "
       "thanks to members of the Slicer User Community who have helped us to design the contents "
       "of this Welcome Module, and whose feedback continues to improve functionality, usability "
       "and Slicer user experience\n.";

--- a/Modules/Loadable/Tables/qSlicerTablesModule.cxx
+++ b/Modules/Loadable/Tables/qSlicerTablesModule.cxx
@@ -72,7 +72,6 @@ QIcon qSlicerTablesModule::icon()const
 //-----------------------------------------------------------------------------
 QString qSlicerTablesModule::helpText()const
 {
-  return "This module provides support for data table nodes";
   QString help =
     "The Tables module allows displaying and editing of spreadsheets.<br>"
     "For more information see <a href=\"%1/Documentation/%2.%3/Modules/Tables\">%1/Documentation/%2.%3/Modules/Tables</a><br>";

--- a/Modules/Loadable/Terminologies/qSlicerTerminologiesModule.cxx
+++ b/Modules/Loadable/Terminologies/qSlicerTerminologiesModule.cxx
@@ -67,7 +67,7 @@ QString qSlicerTerminologiesModule::helpText()const
 {
   QString help = 
     "The Terminologies module enables viewing and editing terminology dictionaries used for segmentation"
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/Terminologies\">%1/Documentation/%2.%3/Modules/Models</a><br>";
+    "For more information see the <a href=\"%1/Documentation/%2.%3/Modules/Terminologies\">online documentation</a>.<br>";
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 

--- a/Modules/Loadable/Texts/qSlicerTextsModule.cxx
+++ b/Modules/Loadable/Texts/qSlicerTextsModule.cxx
@@ -88,7 +88,7 @@ QString qSlicerTextsModule::helpText()const
 {
   QString help =
     "A module to create, edit and manage text data in the scene.<br>"
-    "<a href=%1/Documentation/%2.%3/Modules/Texts>%1/Documentation/%2.%3/Modules/Texts</a>";
+    "For more information see the <a href=%1/Documentation/%2.%3/Modules/Texts>online documentation</a>.<br>";
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 

--- a/Modules/Loadable/Transforms/qSlicerTransformsModule.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModule.cxx
@@ -97,7 +97,7 @@ QString qSlicerTransformsModule::helpText()const
 {
   QString help =
     "The Transforms Module creates and edits transforms.<br>"
-    "<a href=%1/Documentation/%2.%3/Modules/Transforms>%1/Documentation/%2.%3/Modules/Transforms</a>";
+    "For more information see the <a href=%1/Documentation/%2.%3/Modules/Transforms>online documentation</a>.<br>";
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 
@@ -105,11 +105,7 @@ QString qSlicerTransformsModule::helpText()const
 QString qSlicerTransformsModule::acknowledgementText()const
 {
   QString acknowledgement =
-    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer "
-    "Community.<br>"
-    "See <a href=\"http://www.slicer.org\">www.slicer.org</a> for details.<br>"
-    "The Transforms module was contributed by Alex Yarmarkovich, Isomics Inc. "
-    "with help from others at SPL, BWH (Ron Kikinis) and Kitware Inc.";
+    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.";
   return acknowledgement;
 }
 
@@ -122,6 +118,7 @@ QStringList qSlicerTransformsModule::contributors()const
   moduleContributors << QString("Julien Finet (Kitware)");
   moduleContributors << QString("Andras Lasso (PerkLab, Queen's)");
   moduleContributors << QString("Franklin King (PerkLab, Queen's)");
+  moduleContributors << QString("Ron Kikinis (SPL, BWH)");
   return moduleContributors;
 }
 

--- a/Modules/Loadable/Units/qSlicerUnitsModule.cxx
+++ b/Modules/Loadable/Units/qSlicerUnitsModule.cxx
@@ -77,11 +77,7 @@ QString qSlicerUnitsModule::acknowledgementText()const
     "<td><img src=\":Logos/BIRN-NoText.png\" alt\"BIRN\"></td>"
     "<td><img src=\":Logos/NCIGT.png\" alt\"NCIGT\"></td>"
     "</tr></table></center>"
-    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer "
-    "Community. See <a href=\"http://www.slicer.org\">http://www.slicer.org"
-    "</a> for details.<br>"
-    "The Units module was contributed by Johan Andruejol, Kitware Inc "
-    "and Julien Finet, Kitware Inc.<br><br>");
+    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.");
   return acknowledgement;
 }
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.cxx
+++ b/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.cxx
@@ -75,7 +75,7 @@ QString qSlicerViewControllersModule::helpText() const
 {
   QString help =
     "The ViewControllers module allows modifying the views options.<br>"
-    "For more information see <a href=\"%1/Documentation/%2.%3/Modules/ViewControllers\">%1/Documentation/%2.%3/Modules/ViewControllers</a><br>";
+    "For more information see the <a href=\"%1/Documentation/%2.%3/Modules/ViewControllers\">online documentation</a>.<br>";
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
@@ -79,10 +79,8 @@ QString qSlicerVolumeRenderingModule::helpText()const
     "The module permits selection of preset transfer functions to colorize and set opacity "
     "of data in a task-appropriate way, and tools to customize the transfer functions that specify "
     "these parameters.<br/>"
-    "<a href=\"%1/Documentation/%2.%3/Modules/VolumeRendering\">"
-    "%1/Documentation/%2.%3/Modules/VolumeRendering</a><br/>"
-    "Tutorials are available at <a href=\"%1/Documentation/%2.%3/Modules/VolumeRendering\">"
-    "%1/Documentation/%2.%3/Modules/VolumeRendering</a>");
+    "For more information and tutorials see the <a href=\"%1/Documentation/%2.%3/Modules/VolumeRendering\">"
+    "online documentation</a><br/>");
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 
@@ -97,10 +95,8 @@ QString qSlicerVolumeRenderingModule::acknowledgementText()const
     "<td><img src=\":Logos/BIRN-NoText.png\" alt\"BIRN\"></td>"
     "<td><img src=\":Logos/NCIGT.png\" alt\"NCIGT\"></td>"
     "</tr></table></center>"
-    "This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. "
-    "See <a href=\"http://www.slicer.org\">slicer.org</a> for details.<br/>"
-    "Some of the transfer functions were contributed by Kitware Inc. (VolView)"
-    ;
+    "This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community."
+    "Some of the transfer functions were contributed by Kitware Inc. (VolView)";
   return acknowledgement;
 }
 

--- a/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
@@ -68,8 +68,8 @@ QString qSlicerVolumesModule::helpText()const
     "The Volumes Module is the interface for adjusting Window, Level, Threshold, "
     "Color LUT and other parameters that control the display of volume image data "
     "in the scene.<br>"
-    "<a href=\"%1/Documentation/%2.%3/Modules/Volumes\">"
-    "%1/Documentation/%2.%3/Modules/Volumes</a><br>");
+    "For more information see the <a href=\"%1/Documentation/%2.%3/Modules/Volumes\">"
+    "online documentation</a>.<br>");
   return help.arg(this->slicerWikiUrl()).arg(Slicer_VERSION_MAJOR).arg(Slicer_VERSION_MINOR);
 }
 
@@ -84,12 +84,7 @@ QString qSlicerVolumesModule::acknowledgementText()const
     "<td><img src=\":Logos/BIRN-NoText.png\" alt\"BIRN\"></td>"
     "<td><img src=\":Logos/NCIGT.png\" alt\"NCIGT\"></td>"
     "</tr></table></center>"
-    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer "
-    "Community. See <a href=\"http://www.slicer.org\">http://www.slicer.org"
-    "</a> for details.<br>"
-    "The Volumes module was contributed by Alex Yarmarkovich, Isomics Inc. "
-    "(Steve Pieper) and Julien Finet, Kitware Inc. with help from others at "
-    "SPL, BWH (Ron Kikinis).<br><br>");
+    "This work was supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.");
   return acknowledgement;
 }
 
@@ -101,6 +96,7 @@ QStringList qSlicerVolumesModule::contributors()const
   moduleContributors << QString("Julien Finet (Kitware)");
   moduleContributors << QString("Alex Yarmarkovich (Isomics)");
   moduleContributors << QString("Nicole Aucoin (SPL, BWH)");
+  moduleContributors << QString("Ron Kikinis (SPL, BWH)");
   return moduleContributors;
 }
 

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -33,7 +33,7 @@ This module allows importing, loading, and exporting DICOM files, and sending re
 """
     self.parent.helpText += self.getDefaultModuleDocumentationLink()
     self.parent.acknowledgementText = """
-This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. See <a href=http://www.slicer.org>http://www.slicer.org</a> for details.  Module implemented by Steve Pieper.  Based on work from CommonTK (http://www.commontk.org).
+This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.
 """
     self.parent.icon = qt.QIcon(':Icons/Medium/SlicerLoadDICOM.png')
     self.parent.dependencies = ["SubjectHierarchy"]

--- a/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
+++ b/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
@@ -20,7 +20,8 @@ class DICOMPatcher(ScriptedLoadableModule):
     self.parent.dependencies = ["DICOM"]
     self.parent.contributors = ["Andras Lasso (PerkLab)"]
     self.parent.helpText = """Fix common issues in DICOM files. This module may help fixing DICOM files that Slicer fails to import."""
-    self.parent.acknowledgementText = """ """
+    self.parent.helpText += parent.defaultDocumentationLink
+    self.parent.acknowledgementText = """This file was originally developed by Andras Lasso, PerkLab."""
 
 #
 # DICOMPatcherWidget

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -765,6 +765,9 @@ class DICOMScalarVolumePlugin(object):
     and was partially funded by NIH grant 3P41RR013218.
     """
 
+    # don't show this module - it only appears in the DICOM module
+    parent.hidden = True
+
     # Add this extension to the DICOM module's list for discovery when the module
     # is created.  Since this module may be discovered before DICOM itself,
     # create the list if it doesn't already exist.

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -19,13 +19,11 @@ class DataProbe(ScriptedLoadableModule):
     parent.title = "DataProbe"
     parent.categories = ["Quantification"]
     parent.contributors = ["Steve Pieper (Isomics)"]
-    parent.helpText = string.Template("""
-The DataProbe module is used to get information about the current RAS position being indicated by the mouse position.  See <a href=\"$a/Documentation/$b.$c/Modules/DataProbe\">$a/Documentation/$b.$c/Modules/DataProbe</a> for more information.
-    """).substitute({ 'a':parent.slicerWikiUrl, 'b':slicer.app.majorVersion, 'c':slicer.app.minorVersion })
-    parent.acknowledgementText = """
-This work is supported by NA-MIC, NAC, NCIGT, NIH U24 CA180918 (PIs Kikinis and Fedorov) and the Slicer Community.
-See <a>http://www.slicer.org</a> for details.  Module implemented by Steve Pieper.
-    """
+    parent.helpText = string.Template("""The DataProbe module is used to get information about the current RAS position being
+indicated by the mouse position. For more information see the
+<a href=\"$a/Documentation/$b.$c/Modules/DataProbe\">online documentation</a>.
+""").substitute({ 'a':parent.slicerWikiUrl, 'b':slicer.app.majorVersion, 'c':slicer.app.minorVersion })
+    parent.acknowledgementText = """This work is supported by NA-MIC, NAC, NCIGT, NIH U24 CA180918 (PIs Kikinis and Fedorov) and the Slicer Community."""
     # TODO: need a DataProbe icon
     #parent.icon = qt.QIcon(':Icons/XLarge/SlicerDownloadMRHead.png')
     self.infoWidget = None

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -33,7 +33,7 @@ The View Angle provides is used to approximate the optics of an endoscopy system
     self.parent.acknowledgementText = """
 This work is supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colonoscopy
 (See <a>http://www.na-mic.org/Wiki/index.php/NA-MIC_NCBC_Collaboration:NA-MIC_virtual_colonoscopy</a>)
-NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. See http://www.slicer.org for details.  Module implemented by Steve Pieper.
+NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.
 """
 
 #

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizard.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizard.py
@@ -36,11 +36,11 @@ class ExtensionWizard(object):
     parent.dependencies = []
     parent.contributors = ["Matthew Woehlke (Kitware)"]
     parent.helpText = """
-    This module provides tools to create and manage extensions from within Slicer.
-    """
+This module provides tools to create and manage extensions from within Slicer.
+"""
     parent.acknowledgementText = """
-    This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.
-    See <a>http://www.slicer.org</a> for details."""
+This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.
+"""
     self.parent = parent
 
     self.settingsPanel = SettingsPanel()

--- a/Modules/Scripted/SegmentEditor/SegmentEditor.py
+++ b/Modules/Scripted/SegmentEditor/SegmentEditor.py
@@ -20,7 +20,7 @@ This module allows editing segmentation objects by directly drawing and using se
 Representations other than the labelmap one (which is used for editing) are automatically updated real-time,
 so for example the closed surface can be visualized as edited in the 3D view.
 """
-    self.parent.helpText += self.getDefaultModuleDocumentationLink()
+    self.parent.helpText += parent.defaultDocumentationLink
     self.parent.acknowledgementText = """
 This work is part of SparKit project, funded by Cancer Care Ontario (CCO)'s ACRU program
 and Ontario Consortium for Adaptive Interventions in Radiation Oncology (OCAIRO).

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -27,7 +27,7 @@ Requires segment labelmap representation and selection of a scalar volume
 Closed surface statistics (CS): surface mm2, volume mm3, volume cm3 (computed from closed surface).
 Requires segment closed surface representation.
 """
-    self.parent.helpText += self.getDefaultModuleDocumentationLink()
+    self.parent.helpText += parent.defaultDocumentationLink
     self.parent.acknowledgementText = """
 Supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community. See http://www.slicer.org for details.
 """


### PR DESCRIPTION
This commit replaces module selector combobox search and "All modules" submenu by a new module finder dialog.

Module menu's "All modules" section could not show all the modules in one screen.

Solution: Replaced the module toolbar's combobox and the "All modules" list with a  "Module finder" window, which is brought up when user clicks module search icon or hits Ctrl/Cmd + F.
It can select a module using the same number of clicks as the combobox (type characters, press arrow-down key N times, then press Enter to go to that module).

Built-in modules can be hidden, so it is easy to find modules installed by extensions.
Module category is shown (e.g., Cleaner module is available in Surface models->Advanced category).
Developer information can be optionally displayed: module type (CLI, C++ loadable, scripted loadable), location, dependencies.

Demo video:

https://youtu.be/bhPbT0pu2K8
