### PR TITLE
ENH: add writtenNodes prop to scripted writer

### DIFF
--- a/Base/QTCore/qSlicerFileWriter.h
+++ b/Base/QTCore/qSlicerFileWriter.h
@@ -53,10 +53,10 @@ public:
   /// ...
   virtual bool write(const qSlicerIO::IOProperties& properties);
 
-  QStringList writtenNodes()const;
+  virtual QStringList writtenNodes()const;
 
 protected:
-  void setWrittenNodes(const QStringList& nodes);
+  virtual void setWrittenNodes(const QStringList& nodes);
 
 protected:
   QScopedPointer<qSlicerFileWriterPrivate> d_ptr;

--- a/Base/QTCore/qSlicerScriptedFileReader.h
+++ b/Base/QTCore/qSlicerScriptedFileReader.h
@@ -38,6 +38,9 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerScriptedFileReader
 {
   Q_OBJECT
 
+  /// This property allows the reader to report back what nodes it was able to load
+  Q_PROPERTY(QStringList loadedNodes READ loadedNodes WRITE setLoadedNodes)
+
 public:
   typedef qSlicerFileReader Superclass;
   qSlicerScriptedFileReader(QObject* parent = nullptr);
@@ -67,6 +70,17 @@ public:
   /// Reimplemented to propagate to python methods
   /// \sa qSlicerFileReader::write()
   bool load(const qSlicerIO::IOProperties& properties) override;
+
+  /// Reimplemented to support python methods and q_property
+  /// Exposes setLoadedNodes, which is protected in superclass
+  /// \sa qSlicerFileReader::loadedNodes()
+  /// \sa qSlicerFileWriter::writtenNodes()
+  QStringList loadedNodes()const override {
+    return Superclass::loadedNodes();
+  };
+  void setLoadedNodes(const QStringList& nodes) override {
+    Superclass::setLoadedNodes(nodes);
+  };
 
 protected:
   QScopedPointer<qSlicerScriptedFileReaderPrivate> d_ptr;

--- a/Base/QTCore/qSlicerScriptedFileWriter.h
+++ b/Base/QTCore/qSlicerScriptedFileWriter.h
@@ -37,6 +37,9 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerScriptedFileWriter
 {
   Q_OBJECT
 
+  /// This property allows the writer to report back what nodes it was able to write
+  Q_PROPERTY(QStringList writtenNodes READ writtenNodes WRITE setWrittenNodes)
+
 public:
   typedef qSlicerFileWriter Superclass;
   qSlicerScriptedFileWriter(QObject* parent = nullptr);
@@ -70,6 +73,19 @@ public:
   /// Reimplemented to propagate to python methods
   /// \sa qSlicerFileWriter::write()
   bool write(const qSlicerIO::IOProperties& properties) override;
+
+  /// Added so node writers can report back written nodes
+  /// \sa qSlicerFileWriter::writtenNodex()
+  void addWrittenNode(const QString& writtenNode);
+
+  /// Reimplemented to propagate to python methods
+  /// \sa qSlicerFileWriter::writtenNodes()
+  QStringList writtenNodes()const override {
+    return Superclass::writtenNodes();
+  };
+  void setWrittenNodes(const QStringList& nodes) override {
+    Superclass::setWrittenNodes(nodes);
+  };
 
 protected:
   QScopedPointer<qSlicerScriptedFileWriterPrivate> d_ptr;

--- a/Base/QTCore/qSlicerScriptedFileWriter.h
+++ b/Base/QTCore/qSlicerScriptedFileWriter.h
@@ -78,8 +78,10 @@ public:
   /// \sa qSlicerFileWriter::writtenNodex()
   void addWrittenNode(const QString& writtenNode);
 
-  /// Reimplemented to propagate to python methods
+  /// Reimplemented to support python methods and q_property
+  /// Exposes setWrittenNodes, which is protected in superclass
   /// \sa qSlicerFileWriter::writtenNodes()
+  /// \sa qSlicerFileReader::loadedNodes()
   QStringList writtenNodes()const override {
     return Superclass::writtenNodes();
   };


### PR DESCRIPTION
A qSlicerFileWriter uses the writtenNodes QStringList variable
to indicate which nodes were written when the write method is
invoked.  Prior to this change, a qScriptedFileWriter had no
way to set this variable, so, for example, the Save Data
dialog would always report a failure when saving with a scripted
writer.

This change makes the method virtual in the super class so that
it can be made a wrapped property in the subclass.

This allows usage as in the example below.

class MarkupsFcsvFileWriter:
    def __init__(self, parent):
        self.parent = parent

    def description(self):
        return 'Markup points as fcsv'

    def fileType(self):
        return 'MarkupsFile'

    def canWriteObject(self, obj):
        return isinstance(obj, slicer.vtkMRMLMarkupsNode)

    def extensions(self, obj):
        return ['Fiducial csv (*.fcsv)']

    def write(self, properties):
        print("parent", self.parent)
        print("Write", properties)

        if (not "nodeID" in properties
                or not "fileName" in properties):
            logging.error("Bad properties passed to MarkupsFcsvFileWriter.write")
            return False
        markupNode = slicer.mrmlScene.GetNodeByID(properties["nodeID"])
        if not markupNode or not self.canWriteObject(markupNode):
            logging.error("Bad MarkupNode passed to MarkupsFcsvFileWriter.write")
            return False
        storageNode = slicer.vtkMRMLMarkupsFiducialStorageNode()
        slicer.mrmlScene.AddNode(storageNode)
        fileName = properties["fileName"]
        if fileName.endswith(".fcsv.fcsv"):
            fileName = fileName[:-5]
        properties["fileName"] = fileName
        storageNode.SetFileName(fileName)
        storageNode.SetURI(None)
        result = storageNode.WriteData(markupNode)
        if result:
            self.parent.writtenNodes = [markupNode.GetID()]
        return bool(result)