### PR TITLE
BUG: Fix name of node loaded from filename containing multiple dots

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLColorLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLColorLogic.cxx
@@ -640,7 +640,7 @@ vtkMRMLColorTableNode* vtkMRMLColorLogic::CreateFileNode(const char* fileName)
     }
 
   ctnode->GetStorageNode()->SetFileName(fileName);
-  std::string basename = vtksys::SystemTools::GetFilenameWithoutExtension(fileName);
+  std::string basename = ctnode->GetStorageNode()->GetFileNameWithoutExtension(fileName);
   if (this->GetMRMLScene())
     {
     std::string uname(this->GetMRMLScene()->GetUniqueNameByString(basename.c_str()));
@@ -693,7 +693,7 @@ vtkMRMLProceduralColorNode* vtkMRMLColorLogic::CreateProceduralFileNode(const ch
   colorStorageNode->Delete();
 
   cpnode->GetStorageNode()->SetFileName(fileName);
-  std::string basename = vtksys::SystemTools::GetFilenameWithoutExtension(fileName);
+  std::string basename = cpnode->GetStorageNode()->GetFileNameWithoutExtension(fileName);
   if (this->GetMRMLScene())
     {
     std::string uname(this->GetMRMLScene()->GetUniqueNameByString(basename.c_str()));

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -591,8 +591,7 @@ int vtkMRMLMarkupsFiducialStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
                 {
                 vtkDebugMacro("Got point string = " << component.c_str());
                 // use the file name for the point label
-                std::string filenameName = vtksys::SystemTools::GetFilenameName(this->GetFileName());
-                label = vtksys::SystemTools::GetFilenameWithoutExtension(filenameName);
+                label = this->GetFileNameWithoutExtension(this->GetFileName());
                 markupsNode->SetNthControlPointLabel(thisMarkupNumber,label);
                 }
 

--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
@@ -302,7 +302,7 @@ vtkMRMLModelNode* vtkSlicerModelsLogic::AddModel(const char* filename,
   */
   if (storageNode != nullptr)
     {
-    std::string baseName = itksys::SystemTools::GetFilenameWithoutExtension(fname);
+    std::string baseName = storageNode->GetFileNameWithoutExtension(fname.c_str());
     std::string uname( this->GetMRMLScene()->GetUniqueNameByString(baseName.c_str()));
     modelNode->SetName(uname.c_str());
 

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -244,7 +244,8 @@ vtkMRMLSegmentationNode* vtkSlicerSegmentationsModuleLogic::GetSegmentationNodeF
 }
 
 //-----------------------------------------------------------------------------
-vtkMRMLSegmentationNode* vtkSlicerSegmentationsModuleLogic::LoadSegmentationFromFile(const char* fileName, bool autoOpacities/*=true*/)
+vtkMRMLSegmentationNode* vtkSlicerSegmentationsModuleLogic::LoadSegmentationFromFile(const char* fileName,
+  bool autoOpacities/*=true*/, const char* nodeName/*=nullptr*/)
 {
   if (this->GetMRMLScene() == nullptr || fileName == nullptr)
     {
@@ -261,8 +262,16 @@ vtkMRMLSegmentationNode* vtkSlicerSegmentationsModuleLogic::LoadSegmentationFrom
     return nullptr;
     }
 
-  std::string baseName = vtksys::SystemTools::GetFilenameWithoutExtension(fileName);
-  std::string uname( this->GetMRMLScene()->GetUniqueNameByString(baseName.c_str()));
+  std::string uname;
+  if (nodeName && strlen(nodeName)>0)
+    {
+    uname = nodeName;
+    }
+  else
+    {
+    uname = this->GetMRMLScene()->GetUniqueNameByString(storageNode->GetFileNameWithoutExtension(fileName).c_str());
+    }
+
   segmentationNode->SetName(uname.c_str());
   std::string storageUName = uname + "_Storage";
   storageNode->SetName(storageUName.c_str());

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -74,7 +74,7 @@ public:
   /// \param filename Path and name of file containing segmentation (nrrd, vtm, etc.)
   /// \param autoOpacities Optional flag determining whether segment opacities are calculated automatically based on containment. True by default
   /// \return Loaded segmentation node
-  vtkMRMLSegmentationNode* LoadSegmentationFromFile(const char* filename, bool autoOpacities = true);
+  vtkMRMLSegmentationNode* LoadSegmentationFromFile(const char* filename, bool autoOpacities = true, const char* nodeName=nullptr);
 
   /// Create labelmap volume MRML node from oriented image data.
   /// Creates a display node if a display node does not exist. Shifts image extent to start from zero.

--- a/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.cxx
+++ b/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.cxx
@@ -189,7 +189,7 @@ vtkMRMLSequenceNode* vtkSlicerSequencesLogic::AddSequence(const char* filename)
   // check to see which node can read this type of file
   if (storageNode->SupportedFileType(name.c_str()))
     {
-    std::string baseName = vtksys::SystemTools::GetFilenameWithoutExtension(fname);
+    std::string baseName = storageNode->GetFileNameWithoutExtension(fname.c_str());
     std::string uname(this->GetMRMLScene()->GetUniqueNameByString(baseName.c_str()));
     sequenceNode->SetName(uname.c_str());
 

--- a/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.cxx
+++ b/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.cxx
@@ -177,7 +177,7 @@ vtkMRMLTransformNode* vtkSlicerTransformLogic::AddTransform(const char* filename
     tnode = generalTransform.GetPointer();
   }
 
-  const std::string basename(itksys::SystemTools::GetFilenameWithoutExtension(fname));
+  const std::string basename(storageNode->GetFileNameWithoutExtension(fname.c_str()));
   const std::string uname(scene->GetUniqueNameByString(basename.c_str()));
   tnode->SetName(uname.c_str());
   scene->AddNode(storageNode.GetPointer());

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -1092,10 +1092,6 @@ vtkMRMLVolumePropertyNode* vtkSlicerVolumeRenderingLogic::AddVolumePropertyFromF
     localFile = filename;
     }
   const std::string fname(localFile);
-  // the node name is based on the file name (itksys call should work even if
-  // file is not on disk yet)
-  std::string filenameName = itksys::SystemTools::GetFilenameName(fname);
-  const std::string name = itksys::SystemTools::GetFilenameWithoutExtension(filenameName);
 
   // check to see which node can read this type of file
   if (!vpStorageNode->SupportedFileType(fname.c_str()))
@@ -1104,6 +1100,8 @@ vtkMRMLVolumePropertyNode* vtkSlicerVolumeRenderingLogic::AddVolumePropertyFromF
     return nullptr;
     }
 
+  // the node name is based on the file name
+  const std::string name = vpStorageNode->GetFileNameWithoutExtension(fname.c_str());
   std::string uname( this->GetMRMLScene()->GetUniqueNameByString(name.c_str()));
   vpNode->SetName(uname.c_str());
   this->GetMRMLScene()->AddNode(vpNode);
@@ -1159,10 +1157,8 @@ vtkMRMLShaderPropertyNode* vtkSlicerVolumeRenderingLogic::AddShaderPropertyFromF
     localFile = filename;
     }
   const std::string fname(localFile);
-  // the node name is based on the file name (itksys call should work even if
-  // file is not on disk yet)
-  std::string filenameName = itksys::SystemTools::GetFilenameName(fname);
-  const std::string name = itksys::SystemTools::GetFilenameWithoutExtension(filenameName);
+  // the node name is based on the file name
+  const std::string name = spStorageNode->GetFileNameWithoutExtension(fname.c_str());
 
   // check to see which node can read this type of file
   if (spStorageNode->SupportedFileType(fname.c_str()))
@@ -1193,7 +1189,6 @@ vtkMRMLShaderPropertyNode* vtkSlicerVolumeRenderingLogic::AddShaderPropertyFromF
   else
     {
     vtkDebugMacro("Couldn't read file, returning null model node: " << filename);
-    spNode->Delete();
     return nullptr;
     }
 }


### PR DESCRIPTION
When loading filenames, such as segmentation.1.seg.nrrd, the loaded node was named "segmentation" by default (everything after the first "." character was ignored).

Fixes issue reported at https://discourse.slicer.org/t/cannot-rename-markupsfiducial-in-load-data-window/11994/7?u=lassoan