### PR TITLE
BUG: Increase button margin for better visual appearance

### DIFF
--- a/Base/QTGUI/qSlicerStyle.cxx
+++ b/Base/QTGUI/qSlicerStyle.cxx
@@ -96,9 +96,6 @@ int qSlicerStyle::pixelMetric(PixelMetric metric, const QStyleOption * option,
 {
   switch(metric)
     {
-    case QStyle::PM_ButtonMargin:
-      return 3; // 6 by default
-      break;
     case QStyle::PM_LayoutLeftMargin:
     case QStyle::PM_LayoutTopMargin:
     case QStyle::PM_LayoutRightMargin:
@@ -268,4 +265,3 @@ bool qSlicerStyle::eventFilter(QObject* obj, QEvent* event)
     }
   return this->Superclass::eventFilter(obj, event);
 }
-


### PR DESCRIPTION
Text on buttons almost touched the border (especially in button boxes), which did not look nice. This commit reverts button margin to the default value.

Before this change (current Slicer Preview Release):

![image](https://user-images.githubusercontent.com/307929/86486459-51afb580-bd29-11ea-83f6-2140dfcbab21.png)

With this proposed change:

![image](https://user-images.githubusercontent.com/307929/86486474-5a07f080-bd29-11ea-8536-53bbc1dba141.png)

