### PR TITLE
ENH: Take Python console colors from style

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -494,6 +494,8 @@ void qSlicerMainWindowPrivate::setupUi(QMainWindow * mainWindow)
       this->PythonConsoleToggleViewAction = new QAction("", this->ViewMenu);
       this->PythonConsoleToggleViewAction->setCheckable(true);
       }
+    q->pythonConsole()->setScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    this->updatePythonConsolePalette();
     QObject::connect(q->pythonConsole(), SIGNAL(aboutToExecute(const QString&)),
       q, SLOT(onPythonConsoleUserInput(const QString&)));
     // Set up show/hide action
@@ -511,6 +513,41 @@ void qSlicerMainWindowPrivate::setupUi(QMainWindow * mainWindow)
     {
     qWarning("qSlicerMainWindowPrivate::setupUi: Failed to create Python console");
     }
+#endif
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerMainWindowPrivate::updatePythonConsolePalette()
+{
+  Q_Q(qSlicerMainWindow);
+#ifdef Slicer_USE_PYTHONQT
+  ctkPythonConsole* pythonConsole = q->pythonConsole();
+  if (!pythonConsole)
+    {
+    return;
+    }
+  QPalette palette = qSlicerApplication::application()->palette();
+
+  // pythonConsole->setBackgroundColor is not called, because by default
+  // the background color of the current palette is used, which is good.
+
+  // Color of the >> prompt. Blue in both bright and dark styles (brighter in dark style).
+  pythonConsole->setPromptColor(palette.color(QPalette::Highlight));
+
+  // Color of text that user types in the console. Blue in both bright and dark styles (brighter in dark style).
+  pythonConsole->setCommandTextColor(palette.color(QPalette::Link));
+
+  // Color of output of commands. Black in bright style, white in dark style.
+  pythonConsole->setOutputTextColor(palette.color(QPalette::WindowText));
+
+  // Color of error messages. Red in both bright and dark styles.
+  pythonConsole->setErrorTextColor(palette.color(QPalette::BrightText));
+
+  // Color of welcome message (printed when the terminal is reset)
+  // and "user input" (this does not seem to be used in Slicer).
+  // Gray in both bright and dark styles.
+  pythonConsole->setStdinTextColor(palette.color(QPalette::Disabled, QPalette::WindowText));   // gray
+  pythonConsole->setWelcomeTextColor(palette.color(QPalette::Disabled, QPalette::WindowText)); // gray
 #endif
 }
 
@@ -1668,4 +1705,26 @@ bool qSlicerMainWindow::eventFilter(QObject* object, QEvent* event)
     }
 #endif
   return this->Superclass::eventFilter(object, event);
+}
+
+//---------------------------------------------------------------------------
+void qSlicerMainWindow::onStyleChanged()
+{
+  Q_D(qSlicerMainWindow);
+#ifdef Slicer_USE_PYTHONQT
+  d->updatePythonConsolePalette();
+#endif
+}
+
+//---------------------------------------------------------------------------
+void qSlicerMainWindow::changeEvent(QEvent* event)
+{
+  Q_D(qSlicerMainWindow);
+  this->Superclass::changeEvent(event);
+  if (event->type() == QEvent::StyleChange)
+    {
+    // At this point, style change is in progress, therefore palette update has not happened yet.
+    // We just set a timer to update the colormap when the application becomes idle.
+    QTimer::singleShot(0, this, SLOT(onStyleChanged()));
+    }
 }

--- a/Base/QTApp/qSlicerMainWindow.h
+++ b/Base/QTApp/qSlicerMainWindow.h
@@ -123,6 +123,8 @@ protected slots:
   virtual void onLayoutChanged(int);
   virtual void onWarningsOrErrorsOccurred(ctkErrorLogLevel::LogLevel logLevel);
 
+  virtual void onStyleChanged();
+
 #ifdef Slicer_USE_PYTHONQT
   virtual void onPythonConsoleUserInput(const QString&);
 #endif
@@ -156,6 +158,8 @@ protected:
 
   void closeEvent(QCloseEvent *event) override;
   void showEvent(QShowEvent *event) override;
+
+  void changeEvent(QEvent* event) override;
 
 protected:
   QScopedPointer<qSlicerMainWindowPrivate> d_ptr;

--- a/Base/QTApp/qSlicerMainWindow_p.h
+++ b/Base/QTApp/qSlicerMainWindow_p.h
@@ -67,6 +67,8 @@ public:
 
   void setErrorLogIconHighlighted(bool);
 
+  void updatePythonConsolePalette();
+
 #ifdef Slicer_USE_PYTHONQT
   QDockWidget*                    PythonConsoleDockWidget;
   QAction*                        PythonConsoleToggleViewAction;

--- a/Base/QTGUI/Resources/UI/qSlicerSettingsPythonPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsPythonPanel.ui
@@ -26,130 +26,6 @@
       <property name="fieldGrowthPolicy">
        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
       </property>
-      <item row="1" column="0">
-       <widget class="QLabel" name="BackgroundColorLabel">
-        <property name="text">
-         <string>Background color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="ctkColorPickerButton" name="BackgroundColorPicker"/>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="Line" name="ShellDisplayFirstLine">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="PromptColorLabel">
-        <property name="text">
-         <string>Prompt color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="ctkColorPickerButton" name="PromptColorPicker"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="OutputTextColorLabel">
-        <property name="text">
-         <string>Output text color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="ctkColorPickerButton" name="OutputTextColorPicker"/>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="ErrorTextColorLabel">
-        <property name="text">
-         <string>Error text color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="ctkColorPickerButton" name="ErrorTextColorPicker"/>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="StdinTextColorLabel">
-        <property name="text">
-         <string>Standard input text color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="ctkColorPickerButton" name="StdinTextColorPicker"/>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="CommandTextColorLabel">
-        <property name="text">
-         <string>Command text color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="ctkColorPickerButton" name="CommandTextColorPicker"/>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="WelcomeTextColorLabel">
-        <property name="text">
-         <string>Welcome text color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <widget class="ctkColorPickerButton" name="WelcomeTextColorPicker"/>
-      </item>
-      <item row="10" column="0" colspan="2">
-       <widget class="Line" name="ShellDisplaySecondLine">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="0">
-       <widget class="QLabel" name="ScrollBarPolicyLabel">
-        <property name="text">
-         <string>Scrollbar is:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="1">
-       <widget class="QComboBox" name="ScrollBarPolicyComboBox">
-        <item>
-         <property name="text">
-          <string>Visible if needed</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Disabled</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Always visible</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="11" column="0">
-       <widget class="QLabel" name="PromptFontLabel">
-        <property name="text">
-         <string>Shell font:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="11" column="1">
-       <widget class="ctkFontButton" name="pythonFontButton">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="DockableWindowLabel">
         <property name="text">
@@ -167,6 +43,20 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="PromptFontLabel">
+        <property name="text">
+         <string>Shell font:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ctkFontButton" name="pythonFontButton">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -177,11 +67,6 @@
    <class>ctkCheckBox</class>
    <extends>QCheckBox</extends>
    <header>ctkCheckBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ctkColorPickerButton</class>
-   <extends>QPushButton</extends>
-   <header>ctkColorPickerButton.h</header>
   </customwidget>
   <customwidget>
    <class>ctkFontButton</class>

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -205,6 +205,11 @@ void qSlicerApplicationPrivate::init()
 #ifdef Slicer_USE_PYTHONQT
   if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
     {
+    // Initialize method prints the welcome message and a prompt, so we need to set these colors now.
+    // All the other colors will be set later in the main window.
+    QPalette palette = qSlicerApplication::application()->palette();
+    q->pythonConsole()->setWelcomeTextColor(palette.color(QPalette::Disabled, QPalette::WindowText));
+    q->pythonConsole()->setPromptColor(palette.color(QPalette::Highlight));
     q->pythonConsole()->initialize(q->pythonManager());
     QStringList autocompletePreferenceList;
     autocompletePreferenceList

--- a/Base/QTGUI/qSlicerSettingsPythonPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsPythonPanel.cxx
@@ -72,51 +72,11 @@ void qSlicerSettingsPythonPanelPrivate::init()
 
   // Set default properties
 
-  this->BackgroundColorPicker->setColor(this->PythonConsole->backgroundColor());
-
-  this->PromptColorPicker->setColor(this->PythonConsole->promptColor());
-
-  this->OutputTextColorPicker->setColor(this->PythonConsole->outputTextColor());
-
-  this->ErrorTextColorPicker->setColor(this->PythonConsole->errorTextColor());
-
-  this->StdinTextColorPicker->setColor(this->PythonConsole->stdinTextColor());
-
-  this->CommandTextColorPicker->setColor(this->PythonConsole->commandTextColor());
-
-  this->WelcomeTextColorPicker->setColor(this->PythonConsole->welcomeTextColor());
-
-  this->ScrollBarPolicyComboBox->setCurrentIndex(this->PythonConsole->scrollBarPolicy());
-
   this->pythonFontButton->setCurrentFont(this->PythonConsole->shellFont());
 
   //
   // Connect panel widgets with associated slots
   //
-
-  QObject::connect(this->BackgroundColorPicker, SIGNAL(colorChanged(QColor)),
-                   q, SLOT(onBackgroundColorChanged(QColor)));
-
-  QObject::connect(this->PromptColorPicker, SIGNAL(colorChanged(QColor)),
-                   q, SLOT(onPromptColorChanged(QColor)));
-
-  QObject::connect(this->OutputTextColorPicker, SIGNAL(colorChanged(QColor)),
-                   q, SLOT(onOutputTextColorChanged(QColor)));
-
-  QObject::connect(this->ErrorTextColorPicker, SIGNAL(colorChanged(QColor)),
-                   q, SLOT(onErrorTextColorChanged(QColor)));
-
-  QObject::connect(this->StdinTextColorPicker, SIGNAL(colorChanged(QColor)),
-                   q, SLOT(onStdinTextColorChanged(QColor)));
-
-  QObject::connect(this->CommandTextColorPicker, SIGNAL(colorChanged(QColor)),
-                   q, SLOT(onCommandTextColorChanged(QColor)));
-
-  QObject::connect(this->WelcomeTextColorPicker, SIGNAL(colorChanged(QColor)),
-                   q, SLOT(onWelcomeTextColorChanged(QColor)));
-
-  QObject::connect(this->ScrollBarPolicyComboBox, SIGNAL(currentIndexChanged(int)),
-                   q, SLOT(onScrollBarPolicyChanged(int)));
 
   QObject::connect(this->pythonFontButton, SIGNAL(currentFontChanged(QFont)),
                    q, SLOT(onFontChanged(QFont)));
@@ -128,30 +88,6 @@ void qSlicerSettingsPythonPanelPrivate::init()
     "checked", SIGNAL(toggled(bool)),
     "Display Python interactor in a window that can be placed inside the main window.",
     ctkSettingsPanel::OptionRequireRestart);
-
-  q->registerProperty("Python/BackgroundColor", this->BackgroundColorPicker, "color",
-                      SIGNAL(colorChanged(QColor)));
-
-  q->registerProperty("Python/PromptColor", this->PromptColorPicker, "color",
-                      SIGNAL(colorChanged(QColor)));
-
-  q->registerProperty("Python/OutputTextColor", this->OutputTextColorPicker, "color",
-                      SIGNAL(colorChanged(QColor)));
-
-  q->registerProperty("Python/ErrorTextColor", this->ErrorTextColorPicker, "color",
-                      SIGNAL(colorChanged(QColor)));
-
-  q->registerProperty("Python/StdinTextColor", this->StdinTextColorPicker, "color",
-                      SIGNAL(colorChanged(QColor)));
-
-  q->registerProperty("Python/CommandTextColor", this->CommandTextColorPicker, "color",
-                      SIGNAL(colorChanged(QColor)));
-
-  q->registerProperty("Python/WelcomeTextColor", this->WelcomeTextColorPicker, "color",
-                      SIGNAL(colorChanged(QColor)));
-
-  q->registerProperty("Python/ScrollBarPolicy", this->ScrollBarPolicyComboBox, "currentIndex",
-                      SIGNAL(currentIndexChanged(int)));
 
   q->registerProperty("Python/Font", this->pythonFontButton, "currentFont",
                       SIGNAL(currentFontChanged(QFont)));
@@ -171,62 +107,6 @@ qSlicerSettingsPythonPanel::qSlicerSettingsPythonPanel(QWidget* _parent)
 
 // --------------------------------------------------------------------------
 qSlicerSettingsPythonPanel::~qSlicerSettingsPythonPanel() = default;
-
-// --------------------------------------------------------------------------
-void qSlicerSettingsPythonPanel::onBackgroundColorChanged(const QColor& newColor)
-{
-  Q_D(qSlicerSettingsPythonPanel);
-  d->PythonConsole->setBackgroundColor(newColor);
-}
-
-// --------------------------------------------------------------------------
-void qSlicerSettingsPythonPanel::onPromptColorChanged(const QColor& newColor)
-{
-  Q_D(qSlicerSettingsPythonPanel);
-  d->PythonConsole->setPromptColor(newColor);
-}
-
-// --------------------------------------------------------------------------
-void qSlicerSettingsPythonPanel::onOutputTextColorChanged(const QColor& newColor)
-{
-  Q_D(qSlicerSettingsPythonPanel);
-  d->PythonConsole->setOutputTextColor(newColor);
-}
-
-// --------------------------------------------------------------------------
-void qSlicerSettingsPythonPanel::onErrorTextColorChanged(const QColor& newColor)
-{
-  Q_D(qSlicerSettingsPythonPanel);
-  d->PythonConsole->setErrorTextColor(newColor);
-}
-
-// --------------------------------------------------------------------------
-void qSlicerSettingsPythonPanel::onStdinTextColorChanged(const QColor& newColor)
-{
-  Q_D(qSlicerSettingsPythonPanel);
-  d->PythonConsole->setStdinTextColor(newColor);
-}
-
-// --------------------------------------------------------------------------
-void qSlicerSettingsPythonPanel::onCommandTextColorChanged(const QColor& newColor)
-{
-  Q_D(qSlicerSettingsPythonPanel);
-  d->PythonConsole->setCommandTextColor(newColor);
-}
-
-// --------------------------------------------------------------------------
-void qSlicerSettingsPythonPanel::onWelcomeTextColorChanged(const QColor& newColor)
-{
-  Q_D(qSlicerSettingsPythonPanel);
-  d->PythonConsole->setWelcomeTextColor(newColor);
-}
-
-// --------------------------------------------------------------------------
-void qSlicerSettingsPythonPanel::onScrollBarPolicyChanged(int index)
-{
-  Q_D(qSlicerSettingsPythonPanel);
-  d->PythonConsole->setScrollBarPolicy(static_cast<Qt::ScrollBarPolicy>(index));
-}
 
 // --------------------------------------------------------------------------
 void qSlicerSettingsPythonPanel::onFontChanged(const QFont& font)

--- a/Base/QTGUI/qSlicerSettingsPythonPanel.h
+++ b/Base/QTGUI/qSlicerSettingsPythonPanel.h
@@ -48,22 +48,7 @@ public:
   ~qSlicerSettingsPythonPanel() override;
 
 protected slots:
-
-  void onBackgroundColorChanged(const QColor& newColor);
-
-  void onPromptColorChanged(const QColor& newColor);
-  void onOutputTextColorChanged(const QColor& newColor);
-  void onErrorTextColorChanged(const QColor& newColor);
-  void onStdinTextColorChanged(const QColor& newColor);
-  void onCommandTextColorChanged(const QColor& newColor);
-  void onWelcomeTextColorChanged(const QColor& newColor);
-
-  void onScrollBarPolicyChanged(int index);
-
   void onFontChanged(const QFont& font);
-//  void onFontChanged(const QFont& font);
-//  void onShowToolTipsToggled(bool);
-//  void onShowToolButtonTextToggled(bool enable);
 
 protected:
   QScopedPointer<qSlicerSettingsPythonPanelPrivate> d_ptr;


### PR DESCRIPTION
Requires merging of #4993 first! 

Python console colors were stored in application settings and so the same colors were used regardless of chosen style (dark or light Slicer).
Since setting up color scheme for the Python console takes quite an effort (manual selection of 7 colors) so probably very few people did it.

To make things simpler and make Python console match the current style, with this commit we remove customization option for console colors and use colors from the style's palette.

Partial fix for #4803.

Before this change (with default settings):

![image](https://user-images.githubusercontent.com/307929/86505131-295aa200-bd8f-11ea-9502-59426275cc01.png)

After this change, bright style:

![image](https://user-images.githubusercontent.com/307929/86505135-35466400-bd8f-11ea-922b-b82abb2f86a2.png)

After this change, dark style:

![image](https://user-images.githubusercontent.com/307929/86505140-3d9e9f00-bd8f-11ea-8dd2-272bffae6558.png)
