### PR TITLE
ENH: Make Slicer application fully portable

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -707,6 +707,18 @@ bool vtkSlicerApplicationLogic::IsEmbeddedModule(const std::string& filePath,
   std::string extensionPath = itksys::SystemTools::GetFilenamePath(filePath);
   bool isEmbedded = itksys::SystemTools::StringStartsWith(extensionPath.c_str(), applicationHomeDir.c_str());
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
+  // If settings are stored in application home directory then extensions are installed within the home directory
+  // in <applicationHomeDir>/<Slicer_ORGANIZATION_NAME/DOMAIN>/<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>.
+  // Therefore we consider the module not embedded it it is within <Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision> folder.
+  // It would be even more robust if we checked <organization>/<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>
+  // subfolder, but getting organization folder name from Slicer_ORGANIZATION_NAME/Slicer_ORGANIZATION_DOMAIN values is not a trivial,
+  // so for now we do not check the organization.
+#ifdef Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR
+  if (isEmbedded && extensionPath.find(Slicer_EXTENSIONS_DIRBASENAME "-" + slicerRevision) != std::string::npos)
+    {
+    isEmbedded = false;
+    }
+#endif
   // On MacOSX extensions are installed in the "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>"
   // folder being a sub directory of the application dir, an extra test is required to make sure the
   // tested filePath doesn't belong to that "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>" folder.

--- a/Base/Python/slicer/slicerqt.py
+++ b/Base/Python/slicer/slicerqt.py
@@ -101,13 +101,18 @@ def initLogging(logger):
 initLogging(logging.getLogger())
 
 def getSlicerRCFileName():
-  """Return slicer resource script file name '~/.slicerrc.py'"""
+  """Return application startup file (Slicer resource script) file name.
+  If a .slicerrc.py file is found in slicer.app.slicerHome folder then that will be used.
+  If that is not found then the path defined in SLICERRC environment variable will be used.
+  If that environment variable is not specified then .slicerrc.py in the user's home folder
+  will be used ('~/.slicerrc.py')."""
   import os
-  if 'SLICERRC' in os.environ:
-    rcfile = os.environ['SLICERRC']
-  else:
-    import os.path
-    rcfile = os.path.expanduser( '~/.slicerrc.py' )
+  rcfile = os.path.join(slicer.app.slicerHome,".slicerrc.py")
+  if not os.path.exists(rcfile):
+    if 'SLICERRC' in os.environ:
+      rcfile = os.environ['SLICERRC']
+    else:
+      rcfile = os.path.expanduser( '~/.slicerrc.py' )
   rcfile = rcfile.replace('\\','/') # make slashed consistent on Windows
   return rcfile
 

--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -204,7 +204,7 @@ void qSlicerApplicationHelper::setupModuleFactoryManager(qSlicerModuleFactoryMan
     }
 #endif
   moduleFactoryManager->addSearchPaths(
-    app->revisionUserSettings()->value("Modules/AdditionalPaths").toStringList());
+    app->toSlicerHomeAbsolutePaths(app->revisionUserSettings()->value("Modules/AdditionalPaths").toStringList()));
 
   QStringList modulesToAlwaysIgnore =
     app->revisionUserSettings()->value("Modules/IgnoreModules").toStringList();

--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -639,7 +639,9 @@ QList<qSlicerIO::IOProperties> qSlicerMainWindowPrivate::readRecentlyLoadedFiles
     {
     settings.setArrayIndex(i);
     QVariant file = settings.value("file");
-    fileProperties << file.toMap();
+    qSlicerIO::IOProperties properties = file.toMap();
+    properties["fileName"] = qSlicerApplication::application()->toSlicerHomeAbsolutePath(properties["fileName"].toString());
+    fileProperties << properties;
     }
   settings.endArray();
 
@@ -654,7 +656,9 @@ void qSlicerMainWindowPrivate::writeRecentlyLoadedFiles(const QList<qSlicerIO::I
   for (int i = 0; i < fileProperties.size(); ++i)
     {
     settings.setArrayIndex(i);
-    settings.setValue("file", fileProperties.at(i));
+    qSlicerIO::IOProperties properties = fileProperties.at(i);
+    properties["fileName"] = qSlicerApplication::application()->toSlicerHomeRelativePath(properties["fileName"].toString());
+    settings.setValue("file", properties);
     }
   settings.endArray();
 }

--- a/Base/QTCLI/qSlicerCLIModuleFactoryHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleFactoryHelper.cxx
@@ -59,7 +59,7 @@ const QStringList qSlicerCLIModuleFactoryHelper::modulePaths()
     }
 
   QSettings * settings = app->revisionUserSettings();
-  QStringList additionalModulePaths = settings->value("Modules/AdditionalPaths").toStringList();
+  QStringList additionalModulePaths = app->toSlicerHomeAbsolutePaths(settings->value("Modules/AdditionalPaths").toStringList());
   QStringList cmdLineModulePaths = additionalModulePaths + defaultCmdLineModulePaths;
   foreach(const QString& path, cmdLineModulePaths)
     {

--- a/Base/QTCore/CMakeLists.txt
+++ b/Base/QTCore/CMakeLists.txt
@@ -97,6 +97,8 @@ set(KIT_SRCS
   qSlicerObject.h
   qSlicerPersistentCookieJar.cxx
   qSlicerPersistentCookieJar.h
+  qSlicerRelativePathMapper.cxx
+  qSlicerRelativePathMapper.h
   qSlicerSceneBundleReader.cxx
   qSlicerSceneBundleReader.h
   qSlicerSlicer2SceneReader.cxx
@@ -145,6 +147,7 @@ set(KIT_MOC_SRCS
   qSlicerIO.h
   qSlicerModuleFactoryManager.h
   qSlicerModuleManager.h
+  qSlicerRelativePathMapper.h
   qSlicerSceneBundleReader.h
   qSlicerSlicer2SceneReader.h
   )

--- a/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
@@ -19,7 +19,7 @@
 ==============================================================================*/
 
 // Qt includes
-#include <QApplication>
+#include <qSlicerCoreApplication.h>
 #include <QScriptEngine>
 
 // CTK includes
@@ -352,11 +352,6 @@ void qSlicerExtensionsManagerModelTester::initTestCase()
 
   this->TemporaryDirName =
       QString("qSlicerExtensionsManagerModelTester.%1").arg(QTime::currentTime().toString("hhmmsszzz"));
-
-  // Setup QApplication for settings
-  qApp->setOrganizationName("NA-MIC");
-  qApp->setOrganizationDomain("www.slicer.org/tests");
-  qApp->setApplicationName("SlicerTests");
 
   QSettings().clear();
 }
@@ -2050,6 +2045,12 @@ void qSlicerExtensionsManagerModelTester::testSetSlicerVersion_data()
 }
 
 // ----------------------------------------------------------------------------
-CTK_TEST_MAIN(qSlicerExtensionsManagerModelTest)
+int qSlicerExtensionsManagerModelTest(int argc, char* argv[])
+{
+  qSlicerCoreApplication app(argc, argv);
+  QTEST_DISABLE_KEYPAD_NAVIGATION
+  qSlicerExtensionsManagerModelTester tc;
+  return QTest::qExec(&tc, argc, argv);
+}
 #include "moc_qSlicerExtensionsManagerModelTest.cxx"
 

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -471,6 +471,22 @@ public:
   /// If error is true then the message is printed on stderr, otherwise on stdout.
   Q_INVOKABLE void showConsoleMessage(QString message, bool error=true) const;
 
+  /// Converts relative path to absolute path using slicerHome directory.
+  /// Returns absolute path unchanged.
+  Q_INVOKABLE QString toSlicerHomeAbsolutePath(const QString& path) const;
+
+  /// Converts paths within slicerHome directory to relative paths.
+  /// Leaves other paths unchanged.
+  Q_INVOKABLE QString toSlicerHomeRelativePath(const QString& path) const;
+
+  /// Converts relative path to absolute path using slicerHome directory.
+  /// Returns absolute path unchanged.
+  Q_INVOKABLE QStringList toSlicerHomeAbsolutePaths(const QStringList& path) const;
+
+  /// Converts paths within slicerHome directory to relative paths.
+  /// Leaves other paths unchanged.
+  Q_INVOKABLE QStringList toSlicerHomeRelativePaths(const QStringList& path) const;
+
 public slots:
 
   /// Restart the application with the arguments passed at startup time

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -43,6 +43,7 @@
 #include <qRestResult.h>
 
 // QtCore includes
+#include "qSlicerCoreApplication.h"
 #include "qSlicerExtensionsManagerModel.h"
 #include "vtkSlicerConfigure.h"
 #include "vtkSlicerVersionConfigure.h"
@@ -492,9 +493,9 @@ void qSlicerExtensionsManagerModelPrivate::addExtensionPathToApplicationSettings
 {
   Q_Q(qSlicerExtensionsManagerModel);
   QSettings settings(q->extensionsSettingsFilePath(), QSettings::IniFormat);
-  QStringList additionalPaths = settings.value("Modules/AdditionalPaths").toStringList();
+  QStringList additionalPaths = qSlicerCoreApplication::application()->toSlicerHomeAbsolutePaths(settings.value("Modules/AdditionalPaths").toStringList());
   settings.setValue("Modules/AdditionalPaths",
-                    appendToPathList(additionalPaths, q->extensionModulePaths(extensionName)));
+    qSlicerCoreApplication::application()->toSlicerHomeRelativePaths(appendToPathList(additionalPaths, q->extensionModulePaths(extensionName))));
 }
 
 // --------------------------------------------------------------------------
@@ -502,9 +503,9 @@ void qSlicerExtensionsManagerModelPrivate::removeExtensionPathFromApplicationSet
 {
   Q_Q(qSlicerExtensionsManagerModel);
   QSettings settings(q->extensionsSettingsFilePath(), QSettings::IniFormat);
-  QStringList additionalPaths = settings.value("Modules/AdditionalPaths").toStringList();
+  QStringList additionalPaths = qSlicerCoreApplication::application()->toSlicerHomeAbsolutePaths(settings.value("Modules/AdditionalPaths").toStringList());
   settings.setValue("Modules/AdditionalPaths",
-                    removeFromPathList(additionalPaths, q->extensionModulePaths(extensionName)));
+    qSlicerCoreApplication::application()->toSlicerHomeRelativePaths(removeFromPathList(additionalPaths, q->extensionModulePaths(extensionName))));
 }
 
 // --------------------------------------------------------------------------
@@ -520,27 +521,28 @@ void qSlicerExtensionsManagerModelPrivate::addExtensionPathToLauncherSettings(co
     this->warning(qSlicerExtensionsManagerModel::tr("Failed to open extensions settings file %1").arg(this->ExtensionsSettingsFilePath));
     return;
     }
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
 
-  QStringList libraryPath = qSlicerExtensionsManagerModel::readArrayValues(settings, "LibraryPaths", "path");
+  QStringList libraryPath = app->toSlicerHomeAbsolutePaths(qSlicerExtensionsManagerModel::readArrayValues(settings, "LibraryPaths", "path"));
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
-                         appendToPathList(libraryPath, this->extensionLibraryPaths(extensionName)),
+                         app->toSlicerHomeRelativePaths(appendToPathList(libraryPath, this->extensionLibraryPaths(extensionName))),
                          "LibraryPaths", "path");
 
-  QStringList paths = qSlicerExtensionsManagerModel::readArrayValues(settings, "Paths", "path");
+  QStringList paths = app->toSlicerHomeAbsolutePaths(qSlicerExtensionsManagerModel::readArrayValues(settings, "Paths", "path"));
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
-                         appendToPathList(paths, this->extensionPaths(extensionName)),
+                         app->toSlicerHomeRelativePaths(appendToPathList(paths, this->extensionPaths(extensionName))),
                          "Paths", "path");
 
 #ifdef Slicer_USE_PYTHONQT
-  QStringList pythonPaths = qSlicerExtensionsManagerModel::readArrayValues(settings, "PYTHONPATH", "path");
+  QStringList pythonPaths = app->toSlicerHomeAbsolutePaths(qSlicerExtensionsManagerModel::readArrayValues(settings, "PYTHONPATH", "path"));
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
-                         appendToPathList(pythonPaths, this->extensionPythonPaths(extensionName)),
+                         app->toSlicerHomeRelativePaths(appendToPathList(pythonPaths, this->extensionPythonPaths(extensionName))),
                          "PYTHONPATH", "path");
 #endif
 
-  QStringList qtPluginPaths = qSlicerExtensionsManagerModel::readArrayValues(settings, "QT_PLUGIN_PATH", "path");
+  QStringList qtPluginPaths = app->toSlicerHomeAbsolutePaths(qSlicerExtensionsManagerModel::readArrayValues(settings, "QT_PLUGIN_PATH", "path"));
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
-                         appendToPathList(qtPluginPaths, this->extensionQtPluginPaths(extensionName)),
+                         app->toSlicerHomeRelativePaths(appendToPathList(qtPluginPaths, this->extensionQtPluginPaths(extensionName))),
                          "QT_PLUGIN_PATH", "path");
 }
 
@@ -557,27 +559,28 @@ void qSlicerExtensionsManagerModelPrivate::removeExtensionPathFromLauncherSettin
     this->warning(qSlicerExtensionsManagerModel::tr("Failed to open extensions settings file: %1").arg(this->ExtensionsSettingsFilePath));
     return;
     }
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
 
-  QStringList libraryPath = qSlicerExtensionsManagerModel::readArrayValues(settings, "LibraryPaths", "path");
+  QStringList libraryPath = app->toSlicerHomeAbsolutePaths(qSlicerExtensionsManagerModel::readArrayValues(settings, "LibraryPaths", "path"));
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
-                         removeFromPathList(libraryPath, this->extensionLibraryPaths(extensionName)),
+                         app->toSlicerHomeRelativePaths(removeFromPathList(libraryPath, this->extensionLibraryPaths(extensionName))),
                          "LibraryPaths", "path");
 
-  QStringList paths = qSlicerExtensionsManagerModel::readArrayValues(settings, "Paths", "path");
+  QStringList paths = app->toSlicerHomeAbsolutePaths(qSlicerExtensionsManagerModel::readArrayValues(settings, "Paths", "path"));
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
-                         removeFromPathList(paths, this->extensionPaths(extensionName)),
+                         app->toSlicerHomeRelativePaths(removeFromPathList(paths, this->extensionPaths(extensionName))),
                          "Paths", "path");
 
 #ifdef Slicer_USE_PYTHONQT
-  QStringList pythonPaths = qSlicerExtensionsManagerModel::readArrayValues(settings, "PYTHONPATH", "path");
+  QStringList pythonPaths = app->toSlicerHomeAbsolutePaths(qSlicerExtensionsManagerModel::readArrayValues(settings, "PYTHONPATH", "path"));
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
-                         removeFromPathList(pythonPaths, this->extensionPythonPaths(extensionName)),
+                         app->toSlicerHomeRelativePaths(removeFromPathList(pythonPaths, this->extensionPythonPaths(extensionName))),
                          "PYTHONPATH", "path");
 #endif
 
-  QStringList qtPluginPaths = qSlicerExtensionsManagerModel::readArrayValues(settings, "QT_PLUGIN_PATH", "path");
+  QStringList qtPluginPaths = app->toSlicerHomeAbsolutePaths(qSlicerExtensionsManagerModel::readArrayValues(settings, "QT_PLUGIN_PATH", "path"));
   qSlicerExtensionsManagerModel::writeArrayValues(settings,
-                         removeFromPathList(qtPluginPaths, this->extensionQtPluginPaths(extensionName)),
+                         app->toSlicerHomeRelativePaths(removeFromPathList(qtPluginPaths, this->extensionQtPluginPaths(extensionName))),
                          "QT_PLUGIN_PATH", "path");
 }
 
@@ -1108,7 +1111,7 @@ QUrl qSlicerExtensionsManagerModel::serverUrlWithExtensionsStorePath()const
 QString qSlicerExtensionsManagerModel::extensionsInstallPath()const
 {
   QSettings settings(this->extensionsSettingsFilePath(), QSettings::IniFormat);
-  return settings.value("Extensions/InstallPath").toString();
+  return qSlicerCoreApplication::application()->toSlicerHomeAbsolutePath(settings.value("Extensions/InstallPath").toString());
 }
 
 // --------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerLoadableModuleFactory.cxx
+++ b/Base/QTCore/qSlicerLoadableModuleFactory.cxx
@@ -89,7 +89,7 @@ QStringList qSlicerLoadableModuleFactoryPrivate::modulePaths() const
     }
 
   QSettings * settings = app->revisionUserSettings();
-  QStringList additionalModulePaths = settings->value("Modules/AdditionalPaths").toStringList();
+  QStringList additionalModulePaths = app->toSlicerHomeAbsolutePaths(settings->value("Modules/AdditionalPaths").toStringList());
   QStringList qtModulePaths =  additionalModulePaths + defaultQTModulePaths;
 
   //qDebug() << "qtModulePaths:" << qtModulePaths;

--- a/Base/QTCore/qSlicerRelativePathMapper.cxx
+++ b/Base/QTCore/qSlicerRelativePathMapper.cxx
@@ -1,0 +1,164 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+// Qt includes
+#include <QVariant>
+
+// Slicer includes
+#include "qSlicerRelativePathMapper.h"
+#include "qSlicerCoreApplication.h"
+
+//-----------------------------------------------------------------------------
+class qSlicerRelativePathMapperPrivate
+{
+public:
+  qSlicerRelativePathMapperPrivate();
+  QByteArray PropertyName;
+};
+
+// --------------------------------------------------------------------------
+qSlicerRelativePathMapperPrivate::qSlicerRelativePathMapperPrivate()
+{
+}
+
+// --------------------------------------------------------------------------
+// qSlicerRelativePathMapper methods
+
+// --------------------------------------------------------------------------
+qSlicerRelativePathMapper::qSlicerRelativePathMapper(
+  QObject* targetObject, const QByteArray& property, const QByteArray& signal)
+  : QObject(targetObject)
+  , d_ptr(new qSlicerRelativePathMapperPrivate)
+{
+  Q_ASSERT(!property.isEmpty());
+  Q_ASSERT(targetObject != nullptr);
+  Q_D(qSlicerRelativePathMapper);
+  d->PropertyName = property;
+  if (!signal.isEmpty())
+    {
+    if (QString(this->targetObject()->property(this->propertyName()).typeName()).compare("QStringList") == 0)
+      {
+      // Property is a QStringList
+      connect(targetObject, signal, this, SLOT(emitPathsChanged()));
+      }
+    else
+      {
+      connect(targetObject, signal, this, SLOT(emitPathChanged()));
+      }
+    }
+}
+
+// --------------------------------------------------------------------------
+qSlicerRelativePathMapper::~qSlicerRelativePathMapper()
+{
+}
+
+// --------------------------------------------------------------------------
+QByteArray qSlicerRelativePathMapper::propertyName()const
+{
+  Q_D(const qSlicerRelativePathMapper);
+  return d->PropertyName;
+}
+
+// --------------------------------------------------------------------------
+QObject* qSlicerRelativePathMapper::targetObject()const
+{
+  return this->parent();
+}
+
+// --------------------------------------------------------------------------
+QString qSlicerRelativePathMapper::path()const
+{
+  Q_D(const qSlicerRelativePathMapper);
+  return this->targetObject()->property(this->propertyName()).toString();
+}
+
+// --------------------------------------------------------------------------
+QStringList qSlicerRelativePathMapper::paths()const
+{
+  Q_D(const qSlicerRelativePathMapper);
+  return this->targetObject()->property(this->propertyName()).toStringList();
+}
+
+// --------------------------------------------------------------------------
+QString qSlicerRelativePathMapper::relativePath()const
+{
+  Q_D(const qSlicerRelativePathMapper);
+  return qSlicerCoreApplication::application()->toSlicerHomeRelativePath(this->path());
+}
+
+// --------------------------------------------------------------------------
+QStringList qSlicerRelativePathMapper::relativePaths()const
+{
+  Q_D(const qSlicerRelativePathMapper);
+  return qSlicerCoreApplication::application()->toSlicerHomeRelativePaths(this->paths());
+}
+
+// --------------------------------------------------------------------------
+void qSlicerRelativePathMapper::setPath(const QString& newPath)
+{
+  Q_D(qSlicerRelativePathMapper);
+  if (this->path() == newPath)
+    {
+    return;
+    }
+  this->targetObject()->setProperty(this->propertyName(), QVariant(newPath));
+  this->emitPathChanged();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerRelativePathMapper::setPaths(const QStringList& newPaths)
+{
+  Q_D(qSlicerRelativePathMapper);
+  if (this->paths() == newPaths)
+    {
+    return;
+    }
+  this->targetObject()->setProperty(this->propertyName(), QVariant(newPaths));
+  this->emitPathsChanged();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerRelativePathMapper::setRelativePath(const QString& newRelativePath)
+{
+  Q_D(qSlicerRelativePathMapper);
+  this->setPath(qSlicerCoreApplication::application()->toSlicerHomeAbsolutePath(newRelativePath));
+}
+
+// --------------------------------------------------------------------------
+void qSlicerRelativePathMapper::setRelativePaths(const QStringList& newRelativePaths)
+{
+  Q_D(qSlicerRelativePathMapper);
+  this->setPaths(qSlicerCoreApplication::application()->toSlicerHomeAbsolutePaths(newRelativePaths));
+}
+
+// --------------------------------------------------------------------------
+void qSlicerRelativePathMapper::emitPathChanged()
+{
+  emit pathChanged(this->path());
+  emit relativePathChanged(this->relativePath());
+}
+
+// --------------------------------------------------------------------------
+void qSlicerRelativePathMapper::emitPathsChanged()
+{
+  emit pathsChanged(this->paths());
+  emit relativePathsChanged(this->relativePaths());
+}

--- a/Base/QTCore/qSlicerRelativePathMapper.h
+++ b/Base/QTCore/qSlicerRelativePathMapper.h
@@ -1,0 +1,101 @@
+/*=========================================================================
+
+  Library:   CTK
+
+  Copyright (c) Kitware Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+=========================================================================*/
+
+#ifndef __qSlicerRelativePathMapper_h
+#define __qSlicerRelativePathMapper_h
+
+// Qt includes
+#include <QObject>
+
+// CTK includes
+#include "qSlicerBaseQTCoreExport.h"
+class qSlicerRelativePathMapperPrivate;
+
+//---------------------------------------------------------------------------
+///
+/// Example:
+///   ctkDirectoryButton* directorySelector = new ctkDirectoryButton;
+///   qSlicerRelativePathMapper* makeRelative =
+///     new qSlicerRelativePathMapper("directory", SIGNAL("directoryChanged(QString)"), directorySelector);
+///   makeRelative->setPath("some/folder");
+///   // -> directorySelector->directory() == "applicationhome/some/folder"
+///   makeRelative->setPath("/some/absolute/folder");
+///   // -> directorySelector->directory() == "/some/absolute/folder"
+///
+/// Python example:
+///   relativePathMapper = slicer.qSlicerRelativePathMapper(directorySelector, "directory", "directoryChanged(QString)")
+///   parent.registerProperty(
+///     "settingsPropertyName", relativePathMapper, "relativePath", qt.SIGNAL("relativePathChanged(QString)"))
+///
+class Q_SLICER_BASE_QTCORE_EXPORT qSlicerRelativePathMapper : public QObject
+{
+  Q_OBJECT
+  /// This property contains the name of the object mapped property.
+  Q_PROPERTY(QByteArray propertyName READ propertyName)
+
+  Q_PROPERTY(QString path READ path WRITE setPath NOTIFY pathChanged)
+  Q_PROPERTY(QStringList paths READ paths WRITE setPaths NOTIFY pathsChanged)
+
+  Q_PROPERTY(QString relativePath READ relativePath WRITE setRelativePath NOTIFY relativePathChanged STORED false)
+  Q_PROPERTY(QStringList relativePaths READ relativePaths WRITE setRelativePaths NOTIFY relativePathsChanged STORED false)
+public:
+  /// Map the property \a property of the object.
+  /// The mapper becomes a child of \a object and will be destructed when
+  /// \a object is destructed.
+  /// property and object must be valid and non empty. If signal is 0,
+  /// \a pathChanged(bool) and \a relativePathChanged(bool) won't be fired.
+  qSlicerRelativePathMapper(QObject* targetObject, const QByteArray& propertyName, const QByteArray& signal);
+  virtual ~qSlicerRelativePathMapper();
+
+  QByteArray propertyName()const;
+
+  /// The mapped object (the mapper parent)
+  QObject* targetObject()const;
+
+  QString path()const;
+  QStringList paths()const;
+
+  QString relativePath()const;
+  QStringList relativePaths()const;
+public Q_SLOTS:
+  void setPath(const QString& path);
+  void setPaths(const QStringList& path);
+  void setRelativePath(const QString& path);
+  void setRelativePaths(const QStringList& paths);
+
+protected Q_SLOTS:
+  void emitPathChanged();
+  void emitPathsChanged();
+
+Q_SIGNALS:
+  void pathChanged(const QString& value);
+  void pathsChanged(const QStringList& value);
+  void relativePathChanged(const QString& value);
+  void relativePathsChanged(const QStringList& value);
+
+protected:
+  QScopedPointer<qSlicerRelativePathMapperPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerRelativePathMapper);
+  Q_DISABLE_COPY(qSlicerRelativePathMapper);
+};
+
+#endif

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -827,7 +827,7 @@ QStringList qSlicerApplication::recentLogFiles()
   for (int fileNumber = 0; fileNumber < numberOfFilesToKeep; ++fileNumber)
     {
     QString paddedFileNumber = QString("%1").arg(fileNumber, 3, 10, QChar('0')).toUpper();
-    QString filePath = revisionUserSettings->value(paddedFileNumber, "").toString();
+    QString filePath = qSlicerCoreApplication::application()->toSlicerHomeAbsolutePath(revisionUserSettings->value(paddedFileNumber, "").toString());
     if (!filePath.isEmpty())
       {
       logFilePaths.append(filePath);
@@ -878,7 +878,7 @@ void qSlicerApplication::setupFileLogging()
     if (fileNumber < numberOfFilesToKeep)
       {
       QString paddedFileNumber = QString("%1").arg(fileNumber, 3, 10, QChar('0')).toUpper();
-      revisionUserSettings->setValue(paddedFileNumber, filePath);
+      revisionUserSettings->setValue(paddedFileNumber, qSlicerCoreApplication::application()->toSlicerHomeRelativePath(filePath));
       }
     // Otherwise delete file
     else
@@ -1108,6 +1108,7 @@ void qSlicerApplication::logApplicationInformation() const
          preferExecutableCli ? "yes" : "no");
 
   // Additional module paths
+  // These paths are not converted to absolute path, because the raw values are moreuseful for troubleshooting.
   QStringList additionalModulePaths =
       this->revisionUserSettings()->value("Modules/AdditionalPaths").toStringList();
 
@@ -1164,7 +1165,12 @@ void qSlicerApplication::resumeRender()
 //-----------------------------------------------------------------------------
 ctkDICOMBrowser* qSlicerApplication::createDICOMBrowserForMainDatabase()
 {
-  return new ctkDICOMBrowser(this->dicomDatabaseShared());
+  ctkDICOMBrowser* browser = new ctkDICOMBrowser(this->dicomDatabaseShared());
+
+  // Allow database directory to be stored with a path relative to slicerHome
+  browser->setDatabaseDirectoryBase(this->slicerHome());
+
+  return browser;
 }
 #endif
 

--- a/Base/QTGUI/qSlicerExtensionsManagerDialog.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerDialog.cxx
@@ -71,6 +71,7 @@ void qSlicerExtensionsManagerDialogPrivate::init()
   // only if it applies. Note also that keep track of "EnvironmentVariables/PYTHONPATH'
   // isn't required, "Modules/AdditionalPaths" is enough to know if we should restart.
   QSettings * settings = qSlicerCoreApplication::application()->revisionUserSettings();
+    // this->PreviousModulesAdditionalPaths contain the raw (relative or absolute) paths, not converted to absolute
   this->PreviousModulesAdditionalPaths = settings->value("Modules/AdditionalPaths").toStringList();
   this->PreviousExtensionsScheduledForUninstall = settings->value("Extensions/ScheduledForUninstall").toStringList();
   this->PreviousExtensionsScheduledForUpdate = settings->value("Extensions/ScheduledForUpdate").toMap();
@@ -165,6 +166,7 @@ void qSlicerExtensionsManagerDialog::onModelUpdated()
   Q_ASSERT(this->extensionsManagerModel());
   bool shouldRestart = false;
   qSlicerCoreApplication * coreApp = qSlicerCoreApplication::application();
+  // this->PreviousModulesAdditionalPaths contain the raw (relative or absolute) paths, not converted to absolute
   if (d->PreviousModulesAdditionalPaths
       != coreApp->revisionUserSettings()->value("Modules/AdditionalPaths").toStringList() ||
       d->PreviousExtensionsScheduledForUninstall

--- a/Base/QTGUI/qSlicerIOManager.cxx
+++ b/Base/QTGUI/qSlicerIOManager.cxx
@@ -132,7 +132,8 @@ void qSlicerIOManagerPrivate::readSettings()
 
   if (!settings.value("favoritesPaths").toList().isEmpty())
     {
-    foreach (const QString& varUrl, settings.value("favoritesPaths").toStringList())
+    QStringList paths = qSlicerCoreApplication::application()->toSlicerHomeAbsolutePaths(settings.value("favoritesPaths").toStringList());
+    foreach (const QString& varUrl, paths)
       {
       this->Favorites << QUrl(varUrl);
       }
@@ -156,7 +157,8 @@ void qSlicerIOManagerPrivate::writeSettings()
     {
     list << url.toString();
     }
-  settings.setValue("favoritesPaths", QVariant(list));
+  QStringList paths = qSlicerCoreApplication::application()->toSlicerHomeRelativePaths(list);
+  settings.setValue("favoritesPaths", QVariant(paths));
   settings.endGroup();
 }
 

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
@@ -131,7 +131,7 @@ QStringList qSlicerScriptedLoadableModuleFactoryPrivate::modulePaths() const
   // Add the default modules directory (based on the slicer
   // installation or build tree) to the user paths
   QSettings * settings = app->revisionUserSettings();
-  QStringList additionalModulePaths = settings->value("Modules/AdditionalPaths").toStringList();
+  QStringList additionalModulePaths = app->toSlicerHomeAbsolutePaths(settings->value("Modules/AdditionalPaths").toStringList());
   QStringList qtModulePaths = additionalModulePaths + defaultQTModulePaths;
 
 //  qDebug() << "scriptedModulePaths:" << qtModulePaths;

--- a/Base/QTGUI/qSlicerSettingsCachePanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsCachePanel.cxx
@@ -25,6 +25,7 @@
 // CTK includes
 
 // QtGUI includes
+#include "qSlicerRelativePathMapper.h"
 #include "qSlicerSettingsCachePanel.h"
 #include "ui_qSlicerSettingsCachePanel.h"
 
@@ -113,8 +114,9 @@ void qSlicerSettingsCachePanel::setCacheManager(vtkCacheManager* cacheManager)
   // Default values
   this->updateFromCacheManager();
 
-  this->registerProperty("Cache/Path", d->CachePathButton, "directory",
-                         SIGNAL(directoryChanged(QString)));
+  qSlicerRelativePathMapper* relativePathMapper = new qSlicerRelativePathMapper(d->CachePathButton, "directory", SIGNAL(directoryChanged(QString)));
+  this->registerProperty("Cache/Path", relativePathMapper, "relativePath",
+                         SIGNAL(relativePathChanged(QString)));
   this->registerProperty("Cache/Size", d->CacheSizeSpinBox, "value",
                          SIGNAL(valueChanged(int)));
   this->registerProperty("Cache/FreeBufferSize", d->CacheFreeBufferSpinBox, "value",

--- a/Base/QTGUI/qSlicerSettingsExtensionsPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsExtensionsPanel.cxx
@@ -25,6 +25,7 @@
 // QtGUI includes
 #include "qSlicerApplication.h"
 #include "qSlicerModuleSelectorToolBar.h"
+#include "qSlicerRelativePathMapper.h"
 #include "qSlicerSettingsExtensionsPanel.h"
 #include "ui_qSlicerSettingsExtensionsPanel.h"
 
@@ -78,8 +79,11 @@ void qSlicerSettingsExtensionsPanelPrivate::init()
                       "text", SIGNAL(textChanged(QString)),
                       QString(), ctkSettingsPanel::OptionNone,
                       app->revisionUserSettings());
-  q->registerProperty("Extensions/InstallPath", this->ExtensionsInstallPathButton,
-                      "directory", SIGNAL(directoryChanged(QString)),
+
+  qSlicerRelativePathMapper* relativePathMapper = new qSlicerRelativePathMapper(
+    this->ExtensionsInstallPathButton, "directory", SIGNAL(directoryChanged(QString)));
+  q->registerProperty("Extensions/InstallPath", relativePathMapper,
+                      "relativePath", SIGNAL(relativePathChanged(QString)),
                       QString(), ctkSettingsPanel::OptionNone,
                       app->revisionUserSettings());
 
@@ -89,7 +93,7 @@ void qSlicerSettingsExtensionsPanelPrivate::init()
   QObject::connect(this->ExtensionsServerUrlLineEdit, SIGNAL(textChanged(QString)),
                    q, SIGNAL(extensionsServerUrlChanged(QString)));
   QObject::connect(this->ExtensionsInstallPathButton, SIGNAL(directoryChanged(QString)),
-                   q, SLOT(onExensionsPathChanged(QString)));
+                   q, SLOT(onExtensionsPathChanged(QString)));
   QObject::connect(this->OpenExtensionsManagerPushButton, SIGNAL(clicked()),
                    app, SLOT(openExtensionsManagerDialog()));
 }
@@ -116,7 +120,7 @@ void qSlicerSettingsExtensionsPanel::onExtensionsManagerEnabled(bool value)
 }
 
 // --------------------------------------------------------------------------
-void qSlicerSettingsExtensionsPanel::onExensionsPathChanged(const QString& path)
+void qSlicerSettingsExtensionsPanel::onExtensionsPathChanged(const QString& path)
 {
   qSlicerCoreApplication::application()->setExtensionsInstallPath(path);
 }

--- a/Base/QTGUI/qSlicerSettingsExtensionsPanel.h
+++ b/Base/QTGUI/qSlicerSettingsExtensionsPanel.h
@@ -53,7 +53,7 @@ signals:
 protected slots:
   void onExtensionsManagerEnabled(bool value);
   /// \todo This slot does nothing.
-  void onExensionsPathChanged(const QString& path);
+  void onExtensionsPathChanged(const QString& path);
 
 protected:
   QScopedPointer<qSlicerSettingsExtensionsPanelPrivate> d_ptr;

--- a/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
@@ -32,6 +32,7 @@
 
 // QtGUI includes
 #include "qSlicerApplication.h"
+#include "qSlicerRelativePathMapper.h"
 #include "qSlicerSettingsGeneralPanel.h"
 #include "ui_qSlicerSettingsGeneralPanel.h"
 
@@ -118,8 +119,9 @@ void qSlicerSettingsGeneralPanelPrivate::init()
   // Default values
 
   this->DefaultScenePathButton->setDirectory(qSlicerCoreApplication::application()->defaultScenePath());
-  q->registerProperty("DefaultScenePath", this->DefaultScenePathButton,"directory",
-                      SIGNAL(directoryChanged(QString)),
+  qSlicerRelativePathMapper* relativePathMapper = new qSlicerRelativePathMapper(this->DefaultScenePathButton, "directory", SIGNAL(directoryChanged(QString)));
+  q->registerProperty("DefaultScenePath", relativePathMapper, "relativePath",
+                      SIGNAL(relativePathChanged(QString)),
                       "Default scene path",
                      ctkSettingsPanel::OptionRequireRestart);
   QObject::connect(this->DefaultScenePathButton, SIGNAL(directoryChanged(QString)),

--- a/Base/QTGUI/qSlicerSettingsStylesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsStylesPanel.cxx
@@ -27,6 +27,7 @@
 
 // QtGUI includes
 #include "qSlicerApplication.h"
+#include "qSlicerRelativePathMapper.h"
 #include "qSlicerSettingsStylesPanel.h"
 #include "ui_qSlicerSettingsStylesPanel.h"
 
@@ -93,9 +94,11 @@ void qSlicerSettingsStylesPanelPrivate::init()
   // Additional path setting
   QObject::connect(this->AdditionalStylePathsView,
     SIGNAL(directoryListChanged()), q, SLOT(onAdditionalStylePathsChanged()));
+  qSlicerRelativePathMapper* relativePathMapper = new qSlicerRelativePathMapper(
+    this->AdditionalStylePathsView, "directoryList", SIGNAL(directoryListChanged()));
   q->registerProperty("Styles/AdditionalPaths",
-                      this->AdditionalStylePathsView,
-                      "directoryList", SIGNAL(directoryListChanged()),
+                      relativePathMapper,
+                      "relativePaths", SIGNAL(relativePathsChanged(QStringList)),
                       "Additional style paths",
                       ctkSettingsPanel::OptionRequireRestart);
 
@@ -243,8 +246,8 @@ void qSlicerSettingsStylesPanel::onAddStyleAdditionalPathClicked()
 {
   Q_D(qSlicerSettingsStylesPanel);
   qSlicerCoreApplication* coreApp = qSlicerCoreApplication::application();
-  QString extensionInstallPath =
-    coreApp->revisionUserSettings()->value("Extensions/InstallPath").toString();
+  QString extensionInstallPath = coreApp->toSlicerHomeAbsolutePath(
+    coreApp->revisionUserSettings()->value("Extensions/InstallPath").toString());
   QString path = QFileDialog::getExistingDirectory(
       this, tr("Select a path containing a \"styles\" plugin directory"),
       extensionInstallPath);

--- a/CMake/SlicerApplicationOptions.cmake
+++ b/CMake/SlicerApplicationOptions.cmake
@@ -164,3 +164,26 @@ if(WIN32)
   message(STATUS "Configuring ${Slicer_MAIN_PROJECT_APPLICATION_NAME} install root [${Slicer_CPACK_NSIS_INSTALL_ROOT}]")
 
 endif()
+
+#-----------------------------------------------------------------------------
+# Set Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR
+#-----------------------------------------------------------------------------
+#
+# If Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR is enabled (default) then revision-specific
+# settings (such as Slicer-12345.ini) and extensions are stored in application
+# home directory, within (OrganizationName) subdirectory.
+# Non-revision-specific settings (such as Slicer.ini) is still stored in
+# the user profile directory and shared between all installed applications,
+# unless a setting file is found in the application home (in which case settings
+# are stored in this local file, making the installation fully self-contained).
+#
+# If Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR is disabled then all settings and extensions
+# are always written in the the user profile, which is useful if application
+# home directory is read-only.
+#
+# Since Python packages are always installed in the application home directory,
+# it is recommended to install the application in a writeable directory and
+# enable Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR.
+#
+option(Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR "Store all settings in the application home directory (makes the application portable)" ON)
+mark_as_superbuild(Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR:BOOL)

--- a/CMake/vtkSlicerConfigure.h.in
+++ b/CMake/vtkSlicerConfigure.h.in
@@ -32,6 +32,8 @@
 #define VTKSLICER_STATIC
 #endif
 
+#cmakedefine Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR
+
 #cmakedefine Slicer_USE_IGSTK
 #cmakedefine Slicer_USE_NAVITRACK
 #cmakedefine Slicer_USE_NUMPY

--- a/Docs/user_guide/settings.md
+++ b/Docs/user_guide/settings.md
@@ -83,7 +83,9 @@ The overall theme of Slicer is controlled by the selected Style:
 
 ### Settings file location
 
-Settings are stored in a *.ini files located in directory like these ones:
+Settings are stored in *.ini files. If the settings file is found in application home directory (within organization name or domain subfolder) then that .ini file is used. This can be used for creating a portable application that contains all software and settings in a relocatable folder. Relative paths in settings files are resolved using the application home directory, and therefore are portable along with the application.
+
+If .ini file is not found in the the application home directory then it is searched in user profile:
 
 -  Windows: `%USERPROFILE%\AppData\Roaming\NA-MIC\` (typically `C:\Users\<your_user_name>\AppData\Roaming\NA-MIC\`)
 -  Linux: `~/.config/NA-MIC/`
@@ -91,7 +93,7 @@ Settings are stored in a *.ini files located in directory like these ones:
 
 Deleting the *.ini files restores all the settings to default.
 
-There are two types of settings:
+There are two types of settings: `user specific settings` and `user and revision specific settings`.
 
 #### User specific settings
 
@@ -119,11 +121,14 @@ To display the exact location of this settings file, enter the following in the 
 
 ### Application startup file
 
-Each time Slicer starts, it will look up for a startup script file named <code>.slicerrc.py</code> in your home (user profile) folder. Content of this file is executed automatically at each startup of Slicer.
+Each time Slicer starts, it will look up for a startup script file named <code>.slicerrc.py</code>. Content of this file is executed automatically at each startup of Slicer.
+
+The file is searched at multiple location and the first one that is found is used. Searched locations:
+- Application home folder (`slicer.app.slicerHome`)
+- Path defined in `SLICERRC` environment variable
+- User profile folder (`~/.slicerrc.py`)
 
 You can find the path to the startup script in Slicer by opening in the menu: Edit / Application Settings. ''Application startup script'' path is shown in the ''General'' section (or running `getSlicerRCFileName()` command in Slicer Python console).
-
-The default name and location of the file can be overridden by setting `SLICERRC` environment variable before launching Slicer.
 
 ### Runtime environment variables
 
@@ -137,4 +142,4 @@ The following environment variables can be set before the application is started
   and `compatibility` (compatiblity profile). Default value is `compatibility` on Windows systems.
 - `SLICER_BACKGROUND_THREAD_PRIORITY`: Set priority for background processing tasks. On Linux, it may affect the
   entire process priority. An integer value is expected, default = `20` on Linux and macOS, and `-1` on Windows.
-- `SLICERRC`: Custom application startup file path. Contains a full path to a Python script. By default it is `~/.slicerrc.py` (where ~ is the home or user profile folder).
+- `SLICERRC`: Custom application startup file path. Contains a full path to a Python script. By default it is `~/.slicerrc.py` (where ~ is the user profile a.k.a user home folder).

--- a/Modules/Loadable/Colors/qSlicerColorsModule.cxx
+++ b/Modules/Loadable/Colors/qSlicerColorsModule.cxx
@@ -98,7 +98,8 @@ void qSlicerColorsModule::setup()
     "Colors", QString("ColorTableFile"),
     QStringList() << "vtkMRMLColorNode", true, this));
 
-  QStringList paths = app->userSettings()->value("QTCoreModules/Colors/ColorFilePaths").toStringList();
+  QStringList paths = qSlicerCoreApplication::application()->toSlicerHomeAbsolutePaths(
+    app->userSettings()->value("QTCoreModules/Colors/ColorFilePaths").toStringList());
 #ifdef Q_OS_WIN32
   QString joinedPaths = paths.join(";");
 #else

--- a/Modules/Loadable/Data/qSlicerDataModuleWidget.cxx
+++ b/Modules/Loadable/Data/qSlicerDataModuleWidget.cxx
@@ -49,7 +49,6 @@
 // Qt includes
 #include <QAction>
 #include <QDebug>
-#include <QSettings>
 #include <QTimer>
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.cxx
@@ -42,6 +42,7 @@
 #include <QUrl>
 
 // Slicer includes
+#include "qSlicerCoreApplication.h"
 #include <vtkMRMLSliceLogic.h>
 #include <vtkSlicerApplicationLogic.h>
 
@@ -180,7 +181,8 @@ void qMRMLSegmentationFileExportWidget::updateWidgetFromSettings()
   d->FileFormatComboBox->setCurrentIndex(d->FileFormatComboBox->findText(fileFormat));
   this->setFileFormat(fileFormat);
 
-  d->DestinationFolderButton->setDirectory(settings.value(d->SettingsKey + "/DestinationFolder", ".").toString());
+  QString path = qSlicerCoreApplication::application()->toSlicerHomeAbsolutePath(settings.value(d->SettingsKey + "/DestinationFolder", ".").toString());
+  d->DestinationFolderButton->setDirectory(path);
   d->VisibleSegmentsOnlyCheckBox->setChecked(settings.value(d->SettingsKey + "/VisibleSegmentsOnly", false).toBool());
 
   d->MergeIntoSingleSTLFileCheckBox->setChecked(settings.value(d->SettingsKey + "/MergeIntoSingleFile", false).toBool());
@@ -206,7 +208,8 @@ void qMRMLSegmentationFileExportWidget::updateSettingsFromWidget()
   QSettings settings;
 
   settings.setValue(d->SettingsKey + "/FileFormat", d->FileFormatComboBox->currentText());
-  settings.setValue(d->SettingsKey + "/DestinationFolder", d->DestinationFolderButton->directory());
+  QString path = qSlicerCoreApplication::application()->toSlicerHomeRelativePath(d->DestinationFolderButton->directory());
+  settings.setValue(d->SettingsKey + "/DestinationFolder", path);
   settings.setValue(d->SettingsKey + "/VisibleSegmentsOnly", d->VisibleSegmentsOnlyCheckBox->isChecked());
   settings.setValue(d->SettingsKey + "/MergeIntoSingleFile", d->MergeIntoSingleSTLFileCheckBox->isChecked());
   settings.setValue(d->SettingsKey + "/SizeScale", d->SizeScaleSpinBox->value());

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -793,7 +793,7 @@ class DICOMWidget(ScriptedLoadableModuleWidget):
         # TODO: deal with Debug/RelWithDebInfo on windows
 
         # set up temp dir
-        tmpDir = slicer.app.userSettings().value('Modules/TemporaryDirectory')
+        tmpDir = slicer.app.temporaryPath
         if not os.path.exists(tmpDir):
           os.mkdir(tmpDir)
         self.tmpDir = tmpDir + '/DICOM'

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -917,16 +917,16 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
   def getFfmpegPath(self):
     settings = qt.QSettings()
     if settings.contains('General/ffmpegPath'):
-      return settings.value('General/ffmpegPath')
+      return slicer.app.toSlicerHomeAbsolutePath(settings.value('General/ffmpegPath'))
     return ''
 
   def setFfmpegPath(self, ffmpegPath):
     # don't save it if already saved
     settings = qt.QSettings()
     if settings.contains('General/ffmpegPath'):
-      if ffmpegPath == settings.value('General/ffmpegPath'):
+      if ffmpegPath == slicer.app.toSlicerHomeAbsolutePath(settings.value('General/ffmpegPath')):
         return
-    settings.setValue('General/ffmpegPath',ffmpegPath)
+    settings.setValue('General/ffmpegPath', slicer.app.toSlicerHomeRelativePath(ffmpegPath))
 
   def setWatermarkPosition(self, watermarkPosition):
     self.watermarkPosition = watermarkPosition

--- a/SuperBuild/External_CTKAPPLAUNCHER.cmake
+++ b/SuperBuild/External_CTKAPPLAUNCHER.cmake
@@ -24,22 +24,23 @@ if(Slicer_USE_CTKAPPLAUNCHER)
   if(NOT DEFINED CTKAppLauncher_DIR)
 
     SlicerMacroGetOperatingSystemArchitectureBitness(VAR_PREFIX CTKAPPLAUNCHER)
-    set(launcher_version "0.1.27")
+    set(launcher_version "0.1.28")
     # On windows, use i386 launcher unconditionally
     if("${CTKAPPLAUNCHER_OS}" STREQUAL "win")
       set(CTKAPPLAUNCHER_ARCHITECTURE "i386")
-      set(md5 "3f05dcc605ac2144edc69b28c27bb8d1")
+      set(md5 "130a9c869844452b9693156bcc71ba2f")
     elseif("${CTKAPPLAUNCHER_OS}" STREQUAL "linux")
-      set(md5 "a9a8aab9c0e91cdd0b5265eb799daf74")
+      set(md5 "c574f95b210c99741c1dbd87889ad346")
     elseif("${CTKAPPLAUNCHER_OS}" STREQUAL "macosx")
-      set(md5 "a9de73a1609c988167884efa23819287")
+      set(md5 "a006790521ce69312e3ed024a32316ee")
     endif()
 
     set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj})
 
+    set(CTKAppLauncherFileName CTKAppLauncher-${launcher_version}-${CTKAPPLAUNCHER_OS}-${CTKAPPLAUNCHER_ARCHITECTURE}.tar.gz)
     ExternalProject_Add(${proj}
       ${${proj}_EP_ARGS}
-      URL https://github.com/commontk/AppLauncher/releases/download/v${launcher_version}/CTKAppLauncher-${launcher_version}-${CTKAPPLAUNCHER_OS}-${CTKAPPLAUNCHER_ARCHITECTURE}.tar.gz
+      URL https://github.com/commontk/AppLauncher/releases/download/v${launcher_version}/${CTKAppLauncherFileName}
       URL_MD5 ${md5}
       DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
       SOURCE_DIR ${EP_BINARY_DIR}

--- a/SuperBuild/External_CTKAppLauncherLib.cmake
+++ b/SuperBuild/External_CTKAppLauncherLib.cmake
@@ -26,7 +26,7 @@ if(NOT DEFINED CTKAppLauncherLib_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "692164585e623bd585a34c36a514c1a15f5b9895"
+    "0b0cd10a9f6965d4c245a5cc094d6a71c1c2879c"
     QUIET
     )
 


### PR DESCRIPTION
Slicer install tree was portable but not fully self-contained, as settings and extensions were stored in the user profile folder.

Added a new option Slicer_STORE_SETTINGS_IN_HOME_DIR (enabled by default) that makes Slicer store all settings and extensions in the application home folder, within (organizationName) subfolder (as QSettings default constructor saves settings file into (organizationName) subfolder by default), making the application fully portable.

To still allow having settings that are common to all installed application versions for a user (e.g., DICOM database folder, confirmation popup suppressions, ...), the common non-revision-specific is still stored in the user profile directory by default. However, if the user places an (applicationName).ini file in the application home folder/(organizationName) then that file is used instead.

By default, (applicationName)=Slicer and (organizationName)=NA-MIC and therefore the .ini files are: (applicationHome)/NA-MIC/Slicer.ini and (applicationHome)/NA-MIC/Slicer-(revision).ini; and extensions are stored in (applicationHome)/NA-MIC/Extensions-(revision).

re #4966

Prerequisites to merge:
- [x] Merge https://github.com/commontk/AppLauncher/pull/114
- [x] Update AppLauncher
- [x] Update AppLauncher hash in Slicer
