### PR TITLE
ENH: Improve performance for markup nodes

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
@@ -1015,9 +1015,13 @@ int vtkCurveGenerator::GetSurfaceCostFunctionType()
 }
 
 //------------------------------------------------------------------------------
-void vtkCurveGenerator::SetSurfaceCostFunctionType(int setSurfaceCostFunctionType)
+void vtkCurveGenerator::SetSurfaceCostFunctionType(int surfaceCostFunctionType)
 {
-  this->SurfacePathFilter->SetCostFunctionType(setSurfaceCostFunctionType);
+  if (this->SurfacePathFilter->GetCostFunctionType() == surfaceCostFunctionType)
+    {
+    return;
+    }
+  this->SurfacePathFilter->SetCostFunctionType(surfaceCostFunctionType);
   this->Modified();
 }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.cxx
@@ -60,7 +60,7 @@ void vtkMRMLMarkupsAngleNode::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLMarkupsAngleNode::UpdateMeasurements()
+void vtkMRMLMarkupsAngleNode::UpdateMeasurementsInternal()
 {
   this->RemoveAllMeasurements();
   if (this->GetNumberOfDefinedControlPoints(true) == 3)

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.h
@@ -70,7 +70,7 @@ protected:
   /// Calculates the handle to world matrix based on the current control points
   void UpdateInteractionHandleToWorldMatrix() override;
 
-  void UpdateMeasurements() override;
+  void UpdateMeasurementsInternal() override;
 };
 
 #endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -236,7 +236,7 @@ protected:
   vtkMRMLMarkupsCurveNode(const vtkMRMLMarkupsCurveNode&);
   void operator=(const vtkMRMLMarkupsCurveNode&);
 
-  void UpdateMeasurements() override;
+  void UpdateMeasurementsInternal() override;
 };
 
 #endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.cxx
@@ -63,7 +63,7 @@ void vtkMRMLMarkupsLineNode::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLMarkupsLineNode::UpdateMeasurements()
+void vtkMRMLMarkupsLineNode::UpdateMeasurementsInternal()
 {
   this->RemoveAllMeasurements();
   if (this->GetNumberOfDefinedControlPoints(true) == 2)

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.h
@@ -67,7 +67,7 @@ protected:
   vtkMRMLMarkupsLineNode(const vtkMRMLMarkupsLineNode&);
   void operator=(const vtkMRMLMarkupsLineNode&);
 
-  void UpdateMeasurements() override;
+  void UpdateMeasurementsInternal() override;
 
   /// Calculates the handle to world matrix based on the current control points
   void UpdateInteractionHandleToWorldMatrix() override;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -617,7 +617,12 @@ protected:
 
   void OnTransformNodeReferenceChanged(vtkMRMLTransformNode* transformNode) override;
 
-  virtual void UpdateMeasurements();
+  /// Calls UpdateMeasurementsInternal()
+  void UpdateMeasurements();
+
+  /// Calculates the updated measurements
+  /// Should be overwritten by child classes to compute measurements
+  virtual void UpdateMeasurementsInternal();
 
   /// Helper function to write measurements to node Description property.
   /// This is a short-term solution until measurements display is properly implemented.
@@ -676,6 +681,8 @@ protected:
   // Transform that moves the xyz unit vectors and origin of the interaction handles to local coordinates
   vtkSmartPointer<vtkMatrix4x4> InteractionHandleToWorldMatrix;
 
+  /// Flag set from SetControlPointPositionsWorld that pauses update of measurements until the update is complete.
+  bool IsUpdatingPoints;
 };
 
 #endif


### PR DESCRIPTION
Removed unnecessary modified events caused by setting the SurfaceCostFunctionType or SurfaceDistanceWeightingFunction to the same value.
Improved speed when calling SetControlPointPositionsWorld by pausing the calculation of measurements until all of the points have been set.