### PR TITLE
BUG: Fix invalid oversampling in segmentation geometry dialog

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.cxx
@@ -64,7 +64,7 @@ vtkSlicerSegmentationGeometryLogic::vtkSlicerSegmentationGeometryLogic()
 vtkSlicerSegmentationGeometryLogic::~vtkSlicerSegmentationGeometryLogic()
 {
   this->SetInputSegmentationNode(nullptr);
-
+  this->SetSourceGeometryNode(nullptr);
   if (this->OutputGeometryImageData)
     {
     this->OutputGeometryImageData->Delete();

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryDialog.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryDialog.cxx
@@ -166,6 +166,8 @@ bool qMRMLSegmentationGeometryDialog::exec()
     return result;
     }
 
+  MRMLNodeModifyBlocker blocker(d->SegmentationNode);
+
   // Apply geometry after clean exit
   if (d->GeometryWidget->editEnabled())
     {

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationGeometryWidget.cxx
@@ -452,8 +452,13 @@ void qMRMLSegmentationGeometryWidget::setReferenceImageGeometryForSegmentationNo
     {
     referenceGeometryNodeID = d->Logic->GetSourceGeometryNode()->GetID();
     }
-  d->SegmentationNode->SetNodeReferenceID(
-    vtkMRMLSegmentationNode::GetReferenceImageGeometryReferenceRole().c_str(), referenceGeometryNodeID);
+
+  // If the reference geometry node is the same as the segmentation node, then don't change the node reference
+  if (vtkMRMLSegmentationNode::SafeDownCast(d->Logic->GetSourceGeometryNode()) != d->SegmentationNode)
+    {
+    d->SegmentationNode->SetNodeReferenceID(
+      vtkMRMLSegmentationNode::GetReferenceImageGeometryReferenceRole().c_str(), referenceGeometryNodeID);
+    }
 
   // Note: it could be also useful to save oversampling value and isotropic flag,
   // we could then allow the user to modify these settings instead of always


### PR DESCRIPTION
When oversampling a segmentation, the oversampling factor would be doubled if the same segmentation node was set as the reference geometry.
While updating the segmentation node, modification events would cause widget to recalculate the output geometry. The specific action that caused the update was setting the segmentation node ReferenceImageGeometry reference.

Fixed by blocking modified events from the segmentation node until the resampling has been applied, and by not changing the ReferenceImageGeometry reference if the same segmentation node is being used as the reference geometry node.

Also fixes memory leak in vtkSlicerSegmentationGeometryLogic.

fixes #5032