### PR TITLE
COMP: add virtual to file reader declaration

### DIFF
--- a/Base/QTCore/qSlicerFileReader.h
+++ b/Base/QTCore/qSlicerFileReader.h
@@ -63,9 +63,9 @@ public:
   virtual bool load(const IOProperties& properties);
 
   /// Return the list of generated nodes from loading the file(s) in load().
-  /// Empty list of load() failed
+  /// Empty list if load() failed
   /// \sa setLoadedNodes(), load()
-  QStringList loadedNodes()const;
+  virtual QStringList loadedNodes()const;
 
   /// Implements the file list examination for the corresponding method in the core
   /// IO manager.
@@ -75,7 +75,7 @@ public:
 protected:
   /// Must be called in load() on success with the list of nodes added into the
   /// scene.
-  void setLoadedNodes(const QStringList& nodes);
+  virtual void setLoadedNodes(const QStringList& nodes);
 
 protected:
   QScopedPointer<qSlicerFileReaderPrivate> d_ptr;

--- a/Base/QTCore/qSlicerFileWriter.h
+++ b/Base/QTCore/qSlicerFileWriter.h
@@ -53,6 +53,9 @@ public:
   /// ...
   virtual bool write(const qSlicerIO::IOProperties& properties);
 
+  /// Return the list of saved nodes from writing the file(s) in write().
+  /// Empty list if write() failed
+  /// \sa setWrittenNodes(), write()
   virtual QStringList writtenNodes()const;
 
 protected:


### PR DESCRIPTION
Fix build error for overriding non-virtual method.

Fixes issue introduced by https://github.com/Slicer/Slicer/pull/5025