### PR TITLE
ENH: Add view id to plugin events

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -38,6 +38,7 @@
 #include "qSlicerSubjectHierarchyVisibilityPlugin.h"
 
 // MRML includes
+#include "vtkMRMLAbstractViewNode.h"
 #include "vtkMRMLDisplayableNode.h"
 #include "vtkMRMLDisplayNode.h"
 #include "vtkMRMLInteractionEventData.h"
@@ -485,6 +486,10 @@ void qSlicerSubjectHierarchyPluginLogic::onDisplayMenuEvent(vtkObject* displayNo
   QVariantMap eventDataMap;
   eventDataMap["ComponentType"] = QVariant(eventData->GetComponentType());
   eventDataMap["ComponentIndex"] = QVariant(eventData->GetComponentIndex());
+  if (eventData->GetViewNode())
+    {
+    eventDataMap["ViewNodeID"] = QVariant(eventData->GetViewNode()->GetID());
+    }
 
   // Get subject hierarchy item ID
   vtkIdType itemID = shNode->GetItemByDataNode(displayableNode);


### PR DESCRIPTION
This adds the view node id to the eventData passed
to a subject hierarchy plugin, allowing them
to use it in the handling actions.

For example, an action may only make sense on threeDViews
and not on sliceViews, or handling the action may require
knowing which camera and renderer to use in handling the action.