### PR TITLE
ENH: Display warnings and errors in the Save Data dialog

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSaveDataDialog.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSaveDataDialog.ui
@@ -38,7 +38,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="6">
+   <item row="1" column="0" colspan="7">
     <widget class="QTableWidget" name="FileWidget">
      <property name="editTriggers">
       <set>QAbstractItemView::AllEditTriggers</set>
@@ -82,6 +82,11 @@
      <column>
       <property name="text">
        <string>Status</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Notes</string>
       </property>
      </column>
     </widget>

--- a/Base/QTGUI/qSlicerSaveDataDialog_p.h
+++ b/Base/QTGUI/qSlicerSaveDataDialog_p.h
@@ -81,7 +81,8 @@ protected:
     OptionsColumn = 3,
     NodeNameColumn = 4,
     NodeTypeColumn = 5,
-    NodeStatusColumn = 6
+    NodeStatusColumn = 6,
+    UserMessagesColumn = 7
   };
 
   enum CustomRole
@@ -97,6 +98,7 @@ protected:
   void              restoreAfterSaving();
   void              setSceneRootDirectory(const QString& rootDirectory);
   void              updateOptionsWidget(int row);
+  void              updateUserMessagesItem(int row);
 
   QString           sceneFileFormat()const;
 
@@ -110,6 +112,9 @@ protected:
   QWidget*          createFileFormatsWidget(vtkMRMLStorableNode* node, QFileInfo& fileInfo);
   QTableWidgetItem* createFileNameItem(const QFileInfo& fileInfo, const QString& extension, const QString& nodeID);
   ctkDirectoryButton* createFileDirectoryWidget(const QFileInfo& fileInfo);
+  QWidget*          createUserMessagesItem(vtkMRMLStorableNode *node);
+  void              makeUserMessages(vtkMRMLStorableNode *node, QWidget *userMessagesLayoutItem);
+  void              clearUserMessages();
 
   static QString extractKnownExtension(const QString& fileName, vtkObject* object);
   static QString stripKnownExtension(const QString& fileName, vtkObject* object);

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -152,6 +152,7 @@ set(MRMLCore_SRCS
   vtkMRMLLinearTransformSequenceStorageNode.cxx
   vtkMRMLLinearTransformSequenceStorageNode.h
   vtkMRMLMarkupsStorageNode.cxx
+  vtkMRMLMessageCollection.cxx
   vtkMRMLModelDisplayNode.cxx
   vtkMRMLModelHierarchyNode.cxx
   vtkMRMLModelNode.cxx

--- a/Libs/MRML/Core/vtkMRMLMessageCollection.cxx
+++ b/Libs/MRML/Core/vtkMRMLMessageCollection.cxx
@@ -1,0 +1,121 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Lee Newberg, Kitware Inc.
+
+==============================================================================*/
+
+
+#include "vtkMRMLMessageCollection.h"
+
+// MRML includes
+#include "vtkCommand.h"
+
+//----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkMRMLMessageCollection);
+
+//----------------------------------------------------------------------------
+void
+vtkMRMLMessageCollection
+::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+  os << indent << "Messages: " << &this->Messages << "\n";
+  for (int i = 0; i < this->GetNumberOfMessages(); i++)
+    {
+    const unsigned long messageType = this->GetNthMessageType(i);
+    const std::string messageText = this->GetNthMessageText(i);
+    os << indent << "MessagesMember: " << messageType << " "
+       << messageText << "\n";
+    }
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMessageCollection::Message
+::Message(unsigned long messageType, const std::string &messageText)
+  : MessageType(messageType), MessageText(messageText)
+{
+}
+
+//----------------------------------------------------------------------------
+int
+vtkMRMLMessageCollection
+::GetNumberOfMessages() const
+{
+  return this->Messages.size();
+}
+
+//----------------------------------------------------------------------------
+int
+vtkMRMLMessageCollection
+::GetNumberOfMessagesOfType(unsigned long messageType) const
+{
+  int response = 0;
+  for (int i = 0; i < this->Messages.size(); ++i)
+    {
+    response += static_cast<int>(GetNthMessageType(i) == messageType);
+    }
+  return response;
+}
+
+//----------------------------------------------------------------------------
+int
+vtkMRMLMessageCollection
+::GetNumberOfMessagesOfType(const char *eventName) const
+{
+  return GetNumberOfMessagesOfType(vtkCommand::GetEventIdFromString(eventName));
+}
+
+//----------------------------------------------------------------------------
+unsigned long
+vtkMRMLMessageCollection
+::GetNthMessageType(int index) const
+{
+  return this->Messages.at(index).MessageType;
+}
+
+//----------------------------------------------------------------------------
+std::string
+vtkMRMLMessageCollection
+::GetNthMessageText(int index) const
+{
+  return this->Messages.at(index).MessageText;
+}
+
+//----------------------------------------------------------------------------
+void
+vtkMRMLMessageCollection
+::AddMessage(unsigned long messageType, const std::string &messageText)
+{
+  this->Messages.push_back({messageType, messageText});
+}
+
+//----------------------------------------------------------------------------
+void
+vtkMRMLMessageCollection
+::ClearMessages()
+{
+  this->Messages.clear();
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMessageCollection::vtkMRMLMessageCollection()
+{
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMessageCollection::~vtkMRMLMessageCollection()
+{
+}

--- a/Libs/MRML/Core/vtkMRMLMessageCollection.h
+++ b/Libs/MRML/Core/vtkMRMLMessageCollection.h
@@ -1,0 +1,89 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Lee Newberg, Kitware Inc.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLMessageCollection_h
+#define __vtkMRMLMessageCollection_h
+
+// MRML includes
+#include "vtkMRML.h"
+
+// VTK includes
+#include <vtkIdTypeArray.h>
+
+// STD includes
+#include <string>
+#include <vector>
+
+///
+/// A class for recording warnings and errors associated with this
+/// vtkMRMLStorableNode.  A substantially similar vtkMessageCollection
+/// is planned for vtkAddon.  When that is released, this will be
+/// replaced by that.
+class VTK_MRML_EXPORT vtkMRMLMessageCollection : public vtkObject
+{
+public:
+  vtkTypeMacro(vtkMRMLMessageCollection,vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+  static vtkMRMLMessageCollection* New();
+
+  ///
+  /// Return the total number of reported messages.
+  virtual int GetNumberOfMessages() const;
+
+  ///
+  /// Return the number of reported messages of the specified event
+  /// type
+  virtual int GetNumberOfMessagesOfType(unsigned long messageType) const;
+
+  ///
+  /// Return the number of reported messages of the specified event
+  /// type
+  virtual int GetNumberOfMessagesOfType(const char *eventName) const;
+
+  // Get the Nth message from the message vector
+  virtual unsigned long GetNthMessageType(int index) const;
+  virtual std::string GetNthMessageText(int index) const;
+
+  // Append a message to the message vector
+  virtual void AddMessage(unsigned long messageType, const std::string &messageText);
+
+  // Clear the message vector
+  virtual void ClearMessages();
+
+protected:
+  vtkMRMLMessageCollection();
+  ~vtkMRMLMessageCollection() override;
+  vtkMRMLMessageCollection(const vtkMRMLMessageCollection&);
+  void operator=(const vtkMRMLMessageCollection&);
+
+  ///
+  /// A helper class that describes a single message
+  struct Message
+    {
+    Message(unsigned long messageType, const std::string &messageText);
+
+    unsigned long MessageType;
+    std::string MessageText;
+    };
+
+  std::vector<Message> Messages;
+};
+
+
+#endif

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -17,7 +17,9 @@
 
 // MRML includes
 #include "vtkMRMLNode.h"
+#include "vtkCommand.h"
 class vtkMRMLStorableNode;
+class vtkMRMLMessageCollection;
 
 class vtkURIHandler;
 
@@ -369,6 +371,9 @@ public:
   static const char *GetCoordinateSystemTypeAsString(int id);
   static int GetCoordinateSystemTypeFromString(const char *name);
 
+  const vtkMRMLMessageCollection *GetUserMessages() const { return this->UserMessages; }
+  vtkMRMLMessageCollection *GetUserMessages() { return this->UserMessages; }
+
 protected:
   vtkMRMLStorageNode();
   ~vtkMRMLStorageNode() override;
@@ -439,6 +444,10 @@ protected:
   vtkTimeStamp* StoredTime;
 
   vtkWeakPointer<vtkMRMLStorableNode> LastFoundStorableNode;
+
+  // Record warnings and errors associated with this
+  // vtkMRMLStorableNode.
+  vtkMRMLMessageCollection *UserMessages;
 };
 
 #endif


### PR DESCRIPTION
This is the code associated with https://github.com/Slicer/Slicer/issues/4968 for collecting the user-friendly messages at the time of saving.  Still to do is presenting the collected messages in the Base/QTGUI/qSlicerSaveDataDialog.cxx.