### PR TITLE
BUG: Fix segment editor masking for Set-type effects

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -655,22 +655,6 @@ bool vtkMRMLSegmentationNode::GenerateEditMask(vtkOrientedImageData* maskImage, 
     return false;
     }
 
-  // Always allow paint inside edited segment
-  if (paintInsideSegments)
-    {
-    // include edited segment in "inside" mask
-    if (std::find(maskSegmentIDs.begin(), maskSegmentIDs.end(), editedSegmentID) == maskSegmentIDs.end())
-      {
-      // add it if it's not in the segment list already
-      maskSegmentIDs.push_back(editedSegmentID);
-      }
-    }
-  else
-    {
-    // exclude edited segment from "outside" mask
-    maskSegmentIDs.erase(std::remove(maskSegmentIDs.begin(), maskSegmentIDs.end(), editedSegmentID), maskSegmentIDs.end());
-    }
-
   maskImage->SetExtent(extent);
   vtkNew<vtkMatrix4x4> referenceImageToWorldMatrix;
   referenceGeometry->GetImageToWorldMatrix(referenceImageToWorldMatrix.GetPointer());


### PR DESCRIPTION
Segment editor effects that used ModificationModeSet (Margin, Threshold, AutoComplete, etc.) would adhere to the mask when adding new regions, but would not prevent the deletion of regions within the mask.

Fixed by:
- Not always including the edited segment in the mask, so that we can accurately determine actual mask region
- Adding the regions of the segment labelmap outside of the mask to the modifier labelmap

fixes #4984