### PR TITLE
Documentation build instructions

### DIFF
--- a/Docs/developer_guide/build_instructions/index.rst
+++ b/Docs/developer_guide/build_instructions/index.rst
@@ -1,0 +1,12 @@
+
+.. _build_instructions_index:
+
+#####################
+Build Instructions
+#####################
+.. toctree::
+
+   overview.md
+   windows.md
+   macos.md
+   linux.md

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -1,0 +1,191 @@
+# GNU/Linux Systems
+
+The instructions to build Slicer for GNU/Linux systems are slightly different
+depending on the linux distribution and the specific configuration of the
+system. In the following sections you can find instructions that will work for
+some of the most common linux distributions in their standard configuration. If
+you are using a different distribution you can use these instructions as
+guidelines to adapt the process to your system. You can also ask questions
+related to the building process in the [Slicer forum](https://discourse.slicer.org).
+
+## Pre-requisites
+
+First, you need to install the tools that will be used for fetching the source
+code of slicer, generating the project files and build the project.
+
+- Git and Subversion for fetching the code and version control.
+- GNU Compiler Collection (GCC) for code compilation.
+- CMake for configuration/generation of the project.
+  - (Optional) CMake curses gui to configure the project from the command line.
+  - (Optional) CMake Qt gui to configure the project through a GUI.
+- GNU Make
+- GNU Patch
+  
+In addition, Slicer requires a set of support libraries that are not includes as
+part of the *superbuild*:
+
+- Qt5 with the following components:
+  - Multimedia
+  - UiTools
+  - XMLPatterns
+  - SVG
+  - WebEngine
+  - Script
+  - X11Extras
+  - Private
+- libXt
+  
+### Debian Stable (Buster)
+
+Install the development tools and the support libraries:
+```
+sudo apt install git subversion build-essential cmake cmake-curses-gui cmake-qt-gui qt5-default qt5multimedia-dev qttools5-dev libqt5xmlpatterns5-dev libqt5svg5-dev qtwebengine5-dev qtscript5-dev  lqtbase5-private-dev libqt5x11extras5-dev libxt-dev 
+```
+
+### Debian Testing (Bullseye)
+
+Install the development tools and the support libraries:
+```
+sudo apt install git subversion build-essential cmake cmake-curses-gui cmake-qt-gui qt5-default qtmultimedia5-dev qttools5-dev libqt5xmlpatterns5-dev libqt5svg5-dev qtwebengine5-dev qtscript5-dev qtbase5-private-dev libqt5x11extras5-dev libxt-dev 
+```
+### Ubuntu 20.04 (Focal Fossa)
+
+Install the development tools and the support libraries:
+```
+sudo apt install git subversion build-essential cmake cmake-curses-gui cmake-qt-gui qt5-default qtmultimedia5-dev qttools5-dev libqt5xmlpatterns5-dev libqt5svg5-dev qtwebengine5-dev qtscript5-dev qtbase5-private-dev libqt5x11extras5-dev libxt-dev 
+```
+### ArchLinux
+
+Install the development tools and the support libraries:
+
+```
+sudo pacman -S git make patch subversion gcc cmake qt5-base qt5-multimedia qt5-tools qt5-xmlpatterns qt5-svg qt5-webengine qt5-script qt5-x11extras libxt
+```
+
+## Checkout Slicer source files
+
+The recommended way to obtain the source code of SLicer is cloning the repository using `git`:
+
+```
+git clone git://github.com/Slicer/Slicer.git
+```
+
+This will create a `Slicer` directory contaning the source code of Slicer.
+Hereafter we will call this directory the `source directory`.
+
+<div class="admonition warning">
+ 
+  <p class="admonition-title">Warning</p>
+
+  <p>It is highly recommended to <b>avoid</b> the use of the <b>space</b>
+  character in the name of the <code class="docutils literal notranslate"><span
+  class="pre">source directory</span></code> or any of its parent
+  directories.</p> </div>
+
+
+After obtaining the source code, we need to set up the development environment:
+
+```
+cd Slicer
+./Utilities/SetupForDevelopment.sh
+```
+
+[comment]: <> (TODO: Link to the readthedocs equivalent of https://www.slicer.org/wiki/Documentation/Nightly/Developers/DevelopmentWithGit)
+
+## Configure and generate the Slicer build project files
+ 
+Slicer is highly configurable and multi-platform. To support this,
+Slicer needs a configuration of the build parameters before the build process
+takes place. In this configuration stage, it is possible to adjust variables
+that change the nature and behaviour of its components. For instance, the type
+of build (Debug or Release mode), whether to use system-installed libraries,
+let the build process fetch and compile own libraries, or enable/disable some of
+the software components and functionalities of Slicer.
+
+To obtain a default configuration of the Slicer build project use `cmake`:
+
+```
+mkdir Slicer-SuperBuild-Debug
+cd Slicer-SuperBuild-Debug
+cmake ../Slicer
+```
+It is possible to change variables with `cmake`. In the following example we
+change the built type (Debug as default) to Release:
+
+```
+cmake -DCMAKE_BUILD_TYPE:STRING=Release ../Slicer
+```
+
+<div class="admonition tip">
+ 
+  <p class="admonition-title">Tip</p>
+
+  <p>Instead of <code class="docutils literal notranslate"><span
+  class="pre">cmake</span></code>, one can use <code class="docutils literal
+  notranslate"><span class="pre">ccmake</span></code>, which provides a
+  text-based interface or <code class="docutils literal notranslate"><span
+  class="pre">cmake-gui</span></code>, which provides a graphical user interface.
+  These applications will also provide a list of variables that can be changed.
+  </p>
+
+</div>
+
+## Build Slicer
+
+Once the Slicer build project files have been generated, the Slicer project can
+be build:
+
+```
+cd Slicer-SuperBuild-Debug
+make
+```
+
+<div class="admonition tip">
+ 
+  <p class="admonition-title">Tip</p> 
+  
+  <p>Building Slicer will generally take long
+  time, particularly on the first build or upon code/configuration changes. To
+  help speeding up the process one can use <code class="docutils literal
+  notranslate"><span class="pre">make -j&lt;N&gt;</span></code>, where <code
+  class="docutils literal notranslate"><span class="pre">N</span></code> is the
+  number of parallel builds. As a rule of thumb, many uses the <em>number of CPU
+  threads + 1</em> as the number of parallel builds.</p>
+  
+
+</div>
+
+
+<div class="admonition warning">
+ 
+  <p class="admonition-title">Warning</p>
+
+  <p>Increasing the number of parallel builds generally
+  increases the memory required for the build process. In the event that the
+  required memory exceeds the available memory, the process will either fail or
+  start using swap memory, which will make in practice the system to freeze.</p>
+
+</div>
+
+<div class="admonition tip">
+ 
+  <p class="admonition-title">Tip</p> 
+  
+  <p>Using parallel builds makes finding compilation errors difficult due to the
+  fact that all parallel build processes use the same screen otput, as opposed
+  to sequential builds, where the compilation process will stop at the error. A
+  common technique to have parallel builds and easily find errors is launch a
+  parallel build followed by a sequential build. For the parallel build, it is adviced to run <code
+  class="docutils literal notranslate"><span class="pre">make
+  -j&lt;N&gt; -k</span></code> to have the parallel build keep going as far as
+  possible before doing the sequential build with<code class="docutils literal
+  notranslate"><span class="pre">make</span></code></p>
+
+</div>
+
+
+## Running Slicer
+
+After the building process has successfully completed, the executable file to
+run slicer will be located in `./Slicer-build/Slicer`
+

--- a/Docs/developer_guide/build_instructions/macos.md
+++ b/Docs/developer_guide/build_instructions/macos.md
@@ -1,0 +1,330 @@
+# Mac OS
+
+## Prerequisites
+
+The prerequisites listed below are required to be able to configure/build/package/test Slicer.
+
+- XCode command line tools must be installed:
+```
+xcode-select --install
+```
+- El Capitan is what most developers use.
+- CMake 3.12.2 is recommended. Check the minimum required CMake version [here](https://github.com/Slicer/Slicer/blob/master/CMakeLists.txt#L1)
+- Large File Storage for git is required. (`brew install git-lvs`)
+- Qt 5: **tested and recommended**.
+  - For building Slicer: download and execute [qt-unified-mac-x64-online.dmg](https://download.qt.io/official_releases/online_installers/qt-unified-mac-x64-online.dmg), install Qt 5.10, make sure to select `qtscript` and `qtwebengine` components.
+  - For packaging and redistributing Slicer: build Qt using [qt-easy-build](https://github.com/jcfr/qt-easy-build#readme)
+- Setting `CMAKE_OSX_DEPLOYMENT_TARGET` CMake variable specifies the minimum macOS version a generated installer may target.  So it should be equal to or less than the version of SDK you are building on. Note that the SDK version is set using `CMAKE_OSX_SYSROOT` CMake variable automatically initialized during CMake configuration.
+
+### Mac OSX 10.9.4 (Mavericks)
+
+- Make sure to install this update: http://support.apple.com/kb/DL1754
+
+- Use CMake 3.12.2 - it is known to be working and is supported (if you want to use CMake already installed on your system, 2.8.12.2 is known to work on Mac OS X 10.9.5)
+
+### Mac OSX >= 10.5 (Leopard)
+
+- CMake >= 2.8.9
+  - For Mac Os X >= 10.8 ([Mountain Lion](http://en.wikipedia.org/wiki/OS_X_Mountain_Lion)) and/or recent XCode >= 4.5.X - CMake >= 2.8.11 is required. See http://www.cmake.org/files/v2.8/cmake-2.8.11-Darwin64-universal.tar.gz
+
+```
+$ curl -O http://www.cmake.org/files/v2.8/cmake-2.8.11-Darwin64-universal.tar.gz
+$ tar -xzvf cmake-2.8.11-Darwin64-universal.tar.gz --strip-components=1
+```
+
+```
+$ CMake\ 2.8-11.app/Contents/bin/cmake --version
+ cmake version 2.8.11
+```
+
+- Git >= 1.7.10
+- Svn >= 1.7
+- XCode (for the SDK libs)
+  - After installing XCode, install XCode command line developer tools:
+```
+xcode-select --install
+```
+- XQuartz - For Mac Os X >= 10.8 ([Mountain Lion](http://en.wikipedia.org/wiki/OS_X_Mountain_Lion)) install XQuartz (http://xquartz.macosforge.org) to get X11 (no longer a default in OS X).
+- Qt 4 >= 4.8.5. We recommend you install the following two packages:
+  - Download and install [http://download.qt-project.org/official_releases/qt/4.8/4.8.6/qt-opensource-mac-4.8.6-1.dmg qt-opensource-mac-4.8.6-1.dmg]
+  - Download and install [http://download.qt-project.org/official_releases/qt/4.8/4.8.6/qt-opensource-mac-4.8.6-1-debug-libs.dmg qt-opensource-mac-4.8.6-1-debug-libs.dmg]
+
+### Mac OSX 10.11 (El Capitan)
+
+XCode up to version 7 is known to work for Slicer compilation. XCode 8 breaks things on several levels for now.
+Remember to install XCode command line tools (see above) if a reinstall for XCode is needed. 
+
+The standard Qt4 installers fail on this version and the 4.8.6 source code won't build.  But [as described on the slicer-devel mailing list](http://slicer-devel.65872.n3.nabble.com/incompatible-qt-4-8-6-with-OS-X-El-Capitan-td4035551.html) it is possible to install the [homebrew version of qt4 which patches it to work on El Capitan](https://github.com/Homebrew/formula-patches/blob/master/qt/el-capitan.patch) (see below).
+
+- Install the `OS`, `Xcode`, and `XQuartz` (see MacOSX 10.10 above)
+- Install `Qt4` by running the following two commands:
+```
+brew install qt4
+xcode-select --install
+```
+- TCL does not build correctly on El Capitan as of 2015-12-03, so when building Slicer turn `Slicer_USE_PYTHONQT_WITH_TCL` off.
+
+### Mac OSX 10.12 (Sierra)
+
+Similar to 10.11 (El Capitan), there are new issues with Qt4 (caused by Phonon).
+The GitHub user Cartr [offered a patch to the brew team](https://github.com/Homebrew/homebrew-core/pull/5216), and even though it was not integrated (the homebrew team decided to stop patching their recipe to encourage people to use Qt5), he [turned his formula into a tap](https://github.com/cartr/homebrew-qt4) that can be installed (see below).
+
+Follow instructions for 10.11 *(Installing Xcode, XQuartz, run without TCL)* but install **Qt4** like shown below instead:
+```
+brew install cartr/qt4/qt
+xcode-select --install
+```
+
+Confirmed with Xcode: 
+
+- Version 8.1 (8B62) and cmake version 3.4.20151021-g8fbc8e
+- Version 8.3.3 and cmake 3.5.2
+
+### Mac OSX 10.14 (Mojave)
+
+(Associated discussion topic is https://discourse.slicer.org/t/building-on-mac-10-14-mojave/4554/21)
+
+- Install Qt 5.11.2 using [Qt Online Installer for macOS](http://download.qt.io/official_releases/online_installers/qt-unified-mac-x64-online.dmg)
+- Install XCode:
+```
+xcode-select --install
+```
+- Build qt from homebrew
+```
+brew install qt
+ccmake -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 -DQt5_DIR=/usr/local//Cellar/qt/5.13.2/lib/cmake/Qt5 ~/slicer/latest/Slicer
+```
+- Explicitly set the SDK when running make
+```
+SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk make -j20
+```
+
+Note if you have build errors in dcmtk related to iconv symbols, you may need to uninstall the icu4c and dcmtk homebrew packages during the build process.  See [here](https://github.com/QIICR/dcmqi/issues/395) and [here](https://github.com/Slicer/Slicer/commit/6523a62d776e64f970c554978a3c3a8f26022db5).
+
+## Checkout Slicer source files
+
+Notes:
+- While it is not enforced, we strongly recommend you to *avoid* the use of *spaces* for both the `source directory` and the `build directory`.
+- Due to maximum path length limitations during build the build process, source and build folders must be located in a folder with very short total path length. This is expecially critical on Windows and MacOS. For example, `/sq5` has been confirmed to work on MacOS.
+
+Check out the code using `git`:
+- Clone the github repository</p>
+```cd MyProjects
+git clone git://github.com/Slicer/Slicer.git
+```
+The `Slicer``` directory is automatically created after cloning Slicer.
+- Setup the development environment:
+```cd Slicer
+./Utilities/SetupForDevelopment.sh
+```
+
+## Configure and generate Slicer solution files
+
+- Configure using the following commands. By default `CMAKE_BUILD_TYPE` is set to `Debug` (replace `/path/to/QtSDK` with the real path on your machine where QtSDK is located):
+```
+mkdir Slicer-SuperBuild-Debug
+cd Slicer-SuperBuild-Debug
+cmake -DCMAKE_BUILD_TYPE:STRING=Debug -DQt5_DIR:PATH=/path/to/Qt5.15.0/5.15.0/gcc_64/lib/cmake/Qt5 ../Slicer
+```
+- If `using Qt from the system`, do not forget to add the following CMake variable to your configuration command line: `-DSlicer_USE_SYSTEM_QT:BOOL=ON`
+- Remarks:
+  - Instead of `cmake`, you can use `ccmake` or `cmake-gui` to visually inspect and edit configure options.
+  - Using top-level directory name like `Slicer-SuperBuild-Release` or `Slicer-SuperBuild-Debug` is recommended.
+  - [Step-by-step debug instuctions](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/Debug_Instructions)
+  - Additional configuration options to customize the application are described [here](overview.md#Customized_builds).
+
+- On Mac OS X 10.9 (Mavericks) / 10.10 (Yosemite) / 10.11 (El Capitan), also set the following variables (see [ discussion](http://massmail.spl.harvard.edu/public-archives/slicer-devel/2014/thread.html#16440)):
+  - `Slicer_USE_PYTHONQT_WITH_TCL` -> `OFF`
+  - `CMAKE_OSX_DEPLOYMENT_TARGET` -> `10.9` or `10.10` or `10.11`
+
+### General information
+
+Two projects are generated by either `cmake`, `ccmake` or `cmake-gui`. One of them is in the top-level bin directory `Slicer-SuperBuild` and the other one is in the subdirectory `Slicer-build`:
+- `Slicer-SuperBuild` manages all the external dependencies of Slicer (VTK, ITK, Python, ...). To build Slicer for the first time, run make (or build the solution file in Visual Studio) in `Slicer-SuperBuild`, which will update and build the external libraries and if successful will then build the subproject Slicer-build.
+- `Slicer-SuperBuild/Slicer-build` is the "traditional" build directory of Slicer.  After local changes in Slicer (or after an svn update on the source directory of Slicer), only running make (or building the solution file in Visual Studio) in `Slicer-SuperBuild/Slicer-build` is necessary (the external libraries are considered built and up to date).
+
+*Warning:* An significant amount of disk space is required to compile Slicer in Debug mode (>10GB)
+
+#### Workaround for if the firewall is blocking git protocol
+
+Some firewalls will block the git protocol. A possible workaround is to configure Slicer by disabling the option `Slicer_USE_GIT_PROTOCOL`. Then the http protocol will be used instead. Consider also reading https://github.com/commontk/CTK/issues/33
+
+## Build Slicer
+
+After configuration, start the build process in the `Slicer-SuperBuild` directory
+
+- Start a terminal and type the following (you can replace 4 by the number of processor cores in the computer):
+```
+cd ~/Projects/Slicer-SuperBuild
+make -j4
+```
+
+In case of file download hash mismatch error, you need to acquire the latest wget, and build cmake with OpenSSL turned on. For more information, see [here](http://slicer-devel.65872.n3.nabble.com/How-to-solve-wget-error-certificate-common-name-c-ssl-fastly-net-doesn-t-match-requested-host-name-p-td4031491.html) and [here](http://slicer-devel.65872.n3.nabble.com/Re-Hash-Error-td4031386.html).
+
+When using the -j option, the build will continue past the source of the first error. If the build fails and you don't see what failed, rebuild without the -j option. Or, to speed up this process build first with the -j and -k options and then run plain make. The -k option will make the build keep going so that any code that can be compiled independent of the error will be completed and the second make will reach the error condition more efficiently.
+
+## Run Slicer
+
+Start a terminal and type the following:
+```
+Slicer-SuperBuild/Slicer-build/Slicer
+```
+
+## Test Slicer
+
+After building, run the tests in the  `Slicer-SuperBuild/Slicer-build` directory.
+
+Start a terminal and type the following (you can replace 4 by the number of processor cores in the computer):
+```
+cd ~/Projects/Slicer-SuperBuild/Slicer-build
+ctest -j4
+```
+
+## Package Slicer
+
+Start a terminal and type the following:
+```
+cd ~/Projects/Slicer-SuperBuild
+cd Slicer-build
+make package
+```
+
+## Common errors
+
+### CMake complains during configuration
+
+CMake may not directly show what's wrong; try to look for log files of the form BUILD/CMakeFiles/*.log (where BUILD is your build directory) to glean further information.
+
+### error: ‘class QList<QString>’ has no member named ‘reserve’
+
+```
+ /nfs/Users/blowekamp/QtSDK/Desktop/Qt/474/gcc/include/QtCore/qdatastream.h: In function ‘QDataStream& operator>>(QDataStream&, QList<T>&) [with T = QString]’:
+ /nfs/Users/blowekamp/QtSDK/Desktop/Qt/474/gcc/include/QtCore/qstringlist.h:247:   instantiated from here
+ /nfs/Users/blowekamp/QtSDK/Desktop/Qt/474/gcc/include/QtCore/qdatastream.h:246: error: ‘class QList<QString>’ has no member named ‘reserve’
+```
+You have multiple Qt versions installed on your machine. Try removing the Qt version installed on the system.
+
+### libarchive.so: undefined reference to `SHA256_Update'
+
+```
+ Linking CXX executable ../../../../../bin/MRMLLogicCxxTests
+ /home/benjaminlong/work/slicer/Slicer-SuperBuild-Debug/LibArchive-install/lib/libarchive.so: undefined reference to `SHA256_Update'
+ /home/benjaminlong/work/slicer/Slicer-SuperBuild-Debug/LibArchive-install/lib/libarchive.so: undefined reference to `SHA256_Final'
+ /home/benjaminlong/work/slicer/Slicer-SuperBuild-Debug/LibArchive-install/lib/libarchive.so: undefined reference to `SHA256_Init'
+ /home/benjaminlong/work/slicer/Slicer-SuperBuild-Debug/LibArchive-install/lib/libarchive.so: undefined reference to `MD5_Init'
+```
+
+Solution:
+```
+ cd Slicer-SuperBuild
+ rm -rf LibArchive-*
+ make -j4
+```
+
+Details:
+- http://na-mic.org/Mantis/view.php?id=1616
+- http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=18923
+- http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=18969
+
+### ld: framework not found QtWebKit
+
+```
+Linking CXX shared library libPythonQt.dylib
+ld: framework not found QtWebKit
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+make[8]: *** [libPythonQt.dylib] Error 1
+```
+
+See Slicer issue [2860](http://na-mic.org/Mantis/view.php?id=2860).
+
+Workaround:
+- See http://public.kitware.com/Bug/view.php?id=13765#c31824
+
+Solution:
+- Use a recent CMake. It includes patch [cc676c3a](http://cmake.org/gitweb?p=cmake.git;a=commitdiff;h=cc676c3a). Note also that the coming version of CMake 2.8.11 will work as expected.
+
+### On MacOSX 10.8, CMake hangs forever
+
+Issue: http://www.na-mic.org/Bug/view.php?id=2957
+
+Solution: Use CMake build >= 2.8.10.20130220-g53b279. See http://www.cmake.org/files/dev/cmake-2.8.10.20130220-g53b279-Darwin-universal.tar.gz
+
+Details:
+
+CMake folks (Thanks Brad King :)) fixed an issue that was preventing the most recent nightly from being used to successfully compile Slicer. The fix has been tested and is known to work. Tomorrow nightly build of CMake and by extension the coming release of CMake 2.8.11 will work.
+
+If you are curious about the details, check the commit message: http://cmake.org/gitweb?p=cmake.git;a=commitdiff;h=1df09e57
+
+The associated CMake test have also been updated: http://cmake.org/gitweb?p=cmake.git;a=commitdiff;h=bff3d9ce
+
+### On MacOSX 10.8/10.9 with XQuartz, 'X11/Xlib.h' file not found
+
+Issue: http://www.na-mic.org/Bug/view.php?id=3405
+
+Workaround: Build with -DSlicer_USE_PYTHONQT_WITH_TCL:BOOL=OFF
+
+Tcl is required only for EMSegment module.
+
+Details: See http://www.na-mic.org/Bug/view.php?id=3405
+
+### 'QSslSocket' : is not a class or namespace name
+
+This error message occurs if Slicer is configured to use SSL but Qt is built without SSL support.
+
+Either set Slicer_USE_PYTHONQT_WITH_OPENSSL to OFF when configuring Slicer build in CMake, or build Qt with SSL support.
+
+### error: Missing Qt module QTWEBKIT
+
+```
+ CMake Error at CMake/SlicerBlockFindQtAndCheckVersion.cmake:43 (message):
+  error: Missing Qt module QTWEBKIT
+ Call Stack (most recent call first):
+  CMake/SlicerBlockFindQtAndCheckVersion.cmake:88 (__SlicerBlockFindQtAndCheckVersion_find_qt)
+  CMakeLists.txt:607 (include)
+```
+
+Solution:
+```
+sudo apt-get -y install libqtwebkit-dev
+```
+
+Details: http://slicer-devel.65872.n3.nabble.com/Re-slicer-devel-Digest-Vol-143-Issue-39-td4037122.html
+
+### error when starting Slicer: NameError: name 'getSlicerRCFileName' is not defined
+
+```
+./Slicer
+Traceback (most recent call last):
+  File "<string>", line 7, in <module>
+  File "/home/fbudin/Devel/Slicer-SuperBuild-Release/Slicer-build/bin/Python/slicer/slicerqt.py", line 6, in <module>
+    import vtk
+  File "/home/fbudin/Devel/Slicer-SuperBuild-Release/VTKv7-build/Wrapping/Python/vtk/__init__.py", line 41, in <module>
+    from .vtkCommonKit import *
+  File "/home/fbudin/Devel/Slicer-SuperBuild-Release/VTKv7-build/Wrapping/Python/vtk/vtkCommonKit.py", line 9, in <module>
+    from vtkCommonKitPython import *
+ImportError: /home/fbudin/Devel/Slicer-SuperBuild-Release/VTKv7-build/lib/./libvtkCommonKitPython27D-7.1.so.1: undefined symbol: PyUnicodeUCS2_DecodeUTF8
+Traceback (most recent call last):
+  File "<string>", line 1, in <module>
+NameError: name 'getSlicerRCFileName' is not defined
+Number of registered modules: 138
+error: [/home/fbudin/Devel/Slicer-SuperBuild-Release/Slicer-build/bin/./SlicerApp-real] exit abnormally - Report the problem.
+```
+
+Solution and details [here](http://na-mic.org/Mantis/view.php?id=3574)
+
+### macOS: error while configuring PCRE: "cannot run C compiled program"
+
+If the XCode command line tools are not properly set up on OS X, PCRE could fail to build in the Superbuild process with the errors like below:
+```
+configure: error: in `/Users/fedorov/local/Slicer4-Debug/PCRE-build':
+configure: error: cannot run C compiled programs.
+```
+
+To install XCode command line tools, use the following command from the terminal:
+```
+xcode-select --install
+```
+
+### macOS: dyld: malformed mach-o: load commands size (...) > 32768
+
+Path of source or build folder is too long. For example building Slicer in */User/somebody/projects/something/dev/slicer/slicer-qt5-rel* may fail with malformed mach-o error, while it succeeds in */sq5* folder. To resolve this error, move source and binary files into a folder with shorter full path and restart the build from scratch (the build tree is not relocatable).

--- a/Docs/developer_guide/build_instructions/overview.md
+++ b/Docs/developer_guide/build_instructions/overview.md
@@ -1,0 +1,40 @@
+#  Overview
+
+Building Slicer is the process of obtaining a copy of the source code of the
+project and use tools, such as compilers, project generators and build systems,
+to create binary libraries and executables&mdash;Slicer documentation can be
+also generated in this process. Users interested on using the Slicer application
+and its ecosystem of extensions will not typically be interested on building 3D
+Slicer. On the other hand, users interested on developing Slicer
+[modules](../user_guide/modules/index.html) or contributing to the development of
+Slicer, need to have the source code of Slicer and the corresponding generated
+binaries.
+
+Slicer is based on a *superbuild* architecture. This means that the in the
+building process, most of the dependencies of Slicer will be downloaded in local
+directories (within the Slicer build directory) and will be configured, built
+and installed locally, before Slicer itself is built. This helps reducing the
+complexity for developers.
+
+The instructions provided in this document have been tested for Slicer in its
+**latest version** and generally will work on versions that are not too far from it
+in the development process.
+
+## Custom builds
+
+Customized editions of Slicer can be generated without changing Slicer source code, just by modifying CMake variables:
+
+- `SlicerApp_APPLICATION_NAME`: Custom application name to be used, instead of default "Slicer". The name is used in installation package name, window title bar, etc.
+- `Slicer_DISCLAIMER_AT_STARTUP`: String that is displayed to the user after first startup of Slicer after installation (disclaimer, welcome message, etc).
+- `Slicer_DEFAULT_HOME_MODULE`: Module name that is activated automatically on application start.
+- `Slicer_DEFAULT_FAVORITE_MODULES`: Modules that will be added to the toolbar by default for easy access. List contains module names, separated by space character.
+- `Slicer_CLIMODULES_DISABLED`: Built-in CLI modules that will be removed from the application. List contains module names, separated by semicolon character.
+- `Slicer_QTLOADABLEMODULES_DISABLED`: Built-in Qt loadable modules that will be removed from the application. List contains module names, separated by semicolon character.
+- `Slicer_QTSCRIPTEDMODULES_DISABLED`: Built-in scripted loadable modules that will be removed from the application. List contains module names, separated by semicolon character.
+- `Slicer_USE_PYTHONQT_WITH_OPENSSL`: enable/disable building the application with SSL support (ON/OFF)
+- `Slicer_USE_SimpleITK`: enable/disable SimpleITK support (ON/OFF)
+- `Slicer_BUILD_SimpleFilters`: enable/disable building SimpleFilters. Requires SimpleITK. (ON/OFF)
+- `Slicer_USE_PYTHONQT_WITH_TCL`: TCL support (ON/OFF)
+- `Slicer_EXTENSION_SOURCE_DIRS`: Defines additional extensions that will be included in the application package as built-in modules. Full paths of extension source directories has to be specified, separated by semicolons.
+
+More customization is available by using [SlicerCustomAppTemplate](https://github.com/KitwareMedical/SlicerCustomAppTemplate) project maintained by Kitware.

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -1,0 +1,143 @@
+# Windows
+
+## Install prerequisites
+
+- [CMake](http://www.cmake.org/cmake/resources/software.html) >= 3.15.1
+- [Git](https://git-scm.com/download/win) >= 1.7.10
+  - Note CMake must be able to find `git.exe` and `patch.exe`. If git is installed in the default location then they may be found there, but if they are not found then either add the folder that contains them to `PATH` environment variable; or set `GIT_EXECUTABLE` and `Patch_EXECUTABLE` as environment variables or as CMake variables at configure time.
+- [NSIS](http://nsis.sourceforge.net/Download) (optional): Needed if packaging Slicer. Make sure you install the language packs.
+- [Qt5](https://www.qt.io/download-open-source): Download Qt universal installer and install Qt 5.15 along with qtscript and qtwebengine components.
+- [Visual Studio](https://visualstudio.microsoft.com/downloads/)
+  - any edition can be used (including the free Community edition)
+  - when configuring the installer, enable installation of Visual Studio 2019 (v142) toolset and component Programming languages / Visual C++ / Common Tools for Visual C++ (in some distributions, this option is not enabled by default)
+
+Other versions:
+- Visual Studio 2017 (v141) toolset is not tested anymore but probably still works. Qt-5.15 requires v142 redistributables, so either these extra DLL files need to be added to the installation package or each user may need to install "Microsoft Visual C++ Redistributable" package.
+- Visual Studio 2015 (v140) toolset is not tested anymore and probably does not work. Requires Qt 5.10.x to build due to QtWebEngine.
+- Cygwin: not testes and not recommended. Building with cygwin gcc not supported, but the cygwin shell environment can be used to run git, svn, etc.
+
+## Set up source and build folders
+
+- Create source folder. This folder will be referred to as `<Slicer_SOURCE>` in the followings. Recommended path: `C:\D\S4`
+  - Due to maximum path length limitations during build the build process, source and build folders must be located in a folder with very short (couple of characters) total path length.
+  - While it is not enforced, we strongly recommend you to avoid the use of spaces for both the source directory and the build directory.
+- Create build folder. This folder will be referred to as `<Slicer_BUILD>` in the followings. Recommended path: `C:\D\S4R` for release-mode build, `C:\D\S4D` for debug-mode build.
+  - You cannot use the same build tree for both release or debug mode builds. If both build types are needed, then the same source directory can be used, but a separate build directory must be created and configured for each build type.
+- Download source code into _Slicer source_ folder from GitHub: https://github.com/Slicer/Slicer.git
+  - The following command can be executed in _Slicer source_ folder to achieve this: `git clone https://github.com/Slicer/Slicer.git .`
+- Configure the repository for developers (optional): Needed if changes need to be contributed to Slicer repository.
+  - Right-click on `<Slicer_SOURCE>/Utilities` folder in Windows Explorer and select `Git bash here`
+  - Execute this command in the terminal (and answer all questions): `./SetupForDevelopment.sh`
+  - Note: more information about how to use git in Slicer can be found on [this page](https://www.slicer.org/wiki/Documentation/Nightly/Developers/DevelopmentWithGit)
+
+## Configure and build Slicer
+
+### Using command-line (recommended)
+
+Specify source, build, and Qt location and compiler version and start the build using the following commands (these can be put into a .bat file so that they can be executed again easily), assuming default folder locations:
+
+Release mode:
+
+```
+mkdir C:\D\S4R
+cd /d C:\D\S4R
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019 Win64" -DQt5_DIR:PATH=C:\Qt\5.15.0\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" --build . --config Release
+```
+
+Debug mode:
+
+```
+mkdir C:\D\S4D
+cd /d C:\D\S4D
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019 Win64" -DQt5_DIR:PATH=C:\Qt\5.15.0\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" --build . --config Debug
+```
+
+### Using graphical user interface (alternative solution)
+
+- Run `CMake (cmake-gui)` from the Windows Start menu
+- Set `Where is the source code` to `<Slicer_SOURCE>` location
+- Set `Where to build the binaries` to `<Slicer_BUILD>` location. Do not configure yet!
+- Add `Qt5_DIR` variable pointing to Qt5 folder: click Add entry button, set `Name` to `Qt5_DIR`, set `Type` to `PATH`, and set `Value` to the Qt5 folder, such as `C:\Qt\5.15.0\msvc2019_64\lib\cmake\Qt5`.
+- Click `Configure`
+- Select your compiler: `Visual Studio 16 2019`, and click `Finish`
+- Click `Generate` and wait for project generation to finish (may take a few minues)
+- Click `Open Project`
+- If building in release mode:
+  - Open the top-level Slicer.sln file in the build directory in Visual Studio
+  - Set active configuration to Release. Visual Studio will select Debug build configuration by default when you first open the solution in the Visual Studio GUI. If you build Slicer in release mode and accidentally forget to switch the build configuration to Release then the build will fail. Note: you can avoid this manual configuration mode selection by setting `CMAKE_CONFIGURATION_TYPES` to Release in cmake-gui.
+- Build the `ALL_BUILD` project
+
+## Run Slicer
+
+Run `<Slicer_BUILD>/Slicer-build/Slicer.exe` application.
+
+Note: `Slicer.exe` is a "launcher", which sets environment variables and launches the real executable: `<Slicer_BUILD>/Slicer-build\bin\Release\SlicerApp-real.exe` (use `Debug` instead of `Release` for debug-mode builds).
+
+## Test Slicer
+
+- Start Visual Studio with the launcher:
+```
+Slicer.exe --VisualStudioProject
+```
+- Select build configuration. Usually `Release` or `Debug`.
+- In the "Solution Explorer", right click on `RUN_TESTS` project (in the CMakePredefinedTargets folder) and then select `Build`.
+
+## Package Slicer (create installer package)
+
+- Start Visual Studio with the launcher:
+```
+Slicer.exe --VisualStudioProject
+```
+- Select `Release` build configuration.
+- In the "Solution Explorer", right click on `PACKAGE` project (in the CMakePredefinedTargets folder) and then select `Build`.
+
+## Debug Slicer
+
+1. To run Slicer, the launcher needs to set certain environment variables. The easiest is to use the launcher to set these and start Visual Studio in this environment. All these can be accomplished by running the following command in `<Slicer_BUILD>/c:\D\S4R\Slicer-build` folder:
+
+```
+Slicer.exe --VisualStudioProject
+```
+
+Notes:
+- If you just want to start VisualStudio with the launcher (and then load project file manually), run: `Slicer.exe --VisualStudio`
+- To debug an extension that builds third-party DLLs, also specify `--launcher-additional-settings` option.
+- While you can launch debugger using Slicer's solution file, it is usually more convenient to load your extension's solution file (because your extension solution is smaller and most likely you want to have that solution open anyway for making changes in your code). For example, you can launch Visual Studio to debug your extension like this:
+
+```
+.\S4D\Slicer-build\Slicer.exe --VisualStudio --launcher-no-splash --launcher-additional-settings ./SlicerRT_D/inner-build/AdditionalLauncherSettings.ini c:\d\_Extensions\SlicerRT_D\inner-build\SlicerRT.sln
+```
+
+2. In Solution Explorer window in Visual Studio, expand `App-Slicer`, right-click on `SlicerApp` (NOT qSlicerApp) and select "Set as Startup Project"
+
+To debug in an extension's solution: set `ALL_BUILD` project as startup project and in project settings, set `Debugging` / `Command` field to the full path of `SlicerApp-real.exe` - something like `.../Slicer-build/bin/Debug/SlicerApp-real.exe`
+
+3. Run Slicer in debug mode by Start Debugging command (in Debug menu).
+
+Note that because CMake re-creates the solution file from within the build process, Visual Studio will sometimes need to stop and reload the project, requiring manual button pressing on your part (just press Yes or OK whenever you are asked). To avoid this, you can use a script to complete the build process and then re-start the Visual Studio.
+
+For more debugging tips and tricks, check out [this page](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/Troubleshooting).
+
+### Debug a test
+
+Once VisualStudio is open with the Slicer environment loaded, it is possible to run and debug tests. To run all tests, build the `RUN_TESTS` project.
+
+- To debug a test, find its project:
+  - `Libs/MRML/Core` tests are in the `MRMLCoreCxxTests` project
+  - CLI module tests are in `<CLI_NAME>Test` project (e.g. `ThresholdScalarVolumeTest`)
+  Loadable module tests are in `qSlicer<LOADABLE_NAME>CxxTests` project (e.g. `qSlicerVolumeRenderingCxxTests`)
+  - Module logic tests are in `<MODULE_NAME>LogicCxxTests` project (e.g. `VolumeRenderingLogicCxxTests`)
+  - Module widgets tests are in `<MODULE_NAME>WidgetsCxxTests` project (e.g. `VolumesWidgetsCxxTests`)
+- Go to the project debugging properties (right click -> Properties, then Configuration Properties/Debugging)
+- In `Command Arguments`, type the name of the test (e.g. `vtkMRMLSceneImportTest` for project `MRMLCoreCxxTests`)
+- If the test takes argument(s), enter the argument(s) after the test name in `Command Arguments` (e.g. `vtkMRMLSceneImportTest C:\Path\To\Slicer4\Libs\MRML\Core\Testing\vol_and_cube.mrml`)
+  - You can see what arguments are passed by the dashboards by looking at the test details in CDash.
+  - Most VTK and Qt tests support the `-I` argument, it allows the test to be run in "interactive" mode. It doesn't exit at the end of the test.
+- Make the project Set As Startup Project
+- Start Debugging (F5)
+
+### Debugging Python scripts
+
+See [Python scripting page](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Python_scripting#How_can_I_use_a_visual_debugger_for_step-by-step_debugging) for detailed instructions.

--- a/Docs/index.rst
+++ b/Docs/index.rst
@@ -31,6 +31,7 @@ For Slicer-4.10 documentation, refer to the `3D Slicer wiki <https://www.slicer.
    :maxdepth: 3
    :caption: Developer Guide:
 
+   developer_guide/build_instructions/index.rst
    developer_guide/api
    developer_guide/mrml_overview
    developer_guide/extensions


### PR DESCRIPTION
**This is a work-in-progress branch**

As suggested in the last meeting, I started a documentation section for building Slicer on Linux using different distributions. I welcome comments on structure and contents and appreciate feedback on the following questions:

- I added the section to the `index.rst` file. It seems, however, that the section link does not appear in the left column when visiting some other content (e.g., content in the user guide)?
- The content is inspired on the current Slicer wiki content. There are a few links to other articles (e.g., link to https://www.slicer.org/wiki/Documentation/Nightly/Developers/DevelopmentWithGit). What to to with this type of content: keep external link? open an new section in the readthedocs documentation?
- In the same way, in the Wiki, there are links to presentations and pdf files.  Should we transfer the files and link them?
- Change the `building_slicer.md` to `.rst` format? For adding tips, warnings, notes, etc., one need to embed `html` code into the markdown, which is not very elegant.

TODOs:
- [ ] Add installation of pre-requisites for Fedora
- [ ] Add installation of pre-requisites for Gentoo
- [ ] Add a note to use `-DSlicer_USE_SYSTEM_curl=ON` for Gentoo/Arch while #5049 is open