### PR TITLE
ENH: Utilize color table node for segmentation import/export

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -87,6 +87,9 @@ vtkMRMLSegmentationNode::vtkMRMLSegmentationNode()
   this->ContentModifiedEvents->InsertNextValue(vtkSegmentation::SegmentRemoved);
   this->ContentModifiedEvents->InsertNextValue(vtkSegmentation::SegmentModified);
   this->ContentModifiedEvents->InsertNextValue(vtkSegmentation::SegmentsOrderModified);
+
+  this->AddNodeReferenceRole(this->GetLabelmapConversionColorTableNodeReferenceRole(),
+    this->GetLabelmapConversionColorTableNodeReferenceMRMLAttributeName());
 }
 
 //----------------------------------------------------------------------------
@@ -538,15 +541,16 @@ bool vtkMRMLSegmentationNode::GenerateMergedLabelmap(
   vtkOrientedImageData* mergedImageData,
   int extentComputationMode,
   vtkOrientedImageData* mergedLabelmapGeometry/*=nullptr*/,
-  const std::vector<std::string>& segmentIDs/*=std::vector<std::string>()*/
+  const std::vector<std::string>& segmentIDs/*=std::vector<std::string>()*/,
+  vtkIntArray* labelValues/*=nullptr*/
   )
 {
-  return this->Segmentation->GenerateMergedLabelmap(mergedImageData, extentComputationMode, mergedLabelmapGeometry, segmentIDs);
+  return this->Segmentation->GenerateMergedLabelmap(mergedImageData, extentComputationMode, mergedLabelmapGeometry, segmentIDs, labelValues);
 }
 
 //---------------------------------------------------------------------------
 bool vtkMRMLSegmentationNode::GenerateMergedLabelmapForAllSegments(vtkOrientedImageData* mergedImageData, int extentComputationMode,
-  vtkOrientedImageData* mergedLabelmapGeometry /*=nullptr*/, vtkStringArray* segmentIDs /*=nullptr*/)
+  vtkOrientedImageData* mergedLabelmapGeometry /*=nullptr*/, vtkStringArray* segmentIDs /*=nullptr*/, vtkIntArray* labelValues/*nullptr*/)
 {
   std::vector<std::string> segmentIDsVector;
   if (segmentIDs)
@@ -556,7 +560,7 @@ bool vtkMRMLSegmentationNode::GenerateMergedLabelmapForAllSegments(vtkOrientedIm
       segmentIDsVector.push_back(segmentIDs->GetValue(i));
       }
     }
-  return this->GenerateMergedLabelmap(mergedImageData, extentComputationMode, mergedLabelmapGeometry, segmentIDsVector);
+  return this->GenerateMergedLabelmap(mergedImageData, extentComputationMode, mergedLabelmapGeometry, segmentIDsVector, labelValues);
 }
 
 //-----------------------------------------------------------------------------
@@ -1178,4 +1182,16 @@ void vtkMRMLSegmentationNode::GetSegmentCenterRAS(const std::string& segmentID, 
     centerRAS[1] = segmentCenterPositionRAS[1];
     centerRAS[2] = segmentCenterPositionRAS[2];
     }
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLSegmentationNode::SetLabelmapConversionColorTableNodeID(const char* labelmapConversionColorTableNodeID)
+{
+  this->SetNodeReferenceID(this->GetLabelmapConversionColorTableNodeReferenceRole(), labelmapConversionColorTableNodeID);
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLColorTableNode* vtkMRMLSegmentationNode::GetLabelmapConversionColorTableNode()
+{
+  return vtkMRMLColorTableNode::SafeDownCast(this->GetNodeReference(this->GetLabelmapConversionColorTableNodeReferenceRole()));
 }

--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -802,6 +802,8 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
       }
     }
 
+  vtkMRMLColorTableNode* exportColorTableNode = segmentationNode->GetLabelmapConversionColorTableNode();
+
   // Add the created segments to the segmentation
   for (int segmentIndex = 0; segmentIndex < static_cast<int>(segments.size()); ++segmentIndex)
     {
@@ -855,7 +857,20 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
       {
       std::stringstream segmentNameSS;
       segmentNameSS << "Segment_" << currentSegment->GetLabelValue();
-      currentSegmentID = segmentation->GenerateUniqueSegmentID(segmentNameSS.str());
+      std::string segmentName = segmentNameSS.str();
+      if (exportColorTableNode)
+        {
+        const char* colorName = exportColorTableNode->GetColorName(currentSegment->GetLabelValue());
+        if (colorName)
+          {
+          segmentName = colorName;
+          }
+
+        double color[4] = { 0.0, 0.0, 0.0 };
+        exportColorTableNode->GetColor(currentSegment->GetLabelValue(), color);
+        currentSegment->SetColor(color);
+        }
+      currentSegmentID = segmentation->GenerateUniqueSegmentID(segmentName);
       currentSegment->SetName(currentSegmentID.c_str());
       }
     segmentation->AddSegment(currentSegment, currentSegmentID);

--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -40,6 +40,7 @@
 class vtkAbstractTransform;
 class vtkCallbackCommand;
 class vtkCollection;
+class vtkIntArray;
 class vtkStringArray;
 
 /// \ingroup SegmentationCore
@@ -309,8 +310,18 @@ public:
 #ifndef __VTK_WRAP__
   /// Create a merged labelmap from the segment IDs
   /// If no segment IDs are specified, then all segments will be merged
+  /// \param mergedImageData Output image data for the merged labelmap image data. Voxels of background volume will be
+  /// of signed short type. Label value of n-th segment in segmentIDs list will be (n + 1), or will be specified in labelValues.
+  /// Label value of background = 0.
+  /// \param extentComputationMode Input that determines how to compute extents (EXTENT_REFERENCE_GEOMETRY, EXTENT_UNION_OF_SEGMENTS,
+  ///   EXTENT_UNION_OF_SEGMENTS_PADDED, EXTENT_UNION_OF_EFFECTIVE_SEGMENTS, or EXTENT_UNION_OF_EFFECTIVE_SEGMENTS_PADDED).
+  /// \param mergedLabelmapGeometry Determines geometry of merged labelmap if not nullptr, automatically determined otherwise
+  /// \param segmentIDs List of IDs of segments to include in the merged labelmap. If empty or missing, then all segments are included
+  /// \param labelValues Input list of label values that will be used in the merged labelmap.
+  ///   If not specified, then the label values in the segmentation will be used.
+  ///   The size of the array should match the number of segment IDs used in the merged labelmap.
   bool GenerateMergedLabelmap(vtkOrientedImageData* mergedImageData, int extentComputationMode, vtkOrientedImageData* mergedLabelmapGeometry = nullptr,
-    const std::vector<std::string>& segmentIDs = std::vector<std::string>());
+    const std::vector<std::string>& segmentIDs = std::vector<std::string>(), vtkIntArray* labelValues = nullptr);
 #endif // __VTK_WRAP__
 
  /// Shared labelmap utility functions

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -72,9 +72,12 @@ public:
 
   /// Load segmentation from file
   /// \param filename Path and name of file containing segmentation (nrrd, vtm, etc.)
-  /// \param autoOpacities Optional flag determining whether segment opacities are calculated automatically based on containment. True by default
+  /// \param autoOpacities Optional flag determining whether segment opacities are calculated automatically based on containment. True by default.
+  /// \param nodeName Optional string to use for the segmentation node name.
+  /// \param colorTableNode Optional color node used to name the segments and set segment color.
   /// \return Loaded segmentation node
-  vtkMRMLSegmentationNode* LoadSegmentationFromFile(const char* filename, bool autoOpacities = true, const char* nodeName=nullptr);
+  vtkMRMLSegmentationNode* LoadSegmentationFromFile(const char* filename, bool autoOpacities = true, const char* nodeName=nullptr,
+    vtkMRMLColorTableNode* colorTableNode=nullptr);
 
   /// Create labelmap volume MRML node from oriented image data.
   /// Creates a display node if a display node does not exist. Shifts image extent to start from zero.
@@ -174,7 +177,7 @@ public:
   ///   By default, the minimum necessary size is used. Set value to vtkSegmentation::EXTENT_REFERENCE_GEOMETRY to use reference geometry extent.
   static bool ExportSegmentsToLabelmapNode(vtkMRMLSegmentationNode* segmentationNode, std::vector<std::string>& segmentIDs,
     vtkMRMLLabelMapVolumeNode* labelmapNode, vtkMRMLVolumeNode* referenceVolumeNode = nullptr,
-    int extentComputationMode = vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS);
+    int extentComputationMode = vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS, vtkMRMLColorTableNode* colorTableNode = nullptr);
 
   /// Export multiple segments into a multi-label labelmap volume node
   /// \param segmentationNode Segmentation node from which the the segments are exported
@@ -185,7 +188,7 @@ public:
   ///   By default, the minimum necessary size is used. Set value to vtkSegmentation::EXTENT_REFERENCE_GEOMETRY to use reference geometry extent.
   static bool ExportSegmentsToLabelmapNode(vtkMRMLSegmentationNode* segmentationNode, vtkStringArray* segmentIDs,
     vtkMRMLLabelMapVolumeNode* labelmapNode, vtkMRMLVolumeNode* referenceVolumeNode = nullptr,
-    int extentComputationMode = vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS);
+    int extentComputationMode = vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS, vtkMRMLColorTableNode* colorTableNode = nullptr);
 
   /// Export visible segments into a multi-label labelmap volume node
   /// \param segmentationNode Segmentation node from which the the visible segments are exported
@@ -255,6 +258,27 @@ public:
   static bool ExportSegmentsClosedSurfaceRepresentationToFiles(std::string destinationFolder,
     vtkMRMLSegmentationNode* segmentationNode, vtkStringArray* segmentIds = nullptr,
     std::string fileFormat = "STL", bool lps = true, double sizeScale = 1.0, bool merge = false);
+
+  /// Gets the label values for the current segment from the color node reference.
+  /// Label values found by matching color + segment name. If a segment name is not found in the table, then the label value returned for the segment
+  /// is the first label value outside the table range.
+  /// \param segmentationNode Segmentation node that has the export color node reference.
+  /// \param colorTableNode Color table used to get the label values for the segments.
+  /// \param segmentIds List of segment ids to get values for. The order of segmentIds dictates the order of the returned label values.
+  /// \param labelValues Output label values from the color node. Lenght of the array will be the same as the number of segmentIds.
+  static void GetLabelValuesFromColorNode(vtkMRMLSegmentationNode* segmentationNode, vtkMRMLColorTableNode* colorTableNode,
+    vtkStringArray* segmentIds, vtkIntArray* labelValues);
+
+  /// Export binary surface representation of multiple segments to a single output volume.
+  /// \param destinationFolder Folder name where segments will be exported to
+  /// \param segmentationNode Segmentation node that has the export color node reference.
+  /// \param segmentIds List of segment ids to get values for. The order of segmentIds dictates the order of the returned label values.
+  /// \param extension The file extension used for the output file. "nrrd" by default.
+  /// \param useCompression If compression should be applied to the output file.
+  /// \param colorTableNode Color table node used to set the exported labelmap values for the segments.
+  static bool ExportSegmentsBinaryLabelmapRepresentationToFiles(std::string destinationFolder,
+    vtkMRMLSegmentationNode* segmentationNode, vtkStringArray* segmentIds = nullptr, std::string extension = "nrrd", bool useCompression = false,
+    vtkMRMLColorTableNode* colorTableNode = nullptr);
 
   /// Create representation of only one segment in a segmentation.
   /// Useful if only one segment is processed, and we do not want to convert all segments to a certain

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsIOOptionsWidget.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsIOOptionsWidget.ui
@@ -6,15 +6,24 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>216</width>
-    <height>23</height>
+    <width>322</width>
+    <height>20</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Segmentations Options</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -30,9 +39,51 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QLabel" name="ColorLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Color node:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="qMRMLNodeComboBox" name="ColorNodeSelector">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="nodeTypes">
+      <stringlist>
+       <string>vtkMRMLColorTableNode</string>
+      </stringlist>
+     </property>
+     <property name="noneEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="addEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="removeEnabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+  </customwidget>
   <customwidget>
    <class>qSlicerWidget</class>
    <extends>QWidget</extends>
@@ -41,5 +92,22 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>qSlicerSegmentationsIOOptionsWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>ColorNodeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>160</x>
+     <y>9</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>276</x>
+     <y>9</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
@@ -635,13 +635,39 @@
           </widget>
          </item>
          <item row="2" column="0">
-          <widget class="QLabel" name="label_TerminologyContext">
+          <widget class="QLabel" name="UseColorTableValuesLabel">
            <property name="text">
-            <string>Terminology context:</string>
+            <string>Use color table values:</string>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QCheckBox" name="UseColorTableValuesCheckBox">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="qMRMLNodeComboBox" name="ColorTableNodeSelector">
+             <property name="nodeTypes">
+              <stringlist>
+               <string>vtkMRMLColorTableNode</string>
+              </stringlist>
+             </property>
+             <property name="addEnabled">
+              <bool>false</bool>
+             </property>
+             <property name="removeEnabled">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="3" column="1">
           <widget class="ctkComboBox" name="ComboBox_TerminologyContext">
            <property name="toolTip">
             <string>Labels of the imported labelmap will be mapped to terminology entries of this context</string>
@@ -651,6 +677,13 @@
            </property>
            <property name="defaultText">
             <string>Choose terminology...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="label_TerminologyContext">
+           <property name="text">
+            <string>Terminology context:</string>
            </property>
           </widget>
          </item>
@@ -731,11 +764,11 @@
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="label_OverwriteSegmentsText">
-        <property name="text">
-         <string>Force collapse to single layer:</string>
-        </property>
         <property name="toolTip">
          <string>Forcing all segments to a single layer will modify overlapping segments. Regions where multiple segments overlap will be assigned to the segment closest to the end of the segment list.</string>
+        </property>
+        <property name="text">
+         <string>Force collapse to single layer:</string>
         </property>
        </widget>
       </item>
@@ -757,11 +790,11 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="text">
-         <string>Collapse labelmap layers</string>
-        </property>
         <property name="toolTip">
          <string>Minimize the number of layers by moving segments to shared layers to minimize memory usage. Contents of segments are not modified unless there are overlapping segments and collapsing to a single layer is forced.</string>
+        </property>
+        <property name="text">
+         <string>Collapse labelmap layers</string>
         </property>
        </widget>
       </item>
@@ -979,6 +1012,22 @@
     <hint type="destinationlabel">
      <x>275</x>
      <y>708</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerSegmentationsModule</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>ColorTableNodeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>169</x>
+     <y>431</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>224</x>
+     <y>699</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationFileExportWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationFileExportWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>326</width>
-    <height>184</height>
+    <width>298</width>
+    <height>229</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,82 +29,57 @@
    <property name="spacing">
     <number>4</number>
    </property>
-   <item row="7" column="1">
-    <widget class="QCheckBox" name="VisibleSegmentsOnlyCheckBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>Only export those segments that are currently visible.</string>
-     </property>
+   <item row="2" column="0">
+    <widget class="QLabel" name="DestinationFoldeLabel">
      <property name="text">
-      <string/>
+      <string>Destination folder: </string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="SizeScaleLabel">
+   <item row="6" column="0">
+    <widget class="QLabel" name="MergeIntoSingleFileLabel">
      <property name="text">
-      <string>Size scale:</string>
+      <string>Merge into single file:</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
-    <widget class="QComboBox" name="CoordinateSystemComboBox">
-     <property name="toolTip">
-      <string>Output model XYZ axes are mapped to LPS (left-posterior-superior) or RAS (right-anterior-superior) patient axis directions. LPS is used more commonly.</string>
-     </property>
-     <item>
-      <property name="text">
-       <string>LPS</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>RAS</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="VisibleSegmentsOnlyLabel">
+   <item row="4" column="0">
+    <widget class="QLabel" name="FileFormatLabel">
      <property name="text">
-      <string>Visible segments only: </string>
+      <string>File format:</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="HorizontalLayout">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
+   <item row="11" column="1">
+    <layout class="QHBoxLayout" name="ColorTableLayout">
      <item>
-      <widget class="ctkDirectoryButton" name="DestinationFolderButton">
-       <property name="focusPolicy">
-        <enum>Qt::TabFocus</enum>
+      <widget class="QCheckBox" name="UseColorTableValuesCheckBox">
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="ShowDestinationFolderButton">
-       <property name="toolTip">
-        <string>Browse to destination folder</string>
+      <widget class="qMRMLNodeComboBox" name="ColorTableNodeSelector">
+       <property name="nodeTypes">
+        <stringlist>
+         <string>vtkMRMLColorTableNode</string>
+        </stringlist>
        </property>
-       <property name="text">
-        <string>...</string>
+       <property name="noneEnabled">
+        <bool>false</bool>
        </property>
-       <property name="icon">
-        <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
-         <normaloff>:/Icons/Go.png</normaloff>:/Icons/Go.png</iconset>
+       <property name="addEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="removeEnabled">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="10" column="1">
+   <item row="12" column="1">
     <widget class="QCheckBox" name="ShowDestinationFolderOnExportCompleteCheckBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -120,90 +95,6 @@
      </property>
      <property name="checked">
       <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="DestinationFoldeLabel">
-     <property name="text">
-      <string>Destination folder: </string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="FileFormatComboBox">
-     <item>
-      <property name="text">
-       <string>STL</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>OBJ</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="FileFormatLabel">
-     <property name="text">
-      <string>File format:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="CoordinateSystemLabel">
-     <property name="text">
-      <string>Coordinate system: </string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="2">
-    <widget class="QPushButton" name="ExportToFilesButton">
-     <property name="text">
-      <string>Export</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="MergeIntoSingleFileLabel">
-     <property name="text">
-      <string>Merge into single file:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="ShowDestinationFolderOnExportCompleteLabel">
-     <property name="text">
-      <string>Show destination folder:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="ctkDoubleSpinBox" name="SizeScaleSpinBox">
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-     <property name="toolTip">
-      <string>Adjust the exported model size. Point coordinates in the exported model will be multiplied by this number. By default Slicer uses millimeter unit for coordinates.</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="decimalsOption">
-      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
-     </property>
-     <property name="minimum">
-      <double>0.000001000000000</double>
-     </property>
-     <property name="maximum">
-      <double>1000000.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-     <property name="value">
-      <double>1.000000000000000</double>
      </property>
     </widget>
    </item>
@@ -243,9 +134,184 @@
      </item>
     </layout>
    </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="ShowDestinationFolderOnExportCompleteLabel">
+     <property name="text">
+      <string>Show destination folder:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="UseColorTableValuesLabel">
+     <property name="text">
+      <string>Use color table values:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="CoordinateSystemLabel">
+     <property name="text">
+      <string>Coordinate system: </string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QComboBox" name="CoordinateSystemComboBox">
+     <property name="toolTip">
+      <string>Output model XYZ axes are mapped to LPS (left-posterior-superior) or RAS (right-anterior-superior) patient axis directions. LPS is used more commonly.</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>LPS</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>RAS</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="FileFormatComboBox">
+     <item>
+      <property name="text">
+       <string>STL</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>OBJ</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>NRRD</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>NIFTI</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="ctkDoubleSpinBox" name="SizeScaleSpinBox">
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+     <property name="toolTip">
+      <string>Adjust the exported model size. Point coordinates in the exported model will be multiplied by this number. By default Slicer uses millimeter unit for coordinates.</string>
+     </property>
+     <property name="decimals">
+      <number>3</number>
+     </property>
+     <property name="decimalsOption">
+      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
+     </property>
+     <property name="minimum">
+      <double>0.000001000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0" colspan="2">
+    <widget class="QPushButton" name="ExportToFilesButton">
+     <property name="text">
+      <string>Export</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="HorizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="ctkDirectoryButton" name="DestinationFolderButton">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="ShowDestinationFolderButton">
+       <property name="toolTip">
+        <string>Browse to destination folder</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
+         <normaloff>:/Icons/Go.png</normaloff>:/Icons/Go.png</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="VisibleSegmentsOnlyCheckBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>Only export those segments that are currently visible.</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="SizeScaleLabel">
+     <property name="text">
+      <string>Size scale:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="VisibleSegmentsOnlyLabel">
+     <property name="text">
+      <string>Visible segments only: </string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QCheckBox" name="UseCompressionCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="UseCompressionLabel">
+     <property name="text">
+      <string>Use compression:</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>
    <extends>QWidget</extends>
@@ -267,14 +333,29 @@
   <tabstop>DestinationFolderButton</tabstop>
   <tabstop>ShowDestinationFolderButton</tabstop>
   <tabstop>FileFormatComboBox</tabstop>
-  <tabstop>VisibleSegmentsOnlyCheckBox</tabstop>
   <tabstop>SizeScaleSpinBox</tabstop>
   <tabstop>CoordinateSystemComboBox</tabstop>
-  <tabstop>ShowDestinationFolderOnExportCompleteCheckBox</tabstop>
   <tabstop>ExportToFilesButton</tabstop>
  </tabstops>
  <resources>
   <include location="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>qMRMLSegmentationFileExportWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>ColorTableNodeSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>169</x>
+     <y>122</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>281</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -3567,6 +3567,7 @@ void qMRMLSegmentEditorWidget::onExportToFilesActionClicked()
   // Create file export widget to allow user editing conversion details
 
   qMRMLSegmentationFileExportWidget* exportToFileWidget = new qMRMLSegmentationFileExportWidget(exportDialog);
+  exportToFileWidget->setMRMLScene(this->mrmlScene());
   exportToFileWidget->setSegmentationNode(d->SegmentationNode);
   exportToFileWidget->setSettingsKey("ExportSegmentsToFiles");
   layout->addWidget(exportToFileWidget);

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.h
@@ -71,6 +71,8 @@ signals:
   void exportToFilesDone();
 
 public slots:
+  void setMRMLScene(vtkMRMLScene* mrmlScene) override;
+
   /// Set segmentation MRML node
   void setSegmentationNode(vtkMRMLSegmentationNode* node);
   void setSegmentationNode(vtkMRMLNode* node);
@@ -82,9 +84,13 @@ public slots:
   void updateWidgetFromSettings();
   void updateSettingsFromWidget();
 
+  void updateWidgetFromMRML();
+
 protected slots:
 
   void setFileFormat(const QString&);
+  void setColorNodeID(const QString&);
+  void setUseLabelsFromColorNode(bool useColorNode);
 
 protected:
   QScopedPointer<qMRMLSegmentationFileExportWidgetPrivate> d_ptr;

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsIOOptionsWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsIOOptionsWidget.cxx
@@ -65,6 +65,8 @@ qSlicerSegmentationsIOOptionsWidget::qSlicerSegmentationsIOOptionsWidget(QWidget
 
   connect(d->AutoOpacitiesCheckBox, SIGNAL(toggled(bool)),
           this, SLOT(updateProperties()));
+  connect(d->ColorNodeSelector, SIGNAL(currentNodeIDChanged(QString)),
+          this, SLOT(updateProperties()));
 }
 
 //-----------------------------------------------------------------------------
@@ -76,4 +78,5 @@ void qSlicerSegmentationsIOOptionsWidget::updateProperties()
   Q_D(qSlicerSegmentationsIOOptionsWidget);
 
   d->Properties["autoOpacities"] = d->AutoOpacitiesCheckBox->isChecked();
+  d->Properties["colorNodeID"] = d->ColorNodeSelector->currentNodeID();
 }

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.h
@@ -125,6 +125,8 @@ protected slots:
   void updateImportExportWidgets();
   void onImportExportApply();
   void onImportExportClearSelection();
+  void updateExportColorWidgets();
+  void onExportColorTableChanged();
 
   void onMoveFromCurrentSegmentation();
   void onCopyFromCurrentSegmentation();

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
@@ -190,7 +190,15 @@ bool qSlicerSegmentationsReader::load(const IOProperties& properties)
       autoOpacities = properties["autoOpacities"].toBool();
       }
 
-    vtkMRMLSegmentationNode* node = d->SegmentationsLogic->LoadSegmentationFromFile(fileName.toUtf8().constData(), autoOpacities, name.toUtf8());
+    vtkMRMLColorTableNode* colorTableNode = nullptr;
+    if (properties.contains("colorNodeID"))
+      {
+      std::string nodeID = properties["colorNodeID"].toString().toStdString();
+      colorTableNode = vtkMRMLColorTableNode::SafeDownCast(this->mrmlScene()->GetNodeByID(nodeID));
+      }
+
+    vtkMRMLSegmentationNode* node = d->SegmentationsLogic->LoadSegmentationFromFile(
+      fileName.toUtf8().constData(), autoOpacities, name.toUtf8(), colorTableNode);
     if (!node)
       {
       this->setLoadedNodes(QStringList());


### PR DESCRIPTION
When importing a segmentation node from file, users can now specify an existing color table node to create the segments with the expected color and name.
The same (or different) node can be used when exporting the segmentation to labelmap to ensure that the label values of the output match the input.

Users can now also export segmentations directly to NRRD/NIFTI from the "Export to files" section of the segmentation module. The same color node can be used to ensure that the correct expected label values are used during export.

![image](https://user-images.githubusercontent.com/9222709/88324199-585e9680-ccf1-11ea-8210-7f739a712884.png)

re #5044