### PR TITLE
ENH: Allow file readers to override canLoadFile method

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -418,6 +418,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
   slicer_add_python_unittest(SCRIPT JRC2013Vis.py)
   slicer_add_python_unittest(SCRIPT FiducialLayoutSwitchBug1914.py)
   slicer_add_python_unittest(SCRIPT ShaderProperties.py)
+  slicer_add_python_unittest(SCRIPT SlicerScriptedFileReaderWriterTest.py)
 
   # add as hidden module for use at run time
   set(KIT_PYTHON_SCRIPTS
@@ -443,6 +444,7 @@ if(Slicer_USE_QtTesting AND Slicer_USE_PYTHONQT)
     FiducialLayoutSwitchBug1914.py
     ShaderProperties.py
     UtilTest.py
+    SlicerScriptedFileReaderWriterTest.py
     )
 
   if(Slicer_BUILD_CLI_SUPPORT)

--- a/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
@@ -1,0 +1,157 @@
+import logging
+import os
+import unittest
+import vtk, qt, ctk, slicer
+from slicer.ScriptedLoadableModule import *
+
+class SlicerScriptedFileReaderWriterTest(ScriptedLoadableModule):
+  def __init__(self, parent):
+    ScriptedLoadableModule.__init__(self, parent)
+    parent.title = 'SlicerScriptedFileReaderWriterTest'
+    parent.categories = ['Testing.TestCases']
+    parent.dependencies = []
+    parent.contributors = ["Andras Lasso (PerkLab, Queen's)"]
+    parent.helpText = '''
+    This module is used to test qSlicerScriptedFileReader and qSlicerScriptedFileWriter classes.
+    '''
+    parent.acknowledgementText = '''
+    This file was originally developed by Andras Lasso, PerkLab.
+    '''
+    self.parent = parent
+
+class SlicerScriptedFileReaderWriterTestWidget(ScriptedLoadableModuleWidget):
+  def setup(self):
+    ScriptedLoadableModuleWidget.setup(self)
+    # Default reload&test widgets are enough.
+    # Note that reader and writer is not reloaded.
+
+class SlicerScriptedFileReaderWriterTestFileReader(object):
+
+  def __init__(self, parent):
+    self.parent = parent
+
+  def description(self):
+    return 'My file type'
+
+  def fileType(self):
+    return 'MyFileType'
+
+  def extensions(self):
+    return ['My file type (*.mft)']
+
+  def canLoadFile(self, filePath):
+    firstLine = ''
+    with open(filePath, 'r') as f:
+      firstLine = f.readline()
+    validFile = 'magic' in firstLine
+    return validFile
+
+  def load(self, properties):
+    try:
+      filePath = properties['fileName']
+
+      # Get node base name from filename
+      if 'name' in properties.keys():
+        baseName = properties['name']
+      else:
+        baseName = os.path.splitext(os.path.basename(filePath))[0]
+        baseName = slicer.mrmlScene.GenerateUniqueName(baseName)
+
+      # Read file content
+      with open (filePath, 'r') as myfile:
+        data = myfile.readlines()
+
+      # Check if file is valid
+      firstLine = data[0].rstrip()
+      if firstLine != 'magic':
+        raise ValueError('Cannot read file, it is expected to start with magic')
+
+      # Load content into new node
+      loadedNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLTextNode', baseName)
+      loadedNode.SetText(''.join(data[1:]))
+
+    except Exception as e:
+      logging.error('Failed to load file: '+str(e))
+      import traceback
+      traceback.print_exc()
+      return False
+
+    self.parent.loadedNodes = [loadedNode.GetID()]
+    return True
+
+
+class SlicerScriptedFileReaderWriterTestFileWriter(object):
+
+  def __init__(self, parent):
+    self.parent = parent
+
+  def description(self):
+    return 'My file type'
+
+  def fileType(self):
+    return 'MyFileType'
+
+  def extensions(self, obj):
+    return ['My file type (*.mft)']
+
+  def canWriteObject(self, obj):
+    return bool(obj.IsA("vtkMRMLTextNode"))
+
+  def write(self, properties):
+    try:
+
+      # Get node
+      node = slicer.mrmlScene.GetNodeByID(properties["nodeID"])
+
+      # Write node content to file
+      filePath = properties['fileName']
+      with open (filePath, 'w') as myfile:
+        myfile.write("magic\n")
+        myfile.write(node.GetText())
+
+    except Exception as e:
+      logging.error('Failed to write file: '+str(e))
+      import traceback
+      traceback.print_exc()
+      return False
+
+    self.parent.writtenNodes = [node.GetID()]
+    return True
+
+
+class SlicerScriptedFileReaderWriterTestTest(ScriptedLoadableModuleTest):
+  def runTest(self):
+    """Run as few or as many tests as needed here.
+    """
+    self.setUp()
+    self.test_Writer()
+    self.test_Reader()
+    self.tearDown()
+    self.delayDisplay('Testing complete')
+
+  def setUp(self):
+    self.tempDir = slicer.util.tempDirectory()
+    logging.info("tempDir: " + self.tempDir)
+    self.textInNode = "This is\nsome example test"
+    self.validFilename = self.tempDir + "/tempSlicerScriptedFileReaderWriterTestValid.mft"
+    self.invalidFilename = self.tempDir + "/tempSlicerScriptedFileReaderWriterTestInvalid.mft"
+    slicer.mrmlScene.Clear()
+
+  def tearDown(self):
+    import shutil
+    shutil.rmtree(self.tempDir, True)
+
+  def test_Writer(self):
+    self.delayDisplay('Testing node writer')
+    slicer.mrmlScene.Clear()
+    textNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLTextNode')
+    textNode.SetText(self.textInNode)
+    self.assertTrue(slicer.util.saveNode(textNode, self.validFilename, {'fileType': 'MyFileType'}))
+
+  def test_Reader(self):
+    self.delayDisplay('Testing node reader')
+    slicer.mrmlScene.Clear()
+    loadedNode = slicer.util.loadNodeFromFile(self.validFilename, 'MyFileType')
+    self.assertIsNotNone(loadedNode)
+    self.assertTrue(loadedNode.IsA('vtkMRMLTextNode'))
+    self.assertEqual(loadedNode.GetText(), self.textInNode)

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -98,7 +98,7 @@ QList<qSlicerFileReader*> qSlicerCoreIOManagerPrivate::readers(const QString& fi
     // in longestExtensionMatch variable.
     int longestExtensionMatch = 0;
     QStringList matchedNameFilters = reader->supportedNameFilters(fileName, &longestExtensionMatch);
-    if (!matchedNameFilters.empty())
+    if (!matchedNameFilters.empty() && reader->canLoadFile(fileName))
       {
       matchingReadersSortedByConfidence.insert(longestExtensionMatch, reader);
       }

--- a/Base/QTCore/qSlicerFileReader.h
+++ b/Base/QTCore/qSlicerFileReader.h
@@ -45,10 +45,10 @@ public:
   /// Example: "Image (*.jpg *.png *.tiff)", "Model (*.vtk)"
   virtual QStringList extensions()const;
 
-  /// Based on the file extensions, returns true if the file can be read,
-  /// false otherwise.
-  /// This function is relatively fast as it doesn't try to access the file.
-  bool canLoadFile(const QString& file)const;
+  /// Returns true if the reader can load this file.
+  /// Default implementation is a simple and fast, it just checks
+  /// if file extension matches any of the wildcards returned by extensions() method.
+  virtual bool canLoadFile(const QString& file)const;
 
   /// Return the matching name filters -> if the fileName is "myimage.nrrd"
   /// and the supported extensions are "Volumes (*.mha *.nrrd *.raw)",

--- a/Base/QTCore/qSlicerScriptedFileReader.cxx
+++ b/Base/QTCore/qSlicerScriptedFileReader.cxx
@@ -45,6 +45,7 @@ public:
     DescriptionMethod = 0,
     FileTypeMethod,
     ExtensionsMethod,
+    CanLoadFileMethod,
     LoadMethod,
     };
 
@@ -63,6 +64,7 @@ qSlicerScriptedFileReaderPrivate::qSlicerScriptedFileReaderPrivate()
   this->PythonCppAPI.declareMethod(Self::DescriptionMethod, "description");
   this->PythonCppAPI.declareMethod(Self::FileTypeMethod, "fileType");
   this->PythonCppAPI.declareMethod(Self::ExtensionsMethod, "extensions");
+  this->PythonCppAPI.declareMethod(Self::CanLoadFileMethod, "canLoadFile");
   this->PythonCppAPI.declareMethod(Self::LoadMethod, "load");
 }
 
@@ -235,6 +237,29 @@ QStringList qSlicerScriptedFileReader::extensions()const
     }
   Py_DECREF(resultAsTuple);
   return extensionList;
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerScriptedFileReader::canLoadFile(const QString& file)const
+{
+  Q_D(const qSlicerScriptedFileReader);
+  PyObject* arguments = PyTuple_New(1);
+  PyTuple_SET_ITEM(arguments, 0, PyString_FromString(file.toUtf8()));
+  PyObject* result = d->PythonCppAPI.callMethod(d->CanLoadFileMethod, arguments);
+  Py_DECREF(arguments);
+  if (!result)
+    {
+    // Method call failed (probably an omitted function), call default implementation
+    return this->Superclass::canLoadFile(file);
+    }
+  if (!PyBool_Check(result))
+    {
+    qWarning() << d->PythonSource
+               << " - In" << d->PythonClassName << "class, function 'canLoadFile' "
+               << "is expected to return a boolean!";
+    return false;
+    }
+  return result == Py_True;
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerScriptedFileReader.h
+++ b/Base/QTCore/qSlicerScriptedFileReader.h
@@ -68,6 +68,10 @@ public:
   QStringList extensions()const override;
 
   /// Reimplemented to propagate to python methods
+  /// \sa qSlicerFileReader::canLoadFile()
+  bool canLoadFile(const QString& file)const override;
+
+  /// Reimplemented to propagate to python methods
   /// \sa qSlicerFileReader::write()
   bool load(const qSlicerIO::IOProperties& properties) override;
 


### PR DESCRIPTION
canLoadFile method can be used for inspecting file content before offering a reader for a file.

Also added automated test for scripted file reader and writer.