### PR TITLE
COMP: Update python packages to latest - July 2020

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -40,16 +40,17 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  pydicom==1.4.2 --hash=sha256:f315ba2296346f4f9913c269618201e170b9326362e2ada6041ca91b7cb2117b
+  pydicom==2.0.0 --hash=sha256:667c5bf9ca52f440e538c9d03ce86b04555c10d069472a5db53103fe40d310c0
   # Hashes correspond to the following packages:
-  #  - Pillow-7.0.0-cp36-cp36m-win_amd64.whl
-  #  - Pillow-7.0.0-cp36-cp36m-macosx_10_6_intel.whl
-  #  - Pillow-7.0.0-cp36-cp36m-manylinux1_x86_64.whl
-  pillow==7.0.0 --hash=sha256:bf598d2e37cf8edb1a2f26ed3fb255191f5232badea4003c16301cb94ac5bdd0 \
-                --hash=sha256:ab76e5580b0ed647a8d8d2d2daee170e8e9f8aad225ede314f684e297e3643c2 \
-                --hash=sha256:8ac6ce7ff3892e5deaab7abaec763538ffd011f74dc1801d93d3c5fc541feee2
-  six==1.14.0 --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
-  dicomweb-client==0.21.0 --hash=sha256:e8b46e517a5399b85b2f4e724e54bfe3a934bc22c9c2ba3d0e92eb3e87846228
+  #  - Pillow-7.2.0-cp36-cp36m-win_amd64.whl
+  #  - Pillow-7.2.0-cp36-cp36m-macosx_10_10_x86_64.whl
+  #  - Pillow-7.2.0-cp36-cp36m-manylinux1_x86_64.whl
+  pillow==7.2.0 --hash=sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce \
+                --hash=sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d \
+                --hash=sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f
+  six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
+  retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b
+  dicomweb-client==0.41.0 --hash=sha256:e79163362d2af9399d4661216d6bcc3de9af755a1eec36995d35e3e135f22fa0
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -35,10 +35,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
-  gitdb==4.0.2 --hash=sha256:284a6a4554f954d6e737cddcff946404393e030b76a282c6640df8efd6b3da5e
-  smmap==3.0.1 --hash=sha256:5fead614cf2de17ee0707a8c6a5f2aa5a2fc6c698c70993ba42f515485ffda78
-  GitPython==3.1.0 --hash=sha256:43da89427bdf18bf07f1164c6d415750693b4d50e28fc9b68de706245147b9dd
-  six==1.14.0 --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
+  gitdb==4.0.5 --hash=sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac
+  smmap==3.0.4 --hash=sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4
+  GitPython==3.1.7 --hash=sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5
+  six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -34,8 +34,8 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   PyJWT==1.7.1 --hash=sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e
   wrapt==1.12.1 --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
-  Deprecated==1.2.7 --hash=sha256:8b6a5aa50e482d8244a62e5582b96c372e87e3a28e8b49c316e46b95c76a611d
-  PyGithub==1.47 --hash=sha256:2638ea9a2070d995197dca2ac521c207f8de000cc3aa5e912e264932886781ba
+  Deprecated==1.2.10 --hash=sha256:a766c1dccb30c5f6eb2b203f87edd1d8588847709c78589e1521d769addc8218
+  PyGithub==1.51 --hash=sha256:8375a058ec651cc0774244a3bc7395cf93617298735934cdd59e5bcd9a1df96e
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -31,12 +31,12 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   nose==1.3.7 --hash=sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac  # needed for NumPy unit tests
   # Hashes correspond to the following packages:
-  # - numpy-1.18.1-cp36-cp36m-win_amd64.whl
-  # - numpy-1.18.1-cp36-cp36m-macosx_10_9_x86_64.whl
-  # - numpy-1.18.1-cp36-cp36m-manylinux1_x86_64.whl
-  numpy==1.18.1 --hash=sha256:9acdf933c1fd263c513a2df3dceecea6f3ff4419d80bf238510976bf9bcb26cd \
-                --hash=sha256:ae0975f42ab1f28364dcda3dde3cf6c1ddab3e1d4b2909da0cb0191fa9ca0480 \
-                --hash=sha256:b765ed3930b92812aa698a455847141869ef755a87e099fddd4ccf9d81fffb57
+  # - numpy-1.19.1-cp36-cp36m-win_amd64.whl
+  # - numpy-1.19.1-cp36-cp36m-macosx_10_9_x86_64.whl
+  # - numpy-1.19.1-cp36-cp36m-manylinux1_x86_64.whl
+  numpy==1.19.1 --hash=sha256:082f8d4dd69b6b688f64f509b91d482362124986d98dc7dc5f5e9f9b9c3bb983 \
+                --hash=sha256:b1cca51512299841bf69add3b75361779962f9cee7d9ee3bb446d5982e925b69 \
+                --hash=sha256:cf1347450c0b7644ea142712619533553f02ef23f92f781312f6a3553d031fc7
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -26,7 +26,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  pip==20.1 --hash=sha256:4fdc7fd2db7636777d28d2e1432e2876e30c2b790d461f135716577f73104369
+  pip==20.1.1 --hash=sha256:b27c4dedae8c41aa59108f2fa38bf78e0890e590545bc8ece7cdceb4ba60f6e4
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -31,9 +31,9 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  packaging==20.3 --hash=sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752
-  pyparsing==2.4.6 --hash=sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec
-  six==1.14.0 --hash=sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c
+  packaging==20.4 --hash=sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181
+  pyparsing==2.4.7 --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
+  six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -26,11 +26,11 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  certifi==2019.11.28 --hash=sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3
-  idna==2.9 --hash=sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa
+  certifi==2020.6.20 --hash=sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41
+  idna==2.10 --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
   chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-  urllib3==1.25.8 --hash=sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc
-  requests==2.23.0 --hash=sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee
+  urllib3==1.25.10 --hash=sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461
+  requests==2.24.0 --hash=sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -30,12 +30,12 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # Hashes correspond to the following packages:
-  # - scipy-1.4.1-cp36-cp36m-win_amd64.whl
-  # - scipy-1.4.1-cp36-cp36m-macosx_10_6_intel.whl
-  # - scipy-1.4.1-cp36-cp36m-manylinux1_x86_64.whl
-  scipy==1.4.1 --hash=sha256:dc60bb302f48acf6da8ca4444cfa17d52c63c5415302a9ee77b3b21618090521 \
-              --hash=sha256:bb517872058a1f087c4528e7429b4a44533a902644987e7b2fe35ecc223bc408 \
-              --hash=sha256:386086e2972ed2db17cebf88610aab7d7f6e2c0ca30042dc9a89cf18dcc363fa
+  # - scipy-1.5.2-cp36-cp36m-win_amd64.whl
+  # - scipy-1.5.2-cp36-cp36m-macosx_10_9_x86_64.whl
+  # - scipy-1.5.2-cp36-cp36m-manylinux1_x86_64.whl
+  scipy==1.5.2 --hash=sha256:8e28e74b97fc8d6aa0454989db3b5d36fc27e69cef39a7ee5eaf8174ca1123cb \
+              --hash=sha256:cca9fce15109a36a0a9f9cfc64f870f1c140cb235ddf27fe0328e6afb44dfed0 \
+              --hash=sha256:07e52b316b40a4f001667d1ad4eb5f2318738de34597bd91537851365b6c61f1
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -25,7 +25,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  setuptools==46.1.3 --hash=sha256:4fe404eec2738c20ab5841fa2d791902d2a645f32318a7850ef26f8d7215a8ee
+  setuptools==49.2.0 --hash=sha256:272c7f48f5cddc5af5901f4265274c421c7eede5c8bc454ac2903d3f8fc365e9
   ]===])
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
Python packages were last updated March 16th, 2020. Outdated python packages were discovered using the below code snippet and then versions, hashes and dependencies were determined and updated.

As always we'll keep an eye on the dashboard for any potential regressions.  Generally no major changes in any package.

```
PS C:\S5R-nightly\python-install\bin> ./PythonSlicer.exe -m pip list --outdated
Package         Version    Latest    Type
--------------- ---------- --------- -----
certifi         2019.11.28 2020.6.20 wheel
Deprecated      1.2.7      1.2.10    wheel
dicomweb-client 0.21.0     0.41.0    wheel
gitdb           4.0.2      4.0.5     wheel
GitPython       3.1.0      3.1.7     wheel
idna            2.9        2.10      wheel
numpy           1.18.1     1.19.1    wheel
packaging       20.3       20.4      wheel
Pillow          7.0.0      7.2.0     wheel
pip             20.1       20.1.1    wheel
pydicom         1.4.2      2.0.0     wheel
PyGithub        1.47       1.51      wheel
pyparsing       2.4.6      2.4.7     wheel
requests        2.23.0     2.24.0    wheel
scipy           1.4.1      1.5.2     wheel
setuptools      46.1.3     49.2.0    wheel
six             1.14.0     1.15.0    wheel
smmap           3.0.1      3.0.4     wheel
urllib3         1.25.8     1.25.10   wheel
vtk             8.2.0      9.0.1     wheel
```