### PR TITLE
BUG: Add support for downloading PyPI package linux aarch64

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -45,9 +45,11 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   #  - Pillow-7.2.0-cp36-cp36m-win_amd64.whl
   #  - Pillow-7.2.0-cp36-cp36m-macosx_10_10_x86_64.whl
   #  - Pillow-7.2.0-cp36-cp36m-manylinux1_x86_64.whl
+  #  - Pillow-7.2.0-cp36-cp36m-manylinux2014_aarch64.whl
   pillow==7.2.0 --hash=sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce \
                 --hash=sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d \
-                --hash=sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f
+                --hash=sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f \
+                --hash=sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8
   six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
   retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b
   dicomweb-client==0.41.0 --hash=sha256:e79163362d2af9399d4661216d6bcc3de9af755a1eec36995d35e3e135f22fa0

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -34,9 +34,13 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # - numpy-1.19.1-cp36-cp36m-win_amd64.whl
   # - numpy-1.19.1-cp36-cp36m-macosx_10_9_x86_64.whl
   # - numpy-1.19.1-cp36-cp36m-manylinux1_x86_64.whl
+  # - numpy-1.19.1-cp36-cp36m-manylinux2010_x86_64.whl
+  # - numpy-1.19.1-cp36-cp36m-manylinux2014_aarch64.whl
   numpy==1.19.1 --hash=sha256:082f8d4dd69b6b688f64f509b91d482362124986d98dc7dc5f5e9f9b9c3bb983 \
                 --hash=sha256:b1cca51512299841bf69add3b75361779962f9cee7d9ee3bb446d5982e925b69 \
-                --hash=sha256:cf1347450c0b7644ea142712619533553f02ef23f92f781312f6a3553d031fc7
+                --hash=sha256:cf1347450c0b7644ea142712619533553f02ef23f92f781312f6a3553d031fc7 \
+                --hash=sha256:3673c8b2b29077f1b7b3a848794f8e11f401ba0b71c49fbd26fb40b71788b132 \
+                --hash=sha256:56ef7f56470c24bb67fb43dae442e946a6ce172f97c69f8d067ff8550cf782ff
   ]===])
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
This was introduced by 111b131e733b10f2f7fbcb8f5d4284e1281cf96d where Pillow was updated from 7.0.0 to 7.2.0.  The new version now has both a manylinux1 and manylinux2014 option.

This should address @adamrankin 's comment at https://github.com/Slicer/Slicer/commit/111b131e733b10f2f7fbcb8f5d4284e1281cf96d#commitcomment-40980312