### PR TITLE
COMP: disable parameter serializer by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,7 +324,7 @@ CMAKE_DEPENDENT_OPTION(
   "Slicer_BUILD_ITKPython" OFF)
 mark_as_superbuild(Slicer_INSTALL_ITKPython)
 
-option(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT "Build Slicer with parameter serializer support" ON)
+option(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT "Build Slicer with parameter serializer support" OFF)
 mark_as_superbuild(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT)
 
 set(_default_vtk "8")


### PR DESCRIPTION
This feature wasn't presently being used and it led to
multiply defined symbols in CLI builds for some
tests and extensions.

https://discourse.slicer.org/t/the-slicerdmri-extension-is-currently-unavailable/12276/21

https://github.com/pnlbwh/ukftractography/pull/130

Thanks @sjh26 for shared pain and @jcfr for suggesting the fix.