### PR TITLE
Improved model display

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
@@ -74,9 +74,10 @@ vtkMRMLDisplayNode::vtkMRMLDisplayNode()
   this->ScalarRange[0] = 0;
   this->ScalarRange[1] = 100;
 
-  this->Color[0] = 0.5;
-  this->Color[1] = 0.5;
-  this->Color[2] = 0.5;
+  // Set default color to yellow to have some contrast compared to grayscale images
+  this->Color[0] = 0.9;
+  this->Color[1] = 0.9;
+  this->Color[2] = 0.3;
   this->EdgeColor[0] = 0.0;
   this->EdgeColor[1] = 0.0;
   this->EdgeColor[2] = 0.0;

--- a/Libs/MRML/Core/vtkMRMLModelDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLModelDisplayNode.cxx
@@ -53,6 +53,11 @@ vtkMRMLModelDisplayNode::vtkMRMLModelDisplayNode()
   this->SliceDisplayMode = SliceDisplayIntersection;
   this->BackfaceCulling = 0;
 
+  // Backface color has slightly different hue and less saturated compared to frontface
+  this->BackfaceColorHSVOffset[0] = -0.05;
+  this->BackfaceColorHSVOffset[1] = -0.1;
+  this->BackfaceColorHSVOffset[2] = 0.0;
+
   // the default behavior for models is to use the scalar range of the data
   // to reset the display scalar range, so use the Data flag
   this->SetScalarRangeFlag(vtkMRMLDisplayNode::UseDataScalarRange);
@@ -83,6 +88,7 @@ void vtkMRMLModelDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintEnumMacro(SliceDisplayMode);
   vtkMRMLPrintBooleanMacro(ThresholdEnabled);
   vtkMRMLPrintVectorMacro(ThresholdRange, double, 2);
+  vtkMRMLPrintVectorMacro(BackfaceColorHSVOffset, double, 3);
   vtkMRMLPrintEndMacro();
 }
 
@@ -96,6 +102,7 @@ void vtkMRMLModelDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLEnumMacro(sliceDisplayMode, SliceDisplayMode);
   vtkMRMLWriteXMLBooleanMacro(thresholdEnabled, ThresholdEnabled);
   vtkMRMLWriteXMLVectorMacro(thresholdRange, ThresholdRange, double, 2);
+  vtkMRMLWriteXMLVectorMacro(backfaceColorHSVOffset, BackfaceColorHSVOffset, double, 3);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -109,6 +116,7 @@ void vtkMRMLModelDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLEnumMacro(sliceDisplayMode, SliceDisplayMode);
   vtkMRMLReadXMLBooleanMacro(thresholdEnabled, ThresholdEnabled);
   vtkMRMLReadXMLVectorMacro(thresholdRange, ThresholdRange, double, 2);
+  vtkMRMLReadXMLVectorMacro(backfaceColorHSVOffset, BackfaceColorHSVOffset, double, 3);
   vtkMRMLReadXMLEndMacro();
 
   this->EndModify(disabledModify);
@@ -130,6 +138,7 @@ void vtkMRMLModelDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=tr
   vtkMRMLCopyEnumMacro(SliceDisplayMode);
   vtkMRMLCopyBooleanMacro(ThresholdEnabled);
   vtkMRMLCopyVectorMacro(ThresholdRange, double, 2);
+  vtkMRMLCopyVectorMacro(BackfaceColorHSVOffset, double, 3);
   vtkMRMLCopyEndMacro();
 }
 

--- a/Libs/MRML/Core/vtkMRMLModelDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelDisplayNode.h
@@ -170,6 +170,12 @@ public:
   /// Returns the current active scalar array (based on active scalar name and location)
   virtual vtkDataArray* GetActiveScalarArray();
 
+  ///
+  /// Set color of backface surface as HSV (hue, saturation, brighness) offset compared to node color.
+  /// Values are in [-1, 1] range, 0 value means same as node color.
+  vtkSetVector3Macro(BackfaceColorHSVOffset, double);
+  vtkGetVector3Macro(BackfaceColorHSVOffset, double);
+
 protected:
   vtkMRMLModelDisplayNode();
   ~vtkMRMLModelDisplayNode() override;
@@ -223,6 +229,8 @@ protected:
 
   /// Temporary variable to allow GetThresholdRange() method to return threshold range as a pointer
   double ThresholdRangeTemp[2];
+
+  double BackfaceColorHSVOffset[3];
 };
 
 #endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -1591,6 +1591,37 @@ void vtkMRMLModelDisplayableManager::SetModelDisplayProperty(vtkMRMLDisplayableN
         actor->SetTexture(nullptr);
         actor->ForceOpaqueOff();
         }
+
+      // Set backface properties
+      vtkProperty* actorBackfaceProperties = actor->GetBackfaceProperty();
+      if (!actorBackfaceProperties)
+        {
+        vtkNew<vtkProperty> newActorBackfaceProperties;
+        actor->SetBackfaceProperty(newActorBackfaceProperties);
+        actorBackfaceProperties = newActorBackfaceProperties;
+        }
+      actorBackfaceProperties->DeepCopy(actorProperties);
+
+      double offsetHsv[3];
+      modelDisplayNode->GetBackfaceColorHSVOffset(offsetHsv);
+
+      double colorHsv[3];
+      vtkMath::RGBToHSV(actorProperties->GetColor(), colorHsv);
+      double colorRgb[3];
+      colorHsv[0] += offsetHsv[0];
+      // wrap around hue value
+      if (colorHsv[0] < 0.0)
+        {
+        colorHsv[0] += 1.0;
+        }
+      else if (colorHsv[0] > 1.0)
+        {
+        colorHsv[0] -= 1.0;
+        }
+      colorHsv[1] = vtkMath::ClampValue<double>(colorHsv[1] + offsetHsv[1], 0, 1);
+      colorHsv[2] = vtkMath::ClampValue<double>(colorHsv[2] + offsetHsv[2], 0, 1);
+      vtkMath::HSVToRGB(colorHsv, colorRgb);
+      actorBackfaceProperties->SetColor(colorRgb);
       }
     else if (imageActor)
       {

--- a/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
+++ b/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>297</width>
-    <height>476</height>
+    <height>405</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -200,38 +200,38 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="EdgeColorLabel">
            <property name="text">
             <string>Edge Color:</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
+         <item row="3" column="1">
           <widget class="ctkColorPickerButton" name="EdgeColorPickerButton"/>
          </item>
-         <item row="3" column="0">
+         <item row="4" column="0">
           <widget class="QLabel" name="LightingLabel">
            <property name="text">
             <string>Lighting:</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="4" column="1">
           <widget class="QCheckBox" name="LightingCheckBox">
            <property name="text">
             <string/>
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="5" column="0">
           <widget class="QLabel" name="InterpolationLabel">
            <property name="text">
             <string>Interpolation:</string>
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="5" column="1">
           <widget class="QComboBox" name="InterpolationComboBox">
            <item>
             <property name="text">
@@ -250,7 +250,7 @@
            </item>
           </widget>
          </item>
-         <item row="5" column="0" colspan="2">
+         <item row="6" column="0" colspan="2">
           <widget class="ctkVTKSurfaceMaterialPropertyWidget" name="MaterialPropertyWidget">
            <property name="colorVisible">
             <bool>false</bool>
@@ -262,6 +262,77 @@
             <bool>false</bool>
            </property>
           </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="toolTip">
+            <string>Backface color hue, saturation, and brightess offset to frontface color</string>
+           </property>
+           <property name="text">
+            <string>Backface Color Offset:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="ctkDoubleSpinBox" name="BackfaceHueOffsetSpinBox">
+             <property name="toolTip">
+              <string>Color hue offset</string>
+             </property>
+             <property name="decimalsOption">
+              <set>ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::ReplaceDecimals</set>
+             </property>
+             <property name="minimum">
+              <double>-0.500000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>0.500000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.050000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="ctkDoubleSpinBox" name="BackfaceSaturationOffsetSpinBox">
+             <property name="toolTip">
+              <string>Color saturation offset</string>
+             </property>
+             <property name="decimalsOption">
+              <set>ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::InsertDecimals|ctkDoubleSpinBox::ReplaceDecimals</set>
+             </property>
+             <property name="minimum">
+              <double>-1.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.050000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="ctkDoubleSpinBox" name="BackfaceBrightnessOffsetSpinBox">
+             <property name="toolTip">
+              <string>Color saturation offset</string>
+             </property>
+             <property name="decimalsOption">
+              <set>ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::InsertDecimals|ctkDoubleSpinBox::ReplaceDecimals</set>
+             </property>
+             <property name="minimum">
+              <double>-1.000000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.050000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </widget>
@@ -602,12 +673,6 @@ should set &quot;backface&quot; and &quot;frontface&quot; to OFF in the Represen
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>qMRMLCheckableNodeComboBox</class>
    <extends>qMRMLNodeComboBox</extends>
    <header>qMRMLCheckableNodeComboBox.h</header>
@@ -636,6 +701,12 @@ should set &quot;backface&quot; and &quot;frontface&quot; to OFF in the Represen
    <header>qMRMLRangeWidget.h</header>
   </customwidget>
   <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>ctkVTKDataSetArrayComboBox</class>
    <extends>QComboBox</extends>
    <header>ctkVTKDataSetArrayComboBox.h</header>
@@ -655,6 +726,11 @@ should set &quot;backface&quot; and &quot;frontface&quot; to OFF in the Represen
    <class>ctkColorPickerButton</class>
    <extends>QPushButton</extends>
    <header>ctkColorPickerButton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkDoubleSpinBox</class>
+   <extends>QWidget</extends>
+   <header>ctkDoubleSpinBox.h</header>
   </customwidget>
   <customwidget>
    <class>ctkMaterialPropertyWidget</class>

--- a/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.h
+++ b/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.h
@@ -135,6 +135,10 @@ public slots:
   void setLineWidth(double);
   void setShowFaces(int);
   void setColor(const QColor&);
+  void setBackfaceHueOffset(double newOffset);
+  void setBackfaceSaturationOffset(double newOffset);
+  void setBackfaceBrightnessOffset(double newOffset);
+
   void setOpacity(double);
   void setEdgeVisibility(bool);
   void setEdgeColor(const QColor&);


### PR DESCRIPTION
This pull request contains two improvements for model display:

1. Changes default model color to yellow from the old default mid gray. This make default scenes more interesting and model intersections visible over grayscale images.

2. Slightly changes inside (backface) color so that inside/outside surface can be visually distinguished. Change is specified as relative HSV offset (can be changed in Models module GUI).

**Example**

Old:

![image](https://user-images.githubusercontent.com/307929/88859388-a3801a00-d1c7-11ea-8187-0b6a5eda4afe.png)

New:

![image](https://user-images.githubusercontent.com/307929/88859399-a844ce00-d1c7-11ea-929a-8a2d71263b64.png)
