### PR TITLE
COMP: Fix -Wunused-parameter warning in qMRMLSegmentationFileExportWidget

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.cxx
@@ -318,6 +318,7 @@ void qMRMLSegmentationFileExportWidget::setFileFormat(const QString& formatStr)
 //-----------------------------------------------------------------------------
 void qMRMLSegmentationFileExportWidget::setUseLabelsFromColorNode(bool useColorNode)
 {
+  Q_UNUSED(useColorNode);
   Q_D(qMRMLSegmentationFileExportWidget);
   d->ColorTableNodeSelector->setEnabled(d->UseColorTableValuesCheckBox->isEnabled() && d->UseColorTableValuesCheckBox->isChecked());
 }


### PR DESCRIPTION
This commit fixes the following warning:
````
  /path/to/Slicer/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.cxx:319:72: warning: unused parameter ‘useColorNode’ [-Wunused-parameter]
   void qMRMLSegmentationFileExportWidget::setUseLabelsFromColorNode(bool useColorNode)
                                                                          ^
```