### PR TITLE
COMP: Fix -Wunused-variable warnings in qMRMLSubjectHierarchyTreeView

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -485,8 +485,6 @@ vtkMRMLTransformNode* qMRMLSubjectHierarchyTreeViewPrivate::firstAppliedTransfor
     this->SubjectHierarchyNode->GetItemChildren(itemID, childItemIDs, true);
     childItemIDs.insert(childItemIDs.begin(), itemID);
 
-    bool foundTransform = false;
-    vtkMRMLTransformNode* commonTransformNode = nullptr;
     // Apply transform to the node and all its suitable children
     for (std::vector<vtkIdType>::iterator childItemIDsIt = childItemIDs.begin();
       childItemIDsIt != childItemIDs.end(); ++childItemIDsIt)


### PR DESCRIPTION
This commit fixes the following warnings:

```
  /path/to/Slicer/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx:488:10: warning: unused variable ‘foundTransform’ [-Wunused-variable]
       bool foundTransform = false;
            ^
  /path/to/Slicer/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx:489:27: warning: unused variable ‘commonTransformNode’ [-Wunused-variable]
       vtkMRMLTransformNode* commonTransformNode = nullptr;
                             ^
```