### PR TITLE
COMP: Fix -Wunused-variable warning in vtkSlicerSegmentationGeometryLogic

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.cxx
@@ -129,7 +129,8 @@ std::string vtkSlicerSegmentationGeometryLogic::CalculateOutputGeometry()
   vtkMRMLAnnotationROINode* sourceRoiNode = vtkMRMLAnnotationROINode::SafeDownCast(this->SourceGeometryNode);
   vtkMRMLSegmentationNode* sourceSegmentationNode = vtkMRMLSegmentationNode::SafeDownCast(this->SourceGeometryNode);
 
-  if (sourceVolumeNode || this->IsSourceSegmentationWithBinaryLabelmapMaster())
+  if (sourceVolumeNode
+      || (sourceSegmentationNode && this->IsSourceSegmentationWithBinaryLabelmapMaster()))
     {
     //TODO: Fractional labelmaps cannot be used yet as source, as DetermineCommonLabelmapGeometry only supports binary labelmaps
     return this->CalculateOutputGeometryFromImage();


### PR DESCRIPTION
This commit fixes the following warning:

```
  /path/to/Slicer/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.cxx:130:28: warning: unused variable ‘sourceSegmentationNode’ [-Wunused-variable]
     vtkMRMLSegmentationNode* sourceSegmentationNode = vtkMRMLSegmentationNode::SafeDownCast(this->SourceGeometryNode);
                              ^
```