### PR TITLE
COMP: Fix -Wsign-compare warning in qMRMLSegmentationFileExportWidget

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -1123,7 +1123,7 @@ bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(vtkMRMLSegm
   int numberOfColors = exportedSegmentIDs.size() + 1;
   if (labelValues)
     {
-    for (int i = 0; i < exportedSegmentIDs.size(); ++i)
+    for (int i = 0; i < static_cast<int>(exportedSegmentIDs.size()); ++i)
       {
       numberOfColors = std::max(numberOfColors, labelValues->GetValue(i) + 1);
       }


### PR DESCRIPTION
This commit fixes the following warning:

```
  /path/to/Slicer/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx:1126:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       for (int i = 0; i < exportedSegmentIDs.size(); ++i)
                         ^
```