### PR TITLE
COMP: Fix -Wunused-* warnings in qSlicerModuleFinderDialog

### DIFF
--- a/Base/QTGUI/qSlicerModuleFinderDialog.cxx
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.cxx
@@ -87,7 +87,7 @@ void qSlicerModuleFinderDialogPrivate::init()
   QObject::connect(this->ShowTestingCheckBox, SIGNAL(toggled(bool)),
     q, SLOT(setShowTestingModules(bool)));
   QObject::connect(this->FilterTitleSearchBox, SIGNAL(textChanged(QString)),
-    q, SLOT(setModuleTitleFilterText(QString)));
+    q, SLOT(onModuleTitleFilterTextChanged()));
 
   QObject::connect(this->ModuleListView->selectionModel(), SIGNAL(selectionChanged(QItemSelection, QItemSelection)),
     q, SLOT(onSelectionChanged(QItemSelection, QItemSelection)));
@@ -369,6 +369,13 @@ void qSlicerModuleFinderDialog::setFocusToModuleTitleFilter()
 
 //---------------------------------------------------------------------------
 void qSlicerModuleFinderDialog::setModuleTitleFilterText(const QString& text)
+{
+  Q_D(qSlicerModuleFinderDialog);
+  d->FilterTitleSearchBox->setText(text);
+}
+
+//---------------------------------------------------------------------------
+void qSlicerModuleFinderDialog::onModuleTitleFilterTextChanged()
 {
   Q_D(qSlicerModuleFinderDialog);
   qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();

--- a/Base/QTGUI/qSlicerModuleFinderDialog.h
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.h
@@ -56,6 +56,7 @@ public Q_SLOTS:
 
 protected Q_SLOTS:
   void onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
+  void onModuleTitleFilterTextChanged();
 
 protected:
   QScopedPointer<qSlicerModuleFinderDialogPrivate> d_ptr;


### PR DESCRIPTION
This commit fixes the following warnings:

```
  /path/to/Slicer/Base/QTGUI/qSlicerModuleFinderDialog.cxx: In member function ‘void qSlicerModuleFinderDialogPrivate::init()’:
  /path/to/Slicer/Base/QTGUI/qSlicerModuleFinderDialog.cxx:74:40: warning: unused variable ‘factoryManager’ [-Wunused-variable]
     qSlicerAbstractModuleFactoryManager* factoryManager = coreApp->moduleManager()->factoryManager();
                                          ^
  /path/to/Slicer/Base/QTGUI/qSlicerModuleFinderDialog.cxx: At global scope:
  /path/to/Slicer/Base/QTGUI/qSlicerModuleFinderDialog.cxx:371:73: warning: unused parameter ‘text’ [-Wunused-parameter]
   void qSlicerModuleFinderDialog::setModuleTitleFilterText(const QString& text)
                                                                           ^
```