### PR TITLE
BUG: Make sure subject hierarchy context menu is always up-to-date

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
@@ -162,6 +162,9 @@ bool qSlicerSubjectHierarchyPluginHandler::registerPlugin(qSlicerSubjectHierarch
   // Add the plugin to the list
   this->m_RegisteredPlugins << pluginToRegister;
 
+  // Update timestamp
+  this->LastPluginRegistrationTime = QDateTime::currentDateTimeUtc();
+
   return true;
 }
 
@@ -462,7 +465,7 @@ void qSlicerSubjectHierarchyPluginHandler::setPluginLogic(qSlicerSubjectHierarch
   // Register view menu actions of those plugins that were registered before the PluginLogic was set.
   if (this->m_PluginLogic)
     {
-    foreach(qSlicerSubjectHierarchyAbstractPlugin * pluginToRegister, this->m_RegisteredPlugins)
+    foreach(qSlicerSubjectHierarchyAbstractPlugin* pluginToRegister, this->m_RegisteredPlugins)
       {
       foreach(QAction * action, pluginToRegister->viewContextMenuActions())
         {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
@@ -35,8 +35,9 @@
 #include <vtkWeakPointer.h>
 
 // Qt includes
-#include <QObject>
+#include <QDateTime>
 #include <QList>
+#include <QObject>
 #include <QString>
 
 class vtkMRMLScene;
@@ -228,6 +229,9 @@ public:
 
   /// Private destructor made public to enable python wrapping
   ~qSlicerSubjectHierarchyPluginHandler() override;
+
+  /// Timestamp of the last plugin registration. Used to allow context menus be repopulated if needed.
+  QDateTime LastPluginRegistrationTime;
 
 private:
   Q_DISABLE_COPY(qSlicerSubjectHierarchyPluginHandler);


### PR DESCRIPTION
If a plugin was registered later than the tree view created, then the context menus from the new plugin were not available. With this change, the context menu for each tree view is re-generated if a new plugin was registered since the last context menu generation.

Re https://github.com/SlicerMorph/SlicerMorph/issues/71
