### PR TITLE
ENH: Improve display performance if TransformModifiedEvent is invoked

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -621,12 +621,12 @@ void vtkMRMLModelDisplayableManager::ProcessMRMLNodesEvents(vtkObject *caller,
           break;
           } // else fall through
       case vtkCommand::ModifiedEvent:
-        VTK_FALLTHROUGH;
       case vtkMRMLModelNode::MeshModifiedEvent:
+      case vtkMRMLTransformableNode::TransformModifiedEvent:
         requestRender = this->OnMRMLDisplayableModelNodeModifiedEvent(displayableNode);
         break;
       default:
-        this->SetUpdateFromMRMLRequested(true);
+        // We don't expect any other types of events.
         break;
       }
     if (!isUpdating && requestRender)
@@ -856,9 +856,7 @@ bool vtkMRMLModelDisplayableManager::OnMRMLDisplayableModelNodeModifiedEvent(
     }
   if (updateModel)
     {
-    this->UpdateClipSlicesFromMRML();
     this->UpdateModifiedModel(modelNode);
-    this->SetUpdateFromMRMLRequested(true);
     }
   if (updateMRML)
     {
@@ -891,7 +889,7 @@ void vtkMRMLModelDisplayableManager::UpdateFromMRML()
 void vtkMRMLModelDisplayableManager::UpdateModelsFromMRML()
 {
   // UpdateModelsFromMRML may recursively trigger calling of UpdateModelsFromMRML
-  // via node reference updates. IsUdatingModelsFromMRML flag prevents restarting
+  // via node reference updates. IsUpdatingModelsFromMRML flag prevents restarting
   // UpdateModelsFromMRML if it is already in progress.
   if (this->Internal->IsUpdatingModelsFromMRML)
     {


### PR DESCRIPTION
When a TransformModified event was invoked on any node in the scene, all model display pipelines were updated. This caused a noticeable drop in performance when there were a large number of nodes in the scene.

Fixed by not setting UpdateFromMRMLRequested to true when a transform was updated, and instead calling  OnMRMLDisplayableModelNodeModifiedEvent.

The performance of OnMRMLDisplayableModelNodeModifiedEvent was also improved, as it was not necessary to call UpdateClipSlicesFromMRML, and SetUpdateFromMRMLRequested functions when only a display node was modified.