### PR TITLE
COMP: add rpath to QWebEngineProcess

### DIFF
--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -332,7 +332,7 @@ function(fixup_bundle_with_plugins app)
       endforeach()
       # Update executable
       execute_process(COMMAND install_name_tool
-        -rpath "@executable_path/Frameworks" "@loader_path/../../../../../../../../"
+        -add_rpath "@loader_path/../../../../../../../../"
         ${changes} "${qtwebengineprocess_executable}"
         )
       # Create relative symlinks in <package_root>/Contents/Frameworks/QtWebEngineCore.framework


### PR DESCRIPTION
Other parts of the Qt installation have existing rpath
info in the mach-o file so they require the replacement
form of the install_name_tool command.

But QWebEngineProcess does not have an rpath, so
as described in the man page, this creates an
error condition so the other replacements are not
made.

This change uses the -add_rpath command command instead.

Fixes #5022
Fixes #4999