### PR TITLE
COMP: Update SlicerExecutionModel to fix extension configuration

### DIFF
--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "1788b378ed2e4928cded2bc9ecdc2b37c7f2af5f"
+    "f19d6e88a94ba8f31ddafcff4adf185fe90d7e72"
     QUIET
     )
 


### PR DESCRIPTION
This commit fixes a regression introduced in 7c60390212 (COMP: disable
parameter serializer by default (#5065))

Fixes #5080

List of changes:

```
$ git shortlog 1788b378e..f19d6e88a --no-merges
Hans Johnson (2):
      ENH: Update docker base image to include newer cmake version.
      COMP: Protect duplicate definition warnings

Jean-Christophe Fillion-Robin (1):
      COMP: Do not force JsonCpp and ParameterSerializer DIR variables to empty string

Julien Finet (1):
      COMP: Do not link ModuleDescriptionParser with entire ITK
```