### PR TITLE
ENH: Improve markup plane widget appearance

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -84,6 +84,10 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
 
   this->PropertiesLabelVisibility = true;
   this->PointLabelsVisibility = false;
+  this->FillVisibility = true;
+  this->OutlineVisibility = true;
+  this->FillOpacity = 0.5;
+  this->OutlineOpacity = 1.0;
 
   // Set active component defaults for mouse (identified by empty string)
   this->ActiveComponents[GetDefaultContextName()] = ComponentInfo();
@@ -139,6 +143,10 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingHueOffset, LineColorFadingHueOffset);
   vtkMRMLWriteXMLBooleanMacro(handlesInteractive, HandlesInteractive);
+  vtkMRMLWriteXMLBooleanMacro(fillVisibility, FillVisibility);
+  vtkMRMLWriteXMLBooleanMacro(outlineVisibility, OutlineVisibility);
+  vtkMRMLWriteXMLFloatMacro(fillOpacity, FillOpacity);
+  vtkMRMLWriteXMLFloatMacro(outlineOpacity, OutlineOpacity);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -171,6 +179,10 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
   vtkMRMLReadXMLFloatMacro(lineColorFadingHueOffset, LineColorFadingHueOffset);
   vtkMRMLReadXMLBooleanMacro(handlesInteractive, HandlesInteractive);
+  vtkMRMLReadXMLBooleanMacro(fillVisibility, FillVisibility);
+  vtkMRMLReadXMLBooleanMacro(outlineVisibility, OutlineVisibility);
+  vtkMRMLReadXMLFloatMacro(fillOpacity, FillOpacity);
+  vtkMRMLReadXMLFloatMacro(outlineOpacity, OutlineOpacity);
   vtkMRMLReadXMLEndMacro();
 
   // Fix up legacy markups fiducial nodes
@@ -231,6 +243,10 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   vtkMRMLCopyFloatMacro(LineColorFadingSaturation);
   vtkMRMLCopyFloatMacro(LineColorFadingHueOffset);
   vtkMRMLCopyBooleanMacro(HandlesInteractive);
+  vtkMRMLCopyBooleanMacro(FillVisibility);
+  vtkMRMLCopyBooleanMacro(OutlineVisibility);
+  vtkMRMLCopyFloatMacro(FillOpacity);
+  vtkMRMLCopyFloatMacro(OutlineOpacity);
   vtkMRMLCopyEndMacro();
 }
 
@@ -405,6 +421,10 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(LineColorFadingSaturation);
   vtkMRMLPrintFloatMacro(LineColorFadingHueOffset);
   vtkMRMLPrintBooleanMacro(HandlesInteractive);
+  vtkMRMLPrintBooleanMacro(FillVisibility);
+  vtkMRMLPrintBooleanMacro(OutlineVisibility);
+  vtkMRMLPrintFloatMacro(FillOpacity);
+  vtkMRMLPrintFloatMacro(OutlineOpacity);
   vtkMRMLPrintEndMacro();
 }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -159,6 +159,38 @@ public:
   vtkBooleanMacro(PropertiesLabelVisibility, bool);
   //@}
 
+  //@{
+  /**
+   * Control visibility of representation fill.
+   */
+  vtkSetMacro(FillVisibility, bool);
+  vtkGetMacro(FillVisibility, bool);
+  vtkBooleanMacro(FillVisibility, bool);
+
+  //@{
+  /**
+   * Control visibility of representation outline.
+   */
+  vtkSetMacro(OutlineVisibility, bool);
+  vtkGetMacro(OutlineVisibility, bool);
+  vtkBooleanMacro(OutlineVisibility, bool);
+
+  //@{
+  /**
+   * Control opacity of representation fill.
+   */
+  vtkSetMacro(FillOpacity, double);
+  vtkGetMacro(FillOpacity, double);
+  vtkBooleanMacro(FillOpacity, double);
+
+  //@{
+  /**
+   * Control opacity of representation edges.
+   */
+  vtkSetMacro(OutlineOpacity, double);
+  vtkGetMacro(OutlineOpacity, double);
+  vtkBooleanMacro(OutlineOpacity, double);
+
   /// Define how points are placed and moved in views
   enum SnapModes
     {
@@ -360,6 +392,10 @@ protected:
 
   bool PropertiesLabelVisibility;
   bool PointLabelsVisibility;
+  bool FillVisibility;
+  bool OutlineVisibility;
+  double FillOpacity;
+  double OutlineOpacity;
   double TextScale;
   int GlyphType;
   double GlyphScale;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
@@ -103,27 +103,28 @@ vtkSlicerPlaneRepresentation2D::vtkSlicerPlaneRepresentation2D()
   this->PlaneWorldToSliceTransformer->SetTransform(this->WorldToSliceTransform);
   this->PlaneWorldToSliceTransformer->SetInputConnection(this->PlaneSliceDistance->GetOutputPort());
 
-  this->PlaneMapper->SetInputConnection(this->PlaneWorldToSliceTransformer->GetOutputPort());
-  this->PlaneMapper->SetLookupTable(this->ColorMap);
-  this->PlaneMapper->SetScalarVisibility(true);
+  this->PlaneFillMapper->SetInputConnection(this->PlaneWorldToSliceTransformer->GetOutputPort());
+  this->PlaneFillMapper->SetLookupTable(this->PlaneFillColorMap);
+  this->PlaneFillMapper->SetScalarVisibility(true);
 
-  this->PlaneActor->SetMapper(this->PlaneMapper);
-  this->PlaneActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
+  this->PlaneFillActor->SetMapper(this->PlaneFillMapper);
+  this->PlaneFillActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
 
-  this->PlaneBorderWorldToSliceTransformer->SetTransform(this->WorldToSliceTransform);
-  this->PlaneBorderWorldToSliceTransformer->SetInputConnection(this->PlaneFilter->GetOutputPort());
+  this->PlaneOutlineWorldToSliceTransformer->SetTransform(this->WorldToSliceTransform);
+  this->PlaneOutlineWorldToSliceTransformer->SetInputConnection(this->PlaneFilter->GetOutputPort());
 
-  this->PlaneBorderFilter->SetInputConnection(this->PlaneBorderWorldToSliceTransformer->GetOutputPort());
-  this->PlaneBorderMapper->SetInputConnection(this->PlaneBorderFilter->GetOutputPort());
-  this->PlaneBorderActor->SetMapper(this->PlaneBorderMapper);
+  this->PlaneOutlineFilter->SetInputConnection(this->PlaneOutlineWorldToSliceTransformer->GetOutputPort());
 
-  this->PlaneBorderActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
+  this->PlaneOutlineMapper->SetInputConnection(this->PlaneOutlineFilter->GetOutputPort());
+  this->PlaneOutlineMapper->SetScalarVisibility(true);
+
+  this->PlaneOutlineActor->SetMapper(this->PlaneOutlineMapper);
+  this->PlaneOutlineActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
 
   this->ArrowFilter->SetGlyphTypeToThickArrow();
   this->ArrowFilter->FilledOn();
 
   this->ArrowGlypher->SetSourceConnection(this->ArrowFilter->GetOutputPort());
-  //this->ArrowGlypher->OrientOn();
 
   this->ArrowMapper->SetInputConnection(this->ArrowGlypher->GetOutputPort());
   this->ArrowMapper->SetScalarVisibility(true);
@@ -198,8 +199,8 @@ void vtkSlicerPlaneRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
       }
     }
 
-  this->PlaneActor->SetVisibility(visible);
-  this->PlaneBorderActor->SetVisibility(visible);
+  this->PlaneFillActor->SetVisibility(visible);
+  this->PlaneOutlineActor->SetVisibility(visible);
   this->ArrowActor->SetVisibility(visible);
 
   if (!visible)
@@ -225,8 +226,8 @@ void vtkSlicerPlaneRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   vtkNew<vtkProperty2D> borderProperty;
   borderProperty->DeepCopy(this->GetControlPointsPipeline(Unselected)->Property);
 
-  this->PlaneActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
-  this->PlaneBorderActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
+  this->PlaneFillActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
+  this->PlaneOutlineActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
   this->ArrowActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
   this->TextActor->SetTextProperty(this->GetControlPointsPipeline(controlPointType)->TextProperty);
 
@@ -234,34 +235,46 @@ void vtkSlicerPlaneRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
     {
     // Update the line color mapping from the colorNode stored in the markups display node
     vtkColorTransferFunction* colormap = this->MarkupsDisplayNode->GetLineColorNode()->GetColorTransferFunction();
-    this->PlaneMapper->SetLookupTable(colormap);
-    this->PlaneBorderMapper->SetLookupTable(colormap);
+    this->PlaneFillMapper->SetLookupTable(colormap);
+    this->PlaneOutlineMapper->SetLookupTable(colormap);
     this->ArrowMapper->SetLookupTable(colormap);
     }
   else
     {
     // if there is no line color node, build the color mapping from few variables
     // (color, opacity, distance fading, saturation and hue offset) stored in the display node
-    this->UpdateDistanceColorMap(this->ColorMap, this->PlaneActor->GetProperty()->GetColor());
-    this->PlaneMapper->SetLookupTable(this->ColorMap);
-    this->PlaneBorderMapper->SetLookupTable(this->ColorMap);
-    this->ArrowMapper->SetLookupTable(this->ColorMap);
+    this->UpdatePlaneFillColorMap(this->PlaneFillColorMap, this->PlaneFillActor->GetProperty()->GetColor());
+    this->UpdatePlaneOutlineColorMap(this->PlaneOutlineColorMap, this->PlaneFillActor->GetProperty()->GetColor());
+
+    this->PlaneFillMapper->SetLookupTable(this->PlaneFillColorMap);
+    this->PlaneOutlineMapper->SetLookupTable(this->PlaneOutlineColorMap);
+    this->ArrowMapper->SetLookupTable(this->PlaneFillColorMap);
     }
 }
 
 //----------------------------------------------------------------------
-void vtkSlicerPlaneRepresentation2D::UpdateDistanceColorMap(vtkDiscretizableColorTransferFunction* colormap, double color[3])
+void vtkSlicerPlaneRepresentation2D::UpdatePlaneFillColorMap(vtkDiscretizableColorTransferFunction* colormap, double color[3])
 {
   Superclass::UpdateDistanceColorMap(colormap, color);
-  double opacity = this->MarkupsDisplayNode->GetOpacity();
+  double opacity = this->MarkupsDisplayNode->GetOpacity() * this->MarkupsDisplayNode->GetFillOpacity();
   double limit = this->MarkupsDisplayNode->GetLineColorFadingEnd();
   double tolerance = this->MarkupsDisplayNode->GetLineColorFadingStart();
   vtkPiecewiseFunction* opacityFunction = colormap->GetScalarOpacityFunction();
   opacityFunction->RemoveAllPoints();
   opacityFunction->AddPoint(-limit, opacity * 0.2);
-  opacityFunction->AddPoint(-tolerance, opacity * 0.5);
-  opacityFunction->AddPoint(tolerance, opacity * 0.5);
+  opacityFunction->AddPoint(-tolerance, opacity);
+  opacityFunction->AddPoint(tolerance, opacity);
   opacityFunction->AddPoint(limit, opacity * 0.2);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerPlaneRepresentation2D::UpdatePlaneOutlineColorMap(vtkDiscretizableColorTransferFunction* colormap, double color[3])
+{
+  Superclass::UpdateDistanceColorMap(colormap, color);
+  double opacity = this->MarkupsDisplayNode->GetOpacity() * this->MarkupsDisplayNode->GetOutlineOpacity();
+  vtkPiecewiseFunction* opacityFunction = colormap->GetScalarOpacityFunction();
+  opacityFunction->RemoveAllPoints();
+  opacityFunction->AddPoint(0.0, opacity);
 }
 
 //----------------------------------------------------------------------
@@ -322,8 +335,8 @@ void vtkSlicerPlaneRepresentation2D::CanInteractWithPlane(
 //----------------------------------------------------------------------
 void vtkSlicerPlaneRepresentation2D::GetActors(vtkPropCollection *pc)
 {
-  this->PlaneActor->GetActors(pc);
-  this->PlaneBorderActor->GetActors(pc);
+  this->PlaneFillActor->GetActors(pc);
+  this->PlaneOutlineActor->GetActors(pc);
   this->ArrowActor->GetActors(pc);
   this->Superclass::GetActors(pc);
 }
@@ -332,8 +345,8 @@ void vtkSlicerPlaneRepresentation2D::GetActors(vtkPropCollection *pc)
 void vtkSlicerPlaneRepresentation2D::ReleaseGraphicsResources(
   vtkWindow *win)
 {
-  this->PlaneActor->ReleaseGraphicsResources(win);
-  this->PlaneBorderActor->ReleaseGraphicsResources(win);
+  this->PlaneFillActor->ReleaseGraphicsResources(win);
+  this->PlaneOutlineActor->ReleaseGraphicsResources(win);
   this->ArrowActor->ReleaseGraphicsResources(win);
   this->Superclass::ReleaseGraphicsResources(win);
 }
@@ -342,13 +355,13 @@ void vtkSlicerPlaneRepresentation2D::ReleaseGraphicsResources(
 int vtkSlicerPlaneRepresentation2D::RenderOverlay(vtkViewport *viewport)
 {
   int count = Superclass::RenderOverlay(viewport);
-  if (this->PlaneActor->GetVisibility())
+  if (this->PlaneFillActor->GetVisibility())
     {
-    count +=  this->PlaneActor->RenderOverlay(viewport);
+    count +=  this->PlaneFillActor->RenderOverlay(viewport);
     }
-  if (this->PlaneBorderActor->GetVisibility())
+  if (this->PlaneOutlineActor->GetVisibility())
     {
-    count +=  this->PlaneBorderActor->RenderOverlay(viewport);
+    count +=  this->PlaneOutlineActor->RenderOverlay(viewport);
     }
   if (this->ArrowActor->GetVisibility())
     {
@@ -364,13 +377,13 @@ int vtkSlicerPlaneRepresentation2D::RenderOpaqueGeometry(
   vtkViewport *viewport)
 {
   int count = Superclass::RenderOpaqueGeometry(viewport);
-  if (this->PlaneActor->GetVisibility())
+  if (this->PlaneFillActor->GetVisibility())
     {
-    count += this->PlaneActor->RenderOpaqueGeometry(viewport);
+    count += this->PlaneFillActor->RenderOpaqueGeometry(viewport);
     }
-  if (this->PlaneBorderActor->GetVisibility())
+  if (this->PlaneOutlineActor->GetVisibility())
     {
-    count += this->PlaneBorderActor->RenderOpaqueGeometry(viewport);
+    count += this->PlaneOutlineActor->RenderOpaqueGeometry(viewport);
     }
   if (this->ArrowActor->GetVisibility())
     {
@@ -386,13 +399,13 @@ int vtkSlicerPlaneRepresentation2D::RenderTranslucentPolygonalGeometry(
   vtkViewport *viewport)
 {
   int count = Superclass::RenderTranslucentPolygonalGeometry(viewport);
-  if (this->PlaneActor->GetVisibility())
+  if (this->PlaneFillActor->GetVisibility())
     {
-    count += this->PlaneActor->RenderTranslucentPolygonalGeometry(viewport);
+    count += this->PlaneFillActor->RenderTranslucentPolygonalGeometry(viewport);
     }
-  if (this->PlaneBorderActor->GetVisibility())
+  if (this->PlaneOutlineActor->GetVisibility())
     {
-    count += this->PlaneBorderActor->RenderTranslucentPolygonalGeometry(viewport);
+    count += this->PlaneOutlineActor->RenderTranslucentPolygonalGeometry(viewport);
     }
   if (this->ArrowActor->GetVisibility())
     {
@@ -410,11 +423,11 @@ vtkTypeBool vtkSlicerPlaneRepresentation2D::HasTranslucentPolygonalGeometry()
     {
     return true;
     }
-  if (this->PlaneActor->GetVisibility() && this->PlaneActor->HasTranslucentPolygonalGeometry())
+  if (this->PlaneFillActor->GetVisibility() && this->PlaneFillActor->HasTranslucentPolygonalGeometry())
     {
     return true;
     }
-  if (this->PlaneBorderActor->GetVisibility() && this->PlaneBorderActor->HasTranslucentPolygonalGeometry())
+  if (this->PlaneOutlineActor->GetVisibility() && this->PlaneOutlineActor->HasTranslucentPolygonalGeometry())
     {
     return true;
     }
@@ -437,13 +450,13 @@ void vtkSlicerPlaneRepresentation2D::PrintSelf(ostream& os, vtkIndent indent)
   //Superclass typedef defined in vtkTypeMacro() found in vtkSetGet.h
   this->Superclass::PrintSelf(os, indent);
 
-  if (this->PlaneActor)
+  if (this->PlaneFillActor)
     {
-    os << indent << "Plane Actor Visibility: " << this->PlaneActor->GetVisibility() << "\n";
+    os << indent << "Plane Actor Visibility: " << this->PlaneFillActor->GetVisibility() << "\n";
     }
-  else if (this->PlaneBorderActor)
+  else if (this->PlaneOutlineActor)
     {
-    os << indent << "Plane Border Actor Visibility: " << this->PlaneBorderActor->GetVisibility() << "\n";
+    os << indent << "Plane Border Actor Visibility: " << this->PlaneOutlineActor->GetVisibility() << "\n";
     }
   else if (this->ArrowActor)
     {
@@ -464,7 +477,7 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
   vtkMRMLMarkupsPlaneNode* markupsNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
   if (!markupsNode || markupsNode->GetNumberOfControlPoints() != 3)
   {
-    this->PlaneMapper->SetInputData(vtkNew<vtkPolyData>());
+    this->PlaneFillMapper->SetInputData(vtkNew<vtkPolyData>());
     this->ArrowMapper->SetInputData(vtkNew<vtkPolyData>());
     return;
   }
@@ -479,12 +492,12 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
       vtkMath::Norm(yAxis_World) <= epsilon ||
       vtkMath::Norm(zAxis_World) <= epsilon)
   {
-    this->PlaneMapper->SetInputData(vtkNew<vtkPolyData>());
+    this->PlaneFillMapper->SetInputData(vtkNew<vtkPolyData>());
     this->ArrowMapper->SetInputData(vtkNew<vtkPolyData>());
     return;
   }
 
-  this->PlaneMapper->SetInputConnection(this->PlaneWorldToSliceTransformer->GetOutputPort());
+  this->PlaneFillMapper->SetInputConnection(this->PlaneWorldToSliceTransformer->GetOutputPort());
   this->ArrowMapper->SetInputConnection(this->ArrowGlypher->GetOutputPort());
 
   double origin_World[3] = { 0.0 };
@@ -599,7 +612,7 @@ void vtkSlicerPlaneRepresentation2D::UpdateInteractionPipeline()
     this->InteractionPipeline->Actor->SetVisibility(false);
     return;
     }
-  if (!this->PlaneActor->GetVisibility())
+  if (!this->PlaneFillActor->GetVisibility())
     {
     this->InteractionPipeline->Actor->SetVisibility(false);
     return;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
@@ -88,8 +88,8 @@ protected:
   vtkSlicerPlaneRepresentation2D();
   ~vtkSlicerPlaneRepresentation2D() override;
 
-  /// Re-implemented to adjust plane opacity
-  void UpdateDistanceColorMap(vtkDiscretizableColorTransferFunction* colormap, double color[3]) override;
+  virtual void UpdatePlaneFillColorMap(vtkDiscretizableColorTransferFunction* colormap, double color[3]);
+  virtual void UpdatePlaneOutlineColorMap(vtkDiscretizableColorTransferFunction* colormap, double color[3]);
 
   vtkNew<vtkPlaneSource> PlaneFilter;
   vtkNew<vtkPlaneCutter> PlaneCutter;
@@ -103,20 +103,21 @@ protected:
   vtkNew<vtkCompositeDataGeometryFilter> PlaneCompositeFilter;
   vtkNew<vtkAppendPolyData> PlaneAppend;
   vtkNew<vtkTransformPolyDataFilter> PlaneWorldToSliceTransformer;
-  vtkNew<vtkPolyDataMapper2D> PlaneMapper;
-  vtkNew<vtkActor2D> PlaneActor;
+  vtkNew<vtkPolyDataMapper2D> PlaneFillMapper;
+  vtkNew<vtkActor2D> PlaneFillActor;
 
-  vtkNew<vtkFeatureEdges> PlaneBorderFilter;
-  vtkNew<vtkTransformPolyDataFilter> PlaneBorderWorldToSliceTransformer;
-  vtkNew<vtkPolyDataMapper2D> PlaneBorderMapper;
-  vtkNew<vtkActor2D> PlaneBorderActor;
+  vtkNew<vtkFeatureEdges> PlaneOutlineFilter;
+  vtkNew<vtkDiscretizableColorTransferFunction> PlaneOutlineColorMap;
+  vtkNew<vtkTransformPolyDataFilter> PlaneOutlineWorldToSliceTransformer;
+  vtkNew<vtkPolyDataMapper2D> PlaneOutlineMapper;
+  vtkNew<vtkActor2D> PlaneOutlineActor;
 
   vtkNew<vtkMarkupsGlyphSource2D> ArrowFilter;
   vtkNew<vtkGlyph2D> ArrowGlypher;
   vtkNew<vtkPolyDataMapper2D> ArrowMapper;
   vtkNew<vtkActor2D> ArrowActor;
 
-  vtkNew<vtkDiscretizableColorTransferFunction> ColorMap;
+  vtkNew<vtkDiscretizableColorTransferFunction> PlaneFillColorMap;
   vtkNew<vtkSampleImplicitFunctionFilter> PlaneSliceDistance;
   std::string LabelFormat;
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
@@ -36,14 +36,17 @@
 #include "vtkSlicerMarkupsWidgetRepresentation3D.h"
 
 class vtkActor;
+class vtkArrayCalculator;
 class vtkAppendPolyData;
 class vtkArrowSource;
 class vtkGlyph3DMapper;
+class vtkLookupTable;
 class vtkMRMLInteractionEventData;
 class vtkPlaneSource;
 class vtkPolyDataMapper;
 class vtkPolyData;
 class vtkTransformPolyDataFilter;
+class vtkTubeFilter;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerPlaneRepresentation3D : public vtkSlicerMarkupsWidgetRepresentation3D
 {
@@ -83,14 +86,21 @@ protected:
   vtkSlicerPlaneRepresentation3D();
   ~vtkSlicerPlaneRepresentation3D() override;
 
-  vtkNew<vtkPlaneSource>    PlaneFilter;
+  vtkNew<vtkPlaneSource>     PlaneFillFilter;
+  vtkNew<vtkArrayCalculator> PlaneFillColorFilter;
 
-  vtkNew<vtkArrowSource>    ArrowFilter;
-  vtkNew<vtkGlyph3D>        ArrowGlypher;
+  vtkNew<vtkArrowSource>     ArrowFilter;
+  vtkNew<vtkGlyph3D>         ArrowGlypher;
+  vtkNew<vtkArrayCalculator> ArrowColorFilter;
 
-  vtkNew<vtkAppendPolyData> Append;
-  vtkNew<vtkPolyDataMapper> PlaneMapper;
-  vtkNew<vtkActor>          PlaneActor;
+  vtkNew<vtkTubeFilter>      PlaneOutlineFilter;
+  vtkNew<vtkArrayCalculator> PlaneOutlineColorFilter;
+
+  vtkNew<vtkAppendPolyData>  Append;
+  vtkNew<vtkPolyDataMapper>  PlaneMapper;
+  vtkNew<vtkActor>           PlaneActor;
+
+  vtkNew<vtkLookupTable>    PlaneColorLUT;
 
   std::string LabelFormat;
 

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -26,10 +26,43 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="5" column="0">
-    <widget class="QLabel" name="glyphScaleLabel">
+   <item row="0" column="0">
+    <widget class="QLabel" name="VisibilityLabel">
      <property name="text">
-      <string>Glyph Size:</string>
+      <string>Visibility:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="ctkCollapsibleGroupBox" name="InteractionGroupBox">
+     <property name="title">
+      <string>Interaction</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="interactionLabel">
+        <property name="text">
+         <string>Visible:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="interactionCheckBox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="textScaleLabel">
+     <property name="text">
+      <string>Text Size:</string>
      </property>
     </widget>
    </item>
@@ -73,23 +106,179 @@
      </item>
     </layout>
    </item>
-   <item row="7" column="1">
-    <widget class="ctkSliderWidget" name="textScaleSliderWidget">
-     <property name="singleStep">
-      <double>0.100000000000000</double>
+   <item row="9" column="0" colspan="2">
+    <widget class="ctkCollapsibleGroupBox" name="SliceDisplayCollapsibleGroupBox">
+     <property name="title">
+      <string>Advanced</string>
      </property>
-     <property name="maximum">
-      <double>20.000000000000000</double>
+     <property name="checked">
+      <bool>false</bool>
      </property>
-     <property name="suffix">
-      <string> %</string>
+     <property name="collapsed">
+      <bool>true</bool>
      </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>5</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="8" column="0" colspan="2">
+       <widget class="qMRMLMarkupsFiducialProjectionPropertyWidget" name="pointFiducialProjectionWidget"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="unselectedColorLabel">
+        <property name="text">
+         <string>Unselected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QCheckBox" name="FillVisibilityCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="OpacityLabel3">
+          <property name="text">
+           <string>Opacity:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="FillOpacitySliderWidget">
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="selectedColorLabel">
+        <property name="text">
+         <string>Selected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="DisplayNodeViewLabel">
+        <property name="text">
+         <string>View:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="glyphTypeLabel">
+        <property name="text">
+         <string>Glyph Type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="FillLabel">
+        <property name="text">
+         <string>Fill:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="OutlineLabel">
+        <property name="text">
+         <string>Outline:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
+        <property name="toolTip">
+         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="glyphTypeComboBox"/>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="PointLabelsVisibilityLabel">
+        <property name="text">
+         <string>Point Labels:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QCheckBox" name="OutlineVisibilityCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="OpacityLabel2">
+          <property name="text">
+           <string>Opacity:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="OutlineOpacitySliderWidget">
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="textScaleLabel">
+   <item row="5" column="0">
+    <widget class="QLabel" name="glyphScaleLabel">
      <property name="text">
-      <string>Text Size:</string>
+      <string>Glyph Size:</string>
      </property>
     </widget>
    </item>
@@ -121,130 +310,17 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="VisibilityLabel">
-     <property name="text">
-      <string>Visibility:</string>
+   <item row="7" column="1">
+    <widget class="ctkSliderWidget" name="textScaleSliderWidget">
+     <property name="singleStep">
+      <double>0.100000000000000</double>
      </property>
-    </widget>
-   </item>
-   <item row="9" column="0" colspan="2">
-    <widget class="ctkCollapsibleGroupBox" name="SliceDisplayCollapsibleGroupBox">
-     <property name="title">
-      <string>Advanced</string>
+     <property name="maximum">
+      <double>20.000000000000000</double>
      </property>
-     <property name="checked">
-      <bool>false</bool>
+     <property name="suffix">
+      <string> %</string>
      </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>5</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="DisplayNodeViewLabel">
-        <property name="text">
-         <string>View:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="selectedColorLabel">
-        <property name="text">
-         <string>Selected Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="unselectedColorLabel">
-        <property name="text">
-         <string>Unselected Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="glyphTypeLabel">
-        <property name="text">
-         <string>Glyph Type:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="glyphTypeComboBox"/>
-      </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="qMRMLMarkupsFiducialProjectionPropertyWidget" name="pointFiducialProjectionWidget"/>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
-        <property name="toolTip">
-         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="PointLabelsVisibilityLabel">
-        <property name="text">
-         <string>Point Labels:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="2">
-    <widget class="ctkCollapsibleGroupBox" name="InteractionGroupBox">
-     <property name="title">
-      <string>Interaction</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="interactionLabel">
-        <property name="text">
-         <string>Visible:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="interactionCheckBox">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
   </layout>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -98,6 +98,13 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
   QObject::connect(this->interactionCheckBox, SIGNAL(stateChanged(int)),
     q, SLOT(onInteractionCheckBoxChanged(int)));
 
+  QObject::connect(this->FillVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setFillVisibility(bool)));
+  QObject::connect(this->OutlineVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setOutlineVisibility(bool)));
+  QObject::connect(this->FillOpacitySliderWidget, SIGNAL(valueChanged(double)),
+    q, SLOT(onFillOpacitySliderWidgetChanged(double)));
+  QObject::connect(this->OutlineOpacitySliderWidget, SIGNAL(valueChanged(double)),
+    q, SLOT(onOutlineOpacitySliderWidgetChanged(double)));
+
     // populate the glyph type combo box
   if (this->glyphTypeComboBox->count() == 0)
     {
@@ -263,6 +270,23 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
 
   bool handlesInteractive = markupsDisplayNode->GetHandlesInteractive();
   d->interactionCheckBox->setChecked(handlesInteractive);
+
+  bool wasBlocking = false;
+  wasBlocking = d->FillVisibilityCheckBox->blockSignals(true);
+  d->FillVisibilityCheckBox->setChecked(d->MarkupsDisplayNode ? d->MarkupsDisplayNode->GetFillVisibility() : false);
+  d->FillVisibilityCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->OutlineVisibilityCheckBox->blockSignals(true);
+  d->OutlineVisibilityCheckBox->setChecked(d->MarkupsDisplayNode ? d->MarkupsDisplayNode->GetOutlineVisibility() : false);
+  d->OutlineVisibilityCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->FillOpacitySliderWidget->blockSignals(true);
+  d->FillOpacitySliderWidget->setValue(d->MarkupsDisplayNode ? d->MarkupsDisplayNode->GetFillOpacity() : 0.0);
+  d->FillOpacitySliderWidget->blockSignals(wasBlocking);
+
+  wasBlocking = d->OutlineOpacitySliderWidget->blockSignals(true);
+  d->OutlineOpacitySliderWidget->setValue(d->MarkupsDisplayNode ? d->MarkupsDisplayNode->GetOutlineOpacity() : 0.0);
+  d->OutlineOpacitySliderWidget->blockSignals(wasBlocking);
 
   emit displayNodeChanged();
 }
@@ -449,4 +473,48 @@ void qMRMLMarkupsDisplayNodeWidget::onInteractionCheckBoxChanged(int state)
     return;
     }
   d->MarkupsDisplayNode->SetHandlesInteractive(state);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setFillVisibility(bool visibility)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetFillVisibility(visibility);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setOutlineVisibility(bool visibility)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetOutlineVisibility(visibility);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::onFillOpacitySliderWidgetChanged(double opacity)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetFillOpacity(opacity);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::onOutlineOpacitySliderWidgetChanged(double opacity)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetOutlineOpacity(opacity);
 }

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
@@ -85,6 +85,11 @@ public slots:
   void setMaximumMarkupsScale(double maxScale);
   void setMaximumMarkupsSize(double maxScale);
 
+  void setFillVisibility(bool visibility);
+  void setOutlineVisibility(bool visibility);
+  void onFillOpacitySliderWidgetChanged(double opacity);
+  void onOutlineOpacitySliderWidgetChanged(double opacity);
+
 protected slots:
   void updateWidgetFromMRML();
   vtkMRMLSelectionNode* getSelectionNode(vtkMRMLScene *mrmlScene);


### PR DESCRIPTION
Improves the appearance of plane widgets by adding a border around the plane and allowing control of plane fill/border opacity.

fixes #4930

![image](https://user-images.githubusercontent.com/9222709/89316942-b886fe00-d64a-11ea-9bee-4ea61e67cf3e.png)
