### PR TITLE
BUG: Prevent Traceback from undo/redo in AutoComplete effects

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -160,10 +160,13 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
         return
       segmentLabelmap = segment.GetRepresentation(vtkSegmentationCore.vtkSegmentationConverter.GetSegmentationBinaryLabelmapRepresentationName())
       if segmentID in self.selectedSegmentModifiedTimes \
-        and segmentLabelmap.GetMTime() == self.selectedSegmentModifiedTimes[segmentID]:
+        and segmentLabelmap and segmentLabelmap.GetMTime() == self.selectedSegmentModifiedTimes[segmentID]:
         # this segment has not changed since last update
         continue
-      self.selectedSegmentModifiedTimes[segmentID] = segmentLabelmap.GetMTime()
+      if segmentLabelmap:
+        self.selectedSegmentModifiedTimes[segmentID] = segmentLabelmap.GetMTime()
+      elif segmentID in self.selectedSegmentModifiedTimes:
+        self.selectedSegmentModifiedTimes.pop(segmentID)
       updateNeeded = True
       # continue so that all segment modified times are updated
 


### PR DESCRIPTION
Check to make sure that the segment labelmap exists before getting the MTime.
If the labelmap does not exist, remove it from the list of MTimes.

fixes #5088