### PR TITLE
ENH: Update VTK backporting support for shading with multi-volume rendering

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -122,7 +122,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
 set(_git_tag)
 if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "8")
-  set(_git_tag "b4a181566f8510103333d32d19a567cd5a455a34") # slicer-v8.2.0-2018-10-02-74d9488523
+  set(_git_tag "9c813fe590b5f604dbd7f6641021308a21b3cea1") # slicer-v8.2.0-2018-10-02-74d9488523
 else()
   message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
 endif()


### PR DESCRIPTION
List of changes:

```
$ git shortlog b4a181566f..9c813fe590 --no-merges
Csaba Pinter (1):
      [backport] Add shading to multi-volume rendering

Michael Migliore (1):
      [backport] Fix shader error on Mesa and use enum
```

Co-authored-by: Csaba Pinter <pinter.csaba@gmail.com>