### PR TITLE
BUG: Fix QAccessibleTable::child: Invalid index warning

### DIFF
--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
@@ -683,7 +683,13 @@ void qMRMLNodeComboBox::emitCurrentNodeChanged()
   vtkMRMLNode*  node = d->mrmlNode(currentIndex);
   if (!node && ((!d->NoneEnabled &&currentIndex != -1) || (d->NoneEnabled && currentIndex != 0)) )
     {
-    this->setCurrentNode(this->nodeFromIndex(this->nodeCount()-1));
+    // we only set the current node if the new selected is different
+    // (not nullptr) to avoid warning in QAccessibleTable::child
+    vtkMRMLNode* newSelectedNode = this->nodeFromIndex(this->nodeCount() - 1);
+    if (newSelectedNode)
+      {
+      this->setCurrentNode(newSelectedNode);
+      }
     }
   else
     {


### PR DESCRIPTION
On Windows 10, with Qt-5.15.0, setting the scene in qMRMLNodeComboBox caused warnings such as this:

```
[WARNING][Qt] 11.08.2020 15:44:08 [] (unknown:0) - QAccessibleTable::child: Invalid index at: 0 0
[WARNING][Qt] 11.08.2020 15:44:08 [] (unknown:0) - QAccessibleTable::child: Invalid index at: 0 0
```

It was reproducible by this script:

```
   c=slicer.qMRMLNodeComboBox(); c.setMRMLScene(slicer.mrmlScene); c.show()
```

The problem was that during scene setting, when the scene item was placed in the scene model, `setCurrentNode(nullptr)` got called, which triggered a warning in `QAccessibleTable::child(int logicalIndex)` because the item index was invalid.

Fixed the issue by not calling `setCurrentNode(nullptr)` if the current node was already `nullptr`.

fixes #5094