### PR TITLE
ENH: Improve segment threshold histogram for floating point volumes

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorThresholdEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorThresholdEffect.py
@@ -813,7 +813,11 @@ class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
     maxNumberOfBins = 1000
     masterImageData = self.scriptedEffect.masterVolumeImageData()
     scalarRange = masterImageData.GetScalarRange()
-    numberOfBins = int(scalarRange[1] - scalarRange[0]) + 1
+    scalarType = masterImageData.GetScalarType()
+    if scalarType == vtk.VTK_FLOAT or scalarType == vtk.VTK_DOUBLE:
+      numberOfBins = maxNumberOfBins
+    else:
+      numberOfBins = int(scalarRange[1] - scalarRange[0]) + 1
     if numberOfBins > maxNumberOfBins:
       numberOfBins = maxNumberOfBins
     binSpacing = (scalarRange[1] - scalarRange[0] + 1) / numberOfBins


### PR DESCRIPTION
The number of bins used for the selected region histogram was calculated with the following formula:
  ```max(scalarRangeMax - scalarRangeMin + 1, 1000)```

This worked well for integer type images, but resulted in a low resolution for floating point types.
The number of bins for floating point types is now automatically set to the maximum allowed (1000).