### PR TITLE
BUG: Fix paint brush resize using shift+mousewheel on MacOS

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
@@ -1156,7 +1156,7 @@ bool qSlicerSegmentEditorPaintEffect::processInteractionEvents(
     {
     return false;
     }
-  else if (eid == vtkCommand::MouseWheelForwardEvent)
+  else if (eid == vtkCommand::MouseWheelForwardEvent || eid == vtkCommand::MouseWheelLeftEvent)
     {
     if (shiftKeyPressed)
       {
@@ -1167,17 +1167,18 @@ bool qSlicerSegmentEditorPaintEffect::processInteractionEvents(
       return false;
       }
     }
-  else if (eid == vtkCommand::MouseWheelBackwardEvent)
+  else if (eid == vtkCommand::MouseWheelBackwardEvent || eid == vtkCommand::MouseWheelRightEvent)
     {
     if (shiftKeyPressed)
       {
-    scaleDiameterRequested = (1.0 - zoomFactor);
+      scaleDiameterRequested = (1.0 - zoomFactor);
       }
     else
       {
       return false;
       }
     }
+
   if (scaleDiameterRequested > 0)
     {
     d->scaleDiameter(scaleDiameterRequested);

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -2644,6 +2644,8 @@ void qMRMLSegmentEditorWidget::setupViewObservations()
     interactorObservation.ObservationTags << interactor->AddObserver(vtkCommand::MouseMoveEvent, interactorObservation.CallbackCommand, 1.0);
     interactorObservation.ObservationTags << interactor->AddObserver(vtkCommand::MouseWheelForwardEvent, interactorObservation.CallbackCommand, 1.0);
     interactorObservation.ObservationTags << interactor->AddObserver(vtkCommand::MouseWheelBackwardEvent, interactorObservation.CallbackCommand, 1.0);
+    interactorObservation.ObservationTags << interactor->AddObserver(vtkCommand::MouseWheelLeftEvent, interactorObservation.CallbackCommand, 1.0);
+    interactorObservation.ObservationTags << interactor->AddObserver(vtkCommand::MouseWheelRightEvent, interactorObservation.CallbackCommand, 1.0);
     interactorObservation.ObservationTags << interactor->AddObserver(vtkCommand::KeyPressEvent, interactorObservation.CallbackCommand, 1.0);
     interactorObservation.ObservationTags << interactor->AddObserver(vtkCommand::KeyReleaseEvent, interactorObservation.CallbackCommand, 1.0);
     interactorObservation.ObservationTags << interactor->AddObserver(vtkCommand::EnterEvent, interactorObservation.CallbackCommand, 1.0);


### PR DESCRIPTION
Vertical mousewheel+shift on MacOS is mapped to the horizontal, rather than vertical axis.
As a result, using shift+mousewheel to resize the paintbrush was not functional on MacOS.

Fixed by allowing both MouseWheelForward/BackwardEvent and MouseWheelLeft/RightEvent for paint brush resize.

Fixes #4661