### PR TITLE
BUG: Fix running of multiple Slicer instances

### DIFF
--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -57,6 +57,7 @@
 #include <cassert>
 #include <ctime>
 #include <mutex>
+#include <random>
 #include <set>
 
 #ifdef _WIN32
@@ -202,6 +203,8 @@ public:
 
   int RedirectModuleStreams;
 
+  std::default_random_engine RandomGenerator;
+
   std::mutex ProcessesKillLock;
   std::vector<itksysProcess*> Processes;
 
@@ -297,6 +300,8 @@ vtkStandardNewMacro(vtkSlicerCLIModuleLogic);
 vtkSlicerCLIModuleLogic::vtkSlicerCLIModuleLogic()
 {
   this->Internal = new vtkInternal();
+
+  this->Internal->RandomGenerator.seed(std::random_device{}());
 
   this->Internal->DeleteTemporaryFiles = 1;
   this->Internal->AllowInMemoryTransfer = 1;
@@ -1254,12 +1259,11 @@ void vtkSlicerCLIModuleLogic::ApplyTask(void *clientdata)
         "0123456789"
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz";
-    srand(time(nullptr));
 
     std::ostringstream code;
     for (int ii = 0; ii < 10; ii++)
       {
-      code << alphanum[rand() % (sizeof(alphanum)-1)];
+      code << alphanum[this->Internal->RandomGenerator() % (sizeof(alphanum)-1)];
       }
     std::string returnFile = temporaryDirectory + "/" + pidString.str()
       + "_" + code.str() + ".params";

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -24,6 +24,7 @@
 #include <QFile>
 #include <QtGlobal>
 #include <QMainWindow>
+#include <QRandomGenerator>
 #include <QSurfaceFormat>
 #include <QSysInfo>
 
@@ -809,10 +810,12 @@ void qSlicerApplication::setupFileLogging()
 
   // Add new log file path for the current session
   QString tempDir = this->temporaryPath();
-  QString currentLogFilePath = tempDir + QString("/") + this->applicationName() + QString("_") +
-    this->revision() + QString("_") +
-    QDateTime::currentDateTime().toString("yyyyMMdd_hhmmss") +
-    QString(".log");
+  QString currentLogFilePath = QString("%1/%2_%3_%4_%5.log")
+    .arg(tempDir)
+    .arg(this->applicationName())
+    .arg(this->revision())
+    .arg(QDateTime::currentDateTime().toString("yyyyMMdd_hhmmss"))
+    .arg(QRandomGenerator::global()->generate() % 1000, 3, 10, QLatin1Char('0'));
   logFilePaths.prepend(currentLogFilePath);
 
   // Save settings

--- a/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.cxx
@@ -24,6 +24,7 @@ Version:   $Revision: 1.0 $
 #include <vtkObjectFactory.h>
 
 // STD includes
+#include <random>
 #include <sstream>
 
 //------------------------------------------------------------------------------
@@ -1198,6 +1199,7 @@ void vtkMRMLColorTableNode::SetType(int type)
     else if (this->Type == this->Random)
       {
       int size = 255;
+      std::default_random_engine randomGenerator(std::random_device{}());
 
       this->GetLookupTable()->SetNumberOfTableValues(size + 1);
       this->GetLookupTable()->SetTableRange(0, 255);
@@ -1205,9 +1207,9 @@ void vtkMRMLColorTableNode::SetType(int type)
       for (int i = 1; i <= size; i++)
         {
         // table values have to be 0-1
-        double r = (rand()%255)/255.0;
-        double g = (rand()%255)/255.0;
-        double b = (rand()%255)/255.0;
+        double r = static_cast<double>(randomGenerator()) / randomGenerator.max();
+        double g = static_cast<double>(randomGenerator()) / randomGenerator.max();
+        double b = static_cast<double>(randomGenerator()) / randomGenerator.max();
 
         this->GetLookupTable()->SetTableValue(i, r, g, b, 1.0);
         }

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -119,6 +119,8 @@ vtkCxxSetObjectMacro(vtkMRMLScene, URIHandlerCollection, vtkCollection)
 //------------------------------------------------------------------------------
 vtkMRMLScene::vtkMRMLScene()
 {
+  this->RandomGenerator.seed(std::random_device{}());
+
   this->NodeIDsMTime = 0;
 
   this->RegisteredNodeClasses.clear();
@@ -3714,7 +3716,7 @@ bool vtkMRMLScene::WriteToMRB(const char* filename, vtkImageData* thumbnail/*=nu
   // Use the output directory as temporary directory.
   // This may not be ideal if the output directory has limited storage space (e.g., USB stick).
   std::stringstream tempDirStr;
-  tempDirStr << mrbDir<< "/" << vtksys::SystemTools::GetCurrentDateTime("__BundleSaveTemp-%F_%H+M+%S.") << (rand() % 1000);
+  tempDirStr << mrbDir<< "/" << vtksys::SystemTools::GetCurrentDateTime("__BundleSaveTemp-%F_%H%M%S_") << (this->RandomGenerator() % 1000);
   std::string tempDir = tempDirStr.str();
   vtkDebugMacro("Packing to " << tempDir);
 
@@ -3776,7 +3778,7 @@ bool vtkMRMLScene::ReadFromMRB(const char* fullName, bool clear/*=false*/)
     tempBaseDir = this->GetDataIOManager()->GetCacheManager()->GetRemoteCacheDirectory();
     }
   std::stringstream unpackDirStr;
-  unpackDirStr << tempBaseDir << "/" << vtksys::SystemTools::GetCurrentDateTime("__BundleLoadTemp-%F_%H+M+%S.") << (rand() % 1000);
+  unpackDirStr << tempBaseDir << "/" << vtksys::SystemTools::GetCurrentDateTime("__BundleLoadTemp-%F_%H%M%S_") << (this->RandomGenerator() % 1000);
   std::string unpackDir = unpackDirStr.str();
   vtkDebugMacro("Unpacking bundle to " << unpackDir);
 

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -30,6 +30,7 @@ Version:   $Revision: 1.18 $
 // STD includes
 #include <list>
 #include <map>
+#include <random>
 #include <set>
 #include <string>
 #include <vector>
@@ -919,6 +920,8 @@ protected:
   char * LastLoadedVersion;
 
   vtkCallbackCommand *DeleteEventCallback;
+
+  std::default_random_engine RandomGenerator;
 
 private:
 

--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
@@ -45,8 +45,9 @@
 
 // STD includes
 #include <algorithm>
-#include <vector>
+#include <random>
 #include <sstream>
+#include <vector>
 
 //----------------------------------------------------------------------------
 const double vtkMRMLSegmentationDisplayNode::SEGMENT_COLOR_NO_OVERRIDE = -1.0;
@@ -907,9 +908,10 @@ void vtkMRMLSegmentationDisplayNode::GenerateSegmentColor(double color[3], int c
   if (!genericAnatomyColorNode || colorNumber == -1)
     {
     // Generate random color if default color table is not available (such as in logic tests)
-    color[0] = rand() * 1.0 / RAND_MAX;
-    color[1] = rand() * 1.0 / RAND_MAX;
-    color[2] = rand() * 1.0 / RAND_MAX;
+    std::default_random_engine randomGenerator(std::random_device{}());
+    color[0] = static_cast<double>(randomGenerator()) / randomGenerator.max();
+    color[1] = static_cast<double>(randomGenerator()) / randomGenerator.max();
+    color[2] = static_cast<double>(randomGenerator()) / randomGenerator.max();
     return;
     }
 

--- a/Libs/MRML/Logic/vtkMRMLColorLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLColorLogic.cxx
@@ -37,6 +37,7 @@
 #include <cassert>
 #include <ctype.h> // For isspace
 #include <functional>
+#include <random>
 #include <sstream>
 
 //----------------------------------------------------------------------------
@@ -484,15 +485,17 @@ vtkMRMLProceduralColorNode* vtkMRMLColorLogic::CreateRandomNode()
   procNode->SaveWithSceneOff();
   procNode->SetSingletonTag(procNode->GetTypeAsString());
 
+  std::default_random_engine randomGenerator(std::random_device{}());
+
   vtkColorTransferFunction *func = procNode->GetColorTransferFunction();
   const int dimension = 1000;
   double table[3*dimension];
   double* tablePtr = table;
   for (int i = 0; i < dimension; ++i)
     {
-    *tablePtr++ = static_cast<double>(rand())/RAND_MAX;
-    *tablePtr++ = static_cast<double>(rand())/RAND_MAX;
-    *tablePtr++ = static_cast<double>(rand())/RAND_MAX;
+    *tablePtr++ = static_cast<double>(randomGenerator()) / randomGenerator.max();
+    *tablePtr++ = static_cast<double>(randomGenerator()) / randomGenerator.max();
+    *tablePtr++ = static_cast<double>(randomGenerator()) / randomGenerator.max();
     }
   func->BuildFunctionFromTable(VTK_INT_MIN, VTK_INT_MAX, dimension, table);
   func->Build();

--- a/Libs/MRML/Widgets/qMRMLSceneFactoryWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneFactoryWidget.cxx
@@ -20,6 +20,7 @@
 
 // Qt includes
 #include <QDebug>
+#include <QRandomGenerator>
 
 // qMRML includes
 #include "qMRMLSceneFactoryWidget.h"
@@ -41,6 +42,7 @@ public:
   void setNodeActionsEnabled(bool enable);
 
   vtkMRMLScene*  MRMLScene;
+  QRandomGenerator RandomGenerator;
 };
 
 // --------------------------------------------------------------------------
@@ -48,6 +50,7 @@ qMRMLSceneFactoryWidgetPrivate::qMRMLSceneFactoryWidgetPrivate(qMRMLSceneFactory
   : q_ptr(&object)
 {
   this->MRMLScene = nullptr;
+  // RandomGenerator is not seeded with random number to make behavior reproducible
 }
 
 // --------------------------------------------------------------------------
@@ -134,12 +137,12 @@ vtkMRMLNode* qMRMLSceneFactoryWidget::generateNode()
   if (nodeClassName.isEmpty())
     {
     int numClasses = d->MRMLScene->GetNumberOfRegisteredNodeClasses();
-    int classNumber = rand() % numClasses;
+    int classNumber = d->RandomGenerator.generate() % numClasses;
     vtkMRMLNode* node = d->MRMLScene->GetNthRegisteredNodeClass(classNumber);
     Q_ASSERT(node);
     while (node->GetSingletonTag())
       {
-      classNumber = rand() % numClasses;
+      classNumber = d->RandomGenerator.generate() % numClasses;
       node = d->MRMLScene->GetNthRegisteredNodeClass(classNumber);
       Q_ASSERT(node);
       }
@@ -184,7 +187,7 @@ void qMRMLSceneFactoryWidget::deleteNode()
     {
     return;
     }
-  vtkMRMLNode* node = d->MRMLScene->GetNthNode(rand() % numNodes);
+  vtkMRMLNode* node = d->MRMLScene->GetNthNode(d->RandomGenerator.generate() % numNodes);
   d->MRMLScene->RemoveNode(node);
   // FIXME: disable delete button when there is no more nodes in the scene to delete
   emit mrmlNodeRemoved(node);
@@ -202,7 +205,7 @@ void qMRMLSceneFactoryWidget::deleteNode(const QString& className)
     qDebug() << "qMRMLSceneFactoryWidget::deleteNode(" <<className <<") no node";
     return;
     }
-  vtkMRMLNode* node = d->MRMLScene->GetNthNodeByClass(rand() % numNodes, className.toUtf8());
+  vtkMRMLNode* node = d->MRMLScene->GetNthNodeByClass(d->RandomGenerator.generate() % numNodes, className.toUtf8());
   qDebug() << "qMRMLSceneFactoryWidget::deleteNode(" <<className <<") ==" << node->GetClassName();
   d->MRMLScene->RemoveNode(node);
   // FIXME: disable delete button when there is no more nodes in the scene to delete


### PR DESCRIPTION
When started multiple Slicer instances exactly at the same time, only one log file was created and MRB file loading was failed due to insufficient timestamp (1 second precision) and random number generation with uninitialized seed.

Fixed by adding a 3-digit random counter to log file name and switching to C++ random number generators.