### PR TITLE
BUG: Fix model slice display crash when lookup table node is null

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
@@ -605,7 +605,10 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
         // that lookup table original range.
         vtkSmartPointer<vtkLookupTable> dNodeLUT = vtkSmartPointer<vtkLookupTable>::Take(displayNode->GetColorNode() ?
           displayNode->GetColorNode()->CreateLookupTableCopy() : nullptr);
-        dNodeLUT->SetAlpha(hierarchyOpacity * displayNode->GetSliceIntersectionOpacity());
+        if (dNodeLUT)
+          {
+          dNodeLUT->SetAlpha(hierarchyOpacity * displayNode->GetSliceIntersectionOpacity());
+          }
         mapper->SetLookupTable(dNodeLUT);
         }
 


### PR DESCRIPTION
Loading a scene that used an invalid LUT for the model scalar overlay, would cause a crash.
Fixed by checking that the LUT exists before attempting to access it.