### PR TITLE
BUG: Fix crash when loading closed surface segmentations

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -923,6 +923,11 @@ int vtkMRMLSegmentationStorageNode::ReadPolyDataRepresentation(vtkMRMLSegmentati
     {
     // Get poly data representation
     vtkPolyData* currentPolyData = vtkPolyData::SafeDownCast(multiBlockDataset->GetBlock(blockIndex));
+    if (!currentPolyData)
+      {
+      vtkErrorMacro("ReadPolyDataRepresentation: Could not read block " << blockIndex);
+      continue;
+      }
 
     // Set master representation if it has not been set yet
     // (there is no global place to store it, but every segment field data contains a copy of it)


### PR DESCRIPTION
When loading a segmentation from closed surface, the vtkMRMLSegmentationStorageNode will cause a crash if one of the blocks in the seg.vtm is unable to be loaded. Fixed by checking that the block could be read before trying to access it, and logging an error message if it could not.

I haven't figured out what causes a segmentation to be written missing some blocks, but this fixes the error when it does occur.