### PR TITLE
BUG: Fix layout errors in qSlicerSaveDataDialog

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSaveDataDialog.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSaveDataDialog.ui
@@ -17,7 +17,54 @@
    <iconset resource="../qSlicerBaseQTGUI.qrc">
     <normaloff>:/Icons/SaveScene.png</normaloff>:/Icons/SaveScene.png</iconset>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,1,0,0">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,1,0,0,0,0">
+   <item row="0" column="1">
+    <widget class="QToolButton" name="SelectDataButton">
+     <property name="toolTip">
+      <string>select modified data only</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="icon">
+      <iconset resource="../qSlicerBaseQTGUI.qrc">
+       <normaloff>:/Icons/CheckModifiedData.png</normaloff>:/Icons/CheckModifiedData.png</iconset>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="5" colspan="2">
+    <widget class="QDialogButtonBox" name="ButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="4">
+    <widget class="ctkDirectoryButton" name="DirectoryButton">
+     <property name="text">
+      <string>Change directory for selected files</string>
+     </property>
+     <property name="options">
+      <set>ctkDirectoryButton::DontUseNativeDialog</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="6">
+    <widget class="QCheckBox" name="ShowMoreCheckBox">
+     <property name="text">
+      <string>Show options</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QToolButton" name="SelectSceneDataButton">
      <property name="toolTip">
@@ -38,7 +85,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="7">
+   <item row="1" column="0" colspan="8">
     <widget class="QTableWidget" name="FileWidget">
      <property name="editTriggers">
       <set>QAbstractItemView::AllEditTriggers</set>
@@ -84,61 +131,6 @@
        <string>Status</string>
       </property>
      </column>
-     <column>
-      <property name="text">
-       <string>Notes</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="2" column="4" colspan="2">
-    <widget class="QDialogButtonBox" name="ButtonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="4">
-    <widget class="ctkDirectoryButton" name="DirectoryButton">
-     <property name="text">
-      <string>Change directory for selected files</string>
-     </property>
-     <property name="options">
-      <set>ctkDirectoryButton::DontUseNativeDialog</set>
-     </property>
-     <property name="acceptMode">
-      <set>QFileDialog::AcceptSave</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QToolButton" name="SelectDataButton">
-     <property name="toolTip">
-      <string>select modified data only</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="../qSlicerBaseQTGUI.qrc">
-       <normaloff>:/Icons/CheckModifiedData.png</normaloff>:/Icons/CheckModifiedData.png</iconset>
-     </property>
-     <property name="iconSize">
-      <size>
-       <width>32</width>
-       <height>32</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="5">
-    <widget class="QCheckBox" name="ShowMoreCheckBox">
-     <property name="text">
-      <string>Show options</string>
-     </property>
     </widget>
    </item>
    <item row="0" column="2">
@@ -158,6 +150,13 @@
        <width>32</width>
        <height>32</height>
       </size>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="QLabel" name="ErrorLabel">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;Errors or warnings occurred while saving. See status icons for details.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>

--- a/Base/QTGUI/qSlicerSaveDataDialog_p.h
+++ b/Base/QTGUI/qSlicerSaveDataDialog_p.h
@@ -16,6 +16,7 @@
 #include <QDialog>
 #include <QDir>
 #include <QFileInfo>
+#include <QMessageBox>
 #include <QStyledItemDelegate>
 
 // Slicer includes
@@ -23,6 +24,7 @@
 #include "qSlicerSaveDataDialog.h"
 #include "ui_qSlicerSaveDataDialog.h"
 
+class ctkPathLineEdit;
 class vtkMRMLNode;
 class vtkMRMLStorableNode;
 class vtkObject;
@@ -81,8 +83,7 @@ protected:
     OptionsColumn = 3,
     NodeNameColumn = 4,
     NodeTypeColumn = 5,
-    NodeStatusColumn = 6,
-    UserMessagesColumn = 7
+    NodeStatusColumn = 6
   };
 
   enum CustomRole
@@ -94,11 +95,10 @@ protected:
 
   int               findSceneRow()const;
   bool              mustSceneBeSaved()const;
-  bool              prepareForSaving();
-  void              restoreAfterSaving();
   void              setSceneRootDirectory(const QString& rootDirectory);
   void              updateOptionsWidget(int row);
-  void              updateUserMessagesItem(int row);
+  void              updateStatusIconFromStorageNode(int row);
+  void              setStatusIcon(int row, QIcon& icon, const QString& message);
 
   QString           sceneFileFormat()const;
 
@@ -111,10 +111,8 @@ protected:
   QTableWidgetItem* createNodeStatusItem(vtkMRMLStorableNode* node, const QFileInfo& fileInfo);
   QWidget*          createFileFormatsWidget(vtkMRMLStorableNode* node, QFileInfo& fileInfo);
   QTableWidgetItem* createFileNameItem(const QFileInfo& fileInfo, const QString& extension, const QString& nodeID);
-  ctkDirectoryButton* createFileDirectoryWidget(const QFileInfo& fileInfo);
-  QWidget*          createUserMessagesItem(vtkMRMLStorableNode *node);
-  void              makeUserMessages(vtkMRMLStorableNode *node, QWidget *userMessagesLayoutItem);
-  void              clearUserMessages();
+  ctkPathLineEdit*  createFileDirectoryWidget(const QFileInfo& fileInfo);
+  void              clearUserMessagesInStorageNodes();
 
   static QString extractKnownExtension(const QString& fileName, vtkObject* object);
   static QString stripKnownExtension(const QString& fileName, vtkObject* object);
@@ -125,6 +123,8 @@ protected:
   QString           type(int row)const;
   qSlicerIOOptions* options(int row)const;
 
+  bool confirmOverwrite(const QString& filepath);
+
   /// Helper function for finding a node in the main scene and all scene view scenes
   vtkMRMLNode*      getNodeByID(char *id)const;
 
@@ -133,6 +133,11 @@ protected:
 
   // Items are currently being added to the scene, indicates that no GUI updates should be performed.
   bool PopulatingItems;
+
+  QMessageBox::StandardButton ConfirmOverwriteAnswer;
+  bool CancelRequested;
+  QIcon WarningIcon;
+  QIcon ErrorIcon;
 
   friend class qSlicerFileNameItemDelegate;
 };


### PR DESCRIPTION
Fix the following problems in qSlicerSaveDataDialog:
- when a long directory path was used then the dialog did not fit the screen on some systems and "Save" button was not visible (fixed by using ctkPathLineEdit instead of ctkDirectoryButton)
- fixed lots of widgets appearing and disappearing before save dialog is shown (recent regression introduced by status icon display)
- remove separate "Notes" column for saving status (added icon to filename column instead, where it is much more visible, take less space, and simpler to implement)
- fix deselection of successfully saved items

![image](https://user-images.githubusercontent.com/307929/90473522-1c9cce00-e0f1-11ea-9a6b-9a6bb42ef88b.png)

Also add warning if saving in Analyze format or rotated volume in VTK format - fixes #2443
