### PR TITLE
ENH: Prevent horizontal resizing of module panel by data probe widget

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -412,11 +412,10 @@ class DataProbeInfoWidget(object):
     self.viewerFrame.setLayout(qt.QHBoxLayout())
     self.frame.layout().addWidget(self.viewerFrame)
     self.viewerColor = qt.QLabel(self.viewerFrame)
+    self.viewerColor.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Preferred)
     self.viewerFrame.layout().addWidget(self.viewerColor)
     self.viewInfo = qt.QLabel()
     self.viewerFrame.layout().addWidget(self.viewInfo)
-
-    self.viewerFrame.layout().addStretch(1)
 
     def _setFixedFontFamily(widget, family=None):
       if family is None:
@@ -424,7 +423,7 @@ class DataProbeInfoWidget(object):
       font = widget.font
       font.setFamily(family)
       widget.font = font
-
+      widget.wordWrap = True
     _setFixedFontFamily(self.viewInfo)
 
     # the grid - things about the layers


### PR DESCRIPTION
Enables word wrap on the text of the data probe widget to prevent constant resizing of the module panel.