### PR TITLE
BUG: Update EditBox.py to use setExclusive method

### DIFF
--- a/Modules/Scripted/EditorLib/EditBox.py
+++ b/Modules/Scripted/EditorLib/EditBox.py
@@ -34,7 +34,7 @@ class EditBox(VTKObservationMixin):
     self.effectCursors = {}
     self.effectActionGroup = qt.QActionGroup(parent)
     self.effectActionGroup.connect('triggered(QAction*)', self._onEffectActionTriggered)
-    self.effectActionGroup.exclusive = True
+    self.effectActionGroup.setExclusive(True)
     self.currentEffect = None
     self.undoRedo = UndoRedo()
     self.undoRedo.stateChangedCallback = self.updateUndoRedoButtons


### PR DESCRIPTION
Use method to enable the group exclusion checking property.
Direct assignment of this property results in the message:
      AttributeError: 'exclusive' does not exist on QActionGroup and creating new attributes on C++ objects is not allowed
and the EditBox will not open.