### PR TITLE
ENH: Add option to render markups on top of everything else

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -102,6 +102,9 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->LineColorFadingSaturation = 1.;
   this->LineColorFadingHueOffset = 0.;
 
+  this->OccludedVisibility = false;
+  this->OccludedOpacity = 0.3;
+
   this->HandlesInteractive = false;
 
   // Line color node
@@ -147,6 +150,8 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(outlineVisibility, OutlineVisibility);
   vtkMRMLWriteXMLFloatMacro(fillOpacity, FillOpacity);
   vtkMRMLWriteXMLFloatMacro(outlineOpacity, OutlineOpacity);
+  vtkMRMLWriteXMLBooleanMacro(occludedVisibility, OccludedVisibility);
+  vtkMRMLWriteXMLFloatMacro(occludedOpacity, OccludedOpacity);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -183,6 +188,8 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(outlineVisibility, OutlineVisibility);
   vtkMRMLReadXMLFloatMacro(fillOpacity, FillOpacity);
   vtkMRMLReadXMLFloatMacro(outlineOpacity, OutlineOpacity);
+  vtkMRMLReadXMLBooleanMacro(occludedVisibility, OccludedVisibility);
+  vtkMRMLReadXMLFloatMacro(occludedOpacity, OccludedOpacity);
   vtkMRMLReadXMLEndMacro();
 
   // Fix up legacy markups fiducial nodes
@@ -247,6 +254,8 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   vtkMRMLCopyBooleanMacro(OutlineVisibility);
   vtkMRMLCopyFloatMacro(FillOpacity);
   vtkMRMLCopyFloatMacro(OutlineOpacity);
+  vtkMRMLCopyBooleanMacro(OccludedVisibility);
+  vtkMRMLCopyFloatMacro(OccludedOpacity);
   vtkMRMLCopyEndMacro();
 }
 
@@ -425,6 +434,8 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(OutlineVisibility);
   vtkMRMLPrintFloatMacro(FillOpacity);
   vtkMRMLPrintFloatMacro(OutlineOpacity);
+  vtkMRMLPrintBooleanMacro(OccludedVisibility);
+  vtkMRMLPrintFloatMacro(OccludedOpacity);
   vtkMRMLPrintEndMacro();
 }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -373,6 +373,19 @@ public:
   vtkMRMLProceduralColorNode* GetLineColorNode();
   virtual const char* GetLineColorNodeReferenceRole();
 
+  /// Displays the occluded regions of the markup on top of other objects.
+  /// Opacity can be adjusted with OccludedOpacity
+  /// \sa SetOccludedOpacity, GetOccludedOpacity
+  vtkGetMacro(OccludedVisibility, bool);
+  vtkSetMacro(OccludedVisibility, bool);
+  vtkBooleanMacro(OccludedVisibility, bool);
+
+  /// Opacity of the occluded parts of the markup.
+  /// 0.0 results in the markup being fully transparent, while 1.0 is fully opaque.
+  /// \sa SetOccludedVisibility, GetOccludedVisibility
+  vtkGetMacro(OccludedOpacity, double);
+  vtkSetMacro(OccludedOpacity, double);
+
   /// The visibility and interactability of the interaction handles
   vtkGetMacro(HandlesInteractive, bool);
   vtkSetMacro(HandlesInteractive, bool);
@@ -421,6 +434,9 @@ protected:
   double LineColorFadingEnd;
   double LineColorFadingSaturation;
   double LineColorFadingHueOffset;
+
+  bool OccludedVisibility;
+  double OccludedOpacity;
 
   bool HandlesInteractive;
 };

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
@@ -87,6 +87,12 @@ protected:
   vtkSmartPointer<vtkTubeFilter>              TubeFilter;
   vtkSmartPointer<vtkTubeFilter>              ArcTubeFilter;
 
+  vtkSmartPointer<vtkPolyDataMapper>    LineOccludedMapper;
+  vtkSmartPointer<vtkActor>             LineOccludedActor;
+
+  vtkSmartPointer<vtkPolyDataMapper>    ArcOccludedMapper;
+  vtkSmartPointer<vtkActor>             ArcOccludedActor;
+
   void BuildArc();
 
   // Update visibility of interaction handles for representation

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.h
@@ -84,6 +84,9 @@ protected:
   vtkSmartPointer<vtkPolyDataMapper> LineMapper;
   vtkSmartPointer<vtkActor> LineActor;
 
+  vtkSmartPointer<vtkPolyDataMapper> LineOccludedMapper;
+  vtkSmartPointer<vtkActor> LineOccludedActor;
+
   vtkSmartPointer<vtkTubeFilter> TubeFilter;
 
   vtkSmartPointer<vtkCellLocator> CurvePointLocator;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -51,6 +51,13 @@ vtkSlicerLineRepresentation3D::vtkSlicerLineRepresentation3D()
   this->LineActor->SetMapper(this->LineMapper);
   this->LineActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
 
+  this->LineOccludedMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  this->LineOccludedMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
+
+  this->LineOccludedActor = vtkSmartPointer<vtkActor>::New();
+  this->LineOccludedActor->SetMapper(this->LineOccludedMapper);
+  this->LineOccludedActor->SetProperty(this->GetControlPointsPipeline(Unselected)->OccludedProperty);
+
   this->HideTextActorIfAllPointsOccluded = true;
 }
 
@@ -62,6 +69,7 @@ void vtkSlicerLineRepresentation3D::GetActors(vtkPropCollection *pc)
 {
   this->Superclass::GetActors(pc);
   this->LineActor->GetActors(pc);
+  this->LineOccludedActor->GetActors(pc);
 }
 
 //----------------------------------------------------------------------
@@ -70,6 +78,7 @@ void vtkSlicerLineRepresentation3D::ReleaseGraphicsResources(
 {
   this->Superclass::ReleaseGraphicsResources(win);
   this->LineActor->ReleaseGraphicsResources(win);
+  this->LineOccludedActor->ReleaseGraphicsResources(win);
 }
 
 //----------------------------------------------------------------------
@@ -80,6 +89,10 @@ int vtkSlicerLineRepresentation3D::RenderOverlay(vtkViewport *viewport)
   if (this->LineActor->GetVisibility())
     {
     count +=  this->LineActor->RenderOverlay(viewport);
+    }
+  if (this->LineOccludedActor->GetVisibility())
+    {
+    count +=  this->LineOccludedActor->RenderOverlay(viewport);
     }
   return count;
 }
@@ -97,6 +110,10 @@ int vtkSlicerLineRepresentation3D::RenderOpaqueGeometry(
     this->TubeFilter->SetRadius(diameter * 0.5);
     count += this->LineActor->RenderOpaqueGeometry(viewport);
     }
+  if (this->LineOccludedActor->GetVisibility())
+    {
+    count += this->LineOccludedActor->RenderOpaqueGeometry(viewport);
+    }
   return count;
 }
 
@@ -113,6 +130,13 @@ int vtkSlicerLineRepresentation3D::RenderTranslucentPolygonalGeometry(
     this->LineActor->SetPropertyKeys(this->GetPropertyKeys());
     count += this->LineActor->RenderTranslucentPolygonalGeometry(viewport);
     }
+  if (this->LineOccludedActor->GetVisibility())
+    {
+    // The internal actor needs to share property keys.
+    // This ensures the mapper state is consistent and allows depth peeling to work as expected.
+    this->LineOccludedActor->SetPropertyKeys(this->GetPropertyKeys());
+    count += this->LineOccludedActor->RenderTranslucentPolygonalGeometry(viewport);
+    }
   return count;
 }
 
@@ -124,6 +148,10 @@ vtkTypeBool vtkSlicerLineRepresentation3D::HasTranslucentPolygonalGeometry()
     return true;
     }
   if (this->LineActor->GetVisibility() && this->LineActor->HasTranslucentPolygonalGeometry())
+    {
+    return true;
+    }
+  if (this->LineOccludedActor->GetVisibility() && this->LineOccludedActor->HasTranslucentPolygonalGeometry())
     {
     return true;
     }
@@ -163,6 +191,7 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
   // Line display
 
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
+  this->UpdateOccludedRelativeCoincidentTopologyOffsets(this->LineOccludedMapper);
 
   double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
     this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
@@ -176,6 +205,11 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
     }
   this->LineActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->Property);
   this->TextActor->SetTextProperty(this->GetControlPointsPipeline(controlPointType)->TextProperty);
+
+  this->LineOccludedActor->SetProperty(this->GetControlPointsPipeline(controlPointType)->OccludedProperty);
+  this->LineOccludedActor->SetVisibility(this->MarkupsDisplayNode
+    && this->LineActor->GetVisibility()
+    && this->MarkupsDisplayNode->GetOccludedVisibility());
 
   if (markupsNode->GetNumberOfDefinedControlPoints(true) == 2 && this->GetAllControlPointsVisible())
     {
@@ -235,7 +269,7 @@ void vtkSlicerLineRepresentation3D::PrintSelf(ostream& os, vtkIndent indent)
 //-----------------------------------------------------------------------------
 void vtkSlicerLineRepresentation3D::UpdateInteractionPipeline()
 {
-  if (this->MarkupsNode->GetNumberOfDefinedControlPoints(true) < 2)
+  if (!this->MarkupsNode || this->MarkupsNode->GetNumberOfDefinedControlPoints(true) < 2)
     {
     this->InteractionPipeline->Actor->SetVisibility(false);
     return;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
@@ -80,6 +80,9 @@ protected:
   vtkSmartPointer<vtkPolyDataMapper> LineMapper;
   vtkSmartPointer<vtkActor> LineActor;
 
+  vtkSmartPointer<vtkPolyDataMapper> LineOccludedMapper;
+  vtkSmartPointer<vtkActor> LineOccludedActor;
+
   vtkSmartPointer<vtkTubeFilter> TubeFilter;
 
 private:

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -92,6 +92,9 @@ vtkSlicerMarkupsWidget::vtkSlicerMarkupsWidget()
   this->SetEventTranslation(WidgetStateIdle, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
   this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
   this->SetEventTranslation(WidgetStateDefine, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+
+  this->SetKeyboardEventTranslation(WidgetStateDefine, vtkEvent::AnyModifier, 0, 0, "Shift_L", WidgetEventMouseMove);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::AnyModifier, 0, 0, "Shift_L", WidgetEventMouseMove);
 }
 
 //----------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -85,6 +85,11 @@ public:
   /// Useful for non-regression tests that need to inspect internal state of the widget.
   bool GetNthControlPointViewVisibility(int n);
 
+  /// Relative offset used for rendering occluded actors.
+  /// Default value is -25000.
+  vtkSetMacro(OccludedRelativeOffset, double);
+  vtkGetMacro(OccludedRelativeOffset, double);
+
 protected:
   vtkSlicerMarkupsWidgetRepresentation3D();
   ~vtkSlicerMarkupsWidgetRepresentation3D() override;
@@ -113,6 +118,15 @@ protected:
     // Properties used to control the appearance of selected objects and
     // the manipulator in general.
     vtkSmartPointer<vtkProperty> Property;
+
+    vtkSmartPointer<vtkPointSetToLabelHierarchy> OccludedPointSetToLabelHierarchyFilter;
+    vtkSmartPointer<vtkLabelPlacementMapper> LabelsOccludedMapper;
+    vtkSmartPointer<vtkActor2D> LabelsOccludedActor;
+    vtkSmartPointer<vtkTextProperty> OccludedTextProperty;
+
+    vtkSmartPointer<vtkPolyDataMapper> OccludedMapper;
+    vtkSmartPointer<vtkActor> OccludedActor;
+    vtkSmartPointer<vtkProperty> OccludedProperty;
   };
 
   ControlPointsPipeline3D* GetControlPointsPipeline(int controlPointType);
@@ -121,11 +135,20 @@ protected:
 
   virtual void UpdateAllPointsAndLabelsFromMRML();
 
+  /// Update the occluded relative offsets for an occluded mapper
+  /// Allows occluded regions to be rendered on top.
+  /// Sets the folowing parameter on the mappers:
+  /// - RelativeCoincidentTopologyLineOffsetParameters
+  /// - RelativeCoincidentTopologyPolygonOffsetParameters
+  /// - RelativeCoincidentTopologyPointOffsetParameter
+  virtual void UpdateOccludedRelativeCoincidentTopologyOffsets(vtkMapper* mapper);
+
   vtkSmartPointer<vtkCellPicker> AccuratePicker;
 
   double TextActorPositionWorld[3];
   bool TextActorOccluded;
   bool HideTextActorIfAllPointsOccluded;
+  double OccludedRelativeOffset;
 
 private:
   vtkSlicerMarkupsWidgetRepresentation3D(const vtkSlicerMarkupsWidgetRepresentation3D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
@@ -100,6 +100,9 @@ protected:
   vtkNew<vtkPolyDataMapper>  PlaneMapper;
   vtkNew<vtkActor>           PlaneActor;
 
+  vtkNew<vtkPolyDataMapper>  PlaneOccludedMapper;
+  vtkNew<vtkActor>           PlaneOccludedActor;
+
   vtkNew<vtkLookupTable>    PlaneColorLUT;
 
   std::string LabelFormat;

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>244</width>
-    <height>113</height>
+    <width>320</width>
+    <height>137</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -133,78 +133,15 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="2" column="0">
-       <widget class="QLabel" name="unselectedColorLabel">
-        <property name="text">
-         <string>Unselected Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="DisplayNodeViewLabel">
-        <property name="text">
-         <string>View:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QCheckBox" name="FillVisibilityCheckBox">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="OpacityLabel3">
-          <property name="text">
-           <string>Opacity:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ctkSliderWidget" name="FillOpacitySliderWidget">
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
-        <property name="toolTip">
-         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="selectedColorLabel">
-        <property name="text">
-         <string>Selected Color:</string>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="glyphTypeLabel">
         <property name="text">
          <string>Glyph Type:</string>
         </property>
        </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="glyphTypeComboBox"/>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="OutlineLabel">
@@ -213,14 +150,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
+      <item row="9" column="0">
        <widget class="QLabel" name="PointLabelsVisibilityLabel">
         <property name="text">
          <string>Point Labels:</string>
@@ -257,33 +187,6 @@
          </widget>
         </item>
        </layout>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="FillLabel">
-        <property name="text">
-         <string>Fill:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="glyphTypeComboBox"/>
-      </item>
-      <item row="9" column="0" colspan="2">
-       <widget class="qMRMLMarkupsFiducialProjectionPropertyWidget" name="pointFiducialProjectionWidget"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="lineThicknessLabel">
-        <property name="text">
-         <string>Line Thickness:</string>
-        </property>
-       </widget>
       </item>
       <item row="4" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -336,6 +239,180 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
+        <property name="toolTip">
+         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0" colspan="2">
+       <widget class="ctkCollapsibleGroupBox" name="ThreeDDisplayGroupBox">
+        <property name="title">
+         <string>3D Display</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="OccludedVisibilityLabel">
+           <property name="text">
+            <string>Occluded Visibility:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QCheckBox" name="OccludedVisibilityCheckBox">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="OpacityLabel">
+             <property name="text">
+              <string>Opacity:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="ctkSliderWidget" name="OccludedOpacitySliderWidget">
+             <property name="singleStep">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="pageStep">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QCheckBox" name="FillVisibilityCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="OpacityLabel3">
+          <property name="text">
+           <string>Opacity:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="FillOpacitySliderWidget">
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="FillLabel">
+        <property name="text">
+         <string>Fill:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="DisplayNodeViewLabel">
+        <property name="text">
+         <string>View:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="lineThicknessLabel">
+        <property name="text">
+         <string>Line Thickness:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="unselectedColorLabel">
+        <property name="text">
+         <string>Unselected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="selectedColorLabel">
+        <property name="text">
+         <string>Selected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0" colspan="2">
+       <widget class="ctkCollapsibleGroupBox" name="TwoDDisplayGroupBox">
+        <property name="title">
+         <string>2D Display</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="qMRMLMarkupsFiducialProjectionPropertyWidget" name="pointFiducialProjectionWidget"/>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsFiducialProjectionPropertyWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsFiducialProjectionPropertyWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>281</width>
-    <height>145</height>
+    <width>280</width>
+    <height>102</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -21,53 +21,41 @@
   </property>
   <layout class="QFormLayout" name="formLayout">
    <property name="labelAlignment">
-    <set>Qt::AlignCenter</set>
+    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
    </property>
    <property name="formAlignment">
     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
    </property>
-   <property name="margin">
+   <property name="topMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
+   <property name="rightMargin">
+    <number>5</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="1" column="0">
     <widget class="QLabel" name="point2DProjectionLabel">
      <property name="toolTip">
       <string>Turn on/off visualization of projected fiducial on 2D viewers</string>
      </property>
      <property name="text">
-      <string>2D Projection</string>
+      <string>Projection Visibility:</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="ctkCheckBox" name="point2DProjectionCheckBox">
-     <property name="toolTip">
-      <string>Turn on/off visualization of projected fiducial on 2D viewers</string>
-     </property>
-     <property name="indicatorIcon">
-      <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
-       <normaloff>:/Icons/XLarge/SlicerVisible.png</normaloff>
-       <normalon>:/Icons/XLarge/SlicerInvisible.png</normalon>:/Icons/XLarge/SlicerVisible.png</iconset>
-     </property>
-     <property name="indicatorIconSize">
-      <size>
-       <width>23</width>
-       <height>23</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="pointProjectionColorLabel">
      <property name="toolTip">
       <string>Color of the projected fiducial on 2D viewers</string>
      </property>
      <property name="text">
-      <string>Projection Color</string>
+      <string>Projection Color:</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="ctkColorPickerButton" name="pointProjectionColorPickerButton">
      <property name="minimumSize">
       <size>
@@ -93,17 +81,17 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="pointOutlinedBehindSlicePlaneLabel">
      <property name="toolTip">
       <string>Fiducial projection is displayed filled (opacity = Projection Opacity) when on top of slice plane, outlined when behind, and with full opacity when in the plane. Outline isn't used for some glyphs (Dash2D, Cross2D, Starburst).</string>
      </property>
      <property name="text">
-      <string>Outlined Behind Slice Plane</string>
+      <string>Outlined Behind Slice Plane:</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QCheckBox" name="pointOutlinedBehindSlicePlaneCheckBox">
      <property name="toolTip">
       <string>Fiducial projection is displayed filled (opacity = Projection Opacity) when on top of slice plane, outlined when behind, and with full opacity when in the plane. Outline isn't used for some glyphs (Dash2D, Cross2D, Starburst).</string>
@@ -116,17 +104,17 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="pointUseFiducialColorLabel">
      <property name="toolTip">
       <string>Use the same color as fiducial</string>
      </property>
      <property name="text">
-      <string>Use Fiducial Color</string>
+      <string>Use Fiducial Color:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1">
     <widget class="QCheckBox" name="pointUseFiducialColorCheckBox">
      <property name="toolTip">
       <string>Use the same color as fiducial</string>
@@ -139,28 +127,45 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="projectionOpacityLabel">
-     <property name="text">
-      <string>Projection Opacity</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="ctkSliderWidget" name="projectionOpacitySliderWidget">
-     <property name="toolTip">
-      <string>The opacity of the projection.</string>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>1.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>0.6</double>
-     </property>
-    </widget>
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="ctkCheckBox" name="point2DProjectionCheckBox">
+       <property name="toolTip">
+        <string>Turn on/off visualization of projected fiducial on 2D viewers</string>
+       </property>
+       <property name="indicatorIconSize">
+        <size>
+         <width>23</width>
+         <height>23</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="projectionOpacityLabel">
+       <property name="text">
+        <string>Opacity:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ctkSliderWidget" name="projectionOpacitySliderWidget">
+       <property name="toolTip">
+        <string>The opacity of the projection.</string>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.600000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -112,7 +112,11 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
   QObject::connect(this->OutlineOpacitySliderWidget, SIGNAL(valueChanged(double)),
     q, SLOT(onOutlineOpacitySliderWidgetChanged(double)));
 
-    // populate the glyph type combo box
+  QObject::connect(this->OccludedVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setOccludedVisibility(bool)));
+  QObject::connect(this->OccludedOpacitySliderWidget, SIGNAL(valueChanged(double)),
+    q, SLOT(setOccludedOpacity(double)));
+
+  // populate the glyph type combo box
   if (this->glyphTypeComboBox->count() == 0)
     {
     vtkNew<vtkMRMLMarkupsDisplayNode> displayNode;
@@ -325,6 +329,14 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
   wasBlocking = d->OutlineOpacitySliderWidget->blockSignals(true);
   d->OutlineOpacitySliderWidget->setValue(d->MarkupsDisplayNode ? d->MarkupsDisplayNode->GetOutlineOpacity() : 0.0);
   d->OutlineOpacitySliderWidget->blockSignals(wasBlocking);
+
+  wasBlocking = d->OccludedVisibilityCheckBox->blockSignals(true);
+  d->OccludedVisibilityCheckBox->setChecked(d->MarkupsDisplayNode ? d->MarkupsDisplayNode->GetOccludedVisibility() : false);
+  d->OccludedVisibilityCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->OccludedOpacitySliderWidget->blockSignals(true);
+  d->OccludedOpacitySliderWidget->setValue(d->MarkupsDisplayNode ? d->MarkupsDisplayNode->GetOccludedOpacity() : 0.0);
+  d->OccludedOpacitySliderWidget->blockSignals(wasBlocking);
 
   emit displayNodeChanged();
 }
@@ -596,4 +608,26 @@ void qMRMLMarkupsDisplayNodeWidget::onOutlineOpacitySliderWidgetChanged(double o
     return;
     }
   d->MarkupsDisplayNode->SetOutlineOpacity(opacity);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setOccludedVisibility(bool visibility)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetOccludedVisibility(visibility);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setOccludedOpacity(double OccludedOpacity)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetOccludedOpacity(OccludedOpacity);
 }

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
@@ -91,6 +91,8 @@ public slots:
   void setOutlineVisibility(bool visibility);
   void onFillOpacitySliderWidgetChanged(double opacity);
   void onOutlineOpacitySliderWidgetChanged(double opacity);
+  void setOccludedVisibility(bool visibility);
+  void setOccludedOpacity(double OccludedOpacity);
 
 protected slots:
   void updateWidgetFromMRML();


### PR DESCRIPTION
By enabling vtkMRMLMarkupsDisplayNode::AlwaysOnTop, the markup widget will be rendered on top of all other objects in the scene.
This option can be toggled on and off from the markups display node ui.