### PR TITLE
BUG: Fix invalid use of QActionGroup exclusive attribute

### DIFF
--- a/Modules/Scripted/EditorLib/EditBox.py
+++ b/Modules/Scripted/EditorLib/EditBox.py
@@ -34,7 +34,7 @@ class EditBox(VTKObservationMixin):
     self.effectCursors = {}
     self.effectActionGroup = qt.QActionGroup(parent)
     self.effectActionGroup.connect('triggered(QAction*)', self._onEffectActionTriggered)
-    self.effectActionGroup.exclusive = True
+    self.effectActionGroup.setExclusive(True)
     self.currentEffect = None
     self.undoRedo = UndoRedo()
     self.undoRedo.stateChangedCallback = self.updateUndoRedoButtons


### PR DESCRIPTION
The exclusive attribute for QActionGroup was replaced starting in Qt 5.14 with the exclusionPolicy attribute. Using the setExclusive method will set the exclusive or exclusionPolicy attribute depending on the Qt 5 version being used.

Reference: https://github.com/Slicer/Slicer/pull/5127