### PR TITLE
BUG: Prevent cropping of segments imported from models

### DIFF
--- a/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.cxx
@@ -434,6 +434,5 @@ std::string vtkClosedSurfaceToBinaryLabelmapConversionRule::GetDefaultImageGeome
 
   // Serialize geometry
   std::string serializedGeometry = vtkSegmentationConverter::SerializeImageGeometry(geometryMatrix, extent);
-  this->ConversionParameters[vtkSegmentationConverter::GetReferenceImageGeometryParameterName()].first = serializedGeometry;
   return serializedGeometry;
 }

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -1997,6 +1997,13 @@ std::string vtkSegmentation::DetermineCommonLabelmapGeometry(int extentComputati
       return std::string("");
       }
     referenceGeometryString = vtkSegmentationConverter::SerializeImageGeometry(highestResolutionLabelmap);
+
+    // We were supposed to use the extent from the reference geometry string, however it did  not exist.
+    // Instead, calculate extent from effective extent of segments.
+    if (extentComputationMode == EXTENT_REFERENCE_GEOMETRY)
+      {
+      extentComputationMode = EXTENT_UNION_OF_EFFECTIVE_SEGMENTS;
+      }
     }
 
   vtkSmartPointer<vtkOrientedImageData> commonGeometryImage = vtkSmartPointer<vtkOrientedImageData>::New();


### PR DESCRIPTION
If the reference geometry conversion parameter had not been set, performing a closed surface to binary labelmap conversion would create the reference geometry if it didn't already exist, setting it to the geometry of the first imported model. This caused all subsequent models to be cropped to the same extent as the first one when exported or saved as labelmap.

Fixed by not setting the reference image geometry from vtkClosedSurfaceToBinaryLabelmapConversionRule, and by calculating extent from the union of segments in vtkSegmentation::DetermineCommonLabelmapGeometry if the reference geometry was not specified, and the extent mode was EXTENT_REFERENCE_GEOMETRY.

fixes #5093