### PR TITLE
BUG: remove unavailable extension suggestion

### DIFF
--- a/Modules/Scripted/DICOM/DICOMExtensions.json
+++ b/Modules/Scripted/DICOM/DICOMExtensions.json
@@ -1,16 +1,6 @@
 {
   "extensions": [
     {
-      "name": "LongitudinalPETCT",
-      "repository": "https://github.com/QIICR/LongitudinalPETCT",
-      "typeDescription": "PET Images",
-      "tagValues": {
-        "Modality": [
-          "PT"
-        ]
-      }
-    },
-    {
       "name": "PETDICOMExtension",
       "repository": "https://github.com/QIICR/Slicer-PETDICOMExtension.git",
       "typeDescription": "PET Images and real world value mappings",


### PR DESCRIPTION
Since the Longitudinal PET/CT extension
is not currently available, remove
it from the suggestion list for now.

Longer term: once the new extension manager
is in place, consider auto-generating
suggestions based on a query of available
extension.  We should also explore adding
tags to s4ext files that could explicitly
declare the data types they are appropriate
for.

Co-authored-by: Andras Lasso <lasso@queensu.ca>
Co-authored-by: Sonia Pujol <spujol@bwh.harvard.edu>