### PR TITLE
ENH: Add option to toggle the markup measurements included in the des…

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.cxx
@@ -38,6 +38,8 @@ vtkMRMLMarkupsAngleNode::vtkMRMLMarkupsAngleNode()
 {
   this->MaximumNumberOfControlPoints = 3;
   this->RequiredNumberOfControlPoints = 3;
+
+  this->MeasurementsInDescription = { "angle" };
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -97,6 +97,8 @@ vtkMRMLMarkupsCurveNode::vtkMRMLMarkupsCurveNode()
   this->AddNodeReferenceRole(this->GetShortestDistanceSurfaceNodeReferenceRole(), this->GetShortestDistanceSurfaceNodeReferenceMRMLAttributeName(), events);
 
   this->ActiveScalar = "";
+
+  this->MeasurementsInDescription = { "length" };
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.cxx
@@ -39,6 +39,8 @@ vtkMRMLMarkupsLineNode::vtkMRMLMarkupsLineNode()
 {
   this->MaximumNumberOfControlPoints = 2;
   this->RequiredNumberOfControlPoints = 2;
+
+  this->MeasurementsInDescription = { "length" };
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -26,6 +26,9 @@
 // Markups includes
 #include "vtkSlicerMarkupsModuleMRMLExport.h"
 
+// vktAddon includes
+#include <vtkAddonSetGet.h>
+
 // VTK includes
 #include <vtkPointLocator.h>
 #include <vtkSmartPointer.h>
@@ -578,6 +581,11 @@ public:
 
   virtual std::string GetPropertiesLabelText();
 
+  /// List of measurements that should be added to the discription in WriteMeasurementsToDescription.
+  /// Affects the measurements included in the 3D/Slice view labels, and in the markups tree view description.
+  vtkGetStdVectorMacro(MeasurementsInDescription, std::vector<std::string>);
+  void SetMeasurementsInDescription(const std::vector<std::string> measurementsInDescription);
+
 protected:
   vtkMRMLMarkupsNode();
   ~vtkMRMLMarkupsNode() override;
@@ -626,6 +634,7 @@ protected:
 
   /// Helper function to write measurements to node Description property.
   /// This is a short-term solution until measurements display is properly implemented.
+  /// The measurements that are written to the description can be controlled by MeasurementsInDescription.
   virtual void WriteMeasurementsToDescription();
 
   /// Calculates the handle to world matrix based on the current control points
@@ -675,6 +684,7 @@ protected:
   vtkVector3d CenterPos;
 
   std::vector< vtkSmartPointer<vtkMRMLMeasurement> > Measurements;
+  std::vector<std::string> MeasurementsInDescription;
 
   std::string PropertiesLabelText;
 

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -98,6 +98,14 @@ public:
   /// \param eventData Supplementary data for the item that may be considered for the menu (sub-item ID, attribute, etc.)
   void showViewContextMenuActionsForItem(vtkIdType itemID, QVariantMap eventData) override;
 
+  /// Get view context menu item actions that are available when right-clicking an object in the views.
+  /// These item context menu actions can be shown in the implementations of \sa showViewContextMenuActionsForItem
+  QList<QAction*> itemContextMenuActions()const override;
+
+  /// Show context menu actions valid for a given subject hierarchy item.
+  /// \param itemID Subject Hierarchy item to show the context menu items for
+  void showContextMenuActionsForItem(vtkIdType itemID) override;
+
 protected slots:
   /// Called when clicking on rename point action
   void renamePoint();
@@ -107,7 +115,8 @@ protected slots:
   void toggleSelectPoint();
   /// Called when clicking on handle interactive action
   void toggleHandleInteractive();
-
+  /// Called when clicking on a measurement action
+  void toggleMeasurement();
 protected:
   QScopedPointer<qSlicerSubjectHierarchyMarkupsPluginPrivate> d_ptr;
 


### PR DESCRIPTION
…cription

Adds the MeasurementsInDescription attribute to vtkMRMLMarkupsNode, that controls the markups added to the description by WriteMeasurementsToDescription.
If MeasurementsInDescription is empty, then the description will be empty, and the measurement label in the 3D/2D views will not be displayed.

MeasurementsInDescription can be controlled from the markups subject hierarchy plugin. Each measurement adds a checkbox to the context menu to enable/disable display.

![image](https://user-images.githubusercontent.com/9222709/91242071-6c445080-e714-11ea-80b6-7fd4e67bf967.png)
