### PR TITLE
Add support for building against VTK 8.2.0 or VTK 9.0.0

### DIFF
--- a/Base/Logic/CMakeLists.txt
+++ b/Base/Logic/CMakeLists.txt
@@ -158,7 +158,7 @@ endif()
 
 if(Slicer_USE_PYTHONQT)
   set(VTK_COMMON_PYTHON_LIBRARY
-    vtkWrappingPythonCore # For vtkPythonUtil
+    ${VTK_TARGET_PREFIX}WrappingPythonCore # For vtkPythonUtil
     )
   list(APPEND libs
     ${VTK_COMMON_PYTHON_LIBRARY}
@@ -195,18 +195,32 @@ install(TARGETS ${lib_name}
 if(VTK_WRAP_PYTHON)
   include(vtkMacroKitPythonWrap)
 
+  set(_python_wrapped_libraries
+    )
+
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    list(APPEND _python_wrapped_libraries
+      MRMLLogicPythonD
+      )
+  endif()
+
   vtkMacroKitPythonWrap(
     KIT_NAME ${lib_name}
     KIT_SRCS ${SlicerBaseLogic_SRCS}
-    KIT_PYTHON_LIBRARIES MRMLLogicPythonD
+    KIT_PYTHON_LIBRARIES ${_python_wrapped_libraries}
     KIT_INSTALL_BIN_DIR ${Slicer_INSTALL_BIN_DIR}
     KIT_INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR}
     )
   # Export target
-  set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${lib_name}Python ${lib_name}PythonD)
+  set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${lib_name}Python)
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${lib_name}PythonD)
+  endif()
 
   set_target_properties(${lib_name}Python PROPERTIES FOLDER "Core-Base")
-  set_target_properties(${lib_name}PythonD PROPERTIES FOLDER "Core-Base")
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    set_target_properties(${lib_name}PythonD PROPERTIES FOLDER "Core-Base")
+  endif()
   if(TARGET ${lib_name}Hierarchy)
     set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER "Core-Base")
   endif()

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -155,7 +155,7 @@ def importModuleObjects(from_module_name, dest_module_name, type_info):
   dest_module = sys.modules[dest_module_name]
 
   # Skip if module has already been loaded
-  if from_module_name in sys.modules:
+  if from_module_name in dir(dest_module):
     return
 
   # Obtain a reference to the module identified by 'from_module_name'

--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -64,6 +64,10 @@
 // VTK includes
 #include <vtksys/SystemTools.hxx>
 #include <vtkNew.h>
+#include <vtkVersionMacros.h>
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+#include <vtkLogger.h>
+#endif
 
 // PythonQt includes
 #ifdef Slicer_USE_PYTHONQT
@@ -87,6 +91,9 @@ qSlicerApplicationHelper::~qSlicerApplicationHelper() = default;
 void qSlicerApplicationHelper::preInitializeApplication(
     const char* argv0, ctkProxyStyle* style)
 {
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  vtkLogger::SetStderrVerbosity(vtkLogger::VERBOSITY_OFF);
+#endif
   itk::itkFactoryRegistration();
   qMRMLWidget::preInitializeApplication();
 

--- a/Base/QTCLI/CMakeLists.txt
+++ b/Base/QTCLI/CMakeLists.txt
@@ -127,17 +127,31 @@ endif()
 if(VTK_WRAP_PYTHON)
   include(vtkMacroKitPythonWrap)
 
+  set(_python_wrapped_libraries
+    )
+
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    list(APPEND _python_wrapped_libraries
+      SlicerBaseLogicPythonD
+      )
+  endif()
+
   vtkMacroKitPythonWrap(
     KIT_NAME ${PROJECT_NAME}
     KIT_SRCS ${KIT_VTK_SRCS}
     KIT_INSTALL_BIN_DIR ${Slicer_INSTALL_BIN_DIR}
     KIT_INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR}
-    KIT_PYTHON_LIBRARIES SlicerBaseLogicPythonD
+    KIT_PYTHON_LIBRARIES ${_python_wrapped_libraries}
     )
-  set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${PROJECT_NAME}Python ${PROJECT_NAME}PythonD)
+  set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${PROJECT_NAME}Python)
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${PROJECT_NAME}PythonD)
+  endif()
   # Folder
   set_target_properties(${PROJECT_NAME}Python PROPERTIES FOLDER "Core-Base")
-  set_target_properties(${PROJECT_NAME}PythonD PROPERTIES FOLDER "Core-Base")
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    set_target_properties(${PROJECT_NAME}PythonD PROPERTIES FOLDER "Core-Base")
+  endif()
   if(TARGET ${PROJECT_NAME}Hierarchy)
     set_target_properties(${PROJECT_NAME}Hierarchy PROPERTIES FOLDER "Core-Base")
   endif()

--- a/Base/QTCore/CMakeLists.txt
+++ b/Base/QTCore/CMakeLists.txt
@@ -220,7 +220,7 @@ endif()
 # Python wrap
 if(Slicer_USE_PYTHONQT)
   set(VTK_COMMON_PYTHON_LIBRARY
-    vtkWrappingPythonCore # For vtkPythonUtil
+    ${VTK_TARGET_PREFIX}WrappingPythonCore # For vtkPythonUtil
     )
   list(APPEND KIT_target_libraries
     CTKScriptingPythonCore

--- a/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerWidgetTest2.cxx
@@ -174,7 +174,11 @@ int qSlicerWidgetTest2(int argc, char * argv[] )
 
   vtkWidget->setParent(&parentWidget);
   vbox.addWidget(vtkWidget);
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  vtkWidget->renderWindow()->Render();
+#else
   vtkWidget->GetRenderWindow()->Render();
+#endif
 
 #ifdef Slicer_BUILD_WEBENGINE_SUPPORT
   QWebEngineView webView;
@@ -188,9 +192,13 @@ int qSlicerWidgetTest2(int argc, char * argv[] )
   parentWidget.show();
   parentWidget.raise();
 
-  vtkMRMLSliceLogic *sliceLogic = setupSliceDisplay(
-          scene, vtkWidget->GetRenderWindow(), argv[1] );
-
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  vtkMRMLSliceLogic* sliceLogic = setupSliceDisplay(
+    scene, vtkWidget->renderWindow(), argv[1] );
+#else
+  vtkMRMLSliceLogic* sliceLogic = setupSliceDisplay(
+    scene, vtkWidget->GetRenderWindow(), argv[1]);
+#endif
 
   if (argc < 3 || QString(argv[2]) != "-I")
   {

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -108,6 +108,10 @@
 
 // VTK includes
 #include <vtkNew.h>
+#include <vtkVersionMacros.h> // must precede reference to VTK_*_VERSION
+#if VTK_MAJOR_VERSION >= 9
+#include <vtkSMP.h> // For VTK_SMP_BACKEND
+#endif
 
 //-----------------------------------------------------------------------------
 class qSlicerApplicationPrivate : public qSlicerCoreApplicationPrivate

--- a/CMake/FindJsonCpp.cmake
+++ b/CMake/FindJsonCpp.cmake
@@ -1,0 +1,40 @@
+# Find the JsonCpp include files and library.
+#
+# JsonCpp is a C++ library that can read/write JSON (JavaScript Object Notation)
+# documents. See http://jsoncpp.sourceforge.net/ for more details.
+#
+# This module defines:
+# JsonCpp_INCLUDE_DIRS - where to find json/json.h
+# JsonCpp_LIBRARIES - the libraries to link against to use JsonCpp
+# JsonCpp_FOUND - if false the library was not found.
+
+find_path(JsonCpp_INCLUDE_DIR "json/json.h"
+  PATH_SUFFIXES "jsoncpp"
+  DOC "Specify the JsonCpp include directory here")
+
+find_library(JsonCpp_LIBRARY
+  NAMES jsoncpp
+  PATHS
+  DOC "Specify the JsonCpp library here")
+set(JsonCpp_INCLUDE_DIRS ${JsonCpp_INCLUDE_DIR})
+set(JsonCpp_LIBRARIES "${JsonCpp_LIBRARY}")
+
+set(_JsonCpp_version_args)
+if (EXISTS "${JsonCpp_INCLUDE_DIR}/json/version.h")
+  file(STRINGS "${JsonCpp_INCLUDE_DIR}/json/version.h" _JsonCpp_version_contents REGEX "JSONCPP_VERSION_[A-Z]+")
+  foreach (_JsonCpp_version_part MAJOR MINOR PATCH)
+    string(REGEX REPLACE ".*# *define +JSONCPP_VERSION_${_JsonCpp_version_part} +([0-9]+).*"
+      "\\1" JsonCpp_VERSION_${_JsonCpp_version_part} "${_JsonCpp_version_contents}")
+  endforeach ()
+
+  set(JsonCpp_VERSION_STRING "${JsonCpp_VERSION_MAJOR}.${JsonCpp_VERSION_MINOR}.${JsonCpp_VERSION_PATCH}")
+
+  set(_JsonCpp_version_args VERSION_VAR JsonCpp_VERSION_STRING)
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(JsonCpp
+  REQUIRED_VARS JsonCpp_LIBRARIES JsonCpp_INCLUDE_DIRS
+  ${_JsonCpp_version_args})
+
+mark_as_advanced(JsonCpp_INCLUDE_DIR JsonCpp_LIBRARY)

--- a/CMake/SlicerBlockInstallCMakeProjects.cmake
+++ b/CMake/SlicerBlockInstallCMakeProjects.cmake
@@ -4,7 +4,15 @@ include(${Slicer_CMAKE_DIR}/SlicerCheckModuleEnabled.cmake)  # For slicer_is_loa
 # Install VTK
 # -------------------------------------------------------------------------
 if(NOT "${VTK_DIR}" STREQUAL "" AND EXISTS "${VTK_DIR}/CMakeCache.txt")
-  set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${VTK_DIR};VTK;RuntimeLibraries;/")
+  if(${VTK_VERSION} VERSION_GREATER_EQUAL "8.90")
+    set(_runtime_component "runtime")
+  else()
+    set(_runtime_component "RuntimeLibraries")
+  endif()
+  set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${VTK_DIR};VTK;${_runtime_component};/")
+  if(${VTK_VERSION} VERSION_GREATER_EQUAL "8.90" AND Slicer_USE_PYTHONQT)
+    set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${VTK_DIR};VTK;python;/")
+  endif()
 endif()
 
 # -------------------------------------------------------------------------

--- a/CMake/SlicerMacroBuildModuleLogic.cmake
+++ b/CMake/SlicerMacroBuildModuleLogic.cmake
@@ -70,6 +70,15 @@ macro(SlicerMacroBuildModuleLogic)
     list(APPEND MODULELOGIC_TARGET_LIBRARIES
       qSlicerBaseQTCLI
       )
+    # HACK Explicitly list transitive VTK dependencies because _get_dependencies_recurse
+    # used in vtkAddon/CMake/vtkMacroKitPythonWrap.cmake does not recurse over dependencies
+    # that are VTK python wrapped.
+    if(NOT ${MODULELOGIC_DISABLE_WRAP_PYTHON} AND VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
+      list(APPEND MODULELOGIC_TARGET_LIBRARIES
+        SlicerBaseLogic
+        MRMLDisplayableManager
+        )
+    endif()
   else()
     list(APPEND MODULELOGIC_TARGET_LIBRARIES
       SlicerBaseLogic
@@ -113,14 +122,18 @@ macro(SlicerMacroBuildModuleLogic)
   if(NOT ${MODULELOGIC_DISABLE_WRAP_PYTHON} AND VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
 
     set(Slicer_Wrapped_LIBRARIES
-      SlicerBaseLogicPythonD
       )
 
-    foreach(library ${MODULELOGIC_TARGET_LIBRARIES})
-      if(TARGET ${library}PythonD)
-        list(APPEND Slicer_Wrapped_LIBRARIES ${library}PythonD)
-      endif()
-    endforeach()
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      list(APPEND Slicer_Wrapped_LIBRARIES
+        SlicerBaseLogicPythonD
+        )
+      foreach(library ${MODULELOGIC_TARGET_LIBRARIES})
+        if(TARGET ${library}PythonD)
+          list(APPEND Slicer_Wrapped_LIBRARIES ${library}PythonD)
+        endif()
+      endforeach()
+    endif()
 
     SlicerMacroPythonWrapModuleVTKLibrary(
       NAME ${MODULELOGIC_NAME}
@@ -130,22 +143,34 @@ macro(SlicerMacroBuildModuleLogic)
       )
 
     # Set python module logic output
-    set_target_properties(${MODULELOGIC_NAME}Python ${MODULELOGIC_NAME}PythonD PROPERTIES
+    set_target_properties(${MODULELOGIC_NAME}Python PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_BIN_DIR}"
       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
       )
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${MODULELOGIC_NAME}PythonD PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_BIN_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
+        )
+    endif()
 
     if(NOT "${MODULELOGIC_FOLDER}" STREQUAL "")
       set_target_properties(${MODULELOGIC_NAME}Python PROPERTIES FOLDER ${MODULELOGIC_FOLDER})
-      set_target_properties(${MODULELOGIC_NAME}PythonD PROPERTIES FOLDER ${MODULELOGIC_FOLDER})
+      if(${VTK_VERSION} VERSION_LESS "8.90")
+        set_target_properties(${MODULELOGIC_NAME}PythonD PROPERTIES FOLDER ${MODULELOGIC_FOLDER})
+      endif()
       if(TARGET ${MODULELOGIC_NAME}Hierarchy)
         set_target_properties(${MODULELOGIC_NAME}Hierarchy PROPERTIES FOLDER ${MODULELOGIC_FOLDER})
       endif()
     endif()
 
     # Export target
-    set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${MODULELOGIC_NAME}Python ${MODULELOGIC_NAME}PythonD)
+    set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${MODULELOGIC_NAME}Python)
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${MODULELOGIC_NAME}PythonD)
+    endif()
   endif()
 
 endmacro()

--- a/CMake/SlicerMacroBuildModuleMRML.cmake
+++ b/CMake/SlicerMacroBuildModuleMRML.cmake
@@ -91,11 +91,13 @@ macro(SlicerMacroBuildModuleMRML)
     set(Slicer_Wrapped_LIBRARIES
       )
 
-    foreach(library ${MODULEMRML_TARGET_LIBRARIES})
-      if(TARGET ${library}PythonD)
-        list(APPEND Slicer_Wrapped_LIBRARIES ${library}PythonD)
-      endif()
-    endforeach()
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      foreach(library ${MODULEMRML_TARGET_LIBRARIES})
+        if(TARGET ${library}PythonD)
+          list(APPEND Slicer_Wrapped_LIBRARIES ${library}PythonD)
+        endif()
+      endforeach()
+    endif()
 
     SlicerMacroPythonWrapModuleVTKLibrary(
       NAME ${MODULEMRML_NAME}
@@ -105,22 +107,34 @@ macro(SlicerMacroBuildModuleMRML)
       )
 
     # Set python module logic output
-    set_target_properties(${MODULEMRML_NAME}Python ${MODULEMRML_NAME}PythonD PROPERTIES
+    set_target_properties(${MODULEMRML_NAME}Python PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_BIN_DIR}"
       LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
       )
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${MODULEMRML_NAME}PythonD PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_BIN_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}"
+        )
+    endif()
 
     if(NOT "${MODULEMRML_FOLDER}" STREQUAL "")
       set_target_properties(${MODULEMRML_NAME}Python PROPERTIES FOLDER ${MODULEMRML_FOLDER})
-      set_target_properties(${MODULEMRML_NAME}PythonD PROPERTIES FOLDER ${MODULEMRML_FOLDER})
+      if(${VTK_VERSION} VERSION_LESS "8.90")
+        set_target_properties(${MODULEMRML_NAME}PythonD PROPERTIES FOLDER ${MODULEMRML_FOLDER})
+      endif()
       if(TARGET ${MODULEMRML_NAME}Hierarchy)
         set_target_properties(${MODULEMRML_NAME}Hierarchy PROPERTIES FOLDER ${MODULEMRML_FOLDER})
       endif()
     endif()
 
     # Export target
-    set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${MODULEMRML_NAME}Python ${MODULEMRML_NAME}PythonD)
+    set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${MODULEMRML_NAME}Python)
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_property(GLOBAL APPEND PROPERTY Slicer_TARGETS ${MODULEMRML_NAME}PythonD)
+    endif()
   endif()
 
 endmacro()

--- a/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
+++ b/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
@@ -71,7 +71,11 @@ macro(SlicerMacroConfigureModuleCxxTestDriver)
           vtkWin32OutputWindow::SafeDownCast(vtkOutputWindow::GetInstance());
         if (outputWindow)
           {
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+          outputWindow->SetDisplayModeToAlwaysStdErr();
+#else
           outputWindow->SendToStdErrOn();
+#endif
           }
       #endif")
     endif()

--- a/CMake/SlicerMacroPythonWrapModuleVTKLibrary.cmake
+++ b/CMake/SlicerMacroPythonWrapModuleVTKLibrary.cmake
@@ -64,9 +64,11 @@ macro(SlicerMacroPythonWrapModuleVTKLibrary)
   endforeach()
 
   set(Slicer_Libs_VTK_PYTHON_WRAPPED_LIBRARIES)
-  foreach(lib ${Slicer_Libs_VTK_WRAPPED_LIBRARIES})
-    list(APPEND Slicer_Libs_VTK_PYTHON_WRAPPED_LIBRARIES ${lib}PythonD)
-  endforeach()
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    foreach(lib ${Slicer_Libs_VTK_WRAPPED_LIBRARIES})
+      list(APPEND Slicer_Libs_VTK_PYTHON_WRAPPED_LIBRARIES ${lib}PythonD)
+    endforeach()
+  endif()
 
   set(PYTHONWRAPMODULEVTKLIBRARY_Wrapped_LIBRARIES
     ${Slicer_Libs_VTK_PYTHON_WRAPPED_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,15 +328,10 @@ option(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT "Build Slicer with parameter ser
 mark_as_superbuild(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT)
 
 set(_default_vtk "8")
-set(Slicer_VTK_VERSION_MAJOR ${_default_vtk} CACHE STRING "VTK major version")
-set_property(CACHE Slicer_VTK_VERSION_MAJOR PROPERTY STRINGS "8")
-if(NOT "${Slicer_VTK_VERSION_MAJOR}" MATCHES "^(8)$")
-  if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(Slicer_VTK_VERSION_MAJOR 8 CACHE STRING "The VTK major version (7 or 8)." FORCE)
-    message(WARNING "Forcing Slicer_VTK_VERSION_MAJOR to 8 because VTK version was changed from 9.0 to 8.2. See http://vtk.1045678.n5.nabble.com/Discussion-OK-to-change-VTK-s-version-number-from-9-0-to-8-2-tt5748702.html")
-  else()
-    message(FATAL_ERROR "error: Slicer_VTK_VERSION_MAJOR must be 8.")
-  endif()
+set(Slicer_VTK_VERSION_MAJOR ${_default_vtk} CACHE STRING "VTK major version (8 or 9)")
+set_property(CACHE Slicer_VTK_VERSION_MAJOR PROPERTY STRINGS "8" "9")
+if(NOT "${Slicer_VTK_VERSION_MAJOR}" MATCHES "^(8|9)$")
+  message(FATAL_ERROR "error: Slicer_VTK_VERSION_MAJOR must be 8 or 9.")
 endif()
 mark_as_superbuild(Slicer_VTK_VERSION_MAJOR)
 
@@ -511,42 +506,55 @@ message(STATUS "  Slicer_VTK_VERSION_MAJOR is ${Slicer_VTK_VERSION_MAJOR}")
 #-----------------------------------------------------------------------------
 # Slicer_VTK_COMPONENTS
 #-----------------------------------------------------------------------------
+if (Slicer_VTK_VERSION_MAJOR VERSION_LESS "9")
+  set(VTK_COMPONENT_PREFIX "vtk")
+  set(VTK_TARGET_PREFIX "vtk")
+else()
+  set(VTK_COMPONENT_PREFIX "")
+  set(VTK_TARGET_PREFIX "VTK::")
+endif()
 set(Slicer_VTK_COMPONENTS
-  vtkFiltersExtraction
-  vtkFiltersFlowPaths
-  vtkFiltersGeometry
-  vtkGUISupportQtOpenGL
-  vtkGUISupportQtSQL
-  vtkIOExport
-  vtkIOImage
-  vtkIOLegacy
-  vtkIOPLY
-  vtkIOXML
-  vtkImagingMath
-  vtkImagingMorphological
-  vtkImagingStatistics
-  vtkImagingStencil
-  vtkInteractionImage
-  vtkRenderingContext${Slicer_VTK_RENDERING_BACKEND}
-  vtkRenderingQt
-  vtkRenderingVolume${Slicer_VTK_RENDERING_BACKEND}
-  vtkTestingRendering
-  vtkViewsQt
-  vtkzlib
+  ${VTK_COMPONENT_PREFIX}FiltersExtraction
+  ${VTK_COMPONENT_PREFIX}FiltersFlowPaths
+  ${VTK_COMPONENT_PREFIX}FiltersGeometry
+  ${VTK_COMPONENT_PREFIX}FiltersParallel
+  ${VTK_COMPONENT_PREFIX}GUISupportQtSQL
+  ${VTK_COMPONENT_PREFIX}IOExport
+  ${VTK_COMPONENT_PREFIX}IOImage
+  ${VTK_COMPONENT_PREFIX}IOLegacy
+  ${VTK_COMPONENT_PREFIX}IOPLY
+  ${VTK_COMPONENT_PREFIX}IOXML
+  ${VTK_COMPONENT_PREFIX}ImagingMath
+  ${VTK_COMPONENT_PREFIX}ImagingMorphological
+  ${VTK_COMPONENT_PREFIX}ImagingStatistics
+  ${VTK_COMPONENT_PREFIX}ImagingStencil
+  ${VTK_COMPONENT_PREFIX}InteractionImage
+  ${VTK_COMPONENT_PREFIX}RenderingContext${Slicer_VTK_RENDERING_BACKEND}
+  ${VTK_COMPONENT_PREFIX}RenderingQt
+  ${VTK_COMPONENT_PREFIX}RenderingVolume${Slicer_VTK_RENDERING_BACKEND}
+  ${VTK_COMPONENT_PREFIX}TestingRendering
+  ${VTK_COMPONENT_PREFIX}ViewsQt
+  ${VTK_COMPONENT_PREFIX}zlib
   )
-if(Slicer_USE_PYTHONQT)
+if (Slicer_VTK_VERSION_MAJOR VERSION_LESS "9")
   list(APPEND Slicer_VTK_COMPONENTS
-    vtkWrappingPythonCore
+    ${VTK_COMPONENT_PREFIX}GUISupportQtOpenGL
     )
 endif()
-if(UNIX AND NOT APPLE)
+
+if(Slicer_USE_PYTHONQT)
+  list(APPEND Slicer_VTK_COMPONENTS
+    ${VTK_COMPONENT_PREFIX}WrappingPythonCore
+    )
+endif()
+if(UNIX AND NOT APPLE AND Slicer_VTK_VERSION_MAJOR VERSION_LESS "9")
   find_package(FontConfig QUIET)
   if(FONTCONFIG_FOUND)
     list(APPEND Slicer_VTK_COMPONENTS
-      vtkRenderingFreeTypeFontConfig
+      ${VTK_COMPONENT_PREFIX}RenderingFreeTypeFontConfig
       )
     if(TARGET vtkRenderingFreeTypeOpenGL)
-      list(APPEND VTK_LIBRARIES vtkRenderingFreeTypeOpenGL)
+      list(APPEND VTK_LIBRARIES ${VTK_TARGET_PREFIX}RenderingFreeTypeOpenGL)
     endif()
   endif()
 endif()
@@ -797,13 +805,22 @@ endif()
 #-----------------------------------------------------------------------------
 # VTK
 #-----------------------------------------------------------------------------
-find_package(VTK ${Slicer_VTK_VERSION_MAJOR} COMPONENTS ${Slicer_VTK_COMPONENTS} REQUIRED NO_MODULE)
-if(NOT TARGET vtkGUISupportQt)
+find_package(VTK REQUIRED)
+if (VTK_VERSION VERSION_LESS "8.90")
+  find_package(VTK ${Slicer_VTK_VERSION_MAJOR} COMPONENTS ${Slicer_VTK_COMPONENTS} REQUIRED NO_MODULE)
+  include(${VTK_USE_FILE})
+  set(VTK_GUI_SUPPORT_QT_TARGET_NAME "vtkGUISupportQt")
+else()
+  set(VTK_LIBRARIES "")
+  find_package(VTK ${Slicer_VTK_VERSION_MAJOR} COMPONENTS ${Slicer_VTK_COMPONENTS} REQUIRED)
+  set(VTK_GUI_SUPPORT_QT_TARGET_NAME "VTK::GUISupportQt")
+endif ()
+
+if(NOT TARGET ${VTK_GUI_SUPPORT_QT_TARGET_NAME})
   message(FATAL_ERROR "error: VTK was not configured to use Qt, you probably need "
                     "to recompile it with VTK_USE_GUISUPPORT ON, VTK_Group_Qt ON, "
                     "Note that Qt >= ${Slicer_REQUIRED_QT_VERSION} is *required*")
 endif()
-include(${VTK_USE_FILE})
 set(VTK_RENDERING_BACKEND "${Slicer_VTK_RENDERING_BACKEND}")
 
 #-----------------------------------------------------------------------------

--- a/Libs/MRML/CLI/CMakeLists.txt
+++ b/Libs/MRML/CLI/CMakeLists.txt
@@ -135,19 +135,32 @@ install(TARGETS ${lib_name}
 if(VTK_WRAP_PYTHON)
   include(vtkMacroKitPythonWrap)
 
+  set(_python_wrapped_libraries)
+
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    list(APPEND _python_wrapped_libraries
+      MRMLCorePythonD
+      )
+  endif()
+
   vtkMacroKitPythonWrap(
     KIT_NAME ${lib_name}
     KIT_SRCS ${MRMLCLI_SRCS}
-    KIT_PYTHON_LIBRARIES MRMLCorePythonD
+    KIT_PYTHON_LIBRARIES ${_python_wrapped_libraries}
     KIT_INSTALL_BIN_DIR ${${PROJECT_NAME}_INSTALL_BIN_DIR}
     KIT_INSTALL_LIB_DIR ${${PROJECT_NAME}_INSTALL_LIB_DIR}
     )
   # Export target
-  export(TARGETS ${lib_name}Python ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  export(TARGETS ${lib_name}Python APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    export(TARGETS ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  endif()
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
-    set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    endif()
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -289,7 +289,7 @@ set(libs
   vtkSegmentationCore
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}
-  vtkIOInfovis
+  ${VTK_TARGET_PREFIX}IOInfovis
   ${LibArchive_LIBRARY}
   )
 if(MRML_USE_vtkTeem)
@@ -347,11 +347,16 @@ if(VTK_WRAP_PYTHON)
     KIT_INSTALL_LIB_DIR ${${PROJECT_NAME}_INSTALL_LIB_DIR}
     )
   # Export target
-  export(TARGETS ${lib_name}Python ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  export(TARGETS ${lib_name}Python APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    export(TARGETS ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  endif()
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
-    set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    endif()
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/MRML/Core/vtkArchive.cxx
+++ b/Libs/MRML/Core/vtkArchive.cxx
@@ -386,7 +386,12 @@ bool vtkArchive::Zip(const char* zipFileName, const char* directoryToZip)
     return false;
     }
 
+
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  std::vector<std::string> directoryParts;
+#else
   std::vector<vtksys::String> directoryParts;
+#endif
   directoryParts = vtksys::SystemTools::SplitString(directoryToZip, '/', true);
   std::string directoryName = directoryParts.back();
 

--- a/Libs/MRML/Core/vtkArchive.cxx
+++ b/Libs/MRML/Core/vtkArchive.cxx
@@ -530,7 +530,7 @@ bool vtkArchive::UnZip(const char* zipFileName, const char* destinationDirectory
     return false;
     }
 
-  std::string cwd = vtksys::SystemTools::GetCurrentWorkingDirectory(true);
+  std::string cwd = vtksys::SystemTools::GetCurrentWorkingDirectory();
 
   if ( vtksys::SystemTools::ChangeDirectory(destinationDirectory) )
     {

--- a/Libs/MRML/Core/vtkMRMLTextStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTextStorageNode.cxx
@@ -138,7 +138,7 @@ int vtkMRMLTextStorageNode::WriteDataInternal(vtkMRMLNode * refNode)
       }
     }
 
-  ofstream file;
+  std::ofstream file;
   file.open(fullName);
   file << textNode->GetText();
   this->StageWriteData(refNode);

--- a/Libs/MRML/DisplayableManager/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/CMakeLists.txt
@@ -168,7 +168,7 @@ set(libs
 
 if(MRMLDisplayableManager_USE_PYTHON)
   set(VTK_COMMON_PYTHON_LIBRARY
-    vtkWrappingPythonCore # For vtkPythonUtil
+    ${VTK_TARGET_PREFIX}WrappingPythonCore # For vtkPythonUtil
     )
   list(APPEND libs
     ${VTK_COMMON_PYTHON_LIBRARY} # For vtkPythonUtils
@@ -230,19 +230,32 @@ install(TARGETS ${lib_name}
 if(MRMLDisplayableManager_USE_PYTHON)
   include(vtkMacroKitPythonWrap)
 
+  set(_python_wrapped_libraries)
+
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    list(APPEND _python_wrapped_libraries
+      MRMLLogicPythonD
+      )
+  endif()
+
   vtkMacroKitPythonWrap(
     KIT_NAME ${lib_name}
     KIT_SRCS ${KIT_SRCS}
-    KIT_PYTHON_LIBRARIES MRMLLogicPythonD
+    KIT_PYTHON_LIBRARIES ${_python_wrapped_libraries}
     KIT_INSTALL_BIN_DIR ${${PROJECT_NAME}_INSTALL_BIN_DIR}
     KIT_INSTALL_LIB_DIR ${${PROJECT_NAME}_INSTALL_LIB_DIR}
     )
   # Export target
-  export(TARGETS ${lib_name}Python ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  export(TARGETS ${lib_name}Python APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    export(TARGETS ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  endif()
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
-    set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    endif()
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/MRML/Logic/CMakeLists.txt
+++ b/Libs/MRML/Logic/CMakeLists.txt
@@ -144,19 +144,32 @@ install(TARGETS ${lib_name}
 if(VTK_WRAP_PYTHON)
   include(vtkMacroKitPythonWrap)
 
+  set(_python_wrapped_libraries)
+
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    list(APPEND _python_wrapped_libraries
+      MRMLCorePythonD
+      )
+  endif()
+
   vtkMacroKitPythonWrap(
     KIT_NAME ${lib_name}
     KIT_SRCS ${MRMLLogic_SRCS}
-    KIT_PYTHON_LIBRARIES MRMLCorePythonD
+    KIT_PYTHON_LIBRARIES ${_python_wrapped_libraries}
     KIT_INSTALL_BIN_DIR ${${PROJECT_NAME}_INSTALL_BIN_DIR}
     KIT_INSTALL_LIB_DIR ${${PROJECT_NAME}_INSTALL_LIB_DIR}
     )
   # Export target
-  export(TARGETS ${lib_name}Python ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  export(TARGETS ${lib_name}Python APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    export(TARGETS ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  endif()
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
-    set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    endif()
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/MRML/Widgets/CMakeLists.txt
+++ b/Libs/MRML/Widgets/CMakeLists.txt
@@ -498,11 +498,8 @@ set(MRMLWidgets_LIBRARIES
   ${CTK_LIBRARIES}
   MRMLLogic
   MRMLDisplayableManager
+  ${VTK_TARGET_PREFIX}RenderingQt
   )
-list(APPEND MRMLWidgets_LIBRARIES
-  vtkRenderingQt
-  )
-
 
 target_link_libraries(${lib_name} ${MRMLWidgets_LIBRARIES})
 

--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerWithCustomFactoryTest.cxx
@@ -79,7 +79,7 @@ protected:
     // there is a unique slice widget per node
     Q_ASSERT(!this->viewWidget(viewNode));
 
-    this->LastNode = viewNode;
+    this->LastNode = vtkMRMLSliceNode::SafeDownCast(viewNode);
 
     qMRMLSliceWidget * sliceWidget = new qMRMLSliceWidget(this->layoutManager()->viewport());
     sliceWidget->sliceController()->setControllerButtonGroup(this->SliceControllerButtonGroup);
@@ -177,7 +177,7 @@ protected:
     // There must be a unique Custom widget per node
     Q_ASSERT(!this->viewWidget(viewNode));
 
-    this->LastNode = viewNode;
+    this->LastNode = vtkMRMLSliceNode::SafeDownCast(viewNode);
 
     QLabel* label = new QLabel();
     label->setText("This is a custom view");

--- a/Libs/MRML/Widgets/qMRMLPlotView.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotView.cxx
@@ -1124,7 +1124,7 @@ void qMRMLPlotView::saveAsSVG(const QString &filePathPrefix)
 
   exporter->SetFileFormatToSVG();
   exporter->CompressOff();
-  exporter->SetRenderWindow(this->GetRenderWindow());
+  exporter->SetRenderWindow(this->renderWindow());
   exporter->SetFilePrefix(filePathPrefix.toStdString().c_str());
   exporter->Update();
 }

--- a/Libs/MRML/Widgets/qMRMLSliceView.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceView.cxx
@@ -54,6 +54,7 @@
 #include <vtkRenderWindow.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkSmartPointer.h>
+#include <vtkVersionMacros.h>
 
 //--------------------------------------------------------------------------
 // qMRMLSliceViewPrivate::vtkInternalLightBoxRendererManagerProxy class
@@ -432,35 +433,41 @@ QList<double> qMRMLSliceView::convertXYZToRAS(const QList<double>& xyz)const
 void qMRMLSliceView::setViewCursor(const QCursor &cursor)
 {
   this->setCursor(cursor);
-#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
   if (this->VTKWidget() != nullptr)
     {
-    this->VTKWidget()->setQVTKCursor(cursor);
-    }
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION > 2)
+    this->VTKWidget()->setCursor(cursor);  // TODO: test if cursor settings works
+#elif (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION == 2)
+    this->VTKWidget()->setQVTKCursor(cursor);  // TODO: test if cursor settings works
 #endif
+    }
 }
 
 // --------------------------------------------------------------------------
 void qMRMLSliceView::unsetViewCursor()
 {
   this->unsetCursor();
-#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
   if (this->VTKWidget() != nullptr)
     {
     // TODO: it would be better to restore default cursor, but QVTKOpenGLNativeWidget
     // API does not have an accessor method to the default cursor.
-    this->VTKWidget()->setQVTKCursor(QCursor(Qt::ArrowCursor));
-    }
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION > 2)
+    this->VTKWidget()->setCursor(QCursor(Qt::ArrowCursor));  // TODO: test if cursor settings works
+#elif (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION == 2)
+    this->VTKWidget()->setQVTKCursor(QCursor(Qt::ArrowCursor));  // TODO: test if cursor settings works
 #endif
+    }
 }
 
 // --------------------------------------------------------------------------
 void qMRMLSliceView::setDefaultViewCursor(const QCursor &cursor)
 {
-#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
   if (this->VTKWidget() != nullptr)
     {
-    this->VTKWidget()->setDefaultQVTKCursor(cursor);
-    }
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION > 2)
+    this->VTKWidget()->setDefaultCursor(cursor);  // TODO: test if cursor settings works
+#elif (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION == 2)
+    this->VTKWidget()->setDefaultQVTKCursor(cursor);  // TODO: test if cursor settings works
 #endif
+    }
 }

--- a/Libs/MRML/Widgets/qMRMLTableViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLTableViewControllerWidget.cxx
@@ -162,7 +162,7 @@ void qMRMLTableViewControllerWidgetPrivate::onTableNodeSelected(vtkMRMLNode * no
 
   this->qvtkReconnect(this->TableNode, node, vtkCommand::ModifiedEvent,
                       q, SLOT(updateWidgetFromMRML()));
-  this->TableNode = node;
+  this->TableNode = vtkMRMLTableNode::SafeDownCast(node);
 
   this->TableViewNode->SetTableNodeID(this->TableNode ? this->TableNode->GetID() : nullptr);
 

--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -52,6 +52,7 @@
 #include <vtkRenderer.h>
 #include <vtkRenderWindowInteractor.h>
 #include <vtkSmartPointer.h>
+#include <vtkVersionMacros.h>
 
 //--------------------------------------------------------------------------
 // qMRMLThreeDViewPrivate methods
@@ -546,35 +547,41 @@ vtkMRMLAbstractDisplayableManager* qMRMLThreeDView::displayableManagerByClassNam
 void qMRMLThreeDView::setViewCursor(const QCursor &cursor)
 {
   this->setCursor(cursor);
-#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
   if (this->VTKWidget() != nullptr)
-   {
-    this->VTKWidget()->setQVTKCursor(cursor);
-    }
+    {
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION > 2)
+    this->VTKWidget()->setCursor(cursor);  // TODO: test if cursor settings works
+#elif (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION == 2)
+    this->VTKWidget()->setQVTKCursor(cursor);  // TODO: test if cursor settings works
 #endif
+    }
 }
 
 // --------------------------------------------------------------------------
 void qMRMLThreeDView::unsetViewCursor()
 {
   this->unsetCursor();
-#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
   if (this->VTKWidget() != nullptr)
     {
     // TODO: it would be better to restore default cursor, but QVTKOpenGLNativeWidget
     // API does not have an accessor method to the default cursor.
-    this->VTKWidget()->setQVTKCursor(QCursor(Qt::ArrowCursor));
-    }
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION > 2)
+    this->VTKWidget()->setCursor(QCursor(Qt::ArrowCursor));  // TODO: test if cursor settings works
+#elif (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION == 2)
+    this->VTKWidget()->setQVTKCursor(QCursor(Qt::ArrowCursor));  // TODO: test if cursor settings works
 #endif
+    }
 }
 
 // --------------------------------------------------------------------------
 void qMRMLThreeDView::setDefaultViewCursor(const QCursor &cursor)
 {
-#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2)
   if (this->VTKWidget() != nullptr)
     {
-    this->VTKWidget()->setDefaultQVTKCursor(cursor);
-    }
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION > 2)
+    this->VTKWidget()->setDefaultCursor(cursor);  // TODO: test if cursor settings works
+#elif (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION == 2)
+    this->VTKWidget()->setDefaultQVTKCursor(cursor);  // TODO: test if cursor settings works
 #endif
+    }
 }

--- a/Libs/vtkITK/CMakeLists.txt
+++ b/Libs/vtkITK/CMakeLists.txt
@@ -214,11 +214,16 @@ if(VTK_WRAP_PYTHON)
     KIT_INSTALL_LIB_DIR ${${PROJECT_NAME}_INSTALL_LIB_DIR}
     )
   # Export target
-  export(TARGETS ${lib_name}Python ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  export(TARGETS ${lib_name}Python APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    export(TARGETS ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  endif()
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
-    set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    endif()
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/vtkSegmentationCore/CMakeLists.txt
+++ b/Libs/vtkSegmentationCore/CMakeLists.txt
@@ -149,11 +149,13 @@ if(VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
   set(Slicer_Wrapped_LIBRARIES
     )
 
-  foreach(library ${PROJECT_NAME})
-    if(TARGET ${library}PythonD)
-      list(APPEND Slicer_Wrapped_LIBRARIES ${library}PythonD)
-    endif()
-  endforeach()
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    foreach(library ${PROJECT_NAME})
+      if(TARGET ${library}PythonD)
+        list(APPEND Slicer_Wrapped_LIBRARIES ${library}PythonD)
+      endif()
+    endforeach()
+  endif()
 
   include(vtkMacroKitPythonWrap)
 
@@ -165,11 +167,16 @@ if(VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
     )
 
   # Export target
-  export(TARGETS ${PROJECT_NAME}Python ${PROJECT_NAME}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  export(TARGETS ${PROJECT_NAME}Python APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    export(TARGETS ${PROJECT_NAME}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  endif()
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${PROJECT_NAME}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
-    set_target_properties(${PROJECT_NAME}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${PROJECT_NAME}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    endif()
     if(TARGET ${PROJECT_NAME}Hierarchy)
       set_target_properties(${PROJECT_NAME}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Libs/vtkSegmentationCore/vtkOrientedImageData.h
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageData.h
@@ -64,8 +64,15 @@ public:
   double GetMaxSpacing();
 
   /// Get matrix including directions only
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION > 2)
+  using vtkImageData::GetDirectionMatrix;
+#endif
   void GetDirectionMatrix(vtkMatrix4x4* mat);
+
   /// Set directions by matrix
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION > 2)
+  using vtkImageData::SetDirectionMatrix;
+#endif
   void SetDirectionMatrix(vtkMatrix4x4* mat);
 
   /// Get the geometry matrix that includes the spacing and origin information

--- a/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.cxx
+++ b/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.cxx
@@ -299,7 +299,11 @@ void vtkPolyDataToFractionalLabelmapFilter::GetOutputOrigin(double origin[3])
 }
 
 //----------------------------------------------------------------------------
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+void vtkPolyDataToFractionalLabelmapFilter::SetOutputOrigin(const double origin[3])
+#else
 void vtkPolyDataToFractionalLabelmapFilter::SetOutputOrigin(double origin[3])
+#endif
 {
   this->OutputImageTransformData->SetOrigin(origin);
 }
@@ -323,7 +327,11 @@ void vtkPolyDataToFractionalLabelmapFilter::GetOutputSpacing(double spacing[3])
 }
 
 //----------------------------------------------------------------------------
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+void vtkPolyDataToFractionalLabelmapFilter::SetOutputSpacing(const double spacing[3])
+#else
 void vtkPolyDataToFractionalLabelmapFilter::SetOutputSpacing(double spacing[3])
+#endif
 {
   this->OutputImageTransformData->SetSpacing(spacing);
 }
@@ -640,7 +648,11 @@ void vtkPolyDataToFractionalLabelmapFilter::FillImageStencilData(
       // get the connectivity count for each point
       vtkSmartPointer<vtkCellArray> lines = slice->GetLines();
       vtkIdType npts = 0;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+      const vtkIdType *pointIds = nullptr;
+#else
       vtkIdType *pointIds = nullptr;
+#endif
       vtkIdType count = lines->GetNumberOfConnectivityEntries();
       for (vtkIdType loc = 0; loc < count; loc += npts + 1)
         {
@@ -828,7 +840,11 @@ void vtkPolyDataToFractionalLabelmapFilter::FillImageStencilData(
 
     vtkCellArray* lines = this->LinesCache[z];
     vtkIdType count = lines->GetNumberOfConnectivityEntries();
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+    const vtkIdType* pointIds = this->PointIdsCache[z];
+#else
     vtkIdType* pointIds = this->PointIdsCache[z];
+#endif
     vtkIdType npts = this->NptsCache[z];
     vtkIdTypeArray* pointNeighborCountsArray = this->PointNeighborCountsCache[z];
     vtkIdType* pointNeighborCounts = pointNeighborCountsArray->GetPointer(0);
@@ -916,7 +932,12 @@ void vtkPolyDataToFractionalLabelmapFilter::PolyDataCutter(
         continue;
       }
 
-    vtkIdType npts, *ptIds;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+    const vtkIdType *ptIds = nullptr;
+#else
+    vtkIdType *ptIds = nullptr;
+#endif
+    vtkIdType npts;
     input->GetCellPoints(id, npts, ptIds);
     loc += npts + 1;
 

--- a/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.h
+++ b/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.h
@@ -89,14 +89,24 @@ public:
   double* GetOutputOrigin() override;
   void GetOutputOrigin(double origin[3]) override;
 
-  void SetOutputOrigin(double origin[3]) override;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  using Superclass::SetOutputOrigin;
+  void SetOutputOrigin(const double origin[3]) override;
+#else
+  void SetOutputOrigin(double origin[3]);
+#endif
   void SetOutputOrigin(double x, double y, double z) override;
 
   using Superclass::GetOutputSpacing;
   double* GetOutputSpacing() override;
   void GetOutputSpacing(double spacing[3]) override;
 
-  void SetOutputSpacing(double spacing[3]) override;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  using Superclass::SetOutputSpacing;
+  void SetOutputSpacing(const double spacing[3]) override;
+#else
+  void SetOutputSpacing(double spacing[3]);
+#endif
   void SetOutputSpacing(double x, double y, double z) override;
 
 

--- a/Libs/vtkTeem/CMakeLists.txt
+++ b/Libs/vtkTeem/CMakeLists.txt
@@ -155,11 +155,16 @@ if(VTK_WRAP_PYTHON)
     KIT_INSTALL_LIB_DIR ${${PROJECT_NAME}_INSTALL_LIB_DIR}
     )
   # Export target
-  export(TARGETS ${lib_name}Python ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  export(TARGETS ${lib_name}Python APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  if(${VTK_VERSION} VERSION_LESS "8.90")
+    export(TARGETS ${lib_name}PythonD APPEND FILE ${${PROJECT_NAME}_EXPORT_FILE})
+  endif()
   # Folder
   if(NOT "${${PROJECT_NAME}_FOLDER}" STREQUAL "")
     set_target_properties(${lib_name}Python PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
-    set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    if(${VTK_VERSION} VERSION_LESS "8.90")
+      set_target_properties(${lib_name}PythonD PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
+    endif()
     if(TARGET ${lib_name}Hierarchy)
       set_target_properties(${lib_name}Hierarchy PROPERTIES FOLDER ${${PROJECT_NAME}_FOLDER})
     endif()

--- a/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
+++ b/Modules/Loadable/Annotations/MRML/vtkMRMLAnnotationLinesNode.cxx
@@ -39,7 +39,11 @@ void vtkMRMLAnnotationLinesNode::WriteXML(ostream& of, int nIndent)
     for (int i = 0; i < n; i++)
       {
       vtkIdType npts = 0;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+      const vtkIdType *pts = nullptr;
+#else
       vtkIdType *pts = nullptr;
+#endif
       lines->GetNextCell(npts, pts);
       for (int j= 0; j < npts; j++)
         {
@@ -185,7 +189,11 @@ void vtkMRMLAnnotationLinesNode::PrintAnnotationInfo(ostream& os, vtkIndent inde
     for (int i = 0; i < n; i++ )
       {
       vtkIdType npts;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+      const vtkIdType *pts = nullptr;
+#else
       vtkIdType *pts = nullptr;
+#endif
       lines->GetNextCell(npts, pts);
       if (!pts)
         {
@@ -331,9 +339,17 @@ void vtkMRMLAnnotationLinesNode::DeleteLine(int id)
   lines->InitTraversal();
   // cellLine->SetTraversalLocation(id);
 
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  const vtkIdType *cPts = nullptr;
+#else
   vtkIdType *cPts = nullptr;
+#endif
   vtkIdType cNpts = 0;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  const vtkIdType *nPts = nullptr;
+#else
   vtkIdType *nPts = nullptr;
+#endif
   vtkIdType nNpts = 0;
   for (int i = 0; i <= id; i++ )
     {
@@ -347,7 +363,11 @@ void vtkMRMLAnnotationLinesNode::DeleteLine(int id)
       vtkErrorMacro("Error in cell structure " << cNpts  << " " << nNpts);
       return;
     }
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+      // TODO
+#else
       cPts[0]=nPts[0]; cPts[1]=nPts[1];
+#endif
       cPts=nPts;
     }
   lines->SetNumberOfCells(n-1);
@@ -387,7 +407,11 @@ int vtkMRMLAnnotationLinesNode::GetEndPointsId(vtkIdType id, vtkIdType ctrlPtsID
   lines->InitTraversal();
 
   vtkIdType npts = 0;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  const vtkIdType *pts = nullptr;
+#else
   vtkIdType *pts = nullptr;
+#endif
 
   for (int i = 0; i < id; i++ )
     {

--- a/Modules/Loadable/Annotations/MRMLDM/CMakeLists.txt
+++ b/Modules/Loadable/Annotations/MRMLDM/CMakeLists.txt
@@ -42,12 +42,11 @@ set(${KIT}_SRCS
 
 set(${KIT}_TARGET_LIBRARIES
   ${MRML_LIBRARIES}
-  vtkRenderingAnnotation
+  ${VTK_TARGET_PREFIX}RenderingAnnotation
   vtkSlicer${MODULE_NAME}ModuleLogic
   vtkSlicer${MODULE_NAME}ModuleMRML
   vtkSlicer${MODULE_NAME}ModuleVTKWidgets
   )
-
 
 #-----------------------------------------------------------------------------
 SlicerMacroBuildModuleLogic(

--- a/Modules/Loadable/Annotations/VTKWidgets/CMakeLists.txt
+++ b/Modules/Loadable/Annotations/VTKWidgets/CMakeLists.txt
@@ -36,7 +36,7 @@ set(${KIT}_SRCS
   )
 
 set(${KIT}_TARGET_LIBRARIES
-  vtkRenderingAnnotation
+  ${VTK_TARGET_PREFIX}RenderingAnnotation
   vtkSlicer${MODULE_NAME}ModuleMRML
   )
 

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation.cxx
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation.cxx
@@ -1338,7 +1338,11 @@ void vtkAnnotationROIRepresentation::HighlightFace(int cellId)
   if ( cellId >= 0 )
     {
     vtkIdType npts;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+    const vtkIdType *pts;
+#else
     vtkIdType *pts;
+#endif
     vtkCellArray *cells = this->HexFacePolyData->GetPolys();
     this->HexPolyData->GetCellPoints(cellId, npts, pts);
     this->HexFacePolyData->Modified();

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation2D.cxx
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation2D.cxx
@@ -742,7 +742,11 @@ void vtkAnnotationROIRepresentation2D::PrintIntersections(ostream& os)
     {
     double *pts = static_cast<vtkDoubleArray *>(this->Points->GetData())->GetPointer(0);
     vtkIdType ncpts;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+    const vtkIdType *cpts;
+#else
     vtkIdType *cpts;
+#endif
     this->IntersectionFaces[i]->GetCellPoints(0, ncpts, cpts);
     os << "   Face[" << i << "]=(" << pts[3*cpts[0]] << ", " << pts[3*cpts[0]+1] << ", " << pts[3*cpts[0]+2] <<
                              "), (" << pts[3*cpts[1]] << ", " << pts[3*cpts[1]+1] << ", " << pts[3*cpts[1]+2] <<

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
@@ -419,7 +419,7 @@ void qSlicerCropVolumeModuleWidget::setInputVolume(vtkMRMLNode* volumeNode)
     }
 
   qvtkReconnect(d->InputVolumeNode, volumeNode, vtkCommand::ModifiedEvent, this, SLOT(updateVolumeInfo()));
-  d->InputVolumeNode = volumeNode;
+  d->InputVolumeNode = vtkMRMLVolumeNode::SafeDownCast(volumeNode);
   d->ParametersNode->SetInputVolumeNodeID(volumeNode ? volumeNode->GetID() : nullptr);
 }
 

--- a/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
@@ -725,7 +725,11 @@ int vtkCurveGenerator::GenerateLines(vtkPolyData* polyData)
     if (lines->GetNumberOfCells() == 1)
       {
       vtkIdType currentNumberOfCellPoints = 0;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+      const vtkIdType* currentCellPoints = nullptr;
+#else
       vtkIdType* currentCellPoints = nullptr;
+#endif
       lines->GetCell(0, currentNumberOfCellPoints, currentCellPoints);
 
       if (currentNumberOfCellPoints == numberOfCellPoints)

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -806,10 +806,17 @@ void vtkMRMLMarkupsDisplayNode::UpdateTextPropertyFromString(std::string inputSt
     return ;
     }
 
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  std::vector<std::string> textProperties = vtksys::SystemTools::SplitString(inputString, ';');
+  for (std::string textPropertyString : textProperties)
+    {
+    std::vector<std::string> keyValue = vtksys::SystemTools::SplitString(textPropertyString, ':');
+#else
   std::vector<vtksys::String> textProperties = vtksys::SystemTools::SplitString(inputString, ';');
   for (vtksys::String textPropertyString : textProperties)
     {
     std::vector<vtksys::String> keyValue = vtksys::SystemTools::SplitString(textPropertyString, ':');
+#endif
     if (keyValue.empty())
       {
       continue;
@@ -875,10 +882,18 @@ void vtkMRMLMarkupsDisplayNode::UpdateTextPropertyFromString(std::string inputSt
       }
     else if (key == "text-shadow")
       {
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+      std::vector<std::string> shadowProperties = vtksys::SystemTools::SplitString(textPropertyString, ' ');
+#else
       std::vector<vtksys::String> shadowProperties = vtksys::SystemTools::SplitString(textPropertyString, ' ');
+#endif
       int shadowOffset[2] = { 0,0 };
       int shadowPropertyIndex = 0;
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+      for (std::string shadowProperty : shadowProperties)
+#else
       for (vtksys::String shadowProperty : shadowProperties)
+#endif
         {
         if (shadowPropertyIndex == SHADOW_H_OFFSET_INDEX || shadowPropertyIndex == SHADOW_V_OFFSET_INDEX)
           {
@@ -928,7 +943,11 @@ void vtkMRMLMarkupsDisplayNode::GetColorFromString(const std::string& inputStrin
     colorString = colorString.substr(0, pos);
     }
 
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  std::vector<std::string> componentStrings = vtksys::SystemTools::SplitString(colorString, ',');
+#else
   std::vector<vtksys::String> componentStrings = vtksys::SystemTools::SplitString(colorString, ',');
+#endif
   for (int i = 0; i < 4 && i <static_cast<int>(componentStrings.size()); ++i)
     {
     double componentF = vtkVariant(componentStrings[i]).ToDouble();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -1184,7 +1184,7 @@ void vtkSlicerMarkupsWidget::RotateWidget(double eventPos[2])
     double intersection_World[3] = { 0.0 };
     if (!this->GetIntersectionOnAxisPlane(vtkMRMLMarkupsDisplayNode::ComponentRotationHandle, index, eventPos_Display, intersection_World))
       {
-      vtkWarningMacro("RotateWidget: Could not calculate intended orientation")
+      vtkWarningMacro("RotateWidget: Could not calculate intended orientation");
       return;
       }
 

--- a/Modules/Loadable/Sequences/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Sequences/MRML/CMakeLists.txt
@@ -19,8 +19,6 @@ set(${KIT}_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
   ${MRML_LIBRARIES}
   SlicerBaseLogic
-  vtkSlicerMarkupsModuleMRML
-  vtkSlicerVolumeRenderingModuleMRML
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
@@ -2048,7 +2048,11 @@ bool vtkSlicerTerminologiesModuleLogic::DeserializeTerminologyEntry(std::string 
   entry->SetTerminologyContextName(terminologyName.empty()?nullptr:terminologyName.c_str());
 
   // Category
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  std::vector<std::string> categoryIds = vtksys::SystemTools::SplitString(entryComponents[1], '^');
+#else
   std::vector<vtksys::String> categoryIds = vtksys::SystemTools::SplitString(entryComponents[1], '^');
+#endif
   if (categoryIds.size() != 3)
     {
     vtkErrorWithObjectMacro(entry, "DeserializeTerminologyEntry: Invalid category component");
@@ -2064,7 +2068,12 @@ bool vtkSlicerTerminologiesModuleLogic::DeserializeTerminologyEntry(std::string 
   entry->GetCategoryObject()->Copy(categoryObject);
 
   // Type
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  std::vector<std::string> typeIds = vtksys::SystemTools::SplitString(entryComponents[2], '^');
+#else
   std::vector<vtksys::String> typeIds = vtksys::SystemTools::SplitString(entryComponents[2], '^');
+#endif
+
   if (typeIds.size() != 3)
     {
     vtkErrorWithObjectMacro(entry, "DeserializeTerminologyEntry: Invalid type component");
@@ -2080,7 +2089,11 @@ bool vtkSlicerTerminologiesModuleLogic::DeserializeTerminologyEntry(std::string 
   entry->GetTypeObject()->Copy(typeObject);
 
   // Type modifier (optional)
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  std::vector<std::string> typeModifierIds = vtksys::SystemTools::SplitString(entryComponents[3], '^');
+#else
   std::vector<vtksys::String> typeModifierIds = vtksys::SystemTools::SplitString(entryComponents[3], '^');
+#endif
   if (typeModifierIds.size() == 3)
     {
     vtkSlicerTerminologiesModuleLogic::CodeIdentifier typeModifierId(typeModifierIds[0], typeModifierIds[1], typeModifierIds[2]);
@@ -2100,7 +2113,12 @@ bool vtkSlicerTerminologiesModuleLogic::DeserializeTerminologyEntry(std::string 
   entry->SetAnatomicContextName(anatomicContextName.empty()?nullptr:anatomicContextName.c_str());
 
   // Anatomic region (optional)
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+  std::vector<std::string> regionIds = vtksys::SystemTools::SplitString(entryComponents[5], '^');
+#else
   std::vector<vtksys::String> regionIds = vtksys::SystemTools::SplitString(entryComponents[5], '^');
+#endif
+
   if (regionIds.size() == 3)
     {
     vtkSlicerTerminologiesModuleLogic::CodeIdentifier regionId(regionIds[0], regionIds[1], regionIds[2]);
@@ -2115,7 +2133,11 @@ bool vtkSlicerTerminologiesModuleLogic::DeserializeTerminologyEntry(std::string 
       }
 
     // Anatomic region modifier (optional)
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+    std::vector<std::string> regionModifierIds = vtksys::SystemTools::SplitString(entryComponents[6], '^');
+#else
     std::vector<vtksys::String> regionModifierIds = vtksys::SystemTools::SplitString(entryComponents[6], '^');
+#endif
     if (regionModifierIds.size() == 3)
       {
       vtkSlicerTerminologiesModuleLogic::CodeIdentifier regionModifierId(regionModifierIds[0], regionModifierIds[1], regionModifierIds[2]);

--- a/Modules/Loadable/VolumeRendering/MRMLDM/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/CMakeLists.txt
@@ -29,8 +29,8 @@ set(${KIT}_SRCS
   )
 
 set(${KIT}_VTK_LIBRARIES
-  vtkRenderingVolume
-  vtkRenderingVolume${VTK_RENDERING_BACKEND}
+  ${VTK_TARGET_PREFIX}RenderingVolume
+  ${VTK_TARGET_PREFIX}RenderingVolume${VTK_RENDERING_BACKEND}
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/Modules/Scripted/DataProbe/Logic/vtkPVScalarBarActor.cxx
+++ b/Modules/Scripted/DataProbe/Logic/vtkPVScalarBarActor.cxx
@@ -1246,7 +1246,7 @@ void vtkPVScalarBarActor::BuildScalarBarTexture()
   colorMapImage->SetExtent(0, COLOR_TEXTURE_MAP_SIZE-1, 0, 0, 0, 0);
   colorMapImage->AllocateScalars(VTK_UNSIGNED_CHAR, 4);
   vtkDataArray* colors
-    = this->LookupTable->MapScalars(tmp.GetPointer(), VTK_COLOR_MODE_MAP_SCALARS, 0);
+    = vtkDataArray::SafeDownCast(this->LookupTable->MapScalars(tmp.GetPointer(), VTK_COLOR_MODE_MAP_SCALARS, 0));
   colorMapImage->GetPointData()->SetScalars(colors);
   colors->Delete();
 

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,7 +202,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG a64d854cd826fb90b2aeb88907e948b3639f517f
+  GIT_TAG 5df87dee75c049320943f445200b4cbe7309f811
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)
@@ -354,7 +354,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG 28b2567f8c155d4665ae5c684c5d8ad9e7961934
+  GIT_TAG 501a0c7c5754d90c1ad7f2341e5bc250c923e66d
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -35,6 +35,19 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
       -DPYTHON_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}
       )
+    if(Slicer_VTK_VERSION_MAJOR STREQUAL "9")
+      list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+        # Required by CTK SuperBuild to conditionally pass Python3_* variables
+        -DVTK_PYTHON_VERSION:STRING=3
+        # Required by FindPython3 CMake module used by VTK
+        -DPython3_ROOT_DIR:PATH=${Python3_ROOT_DIR}
+        -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR}
+        -DPython3_LIBRARY:FILEPATH=${Python3_LIBRARY}
+        -DPython3_LIBRARY_DEBUG:FILEPATH=${Python3_LIBRARY_DEBUG}
+        -DPython3_LIBRARY_RELEASE:FILEPATH=${Python3_LIBRARY_RELEASE}
+        -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE}
+        )
+    endif()
   endif()
 
   if(Slicer_BUILD_DICOM_SUPPORT)
@@ -57,7 +70,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "92d2191b15894f42aa7446970faa974652410536"
+    "48e4a3f385ff89b0e013d11177cecceccbde2d87"
     QUIET
     )
 

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -57,6 +57,17 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
       -DPYTHON_EXECUTABLE:PATH=${PYTHON_EXECUTABLE}
       )
+    if(Slicer_VTK_VERSION_MAJOR STREQUAL "9")
+      list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+        # Required by FindPython3 CMake module used by VTK
+        -DPython3_ROOT_DIR:PATH=${Python3_ROOT_DIR}
+        -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR}
+        -DPython3_LIBRARY:FILEPATH=${Python3_LIBRARY}
+        -DPython3_LIBRARY_DEBUG:FILEPATH=${Python3_LIBRARY_DEBUG}
+        -DPython3_LIBRARY_RELEASE:FILEPATH=${Python3_LIBRARY_RELEASE}
+        -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE}
+        )
+    endif()
   endif()
 
   if(Slicer_BUILD_ITKPython)

--- a/SuperBuild/External_ParameterSerializer.cmake
+++ b/SuperBuild/External_ParameterSerializer.cmake
@@ -32,6 +32,20 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
 
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+
+  if(Slicer_VTK_VERSION_MAJOR STREQUAL "9" AND Slicer_USE_PYTHONQT)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      # Required by FindPython3 CMake module used by VTK
+      -DPython3_ROOT_DIR:PATH=${Python3_ROOT_DIR}
+      -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR}
+      -DPython3_LIBRARY:FILEPATH=${Python3_LIBRARY}
+      -DPython3_LIBRARY_DEBUG:FILEPATH=${Python3_LIBRARY_DEBUG}
+      -DPython3_LIBRARY_RELEASE:FILEPATH=${Python3_LIBRARY_RELEASE}
+      -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE}
+      )
+  endif()
+
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
     GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
@@ -51,6 +65,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DJsonCpp_INCLUDE_DIR:PATH=${JsonCpp_INCLUDE_DIR}
       -DJsonCpp_LIBRARY:PATH=${JsonCpp_LIBRARY}
       -DITK_DIR:PATH=${ITK_DIR}
+      ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
     INSTALL_COMMAND ""
     DEPENDS
       ${${proj}_DEPENDENCIES}

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -49,6 +49,18 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       )
   endif()
 
+  if(Slicer_VTK_VERSION_MAJOR STREQUAL "9" AND Slicer_USE_PYTHONQT)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      # Required by FindPython3 CMake module used by VTK
+      -DPython3_ROOT_DIR:PATH=${Python3_ROOT_DIR}
+      -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR}
+      -DPython3_LIBRARY:FILEPATH=${Python3_LIBRARY}
+      -DPython3_LIBRARY_DEBUG:FILEPATH=${Python3_LIBRARY_DEBUG}
+      -DPython3_LIBRARY_RELEASE:FILEPATH=${Python3_LIBRARY_RELEASE}
+      -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE}
+      )
+  endif()
+
   if(Slicer_USE_TBB)
     list(APPEND EXTERNAL_PROJECT_ADDITIONAL_FORWARD_PATHS_BUILD
       ${TBB_BIN_DIR}

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -32,6 +32,8 @@ endif()
 if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM_${proj})
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
+  set(EXTERNAL_PROJECT_OPTIONAL_VTK8_CMAKE_CACHE_ARGS)
+  set(EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS)
 
   set(VTK_WRAP_PYTHON OFF)
 
@@ -45,31 +47,59 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
       -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR}
       -DPYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}
       )
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS
+      -DVTK_PYTHON_VERSION:STRING=3
+      -DPython3_ROOT_DIR:PATH=${Python3_ROOT_DIR}
+      -DPython3_INCLUDE_DIR:PATH=${Python3_INCLUDE_DIR}
+      -DPython3_LIBRARY:FILEPATH=${Python3_LIBRARY}
+      -DPython3_LIBRARY_DEBUG:FILEPATH=${Python3_LIBRARY_DEBUG}
+      -DPython3_LIBRARY_RELEASE:FILEPATH=${Python3_LIBRARY_RELEASE}
+      -DPython3_EXECUTABLE:FILEPATH=${Python3_EXECUTABLE}
+      )
   endif()
 
   # Markups module needs vtkFrenetSerretFrame, which is available in
   # SplineDrivenImageSlicer remote module.
-  list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK8_CMAKE_CACHE_ARGS
     -DModule_SplineDrivenImageSlicer:BOOL=ON
     )
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS
+    -DVTK_MODULE_ENABLE_VTK_SplineDrivenImageSlicer:BOOL=YES
+    )
 
-  list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS
+    -DVTK_MODULE_ENABLE_VTK_ChartsCore:STRING=YES
+    -DVTK_MODULE_ENABLE_VTK_ViewsContext2D:STRING=YES
+    -DVTK_MODULE_ENABLE_VTK_RenderingContext2D:STRING=YES
+    -DVTK_MODULE_ENABLE_VTK_RenderingContextOpenGL2:STRING=YES
+    )
+
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK8_CMAKE_CACHE_ARGS
     -DVTK_USE_GUISUPPORT:BOOL=ON
     -DVTK_USE_QVTK_QTOPENGL:BOOL=ON
     -DModule_vtkTestingRendering:BOOL=ON
     )
-    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
-      -DVTK_QT_VERSION:STRING=5
-      -DVTK_Group_Qt:BOOL=ON
-      -DQt5_DIR:FILEPATH=${Qt5_DIR}
-      )
-  if("${Slicer_VTK_RENDERING_BACKEND}" STREQUAL "OpenGL2")
-    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
-      -DModule_vtkGUISupportQtOpenGL:BOOL=ON
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS
+    -DVTK_MODULE_ENABLE_VTK_GUISupportQt:STRING=YES
+    -DVTK_GROUP_ENABLE_Qt:STRING=YES
     )
+
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+    -DVTK_QT_VERSION:STRING=5
+    -DVTK_Group_Qt:BOOL=ON
+    -DQt5_DIR:FILEPATH=${Qt5_DIR}
+    )
+
+  if("${Slicer_VTK_RENDERING_BACKEND}" STREQUAL "OpenGL2")
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK8_CMAKE_CACHE_ARGS
+      -DModule_vtkGUISupportQtOpenGL:BOOL=ON
+      )
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS
+      -DVTK_MODULE_ENABLE_VTK_GUISupportQtOpenGL:STRING=YES
+      )
   endif()
   if(Slicer_USE_TBB)
-    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK8_CMAKE_CACHE_ARGS
       -DTBB_INCLUDE_DIR:PATH=${TBB_INCLUDE_DIR}
       -DTBB_LIBRARY_DEBUG:FILEPATH=${TBB_LIBRARY_DEBUG}
       -DTBB_LIBRARY_RELEASE:FILEPATH=${TBB_LIBRARY_RELEASE}
@@ -79,6 +109,9 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
       -DTBB_MALLOC_PROXY_INCLUDE_DIR:PATH=${TBB_MALLOC_PROXY_INCLUDE_DIR}
       -DTBB_MALLOC_PROXY_LIBRARY_DEBUG:FILEPATH=${TBB_MALLOC_PROXY_LIBRARY_DEBUG}
       -DTBB_MALLOC_PROXY_LIBRARY_RELEASE:FILEPATH=${TBB_MALLOC_PROXY_LIBRARY_RELEASE}
+      )
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS
+      -DTBB_DIR:PATH=${TBB_INSTALL_DIR}/tbb${tbb_ver}/cmake
       )
   endif()
   if(APPLE)
@@ -114,18 +147,42 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
       )
   endif()
 
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK8_CMAKE_CACHE_ARGS
+    -DBUILD_TESTING:BOOL=OFF
+    -DBUILD_EXAMPLES:BOOL=OFF
+    -DBUILD_SHARED_LIBS:BOOL=ON
+    -DVTK_USE_PARALLEL:BOOL=ON
+    -DVTK_WRAP_TCL:BOOL=OFF
+    -DModule_vtkAcceleratorsVTKm:BOOL=OFF
+    )
+  list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS
+    -DVTK_BUILD_TESTING:STRING=OFF
+    -DVTK_MODULE_ENABLE_VTK_AcceleratorsVTKm:BOOL=OFF
+    -DCMAKE_INSTALL_LIBDIR:STRING=lib # Force value to prevent lib64 from being used on Linux
+    # These options have been removed in VTK >= 8.90:
+    # - BUILD_EXAMPLE
+    # - BUILD_SHARED_LIBS
+    # - VTK_USE_PARALLEL
+    # - VTK_WRAP_TCL
+    )
+
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
     "${EP_GIT_PROTOCOL}://github.com/slicer/VTK.git"
     QUIET
     )
 
-set(_git_tag)
-if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "8")
-  set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
-else()
-  message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
-endif()
+  set(_git_tag)
+  if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "8")
+    set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
+    set(vtk_egg_info_version "8.2.0")
+  elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
+    set(_git_tag "2f4e011bfcf95cb6c10ac42403b37f3fc7808048") # slicer-v9.0.20200929-3fa220f28e
+    set(vtk_egg_info_version "9.0.20200825")
+  else()
+    message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
+  endif()
+
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
     ${_git_tag}
@@ -149,13 +206,8 @@ endif()
       -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
       -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
       -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
-      -DBUILD_TESTING:BOOL=OFF
-      -DBUILD_EXAMPLES:BOOL=OFF
-      -DBUILD_SHARED_LIBS:BOOL=ON
-      -DVTK_USE_PARALLEL:BOOL=ON
       -DVTK_DEBUG_LEAKS:BOOL=${VTK_DEBUG_LEAKS}
       -DVTK_LEGACY_REMOVE:BOOL=ON
-      -DVTK_WRAP_TCL:BOOL=OFF
       #-DVTK_USE_RPATH:BOOL=ON # Unused
       -DVTK_WRAP_PYTHON:BOOL=${VTK_WRAP_PYTHON}
       -DVTK_INSTALL_RUNTIME_DIR:PATH=${Slicer_INSTALL_BIN_DIR}
@@ -169,8 +221,8 @@ endif()
       -DVTK_ENABLE_KITS:BOOL=ON
       -DVTK_RENDERING_BACKEND:STRING=${Slicer_VTK_RENDERING_BACKEND}
       -DVTK_SMP_IMPLEMENTATION_TYPE:STRING=${Slicer_VTK_SMP_IMPLEMENTATION_TYPE}
-      -DModule_vtkAcceleratorsVTKm:BOOL=OFF
       ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
+      ${EXTERNAL_PROJECT_OPTIONAL_VTK${Slicer_VTK_VERSION_MAJOR}_CMAKE_CACHE_ARGS}
     INSTALL_COMMAND ""
     DEPENDS
       ${${proj}_DEPENDENCIES}
@@ -179,7 +231,7 @@ endif()
   if(Slicer_USE_PYTHONQT AND NOT Slicer_USE_SYSTEM_python)
     # Create the vtk-*.egg-info directory to prevent pip from re-installing
     # vtk package as a wheel when listed as dependency in Slicer extension.
-    set(_vtk_egg_info_dir "${python_DIR}/${PYTHON_SITE_PACKAGES_SUBDIR}/vtk-8.2.0-py3.6.egg-info")
+    set(_vtk_egg_info_dir "${python_DIR}/${PYTHON_SITE_PACKAGES_SUBDIR}/vtk-${vtk_egg_info_version}-py3.6.egg-info")
     ExternalProject_Add_Step(${proj} create_egg_info
       COMMAND ${CMAKE_COMMAND} -E make_directory ${_vtk_egg_info_dir}
       COMMAND ${CMAKE_COMMAND} -E touch ${_vtk_egg_info_dir}/PKG-INFO
@@ -218,9 +270,15 @@ endif()
         ${VTK_DIR}/${_library_output_subdir}/python3.6/site-packages
         )
     else()
-      set(${proj}_PYTHONPATH_LAUNCHER_BUILD
-        ${VTK_DIR}/${_library_output_subdir}/<CMAKE_CFG_INTDIR>/Lib/site-packages
-        )
+      if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
+        set(${proj}_PYTHONPATH_LAUNCHER_BUILD
+          ${VTK_DIR}/${_library_output_subdir}/Lib/site-packages
+          )
+      else()
+        set(${proj}_PYTHONPATH_LAUNCHER_BUILD
+          ${VTK_DIR}/${_library_output_subdir}/<CMAKE_CFG_INTDIR>/Lib/site-packages
+          )
+      endif()
     endif()
 
   mark_as_superbuild(

--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -394,6 +394,32 @@ if(WIN32)
   ExternalProject_Message(${proj} "PYTHON_DEBUG_LIBRARY:${PYTHON_DEBUG_LIBRARY}")
 endif()
 
+# Variable expected by FindPython3 CMake module
+set(Python3_ROOT_DIR ${python_DIR})
+set(Python3_INCLUDE_DIR ${PYTHON_INCLUDE_DIR})
+set(Python3_LIBRARY ${PYTHON_LIBRARY})
+set(Python3_LIBRARY_DEBUG ${PYTHON_LIBRARY})
+set(Python3_LIBRARY_RELEASE ${PYTHON_LIBRARY})
+set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
+
+mark_as_superbuild(
+  VARS
+    Python3_ROOT_DIR:PATH
+    Python3_INCLUDE_DIR:PATH
+    Python3_LIBRARY:FILEPATH
+    Python3_LIBRARY_DEBUG:FILEPATH
+    Python3_LIBRARY_RELEASE:FILEPATH
+    Python3_EXECUTABLE:FILEPATH
+  LABELS "FIND_PACKAGE"
+  )
+
+ExternalProject_Message(${proj} "Python3_ROOT_DIR:${Python3_ROOT_DIR}")
+ExternalProject_Message(${proj} "Python3_INCLUDE_DIR:${Python3_INCLUDE_DIR}")
+ExternalProject_Message(${proj} "Python3_LIBRARY:${Python3_LIBRARY}")
+ExternalProject_Message(${proj} "Python3_LIBRARY_DEBUG:${Python3_LIBRARY_DEBUG}")
+ExternalProject_Message(${proj} "Python3_LIBRARY_RELEASE:${Python3_LIBRARY_RELEASE}")
+ExternalProject_Message(${proj} "Python3_EXECUTABLE:${Python3_EXECUTABLE}")
+
 #!
 #! ExternalProject_PythonModule_InstallTreeCleanup(<proj> <modname> "[<dirname1>;[<dirname2>;[...]]]"))
 #!


### PR DESCRIPTION
Option `Slicer_VTK_VERSION_MAJOR` now accepts value `8` and `9` and default is `9`.

Notes:
* <s>This PR should be integrated after https://github.com/Slicer/Slicer/pull/5105</s> :heavy_check_mark: 

Status:
* Linux build complete with `Slicer_VTK_VERSION_MAJOR` set to either `8` or `9`
* Building with `Slicer_VTK_VERSION_MAJOR` set to `8` is expected to work.

Remaining tasks when `Slicer_VTK_VERSION_MAJOR` is set to `9` (enabled by default with this branch):
* [x] Fix loading of python modules. See https://discourse.vtk.org/t/issue-with-using-vtkpythonutil-getobjectfrompointer-for-custom-vtk-classes/4100
* [x] Test building without error on all platforms
   * [x] Linux :heavy_check_mark: 
   * [x] macOS :heavy_check_mark: 
   * [x] Windows :heavy_check_mark: 
* [ ] Test packaging on all platforms
   * [ ] Linux :hourglass_flowing_sand: 
   * [ ] macOS :hourglass_flowing_sand: 
   * [ ] Windows :hourglass_flowing_sand: 
* [x] Update wrapping macros to not build `PythonD` libraries
* [ ] Test build of extensions
* [ ] Add support for building SlicerOpenVR extension
* [x] Add support for `MiddleButtonDoubleClickEvent`. See https://github.com/Slicer/Slicer/pull/5141#discussion_r479690583
* [ ] Address `vtkImageData` warnings. See https://github.com/Slicer/Slicer/pull/5141#issuecomment-683343254
* [x] <s>Address error with `qSlicerSubjectHierarchyPluginLogic`. See https://github.com/Slicer/Slicer/pull/5141#issuecomment-683343254</s>. **Known regression:** It is currently in Slicer master, it will be addressed independently by Csaba. See https://github.com/Slicer/Slicer/pull/5141#issuecomment-683377638
* [ ] Integrate branches:
  - [x] [commontk/CTK@support-build-with-vtk89](https://github.com/commontk/CTK/tree/support-build-with-vtk89)
  - [x] [fedorov/MultiVolumeExplorer@use-override-support-cpp11-only](https://github.com/fedorov/MultiVolumeExplorer/tree/use-override-support-cpp11-only). :heavy_check_mark:  Integrated in https://github.com/Slicer/Slicer/pull/5168
  - [x] [Slicer/vtkAddon@support-build-with-vtk89](https://github.com/Slicer/vtkAddon/tree/support-build-with-vtk89)
  - [x] [Slicer/SlicerSurfaceToolbox@support-build-with-vtk89](https://github.com/Slicer/SlicerSurfaceToolbox/tree/support-build-with-vtk89) 