### PR TITLE
ENH: Allow switch between json and fcsv format for markups

### DIFF
--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -890,7 +890,7 @@ bool qSlicerSaveDataDialogPrivate::saveNodes()
     qSlicerIOOptions* options = this->options(row);
     vtkMRMLNode* node = vtkMRMLNode::SafeDownCast(this->object(row));
     vtkMRMLStorableNode* const storableNode = vtkMRMLStorableNode::SafeDownCast(this->object(row));
-    vtkMRMLStorageNode* const snode = storableNode ? storableNode->GetStorageNode() : nullptr;
+    vtkMRMLStorageNode* snode = storableNode ? storableNode->GetStorageNode() : nullptr;
 
     if (snode)
       {
@@ -938,6 +938,8 @@ bool qSlicerSaveDataDialogPrivate::saveNodes()
     QApplication::restoreOverrideCursor();
 
     // node has failed to be written
+    // get storage node again because the writer plugin may replace the storage node with a different class
+    snode = storableNode->GetStorageNode();
     if (!success)
       {
       if (snode)

--- a/Modules/Loadable/Markups/CMakeLists.txt
+++ b/Modules/Loadable/Markups/CMakeLists.txt
@@ -38,6 +38,8 @@ set(MODULE_SRCS
   qSlicer${MODULE_NAME}Reader.h
   qSlicer${MODULE_NAME}SettingsPanel.cxx
   qSlicer${MODULE_NAME}SettingsPanel.h
+  qSlicer${MODULE_NAME}Writer.cxx
+  qSlicer${MODULE_NAME}Writer.h
   )
 
 set(MODULE_MOC_SRCS
@@ -45,6 +47,7 @@ set(MODULE_MOC_SRCS
   qSlicer${MODULE_NAME}ModuleWidget.h
   qSlicer${MODULE_NAME}Reader.h
   qSlicer${MODULE_NAME}SettingsPanel.h
+  qSlicer${MODULE_NAME}Writer.h
   )
 
 set(MODULE_UI_SRCS

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -225,18 +225,3 @@ void vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes()
     }
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }
-
-//-------------------------------------------------------------------------
-vtkMRMLStorageNode* vtkMRMLMarkupsFiducialNode::CreateDefaultStorageNode()
-{
-  vtkMRMLScene* scene = this->GetScene();
-  if (scene == nullptr)
-    {
-    vtkErrorMacro("CreateDefaultStorageNode failed: scene is invalid");
-    return nullptr;
-    }
-  // Use csv-based vtkMRMLMarkupsFiducialStorageNode as default storage node
-  // by default for backward compatibility.
-  return vtkMRMLStorageNode::SafeDownCast(
-    scene->CreateNodeByClass("vtkMRMLMarkupsFiducialStorageNode"));
-}

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -124,9 +124,6 @@ public:
   /// Create and observe default display node(s)
   void CreateDefaultDisplayNodes() override;
 
-  /// Create default storage node or nullptr if does not have one
-  vtkMRMLStorageNode* CreateDefaultStorageNode() override;
-
 protected:
   vtkMRMLMarkupsFiducialNode();
   ~vtkMRMLMarkupsFiducialNode() override;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -19,6 +19,7 @@
 #include "vtkMRMLMarkupsNode.h"
 
 #include "vtkMRMLScene.h"
+#include "vtkMRMLMessageCollection.h"
 #include "vtkSlicerVersionConfigure.h"
 
 #include "vtkObjectFactory.h"
@@ -705,6 +706,9 @@ int vtkMRMLMarkupsFiducialStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
     vtkErrorMacro("WriteData: unable to cast input node " << refNode->GetID() << " to a known markups node");
     return 0;
     }
+
+  this->GetUserMessages()->AddMessage(vtkCommand::WarningEvent,
+    "fcsv file format only stores control point coordinates and a limited set of display properties.");
 
   // open the file for writing
   fstream of;

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -40,6 +40,7 @@
 #include "qSlicerMarkupsModule.h"
 #include "qSlicerMarkupsModuleWidget.h"
 #include "qSlicerMarkupsReader.h"
+#include "qSlicerMarkupsWriter.h"
 //#include "qSlicerMarkupsSettingsPanel.h"
 //#include "vtkSlicerMarkupsLogic.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
@@ -126,8 +127,7 @@ void qSlicerMarkupsModule::setup()
   qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
   qSlicerMarkupsReader *markupsReader = new qSlicerMarkupsReader(vtkSlicerMarkupsLogic::SafeDownCast(this->logic()), this);
   ioManager->registerIO(markupsReader);
-  ioManager->registerIO(new qSlicerNodeWriter("Markups", "MarkupsFile", QStringList() << "vtkMRMLMarkupsNode", true, this));
-  ioManager->registerIO(new qSlicerNodeWriter("Markups Fiducial", "MarkupsFiducialFile", QStringList() << "vtkMRMLMarkupsFiducialNode", true, this));
+  ioManager->registerIO(new qSlicerMarkupsWriter(this));
 
   // settings
   /*

--- a/Modules/Loadable/Markups/qSlicerMarkupsWriter.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsWriter.cxx
@@ -1,0 +1,135 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women�s Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+// Qt includes
+#include <QDebug>
+
+// QtGUI includes
+#include "qSlicerMarkupsWriter.h"
+
+// QTCore includes
+#include "qSlicerCoreApplication.h"
+#include "qSlicerCoreIOManager.h"
+
+// MRML includes
+#include <vtkMRMLScene.h>
+#include <vtkMRMLSceneViewNode.h>
+#include <vtkMRMLMarkupsJsonStorageNode.h>
+#include <vtkMRMLMarkupsFiducialStorageNode.h>
+#include <vtkMRMLStorableNode.h>
+#include <vtkMRMLStorageNode.h>
+
+// VTK includes
+#include <vtkStdString.h>
+#include <vtkStringArray.h>
+
+//----------------------------------------------------------------------------
+qSlicerMarkupsWriter::qSlicerMarkupsWriter(QObject* parentObject)
+  : qSlicerNodeWriter("Markups", QString("MarkupsFile"), QStringList() << "vtkMRMLMarkupsNode", true, parentObject)
+{
+}
+
+//----------------------------------------------------------------------------
+qSlicerMarkupsWriter::~qSlicerMarkupsWriter() = default;
+
+//----------------------------------------------------------------------------
+QStringList qSlicerMarkupsWriter::extensions(vtkObject* object)const
+{
+  QStringList supportedExtensions;
+
+  vtkNew<vtkMRMLMarkupsJsonStorageNode> jsonStorageNode;
+  const int formatCount = jsonStorageNode->GetSupportedWriteFileTypes()->GetNumberOfValues();
+  for (int formatIt = 0; formatIt < formatCount; ++formatIt)
+    {
+    vtkStdString format = jsonStorageNode->GetSupportedWriteFileTypes()->GetValue(formatIt);
+    supportedExtensions << QString::fromStdString(format);
+    }
+
+  vtkNew<vtkMRMLMarkupsFiducialStorageNode> fcsvStorageNode;
+  const int fidsFormatCount = fcsvStorageNode->GetSupportedWriteFileTypes()->GetNumberOfValues();
+  for (int formatIt = 0; formatIt < fidsFormatCount; ++formatIt)
+    {
+    vtkStdString format = fcsvStorageNode->GetSupportedWriteFileTypes()->GetValue(formatIt);
+    supportedExtensions << QString::fromStdString(format);
+    }
+
+  return supportedExtensions;
+}
+
+//----------------------------------------------------------------------------
+void qSlicerMarkupsWriter::setStorageNodeClass(vtkMRMLStorableNode* storableNode, const QString& storageNodeClassName)
+{
+  if (!storableNode)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: invalid storable node";
+    return;
+    }
+  vtkMRMLScene* scene = storableNode->GetScene();
+  if (!scene)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: invalid scene";
+    return;
+    }
+
+  vtkMRMLStorageNode* currentStorageNode = storableNode->GetStorageNode();
+  std::string storageNodeClassNameStr = storageNodeClassName.toStdString();
+  if (currentStorageNode != nullptr && currentStorageNode->IsA(storageNodeClassNameStr.c_str()))
+    {
+    // requested storage node class is the same as current class, there is nothing to do
+    return;
+    }
+
+  // Create and use new storage node of the correct class
+  vtkMRMLStorageNode* newStorageNode = vtkMRMLStorageNode::SafeDownCast(scene->AddNewNodeByClass(storageNodeClassNameStr));
+  if (!newStorageNode)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: cannot create new storage noed of class " << storageNodeClassName;
+    return;
+    }
+  storableNode->SetAndObserveStorageNodeID(newStorageNode->GetID());
+
+  // Remove old storage node
+  if (currentStorageNode)
+    {
+    scene->RemoveNode(currentStorageNode);
+    }
+}
+
+//----------------------------------------------------------------------------
+bool qSlicerMarkupsWriter::write(const qSlicerIO::IOProperties& properties)
+{
+  vtkMRMLStorableNode* node = vtkMRMLStorableNode::SafeDownCast(this->getNodeByID(properties["nodeID"].toString().toUtf8().data()));
+  std::string fileName = properties["fileName"].toString().toUtf8();
+
+  vtkNew<vtkMRMLMarkupsFiducialStorageNode> fcsvStorageNode;
+  std::string fcsvCompatibleFileExtension = fcsvStorageNode->GetSupportedFileExtension(fileName.c_str(), false, true);
+  if (!fcsvCompatibleFileExtension.empty())
+    {
+    // fcsv file needs to be written
+    this->setStorageNodeClass(node, "vtkMRMLMarkupsFiducialStorageNode");
+    }
+  else
+    {
+    // json file needs to be written
+    this->setStorageNodeClass(node, "vtkMRMLMarkupsJsonStorageNode");
+    }
+
+  return Superclass::write(properties);
+}

--- a/Modules/Loadable/Markups/qSlicerMarkupsWriter.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsWriter.h
@@ -1,0 +1,51 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women�s Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#ifndef __qSlicerMarkupsWriter_h
+#define __qSlicerMarkupsWriter_h
+
+// QtCore includes
+#include "qSlicerMarkupsModuleExport.h"
+#include "qSlicerNodeWriter.h"
+
+class vtkMRMLNode;
+class vtkMRMLStorableNode;
+
+/// Utility class that offers writing of markups in both json format, regardless of the current storage node.
+class Q_SLICER_QTMODULES_MARKUPS_EXPORT qSlicerMarkupsWriter
+  : public qSlicerNodeWriter
+{
+  Q_OBJECT
+public:
+  typedef qSlicerNodeWriter Superclass;
+  qSlicerMarkupsWriter(QObject* parent);
+  ~qSlicerMarkupsWriter() override;
+
+  QStringList extensions(vtkObject* object)const override;
+
+  bool write(const qSlicerIO::IOProperties& properties) override;
+
+  void setStorageNodeClass(vtkMRMLStorableNode* storableNode, const QString& storageNodeClassName);
+
+private:
+  Q_DISABLE_COPY(qSlicerMarkupsWriter);
+};
+
+#endif


### PR DESCRIPTION
Added a dedicated markups writer plugin that offers loading both json and fcsv formats for saving any markup node type. This allows easy switching between formats in save dialog:

![image](https://user-images.githubusercontent.com/307929/91468074-7757c780-e85f-11ea-988e-64bfc68b22a3.png)

Default format is now json for all types (as user can easily change in save dialog). If fcsv format is used then a warning icon is displayed about the lossy storage (no popup is displayed, the warning can be dismissed by closing the save dialog by clicking a button or hitting escape or enter key):

![image](https://user-images.githubusercontent.com/307929/91468124-88083d80-e85f-11ea-9d17-bd34987daa17.png)
