### PR TITLE
BUG: Fix duplicate python logging messages in the log

### DIFF
--- a/Base/Python/slicer/slicerqt.py
+++ b/Base/Python/slicer/slicerqt.py
@@ -64,9 +64,7 @@ def initLogging(logger):
   Initialize logging by creating log handlers and setting default log level.
   """
 
-  # Prints debug messages to Slicer application log.
-  # Only debug level messages are logged this way, as higher level messages are printed on console
-  # and all console outputs are sent automatically to the application log anyway.
+  # Prints debug, info, warning and error messages to Slicer application log.
   applicationLogHandler = SlicerApplicationLogHandler()
   applicationLogHandler.setLevel(logging.DEBUG)
   # We could filter out messages at INFO level or above (as they will be printed on the console anyway) by adding
@@ -74,18 +72,6 @@ def initLogging(logger):
   # but then we would not log file name and line number of info, warning, and error level messages.
   applicationLogHandler.setFormatter(logging.Formatter('%(message)s'))
   logger.addHandler(applicationLogHandler)
-
-  # Prints info message to stdout (anything on stdout will also show up in the application log)
-  consoleInfoHandler = logging.StreamHandler(sys.stdout)
-  consoleInfoHandler.setLevel(logging.INFO)
-  # Filter messages at WARNING level or above (they will be printed on stderr)
-  consoleInfoHandler.addFilter(_LogReverseLevelFilter(logging.WARNING))
-  logger.addHandler(consoleInfoHandler)
-
-  # Prints error and warning messages to stderr (anything on stderr will also show it in the application log)
-  consoleErrorHandler = logging.StreamHandler(sys.stderr)
-  consoleErrorHandler.setLevel(logging.WARNING)
-  logger.addHandler(consoleErrorHandler)
 
   # Log debug messages from scripts by default, as they are useful for troubleshooting with users
   logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Python INFO, WARNING, and ERROR messages generated by the python logging module created duplicate entries as seen in the Slicer log file and in the Error Log Dialog.  This commit removes python logging messages from showing in the python console as they are already included in the Slicer log and should be viewed there.

When using logging across many scripted modules, this current duplication makes reading the Slicer log and using the Error Log Dialog **much** more difficult to understand.

### Before:
```
[DEBUG][Qt] 27.08.2020 22:56:22 [] (unknown:0) - Switch to module:  "ScreenCapture"
[INFO][Python] 27.08.2020 22:56:25 [Python] (C:/Users/james/AppData/Local/NA-MIC/Slicer 4.11.0-2020-08-26/bin/../lib/Slicer-4.11/qt-scripted-modules/ScreenCapture.py:805) - Write C:\Users\james\Documents\SlicerCapture\image_00004.png
[INFO][Stream] 27.08.2020 22:56:25 [] (unknown:0) - Write C:\Users\james\Documents\SlicerCapture\image_00004.png
```
![image](https://user-images.githubusercontent.com/15837524/91516864-8a4bb580-e8ba-11ea-9903-aee2ff855633.png)

### After:
```
[DEBUG][Qt] 27.08.2020 23:13:22 [] (unknown:0) - Switch to module:  "ScreenCapture"
[INFO][Python] 27.08.2020 23:13:25 [Python] (C:/Users/james/AppData/Local/NA-MIC/Slicer 4.11.0-2020-08-26/bin/../lib/Slicer-4.11/qt-scripted-modules/ScreenCapture.py:805) - Write C:\Users\james\Documents\SlicerCapture\image_00005.png
```
![image](https://user-images.githubusercontent.com/15837524/91517194-3ee5d700-e8bb-11ea-8de5-20def1018c60.png)

