### PR TITLE
BUG: Fix duplicate python logging messages in the log for regular users

### DIFF
--- a/Base/Python/slicer/slicerqt.py
+++ b/Base/Python/slicer/slicerqt.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import ctk
 import qt
@@ -48,6 +47,7 @@ class SlicerApplicationLogHandler(logging.Handler):
 
     def emit(self, record):
         try:
+            # Add application log entry
             msg = self.format(record)
             context = ctk.ctkErrorLogContext()
             context.setCategory(self.category)
@@ -56,8 +56,8 @@ class SlicerApplicationLogHandler(logging.Handler):
             context.setFunction(record.funcName)
             context.setMessage(msg)
             threadId = f"{record.threadName}({record.thread})"
-            slicer.app.errorLogModel().addEntry(qt.QDateTime.currentDateTime(), threadId,
-                                                self.pythonToCtkLevelConverter[record.levelno], self.origin, context, msg)
+            slicer.app.errorLogModel().postEntry(qt.QDateTime.currentDateTime(), threadId,
+                                                 self.pythonToCtkLevelConverter[record.levelno], self.origin, context, msg)
         except:
             self.handleError(record)
 
@@ -71,25 +71,13 @@ def initLogging(logger):
     # Prints debug messages to Slicer application log.
     # Only debug level messages are logged this way, as higher level messages are printed on console
     # and all console outputs are sent automatically to the application log anyway.
-    applicationLogHandler = SlicerApplicationLogHandler()
-    applicationLogHandler.setLevel(logging.DEBUG)
+    slicer.pythonApplicationLogHandler = SlicerApplicationLogHandler()
+    slicer.pythonApplicationLogHandler.setLevel(logging.DEBUG)
     # We could filter out messages at INFO level or above (as they will be printed on the console anyway) by adding
     # applicationLogHandler.addFilter(_LogReverseLevelFilter(logging.INFO))
     # but then we would not log file name and line number of info, warning, and error level messages.
-    applicationLogHandler.setFormatter(logging.Formatter('%(message)s'))
-    logger.addHandler(applicationLogHandler)
-
-    # Prints info message to stdout (anything on stdout will also show up in the application log)
-    consoleInfoHandler = logging.StreamHandler(sys.stdout)
-    consoleInfoHandler.setLevel(logging.INFO)
-    # Filter messages at WARNING level or above (they will be printed on stderr)
-    consoleInfoHandler.addFilter(_LogReverseLevelFilter(logging.WARNING))
-    logger.addHandler(consoleInfoHandler)
-
-    # Prints error and warning messages to stderr (anything on stderr will also show it in the application log)
-    consoleErrorHandler = logging.StreamHandler(sys.stderr)
-    consoleErrorHandler.setLevel(logging.WARNING)
-    logger.addHandler(consoleErrorHandler)
+    slicer.pythonApplicationLogHandler.setFormatter(logging.Formatter('%(message)s'))
+    logger.addHandler(slicer.pythonApplicationLogHandler)
 
     # Log debug messages from scripts by default, as they are useful for troubleshooting with users
     logger.setLevel(logging.DEBUG)

--- a/Base/QTGUI/Resources/UI/qSlicerSettingsPythonPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsPythonPanel.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QGroupBox" name="ShellDisplayGroupBox">
      <property name="title">
-      <string>Shell Display</string>
+      <string>Python Interactor</string>
      </property>
      <property name="flat">
       <bool>true</bool>
@@ -46,14 +46,28 @@
       <item row="1" column="0">
        <widget class="QLabel" name="PromptFontLabel">
         <property name="text">
-         <string>Shell font:</string>
+         <string>Font:</string>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="ctkFontButton" name="pythonFontButton">
+       <widget class="ctkFontButton" name="ConsoleFontButton">
         <property name="text">
          <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="LogLevelLabel">
+        <property name="text">
+         <string>Log level:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="ConsoleLogLevelComboBox">
+        <property name="toolTip">
+         <string>Log messages at this level and above are displayed in the Python interactor.</string>
         </property>
        </widget>
       </item>

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -25,6 +25,7 @@
 class QPalette;
 
 // CTK includes
+#include <ctkErrorLogModel.h>
 #include <ctkPimpl.h>
 #include <ctkSettingsDialog.h>
 
@@ -91,6 +92,8 @@ public:
   /// Get Python Manager
   Q_INVOKABLE qSlicerPythonManager * pythonManager();
   Q_INVOKABLE ctkPythonConsole * pythonConsole();
+  /// Log messages at this or higher level will be displayed in the Python console.
+  Q_INVOKABLE ctkErrorLogLevel::LogLevel pythonConsoleLogLevel()const;
 #endif
 
   #ifdef Slicer_USE_QtTesting
@@ -225,6 +228,11 @@ public slots:
   /// Override the qSlicerCoreApplication implementation to also show error messages in a popup window.
   bool loadFiles(const QStringList& filePaths, vtkMRMLMessageCollection* userMessages = nullptr) override;
 
+#ifdef Slicer_USE_PYTHONQT
+  /// Log messages at this or higher level will be displayed in the Python console.
+  void setPythonConsoleLogLevel(ctkErrorLogLevel::LogLevel logLevel);
+#endif
+
 signals:
 
   /// Emitted when the startup phase has been completed.
@@ -248,6 +256,12 @@ protected slots:
 
   /// Request editing of a MRML node
   void editNode(vtkObject*, void*, unsigned long) override;
+
+#ifdef Slicer_USE_PYTHONQT
+  /// Add log message to Python console
+  void logToPythonConsole(const QDateTime& currentDateTime, const QString& threadId,
+    ctkErrorLogLevel::LogLevel logLevel, const QString& origin, const ctkErrorLogContext& context, const QString& text);
+#endif
 
 protected:
   /// Reimplemented from qSlicerCoreApplication

--- a/Base/QTGUI/qSlicerSettingsPythonPanel.h
+++ b/Base/QTGUI/qSlicerSettingsPythonPanel.h
@@ -37,6 +37,7 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerSettingsPythonPanel
   : public ctkSettingsPanel
 {
   Q_OBJECT
+  Q_PROPERTY(QString consoleLogLevel READ consoleLogLevel WRITE setConsoleLogLevel NOTIFY consoleLogLevelChanged)
 public:
   /// Superclass typedef
   typedef ctkSettingsPanel Superclass;
@@ -47,8 +48,17 @@ public:
   /// Destructor
   ~qSlicerSettingsPythonPanel() override;
 
+  QString consoleLogLevel() const;
+
+public slots:
+  void setConsoleLogLevel(const QString& levelStr);
+
 protected slots:
   void onFontChanged(const QFont& font);
+  void onConsoleLogLevelChanged(const QString& levelStr);
+
+signals:
+  void consoleLogLevelChanged(const QString&);
 
 protected:
   QScopedPointer<qSlicerSettingsPythonPanelPrivate> d_ptr;


### PR DESCRIPTION
The motivation of this change is to improve user experience when viewing the Error Log Dialog and the slicer log as seen in the Report A Bug Dialog.  When there are, for example, 3 errors and 3 warnings, the user will see 3 errors and 3 warnings.  This is instead of 6 errors and 6 warnings where half were indicated from python and the other half were indicated from the stream.

This proposed change only shows python logging output in the console stream while in Developer Mode. For regular users not in developer mode they will no longer see double python logging (one from python and one from the stream).  

Developers will still have the double logging, but this appears to be desired behavior as they want knowledge of everything from the console stream in addition to everything from the python source.  The following code below indicates a method to prevent the double logging, but as it says, it would remove the line that includes the log file name and line number which is arguably the more important of the double logged messages.
https://github.com/Slicer/Slicer/blob/03113368de2e2afac71ade15ba0058b5e78dc39d/Base/Python/slicer/slicerqt.py#L72-L74

### Developer Mode:
```
[DEBUG][Qt] 27.08.2020 22:56:22 [] (unknown:0) - Switch to module:  "ScreenCapture"
[INFO][Python] 27.08.2020 22:56:25 [Python] (C:/Users/james/AppData/Local/NA-MIC/Slicer 4.11.0-2020-08-26/bin/../lib/Slicer-4.11/qt-scripted-modules/ScreenCapture.py:805) - Write C:\Users\james\Documents\SlicerCapture\image_00004.png
[INFO][Stream] 27.08.2020 22:56:25 [] (unknown:0) - Write C:\Users\james\Documents\SlicerCapture\image_00004.png
```
![image](https://user-images.githubusercontent.com/15837524/91516864-8a4bb580-e8ba-11ea-9903-aee2ff855633.png)

### Regular Users:
```
[DEBUG][Qt] 27.08.2020 23:13:22 [] (unknown:0) - Switch to module:  "ScreenCapture"
[INFO][Python] 27.08.2020 23:13:25 [Python] (C:/Users/james/AppData/Local/NA-MIC/Slicer 4.11.0-2020-08-26/bin/../lib/Slicer-4.11/qt-scripted-modules/ScreenCapture.py:805) - Write C:\Users\james\Documents\SlicerCapture\image_00005.png
```
![image](https://user-images.githubusercontent.com/15837524/91517194-3ee5d700-e8bb-11ea-8de5-20def1018c60.png)