### PR TITLE
ENH: Add miscellaneous improvements to markups VTK widgets

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
@@ -145,7 +145,7 @@ public:
   /// using the renderer of this class.
   void GetRendererComputedDisplayPositionFromWorldPosition(const double worldPos[3], double displayPos[2]);
 
-  void UpdateRelativeCoincidentTopologyOffsets(vtkMapper* mapper);
+  virtual void UpdateRelativeCoincidentTopologyOffsets(vtkMapper* mapper);
 
   /// The renderer in which this widget is placed
   vtkWeakPointer<vtkRenderer> Renderer;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
@@ -42,6 +42,7 @@ vtkStandardNewMacro(vtkSlicerAngleRepresentation3D);
 vtkSlicerAngleRepresentation3D::vtkSlicerAngleRepresentation3D()
 {
   this->Line = vtkSmartPointer<vtkPolyData>::New();
+
   this->Arc = vtkSmartPointer<vtkArcSource>::New();
   this->Arc->SetResolution(30);
 
@@ -55,12 +56,20 @@ vtkSlicerAngleRepresentation3D::vtkSlicerAngleRepresentation3D()
   this->ArcTubeFilter->SetNumberOfSides(20);
   this->ArcTubeFilter->SetRadius(1);
 
+  // Mappers
   this->LineMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
   this->LineMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
 
   this->ArcMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
   this->ArcMapper->SetInputConnection(this->ArcTubeFilter->GetOutputPort());
 
+  this->LineOccludedMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  this->LineOccludedMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
+
+  this->ArcOccludedMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  this->ArcOccludedMapper->SetInputConnection(this->ArcTubeFilter->GetOutputPort());
+
+  // Actors
   this->LineActor = vtkSmartPointer<vtkActor>::New();
   this->LineActor->SetMapper(this->LineMapper);
   this->LineActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
@@ -68,12 +77,6 @@ vtkSlicerAngleRepresentation3D::vtkSlicerAngleRepresentation3D()
   this->ArcActor = vtkSmartPointer<vtkActor>::New();
   this->ArcActor->SetMapper(this->ArcMapper);
   this->ArcActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
-
-  this->LineOccludedMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-  this->LineOccludedMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
-
-  this->ArcOccludedMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-  this->ArcOccludedMapper->SetInputConnection(this->ArcTubeFilter->GetOutputPort());
 
   this->LineOccludedActor = vtkSmartPointer<vtkActor>::New();
   this->LineOccludedActor->SetMapper(this->LineOccludedMapper);
@@ -200,10 +203,8 @@ void vtkSlicerAngleRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
 
   // Update lines display properties
 
-  this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
-  this->UpdateRelativeCoincidentTopologyOffsets(this->ArcMapper);
-  this->UpdateOccludedRelativeCoincidentTopologyOffsets(this->LineOccludedMapper);
-  this->UpdateOccludedRelativeCoincidentTopologyOffsets(this->ArcOccludedMapper);
+  this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper, this->LineOccludedMapper);
+  this->UpdateRelativeCoincidentTopologyOffsets(this->ArcMapper, this->ArcOccludedMapper);
 
   double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
     this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
@@ -76,22 +76,20 @@ protected:
   vtkSlicerAngleRepresentation3D();
   ~vtkSlicerAngleRepresentation3D() override;
 
-  vtkSmartPointer<vtkPolyData>                Line;
-  vtkSmartPointer<vtkPolyDataMapper>    LineMapper;
-  vtkSmartPointer<vtkActor>             LineActor;
+  vtkSmartPointer<vtkPolyData>   Line;
+  vtkSmartPointer<vtkArcSource>  Arc;
+  vtkSmartPointer<vtkTubeFilter> TubeFilter;
+  vtkSmartPointer<vtkTubeFilter> ArcTubeFilter;
 
-  vtkSmartPointer<vtkArcSource>               Arc;
-  vtkSmartPointer<vtkPolyDataMapper>    ArcMapper;
-  vtkSmartPointer<vtkActor>             ArcActor;
+  vtkSmartPointer<vtkPolyDataMapper> LineMapper;
+  vtkSmartPointer<vtkPolyDataMapper> ArcMapper;
+  vtkSmartPointer<vtkPolyDataMapper> LineOccludedMapper;
+  vtkSmartPointer<vtkPolyDataMapper> ArcOccludedMapper;
 
-  vtkSmartPointer<vtkTubeFilter>              TubeFilter;
-  vtkSmartPointer<vtkTubeFilter>              ArcTubeFilter;
-
-  vtkSmartPointer<vtkPolyDataMapper>    LineOccludedMapper;
-  vtkSmartPointer<vtkActor>             LineOccludedActor;
-
-  vtkSmartPointer<vtkPolyDataMapper>    ArcOccludedMapper;
-  vtkSmartPointer<vtkActor>             ArcOccludedActor;
+  vtkSmartPointer<vtkActor> LineActor;
+  vtkSmartPointer<vtkActor> ArcActor;
+  vtkSmartPointer<vtkActor> LineOccludedActor;
+  vtkSmartPointer<vtkActor> ArcOccludedActor;
 
   void BuildArc();
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
@@ -43,15 +43,17 @@ vtkSlicerCurveRepresentation3D::vtkSlicerCurveRepresentation3D()
   this->TubeFilter->SetNumberOfSides(20);
   this->TubeFilter->SetRadius(1);
 
+  // Mappers
   this->LineMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
   this->LineMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
 
+  this->LineOccludedMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  this->LineOccludedMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
+
+  // Actors
   this->LineActor = vtkSmartPointer<vtkActor>::New();
   this->LineActor->SetMapper(this->LineMapper);
   this->LineActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
-
-  this->LineOccludedMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-  this->LineOccludedMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
 
   this->LineOccludedActor = vtkSmartPointer<vtkActor>::New();
   this->LineOccludedActor->SetMapper(this->LineOccludedMapper);
@@ -89,11 +91,10 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
       && this->MarkupsDisplayNode->GetTextScale() > 0.0);
     controlPoints->Glypher->SetScaleFactor(this->ControlPointSize);
 
-    this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->Mapper);
+    this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->Mapper, controlPoints->OccludedMapper);
     }
 
-  this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
-  this->UpdateOccludedRelativeCoincidentTopologyOffsets(this->LineOccludedMapper);
+  this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper, this->LineOccludedMapper);
 
   double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
     this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.h
@@ -80,14 +80,14 @@ protected:
 
   void SetMarkupsNode(vtkMRMLMarkupsNode *markupsNode) override;
 
-  vtkSmartPointer<vtkPolyData> Line;
-  vtkSmartPointer<vtkPolyDataMapper> LineMapper;
-  vtkSmartPointer<vtkActor> LineActor;
-
-  vtkSmartPointer<vtkPolyDataMapper> LineOccludedMapper;
-  vtkSmartPointer<vtkActor> LineOccludedActor;
-
+  vtkSmartPointer<vtkPolyData>   Line;
   vtkSmartPointer<vtkTubeFilter> TubeFilter;
+
+  vtkSmartPointer<vtkPolyDataMapper> LineMapper;
+  vtkSmartPointer<vtkPolyDataMapper> LineOccludedMapper;
+
+  vtkSmartPointer<vtkActor> LineActor;
+  vtkSmartPointer<vtkActor> LineOccludedActor;
 
   vtkSmartPointer<vtkCellLocator> CurvePointLocator;
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -44,15 +44,17 @@ vtkSlicerLineRepresentation3D::vtkSlicerLineRepresentation3D()
   this->TubeFilter->SetNumberOfSides(20);
   this->TubeFilter->SetRadius(1);
 
+  // Mappers
   this->LineMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
   this->LineMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
 
+  this->LineOccludedMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  this->LineOccludedMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
+
+  // Actors
   this->LineActor = vtkSmartPointer<vtkActor>::New();
   this->LineActor->SetMapper(this->LineMapper);
   this->LineActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
-
-  this->LineOccludedMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
-  this->LineOccludedMapper->SetInputConnection(this->TubeFilter->GetOutputPort());
 
   this->LineOccludedActor = vtkSmartPointer<vtkActor>::New();
   this->LineOccludedActor->SetMapper(this->LineOccludedMapper);
@@ -190,8 +192,7 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
 
   // Line display
 
-  this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper);
-  this->UpdateOccludedRelativeCoincidentTopologyOffsets(this->LineOccludedMapper);
+  this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper, this->LineOccludedMapper);
 
   double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
     this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
@@ -77,13 +77,13 @@ protected:
   void UpdateInteractionPipeline() override;
 
   vtkSmartPointer<vtkPolyData> Line;
-  vtkSmartPointer<vtkPolyDataMapper> LineMapper;
-  vtkSmartPointer<vtkActor> LineActor;
-
-  vtkSmartPointer<vtkPolyDataMapper> LineOccludedMapper;
-  vtkSmartPointer<vtkActor> LineOccludedActor;
-
   vtkSmartPointer<vtkTubeFilter> TubeFilter;
+
+  vtkSmartPointer<vtkPolyDataMapper> LineMapper;
+  vtkSmartPointer<vtkPolyDataMapper> LineOccludedMapper;
+
+  vtkSmartPointer<vtkActor> LineActor;
+  vtkSmartPointer<vtkActor> LineOccludedActor;
 
 private:
   vtkSlicerLineRepresentation3D(const vtkSlicerLineRepresentation3D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -86,6 +86,8 @@ public:
   bool GetNthControlPointViewVisibility(int n);
 
   /// Relative offset used for rendering occluded actors.
+  /// The range of coincident offset can be betweeen +/- 65000.
+  /// Positive values move the occluded objects away from the camera, and negative values towards.
   /// Default value is -25000.
   vtkSetMacro(OccludedRelativeOffset, double);
   vtkGetMacro(OccludedRelativeOffset, double);
@@ -108,25 +110,27 @@ protected:
     ControlPointsPipeline3D();
     ~ControlPointsPipeline3D() override;
 
-    vtkSmartPointer<vtkSelectVisiblePoints> SelectVisiblePoints;
-    vtkSmartPointer<vtkIdTypeArray> ControlPointIndices;  // store original ID to determine which control point is actually visible
-    vtkSmartPointer<vtkActor> Actor;
-    vtkSmartPointer<vtkPolyDataMapper> Mapper;
     vtkSmartPointer<vtkGlyph3D> Glypher;
-    vtkSmartPointer<vtkActor2D> LabelsActor;
-    vtkSmartPointer<vtkLabelPlacementMapper> LabelsMapper;
+
     // Properties used to control the appearance of selected objects and
     // the manipulator in general.
-    vtkSmartPointer<vtkProperty> Property;
-
-    vtkSmartPointer<vtkPointSetToLabelHierarchy> OccludedPointSetToLabelHierarchyFilter;
-    vtkSmartPointer<vtkLabelPlacementMapper> LabelsOccludedMapper;
-    vtkSmartPointer<vtkActor2D> LabelsOccludedActor;
+    vtkSmartPointer<vtkProperty>     Property;
+    vtkSmartPointer<vtkProperty>     OccludedProperty;
     vtkSmartPointer<vtkTextProperty> OccludedTextProperty;
 
-    vtkSmartPointer<vtkPolyDataMapper> OccludedMapper;
-    vtkSmartPointer<vtkActor> OccludedActor;
-    vtkSmartPointer<vtkProperty> OccludedProperty;
+    vtkSmartPointer<vtkSelectVisiblePoints>      SelectVisiblePoints;
+    vtkSmartPointer<vtkIdTypeArray>              ControlPointIndices;  // store original ID to determine which control point is actually visible
+    vtkSmartPointer<vtkPointSetToLabelHierarchy> OccludedPointSetToLabelHierarchyFilter;
+
+    vtkSmartPointer<vtkPolyDataMapper>       Mapper;
+    vtkSmartPointer<vtkPolyDataMapper>       OccludedMapper;
+    vtkSmartPointer<vtkLabelPlacementMapper> LabelsMapper;
+    vtkSmartPointer<vtkLabelPlacementMapper> LabelsOccludedMapper;
+
+    vtkSmartPointer<vtkActor>   Actor;
+    vtkSmartPointer<vtkActor>   OccludedActor;
+    vtkSmartPointer<vtkActor2D> LabelsActor;
+    vtkSmartPointer<vtkActor2D> LabelsOccludedActor;
   };
 
   ControlPointsPipeline3D* GetControlPointsPipeline(int controlPointType);
@@ -141,7 +145,7 @@ protected:
   /// - RelativeCoincidentTopologyLineOffsetParameters
   /// - RelativeCoincidentTopologyPolygonOffsetParameters
   /// - RelativeCoincidentTopologyPointOffsetParameter
-  virtual void UpdateOccludedRelativeCoincidentTopologyOffsets(vtkMapper* mapper);
+  void UpdateRelativeCoincidentTopologyOffsets(vtkMapper* mapper, vtkMapper* occludedMapper);
 
   vtkSmartPointer<vtkCellPicker> AccuratePicker;
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.cxx
@@ -75,6 +75,9 @@ vtkSlicerPlaneRepresentation3D::vtkSlicerPlaneRepresentation3D()
   this->ArrowGlypher->SetScaleModeToDataScalingOff();
   this->ArrowGlypher->SetInputArrayToProcess(1, 0, 0, vtkDataObject::FIELD_ASSOCIATION_POINTS, vtkDataSetAttributes::SCALARS);
 
+  this->PlaneOutlineFilter->CappingOff();
+
+  // Color filters
   this->ArrowColorFilter->SetInputConnection(this->ArrowGlypher->GetOutputPort());
   this->ArrowColorFilter->SetFunction(arrowFunction.c_str());
   this->ArrowColorFilter->SetResultArrayName("component");
@@ -84,8 +87,6 @@ vtkSlicerPlaneRepresentation3D::vtkSlicerPlaneRepresentation3D()
   std::stringstream outlineFunctionSS;
   outlineFunctionSS << OUTLINE_COMPONENT;
   std::string outlineFunction = outlineFunctionSS.str();
-
-  this->PlaneOutlineFilter->CappingOff();
 
   this->PlaneOutlineColorFilter->SetInputConnection(this->PlaneOutlineFilter->GetOutputPort());
   this->PlaneOutlineColorFilter->SetFunction(outlineFunction.c_str());
@@ -107,6 +108,7 @@ vtkSlicerPlaneRepresentation3D::vtkSlicerPlaneRepresentation3D()
   this->Append->AddInputConnection(this->PlaneOutlineColorFilter->GetOutputPort());
   this->Append->AddInputConnection(this->PlaneFillColorFilter->GetOutputPort());
 
+  // Mappers
   this->PlaneMapper->SetInputConnection(this->Append->GetOutputPort());
   this->PlaneMapper->SetColorModeToMapScalars();
   this->PlaneMapper->SetScalarModeToUsePointFieldData();
@@ -116,9 +118,6 @@ vtkSlicerPlaneRepresentation3D::vtkSlicerPlaneRepresentation3D()
   this->PlaneMapper->SetArrayAccessMode(VTK_GET_ARRAY_BY_NAME);
   this->PlaneMapper->SetArrayName("component");
 
-  this->PlaneActor->SetMapper(this->PlaneMapper);
-  this->PlaneActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
-
   this->PlaneOccludedMapper->SetInputConnection(this->Append->GetOutputPort());
   this->PlaneOccludedMapper->SetColorModeToMapScalars();
   this->PlaneOccludedMapper->SetScalarModeToUsePointFieldData();
@@ -127,6 +126,10 @@ vtkSlicerPlaneRepresentation3D::vtkSlicerPlaneRepresentation3D()
   this->PlaneOccludedMapper->SetLookupTable(this->PlaneColorLUT);
   this->PlaneOccludedMapper->SetArrayAccessMode(VTK_GET_ARRAY_BY_NAME);
   this->PlaneOccludedMapper->SetArrayName("component");
+
+  // Actors
+  this->PlaneActor->SetMapper(this->PlaneMapper);
+  this->PlaneActor->SetProperty(this->GetControlPointsPipeline(Unselected)->Property);
 
   this->PlaneOccludedActor->SetMapper(this->PlaneOccludedMapper);
   this->PlaneOccludedActor->SetProperty(this->GetControlPointsPipeline(Unselected)->OccludedProperty);
@@ -277,8 +280,7 @@ void vtkSlicerPlaneRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   this->TextActor->SetVisibility(this->MarkupsDisplayNode->GetPropertiesLabelVisibility()
     && markupsNode->GetNumberOfControlPoints() > 0);
 
-  this->UpdateRelativeCoincidentTopologyOffsets(this->PlaneMapper);
-  this->UpdateOccludedRelativeCoincidentTopologyOffsets(this->PlaneOccludedMapper);
+  this->UpdateRelativeCoincidentTopologyOffsets(this->PlaneMapper, this->PlaneOccludedMapper);
 
   int controlPointType = Active;
   if (this->MarkupsDisplayNode->GetActiveComponentType() != vtkMRMLMarkupsDisplayNode::ComponentPlane)

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
@@ -87,21 +87,19 @@ protected:
   ~vtkSlicerPlaneRepresentation3D() override;
 
   vtkNew<vtkPlaneSource>     PlaneFillFilter;
-  vtkNew<vtkArrayCalculator> PlaneFillColorFilter;
-
   vtkNew<vtkArrowSource>     ArrowFilter;
   vtkNew<vtkGlyph3D>         ArrowGlypher;
-  vtkNew<vtkArrayCalculator> ArrowColorFilter;
-
   vtkNew<vtkTubeFilter>      PlaneOutlineFilter;
+  vtkNew<vtkArrayCalculator> ArrowColorFilter;
   vtkNew<vtkArrayCalculator> PlaneOutlineColorFilter;
-
+  vtkNew<vtkArrayCalculator> PlaneFillColorFilter;
   vtkNew<vtkAppendPolyData>  Append;
-  vtkNew<vtkPolyDataMapper>  PlaneMapper;
-  vtkNew<vtkActor>           PlaneActor;
 
-  vtkNew<vtkPolyDataMapper>  PlaneOccludedMapper;
+  vtkNew<vtkActor>           PlaneActor;
   vtkNew<vtkActor>           PlaneOccludedActor;
+
+  vtkNew<vtkPolyDataMapper>  PlaneMapper;
+  vtkNew<vtkPolyDataMapper>  PlaneOccludedMapper;
 
   vtkNew<vtkLookupTable>    PlaneColorLUT;
 

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -626,8 +626,8 @@ void qMRMLMarkupsDisplayNodeWidget::setOccludedOpacity(double OccludedOpacity)
 {
   Q_D(qMRMLMarkupsDisplayNodeWidget);
   if (!d->MarkupsDisplayNode)
-  {
+    {
     return;
-  }
+    }
   d->MarkupsDisplayNode->SetOccludedOpacity(OccludedOpacity);
 }


### PR DESCRIPTION
- Improve organization of actors/mappers in VTK markup widgets
    - Mappers, actors, etc. are now grouped together
- Remove UpdateOccludedRelativeCoincidentTopologyOffsets and update UpdateRelativeCoincidentTopologyOffsets to accept two arguments.
- Add explanation for default OccludedRelativeOffset
- Reduce opacity maximum to 0.99 (was 0.99999999) to prevent floating point issues
- Indentation fixes

Fixes issues mentioned in https://github.com/Slicer/Slicer/pull/5128.