### PR TITLE
BUG: Allow PropertiesLabelVisibility to control line text visibility in 3D

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -212,7 +212,8 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
     && this->LineActor->GetVisibility()
     && this->MarkupsDisplayNode->GetOccludedVisibility());
 
-  if (markupsNode->GetNumberOfDefinedControlPoints(true) == 2 && this->GetAllControlPointsVisible())
+  if (markupsNode->GetNumberOfDefinedControlPoints(true) == 2 && this->GetAllControlPointsVisible()
+    && this->MarkupsDisplayNode->GetPropertiesLabelVisibility())
     {
     this->TextActor->SetVisibility(true);
     double p1[3] = { 0.0 };


### PR DESCRIPTION
PropertiesLabelVisibility was used to control the visibility of the line representation text actor in 2D, however it had no effect in 3D.
Fixed by checking PropertiesLabelVisibility before setting text actor visibility.