### PR TITLE
ENH: Change python version to 3.6.12

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -154,8 +154,8 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
   "warning: the use of .tmpnam_r. is dangerous, better use .mkstemp."
 
   # Python - Windows
-  "(P|p)ython-3.6.7.(M|m)odules"
-  "(P|p)ython-3.6.7.PC"
+  "(P|p)ython-3.6.12.(M|m)odules"
+  "(P|p)ython-3.6.12.PC"
   "Include\\um\\winsock2.h.*warning C4005: 'INVALID_SOCKET': macro redefinition"
   # Python - Linux
   "Objects.unicodeobject.c.*warning:.*differ in signedness"

--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -47,11 +47,11 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
    OR NOT DEFINED PYTHON_LIBRARY
    OR NOT DEFINED PYTHON_EXECUTABLE) AND NOT Slicer_USE_SYSTEM_${proj})
 
-  set(python_SOURCE_DIR "${CMAKE_BINARY_DIR}/Python-3.6.7")
+  set(python_SOURCE_DIR "${CMAKE_BINARY_DIR}/Python-3.6.12")
 
   ExternalProject_Add(python-source
-    URL "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tgz"
-    URL_MD5 "c83551d83bf015134b4b2249213f3f85"
+    URL "https://www.python.org/ftp/python/3.6.12/Python-3.6.12.tgz"
+    URL_MD5 "00c3346f314072fcc810d4a51d06f04e"
     DOWNLOAD_DIR ${CMAKE_BINARY_DIR}
     SOURCE_DIR ${python_SOURCE_DIR}
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
Current python version 3.6.7 has not received any update since October 20,2018. All bug fixes for branch 3.6 are integrated in version 3.6.12 which is still receiving corrections (the last one from August 17, 2020)

Some bugs from version 3.6.7 are rising and exposed [here](https://discourse.slicer.org/t/impossibility-to-test-for-coverage-in-extensions/13291/5)