### PR TITLE
BUG: Fix deletion of segments when running smoothing effect

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
@@ -297,7 +297,11 @@ void qSlicerSegmentEditorAbstractEffect::modifySegmentByLabelmap(vtkMRMLSegmenta
     parameterSetNode->GetMasterVolumeIntensityMask())
     {
     vtkNew<vtkOrientedImageData> maskImage;
-    maskImage->DeepCopy(modifierLabelmap);
+    maskImage->SetExtent(modifierLabelmap->GetExtent());
+    maskImage->SetSpacing(modifierLabelmap->GetSpacing());
+    maskImage->SetOrigin(modifierLabelmap->GetOrigin());
+    maskImage->CopyDirections(modifierLabelmap);
+    maskImage->AllocateScalars(VTK_UNSIGNED_CHAR, 1);
     vtkOrientedImageDataResample::FillImage(maskImage, m_EraseValue);
 
     // Apply mask to modifier labelmap if masking is enabled


### PR DESCRIPTION
When running the smoothing effect, the current segment could be deleted if the mask was an incorrect datatype.
The mask image was copied from the modifier labelmap, and could be a data type other than unsigned char, which would cause the vtkImageMask filter to fail.
Fixed by setting the mask datatype to VTK_UNSIGNED_CHAR.

See topic here: https://discourse.slicer.org/t/13295