### PR TITLE
COMP: Update vtkAddon to remove VTK < 8.2 support from vtkMacroKitPythonWrap

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,7 +202,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 48a644d6b0ba4bb1bdb9721f9b361341f9051a95
+  GIT_TAG a64d854cd826fb90b2aeb88907e948b3639f517f
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)


### PR DESCRIPTION
List of changes:

```
$ git shortlog 48a644d..a64d854 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Update vtkMacroKitPythonWrap removing support for VTK < 8.2
```