### PR TITLE
COMP: Update MultiVolumeExplorer to remove support for VTK <= 8

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -237,7 +237,7 @@ mark_as_advanced(Slicer_BUILD_MULTIVOLUME_SUPPORT)
 
 Slicer_Remote_Add(MultiVolumeExplorer
   GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/fedorov/MultiVolumeExplorer.git
-  GIT_TAG b907c39b876a1d5f9eac1359ce6c829c13c53c93
+  GIT_TAG 8be7d7aa3bfb6878a30420ef68c23a9577cc7b1f
   OPTION_NAME Slicer_BUILD_MultiVolumeExplorer
   OPTION_DEPENDS "Slicer_BUILD_QTLOADABLEMODULES;Slicer_BUILD_MULTIVOLUME_SUPPORT;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
This changes is done to prepare the support for VTK <= 8.90

List of changes:

```
$ git shortlog b907c39..8be7d7a --no-merges
Csaba Pinter (1):
      STYLE: Remove VTK <= 8 support using override statements for C++11
```