### PR TITLE
COMP: Update libarchive to fix Visual Studio build error

### DIFF
--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -38,15 +38,13 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/Slicer/LibArchive.git"
+    "${EP_GIT_PROTOCOL}://github.com/libarchive/libarchive.git"
     QUIET
     )
 
-  # master (v3.4.0) with patches:
-  # - disabling LHA (See #4407)
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "92ad4c79e46805ce2dfbc46746e10d204108655e" # slicer-v3.4.0-2019-06-11-614110e7
+    "34940ef6ea0b21d77cb501d235164ad88f19d40c"  # master (v3.4.3) with fix-enum-cases
     QUIET
     )
 


### PR DESCRIPTION
Fixes Visual Studio build errors of LibArchive:

Error	C4061	enumerator 'WT_NONE' in switch of enum 'warc_type_t' is not explicitly handled by a case label [C:\Slicer_LMU\LibArchive-build\libarchive\archive.vcxproj]	LibArchive	C:\Slicer_LMU\LibArchive\libarchive\archive_read_support_format_warc.c	344
Error	C4061	enumerator 'WT_INFO' in switch of enum 'warc_type_t' is not explicitly handled by a case label [C:\Slicer_LMU\LibArchive-build\libarchive\archive.vcxproj]	LibArchive	C:\Slicer_LMU\LibArchive\libarchive\archive_read_support_format_warc.c	344
Error	C4061	enumerator 'WT_META' in switch of enum 'warc_type_t' is not explicitly handled by a case label [C:\Slicer_LMU\LibArchive-build\libarchive\archive.vcxproj]	LibArchive	C:\Slicer_LMU\LibArchive\libarchive\archive_read_support_format_warc.c	344

More information:
https://discourse.slicer.org/t/libarchive-build-errors/13310