### PR TITLE
Logging improvements

### DIFF
--- a/Base/Python/slicer/slicerqt.py
+++ b/Base/Python/slicer/slicerqt.py
@@ -63,29 +63,11 @@ def initLogging(logger):
   """
   Initialize logging by creating log handlers and setting default log level.
   """
-
-  # Prints debug messages to Slicer application log.
-  # Only debug level messages are logged this way, as higher level messages are printed on console
-  # and all console outputs are sent automatically to the application log anyway.
+  # Prints debug, info, warning and error messages to Slicer application log.
   applicationLogHandler = SlicerApplicationLogHandler()
   applicationLogHandler.setLevel(logging.DEBUG)
-  # We could filter out messages at INFO level or above (as they will be printed on the console anyway) by adding
-  # applicationLogHandler.addFilter(_LogReverseLevelFilter(logging.INFO))
-  # but then we would not log file name and line number of info, warning, and error level messages.
   applicationLogHandler.setFormatter(logging.Formatter('%(message)s'))
   logger.addHandler(applicationLogHandler)
-
-  # Prints info message to stdout (anything on stdout will also show up in the application log)
-  consoleInfoHandler = logging.StreamHandler(sys.stdout)
-  consoleInfoHandler.setLevel(logging.INFO)
-  # Filter messages at WARNING level or above (they will be printed on stderr)
-  consoleInfoHandler.addFilter(_LogReverseLevelFilter(logging.WARNING))
-  logger.addHandler(consoleInfoHandler)
-
-  # Prints error and warning messages to stderr (anything on stderr will also show it in the application log)
-  consoleErrorHandler = logging.StreamHandler(sys.stderr)
-  consoleErrorHandler.setLevel(logging.WARNING)
-  logger.addHandler(consoleErrorHandler)
 
   # Log debug messages from scripts by default, as they are useful for troubleshooting with users
   logger.setLevel(logging.DEBUG)

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -534,6 +534,10 @@ def setPythonConsoleVisible(visible):
   """Show/hide Python console."""
   mainWindow().pythonConsole().parent().setVisible(visible)
 
+def setErrorLogWidgetVisible(visible):
+  """Show/hide the Error Log widget."""
+  mainWindow().errorLogWidget().parent().setVisible(visible)
+
 def setStatusBarVisible(visible):
   """Show/hide status bar"""
   mainWindow(verbose=False).statusBar().setVisible(visible)
@@ -763,8 +767,7 @@ def loadLabelVolume(filename, properties={}, returnNode=False):
   :return: loaded node (if multiple nodes are loaded then a list of nodes).
     If returnNode is True then a status flag and loaded node are returned.
   """
-  properties['labelmap'] = True
-  return loadNodeFromFile(filename, 'VolumeFile', properties, returnNode)
+  return loadNodeFromFile(filename, 'VolumeFile', {'labelmap': True}, returnNode)
 
 def loadShaderProperty(filename, returnNode=False):
   """Load node from file.

--- a/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
+++ b/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
@@ -345,8 +345,6 @@
     <addaction name="WindowToolbarsResetToDefaultAction"/>
     <addaction name="ModuleHomeAction"/>
     <addaction name="separator"/>
-    <addaction name="WindowErrorLogAction"/>
-    <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="HelpMenu">
     <property name="title">
@@ -653,17 +651,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+6</string>
-   </property>
-  </action>
-  <action name="WindowErrorLogAction">
-   <property name="text">
-    <string>&amp;Error Log</string>
-   </property>
-   <property name="toolTip">
-    <string>Raise the error log display.</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+0</string>
    </property>
   </action>
   <action name="FeedbackReportUsabilityIssueAction">

--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -32,10 +32,13 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QQueue>
+#include <QScrollBar>
 #include <QSettings>
 #include <QShowEvent>
 #include <QSignalMapper>
 #include <QStyle>
+#include <QTableView>
+#include <QTextBrowser>
 #include <QTextEdit>
 #include <QTimer>
 #include <QToolButton>
@@ -1046,6 +1049,16 @@ void qSlicerMainWindow::onErrorLogToggled(bool toggled)
       if (textEditWidget)
         {
         textEditWidget->setFocus();
+        }
+      QTableView* logTableView = errorLogWidget->findChild<QTableView*>();
+      if (logTableView)
+        {
+        logTableView->scrollToBottom();
+        }
+      QTextBrowser* textBrowserWidget = errorLogWidget->findChild<QTextBrowser*>();
+      if (textBrowserWidget)
+        {
+        textBrowserWidget->verticalScrollBar()->setValue(textBrowserWidget->verticalScrollBar()->maximum());
         }
       }
     }

--- a/Base/QTApp/qSlicerMainWindow.h
+++ b/Base/QTApp/qSlicerMainWindow.h
@@ -99,8 +99,8 @@ public slots:
   virtual void setLayoutNumberOfCompareViewColumns(int);
 
   virtual void onPythonConsoleToggled(bool);
+  virtual void onErrorLogToggled(bool);
 
-  virtual void on_WindowErrorLogAction_triggered();
   virtual void on_WindowToolbarsResetToDefaultAction_triggered();
 
   virtual void on_EditApplicationSettingsAction_triggered();

--- a/Base/QTApp/qSlicerMainWindow_p.h
+++ b/Base/QTApp/qSlicerMainWindow_p.h
@@ -72,6 +72,8 @@ public:
   QAction*                        PythonConsoleToggleViewAction;
 #endif
   ctkErrorLogWidget*              ErrorLogWidget;
+  QDockWidget*                    ErrorLogDockWidget;
+  QAction*                        ErrorLogToggleViewAction;
   QToolButton*                    ErrorLogToolButton;
   qSlicerModuleSelectorToolBar*   ModuleSelectorToolBar;
   QStringList                     FavoriteModules;

--- a/Base/QTApp/qSlicerMainWindow_p.h
+++ b/Base/QTApp/qSlicerMainWindow_p.h
@@ -65,8 +65,6 @@ public:
   virtual bool confirmCloseApplication();
   virtual bool confirmCloseScene();
 
-  void setErrorLogIconHighlighted(bool);
-
   void updatePythonConsolePalette();
 
 #ifdef Slicer_USE_PYTHONQT

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -96,6 +96,9 @@
 #include <ctkAppLauncherEnvironment.h>
 #include <ctkAppLauncherSettings.h>
 
+// CTK includes
+#include <ctkErrorLogWidget.h>
+
 // VTK includes
 #include <vtkNew.h>
 #include <vtksys/SystemTools.hxx>
@@ -1358,6 +1361,20 @@ ctkErrorLogAbstractModel* qSlicerCoreApplication::errorLogModel()const
 {
   Q_D(const qSlicerCoreApplication);
   return d->ErrorLogModel.data();
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerCoreApplication::setErrorLogWidget(ctkErrorLogWidget* ErrorLogWidget)
+{
+  Q_D(qSlicerCoreApplication);
+  d->ErrorLogWidget = ErrorLogWidget;
+}
+
+//-----------------------------------------------------------------------------
+ctkErrorLogWidget* qSlicerCoreApplication::errorLogWidget()const
+{
+  Q_D(const qSlicerCoreApplication);
+  return d->ErrorLogWidget.data();
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -39,6 +39,7 @@
 class ctkDICOMDatabase;
 #endif
 class ctkErrorLogAbstractModel;
+class ctkErrorLogWidget;
 class QSettings;
 class qSlicerCoreIOManager;
 class qSlicerCoreCommandOptions;
@@ -333,8 +334,17 @@ public:
   void setExtensionsManagerModel(qSlicerExtensionsManagerModel* model);
 #endif
 
-  /// Get errorLogModel
+  /// Get the Error Log model
   Q_INVOKABLE ctkErrorLogAbstractModel* errorLogModel()const;
+
+  /// Get the Error Log widget
+  ctkErrorLogWidget* errorLogWidget()const;
+
+  /// Set the error log widget
+  /// \note qSlicerCoreApplication will not take ownership of the object,
+  /// because it will be owned by the widget that it is part of
+  /// (either it is part of the main window or a top-level window).
+  void setErrorLogWidget(ctkErrorLogWidget* errorLogWidget);
 
   /// Get the module manager
   Q_INVOKABLE qSlicerModuleManager* moduleManager()const;

--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -156,6 +156,7 @@ public:
 
   /// ErrorLogModel - It should exist only one instance of the ErrorLogModel
   QSharedPointer<ctkErrorLogAbstractModel> ErrorLogModel;
+  QPointer<ctkErrorLogWidget> ErrorLogWidget; // it may be owned by a widget, so we cannot refer to it by a strong pointer
 
   /// ReturnCode flag
   int                                         ReturnCode;

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -37,6 +37,7 @@
 // CTK includes
 #include <ctkColorDialog.h>
 #include <ctkErrorLogModel.h>
+#include <ctkErrorLogWidget.h>
 #include <ctkErrorLogFDMessageHandler.h>
 #include <ctkErrorLogQtMessageHandler.h>
 #include <ctkErrorLogStreamMessageHandler.h>
@@ -251,6 +252,7 @@ void qSlicerApplicationPrivate::init()
 
   q->setupFileLogging();
   q->logApplicationInformation();
+  q->setErrorLogWidget(new ctkErrorLogWidget());
 
   //----------------------------------------------------------------------------
   // Settings Dialog
@@ -384,6 +386,14 @@ qSlicerApplication::~qSlicerApplication()
       }
     }
 #endif
+ctkErrorLogWidget* errorLogPtr = this->errorLogWidget();
+if (errorLogPtr)
+  {
+  if (errorLogPtr->parent() == nullptr)
+    {
+    delete errorLogPtr;
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -498,6 +508,12 @@ ctkPythonConsole* qSlicerApplication::pythonConsole()
   return Superclass::pythonConsole();
 }
 #endif
+
+//-----------------------------------------------------------------------------
+ctkErrorLogWidget* qSlicerApplication::errorLogWidget()
+{
+  return Superclass::errorLogWidget();
+}
 
 #ifdef Slicer_USE_QtTesting
 //-----------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -93,6 +93,8 @@ public:
   Q_INVOKABLE ctkPythonConsole * pythonConsole();
 #endif
 
+  Q_INVOKABLE ctkErrorLogWidget * errorLogWidget();
+
   #ifdef Slicer_USE_QtTesting
   /// Get test utility
   Q_INVOKABLE ctkQtTestingUtility* testingUtility();

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -51,13 +51,13 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/commontk/CTK.git"
+    "${EP_GIT_PROTOCOL}://github.com/jamesobutler/CTK.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "92d2191b15894f42aa7446970faa974652410536"
+    "7cda4312d2333b0eebbee8ea13338c5d66e9babe"
     QUIET
     )
 


### PR DESCRIPTION
This would supersede https://github.com/Slicer/Slicer/pull/5156 and the changes proposed here are based on discussions from that PR.

Requires changes in https://github.com/commontk/CTK/pull/928 where there are changes such as:

- a console mode button which allows viewing the log not in table format, but just simple text format. This is supported by selecting all fields when hiding the table. When hiding the table you can still use the filter buttons to view all errors in the simple text format as well.
- supporting colored text in the description column and full description fields. Warning (orange), Error and Critical (red)

- The ctkErrorLogWidget table view option is shown by default instead of the "Console Mode" option being in the checked state.

![image](https://user-images.githubusercontent.com/15837524/92498868-259d2e80-f1c9-11ea-9966-eeac289763c9.png)

- The error log toolbutton in the status bar now has an icon that reflects the highest logged level state since viewing the log widget.
- The error log can now be docked just like the python console and is by default in the bottom area.  There is a grabber tool between the python console and error log that allows resizing the two if both are shown.
- logging is no longer shown in the python console, but in the log messages area.  If someone wants to add a consoleInfoHandler again, they can add that in code.
- ~~The log text in the ErrorReport Dialog area is no longer editable. I've made it read-only as I don't think it was intended to be editable there.~~ See 7e6a62dccd1b1f17fdb0b8e2946a75286af6d71b
- The log table and log description error are both scrolled to the bottom upon showing the error log. It also scrolls upon adding of a new entry.