### PR TITLE
BUG: Fix segment color not updating in subject hierarchy

### DIFF
--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
@@ -795,6 +795,12 @@ void qSlicerSubjectHierarchySegmentationsPlugin::onSegmentModified(vtkObject* ca
   if (shNode->GetItemName(segmentShItemID).compare(segment->GetName() ? segment->GetName() : ""))
     {
     shNode->SetItemName(segmentShItemID, (segment->GetName() ? segment->GetName() : ""));
+    // modified event is triggered by the name change, so there is no need for invoking modified event
+    }
+  else
+    {
+    shNode->InvokeCustomModifiedEvent(
+      vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemModifiedEvent, (void*)&segmentShItemID);
     }
 }
 


### PR DESCRIPTION
When segment color was changed by calling segment->SetColor then subject hierarchy widget was not updated.

Fixed by calling vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemModifiedEvent when segment is modified.
