### PR TITLE
COMP: avoid JDK warning from Swig on mac

### DIFF
--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -81,6 +81,7 @@ ExternalProject_Execute(${proj} \"configure\" sh ${EP_SOURCE_DIR}/configure
     --prefix=${EP_INSTALL_DIR}
     --with-pcre-prefix=${PCRE_DIR}
     --without-octave
+    --without-java
     --with-python=${PYTHON_EXECUTABLE})
 ")
 


### PR DESCRIPTION
Fixes the issue described here: https://github.com/SimpleITK/SimpleITK/issues/1190