### PR TITLE
Minor logging improvements

### DIFF
--- a/Base/QTApp/Resources/UI/qSlicerErrorReportDialog.ui
+++ b/Base/QTApp/Resources/UI/qSlicerErrorReportDialog.ui
@@ -62,6 +62,9 @@
        <height>50</height>
       </size>
      </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="4" column="0" colspan="2">
@@ -83,6 +86,13 @@
        </property>
        <property name="autoDefault">
         <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="LogFileEditCheckBox">
+       <property name="text">
+        <string>Edit Log</string>
        </property>
       </widget>
      </item>

--- a/Base/QTApp/qSlicerErrorReportDialog.cxx
+++ b/Base/QTApp/qSlicerErrorReportDialog.cxx
@@ -62,6 +62,7 @@ qSlicerErrorReportDialog::qSlicerErrorReportDialog(QWidget* parentWidget)
   QObject::connect(d->RecentLogFilesComboBox, SIGNAL(currentIndexChanged(QString)), this, SLOT(onLogFileSelectionChanged()));
   QObject::connect(d->LogCopyToClipboardPushButton, SIGNAL(clicked()), this, SLOT(onLogCopy()));
   QObject::connect(d->LogFileOpenPushButton, SIGNAL(clicked()), this, SLOT(onLogFileOpen()));
+  QObject::connect(d->LogFileEditCheckBox, SIGNAL(clicked(bool)), this, SLOT(onLogFileEditClicked(bool)));
 
   connect(d->ButtonBox, SIGNAL(rejected()), this, SLOT(close()));
 
@@ -101,4 +102,11 @@ void qSlicerErrorReportDialog::onLogFileOpen()
 {
   Q_D(qSlicerErrorReportDialog);
   QDesktopServices::openUrl(QUrl("file:///"+d->RecentLogFilesComboBox->currentText(), QUrl::TolerantMode));
+}
+
+// --------------------------------------------------------------------------
+void qSlicerErrorReportDialog::onLogFileEditClicked(bool editable)
+{
+  Q_D(qSlicerErrorReportDialog);
+  d->LogText->setReadOnly(!editable);
 }

--- a/Base/QTApp/qSlicerErrorReportDialog.h
+++ b/Base/QTApp/qSlicerErrorReportDialog.h
@@ -45,6 +45,7 @@ protected slots:
   void onLogFileOpen();
   void onLogCopy();
   void onLogFileSelectionChanged();
+  void onLogFileEditClicked(bool editable);
 
 protected:
   QScopedPointer<qSlicerErrorReportDialogPrivate> d_ptr;

--- a/Base/QTApp/qSlicerMainWindow_p.h
+++ b/Base/QTApp/qSlicerMainWindow_p.h
@@ -65,8 +65,6 @@ public:
   virtual bool confirmCloseApplication();
   virtual bool confirmCloseScene();
 
-  void setErrorLogIconHighlighted(bool);
-
   void updatePythonConsolePalette();
 
 #ifdef Slicer_USE_PYTHONQT


### PR DESCRIPTION
These are pulled out from #5176 and represent small individual improvements to logging outside of the conversation about how the console view of logging messages should be changed.
- The error log toolbutton in the status bar now has an icon that reflects the highest logged level state since viewing the log widget.
- The log text in the ErrorReport Dialog area is no longer editable. I've made it read-only as I don't think it was intended to be editable there.