### PR TITLE
COMP: Attempt to fix extension package upload updating timeout from 120 to 240

### DIFF
--- a/Extensions/CMake/MIDASAPIUploadExtension.cmake
+++ b/Extensions/CMake/MIDASAPIUploadExtension.cmake
@@ -127,7 +127,7 @@ function(midas_api_upload_extension)
   set(params "${params}&release=${release}")
   set(url "${MY_SERVER_URL}/api/json?method=${api_method}${params}")
 
-  file(UPLOAD ${MY_PACKAGE_FILEPATH} ${url} INACTIVITY_TIMEOUT 120 STATUS status LOG log SHOW_PROGRESS)
+  file(UPLOAD ${MY_PACKAGE_FILEPATH} ${url} INACTIVITY_TIMEOUT 240 STATUS status LOG log SHOW_PROGRESS)
   string(REGEX REPLACE ".*{\"stat\":[ ]*\"([^\"]*)\".*" "\\1" status ${log})
 
   set(api_call_log ${CMAKE_CURRENT_BINARY_DIR}/${api_method}_response.txt)


### PR DESCRIPTION
Despite of having an error like the following reported on CDash, the
package is still available in the extensions manager. This commit updates
the timeout to provide more time to the server for acknowledging the
upload and avoid to report a failure.

Co-authored-by: Sam Horvath <sam.horvath@kitware.com>