### PR TITLE
ENH: Remove Ctrl-A shortcut for loading data

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -142,13 +142,6 @@ void qSlicerMainWindowPrivate::setupUi(QMainWindow * mainWindow)
   qSlicerApplication * app = qSlicerApplication::application();
 
   //----------------------------------------------------------------------------
-  // Load data shortcuts for backward compatibility
-  //----------------------------------------------------------------------------
-  QList<QKeySequence> addShortcuts = this->FileAddDataAction->shortcuts();
-  addShortcuts << QKeySequence(Qt::CTRL + Qt::Key_A);
-  this->FileAddDataAction->setShortcuts(addShortcuts);
-
-  //----------------------------------------------------------------------------
   // Recently loaded files
   //----------------------------------------------------------------------------
   QObject::connect(app->coreIOManager(), SIGNAL(newFileLoaded(qSlicerIO::IOProperties)),

--- a/Docs/user_guide/user_interface.md
+++ b/Docs/user_guide/user_interface.md
@@ -111,7 +111,6 @@ View Controllers module provides an alternate way of displaying these controller
 | Shortcut | Operation |
 | -------- | --------- |
 | `Ctrl` + `f` | find module by name (hit `Enter` to select) |
-| `Ctrl` + `a` | add data from file |
 | `Ctrl` + `o` | add data from file |
 | `Ctrl` + `s` | save data to files |
 | `Ctrl` + `w` | close scene |


### PR DESCRIPTION
Ctrl-O is the standard shortcut for loading data in most other applications, and Slicer already support this shortcut.

Ctrl-A was kept for backward compatibility, but it cause frustration to many users, as it prevented using this shortcut for selecting all items in lists and tables. For example, there was no keyboard shortcut for selecting all markup control points or segments in a list or all cells in a table.

This has been discussed at the last Slicer weekly meeting and everybody agreed on this change.