### PR TITLE
BUG: Add wsgi package to Python

### DIFF
--- a/CMake/SlicerBlockInstallPython.cmake
+++ b/CMake/SlicerBlockInstallPython.cmake
@@ -42,7 +42,6 @@ To create a Slicer package including python libraries, you can *NOT* provide you
     REGEX "lib[-]old/" EXCLUDE
     REGEX "plat[-].*" EXCLUDE
     REGEX "/test/" EXCLUDE
-    REGEX "wsgiref*" EXCLUDE
     ${extra_exclude_pattern}
     )
   slicerStripInstalledLibrary(


### PR DESCRIPTION
Do not exclude wsgi package from Python, as it is required by Jupyter notebook server.
Without this, it is not possible to run Jupyter server in Slicer's Python environment.

Fixes https://github.com/Slicer/SlicerJupyter/issues/39

@pieper 