### PR TITLE
BUG: fix failing volume rendering test

### DIFF
--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/CMakeLists.txt
@@ -59,5 +59,5 @@ simple_test(qSlicer${MODULE_NAME}ModuleWidgetTest2 DATA{${MRML_CORE_INPUT}/fixed
 simple_test(vtkMRMLShaderPropertyStorageNodeTest1 ${TEMP})
 simple_test(vtkMRMLVolumePropertyNodeTest1 ${INPUT}/volRender.mrml)
 simple_test(vtkMRMLVolumePropertyStorageNodeTest1)
-simple_test(vtkMRMLVolumeRenderingDisplayableManagerTest1)
+simple_test(vtkMRMLVolumeRenderingDisplayableManagerTest1 ${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_SHARE_DIR}/VolumeRendering)
 simple_test(vtkMRMLVolumeRenderingMultiVolumeTest)

--- a/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
+++ b/Modules/Loadable/VolumeRendering/Testing/Cxx/vtkMRMLVolumeRenderingDisplayableManagerTest1.cxx
@@ -61,6 +61,12 @@ const char vtkMRMLVolumeRenderingDisplayableManagerTest1EventLog[] =
 //----------------------------------------------------------------------------
 int vtkMRMLVolumeRenderingDisplayableManagerTest1(int argc, char* argv[])
 {
+  if (argc < 2)
+    {
+    std::cerr << "Must pass share directory as first argument to test" << std::endl;
+    }
+  const char *moduleShareDirectory = argv[1];
+
   // Renderer, RenderWindow and Interactor
   vtkNew<vtkRenderer> renderer;
   vtkNew<vtkRenderWindow> renderWindow;
@@ -133,6 +139,7 @@ int vtkMRMLVolumeRenderingDisplayableManagerTest1(int argc, char* argv[])
   vtkNew<vtkSlicerVolumeRenderingLogic> vrLogic;
   vrLogic->SetDefaultRenderingMethod("vtkMRMLGPURayCastVolumeRenderingDisplayNode");
   vrLogic->SetMRMLScene(scene);
+  vrLogic->SetModuleShareDirectory(moduleShareDirectory);
 
   vrLogic->CreateDefaultVolumeRenderingNodes(volumeNode.GetPointer());
   vtkMRMLVolumeRenderingDisplayNode* vrDisplayNode = vrLogic->GetFirstVolumeRenderingDisplayNode(volumeNode.GetPointer());


### PR DESCRIPTION
The test was failing because of an error message
from the logic class that the share directory
was not set:
```
ERROR: In D:\D\P\Slicer-0\Modules\Loadable\VolumeRendering\Logic\vtkSlicerVolumeRenderingLogic.cxx, line 1243
vtkSlicerVolumeRenderingLogic (00000222CD51C6D0): Failed to load presets: Share directory *NOT* set !
```
See: http://slicer.cdash.org/testDetails.php?test=10139125&build=2017840

In normal use in the application, this share directory is set
at the Qt level, but that path is not available to this vtk-only
test.

But the path is known to CMake, so here we pass in the path
as a command line argument to the test.