### PR TITLE
ENH: Update segmentation node Get..Representation to return status

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -885,18 +885,18 @@ void vtkMRMLSegmentationNode::RemoveBinaryLabelmapRepresentation()
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLSegmentationNode::GetBinaryLabelmapRepresentation(const std::string segmentId, vtkOrientedImageData* outputBinaryLabelmap)
+bool vtkMRMLSegmentationNode::GetBinaryLabelmapRepresentation(const std::string segmentId, vtkOrientedImageData* outputBinaryLabelmap)
 {
   if (!this->Segmentation)
     {
     vtkErrorMacro("GetBinaryLabelmapRepresentation: Invalid segmentation");
-    return;
+    return false;
     }
   vtkSegment* segment = this->Segmentation->GetSegment(segmentId);
   if (!segment)
     {
     vtkErrorMacro("GetBinaryLabelmapRepresentation: Invalid segment");
-    return;
+    return false;
     }
 
   vtkOrientedImageData* binaryLabelmap = vtkOrientedImageData::SafeDownCast(
@@ -904,7 +904,7 @@ void vtkMRMLSegmentationNode::GetBinaryLabelmapRepresentation(const std::string 
   if (!binaryLabelmap)
     {
     vtkErrorMacro("GetBinaryLabelmapRepresentation: No binary labelmap representation in segment");
-    return;
+    return false;
     }
 
   vtkNew<vtkImageThreshold> threshold;
@@ -916,6 +916,7 @@ void vtkMRMLSegmentationNode::GetBinaryLabelmapRepresentation(const std::string 
 
   outputBinaryLabelmap->ShallowCopy(threshold->GetOutput());
   outputBinaryLabelmap->CopyDirections(binaryLabelmap);
+  return true;
 }
 
 //---------------------------------------------------------------------------
@@ -958,26 +959,27 @@ void vtkMRMLSegmentationNode::RemoveClosedSurfaceRepresentation()
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLSegmentationNode::GetClosedSurfaceRepresentation(const std::string segmentId, vtkPolyData* outputClosedSurface)
+bool vtkMRMLSegmentationNode::GetClosedSurfaceRepresentation(const std::string segmentId, vtkPolyData* outputClosedSurface)
 {
   if (!this->Segmentation)
     {
     vtkErrorMacro("GetClosedSurfaceRepresentation: Invalid segmentation");
-    return;
+    return false;
     }
   vtkSegment* segment = this->Segmentation->GetSegment(segmentId);
   if (!segment)
     {
     vtkErrorMacro("GetClosedSurfaceRepresentation: Invalid segment");
-    return;
+    return false;
     }
   vtkDataObject* closedSurface = segment->GetRepresentation(vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
   if (!closedSurface)
     {
     vtkErrorMacro("GetClosedSurfaceRepresentation: No closed surface representation in segment");
-    return;
+    return false;
     }
   outputClosedSurface->DeepCopy(closedSurface);
+  return true;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.h
@@ -218,8 +218,9 @@ public:
 
   /// Get a segment as binary labelmap.
   /// If representation does not exist yet then call CreateBinaryLabelmapRepresentation() before.
-  /// This function returns a copy of the segment binary labelmap.
-  virtual void GetBinaryLabelmapRepresentation(const std::string segmentId, vtkOrientedImageData* outputBinaryLabelmap);
+  /// This function returns a copy of the segment binary labelmap in outputBinaryLabelmap.
+  /// Returns true on success.
+  virtual bool GetBinaryLabelmapRepresentation(const std::string segmentId, vtkOrientedImageData* outputBinaryLabelmap);
 
   /// Get a segment as binary labelmap.
   /// If representation does not exist yet then call CreateBinaryLabelmapRepresentation() before.
@@ -238,8 +239,9 @@ public:
 
   /// Get a segment as binary labelmap.
   /// If representation does not exist yet then call CreateClosedSurfaceRepresentation() before.
-  /// This function returns a copy of the segment closed surface.
-  virtual void GetClosedSurfaceRepresentation(const std::string segmentId, vtkPolyData* outputClosedSurface);
+  /// This function returns a copy of the segment closed surface in outputClosedSurface.
+  /// Returns true on success.
+  virtual bool GetClosedSurfaceRepresentation(const std::string segmentId, vtkPolyData* outputClosedSurface);
 
   /// Get a segment as binary labelmap.
   /// If representation does not exist yet then call CreateClosedSurfaceRepresentation() before.


### PR DESCRIPTION
The vtkMRMLSegmentation node functions GetBinaryLabelmapRepresentation or GetClosedSurfaceRepresentation now return True/False depending on if the operation was successful/unsuccessful.