### PR TITLE
ENH: Enable markup preview when holding shift key

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
@@ -194,6 +194,17 @@ bool vtkMRMLCameraWidget::CanProcessInteractionEvent(vtkMRMLInteractionEventData
     return true;
     }
 
+  // By processing the SetCrosshairPosition action at this point, rather than in ProcessInteractionEvent,
+  // we allow other widgets to perform actions at the same time.
+  // For example, this allows markup preview to remain visible in place mode while adjusting slice position
+  // with shift + mouse-move.
+  if (this->WidgetState == WidgetStateIdle
+    && eventData->GetType() == vtkCommand::MouseMoveEvent
+    && eventData->GetModifiers() & vtkEvent::ShiftModifier)
+    {
+    this->ProcessSetCrosshair(eventData);
+    }
+
   distance2 = 1e10; // we can process this event but we let more specific widgets to claim it (if they are closer)
   return true;
 }
@@ -369,7 +380,7 @@ bool vtkMRMLCameraWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* e
       break;
 
     case WidgetEventSetCrosshairPosition:
-      processedEvent = this->ProcessSetCrosshair(eventData);
+      // Event is handled in CanProcessInteractionEvent
       break;
     default:
       processedEvent = false;

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -251,6 +251,18 @@ bool vtkMRMLSliceIntersectionWidget::CanProcessInteractionEvent(vtkMRMLInteracti
     return true;
     }
 
+  // By processing the SetCrosshairPosition action at this point, rather than in ProcessInteractionEvent,
+  // we allow other widgets to perform actions at the same time.
+  // For example, this allows markup preview to remain visible in place mode while adjusting slice position
+  // with shift + mouse-move.
+  if (this->GetActionEnabled(ActionSetCrosshairPosition)
+    && this->WidgetState == WidgetStateIdle
+    && eventData->GetType() == vtkCommand::MouseMoveEvent
+    && eventData->GetModifiers() & vtkEvent::ShiftModifier)
+    {
+    this->ProcessSetCrosshair(eventData);
+    }
+
   distance2 = 1e10; // we can process this event but we let more specific widgets to claim it (if they are closer)
   return true;
 }
@@ -339,7 +351,7 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
       processedEvent = this->ProcessEndMouseDrag(eventData);
       break;
     case WidgetEventSetCrosshairPosition:
-      processedEvent = this->ProcessSetCrosshair(eventData);
+      // Event is handled in CanProcessInteractionEvent
       break;
     case WidgetEventToggleLabelOpacity:
       {

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
@@ -639,9 +639,15 @@ vtkSlicerMarkupsWidget* vtkMRMLMarkupsDisplayableManager::FindClosestWidget(vtkM
 //---------------------------------------------------------------------------
 bool vtkMRMLMarkupsDisplayableManager::CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double &closestDistance2)
 {
+  vtkMRMLInteractionNode* interactionNode = this->GetInteractionNode();
   // New point can be placed anywhere
   int eventid = eventData->GetType();
-  if ( (eventid == vtkCommand::MouseMoveEvent && eventData->GetModifiers() == vtkEvent::NoModifier)
+  // We allow mouse move with the shift modifier to be processed while in place mode so that we can continue to update the
+  // preview positionm, even when using shift + mouse-move to adjust the crosshair position.
+  if ((eventid == vtkCommand::MouseMoveEvent
+       && (eventData->GetModifiers() == vtkEvent::NoModifier ||
+          (eventData->GetModifiers() & vtkEvent::ShiftModifier &&
+           interactionNode && interactionNode->GetCurrentInteractionMode() == vtkMRMLInteractionNode::Place)))
     || eventid == vtkCommand::Move3DEvent
     /*|| (eventid == vtkCommand::LeftButtonPressEvent && eventData->GetModifiers() == vtkEvent::NoModifier)
     || eventid == vtkCommand::LeftButtonReleaseEvent
@@ -649,7 +655,6 @@ bool vtkMRMLMarkupsDisplayableManager::CanProcessInteractionEvent(vtkMRMLInterac
     || eventid == vtkCommand::EnterEvent
     || eventid == vtkCommand::LeaveEvent*/)
     {
-    vtkMRMLInteractionNode *interactionNode = this->GetInteractionNode();
     vtkMRMLSelectionNode *selectionNode = this->GetSelectionNode();
     if (!interactionNode || !selectionNode)
       {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -88,13 +88,14 @@ vtkSlicerMarkupsWidget::vtkSlicerMarkupsWidget()
   // Update active component
   this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseMoveEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
   this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::MouseMoveEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
-  this->SetEventTranslation(WidgetStateDefine, vtkCommand::MouseMoveEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  // Allow AnyModifier when defining the markup position. This allows the markup preview to be continually updated, even
+  // when using shift + mouse-move to change the slice positions.
+  // We still do not allow shift+left click for placement however, so that the shift + left-click-and-drag interaction can
+  // still be used to pan the slice.
+  this->SetEventTranslation(WidgetStateDefine, vtkCommand::MouseMoveEvent, vtkEvent::AnyModifier, WidgetEventMouseMove);
   this->SetEventTranslation(WidgetStateIdle, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
   this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
   this->SetEventTranslation(WidgetStateDefine, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
-
-  this->SetKeyboardEventTranslation(WidgetStateDefine, vtkEvent::AnyModifier, 0, 0, "Shift_L", WidgetEventMouseMove);
-  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::AnyModifier, 0, 0, "Shift_L", WidgetEventMouseMove);
 }
 
 //----------------------------------------------------------------------


### PR DESCRIPTION
Allows markups (and other widgets) to process events when the crosshair position is being changed with shift + mouse move.
This is done by processing ActionSetCrosshairPosition in CanProcessInteractionEvent, rather than ProcessInteractionEvent.