### PR TITLE
ENH: Adjust subject hierarchy tree defaults to avoid confusion

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -202,6 +202,12 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
   // Set generic MRML item delegate
   q->setItemDelegate(new qMRMLItemDelegate(q));
 
+  // Set appropriate defaults
+  q->setIndentation(8);
+  q->setDragDropMode(QAbstractItemView::InternalMove);
+  q->setSelectionMode(QAbstractItemView::ExtendedSelection);
+  q->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
+
   // Create default menu actions
   this->NodeMenu = new QMenu(q);
   this->NodeMenu->setObjectName("nodeMenuTreeView");


### PR DESCRIPTION
- Drag&drop is enabled by default: users have been confused about why drag&drop selects items in some views like DICOM and DICOM export instead of reparenting like in the Data module
- Indentation is set to 8 pixels: there is a wide empty area on the left otherwise
- Selection mode is extended like in the Data module
- Edit triggers like double click and key presses work by default