### PR TITLE
BUG: Fix application startup when built against Qt 5.15.1

### DIFF
--- a/CMake/SlicerBlockInstallQt.cmake
+++ b/CMake/SlicerBlockInstallQt.cmake
@@ -23,6 +23,10 @@ set(QT_INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR})
       "Qt5::QuickWidgets"
       "Qt5::WebEngineCore"
       )
+    # QmlModels moved into its own library in Qt >= 5.14
+    if(TARGET Qt5::QmlModels)
+      list(APPEND QT_LIBRARIES "Qt5::QmlModels")
+    endif()
     if(TARGET Qt5::Positioning)
       list(APPEND QT_LIBRARIES "Qt5::Positioning")
     endif()


### PR DESCRIPTION
This commit ensures QmlModels introduced in 5.14 is packaged.
See https://github.com/qt/qtdeclarative/commit/325e6305b418ffe1dfb9a36c2516c6a8a3de5733

Notes:

* On linux, installing `libxcb-xinerama0` is required

* Requirement for freetype version changed. See details below



### freetype requirements

On an older linux system (Ubuntu  15.10), attempt to start Slicer built using latest [build environment](https://github.com/Slicer/SlicerBuildEnvironment/) including Qt 5.15.1 returns the following error:

```
$ export QT_DEBUG_PLUGINS=1
$ ./Slicer
[...] 
Got keys from plugin meta data ("xcb_glx")
QFactoryLoader::QFactoryLoader() checking directory path "/path/to/bin/xcbglintegrations" ...
loaded library "/path/to/lib/QtPlugins/xcbglintegrations/libqxcb-glx-integration.so"
/path/to/bin/SlicerApp-real: symbol lookup error: /path/to/bin/../lib/Slicer-4.11/libQt5XcbQpa.so.5: undefined symbol: FT_Get_Font_Format
```

This is likely due to a rename of the symbol in FreeType 2.5.5 (see https://git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=f4d1c11) and in my (older) system, I only have `2.5.2`:

```
$ freetype-config --ftversion
2.5.2
```

Qt 5.12.8 official packages were built using RHEL_7_4 (see [here](https://wiki.qt.io/Qt_5.12_Tools_and_Versions#Software_configurations_for_Qt_5.12.8)) whereas Qt 5.15.1 official packages are built using RHEL_7_6 (see [here](https://wiki.qt.io/Qt_5.15_Tools_and_Versions#Software_configurations_for_Qt_5.15.1))

RHEL_7_4 provides freetype 2.4.11. See http://vault.centos.org/7.4.1708/os/x86_64/Packages/

RHEL_7_6 provides freetype 2.8.12.  See http://vault.centos.org/7.6.1810/os/x86_64/Packages/