### PR TITLE
BUG: Fix installed Slicer app startup on windows when built against Qt 5.15.1

### DIFF
--- a/CMake/SlicerBlockInstallQt.cmake
+++ b/CMake/SlicerBlockInstallQt.cmake
@@ -24,7 +24,9 @@ set(QT_INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR})
       "Qt5::WebEngineCore"
       )
     # QmlModels moved into its own library in Qt >= 5.14
-    if(TARGET Qt5::QmlModels)
+    # Since windeployqt implicitly copies "Qt5QmlModels.dll" when
+    # "-qml" is specified, exclude it on Windows.
+    if(TARGET Qt5::QmlModels AND NOT WIN32)
       list(APPEND QT_LIBRARIES "Qt5::QmlModels")
     endif()
     if(TARGET Qt5::Positioning)


### PR DESCRIPTION
This commit fixes a regression introduced in 26f1f47a8a (BUG: Fix
application startup when built against Qt 5.15.1 (#5207)) that was intended
to fix Linux packaging.

It ensures the installed Slicer application can successfully start.

On windows the "windeployqt" tool implicitly takes care of copying the
"Qt5QmlModels.dll" by only specifying the "-qml" option.

Fixes #5208