### PR TITLE
COMP: Update SimpleITK from v2.0rc3 to v2.0.0

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -51,7 +51,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v2.0rc3"  # v2.0rc3 is paired with a specific SimpleITKFilters remote module git tag in the ITK project
+    "v2.0.0"  # Paired with a specific SimpleITKFilters remote module git tag in the ITK project
     QUIET
     )
 


### PR DESCRIPTION
```
$ git shortlog --no-merges v2.0rc3..v2.0.0
Bradley Lowekamp (19):
      Add __version__ to Python module for PEP 376 compatibility.
      Remove outdated, and disabled download_url field from setup.py
      Add project_urls to setup.py for link on  PyPi
      Use Readme for long description in setup.py and PyPi
      Update ITK version to official 5.1.1 tag
      Fix PasteImageFilter doxygen class name
      Update IO docs with Python keyword argument usage.
      Various improvements to the Sphinx build document.
      Update Sphinx for SimpleITK 2.0
      Minor tweaks to the Sphinx Getting Started documentation.
      Fix unsigned to signed integer comparison warning in generated tests
      Fix Sphinx warnings.
      Add C++ example for executing filters in place
      Add example for processing high dimension images.
      Fix Sphinx building docs label syntax
      Only add the path from the source external data if it exists
      Fix typo in CMake file
      Extend and improve the 2.0 migration guide
      Address signed to unsigned comparison warning

Ziv Yaniv (2):
      Updating the documentation for transformation IO.
      Migration guide for SimpleITK 2.0.
```

I haven't personally built Slicer with this update which seemingly only has documentation and non-significant changes.