### PR TITLE
COMP: Fix installation of SimpleITK

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -20,9 +20,32 @@ if(NOT Slicer_USE_SYSTEM_${proj})
 
   include(ExternalProjectForNonCMakeProject)
 
+  # Variables used to update PATH, LD_LIBRARY_PATH or DYLD_LIBRARY_PATH in env. script below
+  if(WIN32)
+    set(_varname "PATH")
+    set(_path_sep ";")
+  elseif(UNIX)
+    set(_path_sep ":")
+    if(APPLE)
+      set(_varname "DYLD_LIBRARY_PATH")
+    else()
+      set(_varname "LD_LIBRARY_PATH")
+    endif()
+  endif()
+
   # environment
   set(_env_script ${CMAKE_BINARY_DIR}/${proj}_Env.cmake)
   ExternalProject_Write_SetPythonSetupEnv_Commands(${_env_script})
+  file(APPEND ${_env_script}
+"#------------------------------------------------------------------------------
+# Added by '${CMAKE_CURRENT_LIST_FILE}'
+set(ENV{${_varname}} \"${ITK_DIR}/lib${_path_sep}\$ENV{${_varname}}\")
+set(ENV{${_varname}} \"${ITK_DIR}/bin${_path_sep}\$ENV{${_varname}}\")
+set(ENV{${_varname}} \"${ITK_DIR}/bin/Release${_path_sep}\$ENV{${_varname}}\")
+set(ENV{${_varname}} \"${ITK_DIR}/bin/MinSizeRel${_path_sep}\$ENV{${_varname}}\")
+set(ENV{${_varname}} \"${ITK_DIR}/bin/RelWithDebInfo${_path_sep}\$ENV{${_varname}}\")
+set(ENV{${_varname}} \"${ITK_DIR}/bin/Debug${_path_sep}\$ENV{${_varname}}\")
+")
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 


### PR DESCRIPTION
This commit fixes a regression introduced in 127dfbad28 (COMP: Update
SimpleITK from v2.0rc3 to v2.0.0 (#5212)) and ensures that ITK libraries
are in the PATH when running the command:

```bash
  cd /path/to/SimpleITK-build/SimpleITK-build/Wrapping/Python
  python setup.py install
```

It addresses the following error:

```python
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "/work/Preview/Slicer-0-build/SimpleITK-build/SimpleITK-build/Wrapping/Python/SimpleITK/__init__.py", line 18, in <module>
      from SimpleITK.SimpleITK import *
    File "/work/Preview/Slicer-0-build/SimpleITK-build/SimpleITK-build/Wrapping/Python/SimpleITK/SimpleITK.py", line 13, in <module>
      from . import _SimpleITK
  ImportError: libITKIOBruker-5.1.so.1: cannot open shared object file: No such file or directory
```