### PR TITLE
COMP: Fix installation of SimpleITK on windows

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -33,18 +33,37 @@ if(NOT Slicer_USE_SYSTEM_${proj})
     endif()
   endif()
 
+  # Used below to both set the env. script and the launcher settings
+  set(_lib_subdir lib)
+  if(WIN32)
+    set(_lib_subdir bin)
+  endif()
+
+  set(_paths)
+
+  if(CMAKE_CONFIGURATION_TYPES)
+    foreach(config ${CMAKE_CONFIGURATION_TYPES})
+      list(APPEND _paths
+        # ITK
+        ${ITK_DIR}/${_lib_subdir}/${config}
+        )
+    endforeach()
+  else()
+    list(APPEND _paths
+      # ITK
+      ${ITK_DIR}/${_lib_subdir}
+      )
+  endif()
+
+  list(JOIN _paths "${_path_sep}" _paths)
+
   # environment
   set(_env_script ${CMAKE_BINARY_DIR}/${proj}_Env.cmake)
   ExternalProject_Write_SetPythonSetupEnv_Commands(${_env_script})
   file(APPEND ${_env_script}
 "#------------------------------------------------------------------------------
 # Added by '${CMAKE_CURRENT_LIST_FILE}'
-set(ENV{${_varname}} \"${ITK_DIR}/lib${_path_sep}\$ENV{${_varname}}\")
-set(ENV{${_varname}} \"${ITK_DIR}/bin${_path_sep}\$ENV{${_varname}}\")
-set(ENV{${_varname}} \"${ITK_DIR}/bin/Release${_path_sep}\$ENV{${_varname}}\")
-set(ENV{${_varname}} \"${ITK_DIR}/bin/MinSizeRel${_path_sep}\$ENV{${_varname}}\")
-set(ENV{${_varname}} \"${ITK_DIR}/bin/RelWithDebInfo${_path_sep}\$ENV{${_varname}}\")
-set(ENV{${_varname}} \"${ITK_DIR}/bin/Debug${_path_sep}\$ENV{${_varname}}\")
+set(ENV{${_varname}} \"${_paths}${_path_sep}\$ENV{${_varname}}\")
 ")
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
@@ -144,11 +163,6 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
     DEPENDS SimpleITK-download ${${proj}_DEPENDENCIES}
     )
   set(SimpleITK_DIR ${CMAKE_BINARY_DIR}/SimpleITK-build/SimpleITK-build)
-
-  set(_lib_subdir lib)
-  if(WIN32)
-    set(_lib_subdir bin)
-  endif()
 
   #-----------------------------------------------------------------------------
   # Launcher setting specific to build tree

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -20,6 +20,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
 
   include(ExternalProjectForNonCMakeProject)
 
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+
   # Variables used to update PATH, LD_LIBRARY_PATH or DYLD_LIBRARY_PATH in env. script below
   if(WIN32)
     set(_varname "PATH")
@@ -53,6 +57,31 @@ if(NOT Slicer_USE_SYSTEM_${proj})
       # ITK
       ${ITK_DIR}/${_lib_subdir}
       )
+  endif()
+
+  if(Slicer_USE_SimpleITK_SHARED)
+    if(CMAKE_CONFIGURATION_TYPES)
+      foreach(config ${CMAKE_CONFIGURATION_TYPES})
+        list(APPEND _paths
+          # SimpleITK
+          ${EP_BINARY_DIR}/SimpleITK-build/${_lib_subdir}/${config}
+          # DCMTK
+          ${DCMTK_DIR}/${_lib_subdir}/${config}
+          )
+      endforeach()
+    else()
+      list(APPEND _paths
+        # SimpleITK
+        ${EP_BINARY_DIR}/SimpleITK-build/${_lib_subdir}
+        # DCMTK
+        ${DCMTK_DIR}/${_lib_subdir}
+        )
+    endif()
+
+    # TBB
+    if(Slicer_USE_TBB)
+      list(APPEND _paths ${TBB_BIN_DIR})
+    endif()
   endif()
 
   list(JOIN _paths "${_path_sep}" _paths)
@@ -96,11 +125,6 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
     "v2.0.0"  # Paired with a specific SimpleITKFilters remote module git tag in the ITK project
     QUIET
     )
-
-  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
-
 
   # A separate project is used to download, so that the SuperBuild
   # subdirectory can be use for SimpleITK's SuperBuild to build


### PR DESCRIPTION
This commit fixes a regression introduced in 127dfbad28 (COMP: Update
SimpleITK from v2.0rc3 to v2.0.0 (#5212)) and ensures that SimpleITK
libraries are also in the PATH when running the command:

  cd /path/to/SimpleITK-build/SimpleITK-build/Wrapping/Python
  python setup.py install

Adding the SimpleITK libraries is required on windows where
Slicer_USE_SimpleITK_SHARED is enabled.