### PR TITLE
ENH: Add option to set reference volume when exporting segmentation to file

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -1187,3 +1187,33 @@ vtkMRMLColorTableNode* vtkMRMLSegmentationNode::GetLabelmapConversionColorTableN
 {
   return vtkMRMLColorTableNode::SafeDownCast(this->GetNodeReference(this->GetLabelmapConversionColorTableNodeReferenceRole()));
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLSegmentationNode::OnNodeReferenceAdded(vtkMRMLNodeReference* reference)
+{
+  this->Superclass::OnNodeReferenceAdded(reference);
+  if (std::string(reference->GetReferenceRole()) == this->GetReferenceImageGeometryReferenceRole())
+    {
+    this->InvokeCustomModifiedEvent(vtkMRMLSegmentationNode::ReferenceImageGeometryChangedEvent, reference->GetReferencedNode());
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSegmentationNode::OnNodeReferenceModified(vtkMRMLNodeReference* reference)
+{
+  this->Superclass::OnNodeReferenceModified(reference);
+  if (std::string(reference->GetReferenceRole()) == this->GetReferenceImageGeometryReferenceRole())
+    {
+    this->InvokeCustomModifiedEvent(vtkMRMLSegmentationNode::ReferenceImageGeometryChangedEvent, reference->GetReferencedNode());
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSegmentationNode::OnNodeReferenceRemoved(vtkMRMLNodeReference* reference)
+{
+  this->Superclass::OnNodeReferenceRemoved(reference);
+  if (std::string(reference->GetReferenceRole()) == this->GetReferenceImageGeometryReferenceRole())
+    {
+    this->InvokeCustomModifiedEvent(vtkMRMLSegmentationNode::ReferenceImageGeometryChangedEvent, reference->GetReferencedNode());
+    }
+}

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.h
@@ -290,6 +290,12 @@ public:
   void SetLabelmapConversionColorTableNodeID(const char* labelmapConversionColorTableNodeID);
   vtkMRMLColorTableNode* GetLabelmapConversionColorTableNode();
 
+  /// ReferenceImageGeometryChangedEvent is fired when the ReferenceImageGeometry node reference is Added, Modified, or Removed
+  enum
+  {
+    ReferenceImageGeometryChangedEvent = 23000
+  };
+
 protected:
   /// Set segmentation object
   vtkSetObjectMacro(Segmentation, vtkSegmentation);
@@ -315,6 +321,15 @@ protected:
 
   static const char* GetLabelmapConversionColorTableNodeReferenceRole() { return "labelmapConversionColorTableNode"; };
   static const char* GetLabelmapConversionColorTableNodeReferenceMRMLAttributeName() { return "labelmapConversionColorTableNodeRef"; };
+
+  /// Reimplemented to invoke ReferenceImageGeometryChangedEvent
+  void OnNodeReferenceAdded(vtkMRMLNodeReference* reference) override;
+
+  /// Reimplemented to invoke ReferenceImageGeometryChangedEvent
+  void OnNodeReferenceModified(vtkMRMLNodeReference* reference) override;
+
+  /// Reimplemented to invoke ReferenceImageGeometryChangedEvent
+  void OnNodeReferenceRemoved(vtkMRMLNodeReference* reference) override;
 
 protected:
   vtkMRMLSegmentationNode();

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -977,6 +977,60 @@ bool vtkSlicerSegmentationsModuleLogic::ExportAllSegmentsToModels(vtkMRMLSegment
 }
 
 //-----------------------------------------------------------------------------
+void vtkSlicerSegmentationsModuleLogic::GenerateMergedLabelmapInReferenceGeometry(vtkMRMLSegmentationNode* segmentationNode,
+  vtkMRMLVolumeNode* referenceVolumeNode, vtkStringArray* segmentIDs, int extentComputationMode, vtkOrientedImageData* mergedLabelmap_Reference)
+{
+  // Get reference geometry in the segmentation node's coordinate system
+  vtkSmartPointer<vtkOrientedImageData> referenceGeometry_Reference; // reference geometry in reference node coordinate system
+  vtkSmartPointer<vtkOrientedImageData> referenceGeometry_Segmentation;
+  vtkSmartPointer<vtkGeneralTransform> referenceGeometryToSegmentationTransform;
+  if (referenceVolumeNode && referenceVolumeNode->GetImageData())
+    {
+    // Create (non-allocated) image data that matches reference geometry
+    referenceGeometry_Reference = vtkSmartPointer<vtkOrientedImageData>::New();
+    referenceGeometry_Reference->SetExtent(referenceVolumeNode->GetImageData()->GetExtent());
+    vtkSmartPointer<vtkMatrix4x4> ijkToRasMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+    referenceVolumeNode->GetIJKToRASMatrix(ijkToRasMatrix);
+    referenceGeometry_Reference->SetGeometryFromImageToWorldMatrix(ijkToRasMatrix);
+
+    // Transform it to the segmentation node coordinate system
+    referenceGeometry_Segmentation = vtkSmartPointer<vtkOrientedImageData>::New();
+    referenceGeometry_Segmentation->DeepCopy(referenceGeometry_Reference);
+
+    // Get transform between reference volume and segmentation node
+    if (referenceVolumeNode->GetParentTransformNode() != segmentationNode->GetParentTransformNode())
+      {
+      referenceGeometryToSegmentationTransform = vtkSmartPointer<vtkGeneralTransform>::New();
+      vtkMRMLTransformNode::GetTransformBetweenNodes(referenceVolumeNode->GetParentTransformNode(),
+        segmentationNode->GetParentTransformNode(), referenceGeometryToSegmentationTransform);
+      vtkOrientedImageDataResample::TransformOrientedImage(referenceGeometry_Segmentation, referenceGeometryToSegmentationTransform, true /* geometry only */);
+      }
+    }
+
+  // Generate shared labelmap for the exported segments in segmentation coordinates
+  vtkSmartPointer<vtkOrientedImageData> sharedImage_Segmentation = vtkSmartPointer<vtkOrientedImageData>::New();
+  if (!segmentationNode->GenerateMergedLabelmapForAllSegments(sharedImage_Segmentation, extentComputationMode,
+    referenceGeometry_Segmentation, segmentIDs))
+    {
+    vtkErrorWithObjectMacro(segmentationNode, "ExportSegmentsToLabelmapNode: Failed to generate shared labelmap");
+    return;
+    }
+
+  // Transform shared labelmap to reference geometry coordinate system
+  if (referenceGeometryToSegmentationTransform)
+    {
+    vtkAbstractTransform* segmentationToReferenceGeometryTransform = referenceGeometryToSegmentationTransform->GetInverse();
+    segmentationToReferenceGeometryTransform->Update();
+    vtkOrientedImageDataResample::ResampleOrientedImageToReferenceOrientedImage(sharedImage_Segmentation, referenceGeometry_Reference, mergedLabelmap_Reference,
+      false /* nearest neighbor interpolation*/, false /* no padding */, segmentationToReferenceGeometryTransform);
+    }
+  else
+    {
+    mergedLabelmap_Reference->DeepCopy(sharedImage_Segmentation);
+    }
+}
+
+//-----------------------------------------------------------------------------
 bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(vtkMRMLSegmentationNode* segmentationNode,
   std::vector<std::string>& segmentIDs, vtkMRMLLabelMapVolumeNode* labelmapNode, vtkMRMLVolumeNode* referenceVolumeNode /*=nullptr*/,
   int extentComputationMode /*=vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS*/, vtkMRMLColorTableNode* exportColorTable/*=nullptr*/)
@@ -1013,31 +1067,14 @@ bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(vtkMRMLSegm
     }
   labelmapNode->SetAndObserveTransformNodeID(parentTransformNode ? parentTransformNode->GetID() : "");
 
-  // Get reference geometry in the segmentation node's coordinate system
-  vtkSmartPointer<vtkOrientedImageData> referenceGeometry_Reference; // reference geometry in reference node coordinate system
-  vtkSmartPointer<vtkOrientedImageData> referenceGeometry_Segmentation; // reference geometry in segmentation coordinate system
-  vtkSmartPointer<vtkGeneralTransform> referenceGeometryToSegmentationTransform;
-  if (referenceVolumeNode && referenceVolumeNode->GetImageData())
+  vtkNew<vtkOrientedImageData> mergedLabelmap_Reference;
+  vtkNew<vtkStringArray> segmentIDsArray;
+  for (std::string segmentID : segmentIDs)
     {
-    // Create (non-allocated) image data that matches reference geometry
-    referenceGeometry_Reference = vtkSmartPointer<vtkOrientedImageData>::New();
-    referenceGeometry_Reference->SetExtent(referenceVolumeNode->GetImageData()->GetExtent());
-    vtkSmartPointer<vtkMatrix4x4> ijkToRasMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
-    referenceVolumeNode->GetIJKToRASMatrix(ijkToRasMatrix);
-    referenceGeometry_Reference->SetGeometryFromImageToWorldMatrix(ijkToRasMatrix);
-
-    // Transform it to the segmentation node coordinate system
-    referenceGeometry_Segmentation = vtkSmartPointer<vtkOrientedImageData>::New();
-    referenceGeometry_Segmentation->DeepCopy(referenceGeometry_Reference);
-    // Apply parent transform of the volume node if any
-    if (referenceVolumeNode->GetParentTransformNode() != segmentationNode->GetParentTransformNode())
-      {
-      referenceGeometryToSegmentationTransform = vtkSmartPointer<vtkGeneralTransform>::New();
-      vtkMRMLTransformNode::GetTransformBetweenNodes(referenceVolumeNode->GetParentTransformNode(),
-        segmentationNode->GetParentTransformNode(), referenceGeometryToSegmentationTransform);
-      vtkOrientedImageDataResample::TransformOrientedImage(referenceGeometry_Segmentation, referenceGeometryToSegmentationTransform, true /* geometry only */);
-      }
+    segmentIDsArray->InsertNextValue(segmentID);
     }
+  vtkSlicerSegmentationsModuleLogic::GenerateMergedLabelmapInReferenceGeometry(segmentationNode, referenceVolumeNode,
+    segmentIDsArray, extentComputationMode, mergedLabelmap_Reference);
 
   vtkSmartPointer<vtkIntArray> labelValues = nullptr;
   if (exportColorTable)
@@ -1051,33 +1088,8 @@ bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(vtkMRMLSegm
     vtkSlicerSegmentationsModuleLogic::GetLabelValuesFromColorNode(segmentationNode, exportColorTable, segmentIdsArray, labelValues);
     }
 
-  // Generate shared labelmap for the exported segments
-  vtkSmartPointer<vtkOrientedImageData> sharedImage_Segmentation = vtkSmartPointer<vtkOrientedImageData>::New();
-  if (!segmentationNode->GenerateMergedLabelmap(sharedImage_Segmentation, extentComputationMode,
-    referenceGeometry_Segmentation, segmentIDs, labelValues))
-    {
-    vtkErrorWithObjectMacro(segmentationNode, "ExportSegmentsToLabelmapNode: Failed to generate shared labelmap");
-    return false;
-    }
-
-  // Transform shared labelmap to reference geometry coordinate system
-  vtkSmartPointer<vtkOrientedImageData> sharedImage_Reference;
-  if (referenceGeometryToSegmentationTransform)
-    {
-    sharedImage_Reference = vtkSmartPointer<vtkOrientedImageData>::New();
-    vtkAbstractTransform* segmentationToReferenceGeometryTransform = referenceGeometryToSegmentationTransform->GetInverse();
-    segmentationToReferenceGeometryTransform->Update();
-    vtkOrientedImageDataResample::ResampleOrientedImageToReferenceOrientedImage(sharedImage_Segmentation, referenceGeometry_Reference, sharedImage_Reference,
-      false /* nearest neighbor interpolation*/, false /* no padding */, segmentationToReferenceGeometryTransform);
-    }
-  else
-    {
-    sharedImage_Reference = sharedImage_Segmentation;
-    }
-  sharedImage_Segmentation = nullptr; // free up memory
-
   // Export shared labelmap to the output node
-  if (!vtkSlicerSegmentationsModuleLogic::CreateLabelmapVolumeFromOrientedImageData(sharedImage_Reference, labelmapNode))
+  if (!vtkSlicerSegmentationsModuleLogic::CreateLabelmapVolumeFromOrientedImageData(mergedLabelmap_Reference, labelmapNode))
     {
     vtkErrorWithObjectMacro(segmentationNode, "ExportSegmentsToLabelmapNode: Failed to create labelmap from shared segments image");
     return false;
@@ -2311,6 +2323,7 @@ void vtkSlicerSegmentationsModuleLogic::GetLabelValuesFromColorNode(vtkMRMLSegme
 //-----------------------------------------------------------------------------
 bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsBinaryLabelmapRepresentationToFiles(std::string destinationFolder,
   vtkMRMLSegmentationNode* segmentationNode, vtkStringArray* segmentIds/*=nullptr*/, std::string extension/*="NRRD"*/, bool useCompression/*=false*/,
+  vtkMRMLVolumeNode* referenceVolumeNode /*=nullptr*/, int extentComputationMode /*=vtkSegmentation::EXTENT_REFERENCE_GEOMETRY*/,
   vtkMRMLColorTableNode* colorTableNode/*=nullptr*/)
 {
   if (!segmentationNode)
@@ -2326,11 +2339,13 @@ bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsBinaryLabelmapRepresentati
     vtkSlicerSegmentationsModuleLogic::GetLabelValuesFromColorNode(segmentationNode, colorTableNode, segmentIds, labelValues);
     }
 
-  vtkNew<vtkOrientedImageData> mergedLabelmap;
-  segmentationNode->GenerateMergedLabelmapForAllSegments(mergedLabelmap, vtkSegmentation::EXTENT_REFERENCE_GEOMETRY, nullptr, segmentIds, labelValues);
+
+  vtkNew<vtkOrientedImageData> mergedLabelmap_Reference;
+  vtkSlicerSegmentationsModuleLogic::GenerateMergedLabelmapInReferenceGeometry(segmentationNode, referenceVolumeNode,
+    segmentIds, extentComputationMode, mergedLabelmap_Reference);
 
   vtkNew<vtkMatrix4x4> rasToIJKMatrix;
-  mergedLabelmap->GetWorldToImageMatrix(rasToIJKMatrix);
+  mergedLabelmap_Reference->GetWorldToImageMatrix(rasToIJKMatrix);
 
   std::string safeFileName = vtkSlicerSegmentationsModuleLogic::GetSafeFileName(segmentationNode->GetName());
   std::string fullNameWithoutExtension = destinationFolder + "/" + safeFileName;
@@ -2338,7 +2353,7 @@ bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsBinaryLabelmapRepresentati
   std::string fullNameWithExtension = fullNameWithoutExtension + "." + fileExtension;
 
   vtkNew<vtkITKImageWriter> writer;
-  writer->SetInputData(mergedLabelmap);
+  writer->SetInputData(mergedLabelmap_Reference);
   writer->SetRasToIJKMatrix(rasToIJKMatrix);
   writer->SetFileName(fullNameWithExtension.c_str());
   writer->SetUseCompression(useCompression);

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -275,9 +275,12 @@ public:
   /// \param segmentIds List of segment ids to get values for. The order of segmentIds dictates the order of the returned label values.
   /// \param extension The file extension used for the output file. "nrrd" by default.
   /// \param useCompression If compression should be applied to the output file.
+  /// \param referenceVolumeNode If specified, then the saved segmentation will match the geometry of referenceVolumeNode
+  /// \param extentComputationMode If referenceVolumeNode is not specified then the saved segmentation extents will be determined based on this value.
   /// \param colorTableNode Color table node used to set the exported labelmap values for the segments.
   static bool ExportSegmentsBinaryLabelmapRepresentationToFiles(std::string destinationFolder,
     vtkMRMLSegmentationNode* segmentationNode, vtkStringArray* segmentIds = nullptr, std::string extension = "nrrd", bool useCompression = false,
+    vtkMRMLVolumeNode* referenceVolumeNode = nullptr, int extentComputationMode = vtkSegmentation::EXTENT_REFERENCE_GEOMETRY,
     vtkMRMLColorTableNode* colorTableNode = nullptr);
 
   /// Create representation of only one segment in a segmentation.
@@ -420,6 +423,9 @@ public:
   ///   overwrite each other, but the result is guaranteed to have one layer
   /// \return True if the representation was created, False otherwise
   static void CollapseBinaryLabelmaps(vtkMRMLSegmentationNode* segmentationNode, bool forceToSingleLayer);
+
+  static void GenerateMergedLabelmapInReferenceGeometry(vtkMRMLSegmentationNode* segmentationNode, vtkMRMLVolumeNode* referenceVolumeNode,
+    vtkStringArray* segmentIDs, int extentComputationMode, vtkOrientedImageData* mergedLabelmap_Reference);
 
 public:
   /// Set Terminologies module logic

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationFileExportWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationFileExportWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>298</width>
-    <height>229</height>
+    <height>253</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,28 +29,42 @@
    <property name="spacing">
     <number>4</number>
    </property>
-   <item row="2" column="0">
-    <widget class="QLabel" name="DestinationFoldeLabel">
+   <item row="3" column="0">
+    <widget class="QLabel" name="VisibleSegmentsOnlyLabel">
      <property name="text">
-      <string>Destination folder: </string>
+      <string>Visible segments only: </string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="MergeIntoSingleFileLabel">
-     <property name="text">
-      <string>Merge into single file:</string>
+   <item row="9" column="1">
+    <widget class="ctkDoubleSpinBox" name="SizeScaleSpinBox">
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+     <property name="toolTip">
+      <string>Adjust the exported model size. Point coordinates in the exported model will be multiplied by this number. By default Slicer uses millimeter unit for coordinates.</string>
+     </property>
+     <property name="decimals">
+      <number>3</number>
+     </property>
+     <property name="decimalsOption">
+      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
+     </property>
+     <property name="minimum">
+      <double>0.000001000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="FileFormatLabel">
-     <property name="text">
-      <string>File format:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="1">
+   <item row="12" column="1">
     <layout class="QHBoxLayout" name="ColorTableLayout">
      <item>
       <widget class="QCheckBox" name="UseColorTableValuesCheckBox">
@@ -79,7 +93,82 @@
      </item>
     </layout>
    </item>
-   <item row="12" column="1">
+   <item row="2" column="0">
+    <widget class="QLabel" name="DestinationFoldeLabel">
+     <property name="text">
+      <string>Destination folder: </string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QComboBox" name="CoordinateSystemComboBox">
+     <property name="toolTip">
+      <string>Output model XYZ axes are mapped to LPS (left-posterior-superior) or RAS (right-anterior-superior) patient axis directions. LPS is used more commonly.</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>LPS</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>RAS</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="UseColorTableValuesLabel">
+     <property name="text">
+      <string>Use color table values:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="FileFormatLabel">
+     <property name="text">
+      <string>File format:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="CoordinateSystemLabel">
+     <property name="text">
+      <string>Coordinate system: </string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="VisibleSegmentsOnlyCheckBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>Only export those segments that are currently visible.</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="MergeIntoSingleFileLabel">
+     <property name="text">
+      <string>Merge into single file:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0" colspan="2">
+    <widget class="QPushButton" name="ExportToFilesButton">
+     <property name="text">
+      <string>Export</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
     <widget class="QCheckBox" name="ShowDestinationFolderOnExportCompleteCheckBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -98,7 +187,42 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="HorizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="ctkDirectoryButton" name="DestinationFolderButton">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="ShowDestinationFolderButton">
+       <property name="toolTip">
+        <string>Browse to destination folder</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
+         <normaloff>:/Icons/Go.png</normaloff>:/Icons/Go.png</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="SizeScaleLabel">
+     <property name="text">
+      <string>Size scale:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QCheckBox" name="MergeIntoSingleOBJFileCheckBox">
@@ -134,45 +258,14 @@
      </item>
     </layout>
    </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="ShowDestinationFolderOnExportCompleteLabel">
+   <item row="11" column="1">
+    <widget class="QCheckBox" name="UseCompressionCheckBox">
      <property name="text">
-      <string>Show destination folder:</string>
+      <string/>
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="UseColorTableValuesLabel">
-     <property name="text">
-      <string>Use color table values:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="CoordinateSystemLabel">
-     <property name="text">
-      <string>Coordinate system: </string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QComboBox" name="CoordinateSystemComboBox">
-     <property name="toolTip">
-      <string>Output model XYZ axes are mapped to LPS (left-posterior-superior) or RAS (right-anterior-superior) patient axis directions. LPS is used more commonly.</string>
-     </property>
-     <item>
-      <property name="text">
-       <string>LPS</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>RAS</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QComboBox" name="FileFormatComboBox">
      <item>
       <property name="text">
@@ -196,110 +289,42 @@
      </item>
     </widget>
    </item>
-   <item row="8" column="1">
-    <widget class="ctkDoubleSpinBox" name="SizeScaleSpinBox">
-     <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
-     </property>
-     <property name="toolTip">
-      <string>Adjust the exported model size. Point coordinates in the exported model will be multiplied by this number. By default Slicer uses millimeter unit for coordinates.</string>
-     </property>
-     <property name="decimals">
-      <number>3</number>
-     </property>
-     <property name="decimalsOption">
-      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
-     </property>
-     <property name="minimum">
-      <double>0.000001000000000</double>
-     </property>
-     <property name="maximum">
-      <double>1000000.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-     <property name="value">
-      <double>1.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0" colspan="2">
-    <widget class="QPushButton" name="ExportToFilesButton">
-     <property name="text">
-      <string>Export</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="HorizontalLayout">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="ctkDirectoryButton" name="DestinationFolderButton">
-       <property name="focusPolicy">
-        <enum>Qt::TabFocus</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="ShowDestinationFolderButton">
-       <property name="toolTip">
-        <string>Browse to destination folder</string>
-       </property>
-       <property name="text">
-        <string>...</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
-         <normaloff>:/Icons/Go.png</normaloff>:/Icons/Go.png</iconset>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="1">
-    <widget class="QCheckBox" name="VisibleSegmentsOnlyCheckBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>Only export those segments that are currently visible.</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="SizeScaleLabel">
-     <property name="text">
-      <string>Size scale:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="VisibleSegmentsOnlyLabel">
-     <property name="text">
-      <string>Visible segments only: </string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
-    <widget class="QCheckBox" name="UseCompressionCheckBox">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0">
+   <item row="11" column="0">
     <widget class="QLabel" name="UseCompressionLabel">
      <property name="text">
       <string>Use compression:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0">
+    <widget class="QLabel" name="ShowDestinationFolderOnExportCompleteLabel">
+     <property name="text">
+      <string>Show destination folder:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="ReferenceVolumeLabel">
+     <property name="text">
+      <string>Reference volume:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="qMRMLNodeComboBox" name="ReferenceVolumeComboBox">
+     <property name="nodeTypes">
+      <stringlist>
+       <string>vtkMRMLVolumeNode</string>
+      </stringlist>
+     </property>
+     <property name="noneEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="addEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="removeEnabled">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -354,6 +379,22 @@
     <hint type="destinationlabel">
      <x>281</x>
      <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qMRMLSegmentationFileExportWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>ReferenceVolumeComboBox</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>148</x>
+     <y>114</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>209</x>
+     <y>51</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationFileExportWidget.h
@@ -86,6 +86,8 @@ public slots:
 
   void updateWidgetFromMRML();
 
+  void onSegmentationReferenceImageGeometryChanged();
+
 protected slots:
 
   void setFileFormat(const QString&);


### PR DESCRIPTION
This commit adds a vtkMRMLVolumeNode selector to the file export dialog, which allows a reference geometry to be specified when exporting a segmentation volume to file.
See discussion here: https://discourse.slicer.org/t/segmentation-alignment/13449/15