### PR TITLE
COMP: Fix macOS package adding fixup rules for VTK9 python modules

### DIFF
--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -167,6 +167,13 @@ function(fixup_bundle_with_plugins app)
       )
   endif()
 
+  set(Slicer_VTK_VERSION_MAJOR "@Slicer_VTK_VERSION_MAJOR@")
+  if(Slicer_USE_PYTHONQT AND ${Slicer_VTK_VERSION_MAJOR} VERSION_GREATER_EQUAL 9)
+    list(APPEND candidates_pattern
+      "${app_dir}/Contents/bin/Python/vtkmodules/vtk*.so"
+      )
+  endif()
+
   set(Slicer_USE_PYTHONQT_WITH_OPENSSL "@Slicer_USE_PYTHONQT_WITH_OPENSSL@")
   if(Slicer_USE_PYTHONQT_WITH_OPENSSL)
     list(APPEND candidates_pattern


### PR DESCRIPTION
This commit adds rules for Slicer package.

Note that commit 08789e8 (COMP: Fix packaging of VTK9 python modules)
added similar rules for extension fixup.