### PR TITLE
COMP: Fix macOS package setting "path" in VTK9 python modules fixup rules

### DIFF
--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -60,6 +60,10 @@ function(gp_item_default_embedded_path_override item default_embedded_path_var)
     if(item MATCHES "lib-dynload/[^/]+\\.so$")
       set(path "@fixup_path@/lib/Python/${PYTHON_STDLIB_SUBDIR}/lib-dynload")
     endif()
+    # VTK python modules
+    if(item MATCHES "vtkmodules/[^/]+\\.so$")
+      set(path "@fixup_path@/bin/Python/vtkmodules")
+    endif()
   endif()
 
   set(Slicer_USE_SimpleITK "@Slicer_USE_SimpleITK@")


### PR DESCRIPTION
This commit is a follow up of d6300056c4 (COMP: Fix macOS package adding
fixup rules for VTK9 python modules)