### PR TITLE
BUG: Remove P shortcut from incorrect location

### DIFF
--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -682,8 +682,6 @@ qSlicerMarkupsModuleWidget::qSlicerMarkupsModuleWidget(QWidget* _parent)
   : Superclass( _parent )
     , d_ptr( new qSlicerMarkupsModuleWidgetPrivate(*this) )
 {
-  this->pToAddShortcut = nullptr;
-
   this->volumeSpacingScaleFactor = 10.0;
 }
 
@@ -742,9 +740,6 @@ void qSlicerMarkupsModuleWidget::enter()
     this->setMRMLMarkupsNode(markupsNode);
     }
 
-  // install some shortcuts for use while in this module
-  this->installShortcuts();
-
   // check the max scales against volume spacing, they might need to be updated
   this->updateMaximumScaleFromVolumes();
 }
@@ -791,30 +786,6 @@ void qSlicerMarkupsModuleWidget::checkForAnnotationFiducialConversion()
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerMarkupsModuleWidget::installShortcuts()
-{
-  // add some shortcut keys
-  if (this->pToAddShortcut == nullptr)
-    {
-    this->pToAddShortcut = new QShortcut(QKeySequence(QString("p")), this);
-    }
-  QObject::connect(this->pToAddShortcut, SIGNAL(activated()),
-                   this, SLOT(onPKeyActivated()));
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerMarkupsModuleWidget::removeShortcuts()
-{
-  if (this->pToAddShortcut != nullptr)
-    {
-    //qDebug() << "removeShortcuts";
-    this->pToAddShortcut->disconnect(SIGNAL(activated()));
-    // TODO: when parent is set to null, using the mouse to place a fid when outside the Markups module is triggering a crash
-    //       this->pToAddShortcut->setParent(nullptr);
-    }
-}
-
-//-----------------------------------------------------------------------------
 void qSlicerMarkupsModuleWidget::convertAnnotationFiducialsToMarkups()
 {
   if (this->markupsLogic())
@@ -829,8 +800,6 @@ void qSlicerMarkupsModuleWidget::exit()
   this->Superclass::exit();
 
   // qDebug() << "exit widget";
-
-  this->removeShortcuts();
 
   // remove mrml scene observations, don't need to update the GUI while the
   // module is not showing

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
@@ -51,10 +51,6 @@ public:
   /// Disconnect from scene when exiting
   void exit() override;
 
-  /// Manage short cuts that allow key bindings for certain functions
-  void installShortcuts();
-  void removeShortcuts();
-
   /// Get the logic in the proper class
   vtkSlicerMarkupsLogic *markupsLogic();
 
@@ -251,7 +247,6 @@ private:
   Q_DECLARE_PRIVATE(qSlicerMarkupsModuleWidget);
   Q_DISABLE_COPY(qSlicerMarkupsModuleWidget);
 
-  QShortcut *pToAddShortcut;
 };
 
 #endif


### PR DESCRIPTION
This commit removes a 'P' shortcut implemented in the wrong place. It will be reimplemented but the current definition is interfering with customized shortcuts.

From @lassoan:

> I’ve found a ‘P’ key shortcut in qSlicerMarkupsModuleWidget. This is implemented at completely wrong place, so it should be removed.
> Since “P” shortcut would be generally useful, I think it should be handled in vtkSlicerMarkupsWidget, the same way how “Delete”, “Backpace” and “S” keys are handled already. We also plan to make widget GUI to widget event mapping (‘P’ key press -> pick point) customizable by users and modules.”