### PR TITLE
BUG: Fix crash when selecting a lookup table for slice distance color

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
@@ -552,6 +552,7 @@ void vtkMRMLModelSliceDisplayableManager::vtkInternal
         vtkSmartPointer<vtkLookupTable> dNodeLUT = vtkSmartPointer<vtkLookupTable>::Take(colorNode ? colorNode->CreateLookupTableCopy() : nullptr);
         if (dNodeLUT)
           {
+          lut = dNodeLUT;
           mapper->SetScalarRange(displayNode->GetScalarRange());
           lut->SetAlpha(hierarchyOpacity * displayNode->GetSliceIntersectionOpacity());
           }


### PR DESCRIPTION
The pointer to the lookup table was not set when using a lookup table color node.
Fixed by setting the lut pointer to the correct object.

fixes #5241