### PR TITLE
ENH: Update VTK

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -177,8 +177,8 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "1ecbd5001edd6a8ae3c725d8486f51f39afc0b2e") # slicer-v9.0.20200929-3fa220f28e
-    set(vtk_egg_info_version "9.0.20200825")
+    set(_git_tag "a889f4730498b796b6999ae6effd522334bdc577") # slicer-v9.0.20201013-bc2f5892b3
+    set(vtk_egg_info_version "9.0.20201013")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
   endif()


### PR DESCRIPTION
List of changes:

```
$ git shortlog 1ecbd5001..a889f47304 --no-merges
Ben Boeckel (3):
      hdf5: update for H5Tinit.c fix
      xdmf2: use the proper preprocessor definition
      cmake: fix the library suffix for WrappingPythonCore

Boonthanome Nouanesengsy (1):
      Deal with wraparound for PIO Reader, made PIO Reader parallel

Caitlin Ross (1):
      edit tag for fides update

Cory Quammen (1):
      macos: implement setting of DisplayId

David Thompson (1):
      Glyph3D should copy global IDs to its output.

Davide Punzo (1):
      ENH: add double click events

Fides Upstream (1):
      fides 2020-10-04 (0c29bd4a)

Freetype Upstream (1):
      freetype 2020-09-30 (b610a2a4)

HDF Upstream (1):
      hdf5 2020-10-05 (7867cd4a)

Jean-Christophe Fillion-Robin (4):
      COMP: Remove vtk-m submodule
      COMP: Remove FindTBB and expect VTK to be configured with TBB_DIR
      BUG: Update vtkPythonUtil to disable relative import causing crash for Slicer modules
      COMP: Associate "all.py" install rule with "python" component

JsonCpp Upstream (1):
      jsoncpp 2020-10-01 (dc44a205)

Ken Martin (1):
      Fix an issue with opengl state with Qwidgettexture

Kitware Robot (14):
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp

Mathieu Westphal (1):
      Adding Tracklength to the pathlines

Michael Migliore (5):
      Print JSON parsing error for material library
      Add error when PROJ4 string is not valid
      Fix categories when NaN is present
      Fix TIFF3D with RGB palette
      Improve precision during plane slicing

PEGTL Upstream (1):
      pegtl 2020-10-01 (07ff3adc)

Paul Lafoix (1):
      Add get accessor of Stereo attribute of vtkCamera

Peter Franz (4):

Ken Martin (1):
      Fix an issue with opengl state with Qwidgettexture

Kitware Robot (14):
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp
      VTK Nightly Date Stamp

Mathieu Westphal (1):
      Adding Tracklength to the pathlines

Michael Migliore (5):
      Print JSON parsing error for material library
      Add error when PROJ4 string is not valid
      Fix categories when NaN is present
      Fix TIFF3D with RGB palette
      Improve precision during plane slicing

PEGTL Upstream (1):
      pegtl 2020-10-01 (07ff3adc)

Paul Lafoix (1):
      Add get accessor of Stereo attribute of vtkCamera

Peter Franz (4):
      Fixing vtkAxisActor Numerical Issues for Ranges Close to Zero
      Merge branch 'vtkAxisActor-fix-epsilon-checks' of https://gitlab.kitware.com/drpeterfranz/vtk into vtkAxisActor-fix-epsilon-checks
      Bugfix vtkCellDataToPointData removes arrays from input data set
      Add test for vtkCellDataToPointData preserving input data set.

Utkarsh Ayachit (14):
      tpl: freetype 2.10.2
      tpl: gl2ps update to 1.4.2.
      tpl: update jpeg to 2.0.5.
      IO/XML: read idtype arrays from old files
      TestParallelUnstructuredGridIO: init controller correctly.
      add test for paraview/paraview#20179
      vtkXMLCompositeDataReader: handle blocks changing over time
      tpl: update jsoncpp to 1.9.4.
      tpl: update netcdf to 4.7.4.
      tpl: update pegtl to 2.8.3
      add test for paraview/paraview#20206.
      vtkCompositeDataDisplayAttributes: fix logic
      update baselines
      vtkGeometryFilter: fix warnings.

Will Schroeder (2):
      Added a feature to exclude specified faces from the output
      This subclass only supports one input.

Yohann Bearzi (4):
      Revert "AppendDataSets now support integer ids"
      Bug fix in vtkAppendFilter with global id merging
      Init non used bits of last byte in vtkBitArray
      Misc fixes on htg reader and writer

gl2ps Upstream (1):
      gl2ps 2020-09-30 (0a358b9f)

jpeg-turbo Upstream (1):
      jpeg 2020-09-30 (2953b5b4)

netcdf Upstream (1):
      netcdf 2020-10-01 (3b888566)
```