### PR TITLE
ENH: Add support for closed curves to curvature calculation

### DIFF
--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -120,6 +120,7 @@ set(MRMLCore_SRCS
   vtkEventBroker.cxx
   vtkDataFileFormatHelper.cxx
   vtkMRMLMeasurement.cxx
+  vtkMRMLMeasurementConstant.cxx
   vtkMRMLLogic.cxx
   vtkMRMLAbstractLayoutNode.cxx
   vtkMRMLAbstractViewNode.cxx

--- a/Libs/MRML/Core/vtkMRMLMeasurement.cxx
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.cxx
@@ -15,8 +15,6 @@ or http://www.slicer.org/copyright/copyright.txt for details.
 // STD include
 #include <sstream>
 
-vtkStandardNewMacro(vtkMRMLMeasurement);
-
 //----------------------------------------------------------------------------
 vtkMRMLMeasurement::vtkMRMLMeasurement()
   : InputMRMLNode(nullptr)

--- a/Libs/MRML/Core/vtkMRMLMeasurement.h
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.h
@@ -34,7 +34,6 @@ class VTK_MRML_EXPORT vtkMRMLMeasurement : public vtkObject
 {
 public:
 
-  static vtkMRMLMeasurement *New();
   vtkTypeMacro(vtkMRMLMeasurement, vtkObject);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
@@ -48,8 +47,9 @@ public:
   /// Copy one type into another (deep copy)
   virtual void Copy(vtkMRMLMeasurement* aEntry);
 
-  /// Perform calculation on \sa InputMRMLNode and store the result internally
-  virtual void Compute() {};
+  /// Perform calculation on \sa InputMRMLNode and store the result internally.
+  /// The subclasses need to implement this function
+  virtual void Compute() = 0;
 
   /// Enabled
   vtkSetMacro(Enabled, bool);

--- a/Libs/MRML/Core/vtkMRMLMeasurementConstant.cxx
+++ b/Libs/MRML/Core/vtkMRMLMeasurementConstant.cxx
@@ -15,26 +15,29 @@
 
 ==============================================================================*/
 
-#include "vtkMRMLMarkupsClosedCurveNode.h"
-
 // MRML includes
-#include "vtkCurveGenerator.h"
-#include "vtkCurveMeasurementsCalculator.h"
+#include "vtkMRMLMeasurementConstant.h"
 
-// VTK includes
-#include <vtkNew.h>
-#include <vtkObjectFactory.h>
+vtkStandardNewMacro(vtkMRMLMeasurementConstant);
 
 //----------------------------------------------------------------------------
-vtkMRMLNodeNewMacro(vtkMRMLMarkupsClosedCurveNode);
-
-//----------------------------------------------------------------------------
-vtkMRMLMarkupsClosedCurveNode::vtkMRMLMarkupsClosedCurveNode()
+vtkMRMLMeasurementConstant::vtkMRMLMeasurementConstant()
 {
-  this->CurveClosed = true;
-  this->CurveGenerator->SetCurveIsClosed(true);
-  this->CurveMeasurementsCalculator->SetCurveIsClosed(true);
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLMarkupsClosedCurveNode::~vtkMRMLMarkupsClosedCurveNode() = default;
+vtkMRMLMeasurementConstant::~vtkMRMLMeasurementConstant() = default;
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurementConstant::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMeasurementConstant::Compute()
+{
+  // No action is needed because this class is a constant variant of the dynamic
+  // vtkMRMLMeasurement. Typically all measurements calculate their own value from
+  // its input MRML node. This class is to be able to store constant measurements.
+}

--- a/Libs/MRML/Core/vtkMRMLMeasurementConstant.h
+++ b/Libs/MRML/Core/vtkMRMLMeasurementConstant.h
@@ -1,0 +1,47 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLMeasurementConstant_h
+#define __vtkMRMLMeasurementConstant_h
+
+// MRML includes
+#include "vtkMRMLMeasurement.h"
+
+/// \brief Measurement class storing a constant measurement.
+///
+/// Typically all measurements calculate their own value from its input
+/// MRML node. This class is to be able to store constant measurements.
+///
+/// \ingroup Slicer_QtModules_Markups
+class VTK_MRML_EXPORT vtkMRMLMeasurementConstant : public vtkMRMLMeasurement
+{
+public:
+  static vtkMRMLMeasurementConstant *New();
+  vtkTypeMacro(vtkMRMLMeasurementConstant, vtkMRMLMeasurement);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Do nothing to compute the measurement as it is static
+  void Compute() override;
+
+protected:
+  vtkMRMLMeasurementConstant();
+  ~vtkMRMLMeasurementConstant() override;
+  vtkMRMLMeasurementConstant(const vtkMRMLMeasurementConstant&);
+  void operator=(const vtkMRMLMeasurementConstant&);
+};
+
+#endif

--- a/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkCurveGenerator.cxx
@@ -51,7 +51,7 @@ vtkCurveGenerator::vtkCurveGenerator()
   this->SetNumberOfInputPorts(2);
 
   this->SetCurveTypeToLinearSpline();
-  this->CurveIsLoop = false;
+  this->CurveIsClosed = false;
   this->NumberOfPointsPerInterpolatingSegment = 5;
   this->KochanekBias = 0.0;
   this->KochanekContinuity = 0.0;
@@ -84,7 +84,7 @@ void vtkCurveGenerator::PrintSelf(std::ostream &os, vtkIndent indent)
   Superclass::PrintSelf(os, indent);
   os << indent << "InputParameters size: " << (this->InputParameters != nullptr ? this->InputParameters->GetNumberOfTuples() : 0) << std::endl;
   os << indent << "CurveType: " << this->GetCurveTypeAsString(this->CurveType) << std::endl;
-  os << indent << "CurveIsLoop: " << this->CurveIsLoop << std::endl;
+  os << indent << "CurveIsClosed: " << this->CurveIsClosed << std::endl;
   os << indent << "KochanekBias: " << this->KochanekBias << std::endl;
   os << indent << "KochanekContinuity: " << this->KochanekContinuity << std::endl;
   os << indent << "KochanekTension: " << this->KochanekTension << std::endl;
@@ -371,7 +371,7 @@ void vtkCurveGenerator::SetParametricFunctionToSpline(vtkPoints* inputPoints, vt
   parametricSpline->SetYSpline(ySpline);
   parametricSpline->SetZSpline(zSpline);
   parametricSpline->SetPoints(inputPoints);
-  parametricSpline->SetClosed(this->CurveIsLoop);
+  parametricSpline->SetClosed(this->CurveIsClosed);
   parametricSpline->SetParameterizeByLength(false);
   this->ParametricFunction = parametricSpline;
 }
@@ -609,7 +609,7 @@ int vtkCurveGenerator::GeneratePointsFromFunction(vtkPoints* inputPoints, vtkPoi
     }
 
   int numberOfSegments = 0; // temporary value
-  if (this->CurveIsLoop && this->CurveType != vtkCurveGenerator::CURVE_TYPE_POLYNOMIAL)
+  if (this->CurveIsClosed && this->CurveType != vtkCurveGenerator::CURVE_TYPE_POLYNOMIAL)
     {
     numberOfSegments = numberOfInputPoints;
     }
@@ -675,7 +675,7 @@ int vtkCurveGenerator::GeneratePointsFromSurface(
     }
 
   vtkIdType numberOfSegments = 0;
-  if (this->CurveIsLoop)
+  if (this->CurveIsClosed)
     {
     numberOfSegments = numberOfInputPoints;
     }
@@ -764,8 +764,8 @@ int vtkCurveGenerator::GenerateLines(vtkPolyData* polyData)
   vtkNew<vtkCellArray> lines;
   if (numberOfPoints > 1)
     {
-    bool loop = (numberOfPoints > 2 && this->CurveIsLoop);
-    vtkIdType numberOfCellPoints = (loop ? numberOfPoints + 1 : numberOfPoints);
+    bool closed = (numberOfPoints > 2 && this->CurveIsClosed);
+    vtkIdType numberOfCellPoints = (closed ? numberOfPoints + 1 : numberOfPoints);
 
     // Only regenerate indices if necessary
     bool needToUpdateLines = true;
@@ -793,7 +793,7 @@ int vtkCurveGenerator::GenerateLines(vtkPolyData* polyData)
         {
         lines->InsertCellPoint(i);
         }
-      if (loop)
+      if (closed)
         {
         lines->InsertCellPoint(0);
         }

--- a/Modules/Loadable/Markups/MRML/vtkCurveGenerator.h
+++ b/Modules/Loadable/Markups/MRML/vtkCurveGenerator.h
@@ -47,9 +47,9 @@ public:
 
   /// This indicates whether the curve should loop back in on itself,
   /// connecting the last point back to the first point (disabled by default).
-  vtkSetMacro(CurveIsLoop, bool);
-  vtkGetMacro(CurveIsLoop, bool);
-  vtkBooleanMacro(CurveIsLoop, bool);
+  vtkSetMacro(CurveIsClosed, bool);
+  vtkGetMacro(CurveIsClosed, bool);
+  vtkBooleanMacro(CurveIsClosed, bool);
 
   /// Type of curve to generate
   enum
@@ -208,7 +208,7 @@ protected:
   // input parameters
   int NumberOfPointsPerInterpolatingSegment;
   int CurveType;
-  bool CurveIsLoop;
+  bool CurveIsClosed;
   double KochanekBias;
   double KochanekContinuity;
   double KochanekTension;

--- a/Modules/Loadable/Markups/MRML/vtkCurveMeasurementsCalculator.h
+++ b/Modules/Loadable/Markups/MRML/vtkCurveMeasurementsCalculator.h
@@ -47,6 +47,14 @@ public:
   //@}
 
   //@{
+  /// This indicates whether the curve loops back in on itself,
+  /// connecting the last point back to the first point (disabled by default).
+  vtkSetMacro(CurveIsClosed, bool);
+  vtkGetMacro(CurveIsClosed, bool);
+  vtkBooleanMacro(CurveIsClosed, bool);
+  //@}
+
+  //@{
   /// Set/Get flag determining whether to calculate curvature
   vtkSetMacro(CalculateCurvature, bool);
   vtkGetMacro(CalculateCurvature, bool);
@@ -69,13 +77,24 @@ protected:
   static void OnControlPointArrayModified(vtkObject* caller, unsigned long eid, void* clientData, void* callData);
 
 protected:
+  /// Measurement list from the markups node for derived measurements (such as interpolation)
   vtkWeakPointer<vtkCollection> Measurements;
+
+  /// Flag indicating whether the current curve is closed
+  bool CurveIsClosed{false};
+
+  /// Flag determining whether the filter should calculate curvature
   bool CalculateCurvature{false};
+
+  /// Flag determining whether the filter should interpolate control point measurements
   bool InterpolateControlPointMeasurement{false};
 
   /// Command handling data array modified events
   vtkCallbackCommand* ControlPointArrayModifiedCallbackCommand;
+  /// List of observed control point arrays (for removal of observations)
+  vtkCollection* ObservedControlPointArrays;
 
+protected:
   int FillInputPortInformation(int port, vtkInformation* info) override;
   int RequestData(vtkInformation* request, vtkInformationVector** inputVector, vtkInformationVector* outputVector) override;
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -21,6 +21,7 @@
 #include "vtkCurveGenerator.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkMRMLMarkupsStorageNode.h"
+#include "vtkMRMLMeasurementConstant.h"
 #include "vtkMRMLSelectionNode.h"
 #include "vtkMRMLTransformNode.h"
 #include "vtkMRMLUnitNode.h"
@@ -1986,15 +1987,20 @@ void vtkMRMLMarkupsNode::SetNthMeasurement(int id,
     vtkErrorMacro("vtkMRMLMarkupsNode::SetNthMeasurement failed: id out of range");
     return;
     }
-  vtkSmartPointer<vtkMRMLMeasurement> measurement;
+  vtkSmartPointer<vtkMRMLMeasurementConstant> measurement;
   if (id >= this->GetNumberOfMeasurements())
     {
-    measurement = vtkSmartPointer<vtkMRMLMeasurement>::New();
+    measurement = vtkSmartPointer<vtkMRMLMeasurementConstant>::New();
     this->Measurements->AddItem(measurement);
     }
   else
     {
-    measurement = vtkMRMLMeasurement::SafeDownCast(this->Measurements->GetItemAsObject(id));
+    measurement = vtkMRMLMeasurementConstant::SafeDownCast(this->Measurements->GetItemAsObject(id));
+    if (measurement == nullptr)
+      {
+      vtkErrorMacro("SetNthMeasurement: Cannot set non-constant measurement manually (ID: " << id << ")");
+      return;
+      }
     }
   measurement->SetName(name.c_str());
   measurement->SetValue(value);

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
@@ -18,6 +18,7 @@
 // MRML includes
 #include "vtkMRMLCoreTestingMacros.h"
 #include "vtkMRMLMarkupsNode.h"
+#include "vtkMRMLMeasurementConstant.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLStorageNode.h"
 
@@ -45,7 +46,7 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
   std::string formatTest = node1->ReplaceListNameInMarkupLabelFormat();
   CHECK_STD_STRING(formatTest, "testingname-%d");
 
-  vtkNew<vtkMRMLMeasurement> measurement1;
+  vtkNew<vtkMRMLMeasurementConstant> measurement1;
   measurement1->SetName("Diameter");
   measurement1->SetValue(15.0);
   measurement1->SetUnits("mm2");

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from slicer.util import TESTING_DATA_URL
 import os
+import numpy as np
 
 #
 # Test curvature computation for curve markups
@@ -44,11 +45,14 @@ if curvePointData.GetArrayName(1) != 'Curvature':
 
 curvatureArray = curvePointData.GetArray(1)
 if curvatureArray.GetMaxId() != curvePointData.GetNumberOfTuples()-1:
-  exceptionMessage = "Unexpected number of values in curvature data array: " + str(curvatureArray.GetMaxId())
+  exceptionMessage = "Unexpected number of values in curvature data array: %d (expected %d)" % (curvatureArray.GetMaxId(), curvePointData.GetNumberOfTuples()-1)
   raise Exception(exceptionMessage)
 
-if abs(curvatureArray.GetMaxNorm() - 0.9816015970208652) > 0.0001:
-  exceptionMessage = "Unexpected maximum norm in curvature data array: " + str(curvatureArray.GetMaxNorm())
+if abs(curvatureArray.GetRange()[0] - 0.0) > 0.0001:
+  exceptionMessage = "Unexpected minimum in curvature data array: " + str(curvatureArray.GetRange()[0])
+  raise Exception(exceptionMessage)
+if abs(curvatureArray.GetRange()[1] - 0.9816015970208652) > 0.0001:
+  exceptionMessage = "Unexpected maximum in curvature data array: " + str(curvatureArray.GetRange()[1])
   raise Exception(exceptionMessage)
 
 # Turn off curvature computation
@@ -56,3 +60,117 @@ curveNode.SetCalculateCurvature(False)
 if curvePointData.GetNumberOfArrays() != 1:
   exceptionMessage = "Unexpected number of data arrays in curve: " + str(curvePointData.GetNumberOfArrays())
   raise Exception(exceptionMessage)
+
+print('Open curve curvature test finished successfully')
+
+#
+# Test closed curve curvature computation
+#
+
+closedCurveNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsClosedCurveNode')
+pos = np.zeros(3)
+for i in range(curveNode.GetNumberOfControlPoints()):
+  curveNode.GetNthControlPointPosition(i, pos)
+  closedCurveNode.AddControlPoint(vtk.vtkVector3d(pos))
+
+closedCurveNode.SetCalculateCurvature(True)
+
+curvePolyData = closedCurveNode.GetCurveWorld()
+curvePointData = curvePolyData.GetPointData()
+if curvePointData.GetNumberOfArrays() != 2:
+  exceptionMessage = "Unexpected number of data arrays in curve: " + str(curvePointData.GetNumberOfArrays())
+  raise Exception(exceptionMessage)
+
+if curvePointData.GetArrayName(1) != 'Curvature':
+  exceptionMessage = "Unexpected data array name in curve: " + str(curvePointData.GetArrayName(1))
+  raise Exception(exceptionMessage)
+
+curvatureArray = curvePointData.GetArray(1)
+if curvatureArray.GetMaxId() != curvePointData.GetNumberOfTuples()-1:
+  exceptionMessage = "Unexpected number of values in curvature data array: %d (expected %d)" % (curvatureArray.GetMaxId(), curvePointData.GetNumberOfTuples()-1)
+  raise Exception(exceptionMessage)
+
+if abs(curvatureArray.GetRange()[0] - 0.0) > 0.0001:
+  exceptionMessage = "Unexpected minimum in curvature data array: " + str(curvatureArray.GetRange()[0])
+  raise Exception(exceptionMessage)
+if abs(curvatureArray.GetRange()[1] - 0.26402460470400924) > 0.0001:
+  exceptionMessage = "Unexpected maximum in curvature data array: " + str(curvatureArray.GetRange()[1])
+  raise Exception(exceptionMessage)
+
+print('Closed curve curvature test finished successfully')
+
+#
+# Test interpolation of control point measurements
+#
+# This test case uses a stripped scene that is the result of calculating radius
+# of a model using the ExtractCenterline module in the SlicerVMTK extension.
+#
+
+slicer.mrmlScene.Clear()
+
+testSceneFilePath = curveMeasurementsTestDir + '/MarkupsControlPointMeasurementInterpolationTestScene.mrb'
+
+slicer.util.downloadFile(
+  TESTING_DATA_URL + 'SHA256/b636ecfc1be54504c2c9843e1ff53242ee6b951228490ae99a89e06c8890e344',
+  testSceneFilePath,
+  checksum='SHA256:b636ecfc1be54504c2c9843e1ff53242ee6b951228490ae99a89e06c8890e344')
+
+# Import test scene
+slicer.util.loadScene(testSceneFilePath)
+
+centerlineModel = slicer.util.getNode('Centerline model')
+centerlinePolyData = centerlineModel.GetPolyData()
+
+# Create curve node from centerline model
+# (markups curve with radius array output is not yet available in SlicerVMTK)
+centerlineCurve = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsCurveNode')
+centerlineCurve.SetName('CenterlineCurve')
+for i in range(centerlinePolyData.GetNumberOfPoints()):
+  centerlineCurve.AddControlPoint(vtk.vtkVector3d(centerlinePolyData.GetPoint(i)))
+
+# Add radius data to centerline curve as measurement
+radiusMeasurement = slicer.vtkMRMLMeasurementConstant()
+radiusMeasurement.SetName('Radius')
+radiusMeasurement.SetUnits('mm')
+radiusMeasurement.SetPrintFormat(None) # Prevent from showing up in SH Description
+radiusMeasurement.SetControlPointValues(centerlinePolyData.GetPointData().GetArray('Radius'))
+centerlineCurve.AddMeasurement(radiusMeasurement)
+centerlineCurve.SetInterpolateControlPointMeasurement(True)
+
+centerlineCurvePolyData = centerlineCurve.GetCurveWorld()
+centerlineCurvePointData = centerlineCurvePolyData.GetPointData()
+
+# Check interpolation computation result
+if centerlineCurvePointData.GetNumberOfArrays() != 2:
+  exceptionMessage = "Unexpected number of data arrays in curve: " + str(centerlineCurvePointData.GetNumberOfArrays())
+  raise Exception(exceptionMessage)
+
+if centerlineCurvePointData.GetArrayName(1) != 'Interpolated:Radius':
+  exceptionMessage = "Unexpected data array name in curve: " + str(centerlineCurvePointData.GetArrayName(1))
+  raise Exception(exceptionMessage)
+
+interpolatedRadiusArray = centerlineCurvePointData.GetArray(1)
+if interpolatedRadiusArray.GetNumberOfTuples() != 571:
+  exceptionMessage = "Unexpected number of data points in interpolated radius array: " + str(interpolatedRadiusArray.GetNumberOfTuples())
+  raise Exception(exceptionMessage)
+
+if abs(interpolatedRadiusArray.GetRange()[0] - 12.322814731747465) > 0.0001:
+  exceptionMessage = "Unexpected minimum in curvature data array: " + str(interpolatedRadiusArray.GetRange()[0])
+  raise Exception(exceptionMessage)
+if abs(interpolatedRadiusArray.GetRange()[1] - 42.9542138185081) > 0.0001:
+  exceptionMessage = "Unexpected maximum in curvature data array: " + str(interpolatedRadiusArray.GetRange()[1])
+  raise Exception(exceptionMessage)
+if abs(interpolatedRadiusArray.GetValue(9) - 42.92838813390291) > 0.0001:
+  exceptionMessage = "Unexpected maximum in curvature data array: " + str(interpolatedRadiusArray.GetValue(9))
+  raise Exception(exceptionMessage)
+if abs(interpolatedRadiusArray.GetValue(10) - 42.9542138185081) > 0.0001:
+  exceptionMessage = "Unexpected maximum in curvature data array: " + str(interpolatedRadiusArray.GetValue(10))
+  raise Exception(exceptionMessage)
+if abs(interpolatedRadiusArray.GetValue(569) - 12.904227531040913) > 0.0001:
+  exceptionMessage = "Unexpected maximum in curvature data array: " + str(interpolatedRadiusArray.GetValue(569))
+  raise Exception(exceptionMessage)
+if abs(interpolatedRadiusArray.GetValue(570) - 12.765926543271583) > 0.0001:
+  exceptionMessage = "Unexpected maximum in curvature data array: " + str(interpolatedRadiusArray.GetValue(570))
+  raise Exception(exceptionMessage)
+
+print('Control point measurement interpolation test finished successfully')

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
@@ -140,7 +140,7 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   // Display center position
   // It would be cleaner to use a dedicated actor for this instead of using the control points actors
   // as it would give flexibility in what glyph we use, it would not interfere with active control point display, etc.
-  if (this->ClosedLoop && markupsNode->GetNumberOfControlPoints() > 2 && this->CenterVisibilityOnSlice && !allNodesHidden)
+  if (this->CurveClosed && markupsNode->GetNumberOfControlPoints() > 2 && this->CenterVisibilityOnSlice && !allNodesHidden)
     {
     double centerPosWorld[3], centerPosDisplay[3], orient[3] = { 0 };
     markupsNode->GetCenterPosition(centerPosWorld);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
@@ -127,7 +127,7 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
       }
     }
 
-  if (this->ClosedLoop && markupsNode->GetNumberOfControlPoints() > 2 && !allNodesHidden)
+  if (this->CurveClosed && markupsNode->GetNumberOfControlPoints() > 2 && !allNodesHidden)
     {
     double centerPosWorld[3], orient[3] = { 0 };
     markupsNode->GetCenterPosition(centerPosWorld);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -133,7 +133,7 @@ vtkSlicerMarkupsWidgetRepresentation::vtkSlicerMarkupsWidgetRepresentation()
 
   this->ControlPointSize = 3.0;
   this->NeedToRender = false;
-  this->ClosedLoop = 0;
+  this->CurveClosed = 0;
 
   this->TextActor = vtkSmartPointer<vtkTextActor>::New();
   // hide by default, if a concrete class implements properties display, it will enable it
@@ -285,7 +285,7 @@ int vtkSlicerMarkupsWidgetRepresentation::FindClosestPointOnWidget(
       }
     else
       {
-      if (!this->ClosedLoop)
+      if (!this->CurveClosed)
         {
         continue;
         }
@@ -347,7 +347,7 @@ int vtkSlicerMarkupsWidgetRepresentation::FindClosestPointOnWidget(
       *idx = closestNode+1;
       return 1;
       }
-    else if (this->ClosedLoop)
+    else if (this->CurveClosed)
       {
       *idx = 0;
       return 1;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -310,7 +310,7 @@ protected:
 
   vtkSmartPointer<vtkTextActor> TextActor;
 
-  vtkTypeBool ClosedLoop;
+  vtkTypeBool CurveClosed;
 
   /// Convenience method.
   virtual bool GetAllControlPointsVisible();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -529,7 +529,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::CanInteract(
     return;
     }
 
-  if (markupsNode->GetNumberOfControlPoints() > 2 && this->ClosedLoop && this->CenterVisibilityOnSlice)
+  if (markupsNode->GetNumberOfControlPoints() > 2 && this->CurveClosed && this->CenterVisibilityOnSlice)
     {
     // Check if center is selected
     double centerPosWorld[3], centerPosDisplay[3];

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -355,7 +355,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
     return;
     }
 
-  if (markupsNode->GetNumberOfControlPoints() > 2 && this->ClosedLoop)
+  if (markupsNode->GetNumberOfControlPoints() > 2 && this->CurveClosed)
     {
     // Check if center is selected
     double centerPosWorld[3], centerPosDisplay[3];


### PR DESCRIPTION
- Since for closed curves the two ends meet, instead of setting the end curvature values to zero, we use the adjacent values
- Force measurements to implement Compute function (and thus using the new method for measurement calculation) by making it pure virtual
- Add test for closed curve curvature calculation