### PR TITLE
ENH: Make logs of previous sessions more easily accessible

### DIFF
--- a/Base/QTApp/Resources/UI/qSlicerErrorReportDialog.ui
+++ b/Base/QTApp/Resources/UI/qSlicerErrorReportDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>702</width>
-    <height>441</height>
+    <width>607</width>
+    <height>638</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,7 +26,8 @@
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="InstructionsLabel">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Questions and feature requests:&lt;/span&gt; visit the &lt;a href=&quot;https://discourse.slicer.org&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Slicer forum&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bug reports: &lt;/span&gt;&lt;a href=&quot;https://discourse.slicer.org/new-topic?body=Problem%20report%20for%20[appname-version-platform]:%20[please%20describe%20expected%20and%20actual%20behavior]&amp;amp;category=support&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;post a new topic to the Slicer forum&lt;/span&gt;&lt;/a&gt; to tell us about your problem or submit a bug report to the &lt;a href=&quot;https://issues.slicer.org&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;3D Slicer bugtracker&lt;/span&gt;&lt;/a&gt;. Describe the steps that lead to the error and also attach log messages.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Warning - if you work with patient data:&lt;/span&gt; Check that the log messages do not contain any information that may identify a patient. Send the log messages to specific people instead of sharing them publicly on a mailing list or website.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>     </property>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Questions and feature requests:&lt;/span&gt; visit the &lt;a href=&quot;https://discourse.slicer.org&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Slicer forum&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bug reports: &lt;/span&gt;&lt;a href=&quot;https://discourse.slicer.org/new-topic?body=Problem%20report%20for%20[appname-version-platform]:%20[please%20describe%20expected%20and%20actual%20behavior]&amp;amp;category=support&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;post a new topic to the Slicer forum&lt;/span&gt;&lt;/a&gt; to tell us about your problem or submit a bug report to the &lt;a href=&quot;https://issues.slicer.org&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;3D Slicer bugtracker&lt;/span&gt;&lt;/a&gt;. Describe the steps that lead to the error and also attach log messages.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Warning - if you work with patient data:&lt;/span&gt; Check that the log messages do not contain any information that may identify a patient. Send the log messages to specific people instead of sharing them publicly on a mailing list or website.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>
      </property>
@@ -45,10 +46,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="ctkComboBox" name="RecentLogFilesComboBox"/>
-   </item>
-   <item row="2" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QPlainTextEdit" name="LogText">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
@@ -67,7 +65,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="ctkPushButton" name="LogCopyToClipboardPushButton">
@@ -105,13 +103,23 @@
      </item>
     </layout>
    </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="ctkPathListWidget" name="RecentLogFilesComboBox"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="RecentLogFilesLabel_2">
+     <property name="text">
+      <string>Log file content:</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ctkComboBox</class>
-   <extends>QComboBox</extends>
-   <header>ctkComboBox.h</header>
+   <class>ctkPathListWidget</class>
+   <extends>QListView</extends>
+   <header>ctkPathListWidget.h</header>
   </customwidget>
   <customwidget>
    <class>ctkPushButton</class>
@@ -121,7 +129,7 @@
  </customwidgets>
  <resources>
   <include location="../SlicerApp.qrc"/>
-  <include location="../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc"/>
+  <include location="../../../QTGUI/Resources/qSlicerBaseQTGUI.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/Base/QTApp/qSlicerErrorReportDialog.cxx
+++ b/Base/QTApp/qSlicerErrorReportDialog.cxx
@@ -57,9 +57,15 @@ qSlicerErrorReportDialog::qSlicerErrorReportDialog(QWidget* parentWidget)
   d->InstructionsLabel->setText(instructionsText);
 
   QStringList logFilePaths = qSlicerApplication::application()->recentLogFiles();
-  d->RecentLogFilesComboBox->addItems(logFilePaths);
+  d->RecentLogFilesComboBox->addPaths(logFilePaths);
+  if (d->RecentLogFilesComboBox->count() > 0)
+    {
+    d->RecentLogFilesComboBox->setCurrentIndex(d->RecentLogFilesComboBox->model()->index(0, 0));
+    }
 
-  QObject::connect(d->RecentLogFilesComboBox, SIGNAL(currentIndexChanged(QString)), this, SLOT(onLogFileSelectionChanged()));
+
+  //QObject::connect(d->RecentLogFilesComboBox, SIGNAL(currentTextChanged(QString)), this, SLOT(onLogFileSelectionChanged()));
+  QObject::connect(d->RecentLogFilesComboBox, SIGNAL(currentPathChanged(QString,QString)), this, SLOT(onLogFileSelectionChanged()));
   QObject::connect(d->LogCopyToClipboardPushButton, SIGNAL(clicked()), this, SLOT(onLogCopy()));
   QObject::connect(d->LogFileOpenPushButton, SIGNAL(clicked()), this, SLOT(onLogFileOpen()));
   QObject::connect(d->LogFileEditCheckBox, SIGNAL(clicked(bool)), this, SLOT(onLogFileEditClicked(bool)));
@@ -84,7 +90,7 @@ void qSlicerErrorReportDialog::onLogCopy()
 void qSlicerErrorReportDialog::onLogFileSelectionChanged()
 {
   Q_D(qSlicerErrorReportDialog);
-  QFile f(d->RecentLogFilesComboBox->currentText());
+  QFile f(d->RecentLogFilesComboBox->currentPath());
   if (f.open(QFile::ReadOnly | QFile::Text))
     {
     QTextStream in(&f);
@@ -101,7 +107,7 @@ void qSlicerErrorReportDialog::onLogFileSelectionChanged()
 void qSlicerErrorReportDialog::onLogFileOpen()
 {
   Q_D(qSlicerErrorReportDialog);
-  QDesktopServices::openUrl(QUrl("file:///"+d->RecentLogFilesComboBox->currentText(), QUrl::TolerantMode));
+  QDesktopServices::openUrl(QUrl("file:///"+d->RecentLogFilesComboBox->currentPath(), QUrl::TolerantMode));
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
"Report a bug" dialog had a combobox for selecting logs from previous sessions but users had trouble finding it.
This commit replaces the single-line combobox with a list widget, which is easier to discover and it also easier to browse through the files.

![image](https://user-images.githubusercontent.com/307929/96806667-b8dd9c80-13e2-11eb-82c1-fbc419cf8e12.png)
