### PR TITLE
ENH: Update qSlicerWebWidget to allow export to PDF

### DIFF
--- a/Base/QTGUI/qSlicerWebWidget.cxx
+++ b/Base/QTGUI/qSlicerWebWidget.cxx
@@ -145,6 +145,9 @@ void qSlicerWebWidgetPrivate::init()
   QObject::connect(this->WebView, SIGNAL(loadProgress(int)),
                    this->ProgressBar, SLOT(setValue(int)));
 
+  QObject::connect(this->WebEnginePage, SIGNAL(pdfPrintingFinished(QString, bool)),
+                   q, SIGNAL(pdfPrintingFinished(QString, bool)));
+
   this->ProgressBar->setVisible(false);
 }
 
@@ -378,6 +381,13 @@ void qSlicerWebWidget::onDownloadFinished(QNetworkReply* reply)
   Q_UNUSED(reply);
   d->ProgressBar->reset();
   d->ProgressBar->setVisible(false);
+}
+
+// --------------------------------------------------------------------------
+void qSlicerWebWidget::printToPdf(const QString& filePath)
+{
+  Q_D(qSlicerWebWidget);
+  d->WebEnginePage->printToPdf(filePath);
 }
 
 // --------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerWebWidget.h
+++ b/Base/QTGUI/qSlicerWebWidget.h
@@ -103,6 +103,16 @@ public slots:
 
   void onDownloadFinished(QNetworkReply* reply);
 
+  /// Renders the current content of the page into a PDF document and saves it in the location specified in filePath.
+  ///
+  /// The page size and orientation of the produced PDF document are taken from the values specified in pageLayout.
+  /// This method issues an asynchronous request for printing the web page into a PDF and returns immediately.
+  /// To be informed about the result of the request, connect to the signal pdfPrintingFinished().
+  ///
+  /// If a file already exists at the provided file path, it will be overwritten.
+  /// \sa QWebEnginePage::printToPdf
+  void printToPdf(const QString& filePath);
+
 signals:
   /// emited with result of evalJS
   void evalResult(QString js, QString result);
@@ -111,6 +121,9 @@ signals:
   void loadStarted();
   void loadProgress(int progress);
   void loadFinished(bool ok);
+
+  /// signal passed through from QWebEnginePage
+  void pdfPrintingFinished(const QString &filePath, bool success);
 
 protected slots:
   virtual void initJavascript();


### PR DESCRIPTION
Since WebEngine objects are not exposed in PythonQt, this commit updates
the existing qSlicerWebWidget to support using existing PDF export
functionality built-in WebEngine widget.

For example:

```
  url = "file:///home/jcfr/Downloads/index.html"
  outputPath = "/tmp/test.pdf"

  webWidget = slicer.qSlicerWebWidget()

  def loadFinished(ok):
    if not ok:
      print("failed to load URL %s" % url)
      return
    webWidget.printToPdf(outputPath);

  def pdfPrintingFinished(filePath, success):
    print("export completed [%s]: %s" % (success, filePath))

  webWidget.connect("loadFinished(bool)", loadFinished)
  webWidget.connect("pdfPrintingFinished(QString,bool)", pdfPrintingFinished)
  webWidget.setUrl(url)
```