### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -42,17 +42,17 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   pydicom==2.0.0 --hash=sha256:667c5bf9ca52f440e538c9d03ce86b04555c10d069472a5db53103fe40d310c0
   # Hashes correspond to the following packages:
-  #  - Pillow-7.2.0-cp36-cp36m-win_amd64.whl
-  #  - Pillow-7.2.0-cp36-cp36m-macosx_10_10_x86_64.whl
-  #  - Pillow-7.2.0-cp36-cp36m-manylinux1_x86_64.whl
-  #  - Pillow-7.2.0-cp36-cp36m-manylinux2014_aarch64.whl
-  pillow==7.2.0 --hash=sha256:ffe538682dc19cc542ae7c3e504fdf54ca7f86fb8a135e59dd6bc8627eae6cce \
-                --hash=sha256:ec29604081f10f16a7aea809ad42e27764188fc258b02259a03a8ff7ded3808d \
-                --hash=sha256:0a80dd307a5d8440b0a08bd7b81617e04d870e40a3e46a32d9c246e54705e86f \
-                --hash=sha256:06aba4169e78c439d528fdeb34762c3b61a70813527a2c57f0540541e9f433a8
+  #  - Pillow-8.0.1-cp36-cp36m-win_amd64.whl
+  #  - Pillow-8.0.1-cp36-cp36m-macosx_10_10_x86_64.whl
+  #  - Pillow-8.0.1-cp36-cp36m-manylinux1_x86_64.whl
+  #  - Pillow-8.0.1-cp36-cp36m-manylinux2014_aarch64.whl
+  pillow==8.0.1 --hash=sha256:7ba0ba61252ab23052e642abdb17fd08fdcfdbbf3b74c969a30c58ac1ade7cd3 \
+                --hash=sha256:b63d4ff734263ae4ce6593798bcfee6dbfb00523c82753a3a03cbc05555a9cc3 \
+                --hash=sha256:6b4a8fd632b4ebee28282a9fef4c341835a1aa8671e2770b6f89adc8e8c2703c \
+                --hash=sha256:cc3ea6b23954da84dbee8025c616040d9aa5eaf34ea6895a0a762ee9d3e12e11
   six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
   retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b
-  dicomweb-client==0.41.0 --hash=sha256:e79163362d2af9399d4661216d6bcc3de9af755a1eec36995d35e3e135f22fa0
+  dicomweb-client==0.50.2 --hash=sha256:e839b925a89e213c9e1f3b5b9046071c50b291e3d54f975e422ee39edd06c3f8
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -37,7 +37,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
   gitdb==4.0.5 --hash=sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac
   smmap==3.0.4 --hash=sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4
-  GitPython==3.1.7 --hash=sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5
+  GitPython==3.1.11 --hash=sha256:6eea89b655917b500437e9668e4a12eabdcf00229a0df1762aabd692ef9b746b
   six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -35,7 +35,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   PyJWT==1.7.1 --hash=sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e
   wrapt==1.12.1 --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
   Deprecated==1.2.10 --hash=sha256:a766c1dccb30c5f6eb2b203f87edd1d8588847709c78589e1521d769addc8218
-  PyGithub==1.51 --hash=sha256:8375a058ec651cc0774244a3bc7395cf93617298735934cdd59e5bcd9a1df96e
+  PyGithub==1.53 --hash=sha256:8ad656bf79958e775ec59f7f5a3dbcbadac12147ae3dc42708b951064096af15
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -31,16 +31,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   nose==1.3.7 --hash=sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac  # needed for NumPy unit tests
   # Hashes correspond to the following packages:
-  # - numpy-1.19.1-cp36-cp36m-win_amd64.whl
-  # - numpy-1.19.1-cp36-cp36m-macosx_10_9_x86_64.whl
-  # - numpy-1.19.1-cp36-cp36m-manylinux1_x86_64.whl
-  # - numpy-1.19.1-cp36-cp36m-manylinux2010_x86_64.whl
-  # - numpy-1.19.1-cp36-cp36m-manylinux2014_aarch64.whl
-  numpy==1.19.1 --hash=sha256:082f8d4dd69b6b688f64f509b91d482362124986d98dc7dc5f5e9f9b9c3bb983 \
-                --hash=sha256:b1cca51512299841bf69add3b75361779962f9cee7d9ee3bb446d5982e925b69 \
-                --hash=sha256:cf1347450c0b7644ea142712619533553f02ef23f92f781312f6a3553d031fc7 \
-                --hash=sha256:3673c8b2b29077f1b7b3a848794f8e11f401ba0b71c49fbd26fb40b71788b132 \
-                --hash=sha256:56ef7f56470c24bb67fb43dae442e946a6ce172f97c69f8d067ff8550cf782ff
+  # - numpy-1.19.2-cp36-cp36m-win_amd64.whl
+  # - numpy-1.19.2-cp36-cp36m-macosx_10_9_x86_64.whl
+  # - numpy-1.19.2-cp36-cp36m-manylinux1_x86_64.whl
+  # - numpy-1.19.2-cp36-cp36m-manylinux2010_x86_64.whl
+  # - numpy-1.19.2-cp36-cp36m-manylinux2014_aarch64.whl
+  numpy==1.19.2 --hash=sha256:967c92435f0b3ba37a4257c48b8715b76741410467e2bdb1097e8391fccfae15 \
+                --hash=sha256:b594f76771bc7fc8a044c5ba303427ee67c17a09b36e1fa32bde82f5c419d17a \
+                --hash=sha256:3733640466733441295b0d6d3dcbf8e1ffa7e897d4d82903169529fd3386919a \
+                --hash=sha256:7c6646314291d8f5ea900a7ea9c4261f834b5b62159ba2abe3836f4fa6705526 \
+                --hash=sha256:7118f0a9f2f617f921ec7d278d981244ba83c85eea197be7c5a4f84af80a9c3c
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -26,7 +26,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  pip==20.1.1 --hash=sha256:b27c4dedae8c41aa59108f2fa38bf78e0890e590545bc8ece7cdceb4ba60f6e4
+  pip==20.2.4 --hash=sha256:51f1c7514530bd5c145d8f13ed936ad6b8bfcb8cf74e10403d0890bc986f0033
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -29,7 +29,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   certifi==2020.6.20 --hash=sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41
   idna==2.10 --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
   chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
-  urllib3==1.25.10 --hash=sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461
+  urllib3==1.25.11 --hash=sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e
   requests==2.24.0 --hash=sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898
   ]===])
 

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -30,12 +30,14 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # Hashes correspond to the following packages:
-  # - scipy-1.5.2-cp36-cp36m-win_amd64.whl
-  # - scipy-1.5.2-cp36-cp36m-macosx_10_9_x86_64.whl
-  # - scipy-1.5.2-cp36-cp36m-manylinux1_x86_64.whl
-  scipy==1.5.2 --hash=sha256:8e28e74b97fc8d6aa0454989db3b5d36fc27e69cef39a7ee5eaf8174ca1123cb \
-              --hash=sha256:cca9fce15109a36a0a9f9cfc64f870f1c140cb235ddf27fe0328e6afb44dfed0 \
-              --hash=sha256:07e52b316b40a4f001667d1ad4eb5f2318738de34597bd91537851365b6c61f1
+  # - scipy-1.5.3-cp36-cp36m-win_amd64.whl
+  # - scipy-1.5.3-cp36-cp36m-macosx_10_9_x86_64.whl
+  # - scipy-1.5.3-cp36-cp36m-manylinux1_x86_64.whl
+  # - scipy-1.5.3-cp36-cp36m-manylinux2014_aarch64.whl
+  scipy==1.5.3 --hash=sha256:ffcbd331f1ffa82e22f1d408e93c37463c9a83088243158635baec61983aaacf \
+               --hash=sha256:f574558f1b774864516f3c3fe072ebc90a29186f49b720f60ed339294b7f32ac \
+               --hash=sha256:b9751b39c52a3fa59312bd2e1f40144ee26b51404db5d2f0d5259c511ff6f614 \
+               --hash=sha256:d5e3cc60868f396b78fc881d2c76460febccfe90f6d2f082b9952265c79a8788
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -25,7 +25,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  setuptools==49.2.0 --hash=sha256:272c7f48f5cddc5af5901f4265274c421c7eede5c8bc454ac2903d3f8fc365e9
+  setuptools==50.3.2 --hash=sha256:2c242a0856fbad7efbe560df4a7add9324f340cf48df43651e9604924466794a
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -26,7 +26,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  wheel==0.34.2 --hash=sha256:df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e
+  wheel==0.35.1 --hash=sha256:497add53525d16c173c2c1c733b8f655510e909ea78cc0e29d374243544b77a2
   ]===])
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
Python packages were last updated July 27th, 2020. Outdated python packages were discovered using the below code snippet and then versions, hashes and dependencies were determined and updated.

@adamrankin The last time python packages were updated Scipy did not have an aarch64 wheel as mentioned in https://github.com/Slicer/Slicer/pull/5064#issuecomment-666611759.  However, the latest Scipy which will now be used does have a wheel for aarch64.

In this PR I'm only updating python packages downloaded from pypi. This means not updating SimpleITK and VTK python packages.
```
PS C:\S5R-nightly\python-install\bin> ./PythonSlicer.exe -m pip list --outdated
Package         Version Latest  Type
--------------- ------- ------- -----
dicomweb-client 0.41.0  0.50.2  wheel
GitPython       3.1.7   3.1.11  wheel
numpy           1.19.1  1.19.2  wheel
Pillow          7.2.0   8.0.1   wheel
pip             20.1.1  20.2.4  wheel
PyGithub        1.51    1.53    wheel
scipy           1.5.2   1.5.3   wheel
setuptools      49.2.0  50.3.2  wheel
simpleitk       2.0.0   2.0.1   wheel
urllib3         1.25.10 1.25.11 wheel
vtk             8.2.0   9.0.1   wheel
wheel           0.34.2  0.35.1  wheel
```