### PR TITLE
COMP: Fix bundling of extension ensuring Slicer_BUILD_SHARED is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ mark_as_superbuild(Slicer_REQUIRED_QT_VERSION)
 # option(BUILD_SHARED_LIBS "Build Slicer with shared libraries." ON)
 set(BUILD_SHARED_LIBS ON)
 mark_as_superbuild(BUILD_SHARED_LIBS:BOOL)
+set(Slicer_BUILD_SHARED ${BUILD_SHARED_LIBS})
 
 #-----------------------------------------------------------------------------
 # Slicer application options


### PR DESCRIPTION
This commit fixes the bundling of extension like SlicerVirtualReality
having external projects setting BUILD_SHARED_LIBS based on the value
of Slicer_BUILD_SHARED.