### PR TITLE
BUG: Update CTK to workaround slicer rendering issue when built against VTK9

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "03bf84789d8c1f5ba7aeb8f6139d07e12ab94fd1"
+    "2f164d767f8d944d2565f9a08ace91f779e6f142"
     QUIET
     )
 


### PR DESCRIPTION
Waiting issue Slicer/Slicer#5220 is resolved, accept that other actors
like corner annotations and crosshairs are occluded and ensure image
data is displayed.

List of changes:

```
$ git shortlog 03bf84789..2f164d767 --no-merges
Jean-Christophe Fillion-Robin (2):
      COMP: Fix build of CTKVisualizationVTK tests against VTK9
      BUG: Workaround slice viewer rendering issue when built against VTK9

Tobias Krähling (3):
      STYLE: Update CTKVisualizationVTK test requirements to be more specific
      BUG: Fix CTKVisualizationVTKWidgets tests updating QSurfaceFormat initialization
      ENH: Re-factor code centralizing setting of default surface format
```