### PR TITLE
BUG: Update CTK

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "03bf84789d8c1f5ba7aeb8f6139d07e12ab94fd1"
+    "44cb1276ba0bff212f631516c7558ee5c63febf0"
     QUIET
     )
 


### PR DESCRIPTION
List of changes:

```
$ git shortlog 03bf8478..44cb1276 --no-merges
Jean-Christophe Fillion-Robin (3):
      COMP: Fix build of CTKVisualizationVTK tests against VTK9
      [...]

Tobias Krähling (3):
      STYLE: Update CTKVisualizationVTK test requirements to be more specific
      BUG: Fix CTKVisualizationVTKWidgets tests updating QSurfaceFormat initialization
      ENH: Re-factor code centralizing setting of default surface format
```