### PR TITLE
ENH: Segment Editor: Add warning (overridable) when user hits "Apply" on not-visible segment #5259

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorIslandsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorIslandsEffect.py
@@ -109,14 +109,17 @@ class SegmentEditorIslandsEffect(AbstractScriptedSegmentEditorEffect):
     return operationName in [KEEP_SELECTED_ISLAND, REMOVE_SELECTED_ISLAND, ADD_SELECTED_ISLAND]
 
   def onApply(self):
-    operationName = self.scriptedEffect.parameter("Operation")
-    minimumSize = self.scriptedEffect.integerParameter("MinimumSize")
-    if operationName == KEEP_LARGEST_ISLAND:
-      self.splitSegments(minimumSize = minimumSize, maxNumberOfSegments = 1)
-    elif operationName == REMOVE_SMALL_ISLANDS:
-      self.splitSegments(minimumSize = minimumSize, split = False)
-    elif operationName == SPLIT_ISLANDS_TO_SEGMENTS:
-      self.splitSegments(minimumSize = minimumSize)
+    # Visibility check - Make sure the user wants to do the operation, even if the
+    # segment is not visible.
+    if self.scriptedEffect.confirmCurrentSegmentVisible():
+      operationName = self.scriptedEffect.parameter("Operation")
+      minimumSize = self.scriptedEffect.integerParameter("MinimumSize")
+      if operationName == KEEP_LARGEST_ISLAND:
+        self.splitSegments(minimumSize = minimumSize, maxNumberOfSegments = 1)
+      elif operationName == REMOVE_SMALL_ISLANDS:
+        self.splitSegments(minimumSize = minimumSize, split = False)
+      elif operationName == SPLIT_ISLANDS_TO_SEGMENTS:
+        self.splitSegments(minimumSize = minimumSize)
 
   def splitSegments(self, minimumSize = 0, maxNumberOfSegments = 0, split = True):
     """

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.h
@@ -324,6 +324,8 @@ public:
   /// Returns true if the common parameter is already defined.
   Q_INVOKABLE bool commonParameterDefined(QString name);
 
+  Q_INVOKABLE bool confirmCurrentSegmentVisible();
+
   Q_INVOKABLE vtkOrientedImageData* modifierLabelmap();
 
   /// Reset modifier labelmap to default (resets geometry, clears content)


### PR DESCRIPTION
Added qSlicerSegmentEditorAbstractEffect::confirmCurrentSegmentVisible() method to check for segment visibility on Segment Editor operations with "Yes", "No", or "Cancel". Dialog is only shown if "Apply" is clicked when a segment is invisible. On "Yes", the operation is performed and the segment is made visible, on "No", the operation is performed and the segment remains invisible, and on "Cancel", the operation is NOT performed and the segment remains invisible.

This is currently only implemented for Islands operations but is generally useable by any Segment Editor affect with an Apply button.

This dialog is currently always shown, but a "Don't ask again" could be added.
