### PR TITLE
DOC: Experimental moving of developer manual into a documentation subsection

### DIFF
--- a/Docs/developer_guide/index.rst
+++ b/Docs/developer_guide/index.rst
@@ -1,0 +1,17 @@
+.. _developer_guide_index:
+
+###############
+Developer Guide
+###############
+
+.. toctree::
+   :maxdepth: 2
+
+   build_instructions/index.rst
+   api
+   mrml_overview
+   modules/index.rst
+   extensions
+   python_faq
+   contributing
+   authors

--- a/Docs/developer_guide/modules/index.rst
+++ b/Docs/developer_guide/modules/index.rst
@@ -7,6 +7,7 @@ Modules API
 Modules usually interact with each other only indirectly, by making changes and observing changes in the MRML scene. However, modules can also directly use functions offered by other modules, by calling its logic functions. Examples and notes for using specific modules are provided below.
 
 .. toctree::
+    :maxdepth: 2
 
     markups.md
     segmenteditor.md

--- a/Docs/index.rst
+++ b/Docs/index.rst
@@ -16,10 +16,6 @@ For Slicer-4.10 documentation, refer to the `3D Slicer wiki <https://www.slicer.
    user_guide/about
    user_guide/getting_started
 
-.. toctree::
-   :maxdepth: 3
-   :caption: User Guide:
-
    user_guide/user_interface
    user_guide/data_loading_and_saving
    user_guide/image_segmentation
@@ -28,18 +24,7 @@ For Slicer-4.10 documentation, refer to the `3D Slicer wiki <https://www.slicer.
    user_guide/supported_data_formats
    user_guide/settings
 
-.. toctree::
-   :maxdepth: 3
-   :caption: Developer Guide:
-
-   developer_guide/build_instructions/index.rst
-   developer_guide/api
-   developer_guide/mrml_overview
-   developer_guide/modules/index.rst
-   developer_guide/extensions
-   developer_guide/python_faq
-   developer_guide/contributing
-   developer_guide/authors
+   developer_guide/index
 
 Indices and tables
 ==================


### PR DESCRIPTION
Pull request created to generate preview documentation to facilitate discussion - see https://discourse.slicer.org/t/user-guide-and-developer-guide-cannot-be-clicked-and-linked-as-distinct-url/14042/3