### PR TITLE
DOC: Experimental splitting of user and developer manual

### DIFF
--- a/Docs/developer_guide/index.rst
+++ b/Docs/developer_guide/index.rst
@@ -1,0 +1,17 @@
+.. _developer_guide_index:
+
+###############
+Developer Guide
+###############
+
+.. toctree::
+   :maxdepth: 2
+
+   build_instructions/index.rst
+   api
+   mrml_overview
+   modules/index.rst
+   extensions
+   python_faq
+   contributing
+   authors

--- a/Docs/developer_guide/modules/index.rst
+++ b/Docs/developer_guide/modules/index.rst
@@ -7,6 +7,7 @@ Modules API
 Modules usually interact with each other only indirectly, by making changes and observing changes in the MRML scene. However, modules can also directly use functions offered by other modules, by calling its logic functions. Examples and notes for using specific modules are provided below.
 
 .. toctree::
+    :maxdepth: 2
 
     markups.md
     segmenteditor.md

--- a/Docs/index.rst
+++ b/Docs/index.rst
@@ -13,33 +13,8 @@ For Slicer-4.10 documentation, refer to the `3D Slicer wiki <https://www.slicer.
 .. toctree::
    :maxdepth: 2
 
-   user_guide/about
-   user_guide/getting_started
-
-.. toctree::
-   :maxdepth: 3
-   :caption: User Guide:
-
-   user_guide/user_interface
-   user_guide/data_loading_and_saving
-   user_guide/image_segmentation
-   user_guide/modules/index.rst
-   user_guide/extensions_manager
-   user_guide/supported_data_formats
-   user_guide/settings
-
-.. toctree::
-   :maxdepth: 3
-   :caption: Developer Guide:
-
-   developer_guide/build_instructions/index.rst
-   developer_guide/api
-   developer_guide/mrml_overview
-   developer_guide/modules/index.rst
-   developer_guide/extensions
-   developer_guide/python_faq
-   developer_guide/contributing
-   developer_guide/authors
+   user_guide/index
+   developer_guide/index
 
 Indices and tables
 ==================

--- a/Docs/user_guide/index.rst
+++ b/Docs/user_guide/index.rst
@@ -1,0 +1,19 @@
+.. _user_guide_index:
+
+##########
+User Guide
+##########
+
+.. toctree::
+   :maxdepth: 2
+
+   about
+   getting_started
+
+   user_interface
+   data_loading_and_saving
+   image_segmentation
+   modules/index.rst
+   extensions_manager
+   supported_data_formats
+   settings


### PR DESCRIPTION
Pull request created to generate preview documentation to facilitate discussion - see https://discourse.slicer.org/t/user-guide-and-developer-guide-cannot-be-clicked-and-linked-as-distinct-url/14042/3