### PR TITLE
BUG: use exec not execfile for scripted MRMLDM

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLScriptedDisplayableManager.cxx
@@ -297,7 +297,7 @@ void vtkMRMLScriptedDisplayableManager::SetPythonSource(const std::string& pytho
     PyObject * pyRes = nullptr;
     if (pythonSource.find(".py") != std::string::npos)
       {
-      std::string pyRunStr = std::string("execfile('") + pythonSource + std::string("')");
+      std::string pyRunStr = std::string("exec(open('") + pythonSource + std::string("').read())");
       pyRes = PyRun_String(pyRunStr.c_str(),
                            Py_file_input, global_dict, global_dict);
       }


### PR DESCRIPTION
vtkMRMLScriptedDisplayableManager::SetPythonSource evaluates
a python code string to load a the source file.

The code used execfile, which worked in python2 but does not
exist in python3.

This changes the code to use exec, open, and read in order
to emulate the execfile behavior.