### PR TITLE
CRASH: fix observer manager events and priorities

### DIFF
--- a/Libs/MRML/Core/vtkObserverManager.cxx
+++ b/Libs/MRML/Core/vtkObserverManager.cxx
@@ -224,11 +224,16 @@ void vtkObserverManager::ObserveObject(vtkObject* node, float priority)
 //----------------------------------------------------------------------------
 void vtkObserverManager::AddObjectEvents(vtkObject *nodePtr, vtkIntArray *events, vtkFloatArray *priorities)
 {
+  if ( (priorities && !events) )
+    {
+    vtkWarningMacro(<< "Need events if given priorities");
+    return;
+    }
   // check whether no priorities are provided or the same number of
   // events and priorities are provided
-  if ( !((events && priorities && events->GetNumberOfTuples() == priorities->GetNumberOfTuples()) || (events && !priorities)))
+  if ( (events && priorities) && (events->GetNumberOfTuples() != priorities->GetNumberOfTuples()) )
     {
-    vtkWarningMacro(<< "Number of events (" << events->GetNumberOfTuples()
+    vtkWarningMacro(<< "Given events and priorities, but the number of events (" << events->GetNumberOfTuples()
                     << ") doesn't match number of priorities ("
                     << priorities->GetNumberOfTuples());
     return;


### PR DESCRIPTION
The method gives the option of providing a list of priorities
with one priority per event in two lists.

The check logic was incorrect however, because in the case
where no priorities had been provided (null list pointer) the
'if' condition was triggered and the warning macro would
indirect through the null priorities pointer.

Now the two checks have been separated and each has a custom
warning message so that pointers are only used when they are
known to be non-null.