### PR TITLE
ENH: Add markups curvature mean and max measurements

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkCurveMeasurementsCalculator.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkCurveMeasurementsCalculator.cxx
@@ -296,6 +296,25 @@ bool vtkCurveMeasurementsCalculator::CalculatePolyDataCurvature(vtkPolyData* pol
   length += currentLength;
   meanKappa = meanKappa / length;
 
+  // Set mean and max curvature to measurements
+  // Calculate and set interpolated control point measurements in poly data
+  for (int index=0; index<this->Measurements->GetNumberOfItems(); ++index)
+    {
+    vtkMRMLMeasurement* currentMeasurement = vtkMRMLMeasurement::SafeDownCast(this->Measurements->GetItemAsObject(index));
+    if (!currentMeasurement || !currentMeasurement->GetEnabled())
+      {
+      continue;
+      }
+    if (currentMeasurement->GetName() && !strcmp(currentMeasurement->GetName(), this->GetMeanCurvatureName()))
+      {
+      currentMeasurement->SetValue(meanKappa);
+      }
+    else if (currentMeasurement->GetName() && !strcmp(currentMeasurement->GetName(), this->GetMaxCurvatureName()))
+      {
+      currentMeasurement->SetValue(maxKappa);
+      }
+    }
+
   // Set curvature array to output
   polyData->GetPointData()->AddArray(curvatureValues);
 
@@ -334,9 +353,7 @@ bool vtkCurveMeasurementsCalculator::InterpolateControlPointMeasurementToPolyDat
   // Calculate and set interpolated control point measurements in poly data
   for (int index=0; index<this->Measurements->GetNumberOfItems(); ++index)
     {
-    vtkMRMLMeasurement* currentMeasurement = vtkMRMLMeasurement::SafeDownCast(
-      this->Measurements->GetItemAsObject(index) );
-
+    vtkMRMLMeasurement* currentMeasurement = vtkMRMLMeasurement::SafeDownCast(this->Measurements->GetItemAsObject(index));
     if (!currentMeasurement || !currentMeasurement->GetEnabled())
       {
       continue;

--- a/Modules/Loadable/Markups/MRML/vtkCurveMeasurementsCalculator.h
+++ b/Modules/Loadable/Markups/MRML/vtkCurveMeasurementsCalculator.h
@@ -68,6 +68,11 @@ public:
   vtkBooleanMacro(InterpolateControlPointMeasurement, bool);
   //@}
 
+  /// Get name of mean curvature measurement
+  static const char* GetMeanCurvatureName() { return "curvature mean"; };
+  /// Get name of max curvature measurement
+  static const char* GetMaxCurvatureName() { return "curvature max"; };
+
 protected:
   bool CalculatePolyDataCurvature(vtkPolyData* polyData);
   bool InterpolateControlPointMeasurementToPolyData(vtkPolyData* outputPolyData);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.cxx
@@ -250,9 +250,8 @@ void vtkMRMLMarkupsAngleNode::UpdateMeasurementsInternal()
     // Calculate enabled measurements
     for (int index=0; index<this->Measurements->GetNumberOfItems(); ++index)
       {
-      vtkMRMLMeasurement* currentMeasurement = vtkMRMLMeasurement::SafeDownCast(
-        this->Measurements->GetItemAsObject(index) );
-      if (currentMeasurement && currentMeasurement->GetEnabled())
+      vtkMRMLMeasurement* currentMeasurement = vtkMRMLMeasurement::SafeDownCast(this->Measurements->GetItemAsObject(index));
+      if (currentMeasurement && currentMeasurement->GetEnabled() && !currentMeasurement->IsA("vtkMRMLMeasurementConstant"))
         {
         currentMeasurement->ClearValue();
         currentMeasurement->Compute();

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.cxx
@@ -89,9 +89,8 @@ void vtkMRMLMarkupsLineNode::UpdateMeasurementsInternal()
     // Calculate enabled measurements
     for (int index=0; index<this->Measurements->GetNumberOfItems(); ++index)
       {
-      vtkMRMLMeasurement* currentMeasurement = vtkMRMLMeasurement::SafeDownCast(
-        this->Measurements->GetItemAsObject(index) );
-      if (currentMeasurement && currentMeasurement->GetEnabled())
+      vtkMRMLMeasurement* currentMeasurement = vtkMRMLMeasurement::SafeDownCast(this->Measurements->GetItemAsObject(index));
+      if (currentMeasurement && currentMeasurement->GetEnabled() && !currentMeasurement->IsA("vtkMRMLMeasurementConstant"))
         {
         currentMeasurement->ClearValue();
         currentMeasurement->Compute();

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
@@ -174,3 +174,34 @@ if abs(interpolatedRadiusArray.GetValue(570) - 12.765926543271583) > 0.0001:
   raise Exception(exceptionMessage)
 
 print('Control point measurement interpolation test finished successfully')
+
+#
+# Test curvature computation for a circle-shaped closed curve
+#
+
+radius = 35
+numberOfControlPoints = 40
+import math
+closedCurveNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsClosedCurveNode")
+for controlPointIndex in range(numberOfControlPoints):
+    angle = 2.0*math.pi * controlPointIndex/numberOfControlPoints
+    closedCurveNode.AddControlPoint(vtk.vtkVector3d(radius * math.sin(angle), radius * math.cos(angle), 0.0))
+
+# Turn on curvature calculation in curve node
+closedCurveNode.SetCalculateCurvature(True)
+
+curvePolyData = closedCurveNode.GetCurveWorld()
+curvatureArray = curvePolyData.GetPointData().GetArray('Curvature')
+
+if curvatureArray.GetNumberOfValues() < 10:
+  exceptionMessage = "Many values are expected in the curvature array, instead found just %d" % curvatureArray.GetNumberOfValues()
+  raise Exception(exceptionMessage)
+
+if abs(curvatureArray.GetRange()[0] - 1/radius) > 1e-4:
+  exceptionMessage = "Unexpected minimum in curvature data array: " + str(curvatureArray.GetRange()[0])
+  raise Exception(exceptionMessage)
+if abs(curvatureArray.GetRange()[1] - 1/radius) > 1e-4:
+  exceptionMessage = "Unexpected maximum in curvature data array: " + str(curvatureArray.GetRange()[1])
+  raise Exception(exceptionMessage)
+
+print('Radius of curvature computation is verified successfully')


### PR DESCRIPTION
* Curvature mean and max measurements are added to curve markup. These two are disabled by default and get enabled when the user enables curvature calculation for the markup itself.
* They are constant measurements (because these values are calculated in vtkCurveMeasurementsCalculator and it would not make much sense recalculating them in each measurement) and set by vtkCurveMeasurementsCalculator.
* They show up in the description as "curvature mean" and "curvature max"
* Their unit is "kappa" given that this was the only option I could find. We can remove the unit name if this seems incorrect.