### PR TITLE
BUG: Update VTK to fix Slicer view rendering with VTK9. Fixes #5220

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -177,7 +177,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "a889f4730498b796b6999ae6effd522334bdc577") # slicer-v9.0.20201013-bc2f5892b3
+    set(_git_tag "548df0286b7afadb7b85485b83b2af17e08e7d1e") # slicer-v9.0.20201013-bc2f5892b3
     set(vtk_egg_info_version "9.0.20201013")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of changes:

```
$ git shortlog a889f47304..548df0286b --no-merges
Sankhesh Jhaveri (1):
      [backport MR-7407] Shift the Z value of the 2D vertices when in the background
```

Co-authored-by: Sankhesh Jhaveri <sankhesh.jhaveri@kitware.com>
Co-authored-by: Ken Martin <ken.martin@kitware.com>
Co-authored-by: Andras Lasso <lasso@queensu.ca>