### PR TITLE
BUG: Fix markup selection with VTK9 updating tolerance

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -89,7 +89,10 @@ vtkSlicerMarkupsWidgetRepresentation3D::ControlPointsPipeline3D::ControlPointsPi
 
   this->SelectVisiblePoints = vtkSmartPointer<vtkSelectVisiblePoints>::New();
   this->SelectVisiblePoints->SetInputData(this->LabelControlPointsPolyData);
-  this->SelectVisiblePoints->SetTolerance(0.0); // we will set tolerance in world coordinate system
+  // Set tiny tolerance to account for updated the z-buffer computation and coincident topology
+  // resolution strategy integrated in VTK9. World tolerance based on control point size is set
+  // later.
+  this->SelectVisiblePoints->SetTolerance(1e-4);
   this->SelectVisiblePoints->SetOutput(vtkNew<vtkPolyData>());
 
   // The SelectVisiblePoints filter should not be added to any pipeline with SetInputConnection.
@@ -902,7 +905,7 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderOpaqueGeometry(
       if (updateControlPointSize)
         {
         controlPoints->Glypher->SetScaleFactor(this->ControlPointSize);
-        controlPoints->SelectVisiblePoints->SetToleranceWorld(this->ControlPointSize * 0.5);
+        controlPoints->SelectVisiblePoints->SetToleranceWorld(this->ControlPointSize * 0.7);
         }
       count += controlPoints->Actor->RenderOpaqueGeometry(viewport);
       }
@@ -1205,7 +1208,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateControlPointSize()
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
     {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[controlPointType]);
-    controlPoints->SelectVisiblePoints->SetToleranceWorld(this->ControlPointSize*0.5);
+    controlPoints->SelectVisiblePoints->SetToleranceWorld(this->ControlPointSize * 0.7);
     }
 }
 


### PR DESCRIPTION
(Edited by @jcfr)

Following the revamp of the z-buffer computation and coincident topology
resolution integrated in VTK9 (See [1][2]), the z-buffer values are
now different. This commit accounts for this change by increasing the
world tolerance associated with small spheroid objects (such as glyphs)
and by setting a tiny tolerance for normalized display coordinates.
These tolerances are used to configure vtkSelectVisiblePoints filter
used to determine visibility of markups used to enable/disable
selectability.

[1] update and improve the coincident rendering code
    https://github.com/Kitware/VTK/commit/3052137e6621684f9184b293b82c677e976c2f89

[2] Add support for camera based shift scale methods
https://github.com/Kitware/VTK/commit/8f3aef771a25b81d89ae591ef26aca5162c8c6b2

Fixes #5250

Co-authored-by: Andras Lasso <lasso@queensu.ca>