### PR TITLE
Update VTK to integrate improved fix for #5220

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -177,7 +177,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "fbfecacef8e46ce312d6840a9471e4cc1d1a797e") # slicer-v9.0.20201111-733234c785
+    set(_git_tag "9e9746fa49fdffc8b347a4999aec882bf0b1eaf6") # slicer-v9.0.20201111-733234c785
     set(vtk_egg_info_version "9.0.20201013")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
BUG: Update VTK to integrate improved fix for #5220

List of changes:

```
$ git shortlog fbfecacef8..9e9746fa49 --no-merges
Jean-Christophe Fillion-Robin (1):
      Revert "[backport MR-7407] Shift the Z value of the 2D vertices when in the background"

Sankhesh Jhaveri (3):
      [Backport MR-7413] Ensure depth function is GL_LEQUAL in Qt widgets
      [Backport MR-7413] Initialize the opengl state with proper depth function in QVTK widgets
      [Backport MR-7407] Fix the 2D mapper foreground/background transform to ignore Z values
```