### PR TITLE
COMP: Fix "command line too long error" using ninja generator on windows

### DIFF
--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -102,13 +102,13 @@ class JRC2013VisWidget(ScriptedLoadableModuleWidget):
       import subprocess
       dcmqrscpExeOptions = (
         '/bin',
-        '/../CTK-build/CMakeExternals/Install/bin',
+        '/../CTK-b/CMakeExternals/Install/bin',
         '/../DCMTK-install/bin',
-        '/../DCMTK-build/bin',
-        '/../DCMTK-build/bin/Release'
-        '/../DCMTK-build/bin/Debug'
-        '/../DCMTK-build/bin/RelWithDebInfo'
-        '/../DCMTK-build/bin/MinSizeRel'
+        '/../DCMTK-b/bin',
+        '/../DCMTK-b/bin/Release'
+        '/../DCMTK-b/bin/Debug'
+        '/../DCMTK-b/bin/RelWithDebInfo'
+        '/../DCMTK-b/bin/MinSizeRel'
         )
 
       dcmqrscpExePath = None
@@ -198,13 +198,13 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
 
       dcmqrscpExeOptions = (
         '/bin',
-        '/../CTK-build/CMakeExternals/Install/bin',
+        '/../CTK-b/CMakeExternals/Install/bin',
         '/../DCMTK-install/bin',
-        '/../DCMTK-build/bin',
-        '/../DCMTK-build/bin/Release',
-        '/../DCMTK-build/bin/Debug',
-        '/../DCMTK-build/bin/RelWithDebInfo'
-        '/../DCMTK-build/bin/MinSizeRel'
+        '/../DCMTK-b/bin',
+        '/../DCMTK-b/bin/Release',
+        '/../DCMTK-b/bin/Debug',
+        '/../DCMTK-b/bin/RelWithDebInfo'
+        '/../DCMTK-b/bin/MinSizeRel'
         )
 
       dcmqrscpExePath = None

--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -103,7 +103,7 @@ class JRC2013VisWidget(ScriptedLoadableModuleWidget):
       dcmqrscpExeOptions = (
         '/bin',
         '/../CTK-b/CMakeExternals/Install/bin',
-        '/../DCMTK-install/bin',
+        '/../DCMTK-i/bin',
         '/../DCMTK-b/bin',
         '/../DCMTK-b/bin/Release'
         '/../DCMTK-b/bin/Debug'
@@ -199,7 +199,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
       dcmqrscpExeOptions = (
         '/bin',
         '/../CTK-b/CMakeExternals/Install/bin',
-        '/../DCMTK-install/bin',
+        '/../DCMTK-i/bin',
         '/../DCMTK-b/bin',
         '/../DCMTK-b/bin/Release',
         '/../DCMTK-b/bin/Debug',

--- a/CMake/SlicerBlockInstallPython.cmake
+++ b/CMake/SlicerBlockInstallPython.cmake
@@ -10,7 +10,7 @@ if(Slicer_USE_PYTHONQT)
     endif()
   endforeach()
 
-  set(PYTHON_DIR "${Slicer_SUPERBUILD_DIR}/python-install")
+  set(PYTHON_DIR "${Slicer_SUPERBUILD_DIR}/python-i")
   if(NOT EXISTS "${PYTHON_DIR}/${PYTHON_STDLIB_SUBDIR}")
     message(WARNING "###############################################################################
 Skipping generation of python install rules

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -788,7 +788,7 @@ class DICOMWidget(ScriptedLoadableModuleWidget):
         self.exeDir = slicer.app.slicerHome
         if slicer.app.intDir:
           self.exeDir = self.exeDir + '/' + slicer.app.intDir
-        self.exeDir = self.exeDir + '/../CTK-build/DCMTK-build'
+        self.exeDir = self.exeDir + '/../CTK-b/DCMTK-build'
 
         # TODO: deal with Debug/RelWithDebInfo on windows
 

--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -29,12 +29,12 @@ class DICOMProcess(object):
     self.process = None
     self.connections = {}
     pathOptions = (
-        '/../DCMTK-build/bin/Debug',
-        '/../DCMTK-build/bin/Release',
-        '/../DCMTK-build/bin/RelWithDebInfo',
-        '/../DCMTK-build/bin/MinSizeRel',
-        '/../DCMTK-build/bin',
-        '/../CTK-build/CMakeExternals/Install/bin',
+        '/../DCMTK-b/bin/Debug',
+        '/../DCMTK-b/bin/Release',
+        '/../DCMTK-b/bin/RelWithDebInfo',
+        '/../DCMTK-b/bin/MinSizeRel',
+        '/../DCMTK-b/bin',
+        '/../CTK-b/CMakeExternals/Install/bin',
         '/bin'
         )
 

--- a/SuperBuild/External_CTKAppLauncherLib.cmake
+++ b/SuperBuild/External_CTKAppLauncherLib.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED CTKAppLauncherLib_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -63,7 +63,7 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -98,7 +98,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
   endif()
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
     -DITK_LEGACY_REMOVE:BOOL=OFF   #<-- Allow LEGACY ITKv4 features for now.

--- a/SuperBuild/External_JsonCpp.cmake
+++ b/SuperBuild/External_JsonCpp.cmake
@@ -30,7 +30,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_LZMA.cmake
+++ b/SuperBuild/External_LZMA.cmake
@@ -41,7 +41,7 @@ if((NOT DEFINED ${proj}_INCLUDE_DIR
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-i)
   set(EP_INSTALL_LIBDIR "lib")
 
   set(${proj}_CMAKE_C_FLAGS ${ep_common_c_flags})

--- a/SuperBuild/External_LZMA.cmake
+++ b/SuperBuild/External_LZMA.cmake
@@ -40,7 +40,7 @@ if((NOT DEFINED ${proj}_INCLUDE_DIR
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
   set(EP_INSTALL_LIBDIR "lib")
 

--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -49,7 +49,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -50,7 +50,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-i)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}
@@ -94,7 +94,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
 
   ExternalProject_GenerateProjectDescription_Step(${proj})
 
-  set(LibArchive_DIR ${CMAKE_BINARY_DIR}/LibArchive-install)
+  set(LibArchive_DIR ${EP_INSTALL_DIR})
 
   set(LibArchive_INCLUDE_DIR ${LibArchive_DIR}/include)
   if(WIN32)

--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -300,7 +300,7 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
     endif()
 
     #------------------------------------------------------------------------------
-    set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+    set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj}-i)
 
     ExternalProject_Add(${proj}
       ${${proj}_EP_ARGS}

--- a/SuperBuild/External_PCRE.cmake
+++ b/SuperBuild/External_PCRE.cmake
@@ -23,7 +23,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/PCRE)
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/PCRE-b)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/PCRE-install)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/PCRE-i)
 
   include(ExternalProjectForNonCMakeProject)
 

--- a/SuperBuild/External_PCRE.cmake
+++ b/SuperBuild/External_PCRE.cmake
@@ -22,7 +22,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   #
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/PCRE)
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/PCRE-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/PCRE-b)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/PCRE-install)
 
   include(ExternalProjectForNonCMakeProject)

--- a/SuperBuild/External_ParameterSerializer.cmake
+++ b/SuperBuild/External_ParameterSerializer.cmake
@@ -30,7 +30,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 

--- a/SuperBuild/External_RapidJSON.cmake
+++ b/SuperBuild/External_RapidJSON.cmake
@@ -32,7 +32,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -21,7 +21,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   include(ExternalProjectForNonCMakeProject)
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
 
   # Variables used to update PATH, LD_LIBRARY_PATH or DYLD_LIBRARY_PATH in env. script below

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -22,7 +22,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-i)
 
   # Variables used to update PATH, LD_LIBRARY_PATH or DYLD_LIBRARY_PATH in env. script below
   if(WIN32)

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -90,7 +90,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -57,7 +57,7 @@ if(NOT SWIG_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
     set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/Swig)
     set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/Swig-b)
-    set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/Swig-install)
+    set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/Swig-i)
 
     include(ExternalProjectForNonCMakeProject)
 

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -56,7 +56,7 @@ if(NOT SWIG_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     mark_as_advanced(BISON_FLAGS)
 
     set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/Swig)
-    set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/Swig-build)
+    set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/Swig-b)
     set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/Swig-install)
 
     include(ExternalProjectForNonCMakeProject)

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -190,7 +190,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_bzip2.cmake
+++ b/SuperBuild/External_bzip2.cmake
@@ -40,7 +40,7 @@ if((NOT DEFINED BZIP2_INCLUDE_DIR
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-i)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_bzip2.cmake
+++ b/SuperBuild/External_bzip2.cmake
@@ -39,7 +39,7 @@ if((NOT DEFINED BZIP2_INCLUDE_DIR
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_curl.cmake
+++ b/SuperBuild/External_curl.cmake
@@ -63,7 +63,7 @@ if((NOT DEFINED CURL_INCLUDE_DIR
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
 
   # If it applies, prepend "CMAKE_ARGS"

--- a/SuperBuild/External_curl.cmake
+++ b/SuperBuild/External_curl.cmake
@@ -64,7 +64,7 @@ if((NOT DEFINED CURL_INCLUDE_DIR
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-i)
 
   # If it applies, prepend "CMAKE_ARGS"
   if(NOT EXTERNAL_PROJECT_OPTIONAL_CMAKE_ARGS STREQUAL "")

--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -119,7 +119,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
 
   # If it applies, prepend "CMAKE_ARGS"

--- a/SuperBuild/External_qRestAPI.cmake
+++ b/SuperBuild/External_qRestAPI.cmake
@@ -38,7 +38,7 @@ if(NOT DEFINED qRestAPI_DIR)
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_sqlite.cmake
+++ b/SuperBuild/External_sqlite.cmake
@@ -34,7 +34,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-i)
   set(EP_INSTALL_LIBDIR "lib")
 
   set(${proj}_CMAKE_C_FLAGS ${ep_common_c_flags})

--- a/SuperBuild/External_sqlite.cmake
+++ b/SuperBuild/External_sqlite.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
   set(EP_INSTALL_LIBDIR "lib")
 

--- a/SuperBuild/External_tbb.cmake
+++ b/SuperBuild/External_tbb.cmake
@@ -18,7 +18,7 @@ else ()
 endif ()
 
 #------------------------------------------------------------------------------
-set(TBB_INSTALL_DIR "${CMAKE_BINARY_DIR}/${proj}-install")
+set(TBB_INSTALL_DIR "${CMAKE_BINARY_DIR}/${proj}-i")
 ExternalProject_Message(${proj} "TBB_INSTALL_DIR:${TBB_INSTALL_DIR}")
 
 ExternalProject_Add(${proj}

--- a/SuperBuild/External_teem.cmake
+++ b/SuperBuild/External_teem.cmake
@@ -51,7 +51,7 @@ if(NOT DEFINED Teem_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     )
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
 
   ExternalProject_Add(${proj}
     ${${proj}_EP_ARGS}

--- a/SuperBuild/External_zlib.cmake
+++ b/SuperBuild/External_zlib.cmake
@@ -23,7 +23,7 @@ if(NOT DEFINED zlib_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
-  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-i)
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY

--- a/SuperBuild/External_zlib.cmake
+++ b/SuperBuild/External_zlib.cmake
@@ -22,7 +22,7 @@ endif()
 if(NOT DEFINED zlib_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
-  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-b)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
 
   ExternalProject_SetIfNotDefined(

--- a/Utilities/Scripts/CMakeLists.txt
+++ b/Utilities/Scripts/CMakeLists.txt
@@ -7,7 +7,7 @@ if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT AND Slicer_USE_PYTHONQT)
     set(PYTHON python)
   else()
     find_program(PYTHON python
-      PATHS ${Slicer_SUPERBUILD_DIR}/python-install/bin
+      PATHS ${Slicer_SUPERBUILD_DIR}/python-i/bin
       NO_DEFAULT_PATH
       )
   endif()


### PR DESCRIPTION
This commit is an attempt to avoid error reported when using Ninja generator
on Windows.

Co-authored-by: Stephen Aylward <Stephen.Aylward@kitware.com>

See also https://discourse.slicer.org/t/build-failure-using-visual-studio-2015/7351