### PR TITLE
BUG: Do not skip adding hidden and excluded nodes to subject hierarchy

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -222,11 +222,10 @@ void qSlicerSubjectHierarchyPluginLogic::onNodeAdded(vtkObject* sceneObject, vtk
 
     // Add subject hierarchy node for the added data node
     // Don't add to subject hierarchy automatically one-by-one if importing scene, because the SH nodes may be stored in the scene and loaded
-    // Also abort if invalid or hidden node or if explicitly excluded from subject hierarchy before even adding to the scene
-    if ( scene->IsImporting()
-      || !node
-      || node->GetHideFromEditors()
-      || node->GetAttribute(vtkMRMLSubjectHierarchyConstants::GetSubjectHierarchyExcludeFromTreeAttributeName().c_str()) )
+    // Also abort if invalid or hidden node. The HideFromEditors flag is not considered to work dynamically, meaning that
+    // we don't expect changes on the UI when we set it after adding it to the scene, so not adding it to SH should not cause issues.
+    // The GetSubjectHierarchyExcludeFromTreeAttributeName attribute on the other hand is dynamic, so we add the node to SH despite that.
+    if (scene->IsImporting() || !node || node->GetHideFromEditors())
       {
       return;
       }
@@ -562,9 +561,10 @@ void qSlicerSubjectHierarchyPluginLogic::addSupportedDataNodesToSubjectHierarchy
   for (std::vector<vtkMRMLNode*>::iterator nodeIt = supportedNodes.begin(); nodeIt != supportedNodes.end(); ++nodeIt)
     {
     vtkMRMLNode* node = (*nodeIt);
-    // Do not add into subject hierarchy if hidden or excluded
-    if ( node->GetHideFromEditors()
-      || node->GetAttribute(vtkMRMLSubjectHierarchyConstants::GetSubjectHierarchyExcludeFromTreeAttributeName().c_str()))
+    // Do not add into subject hierarchy if hidden. The HideFromEditors flag is not considered to work dynamically, meaning that
+    // we don't expect changes on the UI when we set it after adding it to the scene, so not adding it to SH should not cause issues.
+    // The GetSubjectHierarchyExcludeFromTreeAttributeName attribute on the other hand is dynamic, so we add the node to SH despite that.
+    if (node->GetHideFromEditors())
       {
       continue;
       }


### PR DESCRIPTION
The purpose of hidden and excluded nodes is not to show them in the UI. Since subject hierarchy is supposed to have an item to every supported node in the scene, and the hidden/excluded attributes can change, it does not make sense to not add them to subject hierarchy when adding the node or loading a scene containing the node.