### PR TITLE
Minor updates to ITK and SimpleITK version

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v5.1.1"
+    "v5.1.2"
     QUIET
     )
 

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -105,7 +105,6 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
     -DITK_LEGACY_SILENT:BOOL=ON    #<-- Silence for initial ITKv5 migration.
     -DModule_ITKDeprecated:BOOL=ON #<-- Needed for ITKv5 now. (itkMultiThreader.h and MutexLock backwards compatibility.)
     -DModule_SimpleITKFilters:BOOL=${Slicer_USE_SimpleITK}
-    -DModule_SimpleITKFilters_GIT_TAG:STRING=ce51d77771a54e7e0791fadb15e50dc38cbd8358
     )
 
 

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -122,7 +122,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v2.0.0"  # Paired with a specific SimpleITKFilters remote module git tag in the ITK project
+    "v2.0.1"
     QUIET
     )
 


### PR DESCRIPTION
Based on desire to update ITK to 5.1.2 in Slicer sooner rather than later (see https://discourse.itk.org/t/patches-for-itk-5-1-2/3635/11), this PR bumps the ITK version to that and SimpleITK also gets a minor update. With SimpleITK v2.0.1 it doesn't need to specify `Module_SimpleITKFilters_GIT_TAG`. This is because https://github.com/SimpleITK/SimpleITK/commit/b71184d1282deff2550026e87e8ce430022e04ea specified that a later ITK version no longer needed the custom SimpleITKFilters remote git tag.  ITK 5.1.2 is even later and meets the criteria to not need the custom SimpleITKFilters remote git tag.

Marking as draft first as I haven't tested the build yet.