### PR TITLE
ENH: Allow showing nodes by drag-and-dropping into views from subject hierarchy tree

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.cxx
@@ -3654,3 +3654,13 @@ vtkMRMLSubjectHierarchyNode* vtkMRMLSubjectHierarchyNode::GetSubjectHierarchyNod
 
   return scene->GetSubjectHierarchyNode();
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLSubjectHierarchyNode::ShowItemsInView(vtkIdList* itemIDs, vtkMRMLAbstractViewNode* viewNode)
+{
+  SubjectHierarchyItemsShowInViewRequestedEventData eventData;
+  eventData.itemIDsToShow = itemIDs;
+  eventData.viewNode = viewNode;
+  this->InvokeEvent(SubjectHierarchyItemsShowInViewRequestedEvent, &eventData);
+  // The event will be processed by qSlicerSubjectHierarchyPluginHandler
+}

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyNode.h
@@ -33,8 +33,10 @@
 #include <vtkMRMLSubjectHierarchyConstants.h>
 
 class vtkCallbackCommand;
+class vtkIdList;
 class vtkMRMLDisplayNode;
 class vtkMRMLTransformNode;
+class vtkMRMLAbstractViewNode;
 
 /// \ingroup Slicer_MRML_Core
 /// \brief MRML node to represent a complete subject hierarchy tree
@@ -82,8 +84,22 @@ public:
     /// Event invoked when item resolving starts (e.g. after scene import)
     SubjectHierarchyStartResolveEvent,
     /// Event invoked when item resolving finished (e.g. after scene import)
-    SubjectHierarchyEndResolveEvent
+    SubjectHierarchyEndResolveEvent,
+    /// Event invoked when showing of subject hierarchy items in a specific view is requested
+    /// (processed by the widget classes, by delegating to the owner subject hierarchy plugin).
+    /// For internal use only.
+    /// Use vtkMRMLSubjectHierarchyNode::ShowItemsInView or qSlicerSubjectHierarchyPluginHandler::showItemsInView
+    /// method to request view of subject hierarchy items in a view.
+    SubjectHierarchyItemsShowInViewRequestedEvent,
   };
+
+  /// Event data used with SubjectHierarchyItemsShowInViewRequestedEvent.
+  /// For internal use only.
+  struct SubjectHierarchyItemsShowInViewRequestedEventData
+    {
+    vtkIdList* itemIDsToShow = nullptr;
+    vtkMRMLAbstractViewNode* viewNode = nullptr;
+    };
 
 public:
   static vtkMRMLSubjectHierarchyNode *New();
@@ -389,6 +405,9 @@ public:
 
   /// Ensure the consistency and validity of the SH node in the scene
   static vtkMRMLSubjectHierarchyNode* ResolveSubjectHierarchy(vtkMRMLScene* scene);
+
+  /// Show items in selected view (used for drag&drop of subject hierarchy items into the viewer)
+  void ShowItemsInView(vtkIdList* itemIDs, vtkMRMLAbstractViewNode* viewNode);
 
 protected:
   /// Callback function for all events from the subject hierarchy items

--- a/Libs/MRML/Widgets/qMRMLSliceView.h
+++ b/Libs/MRML/Widgets/qMRMLSliceView.h
@@ -27,6 +27,7 @@
 // MRML includes
 #include "qMRMLWidgetsExport.h"
 
+class QDropEvent;
 class qMRMLSliceViewPrivate;
 class vtkCollection;
 class vtkMRMLAbstractDisplayableManager;
@@ -97,6 +98,9 @@ public:
   Q_INVOKABLE void unsetViewCursor();
   /// Set default cursor in the view area
   Q_INVOKABLE void setDefaultViewCursor(const QCursor &cursor);
+
+  void dragEnterEvent(QDragEnterEvent* event) override;
+  void dropEvent(QDropEvent* event) override;
 
 public slots:
 

--- a/Libs/MRML/Widgets/qMRMLThreeDView.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.h
@@ -27,6 +27,7 @@
 
 #include "qMRMLWidgetsExport.h"
 
+class QDropEvent;
 class qMRMLThreeDViewPrivate;
 class vtkMRMLAbstractDisplayableManager;
 class vtkMRMLCameraNode;
@@ -92,6 +93,9 @@ public:
 
   /// Set default cursor in the view area
   Q_INVOKABLE void setDefaultViewCursor(const QCursor &cursor);
+
+  void dragEnterEvent(QDragEnterEvent* event) override;
+  void dropEvent(QDropEvent* event) override;
 
 public slots:
 

--- a/Libs/MRML/Widgets/qMRMLUtils.cxx
+++ b/Libs/MRML/Widgets/qMRMLUtils.cxx
@@ -19,8 +19,11 @@
 ==============================================================================*/
 
 // Qt includes
-#include <QStyle>
+#include <QMimeData>
 #include <QPainter>
+#include <QStyle>
+#include <QUrl>
+#include <QUrlQuery>
 
 // CTK includes
 #include "ctkVTKWidgetsUtils.h"
@@ -180,5 +183,28 @@ void qMRMLUtils::qColorToColor(const QColor &qcolor, double* color)
     color[0] = qcolor.redF();
     color[1] = qcolor.greenF();
     color[2] = qcolor.blueF();
+    }
+}
+
+//------------------------------------------------------------------------------
+void qMRMLUtils::mimeDataToSubjectHierarchyItemIDs(const QMimeData* mimeData, vtkIdList* idList)
+{
+  if (!mimeData->hasFormat("text/uri-list") || !idList)
+    {
+    return;
+    }
+  idList->Reset();
+  foreach(QUrl url, mimeData->urls())
+    {
+    if (!url.isValid() || url.isEmpty())
+      {
+      continue;
+      }
+    if (url.scheme() != "mrml" || url.host() != "scene" || url.path() != "/subjecthierarchy/item")
+      {
+      continue;
+      }
+    QUrlQuery query(url.query());
+    idList->InsertNextId(query.queryItemValue("id").toLong());
     }
 }

--- a/Libs/MRML/Widgets/qMRMLUtils.h
+++ b/Libs/MRML/Widgets/qMRMLUtils.h
@@ -27,8 +27,10 @@
 #include <QIcon>
 #include <QPixmap>
 
+#include "vtkIdList.h"
 #include "qMRMLWidgetsExport.h"
 
+class QMimeData;
 class QStyle;
 class vtkMRMLNode;
 class vtkMRMLTransformNode;
@@ -74,6 +76,8 @@ public:
 
   /// Convert QColor to C++ RGB array
   Q_INVOKABLE static void qColorToColor(const QColor &qcolor, double* color);
+
+  Q_INVOKABLE static void mimeDataToSubjectHierarchyItemIDs(const QMimeData* mimeData, vtkIdList* idList);
 
 private:
   Q_DISABLE_COPY(qMRMLUtils);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
@@ -39,6 +39,7 @@ class QStandardItem;
 class QAction;
 class QColor;
 class qSlicerAbstractModuleWidget;
+class vtkMRMLAbstractViewNode;
 
 /// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
 ///    In Widgets, not Plugins because the paths and libs need to be exported to extensions
@@ -202,6 +203,12 @@ public:
   /// Reparent an item that was already in the subject hierarchy under a new parent.
   /// \return True if reparented successfully, false otherwise
   virtual bool reparentItemInsideSubjectHierarchy(vtkIdType itemID, vtkIdType parentItemID);
+
+  /// Show an item in a selected view.
+  /// List of all other item IDs that will be shown in this request is also provided, as it may help
+  /// in determining the optimal view setup. For example, if multiple volume nodes will be shown
+  /// then the first node may be displayed as background and the second as foreground.
+  virtual bool showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow);
 
 // Utility functions
 public:

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
@@ -408,6 +408,7 @@ void qSlicerSubjectHierarchyPluginHandler::observeSubjectHierarchyNode(vtkMRMLSu
 
     shNode->AddObserver(vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemAddedEvent, m_CallBack);
     shNode->AddObserver(vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemOwnerPluginSearchRequested, m_CallBack);
+    shNode->AddObserver(vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemsShowInViewRequestedEvent, m_CallBack);
   }
 }
 
@@ -660,6 +661,36 @@ void qSlicerSubjectHierarchyPluginHandler::onSubjectHierarchyNodeEvent(
         {
         qCritical() << Q_FUNC_INFO << ": No subject hierarchy node could be retrieved from the scene";
         }
+      }
+    }
+  // Handle scene events
+  else if (event == vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemsShowInViewRequestedEvent)
+  {
+    if (!callData)
+      {
+      qCritical() << Q_FUNC_INFO << ": SubjectHierarchyItemsShowInViewEvent processing failed, invalid event data";
+      return;
+      }
+    vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemsShowInViewRequestedEventData* showNodesEventData
+      = reinterpret_cast<vtkMRMLSubjectHierarchyNode::SubjectHierarchyItemsShowInViewRequestedEventData*>(callData);
+    pluginHandler->showItemsInView(showNodesEventData->itemIDsToShow, showNodesEventData->viewNode);
+  }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyPluginHandler::showItemsInView(vtkIdList* itemIDsToShow, vtkMRMLAbstractViewNode* viewNode)
+{
+  if (!itemIDsToShow)
+    {
+    return;
+    }
+  for (int index = 0; index < itemIDsToShow->GetNumberOfIds(); ++index)
+    {
+    vtkIdType itemID = itemIDsToShow->GetId(index);
+    qSlicerSubjectHierarchyAbstractPlugin* ownerPlugin = this->getOwnerPluginForSubjectHierarchyItem(itemID);
+    if (ownerPlugin)
+      {
+      ownerPlugin->showItemInView(itemID, viewNode, itemIDsToShow);
       }
     }
 }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
@@ -197,6 +197,9 @@ public:
   /// \param shNode the subject hierarchy node to observe
   void observeSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode* shNode);
 
+  /// Show a list of items in a selected view (used for drag&drop of items into a view node)
+  void showItemsInView(vtkIdList* itemIDsToShow, vtkMRMLAbstractViewNode* viewNode);
+
 protected:
   /// Handle subject hierarchy node events
   static void onSubjectHierarchyNodeEvent(vtkObject* caller, unsigned long event, void* clientData, void* callData);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyVisibilityPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyVisibilityPlugin.h
@@ -55,6 +55,8 @@ protected slots:
   void toggleCurrentItemVisibility2D(bool on);
   /// Toggle 3D visibility on currently selected subject hierarchy item
   void toggleCurrentItemVisibility3D(bool on);
+  /// Makes the node visible in all views (otherwise it is just visible in selected views)
+  void showInAllViews();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyVisibilityPluginPrivate> d_ptr;

--- a/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/CMakeLists.txt
@@ -9,6 +9,7 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${vtkSlicerVolumeRenderingModuleLogic_INCLUDE_DIRS}
   ${qSlicerSubjectHierarchyModuleWidgets_INCLUDE_DIRS}
   ${vtkSlicerSubjectHierarchyModuleLogic_INCLUDE_DIRS}
+  ${qSlicerVolumesSubjectHierarchyPlugins_INCLUDE_DIRS}
   ${qMRMLWidgets_INCLUDE_DIRS}
   ${MRMLLogic_INCLUDE_DIRS}
   ${MRMLCore_INCLUDE_DIRS}
@@ -33,6 +34,7 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleMRML
   vtkSlicer${MODULE_NAME}ModuleLogic
   qSlicerSubjectHierarchyModuleWidgets
+  qSlicerVolumesSubjectHierarchyPlugins
   vtkSlicerSubjectHierarchyModuleLogic
   qMRMLWidgets
   MRMLLogic

--- a/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.cxx
+++ b/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.cxx
@@ -23,6 +23,7 @@
 // SubjectHierarchy Plugins includes
 #include "qSlicerSubjectHierarchyPluginHandler.h"
 #include "qSlicerSubjectHierarchyVolumeRenderingPlugin.h"
+#include "qSlicerSubjectHierarchyVolumesPlugin.h"
 
 // Slicer includes
 #include "qSlicerAbstractModuleWidget.h"
@@ -36,6 +37,7 @@
 #include <vtkMRMLCameraNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLScalarVolumeNode.h>
+#include <vtkMRMLViewLogic.h>
 #include <vtkMRMLViewNode.h>
 #include <vtkMRMLVolumeRenderingDisplayNode.h>
 #include <vtkMRMLVolumePropertyNode.h>
@@ -184,88 +186,160 @@ void qSlicerSubjectHierarchyVolumeRenderingPlugin::showVisibilityContextMenuActi
 void qSlicerSubjectHierarchyVolumeRenderingPlugin::toggleVolumeRenderingForCurrentItem(bool on)
 {
   Q_D(qSlicerSubjectHierarchyVolumeRenderingPlugin);
-
-  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
-  if (!shNode)
-    {
-    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
-    return;
-    }
   vtkIdType currentItemID = qSlicerSubjectHierarchyPluginHandler::instance()->currentItem();
   if (currentItemID == vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
     {
     qCritical() << Q_FUNC_INFO << ": Invalid current item";
     return;
     }
-  vtkMRMLScalarVolumeNode* volumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(shNode->GetItemDataNode(currentItemID));
+  this->showVolumeRendering(on, currentItemID, nullptr);
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyVolumeRenderingPlugin::resetFieldOfView(vtkMRMLDisplayNode* displayNode, vtkMRMLViewNode* viewNode/*=nullptr*/)
+{
+  Q_D(qSlicerSubjectHierarchyVolumeRenderingPlugin);
+  vtkMRMLDisplayableNode* volumeNode = displayNode->GetDisplayableNode();
+  double rasBounds[6] = { 0.0 };
+  volumeNode->GetRASBounds(rasBounds);
+  double cameraFocalPoint[3] =
+    {
+    (rasBounds[0] + rasBounds[1]) / 2.0,
+    (rasBounds[2] + rasBounds[3]) / 2.0,
+    (rasBounds[4] + rasBounds[5]) / 2.0,
+    };
+
+  // Get list of view nodes that will have their FOV reset
+  QList<vtkMRMLViewNode*> viewNodes;
+  if (viewNode)
+    {
+    // Specific view is provided - reset FOV in that single view
+    viewNodes << viewNode;
+    }
+  else
+    {
+    // FOV reset in all views is requested - do it in all views where the volume is visible in
+    qMRMLLayoutManager* layoutManager = qSlicerApplication::application()->layoutManager();
+    if (layoutManager)
+      {
+      qCritical() << Q_FUNC_INFO << " failed: invalid layout manager";
+      return;
+      }
+    for (int i = 0; i < layoutManager->threeDViewCount(); i++)
+      {
+      qMRMLThreeDWidget* threeDWidget = layoutManager->threeDWidget(i);
+      if (!threeDWidget)
+        {
+        continue;
+        }
+      vtkMRMLViewNode* currentViewNode = threeDWidget->mrmlViewNode();
+      if (!currentViewNode)
+        {
+        continue;
+        }
+      if (!displayNode->IsDisplayableInView(currentViewNode->GetID()))
+        {
+        continue;
+        }
+      viewNodes << currentViewNode;
+      }
+    }
+
+  vtkSlicerApplicationLogic* appLogic = qSlicerApplication::application()->applicationLogic();
+  if (!appLogic)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: cannot get application logic";
+    return;
+    }
+  foreach(vtkMRMLViewNode* currentViewNode, viewNodes)
+    {
+    // Show the volume in slice view
+    vtkMRMLViewLogic* viewLogic = appLogic->GetViewLogic(currentViewNode);
+    if (!viewLogic)
+      {
+      qCritical() << Q_FUNC_INFO << " failed: cannot get slice logic";
+      continue;
+      }
+    vtkMRMLCameraNode* cameraNode = viewLogic->GetCameraNode();
+    if (!cameraNode)
+      {
+      continue;
+      }
+    cameraNode->SetFocalPoint(cameraFocalPoint);
+    cameraNode->ResetClippingRange();
+    }
+}
+
+
+//---------------------------------------------------------------------------
+bool qSlicerSubjectHierarchyVolumeRenderingPlugin::showVolumeRendering(bool show, vtkIdType itemID, vtkMRMLViewNode* viewNode/*=nullptr*/)
+{
+  Q_D(qSlicerSubjectHierarchyVolumeRenderingPlugin);
+
+  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
+  if (!shNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
+    return false;
+    }
+  vtkMRMLScalarVolumeNode* volumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(shNode->GetItemDataNode(itemID));
   if (!volumeNode)
     {
-    qCritical() << Q_FUNC_INFO << ": Failed to find scalar volume node associated to subject hierarchy item " << currentItemID;
-    return;
+    qCritical() << Q_FUNC_INFO << ": Failed to find scalar volume node associated to subject hierarchy item " << itemID;
+    return false;
     }
   if (!d->VolumeRenderingLogic)
     {
     qWarning() << Q_FUNC_INFO << ": volume rendering logic is not set, cannot set up toggle volume rendering action";
-    return;
+    return false;
     }
-
-  vtkMRMLVolumeRenderingDisplayNode* displayNode = d->VolumeRenderingLogic->CreateDefaultVolumeRenderingNodes(volumeNode);
+  bool wasVisible = false;
+  vtkMRMLVolumeRenderingDisplayNode* displayNode = d->VolumeRenderingLogic->GetFirstVolumeRenderingDisplayNode(volumeNode);
+  if (displayNode)
+    {
+    wasVisible = displayNode->GetVisibility();
+    }
+  else
+    {
+    displayNode = d->VolumeRenderingLogic->CreateDefaultVolumeRenderingNodes(volumeNode);
+    }
   if (!displayNode)
     {
     qCritical() << Q_FUNC_INFO << ": Failed to create volume rendering display node for scalar volume node " << volumeNode->GetName();
-    return;
+    return false;
     }
 
-  if (on)
+  if (show)
     {
     QSettings settings;
     bool resetFieldOfView = settings.value("SubjectHierarchy/ResetFieldOfViewOnShowVolume", true).toBool();
     if (resetFieldOfView)
       {
-      double rasBounds[6] = { 0.0 };
-      volumeNode->GetRASBounds(rasBounds);
-      double cameraFocalPoint[3] =
-        {
-        (rasBounds[0] + rasBounds[1]) / 2.0,
-        (rasBounds[2] + rasBounds[3]) / 2.0,
-        (rasBounds[4] + rasBounds[5]) / 2.0,
-        };
-      qMRMLLayoutManager* layoutManager = qSlicerApplication::application()->layoutManager();
-      if (layoutManager)
-        {
-        for (int i = 0; i < layoutManager->threeDViewCount(); i++)
-          {
-          qMRMLThreeDWidget* threeDWidget = layoutManager->threeDWidget(i);
-          if (!threeDWidget)
-            {
-            continue;
-            }
-          vtkMRMLViewNode* viewNode = threeDWidget->mrmlViewNode();
-          if (!viewNode)
-            {
-            continue;
-            }
-          if (!displayNode->IsDisplayableInView(viewNode->GetID()))
-            {
-            continue;
-            }
-          qMRMLThreeDView* threeDView = threeDWidget->threeDView();
-          if (!threeDView)
-            {
-            continue;
-            }
-          vtkMRMLCameraNode* cameraNode = threeDView->cameraNode();
-          if (!cameraNode)
-            {
-            continue;
-            }
-          cameraNode->SetFocalPoint(cameraFocalPoint);
-          cameraNode->ResetClippingRange();
-          }
-        }
+      this->resetFieldOfView(displayNode, viewNode);
       }
     }
-  displayNode->SetVisibility(on);
+
+  if (viewNode)
+    {
+    // Show in specific view
+    MRMLNodeModifyBlocker blocker(displayNode);
+    if (!wasVisible)
+      {
+      displayNode->SetVisibility(true);
+      // This was hidden in all views, show it only in the currently selected view
+      displayNode->RemoveAllViewNodeIDs();
+      }
+    displayNode->AddViewNodeID(viewNode->GetID());
+    }
+  else
+    {
+    // Show in all views
+    MRMLNodeModifyBlocker blocker(displayNode);
+    displayNode->RemoveAllViewNodeIDs();
+    displayNode->SetVisibility(true);
+    }
+
+  return true;
 }
 
 //---------------------------------------------------------------------------
@@ -296,5 +370,27 @@ void qSlicerSubjectHierarchyVolumeRenderingPlugin::showVolumeRenderingOptionsFor
       {
       nodeSelector->setCurrentNode(shNode->GetItemDataNode(currentItemID));
       }
+    }
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerSubjectHierarchyVolumeRenderingPlugin::showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow)
+{
+  vtkMRMLViewNode* threeDViewNode = vtkMRMLViewNode::SafeDownCast(viewNode);
+  if (threeDViewNode)
+    {
+    return this->showVolumeRendering(true, itemID, threeDViewNode);
+    }
+  else
+    {
+    // Use volume's module implementation for displaying volume in slice views
+    qSlicerSubjectHierarchyVolumesPlugin* volumesPlugin = qobject_cast<qSlicerSubjectHierarchyVolumesPlugin*>(
+      qSlicerSubjectHierarchyPluginHandler::instance()->pluginByName("Volumes"));
+    if (!volumesPlugin)
+      {
+      qCritical() << Q_FUNC_INFO << ": Failed to access Volumes subject hierarchy plugin";
+      return false;
+      }
+    return volumesPlugin->showItemInView(itemID, viewNode, allItemsToShow);
     }
 }

--- a/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.h
+++ b/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.h
@@ -29,6 +29,8 @@
 #include "qSlicerVolumeRenderingSubjectHierarchyPluginsExport.h"
 
 class qSlicerSubjectHierarchyVolumeRenderingPluginPrivate;
+class vtkMRMLViewNode;
+class vtkMRMLDisplayNode;
 class vtkSlicerVolumeRenderingLogic;
 
 /// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
@@ -54,6 +56,16 @@ public:
   /// \param itemID Subject Hierarchy item to show the visibility context menu items for
   void showVisibilityContextMenuActionsForItem(vtkIdType itemID) override;
 
+  /// Show an item in a selected view.
+  /// Calls Volumes plugin's showItemInView implementation and adds support for showing a volume
+  /// in 3D views using volume rendering.
+  /// Returns true on success.
+  bool showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow) override;
+
+  /// Show/hide volume rendering in a view.
+  /// If viewNode is nullptr then it is displayed in all 3D views in the current layout.
+  bool showVolumeRendering(bool show, vtkIdType itemID, vtkMRMLViewNode* viewNode=nullptr);
+
 protected slots:
   /// Toggle volume rendering option for current volume item
   void toggleVolumeRenderingForCurrentItem(bool);
@@ -62,6 +74,8 @@ protected slots:
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyVolumeRenderingPluginPrivate> d_ptr;
+
+  void resetFieldOfView(vtkMRMLDisplayNode* displayNode, vtkMRMLViewNode* viewNode=nullptr);
 
 private:
   Q_DECLARE_PRIVATE(qSlicerSubjectHierarchyVolumeRenderingPlugin);

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDiffusionTensorVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDiffusionTensorVolumesPlugin.cxx
@@ -330,3 +330,16 @@ void qSlicerSubjectHierarchyDiffusionTensorVolumesPlugin::onTractographyInteract
 
   qSlicerApplication::application()->openNodeModule(shNode->GetItemDataNode(currentItemID));
 }
+
+//-----------------------------------------------------------------------------
+bool qSlicerSubjectHierarchyDiffusionTensorVolumesPlugin::showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow)
+{
+  qSlicerSubjectHierarchyVolumesPlugin* volumesPlugin = qobject_cast<qSlicerSubjectHierarchyVolumesPlugin*>(
+    qSlicerSubjectHierarchyPluginHandler::instance()->pluginByName("Volumes"));
+  if (!volumesPlugin)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access Volumes subject hierarchy plugin";
+    return false;
+    }
+  return volumesPlugin->showItemInView(itemID, viewNode, allItemsToShow);
+}

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDiffusionTensorVolumesPlugin.h
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDiffusionTensorVolumesPlugin.h
@@ -90,6 +90,10 @@ public:
   /// \param itemID Subject Hierarchy item to show the context menu items for
   void showContextMenuActionsForItem(vtkIdType itemID) override;
 
+  /// Show an item in a selected view.
+  /// Calls Volumes plugin's showItemInView implementation.
+  bool showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow) override;
+
 protected slots:
   void onTractographyLabelMapSeeding();
   void onTractographyInteractiveSeeding();

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyLabelMapsPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyLabelMapsPlugin.cxx
@@ -345,3 +345,16 @@ void qSlicerSubjectHierarchyLabelMapsPlugin::toggle2DOutlineVisibility(bool chec
     sliceNode->SetUseLabelOutline(checked);
     }
 }
+
+//-----------------------------------------------------------------------------
+bool qSlicerSubjectHierarchyLabelMapsPlugin::showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow)
+{
+  qSlicerSubjectHierarchyVolumesPlugin* volumesPlugin = qobject_cast<qSlicerSubjectHierarchyVolumesPlugin*>(
+    qSlicerSubjectHierarchyPluginHandler::instance()->pluginByName("Volumes"));
+  if (!volumesPlugin)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access Volumes subject hierarchy plugin";
+    return false;
+    }
+  return volumesPlugin->showItemInView(itemID, viewNode, allItemsToShow);
+}

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyLabelMapsPlugin.h
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyLabelMapsPlugin.h
@@ -91,6 +91,10 @@ public:
   /// \param itemID Subject Hierarchy item to show the visibility context menu items for
   void showVisibilityContextMenuActionsForItem(vtkIdType itemID) override;
 
+  /// Show an item in a selected view.
+  /// Calls Volumes plugin's showItemInView implementation.
+  bool showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow) override;
+
 public:
   /// Show labelmap in all slice views. The argument node replaces any labelmap shown on the label layer
   void showLabelMapInAllViews(vtkMRMLLabelMapVolumeNode* node);

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
@@ -98,6 +98,9 @@ public:
   /// \param itemID Subject Hierarchy item to show the visibility context menu items for
   void showVisibilityContextMenuActionsForItem(vtkIdType itemID) override;
 
+  /// Show an item in a selected view.
+  bool showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow) override;
+
 public:
   /// Show volume in all slice views. The argument node replaces any volume shown on the specified layer
   /// \param node Volume node to show


### PR DESCRIPTION
A node can be shown in a view by drag-and-dropping it from the subject hierarchy into a view.
If a volume is dragged to a 3D view then volume rendering is displayed.
To show a node in a single view only, hide the node (click on the eye icon in subject hierarchy) and then drag-and-drop it into a view.
To restore visibility of a node in all views, choose "Show in all views" in subject hierarchy item visibility.

**Demo video:**

**https://youtu.be/muIlmbUSz3A**