### PR TITLE
BUG: Add tests and fix issues with Segment Editor margin effect

### DIFF
--- a/Libs/vtkITK/vtkITKImageMargin.cxx
+++ b/Libs/vtkITK/vtkITKImageMargin.cxx
@@ -193,6 +193,8 @@ void vtkITKImageMargin::SimpleExecute(vtkImageData *input, vtkImageData *output)
       vtkTemplateMacroCase(VTK_CHAR, char, CALL);                               \
       vtkTemplateMacroCase(VTK_SIGNED_CHAR, signed char, CALL);                 \
       vtkTemplateMacroCase(VTK_UNSIGNED_CHAR, unsigned char, CALL);             \
+      vtkTemplateMacroCase(VTK_FLOAT, float, CALL);                             \
+      vtkTemplateMacroCase(VTK_DOUBLE, double, CALL);                           \
       default:
         {
         vtkErrorMacro(<< "Incompatible data type for this version of ITK.");


### PR DESCRIPTION
- vtkITKImageMargin would not accept labelmaps with scalar types of float or double. Fixed by adding both types to the template macro.
- Shrinking operation was not very accurate when tested on small anisotropic images (eg. TinyPatient). Improved the accuracy of the shrink operation by inverting the labelmap and using positive distance. This is necessary because  itk::SignedMaurerDistanceMapImageFilter calculates the distance of the voxels starting from the interior border voxels (which have a distance of 0.0). By inverting the labelmap the boundary voxels are outside the structure, rather than inside it.
- Add a section testing the Margin effect to SegmentationsModuleTest2. Tests shrink/grow operations on both shared and separated labelmaps of every supported data type.