### PR TITLE
COMP: Fix -Woverloaded-virtual in vtkSlicerMarkupsWidgetRepresentation3D

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -146,6 +146,7 @@ protected:
   /// - RelativeCoincidentTopologyPolygonOffsetParameters
   /// - RelativeCoincidentTopologyPointOffsetParameter
   void UpdateRelativeCoincidentTopologyOffsets(vtkMapper* mapper, vtkMapper* occludedMapper);
+  using vtkMRMLAbstractWidgetRepresentation::UpdateRelativeCoincidentTopologyOffsets;
 
   vtkSmartPointer<vtkCellPicker> AccuratePicker;
 


### PR DESCRIPTION
This commit fixes the following warning introduced in 412b65617 (ENH: Add
miscellaneous improvements to markups VTK widgets)

```
  In file included from /path/to/Slicer/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h:45:0,
                   from /path/to/Slicer/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h:31,
                   from /path/to/Slicer/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx:36:
  /path/to/Slicer/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h:148:16: warning: ‘virtual void vtkMRMLAbstractWidgetRepresentation::UpdateRelativeCoincidentTopologyOffsets(vtkMapper*)’ was hidden [-Woverloaded-virtual]
     virtual void UpdateRelativeCoincidentTopologyOffsets(vtkMapper* mapper);
                  ^
  In file included from /path/to/Slicer/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx:36:0:
  /path/to/Slicer/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h:148:8: warning:   by ‘void vtkSlicerMarkupsWidgetRepresentation3D::UpdateRelativeCoincidentTopologyOffsets(vtkMapper*, vtkMapper*)’ [-Woverloaded-virtual]
     void UpdateRelativeCoincidentTopologyOffsets(vtkMapper* mapper, vtkMapper* occludedMapper);
          ^
```