### PR TITLE
EHN: Removing hard-coded markup types from DM

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
@@ -30,7 +30,8 @@
 // VTK includes
 #include <vtkSlicerMarkupsWidget.h>
 
-#include <set>
+// STD includes
+#include <map>
 
 class vtkMRMLMarkupsNode;
 class vtkSlicerViewerWidget;
@@ -49,6 +50,12 @@ public:
   static vtkMRMLMarkupsDisplayableManager *New();
   vtkTypeMacro(vtkMRMLMarkupsDisplayableManager, vtkMRMLAbstractDisplayableManager);
   void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  // Registers the markup node and the associated type of widget. Pass onto
+  // these derivatives of vtkMRMLNode and vtkSlicerMarkupsWidget.
+  void RegisterMarkup(vtkMRMLMarkupsNode* node,
+                      vtkSlicerMarkupsWidget* widget,
+                      const std::string& name);
 
   /// Check if this is a 2d SliceView displayable manager, returns true if so,
   /// false otherwise. Checks return from GetSliceNode for non null, which means
@@ -138,8 +145,12 @@ protected:
   /// \sa IsManageable(vtkMRMLNode*), IsCorrectDisplayableManager()
   virtual bool IsManageable(const char* nodeClassName);
 
-  /// Contains class names of markups nodes that this displayable manager can handle
-  std::set<std::string> Focus;
+  /// Contains types of markups nodes that this displayable manager can
+  /// handle as well as the associated widgets.
+  std::map<std::string, vtkSlicerMarkupsWidget*> MarkupsNodesWidgets;
+
+  /// Relates types of markups and node naming strings
+  std::map<std::string, std::string> MarkupsNames;
 
   /// Respond to interactor style events
   void OnInteractorStyleEvent(int eventid) override;

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.cxx
@@ -286,14 +286,16 @@ void vtkMRMLMarkupsDisplayableManagerHelper::AddDisplayNode(vtkMRMLMarkupsDispla
   // There should not be a widget for the new node
   if (this->GetWidget(markupsDisplayNode) != nullptr)
     {
-    vtkErrorMacro("vtkMRMLMarkupsDisplayableManager2D: A widget is already associated to this node");
+    vtkErrorMacro("vtkMRMLMarkupsDisplayableManager: A widget is already associated to "
+                  << markupsDisplayNode->GetMarkupsNode()->GetNodeTagName());
     return;
     }
 
   vtkSlicerMarkupsWidget* newWidget = this->DisplayableManager->CreateWidget(markupsDisplayNode);
   if (!newWidget)
     {
-    vtkErrorMacro("vtkMRMLMarkupsDisplayableManager2D: Failed to create widget");
+    vtkErrorMacro("vtkMRMLMarkupsDisplayableManager: Failed to create widget for node "
+                  << markupsDisplayNode->GetMarkupsNode()->GetNodeTagName());
     return;
     }
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleWidget.cxx
@@ -39,6 +39,12 @@ vtkSlicerAngleWidget::vtkSlicerAngleWidget()
 vtkSlicerAngleWidget::~vtkSlicerAngleWidget() = default;
 
 //----------------------------------------------------------------------
+vtkSlicerMarkupsWidget* vtkSlicerAngleWidget::CreateInstance() const
+{
+  return vtkSlicerAngleWidget::New();
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerAngleWidget::CreateDefaultRepresentation(
   vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer)
 {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleWidget.h
@@ -46,6 +46,9 @@ public:
   /// Create the default widget representation and initializes the widget and representation.
   void CreateDefaultRepresentation(vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer) override;
 
+  /// Create instance of the markups widget
+  virtual vtkSlicerMarkupsWidget* CreateInstance() const;
+
 protected:
   vtkSlicerAngleWidget();
   ~vtkSlicerAngleWidget() override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerClosedCurveWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerClosedCurveWidget.cxx
@@ -61,6 +61,12 @@ void vtkSlicerClosedCurveWidget::CreateDefaultRepresentation(
 }
 
 //----------------------------------------------------------------------
+vtkSlicerMarkupsWidget* vtkSlicerClosedCurveWidget::CreateInstance() const
+{
+  return vtkSlicerClosedCurveWidget::New();
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerClosedCurveWidget::AddPointOnCurveAction(vtkAbstractWidget *vtkNotUsed(w))
 {
   /* TODO: implement this

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerClosedCurveWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerClosedCurveWidget.h
@@ -77,6 +77,9 @@ public:
   /// Create the default widget representation and initializes the widget and representation.
   void CreateDefaultRepresentation(vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer) override;
 
+  /// Create instance of the markups widget
+  virtual vtkSlicerMarkupsWidget* CreateInstance() const;
+
 protected:
   vtkSlicerClosedCurveWidget();
   ~vtkSlicerClosedCurveWidget() override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveWidget.cxx
@@ -65,6 +65,12 @@ void vtkSlicerCurveWidget::CreateDefaultRepresentation(
 }
 
 //----------------------------------------------------------------------
+vtkSlicerMarkupsWidget* vtkSlicerCurveWidget::CreateInstance() const
+{
+  return vtkSlicerCurveWidget::New();
+}
+
+//----------------------------------------------------------------------
 bool vtkSlicerCurveWidget::ProcessControlPointInsert(vtkMRMLInteractionEventData* eventData)
 {
   vtkMRMLMarkupsCurveNode* markupsNode = this->GetMarkupsCurveNode();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveWidget.h
@@ -46,6 +46,9 @@ public:
   /// Create the default widget representation and initializes the widget and representation.
   void CreateDefaultRepresentation(vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer) override;
 
+  /// Create instance of the markups widget
+  virtual vtkSlicerMarkupsWidget* CreateInstance() const;
+
 protected:
   vtkSlicerCurveWidget();
   ~vtkSlicerCurveWidget() override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineWidget.cxx
@@ -40,6 +40,12 @@ vtkSlicerLineWidget::vtkSlicerLineWidget()
 vtkSlicerLineWidget::~vtkSlicerLineWidget() = default;
 
 //----------------------------------------------------------------------
+vtkSlicerMarkupsWidget* vtkSlicerLineWidget::CreateInstance() const
+{
+  return vtkSlicerLineWidget::New();
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerLineWidget::CreateDefaultRepresentation(
   vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer)
 {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineWidget.h
@@ -46,6 +46,9 @@ public:
   /// Create the default widget representation and initializes the widget and representation.
   void CreateDefaultRepresentation(vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer) override;
 
+  /// Create instance of the markups widget
+  virtual vtkSlicerMarkupsWidget* CreateInstance() const;
+
 protected:
   vtkSlicerLineWidget();
   ~vtkSlicerLineWidget() override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -38,6 +38,7 @@
 #include <vtkRenderWindow.h>
 #include <vtkRenderer.h>
 #include <vtkTransform.h>
+#include <vtkObjectFactory.h>
 
 // MRML includes
 #include "vtkMRMLTransformNode.h"

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
@@ -52,6 +52,9 @@ public:
   /// Create the default widget representation and initializes the widget and representation.
   virtual void CreateDefaultRepresentation(vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer) = 0;
 
+  /// Create instance of the markups widget
+  virtual vtkSlicerMarkupsWidget* CreateInstance() const = 0;
+
   /// Widget states
   enum
   {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
@@ -45,6 +45,12 @@ vtkSlicerPlaneWidget::vtkSlicerPlaneWidget()
 vtkSlicerPlaneWidget::~vtkSlicerPlaneWidget() = default;
 
 //----------------------------------------------------------------------
+vtkSlicerMarkupsWidget* vtkSlicerPlaneWidget::CreateInstance() const
+{
+  return vtkSlicerPlaneWidget::New();
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerPlaneWidget::CreateDefaultRepresentation(
   vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer)
 {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.h
@@ -45,6 +45,9 @@ public:
   /// Standard methods for a VTK class.
   vtkTypeMacro(vtkSlicerPlaneWidget,vtkSlicerMarkupsWidget);
 
+  /// Create instance of the markups widget
+  virtual vtkSlicerMarkupsWidget* CreateInstance() const;
+
   /// Widget states
   enum
   {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPointsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPointsWidget.cxx
@@ -50,3 +50,9 @@ void vtkSlicerPointsWidget::CreateDefaultRepresentation(
   rep->SetMarkupsDisplayNode(markupsDisplayNode);
   rep->UpdateFromMRML(nullptr, 0); // full update
 }
+
+//----------------------------------------------------------------------
+vtkSlicerMarkupsWidget* vtkSlicerPointsWidget::CreateInstance() const
+{
+  return vtkSlicerPointsWidget::New();
+}

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPointsWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPointsWidget.h
@@ -45,6 +45,9 @@ public:
   /// Create the default widget representation and initializes the widget and representation.
   void CreateDefaultRepresentation(vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer) override;
 
+  /// Create instance of the markups widget
+  vtkSlicerMarkupsWidget* CreateInstance() const;
+
 protected:
   vtkSlicerPointsWidget();
   ~vtkSlicerPointsWidget() override;


### PR DESCRIPTION
This commit adds Markup nodes registration capabilities to  `vtkMRMLMarkupsDisplayableManager` and removes the need to hard-code markup nodes. The following changes have been applied:

- Adding a factory method (`CreateInstance()`) in `vtkSlicerMarkupsWIdget`. This method is *pure virtual*, thus forcing sub-classes to define it.
- Adding a `CreateIntance()` to all the existing markups widgets.
- Adding a `RegisterMarkup()` function to `vtkMRMLMarkupsDisplayableManager`. This function will register a new markup and the associated needed items (short name for new fiducials and markup widget type associated to the node).
- Replacing the `std::set<std::string> Focus` member used to keep track of registered nodes, by `std::map<std::string, vtkSlicerMarkupsWidget>` (keeping association between nodes registered and corresponding wiget types), and `std::map<std::string, std::string>` (keeping association between nodes registered and corresponding short names).