### PR TITLE
BUG: Enabling builtin ctypes in python

### DIFF
--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -91,7 +91,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
       )
   elseif(UNIX)
     list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_ARGS
-        #Fixes segfault in some linux distributions
+        # Avoid segfault on Linux distributions including an incompatible version of libffi
         -DBUILTIN_CTYPES:BOOL=ON
       )
   endif()

--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -89,6 +89,11 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
         -DBUILTIN_BINASCII:BOOL=OFF
         -DBUILTIN_ZLIB:BOOL=OFF
       )
+  elseif(UNIX)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_ARGS
+        #Fixes segfault in some linux distributions
+        -DBUILTIN_CTYPES:BOOL=ON
+      )
   endif()
 
   # Force python build to "Release"


### PR DESCRIPTION
This fixes a segfault occurring in some linux distributions. Suspected
incompatibility between libffi>=3.4 and Slicer cpython, but not 100% confirmed. The proposed changes seem harmless anyways.

For discussion see [https://discourse.slicer.org/t/cant-start-latest-stable-on-ubuntu-20-04/14029/35](https://discourse.slicer.org/t/cant-start-latest-stable-on-ubuntu-20-04/14029/35)