### PR TITLE
ENH: Allow dropping SH folders into views

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.cxx
@@ -648,3 +648,25 @@ void qSlicerSubjectHierarchyFolderPlugin::setApplyColorToBranchEnabledForItem(vt
 
   folderDisplayNode->SetApplyDisplayPropertiesOnBranch(enabled);
 }
+
+//-----------------------------------------------------------------------------
+bool qSlicerSubjectHierarchyFolderPlugin::showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow)
+{
+  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
+  if (!shNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
+    return false;
+    }
+
+  std::vector<vtkIdType> folderContentItemIDs;
+  shNode->GetItemChildren(itemID, folderContentItemIDs, true);
+  for (auto childItem : folderContentItemIDs)
+    {
+    qSlicerSubjectHierarchyAbstractPlugin* ownerPlugin = qSlicerSubjectHierarchyPluginHandler::instance()->getOwnerPluginForSubjectHierarchyItem(childItem);
+    if (ownerPlugin)
+      {
+      ownerPlugin->showItemInView(childItem, viewNode, allItemsToShow);
+      }
+    }
+}

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
@@ -137,6 +137,9 @@ public:
   /// \param itemID Subject Hierarchy item to show the visibility context menu items for
   void showVisibilityContextMenuActionsForItem(vtkIdType itemID) override;
 
+  /// Show the contents of the colder in a selected view.
+  bool showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow) override;
+
 public:
   /// Create folder under specified item
   /// \param parentNode Parent item for folder to create


### PR DESCRIPTION
As an addition to recent work about dropping SH items into views (https://github.com/Slicer/Slicer/pull/5327), this commit adds the ability to drag&drop folders as well. In that case all the child items (recursively) of the folder are shown in the view the folder has been dropped. See alsohttps://github.com/NA-MIC/ProjectWeek/blob/master/PW34_2020_Virtual/Projects/SubjectHierarchyFolders/README.md