### PR TITLE
ENH: Add option to automatically release resources when volume rendering is hidden

### DIFF
--- a/Docs/user_guide/modules/volumerendering.md
+++ b/Docs/user_guide/modules/volumerendering.md
@@ -59,6 +59,7 @@ This is accomplished by specifying color and opacity for each voxel, based on it
         - Interactive speed: Ensure the given frame per second (FPS) is enforced in the views during interaction. The higher the FPS, the lower the resolution of the volume rendering
       - Normal (default): fixed rendering quality, should work well for volumes that the renderer can handle without difficulties.
       - Maximum: oversamples the image to achieve higher image quality, at the cost of slowing down the rendering.
+    - Auto-release resources: When a volume is shown using volume rendering then graphics resources are allocated (GPU memory, precomputed gradient and space leaping volumes, etc.). This flag controls if these resources are automatically released when the volume is hidden. Releasing the resources reduces memory usage, but it increases the time required to show the volume again. Default value can be set in application settings Volume Rendering panel.
     - Technique:
       - Composite with shading (default): display as a shaded surface
       - Maximum intensity projection: display brightest voxel value encountered in each projection line

--- a/Libs/MRML/Core/vtkMRMLViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLViewNode.cxx
@@ -56,6 +56,7 @@ vtkMRMLViewNode::vtkMRMLViewNode()
   this->OrientationMarkerEnabled = true;
   this->RulerEnabled = true;
   this->GPUMemorySize = 0; // Means application default
+  this->AutoReleaseGraphicsResources = false;
   this->ExpectedFPS = 8.;
   this->VolumeRenderingQuality = vtkMRMLViewNode::Normal;
   this->RaycastTechnique = vtkMRMLViewNode::Composite;
@@ -101,6 +102,7 @@ void vtkMRMLViewNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLEnumMacro(renderMode, RenderMode);
   vtkMRMLWriteXMLIntMacro(useDepthPeeling, UseDepthPeeling);
   vtkMRMLWriteXMLIntMacro(gpuMemorySize, GPUMemorySize);
+  vtkMRMLWriteXMLBooleanMacro(autoReleaseGraphicsResources, AutoReleaseGraphicsResources);
   vtkMRMLWriteXMLFloatMacro(expectedFPS, ExpectedFPS);
   vtkMRMLWriteXMLEnumMacro(volumeRenderingQuality, VolumeRenderingQuality);
   vtkMRMLWriteXMLEnumMacro(raycastTechnique, RaycastTechnique);
@@ -137,6 +139,7 @@ void vtkMRMLViewNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLEnumMacro(renderMode, RenderMode);
   vtkMRMLReadXMLIntMacro(useDepthPeeling, UseDepthPeeling);
   vtkMRMLReadXMLIntMacro(gpuMemorySize, GPUMemorySize);
+  vtkMRMLReadXMLBooleanMacro(autoReleaseGraphicsResources, AutoReleaseGraphicsResources);
   vtkMRMLReadXMLFloatMacro(expectedFPS, ExpectedFPS);
   vtkMRMLReadXMLEnumMacro(volumeRenderingQuality, VolumeRenderingQuality);
   vtkMRMLReadXMLEnumMacro(raycastTechnique, RaycastTechnique);
@@ -174,6 +177,7 @@ void vtkMRMLViewNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
   vtkMRMLCopyEnumMacro(RenderMode);
   vtkMRMLCopyIntMacro(UseDepthPeeling);
   vtkMRMLCopyIntMacro(GPUMemorySize);
+  vtkMRMLCopyBooleanMacro(AutoReleaseGraphicsResources);
   vtkMRMLCopyFloatMacro(ExpectedFPS);
   vtkMRMLCopyIntMacro(VolumeRenderingQuality);
   vtkMRMLCopyIntMacro(RaycastTechnique);
@@ -208,6 +212,7 @@ void vtkMRMLViewNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintEnumMacro(RenderMode);
   vtkMRMLPrintIntMacro(UseDepthPeeling);
   vtkMRMLPrintIntMacro(GPUMemorySize);
+  vtkMRMLPrintBooleanMacro(AutoReleaseGraphicsResources);
   vtkMRMLPrintFloatMacro(ExpectedFPS);
   vtkMRMLPrintIntMacro(VolumeRenderingQuality);
   vtkMRMLPrintIntMacro(RaycastTechnique);

--- a/Libs/MRML/Core/vtkMRMLViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLViewNode.h
@@ -142,6 +142,18 @@ public:
   vtkGetMacro(GPUMemorySize, int);
   vtkSetMacro(GPUMemorySize, int);
 
+  ///@{
+  /// Enable/Disable automatic immediate release of graphics resources
+  /// when not in use. If GPU volume rendering is used, enabling this option
+  /// makes the volume immediately unloaded from GPU memory when visibility
+  /// is turned off.
+  /// Disabled by default to allow faster toggling of visibility.
+  vtkSetMacro(AutoReleaseGraphicsResources, bool);
+  vtkGetMacro(AutoReleaseGraphicsResources, bool);
+  vtkBooleanMacro(AutoReleaseGraphicsResources, bool);
+  ///@}
+
+
   /// Expected FPS
   vtkSetMacro(ExpectedFPS, double);
   vtkGetMacro(ExpectedFPS, double);
@@ -343,6 +355,9 @@ protected:
   /// Not saved into scene file because different machines may have different GPU memory values.
   /// A value of 0 indicates to use the default value in the settings
   int GPUMemorySize;
+
+  /// Immediately release graphics resources when they are not in use.
+  bool AutoReleaseGraphicsResources;
 
   /// Expected frame per second rendered
   double ExpectedFPS;

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -360,7 +360,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="2">
+          <item row="5" column="0" colspan="2">
            <widget class="ctkCollapsibleGroupBox" name="AdvancedGroupBox">
             <property name="title">
              <string>Advanced rendering properties</string>
@@ -389,6 +389,23 @@
               </widget>
              </item>
             </layout>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="FramerateLabel_2">
+            <property name="text">
+             <string>Auto-release resources:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QCheckBox" name="AutoReleaseGraphicsResourcesCheckBox">
+            <property name="toolTip">
+             <string>Immediately unload volumes from graphics memory when not visible. Reduces memory usage but makes toggling volume visibility slower.</string>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
            </widget>
           </item>
          </layout>
@@ -487,42 +504,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLCheckableNodeComboBox</class>
-   <extends>qMRMLNodeComboBox</extends>
-   <header>qMRMLCheckableNodeComboBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLDisplayNodeViewComboBox</class>
-   <extends>qMRMLCheckableNodeComboBox</extends>
-   <header>qMRMLDisplayNodeViewComboBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLAnnotationROIWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLAnnotationROIWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerWidget</class>
-   <extends>QWidget</extends>
-   <header>qSlicerWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLVolumePropertyNodeWidget</class>
-   <extends>QWidget</extends>
-   <header>qMRMLVolumePropertyNodeWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerVolumeRenderingPresetComboBox</class>
-   <extends>qSlicerWidget</extends>
-   <header>qSlicerVolumeRenderingPresetComboBox.h</header>
-  </customwidget>
-  <customwidget>
    <class>ctkCheckablePushButton</class>
    <extends>ctkPushButton</extends>
    <header>ctkCheckablePushButton.h</header>
@@ -558,6 +539,42 @@
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLCheckableNodeComboBox</class>
+   <extends>qMRMLNodeComboBox</extends>
+   <header>qMRMLCheckableNodeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLDisplayNodeViewComboBox</class>
+   <extends>qMRMLCheckableNodeComboBox</extends>
+   <header>qMRMLDisplayNodeViewComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLAnnotationROIWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLAnnotationROIWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLVolumePropertyNodeWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLVolumePropertyNodeWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerVolumeRenderingPresetComboBox</class>
+   <extends>qSlicerWidget</extends>
+   <header>qSlicerVolumeRenderingPresetComboBox.h</header>
   </customwidget>
   <customwidget>
    <class>qSlicerGPUMemoryComboBox</class>

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingSettingsPanel.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingSettingsPanel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>345</width>
-    <height>155</height>
+    <height>156</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -99,6 +99,23 @@
     <widget class="QCheckBox" name="SurfaceSmoothingCheckBox">
      <property name="toolTip">
       <string>Reduce wood grain artifact to make surfaces appear smoother.</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="FramerateLabel_2">
+     <property name="text">
+      <string>Auto-release resources:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="AutoReleaseGraphicsResourcesCheckBox">
+     <property name="toolTip">
+      <string>Immediately unload volumes from graphics memory when not visible. Reduces memory usage but makes toggling volume visibility slower.</string>
      </property>
      <property name="text">
       <string/>

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -144,6 +144,11 @@ void qSlicerVolumeRenderingModuleWidgetPrivate::setupUi(qSlicerVolumeRenderingMo
   QObject::connect(this->FramerateSliderWidget, SIGNAL(valueChanged(double)),
                    q, SLOT(onCurrentFramerateChanged(double)));
 
+  QObject::connect(this->AutoReleaseGraphicsResourcesCheckBox, SIGNAL(toggled(bool)),
+                   q, SLOT(onAutoReleaseGraphicsResourcesCheckBoxToggled(bool)));
+
+  void onAutoReleaseGraphicsResourcesChanged(bool autoRelease);
+
   // Volume Properties
   this->PresetComboBox->setMRMLScene(volumeRenderingLogic->GetPresetsScene());
   this->PresetComboBox->setCurrentNode(nullptr);
@@ -406,6 +411,8 @@ void qSlicerVolumeRenderingModuleWidget::updateWidgetFromMRML()
   d->RenderingMethodComboBox->setCurrentIndex(d->RenderingMethodComboBox->findData(currentRenderingMethod) );
   d->MemorySizeComboBox->setCurrentGPUMemory(firstViewNode ? firstViewNode->GetGPUMemorySize() : 0);
   d->QualityControlComboBox->setCurrentIndex(firstViewNode ? firstViewNode->GetVolumeRenderingQuality() : -1);
+  d->AutoReleaseGraphicsResourcesCheckBox->setChecked(firstViewNode ? firstViewNode->GetAutoReleaseGraphicsResources() : false);
+
   if (firstViewNode)
     {
     d->FramerateSliderWidget->setValue(firstViewNode->GetExpectedFPS());
@@ -640,6 +647,29 @@ void qSlicerVolumeRenderingModuleWidget::onCurrentQualityControlChanged(int inde
     if (displayNode->IsDisplayableInView(viewNode->GetID()))
       {
       viewNode->SetVolumeRenderingQuality(index);
+      }
+    }
+
+  this->updateWidgetFromMRML();
+}
+
+// --------------------------------------------------------------------------
+void qSlicerVolumeRenderingModuleWidget::onAutoReleaseGraphicsResourcesCheckBoxToggled(bool autoRelease)
+{
+  vtkMRMLVolumeRenderingDisplayNode* displayNode = this->mrmlDisplayNode();
+  if (!displayNode)
+    {
+    return;
+    }
+
+  std::vector<vtkMRMLNode*> viewNodes;
+  displayNode->GetScene()->GetNodesByClass("vtkMRMLViewNode", viewNodes);
+  for (std::vector<vtkMRMLNode*>::iterator it=viewNodes.begin(); it!=viewNodes.end(); ++it)
+    {
+    vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(*it);
+    if (displayNode->IsDisplayableInView(viewNode->GetID()))
+      {
+      viewNode->SetAutoReleaseGraphicsResources(autoRelease);
       }
     }
 

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.h
@@ -78,6 +78,7 @@ protected slots:
   void onCurrentMemorySizeChanged();
   void onCurrentQualityControlChanged(int index);
   void onCurrentFramerateChanged(double fps);
+  void onAutoReleaseGraphicsResourcesCheckBoxToggled(bool autoRelease);
 
   void updateWidgetFromMRML();
   void updateWidgetFromROINode();

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.h
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingSettingsPanel.h
@@ -39,6 +39,8 @@ class Q_SLICER_QTMODULES_VOLUMERENDERING_EXPORT qSlicerVolumeRenderingSettingsPa
   Q_PROPERTY(QString defaultQuality READ defaultQuality WRITE setDefaultQuality NOTIFY defaultQualityChanged)
   Q_PROPERTY(int defaultInteractiveSpeed READ defaultInteractiveSpeed WRITE setDefaultInteractiveSpeed NOTIFY defaultInteractiveSpeedChanged)
   Q_PROPERTY(bool defaultSurfaceSmoothing READ defaultSurfaceSmoothing WRITE setDefaultSurfaceSmoothing NOTIFY defaultSurfaceSmoothingChanged)
+  Q_PROPERTY(bool defaultAutoReleaseGraphicsResources READ defaultAutoReleaseGraphicsResources \
+    WRITE setDefaultAutoReleaseGraphicsResources NOTIFY defaultAutoReleaseGraphicsResourcesChanged)
   Q_PROPERTY(QString gpuMemory READ gpuMemory WRITE setGPUMemory NOTIFY gpuMemoryChanged)
 
 public:
@@ -60,6 +62,7 @@ public:
   QString defaultQuality()const;
   int defaultInteractiveSpeed()const;
   bool defaultSurfaceSmoothing()const;
+  bool defaultAutoReleaseGraphicsResources()const;
   QString gpuMemory()const;
 
 public slots:
@@ -67,6 +70,7 @@ public slots:
   void setDefaultQuality(const QString& quality);
   void setDefaultInteractiveSpeed(int interactiveSpeed);
   void setDefaultSurfaceSmoothing(bool surfaceSmoothing);
+  void setDefaultAutoReleaseGraphicsResources(bool autoRelease);
   void setGPUMemory(const QString& gpuMemory);
 
 signals:
@@ -74,6 +78,7 @@ signals:
   void defaultQualityChanged(const QString&);
   void defaultInteractiveSpeedChanged(int);
   void defaultSurfaceSmoothingChanged(bool);
+  void defaultAutoReleaseGraphicsResourcesChanged(bool);
   void gpuMemoryChanged(QString);
 
 protected slots:
@@ -83,6 +88,7 @@ protected slots:
   void onDefaultQualityChanged(int);
   void onDefaultInteractiveSpeedChanged(double);
   void onDefaultSurfaceSmoothingChanged(bool);
+  void onDefaultAutoReleaseGraphicsResourcesChanged(bool);
   void onGPUMemoryChanged();
   void updateDefaultViewNodeFromWidget();
 


### PR DESCRIPTION
When rendering large volumes, it may be necessary to unload hidden volume from GPU memory.
See also: https://discourse.slicer.org/t/setting-visibility-to-off-in-volume-rendering-does-not-unload-the-volume-from-texture-memory/15127

Solution: Added "Auto-release resources" checkbox (in Volume Rendering module advanced settings). If it is checked then volume that do not have visible volume rendering are automatically unloaded from GPU memory.