### PR TITLE
ENH: Show child items of any dropped SH item in view

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.cxx
@@ -648,25 +648,3 @@ void qSlicerSubjectHierarchyFolderPlugin::setApplyColorToBranchEnabledForItem(vt
 
   folderDisplayNode->SetApplyDisplayPropertiesOnBranch(enabled);
 }
-
-//-----------------------------------------------------------------------------
-bool qSlicerSubjectHierarchyFolderPlugin::showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow)
-{
-  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
-  if (!shNode)
-    {
-    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
-    return false;
-    }
-
-  std::vector<vtkIdType> folderContentItemIDs;
-  shNode->GetItemChildren(itemID, folderContentItemIDs, true);
-  for (auto childItem : folderContentItemIDs)
-    {
-    qSlicerSubjectHierarchyAbstractPlugin* ownerPlugin = qSlicerSubjectHierarchyPluginHandler::instance()->getOwnerPluginForSubjectHierarchyItem(childItem);
-    if (ownerPlugin)
-      {
-      ownerPlugin->showItemInView(childItem, viewNode, allItemsToShow);
-      }
-    }
-}

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.h
@@ -137,9 +137,6 @@ public:
   /// \param itemID Subject Hierarchy item to show the visibility context menu items for
   void showVisibilityContextMenuActionsForItem(vtkIdType itemID) override;
 
-  /// Show the contents of the colder in a selected view.
-  bool showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow) override;
-
 public:
   /// Create folder under specified item
   /// \param parentNode Parent item for folder to create


### PR DESCRIPTION
As discussed in the PR https://github.com/Slicer/Slicer/pull/5350 it may be confusing if only the folders would show their children. Also the plugin handler needs to collect all the shown child items so that the individual plugins have the complete item list to best show the items (e.g. volumes in background and foreground). So instead of the folder plugin managing its children when dropping it, the plugin handler collects and shows all the dropped items and their children, recursively.