### PR TITLE
BUG: Fix Qt printer support for Slicer installations

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -31,6 +31,7 @@ if(NOT Slicer_USE_SYSTEM_QT)
   set(SlicerBlockInstallQtPlugins_subdirectories
     audio
     imageformats
+    printsupport
     sqldrivers
     )
     if(Slicer_BUILD_WEBENGINE_SUPPORT)

--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -79,7 +79,7 @@ function(gp_item_default_embedded_path_override item default_embedded_path_var)
     set(path "@fixup_path@/@Slicer_ITKFACTORIES_DIR@")
   endif()
 
-  foreach(qt_plugin_dir designer iconengines styles audio imageformats sqldrivers platforms)
+  foreach(qt_plugin_dir designer iconengines styles audio imageformats sqldrivers platforms printsupport)
     if(item MATCHES "@Slicer_QtPlugins_DIR@/${qt_plugin_dir}/[^/]+\\.(so|dylib)$")
       set(path "@fixup_path@/@Slicer_QtPlugins_DIR@/${qt_plugin_dir}")
     endif()
@@ -141,6 +141,7 @@ function(fixup_bundle_with_plugins app)
     "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/imageformats/*${suffix}"
     "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/sqldrivers/*${suffix}"
     "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/platforms/*${suffix}"
+    "${app_dir}/Contents/@Slicer_QtPlugins_DIR@/printsupport/*${suffix}"
     )
 
   set(Slicer_BUILD_CLI_SUPPORT "@Slicer_BUILD_CLI_SUPPORT@")


### PR DESCRIPTION
For installed versions of Slicer, calling QPrinterInfo::availablePrinterNames() would return an empty list, while built versions would have the list of printers populated as normal.
The lack of available printers made it impossible to set the output of QPrinter to NativeFormat.

By bundling the printsupport plugin with the installer, the available printers can be found.