### PR TITLE
COMP: Update vtkMRMLReadXMLStdStringVectorMacro to fix VTK9 build error

### DIFF
--- a/Libs/MRML/Core/vtkMRMLNodePropertyMacros.h
+++ b/Libs/MRML/Core/vtkMRMLNodePropertyMacros.h
@@ -326,6 +326,24 @@
     }
 
 /// Macro for reading an iterable container (of std::string) node property from XML.
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
+// Use std::string
+#define vtkMRMLReadXMLStdStringVectorMacro(xmlAttributeName, propertyName, vectorType) \
+  if (!strcmp(xmlReadAttName, #xmlAttributeName)) \
+    { \
+    vectorType<std::string> attributeValues; \
+    std::string valueString(xmlReadAttValue); \
+    std::vector<std::string> splitXmlReadAttValue = vtksys::SystemTools::SplitString(valueString, ';'); \
+    for (std::string attributeValue : splitXmlReadAttValue) \
+      { \
+      vtksys::SystemTools::ReplaceString(attributeValue, "%3B", ";"); \
+      vtksys::SystemTools::ReplaceString(attributeValue, "%25", "%"); \
+      attributeValues.emplace_back(attributeValue); \
+      } \
+    this->Set##propertyName(attributeValues); \
+    }
+#else
+// Use vtksys::String
 #define vtkMRMLReadXMLStdStringVectorMacro(xmlAttributeName, propertyName, vectorType) \
   if (!strcmp(xmlReadAttName, #xmlAttributeName)) \
     { \
@@ -340,6 +358,7 @@
       } \
     this->Set##propertyName(attributeValues); \
     }
+#endif
 
 /// Macro for reading a vtkMatrix4x4* node property from XML.
 /// "Owned" means that the node owns the matrix, the object is always valid and cannot be replaced from outside


### PR DESCRIPTION
This commit updates the macro to use "std::string" because "vtksys::String"
is not available when building against VTK 9.

It fixes a regression introduced in commit 1e0b70925 (BUG: Fixed MRML
string vector attribute writing)