### PR TITLE
Fix common Error documentation page links

### DIFF
--- a/Docs/developer_guide/build_instructions/common_errors.md
+++ b/Docs/developer_guide/build_instructions/common_errors.md
@@ -3,3 +3,13 @@
 ## Firewall is blocking git protocol
 
 Some firewalls will block the git protocol. A possible workaround is to configure Slicer by disabling the option `Slicer_USE_GIT_PROTOCOL`. Then the http protocol will be used instead. Consider also reading https://github.com/commontk/CTK/issues/33.
+
+## CMake complains during configuration
+
+CMake may not directly show what's wrong; try to look for log files of the form BUILD/CMakeFiles/*.log (where BUILD is your build directory) to glean further information.
+
+## 'QSslSocket' : is not a class or namespace name
+
+This error message occurs if Slicer is configured to use SSL but Qt is built without SSL support.
+
+Either set Slicer_USE_PYTHONQT_WITH_OPENSSL to OFF when configuring Slicer build in CMake, or build Qt with SSL support.

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -212,4 +212,4 @@ make package
 
 ## Common errors
 
-See list of issues common to all operating systems on [Common errors](common_errors) page.
+See list of issues common to all operating systems on [Common errors](common_errors.md) page.

--- a/Docs/developer_guide/build_instructions/macos.md
+++ b/Docs/developer_guide/build_instructions/macos.md
@@ -99,17 +99,7 @@ make package
 
 See list of issues common to all operating systems on [Common errors](common_errors) page.
 
-### CMake complains during configuration
-
-CMake may not directly show what's wrong; try to look for log files of the form BUILD/CMakeFiles/*.log (where BUILD is your build directory) to glean further information.
-
-### 'QSslSocket' : is not a class or namespace name
-
-This error message occurs if Slicer is configured to use SSL but Qt is built without SSL support.
-
-Either set Slicer_USE_PYTHONQT_WITH_OPENSSL to OFF when configuring Slicer build in CMake, or build Qt with SSL support.
-
-### macOS: error while configuring PCRE: "cannot run C compiled program"
+### error while configuring PCRE: "cannot run C compiled program"
 
 If the XCode command line tools are not properly set up on macOS, PCRE could fail to build in the Superbuild process with the errors like below:
 ```
@@ -122,6 +112,6 @@ To install XCode command line tools, use the following command from the terminal
 xcode-select --install
 ```
 
-### macOS: dyld: malformed mach-o: load commands size (...) > 32768
+### dyld: malformed mach-o: load commands size (...) > 32768
 
 Path of source or build folder is too long. For example building Slicer in */User/somebody/projects/something/dev/slicer/slicer-qt5-rel* may fail with malformed mach-o error, while it succeeds in */sq5* folder. To resolve this error, move source and binary files into a folder with shorter full path and restart the build from scratch (the build tree is not relocatable).

--- a/Docs/developer_guide/build_instructions/macos.md
+++ b/Docs/developer_guide/build_instructions/macos.md
@@ -97,7 +97,7 @@ make package
 
 ## Common errors
 
-See list of issues common to all operating systems on [Common errors](common_errors) page.
+See list of issues common to all operating systems on [Common errors](common_errors.md) page.
 
 ### error while configuring PCRE: "cannot run C compiled program"
 

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -144,4 +144,4 @@ See [Python scripting page](https://www.slicer.org/wiki/Documentation/Nightly/De
 
 ## Common errors
 
-See list of issues common to all operating systems on [Common errors](common_errors) page.
+See list of issues common to all operating systems on [Common errors](common_errors.md) page.


### PR DESCRIPTION
This fixes some broken links on GitHub to the Common Errors documentation page. See https://github.com/Slicer/Slicer/blob/bc4a07dc408089328f359436de05c3e440f7a39e/Docs/developer_guide/build_instructions/common_errors from the https://github.com/Slicer/Slicer/blob/bc4a07dc408089328f359436de05c3e440f7a39e/Docs/developer_guide/build_instructions/windows.md page.

Will see if this breaks the ReadTheDocs link with the generated preview from this PR.