### PR TITLE
ENH: exposing module logic in vtk mrml application logic

### DIFF
--- a/Base/QTCore/qSlicerModuleFactoryManager.cxx
+++ b/Base/QTCore/qSlicerModuleFactoryManager.cxx
@@ -24,6 +24,8 @@
 
 #include "vtkSlicerConfigure.h" // XXX For modulePaths() function.
 
+#include <vtkSlicerApplicationLogic.h>
+
 // STD includes
 #include <algorithm>
 
@@ -168,12 +170,16 @@ bool qSlicerModuleFactoryManager::loadModule(const QString& name, const QString&
   // Update internal Map
   d->LoadedModules << name;
 
+  // Sets the logic for the module in the application logic
+  d->AppLogic->SetModuleLogic(name.toStdString().c_str(), instance->logic());
+
   // Initialize module
   instance->initialize(d->AppLogic);
 
   // Check the module has a title (required)
   if (instance->title().isEmpty())
     {
+    d->AppLogic->SetModuleLogic(name.toStdString().c_str(), nullptr);
     qWarning() << "Failed to retrieve module title corresponding to module name: " << name;
     Q_ASSERT(!instance->title().isEmpty());
     return false;
@@ -245,6 +251,10 @@ void qSlicerModuleFactoryManager::unloadModule(const QString& name)
   emit this->moduleAboutToBeUnloaded(name);
   d->LoadedModules.removeOne(name);
   this->uninstantiateModule(name);
+
+  // Remove the registration of module logic in application logic.
+  d->AppLogic->SetModuleLogic(name.toStdString().c_str(), nullptr);
+
   emit this->moduleUnloaded(name);
 }
 

--- a/Base/QTGUI/qSlicerWidget.cxx
+++ b/Base/QTGUI/qSlicerWidget.cxx
@@ -23,28 +23,42 @@
 
 #include "qSlicerWidget.h"
 
+// MRML includes
+#include <vtkSlicerApplicationLogic.h>
+
 // VTK includes
 
 //-----------------------------------------------------------------------------
 class qSlicerWidgetPrivate
 {
+  Q_DECLARE_PUBLIC(qSlicerWidget);
+protected:
+  qSlicerWidget* const q_ptr;
+
 public:
+  qSlicerWidgetPrivate(qSlicerWidget& object);
+
   QPointer<QWidget>                          ParentContainer;
+  vtkSlicerApplicationLogic*                 AppLogic;
 };
+
+//-----------------------------------------------------------------------------
+qSlicerWidgetPrivate::qSlicerWidgetPrivate(qSlicerWidget& object)
+  : q_ptr(&object)
+{
+  this->AppLogic = nullptr;
+}
 
 //-----------------------------------------------------------------------------
 qSlicerWidget::qSlicerWidget(QWidget * _parent, Qt::WindowFlags f)
   :QWidget(_parent, f)
-  , d_ptr(new qSlicerWidgetPrivate)
+  , d_ptr(new qSlicerWidgetPrivate(*this))
 {
 }
 
 //-----------------------------------------------------------------------------
 qSlicerWidget::~qSlicerWidget() = default;
 
-//-----------------------------------------------------------------------------
-//CTK_SET_CPP(qSlicerWidget, vtkSlicerApplicationLogic*, setAppLogic, AppLogic);
-//CTK_GET_CPP(qSlicerWidget, vtkSlicerApplicationLogic*, appLogic, AppLogic);
 //-----------------------------------------------------------------------------
 
 void qSlicerWidget::setMRMLScene(vtkMRMLScene* scene)
@@ -55,4 +69,18 @@ void qSlicerWidget::setMRMLScene(vtkMRMLScene* scene)
     {
     emit mrmlSceneChanged(scene);
     }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerWidget::setAppLogic(vtkSlicerApplicationLogic* logic)
+{
+  Q_D(qSlicerWidget);
+  d->AppLogic = logic;
+}
+
+//-----------------------------------------------------------------------------
+vtkSlicerApplicationLogic* qSlicerWidget::appLogic()const
+{
+  Q_D(const qSlicerWidget);
+  return d->AppLogic;
 }

--- a/Base/QTGUI/qSlicerWidget.h
+++ b/Base/QTGUI/qSlicerWidget.h
@@ -32,6 +32,7 @@
 #include "qSlicerBaseQTGUIExport.h"
 
 class vtkMRMLScene;
+class vtkSlicerApplicationLogic;
 class QScrollArea;
 class qSlicerWidgetPrivate;
 
@@ -42,6 +43,10 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerWidget : public QWidget, public virtual 
 public:
   qSlicerWidget(QWidget *parent=nullptr, Qt::WindowFlags f=nullptr);
   ~qSlicerWidget() override;
+
+  // Set the application logic to be used inside widgets
+  void setAppLogic(vtkSlicerApplicationLogic* applicationLogic);
+  vtkSlicerApplicationLogic* appLogic()const;
 
 public slots:
   void setMRMLScene(vtkMRMLScene* scene) override;

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -235,6 +235,19 @@ public:
   /// Requests the application to show user interface for editing a node.
   virtual void EditNode(vtkMRMLNode* node);
 
+  /// Sets a module with its corresponding logic to the application logic.
+  /// \param moduleName name of the module.
+  /// \param moduleLogic pointer to logic to be associated to the module. If this
+  /// parameter is nullptr, then the module logic will be removed from the application
+  /// logic.
+  void SetModuleLogic(const char* moduleName, vtkMRMLAbstractLogic* moduleLogic);
+
+  /// Gets a constant pointer to module logic associated with a given module
+  /// \param moduleName name of the module associated to the logic
+  /// \return constant pointer to vtkMRMLAbstractLogic corresponding to the
+  /// logic associated to th logic
+  vtkMRMLAbstractLogic* GetModuleLogic(const char* moduleName) const;
+
 protected:
 
   vtkMRMLApplicationLogic();

--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
@@ -71,12 +71,6 @@ public:
   vtkTypeMacro(vtkSlicerCropVolumeLogic,vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  void SetVolumesLogic(vtkSlicerVolumesLogic* logic);
-  vtkSlicerVolumesLogic* GetVolumesLogic();
-
-  void SetResampleLogic(vtkSlicerCLIModuleLogic* logic);
-  vtkSlicerCLIModuleLogic* GetResampleLogic();
-
   /// Crop input volume using the specified ROI node.
   int Apply(vtkMRMLCropVolumeParametersNode*);
 

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModule.cxx
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModule.cxx
@@ -88,35 +88,6 @@ QStringList qSlicerCropVolumeModule::dependencies()const
 void qSlicerCropVolumeModule::setup()
 {
   this->Superclass::setup();
-
-  vtkSlicerCropVolumeLogic* cropVolumeLogic =
-    vtkSlicerCropVolumeLogic::SafeDownCast(this->logic());
-
-  qSlicerAbstractCoreModule* volumesModule =
-    qSlicerCoreApplication::application()->moduleManager()->module("Volumes");
-  if (volumesModule)
-    {
-    vtkSlicerVolumesLogic* volumesLogic =
-      vtkSlicerVolumesLogic::SafeDownCast(volumesModule->logic());
-    cropVolumeLogic->SetVolumesLogic(volumesLogic);
-    }
-  else
-    {
-    qWarning() << "Volumes module is not found";
-    }
-
-  qSlicerAbstractCoreModule* resampleModule =
-    qSlicerCoreApplication::application()->moduleManager()->module("ResampleScalarVectorDWIVolume");
-  if (resampleModule)
-    {
-    vtkSlicerCLIModuleLogic* resampleLogic =
-      vtkSlicerCLIModuleLogic::SafeDownCast(resampleModule->logic());
-    cropVolumeLogic->SetResampleLogic(resampleLogic);
-    }
-  else
-    {
-    qWarning() << "ResampleScalarVectorDWIVolume module is not found";
-    }
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Data/qSlicerDataModule.cxx
+++ b/Modules/Loadable/Data/qSlicerDataModule.cxx
@@ -17,6 +17,8 @@
   and was partially funded by NIH grant 3P41RR013218-12S1
 
 ==============================================================================*/
+// Qt includes
+#include <QDebug>
 
 // Slicer includes
 #include "qSlicerApplication.h"
@@ -48,7 +50,6 @@
 //-----------------------------------------------------------------------------
 class qSlicerDataModulePrivate
 {
-public:
 };
 
 //-----------------------------------------------------------------------------
@@ -85,12 +86,19 @@ QStringList qSlicerDataModule::dependencies() const
 //-----------------------------------------------------------------------------
 void qSlicerDataModule::setup()
 {
+  Q_D(const qSlicerDataModule);
+
   this->Superclass::setup();
 
-  qSlicerAbstractCoreModule* camerasModule =
-    qSlicerCoreApplication::application()->moduleManager()->module("Cameras");
   vtkSlicerCamerasModuleLogic* camerasLogic =
-    vtkSlicerCamerasModuleLogic::SafeDownCast(camerasModule ? camerasModule->logic() : nullptr);
+    vtkSlicerCamerasModuleLogic::SafeDownCast(this->appLogic()->GetModuleLogic("Cameras"));
+  // NOTE: here we assume that camerasLogic with a nullptr value can be passed
+  // to the qSlicerSceneReader. Therefore we trigger a warning but don't return
+  // immediately.
+  if (!camerasLogic)
+    {
+    qCritical() << Q_FUNC_INFO << ": Cameras module is not found";
+    }
 
   qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
 

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.h
@@ -427,10 +427,6 @@ public:
   static void GenerateMergedLabelmapInReferenceGeometry(vtkMRMLSegmentationNode* segmentationNode, vtkMRMLVolumeNode* referenceVolumeNode,
     vtkStringArray* segmentIDs, int extentComputationMode, vtkOrientedImageData* mergedLabelmap_Reference);
 
-public:
-  /// Set Terminologies module logic
-  void SetTerminologiesLogic(vtkSlicerTerminologiesModuleLogic* terminologiesLogic);
-
 protected:
   void SetMRMLSceneInternal(vtkMRMLScene * newScene) override;
 
@@ -463,9 +459,6 @@ protected:
 
   /// Command handling subject hierarchy UID added events
   vtkCallbackCommand* SubjectHierarchyUIDCallbackCommand;
-
-  /// Terminologies module logic
-  vtkSlicerTerminologiesModuleLogic* TerminologiesLogic{nullptr};
 
 private:
   vtkSlicerSegmentationsModuleLogic(const vtkSlicerSegmentationsModuleLogic&) = delete;

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
@@ -209,39 +209,14 @@ void qSlicerSegmentationsModule::setup()
 qSlicerAbstractModuleRepresentation* qSlicerSegmentationsModule::createWidgetRepresentation()
 {
   qSlicerSegmentationsModuleWidget* moduleWidget = new qSlicerSegmentationsModuleWidget();
-
-  qSlicerAbstractCoreModule* terminologiesModule = qSlicerCoreApplication::application()->moduleManager()->module("Terminologies");
-  if (terminologiesModule)
-    {
-    vtkSlicerTerminologiesModuleLogic* terminologiesLogic = vtkSlicerTerminologiesModuleLogic::SafeDownCast(terminologiesModule->logic());
-    moduleWidget->setTerminologiesLogic(terminologiesLogic);
-    }
-  else
-    {
-    qCritical() << Q_FUNC_INFO << ": Terminologies module is not found";
-    } 
-
+  moduleWidget->setAppLogic(this->appLogic());
   return moduleWidget;
 }
 
 //-----------------------------------------------------------------------------
 vtkMRMLAbstractLogic* qSlicerSegmentationsModule::createLogic()
 {
-  vtkSlicerSegmentationsModuleLogic* moduleLogic = vtkSlicerSegmentationsModuleLogic::New();
-
-  qSlicerAbstractCoreModule* terminologiesModule = qSlicerCoreApplication::application()->moduleManager()->module("Terminologies");
-  if (terminologiesModule)
-    {
-    vtkSlicerTerminologiesModuleLogic* terminologiesLogic = vtkSlicerTerminologiesModuleLogic::SafeDownCast(terminologiesModule->logic());
-    moduleLogic->SetTerminologiesLogic(terminologiesLogic);
-    }
-  else
-    {
-    qCritical() << Q_FUNC_INFO << ": Terminologies module is not found";
-    } 
-
-  return moduleLogic;
-
+  return vtkSlicerSegmentationsModuleLogic::New();
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -19,6 +19,7 @@
 ==============================================================================*/
 
 // Segmentations includes
+#include "Logic/vtkSlicerSegmentationsModuleLogic.h"
 #include "qMRMLSortFilterSegmentsProxyModel.h"
 #include "qSlicerSegmentationsModuleWidget.h"
 #include "ui_qSlicerSegmentationsModule.h"
@@ -77,9 +78,6 @@ public:
   ///   QMRMLCombobox selects the first instance of the specified node type when initializing
   bool ModuleWindowInitialized;
 
-  /// Terminologies module logic
-  vtkSlicerTerminologiesModuleLogic* TerminologiesLogic;
-
   /// Import/export buttons
   QButtonGroup* ImportExportOperationButtonGroup;
   /// Model/labelmap buttons
@@ -93,7 +91,6 @@ public:
 qSlicerSegmentationsModuleWidgetPrivate::qSlicerSegmentationsModuleWidgetPrivate(qSlicerSegmentationsModuleWidget& object)
   : q_ptr(&object)
   , ModuleWindowInitialized(false)
-  , TerminologiesLogic(nullptr)
   , ImportExportOperationButtonGroup(nullptr)
   , ImportExportTypeButtonGroup(nullptr)
 {
@@ -113,15 +110,20 @@ qSlicerSegmentationsModuleWidgetPrivate::logic() const
 //-----------------------------------------------------------------------------
 void qSlicerSegmentationsModuleWidgetPrivate::populateTerminologyContextComboBox()
 {
+  Q_Q(const qSlicerWidget);
+
   this->ComboBox_TerminologyContext->clear();
 
-  if (!this->TerminologiesLogic)
+  vtkSlicerTerminologiesModuleLogic* terminologiesLogic =
+    vtkSlicerTerminologiesModuleLogic::SafeDownCast(q->appLogic()->GetModuleLogic("Terminologies"));
+  if (!terminologiesLogic)
     {
+    qCritical() << Q_FUNC_INFO << ": Terminologies module is not found";
     return;
     }
 
   std::vector<std::string> terminologyNames;
-  this->TerminologiesLogic->GetLoadedTerminologyNames(terminologyNames);
+  terminologiesLogic->GetLoadedTerminologyNames(terminologyNames);
   for (std::vector<std::string>::iterator termIt=terminologyNames.begin(); termIt!=terminologyNames.end(); ++termIt)
     {
     this->ComboBox_TerminologyContext->addItem(termIt->c_str());
@@ -1160,11 +1162,4 @@ void qSlicerSegmentationsModuleWidget::onSegmentationNodeReferenceChanged()
   d->label_ReferenceVolumeName->setText(referenceVolumeNode->GetName());
 
   d->MRMLNodeComboBox_ExportLabelmapReferenceVolume->setCurrentNode(referenceVolumeNode);
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerSegmentationsModuleWidget::setTerminologiesLogic(vtkSlicerTerminologiesModuleLogic* logic)
-{
-  Q_D(qSlicerSegmentationsModuleWidget);
-  d->TerminologiesLogic = logic;
 }

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.h
@@ -38,7 +38,6 @@ class vtkMRMLSegmentationDisplayNode;
 class vtkMRMLSubjectHierarchyNode;
 class vtkMRMLNodeReference;
 class vtkMRMLNode;
-class vtkSlicerTerminologiesModuleLogic;
 class QItemSelection;
 class Ui_qSlicerSegmentationsModule;
 
@@ -59,9 +58,6 @@ public:
 
   /// Support of node editing. Selects node in user interface that the user wants to edit
   bool setEditedNode(vtkMRMLNode* node, QString role=QString(), QString context=QString()) override;
-
-  /// Set Terminologies module logic
-  void setTerminologiesLogic(vtkSlicerTerminologiesModuleLogic* logic);
 
 public slots:
   /// Update widget GUI from parameter node

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -421,23 +421,6 @@ void vtkSlicerVolumesLogic::ProcessMRMLNodesEvents(vtkObject *vtkNotUsed(caller)
 }
 
 //----------------------------------------------------------------------------
-void vtkSlicerVolumesLogic::SetColorLogic(vtkMRMLColorLogic *colorLogic)
-{
-  if (this->ColorLogic == colorLogic)
-    {
-    return;
-    }
-  this->ColorLogic = colorLogic;
-  this->Modified();
-}
-
-//----------------------------------------------------------------------------
-vtkMRMLColorLogic* vtkSlicerVolumesLogic::GetColorLogic()const
-{
-  return this->ColorLogic;
-}
-
-//----------------------------------------------------------------------------
 void vtkSlicerVolumesLogic::SetActiveVolumeNode(vtkMRMLVolumeNode *activeNode)
 {
   vtkSetMRMLNodeMacro(this->ActiveVolumeNode, activeNode);
@@ -454,9 +437,12 @@ void vtkSlicerVolumesLogic
 ::SetAndObserveColorToDisplayNode(vtkMRMLDisplayNode * displayNode,
                                   int labelMap, const char* filename)
 {
-  vtkMRMLColorLogic * colorLogic = this->GetColorLogic();
+  vtkMRMLColorLogic* colorLogic =
+    vtkMRMLColorLogic::SafeDownCast(this->GetMRMLApplicationLogic()->GetModuleLogic("Colors"));
+
   if (colorLogic == nullptr)
     {
+    vtkErrorMacro("SetAndObserveColorToDisplayNode: invalid Colors module logic.");
     return;
     }
   if (labelMap)

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
@@ -85,9 +85,6 @@ public:
   /// initialize the storage node with the "options".
   typedef ArchetypeVolumeNodeSet (*ArchetypeVolumeNodeSetFactory)(std::string& volumeName, vtkMRMLScene* scene, int options);
 
-  virtual void SetColorLogic(vtkMRMLColorLogic* colorLogic);
-  vtkMRMLColorLogic* GetColorLogic()const;
-
   /// Examine the file name to see if the extension is one of the supported
   /// freesurfer volume formats. Used to assign the proper colour node to label maps.
   int IsFreeSurferVolume(const char* filename);
@@ -318,8 +315,6 @@ protected:
 
 protected:
   vtkSmartPointer<vtkMRMLVolumeNode> ActiveVolumeNode;
-
-  vtkSmartPointer<vtkMRMLColorLogic> ColorLogic;
 
   NodeSetFactoryRegistry VolumeRegistry;
 

--- a/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
@@ -17,6 +17,7 @@
   and was partially funded by NIH grant 3P41RR013218-12S1
 
 ==============================================================================*/
+#include <QDebug>
 
 // Slicer includes
 #include <qSlicerCoreApplication.h>
@@ -124,16 +125,9 @@ QStringList qSlicerVolumesModule::dependencies() const
 void qSlicerVolumesModule::setup()
 {
   this->Superclass::setup();
+
   vtkSlicerVolumesLogic* volumesLogic =
     vtkSlicerVolumesLogic::SafeDownCast(this->logic());
-  qSlicerAbstractCoreModule* colorsModule =
-    qSlicerCoreApplication::application()->moduleManager()->module("Colors");
-  if (colorsModule)
-    {
-    vtkMRMLColorLogic* colorLogic =
-      vtkMRMLColorLogic::SafeDownCast(colorsModule->logic());
-    volumesLogic->SetColorLogic(colorLogic);
-    }
 
   qSlicerCoreIOManager* ioManager =
     qSlicerCoreApplication::application()->coreIOManager();


### PR DESCRIPTION
The purpose of this PR is to frame the discussion around improving the exposure of `vtkSlicerModuleLogics` to other Slicer components (e.g., displayable managers) through `vtkMRMLApplicationLogic`. A discussion on this can be found in [https://discourse.slicer.org/t/improving-the-exposure-of-vtkslicermodulelogic-s-to-other-components/15375](https://discourse.slicer.org/t/improving-the-exposure-of-vtkslicermodulelogic-s-to-other-components/15375)

The following changes are proposed:

- Add module logic registration/unregistration methods, as well as query methods in `vtkMRMLApplicationLogic`. Unit testing has been added.
- Use registration/unregistration methods in `qSlicerModuleFactoryManager` for automatic registration of module logics on registration/unregistration of modules.
- `qSlicerWidget` has been extended to hold a pointer to the application logic. In this way, `qSlicerWidgets` can have access to all modules logics.
- Different modules have been undergoing a minor refactoring to exploit this new mechanics in favor to the former way. Note that this does not mean any change in the old API (it is till available and unchanged), but the new code is shorter and more tidy.