### PR TITLE
ENH: Removing unneeded code from Models module

### DIFF
--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.cxx
@@ -8,7 +8,6 @@
 =========================================================================auto=*/
 
 /// Slicer logic includes
-#include "vtkSlicerColorLogic.h"
 #include "vtkSlicerModelsLogic.h"
 #include "vtkMRMLSliceLogic.h"
 
@@ -41,23 +40,12 @@
 #include <cassert>
 
 vtkStandardNewMacro(vtkSlicerModelsLogic);
-vtkCxxSetObjectMacro(vtkSlicerModelsLogic, ColorLogic, vtkMRMLColorLogic);
 
 //----------------------------------------------------------------------------
-vtkSlicerModelsLogic::vtkSlicerModelsLogic()
-{
-  this->ColorLogic = nullptr;
-}
+vtkSlicerModelsLogic::vtkSlicerModelsLogic()=default;
 
 //----------------------------------------------------------------------------
-vtkSlicerModelsLogic::~vtkSlicerModelsLogic()
-{
-  if (this->ColorLogic != nullptr)
-    {
-    this->ColorLogic->Delete();
-    this->ColorLogic = nullptr;
-    }
-}
+vtkSlicerModelsLogic::~vtkSlicerModelsLogic()=default;
 
 //----------------------------------------------------------------------------
 void vtkSlicerModelsLogic::SetMRMLSceneInternal(vtkMRMLScene* newScene)
@@ -389,13 +377,7 @@ int vtkSlicerModelsLogic::SaveModel (const char* filename, vtkMRMLModelNode *mod
 void vtkSlicerModelsLogic::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->vtkObject::PrintSelf(os, indent);
-
   os << indent << "vtkSlicerModelsLogic:             " << this->GetClassName() << "\n";
-  if (this->ColorLogic)
-    {
-    os << indent << "ColorLogic: ";
-    this->ColorLogic->PrintSelf(os, indent);
-    }
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.h
+++ b/Modules/Loadable/Models/Logic/vtkSlicerModelsLogic.h
@@ -41,11 +41,6 @@ class VTK_SLICER_MODELS_MODULE_LOGIC_EXPORT vtkSlicerModelsLogic
   vtkTypeMacro(vtkSlicerModelsLogic, vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  /// The color logic is used to retrieve the default color node ID for
-  /// model nodes.
-  virtual void SetColorLogic(vtkMRMLColorLogic* colorLogic);
-  vtkGetObjectMacro(ColorLogic, vtkMRMLColorLogic);
-
   /// Add into the scene a new mrml model node with an existing polydata
   /// A display node is also added into the scene.
   ///param polyData surface mesh in RAS coordinate system.
@@ -100,10 +95,6 @@ protected:
   void ObserveMRMLScene() override;
 
   void OnMRMLSceneEndImport() override;
-
-  /// Color logic
-  vtkMRMLColorLogic* ColorLogic;
-
 };
 
 #endif

--- a/Modules/Loadable/Models/qSlicerModelsModule.cxx
+++ b/Modules/Loadable/Models/qSlicerModelsModule.cxx
@@ -137,14 +137,6 @@ void qSlicerModelsModule::setup()
     vtkSlicerModelsLogic::SafeDownCast(this->logic());
   if (qSlicerApplication::application())
     {
-    qSlicerAbstractCoreModule* colorsModule =
-      qSlicerCoreApplication::application()->moduleManager()->module("Colors");
-    if (colorsModule)
-      {
-      vtkMRMLColorLogic* colorLogic =
-        vtkMRMLColorLogic::SafeDownCast(colorsModule->logic());
-      modelsLogic->SetColorLogic(colorLogic);
-      }
     // Register IOs
     qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
     ioManager->registerIO(new qSlicerModelsReader(modelsLogic, this));


### PR DESCRIPTION
In this PR some code that seems to be not needed is removed. I found out that the Models has some functionality to keep a copy of the Colors module logic. Similar functionality found in other modules which make use of the logic they hold, however, the Models module does not seem to make any use of it. 

Removing all this functionality does not seem to break anything. There is a small change on the API (set/get functions for colors logic in ModelsLogic are removed). To me, it seems unlikely that any other module would want obtain a pointer to Colors logic through the Models logic; there are much better ways.