### PR TITLE
ENH: Update VTK from 9.0.20201111 to 9.0.20210108, sqlite from 3.30 to 3.33

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -177,8 +177,8 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "106104086f5fd15bfe613bf534565dc0e77659ae") # slicer-v9.0.20201111-733234c785
-    set(vtk_egg_info_version "9.0.20201111")
+    set(_git_tag "5943662f2f77b6131128fe8c05c3301d299392d5") # slicer-v9.0.20210108-e722237c1a
+    set(vtk_egg_info_version "9.0.20210108")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
   endif()

--- a/SuperBuild/External_sqlite.cmake
+++ b/SuperBuild/External_sqlite.cmake
@@ -28,7 +28,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "3.30.1"
+    "3.33.0"
     QUIET
     )
 


### PR DESCRIPTION

----
List of sqlite changes:

```
$ git shortlog 3.30.1..3.33.0 --no-merges
Amir Zamani (6):
      update recommended compile options
      update to 3031000 (3.31.0)
      update to 3031001 (3.31.1)
      refactor cmake
      update to 3032003 (3.32.3)
      update to 3033000 (3.33.0)

Anton Dyachenko (1):
      Make config file compatible with FindSQLite3 provided by cmake
```

----
List of VTK changes:

```
$ git shortlog 106104086..5943662f2 --no-merges
Adrien Boucaud (2):
      ENH: Add volume export functionality to vtkJSONSceneExporter
      ENH: Improve VolumeProperty export to .vtkjs

Andras Lasso (1):
      Prevent vtkDebugLeaks from polluting process output if no leaks are found

Andrew Bauer (1):
      Make protected setter method public

Andrew Maclean (4):
      Moving links to the new vtk-examples site
      Improving the documentation
      Adding links to VTK Examples and the textbook
      Change http to https

Ben Boeckel (9):
      sqlite: update to 3.33.0
      numpy_interface/algorithms: use `== 1` instead of `is 1`
      vtkModuleTesting: set PROCESSORS property for Python MPI tests
      ioss: update for MPI fixes
      vtkFreeTypeTools: avoid using an internal macro
      vtkFontConfigFreeTypeTools: remove last FT_CALLBACK_DEF usage
      pugixml: add support for 1.11
      vtkModule: add missing docs for `v_m_third_party_external(TARGETS)`
      vtkSocketCommunicator: avoid hash differences based on platform

Berk Geveci (1):
      Minor fix to TestParallelNumpy.

Cory Quammen (5):
      TestVortexCore: add output dataset verification to test
      Fix point data arrays in output data
      Move counter index check to avoid invalid read
      vtkVortexCore: fix integer type comparison warning
      Move computation of parent directory outside for loop

David E. DeMarle (8):
      Plug a bad leak in time varying animation
      Fix multicomponent image data volume rendering with OSPRay
      add newly added function to VisRTX backend too
      fix crash when ray trace molecule data that has no bonds
      fix progressive refinement start with ospray ray cast render
      be more consistent and release only after commit
      plug memory leaks in ospray structured volume mapper
      let ray tracers respect server side widget visibility again

David Gobbi (2):
      Rename wrapper function name to fix warning
      Rename wrapper function name to fix warning

Jean-Christophe Fillion-Robin (4):
      COMP: Associate "all.py" install rule with "python" component
      COMP: Remove vtk-m submodule
      COMP: Remove FindTBB and expect VTK to be configured with TBB_DIR
      BUG: Update vtkPythonUtil to disable relative import causing crash for Slicer modules

Julien Schueller (1):
      vtkModule: Ignore missing targets

Jérôme Dubois (1):
      Testing bbox larger than dataset and fix min coords

Ken Martin (6):
      Fix three issues with picking on large datasets
      Report when program exceeds texture buffer limit
      Turn off multisamples on intel OSX
      Fix point picking with render points as spheres
      Fix three issues with picking on large datasets
      Fix point picking with render points as spheres

Kitware Robot (58):
      VTK Nightly Date Stamp
      [...]

Mark Olesen (9):
      openfoam: support reading of internal dimensioned fields
      openfoam: handle '#sinclude' directive (silent include)
      openfoam: handle '<case>', '<constant>, '<system>' tags
      openfoam: remove special handling of uniformFixedValue
      openfoam: mark constants with constexpr
      openfoam: extract object names directly from the filenames
      openfoam: add release documentation
      openfoam: provision for skipping OpenFOAM "_0" restart files
      openfoam: add DimensionedField test

Mathieu Westphal (2):
      Adding an update data event to the GLTFImporter
      Fix a segfault in probe filter when there is no cells

Michael Migliore (3):
      Add OBJ importer vertex coloring
      Fix OBJ importer
      Allow Win32 output window custom title

Mickael PHILIT (3):
      Add cgns ThirdParty library
      Add CGNS test data
      Add FindCGNS.cmake

Mickael Philit (1):
      Import CGNS reader from ParaView

Nicolas Vuaille (1):
      Handle double precision for atom position

Paul Lafoix (6):
      Do not hide border if show border is on
      Add method ResetCloseToData in Renderer
      Multiline and multicolumn support of MatplotlibMathText
      Change default line spacing from 1.1 to 1.0
      Copy cell offset attribute in text property
      Remove unused include in MatplotlibMathTextUtilities

Peter Franz (11):
      Fix vtkChartXY::RecalculatePlotBounds() for plots containing NANs.
      Add IgnoreNanInBounds flag for vtkChartXY.
      Add Get/Set/Boolean macro for IgnoreNanInBounds.
      Bugfix vtkLine::Intersection for parallel lines
      Use previous, more relaxed criterion for line intersection tolerance
      Add user-definable tolerance to arguments of vtkLine::Intersection
      reformatting
      Merge branch 'bugfix-vtkLine-intersection-parallel-lines' of https://gitlab.kitware.com/drpeterfranz/vtk into bugfix-vtkLine-intersection-parallel-lines
      Set tolerance in vtkLine::IntersectWithLine
      Add std::finite() check to tolerance to prevent SIGFPE exceptions.
      Implement GEPP method for solving 2x2 linear systems.

Roxana Bujack (2):
      add .md to explain the changes in the enum type
      integrationDirection can now be set to BOTH

Sankhesh Jhaveri (16):
      Fix Windows Graphics Resource leak with custom cursor
      Ensure depth function is GL_LEQUAL in Qt widgets
      Fix the 2D mapper foreground/background transform to ignore Z values
      Initialize the opengl state with proper depth function in QVTK widgets
      Update the vtkTexture API for wrapping
      Release note for vtkTexture API change
      Fix dashboard issue with context drawing
      Update release note with migration guide to new API
      Defer the OpenGL version checking to vtkOpenGLTexture
      Add test for texture wrap methods
      Report test failure on vtkErrorMacro use with loguru
      Silence output window errors and warnings when observer attached
      Fix no active camera error in widget tests
      [Backport MR-7880] Simplify coincident topology resolution
      [Backport MR-7480] Update coincident topology baselines
      [Backport MR-7480] Ignore Z values for 2D polydata mapper when transform to view space

Seacas Upstream (3):
      ioss 2020-11-17 (22addbf4)
      ioss 2020-11-18 (02900268)
      ioss 2020-11-24 (e6b06185)

Sean McBride (10):
      Fixed #18047: modified Cocoa drawRect: to push/pop OpenGLState before Render
      Suppress warnings from ThirdParty macro expansions into Xcode headers
      Issue #17740: add std:: namespace to calls to abs()
      Removed a 21 year old workaround for old HP systems, surely irrelevent now
      Removed reference to non-existant vtkMutexVariable
      Replaced vtkCriticalSection, vtkMutexLock, vtkConditionVariable with STL
      Fixed qsort compare function to return zero when numbers are equal
      Fixed out-of-bounds NSArray access by checking index first
      Updated netcdf tag to for/vtk-20201116-4.7.4
      Removed dead code and updated cppcheck suppressions for v2.3

Sebastien Jourdain (1):
      VTKWeb: Fix vtkWebPublishImageDelivery

Seun Odutola (2):
      Layer-backed macOS applications shouldn't override the rendering context.
      Layer-backed macOS applications shouldn't override the rendering context.

Timo Niemi (1):
      Fix Issue #12322 in vtkOpenFOAMReader

Timothee Chabat (3):
      Solve bug in vtkJSONDataSetWriter
      Add python for bundling mulitple folder as a single vtk.js archive
      Migrate vtkJSONSceneExporter index.json file syntax

Utkarsh Ayachit (17):
      ioss: mangle `fmt`
      vtkMultiBlockPLOT3DReader: auto-detection issues
      netcdf: detect parallel-support
      tpl: update ioss for MPI-awareness fixes
      FindNetCDF: fix regex and mangle function.
      vtkCompositeDataSet: copy-structure fixes
      Fix issues with vtkArrayListTemplate use.
      vtkTimerLog: use Schwarz counter
      Update rectilinear volume rendering test
      vtkVolumeTexture: upload coords even when HandleLargeDataTypes is true.
      vtkSmartVolumeMapper: avoid segfault when array is missing.
      update optix baseline.
      vtkDataObjectTree: fix shallow-copy bug
      vtkDataObjectTree: fix shallow-copy bug
      vtkProbeFilter: correctly handle input ghost cells.
      IOSS: preserve output structure
      Ioss: add support for reading assemblies.

Vicente Adolfo Bolea Sanchez (3):
      VTKm: Updates submodule commit to latest master
      OpenGLRenderWindow: hide xutil include
      vtkmClip: reduce compilation memory overhead

Will Schroeder (9):
      Removed static instantiations of class to ensure thread safety
      Added new filter to clip vtkPolyData with a plane
      Performance improvements
      Handle multiple manifold loops
      Support for multiple loops; point and cell data
      vtkCellLinks::BuildLinks() was causing segfault
      Control number of warning messages
      Removed unused variables
      Added fast path for non-categorical data.

cgns Upstream (1):
      cgns 2020-12-01 (c341593d)

netcdf Upstream (1):
      netcdf 2020-11-16 (3fd31153)

roxana bujack (3):
      add more detailed type to critical points to indicate sprialling behavior
      add underscores and remove unused variable
      update test image

sqlite Upstream (1):
      sqlite 2020-11-11 (e875cf65)
```