### PR TITLE
BUG: Fix crash when creating qSlicerMarkupsPlaceWidget and qSlicerSim…

### DIFF
--- a/Applications/SlicerApp/Testing/Cpp/qSlicerModuleFactoryManagerTest1.cxx
+++ b/Applications/SlicerApp/Testing/Cpp/qSlicerModuleFactoryManagerTest1.cxx
@@ -24,9 +24,10 @@
 #include <qSlicerModuleFactoryManager.h>
 #include <qSlicerCoreModuleFactory.h>
 #include <qSlicerCoreApplication.h>
+#include <vtkSlicerApplicationLogic.h>
 
-// STD includes
-
+// VTK includes
+#include <vtkNew.h>
 
 int qSlicerModuleFactoryManagerTest1(int argc, char * argv[])
 {
@@ -34,6 +35,9 @@ int qSlicerModuleFactoryManagerTest1(int argc, char * argv[])
   Q_UNUSED(app);
 
   qSlicerModuleFactoryManager moduleFactoryManager;
+
+  vtkNew<vtkSlicerApplicationLogic> appLogic;
+  moduleFactoryManager.setAppLogic(appLogic);
 
   // Register factories
   moduleFactoryManager.registerFactory(new qSlicerCoreModuleFactory());

--- a/Base/Logic/vtkSlicerModuleLogic.cxx
+++ b/Base/Logic/vtkSlicerModuleLogic.cxx
@@ -32,6 +32,18 @@ vtkSlicerApplicationLogic* vtkSlicerModuleLogic::GetApplicationLogic()
 }
 
 //----------------------------------------------------------------------------
+vtkMRMLAbstractLogic* vtkSlicerModuleLogic::GetModuleLogic(const char* moduleName)
+{
+  vtkMRMLApplicationLogic* appLogic =
+    vtkMRMLApplicationLogic::SafeDownCast(this->GetMRMLApplicationLogic());
+  if (!appLogic)
+    {
+    return nullptr;
+    }
+  return appLogic->GetModuleLogic(moduleName);
+}
+
+//----------------------------------------------------------------------------
 std::string vtkSlicerModuleLogic::GetModuleShareDirectory()const
 {
   return this->ModuleShareDirectory;

--- a/Base/Logic/vtkSlicerModuleLogic.h
+++ b/Base/Logic/vtkSlicerModuleLogic.h
@@ -33,6 +33,9 @@ public:
   virtual vtkSlicerApplicationLogic* GetApplicationLogic();
   //TODO virtual void SetApplicationLogic(vtkSlicerApplicationLogic* logic);
 
+  /// Convenience method for getting another module's logic from the application logic.
+  virtual vtkMRMLAbstractLogic* GetModuleLogic(const char* moduleName);
+
   std::string GetModuleShareDirectory()const;
   void SetModuleShareDirectory(const std::string& shareDirectory);
 

--- a/Base/QTCore/qSlicerAbstractCoreModule.cxx
+++ b/Base/QTCore/qSlicerAbstractCoreModule.cxx
@@ -193,6 +193,16 @@ void qSlicerAbstractCoreModule::setAppLogic(vtkSlicerApplicationLogic* newAppLog
 CTK_GET_CPP(qSlicerAbstractCoreModule, vtkSlicerApplicationLogic*, appLogic, AppLogic);
 
 //-----------------------------------------------------------------------------
+vtkMRMLAbstractLogic* qSlicerAbstractCoreModule::moduleLogic(const QString& moduleName) const
+{
+  if (!this->appLogic())
+    {
+    return nullptr;
+    }
+  return this->appLogic()->GetModuleLogic(moduleName.toUtf8());
+}
+
+//-----------------------------------------------------------------------------
 bool qSlicerAbstractCoreModule::isHidden()const
 {
   return this->isWidgetRepresentationCreationEnabled() ? false : true;

--- a/Base/QTCore/qSlicerAbstractCoreModule.h
+++ b/Base/QTCore/qSlicerAbstractCoreModule.h
@@ -277,6 +277,9 @@ public:
   void setAppLogic(vtkSlicerApplicationLogic* appLogic);
   vtkSlicerApplicationLogic* appLogic() const;
 
+  /// Convenience method for getting another module's logic from appLogic.
+  vtkMRMLAbstractLogic* moduleLogic(const QString& moduleName) const;
+
   /// This method allows to get a pointer to the module logic.
   /// If no moduleLogic already exists, one will be created calling
   /// the 'createLogic' method.

--- a/Base/QTCore/qSlicerModuleFactoryManager.cxx
+++ b/Base/QTCore/qSlicerModuleFactoryManager.cxx
@@ -126,6 +126,12 @@ bool qSlicerModuleFactoryManager::loadModule(const QString& name, const QString&
     return false;
     }
 
+  if (!d->AppLogic)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: application logic must be set before loading modules";
+    return false;
+    }
+
   // A module should be registered when attempting to load it
   if (!this->isRegistered(name) ||
       !this->isInstantiated(name))

--- a/Base/QTGUI/qSlicerWidget.cxx
+++ b/Base/QTGUI/qSlicerWidget.cxx
@@ -23,6 +23,9 @@
 
 #include "qSlicerWidget.h"
 
+// Slicer includes
+#include <qSlicerApplication.h>
+
 // MRML includes
 #include <vtkSlicerApplicationLogic.h>
 
@@ -39,14 +42,12 @@ public:
   qSlicerWidgetPrivate(qSlicerWidget& object);
 
   QPointer<QWidget>                          ParentContainer;
-  vtkSlicerApplicationLogic*                 AppLogic;
 };
 
 //-----------------------------------------------------------------------------
 qSlicerWidgetPrivate::qSlicerWidgetPrivate(qSlicerWidget& object)
   : q_ptr(&object)
 {
-  this->AppLogic = nullptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -72,15 +73,24 @@ void qSlicerWidget::setMRMLScene(vtkMRMLScene* scene)
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerWidget::setAppLogic(vtkSlicerApplicationLogic* logic)
-{
-  Q_D(qSlicerWidget);
-  d->AppLogic = logic;
-}
-
-//-----------------------------------------------------------------------------
 vtkSlicerApplicationLogic* qSlicerWidget::appLogic()const
 {
   Q_D(const qSlicerWidget);
-  return d->AppLogic;
+  if (!qSlicerApplication::application())
+    {
+    return nullptr;
+    }
+  return qSlicerApplication::application()->applicationLogic();
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLAbstractLogic* qSlicerWidget::moduleLogic(const QString& moduleName)const
+{
+  Q_D(const qSlicerWidget);
+  vtkSlicerApplicationLogic* applicationLogic = this->appLogic();
+  if (!applicationLogic)
+    {
+    return nullptr;
+    }
+  return applicationLogic->GetModuleLogic(moduleName.toUtf8());
 }

--- a/Base/QTGUI/qSlicerWidget.h
+++ b/Base/QTGUI/qSlicerWidget.h
@@ -31,6 +31,7 @@
 #include "qSlicerObject.h"
 #include "qSlicerBaseQTGUIExport.h"
 
+class vtkMRMLAbstractLogic;
 class vtkMRMLScene;
 class vtkSlicerApplicationLogic;
 class QScrollArea;
@@ -44,9 +45,11 @@ public:
   qSlicerWidget(QWidget *parent=nullptr, Qt::WindowFlags f=nullptr);
   ~qSlicerWidget() override;
 
-  // Set the application logic to be used inside widgets
-  void setAppLogic(vtkSlicerApplicationLogic* applicationLogic);
+  // Convenience method for getting application logic from the application.
   vtkSlicerApplicationLogic* appLogic()const;
+
+  // Convenience method for getting a module logic from the application.
+  vtkMRMLAbstractLogic* moduleLogic(const QString& moduleName)const;
 
 public slots:
   void setMRMLScene(vtkMRMLScene* scene) override;

--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLApplicationLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLApplicationLogicTest1.cxx
@@ -87,8 +87,8 @@ int SliceLogicsTest()
     vtkMTimeType mtime = appLogic->GetMTime();
     vtkNew<vtkCollection> logics;
     logics->AddItem(vtkSmartPointer<vtkObject>::New());
-    appLogic->SetSliceLogics(logics.GetPointer());
-    CHECK_POINTER(appLogic->GetSliceLogics(), logics.GetPointer());
+    appLogic->SetSliceLogics(logics);
+    CHECK_POINTER(appLogic->GetSliceLogics(), logics);
     CHECK_INT(appLogic->GetSliceLogics()->GetNumberOfItems(), 1);
     CHECK_BOOL(appLogic->GetMTime() > mtime, true);
   }
@@ -104,14 +104,14 @@ int SliceLogicsTest()
   {
     vtkNew<vtkCollection> logics;
     logics->AddItem(vtkSmartPointer<vtkObject>::New());
-    appLogic->SetSliceLogics(logics.GetPointer());
+    appLogic->SetSliceLogics(logics);
   }
 
   // Set an empty collection.
   {
     vtkMTimeType mtime = appLogic->GetMTime();
     vtkNew<vtkCollection> logics;
-    appLogic->SetSliceLogics(logics.GetPointer());
+    appLogic->SetSliceLogics(logics);
     CHECK_NOT_NULL(appLogic->GetSliceLogics());
     CHECK_INT(appLogic->GetSliceLogics()->GetNumberOfItems(), 0);
     CHECK_BOOL(appLogic->GetMTime() > mtime, true);
@@ -138,7 +138,7 @@ int SliceOrientationPresetInitializationTest()
   {
     vtkNew<vtkMRMLScene> scene;
     vtkNew<vtkMRMLApplicationLogic> appLogic;
-    appLogic->SetMRMLScene(scene.GetPointer());
+    appLogic->SetMRMLScene(scene);
     vtkMRMLSliceNode * defaultSliceNode =
         vtkMRMLSliceNode::SafeDownCast(scene->GetDefaultNodeByClass("vtkMRMLSliceNode"));
     CHECK_INT(defaultSliceNode->GetNumberOfSliceOrientationPresets(), 3);
@@ -252,10 +252,9 @@ int AddModuleLogicTest()
   // Registration of a module logic should work
   {
     vtkNew<vtkMRMLAbstractLogic> moduleLogic;
-    appLogic->SetModuleLogic(module_name.c_str(), moduleLogic.GetPointer());
+    appLogic->SetModuleLogic(module_name.c_str(), moduleLogic);
 
-    CHECK_POINTER(appLogic->GetModuleLogic(module_name.c_str()),
-                  moduleLogic.GetPointer());
+    CHECK_POINTER(appLogic->GetModuleLogic(module_name.c_str()), moduleLogic);
   }
 
   // Getting a pointer to a logic that it is gone should give nullptr.
@@ -264,14 +263,11 @@ int AddModuleLogicTest()
     CHECK_NULL(appLogic->GetModuleLogic(module_name.c_str()));
   }
 
-  // Trying to register a module logic associated to an already registered module
-  // should trigger an error.
+  // Updating module logic with a new object can be useful for dynamic reloading of modules.
   {
     vtkNew<vtkMRMLAbstractLogic> moduleLogic;
-    TESTING_OUTPUT_ASSERT_WARNINGS_BEGIN();
-    appLogic->SetModuleLogic(module_name.c_str(), moduleLogic.GetPointer());
-    TESTING_OUTPUT_ASSERT_WARNINGS(1);
-    TESTING_OUTPUT_ASSERT_WARNINGS_END();
+    appLogic->SetModuleLogic(module_name.c_str(), moduleLogic);
+    CHECK_POINTER(appLogic->GetModuleLogic(module_name.c_str()), moduleLogic);
   }
 
   // Trying to get a logic that has not been registered should return nullptr
@@ -299,11 +295,13 @@ int AddModuleLogicTest()
     appLogic->SetModuleLogic((module_name+"a").c_str(), nullptr);
   }
 
-  // Removeing an already registered module logic should succeed
+  // Removing an already registered module logic should succeed
   {
     // Successfully removes module logic association
     appLogic->SetModuleLogic(module_name.c_str(), nullptr);
 
     const vtkMRMLAbstractLogic* retval = appLogic->GetModuleLogic((module_name).c_str());
   }
+
+  return EXIT_SUCCESS;
 }

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -834,22 +834,15 @@ void vtkMRMLApplicationLogic::SetModuleLogic(const char* moduleName,
     vtkErrorMacro("AddModuleLogic: invalid module name.");
     return;
     }
-
-  // If no logic is provided, erase the module-logic association.
-  if (!moduleLogic)
+  if (moduleLogic)
     {
+    this->Internal->ModuleLogicMap[moduleName] = moduleLogic;
+    }
+  else
+    {
+    // If no logic is provided, erase the module-logic association.
     this->Internal->ModuleLogicMap.erase(moduleName);
-    return;
     }
-
-  // Check that the module has not any registered logic.
-  if (this->Internal->ModuleLogicMap.count(moduleName))
-    {
-    vtkWarningMacro("AddModuleLogic: Logic already register for " << moduleName);
-    return;
-    }
-
-  this->Internal->ModuleLogicMap[moduleName] = moduleLogic;
 }
 
 //----------------------------------------------------------------------------
@@ -860,12 +853,10 @@ vtkMRMLAbstractLogic* vtkMRMLApplicationLogic::GetModuleLogic(const char* module
     vtkErrorMacro("GetModuleLogic: invalid module name");
     return nullptr;
     }
-
   //Check that the logic is registered.
   if (this->Internal->ModuleLogicMap.count(moduleName) == 0)
     {
     return nullptr;
     }
-
-  return this->Internal->ModuleLogicMap.at(moduleName);
+  return this->Internal->ModuleLogicMap[moduleName];
 }

--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.cxx
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.cxx
@@ -146,7 +146,7 @@ int vtkSlicerCropVolumeLogic::Apply(vtkMRMLCropVolumeParametersNode* pnode)
     {
 
     vtkSlicerVolumesLogic* volumesLogic =
-      vtkSlicerVolumesLogic::SafeDownCast(this->GetMRMLApplicationLogic()->GetModuleLogic("Volumes"));
+      vtkSlicerVolumesLogic::SafeDownCast(this->GetModuleLogic("Volumes"));
 
     // Create compatible output volume
     if (!volumesLogic)
@@ -401,7 +401,7 @@ int vtkSlicerCropVolumeLogic::CropInterpolated(vtkMRMLAnnotationROINode* roi, vt
     }
 
   vtkSlicerCLIModuleLogic* resampleLogic =
-    vtkSlicerCLIModuleLogic::SafeDownCast(this->GetMRMLApplicationLogic()->GetModuleLogic("ResampleScalarVectorDWIVolume"));
+    vtkSlicerCLIModuleLogic::SafeDownCast(this->GetModuleLogic("ResampleScalarVectorDWIVolume"));
   if (!resampleLogic)
     {
     vtkErrorMacro("CropVolume: resample logic is not set");

--- a/Modules/Loadable/Data/qSlicerDataModule.cxx
+++ b/Modules/Loadable/Data/qSlicerDataModule.cxx
@@ -91,7 +91,7 @@ void qSlicerDataModule::setup()
   this->Superclass::setup();
 
   vtkSlicerCamerasModuleLogic* camerasLogic =
-    vtkSlicerCamerasModuleLogic::SafeDownCast(this->appLogic()->GetModuleLogic("Cameras"));
+    vtkSlicerCamerasModuleLogic::SafeDownCast(this->moduleLogic("Cameras"));
   // NOTE: here we assume that camerasLogic with a nullptr value can be passed
   // to the qSlicerSceneReader. Therefore we trigger a warning but don't return
   // immediately.

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -1931,7 +1931,7 @@ bool vtkSlicerSegmentationsModuleLogic::SetTerminologyToSegmentationFromLabelmap
     }
 
   vtkSlicerTerminologiesModuleLogic* terminologiesLogic =
-    vtkSlicerTerminologiesModuleLogic::SafeDownCast(this->GetMRMLApplicationLogic()->GetModuleLogic("Terminologies"));
+    vtkSlicerTerminologiesModuleLogic::SafeDownCast(this->GetModuleLogic("Terminologies"));
   if (!terminologiesLogic)
     {
     vtkErrorMacro("SetTerminologyToSegmentationFromLabelmapNode: Terminology logic cannot be accessed");

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
@@ -209,7 +209,6 @@ void qSlicerSegmentationsModule::setup()
 qSlicerAbstractModuleRepresentation* qSlicerSegmentationsModule::createWidgetRepresentation()
 {
   qSlicerSegmentationsModuleWidget* moduleWidget = new qSlicerSegmentationsModuleWidget();
-  moduleWidget->setAppLogic(this->appLogic());
   return moduleWidget;
 }
 

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -115,7 +115,7 @@ void qSlicerSegmentationsModuleWidgetPrivate::populateTerminologyContextComboBox
   this->ComboBox_TerminologyContext->clear();
 
   vtkSlicerTerminologiesModuleLogic* terminologiesLogic =
-    vtkSlicerTerminologiesModuleLogic::SafeDownCast(q->appLogic()->GetModuleLogic("Terminologies"));
+    vtkSlicerTerminologiesModuleLogic::SafeDownCast(q->moduleLogic("Terminologies"));
   if (!terminologiesLogic)
     {
     qCritical() << Q_FUNC_INFO << ": Terminologies module is not found";

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -437,25 +437,23 @@ void vtkSlicerVolumesLogic
 ::SetAndObserveColorToDisplayNode(vtkMRMLDisplayNode * displayNode,
                                   int labelMap, const char* vtkNotUsed(filename))
 {
-  vtkMRMLColorLogic* colorLogic =
-    vtkMRMLColorLogic::SafeDownCast(this->GetMRMLApplicationLogic()->GetModuleLogic("Colors"));
-
+  if (displayNode->GetColorNodeID())
+    {
+    // only set default color node ID if it was not set already (by default volume node stored in the scene)
+    return;
+    }
+  vtkMRMLColorLogic* colorLogic = vtkMRMLColorLogic::SafeDownCast(this->GetModuleLogic("Colors"));
   if (colorLogic == nullptr)
     {
-    vtkErrorMacro("SetAndObserveColorToDisplayNode: invalid Colors module logic.");
+    vtkErrorMacro("SetAndObserveColorToDisplayNode failed: invalid Colors module logic.");
     return;
     }
   if (labelMap)
     {
-    if (displayNode->GetColorNodeID() == nullptr)
-      {
-      // only set default color node ID if it was not set already (by default volume node stored in the scene)
-      displayNode->SetAndObserveColorNodeID(colorLogic->GetDefaultLabelMapColorNodeID());
-      }
+    displayNode->SetAndObserveColorNodeID(colorLogic->GetDefaultLabelMapColorNodeID());
     }
-  else if (displayNode->GetColorNodeID() == nullptr)
+  else
     {
-    // only set default color node ID if it was not set already (by default volume node stored in the scene)
     displayNode->SetAndObserveColorNodeID(colorLogic->GetDefaultVolumeColorNodeID());
     }
 }

--- a/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
+++ b/Modules/Loadable/Volumes/Testing/Cxx/vtkSlicerVolumesLogicTest1.cxx
@@ -23,6 +23,7 @@
 #include "vtkMRMLCoreTestingMacros.h"
 
 // MRML includes
+#include <vtkMRMLColorLogic.h>
 #include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLScalarVolumeNode.h>
 #include <vtkMRMLScene.h>
@@ -63,7 +64,17 @@ int vtkSlicerVolumesLogicTest1( int argc, char * argv[] )
   itk::itkFactoryRegistration();
 
   vtkNew<vtkMRMLScene> scene;
+
+  vtkNew<vtkSlicerApplicationLogic> appLogic;
+
+  // Add Color logic (used by volumes logic)
+  vtkNew<vtkMRMLColorLogic> colorLogic;
+  colorLogic->SetMRMLScene(scene.GetPointer());
+  colorLogic->SetMRMLApplicationLogic(appLogic);
+  appLogic->SetModuleLogic("Colors", colorLogic);
+
   vtkNew<vtkSlicerVolumesLogic> logic;
+  logic->SetMRMLApplicationLogic(appLogic);
 
   if (argc < 2)
     {


### PR DESCRIPTION
…pleMarkupsWidget

Accessing the Markups module logic the way it was changed to did not work and lead to a crash. Since all the change to this class in the Markups module refactoring was related to accessing the Markups logic, it made sense to simply revert those changes.

Same applied to qSlicerSimpleMarkupsWidget.

Re https://github.com/Slicer/Slicer/issues/5385