### PR TITLE
COMP: Update python pip to latest

### DIFF
--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -26,7 +26,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
-  pip==20.2.4 --hash=sha256:51f1c7514530bd5c145d8f13ed936ad6b8bfcb8cf74e10403d0890bc986f0033
+  pip==20.3.3 --hash=sha256:fab098c8a1758295dd9f57413c199f23571e8fde6cc39c22c78c961b4ac6286d
   ]===])
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
This attempts to fix an issue originally reported at https://discourse.slicer.org/t/build-on-macos-11-fails-in-the-middle-after-building-vtkpython/15570/4.

Updating Pip to version 20.3 should fix the issue as the [release notes](https://pip.pypa.io/en/stable/news/#id15) mention "Add support for MacOS Big Sur compatibility tags." With the changes it appears that macos_10_9 type wheels will be accepted on the Big Sur macOS 11 platform.

It would then be able to pick [numpy-1.19.2-cp36-cp36m-macosx_10_9_x86_64.whl](https://pypi.org/project/numpy/1.19.2/#files) as a matching wheel instead of trying to pull the source zip and then it failing to match the hash since we specifically don't include the source zip since it will require many more dependencies.

cc: @piiq