### PR TITLE
ENH: Update CompareVolumes to improve layouts

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -336,7 +336,7 @@ list_conditional_append(Slicer_BUILD_DataStore Slicer_REMOTE_DEPENDENCIES DataSt
 
 Slicer_Remote_Add(CompareVolumes
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/pieper/CompareVolumes"
-  GIT_TAG c7a61fa65a96a95477d03053497733b860df669a
+  GIT_TAG 3b74d1fca03ced93f77f21d8873df43e1bfc2bf1
   OPTION_NAME Slicer_BUILD_CompareVolumes
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Previously 4 volumes were laid out in a 3x2 grid with empty
slots at the bottom so space was wasted.

Now 4 volumes are in a 2x2 and 6 volumes are in a 3x2 grid.


https://github.com/pieper/CompareVolumes/pull/11