### PR TITLE
COMP: Update qSlicerModelsModuleWidgetTest1 to fix build with Qt < 5.11

### DIFF
--- a/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest1.cxx
+++ b/Modules/Loadable/Models/Testing/Cxx/qSlicerModelsModuleWidgetTest1.cxx
@@ -85,7 +85,7 @@ int qSlicerModelsModuleWidgetTest1( int argc, char * argv[] )
   shModuleLogic->SetMRMLScene(scene);
   QScopedPointer<qSlicerSubjectHierarchyPluginLogic> pluginLogic(new qSlicerSubjectHierarchyPluginLogic());
   pluginLogic->setMRMLScene(scene);
-  qSlicerSubjectHierarchyPluginHandler::instance()->setPluginLogic(pluginLogic.get());
+  qSlicerSubjectHierarchyPluginHandler::instance()->setPluginLogic(pluginLogic.data());
   qSlicerSubjectHierarchyPluginHandler::instance()->setMRMLScene(scene);
 
   // Add a model node


### PR DESCRIPTION
Functions "data()" and "get()" are equivalent