### PR TITLE
ENH: Re-factor vtkMRMLSliceCompositeNode to use node references

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
@@ -46,35 +46,21 @@ class VTK_MRML_EXPORT vtkMRMLSliceCompositeNode : public vtkMRMLNode
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override {return "SliceComposite";}
 
-  /// Set the volumes as reference in the scene
-  void SetSceneReferences() override;
-
-  ///
-  /// Updates this node if it depends on other nodes
-  /// when the node is deleted in the scene
-  void UpdateReferences() override;
-
-  ///
-  /// Update the stored reference to another node in the scene
-  void UpdateReferenceID(const char *oldID, const char *newID) override;
-
   ///
   /// the ID of a MRMLVolumeNode
-  vtkGetStringMacro (BackgroundVolumeID);
+  const char* GetBackgroundVolumeID();
   void SetBackgroundVolumeID(const char* id);
   void SetReferenceBackgroundVolumeID(const char *id) { this->SetBackgroundVolumeID(id); }
 
   ///
   /// the ID of a MRMLVolumeNode
-  /// TODO: make this an arbitrary list of layers
-  vtkGetStringMacro (ForegroundVolumeID);
+  const char* GetForegroundVolumeID();
   void SetForegroundVolumeID(const char* id);
   void SetReferenceForegroundVolumeID(const char *id) { this->SetForegroundVolumeID(id); }
 
   ///
   /// the ID of a MRMLVolumeNode
-  /// TODO: make this an arbitrary list of layers
-  vtkGetStringMacro (LabelVolumeID);
+  const char* GetLabelVolumeID();
   void SetLabelVolumeID(const char* id);
   void SetReferenceLabelVolumeID(const char *id) { this->SetLabelVolumeID(id); }
 
@@ -253,9 +239,6 @@ protected:
   vtkMRMLSliceCompositeNode(const vtkMRMLSliceCompositeNode&);
   void operator=(const vtkMRMLSliceCompositeNode&);
 
-  char *BackgroundVolumeID;
-  char *ForegroundVolumeID;
-  char *LabelVolumeID;
   double ForegroundOpacity;
 
   int Compositing;

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -914,7 +914,7 @@ void vtkMRMLSliceIntersectionWidget::CycleVolumeLayer(int layer, int direction)
   // first, find the current volume index for the given layer (can be nullptr)
   vtkMRMLScene *scene = this->SliceLogic->GetMRMLScene();
   vtkMRMLSliceCompositeNode *sliceCompositeNode = this->SliceLogic->GetSliceCompositeNode();
-  char *volumeID = nullptr;
+  const char *volumeID = nullptr;
   switch (layer)
     {
     case 0: { volumeID = sliceCompositeNode->GetBackgroundVolumeID(); } break;

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -1419,7 +1419,7 @@ vtkMRMLVolumeNode *vtkMRMLSliceLogic::GetLayerVolumeNode(int layer)
     return (nullptr);
     }
 
-  char *id = nullptr;
+  const char *id = nullptr;
   switch (layer)
     {
     case LayerBackground:

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
@@ -488,9 +488,9 @@ void qSlicerSubjectHierarchyVolumesPlugin::hideVolumeFromAllViews(vtkMRMLScalarV
   for (int i=0; i<numberOfCompositeNodes; i++)
     {
     compositeNode = vtkMRMLSliceCompositeNode::SafeDownCast(scene->GetNthNodeByClass(i, "vtkMRMLSliceCompositeNode"));
-    char* backgroundVolumeID = compositeNode->GetBackgroundVolumeID();
-    char* foregroundVolumeID = compositeNode->GetForegroundVolumeID();
-    char* labelVolumeID = compositeNode->GetLabelVolumeID();
+    const char* backgroundVolumeID = compositeNode->GetBackgroundVolumeID();
+    const char* foregroundVolumeID = compositeNode->GetForegroundVolumeID();
+    const char* labelVolumeID = compositeNode->GetLabelVolumeID();
     if (backgroundVolumeID && !strcmp(backgroundVolumeID, volumeNodeID))
       {
       compositeNode->SetBackgroundVolumeID(nullptr);


### PR DESCRIPTION
This commit simplifies management of background, foreground and layer
volume references.

Co-authored-by: Andras Lasso <lasso@queensu.ca>