### PR TITLE
ENH: Always copy camera when importing MRML scene

### DIFF
--- a/Modules/Loadable/Cameras/Logic/vtkSlicerCamerasModuleLogic.cxx
+++ b/Modules/Loadable/Cameras/Logic/vtkSlicerCamerasModuleLogic.cxx
@@ -41,7 +41,6 @@ vtkStandardNewMacro(vtkSlicerCamerasModuleLogic);
 //----------------------------------------------------------------------------
 vtkSlicerCamerasModuleLogic::vtkSlicerCamerasModuleLogic()
 {
-  this->CopyImportedCameras = true;
 }
 
 //----------------------------------------------------------------------------
@@ -92,8 +91,7 @@ void vtkSlicerCamerasModuleLogic
 {
   this->Superclass::ProcessMRMLSceneEvents(caller, event, callData);
   if (event == vtkMRMLScene::NodeAboutToBeAddedEvent &&
-      this->GetMRMLScene()->IsImporting() &&
-      this->CopyImportedCameras)
+      this->GetMRMLScene()->IsImporting())
     {
     vtkMRMLCameraNode* cameraNode = vtkMRMLCameraNode::SafeDownCast(
       reinterpret_cast<vtkObject*>(callData));

--- a/Modules/Loadable/Cameras/Logic/vtkSlicerCamerasModuleLogic.h
+++ b/Modules/Loadable/Cameras/Logic/vtkSlicerCamerasModuleLogic.h
@@ -32,6 +32,11 @@ class vtkMRMLCameraNode;
 class vtkMRMLViewNode;
 
 /// \ingroup Slicer_QtModules_ExtensionTemplate
+///
+/// Properties of the scene-to-import camera nodes are always
+/// copied into the existing nodes having the same name. This is done
+/// when a camera node is about to be added to the scene.
+///
 class VTK_SLICER_CAMERAS_LOGIC_EXPORT vtkSlicerCamerasModuleLogic
   : public vtkSlicerModuleLogic
 {
@@ -44,23 +49,12 @@ public:
   /// in the view.
   vtkMRMLCameraNode* GetViewActiveCameraNode(vtkMRMLViewNode* view);
 
-  /// CopyImportedCameras controls whether the logic copies the properties of
-  /// the scene-to-import camera nodes into the existing nodes having the same
-  /// name. If true, this is done when a camera node is about to be added to
-  /// the scene.
-  /// True by default.
-  /// \sa vtkMRMLScene::Import, vtkMRMLScene::Connect
-  vtkSetMacro(CopyImportedCameras, bool);
-  vtkGetMacro(CopyImportedCameras, bool);
-
 protected:
   vtkSlicerCamerasModuleLogic();
   ~vtkSlicerCamerasModuleLogic() override;
 
   void SetMRMLSceneInternal(vtkMRMLScene* newScene) override;
   void ProcessMRMLSceneEvents(vtkObject *, unsigned long, void *) override;
-
-  bool CopyImportedCameras;
 
 private:
   vtkSlicerCamerasModuleLogic(const vtkSlicerCamerasModuleLogic&) = delete;

--- a/Modules/Loadable/Cameras/Testing/Cxx/vtkSlicerCamerasModuleLogicCopyImportedCamerasTest.cxx
+++ b/Modules/Loadable/Cameras/Testing/Cxx/vtkSlicerCamerasModuleLogicCopyImportedCamerasTest.cxx
@@ -32,22 +32,20 @@
 #include <cassert>
 
 //----------------------------------------------------------------------------
-bool TestCopyImportedCameras(bool clear, bool copy);
+bool TestCopyImportedCameras(bool clear);
 
 //----------------------------------------------------------------------------
 int vtkSlicerCamerasModuleLogicCopyImportedCamerasTest(int vtkNotUsed(argc),
                                                        char* vtkNotUsed(argv)[])
 {
   bool res = true;
-  res = TestCopyImportedCameras(false, false) && res;
-  res = TestCopyImportedCameras(false, true) && res;
-  res = TestCopyImportedCameras(true, false) && res;
-  res = TestCopyImportedCameras(true, true) && res;
+  res = TestCopyImportedCameras(false) && res;
+  res = TestCopyImportedCameras(true) && res;
   return res ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 //----------------------------------------------------------------------------
-bool TestCopyImportedCameras(bool clear, bool copy)
+bool TestCopyImportedCameras(bool clear)
 {
   double camera1Pos[3] = {10., 10., 10.};
   double camera2Pos[3] = {10., 10., 10.};
@@ -65,7 +63,6 @@ bool TestCopyImportedCameras(bool clear, bool copy)
 
   vtkNew<vtkSlicerCamerasModuleLogic> logic;
   logic->SetMRMLScene(scene.GetPointer());
-  logic->SetCopyImportedCameras(copy);
 
   std::string sceneXML =
 "<MRML  version=\"Slicer4\" userTags=\"\">\n"
@@ -105,19 +102,21 @@ bool TestCopyImportedCameras(bool clear, bool copy)
     {
     expectedFirstCamera = importedCamera1Pos;
     }
-  else if (copy)
+  else
     {
     expectedCamera1Pos = importedCamera1Pos;
     expectedFirstCamera = importedCamera1Pos;
     }
+
   vtkMRMLCameraNode* firstCamera = vtkMRMLCameraNode::SafeDownCast(
     scene->GetFirstNodeByClass("vtkMRMLCameraNode"));
+
   if (camera1->GetPosition()[0] != expectedCamera1Pos[0] ||
       camera2->GetPosition()[0] != expectedCamera2Pos[0] ||
       firstCamera->GetPosition()[0] != expectedFirstCamera[0])
     {
     std::cout << "vtkSlicerCamerasModuleLogic::CopyImportedCameras failed.\n"
-              << "Clear: " << clear << " Copy: " << copy
+              << "Clear: " << clear
               << " Cam1: " << camera1->GetPosition()[0]
               << " Exp: " << expectedCamera1Pos[0]
               << " Cam2: " << camera2->GetPosition()[0]

--- a/Modules/Loadable/Data/Resources/UI/qSlicerSceneIOOptionsWidget.ui
+++ b/Modules/Loadable/Data/Resources/UI/qSlicerSceneIOOptionsWidget.ui
@@ -27,16 +27,6 @@
      </property>
     </widget>
    </item>
-   <item>
-    <widget class="QCheckBox" name="CopyCameraCheckBox">
-     <property name="text">
-      <string>Replace active camera</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -49,21 +39,5 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>ClearSceneCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>CopyCameraCheckBox</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>66</x>
-     <y>8</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>156</x>
-     <y>9</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>

--- a/Modules/Loadable/Data/qSlicerSceneIOOptionsWidget.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneIOOptionsWidget.cxx
@@ -50,8 +50,6 @@ qSlicerSceneIOOptionsWidget::qSlicerSceneIOOptionsWidget(QWidget* parentWidget)
 
   connect(d->ClearSceneCheckBox, SIGNAL(toggled(bool)),
           this, SLOT(updateProperties()));
-  connect(d->CopyCameraCheckBox, SIGNAL(toggled(bool)),
-          this, SLOT(updateProperties()));
 
   this->updateProperties();
 }
@@ -65,7 +63,6 @@ void qSlicerSceneIOOptionsWidget::updateProperties()
   Q_D(qSlicerSceneIOOptionsWidget);
 
   d->Properties["clear"] = d->ClearSceneCheckBox->isChecked();
-  d->Properties["copyCameras"] = d->CopyCameraCheckBox->isChecked();
 }
 
 //------------------------------------------------------------------------------
@@ -76,9 +73,5 @@ void qSlicerSceneIOOptionsWidget::updateGUI(const qSlicerIO::IOProperties& ioPro
   if (ioProperties.contains("clear"))
     {
     d->ClearSceneCheckBox->setChecked(ioProperties["clear"].toBool());
-    }
-  if (ioProperties.contains("copyCameras"))
-    {
-    d->CopyCameraCheckBox->setChecked(ioProperties["copyCameras"].toBool());
     }
 }

--- a/Modules/Loadable/Data/qSlicerSceneReader.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneReader.cxx
@@ -19,6 +19,7 @@
 ==============================================================================*/
 
 // QtCore includes
+#include <QDebug>
 #include <QMessageBox>
 
 #include "qSlicerSceneReader.h"
@@ -99,12 +100,11 @@ bool qSlicerSceneReader::load(const qSlicerIO::IOProperties& properties)
     }
   else
     {
-    bool wasCopying = d->CamerasLogic->GetCopyImportedCameras();
-    bool copyCameras = properties.value("copyCameras", wasCopying).toBool();
-    d->CamerasLogic->SetCopyImportedCameras(copyCameras);
-    qDebug("Import into main MRML scene");
+    if (properties.value("copyCameras", true).toBool() == false)
+      {
+      qWarning() << Q_FUNC_INFO << ": copyCameras=false property is ignored, cameras are now always replaced in the scene";
+      }
     res = this->mrmlScene()->Import();
-    d->CamerasLogic->SetCopyImportedCameras(wasCopying);
     }
 
   if (this->mrmlScene()->GetLastLoadedVersion() &&


### PR DESCRIPTION
Properties of the scene-to-import camera nodes are always copied into the existing nodes having the same name. This is done when a camera node is about to be added to the scene.