### PR TITLE
BUG: Fix vtkSegmentationConverter::GetCheapestPath if cost >= 10000000

### DIFF
--- a/Libs/vtkSegmentationCore/vtkSegmentationConverter.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConverter.cxx
@@ -303,7 +303,7 @@ std::string vtkSegmentationConverter::GetConversionParameterDescription(const st
 //----------------------------------------------------------------------------
 vtkSegmentationConverter::ConversionPathType vtkSegmentationConverter::GetCheapestPath(const ConversionPathAndCostListType &pathsCosts)
 {
-  unsigned int cheapestPathCost = vtkSegmentationConverterRule::GetConversionInfiniteCost();
+  unsigned int cheapestPathCost = VTK_UNSIGNED_INT_MAX;
   unsigned int cheapestPathNumberOfConversions = 0;
   ConversionPathType cheapestPath;
   for (ConversionPathAndCostListType::const_iterator pathIt = pathsCosts.begin(); pathIt != pathsCosts.end(); ++pathIt)


### PR DESCRIPTION
For some Segmentation conversion methods vtkSegmentationConverterRule::GetConversionInfiniteCost() (10000000) is used to represent a last resort conversion path that should not be used unless it is the only one that can be found.
GetCheapestPath initialized the cheapestPathCost using 10000000. This meant that the cheapest path would never be found if its cost was >= 10000000.

Fixed by initializing cheapestPathCost to VTK_UNSIGNED_INT_MAX.

See SlicerRt/SlicerRT#177