### PR TITLE
ENH: Double click on type selects terminology

### DIFF
--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -252,6 +252,8 @@ void qSlicerTerminologyNavigatorWidgetPrivate::init()
     q, SLOT(onCategorySelectionChanged()) );
   QObject::connect(this->tableWidget_Type, SIGNAL(currentItemChanged(QTableWidgetItem*,QTableWidgetItem*)),
     q, SLOT(onTypeSelected(QTableWidgetItem*,QTableWidgetItem*)) );
+  QObject::connect(this->tableWidget_Type, SIGNAL(cellDoubleClicked(int,int)),
+    q, SLOT(onTypeCellDoubleClicked(int,int)) );
   QObject::connect(this->ComboBox_TypeModifier, SIGNAL(currentIndexChanged(int)),
     q, SLOT(onTypeModifierSelectionChanged(int)) );
   QObject::connect(this->SearchBox_Category, SIGNAL(textChanged(QString)),
@@ -1658,6 +1660,14 @@ void qSlicerTerminologyNavigatorWidget::onTypeSelected(QTableWidgetItem* current
     {
     d->setRecommendedColorFromCurrentTerminology();
     }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerTerminologyNavigatorWidget::onTypeCellDoubleClicked(int row, int column)
+{
+  Q_UNUSED(row);
+  Q_UNUSED(column);
+  emit typeDoubleClicked();
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.h
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.h
@@ -176,6 +176,7 @@ protected slots:
   void onTerminologySelectionChanged(int);
   void onCategorySelectionChanged();
   void onTypeSelected(QTableWidgetItem*, QTableWidgetItem*);
+  void onTypeCellDoubleClicked(int, int);
   void onTypeModifierSelectionChanged(int);
   void onCategorySearchTextChanged(QString);
   void onTypeSearchTextChanged(QString);
@@ -201,6 +202,8 @@ protected slots:
 signals:
   /// Emitted when selection becomes valid (true argument) or invalid (false argument)
   void selectionValidityChanged(bool);
+  /// Emitted when type is double clicked. It can be interpreted as having made a selection
+  void typeDoubleClicked();
 
 protected:
   QScopedPointer<qSlicerTerminologyNavigatorWidgetPrivate> d_ptr;

--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologySelectorDialog.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologySelectorDialog.cxx
@@ -91,6 +91,7 @@ void qSlicerTerminologySelectorDialogPrivate::init()
 
   // Make connections
   connect(this->NavigatorWidget, SIGNAL(selectionValidityChanged(bool)), q, SLOT(setSelectButtonEnabled(bool)));
+  connect(this->NavigatorWidget, SIGNAL(typeDoubleClicked()), this, SLOT(accept()));
   connect(this->SelectButton, SIGNAL(clicked()), this, SLOT(accept()));
   connect(this->CancelButton, SIGNAL(clicked()), this, SLOT(reject()));
 }


### PR DESCRIPTION
Besides clicking Select in the terminology selector dialog, now double-clicking on the type has the same effect. It makes selecting terminology faster in simple cases (when modifiers do not need to be set).