### PR TITLE
ENH: Make slice views aligned with image axes by default

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -471,6 +471,7 @@ public:
     SliceVisibleFlag = 128,
     SliceSpacingFlag = 256,
     ResetOrientationFlag = 512,
+    RotateToBackgroundVolumePlaneFlag = 1024
   };
 
   /// Get/Set a flag indicating what parameters are being manipulated

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -526,6 +526,10 @@ void vtkMRMLApplicationLogic::FitSliceToAll(bool onlyIfPropagateVolumeSelectionA
         }
       }
     vtkMRMLSliceNode* sliceNode = sliceLogic->GetSliceNode();
+    // Set to default orientation before rotation so that the view is snapped
+    // closest to the default orientation of this slice view.
+    sliceNode->SetOrientationToDefault();
+    sliceLogic->RotateSliceToLowestVolumeAxes();
     int* dims = sliceNode->GetDimensions();
     sliceLogic->FitSliceToAll(dims[0], dims[1]);
     sliceLogic->SnapSliceOffsetToIJK();

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -2436,3 +2436,28 @@ vtkImageBlend* vtkMRMLSliceLogic::GetBlendUVW()
 {
   return this->PipelineUVW->Blend.GetPointer();
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceLogic::RotateSliceToLowestVolumeAxes()
+{
+  vtkMRMLVolumeNode* volumeNode;
+  for (int layer = 0; layer < 3; layer++)
+    {
+    volumeNode = this->GetLayerVolumeNode(layer);
+    if (volumeNode)
+      {
+      break;
+      }
+    }
+  if (!volumeNode)
+    {
+    return;
+    }
+  vtkMRMLSliceNode* sliceNode = this->GetSliceNode();
+  if (!sliceNode)
+    {
+    return;
+    }
+  sliceNode->RotateToVolumePlane(volumeNode);
+  this->SnapSliceOffsetToIJK();
+}

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -239,6 +239,9 @@ public:
   ///   be used to calculate the range (e.g. of a slider) that operates in slice space
   void GetBackgroundSliceBounds(double sliceBounds[6]);
 
+  /// Rotate slice view to match axes of the lowest volume layer (background, foreground, label).
+  void RotateSliceToLowestVolumeAxes();
+
   ///
   /// adjust the node's field of view to match the extent of current background volume
   void FitSliceToBackground(int width, int height);

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -194,7 +194,7 @@ void qMRMLSliceControllerWidgetPrivate::setupPopupUi()
   QObject::connect(this->actionFit_to_window, SIGNAL(triggered()),
                    q, SLOT(fitSliceToBackground()));
   QObject::connect(this->actionRotate_to_volume_plane, SIGNAL(triggered()),
-                   q, SLOT(rotateSliceToBackground()));
+                   q, SLOT(rotateSliceToLowestVolumeAxes()));
   QObject::connect(this->actionShow_reformat_widget, SIGNAL(triggered(bool)),
                    q, SLOT(showReformatWidget(bool)));
   QObject::connect(this->actionCompositingAlpha_blend, SIGNAL(triggered()),
@@ -2124,7 +2124,7 @@ void qMRMLSliceControllerWidget::moveBackgroundComboBox(bool more)
 }
 
 //---------------------------------------------------------------------------
-void qMRMLSliceControllerWidget::rotateSliceToBackground()
+void qMRMLSliceControllerWidget::rotateSliceToLowestVolumeAxes()
 {
   Q_D(qMRMLSliceControllerWidget);
   vtkSmartPointer<vtkCollection> nodes = d->saveNodesForUndo("vtkMRMLSliceNode");
@@ -2132,19 +2132,9 @@ void qMRMLSliceControllerWidget::rotateSliceToBackground()
     {
     return;
     }
-  vtkMRMLSliceNode* node = nullptr;
-  vtkCollectionSimpleIterator it;
-  for (nodes->InitTraversal(it);(node = static_cast<vtkMRMLSliceNode*>(
-                                   nodes->GetNextItemAsObject(it)));)
-    {
-    vtkMRMLSliceLogic* nodeLogic = d->sliceNodeLogic(node);
-    if (nodeLogic && (nodeLogic == d->SliceLogic.GetPointer() || this->isLinked()))
-      {
-      vtkMRMLVolumeNode* backgroundNode = nodeLogic->GetLayerVolumeNode(0);
-      node->RotateToVolumePlane(backgroundNode);
-      nodeLogic->SnapSliceOffsetToIJK();
-      }
-    }
+  d->SliceLogic->StartSliceNodeInteraction(vtkMRMLSliceNode::RotateToBackgroundVolumePlaneFlag);
+  d->SliceLogic->RotateSliceToLowestVolumeAxes();
+  d->SliceLogic->EndSliceNodeInteraction();
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
@@ -136,8 +136,13 @@ protected slots:
   void onSliceCompositeNodeModified();
 
   /// Toggle flag determining whether field of view in slice views is reset when showing a volume
-  /// in subject hierarchy. By default it is off. State is stored in the application settings.
+  /// in subject hierarchy. By default it is on. State is stored in the application settings.
   void toggleResetFieldOfViewOnShowAction(bool);
+
+  /// Toggle flag determining whether orientation slice views should be reset to background volume axis
+  /// closest to the view's default view axis when showing a volume in subject hierarchy.
+  /// By default it is on. State is stored in the application settings.
+  void toggleResetViewOrientationOnShowAction(bool);
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyVolumesPluginPrivate> d_ptr;


### PR DESCRIPTION
Users were confused by showing reformatted images by default, therefore image display actions are changed to facilitate axis-aligned display.
Slice views are rotated to be aligned with closest image axes if:
- Volume selection is propagated - for example when a volume is loaded or a CLI completes execution. Unless if a view is excluded by setting vtkMRMLSliceCompositeNode::DoPropagateVolumeSelection to false or "show" option is disable in Add data dialog.
- In Data module / Subject hierarchy tree -> eye icon is clicked. Unless "Reset view orientation on show" checkbox (checked by default) is unchecked in context menu of the eye icon.
- Dragging a volume from Data module / Subject hierarchy tree to a view. Unless "Reset view orientation on show" checkbox (checked by default) is unchecked in context menu of the eye icon.

fixes #5379