### PR TITLE
Various doc updates removing old TCL build option, build instructions link, and old macOS names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ blog post.
 #### Nightly tests
 
 After changes are integrated, every evening at 10pm EST (3am UTC), Slicer build bots (aka factories)
-will build, test and package the Slicer application and all its extensions on Linux, MacOSX
+will build, test and package the Slicer application and all its extensions on Linux, macOS
 and Windows. Results are published daily on CDash ([Stable](http://slicer.cdash.org/index.php?project=Slicer4) & [Preview](http://slicer.cdash.org/index.php?project=SlicerPreview))
 and developers that introduced changes resulting in build or test failures are notified by
 email.

--- a/Docs/developer_guide/build_instructions/macos.md
+++ b/Docs/developer_guide/build_instructions/macos.md
@@ -1,4 +1,4 @@
-# Mac OS
+# macOS
 
 ## Prerequisites
 
@@ -19,7 +19,7 @@ xcode-select --install
 
 Notes:
 - While it is not enforced, we strongly recommend you to *avoid* the use of *spaces* for both the `source directory` and the `build directory`.
-- Due to maximum path length limitations during build the build process, source and build folders must be located in a folder with very short total path length. This is expecially critical on Windows and MacOS. For example, `/sq5` has been confirmed to work on MacOS.
+- Due to maximum path length limitations during build the build process, source and build folders must be located in a folder with very short total path length. This is expecially critical on Windows and macOS. For example, `/sq5` has been confirmed to work on macOS.
 
 Check out the code using `git`:
 - Clone the github repository</p>

--- a/Docs/developer_guide/build_instructions/overview.md
+++ b/Docs/developer_guide/build_instructions/overview.md
@@ -22,7 +22,6 @@ Customized editions of Slicer can be generated without changing Slicer source co
 - `Slicer_USE_PYTHONQT_WITH_OPENSSL`: enable/disable building the application with SSL support (ON/OFF)
 - `Slicer_USE_SimpleITK`: enable/disable SimpleITK support (ON/OFF)
 - `Slicer_BUILD_SimpleFilters`: enable/disable building SimpleFilters. Requires SimpleITK. (ON/OFF)
-- `Slicer_USE_PYTHONQT_WITH_TCL`: TCL support (ON/OFF)
 - `Slicer_EXTENSION_SOURCE_DIRS`: Defines additional extensions that will be included in the application package as built-in modules. Full paths of extension source directories has to be specified, separated by semicolons.
 
 More customization is available by using [SlicerCustomAppTemplate](https://github.com/KitwareMedical/SlicerCustomAppTemplate) project maintained by Kitware.

--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -52,7 +52,7 @@ If you shared your extension by using the ExtensionWizard, make sure you know ab
 
 ![](http://slicer.cdash.org/index.php?project=Slicer4&display=project)
 
-The dashboard will attempt to check out the source code of your extension, build, test and package it on Linux, MacOSX and Windows platforms.
+The dashboard will attempt to check out the source code of your extension, build, test and package it on Linux, macOS and Windows platforms.
 
 To find your extension, use the following link replacing `SlicerMyExtension` with the name of your extension:
 

--- a/Docs/user_guide/about.md
+++ b/Docs/user_guide/about.md
@@ -9,7 +9,7 @@
 **Note:** There is no restriction on use, but Slicer is **NOT** approved for clinical use and the distributed application is intended for research use. Permissions and compliance with applicable rules are the responsibility of the user. For details on the license see [here](https://www.slicer.org/wiki/License).
 
 Highlights:
-- Free, [open-source](http://en.wikipedia.org/wiki/Open_source>) software available on multiple operating systems: Linux, MacOSX and Windows.
+- Free, [open-source](http://en.wikipedia.org/wiki/Open_source>) software available on multiple operating systems: Linux, macOS and Windows.
 - Multi organ: from head to toe.
 - Support for multi-modality imaging including, MRI, CT, US, nuclear medicine, and microscopy.
 - Real-time interface for medical devices, such as surgical navigation systems, imaging systems, robotic devices, and sensors.
@@ -26,7 +26,7 @@ To use Slicer, please read the [3D Slicer Software License Agreement](https://gi
 
 ### 3D Slicer as a platform
 
-To acknowledge 3D Slicer as a platform, please cite the [Slicer web site](http://www.slicer.org/) and the following publications when publishing work that uses or incorporates 3D Slicer: 
+To acknowledge 3D Slicer as a platform, please cite the [Slicer web site](http://www.slicer.org/) and the following publications when publishing work that uses or incorporates 3D Slicer:
 
 **Fedorov A., Beichel R., Kalpathy-Cramer J., Finet J., Fillion-Robin J-C., Pujol S., Bauer C., Jennings D., Fennessy F.M., Sonka M., Buatti J., Aylward S.R., Miller J.V., Pieper S., Kikinis R. [3D Slicer as an Image Computing Platform for the Quantitative Imaging Network](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3466397/pdf/nihms383480.pdf). Magn Reson Imaging. 2012 Nov;30(9):1323-41. PMID: 22770690. PMCID: PMC3466397.**
 
@@ -111,7 +111,7 @@ _Listed in alphabetical order._
 
 ### 3D Slicer based products
 
-Many companies prefer not to disclose what software components they use in their products, therefore here we can only list a few commercial products that are based on 3D Slicer: 
+Many companies prefer not to disclose what software components they use in their products, therefore here we can only list a few commercial products that are based on 3D Slicer:
 
 - Allen Institute for Brain Science: [Cell Locator](https://github.com/BICCN/cell-locator/#readme), Desktop application for manually aligning specimens to annotated 3D spaces.
 - Radiopharmaceutical Imaging and Dosimetry: RPTDose, a 3D Slicer-based application that streamlines and integrates quantitative imaging analysis and dose estimation techniques to guide and optimize the use of radiopharmaceutical therapy agents in clinical trials. See more information on this [Kitware blog](https://blog.kitware.com/kitware-customer-highlight-radiopharmaceutical-imaging-and-dosimetry-llc-rapid/).

--- a/README.txt
+++ b/README.txt
@@ -1,12 +1,12 @@
-Slicer, or 3D Slicer, is a free, open source software package for visualization and 
-image analysis. 
+Slicer, or 3D Slicer, is a free, open source software package for visualization and
+image analysis.
 
-3D Slicer is natively designed to be available on multiple platforms, 
-including Windows, Linux and Mac Os X. 
+3D Slicer is natively designed to be available on multiple platforms,
+including Windows, Linux and Mac Os X.
 
 Build instructions for all platforms are available on the Slicer wiki:
 
-                      https://www.slicer.org/wiki/Documentation/Nightly/Developers/Build_Instructions
+                      https://slicer.readthedocs.io/en/latest/developer_guide/build_instructions/index.html
 
 For Slicer community announcements and support, visit:
 

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@ Slicer, or 3D Slicer, is a free, open source software package for visualization 
 image analysis.
 
 3D Slicer is natively designed to be available on multiple platforms,
-including Windows, Linux and Mac Os X.
+including Windows, Linux and macOS.
 
 Build instructions for all platforms are available on the Slicer wiki:
 


### PR DESCRIPTION
This PR includes various updates to doc files.

- Removes documentation of old `Slicer_USE_PYTHONQT_WITH_TCL` build option.
- Replaces the build instructions link in the README with the Slicer ReadTheDocs build instructions link
- Uses correct name usage of macOS instead of Mac OS or Mac OS X in documentation files