### PR TITLE
STYLE: Use macOS in comments instead of old Mac OS X

### DIFF
--- a/Applications/SlicerApp/Testing/Python/SlicerAppTesting.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerAppTesting.py
@@ -44,7 +44,7 @@ def dropcache():
   if sys.platform in ["linux", "linux2"]:
     run('/usr/bin/sudo', ['sysctl', 'vm.drop_caches=1'], drop_cache=False)
   else:
-    # XXX Implement other platform (Windows: EmptyStandbyList ?, MacOSX: Purge ?)
+    # XXX Implement other platform (Windows: EmptyStandbyList ?, macOS: Purge ?)
     raise Exception("--drop-cache is not supported on %s" % sys.platform)
 
 def run(executable, arguments=[], verbose=True, shell=False, drop_cache=False):

--- a/Base/Logic/vtkSlicerApplicationLogic.cxx
+++ b/Base/Logic/vtkSlicerApplicationLogic.cxx
@@ -731,7 +731,7 @@ bool vtkSlicerApplicationLogic::IsEmbeddedModule(const std::string& filePath,
     isEmbedded = false;
     }
 #endif
-  // On MacOSX extensions are installed in the "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>"
+  // On macOS extensions are installed in the "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>"
   // folder being a sub directory of the application dir, an extra test is required to make sure the
   // tested filePath doesn't belong to that "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>" folder.
   // BUG 2848: Since package name can be rename from "Slicer.app" to "Something.app", let's compare
@@ -812,7 +812,7 @@ bool vtkSlicerApplicationLogic::IsPluginBuiltIn(const std::string& filePath,
         canonicalPath.c_str(), canonicalApplicationHomeDir.c_str());
 
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
-  // On MacOSX extensions are installed in the "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>"
+  // On macOS extensions are installed in the "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>"
   // folder being a sub directory of the application dir, an extra test is required to make sure the
   // tested filePath doesn't belong to that "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>" folder.
   // Since package name can be rename from "Slicer.app" to "Something.app", let's compare

--- a/Base/Logic/vtkSlicerApplicationLogic.h
+++ b/Base/Logic/vtkSlicerApplicationLogic.h
@@ -192,7 +192,7 @@ class VTK_SLICER_BASE_LOGIC_EXPORT vtkSlicerApplicationLogic
   void SetTracingOff () { this->Tracing = 0; }
 
   /// Return True if \a filePath is a descendant of \a applicationHomeDir.
-  /// \note On MacOSX extensions are installed in the "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>"
+  /// \note On macOS extensions are installed in the "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>"
   /// folder being a sub directory of the application dir, an extra test is performed to make sure the
   /// tested filePath doesn't belong to that "<Slicer_EXTENSIONS_DIRBASENAME>-<slicerRevision>" folder.
   /// If this is the case, False will be returned.

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -775,7 +775,7 @@ void vtkSlicerCLIModuleLogic
 //       typedef int (*ModuleEntryPoint)(int argc, char* argv[]);
 //
 // #if defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1030)
-//       // Mac OS X defaults to RTLD_GLOBAL and there is no way to
+//       // macOS defaults to RTLD_GLOBAL and there is no way to
 //       // override in itksys. So make the direct call to dlopen().
 //       itksys::DynamicLoader::LibraryHandle lib
 //         = dlopen(moduleDescriptionObject.GetLocation().c_str(), RTLD_LAZY | RTLD_LOCAL);

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.cxx
@@ -48,10 +48,6 @@
 // Qt includes
 #include <QDebug>
 
-#if defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1030)
-// needed to hack around itksys to override defaults used by Mac OS X
-#endif
-
 // STL includes
 #include <algorithm>
 #include <cassert>

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -234,7 +234,7 @@ void qSlicerCoreApplicationPrivate::init()
   this->SlicerHome = this->discoverSlicerHomeDirectory();
 
   // Save the environment if no launcher is used (this is for example the case
-  // on MacOSX when slicer is started from an install tree)
+  // on macOS when slicer is started from an install tree)
   if (ctkAppLauncherEnvironment::currentLevel() == 0)
     {
     QProcessEnvironment updatedEnv;

--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -114,7 +114,7 @@ public:
   ///         | Build tree | Install tree
   /// --------| -----------|---------------
   /// Linux   |  true      |  true
-  /// MacOSX  |  true      |  false
+  /// macOS   |  true      |  false
   /// Windows |  true      |  true
   ///
   bool isUsingLauncher()const;

--- a/CMake/BundleUtilitiesWithRPath.cmake
+++ b/CMake/BundleUtilitiesWithRPath.cmake
@@ -807,7 +807,7 @@ function(fixup_bundle app libs dirs)
   if(valid)
     get_filename_component(exepath "${executable}" PATH)
 
-    # TODO: Extract list of rpath dirs automatically. On MacOSX, the following could be
+    # TODO: Extract list of rpath dirs automatically. On macOS, the following could be
     #       done: otool -l path/to/executable | grep -A 3 LC_RPATH | grep path
     #       See http://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html#comment-87ea054b4839586412727dcfc94c79d2
     set(GP_RPATH_DIR ${bundle}/Contents)

--- a/CMake/GetPrerequisitesWithRPath.cmake
+++ b/CMake/GetPrerequisitesWithRPath.cmake
@@ -103,7 +103,7 @@
 #
 # If GP_RPATH_DIR variable is set then item matching '@rpath' are
 # resolved using the provided directory. Currently setting this variable
-# has an effect only on MacOSX when fixing up application bundle. The directory
+# has an effect only on macOS when fixing up application bundle. The directory
 # are also assumed to be located within the application bundle. It is
 # usually the directory passed to the 'rpath' linker option.
 #

--- a/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+++ b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
@@ -209,7 +209,7 @@ endif()
 #  Do not use Slicer_INSTALL_* variables
 #  -------------------------------------
 #
-#  Indeed, on MacOSX, since Slicer_INSTALL_* variables already includes
+#  Indeed, on macOS, since Slicer_INSTALL_* variables already includes
 #  Slicer_BUNDLE_LOCATION (<appname>.app/Contents) they can *NOT*
 #  be used to reference paths from <APPLAUNCHER_SETTINGS_DIR> which is itself
 #  set to /path/to/<appname>.app/Contents/bin.

--- a/CMake/SlicerConfig.cmake.in
+++ b/CMake/SlicerConfig.cmake.in
@@ -8,7 +8,7 @@
 #
 
 #
-# When manually building extension on MacOSX, in addition to the usual configure
+# When manually building extension on macOS, in addition to the usual configure
 # option (CMAKE_BUILD_TYPE, ...), the developer is also expected to
 # configure it passing the variables:
 #   CMAKE_OSX_ARCHITECTURES

--- a/CMake/SlicerExtensionCPackBundleFixup.cmake.in
+++ b/CMake/SlicerExtensionCPackBundleFixup.cmake.in
@@ -196,7 +196,7 @@ function(fixup_extension ext libs dirs)
   #  get_filename_component(exepath "${executable}" PATH)
     set(exepath "${bundle}/Contents/MacOS")
 
-    # TODO: Extract list of rpath dirs automatically. On MacOSX, the following could be
+    # TODO: Extract list of rpath dirs automatically. On macOS, the following could be
     #       done: otool -l path/to/executable | grep -A 3 LC_RPATH | grep path
     #       See http://www.mikeash.com/pyblog/friday-qa-2009-11-06-linking-and-install-names.html#comment-87ea054b4839586412727dcfc94c79d2
     set(GP_RPATH_DIR ${bundle}/Contents)

--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -696,7 +696,7 @@ macro(slicerMacroBuildApplication)
       endif()
 
       #
-      # On MacOSX, the installed launcher settings are *only* read directly by the
+      # On macOS, the installed launcher settings are *only* read directly by the
       # qSlicerCoreApplication using the LauncherLib.
       #
       # On Linux and Windows, the installed launcher settings are first read by the

--- a/CMake/vtkSlicerVersionConfigureInternal.h.in
+++ b/CMake/vtkSlicerVersionConfigureInternal.h.in
@@ -53,7 +53,7 @@
 #define Slicer_OS_LINUX_NAME "@Slicer_OS_LINUX_NAME@"
 
 /// \def Slicer_OS_MAC_NAME
-/// String describing MacOSX operating system.
+/// String describing macOS operating system.
 #define Slicer_OS_MAC_NAME "@Slicer_OS_MAC_NAME@"
 
 /// \def Slicer_OS_WIN_NAME

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -734,15 +734,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${Slicer_BINARY_DIR}/${Slicer_LIB_DIR})
 set(Slicer_HOME "${Slicer_BINARY_DIR}")
 
 #-----------------------------------------------------------------------------
-# Avoid linker bug in Mac OS 10.5
-# See http://wiki.finkproject.org/index.php/Fink:Packaging:Preparing_for_10.5#OpenGL_Bug
-#
-if(APPLE)
-  set(CMAKE_SHARED_LINKER_FLAGS "-Wl,-dylib_file,/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib:/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib")
-  set(CMAKE_EXE_LINKER_FLAGS "-Wl,-dylib_file,/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib:/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib")
-endif()
-
-#-----------------------------------------------------------------------------
 # Slicer include and libraries subdirectory
 #-----------------------------------------------------------------------------
 set(Slicer_Base_LIBRARIES CACHE INTERNAL "Slicer Base libraries" FORCE)

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
@@ -134,7 +134,7 @@ protected:
 
   // Gesture events
   //@{
-  /// MacOSX touchpad events
+  /// macOS touchpad events
   double Rotation;
   double LastRotation;
   double Scale;

--- a/Libs/MRML/Widgets/qMRMLWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLWidget.cxx
@@ -77,15 +77,6 @@ vtkMRMLScene* qMRMLWidget::mrmlScene() const
 //-----------------------------------------------------------------------------
 void qMRMLWidget::preInitializeApplication()
 {
-  #ifdef Q_OS_MACX
-  if (QSysInfo::MacintoshVersion > QSysInfo::MV_10_8)
-    {
-    // Fix Mac OS X 10.9 (mavericks) font issue
-    // https://bugreports.qt-project.org/browse/QTBUG-32789
-    QFont::insertSubstitution(".Lucida Grande UI", "Lucida Grande");
-    }
-#endif
-
 #ifdef _WIN32
   // Qt windows defaults to the PROCESS_PER_MONITOR_DPI_AWARE for DPI display
   // on windows. Unfortunately, this doesn't work well on multi-screens setups.

--- a/Libs/vtkITK/vtkITKImageMargin.h
+++ b/Libs/vtkITK/vtkITKImageMargin.h
@@ -14,7 +14,7 @@
 
   This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
   and was supported through CANARIE's Research Software Program, Cancer
-  Care Ontario, OpenAnatomy, and Brigham and Women’s Hospital through NIH grant R01MH112748.
+  Care Ontario, OpenAnatomy, and Brigham and Womenï¿½s Hospital through NIH grant R01MH112748.
 
 ==============================================================================*/
 
@@ -26,7 +26,7 @@
 
 /// \brief ITK-based utilities for manipulating connected regions in label maps.
 /// Limitation: The filter does not work correctly with input volume that has
-/// unsigned long scalar type on Linux and MacOSX.
+/// unsigned long scalar type on Linux and macOS.
 ///
 class VTK_ITK_EXPORT vtkITKImageMargin : public vtkSimpleImageToImageFilter
 {

--- a/Libs/vtkITK/vtkITKIslandMath.h
+++ b/Libs/vtkITK/vtkITKIslandMath.h
@@ -15,7 +15,7 @@
 
 /// \brief ITK-based utilities for manipulating connected regions in label maps.
 /// Limitation: The filter does not work correctly with input volume that has
-/// unsigned long scalar type on Linux and MacOSX.
+/// unsigned long scalar type on Linux and macOS.
 ///
 class VTK_ITK_EXPORT vtkITKIslandMath : public vtkSimpleImageToImageFilter
 {

--- a/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
@@ -12,7 +12,7 @@ def haveGit():
   """Return True if git is available.
 
   A side effect of `import git` is that it shows a popup window on
-  MacOSX, asking the user to install XCode (if git is not installed already),
+  macOS, asking the user to install XCode (if git is not installed already),
   therefore this method should only be called if git is actually needed.
   """
 

--- a/Utilities/Scripts/SlicerWizard/Utilities.py
+++ b/Utilities/Scripts/SlicerWizard/Utilities.py
@@ -11,7 +11,7 @@ def haveGit():
   """Return True if git is available.
 
   A side effect of `import git` is that it shows a popup window on
-  MacOSX, asking the user to install XCode (if git is not installed already),
+  macOS, asking the user to install XCode (if git is not installed already),
   therefore this method should only be called if git is actually needed.
   """
 


### PR DESCRIPTION
This includes updates to use macOS term in code comments instead of older Mac OS X name.  There a few additional commits that remove workarounds for old mac versions.