### PR TITLE
BUG: Avoid crash in DisplayableManager by checking for null scene pointer

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractDisplayableManager.cxx
@@ -670,7 +670,7 @@ vtkMRMLInteractionNode* vtkMRMLAbstractDisplayableManager::GetInteractionNode()
 //---------------------------------------------------------------------------
 vtkMRMLSelectionNode* vtkMRMLAbstractDisplayableManager::GetSelectionNode()
 {
-  return vtkMRMLSelectionNode::SafeDownCast(this->GetMRMLScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton"));
+  return this->GetMRMLScene() ? vtkMRMLSelectionNode::SafeDownCast(this->GetMRMLScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton")): nullptr;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelSliceDisplayableManager.cxx
@@ -866,7 +866,7 @@ void vtkMRMLModelSliceDisplayableManager
 {
   vtkMRMLScene* scene = this->GetMRMLScene();
 
-  if ( scene->IsBatchProcessing() )
+  if (scene == nullptr || scene->IsBatchProcessing())
     {
     return;
     }

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager2D.cxx
@@ -1380,7 +1380,7 @@ void vtkMRMLSegmentationsDisplayableManager2D::ProcessMRMLNodesEvents(vtkObject*
 {
   vtkMRMLScene* scene = this->GetMRMLScene();
 
-  if ( scene->IsBatchProcessing() )
+  if (scene == nullptr || scene->IsBatchProcessing())
     {
     return;
     }

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
@@ -821,7 +821,7 @@ void vtkMRMLSegmentationsDisplayableManager3D::ProcessMRMLNodesEvents(vtkObject*
 {
   vtkMRMLScene* scene = this->GetMRMLScene();
 
-  if ( scene->IsBatchProcessing() )
+  if (scene == nullptr || scene->IsBatchProcessing())
     {
     return;
     }

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLLinearTransformsDisplayableManager3D.cxx
@@ -665,7 +665,7 @@ void vtkMRMLLinearTransformsDisplayableManager3D::ProcessMRMLNodesEvents(vtkObje
 {
   vtkMRMLScene* scene = this->GetMRMLScene();
 
-  if ( scene->IsBatchProcessing() )
+  if (scene == nullptr || scene->IsBatchProcessing())
     {
     return;
     }

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager2D.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager2D.cxx
@@ -527,7 +527,7 @@ void vtkMRMLTransformsDisplayableManager2D::ProcessMRMLNodesEvents(vtkObject* ca
 {
   vtkMRMLScene* scene = this->GetMRMLScene();
 
-  if ( scene->IsBatchProcessing() )
+  if (scene == nullptr || scene->IsBatchProcessing())
     {
     return;
     }

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager3D.cxx
@@ -528,7 +528,7 @@ void vtkMRMLTransformsDisplayableManager3D::ProcessMRMLNodesEvents(vtkObject* ca
 {
   vtkMRMLScene* scene = this->GetMRMLScene();
 
-  if ( scene->IsBatchProcessing() )
+  if (scene == nullptr || scene->IsBatchProcessing())
     {
     return;
     }

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -1381,7 +1381,7 @@ void vtkMRMLVolumeRenderingDisplayableManager::ProcessMRMLNodesEvents(vtkObject*
 {
   vtkMRMLScene* scene = this->GetMRMLScene();
 
-  if (scene->IsBatchProcessing())
+  if (scene == nullptr || scene->IsBatchProcessing())
     {
     return;
     }


### PR DESCRIPTION
This commit fixes crashes when using the python interactor by improving check for MRML scene validity in ProcessMRMLNodesEvent() and GetSelectionNode()