### PR TITLE
BUG: Update vtkAddon and fix execution of associated tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,14 @@ if(CMAKE_CONFIGURATION_TYPES)
 endif()
 add_custom_target(Experimental ${CMAKE_CTEST_COMMAND} ${__conf_types} -D Experimental)
 
+if(Slicer_SUPERBUILD)
+  set(_slicer_dir ${CMAKE_BINARY_DIR}/${Slicer_BINARY_INNER_SUBDIR})
+else()
+  set(_slicer_dir ${Slicer_BINARY_DIR})
+endif()
+set(Slicer_LAUNCHER_EXECUTABLE ${_slicer_dir}/${Slicer_MAIN_PROJECT_APPLICATION_NAME}${CMAKE_EXECUTABLE_SUFFIX})
+set(Slicer_LAUNCH_COMMAND ${Slicer_LAUNCHER_EXECUTABLE} --launch)
+
 #-----------------------------------------------------------------------------
 # ExternalData Object Stores configuration
 #-----------------------------------------------------------------------------
@@ -754,9 +762,6 @@ set(Slicer_ExternalData_URL_TEMPLATES ${ExternalData_URL_TEMPLATES})
 #-----------------------------------------------------------------------------
 # Testing
 #-----------------------------------------------------------------------------
-set(Slicer_LAUNCHER_EXECUTABLE ${Slicer_BINARY_DIR}/${Slicer_MAIN_PROJECT_APPLICATION_NAME}${CMAKE_EXECUTABLE_SUFFIX})
-set(Slicer_LAUNCH_COMMAND ${Slicer_LAUNCHER_EXECUTABLE} --launch)
-
 include(SlicerMacroConfigureModuleCxxTestDriver)
 include(SlicerMacroSimpleTest)
 include(SlicerMacroPythonTesting)

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,13 +202,16 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 5df87dee75c049320943f445200b4cbe7309f811
+  GIT_TAG 4a5061920f6f72a2ddff6932176f7de2661b5f76
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)
 
 set(vtkAddon_CMAKE_DIR ${vtkAddon_SOURCE_DIR}/CMake)
 mark_as_superbuild(vtkAddon_CMAKE_DIR:PATH)
+
+set(vtkAddon_LAUNCH_COMMAND ${Slicer_LAUNCH_COMMAND})
+mark_as_superbuild(vtkAddon_LAUNCH_COMMAND:STRING)
 
 set(vtkAddon_USE_UTF8 ON)
 mark_as_superbuild(vtkAddon_USE_UTF8:BOOL)


### PR DESCRIPTION
This commit sets `vtkAddon_LAUNCH_COMMAND` using `Slicer_LAUNCH_COMMAND` so that
the environment allowing to run vtkAddon tests on Windows is setup.


List of vtkAddon changes:

```
$ git shortlog 5df87dee7..4a50619 --no-merges
Jean-Christophe Fillion-Robin (1):
      BUG: Fix tests execution on windows adding "vtkAddon_LAUNCH_COMMAND" option

Rafael Palomar (2):
      COMP: Fix configuration for VTK with external HDF5
      ENH: Add installation of vtkAddon CMake files
```