### PR TITLE
ENH: Add properties for easy visibility setting of SH tree columns

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -1068,6 +1068,66 @@ QStringList qMRMLSubjectHierarchyTreeView::hideChildNodeTypes()const
   return this->sortFilterProxyModel()->hideChildNodeTypes();
 }
 
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::setVisibilityColumnVisible(bool visible)
+{
+  this->setColumnHidden(this->model()->visibilityColumn(), !visible);
+}
+
+//--------------------------------------------------------------------------
+bool qMRMLSubjectHierarchyTreeView::visibilityColumnVisible()
+{
+  return !this->isColumnHidden(this->model()->visibilityColumn());
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::setIdColumnVisible(bool visible)
+{
+  this->setColumnHidden(this->model()->idColumn(), !visible);
+}
+
+//--------------------------------------------------------------------------
+bool qMRMLSubjectHierarchyTreeView::idColumnVisible()
+{
+  return !this->isColumnHidden(this->model()->idColumn());
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::setColorColumnVisible(bool visible)
+{
+  this->setColumnHidden(this->model()->colorColumn(), !visible);
+}
+
+//--------------------------------------------------------------------------
+bool qMRMLSubjectHierarchyTreeView::colorColumnVisible()
+{
+  return !this->isColumnHidden(this->model()->colorColumn());
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::setTransformColumnVisible(bool visible)
+{
+  this->setColumnHidden(this->model()->transformColumn(), !visible);
+}
+
+//--------------------------------------------------------------------------
+bool qMRMLSubjectHierarchyTreeView::transformColumnVisible()
+{
+  return !this->isColumnHidden(this->model()->transformColumn());
+}
+
+//--------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::setDescriptionColumnVisible(bool visible)
+{
+  this->setColumnHidden(this->model()->descriptionColumn(), !visible);
+}
+
+//--------------------------------------------------------------------------
+bool qMRMLSubjectHierarchyTreeView::descriptionColumnVisible()
+{
+  return !this->isColumnHidden(this->model()->descriptionColumn());
+}
+
 //------------------------------------------------------------------------------
 void qMRMLSubjectHierarchyTreeView::toggleSubjectHierarchyItemVisibility(vtkIdType itemID)
 {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -69,6 +69,11 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qMRMLSubjectHierarchyTreeV
   Q_PROPERTY(QString nameFilter READ nameFilter WRITE setNameFilter)
   Q_PROPERTY(QStringList nodeTypes READ nodeTypes WRITE setNodeTypes)
   Q_PROPERTY(QStringList hideChildNodeTypes READ hideChildNodeTypes WRITE setHideChildNodeTypes)
+  Q_PROPERTY(bool visibilityColumnVisible READ visibilityColumnVisible WRITE setVisibilityColumnVisible)
+  Q_PROPERTY(bool idColumnVisible READ idColumnVisible WRITE setIdColumnVisible)
+  Q_PROPERTY(bool colorColumnVisible READ colorColumnVisible WRITE setColorColumnVisible)
+  Q_PROPERTY(bool transformColumnVisible READ transformColumnVisible WRITE setTransformColumnVisible)
+  Q_PROPERTY(bool descriptionColumnVisible READ descriptionColumnVisible WRITE setDescriptionColumnVisible)
 
 public:
   typedef QTreeView Superclass;
@@ -137,6 +142,22 @@ public:
   bool contextMenuEnabled()const;
   bool editMenuActionVisible()const;
   bool selectRoleSubMenuVisible()const;
+
+  /// Set visibility column visibility
+  void setVisibilityColumnVisible(bool visible);
+  bool visibilityColumnVisible();
+  /// Set ID column visibility
+  void setIdColumnVisible(bool visible);
+  bool idColumnVisible();
+  /// Set color column visibility
+  void setColorColumnVisible(bool visible);
+  bool colorColumnVisible();
+  /// Set transform column visibility
+  void setTransformColumnVisible(bool visible);
+  bool transformColumnVisible();
+  /// Set description column visibility
+  void setDescriptionColumnVisible(bool visible);
+  bool descriptionColumnVisible();
 
 public slots:
   /// Set MRML scene


### PR DESCRIPTION
Instead of
`self.ui.SubjectHierarchyTreeView.setColumnHidden(self.ui.SubjectHierarchyTreeView.model().idColumn, True)`
we can now use
`self.ui.SubjectHierarchyTreeView.idColumnVisible = False`

Same for color and transform columns.