### PR TITLE
BUG: Fix incorrect/missing volume node copy content macros

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDiffusionImageVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionImageVolumeNode.h
@@ -46,7 +46,7 @@ class VTK_MRML_EXPORT vtkMRMLDiffusionImageVolumeNode : public vtkMRMLTensorVolu
 
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
-  vtkMRMLCopyContentDefaultMacro(vtkMRMLLabelMapVolumeDisplayNode);
+  vtkMRMLCopyContentDefaultMacro(vtkMRMLDiffusionImageVolumeNode);
 
   ///
   /// Get node XML tag name (like Volume, Model)

--- a/Libs/MRML/Core/vtkMRMLVectorVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLVectorVolumeNode.h
@@ -31,6 +31,10 @@ class VTK_MRML_EXPORT vtkMRMLVectorVolumeNode : public vtkMRMLTensorVolumeNode
 
   vtkMRMLNode* CreateNodeInstance() override;
 
+  /// Copy node content (excludes basic data, such as name and node references).
+  /// \sa vtkMRMLNode::CopyContent
+  vtkMRMLCopyContentDefaultMacro(vtkMRMLVectorVolumeNode);
+
   ///
   /// Set node attributes
   void ReadXMLAttributes( const char** atts) override;

--- a/Libs/MRML/Core/vtkMRMLVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.h
@@ -64,7 +64,7 @@ public:
 
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
-  vtkMRMLCopyContentMacro(vtkMRMLVectorVolumeDisplayNode);
+  vtkMRMLCopyContentMacro(vtkMRMLVolumeNode);
 
   ///
   /// Copy the node's attributes to this object


### PR DESCRIPTION
In vtkMRMLVolumeNode, vtkMRMLVectorVolumeDisplayNode was used as the class name in vtkMRMLCopyContentMacro, rather than vtkMRMLVolumeNode.
Fixed by updating the macro with the correct class name.

vtkMRMLVectorVolumeNode was missing a vtkMRMLCopyContentDefaultMacro() so HasCopyContent() always returned false.
This prevented vector volume nodes from being displayed in the list of proxy nodes in the Sequences module.
Fixed by adding the missing macro.