### PR TITLE
COMP: Update SimpleITK to v2.0.2

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -122,7 +122,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v2.0.1"
+    "v2.0.2"
     QUIET
     )
 


### PR DESCRIPTION
On Nov. 30th 2020 I upgraded Slicer to use SimpleITK v2.0.1 and also updated ITK to 5.1.2. SimpleITK v2.0.2 was released later that day, so I just barely missed that update.  No major changes with v2.0.2, but it officially was targeting ITK 5.1.2 as well.
```
$ git shortlog --no-merges v2.0.1..v2.0.2
Bradley Lowekamp (3):
      Add missing SWIG mapping for int 64 and void pointer types
      Update ITK Superbuild version to 5.1.2
      Update release version to 2.0.2
```