### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -40,7 +40,10 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [pydicom]
   pydicom==2.0.0 --hash=sha256:667c5bf9ca52f440e538c9d03ce86b04555c10d069472a5db53103fe40d310c0
+  # [/pydicom]
+  # [Pillow]
   # Hashes correspond to the following packages:
   #  - Pillow-8.0.1-cp36-cp36m-win_amd64.whl
   #  - Pillow-8.0.1-cp36-cp36m-macosx_10_10_x86_64.whl
@@ -50,9 +53,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                 --hash=sha256:b63d4ff734263ae4ce6593798bcfee6dbfb00523c82753a3a03cbc05555a9cc3 \
                 --hash=sha256:6b4a8fd632b4ebee28282a9fef4c341835a1aa8671e2770b6f89adc8e8c2703c \
                 --hash=sha256:cc3ea6b23954da84dbee8025c616040d9aa5eaf34ea6895a0a762ee9d3e12e11
+  # [/Pillow]
+  # [six]
   six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
+  # [/six]
+  # [retrying]
   retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b
+  # [/retrying]
+  # [dicomweb-client]
   dicomweb-client==0.50.2 --hash=sha256:e839b925a89e213c9e1f3b5b9046071c50b291e3d54f975e422ee39edd06c3f8
+  # [/dicomweb-client]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -41,18 +41,18 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pydicom]
-  pydicom==2.0.0 --hash=sha256:667c5bf9ca52f440e538c9d03ce86b04555c10d069472a5db53103fe40d310c0
+  pydicom==2.1.2 --hash=sha256:d97f53a7b269dbd7414d18342f1b70f80d7d35dc4e479316bab146daac0e0c15
   # [/pydicom]
   # [Pillow]
   # Hashes correspond to the following packages:
-  #  - Pillow-8.0.1-cp36-cp36m-win_amd64.whl
-  #  - Pillow-8.0.1-cp36-cp36m-macosx_10_10_x86_64.whl
-  #  - Pillow-8.0.1-cp36-cp36m-manylinux1_x86_64.whl
-  #  - Pillow-8.0.1-cp36-cp36m-manylinux2014_aarch64.whl
-  pillow==8.0.1 --hash=sha256:7ba0ba61252ab23052e642abdb17fd08fdcfdbbf3b74c969a30c58ac1ade7cd3 \
-                --hash=sha256:b63d4ff734263ae4ce6593798bcfee6dbfb00523c82753a3a03cbc05555a9cc3 \
-                --hash=sha256:6b4a8fd632b4ebee28282a9fef4c341835a1aa8671e2770b6f89adc8e8c2703c \
-                --hash=sha256:cc3ea6b23954da84dbee8025c616040d9aa5eaf34ea6895a0a762ee9d3e12e11
+  #  - Pillow-8.1.2-cp36-cp36m-macosx_10_10_x86_64.whl
+  #  - Pillow-8.1.2-cp36-cp36m-manylinux1_x86_64.whl
+  #  - Pillow-8.1.2-cp36-cp36m-manylinux2014_aarch64.whl
+  #  - Pillow-8.1.2-cp36-cp36m-win_amd64.whl
+  Pillow==8.1.2 --hash=sha256:5cf03b9534aca63b192856aa601c68d0764810857786ea5da652581f3a44c2b0 \
+                --hash=sha256:5762ebb4436f46b566fc6351d67a9b5386b5e5de4e58fdaa18a1c83e0e20f1a8 \
+                --hash=sha256:e2cd8ac157c1e5ae88b6dd790648ee5d2777e76f1e5c7d184eaddb2938594f34 \
+                --hash=sha256:d1d6bca39bb6dd94fba23cdb3eeaea5e30c7717c5343004d900e2a63b132c341
   # [/Pillow]
   # [six]
   six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
@@ -61,7 +61,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b
   # [/retrying]
   # [dicomweb-client]
-  dicomweb-client==0.50.2 --hash=sha256:e839b925a89e213c9e1f3b5b9046071c50b291e3d54f975e422ee39edd06c3f8
+  dicomweb-client==0.52.0 --hash=sha256:2fd1e6f599198246ca082f25561dce406d9ec32fda0bcec757910c79481e54c9
   # [/dicomweb-client]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -33,12 +33,24 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [chardet]
   chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+  # [/chardet]
+  # [CouchDB]
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
+  # [/CouchDB]
+  # [gitdb]
   gitdb==4.0.5 --hash=sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac
+  # [/gitdb]
+  # [smmap]
   smmap==3.0.4 --hash=sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4
+  # [/smmap]
+  # [GitPython]
   GitPython==3.1.11 --hash=sha256:6eea89b655917b500437e9668e4a12eabdcf00229a0df1762aabd692ef9b746b
+  # [/GitPython]
+  # [six]
   six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
+  # [/six]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -34,7 +34,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [chardet]
-  chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+  chardet==4.0.0 --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
   # [/chardet]
   # [CouchDB]
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
@@ -43,10 +43,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   gitdb==4.0.5 --hash=sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac
   # [/gitdb]
   # [smmap]
-  smmap==3.0.4 --hash=sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4
+  smmap==3.0.5 --hash=sha256:7bfcf367828031dc893530a29cb35eb8c8f2d7c8f2d0989354d75d24c8573714
   # [/smmap]
   # [GitPython]
-  GitPython==3.1.11 --hash=sha256:6eea89b655917b500437e9668e4a12eabdcf00229a0df1762aabd692ef9b746b
+  GitPython==3.1.14 --hash=sha256:3283ae2fba31c913d857e12e5ba5f9a7772bbc064ae2bb09efafa71b0dd4939b
   # [/GitPython]
   # [six]
   six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -39,10 +39,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   wrapt==1.12.1 --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
   # [/wrapt]
   # [Deprecated]
-  Deprecated==1.2.10 --hash=sha256:a766c1dccb30c5f6eb2b203f87edd1d8588847709c78589e1521d769addc8218
+  Deprecated==1.2.11 --hash=sha256:924b6921f822b64ec54f49be6700a126bab0640cfafca78f22c9d429ed590560
   # [/Deprecated]
   # [PyGithub]
-  PyGithub==1.53 --hash=sha256:8ad656bf79958e775ec59f7f5a3dbcbadac12147ae3dc42708b951064096af15
+  PyGithub==1.54.1 --hash=sha256:87afd6a67ea582aa7533afdbf41635725f13d12581faed7e3e04b1579c0c0627
   # [/PyGithub]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -32,10 +32,18 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [PyJWT]
   PyJWT==1.7.1 --hash=sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e
+  # [/PyJWT]
+  # [wrapt]
   wrapt==1.12.1 --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
+  # [/wrapt]
+  # [Deprecated]
   Deprecated==1.2.10 --hash=sha256:a766c1dccb30c5f6eb2b203f87edd1d8588847709c78589e1521d769addc8218
+  # [/Deprecated]
+  # [PyGithub]
   PyGithub==1.53 --hash=sha256:8ad656bf79958e775ec59f7f5a3dbcbadac12147ae3dc42708b951064096af15
+  # [/PyGithub]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -34,16 +34,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/nose]
   # [numpy]
   # Hashes correspond to the following packages:
-  # - numpy-1.19.2-cp36-cp36m-win_amd64.whl
-  # - numpy-1.19.2-cp36-cp36m-macosx_10_9_x86_64.whl
-  # - numpy-1.19.2-cp36-cp36m-manylinux1_x86_64.whl
-  # - numpy-1.19.2-cp36-cp36m-manylinux2010_x86_64.whl
-  # - numpy-1.19.2-cp36-cp36m-manylinux2014_aarch64.whl
-  numpy==1.19.2 --hash=sha256:967c92435f0b3ba37a4257c48b8715b76741410467e2bdb1097e8391fccfae15 \
-                --hash=sha256:b594f76771bc7fc8a044c5ba303427ee67c17a09b36e1fa32bde82f5c419d17a \
-                --hash=sha256:3733640466733441295b0d6d3dcbf8e1ffa7e897d4d82903169529fd3386919a \
-                --hash=sha256:7c6646314291d8f5ea900a7ea9c4261f834b5b62159ba2abe3836f4fa6705526 \
-                --hash=sha256:7118f0a9f2f617f921ec7d278d981244ba83c85eea197be7c5a4f84af80a9c3c
+  #  - numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl
+  #  - numpy-1.19.5-cp36-cp36m-manylinux1_x86_64.whl
+  #  - numpy-1.19.5-cp36-cp36m-manylinux2010_x86_64.whl
+  #  - numpy-1.19.5-cp36-cp36m-manylinux2014_aarch64.whl
+  #  - numpy-1.19.5-cp36-cp36m-win_amd64.whl
+  numpy==1.19.5 --hash=sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff \
+                --hash=sha256:8b5e972b43c8fc27d56550b4120fe6257fdc15f9301914380b27f74856299fea \
+                --hash=sha256:a4646724fba402aa7504cd48b4b50e783296b5e10a524c7a6da62e4a8ac9698d \
+                --hash=sha256:2e55195bc1c6b705bfd8ad6f288b38b11b1af32f3c8289d6c50d47f950c12e76 \
+                --hash=sha256:dbd18bcf4889b720ba13a27ec2f2aac1981bd41203b3a3b27ba7a33f88ae4827
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -29,7 +29,10 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [nose]
   nose==1.3.7 --hash=sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac  # needed for NumPy unit tests
+  # [/nose]
+  # [numpy]
   # Hashes correspond to the following packages:
   # - numpy-1.19.2-cp36-cp36m-win_amd64.whl
   # - numpy-1.19.2-cp36-cp36m-macosx_10_9_x86_64.whl
@@ -41,6 +44,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                 --hash=sha256:3733640466733441295b0d6d3dcbf8e1ffa7e897d4d82903169529fd3386919a \
                 --hash=sha256:7c6646314291d8f5ea900a7ea9c4261f834b5b62159ba2abe3836f4fa6705526 \
                 --hash=sha256:7118f0a9f2f617f921ec7d278d981244ba83c85eea197be7c5a4f84af80a9c3c
+  # [/numpy]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -26,7 +26,9 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [pip]
   pip==20.3.3 --hash=sha256:fab098c8a1758295dd9f57413c199f23571e8fde6cc39c22c78c961b4ac6286d
+  # [/pip]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==20.3.3 --hash=sha256:fab098c8a1758295dd9f57413c199f23571e8fde6cc39c22c78c961b4ac6286d
+  pip==21.0.1 --hash=sha256:37fd50e056e2aed635dec96594606f0286640489b0db0ce7607f7e51890372d5
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -31,9 +31,15 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [packaging]
   packaging==20.4 --hash=sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181
+  # [/packaging]
+  # [pyparsing]
   pyparsing==2.4.7 --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
+  # [/pyparsing]
+  # [six]
   six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
+  # [/six]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -32,7 +32,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [packaging]
-  packaging==20.4 --hash=sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181
+  packaging==20.9 --hash=sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a
   # [/packaging]
   # [pyparsing]
   pyparsing==2.4.7 --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -27,19 +27,19 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [certifi]
-  certifi==2020.6.20 --hash=sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41
+  certifi==2020.12.5 --hash=sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830
   # [/certifi]
   # [idna]
   idna==2.10 --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
   # [/idna]
   # [chardet]
-  chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+  chardet==4.0.0 --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
   # [/chardet]
   # [urllib3]
-  urllib3==1.25.11 --hash=sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e
+  urllib3==1.26.3 --hash=sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80
   # [/urllib3]
   # [requests]
-  requests==2.24.0 --hash=sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898
+  requests==2.25.1 --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
   # [/requests]
   ]===])
 

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -26,11 +26,21 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [certifi]
   certifi==2020.6.20 --hash=sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41
+  # [/certifi]
+  # [idna]
   idna==2.10 --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
+  # [/idna]
+  # [chardet]
   chardet==3.0.4 --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
+  # [/chardet]
+  # [urllib3]
   urllib3==1.25.11 --hash=sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e
+  # [/urllib3]
+  # [requests]
   requests==2.24.0 --hash=sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898
+  # [/requests]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -29,6 +29,7 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [scipy]
   # Hashes correspond to the following packages:
   # - scipy-1.5.3-cp36-cp36m-win_amd64.whl
   # - scipy-1.5.3-cp36-cp36m-macosx_10_9_x86_64.whl
@@ -38,6 +39,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                --hash=sha256:f574558f1b774864516f3c3fe072ebc90a29186f49b720f60ed339294b7f32ac \
                --hash=sha256:b9751b39c52a3fa59312bd2e1f40144ee26b51404db5d2f0d5259c511ff6f614 \
                --hash=sha256:d5e3cc60868f396b78fc881d2c76460febccfe90f6d2f082b9952265c79a8788
+  # [/scipy]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -31,14 +31,14 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [scipy]
   # Hashes correspond to the following packages:
-  # - scipy-1.5.3-cp36-cp36m-win_amd64.whl
-  # - scipy-1.5.3-cp36-cp36m-macosx_10_9_x86_64.whl
-  # - scipy-1.5.3-cp36-cp36m-manylinux1_x86_64.whl
-  # - scipy-1.5.3-cp36-cp36m-manylinux2014_aarch64.whl
-  scipy==1.5.3 --hash=sha256:ffcbd331f1ffa82e22f1d408e93c37463c9a83088243158635baec61983aaacf \
-               --hash=sha256:f574558f1b774864516f3c3fe072ebc90a29186f49b720f60ed339294b7f32ac \
-               --hash=sha256:b9751b39c52a3fa59312bd2e1f40144ee26b51404db5d2f0d5259c511ff6f614 \
-               --hash=sha256:d5e3cc60868f396b78fc881d2c76460febccfe90f6d2f082b9952265c79a8788
+  #  - scipy-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl
+  #  - scipy-1.5.4-cp36-cp36m-manylinux1_x86_64.whl
+  #  - scipy-1.5.4-cp36-cp36m-manylinux2014_aarch64.whl
+  #  - scipy-1.5.4-cp36-cp36m-win_amd64.whl
+  scipy==1.5.4 --hash=sha256:4f12d13ffbc16e988fa40809cbbd7a8b45bc05ff6ea0ba8e3e41f6f4db3a9e47 \
+               --hash=sha256:368c0f69f93186309e1b4beb8e26d51dd6f5010b79264c0f1e9ca00cd92ea8c9 \
+               --hash=sha256:4598cf03136067000855d6b44d7a1f4f46994164bcd450fb2c3d481afc25dd06 \
+               --hash=sha256:65923bc3809524e46fb7eb4d6346552cbb6a1ffc41be748535aa502a2e3d3389
   # [/scipy]
   ]===])
 

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -25,7 +25,9 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [setuptools]
   setuptools==50.3.2 --hash=sha256:2c242a0856fbad7efbe560df4a7add9324f340cf48df43651e9604924466794a
+  # [/setuptools]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==50.3.2 --hash=sha256:2c242a0856fbad7efbe560df4a7add9324f340cf48df43651e9604924466794a
+  setuptools==54.1.1 --hash=sha256:75c5c4479f4961f1ffdb597c98aa4e4077e6813685025e8bdebf7598aa84e859
   # [/setuptools]
   ]===])
 

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -26,7 +26,9 @@ endif()
 if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
+  # [wheel]
   wheel==0.35.1 --hash=sha256:497add53525d16c173c2c1c733b8f655510e909ea78cc0e29d374243544b77a2
+  # [/wheel]
   ]===])
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [wheel]
-  wheel==0.35.1 --hash=sha256:497add53525d16c173c2c1c733b8f655510e909ea78cc0e29d374243544b77a2
+  wheel==0.36.2 --hash=sha256:78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e
   # [/wheel]
   ]===])
 

--- a/Utilities/Scripts/python_package_updater.py
+++ b/Utilities/Scripts/python_package_updater.py
@@ -1,0 +1,137 @@
+import subprocess
+import sys
+from argparse import ArgumentParser
+import os
+import re
+import requests
+
+
+def get_installed_packages():
+    """Get the output of installed python packages as a list of lines."""
+    output = subprocess.check_output([sys.executable, "-m", "pip", "list"])
+    pip_list = output.decode()
+    print(pip_list)
+    lines = pip_list.split("\n")
+    return lines
+
+
+def get_outdated_packages():
+    """Get the output of outdated installed python packages as a list of lines."""
+    output = subprocess.check_output([sys.executable, "-m", "pip", "list", "--outdated"])
+    pip_list_outdated = output.decode()
+    print(pip_list_outdated)
+    lines = pip_list_outdated.split("\n")
+    return lines
+
+
+def update_external_project_python_packages(packages_to_update, directory, cpython_tag):
+    """
+    Find and replace outdated python package versions and hashes specified in external python project files.
+
+    Input: Packages to Update (list of str), Directory to search and update python packages (str), CPython Tag (str) (eg "cp36")
+    """
+    python_version_info = sys.version_info
+    interpreter_cpython_tag = f"cp{python_version_info.major}{python_version_info.minor}"
+
+    indentation = 2
+    lines_to_write = {}
+    for i in range(2, len(packages_to_update) - 1):  # First two lines are headings, so skip parsing these. Last line is empty
+        details = packages_to_update[i].split()  # ['asn1crypto', '0.24.0', '1.4.0', 'wheel']
+        package_name = details[0]
+        current_version = details[1]
+
+        if package_name in ["vtk", "simpleitk"]:
+            continue  # Slicer python wraps VTK and SimpleITK instead of installing the official python package from PyPI
+
+        url = f"https://pypi.org/pypi/{package_name}/json"
+        url_request = requests.get(url)
+        data = url_request.json()
+
+        if cpython_tag == interpreter_cpython_tag:
+            latest_version = details[2]
+            desired_version = latest_version
+        else:
+            desired_version = current_version
+
+        filenames = []
+        hashes = []
+        desired_version_files = data["releases"][desired_version]
+        for release_file in desired_version_files:
+            if release_file["python_version"] not in ["py3", "py2.py3", cpython_tag]:
+                continue  # means we did 'pip list --outdated' earlier which confirmed version supports our python version
+            if release_file["packagetype"] != "bdist_wheel":
+                continue  # Only want to install with wheels as building from source can require complex build tools
+            filename = release_file["filename"]
+            if not filename.endswith(("py3-none-any.whl", "64.whl")):  # win_amd64.whl, aarch64.whl, x86_64.whl
+                continue  # Only want 64-bit wheels
+            wheel_hash = release_file["digests"]["sha256"]
+            filenames.append(" " * indentation + f"#  - {filename}")
+            hashes.append(f"--hash=sha256:{wheel_hash}")
+        if not hashes:
+            print(f"ERROR UPDATING '{package_name}': Unable to find latest version for specified python version." +
+                  "This package might need an updated package version for the specified CPython tag.")
+            continue
+        simple_package_version = " " * indentation + f"{package_name}=={desired_version} "
+        hashes_joiner_text = " \\\n" + " " * len(simple_package_version)  # new line for each additional hash and with indentation to line up vertically
+        all_hashes = simple_package_version + hashes_joiner_text.join(hashes)
+
+        # Only include filenames if there are multiple wheels for a given package
+        if len(filenames) > 1:
+            filenames.insert(0, " " * indentation + "# Hashes correspond to the following packages:")
+            all_filenames = "\n".join(filenames)
+            text = all_filenames + "\n" + all_hashes
+        else:
+            text = all_hashes
+
+        print(text)  # Show progress in terminal
+        lines_to_write[package_name] = f"{text}\n"
+
+    for dirpath, _, filenames, in os.walk(directory):
+        for filename in filenames:
+            filepath = os.path.join(dirpath, filename)
+            with open(filepath, "r") as open_file:
+                file_text = open_file.read()
+
+            for package_name, updated_line in lines_to_write.items():
+                regex = fr"(# \[{package_name}]).*?(# \[/{package_name}])"
+                updated_line = f"# [{package_name}]" + "\n" + updated_line + " " * indentation + f"# [/{package_name}]"
+                file_text = re.sub(regex, updated_line, file_text, flags=re.DOTALL)  # but new lines in the unlimited match messing things up
+                with open(filepath, "w") as open_file:
+                    open_file.write(file_text)
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.description = """
+        Use this script to update external python project files with the latest version
+        and the download hashes for the specified python modules.
+
+        For updating Slicer python packages for https://github.com/Slicer/Slicer/tree/master,
+        run using PythonSlicer.exe from the latest Slicer preview.
+        In the specified search directory it will then locally update all the external python
+        projects to have the latest version of the package with updated hashes.
+
+        This script DOES NOT handle python package version incompatibilities or the
+        addition/removal of other package dependencies for a given package.
+    """
+    parser.add_argument('-s', '--search-directory', metavar="Path/To/Directory", required=False, help="Directory to search and replace python version info")
+    parser.add_argument('-c', '--cpython-tag', metavar="cp{Major}.{Minor}", required=False, help="CPython version of python packages to check for")
+    args = parser.parse_args()
+
+    search_directory = args.search_directory
+    if not search_directory:
+        # Assume script is in cloned Slicer repo, so choose the SuperBuild directory to search
+        search_directory = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "SuperBuild")
+
+    python_version_info = sys.version_info
+    interpreter_cpython_tag = f"cp{python_version_info.major}{python_version_info.minor}"
+
+    cpython_tag = args.cpython_tag
+    if not cpython_tag:
+        # Assume script is updating python package versions for same cpython version being used to run script
+        cpython_tag = interpreter_cpython_tag
+    if cpython_tag == interpreter_cpython_tag:
+        packages_to_update = get_outdated_packages()
+    else:
+        packages_to_update = get_installed_packages()
+    update_external_project_python_packages(packages_to_update, search_directory, cpython_tag)


### PR DESCRIPTION
Python packages were last updated October 25th, 2020. Outdated python packages were discovered using the below code snippet and then versions, hashes and dependencies were determined and updated.

In this PR I'm only updating python packages that Slicer downloads from pypi. This means not updating SimpleITK and VTK python packages.
```
PS C:\Users\JamesButler\AppData\Local\NA-MIC\Slicer 4.13.0-2021-03-09\bin> ./PythonSlicer.exe -m pip list --outdated
Package         Version   Latest    Type
--------------- --------- --------- -----
certifi         2020.6.20 2020.12.5 wheel
chardet         3.0.4     4.0.0     wheel
Deprecated      1.2.10    1.2.11    wheel
dicomweb-client 0.50.2    0.52.0    wheel
GitPython       3.1.11    3.1.14    wheel
idna            2.10      3.1       wheel
numpy           1.19.2    1.19.5    wheel
packaging       20.4      20.9      wheel
Pillow          8.0.1     8.1.2     wheel
pip             20.3.3    21.0.1    wheel
pydicom         2.0.0     2.1.2     wheel
PyGithub        1.53      1.54.1    wheel
PyJWT           1.7.1     2.0.1     wheel
requests        2.24.0    2.25.1    wheel
scipy           1.5.3     1.5.4     wheel
setuptools      50.3.2    54.1.1    wheel
smmap           3.0.4     4.0.0     wheel
urllib3         1.25.11   1.26.3    wheel
wheel           0.35.1    0.36.2    wheel
```

- I'm unable to upgrade `idna`  because `requests` requires idna >=2.5, <3
- I'm unable to upgrade `PyJWT` because `PyGithub` requires pyjwt<2.0
- I'm unable to upgrade `smmap` to latest because `gitdb` has the requirement smmap>=3.0.1,<4, so I have it at 3.0.5.

Packages I'm unable to upgrade to their latest release because they dropped support for Python 3.6 (see https://github.com/Slicer/Slicer/issues/5014#issuecomment-742599890):
- `numpy` >= v1.20.0
- `scipy` >= v1.6.0