### PR TITLE
BUG: Fix segment subject hierarchy visibility when display node modified

### DIFF
--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
@@ -805,6 +805,18 @@ void qSlicerSubjectHierarchySegmentationsPlugin::onSegmentModified(vtkObject* ca
 }
 
 //---------------------------------------------------------------------------
+void qSlicerSubjectHierarchySegmentationsPlugin::onDisplayNodeModified(vtkObject* caller)
+{
+  // Get segmentation node
+  vtkMRMLSegmentationNode* segmentationNode = reinterpret_cast<vtkMRMLSegmentationNode*>(caller);
+  if (!segmentationNode)
+    {
+    return;
+    }
+  this->updateAllSegmentsFromMRML(segmentationNode);
+}
+
+//---------------------------------------------------------------------------
 void qSlicerSubjectHierarchySegmentationsPlugin::onSubjectHierarchyItemModified(vtkObject* caller, void* callData)
 {
   vtkMRMLSubjectHierarchyNode* shNode = reinterpret_cast<vtkMRMLSubjectHierarchyNode*>(caller);

--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.h
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.h
@@ -127,6 +127,9 @@ public slots:
   /// Renames per-segment subject hierarchy node if necessary
   void onSegmentModified(vtkObject* caller, void* callData);
 
+  ///  Called when segmentation display node is modified
+  void onDisplayNodeModified(vtkObject* caller);
+
   /// Called when a subject hierarchy item is modified.
   /// Renames segment if the modified item belongs to a segment
   void onSubjectHierarchyItemModified(vtkObject* caller, void* callData);

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.cxx
@@ -246,6 +246,8 @@ void qSlicerSegmentationsModule::onNodeAdded(vtkObject* sceneObject, vtkObject* 
       segmentationsPlugin, SLOT( onSegmentRemoved(vtkObject*,void*) ) );
     qvtkConnect( segmentationNode, vtkSegmentation::SegmentModified,
       segmentationsPlugin, SLOT( onSegmentModified(vtkObject*,void*) ) );
+    qvtkConnect(segmentationNode, vtkMRMLSegmentationNode::DisplayModifiedEvent,
+      segmentationsPlugin, SLOT( onDisplayNodeModified(vtkObject*) ) );
     }
 
   // Connect subject hierarchy modified event to handle renaming segments from subject hierarchy


### PR DESCRIPTION
The visibility of the segment subject hierarchy visibility was not being updated when segment display properties were modified.
Fixed by adding the slot qSlicerSubjectHierarchySegmentationsPlugin::onDisplayNodeModified() that is invoked when the display node is modified.
This slot updates all segment items from the corresponding display node.

See discussion here: https://discourse.slicer.org/t/visibility-of-segments-from-data-module-vs-segment-editor-segmentations/15888