### PR TITLE
ENH: Extend capabilities of subject hierarchy attribute filtering

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1188,6 +1188,31 @@ class NodeModify(object):
   def __exit__(self, type, value, traceback):
     self.node.EndModify(self.wasModifying)
 
+
+
+#
+# Subject hierarchy
+#
+def getSubjectHierarchyItemChildren(parentItem=None, recursive=False):
+  """Convenience method to get children of a subject hierarchy item.
+  :param vtkIdType parentItem: Item for which to get children for. If omitted
+         or None then use scene item (i.e. get all items)
+  :param bool recursive: Whether the query is recursive. False by default
+  :return: List of child item IDs
+  """
+  children = []
+  shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
+  # Use scene as parent item if not given
+  if not parentItem:
+    parentItem = shNode.GetSceneItemID()
+  childrenIdList = vtk.vtkIdList()
+  shNode.GetItemChildren(parentItem, childrenIdList, recursive)
+  for childIndex in range(childrenIdList.GetNumberOfIds()):
+    children.append(childrenIdList.GetId(childIndex))
+  return children
+
+
+
 #
 # MRML-numpy
 #

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.cxx
@@ -31,7 +31,11 @@
 #include "qMRMLSubjectHierarchyModel.h"
 
 // Qt includes
+#include <QDebug>
 #include <QStandardItem>
+
+// STD includes
+#include <algorithm>
 
 // -----------------------------------------------------------------------------
 // qMRMLSortFilterSubjectHierarchyProxyModelPrivate
@@ -43,25 +47,150 @@ class qMRMLSortFilterSubjectHierarchyProxyModelPrivate
 public:
   qMRMLSortFilterSubjectHierarchyProxyModelPrivate();
 
-  QString NameFilter;
-  QString AttributeNameFilter;
-  QString AttributeValueFilter;
-  QStringList LevelFilter;
-  QStringList NodeTypes;
-  QStringList HideChildNodeTypes;
-  vtkIdType HideItemsUnaffiliatedWithItemID;
+  class AttributeFilter
+    {
+    public:
+      AttributeFilter(QString attributeName)
+        : AttributeName(attributeName) { };
+
+      AttributeFilter(QString attributeName, QVariant attributeValue, bool include, QString className=QString())
+        : AttributeName(attributeName), AttributeValue(attributeValue), Include(include), ClassName(className) { };
+
+      /// Name of the attribute to filter
+      QString AttributeName;
+      /// Value of the attribute to filter. Empty by default (i.e. allow any value)
+      QVariant AttributeValue{QString()};
+      /// Flag indicating whether this is an include filter or exclude filter.
+      /// - Include filter means that only the items are shown that match the filter.
+      /// - Exclude filter hides items that match the filter. Overrides include filters.
+      /// True by default (i.e. include filter).
+      bool Include{true};
+      /// Only filter attributes on a certain type. Empty by default (i.e. allow all classes).
+      /// Not used for item filters, only node filters.
+      QString ClassName{QString()};
+      };
+
+    /// Find item attribute filter
+    /// \return List index if found, -1 otherwise.
+    int findItemAttributeFilter(QString attributeName, QVariant attributeValue, bool include);
+    /// Find item attribute filters for an attribute name and include flag
+    /// \return List of list indices for the found filters. Empty list if not found
+    QList<int> findItemAttributeFilters(QString attributeName, bool include);
+    /// Find node attribute filter
+    /// \return List index if found, -1 otherwise.
+    int findNodeAttributeFilter(QString attributeName, QVariant attributeValue, bool include, QString className);
+    /// Find node attribute filters for an attribute name and include flag
+    /// \return List of list indices for the found filters. Empty list if not found
+    QList<int> findNodeAttributeFilters(QString attributeName, bool include);
+    /// Remove include or exclude filters from a given filter list
+    void removeFiltersByIncludeFlag(QList<AttributeFilter>& filterList, bool include);
+  private:
+    /// Find attribute filter in given filter list
+    /// \return List index if found, -1 otherwise.
+    int findAttributeFilter(QList<AttributeFilter> filterList, QString attributeName, QVariant attributeValue, bool include, QString className);
+    /// Find node attribute filters for an attribute name and include flag in given filter list
+    /// \param attributeName Attribute name that the found filters contain. If empty then all filters are considered
+    /// \param include Include/exclude flag for the found filters.
+    /// \return List of list indices for the found filters. Empty list if not found
+    QList<int> findAttributeFilters(QList<AttributeFilter> filterList, QString attributeName, bool include);
+
+  public:
+    QString NameFilter;
+    QStringList LevelFilter;
+    QStringList NodeTypes;
+    QStringList HideChildNodeTypes;
+    vtkIdType HideItemsUnaffiliatedWithItemID;
+    QList<AttributeFilter> ItemAttributeFilters;
+    QList<AttributeFilter> NodeAttributeFilters;
 };
 
 // -----------------------------------------------------------------------------
 qMRMLSortFilterSubjectHierarchyProxyModelPrivate::qMRMLSortFilterSubjectHierarchyProxyModelPrivate()
   : NameFilter(QString())
-  , AttributeNameFilter(QString())
-  , AttributeValueFilter(QString())
   , LevelFilter(QStringList())
   , NodeTypes(QStringList())
+  , ItemAttributeFilters(QList<AttributeFilter>())
+  , NodeAttributeFilters(QList<AttributeFilter>())
   , HideChildNodeTypes(QStringList())
   , HideItemsUnaffiliatedWithItemID(vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID)
 {
+}
+
+// -----------------------------------------------------------------------------
+int qMRMLSortFilterSubjectHierarchyProxyModelPrivate::findItemAttributeFilter(
+  QString attributeName, QVariant attributeValue, bool include)
+{
+  return this->findAttributeFilter(this->ItemAttributeFilters, attributeName, attributeValue, include, QString());
+}
+
+// -----------------------------------------------------------------------------
+QList<int> qMRMLSortFilterSubjectHierarchyProxyModelPrivate::findItemAttributeFilters(QString attributeName, bool include)
+{
+  return this->findAttributeFilters(this->ItemAttributeFilters, attributeName, include);
+}
+
+// -----------------------------------------------------------------------------
+int qMRMLSortFilterSubjectHierarchyProxyModelPrivate::findNodeAttributeFilter(
+  QString attributeName, QVariant attributeValue, bool include, QString className)
+{
+  return this->findAttributeFilter(this->NodeAttributeFilters, attributeName, attributeValue, include, className);
+}
+
+// -----------------------------------------------------------------------------
+QList<int> qMRMLSortFilterSubjectHierarchyProxyModelPrivate::findNodeAttributeFilters(QString attributeName, bool include)
+{
+  return this->findAttributeFilters(this->NodeAttributeFilters, attributeName, include);
+}
+
+// -----------------------------------------------------------------------------
+int qMRMLSortFilterSubjectHierarchyProxyModelPrivate::findAttributeFilter(
+  QList<AttributeFilter> filterList, QString attributeName, QVariant attributeValue, bool include, QString className)
+{
+  int index = 0;
+  foreach (AttributeFilter filter, filterList)
+    {
+    if (filter.AttributeName == attributeName && filter.AttributeValue == attributeValue
+      && filter.Include == include && filter.ClassName == className)
+      {
+      return index;
+      }
+    index++;
+    }
+  return -1;
+}
+
+// -----------------------------------------------------------------------------
+QList<int> qMRMLSortFilterSubjectHierarchyProxyModelPrivate::findAttributeFilters(
+  QList<AttributeFilter> filterList, QString attributeName, bool include)
+{
+  QList<int> foundIndices;
+  int index = 0;
+  foreach (AttributeFilter filter, filterList)
+    {
+    if ((attributeName.isEmpty() || filter.AttributeName == attributeName) && filter.Include == include)
+      {
+      foundIndices << index;
+      }
+    index++;
+    }
+  return foundIndices;
+}
+
+// -----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModelPrivate::removeFiltersByIncludeFlag(QList<AttributeFilter>& filterList, bool include)
+{
+  QList<int> foundIndices = this->findAttributeFilters(filterList, QString(), include);
+  if (foundIndices.size() == 0)
+    {
+    return;
+    }
+
+  while (foundIndices.size() > 0)
+    {
+    // Remove the largest index first
+    int lastIndex = foundIndices.takeLast();
+    filterList.removeAt(lastIndex);
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -69,8 +198,6 @@ qMRMLSortFilterSubjectHierarchyProxyModelPrivate::qMRMLSortFilterSubjectHierarch
 
 // -----------------------------------------------------------------------------
 CTK_GET_CPP(qMRMLSortFilterSubjectHierarchyProxyModel, QString, nameFilter, NameFilter);
-CTK_GET_CPP(qMRMLSortFilterSubjectHierarchyProxyModel, QString, attributeNameFilter, AttributeNameFilter);
-CTK_GET_CPP(qMRMLSortFilterSubjectHierarchyProxyModel, QString, attributeValueFilter, AttributeValueFilter);
 CTK_GET_CPP(qMRMLSortFilterSubjectHierarchyProxyModel, QStringList, levelFilter, LevelFilter);
 CTK_GET_CPP(qMRMLSortFilterSubjectHierarchyProxyModel, QStringList, nodeTypes, NodeTypes);
 CTK_GET_CPP(qMRMLSortFilterSubjectHierarchyProxyModel, QStringList, hideChildNodeTypes, HideChildNodeTypes);
@@ -127,27 +254,271 @@ void qMRMLSortFilterSubjectHierarchyProxyModel::setNameFilter(QString filter)
 }
 
 //-----------------------------------------------------------------------------
-void qMRMLSortFilterSubjectHierarchyProxyModel::setAttributeNameFilter(QString filter)
+void qMRMLSortFilterSubjectHierarchyProxyModel::addItemAttributeFilter(
+  QString attributeName, QVariant attributeValue/*=QString()*/, bool include/*=true*/)
 {
   Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
-  if (d->AttributeNameFilter == filter)
+  if (d->findItemAttributeFilter(attributeName, attributeValue, include) >= 0)
     {
     return;
     }
-  d->AttributeNameFilter = filter;
+
+  qMRMLSortFilterSubjectHierarchyProxyModelPrivate::AttributeFilter newFilter(attributeName, attributeValue, include);
+  d->ItemAttributeFilters << newFilter;
   this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::removeItemAttributeFilter(QString attributeName, QVariant attributeValue, bool include)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+  int foundIndex = d->findItemAttributeFilter(attributeName, attributeValue, include);
+  if (foundIndex < 0)
+    {
+    qWarning() << Q_FUNC_INFO << ": Failed to remove item attribute filter by exact match";
+    return;
+    }
+
+  d->ItemAttributeFilters.removeAt(foundIndex);
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::removeItemAttributeFilter(QString attributeName, bool include)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+  QList<int> foundIndices = d->findItemAttributeFilters(attributeName, include);
+  if (foundIndices.size() == 0)
+    {
+    qWarning() << Q_FUNC_INFO << ": Failed to remove item attribute filter by name and include flag";
+    return;
+    }
+
+  while (foundIndices.size() > 0)
+    {
+    // Remove the largest index first
+    int lastIndex = foundIndices.takeLast();
+    d->ItemAttributeFilters.removeAt(lastIndex);
+    }
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::addNodeAttributeFilter(
+  QString attributeName, QVariant attributeValue/*=QString()*/, bool include/*=true*/, QString className/*=QString()*/)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+  if (d->findNodeAttributeFilter(attributeName, attributeValue, include, className) >= 0)
+    {
+    return;
+    }
+
+  qMRMLSortFilterSubjectHierarchyProxyModelPrivate::AttributeFilter newFilter(attributeName, attributeValue, include, className);
+  d->NodeAttributeFilters << newFilter;
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::removeNodeAttributeFilter(QString attributeName, QVariant attributeValue, bool include, QString className)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+  int foundIndex = d->findNodeAttributeFilter(attributeName, attributeValue, include, className);
+  if (foundIndex < 0)
+    {
+    qWarning() << Q_FUNC_INFO << ": Failed to remove node attribute filter by exact match";
+    return;
+    }
+
+  d->NodeAttributeFilters.removeAt(foundIndex);
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::removeNodeAttributeFilter(QString attributeName, bool include)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+  QList<int> foundIndices = d->findNodeAttributeFilters(attributeName, include);
+  if (foundIndices.size() == 0)
+    {
+    qWarning() << Q_FUNC_INFO << ": Failed to remove node attribute filter by name and include flag";
+    return;
+    }
+
+  while (foundIndices.size() > 0)
+    {
+    // Remove the largest index first
+    int lastIndex = foundIndices.takeLast();
+    d->NodeAttributeFilters.removeAt(lastIndex);
+    }
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::setIncludeItemAttributeNamesFilter(QStringList filterList)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+
+  d->removeFiltersByIncludeFlag(d->ItemAttributeFilters, true);
+  foreach (QString filter, filterList)
+    {
+    this->addItemAttributeFilter(filter);
+    }
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSortFilterSubjectHierarchyProxyModel::includeItemAttributeNamesFilter()const
+{
+  Q_D(const qMRMLSortFilterSubjectHierarchyProxyModel);
+
+  QStringList filteredAttributeNameList;
+  QList<qMRMLSortFilterSubjectHierarchyProxyModelPrivate::AttributeFilter>::const_iterator it;
+  for (it = d->ItemAttributeFilters.constBegin(); it != d->ItemAttributeFilters.constEnd(); ++it)
+    {
+    if (it->Include == true)
+      {
+      filteredAttributeNameList << it->AttributeName;
+      }
+    }
+  return filteredAttributeNameList;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::setIncludeNodeAttributeNamesFilter(QStringList filterList)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+
+  d->removeFiltersByIncludeFlag(d->NodeAttributeFilters, true);
+  foreach (QString filter, filterList)
+    {
+    this->addNodeAttributeFilter(filter);
+    }
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSortFilterSubjectHierarchyProxyModel::includeNodeAttributeNamesFilter()const
+{
+  Q_D(const qMRMLSortFilterSubjectHierarchyProxyModel);
+
+  QStringList filteredAttributeNameList;
+  QList<qMRMLSortFilterSubjectHierarchyProxyModelPrivate::AttributeFilter>::const_iterator it;
+  for (it = d->NodeAttributeFilters.constBegin(); it != d->NodeAttributeFilters.constEnd(); ++it)
+    {
+    if (it->Include == true)
+      {
+      filteredAttributeNameList << it->AttributeName;
+      }
+    }
+  return filteredAttributeNameList;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::setExcludeItemAttributeNamesFilter(QStringList filterList)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+
+  d->removeFiltersByIncludeFlag(d->ItemAttributeFilters, false);
+  foreach (QString filter, filterList)
+    {
+    this->addItemAttributeFilter(filter, QString(), false);
+    }
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSortFilterSubjectHierarchyProxyModel::excludeItemAttributeNamesFilter()const
+{
+  Q_D(const qMRMLSortFilterSubjectHierarchyProxyModel);
+
+  QStringList filteredAttributeNameList;
+  QList<qMRMLSortFilterSubjectHierarchyProxyModelPrivate::AttributeFilter>::const_iterator it;
+  for (it = d->ItemAttributeFilters.constBegin(); it != d->ItemAttributeFilters.constEnd(); ++it)
+    {
+    if (it->Include == false)
+      {
+      filteredAttributeNameList << it->AttributeName;
+      }
+    }
+  return filteredAttributeNameList;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::setExcludeNodeAttributeNamesFilter(QStringList filterList)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+
+  d->removeFiltersByIncludeFlag(d->NodeAttributeFilters, false);
+  foreach (QString filter, filterList)
+    {
+    this->addNodeAttributeFilter(filter, QString(), false);
+    }
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSortFilterSubjectHierarchyProxyModel::excludeNodeAttributeNamesFilter()const
+{
+  Q_D(const qMRMLSortFilterSubjectHierarchyProxyModel);
+
+  QStringList filteredAttributeNameList;
+  QList<qMRMLSortFilterSubjectHierarchyProxyModelPrivate::AttributeFilter>::const_iterator it;
+  for (it = d->NodeAttributeFilters.constBegin(); it != d->NodeAttributeFilters.constEnd(); ++it)
+    {
+    if (it->Include == false)
+      {
+      filteredAttributeNameList << it->AttributeName;
+      }
+    }
+  return filteredAttributeNameList;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSortFilterSubjectHierarchyProxyModel::setAttributeNameFilter(QString filter)
+{
+  Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
+  d->ItemAttributeFilters.clear();
+  if (!filter.isEmpty())
+    {
+    this->addItemAttributeFilter(filter);
+    }
+  this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSortFilterSubjectHierarchyProxyModel::attributeNameFilter()const
+{
+  Q_D(const qMRMLSortFilterSubjectHierarchyProxyModel);
+  if (d->ItemAttributeFilters.size() > 0)
+    {
+    return d->ItemAttributeFilters[0].AttributeName;
+    }
+  return QString();
 }
 
 //-----------------------------------------------------------------------------
 void qMRMLSortFilterSubjectHierarchyProxyModel::setAttributeValueFilter(QString filter)
 {
   Q_D(qMRMLSortFilterSubjectHierarchyProxyModel);
-  if (d->AttributeValueFilter == filter)
+  if (d->ItemAttributeFilters.size() != 1)
     {
+    qCritical() << Q_FUNC_INFO << ": Attribute value filter must be set after setting name filter using attributeNameFilter";
     return;
     }
-  d->AttributeValueFilter = filter;
+
+  d->ItemAttributeFilters[0].AttributeValue = filter;
   this->invalidateFilter();
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSortFilterSubjectHierarchyProxyModel::attributeValueFilter() const
+{
+  Q_D(const qMRMLSortFilterSubjectHierarchyProxyModel);
+  if (d->ItemAttributeFilters.size() > 0)
+    {
+    return d->ItemAttributeFilters[0].AttributeValue.toString();
+    }
+  return QString();
 }
 
 //-----------------------------------------------------------------------------
@@ -227,12 +598,16 @@ QModelIndex qMRMLSortFilterSubjectHierarchyProxyModel::indexFromSubjectHierarchy
 }
 
 //------------------------------------------------------------------------------
-int qMRMLSortFilterSubjectHierarchyProxyModel::acceptedItemCount(vtkIdType rootItemID)const
+int qMRMLSortFilterSubjectHierarchyProxyModel::acceptedItemCount(vtkIdType rootItemID/*=0*/)const
 {
   vtkMRMLSubjectHierarchyNode* shNode = this->subjectHierarchyNode();
   if (!shNode)
     {
     return 0;
+    }
+  if (!rootItemID)
+    {
+    rootItemID = shNode->GetSceneItemID();
     }
 
   // Count the accepted items under the root item
@@ -345,7 +720,6 @@ bool qMRMLSortFilterSubjectHierarchyProxyModel::filterAcceptsItem(vtkIdType item
     bool nodeTypeAccepted = false;
     if (!d->NodeTypes.isEmpty())
       {
-      QString dataNodeClass(dataNode->GetClassName());
       foreach (const QString& nodeType, d->NodeTypes)
         {
         if (dataNode->IsA(nodeType.toUtf8().data()))
@@ -381,6 +755,89 @@ bool qMRMLSortFilterSubjectHierarchyProxyModel::filterAcceptsItem(vtkIdType item
         return false;
         }
       }
+
+    // Filter by node attribute
+    std::vector<std::string> nodeAttributeNames = dataNode->GetAttributeNames();
+    std::vector<std::string>::iterator nodeAttrIt;
+    QList<qMRMLSortFilterSubjectHierarchyProxyModelPrivate::AttributeFilter>::const_iterator filterIt;
+    // Handle exclude filters first
+    for (filterIt = d->NodeAttributeFilters.constBegin(); filterIt != d->NodeAttributeFilters.constEnd(); ++filterIt)
+      {
+      if (filterIt->Include)
+        {
+        continue; // Skip include filters
+        }
+      if (!filterIt->ClassName.isEmpty() && !dataNode->IsA(filterIt->ClassName.toUtf8().constData()))
+        {
+        // If class name is specified and the data node is not of the class then filter does not apply
+        continue;
+        }
+      nodeAttrIt = std::find(nodeAttributeNames.begin(), nodeAttributeNames.end(), filterIt->AttributeName.toUtf8().constData());
+      if (nodeAttrIt == nodeAttributeNames.end())
+        {
+        // If filtered attribute name is not present in the data node then filter does not apply
+        continue;
+        }
+      if (filterIt->AttributeValue.toString().isEmpty())
+        {
+        // If attribute value is not specified in the filter then reject node
+        return false;
+        }
+      const char* attributeValue = dataNode->GetAttribute(nodeAttrIt->c_str());
+      if (!filterIt->AttributeValue.toString().compare(attributeValue))
+        {
+        // If attribute value is specified and matches the attribute value in the data node then reject node
+        return false;
+        }
+      }
+    // Handle include filters second
+    bool hasIncludeFilter = false;
+    bool anyIncludedAttributeFound = false;
+    for (filterIt = d->NodeAttributeFilters.constBegin(); filterIt != d->NodeAttributeFilters.constEnd(); ++filterIt)
+      {
+      if (!filterIt->Include)
+        {
+        continue; // Skip exclude filters
+        }
+      hasIncludeFilter = true;
+      if (!filterIt->ClassName.isEmpty() && !dataNode->IsA(filterIt->ClassName.toUtf8().constData()))
+        {
+        // If class name is specified the data node is not of the class then filter does not apply
+        continue;
+        }
+      nodeAttrIt = std::find(nodeAttributeNames.begin(), nodeAttributeNames.end(), filterIt->AttributeName.toUtf8().constData());
+      if (nodeAttrIt == nodeAttributeNames.end())
+        {
+        // If filtered attribute name is not present in the data node then filter does not apply
+        continue;
+        }
+      if (filterIt->AttributeValue.toString().isEmpty())
+        {
+        // If attribute value is not specified in the filter then accept
+        anyIncludedAttributeFound = true;
+        break;
+        }
+      const char* attributeValue = dataNode->GetAttribute(nodeAttrIt->c_str());
+      if (!filterIt->AttributeValue.toString().compare(attributeValue))
+        {
+        // If attribute value is specified and matches the attribute value in the data node then accept
+        anyIncludedAttributeFound = true;
+        break;
+        }
+      }
+    if (hasIncludeFilter && !anyIncludedAttributeFound)
+      {
+      if (canAcceptIfAnyChildIsAccepted)
+        {
+        // If included node attribute is missing, then only show if any of its children are shown
+        onlyAcceptIfAnyChildIsAccepted = true;
+        }
+      else
+        {
+        return false;
+        }
+      }
+
     } // If data node
 
   // Filter by level
@@ -425,37 +882,70 @@ bool qMRMLSortFilterSubjectHierarchyProxyModel::filterAcceptsItem(vtkIdType item
     }
 
   // Filter by item attribute
-  if (!d->AttributeNameFilter.isEmpty())
+  QList<qMRMLSortFilterSubjectHierarchyProxyModelPrivate::AttributeFilter>::const_iterator filterIt;
+  // Handle exclude filters first
+  for (filterIt = d->ItemAttributeFilters.constBegin(); filterIt != d->ItemAttributeFilters.constEnd(); ++filterIt)
     {
-    std::string attributeNameFilterStr(d->AttributeNameFilter.toUtf8().constData());
-    if (!shNode->HasItemAttribute(itemID, attributeNameFilterStr))
+    if (filterIt->Include)
       {
-      if (canAcceptIfAnyChildIsAccepted)
-        {
-        // If attribute was requested but missing, then only show if any of its children are shown
-        onlyAcceptIfAnyChildIsAccepted = true;
-        }
-      else
-        {
-        return false;
-        }
+      continue; // Skip include filters
       }
-    else if (!d->AttributeValueFilter.isEmpty())
+    if (!shNode->HasItemAttribute(itemID, filterIt->AttributeName.toUtf8().constData()))
       {
-      std::string attributeValueFilterStr(d->AttributeValueFilter.toUtf8().constData());
-      std::string attributeValue = shNode->GetItemAttribute(itemID, attributeNameFilterStr);
-      if (attributeValue.compare(attributeValueFilterStr))
-        {
-        if (canAcceptIfAnyChildIsAccepted)
-          {
-          // If attribute value check was requested but failed, then only show if any of its children are shown
-          onlyAcceptIfAnyChildIsAccepted = true;
-          }
-        else
-          {
-          return false;
-          }
-        }
+      // If filtered attribute name is not present in the item then filter does not apply
+      continue;
+      }
+    if (filterIt->AttributeValue.toString().isEmpty())
+      {
+      // If attribute value is not specified in the filter then reject item
+      return false;
+      }
+    std::string attributeValue = shNode->GetItemAttribute(itemID, filterIt->AttributeName.toUtf8().constData());
+    if (!filterIt->AttributeValue.toString().compare(attributeValue.c_str()))
+      {
+      // If attribute value is specified and matches the attribute value in the item then reject item
+      return false;
+      }
+    }
+  // Handle include filters second
+  bool hasIncludeFilter = false;
+  bool anyIncludedAttributeFound = false;
+  for (filterIt = d->ItemAttributeFilters.constBegin(); filterIt != d->ItemAttributeFilters.constEnd(); ++filterIt)
+    {
+    if (!filterIt->Include)
+      {
+      continue; // Skip exclude filters
+      }
+    hasIncludeFilter = true;
+    if (!shNode->HasItemAttribute(itemID, filterIt->AttributeName.toUtf8().constData()))
+      {
+      // If filtered attribute name is not present in the item then filter does not apply
+      continue;
+      }
+    if (filterIt->AttributeValue.toString().isEmpty())
+      {
+      // If attribute value is not specified in the filter then accept
+      anyIncludedAttributeFound = true;
+      break;
+      }
+    std::string attributeValue = shNode->GetItemAttribute(itemID, filterIt->AttributeName.toUtf8().constData());
+    if (!filterIt->AttributeValue.toString().compare(attributeValue.c_str()))
+      {
+      // If attribute value is specified and matches the attribute value in the item then accept
+      anyIncludedAttributeFound = true;
+      break;
+      }
+    }
+  if (hasIncludeFilter && !anyIncludedAttributeFound)
+    {
+    if (canAcceptIfAnyChildIsAccepted)
+      {
+      // If included item attribute is missing, then only show if any of its children are shown
+      onlyAcceptIfAnyChildIsAccepted = true;
+      }
+    else
+      {
+      return false;
       }
     }
 
@@ -502,7 +992,7 @@ bool qMRMLSortFilterSubjectHierarchyProxyModel::filterAcceptsItem(vtkIdType item
 }
 
 //------------------------------------------------------------------------------
-Qt::ItemFlags qMRMLSortFilterSubjectHierarchyProxyModel::flags(const QModelIndex & index)const 
+Qt::ItemFlags qMRMLSortFilterSubjectHierarchyProxyModel::flags(const QModelIndex & index)const
 {
   vtkIdType itemID = this->subjectHierarchyItemFromIndex(index);
   bool isSelectable = this->filterAcceptsItem(itemID, false);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -263,18 +263,161 @@ void qMRMLSubjectHierarchyComboBox::disablePlugin(QString plugin)
   d->TreeView->disablePlugin(plugin);
 }
 
-//--------------------------------------------------------------------------
-void qMRMLSubjectHierarchyComboBox::setAttributeFilter(const QString& attributeName, const QVariant& attributeValue/*=QVariant()*/)
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::setIncludeItemAttributeNamesFilter(QStringList filter)
 {
   Q_D(qMRMLSubjectHierarchyComboBox);
-  d->TreeView->setAttributeFilter(attributeName, attributeValue);
+  this->sortFilterProxyModel()->setIncludeItemAttributeNamesFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
 }
 
-//--------------------------------------------------------------------------
-void qMRMLSubjectHierarchyComboBox::removeAttributeFilter()
+//-----------------------------------------------------------------------------
+QStringList qMRMLSubjectHierarchyComboBox::includeItemAttributeNamesFilter()const
+{
+  return this->sortFilterProxyModel()->includeItemAttributeNamesFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::setIncludeNodeAttributeNamesFilter(QStringList filter)
 {
   Q_D(qMRMLSubjectHierarchyComboBox);
-  d->TreeView->removeAttributeFilter();
+  this->sortFilterProxyModel()->setIncludeNodeAttributeNamesFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSubjectHierarchyComboBox::includeNodeAttributeNamesFilter()const
+{
+  return this->sortFilterProxyModel()->includeNodeAttributeNamesFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::setExcludeItemAttributeNamesFilter(QStringList filter)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->setExcludeItemAttributeNamesFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSubjectHierarchyComboBox::excludeItemAttributeNamesFilter()const
+{
+  return this->sortFilterProxyModel()->excludeItemAttributeNamesFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::setExcludeNodeAttributeNamesFilter(QStringList filter)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->setExcludeNodeAttributeNamesFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSubjectHierarchyComboBox::excludeNodeAttributeNamesFilter()const
+{
+  return this->sortFilterProxyModel()->excludeNodeAttributeNamesFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::setAttributeNameFilter(QString& filter)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->setAttributeNameFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSubjectHierarchyComboBox::attributeNameFilter()const
+{
+  return this->sortFilterProxyModel()->attributeNameFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::setAttributeValueFilter(QString& filter)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->setAttributeValueFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSubjectHierarchyComboBox::attributeValueFilter()const
+{
+  return this->sortFilterProxyModel()->attributeValueFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::addItemAttributeFilter(QString attributeName, QVariant attributeValue/*=QString()*/, bool include/*=true*/)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->addItemAttributeFilter(attributeName, attributeValue, include);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::removeItemAttributeFilter(QString attributeName, QVariant attributeValue, bool include)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->removeItemAttributeFilter(attributeName, attributeValue, include);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::removeItemAttributeFilter(QString attributeName, bool include)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->removeItemAttributeFilter(attributeName, include);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::addNodeAttributeFilter(
+  QString attributeName, QVariant attributeValue/*=QString()*/, bool include/*=true*/, QString className/*=QString()*/)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->addNodeAttributeFilter(attributeName, attributeValue, include, className);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::removeNodeAttributeFilter(QString attributeName, QVariant attributeValue, bool include, QString className)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->removeNodeAttributeFilter(attributeName, attributeValue, include, className);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::removeNodeAttributeFilter(QString attributeName, bool include)
+{
+  Q_D(qMRMLSubjectHierarchyComboBox);
+  this->sortFilterProxyModel()->removeNodeAttributeFilter(attributeName, include);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  d->TreeView->setRootItem(d->TreeView->rootItem());
 }
 
 //--------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
@@ -57,6 +57,26 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qMRMLSubjectHierarchyCombo
   /// Else, the popup tree appears below the combobox, like for a qMRMLNodeComboBox.
   Q_PROPERTY(bool alignPopupVertically READ alignPopupVertically WRITE setAlignPopupVertically)
 
+  /// Filter to show only items that contain any of the given attributes with this name. Empty by default
+  Q_PROPERTY(QStringList includeItemAttributeNamesFilter READ includeItemAttributeNamesFilter WRITE setIncludeItemAttributeNamesFilter)
+  /// Filter to show only items for data nodes that contain any of the given attributes with this name. Empty by default
+  Q_PROPERTY(QStringList includeNodeAttributeNamesFilter READ includeNodeAttributeNamesFilter WRITE setIncludeNodeAttributeNamesFilter)
+  /// Filter to hide items that contain any of the given attributes with this name. Empty by default
+  /// Overrides \sa includeItemAttributeNamesFilter
+  Q_PROPERTY(QStringList excludeItemAttributeNamesFilter READ excludeItemAttributeNamesFilter WRITE setExcludeItemAttributeNamesFilter)
+  /// Filter to hide items for data nodes that contain any of the given attributes with this name. Empty by default
+  /// Overrides \sa includeNodeAttributeNamesFilter
+  Q_PROPERTY(QStringList excludeNodeAttributeNamesFilter READ excludeNodeAttributeNamesFilter WRITE setExcludeNodeAttributeNamesFilter)
+
+  /// Filter to show only items that contain an attribute with this name. Empty by default
+  /// Note: Deprecated, kept only for backwards compatibility. Sets and returns the first attribute in \sa includeNodeAttributeNamesFilter
+  Q_PROPERTY(QString attributeNameFilter READ attributeNameFilter WRITE setAttributeNameFilter)
+  /// Filter to show only items that contain any attribute given in \sa includeItemAttributeNamesFilter with the value.
+  /// If empty, then existence of the attributes is enough to show.
+  /// Exact match is required. Empty by default
+  /// Note: Deprecated, kept only for backwards compatibility. Works consistently with the previous operation.
+  Q_PROPERTY(QString attributeValueFilter READ attributeValueFilter WRITE setAttributeValueFilter)
+
 public:
   typedef ctkComboBox Superclass;
   qMRMLSubjectHierarchyComboBox(QWidget *parent=nullptr);
@@ -82,13 +102,38 @@ public:
   bool alignPopupVertically()const;
   void setAlignPopupVertically(bool align);
 
-  /// Set attribute filter that allows showing only items that have the specified attribute and their parents.
-  /// \param attributeName Name of the attribute by which the items are filtered
-  /// \param attributeValue Value of the specified attribute that needs to match this given value in order
-  ///   for it to be shown. If empty, then existence of the attribute is enough to show. Empty by default
-  Q_INVOKABLE void setAttributeFilter(const QString& attributeName, const QVariant& attributeValue=QVariant());
-  /// Remove item attribute filtering \sa setAttribute
-  Q_INVOKABLE void removeAttributeFilter();
+  QStringList includeItemAttributeNamesFilter()const;
+  QStringList includeNodeAttributeNamesFilter()const;
+  QStringList excludeItemAttributeNamesFilter()const;
+  QStringList excludeNodeAttributeNamesFilter()const;
+  QString attributeValueFilter()const;
+  QString attributeNameFilter()const;
+  /// Add single item attribute filter specifying attribute name, value, include/exclude, and class name
+  /// \param attributeName Name of the item attribute to filter
+  /// \param attributeValue Value of the item attribute to filter
+  /// \param include Flag indicating whether this is an include filter or exclude filter.
+  ///   - Include filter means that only the items are shown that match the filter.
+  ///   - Exclude filter hides items that match the filter. Overrides include filters.
+  ///   True by default (i.e. include filter).
+  Q_INVOKABLE void addItemAttributeFilter(QString attributeName, QVariant attributeValue=QString(), bool include=true);
+  /// Remove single item attribute filter specifying each attribute \sa addAttributeFilter
+  Q_INVOKABLE void removeItemAttributeFilter(QString attributeName, QVariant attributeValue, bool include);
+  /// Remove all item attribute filters specifying a given attribute name and include flag
+  Q_INVOKABLE void removeItemAttributeFilter(QString attributeName, bool include);
+  /// Add single node attribute filter specifying attribute name, value, include/exclude, and class name
+  /// \param attributeName Name of the node attribute to filter
+  /// \param attributeValue Value of the node attribute to filter
+  /// \param include Flag indicating whether this is an include filter or exclude filter.
+  ///   - Include filter means that only the items are shown that match the filter.
+  ///   - Exclude filter hides items that match the filter. Overrides include filters.
+  ///   True by default (i.e. include filter).
+  /// \param className Only filter attributes on a certain type. Empty by default (i.e. allow all classes)
+  Q_INVOKABLE void addNodeAttributeFilter(QString attributeName, QVariant attributeValue=QString(), bool include=true, QString className=QString());
+  /// Remove single node attribute filter specifying each attribute \sa addAttributeFilter
+  Q_INVOKABLE void removeNodeAttributeFilter(QString attributeName, QVariant attributeValue, bool include, QString className);
+  /// Remove all node attribute filters specifying a given attribute name and include flag
+  Q_INVOKABLE void removeNodeAttributeFilter(QString attributeName, bool include);
+
 
   /// Set level filter that allows showing only items at a specified level and their parents. Show all items if empty
   Q_INVOKABLE void setLevelFilter(QStringList &levelFilter);
@@ -126,6 +171,13 @@ public slots:
   /// Disable subject hierarchy plugin by adding it to the blacklist \sa setPluginBlacklist
   /// \param plugin Name of the plugin to disable
   void disablePlugin(QString plugin);
+
+  void setIncludeItemAttributeNamesFilter(QStringList filter);
+  void setIncludeNodeAttributeNamesFilter(QStringList filter);
+  void setExcludeItemAttributeNamesFilter(QStringList filter);
+  void setExcludeNodeAttributeNamesFilter(QStringList filter);
+  void setAttributeNameFilter(QString& filter);
+  void setAttributeValueFilter(QString& filter);
 
 signals:
   void currentItemChanged(vtkIdType);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -899,7 +899,7 @@ void qMRMLSubjectHierarchyTreeView::updateRootItem()
   Q_D(qMRMLSubjectHierarchyTreeView);
 
   // The scene might have been updated, need to update root item as well to restore view
-  this->setRootItem(d->RootItemID);
+  this->setRootItem(this->rootItem());
 }
 
 //--------------------------------------------------------------------------
@@ -958,6 +958,66 @@ void qMRMLSubjectHierarchyTreeView::setSelectRoleSubMenuVisible(bool visible)
   d->SelectRoleSubMenuVisible = visible;
 }
 
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::setIncludeItemAttributeNamesFilter(QStringList filter)
+{
+  this->sortFilterProxyModel()->setIncludeItemAttributeNamesFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSubjectHierarchyTreeView::includeItemAttributeNamesFilter()const
+{
+  return this->sortFilterProxyModel()->includeItemAttributeNamesFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::setIncludeNodeAttributeNamesFilter(QStringList filter)
+{
+  this->sortFilterProxyModel()->setIncludeNodeAttributeNamesFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSubjectHierarchyTreeView::includeNodeAttributeNamesFilter()const
+{
+  return this->sortFilterProxyModel()->includeNodeAttributeNamesFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::setExcludeItemAttributeNamesFilter(QStringList filter)
+{
+  this->sortFilterProxyModel()->setExcludeItemAttributeNamesFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSubjectHierarchyTreeView::excludeItemAttributeNamesFilter()const
+{
+  return this->sortFilterProxyModel()->excludeItemAttributeNamesFilter();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::setExcludeNodeAttributeNamesFilter(QStringList filter)
+{
+  this->sortFilterProxyModel()->setExcludeNodeAttributeNamesFilter(filter);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+QStringList qMRMLSubjectHierarchyTreeView::excludeNodeAttributeNamesFilter()const
+{
+  return this->sortFilterProxyModel()->excludeNodeAttributeNamesFilter();
+}
+
 //--------------------------------------------------------------------------
 void qMRMLSubjectHierarchyTreeView::setAttributeFilter(const QString& attributeName, const QVariant& attributeValue/*=QVariant()*/)
 {
@@ -965,16 +1025,16 @@ void qMRMLSubjectHierarchyTreeView::setAttributeFilter(const QString& attributeN
   this->sortFilterProxyModel()->setAttributeValueFilter(attributeValue.toString());
 
   // Reset root item, as it may have been corrupted, when tree became empty due to the filter
-  this->setRootItem(this->rootItem());
+  this->updateRootItem();
 }
 
 //--------------------------------------------------------------------------
-void qMRMLSubjectHierarchyTreeView::setAttributeNameFilter(const QString& attributeName)
+void qMRMLSubjectHierarchyTreeView::setAttributeNameFilter(QString& attributeName)
 {
   this->sortFilterProxyModel()->setAttributeNameFilter(attributeName);
 
   // Reset root item, as it may have been corrupted, when tree became empty due to the filter
-  this->setRootItem(this->rootItem());
+  this->updateRootItem();
 }
 
 //--------------------------------------------------------------------------
@@ -984,12 +1044,12 @@ QString qMRMLSubjectHierarchyTreeView::attributeNameFilter()const
 }
 
 //--------------------------------------------------------------------------
-void qMRMLSubjectHierarchyTreeView::setAttributeValueFilter(const QString& attributeValue)
+void qMRMLSubjectHierarchyTreeView::setAttributeValueFilter(QString& attributeValue)
 {
   this->sortFilterProxyModel()->setAttributeValueFilter(attributeValue);
 
   // Reset root item, as it may have been corrupted, when tree became empty due to the filter
-  this->setRootItem(this->rootItem());
+  this->updateRootItem();
 }
 
 //--------------------------------------------------------------------------
@@ -1005,7 +1065,68 @@ void qMRMLSubjectHierarchyTreeView::removeAttributeFilter()
   this->sortFilterProxyModel()->setAttributeValueFilter(QString());
 
   // Reset root item, as it may have been corrupted, when tree became empty due to the filter
-  this->setRootItem(this->rootItem());
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::addItemAttributeFilter(QString attributeName, QVariant attributeValue/*=QString()*/, bool include/*=true*/)
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  this->sortFilterProxyModel()->addItemAttributeFilter(attributeName, attributeValue, include);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::removeItemAttributeFilter(QString attributeName, QVariant attributeValue, bool include)
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  this->sortFilterProxyModel()->removeItemAttributeFilter(attributeName, attributeValue, include);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::removeItemAttributeFilter(QString attributeName, bool include)
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  this->sortFilterProxyModel()->removeItemAttributeFilter(attributeName, include);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::addNodeAttributeFilter(
+  QString attributeName, QVariant attributeValue/*=QString()*/, bool include/*=true*/, QString className/*=QString()*/)
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  this->sortFilterProxyModel()->addNodeAttributeFilter(attributeName, attributeValue, include, className);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::removeNodeAttributeFilter(QString attributeName, QVariant attributeValue, bool include, QString className)
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  this->sortFilterProxyModel()->removeNodeAttributeFilter(attributeName, attributeValue, include, className);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::removeNodeAttributeFilter(QString attributeName, bool include)
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  this->sortFilterProxyModel()->removeNodeAttributeFilter(attributeName, include);
+
+  // Reset root item, as it may have been corrupted, when tree became empty due to the filter
+  this->updateRootItem();
 }
 
 //--------------------------------------------------------------------------
@@ -1014,7 +1135,7 @@ void qMRMLSubjectHierarchyTreeView::setLevelFilter(QStringList &levelFilter)
   this->sortFilterProxyModel()->setLevelFilter(levelFilter);
 
   // Reset root item, as it may have been corrupted, when tree became empty due to the filter
-  this->setRootItem(this->rootItem());
+  this->updateRootItem();
 }
 
 //--------------------------------------------------------------------------
@@ -1029,7 +1150,7 @@ void qMRMLSubjectHierarchyTreeView::setNameFilter(QString &nameFilter)
   this->sortFilterProxyModel()->setNameFilter(nameFilter);
 
   // Reset root item, as it may have been corrupted, when tree became empty due to the filter
-  this->setRootItem(this->rootItem());
+  this->updateRootItem();
 }
 
 //--------------------------------------------------------------------------
@@ -1044,7 +1165,7 @@ void qMRMLSubjectHierarchyTreeView::setNodeTypes(const QStringList& types)
   this->sortFilterProxyModel()->setNodeTypes(types);
 
   // Reset root item, as it may have been corrupted, when tree became empty due to the filter
-  this->setRootItem(this->rootItem());
+  this->updateRootItem();
 }
 
 //--------------------------------------------------------------------------
@@ -1059,7 +1180,7 @@ void qMRMLSubjectHierarchyTreeView::setHideChildNodeTypes(const QStringList& typ
   this->sortFilterProxyModel()->setHideChildNodeTypes(types);
 
   // Reset root item, as it may have been corrupted, when tree became empty due to the filter
-  this->setRootItem(this->rootItem());
+  this->updateRootItem();
 }
 
 //--------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -63,12 +63,30 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qMRMLSubjectHierarchyTreeV
   Q_PROPERTY(bool selectRoleSubMenuVisible READ selectRoleSubMenuVisible WRITE setSelectRoleSubMenuVisible)
   /// Flag determining whether multiple items can be selected
   Q_PROPERTY(bool multiSelection READ multiSelection WRITE setMultiSelection)
-  Q_PROPERTY(QString attributeNameFilter READ attributeNameFilter WRITE setAttributeNameFilter)
-  Q_PROPERTY(QString attributeValueFilter READ attributeValueFilter WRITE setAttributeValueFilter)
   Q_PROPERTY(QStringList levelFilter READ levelFilter WRITE setLevelFilter)
   Q_PROPERTY(QString nameFilter READ nameFilter WRITE setNameFilter)
   Q_PROPERTY(QStringList nodeTypes READ nodeTypes WRITE setNodeTypes)
   Q_PROPERTY(QStringList hideChildNodeTypes READ hideChildNodeTypes WRITE setHideChildNodeTypes)
+
+  /// Filter to show only items that contain any of the given attributes with this name. Empty by default
+  Q_PROPERTY(QStringList includeItemAttributeNamesFilter READ includeItemAttributeNamesFilter WRITE setIncludeItemAttributeNamesFilter)
+  /// Filter to show only items for data nodes that contain any of the given attributes with this name. Empty by default
+  Q_PROPERTY(QStringList includeNodeAttributeNamesFilter READ includeNodeAttributeNamesFilter WRITE setIncludeNodeAttributeNamesFilter)
+  /// Filter to hide items that contain any of the given attributes with this name. Empty by default
+  /// Overrides \sa includeItemAttributeNamesFilter
+  Q_PROPERTY(QStringList excludeItemAttributeNamesFilter READ excludeItemAttributeNamesFilter WRITE setExcludeItemAttributeNamesFilter)
+  /// Filter to hide items for data nodes that contain any of the given attributes with this name. Empty by default
+  /// Overrides \sa includeNodeAttributeNamesFilter
+  Q_PROPERTY(QStringList excludeNodeAttributeNamesFilter READ excludeNodeAttributeNamesFilter WRITE setExcludeNodeAttributeNamesFilter)
+
+  /// Filter to show only items that contain an attribute with this name. Empty by default
+  /// Note: Deprecated, kept only for backwards compatibility. Sets and returns the first attribute in \sa includeNodeAttributeNamesFilter
+  Q_PROPERTY(QString attributeNameFilter READ attributeNameFilter WRITE setAttributeNameFilter)
+  /// Filter to show only items that contain any attribute given in \sa includeItemAttributeNamesFilter with the value.
+  /// If empty, then existence of the attributes is enough to show.
+  /// Exact match is required. Empty by default
+  /// Note: Deprecated, kept only for backwards compatibility. Works consistently with the previous operation.
+  Q_PROPERTY(QString attributeValueFilter READ attributeValueFilter WRITE setAttributeValueFilter)
 
 public:
   typedef QTreeView Superclass;
@@ -98,6 +116,12 @@ public:
   /// Get whether multi-selection is enabled
   bool multiSelection();
 
+  QStringList includeItemAttributeNamesFilter()const;
+  QStringList includeNodeAttributeNamesFilter()const;
+  QStringList excludeItemAttributeNamesFilter()const;
+  QStringList excludeNodeAttributeNamesFilter()const;
+  QString attributeValueFilter()const;
+  QString attributeNameFilter()const;
   /// Set attribute filter that allows showing only items that have the specified attribute and their parents.
   /// \param attributeName Name of the attribute by which the items are filtered
   /// \param attributeValue Value of the specified attribute that needs to match this given value in order
@@ -105,10 +129,32 @@ public:
   Q_INVOKABLE void setAttributeFilter(const QString& attributeName, const QVariant& attributeValue=QVariant());
   /// Remove item attribute filtering \sa setAttribute
   Q_INVOKABLE void removeAttributeFilter();
-  void setAttributeNameFilter(const QString& attributeName);
-  void setAttributeValueFilter(const QString& attributeValue);
-  QString attributeNameFilter()const;
-  QString attributeValueFilter()const;
+  /// Add single item attribute filter specifying attribute name, value, include/exclude, and class name
+  /// \param attributeName Name of the item attribute to filter
+  /// \param attributeValue Value of the item attribute to filter
+  /// \param include Flag indicating whether this is an include filter or exclude filter.
+  ///   - Include filter means that only the items are shown that match the filter.
+  ///   - Exclude filter hides items that match the filter. Overrides include filters.
+  ///   True by default (i.e. include filter).
+  Q_INVOKABLE void addItemAttributeFilter(QString attributeName, QVariant attributeValue=QString(), bool include=true);
+  /// Remove single item attribute filter specifying each attribute \sa addAttributeFilter
+  Q_INVOKABLE void removeItemAttributeFilter(QString attributeName, QVariant attributeValue, bool include);
+  /// Remove all item attribute filters specifying a given attribute name and include flag
+  Q_INVOKABLE void removeItemAttributeFilter(QString attributeName, bool include);
+  /// Add single node attribute filter specifying attribute name, value, include/exclude, and class name
+  /// \param attributeName Name of the node attribute to filter
+  /// \param attributeValue Value of the node attribute to filter
+  /// \param include Flag indicating whether this is an include filter or exclude filter.
+  ///   - Include filter means that only the items are shown that match the filter.
+  ///   - Exclude filter hides items that match the filter. Overrides include filters.
+  ///   True by default (i.e. include filter).
+  /// \param className Only filter attributes on a certain type. Empty by default (i.e. allow all classes)
+  Q_INVOKABLE void addNodeAttributeFilter(QString attributeName, QVariant attributeValue=QString(), bool include=true, QString className=QString());
+  /// Remove single node attribute filter specifying each attribute \sa addAttributeFilter
+  Q_INVOKABLE void removeNodeAttributeFilter(QString attributeName, QVariant attributeValue, bool include, QString className);
+  /// Remove all node attribute filters specifying a given attribute name and include flag
+  Q_INVOKABLE void removeNodeAttributeFilter(QString attributeName, bool include);
+
 
   /// Set level filter that allows showing only items at a specified level and their parents. Show all items if empty
   void setLevelFilter(QStringList &levelFilter);
@@ -245,6 +291,13 @@ protected slots:
   virtual void onTransformInteractionInViewToggled(bool show);
   virtual void onTransformEditProperties();
   virtual void onCreateNewTransform();
+
+  void setIncludeItemAttributeNamesFilter(QStringList filter);
+  void setIncludeNodeAttributeNamesFilter(QStringList filter);
+  void setExcludeItemAttributeNamesFilter(QStringList filter);
+  void setExcludeNodeAttributeNamesFilter(QStringList filter);
+  void setAttributeNameFilter(QString& filter);
+  void setAttributeValueFilter(QString& filter);
 
 protected:
   /// Set the subject hierarchy node found in the given scene. Called only internally.


### PR DESCRIPTION
In addition to allowing one attribute name (and value for that attribute) to be filtered, now multiple attributes can be specified that control which items show up in the subject hierarchy trees and comboboxes with more granularity.
- addItemAttributeFilter / addNodeAttributeFilter: add new attribute filter that can filter by attribute name and value, and class name in case of node filter
- removeItemAttributeFilter / removeNodeAttributeFilter: remove certain filters defined by only attribute name or each property
- includeItemAttributeNamesFilter: convenience function to show only items that contain any of the given attributes with this name (removes all previously added include item attribute filters)
- includeNodeAttributeNamesFilter: convenience function to show only items for data nodes that contain any of the given attributes with this name (removes all previously added include node attribute filters)
- excludeItemAttributeNamesFilter: convenience function to hide items that contain any of the given attributes with this name (removes all previously added exclude item attribute filters)
- excludeNodeAttributeNamesFilter: convenience function to hide items for data nodes that contain any of the given attributes with this name (removes all previously added exclude node attribute filters)
Each of these are disabled (empty string list) by default. The legacy filters were kept for backward compatibility:
- attributeNameFilter: show only items that contain an attribute with this name
- attributeValueFilter: show only items that contain the attribute specified in attributeNameFilter and have a given value

Test case added to SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py

Add two convenience functions to slicer.util for getting SH children items: getSubjectHierarchyItemChildren and getSubjectHierarchyItemAllChildren