### PR TITLE
ENH: Performance improvements

### DIFF
--- a/Base/QTGUI/qSlicerIOManager.cxx
+++ b/Base/QTGUI/qSlicerIOManager.cxx
@@ -429,7 +429,13 @@ bool qSlicerIOManager::loadNodes(const qSlicerIO::IOFileType& fileType,
   vtkMRMLMessageCollection* userMessages/*=nullptr*/)
 {
   Q_D(qSlicerIOManager);
-
+  qSlicerApplication* application = qSlicerApplication::application();
+  if (application)
+    {
+    // speed up data loading by disabling re-rendering
+    // (it can make a big difference if hundreds of nodes are loaded)
+    application->pauseRender();
+    }
   bool needStop = d->startProgressDialog(1);
   d->ProgressDialog->setLabelText(
     "Loading file " + parameters.value("fileName").toString() + " ...");
@@ -443,6 +449,10 @@ bool qSlicerIOManager::loadNodes(const qSlicerIO::IOFileType& fileType,
     {
     d->stopProgressDialog();
     }
+  if (application)
+    {
+    application->resumeRender();
+    }
   return res;
 }
 
@@ -452,7 +462,13 @@ bool qSlicerIOManager::loadNodes(const QList<qSlicerIO::IOProperties>& files,
   vtkCollection* loadedNodes, vtkMRMLMessageCollection* userMessages/*=nullptr*/)
 {
   Q_D(qSlicerIOManager);
-
+  qSlicerApplication* application = qSlicerApplication::application();
+  if (application)
+    {
+    // speed up data loading by disabling re-rendering
+    // (it can make a big difference if hundreds of nodes are loaded)
+    application->pauseRender();
+    }
   bool needStop = d->startProgressDialog(files.count());
   bool success = true;
   foreach(qSlicerIO::IOProperties fileProperties, files)
@@ -479,7 +495,10 @@ bool qSlicerIOManager::loadNodes(const QList<qSlicerIO::IOProperties>& files,
     {
     d->stopProgressDialog();
     }
-
+  if (application)
+    {
+    application->resumeRender();
+    }
   return success;
 }
 

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -396,7 +396,16 @@ void vtkMRMLApplicationLogic::SetMRMLSceneInternal(vtkMRMLScene* newScene)
   // Add default slice orientation presets
   vtkMRMLSliceNode::AddDefaultSliceOrientationPresets(newScene);
 
-  this->Superclass::SetMRMLSceneInternal(newScene);
+  vtkNew<vtkIntArray> sceneEvents;
+  sceneEvents->InsertNextValue(vtkMRMLScene::StartBatchProcessEvent);
+  sceneEvents->InsertNextValue(vtkMRMLScene::EndBatchProcessEvent);
+  sceneEvents->InsertNextValue(vtkMRMLScene::StartCloseEvent);
+  sceneEvents->InsertNextValue(vtkMRMLScene::EndCloseEvent);
+  sceneEvents->InsertNextValue(vtkMRMLScene::StartImportEvent);
+  sceneEvents->InsertNextValue(vtkMRMLScene::EndImportEvent);
+  sceneEvents->InsertNextValue(vtkMRMLScene::StartRestoreEvent);
+  sceneEvents->InsertNextValue(vtkMRMLScene::EndRestoreEvent);
+  this->SetAndObserveMRMLSceneEventsInternal(newScene, sceneEvents.GetPointer());
 
   this->Internal->SliceLinkLogic->SetMRMLScene(newScene);
   this->Internal->ViewLinkLogic->SetMRMLScene(newScene);
@@ -863,4 +872,40 @@ vtkMRMLAbstractLogic* vtkMRMLApplicationLogic::GetModuleLogic(const char* module
     return nullptr;
     }
   return this->Internal->ModuleLogicMap[moduleName];
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::OnMRMLSceneStartBatchProcess()
+{
+  this->PauseRender();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::OnMRMLSceneEndBatchProcess()
+{
+  this->ResumeRender();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::OnMRMLSceneStartImport()
+{
+  this->PauseRender();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::OnMRMLSceneEndImport()
+{
+  this->ResumeRender();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::OnMRMLSceneStartRestore()
+{
+  this->PauseRender();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::OnMRMLSceneEndRestore()
+{
+  this->ResumeRender();
 }

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -260,6 +260,13 @@ protected:
 
   void ProcessMRMLNodesEvents(vtkObject* caller, unsigned long event, void* callData) override;
 
+  void OnMRMLSceneStartBatchProcess() override;
+  void OnMRMLSceneEndBatchProcess() override;
+  void OnMRMLSceneStartImport() override;
+  void OnMRMLSceneEndImport() override;
+  void OnMRMLSceneStartRestore() override;
+  void OnMRMLSceneEndRestore() override;
+
 private:
 
   vtkMRMLApplicationLogic(const vtkMRMLApplicationLogic&) = delete;

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -1303,7 +1303,21 @@ void qMRMLLayoutManager::setRenderPaused(bool pause)
   foreach(const QString& viewName, sliceViewFactory->viewNodeNames())
     {
     ctkVTKAbstractView* view = this->sliceWidget(viewName)->sliceView();
-    view->setRenderPaused(pause);
+    if (!pause && !view->isRenderPaused())
+      {
+      // This view is already resumed and a resume is requested.
+      // This is probably because the view has just been added
+      // and so it missed a few PauseRender requests.
+      // Do not try to resume render to avoid logging of a warning,
+      // and just log a debug message here to help with troubleshooting if
+      // any problem comes up related to pausing rendering.
+      qDebug() << Q_FUNC_INFO << "Resume render request is ignored for view "
+        << viewName << ", probably the view has just been created";
+      }
+    else
+      {
+      view->setRenderPaused(pause);
+      }
     }
 
   qMRMLLayoutViewFactory* threeDViewFactory = this->mrmlViewFactory("vtkMRMLViewNode");

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -441,7 +441,10 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
         break;
         }
       }
-
+    if (!pointVisible)
+      {
+      continue;
+      }
     if (interactionEventData->IsDisplayPositionValid())
       {
       double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(centerPosWorld)
@@ -451,7 +454,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
       this->Renderer->GetDisplayPoint(centerPosDisplay);
       centerPosDisplay[2] = 0.0;
       double dist2 = vtkMath::Distance2BetweenPoints(centerPosDisplay, displayPosition3);
-      if (dist2 < pixelTolerance * pixelTolerance && dist2 < closestDistance2 && pointVisible)
+      if (dist2 < pixelTolerance * pixelTolerance && dist2 < closestDistance2)
         {
         closestDistance2 = dist2;
         foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentControlPoint;
@@ -464,7 +467,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
       double worldTolerance = this->ControlPointSize / 2.0 +
         this->PickingTolerance / interactionEventData->GetWorldToPhysicalScale();
       double dist2 = vtkMath::Distance2BetweenPoints(centerPosWorld, worldPosition);
-      if (dist2 < worldTolerance * worldTolerance && dist2 < closestDistance2 && pointVisible)
+      if (dist2 < worldTolerance * worldTolerance && dist2 < closestDistance2)
         {
         closestDistance2 = dist2;
         foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentControlPoint;


### PR DESCRIPTION
These changes make scene loading many times faster if there are hundreds of nodes in the scene.

- Pause rendering during batch processing and data loading for better performance. When the operation is completed, rendering is resumed and any pending rendering requests are processed.
- Make show/hide model slice intersections faster by not removing and re-adding all actors, but only removing/adding those that have changed.