### PR TITLE
ENH: Observe markup measurements to trigger necessary updates

### DIFF
--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -2925,7 +2925,4 @@ void qSlicerMarkupsModuleWidget::onMeasurementEnabledCheckboxToggled(bool on)
       currentMeasurement->SetEnabled(on);
       }
     }
-
-  // Make sure the subject hierarchy description is updated as well
-  d->MarkupsNode->UpdateMeasurements();
 }


### PR DESCRIPTION
By observing the Modified event of each measurement in the markup nodes, updating the measurements is possible when any of them are e.g. enabled programmatically.