### PR TITLE
ENH: Miscellaneous ROI display improvements

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -28,6 +28,7 @@
 #include "vtkMRMLMarkupsFiducialNode.h"
 #include "vtkMRMLMarkupsFiducialStorageNode.h"
 #include "vtkMRMLMarkupsJsonStorageNode.h"
+#include "vtkMRMLMarkupsROIDisplayNode.h"
 #include "vtkMRMLMarkupsROIJsonStorageNode.h"
 #include "vtkMRMLMarkupsLineNode.h"
 #include "vtkMRMLMarkupsNode.h"
@@ -222,6 +223,7 @@ void vtkSlicerMarkupsLogic::RegisterNodes()
   // Display nodes
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsDisplayNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsFiducialDisplayNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsROIDisplayNode>::New());
 
   // Storage Nodes
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsStorageNode>::New());

--- a/Modules/Loadable/Markups/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRML/CMakeLists.txt
@@ -23,8 +23,8 @@ set(${KIT}_SRCS
   vtkMRML${MODULE_NAME}Node.cxx
   vtkMRML${MODULE_NAME}PlaneNode.cxx
   vtkMRML${MODULE_NAME}ROINode.cxx
+  vtkMRML${MODULE_NAME}ROIDisplayNode.cxx
   vtkMRML${MODULE_NAME}ROIJsonStorageNode.cxx
-  vtkMRML${MODULE_NAME}ROIJsonStorageNode.h
   vtkCurveGenerator.cxx
   vtkCurveGenerator.h
   vtkCurveMeasurementsCalculator.cxx

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.cxx
@@ -1,0 +1,35 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLMarkupsROIDisplayNode.h"
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLMarkupsROIDisplayNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsROIDisplayNode::vtkMRMLMarkupsROIDisplayNode()
+{
+  this->FillOpacity = 0.2;
+  this->HandlesInteractive = true;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsROIDisplayNode::~vtkMRMLMarkupsROIDisplayNode() = default;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.h
@@ -1,0 +1,57 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+// .NAME vtkMRMLMarkupsROIDisplayNode - MRML node to represent display properties for markups ROI
+// .SECTION Description
+// Adjusts default display parameters for ROI such as fill opacity.
+//
+
+#ifndef __vtkMRMLMarkupsROIDisplayNode_h
+#define __vtkMRMLMarkupsROIDisplayNode_h
+
+#include "vtkSlicerMarkupsModuleMRMLExport.h"
+#include "vtkMRMLMarkupsDisplayNode.h"
+
+/// \ingroup Slicer_QtModules_Markups
+class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsROIDisplayNode : public vtkMRMLMarkupsDisplayNode
+{
+public:
+  static vtkMRMLMarkupsROIDisplayNode *New();
+  vtkTypeMacro ( vtkMRMLMarkupsROIDisplayNode,vtkMRMLMarkupsDisplayNode );
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+
+  vtkMRMLNode* CreateNodeInstance (  ) override;
+
+  // Get node XML tag name (like Volume, Markups)
+  const char* GetNodeTagName() override {return "MarkupsROIDisplay";};
+
+  /// Copy node content (excludes basic data, such as name and node references).
+  /// \sa vtkMRMLNode::CopyContent
+  vtkMRMLCopyContentDefaultMacro(vtkMRMLMarkupsROIDisplayNode);
+
+protected:
+  vtkMRMLMarkupsROIDisplayNode();
+  ~vtkMRMLMarkupsROIDisplayNode() override;
+  vtkMRMLMarkupsROIDisplayNode( const vtkMRMLMarkupsROIDisplayNode& );
+  void operator= ( const vtkMRMLMarkupsROIDisplayNode& );
+};
+#endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
@@ -21,6 +21,7 @@
 #include "vtkMRMLMarkupsROINode.h"
 
 // MRML includes
+#include <vtkMRMLMarkupsROIDisplayNode.h>
 #include <vtkMRMLMarkupsROIJsonStorageNode.h>
 #include "vtkMRMLScene.h"
 #include "vtkMRMLTransformNode.h"
@@ -108,6 +109,30 @@ vtkMRMLStorageNode* vtkMRMLMarkupsROINode::CreateDefaultStorageNode()
     }
   return vtkMRMLStorageNode::SafeDownCast(
     scene->CreateNodeByClass("vtkMRMLMarkupsROIJsonStorageNode"));
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsROINode::CreateDefaultDisplayNodes()
+{
+  if (this->GetDisplayNode() != nullptr &&
+    vtkMRMLMarkupsROIDisplayNode::SafeDownCast(this->GetDisplayNode()) != nullptr)
+    {
+    // display node already exists
+    return;
+    }
+  if (this->GetScene() == nullptr)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsROINode::CreateDefaultDisplayNodes failed: scene is invalid");
+    return;
+    }
+  vtkMRMLMarkupsROIDisplayNode* dispNode = vtkMRMLMarkupsROIDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLMarkupsROIDisplayNode"));
+  if (!dispNode)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsROINode::CreateDefaultDisplayNodes failed: scene failed to instantiate a vtkMRMLMarkupsROIDisplayNode node");
+    return;
+    }
+  this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }
 
 //----------------------------------------------------------------------------
@@ -238,7 +263,7 @@ void vtkMRMLMarkupsROINode::ProcessMRMLEvents(vtkObject* caller, unsigned long e
     this->UpdateInteractionHandleToWorldMatrix();
     this->Modified();
     }
-  else if (caller = this->InteractionHandleToWorldMatrix)
+  else if (caller == this->InteractionHandleToWorldMatrix.GetPointer())
     {
     vtkNew<vtkMatrix4x4> worldToLocalTransform;
     if (this->GetParentTransformNode())

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
@@ -159,6 +159,9 @@ public:
   /// Create default storage node or nullptr if does not have one
   vtkMRMLStorageNode* CreateDefaultStorageNode() override;
 
+  /// Create default storage node or nullptr if does not have one
+  void CreateDefaultDisplayNodes() override;
+
   ///
   /// Legacy vtkMRMLAnnotationROINode methods
   ///

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -98,6 +98,14 @@ public:
   /// \param eventData Supplementary data for the item that may be considered for the menu (sub-item ID, attribute, etc.)
   void showViewContextMenuActionsForItem(vtkIdType itemID, QVariantMap eventData) override;
 
+  /// Get view context menu item actions that are available when right-clicking an object in the views.
+  /// These item context menu actions can be shown in the implementations of \sa showViewContextMenuActionsForItem
+  QList<QAction*> visibilityContextMenuActions()const override;
+
+  /// Show visibility context menu actions valid for a given subject hierarchy item.
+  /// \param itemID Subject Hierarchy item to show the visibility context menu items for
+  void showVisibilityContextMenuActionsForItem(vtkIdType itemID) override;
+
 protected slots:
   /// Called when clicking on rename point action
   void renamePoint();
@@ -105,8 +113,10 @@ protected slots:
   void deletePoint();
   /// Called when clicking on toggle select point action
   void toggleSelectPoint();
-  /// Called when clicking on handle interactive action
+  /// Called when clicking on handle interactive action in view
   void toggleHandleInteractive();
+  /// toggle handle interactive for the current subject hierarchy item
+  void toggleCurrentItemHandleInteractive();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyMarkupsPluginPrivate> d_ptr;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -615,7 +615,10 @@ bool vtkSlicerMarkupsWidget::CanProcessInteractionEvent(vtkMRMLInteractionEventD
 //-------------------------------------------------------------------------
 bool vtkSlicerMarkupsWidget::ProcessWidgetMenu(vtkMRMLInteractionEventData* eventData)
 {
-  if ((this->WidgetState != WidgetStateOnWidget && this->WidgetState != WidgetStateOnTranslationHandle && this->WidgetState != WidgetStateOnRotationHandle)
+  if ((this->WidgetState != WidgetStateOnWidget &&
+       this->WidgetState != WidgetStateOnTranslationHandle &&
+       this->WidgetState != WidgetStateOnRotationHandle &&
+       this->WidgetState != WidgetStateOnScaleHandle)
     || !this->MousePressedSinceMarkupPlace)
     {
     return false;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -56,7 +56,6 @@ static const double INTERACTION_HANDLE_RADIUS = 0.0625;
 static const double INTERACTION_HANDLE_DIAMETER = INTERACTION_HANDLE_RADIUS * 2.0;
 static const double INTERACTION_HANDLE_ROTATION_ARC_TUBE_RADIUS = INTERACTION_HANDLE_RADIUS * 0.4;
 static const double INTERACTION_HANDLE_ROTATION_ARC_RADIUS = 0.80;
-static const double INTERACTION_HANDLE_SCALE_FACTOR = 3.5;
 
 //----------------------------------------------------------------------
 vtkSlicerMarkupsWidgetRepresentation::ControlPointsPipeline::ControlPointsPipeline()
@@ -839,7 +838,7 @@ int vtkSlicerMarkupsWidgetRepresentation::RenderOpaqueGeometry(vtkViewport* view
   if (this->InteractionPipeline && this->InteractionPipeline->Actor->GetVisibility())
     {
     this->InteractionPipeline->UpdateHandleColors();
-    double interactionWidgetScale = INTERACTION_HANDLE_SCALE_FACTOR * this->ControlPointSize;
+    double interactionWidgetScale = this->InteractionPipeline->InteractionHandleScaleFactor * this->ControlPointSize;
     this->InteractionPipeline->SetWidgetScale(interactionWidgetScale);
     count += this->InteractionPipeline->Actor->RenderOpaqueGeometry(viewport);
     }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -220,8 +220,9 @@ protected:
     vtkSmartPointer<vtkActor2D>                         Actor;
     vtkSmartPointer<vtkProperty2D>                      Property;
 
-    double                                              StartFadeAngle;
-    double                                              EndFadeAngle;
+    double                                              StartFadeAngle{30};
+    double                                              EndFadeAngle{20};
+    double                                              InteractionHandleScaleFactor{7.0};
 
     virtual void InitializePipeline();
     virtual void CreateRotationHandles();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -761,7 +761,8 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderOpaqueGeometry(
   if (this->InteractionPipeline && this->InteractionPipeline->Actor->GetVisibility())
     {
     this->InteractionPipeline->UpdateHandleColors();
-    double interactionWidgetScale = 7.0 * this->ControlPointSize * this->ViewScaleFactorMmPerPixel;
+    double interactionWidgetScale = this->InteractionPipeline->InteractionHandleScaleFactor *
+      this->ControlPointSize * this->ViewScaleFactorMmPerPixel;
     this->InteractionPipeline->SetWidgetScale(interactionWidgetScale);
     count += this->InteractionPipeline->Actor->RenderOpaqueGeometry(viewport);
     }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
@@ -88,35 +88,20 @@ protected:
 
   void SetROISource(vtkPolyDataAlgorithm* roiSource);
 
-  vtkSmartPointer<vtkPolyDataAlgorithm> ROISource;
-  vtkSmartPointer<vtkTransformPolyDataFilter> ROITransformFilter;
+  vtkSmartPointer<vtkPolyDataAlgorithm>       ROISource;
   vtkSmartPointer<vtkTransform>               ROIToWorldTransform;
-  vtkSmartPointer<vtkContourTriangulator>     ROIIntersectionTriangulator;
   vtkSmartPointer<vtkTransformPolyDataFilter> ROIToWorldTransformFilter;
-  vtkSmartPointer<vtkPolyDataMapper2D> ROIMapper;
-  vtkSmartPointer<vtkProperty2D> ROIProperty;
-  vtkSmartPointer<vtkActor2D> ROIActor;
-
-  vtkSmartPointer<vtkClipPolyData> OutlineClipperSlicePlane;
-  vtkSmartPointer<vtkClipPolyData> OutlineClipperStartFadeNear;
-  vtkSmartPointer<vtkClipPolyData> OutlineClipperEndFadeNear;
-  vtkSmartPointer<vtkClipPolyData> OutlineClipperStartFadeFar;
-  vtkSmartPointer<vtkClipPolyData> OutlineClipperEndFadeFar;
-  vtkSmartPointer<vtkAppendPolyData> OutlineAppend;
-  vtkSmartPointer<vtkTransformPolyDataFilter> OutlineROIWorldToSliceTransformFilter;
-  vtkSmartPointer<vtkTransformPolyDataFilter> ROIWorldToSliceTransformFilter;
-  vtkSmartPointer<vtkOutlineFilter> OutlineFilter;
-
-  vtkSmartPointer<vtkAppendPolyData> ROIAppend;
-
-  vtkSmartPointer<vtkSampleImplicitFunctionFilter> OutlineDistanceFilter;
-
-  vtkSmartPointer<vtkCutter> ROIOutlineCutter;
+  vtkSmartPointer<vtkCutter>                  ROIOutlineCutter;
   vtkSmartPointer<vtkTransformPolyDataFilter> ROIOutlineWorldToSliceTransformFilter;
+  vtkSmartPointer<vtkContourTriangulator>     ROIIntersectionTriangulator;
+
+  vtkSmartPointer<vtkPolyDataMapper2D> ROIMapper;
+  vtkSmartPointer<vtkProperty2D>       ROIProperty;
+  vtkSmartPointer<vtkActor2D>          ROIActor;
+
   vtkSmartPointer<vtkPolyDataMapper2D> ROIOutlineMapper;
-  vtkSmartPointer<vtkDiscretizableColorTransferFunction> OutlineColorMap;
-  vtkSmartPointer<vtkProperty2D> ROIOutlineProperty;
-  vtkSmartPointer<vtkActor2D> ROIOutlineActor;
+  vtkSmartPointer<vtkProperty2D>       ROIOutlineProperty;
+  vtkSmartPointer<vtkActor2D>          ROIOutlineActor;
 
   class MarkupsInteractionPipelineROI2D : public vtkSlicerROIRepresentation3D::MarkupsInteractionPipelineROI
   {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
@@ -42,15 +42,15 @@ class vtkArrowSource;
 class vtkGlyph3DMapper;
 class vtkLookupTable;
 class vtkMRMLInteractionEventData;
+class vtkMRMLMarkupsROINode;
+class vtkOutlineFilter;
+class vtkPassThroughFilter;
 class vtkPlaneSource;
+class vtkPolyDataAlgorithm;
 class vtkPolyDataMapper;
 class vtkPolyData;
 class vtkTransformPolyDataFilter;
 class vtkTubeFilter;
-
-class vtkPolyDataAlgorithm;
-class vtkMRMLMarkupsROINode;
-
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerROIRepresentation3D : public vtkSlicerMarkupsWidgetRepresentation3D
 {
@@ -94,17 +94,31 @@ protected:
   void SetROISource(vtkPolyDataAlgorithm* roiSource);
 
   vtkSmartPointer<vtkPolyDataAlgorithm> ROISource;
-  vtkNew<vtkTransformPolyDataFilter>    ROITransformFilter;
-  vtkNew<vtkTransform>                  ROIToWorldTransform;
 
-  vtkNew<vtkPolyDataMapper>             ROIMapper;
-  vtkNew<vtkPolyDataMapper>             ROIOccludedMapper;
+  vtkSmartPointer<vtkPassThroughFilter> ROIPipelineInputFilter;
 
-  vtkNew<vtkActor>                      ROIActor;
-  vtkNew<vtkActor>                      ROIOccludedActor;
+  vtkSmartPointer<vtkTransformPolyDataFilter>    ROITransformFilter;
+  vtkSmartPointer<vtkTransform>                  ROIToWorldTransform;
 
-  vtkNew<vtkProperty>                   ROIProperty;
-  vtkNew<vtkProperty>                   ROIOccludedProperty;
+  vtkSmartPointer<vtkPolyDataMapper>             ROIMapper;
+  vtkSmartPointer<vtkProperty>                   ROIProperty;
+  vtkSmartPointer<vtkActor>                      ROIActor;
+
+  vtkSmartPointer<vtkPolyDataMapper>             ROIOccludedMapper;
+  vtkSmartPointer<vtkProperty>                   ROIOccludedProperty;
+  vtkSmartPointer<vtkActor>                      ROIOccludedActor;
+
+  vtkSmartPointer<vtkOutlineFilter>              ROIOutlineFilter;
+
+  vtkSmartPointer<vtkTransformPolyDataFilter>    ROIOutlineTransformFilter;
+
+  vtkSmartPointer<vtkPolyDataMapper>             ROIOutlineMapper;
+  vtkSmartPointer<vtkProperty>                   ROIOutlineProperty;
+  vtkSmartPointer<vtkActor>                      ROIOutlineActor;
+
+  vtkSmartPointer<vtkPolyDataMapper>             ROIOutlineOccludedMapper;
+  vtkSmartPointer<vtkProperty>                   ROIOutlineOccludedProperty;
+  vtkSmartPointer<vtkActor>                      ROIOutlineOccludedActor;
 
   class MarkupsInteractionPipelineROI : public MarkupsInteractionPipeline
   {

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -1090,6 +1090,7 @@ void vtkSlicerVolumeRenderingLogic::UpdateDisplayNodeFromVolumeNode(
       if (markupsDisplayNode)
         {
         markupsDisplayNode->SetHandlesInteractive(true);
+        markupsDisplayNode->SetFillVisibility(false);
         }
       // by default, show the ROI only if cropping is enabled
       markupsROINode->SetDisplayVisibility(displayNode->GetCroppingEnabled());


### PR DESCRIPTION
List of improvements:
- Default fill opacity set to 20%
- Disable fill visibility for volume rendering by default
- Add outline in 3D views
- Remove out of plane ROI outline in 2D
- Increase interaction handle size by 2x in 3D views
- Enable right-click menu for scale handles
- Add interaction handle visibility context menu appear in subject hierarchy widget visibility column
- Hide interaction handles when out of plane
- Enable ROI interaction handles by default