### PR TITLE
BUG: Ensure temporaryPath is writable

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -322,6 +322,17 @@ void qSlicerCoreApplicationPrivate::init()
   modifiedRequestCallback->SetCallback(vtkSlicerApplicationLogic::RequestModifiedCallback);
   vtkEventBroker::GetInstance()->SetRequestModifiedCallback(modifiedRequestCallback);
 
+  // Check if temporary folder is writeable
+  QTemporaryFile fileInTemporaryPathFolder(
+    QFileInfo(q->temporaryPath(), "_write_test_XXXXXX.tmp").absolutePath());
+  if (!fileInTemporaryPathFolder.open())
+    {
+    QString newTempFolder = q->defaultTemporaryPath();
+    qWarning() << Q_FUNC_INFO << "Setting temporary folder to " << newTempFolder
+      << " because previously set " << q->temporaryPath() << " folder was not writeable";
+    q->setTemporaryPath(newTempFolder);
+    }
+
   this->AppLogic->SetTemporaryPath(q->temporaryPath().toUtf8());
   vtkPersonInformation* userInfo = this->AppLogic->GetUserInformation();
   if (userInfo)

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -329,7 +329,7 @@ void qSlicerCoreApplicationPrivate::init()
     {
     QString newTempFolder = q->defaultTemporaryPath();
     qWarning() << Q_FUNC_INFO << "Setting temporary folder to " << newTempFolder
-      << " because previously set " << q->temporaryPath() << " folder was not writeable";
+      << " because previously set " << q->temporaryPath() << " folder is not writable";
     q->setTemporaryPath(newTempFolder);
     }
 

--- a/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
@@ -161,7 +161,7 @@ void qSlicerSettingsModulesPanelPrivate::init()
                       "showModules", SIGNAL(showModulesChanged(QStringList)));
   qSlicerRelativePathMapper* relativePathMapper = new qSlicerRelativePathMapper(
     this->TemporaryDirectoryButton, "directory", SIGNAL(directoryChanged(QString)));
-  q->registerProperty("Modules/TemporaryDirectory", relativePathMapper,
+  q->registerProperty("TemporaryPath", relativePathMapper,
                       "relativePath", SIGNAL(relativePathChanged(QString)));
   q->registerProperty("Modules/ShowHiddenModules", this->ShowHiddenModulesCheckBox,
                       "checked", SIGNAL(toggled(bool)));


### PR DESCRIPTION
To ensure that CLI modules, sample data downloads, etc. work it is necessary to have a writable temporary directory.
In some cases the path specified in application settings does not point to a valid, writable location anymore.

To fix this, the application checks at startup that the temporary path is writeable. If the check fails then the path is reset to the default.

see #4652