### PR TITLE
DOC: Improved linux build instructions

### DIFF
--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -108,9 +108,11 @@ the software components and functionalities of Slicer.
 
 The following folders will be used in the instructions below:
 
-- source folder: ~/Slicer
-- build folder: ~/Slicer-SuperBuild-Debug
-- inner-build folder: ~/Slicer-SuperBuild-Debug/Slicer-build
+| Folder          | Path   |
+|-----------------|--------|
+| **source**      | `~/Slicer` |
+| **build**       |  `~/Slicer-SuperBuild-Debug` |
+| **inner-build** |  `~/Slicer-SuperBuild-Debug/Slicer-build` |
 
 To obtain a default configuration of the Slicer build project, create the build folder and use `cmake`:
 

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -145,7 +145,7 @@ cmake -DCMAKE_BUILD_TYPE:STRING=Release ../Slicer
 ## Build Slicer
 
 Once the Slicer build project files have been generated, the Slicer project can
-be built by running this command in the build folder:
+be built by running this command in the **build** folder
 
 ```
 make

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -91,6 +91,7 @@ After obtaining the source code, we need to set up the development environment:
 ```
 cd Slicer
 ./Utilities/SetupForDevelopment.sh
+cd ..
 ```
 
 [comment]: <> (TODO: Link to the readthedocs equivalent of https://www.slicer.org/wiki/Documentation/Nightly/Developers/DevelopmentWithGit)
@@ -105,7 +106,13 @@ of build (Debug or Release mode), whether to use system-installed libraries,
 let the build process fetch and compile own libraries, or enable/disable some of
 the software components and functionalities of Slicer.
 
-To obtain a default configuration of the Slicer build project use `cmake`:
+The following folders will be used in the instructions below:
+
+- source folder: ~/Slicer
+- build folder: ~/Slicer-SuperBuild-Debug
+- inner-build folder: ~/Slicer-SuperBuild-Debug/Slicer-build
+
+To obtain a default configuration of the Slicer build project, create the build folder and use `cmake`:
 
 ```
 mkdir Slicer-SuperBuild-Debug
@@ -136,10 +143,9 @@ cmake -DCMAKE_BUILD_TYPE:STRING=Release ../Slicer
 ## Build Slicer
 
 Once the Slicer build project files have been generated, the Slicer project can
-be build:
+be built by running this command in the build folder:
 
 ```
-cd Slicer-SuperBuild-Debug
 make
 ```
 
@@ -190,23 +196,27 @@ make
 ## Run Slicer
 
 After the building process has successfully completed, the executable file to
-run slicer will be located in `./Slicer-build/Slicer`
+run Slicer will be located in the inner-build folder.
+
+The application can be launched by these commands:
+```
+cd Slicer-build
+./Slicer`
+```
 
 ## Test Slicer
 
-After building, run the tests in the  `Slicer-SuperBuild/Slicer-build` directory.
+After building, run the tests in the inner-build folder.
 
-Start a terminal and type the following (you can replace 4 by the number of processor cores in the computer):
+Type the following (you can replace 4 by the number of processor cores in the computer):
 ```
-cd Slicer-SuperBuild-Debug/Slicer-build
 ctest -j4
 ```
 
 ## Package Slicer
 
-Start a terminal and type the following:
+Start a terminal and type the following in the inner-build folder:
 ```
-cd Slicer-SuperBuild-Debug/Slicer-build
 make package
 ```
 

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -217,7 +217,7 @@ ctest -j4
 
 ## Package Slicer
 
-Start a terminal and type the following in the inner-build folder:
+Start a terminal and type the following in the **inner-build** folder:
 ```
 make package
 ```

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -114,7 +114,7 @@ The following folders will be used in the instructions below:
 | **build**       |  `~/Slicer-SuperBuild-Debug` |
 | **inner-build** |  `~/Slicer-SuperBuild-Debug/Slicer-build` |
 
-To obtain a default configuration of the Slicer build project, create the build folder and use `cmake`:
+To obtain a default configuration of the Slicer build project, create the **build** folder and use `cmake`:
 
 ```
 mkdir Slicer-SuperBuild-Debug

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -198,7 +198,7 @@ make
 ## Run Slicer
 
 After the building process has successfully completed, the executable file to
-run Slicer will be located in the inner-build folder.
+run Slicer will be located in the **inner-build** folder.
 
 The application can be launched by these commands:
 ```

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -208,7 +208,7 @@ cd Slicer-build
 
 ## Test Slicer
 
-After building, run the tests in the inner-build folder.
+After building, run the tests in the **inner-build** folder.
 
 Type the following (you can replace 4 by the number of processor cores in the computer):
 ```


### PR DESCRIPTION
A few `cd` commands were missed or duplicated, now commands can be copy-pasted into a terminal one after the other to configure, build, test, and package Slicer.