### PR TITLE
BUG: Fix python wrapping of vtkSlicerCLIModuleLogic using VTK9

### DIFF
--- a/Base/QTCLI/CMakeLists.txt
+++ b/Base/QTCLI/CMakeLists.txt
@@ -94,6 +94,14 @@ set(KIT_target_libraries
   ModuleDescriptionParser ${ITK_LIBRARIES}
   MRMLCLI
   )
+if(VTK_WRAP_PYTHON AND ${VTK_VERSION} VERSION_GREATER_EQUAL "8.90")
+  # HACK Explicitly list transitive VTK dependencies because _get_dependencies_recurse
+  # used in vtkAddon/CMake/vtkMacroKitPythonWrap.cmake only recurses over dependencies
+  # that are VTK python wrapped.
+  list(APPEND KIT_target_libraries
+    SlicerBaseLogic
+    )
+endif()
 
 if(Slicer_USE_QtTesting)
   list(APPEND KIT_SRCS

--- a/CMake/SlicerMacroBuildModuleLogic.cmake
+++ b/CMake/SlicerMacroBuildModuleLogic.cmake
@@ -71,7 +71,7 @@ macro(SlicerMacroBuildModuleLogic)
       qSlicerBaseQTCLI
       )
     # HACK Explicitly list transitive VTK dependencies because _get_dependencies_recurse
-    # used in vtkAddon/CMake/vtkMacroKitPythonWrap.cmake does not recurse over dependencies
+    # used in vtkAddon/CMake/vtkMacroKitPythonWrap.cmake only recurses over dependencies
     # that are VTK python wrapped.
     if(NOT ${MODULELOGIC_DISABLE_WRAP_PYTHON} AND VTK_WRAP_PYTHON AND BUILD_SHARED_LIBS)
       list(APPEND MODULELOGIC_TARGET_LIBRARIES


### PR DESCRIPTION
Fixes #5266