### PR TITLE
ENH: Improve markup ROI interaction

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -97,6 +97,7 @@ public:
     ComponentRotationHandle,
     ComponentTranslationHandle,
     ComponentScaleHandle,
+    Component_Last
     };
   struct ComponentInfo
     {

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.h
@@ -48,6 +48,12 @@ public:
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentDefaultMacro(vtkMRMLMarkupsROIDisplayNode);
 
+  enum
+  {
+    ComponentROI = vtkMRMLMarkupsDisplayNode::Component_Last,
+    ComponentROI_Last
+  };
+
 protected:
   vtkMRMLMarkupsROIDisplayNode();
   ~vtkMRMLMarkupsROIDisplayNode() override;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
@@ -118,6 +118,7 @@ public:
   /// Calculate the position of control points from the ROI
   virtual void UpdateControlPointsFromROI();
   virtual void UpdateControlPointsFromBoundingBoxROI();
+  virtual void UpdateControlPointsFromBoxROI();
 
   // ROI type enum defines the calculation method that should be used to convert to and from control points.
   enum
@@ -200,15 +201,15 @@ public:
   vtkBooleanMacro(InsideOut, bool);
 
 protected:
+  bool InsideOut{false};
+  int ROIType{vtkMRMLMarkupsROINode::ROITypeBox};
 
-  bool InsideOut;
-  int ROIType;
+  double Size[3]{ 0.0, 0.0, 0.0 };
 
-  double Size[3];
+  bool IsUpdatingControlPointsFromROI{false};
+  bool IsUpdatingROIFromControlPoints{false};
+
   vtkSmartPointer<vtkMatrix4x4> ROIToLocalMatrix;
-
-  bool IsUpdatingControlPointsFromROI;
-  bool IsUpdatingROIFromControlPoints;
 
   vtkMRMLMarkupsROINode();
   ~vtkMRMLMarkupsROINode() override;

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -40,6 +40,7 @@
 #include <vtkMRMLDisplayableNode.h>
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLMarkupsDisplayNode.h>
+#include <vtkMRMLMarkupsROIDisplayNode.h>
 #include <vtkMRMLMarkupsNode.h>
 #include <vtkMRMLScene.h>
 
@@ -437,14 +438,16 @@ void qSlicerSubjectHierarchyMarkupsPlugin::showViewContextMenuActionsForItem(vtk
     d->ViewMenuEventData["NodeID"] = QVariant(associatedNode->GetID());
 
     int componentType = d->ViewMenuEventData["ComponentType"].toInt();
-    bool handlesSelected =
+    bool pointActionsDisabled =
       componentType == vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle ||
       componentType == vtkMRMLMarkupsDisplayNode::ComponentRotationHandle ||
-      componentType == vtkMRMLMarkupsDisplayNode::ComponentScaleHandle;
+      componentType == vtkMRMLMarkupsDisplayNode::ComponentScaleHandle ||
+      componentType == vtkMRMLMarkupsDisplayNode::ComponentPlane ||
+      componentType == vtkMRMLMarkupsROIDisplayNode::ComponentROI;
 
-    d->RenamePointAction->setVisible(!handlesSelected);
-    d->DeletePointAction->setVisible(!handlesSelected);
-    d->ToggleSelectPointAction->setVisible(!handlesSelected);
+    d->RenamePointAction->setVisible(!pointActionsDisabled);
+    d->DeletePointAction->setVisible(!pointActionsDisabled);
+    d->ToggleSelectPointAction->setVisible(!pointActionsDisabled);
 
     vtkMRMLMarkupsDisplayNode* displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(associatedNode->GetDisplayNode());
     d->ToggleHandleInteractive->setVisible(displayNode != nullptr);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
@@ -71,6 +71,12 @@ public:
   /// Return the bounds of the representation
   double *GetBounds() override;
 
+  void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
+    int& foundComponentType, int& foundComponentIndex, double& closestDistance2) override;
+
+  void CanInteractWithROI(vtkMRMLInteractionEventData* interactionEventData,
+    int& foundComponentType, int& foundComponentIndex, double& closestDistance2);
+
   // Update visibility of interaction handles for representation
   void UpdateInteractionPipeline() override;
 
@@ -89,6 +95,8 @@ protected:
   void SetROISource(vtkPolyDataAlgorithm* roiSource);
 
   vtkSmartPointer<vtkPolyDataAlgorithm>       ROISource;
+
+  vtkSmartPointer<vtkPassThroughFilter>       ROIPipelineInputFilter;
   vtkSmartPointer<vtkTransform>               ROIToWorldTransform;
   vtkSmartPointer<vtkTransformPolyDataFilter> ROIToWorldTransformFilter;
   vtkSmartPointer<vtkCutter>                  ROIOutlineCutter;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
@@ -81,6 +81,12 @@ public:
   /// Return the bounds of the representation
   double *GetBounds() override;
 
+  void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
+    int& foundComponentType, int& foundComponentIndex, double& closestDistance2) override;
+
+  void CanInteractWithROI(vtkMRMLInteractionEventData* interactionEventData,
+    int& foundComponentType, int& foundComponentIndex, double& closestDistance2);
+
 protected:
   vtkSlicerROIRepresentation3D();
   ~vtkSlicerROIRepresentation3D() override;


### PR DESCRIPTION
List of improvements:
- When an ROI is already active and the user clicks place mode, create a new ROI rather than modify the old one.
- Correctly switch between box and bounding box ROI types.
- Enable hover and interaction (right-click) on ROI outline.
- Change box ROI type to place a single fiducial at the center of the ROI.