### PR TITLE
BUG: Fix table view losing table node selection after batch processing

### DIFF
--- a/Libs/MRML/Widgets/qMRMLTableView.cxx
+++ b/Libs/MRML/Widgets/qMRMLTableView.cxx
@@ -164,18 +164,18 @@ bool qMRMLTableViewPrivate::verifyTableModelAndNode(const char* methodName) cons
 void qMRMLTableViewPrivate::updateWidgetFromViewNode()
 {
   Q_Q(qMRMLTableView);
-  if (!this->MRMLScene || !this->MRMLTableViewNode)
+  if (!this->MRMLTableViewNode)
     {
+    // this view is used without view node (table node is set directly)
+    return;
+    }
+  if (!this->MRMLScene
+    || this->MRMLScene != this->MRMLTableViewNode->GetScene())
+    {
+    // the view node is not in the scene anymore, do not show the table
     q->setMRMLTableNode((vtkMRMLNode*)nullptr);
-    return;
     }
-
-  if (!q->isEnabled())
-    {
-    return;
-    }
-
-  // Get the TableNode
+  // Update the TableNode
   q->setMRMLTableNode(this->MRMLTableViewNode->GetTableNode());
 }
 


### PR DESCRIPTION
When table view node was not set in a qMRMLTableView but the table node was set correctly, a scene batch update resulted in resetting the table node.

See user report here: https://discourse.slicer.org/t/cant-modify-a-table-in-tables-module-after-using-landmark-registration-module/16069

qMRMLTableView is allowed to be used without a view node, so fixed the problem by ignoring scene batch processing update if view node is not set.