### PR TITLE
ENH: Improve default axis-aligned display of single-slice volume

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSliceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.cxx
@@ -2114,7 +2114,7 @@ void vtkMRMLSliceNode::SetSliceOffset(double offset)
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLSliceNode::RotateToVolumePlane(vtkMRMLVolumeNode *volumeNode)
+void vtkMRMLSliceNode::RotateToVolumePlane(vtkMRMLVolumeNode *volumeNode, bool forceSlicePlaneToSingleSlice/*=true*/)
 {
   if (volumeNode == nullptr)
     {
@@ -2141,7 +2141,7 @@ void vtkMRMLSliceNode::RotateToVolumePlane(vtkMRMLVolumeNode *volumeNode)
     }
 
   int volumeAxisIndexForSliceZ = -1;
-  if (volumeNode->GetImageData() != nullptr)
+  if (forceSlicePlaneToSingleSlice && volumeNode->GetImageData() != nullptr)
     {
     int dims[3] = { 0, 0, 0 };
     volumeNode->GetImageData()->GetDimensions(dims);

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -422,9 +422,10 @@ public:
   /// native space of the image data so that no oblique resampling
   /// occurs when rendering (helps to see original acquisition data
   /// and for oblique volumes with few slices).
-  /// For single-slice volume, slice normal is aligned to the volume
-  /// plane's normal.
-  void RotateToVolumePlane(vtkMRMLVolumeNode *volumeNode);
+  /// \param forceSlicePlaneToSingleSlice If the volume is single-slice and forceSlicePlaneToSingleSlice
+  /// is enabled then slice view will be aligned with the volume's slice plane. If the flag is disabled
+  /// of the volume has more than one slice then the slice view will be rotated to the closest orthogonal axis.
+  void RotateToVolumePlane(vtkMRMLVolumeNode *volumeNode, bool forceSlicePlaneToSingleSlice=true);
 
   /// Adjusts the slice node to align with the
   /// axes of the provided reference coordinate system

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -424,7 +424,7 @@ public:
   /// and for oblique volumes with few slices).
   /// \param forceSlicePlaneToSingleSlice If the volume is single-slice and forceSlicePlaneToSingleSlice
   /// is enabled then slice view will be aligned with the volume's slice plane. If the flag is disabled
-  /// of the volume has more than one slice then the slice view will be rotated to the closest orthogonal axis.
+  /// or the volume has more than one slice then the slice view will be rotated to the closest orthogonal axis.
   void RotateToVolumePlane(vtkMRMLVolumeNode *volumeNode, bool forceSlicePlaneToSingleSlice=true);
 
   /// Adjusts the slice node to align with the

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -538,7 +538,7 @@ void vtkMRMLApplicationLogic::FitSliceToAll(bool onlyIfPropagateVolumeSelectionA
     // Set to default orientation before rotation so that the view is snapped
     // closest to the default orientation of this slice view.
     sliceNode->SetOrientationToDefault();
-    sliceLogic->RotateSliceToLowestVolumeAxes();
+    sliceLogic->RotateSliceToLowestVolumeAxes(false);
     int* dims = sliceNode->GetDimensions();
     sliceLogic->FitSliceToAll(dims[0], dims[1]);
     sliceLogic->SnapSliceOffsetToIJK();

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -2375,7 +2375,7 @@ vtkImageBlend* vtkMRMLSliceLogic::GetBlendUVW()
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLSliceLogic::RotateSliceToLowestVolumeAxes()
+void vtkMRMLSliceLogic::RotateSliceToLowestVolumeAxes(bool forceSlicePlaneToSingleSlice/*=true*/)
 {
   vtkMRMLVolumeNode* volumeNode;
   for (int layer = 0; layer < 3; layer++)
@@ -2395,6 +2395,6 @@ void vtkMRMLSliceLogic::RotateSliceToLowestVolumeAxes()
     {
     return;
     }
-  sliceNode->RotateToVolumePlane(volumeNode);
+  sliceNode->RotateToVolumePlane(volumeNode, forceSlicePlaneToSingleSlice);
   this->SnapSliceOffsetToIJK();
 }

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -239,7 +239,10 @@ public:
   void GetBackgroundSliceBounds(double sliceBounds[6]);
 
   /// Rotate slice view to match axes of the lowest volume layer (background, foreground, label).
-  void RotateSliceToLowestVolumeAxes();
+  /// \param forceSlicePlaneToSingleSlice If the volume is single-slice and forceSlicePlaneToSingleSlice
+  /// is enabled then slice view will be aligned with the volume's slice plane. If the flag is disabled
+  /// of the volume has more than one slice then the slice view will be rotated to the closest orthogonal axis.
+  void RotateSliceToLowestVolumeAxes(bool forceSlicePlaneToSingleSlice = true);
 
   ///
   /// adjust the node's field of view to match the extent of current background volume

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
@@ -28,7 +28,7 @@
 // Slicer includes
 #include "qMRMLSliceWidget.h"
 #include "qSlicerApplication.h"
-#include "qSlicerLayoutManager.h" 
+#include "qSlicerLayoutManager.h"
 #include "vtkSlicerApplicationLogic.h"
 
 // MRML includes
@@ -460,7 +460,10 @@ void qSlicerSubjectHierarchyVolumesPlugin::showVolumeInAllViews(
           // Set to default orientation before rotation so that the view is snapped
           // closest to the default orientation of this slice view.
           sliceNode->SetOrientationToDefault();
-          sliceWidget->sliceLogic()->RotateSliceToLowestVolumeAxes();
+          // If the volume is shown in only one view and the volume is a single slice then
+          // make sure the view is aligned with that, otherwise just snap to closest view.
+          bool forceSlicePlaneToSingleSlice = (numberOfCompositeNodes == 1);
+          sliceWidget->sliceLogic()->RotateSliceToLowestVolumeAxes(forceSlicePlaneToSingleSlice);
           }
         if (resetFov)
           {


### PR DESCRIPTION
When "Reset view orientation on show" was enabled then single-slice volumes fully appeared in all view (view normal aligned with slice normal), with different rotations.
This resulted in redundant and slightly confusing views.

Fixed the problem by forcing slice view normal to be aligned with the volume slice normal only if a volume is requested to be shown in a single view.
If a volume is shown in multiple views then each slice view is aligned with the nearest volume axis.

Before the fix:

![image](https://user-images.githubusercontent.com/307929/108616584-9bdec780-73dc-11eb-8433-add207d65ec7.png)

After the fix:

![image](https://user-images.githubusercontent.com/307929/108616596-ab5e1080-73dc-11eb-9d90-a7bddf221f8b.png)
