### PR TITLE
BUG: Fix default storage node creation in LoadMarkupsFromJson

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -100,7 +100,7 @@ public:
 vtkSlicerMarkupsLogic::vtkSlicerMarkupsLogic()
 {
   this->AutoCreateDisplayNodes = true;
-  this->RegisterMarkupTypeStorageNode("ROI", "vtkMRMLMarkupsROIJsonStorageNode");
+  this->RegisterJsonStorageNodeForMarkupsType("ROI", "vtkMRMLMarkupsROIJsonStorageNode");
 }
 
 //----------------------------------------------------------------------------
@@ -730,22 +730,22 @@ char* vtkSlicerMarkupsLogic::LoadMarkupsFromJson(const char* fileName, const cha
     return nullptr;
     }
 
-  std::vector<std::string> markupTypes;
-  tempStorageNode->GetMarkupTypesInFile(fileName, markupTypes);
+  std::vector<std::string> markupsTypes;
+  tempStorageNode->GetMarkupsTypesInFile(fileName, markupsTypes);
   this->GetMRMLScene()->RemoveNode(tempStorageNode);
 
   vtkMRMLMarkupsNode* importedMarkupsNode = nullptr;
-  for(int markupIndex = 0; markupIndex < markupTypes.size(); ++markupIndex)
+  for(int markupsIndex = 0; markupsIndex < markupsTypes.size(); ++markupsIndex)
     {
-    std::string markupType = markupTypes[markupIndex];
-    vtkMRMLMarkupsJsonStorageNode* storageNode = this->AddNewStorageNodeForMarkupType(markupType);
+    std::string markupsType = markupsTypes[markupsIndex];
+    vtkMRMLMarkupsJsonStorageNode* storageNode = this->AddNewJsonStorageNodeForMarkupsType(markupsType);
     if (!storageNode)
       {
-      vtkErrorMacro("LoadMarkupsFromJson: Could not create storage node for markup type: " << markupType);
+      vtkErrorMacro("LoadMarkupsFromJson: Could not create storage node for markup type: " << markupsType);
       continue;
       }
 
-    vtkMRMLMarkupsNode* markupsNode = storageNode->AddNewMarkupsNodeFromFile(fileName, nodeName, markupIndex);
+    vtkMRMLMarkupsNode* markupsNode = storageNode->AddNewMarkupsNodeFromFile(fileName, nodeName, markupsIndex);
     if (!importedMarkupsNode)
       {
       importedMarkupsNode = markupsNode;
@@ -1504,25 +1504,24 @@ bool vtkSlicerMarkupsLogic::GetBestFitPlane(vtkMRMLMarkupsNode* curveNode, vtkPl
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::RegisterMarkupTypeStorageNode(std::string markupType, std::string storageNodeClassName)
+void vtkSlicerMarkupsLogic::RegisterJsonStorageNodeForMarkupsType(std::string markupsType, std::string storageNodeClassName)
 {
-  this->MarkupTypeStorageNodes[markupType] = storageNodeClassName;
+  this->MarkupsTypeStorageNodes[markupsType] = storageNodeClassName;
 }
 
 //---------------------------------------------------------------------------
-std::string vtkSlicerMarkupsLogic::GetClassNameForMarkupType(std::string markupType)
+std::string vtkSlicerMarkupsLogic::GetJsonStorageNodeClassNameForMarkupsType(std::string markupsType)
 {
-  auto markupStorageNodeIt = this->MarkupTypeStorageNodes.find(markupType);
-  if (markupStorageNodeIt == this->MarkupTypeStorageNodes.end())
+  auto markupsStorageNodeIt = this->MarkupsTypeStorageNodes.find(markupsType);
+  if (markupsStorageNodeIt == this->MarkupsTypeStorageNodes.end())
     {
-    return "";
+    return "vtkMRMLMarkupsJsonStorageNode";
     }
-  return markupStorageNodeIt->second;
+  return markupsStorageNodeIt->second;
 }
 
-
 //---------------------------------------------------------------------------
-vtkMRMLMarkupsJsonStorageNode* vtkSlicerMarkupsLogic::AddNewStorageNodeForMarkupType(std::string markupType)
+vtkMRMLMarkupsJsonStorageNode* vtkSlicerMarkupsLogic::AddNewJsonStorageNodeForMarkupsType(std::string markupsType)
 {
-  return vtkMRMLMarkupsJsonStorageNode::SafeDownCast(this->GetMRMLScene()->AddNewNodeByClass(this->GetClassNameForMarkupType(markupType)));
+  return vtkMRMLMarkupsJsonStorageNode::SafeDownCast(this->GetMRMLScene()->AddNewNodeByClass(this->GetJsonStorageNodeClassNameForMarkupsType(markupsType)));
 }

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -238,9 +238,9 @@ public:
   /// Get best fit plane for a markup
   static bool GetBestFitPlane(vtkMRMLMarkupsNode* curveNode, vtkPlane* plane);
 
-  std::string GetClassNameForMarkupType(std::string markupType);
-  void RegisterMarkupTypeStorageNode(std::string markupType, std::string storageNodeClassName);
-  vtkMRMLMarkupsJsonStorageNode* AddNewStorageNodeForMarkupType(std::string markupType);
+  std::string GetJsonStorageNodeClassNameForMarkupsType(std::string markupsType);
+  void RegisterJsonStorageNodeForMarkupsType(std::string markupsType, std::string storageNodeClassName);
+  vtkMRMLMarkupsJsonStorageNode* AddNewJsonStorageNodeForMarkupsType(std::string markupsType);
 
 protected:
   vtkSlicerMarkupsLogic();
@@ -256,7 +256,7 @@ protected:
   void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
   void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
 
-  std::map<std::string, std::string> MarkupTypeStorageNodes;
+  std::map<std::string, std::string> MarkupsTypeStorageNodes;
 
 private:
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -953,7 +953,7 @@ bool vtkMRMLMarkupsJsonStorageNode::CanReadInReferenceNode(vtkMRMLNode *refNode)
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsJsonStorageNode::GetMarkupTypesInFile(const char* filePath, std::vector<std::string>& outputMarkupTypes)
+void vtkMRMLMarkupsJsonStorageNode::GetMarkupsTypesInFile(const char* filePath, std::vector<std::string>& outputMarkupsTypes)
 {
   rapidjson::Document* jsonRoot = this->Internal->CreateJsonDocumentFromFile(filePath);
   rapidjson::Value& markups = (*jsonRoot)["markups"];
@@ -964,7 +964,7 @@ void vtkMRMLMarkupsJsonStorageNode::GetMarkupTypesInFile(const char* filePath, s
       {
       rapidjson::Value& markup = markups.GetArray()[markupIndex];
       std::string markupsType = markup["type"].GetString();
-      outputMarkupTypes.push_back(markupsType);
+      outputMarkupsTypes.push_back(markupsType);
       }
     }
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.h
@@ -59,7 +59,7 @@ public:
 
   /// Returns a list of all markup types ("Curve", "ClosedCurve", "Angle", "Plane", etc.) in the json file.
   /// The types are ordered by the index in which they appear in the Json file.
-  void GetMarkupTypesInFile(const char* filePath, std::vector<std::string>& outputMarkupTypes);
+  void GetMarkupsTypesInFile(const char* filePath, std::vector<std::string>& outputMarkupsTypes);
 
 protected:
   vtkMRMLMarkupsJsonStorageNode();


### PR DESCRIPTION
The GetJsonStorageNodeClassNameForMarkupType was supposed to return the default Json storage node "vtkMRMLMarkupsJsonStorageNode" if a specific storage node wasn't registered for the markup type, but it instead returned an empty string.
Fixed by changing default return to the correct value.