### PR TITLE
ENH: Add Shift shortcut for changing ROI size without moving origin

### DIFF
--- a/Docs/user_guide/modules/markups.md
+++ b/Docs/user_guide/modules/markups.md
@@ -37,6 +37,13 @@ To pick a markups node in a viewer so that its properties can be edited in Marku
 
 ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_markups_context_menu_properties.png)
 
+### Edit ROI markups
+
+- ROI size can be changed using handles on the corners and faces of the ROI.
+- If the handles are not visible, right-click on the ROI outline, or on a control point, and check "Interaction handles visible".
+- Left-click-and-drag on interaction handles to change the ROI size.
+- Alt + Left-click-and-drag to symmetrically adjust the ROI size without changing the position of the center.
+
 ## Panels and their use
 
 - Create: click on any of the buttons to create a new markup. Click in any of the viewers to place markup points.

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -299,6 +299,10 @@ bool vtkSlicerMarkupsWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* vt
     {
     this->SetWidgetState(WidgetStateOnRotationHandle);
     }
+  else if (activeComponentType == vtkMRMLMarkupsDisplayNode::ComponentScaleHandle)
+    {
+    this->SetWidgetState(WidgetStateOnScaleHandle);
+    }
   else
     {
     this->SetWidgetState(WidgetStateOnWidget);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
@@ -60,6 +60,7 @@ public:
     WidgetStateOnTranslationHandle, // hovering over a translation interaction handle
     WidgetStateOnRotationHandle, // hovering over a rotation interaction handle
     WidgetStateOnScaleHandle, // hovering over a scale interaction handle
+    WidgetStateMarkups_Last
   };
 
   /// Widget events
@@ -73,7 +74,8 @@ public:
     WidgetEventControlPointMoveEnd,
     WidgetEventControlPointDelete,
     WidgetEventControlPointInsert,
-    WidgetEventControlPointSnapToSlice
+    WidgetEventControlPointSnapToSlice,
+    WidgetEventMarkups_Last
   };
 
   // Returns true if one of the markup points are just being previewed and not placed yet.

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIWidget.h
@@ -41,6 +41,21 @@ public:
   /// Standard methods for a VTK class.
   vtkTypeMacro(vtkSlicerROIWidget,vtkSlicerMarkupsWidget);
 
+  /// Widget states
+  enum
+  {
+    WidgetStateSymmetricScale = WidgetStateMarkups_Last,
+    WidgetStateMarkupsROI_Last
+  };
+
+  // Widget events
+  enum
+  {
+    WidgetEventSymmetricScaleStart = WidgetEventMarkups_Last,
+    WidgetEventSymmetricScaleEnd,
+    WidgetEventMarkupsROI_Last
+  };
+
   /// Create the default widget representation and initializes the widget and representation.
   void CreateDefaultRepresentation(vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer) override;
 
@@ -53,7 +68,14 @@ protected:
   vtkSlicerROIWidget();
   ~vtkSlicerROIWidget() override;
 
+  bool CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double& distance2) override;
+  bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
+  bool ProcessWidgetSymmetricScaleStart(vtkMRMLInteractionEventData* eventData);
+  bool ProcessMouseMove(vtkMRMLInteractionEventData* eventData) override;
+  bool ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData);
+
   void ScaleWidget(double eventPos[2]) override;
+  void ScaleWidget(double eventPos[2], bool symmetricScale);
 
 private:
   vtkSlicerROIWidget(const vtkSlicerROIWidget&) = delete;


### PR DESCRIPTION
Pressing the shift button while scaling the ROI will adjust the size of the ROI symmetrically, keeping the origin in the same location.
Re #5061