### PR TITLE
ENH: Add separate node attributes for interaction handle visibility

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -125,6 +125,9 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->ActiveColor[2] = 0.0;
 
   this->HandlesInteractive = false;
+  this->TranslationHandleVisibility = true;
+  this->RotationHandleVisibility = true;
+  this->ScaleHandleVisibility = true;
 
   // Line color node
   vtkNew<vtkIntArray> events;
@@ -168,6 +171,9 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingHueOffset, LineColorFadingHueOffset);
   vtkMRMLWriteXMLBooleanMacro(handlesInteractive, HandlesInteractive);
+  vtkMRMLWriteXMLBooleanMacro(translationHandleVisibility, TranslationHandleVisibility);
+  vtkMRMLWriteXMLBooleanMacro(rotationHandleVisibility, RotationHandleVisibility);
+  vtkMRMLWriteXMLBooleanMacro(scaleHandleVisibility, ScaleHandleVisibility);
   vtkMRMLWriteXMLBooleanMacro(fillVisibility, FillVisibility);
   vtkMRMLWriteXMLBooleanMacro(outlineVisibility, OutlineVisibility);
   vtkMRMLWriteXMLFloatMacro(fillOpacity, FillOpacity);
@@ -211,6 +217,9 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
   vtkMRMLReadXMLFloatMacro(lineColorFadingHueOffset, LineColorFadingHueOffset);
   vtkMRMLReadXMLBooleanMacro(handlesInteractive, HandlesInteractive);
+  vtkMRMLReadXMLBooleanMacro(translationHandleVisibility, TranslationHandleVisibility);
+  vtkMRMLReadXMLBooleanMacro(rotationHandleVisibility, RotationHandleVisibility);
+  vtkMRMLReadXMLBooleanMacro(scaleHandleVisibility, ScaleHandleVisibility);
   vtkMRMLReadXMLBooleanMacro(fillVisibility, FillVisibility);
   vtkMRMLReadXMLBooleanMacro(outlineVisibility, OutlineVisibility);
   vtkMRMLReadXMLFloatMacro(fillOpacity, FillOpacity);
@@ -277,6 +286,9 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   vtkMRMLCopyFloatMacro(LineColorFadingSaturation);
   vtkMRMLCopyFloatMacro(LineColorFadingHueOffset);
   vtkMRMLCopyBooleanMacro(HandlesInteractive);
+  vtkMRMLCopyBooleanMacro(TranslationHandleVisibility);
+  vtkMRMLCopyBooleanMacro(RotationHandleVisibility);
+  vtkMRMLCopyBooleanMacro(ScaleHandleVisibility);
   vtkMRMLCopyBooleanMacro(FillVisibility);
   vtkMRMLCopyBooleanMacro(OutlineVisibility);
   vtkMRMLCopyFloatMacro(FillOpacity);
@@ -459,6 +471,9 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(LineColorFadingSaturation);
   vtkMRMLPrintFloatMacro(LineColorFadingHueOffset);
   vtkMRMLPrintBooleanMacro(HandlesInteractive);
+  vtkMRMLPrintBooleanMacro(TranslationHandleVisibility);
+  vtkMRMLPrintBooleanMacro(RotationHandleVisibility);
+  vtkMRMLPrintBooleanMacro(ScaleHandleVisibility);
   vtkMRMLPrintBooleanMacro(FillVisibility);
   vtkMRMLPrintBooleanMacro(OutlineVisibility);
   vtkMRMLPrintFloatMacro(FillOpacity);
@@ -1003,4 +1018,41 @@ void vtkMRMLMarkupsDisplayNode::UpdateAssignedAttribute()
   this->UpdateScalarRange();
 
   this->GetMarkupsNode()->UpdateAssignedAttribute();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsDisplayNode::SetHandleVisibility(int componentType, bool visibility)
+{
+  switch (componentType)
+    {
+    case vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle:
+      this->SetTranslationHandleVisibility(visibility);
+      break;
+    case vtkMRMLMarkupsDisplayNode::ComponentRotationHandle:
+      this->SetRotationHandleVisibility(visibility);
+      break;
+    case vtkMRMLMarkupsDisplayNode::ComponentScaleHandle:
+      this->SetScaleHandleVisibility(visibility);
+      break;
+    default:
+      vtkErrorMacro("Unknown handle type");
+      break;
+    }
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLMarkupsDisplayNode::GetHandleVisibility(int componentType)
+{
+  switch (componentType)
+    {
+    case vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle:
+      return this->GetTranslationHandleVisibility();
+    case vtkMRMLMarkupsDisplayNode::ComponentRotationHandle:
+      return this->GetRotationHandleVisibility();
+    case vtkMRMLMarkupsDisplayNode::ComponentScaleHandle:
+      return this->GetScaleHandleVisibility();
+    default:
+      vtkErrorMacro("Unknown handle type");
+    }
+  return false;
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -408,6 +408,17 @@ public:
   vtkGetMacro(HandlesInteractive, bool);
   vtkSetMacro(HandlesInteractive, bool);
   vtkBooleanMacro(HandlesInteractive, bool);
+  vtkGetMacro(TranslationHandleVisibility, bool);
+  vtkSetMacro(TranslationHandleVisibility, bool);
+  vtkBooleanMacro(TranslationHandleVisibility, bool);
+  vtkGetMacro(RotationHandleVisibility, bool);
+  vtkSetMacro(RotationHandleVisibility, bool);
+  vtkBooleanMacro(RotationHandleVisibility, bool);
+  vtkGetMacro(ScaleHandleVisibility, bool);
+  vtkSetMacro(ScaleHandleVisibility, bool);
+  vtkBooleanMacro(ScaleHandleVisibility, bool);
+  void SetHandleVisibility(int handleType, bool visibility);
+  bool GetHandleVisibility(int handleType);
 
   /// Get data set containing the scalar arrays for this node type.
   /// For markups it is the curve poly data
@@ -489,5 +500,8 @@ protected:
   double ActiveColor[3];
 
   bool HandlesInteractive;
+  bool TranslationHandleVisibility;
+  bool RotationHandleVisibility;
+  bool ScaleHandleVisibility;
 };
 #endif

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -117,6 +117,10 @@ protected slots:
   void toggleHandleInteractive();
   /// toggle handle interactive for the current subject hierarchy item
   void toggleCurrentItemHandleInteractive();
+  /// toggle the visibility of the interaction handle type for the current subject hierarchy item
+  void toggleCurrentItemHandleTypeVisibility();
+  /// toggle the visibility of the interaction handle type for the active node in view
+  void toggleHandleTypeVisibility();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyMarkupsPluginPrivate> d_ptr;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
@@ -516,9 +516,11 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
   vtkMRMLMarkupsROINode* roiNode = vtkMRMLMarkupsROINode::SafeDownCast(
     vtkSlicerMarkupsWidgetRepresentation::SafeDownCast(this->Representation)->GetMarkupsNode());
   if (!roiNode)
-  {
+    {
     return;
-  }
+    }
+
+  vtkMRMLMarkupsDisplayNode* displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(roiNode->GetDisplayNode());
 
   double viewPlaneOrigin4[4] = { 0.0, 0.0, 0.0, 1.0 };
   double viewPlaneNormal4[4] = { 0.0, 0.0, 1.0, 0.0 };
@@ -551,7 +553,7 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
 
   vtkIdTypeArray* visibilityArray = vtkIdTypeArray::SafeDownCast(this->ScaleHandlePoints->GetPointData()->GetArray("visibility"));
   visibilityArray->SetNumberOfValues(roiPoints->GetNumberOfPoints());
-  visibilityArray->Fill(1);
+  visibilityArray->Fill(displayNode ? displayNode->GetScaleHandleVisibility() : 1.0);
 
   vtkNew<vtkPlane> plane;
   plane->SetNormal(viewPlaneNormal_ROI);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
@@ -463,11 +463,26 @@ vtkSlicerROIRepresentation3D::MarkupsInteractionPipelineROI::MarkupsInteractionP
 //----------------------------------------------------------------------
 double vtkSlicerROIRepresentation3D::MarkupsInteractionPipelineROI::GetHandleOpacity(int type, int index)
 {
+  double opacity = 1.0;
   if (type == vtkMRMLMarkupsDisplayNode::ComponentScaleHandle && index > 5)
     {
-    return 1.0;
+    vtkSlicerMarkupsWidgetRepresentation* markupsRepresentation = vtkSlicerMarkupsWidgetRepresentation::SafeDownCast(this->Representation);
+    vtkMRMLMarkupsDisplayNode* displayNode = nullptr;
+    if (markupsRepresentation)
+      {
+      displayNode = markupsRepresentation->GetMarkupsDisplayNode();
+      }
+    if (displayNode)
+      {
+      opacity = displayNode->GetScaleHandleVisibility() ? 1.0 : 0.0;
+      }
     }
-  return MarkupsInteractionPipeline::GetHandleOpacity(type, index);
+  else
+    {
+    opacity = MarkupsInteractionPipeline::GetHandleOpacity(type, index);
+    }
+
+  return opacity;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Widgets/CMakeLists.txt
@@ -14,6 +14,8 @@ set(${KIT}_SRCS
   qMRML${MODULE_NAME}DisplayNodeWidget.h
   qMRML${MODULE_NAME}FiducialProjectionPropertyWidget.cxx
   qMRML${MODULE_NAME}FiducialProjectionPropertyWidget.h
+  qMRML${MODULE_NAME}InteractionHandleWidget.cxx
+  qMRML${MODULE_NAME}InteractionHandleWidget.h
   qMRML${MODULE_NAME}ROIWidget.cxx
   qMRML${MODULE_NAME}ROIWidget.h
   qSlicerMarkupsPlaceWidget.cxx
@@ -25,6 +27,7 @@ set(${KIT}_SRCS
 set(${KIT}_MOC_SRCS
   qMRML${MODULE_NAME}DisplayNodeWidget.h
   qMRML${MODULE_NAME}FiducialProjectionPropertyWidget.h
+  qMRML${MODULE_NAME}InteractionHandleWidget.h
   qMRML${MODULE_NAME}ROIWidget.h
   qSlicerMarkupsPlaceWidget.h
   qSlicerSimpleMarkupsWidget.h
@@ -33,6 +36,7 @@ set(${KIT}_MOC_SRCS
 set(${KIT}_UI_SRCS
   Resources/UI/qMRML${MODULE_NAME}DisplayNodeWidget.ui
   Resources/UI/qMRML${MODULE_NAME}FiducialProjectionPropertyWidget.ui
+  Resources/UI/qMRML${MODULE_NAME}InteractionHandleWidget.ui
   Resources/UI/qMRML${MODULE_NAME}ROIWidget.ui
   Resources/UI/qSlicerMarkupsPlaceWidget.ui
   Resources/UI/qSlicerSimpleMarkupsWidget.ui

--- a/Modules/Loadable/Markups/Widgets/DesignerPlugins/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Widgets/DesignerPlugins/CMakeLists.txt
@@ -12,6 +12,8 @@ set(${KIT}_SRCS
   qMRML${MODULE_NAME}DisplayNodeWidgetPlugin.h
   qMRML${MODULE_NAME}FiducialProjectionPropertyWidgetPlugin.cxx
   qMRML${MODULE_NAME}FiducialProjectionPropertyWidgetPlugin.h
+  qMRML${MODULE_NAME}InteractionHandleWidgetPlugin.cxx
+  qMRML${MODULE_NAME}InteractionHandleWidgetPlugin.h
   qMRML${MODULE_NAME}ROIWidgetPlugin.cxx
   qMRML${MODULE_NAME}ROIWidgetPlugin.h
   qSlicerMarkupsPlaceWidgetPlugin.cxx
@@ -24,6 +26,7 @@ set(${KIT}_MOC_SRCS
   qSlicer${MODULE_NAME}ModuleWidgetsPlugin.h
   qMRML${MODULE_NAME}DisplayNodeWidgetPlugin.h
   qMRML${MODULE_NAME}FiducialProjectionPropertyWidgetPlugin.h
+  qMRML${MODULE_NAME}InteractionHandleWidgetPlugin.h
   qMRML${MODULE_NAME}ROIWidgetPlugin.h
   qSlicerMarkupsPlaceWidgetPlugin.h
   qSlicerSimpleMarkupsWidgetPlugin.h

--- a/Modules/Loadable/Markups/Widgets/DesignerPlugins/qMRMLMarkupsInteractionHandleWidgetPlugin.cxx
+++ b/Modules/Loadable/Markups/Widgets/DesignerPlugins/qMRMLMarkupsInteractionHandleWidgetPlugin.cxx
@@ -1,0 +1,62 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#include "qMRMLMarkupsInteractionHandleWidgetPlugin.h"
+#include "qMRMLMarkupsInteractionHandleWidget.h"
+
+//-----------------------------------------------------------------------------
+qMRMLMarkupsInteractionHandleWidgetPlugin::qMRMLMarkupsInteractionHandleWidgetPlugin(QObject *_parent)
+  : QObject(_parent)
+{
+}
+
+//-----------------------------------------------------------------------------
+QWidget *qMRMLMarkupsInteractionHandleWidgetPlugin::createWidget(QWidget *_parent)
+{
+  qMRMLMarkupsInteractionHandleWidget* _widget = new qMRMLMarkupsInteractionHandleWidget(_parent);
+  return _widget;
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLMarkupsInteractionHandleWidgetPlugin::domXml() const
+{
+  return "<widget class=\"qMRMLMarkupsInteractionHandleWidget\" \
+          name=\"MRMLMarkupsInteractionHandleWidget\">\n"
+          "</widget>\n";
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLMarkupsInteractionHandleWidgetPlugin::includeFile() const
+{
+  return "qMRMLMarkupsInteractionHandleWidget.h";
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLMarkupsInteractionHandleWidgetPlugin::isContainer() const
+{
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLMarkupsInteractionHandleWidgetPlugin::name() const
+{
+  return "qMRMLMarkupsInteractionHandleWidget";
+}

--- a/Modules/Loadable/Markups/Widgets/DesignerPlugins/qMRMLMarkupsInteractionHandleWidgetPlugin.h
+++ b/Modules/Loadable/Markups/Widgets/DesignerPlugins/qMRMLMarkupsInteractionHandleWidgetPlugin.h
@@ -1,7 +1,8 @@
 /*==============================================================================
 
-  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
-  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
 
   See COPYRIGHT.txt
   or http://www.slicer.org/copyright/copyright.txt for details.
@@ -18,21 +19,25 @@
 
 ==============================================================================*/
 
-// MRML includes
-#include "vtkMRMLMarkupsROIDisplayNode.h"
+#ifndef __qMRMLMarkupsInteractionHandleWidgetPlugin_h
+#define __qMRMLMarkupsInteractionHandleWidgetPlugin_h
 
-//----------------------------------------------------------------------------
-vtkMRMLNodeNewMacro(vtkMRMLMarkupsROIDisplayNode);
+#include "qSlicerMarkupsModuleWidgetsAbstractPlugin.h"
 
-//----------------------------------------------------------------------------
-vtkMRMLMarkupsROIDisplayNode::vtkMRMLMarkupsROIDisplayNode()
+class Q_SLICER_MODULE_MARKUPS_WIDGETS_PLUGINS_EXPORT qMRMLMarkupsInteractionHandleWidgetPlugin
+    : public QObject, public qSlicerMarkupsModuleWidgetsAbstractPlugin
 {
-  this->FillOpacity = 0.2;
-  this->HandlesInteractive = true;
-  this->TranslationHandleVisibility = false;
-  this->RotationHandleVisibility= false;
-  this->ScaleHandleVisibility = true;
-}
+  Q_OBJECT
 
-//----------------------------------------------------------------------------
-vtkMRMLMarkupsROIDisplayNode::~vtkMRMLMarkupsROIDisplayNode() = default;
+public:
+  qMRMLMarkupsInteractionHandleWidgetPlugin(QObject *_parent = nullptr);
+
+  QWidget *createWidget(QWidget *_parent) override;
+  QString  domXml() const override;
+  QString  includeFile() const override;
+  bool     isContainer() const override;
+  QString  name() const override;
+
+};
+
+#endif

--- a/Modules/Loadable/Markups/Widgets/DesignerPlugins/qSlicerMarkupsModuleWidgetsPlugin.h
+++ b/Modules/Loadable/Markups/Widgets/DesignerPlugins/qSlicerMarkupsModuleWidgetsPlugin.h
@@ -27,6 +27,7 @@
 // Markups includes
 #include "qMRMLMarkupsDisplayNodeWidgetPlugin.h"
 #include "qMRMLMarkupsFiducialProjectionPropertyWidgetPlugin.h"
+#include "qMRMLMarkupsInteractionHandleWidgetPlugin.h"
 #include "qMRMLMarkupsROIWidgetPlugin.h"
 #include "qSlicerMarkupsPlaceWidgetPlugin.h"
 #include "qSlicerSimpleMarkupsWidgetPlugin.h"
@@ -46,6 +47,7 @@ public:
     QList<QDesignerCustomWidgetInterface *> plugins;
     plugins << new qMRMLMarkupsDisplayNodeWidgetPlugin;
     plugins << new qMRMLMarkupsFiducialProjectionPropertyWidgetPlugin;
+    plugins << new qMRMLMarkupsInteractionHandleWidgetPlugin;
     plugins << new qMRMLMarkupsROIWidgetPlugin;
     plugins << new qSlicerMarkupsPlaceWidgetPlugin;
     plugins << new qSlicerSimpleMarkupsWidgetPlugin;

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -57,54 +57,10 @@
      </item>
     </layout>
    </item>
-   <item row="8" column="1">
-    <widget class="QCheckBox" name="interactionCheckBox">
-     <property name="toolTip">
-      <string>Show handles to interactively translate and rotate</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="ctkSliderWidget" name="textScaleSliderWidget">
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>20.000000000000000</double>
-     </property>
-     <property name="suffix">
-      <string> %</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="textScaleLabel">
-     <property name="text">
-      <string>Text Size:</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="VisibilityLabel">
      <property name="text">
       <string>Visibility:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="glyphScaleLabel">
-     <property name="text">
-      <string>Glyph Size:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="interactionLabel">
-     <property name="text">
-      <string>Interaction handles: </string>
      </property>
     </widget>
    </item>
@@ -154,7 +110,7 @@
      </item>
     </layout>
    </item>
-   <item row="9" column="0" colspan="2">
+   <item row="10" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="SliceDisplayCollapsibleGroupBox">
      <property name="title">
       <string>Advanced</string>
@@ -591,7 +547,34 @@
      </layout>
     </widget>
    </item>
-   <item row="10" column="0" colspan="2">
+   <item row="5" column="0">
+    <widget class="QLabel" name="glyphScaleLabel">
+     <property name="text">
+      <string>Glyph Size:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="ctkSliderWidget" name="textScaleSliderWidget">
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>20.000000000000000</double>
+     </property>
+     <property name="suffix">
+      <string> %</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="textScaleLabel">
+     <property name="text">
+      <string>Text Size:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="ScalarsCollapsibleGroupBox">
      <property name="title">
       <string>Scalars</string>
@@ -606,25 +589,21 @@
      </layout>
     </widget>
    </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox">
+     <property name="title">
+      <string>Interaction handles</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="qMRMLMarkupsInteractionHandleWidget" name="InteractionHandleWidget"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>ctkCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>ctkCollapsibleGroupBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkColorPickerButton</class>
-   <extends>QPushButton</extends>
-   <header>ctkColorPickerButton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ctkSliderWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkSliderWidget.h</header>
-  </customwidget>
   <customwidget>
    <class>qMRMLCheckableNodeComboBox</class>
    <extends>qMRMLNodeComboBox</extends>
@@ -665,6 +644,27 @@
    <extends>qMRMLWidget</extends>
    <header>qMRMLMarkupsFiducialProjectionPropertyWidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLMarkupsInteractionHandleWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLMarkupsInteractionHandleWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>ctkCollapsibleGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkColorPickerButton</class>
+   <extends>QPushButton</extends>
+   <header>ctkColorPickerButton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>
@@ -746,6 +746,22 @@
     <hint type="destinationlabel">
      <x>315</x>
      <y>245</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qMRMLMarkupsDisplayNodeWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>InteractionHandleWidget</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>179</x>
+     <y>370</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>179</x>
+     <y>129</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsInteractionHandleWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsInteractionHandleWidget.ui
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qMRMLMarkupsInteractionHandleWidget</class>
+ <widget class="qMRMLWidget" name="qMRMLMarkupsInteractionHandleWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>462</width>
+    <height>38</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="overallVisibilityCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Visibility:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QCheckBox" name="translateVisibilityCheckBox">
+       <property name="text">
+        <string>Translate</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="rotateVisibilityCheckBox">
+       <property name="text">
+        <string>Rotate</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="scaleVisibilityCheckBox">
+       <property name="text">
+        <string>Scale</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -108,9 +108,6 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
   QObject::connect(this->opacitySliderWidget, SIGNAL(valueChanged(double)),
     q, SLOT(onOpacitySliderWidgetChanged(double)));
 
-  QObject::connect(this->interactionCheckBox, SIGNAL(stateChanged(int)),
-    q, SLOT(onInteractionCheckBoxChanged(int)));
-
   QObject::connect(this->FillVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setFillVisibility(bool)));
   QObject::connect(this->OutlineVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setOutlineVisibility(bool)));
   QObject::connect(this->FillOpacitySliderWidget, SIGNAL(valueChanged(double)),
@@ -223,6 +220,7 @@ void qMRMLMarkupsDisplayNodeWidget::setMRMLMarkupsDisplayNode(vtkMRMLNode* node)
 //-----------------------------------------------------------------------------
 void qMRMLMarkupsDisplayNodeWidget::setMRMLMarkupsNode(vtkMRMLMarkupsNode* node)
 {
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
   this->setMRMLMarkupsDisplayNode(
     node ? vtkMRMLMarkupsDisplayNode::SafeDownCast(node->GetDisplayNode()) : nullptr);
 }
@@ -247,6 +245,8 @@ void qMRMLMarkupsDisplayNodeWidget::setMRMLMarkupsDisplayNode(vtkMRMLMarkupsDisp
 
   // Set display node to scalars display widget
   d->ScalarsDisplayWidget->setMRMLDisplayNode(markupsDisplayNode);
+
+  d->InteractionHandleWidget->setMRMLDisplayNode(markupsDisplayNode);
 
   this->updateWidgetFromMRML();
 }
@@ -346,9 +346,6 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
     d->textScaleSliderWidget->setMaximum(textScale);
     }
   d->textScaleSliderWidget->setValue(textScale);
-
-  bool handlesInteractive = markupsDisplayNode->GetHandlesInteractive();
-  d->interactionCheckBox->setChecked(handlesInteractive);
 
   bool wasBlocking = false;
   wasBlocking = d->FillVisibilityCheckBox->blockSignals(true);

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
@@ -1,0 +1,166 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+// Qt includes
+
+// qMRML includes
+#include "qMRMLMarkupsInteractionHandleWidget.h"
+#include "ui_qMRMLMarkupsInteractionHandleWidget.h"
+
+// MRML includes
+#include <vtkMRMLMarkupsNode.h>
+#include <vtkMRMLMarkupsROIDisplayNode.h>
+
+// --------------------------------------------------------------------------
+class qMRMLMarkupsInteractionHandleWidgetPrivate: public Ui_qMRMLMarkupsInteractionHandleWidget
+{
+  Q_DECLARE_PUBLIC(qMRMLMarkupsInteractionHandleWidget);
+protected:
+  qMRMLMarkupsInteractionHandleWidget* const q_ptr;
+public:
+  qMRMLMarkupsInteractionHandleWidgetPrivate(qMRMLMarkupsInteractionHandleWidget& object);
+  void init();
+
+  vtkMRMLMarkupsDisplayNode* DisplayNode;
+};
+
+// --------------------------------------------------------------------------
+qMRMLMarkupsInteractionHandleWidgetPrivate::qMRMLMarkupsInteractionHandleWidgetPrivate(qMRMLMarkupsInteractionHandleWidget& object)
+  : q_ptr(&object)
+{
+  this->DisplayNode = nullptr;
+}
+
+// --------------------------------------------------------------------------
+void qMRMLMarkupsInteractionHandleWidgetPrivate::init()
+{
+  Q_Q(qMRMLMarkupsInteractionHandleWidget);
+  this->setupUi(q);
+  q->setEnabled(this->DisplayNode != nullptr);
+
+  QObject::connect(this->overallVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->translateVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->rotateVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->scaleVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+}
+
+// --------------------------------------------------------------------------
+// qMRMLMarkupsInteractionHandleWidget methods
+
+// --------------------------------------------------------------------------
+qMRMLMarkupsInteractionHandleWidget::qMRMLMarkupsInteractionHandleWidget(QWidget* _parent)
+  : qMRMLWidget(_parent)
+  , d_ptr(new qMRMLMarkupsInteractionHandleWidgetPrivate(*this))
+{
+  Q_D(qMRMLMarkupsInteractionHandleWidget);
+  d->init();
+}
+
+// --------------------------------------------------------------------------
+qMRMLMarkupsInteractionHandleWidget::~qMRMLMarkupsInteractionHandleWidget() = default;
+
+// --------------------------------------------------------------------------
+vtkMRMLMarkupsDisplayNode* qMRMLMarkupsInteractionHandleWidget::mrmlDisplayNode() const
+{
+  Q_D(const qMRMLMarkupsInteractionHandleWidget);
+  return d->DisplayNode;
+}
+
+// --------------------------------------------------------------------------
+void qMRMLMarkupsInteractionHandleWidget::setMRMLDisplayNode(vtkMRMLMarkupsDisplayNode* displayNode)
+{
+  Q_D(qMRMLMarkupsInteractionHandleWidget);
+  this->qvtkReconnect(d->DisplayNode, displayNode, vtkCommand::ModifiedEvent,
+                      this, SLOT(updateWidgetFromMRML()));
+
+  d->DisplayNode = displayNode;
+
+  this->updateWidgetFromMRML();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLMarkupsInteractionHandleWidget::setMRMLDisplayNode(vtkMRMLNode* roiNode)
+{
+  this->setMRMLDisplayNode(vtkMRMLMarkupsNode::SafeDownCast(roiNode));
+}
+
+// --------------------------------------------------------------------------
+void qMRMLMarkupsInteractionHandleWidget::updateWidgetFromMRML()
+{
+  Q_D(qMRMLMarkupsInteractionHandleWidget);
+  this->setEnabled(d->DisplayNode != nullptr);
+  d->overallVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->translateVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->rotateVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->scaleVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
+  if (!d->DisplayNode)
+    {
+    return;
+    }
+
+  // Scale handles currently not implmented for representations other than ROI
+  // Disable by default.
+  if (!vtkMRMLMarkupsROIDisplayNode::SafeDownCast(d->DisplayNode))
+    {
+    // Scale handles not currently implemented for non ROI nodes
+    d->scaleVisibilityCheckBox->setVisible(false);
+    }
+  else
+    {
+    d->scaleVisibilityCheckBox->setVisible(true);
+    }
+
+  bool wasBlocking = false;
+
+  // Interactive Mode
+  wasBlocking = d->overallVisibilityCheckBox->blockSignals(true);
+  d->overallVisibilityCheckBox->setChecked(d->DisplayNode->GetHandlesInteractive());
+  d->overallVisibilityCheckBox->blockSignals(wasBlocking);
+
+
+  wasBlocking = d->translateVisibilityCheckBox->blockSignals(true);
+  d->translateVisibilityCheckBox->setChecked(d->DisplayNode->GetTranslationHandleVisibility());
+  d->translateVisibilityCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->rotateVisibilityCheckBox->blockSignals(true);
+  d->rotateVisibilityCheckBox->setChecked(d->DisplayNode->GetRotationHandleVisibility());
+  d->rotateVisibilityCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->scaleVisibilityCheckBox->blockSignals(true);
+  d->scaleVisibilityCheckBox->setChecked(d->DisplayNode->GetScaleHandleVisibility());
+  d->scaleVisibilityCheckBox->blockSignals(wasBlocking);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLMarkupsInteractionHandleWidget::updateMRMLFromWidget()
+{
+  Q_D(qMRMLMarkupsInteractionHandleWidget);
+  if (!d->DisplayNode)
+    {
+    return;
+    }
+
+  MRMLNodeModifyBlocker displayNodeBlocker(d->DisplayNode);
+  d->DisplayNode->SetHandlesInteractive(d->overallVisibilityCheckBox->isChecked());
+  d->DisplayNode->SetTranslationHandleVisibility(d->translateVisibilityCheckBox->isChecked());
+  d->DisplayNode->SetRotationHandleVisibility(d->rotateVisibilityCheckBox->isChecked());
+  d->DisplayNode->SetScaleHandleVisibility(d->scaleVisibilityCheckBox->isChecked());
+}

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.h
@@ -1,0 +1,74 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#ifndef __qMRMLMarkupsInteractionHandleWidget_h
+#define __qMRMLMarkupsInteractionHandleWidget_h
+
+// Qt includes
+#include <QWidget>
+
+// AnnotationWidgets includes
+#include "qSlicerMarkupsModuleWidgetsExport.h"
+
+// CTK includes
+#include <ctkPimpl.h>
+#include <ctkVTKObject.h>
+
+#include <qMRMLWidget.h>
+
+class vtkMRMLNode;
+class vtkMRMLMarkupsDisplayNode;
+class qMRMLMarkupsInteractionHandleWidgetPrivate;
+
+class Q_SLICER_MODULE_MARKUPS_WIDGETS_EXPORT qMRMLMarkupsInteractionHandleWidget : public qMRMLWidget
+{
+  Q_OBJECT
+  QVTK_OBJECT
+
+public:
+  /// Constructors
+  explicit qMRMLMarkupsInteractionHandleWidget(QWidget* parent = nullptr);
+  ~qMRMLMarkupsInteractionHandleWidget() override;
+
+  /// Returns the current MRML display node
+  vtkMRMLMarkupsDisplayNode* mrmlDisplayNode() const;
+
+public slots:
+  /// Set the MRML display node
+  void setMRMLDisplayNode(vtkMRMLNode* node);
+  void setMRMLDisplayNode(vtkMRMLMarkupsDisplayNode* node);
+
+protected slots:
+  /// Internal function to update the widgets based on the node/display node
+  void updateWidgetFromMRML();
+
+  /// Internal function to update the node based on the widget
+  void updateMRMLFromWidget();
+
+protected:
+  QScopedPointer<qMRMLMarkupsInteractionHandleWidgetPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qMRMLMarkupsInteractionHandleWidget);
+  Q_DISABLE_COPY(qMRMLMarkupsInteractionHandleWidget);
+};
+
+#endif


### PR DESCRIPTION
Markup display nodes now have the option to show/hide interaction handle types separately (Translation, Rotation, Scale).
All interaction handle types are shown by default if interaction visibility is enabled. For ROI display nodes, translation and rotation handles are hidden by default.

Visibility of handle types can be controlled from the markup display node widget, or through the subject hierarchy context menu.

This commit also reduces the thickness of the translation arrows by 25%.

Re #5061

![image](https://user-images.githubusercontent.com/9222709/109228482-e1f6ab00-778f-11eb-8cb1-dfe5d6415215.png)
