### PR TITLE
ENH: Ensure that remote cache folder is writable

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1063,6 +1063,7 @@ def getModuleWidget(module):
   :return: module widget object
   :raises RuntimeError: if the module does not have widget.
   """
+  import slicer
   if isinstance(module, str):
     module = getModule(module)
   widgetRepr = module.widgetRepresentation()
@@ -1086,6 +1087,7 @@ def getNewModuleWidget(module):
   :return: module widget object
   :raises RuntimeError: if the module does not have widget.
   """
+  import slicer
   if isinstance(module, str):
     module = getModule(module)
   widgetRepr = module.createNewWidgetRepresentation()
@@ -1107,6 +1109,7 @@ def getModuleLogic(module):
   :return: module logic object
   :raises RuntimeError: if the module does not have widget.
   """
+  import slicer
   if isinstance(module, str):
     module = getModule(module)
   if isinstance(module, slicer.qSlicerScriptedLoadableModule):

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -72,6 +72,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerCoreApplication : public QApplication
   Q_PROPERTY(QString defaultScenePath READ defaultScenePath WRITE setDefaultScenePath)
   Q_PROPERTY(QString slicerSharePath READ slicerSharePath CONSTANT)
   Q_PROPERTY(QString temporaryPath READ temporaryPath WRITE setTemporaryPath)
+  Q_PROPERTY(QString cachePath READ cachePath WRITE setCachePath)
   Q_PROPERTY(QString launcherExecutableFilePath READ launcherExecutableFilePath CONSTANT)
   Q_PROPERTY(QString launcherSettingsFilePath READ launcherSettingsFilePath CONSTANT)
   Q_PROPERTY(QString slicerDefaultSettingsFilePath READ slicerDefaultSettingsFilePath CONSTANT)
@@ -251,6 +252,19 @@ public:
 
   /// Set slicer temporary directory
   void setTemporaryPath(const QString& path);
+
+  /// Get default cache directory.
+  /// \sa cachePath()
+  QString defaultCachePath() const;
+
+  /// Get cache directory.
+  /// It is a temporary folder that contains files that can be useful to be kept between application sessions.
+  /// For example, files downloaded from network, which may not need to be downloaded again if stored locally.
+  QString cachePath() const;
+
+  /// Set cache directory.
+  /// \sa cachePath()
+  void setCachePath(const QString& path);
 
   /// If any, return slicer launcher executable file path.
   QString launcherExecutableFilePath()const;


### PR DESCRIPTION
macOS started to manage application temporary and cache folders more actively, i.e., remove them after certain time period (or at system restart or application exit) to improve security.

Cache folder by default was initialized to be a subfolder of temporary folder. However, when the system removed the temporary folder, the cache folder has become invalid.

To fix this, implemented an automatic mechanism to check the cache folder at startup and reset it to a system-recommended location if the folder is not writable.

See related user error report: https://discourse.slicer.org/t/slicer-4-11-on-m1-not-loading-mrb-file/16228/7

The pull request also contains an unrelated commit with a trivial fix of missing imports in slicer.util.