### PR TITLE
ENH: Hide markup line in 3D view if the number of control points != 2

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -198,7 +198,7 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
     this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
   this->TubeFilter->SetRadius(diameter * 0.5);
 
-  this->LineActor->SetVisibility(this->GetAllControlPointsVisible());
+  this->LineActor->SetVisibility(this->GetAllControlPointsVisible() && markupsNode->GetNumberOfDefinedControlPoints(true) == 2);
   int controlPointType = Active;
   if (this->MarkupsDisplayNode->GetActiveComponentType() != vtkMRMLMarkupsDisplayNode::ComponentLine)
     {


### PR DESCRIPTION
Previously, creating a vtkMRMLMarkupsLineNode with 2 control points and then removing one or both would leave a line in the 3D view.
This commit hides the line actor if there aren't 2 defined control points.