### PR TITLE
BUG: Fix paint effect drawing extra strokes after interrupted

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorPaintEffect.cxx
@@ -1006,6 +1006,7 @@ void qSlicerSegmentEditorPaintEffect::deactivate()
 {
   Q_D(qSlicerSegmentEditorPaintEffect);
   Superclass::deactivate();
+  d->IsPainting = false;
   d->clearBrushPipelines();
   d->PaintCoordinates_World->Reset();
   d->ActiveViewWidget = nullptr;


### PR DESCRIPTION
If Segment Editor Paint effect was interrupted by hitting Escape then next time it was used again, a stray stroke was added because IsPainting state variable was not reset.

See user error report at https://discourse.slicer.org/t/issue-with-brush-or-eraser/16270