### PR TITLE
BUG: Fix linux package ensuring OpenGL_GL_PREFERENCE is considered with VTK9

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -177,7 +177,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "d76bf153dd694d9fc5d84fcee10702091f60ace0") # slicer-v9.0.20201111-733234c785
+    set(_git_tag "60b13991d37445f70a8e24604a45047022e6cb18") # slicer-v9.0.20201111-733234c785
     set(vtk_egg_info_version "9.0.20201111")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -177,7 +177,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "60b13991d37445f70a8e24604a45047022e6cb18") # slicer-v9.0.20201111-733234c785
+    set(_git_tag "e88e47c9679cb897243abefa05bc391866e70306") # slicer-v9.0.20201111-733234c785
     set(vtk_egg_info_version "9.0.20201111")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
To ensure the Slicer can run on system where only libGL is available,
this commit updates VTK to make sure setting OpenGL_GL_PREFERENCE
to LEGACY works as expected. For reference, setting to LEGACY value
was originally introduced in Slicer@23d8144 (BUG: Fix linux package
removing dependency to GLVND libraries).

List of changes:

```
$ git shortlog d76bf153dd..60b13991d3
Jean-Christophe Fillion-Robin (1):
      COMP: Remove custom FindOpenGL to ensure OpenGL_GL_PREFERENCE is considered
```

Fixes #5228
Fixes #5286