### PR TITLE
ENH: Improve Markups Plane and ROI interaction

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
@@ -113,6 +113,8 @@ protected:
   vtkNew<vtkPolyDataMapper2D> PlaneOutlineMapper;
   vtkNew<vtkActor2D> PlaneOutlineActor;
 
+  vtkNew<vtkAppendPolyData> PlanePickingAppend;
+
   vtkNew<vtkGlyphSource2D> ArrowFilter;
   vtkNew<vtkGlyph2D> ArrowGlypher;
   vtkNew<vtkPolyDataMapper2D> ArrowMapper;


### PR DESCRIPTION
- 2D ROI
  - CanInteractROI threshold is now based on display, rather than world coordinates. Improves behavior at high zoom levels.

- 2D plane
  - CanInteractWithPlane now works for both the outline and slice intersection.

- 3D plane
  - Fixed picking of 3D plane representation by moving the outline to a separate actor.
  - CanInteractWithPlane function now checks to see if the users is hovering over the plane outline, rather than the plane fill.

All representations should be made faster by keeping a reference the cell locator.