### PR TITLE
ENH: Add Markups ROI GetRASBounds and GetBounds functions

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
@@ -163,6 +163,9 @@ public:
   /// Create default storage node or nullptr if does not have one
   void CreateDefaultDisplayNodes() override;
 
+  void GetRASBounds(double bounds[6]) override;
+  void GetBounds(double bounds[6]) override;
+
   ///
   /// Legacy vtkMRMLAnnotationROINode methods
   ///
@@ -210,6 +213,9 @@ protected:
   bool IsUpdatingROIFromControlPoints{false};
 
   vtkSmartPointer<vtkMatrix4x4> ROIToLocalMatrix;
+
+  /// Fills the specified vtkPoints with the points for all of the box ROI corners
+  void GenerateBoxBounds(double bounds[6], double xAxis[3], double yAxis[3], double zAxis[3], double center[3], double size[3]);
 
   vtkMRMLMarkupsROINode();
   ~vtkMRMLMarkupsROINode() override;


### PR DESCRIPTION
The implementation of GetRASBounds and GetBounds implemented by vtkMRMLMarkupsNode only took the control point positions into account.
For ROI bounds, we now compute the bounds based on the location of the corner points of the ROI.

Re #5061