### PR TITLE
Missing #include <QTemporaryFile> in Base/QTCore/qSlicerCoreApplication.cxx 

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -32,6 +32,7 @@
 #include <QSettings>
 #include <QTranslator>
 #include <QStandardPaths>
+#include <QTemporaryFile>
 
 // For:
 //  - Slicer_QTLOADABLEMODULES_LIB_DIR


### PR DESCRIPTION
Lately (two days ago I think) I got error when building Slicer that was saying that `QTemporaryFile` is undefined.
Adding this line solved my problem.