### PR TITLE
COMP: Undefined class "QTemporaryFile" when building using SlicerCAT

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -32,6 +32,7 @@
 #include <QSettings>
 #include <QTranslator>
 #include <QStandardPaths>
+#include <QTemporaryFile>
 
 // For:
 //  - Slicer_QTLOADABLEMODULES_LIB_DIR


### PR DESCRIPTION
Without this `#include <QTemporaryFile>` I got compilation error telling me that `QTemporaryFile` is undefined. With this little change I could compile on Windows 10 MSVC2019, Qt 5.15.2