### PR TITLE
ENH: Add custom volume rendering presets to the top of the preset list by default

### DIFF
--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -1362,7 +1362,7 @@ bool vtkSlicerVolumeRenderingLogic::IsDifferentFunction(vtkColorTransferFunction
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerVolumeRenderingLogic::AddPreset(vtkMRMLVolumePropertyNode* preset, vtkImageData* icon /* = nullptr */)
+void vtkSlicerVolumeRenderingLogic::AddPreset(vtkMRMLVolumePropertyNode* preset, vtkImageData* icon/*=nullptr*/, bool appendToEnd/*=false*/)
 {
   if (preset == nullptr)
   {
@@ -1390,7 +1390,14 @@ void vtkSlicerVolumeRenderingLogic::AddPreset(vtkMRMLVolumePropertyNode* preset,
     // is available immediately when the node is added (otherwise widgets may add the item without an icon)
     preset->SetNodeReferenceID(vtkSlicerVolumeRenderingLogic::GetIconVolumeReferenceRole(), addedIconNode->GetID());
   }
-  presetScene->AddNode(preset);
+  if (appendToEnd || presetScene->GetNumberOfNodes() == 0)
+    {
+    presetScene->AddNode(preset);
+    }
+  else
+    {
+    presetScene->InsertBeforeNode(presetScene->GetNthNode(0), preset);
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.h
@@ -287,8 +287,9 @@ public:
   /// If the optional icon image is specified then that will be used to
   /// in preset selector widgets. The icon is stored as a volume node
   /// in the preset scene.
+  /// \param appendToEnd controls if the preset is added befor or after existing presets.
   /// \sa GetPresetsScene(), GetIconVolumeReferenceRole()
-  void AddPreset(vtkMRMLVolumePropertyNode* preset, vtkImageData* icon = nullptr);
+  void AddPreset(vtkMRMLVolumePropertyNode* preset, vtkImageData* icon = nullptr, bool appendToEnd=false);
 
   /// Removes a preset and its associated icon (if specified) from the preset scene.
   /// \sa GetPresetsScene(), GetIconVolumeReferenceRole()


### PR DESCRIPTION
See user request:
https://discourse.slicer.org/t/i-want-to-boot-up-with-my-very-own-color-map-and-a-black-background/16383/10?u=lassoan