### PR TITLE
ENH: update DCMTK to version 3.6.6

### DIFF
--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -50,15 +50,17 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://git.dcmtk.org/dcmtk"
+    "${EP_GIT_PROTOCOL}://github.com/commontk/DCMTK.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    # Official DCMTK release DCMTK-3.6.5
-    # http://git.dcmtk.org/?p=dcmtk.git;a=commit;h=0f2de2313a00f9360bdf33399a2f37ee5e65c429
-    "DCMTK-3.6.5"
+    # Official DCMTK release DCMTK-3.6.6
+    # https://git.dcmtk.org/?p=dcmtk.git;a=commit;h=6cb30bd7fb42190e0188afbd8cb961c62a6fb9c9
+    # with an extra backported patch
+    # https://git.dcmtk.org/?p=dcmtk.git;a=commit;h=b665e2ec2d5ce435e28da6c938736dcfa84d0da6
+    "patched-DCMTK-3.6.6_20210115"
     QUIET
     )
 


### PR DESCRIPTION
re #5510 and https://github.com/QIICR/dcmqi/issues/341#issuecomment-707053566

Update to official 3.6.6 release plus an extra backported patch:

https://git.dcmtk.org/?p=dcmtk.git;a=commit;h=b665e2ec2d5ce435e28da6c938736dcfa84d0da6

List of changes:

```
$ git shortlog DCMTK-3.6.5..patched-DCMTK-3.6.6_20210115 --no-merges
Jan Schlamelcher (4):
      Updated version information for 3.6.5+ development.
      Fixed various typos and whitespace errors.
      Allow overriding support library search behaviour.
      Harmonized documentation of calcElementLength().

Joerg Riesmeier (120):
      Fixed typos and other minor issues.
      Enhanced performance of inserting sequence items.
      Enhanced performance of getting a sequence item.
      Updated data dictionary for DICOM 2019d.
      Updated code definitions for DICOM 2019d.
      Updated Context Group classes for DICOM 2019d.
      Fixed possible issue with getFullOverlayData().
      Implemented support for CP-1893 (FT).
      Implemented support for CP-1913 (FT).
      Updated data dictionary for DICOM 2019e.
      Updated code definitions for DICOM 2019e.
      Updated Context Group classes for DICOM 2019e.
      Added new option --limit-output to findscu.
      Do not install "dummy" CHANGES file.
      Fixed warning reported by gcc (-Wsign-compare).
      Made sure appropriate data dictionary is used.
      Minor fixes to source code formatting.
      Increased buffer size for use of sprintf().
      Made sure appropriate data dictionary is used.
      Various fixes to formatting and documentation.
      Fixed inappropriate warning on invalid frame time.
      Added transfer syntax UIDs from Supplement 202.
      Added SOP class UIDs from Supplement 202.
      Introduced new internal VR "px" for pixel data.
      Made use of new internal VR "px" for pixel data.
      Updated data dictionary for DICOM 2020a.
      Updated code definitions for DICOM 2020a.
      Updated Context Group classes for DICOM 2020a.
      Output error reason to logger.
      Fixed issue with order of include directories.
      Added new well-known Frame of Reference UID.
      Added support for new Storage SOP Classes.
      Added new VRs UV, SV and OV to the documentation.
      Removed escaping of "\" in Doxygen documentation.
      Added option --socket-timeout to findscu.
      Fixed issues with previous commit.
      Added missing code to DICOM_WARNING_STATUS macro.
      Fixed definition of DICOM_PENDING_STATUS macro.
      Added macros for further DIMSE Status Classes.
      Added new file missing for previous commit.
      Fixed two typos in API documentation.
      Added missing VR "OL" to documentation.
      Added missing VRs "OL" and "OV" to documentation.
      Updated and revised DIMSE Status Code definitions.
      Fixed various issues with new TLS support.
      Added comment on "convert" parameter (Windows).
      Use DIMSE-C message specific status codes.
      Added new attributes to checkMetaHeaderValue().
      Added UID definition of UPS Query SOP Class.
      Added log output on data read from file.
      Fixed documentation on "bulk data" in manpage.
      Report an error if putElementContent() fails.
      Generalized support for Key Object Documents (KO).
      Added support for new SR IOD from Supplement 202.
      Fixed name of SOP classes from Supplement 202.
      Fixed issue with parsing invalid meta info.
      Clarified API documentation (in case of error).
      Added missing VRs to API documentation.
      Output error message on missing sequence element.
      Updated data dictionary for Supplement 199 + 217.
      Added support for new Storage SOP Classes.
      Reworked check on invalid Completion Flag (RDSR).
      Check for data dictionary when needed for a test.
      Fixed issue with attribute tag in JSON output.
      Updated data dictionary for DICOM 2020c.
      Updated code definitions for DICOM 2020c.
      Updated Context Group classes for DICOM 2020c.
      Updated mapping of Body Part Examined to codes.
      Minor fixes to manpage.
      Removed obsolete lines from code example.
      Fixed outdated reference to default option.
      Various fixes to API documentation.
      Fixed issue with invalid length of user item.
      Fixed wrong position of a remark.
      Enhanced support for OFpath filenames.
      Made use of OFswap() in class OFFilename.
      Added explicit typecast to keep VS 2019 quiet.
      Updated copyright date (where applicable).
      Removed superfluous code line.
      Added basic support for leap second.
      Output debug information when changing the VR.
      Fixed incorrect warning on wrong VR for pixel data
      Enhanced documentation of --recognize-aspect.
      Added "Software" field to created TIFF images.
      Enhanced documentation of --recognize-aspect.
      Removed superfluous call of empty() method.
      Updated reference to current standard edition.
      Added support for new Waveform Storage SOP Classes.
      Fixed wrong capitalization of the acronym "JSON".
      Added structure to documented "exit codes".
      Improved documentation of option --grayscale.
      Fixed duplicate value of an error code.
      Fixed wrong variable being read.
      Fixed wrong use of doxygen markup in manpage.
      Removed empty line.
      Added comments and check options in right order.
      Fixed line indentation.
      Extended range of application-specific errors.
      Updated latest tested CMake version.
      Added new well-known Frame of Reference UIDs.
      Added reference to further documentation (HTML).
      Updated data dictionary for DICOM 2020d.
      Updated code definitions for DICOM 2020d.
      Updated Context Group classes for DICOM 2020d.
      Increased buffer size for use of sprintf().
      Fixed typo introduced with previous commit.
      Replaced "http" by "https".
      Output debug message on UN conversion.
      Fixed issue with placeholders (--exec-on-eostudy).
      Renamed libcharls also for Autoconf build system.
      Updated latest tested CMake version.
      Remove unwanted files created by Doxygen.
      Removed superfluous code line.
      Updated data dictionary for DICOM 2020e.
      Updated code definitions for DICOM 2020e.
      Updated Context Group classes for DICOM 2020e.
      Added definition of new Storage SOP Class UID.
      Added missing DCMTK module "dcmect".
      Introduced local constant "lowvalue" for typecast.
      Fixed wrong calculation of sigmoid VOI function.

Marco Eichelberg (85):
      Forward trusted certificates to DcmTLSTransportLayer.
      Added initial support for ECDSA signatures.
      Fix verification of odd-length DSA/ECDSA signatures.
      Added support for SR RSA Digital Signature Profile.
      return non-zero when signature verification fails.
      Fixed DER sequence length computation.
      Revised signature verification code.
      Fixed memory leak in class SiCertificate.
      Implemented well-defined exit codes for dcmsign.
      Added status codes to ofexit.h
      Correctly print EC curve bits.
      Print warning to logger when encountering weak key.
      Fixed warnings reported by gcc -Wshadow.
      Print error message when signature is incomplete.
      Check if cert was valid during signature creation.
      Fixed bug affecting multiple nested signatures.
      Check unconditional attributes in signature profiles.
      Improved handling of CRLs and unsignable attributes.
      Improved timestamp verification code.
      Various improvements to dcmsign module.
      Major revision of dcmsign module.
      Compatibility fixes for OpenSSL 1.0.2 and MSVC.
      Fixed some minor warnings reported by VS2019.
      Compatibility fixes for OpenSSL 1.0.1.
      Added support for OpenSSL without Elliptic Curves.
      Fixed minor bug.
      Fixed bug in the parsing of UN VR sequences.
      Added --convert-un option to dcmsign.
      Increased buffer size to fix gcc 9.2 warning.
      Improved CMake options for the WIN32 build model.
      Fixed inconsistent forward declaration.
      Fixed previous commit, which was incomplete.
      DCMTK now compiles when UNICODE/_UNICODE is defined.
      Fixed compilation with LibreSSL on OpenBSD 6.6.
      Various fixes to the dcmqrscp.cfg parser.
      Fixed Derivation Code Sequence creation.
      Added TLS support to DcmSCP and DcmSCPPool.
      Added TLS support to dcmrecv.
      Fixed minor warnings.
      Replaced strncpy() with OFStandard::strlcpy().
      Cleanup of the TLS support for DcmSCP and DcmSCPPool.
      Fixed dcmtls unit tests.
      Fixed warnings on Sun Studio 12.6.
      Fixed memory leak in DcmFindSCU::performQuery().
      Fixed compiler warning in VS 2008/2010 build.
      Added text describing the maximum UID root length.
      Added alternative service provision API to DcmSCP.
      Removed JPEG-LS option for uninterleaved encoding.
      Documented ENABLE_EXTERNAL_DICTIONARY macro.
      Fixed segmentation fault in OFStandard::atof()
      Fixed HUGE_VAL constant used.
      Fixed comment.
      Changed declaration of tls_init_cleanup_func_type.
      Fixed bug in handling of pixel data representations.
      Fixed various issues in the Json output routines.
      Fixed Json control char escaping in PN VR.
      Various enhancements to dcm2json.
      Further improvements and fixes to dcm2json.
      Fix compilation on platforms where isinf is a macro.
      Minor fixes to dcm2json man page and help output.
      Fixed JSON InlineBinary pixel data encoding.
      Clean-up of dcmsign exit codes.
      Added new compile time macro DCMTK_UNDEF_SANIZITER.
      Fixed typo.
      Clean-up of dcmsign exit codes (cont'd).
      Fixed out-of-bound read in parseSCUSCPRole().
      Fixed use-after-free error in worklist SCP.
      Added quotes for two variables in DCMTKTargets.cmake.
      Fixed incorrect static cast.
      Disable Fiber Local Storage on MinGW.
      Fixed inconsistencies in man page and help text.
      Renamed libcharls to libdcmtkcharls.
      Updated DIMSE compatibility flag.
      First draft of ANNOUNCE file for DCMTK 3.6.6.
      Disabled atof unit test related to underflow.
      Declared finite state machine variables as volatile.
      Properly quote special characters in person names.
      Added typecast required due to commit #09e11a591.
      Fixed memory leak.
      Added typecast required due to commit #09e11a591.
      Fixed minor Sun Studio compiler warnings.
      Fixed bug in dcmscale.
      Fixed socket handling in dcmpsrcv.
      Fixed annotation layout.
      Minor bug fixes in dcmpsprt application.

Michael Onken (37):
      Clarified documentation for dcmodify.
      New module dcmect for working with Enhanced CT.
      Fixed nested angle brackets and other formatting.
      Fix recusion (call base class version instead).
      Fixed data types and compiler warnings.
      Use constants instead of magic numbers.
      Removed accidentially commited configure file.
      Fixed/completed doxygen documentation.
      Fixed compiler warning.
      Fixed more compiler warnings.
      Fix OFtuple-based compile error in VS 2008/2010.
      Fixed compiler warning (shadowed variable).
      Fixed compiler warnings (VS 2019).
      Added support for long code values (CP 1301).
      Minor formatting enhancements.
      Fixed tag type for long code value support.
      Enhanced source code formatting
      Use consistent C-FIND/GET/MOVE status codes.
      Updated autoconf dependencies.
      Renamed method for consistency.
      Force OFBool mapping to system bool type.
      Use typedef instead of #define for OFBool.
      Fixed typo in INSTALL file.
      Enhanced documentation.
      Export more build options to DCMTKConfig.cmake.
      Try to fix VS 2008/2010 build.
      Fixed bug that caused known private tag to be inserted with VR UN.
      Fixed doxygen and formatting.
      New default to always re-create meta header.
      Moved 2 options from processing to output section.
      Fixed access to Depths Of Scan Field attribute.
      Fixed optionality of Image Type atribute.
      Prepared source tree for DCMTK release 3.6.6.
      Updated ANNOUNCE for Release 3.6.6
      Final changes for Release 3.6.6.
      Updated release date in INSTALL file and for autoconf.
      [Backport] Fixed extra padding created for some segmentations.

Pedro ArizpeGomez (3):
      Line spacing minor changes.
      Added Encapsulated Document Length (CP 1851).
      Improved documentation of --key option.
```