### PR TITLE
ENH: Hide markups in slice views when they do not intersect the slice

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
@@ -106,6 +106,13 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() >= 2);
 
+  // Hide the line actor if it doesn't intersect the current slice
+  this->SliceDistance->Update();
+  if (!this->IsRepresentationIntersectingSlice(vtkPolyData::SafeDownCast(this->SliceDistance->GetOutput()), this->SliceDistance->GetScalarArrayName()))
+    {
+    this->LineActor->SetVisibility(false);
+    }
+
   bool allControlPointsSelected = this->GetAllControlPointsSelected();
   int controlPointType = Active;
   if (this->MarkupsDisplayNode->GetActiveComponentType() != vtkMRMLMarkupsDisplayNode::ComponentLine)

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.cxx
@@ -101,6 +101,13 @@ void vtkSlicerLineRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfDefinedControlPoints(true) == 2);
 
+  // Hide the line actor if it doesn't intersect the current slice
+  this->SliceDistance->Update();
+  if (!this->IsRepresentationIntersectingSlice(vtkPolyData::SafeDownCast(this->SliceDistance->GetOutput()), this->SliceDistance->GetScalarArrayName()))
+    {
+    this->LineActor->SetVisibility(false);
+    }
+
   if (markupsNode->GetNumberOfDefinedControlPoints(true) == 2)
     {
     double p1[3] = { 0.0 };

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
@@ -140,6 +140,9 @@ protected:
   void GetWorldToDisplayCoordinates(double r, double a, double s, double * displayCoordinates);
   void GetWorldToDisplayCoordinates(double * worldCoordinates, double * displayCoordinates);
 
+  /// Check if the representation polydata intersects the slice
+  bool IsRepresentationIntersectingSlice(vtkPolyData* representation, const char* arrayName);
+
   class ControlPointsPipeline2D : public ControlPointsPipeline
   {
   public:

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
@@ -179,24 +179,10 @@ void vtkSlicerPlaneRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   if (visible && !this->MarkupsDisplayNode->GetSliceProjection())
     {
     this->PlaneSliceDistance->Update();
-    vtkPolyData* plane = vtkPolyData::SafeDownCast(this->PlaneSliceDistance->GetOutput());
-    if (!plane)
+    if (!this->IsRepresentationIntersectingSlice(vtkPolyData::SafeDownCast(this->PlaneSliceDistance->GetOutput()),
+                                                 this->PlaneSliceDistance->GetScalarArrayName()))
       {
       visible = false;
-      }
-    else
-      {
-      double sliceNormal_XY[4] = { 0.0, 0.0, 1.0, 0.0 };
-      double sliceNormal_World[4] = { 0, 0, 1, 0 };
-      vtkMatrix4x4* xyToRAS = this->GetSliceNode()->GetXYToRAS();
-      xyToRAS->MultiplyPoint(sliceNormal_XY, sliceNormal_World);
-      double sliceThicknessMm = vtkMath::Norm(sliceNormal_World);
-      double* scalarRange = plane->GetScalarRange();
-      // If the closest point on the plane is further than a half-slice thickness, then hide the plane
-      if (scalarRange[0] > 0.5 * sliceThicknessMm || scalarRange[1] < -0.5 * sliceThicknessMm)
-        {
-        visible = false;
-        }
       }
     }
 


### PR DESCRIPTION
This commit hides the line actor if all of the points on the markup curve are outside of the slice by 0.5 * slice thickness.
Re #5480