### PR TITLE
COMP: Ensure all vtk python modules are fixed up on macOS

### DIFF
--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -175,7 +175,7 @@ function(fixup_bundle_with_plugins app)
   set(Slicer_VTK_VERSION_MAJOR "@Slicer_VTK_VERSION_MAJOR@")
   if(Slicer_USE_PYTHONQT AND ${Slicer_VTK_VERSION_MAJOR} VERSION_GREATER_EQUAL 9)
     list(APPEND candidates_pattern
-      "${app_dir}/Contents/bin/Python/vtkmodules/vtk*.so"
+      "${app_dir}/Contents/bin/Python/vtkmodules/*.so"
       )
   endif()
 

--- a/CMake/SlicerExtensionCPackBundleFixup.cmake.in
+++ b/CMake/SlicerExtensionCPackBundleFixup.cmake.in
@@ -316,7 +316,7 @@ function(fixup_slicer_extension)
 
   if(Slicer_USE_PYTHONQT AND ${Slicer_VTK_VERSION_MAJOR} VERSION_GREATER_EQUAL 9)
     list(APPEND candidates_pattern
-      "${ext_dir}/Contents/@Slicer_BUNDLE_EXTENSIONS_LOCATION@bin/Python/vtkmodules/vtk*.so"
+      "${ext_dir}/Contents/@Slicer_BUNDLE_EXTENSIONS_LOCATION@bin/Python/vtkmodules/*.so"
       )
   endif()
 


### PR DESCRIPTION
This commit ensures vtk modules that do not start with "vtk" prefix (e.g SplineDrivenImageSlicer)
are also fixed up.

It is a follow up of these commits:
* 08789e8: COMP: Fix packaging of VTK9 python modules
* d630005: COMP: Fix macOS package adding fixup rules for VTK9 python modules
* 0b15603: COMP: Fix macOS package setting "path" in VTK9 python modules fixup rules

Fixes #5285
Fixes #5521