### PR TITLE
ENH: Improve handling of internal transforms for ROI and plane markups

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -966,13 +966,13 @@ void vtkMRMLMarkupsNode::SetNthControlPointPositionOrientationWorldFromArray(
   int n = pointIndex;
   this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointModifiedEvent, static_cast<void*>(&n));
   if (oldPositionStatus != PositionDefined && positionStatus == PositionDefined)
-  {
+    {
     this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointPositionDefinedEvent, static_cast<void*>(&n));
-  }
+    }
   else if (oldPositionStatus == PositionDefined && positionStatus != PositionDefined)
-  {
+    {
     this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointPositionUndefinedEvent, static_cast<void*>(&n));
-  }
+    }
   this->StorableModifiedTime.Modified();
   if (!this->GetDisableModifiedEvent())
     {

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.h
@@ -54,6 +54,28 @@ public:
     ComponentROI_Last
   };
 
+  // Scale handle indexes
+  enum
+  {
+    HandleLFace,
+    HandleRFace,
+    HandlePFace,
+    HandleAFace,
+    HandleIFace,
+    HandleSFace,
+
+    HandleLPICorner,
+    HandleRPICorner,
+    HandleLAICorner,
+    HandleRAICorner,
+    HandleLPSCorner,
+    HandleRPSCorner,
+    HandleLASCorner,
+    HandleRASCorner,
+
+    HandleROI_Last
+  };
+
 protected:
   vtkMRMLMarkupsROIDisplayNode();
   ~vtkMRMLMarkupsROIDisplayNode() override;

--- a/Modules/Loadable/Markups/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Testing/Cxx/CMakeLists.txt
@@ -12,6 +12,7 @@ set(KIT_TEST_SRCS
   vtkMRMLMarkupsNodeTest2.cxx
   vtkMRMLMarkupsNodeTest3.cxx
   vtkMRMLMarkupsNodeTest4.cxx
+  vtkMRMLMarkupsNodeTest5.cxx
   vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
   vtkMRMLMarkupsFiducialStorageNodeTest3.cxx
   vtkMRMLMarkupsStorageNodeTest1.cxx
@@ -39,6 +40,7 @@ SIMPLE_TEST( vtkMRMLMarkupsNodeTest1 )
 SIMPLE_TEST( vtkMRMLMarkupsNodeTest2 )
 SIMPLE_TEST( vtkMRMLMarkupsNodeTest3 )
 SIMPLE_TEST( vtkMRMLMarkupsNodeTest4 )
+SIMPLE_TEST( vtkMRMLMarkupsNodeTest5 )
 
 # test legacy Slicer3 fcsv file
 SIMPLE_TEST( vtkMRMLMarkupsFiducialStorageNodeTest2 ${INPUT}/slicer3.fcsv )

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
@@ -90,13 +90,13 @@ int vtkMRMLMarkupsNodeTest4(int , char * [] )
 
   /////////////
   std::cout << "Test set axes/origin with plane offset" << std::endl;
-  vtkNew<vtkTransform> planeToPlaneOffset;
-  planeToPlaneOffset->Translate(1.0, 2.0, 3.0);
-  planeToPlaneOffset->RotateX(50.0);
-  planeToPlaneOffset->RotateY(12.0);
-  planeToPlaneOffset->RotateZ(5.0);
-  planeToPlaneOffset->Translate(5.0, 3.0, 10.0);
-  planeNode->GetPlaneToPlaneOffsetMatrix()->DeepCopy(planeToPlaneOffset->GetMatrix());
+  vtkNew<vtkTransform> objectToBase;
+  objectToBase->Translate(1.0, 2.0, 3.0);
+  objectToBase->RotateX(50.0);
+  objectToBase->RotateY(12.0);
+  objectToBase->RotateZ(5.0);
+  objectToBase->Translate(5.0, 3.0, 10.0);
+  planeNode->GetObjectToBaseMatrix()->DeepCopy(objectToBase->GetMatrix());
   planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
   planeNode->SetOriginWorld(origin_World);
   CHECK_BOOL(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON), true);

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest5.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest5.cxx
@@ -1,0 +1,291 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLBSplineTransformNode.h"
+#include "vtkMRMLCoreTestingMacros.h"
+#include "vtkMRMLLinearTransformNode.h"
+#include "vtkMRMLMarkupsROINode.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkImageData.h>
+#include <vtkIndent.h>
+#include <vtkMath.h>
+#include <vtkMatrix4x4.h>
+#include <vtkNew.h>
+#include <vtkOrientedBSplineTransform.h>
+#include <vtkPointData.h>
+#include <vtkRegularPolygonSource.h>
+#include <vtkTestingOutputWindow.h>
+#include <vtkTransform.h>
+
+// STL includes
+#include <sstream>
+
+static const double EPSILON = 1e-4;
+
+//----------------------------------------------------------------------------
+bool CompareROI(double xAxisExpected_World[3], double yAxisExpected_World[3], double zAxisExpected_World[3],
+  double originExpected_World[3], double sizeExpected_World[3], vtkMRMLMarkupsROINode* roiNode, double epsilon)
+{
+  double xAxisActual_World[3] = { 0.0, 0.0, 0.0 };
+  roiNode->GetXAxisWorld(xAxisActual_World);
+
+  double yAxisActual_World[3] = { 0.0, 0.0, 0.0 };
+  roiNode->GetYAxisWorld(yAxisActual_World);
+
+  double zAxisActual_World[3] = { 0.0, 0.0, 0.0 };
+  roiNode->GetZAxisWorld(zAxisActual_World);
+
+  if (vtkMath::Dot(xAxisExpected_World, xAxisActual_World) < 1.0 - epsilon)
+    {
+    std::cerr << "X-axis: expected: ["
+      << xAxisExpected_World[0] << ", "
+      << xAxisExpected_World[1] << ", "
+      << xAxisExpected_World[2] << ", "
+      << "] got: ["
+      << xAxisActual_World[0] << ", "
+      << xAxisActual_World[1] << ", "
+      << xAxisActual_World[2] << ", "
+      << "]" << std::endl;
+    return false;
+    }
+  if (vtkMath::Dot(yAxisExpected_World, yAxisActual_World) < 1.0 - epsilon)
+    {
+    std::cerr << "Y-axis: expected: ["
+      << yAxisExpected_World[0] << ", "
+      << yAxisExpected_World[1] << ", "
+      << yAxisExpected_World[2] << ", "
+      << "] got: ["
+      << yAxisActual_World[0] << ", "
+      << yAxisActual_World[1] << ", "
+      << yAxisActual_World[2] << ", "
+      << "]" << std::endl;
+    return false;
+    }
+  if (vtkMath::Dot(zAxisExpected_World, zAxisActual_World) < 1.0 - epsilon)
+    {
+    std::cerr << "Z-axis: expected: ["
+      << zAxisExpected_World[0] << ", "
+      << zAxisExpected_World[1] << ", "
+      << zAxisExpected_World[2]
+      << "] got: ["
+      << zAxisActual_World[0] << ", "
+      << zAxisActual_World[1] << ", "
+      << zAxisActual_World[2]
+      << "]" << std::endl;
+    return false;
+    }
+
+  double originActual_World[3] = { 0.0, 0.0, 0.0 };
+  roiNode->GetCenterWorld(originActual_World);
+
+  double originDifference_World[3] = { 0.0, 0.0, 0.0 };
+  vtkMath::Subtract(originExpected_World, originActual_World, originDifference_World);
+  if (vtkMath::Norm(originDifference_World) > epsilon)
+    {
+    std::cerr << "Center: expected: ["
+      << originExpected_World[0] << ", "
+      << originExpected_World[1] << ", "
+      << originExpected_World[2]
+      << "] got: ["
+      << originActual_World[0] << ", "
+      << originActual_World[1] << ", "
+      << originActual_World[2]
+      << "]" << std::endl;
+    return false;
+    }
+
+  double sizeActual_World[3] = { 0.0, 0.0, 0.0 };
+  roiNode->GetSizeWorld(sizeActual_World);
+
+  double sizeDifference_World[3] = { 0.0, 0.0, 0.0 };
+  vtkMath::Subtract(sizeExpected_World, sizeActual_World, sizeDifference_World);
+  if (std::abs(sizeDifference_World[0]) > EPSILON
+    || std::abs(sizeDifference_World[1]) > EPSILON
+    || std::abs(sizeDifference_World[2]) > EPSILON
+    )
+  {
+    std::cerr << "Size: expected: ["
+      << sizeExpected_World[0] << ", "
+      << sizeExpected_World[1] << ", "
+      << sizeExpected_World[2]
+      << "] got: ["
+      << sizeActual_World[0] << ", "
+      << sizeActual_World[1] << ", "
+      << sizeActual_World[2]
+      << "]" << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+double DisplacementScale = 0.63;
+
+//----------------------------------------------------------------------------
+void CreateBSplineVtk(vtkOrientedBSplineTransform* bsplineTransform,
+  double origin[3], double spacing[3], double direction[3][3], double dims[3],
+  const double bulkMatrix[3][3], const double bulkOffset[3])
+{
+  vtkNew<vtkImageData> bsplineCoefficients;
+  bsplineCoefficients->SetExtent(0, dims[0] - 1, 0, dims[1] - 1, 0, dims[2] - 1);
+  bsplineCoefficients->SetOrigin(origin);
+  bsplineCoefficients->SetSpacing(spacing);
+  bsplineCoefficients->AllocateScalars(VTK_DOUBLE, 3);
+  bsplineCoefficients->GetPointData()->GetScalars()->Fill(0);
+
+  vtkNew<vtkMatrix4x4> bulkTransform;
+  vtkNew<vtkMatrix4x4> gridOrientation;
+  for (int row = 0; row < 3; row++)
+    {
+    for (int col = 0; col < 3; col++)
+      {
+      bulkTransform->SetElement(row, col, bulkMatrix[row][col]);
+      gridOrientation->SetElement(row, col, direction[row][col]);
+      }
+    bulkTransform->SetElement(row, 3, bulkOffset[row]);
+    }
+
+  bsplineTransform->SetGridDirectionMatrix(gridOrientation.GetPointer());
+  bsplineTransform->SetCoefficientData(bsplineCoefficients.GetPointer());
+  bsplineTransform->SetBulkTransformMatrix(bulkTransform.GetPointer());
+
+  bsplineTransform->SetBorderModeToZero();
+  bsplineTransform->SetDisplacementScale(DisplacementScale);
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMarkupsNodeTest5(int , char * [])
+{
+  std::cout << "Testing vtkMRMLMarkupsROINode" << std::endl;
+  vtkNew<vtkMRMLScene> scene;
+
+  vtkNew<vtkMRMLMarkupsROINode> roiNode;
+  scene->AddNode(roiNode);
+
+  vtkNew<vtkTransform> roiToLocal;
+  roiToLocal->RotateX(55);
+  roiToLocal->RotateY(12);
+  roiToLocal->RotateZ(32);
+  roiToLocal->Translate(50, 150, 200);
+
+  double origin[3] = { 0.0, 0.0, 0.0 };
+  double xAxis[3] = { 1.0, 0.0, 0.0 };
+  double yAxis[3] = { 0.0, 1.0, 0.0 };
+  double zAxis[3] = { 0.0, 0.0, 1.0 };
+
+  double xAxis_Node[3] = { 1.0, 0.0, 0.0 };
+  double yAxis_Node[3] = { 0.0, 1.0, 0.0 };
+  double zAxis_Node[3] = { 0.0, 0.0, 1.0 };
+  double origin_Node[3] = { 0.0, 0.0, 0.0 };
+
+  double size_World[3] = { 5.0, 5.0, 5.0 };
+
+  roiToLocal->TransformVectorAtPoint(origin, xAxis, xAxis_Node);
+  roiToLocal->TransformVectorAtPoint(origin, yAxis, yAxis_Node);
+  roiToLocal->TransformVectorAtPoint(origin, zAxis, zAxis_Node);
+  roiToLocal->TransformPoint(origin, origin_Node);
+
+  /////////////
+  std::cout << "Test set axes/origin" << std::endl;
+  roiNode->GetObjectToNodeMatrix()->DeepCopy(roiToLocal->GetMatrix());
+  roiNode->SetSizeWorld(size_World);
+
+  CHECK_BOOL(CompareROI(xAxis_Node, yAxis_Node, zAxis_Node, origin_Node, size_World, roiNode, EPSILON), true);
+
+  ///////////////
+  std::cout << "Test set axes/origin and linear transform node" << std::endl;
+
+  vtkNew<vtkMRMLLinearTransformNode> transformNode;
+  scene->AddNode(transformNode);
+  roiNode->SetAndObserveTransformNodeID(transformNode->GetID());
+
+  vtkNew<vtkTransform> linearTransform;
+  linearTransform->Translate(30.0, 60.0, 90.0);
+  linearTransform->RotateZ(30.0);
+  linearTransform->RotateY(60.0);
+  linearTransform->RotateX(90.0);
+  linearTransform->Translate(90.0, 60.0, 30.0);
+  linearTransform->Scale(5.0, 12.0, 1.0);
+  transformNode->SetMatrixTransformToParent(linearTransform->GetMatrix());
+
+  double xAxis_World[3] = { 1.0, 0.0, 0.0 };
+  double yAxis_World[3] = { 0.0, 1.0, 0.0 };
+  double zAxis_World[3] = { 0.0, 0.0, 1.0 };
+  double origin_World[3] = { 0.0, 0.0, 0.0 };
+
+  vtkNew<vtkMatrix4x4> matrix;
+  vtkMRMLMarkupsROINode::GenerateOrthogonalMatrix(xAxis_Node, yAxis_Node, zAxis_Node, origin_Node, matrix, linearTransform);
+  for (int i = 0; i < 3; ++i)
+    {
+    xAxis_World[i] = matrix->GetElement(i, 0);
+    yAxis_World[i] = matrix->GetElement(i, 1);
+    zAxis_World[i] = matrix->GetElement(i, 2);
+    origin_World[i] = matrix->GetElement(i, 3);
+    }
+  roiNode->SetSizeWorld(size_World);
+
+  CHECK_BOOL(CompareROI(xAxis_World, yAxis_World, zAxis_World, origin_World, size_World, roiNode, EPSILON), true);
+
+  ///////////////
+  std::cout << "Test harden linear transform" << std::endl;
+  roiNode->HardenTransform();
+  CHECK_BOOL(CompareROI(xAxis_World, yAxis_World, zAxis_World, origin_World, size_World, roiNode, EPSILON), true);
+
+  ///////////////
+  std::cout << "Test b-spline transform" << std::endl;
+
+  vtkNew<vtkOrientedBSplineTransform> bSplineTransform;
+  double bSplineOrigin[3] = { -100, -100, -100 };
+  double bSplineSpacing[3] = { 100, 100, 100 };
+  double bSplineDirection[3][3] = { {0.92128500, -0.36017075, -0.146666625}, {0.31722386, 0.91417248, -0.25230478}, {0.22495105, 0.18591857, 0.95646814} };
+  double bSplineDims[3] = { 7,8,7 };
+  const double bSplineBulkMatrix[3][3] = { { 0.7, 0.2, 0.1 }, { 0.1, 0.8, 0.1 }, { 0.05, 0.2, 0.9 } };
+  const double bSplineBulkOffset[3] = { -5, 3, 6 };
+  CreateBSplineVtk(bSplineTransform, origin, bSplineSpacing, bSplineDirection, bSplineDims, bSplineBulkMatrix, bSplineBulkOffset);
+
+  vtkNew<vtkMRMLBSplineTransformNode> bSplineTransformNode;
+  scene->AddNode(bSplineTransformNode);
+  bSplineTransformNode->SetAndObserveTransformToParent(bSplineTransform);
+  roiNode->GetObjectToNodeMatrix()->Identity();
+  roiNode->SetCenter(0.0, 0.0, 0.0);
+  roiNode->SetAndObserveTransformNodeID(bSplineTransformNode->GetID());
+  roiNode->SetSizeWorld(size_World);
+
+  vtkMRMLMarkupsROINode::GenerateOrthogonalMatrix(xAxis, yAxis, zAxis, origin, matrix, bSplineTransform, false);
+  for (int i = 0; i < 3; ++i)
+    {
+    xAxis_World[i] = matrix->GetElement(i, 0);
+    yAxis_World[i] = matrix->GetElement(i, 1);
+    zAxis_World[i] = matrix->GetElement(i, 2);
+    origin_World[i] = matrix->GetElement(i, 3);
+    }
+
+  CHECK_BOOL(CompareROI(xAxis_World, yAxis_World, zAxis_World, origin_World, size_World, roiNode, EPSILON), true);
+
+  ///////////////
+  std::cout << "Test harden b-spline transform" << std::endl;
+  roiNode->HardenTransform();
+
+  CHECK_BOOL(CompareROI(xAxis_World, yAxis_World, zAxis_World, origin_World, size_World, roiNode, EPSILON), true);
+
+  std::cout << "Success." << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
@@ -33,6 +33,8 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation2D.h"
 
+#include "vtkLookupTable.h"
+
 class vtkArcSource;
 class vtkDiscretizableColorTransferFunction;
 class vtkSampleImplicitFunctionFilter;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -42,32 +42,32 @@
 #define vtkSlicerMarkupsRepresentation_h
 
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
-#include "vtkMRMLAbstractWidgetRepresentation.h"
 
+#include "vtkMRMLAbstractWidgetRepresentation.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkMRMLMarkupsNode.h"
 
+#include "vtkActor2D.h"
+#include "vtkAppendPolyData.h"
+#include "vtkArcSource.h"
+#include "vtkArrowSource.h"
+#include "vtkGlyph3D.h"
+#include "vtkLookupTable.h"
+#include "vtkMarkupsGlyphSource2D.h"
+#include "vtkPointPlacer.h"
+#include "vtkPointSetToLabelHierarchy.h"
+#include "vtkPolyDataMapper2D.h"
+#include "vtkProperty2D.h"
 #include "vtkSmartPointer.h"
+#include "vtkSphereSource.h"
+#include "vtkTextActor.h"
+#include "vtkTextProperty.h"
+#include "vtkTensorGlyph.h"
+#include "vtkTransform.h"
+#include "vtkTransformPolyDataFilter.h"
+#include "vtkTubeFilter.h"
 
-class vtkActor2D;
-class vtkAppendPolyData;
-class vtkArcSource;
-class vtkArrayCalculator;
-class vtkArrowSource;
-class vtkConeSource;
-class vtkGlyph3D;
-class vtkMarkupsGlyphSource2D;
 class vtkMRMLInteractionEventData;
-class vtkPointPlacer;
-class vtkPointSetToLabelHierarchy;
-class vtkPolyDataMapper2D;
-class vtkProperty2D;
-class vtkRegularPolygonSource;
-class vtkSphereSource;
-class vtkTextActor;
-class vtkTextProperty;
-class vtkTensorGlyph;
-class vtkTubeFilter;
 
 class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkSlicerMarkupsWidgetRepresentation : public vtkMRMLAbstractWidgetRepresentation
 {
@@ -185,7 +185,7 @@ protected:
     vtkSmartPointer<vtkTextProperty> TextProperty;
   };
 
-  class MarkupsInteractionPipeline
+  class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT MarkupsInteractionPipeline
   {
   public:
     MarkupsInteractionPipeline(vtkMRMLAbstractWidgetRepresentation* representation);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
@@ -233,23 +233,23 @@ bool vtkSlicerPlaneWidget::ProcessPlaneTranslate(vtkMRMLInteractionEventData* ev
 
   MRMLNodeModifyBlocker blocker(markupsNode);
 
-  vtkNew<vtkMatrix4x4> worldToPlaneMatrix;
-  markupsNode->GetPlaneToWorldMatrix(worldToPlaneMatrix);
-  worldToPlaneMatrix->Invert();
+  vtkNew<vtkMatrix4x4> worldToObjectMatrix;
+  markupsNode->GetObjectToWorldMatrix(worldToObjectMatrix);
+  worldToObjectMatrix->Invert();
 
-  vtkNew<vtkTransform> worldToPlaneTransform;
-  worldToPlaneTransform->PostMultiply();
-  worldToPlaneTransform->SetMatrix(worldToPlaneMatrix);
-  worldToPlaneTransform->Concatenate(markupsNode->GetPlaneToPlaneOffsetMatrix());
+  vtkNew<vtkTransform> worldToObjectTransform;
+  worldToObjectTransform->PostMultiply();
+  worldToObjectTransform->SetMatrix(worldToObjectMatrix);
+  worldToObjectTransform->Concatenate(markupsNode->GetObjectToBaseMatrix());
 
   double vector_Plane[3] = { 0.0 };
-  worldToPlaneTransform->TransformVector(vector_World, vector_Plane);
+  worldToObjectTransform->TransformVector(vector_World, vector_Plane);
 
-  vtkNew<vtkTransform> planeToPlaneOffsetTransform;
-  planeToPlaneOffsetTransform->PostMultiply();
-  planeToPlaneOffsetTransform->SetMatrix(markupsNode->GetPlaneToPlaneOffsetMatrix());
-  planeToPlaneOffsetTransform->Translate(vector_Plane);
-  markupsNode->GetPlaneToPlaneOffsetMatrix()->DeepCopy(planeToPlaneOffsetTransform->GetMatrix());
+  vtkNew<vtkTransform> objectToBaseTransform;
+  objectToBaseTransform->PostMultiply();
+  objectToBaseTransform->SetMatrix(markupsNode->GetObjectToBaseMatrix());
+  objectToBaseTransform->Translate(vector_Plane);
+  markupsNode->GetObjectToBaseMatrix()->DeepCopy(objectToBaseTransform->GetMatrix());
 
   markupsNode->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointModifiedEvent);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
@@ -599,9 +599,9 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
   else
     {
     // Face does not intersect with the slice. Handle should not be visibile.
-    visibilityArray->SetValue(vtkMRMLMarkupsROINode::HandleLFace, false);
+    visibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLFace, false);
     }
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleLFace, lFacePoint_ROI);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleLFace, lFacePoint_ROI);
 
   // Right face handle
   double rFacePoint_ROI[3] =  { sideLengths[0], -sideLengths[1], -sideLengths[2] };
@@ -618,9 +618,9 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
   else
     {
     // Face does not intersect with the slice. Handle should not be visibile.
-    visibilityArray->SetValue(vtkMRMLMarkupsROINode::HandleRFace, false);
+    visibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRFace, false);
     }
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleRFace, rFacePoint_ROI);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleRFace, rFacePoint_ROI);
 
   // Posterior face handle
   double pFacePoint_ROI[3] =  { -sideLengths[0], -sideLengths[1], -sideLengths[2] };
@@ -637,9 +637,9 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
   else
     {
     // Face does not intersect with the slice. Handle should not be visibile.
-    visibilityArray->SetValue(vtkMRMLMarkupsROINode::HandlePFace, false);
+    visibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandlePFace, false);
     }
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandlePFace, pFacePoint_ROI);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandlePFace, pFacePoint_ROI);
 
   // Anterior face handle
   double aFacePoint_ROI[3] =  { -sideLengths[0],  sideLengths[1], -sideLengths[2] };
@@ -656,9 +656,9 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
   else
     {
     // Face does not intersect with the slice. Handle should not be visibile.
-    visibilityArray->SetValue(vtkMRMLMarkupsROINode::HandleAFace, false);
+    visibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleAFace, false);
     }
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleAFace, aFacePoint_ROI);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleAFace, aFacePoint_ROI);
 
   // Inferior face handle
   double iFacePoint_ROI[3] =  { -sideLengths[0], -sideLengths[1], -sideLengths[2] };
@@ -675,9 +675,9 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
   else
     {
     // Face does not intersect with the slice. Handle should not be visibile.
-    visibilityArray->SetValue(vtkMRMLMarkupsROINode::HandleIFace, false);
+    visibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleIFace, false);
     }
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleIFace, iFacePoint_ROI);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleIFace, iFacePoint_ROI);
 
   // Superior face handle
   double sFacePoint_ROI[3] =  { -sideLengths[0], -sideLengths[1], sideLengths[2] };
@@ -694,9 +694,9 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
   else
     {
     // Face does not intersect with the slice. Handle should not be visibile.
-    visibilityArray->SetValue(vtkMRMLMarkupsROINode::HandleSFace, false);
+    visibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleSFace, false);
     }
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleSFace, sFacePoint_ROI);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleSFace, sFacePoint_ROI);
 
   this->ScaleHandlePoints->SetPoints(roiPoints);
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
@@ -130,7 +130,7 @@ void vtkSlicerROIRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned 
       return;
     }
 
-  this->ROIToWorldTransform->SetMatrix(roiNode->GetInteractionHandleToWorldMatrix());
+  this->ROIToWorldTransform->SetMatrix(roiNode->GetObjectToWorldMatrix());
 
   this->ROIActor->SetVisibility(true);
   this->VisibilityOn();
@@ -207,7 +207,7 @@ void vtkSlicerROIRepresentation3D::UpdateCubeSourceFromMRML(vtkMRMLMarkupsROINod
     }
 
   double sideLengths[3] = { 0.0, 0.0, 0.0 };
-  roiNode->GetSizeWorld(sideLengths);
+  roiNode->GetSize(sideLengths);
   cubeSource->SetXLength(sideLengths[0]);
   cubeSource->SetYLength(sideLengths[1]);
   cubeSource->SetZLength(sideLengths[2]);
@@ -403,8 +403,8 @@ void vtkSlicerROIRepresentation3D::CanInteractWithROI(
     displayPosition3[0] = static_cast<double>(displayPosition[0]);
     displayPosition3[1] = static_cast<double>(displayPosition[1]);
 
-    vtkNew<vtkTransform> roiToLocal;
-    roiToLocal->Concatenate(roiNode->GetROIToLocalMatrix());
+    vtkNew<vtkTransform> objectToNode;
+    objectToNode->Concatenate(roiNode->GetObjectToNodeMatrix());
 
     double distance2Display = VTK_DOUBLE_MAX;
 
@@ -419,7 +419,7 @@ void vtkSlicerROIRepresentation3D::CanInteractWithROI(
 
       double edgePoint0Display[3] = { 0.0, 0.0, 0.0 };
       line->GetPoints()->GetPoint(0, edgePoint0Display);
-      roiToLocal->TransformPoint(edgePoint0Display, edgePoint0Display);
+      objectToNode->TransformPoint(edgePoint0Display, edgePoint0Display);
       roiNode->TransformPointToWorld(edgePoint0Display, edgePoint0Display);
       this->Renderer->SetWorldPoint(edgePoint0Display);
       this->Renderer->WorldToDisplay();
@@ -428,7 +428,7 @@ void vtkSlicerROIRepresentation3D::CanInteractWithROI(
 
       double edgePoint1Display[3] = { 0.0, 0.0, 0.0 };
       line->GetPoints()->GetPoint(1, edgePoint1Display);
-      roiToLocal->TransformPoint(edgePoint1Display, edgePoint1Display);
+      objectToNode->TransformPoint(edgePoint1Display, edgePoint1Display);
       roiNode->TransformPointToWorld(edgePoint1Display, edgePoint1Display);
       this->Renderer->SetWorldPoint(edgePoint1Display);
       this->Renderer->WorldToDisplay();
@@ -591,39 +591,39 @@ vtkSlicerROIRepresentation3D::HandleInfoList vtkSlicerROIRepresentation3D::Marku
  vtkSlicerMarkupsWidgetRepresentation::HandleInfoList handleInfoList;
   for (int i = 0; i < this->RotationHandlePoints->GetNumberOfPoints(); ++i)
     {
-    double handlePositionLocal[3] = { 0.0, 0.0, 0.0 };
+    double handlePositionNode[3] = { 0.0, 0.0, 0.0 };
     double handlePositionWorld[3] = { 0.0, 0.0, 0.0 };
-    this->RotationHandlePoints->GetPoint(i, handlePositionLocal);
-    this->RotationScaleTransform->GetTransform()->TransformPoint(handlePositionLocal, handlePositionWorld);
+    this->RotationHandlePoints->GetPoint(i, handlePositionNode);
+    this->RotationScaleTransform->GetTransform()->TransformPoint(handlePositionNode, handlePositionWorld);
     this->HandleToWorldTransform->TransformPoint(handlePositionWorld, handlePositionWorld);
     double color[4] = { 0.0, 0.0, 0.0 };
     this->GetHandleColor(vtkMRMLMarkupsDisplayNode::ComponentRotationHandle, i, color);
-    HandleInfo info(i, vtkMRMLMarkupsDisplayNode::ComponentRotationHandle, handlePositionWorld, handlePositionLocal, color);
+    HandleInfo info(i, vtkMRMLMarkupsDisplayNode::ComponentRotationHandle, handlePositionWorld, handlePositionNode, color);
     handleInfoList.push_back(info);
     }
 
   for (int i = 0; i < this->TranslationHandlePoints->GetNumberOfPoints(); ++i)
     {
-    double handlePositionLocal[3] = { 0.0, 0.0, 0.0 };
+    double handlePositionNode[3] = { 0.0, 0.0, 0.0 };
     double handlePositionWorld[3] = { 0.0, 0.0, 0.0 };
-    this->TranslationHandlePoints->GetPoint(i, handlePositionLocal);
-    this->TranslationScaleTransform->GetTransform()->TransformPoint(handlePositionLocal, handlePositionWorld);
+    this->TranslationHandlePoints->GetPoint(i, handlePositionNode);
+    this->TranslationScaleTransform->GetTransform()->TransformPoint(handlePositionNode, handlePositionWorld);
     this->HandleToWorldTransform->TransformPoint(handlePositionWorld, handlePositionWorld);
     double color[4] = { 0 };
     this->GetHandleColor(vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle, i, color);
-    HandleInfo info(i, vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle, handlePositionWorld, handlePositionLocal, color);
+    HandleInfo info(i, vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle, handlePositionWorld, handlePositionNode, color);
     handleInfoList.push_back(info);
     }
 
   for (int i = 0; i < this->ScaleHandlePoints->GetNumberOfPoints(); ++i)
     {
-    double handlePositionLocal[3] = { 0.0, 0.0, 0.0 };
+    double handlePositionNode[3] = { 0.0, 0.0, 0.0 };
     double handlePositionWorld[3] = { 0.0, 0.0, 0.0 };
-    this->ScaleHandlePoints->GetPoint(i, handlePositionLocal);
-    this->HandleToWorldTransform->TransformPoint(handlePositionLocal, handlePositionWorld);
+    this->ScaleHandlePoints->GetPoint(i, handlePositionNode);
+    this->HandleToWorldTransform->TransformPoint(handlePositionNode, handlePositionWorld);
     double color[4] = { 0 };
     this->GetHandleColor(vtkMRMLMarkupsDisplayNode::ComponentScaleHandle, i, color);
-    HandleInfo info(i, vtkMRMLMarkupsDisplayNode::ComponentScaleHandle, handlePositionWorld, handlePositionLocal, color);
+    HandleInfo info(i, vtkMRMLMarkupsDisplayNode::ComponentScaleHandle, handlePositionWorld, handlePositionNode, color);
     handleInfoList.push_back(info);
     }
 
@@ -646,20 +646,20 @@ void vtkSlicerROIRepresentation3D::MarkupsInteractionPipelineROI::UpdateScaleHan
 
   vtkNew<vtkPoints> roiPoints;
   roiPoints->SetNumberOfPoints(14);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleLFace,     -sideLengths[0],             0.0,             0.0);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleRFace,      sideLengths[0],             0.0,             0.0);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandlePFace,      0.0,            -sideLengths[1],             0.0);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleAFace,      0.0,             sideLengths[1],             0.0);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleIFace,      0.0,                        0.0, -sideLengths[2]);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleSFace,      0.0,                        0.0,  sideLengths[2]);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleLPICorner, -sideLengths[0], -sideLengths[1], -sideLengths[2]);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleRPICorner, sideLengths[0],  -sideLengths[1], -sideLengths[2]);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleLAICorner, -sideLengths[0],  sideLengths[1], -sideLengths[2]);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleRAICorner, sideLengths[0],   sideLengths[1], -sideLengths[2]);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleLPSCorner, -sideLengths[0], -sideLengths[1],  sideLengths[2]);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleRPSCorner, sideLengths[0],  -sideLengths[1],  sideLengths[2]);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleLASCorner, -sideLengths[0],  sideLengths[1],  sideLengths[2]);
-  roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleRASCorner, sideLengths[0],   sideLengths[1],  sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleLFace,     -sideLengths[0],             0.0,             0.0);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleRFace,      sideLengths[0],             0.0,             0.0);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandlePFace,      0.0,            -sideLengths[1],             0.0);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleAFace,      0.0,             sideLengths[1],             0.0);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleIFace,      0.0,                        0.0, -sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleSFace,      0.0,                        0.0,  sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleLPICorner, -sideLengths[0], -sideLengths[1], -sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleRPICorner, sideLengths[0],  -sideLengths[1], -sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleLAICorner, -sideLengths[0],  sideLengths[1], -sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleRAICorner, sideLengths[0],   sideLengths[1], -sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleLPSCorner, -sideLengths[0], -sideLengths[1],  sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleRPSCorner, sideLengths[0],  -sideLengths[1],  sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleLASCorner, -sideLengths[0],  sideLengths[1],  sideLengths[2]);
+  roiPoints->SetPoint(vtkMRMLMarkupsROIDisplayNode::HandleRASCorner, sideLengths[0],   sideLengths[1],  sideLengths[2]);
   this->ScaleHandlePoints->SetPoints(roiPoints);
 
   vtkIdTypeArray* visibilityArray = vtkIdTypeArray::SafeDownCast(this->ScaleHandlePoints->GetPointData()->GetArray("visibility"));
@@ -718,60 +718,60 @@ void vtkSlicerROIRepresentation3D::MarkupsInteractionPipelineROI::GetInteraction
     {
     switch (index)
       {
-      case vtkMRMLMarkupsROINode::HandleLFace:
+      case vtkMRMLMarkupsROIDisplayNode::HandleLFace:
         axisWorld[0] = -1.0;
         break;
-      case  vtkMRMLMarkupsROINode::HandleRFace:
+      case  vtkMRMLMarkupsROIDisplayNode::HandleRFace:
         axisWorld[0] = 1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandlePFace:
+      case vtkMRMLMarkupsROIDisplayNode::HandlePFace:
         axisWorld[1] = -1.0;
         break;
-      case  vtkMRMLMarkupsROINode::HandleAFace:
+      case  vtkMRMLMarkupsROIDisplayNode::HandleAFace:
         axisWorld[1] = 1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandleIFace:
+      case vtkMRMLMarkupsROIDisplayNode::HandleIFace:
         axisWorld[2] = -1.0;
         break;
-      case  vtkMRMLMarkupsROINode::HandleSFace:
+      case  vtkMRMLMarkupsROIDisplayNode::HandleSFace:
         axisWorld[2] = 1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandleLPICorner:
+      case vtkMRMLMarkupsROIDisplayNode::HandleLPICorner:
         axisWorld[0] = -1.0;
         axisWorld[1] = -1.0;
         axisWorld[2] = -1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandleRPICorner:
+      case vtkMRMLMarkupsROIDisplayNode::HandleRPICorner:
           axisWorld[0] = 1.0;
           axisWorld[1] = -1.0;
           axisWorld[2] = -1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandleLAICorner:
+      case vtkMRMLMarkupsROIDisplayNode::HandleLAICorner:
         axisWorld[0] = -1.0;
         axisWorld[1] = 1.0;
         axisWorld[2] = -1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandleRAICorner:
+      case vtkMRMLMarkupsROIDisplayNode::HandleRAICorner:
         axisWorld[0] = 1.0;
         axisWorld[1] = 1.0;
         axisWorld[2] = -1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandleLPSCorner:
+      case vtkMRMLMarkupsROIDisplayNode::HandleLPSCorner:
         axisWorld[0] = -1.0;
         axisWorld[1] = -1.0;
         axisWorld[2] = 1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandleRPSCorner:
+      case vtkMRMLMarkupsROIDisplayNode::HandleRPSCorner:
         axisWorld[0] = 1.0;
         axisWorld[1] = -1.0;
         axisWorld[2] = 1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandleLASCorner:
+      case vtkMRMLMarkupsROIDisplayNode::HandleLASCorner:
         axisWorld[0] = -1.0;
         axisWorld[1] = 1.0;
         axisWorld[2] = 1.0;
         break;
-      case vtkMRMLMarkupsROINode::HandleRASCorner:
+      case vtkMRMLMarkupsROIDisplayNode::HandleRASCorner:
         axisWorld[0] = 1.0;
         axisWorld[1] = 1.0;
         axisWorld[2] = 1.0;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
@@ -126,7 +126,7 @@ protected:
   vtkSmartPointer<vtkProperty>                   ROIOutlineOccludedProperty;
   vtkSmartPointer<vtkActor>                      ROIOutlineOccludedActor;
 
-  class MarkupsInteractionPipelineROI : public MarkupsInteractionPipeline
+  class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT MarkupsInteractionPipelineROI : public MarkupsInteractionPipeline
   {
   public:
     MarkupsInteractionPipelineROI(vtkSlicerMarkupsWidgetRepresentation* representation);

--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -826,7 +826,7 @@ void vtkSlicerVolumeRenderingLogic::FitROIToVolume(vtkMRMLVolumeRenderingDisplay
       xyz[i] *= 0.5;
       }
 
-    markupsROINode->GetROIToLocalMatrix()->Identity();
+    markupsROINode->GetObjectToNodeMatrix()->Identity();
     markupsROINode->SetXYZ(center);
     markupsROINode->SetRadiusXYZ(xyz);
     }

--- a/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
+++ b/Modules/Loadable/VolumeRendering/MRMLDM/vtkMRMLVolumeRenderingDisplayableManager.cxx
@@ -1034,11 +1034,8 @@ void vtkMRMLVolumeRenderingDisplayableManager::vtkInternal::UpdatePipelineROIs(
     }
   else if (markupsROINode)
     {
-    // Make sure the ROI node's inside out flag is on
-    markupsROINode->InsideOutOn();
-
     // Calculate and set clipping planes
-    markupsROINode->GetTransformedPlanes(planes.GetPointer());
+    markupsROINode->GetTransformedPlanes(planes.GetPointer(), true);
     }
   volumeMapper->SetClippingPlanes(planes.GetPointer());
 }


### PR DESCRIPTION
List of changes:
- Renamed "ROI"/"Plane" space to "Object".
- Renamed "Local" space to "Node".
- Improved handling of ROI ObjectToWorld matrix.
  - ObjectToWorld is a matrix generated from ObjectToNode and NodeToWorld transforms that will always represent the transform from the axis-aligned "Object" space, to world space, ensuring that the ROI axes remain orthogonal.
- Moved scale handle indices from vtkMRMLMarkupsROINode to vtkMRMLMarkupsROIDisplayNode.
- Add DLL export to interaction handle pipelines so that they can be inherited by subclasses in other extensions.
- Add vtkMRMLMarkupsROINode::IsPointInROI() and IsPointInROIWorld() functions.
- Added vtkMRMLMarkupsNodeTest5 to test ROI functions, applying transforms, and transform hardening.