### PR TITLE
BUG: Fix import of python modules on Linux selectively stripping libraries

### DIFF
--- a/CMake/SlicerBlockInstallPython.cmake
+++ b/CMake/SlicerBlockInstallPython.cmake
@@ -44,8 +44,12 @@ To create a Slicer package including python libraries, you can *NOT* provide you
     REGEX "/test/" EXCLUDE
     ${extra_exclude_pattern}
     )
+  # Strip symbols of selected libraries for which ones (1) stripping has a
+  # significant impact and (2) stripping does not prevent the import of
+  # of the module.
+  # See https://github.com/Slicer/Slicer/issues/5474
   slicerStripInstalledLibrary(
-    PATTERN "${Slicer_INSTALL_ROOT}lib/Python/${PYTHON_STDLIB_SUBDIR}/*.so"
+    PATTERN "${Slicer_INSTALL_ROOT}lib/Python/${PYTHON_STDLIB_SUBDIR}/_SimpleITK.*.so"
     COMPONENT Runtime
     )
 


### PR DESCRIPTION
This commit fixes "ELF load command address/offset not properly aligned" runtime
error reported when attempting to import some python modules.

Instead of systematically stripping all libraries, this commit updates the
packaging rules Strip symbols of selected libraries for which ones
(1) stripping has a significant impact
and (2)  stripping does not prevent the successful import of the module.

Example of error reported:

```
  $ ./bin/PythonSlicer -c "from scipy.special import _ufuncs as u; from pprint import pprint as pp; pp(dir(u))"
  [...]
  ELF load command address/offset not properly aligned
```

Fixes #5474