### PR TITLE
COMP: Update ITK to post-v5.2rc03 with matching SimpleITK and BRAINSTools

### DIFF
--- a/Libs/vtkITK/vtkITKDistanceTransform.cxx
+++ b/Libs/vtkITK/vtkITKDistanceTransform.cxx
@@ -31,8 +31,8 @@ vtkITKDistanceTransform::~vtkITKDistanceTransform() = default;
 
 template <class T>
 void vtkITKDistanceTransformExecute(vtkITKDistanceTransform *self, vtkImageData* input,
-                vtkImageData* vtkNotUsed(output),
-                T* inPtr, T* outPtr)
+                vtkImageData* output,
+                T* inPtr, T* vtkNotUsed(outPtr))
 {
 
   int dims[3];
@@ -60,7 +60,7 @@ void vtkITKDistanceTransformExecute(vtkITKDistanceTransform *self, vtkImageData*
 
 
   // Calculate the distance transform
-  typedef itk::Image<T,3> DistanceImageType;
+  typedef itk::Image<float,3> DistanceImageType;
   typedef itk::SignedMaurerDistanceMapImageFilter<ImageType, DistanceImageType> DistanceType;
   typename DistanceType::Pointer dist = DistanceType::New();
 
@@ -73,7 +73,9 @@ void vtkITKDistanceTransformExecute(vtkITKDistanceTransform *self, vtkImageData*
   dist->Update();
 
   // Copy to the output
-  memcpy(outPtr, dist->GetOutput()->GetBufferPointer(),
+  output->AllocateScalars(VTK_FLOAT, 1);  // in case the image being worked on is not float type
+  void * oPtr = output->GetScalarPointer();
+  memcpy(oPtr, dist->GetOutput()->GetBufferPointer(),
          dist->GetOutput()->GetBufferedRegion().GetNumberOfPixels() * sizeof(T));
 
 }

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -313,8 +313,8 @@ set(BRAINSTools_slicer_options
 
 
 Slicer_Remote_Add(BRAINSTools
-  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/Slicer/BRAINSTools.git
-  GIT_TAG de71a695f605c7f17c52a168b35dce0231b62dd7 # slicer-2020-04-14-v5.2.0
+  GIT_REPOSITORY ${EP_GIT_PROTOCOL}://github.com/BRAINSia/BRAINSTools.git
+  GIT_TAG "590c371cecfc9e6f4dfed6dcc6416f67bccdaaf6"  # March 8th 2021
   LICENSE_FILES "http://www.apache.org/licenses/LICENSE-2.0.txt"
   OPTION_NAME Slicer_BUILD_BRAINSTOOLS
   OPTION_DEPENDS "Slicer_BUILD_CLI_SUPPORT;Slicer_BUILD_CLI"

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v5.1.2"
+    "2b34388159c20c0a6334d9b174fc6c230853988c"  # March 12th 2021
     QUIET
     )
 

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -122,7 +122,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v2.0.2"
+    "460f9c1553621b649f376bb1c07c94d4bdf6f055"  # March 2nd 2021
     QUIET
     )
 


### PR DESCRIPTION
This PR updates ITK to recent latest in preparation for ITK v5.2.0 release. This includes https://github.com/InsightSoftwareConsortium/ITK/commit/7cebc26dfae73d90dbf4702aa1ccc544e9b70a37 which helped solve an ITK build error that was happening when I was building latest Slicer using Visual Studio 16.9 (recently released).

Slicer vtkITKDistanceTransform.cxx updates were made based on changes introduced in https://github.com/InsightSoftwareConsortium/ITK/commit/076e990904fea748c4f139d1bb69c45ec6669220. Thanks to @dzenanz for helping out on these fixes.

All tests were run on Windows with only 1 test failing which appears to have already been failing on the Windows platform.
```
1>
1>99% tests passed, 1 tests failed out of 680
..
1>The following tests FAILED:
1>	318 - py_SubjectHierarchyGenericSelfTest (Failed)
```

Below is the included log of changes for the various projects which are also included in the commit message body.
```
SHA-1: ce18902c6776f303edcfd34e3931bc8fe347f07b

* COMP: Update ITK to post-v5.2rc03 with matching SimpleITK and BRAINSTools

Slicer updates were made based on changes introduced in https://github.com/InsightSoftwareConsortium/ITK/commit/076e990904fea748c4f139d1bb69c45ec6669220

=====================================================================
ITK:
$ git shortlog --topo-order --no-merges v5.1.2..2b34388
Alex Domingo (1):
      BUG: fix python module definition in VtkGlue wrap

Alexander Burchardt (1):
      DOC: fixes itkSoftwareGuide # 146

Andreas Huber (1):
      BUG: Fix number encoding to use C locale (# 2297)

Antoine Robert (1):
      ENH: Use Numpy bridge with array of dimension 1

Atri Bhattacharya (2):
      Explicit libm linking for NrrdIO and libLBFGS.
      BUG: Use explicit libm linking only on UNIX.

Baptiste Depalle (1):
      ENH: improve wrapping architecture

Bernhard M. Wiedemann (1):
      BUG: Fix issue # 1939: Use -mtune=generic

Brad King (3):
      STYLE: Allow specific HDF5 sources to be larger than normal limit
      ENH: Update to newer third-party update script from CMake
      ENH: Convert VNL import script to use update-third-party.bash

Brad T. Moore (3):
      BUG: WatershedImageFilter would crash with assert.
      BUG: Fix to ITKSetPython3Vars ignoring Python virtual environments (# 2068).
      BUG: Add '_d' POSTFIX to Windows Python Debug (# 2050)

Bradley Lowekamp (34):
      ENH: Use named pipeline inputs for morphological reconstruction
      COMP: Add missing const qualifier
      BUG: Add StatisticsImageFilter::SetNumberOfStreamDivisions Python
      STYLE: remove extraneous semi-colon after bracket
      ENH: Add FunctionCommand with lambda support
      ENH: Add direct support for lambda command to Object class
      DOC: Update Object::AddObserver documentation
      COMP: Fix ~FunctionCommand implicit override warning
      COMP: Address no override keyword warning
      STYLE: Use defaulted constructor for event object macro
      BUG: Remove no output warning in ImageSink filters
      ENH: Bump SimpleITKFilters remote module
      ENH: PasteImageFilter input ND and constant value
      COMP: Update SimpleITKFilters remote module
      ENH: Add TernaryGeneratorImageFilter
      ENH: Change TernaryFunctor usage to TernaryGenerator
      ENH: Add GTest cases for TernaryGeneratorImageFilter
      DOC: Grammar fixes
      ENH: Update ternary filter wrapping for generator base class
      COMP: add missing parentheses
      COMP: Address unused other parameter in defaulted methods
      ENH: Moderinize ShiftScaleImageFilter
      ENH: remove redundant WriteImage overloads
      COMP: Address brace initializer warning
      BUG: Make OutputWindow instance a global singleton
      STYLE: Prefer function of direct access of output instance.
      ENH: Update ternary filter wrapping for generator base class
      BUG: Fix JPEG200Test6 file output clobbering
      ENH: Create ITK_DEFAULT_THREADER definition
      ENH: Add ITK_DEFAULT_THREADER as CMake configuration variable.
      COMP: Address gcc 4.8 compilation errors
      PERF: Replace thread index array with thread local storage
      BUG: Use graft of input to mini-pipeline
      ENH: Use dynamic threading model

Bryn Lloyd (1):
      COMP: Fix warning in PointSetToPointSetMetricv4 (# 1820)

Charles Garraud (1):
      BUG: Fix BUILD_SHARED_LIBS state consistency for HDF5

Christina Rossmanith (5):
      STYLE: Remove blank before ::MemberName
      STYLE: Edited comments
      STYLE: New methods for translating Nifti datatypes to IOxxxxEnum
      BUG: read data arrays with intent NIFTI_INTENT_NONE for point or cell data
      STYLE: RGB comment

Darren Thompson (1):
      ENH: Added itkPointSetToImageFilter.wrap

David Thompson (1):
      ENH: Let gitlab-ci runners build with clang-tidy.

Davis Vigneault (10):
      STYLE: Prefer Early Return
      ENH: Add Python Wrappers for Mesh Source Classes
      ENH: Review Cuberille Remote Module Compliance
      ENH: Assert in Debug Mode
      COMP: Address Wdeprecated-copy warnings in gcc9
      STYLE: Call Superclass assignment operator
      ENH: Test Assignment and Copy of Spatial Objects
      COMP: Address Warnings in Vector and Map Container
      ENH: Test Map and Vector Iterators
      ENH: Add Missing Boolean Macros in QEFilters

Dženan Zukić (34):
      ENH: updating remote modules to latest versions
      COMP: fix GPU compile errors when building as DLLs
      BUG: fix Statistics::Histogram::Mean calculation
      ENH: update remote modules
      DOC: restore LICENSE accidentally overwritten by a merge commit
      STYLE: rename libPNG's license to match the original one
      STYLE: remove duplicate item in a list
      ENH: progress reporting does not stall with PoolMultiThreader
      COMP: variable is uninitialized when passed as a const reference
      ENH: append properties instead of overwrite in HDF5
      BUG: Filter inputs are erroneously released
      ENH: allow dependencies on remote modules
      DOC: add ComputeJacobianWithRespectToPosition change to migration guide
      DOC: hyperlink mentioned commits
      ENH: remove NumPy presence conditions from tests' CMakeLists.txt
      COMP: fix compilation with Python and tests enabled on Visual Studio
      ENH: add a convenience function WriteImage
      ENH: update remote modules
      COMP: externally built remote module libs went in /lib or C:/lib
      ENH: Python wrapping fixes
      ENH: updating remote modules using the script
      ENH: supporting multi-channel tensors as inputs and outputs in Python
      ENH: use master branch of GoogleTest until a stable version is released
      ENH: manually update minimum CMake version to 2.8.12 to avoid warning
      Revert "ENH: manually update minimum CMake version to 2.8.12 to avoid warning"
      Revert "ENH: use master branch of GoogleTest until a stable version is released"
      Revert "Merge branch 'upstream-googletest' into updateGTest"
      COMP: fix rename error from re-basing parallel branches
      ENH: make shared variables local to facilitate code reuse/parallelism
      ENH: reduce duplication in ContourExtractor2DImageFilter
      STYLE: review suggestions
      PERF: using constant boundary condition instead of filling the edge
      DOC: fix AtomicInt and MutexLock broken links in migration guide
      ENH: update remote modules using the script

Eigen Upstream (1):
      Eigen3 2020-12-08 (b51eab5c)

GCC-XML Upstream (1):
      ENH: pygccxml v2.0.1 (reduced)

GDCM Upstream (2):
      GDCM 2020-06-30 (c0824c0a)
      GDCM 2020-12-10 (b380cbac)

GoogleTest Upstream (1):
      GoogleTest 2021-02-05 (f3ef7e17)

Gregory Lee (1):
      DOC: update references for recursive Gaussian filters

HDF5 Maintainers (1):
      HDF5 2019-12-24 (5b9cf732)

Hans J. Johnson (3):
      ENH: Prefer to use sform over qform when both are set
      VNL 2020-07-07 (4a5f1059) (# 1916)
      ENH: Exercise converting Object::Pointer to Object::ConstPointer

Hans Johnson (164):
      BUG: Double scaling introduced in refactoring
      ENH: Add test to monitor metric result value
      COMP: Missing defition of ITK_DISALLOW_COPY_AND_ASSIGN
      COMP: Resolve multi-line comment warning
      ENH: New test data for nifti qform/sform
      ENH: Add nifti sform read/write testing
      ENH: Do not pollute the global link_directories namespace
      BUG: Incomplete removal of ITK_INSTALL_NO_* variables
      COMP: Refine order of searching for header files
      BUG: itkhdf5 installed paths were incorrect with recent hdf5 versions
      ENH: Update building internal FFTW version
      BUG: Centos internal lib64 lib path
      BUG: Fix fftw linkage issue with system fftw
      STYLE: Use black formatting for python
      COMP: Ensure consistent ordering of list printed
      COMP: Local variable 's' might be referenced before assignment
      STYLE: Prefer fstrings for python 3.6+
      BUG: snake case functions are erased
      STYLE:  Missed conversions for new macro name
      BUG: Writing snake_files should not be appended
      BUG: Decoupled config files should not depend
      STYLE: Use consistent formatting for python files
      ENH: Move cmake config items into common itkConfig.py.in file
      ENH: Remove alias to 'object' variable name
      ENH: Extend dictionary with `update` not `add`
      ENH: Avoid bugs with mutable default arguments
      ENH: Use targeted import for element of sys
      COMP: Ambiguous 'range' function made explicit
      STYLE: Fix comment spelling errors.
      COMP: Avoid outscope variable shadowing
      COMP: Selective import of required components
      COMP: Avoid possible variable use before assignment.
      COMP: Remove redundant import.
      ENH: import modules at top of file
      COMP: Remove unneccessary HAVE_NUMPY conditionals
      STYLE: Apply consistent pep8 compatible indentation.
      COMP: Avoid reassigning parameters
      COMP: Too broad exception narrowed.
      STYLE: Prefer to use @staticmethod decorator.
      STYLE: Initial typehints added.
      ENH: Avoid poluting the global namespace
      STYLE: Avoid difficult to read anit-pattern
      STYLE: Remove python2 dictionary facade
      COMP: PEP 8: E722 do not use bare 'except'
      COMP: Address protected member warning
      COMP: Shadows name 'input_type','keys' from outer scope
      DOC: Spelling warnings removed.
      STYLE: Fix name and spelling issues
      COMP: Remove python2 dictionary compatibilties.
      COMP: Too broad exception clause fixed
      COMP: Method 'Stop' may be 'static'
      ENH: Remove unused variable warnings.
      STYLE: Applied recommend code refactorings
      COMP: Remove potential referenced before assignment
      COMP: Remove shadows name from outer scope.
      DOC: Improve variable name spelling
      COMP: Instance attributes should be defined in __init__
      COMP: Remove shadow variable outer scope warnings.
      COMP: Remove difficult to debug use of global variable
      COMP: Avoid poluting the module namespace
      COMP: Remove unused local variables.
      STYLE: Use python preferred lower-snake-case variable names
      ENH: Prevent contaminating global namespace
      COMP: Keep local functions out of global namespace
      COMP: Use lowercase python compatible function name.
      COMP: Match variable names from itkBase.
      STYLE: pytype warning disabled.
      ENH: disable a false positive naming error from pytype.
      STYLE: Address shadow variable and python style issues
      COMP: Unresolved reference 'sqrt'
      STYLE: Remove pass through return of read-only values.
      ENH: Code review and simplified logic
      STYLE: Encapsulate initialization for keeping namespace clean.
      COMP: Simplify exposing elements from itk namespace.
      ENH: Remove circular module dependancy
      STYLE: Prefer to extend existing template
      ENH: Explicitly test the itkConfig.LazyLoad=False option
      ENH: Allow setting default behaviors with environment
      COMP: Allow type inference tracking with dynamic loading.
      ENH: Only copy __path__ __spec__ when needed
      STYLE: Reduce aliased object naming
      STYLE: Localize imports to minimum scope.
      BUG: Pickling of itk module was broken
      STYLE: Update to python3 compatible syntax.
      STYLE: Update python Test with `black` formatting
      DOC: Make variable name clarifications and type designations
      STYLE: Remove unused macro.
      COMP: Fix test for remote python module
      BUG: Must append the list itkConfig.path
      ENH: Avoid adding invalid path to the sys.path
      ENH: Add error checking for required paths
      STYLE: Prefer explicit check to nested try/catch
      COMP: Enforce name.strip() redundantly
      COMP: Provide full path to test script file
      STYLE: Only set paths necessary for current build
      STYLE: Fix spelling error interperter -> interpreter
      STYLE: Make self-contained module.
      ENH: Update minimum required version of ITK
      BUG: WRAPPER_LIBRARY_OUTPUT_DIR is needed before macro call
      STYLE: Prefer explicit in-package pathing
      STYLE: Improve relative pathing computations
      STYLE: Prefer explicit full module specification for __spec__
      ENH: Use more standard symbol lifting into itk namespace
      COMP: Prefer static member function modify static instance vars
      STYLE: Remove duplicated content that was immediately overwritten
      STYLE: Update python Test with `black` formatting
      STYLE: Simplify writing template python code files
      COMP: Place python shared libs as subpackage of itk
      COMP: Unconditionally set wrapped shared lib directory
      ENH: Separate static components into base class
      DOC: Add autodoc request in swig .i files
      COMP: Add initial typing for itkExtras
      ENH: Adding function to help generate __init__.pyi
      STYLE: Use consistent formatting for python files
      BUG: Convert code to python3 compatible
      STYLE: Prefer fstrings for python 3.6+
      BUG: Avoid itkConfig double import trap
      STYLE: Minimize cmake configured python files
      BUG: Limit ignore to build directories only
      COMP: Mypy signature mismatch fixed
      COMP: Adding typing for ITK manually.
      STYLE: Add typehints for the itkTypes
      STYLE: Prefer fstrings for readability.
      COMP: Add typehinting for support classes
      ENH: Exclude cvar from the testing.
      STYLE:  Update processing of *Config.py files
      ENH: Update documentation for generation of itkTemplates.
      DOC: Make swig object registry more transparent
      STYLE: Re-enforce black formatting contraints
      STYLE: Remove duplicate module dependancy entries
      BUG: Explicit use of builtin set
      BUG: Add test exposing multiprocessing LazyLoad failure
      BUG: LazyLoading must be threadsafe
      ENH: Update to SWIG 4.0.2
      ENH: Add swig doxygen and autodoc=2 formats
      BUG: Incorrect loop dimensions in untested code
      BUG: Do not wrap invalid template parameters
      COMP: Fix hidden overloaded-virtual warning
      ENH: Ignore huge file warning for HDF5 paths
      ENH: Remove python interface introspection
      ENH: Simplified multi-config generator wrapping
      ENH: HDF5 upstream now hosted on github Version 1.10.6
      ENH: More closely match the 1.10.6 release hdf5
      COMP: Avoid compiler warnings with IPO
      BUG: CASTXML fails with aggressive optimizer flags
      BUG: Missing output dependency shared/H5init.c
      BUG: New test for 3D support
      BUG: ASAN identified use after delete bug
      STYLE: Fix clang-format styling require macro ';' end
      COMP: Work around ghostflow-check-master warnings
      COMP: Set vxl minimum to 3.0.0
      STYLE: Macros should respect an end-of line ;
      COMP: Use of uninitialzed variable warning
      ENH: Script for updating DoubleConversion library.
      ENH: Update Double-convert third-party
      ENH: Update remote modules to master branch
      COMP: Use ITK_MACROEND_NOOP_STATEMENT for GPU macro ending.
      STYLE: Make prototype match definition names
      STYLE: Throw expression should throw anonymous temporary values instead
      STYLE: Remove deprecated orientation enumeration codes
      COMP: Preserve const qualifier for variable
      ENH: Provide better failure diagnostics
      STYLE: Use default member initialization
      COMP: Prefer const pointer when value does not change

Horea Christian (1):
      ENH: improved support for offline build

James Butler (1):
      COMP: Fix OpenJPEG build error with Visual Studio 16.9

Jan Margeta (1):
      ENH: Support for non-compliant DICOM in itk-js

Jon Haitz Legarreta Gorroño (78):
      STYLE: Transition `Testing/Data` `README` to Markdown
      DOC: Add NumFOCUS-related contents to README
      ENH: Update remote modules
      COMP: Fix SW Guide examples LaTeX block line start warnings
      ENH: Update `Montage` remote module
      COMP: Fix SW Guide examples multi-line comment warnings
      ENH: Improve `itk::ThresholdImageFilter` class coverage
      STYLE: Fix typo in `itkBinaryThresholdImageFilterTest`
      STYLE: Fix ivar print value in `itk::PolygonSpatialObject`
      ENH: Improve the `itk::VideoFileWriter` class coverage.
      COMP: Remove unnecessary inherited member re-definitions
      ENH: Improve `itk::DCMTKSeriesFileNames` class coverage
      ENH: Add `itk::GrayscaleGrindPeakImageFilter` class test
      STYLE: Avoid `try`/`catch` boilerplate code in updating writer
      DOC: Fix typos in DTI 3D reconstruction image filter example
      ENH: Add boolean macros to `SpatialObjects` module boolean ivars
      DOC: Fix typos in DTI module's anisotropy image filter classes
      ENH: Add the `PrintSelf` method to `itk::SpatialFunctionImageEvaluatorFilter`
      STYLE: Remove unnecessary comment lines
      ENH: Improve the DTI module classes coverage
      ENH: Improve coverage for `SpatialFunction` module classes
      COMP: Fix `itk::ContourSpatialObject` ivar initialization value type
      ENH: Improve coverage for `SpatialObjects` module classes.
      ENH: Improve TopHatImageFilter classes coverage
      DOC: Improve math morphology class documentation
      STYLE: Turn commented unnecessary commands into useful comments
      ENH: Use strongly typed enums for the `Algorithm` type in math morphology
      BUG: Fix math morphology strongly typed `enum` scope-resolution
      ENH: Test streaming math morphology `enum class` types
      COMP: Fix missing initialization braces warnings
      DOC: Fix link to NumFOCUS ITK project website in `README`
      DOC: Change the Insight Journal handle links to insight-journal links
      DOC: Fix verbatim block in `UpdatingThirdParty` doc file
      STYLE: Make indentation in `itk::ContourSpatialObject.h` conform to ITK
      ENH: Print all `itk::DCMTKSeriesFileNames` ivars in `PrintSelf`
      BUG: Fix `itk::DCMTKSeriesFileNames::GetOutputFileNames()` returned ivar
      ENH: Improve coverage for `itk::InverseDisplacementFieldImageFilter` class
      ENH: Improve coverage for `itk::RayCastInterpolateImageFunction` class
      ENH: Improve coverage for `itk::DCMTKSeriesFileNames` class
      ENH: Effectively test filename values causing exceptions
      ENH: Improve coverage for `MathematicalMorphology` module classes.
      STYLE: Improve `itk::ImageSeriesWriter` class test file style
      COMP: Fix `itk::DCMTKSeriesFileNames` compilation issues
      ENH: Improve coverage for `itk::GDCMSeriesFileNames` class
      ENH: Add test for `itk::MeshFileReader` class
      BUG: Fix `itkDCMTKSeriesREadImageWrite.cxx` test failures
      ENH: Increase `itk::ImageDuplicator` class coverage
      ENH: Increase `itk::ScaleLogarithmicTransform` class coverage
      BUG: Remove unnecessary IO member filter name of class print calls
      ENH: Increase `itk::BSplineControlPointImageFunction` class coverage
      COMP: Fix undeclared identifier
      ENH: Increase `itk::ObjectByObjectLabelMapFilter` class coverage
      STYLE: Use `itkBooleanMacro` to avoid boilerplate code
      ENH: Increase `ITKImageFeature` module classes coverage
      ENH: Increase `ITKImageGradient` module classes coverage
      COMP: Update legacy boolean ivar set method call to current API
      BUG: Use appropriate dimensionality for image and components weights
      ENH: Check input and output image dimensionality matches
      STYLE: Rename `ITK_EXERCISE_BASIC_OBJECT_METHODS` class names arguments
      STYLE: Provide default initialization to constructor in header file
      STYLE: Use single forward slashes in `CMakeLists.txt` data paths
      STYLE: Use the static `FixedArray::Filled` to initialize array ivars
      ENH: Use strongly typed enums for `itk::NiftiImageIO` readable formats
      BUG: Fix Superclass name in RTTI macro
      COMP: Remove duplicate include file
      ENH: Print all member variables.
      ENH: Use `itkBooleanMacro` for `ImageSpacing`, `InterpolateSurfaceLocation`
      ENH: Increase code coverage
      BUG: Fix `itkMultiphaseSparseFiniteDifferenceImageFilterTest`
      BUG: Fix Superclass name in RTTI macro
      BUG: Fix uninitialized variable use in `ANTS` neighborhood correlation metric
      BUG: Initialize member variables
      COMP: Fix deduced type initialization warning and operand mismatch error
      STYLE: Add missing source file extension to `Common` module tests
      COMP: Fix image pointer casting error
      STYLE: Move `DCMTK` test baselines to module's `Baseline` folder
      DOC: Remove duplicate `README` file from `Review` module test folder
      COMP: Fix missing initializer warning

Jonathan Daniel (1):
      ENH: Added .vs to .gitignore

KWIML Upstream (1):
      KWIML 2020-04-20 (4abfeaa7)

KWSys Upstream (2):
      KWSys 2020-09-29 (4a19ed43)
      KWSys 2021-02-10 (dda7a943)

Kenji Tsumura (1):
      BUG: Fix itkGPUDemonsRegistrationFilterTest fails

Kris Thielemans (2):
      COMP: Fix linking problems with external HDF5
      COMP: use HDF5 targets preferentially if using a system HDF5

LIBPNG Upstream (1):
      PNG 2020-05-24 (dbe3e0c4)

Lee Newberg (26):
      ENH: Support additional pixel types in python wrapping for ShrinkImageFilter.
      BUG: Do not wrap signed distance map filters for integer image outputs
      BUG: Update associated test
      BUG: MinPriorityQueueElementWrapper constructor needs ZeroValue()
      BUG: MinPriorityQueueElementWrapper constructor needs default constructor
      ENH: WIP: Wrap CastImageFilter for VectorImage.
      ENH: Read DICOM directory with Python imread
      ENH: Support for VariableLengthVector in CastImageFilter
      ENH: Move ITKMeshToPolyData functionality into ITK
      ENH: Make Python Image.astype() work for more types
      ENH: Add tests for VectorImage.astype
      BUG: fix tests for VectorContainer and PyVectorContainerPython
      PERF: No need to check whether numpy is available
      COMP: Breaks Continuous test for Microsft OS; disable until debugged.
      ENH: Support `ttype` parameter for numpy<->ITK conversions
      ENH: ttype can be `ImageType` whenever `(ImageType,)` is accepted
      STYLE: Prevent CMake variable name collisions
      ENH: add additional assertions for `ttype` parameter
      COMP: remove warnings for template already defined
      COMP: remove CastImageFilter "template already defined" warnings
      ENH: Add "long long" support to itkVTKImageImport
      BUG: Fix crash of PythonExtrasTest when extra types are wrapped
      ENH: support multiple labels in ContourExtractor2DImageFilter
      COMP: type and const safety in ContourExtractor2DImageFilter
      PERF: Make loop over labels be multi-threaded
      ENH: Use (Shaped)RegionRange instead of (Shaped)RegionIterator.

Mathew Seng (7):
      ENH: Update Remote Modules
      BUG: Missing end-of line macro changes
      BUG: Incorrect path for Sphinx Examples in Doxygen
      BUG: Invalid urls to outside sources
      ENH: Update SpatialObject and SpatialObjectPoint sphinx
      BUG: Incorrect syntax for doxygen code block
      DOC: Add Git upstreams for post-commit hook

Mathieu Malaterre (1):
      STYLE: Teach git about GDCM oversize file

Matt McCormick (73):
      COMP: itkResampleImageTest8 ~ProjectTransform mark as override
      ENH: Bump the ITK CMake version to 5.2.0
      ENH: Add itk.vtk_image_from_image and itk.image_from_vtk_image
      BUG: Fetch full depth in apply-clang-format action
      DOC: Release process updates for 5.1.0
      COMP: CurvesLevelSetImageFilter multi-line comment
      DOC: Add 5.1 Release Notes
      ENH: Bump CI ExternalData version to 5.1.0
      COMP: Unused tc in SquaredEdgeLengthDecimationQuadEdgeMeshFilterTest
      DOC: Fix conda install command in ReleaseDownloadLinks.md
      COMP: Bump CastXML to 0.3.4
      ENH: Add torch.Tensor input/output support for ITK filters
      DOC: Add pointers on how to browse and download testing data
      ENH: Add Label PR GitHub Action
      ENH: Add image.astype(pixel_type) for casting
      COMP: Add lxml to macOS CI environment
      ENH: Update UpdatepygccxmlFromUpstream.sh for pygccxml v2.0.1
      COMP: Add missing itkMacro.h to itkSTLContainerAdapter.h
      DOC: Note content link update for bug fix releases
      ENH: Add Image dict and pixel set/get Python interfaces
      ENH: Wrap LabelOverlapMeasuresImageFilter
      ENH: Support Python debugging with Visual Studio
      ENH: WIP: Wrap CastImageFilter for VectorImage <-> Vector
      PERF: Add IPO flags to Python libraries
      COMP: Remove -fopenmp in castxml invocation
      COMP: Remove gold linker support
      COMP: Do not enable whole program optimization with MSVC
      COMP: Use CMake 3.18.4 in macOS CI builds
      ENH: Install dask for CI testing
      COMP: Set runtime output directory for Windows Python tests
      COMP: Only search for Python 3.6 and above
      DOC: Correct ITKExamples Python package testing command
      BUG: Python support module and __init__.py install location
      BUG: Prevent HDF5 from overwritting ITK library names
      ENH: Update GDCM upstream repository to GitHub
      ENH: Content link updates for ITK 5.2 RC 1
      DOC: Update macOS Python package Release build instructions
      BUG: Set runtime output path for external module binaries
      COMP: Force runtime output with Visual Studio and Python wrapping
      ENH: Add ARM sources to libpng update from upstream script
      ENH: Add libpng ARM sources
      COMP: Add ARM sources to libpng build
      BUG: Do not assert module swig attribute for init_docstring
      BUG: init_docstring with filter instance from the current module
      ENH: Generate a list of remote modules changed for release notes
      BUG: Wrap MetaDataObject for Array and std::vector value types
      STYLE: Add SymmetricEigenAnalysisImageFilter::SetOrderEigenValuesBy
      ENH: Set default dimension for SymmetricEigenAnalysisImageFilter
      STYLE: Add SymmetricEigenAnalysisImageFilter::GetOrderEigenValuesBy
      BUG: Test SymmetricEigenAnalysisImageFilter::GetOrderEigenValuesBy
      ENH: Support alternate dim orders in image_from_xarray
      ENH: NumPy and XArray conversion for 4D images
      ENH: xarray_from_image "c" coords uint32 type
      ENH: Module configuration exec to import
      BUG: Remove Azure coverage CI build
      COMP: Remove invalid Emscripten HDF5 link flags
      COMP: Declare H5O__fsinfo_set_version
      COMP: Provide H5CX_set_apl declaration in H5Odeprec.c
      COMP: Provide H5CX_get_ohdr_flags declaration in H5Oint.c
      COMP: Declare H5CX_set_libver_bounds in H5Rint.c
      COMP: Add output redirection for H5Tinit.c, H5lib_settings.c generation
      BUG: Disable Emscripten exception for floating point exceptions
      COMP: Include stdio.h for printf
      BUG: SetPixelTypeInfo for VARIABLELENGTHVECTOR, ARRAY, VARIABLESIZEMATRIX
      ENH: Add itk.transformread, itk.transformwrite
      ENH: imageio kwarg for imread, imwrite
      STYLE: black formatting on itkExtras.py
      ENH: xarray_from_image .attr, image_from_xarray MetaDataDictionary support
      COMP: Migrate ITKVtkGlue library configuration to itk-module-init.cmake
      COMP: Include directories for CastXML when wrapping ITKVtkGlue
      ENH: Content link synchronization for v5.2rc03
      ENH: Support 32 bit integer IO in wrapping
      BUG: Checkout full depths for clang-format-linter

MetaIO Maintainers (4):
      MetaIO 2020-12-04 (1d5fb8c4)
      MetaIO 2020-12-23 (26d71aa2)
      MetaIO 2021-01-28 (ea2bb780)
      MetaIO 2021-02-12 (df6ad862)

Michael Jackson (1):
      COMP: Detect Apple Silicon arch for Floating Point exceptions

Mihail Isakov (3):
      ENH: GDCMImageIO SINGLEBIT image type
      DOC: Updated GDCMImageIO
      BUG: memory leak in LSMImageIOTest

Mon ius (1):
      COMP: fix error on IBM POWER9 ppcle64 arch

Moritz Schaar (1):
      BUG: Fix Python Wrapping with MSVC and CMake >= 3.18, Closes # 2049

Nick Tustison (6):
      ENH:  Add adaptive denoising module.
      DOC:  Update description.
      ENH:  Add criteria report, update git tag, and enhance description.
      ENH:  Add test.
      ENH:  Review.
      ENH:  Add refactoring and more testing.

Niels Dekker (51):
      STYLE: Move ITK5 ranges, shapes, policies out of Experimental namespace
      COMP: Fix arithmetic overflow MersenneTwisterRandomVariateGenerator
      STYLE: Allow conversion from nullptr to WeakPointer, not from zero
      STYLE: Add in-class default member initializer to SmartPointer m_Pointer
      DOC: Link region iterators to ImageRegionRange, ImageRegionIndexRange
      STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE
      STYLE: Call ITK_DISALLOW_COPY_AND_MOVE, not ITK_DISALLOW_COPY_AND_ASSIGN
      DOC: Add Doxygen links from iterators to ShapedImageNeighborhoodRange
      STYLE: Remove C-style (const void *) casts
      STYLE: Remove space between class and member names in C++ source files
      STYLE: Remove "include guards" from cxx files
      STYLE: Use C++11 override and `= default` in itkWin32OutputWindow.h
      STYLE: Replace `container[container.size() - 1]` by `container.back()`
      ENH: Allow running various tests without arguments
      STYLE: Remove local possibleTransformIO from TransformIOFactoryTemplate
      STYLE: TxtTransformIO Read() no longer copy input file to data string
      STYLE: Declare OptimizerParameters::m_Helper as C++11 std::unique_ptr
      STYLE: Move OptimizerParameters implementation from .hxx to .h file
      STYLE: Replace `vnl_vector[vnl_vector.size() - 1]` by vnl_vector.back()
      BUG: Fix MatrixOffsetTransformBase SetFixedParameters if too few params
      COMP: Work around GCC-4.8 error converting to OptimizerParametersHelper
      COMP: Remove InvalidImageMomentsError from itkImageMomentsCalculator.hxx
      ENH: Test that MetaIO supports a string value of up to 32767 chars
      STYLE: Use the WriteImage convenience function in Core/Common/test
      BUG: DICOMParser should use `&&` instead of comma in for-loop condition
      STYLE: Use the WriteImage convenience function anywhere in Modules/Core
      BUG: Fix Euler3DTransform::SetFixedParameters crash when too few params
      ENH: Add operator== and operator!= to itk::Image
      ENH: Declare FixedArray::size() constexpr
      ENH: Add convenience function ReadImage
      ENH: Extend ITKWriteImageFunctionTest by reading the written image back
      ENH: Array, OptimizerParameters constructors with size and initial value
      ENH: Support calling a const NumberToString, add GoogleTest unit tests
      STYLE: Reduce buf size, remove builder.Reset() calls from NumberToString
      STYLE: Remove virtual from itkGPUKernelClassMacro, use C++11 `= delete`
      COMP: Fix itkGPUKernelClassMacro(kernel) backward compatibility
      STYLE: Remove dynamic_cast and GetPointer() from LightObject::Clone()
      STYLE: Remove 6 no-op dynamic_casts (casting T* to T*) from Modules/Core
      STYLE: Avoid "no-op" dynamic_cast from inside LightObject::New()
      STYLE: Remove 9 no-op dynamic_casts (casting T* to T*)
      ENH: Add explicit OptimizerParameters(inputData, dimension) constructor
      STYLE: Remove unintended extra space from destructors and operators
      STYLE: ExceptionObject may assume that std::string::c_str() never throws
      STYLE: Follow Rule of Zero and use std::shared_ptr in ExceptionObject
      BUG: Remove duplicate "itk::ERROR: itk::ERROR: " from itkExceptionMacro
      STYLE: C++11 inheriting constructors from ExceptionObject for 4 classes
      STYLE: Remove destructors ExceptionObject derived classes (Rule of Zero)
      BUG: Remove duplicate "itk::ERROR: " from itkSpecializedExceptionMacro
      STYLE: Use equal_to on pixel containers DenseFiniteDifferenceImageFilter
      COMP: Add virtual destructor to TestClass in ExceptionObject unit test
      STYLE: Replace "itk::ERROR" by "ITK ERROR" in description of exception

Niklas Johansson (2):
      STYLE: Correct doc for ReadImageInformation
      ENH: Prevent segfault by failing fast in itkGDCMImageIO

Pablo Hernandez-Cerdan (6):
      BUG: Use ITK_WRAP_IMAGE_DIMS in ViewImage.wrap
      ENH: Add data() and size() member functions to FixedArray
      COMP: Remove dynamic exception specifications in tests
      COMP: Avoid Dimension < 3 in FrustumSpatialFunction
      COMP: Fix warning -Wdeprecated-copy in itkQuadEdgeMeshBaseIterator
      COMP: Fix const-correctness of iterators in multiple classes

Pierre Wargnier (2):
      BUG: Fix Mat to Image conversions for OpenCV 4.x; add support for int32
      COMP: fix errors and warnings in OpenCV bridge

Samuel Gerber (1):
      PERF: Avoid Superfluous PointsLocator Updates

Sean McBride (13):
      COMP: Fixed link error with old versions of AppleClang
      COMP: Fixed compile error on old clang 7, prefixed ivar with this->
      COMP: Remove prohibition against building Universal Binaries on macOS
      DOC: Removed obsolete readme info regarding updating HDF5
      COMP: remove invalid double underscore usage
      COMP: ignore try_compile fenv_t results on macOS
      COMP: cherrypicked HDF5 upstream changes for macOS universal binary support
      COMP: Changed conditional include of emmintrin.h to use preprocessor
      ENH: changed CTEST_DROP_METHOD from http to https
      COMP: removed dead atomic operation checks
      ENH: fixed failing test with macOS Rosetta emulation by increasing buffer size
      COMP: remove try-compile for SSE2 detection
      COMP: cherrypick HDF5 commit that added C++11 override keywords

Simon Rit (3):
      COMP: fix itk::ArrowSpatialObject warning when compling 1D wrappings
      DOC: fix description of Concept::SameDimensionOrMinusOne(OrTwo)
      COMP: export ITK_LIBRARY_BUILD_TYPE for external building of modules

Stephen R. Aylward (18):
      BUG: CUFFTW paths were not being set and unnecessary FFTW files used
      BUG: CurvatureRegistrationFilter fix logic re: depends on FFTW (# 1786)
      ENH: Bump TubeTK to support CUFFTW (# 1788)
      ENH: Bump TubeTK to version that removes ArrayFire (replaced by cufft)
      ENH: ITKFFT library is now required, even if cufft is used.
      ENH: Bump MetaIO to address style and const params
      BUG: Frenet frame disrupted along tubes
      BUG: Bump TubeTK
      BUG: Update TubeTK to include version that addressed missing VTK files
      BUG: Bump TubeTK to isolate wrapping on vtk-dependent classes
      ENH: Bump MetaIO to use an enhanced MetaTubePoint (# 1954)
      BUG: TubeSpatialObject normals not unit vectors (# 1972)
      ENH: Bump TubeTK to version that works with updated Spatial Objects (# 2002)
      ENH: Bump TubeTK to offer updated examples and improved tube seg
      COMP: Adds ComputeTangentAndNormals() function
      COMP: Adding itkLegacyMacro wrapping to ComputeTangentAndNormals()
      ENH: TubeTK release candidate for ITK v5.1.2
      BUG: Update itkEventObjectTest to use new event macros

Tom Birdsong (5):
      ENH: Python wrapping for v4 optimizers
      ENH: Relocate and test diff demons reg filter Python wrapping
      ENH: Wrap DisplacementFieldTransform for vector floats
      ENH: Wrap GradientDescentOptimizerv4 for Python
      ENH: Wrap CenteredTransformInitializer for template superclass

VXL Maintainers (7):
      VNL 2020-10-05 (c45970ee)
      VNL 2020-10-07 (a302a89b)
      VNL 2020-11-20 (3d3e8683)
      VNL 2020-12-16 (a05ed916)
      VNL 2020-12-20 (85ae25b7)
      VXL 2020-12-16 (a05ed916)
      VXL 2021-02-15 (7edc7cd8)

Zhiyuan Liu (2):
      DOC: improve helpers of itk.Filters.
      ENH: Add a convenient function to get/set the number of threads.

justbennet (1):
      COMP:  Fixing #include for itkExpectationMaximizationMixtureModelEstimator.h

=====================================================================
SimpleITK:
$ git shortlog --topo-order --no-merges v2.0.2..460f9c1
Bradley Lowekamp (78):
      Bumping version to 2.1 for development
      Add testing for concurrent reading of NIFTI files
      Enable the ITKIOTransformMINC module for xfm transform files
      Add testing for reading and writing transforms in Python
      Wrap Image's GetBuffer methods for Java
      Use "package_data" for SimpleITK documentation files.
      Add support to register single typelist to dual factory
      Add custom_register to DualDispatch template
      Add sitkUInt8 mask image support to MaskNegatedImageFilter
      Use dimension range member function registration method
      Add Python 3.9 to manylinux AZP CI packaging
      Add GetLogBiasFieldAsImage method to N4 filter
      Add testing for N4's GetLogBiasFieldAsImage method
      Update N4 example to use bias field at input resolution
      Add Image::GetSizeOfPixelComponent method
      Add testing for Image::GetSizeOfPixelComponent method
      Remove unused Java carray typemap
      Add to Java interface Image::GetBufferAsByteBuffer
      Add Python 3.9 to packaging pipeline
      AZP Mac Package explicit Python 3.6 version usage
      Exclude the "latest" branch from triggering packaging
      Update ITK Superbuild version along the ITK 5.2 development branch
      Update ITK along 5.2 development branch.
      Tweak manuylinux build scripts
      Add docker file for building manylinux2010 Python 2010 wheels
      Add manylinux2010 to AZP packaging
      Fix AZP Linux packaging to build configure.BuildHash
      Update ITK superbuild version to 5.2 rc1
      Set CMake Policy version to 3.10 in Superbuild
      Suppress MSVC getenv security warning.
      Improve style with C++11 features
      Remove old TraviCI configuration
      Update CircleCCI Python versions to 3.6,3.9
      ShiftScale supports output pixel type
      Add warning macro
      Create ObjectOwnedBase class
      Create ObjectOwnedBase class
      Move definition before HelloWorld target
      Add LoggerBase and ITKLogger classes
      Add wrapping for Logging classes
      Add Python Logger derivation support and example
      Fix implicit parent initialization
      Fix unable to load SWIG R wrapping due to abstract class
      Update Python pip before installation
      Add prose documentation for the Logging example
      Add Logging example to example index
      Add 4D ( and more ) support for PermuteImageFilter
      Discontinue packaging Python 3.5
      Fix Logging example python code include link
      Replace virtualenv with venv
      Directly create CMake commands for creating venv and installing numpy
      Adding suppression of distutils unknow field warning.
      Update ITK version to after 5.2rc1
      Use STEP_TARGETS option over EP Add_Step_Targets command
      Install wheel package to venv for packaging
      Update to support CMake Ruby module prefix
      AZP restore publishing of OSX and MS Windows Python packages
      Update CircleCI images to buster
      Correct setting of command ownership
      Add test to echo CMakeCache.txt
      CircleCI update cmake version to 3.18
      Update ITK superbuild version to 5.2rc02
      CMake fix detection of Ruby variables
      CMake prefer Ruby_EXECUTABLE
      Fix Doxygen style comment for grouping
      Remove unused VirtualEnv configuration variables
      Remove installation of numpy
      Remove numpy installation and unused virtualenv configuration
      Fix "..." in SWIG docstring causing parse error
      Revert removal of including PythonDoc.i file
      Remove old CentOS devtoolset 3,4 and 6
      Set the default ITK Multithreader to Platform in Superbuild
      AZP On Windows separate the building of the core library and python
      AZP add Java build as separate step to Windows CI
      AZP To batch add osx 10.15 with newer xcode builds
      AZP Define env_file for all linux batch jobs
      AZP Add devtoolset-9 for linux batch jobs
      Address Python's pip upgrade warning

Dave Chen (13):
      Spelling bugs I missed the first time around
      Update SetApplication docs
      added Linux example; some formatting tweaks
      Spell checking all the headers
      undoing fixes to TypeList.h
      BUG: unpack was moved to table.unpack for Lua 5.2
      Fixed old,non-working Java HelloWorld example
      added SITK_NOSHOW check
      Run HelloWorld examples when testing
      convential -> conventional
      workflow to run spell checking
      changed pip to install from req.txt
      added IO examples for CSharp, C++, Java, Lua, Ruby and TCL.

Ziv Yaniv (5):
      Correct grammar in displacementfield constructor error message.
      DOC: GetPixel example separated, dynamic and statically typed languages.
      BUG: The GetPixelAsComplexFloat64 in Python was not renamed.
      Updating to modern Python from 2.7 to 3.x.
      Fixed broken link in filters list.

=====================================================================
BRAINSTools:
$ git shortlog --topo-order --no-merges v5.2.0..590c371
Dave Welch (7):
      Create gh-pages branch via GitHub
      ENH: Added legal submodule
      Create gh-pages branch via GitHub
      Delete .gitmodules
      BUG: removed legal submodule dir
      Create gh-pages branch via GitHub
      Create gh-pages branch via GitHub

Hans J. Johnson (112):
      ENH: Update to version 5.2.0 of BRAINSTools
      ENH: Fix error in GTRACT building requirements.
      ENH: Make TBB and FFTW conditional for simplifying windows builds.
      BUG: Double value passed as bool.
      ENH: Fix vxl version for ITK.
      ENH: Missing to_matrix call.
      ENH: Add starting code for reading slicer fiducials.
      ENH: Simplify ITK find_package.
      ENH: Fix ITK MI double scaling.
      ENH: Add Similarity3DTransform to LandmarkInitializer.
      ENH: Adding initial Similarity3D LMKInit
      ENH: Remove references to BRAINSCut from BAW.
      ENH: Remove BrainsCUT old files.
      DOC: Provide better diagnostic failure modes.
      ENH: Use exception failure for invalid cases.
      WIP: Fix version.
      STYLE: Spelling, organize,variable name changes for readability.
      STYLE: Add debugging, and cleanup variable names.
      ENH: Clarify names.
      BUG: Missing transform from msp->eyefixed->orig for RP point.
      DOC: Provide better diagnostics.
      BUG:  Code used in debugging missed update step.
      BUG: Wrong variable name used for final result.
      ENH: Refine search region for eyes based on emperical data.
      ENH: Encapsulate ROI generation code.
      ENH: Restrict second eye location finding based on first eye location.
      COMP: Fix missing header error.
      COMP: Fix type narrowing warning.
      ENH: Allow versor rigid transforms for landmark moving.
      ENH: Allow output based temp file for fixing landmarks.
      BUG: Fix replace index counter variable mismatch for old/new strings
      ENH: Review script for fcsv files.
      ENH: Update ITK version.
      ENH: Update to version 5.3.0 for improved BCD performance.
      ENH: Allow any generic transform to be used for landmarks.
      ENH: Adding better fallthrough logic.
      ENH: Update version for latest tag version.
      ENH: Move useful functions to common library
      ENH: Use more robust computation for generating Tmsp
      ENH: Allow aligning to MSP from landmark points.
      ENH: Preserve original image pixel type.
      BUG: Restore deleted utility function
      ENH: Update test cases for minor numerical precision changes.
      COMP: Fix warning about shadow variable with missing return value
      ENH: Use ITK with sform preference.
      COMP: Better timeout and download behavior for large files.
      ENH: Update ANTs
      ENH: Remove tbb pre oneapi warnings by avoiding tbb.h
      ENH: Remove debugging code from standard runs.
      STYLE: Move build scripts together.
      ENH: Move old superbuild files out of the way.
      ENH: Enable building with shared libraries.
      ENH: Avoid polluting all the projects with build locations.
      BUG: Development installs needed for ITK
      BUG: SEM development install required.
      ENH: Provide installed version of libraries.
      ENH: Allow for shared libary builds of executables.
      ENH: Set default install prefix for builds.
      ENH: Update to fix shared library install of ITK.
      ENH: Remove outdated reference atlas files.
      ENH: Improve install path naming for BRAINSTools.
      ENH: Update to version 5.3.1 with installed shared libs.
      ENH: Update for fixed compilation of ANTS.
      COMP: Need extra flag to monitor built in default.
      ENH: Fixed zlib library extension for mac
      ENH: Fixed up FFTW installs.
      ENH: add BRAINSResample 'input' pixel type
      ENH: Provide linux relative pathing for shared libs
      BUG: Wrong tbb library search path given
      ENH: Use relative relocatable rpath for mac
      ENH: Allow both lmk and image base transforms.
      ENH: Fix for centos pathing of fftw.
      ENH: Adding debugging information for git tag.
      ENH: Updating version to v5.3.2
      ENH: Explicitly set FPIC building.
      DOC: Add future interesting DCMTK option comment.
      COMP: Some systems use lib64 or lib32 for library directories
      BUG:  Need to address the fact that slicer now write LPS landmarks
      STYLE: Remove errant cmake file.
      ENH: Update to install the Atlas reference files as well.
      ENH: Adding initial programs for defacing data.
      BUG: Can not write file to shared directory
      STYLE: Remove unused template parameter
      ENH: Add install commands
      STYLE: Remove duplicate code included in BRAINSCommonLib
      BUG: Fix template parameter to allow 2D and 3D
      ENH: Add implicit resampling to first image
      ENH: Adding simple generic transform for ImageCalculator.
      ENH: Add resampling to ImageCalculator
      ENH: Remove compiler warning unused variable.
      ENH: Deface with gradual blur
      ENH: Update versions to the latest versions.
      BUG: Output mask is not a debugging output.
      ENH: write mask image last as a sentinal file.
      ENH: Add passiveVolume processing
      BUG: Need to force out of FOV code
      ENH: Allow BCD to force any landmark location from input file
      STYLE: Make warning match variable name
      ENH: Improve the defacing algorithm to preserve regions above 80mm below AC point.
      ENH: Update the database to be read-only access.
      COMP: Add both ZLIB*DIR and ZLIB*DIRS variables
      DOC: Provide better documentation from XML for new version.
      ENH: Make SGEGraph only submit jobs that need running.
      ENH: Updating version tag to v5.4.0
      ENH: Avoid incorrect typecasting of distance maps
      BUG: 2D images were not processed correctly
      ENH: Improve diagnostic for landmark comparison.
      ENH: Update ITK to 5.2rc2.
      Set theme jekyll-theme-modernist and migrate Page Generator content
      Update index.md
      ENH: Preparing for gh-pages in doc directory.
      BUG: Fix directory name fo gh-pages.

Jean-Christophe Fillion-Robin (1):
      COMP: Fix windows compilation adding missing check_avx_flags function

Kian Weimer (8):
      ENH: updated external packages to latest version Each external package was checked and updated to its latest version if needed. The following were updated: ANTs, ITK, OpenJPEG, VTK. The VTK component naming convention changes and required a few other files to be modified.
      BUG: Updated VTK utility names. Some VTK utility names were not changed after the recent External package update. This does not affect functionality but does cause CMake to throw an error in debug mode. These names have now been updated.
      DOC: Added markdown instructions for configuring CLion for BRAINSTools This includes several
images.
      ENH: Swapped safe-to-replace local variable copies with a constant reference. In some code locations, local variables are created that simply represent a copy of another variable. For expensive to copy values, this can be inefficient. This commit converts such local variables whose contents are not modified to constant references. This implements a portion of the 'performance-unnecessary-copy-initialization' clang-tidy check.     -"Local copy 'SET_DATA' of the variable 'strname' is never modified; consider avoiding the copy"
      STYLE: Applied clang-format style changes to entire BRAINSTools tree.
      ENH: Replaced string addition operations within loops to append operations. The append operation provided by `std::string` is more efficient than an addition. Large string addition operations
within loops have been changed to append. This implements the 'performance-inefficient-string-concatenation' clang-tidy check.    -"String concatenation results in allocation of unnecessary temporary strings; consider using 'operator+=' or 'string::append()' instead"
      ENH: Replaced single character string literals within find operations with characters. In several locations, a length 1 string is passed to `std::string::find()` or others. The character literal overload is more efficient so these values have been converted. This implements the 'performance-faster-string-find' clang-tidy check.         -"'find' called with a string literal consisting of
a single character; consider using the more effective overload accepting a character."
      ENH: Converted method parameters to pass by refrence. Constant method parameters are copied during each method invocation. These parameters have been changed to pass-by-reference to avoid unnecessary, expensive copies. This implements a portion of the 'performance-unnecessary-value-parm' clang-tidy check.        -"The const qualified parameter 's' is copied for each invocation; consider
making it a reference."

abpwrs (10):
      ENH: mask lower 80mm more efficiently & pseudocode for apply mask
      ENH: adding flake and black configs
      STYLE: indentation change
      STYLE: pythonic if statement
      STYLE: fixing keyword naming `exit` to be exit_status
      ENH: adding diagnostic prints one exceptions
      ENH: BIDS style filename generation ENH: BIDS style file names can be generated automatically from a subject data dictionary
      ENH: adding assertion to bidsUtils_test.py
      FIX: correcting docs/comments + removed extra loop
      ENH: added noMaskApplication and inputMask falgs

Co-authored-by: Dženan Zukić <dzenan.zukic@kitware.com>
```