### PR TITLE
ENH: Use flow layout in Sample Data module

### DIFF
--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -288,7 +288,6 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
     Download buttons are organized in collapsible GroupBox with one GroupBox
     per category.
     """
-    numberOfColumns = 3
     iconPath = os.path.join(os.path.dirname(__file__).replace('\\','/'), 'Resources','Icons')
     desktop = qt.QDesktopWidget()
     mainScreenSize = desktop.availableGeometry(desktop.primaryScreen)
@@ -310,9 +309,9 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
       categoryLayout.addWidget(frame)
       frame.title = category
       frame.name = '%sCollapsibleGroupBox' % category
-      layout = qt.QGridLayout(frame)
-      columnIndex = 0
-      rowIndex = 0
+      layout = ctk.ctkFlowLayout()
+      layout.preferredExpandingDirections = qt.Qt.Vertical
+      frame.setLayout(layout)
       for source in dataSources[category]:
         name = source.sampleDescription
         if not name:
@@ -345,11 +344,7 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
         b.setSizePolicy(qSize)
 
         b.name = '%sPushButton' % name
-        layout.addWidget(b, rowIndex, columnIndex)
-        columnIndex += 1
-        if columnIndex==numberOfColumns:
-          rowIndex += 1
-          columnIndex = 0
+        layout.addWidget(b)
         if source.customDownloader:
           b.connect('clicked()', lambda s=source: s.customDownloader(s))
         else:

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -289,9 +289,8 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
     per category.
     """
     iconPath = os.path.join(os.path.dirname(__file__).replace('\\','/'), 'Resources','Icons')
-    desktop = qt.QDesktopWidget()
-    mainScreenSize = desktop.availableGeometry(desktop.primaryScreen)
-    iconSize = qt.QSize(int(mainScreenSize.width()/15),int(mainScreenSize.height()/10))
+    mainWindow = slicer.util.mainWindow()
+    iconSize = qt.QSize(int(mainWindow.width/8),int(mainWindow.height/6))
 
     categories = sorted(dataSources.keys())
 


### PR DESCRIPTION
The current three-column box layout resizes the module panel if it was narrower than what could fit three thumbnails, which was an inconvenience especially on smaller monitors or smaller window sizes, because the user had to manually resize the panel after switching to another module if they wanted to see the viewers in the usual size.
By using flow layout the thumbnails naturally fit the available horizontal space.


https://user-images.githubusercontent.com/1325980/111494297-40cb9680-8736-11eb-988c-18a8ead0e61e.mp4



