### PR TITLE
BUG: launcher executable now using app name to compose the filepath

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1314,7 +1314,8 @@ QString qSlicerCoreApplication::launcherExecutableFilePath()const
     {
     return QString();
     }
-  return this->slicerHome() + "/Slicer" + qSlicerUtils::executableExtension();
+  QString appName = this->applicationName().replace("-tmp", "");
+  return this->slicerHome() + "/" + appName + qSlicerUtils::executableExtension();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Untested
SlicerJupyter is using this function to determine the Slicer Launcher file path and it is failing for a custom app name.
