### PR TITLE
BUG: Fix circular markups measurement update calls

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMeasurement.cxx
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.cxx
@@ -153,6 +153,54 @@ void vtkMRMLMeasurement::Copy(vtkMRMLMeasurement* src)
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLMeasurement::SetEnabled(bool enabled)
+{
+  vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting Enabled to " << enabled);
+  if (this->Enabled != enabled)
+    {
+    this->Enabled = enabled;
+    this->Modified();
+    this->InvokeEvent(InputDataModifiedEvent);
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::EnabledOn()
+{
+  this->SetEnabled(true);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::EnabledOff()
+{
+  this->SetEnabled(false);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::SetUnits(std::string units)
+{
+  vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting Units to " << units);
+  if (this->Units != units)
+    {
+    this->Units = units;
+    this->Modified();
+    this->InvokeEvent(InputDataModifiedEvent);
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMeasurement::SetPrintFormat(std::string format)
+{
+  vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting PrintFormat to " << format);
+  if (this->PrintFormat != format)
+    {
+    this->PrintFormat = format;
+    this->Modified();
+    this->InvokeEvent(InputDataModifiedEvent);
+    }
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLMeasurement::SetQuantityCode(vtkCodedEntry* entry)
 {
   if (!entry)
@@ -271,7 +319,12 @@ void vtkMRMLMeasurement::SetPolyDataValues(vtkPolyData* inputValues)
 //----------------------------------------------------------------------------
 void vtkMRMLMeasurement::SetInputMRMLNode(vtkMRMLNode* node)
 {
-  this->InputMRMLNode = node;
+  if (this->InputMRMLNode != node)
+    {
+    this->InputMRMLNode = node;
+    this->Modified();
+    this->InvokeEvent(InputDataModifiedEvent);
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLMeasurement.h
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.h
@@ -17,6 +17,7 @@ or http://www.slicer.org/copyright/copyright.txt for details.
 #include "vtkMRMLNode.h"
 
 // VTK includes
+#include <vtkCommand.h>
 #include <vtkDoubleArray.h>
 #include <vtkObject.h>
 #include <vtkPolyData.h>
@@ -46,6 +47,15 @@ public:
     InternalError
     };
 
+  enum Events
+  {
+    /// The node stores both inputs (e.g., input node, enabled, unit, etc.) and computed measurement.
+    /// InputDataModifiedEvent is only invoked when input parameters are changed.
+    /// In contrast, ModifiedEvent event is called if either an input or output parameter is changed.
+    // vtkCommand::UserEvent + 555 is just a random value that is very unlikely to be used for anything else in this class
+    InputDataModifiedEvent = vtkCommand::UserEvent + 555
+  };
+
   vtkTypeMacro(vtkMRMLMeasurement, vtkObject);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
@@ -64,9 +74,10 @@ public:
   virtual void Compute() = 0;
 
   /// Enabled
-  vtkSetMacro(Enabled, bool);
   vtkGetMacro(Enabled, bool);
-  vtkBooleanMacro(Enabled, bool);
+  virtual void SetEnabled(bool enabled);
+  virtual void EnabledOn();
+  virtual void EnabledOff();
 
   /// Measurement name
   vtkGetMacro(Name, std::string);
@@ -87,7 +98,7 @@ public:
 
   /// Measurement unit
   vtkGetMacro(Units, std::string);
-  vtkSetMacro(Units, std::string);
+  virtual void SetUnits(std::string units);
 
   /// Informal description of the measurement
   vtkGetMacro(Description, std::string);
@@ -95,7 +106,7 @@ public:
 
   /// Formatting string for displaying measurement value and units
   vtkGetMacro(PrintFormat, std::string);
-  vtkSetMacro(PrintFormat, std::string);
+  virtual void SetPrintFormat(std::string format);
 
   /// Copy content of coded entry
   void SetQuantityCode(vtkCodedEntry* entry);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -245,13 +245,13 @@ void vtkMRMLMarkupsNode::ProcessMRMLEvents(vtkObject *caller,
     vtkObject* measurementObject = nullptr;
     for (this->Measurements->InitTraversal(it); (measurementObject = this->Measurements->GetNextItemAsObject(it)) ;)
       {
-      if (!broker->GetObservationExist(measurementObject, vtkCommand::ModifiedEvent, this, this->MRMLCallbackCommand))
+      if (!broker->GetObservationExist(measurementObject, vtkMRMLMeasurement::InputDataModifiedEvent, this, this->MRMLCallbackCommand))
         {
-        broker->AddObservation(measurementObject, vtkCommand::ModifiedEvent, this, this->MRMLCallbackCommand);
+        broker->AddObservation(measurementObject, vtkMRMLMeasurement::InputDataModifiedEvent, this, this->MRMLCallbackCommand);
         }
       }
     }
-  else if (caller->IsA("vtkMRMLMeasurement"))
+  else if (caller->IsA("vtkMRMLMeasurement") && event == vtkMRMLMeasurement::InputDataModifiedEvent)
     {
     this->UpdateAllMeasurements();
     }


### PR DESCRIPTION
The custom modified event InputDataModifiedEvent has been introduced in vtkMRMLMeasurement that is invoked only when such members are modified that should trigger update of the measurement. By observing this event for updating the measurements, circular calls are prevented.

A concrete effect is that curvature computation and scalar display update is fast again.

Fixes https://github.com/Slicer/Slicer/issues/5486