### PR TITLE
ENH: Make default slice view orientations configurable

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsViewsPanel.ui
@@ -127,6 +127,20 @@
             </item>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="SliceViewOrientationLabel">
+            <property name="text">
+             <string>View orientation:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="ctkComboBox" name="SliceViewOrientationComboBox">
+            <property name="currentIndex">
+             <number>-1</number>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/Base/QTGUI/qSlicerSettingsViewsPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsViewsPanel.cxx
@@ -27,6 +27,7 @@
 
 // CTK includes
 #include <ctkVTKAbstractView.h>
+#include <ctkComboBox.h>
 
 // --------------------------------------------------------------------------
 // qSlicerSettingsViewsPanelPrivate
@@ -100,6 +101,15 @@ void qSlicerSettingsViewsPanelPrivate::init()
                       "sliceRulerType", SIGNAL(currentSliceRulerTypeChanged(QString)),
                       "Slice view ruler type",
                       ctkSettingsPanel::OptionRequireRestart);
+
+  this->SliceViewOrientationComboBox->addItem(QWidget::tr("patient right is screen left (default)"), QString("PatientRightIsScreenLeft"));
+  this->SliceViewOrientationComboBox->addItem(QWidget::tr("patient right is screen right"), QString("PatientRightIsScreenRight"));
+  q->registerProperty("DefaultSliceView/Orientation", this->SliceViewOrientationComboBox,
+    "currentUserDataAsString", SIGNAL(currentIndexChanged(int)),
+    "Default slice view orientation",
+    ctkSettingsPanel::OptionRequireRestart);
+  QObject::connect(this->SliceViewOrientationComboBox, SIGNAL(activated(int)),
+    q, SLOT(sliceViewOrientationChangedByUser()));
 
   q->registerProperty("Default3DView/BoxVisibility", this->ThreeDBoxVisibilityCheckBox,
                       "checked", SIGNAL(toggled(bool)),
@@ -274,4 +284,19 @@ void qSlicerSettingsViewsPanel::setThreeDRulerType(const QString& text)
   Q_D(qSlicerSettingsViewsPanel);
   // default to first item if conversion fails
   d->ThreeDRulerTypeComboBox->setCurrentIndex(qMax(d->ThreeDRulerTypeComboBox->findText(text), 0));
+}
+
+// --------------------------------------------------------------------------
+void qSlicerSettingsViewsPanel::sliceViewOrientationChangedByUser()
+{
+  Q_D(qSlicerSettingsViewsPanel);
+  if (d->SliceViewOrientationComboBox->currentUserDataAsString() == "PatientRightIsScreenRight")
+    {
+    if (d->SliceOrientationMarkerTypeComboBox->currentText() == "none")
+      {
+      // Non-default orientation is chosen and no orientation marker is displayed.
+      // To ensure that there is no accidental mixup of orientations, show the orientation marker.
+      d->SliceOrientationMarkerTypeComboBox->setCurrentText("axes");
+      }
+    }
 }

--- a/Base/QTGUI/qSlicerSettingsViewsPanel.h
+++ b/Base/QTGUI/qSlicerSettingsViewsPanel.h
@@ -72,6 +72,7 @@ public slots:
   void setThreeDOrientationMarkerType(const QString&);
   void setThreeDOrientationMarkerSize(const QString&);
   void setThreeDRulerType(const QString&);
+  void sliceViewOrientationChangedByUser();
 
 signals:
   /// Signal emitted when the current value is changed

--- a/Libs/MRML/Core/Testing/vtkMRMLSliceNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLSliceNodeTest1.cxx
@@ -57,21 +57,21 @@ void AddSliceOrientationPresets(vtkMRMLSliceNode* sliceNode)
 {
   {
     vtkNew<vtkMatrix3x3> preset;
-    vtkMRMLSliceNode::InitializeAxialMatrix(preset.GetPointer());
+    vtkMRMLSliceNode::GetAxialSliceToRASMatrix(preset.GetPointer());
 
     sliceNode->AddSliceOrientationPreset("Axial", preset.GetPointer());
   }
 
   {
     vtkNew<vtkMatrix3x3> preset;
-    vtkMRMLSliceNode::InitializeSagittalMatrix(preset.GetPointer());
+    vtkMRMLSliceNode::GetSagittalSliceToRASMatrix(preset.GetPointer());
 
     sliceNode->AddSliceOrientationPreset("Sagittal", preset.GetPointer());
   }
 
   {
     vtkNew<vtkMatrix3x3> preset;
-    vtkMRMLSliceNode::InitializeCoronalMatrix(preset.GetPointer());
+    vtkMRMLSliceNode::GetCoronalSliceToRASMatrix(preset.GetPointer());
 
     sliceNode->AddSliceOrientationPreset("Coronal", preset.GetPointer());
   }
@@ -295,10 +295,10 @@ int GetSliceOrientationPresetNameTest()
   vtkNew<vtkMRMLSliceNode> sliceNode;
 
   vtkNew<vtkMatrix3x3> originalPreset;
-  vtkMRMLSliceNode::InitializeAxialMatrix(originalPreset.GetPointer());
+  vtkMRMLSliceNode::GetAxialSliceToRASMatrix(originalPreset.GetPointer());
 
   vtkNew<vtkMatrix3x3> preset;
-  vtkMRMLSliceNode::InitializeAxialMatrix(preset.GetPointer());
+  vtkMRMLSliceNode::GetAxialSliceToRASMatrix(preset.GetPointer());
   sliceNode->AddSliceOrientationPreset("Axial", preset.GetPointer());
 
 
@@ -413,15 +413,15 @@ int SetOrientationTest()
 int InitializeDefaultMatrixTest()
 {
   vtkNew<vtkMatrix3x3> axial;
-  vtkMRMLSliceNode::InitializeAxialMatrix(axial.GetPointer());
+  vtkMRMLSliceNode::GetAxialSliceToRASMatrix(axial.GetPointer());
   CHECK_NOT_NULL(axial.GetPointer());
 
   vtkNew<vtkMatrix3x3> coronal;
-  vtkMRMLSliceNode::InitializeCoronalMatrix(coronal.GetPointer());
+  vtkMRMLSliceNode::GetCoronalSliceToRASMatrix(coronal.GetPointer());
   CHECK_NOT_NULL(coronal.GetPointer());
 
   vtkNew<vtkMatrix3x3> sagittal;
-  vtkMRMLSliceNode::InitializeSagittalMatrix(sagittal.GetPointer());
+  vtkMRMLSliceNode::GetSagittalSliceToRASMatrix(sagittal.GetPointer());
   CHECK_NOT_NULL(sagittal.GetPointer());
 
   return EXIT_SUCCESS;

--- a/Libs/MRML/Core/vtkMRMLSliceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceNode.h
@@ -205,7 +205,7 @@ public:
   /// \sa AddSliceOrientationPreset(const std::string& name, vtkMatrix3x3* orientationMatrix)
   int GetNumberOfSliceOrientationPresets() const;
 
-  /// \brief Add an orientation preset.
+  /// \brief Add or update an orientation preset.
   ///
   /// \sa RenameSliceOrientationPreset(const std::string& name, const std::string& updatedName)
   /// \sa RemoveSliceOrientationPreset(const std::string& name)
@@ -231,21 +231,26 @@ public:
   static const char* GetReformatOrientationName() { return "Reformat"; }
 
   /// \brief Initialize \a orientationMatrix as an `Axial` orientation matrix.
-  static void InitializeAxialMatrix(vtkMatrix3x3* orientationMatrix);
+  /// \param patientRightIsScreenLeft chooses between radiology (default, patient right is left side on the screen)
+  /// and neurology (patient right is right side on the screen) view orientation conventions.
+  static void GetAxialSliceToRASMatrix(vtkMatrix3x3* orientationMatrix, bool patientRightIsScreenLeft=true);
 
   /// \brief Initialize \a orientationMatrix as a `Sagittal` orientation matrix.
-  static void InitializeSagittalMatrix(vtkMatrix3x3* orientationMatrix);
+  /// \param patientRightIsScreenLeft chooses between radiology (default, patient right is left side on the screen)
+  /// and neurology (patient right is right side on the screen) view orientation conventions.
+  static void GetSagittalSliceToRASMatrix(vtkMatrix3x3* orientationMatrix, bool patientRightIsScreenLeft=true);
 
   /// \brief Initialize \a orientationMatrix as a `Coronal` orientation matrix.
-  static void InitializeCoronalMatrix(vtkMatrix3x3* orientationMatrix);
+  /// \param patientRightIsScreenLeft chooses between radiology (default, patient right is left side on the screen)
+  /// and neurology (patient right is right side on the screen) view orientation conventions.
+  static void GetCoronalSliceToRASMatrix(vtkMatrix3x3* orientationMatrix, bool patientRightIsScreenLeft=true);
 
   /// \brief Add default slice orientation presets to \a scene.
-  ///
+  /// \param patientRightIsScreenLeft chooses between radiology (default, patient right is left side on the screen)
+  /// and neurology (patient right is right side on the screen) view orientation conventions.
   /// \sa vtkMRMLScene::AddDefaultNode(vtkMRMLNode* node)
-  /// \sa InitializeAxialMatrix(vtkMatrix3x3* orientationMatrix)
-  /// \sa InitializeSagittalMatrix(vtkMatrix3x3* orientationMatrix)
-  /// \sa InitializeCoronalMatrix(vtkMatrix3x3* orientationMatrix)
-  static void AddDefaultSliceOrientationPresets(vtkMRMLScene* scene);
+  /// \sa GetAxialSliceToRASMatrix, GetSagittalSliceToRASMatrix, GetCoronalSliceToRASMatrix
+  static void AddDefaultSliceOrientationPresets(vtkMRMLScene* scene, bool patientRightIsScreenLeft=true);
 
   ///
   /// Size of the slice plane in millimeters

--- a/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLSliceControllerWidgetTest.cxx
@@ -87,7 +87,7 @@ void qMRMLSliceControllerWidgetTester::init()
   vtkNew<vtkMRMLSliceNode> sliceNode;
   sliceNode->SetLayoutName("Red");
   vtkNew<vtkMatrix3x3> axialSliceToRAS;
-  vtkMRMLSliceNode::InitializeAxialMatrix(axialSliceToRAS.GetPointer());
+  vtkMRMLSliceNode::GetAxialSliceToRASMatrix(axialSliceToRAS.GetPointer());
 
   sliceNode->AddSliceOrientationPreset("Axial", axialSliceToRAS.GetPointer());
   sliceNode->SetOrientation("Axial");

--- a/Modules/Loadable/ViewControllers/Logic/vtkSlicerViewControllersLogic.cxx
+++ b/Modules/Loadable/ViewControllers/Logic/vtkSlicerViewControllersLogic.cxx
@@ -133,7 +133,13 @@ void vtkSlicerViewControllersLogic::ResetAllViewNodesToDefault()
   scene->GetNodesByClass("vtkMRMLSliceNode", viewNodes);
   for (std::vector< vtkMRMLNode* >::iterator it = viewNodes.begin(); it != viewNodes.end(); ++it)
     {
-    (*it)->Reset(defaultSliceViewNode);
+    vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(*it);
+    if (!sliceNode)
+      {
+      continue;
+      }
+    sliceNode->Reset(defaultSliceViewNode);
+    sliceNode->SetOrientationToDefault();
     }
   viewNodes.clear();
   vtkMRMLViewNode* defaultThreeDViewNode = GetDefaultThreeDViewNode();

--- a/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.h
+++ b/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.h
@@ -57,7 +57,7 @@ public:
 
   /// Read default slice view settings from application settings (.ini file)
   /// into defaultViewNode.
-  static void readDefaultSliceViewSettings(vtkMRMLSliceNode* defaultViewNode);
+  void readDefaultSliceViewSettings(vtkMRMLSliceNode* defaultViewNode);
 
   /// Read default 3D view settings from application settings (.ini file)
   /// into defaultViewNode.


### PR DESCRIPTION
User can choose between radiology and neurology view directions (patient left/right on screen right).