### PR TITLE
BUG: Fix logic that determines if a module is built-in

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.h
+++ b/Base/Logic/vtkSlicerApplicationLogic.h
@@ -206,7 +206,8 @@ class VTK_SLICER_BASE_LOGIC_EXPORT vtkSlicerApplicationLogic
   static bool IsPluginInstalled(const std::string& filePath, const std::string& applicationHomeDir);
 
   /// Return \a true if the plugin identified with its \a filePath is a built-in Slicer module.
-  static bool IsPluginBuiltIn(const std::string& filePath, const std::string& applicationHomeDir);
+  static bool IsPluginBuiltIn(const std::string& filePath, const std::string& applicationHomeDir,
+    const std::string& slicerRevision);
 
   /// Get share directory associated with \a moduleName located in \a filePath
   static std::string GetModuleShareDirectory(const std::string& moduleName, const std::string& filePath);

--- a/Base/QTCLI/qSlicerCLIModuleFactoryHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleFactoryHelper.cxx
@@ -79,5 +79,5 @@ bool qSlicerCLIModuleFactoryHelper::isInstalled(const QString& path)
 bool qSlicerCLIModuleFactoryHelper::isBuiltIn(const QString& path)
 {
   qSlicerCoreApplication * app = qSlicerCoreApplication::application();
-  return app ? qSlicerUtils::isPluginBuiltIn(path, app->slicerHome()) : true;
+  return app ? qSlicerUtils::isPluginBuiltIn(path, app->slicerHome(), app->revision()) : true;
 }

--- a/Base/QTCore/Testing/Cxx/qSlicerUtilsTest1.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerUtilsTest1.cxx
@@ -32,6 +32,7 @@
 
 // Slicer includes
 #include "vtkSlicerConfigure.h"
+#include "vtkSlicerVersionConfigure.h"
 
 // STD includes
 #include <cstdlib>
@@ -82,7 +83,7 @@ bool isPluginInstalledTest(int line, bool expectedResult,
 bool isPluginBuiltInTest(int line, bool expectedResult,
                            const QString& path, const QString& applicationHomeDir)
 {
-  bool res = qSlicerUtils::isPluginBuiltIn(path, applicationHomeDir);
+  bool res = qSlicerUtils::isPluginBuiltIn(path, applicationHomeDir, QString::fromUtf8(Slicer_REVISION));
   if (res != expectedResult)
     {
     QString msg("Line %1 - Problem with isPluginBuiltIn()\n\tpath: %2\n\tapplicationHomeDir: %3");

--- a/Base/QTCore/qSlicerLoadableModuleFactory.cxx
+++ b/Base/QTCore/qSlicerLoadableModuleFactory.cxx
@@ -46,7 +46,7 @@ qSlicerAbstractCoreModule* qSlicerLoadableModuleFactoryItem::instanciator()
 
   qSlicerCoreApplication * app = qSlicerCoreApplication::application();
   module->setInstalled(qSlicerUtils::isPluginInstalled(this->path(), app->slicerHome()));
-  module->setBuiltIn(qSlicerUtils::isPluginBuiltIn(this->path(), app->slicerHome()));
+  module->setBuiltIn(qSlicerUtils::isPluginBuiltIn(this->path(), app->slicerHome(), app->revision()));
 
   return module;
 }

--- a/Base/QTCore/qSlicerUtils.cxx
+++ b/Base/QTCore/qSlicerUtils.cxx
@@ -206,9 +206,9 @@ bool qSlicerUtils::isPluginInstalled(const QString& filePath, const QString& app
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerUtils::isPluginBuiltIn(const QString& filePath, const QString& applicationHomeDir)
+bool qSlicerUtils::isPluginBuiltIn(const QString& filePath, const QString& applicationHomeDir, const QString& applicationRevision)
 {
-  return vtkSlicerApplicationLogic::IsPluginBuiltIn(filePath.toStdString(), applicationHomeDir.toStdString());
+  return vtkSlicerApplicationLogic::IsPluginBuiltIn(filePath.toStdString(), applicationHomeDir.toStdString(), applicationRevision.toStdString());
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerUtils.h
+++ b/Base/QTCore/qSlicerUtils.h
@@ -92,7 +92,7 @@ public:
   static bool isPluginInstalled(const QString& filePath, const QString& applicationHomeDir);
 
   /// Return \a true if the plugin identified with its \a filePath is a built-in Slicer module.
-  static bool isPluginBuiltIn(const QString& filePath, const QString& applicationHomeDir);
+  static bool isPluginBuiltIn(const QString& filePath, const QString& applicationHomeDir, const QString& applicationRevision);
 
   /// Return the path without the intermediate directory or return \a path if there is no
   /// expected "IntDir".

--- a/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
+++ b/Base/QTGUI/qSlicerScriptedLoadableModuleFactory.cxx
@@ -75,7 +75,7 @@ qSlicerAbstractCoreModule* ctkFactoryScriptedItem::instanciator()
 
   qSlicerCoreApplication * app = qSlicerCoreApplication::application();
   module->setInstalled(qSlicerUtils::isPluginInstalled(this->path(), app->slicerHome()));
-  module->setBuiltIn(qSlicerUtils::isPluginBuiltIn(this->path(), app->slicerHome()));
+  module->setBuiltIn(qSlicerUtils::isPluginBuiltIn(this->path(), app->slicerHome(), app->revision()));
 
   bool ret = module->setPythonSource(this->path());
   if (!ret)


### PR DESCRIPTION
Modules in Extensions-<revision> folder must be always classified as not built-in, even if that folder is within the application folder.
Previously Extensions-<revision> folder only contained extension modules on macOS, but now since applications are fully portable, this folder contains extension modules on all operating systems.