### PR TITLE
Make Crop volume module compatible with Markups ROI node

### DIFF
--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.h
@@ -26,7 +26,7 @@
 class vtkSlicerCLIModuleLogic;
 class vtkSlicerVolumesLogic;
 class vtkMRMLVolumeNode;
-class vtkMRMLAnnotationROINode;
+class vtkMRMLDisplayableNode;
 // vtk includes
 class vtkMatrix4x4;
 // CropVolumes includes
@@ -76,20 +76,20 @@ public:
 
   /// Perform non-interpolated (voxel-based) cropping.
   /// If limitToInputExtent is set to true (default) then the extent can only be smaller than the input volume.
-  static int CropVoxelBased(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume,
+  static int CropVoxelBased(vtkMRMLDisplayableNode* roi, vtkMRMLVolumeNode* inputVolume,
     vtkMRMLVolumeNode* outputNode, bool limitToInputExtent=true, double fillValue=0.0);
 
   /// Compute non-interpolated (voxel-based) cropping output volume geometry (without actually cropping the image).
   /// If limitToInputExtent is set to true (default) then the extent can only be smaller than the input volume.
-  static bool GetVoxelBasedCropOutputExtent(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume,
+  static bool GetVoxelBasedCropOutputExtent(vtkMRMLDisplayableNode* roi, vtkMRMLVolumeNode* inputVolume,
     int outputExtent[6], bool limitToInputExtent=false);
 
   /// Perform interpolated cropping.
-  int CropInterpolated(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume, vtkMRMLVolumeNode* outputNode,
+  int CropInterpolated(vtkMRMLDisplayableNode* roi, vtkMRMLVolumeNode* inputVolume, vtkMRMLVolumeNode* outputNode,
     bool isotropicResampling, double spacingScale, int interpolationMode, double fillValue);
 
   /// Computes output volume geometry for interpolated cropping (without actually cropping the image).
-  static bool GetInterpolatedCropOutputGeometry(vtkMRMLAnnotationROINode* roi, vtkMRMLVolumeNode* inputVolume,
+  static bool GetInterpolatedCropOutputGeometry(vtkMRMLDisplayableNode* roi, vtkMRMLVolumeNode* inputVolume,
     bool isotropicResampling, double spacingScale, int outputExtent[6], double outputSpacing[3]);
 
   /// Sets ROI to fit to input volume.

--- a/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
+++ b/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.cxx
@@ -21,7 +21,7 @@ or http://www.slicer.org/copyright/copyright.txt for details.
 #include "vtkMRMLCropVolumeParametersNode.h"
 
 // AnnotationModuleMRML includes
-#include "vtkMRMLAnnotationROINode.h"
+#include "vtkMRMLDisplayableNode.h"
 
 // STD includes
 
@@ -176,9 +176,9 @@ const char * vtkMRMLCropVolumeParametersNode::GetROINodeID()
 }
 
 //----------------------------------------------------------------------------
-vtkMRMLAnnotationROINode* vtkMRMLCropVolumeParametersNode::GetROINode()
+vtkMRMLDisplayableNode* vtkMRMLCropVolumeParametersNode::GetROINode()
 {
-  return vtkMRMLAnnotationROINode::SafeDownCast(this->GetNodeReference(ROINodeReferenceRole));
+  return vtkMRMLDisplayableNode::SafeDownCast(this->GetNodeReference(ROINodeReferenceRole));
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.h
+++ b/Modules/Loadable/CropVolume/MRML/vtkMRMLCropVolumeParametersNode.h
@@ -20,7 +20,7 @@
 #include "vtkMRMLNode.h"
 #include "vtkSlicerCropVolumeModuleMRMLExport.h"
 
-class vtkMRMLAnnotationROINode;
+class vtkMRMLDisplayableNode;
 class vtkMRMLTransformNode;
 class vtkMRMLVolumeNode;
 
@@ -67,11 +67,12 @@ public:
   const char* GetOutputVolumeNodeID();
   vtkMRMLVolumeNode* GetOutputVolumeNode();
 
-  /// Set cropping region of interest
+  /// Set cropping region of interest.
+  /// It can be either vtkMRMLAnnotationROINode or vtkMRMLMarkupsROINode.
   void SetROINodeID(const char *nodeID);
   /// Get cropping region of interest
   const char* GetROINodeID();
-  vtkMRMLAnnotationROINode* GetROINode();
+  vtkMRMLDisplayableNode* GetROINode();
 
   /// Set transform node that may be used for aligning
   /// the ROI with the input volume.

--- a/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
+++ b/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
@@ -178,6 +178,7 @@
         <property name="nodeTypes">
          <stringlist>
           <string>vtkMRMLAnnotationROINode</string>
+          <string>vtkMRMLMarkupsROINode</string>
          </stringlist>
         </property>
         <property name="baseName">
@@ -724,23 +725,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>qMRMLCoordinatesWidget</class>
-   <extends>ctkCoordinatesWidget</extends>
-   <header>qMRMLCoordinatesWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerWidget</class>
-   <extends>QWidget</extends>
-   <header>qSlicerWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>ctkCheckBox</class>
    <extends>QCheckBox</extends>
    <header>ctkCheckBox.h</header>
@@ -765,6 +749,23 @@
    <class>ctkFittedTextBrowser</class>
    <extends>QTextBrowser</extends>
    <header>ctkFittedTextBrowser.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLCoordinatesWidget</class>
+   <extends>ctkCoordinatesWidget</extends>
+   <header>qMRMLCoordinatesWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
@@ -516,13 +516,9 @@ void vtkMRMLMarkupsROINode::GetCenter(double center_Local[3])
     vtkErrorMacro("GetCenter: Invalid origin argument");
     return;
     }
-
-  double center_Local4[4] = { 0.0, 0.0, 0.0, 1.0 };
-  this->ROIToLocalMatrix->MultiplyPoint(center_Local4, center_Local4);
-
-  center_Local[0] = center_Local4[0];
-  center_Local[1] = center_Local4[1];
-  center_Local[2] = center_Local4[2];
+  center_Local[0] = this->ROIToLocalMatrix->GetElement(0, 3);
+  center_Local[1] = this->ROIToLocalMatrix->GetElement(1, 3);
+  center_Local[2] = this->ROIToLocalMatrix->GetElement(2, 3);
 }
 
 //----------------------------------------------------------------------------
@@ -583,9 +579,9 @@ void vtkMRMLMarkupsROINode::SetCenter(const double center_Local[3])
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsROINode::SetSize(const double center[3])
+void vtkMRMLMarkupsROINode::SetSize(const double size[3])
 {
-  this->SetSize(center[0], center[1], center[2]);
+  this->SetSize(size[0], size[1], size[2]);
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
@@ -72,10 +72,16 @@ public:
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentMacro(vtkMRMLMarkupsROINode);
 
+  /// Apply the passed transformation to the ROI
+  void ApplyTransform(vtkAbstractTransform* transform) override;
+
   /// Length of the ROI sides
   vtkGetVector3Macro(Size, double);
   void SetSize(const double size[3]);
   void SetSize(double x, double y, double z);
+  void GetSizeWorld(double size_World[3]);
+  void SetSizeWorld(const double size_World[3]);
+  void SetSizeWorld(double x_World, double y_World, double z_World);
 
   /// Center of the ROI
   void GetCenter(double center[3]);
@@ -211,6 +217,7 @@ protected:
 
   bool IsUpdatingControlPointsFromROI{false};
   bool IsUpdatingROIFromControlPoints{false};
+  bool IsUpdatingInteractionHandleToWorldMatrix{false};
 
   vtkSmartPointer<vtkMatrix4x4> ROIToLocalMatrix;
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
@@ -190,7 +190,7 @@ void vtkSlicerROIRepresentation2D::UpdateCubeSourceFromMRML(vtkMRMLMarkupsROINod
     }
 
   double sideLengths[3] = { 0.0, 0.0, 0.0 };
-  roiNode->GetSize(sideLengths);
+  roiNode->GetSizeWorld(sideLengths);
   cubeSource->SetXLength(sideLengths[0]);
   cubeSource->SetYLength(sideLengths[1]);
   cubeSource->SetZLength(sideLengths[2]);
@@ -570,7 +570,7 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
   worldToROITransform->TransformVector(viewPlaneNormal4, viewPlaneNormal_ROI);
 
   double sideLengths[3] = { 0.0,  0.0, 0.0 };
-  roiNode->GetSize(sideLengths);
+  roiNode->GetSizeWorld(sideLengths);
   vtkMath::MultiplyScalar(sideLengths, 0.5);
 
   vtkNew<vtkPoints> roiPoints;
@@ -698,21 +698,5 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
     }
   roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleSFace, sFacePoint_ROI);
 
-  vtkNew<vtkTransform> worldToHandleTransform;
-  worldToHandleTransform->DeepCopy(this->HandleToWorldTransform);
-  worldToHandleTransform->Inverse();
-
-  vtkNew<vtkTransform> roiToHandleTransform;
-  roiToHandleTransform->Concatenate(roiToWorldMatrix);
-  roiToHandleTransform->Concatenate(worldToHandleTransform);
-
-  vtkNew<vtkPolyData> scaleHandlePoints;
-  scaleHandlePoints->SetPoints(roiPoints);
-
-  vtkNew<vtkTransformPolyDataFilter> transformHandlesWorldToHandleFilter;
-  transformHandlesWorldToHandleFilter->SetInputData(scaleHandlePoints);
-  transformHandlesWorldToHandleFilter->SetTransform(roiToHandleTransform);
-  transformHandlesWorldToHandleFilter->Update();
-
-  this->ScaleHandlePoints->SetPoints(transformHandlesWorldToHandleFilter->GetOutput()->GetPoints());
+  this->ScaleHandlePoints->SetPoints(roiPoints);
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
@@ -207,7 +207,7 @@ void vtkSlicerROIRepresentation3D::UpdateCubeSourceFromMRML(vtkMRMLMarkupsROINod
     }
 
   double sideLengths[3] = { 0.0, 0.0, 0.0 };
-  roiNode->GetSize(sideLengths);
+  roiNode->GetSizeWorld(sideLengths);
   cubeSource->SetXLength(sideLengths[0]);
   cubeSource->SetYLength(sideLengths[1]);
   cubeSource->SetZLength(sideLengths[2]);
@@ -641,7 +641,7 @@ void vtkSlicerROIRepresentation3D::MarkupsInteractionPipelineROI::UpdateScaleHan
     }
 
   double sideLengths[3] = { 0.0,  0.0, 0.0 };
-  roiNode->GetSize(sideLengths);
+  roiNode->GetSizeWorld(sideLengths);
   vtkMath::MultiplyScalar(sideLengths, 0.5);
 
   vtkNew<vtkPoints> roiPoints;
@@ -660,25 +660,7 @@ void vtkSlicerROIRepresentation3D::MarkupsInteractionPipelineROI::UpdateScaleHan
   roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleRPSCorner, sideLengths[0],  -sideLengths[1],  sideLengths[2]);
   roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleLASCorner, -sideLengths[0],  sideLengths[1],  sideLengths[2]);
   roiPoints->SetPoint(vtkMRMLMarkupsROINode::HandleRASCorner, sideLengths[0],   sideLengths[1],  sideLengths[2]);
-
-  vtkMatrix4x4* roiToWorldMatrix = roiNode->GetInteractionHandleToWorldMatrix();
-  vtkNew<vtkTransform> worldToHandleTransform;
-  worldToHandleTransform->DeepCopy(this->HandleToWorldTransform);
-  worldToHandleTransform->Inverse();
-
-  vtkNew<vtkTransform> roiToHandleTransform;
-  roiToHandleTransform->Concatenate(roiToWorldMatrix);
-  roiToHandleTransform->Concatenate(worldToHandleTransform);
-
-  vtkNew<vtkPolyData> scaleHandlePoints;
-  scaleHandlePoints->SetPoints(roiPoints);
-
-  vtkNew<vtkTransformPolyDataFilter> transform;
-  transform->SetInputData(scaleHandlePoints);
-  transform->SetTransform(roiToHandleTransform);
-  transform->Update();
-
-  this->ScaleHandlePoints->SetPoints(transform->GetOutput()->GetPoints());
+  this->ScaleHandlePoints->SetPoints(roiPoints);
 
   vtkIdTypeArray* visibilityArray = vtkIdTypeArray::SafeDownCast(this->ScaleHandlePoints->GetPointData()->GetArray("visibility"));
   visibilityArray->SetNumberOfValues(roiPoints->GetNumberOfPoints());

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIWidget.cxx
@@ -274,7 +274,7 @@ void vtkSlicerROIWidget::ScaleWidget(double eventPos[2], bool symmetricScale)
       }
 
     double oldSize[3] = { 0.0, 0.0, 0.0 };
-    markupsNode->GetSize(oldSize);
+    markupsNode->GetSizeWorld(oldSize);
 
     double scaleVector_World[3] = { 0.0, 0.0, 0.0 };
     vtkMath::Subtract(eventPos_World, lastEventPos_World, scaleVector_World);


### PR DESCRIPTION
This pull request makes Crop volume work with the new markups ROI. Markups ROI node has many advantages over Annotation ROI, for example that it can be rotated without applying a transform.