### PR TITLE
BUG: Prevent duplicate paths added to environment variables

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -267,19 +267,19 @@ void qSlicerCoreApplicationPrivate::init()
   QHash<QString, QStringList> pathsEnvVars = appLauncherSettings.pathsEnvVars();
   foreach(const QString& key, pathsEnvVars.keys())
     {
-    QString value = pathsEnvVars.value(key).join(appLauncherSettings.pathSep());
+    QString value;
     if (this->Environment.contains(key))
       {
-      if (!this->Environment.value(key).contains(value))
-        {
-        value = QString("%1%2%3").arg(value, appLauncherSettings.pathSep(), this->Environment.value(key));
-        q->setEnvironmentVariable(key, value);
-        }
+      QStringList consolidatedPaths;
+      consolidatedPaths << pathsEnvVars.value(key) << this->Environment.value(key).split(appLauncherSettings.pathSep());
+      consolidatedPaths.removeDuplicates();
+      value = consolidatedPaths.join(appLauncherSettings.pathSep());
       }
     else
       {
-      q->setEnvironmentVariable(key, value);
+      value = pathsEnvVars.value(key).join(appLauncherSettings.pathSep());
       }
+    q->setEnvironmentVariable(key, value);
     }
 
 #ifdef Slicer_USE_PYTHONQT_WITH_OPENSSL

--- a/Base/QTCore/qSlicerCorePythonManager.cxx
+++ b/Base/QTCore/qSlicerCorePythonManager.cxx
@@ -110,7 +110,13 @@ void qSlicerCorePythonManager::addVTKObjectToPythonMain(const QString& name, vtk
 void qSlicerCorePythonManager::appendPythonPath(const QString& path)
 {
   // TODO Make sure PYTHONPATH is updated
-  this->executeString(QString("import sys; sys.path.append(%1); del sys").arg(qSlicerCorePythonManager::toPythonStringLiteral(path)));
+  this->executeString(QString(
+    "import sys, os\n"
+    "___path = os.path.abspath(%1)\n"
+    "if ___path not in sys.path:\n"
+    "  sys.path.append(___path)\n"
+    "del sys, os"
+    ).arg(qSlicerCorePythonManager::toPythonStringLiteral(path)));
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -435,10 +435,10 @@ namespace
 // --------------------------------------------------------------------------
 bool hasPath(const QStringList& paths, const QString& pathToCheck)
 {
-  QDir dirToCheck(pathToCheck);
+  QString dirToCheck = QDir::cleanPath(pathToCheck);
   foreach(const QString& path, paths)
     {
-    if (dirToCheck == QDir(path))
+    if (dirToCheck == QDir::cleanPath(path))
       {
       return true;
       }
@@ -452,10 +452,17 @@ QStringList appendToPathList(const QStringList& paths, const QStringList& pathsT
   QStringList updatedPaths(paths);
   foreach(const QString& pathToAppend, pathsToAppend)
     {
-    if (!hasPath(paths, pathToAppend) && shouldExist ? QDir(pathToAppend).exists() : true)
+    if (hasPath(updatedPaths, pathToAppend))
       {
-      updatedPaths << pathToAppend;
+      // already inserted, skip it
+      continue;
       }
+    if (shouldExist && !QDir(pathToAppend).exists())
+      {
+      // only existing paths are asked to be added and this one does not exist, skip it
+      continue;
+      }
+    updatedPaths << pathToAppend;
     }
   return updatedPaths;
 }


### PR DESCRIPTION
Path environment variables could grow over 32k when installing a few extensions.
There were some checks trying to prevent adding duplicate paths, but they had logic flaws and some checks were missed.

I've discovered this because Elastix failed to launch because the environment was huge, with lots of duplicate entries in path, pythonpath, and librarypath. Hopefully this will fix the issue (I could not reproduce the massive amount of duplication in a debug-mode local build that occurred in a release build, with installing and updating many extensions).