### PR TITLE
BUG: Fix new segments appearing as hidden

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSegmentSelectorWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSegmentSelectorWidget.cxx
@@ -357,6 +357,21 @@ QStringList qMRMLSegmentSelectorWidget::selectedSegmentIDs()
 }
 
 //-----------------------------------------------------------------------------
+QStringList qMRMLSegmentSelectorWidget::segmentIDs()
+{
+  Q_D(qMRMLSegmentSelectorWidget);
+  QStringList allSegmentIDs;
+  // Update checkbox states in checkable combobox
+  for (int row = 0; row < d->CheckableComboBox_Segment->model()->rowCount(); ++row)
+    {
+    QModelIndex index = d->CheckableComboBox_Segment->model()->index(row, 0);
+    QString segmentID = d->CheckableComboBox_Segment->itemData(row).toString();
+    allSegmentIDs << segmentID;
+    }
+  return allSegmentIDs;
+}
+
+//-----------------------------------------------------------------------------
 void qMRMLSegmentSelectorWidget::setCurrentSegmentID(QString segmentID)
 {
   Q_D(qMRMLSegmentSelectorWidget);

--- a/Libs/MRML/Widgets/qMRMLSegmentSelectorWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSegmentSelectorWidget.h
@@ -74,6 +74,12 @@ public:
   /// Returns empty string in case of single selection (when \sa multiSelection is false)
   Q_INVOKABLE QStringList selectedSegmentIDs();
 
+  /// Get all segment IDs that this widget displays.
+  /// This list may differ from the list of segments in the segmentation node
+  /// during adding/removing of segments, because the segment list in the widget is only
+  /// updated when the segmentation node modification event is invoked.
+  Q_INVOKABLE QStringList segmentIDs();
+
   /// Return true if the "none" is in the segmentation node comboBox list, false otherwise.
   /// \sa noneEnabled, setNoneEnabled()
   bool noneEnabled()const;

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -1595,10 +1595,16 @@ void qMRMLSliceControllerWidgetPrivate::onSegmentVisibilitySelectionChanged(QStr
 
   std::vector<std::string> allSegmentIDs;
   segmentationNode->GetSegmentation()->GetSegmentIDs(allSegmentIDs);
+  QStringList segmentIdsInSegmentSelectorWidget(this->SegmentSelectorWidget->segmentIDs());
   std::vector<std::string>::iterator segmentIDIt;
   for (segmentIDIt = allSegmentIDs.begin(); segmentIDIt != allSegmentIDs.end(); ++segmentIDIt)
     {
     QString segmentID(segmentIDIt->c_str());
+    if (!segmentIdsInSegmentSelectorWidget.contains(segmentID))
+      {
+      // the segment selector widget does not know about this segment yet, so do not update the MRML node from it
+      continue;
+      }
     bool segmentVisibile = displayNode->GetSegmentVisibility(*segmentIDIt);
     // Hide segment that is visible but its checkbox has been unchecked
     if (segmentVisibile && !selectedSegmentIDs.contains(segmentID))


### PR DESCRIPTION
Segment selector widget in qMRMLSliceControllerWidget made segments hidden when the segmentation display node was updated earlier than the segmentation node.
The problem was that qMRMLSliceControllerWidget made all segments that were not in the segment selector widget hidden, and segments were not yet in the segment selector widget when they have just been added but node modified event was not yet invoked.

Fixed by not modifying visibility of those segments that are not yet in the segment selector widget.

Fixes #5533