### PR TITLE
BUG: Make cropping of vector volumes more intuitive

### DIFF
--- a/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
+++ b/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
@@ -261,6 +261,7 @@
         <property name="nodeTypes">
          <stringlist>
           <string>vtkMRMLScalarVolumeNode</string>
+          <string>vtkMRMLVectorVolumeNode</string>
          </stringlist>
         </property>
         <property name="baseName">
@@ -725,6 +726,23 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>qMRMLCoordinatesWidget</class>
+   <extends>ctkCoordinatesWidget</extends>
+   <header>qMRMLCoordinatesWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qSlicerWidget</class>
+   <extends>QWidget</extends>
+   <header>qSlicerWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>ctkCheckBox</class>
    <extends>QCheckBox</extends>
    <header>ctkCheckBox.h</header>
@@ -749,23 +767,6 @@
    <class>ctkFittedTextBrowser</class>
    <extends>QTextBrowser</extends>
    <header>ctkFittedTextBrowser.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLCoordinatesWidget</class>
-   <extends>ctkCoordinatesWidget</extends>
-   <header>qMRMLCoordinatesWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLNodeComboBox</class>
-   <extends>QWidget</extends>
-   <header>qMRMLNodeComboBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>qSlicerWidget</class>
-   <extends>QWidget</extends>
-   <header>qSlicerWidget.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModuleWidget.cxx
@@ -100,6 +100,19 @@ bool qSlicerCropVolumeModuleWidgetPrivate::checkInputs(bool& autoFixAvailable, Q
     return false;
     }
 
+  if (this->ParametersNode->GetOutputVolumeNode() && this->ParametersNode->GetInputVolumeNode()
+    && strcmp(this->ParametersNode->GetOutputVolumeNode()->GetClassName(), this->ParametersNode->GetInputVolumeNode()->GetClassName()) != 0)
+    {
+    message = qSlicerCropVolumeModuleWidget::tr("Output volume type does not match input volume type.");
+    autoFixAvailable = true;
+    if (autoFixProblems)
+      {
+      // create new node automatically
+      this->ParametersNode->SetOutputVolumeNodeID(nullptr);
+      }
+    return false;
+    }
+
   bool roiExists = true;
   bool inputVolumeTransformValid = true;
   bool roiTransformValid = true;


### PR DESCRIPTION
Crop volume requires the output volume node type to be the same as the input volume node type.
There was no option to create vector volume, therefore it was not possible to pre-create the output volume for vector volumes.
The error only appeared in the log.

Fixed by adding display of the error message in the module widget and added the option of creating vector volume output.

Addresses the problem reported by a user: https://discourse.slicer.org/t/crop-volume-reports-error-when-input-is-a-color-volume/16857