### PR TITLE
ENH: Optimize markups batch update speed

### DIFF
--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -473,6 +473,24 @@ public:
   /// \sa GetDisableModifiedEvent()
   vtkGetMacro(ModifiedEventPending, int);
 
+  /// Returns the number of times a custom modified event is requested
+  /// but not yet invoked on the node.
+  /// A modified even is pending (not yet invoked) if it was requested
+  /// after a StartModify() call and EndModify() is not called yet.
+  /// \sa GetModifiedEventPending()
+  int GetCustomModifiedEventPending(int eventId)
+    {
+    std::map< int, int >::iterator it = this->CustomModifiedEventPending.find(eventId);
+    if (it == this->CustomModifiedEventPending.end())
+      {
+      return 0;
+      }
+    else
+      {
+      return it->second;
+      }
+    }
+
   /// \brief Customized version of Modified() allowing to compress
   /// vtkCommand::ModifiedEvent.
   ///

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -163,6 +163,10 @@ public:
                                    unsigned long /*event*/,
                                    void * /*callData*/ ) override;
 
+  /// \brief End modifying the node.
+  /// Updates pending measurements and other updates.
+  /// \sa StartModify()
+  int EndModify(int previousDisableModifiedEventState) override;
 
   /// Create default storage node or nullptr if does not have one
   vtkMRMLStorageNode* CreateDefaultStorageNode() override;


### PR DESCRIPTION
Prevent updating the internal vtkPoints structure, interaction handles, and measurements from control points between StartModify/EndModify calls.
These are performed automatically in EndModify().

This makes point insertion fast, even if points are added one by one (but between StartModify/EndModify calls).

fixes #5564 (slow fcsv loading)