### PR TITLE
COMP: Update ITK to v5.2.0 and update SimpleITK

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "2b34388159c20c0a6334d9b174fc6c230853988c"  # March 12th 2021
+    "v5.2.0"
     QUIET
     )
 

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -122,7 +122,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "460f9c1553621b649f376bb1c07c94d4bdf6f055"  # March 2nd 2021
+    "1062acf7705dd53f0cf01789b7c4a3b4a1bf15a0"  # April 5th 2021
     QUIET
     )
 


### PR DESCRIPTION
This PR updates ITK to v5.2.0 and updates SimpleITK to a commit (https://github.com/SimpleITK/SimpleITK/commit/1062acf7705dd53f0cf01789b7c4a3b4a1bf15a0) where SimpleITK also updated to use ITK v5.2.0.

All Tests passed on the Windows platform
```
1>
1>100% tests passed, 0 tests failed out of 681
1>
```
Changelog:
```
ITK:
$ git shortlog --topo-order --no-merges 2b34388..v5.2.0
Bradley Lowekamp (2):
      BUG: Initialize member variables
      STYLE: Prefer in class initialization

Dženan Zukić (10):
      COMP: fix CMake Deprecation Warning (Compatibility with CMake < 2.8.12)
      ENH: update remote modules
      ENH: add Ultrasound remote module
      STYLE: mark ultrasound remote module enablement as advanced variable
      DOC: improve description of LBFGSERR_ROUNDING_ERROR stopping condition
      STYLE: use ReadImage and WriteImage in PolygonSpatialObjectIsInsideTest
      BUG: Fix crash in itk.image_from_xarray if is_vector and Dimension==4
      COMP: Fix CMake warning by setting policy 0120 to OLD
      ENH: update remote modules by running the script
      COMP: Disable CMake warning by setting policy 0120 to OLD

Flanz, Robert (1):
      BUG: Fix regression in PolygonSpatialObject::IsInsideInObjectSpace

Jon Haitz Legarreta Gorroño (5):
      COMP: Avoid creating a copy variable
      COMP: Fix unreachable code warning
      ENH: Label PRs on filenames
      ENH: Trigger PR labeler workflows from forks
      ENH: Increase code coverage

Lee Newberg (8):
      COMP: Fix gcc4.8 warnings + errors itkContourExtractor2DImageFilter.hxx
      COMP: Replace Type{} with Type() for gcc4.
      ENH: Mark most CMake variables as advanced
      COMP: Address ContourExtractor2DImageFilter valgrind defects
      PERF: Use std::unordered_map in itkContourExtractor2DImageFilter.
      BUG: Fix reference counts for HDF5 DataSet assignment operator
      STYLE: Mimic code that was reviewed for the upstream HDF5 source
      ENH: Support ArrayLike type with both numpy>=1.20 and numpy<1.20.

Matt McCormick (19):
      COMP: Wrap FastSymmetricForcesDemonsRegistrationFilter like its parent class
      DOC: Update notes for ITKExamples -> ITKSphinxExamples repository renaming
      ENH: Bump KWStyle to 2021-03-17 master
      STYLE: Remove extra itk prefix from support Python modules
      ENH: Add typehints for itk types to extras
      STYLE: Use modern, Pythonic style in ImageRegistration3.py
      BUG: Add __all__ to itk.support.init_helpers
      ENH: Add typehints for itk functional filters
      STYLE: black formatting on Python modules
      COMP: Set Windows Python CI version to 3.8
      COMP: Build PNG arm sources for aarch64 CMAKE_SYSTEM_PROCESSOR
      ENH: Add .process_object attribute to functional filters
      BUG: Set ElementType for wrapping PyVectorContainer
      COMP: Constrain x86_64 optimization flags according to CMAKE_SYSTEM_PROCESSOR
      COMP: Add lxmml for Windows Python CI build
      COMP: Do not explicitly instantiate Array in itkArrayTest
      COMP: Add tolerance for patch-based denoising tests on Apple M1
      DOC: Update .zenodo
      ENH: Update testing data content links for ITK 5.2.0

Mihail Isakov (1):
      COMP: Forward CMAKE_APPLE_SILICON_PROCESSOR

Niels Dekker (13):
      COMP: Avoid "message" naming conflicts when calling an exception macro
      STYLE: Inherit constructors (C++11) inside itkDeclareExceptionMacro
      STYLE: Remove ITK_MACROEND_NOOP_STATEMENT calls from exception macro's
      STYLE: Remove dynamic_casts PosteriorImage BayesianClassifierImageFilter
      COMP: Define ExceptionObject destructor out-of-line (doing Rule of Five)
      STYLE: Remove `;` from itkExceptionMacro PatchBasedDenoisingImageFilter
      COMP: Fix macOS clang warnings [-Wunused-variable] in test source files
      COMP: Fix macOS clang warning [-Wunused-variable] in itkMINCImageIOTest
      ENH: Make itk::Matrix trivially copyable, following Rule of Zero
      COMP: No longer test `is_trivially_copyable` in itkMatrixGTest on GCC 4
      COMP: Workaround Clang 3 error default initialization const MatrixGTest
      ENH: Add static member function, `itk::Matrix::GetIdentity()`
      STYLE: Default ImageBase default-constructor, call Matrix::GetIdentity()

Samuel Gerber (1):
      ENH: Add option to access index in point set registration

Sean McBride (1):
      COMP: fix link error building Universal Binary on Intel Mac

Simon Rit (1):
      COMP: add FFTW library directory to FFT module

Tom Birdsong (3):
      ENH: Expose numpy / vector container interface
      BUG: Wrap PyVectorContainer for all VectorContainer templates
      ENH: Type hints in functional interface

VXL Maintainers (2):
      VXL 2021-03-16 (e323b72d)
      VXL 2021-03-24 (188a98c0)

=====================================================================
SimpleITK:
$ git shortlog --topo-order --no-merges 460f9c1..1062acf
Bradley Lowekamp (8):
      Fix extra header line included in the sphinx code snip
      Add support to Python Image's getitem for meta-data dictionary access
      Add testing for the index based meta-data dictionary access in Python
      For Python Image class add support for ellipsis (...) indexing
      Update ITK superbuild version to after 5.2rc3
      Correct the name of the ImageIO used in the example.
      Remove unmatched endif
      Update ITK superbuild version to v5.2.0 tag

Dave Chen (11):
      Update IO docs
      added line num comment; adjusted line nos in doc
      make assert match python
      added R version
      added C# version
      added Java version
      added Lua version
      added Ruby version
      added TCL version
      Fixed C++ type assertion
      tweaked text
```
