### PR TITLE
BUG: Fix Segment Editor Undo/Redo button states

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -1268,9 +1268,7 @@ void qMRMLSegmentEditorWidget::updateWidgetFromMRML()
   this->updateEffectsSectionFromMRML();
 
   // Undo/redo section
-
-  d->UndoButton->setEnabled(!d->Locked);
-  d->RedoButton->setEnabled(!d->Locked);
+  this->updateUndoRedoButtonsState();
 
   // Masking section
   this->updateMaskingSection();
@@ -3116,11 +3114,17 @@ void qMRMLSegmentEditorWidget::redo()
 }
 
 //-----------------------------------------------------------------------------
-void qMRMLSegmentEditorWidget::onSegmentationHistoryChanged()
+void qMRMLSegmentEditorWidget::updateUndoRedoButtonsState()
 {
   Q_D(qMRMLSegmentEditorWidget);
-  d->UndoButton->setEnabled(d->SegmentationHistory->IsRestorePreviousStateAvailable());
-  d->RedoButton->setEnabled(d->SegmentationHistory->IsRestoreNextStateAvailable());
+  d->UndoButton->setEnabled(!d->Locked && d->SegmentationHistory->IsRestorePreviousStateAvailable());
+  d->RedoButton->setEnabled(!d->Locked && d->SegmentationHistory->IsRestoreNextStateAvailable());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentEditorWidget::onSegmentationHistoryChanged()
+{
+  this->updateUndoRedoButtonsState();
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
@@ -209,7 +209,7 @@ public:
   QString defaultTerminologyEntrySettingsKey() const;
 
   /// Set terminology entry string that is used for the first segment by default.
-  /// The value is alwo written to application settings, if defaultTerminologyEntrySettingsKey is not empty.
+  /// The value is also written to application settings, if defaultTerminologyEntrySettingsKey is not empty.
   void setDefaultTerminologyEntry(const QString& terminologyEntry);
   /// Get terminology entry string that is used for the first segment by default.
   /// The value is read from application settings, if defaultTerminologyEntrySettingsKey is not empty.
@@ -404,6 +404,9 @@ protected slots:
 
   /// Set default parameters in parameter set node (after setting or closing scene)
   void initializeParameterSetNode();
+
+  /// Update undo/redo button states
+  void updateUndoRedoButtonsState();
 
   /// Update GUI if segmentation history is changed (e.g., undo/redo button states)
   void onSegmentationHistoryChanged();


### PR DESCRIPTION
Undo/Redo buttons were enabled before having done anything in the module. A new function has been added that does both types of checks that are needed to decide enabled state for these buttons, and this function is called both from updateWidgetFromMRML and onSegmentationHistoryChanged.