### PR TITLE
BUG: Fix qMRMLCollapsibleButton pallete not updating on style change

### DIFF
--- a/Libs/MRML/Widgets/qMRMLCollapsibleButton.cxx
+++ b/Libs/MRML/Widgets/qMRMLCollapsibleButton.cxx
@@ -33,37 +33,10 @@ qMRMLCollapsibleButton::qMRMLCollapsibleButton(QWidget* parentWidget)
   :Superclass(parentWidget)
 {
   this->setAutoFillBackground(true);
-  this->computePalette();
 }
 
 // --------------------------------------------------------------------------
 void qMRMLCollapsibleButton::changeEvent(QEvent* event)
 {
-  if (event->type() == QEvent::ParentChange)
-    {
-    this->computePalette();
-    }
   this->Superclass::changeEvent(event);
-}
-
-void qMRMLCollapsibleButton::computePalette()
-{
-  QColor backgroundColor =
-    this->style()->standardPalette().color(QPalette::Window);
-  QObject* ancestor = this;
-  while(ancestor->parent())
-    {
-    ancestor = ancestor->parent();
-    if (qobject_cast<qMRMLCollapsibleButton*>(ancestor)||
-        qobject_cast<ctkCollapsibleButton*>(ancestor))
-      {
-      backgroundColor = backgroundColor.darker(108);
-      backgroundColor = QColor::fromHsvF(backgroundColor.hueF(),
-                                         backgroundColor.saturationF()*1.2,
-                                         backgroundColor.valueF());
-      }
-    }
-  QPalette newPalette = this->palette();
-  newPalette.setColor(QPalette::Window, backgroundColor);
-  this->setPalette(newPalette);
 }

--- a/Libs/MRML/Widgets/qMRMLCollapsibleButton.h
+++ b/Libs/MRML/Widgets/qMRMLCollapsibleButton.h
@@ -39,7 +39,6 @@ public:
   ~qMRMLCollapsibleButton() override = default;
 protected:
   void changeEvent(QEvent* event) override;
-  void computePalette();
 };
 
 #endif


### PR DESCRIPTION
This closes #5135.

Open Slicer and go to a module that uses a qMRMLCollapsibleButton such as the Markups module Display section. Then change the Slicer style in the settings area.

| Current | This PR |
|----------|---------|
|![image](https://user-images.githubusercontent.com/15837524/113921434-ffb62780-97b3-11eb-8528-4725cc45923f.png)|![image](https://user-images.githubusercontent.com/15837524/113921409-f88f1980-97b3-11eb-9802-e09b306b103f.png)|