### PR TITLE
BUG: Fix closeTemporaryDatabase to re-open original database only if it exists

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -305,10 +305,13 @@ def closeTemporaryDatabase(originalDatabaseDir, cleanup=True):
   settings = qt.QSettings()
   settings.setValue(slicer.dicomDatabaseDirectorySettingsKey, originalDatabaseDir)
 
-  success = openDatabase(originalDatabaseDir)
-  if not success:
-    logging.error('Unable to open DICOM database ' + originalDatabaseDir)
-    return False
+  # Attempt to re-open orginal database only if it exists
+  if os.access(originalDatabaseDir, os.F_OK):
+    success = openDatabase(originalDatabaseDir)
+    if not success:
+      logging.error('Unable to open DICOM database ' + originalDatabaseDir)
+      return False
+
   return True
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This commit avoids reporting error on system where no original database
was created.