### PR TITLE
Improve markups label visibility

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -969,18 +969,44 @@ void vtkSlicerMarkupsLogic::CopyBasicDisplayProperties(vtkMRMLMarkupsDisplayNode
     return;
     }
   MRMLNodeModifyBlocker blocker(targetDisplayNode);
-  targetDisplayNode->SetSelectedColor(sourceDisplayNode->GetSelectedColor());
-  targetDisplayNode->SetColor(sourceDisplayNode->GetColor());
-  targetDisplayNode->SetActiveColor(sourceDisplayNode->GetActiveColor());
-  targetDisplayNode->SetOpacity(sourceDisplayNode->GetOpacity());
+  targetDisplayNode->SetSnapMode(sourceDisplayNode->GetSnapMode());
+  targetDisplayNode->SetPropertiesLabelVisibility(sourceDisplayNode->GetPropertiesLabelVisibility());
+  targetDisplayNode->SetPointLabelsVisibility(sourceDisplayNode->GetPointLabelsVisibility());
+  targetDisplayNode->SetFillVisibility(sourceDisplayNode->GetFillVisibility());
+  targetDisplayNode->SetOutlineVisibility(sourceDisplayNode->GetOutlineVisibility());
+  targetDisplayNode->SetFillOpacity(sourceDisplayNode->GetFillOpacity());
+  targetDisplayNode->SetOutlineOpacity(sourceDisplayNode->GetOutlineOpacity());
+  targetDisplayNode->SetTextScale(sourceDisplayNode->GetTextScale());
+
   targetDisplayNode->SetGlyphType(sourceDisplayNode->GetGlyphType());
   targetDisplayNode->SetGlyphScale(sourceDisplayNode->GetGlyphScale());
   targetDisplayNode->SetGlyphSize(sourceDisplayNode->GetGlyphSize());
   targetDisplayNode->SetUseGlyphScale(sourceDisplayNode->GetUseGlyphScale());
-  targetDisplayNode->SetTextScale(sourceDisplayNode->GetTextScale());
+
   targetDisplayNode->SetSliceProjection(sourceDisplayNode->GetSliceProjection());
+  targetDisplayNode->SetSliceProjectionUseFiducialColor(sourceDisplayNode->GetSliceProjectionUseFiducialColor());
+  targetDisplayNode->SetSliceProjectionOutlinedBehindSlicePlane(sourceDisplayNode->GetSliceProjectionOutlinedBehindSlicePlane());
   targetDisplayNode->SetSliceProjectionColor(sourceDisplayNode->GetSliceProjectionColor());
   targetDisplayNode->SetSliceProjectionOpacity(sourceDisplayNode->GetSliceProjectionOpacity());
+
+  targetDisplayNode->SetCurveLineSizeMode(sourceDisplayNode->GetCurveLineSizeMode());
+  targetDisplayNode->SetLineThickness(sourceDisplayNode->GetLineThickness());
+  targetDisplayNode->SetLineDiameter(sourceDisplayNode->GetLineDiameter());
+
+  targetDisplayNode->SetLineColorFadingStart(sourceDisplayNode->GetLineColorFadingStart());
+  targetDisplayNode->SetLineColorFadingEnd(sourceDisplayNode->GetLineColorFadingEnd());
+  targetDisplayNode->SetLineColorFadingSaturation(sourceDisplayNode->GetLineColorFadingSaturation());
+  targetDisplayNode->SetLineColorFadingHueOffset(sourceDisplayNode->GetLineColorFadingHueOffset());
+
+  targetDisplayNode->SetOccludedVisibility(sourceDisplayNode->GetOccludedVisibility());
+  targetDisplayNode->SetOccludedOpacity(sourceDisplayNode->GetOccludedOpacity());
+  std::string textPropertyStr = vtkMRMLMarkupsDisplayNode::GetTextPropertyAsString(sourceDisplayNode->GetTextProperty());
+  vtkMRMLMarkupsDisplayNode::UpdateTextPropertyFromString(textPropertyStr, targetDisplayNode->GetTextProperty());
+
+  targetDisplayNode->SetSelectedColor(sourceDisplayNode->GetSelectedColor());
+  targetDisplayNode->SetColor(sourceDisplayNode->GetColor());
+  targetDisplayNode->SetActiveColor(sourceDisplayNode->GetActiveColor());
+  targetDisplayNode->SetOpacity(sourceDisplayNode->GetOpacity());
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -825,8 +825,8 @@ std::string vtkMRMLMarkupsDisplayNode::GetTextPropertyAsString(vtkTextProperty* 
     }
   ss << (textProperty->GetFrame() ? "1.0" : "0.0") << ");";
   ss << "text-shadow:";
-  ss << textProperty->GetShadowOffset()[0] << "px " << textProperty->GetShadowOffset()[0] << "px ";
-  ss << "0px "; // blur radius
+  ss << textProperty->GetShadowOffset()[0] << "px " << textProperty->GetShadowOffset()[1] << "px ";
+  ss << "2px "; // blur radius (used in CSS but not supported in VTK yet)
   ss << "rgba(0,0,0," << (textProperty->GetShadow() ? "1.0" : "0.0") << ");";
   return ss.str();
 }
@@ -916,11 +916,11 @@ void vtkMRMLMarkupsDisplayNode::UpdateTextPropertyFromString(std::string inputSt
     else if (key == "text-shadow")
       {
 #if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
-      std::vector<std::string> shadowProperties = vtksys::SystemTools::SplitString(textPropertyString, ' ');
+      std::vector<std::string> shadowProperties = vtksys::SystemTools::SplitString(keyValue[1], ' ');
 #else
-      std::vector<vtksys::String> shadowProperties = vtksys::SystemTools::SplitString(textPropertyString, ' ');
+      std::vector<vtksys::String> shadowProperties = vtksys::SystemTools::SplitString(keyValue[1], ' ');
 #endif
-      int shadowOffset[2] = { 0,0 };
+      int shadowOffset[2] = { 2, 2 };
       int shadowPropertyIndex = 0;
 #if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 90)
       for (std::string shadowProperty : shadowProperties)

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -118,6 +118,8 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   vtkNew<vtkTextProperty> textProperty;
   textProperty->SetBackgroundOpacity(0.0);
   textProperty->SetFontSize(5);
+  textProperty->BoldOn();
+  textProperty->ShadowOn();
   vtkSetAndObserveMRMLObjectMacro(this->TextProperty, textProperty);
 
   this->ActiveColor[0] = 0.4; // bright green

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -429,6 +429,14 @@ public:
   /// Update scalar range and update markups pipeline when the active scalar array is changed
   virtual void UpdateAssignedAttribute() override;
 
+  // Returns a string containing the text style of the vtkTextProperty.
+  // String format follows html-style CSS conventions.
+  static std::string GetTextPropertyAsString(vtkTextProperty* property);
+
+  // Update the style of a vtkTextProperty from a string.
+  // String format follows html-style CSS conventions.
+  static void UpdateTextPropertyFromString(std::string inputString, vtkTextProperty* property);
+
 protected:
   vtkMRMLMarkupsDisplayNode();
   ~vtkMRMLMarkupsDisplayNode() override;
@@ -442,14 +450,6 @@ protected:
   // Return a string representing the text style
   // String format follows html-style conventions
   std::string GetTextPropertyAsString();
-
-  // Returns a string containing the text style of the vtkTextProperty
-  // String format follows html-style conventions
-  static std::string GetTextPropertyAsString(vtkTextProperty* property);
-
-  // Update the style of a vtkTextProperty from a string
-  // String format follows html-style conventions
-  static void UpdateTextPropertyFromString(std::string inputString, vtkTextProperty* property);
 
   // Get the color from a string of the form: rgba(0,0,0,0)
   static void GetColorFromString(const std::string& colorString, double color[4]);

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -198,11 +198,129 @@ void qSlicerMarkupsModule::readDefaultMarkupsDisplaySettings(vtkMRMLMarkupsDispl
     return;
     }
   QSettings settings;
+
+  if (settings.contains("Markups/SnapMode"))
+    {
+    markupsDisplayNode->SetSnapMode(vtkMRMLMarkupsDisplayNode::GetSnapModeFromString(
+      settings.value("Markups/SnapMode").toString().toUtf8()));
+    }
+  if (settings.contains("Markups/PropertiesLabelVisibility"))
+    {
+    markupsDisplayNode->SetPropertiesLabelVisibility(settings.value("Markups/PropertiesLabelVisibility").toBool());
+    }
+  if (settings.contains("Markups/PointLabelsVisibility"))
+    {
+    markupsDisplayNode->SetPointLabelsVisibility(settings.value("Markups/PointLabelsVisibility").toBool());
+    }
+  if (settings.contains("Markups/FillVisibility"))
+    {
+    markupsDisplayNode->SetFillVisibility(settings.value("Markups/FillVisibility").toBool());
+    }
+  if (settings.contains("Markups/OutlineVisibility"))
+    {
+    markupsDisplayNode->SetOutlineVisibility(settings.value("Markups/OutlineVisibility").toBool());
+    }
+  if (settings.contains("Markups/FillOpacity"))
+    {
+    markupsDisplayNode->SetFillOpacity(settings.value("Markups/FillOpacity").toDouble());
+    }
+  if (settings.contains("Markups/OutlineOpacity"))
+    {
+    markupsDisplayNode->SetOutlineOpacity(settings.value("Markups/OutlineOpacity").toDouble());
+    }
+  if (settings.contains("Markups/TextScale"))
+    {
+    markupsDisplayNode->SetTextScale(settings.value("Markups/TextScale").toDouble());
+    }
   if (settings.contains("Markups/GlyphType"))
     {
     markupsDisplayNode->SetGlyphType(vtkMRMLMarkupsDisplayNode::GetGlyphTypeFromString(
       settings.value("Markups/GlyphType").toString().toUtf8()));
     }
+  if (settings.contains("Markups/GlyphScale"))
+    {
+    markupsDisplayNode->SetGlyphScale(settings.value("Markups/GlyphScale").toDouble());
+    }
+  if (settings.contains("Markups/GlyphSize"))
+    {
+    markupsDisplayNode->SetGlyphSize(settings.value("Markups/GlyphSize").toDouble());
+    }
+  if (settings.contains("Markups/UseGlyphScale"))
+    {
+    markupsDisplayNode->SetUseGlyphScale(settings.value("Markups/UseGlyphScale").toBool());
+    }
+
+  if (settings.contains("Markups/SliceProjection"))
+    {
+    markupsDisplayNode->SetSliceProjection(settings.value("Markups/SliceProjection").toBool());
+    }
+  if (settings.contains("Markups/SliceProjectionUseFiducialColor"))
+    {
+    markupsDisplayNode->SetSliceProjectionUseFiducialColor(settings.value("Markups/SliceProjectionUseFiducialColor").toBool());
+    }
+  if (settings.contains("Markups/SliceProjectionOutlinedBehindSlicePlane"))
+    {
+    markupsDisplayNode->SetSliceProjectionOutlinedBehindSlicePlane(settings.value("Markups/SliceProjectionOutlinedBehindSlicePlane").toBool());
+    }
+  if (settings.contains("Markups/SliceProjectionColor"))
+    {
+    QVariant variant = settings.value("Markups/SliceProjectionColor");
+    QColor qcolor = variant.value<QColor>();
+    markupsDisplayNode->SetSliceProjectionColor(qcolor.redF(), qcolor.greenF(), qcolor.blueF());
+    }
+  if (settings.contains("Markups/SliceProjectionOpacity"))
+    {
+    markupsDisplayNode->SetSliceProjectionOpacity(settings.value("Markups/SliceProjectionOpacity").toDouble());
+    }
+
+
+  if (settings.contains("Markups/CurveLineSizeMode"))
+    {
+    markupsDisplayNode->SetCurveLineSizeMode(vtkMRMLMarkupsDisplayNode::GetCurveLineSizeModeFromString(
+      settings.value("Markups/CurveLineSizeMode").toString().toUtf8()));
+    }
+  if (settings.contains("Markups/LineThickness"))
+    {
+    markupsDisplayNode->SetLineThickness(settings.value("Markups/LineThickness").toDouble());
+    }
+  if (settings.contains("Markups/LineDiameter"))
+    {
+    markupsDisplayNode->SetLineDiameter(settings.value("Markups/LineDiameter").toDouble());
+    }
+
+  if (settings.contains("Markups/LineColorFadingStart"))
+    {
+    markupsDisplayNode->SetLineColorFadingStart(settings.value("Markups/LineColorFadingStart").toDouble());
+    }
+  if (settings.contains("Markups/LineColorFadingEnd"))
+    {
+    markupsDisplayNode->SetLineColorFadingEnd(settings.value("Markups/LineColorFadingEnd").toDouble());
+    }
+  if (settings.contains("Markups/LineColorFadingSaturation"))
+    {
+    markupsDisplayNode->SetLineColorFadingSaturation(settings.value("Markups/LineColorFadingSaturation").toDouble());
+    }
+  if (settings.contains("Markups/LineColorFadingHueOffset"))
+    {
+    markupsDisplayNode->SetLineColorFadingHueOffset(settings.value("Markups/LineColorFadingHueOffset").toDouble());
+    }
+
+  if (settings.contains("Markups/OccludedVisibility"))
+    {
+    markupsDisplayNode->SetOccludedVisibility(settings.value("Markups/OccludedVisibility").toBool());
+    }
+  if (settings.contains("Markups/OccludedOpacity"))
+    {
+    markupsDisplayNode->SetOccludedOpacity(settings.value("Markups/OccludedOpacity").toDouble());
+    }
+
+  if (settings.contains("Markups/TextProperty"))
+    {
+    vtkMRMLMarkupsDisplayNode::UpdateTextPropertyFromString(
+      settings.value("Markups/TextProperty").toString().toStdString(),
+      markupsDisplayNode->GetTextProperty());
+    }
+
   if (settings.contains("Markups/SelectedColor"))
     {
     QVariant variant = settings.value("Markups/SelectedColor");
@@ -221,39 +339,9 @@ void qSlicerMarkupsModule::readDefaultMarkupsDisplaySettings(vtkMRMLMarkupsDispl
     QColor qcolor = variant.value<QColor>();
     markupsDisplayNode->SetColor(qcolor.redF(), qcolor.greenF(), qcolor.blueF());
     }
-  if (settings.contains("Markups/UseGlyphScale"))
-    {
-    markupsDisplayNode->SetUseGlyphScale(settings.value("Markups/UseGlyphScale").toBool());
-    }
-  if (settings.contains("Markups/GlyphScale"))
-    {
-    markupsDisplayNode->SetGlyphScale(settings.value("Markups/GlyphScale").toDouble());
-    }
-  if (settings.contains("Markups/GlyphSize"))
-    {
-    markupsDisplayNode->SetGlyphSize(settings.value("Markups/GlyphSize").toDouble());
-    }
-  if (settings.contains("Markups/TextScale"))
-    {
-    markupsDisplayNode->SetTextScale(settings.value("Markups/TextScale").toDouble());
-    }
   if (settings.contains("Markups/Opacity"))
     {
     markupsDisplayNode->SetOpacity(settings.value("Markups/Opacity").toDouble());
-    }
-  if (settings.contains("Markups/SliceProjection"))
-    {
-    markupsDisplayNode->SetSliceProjection(settings.value("Markups/SliceProjection").toBool());
-    }
-  if (settings.contains("Markups/SliceProjectionColor"))
-    {
-    QVariant variant = settings.value("Markups/SliceProjectionColor");
-    QColor qcolor = variant.value<QColor>();
-    markupsDisplayNode->SetSliceProjectionColor(qcolor.redF(), qcolor.greenF(), qcolor.blueF());
-    }
-  if (settings.contains("Markups/SliceProjectionOpacity"))
-    {
-    markupsDisplayNode->SetSliceProjectionOpacity(settings.value("Markups/SliceProjectionOpacity").toDouble());
     }
 }
 
@@ -267,23 +355,49 @@ void qSlicerMarkupsModule::writeDefaultMarkupsDisplaySettings(vtkMRMLMarkupsDisp
     }
   QSettings settings;
 
-  settings.setValue("Markups/GlyphType", vtkMRMLMarkupsDisplayNode::GetGlyphTypeAsString(
-    markupsDisplayNode->GetGlyphType()));
+  settings.setValue("Markups/SnapMode", vtkMRMLMarkupsDisplayNode::GetSnapModeAsString(
+    markupsDisplayNode->GetSnapMode()));
+  settings.setValue("Markups/PropertiesLabelVisibility", markupsDisplayNode->GetPropertiesLabelVisibility());
 
-  double* color = markupsDisplayNode->GetSelectedColor();
+  settings.setValue("Markups/PointLabelsVisibility", markupsDisplayNode->GetPointLabelsVisibility());
+  settings.setValue("Markups/FillVisibility", markupsDisplayNode->GetFillVisibility());
+  settings.setValue("Markups/OutlineVisibility", markupsDisplayNode->GetOutlineVisibility());
+  settings.setValue("Markups/FillOpacity", markupsDisplayNode->GetFillOpacity());
+  settings.setValue("Markups/OutlineOpacity", markupsDisplayNode->GetOutlineOpacity());
+  settings.setValue("Markups/TextScale", markupsDisplayNode->GetTextScale());
+
+  settings.setValue("Markups/GlyphType", vtkMRMLMarkupsDisplayNode::GetGlyphTypeAsString(markupsDisplayNode->GetGlyphType()));
+  settings.setValue("Markups/GlyphScale", markupsDisplayNode->GetGlyphScale());
+  settings.setValue("Markups/GlyphSize", markupsDisplayNode->GetGlyphSize());
+  settings.setValue("Markups/UseGlyphScale", markupsDisplayNode->GetUseGlyphScale());
+
+  settings.setValue("Markups/SliceProjection", markupsDisplayNode->GetSliceProjection());
+  settings.setValue("Markups/SliceProjectionUseFiducialColor", markupsDisplayNode->GetSliceProjectionUseFiducialColor());
+  settings.setValue("Markups/SliceProjectionOutlinedBehindSlicePlane", markupsDisplayNode->GetSliceProjectionOutlinedBehindSlicePlane());
+  double* color = markupsDisplayNode->GetSliceProjectionColor();
+  settings.setValue("Markups/SliceProjectionColor", QColor::fromRgbF(color[0], color[1], color[2]));
+  settings.setValue("Markups/SliceProjectionOpacity", markupsDisplayNode->GetSliceProjectionOpacity());
+
+  settings.setValue("Markups/CurveLineSizeMode", vtkMRMLMarkupsDisplayNode::GetCurveLineSizeModeAsString(markupsDisplayNode->GetCurveLineSizeMode()));
+  settings.setValue("Markups/LineThickness", markupsDisplayNode->GetLineThickness());
+  settings.setValue("Markups/LineDiameter", markupsDisplayNode->GetLineDiameter());
+
+  settings.setValue("Markups/LineColorFadingStart", markupsDisplayNode->GetLineColorFadingStart());
+  settings.setValue("Markups/LineColorFadingEnd", markupsDisplayNode->GetLineColorFadingEnd());
+  settings.setValue("Markups/LineColorFadingSaturation", markupsDisplayNode->GetLineColorFadingSaturation());
+  settings.setValue("Markups/LineLineColorFadingHueOffset", markupsDisplayNode->GetLineColorFadingHueOffset());
+
+  settings.setValue("Markups/OccludedVisibility", markupsDisplayNode->GetOccludedVisibility());
+  settings.setValue("Markups/OccludedOpacity", markupsDisplayNode->GetOccludedOpacity());
+
+  settings.setValue("Markups/TextProperty", QString::fromStdString(
+    vtkMRMLMarkupsDisplayNode::GetTextPropertyAsString(markupsDisplayNode->GetTextProperty())));
+
+  color = markupsDisplayNode->GetSelectedColor();
   settings.setValue("Markups/SelectedColor", QColor::fromRgbF(color[0], color[1], color[2]));
   color = markupsDisplayNode->GetColor();
   settings.setValue("Markups/UnselectedColor", QColor::fromRgbF(color[0], color[1], color[2]));
   color = markupsDisplayNode->GetActiveColor();
   settings.setValue("Markups/ActiveColor", QColor::fromRgbF(color[0], color[1], color[2]));
-  settings.setValue("Markups/UseGlyphScale", markupsDisplayNode->GetUseGlyphScale());
-  settings.setValue("Markups/GlyphScale", markupsDisplayNode->GetGlyphScale());
-  settings.setValue("Markups/GlyphSize", markupsDisplayNode->GetGlyphSize());
-  settings.setValue("Markups/TextScale", markupsDisplayNode->GetTextScale());
   settings.setValue("Markups/Opacity", markupsDisplayNode->GetOpacity());
-
-  settings.setValue("Markups/SliceProjection", markupsDisplayNode->GetSliceProjection());
-  color = markupsDisplayNode->GetSliceProjectionColor();
-  settings.setValue("Markups/SliceProjectionColor", QColor::fromRgbF(color[0], color[1], color[2]));
-  settings.setValue("Markups/SliceProjectionOpacity", markupsDisplayNode->GetSliceProjectionOpacity());
 }


### PR DESCRIPTION
Change default to enable shadow and bold. Fix bug in saving/restoring shadow properties. Allow saving all markups display properties.

See discussion here: https://discourse.slicer.org/t/improve-markups-label-visibility/17022/10
