### PR TITLE
STYLE: Remove unnecessary trailing semicolon in python code

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CLIEventTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLIEventTest.py
@@ -105,7 +105,7 @@ class CLIEventTestTest(ScriptedLoadableModuleTest):
   def _testCLIStatusEventTest(self, wait_for_completion):
     self.delayDisplay('Testing status events for a normal execution of a CLI')
 
-    tempFile = qt.QTemporaryFile("CLIEventTest-outputFile-XXXXXX");
+    tempFile = qt.QTemporaryFile("CLIEventTest-outputFile-XXXXXX")
     self.assertTrue(tempFile.open())
 
     logic = CLIEventTestLogic()
@@ -147,7 +147,7 @@ class CLIEventTestTest(ScriptedLoadableModuleTest):
   def _testCLIStatusEventOnErrorTest(self, wait_for_completion):
     self.delayDisplay('Testing status events for a bad execution of a CLI')
 
-    tempFile = qt.QTemporaryFile("CLIEventTest-outputFile-XXXXXX");
+    tempFile = qt.QTemporaryFile("CLIEventTest-outputFile-XXXXXX")
     self.assertTrue(tempFile.open())
 
     logic = CLIEventTestLogic()
@@ -183,7 +183,7 @@ class CLIEventTestTest(ScriptedLoadableModuleTest):
   def test_CLIStatusEventTestCancel(self):
     self.delayDisplay('Testing status events when cancelling the execution of a CLI')
 
-    tempFile = qt.QTemporaryFile("CLIEventTest-outputFile-XXXXXX");
+    tempFile = qt.QTemporaryFile("CLIEventTest-outputFile-XXXXXX")
     self.assertTrue(tempFile.open())
 
     logic = CLIEventTestLogic()

--- a/Applications/SlicerApp/Testing/Python/Charting.py
+++ b/Applications/SlicerApp/Testing/Python/Charting.py
@@ -187,7 +187,7 @@ class ChartingTest(ScriptedLoadableModuleTest):
     cn.SetProperty('default', 'title', 'A bar chart')
     cn.SetProperty('default', 'xAxisLabel', 'time')
     cn.SetProperty('default', 'yAxisLabel', 'velocity')
-    cn.SetProperty('default', 'type', 'Bar');
+    cn.SetProperty('default', 'type', 'Bar')
 
     # Set the chart to display
     cvn.SetChartNodeID(cn.GetID())
@@ -225,7 +225,7 @@ class ChartingTest(ScriptedLoadableModuleTest):
     cn.SetProperty('default', 'xAxisLabel', 'date')
     cn.SetProperty('default', 'xAxisType', 'date')
     cn.SetProperty('default', 'yAxisLabel', 'size (cm)')
-    cn.SetProperty('default', 'type', 'Bar');
+    cn.SetProperty('default', 'type', 'Bar')
 
     # Set the chart to display
     cvn.SetChartNodeID(cn.GetID())
@@ -262,7 +262,7 @@ class ChartingTest(ScriptedLoadableModuleTest):
     cn.SetProperty('default', 'xAxisLabel', 'structure')
     cn.SetProperty('default', 'xAxisType', 'categorical')
     cn.SetProperty('default', 'yAxisLabel', 'size (cm)')
-    cn.SetProperty('default', 'type', 'Bar');
+    cn.SetProperty('default', 'type', 'Bar')
     cn.SetProperty('Volumes', 'lookupTable', slicer.util.getNode('GenericAnatomyColors').GetID() )
 
     # Set the chart to display
@@ -319,7 +319,7 @@ class ChartingTest(ScriptedLoadableModuleTest):
     cn.SetProperty('default', 'xAxisLabel', 'population')
     cn.SetProperty('default', 'xAxisType', 'categorical')
     cn.SetProperty('default', 'yAxisLabel', 'size (ml)')
-    cn.SetProperty('default', 'type', 'Box');
+    cn.SetProperty('default', 'type', 'Box')
 
     # Set the chart to display
     cvn.SetChartNodeID(cn.GetID())

--- a/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
+++ b/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
@@ -105,7 +105,7 @@ class FiducialLayoutSwitchBug1914Logic(ScriptedLoadableModuleLogic):
     # test difference in display location and then in RAS if this is too fine
     self.maximumDisplayDifference = 1.0
     # for future testing: take into account the volume voxel size
-    self.maximumRASDifference = 1.0;
+    self.maximumRASDifference = 1.0
 
   def getFiducialSliceDisplayableManagerHelper(self,sliceName='Red'):
     sliceWidget = slicer.app.layoutManager().sliceWidget(sliceName)

--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -231,7 +231,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
       dicomRetrieve.setCalledAETitle('DCMTK')
       dicomRetrieve.setPort(12345)
       dicomRetrieve.setHost('localhost')
-      dicomRetrieve.getStudy('1.2.124.113932.1.170.223.162.178.20050502.160340.12640015');
+      dicomRetrieve.getStudy('1.2.124.113932.1.170.223.162.178.20050502.160340.12640015')
       popen.kill()
 
       # Select first patient
@@ -281,7 +281,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
       self.delayDisplay('Conventional, Link, Slice Model')
       layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
       redWidget.sliceController().setSliceLink(True)
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
 
       self.delayDisplay('Rotate')
       threeDView = layoutManager.threeDWidget(0).threeDView()
@@ -330,7 +330,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
 
       self.delayDisplay('Models and Slice Model')
       mainWindow.moduleSelector().selectModule('Models')
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
 
       self.delayDisplay('Scroll Slices')
       for offset in range(-20,20,2):
@@ -347,7 +347,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
       skull.GetDisplayNode().SetVisibility(0)
 
       self.delayDisplay('Green slice and Clipping')
-      greenWidget.sliceController().setSliceVisible(True);
+      greenWidget.sliceController().setSliceVisible(True)
       hemispheric_white_matter = slicer.util.getNode(pattern='hemispheric_white_matter.vtk')
       hemispheric_white_matter.GetDisplayNode().SetClipping(1)
       clip = slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLClipModelsNode')
@@ -422,7 +422,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
       cameraNode.GetCamera().Elevation(-30)
 
       segmentVII = slicer.util.getNode('LiverSegment_II')
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
 
       self.delayDisplay('Middle Hepatic')
       models = slicer.util.getNodes('vtkMRMLModelNode*')
@@ -435,7 +435,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
         modelNode = slicer.util.getNode(nodeName)
         modelNode.GetDisplayNode().SetOpacity(0.5)
         modelNode.GetDisplayNode().SetVisibility(1)
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
       cameraNode.GetCamera().Azimuth(30)
       cameraNode.GetCamera().Elevation(-20)
 
@@ -480,7 +480,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
       self.delayDisplay('View Question 1')
       cameraNode.GetCamera().Azimuth(-100)
       cameraNode.GetCamera().Elevation(-40)
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
       lungs = slicer.util.getNode('chestCT_lungs')
       lungs.GetDisplayNode().SetVisibility(0)
 
@@ -494,7 +494,7 @@ class JRC2013VisTest(ScriptedLoadableModuleTest):
       self.delayDisplay('View Question 3')
       cameraNode.GetCamera().Azimuth(-165)
       cameraNode.GetCamera().Elevation(-10)
-      redWidget.sliceController().setSliceVisible(False);
+      redWidget.sliceController().setSliceVisible(False)
 
       self.delayDisplay('View Question 4')
       cameraNode.GetCamera().Azimuth(20)

--- a/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
@@ -193,7 +193,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
       # show slices
       redWidget = layoutManager.sliceWidget('Red')
       redWidget.sliceController().setSliceLink(True)
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
 
 
       logic.takeScreenshot('Ruler','Ruler used to measure tumor diameter',-1)
@@ -399,7 +399,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
       logic.takeScreenshot('ChangeTracker-GoForward','Go Forward',-1)
 
       self.delayDisplay('Look!')
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
 
 
       self.delayDisplay('Crosshairs')

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
@@ -254,7 +254,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
 
       self.delayDisplay('Skipping Move the Shift slider')
 
-      redWidget.sliceController().setSliceVisible(False);
+      redWidget.sliceController().setSliceVisible(False)
       logic.takeScreenshot('VolumeRendering-SlicesOff','Turn off visibility of slices in 3D',-1)
 
       threeDView = layoutManager.threeDWidget(0).threeDView()
@@ -322,13 +322,13 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       greenController = greenWidget.sliceController()
 
       mainWindow.moduleSelector().selectModule('Models')
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
       logic.takeScreenshot('Head-ModelsAndSliceModel','Models and Slice Model',-1)
 
       slicer.util.clickAndDrag(threeDView)
       logic.takeScreenshot('Head-Rotate','Rotate',-1)
 
-      redController.setSliceVisible(True);
+      redController.setSliceVisible(True)
       logic.takeScreenshot('Head-AxialSlice','Display Axial Slice',-1)
 
       layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
@@ -352,7 +352,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
 
       skull = slicer.util.getNode(pattern='skull_bone.vtk')
 
-      greenWidget.sliceController().setSliceVisible(True);
+      greenWidget.sliceController().setSliceVisible(True)
       logic.takeScreenshot('Head-GreenSlice','Display Coronal Slice',-1)
 
       # hemispheric_white_matter.GetDisplayNode().SetClipping(1)
@@ -444,7 +444,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       segmentII.GetDisplayNode().SetVisibility(0)
       cameraNode.GetCamera().Azimuth(180)
       cameraNode.GetCamera().Elevation(-30)
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
       logic.takeScreenshot('Liver-ViewAdrenal','View Adrenal',-1)
 
       models = slicer.util.getNodes('vtkMRMLModelNode*')
@@ -458,7 +458,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
         modelNode.GetDisplayNode().SetVisibility(1)
       cameraNode.GetCamera().Azimuth(30)
       cameraNode.GetCamera().Elevation(-20)
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
       logic.takeScreenshot('Liver-MiddleHepatic','Middle Hepatic',-1)
 
       self.delayDisplay('Test passed!')
@@ -507,7 +507,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
 
       cameraNode.GetCamera().Azimuth(-100)
       cameraNode.GetCamera().Elevation(-40)
-      redWidget.sliceController().setSliceVisible(True);
+      redWidget.sliceController().setSliceVisible(True)
       lungs = slicer.util.getNode('chestCT_lungs')
       lungs.GetDisplayNode().SetVisibility(0)
       logic.takeScreenshot('Lung-Question1','View Question 1',-1)
@@ -521,7 +521,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
 
       cameraNode.GetCamera().Azimuth(-165)
       cameraNode.GetCamera().Elevation(-10)
-      redWidget.sliceController().setSliceVisible(False);
+      redWidget.sliceController().setSliceVisible(False)
       logic.takeScreenshot('Lung-Question3','View Question 3',-1)
 
       cameraNode.GetCamera().Azimuth(20)

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
@@ -125,7 +125,7 @@ class SlicerMRBSaveRestoreCheckPaths(ScriptedLoadableModuleTest):
     numberOfSceneViews = scene.GetNumberOfNodesByClass('vtkMRMLSceneViewNode')
     slicer.util.delayDisplay("Number of scene views = " + str(numberOfSceneViews))
     if numberOfSceneViews == 0:
-      return;
+      return
     for n in range(numberOfSceneViews):
       sceneViewNode = slicer.mrmlScene.GetNthNodeByClass(n, 'vtkMRMLSceneViewNode')
       slicer.util.delayDisplay('\nChecking scene view ' + sceneViewNode.GetName() + ', id = ' + sceneViewNode.GetID())

--- a/Applications/SlicerApp/Testing/Python/TwoCLIsInARowTest.py
+++ b/Applications/SlicerApp/Testing/Python/TwoCLIsInARowTest.py
@@ -123,7 +123,7 @@ class TwoCLIsInARowTestTest(ScriptedLoadableModuleTest):
   def test_TwoCLIsInARowTest(self):
     self.delayDisplay('Running two CLIs in a row Test')
 
-    tempFile = qt.QTemporaryFile("TwoCLIsInARowTest-outputFile-XXXXXX");
+    tempFile = qt.QTemporaryFile("TwoCLIsInARowTest-outputFile-XXXXXX")
     self.assertTrue(tempFile.open())
 
     logic = TwoCLIsInARowTestLogic()

--- a/Applications/SlicerApp/Testing/Python/TwoCLIsInParallelTest.py
+++ b/Applications/SlicerApp/Testing/Python/TwoCLIsInParallelTest.py
@@ -113,7 +113,7 @@ class TwoCLIsInParallelTestTest(ScriptedLoadableModuleTest):
   def test_TwoCLIsInParallelTest(self):
     self.delayDisplay('Running two CLIs in a row Test')
 
-    tempFile = qt.QTemporaryFile("TwoCLIsInParallelTest-outputFile-XXXXXX");
+    tempFile = qt.QTemporaryFile("TwoCLIsInParallelTest-outputFile-XXXXXX")
     self.assertTrue(tempFile.open())
 
     logic = TwoCLIsInParallelTestLogic()

--- a/Applications/SlicerApp/Testing/Python/WebEngine.py
+++ b/Applications/SlicerApp/Testing/Python/WebEngine.py
@@ -168,7 +168,7 @@ class WebEngineTest(ScriptedLoadableModuleTest):
     self.delayDisplay('Slicer setting a javascript value')
 
     webWidget.evalJS("const valueFromSlicer = 42;")
-    webWidget.evalJS("valueFromSlicer;");
+    webWidget.evalJS("valueFromSlicer;")
 
     iteration = 0
     while not self.gotResponse and iteration < 3:

--- a/Libs/MRML/Widgets/Testing/qMRMLChartViewTest.py
+++ b/Libs/MRML/Widgets/Testing/qMRMLChartViewTest.py
@@ -75,4 +75,4 @@ cn.AddArray('Periodic', dn3.GetID())
 cn.SetProperty('default', 'title', 'A bar chart')
 cn.SetProperty('default', 'xAxisLabel', 'time')
 cn.SetProperty('default', 'yAxisLabel', 'velocity')
-cn.SetProperty('default', 'type', 'Bar');
+cn.SetProperty('default', 'type', 'Bar')

--- a/Libs/vtkITK/Testing/vtkITKArchetypeDiffusionTensorReaderFile.py
+++ b/Libs/vtkITK/Testing/vtkITKArchetypeDiffusionTensorReaderFile.py
@@ -23,7 +23,7 @@ class vtkITKReaderAgainstNRRDReader(unittest.TestCase):
 
         self.ritk = vtkITK.vtkITKArchetypeDiffusionTensorImageReaderFile()
         self.ritk.SetUseOrientationFromFile(True)
-        self.ritk.SetUseNativeOriginOn();
+        self.ritk.SetUseNativeOriginOn()
         self.ritk.SetOutputScalarTypeToNative()
         self.ritk.SetDesiredCoordinateOrientationToNative()
         self.ritk.SetArchetype(self.file_name)

--- a/Libs/vtkITK/Testing/vtkITKArchetypeScalarReaderFile.py
+++ b/Libs/vtkITK/Testing/vtkITKArchetypeScalarReaderFile.py
@@ -22,7 +22,7 @@ class vtkITKReaderAgainstNRRDReader(unittest.TestCase):
 
         self.ritk = vtkITK.vtkITKArchetypeImageSeriesScalarReader()
         self.ritk.SetUseOrientationFromFile(True)
-        self.ritk.SetUseNativeOriginOn();
+        self.ritk.SetUseNativeOriginOn()
         self.ritk.SetOutputScalarTypeToNative()
         self.ritk.SetDesiredCoordinateOrientationToNative()
         self.ritk.SetArchetype(self.file_name)

--- a/Modules/Loadable/Annotations/SubjectHierarchyPlugins/AnnotationsSubjectHierarchyPlugin.py
+++ b/Modules/Loadable/Annotations/SubjectHierarchyPlugins/AnnotationsSubjectHierarchyPlugin.py
@@ -60,7 +60,7 @@ class AnnotationsSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin):
     import os
     pluginHandlerSingleton = slicer.qSlicerSubjectHierarchyPluginHandler.instance()
     shNode = pluginHandlerSingleton.subjectHierarchyNode()
-    associatedNode = shNode.GetItemDataNode(itemID);
+    associatedNode = shNode.GetItemDataNode(itemID)
     if associatedNode is not None:
       # ROI
       if associatedNode.IsA("vtkMRMLAnnotationROINode"):

--- a/Modules/Loadable/Plots/Testing/Python/PlotsSelfTest.py
+++ b/Modules/Loadable/Plots/Testing/Python/PlotsSelfTest.py
@@ -151,7 +151,7 @@ class PlotsSelfTestTest(ScriptedLoadableModuleTest):
 
     # Create plot view node
     plotViewNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLPlotViewNode")
-    plotViewNode.SetPlotChartNodeID(plotChartNode.GetID());
+    plotViewNode.SetPlotChartNodeID(plotChartNode.GetID())
 
     # Create plotWidget
     plotWidget = slicer.qMRMLPlotWidget()

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -465,7 +465,7 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
       # Disable smoothing for closed surface generation to make it fast
       previewNode.GetSegmentation().SetConversionParameter(
         slicer.vtkBinaryLabelmapToClosedSurfaceConversionRule.GetSmoothingFactorParameterName(),
-        "-0.5");
+        "-0.5")
 
       inputContainsClosedSurfaceRepresentation = segmentationNode.GetSegmentation().ContainsRepresentation(
         slicer.vtkSegmentationConverter.GetSegmentationClosedSurfaceRepresentationName())
@@ -519,7 +519,7 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
       thresh.SetInValue(1)
       thresh.SetOutValue(0)
       labelValue = index + 1 # n-th segment label value = n + 1 (background label value is 0)
-      thresh.ThresholdBetween(labelValue, labelValue);
+      thresh.ThresholdBetween(labelValue, labelValue)
       thresh.SetOutputScalarType(vtk.VTK_UNSIGNED_CHAR)
       thresh.SetInputData(outputLabelmap)
       thresh.Update()

--- a/Modules/Loadable/Tables/Testing/Python/TablesSelfTest.py
+++ b/Modules/Loadable/Tables/Testing/Python/TablesSelfTest.py
@@ -89,7 +89,7 @@ class TablesSelfTestTest(ScriptedLoadableModuleTest):
     column.InsertNextValue("data")
     column.InsertNextValue("in this")
     column.InsertNextValue("column")
-    tableNode.Modified();
+    tableNode.Modified()
 
     # Check table
     table = tableNode.GetTable()

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -217,7 +217,7 @@ class DataProbeInfoWidget(object):
 
     # populate the widgets
     self.viewerColor.setText( " " )
-    rgbColor = sliceNode.GetLayoutColor();
+    rgbColor = sliceNode.GetLayoutColor()
     color = qt.QColor.fromRgbF(rgbColor[0], rgbColor[1], rgbColor[2])
     if hasattr(color, 'name'):
       self.viewerColor.setStyleSheet('QLabel {background-color : %s}' % color.name())

--- a/Modules/Scripted/EditorLib/EditUtil.py
+++ b/Modules/Scripted/EditorLib/EditUtil.py
@@ -216,7 +216,7 @@ class EditUtil(object):
   def isEraseEffectEnabled():
     if slicer.mrmlScene.IsBatchProcessing():
       return False
-    return EditUtil.getLabel() == 0;
+    return EditUtil.getLabel() == 0
 
   @staticmethod
   def setEraseEffectEnabled(enabled):

--- a/Modules/Scripted/EditorLib/PaintEffect.py
+++ b/Modules/Scripted/EditorLib/PaintEffect.py
@@ -717,7 +717,7 @@ class PaintEffectTool(LabelEffectTool):
             zVoxelSize_mm = int(distanceSpannedBy100Slices / 100)
         # --
         # Compute number of slices spanned by sphere
-        nNumSlicesInEachDirection=int(brushRadius / zVoxelSize_mm);
+        nNumSlicesInEachDirection=int(brushRadius / zVoxelSize_mm)
         nNumSlicesInEachDirection=nNumSlicesInEachDirection-1
         sliceOffsetArray=numpy.concatenate((-1*numpy.arange(1,nNumSlicesInEachDirection+1,),  numpy.arange(1,nNumSlicesInEachDirection+1)))
         for iSliceOffset in sliceOffsetArray:
@@ -726,7 +726,7 @@ class PaintEffectTool(LabelEffectTool):
             iBrushCenter = xyToRAS.MultiplyPoint( (x, y, iSliceOffset, 1) )[:3]
             self.painter.SetBrushCenter( iBrushCenter[0], iBrushCenter[1], iBrushCenter[2] )
             # [ ] Need to just continue (pass this loop iteration if the brush center is not within the volume
-            zOffset_mm=zVoxelSize_mm*iSliceOffset;
+            zOffset_mm=zVoxelSize_mm*iSliceOffset
             brushRadiusOffset=sqrt(brushRadius*brushRadius - zOffset_mm*zOffset_mm)
             self.painter.SetBrushRadius( brushRadiusOffset )
 

--- a/Modules/Scripted/EditorLib/WatershedFromMarkerEffect.py
+++ b/Modules/Scripted/EditorLib/WatershedFromMarkerEffect.py
@@ -247,7 +247,7 @@ class WatershedFromMarkerEffectLogic(LabelEffectLogic):
     if self.undoRedo:
       self.undoRedo.saveState()
 
-    featureImage = sitk.GradientMagnitudeRecursiveGaussian( backgroundImage, float(self.sigma) );
+    featureImage = sitk.GradientMagnitudeRecursiveGaussian( backgroundImage, float(self.sigma) )
     del backgroundImage
     f = sitk.MorphologicalWatershedFromMarkersImageFilter()
     f.SetMarkWatershedLine( False )

--- a/Modules/Scripted/LabelStatistics/LabelStatistics.py
+++ b/Modules/Scripted/LabelStatistics/LabelStatistics.py
@@ -429,13 +429,13 @@ class LabelStatisticsLogic(ScriptedLoadableModuleLogic):
     chartNode.SetProperty('default', 'title', 'Label Statistics')
     chartNode.SetProperty('default', 'xAxisLabel', 'Label')
     chartNode.SetProperty('default', 'yAxisLabel', valueToPlot)
-    chartNode.SetProperty('default', 'type', 'Bar');
+    chartNode.SetProperty('default', 'type', 'Bar')
     chartNode.SetProperty('default', 'xAxisType', 'categorical')
     chartNode.SetProperty('default', 'showLegend', 'off')
 
     # series level properties
     if labelNode.GetDisplayNode() is not None and self.getColorNode() is not None:
-      chartNode.SetProperty(valueToPlot, 'lookupTable', self.getColorNode().GetID());
+      chartNode.SetProperty(valueToPlot, 'lookupTable', self.getColorNode().GetID())
 
     chartNode.EndModify(state)
 

--- a/Modules/Scripted/PerformanceTests/PerformanceTests.py
+++ b/Modules/Scripted/PerformanceTests/PerformanceTests.py
@@ -247,7 +247,7 @@ class PerformanceTestsWidget(ScriptedLoadableModuleWidget):
     cn.SetProperty('default', 'title', 'A bar chart')
     cn.SetProperty('default', 'xAxisLabel', 'time')
     cn.SetProperty('default', 'yAxisLabel', 'velocity')
-    cn.SetProperty('default', 'type', 'Bar');
+    cn.SetProperty('default', 'type', 'Bar')
 
   def webViewCallback(self,qurl):
     url = qurl.toString()

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -999,7 +999,7 @@ class SampleDataTest(ScriptedLoadableModuleTest):
 
   def test_downloadFromSource_loadMRMLFile(self):
     logic = SampleDataLogic()
-    tempFile = qt.QTemporaryFile(slicer.app.temporaryPath + "/SampleDataTest-loadSceneFile-XXXXXX.mrml");
+    tempFile = qt.QTemporaryFile(slicer.app.temporaryPath + "/SampleDataTest-loadSceneFile-XXXXXX.mrml")
     tempFile.open()
     tempFile.write(textwrap.dedent("""
       <?xml version="1.0" encoding="UTF-8"?>
@@ -1028,7 +1028,7 @@ class SampleDataTest(ScriptedLoadableModuleTest):
 
   def test_downloadFromSource_downloadMRMLFile(self):
     logic = SampleDataLogic()
-    tempFile = qt.QTemporaryFile(slicer.app.temporaryPath + "/SampleDataTest-loadSceneFile-XXXXXX.mrml");
+    tempFile = qt.QTemporaryFile(slicer.app.temporaryPath + "/SampleDataTest-loadSceneFile-XXXXXX.mrml")
     tempFile.open()
     tempFile.write(textwrap.dedent("""
       <?xml version="1.0" encoding="UTF-8"?>

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -447,7 +447,7 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
   def onShowCreatedOutputFile(self):
     if not self.createdOutputFile:
       return
-    qt.QDesktopServices().openUrl(qt.QUrl("file:///"+self.createdOutputFile, qt.QUrl.TolerantMode));
+    qt.QDesktopServices().openUrl(qt.QUrl("file:///"+self.createdOutputFile, qt.QUrl.TolerantMode))
 
   def updateOutputType(self, selectionIndex=0):
     isVideo = self.outputTypeWidget.currentText == "video"
@@ -965,7 +965,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
     sliceLogic = self.getSliceLogicFromSliceNode(sliceNode)
 
     sliceOffsetResolution = 1.0
-    sliceSpacing = sliceLogic.GetLowestVolumeSliceSpacing();
+    sliceSpacing = sliceLogic.GetLowestVolumeSliceSpacing()
     if sliceSpacing is not None and sliceSpacing[2]>0:
       sliceOffsetResolution = sliceSpacing[2]
 

--- a/Utilities/Scripts/ExtensionWizard.py
+++ b/Utilities/Scripts/ExtensionWizard.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import sys
-sys.path.append("./SlicerWizard");
+sys.path.append("./SlicerWizard")
 
 from SlicerWizard import ExtensionWizard
 

--- a/Utilities/Scripts/SlicerWizard/TemplateManager.py
+++ b/Utilities/Scripts/SlicerWizard/TemplateManager.py
@@ -252,7 +252,7 @@ class TemplateManager(object):
     .. seealso:: :meth:`templates`, :meth:`.listTemplates`
     """
 
-    return list(_templateCategories);
+    return list(_templateCategories)
 
   #---------------------------------------------------------------------------
   def templates(self, category=None):


### PR DESCRIPTION
I noticed an instance of a trailing semicolon being used in some python code. I used the following script to find other similar uses and then removed the trailing semicolon after manually reviewing each instance. Some were part of some embedded logic that wasn't python getting passed elsewhere or were some C++ examples in comments of a python file.
```python
import os
search_directory = os.path.join(os.getenv('UserProfile'), "Documents", "GitHub", "Slicer")
for root, dirs, files in os.walk(search_directory):
    for filename in files:
        if filename.endswith(".py"):
            filepath = os.path.join(root, filename)
            with open(filepath, "r") as open_file:
                lines = open_file.readlines()
                for index, line in enumerate(lines):
                    if line.endswith(";\n"):
                        print(filepath)
                        print(f"LINE: {index+1}:" + line)
```