### PR TITLE
Screen capture to node

### DIFF
--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -324,6 +324,11 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
     self.volumeNodeComboBox.setMRMLScene(slicer.mrmlScene)
     advancedFormLayout.addRow("Output volume node:", self.volumeNodeComboBox)
 
+    self.showViewControllersCheckBox = qt.QCheckBox(" ")
+    self.showViewControllersCheckBox.checked = False
+    self.showViewControllersCheckBox.setToolTip("If checked, images will be captured with view controllers visible.")
+    advancedFormLayout.addRow("View controllers:", self.showViewControllersCheckBox)
+
     self.transparentBackgroundCheckBox = qt.QCheckBox(" ")
     self.transparentBackgroundCheckBox.checked = False
     self.transparentBackgroundCheckBox.setToolTip("If checked, images will be captured with transparent background.")
@@ -684,8 +689,11 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
     slicer.app.setOverrideCursor(qt.Qt.WaitCursor)
     captureAllViews = self.captureAllViewsCheckBox.checked
     transparentBackground = self.transparentBackgroundCheckBox.checked
+    showViewControllers = self.showViewControllersCheckBox.checked
     if captureAllViews:
-      self.logic.showViewControllers(False)
+      self.logic.showViewControllers(showViewControllers)
+    elif showViewControllers:
+      logging.warning("View controllers are only available to be shown when capturing all views.")
     try:
       if numberOfSteps < 2:
         if imageFileNamePattern != self.snapshotFileNamePattern or outputDir != self.snapshotOutputDir:


### PR DESCRIPTION
This is a follow up to requests made in https://github.com/Slicer/Slicer/pull/5582#issuecomment-818265101. 

With the changes a user could capture a single image to a vtkMRMLVectorVolumeNode to then save at a later time. This would be used to replace the functionality of the Annotation's module screenshot functionality with storage in a vtkMRMLAnnotationSnapshotNode. vtkMRMLVectorVolumeNode was chosen so color images could be supported.

Specifically using the Screen Capture GUI I can set "Capture all views", set number of images to Single, clear out the output directory to not save to disk directly and then choose a vtkMRMLVectorVolumeNode from a node combobox, and also select View Controllers in the advanced section to keep the slice controllers in the output. 
![image](https://user-images.githubusercontent.com/15837524/114625588-76ee2e80-9c80-11eb-88fa-392fa6f095d7.png)


Upon saving the vtkMRMLVectorVolumeNode as a PNG file, the output is not exactly correct as the coordinate system is off as things are flipped. @lassoan Can you provide guidance about what is the syntax for fixing this issue? Do you manipulate the vtkImageData prior to setting it to be observed by the vtkMRMLVectorVolumeNode?
![VectorVolume](https://user-images.githubusercontent.com/15837524/114625216-e57ebc80-9c7f-11eb-95e2-5cfab5c66b45.png)

Also note that having looked at the ScreenCapture code it could definitely use a cleanup organization as most functionality appears just added on top of other things and so it is a bit difficult to understand in the GUI which options are relevant to the type of capture I'm trying to do. For this PR I just fit code into the current style instead of trying to refactor the module.