### PR TITLE
ENH: Added new color nodes for PET image display: PET-Rainbow2, PET-DICOM, and PET-HotMetalBlue

### DIFF
--- a/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.cxx
@@ -100,6 +100,24 @@ void vtkMRMLPETProceduralColorNode::SetTypeToRainbow()
 }
 
 //---------------------------------------------------------------------------
+void vtkMRMLPETProceduralColorNode::SetTypeToRainbow2()
+{
+  this->SetType(this->PETrainbow);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLPETProceduralColorNode::SetTypeToDICOM()
+{
+  this->SetType(this->PETDICOM);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLPETProceduralColorNode::SetTypeToHotMetalBlue()
+{
+  this->SetType(this->PEThotMetalBlue);
+}
+
+//---------------------------------------------------------------------------
 void vtkMRMLPETProceduralColorNode::SetTypeToMIP()
 {
   this->SetType(this->PETMIP);
@@ -116,9 +134,21 @@ const char *vtkMRMLPETProceduralColorNode::GetTypeAsString()
     {
     return "PET-Rainbow";
     }
+  else if (this->Type == this->PETrainbow2)
+    {
+    return "PET-Rainbow2";
+    }
   else if ( this->Type == this->PETMIP )
     {
     return "PET-MaximumIntensityProjection";
+    }
+  else if ( this->Type == this->PETDICOM )
+    {
+    return "PET-DICOM";
+    }
+  else if ( this->Type == this->PEThotMetalBlue )
+    {
+    return "PET-HotMetalBlue";
     }
   return "(unknown)";
 }
@@ -145,76 +175,62 @@ void vtkMRMLPETProceduralColorNode::SetType(int type)
   if (this->Type == this->PETheat)
     {
     this->SetDescription("Useful for displaying colorized PET data.");
-    if (this->ColorTransferFunction->AddRGBPoint(0, 0.0, 0.0, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType heat: error adding point 0");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(35, 0.36, 0.0, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType heat: error adding point 35");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(38, 0.5, 0.0, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType heat: error adding point 38.0");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(50, 0.7, 0.1, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType heat: error adding point 50");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(70, 0.7, 0.5, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType heat: error adding point 70");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(87, 1.0, 1.0, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType heat: error adding point 87");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(255, 1.0, 1.0, 1.0) == -1)
-      {
-      vtkErrorMacro("SetType heat: error adding point 255");
-      }
+    this->ColorTransferFunction->AddRGBPoint(0, 0.0, 0.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(35, 0.36, 0.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(38, 0.5, 0.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(50, 0.7, 0.1, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(70, 0.7, 0.5, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(87, 1.0, 1.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(255, 1.0, 1.0, 1.0);
     }
   else if (this->Type == this->PETrainbow)
     {
     this->SetDescription("Useful for displaying colorized PET data.");
-    if (this->ColorTransferFunction->AddRGBPoint(0, 0.0, 0.0, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType rainbowT: error adding point 0");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(35, 0.0, 0.0, 0.3) == -1)
-      {
-      vtkErrorMacro("SetType rainbowT: error adding point 35");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(38, 0.2, 0.0, 0.3) == -1)
-      {
-      vtkErrorMacro("SetType rainbowT: error adding point 38");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(50, 0.5, 0.0, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType rainbowT: error adding point 50");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(70, 0.7, 0.5, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType rainbowT: error adding point 70");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(87, 1.0, 1.0, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType rainbowT: error adding point 87");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(255, 1.0, 1.0, 1.0) == -1)
-      {
-      vtkErrorMacro("SetType rainbowT: error adding point 255");      }
+    this->ColorTransferFunction->AddRGBPoint(0, 0.0, 0.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(35, 0.0, 0.0, 0.3);
+    this->ColorTransferFunction->AddRGBPoint(38, 0.2, 0.0, 0.3);
+    this->ColorTransferFunction->AddRGBPoint(50, 0.5, 0.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(70, 0.7, 0.5, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(87, 1.0, 1.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(255, 1.0, 1.0, 1.0);
+    }
+  else if (this->Type == this->PETrainbow2)
+    {
+    this->SetDescription("Useful for displaying colorized PET data. Based on Rainbow.lut at https://sourceforge.net/projects/bifijiplugins/files/extraLUT/");
+    this->ColorTransferFunction->AddRGBPoint(0, 0.0, 0.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(32, 0.250980392, 0, 0.501960784);
+    this->ColorTransferFunction->AddRGBPoint(64, 0.0, 0.0, 1.0);
+    this->ColorTransferFunction->AddRGBPoint(96, 0.0, 1.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(160, 1.0, 1.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(192, 1.0, 0.752941176, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(255, 1.0, 0.011764706, 0.0);
     }
   else if (this->Type == this->PETMIP)
     {
     this->SetDescription("Useful for displaying inverse grey PET data.");
-    if (this->ColorTransferFunction->AddRGBPoint(0, 1.0, 1.0, 1.0) == -1)
-      {
-      vtkErrorMacro("SetType MIP: error adding point 0");
-      }
-    if (this->ColorTransferFunction->AddRGBPoint(255, 0.0, 0.0, 0.0) == -1)
-      {
-      vtkErrorMacro("SetType MIP: error adding point 255");      }
+    this->ColorTransferFunction->AddRGBPoint(0, 1.0, 1.0, 1.0);
+    this->ColorTransferFunction->AddRGBPoint(255, 0.0, 0.0, 0.0);
+    }
+  else if (this->Type == this->PETDICOM)
+    {
+    this->SetDescription("DICOM PET Color Palette (Part 6, B.1.2)");
+    this->ColorTransferFunction->AddRGBPoint(0, 0.0, 0.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(63, 0.0, 0.501960784, 0.490196078);
+    this->ColorTransferFunction->AddRGBPoint(128, 0.501960784, 0.0, 1.0);
+    this->ColorTransferFunction->AddRGBPoint(192, 1.0, 0.501960784, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(255, 1.0, 1.0, 1.0);
+    }
+  else if (this->Type == this->PEThotMetalBlue)
+    {
+    this->SetDescription("DICOM Hot Metal Blue Color Palette (Part 6, B.1.3)");
+    this->ColorTransferFunction->AddRGBPoint(0, 0.0, 0.0, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(85, 0.0, 0.0, 0.654901961);
+    this->ColorTransferFunction->AddRGBPoint(102, 0.196078431, 0.0, 0.784313725);
+    this->ColorTransferFunction->AddRGBPoint(119, 0.352941176, 0.0, 0.588235294);
+    this->ColorTransferFunction->AddRGBPoint(136, 0.549019608, 0.125490196, 0.196078431);
+    this->ColorTransferFunction->AddRGBPoint(153, 0.745098039, 0.250980392, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(170, 1.0, 0.376470588, 0.0);
+    this->ColorTransferFunction->AddRGBPoint(255, 1.0, 1.0, 1.0);
     }
 
   // build it

--- a/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.h
+++ b/Libs/MRML/Core/vtkMRMLPETProceduralColorNode.h
@@ -58,12 +58,20 @@ public:
   /// The list of valid types
   /// PETheat to display PET overlay with red to orange to yellow to white.
   /// PETrainbow to display PET overlay with cool to warm to white.
+  /// PETrainbow2 is absed on the PET lookup-table of Fiji PET-CT plugin (https://sourceforge.net/projects/bifijiplugins/files/extraLUT/).
+  /// PETDICOM is based on the DICOM standard PET color palette
+  /// (http://dicom.nema.org/medical/dicom/current/output/html/part06.html#sect_B.1.2).
+  /// PEThotMetalBlue is based on the DICOM standard Hot Metal Blue color palette
+  /// (http://dicom.nema.org/medical/dicom/current/output/html/part06.html#sect_B.1.3).
   /// PETMIP to display PET overlay  with white to black.
   enum
   {
     PETheat = 0,
     PETrainbow = 1,
-    PETMIP = 2
+    PETrainbow2 = 2,
+    PETDICOM = 3,
+    PEThotMetalBlue = 4,
+    PETMIP = 5
   };
 
   /// Return the lowest and the highest integers, for use in looping
@@ -73,7 +81,10 @@ public:
   const char *GetTypeAsString() override;
   void SetTypeToHeat();
   void SetTypeToRainbow();
+  void SetTypeToRainbow2();
   void SetTypeToMIP();
+  void SetTypeToDICOM();
+  void SetTypeToHotMetalBlue();
 
 protected:
   vtkMRMLPETProceduralColorNode();


### PR DESCRIPTION
See discussion at:
https://discourse.slicer.org/t/custom-color-maps-disappearing-on-mac-big-sur/16904/5

![image](https://user-images.githubusercontent.com/307929/114625805-c9c7e600-9c80-11eb-9a29-72cae6875aa9.png)
