### PR TITLE
COMP: Fix Windows build error in vtkSlicerMarkupsLogicTest4

### DIFF
--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest4.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest4.cxx
@@ -63,19 +63,19 @@ int vtkSlicerMarkupsLogicTest4(int , char*[])
   unregisteredCallbackCommand->SetCallback(UnregisteredEventDetectionCallback);
   logic4->AddObserver(vtkSlicerMarkupsLogic::MarkupUnregistered, unregisteredCallbackCommand);
 
-  // Test registrtation of a Markups Node with correct node and widget
+  // Test registration of a Markups Node with correct node and widget
   logic4->RegisterMarkupsNode(vtkSmartPointer<vtkMRMLMarkupsFiducialNode>::New(),
                               vtkSmartPointer<vtkSlicerPointsWidget>::New());
   CHECK_BOOL(registeredEventReceived, true);
 
-  // Test registrtation of a Markups Node with nullptr node
+  // Test registration of a Markups Node with nullptr node
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   registeredEventReceived = false;
   logic4->RegisterMarkupsNode(nullptr, vtkSmartPointer<vtkSlicerPointsWidget>::New(), false);
   TESTING_OUTPUT_ASSERT_ERRORS_END();
   CHECK_BOOL(registeredEventReceived, false);
 
-  // Test registrtation of a Markups Node with nullptr widget
+  // Test registration of a Markups Node with nullptr widget
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   registeredEventReceived = false;
   logic4->RegisterMarkupsNode(vtkSmartPointer<vtkMRMLMarkupsFiducialNode>::New(), nullptr, false);
@@ -109,10 +109,10 @@ int vtkSlicerMarkupsLogicTest4(int , char*[])
   TESTING_OUTPUT_ASSERT_WARNINGS_END();
   CHECK_BOOL(unregisteredEventReceived, false);
 
-  auto markupsFiducialNode = vtkSmartPointer<vtkMRMLMarkupsFiducialNode>::New();
-  auto markupsAngleNode = vtkSmartPointer<vtkMRMLMarkupsAngleNode>::New();
-  auto markupsPointsWidget = vtkSmartPointer<vtkSlicerPointsWidget>::New();
-  auto markupsAngleWidget = vtkSmartPointer<vtkSlicerAngleWidget>::New();
+  vtkNew<vtkMRMLMarkupsFiducialNode> markupsFiducialNode;
+  vtkNew<vtkMRMLMarkupsAngleNode> markupsAngleNode;
+  vtkNew<vtkSlicerPointsWidget> markupsPointsWidget;
+  vtkNew<vtkSlicerAngleWidget> markupsAngleWidget;
 
   // Register non-registered valid nodes and retrieve the values
   registeredEventReceived = false;


### PR DESCRIPTION
Error was:

"c:\d\S4R\Slicer-build\ALL_BUILD.vcxproj" (default target) (1) ->
"C:\d\S4R\Slicer-build\Modules\Loadable\Markups\Testing\Cxx\qSlicerMarkupsModuleCxxTests.vcxproj" (default target) (520) ->
(ClCompile target) ->
  C:\d\Slicer\Modules\Loadable\Markups\Testing\Cxx\vtkSlicerMarkupsLogicTest4.cxx(124,98): error C2666: 'operator !=': 5 overloads have similar conversions [C:
\d\S4R\Slicer-build\Modules\Loadable\Markups\Testing\Cxx\qSlicerMarkupsModuleCxxTests.vcxproj]
  C:\d\Slicer\Modules\Loadable\Markups\Testing\Cxx\vtkSlicerMarkupsLogicTest4.cxx(129,96): error C2666: 'operator !=': 5 overloads have similar conversions [C:
\d\S4R\Slicer-build\Modules\Loadable\Markups\Testing\Cxx\qSlicerMarkupsModuleCxxTests.vcxproj]
  C:\d\Slicer\Modules\Loadable\Markups\Testing\Cxx\vtkSlicerMarkupsLogicTest4.cxx(139,94): error C2666: 'operator !=': 5 overloads have similar conversions [C:
\d\S4R\Slicer-build\Modules\Loadable\Markups\Testing\Cxx\qSlicerMarkupsModuleCxxTests.vcxproj]
  C:\d\Slicer\Modules\Loadable\Markups\Testing\Cxx\vtkSlicerMarkupsLogicTest4.cxx(144,90): error C2666: 'operator !=': 5 overloads have similar conversions [C:
\d\S4R\Slicer-build\Modules\Loadable\Markups\Testing\Cxx\qSlicerMarkupsModuleCxxTests.vcxproj]