### PR TITLE
ENH: Move testing methods in scripted logic class to test class

### DIFF
--- a/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAQuantTutorial.py
@@ -149,9 +149,8 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
   def test_Part1Ruler(self,enableScreenshotsFlag=0,screenshotScaleFactor=1):
     """ Test using rulers
     """
-    logic = RSNAQuantTutorialLogic()
-    logic.enableScreenshots = enableScreenshotsFlag
-    logic.screenshotScaleFactor = screenshotScaleFactor
+    self.enableScreenshots = enableScreenshotsFlag
+    self.screenshotScaleFactor = screenshotScaleFactor
 
     self.delayDisplay("Starting the test")
 
@@ -196,7 +195,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
       redWidget.sliceController().setSliceVisible(True)
 
 
-      logic.takeScreenshot('Ruler','Ruler used to measure tumor diameter',-1)
+      self.takeScreenshot('Ruler','Ruler used to measure tumor diameter',-1)
 
       self.delayDisplay('Test passed!')
     except Exception as e:
@@ -208,9 +207,8 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
   def test_Part3PETCT(self,enableScreenshotsFlag=0,screenshotScaleFactor=1):
     """ Test using the PETCT module
     """
-    logic = RSNAQuantTutorialLogic()
-    logic.enableScreenshots = enableScreenshotsFlag
-    logic.screenshotScaleFactor = screenshotScaleFactor
+    self.enableScreenshots = enableScreenshotsFlag
+    self.screenshotScaleFactor = screenshotScaleFactor
 
     self.delayDisplay("Starting the test")
 
@@ -226,7 +224,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
     self.delayDisplay("Loading PET_CT_pre-treatment.mrb")
     preTreatmentPath = extractPath + '/PET_CT_pre-treatment.mrb'
     slicer.util.loadScene(preTreatmentPath)
-    logic.takeScreenshot('PETCT-LoadedPre','Loaded pre-treatement scene',-1)
+    self.takeScreenshot('PETCT-LoadedPre','Loaded pre-treatement scene',-1)
 
     try:
       mainWindow = slicer.util.mainWindow()
@@ -248,19 +246,19 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
       slicer.util.clickAndDrag(threeDView,button='Right')
       redWidget.sliceController().setSliceVisible(True)
       yellowWidget.sliceController().setSliceVisible(True)
-      logic.takeScreenshot('PETCT-ConfigureView','Configure View',-1)
+      self.takeScreenshot('PETCT-ConfigureView','Configure View',-1)
 
       mainWindow.moduleSelector().selectModule('Volumes')
       compositNode = redWidget.mrmlSliceCompositeNode()
       compositNode.SetForegroundOpacity(0.2)
-      logic.takeScreenshot('PETCT-ShowVolumes','Show Volumes with lesion',-1)
+      self.takeScreenshot('PETCT-ShowVolumes','Show Volumes with lesion',-1)
 
       compositNode.SetForegroundOpacity(0.5)
-      logic.takeScreenshot('PETCT-CTOpacity','CT1 volume opacity to 0.5',-1)
+      self.takeScreenshot('PETCT-CTOpacity','CT1 volume opacity to 0.5',-1)
 
       yellowWidget.sliceController().setSliceVisible(False)
       greenWidget.sliceController().setSliceVisible(True)
-      logic.takeScreenshot('PETCT-ShowSlices','Show axial and sagittal slices',-1)
+      self.takeScreenshot('PETCT-ShowSlices','Show axial and sagittal slices',-1)
 
       self.delayDisplay('SUV Computation')
       if not hasattr(slicer.modules, 'petstandarduptakevaluecomputation'):
@@ -285,16 +283,16 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
       self.delayDisplay("Loading PET_CT_post-treatment.mrb")
       postTreatmentPath = extractPath + '/PET_CT_post-treatment.mrb'
       slicer.util.loadScene(postTreatmentPath)
-      logic.takeScreenshot('PETCT-LoadedPost','Loaded post-treatement scene',-1)
+      self.takeScreenshot('PETCT-LoadedPost','Loaded post-treatement scene',-1)
 
       compositNode.SetForegroundOpacity(0.5)
-      logic.takeScreenshot('PETCT-CT2Opacity','CT2 volume opacity to 0.5',-1)
+      self.takeScreenshot('PETCT-CT2Opacity','CT2 volume opacity to 0.5',-1)
 
       redController.setSliceOffsetValue(-165.01)
-      logic.takeScreenshot('PETCT-LarynxUptake','Mild uptake in the larynx and pharynx',-1)
+      self.takeScreenshot('PETCT-LarynxUptake','Mild uptake in the larynx and pharynx',-1)
 
       redController.setSliceOffsetValue(-106.15)
-      logic.takeScreenshot('PETCT-TumorUptake','No uptake in the area of the primary tumor',-1)
+      self.takeScreenshot('PETCT-TumorUptake','No uptake in the area of the primary tumor',-1)
 
       self.delayDisplay('Test passed!')
     except Exception as e:
@@ -306,10 +304,8 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
   def test_Part2ChangeTracker(self,enableScreenshotsFlag=0,screenshotScaleFactor=1):
     """ Test the ChangeTracker module
     """
-
-    logic = RSNAQuantTutorialLogic()
-    logic.enableScreenshots = enableScreenshotsFlag
-    logic.screenshotScaleFactor = screenshotScaleFactor
+    self.enableScreenshots = enableScreenshotsFlag
+    self.screenshotScaleFactor = screenshotScaleFactor
 
     self.delayDisplay("Starting the test")
 
@@ -326,7 +322,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
       loadFiles=True,
       uris=TESTING_DATA_URL + 'SHA256/64734cbbf8ebafe4a52f551d1510a8f6f3d0625eb5b6c1e328be117c48e2c653',
       checksums='SHA256:64734cbbf8ebafe4a52f551d1510a8f6f3d0625eb5b6c1e328be117c48e2c653')
-    logic.takeScreenshot('ChangeTracker-Loaded','Finished with download and loading',-1)
+    self.takeScreenshot('ChangeTracker-Loaded','Finished with download and loading',-1)
 
     try:
       mainWindow = slicer.util.mainWindow()
@@ -342,7 +338,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
 
       self.delayDisplay('Configure Module')
       mainWindow.moduleSelector().selectModule('ChangeTracker')
-      logic.takeScreenshot('ChangeTracker-ModuleGUI','Select the ChangeTracker module',-1)
+      self.takeScreenshot('ChangeTracker-ModuleGUI','Select the ChangeTracker module',-1)
 
       changeTracker = slicer.modules.changetracker.widgetRepresentation().self()
 
@@ -350,53 +346,53 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
       followupNode = slicer.util.getNode('2007-spgr1')
       changeTracker.selectScansStep._ChangeTrackerSelectScansStep__baselineVolumeSelector.setCurrentNode(baselineNode)
       changeTracker.selectScansStep._ChangeTrackerSelectScansStep__followupVolumeSelector.setCurrentNode(followupNode)
-      logic.takeScreenshot('ChangeTracker-SetInputs','Select input scans',-1)
+      self.takeScreenshot('ChangeTracker-SetInputs','Select input scans',-1)
 
       changeTracker.workflow.goForward()
-      logic.takeScreenshot('ChangeTracker-GoForward','Go Forward',-1)
+      self.takeScreenshot('ChangeTracker-GoForward','Go Forward',-1)
 
       slicer.util.clickAndDrag(redWidget,button='Right')
-      logic.takeScreenshot('ChangeTracker-Zoom','Inspect - zoom',-1)
+      self.takeScreenshot('ChangeTracker-Zoom','Inspect - zoom',-1)
 
       slicer.util.clickAndDrag(redWidget,button='Middle')
-      logic.takeScreenshot('ChangeTracker-Pan','Inspect - pan',-1)
+      self.takeScreenshot('ChangeTracker-Pan','Inspect - pan',-1)
 
       for offset in range(-20,20,2):
         redController.setSliceOffsetValue(offset)
-      logic.takeScreenshot('ChangeTracker-Scroll','Inspect - scroll',-1)
+      self.takeScreenshot('ChangeTracker-Scroll','Inspect - scroll',-1)
 
       self.delayDisplay('Set ROI')
       roi = changeTracker.defineROIStep._ChangeTrackerDefineROIStep__roi
       roi.SetXYZ(-2.81037, 28.7629, 28.4536)
-      logic.takeScreenshot('ChangeTracker-SetROICenter','Center VOI',-1)
+      self.takeScreenshot('ChangeTracker-SetROICenter','Center VOI',-1)
       roi.SetRadiusXYZ(22.6467, 22.6804, 22.9897)
-      logic.takeScreenshot('ChangeTracker-SetROIExtent','Resize the VOI',-1)
+      self.takeScreenshot('ChangeTracker-SetROIExtent','Resize the VOI',-1)
 
       layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalWidescreenView)
-      logic.takeScreenshot('ChangeTracker-ConventionalWidescreen','Select the viewing mode Conventional Widescreen',-1)
+      self.takeScreenshot('ChangeTracker-ConventionalWidescreen','Select the viewing mode Conventional Widescreen',-1)
 
       slicer.util.clickAndDrag(redWidget,button='Right')
-      logic.takeScreenshot('ChangeTracker-ZoomVOI','Zoom',-1)
+      self.takeScreenshot('ChangeTracker-ZoomVOI','Zoom',-1)
 
       layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutFourUpView)
-      logic.takeScreenshot('ChangeTracker-FourUpLayout','Go back to Four-Up layout',-1)
+      self.takeScreenshot('ChangeTracker-FourUpLayout','Go back to Four-Up layout',-1)
 
       changeTracker.workflow.goForward()
-      logic.takeScreenshot('ChangeTracker-GoForward','Go Forward',-1)
+      self.takeScreenshot('ChangeTracker-GoForward','Go Forward',-1)
 
       changeTracker.segmentROIStep._ChangeTrackerSegmentROIStep__threshRange.minimumValue = 120
-      logic.takeScreenshot('ChangeTracker-Threshold','Set threshold',-1)
+      self.takeScreenshot('ChangeTracker-Threshold','Set threshold',-1)
 
       changeTracker.workflow.goForward()
-      logic.takeScreenshot('ChangeTracker-GoForward','Go Forward',-1)
+      self.takeScreenshot('ChangeTracker-GoForward','Go Forward',-1)
 
       checkList = changeTracker.analyzeROIStep._ChangeTrackerAnalyzeROIStep__metricCheckboxList
       index = list(checkList.values()).index('IntensityDifferenceMetric')
       list(checkList.keys())[index].checked = True
-      logic.takeScreenshot('ChangeTracker-PickMetric','Select the ROI analysis method',-1)
+      self.takeScreenshot('ChangeTracker-PickMetric','Select the ROI analysis method',-1)
 
       changeTracker.workflow.goForward()
-      logic.takeScreenshot('ChangeTracker-GoForward','Go Forward',-1)
+      self.takeScreenshot('ChangeTracker-GoForward','Go Forward',-1)
 
       self.delayDisplay('Look!')
       redWidget.sliceController().setSliceVisible(True)
@@ -421,7 +417,7 @@ class RSNAQuantTutorialTest(ScriptedLoadableModuleTest):
       for offset in range(10,30,2):
         compareController.setSliceOffsetValue(offset)
 
-      logic.takeScreenshot('ChangeTracker-InspectResults','Inspected results',-1)
+      self.takeScreenshot('ChangeTracker-InspectResults','Inspected results',-1)
 
       self.delayDisplay('Test passed!')
     except Exception as e:

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
@@ -174,10 +174,8 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
   def test_Part1DICOM(self,enableScreenshotsFlag=0,screenshotScaleFactor=1):
     """ Test the DICOM part of the test using the head atlas
     """
-
-    logic = RSNAVisTutorialLogic()
-    logic.enableScreenshots = enableScreenshotsFlag
-    logic.screenshotScaleFactor = screenshotScaleFactor
+    self.enableScreenshots = enableScreenshotsFlag
+    self.screenshotScaleFactor = screenshotScaleFactor
 
     import os
     self.delayDisplay("Starting the DICOM test")
@@ -207,81 +205,81 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       self.delayDisplay('Loading Selection')
       browserWidget.loadCheckedLoadables()
 
-      logic.takeScreenshot('LoadingADICOMVolume-Loaded','Loaded DICOM Volume',-1)
+      self.takeScreenshot('LoadingADICOMVolume-Loaded','Loaded DICOM Volume',-1)
 
       layoutManager = slicer.app.layoutManager()
       redWidget = layoutManager.sliceWidget('Red')
       slicer.util.clickAndDrag(redWidget,start=(10,10),end=(10,40))
       slicer.util.clickAndDrag(redWidget,start=(10,10),end=(40,10))
 
-      logic.takeScreenshot('LoadingADICOMVolume-WL','Changed level and window',-1)
+      self.takeScreenshot('LoadingADICOMVolume-WL','Changed level and window',-1)
 
       redWidget.sliceController().setSliceLink(True)
       redWidget.sliceController().setSliceVisible(True)
-      logic.takeScreenshot('LoadingADICOMVolume-LinkView','Linked and visible',-1)
+      self.takeScreenshot('LoadingADICOMVolume-LinkView','Linked and visible',-1)
 
       slicer.util.clickAndDrag(redWidget,button='Right',start=(10,10),end=(10,40))
-      logic.takeScreenshot('LoadingADICOMVolume-Zoom','Zoom',-1)
+      self.takeScreenshot('LoadingADICOMVolume-Zoom','Zoom',-1)
 
       threeDView = layoutManager.threeDWidget(0).threeDView()
       slicer.util.clickAndDrag(threeDView)
-      logic.takeScreenshot('LoadingADICOMVolume-Rotate','Rotate',-1)
+      self.takeScreenshot('LoadingADICOMVolume-Rotate','Rotate',-1)
 
       threeDView.resetFocalPoint()
-      logic.takeScreenshot('LoadingADICOMVolume-Center','Center the view',-1)
+      self.takeScreenshot('LoadingADICOMVolume-Center','Center the view',-1)
 
       layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalWidescreenView)
-      logic.takeScreenshot('LoadingADICOMVolume-ConventionalWidescreen','Conventional Widescreen Layout',-1)
+      self.takeScreenshot('LoadingADICOMVolume-ConventionalWidescreen','Conventional Widescreen Layout',-1)
 
       slicer.util.mainWindow().moduleSelector().selectModule('VolumeRendering')
-      logic.takeScreenshot('VolumeRendering-Module','Volume Rendering',-1)
+      self.takeScreenshot('VolumeRendering-Module','Volume Rendering',-1)
 
       volumeRenderingWidgetRep = slicer.modules.volumerendering.widgetRepresentation()
       abdomenVolume = slicer.mrmlScene.GetFirstNodeByName('6: CT_Thorax_Abdomen')
       volumeRenderingWidgetRep.setMRMLVolumeNode(abdomenVolume)
-      logic.takeScreenshot('VolumeRendering-SelectVolume','Select the volume 6: CT_Thorax_Abdomen',-1)
+      self.takeScreenshot('VolumeRendering-SelectVolume','Select the volume 6: CT_Thorax_Abdomen',-1)
 
       presetsScene = slicer.modules.volumerendering.logic().GetPresetsScene()
       ctCardiac3 = presetsScene.GetFirstNodeByName('CT-Cardiac3')
       volumeRenderingWidgetRep.mrmlVolumePropertyNode().Copy(ctCardiac3)
-      logic.takeScreenshot('VolumeRendering-SelectPreset','Select the Preset CT-Cardiac-3')
+      self.takeScreenshot('VolumeRendering-SelectPreset','Select the Preset CT-Cardiac-3')
 
       self.delayDisplay('Skipping: Select VTK CPU Ray Casting')
 
       volumeRenderingNode = slicer.mrmlScene.GetFirstNodeByName('VolumeRendering')
       volumeRenderingNode.SetVisibility(1)
-      logic.takeScreenshot('VolumeRendering-ViewRendering','View Volume Rendering',-1)
+      self.takeScreenshot('VolumeRendering-ViewRendering','View Volume Rendering',-1)
 
       self.delayDisplay('Skipping Move the Shift slider')
 
       redWidget.sliceController().setSliceVisible(False)
-      logic.takeScreenshot('VolumeRendering-SlicesOff','Turn off visibility of slices in 3D',-1)
+      self.takeScreenshot('VolumeRendering-SlicesOff','Turn off visibility of slices in 3D',-1)
 
       threeDView = layoutManager.threeDWidget(0).threeDView()
       slicer.util.clickAndDrag(threeDView)
-      logic.takeScreenshot('VolumeRendering-RotateVolumeRendering','Rotate volume rendered image',-1)
+      self.takeScreenshot('VolumeRendering-RotateVolumeRendering','Rotate volume rendered image',-1)
 
       volumeRenderingNode.SetVisibility(0)
-      logic.takeScreenshot('VolumeRendering-TurnOffVolumeRendering','Turn off volume rendered image',-1)
+      self.takeScreenshot('VolumeRendering-TurnOffVolumeRendering','Turn off volume rendered image',-1)
 
       volumeRenderingNode.SetCroppingEnabled(1)
       annotationROI = slicer.mrmlScene.GetFirstNodeByName('AnnotationROI')
       annotationROI.SetDisplayVisibility(1)
-      logic.takeScreenshot('VolumeRendering-DisplayROI','Enable cropping and display ROI',-1)
+      self.takeScreenshot('VolumeRendering-DisplayROI','Enable cropping and display ROI',-1)
 
       redWidget.sliceController().setSliceVisible(True)
-      logic.takeScreenshot('VolumeRendering-SlicesOn','Turn on visibility of slices in 3D',-1)
+      self.takeScreenshot('VolumeRendering-SlicesOn','Turn on visibility of slices in 3D',-1)
 
       annotationROI.SetXYZ(-79.61,154.16,-232.591)
       annotationROI.SetRadiusXYZ(43.4,65.19,70.5)
-      logic.takeScreenshot('VolumeRendering-SizedROI','Position the ROI over a kidney',-1)
+      self.takeScreenshot('VolumeRendering-SizedROI','Position the ROI over a kidney',-1)
 
       volumeRenderingNode.SetVisibility(1)
-      logic.takeScreenshot('VolumeRendering-ROIRendering','ROI volume rendered',-1)
+      self.takeScreenshot('VolumeRendering-ROIRendering','ROI volume rendered',-1)
 
       annotationROI.SetXYZ(15,146,-186)
       annotationROI.SetRadiusXYZ(138,57,61)
-      logic.takeScreenshot('VolumeRendering-BothKidneys','Rendered both kidneys',-1)
+      self.takeScreenshot('VolumeRendering-BothKidneys','Rendered both kidneys',-1)
 
       self.delayDisplay('Test passed!')
     except Exception as e:
@@ -295,9 +293,8 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
   def test_Part2Head(self,enableScreenshotsFlag=0,screenshotScaleFactor=1):
     """ Test using the head atlas - may not be needed - Slicer4Minute is already tested
     """
-    logic = RSNAVisTutorialLogic()
-    logic.enableScreenshots = enableScreenshotsFlag
-    logic.screenshotScaleFactor = screenshotScaleFactor
+    self.enableScreenshots = enableScreenshotsFlag
+    self.screenshotScaleFactor = screenshotScaleFactor
 
     self.delayDisplay("Starting the test")
     #
@@ -310,7 +307,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       uris=TESTING_DATA_URL + 'SHA256/6785e481925c912a5a3940e9c9b71935df93a78a871e10f66ab71f8478229e68',
       checksums='SHA256:6785e481925c912a5a3940e9c9b71935df93a78a871e10f66ab71f8478229e68')
 
-    logic.takeScreenshot('Head-Downloaded','Finished with download and loading',-1)
+    self.takeScreenshot('Head-Downloaded','Finished with download and loading',-1)
 
     try:
       mainWindow = slicer.util.mainWindow()
@@ -323,16 +320,16 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
 
       mainWindow.moduleSelector().selectModule('Models')
       redWidget.sliceController().setSliceVisible(True)
-      logic.takeScreenshot('Head-ModelsAndSliceModel','Models and Slice Model',-1)
+      self.takeScreenshot('Head-ModelsAndSliceModel','Models and Slice Model',-1)
 
       slicer.util.clickAndDrag(threeDView)
-      logic.takeScreenshot('Head-Rotate','Rotate',-1)
+      self.takeScreenshot('Head-Rotate','Rotate',-1)
 
       redController.setSliceVisible(True)
-      logic.takeScreenshot('Head-AxialSlice','Display Axial Slice',-1)
+      self.takeScreenshot('Head-AxialSlice','Display Axial Slice',-1)
 
       layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
-      logic.takeScreenshot('Head-ConventionalView','Conventional Layout',-1)
+      self.takeScreenshot('Head-ConventionalView','Conventional Layout',-1)
 
       viewNode = threeDView.mrmlViewNode()
       cameras = slicer.util.getNodes('vtkMRMLCameraNode*')
@@ -345,15 +342,15 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       # turn off skin and skull
       skin = slicer.util.getNode(pattern='Skin.vtk')
       skin.GetDisplayNode().SetOpacity(0.5)
-      logic.takeScreenshot('Head-SkinOpacity','Skin Opacity to 0.5',-1)
+      self.takeScreenshot('Head-SkinOpacity','Skin Opacity to 0.5',-1)
 
       skin.GetDisplayNode().SetVisibility(0)
-      logic.takeScreenshot('Head-SkinOpacityZero','Skin Opacity to 0',-1)
+      self.takeScreenshot('Head-SkinOpacityZero','Skin Opacity to 0',-1)
 
       skull = slicer.util.getNode(pattern='skull_bone.vtk')
 
       greenWidget.sliceController().setSliceVisible(True)
-      logic.takeScreenshot('Head-GreenSlice','Display Coronal Slice',-1)
+      self.takeScreenshot('Head-GreenSlice','Display Coronal Slice',-1)
 
       # hemispheric_white_matter.GetDisplayNode().SetClipping(1)
       skull.GetDisplayNode().SetClipping(1)
@@ -361,22 +358,22 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       clip.SetRedSliceClipState(0)
       clip.SetYellowSliceClipState(0)
       clip.SetGreenSliceClipState(2)
-      logic.takeScreenshot('Head-SkullClipping','Turn on clipping for skull model',-1)
+      self.takeScreenshot('Head-SkullClipping','Turn on clipping for skull model',-1)
 
       for offset in range(-20,20,2):
         greenController.setSliceOffsetValue(offset)
-      logic.takeScreenshot('Head-ScrollCoronal','Scroll through coronal slices',-1)
+      self.takeScreenshot('Head-ScrollCoronal','Scroll through coronal slices',-1)
 
       skull.GetDisplayNode().SetVisibility(0)
-      logic.takeScreenshot('Head-HideSkull','Make the skull invisible',-1)
+      self.takeScreenshot('Head-HideSkull','Make the skull invisible',-1)
 
       for offset in range(-40,-20,2):
         greenController.setSliceOffsetValue(offset)
-      logic.takeScreenshot('Head-ScrollCoronalWhiteMatter','Scroll through coronal slices to show white matter',-1)
+      self.takeScreenshot('Head-ScrollCoronalWhiteMatter','Scroll through coronal slices to show white matter',-1)
 
       hemispheric_white_matter = slicer.util.getNode(pattern='hemispheric_white_matter.vtk')
       hemispheric_white_matter.GetDisplayNode().SetVisibility(0)
-      logic.takeScreenshot('Head-HideWhiteMatter','Turn off white matter',-1)
+      self.takeScreenshot('Head-HideWhiteMatter','Turn off white matter',-1)
 
       self.delayDisplay('Rotate')
       slicer.util.clickAndDrag(threeDView)
@@ -384,7 +381,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       self.delayDisplay('Zoom')
       threeDView = layoutManager.threeDWidget(0).threeDView()
       slicer.util.clickAndDrag(threeDView,button='Right')
-      logic.takeScreenshot('Head-Zoom','Zoom',-1)
+      self.takeScreenshot('Head-Zoom','Zoom',-1)
 
       self.delayDisplay('Test passed!')
     except Exception as e:
@@ -396,9 +393,8 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
   def test_Part3Liver(self,enableScreenshotsFlag=0,screenshotScaleFactor=1):
     """ Test using the liver example data
     """
-    logic = RSNAVisTutorialLogic()
-    logic.enableScreenshots = enableScreenshotsFlag
-    logic.screenshotScaleFactor = screenshotScaleFactor
+    self.enableScreenshots = enableScreenshotsFlag
+    self.screenshotScaleFactor = screenshotScaleFactor
 
     self.delayDisplay("Starting the test")
     #
@@ -411,10 +407,9 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       uris=TESTING_DATA_URL + 'SHA256/ff797140c13a5988a7b72920adf0d2dab390a9babeab9161d5c52613328249f7',
       checksums='SHA256:ff797140c13a5988a7b72920adf0d2dab390a9babeab9161d5c52613328249f7')
 
-    logic.takeScreenshot('Liver-Loaded','Loaded Liver scene',-1)
+    self.takeScreenshot('Liver-Loaded','Loaded Liver scene',-1)
 
     try:
-      logic = RSNAVisTutorialLogic()
       mainWindow = slicer.util.mainWindow()
       layoutManager = slicer.app.layoutManager()
       threeDView = layoutManager.threeDWidget(0).threeDView()
@@ -427,25 +422,25 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
           break
 
       mainWindow.moduleSelector().selectModule('Models')
-      logic.takeScreenshot('Liver-Models','Models module',-1)
+      self.takeScreenshot('Liver-Models','Models module',-1)
 
       segmentII = slicer.util.getNode('LiverSegment_II')
       segmentII.GetDisplayNode().SetVisibility(0)
       slicer.util.clickAndDrag(threeDView,start=(10,200),end=(10,10))
-      logic.takeScreenshot('Liver-SegmentII','Segment II invisible',-1)
+      self.takeScreenshot('Liver-SegmentII','Segment II invisible',-1)
 
       segmentII.GetDisplayNode().SetVisibility(1)
-      logic.takeScreenshot('Liver-SegmentII','Segment II visible',-1)
+      self.takeScreenshot('Liver-SegmentII','Segment II visible',-1)
 
       cameraNode.GetCamera().Azimuth(0)
       cameraNode.GetCamera().Elevation(0)
-      logic.takeScreenshot('Liver-SuperiorView','Superior view',-1)
+      self.takeScreenshot('Liver-SuperiorView','Superior view',-1)
 
       segmentII.GetDisplayNode().SetVisibility(0)
       cameraNode.GetCamera().Azimuth(180)
       cameraNode.GetCamera().Elevation(-30)
       redWidget.sliceController().setSliceVisible(True)
-      logic.takeScreenshot('Liver-ViewAdrenal','View Adrenal',-1)
+      self.takeScreenshot('Liver-ViewAdrenal','View Adrenal',-1)
 
       models = slicer.util.getNodes('vtkMRMLModelNode*')
       for modelNode in models.values():
@@ -459,7 +454,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       cameraNode.GetCamera().Azimuth(30)
       cameraNode.GetCamera().Elevation(-20)
       redWidget.sliceController().setSliceVisible(True)
-      logic.takeScreenshot('Liver-MiddleHepatic','Middle Hepatic',-1)
+      self.takeScreenshot('Liver-MiddleHepatic','Middle Hepatic',-1)
 
       self.delayDisplay('Test passed!')
     except Exception as e:
@@ -470,9 +465,8 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
   def test_Part4Lung(self,enableScreenshotsFlag=0,screenshotScaleFactor=1):
     """ Test using the lung data
     """
-    logic = RSNAVisTutorialLogic()
-    logic.enableScreenshots = enableScreenshotsFlag
-    logic.screenshotScaleFactor = screenshotScaleFactor
+    self.enableScreenshots = enableScreenshotsFlag
+    self.screenshotScaleFactor = screenshotScaleFactor
 
     self.delayDisplay("Starting the test")
     #
@@ -485,7 +479,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
       uris=TESTING_DATA_URL + 'SHA256/89ffc6cabd76a17dfa6beb404a5901a4b4e4b4f2f4ee46c2d5f4d34459f554a1',
       checksums='SHA256:89ffc6cabd76a17dfa6beb404a5901a4b4e4b4f2f4ee46c2d5f4d34459f554a1')
 
-    logic.takeScreenshot('Lung-Loaded','Finished with download and loading',-1)
+    self.takeScreenshot('Lung-Loaded','Finished with download and loading',-1)
 
     try:
       mainWindow = slicer.util.mainWindow()
@@ -500,29 +494,29 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
           break
 
       threeDView.resetFocalPoint()
-      logic.takeScreenshot('Lung-ResetView','Reset view',-1)
+      self.takeScreenshot('Lung-ResetView','Reset view',-1)
 
       mainWindow.moduleSelector().selectModule('Models')
-      logic.takeScreenshot('Lung-Models','Models module',-1)
+      self.takeScreenshot('Lung-Models','Models module',-1)
 
       cameraNode.GetCamera().Azimuth(-100)
       cameraNode.GetCamera().Elevation(-40)
       redWidget.sliceController().setSliceVisible(True)
       lungs = slicer.util.getNode('chestCT_lungs')
       lungs.GetDisplayNode().SetVisibility(0)
-      logic.takeScreenshot('Lung-Question1','View Question 1',-1)
+      self.takeScreenshot('Lung-Question1','View Question 1',-1)
 
       cameraNode.GetCamera().Azimuth(-65)
       cameraNode.GetCamera().Elevation(-20)
       lungs.GetDisplayNode().SetVisibility(1)
       lungs.GetDisplayNode().SetOpacity(0.24)
       redController.setSliceOffsetValue(-50)
-      logic.takeScreenshot('Lung-Question2','View Question 2',-1)
+      self.takeScreenshot('Lung-Question2','View Question 2',-1)
 
       cameraNode.GetCamera().Azimuth(-165)
       cameraNode.GetCamera().Elevation(-10)
       redWidget.sliceController().setSliceVisible(False)
-      logic.takeScreenshot('Lung-Question3','View Question 3',-1)
+      self.takeScreenshot('Lung-Question3','View Question 3',-1)
 
       cameraNode.GetCamera().Azimuth(20)
       cameraNode.GetCamera().Elevation(-10)
@@ -533,7 +527,7 @@ class RSNAVisTutorialTest(ScriptedLoadableModuleTest):
           displayNode = lowerLobeNodes[node].GetDisplayNode()
           if displayNode:
             displayNode.SetVisibility(1 if node == showNode else 0)
-      logic.takeScreenshot('Lung-Question4','View Question 4',-1)
+      self.takeScreenshot('Lung-Question4','View Question 4',-1)
 
       self.delayDisplay('Test passed!')
     except Exception as e:

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -281,15 +281,6 @@ class ScriptedLoadableModuleLogic(object):
     node.SetName(slicer.mrmlScene.GenerateUniqueName(self.moduleName))
     return node
 
-  def clickAndDrag(self,widget,button='Left',start=(10,10),end=(10,40),steps=20,modifiers=[]):
-    """
-    Send synthetic mouse events to the specified widget (qMRMLSliceWidget or qMRMLThreeDView).
-    It is recommended to directly use slicer.util.clickAndDrag function.
-    This method is only kept for backward compatibility and may be removed in the future.
-    """
-    slicer.util.clickAndDrag(widget,button=button,start=start,end=end,steps=steps,modifiers=modifiers)
-
-
 
 class ScriptedLoadableModuleTest(unittest.TestCase):
   """

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -225,10 +225,6 @@ class ScriptedLoadableModuleLogic(object):
     # to allow having multiple parameter nodes in the scene.
     self.isSingletonParameterNode = True
 
-    # takeScreenshot default parameters
-    self.enableScreenshots = False
-    self.screenshotScaleFactor = 1.0
-
   def getParameterNode(self):
     """
     Return the first available parameter node for this module
@@ -285,14 +281,6 @@ class ScriptedLoadableModuleLogic(object):
     node.SetName(slicer.mrmlScene.GenerateUniqueName(self.moduleName))
     return node
 
-  def delayDisplay(self,message,msec=1000):
-    """
-    Display a message in a popup window for a short time.
-    It is recommended to directly use slicer.util.delayDisplay function.
-    This method is only kept for backward compatibility and may be removed in the future.
-    """
-    slicer.util.delayDisplay(message, msec)
-
   def clickAndDrag(self,widget,button='Left',start=(10,10),end=(10,40),steps=20,modifiers=[]):
     """
     Send synthetic mouse events to the specified widget (qMRMLSliceWidget or qMRMLThreeDView).
@@ -301,58 +289,7 @@ class ScriptedLoadableModuleLogic(object):
     """
     slicer.util.clickAndDrag(widget,button=button,start=start,end=end,steps=steps,modifiers=modifiers)
 
-  def takeScreenshot(self,name,description,type=-1):
-    """ Take a screenshot of the selected viewport and store as and
-    annotation snapshot node. Convenience method for automated testing.
 
-    If self.enableScreenshots is False then only a message is displayed but screenshot
-    is not stored. Screenshots are scaled by self.screenshotScaleFactor.
-
-    :param name: snapshot node name
-    :param description: description of the node
-    :param type: which viewport to capture. If not specified then captures the entire window.
-      Valid values: slicer.qMRMLScreenShotDialog.FullLayout,
-      slicer.qMRMLScreenShotDialog.ThreeD, slicer.qMRMLScreenShotDialog.Red,
-      slicer.qMRMLScreenShotDialog.Yellow, slicer.qMRMLScreenShotDialog.Green.
-    """
-
-    # show the message even if not taking a screen shot
-    slicer.util.delayDisplay(description)
-
-    if not self.enableScreenshots:
-      return
-
-    lm = slicer.app.layoutManager()
-    # switch on the type to get the requested window
-    widget = 0
-    if type == slicer.qMRMLScreenShotDialog.FullLayout:
-      # full layout
-      widget = lm.viewport()
-    elif type == slicer.qMRMLScreenShotDialog.ThreeD:
-      # just the 3D window
-      widget = lm.threeDWidget(0).threeDView()
-    elif type == slicer.qMRMLScreenShotDialog.Red:
-      # red slice window
-      widget = lm.sliceWidget("Red")
-    elif type == slicer.qMRMLScreenShotDialog.Yellow:
-      # yellow slice window
-      widget = lm.sliceWidget("Yellow")
-    elif type == slicer.qMRMLScreenShotDialog.Green:
-      # green slice window
-      widget = lm.sliceWidget("Green")
-    else:
-      # default to using the full window
-      widget = slicer.util.mainWindow()
-      # reset the type so that the node is set correctly
-      type = slicer.qMRMLScreenShotDialog.FullLayout
-
-    # grab and convert to vtk image data
-    qimage = ctk.ctkWidgetsUtils.grabWidget(widget)
-    imageData = vtk.vtkImageData()
-    slicer.qMRMLUtils().qImageToVtkImageData(qimage,imageData)
-
-    annotationLogic = slicer.modules.annotations.logic()
-    annotationLogic.CreateSnapShot(name, description, type, self.screenshotScaleFactor, imageData)
 
 class ScriptedLoadableModuleTest(unittest.TestCase):
   """
@@ -363,6 +300,10 @@ class ScriptedLoadableModuleTest(unittest.TestCase):
 
   def __init__(self, *args, **kwargs):
     super(ScriptedLoadableModuleTest, self).__init__(*args, **kwargs)
+
+    # takeScreenshot default parameters
+    self.enableScreenshots = False
+    self.screenshotScaleFactor = 1.0
 
   def delayDisplay(self,message,requestedDelay=None,msec=None):
     """
@@ -399,6 +340,59 @@ class ScriptedLoadableModuleTest(unittest.TestCase):
       msec = 100
 
     slicer.util.delayDisplay(message, msec)
+
+  def takeScreenshot(self,name,description,type=-1):
+    """ Take a screenshot of the selected viewport and store as and
+    annotation snapshot node. Convenience method for automated testing.
+
+    If self.enableScreenshots is False then only a message is displayed but screenshot
+    is not stored. Screenshots are scaled by self.screenshotScaleFactor.
+
+    :param name: snapshot node name
+    :param description: description of the node
+    :param type: which viewport to capture. If not specified then captures the entire window.
+      Valid values: slicer.qMRMLScreenShotDialog.FullLayout,
+      slicer.qMRMLScreenShotDialog.ThreeD, slicer.qMRMLScreenShotDialog.Red,
+      slicer.qMRMLScreenShotDialog.Yellow, slicer.qMRMLScreenShotDialog.Green.
+    """
+
+    # show the message even if not taking a screen shot
+    self.delayDisplay(description)
+
+    if not self.enableScreenshots:
+      return
+
+    lm = slicer.app.layoutManager()
+    # switch on the type to get the requested window
+    widget = 0
+    if type == slicer.qMRMLScreenShotDialog.FullLayout:
+      # full layout
+      widget = lm.viewport()
+    elif type == slicer.qMRMLScreenShotDialog.ThreeD:
+      # just the 3D window
+      widget = lm.threeDWidget(0).threeDView()
+    elif type == slicer.qMRMLScreenShotDialog.Red:
+      # red slice window
+      widget = lm.sliceWidget("Red")
+    elif type == slicer.qMRMLScreenShotDialog.Yellow:
+      # yellow slice window
+      widget = lm.sliceWidget("Yellow")
+    elif type == slicer.qMRMLScreenShotDialog.Green:
+      # green slice window
+      widget = lm.sliceWidget("Green")
+    else:
+      # default to using the full window
+      widget = slicer.util.mainWindow()
+      # reset the type so that the node is set correctly
+      type = slicer.qMRMLScreenShotDialog.FullLayout
+
+    # grab and convert to vtk image data
+    qimage = ctk.ctkWidgetsUtils.grabWidget(widget)
+    imageData = vtk.vtkImageData()
+    slicer.qMRMLUtils().qImageToVtkImageData(qimage,imageData)
+
+    annotationLogic = slicer.modules.annotations.logic()
+    annotationLogic.CreateSnapShot(name, description, type, self.screenshotScaleFactor, imageData)
 
   def runTest(self):
     """

--- a/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
+++ b/Extensions/Testing/ScriptedLoadableExtensionTemplate/ScriptedLoadableModuleTemplate/ScriptedLoadableModuleTemplate.py
@@ -175,7 +175,7 @@ class ScriptedLoadableModuleTemplateLogic(ScriptedLoadableModuleLogic):
       return False
     return True
 
-  def run(self, inputVolume, outputVolume, imageThreshold, enableScreenshots=0):
+  def run(self, inputVolume, outputVolume, imageThreshold):
     """
     Run the actual algorithm
     """
@@ -189,10 +189,6 @@ class ScriptedLoadableModuleTemplateLogic(ScriptedLoadableModuleLogic):
     # Compute the thresholded output volume using the Threshold Scalar Volume CLI module
     cliParams = {'InputVolume': inputVolume.GetID(), 'OutputVolume': outputVolume.GetID(), 'ThresholdValue' : imageThreshold, 'ThresholdType' : 'Above'}
     cliNode = slicer.cli.run(slicer.modules.thresholdscalarvolume, None, cliParams, wait_for_completion=True)
-
-    # Capture screenshot
-    if enableScreenshots:
-      self.takeScreenshot('ScriptedLoadableModuleTemplateTest-Start','MyScreenshot',-1)
 
     logging.info('Processing completed')
 
@@ -243,4 +239,5 @@ class ScriptedLoadableModuleTemplateTest(ScriptedLoadableModuleTest):
 
     logic = ScriptedLoadableModuleTemplateLogic()
     self.assertIsNotNone( logic.hasImageData(volumeNode) )
+    self.takeScreenshot('ScriptedLoadableModuleTemplateTest-Start','MyScreenshot',-1)
     self.delayDisplay('Test passed!')

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
@@ -127,13 +127,13 @@ class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
     index = fidNode.AddFiducialFromArray(nose)
     fidNode.SetNthFiducialLabel(index, "nose")
 
-    self.delayDisplay("Placed 3 fiducials")
+    slicer.util.delayDisplay("Placed 3 fiducials")
 
     #
     # switch to 2 viewers compare layout
     #
     lm.setLayout(12)
-    self.delayDisplay("Switched to Compare 2 viewers")
+    slicer.util.delayDisplay("Switched to Compare 2 viewers")
 
     #
     # get compare slice composite node
@@ -153,7 +153,7 @@ class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
     compareLogic1.StartSliceOffsetInteraction()
     compareLogic1.SetSliceOffset(eye1[2])
     compareLogic1.EndSliceOffsetInteraction()
-    self.delayDisplay("MH Head in background, scrolled to a fiducial")
+    slicer.util.delayDisplay("MH Head in background, scrolled to a fiducial")
 
     # scroll around through the range of points
     offset = nose[2]
@@ -162,21 +162,21 @@ class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
       compareLogic1.SetSliceOffset(offset)
       compareLogic1.EndSliceOffsetInteraction()
       msg = "Scrolled to " + str(offset)
-      self.delayDisplay(msg,250)
+      slicer.util.delayDisplay(msg,250)
       offset += 1.0
 
     # switch back to conventional
     lm.setLayout(2)
-    self.delayDisplay("Switched back to conventional layout")
+    slicer.util.delayDisplay("Switched back to conventional layout")
 
     # switch to compare grid
     lm.setLayout(23)
     compareLogic1.FitSliceToAll()
-    self.delayDisplay("Switched to Compare grid")
+    slicer.util.delayDisplay("Switched to Compare grid")
 
     # switch back to conventional
     lm.setLayout(2)
-    self.delayDisplay("Switched back to conventional layout")
+    slicer.util.delayDisplay("Switched back to conventional layout")
 
     return True
 

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
@@ -209,12 +209,12 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     for tag in fidNodeObserverTags:
       fidNode.RemoveObserver(tag)
 
-    self.delayDisplay("Placed 3 fiducials")
+    slicer.util.delayDisplay("Placed 3 fiducials")
 
     # self.printViewAndSliceNodes()
 
     if not self.controlPointVisible3D(fidNode, 'vtkMRMLViewNode1', controlPointIndex):
-      self.delayDisplay("Test failed: widget is not visible in view 1")
+      slicer.util.delayDisplay("Test failed: widget is not visible in view 1")
       # self.printViewNodeIDs(displayNode)
       return False
 
@@ -222,7 +222,7 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     # switch to 2 3D views layout
     #
     lm.setLayout(15)
-    self.delayDisplay("Switched to 2 3D views")
+    slicer.util.delayDisplay("Switched to 2 3D views")
     # self.printViewAndSliceNodes()
 
     controlPointIndex = 0
@@ -231,7 +231,7 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
 
     if (not self.controlPointVisible3D(fidNode, 'vtkMRMLViewNode1', controlPointIndex)
         or not self.controlPointVisible3D(fidNode, 'vtkMRMLViewNode2', controlPointIndex)):
-      self.delayDisplay("Test failed: widget is not visible in view 1 and 2")
+      slicer.util.delayDisplay("Test failed: widget is not visible in view 1 and 2")
       # self.printViewNodeIDs(displayNode)
       return False
 
@@ -239,13 +239,13 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     # show only in view 2
     #
     displayNode.AddViewNodeID("vtkMRMLViewNode2")
-    self.delayDisplay("Showing only in view 2")
+    slicer.util.delayDisplay("Showing only in view 2")
     if self.controlPointVisible3D(fidNode, 'vtkMRMLViewNode1', controlPointIndex):
-      self.delayDisplay("Test failed: widget is not supposed to be visible in view 1")
+      slicer.util.delayDisplay("Test failed: widget is not supposed to be visible in view 1")
       # self.printViewNodeIDs(displayNode)
       return False
     if not self.controlPointVisible3D(fidNode, 'vtkMRMLViewNode2', controlPointIndex):
-      self.delayDisplay("Test failed: widget is not visible in view 2")
+      slicer.util.delayDisplay("Test failed: widget is not visible in view 2")
       # self.printViewNodeIDs(displayNode)
       return False
 
@@ -253,10 +253,10 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     # remove it so show in all
     #
     displayNode.RemoveAllViewNodeIDs()
-    self.delayDisplay("Showing in both views")
+    slicer.util.delayDisplay("Showing in both views")
     if (not self.controlPointVisible3D(fidNode, 'vtkMRMLViewNode1', controlPointIndex)
         or not self.controlPointVisible3D(fidNode, 'vtkMRMLViewNode2', controlPointIndex)):
-      self.delayDisplay("Test failed: widget is not visible in view 1 and 2")
+      slicer.util.delayDisplay("Test failed: widget is not visible in view 1 and 2")
       self.printViewNodeIDs(displayNode)
       return False
 
@@ -264,19 +264,19 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     # show only in view 1
     #
     displayNode.AddViewNodeID("vtkMRMLViewNode1")
-    self.delayDisplay("Showing only in view 1")
+    slicer.util.delayDisplay("Showing only in view 1")
     if self.controlPointVisible3D(fidNode, 'vtkMRMLViewNode2', controlPointIndex):
-      self.delayDisplay("Test failed: widget is not supposed to be visible in view 2")
+      slicer.util.delayDisplay("Test failed: widget is not supposed to be visible in view 2")
       # self.printViewNodeIDs(displayNode)
       return False
     if not self.controlPointVisible3D(fidNode, 'vtkMRMLViewNode1', controlPointIndex):
-      self.delayDisplay("Test failed: widget is not visible in view 1")
+      slicer.util.delayDisplay("Test failed: widget is not visible in view 1")
       # self.printViewNodeIDs(displayNode)
       return False
 
     # switch back to conventional
     lm.setLayout(2)
-    self.delayDisplay("Switched back to conventional layout")
+    slicer.util.delayDisplay("Switched back to conventional layout")
     # self.printViewAndSliceNodes()
 
     # test of the visibility in slice views
@@ -289,9 +289,9 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
 
     # show only in red
     displayNode.AddViewNodeID('vtkMRMLSliceNodeRed')
-    self.delayDisplay("Show only in red slice")
+    slicer.util.delayDisplay("Show only in red slice")
     if not self.controlPointVisibleSlice(fidNode,'vtkMRMLSliceNodeRed', controlPointIndex):
-      self.delayDisplay("Test failed: widget not displayed on red slice")
+      slicer.util.delayDisplay("Test failed: widget not displayed on red slice")
       # self.printViewNodeIDs(displayNode)
       return False
 
@@ -302,10 +302,10 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     # print 'after removed all'
     # self.printViewNodeIDs(displayNode)
     displayNode.AddViewNodeID('vtkMRMLSliceNodeGreen')
-    self.delayDisplay('Show only in green slice')
+    slicer.util.delayDisplay('Show only in green slice')
     if (self.controlPointVisibleSlice(fidNode,'vtkMRMLSliceNodeRed', controlPointIndex)
         or not self.controlPointVisibleSlice(fidNode,'vtkMRMLSliceNodeGreen', controlPointIndex)):
-      self.delayDisplay("Test failed: widget not displayed only on green slice")
+      slicer.util.delayDisplay("Test failed: widget not displayed only on green slice")
       print('\tred = ',self.controlPointVisibleSlice(fidNode,'vtkMRMLSliceNodeRed', controlPointIndex))
       print('\tgreen =',self.controlPointVisibleSlice(fidNode,'vtkMRMLSliceNodeGreen', controlPointIndex))
       self.printViewNodeIDs(displayNode)

--- a/Modules/Loadable/Markups/Testing/Python/NeurosurgicalPlanningTutorialMarkupsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/NeurosurgicalPlanningTutorialMarkupsSelfTest.py
@@ -119,10 +119,35 @@ class NeurosurgicalPlanningTutorialMarkupsSelfTestLogic(ScriptedLoadableModuleLo
 
     return (int(displayCoords[0]), int(displayCoords[1]))
 
-  def run(self):
+
+class NeurosurgicalPlanningTutorialMarkupsSelfTestTest(ScriptedLoadableModuleTest):
+  """
+  This is the test case for your scripted module.
+  """
+
+  def setUp(self):
+    """ Do whatever is needed to reset the state - typically a scene clear will be enough.
     """
-    Run the actual algorithm
+    slicer.mrmlScene.Clear(0)
+    # reset to conventional layout
+    lm = slicer.app.layoutManager()
+    lm.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
+
+  def runTest(self):
+    """Run as few or as many tests as needed here.
     """
+    self.setUp()
+    self.test_NeurosurgicalPlanningTutorialMarkupsSelfTest1()
+
+  def test_NeurosurgicalPlanningTutorialMarkupsSelfTest1(self):
+
+    self.delayDisplay("Starting the Neurosurgical Planning Tutorial Markups test")
+
+    # start in the welcome module
+    m = slicer.util.mainWindow()
+    m.moduleSelector().selectModule('Welcome')
+
+    logic = NeurosurgicalPlanningTutorialMarkupsSelfTestLogic()
     self.delayDisplay('Running test of the Neurosurgical Planning tutorial')
 
     # conventional layout
@@ -253,7 +278,7 @@ class NeurosurgicalPlanningTutorialMarkupsSelfTestLogic(ScriptedLoadableModuleLo
     currentCoords = None
     for clickCoords in clickCoordsList:
       if currentCoords:
-        slicer.util.clickAndDrag(sliceWidget, start=self.rasToDisplay(*currentCoords), end=self.rasToDisplay(*clickCoords), steps=10)
+        slicer.util.clickAndDrag(sliceWidget, start=logic.rasToDisplay(*currentCoords), end=logic.rasToDisplay(*clickCoords), steps=10)
       currentCoords = clickCoords
 
     self.takeScreenshot('NeurosurgicalPlanning-PaintCystic','Paint cystic part of tumor')
@@ -262,7 +287,7 @@ class NeurosurgicalPlanningTutorialMarkupsSelfTestLogic(ScriptedLoadableModuleLo
     # paint in solid part of tumor
     #
     segmentEditorNode.SetSelectedSegmentID(region2SegmentId)
-    slicer.util.clickAndDrag(sliceWidget, start=self.rasToDisplay(-0.5, 118.5, sliceOffset), end=self.rasToDisplay(-7.4, 116, sliceOffset), steps=10)
+    slicer.util.clickAndDrag(sliceWidget, start=logic.rasToDisplay(-0.5, 118.5, sliceOffset), end=logic.rasToDisplay(-7.4, 116, sliceOffset), steps=10)
     self.takeScreenshot('NeurosurgicalPlanning-PaintSolid','Paint solid part of tumor')
 
     #
@@ -279,7 +304,7 @@ class NeurosurgicalPlanningTutorialMarkupsSelfTestLogic(ScriptedLoadableModuleLo
     currentCoords = None
     for clickCoords in clickCoordsList:
       if currentCoords:
-        slicer.util.clickAndDrag(sliceWidget, start=self.rasToDisplay(*currentCoords), end=self.rasToDisplay(*clickCoords), steps=30)
+        slicer.util.clickAndDrag(sliceWidget, start=logic.rasToDisplay(*currentCoords), end=logic.rasToDisplay(*clickCoords), steps=30)
       currentCoords = clickCoords
     self.takeScreenshot('NeurosurgicalPlanning-PaintAround','Paint around tumor')
 
@@ -323,7 +348,7 @@ class NeurosurgicalPlanningTutorialMarkupsSelfTestLogic(ScriptedLoadableModuleLo
     segmentEditorWidget.setActiveEffectByName("Islands")
     effect = segmentEditorWidget.activeEffect()
     effect.setParameter("Operation","KEEP_SELECTED_ISLAND")
-    slicer.util.clickAndDrag(sliceWidget, start=self.rasToDisplay(25.3, 5.8, sliceOffset), end=self.rasToDisplay(25.3, 5.8, sliceOffset), steps=1)
+    slicer.util.clickAndDrag(sliceWidget, start=logic.rasToDisplay(25.3, 5.8, sliceOffset), end=logic.rasToDisplay(25.3, 5.8, sliceOffset), steps=1)
     self.takeScreenshot('NeurosurgicalPlanning-SaveIsland','Ventricles save island')
 
     #
@@ -352,38 +377,5 @@ class NeurosurgicalPlanningTutorialMarkupsSelfTestLogic(ScriptedLoadableModuleLo
     effect.setParameter("MarginSizeMm", 3.0)
     effect.self().onApply()
     self.takeScreenshot('NeurosurgicalPlanning-Dilated','Dilated tumor')
-
-    return True
-
-
-class NeurosurgicalPlanningTutorialMarkupsSelfTestTest(ScriptedLoadableModuleTest):
-  """
-  This is the test case for your scripted module.
-  """
-
-  def setUp(self):
-    """ Do whatever is needed to reset the state - typically a scene clear will be enough.
-    """
-    slicer.mrmlScene.Clear(0)
-    # reset to conventional layout
-    lm = slicer.app.layoutManager()
-    lm.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
-
-  def runTest(self):
-    """Run as few or as many tests as needed here.
-    """
-    self.setUp()
-    self.test_NeurosurgicalPlanningTutorialMarkupsSelfTest1()
-
-  def test_NeurosurgicalPlanningTutorialMarkupsSelfTest1(self):
-
-    self.delayDisplay("Starting the Neurosurgical Planning Tutorial Markups test")
-
-    # start in the welcome module
-    m = slicer.util.mainWindow()
-    m.moduleSelector().selectModule('Welcome')
-
-    logic = NeurosurgicalPlanningTutorialMarkupsSelfTestLogic()
-    logic.run()
 
     self.delayDisplay('Test passed!')

--- a/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
@@ -99,19 +99,19 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
 
   def __checkPushButtonExists(self, widget, name):
     pushButtonObjectName = "Create%sPushButton" % name
-    #self.delayDisplay("Checking wether '%s' exists" % pushButtonObjectName)
+    #slicer.util.delayDisplay("Checking wether '%s' exists" % pushButtonObjectName)
     if widget.findChild(qt.QPushButton, pushButtonObjectName):
       return True
     return False
 
   def __checkWidgetExists(self, widget, name):
-    #self.delayDisplay("Checking wether '%s' exists" % name)
+    #slicer.util.delayDisplay("Checking wether '%s' exists" % name)
     if widget.findChild(qt.QWidget, name):
       return True
     return False
 
   def __checkWidgetVisibility(self, widget, name):
-    #self.delayDisplay("Checking wether '%s' is visible" % pushButtonObjectName)
+    #slicer.util.delayDisplay("Checking wether '%s' is visible" % pushButtonObjectName)
     w = widget.findChild(qt.QWidget, name)
     return w.isVisible()
 
@@ -155,7 +155,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
 
     # Unregister Markups and check the buttons are gone
     for markupNode in self.markupsNodes():
-      self.delayDisplay("Unregistering %s" % markupNode.GetMarkupType())
+      slicer.util.delayDisplay("Unregistering %s" % markupNode.GetMarkupType())
       markupsLogic.UnregisterMarkupsNode(markupNode)
       if self.__checkPushButtonExists(markupsWidget, markupNode.GetMarkupType()):
        raise Exception("Create PushButton for %s is present after unregistration" % markupNode.GetMarkupType())
@@ -176,7 +176,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
 
     #Check Markups module standard nodes are registered
     for markupNode in markupsNodes:
-      self.delayDisplay("Registering %s" % markupNode.GetMarkupType())
+      slicer.util.delayDisplay("Registering %s" % markupNode.GetMarkupType())
       markupsLogic.RegisterMarkupsNode(markupNode, markupsNodes[markupNode])
       if self.__checkPushButtonExists(markupsWidget, markupNode.GetMarkupType()) is None:
         raise Exception("Create PushButton for %s is not present" % markupNode.GetMarkupType())
@@ -218,7 +218,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
       raise Exception("Could't get the Markups module widget")
 
     for additionalOptionsWidget in self.additionalOptionsWidgets():
-      self.delayDisplay("Registering %s" % additionalOptionsWidget.objectName)
+      slicer.util.delayDisplay("Registering %s" % additionalOptionsWidget.objectName)
       additionalOptionsWidgetsFactory.registerAdditionalOptionsWidget(additionalOptionsWidget)
 
       # Check the widget exists
@@ -230,7 +230,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
     """
     Run the tests
     """
-    self.delayDisplay('Running integration tests for Pluggable Markups')
+    slicer.util.delayDisplay('Running integration tests for Pluggable Markups')
 
     self.test_unregister_existing_markups()
     self.test_register_markups()

--- a/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
+++ b/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
@@ -111,10 +111,6 @@ class AddStorableDataAfterSceneViewTestLogic(ScriptedLoadableModuleLogic):
       errorMessage = "Add storable data after scene view test: Exception!\n\n" + str(e) + "\n\nSee Python Console for Stack Trace"
       slicer.util.errorDisplay(errorMessage)
 
-    # Capture screenshot
-    if enableScreenshots:
-      self.takeScreenshot('AddStorableDataAfterSceneViewTest-Start','MyScreenshot',-1)
-
     logging.info('Processing completed')
 
     return True

--- a/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
@@ -96,28 +96,28 @@ class VolumeRenderingSceneCloseLogic(ScriptedLoadableModuleLogic):
     layoutManager = slicer.app.layoutManager()
     layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutConventionalView)
 
-    self.delayDisplay('Running the aglorithm')
+    slicer.util.delayDisplay('Running the aglorithm')
 
     import SampleData
     ctVolume = SampleData.downloadSample('CTChest')
-    self.delayDisplay('Downloaded CT sample data')
+    slicer.util.delayDisplay('Downloaded CT sample data')
 
     # go to the volume rendering module
     slicer.util.mainWindow().moduleSelector().selectModule('VolumeRendering')
-    self.delayDisplay('Volume Rendering module')
+    slicer.util.delayDisplay('Volume Rendering module')
 
     # turn it on
     volumeRenderingWidgetRep = slicer.modules.volumerendering.widgetRepresentation()
     volumeRenderingWidgetRep.setMRMLVolumeNode(ctVolume)
     volumeRenderingNode = slicer.mrmlScene.GetFirstNodeByName('VolumeRendering')
     volumeRenderingNode.SetVisibility(1)
-    self.delayDisplay('Volume Rendering')
+    slicer.util.delayDisplay('Volume Rendering')
 
     # set up a cropping ROI
     volumeRenderingNode.SetCroppingEnabled(1)
     annotationROI = slicer.mrmlScene.GetFirstNodeByName('AnnotationROI')
     annotationROI.SetDisplayVisibility(1)
-    self.delayDisplay('Cropping')
+    slicer.util.delayDisplay('Cropping')
 
     # close the scene
     slicer.mrmlScene.Clear(0)

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -347,8 +347,8 @@ Slicer_Remote_Add(CompareVolumes
 list_conditional_append(Slicer_BUILD_CompareVolumes Slicer_REMOTE_DEPENDENCIES CompareVolumes)
 
 Slicer_Remote_Add(LandmarkRegistration
-  GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/pieper/LandmarkRegistration"
-  GIT_TAG b6935353d49bea3291635874adaa2ebfd9e0f8c9
+  GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/LandmarkRegistration"
+  GIT_TAG 81089c82858411cea7fe260851ec042433b5c074
   OPTION_NAME Slicer_BUILD_LandmarkRegistration
   OPTION_DEPENDS "Slicer_BUILD_CompareVolumes;Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
As I found out in https://github.com/Slicer/Slicer/pull/5582#issuecomment-818070072 there are some methods in ScriptedLoadableModuleLogic class that is intended for testing purposes only. Therefore the work (originally mentioned in https://github.com/Slicer/Slicer/pull/5582#issuecomment-818758575) in this PR moves these methods to the ScriptedLoadableModuleTest class and update a few tests that were using the testing methods from the logic class. 

Part of this is enforcing the removal of some deprecated methods in the ScriptedLoadableModuleLogic class. `delayDisplay` usage in ScriptedLoadableModuleLogic has been deprecated since Dec 10th 2014 and `clickAndDrag` usage since Dec 6th 2016.