### PR TITLE
BUG: Fix use of qrcc when building against Python3.9

### DIFF
--- a/Utilities/Scripts/qrcc.py
+++ b/Utilities/Scripts/qrcc.py
@@ -64,7 +64,7 @@ def compileResources(in_path, out_file, args):
 
     os.remove(tmp_path)
 
-  _data = base64.encodestring(data).rstrip().decode()
+  _data = base64.encodebytes(data).rstrip().decode()
 
   # Write output script
   out_file.write(_header)


### PR DESCRIPTION
This commit replaces usage of base64.encodestring for base64.encodebytes
that was deprecated in python 3.1 and removed in 3.9.

See https://bugs.python.org/issue39351
