### PR TITLE
BUG: Fix 'fabs' was not declared

### DIFF
--- a/Base/Logic/vtkImageRectangularSource.cxx
+++ b/Base/Logic/vtkImageRectangularSource.cxx
@@ -9,6 +9,7 @@
 
 // STD includes
 #include <cassert>
+#include <cmath> // for fabs
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkImageRectangularSource);

--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.h
@@ -29,6 +29,7 @@
 
 // std includes
 #include <vector>
+#include <cmath> // for fabs
 
 class vtkImageData;
 class vtkMatrix4x4;


### PR DESCRIPTION
Adding `<cmath>` header.

In:
- vtkImageRectangularSource.cxx
- vtkOrientedImageDataResample.h