### PR TITLE
BUG: Fix missing markups place button icon

### DIFF
--- a/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
@@ -78,7 +78,7 @@ int qSlicerMouseModeToolBarTest1(int argc, char * argv[] )
     // add the new annotation types to it
     selectionNode->AddNewPlaceNodeClassNameToList("vtkMRMLAnnotationFiducialNode", ":/Icons/AnnotationPointWithArrow.png", "Fiducial");
     selectionNode->AddNewPlaceNodeClassNameToList("vtkMRMLAnnotationRulerNode", ":/Icons/AnnotationDistanceWithArrow.png", "Ruler");
-    selectionNode->AddNewPlaceNodeClassNameToList("vtkMRMLMarkupsFiducialNode", ":/Icons/MarkupsMouseModePlace.png");
+    selectionNode->AddNewPlaceNodeClassNameToList("vtkMRMLMarkupsFiducialNode", ":/Icons/MarkupsFiducialMouseModePlace.png");
 
     selectionNode->SetReferenceActivePlaceNodeClassName("vtkMRMLAnnotationFiducialNode");
     activeActionText = activePlaceActionText(mouseToolBar);

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerMarkupsPlaceWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerMarkupsPlaceWidget.ui
@@ -58,7 +58,7 @@
      </property>
      <property name="icon">
       <iconset resource="../../../Resources/qSlicerMarkupsModule.qrc">
-       <normaloff>:/Icons/MarkupsMouseModePlace.png</normaloff>:/Icons/MarkupsMouseModePlace.png</iconset>
+       <normaloff>:/Icons/MarkupsFiducialMouseModePlace.png</normaloff>:/Icons/MarkupsFiducialMouseModePlace.png</iconset>
      </property>
      <property name="checkable">
       <bool>true</bool>

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -399,6 +399,7 @@ void qSlicerMarkupsPlaceWidget::updateWidget()
     {
     d->ColorButton->setEnabled(false);
     d->PlaceButton->setEnabled(false);
+    d->PlaceButton->setIcon(QIcon(":/Icons/MarkupsGenericMouseModePlace.png"));
     d->DeleteButton->setEnabled(false);
     d->MoreButton->setEnabled(false);
     bool wasBlockedColorButton = d->ColorButton->blockSignals(true);
@@ -460,6 +461,7 @@ void qSlicerMarkupsPlaceWidget::updateWidget()
   bool wasBlockedPlaceButton = d->PlaceButton->blockSignals( true );
   d->PlaceButton->setChecked(placeModeEnabled());
   d->PlaceButton->blockSignals( wasBlockedPlaceButton );
+  d->PlaceButton->setIcon(QIcon(currentMarkupsNode->GetAddIcon()));
 
   bool wasBlockedPersistencyAction = d->ActionPersistent->blockSignals( true );
   d->ActionPersistent->setChecked(placeModePersistency());


### PR DESCRIPTION
This closes #5608.

MarkupsMouse... became "MarkupsFiducialMouse... for naming consistency in 6082a9bf488431ab0d14748c577f82c1dcf29e17


```python
widget = slicer.qSlicerMarkupsPlaceWidget()
widget.show()
```

| Current | This PR |
|----------|---------|
|![image](https://user-images.githubusercontent.com/15837524/115563728-d7372e80-a285-11eb-83b6-a9f56903d437.png) |![image](https://user-images.githubusercontent.com/15837524/115587830-1a9c9780-a29c-11eb-9b21-117720bc4622.png)|
