### PR TITLE
ENH: Add restoreGUIState/saveGUIState to qSlicerMainWindow public API

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.h
+++ b/Base/QTApp/qSlicerMainWindow.h
@@ -117,6 +117,22 @@ public slots:
   virtual void on_PasteAction_triggered();
   virtual void on_ViewExtensionsManagerAction_triggered();
 
+  /// Read GUI state from application settings and update the user interface accordingly.
+  ///
+  /// GUI state includes:
+  /// - main window state and geometry (only if MainWindow/geometry application setting is
+  ///   enabled or force argument is set to true)
+  /// - current view layout ID
+  /// - favorite modules
+  /// - recently loaded files
+  ///
+  /// \sa restoreGUIState()
+  virtual void saveGUIState(bool force=false);
+
+  /// Write GUI state to application settings.
+  /// \sa saveGUIState()
+  virtual void restoreGUIState(bool force=false);
+
 signals:
   /// Emitted when the window is first shown to the user.
   /// \sa showEvent(QShowEvent *)

--- a/Base/QTApp/qSlicerMainWindow_p.h
+++ b/Base/QTApp/qSlicerMainWindow_p.h
@@ -52,9 +52,6 @@ public:
   virtual void setupUi(QMainWindow * mainWindow);
   virtual void setupStatusBar();
 
-  virtual void readSettings();
-  virtual void writeSettings();
-
   virtual void setupRecentlyLoadedMenu(const QList<qSlicerIO::IOProperties>& fileProperties);
 
   virtual void filterRecentlyLoadedFileProperties();


### PR DESCRIPTION
This is useful when writing custom applications overriding the default
application close behavior.

See https://www.slicer.org/wiki/Documentation/Nightly/ScriptRepository#Override_application_close_behavior