### PR TITLE
COMP: Fix configruation of qSlicerSimpleMarkupsWidgetTest1 with QtTesting OFF

### DIFF
--- a/Modules/Loadable/Markups/Widgets/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Widgets/Testing/Cxx/CMakeLists.txt
@@ -5,46 +5,38 @@ set(INPUT ${MRMLCore_SOURCE_DIR}/Testing)
 
 #-----------------------------------------------------------------------------
 set(KIT_TEST_SOURCES
+  qSlicerMarkupsAdditionalOptionsWidgetsFactoryTest.cxx
   qSlicerSimpleMarkupsWidgetTest1.cxx
   )
 
-if(Slicer_USE_QtTesting)
+create_test_sourcelist(Tests ${KIT}CppTests.cxx
+  ${KIT_TEST_SOURCES}
+  )
 
-  list(APPEND KIT_TEST_SOURCES
-    qSlicerMarkupsAdditionalOptionsWidgetsFactoryTest.cxx
-    )
+set(Tests_MOC_SRCS
+  qSlicerMarkupsMalformedWidget.h
+  )
+set(Tests_UtilityFiles
+  qSlicerMarkupsMalformedWidget.h
+  qSlicerMarkupsMalformedWidget.cxx
+  )
 
-  create_test_sourcelist(Tests ${KIT}CppTests.cxx
-    ${KIT_TEST_SOURCES}
-    )
+set(KIT_TEST_GENERATE_MOC_SRCS
+  qSlicerMarkupsAdditionalOptionsWidgetsFactoryTest.cxx
+  )
 
-  set(Tests_MOC_SRCS qSlicerMarkupsMalformedWidget.h)
-  set(Tests_UtilityFiles
-    qSlicerMarkupsMalformedWidget.h
-    qSlicerMarkupsMalformedWidget.cxx
-    )
+set(_moc_options OPTIONS -DMRML_WIDGETS_HAVE_QT5)
+QT5_WRAP_CPP(Tests_MOC_CXX ${Tests_MOC_SRCS} ${_moc_options})
+QT5_GENERATE_MOCS(${KIT_TEST_GENERATE_MOC_SRCS})
 
-  set(KIT_TEST_GENERATE_MOC_SRCS
-    qSlicerMarkupsAdditionalOptionsWidgetsFactoryTest.cxx
-    )
+include_directories( ${CMAKE_CURRENT_BINARY_DIR})
+include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
 
-  set(_moc_options OPTIONS -DMRML_WIDGETS_HAVE_QT5)
-  QT5_WRAP_CPP(Tests_MOC_CXX ${Tests_MOC_SRCS} ${_moc_options})
-  QT5_GENERATE_MOCS(${KIT_TEST_GENERATE_MOC_SRCS})
+ctk_add_executable_utf8(${KIT}CxxTests ${Tests} ${Tests_MOC_CXX} ${Tests_UtilityFiles})
+target_link_libraries(${KIT}CxxTests ${KIT})
 
-  include_directories( ${CMAKE_CURRENT_BINARY_DIR})
-  include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
-
-  ctk_add_executable_utf8(${KIT}CxxTests ${Tests} ${Tests_MOC_CXX} ${Tests_UtilityFiles})
-  target_link_libraries(${KIT}CxxTests ${KIT})
-
-  set_target_properties(${KIT}CxxTests PROPERTIES FOLDER "Module-${KIT}")
-
-endif()
+set_target_properties(${KIT}CxxTests PROPERTIES FOLDER "Module-${KIT}")
 
 #-----------------------------------------------------------------------------
+simple_test( qSlicerMarkupsAdditionalOptionsWidgetsFactoryTest )
 simple_test( qSlicerSimpleMarkupsWidgetTest1 )
-
-if(Slicer_USE_QtTesting)
-  simple_test( qSlicerMarkupsAdditionalOptionsWidgetsFactoryTest )
-endif()


### PR DESCRIPTION
This commit fixes a regression introduced in 0242927e3 (ENH: Add unit tests
for markups factory)

This pull request fixes the following error:

```
CMake Error at CMake/SlicerMacroSimpleTest.cmake:61 (message):
  error: Target 'qSlicerMarkupsModuleWidgetsCxxTests' is not defined !
Call Stack (most recent call first):
  Modules/Loadable/Markups/Widgets/Testing/Cxx/CMakeLists.txt:46 (simple_test)
```