### PR TITLE
ENH: Update CTK to include multi-instance DICOM display roles

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "2e0abb8edbdff62a66e0edd1ca5df488a7b605e4"
+    "88d954ff72676c96002134de379a92fb8551f476"
     QUIET
     )
 


### PR DESCRIPTION
A recent change in CTK converted four hard-coded multi-instance display fields (i.e. they concern more than a single instance such as series/study/patient), and fixed the last study date role, which sometimes failed to calculate the date on newly added datasets.