### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/Applications/SlicerApp/Testing/Python/AtlasTests.py
+++ b/Applications/SlicerApp/Testing/Python/AtlasTests.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/CLIEventTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLIEventTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 from __main__ import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/CLISerializationTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLISerializationTest.py
@@ -17,7 +17,6 @@
 #  This file was originally developed by Johan Andruejol, Kitware Inc.
 #
 
-from __future__ import print_function
 import argparse
 import csv
 import json
@@ -33,7 +32,7 @@ Usage:
     CLISerializationTest.py
       /path/to/Slicer /path/to/CLIExecutables /path/to/data_dir /path/to/temp_dir
 """
-class CLISerializationTest(object):
+class CLISerializationTest:
   def __init__(self):
     self.SlicerExecutable = None
 

--- a/Applications/SlicerApp/Testing/Python/Charting.py
+++ b/Applications/SlicerApp/Testing/Python/Charting.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import math

--- a/Applications/SlicerApp/Testing/Python/DICOMReaders.py
+++ b/Applications/SlicerApp/Testing/Python/DICOMReaders.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import logging
 import numpy
 import os
@@ -178,7 +177,7 @@ class DICOMReadersTest(ScriptedLoadableModuleTest):
           for secondApproachIndex in range(approachIndex+1,len(approachesThatLoaded)):
             secondApproach = approachesThatLoaded[secondApproachIndex]
             secondVolume = volumesByApproach[secondApproach]
-            print('comparing  %s,%s' % (firstApproach, secondApproach))
+            print(f'comparing  {firstApproach},{secondApproach}')
             comparison = slicer.modules.dicomPlugins['DICOMScalarVolumePlugin'].compareVolumeNodes(firstVolume,secondVolume)
             if comparison != "":
               print(('failed: %s', comparison))

--- a/Applications/SlicerApp/Testing/Python/DWMRIMultishellIOTests.py
+++ b/Applications/SlicerApp/Testing/Python/DWMRIMultishellIOTests.py
@@ -25,7 +25,7 @@ def parse_nhdr(path):
     kvdict = {}
     grad_count = 0
 
-    with open(path, "rU") as f:
+    with open(path) as f:
         magic = f.readline().strip()
         assert(magic == "NRRD0005")
 
@@ -121,7 +121,7 @@ def test_nrrd_dwi_load(first_file, second_file=None):
     # 3) check gradients in the node attribute dictionary
     #    gradients must match the value on-disk.
     for i in range(0, slicer_numgrads):
-        grad_key = "DWMRI_gradient_{:04d}".format(i)
+        grad_key = f"DWMRI_gradient_{i:04d}"
         parsed_gradient = np.fromstring(parsed_nrrd.header[grad_key], count=3, sep=' ', dtype=np.float64)
         attr_gradient =   np.fromstring(dw_node.GetAttribute(grad_key), count=3, sep=' ', dtype=np.float64)
 

--- a/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
+++ b/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import math
@@ -105,7 +104,7 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
     fidIndex = markupsLogic.AddFiducial(eye[0], eye[1], eye[2])
     fidID = markupsLogic.GetActiveListID()
     fidNode = slicer.mrmlScene.GetNodeByID(fidID)
-    self.delayDisplay("Placed a fiducial at %g, %g, %g" % (eye[0], eye[1], eye[2]))
+    self.delayDisplay(f"Placed a fiducial at {eye[0]:g}, {eye[1]:g}, {eye[2]:g}")
 
     # Pan and zoom
     sliceWidget = slicer.app.layoutManager().sliceWidget('Red')
@@ -166,9 +165,9 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
       print('Checking the difference between fiducial RAS position',seedRAS,
             'and volume RAS as derived from the fiducial display position',volumeRAS,': ',rasDiff)
       if rasDiff > maximumRASDifference:
-        raise Exception("RAS coordinate difference is too large as well!\nExpected < %g but got %g" % (maximumRASDifference, rasDiff))
+        raise Exception(f"RAS coordinate difference is too large as well!\nExpected < {maximumRASDifference:g} but got {rasDiff:g}")
       else:
-        self.delayDisplay("RAS coordinate difference is %g which is < %g, test passes." % (rasDiff, maximumRASDifference))
+        self.delayDisplay(f"RAS coordinate difference is {rasDiff:g} which is < {maximumRASDifference:g}, test passes.")
 
     if enableScreenshots == 1:
       # compare the screen snapshots

--- a/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
+++ b/Applications/SlicerApp/Testing/Python/JRC2013Vis.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/KneeAtlasTest.py
+++ b/Applications/SlicerApp/Testing/Python/KneeAtlasTest.py
@@ -1,9 +1,8 @@
-from __future__ import print_function
 import unittest
 import slicer
 import AtlasTests
 
-class testClass(object):
+class testClass:
   """ Run the knee atlas test by itself
   """
 

--- a/Applications/SlicerApp/Testing/Python/MeasureStartupTimes.py
+++ b/Applications/SlicerApp/Testing/Python/MeasureStartupTimes.py
@@ -18,7 +18,6 @@
 #  and was partially funded by NIH grant 1U24CA194354-01
 #
 
-from __future__ import print_function
 import argparse
 import json
 import os
@@ -40,7 +39,7 @@ def TemporaryPythonScript(code, *args, **kwargs):
   script = tempfile.NamedTemporaryFile(*args, **kwargs)
   script.write(code)
   script.flush()
-  print("Written script %s [%s]" % (script.name, code))
+  print(f"Written script {script.name} [{code}]")
   return script
 
 def collect_startup_times_normal(output_file, drop_cache=False, display_output=False):

--- a/Applications/SlicerApp/Testing/Python/RSNA2012ProstateDemo.py
+++ b/Applications/SlicerApp/Testing/Python/RSNA2012ProstateDemo.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
+++ b/Applications/SlicerApp/Testing/Python/RSNAVisTutorial.py
@@ -125,7 +125,7 @@ class RSNAVisTutorialWidget(ScriptedLoadableModuleWidget):
 
   def onReloadAndTest(self,moduleName="RSNAVisTutorial"):
     self.onReload()
-    evalString = 'globals()["%s"].%sTest()' % (moduleName, moduleName)
+    evalString = f'globals()["{moduleName}"].{moduleName}Test()'
     tester = eval(evalString)
     tester.runTest()
 

--- a/Applications/SlicerApp/Testing/Python/ScenePerformance.py
+++ b/Applications/SlicerApp/Testing/Python/ScenePerformance.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer
@@ -170,10 +169,10 @@ class ScenePerformanceTest(ScriptedLoadableModuleTest):
 
   def reportPerformance(self, action, property, time):
     message = self.displayPerformance(action, property, time)
-    print ( '<DartMeasurement name="%s-%s" type="numeric/integer">%s</DartMeasurement>' % (action, property, time))
+    print ( f'<DartMeasurement name="{action}-{property}" type="numeric/integer">{time}</DartMeasurement>')
     return message
   def displayPerformance(self, action, property, time):
-    message = '%s (%s) took %s msecs ' % (action, property, time)
+    message = f'{action} ({property}) took {time} msecs '
     self.delayDisplay(message)
     return message
 

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
@@ -1,4 +1,3 @@
-
 import __main__
 
 assert not hasattr(__main__, 'SOMEVAR')

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from slicer.ScriptedLoadableModule import *
 
 SOMEVAR = 'A'

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleB.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleB.py
@@ -1,4 +1,3 @@
-
 from slicer.ScriptedLoadableModule import *
 
 SOMEVAR = 'B'

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleC_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleC_WithoutWidget.py
@@ -1,4 +1,3 @@
-
 from slicer.ScriptedLoadableModule import *
 
 SOMEVAR = 'C'

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleD_WithFileDialog_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleD_WithFileDialog_WithoutWidget.py
@@ -1,4 +1,3 @@
-
 from slicer.ScriptedLoadableModule import *
 
 SOMEVAR = 'D'
@@ -20,7 +19,7 @@ class ModuleD_WithFileDialog_WithoutWidget(ScriptedLoadableModule):
     return SOMEVAR
 
 
-class DICOMFileDialog(object):
+class DICOMFileDialog:
 
   def __init__(self,qSlicerFileDialog):
     self.qSlicerFileDialog = qSlicerFileDialog

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleE_WithFileWriter_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleE_WithFileWriter_WithoutWidget.py
@@ -1,4 +1,3 @@
-
 from slicer.ScriptedLoadableModule import *
 
 SOMEVAR = 'E'

--- a/Applications/SlicerApp/Testing/Python/ShaderProperties.py
+++ b/Applications/SlicerApp/Testing/Python/ShaderProperties.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/SliceLinkLogic.py
+++ b/Applications/SlicerApp/Testing/Python/SliceLinkLogic.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/Slicer4Minute.py
+++ b/Applications/SlicerApp/Testing/Python/Slicer4Minute.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/SlicerAppTesting.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerAppTesting.py
@@ -27,7 +27,6 @@
 # We mean it.
 #
 
-from __future__ import print_function
 
 import os
 import pipes
@@ -53,7 +52,7 @@ def run(executable, arguments=[], verbose=True, shell=False, drop_cache=False):
   if drop_cache:
     dropcache()
   if verbose:
-    print("%s %s" % (os.path.basename(executable), " ".join([pipes.quote(arg) for arg in arguments])))
+    print("{} {}".format(os.path.basename(executable), " ".join([pipes.quote(arg) for arg in arguments])))
   arguments.insert(0, executable)
   if shell:
     arguments = " ".join([pipes.quote(arg) for arg in arguments])
@@ -92,9 +91,9 @@ def timecall(method, **kwargs):
       start = time.time()
       result = method(*args, **kwargs)
       durations.append(time.time() - start)
-      print("{:d}/{:d}: {:.2f}s".format(iteration, repeat, durations[-1]))
+      print(f"{iteration:d}/{repeat:d}: {durations[-1]:.2f}s")
     average = sum(durations) / len(durations)
-    print("Average: {:.2f}s\n".format(average))
+    print(f"Average: {average:.2f}s\n")
     duration = average
     return (duration, result)
   return wrapper

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBSaveRestoreCheckPathsTest.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
@@ -180,10 +178,10 @@ class SlicerMRBSaveRestoreCheckPaths(ScriptedLoadableModuleTest):
     slicer.util.delayDisplay('Temp dir = %s ' % tempDir)
     mrmlFilePath = tempDir + '/SlicerMRBSaveRestoreCheckPath.mrml'
     slicer.mrmlScene.SetURL(mrmlFilePath)
-    slicer.util.delayDisplay('Saving mrml file to %s, current url of scene is %s' % (mrmlFilePath, slicer.mrmlScene.GetURL()))
+    slicer.util.delayDisplay(f'Saving mrml file to {mrmlFilePath}, current url of scene is {slicer.mrmlScene.GetURL()}')
     # saveScene just writes out the .mrml file
     self.assertTrue(ioManager.saveScene(mrmlFilePath, screenShot))
-    slicer.util.delayDisplay('Finished saving mrml file %s, mrml url is now %s\n\n\n' % (mrmlFilePath, slicer.mrmlScene.GetURL()))
+    slicer.util.delayDisplay(f'Finished saving mrml file {mrmlFilePath}, mrml url is now {slicer.mrmlScene.GetURL()}\n\n\n')
     slicer.util.delayDisplay('mrml root dir = %s' % slicer.mrmlScene.GetRootDirectory())
     # explicitly save MRHead
     ioManager.addDefaultStorageNodes()

--- a/Applications/SlicerApp/Testing/Python/SlicerOptionDisableSettingsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOptionDisableSettingsTest.py
@@ -18,7 +18,6 @@
 #  and was partially funded by NIH grant 1U24CA194354-01
 #
 
-from __future__ import print_function
 import os
 import sys
 
@@ -82,8 +81,8 @@ def checkKeepTemporarySettingsWithoutDisableSettingsDisplayWarning(slicer_execut
   (returnCode, stdout, stderr) = runSlicerAndExit(slicer_executable, args)
   expectedMessage = "Argument '--keep-temporary-settings' requires '--settings-disabled' to be specified."
   if expectedMessage not in stderr:
-    print("=> return code{0}\n".format(returnCode))
-    raise Exception("Warning [%s] not found in stderr [%s]" % (expectedMessage, stderr))
+    print(f"=> return code{returnCode}\n")
+    raise Exception(f"Warning [{expectedMessage}] not found in stderr [{stderr}]")
   assert returnCode == EXIT_SUCCESS
   print("=> ok\n")
 

--- a/Applications/SlicerApp/Testing/Python/SlicerOptionIgnoreSlicerRCTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOptionIgnoreSlicerRCTest.py
@@ -18,7 +18,6 @@
 #  and was partially funded by NIH grant 1U24CA194354-01
 #
 
-from __future__ import print_function
 import os
 import sys
 import tempfile

--- a/Applications/SlicerApp/Testing/Python/SlicerOptionModulesToIgnoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOptionModulesToIgnoreTest.py
@@ -18,7 +18,6 @@
 #  and was partially funded by NIH grant 1U24CA194354-01
 #
 
-from __future__ import print_function
 import os
 import shutil
 import sys
@@ -58,7 +57,7 @@ if __name__ == '__main__':
   moduleNames = ['A', 'B', 'C', 'D']
 
   additional_module_paths = ['--additional-module-paths']
-  additional_module_paths.extend(['%s/Test/%s' % (extension_dir, moduleName) for moduleName in moduleNames])
+  additional_module_paths.extend([f'{extension_dir}/Test/{moduleName}' for moduleName in moduleNames])
 
   args = ['--create', 'Test']
   for moduleName in moduleNames:

--- a/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerOrientationSelectorTest.py
@@ -123,6 +123,6 @@ class SlicerOrientationSelectorTestTest(ScriptedLoadableModuleTest):
     orientations = [sliceOrientationSelector.itemText(idx) for idx in range(sliceOrientationSelector.count)]
     expectedOrientations = ['Axial', 'Sagittal', 'Coronal', 'Reformat']
     if orientations != expectedOrientations:
-      raise Exception('Problem with orientation selector\norientations: %s\nexpectedOrientations: %s' % (orientations, expectedOrientations))
+      raise Exception(f'Problem with orientation selector\norientations: {orientations}\nexpectedOrientations: {expectedOrientations}')
 
     self.delayDisplay('Test passed!')

--- a/Applications/SlicerApp/Testing/Python/SlicerSceneObserverTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerSceneObserverTest.py
@@ -1,13 +1,12 @@
-from __future__ import print_function
 import unittest
 import slicer
 import vtk
 
-class testClass(object):
+class testClass:
   """ Check that slicer exits correctly after adding an observer to the mrml scene
   """
   def callback(self, caller, event):
-    print('Got %s from %s' % (event, caller))
+    print(f'Got {event} from {caller}')
 
   def setUp(self):
     print("Adding observer to the scene")

--- a/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerScriptedFileReaderWriterTest.py
@@ -25,7 +25,7 @@ class SlicerScriptedFileReaderWriterTestWidget(ScriptedLoadableModuleWidget):
     # Default reload&test widgets are enough.
     # Note that reader and writer is not reloaded.
 
-class SlicerScriptedFileReaderWriterTestFileReader(object):
+class SlicerScriptedFileReaderWriterTestFileReader:
 
   def __init__(self, parent):
     self.parent = parent
@@ -45,7 +45,7 @@ class SlicerScriptedFileReaderWriterTestFileReader(object):
       return False
 
     firstLine = ''
-    with open(filePath, 'r') as f:
+    with open(filePath) as f:
       firstLine = f.readline()
     validFile = 'magic' in firstLine
     return validFile
@@ -62,7 +62,7 @@ class SlicerScriptedFileReaderWriterTestFileReader(object):
         baseName = slicer.mrmlScene.GenerateUniqueName(baseName)
 
       # Read file content
-      with open (filePath, 'r') as myfile:
+      with open (filePath) as myfile:
         data = myfile.readlines()
 
       # Check if file is valid
@@ -84,7 +84,7 @@ class SlicerScriptedFileReaderWriterTestFileReader(object):
     return True
 
 
-class SlicerScriptedFileReaderWriterTestFileWriter(object):
+class SlicerScriptedFileReaderWriterTestFileWriter:
 
   def __init__(self, parent):
     self.parent = parent

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedTest.py
@@ -18,7 +18,6 @@
 #  and was partially funded by NIH grant 1U24CA194354-01
 #
 
-from __future__ import print_function
 import os
 import sys
 import tempfile

--- a/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedTestHelperModule.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerStartupCompletedTestHelperModule.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import slicer
 import os
 

--- a/Applications/SlicerApp/Testing/Python/SlicerTestingExitFailureTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTestingExitFailureTest.py
@@ -1,2 +1,1 @@
-
 raise Exception('This test is expected to fail')

--- a/Applications/SlicerApp/Testing/Python/SlicerTestingExitSuccessTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTestingExitSuccessTest.py
@@ -1,4 +1,2 @@
-from __future__ import print_function
-
 print("Hello Slicer !")
 

--- a/Applications/SlicerApp/Testing/Python/TwoCLIsInARowTest.py
+++ b/Applications/SlicerApp/Testing/Python/TwoCLIsInARowTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 from __main__ import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/TwoCLIsInParallelTest.py
+++ b/Applications/SlicerApp/Testing/Python/TwoCLIsInParallelTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 from __main__ import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926.py
+++ b/Applications/SlicerApp/Testing/Python/ViewControllersSliceInterpolationBug1926.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Applications/SlicerApp/Testing/Python/WebEngine.py
+++ b/Applications/SlicerApp/Testing/Python/WebEngine.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import math

--- a/Applications/SlicerApp/Testing/Python/bSlicerTestingExitSuccessTest.py
+++ b/Applications/SlicerApp/Testing/Python/bSlicerTestingExitSuccessTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # Name of this file starts with 'b' to verify that having ...\b... in the full path
 # a Python script does not cause any errors (on Windows, path may be defined using backslash).
 # See more details in https://issues.slicer.org/view.php?id=4471.

--- a/Applications/SlicerApp/Testing/Python/sceneImport2428.py
+++ b/Applications/SlicerApp/Testing/Python/sceneImport2428.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer
@@ -231,7 +230,7 @@ verifyModels()
     for n in range(numModels):
       modelNode = slicer.mrmlScene.GetNthNodeByClass( n, "vtkMRMLModelNode" )
       if polyDataInScene.count(modelNode.GetPolyData()) > 1:
-        self.delayDisplay("Polydata for Model is duplicated! (id: %s and %s)" % (n,modelNode.GetID()))
+        self.delayDisplay(f"Polydata for Model is duplicated! (id: {n} and {modelNode.GetID()})")
         success = False
 
     return success

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os, string
 import unittest
 import vtk, qt, ctk, slicer
@@ -7,7 +6,7 @@ import importlib
 
 __all__ = ['ScriptedLoadableModule', 'ScriptedLoadableModuleWidget', 'ScriptedLoadableModuleLogic', 'ScriptedLoadableModuleTest']
 
-class ScriptedLoadableModule(object):
+class ScriptedLoadableModule:
   def __init__(self, parent):
     self.parent = parent
     self.moduleName = self.__class__.__name__
@@ -48,7 +47,7 @@ This work is partially supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colon
     """
     if not docPage:
       docPage = "Modules/"+self.moduleName
-    linkText = '<p>For more information see the <a href="{0}/Documentation/{1}.{2}/{3}">online documentation</a>.</p>'.format(
+    linkText = '<p>For more information see the <a href="{}/Documentation/{}.{}/{}">online documentation</a>.</p>'.format(
       self.parent.slicerWikiUrl, slicer.app.majorVersion, slicer.app.minorVersion, docPage)
     return linkText
 
@@ -63,13 +62,13 @@ This work is partially supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colon
       TestCaseClass = getattr(module, className)
     except AttributeError:
       # Treat missing test case class as a failure; provide useful error message
-      raise AssertionError('Test case class not found: %s.%s ' % (self.__module__, className))
+      raise AssertionError(f'Test case class not found: {self.__module__}.{className} ')
 
     testCase = TestCaseClass()
     testCase.messageDelay = msec
     testCase.runTest(**kwargs)
 
-class ScriptedLoadableModuleWidget(object):
+class ScriptedLoadableModuleWidget:
   def __init__(self, parent = None):
     """If parent widget is not specified: a top-level widget is created automatically;
     the application has to delete this widget (by calling widget.parent.deleteLater() to avoid memory leaks.
@@ -212,7 +211,7 @@ class ScriptedLoadableModuleWidget(object):
     filePath = slicer.util.modulePath(self.moduleName)
     qt.QDesktopServices.openUrl(qt.QUrl("file:///"+filePath, qt.QUrl.TolerantMode))
 
-class ScriptedLoadableModuleLogic(object):
+class ScriptedLoadableModuleLogic:
   def __init__(self, parent = None):
     # Get module name by stripping 'Logic' from the class name
     self.moduleName = self.__class__.__name__
@@ -290,7 +289,7 @@ class ScriptedLoadableModuleTest(unittest.TestCase):
   """
 
   def __init__(self, *args, **kwargs):
-    super(ScriptedLoadableModuleTest, self).__init__(*args, **kwargs)
+    super().__init__(*args, **kwargs)
 
     # takeScreenshot default parameters
     self.enableScreenshots = False

--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -1,5 +1,4 @@
 """ This module sets up root logging and loads the Slicer library modules into its namespace."""
-from __future__ import print_function
 
 #-----------------------------------------------------------------------------
 def _createModule(name, globals, docstring):

--- a/Base/Python/slicer/cli.py
+++ b/Base/Python/slicer/cli.py
@@ -1,5 +1,4 @@
 """ This module is a place holder for convenient functions allowing to interact with CLI."""
-from __future__ import print_function
 
 def createNode(cliModule, parameters = None):
   """Creates a new vtkMRMLCommandLineModuleNode for a specific module, with

--- a/Base/Python/slicer/release/midasdata.py
+++ b/Base/Python/slicer/release/midasdata.py
@@ -4,7 +4,6 @@
     The script does not accept any input arguments. All arguments are to be provided using the option flags. For a list of the option flags, run
         python release.py --help"""
 
-from __future__ import print_function
 
 from optparse import OptionParser
 import re, sys
@@ -202,17 +201,17 @@ def versionDataModulesDirectory(sourceVersion, destVersion, token, communicator,
     # If needed, create a new folder for destination under the module folder
     destIndex = _getFolderIndex(availableVersions, destVersion)
     if destIndex == -1:
-      print("Creating folder %s under %s module directory" % (destVersion, moduleName))
+      print(f"Creating folder {destVersion} under {moduleName} module directory")
       dest_folder = communicator.create_folder(token, destVersion, moduleFolderID)
       destID = dest_folder["folder_id"]
     else:
-      print("Re-using existing folder %s under %s module directory" % (destVersion, moduleName))
+      print(f"Re-using existing folder {destVersion} under {moduleName} module directory")
       destID = _getIDfromIndex(availableVersions, "folder", destIndex)
 
     # Duplicate the child items from source to destination
     duplicateFolderItems(sourceID, destID, token, communicator, overwrite)
 
-    message = "Duplicating subfolders from %s to %s for %s module..." % (sourceVersion, destVersion, moduleName)
+    message = f"Duplicating subfolders from {sourceVersion} to {destVersion} for {moduleName} module..."
     print(message)
     # Duplicate all the sub-folders from source to destination
     duplicateFolderfolders(sourceID, destID, token, communicator, overwrite)
@@ -247,7 +246,7 @@ def printSourceStructure(modulesID, applicationID, sourceVersion, token, communi
       print("Warning:", msg)
       continue
     sourceModuleID = _getIDfromIndex(moduleChildren, "folder", sourceVersionModuleIndex)
-    print("Module:%s( folder_id:%s )" % (module["name"], sourceModuleID))
+    print("Module:{}( folder_id:{} )".format(module["name"], sourceModuleID))
     printFolderStructure(sourceModuleID, token, communicator, 1)
     print("\n")
 

--- a/Base/Python/slicer/release/midasdata_test.py
+++ b/Base/Python/slicer/release/midasdata_test.py
@@ -2,7 +2,6 @@
 """ Unit Test for NA-MIC data tree versioning script.
     This test requires the user to enter the Midas server URL, the authentication email, the authentication API key and folder ID of an empty folder. The test first creates a mock data tree in the empty folder provided and runs tests off of that.
     Usage: python midasdata_test.py"""
-from __future__ import print_function
 
 import midasdata
 import re

--- a/Base/Python/slicer/release/wiki.py
+++ b/Base/Python/slicer/release/wiki.py
@@ -102,7 +102,6 @@ Example of update
   skipping Template:Documentation/acknowledgments-versionlist: version is 4.6
   skipping Documentation: version 4.6 already added
 """
-from __future__ import print_function
 
 import argparse
 import logging
@@ -113,7 +112,7 @@ import re
 log = logging.getLogger(__name__)
 
 
-class Wiki(object):
+class Wiki:
 
   def __init__(self, username="UpdateBot", password=None):
     log.info("connecting")
@@ -184,26 +183,26 @@ class Wiki(object):
       # check if update is needed
       current_version = self.version_info(page_name)
       updated_version = updated_version_info[page_short_name]
-      log.debug("%s: current version: %s" % (page_short_name, current_version))
-      log.debug("%s: updated version: %s" % (page_short_name, updated_version))
+      log.debug(f"{page_short_name}: current version: {current_version}")
+      log.debug(f"{page_short_name}: updated version: {updated_version}")
       if current_version == updated_version:
-        log.info("skipping %s: version is %s" % (page_name, updated_version))
+        log.info(f"skipping {page_name}: version is {updated_version}")
         break
       # update page
       content = self.page_content(page_name)
       template = "<includeonly>%s</includeonly>"
-      log.debug("replacing '%s' with '%s'" % (
+      log.debug("replacing '{}' with '{}'".format(
         template % current_version, template % updated_version))
       content = content.replace(
         template % current_version, template % updated_version)
-      summary = "Update %s version from %s to %s" % (
+      summary = "Update {} version from {} to {}".format(
         page_short_name, current_version, updated_version)
       self.set_page_content(page_name, content, summary)
       # sanity check
       current_version = self.version_info(page_name)
       if current_version != updated_version:
         raise RuntimeError(
-          "Failed to update %s: %s version is %s" % (
+          "Failed to update {}: {} version is {}".format(
             page_name, page_short_name, current_version))
 
   def version_list(self):
@@ -216,7 +215,7 @@ class Wiki(object):
     current_list = self.version_list()
     page_name = "Template:Documentation/versionlist"
     if release_version in current_list:
-      log.info("skipping %s: version is %s" % (page_name, release_version))
+      log.info(f"skipping {page_name}: version is {release_version}")
       return
     # update page
     assert current_list[0] == "Nightly"
@@ -225,7 +224,7 @@ class Wiki(object):
     template = "[[Documentation/%s|%s]]"
     current = template % (current_version, current_version)
     updated = template % (release_version, release_version) + " " + current
-    log.debug("replacing '%s' with '%s'" % (current, updated))
+    log.debug(f"replacing '{current}' with '{updated}'")
     content = content.replace(current, updated)
     summary = "Add %s to version list" % current_version
     self.set_page_content(page_name, content, summary)
@@ -233,7 +232,7 @@ class Wiki(object):
     current_list = self.version_list()
     if release_version not in current_list:
       raise RuntimeError(
-        "Failed to update %s: version %s is not in the list" % (
+        "Failed to update {}: version {} is not in the list".format(
           page_name, release_version))
 
   def acknowledgments_main_version(self):
@@ -266,7 +265,7 @@ class Wiki(object):
       # check if update is needed
       current_version = self.redirect_page_version(redirect_page)
       if current_version == release_version:
-        log.info("skipping %s: version is %s" % (redirect_page, release_version))
+        log.info(f"skipping {redirect_page}: version is {release_version}")
         break
       # update page
       content = self.page_content(redirect_page)
@@ -274,14 +273,14 @@ class Wiki(object):
       log.debug("replacing %s" % (template % current_version))
       content = content.replace(
         template % current_version, template % release_version)
-      summary = "Update REDIRECT from Documentation/%s to Documentation/%s" % (
+      summary = "Update REDIRECT from Documentation/{} to Documentation/{}".format(
         current_version, release_version)
       self.set_page_content(redirect_page, content, summary)
       # sanity check
       current_version = self.redirect_page_version(redirect_page)
       if current_version != release_version:
         raise RuntimeError(
-          "Failed to update %s: version is %s" % (
+          "Failed to update {}: version is {}".format(
             redirect_page, current_version))
 
   def update_top_level_documentation_page(self, release_version):
@@ -295,11 +294,11 @@ class Wiki(object):
     content = self.page_content(page_name)
     if marker not in content:
       log.error(
-        "failed to update %s: marker %s not found" % (page_name, marker))
+        f"failed to update {page_name}: marker {marker} not found")
       return
     if template.format(version=release_version) in content:
       log.info(
-        "skipping %s: version %s already added" % (page_name, release_version))
+        f"skipping {page_name}: version {release_version} already added")
       return
     # update page
     content = content.replace(
@@ -320,14 +319,14 @@ def handle_query(wiki, args):
     print("Version info:")
     for page_short_name, page_name in Wiki.VERSION_INFO_PAGES.items():
       method = getattr(wiki, "%s_version" % page_short_name)
-      print("  %s: %s" % (page_name, method()))
+      print(f"  {page_name}: {method()}")
 
   def display_next_version_info():
     print("Next version info:")
     for page_short_name, version in \
             wiki.compute_updated_version_info(wiki.next_version()).items():
       page_name = Wiki.VERSION_INFO_PAGES[page_short_name]
-      print("  %s: %s" % (page_name, version))
+      print(f"  {page_name}: {version}")
 
   def display_version_list():
     print("Versions: %s" % " ".join(wiki.version_list()))
@@ -339,7 +338,7 @@ def handle_query(wiki, args):
   def display_redirect_pages_version():
     print("Redirect pages:")
     for redirect_page, version in wiki.redirect_pages_version():
-      print("  %s: %s" % (redirect_page, version))
+      print(f"  {redirect_page}: {version}")
 
   def display_all():
     display_version_info()

--- a/Base/Python/slicer/slicerqt.py
+++ b/Base/Python/slicer/slicerqt.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import logging
 import sys
 
@@ -8,7 +7,6 @@ import vtk
 
 import slicer
 from slicer.util import *
-del print_function
 
 # HACK Ideally constant from vtkSlicerConfigure should be wrapped,
 #      that way the following try/except could be avoided.
@@ -52,7 +50,7 @@ class SlicerApplicationLogHandler(logging.Handler):
       context.setFile(record.pathname)
       context.setFunction(record.funcName)
       context.setMessage(msg)
-      threadId = "{0}({1})".format(record.threadName, record.thread)
+      threadId = f"{record.threadName}({record.thread})"
       slicer.app.errorLogModel().addEntry(qt.QDateTime.currentDateTime(), threadId,
         self.pythonToCtkLevelConverter[record.levelno], self.origin, context, msg)
     except:
@@ -135,7 +133,7 @@ def loadSlicerRCFile():
 # Internal
 #
 
-class _Internal(object):
+class _Internal:
 
   def __init__( self ):
     import imp

--- a/Base/Python/slicer/testing.py
+++ b/Base/Python/slicer/testing.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # Testing
 #
@@ -18,7 +16,7 @@ def runUnitTest(path, testname):
   else:
     sys.path.extend(path)
   print("-------------------------------------------")
-  print("path: %s\ntestname: %s" % (path, testname))
+  print(f"path: {path}\ntestname: {testname}")
   print("-------------------------------------------")
   suite = unittest.TestLoader().loadTestsFromName(testname)
   result = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/Base/Python/slicer/tests/test_slicer_environment.py
+++ b/Base/Python/slicer/tests/test_slicer_environment.py
@@ -1,4 +1,3 @@
-
 import qt
 import slicer
 import unittest

--- a/Base/Python/slicer/tests/test_slicer_util_VTKObservationMixin.py
+++ b/Base/Python/slicer/tests/test_slicer_util_VTKObservationMixin.py
@@ -1,4 +1,3 @@
-
 import slicer
 import unittest
 import vtk

--- a/Base/Python/slicer/tests/test_slicer_util_without_modules.py
+++ b/Base/Python/slicer/tests/test_slicer_util_without_modules.py
@@ -17,7 +17,7 @@ class SlicerUtilWithoutModulesTest(unittest.TestCase):
     with tempfile.TemporaryDirectory() as tmpdirname:
 
       input_file = os.path.join(tmpdirname, 'compute-checksum.txt')
-      with io.open(input_file, 'w', newline='\n') as content:
+      with open(input_file, 'w', newline='\n') as content:
         content.write('This is a text file!\n')
 
       self.assertTrue(os.path.exists(input_file))

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1,6 +1,3 @@
-
-from __future__ import print_function
-
 #
 # General
 #
@@ -1162,7 +1159,7 @@ def reloadScriptedModule(moduleName):
   p = os.path.dirname(filePath)
   if not p in sys.path:
     sys.path.insert(0,p)
-  with open(filePath, "r") as fp:
+  with open(filePath) as fp:
     reloaded_module = imp.load_module(
         moduleName, fp, filePath, ('.py', 'r', imp.PY_SOURCE))
 
@@ -1343,7 +1340,7 @@ def getFirstNodeByName(name, className=None):
   scene = slicer.mrmlScene
   return scene.GetFirstNode(name, className, False, False)
 
-class NodeModify(object):
+class NodeModify:
   """Context manager to conveniently compress mrml node modified event."""
   def __init__(self, node):
     self.node = node
@@ -1504,7 +1501,7 @@ def _vtkArrayFromModelData(modelNode, arrayName, location):
   arrayVtk = modelData.GetArray(arrayName)
   if not arrayVtk:
     availableArrayNames = [modelData.GetArrayName(i) for i in range(modelData.GetNumberOfArrays())]
-    raise ValueError("Input modelNode does not contain {0} data array '{1}'. Available array names: '{2}'".format(
+    raise ValueError("Input modelNode does not contain {} data array '{}'. Available array names: '{}'".format(
       location, arrayName, "', '".join(availableArrayNames)))
   return arrayVtk
 
@@ -2112,9 +2109,9 @@ def dataframeFromMarkups(markupsNode):
 # VTK
 #
 
-class VTKObservationMixin(object):
+class VTKObservationMixin:
   def __init__(self):
-    super(VTKObservationMixin, self).__init__()
+    super().__init__()
     self.Observations = []
 
   def removeObservers(self, method=None):
@@ -2456,7 +2453,7 @@ def downloadFile(url, targetFilePath, checksum=None, reDownloadIfChecksumInvalid
     logging.error('Failed to parse checksum: ' + excinfo.message)
     return False
   if not os.path.exists(targetFilePath) or os.stat(targetFilePath).st_size == 0:
-    logging.info('Downloading from\n  %s\nas file\n  %s\nIt may take a few minutes...' % (url,targetFilePath))
+    logging.info(f'Downloading from\n  {url}\nas file\n  {targetFilePath}\nIt may take a few minutes...')
     try:
       import urllib.request, urllib.parse, urllib.error
       urllib.request.urlretrieve(url, targetFilePath)
@@ -2516,16 +2513,16 @@ def extractArchive(archiveFilePath, outputDir, expectedNumberOfExtractedFiles=No
   numOfFilesInOutputDir = len(getFilesInDirectory(outputDir, False))
   if expectedNumberOfExtractedFiles is not None \
       and numOfFilesInOutputDir == expectedNumberOfExtractedFiles:
-    logging.info('File %s already unzipped into %s' % (archiveFilePath, outputDir))
+    logging.info(f'File {archiveFilePath} already unzipped into {outputDir}')
     return True
 
   extractSuccessful = app.applicationLogic().Unzip(archiveFilePath, outputDir)
   numOfFilesInOutputDirTest = len(getFilesInDirectory(outputDir, False))
   if extractSuccessful is False or (expectedNumberOfExtractedFiles is not None \
       and numOfFilesInOutputDirTest != expectedNumberOfExtractedFiles):
-    logging.error('Unzipping %s into %s failed' % (archiveFilePath, outputDir))
+    logging.error(f'Unzipping {archiveFilePath} into {outputDir} failed')
     return False
-  logging.info('Unzipping %s into %s successful' % (archiveFilePath, outputDir))
+  logging.info(f'Unzipping {archiveFilePath} into {outputDir} successful')
   return True
 
 def computeChecksum(algo, filePath):
@@ -2567,7 +2564,7 @@ def extractAlgoAndDigest(checksum):
   (algo, digest) = checksum.split(':')
   expected_algos = ['SHA256', 'SHA512', 'MD5']
   if algo not in expected_algos:
-    raise ValueError("invalid algo '%s'. Algo must be one of %s" % (algo, ", ".join(expected_algos)))
+    raise ValueError("invalid algo '{}'. Algo must be one of {}".format(algo, ", ".join(expected_algos)))
   expected_digest_length = {'SHA256': 64, 'SHA512': 128, 'MD5': 32}
   if len(digest) != expected_digest_length[algo]:
     raise ValueError("invalid digest length %d. Expected digest length for %s is %d" % (len(digest), algo, expected_digest_length[algo]))
@@ -2926,4 +2923,4 @@ def longPath(path):
   # Return path as is if UNC prefix is already applied
   if path[:4] == '\\\\?\\':
     return path
-  return u"\\\\?\\" + path.replace('/', '\\')
+  return "\\\\?\\" + path.replace('/', '\\')

--- a/Base/Python/tests/test_PythonManager.py
+++ b/Base/Python/tests/test_PythonManager.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import slicer
 
 import unittest

--- a/Base/Python/tests/test_sitkUtils.py
+++ b/Base/Python/tests/test_sitkUtils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import slicer
 import sitkUtils as su
 

--- a/Base/QTCLI/Testing/PyCLIModule4Test.py
+++ b/Base/QTCLI/Testing/PyCLIModule4Test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import argparse, sys
 import numpy as np
 

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTest.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTest.py
@@ -1,6 +1,4 @@
-
-
-class qSlicerScriptedLoadableModuleNewStyleTest(object):
+class qSlicerScriptedLoadableModuleNewStyleTest:
   def __init__(self, parent):
     parent.title = "qSlicerScriptedLoadableModuleNewStyle Test"
     parent.categories = ["Testing"]

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTestWidget.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleNewStyleTestWidget.py
@@ -1,6 +1,4 @@
-
-
-class qSlicerScriptedLoadableModuleNewStyleTestWidget(object):
+class qSlicerScriptedLoadableModuleNewStyleTestWidget:
   def __init__(self, parent=None):
     self.parent = parent
 

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTest.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTest.py
@@ -1,5 +1,3 @@
-
-
 class qSlicerScriptedLoadableModuleSyntaxErrorTest:
   def __init__(self, parent):
     s elf.parent = parent # Syntax error

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTestWidget.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleSyntaxErrorTestWidget.py
@@ -1,5 +1,3 @@
-
-
 class qSlicerScriptedLoadableModuleSyntaxErrorTestWidget:
   def __init__(self, parent=None):
     s elf.parent = parent # Syntax error

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleTest.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleTest.py
@@ -1,6 +1,4 @@
-
-
-class qSlicerScriptedLoadableModuleTest(object):
+class qSlicerScriptedLoadableModuleTest:
   def __init__(self, parent):
     import string
     parent.title = "qSlicerScriptedLoadableModule Test"
@@ -19,7 +17,7 @@ class qSlicerScriptedLoadableModuleTest(object):
     self.parent.setProperty('setup_called_within_Python', True)
 
 
-class qSlicerScriptedLoadableModuleTestWidget(object):
+class qSlicerScriptedLoadableModuleTestWidget:
   def __init__(self, parent=None):
     self.parent = parent
 

--- a/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleTestWidget.py
+++ b/Base/QTGUI/Testing/Data/Input/qSlicerScriptedLoadableModuleTestWidget.py
@@ -1,6 +1,4 @@
-
-
-class qSlicerScriptedLoadableModuleTestWidget(object):
+class qSlicerScriptedLoadableModuleTestWidget:
   def __init__(self, parent=None):
     self.parent = parent
 

--- a/Docs/_sphinxext/workaround_recommonmark_issue_191.py
+++ b/Docs/_sphinxext/workaround_recommonmark_issue_191.py
@@ -52,7 +52,7 @@ class MdInclude(rst.Directive):
                               'Cannot encode input file path "%s" '
                               '(wrong locale?).' %
                               (self.name, SafeString(path)))
-        except IOError as error:
+        except OSError as error:
             raise self.severe('Problems with "%s" directive path:\n%s.' %
                               (self.name, ErrorString(error)))
 

--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # 3D Slicer documentation build configuration file, created by
 # sphinx-quickstart on Tue Mar 21 03:07:30 2017.
@@ -109,7 +108,7 @@ pygments_style = 'sphinx'
 todo_include_todos = False
 
 # A string of reStructuredText that will be included at the beginning of every source file that is read.
-rst_prolog = open('global.rst.in', 'r').read()
+rst_prolog = open('global.rst.in').read()
 
 # If given, this must be the name of an image file (path relative to the configuration directory) that is the logo of the docs.
 # It is placed at the top of the sidebar; its width should therefore not exceed 200 pixels

--- a/Extensions/CMake/Testing/SlicerExtensionBuildSystemTest.py
+++ b/Extensions/CMake/Testing/SlicerExtensionBuildSystemTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import hashlib
 import io
 import json
@@ -168,7 +167,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
     save_request(request, response_code)
 
 
-class ServerThread(object):
+class ServerThread:
   def __init__(self, port):
     self.port = port
     self.httpd = socketserver.TCPServer(('127.0.0.1', self.port), Handler)

--- a/Extensions/Testing/EditorExtensionTemplate/EditorEffectTemplate/EditorEffectTemplate.py
+++ b/Extensions/Testing/EditorExtensionTemplate/EditorEffectTemplate/EditorEffectTemplate.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk, qt, ctk, slicer
 import EditorLib
@@ -22,7 +21,7 @@ class EditorEffectTemplateOptions(LabelEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(EditorEffectTemplateOptions,self).__init__(parent)
+    super().__init__(parent)
 
     # self.attributes should be tuple of options:
     # 'MouseTool' - grabs the cursor
@@ -32,10 +31,10 @@ class EditorEffectTemplateOptions(LabelEffectOptions):
     self.displayName = 'EditorEffectTemplate Effect'
 
   def __del__(self):
-    super(EditorEffectTemplateOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(EditorEffectTemplateOptions,self).create()
+    super().create()
     self.apply = qt.QPushButton("Apply", self.frame)
     self.apply.objectName = self.__class__.__name__ + 'Apply'
     self.apply.setToolTip("Apply the extension operation")
@@ -50,7 +49,7 @@ class EditorEffectTemplateOptions(LabelEffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(EditorEffectTemplateOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -64,11 +63,11 @@ class EditorEffectTemplateOptions(LabelEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(EditorEffectTemplateOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
     self.disconnectWidgets()
-    super(EditorEffectTemplateOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.connectWidgets()
 
   def onApply(self):
@@ -79,7 +78,7 @@ class EditorEffectTemplateOptions(LabelEffectOptions):
       return
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(EditorEffectTemplateOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetDisableModifiedEvent(disableState)
     if not disableState:
       self.parameterNode.InvokePendingModifiedEvent()
@@ -100,12 +99,12 @@ class EditorEffectTemplateTool(LabelEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(EditorEffectTemplateTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
     # create a logic instance to do the non-gui work
     self.logic = EditorEffectTemplateLogic(self.sliceWidget.sliceLogic())
 
   def cleanup(self):
-    super(EditorEffectTemplateTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
     """
@@ -113,7 +112,7 @@ class EditorEffectTemplateTool(LabelEffectTool):
     """
 
     # let the superclass deal with the event if it wants to
-    if super(EditorEffectTemplateTool,self).processEvent(caller,event):
+    if super().processEvent(caller,event):
       return
 
     if event == "LeftButtonPressEvent":
@@ -186,7 +185,7 @@ pet = EditorLib.EditorEffectTemplateTool(sw)
 # EditorEffectTemplate
 #
 
-class EditorEffectTemplate(object):
+class EditorEffectTemplate:
   """
   This class is the 'hook' for slicer to detect and recognize the extension
   as a loadable scripted module
@@ -225,7 +224,7 @@ class EditorEffectTemplate(object):
 # EditorEffectTemplateWidget
 #
 
-class EditorEffectTemplateWidget(object):
+class EditorEffectTemplateWidget:
   def __init__(self, parent = None):
     self.parent = parent
 

--- a/Libs/MRML/Core/Documentation/generate_default_color_node_property_table.py
+++ b/Libs/MRML/Core/Documentation/generate_default_color_node_property_table.py
@@ -20,7 +20,6 @@
 This script allows to generate the markdown table displayed in doxygen
 documentation of vtkMRMLColorLogic::AddDefaultColorNodes()
 """
-from __future__ import print_function
 
 nodes = slicer.mrmlScene.GetNodesByClass("vtkMRMLColorNode")
 nodes.UnRegister(slicer.mrmlScene)

--- a/Libs/MRML/DisplayableManager/Python/mrmlDisplayableManager/vtkScriptedExampleDisplayableManager.py
+++ b/Libs/MRML/DisplayableManager/Python/mrmlDisplayableManager/vtkScriptedExampleDisplayableManager.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 #
 # ScriptedExampleDisplayableManager
 #
@@ -50,7 +48,7 @@ from __future__ import print_function
 #     - The list of logic internally used by the qSlicerLayoutManager should be removed and
 #     the list from the MRMLApplicationLogic used instead.
 
-class vtkScriptedExampleDisplayableManager(object):
+class vtkScriptedExampleDisplayableManager:
 
   def __init__(self, parent):
     self.Parent = parent

--- a/Libs/MRML/Widgets/Testing/qMRMLChartViewTest.py
+++ b/Libs/MRML/Widgets/Testing/qMRMLChartViewTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import slicer
 import math
 

--- a/Libs/vtkITK/Testing/vtkITKArchetypeDiffusionTensorReaderFile.py
+++ b/Libs/vtkITK/Testing/vtkITKArchetypeDiffusionTensorReaderFile.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 #Testing against the NRRD reader
 import unittest
 import slicer

--- a/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyFiducials.py
+++ b/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyFiducials.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import time
 
 def TestFiducialAdd(renameFlag=1, visibilityFlag=1, numToAdd=20):

--- a/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyROIs.py
+++ b/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyROIs.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import time
 
 def TestROIAdd(renameFlag=1, visibilityFlag=1, numToAdd=20):

--- a/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyRulers.py
+++ b/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyRulers.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import time
 
 def TestRulerAdd(renameFlag=1, visibilityFlag=1, numToAdd=20):

--- a/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingFiducialWithSceneViewRestore.py
+++ b/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingFiducialWithSceneViewRestore.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # Test that setting a fiducial coordinate is consistent across scene view saves and restores
 
 fid = slicer.vtkMRMLAnnotationFiducialNode()

--- a/Modules/Loadable/Annotations/Testing/Python/LoadAnnotationRulerScene.py
+++ b/Modules/Loadable/Annotations/Testing/Python/LoadAnnotationRulerScene.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 
 # try get the path of the ruler scene file from the arguments

--- a/Modules/Loadable/Annotations/Testing/Python/RemoveAnnotationsIDFromSelectionNode.py
+++ b/Modules/Loadable/Annotations/Testing/Python/RemoveAnnotationsIDFromSelectionNode.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # get the selection node
 selectionNode = slicer.mrmlScene.GetNodeByID("vtkMRMLSelectionNodeSingleton")
 
@@ -13,7 +11,7 @@ if selectionNode:
   print(selectionNode)
   print("Start index for ", annotClassName, " = ", startIndex, ", end index after removing it = ", endIndex)
   if endIndex != -1:
-    raise Exception("Failed to remove annotation %s from list, end index = %s should be -1" % (annotClassName, endIndex))
+    raise Exception(f"Failed to remove annotation {annotClassName} from list, end index = {endIndex} should be -1")
 
   # now make one active and remove it
   annotClassName = "vtkMRMLAnnotationFiducialNode"
@@ -24,7 +22,7 @@ if selectionNode:
   selectionNode.RemovePlaceNodeClassNameFromList(annotClassName)
   endIndex = selectionNode.PlaceNodeClassNameInList(annotClassName)
   if endIndex != -1:
-    raise Exception("Failed to remove active annotation %s from list, end index = %s should be -1" % (annotClassName, endIndex))
+    raise Exception(f"Failed to remove active annotation {annotClassName} from list, end index = {endIndex} should be -1")
 
   # re-add the ruler one
   annotClassName = "vtkMRMLAnnotationRulerNode"
@@ -32,5 +30,5 @@ if selectionNode:
   selectionNode.AddNewPlaceNodeClassNameToList("vtkMRMLAnnotationRulerNode", ":/Icons/AnnotationDistanceWithArrow.png")
   endIndex = selectionNode.PlaceNodeClassNameInList(annotClassName)
   if endIndex == -1:
-    raise Exception("Failed to re-add %s, end index = %s" % (annotClassName, endIndex))
+    raise Exception(f"Failed to re-add {annotClassName}, end index = {endIndex}")
 

--- a/Modules/Loadable/Colors/Testing/Python/ColorsScalarBarSelfTest.py
+++ b/Modules/Loadable/Colors/Testing/Python/ColorsScalarBarSelfTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import time
 import unittest

--- a/Modules/Loadable/Colors/Testing/Python/CustomColorTableSceneViewRestoreTestBug3992.py
+++ b/Modules/Loadable/Colors/Testing/Python/CustomColorTableSceneViewRestoreTestBug3992.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import math
 
 # Test that a custom color table is consistent across scene view saves

--- a/Modules/Loadable/CropVolume/Testing/Python/CropVolumeSelfTest.py
+++ b/Modules/Loadable/CropVolume/Testing/Python/CropVolumeSelfTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import time
 import unittest
@@ -100,7 +99,7 @@ class AddManyMarkupsFiducialTestLogic(ScriptedLoadableModuleLogic):
     """
     Run the actual algorithm
     """
-    print('Running test to add %s fidicuals' % (numToAdd,))
+    print(f'Running test to add {numToAdd} fidicuals')
     print('Index\tTime to add fid\tDelta between adds')
     print("%(index)04s\t" % {'index': "i"}, "t\tdt'")
     r = rOffset

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsCurveCoordinateFrameTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsCurveCoordinateFrameTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from slicer.util import TESTING_DATA_URL
 import os
 import numpy as np

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from slicer.util import TESTING_DATA_URL
 import os
 import numpy as np

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import time
 import unittest

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import time
 import unittest

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsMeasurementsTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsMeasurementsTest.py
@@ -1,6 +1,5 @@
 # markups measurements test
 
-from __future__ import print_function
 from slicer.util import TESTING_DATA_URL
 import json
 import os
@@ -39,7 +38,7 @@ if measurement.GetValueWithUnitsAsPrintableString() != '34.12mm':
 markupsFilename = markupsMeasurementsTestDir+'/line.mkp.json'
 slicer.util.saveNode(markupsNode, markupsFilename)
 
-with open(markupsFilename, 'r') as f:
+with open(markupsFilename) as f:
     markupsJson = json.load(f)
 
 result = [{'name': 'length', 'enabled': True, 'value': 34.12, 'units': 'mm', 'printFormat': '%-#4.4gmm'}]
@@ -68,7 +67,7 @@ if measurement.GetValueWithUnitsAsPrintableString() != '117.4deg':
 markupsFilename = markupsMeasurementsTestDir+'/angle.mkp.json'
 slicer.util.saveNode(markupsNode, markupsFilename)
 
-with open(markupsFilename, 'r') as f:
+with open(markupsFilename) as f:
     markupsJson = json.load(f)
 
 result = [{'name': 'angle', 'enabled': True, 'value': 117.36891896165277, 'units': 'deg', 'printFormat': '%3.1f%s'}]
@@ -105,7 +104,7 @@ if measurement.GetValueWithUnitsAsPrintableString() != '32.00cm2':
 markupsFilename = markupsMeasurementsTestDir+'/plane.mkp.json'
 slicer.util.saveNode(markupsNode, markupsFilename)
 
-with open(markupsFilename, 'r') as f:
+with open(markupsFilename) as f:
     markupsJson = json.load(f)
 
 result = [{'name': 'area', 'enabled': True, 'value': 32.00000000000001, 'units': 'cm2', 'printFormat': '%-#4.4gcm2'}]
@@ -131,7 +130,7 @@ if measurement.GetValueWithUnitsAsPrintableString() != '24.000cm3':
 markupsFilename = markupsMeasurementsTestDir+'/roi.mkp.json'
 slicer.util.saveNode(markupsNode, markupsFilename)
 
-with open(markupsFilename, 'r') as f:
+with open(markupsFilename) as f:
     markupsJson = json.load(f)
 
 result = [{'name': 'volume', 'enabled': True, 'value': 24.000000000000007, 'units': 'cm3', 'printFormat': '%-#4.5gcm3'}]

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestManyLists.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestManyLists.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # Test restoring a scene with multiple lists with different number
 # of fiducials
 
@@ -82,7 +80,7 @@ for markupsNode in [fid1AfterRestore, fid2AfterRestore]:
   rep = markupsWidget.GetRepresentation()
   controlPointsPoly = rep.GetControlPointsPolyData(rep.Selected)
   numberOfControlPoints = controlPointsPoly.GetNumberOfPoints()
-  print("Markups widget {0} has number of control points = {1}".format(markupsNode.GetName(), numberOfControlPoints))
+  print(f"Markups widget {markupsNode.GetName()} has number of control points = {numberOfControlPoints}")
   if numberOfControlPoints != markupsNode.GetNumberOfControlPoints():
     exceptionMessage = "After restoring " + markupsNode.GetName() + ", expected widget to have "
     exceptionMessage += str(markupsNode.GetNumberOfControlPoints()) + " points, but it has "

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestSimple.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestSimple.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # Test that setting a fiducial coordinate is consistent across scene view saves
 # and restores
 

--- a/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
+++ b/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk, qt, ctk, slicer, logging
 from .AbstractScriptedSegmentEditorEffect import *
@@ -259,7 +258,7 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
     self.scriptedEffect.setParameter("AutoUpdate", autoUpdate)
 
   def onPreview(self):
-    slicer.util.showStatusMessage("Running {0} auto-complete...".format(self.scriptedEffect.name), 2000)
+    slicer.util.showStatusMessage(f"Running {self.scriptedEffect.name} auto-complete...", 2000)
     try:
       # This can be a long operation - indicate it to the user
       qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
@@ -417,7 +416,7 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
         self.selectedSegmentIds = vtk.vtkStringArray()
         segmentationNode.GetDisplayNode().GetVisibleSegmentIDs(self.selectedSegmentIds)
       if self.selectedSegmentIds.GetNumberOfValues() < self.minimumNumberOfSegments:
-        logging.error("Auto-complete operation skipped: at least {0} visible segments are required".format(self.minimumNumberOfSegments))
+        logging.error(f"Auto-complete operation skipped: at least {self.minimumNumberOfSegments} visible segments are required")
         self.selectedSegmentIds = None
         return
 
@@ -435,7 +434,7 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
       masterImageExtent = masterImageData.GetExtent()
       labelsEffectiveExtent = self.mergedLabelmapGeometryImage.GetExtent()
       # Margin size is relative to combined seed region size, but minimum of 3 voxels
-      print("self.extentGrowthRatio = {0}".format(self.extentGrowthRatio))
+      print(f"self.extentGrowthRatio = {self.extentGrowthRatio}")
       margin = [
         int(max(3, self.extentGrowthRatio * (labelsEffectiveExtent[1]-labelsEffectiveExtent[0]))),
         int(max(3, self.extentGrowthRatio * (labelsEffectiveExtent[3]-labelsEffectiveExtent[2]))),

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorEffect.py
@@ -5,7 +5,7 @@ import vtk, qt, ctk, slicer, logging
 # Abstract class of python scripted segment editor effects
 #
 
-class AbstractScriptedSegmentEditorEffect(object):
+class AbstractScriptedSegmentEditorEffect:
   """ Abstract scripted segment editor effects for effects implemented in python
 
       USAGE:

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorDrawEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorDrawEffect.py
@@ -139,7 +139,7 @@ class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
 #
 # DrawPipeline
 #
-class DrawPipeline(object):
+class DrawPipeline:
   """ Visualization objects and pipeline for each slice view for drawing
   """
   def __init__(self, scriptedEffect, sliceWidget):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorGrowFromSeedsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorGrowFromSeedsEffect.py
@@ -121,7 +121,7 @@ The effect uses <a href="http://interactivemedical.org/imic2014/CameraReadyPaper
     self.growCutFilter.SetSeedLabelVolume(mergedImage)
     startTime = time.time()
     self.growCutFilter.Update()
-    logging.info('Grow-cut operation on volume of {0}x{1}x{2} voxels was completed in {3:3.1f} seconds.'.format(
+    logging.info('Grow-cut operation on volume of {}x{}x{} voxels was completed in {:3.1f} seconds.'.format(
       self.clippedMasterImageData.GetDimensions()[0],
       self.clippedMasterImageData.GetDimensions()[1],
       self.clippedMasterImageData.GetDimensions()[2],

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorHollowEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorHollowEffect.py
@@ -114,7 +114,7 @@ class SegmentEditorHollowEffect(AbstractScriptedSegmentEditorEffect):
         self.applyButton.setEnabled(False)
       else:
         thicknessMM = self.getShellThicknessMM()
-        self.shellThicknessLabel.text = "Actual: {0} x {1} x {2} mm ({3}x{4}x{5} pixel)".format(*thicknessMM, *shellThicknessPixel)
+        self.shellThicknessLabel.text = "Actual: {} x {} x {} mm ({}x{}x{} pixel)".format(*thicknessMM, *shellThicknessPixel)
         self.applyButton.setEnabled(True)
     else:
       self.shellThicknessLabel.text = "Empty segment"

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLevelTracingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLevelTracingEffect.py
@@ -121,7 +121,7 @@ follows the same intensity value back to the starting point within the current s
 #
 # LevelTracingPipeline
 #
-class LevelTracingPipeline(object):
+class LevelTracingPipeline:
   """ Visualization objects and pipeline for each slice view for level tracing
   """
   def __init__(self, effect, sliceWidget):

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLogicalEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLogicalEffect.py
@@ -201,7 +201,7 @@ class SegmentEditorLogicalEffect(AbstractScriptedSegmentEditorEffect):
       # Get modifier segment
       modifierSegmentID = self.modifierSegmentID()
       if not modifierSegmentID:
-        logging.error("Operation {0} requires a selected modifier segment".format(operation))
+        logging.error(f"Operation {operation} requires a selected modifier segment")
         return
       modifierSegment = segmentation.GetSegment(modifierSegmentID)
       modifierSegmentLabelmap = slicer.vtkOrientedImageData()
@@ -266,7 +266,7 @@ class SegmentEditorLogicalEffect(AbstractScriptedSegmentEditorEffect):
         selectedSegmentLabelmap, slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeSet, bypassMasking)
 
     else:
-      logging.error("Unknown operation: {0}".format(operation))
+      logging.error(f"Unknown operation: {operation}")
 
 LOGICAL_COPY = 'COPY'
 LOGICAL_UNION = 'UNION'

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorMarginEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorMarginEffect.py
@@ -105,7 +105,7 @@ class SegmentEditorMarginEffect(AbstractScriptedSegmentEditorEffect):
         self.applyButton.setEnabled(False)
       else:
         marginSizeMM = self.getMarginSizeMM()
-        self.marginSizeLabel.text = "Actual: {0} x {1} x {2} mm ({3}x{4}x{5} pixel)".format(*marginSizeMM, *marginSizePixel)
+        self.marginSizeLabel.text = "Actual: {} x {} x {} mm ({}x{}x{} pixel)".format(*marginSizeMM, *marginSizePixel)
         self.applyButton.setEnabled(True)
     else:
       self.marginSizeLabel.text = "Empty segment"

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
@@ -138,7 +138,7 @@ If segments overlap, segment higher in the segments table will have priority. <b
     self.kernelSizeMMSpinBox.value = self.scriptedEffect.doubleParameter("KernelSizeMm")
     self.kernelSizeMMSpinBox.blockSignals(wasBlocked)
     kernelSizePixel = self.getKernelSizePixel()
-    self.kernelSizePixel.text = "{0}x{1}x{2} pixel".format(kernelSizePixel[0], kernelSizePixel[1], kernelSizePixel[2])
+    self.kernelSizePixel.text = f"{kernelSizePixel[0]}x{kernelSizePixel[1]}x{kernelSizePixel[2]} pixel"
 
     wasBlocked = self.gaussianStandardDeviationMMSpinBox.blockSignals(True)
     self.setWidgetMinMaxStepFromImageSpacing(self.gaussianStandardDeviationMMSpinBox, self.scriptedEffect.selectedSegmentLabelmap())

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorThresholdEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorThresholdEffect.py
@@ -553,7 +553,7 @@ class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
     elif autoThresholdMethod == METHOD_YEN:
       self.autoThresholdCalculator.SetMethodToYen()
     else:
-      logging.error("Unknown AutoThresholdMethod {0}".format(autoThresholdMethod))
+      logging.error(f"Unknown AutoThresholdMethod {autoThresholdMethod}")
 
     masterImageData = self.scriptedEffect.masterVolumeImageData()
     self.autoThresholdCalculator.SetInputData(masterImageData)
@@ -574,7 +574,7 @@ class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
       self.scriptedEffect.setParameter("MinimumThreshold", computedThreshold)
       self.scriptedEffect.setParameter("MaximumThreshold", masterVolumeMax)
     else:
-      logging.error("Unknown AutoThresholdMode {0}".format(autoThresholdMode))
+      logging.error(f"Unknown AutoThresholdMode {autoThresholdMode}")
 
   def onApply(self):
     if not self.scriptedEffect.confirmCurrentSegmentVisible():
@@ -918,7 +918,7 @@ class SegmentEditorThresholdEffect(AbstractScriptedSegmentEditorEffect):
 #
 # PreviewPipeline
 #
-class PreviewPipeline(object):
+class PreviewPipeline:
   """ Visualization objects and pipeline for each slice view for threshold preview
   """
 
@@ -986,7 +986,7 @@ class HistogramEventFilter(qt.QObject):
     return False
 
 
-class HistogramPipeline(object):
+class HistogramPipeline:
 
   def __init__(self, thresholdEffect, scriptedEffect, sliceWidget, brushMode):
     self.thresholdEffect = thresholdEffect

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest1.py
@@ -101,12 +101,12 @@ class SegmentationsModuleTest1(unittest.TestCase):
     self.assertIsNotNone(displayNode)
     # If segments are not found then the returned color is the pre-defined invalid color
     bodyColor = self.inputSegmentationNode.GetSegmentation().GetSegment(self.bodySegmentName).GetColor()
-    logging.info("bodyColor: {0}".format(bodyColor))
+    logging.info(f"bodyColor: {bodyColor}")
     self.assertEqual(int(bodyColor[0]*100), 33)
     self.assertEqual(int(bodyColor[1]*100), 66)
     self.assertEqual(int(bodyColor[2]*100), 0)
     tumorColor = self.inputSegmentationNode.GetSegmentation().GetSegment(self.tumorSegmentName).GetColor()
-    logging.info("tumorColor: {0}".format(tumorColor))
+    logging.info(f"tumorColor: {tumorColor}")
     self.assertEqual(int(tumorColor[0]*100), 100)
     self.assertEqual(int(tumorColor[1]*100), 0)
     self.assertEqual(int(tumorColor[2]*100), 0)
@@ -140,7 +140,7 @@ class SegmentationsModuleTest1(unittest.TestCase):
     imageStat.Update()
     imageStatResult = imageStat.GetOutput()
     for i in range(4):
-      logging.info("Volume {0}: {1}".format(i, imageStatResult.GetScalarComponentAsDouble(i,0,0,0)))
+      logging.info(f"Volume {i}: {imageStatResult.GetScalarComponentAsDouble(i,0,0,0)}")
     self.assertEqual(imageStat.GetVoxelCount(), 1000)
     self.assertEqual(imageStatResult.GetScalarComponentAsDouble(0,0,0,0), 786)
     self.assertEqual(imageStatResult.GetScalarComponentAsDouble(1,0,0,0), 170)
@@ -157,7 +157,7 @@ class SegmentationsModuleTest1(unittest.TestCase):
     imageStat.Update()
     imageStatResult = imageStat.GetOutput()
     for i in range(4):
-      logging.info("Volume {0}: {1}".format(i, imageStatResult.GetScalarComponentAsDouble(i,0,0,0)))
+      logging.info(f"Volume {i}: {imageStatResult.GetScalarComponentAsDouble(i,0,0,0)}")
     self.assertEqual(imageStat.GetVoxelCount(), 1000)
     self.assertEqual(imageStatResult.GetScalarComponentAsDouble(0,0,0,0), 786)
     self.assertEqual(imageStatResult.GetScalarComponentAsDouble(1,0,0,0), 170)
@@ -218,7 +218,7 @@ class SegmentationsModuleTest1(unittest.TestCase):
     imageStat.Update()
     imageStatResult = imageStat.GetOutput()
     for i in range(5):
-      logging.info("Volume {0}: {1}".format(i, imageStatResult.GetScalarComponentAsDouble(i,0,0,0)))
+      logging.info(f"Volume {i}: {imageStatResult.GetScalarComponentAsDouble(i,0,0,0)}")
     self.assertEqual(imageStat.GetVoxelCount(), 226981000)
     self.assertEqual(imageStatResult.GetScalarComponentAsDouble(0,0,0,0), 178838889)
     self.assertEqual(imageStatResult.GetScalarComponentAsDouble(1,0,0,0), 39705288)
@@ -277,7 +277,7 @@ class SegmentationsModuleTest1(unittest.TestCase):
     imageStat.Update()
     imageStatResult = imageStat.GetOutput()
     for i in range(4):
-      logging.info("Volume {0}: {1}".format(i, imageStatResult.GetScalarComponentAsDouble(i,0,0,0)))
+      logging.info(f"Volume {i}: {imageStatResult.GetScalarComponentAsDouble(i,0,0,0)}")
     self.assertEqual(imageStat.GetVoxelCount(), 127109360)
     self.assertEqual(imageStatResult.GetScalarComponentAsDouble(0,0,0,0), 78967249)
     self.assertEqual(imageStatResult.GetScalarComponentAsDouble(1,0,0,0), 39705288)

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
@@ -314,7 +314,7 @@ class SegmentationsModuleTest2(unittest.TestCase):
       self.assertEqual(self.segmentation.GetNumberOfLayers(), 2)
 
   def runMarginEffect(self, segment1, segment2, dataType, overwriteMode):
-    logging.info("Running margin effect with data type: {0}, and overwriteMode {1}".format(dataType, overwriteMode))
+    logging.info(f"Running margin effect with data type: {dataType}, and overwriteMode {overwriteMode}")
     marginEffect = slicer.modules.segmenteditor.widgetRepresentation().self().editor.effectByName("Margin")
 
     marginEffect.setParameter("MarginSizeMm", 50.0)

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import logging
 import os
 import unittest

--- a/Modules/Loadable/SubjectHierarchy/Widgets/Python/AbstractScriptedSubjectHierarchyPlugin.py
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/Python/AbstractScriptedSubjectHierarchyPlugin.py
@@ -5,7 +5,7 @@ import vtk, qt, ctk, slicer, logging
 # Abstract class of python scripted subject hierarchy plugins
 #
 
-class AbstractScriptedSubjectHierarchyPlugin(object):
+class AbstractScriptedSubjectHierarchyPlugin:
   """ Abstract scripted subject hierarchy plugin for python scripted plugins
 
       USAGE: Instantiate scripted subject hierarchy plugin adaptor class from

--- a/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
+++ b/Modules/Loadable/VolumeRendering/Testing/Python/VolumeRenderingSceneClose.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer

--- a/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
+++ b/Modules/Loadable/Volumes/Testing/Python/VolumesLogicCompareVolumeGeometry.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -317,7 +317,7 @@ This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.
         'moduleAboutToBeUnloaded(QString)', self._onModuleAboutToBeUnloaded)
 
 
-class _ui_DICOMSettingsPanel(object):
+class _ui_DICOMSettingsPanel:
   def __init__(self, parent):
     vBoxLayout = qt.QVBoxLayout(parent)
     # Add generic settings
@@ -378,7 +378,7 @@ class DICOMSettingsPanel(ctk.ctkSettingsPanel):
 #
 # DICOM file dialog
 #
-class DICOMFileDialog(object):
+class DICOMFileDialog:
   """This specially named class is detected by the scripted loadable
   module and is the target for optional drag and drop operations.
   See: Base/QTGUI/qSlicerScriptedFileDialog.h

--- a/Modules/Scripted/DICOMLib/DICOMBrowser.py
+++ b/Modules/Scripted/DICOMLib/DICOMBrowser.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ctk
 import os, copy
 import qt
@@ -254,7 +253,7 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
     modulePath = os.path.dirname(slicer.modules.dicom.path)
     extensionDescriptorPath = os.path.join(modulePath, 'DICOMExtensions.json')
     try:
-      with open(extensionDescriptorPath, 'r') as extensionDescriptorFP:
+      with open(extensionDescriptorPath) as extensionDescriptorFP:
         extensionDescriptor = extensionDescriptorFP.read()
         dicomExtensions = json.loads(extensionDescriptor)
     except:
@@ -467,7 +466,7 @@ class SlicerDICOMBrowser(VTKObservationMixin, qt.QWidget):
         isEqual = True
         for pair in zip(inputFileListCopy, loadableFileListCopy):
           if pair[0] != pair[1]:
-            print("{} != {}".format(pair[0], pair[1]))
+            print(f"{pair[0]} != {pair[1]}")
             isEqual = False
             break
         if not isEqual:
@@ -611,7 +610,7 @@ class DICOMReferencesDialog(qt.QMessageBox):
                 "originally selected series, or Cancel to abort loading."
 
   def __init__(self, parent, loadables):
-    super(DICOMReferencesDialog, self).__init__(parent)
+    super().__init__(parent)
     self.loadables = loadables
     self.checkboxes = dict()
     self.setup()
@@ -665,7 +664,7 @@ class DICOMLoadableTable(qt.QTableWidget):
   """
 
   def __init__(self, parent, width=350, height=100):
-    super(DICOMLoadableTable, self).__init__(parent)
+    super().__init__(parent)
     self.setMinimumHeight(height)
     self.setMinimumWidth(width)
     self.loadables = {}

--- a/Modules/Scripted/DICOMLib/DICOMExportScalarVolume.py
+++ b/Modules/Scripted/DICOMLib/DICOMExportScalarVolume.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import glob
 import slicer
@@ -19,7 +18,7 @@ for elements like slicer.dicomDatatabase and slicer.mrmlScene
 #
 #########################################################
 
-class DICOMExportScalarVolume(object):
+class DICOMExportScalarVolume:
   """Code to export slicer data to dicom database
   TODO: delete temp directories and files
   """

--- a/Modules/Scripted/DICOMLib/DICOMExportScene.py
+++ b/Modules/Scripted/DICOMLib/DICOMExportScene.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import glob
 import tempfile
@@ -29,7 +28,7 @@ for elements like slicer.dicomDatatabase and slicer.mrmlScene
 #
 #########################################################
 
-class DICOMExportScene(object):
+class DICOMExportScene:
   """Export slicer scene to dicom database
   """
 
@@ -156,7 +155,7 @@ class DICOMExportScene(object):
     argIndex = 6
     for key, value in self.optionalTags.items():
       args.insert(argIndex, '-k')
-      tagNameValue = '%s=%s' % (str(key), str(value))
+      tagNameValue = f'{str(key)}={str(value)}'
       args.insert(argIndex+1, tagNameValue)
       argIndex += 2
     self.progress('Creating DICOM binary file...')

--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -19,7 +19,7 @@ comment = """
 # DICOMLoadable
 #
 
-class DICOMLoadable(object):
+class DICOMLoadable:
   """Container class for things that can be
   loaded from dicom files into slicer.
   Each plugin returns a list of instances from its
@@ -65,7 +65,7 @@ class DICOMLoadable(object):
 # DICOMPlugin
 #
 
-class DICOMPlugin(object):
+class DICOMPlugin:
   """ Base class for DICOM plugins
   """
 

--- a/Modules/Scripted/DICOMLib/DICOMPluginSelector.py
+++ b/Modules/Scripted/DICOMLib/DICOMPluginSelector.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os, copy
 import qt
 import vtk
@@ -19,7 +18,7 @@ class DICOMPluginSelector(qt.QWidget):
   """
 
   def __init__(self, parent, width=50, height=100):
-    super(DICOMPluginSelector, self).__init__(parent)
+    super().__init__(parent)
     self.setMinimumHeight(height)
     self.setMinimumWidth(width)
     verticalBox = qt.QVBoxLayout()

--- a/Modules/Scripted/DICOMLib/DICOMRecentActivityWidget.py
+++ b/Modules/Scripted/DICOMLib/DICOMRecentActivityWidget.py
@@ -17,7 +17,7 @@ class DICOMRecentActivityWidget(qt.QWidget):
     """If browserWidget is specified (e.g., set to slicer.modules.DICOMInstance.browserWidget)
     then clicking on an item selects the series in that browserWidget.
     """
-    super(DICOMRecentActivityWidget, self).__init__(parent)
+    super().__init__(parent)
     if dicomDatabase:
       self.dicomDatabase = dicomDatabase
     else:
@@ -49,7 +49,7 @@ class DICOMRecentActivityWidget(qt.QWidget):
     self.tags['seriesDescription'] = "0008,103e"
     self.tags['patientName'] = "0010,0010"
 
-  class seriesWithTime(object):
+  class seriesWithTime:
     """helper class to track series and time..."""
 
     def __init__(self, series, elapsedSinceInsert, insertDateTime, text):
@@ -98,7 +98,7 @@ class DICOMRecentActivityWidget(qt.QWidget):
             elif elapsed < 30 * 7 * secondsPerDay:
               timeNote = 'Past Month'
             if timeNote:
-              text = "%s: %s for %s" % (timeNote, seriesDescription, patientName)
+              text = f"{timeNote}: {seriesDescription} for {patientName}"
               recentSeries.append(self.seriesWithTime(series, elapsed, seriesTime, text))
     recentSeries.sort(key=cmp_to_key(self.compareSeriesTimes))
     return recentSeries

--- a/Modules/Scripted/DICOMLib/DICOMSendDialog.py
+++ b/Modules/Scripted/DICOMLib/DICOMSendDialog.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os, copy
 import qt
 import vtk
@@ -16,7 +15,7 @@ class DICOMSendDialog(qt.QDialog):
   """
 
   def __init__(self, files, parent="mainWindow"):
-    super(DICOMSendDialog, self).__init__(slicer.util.mainWindow() if parent == "mainWindow" else parent)
+    super().__init__(slicer.util.mainWindow() if parent == "mainWindow" else parent)
     self.setWindowTitle('Send DICOM Study')
     self.setWindowModality(1)
     self.setLayout(qt.QVBoxLayout())

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -54,21 +54,21 @@ def loadPatientByUID(patientUID):
     rather than just copying an existing one).
   """
   if not slicer.dicomDatabase.isOpen:
-    raise IOError('DICOM module or database cannot be accessed')
+    raise OSError('DICOM module or database cannot be accessed')
 
   patientUIDstr = str(patientUID)
   if not patientUIDstr in slicer.dicomDatabase.patients():
-    raise IOError('No patient found with DICOM database UID %s' % patientUIDstr)
+    raise OSError('No patient found with DICOM database UID %s' % patientUIDstr)
 
   # Select all series in selected patient
   studies = slicer.dicomDatabase.studiesForPatient(patientUIDstr)
   if len(studies) == 0:
-    raise IOError('No studies found in patient with DICOM database UID ' + patientUIDstr)
+    raise OSError('No studies found in patient with DICOM database UID ' + patientUIDstr)
 
   series = [slicer.dicomDatabase.seriesForStudy(study) for study in studies]
   seriesUIDs = [uid for uidList in series for uid in uidList]
   if len(seriesUIDs) == 0:
-    raise IOError('No series found in patient with DICOM database UID ' + patientUIDstr)
+    raise OSError('No series found in patient with DICOM database UID ' + patientUIDstr)
 
   return loadSeriesByUID(seriesUIDs)
 
@@ -77,7 +77,7 @@ def getDatabasePatientUIDByPatientName(name):
   """ Get patient UID by patient name for easy loading of a patient
   """
   if not slicer.dicomDatabase.isOpen:
-    raise IOError('DICOM module or database cannot be accessed')
+    raise OSError('DICOM module or database cannot be accessed')
 
   patients = slicer.dicomDatabase.patients()
   for patientUID in patients:
@@ -93,7 +93,7 @@ def loadPatientByName(patientName):
   """
   patientUID = getDatabasePatientUIDByPatientName(patientName)
   if patientUID is None:
-    raise IOError('Patient not found by name %s' % patientName)
+    raise OSError('Patient not found by name %s' % patientName)
   return loadPatientByUID(patientUID)
 
 #------------------------------------------------------------------------------
@@ -101,7 +101,7 @@ def getDatabasePatientUIDByPatientID(patientID):
   """ Get database patient UID by DICOM patient ID for easy loading of a patient
   """
   if not slicer.dicomDatabase.isOpen:
-    raise IOError('DICOM module or database cannot be accessed')
+    raise OSError('DICOM module or database cannot be accessed')
 
   patients = slicer.dicomDatabase.patients()
   for patientUID in patients:
@@ -128,7 +128,7 @@ def loadPatientByPatientID(patientID):
   """
   patientUID = getDatabasePatientUIDByPatientID(patientID)
   if patientUID is None:
-    raise IOError('Patient not found by PatientID %s' % patientID)
+    raise OSError('Patient not found by PatientID %s' % patientID)
   return loadPatientByUID(patientUID)
 
 #------------------------------------------------------------------------------
@@ -156,7 +156,7 @@ def loadSeriesByUID(seriesUIDs):
     raise ValueError('No series UIDs given')
 
   if not slicer.dicomDatabase.isOpen:
-    raise IOError('DICOM module or database cannot be accessed')
+    raise OSError('DICOM module or database cannot be accessed')
 
   fileLists = []
   for seriesUID in seriesUIDs:
@@ -183,7 +183,7 @@ def loadByInstanceUID(instanceUID):
   """
 
   if not slicer.dicomDatabase.isOpen:
-    raise IOError('DICOM module or database cannot be accessed')
+    raise OSError('DICOM module or database cannot be accessed')
 
   # get the loadables corresponding to this instance's series
   filePath = slicer.dicomDatabase.fileForInstance(instanceUID)
@@ -361,7 +361,7 @@ def deleteTemporaryDatabase(dicomDatabase, cleanup=True):
   return True
 
 #------------------------------------------------------------------------------
-class TemporaryDICOMDatabase(object):
+class TemporaryDICOMDatabase:
   """Context manager to conveniently use temporary DICOM database.
      It creates a new DICOM database and temporarily sets it as the main
      DICOM database in the application (slicer.dicomDatabase).
@@ -491,7 +491,7 @@ def seriesUIDsForFiles(files):
   return seriesUIDs
 
 #------------------------------------------------------------------------------
-class LoadDICOMFilesToDatabase(object):
+class LoadDICOMFilesToDatabase:
   """Context manager to conveniently load DICOM files downloaded zipped from the internet
   """
   def __init__( self, url, archiveFilePath=None, dicomDataDir=None, \
@@ -619,7 +619,7 @@ def getSortedImageFiles(filePaths, epsilon=0.01):
       spaceError = spacingN - spacing0
       if abs(spaceError) > epsilon:
         spaceWarnings += 1
-        warningText += "Images are not equally spaced (a difference of %g vs %g in spacings was detected)." % (spaceError, spacing0)
+        warningText += f"Images are not equally spaced (a difference of {spaceError:g} vs {spacing0:g} in spacings was detected)."
         if acquisitionGeometryRegularizationEnabled:
           warningText += "  Slicer will apply a transform to this series trying to regularize the volume. Please use caution.\n"
         else:
@@ -727,7 +727,7 @@ def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
         + loadable.name + "' as a '" + plugin.loadType + "'.\n"
         + traceback.format_exc())
     if (not loadSuccess) and (messages is not None):
-      messages.append('Could not load: %s as a %s' % (loadable.name, plugin.loadType))
+      messages.append(f'Could not load: {loadable.name} as a {plugin.loadType}')
 
     cancelled = False
     try:
@@ -736,7 +736,7 @@ def loadLoadables(loadablesByPlugin, messages=None, progressCallback=None):
       for derivedItem in loadable.derivedItems:
         indexer = ctk.ctkDICOMIndexer()
         if progressCallback:
-          cancelled = progressCallback("{0} ({1})".format(loadable.name, derivedItem), step*100/len(selectedLoadables))
+          cancelled = progressCallback(f"{loadable.name} ({derivedItem})", step*100/len(selectedLoadables))
           if cancelled:
             break
         indexer.addFile(slicer.dicomDatabase, derivedItem)
@@ -778,7 +778,7 @@ def importFromDICOMWeb(dicomWebEndpoint, studyInstanceUID, seriesInstanceUID=Non
   else:
     client = DICOMwebClient(
               url = dicomWebEndpoint,
-              headers = { "Authorization": "Bearer {}".format(accessToken) },
+              headers = { "Authorization": f"Bearer {accessToken}" },
               )
 
   seriesList = client.search_for_series(study_instance_uid=studyInstanceUID)

--- a/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
+++ b/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
@@ -156,7 +156,7 @@ class DICOMPatcherWidget(ScriptedLoadableModuleWidget):
       self.logic.patchDicomDir(self.inputDirSelector.currentPath, self.outputDirSelector.currentPath)
 
     except Exception as e:
-      self.addLog("Unexpected error: {0}".format(str(e)))
+      self.addLog(f"Unexpected error: {str(e)}")
       import traceback
       traceback.print_exc()
     slicer.app.restoreOverrideCursor()
@@ -174,7 +174,7 @@ class DICOMPatcherWidget(ScriptedLoadableModuleWidget):
 # Patcher rules
 #
 
-class DICOMPatcherRule(object):
+class DICOMPatcherRule:
   def __init__(self):
     self.logCallback = None
   def addLog(self, text):
@@ -459,7 +459,7 @@ class NormalizeFileNames(DICOMPatcherRule):
   def getNextItemName(self, prefix, root):
     numberOfFilesInFolder = self.numberOfItemsInFolderMap[root] if root in self.numberOfItemsInFolderMap else 0
     self.numberOfItemsInFolderMap[root] = numberOfFilesInFolder+1
-    return "{0}{1:03d}".format(prefix, numberOfFilesInFolder)
+    return f"{prefix}{numberOfFilesInFolder:03d}"
   def generateOutputFilePath(self, ds, filepath):
     folderName = ""
     patientNameID = str(ds.PatientName)+"*"+ds.PatientID
@@ -560,7 +560,7 @@ class DICOMPatcherLogic(ScriptedLoadableModuleLogic):
 
         try:
           ds = pydicom.read_file(filePath)
-        except (IOError, pydicom.filereader.InvalidDicomError):
+        except (OSError, pydicom.filereader.InvalidDicomError):
           self.addLog('  Not DICOM file. Skipped.')
           continue
 
@@ -584,7 +584,7 @@ class DICOMPatcherLogic(ScriptedLoadableModuleLogic):
         pydicom.write_file(patchedFilePath, ds)
         self.addLog('  Created DICOM file: %s' % patchedFilePath)
 
-    self.addLog('DICOM patching completed. Patched files are written to:\n{0}'.format(outputDirPath))
+    self.addLog(f'DICOM patching completed. Patched files are written to:\n{outputDirPath}')
 
   def importDicomDir(self, outputDirPath):
     """

--- a/Modules/Scripted/DICOMPlugins/DICOMEnhancedUSVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMEnhancedUSVolumePlugin.py
@@ -24,7 +24,7 @@ class DICOMEnhancedUSVolumePluginClass(DICOMPlugin):
   """
 
   def __init__(self):
-    super(DICOMEnhancedUSVolumePluginClass,self).__init__()
+    super().__init__()
     self.loadType = "Enhanced US volume"
 
     self.tags['sopClassUID'] = "0008,0016"
@@ -134,7 +134,7 @@ class DICOMEnhancedUSVolumePluginClass(DICOMPlugin):
     if reader.GetErrorCode() != vtk.vtkErrorCode.NoError:
       errorString = vtk.vtkErrorCode.GetStringFromErrorCode(reader.GetErrorCode())
       raise ValueError(
-        "Could not read image {0} from file {1}. Error is: {2}".format(loadable.name, filePath, errorString))
+        f"Could not read image {loadable.name} from file {filePath}. Error is: {errorString}")
 
     rasToIjk = reader.GetRasToIjkMatrix()
     ijkToRas = vtk.vtkMatrix4x4()

--- a/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
@@ -21,7 +21,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
   """
 
   def __init__(self):
-    super(DICOMGeAbusPluginClass,self).__init__()
+    super().__init__()
     self.loadType = "GE ABUS"
 
     self.tags['sopClassUID'] = "0008,0016"
@@ -80,7 +80,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
       try:
         ds = dicom.read_file(filePath, stop_before_pixels=True)
       except Exception as e:
-        logging.debug("Failed to parse DICOM file: {0}".format(str(e)))
+        logging.debug(f"Failed to parse DICOM file: {str(e)}")
         continue
 
       # check if probeCurvatureRadius is available
@@ -97,13 +97,13 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
 
       name = ''
       if hasattr(ds, 'SeriesNumber') and ds.SeriesNumber:
-        name = '{0}:'.format(ds.SeriesNumber)
+        name = f'{ds.SeriesNumber}:'
       if hasattr(ds, 'Modality') and ds.Modality:
-        name = '{0} {1}'.format(name, ds.Modality)
+        name = f'{name} {ds.Modality}'
       if hasattr(ds, 'SeriesDescription') and ds.SeriesDescription:
-        name = '{0} {1}'.format(name, ds.SeriesDescription)
+        name = f'{name} {ds.SeriesDescription}'
       if hasattr(ds, 'InstanceNumber') and ds.InstanceNumber:
-        name = '{0} [{1}]'.format(name, ds.InstanceNumber)
+        name = f'{name} [{ds.InstanceNumber}]'
 
       loadable = DICOMLoadable()
       loadable.files = [filePath]
@@ -122,7 +122,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
     try:
       ds = dicom.read_file(filePath, stop_before_pixels=True)
     except Exception as e:
-      raise ValueError("Failed to parse DICOM file: {0}".format(str(e)))
+      raise ValueError(f"Failed to parse DICOM file: {str(e)}")
 
     fieldsInfo = {
       'NipplePosition': { 'group': 0x0021, 'element': 0x20, 'private': True, 'required': False},
@@ -182,7 +182,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
     if reader.GetErrorCode() != vtk.vtkErrorCode.NoError:
       errorString = vtk.vtkErrorCode.GetStringFromErrorCode(reader.GetErrorCode())
       raise ValueError(
-        "Could not read image {0} from file {1}. Error is: {2}".format(loadable.name, filePath, errorString))
+        f"Could not read image {loadable.name} from file {filePath}. Error is: {errorString}")
 
     # Image origin and spacing is stored in IJK to RAS matrix
     imageData.SetSpacing(1.0, 1.0, 1.0)

--- a/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMImageSequencePlugin.py
@@ -31,7 +31,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
   """
 
   def __init__(self):
-    super(DICOMImageSequencePluginClass,self).__init__()
+    super().__init__()
     self.loadType = "Image sequence"
 
     self.tags['sopClassUID'] = "0008,0016"
@@ -134,20 +134,20 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
           photometricInterpretation = slicer.dicomDatabase.fileValue(filePath, self.tags['photometricInterpretation'])
           name = ''
           if seriesNumber:
-            name = '{0}:'.format(seriesNumber)
+            name = f'{seriesNumber}:'
           if modality:
-            name = '{0} {1}'.format(name, modality)
+            name = f'{name} {modality}'
           if seriesDescription:
-            name = '{0} {1}'.format(name, seriesDescription)
+            name = f'{name} {seriesDescription}'
           if instanceNumber:
-            name = '{0} [{1}]'.format(name, instanceNumber)
+            name = f'{name} [{instanceNumber}]'
 
           loadable = DICOMLoadable()
           loadable.singleSequence = False  # put each instance in a separate sequence
           loadable.files = [filePath]
           loadable.name = name.strip()  # remove leading and trailing spaces, if any
           loadable.warning = "Image spacing may need to be calibrated for accurate size measurements."
-          loadable.tooltip = "{0} image sequence".format(modality)
+          loadable.tooltip = f"{modality} image sequence"
           loadable.selected = True
           # Confidence is slightly larger than default scalar volume plugin's (0.5)
           # but still leaving room for more specialized plugins.
@@ -161,25 +161,25 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
           # existing instance number, add this file
           loadableIndex = instanceNumberToLoadableIndex[instanceNumber]
           loadables[loadableIndex].files.append(filePath)
-          loadable.tooltip = "{0} image sequence ({1} planes)".format(modality, len(loadables[loadableIndex].files))
+          loadable.tooltip = f"{modality} image sequence ({len(loadables[loadableIndex].files)} planes)"
 
     if canBeCineMri and len(cineMriInstanceNumberToFilenameIndex) > 1:
       # Get description from first
       ds = dicom.read_file(cineMriInstanceNumberToFilenameIndex[next(iter(cineMriInstanceNumberToFilenameIndex))], stop_before_pixels=True)
       name = ''
       if hasattr(ds, 'SeriesNumber') and ds.SeriesNumber:
-        name = '{0}:'.format(ds.SeriesNumber)
+        name = f'{ds.SeriesNumber}:'
       if hasattr(ds, 'Modality') and ds.Modality:
-        name = '{0} {1}'.format(name, ds.Modality)
+        name = f'{name} {ds.Modality}'
       if hasattr(ds, 'SeriesDescription') and ds.SeriesDescription:
-        name = '{0} {1}'.format(name, ds.SeriesDescription)
+        name = f'{name} {ds.SeriesDescription}'
 
       loadable = DICOMLoadable()
       loadable.singleSequence = True  # put all instances in a single sequence
       loadable.instanceNumbers = sorted(cineMriInstanceNumberToFilenameIndex)
       loadable.files = [cineMriInstanceNumberToFilenameIndex[instanceNumber] for instanceNumber in loadable.instanceNumbers]
       loadable.name = name.strip()  # remove leading and trailing spaces, if any
-      loadable.tooltip = "{0} image sequence".format(ds.Modality)
+      loadable.tooltip = f"{ds.Modality} image sequence"
       loadable.selected = True
       if len(cineMriTriggerTimes)>3:
         if self.detailedLogging:
@@ -218,7 +218,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
     if reader.GetErrorCode() != vtk.vtkErrorCode.NoError:
       errorString = vtk.vtkErrorCode.GetStringFromErrorCode(reader.GetErrorCode())
       raise ValueError(
-        "Could not read image {0} from file {1}. Error is: {2}".format(loadable.name, filePath, errorString))
+        f"Could not read image {loadable.name} from file {filePath}. Error is: {errorString}")
 
     rasToIjk = reader.GetRasToIjkMatrix()
     ijkToRas = vtk.vtkMatrix4x4()
@@ -274,7 +274,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
     else:
       ds = dicom.read_file(filePath, stop_before_pixels=True)
       if hasattr(ds, 'PositionerPrimaryAngle') and hasattr(ds, 'PositionerSecondaryAngle'):
-        outputSequenceNode.SetName('{0} ({1}/{2})'.format(name, ds.PositionerPrimaryAngle,ds.PositionerSecondaryAngle))
+        outputSequenceNode.SetName(f'{name} ({ds.PositionerPrimaryAngle}/{ds.PositionerSecondaryAngle})')
       else:
         outputSequenceNode.SetName(name)
 
@@ -310,7 +310,7 @@ class DICOMImageSequencePluginClass(DICOMPlugin):
       if type(frameTime) == int:
         timeStampSec = str(frame * frameTime)
       else:
-        timeStampSec = "{:.3f}".format(frame * frameTime)
+        timeStampSec = f"{frame * frameTime:.3f}"
       outputSequenceNode.SetDataNodeAtValue(tempFrameVolume, timeStampSec)
 
     # Create storage node that allows saving node as nrrd

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -19,7 +19,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
   """
 
   def __init__(self,epsilon=0.01):
-    super(DICOMScalarVolumePluginClass,self).__init__()
+    super().__init__()
     self.loadType = "Scalar Volume"
     self.epsilon = epsilon
     self.acquisitionModeling = None
@@ -115,7 +115,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
     image1 = volumeNode1.GetImageData()
     image2 = volumeNode2.GetImageData()
     if image1.GetScalarType() != image2.GetScalarType():
-      comparison += "First volume is %s, but second is %s" % (image1.GetScalarTypeAsString(), image2.GetScalarTypeAsString())
+      comparison += f"First volume is {image1.GetScalarTypeAsString()}, but second is {image2.GetScalarTypeAsString()}"
     array1 = slicer.util.array(volumeNode1.GetID())
     array2 = slicer.util.array(volumeNode2.GetID())
     if not numpy.all(array1 == array2):
@@ -244,7 +244,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
           if tag in subseriesTagsToEnumerateValues:
             loadable.name = seriesName + " - %s %d" % (tag, valueIndex+1)
           else:
-            loadable.name = seriesName + " - %s %s" % (tag, value)
+            loadable.name = seriesName + f" - {tag} {value}"
           loadable.name = self.cleanNodeName(loadable.name)
           loadable.tooltip = "%d files, grouped by %s = %s. First file: %s. %s = %s" % (len(loadable.files), tag, value, loadable.files[0], tag, value)
           loadable.selected = False
@@ -635,7 +635,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
     # Success
     return ""
 
-  class AcquisitionModeling(object):
+  class AcquisitionModeling:
     """Code for representing and analyzing acquisition properties in slicer
     This is an internal class of the DICOMScalarVolumePluginClass so that
     it can be used here and from within the DICOMReaders test.
@@ -787,7 +787,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
       maxError = (abs(self.originalCorners - self.targetCorners)).max()
 
       if maxError > self.cornerEpsilon:
-        warningText = "Irregular volume geometry detected (maximum error of %g mm is above tolerance threshold of %g mm)." % (maxError, self.cornerEpsilon)
+        warningText = f"Irregular volume geometry detected (maximum error of {maxError:g} mm is above tolerance threshold of {self.cornerEpsilon:g} mm)."
         if addAcquisitionTransformIfNeeded:
           logging.warning(warningText + "  Adding acquisition transform to regularize geometry.")
           self.gridTransformFromCorners(volumeNode, self.originalCorners, self.targetCorners)
@@ -798,14 +798,14 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
           logging.warning(warningText + "  Regularization transform is not added, as the option is disabled.")
       elif maxError > 0 and maxError > self.zeroEpsilon:
         logging.debug("Irregular volume geometry detected, but maximum error is within tolerance"+
-          " (maximum error of %g mm, tolerance threshold is %g mm)." % (maxError, self.cornerEpsilon))
+          f" (maximum error of {maxError:g} mm, tolerance threshold is {self.cornerEpsilon:g} mm).")
 
 
 #
 # DICOMScalarVolumePlugin
 #
 
-class DICOMScalarVolumePlugin(object):
+class DICOMScalarVolumePlugin:
   """
   This class is the 'hook' for slicer to detect and recognize the plugin
   as a loadable scripted module

--- a/Modules/Scripted/DICOMPlugins/DICOMSlicerDataBundlePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMSlicerDataBundlePlugin.py
@@ -18,7 +18,7 @@ class DICOMSlicerDataBundlePluginClass(DICOMPlugin):
   """
 
   def __init__(self):
-    super(DICOMSlicerDataBundlePluginClass, self).__init__()
+    super().__init__()
     self.loadType = "Slicer Data Bundle"
     self.tags['seriesDescription'] = "0008,103e"
     self.tags['candygram'] = "cadb,0010"
@@ -230,7 +230,7 @@ class DICOMSlicerDataBundlePluginClass(DICOMPlugin):
 # DICOMSlicerDataBundlePlugin
 #
 
-class DICOMSlicerDataBundlePlugin(object):
+class DICOMSlicerDataBundlePlugin:
   """
   This class is the 'hook' for slicer to detect and recognize the plugin
   as a loadable scripted module
@@ -268,7 +268,7 @@ and was partially funded by NIH grant 3P41RR013218.
 # DICOMSlicerDataBundleWidget
 #
 
-class DICOMSlicerDataBundleWidget(object):
+class DICOMSlicerDataBundleWidget:
   def __init__(self, parent=None):
     self.parent = parent
 

--- a/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
@@ -21,7 +21,7 @@ class DICOMVolumeSequencePluginClass(DICOMPlugin):
   """
 
   def __init__(self):
-    super(DICOMVolumeSequencePluginClass,self).__init__()
+    super().__init__()
     self.loadType = "Volume Sequence"
 
     self.tags['studyID'] = '0020,0010'
@@ -96,7 +96,7 @@ class DICOMVolumeSequencePluginClass(DICOMPlugin):
     exportable.confidence = 0.6 # Simple volume has confidence of 0.5, use a slightly higher value here
 
     # Define required tags and default values
-    exportable.setTag('SeriesDescription', 'Volume sequence of {0} frames'.format(sequenceItemCount))
+    exportable.setTag('SeriesDescription', f'Volume sequence of {sequenceItemCount} frames')
     exportable.setTag('Modality', 'CT')
     exportable.setTag('Manufacturer', 'Unknown manufacturer')
     exportable.setTag('Model', 'Unknown model')
@@ -116,7 +116,7 @@ class DICOMVolumeSequencePluginClass(DICOMPlugin):
       month = int(dt[4:6])
       day = int(dt[6:8])
     else:
-      raise IOError("Invalid DICOM date string: "+tm+" (failed to parse YYYYMMDD)")
+      raise OSError("Invalid DICOM date string: "+tm+" (failed to parse YYYYMMDD)")
 
     hour = 0
     minute = 0
@@ -141,7 +141,7 @@ class DICOMVolumeSequencePluginClass(DICOMPlugin):
       elif len(hhmmss)==2: # HH
         hour = int(hhmmss[0:2])
       else:
-        raise IOError("Invalid DICOM time string: "+tm+" (failed to parse HHMMSS)")
+        raise OSError("Invalid DICOM time string: "+tm+" (failed to parse HHMMSS)")
 
     import datetime
     return datetime.datetime(year, month, day, hour, minute, second, microsecond)
@@ -256,7 +256,7 @@ class DICOMVolumeSequencePluginClass(DICOMPlugin):
         tags['Content Date'] = contentDatetime.strftime("%Y%m%d")
         tags['Content Time'] = contentDatetime.strftime("%H%M%S.%f")
         # Perform export
-        filenamePrefix = "IMG_{0:04d}_".format(sequenceItemIndex)
+        filenamePrefix = f"IMG_{sequenceItemIndex:04d}_"
         exporter = DICOMExportScalarVolume(tags['Study ID'], volumeNode, tags, directory, filenamePrefix)
         exporter.export()
 

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import logging
 import os
 import unittest
@@ -59,7 +58,7 @@ indicated by the mouse position. For more information see the
     if self.infoWidget:
       self.infoWidget.onShowImage(value)
 
-class DataProbeInfoWidget(object):
+class DataProbeInfoWidget:
 
   def __init__(self, parent=None):
     self.nameSize = 24
@@ -316,7 +315,7 @@ class DataProbeInfoWidget(object):
 
   def generateIJKPixelDescription(self, ijk, slicerLayerLogic):
     volumeNode = slicerLayerLogic.GetVolumeNode()
-    return "({i:3d}, {j:3d}, {k:3d})".format(i=ijk[0], j=ijk[1], k=ijk[2]) if volumeNode else ""
+    return f"({ijk[0]:3d}, {ijk[1]:3d}, {ijk[2]:3d})" if volumeNode else ""
 
   def generateIJKPixelValueDescription(self, ijk, slicerLayerLogic):
     volumeNode = slicerLayerLogic.GetVolumeNode()
@@ -515,7 +514,7 @@ class DataProbeWidget(ScriptedLoadableModuleWidget):
     self.parent.layout().addStretch(1)
 
 
-class CalculateTensorScalars(object):
+class CalculateTensorScalars:
     def __init__(self):
         self.dti_math = vtkTeem.vtkDiffusionTensorMathematics()
 

--- a/Modules/Scripted/DataProbe/DataProbeLib/DataProbeUtil.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/DataProbeUtil.py
@@ -16,7 +16,7 @@ comment = """
 #
 #########################################################
 
-class DataProbeUtil(object):
+class DataProbeUtil:
 
   def getParameterNode(self):
     """Get the DataProbe parameter node - a singleton in the scene"""

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import os
 import logging
 import qt

--- a/Modules/Scripted/EditorLib/ChangeIslandEffect.py
+++ b/Modules/Scripted/EditorLib/ChangeIslandEffect.py
@@ -38,16 +38,16 @@ class ChangeIslandEffectOptions(IslandEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(ChangeIslandEffectOptions,self).__init__(parent)
+    super().__init__(parent)
     # create a logic instance to do the non-gui work
     # (since this is created from the option gui it has no slice logic)
     self.logic = ChangeIslandEffectLogic(None)
 
   def __del__(self):
-    super(ChangeIslandEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(ChangeIslandEffectOptions,self).create()
+    super().create()
     # don't need minimum size or fully connected options for this
     self.sizeLabel.hide()
     self.minimumSize.hide()
@@ -62,7 +62,7 @@ class ChangeIslandEffectOptions(IslandEffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(ChangeIslandEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -76,13 +76,13 @@ class ChangeIslandEffectOptions(IslandEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(ChangeIslandEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(ChangeIslandEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
-    super(ChangeIslandEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
 
 #
 # ChangeIslandEffectTool
@@ -99,7 +99,7 @@ class ChangeIslandEffectTool(IslandEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(ChangeIslandEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
     # create a logic instance to do the non-gui work
     self.logic = ChangeIslandEffectLogic(self.sliceWidget.sliceLogic())
 
@@ -107,14 +107,14 @@ class ChangeIslandEffectTool(IslandEffectTool):
     """
     call superclass to clean up actors
     """
-    super(ChangeIslandEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
     """
     handle events from the render window interactor
     """
 
-    if super(ChangeIslandEffectTool,self).processEvent(caller,event):
+    if super().processEvent(caller,event):
       return
 
     # events from the interactory
@@ -140,7 +140,7 @@ class ChangeIslandEffectLogic(IslandEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(ChangeIslandEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
   def changeIsland(self,xy):
     #

--- a/Modules/Scripted/EditorLib/ChangeLabelEffect.py
+++ b/Modules/Scripted/EditorLib/ChangeLabelEffect.py
@@ -37,16 +37,16 @@ class ChangeLabelEffectOptions(EffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(ChangeLabelEffectOptions,self).__init__(parent)
+    super().__init__(parent)
     # create a logic instance to do the non-gui work
     # (since this is created from the option gui it has no slice logic)
     self.logic = ChangeLabelEffectLogic(None)
 
   def __del__(self):
-    super(ChangeLabelEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(ChangeLabelEffectOptions,self).create()
+    super().create()
     self.logic.undoRedo = self.undoRedo
     self.inputColor = EditColor(self.frame,'ChangeLabelEffect,inputColor')
     self.inputColor.label.setText("Input Color:")
@@ -70,7 +70,7 @@ class ChangeLabelEffectOptions(EffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(ChangeLabelEffectOptions,self).destroy()
+    super().destroy()
 
   def updateParameterNode(self, caller, event):
     """
@@ -92,7 +92,7 @@ class ChangeLabelEffectOptions(EffectOptions):
     self.logic.changeLabel()
 
   def setMRMLDefaults(self):
-    super(ChangeLabelEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
     defaults = (
@@ -112,7 +112,7 @@ class ChangeLabelEffectOptions(EffectOptions):
       if self.parameterNode.GetParameter("ChangeLabelEffect,"+p) == '':
         # don't update if the parameter node has not got all values yet
         return
-    super(ChangeLabelEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.disconnectWidgets()
     self.inputColor.colorSpin.setValue( int(self.parameterNode.GetParameter("ChangeLabelEffect,inputColor")) )
     self.outputColor.colorSpin.setValue( int(self.parameterNode.GetParameter("ChangeLabelEffect,outputColor")) )
@@ -121,7 +121,7 @@ class ChangeLabelEffectOptions(EffectOptions):
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(ChangeLabelEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetParameter( "ChangeLabelEffect,inputColor", str(self.inputColor.colorSpin.value) )
     self.parameterNode.SetParameter( "ChangeLabelEffect,outputColor", str(self.outputColor.colorSpin.value) )
     self.parameterNode.SetDisableModifiedEvent(disableState)
@@ -143,10 +143,10 @@ class ChangeLabelEffectTool(EffectTool):
   """
 
   def __init__(self,sliceWidget):
-    super(ChangeLabelEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
-    super(ChangeLabelEffectTool,self).cleanup()
+    super().cleanup()
 
 #
 # ChangeLabelEffectLogic
@@ -164,7 +164,7 @@ class ChangeLabelEffectLogic(EffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(ChangeLabelEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
   def changeLabel(self):
     #

--- a/Modules/Scripted/EditorLib/ColorBox.py
+++ b/Modules/Scripted/EditorLib/ColorBox.py
@@ -17,7 +17,7 @@ comment = """
 #
 #########################################################
 
-class ColorBox(object):
+class ColorBox:
 
   def __init__(self, parent=None, parameterNode=None, parameter=None, colorNode=None, selectCommand=None):
     self.colorNode = colorNode

--- a/Modules/Scripted/EditorLib/DilateEffect.py
+++ b/Modules/Scripted/EditorLib/DilateEffect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk
 import ctk
@@ -38,13 +37,13 @@ class DilateEffectOptions(MorphologyEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(DilateEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
   def __del__(self):
-    super(DilateEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(DilateEffectOptions,self).create()
+    super().create()
     self.apply = qt.QPushButton("Apply", self.frame)
     self.apply.objectName = self.__class__.__name__ + 'Apply'
     self.apply.setToolTip("Dilate current label")
@@ -59,7 +58,7 @@ class DilateEffectOptions(MorphologyEffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(DilateEffectOptions,self).destroy()
+    super().destroy()
 
   def onApply(self):
     logic = DilateEffectLogic(EditUtil.getSliceLogic())
@@ -81,15 +80,15 @@ class DilateEffectOptions(MorphologyEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(DilateEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(DilateEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(DilateEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetDisableModifiedEvent(disableState)
     if not disableState:
       self.parameterNode.InvokePendingModifiedEvent()
@@ -109,13 +108,13 @@ class DilateEffectTool(MorphologyEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(DilateEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
     """
     call superclass to clean up actors
     """
-    super(DilateEffectTool,self).cleanup()
+    super().cleanup()
 
 #
 # DilateEffectLogic
@@ -133,7 +132,7 @@ class DilateEffectLogic(MorphologyEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(DilateEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
   def erode(self,fill,neighborMode,iterations):
 

--- a/Modules/Scripted/EditorLib/DrawEffect.py
+++ b/Modules/Scripted/EditorLib/DrawEffect.py
@@ -38,13 +38,13 @@ class DrawEffectOptions(LabelEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(DrawEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
   def __del__(self):
-    super(DrawEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(DrawEffectOptions,self).create()
+    super().create()
 
     self.apply = qt.QPushButton("Apply", self.frame)
     self.apply.objectName = self.__class__.__name__ + 'Apply'
@@ -64,7 +64,7 @@ class DrawEffectOptions(LabelEffectOptions):
       tool.apply()
 
   def destroy(self):
-    super(DrawEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -78,15 +78,15 @@ class DrawEffectOptions(LabelEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(DrawEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(DrawEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(DrawEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetDisableModifiedEvent(disableState)
     if not disableState:
       self.parameterNode.InvokePendingModifiedEvent()
@@ -112,7 +112,7 @@ class DrawEffectTool(LabelEffectTool):
     # invoke our processEvents method
     self.initialized = False
 
-    super(DrawEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
     # create a logic instance to do the non-gui work
     self.logic = DrawEffectLogic(self.sliceWidget.sliceLogic())
@@ -143,7 +143,7 @@ class DrawEffectTool(LabelEffectTool):
     """
     call superclass to clean up actor
     """
-    super(DrawEffectTool,self).cleanup()
+    super().cleanup()
 
   def setLineMode(self,mode="solid"):
     property_ = self.actor.GetProperty()
@@ -157,7 +157,7 @@ class DrawEffectTool(LabelEffectTool):
     handle events from the render window interactor
     """
 
-    if super(DrawEffectTool,self).processEvent(caller,event):
+    if super().processEvent(caller,event):
       return
 
     if not self.initialized:
@@ -331,7 +331,7 @@ class DrawEffectLogic(LabelEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(DrawEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
 
 #

--- a/Modules/Scripted/EditorLib/EditBox.py
+++ b/Modules/Scripted/EditorLib/EditBox.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import slicer
 import vtk

--- a/Modules/Scripted/EditorLib/EditColor.py
+++ b/Modules/Scripted/EditorLib/EditColor.py
@@ -125,7 +125,7 @@ class EditColor(VTKObservationMixin):
       lut = self.colorNode.GetLookupTable()
       rgb = lut.GetTableValue( label )
       self.colorPatch.setStyleSheet(
-          "background-color: rgb(%s,%s,%s)" % (rgb[0]*255, rgb[1]*255, rgb[2]*255) )
+          f"background-color: rgb({rgb[0]*255},{rgb[1]*255},{rgb[2]*255})" )
       self.colorSpin.setMaximum( self.colorNode.GetNumberOfColors()-1 )
     else:
       self.frame.setDisabled(1)

--- a/Modules/Scripted/EditorLib/EditOptions.py
+++ b/Modules/Scripted/EditorLib/EditOptions.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import slicer
 import qt
 import ctk
@@ -34,7 +33,7 @@ In this file:
 # Helpers
 #########################################################
 
-class HelpButton(object):
+class HelpButton:
   """
   Puts a button on the interface that pops up a message
   dialog for help when pressed

--- a/Modules/Scripted/EditorLib/EditUtil.py
+++ b/Modules/Scripted/EditorLib/EditUtil.py
@@ -21,7 +21,7 @@ comment = """
 #
 #########################################################
 
-class EditUtil(object):
+class EditUtil:
 
   @staticmethod
   def getParameterNode():
@@ -359,13 +359,13 @@ class EditUtil(object):
         structureVolume.GetImageData().DeepCopy( thresholder.GetOutput() )
         EditUtil.markVolumeNodeAsModified(structureVolume)
 
-class UndoRedo(object):
+class UndoRedo:
   """ Code to manage a list of undo/redo volumes
   stored in a compressed format using the vtkImageStash
   class to compress label maps in a thread
   """
 
-  class checkPoint(object):
+  class checkPoint:
     """Internal class to store one checkpoint
     step consisting of the stashed data
     and the volumeNode it corresponds to

--- a/Modules/Scripted/EditorLib/Effect.py
+++ b/Modules/Scripted/EditorLib/Effect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk
 import qt
@@ -49,7 +48,7 @@ class EffectOptions(EditOptions):
   """
 
   def __init__(self, parent=0):
-    super(EffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
     #
     # options for operating only on a portion of the input volume
@@ -63,10 +62,10 @@ class EffectOptions(EditOptions):
     self.scope = 'All'
 
   def __del__(self):
-    super(EffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(EffectOptions,self).create()
+    super().create()
 
     # interface for the scope options
     self.scopeFrame = qt.QFrame(self.frame)
@@ -88,7 +87,7 @@ class EffectOptions(EditOptions):
     self.connections.append( (self.scopeComboBox, 'currentIndexChanged(int)', self.onScopeChanged) )
 
   def destroy(self):
-    super(EffectOptions,self).destroy()
+    super().destroy()
 
   def updateParameterNode(self, caller, event):
     """
@@ -99,7 +98,7 @@ class EffectOptions(EditOptions):
     pass
 
   def setMRMLDefaults(self):
-    super(EffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
     defaults = (
@@ -122,7 +121,7 @@ class EffectOptions(EditOptions):
       if self.parameterNode.GetParameter("Effect,"+p) == '':
         # don't update if the parameter node has not got all values yet
         return
-    super(EffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.disconnectWidgets()
     self.scope = self.parameterNode.GetParameter("Effect,scope")
     scopeIndex = self.availableScopeOptions.index(self.scope)
@@ -134,7 +133,7 @@ class EffectOptions(EditOptions):
 
   def updateMRMLFromGUI(self):
     with NodeModify(self.parameterNode):
-      super(EffectOptions,self).updateMRMLFromGUI()
+      super().updateMRMLFromGUI()
       self.scope = self.availableScopeOptions[self.scopeComboBox.currentIndex]
       self.parameterNode.SetParameter( "Effect,scope", str(self.scope) )
 
@@ -142,7 +141,7 @@ class EffectOptions(EditOptions):
 # EffectTool
 #
 
-class EffectTool(object):
+class EffectTool:
   """
   One instance of this will be created per-view when the effect
   is selected.  It is responsible for implementing feedback and
@@ -261,7 +260,7 @@ class EffectTool(object):
 # EffectLogic
 #
 
-class EffectLogic(object):
+class EffectLogic:
   """
   This class contains helper methods for a given effect
   type.  It can be instanced as needed by an EffectTool
@@ -441,7 +440,7 @@ class EffectLogic(object):
 # The Effect class definition
 #
 
-class Effect(object):
+class Effect:
   """Organizes the Options, Tool, and Logic classes into a single instance
   that can be managed by the EditBox
   """

--- a/Modules/Scripted/EditorLib/ErodeEffect.py
+++ b/Modules/Scripted/EditorLib/ErodeEffect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk
 import ctk
@@ -38,13 +37,13 @@ class ErodeEffectOptions(MorphologyEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(ErodeEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
   def __del__(self):
-    super(ErodeEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(ErodeEffectOptions,self).create()
+    super().create()
     self.apply = qt.QPushButton("Apply", self.frame)
     self.apply.objectName = self.__class__.__name__ + 'Apply'
     self.apply.setToolTip("Erode current label")
@@ -59,7 +58,7 @@ class ErodeEffectOptions(MorphologyEffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(ErodeEffectOptions,self).destroy()
+    super().destroy()
 
   def onApply(self):
     logic = ErodeEffectLogic(EditUtil.getSliceLogic())
@@ -81,15 +80,15 @@ class ErodeEffectOptions(MorphologyEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(ErodeEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(ErodeEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(ErodeEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetDisableModifiedEvent(disableState)
     if not disableState:
       self.parameterNode.InvokePendingModifiedEvent()
@@ -109,13 +108,13 @@ class ErodeEffectTool(MorphologyEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(ErodeEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
     """
     call superclass to clean up actors
     """
-    super(ErodeEffectTool,self).cleanup()
+    super().cleanup()
 
 #
 # ErodeEffectLogic
@@ -133,7 +132,7 @@ class ErodeEffectLogic(MorphologyEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(ErodeEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
   def erode(self,fill,neighborMode,iterations):
 

--- a/Modules/Scripted/EditorLib/FastMarchingEffect.py
+++ b/Modules/Scripted/EditorLib/FastMarchingEffect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk, qt, ctk, slicer
 from . import HelpButton
@@ -27,7 +26,7 @@ class FastMarchingEffectOptions(EffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(FastMarchingEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
     # self.attributes should be tuple of options:
     # 'MouseTool' - grabs the cursor
@@ -39,10 +38,10 @@ class FastMarchingEffectOptions(EffectOptions):
     self.logic = FastMarchingEffectLogic(EditUtil.getSliceLogic())
 
   def __del__(self):
-    super(FastMarchingEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(FastMarchingEffectOptions,self).create()
+    super().create()
 
     self.defaultMaxPercent = 30
 
@@ -90,7 +89,7 @@ class FastMarchingEffectOptions(EffectOptions):
     self.percentMaxChanged(self.percentMax.value)
 
   def destroy(self):
-    super(FastMarchingEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -104,10 +103,10 @@ class FastMarchingEffectOptions(EffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(FastMarchingEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(FastMarchingEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.disconnectWidgets()
     # TODO: get the march parameter from the node
     # march = float(self.parameterNode.GetParameter
@@ -148,7 +147,7 @@ class FastMarchingEffectOptions(EffectOptions):
       return
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(FastMarchingEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetDisableModifiedEvent(disableState)
     if not disableState:
       self.parameterNode.InvokePendingModifiedEvent()
@@ -169,11 +168,11 @@ class FastMarchingEffectTool(EffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(FastMarchingEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
 
   def cleanup(self):
-    super(FastMarchingEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
     """
@@ -199,7 +198,7 @@ class FastMarchingEffectLogic(EffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(FastMarchingEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
   def fastMarching(self,percentMax):
 

--- a/Modules/Scripted/EditorLib/GrowCutEffect.py
+++ b/Modules/Scripted/EditorLib/GrowCutEffect.py
@@ -42,14 +42,14 @@ class GrowCutEffectOptions(EffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(GrowCutEffectOptions,self).__init__(parent)
+    super().__init__(parent)
     self.logic = GrowCutEffectLogic(EditUtil.getSliceLogic())
 
   def __del__(self):
-    super(GrowCutEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(GrowCutEffectOptions,self).create()
+    super().create()
 
     self.helpLabel = qt.QLabel("Run the GrowCut segmentation on the current label map.\nThis will use your current segmentation as an example\nto fill in the rest of the volume.", self.frame)
     self.frame.layout().addWidget(self.helpLabel)
@@ -68,7 +68,7 @@ class GrowCutEffectOptions(EffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(GrowCutEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -82,10 +82,10 @@ class GrowCutEffectOptions(EffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(GrowCutEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(GrowCutEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def onApply(self):
 
@@ -94,7 +94,7 @@ class GrowCutEffectOptions(EffectOptions):
       logging.warning(self.logic.getInvalidInputsMessage())
       background = self.logic.getScopedBackground()
       labelInput = self.logic.getScopedLabelInput()
-      if not slicer.util.confirmOkCancelDisplay("Current image type is '{0}' and labelmap type is '{1}'. GrowCut only works "
+      if not slicer.util.confirmOkCancelDisplay("Current image type is '{}' and labelmap type is '{}'. GrowCut only works "
                                          "reliably with 'short' type.\n\nIf the segmentation result is not satisfactory"
                                          ", then cast the image and labelmap to 'short' type (using Cast Scalar Volume "
                                          "module) or install Fast GrowCut extension and use FastGrowCutEffect editor "
@@ -109,7 +109,7 @@ class GrowCutEffectOptions(EffectOptions):
     slicer.util.showStatusMessage("GrowCut Finished", 2000)
 
   def updateMRMLFromGUI(self):
-    super(GrowCutEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
 
 #
 # GrowCutEffectTool
@@ -126,10 +126,10 @@ class GrowCutEffectTool(EffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(GrowCutEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
-    super(GrowCutEffectTool,self).cleanup()
+    super().cleanup()
 
 #
 # GrowCutEffectLogic
@@ -147,13 +147,13 @@ class GrowCutEffectLogic(EffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(GrowCutEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
   def getInvalidInputsMessage(self):
     background = self.getScopedBackground()
     labelInput = self.getScopedLabelInput()
-    return "GrowCut is attempted with image type '{0}' and labelmap " \
-           "type '{1}'. GrowCut only works robustly with 'short' " \
+    return "GrowCut is attempted with image type '{}' and labelmap " \
+           "type '{}'. GrowCut only works robustly with 'short' " \
            "image and labelmap types.".format(
              background.GetScalarTypeAsString(),
              labelInput.GetScalarTypeAsString())

--- a/Modules/Scripted/EditorLib/IdentifyIslandsEffect.py
+++ b/Modules/Scripted/EditorLib/IdentifyIslandsEffect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk
 import vtkITK
@@ -40,16 +39,16 @@ class IdentifyIslandsEffectOptions(IslandEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(IdentifyIslandsEffectOptions,self).__init__(parent)
+    super().__init__(parent)
     # create a logic instance to do the non-gui work
     # (since this is created from the option gui it has no slice logic)
     self.logic = IdentifyIslandsEffectLogic(None)
 
   def __del__(self):
-    super(IdentifyIslandsEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(IdentifyIslandsEffectOptions,self).create()
+    super().create()
 
     self.apply = qt.QPushButton("Apply", self.frame)
     self.apply.objectName = self.__class__.__name__ + 'Apply'
@@ -69,7 +68,7 @@ class IdentifyIslandsEffectOptions(IslandEffectOptions):
     self.logic.removeIslands()
 
   def destroy(self):
-    super(IdentifyIslandsEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -83,13 +82,13 @@ class IdentifyIslandsEffectOptions(IslandEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(IdentifyIslandsEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(IdentifyIslandsEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
-    super(IdentifyIslandsEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
 
 #
 # IdentifyIslandsEffectTool
@@ -106,16 +105,16 @@ class IdentifyIslandsEffectTool(IslandEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(IdentifyIslandsEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
     """
     call superclass to clean up actors
     """
-    super(IdentifyIslandsEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
-    super(IdentifyIslandsEffectTool,self).processEvent()
+    super().processEvent()
 
 #
 # IdentifyIslandsEffectLogic
@@ -133,7 +132,7 @@ class IdentifyIslandsEffectLogic(IslandEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(IdentifyIslandsEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
   def removeIslands(self):
     #

--- a/Modules/Scripted/EditorLib/IslandEffect.py
+++ b/Modules/Scripted/EditorLib/IslandEffect.py
@@ -36,13 +36,13 @@ class IslandEffectOptions(EffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(IslandEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
   def __del__(self):
-    super(IslandEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(IslandEffectOptions,self).create()
+    super().create()
     self.fullyConnected = qt.QCheckBox("Fully Connected", self.frame)
     self.fullyConnected.setToolTip("When set, only pixels that share faces (not corners or edges) are considered connected.")
     self.frame.layout().addWidget(self.fullyConnected)
@@ -63,7 +63,7 @@ class IslandEffectOptions(EffectOptions):
     self.connections.append( (self.minimumSize, "valueChanged(int)", self.updateMRMLFromGUI ) )
 
   def destroy(self):
-    super(IslandEffectOptions,self).destroy()
+    super().destroy()
 
   def updateParameterNode(self, caller, event):
     """
@@ -74,7 +74,7 @@ class IslandEffectOptions(EffectOptions):
     pass
 
   def setMRMLDefaults(self):
-    super(IslandEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
     defaults = (
@@ -98,7 +98,7 @@ class IslandEffectOptions(EffectOptions):
       if self.parameterNode.GetParameter("IslandEffect,"+p) == '':
         # don't update if the parameter node has not got all values yet
         return
-    super(IslandEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.disconnectWidgets()
     self.fullyConnected.setChecked(
                 int(self.parameterNode.GetParameter("IslandEffect,fullyConnected")) )
@@ -109,7 +109,7 @@ class IslandEffectOptions(EffectOptions):
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(IslandEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     if self.fullyConnected.checked:
       self.parameterNode.SetParameter( "IslandEffect,fullyConnected", "1" )
     else:
@@ -135,10 +135,10 @@ class IslandEffectTool(EffectTool):
   """
 
   def __init__(self,sliceWidget):
-    super(IslandEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
-    super(IslandEffectTool,self).cleanup()
+    super().cleanup()
 
 
 #
@@ -157,7 +157,7 @@ class IslandEffectLogic(EffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(IslandEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
 #
 # The IslandEffect class definition

--- a/Modules/Scripted/EditorLib/LabelCreateDialog.py
+++ b/Modules/Scripted/EditorLib/LabelCreateDialog.py
@@ -1,4 +1,3 @@
-
 import qt
 import slicer
 
@@ -16,7 +15,7 @@ def _map_property(objfunc, name):
 # _ui_LabelCreateDialog
 #
 #=============================================================================
-class _ui_LabelCreateDialog(object):
+class _ui_LabelCreateDialog:
   #---------------------------------------------------------------------------
   def __init__(self, parent):
     vLayout = qt.QVBoxLayout(parent)
@@ -58,7 +57,7 @@ class _ui_LabelCreateDialog(object):
 # LabelCreateDialog
 #
 #=============================================================================
-class LabelCreateDialog(object):
+class LabelCreateDialog:
 
   colorNodeID = _map_property(lambda self: self.ui.colorSelector, "currentNodeID")
 

--- a/Modules/Scripted/EditorLib/LabelEffect.py
+++ b/Modules/Scripted/EditorLib/LabelEffect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk
 import qt
@@ -38,15 +37,15 @@ class LabelEffectOptions(EffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(LabelEffectOptions,self).__init__(parent)
+    super().__init__(parent)
     self.usesPaintOver = True
     self.usesThreshold = True
 
   def __del__(self):
-    super(LabelEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(LabelEffectOptions,self).create()
+    super().create()
     self.paintOver = qt.QCheckBox("Paint Over", self.frame)
     self.paintOver.setToolTip("Allow effect to overwrite non-zero labels.")
     self.frame.layout().addWidget(self.paintOver)
@@ -80,7 +79,7 @@ class LabelEffectOptions(EffectOptions):
     self.connections.append( (self.threshold, "valuesChanged(double,double)", self.onThresholdValuesChange ) )
 
   def destroy(self):
-    super(LabelEffectOptions,self).destroy()
+    super().destroy()
 
   def updateParameterNode(self, caller, event):
     """
@@ -91,7 +90,7 @@ class LabelEffectOptions(EffectOptions):
     pass
 
   def setMRMLDefaults(self):
-    super(LabelEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
     defaults = (
@@ -117,7 +116,7 @@ class LabelEffectOptions(EffectOptions):
       if self.parameterNode.GetParameter("LabelEffect,"+p) == '':
         # don't update if the parameter node has not got all values yet
         return
-    super(LabelEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.disconnectWidgets()
     self.paintOver.setChecked(
                 int(self.parameterNode.GetParameter("LabelEffect,paintOver")) )
@@ -138,7 +137,7 @@ class LabelEffectOptions(EffectOptions):
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(LabelEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     if self.paintOver.checked:
       self.parameterNode.SetParameter( "LabelEffect,paintOver", "1" )
     else:
@@ -170,15 +169,15 @@ class LabelEffectTool(EffectTool):
   """
 
   def __init__(self,sliceWidget):
-    super(LabelEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
     self.rotateSliceToImage()
 
   def processEvent(self, caller=None, event=None):
     """Default implementation for tools that ignore events"""
-    return super(LabelEffectTool,self).processEvent(caller,event)
+    return super().processEvent(caller,event)
 
   def cleanup(self):
-    super(LabelEffectTool,self).cleanup()
+    super().cleanup()
 
   def rotateSliceToImage(self):
     """adjusts the slice node to align with the
@@ -213,7 +212,7 @@ class LabelEffectLogic(EffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(LabelEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
     self.paintThreshold = 0
     self.paintThresholdMin = 1
     self.paintThresholdMax = 1

--- a/Modules/Scripted/EditorLib/LabelStructureListWidget.py
+++ b/Modules/Scripted/EditorLib/LabelStructureListWidget.py
@@ -202,7 +202,7 @@ class LabelStructureListWidget(qt.QWidget):
 
       vName = vNode.GetName()
       # match something like "CT-lung-label1"
-      fnmatchExp = "%s-*%s*" % (masterName, self.mergeVolumePostfix)
+      fnmatchExp = f"{masterName}-*{self.mergeVolumePostfix}*"
       if fnmatch.fnmatchcase(vName,fnmatchExp):
         volumeNodes.append(vNode)
 

--- a/Modules/Scripted/EditorLib/LevelTracingEffect.py
+++ b/Modules/Scripted/EditorLib/LevelTracingEffect.py
@@ -39,13 +39,13 @@ class LevelTracingEffectOptions(LabelEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(LevelTracingEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
   def __del__(self):
-    super(LevelTracingEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(LevelTracingEffectOptions,self).create()
+    super().create()
 
     HelpButton(self.frame, "Use this tool to track around similar intensity levels.\n\nAs you move the mouse, the current background voxel is used to find a closed path that follows the same intensity value back to the starting point within the current slice.  Pressing the left mouse button fills the the path according to the current labeling rules.")
 
@@ -57,7 +57,7 @@ class LevelTracingEffectOptions(LabelEffectOptions):
       tool.apply()
 
   def destroy(self):
-    super(LevelTracingEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -71,15 +71,15 @@ class LevelTracingEffectOptions(LabelEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(LevelTracingEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(LevelTracingEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(LevelTracingEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetDisableModifiedEvent(disableState)
     if not disableState:
       self.parameterNode.InvokePendingModifiedEvent()
@@ -99,7 +99,7 @@ class LevelTracingEffectTool(LabelEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(LevelTracingEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
     # create a logic instance to do the non-gui work
     self.logic = LevelTracingEffectLogic(self.sliceWidget.sliceLogic())
@@ -132,14 +132,14 @@ class LevelTracingEffectTool(LabelEffectTool):
     """
     call superclass to clean up actor
     """
-    super(LevelTracingEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
     """
     handle events from the render window interactor
     """
 
-    if super(LevelTracingEffectTool,self).processEvent(caller,event):
+    if super().processEvent(caller,event):
       return
 
     # events from the interactory
@@ -219,7 +219,7 @@ class LevelTracingEffectLogic(LabelEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(LevelTracingEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
 
 #

--- a/Modules/Scripted/EditorLib/MakeModelEffect.py
+++ b/Modules/Scripted/EditorLib/MakeModelEffect.py
@@ -37,16 +37,16 @@ class MakeModelEffectOptions(EffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(MakeModelEffectOptions,self).__init__(parent)
+    super().__init__(parent)
     # create a logic instance to do the non-gui work
     # (since this is created from the option gui it has no slice logic)
     self.logic = MakeModelEffectLogic(None)
 
   def __del__(self):
-    super(MakeModelEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(MakeModelEffectOptions,self).create()
+    super().create()
 
     self.goToModelMaker = qt.QPushButton("Go To Model Maker", self.frame)
     self.goToModelMaker.setToolTip( "The Model Maker interface contains a whole range of options for building sets of models and controlling the parameters." )
@@ -92,7 +92,7 @@ class MakeModelEffectOptions(EffectOptions):
     self.connections.append( (self.goToModelMaker, 'clicked()', self.onGoToModelMaker) )
 
   def destroy(self):
-    super(MakeModelEffectOptions,self).destroy()
+    super().destroy()
 
   def updateParameterNode(self, caller, event):
     """
@@ -133,10 +133,10 @@ class MakeModelEffectOptions(EffectOptions):
       self.logic.makeModel(self.modelName.text,self.smooth.checked)
 
   def setMRMLDefaults(self):
-    super(MakeModelEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(MakeModelEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
@@ -170,10 +170,10 @@ class MakeModelEffectTool(EffectTool):
   """
 
   def __init__(self,sliceWidget):
-    super(MakeModelEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
-    super(MakeModelEffectTool,self).cleanup()
+    super().cleanup()
 
 #
 # MakeModelEffectLogic
@@ -191,7 +191,7 @@ class MakeModelEffectLogic(EffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(MakeModelEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
   def makeModel(self,modelName='EditorModel',smooth=True):
     #

--- a/Modules/Scripted/EditorLib/MorphologyEffect.py
+++ b/Modules/Scripted/EditorLib/MorphologyEffect.py
@@ -35,16 +35,16 @@ class MorphologyEffectOptions(EffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(MorphologyEffectOptions,self).__init__(parent)
+    super().__init__(parent)
     # TODO: figure out if Visible scope makes sense for these effects
     #self.scopeOptions = ('All','Visible')
     self.scopeOptions = ('All',)
 
   def __del__(self):
-    super(MorphologyEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(MorphologyEffectOptions,self).create()
+    super().create()
     # TODO: provide an entry for label to replace with (defaults to zero)
     self.eightNeighbors = qt.QRadioButton("Eight Neighbors", self.frame)
     self.eightNeighbors.setToolTip("Treat diagonally adjacent voxels as neighbors.")
@@ -62,7 +62,7 @@ class MorphologyEffectOptions(EffectOptions):
     self.connections.append( (self.fourNeighbors, 'clicked()', self.updateMRMLFromGUI) )
 
   def destroy(self):
-    super(MorphologyEffectOptions,self).destroy()
+    super().destroy()
 
   def updateParameterNode(self, caller, event):
     """
@@ -73,7 +73,7 @@ class MorphologyEffectOptions(EffectOptions):
     pass
 
   def setMRMLDefaults(self):
-    super(MorphologyEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
     defaults = (
@@ -98,7 +98,7 @@ class MorphologyEffectOptions(EffectOptions):
       if self.parameterNode.GetParameter("MorphologyEffect,"+p) == '':
         # don't update if the parameter node has not got all values yet
         return
-    super(MorphologyEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.disconnectWidgets()
     neighborMode = self.parameterNode.GetParameter("MorphologyEffect,neighborMode")
     if neighborMode == '8':
@@ -113,7 +113,7 @@ class MorphologyEffectOptions(EffectOptions):
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(MorphologyEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     if self.eightNeighbors.checked:
       self.parameterNode.SetParameter( "MorphologyEffect,neighborMode", "8" )
     else:
@@ -138,10 +138,10 @@ class MorphologyEffectTool(EffectTool):
   """
 
   def __init__(self,sliceWidget):
-    super(MorphologyEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
-    super(MorphologyEffectTool,self).cleanup()
+    super().cleanup()
 
 #
 # MorphologyEffectLogic
@@ -159,7 +159,7 @@ class MorphologyEffectLogic(EffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(MorphologyEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
 #
 # The MorphologyEffect class definition

--- a/Modules/Scripted/EditorLib/PaintEffect.py
+++ b/Modules/Scripted/EditorLib/PaintEffect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk
 import ctk
@@ -56,7 +55,7 @@ class PaintEffectOptions(LabelEffectOptions):
       self.minimumRadius = 0.01
       self.maximumRadius = 100
 
-    super(PaintEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
     # option to use 'min' or 'diag'
     # - min means pixel radius is min spacing
@@ -65,10 +64,10 @@ class PaintEffectOptions(LabelEffectOptions):
 
 
   def __del__(self):
-    super(PaintEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(PaintEffectOptions,self).create()
+    super().create()
 
     self.radiusFrame = qt.QFrame(self.frame)
     self.radiusFrame.setLayout(qt.QHBoxLayout())
@@ -106,7 +105,7 @@ class PaintEffectOptions(LabelEffectOptions):
                  (10, self.onQuickie10Clicked), (20, self.onQuickie20Clicked) )
     for rad,callback in quickies:
       self.radiusQuickies[rad] = qt.QPushButton(str(rad))
-      self.radiusQuickies[rad].objectName = 'PushButton_QuickRadius_{0}'.format(rad)
+      self.radiusQuickies[rad].objectName = f'PushButton_QuickRadius_{rad}'
       self.radiusFrame.layout().addWidget(self.radiusQuickies[rad])
       self.radiusQuickies[rad].setFixedWidth(25)
       self.radiusQuickies[rad].connect('clicked()', callback)
@@ -154,7 +153,7 @@ class PaintEffectOptions(LabelEffectOptions):
     # self.parameterNode.SetParameter( "PaintEffect,radius", str(self.minimumRadius * 10) )
 
   def destroy(self):
-    super(PaintEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -168,7 +167,7 @@ class PaintEffectOptions(LabelEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(PaintEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
     defaults = (
@@ -190,7 +189,7 @@ class PaintEffectOptions(LabelEffectOptions):
       if self.parameterNode.GetParameter("PaintEffect,"+p) == '':
         # don't update if the parameter node has not got all values yet
         return
-    super(PaintEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.disconnectWidgets()
     sphere = not (0 == int(self.parameterNode.GetParameter("PaintEffect,sphere")))
     self.sphere.setChecked( sphere )
@@ -265,7 +264,7 @@ class PaintEffectOptions(LabelEffectOptions):
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(PaintEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     if self.sphere.checked:
       self.parameterNode.SetParameter( "PaintEffect,sphere", "1" )
     else:
@@ -298,7 +297,7 @@ class PaintEffectTool(LabelEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(PaintEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
     # create a logic instance to do the non-gui work
     self.logic = PaintEffectLogic(self.sliceWidget.sliceLogic())
 
@@ -340,7 +339,7 @@ class PaintEffectTool(LabelEffectTool):
     for a in self.feedbackActors:
       self.renderer.RemoveActor2D(a)
     self.sliceView.scheduleRender()
-    super(PaintEffectTool,self).cleanup()
+    super().cleanup()
 
   def getLabelPixel(self,xy):
     sliceLogic = self.sliceWidget.sliceLogic()
@@ -364,7 +363,7 @@ class PaintEffectTool(LabelEffectTool):
     handle events from the render window interactor
     """
 
-    if super(PaintEffectTool,self).processEvent(caller,event):
+    if super().processEvent(caller,event):
       return
 
     # interactor events
@@ -797,7 +796,7 @@ class PaintEffectLogic(LabelEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(PaintEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
 
 #

--- a/Modules/Scripted/EditorLib/RectangleEffect.py
+++ b/Modules/Scripted/EditorLib/RectangleEffect.py
@@ -38,13 +38,13 @@ class RectangleEffectOptions(LabelEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(RectangleEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
   def __del__(self):
-    super(RectangleEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(RectangleEffectOptions,self).create()
+    super().create()
 
     HelpButton(self.frame, "Use this tool to draw a rectangle.\n\nLeft Click and Drag: sweep out an outline that will draw when the button is released.")
 
@@ -52,7 +52,7 @@ class RectangleEffectOptions(LabelEffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(RectangleEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -66,15 +66,15 @@ class RectangleEffectOptions(LabelEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(RectangleEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(RectangleEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(RectangleEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetDisableModifiedEvent(disableState)
     if not disableState:
       self.parameterNode.InvokePendingModifiedEvent()
@@ -94,7 +94,7 @@ class RectangleEffectTool(LabelEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(RectangleEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
     # create a logic instance to do the non-gui work
     self.logic = RectangleEffectLogic(self.sliceWidget.sliceLogic())
@@ -121,7 +121,7 @@ class RectangleEffectTool(LabelEffectTool):
     """
     call superclass to clean up actor
     """
-    super(RectangleEffectTool,self).cleanup()
+    super().cleanup()
 
 
   def createGlyph(self):
@@ -168,7 +168,7 @@ class RectangleEffectTool(LabelEffectTool):
     handle events from the render window interactor
     """
 
-    if super(RectangleEffectTool,self).processEvent(caller,event):
+    if super().processEvent(caller,event):
       return
 
     if event == "LeftButtonPressEvent":
@@ -216,7 +216,7 @@ class RectangleEffectLogic(LabelEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(RectangleEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
 
 #

--- a/Modules/Scripted/EditorLib/RemoveIslandsEffect.py
+++ b/Modules/Scripted/EditorLib/RemoveIslandsEffect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk
 import vtkITK
@@ -40,16 +39,16 @@ class RemoveIslandsEffectOptions(IslandEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(RemoveIslandsEffectOptions,self).__init__(parent)
+    super().__init__(parent)
     # create a logic instance to do the non-gui work
     # (since this is created from the option gui it has no slice logic)
     self.logic = RemoveIslandsEffectLogic(None)
 
   def __del__(self):
-    super(RemoveIslandsEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(RemoveIslandsEffectOptions,self).create()
+    super().create()
 
     self.applyConnectivity = qt.QPushButton("Apply Connectivity Method", self.frame)
     self.applyConnectivity.setToolTip("Remove islands that are not connected at all to the surface.  Islands with thin connections will not be removed.")
@@ -78,7 +77,7 @@ class RemoveIslandsEffectOptions(IslandEffectOptions):
     self.logic.removeIslandsMorphology()
 
   def destroy(self):
-    super(RemoveIslandsEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -92,13 +91,13 @@ class RemoveIslandsEffectOptions(IslandEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(RemoveIslandsEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(RemoveIslandsEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
-    super(RemoveIslandsEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
 
 #
 # RemoveIslandsEffectTool
@@ -115,16 +114,16 @@ class RemoveIslandsEffectTool(IslandEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(RemoveIslandsEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
     """
     call superclass to clean up actors
     """
-    super(RemoveIslandsEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
-    super(RemoveIslandsEffectTool,self).processEvent()
+    super().processEvent()
 
 #
 # RemoveIslandsEffectLogic
@@ -142,7 +141,7 @@ class RemoveIslandsEffectLogic(IslandEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(RemoveIslandsEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
 
   def findNonZeroBorderPixel(self, imageData):

--- a/Modules/Scripted/EditorLib/SaveIslandEffect.py
+++ b/Modules/Scripted/EditorLib/SaveIslandEffect.py
@@ -38,16 +38,16 @@ class SaveIslandEffectOptions(IslandEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(SaveIslandEffectOptions,self).__init__(parent)
+    super().__init__(parent)
     # create a logic instance to do the non-gui work
     # (since this is created from the option gui it has no slice logic)
     self.logic = SaveIslandEffectLogic(None)
 
   def __del__(self):
-    super(SaveIslandEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(SaveIslandEffectOptions,self).create()
+    super().create()
     # don't need minimum size or fully connected options for this
     self.sizeLabel.hide()
     self.minimumSize.hide()
@@ -62,7 +62,7 @@ class SaveIslandEffectOptions(IslandEffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(SaveIslandEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -76,13 +76,13 @@ class SaveIslandEffectOptions(IslandEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(SaveIslandEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
-    super(SaveIslandEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
 
   def updateMRMLFromGUI(self):
-    super(SaveIslandEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
 
 #
 # SaveIslandEffectTool
@@ -99,7 +99,7 @@ class SaveIslandEffectTool(IslandEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(SaveIslandEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
     # create a logic instance to do the non-gui work
     self.logic = SaveIslandEffectLogic(self.sliceWidget.sliceLogic())
 
@@ -107,7 +107,7 @@ class SaveIslandEffectTool(IslandEffectTool):
     """
     call superclass to clean up actors
     """
-    super(SaveIslandEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
     """
@@ -136,7 +136,7 @@ class SaveIslandEffectLogic(IslandEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(SaveIslandEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
   def saveIsland(self,xy):
     #

--- a/Modules/Scripted/EditorLib/Testing/StandaloneEditorWidgetTest.py
+++ b/Modules/Scripted/EditorLib/Testing/StandaloneEditorWidgetTest.py
@@ -1,4 +1,3 @@
-
 import unittest
 import slicer
 import EditorLib

--- a/Modules/Scripted/EditorLib/Testing/ThresholdThreadingTest.py
+++ b/Modules/Scripted/EditorLib/Testing/ThresholdThreadingTest.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import qt
 import slicer

--- a/Modules/Scripted/EditorLib/ThresholdEffect.py
+++ b/Modules/Scripted/EditorLib/ThresholdEffect.py
@@ -38,13 +38,13 @@ class ThresholdEffectOptions(EffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(ThresholdEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
   def __del__(self):
-    super(ThresholdEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(ThresholdEffectOptions,self).create()
+    super().create()
 
     self.thresholdLabel = qt.QLabel("Threshold Range:", self.frame)
     self.thresholdLabel.setToolTip("Set the range of the background values that should be labeled.")
@@ -104,7 +104,7 @@ class ThresholdEffectOptions(EffectOptions):
     self.defaultEffect()
 
   def destroy(self):
-    super(ThresholdEffectOptions,self).destroy()
+    super().destroy()
     self.timer.stop()
 
   # note: this method needs to be implemented exactly as-is
@@ -119,7 +119,7 @@ class ThresholdEffectOptions(EffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(ThresholdEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
     defaults = (
@@ -157,7 +157,7 @@ class ThresholdEffectOptions(EffectOptions):
       if self.parameterNode.GetParameter("ThresholdEffect,"+p) == '':
         # don't update if the parameter node has not got all values yet
         return
-    super(ThresholdEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.disconnectWidgets()
     min = float(self.parameterNode.GetParameter("ThresholdEffect,min"))
     max = float(self.parameterNode.GetParameter("ThresholdEffect,max"))
@@ -171,7 +171,7 @@ class ThresholdEffectOptions(EffectOptions):
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(ThresholdEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetParameter( "ThresholdEffect,min", str(self.threshold.minimumValue) )
     self.parameterNode.SetParameter( "ThresholdEffect,max", str(self.threshold.maximumValue) )
     self.parameterNode.SetDisableModifiedEvent(disableState)
@@ -207,7 +207,7 @@ class ThresholdEffectTool(EffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(ThresholdEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
     # create a logic instance to do the non-gui work
     self.logic = ThresholdEffectLogic(self.sliceWidget.sliceLogic())
@@ -241,7 +241,7 @@ class ThresholdEffectTool(EffectTool):
     """
     call superclass to clean up actors
     """
-    super(ThresholdEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
     """
@@ -335,7 +335,7 @@ class ThresholdEffectLogic(EffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(ThresholdEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
 
 
 #

--- a/Modules/Scripted/EditorLib/WandEffect.py
+++ b/Modules/Scripted/EditorLib/WandEffect.py
@@ -28,7 +28,7 @@ class WandEffectOptions(LabelEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(WandEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
     # self.attributes should be tuple of options:
     # 'MouseTool' - grabs the cursor
@@ -38,10 +38,10 @@ class WandEffectOptions(LabelEffectOptions):
     self.displayName = 'Wand Effect'
 
   def __del__(self):
-    super(WandEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(WandEffectOptions,self).create()
+    super().create()
 
     self.toleranceFrame = qt.QFrame(self.frame)
     self.toleranceFrame.setLayout(qt.QHBoxLayout())
@@ -103,7 +103,7 @@ class WandEffectOptions(LabelEffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(WandEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -117,7 +117,7 @@ class WandEffectOptions(LabelEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(WandEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
     defaults = (
@@ -133,13 +133,13 @@ class WandEffectOptions(LabelEffectOptions):
     self.parameterNode.SetDisableModifiedEvent(disableState)
 
   def updateGUIFromMRML(self,caller,event):
-    super(WandEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     params = ("tolerance", "maxPixels",)
     for p in params:
       if self.parameterNode.GetParameter("WandEffect,"+p) == '':
         # don't update if the parameter node has not got all values yet
         return
-    super(WandEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.disconnectWidgets()
     self.toleranceSpinBox.setValue( float(self.parameterNode.GetParameter("WandEffect,tolerance")) )
     self.maxPixelsSpinBox.setValue( float(self.parameterNode.GetParameter("WandEffect,maxPixels")) )
@@ -165,7 +165,7 @@ class WandEffectOptions(LabelEffectOptions):
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(WandEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetParameter( "WandEffect,tolerance", str(self.toleranceSpinBox.value) )
     self.parameterNode.SetParameter( "WandEffect,maxPixels", str(self.maxPixelsSpinBox.value) )
     fillMode = "Volume" if self.fillModeCheckBox.checked else "Plane"
@@ -190,18 +190,18 @@ class WandEffectTool(LabelEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(WandEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
     self.logic = WandEffectLogic(self.sliceWidget.sliceLogic())
 
   def cleanup(self):
-    super(WandEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
     """
     handle events from the render window interactor
     """
 
-    if super(WandEffectTool,self).processEvent(caller,event):
+    if super().processEvent(caller,event):
       return
 
     if event == "LeftButtonPressEvent":
@@ -231,7 +231,7 @@ class WandEffectLogic(LabelEffectLogic):
   """
 
   def __init__(self,sliceLogic):
-    super(WandEffectLogic,self).__init__(sliceLogic)
+    super().__init__(sliceLogic)
     self.sliceLogic = sliceLogic
     self.fillMode = 'Plane' # can be Plane or Volume
 

--- a/Modules/Scripted/EditorLib/WatershedFromMarkerEffect.py
+++ b/Modules/Scripted/EditorLib/WatershedFromMarkerEffect.py
@@ -30,14 +30,14 @@ class WatershedFromMarkerEffectOptions(EffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(WatershedFromMarkerEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
 
   def __del__(self):
-    super(WatershedFromMarkerEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(WatershedFromMarkerEffectOptions,self).create()
+    super().create()
 
     try:
       import SimpleITK as sitk
@@ -122,7 +122,7 @@ The "Object Scale" parameter is use to adjust the smoothness of the output image
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(WatershedFromMarkerEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -136,7 +136,7 @@ The "Object Scale" parameter is use to adjust the smoothness of the output image
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(WatershedFromMarkerEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
@@ -154,7 +154,7 @@ The "Object Scale" parameter is use to adjust the smoothness of the output image
 
   def updateGUIFromMRML(self,caller,event):
     self.updatingGUI = True
-    super(WatershedFromMarkerEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.updatingGUI = False
 
   def onApply(self):
@@ -172,7 +172,7 @@ The "Object Scale" parameter is use to adjust the smoothness of the output image
   def updateMRMLFromGUI(self):
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(WatershedFromMarkerEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetDisableModifiedEvent(disableState)
     if not disableState:
       self.parameterNode.InvokePendingModifiedEvent()
@@ -192,10 +192,10 @@ class WatershedFromMarkerEffectTool(LabelEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(WatershedFromMarkerEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
 
   def cleanup(self):
-    super(WatershedFromMarkerEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
     """

--- a/Modules/Scripted/EditorLib/__init__.py
+++ b/Modules/Scripted/EditorLib/__init__.py
@@ -1,4 +1,3 @@
-
 import os
 ICON_DIR = os.path.dirname(os.path.realpath(__file__)) + '/Resources/Icons/'
 del os

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer
@@ -331,7 +330,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget):
     self.cameraNode.EndModify(wasModified)
     self.cameraNode.ResetClippingRange()
 
-class EndoscopyComputePath(object):
+class EndoscopyComputePath:
   """Compute path given a list of fiducials.
   If a point list is received then curve points are generated using Hermite spline interpolation.
   See http://en.wikipedia.org/wiki/Cubic_Hermite_spline
@@ -490,7 +489,7 @@ class EndoscopyComputePath(object):
     return (t1, pguess, remainder)
 
 
-class EndoscopyPathModel(object):
+class EndoscopyPathModel:
   """Create a vtkPolyData for a polyline:
        - Add one point per path point.
        - Add a single polyline
@@ -572,7 +571,7 @@ class EndoscopyPathModel(object):
     import numpy as np
     from numpy.linalg import svd
     points = np.reshape(points, (np.shape(points)[0], -1)) # Collapse trialing dimensions
-    assert points.shape[0] <= points.shape[1], "There are only {} points in {} dimensions.".format(points.shape[1], points.shape[0])
+    assert points.shape[0] <= points.shape[1], f"There are only {points.shape[1]} points in {points.shape[0]} dimensions."
     ctr = points.mean(axis=1)
     x = points - ctr[:,np.newaxis]
     M = np.dot(x, x.T) # Could also use np.cov(x) here.

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizard.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizard.py
@@ -34,7 +34,7 @@ def _settingsList(settings, key, convertToAbsolutePaths=False):
 # ExtensionWizard
 #
 #=============================================================================
-class ExtensionWizard(object):
+class ExtensionWizard:
   #---------------------------------------------------------------------------
   def __init__(self, parent):
     parent.title = "Extension Wizard"
@@ -58,7 +58,7 @@ This work is supported by NA-MIC, NAC, BIRN, NCIGT, and the Slicer Community.
 # ExtensionWizardWidget
 #
 #=============================================================================
-class ExtensionWizardWidget(object):
+class ExtensionWizardWidget:
   #---------------------------------------------------------------------------
   def __init__(self, parent = None):
     if not parent:
@@ -222,7 +222,7 @@ class ExtensionWizardWidget(object):
         if repo is None:
           destination = os.path.join(dlg.destination, dlg.componentName)
           if os.path.exists(destination):
-            raise IOError("create extension: refusing to overwrite"
+            raise OSError("create extension: refusing to overwrite"
                           " existing directory '%s'" % destination)
           createInSubdirectory = False
 
@@ -232,7 +232,7 @@ class ExtensionWizardWidget(object):
           createInSubdirectory = False # create the files in the destination directory
           requireEmptyDirectory = False # we only check if no CMakeLists.txt file exists
           if os.path.exists(cmakeFile):
-            raise IOError("create extension: refusing to overwrite"
+            raise OSError("create extension: refusing to overwrite"
                           " directory containing CMakeLists.txt file at '%s'" % dlg.destination)
 
         path = self.templateManager.copyTemplate(

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/CreateComponentDialog.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/CreateComponentDialog.py
@@ -8,7 +8,7 @@ import re
 # _ui_CreateComponentDialog
 #
 #=============================================================================
-class _ui_CreateComponentDialog(object):
+class _ui_CreateComponentDialog:
   #---------------------------------------------------------------------------
   def __init__(self, parent):
     self.vLayout = qt.QVBoxLayout(parent)
@@ -41,7 +41,7 @@ class _ui_CreateComponentDialog(object):
 # CreateComponentDialog
 #
 #=============================================================================
-class CreateComponentDialog(object):
+class CreateComponentDialog:
   #---------------------------------------------------------------------------
   def __init__(self, componenttype, parent):
     self.dialog = qt.QDialog(parent)

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/DirectoryListWidget.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/DirectoryListWidget.py
@@ -5,7 +5,7 @@ import slicer, qt
 # _ui_DirectoryListWidget
 #
 #=============================================================================
-class _ui_DirectoryListWidget(object):
+class _ui_DirectoryListWidget:
   #---------------------------------------------------------------------------
   def __init__(self, parent):
     layout = qt.QGridLayout(parent)

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/EditExtensionMetadataDialog.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/EditExtensionMetadataDialog.py
@@ -15,7 +15,7 @@ def _map_property(objfunc, name):
 # _ui_EditExtensionMetadataDialog
 #
 #=============================================================================
-class _ui_EditExtensionMetadataDialog(object):
+class _ui_EditExtensionMetadataDialog:
   #---------------------------------------------------------------------------
   def __init__(self, parent):
     vLayout = qt.QVBoxLayout(parent)
@@ -51,7 +51,7 @@ class _ui_EditExtensionMetadataDialog(object):
 # EditExtensionMetadataDialog
 #
 #=============================================================================
-class EditExtensionMetadataDialog(object):
+class EditExtensionMetadataDialog:
   project = _map_property(lambda self: self.ui.nameEdit, "text")
   category = _map_property(lambda self: self.ui.categoryEdit, "text")
   description = _map_property(lambda self: self.ui.descriptionEdit, "plainText")
@@ -90,7 +90,7 @@ class EditExtensionMetadataDialog(object):
       name = item.text(0)
       organization = item.text(1)
       if len(organization):
-        result.append("%s (%s)" % (name, organization))
+        result.append(f"{name} ({organization})")
       else:
         result.append(name)
     return ", ".join(result)
@@ -99,7 +99,7 @@ class EditExtensionMetadataDialog(object):
   @contributors.setter
   def contributors(self, value):
     self.ui.contributorsList.clear()
-    for c in re.split("(?<=[)])\s*,", value):
+    for c in re.split(r"(?<=[)])\s*,", value):
       c = c.strip()
       item = qt.QTreeWidgetItem()
 

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/EditableTreeWidget.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/EditableTreeWidget.py
@@ -139,7 +139,7 @@ class EditableTreeWidget(qt.QTreeWidget):
       self._items.insert(row + delta, item)
       self.insertTopLevelItem(row + delta, item)
 
-    self.setSelectedRows((row + delta for row in rows))
+    self.setSelectedRows(row + delta for row in rows)
     self.setCurrentItem(current)
 
   #---------------------------------------------------------------------------

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/LoadModulesDialog.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/LoadModulesDialog.py
@@ -11,7 +11,7 @@ def _dialogIcon(icon):
 # _ui_LoadModulesDialog
 #
 #=============================================================================
-class _ui_LoadModulesDialog(object):
+class _ui_LoadModulesDialog:
   #---------------------------------------------------------------------------
   def __init__(self, parent):
     vLayout = qt.QVBoxLayout(parent)
@@ -51,7 +51,7 @@ class _ui_LoadModulesDialog(object):
 # LoadModulesDialog
 #
 #=============================================================================
-class LoadModulesDialog(object):
+class LoadModulesDialog:
   #---------------------------------------------------------------------------
   def __init__(self, parent):
     self.dialog = qt.QDialog(parent)

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/ModuleInfo.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/ModuleInfo.py
@@ -12,7 +12,7 @@ import slicer
 # ModuleInfo
 #
 #=============================================================================
-class ModuleInfo(object):
+class ModuleInfo:
   #---------------------------------------------------------------------------
   def __init__(self, path, key=None):
     self.path = path

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/SettingsPanel.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/SettingsPanel.py
@@ -10,7 +10,7 @@ from .TemplatePathUtilities import *
 # _ui_SettingsPanel
 #
 #=============================================================================
-class _ui_SettingsPanel(object):
+class _ui_SettingsPanel:
   #---------------------------------------------------------------------------
   def __init__(self, parent):
     self.formLayout = qt.QFormLayout(parent)

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/TemplatePathUtilities.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/TemplatePathUtilities.py
@@ -9,7 +9,7 @@ def userTemplatePathKey(category=None):
   if category is None:
     return _userTemplatePathKey
   else:
-    return "%s/%s" % (_userTemplatePathKey, category)
+    return f"{_userTemplatePathKey}/{category}"
 
 #-----------------------------------------------------------------------------
 def builtinTemplatePath():

--- a/Modules/Scripted/LabelStatistics/LabelStatistics.py
+++ b/Modules/Scripted/LabelStatistics/LabelStatistics.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import unittest
 import vtk, qt, ctk, slicer
@@ -554,7 +553,7 @@ class LabelStatisticsTest(ScriptedLoadableModuleTest):
 
     self.delayDisplay('test_LabelStatisticsBasic passed!')
 
-class Slicelet(object):
+class Slicelet:
   """A slicer slicelet is a module widget that comes up in stand alone mode
   implemented as a python class.
   This class provides common wrapper functionality used by all slicer modlets.
@@ -588,7 +587,7 @@ class LabelStatisticsSlicelet(Slicelet):
   """
 
   def __init__(self):
-    super(LabelStatisticsSlicelet,self).__init__(LabelStatisticsWidget)
+    super().__init__(LabelStatisticsWidget)
 
 
 if __name__ == "__main__":

--- a/Modules/Scripted/PerformanceTests/PerformanceTests.py
+++ b/Modules/Scripted/PerformanceTests/PerformanceTests.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 
@@ -79,7 +78,7 @@ class PerformanceTestsWidget(ScriptedLoadableModuleWidget):
       endTime = time.time()
       elapsedTime += (endTime - startTime)
     fps = int(iters / elapsedTime)
-    result =  "fps = %g (%g ms per frame)" % (fps, 1000./fps)
+    result =  f"fps = {fps:g} ({1000./fps:g} ms per frame)"
     print (result)
     self.log.insertHtml('<i>%s</i>' % result)
     self.log.insertPlainText('\n')
@@ -313,7 +312,7 @@ class PerformanceTestsWidget(ScriptedLoadableModuleWidget):
     self.memoryCallback()
 
 
-class sliceLogicTest(object):
+class sliceLogicTest:
   def __init__(self):
     self.step = 0
     self.sliceLogic = slicer.vtkMRMLSliceLayerLogic()

--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import logging
 import os
 import textwrap
@@ -116,7 +115,7 @@ use it for commercial purposes.</p>
 #
 # SampleDataSource
 #
-class SampleDataSource(object):
+class SampleDataSource:
   """Describe a set of sample data associated with one or multiple URIs and filenames.
 
   Example::
@@ -396,7 +395,7 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
 # SampleData logic
 #
 
-class SampleDataLogic(object):
+class SampleDataLogic:
   """Manage the slicer.modules.sampleDataSources dictionary.
   The dictionary keys are categories of sample data sources.
   The BuiltIn category is managed here.  Modules or extensions can
@@ -481,7 +480,7 @@ class SampleDataLogic(object):
       slicer.modules.sampleDataSources = {}
 
     if not isinstance(sampleDataSource, SampleDataSource):
-      raise TypeError("unsupported sampleDataSource type '%s': '%s' is expected" % (type(sampleDataSource), str(SampleDataSource)))
+      raise TypeError(f"unsupported sampleDataSource type '{type(sampleDataSource)}': '{str(SampleDataSource)}' is expected")
 
     return sampleDataSource in slicer.modules.sampleDataSources.get(category, [])
 
@@ -807,9 +806,9 @@ class SampleDataLogic(object):
     """ from http://stackoverflow.com/questions/1094841/reusable-library-to-get-human-readable-version-of-file-size"""
     for x in ['bytes','KB','MB','GB']:
       if size < 1024.0 and size > -1024.0:
-        return "%3.1f %s" % (size, x)
+        return f"{size:3.1f} {x}"
       size /= 1024.0
-    return "%3.1f %s" % (size, 'TB')
+    return "{:3.1f} {}".format(size, 'TB')
 
   def reportHook(self,blocksSoFar,blockSize,totalSize):
     # we clamp to 100% because the blockSize might be larger than the file itself
@@ -833,11 +832,11 @@ class SampleDataLogic(object):
     (algo, digest) = extractAlgoAndDigest(checksum)
     if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
       import urllib.request, urllib.parse, urllib.error
-      self.logMessage('<b>Requesting download</b> <i>%s</i> from %s ...' % (name, uri))
+      self.logMessage(f'<b>Requesting download</b> <i>{name}</i> from {uri} ...')
       try:
         urllib.request.urlretrieve(uri, filePath, self.reportHook)
         self.logMessage('<b>Download finished</b>')
-      except IOError as e:
+      except OSError as e:
         self.logMessage('<b>\tDownload failed: %s</b>' % e, logging.ERROR)
         raise ValueError(f"Failed to download {uri} to {filePath}")
 
@@ -845,7 +844,7 @@ class SampleDataLogic(object):
         self.logMessage('<b>Verifying checksum</b>')
         current_digest = computeChecksum(algo, filePath)
         if current_digest != digest:
-          self.logMessage('<b>Checksum verification failed. Computed checksum %s different from expected checksum %s</b>' % (current_digest, digest))
+          self.logMessage(f'<b>Checksum verification failed. Computed checksum {current_digest} different from expected checksum {digest}</b>')
           qt.QFile(filePath).remove()
         else:
           self.downloadPercent = 100
@@ -877,7 +876,7 @@ class SampleDataLogic(object):
     return True
 
   def loadNode(self, uri, name, fileType = 'VolumeFile', fileProperties = {}):
-    self.logMessage('<b>Requesting load</b> <i>%s</i> from %s ...' % (name, uri))
+    self.logMessage(f'<b>Requesting load</b> <i>{name}</i> from {uri} ...')
 
     fileProperties['fileName'] = uri
     fileProperties['name'] = name
@@ -1124,7 +1123,7 @@ class SampleDataTest(ScriptedLoadableModuleTest):
     self.assertTrue(SampleDataLogic.isSampleDataSourceRegistered("Testing", SampleDataSource(**sourceArguments)))
     self.assertFalse(SampleDataLogic.isSampleDataSourceRegistered("Other", SampleDataSource(**sourceArguments)))
 
-  class CustomDownloader(object):
+  class CustomDownloader:
     def __call__(self, source):
       SampleDataTest.customDownloads.append(source)
 

--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -779,7 +779,7 @@ class ScreenCaptureWidget(ScriptedLoadableModuleWidget):
       self.createdOutputFile = os.path.join(outputDir, self.videoFileNameWidget.text) if videoOutputRequested else outputDir
       self.showCreatedOutputFileButton.enabled = True
     except Exception as e:
-      self.addLog("Error: {0}".format(str(e)))
+      self.addLog(f"Error: {str(e)}")
       import traceback
       traceback.print_exc()
       self.showCreatedOutputFileButton.enabled = False

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 import logging
@@ -557,14 +556,14 @@ class SegmentStatisticsLogic(ScriptedLoadableModuleLogic):
           name += ' ['+units+']'
       headerNames.append(name)
     uniqueHeaderNames = list(headerNames)
-    for name in set(name for name in uniqueHeaderNames if uniqueHeaderNames.count(name)>1):
+    for name in {name for name in uniqueHeaderNames if uniqueHeaderNames.count(name)>1}:
       j = 1
       for i in range(len(uniqueHeaderNames)):
         if uniqueHeaderNames[i]==name:
           uniqueHeaderNames[i] = name+' ('+str(j)+')'
           j += 1
-    headerNames = dict((keys[i], headerNames[i]) for i in range(len(keys)))
-    uniqueHeaderNames = dict((keys[i], uniqueHeaderNames[i]) for i in range(len(keys)))
+    headerNames = {keys[i]: headerNames[i] for i in range(len(keys))}
+    uniqueHeaderNames = {keys[i]: uniqueHeaderNames[i] for i in range(len(keys))}
     return headerNames, uniqueHeaderNames
 
   def exportToTable(self, table, nonEmptyKeysOnly = True):
@@ -926,7 +925,7 @@ class SegmentStatisticsTest(ScriptedLoadableModuleTest):
     self.delayDisplay('test_SegmentStatisticsPlugins passed!')
 
 
-class Slicelet(object):
+class Slicelet:
   """A slicer slicelet is a module widget that comes up in stand alone mode
   implemented as a python class.
   This class provides common wrapper functionality used by all slicer modlets.
@@ -960,7 +959,7 @@ class SegmentStatisticsSlicelet(Slicelet):
   """
 
   def __init__(self):
-    super(SegmentStatisticsSlicelet,self).__init__(SegmentStatisticsWidget)
+    super().__init__(SegmentStatisticsWidget)
 
 
 if __name__ == "__main__":

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/ClosedSurfaceSegmentStatisticsPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/ClosedSurfaceSegmentStatisticsPlugin.py
@@ -7,7 +7,7 @@ class ClosedSurfaceSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
   """Statistical plugin for closed surfaces"""
 
   def __init__(self):
-    super(ClosedSurfaceSegmentStatisticsPlugin,self).__init__()
+    super().__init__()
     self.name = "Closed Surface"
     self.keys = ["surface_mm2", "volume_mm3", "volume_cm3"]
     self.defaultKeys = self.keys # calculate all measurements by default

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/LabelmapSegmentStatisticsPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/LabelmapSegmentStatisticsPlugin.py
@@ -9,7 +9,7 @@ class LabelmapSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
   """Statistical plugin for Labelmaps"""
 
   def __init__(self):
-    super(LabelmapSegmentStatisticsPlugin,self).__init__()
+    super().__init__()
     self.name = "Labelmap"
     self.obbKeys = ["obb_origin_ras", "obb_diameter_mm", "obb_direction_ras_x", "obb_direction_ras_y", "obb_direction_ras_z"]
     self.principalAxisKeys = ["principal_axis_x", "principal_axis_y", "principal_axis_z"]

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/ScalarVolumeSegmentStatisticsPlugin.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/ScalarVolumeSegmentStatisticsPlugin.py
@@ -7,7 +7,7 @@ class ScalarVolumeSegmentStatisticsPlugin(SegmentStatisticsPluginBase):
   """Statistical plugin for segmentations with scalar volumes"""
 
   def __init__(self):
-    super(ScalarVolumeSegmentStatisticsPlugin,self).__init__()
+    super().__init__()
     self.name = "Scalar Volume"
     self.keys = ["voxel_count", "volume_mm3", "volume_cm3", "min", "max", "mean", "median", "stdev"]
     self.defaultKeys = self.keys # calculate all measurements by default

--- a/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/SegmentStatisticsPluginBase.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatisticsPlugins/SegmentStatisticsPluginBase.py
@@ -2,7 +2,7 @@ import vtk
 import qt
 import slicer
 
-class SegmentStatisticsPluginBase(object):
+class SegmentStatisticsPluginBase:
   """Base class for statistics plugins operating on segments.
   Derived classes should specify: self.name, self.keys, self.defaultKeys
   and implement: computeStatistics, getMeasurementInfo

--- a/Modules/Scripted/SelfTests/SelfTests.py
+++ b/Modules/Scripted/SelfTests/SelfTests.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import traceback
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
@@ -11,7 +10,7 @@ import logging
 # framework for slicer as discussed here: http://na-mic.org/Bug/view.php?id=1922
 #
 
-class ExampleSelfTests(object):
+class ExampleSelfTests:
 
   @staticmethod
   def closeScene():
@@ -116,7 +115,7 @@ class SelfTestsWidget(ScriptedLoadableModuleWidget):
     slicer.app.processEvents(qt.QEventLoop.ExcludeUserInputEvents)
     return True
 
-class SelfTestsLogic(object):
+class SelfTestsLogic:
   """Logic to handle invoking the tests and reporting the results"""
 
   def __init__(self,selfTests):
@@ -134,7 +133,7 @@ class SelfTestsLogic(object):
         len(self.passed), testsRun )
     s +="\n---\n"
     for test in self.results:
-      s += "%s\t%s\n" % (test, self.results[test])
+      s += f"{test}\t{self.results[test]}\n"
     return s
 
   def run(self,tests=None,continueCheck=None):

--- a/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
+++ b/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
@@ -418,7 +418,7 @@ class VectorToScalarVolumeLogic(ScriptedLoadableModuleLogic):
     outputVolumeNode = getNode(parameterNode.GetParameter("OutputScalarVolume"))
     conversionMethod = parameterNode.GetParameter("ConversionMethod")
     componentToExtract = parameterNode.GetParameter("ComponentToExtract")
-    if componentToExtract is '':
+    if componentToExtract == '':
       componentToExtract = str(self.EXTRACT_COMPONENT_NONE)
     componentToExtract = int(componentToExtract)
 

--- a/Testing/ModelRender.py
+++ b/Testing/ModelRender.py
@@ -1,4 +1,3 @@
-
 import Slicer
 import time
 import random

--- a/Testing/SimpleNUMPYTest.py
+++ b/Testing/SimpleNUMPYTest.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 

--- a/Testing/TextureModel.py
+++ b/Testing/TextureModel.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import Slicer
 import time
 

--- a/Utilities/Scripts/ModuleWizard.py
+++ b/Utilities/Scripts/ModuleWizard.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import sys
 import os
 import fnmatch
@@ -108,7 +107,7 @@ def main(argv):
     usage()
     exit()
 
-  print ("\nWill copy \n\t%s \nto \n\t%s \nreplacing \"%s\" with \"%s\"\n" % (template, target, templateKey, moduleName))
+  print (f"\nWill copy \n\t{template} \nto \n\t{target} \nreplacing \"{templateKey}\" with \"{moduleName}\"\n")
   sources = findSource( template )
   print (sources)
 

--- a/Utilities/Scripts/SEMToMediaWiki.py
+++ b/Utilities/Scripts/SEMToMediaWiki.py
@@ -45,7 +45,7 @@ def getLongFlagDefinition(currentNode):
     labelNodeList = currentNode.getElementsByTagName("longflag")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
-        return "{0}{1}{2}".format("[<span style=\"color:orange\">--",
+        return "{}{}{}".format("[<span style=\"color:orange\">--",
             getTextValuesFromNode(labelNode.childNodes), "</span>]")
     return ""
 
@@ -57,7 +57,7 @@ def getFlagDefinition(currentNode):
     labelNodeList = currentNode.getElementsByTagName("flag")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
-        return "{0}{1}{2}".format("[<span style=\"color:pink\">-",
+        return "{}{}{}".format("[<span style=\"color:pink\">-",
             getTextValuesFromNode(labelNode.childNodes), "</span>]")
     return ""
 
@@ -69,7 +69,7 @@ def getLabelDefinition(currentNode):
     labelNodeList = currentNode.getElementsByTagName("label")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
-        return "{0}{1}{2}".format("** <span style=\"color:green\">'''",
+        return "{}{}{}".format("** <span style=\"color:green\">'''",
             getTextValuesFromNode(labelNode.childNodes), "'''</span>")
     return ""
 
@@ -81,7 +81,7 @@ def getDefaultValueDefinition(currentNode):
     labelNodeList = currentNode.getElementsByTagName("default")
     if labelNodeList.length > 0:
         labelNode = labelNodeList[0]  # Only get the first one
-        return "{0}{1}{2}".format("''Default value: ",
+        return "{}{}{}".format("''Default value: ",
             getTextValuesFromNode(labelNode.childNodes), "''")
     return ""
 
@@ -186,13 +186,13 @@ Examples of the module in use:
 def DumpSEMMediaWikiFeatures(executableNode):
     outRegion = ""
     outRegion += "===Quick Tour of Features and Use===\n\n"
-    outRegion += "{0}{1}".format("A list panels in the interface,",
+    outRegion += "{}{}".format("A list panels in the interface,",
            " their features, what they mean, and how to use them.\n")
     outRegion += "{|\n|\n"
     # Now print all the command line arguments and the labels
     # that showup in the GUI interface
     for parameterNode in executableNode.getElementsByTagName("parameters"):
-        outRegion += "* <span style=\"color:blue\">'''''{0}'''''</span>: {1}\n".format(
+        outRegion += "* <span style=\"color:blue\">'''''{}'''''</span>: {}\n".format(
             getThisNodesInfoAsText(parameterNode, "label"),
             getThisNodesInfoAsText(parameterNode, "description"))
         currentNode = parameterNode.firstChild
@@ -202,7 +202,7 @@ def DumpSEMMediaWikiFeatures(executableNode):
                 if getThisNodesInfoAsText(currentNode, "label") != "":
                     # if this node has a default value -- document it!
                     if getThisNodesInfoAsText(currentNode, "default") != "":
-                        outRegion += "{0} {1} {2}: {3} {4}\n".format(
+                        outRegion += "{} {} {}: {} {}\n".format(
                                 getLabelDefinition(currentNode),
                                 getLongFlagDefinition(currentNode),
                                 getFlagDefinition(currentNode),
@@ -210,7 +210,7 @@ def DumpSEMMediaWikiFeatures(executableNode):
                                     "description"),
                                 getDefaultValueDefinition(currentNode))
                     else:
-                        outRegion += "{0} {1} {2}: {3}\n\n".format(
+                        outRegion += "{} {} {}: {}\n\n".format(
                                 getLabelDefinition(currentNode),
                                 getLongFlagDefinition(currentNode),
                                 getFlagDefinition(currentNode),
@@ -218,7 +218,7 @@ def DumpSEMMediaWikiFeatures(executableNode):
                                     "description"))
             currentNode = currentNode.nextSibling
 
-    outRegion += "{0}{1}\n".format("|[[Image:screenshotBlankNotOptional.png|",
+    outRegion += "{}{}\n".format("|[[Image:screenshotBlankNotOptional.png|",
             "thumb|280px|User Interface]]")
     outRegion += "|}\n\n"
     return outRegion
@@ -318,7 +318,7 @@ def SEMToMediaWikiProg():
             docString += DumpSEMMediaWikiFooter(ExecutableNode)
         else:
             parser.error(
-                "The only valid options are [h|b|f]: Given {0}".format(
+                "The only valid options are [h|b|f]: Given {}".format(
                     stage))
 
     if options.xmlfilename is not None:

--- a/Utilities/Scripts/SlicerWizard/CMakeParser.py
+++ b/Utilities/Scripts/SlicerWizard/CMakeParser.py
@@ -24,7 +24,7 @@ import re
 import string
 
 #=============================================================================
-class Token(object):
+class Token:
   """Base class for CMake script tokens.
 
   This is the base class for CMake script tokens. An occurrence of a token
@@ -79,7 +79,7 @@ class String(Token):
 
   #---------------------------------------------------------------------------
   def __init__(self, text, indent="", prefix="", suffix=""):
-    text = super(String, self).__init__(text, indent)
+    text = super().__init__(text, indent)
     self.prefix = prefix
     self.suffix = suffix
 
@@ -113,7 +113,7 @@ class Comment(Token):
 
   #---------------------------------------------------------------------------
   def __init__(self, prefix, text, indent="", suffix=""):
-    text = super(Comment, self).__init__(text, indent)
+    text = super().__init__(text, indent)
     self.prefix = prefix
     self.suffix = suffix
 
@@ -154,7 +154,7 @@ class Command(Token):
 
   #---------------------------------------------------------------------------
   def __init__(self, text, arguments=[], indent="", prefix="(", suffix=")"):
-    text = super(Command, self).__init__(text, indent)
+    text = super().__init__(text, indent)
     self.prefix = prefix
     self.suffix = suffix
     self.arguments = arguments
@@ -171,7 +171,7 @@ class Command(Token):
     return self.indent + self.text + self.prefix + args + self.suffix
 
 #=============================================================================
-class CMakeScript(object):
+class CMakeScript:
   """Tokenized representation of a CMake script.
 
   .. attribute:: tokens

--- a/Utilities/Scripts/SlicerWizard/ExtensionDescription.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionDescription.py
@@ -6,7 +6,7 @@ import re
 from .ExtensionProject import ExtensionProject
 
 #=============================================================================
-class ExtensionDescription(object):
+class ExtensionDescription:
   """Representation of an extension description.
 
   This class provides a Python object representation of an extension
@@ -232,10 +232,10 @@ class ExtensionDescription(object):
 
     descriptionFiles = glob.glob(os.path.join(path, "*.[Ss]4[Ee][Xx][Tt]"))
     if len(descriptionFiles) < 1:
-      raise IOError("extension description file not found")
+      raise OSError("extension description file not found")
 
     if len(descriptionFiles) > 1:
-      raise IOError("multiple extension description files found")
+      raise OSError("multiple extension description files found")
 
     with open(descriptionFiles[0]) as fp:
       self._read(fp)
@@ -269,16 +269,16 @@ class ExtensionDescription(object):
     dictio["MY_EXTENSION_ENABLED"] = getattr(self, "enabled")
 
     if self.DESCRIPTION_FILE_TEMPLATE is not None:
-      extDescriptFile = open(self.DESCRIPTION_FILE_TEMPLATE,'r')
+      extDescriptFile = open(self.DESCRIPTION_FILE_TEMPLATE)
       for line in extDescriptFile.readlines() :
         if "${" in line:
           variables = self._findOccurences(line, "$")
           temp = line
           for variable in variables:
-            if line[variable] is '$' and line[variable + 1] is '{':
+            if line[variable] == '$' and line[variable + 1] == '{':
               var = ""
               i = variable + 2
-              while line[i] is not '}':
+              while line[i] != '}':
                 var+=line[i]
                 i+=1
               temp = temp.replace("${" + var + "}", dictio[var])
@@ -289,7 +289,7 @@ class ExtensionDescription(object):
       logging.warning("failed to generate description file using template")
       logging.warning("generating description file using fallback method")
       for key in sorted(self.__dict__):
-        fp.write(("%s %s" % (key, getattr(self, key))).strip() + "\n")
+        fp.write((f"{key} {getattr(self, key)}").strip() + "\n")
 
   #---------------------------------------------------------------------------
   def write(self, out):

--- a/Utilities/Scripts/SlicerWizard/ExtensionProject.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionProject.py
@@ -16,7 +16,7 @@ def _trimIndent(indent):
   return indent[n:]
 
 #=============================================================================
-class ExtensionProject(object):
+class ExtensionProject:
   """Convenience class for manipulating an extension project.
 
   This class provides an additional layer of convenience for users that wish to
@@ -50,7 +50,7 @@ class ExtensionProject(object):
     """
     cmakeFile = os.path.join(path, filename)
     if not os.path.exists(cmakeFile):
-      raise IOError("%s not found" % filename)
+      raise OSError("%s not found" % filename)
 
     self._scriptContents, self._encoding = self._parse(cmakeFile, encoding=encoding)
     try:

--- a/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
+++ b/Utilities/Scripts/SlicerWizard/ExtensionWizard.py
@@ -44,7 +44,7 @@ from .Utilities import *
 from .WizardHelpFormatter import WizardHelpFormatter
 
 #=============================================================================
-class ExtensionWizard(object):
+class ExtensionWizard:
   """Implementation class for the Extension Wizard.
 
   This class provides the entry point and implementation of the Extension
@@ -291,9 +291,9 @@ class ExtensionWizard(object):
 
       # Set extension meta-information
       logging.info("updating extension meta-information")
-      raw_url = "%s/%s" % (ghr.html_url.replace("//", "//raw."), branch)
+      raw_url = "{}/{}".format(ghr.html_url.replace("//", "//raw."), branch)
       self._setExtensionUrl(p, "HOMEPAGE", ghr.html_url)
-      self._setExtensionUrl(p, "ICONURL", "%s/%s.png" % (raw_url, name))
+      self._setExtensionUrl(p, "ICONURL", f"{raw_url}/{name}.png")
       p.save()
 
       # Commit the initial commit or updated meta-information
@@ -493,15 +493,15 @@ class ExtensionWizard(object):
 
       # Ensure that user's fork is up to date
       logging.info("updating target branch (%s) branch on fork", args.target)
-      xiRemote.push("%s:refs/heads/%s" % (xiBase, args.target))
+      xiRemote.push(f"{xiBase}:refs/heads/{args.target}")
 
       # Determine if this is an addition or update to the index
       xdf = name + ".s4ext"
       if xdf in xiBase.commit.tree:
-        branch = 'update-%s-%s' % (name, args.target)
+        branch = f'update-{name}-{args.target}'
         update = True
       else:
-        branch = 'add-%s-%s' % (name, args.target)
+        branch = f'add-{name}-{args.target}'
         update = False
 
       logging.debug("create index branch %s", branch)
@@ -586,7 +586,7 @@ class ExtensionWizard(object):
       if pullRequest is None:
         logging.info("creating pull request")
 
-        pull = "%s:%s" % (forkedRepo.owner.login, branch)
+        pull = f"{forkedRepo.owner.login}:{branch}"
         pullRequest = upstreamRepo.create_pull(
                         title=msg[0], body="\n".join(msg[1:]),
                         head=pull, base=args.target)

--- a/Utilities/Scripts/SlicerWizard/GithubHelper.py
+++ b/Utilities/Scripts/SlicerWizard/GithubHelper.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 #=============================================================================
-class _CredentialToken(object):
+class _CredentialToken:
   #---------------------------------------------------------------------------
   def __init__(self, text=None, **kwargs):
     # Set attributes from named arguments
@@ -36,7 +36,7 @@ class _CredentialToken(object):
   #---------------------------------------------------------------------------
   def __str__(self):
     # Return string representation suitable for being fed to 'git credential'
-    lines = ["%s=%s" % (k, getattr(self, k)) for k in self._keys]
+    lines = [f"{k}={getattr(self, k)}" for k in self._keys]
     return "%s\n\n" % "\n".join(lines)
 
 #-----------------------------------------------------------------------------

--- a/Utilities/Scripts/SlicerWizard/Subversion.py
+++ b/Utilities/Scripts/SlicerWizard/Subversion.py
@@ -35,7 +35,7 @@ class CommandError(Exception):
     self.stderr = stderr
 
 #=============================================================================
-class Client(object):
+class Client:
   """Wrapper for executing the ``svn`` process.
 
   This class provides a convenience wrapping for invoking the ``svn`` process.
@@ -137,7 +137,7 @@ class Client(object):
     return result
 
 #=============================================================================
-class Repository(object):
+class Repository:
   """Abstract representation of a subversion repository.
 
   .. attribute:: url

--- a/Utilities/Scripts/SlicerWizard/TemplateManager.py
+++ b/Utilities/Scripts/SlicerWizard/TemplateManager.py
@@ -51,7 +51,7 @@ def _listSources(directory):
         yield f[len(directory) + 1:] # strip common dir
 
 #=============================================================================
-class TemplateManager(object):
+class TemplateManager:
   """Template collection manager.
 
   This class provides a template collection and operations for managing and
@@ -162,7 +162,7 @@ class TemplateManager(object):
       destination = os.path.join(destination, name)
 
     if requireEmptyDirectory and os.path.exists(destination):
-      raise IOError("create %s: refusing to overwrite"
+      raise OSError("create %s: refusing to overwrite"
                     " existing directory '%s'" % (category, destination))
 
     template = templates[kind]
@@ -301,7 +301,7 @@ class TemplateManager(object):
 
       if len(self._paths[c]):
         for t in sorted(self._paths[c].keys()):
-          logging.info("  '%s' ('%s')" % (t, self._getKey(t)))
+          logging.info(f"  '{t}' ('{self._getKey(t)}')")
 
       else:
         logging.info("  (none)")

--- a/Utilities/Scripts/SlicerWizard/Utilities.py
+++ b/Utilities/Scripts/SlicerWizard/Utilities.py
@@ -57,7 +57,7 @@ _logLevel = None
 class _LogWrapFormatter(logging.Formatter):
   #---------------------------------------------------------------------------
   def __init__(self):
-    super(_LogWrapFormatter, self).__init__()
+    super().__init__()
     try:
       self._width = int(os.environ['COLUMNS']) - 1
     except:
@@ -65,7 +65,7 @@ class _LogWrapFormatter(logging.Formatter):
 
   #---------------------------------------------------------------------------
   def format(self, record):
-    lines = super(_LogWrapFormatter, self).format(record).split("\n")
+    lines = super().format(record).split("\n")
     return "\n".join([textwrap.fill(l, self._width) for l in lines])
 
 #=============================================================================
@@ -159,7 +159,7 @@ def inquire(msg, choices=_yesno):
   """
 
   choiceKeys = list(choices.keys())
-  msg = "%s %s? " % (msg, ",".join(choiceKeys))
+  msg = "{} {}? ".format(msg, ",".join(choiceKeys))
 
   def throw(*args):
     raise ValueError()
@@ -287,7 +287,7 @@ def buildProcessArgs(*args, **kwargs):
     if v is None or v is False:
       continue
 
-    result += ["%s%s" % ("-" if len(k) == 1 else "--", k.replace("_", "-"))]
+    result += ["{}{}".format("-" if len(k) == 1 else "--", k.replace("_", "-"))]
 
     if v is not True:
       result += ["%s" % v]
@@ -334,7 +334,7 @@ def createEmptyRepo(path, tool=None):
   return git.Repo.init(path)
 
 #-----------------------------------------------------------------------------
-class SourceTreeDirectory(object):
+class SourceTreeDirectory:
   """Abstract representation of a source tree directory.
 
   .. attribute:: root
@@ -359,7 +359,7 @@ class SourceTreeDirectory(object):
       .
     """
     if not os.path.exists(os.path.join(root, relative_directory)):
-      raise IOError("'root/relative_directory' does not exist")
+      raise OSError("'root/relative_directory' does not exist")
     self.root = root
     self.relative_directory = relative_directory
 

--- a/Utilities/Scripts/SlicerWizard/WizardHelpFormatter.py
+++ b/Utilities/Scripts/SlicerWizard/WizardHelpFormatter.py
@@ -13,10 +13,10 @@ class WizardHelpFormatter(argparse.HelpFormatter):
 
   #---------------------------------------------------------------------------
   def _format_action_invocation(self, *args):
-    text = super(WizardHelpFormatter, self)._format_action_invocation(*args)
+    text = super()._format_action_invocation(*args)
     return text.replace("<", "[").replace(">", "]")
 
   #---------------------------------------------------------------------------
   def _format_usage(self, *args):
-    text = super(WizardHelpFormatter, self)._format_usage(*args)
+    text = super()._format_usage(*args)
     return text.replace("<", "[").replace(">", "]")

--- a/Utilities/Scripts/SlicerWizard/doc/conf.py
+++ b/Utilities/Scripts/SlicerWizard/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # SlicerWizard documentation build configuration file, created by
 # sphinx-quickstart on Mon Feb 10 14:47:54 2014.
@@ -30,7 +29,7 @@ sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
 #%%% Site extensions %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #===============================================================================
-class WikidocRole(object):
+class WikidocRole:
   wiki_root = 'http://wiki.slicer.org/slicerWiki/index.php'
 
   #-----------------------------------------------------------------------------
@@ -40,7 +39,7 @@ class WikidocRole(object):
     roles.set_classes(options)
 
     parts = utils.unescape(text).split(' ', 1)
-    uri = '%s/Documentation/%s/%s' % (self.wiki_root, self.wiki_doc_version,
+    uri = '{}/Documentation/{}/{}'.format(self.wiki_root, self.wiki_doc_version,
                                       parts[0])
     text = parts[1]
 
@@ -51,7 +50,7 @@ class WikidocRole(object):
 class ClassModuleClassDocumenter(autodoc.ClassDocumenter):
   #-----------------------------------------------------------------------------
   def resolve_name(self, *args):
-    module, attrs = super(ClassModuleClassDocumenter, self).resolve_name(*args)
+    module, attrs = super().resolve_name(*args)
     module = module.split('.')
     if module[-1] == attrs[0]:
       del module[-1]
@@ -109,9 +108,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'SlicerWizard'
-author = u'Kitware'
-copyright = u'2014, Kitware'
+project = 'SlicerWizard'
+author = 'Kitware'
+copyright = '2014, Kitware'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -253,7 +252,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'SlicerWizard.tex', u'SlicerWizard Documentation',
+  ('index', 'SlicerWizard.tex', 'SlicerWizard Documentation',
    author, 'manual'),
 ]
 
@@ -283,7 +282,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'slicerwizard', u'SlicerWizard Documentation',
+    ('index', 'slicerwizard', 'SlicerWizard Documentation',
      [author], 1)
 ]
 
@@ -297,7 +296,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'SlicerWizard', u'SlicerWizard Documentation',
+  ('index', 'SlicerWizard', 'SlicerWizard Documentation',
    author, 'SlicerWizard', 'One line description of project.',
    'Miscellaneous'),
 ]
@@ -315,7 +314,7 @@ texinfo_documents = [
 #%%% Options for Epub output %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 # Bibliographic Dublin Core info.
-epub_title = u'SlicerWizard'
+epub_title = 'SlicerWizard'
 epub_author = author
 epub_publisher = author
 epub_copyright = copyright

--- a/Utilities/Scripts/genqrc.py
+++ b/Utilities/Scripts/genqrc.py
@@ -9,7 +9,7 @@ def writeFile(path, content):
   # Test if file already contains desired content
   if os.path.exists(path):
     try:
-      with open(path, "rt") as f:
+      with open(path) as f:
         if f.read() == content:
           return
 
@@ -23,7 +23,7 @@ def writeFile(path, content):
 #-----------------------------------------------------------------------------
 def addFile(path):
   name = os.path.basename(path)
-  return ["    <file alias=\"%s\">%s</file>" % (name, path)]
+  return [f"    <file alias=\"{name}\">{path}</file>"]
 
 #-----------------------------------------------------------------------------
 def buildContent(root, path):

--- a/Utilities/Scripts/python_package_updater.py
+++ b/Utilities/Scripts/python_package_updater.py
@@ -89,7 +89,7 @@ def update_external_project_python_packages(packages_to_update, directory, cpyth
     for dirpath, _, filenames, in os.walk(directory):
         for filename in filenames:
             filepath = os.path.join(dirpath, filename)
-            with open(filepath, "r") as open_file:
+            with open(filepath) as open_file:
                 file_text = open_file.read()
 
             for package_name, updated_line in lines_to_write.items():

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -344,7 +344,7 @@ class TemplateKeyLogic(ScriptedLoadableModuleLogic):
     slicer.mrmlScene.RemoveNode(cliNode)
 
     stopTime = time.time()
-    logging.info('Processing completed in {0:.2f} seconds'.format(stopTime-startTime))
+    logging.info(f'Processing completed in {stopTime-startTime:.2f} seconds')
 
 #
 # TemplateKeyTest

--- a/Utilities/Templates/Modules/ScriptedEditorEffect/TemplateKeyEffect.py
+++ b/Utilities/Templates/Modules/ScriptedEditorEffect/TemplateKeyEffect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import vtk, qt, ctk, slicer
 import EditorLib
@@ -22,7 +21,7 @@ class TemplateKeyEffectOptions(LabelEffectOptions):
   """
 
   def __init__(self, parent=0):
-    super(TemplateKeyEffectOptions,self).__init__(parent)
+    super().__init__(parent)
 
     # self.attributes should be tuple of options:
     # 'MouseTool' - grabs the cursor
@@ -32,10 +31,10 @@ class TemplateKeyEffectOptions(LabelEffectOptions):
     self.displayName = 'TemplateKeyEffect Effect'
 
   def __del__(self):
-    super(TemplateKeyEffectOptions,self).__del__()
+    super().__del__()
 
   def create(self):
-    super(TemplateKeyEffectOptions,self).create()
+    super().create()
     self.apply = qt.QPushButton("Apply", self.frame)
     self.apply.objectName = self.__class__.__name__ + 'Apply'
     self.apply.setToolTip("Apply the extension operation")
@@ -50,7 +49,7 @@ class TemplateKeyEffectOptions(LabelEffectOptions):
     self.frame.layout().addStretch(1)
 
   def destroy(self):
-    super(TemplateKeyEffectOptions,self).destroy()
+    super().destroy()
 
   # note: this method needs to be implemented exactly as-is
   # in each leaf subclass so that "self" in the observer
@@ -64,11 +63,11 @@ class TemplateKeyEffectOptions(LabelEffectOptions):
       self.parameterNodeTag = node.AddObserver(vtk.vtkCommand.ModifiedEvent, self.updateGUIFromMRML)
 
   def setMRMLDefaults(self):
-    super(TemplateKeyEffectOptions,self).setMRMLDefaults()
+    super().setMRMLDefaults()
 
   def updateGUIFromMRML(self,caller,event):
     self.disconnectWidgets()
-    super(TemplateKeyEffectOptions,self).updateGUIFromMRML(caller,event)
+    super().updateGUIFromMRML(caller,event)
     self.connectWidgets()
 
   def onApply(self):
@@ -79,7 +78,7 @@ class TemplateKeyEffectOptions(LabelEffectOptions):
       return
     disableState = self.parameterNode.GetDisableModifiedEvent()
     self.parameterNode.SetDisableModifiedEvent(1)
-    super(TemplateKeyEffectOptions,self).updateMRMLFromGUI()
+    super().updateMRMLFromGUI()
     self.parameterNode.SetDisableModifiedEvent(disableState)
     if not disableState:
       self.parameterNode.InvokePendingModifiedEvent()
@@ -100,12 +99,12 @@ class TemplateKeyEffectTool(LabelEffectTool):
   """
 
   def __init__(self, sliceWidget):
-    super(TemplateKeyEffectTool,self).__init__(sliceWidget)
+    super().__init__(sliceWidget)
     # create a logic instance to do the non-gui work
     self.logic = TemplateKeyEffectLogic(self.sliceWidget.sliceLogic())
 
   def cleanup(self):
-    super(TemplateKeyEffectTool,self).cleanup()
+    super().cleanup()
 
   def processEvent(self, caller=None, event=None):
     """
@@ -113,7 +112,7 @@ class TemplateKeyEffectTool(LabelEffectTool):
     """
 
     # let the superclass deal with the event if it wants to
-    if super(TemplateKeyEffectTool,self).processEvent(caller,event):
+    if super().processEvent(caller,event):
       return
 
     if event == "LeftButtonPressEvent":
@@ -186,7 +185,7 @@ pet = EditorLib.TemplateKeyEffectTool(sw)
 # TemplateKeyEffect
 #
 
-class TemplateKeyEffect(object):
+class TemplateKeyEffect:
   """
   This class is the 'hook' for slicer to detect and recognize the extension
   as a loadable scripted module
@@ -225,7 +224,7 @@ class TemplateKeyEffect(object):
 # TemplateKeyEffectWidget
 #
 
-class TemplateKeyEffectWidget(object):
+class TemplateKeyEffectWidget:
   def __init__(self, parent = None):
     self.parent = parent
 


### PR DESCRIPTION
This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. This ultimately removes Python 2 compatibility. Slicer seemingly hasn't been trying to maintain Python 2 compatibility given that many libraries have already dropped Python 2 support since it went EOL on January 1st 2020. Slicer already includes some f-string formatting only supported by Python 3.6 and newer (See [usage](https://github.com/Slicer/Slicer/blob/master/Modules/Scripted/DICOMLib/DICOMUtils.py#L838) in DICOMUtils.py). Slicer's current Stable past couple of stable releases (4.11.20210226 and 4.11.20200930) have both included Python 3 as well.

Around early April 2019 @jcfr began using scripts, such as [`futurize`](https://python-future.org/futurize.html), provided by https://python-future.org/ to turn Python 2 code into valid Python 3 code. This was because Slicer was in a transition period and the Slicer nightly would begin using Python 3 while Slicer stable would still be using Python 2. This work was documented at https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide#Python_2_to_Python_3 and at https://discourse.slicer.org/t/updating-slicer-to-work-with-python-3/4662/9.

Notably, most of the changes in this PR are changes due to the following commits:
- `STYLE: Update python scripts to use print function for python 3.x`: https://github.com/Slicer/Slicer/commit/7df896e839dc03e1c2f3b5458590ea16e80fcbba
- `STYLE: Update python classes to follow new-style`: https://github.com/Slicer/Slicer/commit/d366e32491d13461c9c6316b3e4ed80fb4279d3f

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the Slicer repo. It was run by `PythonSlicer pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/Slicer"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py36-plus", file_path])
```
