### PR TITLE
BUG: Fix missing attributes when proxy node is changed

### DIFF
--- a/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.cxx
+++ b/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.cxx
@@ -386,7 +386,7 @@ void vtkSlicerSequencesLogic::UpdateProxyNodesFromSequences(vtkMRMLSequenceBrows
       }
 
     // Get the current target output node
-    vtkMRMLNode* targetProxyNode=browserNode->GetProxyNode(synchronizedSequenceNode);
+    vtkMRMLNode* targetProxyNode = browserNode->GetProxyNode(synchronizedSequenceNode);
     if (targetProxyNode!=nullptr)
       {
       // a proxy node with the requested role exists already
@@ -410,6 +410,8 @@ void vtkSlicerSequencesLogic::UpdateProxyNodesFromSequences(vtkMRMLSequenceBrows
       // failed to add target output node
       continue;
       }
+
+    this->CopyNodeAttributes(targetProxyNode, sourceDataNode);
 
     // Update the target node with the contents of the source node
 
@@ -475,6 +477,17 @@ void vtkSlicerSequencesLogic::UpdateProxyNodesFromSequences(vtkMRMLSequenceBrows
   timer->StopTimer();
   vtkInfoMacro("UpdateProxyNodesFromSequences: " << timer->GetElapsedTime() << "sec\n");
 #endif
+}
+
+//---------------------------------------------------------------------------
+void vtkSlicerSequencesLogic::CopyNodeAttributes(vtkMRMLNode* source, vtkMRMLNode* target)
+{
+  std::vector< std::string > attributeNames = source->GetAttributeNames();
+  for (std::vector< std::string >::iterator attributeNamesIt = attributeNames.begin();
+    attributeNamesIt != attributeNames.end(); ++attributeNamesIt)
+    {
+    target->SetAttribute(attributeNamesIt->c_str(), source->GetAttribute(attributeNamesIt->c_str()));
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.h
+++ b/Modules/Loadable/Sequences/Logic/vtkSlicerSequencesLogic.h
@@ -118,6 +118,7 @@ protected:
   void ProcessMRMLNodesEvents(vtkObject *caller, unsigned long event, void *callData) override;
 
   bool IsDataConnectorNode(vtkMRMLNode*);
+  void CopyNodeAttributes(vtkMRMLNode* source, vtkMRMLNode* target);
 
   // Time of the last update of each browser node (in universal time)
   std::map< vtkMRMLSequenceBrowserNode*, double > LastSequenceBrowserUpdateTimeSec;


### PR DESCRIPTION
Attributes of proxy nodes are lost after vtkSlicerSequencesLogic::UpdateProxyNodesFromSequences.
Before updating the proxy node copy all its attributes.
Naming of variable "source" and "target" may be confusing with existing targetProxyNode and sourceDataNode variable names.