### PR TITLE
BUG: Prevent flood of terminology errors in the log if using an older scene

### DIFF
--- a/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
+++ b/Modules/Loadable/Terminologies/Logic/vtkSlicerTerminologiesModuleLogic.cxx
@@ -1519,6 +1519,12 @@ bool vtkSlicerTerminologiesModuleLogic::GetCategoryInTerminology(std::string ter
   rapidjson::Value& categoryObject = this->Internal->GetCategoryInTerminology(terminologyName, categoryId);
   if (categoryObject.IsNull())
   {
+    if (!categoryId.CodingSchemeDesignator.compare("SRT"))
+      {
+      // Do not report error if it is due to using an old scene with the SRT category codes instead of the SCT ones
+      // that replaced them on 2020.03.17 in Slicer@5ae556436.
+      return false;
+      }
     vtkErrorMacro("GetCategoryInTerminology: Failed to find category '" << categoryId.CodeMeaning << "' in terminology '" << terminologyName << "'");
     return false;
   }
@@ -2057,6 +2063,12 @@ bool vtkSlicerTerminologiesModuleLogic::DeserializeTerminologyEntry(std::string 
   vtkSmartPointer<vtkSlicerTerminologyCategory> categoryObject = vtkSmartPointer<vtkSlicerTerminologyCategory>::New();
   if ( !this->GetCategoryInTerminology(terminologyName, categoryId, categoryObject) )
     {
+    if (!categoryIds[0].compare("SRT"))
+      {
+      // Do not report error if it is due to using an old scene with the SRT category codes instead of the SCT ones
+      // that replaced them on 2020.03.17 in Slicer@5ae556436.
+      return false;
+      }
     vtkErrorWithObjectMacro(entry, "DeserializeTerminologyEntry: Failed to get terminology category");
     return false;
    }


### PR DESCRIPTION
The commit 5ae5564362b40e43730a289e1fa0531feee8ca73 on 2020.03.17 changed all the terminology category codes in the default terminology contexts. As a result, if a scene saved before this date containing terminology information is loaded in a version newer than that, lots of errors are reported about the category not found in the specified terminology category.

The errors logged are pairs of entries looking like this:
"GetCategoryInTerminology: Failed to find category 'Anatomical Structure' in terminology 'Segmentation category and type - 3D Slicer General Anatomy list'
DeserializeTerminologyEntry: Failed to get terminology category"