### PR TITLE
Sh combobox improvements

### DIFF
--- a/Modules/Loadable/Data/Resources/UI/qSlicerDataModuleWidget.ui
+++ b/Modules/Loadable/Data/Resources/UI/qSlicerDataModuleWidget.ui
@@ -18,7 +18,16 @@
     <normaloff>:/Icons/Data.png</normaloff>:/Icons/Data.png</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout_5">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
     <number>4</number>
    </property>
    <property name="spacing">
@@ -71,6 +80,21 @@
        <string>Subject hierarchy</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
+       <property name="leftMargin">
+        <number>4</number>
+       </property>
+       <property name="topMargin">
+        <number>4</number>
+       </property>
+       <property name="rightMargin">
+        <number>4</number>
+       </property>
+       <property name="bottomMargin">
+        <number>4</number>
+       </property>
+       <property name="spacing">
+        <number>4</number>
+       </property>
        <item row="1" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <property name="spacing">
@@ -142,6 +166,9 @@
          <property name="indentation">
           <number>12</number>
          </property>
+         <property name="showRootItem">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item row="2" column="0">
@@ -156,7 +183,16 @@
           <property name="spacing">
            <number>4</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>4</number>
+          </property>
+          <property name="topMargin">
+           <number>4</number>
+          </property>
+          <property name="rightMargin">
+           <number>4</number>
+          </property>
+          <property name="bottomMargin">
            <number>4</number>
           </property>
           <item>
@@ -179,6 +215,21 @@
        <string>Transform hierarchy</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_6">
+       <property name="leftMargin">
+        <number>4</number>
+       </property>
+       <property name="topMargin">
+        <number>4</number>
+       </property>
+       <property name="rightMargin">
+        <number>4</number>
+       </property>
+       <property name="bottomMargin">
+        <number>4</number>
+       </property>
+       <property name="spacing">
+        <number>4</number>
+       </property>
        <item row="1" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
@@ -241,6 +292,21 @@
        <string>All nodes</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
+       <property name="leftMargin">
+        <number>4</number>
+       </property>
+       <property name="topMargin">
+        <number>4</number>
+       </property>
+       <property name="rightMargin">
+        <number>4</number>
+       </property>
+       <property name="bottomMargin">
+        <number>4</number>
+       </property>
+       <property name="spacing">
+        <number>4</number>
+       </property>
        <item row="1" column="0">
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
@@ -310,7 +376,16 @@
       <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
        <number>4</number>
       </property>
       <property name="spacing">

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
@@ -471,22 +471,22 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
       # Check include node attribute name filter
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
       filteredObject.includeNodeAttributeNamesFilter = ['Markups.MovingInSliceView']
-      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 6)
+      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 5)
       filteredObject.addNodeAttributeFilter('Sajt')
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
       filteredObject.includeNodeAttributeNamesFilter = []
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
       # Check attribute value filter
       filteredObject.addNodeAttributeFilter('Markups.MovingMarkupIndex', 3)
-      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4)
+      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 3)
       filteredObject.includeNodeAttributeNamesFilter = []
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
       filteredObject.addNodeAttributeFilter('Markups.MovingMarkupIndex', '3')
-      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4)
+      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 3)
       filteredObject.includeNodeAttributeNamesFilter = []
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
 
-      # ChecfilteredObjectk exclude node attribute name filter (overrides include node attribute name filter)
+      # Check exclude node attribute name filter (overrides include node attribute name filter)
       filteredObject.excludeNodeAttributeNamesFilter = ['Markups.MovingInSliceView']
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 5)
       filteredObject.excludeNodeAttributeNamesFilter = []
@@ -495,7 +495,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
       filteredObject.includeNodeAttributeNamesFilter = ['Markups.MovingMarkupIndex']
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
       filteredObject.excludeNodeAttributeNamesFilter = ['Markups.MovingInSliceView']
-      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 5)
+      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4)
       filteredObject.includeNodeAttributeNamesFilter = []
       filteredObject.excludeNodeAttributeNamesFilter = []
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
@@ -542,7 +542,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
 
       # Check attribute filtering with class name and attribute value
       filteredObject.addNodeAttributeFilter('Markups.MovingMarkupIndex', 3, True, 'vtkMRMLMarkupsCurveNode')
-      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4)
+      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 3)
       filteredObject.addNodeAttributeFilter('ParentAttribute', '', True, 'vtkMRMLMarkupsAngleNode')
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 5)
       filteredObject.addNodeAttributeFilter('ChildAttribute', '', True, 'vtkMRMLMarkupsAngleNode')
@@ -551,7 +551,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
       # Check with empty attribute value
       filteredObject.addNodeAttributeFilter('Markups.MovingMarkupIndex', '', True, 'vtkMRMLMarkupsCurveNode')
-      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 5)
+      self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 4)
       filteredObject.includeNodeAttributeNamesFilter = []
       self.assertEqual(shProxyModel.acceptedItemCount(shNode.GetSceneItemID()), 9)
 
@@ -559,7 +559,6 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
     testAttributeFilters(shProxyModel, shProxyModel)
     logging.info('Test attribute filters on tree view')
     testAttributeFilters(shTreeView, shProxyModel)
-
 
   # ------------------------------------------------------------------------------
   # Utility functions

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyGenericSelfTest.py
@@ -105,6 +105,7 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
     self.section_LoadScene()
     self.section_TestCircularParenthood()
     self.section_AttributeFilters()
+    self.section_ComboboxFeatures()
 
     logging.info('Test finished')
 
@@ -559,6 +560,44 @@ class SubjectHierarchyGenericSelfTestTest(ScriptedLoadableModuleTest):
     testAttributeFilters(shProxyModel, shProxyModel)
     logging.info('Test attribute filters on tree view')
     testAttributeFilters(shTreeView, shProxyModel)
+
+  # ------------------------------------------------------------------------------
+  def section_ComboboxFeatures(self):
+    self.delayDisplay("Combobox features",self.delayMs)
+
+    comboBox = slicer.qMRMLSubjectHierarchyComboBox()
+    comboBox.setMRMLScene(slicer.mrmlScene)
+    comboBox.show()
+
+    shNode = slicer.mrmlScene.GetSubjectHierarchyNode()
+    self.assertEqual(comboBox.sortFilterProxyModel().acceptedItemCount(shNode.GetSceneItemID()), 9)
+
+    # Enable None item, number of accepted SH items is the same (None does not have a corresponding accepted SH item)
+    comboBox.noneEnabled = True
+    self.assertEqual(comboBox.sortFilterProxyModel().acceptedItemCount(shNode.GetSceneItemID()), 9)
+
+    # Default text
+    self.assertEqual(comboBox.defaultText, 'Select subject hierarchy item')
+
+    # Select node, include parent names in current item text (when collapsed)
+    markupsCurve1ItemID = shNode.GetItemByName('MarkupsCurve_1')
+    comboBox.setCurrentItem(markupsCurve1ItemID)
+    self.assertEqual(comboBox.defaultText, 'NewFolder_1 / MarkupsCurve_1')
+
+    # Select None item
+    comboBox.setCurrentItem(0)
+    self.assertEqual(comboBox.defaultText, comboBox.noneDisplay)
+
+    # Do not show parent names in current item text
+    comboBox.showCurrentItemParents = False
+    comboBox.setCurrentItem(markupsCurve1ItemID)
+    self.assertEqual(comboBox.defaultText, 'MarkupsCurve_1')
+
+    # Change None item name
+    comboBox.noneDisplay = 'No selection'
+    comboBox.setCurrentItem(0)
+    self.assertEqual(comboBox.defaultText, comboBox.noneDisplay)
+
 
   # ------------------------------------------------------------------------------
   # Utility functions

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.cxx
@@ -1012,6 +1012,12 @@ qMRMLSortFilterSubjectHierarchyProxyModel::AcceptType qMRMLSortFilterSubjectHier
 Qt::ItemFlags qMRMLSortFilterSubjectHierarchyProxyModel::flags(const QModelIndex & index)const
 {
   vtkIdType itemID = this->subjectHierarchyItemFromIndex(index);
+  if (!itemID)
+    {
+    // Extra item (e.g. None)
+    return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+    }
+
   bool isSelectable = (this->filterAcceptsItem(itemID) == Accept);
   qMRMLSubjectHierarchyModel* sceneModel = qobject_cast<qMRMLSubjectHierarchyModel*>(this->sourceModel());
   QStandardItem* item = sceneModel->itemFromSubjectHierarchyItem(itemID, index.column());

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSortFilterSubjectHierarchyProxyModel.h
@@ -154,9 +154,6 @@ public:
   /// This method test each item via \a filterAcceptsItem
   bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent)const override;
 
-  /// Filters items to decide which to display in the view
-  virtual bool filterAcceptsItem(vtkIdType itemID, bool canAcceptIfAnyChildIsAccepted=true)const;
-
   Qt::ItemFlags flags(const QModelIndex & index)const override;
 
 public slots:
@@ -172,6 +169,23 @@ public slots:
   void setExcludeNodeAttributeNamesFilter(QStringList filterList);
 
 protected:
+  /// This enum type is used to describe the behavior of an item with regard to
+  /// filtering:
+  ///   * Reject if the item should not be visible and has no chance of being
+  ///     visible.
+  ///   * Accept if the item should be visible and will always be.
+  ///   * AcceptDueToBeingParentOfAccepted if the item should not be visible
+  ///     based on the applied filters, but it is the parent of an accepted item,
+  ///     so the item needs to be shown to indicate hierarchy.
+  enum AcceptType
+  {
+    Reject = 0,
+    Accept,
+    AcceptDueToBeingParentOfAccepted,
+  };
+
+  /// Filters items to decide which to display in the view
+  virtual AcceptType filterAcceptsItem(vtkIdType itemID, bool canAcceptIfAnyChildIsAccepted=true)const;
 
   QStandardItem* sourceItem(const QModelIndex& index)const;
 
@@ -181,6 +195,7 @@ protected:
 private:
   Q_DECLARE_PRIVATE(qMRMLSortFilterSubjectHierarchyProxyModel);
   Q_DISABLE_COPY(qMRMLSortFilterSubjectHierarchyProxyModel);
+  friend class qMRMLSubjectHierarchyTreeView;
 };
 
 #endif

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
@@ -56,6 +56,17 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qMRMLSubjectHierarchyCombo
   /// If aligned, the popup will shift vertically so that the selected item overlays above the combobox.
   /// Else, the popup tree appears below the combobox, like for a qMRMLNodeComboBox.
   Q_PROPERTY(bool alignPopupVertically READ alignPopupVertically WRITE setAlignPopupVertically)
+  /// This property controls whether an extra item is added before any subject hierarchy item under
+  /// the scene item for indicating 'None' selection.
+  Q_PROPERTY(bool noneEnabled READ noneEnabled WRITE setNoneEnabled)
+  /// This property controls the name that is displayed for the None item.
+  /// "None" by default.
+  /// \sa noneItemEnabled
+  Q_PROPERTY(QString noneDisplay READ noneDisplay WRITE setNoneDisplay)
+  /// This property controls whether hierarchy information is included in the current item text (showed when collapsed).
+  /// If enabled (which is the default), then the text looks like "[ParentName] / [ParentName] / [SelectedItemName]".
+  /// If disabled, the title will only be "[SelectedItemName]".
+  Q_PROPERTY(bool showCurrentItemParents READ showCurrentItemParents WRITE setShowCurrentItemParents)
 
   /// Filter to show only items that contain any of the given attributes with this name. Empty by default
   Q_PROPERTY(QStringList includeItemAttributeNamesFilter READ includeItemAttributeNamesFilter WRITE setIncludeItemAttributeNamesFilter)
@@ -101,6 +112,15 @@ public:
 
   bool alignPopupVertically()const;
   void setAlignPopupVertically(bool align);
+
+  bool noneEnabled()const;
+  void setNoneEnabled(bool enable);
+
+  QString noneDisplay()const;
+  void setNoneDisplay(const QString& displayName);
+
+  bool showCurrentItemParents()const;
+  void setShowCurrentItemParents(bool enable);
 
   QStringList includeItemAttributeNamesFilter()const;
   QStringList includeNodeAttributeNamesFilter()const;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.h
@@ -76,6 +76,14 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qMRMLSubjectHierarchyModel
   /// A value of -1 hides it. Hidden by default (value of -1)
   Q_PROPERTY (int idColumn READ idColumn WRITE setIDColumn)
 
+  /// This property controls whether an extra item is added before any subject hierarchy item under
+  /// the scene item for indicating 'None' selection. Especially useful for comboboxes.
+  Q_PROPERTY(bool noneEnabled READ noneEnabled WRITE setNoneEnabled)
+  /// This property controls the name that is displayed for the None item.
+  /// "None" by default.
+  /// \sa noneItemEnabled
+  Q_PROPERTY(QString noneDisplay READ noneDisplay WRITE setNoneDisplay)
+
 public:
   typedef QStandardItemModel Superclass;
   qMRMLSubjectHierarchyModel(QObject *parent=nullptr);
@@ -111,6 +119,12 @@ public:
 
   int idColumn()const;
   void setIDColumn(int column);
+
+  bool noneEnabled()const;
+  void setNoneEnabled(bool enable);
+
+  QString noneDisplay()const;
+  void setNoneDisplay(const QString& displayName);
 
   Qt::DropActions supportedDropActions()const override;
   QMimeData* mimeData(const QModelIndexList& indexes)const override;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel_p.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel_p.h
@@ -79,6 +79,9 @@ public:
   /// Get terminologies module logic. If not found in cache get from module object
   vtkSlicerTerminologiesModuleLogic* terminologiesModuleLogic();
 
+  /// Get extra item identifier
+  const QString extraItemIdentifier() { return QString("ExtraItem"); };
+
 public:
   vtkSmartPointer<vtkCallbackCommand> CallBack;
   int PendingItemModified;
@@ -89,6 +92,9 @@ public:
   int ColorColumn;
   int TransformColumn;
   int DescriptionColumn;
+
+  bool NoneEnabled;
+  QString NoneDisplay;
 
   QIcon VisibleIcon;
   QIcon HiddenIcon;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -73,6 +73,14 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qMRMLSubjectHierarchyTreeV
   Q_PROPERTY(bool transformColumnVisible READ transformColumnVisible WRITE setTransformColumnVisible)
   Q_PROPERTY(bool descriptionColumnVisible READ descriptionColumnVisible WRITE setDescriptionColumnVisible)
 
+  /// This property controls whether an extra item is added before any subject hierarchy item under
+  /// the scene item for indicating 'None' selection.
+  Q_PROPERTY(bool noneEnabled READ noneEnabled WRITE setNoneEnabled)
+  /// This property controls the name that is displayed for the None item.
+  /// "None" by default.
+  /// \sa noneItemEnabled
+  Q_PROPERTY(QString noneDisplay READ noneDisplay WRITE setNoneDisplay)
+
   /// Filter to show only items that contain any of the given attributes with this name. Empty by default
   Q_PROPERTY(QStringList includeItemAttributeNamesFilter READ includeItemAttributeNamesFilter WRITE setIncludeItemAttributeNamesFilter)
   /// Filter to show only items for data nodes that contain any of the given attributes with this name. Empty by default
@@ -188,6 +196,8 @@ public:
   bool contextMenuEnabled()const;
   bool editMenuActionVisible()const;
   bool selectRoleSubMenuVisible()const;
+  bool noneEnabled()const;
+  QString noneDisplay()const;
 
   /// Set visibility column visibility
   void setVisibilityColumnVisible(bool visible);
@@ -270,6 +280,8 @@ public slots:
   void setContextMenuEnabled(bool enabled);
   void setEditMenuActionVisible(bool visible);
   void setSelectRoleSubMenuVisible(bool visible);
+  void setNoneEnabled(bool enable);
+  void setNoneDisplay(const QString& displayName);
 
   /// Resets column sizes and size policies to default.
   void resetColumnSizesToDefault();


### PR DESCRIPTION
1. Introduce None item in subject hierarchy
    - If enabled, an "extra item" (similarly to the same concept in qMRMLNodeComboBox) is added as the top item under the scene. This item has the name defined in the noneItemText property, and is selectable but no drag&drop is enabled. When selecting it, the current item will have the ID 0 (= INVALID_ITEM_ID)
    - This enables having empty selections in comboboxes after having made a valid selection

    ![image](https://user-images.githubusercontent.com/1325980/118012293-cc356280-b348-11eb-99ca-94632b240da9.png)

2. Add flag in subject hierarchy combobox for showing parents in title
    - Sometimes it is undesired to see the name of each parent after selecting an item in the combobox (it looks like "[ParentName] / [ParentName] / [SelectedItemName]"). If disabled, only the name of the selected item is shown ("[SelectedItemName]")
    - On by default not to change the current behavior

3. If an include attribute node filter was applied, hierarchy (patient/study/folder) items that were left without shown children were still visible, while they were supposed to only be shown if any child was shown

4. If an include attribute node filter was applied, hierarchy items were still selectable, but due to the filter only the items accepted based on the filter are supposed to be interacted with