### PR TITLE
COMP: Fix build error on Windows

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMeasurement.cxx
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.cxx
@@ -556,3 +556,33 @@ vtkMRMLUnitNode* vtkMRMLMeasurement::GetUnitNode(const char* quantityName)
   // that case hundreds of warnings would be thrown in a non erroneous situation.
   return unitNode;
 }
+
+//----------------------------------------------------------------------------
+vtkCodedEntry* vtkMRMLMeasurement::GetQuantityCode()
+{
+  return this->QuantityCode;
+}
+
+//----------------------------------------------------------------------------
+vtkCodedEntry* vtkMRMLMeasurement::GetDerivationCode()
+{
+  return this->DerivationCode;
+}
+
+//----------------------------------------------------------------------------
+vtkCodedEntry* vtkMRMLMeasurement::GetUnitsCode()
+{
+  return this->UnitsCode;
+}
+
+//----------------------------------------------------------------------------
+vtkCodedEntry* vtkMRMLMeasurement::GetMethodCode()
+{
+  return this->MethodCode;
+}
+
+//----------------------------------------------------------------------------
+vtkPolyData* vtkMRMLMeasurement::GetMeshValue()
+{
+  return this->MeshValue;
+}

--- a/Libs/MRML/Core/vtkMRMLMeasurement.h
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.h
@@ -155,19 +155,19 @@ public:
 
   /// Copy content of coded entry
   void SetQuantityCode(vtkCodedEntry* entry);
-  vtkGetObjectMacro(QuantityCode, vtkCodedEntry);
+  virtual vtkCodedEntry* GetQuantityCode();
 
   /// Copy content of coded entry
   void SetDerivationCode(vtkCodedEntry* entry);
-  vtkGetObjectMacro(DerivationCode, vtkCodedEntry);
+  virtual vtkCodedEntry* GetDerivationCode();
 
   /// Copy content of coded entry
   void SetUnitsCode(vtkCodedEntry* entry);
-  vtkGetObjectMacro(UnitsCode, vtkCodedEntry);
+  virtual vtkCodedEntry* GetUnitsCode();
 
   /// Copy content of coded entry
   void SetMethodCode(vtkCodedEntry* entry);
-  vtkGetObjectMacro(MethodCode, vtkCodedEntry);
+  virtual vtkCodedEntry* GetMethodCode();
 
   /// Get last computation result
   vtkGetMacro(LastComputationResult, int);
@@ -185,7 +185,7 @@ public:
   /// For example, mesh for a calculated area value is the mesh that was generated
   /// to compute the surface area.
   void SetMeshValue(vtkPolyData* meshValue);
-  vtkGetObjectMacro(MeshValue, vtkPolyData);
+  virtual vtkPolyData* GetMeshValue();
 
   /// Set input MRML node used for calculating the measurement \sa Execute
   void SetInputMRMLNode(vtkMRMLNode* node);


### PR DESCRIPTION
Errors like this occurred when compiling vtkMRMLMeasurement on Windows (using VTK8):
C:\d\Slicer\Libs\MRML\Core\vtkMRMLMeasurement.h(158,3): error C2666: 'vtkOStreamWrapper::operator <<': 5 overloads have similar conversions [C:\d\S4D\Slicer-build\Libs\MRML\Core\MRMLCore.vcxproj] [C:\d\S4D\Slicer.vcxproj]

They were due to using vtkGetObjectMacro for vtkSmartPointer objects.