### PR TITLE
ENH: Add additional saved parameters to vtkMRMLMarkupsPlaneNode

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -28,6 +28,7 @@
 #include "vtkMRMLMarkupsFiducialNode.h"
 #include "vtkMRMLMarkupsFiducialStorageNode.h"
 #include "vtkMRMLMarkupsJsonStorageNode.h"
+#include "vtkMRMLMarkupsPlaneJsonStorageNode.h"
 #include "vtkMRMLMarkupsROIDisplayNode.h"
 #include "vtkMRMLMarkupsROIJsonStorageNode.h"
 #include "vtkMRMLMarkupsLineNode.h"
@@ -106,6 +107,7 @@ vtkSlicerMarkupsLogic::vtkSlicerMarkupsLogic()
 {
   this->AutoCreateDisplayNodes = true;
   this->RegisterJsonStorageNodeForMarkupsType("ROI", "vtkMRMLMarkupsROIJsonStorageNode");
+  this->RegisterJsonStorageNodeForMarkupsType("Plane", "vtkMRMLMarkupsPlaneJsonStorageNode");
 }
 
 //----------------------------------------------------------------------------
@@ -280,6 +282,7 @@ void vtkSlicerMarkupsLogic::RegisterNodes()
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsFiducialStorageNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsJsonStorageNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsROIJsonStorageNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsPlaneJsonStorageNode>::New());
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRML/CMakeLists.txt
@@ -24,6 +24,7 @@ set(${KIT}_SRCS
   vtkMRML${MODULE_NAME}LineNode.cxx
   vtkMRML${MODULE_NAME}Node.cxx
   vtkMRML${MODULE_NAME}PlaneNode.cxx
+  vtkMRML${MODULE_NAME}PlaneJsonStorageNode.cxx
   vtkMRML${MODULE_NAME}ROINode.cxx
   vtkMRML${MODULE_NAME}ROIDisplayNode.cxx
   vtkMRML${MODULE_NAME}ROIJsonStorageNode.cxx

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -52,7 +52,7 @@
 namespace
 {
   const std::string MARKUPS_SCHEMA =
-    "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.1.json#";
+    "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.2.json#";
   const std::string ACCEPTED_MARKUPS_SCHEMA_REGEX =
     "^https://raw\\.githubusercontent\\.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1\\.[0-9]+\\.[0-9]+\\.json#";
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode.cxx
@@ -1,0 +1,246 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#include <vtkCodedEntry.h>
+#include "vtkMRMLMarkupsPlaneJsonStorageNode.h"
+#include "vtkMRMLMarkupsDisplayNode.h"
+#include "vtkMRMLMarkupsPlaneNode.h"
+
+#include "vtkMRMLMessageCollection.h"
+#include "vtkMRMLScene.h"
+#include "vtkSlicerVersionConfigure.h"
+
+#include "vtkDoubleArray.h"
+#include "vtkObjectFactory.h"
+#include "vtkStringArray.h"
+#include <vtksys/SystemTools.hxx>
+
+#include <vtkMRMLMarkupsPlaneJsonStorageNode_Private.h>
+
+//---------------------------------------------------------------------------
+// vtkInternal methods
+
+//---------------------------------------------------------------------------
+vtkMRMLMarkupsPlaneJsonStorageNode::vtkInternalPlane::vtkInternalPlane(vtkMRMLMarkupsPlaneJsonStorageNode* external)
+  : vtkMRMLMarkupsJsonStorageNode::vtkInternal(external)
+{
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLMarkupsPlaneJsonStorageNode::vtkInternalPlane::~vtkInternalPlane() = default;
+
+//----------------------------------------------------------------------------
+bool vtkMRMLMarkupsPlaneJsonStorageNode::vtkInternalPlane::WriteMarkup(
+  rapidjson::PrettyWriter<rapidjson::FileWriteStream>& writer, vtkMRMLMarkupsNode* markupsNode)
+{
+  bool success = true;
+  success = success && this->WriteBasicProperties(writer, markupsNode);
+  success = success && this->WritePlaneProperties(writer, vtkMRMLMarkupsPlaneNode::SafeDownCast(markupsNode));
+  success = success && this->WriteControlPoints(writer, markupsNode);
+  success = success && this->WriteMeasurements(writer, markupsNode);
+  if (success)
+    {
+    vtkMRMLMarkupsDisplayNode* displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(markupsNode->GetDisplayNode());
+    if (displayNode)
+      {
+      success = success && this->WriteDisplayProperties(writer, displayNode);
+      }
+    }
+  return success;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLMarkupsPlaneJsonStorageNode::vtkInternalPlane::WritePlaneProperties(
+  rapidjson::PrettyWriter<rapidjson::FileWriteStream>& writer, vtkMRMLMarkupsPlaneNode* planeNode)
+{
+  if (!planeNode)
+    {
+    return false;
+    }
+
+  writer.Key("sizeMode");
+  writer.String(planeNode->GetSizeModeAsString(planeNode->GetSizeMode()));
+
+  writer.Key("autoScalingFactor");
+  writer.Double(planeNode->GetAutoSizeScalingFactor());
+
+  int coordinateSystem = this->External->GetCoordinateSystem();
+  double center_Node[3] = { 0.0, 0.0, 0.0 };
+  planeNode->GetOrigin(center_Node);
+  if (coordinateSystem == vtkMRMLStorageNode::CoordinateSystemLPS)
+    {
+    center_Node[0] = -center_Node[0];
+    center_Node[1] = -center_Node[1];
+    }
+  writer.Key("center");
+  this->WriteVector(writer, center_Node);
+
+  double normal_Node[3] = { 0.0, 0.0, 0.0 };
+  planeNode->GetNormal(normal_Node);
+  if (coordinateSystem == vtkMRMLStorageNode::CoordinateSystemLPS)
+    {
+    normal_Node[0] = -normal_Node[0];
+    normal_Node[1] = -normal_Node[1];
+    }
+  writer.Key("normal");
+  this->WriteVector(writer, normal_Node);
+
+  double objectToBase[16] = { 0.0 };
+  vtkMatrix4x4* objectToBaseMatrix = planeNode->GetObjectToBaseMatrix();
+  for (int i = 0; i < 4; ++i)
+    {
+    objectToBase[4 * i]     = objectToBaseMatrix->GetElement(i, 0);
+    objectToBase[4 * i + 1] = objectToBaseMatrix->GetElement(i, 1);
+    objectToBase[4 * i + 2] = objectToBaseMatrix->GetElement(i, 2);
+    objectToBase[4 * i + 3] = objectToBaseMatrix->GetElement(i, 3);
+    }
+  if (coordinateSystem == vtkMRMLStorageNode::CoordinateSystemLPS)
+    {
+    for (int i = 0; i < 8; ++i)
+      {
+      objectToBase[i] = -objectToBase[i];
+      }
+    }
+  writer.Key("objectToBase");
+  this->WriteVector(writer, objectToBase, 16);
+
+  double orientation[9] = { 0.0 };
+
+  double xAxis_Node[3] = { 0.0, 0.0, 0.0 };
+  double yAxis_Node[3] = { 0.0, 0.0, 0.0 };
+  double zAxis_Node[3] = { 0.0, 0.0, 0.0 };
+  planeNode->GetAxes(xAxis_Node, yAxis_Node, zAxis_Node);
+  double origin_Node[3] = { 0.0, 0.0, 0.0 };
+  planeNode->GetOrigin(origin_Node);
+  for (int i = 0; i < 3; ++i)
+    {
+    orientation[3 * i] = xAxis_Node[i];
+    orientation[3 * i + 1] = yAxis_Node[i];
+    orientation[3 * i + 2] = zAxis_Node[i];
+    }
+  if (coordinateSystem == vtkMRMLStorageNode::CoordinateSystemLPS)
+    {
+    for (int i = 0; i < 6; ++i)
+      {
+      orientation[i] = -orientation[i];
+      }
+    }
+  writer.Key("orientation");
+  this->WriteVector(writer, orientation, 9);
+
+  double size[3] = { 0.0, 0.0, 0.0 };
+  planeNode->GetSize(size);
+  writer.Key("size");
+  this->WriteVector(writer, size);
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLMarkupsPlaneJsonStorageNode::vtkInternalPlane::UpdateMarkupsNodeFromJsonValue(vtkMRMLMarkupsNode* markupsNode, rapidjson::Value& markupsObject)
+{
+  if (!markupsNode)
+    {
+    vtkErrorWithObjectMacro(this->External, "vtkMRMLMarkupsJsonStorageNode::vtkInternalPlane::UpdateMarkupsNodeFromJsonDocument failed: invalid markupsNode");
+    return false;
+    }
+
+  MRMLNodeModifyBlocker blocker(markupsNode);
+
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(markupsNode);
+
+  bool success = true;
+  success = vtkInternal::UpdateMarkupsNodeFromJsonValue(markupsNode, markupsObject);
+
+  int coordinateSystem = this->External->GetCoordinateSystem();
+
+  double objectToBase[16] = { 0.0 };
+  if (markupsObject.HasMember("objectToBase"))
+    {
+    rapidjson::Value& objectToBaseItem= markupsObject["objectToBase"];
+    if (!this->ReadVector(objectToBaseItem, objectToBase, 16))
+      {
+      vtkErrorToMessageCollectionWithObjectMacro(this->External, this->External->GetUserMessages(),
+        "vtkMRMLMarkupsJsonStorageNode::vtkInternal::UpdateMarkupsNodeFromJsonValue",
+        "File reading failed: objectToBase 16-element numeric array.");
+      return false;
+      }
+    if (coordinateSystem == vtkMRMLStorageNode::CoordinateSystemLPS)
+      {
+      for (int i = 0; i < 8; i++)
+        {
+        objectToBase[i] = -objectToBase[i];
+        }
+      }
+    }
+  vtkNew<vtkMatrix4x4> objectToBaseMatrix;
+  for (int i = 0; i < 4; ++i)
+    {
+    objectToBaseMatrix->SetElement(i, 0, objectToBase[4*i]);
+    objectToBaseMatrix->SetElement(i, 1, objectToBase[4*i + 1]);
+    objectToBaseMatrix->SetElement(i, 2, objectToBase[4*i + 2]);
+    objectToBaseMatrix->SetElement(i, 3, objectToBase[4*i + 3]);
+    }
+  planeNode->GetObjectToBaseMatrix()->DeepCopy(objectToBaseMatrix);
+
+  if (markupsObject.HasMember("sizeMode"))
+    {
+    rapidjson::Value& sizeModeItem = markupsObject["sizeMode"];
+    std::string sizeMode = sizeModeItem.GetString();
+    planeNode->SetSizeMode(planeNode->GetSizeModeFromString(sizeMode.c_str()));
+    }
+
+  if (markupsObject.HasMember("autoScalingFactor"))
+    {
+    rapidjson::Value& autoScalingFactorItem = markupsObject["autoScalingFactor"];
+    double autoScalingFactor = autoScalingFactorItem.GetDouble();
+    planeNode->SetAutoSizeScalingFactor(autoScalingFactor);
+    }
+
+  if (markupsObject.HasMember("size"))
+    {
+    rapidjson::Value& sizeItem = markupsObject["size"];
+    double size[3] = { 0.0, 0.0, 0.0 };
+    success &= this->ReadVector(sizeItem, size);
+    planeNode->SetSize(size);
+    }
+
+  return success;
+}
+
+
+//------------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLMarkupsPlaneJsonStorageNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsPlaneJsonStorageNode::vtkMRMLMarkupsPlaneJsonStorageNode()
+{
+  this->Internal = new vtkInternalPlane(this);
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsPlaneJsonStorageNode::~vtkMRMLMarkupsPlaneJsonStorageNode() = default;
+
+//----------------------------------------------------------------------------
+bool vtkMRMLMarkupsPlaneJsonStorageNode::CanReadInReferenceNode(vtkMRMLNode *refNode)
+{
+  return refNode->IsA("vtkMRMLMarkupsPlaneNode");
+}

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode.h
@@ -1,0 +1,62 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+/// Markups Module MRML storage nodes
+///
+/// vtkMRMLMarkupsPlaneJsonStorageNode - MRML node for storing markups in JSON file
+///
+
+#ifndef __vtkMRMLMarkupsPlaneJsonStorageNode_h
+#define __vtkMRMLMarkupsPlaneJsonStorageNode_h
+
+// Markups includes
+#include "vtkSlicerMarkupsModuleMRMLExport.h"
+#include "vtkMRMLMarkupsJsonStorageNode.h"
+
+class vtkMRMLMarkupsNode;
+class vtkMRMLMarkupsDisplayNode;
+
+/// \ingroup Slicer_QtModules_Markups
+class VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsPlaneJsonStorageNode : public vtkMRMLMarkupsJsonStorageNode
+{
+public:
+  static vtkMRMLMarkupsPlaneJsonStorageNode* New();
+  vtkTypeMacro(vtkMRMLMarkupsPlaneJsonStorageNode, vtkMRMLMarkupsJsonStorageNode);
+
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  ///
+  /// Get node XML tag name (like Storage, Model)
+  const char* GetNodeTagName() override { return "MarkupsPlaneJsonStorage"; };
+
+  bool CanReadInReferenceNode(vtkMRMLNode* refNode) override;
+
+protected:
+  vtkMRMLMarkupsPlaneJsonStorageNode();
+  ~vtkMRMLMarkupsPlaneJsonStorageNode() override;
+  vtkMRMLMarkupsPlaneJsonStorageNode(const vtkMRMLMarkupsPlaneJsonStorageNode&);
+  void operator=(const vtkMRMLMarkupsPlaneJsonStorageNode&);
+
+  class vtkInternalPlane;
+  friend class vtkInternalPlane;
+};
+
+#endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode_Private.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneJsonStorageNode_Private.h
@@ -1,0 +1,31 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLMarkupsJsonStorageNode_Private.h"
+
+//---------------------------------------------------------------------------
+class vtkMRMLMarkupsPlaneJsonStorageNode::vtkInternalPlane : public vtkMRMLMarkupsJsonStorageNode::vtkInternal
+{
+public:
+  vtkInternalPlane(vtkMRMLMarkupsPlaneJsonStorageNode* external);
+  ~vtkInternalPlane();
+
+  bool WriteMarkup(rapidjson::PrettyWriter<rapidjson::FileWriteStream>& writer, vtkMRMLMarkupsNode* markupsNode) override;
+  bool UpdateMarkupsNodeFromJsonValue(vtkMRMLMarkupsNode* markupsNode, rapidjson::Value& markupObject) override;
+  bool WritePlaneProperties(rapidjson::PrettyWriter<rapidjson::FileWriteStream>& writer, vtkMRMLMarkupsPlaneNode* markupsNode);
+};

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
@@ -114,19 +114,41 @@ public:
   /// When the size mode is absolute, SetPlaneBounds can be used to specify the size of the plane.
   /// This is only used when the size mode is absolute.
   void GetPlaneBounds(double bounds[6]);
-  vtkSetVector6Macro(PlaneBounds, double);
+  double* GetPlaneBounds() VTK_SIZEHINT(6);
+  void SetPlaneBounds(double bounds[6]);
+  void SetPlaneBounds(double, double, double, double, double, double);
+  void GetSize(double size[2]);
+  double* GetSize() VTK_SIZEHINT(2);
+  vtkSetVector2Macro(Size, double);
 
   /// The normal vector for the plane.
   void GetNormal(double normal[3]);
-  void SetNormal(const double normal[3]);
+  double* GetNormal() VTK_SIZEHINT(3);
   void GetNormalWorld(double normal[3]);
+  double* GetNormalWorld() VTK_SIZEHINT(3);
+  void SetNormal(const double normal[3]);
+  void SetNormal(double x, double y, double z);
   void SetNormalWorld(const double normal[3]);
+  void SetNormalWorld(double x, double y, double z);
 
   /// The origin of the plane.
   void GetOrigin(double origin[3]);
-  void SetOrigin(const double origin[3]);
+  double* GetOrigin() VTK_SIZEHINT(3);
   void GetOriginWorld(double origin[3]);
+  double* GetOriginWorld() VTK_SIZEHINT(3);
+  void SetOrigin(const double origin[3]);
+  void SetOrigin(double x, double y, double z);
   void SetOriginWorld(const double origin[3]);
+  void SetOriginWorld(double x, double y, double z);
+
+  void GetCenter(double origin[3]) { this->GetOrigin(origin); };
+  double* GetCenter() VTK_SIZEHINT(3) { return this->GetOrigin(); };
+  void GetCenterWorld(double origin[3]) { this->GetOriginWorld(origin); };
+  double* GetCenterWorld() VTK_SIZEHINT(3) { return this->GetOriginWorld(); };
+  void SetCenter(const double origin[3]) { this->SetOrigin(origin); };
+  void SetCenter(double x, double y, double z) { this->SetOrigin(x, y, z); };
+  void SetCenterWorld(const double origin[3]) { this->SetOriginWorld(origin); };
+  void SetCenterWorld(double x, double y, double z) { this->SetOriginWorld(x, y, z); };
 
   /// The direction vectors defined by the markup points.
   /// Calculated as follows and then transformed by the offset matrix:
@@ -142,6 +164,8 @@ public:
   virtual void GetObjectToNodeMatrix(vtkMatrix4x4* planeToNodeMatrix);
   // Mapping from XYZ plane coordinates to world coordinates
   virtual void GetObjectToWorldMatrix(vtkMatrix4x4* planeToWorldMatrix);
+  // Mapping from Base plane coordinates to local coordinates
+  virtual void GetBaseToNodeMatrix(vtkMatrix4x4* matrix);
 
   /// 4x4 matrix specifying the relative (rotation/translation) of the plane from the base coordinate system defined by the markup points.
   /// Default is the identity matrix.
@@ -156,15 +180,28 @@ public:
   /// \return Signed distance from the point to the plane. Positive distance is in the direction of the plane normal
   double GetClosestPointOnPlaneWorld(const double posWorld[3], double closestPosWorld[3], bool infinitePlane = true);
 
+  /// Create default storage node or nullptr if does not have one
+  vtkMRMLStorageNode* CreateDefaultStorageNode() override;
+
 protected:
 
   /// Calculates the x y and z axis of the plane from the 3 input points.
   void CalculateAxesFromPoints(const double point0[3], const double point1[3], const double point2[3], double x[3], double y[3], double z[3]);
 
+  // Updates the plane bounds based on SizeMode and AutoSizeScalingFactor.
+  void UpdateSize();
+
   int SizeMode;
   double AutoSizeScalingFactor;
-  double PlaneBounds[6];
+  double Size[2] = { 0.0, 0.0 };
   vtkSmartPointer<vtkMatrix4x4> ObjectToBaseMatrix;
+  double PlaneBounds[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+
+  // Arrays used to return pointers from GetNormal/GetOrigin functions.
+  double Normal[3] = { 0.0, 0.0, 0.0 };
+  double NormalWorld[3] = { 0.0, 0.0, 0.0 };
+  double Origin[3] = { 0.0,0.0,0.0 };
+  double OriginWorld[3] = { 0.0,0.0,0.0 };
 
   /// Helper method for ensuring that the plane has enough points and that the points/vectors are not coincident.
   /// Used when calling SetNormal(), SetVectors() to ensure that the plane is valid before transforming to the new

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementArea.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementArea.cxx
@@ -79,9 +79,9 @@ void vtkMRMLMeasurementArea::Compute()
     }
   else if (planeNode)
     {
-    double bounds[6] = { 0.0 };
-    planeNode->GetPlaneBounds(bounds);
-    area = (bounds[1] - bounds[0]) * (bounds[3] - bounds[2]);
+    double size[2] = { 0.0 };
+    planeNode->GetSize(size);
+    area = size[0] * size[1];
     }
   else
     {

--- a/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.2.json
+++ b/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.2.json
@@ -1,0 +1,618 @@
+    {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "$id": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-v1.0.1-schema.json#",
+        "type": "object",
+        "title": "Schema for storing one or more markups",
+        "description": "Stores points, lines, curves, etc.",
+        "required": ["@schema", "markups"],
+        "additionalProperties": true,
+        "properties": {
+            "@schema": {
+                "$id": "#schema",
+                "type": "string",
+                "title": "Schema",
+                "description": "URL of versioned schema."
+            },
+            "markups": {
+                "$id": "#markups",
+                "type": "array",
+                "title": "Markups",
+                "description": "Stores position and display properties of one or more markups.",
+                "additionalItems": true,
+                "items": {
+                    "$id": "#markupItems",
+                    "anyOf": [
+                        {
+                            "$id": "#markup",
+                            "type": "object",
+                            "title": "Markup",
+                            "description": "Stores a single markup.",
+                            "default": {},
+                            "required": ["type"],
+                            "additionalProperties": true,
+                            "properties": {
+                                "type": {
+                                    "$id": "#markup/type",
+                                    "type": "string",
+                                    "title": "Basic type",
+                                    "enum": ["Fiducial", "Line", "Angle", "Curve", "ClosedCurve", "Plane", "ROI"]
+                                },
+                                "name": {
+                                    "$id": "#markup/name",
+                                    "type": "string",
+                                    "title": "Name",
+                                    "description": "Displayed name of the markup.",
+                                    "default": ""
+                                },
+                                "coordinateSystem": {
+                                    "$id": "#markup/coordinateSystem",
+                                    "type": "string",
+                                    "title": "Control point positions coordinate system name",
+                                    "description": "Coordinate system name. Medical images most commonly use LPS patient coordinate system.",
+                                    "default": "LPS",
+                                    "enum": ["LPS", "RAS"]
+                                },
+                                "coordinateUnits": {
+                                    "$id": "#markup/coordinateUnits",
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "title": "Units of control point coordinates",
+                                            "description": "Control point coordinate values are specified in this length unit. Specified in UCUM.",
+                                            "default": "mm",
+                                            "enum": ["mm", "um"]
+                                        },
+                                        {
+                                            "type": "array",
+                                            "title": "Coordinates units code",
+                                            "description": "Standard DICOM-compliant terminology item containing code, coding scheme designator, code meaning.",
+                                            "examples": [["mm", "UCUM", "millimeter"]],
+                                            "additionalItems": false,
+                                            "items": { "type": "string" },
+                                            "minItems": 3,
+                                            "maxItems": 3
+                                        }
+                                    ]
+                                },
+                                "locked": {
+                                    "$id": "#markup/locked",
+                                    "type": "boolean",
+                                    "title": "Locked",
+                                    "description": "Markup can be interacted with on the user interface.",
+                                    "default": true
+                                },
+                                "labelFormat": {
+                                    "$id": "#markup/labelFormat",
+                                    "type": "string",
+                                    "title": "Label format",
+                                    "description": "Format of generation new labels. %N refers to node name, %d refers to point index.",
+                                    "default": "%N-%d"
+                                },
+                                "roiType": {
+                                    "$id": "#markup/roiType",
+                                    "type": "string",
+                                    "title": "ROI type",
+                                    "description": "Method used to determine ROI bounds from control points. Ex. 'Box', 'BoundingBox'.",
+                                    "default": "Box"
+                                },
+                                "sizeMode": {
+                                    "$id": "#markup/sizeMode",
+                                    "type": "string",
+                                    "title": "Plane size mode",
+                                    "description": "Mode used to calculate the size of the plane representation. (Ex. Static absolute or automatically calculated plane size based on control points).",
+                                    "default": "auto"
+                                },
+                                "autoScalingSizeFactor": {
+                                    "$id": "#markup/autoScalingSizeFactor",
+                                    "type": "number",
+                                    "title": "Plane auto scaling size factor",
+                                    "description": "When the plane size mode is 'auto', the size of the plane is scaled by the auto size scaling factor.",
+                                    "default": "1.0"
+                                },
+                                "center": {
+                                    "$id": "#markup/center",
+                                    "type": "array",
+                                    "title": "Center",
+                                    "description": "The center of the markups representation. Ex. center of ROI or plane markups.",
+                                    "examples": [[0.0, 0.0, 0.0]],
+                                    "additionalItems": false,
+                                    "items": { "type": "number" },
+                                    "minItems": 3,
+                                    "maxItems": 3
+                                },
+                                "normal": {
+                                    "$id": "#markup/normal",
+                                    "type": "array",
+                                    "title": "Normal",
+                                    "description": "The normal direction of plane markups.",
+                                    "examples": [[0.0, 0.0, 1.0]],
+                                    "additionalItems": false,
+                                    "items": { "type": "number" },
+                                    "minItems": 3,
+                                    "maxItems": 3
+                                },
+                                "size": {
+                                    "$id": "#markup/size",
+                                    "type": "array",
+                                    "title": "Size",
+                                    "description": "The size of the markups representation. Ex. size of the ROI or plane markups.",
+                                    "examples": [[5.0, 5.0, 4.0], [5.0, 5.0, 0.0]],
+                                    "additionalItems": false,
+                                    "items": { "type": "number" },
+                                    "minItems": 3,
+                                    "maxItems": 3
+                                },
+                                "objectToBase": {
+                                    "$id": "#markup/objectToBase",
+                                    "type": "array",
+                                    "title": "Object to Base matrix",
+                                    "description": "4x4 transform matrix from the object representation to the coordinate system defined by the control points.",
+                                    "examples": [[-0.9744254538021788, -0.15660098593235834, -0.16115572030626558, 26.459385388492746,
+                                                  -0.08525118065879463, -0.4059244688892957, 0.9099217338613386, -48.04154530201596,
+                                                  -0.20791169081775938, 0.9003896138683279, 0.3821927158637956, -53.35829266424462,
+                                                  0.0, 0.0, 0.0, 1.0]],
+                                    "additionalItems": false,
+                                    "items": { "type": "number" },
+                                    "minItems": 16,
+                                    "maxItems": 16
+                                },
+                                "orientation": {
+                                    "$id": "#markup/orientation",
+                                    "type": "array",
+                                    "title": "Markups orientation",
+                                    "description": "3x3 orientation matrix of the markups representation. Ex. [orientation[0], orientation[3], orientation[6]] is the x vector of the object coordinate system in the node coordinate system.",
+                                    "examples": [[-0.6157905804369491, -0.3641498920623639, 0.6987108251316091,
+                                                  -0.7414677108739087, -0.03213048377225371, -0.6702188193000602,
+                                                  0.2665100275346712, -0.9307859518297049, -0.2502197376306259]],
+                                    "additionalItems": false,
+                                    "items": { "type": "number" },
+                                    "minItems": 9,
+                                    "maxItems": 9
+                                },
+                                "controlPoints": {
+                                    "$id": "#markup/controlPoints",
+                                    "type": "array",
+                                    "title": "Control points",
+                                    "description": "Stores all control points of this markup.",
+                                    "default": [],
+                                    "additionalItems": true,
+                                    "items": {
+                                        "$id": "#markup/controlPointItems",
+                                        "anyOf": [
+                                            {
+                                                "$id": "#markup/controlPoint",
+                                                "type": "object",
+                                                "title": "The first anyOf schema",
+                                                "description": "An explanation about the purpose of this instance.",
+                                                "default": {},
+                                                "required": [],
+                                                "additionalProperties": true,
+                                                "properties": {
+                                                    "id": {
+                                                        "$id": "#markup/controlPoint/id",
+                                                        "type": "string",
+                                                        "title": "Control point ID",
+                                                        "description": "Identifier of the control point within this markup",
+                                                        "default": "",
+                                                        "examples": ["2", "5"]
+                                                    },
+                                                    "label": {
+                                                        "$id": "#markup/controlPoint/label",
+                                                        "type": "string",
+                                                        "title": "Control point label",
+                                                        "description": "Label displayed next to the control point.",
+                                                        "default": "",
+                                                        "examples": ["F_1"]
+                                                    },
+                                                    "description": {
+                                                        "$id": "#markup/controlPoint/description",
+                                                        "type": "string",
+                                                        "title": "Control point description",
+                                                        "description": "Details about the control point.",
+                                                        "default": ""
+                                                    },
+                                                    "associatedNodeID": {
+                                                        "$id": "#markup/controlPoint/associatedNodeID",
+                                                        "type": "string",
+                                                        "title": "Associated node ID",
+                                                        "description": "ID of the node where this markups is defined on.",
+                                                        "default": "",
+                                                        "examples": ["vtkMRMLModelNode1"]
+                                                    },
+                                                    "position": {
+                                                        "$id": "#markup/controlPoint/position",
+                                                        "type": "array",
+                                                        "title": "Control point position",
+                                                        "description": "Tuple of 3 defined in the specified coordinate system.",
+                                                        "examples": [[-9.9, 1.1, 12.3]],
+                                                        "additionalItems": false,
+                                                        "items": { "type": "number" },
+                                                        "minItems": 3,
+                                                        "maxItems": 3
+                                                    },
+                                                    "orientation": {
+                                                        "$id": "#markup/controlPoint/orientation",
+                                                        "type": "array",
+                                                        "title": "Control point orientation",
+                                                        "description": "3x3 orientation matrix",
+                                                        "examples": [[1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 ]],
+                                                        "additionalItems": false,
+                                                        "items": {"type": "number"},
+                                                        "minItems": 9,
+                                                        "maxItems": 9
+                                                    },
+                                                    "selected": {
+                                                        "$id": "#markup/controlPoint/selected",
+                                                        "type": "boolean",
+                                                        "title": "Control point is selected",
+                                                        "description": "Specifies if the control point is selected or unselected.",
+                                                        "default": true
+                                                    },
+                                                    "locked": {
+                                                        "$id": "#markup/controlPoint/locked",
+                                                        "type": "boolean",
+                                                        "title": "Control point locked",
+                                                        "description": "Control point cannot be moved on the user interface.",
+                                                        "default": false
+                                                    },
+                                                    "visibility": {
+                                                        "$id": "#markup/controlPoint/visibility",
+                                                        "type": "boolean",
+                                                        "title": "The visibility schema",
+                                                        "description": "An explanation about the purpose of this instance.",
+                                                        "default": true
+                                                    },
+                                                    "positionStatus": {
+                                                        "$id": "#markup/controlPoint/positionStatus",
+                                                        "type": "string",
+                                                        "title": "The positionStatus schema",
+                                                        "description": "An explanation about the purpose of this instance.",
+                                                        "enum": ["undefined", "preview", "defined"],
+                                                        "default": "defined"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "display": {
+                                    "$id": "#display",
+                                    "type": "object",
+                                    "title": "The display schema",
+                                    "description": "An explanation about the purpose of this instance.",
+                                    "default": {},
+                                    "required": [],
+                                    "additionalProperties": true,
+                                    "properties": {
+                                        "visibility": {
+                                            "$id": "#display/visibility",
+                                            "type": "boolean",
+                                            "title": "Markup visibility",
+                                            "description": "Visibility of the entire markup.",
+                                            "default": true
+                                        },
+                                        "opacity": {
+                                            "$id": "#display/opacity",
+                                            "type": "number",
+                                            "title": "Markup opacity",
+                                            "description": "Overall opacity of the markup.",
+                                            "minimum": 0.0,
+                                            "maximum": 1.0,
+                                            "default": 1.0
+                                        },
+                                        "color": {
+                                            "$id": "#display/color",
+                                            "type": "array",
+                                            "title": "Markup color",
+                                            "description": "Overall RGB color of the markup.",
+                                            "default": [0.4, 1.0, 1.0],
+                                            "additionalItems": false,
+                                            "items": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                                            "minItems": 3,
+                                            "maxItems": 3
+                                        },
+                                        "selectedColor": {
+                                            "$id": "#display/selectedColor",
+                                            "title": "Markup selected color",
+                                            "description": "Overall RGB color of selected points in the markup.",
+                                            "default": [1.0, 0.5, 0.5],
+                                            "additionalItems": false,
+                                            "items": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                                            "minItems": 3,
+                                            "maxItems": 3
+                                        },
+                                        "activeColor": {
+                                            "$id": "#display/activeColor",
+                                            "title": "Markup active color",
+                                            "description": "Overall RGB color of active points in the markup.",
+                                            "default": [0.4, 1.0, 0.0],
+                                            "additionalItems": false,
+                                            "items": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                                            "minItems": 3,
+                                            "maxItems": 3
+                                        },
+                                        "propertiesLabelVisibility": {
+                                            "$id": "#display/propertiesLabelVisibility",
+                                            "type": "boolean",
+                                            "title": "Properties label visibility",
+                                            "description": "Visibility of the label that shows basic properties.",
+                                            "default": false
+                                        },
+                                        "pointLabelsVisibility": {
+                                            "$id": "#display/pointLabelsVisibility",
+                                            "type": "boolean",
+                                            "title": "Point labels visibility",
+                                            "description": "Visibility of control point labels.",
+                                            "default": false
+                                        },
+                                        "textScale": {
+                                            "$id": "#display/textScale",
+                                            "type": "number",
+                                            "title": "Markup overall text scale",
+                                            "description": "Size of displayed text as percentage of window size.",
+                                            "default": 3.0,
+                                            "minimum": 0.0
+                                        },
+                                        "glyphType": {
+                                            "$id": "#display/glyphType",
+                                            "type": "string",
+                                            "title": "The glyphType schema",
+                                            "description": "An explanation about the purpose of this instance.",
+                                            "default": "Sphere3D",
+                                            "enum": ["Vertex2D", "Dash2D", "Cross2D", "ThickCross2D", "Triangle2D", "Square2D",
+                                                "Circle2D", "Diamond2D", "Arrow2D", "ThickArrow2D", "HookedArrow2D", "StarBurst2D",
+                                                "Sphere3D", "Diamond3D"]
+                                        },
+                                        "glyphScale": {
+                                            "$id": "#display/glyphScale",
+                                            "type": "number",
+                                            "title": "Point glyph scale",
+                                            "description": "Glyph size as percentage of window size.",
+                                            "default": 1.0,
+                                            "minimum": 0.0
+                                        },
+                                        "glyphSize": {
+                                            "$id": "#display/glyphSize",
+                                            "type": "number",
+                                            "title": "Point glyph size",
+                                            "description": "Absolute glyph size.",
+                                            "default": 5.0,
+                                            "minimum": 0.0
+                                        },
+                                        "useGlyphScale": {
+                                            "$id": "#display/useGlyphScale",
+                                            "type": "boolean",
+                                            "title": "Use glyph scale",
+                                            "description": "Use relative glyph scale.",
+                                            "default": true
+                                        },
+                                        "sliceProjection": {
+                                            "$id": "#display/sliceProjection",
+                                            "type": "boolean",
+                                            "title": "Slice projection",
+                                            "description": "Enable project markups to slice views.",
+                                            "default": false
+                                        },
+                                        "sliceProjectionUseFiducialColor": {
+                                            "$id": "#display/sliceProjectionUseFiducialColor",
+                                            "type": "boolean",
+                                            "title": "Use fiducial color for slice projection",
+                                            "description": "Choose between projetion color or fiducial color for projections.",
+                                            "default": true
+                                        },
+                                        "sliceProjectionOutlinedBehindSlicePlane": {
+                                            "$id": "#display/sliceProjectionOutlinedBehindSlicePlane",
+                                            "type": "boolean",
+                                            "title": "Display slice projection as outline",
+                                            "description": "Display slice projection as outline if behind slice plane.",
+                                            "default": false
+                                        },
+                                        "sliceProjectionColor": {
+                                            "$id": "#display/sliceProjectionColor",
+                                            "type": "array",
+                                            "title": "Slice projection color",
+                                            "description": "Overall RGB color for displaying projection.",
+                                            "default": [1.0, 1.0, 1.0],
+                                            "additionalItems": false,
+                                            "items": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+                                            "minItems": 3,
+                                            "maxItems": 3
+                                        },
+                                        "sliceProjectionOpacity": {
+                                            "$id": "#display/sliceProjectionOpacity",
+                                            "type": "number",
+                                            "title": "Slice projection opacity",
+                                            "description": "Overall opacity of markup slice projection.",
+                                            "minimum": 0.0,
+                                            "maximum": 1.0,
+                                            "default": 0.6
+                                        },
+                                        "lineThickness": {
+                                            "$id": "#display/lineThickness",
+                                            "type": "number",
+                                            "title": "Line thickness",
+                                            "description": "Line thickness relative to markup size.",
+                                            "default": 0.2,
+                                            "minimum": 0.0
+                                        },
+                                        "lineColorFadingStart": {
+                                            "$id": "#display/lineColorFadingStart",
+                                            "type": "number",
+                                            "title": "Line color fading start",
+                                            "description": "Distance where line starts to fade out.",
+                                            "default": 1.0,
+                                            "minimum": 0.0
+                                        },
+                                        "lineColorFadingEnd": {
+                                            "$id": "#display/lineColorFadingEnd",
+                                            "type": "number",
+                                            "title": "Line color fading end",
+                                            "description": "Distance where line fades out completely.",
+                                            "default": 10.0,
+                                            "minimum": 0.0
+                                        },
+                                        "lineColorFadingSaturation": {
+                                            "$id": "#display/lineColorFadingSaturation",
+                                            "type": "number",
+                                            "title": "Color fading saturation",
+                                            "description": "Amount of color saturation change as the line fades out.",
+                                            "default": 1.0
+                                        },
+                                        "lineColorFadingHueOffset": {
+                                            "$id": "#display/lineColorFadingHueOffset",
+                                            "type": "number",
+                                            "title": "Color fadue hue offset",
+                                            "description": "Change in color hue as the line fades out.",
+                                            "default": 0.0
+                                        },
+                                        "handlesInteractive": {
+                                            "$id": "#display/handlesInteractive",
+                                            "type": "boolean",
+                                            "title": "Handles interactive",
+                                            "description": "Show interactive handles to transform this markup.",
+                                            "default": false
+                                        },
+                                        "snapMode": {
+                                            "$id": "#display/snapMode",
+                                            "type": "string",
+                                            "title": "Snap mode",
+                                            "description": "How control points can be defined and moved.",
+                                            "default": "toVisibleSurface",
+                                            "enum": ["unconstrained", "toVisibleSurface"]
+                                        }
+                                    }
+                                },
+                                "measurements": {
+                                    "$id": "#markup/measurements",
+                                    "type": "array",
+                                    "title": "Measurements",
+                                    "description": "Stores all measurements for this markup.",
+                                    "default": [],
+                                    "additionalItems": true,
+                                    "items": {
+                                        "$id": "#markup/measurementItems",
+                                        "anyOf": [
+                                            {
+                                                "$id": "#markup/measurement",
+                                                "type": "object",
+                                                "title": "Measurement",
+                                                "description": "Store a single measurement.",
+                                                "default": {},
+                                                "required": [],
+                                                "additionalProperties": true,
+                                                "properties": {
+                                                    "name": {
+                                                        "$id": "#markup/measurement/name",
+                                                        "type": "string",
+                                                        "title": "Measurement name",
+                                                        "description": "Printable name of the measurement",
+                                                        "default": "",
+                                                        "examples": ["length", "area"]
+                                                    },
+                                                    "enabled": {
+                                                        "$id": "#markup/measurement/enabled",
+                                                        "type": "boolean",
+                                                        "title": "Computation of the measurement is enabled",
+                                                        "description": "This can be used to define measurements but prevent automatic updates.",
+                                                        "default": true
+                                                    },
+                                                    "value": {
+                                                        "$id": "#display/measurement/value",
+                                                        "type": "number",
+                                                        "title": "Measurement value",
+                                                        "description": "Numberic value of the measurement."
+                                                    },
+                                                    "units": {
+                                                        "$id": "#markup/measurement/units",
+                                                        "anyOf": [
+                                                            {
+                                                                "type": "string",
+                                                                "title": "Measurement unit",
+                                                                "description": "Printable measurement unit. Use of UCUM is preferred.",
+                                                                "default": "",
+                                                                "examples": ["mm", "mm2"]
+                                                            },
+                                                            {
+                                                                "type": "array",
+                                                                "title": "Measurement units code",
+                                                                "description": "Standard DICOM-compliant terminology item containing code, coding scheme designator, code meaning.",
+                                                                "examples": [["cm3", "UCUM", "cubic centimeter"]],
+                                                                "additionalItems": false,
+                                                                "items": { "type": "string" },
+                                                                "minItems": 3,
+                                                                "maxItems": 3
+                                                            }
+                                                        ]
+                                                    },
+                                                    "description": {
+                                                        "$id": "#markup/measurement/description",
+                                                        "type": "string",
+                                                        "title": "Measurement description",
+                                                        "description": "Explanation of the measurement.",
+                                                        "default": ""
+                                                    },
+                                                    "printFormat": {
+                                                        "$id": "#markup/measurement/printFormat",
+                                                        "type": "string",
+                                                        "title": "Print format",
+                                                        "description": "Format string (printf-style) to create user-displayable string from value and units.",
+                                                        "default": "",
+                                                        "examples": ["%5.3f %s"]
+                                                    },
+                                                    "quantityCode": {
+                                                        "$id": "#markup/measurement/quantityCode",
+                                                        "type": "array",
+                                                        "title": "Measurement quantity code",
+                                                        "description": "Standard DICOM-compliant terminology item containing code, coding scheme designator, code meaning.",
+                                                        "default": [],
+                                                        "examples": [["118565006", "SCT", "Volume"]],
+                                                        "additionalItems": false,
+                                                        "items": { "type": "string" },
+                                                        "minItems": 3,
+                                                        "maxItems": 3
+                                                    },
+                                                    "derivationCode": {
+                                                        "$id": "#markup/measurement/derivationCode",
+                                                        "type": "array",
+                                                        "title": "Measurement derivation code",
+                                                        "description": "Standard DICOM-compliant terminology item containing code, coding scheme designator, code meaning.",
+                                                        "default": [],
+                                                        "examples": [["255605001", "SCT", "Minimum"]],
+                                                        "additionalItems": false,
+                                                        "items": { "type": "string" },
+                                                        "minItems": 3,
+                                                        "maxItems": 3
+                                                    },
+                                                    "methodCode": {
+                                                        "$id": "#markup/measurement/methodCode",
+                                                        "type": "array",
+                                                        "title": "Measurement method code",
+                                                        "description": "Standard DICOM-compliant terminology item containing code, coding scheme designator, code meaning.",
+                                                        "default": [],
+                                                        "examples": [["126030", "DCM", "Sum of segmented voxel volumes"]],
+                                                        "additionalItems": false,
+                                                        "items": { "type": "string" },
+                                                        "minItems": 3,
+                                                        "maxItems": 3
+                                                    },
+                                                    "controlPointValues": {
+                                                        "$id": "#markup/controlPoint/controlPointValues",
+                                                        "type": "array",
+                                                        "title": "Measurement values for each control point.",
+                                                        "description": "This stores measurement result if it has value for each control point.",
+                                                        "examples": [[-9.9, 1.1, 12.3, 4.3, 4.8]],
+                                                        "additionalItems": false,
+                                                        "items": { "type": "number" }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
@@ -535,11 +535,11 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
 {
   vtkMRMLMarkupsPlaneNode* markupsNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
   if (!markupsNode || markupsNode->GetNumberOfControlPoints() != 3)
-  {
+    {
     this->PlaneFillMapper->SetInputData(vtkNew<vtkPolyData>());
     this->ArrowMapper->SetInputData(vtkNew<vtkPolyData>());
     return;
-  }
+    }
 
   double xAxis_World[3] = { 0.0 };
   double yAxis_World[3] = { 0.0 };
@@ -550,11 +550,11 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
   if (vtkMath::Norm(xAxis_World) <= epsilon ||
       vtkMath::Norm(yAxis_World) <= epsilon ||
       vtkMath::Norm(zAxis_World) <= epsilon)
-  {
+    {
     this->PlaneFillMapper->SetInputData(vtkNew<vtkPolyData>());
     this->ArrowMapper->SetInputData(vtkNew<vtkPolyData>());
     return;
-  }
+    }
 
   this->PlaneFillMapper->SetInputConnection(this->PlaneWorldToSliceTransformer->GetOutputPort());
   this->ArrowMapper->SetInputConnection(this->ArrowGlypher->GetOutputPort());
@@ -563,8 +563,10 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
   markupsNode->GetOriginWorld(origin_World);
 
   // Update the plane
-  double bounds_Plane[6] = { 0.0 };
-  markupsNode->GetPlaneBounds(bounds_Plane);
+  double size_Object[2] = { 0.0 };
+  markupsNode->GetSize(size_Object);
+
+  double bounds_Object[4] = { -0.5 * size_Object[0], 0.5 * size_Object[0] , -0.5 * size_Object[1] , 0.5 * size_Object[1] };
 
   double planePoint1_World[3] = { 0.0 };
   double planePoint2_World[3] = { 0.0 };
@@ -572,16 +574,16 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
   for (int i = 0; i < 3; ++i)
     {
     planePoint1_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Plane[0])
-      + (yAxis_World[i] * bounds_Plane[2]); // Bottom left corner (Plane filter origin)
+      + (xAxis_World[i] * bounds_Object[0])
+      + (yAxis_World[i] * bounds_Object[2]); // Bottom left corner (Plane filter origin)
 
     planePoint2_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Plane[0])
-      + (yAxis_World[i] * bounds_Plane[3]); // Top left corner
+      + (xAxis_World[i] * bounds_Object[0])
+      + (yAxis_World[i] * bounds_Object[3]); // Top left corner
 
     planePoint3_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Plane[1])
-      + (yAxis_World[i] * bounds_Plane[2]); // Bottom right corner
+      + (xAxis_World[i] * bounds_Object[1])
+      + (yAxis_World[i] * bounds_Object[2]); // Bottom right corner
     }
   this->PlaneFilter->SetOrigin(planePoint1_World);
   this->PlaneFilter->SetPoint1(planePoint2_World);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.cxx
@@ -152,8 +152,8 @@ bool vtkSlicerPlaneRepresentation3D::GetTransformationReferencePoint(double refe
 //----------------------------------------------------------------------
 void vtkSlicerPlaneRepresentation3D::BuildPlane()
 {
-  vtkMRMLMarkupsPlaneNode* markupsNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
-  if (!markupsNode || markupsNode->GetNumberOfControlPoints() != 3)
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (!planeNode || planeNode->GetNumberOfControlPoints() != 3)
     {
     this->PlaneActor->SetVisibility(false);
     this->PlaneOccludedActor->SetVisibility(false);
@@ -163,7 +163,7 @@ void vtkSlicerPlaneRepresentation3D::BuildPlane()
   double xAxis_World[3] = { 0.0 };
   double yAxis_World[3] = { 0.0 };
   double zAxis_World[3] = { 0.0 };
-  markupsNode->GetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+  planeNode->GetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
 
   double epsilon = 1e-5;
   if (vtkMath::Norm(xAxis_World) <= epsilon ||
@@ -178,7 +178,7 @@ void vtkSlicerPlaneRepresentation3D::BuildPlane()
   vtkNew<vtkPoints> arrowPoints_World;
 
   double origin_World[3] = { 0.0 };
-  markupsNode->GetOriginWorld(origin_World);
+  planeNode->GetOriginWorld(origin_World);
   arrowPoints_World->InsertNextPoint(origin_World);
 
   vtkNew<vtkDoubleArray> arrowDirectionArray_World;
@@ -193,8 +193,10 @@ void vtkSlicerPlaneRepresentation3D::BuildPlane()
   this->ArrowGlypher->SetInputData(arrowPositionPolyData_World);
 
   // Update the plane
-  double bounds_Plane[6] = { 0.0 };
-  markupsNode->GetPlaneBounds(bounds_Plane);
+  double size_Object[2] = { 0.0 };
+  planeNode->GetSize(size_Object);
+
+  double bounds_Object[4] = { -0.5 * size_Object[0], 0.5 * size_Object[0] , -0.5 * size_Object[1] , 0.5 * size_Object[1] };
 
   double planePoint1_World[3] = { 0.0 };
   double planePoint2_World[3] = { 0.0 };
@@ -204,20 +206,20 @@ void vtkSlicerPlaneRepresentation3D::BuildPlane()
   for (int i = 0; i < 3; ++i)
     {
     planePoint1_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Plane[0])
-      + (yAxis_World[i] * bounds_Plane[2]); // Bottom left corner (Plane filter origin)
+      + (xAxis_World[i] * bounds_Object[0])
+      + (yAxis_World[i] * bounds_Object[2]); // Bottom left corner (Plane filter origin)
 
     planePoint2_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Plane[0])
-      + (yAxis_World[i] * bounds_Plane[3]); // Top left corner
+      + (xAxis_World[i] * bounds_Object[0])
+      + (yAxis_World[i] * bounds_Object[3]); // Top left corner
 
     planePoint3_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Plane[1])
-      + (yAxis_World[i] * bounds_Plane[3]); // Top right corner
+      + (xAxis_World[i] * bounds_Object[1])
+      + (yAxis_World[i] * bounds_Object[3]); // Top right corner
 
     planePoint4_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Plane[1])
-      + (yAxis_World[i] * bounds_Plane[2]); // Bottom right corner
+      + (xAxis_World[i] * bounds_Object[1])
+      + (yAxis_World[i] * bounds_Object[2]); // Bottom right corner
 
     planePoint5_World[i] = (planePoint1_World[i] + planePoint4_World[i]) / 2.0; // Between bottom left and bottom right
     }


### PR DESCRIPTION
Adds missing attributes to markups plane node XML Read/Write/Copy/Print, as well as the new vtkMRMLMarkupsPlaneJsonStorageNode class that can save additional plane data in the json file.

PlaneBounds (renamed to Size), and AutoSizeScalingFactor attributes in vtkMRMLMarkupsPlaneNode were not included in WriteXML/ReadXMLAttributes/CopyContent/PrintSelf functions. This commit adds the relevant attributes to the functions.