### PR TITLE
COMP: correct CMake parameters (generator name, code folder)

### DIFF
--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -41,7 +41,7 @@ Release mode:
 ```
 mkdir C:\D\S4R
 cd /d C:\D\S4R
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019 Win64" -DQt5_DIR:PATH=C:\Qt\5.15.0\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4\Slicer
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Release
 ```
 
@@ -50,7 +50,7 @@ Debug mode:
 ```
 mkdir C:\D\S4D
 cd /d C:\D\S4D
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019 Win64" -DQt5_DIR:PATH=C:\Qt\5.15.0\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4\Slicer
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Debug
 ```
 

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -41,7 +41,7 @@ Release mode:
 ```
 mkdir C:\D\S4R
 cd /d C:\D\S4R
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4\Slicer
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Release
 ```
 

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -50,7 +50,7 @@ Debug mode:
 ```
 mkdir C:\D\S4D
 cd /d C:\D\S4D
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4\Slicer
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Debug
 ```
 


### PR DESCRIPTION
Just like it was asked [here](https://discourse.slicer.org/t/building-slicer-from-source/17823/2). 
I made a pull request to set up the lines I used to build Slicer and correct the old cmake line that appears on the developer build tutorial for Windows.

I didn't test all the modules after executing the compiled Slicer, just that the sliceViews and the 3D view worked. I did't build debug version, only release



