### PR TITLE
COMP: use ITK to build ANTs

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -147,6 +147,8 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DModule_IOScanco:BOOL=ON
       -DModule_MorphologicalContourInterpolation:BOOL=ON
       -DModule_SimpleITKFilters:BOOL=${Slicer_USE_SimpleITK}
+      -DModule_GenericLabelInterpolator:BOOL=ON
+      -DModule_AdaptiveDenoising:BOOL=ON
       -DBUILD_SHARED_LIBS:BOOL=ON
       -DITK_INSTALL_NO_DEVELOPMENT:BOOL=ON
       -DKWSYS_USE_MD5:BOOL=ON # Required by SlicerExecutionModel


### PR DESCRIPTION
Hi, I'm working on a [ANTs extension](https://github.com/simonoxen/SlicerANTs) and adding these modules to ITK build allows me to build ANTs against Slicer's ITK. They are used in [ANTs ITK Super Build](https://github.com/ANTsX/ANTs/blob/master/SuperBuild/External_ITKv5.cmake).

Would it be possible to include?