### PR TITLE
BUG: Fix markups curve constrain if parent transform node is changed

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -1233,7 +1233,8 @@ void vtkMRMLMarkupsCurveNode::ProcessMRMLEvents(vtkObject* caller,
 //---------------------------------------------------------------------------
 void vtkMRMLMarkupsCurveNode::OnNodeReferenceAdded(vtkMRMLNodeReference* reference)
 {
-  if (strcmp(reference->GetReferenceRole(), this->GetShortestDistanceSurfaceNodeReferenceRole()) == 0)
+  if (strcmp(reference->GetReferenceRole(), this->GetShortestDistanceSurfaceNodeReferenceRole()) == 0 ||
+      strcmp(reference->GetReferenceRole(), this->TransformNodeReferenceRole) == 0)
     {
     this->OnSurfaceModelTransformChanged();
     this->OnSurfaceModelNodeChanged();
@@ -1245,7 +1246,8 @@ void vtkMRMLMarkupsCurveNode::OnNodeReferenceAdded(vtkMRMLNodeReference* referen
 //---------------------------------------------------------------------------
 void vtkMRMLMarkupsCurveNode::OnNodeReferenceModified(vtkMRMLNodeReference* reference)
 {
-  if (strcmp(reference->GetReferenceRole(), this->GetShortestDistanceSurfaceNodeReferenceRole()) == 0)
+  if (strcmp(reference->GetReferenceRole(), this->GetShortestDistanceSurfaceNodeReferenceRole()) == 0 ||
+      strcmp(reference->GetReferenceRole(), this->TransformNodeReferenceRole) == 0)
     {
     this->OnSurfaceModelTransformChanged();
     this->OnSurfaceModelNodeChanged();
@@ -1257,8 +1259,10 @@ void vtkMRMLMarkupsCurveNode::OnNodeReferenceModified(vtkMRMLNodeReference* refe
 //---------------------------------------------------------------------------
 void vtkMRMLMarkupsCurveNode::OnNodeReferenceRemoved(vtkMRMLNodeReference* reference)
 {
-  if (strcmp(reference->GetReferenceRole(), this->GetShortestDistanceSurfaceNodeReferenceRole()) == 0)
+  if (strcmp(reference->GetReferenceRole(), this->GetShortestDistanceSurfaceNodeReferenceRole()) == 0 ||
+      strcmp(reference->GetReferenceRole(), this->TransformNodeReferenceRole) == 0)
     {
+    this->OnSurfaceModelTransformChanged();
     this->OnSurfaceModelNodeChanged();
     }
   Superclass::OnNodeReferenceRemoved(reference);


### PR DESCRIPTION
When the parent transform node reference for the curve node was changed, the transform from the surface model to the curve was not updated. Fixed by updating the transform when the parent transform node reference is changed.

Re #5661