### PR TITLE
ENH: Allow multiple extensions to be excluded from line length check

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -195,7 +195,7 @@ while read src_mode dst_mode src_obj dst_obj status file; do
   if test "$dst_mode" != "160000" -a "$dst_mode" != '000000'; then
     check_size
     #Exclude some files from line lengths check
-    check_line_lengths_extension_to_exclude="^(crt|ui|xml|xml\\.in|mrml|html|json|ts|md|rst)$"
+    check_line_lengths_extension_to_exclude="^.*(crt|ui|xml|xml\\.in|mrml|html|json|ts|md|rst)$"
     if [[ ! ${file#*.} =~ $check_line_lengths_extension_to_exclude ]]; then
       check_line_lengths
     fi


### PR DESCRIPTION
Expands the regex so that files with multiple extensions can still match the regex if the tail of the string contains an excluded extension, instead of requiring a complete match.