### PR TITLE
ENH: Improve directory and file selection by using native dialogs

### DIFF
--- a/Base/QTGUI/Resources/UI/qSlicerSaveDataDialog.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSaveDataDialog.ui
@@ -53,9 +53,6 @@
      <property name="text">
       <string>Change directory for selected files</string>
      </property>
-     <property name="options">
-      <set>ctkDirectoryButton::DontUseNativeDialog</set>
-     </property>
     </widget>
    </item>
    <item row="0" column="6">

--- a/Base/QTGUI/qSlicerFileDialog.cxx
+++ b/Base/QTGUI/qSlicerFileDialog.cxx
@@ -187,10 +187,6 @@ ctkFileDialog* qSlicerStandardFileDialog::createFileDialog(
   qSlicerIOManager* ioManager = qSlicerApplication::application()->ioManager();
   ctkFileDialog* fileDialog = new ctkFileDialog();
 
-  // We don't want the odd dialog in Mac: it shows in gray filenames that
-  // don't match the filter -> we don't want to show files that don't match
-  // the filter.
-  fileDialog->setOption(QFileDialog::DontUseNativeDialog);
   if(ioProperties["fileType"].toBool())
     {
     fileDialog->setNameFilters(

--- a/Modules/Scripted/LabelStatistics/LabelStatistics.py
+++ b/Modules/Scripted/LabelStatistics/LabelStatistics.py
@@ -208,7 +208,6 @@ class LabelStatisticsWidget(ScriptedLoadableModuleWidget):
     """
     if not self.fileDialog:
       self.fileDialog = qt.QFileDialog(self.parent)
-      self.fileDialog.options = self.fileDialog.DontUseNativeDialog
       self.fileDialog.acceptMode = self.fileDialog.AcceptSave
       self.fileDialog.defaultSuffix = "csv"
       self.fileDialog.setNameFilter("Comma Separated Values (*.csv)")

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "01ab373d01e6e8718af42f856278b61bb18fbcfe"
+    "9f12861724155f9929de9be8500c9eabd38507ac"
     QUIET
     )
 


### PR DESCRIPTION
This aims to improve directory selection by using the native dialog instead of Qt's own widget-based dialog design.

See 3D Slicer forum discussion of how users have been doing other methods to avoid using widgets that use Qt's widget-based dialog.
https://discourse.slicer.org/t/using-native-file-dialog-for-selecting-files-and-folders/17926

| Qt widget-based dialog | Native dialog (on Windows)|
|-------------------------|--------------------------------|
|![image](https://user-images.githubusercontent.com/15837524/120825251-3051dd80-c527-11eb-83a4-1a0c2c03971c.png)|![image](https://user-images.githubusercontent.com/15837524/120825677-9e96a000-c527-11eb-8200-2c2a4cecc8ae.png)|

This PR currently contains changes to update the main Slicer Load dialog to choose directories and files using a native dialog. I have not made any changes to the ctkDICOMBrowser dialog tied to import buttons used in the DICOM module as it had some custom widgets into the widget-based dialog which wouldn't be possible when using a native dialog. @lassoan Do you have ideas about what you might want to do here? Would be willing to contribute changes as I don't use DICOM functionality at all so I'm not familiar with the usage in Slicer.

Some limitations of using a native dialog is that you can use Qt functionality such as QTimers and such to manipulate it. It is a modal dialog when opened. However navigation of directories and files is much easier using a native dialog and the current Qt widget based dialog often slows down this navigation process leading others to use drag-and-drop from a native dialog to avoid it entirely.

Will require https://github.com/commontk/CTK/pull/973 and if merged, the upstream and new git tag would be updated here in this PR.