### PR TITLE
ENH: Add create/remove representation options to segmentations subject hierarchy menu

### DIFF
--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.h
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.h
@@ -160,10 +160,19 @@ protected slots:
   /// Toggle 2D outline visibility for the current segmentation
   void toggle2DOutlineVisibility(bool);
 
+  void createBinaryLabelmapRepresentation();
+  void createClosedSurfaceRepresentation();
+  void removeBinaryLabelmapRepresentation();
+  void removeClosedSurfaceRepresentation();
+
 protected:
   QScopedPointer<qSlicerSubjectHierarchySegmentationsPluginPrivate> d_ptr;
 
   void updateAllSegmentsFromMRML(vtkMRMLSegmentationNode* segmentationNode);
+
+  /// Create or remove representation.
+  /// If create is true then representation is created, if false then the representation is removed.
+  void updateRepresentation(const QString& representationName, bool create);
 
 private:
   Q_DECLARE_PRIVATE(qSlicerSubjectHierarchySegmentationsPlugin);


### PR DESCRIPTION
It is quite frequently needed and not easy for users to find how to create closed surface representation for a segmentation node.

This commit adds "create" and "remove" actions for "closed surface" and "binary labelmap" representations.
Only the non-master representation is offered to be created or deleted, therefore typically only one action appears in the menu.
For example, if binary labelmap is the master representation then either "Create closed surface representation"
or "Remove closed surface representation" action is shown.