### PR TITLE
Improving qMRMLVolumeWidget range bounds functionality

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -53,8 +53,6 @@ vtkMRMLScalarVolumeDisplayNode::vtkMRMLScalarVolumeDisplayNode()
   this->AutoWindowLevel = 1;
   this->AutoThreshold = 0;
   this->ApplyThreshold = 0;
-  //this->LowerThreshold = VTK_SHORT_MIN;
-  //this->UpperThreshold = VTK_SHORT_MAX;
 
   // try setting a default grayscale color map
   //this->SetDefaultColorMap(0);
@@ -163,6 +161,7 @@ void vtkMRMLScalarVolumeDisplayNode::SetInputImageDataConnection(vtkAlgorithmOut
     vtkEventBroker::GetInstance()->AddObservation(
       inputImageDataAlgorithm, vtkCommand::ModifiedEvent, this, this->MRMLCallbackCommand );
     }
+
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLVolumeThresholdWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLVolumeThresholdWidget.ui
@@ -50,16 +50,34 @@
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
-    <widget class="ctkRangeWidget" name="VolumeThresholdRangeWidget"/>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="ctkRangeWidget" name="VolumeThresholdRangeWidget"/>
+     </item>
+     <item>
+      <widget class="QToolButton" name="RangeButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>:Icons/SliceMoreOptions.png</normaloff>:Icons/SliceMoreOptions.png</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
-   <customwidget>
-     <class>ctkRangeWidget</class>
-     <extends>QWidget</extends>
-     <header>ctkRangeWidget.h</header>
-   </customwidget>
+  <customwidget>
+   <class>ctkRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkRangeWidget.h</header>
+  </customwidget>
  </customwidgets>
  <resources/>
  <connections/>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLWindowLevelWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLWindowLevelWidget.ui
@@ -19,17 +19,10 @@
   <property name="windowTitle">
    <string>Window Level</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,1,0,0,0">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,1,0,0">
    <property name="margin">
     <number>0</number>
    </property>
-   <item row="1" column="0" colspan="6">
-    <widget class="ctkDoubleRangeSlider" name="WindowLevelRangeSlider">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="ctkDoubleSpinBox" name="WindowSpinBox">
      <property name="prefix">
@@ -43,10 +36,10 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="4">
-    <widget class="ctkDoubleSpinBox" name="LevelSpinBox">
+   <item row="0" column="1">
+    <widget class="ctkDoubleSpinBox" name="MinSpinBox">
      <property name="prefix">
-      <string>L: </string>
+      <string>Min:</string>
      </property>
      <property name="decimals">
       <number>2</number>
@@ -75,19 +68,6 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="ctkDoubleSpinBox" name="MinSpinBox">
-     <property name="prefix">
-      <string>Min:</string>
-     </property>
-     <property name="decimals">
-      <number>2</number>
-     </property>
-     <property name="decimalsOption">
-      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="3">
     <widget class="ctkDoubleSpinBox" name="MaxSpinBox">
      <property name="prefix">
@@ -100,6 +80,44 @@
       <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
      </property>
     </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="ctkDoubleSpinBox" name="LevelSpinBox">
+     <property name="prefix">
+      <string>L: </string>
+     </property>
+     <property name="decimals">
+      <number>2</number>
+     </property>
+     <property name="decimalsOption">
+      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="5">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="ctkDoubleRangeSlider" name="WindowLevelRangeSlider">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="RangeButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normaloff>:Icons/SliceMoreOptions.png</normaloff>:Icons/SliceMoreOptions.png</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.xml
+++ b/Libs/MRML/Widgets/Testing/qMRMLVolumeThresholdWidgetEventTranslatorPlayerTest1.xml
@@ -17,7 +17,6 @@
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/VolumeThresholdRangeWidget/Slider" command="set_min_double" arguments="-117"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/VolumeThresholdRangeWidget/Slider" command="set_min_double" arguments="-147"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/VolumeThresholdRangeWidget/Slider" command="set_min_double" arguments="-157"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/RangeWidgetPopup" command="popupOpen" arguments="true"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/VolumeThresholdRangeWidget/Slider" command="set_max_double" arguments="245"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/VolumeThresholdRangeWidget/Slider" command="set_max_double" arguments="255"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/VolumeThresholdRangeWidget/Slider" command="set_max_double" arguments="265"/>
@@ -65,10 +64,6 @@
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/VolumeThresholdRangeWidget/Slider" command="set_max_double" arguments="315"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/VolumeThresholdRangeWidget/Slider" command="set_min_double" arguments="-207"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/VolumeThresholdRangeWidget/Slider" command="set_max_double" arguments="325"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/RangeWidgetPopup/ctkRangeWidget/Slider" command="set_min_double" arguments="-700"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/RangeWidgetPopup/ctkRangeWidget/Slider" command="set_max_double" arguments="500"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/RangeWidgetPopup/ctkRangeWidget/Slider" command="set_max_double" arguments="400"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/AutoManualComboBox" command="set_string" arguments="Off"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLVolumeThresholdWidget/RangeWidgetPopup" command="popupOpen" arguments="false"/>
     </events>
 </QtTesting>

--- a/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.xml
+++ b/Libs/MRML/Widgets/Testing/qMRMLWindowLevelWidgetEventTranslatorPlayerTest1.xml
@@ -8,7 +8,6 @@
     </settings>
     <events>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_min_double" arguments="-11"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/RangeWidgetPopup" command="popupOpen" arguments="true"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_min_double" arguments="-21"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_max_double" arguments="99"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_min_double" arguments="-31"/>
@@ -197,8 +196,6 @@
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_max_double" arguments="399"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_min_double" arguments="-331"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_max_double" arguments="409"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/RangeWidgetPopup" command="popupOpen" arguments="false"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/RangeWidgetPopup" command="popupOpen" arguments="true"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowSpinBox/1ctkQDoubleSpinBox0" command="set_double" arguments="741"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowSpinBox/1ctkQDoubleSpinBox0" command="set_double" arguments="751"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowSpinBox/1ctkQDoubleSpinBox0" command="set_double" arguments="761"/>
@@ -232,7 +229,6 @@
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowSpinBox/1ctkQDoubleSpinBox0" command="set_double" arguments="581"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowSpinBox/1ctkQDoubleSpinBox0" command="set_double" arguments="571"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowSpinBox/1ctkQDoubleSpinBox0" command="set_double" arguments="561"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/RangeWidgetPopup" command="popupOpen" arguments="true"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/LevelSpinBox/1ctkQDoubleSpinBox0" command="set_double" arguments="44"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/LevelSpinBox/1ctkQDoubleSpinBox0" command="set_double" arguments="54"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/LevelSpinBox/1ctkQDoubleSpinBox0" command="set_double" arguments="64"/>
@@ -368,6 +364,5 @@
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_max_double" arguments="234"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_min_double" arguments="-276"/>
         <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/WindowLevelRangeSlider" command="set_max_double" arguments="244"/>
-        <event widget="ctkEventTranslatorPlayerWidget/centralwidget/stackedWidget/qMRMLWindowLevelWidget/RangeWidgetPopup" command="popupOpen" arguments="false"/>
     </events>
 </QtTesting>

--- a/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.cxx
@@ -16,6 +16,7 @@
 ==============================================================================*/
 
 // qMRML includes
+#include "qMRMLSpinBox.h"
 #include "qMRMLVolumeThresholdWidget.h"
 #include "qMRMLVolumeWidget_p.h"
 #include "ui_qMRMLVolumeThresholdWidget.h"
@@ -249,11 +250,34 @@ void qMRMLVolumeThresholdWidget::setMaximum(double max)
 }
 
 // --------------------------------------------------------------------------
+void qMRMLVolumeThresholdWidget::updateWidgetFromMRMLVolumeNode()
+{
+  Q_D(qMRMLVolumeThresholdWidget);
+  this->Superclass::updateWidgetFromMRMLVolumeNode();
+
+  // When scalar range changes, maintain current threshold values, but update range
+  const double min = d->VolumeDisplayNode->GetLowerThreshold();
+  const double max = d->VolumeDisplayNode->GetUpperThreshold();
+
+  double range[2];
+  d->scalarRange(d->VolumeDisplayNode, range);
+  d->DisplayScalarRange[0] = range[0];
+  d->DisplayScalarRange[1] = range[1];
+  const double minRangeValue = std::min(min, range[0]);
+  const double maxRangeValue = std::max(max, range[1]);
+  d->setRange(minRangeValue, maxRangeValue);
+
+}
+
+// --------------------------------------------------------------------------
 void qMRMLVolumeThresholdWidget::updateWidgetFromMRMLDisplayNode()
 {
   Q_D(qMRMLVolumeThresholdWidget);
 
-  this->Superclass::updateWidgetFromMRMLDisplayNode();
+  // Don't want to call qMRMLVolumeWidget::updateWidgetFromMRMLDisplayNode which would call updateRangeForVolumeDisplayNode
+
+  this->setEnabled(d->VolumeDisplayNode != nullptr &&
+                   d->VolumeNode != nullptr);
 
   if (!d->VolumeDisplayNode)
     {
@@ -275,6 +299,10 @@ void qMRMLVolumeThresholdWidget::updateWidgetFromMRMLDisplayNode()
 
   const double min = d->VolumeDisplayNode->GetLowerThreshold();
   const double max = d->VolumeDisplayNode->GetUpperThreshold();
+  const double minRangeValue = std::min(min, d->MinRangeSpinBox->value());
+  const double maxRangeValue = std::max(max, d->MaxRangeSpinBox->value());
+  d->setRange(minRangeValue, maxRangeValue);
+
   d->VolumeThresholdRangeWidget->setValues(min, max );
 
   d->VolumeThresholdRangeWidget->blockSignals(wasBlocking);

--- a/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.cxx
@@ -15,10 +15,6 @@
 
 ==============================================================================*/
 
-// CTK includes
-#include <ctkDoubleSpinBox.h>
-#include <ctkPopupWidget.h>
-
 // qMRML includes
 #include "qMRMLVolumeThresholdWidget.h"
 #include "qMRMLVolumeWidget_p.h"
@@ -72,6 +68,10 @@ void qMRMLVolumeThresholdWidgetPrivate::init()
 
   this->connect(this->AutoManualComboBox, SIGNAL(currentIndexChanged(int)),
                 q, SLOT(setAutoThreshold(int)));
+
+  this->RangeButton->setMenu(this->OptionsMenu);
+  this->RangeButton->setPopupMode(QToolButton::InstantPopup);
+
 }
 
 
@@ -143,17 +143,6 @@ void qMRMLVolumeThresholdWidget::setAutoThreshold(ControlMode autoThreshold)
       d->VolumeDisplayNode->SetApplyThreshold(0);
       }
     d->VolumeDisplayNode->EndModify(disabledModify);
-
-    if (autoThreshold == qMRMLVolumeThresholdWidget::Manual)
-      {
-      d->PopupWidget->setAutoShow(true);
-      d->PopupWidget->showPopup();
-      }
-    else
-      {
-      d->PopupWidget->setAutoShow(false);
-      d->PopupWidget->hidePopup();
-      }
 
     if (oldAuto != d->VolumeDisplayNode->GetAutoThreshold() ||
         oldApply != d->VolumeDisplayNode->GetApplyThreshold())

--- a/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.h
+++ b/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.h
@@ -85,6 +85,9 @@ protected:
   /// Update the widget from volume display node properties.
   void updateWidgetFromMRMLDisplayNode() override;
 
+  /// Update the widget from volume properties.
+  void updateWidgetFromMRMLVolumeNode() override;
+
   ///
   /// Set sliders range
   void setMinimum(double min);

--- a/Libs/MRML/Widgets/qMRMLVolumeWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLVolumeWidget.cxx
@@ -19,17 +19,17 @@
 ==============================================================================*/
 
 // Qt includes
-#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QMenu>
+#include <QWidgetAction>
 
 // CTK includes
-#include <ctkDoubleSpinBox.h>
-#include <ctkRangeWidget.h>
-#include <ctkPopupWidget.h>
 #include <ctkUtils.h>
 
 // qMRML includes
 #include "qMRMLVolumeWidget.h"
 #include "qMRMLVolumeWidget_p.h"
+#include <qMRMLSpinBox.h>
 
 // MRML includes
 #include "vtkMRMLScalarVolumeNode.h"
@@ -45,8 +45,9 @@ qMRMLVolumeWidgetPrivate
 {
   this->VolumeNode = nullptr;
   this->VolumeDisplayNode = nullptr;
-  this->PopupWidget = nullptr;
-  this->RangeWidget = nullptr;
+  this->OptionsMenu = nullptr;
+  this->MinRangeSpinBox = nullptr;
+  this->MaxRangeSpinBox = nullptr;
   this->DisplayScalarRange[0] = 0;
   this->DisplayScalarRange[1] = 0;
 }
@@ -54,9 +55,10 @@ qMRMLVolumeWidgetPrivate
 // --------------------------------------------------------------------------
 qMRMLVolumeWidgetPrivate::~qMRMLVolumeWidgetPrivate()
 {
-  delete this->PopupWidget;
-  this->PopupWidget = nullptr;
-  this->RangeWidget = nullptr;
+  delete this->OptionsMenu;
+  this->OptionsMenu = nullptr;
+  this->MinRangeSpinBox = nullptr;
+  this->MaxRangeSpinBox = nullptr;
 }
 
 // --------------------------------------------------------------------------
@@ -68,50 +70,37 @@ void qMRMLVolumeWidgetPrivate::init()
   // disable as there is not MRML Node associated with the widget
   q->setEnabled(this->VolumeDisplayNode != nullptr);
 
-  // we can't use the flag Qt::Popup as it automatically closes when there is
-  // a click outside of the rangewidget
-  this->PopupWidget = new ctkPopupWidget(q);
-  this->PopupWidget->setObjectName("RangeWidgetPopup");
+  QWidget* rangeWidget = new QWidget(q);
+  QHBoxLayout* rangeLayout = new QHBoxLayout;
+  rangeWidget->setLayout(rangeLayout);
+  rangeLayout->setContentsMargins(0,0,0,0);
 
-  QPalette popupPalette = q->palette();
-  QColor windowColor = popupPalette.color(QPalette::Window);
-  windowColor.setAlpha(200);
-  QColor darkColor = popupPalette.color(QPalette::Dark);
-  darkColor.setAlpha(200);
-  /*
-  QLinearGradient gradient(QPointF(0.,0.),QPointF(0.,0.5));
-  gradient.setCoordinateMode(QGradient::StretchToDeviceMode);
-  gradient.setColorAt(0, windowColor);
-  gradient.setColorAt(1, darkColor);
-  popupPalette.setBrush(QPalette::Window, gradient);
-  */
-  popupPalette.setColor(QPalette::Window, darkColor);
-  this->PopupWidget->setPalette(popupPalette);
-  this->PopupWidget->setAttribute(Qt::WA_TranslucentBackground, true);
-
-  this->PopupWidget->setAutoShow(false);
-  this->PopupWidget->setAutoHide(true);
-  //this->PopupWidget->setBaseWidget(q);
-  this->RangeWidget = new ctkRangeWidget;
-  this->RangeWidget->minimumSpinBox()->setDecimalsOption(
-    ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts);
-  this->RangeWidget->maximumSpinBox()->setDecimalsOption(
-    ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts);
-
-  QVBoxLayout* layout = new QVBoxLayout;
-  layout->addWidget(this->RangeWidget);
-  this->PopupWidget->setLayout(layout);
-
-  QMargins margins = layout->contentsMargins();
-  margins.setTop(0);
-  layout->setContentsMargins(margins);
-
-  this->RangeWidget->setSpinBoxAlignment(Qt::AlignBottom);
-  this->RangeWidget->setRange(-1000000., 1000000.);
-  QObject::connect(this->RangeWidget, SIGNAL(valuesChanged(double,double)),
-                   this, SLOT(setRange(double,double)));
-  this->RangeWidget->setToolTip(
+  this->MinRangeSpinBox = new qMRMLSpinBox(rangeWidget);
+  this->MinRangeSpinBox->setPrefix("Min: ");
+  this->MinRangeSpinBox->setRange(-std::numeric_limits<double>::max(), std::numeric_limits<double>::max());
+  this->MinRangeSpinBox->setValue(this->MinRangeSpinBox->minimum());
+  this->MinRangeSpinBox->setToolTip(
         qMRMLVolumeWidget::tr("Set the range boundaries to control large numbers or allow fine tuning"));
+  connect(this->MinRangeSpinBox, SIGNAL(editingFinished()),
+          this, SLOT(updateRange()));
+  rangeLayout->addWidget(this->MinRangeSpinBox);
+
+  this->MaxRangeSpinBox = new qMRMLSpinBox(rangeWidget);
+  this->MaxRangeSpinBox->setPrefix("Max: ");
+  this->MaxRangeSpinBox->setRange(-std::numeric_limits<double>::max(), std::numeric_limits<double>::max());
+  this->MaxRangeSpinBox->setValue(this->MaxRangeSpinBox->maximum());
+  this->MaxRangeSpinBox->setToolTip(
+        qMRMLVolumeWidget::tr("Set the range boundaries to control large numbers or allow fine tuning"));
+  connect(this->MaxRangeSpinBox, SIGNAL(editingFinished()),
+          this, SLOT(updateRange()));
+  rangeLayout->addWidget(this->MaxRangeSpinBox);
+
+  QWidgetAction* rangeAction = new QWidgetAction(this);
+  rangeAction->setDefaultWidget(rangeWidget);
+
+  this->OptionsMenu = new QMenu(q);
+  this->OptionsMenu->addAction(rangeAction);
+
 }
 
 
@@ -123,9 +112,10 @@ void qMRMLVolumeWidgetPrivate
   this->scalarRange(dNode, range);
   this->DisplayScalarRange[0] = range[0];
   this->DisplayScalarRange[1] = range[1];
-  // we don't want RangeWidget to fire any signal because we don't have
+  // we don't want Range Widgets to fire any signal because we don't have
   // a display node correctly set here (it's done )
-  this->RangeWidget->blockSignals(true);
+  this->MinRangeSpinBox->blockSignals(true);
+  this->MaxRangeSpinBox->blockSignals(true);
   double interval = range[1] - range[0];
   Q_ASSERT(interval >= 0.);
   double min, max;
@@ -141,8 +131,10 @@ void qMRMLVolumeWidgetPrivate
     max = qMax(900., range[1] + 2.*interval);
     }
 
-  this->RangeWidget->setRange(min, max);
-  this->RangeWidget->blockSignals(false);
+  this->MinRangeSpinBox->setValue(min);
+  this->MaxRangeSpinBox->setValue(max);
+  this->MinRangeSpinBox->blockSignals(false);
+  this->MaxRangeSpinBox->blockSignals(false);
 
   if (interval < 10.)
     {
@@ -164,7 +156,7 @@ void qMRMLVolumeWidgetPrivate
 // --------------------------------------------------------------------------
 bool qMRMLVolumeWidgetPrivate::blockSignals(bool block)
 {
-  return this->RangeWidget->blockSignals(block);
+  return this->MinRangeSpinBox->blockSignals(block) && this->MaxRangeSpinBox->blockSignals(block);
 }
 
 // --------------------------------------------------------------------------
@@ -209,8 +201,8 @@ void qMRMLVolumeWidgetPrivate::updateSingleStep(double min, double max)
   singleStep = pow(10., order - ratio);
   decimals = qMax(0, -order + ratio);
 
-  this->RangeWidget->setDecimals(decimals);
-  this->RangeWidget->setSingleStep(singleStep);
+  this->MinRangeSpinBox->setSingleStep(singleStep);
+  this->MaxRangeSpinBox->setSingleStep(singleStep);
 }
 
 // --------------------------------------------------------------------------
@@ -229,7 +221,15 @@ void qMRMLVolumeWidgetPrivate::setSingleStep(double singleStep)
 void qMRMLVolumeWidgetPrivate::setRange(double min, double max)
 {
   this->updateSingleStep(min, max);
-  this->RangeWidget->setValues(min, max);
+  this->MinRangeSpinBox->setValue(min);
+  this->MaxRangeSpinBox->setValue(max);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLVolumeWidgetPrivate::updateRange()
+{
+  this->setRange(this->MinRangeSpinBox->value(),
+                 this->MaxRangeSpinBox->value());
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLVolumeWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLVolumeWidget.cxx
@@ -148,7 +148,12 @@ void qMRMLVolumeWidgetPrivate
 void qMRMLVolumeWidgetPrivate::updateSingleStep(double min, double max)
 {
   double interval = max - min;
-  int order = interval != 0. ? ctk::orderOfMagnitude(interval) : -2;
+  int order = ctk::orderOfMagnitude(interval);
+  if (order == std::numeric_limits<int>::min())
+    {
+    // the order of magnitude can't be computed (e.g. 0, inf, Nan, denorm)...
+    order = -2;
+    }
 
   int ratio = 2;
   double singleStep = pow(10., order - ratio);

--- a/Libs/MRML/Widgets/qMRMLVolumeWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLVolumeWidget.cxx
@@ -112,45 +112,6 @@ void qMRMLVolumeWidgetPrivate
   this->scalarRange(dNode, range);
   this->DisplayScalarRange[0] = range[0];
   this->DisplayScalarRange[1] = range[1];
-  // we don't want Range Widgets to fire any signal because we don't have
-  // a display node correctly set here (it's done )
-  this->MinRangeSpinBox->blockSignals(true);
-  this->MaxRangeSpinBox->blockSignals(true);
-  double interval = range[1] - range[0];
-  Q_ASSERT(interval >= 0.);
-  double min, max;
-
-  if (interval <= 10.)
-    {
-    min = qMin(-10., range[0] - 2.*interval);
-    max = qMax(10., range[1] + 2.*interval);
-    }
-  else
-    {
-    min = qMin(-1200., range[0] - 2.*interval);
-    max = qMax(900., range[1] + 2.*interval);
-    }
-
-  this->MinRangeSpinBox->setValue(min);
-  this->MaxRangeSpinBox->setValue(max);
-  this->MinRangeSpinBox->blockSignals(false);
-  this->MaxRangeSpinBox->blockSignals(false);
-
-  if (interval < 10.)
-    {
-    //give us some space
-    range[0] = range[0] - interval*0.1;
-    range[1] = range[1] + interval*0.1;
-    }
-  else
-    {
-    //give us some space
-    range[0] = qMin(-600., range[0] - interval*0.1);
-    range[1] = qMax(600., range[1] + interval*0.1);
-    }
-  bool blocked = this->blockSignals(true);
-  this->setRange(range[0], range[1]);
-  this->blockSignals(blocked);
 }
 
 // --------------------------------------------------------------------------
@@ -317,12 +278,7 @@ void qMRMLVolumeWidget::updateWidgetFromMRMLVolumeNode()
   vtkMRMLScalarVolumeDisplayNode* newVolumeDisplayNode = d->VolumeNode ?
     vtkMRMLScalarVolumeDisplayNode::SafeDownCast(
       d->VolumeNode->GetVolumeDisplayNode()) : nullptr;
-/*
-  if (d->VolumeNode && d->VolumeNode->GetImageData())
-    {
-    this->updateRangeForVolumeDisplayNode(newVolumeDisplayNode);
-    }
-*/
+
   this->setMRMLVolumeDisplayNode( newVolumeDisplayNode );
 }
 

--- a/Libs/MRML/Widgets/qMRMLVolumeWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLVolumeWidget_p.h
@@ -38,8 +38,8 @@
 // VTK includes
 #include <vtkWeakPointer.h>
 
-class ctkPopupWidget;
-class ctkRangeWidget;
+class QMenu;
+class qMRMLSpinBox;
 
 // -----------------------------------------------------------------------------
 class qMRMLVolumeWidgetPrivate : public QObject
@@ -73,12 +73,14 @@ public slots:
   virtual void setRange(double min, double max);
   virtual void setDecimals(int decimals);
   virtual void setSingleStep(double singleStep);
+  virtual void updateRange();
 
 protected:
   vtkWeakPointer<vtkMRMLScalarVolumeNode> VolumeNode;
   vtkWeakPointer<vtkMRMLScalarVolumeDisplayNode> VolumeDisplayNode;
-  ctkPopupWidget* PopupWidget;
-  ctkRangeWidget* RangeWidget;
+  QMenu* OptionsMenu;
+  qMRMLSpinBox* MinRangeSpinBox;
+  qMRMLSpinBox* MaxRangeSpinBox;
   double DisplayScalarRange[2];
 };
 

--- a/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
@@ -16,6 +16,7 @@
 ==============================================================================*/
 
 // qMRML includes
+#include "qMRMLSpinBox.h"
 #include "qMRMLVolumeWidget_p.h"
 #include "qMRMLWindowLevelWidget.h"
 #include "ui_qMRMLWindowLevelWidget.h"
@@ -333,6 +334,31 @@ void qMRMLWindowLevelWidget::setMaximumValue(double max)
 }
 
 // --------------------------------------------------------------------------
+void qMRMLWindowLevelWidget::updateWidgetFromMRMLVolumeNode()
+{
+  Q_D(qMRMLWindowLevelWidget);
+  this->Superclass::updateWidgetFromMRMLVolumeNode();
+  double range[2];
+  range[0] = d->DisplayScalarRange[0];
+  range[1] = d->DisplayScalarRange[1];
+  double interval = range[1] - range[0];
+  Q_ASSERT(interval >= 0.);
+  if (interval < 10.)
+    {
+    //give us some space
+    range[0] = range[0] - interval*0.1;
+    range[1] = range[1] + interval*0.1;
+    }
+  else
+    {
+    //give us some space
+    range[0] = qMin(-600., range[0] - interval*0.1);
+    range[1] = qMax(600., range[1] + interval*0.1);
+    }
+  d->setRange(range[0], range[1]);
+}
+
+// --------------------------------------------------------------------------
 void qMRMLWindowLevelWidget::updateWidgetFromMRMLDisplayNode()
 {
   Q_D(qMRMLWindowLevelWidget);
@@ -350,6 +376,11 @@ void qMRMLWindowLevelWidget::updateWidgetFromMRMLDisplayNode()
   // We block here to prevent the widgets to call setWindowLevel which could
   // change the AutoLevel from Auto into Manual.
   bool blocked = d->blockSignals(true);
+
+  // WindowLevelMinMax might have been set to values outside the current range
+  const double minRangeValue = std::min(min, d->MinRangeSpinBox->value());
+  const double maxRangeValue = std::max(max, d->MaxRangeSpinBox->value());
+  d->setRange(minRangeValue, maxRangeValue);
 
   d->WindowSpinBox->setValue(window);
   d->LevelSpinBox->setValue(level);

--- a/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
@@ -15,9 +15,6 @@
 
 ==============================================================================*/
 
-// CTK includes
-#include <ctkPopupWidget.h>
-
 // qMRML includes
 #include "qMRMLVolumeWidget_p.h"
 #include "qMRMLWindowLevelWidget.h"
@@ -83,6 +80,10 @@ void qMRMLWindowLevelWidgetPrivate::init()
 
   QObject::connect(this->AutoManualComboBox, SIGNAL(currentIndexChanged(int)),
                    q, SLOT(setAutoWindowLevel(int)));
+
+  this->RangeButton->setMenu(this->OptionsMenu);
+  this->RangeButton->setPopupMode(QToolButton::InstantPopup);
+
 }
 
 // --------------------------------------------------------------------------
@@ -175,16 +176,6 @@ void qMRMLWindowLevelWidget::setAutoWindowLevel(ControlMode autoWindowLevel)
       d->WindowSpinBox->setVisible(true);
       d->LevelSpinBox->setVisible(true);
       break;
-    }
-  if (autoWindowLevel != qMRMLWindowLevelWidget::Auto)
-    {
-    d->PopupWidget->setAutoShow(true);
-    d->PopupWidget->showPopup();
-    }
-  else
-    {
-    d->PopupWidget->setAutoShow(false);
-    d->PopupWidget->hidePopup();
     }
 
   if (autoWindowLevel != oldAuto)

--- a/Libs/MRML/Widgets/qMRMLWindowLevelWidget.h
+++ b/Libs/MRML/Widgets/qMRMLWindowLevelWidget.h
@@ -103,6 +103,9 @@ protected:
   /// Update the widget from volume display node properties.
   void updateWidgetFromMRMLDisplayNode() override;
 
+  /// Update the widget from volume properties.
+  void updateWidgetFromMRMLVolumeNode() override;
+
 private:
   Q_DECLARE_PRIVATE(qMRMLWindowLevelWidget);
   Q_DISABLE_COPY(qMRMLWindowLevelWidget);


### PR DESCRIPTION
This PR aims to improve range bounds behavior for widgets that use qMRMLVolumeWidget including the Window Level and Threshold widgets. See https://discourse.slicer.org/t/improving-qmrmlvolumewidget-range-bounds/17821 for full discussion about this work.

I have added a "..." toolbutton next to the sliders in the window/level and threshold UI files that is similar in nature to what is used in the Slicer qMRMLRangeWidget. 

Shown in the image below is what things look like now. Pressing the "..." toolbutton will show/hide the popup widget contain widgets for setting the bounds of the main slider widget. The previous hover action that would trigger the popup widget was very frustrating to users as in most cases they were looking to change bounds. This toolbutton now makes changing bounds a deliberate action.

A second commit here also sets the threshold slider bounds based on the scalar range of the set MRML volume node. Thresholding outside of the scalar range does not make sense and does nothing. When things do nothing this often confuses users. Users can still change the bounds using the "..." toolbutton in the threshold widget.

![image](https://user-images.githubusercontent.com/15837524/120936546-5c5f9100-c6d6-11eb-9887-ea9f53d8e48c.png)
