### PR TITLE
ENH: Improve markups rendering performance

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/CMakeLists.txt
+++ b/Modules/Loadable/Markups/VTKWidgets/CMakeLists.txt
@@ -12,6 +12,8 @@ set(${KIT}_INCLUDE_DIRECTORIES
 set(${KIT}_SRCS
   vtk${MODULE_NAME}GlyphSource2D.cxx
   vtk${MODULE_NAME}GlyphSource2D.h
+  vtkFastSelectVisiblePoints.cxx
+  vtkFastSelectVisiblePoints.h
   vtkSlicerMarkupsWidgetRepresentation.cxx
   vtkSlicerMarkupsWidgetRepresentation.h
   vtkSlicerMarkupsWidgetRepresentation3D.cxx

--- a/Modules/Loadable/Markups/VTKWidgets/vtkFastSelectVisiblePoints.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkFastSelectVisiblePoints.cxx
@@ -1,0 +1,172 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was centerally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#include "vtkFastSelectVisiblePoints.h"
+
+#include "vtkCamera.h"
+#include "vtkCellArray.h"
+#include "vtkDataSet.h"
+#include <vtkFloatArray.h>
+#include "vtkInformation.h"
+#include "vtkInformationVector.h"
+#include "vtkMatrix4x4.h"
+#include "vtkObjectFactory.h"
+#include "vtkPointData.h"
+#include "vtkPoints.h"
+#include "vtkPolyData.h"
+#include "vtkRenderWindow.h"
+#include "vtkRenderer.h"
+
+vtkStandardNewMacro(vtkFastSelectVisiblePoints);
+
+//----------------------------------------------------------------------------
+vtkFastSelectVisiblePoints::vtkFastSelectVisiblePoints()
+{
+  this->ZBuffer = nullptr;
+}
+
+//----------------------------------------------------------------------------
+vtkFastSelectVisiblePoints::~vtkFastSelectVisiblePoints() = default;
+
+//----------------------------------------------------------------------------
+void vtkFastSelectVisiblePoints::ResetZBuffer()
+{
+  this->ZBuffer = nullptr;
+}
+
+//----------------------------------------------------------------------------
+void vtkFastSelectVisiblePoints::UpdateZBuffer()
+{
+  this->ResetZBuffer();
+  float* zPtr = this->Initialize(true);
+
+  this->ZBuffer = vtkSmartPointer<vtkFloatArray>::New();
+  vtkIdType size = (this->InternalSelection[1] - this->InternalSelection[0] + 1) * (this->InternalSelection[3] - this->InternalSelection[2] + 1);
+  this->ZBuffer->SetArray(zPtr, size, 0);
+}
+
+//----------------------------------------------------------------------------
+int vtkFastSelectVisiblePoints::RequestData(vtkInformation* vtkNotUsed(request),
+  vtkInformationVector** inputVector, vtkInformationVector* outputVector)
+{
+  // get the info objects
+  vtkInformation* inInfo = inputVector[0]->GetInformationObject(0);
+  vtkInformation* outInfo = outputVector->GetInformationObject(0);
+
+  // get the input and output
+  vtkDataSet* input = vtkDataSet::SafeDownCast(inInfo->Get(vtkDataObject::DATA_OBJECT()));
+  vtkPolyData* output = vtkPolyData::SafeDownCast(outInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+  vtkIdType ptId, cellId;
+  int visible;
+  vtkPointData* inPD = input->GetPointData();
+  vtkPointData* outPD = output->GetPointData();
+  vtkIdType numPts = input->GetNumberOfPoints();
+  double x[4];
+
+  // Nothing to extract if there are no points in the data set.
+  if (numPts < 1)
+    {
+    return 1;
+    }
+
+  if (this->Renderer == nullptr)
+    {
+    vtkErrorMacro(<< "Renderer must be set");
+    return 0;
+    }
+
+  if (!this->Renderer->GetRenderWindow())
+    {
+    vtkErrorMacro("No render window -- can't get window size to query z buffer.");
+    return 0;
+    }
+
+  // This will trigger if you do something like ResetCamera before the Renderer or
+  // RenderWindow have allocated their appropriate system resources (like creating
+  // an OpenGL context)." Resource allocation must occur before we can use the Z
+  // buffer.
+  if (this->Renderer->GetRenderWindow()->GetNeverRendered())
+    {
+    vtkDebugMacro("RenderWindow not initialized -- aborting update.");
+    return 1;
+    }
+
+  vtkCamera* cam = this->Renderer->GetActiveCamera();
+  if (!cam)
+    {
+    return 1;
+    }
+
+  vtkPoints* outPts = vtkPoints::New();
+  outPts->Allocate(numPts / 2 + 1);
+  outPD->CopyAllocate(inPD);
+
+  vtkCellArray* outputVertices = vtkCellArray::New();
+  output->SetVerts(outputVertices);
+  outputVertices->Delete();
+
+  if (!this->ZBuffer)
+    {
+    this->UpdateZBuffer();
+    }
+  else
+    {
+    this->Initialize(false);
+    }
+
+  int abort = 0;
+  vtkIdType progressInterval = numPts / 20 + 1;
+  x[3] = 1.0;
+  for (cellId = (-1), ptId = 0; ptId < numPts && !abort; ptId++)
+    {
+    // perform conversion
+    input->GetPoint(ptId, x);
+
+    if (!(ptId % progressInterval))
+      {
+      this->UpdateProgress(static_cast<double>(ptId) / numPts);
+      abort = this->GetAbortExecute();
+      }
+
+    visible = IsPointOccluded(x, this->ZBuffer->GetPointer(0));
+
+    if ((visible && !this->SelectInvisible) || (!visible && this->SelectInvisible))
+      {
+      cellId = outPts->InsertNextPoint(x);
+      output->InsertNextCell(VTK_VERTEX, 1, &cellId);
+      outPD->CopyData(inPD, ptId, cellId);
+      }
+    } // for all points
+
+  output->SetPoints(outPts);
+  outPts->Delete();
+  output->Squeeze();
+
+  vtkDebugMacro(<< "Selected " << cellId + 1 << " out of " << numPts << " original points");
+
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+void vtkFastSelectVisiblePoints::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+}

--- a/Modules/Loadable/Markups/VTKWidgets/vtkFastSelectVisiblePoints.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkFastSelectVisiblePoints.h
@@ -1,0 +1,89 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was centerally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+/**
+ * @class   vtkFastSelectVisiblePoints
+ * @brief   extract points that are visible (based on z-buffer calculation)
+ *
+ * vtkFastSelectVisiblePoints is a filter that selects points based on
+ * whether they are visible or not. Visibility is determined by
+ * accessing the z-buffer of a rendering window. (The position of each
+ * input point is converted into display coordinates, and then the
+ * z-value at that point is obtained. If within the user-specified
+ * tolerance, the point is considered visible.)
+ *
+ * Points that are visible (or if the ivar SelectInvisible is on,
+ * invisible points) are passed to the output. Associated data
+ * attributes are passed to the output as well.
+ *
+ * This filter also allows you to specify a rectangular window in display
+ * (pixel) coordinates in which the visible points must lie. This can be
+ * used as a sort of local "brushing" operation to select just data within
+ * a window.
+ *
+ *
+ * @warning
+ * You must carefully synchronize the execution of this filter. The
+ * filter refers to a renderer, which is modified every time a render
+ * occurs. Therefore, the filter is always out of date, and always
+ * executes. You may have to perform two rendering passes, or if you
+ * are using this filter in conjunction with vtkLabeledDataMapper,
+ * things work out because 2D rendering occurs after the 3D rendering.
+ */
+
+#ifndef vtkFastSelectVisiblePoints_h
+#define vtkFastSelectVisiblePoints_h
+
+#include "vtkSelectVisiblePoints.h"
+#include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
+
+#include <vtkFloatArray.h>
+
+class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT vtkFastSelectVisiblePoints : public vtkSelectVisiblePoints
+{
+public:
+  vtkTypeMacro(vtkFastSelectVisiblePoints, vtkSelectVisiblePoints);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /**
+   * Instantiate object with no renderer; window selection turned off;
+   * tolerance set to 0.01; and select invisible off.
+   */
+  static vtkFastSelectVisiblePoints* New();
+
+  void UpdateZBuffer();
+  void ResetZBuffer();
+
+  vtkFloatArray* GetZBuffer() { return this->ZBuffer; };
+  void SetZBuffer(vtkFloatArray* zBuffer) { this->ZBuffer = zBuffer; };
+
+protected:
+  vtkFastSelectVisiblePoints();
+  ~vtkFastSelectVisiblePoints() override;
+
+  int RequestData(vtkInformation*, vtkInformationVector**, vtkInformationVector*) override;
+
+  vtkSmartPointer<vtkFloatArray> ZBuffer;
+
+private:
+  vtkFastSelectVisiblePoints(const vtkFastSelectVisiblePoints&) = delete;
+  void operator=(const vtkFastSelectVisiblePoints&) = delete;
+};
+
+#endif

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
@@ -20,7 +20,7 @@
 #include "vtkActor2D.h"
 #include "vtkCellLocator.h"
 #include "vtkCleanPolyData.h"
-#include "vtkGlyph3D.h"
+#include "vtkGlyph3DMapper.h"
 #include "vtkLookupTable.h"
 #include "vtkPolyDataMapper.h"
 #include "vtkPointData.h"
@@ -134,9 +134,9 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
     // For backward compatibility, we hide labels if text scale is set to 0.
     controlPoints->LabelsActor->SetVisibility(this->MarkupsDisplayNode->GetPointLabelsVisibility()
       && this->MarkupsDisplayNode->GetTextScale() > 0.0);
-    controlPoints->Glypher->SetScaleFactor(this->ControlPointSize);
+    controlPoints->GlyphMapper->SetScaleFactor(this->ControlPointSize);
 
-    this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->Mapper, controlPoints->OccludedMapper);
+    this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->GlyphMapper, controlPoints->OccludedGlyphMapper);
     }
 
   this->UpdateRelativeCoincidentTopologyOffsets(this->LineMapper, this->LineOccludedMapper);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -33,7 +33,7 @@
 class vtkActor;
 class vtkActor2D;
 class vtkCellPicker;
-class vtkGlyph3D;
+class vtkGlyph3DMapper;
 class vtkLabelPlacementMapper;
 class vtkPolyDataMapper;
 class vtkProperty;
@@ -110,7 +110,7 @@ protected:
     ControlPointsPipeline3D();
     ~ControlPointsPipeline3D() override;
 
-    vtkSmartPointer<vtkGlyph3D> Glypher;
+    vtkSmartPointer<vtkGlyph3DMapper> GlyphMapper;
 
     // Properties used to control the appearance of selected objects and
     // the manipulator in general.
@@ -119,11 +119,12 @@ protected:
     vtkSmartPointer<vtkTextProperty> OccludedTextProperty;
 
     vtkSmartPointer<vtkSelectVisiblePoints>      SelectVisiblePoints;
+
+    vtkSmartPointer<vtkDoubleArray>              CameraDirectionArray;
     vtkSmartPointer<vtkIdTypeArray>              ControlPointIndices;  // store original ID to determine which control point is actually visible
     vtkSmartPointer<vtkPointSetToLabelHierarchy> OccludedPointSetToLabelHierarchyFilter;
 
-    vtkSmartPointer<vtkPolyDataMapper>       Mapper;
-    vtkSmartPointer<vtkPolyDataMapper>       OccludedMapper;
+    vtkSmartPointer<vtkGlyph3DMapper>        OccludedGlyphMapper;
     vtkSmartPointer<vtkLabelPlacementMapper> LabelsMapper;
     vtkSmartPointer<vtkLabelPlacementMapper> LabelsOccludedMapper;
 
@@ -134,6 +135,8 @@ protected:
   };
 
   ControlPointsPipeline3D* GetControlPointsPipeline(int controlPointType);
+
+  virtual void UpdateControlPointGlyphOrientation();
 
   virtual void UpdateNthPointAndLabelFromMRML(int n);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -30,14 +30,16 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation.h"
 
+#include <map>
+
 class vtkActor;
 class vtkActor2D;
 class vtkCellPicker;
+class vtkFastSelectVisiblePoints;
 class vtkGlyph3DMapper;
 class vtkLabelPlacementMapper;
 class vtkPolyDataMapper;
 class vtkProperty;
-class vtkSelectVisiblePoints;
 
 class vtkMRMLInteractionEventData;
 
@@ -110,6 +112,9 @@ protected:
     ControlPointsPipeline3D();
     ~ControlPointsPipeline3D() override;
 
+    /// Orientation of the glyphs, represented as an array of quaternions
+    vtkSmartPointer<vtkDoubleArray>   GlyphOrientationArray;
+
     vtkSmartPointer<vtkGlyph3DMapper> GlyphMapper;
 
     // Properties used to control the appearance of selected objects and
@@ -118,9 +123,10 @@ protected:
     vtkSmartPointer<vtkProperty>     OccludedProperty;
     vtkSmartPointer<vtkTextProperty> OccludedTextProperty;
 
-    vtkSmartPointer<vtkSelectVisiblePoints>      SelectVisiblePoints;
+    vtkSmartPointer<vtkPolyData> VisiblePointsPolyData;
 
-    vtkSmartPointer<vtkDoubleArray>              CameraDirectionArray;
+    vtkSmartPointer<vtkFastSelectVisiblePoints>      SelectVisiblePoints;
+
     vtkSmartPointer<vtkIdTypeArray>              ControlPointIndices;  // store original ID to determine which control point is actually visible
     vtkSmartPointer<vtkPointSetToLabelHierarchy> OccludedPointSetToLabelHierarchyFilter;
 
@@ -157,6 +163,12 @@ protected:
   bool TextActorOccluded;
   bool HideTextActorIfAllPointsOccluded;
   double OccludedRelativeOffset;
+
+  static std::map<vtkRenderer*, vtkSmartPointer<vtkFloatArray> > CachedZBuffers;
+
+  vtkSmartPointer<vtkCallbackCommand> RenderCompletedCallback;
+  static void OnRenderCompleted(vtkObject* caller, unsigned long event, void* clientData, void* callData);
+  static vtkFloatArray* GetCachedZBuffer(vtkRenderer* renderer);
 
 private:
   vtkSlicerMarkupsWidgetRepresentation3D(const vtkSlicerMarkupsWidgetRepresentation3D&) = delete;


### PR DESCRIPTION
This PR contains 2 improvements to the performance of rendering markups fiducials and visibility detection of control points.

- Improve 3D markups fiducial performance with vtkGlyph3DMapper
  - vtkGlyph3D has a higher overhead when used for a large number of points, since it duplicates the glyph polydata once for each point, and then uploads the duplicated polydata to the mapper.
  - vtkGlyph3DMapper has a higher performance as it uploads the glyph once, and renders the same polydata multiple times on the GPU.

- Improve performance of markups visibility detection 
  - Previously, each ControlPointsPipeline3D had its own vtkSelectVisiblePoints filter to determine if the markups were occluded by opaque geometry in the render window. The filters would all download the ZBuffer data separately, resulting in a performance loss.
  - This commit adds the vtkFastSelectVisiblePoints filter which exposes the option to specify the Z-buffer pointer as a vtkFloatArray. As a result, we now only get the contents of the Z-buffer once, and re-use the same data for each control point pipeline.

Re #5618 