### PR TITLE
ENH: Add context menu when right-clicking in slice or 3D view

### DIFF
--- a/Base/QTCLI/qSlicerCLIProgressBar.cxx
+++ b/Base/QTCLI/qSlicerCLIProgressBar.cxx
@@ -141,6 +141,7 @@ void qSlicerCLIProgressBarPrivate::init()
 
   this->StageProgressBar = new QProgressBar();
   this->StageProgressBar->setObjectName(QString::fromUtf8("StageProgressBar"));
+  this->StageProgressBar->setMaximum(100);
   this->StageProgressBar->setValue(0);
   this->GridLayout->addWidget(StageProgressBar, 4, 0, 1, 3);
 
@@ -327,7 +328,9 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
         {
         d->StatusLabel->setText(QString("%1 (%2)").arg(node->GetStatusString()).arg(info->ElapsedTime));
         }
-      d->StageProgressBar->setMaximum(info->StageProgress != 0.0 ? 100 : 0);
+      // We keep StageProgressBar maximum at 100, because if it was set to 0
+      // then the progress message would not be displayed.
+      d->StageProgressBar->setMaximum(100);
       d->StageProgressBar->setFormat(info->ProgressMessage);
       d->StageProgressBar->setValue(info->StageProgress * 100.);
       break;

--- a/Docs/developer_guide/python_faq.md
+++ b/Docs/developer_guide/python_faq.md
@@ -51,7 +51,7 @@ for groupIndex in range(n.GetNumberOfParameterGroups()):
       n.GetParameterTag(groupIndex, parameterIndex),n.GetParameterLabel(groupIndex, parameterIndex)))
 ```
 
-### Passing markups iducials to CLIs
+### Passing markups fiducials to CLIs
 
 ```python
 import SampleData

--- a/Libs/MRML/Core/vtkMRMLInteractionNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLInteractionNode.cxx
@@ -339,3 +339,10 @@ void vtkMRMLInteractionNode::EditNode(vtkMRMLNode* node)
   // Observers in qSlicerCoreApplication listen for this event
   this->InvokeEvent(EditNodeEvent, node);
 }
+
+//----------------------------------------------------------------------------
+void vtkMRMLInteractionNode::ShowViewContextMenu(vtkMRMLInteractionEventData* eventData)
+{
+  // Observers in qSlicerCoreApplication listen for this event
+  this->InvokeEvent(ShowViewContextMenuEvent, eventData);
+}

--- a/Libs/MRML/Core/vtkMRMLInteractionNode.h
+++ b/Libs/MRML/Core/vtkMRMLInteractionNode.h
@@ -3,6 +3,8 @@
 
 #include "vtkMRMLNode.h"
 
+class vtkMRMLInteractionEventData;
+
 class VTK_MRML_EXPORT vtkMRMLInteractionNode : public vtkMRMLNode
 {
 public:
@@ -61,6 +63,7 @@ public:
       InteractionModePersistenceChangedEvent,
       EndPlacementEvent,
       EditNodeEvent,
+      ShowViewContextMenuEvent,
     };
 
   /// Return a text string describing the mode
@@ -82,6 +85,9 @@ public:
   /// Request the application to display user interface
   /// that allows editing of the node.
   void EditNode(vtkMRMLNode* node);
+
+  /// Request the application to display view menu.
+  void ShowViewContextMenu(vtkMRMLInteractionEventData* eventData);
 
 protected:
   vtkMRMLInteractionNode();

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraDisplayableManager.cxx
@@ -25,6 +25,7 @@
 
 // MRML includes
 #include <vtkEventBroker.h>
+#include <vtkMRMLInteractionEventData.h>
 #include <vtkMRMLCameraWidget.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLViewNode.h>
@@ -363,12 +364,24 @@ void vtkMRMLCameraDisplayableManager::SetCameraToInteractor()
 //---------------------------------------------------------------------------
 bool vtkMRMLCameraDisplayableManager::CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double &closestDistance2)
 {
+  // The CameraWidget does not have representation, so it cannot use the usual representation->GetInteractionNode()
+  // method to get the interactor, therefore we make sure here that the view node is passed to it.
+  if (!eventData->GetViewNode())
+    {
+    eventData->SetViewNode(this->GetMRMLViewNode());
+    }
   return this->Internal->CameraWidget->CanProcessInteractionEvent(eventData, closestDistance2);
 }
 
 //---------------------------------------------------------------------------
 bool vtkMRMLCameraDisplayableManager::ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData)
 {
+  // The CameraWidget does not have representation, so it cannot use the usual representation->GetInteractionNode()
+  // method to get the interactor, therefore we make sure here that the view node is passed to it.
+  if (!eventData->GetViewNode())
+    {
+    eventData->SetViewNode(this->GetMRMLViewNode());
+    }
   return this->Internal->CameraWidget->ProcessInteractionEvent(eventData);
 }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
@@ -152,6 +152,8 @@ protected:
   bool ProcessTouchCameraZoom(vtkMRMLInteractionEventData* eventData);
   bool ProcessTouchCameraTranslate(vtkMRMLInteractionEventData* eventData);
 
+  bool ProcessWidgetMenu(vtkMRMLInteractionEventData* eventData);
+
   bool Dolly(double factor);
   vtkCamera* GetCamera();
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
@@ -179,6 +179,8 @@ protected:
   bool ProcessTouchZoom(vtkMRMLInteractionEventData* eventData);
   bool ProcessTouchTranslate(vtkMRMLInteractionEventData* eventData);
 
+  bool ProcessWidgetMenu(vtkMRMLInteractionEventData* eventData);
+
   /// Rotate the message by the specified amount. Used for touchpad events.
   bool Rotate(double sliceRotationAngleRad);
 

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -432,6 +432,7 @@ void vtkMRMLApplicationLogic::SetInteractionNode(vtkMRMLInteractionNode* interac
 
   vtkNew<vtkIntArray> events;
   events->InsertNextValue(vtkMRMLInteractionNode::EditNodeEvent);
+  events->InsertNextValue(vtkMRMLInteractionNode::ShowViewContextMenuEvent);
   vtkSetAndObserveMRMLNodeEventsMacro(this->Internal->InteractionNode, interactionNode, events);
 }
 
@@ -824,6 +825,10 @@ void vtkMRMLApplicationLogic::ProcessMRMLNodesEvents(vtkObject* caller, unsigned
       vtkMRMLNode* nodeToBeEdited = reinterpret_cast<vtkMRMLNode*>(callData);
       this->EditNode(nodeToBeEdited);
       }
+    }
+  else if (vtkMRMLInteractionNode::SafeDownCast(caller) && event == vtkMRMLInteractionNode::ShowViewContextMenuEvent)
+    {
+    this->InvokeEvent(ShowViewContextMenuEvent, callData);
     }
   else
     {

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -188,7 +188,8 @@ public:
     RequestInvokeEvent = vtkCommand::UserEvent + 1,
     PauseRenderEvent = vtkCommand::UserEvent + 101,
     ResumeRenderEvent,
-    EditNodeEvent
+    EditNodeEvent,
+    ShowViewContextMenuEvent,
   };
   /// Structure passed as calldata pointer in the RequestEvent invoked event.
   struct InvokeRequest{

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -110,7 +110,7 @@ public:
 
   QList< vtkWeakPointer<vtkMRMLMarkupsNode> > NodesToDelete;
 
-  QVariantMap ViewMenuEventData;
+  QVariantMap ViewContextMenuEventData;
 };
 
 //-----------------------------------------------------------------------------
@@ -127,59 +127,41 @@ void qSlicerSubjectHierarchyMarkupsPluginPrivate::init()
 {
   Q_Q(qSlicerSubjectHierarchyMarkupsPlugin);
 
+  // View context menu
+
   this->RenamePointAction = new QAction("Rename point...", q);
   this->RenamePointAction->setObjectName("RenamePointAction");
+  q->setActionPosition(this->RenamePointAction, qSlicerSubjectHierarchyAbstractPlugin::SectionComponent);
   QObject::connect(this->RenamePointAction, SIGNAL(triggered()), q, SLOT(renamePoint()));
+
+  this->ToggleSelectPointAction = new QAction("Toggle select point", q);
+  this->ToggleSelectPointAction->setObjectName("ToggleSelectPointAction");
+  q->setActionPosition(this->ToggleSelectPointAction, qSlicerSubjectHierarchyAbstractPlugin::SectionComponent);
+  QObject::connect(this->ToggleSelectPointAction, SIGNAL(triggered()), q, SLOT(toggleSelectPoint()));
 
   this->DeletePointAction = new QAction("Delete point", q);
   this->DeletePointAction->setObjectName("DeletePointAction");
+  q->setActionPosition(this->DeletePointAction, qSlicerSubjectHierarchyAbstractPlugin::SectionComponent);
   QObject::connect(this->DeletePointAction, SIGNAL(triggered()), q, SLOT(deletePoint()));
 
   this->DeleteNodeAction = new QAction("Delete markup", q);
   this->DeleteNodeAction->setObjectName("DeleteNodeAction");
+  q->setActionPosition(this->DeleteNodeAction, qSlicerSubjectHierarchyAbstractPlugin::SectionNode);
   QObject::connect(this->DeleteNodeAction, SIGNAL(triggered()), q, SLOT(requestDeleteNode()));
-
-  this->ToggleSelectPointAction = new QAction("Toggle select point", q);
-  this->ToggleSelectPointAction->setObjectName("ToggleSelectPointAction");
-  QObject::connect(this->ToggleSelectPointAction, SIGNAL(triggered()), q, SLOT(toggleSelectPoint()));
 
   this->EditNodeTerminologyAction = new QAction("Edit markup terminology...", q);
   this->EditNodeTerminologyAction->setObjectName("editNodeTerminologyAction");
+  q->setActionPosition(this->EditNodeTerminologyAction, qSlicerSubjectHierarchyAbstractPlugin::SectionNode);
   QObject::connect(this->EditNodeTerminologyAction, SIGNAL(triggered()), q, SLOT(editNodeTerminology()));
 
-  this->ToggleCurrentItemHandleInteractive = new QAction("Interaction");
-  this->ToggleCurrentItemHandleInteractive->setObjectName("ToggleCurrentItemHandleInteractive");
-  this->ToggleCurrentItemHandleInteractive->setCheckable(true);
-  QObject::connect(this->ToggleCurrentItemHandleInteractive, SIGNAL(triggered()), q, SLOT(toggleCurrentItemHandleInteractive()));
+  int interactionHandlesSection = qSlicerSubjectHierarchyAbstractPlugin::SectionNode + 20;
+
 
   this->ToggleHandleInteractive = new QAction("Interaction");
   this->ToggleHandleInteractive->setObjectName("ToggleHandleInteractive");
   this->ToggleHandleInteractive->setCheckable(true);
+  q->setActionPosition(this->ToggleHandleInteractive, interactionHandlesSection);
   QObject::connect(this->ToggleHandleInteractive, SIGNAL(triggered()), q, SLOT(toggleHandleInteractive()));
-
-  this->ToggleCurrentItemTranslateHandleVisible = new QAction("Translate");
-  this->ToggleCurrentItemTranslateHandleVisible->setCheckable(true);
-  this->ToggleCurrentItemTranslateHandleVisible->setProperty(INTERACTION_HANDLE_TYPE_PROPERTY, vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle);
-  QObject::connect(this->ToggleCurrentItemTranslateHandleVisible, SIGNAL(triggered()), q, SLOT(toggleCurrentItemHandleTypeVisibility()));
-
-  this->ToggleCurrentItemRotateHandleVisible = new QAction("Rotate");
-  this->ToggleCurrentItemRotateHandleVisible->setCheckable(true);
-  this->ToggleCurrentItemRotateHandleVisible->setProperty(INTERACTION_HANDLE_TYPE_PROPERTY, vtkMRMLMarkupsDisplayNode::ComponentRotationHandle);
-  QObject::connect(this->ToggleCurrentItemRotateHandleVisible, SIGNAL(triggered()), q, SLOT(toggleCurrentItemHandleTypeVisibility()));
-
-  this->ToggleCurrentItemScaleHandleVisible = new QAction("Scale");
-  this->ToggleCurrentItemScaleHandleVisible->setCheckable(true);
-  this->ToggleCurrentItemScaleHandleVisible->setProperty(INTERACTION_HANDLE_TYPE_PROPERTY, vtkMRMLMarkupsDisplayNode::ComponentScaleHandle);
-  QObject::connect(this->ToggleCurrentItemScaleHandleVisible, SIGNAL(triggered()), q, SLOT(toggleCurrentItemHandleTypeVisibility()));
-
-  this->CurrentItemHandleVisibilityMenu = new QMenu();
-
-  this->CurrentItemHandleVisibilityMenu->addAction(this->ToggleCurrentItemTranslateHandleVisible);
-  this->CurrentItemHandleVisibilityMenu->addAction(this->ToggleCurrentItemRotateHandleVisible);
-  this->CurrentItemHandleVisibilityMenu->addAction(this->ToggleCurrentItemScaleHandleVisible);
-
-  this->CurrentItemHandleVisibilityAction = new QAction("Interaction options");
-  this->CurrentItemHandleVisibilityAction->setMenu(this->CurrentItemHandleVisibilityMenu);
 
   this->ToggleTranslateHandleVisible = new QAction("Translate");
   this->ToggleTranslateHandleVisible->setCheckable(true);
@@ -202,7 +184,38 @@ void qSlicerSubjectHierarchyMarkupsPluginPrivate::init()
   this->HandleVisibilityMenu->addAction(this->ToggleScaleHandleVisible);
 
   this->HandleVisibilityAction = new QAction("Interaction options");
+  q->setActionPosition(this->HandleVisibilityAction, interactionHandlesSection);
   this->HandleVisibilityAction->setMenu(this->HandleVisibilityMenu);
+
+  // Visibility menu
+
+  this->ToggleCurrentItemHandleInteractive = new QAction("Interaction");
+  this->ToggleCurrentItemHandleInteractive->setObjectName("ToggleCurrentItemHandleInteractive");
+  this->ToggleCurrentItemHandleInteractive->setCheckable(true);
+  QObject::connect(this->ToggleCurrentItemHandleInteractive, SIGNAL(triggered()), q, SLOT(toggleCurrentItemHandleInteractive()));
+
+  this->ToggleCurrentItemTranslateHandleVisible = new QAction("Translate");
+  this->ToggleCurrentItemTranslateHandleVisible->setCheckable(true);
+  this->ToggleCurrentItemTranslateHandleVisible->setProperty(INTERACTION_HANDLE_TYPE_PROPERTY, vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle);
+  QObject::connect(this->ToggleCurrentItemTranslateHandleVisible, SIGNAL(triggered()), q, SLOT(toggleCurrentItemHandleTypeVisibility()));
+
+  this->ToggleCurrentItemRotateHandleVisible = new QAction("Rotate");
+  this->ToggleCurrentItemRotateHandleVisible->setCheckable(true);
+  this->ToggleCurrentItemRotateHandleVisible->setProperty(INTERACTION_HANDLE_TYPE_PROPERTY, vtkMRMLMarkupsDisplayNode::ComponentRotationHandle);
+  QObject::connect(this->ToggleCurrentItemRotateHandleVisible, SIGNAL(triggered()), q, SLOT(toggleCurrentItemHandleTypeVisibility()));
+
+  this->ToggleCurrentItemScaleHandleVisible = new QAction("Scale");
+  this->ToggleCurrentItemScaleHandleVisible->setCheckable(true);
+  this->ToggleCurrentItemScaleHandleVisible->setProperty(INTERACTION_HANDLE_TYPE_PROPERTY, vtkMRMLMarkupsDisplayNode::ComponentScaleHandle);
+  QObject::connect(this->ToggleCurrentItemScaleHandleVisible, SIGNAL(triggered()), q, SLOT(toggleCurrentItemHandleTypeVisibility()));
+
+  this->CurrentItemHandleVisibilityMenu = new QMenu();
+  this->CurrentItemHandleVisibilityMenu->addAction(this->ToggleCurrentItemTranslateHandleVisible);
+  this->CurrentItemHandleVisibilityMenu->addAction(this->ToggleCurrentItemRotateHandleVisible);
+  this->CurrentItemHandleVisibilityMenu->addAction(this->ToggleCurrentItemScaleHandleVisible);
+
+  this->CurrentItemHandleVisibilityAction = new QAction("Interaction options");
+  this->CurrentItemHandleVisibilityAction->setMenu(this->CurrentItemHandleVisibilityMenu);
 }
 
 //-----------------------------------------------------------------------------
@@ -531,10 +544,10 @@ void qSlicerSubjectHierarchyMarkupsPlugin::showViewContextMenuActionsForItem(vtk
   vtkMRMLMarkupsNode* associatedNode = vtkMRMLMarkupsNode::SafeDownCast(shNode->GetItemDataNode(itemID));
   if (associatedNode)
     {
-    d->ViewMenuEventData = eventData;
-    d->ViewMenuEventData["NodeID"] = QVariant(associatedNode->GetID());
+    d->ViewContextMenuEventData = eventData;
+    d->ViewContextMenuEventData["NodeID"] = QVariant(associatedNode->GetID());
 
-    int componentType = d->ViewMenuEventData["ComponentType"].toInt();
+    int componentType = d->ViewContextMenuEventData["ComponentType"].toInt();
     bool pointActionsDisabled =
       componentType == vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle ||
       componentType == vtkMRMLMarkupsDisplayNode::ComponentRotationHandle ||
@@ -612,7 +625,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::renamePoint()
 {
   Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
 
-  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+  if (d->ViewContextMenuEventData.find("NodeID") == d->ViewContextMenuEventData.end())
     {
     qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
     return;
@@ -625,7 +638,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::renamePoint()
     }
 
   // Get markups node
-  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  QString nodeID = d->ViewContextMenuEventData["NodeID"].toString();
   vtkMRMLNode* node = scene->GetNodeByID(nodeID.toUtf8().constData());
   vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
   if (!markupsNode)
@@ -635,7 +648,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::renamePoint()
     }
 
   // Get point index
-  int componentIndex = d->ViewMenuEventData["ComponentIndex"].toInt();
+  int componentIndex = d->ViewContextMenuEventData["ComponentIndex"].toInt();
 
   // Pop up an entry box for the new name, with the old name as default
   QString oldName(markupsNode->GetNthControlPointLabel(componentIndex).c_str());
@@ -655,7 +668,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::deletePoint()
 {
   Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
 
-  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+  if (d->ViewContextMenuEventData.find("NodeID") == d->ViewContextMenuEventData.end())
     {
     qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
     return;
@@ -668,7 +681,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::deletePoint()
     }
 
   // Get markups node
-  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  QString nodeID = d->ViewContextMenuEventData["NodeID"].toString();
   vtkMRMLNode* node = scene->GetNodeByID(nodeID.toUtf8().constData());
   vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
   if (!markupsNode)
@@ -678,7 +691,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::deletePoint()
     }
 
   // Get point index
-  int componentIndex = d->ViewMenuEventData["ComponentIndex"].toInt();
+  int componentIndex = d->ViewContextMenuEventData["ComponentIndex"].toInt();
 
   markupsNode->RemoveNthControlPoint(componentIndex);
 }
@@ -688,7 +701,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::requestDeleteNode()
 {
   Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
 
-  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+  if (d->ViewContextMenuEventData.find("NodeID") == d->ViewContextMenuEventData.end())
     {
     qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
     return;
@@ -701,7 +714,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::requestDeleteNode()
     }
 
   // Get markups node
-  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  QString nodeID = d->ViewContextMenuEventData["NodeID"].toString();
   vtkMRMLNode* node = scene->GetNodeByID(nodeID.toUtf8().constData());
   vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
   if (!markupsNode)
@@ -745,7 +758,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::toggleSelectPoint()
 {
   Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
 
-  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+  if (d->ViewContextMenuEventData.find("NodeID") == d->ViewContextMenuEventData.end())
     {
     qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
     return;
@@ -758,7 +771,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::toggleSelectPoint()
     }
 
   // Get markups node
-  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  QString nodeID = d->ViewContextMenuEventData["NodeID"].toString();
   vtkMRMLNode* node = scene->GetNodeByID(nodeID.toUtf8().constData());
   vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
   if (!markupsNode)
@@ -768,7 +781,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::toggleSelectPoint()
     }
 
   // Get point index
-  int componentIndex = d->ViewMenuEventData["ComponentIndex"].toInt();
+  int componentIndex = d->ViewContextMenuEventData["ComponentIndex"].toInt();
 
   markupsNode->SetNthControlPointSelected(componentIndex, !markupsNode->GetNthControlPointSelected(componentIndex));
 }
@@ -778,7 +791,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::editNodeTerminology()
 {
   Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
 
-  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+  if (d->ViewContextMenuEventData.find("NodeID") == d->ViewContextMenuEventData.end())
     {
     qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
     return;
@@ -804,7 +817,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::editNodeTerminology()
     }
 
   // Get markups node
-  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  QString nodeID = d->ViewContextMenuEventData["NodeID"].toString();
   vtkMRMLNode* node = scene->GetNodeByID(nodeID.toUtf8().constData());
   vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
   if (!markupsNode)
@@ -873,7 +886,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::toggleHandleInteractive()
 {
   Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
 
-  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+  if (d->ViewContextMenuEventData.find("NodeID") == d->ViewContextMenuEventData.end())
     {
     qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
     return;
@@ -886,7 +899,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::toggleHandleInteractive()
     }
 
   // Get markups node
-  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  QString nodeID = d->ViewContextMenuEventData["NodeID"].toString();
   vtkMRMLNode* node = scene->GetNodeByID(nodeID.toUtf8().constData());
   vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
   if (!markupsNode)
@@ -946,7 +959,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::toggleCurrentItemHandleTypeVisibility
 {
   Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
 
-  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+  if (d->ViewContextMenuEventData.find("NodeID") == d->ViewContextMenuEventData.end())
     {
     qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
     return;
@@ -959,7 +972,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::toggleCurrentItemHandleTypeVisibility
     }
 
   // Get markups node
-  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  QString nodeID = d->ViewContextMenuEventData["NodeID"].toString();
   vtkMRMLNode* node = scene->GetNodeByID(nodeID.toUtf8().constData());
   vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
   if (!markupsNode)
@@ -990,7 +1003,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::toggleHandleTypeVisibility()
 {
   Q_D(qSlicerSubjectHierarchyMarkupsPlugin);
 
-  if (d->ViewMenuEventData.find("NodeID") == d->ViewMenuEventData.end())
+  if (d->ViewContextMenuEventData.find("NodeID") == d->ViewContextMenuEventData.end())
     {
     qCritical() << Q_FUNC_INFO << ": No node ID found in the view menu event data";
     return;
@@ -1003,7 +1016,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::toggleHandleTypeVisibility()
     }
 
   // Get markups node
-  QString nodeID = d->ViewMenuEventData["NodeID"].toString();
+  QString nodeID = d->ViewContextMenuEventData["NodeID"].toString();
   vtkMRMLNode* node = scene->GetNodeByID(nodeID.toUtf8().constData());
   vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
   if (!markupsNode)

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
@@ -105,6 +105,10 @@ class SubjectHierarchyCorePluginsSelfTestTest(ScriptedLoadableModuleTest):
     self.studyItemID = self.invalidItemID
     self.cloneNodeNamePostfix = slicer.qSlicerSubjectHierarchyCloneNodePlugin().getCloneNodeNamePostfix()
 
+    # Test printing of all context menu actions and their section numbers
+    pluginHandler = slicer.qSlicerSubjectHierarchyPluginHandler().instance();
+    print(pluginHandler.dumpContextMenuActions())
+
   # ------------------------------------------------------------------------------
   def section_MarkupRole(self):
     self.delayDisplay("Markup role",self.delayMs)

--- a/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
@@ -45,6 +45,8 @@ set(${KIT}_SRCS
   qSlicerSubjectHierarchyFolderPlugin.h
   qSlicerSubjectHierarchyOpacityPlugin.cxx
   qSlicerSubjectHierarchyOpacityPlugin.h
+  qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
+  qSlicerSubjectHierarchyViewContextMenuPlugin.h
   qSlicerSubjectHierarchyVisibilityPlugin.cxx
   qSlicerSubjectHierarchyVisibilityPlugin.h
   )
@@ -66,6 +68,7 @@ set(${KIT}_MOC_SRCS
   qSlicerSubjectHierarchyRegisterPlugin.h
   qSlicerSubjectHierarchyFolderPlugin.h
   qSlicerSubjectHierarchyOpacityPlugin.h
+  qSlicerSubjectHierarchyViewContextMenuPlugin.h
   qSlicerSubjectHierarchyVisibilityPlugin.h
   qMRMLSubjectHierarchyTreeView.h
   qMRMLSubjectHierarchyComboBox.h

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.cxx
@@ -407,3 +407,14 @@ bool qSlicerSubjectHierarchyAbstractPlugin::showItemInView(vtkIdType itemID, vtk
     }
   return true;
 }
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(QAction* action, int section, int weight/*=0*/, double weightAdjustment/*=0.0*/)
+{
+  if (!action)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: invalid action";
+    return;
+    }
+  action->setProperty("section", section + weight * 0.01 + weightAdjustment * 0.0001);
+}

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
@@ -65,6 +65,7 @@ class vtkMRMLAbstractViewNode;
 class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qSlicerSubjectHierarchyAbstractPlugin : public QObject
 {
   Q_OBJECT
+  Q_ENUMS(ActionSectionType)
 
   /// This property stores the name of the plugin
   /// Cannot be empty.
@@ -226,6 +227,28 @@ public:
   /// Set the name of the plugin
   /// NOTE: name must be defined in constructor in C++ plugins, this can only be used in python scripted ones
   virtual void setName(QString name);
+
+  enum ActionSectionType
+    {
+    SectionTop = -400,   ///< Use this section to make items appear at the top of the menu.
+    SectionInteraction = -300, ///< Actions for changing the current interaction mode (in view context menu).
+    SectionComponent = -200,   ///< Actions for the selected node component (e.g., control point within a node).
+    SectionNode = -100,  ///< Actions for the selected node.
+    SectionDefault = 0,  ///< By default (if no position is defined) actions will appear in this section.
+    SectionFolder = 100, ///< Actions for the selected folder.
+    SectionBottom = 200, ///< Use this section to make items appear at the bottom of the menu.
+    };
+
+  /// Set the action position within a subject hierarchy menu by setting section and weight.
+  /// \param section specifies section where the menu item will appear.
+  ///   SectionDefault, SectionNode, SectionFolder, ... constants can be used.
+  ///   A separator is displayed between each menu section.
+  /// \param weight specifies the position of the action within the section.
+  ///   Lighter actions float up (actions that have lower weight appear higher in the menu).
+  ///   Valid range is -49 to 49.
+  /// \param weightAdjustment specifies additional weight that allows inserting an action right above or below
+  ///   another action. Valid range is -49.0 to 49.0 (non-integer values are allowed).
+  Q_INVOKABLE static void setActionPosition(QAction* action, int section, int weight = 0, double weightAdjustment = 0.0);
 
 signals:
   /// Signal requesting expanding of the subject hierarchy tree item belonging to an item

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyCloneNodePlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyCloneNodePlugin.cxx
@@ -71,6 +71,8 @@ void qSlicerSubjectHierarchyCloneNodePluginPrivate::init()
 
   this->CloneItemAction = new QAction("Clone",q);
   this->CloneItemAction->setToolTip("Clone this item and its data node if any along with display and storage options");
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CloneItemAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionNode, 0.5); // put it right after "Rename" action
   QObject::connect(this->CloneItemAction, SIGNAL(triggered()), q, SLOT(cloneCurrentItem()));
 }
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyFolderPlugin.cxx
@@ -92,13 +92,19 @@ void qSlicerSubjectHierarchyFolderPluginPrivate::init()
   Q_Q(qSlicerSubjectHierarchyFolderPlugin);
 
   this->CreateFolderUnderSceneAction = new QAction("Create new folder",q);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CreateFolderUnderSceneAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionFolder, 5);
   QObject::connect(this->CreateFolderUnderSceneAction, SIGNAL(triggered()), q, SLOT(createFolderUnderScene()));
 
   this->CreateFolderUnderNodeAction = new QAction("Create child folder",q);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CreateFolderUnderNodeAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionFolder, 6);
   QObject::connect(this->CreateFolderUnderNodeAction, SIGNAL(triggered()), q, SLOT(createFolderUnderCurrentNode()));
 
   this->ApplyColorToBranchAction = new QAction("Apply color to all children",q);
   this->ApplyColorToBranchAction->setToolTip("If on, then children items will inherit the display properties (e.g. color or opacity) set to the folder");
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ApplyColorToBranchAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionFolder, 7);
   QObject::connect(this->ApplyColorToBranchAction, SIGNAL(toggled(bool)), q, SLOT(onApplyColorToBranchToggled(bool)));
   this->ApplyColorToBranchAction->setCheckable(true);
 }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyModuleWidgetsPythonQtDecorators.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyModuleWidgetsPythonQtDecorators.h
@@ -17,9 +17,12 @@
 #include <PythonQt.h>
 
 // Slicer includes
+#include "qSlicerSubjectHierarchyAbstractPlugin.h"
 #include "qSlicerSubjectHierarchyPluginHandler.h"
 
 #include "qSlicerSubjectHierarchyModuleWidgetsExport.h"
+
+class QAction;
 
 // NOTE:
 //
@@ -51,6 +54,11 @@ public slots:
   qSlicerSubjectHierarchyPluginHandler* static_qSlicerSubjectHierarchyPluginHandler_instance()
     {
     return qSlicerSubjectHierarchyPluginHandler::instance();
+    }
+
+  void static_qSlicerSubjectHierarchyAbstractPlugin_setActionPosition(QAction* action, int section, int weight = 0, double weightAdjustment = 0.0)
+    {
+    qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(action, section, weight, weightAdjustment);
     }
 
   //----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
@@ -146,7 +146,7 @@ bool qSlicerSubjectHierarchyPluginHandler::registerPlugin(qSlicerSubjectHierarch
     {
     foreach(QAction* action, pluginToRegister->viewContextMenuActions())
       {
-      this->m_PluginLogic->registerViewMenuAction(action);
+      this->m_PluginLogic->registerViewContextMenuAction(action);
       }
     }
 
@@ -461,7 +461,7 @@ void qSlicerSubjectHierarchyPluginHandler::setPluginLogic(qSlicerSubjectHierarch
       {
       foreach(QAction * action, pluginToRegister->viewContextMenuActions())
         {
-        this->m_PluginLogic->registerViewMenuAction(action);
+        this->m_PluginLogic->registerViewContextMenuAction(action);
         }
       }
     }
@@ -713,4 +713,45 @@ void qSlicerSubjectHierarchyPluginHandler::showItemsInView(vtkIdList* itemIDsToS
       ownerPlugin->showItemInView(itemID, viewNode, allItemIDsToShow);
       }
     }
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerSubjectHierarchyPluginHandler::dumpContextMenuActions()
+{
+  QString info;
+  QList< QAction* > actions;
+
+  info.append("=== Item context menu ===\n");
+  actions.clear();
+  foreach(qSlicerSubjectHierarchyAbstractPlugin* plugin, this->m_RegisteredPlugins)
+    {
+    actions << plugin->itemContextMenuActions();
+    }
+  info.append(qSlicerSubjectHierarchyPluginLogic::buildMenuFromActions(nullptr, actions));
+
+  info.append("\n=== Scene context menu ===\n");
+  actions.clear();
+  foreach(qSlicerSubjectHierarchyAbstractPlugin* plugin, this->m_RegisteredPlugins)
+    {
+    actions << plugin->sceneContextMenuActions();
+    }
+  info.append(qSlicerSubjectHierarchyPluginLogic::buildMenuFromActions(nullptr, actions));
+
+  info.append("\n=== Visibility context menu ===\n");
+  actions.clear();
+  foreach(qSlicerSubjectHierarchyAbstractPlugin* plugin, this->m_RegisteredPlugins)
+    {
+    actions << plugin->visibilityContextMenuActions();
+    }
+  info.append(qSlicerSubjectHierarchyPluginLogic::buildMenuFromActions(nullptr, actions));
+
+  info.append("\n=== View context menu ===\n");
+  actions.clear();
+  foreach(qSlicerSubjectHierarchyAbstractPlugin* plugin, this->m_RegisteredPlugins)
+    {
+    actions << plugin->viewContextMenuActions();
+    }
+  info.append(qSlicerSubjectHierarchyPluginLogic::buildMenuFromActions(nullptr, actions));
+
+  return info;
 }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
@@ -195,7 +195,11 @@ public:
   void observeSubjectHierarchyNode(vtkMRMLSubjectHierarchyNode* shNode);
 
   /// Show a list of items in a selected view (used for drag&drop of items into a view node)
-  void showItemsInView(vtkIdList* itemIDsToShow, vtkMRMLAbstractViewNode* viewNode);
+  Q_INVOKABLE void showItemsInView(vtkIdList* itemIDsToShow, vtkMRMLAbstractViewNode* viewNode);
+
+  /// Return information string describing all context menu actions (name and section value) for all plugins.
+  /// Useful for finding suitable section values for new actions.
+  Q_INVOKABLE QString dumpContextMenuActions();
 
 protected:
   /// Handle subject hierarchy node events

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
@@ -39,6 +39,7 @@
 #include "qSlicerSubjectHierarchyModuleWidgetsExport.h"
 
 class QAction;
+class QMenu;
 class qSlicerSubjectHierarchyPluginLogicPrivate;
 class qSlicerSubjectHierarchyAbstractPlugin;
 
@@ -75,13 +76,20 @@ public:
   ///       of the module!
   void registerCorePlugins();
 
-  /// Get all view menu actions available
+  /// Get all view context menu actions available
   /// \return List of object names of all registered view menu actions
-  Q_INVOKABLE QStringList availableViewMenuActionNames();
+  Q_INVOKABLE QStringList availableViewContextMenuActionNames();
   /// Set desired set of view menu actions
   /// \param actionObjectNames List of view menu actions to consider. Only actions included here by object name
   ///        are shown in the menu if they are accepted by the owner plugin. The order set here is used.
-  Q_INVOKABLE void setDisplayedViewMenuActionNames(QStringList actionObjectNames);
+  Q_INVOKABLE void setDisplayedViewContextMenuActionNames(QStringList actionObjectNames);
+
+  /// Create menu from list of actions.
+  /// Uses "section" property to determine position of the action in the menu:
+  /// each integer section value corresponds to a section and fractional part is used for ordering actions within the secion.
+  /// \param menu will be set by inserting the actions. If it is set to nullptr then a string will be returned that contains
+  /// name and "section" value of each action.
+  static Q_INVOKABLE QString buildMenuFromActions(QMenu* menu, QList< QAction* > actions);
 
 protected:
   /// Add observations for node that was added to subject hierarchy
@@ -94,7 +102,7 @@ protected:
   void addSupportedDataNodesToSubjectHierarchy();
 
   /// Add view menu action. Called by plugin handler when registering a plugin
-  void registerViewMenuAction(QAction* action);
+  void registerViewContextMenuAction(QAction* action);
 
 protected slots:
   /// Called when a node is added to the scene so that a plugin can create an item for it

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
@@ -1,0 +1,274 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// SubjectHierarchy MRML includes
+#include "vtkMRMLSubjectHierarchyConstants.h"
+#include "vtkMRMLSubjectHierarchyNode.h"
+
+// SubjectHierarchy Plugins includes
+#include "qSlicerSubjectHierarchyPluginHandler.h"
+#include "qSlicerSubjectHierarchyViewContextMenuPlugin.h"
+#include "qSlicerSubjectHierarchyDefaultPlugin.h"
+
+// Qt includes
+#include <QAction>
+#include <QClipboard>
+#include <QDebug>
+#include <QVariant>
+
+// MRML includes
+#include <qMRMLSliceView.h>
+#include <qMRMLSliceWidget.h>
+#include <qMRMLThreeDView.h>
+#include <qMRMLThreeDWidget.h>
+#include <vtkMRMLAbstractViewNode.h>
+#include <vtkMRMLInteractionNode.h>
+#include <vtkMRMLScene.h>
+
+// Slicer includes
+#include <qSlicerApplication.h>
+#include <qSlicerLayoutManager.h>
+
+// VTK includes
+#include <vtkObjectFactory.h>
+#include <vtkSmartPointer.h>
+
+// CTK includes
+#include "ctkSignalMapper.h"
+#include "ctkVTKWidgetsUtils.h"
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
+class qSlicerSubjectHierarchyViewContextMenuPluginPrivate: public QObject
+{
+  Q_DECLARE_PUBLIC(qSlicerSubjectHierarchyViewContextMenuPlugin);
+protected:
+  qSlicerSubjectHierarchyViewContextMenuPlugin* const q_ptr;
+public:
+  qSlicerSubjectHierarchyViewContextMenuPluginPrivate(qSlicerSubjectHierarchyViewContextMenuPlugin& object);
+  ~qSlicerSubjectHierarchyViewContextMenuPluginPrivate() override;
+  void init();
+public:
+
+  ctkSignalMapper* InteractionModeMapper;
+  QAction* InteractionModeViewTransformAction = nullptr;
+  QAction* InteractionModeAdjustWindowLevelAction = nullptr;
+  QAction* InteractionModePlaceAction = nullptr;
+
+  QAction* SaveScreenshotAction = nullptr;
+
+  vtkWeakPointer<vtkMRMLInteractionNode> InteractionNode;
+  vtkWeakPointer<vtkMRMLAbstractViewNode> ViewNode;
+};
+
+//-----------------------------------------------------------------------------
+// qSlicerSubjectHierarchyViewContextMenuPluginPrivate methods
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyViewContextMenuPluginPrivate::qSlicerSubjectHierarchyViewContextMenuPluginPrivate(qSlicerSubjectHierarchyViewContextMenuPlugin& object)
+: q_ptr(&object)
+{
+}
+
+//------------------------------------------------------------------------------
+void qSlicerSubjectHierarchyViewContextMenuPluginPrivate::init()
+{
+  Q_Q(qSlicerSubjectHierarchyViewContextMenuPlugin);
+
+  // Interaction mode
+
+  this->InteractionModeViewTransformAction = new QAction("View transform",q);
+  this->InteractionModeViewTransformAction->setCheckable(true);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->InteractionModeViewTransformAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionInteraction, 0);
+
+  this->InteractionModeAdjustWindowLevelAction = new QAction("Adjust window/level",q);
+  this->InteractionModeAdjustWindowLevelAction->setCheckable(true);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->InteractionModeAdjustWindowLevelAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionInteraction, 1);
+
+  this->InteractionModePlaceAction = new QAction("Place", q);
+  this->InteractionModePlaceAction->setCheckable(true);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->InteractionModePlaceAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionInteraction, 2);
+
+  QActionGroup* interactionModeActions = new QActionGroup(q);
+  interactionModeActions->setExclusive(true);
+
+  interactionModeActions->addAction(this->InteractionModeViewTransformAction);
+  interactionModeActions->addAction(this->InteractionModeAdjustWindowLevelAction);
+  interactionModeActions->addAction(this->InteractionModePlaceAction);
+
+  this->InteractionModeMapper = new ctkSignalMapper(q);
+  this->InteractionModeMapper->setMapping(this->InteractionModeViewTransformAction, vtkMRMLInteractionNode::ViewTransform);
+  this->InteractionModeMapper->setMapping(this->InteractionModeAdjustWindowLevelAction, vtkMRMLInteractionNode::AdjustWindowLevel);
+  this->InteractionModeMapper->setMapping(this->InteractionModePlaceAction, vtkMRMLInteractionNode::Place);
+  QObject::connect(interactionModeActions, SIGNAL(triggered(QAction*)), this->InteractionModeMapper, SLOT(map(QAction*)));
+  QObject::connect(this->InteractionModeMapper, SIGNAL(mapped(int)), q, SLOT(setInteractionMode(int)));
+
+  // Other
+
+  this->SaveScreenshotAction = new QAction(tr("Copy image"), q);
+  this->SaveScreenshotAction->setToolTip(tr("Copy a screenshot of this view to the clipboard"));
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->SaveScreenshotAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 0);
+
+  QObject::connect(this->SaveScreenshotAction, SIGNAL(triggered()), q, SLOT(saveScreenshot()));
+}
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyViewContextMenuPluginPrivate::~qSlicerSubjectHierarchyViewContextMenuPluginPrivate() = default;
+
+//-----------------------------------------------------------------------------
+// qSlicerSubjectHierarchyViewContextMenuPlugin methods
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyViewContextMenuPlugin::qSlicerSubjectHierarchyViewContextMenuPlugin(QObject* parent)
+ : Superclass(parent)
+ , d_ptr( new qSlicerSubjectHierarchyViewContextMenuPluginPrivate(*this) )
+{
+  this->m_Name = QString("ViewContextMenu");
+
+  Q_D(qSlicerSubjectHierarchyViewContextMenuPlugin);
+  d->init();
+}
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyViewContextMenuPlugin::~qSlicerSubjectHierarchyViewContextMenuPlugin() = default;
+
+//---------------------------------------------------------------------------
+QList<QAction*> qSlicerSubjectHierarchyViewContextMenuPlugin::viewContextMenuActions()const
+{
+  Q_D(const qSlicerSubjectHierarchyViewContextMenuPlugin);
+  QList<QAction*> actions;
+  actions << d->InteractionModeViewTransformAction
+    << d->InteractionModeAdjustWindowLevelAction
+    << d->InteractionModePlaceAction
+    << d->SaveScreenshotAction;
+  return actions;
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyViewContextMenuPlugin::showViewContextMenuActionsForItem(vtkIdType itemID, QVariantMap eventData)
+{
+  Q_D(qSlicerSubjectHierarchyViewContextMenuPlugin);
+
+  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
+  if (!shNode || !shNode->GetScene())
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
+    return;
+    }
+  if (itemID != shNode->GetSceneItemID())
+    {
+    return;
+    }
+  if (!eventData.contains("ViewNodeID"))
+    {
+    return;
+    }
+  vtkMRMLAbstractViewNode* viewNode = vtkMRMLAbstractViewNode::SafeDownCast(
+    shNode->GetScene()->GetNodeByID(eventData["ViewNodeID"].toString().toStdString()));
+  if (!viewNode)
+    {
+    return;
+    }
+  vtkMRMLInteractionNode* interactionNode = viewNode->GetInteractionNode();
+  if (!interactionNode)
+    {
+    return;
+    }
+
+  d->InteractionModeViewTransformAction->setVisible(true);
+  d->InteractionModeAdjustWindowLevelAction->setVisible(true);
+  d->InteractionModePlaceAction->setVisible(true);
+
+  int interactionMode = interactionNode->GetCurrentInteractionMode();
+
+  bool wasBlocked = d->InteractionModeViewTransformAction->blockSignals(true);
+  d->InteractionModeViewTransformAction->setChecked(interactionMode == vtkMRMLInteractionNode::ViewTransform);
+  d->InteractionModeViewTransformAction->blockSignals(wasBlocked);
+
+  wasBlocked = d->InteractionModeAdjustWindowLevelAction->blockSignals(true);
+  d->InteractionModeAdjustWindowLevelAction->setChecked(interactionMode == vtkMRMLInteractionNode::AdjustWindowLevel);
+  d->InteractionModeAdjustWindowLevelAction->blockSignals(wasBlocked);
+
+  wasBlocked = d->InteractionModePlaceAction->blockSignals(true);
+  d->InteractionModePlaceAction->setChecked(interactionMode == vtkMRMLInteractionNode::Place);
+  d->InteractionModePlaceAction->blockSignals(wasBlocked);
+
+  d->SaveScreenshotAction->setVisible(true);
+
+  // Cache nodes to have them available for the menu action execution.
+  d->InteractionNode = interactionNode;
+  d->ViewNode = viewNode;
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyViewContextMenuPlugin::setInteractionMode(int mode)
+{
+  Q_D(qSlicerSubjectHierarchyViewContextMenuPlugin);
+  if (!d->InteractionNode)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: invalid interaction node";
+    return;
+    }
+  d->InteractionNode->SetCurrentInteractionMode(mode);
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyViewContextMenuPlugin::saveScreenshot()
+{
+  Q_D(qSlicerSubjectHierarchyViewContextMenuPlugin);
+  if (!qSlicerApplication::application()
+    || !qSlicerApplication::application()->layoutManager())
+  {
+    qWarning() << Q_FUNC_INFO << " failed: cannot get layout manager";
+    return;
+  }
+  QWidget* widget = qSlicerApplication::application()->layoutManager()->viewWidget(d->ViewNode);
+
+  // Get the inside of the widget (without the view controller bar)
+  qMRMLSliceWidget* sliceWidget = qobject_cast<qMRMLSliceWidget*>(widget);
+  qMRMLThreeDWidget* threeDWidget = qobject_cast<qMRMLThreeDWidget*>(widget);
+  if (sliceWidget)
+    {
+    widget = sliceWidget->sliceView();
+    }
+  else if (threeDWidget)
+    {
+    widget = threeDWidget->threeDView();
+    }
+  if (!widget)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: cannot get view widget from layout manager";
+    return;
+    }
+
+  // Grab image
+  QImage screenshot = ctk::grabVTKWidget(widget);
+
+  // Copy to clipboard
+  QClipboard* clipboard = QApplication::clipboard();
+  if (!clipboard)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: cannot access the clipboard";
+    return;
+    }
+  clipboard->setImage(screenshot);
+}

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
@@ -1,0 +1,74 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __qSlicerSubjectHierarchyViewContextMenuPlugin_h
+#define __qSlicerSubjectHierarchyViewContextMenuPlugin_h
+
+// SubjectHierarchy Plugins includes
+#include "qSlicerSubjectHierarchyAbstractPlugin.h"
+
+#include "qSlicerSubjectHierarchyModuleWidgetsExport.h"
+
+// CTK includes
+#include <ctkVTKObject.h>
+
+class qSlicerSubjectHierarchyViewContextMenuPluginPrivate;
+
+class vtkMRMLDisplayNode;
+
+/// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
+/// \brief Subject hierarchy view menu plugin
+///
+/// Adds menu items to the view context menu (when the user right-clicks in a slice or 3D view
+/// in an empty area).
+///
+class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qSlicerSubjectHierarchyViewContextMenuPlugin : public qSlicerSubjectHierarchyAbstractPlugin
+{
+public:
+  Q_OBJECT
+  QVTK_OBJECT
+
+public:
+  typedef qSlicerSubjectHierarchyAbstractPlugin Superclass;
+  qSlicerSubjectHierarchyViewContextMenuPlugin(QObject* parent = nullptr);
+  ~qSlicerSubjectHierarchyViewContextMenuPlugin() override;
+
+public:
+
+  /// Get view context menu item actions that are available when right-clicking an object in the views.
+  /// These item context menu actions can be shown in the implementations of \sa showViewContextMenuActionsForItem
+  QList<QAction*> viewContextMenuActions()const override;
+
+  /// Show context menu actions valid for a given subject hierarchy item to be shown in the view.
+  /// \param itemID Subject Hierarchy item to show the context menu items for
+  /// \param eventData Supplementary data for the item that may be considered for the menu (sub-item ID, attribute, etc.)
+  void showViewContextMenuActionsForItem(vtkIdType itemID, QVariantMap eventData) override;
+
+protected slots:
+  void setInteractionMode(int mode);
+  void saveScreenshot();
+
+protected:
+  QScopedPointer<qSlicerSubjectHierarchyViewContextMenuPluginPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerSubjectHierarchyViewContextMenuPlugin);
+  Q_DISABLE_COPY(qSlicerSubjectHierarchyViewContextMenuPlugin);
+};
+
+#endif

--- a/Modules/Scripted/DICOMLib/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDICOMPlugin.cxx
+++ b/Modules/Scripted/DICOMLib/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDICOMPlugin.cxx
@@ -92,19 +92,35 @@ void qSlicerSubjectHierarchyDICOMPluginPrivate::init()
 {
   Q_Q(qSlicerSubjectHierarchyDICOMPlugin);
 
+  // Place DICOM folder actions after core folder actions
+  const int folderActionsBaseWeight = 20;
+
   this->CreatePatientAction = new QAction("Create new subject",q);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CreatePatientAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionFolder, folderActionsBaseWeight);
   QObject::connect(this->CreatePatientAction, SIGNAL(triggered()), q, SLOT(createSubjectItem()));
 
   this->CreateStudyAction = new QAction("Create child study",q);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CreateStudyAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionFolder, folderActionsBaseWeight+1);
   QObject::connect(this->CreateStudyAction, SIGNAL(triggered()), q, SLOT(createChildStudyUnderCurrentItem()));
 
   this->ConvertFolderToPatientAction = new QAction("Convert folder to subject",q);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ConvertFolderToPatientAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionFolder, folderActionsBaseWeight+2);
   QObject::connect(this->ConvertFolderToPatientAction, SIGNAL(triggered()), q, SLOT(convertCurrentItemToPatient()));
 
   this->ConvertFolderToStudyAction = new QAction("Convert folder to study",q);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ConvertFolderToStudyAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionFolder, folderActionsBaseWeight+3);
   QObject::connect(this->ConvertFolderToStudyAction, SIGNAL(triggered()), q, SLOT(convertCurrentItemToStudy()));
 
   this->OpenDICOMExportDialogAction = new QAction("Export to DICOM...",q);
+  // Place DICOM export action lower in the default actions section because it is
+  // better to have export features towards the end (after editing and importing actions).
+  const int dicomExportActionWeight = 30;
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->OpenDICOMExportDialogAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, dicomExportActionWeight);
   QObject::connect(this->OpenDICOMExportDialogAction, SIGNAL(triggered()), q, SLOT(openDICOMExportDialog()));
 }
 


### PR DESCRIPTION
Currently, the only actions in the view context menu (when clicking on empty area) then only interaction mode can be changed.
More actions can be added later.

![image](https://user-images.githubusercontent.com/307929/122097796-12656200-cdde-11eb-9d00-385576a6e37d.png)

Let me know if there are other actions that you would like to see in this menu.