### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -45,17 +45,17 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/pydicom]
   # [Pillow]
   # Hashes correspond to the following packages:
-  #  - Pillow-8.1.2-cp36-cp36m-macosx_10_10_x86_64.whl
-  #  - Pillow-8.1.2-cp36-cp36m-manylinux1_x86_64.whl
-  #  - Pillow-8.1.2-cp36-cp36m-manylinux2014_aarch64.whl
-  #  - Pillow-8.1.2-cp36-cp36m-win_amd64.whl
-  Pillow==8.1.2 --hash=sha256:5cf03b9534aca63b192856aa601c68d0764810857786ea5da652581f3a44c2b0 \
-                --hash=sha256:5762ebb4436f46b566fc6351d67a9b5386b5e5de4e58fdaa18a1c83e0e20f1a8 \
-                --hash=sha256:e2cd8ac157c1e5ae88b6dd790648ee5d2777e76f1e5c7d184eaddb2938594f34 \
-                --hash=sha256:d1d6bca39bb6dd94fba23cdb3eeaea5e30c7717c5343004d900e2a63b132c341
+  #  - Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl
+  #  - Pillow-8.2.0-cp36-cp36m-manylinux1_x86_64.whl
+  #  - Pillow-8.2.0-cp36-cp36m-manylinux2014_aarch64.whl
+  #  - Pillow-8.2.0-cp36-cp36m-win_amd64.whl
+  Pillow==8.2.0 --hash=sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9 \
+                --hash=sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b \
+                --hash=sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9 \
+                --hash=sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f
   # [/Pillow]
   # [six]
-  six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
+  six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   # [/six]
   # [retrying]
   retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -40,16 +40,19 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
   # [/CouchDB]
   # [gitdb]
-  gitdb==4.0.5 --hash=sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac
+  gitdb==4.0.7 --hash=sha256:6c4cc71933456991da20917998acbe6cf4fb41eeaab7d6d67fbc05ecd4c865b0
   # [/gitdb]
   # [smmap]
-  smmap==3.0.5 --hash=sha256:7bfcf367828031dc893530a29cb35eb8c8f2d7c8f2d0989354d75d24c8573714
+  smmap==4.0.0 --hash=sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2
   # [/smmap]
+  # [typing-extensions]
+  typing-extensions==3.10.0.0 --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
+  # [/typing-extensions]
   # [GitPython]
-  GitPython==3.1.14 --hash=sha256:3283ae2fba31c913d857e12e5ba5f9a7772bbc064ae2bb09efafa71b0dd4939b
+  GitPython==3.1.17 --hash=sha256:29fe82050709760081f588dd50ce83504feddbebdc4da6956d02351552b1c135
   # [/GitPython]
   # [six]
-  six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
+  six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   # [/six]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -39,7 +39,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   wrapt==1.12.1 --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
   # [/wrapt]
   # [Deprecated]
-  Deprecated==1.2.11 --hash=sha256:924b6921f822b64ec54f49be6700a126bab0640cfafca78f22c9d429ed590560
+  Deprecated==1.2.12 --hash=sha256:08452d69b6b5bc66e8330adde0a4f8642e969b9e1702904d137eeb29c8ffc771
   # [/Deprecated]
   # [PyGithub]
   PyGithub==1.54.1 --hash=sha256:87afd6a67ea582aa7533afdbf41635725f13d12581faed7e3e04b1579c0c0627

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==21.0.1 --hash=sha256:37fd50e056e2aed635dec96594606f0286640489b0db0ce7607f7e51890372d5
+  pip==21.1.2 --hash=sha256:f8ea1baa693b61c8ad1c1d8715e59ab2b93cd3c4769bacab84afcc4279e7a70e
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -38,7 +38,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   pyparsing==2.4.7 --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
   # [/pyparsing]
   # [six]
-  six==1.15.0 --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
+  six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   # [/six]
   ]===])
 

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [certifi]
-  certifi==2020.12.5 --hash=sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830
+  certifi==2021.5.30 --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8
   # [/certifi]
   # [idna]
   idna==2.10 --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
@@ -36,7 +36,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   chardet==4.0.0 --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
   # [/chardet]
   # [urllib3]
-  urllib3==1.26.3 --hash=sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80
+  urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c
   # [/urllib3]
   # [requests]
   requests==2.25.1 --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==54.1.1 --hash=sha256:75c5c4479f4961f1ffdb597c98aa4e4077e6813685025e8bdebf7598aa84e859
+  setuptools==57.0.0 --hash=sha256:c8b9f1a457949002e358fea7d3f2a1e1b94ddc0354b2e40afc066bf95d21bf7b
   # [/setuptools]
   ]===])
 


### PR DESCRIPTION
Python packages were last updated March 11th, 2021. Outdated python packages were discovered and updated using the python_package_updater.py script in the Slicer repo and then dependencies new/conflicting were manually reviewed.

```
PS C:\Users\james\AppData\Local\NA-MIC\Slicer 4.13.0-2021-06-11\bin> ./PythonSlicer.exe "C:\Users\james\Documents\GitHub\Slicer\Utilities\Scripts\python_package_updater.py"
WARNING: You are using pip version 21.0.1; however, version 21.1.2 is available.
You should consider upgrading via the 'C:\Users\james\AppData\Local\NA-MIC\Slicer 4.13.0-2021-06-11\bin\python-real.exe -m pip install --upgrade pip' command.
Package    Version   Latest    Type
---------- --------- --------- -----
certifi    2020.12.5 2021.5.30 wheel
Deprecated 1.2.11    1.2.12    wheel
gitdb      4.0.5     4.0.7     wheel
GitPython  3.1.14    3.1.17    wheel
idna       2.10      3.2       wheel
Pillow     8.1.2     8.2.0     wheel
pip        21.0.1    21.1.2    wheel
PyGithub   1.54.1    1.55      wheel
PyJWT      1.7.1     2.1.0     wheel
setuptools 54.1.1    57.0.0    wheel
six        1.15.0    1.16.0    wheel
smmap      3.0.5     4.0.0     wheel
urllib3    1.26.3    1.26.5    wheel

  certifi==2021.5.30 --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8
  Deprecated==1.2.12 --hash=sha256:08452d69b6b5bc66e8330adde0a4f8642e969b9e1702904d137eeb29c8ffc771
  gitdb==4.0.7 --hash=sha256:6c4cc71933456991da20917998acbe6cf4fb41eeaab7d6d67fbc05ecd4c865b0
  GitPython==3.1.17 --hash=sha256:29fe82050709760081f588dd50ce83504feddbebdc4da6956d02351552b1c135
  idna==3.2 --hash=sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a
  # Hashes correspond to the following packages:
  #  - Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl
  #  - Pillow-8.2.0-cp36-cp36m-manylinux1_x86_64.whl
  #  - Pillow-8.2.0-cp36-cp36m-manylinux2014_aarch64.whl
  #  - Pillow-8.2.0-cp36-cp36m-win_amd64.whl
  Pillow==8.2.0 --hash=sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9 \
                --hash=sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b \
                --hash=sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9 \
                --hash=sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f
  pip==21.1.2 --hash=sha256:f8ea1baa693b61c8ad1c1d8715e59ab2b93cd3c4769bacab84afcc4279e7a70e
  PyGithub==1.55 --hash=sha256:2caf0054ea079b71e539741ae56c5a95e073b81fa472ce222e81667381b9601b
  PyJWT==2.1.0 --hash=sha256:934d73fbba91b0483d3857d1aff50e96b2a892384ee2c17417ed3203f173fca1
  setuptools==57.0.0 --hash=sha256:c8b9f1a457949002e358fea7d3f2a1e1b94ddc0354b2e40afc066bf95d21bf7b
  six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
  smmap==4.0.0 --hash=sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2
  urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c
```

- Unable to upgrade `idna`  because `requests` requires idna >=2.5, <3
- Did not upgrade `PyGithub` to 1.55 because it introduces a new dependency `PyNaCl` that only has wheels for the Windows platform for the Python 3.6 version. Continuing to stay with `PyGithub` 1.54.1 means we must continue to use `PyJWT`<2.

Packages I'm unable to upgrade to their latest release because they dropped support for Python 3.6 (see https://github.com/Slicer/Slicer/issues/5014#issuecomment-742599890):
- `numpy` >= v1.20.0
- `scipy` >= v1.6.0