### PR TITLE
ENH: Add interface to register default sequence storage nodes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -32,7 +32,10 @@ vtkCxxSetObjectMacro(vtkMRMLScalarVolumeNode, VoxelValueQuantity, vtkCodedEntry)
 vtkCxxSetObjectMacro(vtkMRMLScalarVolumeNode, VoxelValueUnits, vtkCodedEntry);
 
 //----------------------------------------------------------------------------
-vtkMRMLScalarVolumeNode::vtkMRMLScalarVolumeNode() = default;
+vtkMRMLScalarVolumeNode::vtkMRMLScalarVolumeNode()
+{
+  this->DefaultSequenceStorageNodeClassName = "vtkMRMLVolumeSequenceStorageNode";
+}
 
 //----------------------------------------------------------------------------
 vtkMRMLScalarVolumeNode::~vtkMRMLScalarVolumeNode()
@@ -173,10 +176,4 @@ void vtkMRMLScalarVolumeNode::CreateDefaultDisplayNodes()
     dispNode->SetDefaultColorMap();
     }
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
-}
-
-//----------------------------------------------------------------------------
-vtkMRMLStorageNode* vtkMRMLScalarVolumeNode::CreateDefaultSequenceStorageNode()
-{
-  return vtkMRMLVolumeSequenceStorageNode::New();
 }

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.h
@@ -72,9 +72,6 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeNode : public vtkMRMLVolumeNode
   /// Create and observe default display node
   void CreateDefaultDisplayNodes() override;
 
-  /// Creates the most appropriate storage node class for storing a sequence of these nodes.
-  vtkMRMLStorageNode* CreateDefaultSequenceStorageNode() override;
-
   /// Measured quantity of voxel values, specified as a standard coded entry.
   /// For example: (DCM, 112031, "Attenuation Coefficient")
   void SetVoxelValueQuantity(vtkCodedEntry*);

--- a/Libs/MRML/Core/vtkMRMLSequenceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSequenceNode.cxx
@@ -673,10 +673,11 @@ std::string vtkMRMLSequenceNode::GetDefaultStorageNodeClassName(const char* file
 
   // Use specific sequence storage node, if possible
   vtkMRMLStorableNode* storableNode = vtkMRMLStorableNode::SafeDownCast(this->GetNthDataNode(0));
-  if (storableNode)
+  if (storableNode && this->GetScene())
     {
+    std::string sequenceStorageNodeClassName = storableNode->GetDefaultSequenceStorageNodeClassName();
     vtkSmartPointer<vtkMRMLStorageNode> storageNode = vtkSmartPointer<vtkMRMLStorageNode>::Take(
-      storableNode->CreateDefaultSequenceStorageNode());
+      vtkMRMLStorageNode::SafeDownCast(this->GetScene()->CreateNodeByClass(sequenceStorageNodeClassName.c_str())));
     if (storageNode)
       {
       // Filename is not specified or it is specified and there is a supported file extension

--- a/Libs/MRML/Core/vtkMRMLStorableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorableNode.cxx
@@ -34,9 +34,9 @@ vtkMRMLStorableNode::vtkMRMLStorableNode()
 {
   this->UserTagTable = vtkTagTable::New();
   this->SlicerDataType = "";
+  this->DefaultSequenceStorageNodeClassName = "vtkMRMLSequenceStorageNode";
   this->AddNodeReferenceRole(this->GetStorageNodeReferenceRole(),
                              this->GetStorageNodeReferenceMRMLAttributeName());
-
 }
 
 //----------------------------------------------------------------------------
@@ -210,6 +210,19 @@ void vtkMRMLStorableNode::ReadXMLAttributes(const char** atts)
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLStorableNode::Copy(vtkMRMLNode* anode)
+{
+  Superclass::Copy(anode);
+  vtkMRMLStorableNode *node = (vtkMRMLStorableNode *) anode;
+  if (!node)
+    {
+    return;
+    }
+
+  this->SetDefaultSequenceStorageNodeClassName(node->GetDefaultSequenceStorageNodeClassName());
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLStorableNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
 {
   MRMLNodeModifyBlocker blocker(this);
@@ -247,6 +260,8 @@ void vtkMRMLStorableNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/
         }
       }
     }
+
+  this->SetDefaultSequenceStorageNodeClassName(node->GetDefaultSequenceStorageNodeClassName());
 }
 
 //----------------------------------------------------------------------------
@@ -469,5 +484,24 @@ bool vtkMRMLStorableNode::AddDefaultStorageNode(const char* filename /* =nullptr
 //---------------------------------------------------------------------------
 vtkMRMLStorageNode* vtkMRMLStorableNode:: CreateDefaultSequenceStorageNode()
 {
-  return vtkMRMLSequenceStorageNode::New();
+  vtkObject* ret = nullptr;
+  if (this->GetScene())
+    {
+    ret = this->GetScene()->CreateNodeByClass(this->DefaultSequenceStorageNodeClassName.c_str());
+    }
+
+  vtkMRMLStorageNode* storageNode = vtkMRMLStorageNode::SafeDownCast(ret);
+  if (storageNode)
+    {
+    return storageNode;
+    }
+
+  if (ret)
+    {
+    // Specified class is not a valid sequence storage node
+    ret->Delete();
+    }
+
+  // No valid sequence storage node
+  return nullptr;
 }

--- a/Libs/MRML/Core/vtkMRMLStorableNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorableNode.h
@@ -123,7 +123,9 @@ public:
   virtual bool AddDefaultStorageNode(const char* filename = nullptr);
 
   /// Class name of the default sequence storage node that is instantiated by CreateDefaultSequenceStorageNode
-  /// Default: "vtkMRMLSequenceStorageNode"
+  /// The value is not stored in the scene but it has to be set manually
+  /// (for example, in the corresponding default node in the scene).
+  /// Default value: "vtkMRMLSequenceStorageNode"
   /// \sa CreateDefaultSequenceStorageNode
   vtkSetMacro(DefaultSequenceStorageNodeClassName, std::string);
   vtkGetMacro(DefaultSequenceStorageNodeClassName, std::string);

--- a/Libs/MRML/Core/vtkMRMLStorableNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorableNode.h
@@ -57,6 +57,10 @@ public:
   /// Write this node's information to a MRML file in XML format.
   void WriteXML(ostream& of, int indent) override;
 
+  /// \brief Copy node contents from another node of the same type.
+  /// Reimplemented to copy default sequence storage node class.
+  void Copy(vtkMRMLNode* node) override;
+
   /// Copy node content (excludes basic data, such as name and node references).
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentMacro(vtkMRMLStorableNode);
@@ -118,6 +122,12 @@ public:
   /// storage node is not created and the method returns with true.
   virtual bool AddDefaultStorageNode(const char* filename = nullptr);
 
+  /// Class name of the default sequence storage node that is instantiated by CreateDefaultSequenceStorageNode
+  /// Default: "vtkMRMLSequenceStorageNode"
+  /// \sa CreateDefaultSequenceStorageNode
+  vtkSetMacro(DefaultSequenceStorageNodeClassName, std::string);
+  vtkGetMacro(DefaultSequenceStorageNodeClassName, std::string);
+
   /// Creates the most appropriate storage node class for storing a sequence of these nodes.
   /// The caller owns the returned object and responsible for deleting it.
   /// If the method is not overwritten by subclass then it creates vtkMRMLSequenceStorageNode,
@@ -162,6 +172,8 @@ public:
   /// SlicerDataType records the kind of storage node that
   /// holds the data. Set in each subclass.
   std::string SlicerDataType;
+
+  std::string DefaultSequenceStorageNodeClassName;
 
   /// Compute when the storable node was read/written for the last time.
   /// This information is used by GetModifiedSinceRead() to know if the node

--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -59,6 +59,8 @@ vtkMRMLTransformNode::vtkMRMLTransformNode()
   this->CachedMatrixTransformFromParent=vtkMatrix4x4::New();
 
   this->ContentModifiedEvents->InsertNextValue(vtkMRMLTransformableNode::TransformModifiedEvent);
+
+  this->DefaultSequenceStorageNodeClassName = "vtkMRMLLinearTransformSequenceStorageNode";
 }
 
 //----------------------------------------------------------------------------
@@ -1655,12 +1657,6 @@ bool vtkMRMLTransformNode::IsGeneralTransformLinear(vtkAbstractTransform* inputT
       }
     }
   return true;
-}
-
-//----------------------------------------------------------------------------
-vtkMRMLStorageNode* vtkMRMLTransformNode::CreateDefaultSequenceStorageNode()
-{
-  return vtkMRMLLinearTransformSequenceStorageNode::New();
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLTransformNode.h
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.h
@@ -250,9 +250,6 @@ public:
   /// Create default storage node or nullptr if does not have one
   vtkMRMLStorageNode* CreateDefaultStorageNode() override;
 
-  /// Creates the most appropriate storage node class for storing a sequence of these nodes.
-  vtkMRMLStorageNode* CreateDefaultSequenceStorageNode() override;
-
   ///
   /// Create and observe default display node
   void CreateDefaultDisplayNodes() override;


### PR DESCRIPTION
Currently, it is not possible in a module to add a default SequenceStorageNode for a data node class in the Slicer core.
This commit adds an interface so that Extensions can now add default sequence storage node classes for specific data types by registering the data node/storage node in the default sequence node.

Example of use:
````
  defaultSequenceNode = slicer.mrmlScene.CreateNodeByClass("vtkMRMLSequenceNode")
  defaultSequenceNode.RegisterAdditionalStorageNode("vtkMRMLStreamingVolumeNode", "vtkMRMLStreamingVolumeSequenceStorageNode")
  slicer.mrmlScene.AddDefaultNode(defaultSequenceNode)
  defaultSequenceNode.UnRegister(None)
````