### PR TITLE
COMP: Check for Qt5X11Extras on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,13 @@ endif()
     Xml XmlPatterns
     Svg Sql
     )
+
+  # Add the Qt5X11Extras component for Linux systems
+  # This component is needed for building VTK
+  if(UNIX AND NOT APPLE)
+    list(APPEND Slicer_REQUIRED_QT_MODULES X11Extras)
+  endif()
+
   find_package(Qt5 COMPONENTS Core QUIET)
   if(Slicer_BUILD_WEBENGINE_SUPPORT)
     list(APPEND Slicer_REQUIRED_QT_MODULES


### PR DESCRIPTION
`Qt5X11Extras` is a Qt componnent required to build the Superbuild `VTK` in
the current configuration, however, this component is not required when
configuring Slicer. In abscence of installed `Qt5X11Extras` the build will
fail on `VTK`.

his commit adds Qt5X11Extras as a required component for Linux systems
and closes Slicer/Slicer#5695
