### PR TITLE
WindowLevel widget mode fixes and Threshold mode improvements

### DIFF
--- a/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.h
+++ b/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.h
@@ -29,6 +29,7 @@ class QMRML_WIDGETS_EXPORT qMRMLVolumeThresholdWidget
   Q_PROPERTY(int  autoThreshold READ autoThreshold WRITE setAutoThreshold)
   Q_PROPERTY(double lowerThreshold READ lowerThreshold WRITE setLowerThreshold)
   Q_PROPERTY(double upperThreshold READ upperThreshold WRITE setUpperThreshold)
+  Q_ENUMS(ControlMode)
 
 public:
   /// Constructors

--- a/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
@@ -152,6 +152,14 @@ void qMRMLWindowLevelWidget::setAutoWindowLevel(ControlMode autoWindowLevel)
     {
     return;
     }
+
+  bool blocked = d->AutoManualComboBox->blockSignals(true);
+  if (d->AutoManualComboBox->currentIndex() != autoWindowLevel)
+  {
+    d->AutoManualComboBox->setCurrentIndex(autoWindowLevel);
+  }
+  d->AutoManualComboBox->blockSignals(blocked);
+
   int oldAuto = d->VolumeDisplayNode->GetAutoWindowLevel();
 
   //int disabledModify = this->VolumeDisplayNode->StartModify();


### PR DESCRIPTION
`BUG: Fix Window Level mode not reflecting ManualMinMax set state` closes #5651.
```python
import SampleData
nodeToClone = SampleData.SampleDataLogic().downloadMRHead()
widget = slicer.qMRMLWindowLevelWidget()
widget.setMRMLVolumeNode(nodeToClone)
widget.setAutoWindowLevel(slicer.qMRMLWindowLevelWidget.ManualMinMax)
widget.show()
```
![image](https://user-images.githubusercontent.com/15837524/123570250-d21ac200-d795-11eb-9f4c-fe3e9dcf0d44.png)

I've also added a second commit that exposes the similar control mode type enums, but for the Volume Threshold widget. This allows for setting the auto threshold using the control mode enum.
```python
import SampleData
nodeToClone = SampleData.SampleDataLogic().downloadMRHead()
widget = slicer.qMRMLVolumeThresholdWidget()
widget.setMRMLVolumeNode(nodeToClone)
widget.setAutoThreshold(slicer.qMRMLVolumeThresholdWidget.Manual)
widget.show()
```
![image](https://user-images.githubusercontent.com/15837524/123570477-46edfc00-d796-11eb-9890-cddb7bad4c9b.png)
