### PR TITLE
DOC: Update plugin logic example based on recent renames

### DIFF
--- a/Docs/developer_guide/script_repository/subjecthierarchy.md
+++ b/Docs/developer_guide/script_repository/subjecthierarchy.md
@@ -165,8 +165,8 @@ When right-clicking certain types of nodes in the 2D/3D views, a subject hierarc
 ```python
 pluginHandler = slicer.qSlicerSubjectHierarchyPluginHandler.instance()
 pluginLogic = pluginHandler.pluginLogic()
-menuActions = pluginLogic.availableViewMenuActionNames()
+menuActions = pluginLogic.availableViewContextMenuActionNames()
 # Returns ("RenamePointAction", "DeletePointAction", "ToggleSelectPointAction", "EditPropertiesAction")
 newActions = ["RenamePointAction"]
-pluginLogic.setDisplayedViewMenuActionNames(newActions)
+pluginLogic.setDisplayedViewContextMenuActionNames(newActions)
 ```


### PR DESCRIPTION
Methods were renamed as part of recent work in 598dea0b5f2acadffde161111bc071eff0dc8b25.

`setDisplayedViewMenuActionNames` and `availableViewMenuActionNames` were originally added as part of 62fe31fb179e5c904f5d8157739483dee6669a44 which was included in Slicer v4.11.20200930 and v4.11.20210226.