### PR TITLE
BUG: Update CTK and PythonQt to fix installation of light-the-torch

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "9f12861724155f9929de9be8500c9eabd38507ac"
+    "e485a3fcecdffc2b40aaafbdbf9f470edf403354"
     QUIET
     )
 


### PR DESCRIPTION
This commit updates PythonQt to add support for `isatty` to `PythonQtStdInRedirect`.

List of changes:

```
$ git shortlog 9f128617..e485a3fc --no-merges
Jean-Christophe Fillion-Robin (1):
      BUG: Update PythonQt to fix installation of light-the-torch in Slicer
```

Fixes #5705

Co-authored-by: Andras Lasso <lasso@queensu.ca>
Co-authored-by: Fernando Perez-Garcia <fernando.perezgarcia.17@ucl.ac.uk>