### PR TITLE
COMP: Update VTK to improve support for extension bundling VTK modules

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -177,7 +177,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "f3c1a72fbf0f7287575ae876efced9c85776d9b4") # slicer-v9.0.20201111-733234c785
+    set(_git_tag "fe57670c3e136162713c40964ddf45a733d94532") # slicer-v9.0.20201111-733234c785
     set(vtk_egg_info_version "9.0.20201111")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
VTK modules can be built in the following scenarios:

1. Module sources and generated buildsystem are respectively in VTK source and build trees (aka built-in case)
2. Module sources are external and module generated buildsystem is in VTK build tree (aka built-in case for a VTK remote module)
3. Module sources and module generated buildsystem are both external
4. Module sources are in VTK source tree and module generated buildsystem is external

This commit updates VTK to include logic ensuring files are not generated
in VTK source for case (3) and (4).

List of changes:

```
$ git shortlog f3c1a72fbf..fe57670c3e --no-merges
Jean-Christophe Fillion-Robin (1):
      [Backport MR-8123] Do not generate files in source tree when building module externally
```