### PR TITLE
ENH: Add context managers to show while waiting

### DIFF
--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -200,15 +200,10 @@ class ScriptedLoadableModuleWidget:
     """Reload scripted module widget representation and call :func:`ScriptedLoadableModuleTest.runTest()`
     passing ``kwargs``.
     """
-    try:
+    with slicer.util.tryWithErrorDisplay("Reload and Test failed."):
       self.onReload()
       test = slicer.selfTests[self.moduleName]
       test(msec=int(slicer.app.userSettings().value("Developer/SelfTestDisplayMessageDelay")), **kwargs)
-    except Exception as e:
-      import traceback
-      traceback.print_exc()
-      errorMessage = "Reload and Test: Exception!\n\n" + str(e) + "\n\nSee Python Console for Stack Trace"
-      slicer.util.errorDisplay(errorMessage)
 
   def onEditSource(self):
     filePath = slicer.util.modulePath(self.moduleName)

--- a/Modules/Scripted/DICOMLib/DICOMSendDialog.py
+++ b/Modules/Scripted/DICOMLib/DICOMSendDialog.py
@@ -88,17 +88,12 @@ class DICOMSendDialog(qt.QDialog):
     self.cancelRequested = False
     okButton = self.bbox.button(self.bbox.Ok)
 
-    try:
-      #qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
+    with slicer.util.tryWithErrorDisplay("DICOM sending failed."):
       okButton.enabled = False
       DICOMLib.DICOMSender(self.files, address, protocol, aeTitle=aeTitle, progressCallback=self.onProgress)
       logging.debug("DICOM sending of %s files succeeded" % len(self.files))
       self.close()
-    except Exception as result:
-      import traceback
-      slicer.util.errorDisplay("DICOM sending failed: %s" % str(result), parent=self.parent().window(), detailedText=traceback.format_exc())
 
-    #qt.QApplication.restoreOverrideCursor()
     okButton.enabled = True
     self.sendingIsInProgress = False
 

--- a/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
+++ b/Modules/Scripted/DICOMPatcher/DICOMPatcher.py
@@ -128,8 +128,8 @@ class DICOMPatcherWidget(ScriptedLoadableModuleWidget):
     pass
 
   def onPatchButton(self):
-    slicer.app.setOverrideCursor(qt.Qt.WaitCursor)
-    try:
+    with slicer.util.tryWithErrorDisplay("Unexpected error.", waitCursor=True):
+
       import tempfile
       if not self.outputDirSelector.currentPath:
         self.outputDirSelector.currentPath =  tempfile.mkdtemp(prefix="DICOMPatcher-", dir=slicer.app.temporaryPath)
@@ -154,12 +154,6 @@ class DICOMPatcherWidget(ScriptedLoadableModuleWidget):
       if self.normalizeFileNamesCheckBox.checked:
         self.logic.addRule("NormalizeFileNames")
       self.logic.patchDicomDir(self.inputDirSelector.currentPath, self.outputDirSelector.currentPath)
-
-    except Exception as e:
-      self.addLog(f"Unexpected error: {str(e)}")
-      import traceback
-      traceback.print_exc()
-    slicer.app.restoreOverrideCursor()
 
   def onImportButton(self):
     self.logic.importDicomDir(self.outputDirSelector.currentPath)

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -182,7 +182,7 @@ class SegmentStatisticsWidget(ScriptedLoadableModuleWidget):
     """Calculate the label statistics
     """
 
-    try:
+    with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
       if not self.outputTableSelector.currentNode():
         newTable = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode")
         self.outputTableSelector.setCurrentNode(newTable)
@@ -201,14 +201,10 @@ class SegmentStatisticsWidget(ScriptedLoadableModuleWidget):
       self.logic.computeStatistics()
       self.logic.exportToTable(self.outputTableSelector.currentNode())
       self.logic.showTable(self.outputTableSelector.currentNode())
-    except Exception as e:
-      slicer.util.errorDisplay("Failed to compute statistics: "+str(e))
-      import traceback
-      traceback.print_exc()
-    finally:
-      # Unlock GUI
-      self.applyButton.setEnabled(True)
-      self.applyButton.text = "Apply"
+
+    # Unlock GUI
+    self.applyButton.setEnabled(True)
+    self.applyButton.text = "Apply"
 
   def onEditParameters(self, pluginName=None):
     """Open dialog box to edit plugin's parameters"""

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -267,7 +267,7 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     """
     Run processing when user clicks "Apply" button.
     """
-    try:
+    with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
 
       # Compute output
       self.logic.process(self.ui.inputSelector.currentNode(), self.ui.outputSelector.currentNode(),
@@ -278,12 +278,6 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # If additional output volume is selected then result with inverted threshold is written there
         self.logic.process(self.ui.inputSelector.currentNode(), self.ui.invertedOutputSelector.currentNode(),
           self.ui.imageThresholdSliderWidget.value, not self.ui.invertOutputCheckBox.checked, showResult=False)
-
-    except Exception as e:
-      slicer.util.errorDisplay("Failed to compute results: "+str(e))
-      import traceback
-      traceback.print_exc()
-
 
 #
 # TemplateKeyLogic


### PR DESCRIPTION
These are some potentially useful utils coming from https://github.com/fepegar/SlicerParcellation/blob/master/lib/GeneralUtils.py.

@lassoan's comments were:

> There is indeed some repeating code pattern with the waitcursor and printing of exception messages which would be nice to simplify. Please send a pull request to Slicer core with the content of GeneralUtils.py to start a discussion. Initial comment: the overridecursor has to be restored when an exception occurs ("finally" is too late because the popup window is displayed in "except" and it is not nice if the waitcursor is still shown when the user gets the error popup). messageContextManager: It seems that it is intended for progress reporting, but for thatyou can already use the statusbar or delaydisplay. A context manager for error messages could be more useful: it would take a general error message (that it would display if there is an exception) and would offer to show the exception text if user clicks "Details" button. Something like this: https://github.com/Slicer/Slicer/blob/aaa9f918a4ee4f35bf09e05c5d7e53d083b2e4e3/Modules/Scripted/DICOMLib/DICOMSendDialog.py#L91-L99

My replies:

> the overridecursor has to be restored when an exception occurs ("finally" is too late because the popup window is displayed in "except" and it is not nice if the waitcursor is still shown when the user gets the error popup)

I'm not sure which popup window you mean. Something created by the user? `showWaitCursor` doesn't show a popup window.

> messageContextManager: It seems that it is intended for progress reporting, but for that you can already use the statusbar or delaydisplay.

The status bar might not be very obvious. This is how I've used this in a module (0:35, here being played at x2): https://youtu.be/Gg02F9DGDc4?t=35. Not sure how I would use delayDisplay with the context manager. I wouldn't like buttons in the window.

> A context manager for error messages could be more useful: it would take a general error message (that it would display if there is an exception) and would offer to show the exception text if user clicks "Details" button. 

Thanks. I have added a `tryWithErrorDisplay` context manager.

Comments:

1. Maybe the names can be improved
1. The goal of these is two remove a bit of verbosity from users' code.
1. I imported `contextmanager` to be able to use the decorator. This seems forbidden in `slicer.util`, though. Another option is to use the class syntax for context managers. Why are all the imports inside the functions? Why are many of them in one line, this is against [PEP8](https://www.python.org/dev/peps/pep-0008/#imports).
1. Why is the file so long? Why not splitting it into different submodules and importing everything here if necessary?

Here are some snippets to try these:

```python
import time
import random

def work():
  time.sleep(random.randrange(1, 3))

def fail():
  work()
  int('Szia')

showThings = True

#
with showWaitCursor(show=showThings):
  work()

#
with showWaitCursor(show=showThings):
  fail()

#
with messageContextManager('¡Hola!', show=showThings):
  work()

#
with messageContextManager('¡Hola!', show=showThings):
  fail()

#
with tryWithErrorDisplay(show=showThings):
  work()

#
with tryWithErrorDisplay(show=showThings):
  fail()

#
getPythonConsoleWidget().show()
with peakPythonConsole(show=showThings):
  print('This should just wait a bit')
  slicer.app.processEvents()
  work()

# This one needs to be pasted with a blank line at the end so it runs
getPythonConsoleWidget().hide()
slicer.app.processEvents()
time.sleep(2)
with peakPythonConsole(show=showThings):
  print('I will close soon!')
  slicer.app.processEvents()
  work()


```