### PR TITLE
BUG: Improve performance of Grow from seeds Segment Editor effect

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorFillBetweenSlicesEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorFillBetweenSlicesEffect.py
@@ -44,3 +44,6 @@ The effect uses  <a href="http://insight-journal.org/browse/publication/977">mor
     interpolator.SetInputData(mergedImage)
     interpolator.Update()
     outputLabelmap.DeepCopy(interpolator.GetOutput())
+    imageToWorld = vtk.vtkMatrix4x4()
+    mergedImage.GetImageToWorldMatrix(imageToWorld)
+    outputLabelmap.SetImageToWorldMatrix(imageToWorld)

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorGrowFromSeedsEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorGrowFromSeedsEffect.py
@@ -127,4 +127,7 @@ The effect uses <a href="http://interactivemedical.org/imic2014/CameraReadyPaper
       self.clippedMasterImageData.GetDimensions()[2],
       time.time() - startTime))
 
-    outputLabelmap.DeepCopy( self.growCutFilter.GetOutput() )
+    outputLabelmap.DeepCopy(self.growCutFilter.GetOutput())
+    imageToWorld = vtk.vtkMatrix4x4()
+    mergedImage.GetImageToWorldMatrix(imageToWorld)
+    outputLabelmap.SetImageToWorldMatrix(imageToWorld)


### PR DESCRIPTION
On a large (400x400x1500) volume with 20 seed segments, Grow from seeds completed in about 50 second, but segment updates added about 30 seconds. There also seemed to be multiple updates for a single user action.

To avoid multiple updates, added previewComputationInProgress flag.
To reduce update time, preview segmentation is filled using ImportLabelmapToSegmentationNode method.

With the changes, initial update takes about 55 seconds, subsequent updates take about 11 seconds.

Remaining problems:
- It would be better to avoid temporary labelmap creation (if we keep this, then before importing we probably need to set the segmentation's parent transform to the labelmap).
- Final update is still slow.