### PR TITLE
ENH: "Apply to all segments" checkbox added in Segment Editor "Smoothing" effect

### DIFF
--- a/Docs/developer_guide/modules/segmenteditor.md
+++ b/Docs/developer_guide/modules/segmenteditor.md
@@ -83,6 +83,8 @@ Common parameters must be set using `setCommonParameter` method (others can be s
 | KernelSizeMm | float | no | 3.0 | >0.0 |
 | GaussianStandardDeviationMm | float | no | 3.0 | >0.0 |
 | JointTaubinSmoothingFactor | float | no | 0.5 | >0.0 |
+| ApplyToAllVisibleSegments | int | no | 0 | 0 or 1 |
+
 
 ### Threshold
 

--- a/Docs/user_guide/modules/segmenteditor.md
+++ b/Docs/user_guide/modules/segmenteditor.md
@@ -148,7 +148,10 @@ Grows or shrinks the selected segment by the specified margin.
 
 ### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_smoothing.png) Smoothing
 
-Smoothes selected labelmap or all labelmaps (only for Joint smoothing method).
+Smoothes, by default, the currently selected labelmap. 
+By checking `Apply to all segments`, all visible labelmaps in the Segment Editor will be smoothed from top to bottom. This operation may be time consuming. The progress will be shown as a Slicer status message.   
+
+The `Joint smoothing` method always smoothes all visible segments. 
 
 By clicking `Apply` button, the entire segmentation is smoothed.
 


### PR DESCRIPTION
Added a new checkbox and logic that enables serial smoothing of all visible segments currently open in the Segment Editor. If no segments are visible there is a logging message. The last selected segment gets restored.

The progress is shown as a statusmessage.