### PR TITLE
DOC: Fix popup help content for Subject Hierarchy usage in Data module

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyDefaultPlugin.cxx
@@ -148,9 +148,9 @@ const QString qSlicerSubjectHierarchyDefaultPlugin::helpText()const
     "</span>"
     "</p>"
     "<p style=\" margin-top:0px; margin-bottom:11px; margin-left:26px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">"
-    "<span style=\" font-size:8pt;\">"
-    "Make sure the transform column is shown using the 'Transforms' checkbox. "
-    "To transform a branch, double click on the cell in the transform column of the row in question, and choose a transform."
+    "<span style=\" font-family:'sans-serif'; font-size:9pt; color:#000000;\">"
+    "Make sure the transform column is shown using the 'Show transforms' checkbox. "
+    "To transform a branch, right-click on the cell in the transform column of the row in question, and choose a transform."
     "</span>"
     "</p>");
 }

--- a/Modules/Scripted/DICOMLib/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDICOMPlugin.cxx
+++ b/Modules/Scripted/DICOMLib/SubjectHierarchyPlugins/qSlicerSubjectHierarchyDICOMPlugin.cxx
@@ -227,7 +227,7 @@ const QString qSlicerSubjectHierarchyDICOMPlugin::helpText()const
     "</p>"
     "<p style=\" margin-top:0px; margin-bottom:11px; margin-left:26px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">"
     "<span style=\" font-family:'sans-serif'; font-size:9pt; color:#000000;\">"
-    "Right-click the empty area (or the top-level item 'Scene' if visible) and select 'Create new subject'."
+    "Right-click the top-level item 'Scene' (or the empty area if scene item is not visible) and select 'Create new subject'."
     "</span>"
     "</p>\n"
     "<p style=\" margin-top:4px; margin-bottom:1px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\">"


### PR DESCRIPTION
Update content of SH help pupup to reflect changes in the application. Fix style where inconsistent.

Before:
![image](https://user-images.githubusercontent.com/1325980/124385666-a4baa080-dcce-11eb-89c4-1ec66b543d6d.png)

After:
![image](https://user-images.githubusercontent.com/1325980/124385669-a71cfa80-dcce-11eb-8ff9-53f10fe01d87.png)
