### PR TITLE
BUG: Revert to previous markups placement behavior

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
@@ -456,3 +456,35 @@ vtkMRMLInteractionNode* vtkMRMLAbstractWidget::GetInteractionNode()
     }
   return viewNode->GetInteractionNode();
 }
+
+//---------------------------------------------------------------------------
+int vtkMRMLAbstractWidget::ProcessButtonClickEvent(vtkMRMLInteractionEventData* eventData)
+{
+  if (eventData->GetMouseMovedSinceButtonDown())
+    {
+    return false;
+    }
+
+  int clickEvent = 0;
+  switch (eventData->GetType())
+    {
+    case vtkCommand::LeftButtonReleaseEvent:
+      clickEvent = vtkMRMLInteractionEventData::LeftButtonClickEvent;
+      break;
+    case vtkCommand::MiddleButtonReleaseEvent:
+      clickEvent = vtkMRMLInteractionEventData::MiddleButtonClickEvent;
+      break;
+    case vtkCommand::RightButtonReleaseEvent:
+      clickEvent = vtkMRMLInteractionEventData::RightButtonClickEvent;
+      break;
+    default:
+      return false;
+    }
+
+  // Temporarily change the event ID to click, and process the event
+  int originalEventType = eventData->GetType();
+  eventData->SetType(clickEvent);
+  bool processedEvent = this->ProcessInteractionEvent(eventData);
+  eventData->SetType(originalEventType);
+  return processedEvent;
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.h
@@ -194,6 +194,10 @@ protected:
   unsigned long TranslateInteractionEventToWidgetEvent(
     vtkWidgetEventTranslator* translator, vtkMRMLInteractionEventData* eventData);
 
+  /// Generate a button click event and get it processed with ProcessInteractionEvent.
+  /// Returns true if the event was processed.
+  virtual int ProcessButtonClickEvent(vtkMRMLInteractionEventData* eventData);
+
   vtkWeakPointer<vtkRenderer> Renderer;
 
   vtkWeakPointer<vtkMRMLApplicationLogic> ApplicationLogic;

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
@@ -393,6 +393,11 @@ bool vtkMRMLCameraWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* e
       processedEvent = false;
     }
 
+  if (!processedEvent)
+    {
+    processedEvent = this->ProcessButtonClickEvent(eventData);
+    }
+
   if (processedEvent)
     {
     // invoke interaction event for compatibility with pre-camera-widget
@@ -464,7 +469,7 @@ bool vtkMRMLCameraWidget::ProcessStartMouseDrag(vtkMRMLInteractionEventData* eve
 }
 
 //-------------------------------------------------------------------------
-bool vtkMRMLCameraWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* vtkNotUsed(eventData))
+bool vtkMRMLCameraWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData)
 {
   if (this->Renderer && this->Renderer->GetRenderWindow() && this->Renderer->GetRenderWindow()->GetInteractor())
     {
@@ -483,7 +488,10 @@ bool vtkMRMLCameraWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* vtkNo
     return false;
     }
   this->SetWidgetState(WidgetStateIdle);
-  return true;
+
+  // only claim this as processed if the mouse was moved (this lets the event interpreted as button click)
+  bool processedEvent = eventData->GetMouseMovedSinceButtonDown();
+  return processedEvent;
 }
 
 //----------------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.cxx
@@ -63,6 +63,7 @@ vtkMRMLInteractionEventData::vtkMRMLInteractionEventData()
   this->InteractionContextName = "";
   this->ComponentType = -1;
   this->ComponentIndex = -1;
+  this->MouseMovedSinceButtonDown = true;
 }
 
 //---------------------------------------------------------------------------
@@ -219,6 +220,18 @@ void vtkMRMLInteractionEventData::SetComponentIndex(int componentIndex)
 int vtkMRMLInteractionEventData::GetComponentIndex() const
 {
   return this->ComponentIndex;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLInteractionEventData::SetMouseMovedSinceButtonDown(bool moved)
+{
+  this->MouseMovedSinceButtonDown = moved;
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLInteractionEventData::GetMouseMovedSinceButtonDown() const
+{
+  return this->MouseMovedSinceButtonDown;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
@@ -85,6 +85,9 @@ public:
   void SetComponentIndex(int componentIndex);
   int GetComponentIndex() const;
 
+  void SetMouseMovedSinceButtonDown(bool moved);
+  bool GetMouseMovedSinceButtonDown() const;
+
   void SetRotation(double v);
   double GetRotation() const;
   void SetLastRotation(double v);
@@ -124,6 +127,7 @@ protected:
   vtkCellPicker* AccuratePicker;
   int ComponentType;
   int ComponentIndex;
+  bool MouseMovedSinceButtonDown;
 
   //@{
   /// For KeyPressEvent

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -444,6 +444,11 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
       processedEvent = false;
     }
 
+  if (!processedEvent)
+    {
+    processedEvent = this->ProcessButtonClickEvent(eventData);
+    }
+
   return processedEvent;
 }
 
@@ -516,14 +521,17 @@ double vtkMRMLSliceIntersectionWidget::GetSliceRotationAngleRad(double eventPos[
 
 
 //-------------------------------------------------------------------------
-bool vtkMRMLSliceIntersectionWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* vtkNotUsed(eventData))
+bool vtkMRMLSliceIntersectionWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData)
 {
   if (this->WidgetState == WidgetStateIdle)
     {
     return false;
     }
   this->SetWidgetState(WidgetStateIdle);
-  return true;
+
+  // only claim this as processed if the mouse was moved (this lets the event interpreted as button click)
+  bool processedEvent = eventData->GetMouseMovedSinceButtonDown();
+  return processedEvent;
 }
 
 //-------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceViewInteractorStyle.cxx
@@ -116,6 +116,7 @@ bool vtkMRMLSliceViewInteractorStyle::DelegateInteractionEventToDisplayableManag
   int displayPositionCorrected[2] = { displayPositionInt[0] - pokedRenderer->GetOrigin()[0], displayPositionInt[1] - pokedRenderer->GetOrigin()[1] };
   ed->SetDisplayPosition(displayPositionCorrected);
   ed->SetWorldPosition(worldPosition);
+  ed->SetMouseMovedSinceButtonDown(this->MouseMovedSinceButtonDown);
   ed->SetAttributesFromInteractor(this->GetInteractor());
 
   // Update cursor position

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceViewInteractorStyle.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceViewInteractorStyle.h
@@ -105,11 +105,6 @@ protected:
 
   vtkMRMLSliceLogic *SliceLogic;
 
-  //bool MouseMovedSinceButtonDown;
-
-  //vtkSmartPointer<vtkTimerLog> ClickTimer;
-  //int NumberOfClicks;
-
   bool EnableCursorUpdate;
 
 private:

--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
@@ -95,6 +95,7 @@ bool vtkMRMLThreeDViewInteractorStyle::DelegateInteractionEventToDisplayableMana
     // set "inaccurate" world position
     ed->SetWorldPosition(worldPosition, false);
     }
+  ed->SetMouseMovedSinceButtonDown(this->MouseMovedSinceButtonDown);
   ed->SetAccuratePicker(this->AccuratePicker);
   ed->SetRenderer(this->CurrentRenderer);
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -310,6 +310,7 @@ bool vtkMRMLViewInteractorStyle::DelegateInteractionEventToDisplayableManagers(v
   ed->SetType(inputEventData ? inputEventData->GetType() : vtkCommand::NoEvent);
   int displayPositionCorrected[2] = { displayPositionInt[0] - pokedRenderer->GetOrigin()[0], displayPositionInt[1] - pokedRenderer->GetOrigin()[1] };
   ed->SetDisplayPosition(displayPositionCorrected);
+  ed->SetMouseMovedSinceButtonDown(this->MouseMovedSinceButtonDown);
   ed->SetAttributesFromInteractor(this->GetInteractor());
   vtkEventDataDevice3D* inputEventDataDevice3D = inputEventData->GetAsEventDataDevice3D();
   if (inputEventDataDevice3D)
@@ -452,27 +453,6 @@ void vtkMRMLViewInteractorStyle::CustomProcessEvents(vtkObject* object,
     {
     // Displayable managers did not processed it
     Superclass::ProcessEvents(object, event, clientdata, calldata);
-    }
-
-  // VTK does not provide click events, detect and invoke them here
-  if (event == vtkCommand::LeftButtonReleaseEvent
-    || event == vtkCommand::MiddleButtonReleaseEvent
-    || event == vtkCommand::RightButtonReleaseEvent)
-    {
-    // invoke a mouse move event to ensure that widget states are updated for the current position when the mouse button is released
-    self->DelegateInteractionEventToDisplayableManagers(vtkCommand::MouseMoveEvent);
-    // invoke click event if mouse did not move since last button down
-    if (!self->MouseMovedSinceButtonDown)
-      {
-      unsigned long clickEvent = 0;
-      switch (event)
-        {
-        case vtkCommand::LeftButtonReleaseEvent: clickEvent = vtkMRMLInteractionEventData::LeftButtonClickEvent; break;
-        case vtkCommand::MiddleButtonReleaseEvent: clickEvent = vtkMRMLInteractionEventData::MiddleButtonClickEvent; break;
-        case vtkCommand::RightButtonReleaseEvent: clickEvent = vtkMRMLInteractionEventData::RightButtonClickEvent; break;
-        };
-      self->DelegateInteractionEventToDisplayableManagers(clickEvent);
-      }
     }
 }
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -54,8 +54,10 @@ vtkSlicerMarkupsWidget::vtkSlicerMarkupsWidget()
   this->PreviewPointIndex = -1;
 
   // Place
-  this->SetEventTranslation(WidgetStateDefine, vtkMRMLInteractionEventData::LeftButtonClickEvent, vtkEvent::NoModifier, WidgetEventControlPointPlace);
-  this->SetEventTranslation(WidgetStateDefine, vtkMRMLInteractionEventData::RightButtonClickEvent, vtkEvent::NoModifier, WidgetEventStopPlace);
+  this->SetEventTranslation(WidgetStateDefine, vtkCommand::LeftButtonPressEvent, vtkEvent::NoModifier, WidgetEventReserved);
+  this->SetEventTranslation(WidgetStateDefine, vtkCommand::LeftButtonReleaseEvent, vtkEvent::NoModifier, WidgetEventControlPointPlace);
+  this->SetEventTranslation(WidgetStateDefine, vtkCommand::RightButtonPressEvent, vtkEvent::NoModifier, WidgetEventReserved);
+  this->SetEventTranslation(WidgetStateDefine, vtkCommand::RightButtonReleaseEvent, vtkEvent::NoModifier, WidgetEventStopPlace);
 
   // Manipulate
   this->SetEventTranslationClickAndDrag(WidgetStateOnWidget, vtkCommand::LeftButtonPressEvent, vtkEvent::NoModifier,
@@ -70,6 +72,8 @@ vtkSlicerMarkupsWidget::vtkSlicerMarkupsWidget()
   this->SetEventTranslation(WidgetStateOnWidget, vtkMRMLInteractionEventData::LeftButtonClickEvent, vtkEvent::NoModifier, WidgetEventJumpCursor);
   this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::LeftButtonDoubleClickEvent, vtkEvent::NoModifier, WidgetEventAction);
 
+  this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::RightButtonPressEvent, vtkEvent::NoModifier, WidgetEventReserved);
+  this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::RightButtonReleaseEvent, vtkEvent::NoModifier, WidgetEventReserved);
   this->SetEventTranslation(WidgetStateOnWidget, vtkMRMLInteractionEventData::RightButtonClickEvent, vtkEvent::NoModifier, WidgetEventMenu);
 
   // Update active component
@@ -279,7 +283,7 @@ bool vtkSlicerMarkupsWidget::ProcessMouseMove(vtkMRMLInteractionEventData* event
 }
 
 //-------------------------------------------------------------------------
-bool vtkSlicerMarkupsWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* vtkNotUsed(eventData))
+bool vtkSlicerMarkupsWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData)
 {
   if (!this->WidgetRep)
     {
@@ -314,7 +318,10 @@ bool vtkSlicerMarkupsWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* vt
     }
 
   this->EndWidgetInteraction();
-  return true;
+
+  // only claim this as processed if the mouse was moved (this lets the event interpreted as button click)
+  bool processedEvent = eventData->GetMouseMovedSinceButtonDown();
+  return processedEvent;
 }
 
 //-------------------------------------------------------------------------
@@ -765,6 +772,11 @@ bool vtkSlicerMarkupsWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData
     case WidgetEventJumpCursor:
       processedEvent = ProcessWidgetJumpCursor(eventData);
       break;
+    }
+
+  if (!processedEvent)
+    {
+    processedEvent = this->ProcessButtonClickEvent(eventData);
     }
 
   return processedEvent;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
@@ -78,6 +78,7 @@ public:
     WidgetEventControlPointDelete,
     WidgetEventControlPointInsert,
     WidgetEventControlPointSnapToSlice,
+    WidgetEventReserved,  // this events is only to prevent other widgets from processing an event
     WidgetEventMarkups_Last
   };
 

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -2187,7 +2187,7 @@ if (clipboardText.contains("\t"))
 
 // SetPointFromString calls various events reporting the id of the point modified.
 // However, already for > 200 points, it gets bad performance. Therefore, we call a simply modified call at the end.
-d->MarkupsNode->DisableModifiedEventOn();
+MRMLNodeModifyBlocker blocker(d->MarkupsNode);
 foreach(QString line, lines)
   {
   line = line.trimmed();
@@ -2196,13 +2196,8 @@ foreach(QString line, lines)
     // empty line or comment line
     continue;
     }
-
   storageNode->SetPointFromString(d->MarkupsNode, d->MarkupsNode->GetNumberOfControlPoints(), line.toUtf8());
   }
-d->MarkupsNode->DisableModifiedEventOff();
-d->MarkupsNode->Modified();
-int n = d->MarkupsNode->GetNumberOfControlPoints() - 1;
-d->MarkupsNode->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::PointModifiedEvent, static_cast<void*>(&n));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
For a long time, markup control points were placed on mouse button press. A week ago we changed the implementation to place a point on click (no mouse move between button press and release), which several users did not like because it required the users to pause while placing points (instead of keep placing points while moving the mouse). See more details here: https://discourse.slicer.org/t/feedback-requested-requirements-to-place-a-fiducial/18407

The only difference is that now point position is finalized on button release (instead of button press) to be consistent with drawing behavior of other software (Microsoft Office, Inkscape, Gimp, etc.).

fixes #5713