### PR TITLE
ENH: "Apply to all segments" checkboxes added in Segment Editor "Hollow" and "Margin" effect

### DIFF
--- a/Docs/developer_guide/modules/segmenteditor.md
+++ b/Docs/developer_guide/modules/segmenteditor.md
@@ -21,35 +21,37 @@ Common parameters must be set using `setCommonParameter` method (others can be s
 
 ### Hollow
 
-| Parameter | Type | Common | Default | Values |
-|-|-|-|-|-|
-| ShellMode | enum | no | INSIDE_SURFACE | INSIDE_SURFACE, MEDIAL_SURFACE, OUTSIDE_SURFACE |
-| ShellThicknessMm | float | no | 3.0 | >0.0 |
-| BypassMasking | int | no |  | 0 or 1 |
+| Parameter                 | Type  | Common | Default        | Values                     |
+|---------------------------|-------|--------|----------------|----------------------------|
+| ApplyToAllVisibleSegments | int   | no     | 0              | 0 or 1                     |
+| ShellMode                 | enum  | no     | INSIDE_SURFACE | INSIDE_SURFACE, MEDIAL_SURFACE, OUTSIDE_SURFACE |
+| ShellThicknessMm          | float | no     | 3.0            | >0.0                       |
+| BypassMasking             | int   | no     | 0              | 0 or 1                     |
 
 ### Islands
 
-| Parameter | Type | Common | Default | Values |
-|-|-|-|-|-|
-| Operation | enum | no | KEEP_LARGEST_ISLAND | KEEP_LARGEST_ISLAND, KEEP_SELECTED_ISLAND, REMOVE_SMALL_ISLANDS, REMOVE_SELECTED_ISLAND, ADD_SELECTED_ISLAND, SPLIT_ISLANDS_TO_SEGMENTS |
-| MinimumSize | int | no | 1000 | >0 |
-| BypassMasking | int | no |  | 0 or 1 |
+| Parameter     | Type | Common | Default             | Values |
+|---------------|------|--------|---------------------|--------|
+| Operation     | enum | no     | KEEP_LARGEST_ISLAND | KEEP_LARGEST_ISLAND, KEEP_SELECTED_ISLAND, REMOVE_SMALL_ISLANDS, REMOVE_SELECTED_ISLAND, ADD_SELECTED_ISLAND, SPLIT_ISLANDS_TO_SEGMENTS |
+| MinimumSize   | int  | no     | 1000                | >0     |
+| BypassMasking | int  | no     | 0                   | 0 or 1 |
 
 ### Logical operators
 
-| Parameter | Type | Common | Default | Values |
-|-|-|-|-|-|
-| Operation | enum | no | COPY | COPY, UNION, INTERSECT, SUBTRACT, INVERT, CLEAR, FILL |
-| ModifierSegmentID | string | no |  | segment ID |
-| BypassMasking | int | no |  | 0 or 1 |
+| Parameter                 | Type   | Common | Default | Values                     |
+|---------------------------|--------|--------|---------|----------------------------|
+| Operation                 | enum   | no     | COPY    | COPY, UNION, INTERSECT, SUBTRACT, INVERT, CLEAR, FILL |
+| ModifierSegmentID         | string | no     |         | segment ID                 |
+| BypassMasking             | int    | no     | 0       | 0 or 1                     |
 
 ### Margin
 
-| Parameter        | Type  | Common | Default | Values                     |
-|------------------|-------|--------|---------|----------------------------|
-| MarginSizeMm     | float | no     | 3.0     | <0.0 (shrink), >0.0 (grow) |
-| ShellThicknessMm | float | no     | 3.0     | >0.0                       |
-| BypassMasking    | int   | no     |         | 0 or 1                     |
+| Parameter                 | Type  | Common | Default | Values                     |
+|---------------------------|-------|--------|---------|----------------------------|
+| ApplyToAllVisibleSegments | int   | no     | 0       | 0 or 1                     |
+| MarginSizeMm              | float | no     | 3.0     | <0.0 (shrink), >0.0 (grow) |
+| ShellThicknessMm          | float | no     | 3.0     | >0.0                       |
+| BypassMasking             | int   | no     |         | 0 or 1                     |
 
 ### Paint effect and Erase effect
 
@@ -68,35 +70,35 @@ Common parameters must be set using `setCommonParameter` method (others can be s
 
 ### Scissors
 
-| Parameter | Type | Common | Default | Values |
-|-|-|-|-|-|
-| Operation | enum | no | EraseInside | EraseInside, EraseOutside, FillInside, FillOutside |
-| Shape | enum | no | FreeForm | FreeForm, Circle, Rectangle |
-| SliceCutMode | enum | no | Unlimited | Unlimited, Positive, Negative, Symmetric |
-| SliceCutDepthMm | float | no | 0.0 | >=0.0 (single slice = 0.0) |
+| Parameter                 | Type  | Common | Default     | Values                                             |
+|---------------------------|-------|--------|-------------|----------------------------------------------------|
+| ApplyToAllVisibleSegments | int   | no     | 0           | 0 or 1                                             |
+| Operation                 | enum  | no     | EraseInside | EraseInside, EraseOutside, FillInside, FillOutside |
+| Shape                     | enum  | no     | FreeForm    | FreeForm, Circle, Rectangle                        |
+| SliceCutMode              | enum  | no     | Unlimited   | Unlimited, Positive, Negative, Symmetric           |
+| SliceCutDepthMm           | float | no     | 0.0         | >=0.0 (single slice = 0.0)                         |
 
 ### Smoothing
 
-| Parameter | Type | Common | Default | Values |
-|-|-|-|-|-|
-| SmoothingMethod | enum | no | MEDIAN | MEDIAN, GAUSSIAN, MORPHOLOGICAL_OPENING, MORPHOLOGICAL_CLOSING, JOINT_TAUBIN |
-| KernelSizeMm | float | no | 3.0 | >0.0 |
-| GaussianStandardDeviationMm | float | no | 3.0 | >0.0 |
-| JointTaubinSmoothingFactor | float | no | 0.5 | >0.0 |
-| ApplyToAllVisibleSegments | int | no | 0 | 0 or 1 |
-
+| Parameter                   | Type  | Common | Default | Values                     |
+|-----------------------------|-------|--------|---------|----------------------------|
+| ApplyToAllVisibleSegments   | int   | no     | 0       | 0 or 1                     |
+| SmoothingMethod             | enum  | no     | MEDIAN  | MEDIAN, GAUSSIAN, MORPHOLOGICAL_OPENING, MORPHOLOGICAL_CLOSING, JOINT_TAUBIN |
+| KernelSizeMm                | float | no     | 3.0     | >0.0                       |
+| GaussianStandardDeviationMm | float | no     | 3.0     | >0.0                       |
+| JointTaubinSmoothingFactor  | float | no     | 0.5     | >0.0                       |
 
 ### Threshold
 
-| Parameter | Type | Common | Default | Values |
-|-|-|-|-|-|
-| AutoThresholdMethod | enum | no | OTSU | HUANG, INTERMODES, ISO_DATA, KITTLER_ILLINGWORTH, LI, MAXIMUM_ENTROPY, MOMENTS, OTSU, RENYI_ENTROPY, SHANBHAG, TRIANGLE, YEN |
-| MinimumThreshold | float | no | 25th percentile voxel value |  |
-| MaximumThreshold | float | no | maximum voxel value |  |
-| AutoThresholdMode | enum | no | SET_LOWER_MAX | SET_LOWER_MAX, SET_UPPER, SET_LOWER, SET_MIN_UPPER |
-| BrushType | enum | no | CIRCLE | CIRCLE, BOX, DRAW, LINE |
-| HistogramSetLower | enum | no | LOWER | MINIMUM, LOWER, AVERAGE |
-| HistogramSetUpper | enum | no | UPPER | AVERAGE, UPPER, MAXIMUM |
+| Parameter           | Type  | Common | Default                     | Values                  |
+|---------------------|-------|--------|-----------------------------|-------------------------|
+| AutoThresholdMethod | enum  | no     | OTSU                        | HUANG, INTERMODES, ISO_DATA, KITTLER_ILLINGWORTH, LI, MAXIMUM_ENTROPY, MOMENTS, OTSU, RENYI_ENTROPY, SHANBHAG, TRIANGLE, YEN |
+| MinimumThreshold    | float | no     | 25th percentile voxel value |                         |
+| MaximumThreshold    | float | no     | maximum voxel value         |                         |
+| AutoThresholdMode   | enum  | no     | SET_LOWER_MAX               | SET_LOWER_MAX, SET_UPPER, SET_LOWER, SET_MIN_UPPER |
+| BrushType           | enum  | no     | CIRCLE                      | CIRCLE, BOX, DRAW, LINE |
+| HistogramSetLower   | enum  | no     | LOWER                       | MINIMUM, LOWER, AVERAGE |
+| HistogramSetUpper   | enum  | no     | UPPER                       | AVERAGE, UPPER, MAXIMUM |
 
 ## Examples
 

--- a/Docs/user_guide/modules/segmenteditor.md
+++ b/Docs/user_guide/modules/segmenteditor.md
@@ -55,6 +55,10 @@ The following keyboard shortcuts are active when you are in the Editor module.  
 
 Effects operate either by clicking the Apply button in the effect options section or by clicking and/or dragging in slice or 3D views.
 
+### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_threshold.png) Threshold
+
+Use Threshold to determine a threshold range and save results to selected segment or use it as Editable intensity range.
+
 ### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_paint.png) Paint
 
 - Pick the radius (in millimeters) of the brush to apply
@@ -138,24 +142,25 @@ Notes:
 - The method does not use the master volume, only the shape of the specified segments.
 - The method uses ND morphological contour interpolation algorithm. See details here: http://insight-journal.org/browse/publication/977
 
-### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_threshold.png) Threshold
-
-Use Threshold to determine a threshold range and save results to selected segment or use it as Editable intensity range.
-
 ### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_margin.png) Margin
 
 Grows or shrinks the selected segment by the specified margin.
 
+By enabling `Apply to all segments`, all visible segments of the segmentation will be processed (in the order of the segment list).
+
+### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_hollow.png) Hollow
+
+Makes the selected visible segment hollow by replacing the segment with a uniform-thickness shell defined by the segment boundary.
+
+By enabling `Apply to all segments`, all visible segments of the segmentation will be processed (in the order of the segment list).
+
 ### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_smoothing.png) Smoothing
 
-Smoothes, by default, the currently selected labelmap. 
-By checking `Apply to all segments`, all visible labelmaps in the Segment Editor will be smoothed from top to bottom. This operation may be time consuming. The progress will be shown as a Slicer status message.   
+Smoothes segments by filling in holes and/or removing extrusions.
 
-The `Joint smoothing` method always smoothes all visible segments. 
+By default, the current segment will be smoothed. By enabling `Apply to all segments`, all visible segments of the segmentation will be smoothed (in the order of the segment list). This operation may be time-consuming for complex segmentations. The `Joint smoothing` method always smoothes all visible segments.
 
-By clicking `Apply` button, the entire segmentation is smoothed.
-
-To smooth a specific region, left click and drag in any slice or 3D view. Same smoothing method and strength is used as for the whole-segmentation mode (size of the brush does not affect smoothing strength, just makes it easier to designate a larger region).
+By clicking `Apply` button, the entire segmentation is smoothed. To smooth a specific region, left click and drag in any slice or 3D view. Same smoothing method and strength is used as for the whole-segmentation mode (size of the brush does not affect smoothing strength, just makes it easier to designate a larger region).
 
 Available methods:
 - Median: removes small extrusions and fills small gaps while keeps smooth contours mostly unchanged. Applied to selected segment only.</li>
@@ -170,6 +175,8 @@ Clip segments to the specified region or fill regions of a segment (typically us
 
 - Left click to start drawing (free-form or rubber band circle or rectangle)
 - Release button to apply
+
+By enabling `Apply to all segments`, all visible segments of the segmentation will be processed (in the order of the segment list).
 
 ### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_islands.png) Islands
 

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
@@ -106,10 +106,11 @@ If segments overlap, segment higher in the segments table will have priority. <b
     self.scriptedEffect.addOptionsWidget(self.paintOptionsGroupBox)
 
   def setMRMLDefaults(self):
-    self.scriptedEffect.setParameterDefault("SmoothingMethod", MEDIAN)
-    self.scriptedEffect.setParameterDefault("KernelSizeMm", 3)
+    self.scriptedEffect.setParameterDefault("ApplyToAllVisibleSegments", 0)
     self.scriptedEffect.setParameterDefault("GaussianStandardDeviationMm", 3)
     self.scriptedEffect.setParameterDefault("JointTaubinSmoothingFactor", 0.5)
+    self.scriptedEffect.setParameterDefault("KernelSizeMm", 3)
+    self.scriptedEffect.setParameterDefault("SmoothingMethod", MEDIAN)
 
   def updateParameterWidgetsVisibility(self):
     methodIndex = self.methodSelectorComboBox.currentIndex
@@ -122,6 +123,8 @@ If segments overlap, segment higher in the segments table will have priority. <b
     self.gaussianStandardDeviationMMSpinBox.setVisible(smoothingMethod==GAUSSIAN)
     self.jointTaubinSmoothingFactorLabel.setVisible(smoothingMethod==JOINT_TAUBIN)
     self.jointTaubinSmoothingFactorSlider.setVisible(smoothingMethod==JOINT_TAUBIN)
+    self.applyToAllVisibleSegmentsLabel.setVisible(smoothingMethod!=JOINT_TAUBIN)
+    self.applyToAllVisibleSegmentsCheckBox.setVisible(smoothingMethod!=JOINT_TAUBIN)
 
   def getKernelSizePixel(self):
     selectedSegmentLabelmapSpacing = [1.0, 1.0, 1.0]
@@ -173,7 +176,6 @@ If segments overlap, segment higher in the segments table will have priority. <b
     applyToAllVisibleSegments = 1 if self.applyToAllVisibleSegmentsCheckBox.isChecked() else 0
     self.scriptedEffect.setParameter("ApplyToAllVisibleSegments", applyToAllVisibleSegments)
 
-
     self.updateParameterWidgetsVisibility()
 
 
@@ -218,7 +220,7 @@ If segments overlap, segment higher in the segments table will have priority. <b
           return
         for index in range(inputSegmentIDs.GetNumberOfValues()):
           segmentID = inputSegmentIDs.GetValue(index)
-          self.showStatusMessage(f'Smoothing {segmentID} ...')
+          self.showStatusMessage(f'Smoothing {segmentationNode.GetSegmentation().GetSegment(segmentID).GetName()}...')
           segmentEditorNode.SetSelectedSegmentID(segmentID)
           self.smoothSelectedSegment(maskImage, maskExtent)
         # restore segment selection


### PR DESCRIPTION
Added new checkboxes and logic that enables serial hollowing as well as growing and shrinking (Margin) of all visible segments currently open in the Segment Editor. If no segments are visible there is a logging message. The last segment selection gets restored.

The progress is shown as a status message.

User Documentation Hollow not yet found. 

This pull request contains 5 changed files, but only two are needed (SegmentEditorHollowEffect and SegmentEditorMarginEffect). Sorry for this