### PR TITLE
BUG: Fix plot export to svg

### DIFF
--- a/Docs/developer_guide/script_repository/plots.md
+++ b/Docs/developer_guide/script_repository/plots.md
@@ -58,16 +58,8 @@ slicer.modules.plots.logic().ShowChartInLayout(plotChartNode)
 ### Save a plot as vector graphics (.svg)
 
 ```python
-filename = "c:/tmp/test.svg"
-plotWidgetIndex = 0
-layoutManager = slicer.app.layoutManager()
-renderWindow = layoutManager.plotWidget(plotWidgetIndex).plotView().renderWindow()
-exp = vtk.vtkGL2PSExporter()
-exp.SetRenderWindow(renderWindow)
-exp.CompressOff()
-exp.SetFileFormatToSVG()
-exp.SetFilePrefix(filename[:-4]) # file prefix expects filename without extension
-exp.Write()
+plotView = slicer.app.layoutManager().plotWidget(0).plotView()
+plotView.saveAsSVG("c:/tmp/test.svg")
 ```
 
 ### Using matplotlib

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLPlotViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLPlotViewControllerWidget.ui
@@ -46,12 +46,12 @@
           </widget>
         </item>
         <item>
-          <widget class="QPushButton" name="savePushButton">
+          <widget class="QPushButton" name="exportPushButton">
            <property name="toolTip">
-            <string>Save plot as SVG file</string>
+            <string>Export plot to SVG file</string>
            </property>
            <property name="text">
-            <string>Save</string>
+            <string>Export...</string>
            </property>
           </widget>
         </item>

--- a/Libs/MRML/Widgets/qMRMLPlotView.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotView.cxx
@@ -19,6 +19,7 @@
 
 // Qt includes
 #include <QDebug>
+#include <QDir>
 #include <QEvent>
 #include <QFileInfo>
 #include <QHBoxLayout>
@@ -1118,10 +1119,12 @@ void qMRMLPlotView::updateMRMLChartAxisRangeFromWidget()
 }
 
 // ----------------------------------------------------------------------------
-void qMRMLPlotView::saveAsSVG(const QString &filePathPrefix)
+void qMRMLPlotView::saveAsSVG(const QString & fileName)
 {
-  vtkNew<vtkGL2PSExporter> exporter;
+  QFileInfo fileInfo(fileName);
+  QString filePathPrefix = fileInfo.absoluteDir().filePath(fileInfo.completeBaseName());
 
+  vtkNew<vtkGL2PSExporter> exporter;
   exporter->SetFileFormatToSVG();
   exporter->CompressOff();
   exporter->SetRenderWindow(this->renderWindow());

--- a/Libs/MRML/Widgets/qMRMLPlotView.h
+++ b/Libs/MRML/Widgets/qMRMLPlotView.h
@@ -76,9 +76,10 @@ public slots:
   /// Unselect all the points
   void RemovePlotSelections();
 
-  /// save the current plot as svg
-  void saveAsSVG(const QString &filePathPrefix);
-
+  /// Save the current plot as vector graphics, in svg file format.
+  /// Note that regardless of the file extension in the input fileName,
+  /// the extension of the created file will always be ".svg".
+  void saveAsSVG(const QString &fileName);
 
 signals:
 

--- a/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
@@ -100,7 +100,7 @@ void qMRMLPlotViewControllerWidgetPrivate::setupPopupUi()
   this->connect(this->interactionModeComboBox, SIGNAL(currentIndexChanged(int)), SLOT(onInteractionModeChanged(int)));
   QObject::connect(this->actionFit_to_window, SIGNAL(triggered()), q, SLOT(fitPlotToAxes()));
 
-  QObject::connect(this->savePushButton, SIGNAL(clicked()), q, SLOT(onSaveButton()));
+  QObject::connect(this->exportPushButton, SIGNAL(clicked()), q, SLOT(onExportButton()));
 
   // Connect the scene
   QObject::connect(q, SIGNAL(mrmlSceneChanged(vtkMRMLScene*)), this->plotChartComboBox, SLOT(setMRMLScene(vtkMRMLScene*)));
@@ -319,7 +319,7 @@ void qMRMLPlotViewControllerWidget::fitPlotToAxes()
 }
 
 //---------------------------------------------------------------------------
-void qMRMLPlotViewControllerWidget::onSaveButton()
+void qMRMLPlotViewControllerWidget::onExportButton()
 {
   Q_D(qMRMLPlotViewControllerWidget);
   if(!d->PlotView || !d->PlotViewNode)
@@ -339,9 +339,7 @@ void qMRMLPlotViewControllerWidget::onSaveButton()
     name, tr("Scalable Vector Graphics (*.svg)"));
   if (!fileName.isEmpty())
     {
-    QFileInfo fileInfo(fileName);
-    QString filePathPrefix = fileInfo.absoluteFilePath() + "/" + fileInfo.completeBaseName();
-    d->PlotView->saveAsSVG(filePathPrefix);
+    d->PlotView->saveAsSVG(fileName);
     }
 }
 

--- a/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.h
@@ -72,7 +72,7 @@ public slots:
   void fitPlotToAxes();
 
   /// Save the selected plot to a file
-  void onSaveButton();
+  void onExportButton();
 
 protected slots:
   void updateWidgetFromMRML();


### PR DESCRIPTION
Filename was not computed correctly.
Use "Export" instead of "Save" because it is a lossy operation (we do not save the plot, just the appearance).