### PR TITLE
BUG: Fix the check for 3D while tool logic is 2D in levelTracing tool

### DIFF
--- a/Libs/vtkITK/itkLevelTracingImageFilter.txx
+++ b/Libs/vtkITK/itkLevelTracingImageFilter.txx
@@ -338,11 +338,14 @@ LevelTracingImageFilter<TInputImage,TOutputImage>
     offsetY = neighbors[zeroIndex][1];
     pixTemp[0] = pix[0] + offsetX;
     pixTemp[1] = pix[1] + offsetY;
-    val = inputImage->GetPixel(pixTemp);
-    if(val < threshold)
+    if(region.IsInside(pixTemp))
       {
-      found = true;
-      break;
+      val = inputImage->GetPixel(pixTemp);
+      if(val < threshold)
+        {
+        found = true;
+        break;
+        }
       }
     }
 
@@ -360,11 +363,14 @@ LevelTracingImageFilter<TInputImage,TOutputImage>
       offsetY = neighbors[zeroIndex][1];
       pixTemp[0] = pix[0] + offsetX;
       pixTemp[1] = pix[1] + offsetY;
-      val = inputImage->GetPixel(pixTemp);
-      if(val < threshold)
+      if(region.IsInside(pixTemp))
         {
-        found = true;
-        break;
+        val = inputImage->GetPixel(pixTemp);
+        if(val < threshold)
+          {
+          found = true;
+          break;
+          }
         }
       }
 

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLevelTracingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorLevelTracingEffect.py
@@ -163,11 +163,6 @@ class LevelTracingPipeline:
     ijk = self.effect.xyToIjk(xy, self.sliceWidget, masterImageData, parentTransformNode)
     dimensions = masterImageData.GetDimensions()
 
-    for index in range(3):
-      # TracingFilter crashes if it receives a seed point at the edge of the image,
-      # so only accept the point if it is inside the image and is at least one pixel away from the edge
-      if ijk[index] < 1 or ijk[index] >= dimensions[index]-1:
-        return
     self.tracingFilter.SetInputData(masterImageData)
     self.tracingFilter.SetSeed(ijk)
 


### PR DESCRIPTION
LevelTracing is implemented in 2D and should work on the first and last slicer; however, there is a check that doesn't allow this for when only one slice is available (drag and drop of one dicom file)


For context see: https://discourse.slicer.org/t/level-tracing-on-a-single-slice-from-a-3d-volume/16693/4