### PR TITLE
BUG: Fix RedGreenBlue color node range

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLColorLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLColorLogic.cxx
@@ -528,9 +528,9 @@ vtkMRMLProceduralColorNode* vtkMRMLColorLogic::CreateRedGreenBlueNode()
   procNode->SetDescription("A color transfer function that maps from -6 to 6, red through green to blue");
   vtkColorTransferFunction *func = procNode->GetColorTransferFunction();
   func->SetColorSpaceToRGB();
-  func->AddRGBPoint(-6.0, 1.0, 0.0, 0.0);
-  func->AddRGBPoint(0.0, 0.0, 1.0, 0.0);
-  func->AddRGBPoint(6.0, 0.0, 0.0, 1.0);
+  func->AddRGBPoint(0.0, 1.0, 0.0, 0.0);
+  func->AddRGBPoint(127.5, 0.0, 1.0, 0.0);
+  func->AddRGBPoint(255.0, 0.0, 0.0, 1.0);
 
   procNode->SetNamesFromColors();
 


### PR DESCRIPTION
The scalar range of the RedGreenBlue color table was previously set to (-6.0, 6.0), which caused problems when trying to render volumes that were mapped to (0, 255).
Fixed by changing the scalar range of the RedGreenBlue volume to (0.0, 255.0).

Re #5336