### PR TITLE
BUG: Fix customization of view context menu

### DIFF
--- a/Docs/developer_guide/script_repository/subjecthierarchy.md
+++ b/Docs/developer_guide/script_repository/subjecthierarchy.md
@@ -165,8 +165,11 @@ When right-clicking certain types of nodes in the 2D/3D views, a subject hierarc
 ```python
 pluginHandler = slicer.qSlicerSubjectHierarchyPluginHandler.instance()
 pluginLogic = pluginHandler.pluginLogic()
-menuActions = pluginLogic.availableViewContextMenuActionNames()
-# Returns ("RenamePointAction", "DeletePointAction", "ToggleSelectPointAction", "EditPropertiesAction")
-newActions = ["RenamePointAction"]
-pluginLogic.setDisplayedViewContextMenuActionNames(newActions)
+
+# Display list of all available view context menu action names.
+# This will print something like this: 'EditPropertiesAction', 'MouseModeViewTransformAction', 'MouseModeAdjustWindowLevelAction', 'MouseModePlaceAction', ...).
+print(pluginLogic.registeredViewContextMenuActionNames)
+
+# Hide all the other menu items and show only "Rename point":
+pluginLogic.allowedViewContextMenuActionNames = ["RenamePointAction"]
 ```

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -184,6 +184,7 @@ void qSlicerSubjectHierarchyMarkupsPluginPrivate::init()
   this->HandleVisibilityMenu->addAction(this->ToggleScaleHandleVisible);
 
   this->HandleVisibilityAction = new QAction("Interaction options");
+  this->HandleVisibilityAction->setObjectName("HandleInteractionOptions");
   q->setActionPosition(this->HandleVisibilityAction, interactionHandlesSection);
   this->HandleVisibilityAction->setMenu(this->HandleVisibilityMenu);
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
@@ -30,6 +30,7 @@
 #include "vtkSlicerSubjectHierarchyModuleLogic.h"
 
 // Qt includes
+#include <QAction>
 #include <QDebug>
 #include <QStringList>
 #include <QInputDialog>
@@ -146,6 +147,11 @@ bool qSlicerSubjectHierarchyPluginHandler::registerPlugin(qSlicerSubjectHierarch
     {
     foreach(QAction* action, pluginToRegister->viewContextMenuActions())
       {
+      if (action != nullptr && action->objectName().isEmpty())
+        {
+        qWarning() << Q_FUNC_INFO << ": view context menu action name is not set for "
+          << action->text() << ", provided subject hierarchy by plugin " << pluginToRegister->name();
+        }
       this->m_PluginLogic->registerViewContextMenuAction(action);
       }
     }
@@ -461,6 +467,11 @@ void qSlicerSubjectHierarchyPluginHandler::setPluginLogic(qSlicerSubjectHierarch
       {
       foreach(QAction * action, pluginToRegister->viewContextMenuActions())
         {
+        if (action != nullptr && action->objectName().isEmpty())
+          {
+          qWarning() << Q_FUNC_INFO << ": action name is not set for menu item "
+            << action->text() << " provided subject hierarchy by plugin " << pluginToRegister->name();
+          }
         this->m_PluginLogic->registerViewContextMenuAction(action);
         }
       }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
@@ -52,6 +52,11 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qSlicerSubjectHierarchyPlu
   Q_OBJECT
   QVTK_OBJECT
 
+  /// Allow-list for view context menu actions. If empty (by default) then all registered view context menu action names will be displayable.
+  Q_PROPERTY(QStringList allowedViewContextMenuActionNames READ allowedViewContextMenuActionNames WRITE setAllowedViewContextMenuActionNames)
+  /// List of all registered view context menu actions.
+  Q_PROPERTY(QStringList registeredViewContextMenuActionNames READ registeredViewContextMenuActionNames)
+
 public:
   typedef QObject Superclass;
   qSlicerSubjectHierarchyPluginLogic(QObject *parent=nullptr);
@@ -78,21 +83,24 @@ public:
 
   /// Get all view context menu actions available
   /// \return List of object names of all registered view menu actions
-  Q_INVOKABLE QStringList availableViewContextMenuActionNames();
-  /// Set desired set of view menu actions
-  /// \param actionObjectNames List of view menu actions to consider. Only actions included here by object name
-  ///        are shown in the menu if they are accepted by the owner plugin. The order set here is used.
-  Q_INVOKABLE void setDisplayedViewContextMenuActionNames(QStringList actionObjectNames);
+  QStringList registeredViewContextMenuActionNames();
+
+  /// Set list of view conext menu action names that are allowed to be displayed.
+  /// \param actionObjectNames List of view context menu actions to consider for displaying.
+  ///        Only actions that are chosen to be visible by the owner plugin and listed in
+  ///        actionObjectNames will be displayed to the user.
+  void setAllowedViewContextMenuActionNames(QStringList actionObjectNames);
+
+  /// Get desired set of view menu actions
+  QStringList allowedViewContextMenuActionNames() const;
 
   /// Create menu from list of actions.
   /// Uses "section" property to determine position of the action in the menu:
   /// each integer section value corresponds to a section and fractional part is used for ordering actions within the secion.
   /// \param menu will be set by inserting the actions. If it is set to nullptr then a string will be returned that contains
   /// name and "section" value of each action.
-  static Q_INVOKABLE QString buildMenuFromActions(QMenu* menu, QList< QAction* > actions);
-
-  /// Returns if properties of the item can be edited (there is a suitable owner plugin that can process a node editing request).
-  bool canEditProperties();
+  /// \param allowedActions specifies object name of actions may be added to the menu. If the list is empty then it is ignored.
+  static Q_INVOKABLE QString buildMenuFromActions(QMenu* menu, QList< QAction* > actions, const QStringList& allowedActions=QStringList());
 
 protected:
   /// Add observations for node that was added to subject hierarchy

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
@@ -70,7 +70,7 @@ public:
   QAction* InteractionModeAdjustWindowLevelAction = nullptr;
   QAction* InteractionModePlaceAction = nullptr;
 
-  QAction* SaveScreenshotAction = nullptr;
+  QAction* CopyImageAction = nullptr;
 
   vtkWeakPointer<vtkMRMLInteractionNode> InteractionNode;
   vtkWeakPointer<vtkMRMLAbstractViewNode> ViewNode;
@@ -93,16 +93,19 @@ void qSlicerSubjectHierarchyViewContextMenuPluginPrivate::init()
   // Interaction mode
 
   this->InteractionModeViewTransformAction = new QAction("View transform",q);
+  this->InteractionModeViewTransformAction->setObjectName("MouseModeViewTransformAction");
   this->InteractionModeViewTransformAction->setCheckable(true);
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->InteractionModeViewTransformAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionInteraction, 0);
 
   this->InteractionModeAdjustWindowLevelAction = new QAction("Adjust window/level",q);
+  this->InteractionModeAdjustWindowLevelAction->setObjectName("MouseModeAdjustWindowLevelAction");
   this->InteractionModeAdjustWindowLevelAction->setCheckable(true);
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->InteractionModeAdjustWindowLevelAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionInteraction, 1);
 
   this->InteractionModePlaceAction = new QAction("Place", q);
+  this->InteractionModePlaceAction->setObjectName("MouseModePlaceAction");
   this->InteractionModePlaceAction->setCheckable(true);
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->InteractionModePlaceAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionInteraction, 2);
@@ -123,12 +126,13 @@ void qSlicerSubjectHierarchyViewContextMenuPluginPrivate::init()
 
   // Other
 
-  this->SaveScreenshotAction = new QAction(tr("Copy image"), q);
-  this->SaveScreenshotAction->setToolTip(tr("Copy a screenshot of this view to the clipboard"));
-  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->SaveScreenshotAction,
+  this->CopyImageAction = new QAction(tr("Copy image"), q);
+  this->CopyImageAction->setObjectName("CopyImageAction");
+  this->CopyImageAction->setToolTip(tr("Copy a screenshot of this view to the clipboard"));
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CopyImageAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 0);
 
-  QObject::connect(this->SaveScreenshotAction, SIGNAL(triggered()), q, SLOT(saveScreenshot()));
+  QObject::connect(this->CopyImageAction, SIGNAL(triggered()), q, SLOT(saveScreenshot()));
 }
 
 //-----------------------------------------------------------------------------
@@ -159,7 +163,7 @@ QList<QAction*> qSlicerSubjectHierarchyViewContextMenuPlugin::viewContextMenuAct
   actions << d->InteractionModeViewTransformAction
     << d->InteractionModeAdjustWindowLevelAction
     << d->InteractionModePlaceAction
-    << d->SaveScreenshotAction;
+    << d->CopyImageAction;
   return actions;
 }
 
@@ -212,7 +216,7 @@ void qSlicerSubjectHierarchyViewContextMenuPlugin::showViewContextMenuActionsFor
   d->InteractionModePlaceAction->setChecked(interactionMode == vtkMRMLInteractionNode::Place);
   d->InteractionModePlaceAction->blockSignals(wasBlocked);
 
-  d->SaveScreenshotAction->setVisible(true);
+  d->CopyImageAction->setVisible(true);
 
   // Cache nodes to have them available for the menu action execution.
   d->InteractionNode = interactionNode;


### PR DESCRIPTION
List of allowed view context menu actions was reset whenever the menu was rebuilt.
Fixed by introducing a string list that stores the allowed action names.

https://discourse.slicer.org/t/customization-of-right-click-context-menu-is-being-reset-to-default-unexpectedly/18603/7