### PR TITLE
BUG: Show error popup if loading via command-line has failed

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -55,6 +55,7 @@ class vtkDataIOManagerLogic;
 class vtkSlicerApplicationLogic;
 class vtkMRMLAbstractLogic;
 class vtkMRMLApplicationLogic;
+class vtkMRMLMessageCollection;
 class vtkMRMLRemoteIOLogic;
 class vtkMRMLScene;
 
@@ -552,6 +553,11 @@ public slots:
   /// Equivalent to setRenderPaused(false)
   /// \sa setRenderPaused
   virtual void resumeRender() {};
+
+  /// Load files into the application.
+  /// \param userMessages if specified then loading errors are returned via this object.
+  /// \return Returns true on success.
+  virtual bool loadFiles(const QStringList& filePaths, vtkMRMLMessageCollection* userMessages=nullptr);
 
 protected:
 

--- a/Base/QTCore/qSlicerSceneBundleReader.cxx
+++ b/Base/QTCore/qSlicerSceneBundleReader.cxx
@@ -92,7 +92,10 @@ bool qSlicerSceneBundleReader::load(const qSlicerIO::IOProperties& properties)
 
   this->mrmlScene()->SetErrorMessage("");
   bool success = this->mrmlScene()->ReadFromMRB(file.toUtf8(), clear);
-  this->userMessages()->AddMessage(vtkCommand::ErrorEvent, this->mrmlScene()->GetErrorMessage());
+  if (!this->mrmlScene()->GetErrorMessage().empty())
+    {
+    this->userMessages()->AddMessage(vtkCommand::ErrorEvent, this->mrmlScene()->GetErrorMessage());
+    }
   if (success)
     {
     // Set default scene file format to mrb

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -107,6 +107,7 @@
 #include <vtkSystemInformation.h>
 
 // MRML includes
+#include <vtkMRMLMessageCollection.h>
 #include <vtkMRMLNode.h>
 #include <vtkMRMLScene.h>
 
@@ -1257,4 +1258,20 @@ void qSlicerApplication::editNode(vtkObject*, void* callData, unsigned long)
     {
     this->openNodeModule(node);
     }
+}
+
+//------------------------------------------------------------------------------
+bool qSlicerApplication::loadFiles(const QStringList& filePaths, vtkMRMLMessageCollection* userMessagesInput/*=nullptr*/)
+{
+  // Even if the caller does not need messages, we need the message list so that we can display
+  // messages to the user.
+  vtkSmartPointer<vtkMRMLMessageCollection> userMessages = userMessagesInput;
+  if (!userMessages)
+    {
+    userMessages = vtkSmartPointer<vtkMRMLMessageCollection>::New();
+    }
+
+  bool success = Superclass::loadFiles(filePaths, userMessages);
+  qSlicerIOManager::showLoadNodesResultDialog(success, userMessages);
+  return success;
 }

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -213,6 +213,9 @@ public slots:
   /// \sa setRenderPaused
   void resumeRender() override;
 
+  /// Override the qSlicerCoreApplication implementation to also show error messages in a popup window.
+  bool loadFiles(const QStringList& filePaths, vtkMRMLMessageCollection* userMessages = nullptr) override;
+
 signals:
 
   /// Emitted when the startup phase has been completed.

--- a/Base/QTGUI/qSlicerIOManager.h
+++ b/Base/QTGUI/qSlicerIOManager.h
@@ -73,6 +73,7 @@ public:
   /// If success is set false then an error popup is displayed.
   /// If success is set to true then a popup is only displayed if error or warning messages are logged.
   /// If a popup is displayed then all the user-displayable messages are displayed in a collapsed "Details" section.
+  /// The dialog is not displayed if the application is launched with testing mode enabled.
   Q_INVOKABLE static void showLoadNodesResultDialog(bool success, vtkMRMLMessageCollection* userMessages);
 
   /// dragEnterEvents can be forwarded to the IOManager, if a registered dialog


### PR DESCRIPTION
When "Open with..." function was used on macOS (or the filename was specified as a command-line argument), then the application did not report any loading errors.