### PR TITLE
ENH: Implementation of a 3D stablizer in 3D view

### DIFF
--- a/Docs/user_guide/user_interface.md
+++ b/Docs/user_guide/user_interface.md
@@ -131,6 +131,7 @@ Default orientation axes: A = anterior, P = posterior, R = right, L = left, S = 
 - **Spin** continuously spins the view around.
 - **Rock** continuously rocks the view left-to-right.
 - **Zoom in/out** slightly zooms in/out the view. Convenient buttons for touchscreens.
+- **Tilt Lock** can be toggled using `Ctrl` + `b` keyboard shortcut. In tilt lock mode 3D view rotation is restricted to the azimuth axis (left-right direction) by disabling rotation around elevation axis (up-down direction).
 
 ### Slice View
 
@@ -224,6 +225,7 @@ view will not activate the view.
 | `Shift` + `Home` or `Shift` + `Keypad 7`| rotate to view from inferior |
 | `right-click` + `drag up/down` | zoom view in/out |
 | `Ctrl` + `mouse wheel` | zoom view in/out |
+| `Ctrl` + `b` | toggle tilt lock |
 | `+` / `-` | zoom view in/out |
 | `middle-click` + `drag` | pan (translate) view |
 | `Shift` + `left-click` + `drag` | pan (translate) view |

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
@@ -42,6 +42,7 @@ vtkMRMLCameraWidget::vtkMRMLCameraWidget()
 {
   this->MotionFactor = 10.0;
   this->MouseWheelMotionFactor = 1.0;
+  this->CameraTiltLocked = false;
 
   this->StartEventPosition[0] = 0.0;
   this->StartEventPosition[1] = 0.0;
@@ -94,6 +95,9 @@ vtkMRMLCameraWidget::vtkMRMLCameraWidget()
 
   this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "plus", WidgetEventCameraZoomIn);
   this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "minus", WidgetEventCameraZoomOut);
+
+  // Toggle tiltLock
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ControlModifier, 0, 0, "b", WidgetEventToggleCameraTiltLock);
 
   // Reset camera
 
@@ -300,6 +304,10 @@ bool vtkMRMLCameraWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* e
       this->SaveStateForUndo();
       this->CameraNode->RotateAround(vtkMRMLCameraNode::S, true);
       break;
+
+    case WidgetEventToggleCameraTiltLock:
+        this->CameraTiltLocked = !this->CameraTiltLocked;
+        break;
 
     case WidgetEventCameraReset:
       this->SaveStateForUndo();
@@ -610,8 +618,15 @@ bool vtkMRMLCameraWidget::ProcessRotate(vtkMRMLInteractionEventData* eventData)
 
   bool wasCameraNodeModified = this->CameraModifyStart();
 
-  camera->Azimuth(rxf);
-  camera->Elevation(ryf);
+  if (this->CameraTiltLocked == true)
+    {
+    camera->Azimuth(rxf);
+    }
+  else
+    {
+    camera->Azimuth(rxf);
+    camera->Elevation(ryf);
+    }
   camera->OrthogonalizeViewUp();
 
   this->CameraModifyEnd(wasCameraNodeModified, true, true);

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
@@ -108,6 +108,8 @@ public:
     WidgetEventCameraWheelZoomIn, // same as WidgetEventCameraZoomIn but with using wheel scaling factor
     WidgetEventCameraWheelZoomOut,
 
+    WidgetEventToggleCameraTiltLock,
+
     WidgetEventCameraReset,
     WidgetEventCameraResetTranslation,
     WidgetEventCameraResetRotation,
@@ -164,6 +166,7 @@ protected:
 
   double MotionFactor;
   double MouseWheelMotionFactor;
+  bool CameraTiltLocked;
 
   vtkWeakPointer<vtkMRMLCameraNode> CameraNode;
 


### PR DESCRIPTION
Problem:  
Rotating 3D models in 3D view with the mouse may cause tumbling effects and often leads to the impression of inaccuracy. Apart from this, permanent corrections are exhausting. 

Solution:  
Pressing the "a" on the keyboard now toggles between "limited rotation mode" (Azimuth only) and "full rotation mode" (all axes). The result is a smooth and reproducible rotation "on demand".  
  
Keys:  
"a" -> toggle 3D stabilizer

To do:

Indication to the user that stabilizer is active ? pls suggest where

If accepted-> documentation