### PR TITLE
BUG: Fix Window Level widget setting bounds inside current values

### DIFF
--- a/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.cxx
@@ -190,7 +190,7 @@ void qMRMLVolumeThresholdWidget::setThreshold(double lowerThreshold, double uppe
     double oldLowerThreshold = d->VolumeDisplayNode->GetLowerThreshold();
     double oldUpperThreshold  = d->VolumeDisplayNode->GetUpperThreshold();
 
-    int disabledModify = d->VolumeDisplayNode->StartModify();
+    int wasModify = d->VolumeDisplayNode->StartModify();
     d->VolumeDisplayNode->SetLowerThreshold(lowerThreshold);
     d->VolumeDisplayNode->SetUpperThreshold(upperThreshold);
     bool changed =
@@ -201,7 +201,7 @@ void qMRMLVolumeThresholdWidget::setThreshold(double lowerThreshold, double uppe
       this->setAutoThreshold(qMRMLVolumeThresholdWidget::Manual);
       emit this->thresholdValuesChanged(lowerThreshold, upperThreshold);
       }
-    d->VolumeDisplayNode->EndModify(disabledModify);
+    d->VolumeDisplayNode->EndModify(wasModify);
     }
 }
 
@@ -231,20 +231,14 @@ void qMRMLVolumeThresholdWidget::setUpperThreshold(double upperThreshold)
 double qMRMLVolumeThresholdWidget::lowerThreshold() const
 {
   Q_D(const qMRMLVolumeThresholdWidget);
-
-  double min = d->VolumeThresholdRangeWidget->minimumValue();
-
-  return min;
+  return d->VolumeThresholdRangeWidget->minimumValue();
 }
 
 // --------------------------------------------------------------------------
 double qMRMLVolumeThresholdWidget::upperThreshold() const
 {
   Q_D(const qMRMLVolumeThresholdWidget);
-
-  double max = d->VolumeThresholdRangeWidget->maximumValue();
-
-  return max;
+  return d->VolumeThresholdRangeWidget->maximumValue();
 }
 
 // --------------------------------------------------------------------------
@@ -262,35 +256,10 @@ void qMRMLVolumeThresholdWidget::setMaximum(double max)
 }
 
 // --------------------------------------------------------------------------
-void qMRMLVolumeThresholdWidget::updateWidgetFromMRMLVolumeNode()
-{
-  Q_D(qMRMLVolumeThresholdWidget);
-  this->Superclass::updateWidgetFromMRMLVolumeNode();
-
-  if (!d->VolumeDisplayNode)
-    {
-    return;
-    }
-
-  d->scalarRange(d->VolumeDisplayNode, d->DisplayScalarRange);
-  double minRangeValue = d->DisplayScalarRange[0];
-  double maxRangeValue = d->DisplayScalarRange[1];
-
-  // We always need to set the slider values and range at the same time
-  // to make sure that they are consistent. This is implemented in one place,
-  // in updateWidgetFromMRMLDisplayNode().
-  this->updateWidgetFromMRMLDisplayNode();
-}
-
-// --------------------------------------------------------------------------
 void qMRMLVolumeThresholdWidget::updateWidgetFromMRMLDisplayNode()
 {
   Q_D(qMRMLVolumeThresholdWidget);
-
-  // Don't want to call qMRMLVolumeWidget::updateWidgetFromMRMLDisplayNode which would call updateRangeForVolumeDisplayNode
-
-  this->setEnabled(d->VolumeDisplayNode != nullptr &&
-                   d->VolumeNode != nullptr);
+  Superclass::updateWidgetFromMRMLDisplayNode();
 
   if (!d->VolumeDisplayNode)
     {

--- a/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.h
+++ b/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.h
@@ -86,9 +86,6 @@ protected:
   /// Update the widget from volume display node properties.
   void updateWidgetFromMRMLDisplayNode() override;
 
-  /// Update the widget from volume properties.
-  void updateWidgetFromMRMLVolumeNode() override;
-
   ///
   /// Set sliders range
   void setMinimum(double min);

--- a/Libs/MRML/Widgets/qMRMLVolumeWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLVolumeWidget_p.h
@@ -55,16 +55,10 @@ public:
 
   virtual void init();
 
-  /// Update the range and single step of the input GUI elements such as
-  /// sliders and spinboxes.
-  void updateRangeForVolumeDisplayNode(vtkMRMLScalarVolumeDisplayNode*);
   /// Block all the signals emitted by the widgets that are impacted by the
   /// range.
   /// To be reimplemented in subclasses
   virtual bool blockSignals(bool block);
-  /// Compute the scalar range of the volume display node.
-  /// It can then be used to set the range of the sliders, spinboxes, etc.
-  void scalarRange(vtkMRMLScalarVolumeDisplayNode* displayNode, double range[2]);
   /// Compute the ideal singleStep based on a range.
   /// Set the single step to the widgets such as sliders, spinboxes...
   void updateSingleStep(double min, double max);
@@ -73,7 +67,7 @@ public slots:
   virtual void setRange(double min, double max);
   virtual void setDecimals(int decimals);
   virtual void setSingleStep(double singleStep);
-  virtual void updateRange();
+  virtual void updateRangeFromSpinBox();
 
 protected:
   vtkWeakPointer<vtkMRMLScalarVolumeNode> VolumeNode;

--- a/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
@@ -344,26 +344,39 @@ void qMRMLWindowLevelWidget::setMaximumValue(double max)
 // --------------------------------------------------------------------------
 void qMRMLWindowLevelWidget::updateWidgetFromMRMLVolumeNode()
 {
-  Q_D(qMRMLWindowLevelWidget);
+  Q_D(qMRMLVolumeWidget);
   this->Superclass::updateWidgetFromMRMLVolumeNode();
-  double range[2];
-  range[0] = d->DisplayScalarRange[0];
-  range[1] = d->DisplayScalarRange[1];
-  double interval = range[1] - range[0];
-  Q_ASSERT(interval >= 0.);
-  if (interval < 10.)
+
+  vtkMRMLScalarVolumeDisplayNode* displayNode = this->mrmlDisplayNode();
+  if (!displayNode)
     {
-    //give us some space
-    range[0] = range[0] - interval*0.1;
-    range[1] = range[1] + interval*0.1;
+    return;
+    }
+
+  double window = displayNode->GetWindow();
+  double windowLevelMin = displayNode->GetWindowLevelMin();
+  double windowLevelMax = displayNode->GetWindowLevelMax();
+
+  // We block here to prevent the widgets to call setWindowLevel which could
+  // change the AutoLevel from Auto into Manual.
+  bool blocked = d->blockSignals(true);
+
+  double sliderRange[2] = { windowLevelMin, windowLevelMax };
+  if (window < 10.)
+    {
+    // unusually small range, make the slider range a bit larger than the current values
+    sliderRange[0] = sliderRange[0] - window * 0.1;
+    sliderRange[1] = sliderRange[1] + window * 0.1;
     }
   else
     {
-    //give us some space
-    range[0] = qMin(-600., range[0] - interval*0.1);
-    range[1] = qMax(600., range[1] + interval*0.1);
+    // usual range for CT, MRI, etc. make the slider range minimum +/- 600
+    sliderRange[0] = qMin(-600., sliderRange[0] - window * 0.1);
+    sliderRange[1] = qMax(600., sliderRange[1] + window * 0.1);
     }
-  d->setRange(range[0], range[1]);
+  d->setRange(sliderRange[0], sliderRange[1]);
+
+  d->blockSignals(blocked);
 }
 
 // --------------------------------------------------------------------------
@@ -378,23 +391,23 @@ void qMRMLWindowLevelWidget::updateWidgetFromMRMLDisplayNode()
 
   double window = d->VolumeDisplayNode->GetWindow();
   double level = d->VolumeDisplayNode->GetLevel();
-  double min = d->VolumeDisplayNode->GetWindowLevelMin();
-  double max = d->VolumeDisplayNode->GetWindowLevelMax();
+  double windowLevelMin = d->VolumeDisplayNode->GetWindowLevelMin();
+  double windowLevelMax = d->VolumeDisplayNode->GetWindowLevelMax();
 
   // We block here to prevent the widgets to call setWindowLevel which could
   // change the AutoLevel from Auto into Manual.
   bool blocked = d->blockSignals(true);
 
   // WindowLevelMinMax might have been set to values outside the current range
-  const double minRangeValue = std::min(min, d->MinRangeSpinBox->value());
-  const double maxRangeValue = std::max(max, d->MaxRangeSpinBox->value());
+  const double minRangeValue = std::min(windowLevelMin, d->MinRangeSpinBox->value());
+  const double maxRangeValue = std::max(windowLevelMax, d->MaxRangeSpinBox->value());
   d->setRange(minRangeValue, maxRangeValue);
 
   d->WindowSpinBox->setValue(window);
   d->LevelSpinBox->setValue(level);
-  d->WindowLevelRangeSlider->setValues(min, max);
-  d->MinSpinBox->setValue(min);
-  d->MaxSpinBox->setValue(max);
+  d->WindowLevelRangeSlider->setValues(windowLevelMin, windowLevelMax);
+  d->MinSpinBox->setValue(windowLevelMax);
+  d->MaxSpinBox->setValue(windowLevelMax);
 
   d->blockSignals(blocked);
 

--- a/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
@@ -406,7 +406,7 @@ void qMRMLWindowLevelWidget::updateWidgetFromMRMLDisplayNode()
   d->WindowSpinBox->setValue(window);
   d->LevelSpinBox->setValue(level);
   d->WindowLevelRangeSlider->setValues(windowLevelMin, windowLevelMax);
-  d->MinSpinBox->setValue(windowLevelMax);
+  d->MinSpinBox->setValue(windowLevelMin);
   d->MaxSpinBox->setValue(windowLevelMax);
 
   d->blockSignals(blocked);

--- a/Libs/MRML/Widgets/qMRMLWindowLevelWidget.h
+++ b/Libs/MRML/Widgets/qMRMLWindowLevelWidget.h
@@ -103,7 +103,7 @@ protected:
   /// Update the widget from volume display node properties.
   void updateWidgetFromMRMLDisplayNode() override;
 
-  /// Update the widget from volume properties.
+  /// Special initial updates that are done only when switching between volumes.
   void updateWidgetFromMRMLVolumeNode() override;
 
 private:

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
@@ -179,12 +179,12 @@ void qSlicerScalarVolumeDisplayWidget::setMRMLVolumeNode(vtkMRMLScalarVolumeNode
 
   vtkMRMLScalarVolumeDisplayNode* oldVolumeDisplayNode = this->volumeDisplayNode();
 
-  d->MRMLWindowLevelWidget->setMRMLVolumeNode(volumeNode);
-  d->MRMLVolumeThresholdWidget->setMRMLVolumeNode(volumeNode);
-
   qvtkReconnect(oldVolumeDisplayNode, volumeNode ? volumeNode->GetVolumeDisplayNode() :nullptr,
                 vtkCommand::ModifiedEvent,
                 this, SLOT(updateWidgetFromMRML()));
+
+  d->MRMLWindowLevelWidget->setMRMLVolumeNode(volumeNode);
+  d->MRMLVolumeThresholdWidget->setMRMLVolumeNode(volumeNode);
 
   this->setEnabled(volumeNode != nullptr);
 


### PR DESCRIPTION
If you select a volume in the Volumes module and the volume's current Window/Level was outside of the bounds, then using the qMRMLWindowLevelWidget would change the current window level to the special Window/Level range bounds. 

Current Slicer `master`
```python
# Open Slicer fresh
import SampleData
volumeNode = SampleData.SampleDataLogic().downloadMRHead()
volumeNode.GetDisplayNode().AutoWindowLevelOff()
volumeNode.GetDisplayNode().SetWindowLevelMinMax(-2000,2000)
print(volumeNode.GetDisplayNode().GetWindowLevelMin())  # -2000
print(volumeNode.GetDisplayNode().GetWindowLevelMax())  # 2000
slicer.util.selectModule("Volumes")  # triggers setting a volume to the qMRMLWindowLevelWidget
print(volumeNode.GetDisplayNode().GetWindowLevelMin())  # -600
print(volumeNode.GetDisplayNode().GetWindowLevelMax())  # 600
```

This PR makes sure that manipulating the widget doesn't change the value of the current Window Level. 
```python
# Open Slicer fresh
import SampleData
volumeNode = SampleData.SampleDataLogic().downloadMRHead()
volumeNode.GetDisplayNode().AutoWindowLevelOff()
volumeNode.GetDisplayNode().SetWindowLevelMinMax(-2000,2000)
print(volumeNode.GetDisplayNode().GetWindowLevelMin())  # -2000
print(volumeNode.GetDisplayNode().GetWindowLevelMax())  # 2000
slicer.util.selectModule("Volumes")  # triggers setting a volume to the qMRMLWindowLevelWidget
print(volumeNode.GetDisplayNode().GetWindowLevelMin())  # -2000
print(volumeNode.GetDisplayNode().GetWindowLevelMax())  # 2000
```