### PR TITLE
COMP: Update CTK

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -70,7 +70,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "e485a3fcecdffc2b40aaafbdbf9f470edf403354"
+    "a964dcc5a222496b30342583bc4f0fbfb4b20897"
     QUIET
     )
 


### PR DESCRIPTION
This is part of #5739 work. It is unclear if this will completely resolve the issue or only some of the issue. Choosing a file to import into the DICOM database, even when using Windows, should not crash anymore upon selecting "import" which closes the native file dialog.
```
$ git shortlog --no-merges e485a3f..a964dcc
James Butler (1):
      BUG: Fix crash upon selecting files with DICOM browser import dialog
```