### PR TITLE
ENH: Update SurfaceToolbox - Fixes invalid ROI cut output

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -362,7 +362,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
   # When updating the GIT_TAG, consider updating documentation in Docs/user_guide (see https://github.com/Slicer/Slicer/issues/5669)
-  GIT_TAG eb344553b1a7c1ec0d489c9788b997fa8494397e
+  GIT_TAG 961a2a4511573f16a8c39ce4fc53b1d4d3a487e7
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
List of changes:

$ git shortlog eb34455..961a2a4
Kyle Sunderland (1):
      BUG: Fix invalid ROI cut output