### PR TITLE
BUG: Fix hang when closing scene

### DIFF
--- a/Libs/MRML/Core/vtkMRMLFolderDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLFolderDisplayNode.cxx
@@ -298,6 +298,11 @@ bool vtkMRMLFolderDisplayNode::GetHierarchyVisibility(vtkMRMLDisplayableNode* no
   vtkIdType parentItemID = nodeShId;
   while ( (parentItemID = shNode->GetItemParent(parentItemID)) != sceneItemID ) // The double parentheses avoids a Linux build warning
     {
+    if (!parentItemID)
+      {
+      vtkErrorWithObjectMacro(node, "GetHierarchyVisibility: Invalid parent of subject hierarchy item");
+      return false;
+      }
     vtkMRMLDisplayNode* displayNode = vtkMRMLDisplayNode::SafeDownCast(shNode->GetItemDataNode(parentItemID));
     if (displayNode && displayNode->GetVisibility() == 0)
       {

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
@@ -352,10 +352,10 @@ void vtkMRMLMarkupsDisplayableManager::OnMRMLSceneNodeAdded(vtkMRMLNode* node)
   if (node->IsA("vtkMRMLMarkupsNode"))
   {
     this->Helper->AddMarkupsNode(vtkMRMLMarkupsNode::SafeDownCast(node));
-  }
 
-  // and render again
-  this->RequestRender();
+    // and render again
+    this->RequestRender();
+  }
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Problem is that on scene close in certain cases, when the new SH node is created, the Markups displayable manager requests render on the node added event of the SH node, then there is an endless loop in the Folder plugin's GetHierarchyVisibility because SH item parent is 0 (i.e. invalid ID) and never reaches the scene.