### PR TITLE
ENH: Add public method to change threshold and WindowLevel bounds

### DIFF
--- a/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.cxx
@@ -117,6 +117,13 @@ qMRMLVolumeThresholdWidget::qMRMLVolumeThresholdWidget(QWidget* parentWidget)
 qMRMLVolumeThresholdWidget::~qMRMLVolumeThresholdWidget() = default;
 
 // --------------------------------------------------------------------------
+void qMRMLVolumeThresholdWidget::setThresholdBounds(double min, double max)
+{
+  Q_D(qMRMLVolumeThresholdWidget);
+  d->setRange(min, max);
+}
+
+// --------------------------------------------------------------------------
 void qMRMLVolumeThresholdWidget::setAutoThreshold(int autoThreshold)
 {
   this->setAutoThreshold(static_cast<ControlMode>(autoThreshold));
@@ -239,6 +246,34 @@ double qMRMLVolumeThresholdWidget::upperThreshold() const
 {
   Q_D(const qMRMLVolumeThresholdWidget);
   return d->VolumeThresholdRangeWidget->maximumValue();
+}
+
+// --------------------------------------------------------------------------
+double qMRMLVolumeThresholdWidget::lowerThresholdBound() const
+{
+  Q_D(const qMRMLVolumeThresholdWidget);
+  return d->VolumeThresholdRangeWidget->minimum();
+}
+
+// --------------------------------------------------------------------------
+double qMRMLVolumeThresholdWidget::upperThresholdBound() const
+{
+  Q_D(const qMRMLVolumeThresholdWidget);
+  return d->VolumeThresholdRangeWidget->maximum();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLVolumeThresholdWidget::setLowerThresholdBound(double lowerThresholdBound)
+{
+  double upperThresholdBound = this->upperThresholdBound();
+  this->setThresholdBounds(lowerThresholdBound, upperThresholdBound);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLVolumeThresholdWidget::setUpperThresholdBound(double upperThresholdBound)
+{
+  double lowerThresholdBound = this->lowerThresholdBound();
+  this->setThresholdBounds(lowerThresholdBound, upperThresholdBound);
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.h
+++ b/Libs/MRML/Widgets/qMRMLVolumeThresholdWidget.h
@@ -29,6 +29,8 @@ class QMRML_WIDGETS_EXPORT qMRMLVolumeThresholdWidget
   Q_PROPERTY(int  autoThreshold READ autoThreshold WRITE setAutoThreshold)
   Q_PROPERTY(double lowerThreshold READ lowerThreshold WRITE setLowerThreshold)
   Q_PROPERTY(double upperThreshold READ upperThreshold WRITE setUpperThreshold)
+  Q_PROPERTY(double lowerThresholdBound READ lowerThresholdBound WRITE setLowerThresholdBound)
+  Q_PROPERTY(double upperThresholdBound READ upperThresholdBound WRITE setUpperThresholdBound)
   Q_ENUMS(ControlMode)
 
 public:
@@ -58,6 +60,14 @@ public:
   /// Get upperThreshold
   double upperThreshold()const;
 
+  ///
+  /// Get lower threshold bound
+  double lowerThresholdBound()const;
+
+  ///
+  /// Get upper threshold bound
+  double upperThresholdBound()const;
+
 signals:
   ///
   /// Signal sent if the lowerThreshold/upperThreshold value is updated
@@ -79,8 +89,20 @@ public slots:
   void setUpperThreshold(double upperThreshold);
 
   ///
+  /// Set lowerThreshold
+  void setLowerThresholdBound(double lowerThresholdBound);
+
+  ///
+  /// Set upperThreshold
+  void setUpperThresholdBound(double upperThresholdBound);
+
+  ///
   /// Set lowerThreshold/upperThreshold in once
   void setThreshold(double lowerThreshold, double upperThreshold);
+
+  ///
+  /// Set sliders bounds
+  void setThresholdBounds(double min, double max);
 
 protected:
   /// Update the widget from volume display node properties.

--- a/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLWindowLevelWidget.cxx
@@ -319,6 +319,24 @@ double qMRMLWindowLevelWidget::maximumValue() const
 }
 
 // --------------------------------------------------------------------------
+double qMRMLWindowLevelWidget::minimumBound() const
+{
+  Q_D(const qMRMLWindowLevelWidget);
+
+  double min = d->WindowLevelRangeSlider->minimum();
+  return min;
+}
+
+// --------------------------------------------------------------------------
+double qMRMLWindowLevelWidget::maximumBound() const
+{
+  Q_D(const qMRMLWindowLevelWidget);
+
+  double max = d->WindowLevelRangeSlider->maximum();
+  return max;
+}
+
+// --------------------------------------------------------------------------
 double qMRMLWindowLevelWidget::level() const
 {
   Q_D(const qMRMLWindowLevelWidget);
@@ -339,6 +357,25 @@ void qMRMLWindowLevelWidget::setMinimumValue(double min)
 void qMRMLWindowLevelWidget::setMaximumValue(double max)
 {
   this->setMinMaxRangeValue(this->minimumValue(), max);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLWindowLevelWidget::setMinimumBound(double min)
+{
+  this->setMinMaxBounds(min, this->maximumBound());
+}
+
+// --------------------------------------------------------------------------
+void qMRMLWindowLevelWidget::setMaximumBound(double max)
+{
+  this->setMinMaxBounds(this->minimumBound(), max);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLWindowLevelWidget::setMinMaxBounds(double min, double max)
+{
+  Q_D(qMRMLWindowLevelWidget);
+  d->setRange(min, max);
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLWindowLevelWidget.h
+++ b/Libs/MRML/Widgets/qMRMLWindowLevelWidget.h
@@ -34,6 +34,8 @@ class QMRML_WIDGETS_EXPORT qMRMLWindowLevelWidget
   Q_PROPERTY(double level READ level WRITE setLevel)
   Q_PROPERTY(double minimumValue READ minimumValue WRITE setMinimumValue)
   Q_PROPERTY(double maximumValue READ maximumValue WRITE setMaximumValue)
+  Q_PROPERTY(double minimumBound READ minimumBound WRITE setMinimumBound)
+  Q_PROPERTY(double maximumBound READ maximumBound WRITE setMaximumBound)
   Q_ENUMS(ControlMode)
 
 public:
@@ -69,6 +71,14 @@ public:
   /// Get maximum of the range
   double maximumValue()const;
 
+  ///
+  /// Get minimum of the range
+  double minimumBound()const;
+
+  ///
+  /// Get maximum of the range
+  double maximumBound()const;
+
 signals:
   ///
   /// Signal sent if the window/level value is updated
@@ -98,6 +108,10 @@ public slots:
   void setMinMaxRangeValue(double min, double max);
   void setMinimumValue(double min);
   void setMaximumValue(double max);
+
+  void setMinimumBound(double min);
+  void setMaximumBound(double max);
+  void setMinMaxBounds(double min, double max);
 
 protected:
   /// Update the widget from volume display node properties.


### PR DESCRIPTION
This is a small change to add some public methods for convenience to manipulate the bounds of Volume Threshold and WindowLevel widgets through code rather than just through the GUI.