### PR TITLE
DOC: Add programmatic installation section to developer guide 

### DIFF
--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -1,3 +1,10 @@
+## Install Slicer
+
+There are different approaches to install Slicer and extensions programmatically:
+
+- Install Slicer manually and install extensions by using `slicer.app.extensionsManagerModel()`. See example [below](script_repository.md#download-and-install-extension) and in [install-slicer-extension.py](https://github.com/pieper/SlicerDockers/blob/master/slicer-plus/install-slicer-extension.py)
+- Directly interact with the REST API endpoints of https://slicer-packages.kitware.com using `curl` and `jq`. See [slicer-download.sh](https://github.com/Slicer/SlicerDocker/blob/master/scripts/slicer-download.sh)
+
 ## Launch Slicer
 
 ### Open a file with Slicer at the command line


### PR DESCRIPTION
This script was built to install Slicer with BoneTextureExtension in a container. See https://github.com/DCBIA-OrthoLab/SlicerCMF-docker/pull/2. I've included the same script here, with some modifications.

The added script `slicer-download.sh` downloads and extracts Slicer to a target directory. It accepts parameters to select slicer version and pre-installed extensions; I've documented these in a comment at the top of the script, however I don't have any `--help` text or similar set up. The script depends on `rsync`, `curl`, and `jq`; I'm not sure the best place to document this.

It can also be used to install extensions into an existing installation of Slicer by setting `-d dest` to the Slicer root directory.

The script only supports the Linux `.tar.gz` binaries. It may be possible to convert only the _extension_ installation to be cross-platform; however cross-platform _Slicer_ installation would be significantly more complex.