### PR TITLE
BUG: Save segmentation imported from plain nrrd using original geometry

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -677,6 +677,8 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
 
     if (numberOfSegments == 0)
       {
+      // No segment metadata. We are loading from a plain volume (not seg.nrrd).
+
       currentBinaryLabelmap = vtkSmartPointer<vtkOrientedImageData>::New();
       extractComponents->SetComponents(frameIndex);
       padder->SetOutputWholeExtent(imageExtentInFile);
@@ -714,6 +716,10 @@ int vtkMRMLSegmentationStorageNode::ReadBinaryLabelmapRepresentation(vtkMRMLSegm
         currentSegment->AddRepresentation(vtkSegmentationConverter::GetBinaryLabelmapRepresentationName(), currentBinaryLabelmap);
         segments.push_back(currentSegment);
         }
+
+      // Set segmentation geometry from loaded image
+      std::string imageGeometryString = vtkSegmentationConverter::SerializeImageGeometry(currentBinaryLabelmap);
+      segmentation->SetConversionParameter(vtkSegmentationConverter::GetReferenceImageGeometryParameterName(), imageGeometryString);
       }
     else
       {


### PR DESCRIPTION
When loading a segmentation from a regular nrrd (rather than seg.nrrd), the reference image geometry of the original image was not saved.
Due to the missing geometry conversion parameter, exporting/saving the segmentation would cause the segmentation to be exported/saved at minimum extent. Fixed by setting the reference image geometry conversion parameter to the size of the imported nrrd.

Re #5323