### PR TITLE
ENH: Trim whitespaces from node names when generating filenames from them

### DIFF
--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -90,6 +90,8 @@ QString qSlicerFileNameItemDelegate::forceFileNameValidCharacters(const QString&
       sanitizedFilename += filename[i];
       }
     }
+  // Remove leading and trailing spaces
+  sanitizedFilename = sanitizedFilename.trimmed();
   return sanitizedFilename;
 }
 

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -2443,17 +2443,21 @@ std::string vtkSlicerSegmentationsModuleLogic::GetSafeFileName(std::string origi
 {
   // Remove characters from node name that cannot be used in file names
   // (same method as in qSlicerFileNameItemDelegate::fixupFileName)
-  std::string safeName("");
+  std::string safeName;
   vtksys::RegularExpression regExp("[A-Za-z0-9\\ \\-\\_\\.\\(\\)\\$\\!\\~\\#\\'\\%\\^\\{\\}]");
   for (size_t i=0; i<originalName.size(); ++i)
     {
-    std::string currentCharStr("");
+    std::string currentCharStr;
     currentCharStr += originalName[i];
     if (regExp.find(currentCharStr))
       {
       safeName += currentCharStr;
       }
     }
+
+  // trim whitespaces
+  safeName.erase(safeName.find_last_not_of(" \t\r\n") + 1);
+  safeName.erase(0, safeName.find_first_not_of(" \t\r\n"));
 
   return safeName;
 }


### PR DESCRIPTION
Filenames starting or ending with spaces may be hard to manage. Therefore, we remove leading and trailing whitespace characters when generating filename from node name (in Save data dialog and in segmentation export).

fixes #4523