### PR TITLE
ENH: Show context menu if clicking on markups interaction handle

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -72,9 +72,13 @@ vtkSlicerMarkupsWidget::vtkSlicerMarkupsWidget()
   this->SetEventTranslation(WidgetStateOnWidget, vtkMRMLInteractionEventData::LeftButtonClickEvent, vtkEvent::NoModifier, WidgetEventJumpCursor);
   this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::LeftButtonDoubleClickEvent, vtkEvent::NoModifier, WidgetEventAction);
 
-  this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::RightButtonPressEvent, vtkEvent::NoModifier, WidgetEventReserved);
-  this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::RightButtonReleaseEvent, vtkEvent::NoModifier, WidgetEventReserved);
-  this->SetEventTranslation(WidgetStateOnWidget, vtkMRMLInteractionEventData::RightButtonClickEvent, vtkEvent::NoModifier, WidgetEventMenu);
+  unsigned int menuStates[] = { WidgetStateOnWidget, WidgetStateOnTranslationHandle, WidgetStateOnRotationHandle, WidgetStateOnScaleHandle };
+  for (auto menuState : menuStates)
+    {
+    this->SetEventTranslation(menuState, vtkCommand::RightButtonPressEvent, vtkEvent::NoModifier, WidgetEventReserved);
+    this->SetEventTranslation(menuState, vtkCommand::RightButtonReleaseEvent, vtkEvent::NoModifier, WidgetEventReserved);
+    this->SetEventTranslation(menuState, vtkMRMLInteractionEventData::RightButtonClickEvent, vtkEvent::NoModifier, WidgetEventMenu);
+    }
 
   // Update active component
   this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseMoveEvent, vtkEvent::NoModifier, WidgetEventMouseMove);


### PR DESCRIPTION
Previously, interaction handles (translate/rotate/scale) did not take right-click events and so the view context menu was shown, so it was hard to turn off interaction handles.

re #5734