### PR TITLE
BUG: Force update of grow from seeds 3D closed surface preview

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/AbstractScriptedSegmentEditorAutoCompleteEffect.py
@@ -510,6 +510,9 @@ class AbstractScriptedSegmentEditorAutoCompleteEffect(AbstractScriptedSegmentEdi
           self.clippedMaskImageData = None
 
     previewNode.SetName(segmentationNode.GetName()+" preview")
+    previewNode.RemoveClosedSurfaceRepresentation() # Force the closed surface representation to update
+                                                    # TODO: This will no longer be required when we can use the segment editor to set multiple segments
+                                                    # as the closed surfaces will be converted as neccesary by the segmentation logic.
 
     mergedImage = slicer.vtkOrientedImageData()
     segmentationNode.GenerateMergedLabelmapForAllSegments(mergedImage,


### PR DESCRIPTION
Due to a previous optimization that set the labelmap representation of the preview segments directly, the 3D preview closed surface was no longer automatically updating. To fix this, we remove the existing closed surface so that it will be reconverted after the segmentation is updated.

When the functions for setting multiple segments are added, we will no longer need this call as the closed surface update will be handled by the segmentation logic.

Re #5757