### PR TITLE
ENH: Get node from volume display widgets using Python interface

### DIFF
--- a/Libs/MRML/Widgets/qMRMLVolumeWidget.h
+++ b/Libs/MRML/Widgets/qMRMLVolumeWidget.h
@@ -48,7 +48,7 @@ public:
 
   ///
   /// Return the current MRML node of interest
-  vtkMRMLScalarVolumeNode* mrmlVolumeNode()const;
+  Q_INVOKABLE vtkMRMLScalarVolumeNode* mrmlVolumeNode()const;
 
 public slots:
   /// Set the volume to observe

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.h
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.h
@@ -31,8 +31,8 @@ public:
   explicit qSlicerScalarVolumeDisplayWidget(QWidget* parent);
   ~qSlicerScalarVolumeDisplayWidget() override;
 
-  vtkMRMLScalarVolumeNode* volumeNode()const;
-  vtkMRMLScalarVolumeDisplayNode* volumeDisplayNode()const;
+  Q_INVOKABLE vtkMRMLScalarVolumeNode* volumeNode()const;
+  Q_INVOKABLE vtkMRMLScalarVolumeDisplayNode* volumeDisplayNode()const;
 
   bool isColorTableComboBoxEnabled()const;
   void setColorTableComboBoxEnabled(bool);


### PR DESCRIPTION
I found exposing to the python interface getting the volume node of some volume widgets helpful. Some other widgets have it exposed from the python interface using calls such as `currentNode()` and now that is possible with these widgets using their already named methods of `mrmlVolumeNode()` and `volumeNode()`. 

It would be nice if getting the node for the associated qMRML/qSlicer widgets had a more consistent naming scheme, but I'll leave that for a more comprehensive future change. 