### PR TITLE
BUG: Fix invalid overlap when splitting segments

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
@@ -457,19 +457,6 @@ void qSlicerSegmentEditorAbstractEffect::modifySegmentByLabelmap(vtkMRMLSegmenta
     segmentIDsToOverwrite.clear();
     }
 
-  std::vector<std::string> sharedSegmentIDs;
-  segmentationNode->GetSegmentation()->GetSegmentIDsSharingBinaryLabelmapRepresentation(segmentID, sharedSegmentIDs, false);
-
-  std::vector<std::string> segmentsToErase;
-  for (std::string segmentIDToOverwrite : segmentIDsToOverwrite)
-    {
-    std::vector<std::string>::iterator foundSegmentIDIt = std::find(sharedSegmentIDs.begin(), sharedSegmentIDs.end(), segmentIDToOverwrite);
-    if (foundSegmentIDIt == sharedSegmentIDs.end())
-      {
-      segmentsToErase.push_back(segmentIDToOverwrite);
-      }
-    }
-
   // Create inverted binary labelmap
   vtkSmartPointer<vtkImageThreshold> inverter = vtkSmartPointer<vtkImageThreshold>::New();
   inverter->SetInputData(modifierLabelmap);
@@ -535,6 +522,19 @@ void qSlicerSegmentEditorAbstractEffect::modifySegmentByLabelmap(vtkMRMLSegmenta
     if (vtkSlicerSegmentationsModuleLogic::GetSegmentStatus(segment) == vtkSlicerSegmentationsModuleLogic::NotStarted)
       {
       vtkSlicerSegmentationsModuleLogic::SetSegmentStatus(segment, vtkSlicerSegmentationsModuleLogic::InProgress);
+      }
+    }
+
+  std::vector<std::string> sharedSegmentIDs;
+  segmentationNode->GetSegmentation()->GetSegmentIDsSharingBinaryLabelmapRepresentation(segmentID, sharedSegmentIDs, false);
+
+  std::vector<std::string> segmentsToErase;
+  for (std::string segmentIDToOverwrite : segmentIDsToOverwrite)
+    {
+    std::vector<std::string>::iterator foundSegmentIDIt = std::find(sharedSegmentIDs.begin(), sharedSegmentIDs.end(), segmentIDToOverwrite);
+    if (foundSegmentIDIt == sharedSegmentIDs.end())
+      {
+      segmentsToErase.push_back(segmentIDToOverwrite);
       }
     }
 


### PR DESCRIPTION
When modifying a segment the list of segments that need to be overwritten does not normally include segments that are on the same layer (since they will be overwritten by default). This list was populated before the selected segment is modified. This causes segments on the same layer to not be overwritten if the selected segment is separated to a new layer.

Fixed by populating the list of segments to overwrite after the selected segment has been modified (and potentially moved to a new layer).

Re #5338