### PR TITLE
ENH: Allow FOV adjustment without slice view reorientation

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -514,7 +514,7 @@ void vtkMRMLApplicationLogic::PropagatePlotChartSelection()
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLApplicationLogic::FitSliceToAll(bool onlyIfPropagateVolumeSelectionAllowed /* =false */)
+void vtkMRMLApplicationLogic::FitSliceToAll(bool onlyIfPropagateVolumeSelectionAllowed /* =false */, bool resetOrientation /* =true */)
 {
   if (this->Internal->SliceLogics.GetPointer() == nullptr)
     {
@@ -536,10 +536,13 @@ void vtkMRMLApplicationLogic::FitSliceToAll(bool onlyIfPropagateVolumeSelectionA
         }
       }
     vtkMRMLSliceNode* sliceNode = sliceLogic->GetSliceNode();
-    // Set to default orientation before rotation so that the view is snapped
-    // closest to the default orientation of this slice view.
-    sliceNode->SetOrientationToDefault();
-    sliceLogic->RotateSliceToLowestVolumeAxes(false);
+    if (resetOrientation)
+      {
+      // Set to default orientation before rotation so that the view is snapped
+      // closest to the default orientation of this slice view.
+      sliceNode->SetOrientationToDefault();
+      sliceLogic->RotateSliceToLowestVolumeAxes(false);
+      }
     int* dims = sliceNode->GetDimensions();
     sliceLogic->FitSliceToAll(dims[0], dims[1]);
     sliceLogic->SnapSliceOffsetToIJK();

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -127,7 +127,8 @@ public:
   /// Fit all the volumes into their views
   /// If onlyIfPropagateVolumeSelectionAllowed is true then field of view will be reset on
   /// only those slices where propagate volume selection is allowed
-  void FitSliceToAll(bool onlyIfPropagateVolumeSelectionAllowed=false);
+  /// If resetOrientation is true then slice orientation can be modified during function call
+  void FitSliceToAll(bool onlyIfPropagateVolumeSelectionAllowed=false, bool resetOrientation=true);
 
   /// Propagate selected table in the SelectionNode to table view nodes.
   void PropagateTableSelection();


### PR DESCRIPTION
The useful FitSliceToAll function in ApplicationLogic may change the slice view orientation. User may want to keep the current orientation and simply adjust the FOV.