### PR TITLE
COMP: Update SimpleITK to v2.1.0

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -122,7 +122,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "1062acf7705dd53f0cf01789b7c4a3b4a1bf15a0"  # April 5th 2021
+    "v2.1.0"
     QUIET
     )
 


### PR DESCRIPTION
This updates SimpleITK to a tagged release. Should be tested across the platforms to confirm none of these final updates from the pre-release version to the tagged release cause issues.

```
$ git shortlog --topo-order --no-merges 1062acf..v2.1.0
Bradley Lowekamp (25):
      Use https://simpleitk.org
      CircleCI fix typo in anchor name
      Wrap the ComposeScaleSkewVersor3DTransform
      Document ComposeScaleSkewVersorTransform in Sphinx overviews
      Add ComposeScaleSkewVersor3DTransform header to wrapping interface
      Add another baseline image for the SLICImageFilter "default" case
      Release tolerance for SLICImageFilter.default measurement
      Add alternative baseline for ImageRegistrationMethodDisplacement1
      Add Image GetBufferAsNativePointer and GetBufferAsBuffer methods
      Ignore constant Image::GetBufferAs.. methods
      Add testing for Java GetBufferAsBuffer interface
      Remove debugging code from ComposeScaleSkewVersor3DTransform test
      Add registration of ComposeScaleSkewVersor3DTransform
      Update SWIG to 4 require in CMake find_package
      Remove filename from sha512 has file
      Add example demonstration Java Image buffer interface
      Update HistogramMatchingImageFilter to use name referenceImage input
      Remove explicit instantiating of Image of deque of LabelObjectLine
      Add StopRegistration method to DemonsRegistrationFilter
      Adding testing for StopRegistration
      Add StopRegistration method to other Demons based registration fitlers
      Update to C++14 for ITK master build
      Add ImageRegistrationMethod::StopRegistration method
      Add Testing for ImageRegistrationMethod::StopRegistration
      Fix comparison between signed and unsigned integer warning

Dave Chen (7):
      Sphinx add_stylesheet -> add_css_file
      Added a Windows build page
      removed { in Cpp examples
      include all langs in the docs
      Changed type from UInt32 to Int32
      initial checkin of MacARM scripts
      don't overwrite SIMPLEITK_GIT_TAG if set in env

Dave Mackey (2):
      Spelling correction
      Minor grammar change to gettingStarted

Richard Beare (1):
      BUG: Calls to nonexistent methods weren't handled gracefully

Ziv Yaniv (6):
      DOC: Registration initialization and center of rotation docs.
      DOC: Adding details on naming conventions and OO, procedural interfaces.
      STYLE: Renamed variables to meaningful names.
      Adding example illustrating usage of optimizer weights.
      DOC: Improve documentation for registration sampling strategies.
      DOC: Additional information on registration sampling strategies.
```