### PR TITLE
BUG: Remove temporary database files when the database is closed

### DIFF
--- a/Libs/MRML/Widgets/qMRMLCheckableNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLCheckableNodeComboBox.cxx
@@ -171,11 +171,11 @@ void qMRMLCheckableNodeComboBox::setCheckState(vtkMRMLNode* node, Qt::CheckState
     qobject_cast<ctkCheckableComboBox*>(d->ComboBox);
   QModelIndexList indexes =
     d->indexesFromMRMLNodeID(node ? node->GetID(): QString());
-  if (indexes.count() == 0)
+  if (indexes.count() < 1)
     {
     return;
     }
-  return checkableComboBox->setCheckState(indexes[0], check);
+  checkableComboBox->setCheckState(indexes[0], check);
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
@@ -390,27 +390,16 @@ void qMRMLPlotViewControllerWidget::updateWidgetFromMRML()
 
   // Plot series selector
   bool plotBlockSignals = d->plotSeriesComboBox->blockSignals(true);
-
   for (int idx = 0; idx < d->plotSeriesComboBox->nodeCount(); idx++)
     {
-    vtkMRMLNode* node = d->plotSeriesComboBox->nodeFromIndex(idx);
-    d->plotSeriesComboBox->setCheckState(node, Qt::Unchecked);
-    }
-
-  std::vector<std::string> plotSeriesNodesIDs;
-  mrmlPlotChartNode->GetPlotSeriesNodeIDs(plotSeriesNodesIDs);
-  for (std::vector<std::string>::iterator it = plotSeriesNodesIDs.begin();
-    it != plotSeriesNodesIDs.end(); ++it)
-    {
-    vtkMRMLPlotSeriesNode *plotSeriesNode = vtkMRMLPlotSeriesNode::SafeDownCast
-      (this->mrmlScene()->GetNodeByID((*it).c_str()));
-    if (plotSeriesNode == nullptr)
+    vtkMRMLNode* plotSeriesNode = d->plotSeriesComboBox->nodeFromIndex(idx);
+    Qt::CheckState checkState = Qt::Unchecked;
+    if (plotSeriesNode && mrmlPlotChartNode->HasPlotSeriesNodeID(plotSeriesNode->GetID()))
       {
-      continue;
+      checkState = Qt::Checked;
       }
-    d->plotSeriesComboBox->setCheckState(plotSeriesNode, Qt::Checked);
+    d->plotSeriesComboBox->setCheckState(plotSeriesNode, checkState);
     }
-
   d->plotSeriesComboBox->blockSignals(plotBlockSignals);
 
   d->actionShow_Grid->setChecked(mrmlPlotChartNode->GetGridVisibility());

--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
@@ -660,7 +660,7 @@ void qSlicerSubjectHierarchySegmentationsPlugin::onSegmentAdded(vtkObject* calle
     {
     return;
     }
-  if (segmentationNode->GetScene()->IsImporting())
+  if (segmentationNode->GetScene() && segmentationNode->GetScene()->IsImporting())
     {
     // During scene import SH may not exist yet (if the scene was created without automatic SH creation)
     return;
@@ -804,9 +804,9 @@ void qSlicerSubjectHierarchySegmentationsPlugin::onSegmentModified(vtkObject* ca
     {
     return;
     }
-  if (segmentationNode->GetScene()->IsImporting())
+  if (segmentationNode->GetScene() && segmentationNode->GetScene()->IsImporting())
     {
-    // during scene import SH may not exist yet (if the scene was created without automatic SH creation)
+    // During scene import SH may not exist yet (if the scene was created without automatic SH creation)
     return;
     }
   vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
@@ -1205,6 +1205,11 @@ void qSlicerSubjectHierarchySegmentationsPlugin::updateAllSegmentsFromMRML(vtkMR
   if (!segmentationNode)
     {
     qWarning() << Q_FUNC_INFO << ": invalid segmentation node";
+    return;
+    }
+  if (segmentationNode->GetScene() && segmentationNode->GetScene()->IsImporting())
+    {
+    // During scene import SH may not exist yet (if the scene was created without automatic SH creation)
     return;
     }
   vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();

--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -349,14 +349,13 @@ def deleteTemporaryDatabase(dicomDatabase, cleanup=True):
   dicomDatabase.closeDatabase()
 
   if cleanup:
-    dicomDatabase.initializeDatabase()
-    # TODO: The database files cannot be deleted even if the database is closed.
-    #       Not critical, as it will be empty, so will not take measurable disk space.
-    # import shutil
-    # databaseDir = os.path.split(dicomDatabase.databaseFilename)[0]
-    # shutil.rmtree(databaseDir)
-    # if os.access(databaseDir, os.F_OK):
-      # logging.error('Failed to delete DICOM database ' + databaseDir)
+    import shutil
+    databaseDir = os.path.split(dicomDatabase.databaseFilename)[0]
+    shutil.rmtree(databaseDir)
+    if os.access(databaseDir, os.F_OK):
+      logging.error('Failed to delete DICOM database ' + databaseDir)
+      # Database is still in use, at least clear its content
+      dicomDatabase.initializeDatabase()
 
   return True
 


### PR DESCRIPTION
The code to delete the database was commented out several years ago (before the large DICOM database refactoring). The temporary database files can now be deleted properly.