### PR TITLE
ENH: Add prefix for oblique slice offset

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -78,7 +78,7 @@ qMRMLSliceControllerWidgetPrivate::qMRMLSliceControllerWidgetPrivate(qMRMLSliceC
   qMRMLOrientation axialOrientation = {qMRMLSliceControllerWidget::tr("S: "), qMRMLSliceControllerWidget::tr("I <-----> S")};
   qMRMLOrientation sagittalOrientation = {qMRMLSliceControllerWidget::tr("R: "), qMRMLSliceControllerWidget::tr("L <-----> R")};
   qMRMLOrientation coronalOrientation = {qMRMLSliceControllerWidget::tr("A: "), qMRMLSliceControllerWidget::tr("P <-----> A")};
-  qMRMLOrientation obliqueOrientation = {"", qMRMLSliceControllerWidget::tr("Oblique")};
+  qMRMLOrientation obliqueOrientation = {qMRMLSliceControllerWidget::tr("O: "), qMRMLSliceControllerWidget::tr("Oblique")};
 
   this->SliceOrientationToDescription["Axial"] = axialOrientation;
   this->SliceOrientationToDescription["Sagittal"] = sagittalOrientation;
@@ -1572,7 +1572,7 @@ qMRMLOrientation qMRMLSliceControllerWidgetPrivate::mrmlOrientation(const QStrin
     {
     return it.value();
     }
-  qMRMLOrientation obliqueOrientation = {"", qMRMLSliceControllerWidget::tr("Oblique")};
+  qMRMLOrientation obliqueOrientation = {qMRMLSliceControllerWidget::tr("O: "), qMRMLSliceControllerWidget::tr("Oblique")};
   return obliqueOrientation;
 }
 

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -406,9 +406,12 @@ void qMRMLSliceControllerWidgetPrivate::init()
 
   //this->SliceOffsetSlider->spinBox()->setParent(this->PopupWidget);
   ctkDoubleSpinBox* spinBox = this->SliceOffsetSlider->spinBox();
+  // Fix the size of the sliceOffset spinbox to avoid flickering when its value changes
+  spinBox->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Ignored);
+  spinBox->setMaximumWidth(60);
+  spinBox->setMinimumWidth(60);
   spinBox->setFrame(false);
   spinBox->spinBox()->setButtonSymbols(QAbstractSpinBox::NoButtons);
-  spinBox->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Ignored);
   int targetHeight = spinBox->parentWidget()->layout()->sizeHint().height();//setSizeConstraint(QLayout::SetMinimumSize);
   int fontHeight = spinBox->fontMetrics().height();
   qreal heightRatio = static_cast<qreal>(targetHeight - 2) / fontHeight;


### PR DESCRIPTION
Currently, no prefix is printed in the slice offset label for oblique slices. This may induce flickering of the slice offset slider when switching view orientations, for instance. 