### PR TITLE
COMP: Update qSlicerSceneReader to fix compilation using Qt < 5.14

### DIFF
--- a/Modules/Loadable/Data/qSlicerSceneReader.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneReader.cxx
@@ -162,11 +162,10 @@ bool qSlicerSceneReader::load(const qSlicerIO::IOProperties& properties)
       QSet<QString> notInstalledExtensions = lastLoadedExtensionsList.toSet().subtract(extensionsList.toSet());
       if (!notInstalledExtensions.isEmpty())
         {
-        QStringList notInstalledExtensionsList(notInstalledExtensions.begin(), notInstalledExtensions.end());
         QString extensionsInformation =
           tr("These extensions were installed when the scene was saved but not installed now: %1."
              " These extensions may be required for successful loading of the scene.")
-          .arg(notInstalledExtensionsList.join(", "));
+          .arg(QStringList::fromSet(notInstalledExtensions).join(", "));
         this->userMessages()->AddMessage(vtkCommand::MessageEvent, extensionsInformation.toStdString());
         }
       }


### PR DESCRIPTION
This commit fixes a regression introduced in 4c8b2803f (ENH: Report more
scene loading errors)

Co-authored-by: Rafael Palomar <rafael.palomar@rr-research.no>