### PR TITLE
Disable default vtk keyboard shortcuts

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
@@ -1065,6 +1065,14 @@ void vtkMRMLSegmentationDisplayNode::GetVisibleSegmentIDs(std::vector<std::strin
 }
 
 //---------------------------------------------------------------------------
+std::vector<std::string> vtkMRMLSegmentationDisplayNode::GetVisibleSegmentIDs()
+{
+  std::vector<std::string> visibleSegmentIDs;
+  this->GetVisibleSegmentIDs(visibleSegmentIDs);
+  return visibleSegmentIDs;
+}
+
+//---------------------------------------------------------------------------
 void vtkMRMLSegmentationDisplayNode::GetSegmentIDs(std::vector<std::string>& segmentIDs, bool visibleSegmentsOnly)
 {
   segmentIDs.clear();

--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.h
@@ -257,6 +257,9 @@ public:
   /// Get all visible segment IDs.
   void GetVisibleSegmentIDs(std::vector<std::string>& segmentIDs);
 
+  /// Get all visible segment IDs.
+  std::vector<std::string> GetVisibleSegmentIDs();
+
 protected:
   /// Convenience function for getting all segment IDs.
   void GetSegmentIDs(std::vector<std::string>& segmentIDs, bool visibleSegmentsOnly);

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
@@ -107,6 +107,7 @@ vtkMRMLCameraWidget::vtkMRMLCameraWidget()
   this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "Clear", WidgetEventCameraResetRotation);
   this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "KP_5", WidgetEventCameraResetTranslation);
   this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::ShiftModifier, 0, 0, "Clear", WidgetEventCameraResetTranslation);
+  this->SetKeyboardEventTranslation(WidgetStateIdle, vtkEvent::NoModifier, 0, 0, "r", WidgetEventCameraResetFieldOfView);
 
   // Rotate
   this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::LeftButtonPressEvent, vtkEvent::NoModifier,
@@ -321,7 +322,13 @@ bool vtkMRMLCameraWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* e
       this->SaveStateForUndo();
       this->CameraNode->Reset(false, true, false, this->Renderer);
       break;
-
+    case WidgetEventCameraResetFieldOfView:
+      this->SaveStateForUndo();
+      if (this->Renderer != nullptr)
+        {
+        this->Renderer->ResetCamera();
+        }
+      break;
     case WidgetEventCameraZoomIn:
       this->SaveStateForUndo();
       this->Dolly(1.2);

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
@@ -113,6 +113,7 @@ public:
     WidgetEventCameraReset,
     WidgetEventCameraResetTranslation,
     WidgetEventCameraResetRotation,
+    WidgetEventCameraResetFieldOfView, // VTK's standard camera reset (centers and resets field of view)
 
     WidgetEventCameraRotate,
     WidgetEventCameraPan,

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewInteractorStyle.cxx
@@ -81,7 +81,9 @@ void vtkMRMLViewInteractorStyle::OnChar()
     {
     return;
     }
-  this->Superclass::OnChar();
+  // Do not call this->Superclass::OnChar(), because char OnChar events perform various
+  // low-level operations on the actors (change their rendering style to wireframe, pick them,
+  // change rendering mode to stereo, etc.), which would interfere with displayable managers.
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/vtkSegmentationCore/vtkSegmentation.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.cxx
@@ -901,6 +901,14 @@ void vtkSegmentation::GetSegmentIDs(vtkStringArray* segmentIds)
 }
 
 //---------------------------------------------------------------------------
+std::vector<std::string> vtkSegmentation::GetSegmentIDs()
+{
+  std::vector<std::string> segmentIds;
+  this->GetSegmentIDs(segmentIds);
+  return segmentIds;
+}
+
+//---------------------------------------------------------------------------
 void vtkSegmentation::ApplyLinearTransform(vtkAbstractTransform* transform)
 {
   // Check if input transform is indeed linear

--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -230,6 +230,9 @@ public:
   /// Get IDs for all contained segments, for python compatibility
   void GetSegmentIDs(vtkStringArray* segmentIds);
 
+  /// Get IDs for all contained segments, for python compatibility
+  std::vector<std::string> GetSegmentIDs();
+
   /// Request the total number of segments, primarily used for iterating over all segments
   int GetNumberOfSegments() const;
 


### PR DESCRIPTION
VTK interactors have a number of keyboard shortcuts for various low-level operations, such as change rendering style of all actors to wireframe or change rendering mode to stereo.
These interfere with rendering settings set by displayable managers, therefore it is better to disable them.

The only useful keyboard shortcut ('r' key for camera reset) is now handled by the vtkCameraWidget.

fixes #5772

Also bundled an unrelated commit in the pull request, to add methods that return std::vector<std::string>. These string vectors are now wrapped in Python and they are much more convenient to use than vtkStringArray.