### PR TITLE
ENH: qSlicerWebWidget: Log javascript message if developer mode is enabled

### DIFF
--- a/Base/QTGUI/qSlicerWebWidget.cxx
+++ b/Base/QTGUI/qSlicerWebWidget.cxx
@@ -67,7 +67,8 @@ public:
 // --------------------------------------------------------------------------
 qSlicerWebEnginePage::qSlicerWebEnginePage(QWebEngineProfile *profile, QObject *parent)
   : QWebEnginePage(profile, parent),
-    WebWidget(nullptr)
+    WebWidget(nullptr),
+    JavaScriptConsoleMessageLoggingEnabled(false)
 {
 }
 
@@ -115,6 +116,7 @@ void qSlicerWebWidgetPrivate::init()
   this->initializeWebEngineProfile(profile);
 
   this->WebEnginePage = new qSlicerWebEnginePage(profile, this->WebView);
+  this->WebEnginePage->JavaScriptConsoleMessageLoggingEnabled = developerModeEnabled;
   this->WebEnginePage->WebWidget = q;
   this->WebView->setPage(this->WebEnginePage);
 
@@ -285,6 +287,20 @@ void qSlicerWebWidget::setInternalHosts(const QStringList& hosts)
 {
   Q_D(qSlicerWebWidget);
   d->InternalHosts = hosts;
+}
+
+// --------------------------------------------------------------------------
+bool qSlicerWebWidget::javaScriptConsoleMessageLoggingEnabled() const
+{
+  Q_D(const qSlicerWebWidget);
+  return d->WebEnginePage->JavaScriptConsoleMessageLoggingEnabled;
+}
+
+// --------------------------------------------------------------------------
+void qSlicerWebWidget::setJavaScriptConsoleMessageLoggingEnabled(bool enable)
+{
+  Q_D(qSlicerWebWidget);
+  d->WebEnginePage->JavaScriptConsoleMessageLoggingEnabled = enable;
 }
 
 // --------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerWebWidget.h
+++ b/Base/QTGUI/qSlicerWebWidget.h
@@ -47,6 +47,7 @@ class Q_SLICER_BASE_QTGUI_EXPORT qSlicerWebWidget
   Q_OBJECT
   Q_PROPERTY(bool handleExternalUrlWithDesktopService READ handleExternalUrlWithDesktopService WRITE setHandleExternalUrlWithDesktopService)
   Q_PROPERTY(QStringList internalHosts READ internalHosts WRITE setInternalHosts)
+  Q_PROPERTY(bool javaScriptConsoleMessageLoggingEnabled READ javaScriptConsoleMessageLoggingEnabled WRITE setJavaScriptConsoleMessageLoggingEnabled)
   Q_PROPERTY(QString url READ url WRITE setUrl)
   friend class qSlicerWebEnginePage;
 public:
@@ -75,6 +76,15 @@ public:
   /// \sa setHandleExternalUrlWithDesktopService(bool)
   QStringList internalHosts() const;
   void setInternalHosts(const QStringList& hosts);
+
+  /// \brief Return true if javascript console messages should be logged.
+  ///
+  /// Default value initialized based on the "Developer/DeveloperMode" setting.
+  ///
+  /// \sa setJavaScriptConsoleMessageLoggingEnabled(bool)
+  /// \sa QWebEnginePage::javaScriptConsoleMessage
+  bool javaScriptConsoleMessageLoggingEnabled() const;
+  void setJavaScriptConsoleMessageLoggingEnabled(bool enable);
 
 //  QWebEngineProfile* profile()const;
 //  void setProfile(QWebEngineProfile* profile);

--- a/Base/QTGUI/qSlicerWebWidget_p.h
+++ b/Base/QTGUI/qSlicerWebWidget_p.h
@@ -69,8 +69,30 @@ protected:
              << qPrintable(certificateError.errorDescription());
     return false;
   }
+
+  void javaScriptConsoleMessage(JavaScriptConsoleMessageLevel level, const QString &message, int lineNumber, const QString &sourceID) override
+  {
+    if (this->JavaScriptConsoleMessageLoggingEnabled)
+      {
+      if (level == QWebEnginePage::InfoMessageLevel)
+        {
+        qInfo() << sourceID << lineNumber << message;
+        }
+      else if (level == QWebEnginePage::WarningMessageLevel)
+        {
+        qWarning() << sourceID << lineNumber << message;
+        }
+      else if (level == QWebEnginePage::ErrorMessageLevel)
+        {
+        qWarning() << sourceID << lineNumber << message;
+        }
+      }
+    this->QWebEnginePage::javaScriptConsoleMessage(level, message, lineNumber, sourceID);
+  }
+
 private:
   qSlicerWebWidget* WebWidget;
+  bool JavaScriptConsoleMessageLoggingEnabled;
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The purpose of this changes is to help identify issues within `qSlicerWebWidget` by inspecting the Slicer log file.