### PR TITLE
ENH: use measurment frame to color dti slices

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.cxx
@@ -32,6 +32,7 @@ Version:   $Revision: 1.2 $
 #include <vtkImageMapToWindowLevelColors.h>
 #include <vtkImageShiftScale.h>
 #include <vtkImageThreshold.h>
+#include <vtkMatrix4x4.h>
 #include <vtkObjectFactory.h>
 #include <vtkSphereSource.h>
 #include <vtkVersion.h>
@@ -224,6 +225,14 @@ void vtkMRMLDiffusionTensorVolumeDisplayNode::UpdateImageDataPipeline()
 
   Superclass::UpdateImageDataPipeline();
 
+}
+
+//----------------------------------------------------------------------------
+void
+vtkMRMLDiffusionTensorVolumeDisplayNode::SetTensorRotationMatrix(vtkMatrix4x4 *rotationMatrix)
+{
+  this->DTIMathematics->SetTensorRotationMatrix(rotationMatrix);
+  this->DTIMathematicsAlpha->SetTensorRotationMatrix(rotationMatrix);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionTensorVolumeDisplayNode.h
@@ -27,6 +27,7 @@ class vtkImageData;
 class vtkImageExtractComponents;
 class vtkImageShiftScale;
 class vtkImageMathematics;
+class vtkMatrix4x4;
 
 /// \brief MRML node for representing a volume (image stack).
 ///
@@ -153,6 +154,12 @@ class VTK_MRML_EXPORT vtkMRMLDiffusionTensorVolumeDisplayNode : public vtkMRMLGl
   vtkAlgorithmOutput* GetBackgroundImageStencilDataConnection() override;
 
   void UpdateImageDataPipeline() override;
+
+  ///
+  /// Set the measurement frame for the tensors so that any
+  /// rotation-dependent calculations, such as ColorByOrientation
+  /// can take it into account when rendering.
+  void SetTensorRotationMatrix(vtkMatrix4x4 *);
 
   vtkGetObjectMacro(DTIMathematics, vtkDiffusionTensorMathematics);
   vtkGetObjectMacro(DTIMathematicsAlpha, vtkDiffusionTensorMathematics);

--- a/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLayerLogic.cxx
@@ -743,7 +743,7 @@ void vtkMRMLSliceLayerLogic::UpdateImageDisplay()
       assignScalarsToTensorOutput->GetPointData()->Print(std::cerr);
       }
 
-    vtkMRMLDiffusionTensorVolumeDisplayNode *tensorDisplayNode = vtkMRMLDiffusionTensorVolumeDisplayNode::SafeDownCast(this->VolumeNode);
+    vtkMRMLDiffusionTensorVolumeDisplayNode *tensorDisplayNode = vtkMRMLDiffusionTensorVolumeDisplayNode::SafeDownCast(this->VolumeDisplayNode);
     vtkMRMLDiffusionTensorVolumeNode *tensorNode = vtkMRMLDiffusionTensorVolumeNode::SafeDownCast(this->VolumeNode);
     if (tensorDisplayNode && tensorNode)
       {


### PR DESCRIPTION
The color-by-orientation slice rendering mode
should take into account the measurement frame
of the tensor acquistion.

This information is stored in the
vtkMRMLDiffusionTensorVolumeNode
and needs to be copied to the
vtkMRMLDiffusionTensorVolumeNode.