### PR TITLE
BUG: Fix loading of extension installed using "Girder_v1" serverAPI

### DIFF
--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -2690,6 +2690,7 @@ QHash<QString, QString> qSlicerExtensionsManagerModel::serverToExtensionDescript
   else if (serverAPI == Self::Girder_v1)
     {
     serverToExtensionDescriptionKey.insert("_id", "extension_id");
+    serverToExtensionDescriptionKey.insert("meta.app_revision", "slicer_revision");
     serverToExtensionDescriptionKey.insert("meta.baseName", "extensionname");
     serverToExtensionDescriptionKey.insert("meta.repository_type", "scm");
     serverToExtensionDescriptionKey.insert("meta.repository_url", "scmurl");


### PR DESCRIPTION
This commit ensures the slicer revision is properly associated with
extension manager model by converting the server specific metadata key
"meta.app_revision" to the one used internally "slicer_revision".

It avoids false positive associated with the function
"qSlicerExtensionsManagerModelPrivate::isExtensionCompatible" and also avoids
message like "Incompatible with Slicer rNNNNN [built for r]" from being reported

Fixes #5786