### PR TITLE
COMP: Report Midas_v1 extension package upload failures as warnings

### DIFF
--- a/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake
+++ b/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake
@@ -313,7 +313,7 @@ foreach(p ${package_list})
         )
       if(NOT slicer_midas_upload_status STREQUAL "ok")
         file(WRITE ${EXTENSION_BINARY_DIR}/PACKAGES.txt "")
-        message(FATAL_ERROR
+        message(WARNING
   "Upload of [${package_name}] failed !
   Check that:
   (1) you have been granted permission to upload


### PR DESCRIPTION
This ensures that the upload to Girder_v1 server will always happen.