### PR TITLE
ENH: captureImageFromView processEvents is optional

### DIFF
--- a/Modules/Scripted/ScreenCapture/ScreenCapture.py
+++ b/Modules/Scripted/ScreenCapture/ScreenCapture.py
@@ -1007,7 +1007,7 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
 
     return sliceOffsetResolution
 
-  def captureImageFromView(self, view, filename=None, transparentBackground=False, volumeNode=None):
+  def captureImageFromView(self, view, filename=None, transparentBackground=False, volumeNode=None, processEvents=True):
     """
     Capture an image of the specified view and store in the specified object.
 
@@ -1015,8 +1015,10 @@ class ScreenCaptureLogic(ScriptedLoadableModuleLogic):
     :param filename: Filename of the desired output file. If none, no file will be written.
     :param transparentBackground: Set the background to be transparent for single-view captures.
     :param volumeNode: Vector volume node to store the capture image. If none, no vector volume node will be updated.
+    :param processEvents: Whether to process events before capturing the image. If true the view will visibly update before capture.
     """
-    slicer.app.processEvents()
+    if processEvents:
+      slicer.app.processEvents()
     if view:
       if type(view)==slicer.qMRMLSliceView or type(view)==slicer.qMRMLThreeDView:
         view.forceRender()


### PR DESCRIPTION
I have a python scripted module which hides segmentations and changes slice offsets before screenshotting, every time a segmentation is modified. After screenshot the slice offsets and segmentation visibilities are restored. I use `ScreenCaptureLogic().captureImageFromView(view, volumeNode=screenshot_node)` but it is very jarring for the user when `slicer.app.processEvents()` is called which makes the offsets and seg update visible to the user before being restored.

I noticed that my screenshots are no different if I remove `slicer.app.processEvents()` so this PR makes that step optional for anyone who wants to take a screenshot without updating what is actually visible to the user.