### PR TITLE
COMP: Fix Girder_v1 upload of extension with semi-colon in any metadata

### DIFF
--- a/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake
+++ b/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake
@@ -335,20 +335,20 @@ foreach(p ${package_list})
         --api-url ${SLICER_EXTENSION_MANAGER_URL}/api/v1
         --api-key ${SLICER_EXTENSION_MANAGER_API_KEY}
           extension upload Slicer ${p}
-            --os ${EXTENSION_OPERATING_SYSTEM}
-            --arch ${EXTENSION_ARCHITECTURE}
-            --name ${EXTENSION_NAME}
-            --repo_type ${EXTENSION_WC_TYPE}
-            --repo_url ${EXTENSION_WC_URL}
-            --revision ${EXTENSION_WC_REVISION}
-            --app_revision ${Slicer_REVISION}
-            --category ${EXTENSION_CATEGORY}
+            --os "${EXTENSION_OPERATING_SYSTEM}"
+            --arch "${EXTENSION_ARCHITECTURE}"
+            --name "${EXTENSION_NAME}"
+            --repo_type "${EXTENSION_WC_TYPE}"
+            --repo_url "${EXTENSION_WC_URL}"
+            --revision "${EXTENSION_WC_REVISION}"
+            --app_revision "${Slicer_REVISION}"
+            --category "${EXTENSION_CATEGORY}"
             --desc "${EXTENSION_DESCRIPTION}"
-            --dependency ${dependency}
-            --icon_url ${EXTENSION_ICONURL}
-            --homepage ${EXTENSION_HOMEPAGE}
-            --screenshots ${EXTENSION_SCREENSHOTURLS}
-            --contributors ${EXTENSION_CONTRIBUTORS}
+            --dependency "${dependency}"
+            --icon_url "${EXTENSION_ICONURL}"
+            --homepage "${EXTENSION_HOMEPAGE}"
+            --screenshots "${EXTENSION_SCREENSHOTURLS}"
+            --contributors "${EXTENSION_CONTRIBUTORS}"
       RESULT_VARIABLE slicer_extension_manager_upload_status
       ERROR_FILE ${error_file}
       )


### PR DESCRIPTION
This commit generalizes to all metadata the change originally introduced
in 23e8fb730f (COMP: Fix upload of extension with semi-colon in description
metadata) and intended to fix a regression previously introduced in
8f33d93e8c (ENH: Ensure dependency metadata is published with extension
packages)

It fixes issue reported in https://github.com/KitwareMedical/slicer-extensions-webapp/issues/44