### PR TITLE
Improve markups rendering performance

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
@@ -615,7 +615,7 @@ bool vtkMRMLCameraWidget::ProcessRotate(vtkMRMLInteractionEventData* eventData)
     return true;
     }
 
-  int *size = this->Renderer->GetRenderWindow()->GetSize();
+  const int *size = this->Renderer->GetRenderWindow()->GetSize();
 
   double delta_elevation = -20.0 / size[1];
   double delta_azimuth = -20.0 / size[0];

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.cxx
@@ -298,7 +298,7 @@ void vtkMRMLCrosshairDisplayableManager::vtkInternal::BuildCrosshair()
     }
 
   // Get the size of the window
-  int *screenSize = this->External->GetInteractor()->GetRenderWindow()->GetScreenSize();
+  const int *screenSize = this->External->GetInteractor()->GetRenderWindow()->GetScreenSize();
 
   // Constants in display coordinates to define the crosshair
   int negW = -1.0*screenSize[0];

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager3D.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager3D.cxx
@@ -149,7 +149,7 @@ void vtkMRMLCrosshairDisplayableManager3D::vtkInternal::BuildCrosshair()
   this->CrosshairWidget->SetInteractor(interactor);
   this->CrosshairWidget->EnabledOn();
 
-  int *screenSize = interactor->GetRenderWindow()->GetScreenSize();
+  const int *screenSize = interactor->GetRenderWindow()->GetScreenSize();
 
   // Handle size is defined a percentage of screen size to accommodate high-DPI screens
   double handleSizeInScreenSizePercent = 5;

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
@@ -115,6 +115,8 @@ public:
   void SetInteractionContextName(const std::string& v);
   const std::string& GetInteractionContextName();
 
+  void WorldToDisplay(const double worldPosition[3], double displayPosition[3]);
+
 protected:
   int Modifiers;
   int DisplayPosition[2];
@@ -128,6 +130,8 @@ protected:
   int ComponentType;
   int ComponentIndex;
   bool MouseMovedSinceButtonDown;
+  double WorldToViewTransformMatrix[16];
+  bool WorldToViewTransformMatrixValid;
 
   //@{
   /// For KeyPressEvent

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -787,7 +787,7 @@ bool vtkMRMLSliceIntersectionWidget::ProcessBlend(vtkMRMLInteractionEventData* e
 {
   const int* eventPosition = eventData->GetDisplayPosition();
 
-  int* windowSize = this->Renderer->GetRenderWindow()->GetSize();
+  const int* windowSize = this->Renderer->GetRenderWindow()->GetSize();
   double windowMinSize = std::min(windowSize[0], windowSize[1]);
 
   int deltaY = eventPosition[1] - this->PreviousEventPosition[1];
@@ -1004,7 +1004,7 @@ bool vtkMRMLSliceIntersectionWidget::ProcessZoomSlice(vtkMRMLInteractionEventDat
 {
   const int* eventPosition = eventData->GetDisplayPosition();
 
-  int* windowSize = this->GetRenderer()->GetRenderWindow()->GetSize();
+  const int* windowSize = this->GetRenderer()->GetRenderWindow()->GetSize();
 
   int deltaY = eventPosition[1] - this->StartEventPosition[1];
   double percent = (windowSize[1] + deltaY) / (1.0 * windowSize[1]);
@@ -1039,7 +1039,7 @@ void vtkMRMLSliceIntersectionWidget::ScaleZoom(double zoomScaleFactor, vtkMRMLIn
 
   // Get distance of event position from slice center
   const int* eventPosition = eventData->GetDisplayPosition();
-  int* windowSize = this->GetRenderer()->GetRenderWindow()->GetSize();
+  const int* windowSize = this->GetRenderer()->GetRenderWindow()->GetSize();
   vtkMatrix4x4* xyToSlice = sliceNode->GetXYToSlice();
   double evenPositionDistanceFromOrigin[2] =
     {

--- a/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
@@ -349,7 +349,7 @@ void vtkMRMLWindowLevelWidget::ProcessAdjustWindowLevel(vtkMRMLInteractionEventD
   double rangeLow = this->VolumeScalarRange[0];
   double rangeHigh = this->VolumeScalarRange[1];
 
-  int* windowSize = this->GetRenderer()->GetRenderWindow()->GetSize();
+  const int* windowSize = this->GetRenderer()->GetRenderWindow()->GetSize();
   double windowMinSize = std::min(windowSize[0], windowSize[1]);
 
   double gain = (rangeHigh - rangeLow) / windowMinSize;

--- a/Libs/MRML/Widgets/qMRMLScreenShotDialog.cxx
+++ b/Libs/MRML/Widgets/qMRMLScreenShotDialog.cxx
@@ -362,7 +362,7 @@ void qMRMLScreenShotDialog::grabScreenShot(int screenshotWindow)
     renderWindow->OffScreenRenderingOn();
 
     // Resize render window and slice widget
-    int* renderWindowSize = renderWindow->GetSize();
+    const int* renderWindowSize = renderWindow->GetSize();
     int width = renderWindowSize[0];
     int height = renderWindowSize[1];
     int scaledWidth = width * scaleFactor;

--- a/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation2D.cxx
+++ b/Modules/Loadable/Annotations/VTKWidgets/vtkAnnotationROIRepresentation2D.cxx
@@ -691,7 +691,7 @@ double vtkAnnotationROIRepresentation2D::ComputeHandleRadiusInWorldCoordinates(d
     {
     return defaultHandleRadius;
     }
-  int* windowSize = this->Renderer->GetRenderWindow()->GetSize();
+  const int* windowSize = this->Renderer->GetRenderWindow()->GetSize();
   if (!windowSize)
     {
     return defaultHandleRadius;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -1228,7 +1228,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateViewScaleFactor()
     return;
     }
 
-  int* screenSize = this->Renderer->GetRenderWindow()->GetScreenSize();
+  const int* screenSize = this->Renderer->GetRenderWindow()->GetScreenSize();
   this->ScreenSizePixel = sqrt(screenSize[0] * screenSize[0] + screenSize[1] * screenSize[1]);
 
   vtkMatrix4x4* xyToSlice = this->GetSliceNode()->GetXYToSlice();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -1316,7 +1316,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateViewScaleFactor()
     return;
     }
 
-  int* screenSize = this->Renderer->GetRenderWindow()->GetScreenSize();
+  const int* screenSize = this->Renderer->GetRenderWindow()->GetScreenSize();
   double screenSizePixel = sqrt(screenSize[0] * screenSize[0] + screenSize[1] * screenSize[1]);
   if (screenSizePixel < 1.0)
     {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -379,7 +379,6 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
     return;
     }
 
-  const auto viewScaleFactorAtPositionInitCache = this->ViewScaleFactorAtPositionCalculationDataCache.InitCache();
   if (markupsNode->GetNumberOfControlPoints() > 2 && this->CurveClosed)
     {
     // Check if center is selected
@@ -387,12 +386,9 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
     markupsNode->GetCenterPosition(centerPosWorld);
     if (interactionEventData->IsDisplayPositionValid())
       {
-      double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(centerPosWorld)
+      double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(centerPosWorld, interactionEventData)
         + this->PickingTolerance * this->ScreenScaleFactor;
-      this->Renderer->SetWorldPoint(centerPosWorld);
-      this->Renderer->WorldToDisplay();
-      this->Renderer->GetDisplayPoint(centerPosDisplay);
-      centerPosDisplay[2] = 0.0;
+      interactionEventData->WorldToDisplay(centerPosWorld, centerPosDisplay);
       double dist2 = vtkMath::Distance2BetweenPoints(centerPosDisplay, displayPosition3);
       if (dist2 < pixelTolerance * pixelTolerance)
         {
@@ -470,12 +466,9 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
       }
     if (interactionEventData->IsDisplayPositionValid())
       {
-      double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(centerPosWorld)
+      double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(centerPosWorld, interactionEventData)
         + this->PickingTolerance * this->ScreenScaleFactor;
-      this->Renderer->SetWorldPoint(centerPosWorld);
-      this->Renderer->WorldToDisplay();
-      this->Renderer->GetDisplayPoint(centerPosDisplay);
-      centerPosDisplay[2] = 0.0;
+      interactionEventData->WorldToDisplay(centerPosWorld, centerPosDisplay);
       double dist2 = vtkMath::Distance2BetweenPoints(centerPosDisplay, displayPosition3);
       if (dist2 < pixelTolerance * pixelTolerance && dist2 < closestDistance2)
         {
@@ -554,12 +547,9 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteractWithHandles(
 
     if (interactionEventData->IsDisplayPositionValid())
       {
-      double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(handleWorldPos)
+      double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(handleWorldPos, interactionEventData)
         + this->PickingTolerance * this->ScreenScaleFactor;
-      this->Renderer->SetWorldPoint(handleWorldPos);
-      this->Renderer->WorldToDisplay();
-      this->Renderer->GetDisplayPoint(handleDisplayPos);
-      handleDisplayPos[2] = 0.0;
+      interactionEventData->WorldToDisplay(handleWorldPos, handleDisplayPos);
       double dist2 = vtkMath::Distance2BetweenPoints(handleDisplayPos, displayPosition3);
       if (dist2 < pixelTolerance * pixelTolerance && dist2 < closestDistance2)
         {
@@ -598,19 +588,14 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteractWithHandles(
 
       if (interactionEventData->IsDisplayPositionValid())
         {
-        double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(handleWorldPos)
+        double pixelTolerance = this->ControlPointSize / 2.0 / this->GetViewScaleFactorAtPosition(handleWorldPos, interactionEventData)
           + this->PickingTolerance * this->ScreenScaleFactor;
-        this->Renderer->SetWorldPoint(handleWorldPos);
-        this->Renderer->WorldToDisplay();
-        this->Renderer->GetDisplayPoint(handleDisplayPos);
-        handleDisplayPos[2] = 0.0;
+        interactionEventData->WorldToDisplay(handleWorldPos, handleDisplayPos);
 
         double originWorldPos[4] = { 0.0, 0.0, 0.0, 1.0 };
         this->InteractionPipeline->GetInteractionHandleOriginWorld(originWorldPos);
         double originDisplayPos[4] = { 0.0 };
-        this->Renderer->SetWorldPoint(originWorldPos);
-        this->Renderer->WorldToDisplay();
-        this->Renderer->GetDisplayPoint(originDisplayPos);
+        interactionEventData->WorldToDisplay(originWorldPos, originDisplayPos);
         originDisplayPos[2] = displayPosition3[2]; // Handles are always projected
         double t = 0;
         double lineDistance = vtkLine::DistanceToLine(displayPosition3, originDisplayPos, handleDisplayPos, t);
@@ -1207,7 +1192,6 @@ void vtkSlicerMarkupsWidgetRepresentation3D::SetRenderer(vtkRenderer *ren)
     }
 
   Superclass::SetRenderer(ren);
-  this->ViewScaleFactorAtPositionCalculationDataCache.SetRenderer(ren);
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
     {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[controlPointType]);
@@ -1252,44 +1236,10 @@ bool vtkSlicerMarkupsWidgetRepresentation3D::AccuratePick(int x, int y, double p
   return true;
 }
 
-//----------------------------------------------------------------------
-vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::InitCacheObject
-vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::InitCache()
-{
-  InitCacheObject result;
-  result.cache = this->NewCache();
-  this->CurrentCache = result.cache;
-  return result;
-}
+
 
 //----------------------------------------------------------------------
-std::shared_ptr<vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::Cache>
-vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::GetCache()
-{
-  if (std::shared_ptr<Cache> locked = this->CurrentCache.lock()) {
-    return locked;
-  }
-  return this->NewCache();
-}
-
-//----------------------------------------------------------------------
-std::shared_ptr<vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::Cache>
-vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::NewCache()
-{
-  std::shared_ptr<Cache> cache = std::make_shared<Cache>();
-  // the following was taken from vtkRenderer::WorldToView
-  if (this->Renderer && this->Renderer->GetActiveCamera())
-    {
-    vtkMatrix4x4::DeepCopy(cache->worldToViewTransform,
-      this->Renderer->GetActiveCamera()->
-      GetCompositeProjectionTransformMatrix(
-        this->Renderer->GetTiledAspectRatio(),0,1));
-    }
-  return cache;
-}
-
-//----------------------------------------------------------------------
-double vtkSlicerMarkupsWidgetRepresentation3D::GetViewScaleFactorAtPosition(double positionWorld[3])
+double vtkSlicerMarkupsWidgetRepresentation3D::GetViewScaleFactorAtPosition(double positionWorld[3], vtkMRMLInteractionEventData* interactionEventData)
 {
   double viewScaleFactorMmPerPixel = 1.0;
   if (!this->Renderer || !this->Renderer->GetActiveCamera())
@@ -1315,56 +1265,35 @@ double vtkSlicerMarkupsWidgetRepresentation3D::GetViewScaleFactorAtPosition(doub
     }
   else
     {
-    using PointType = std::array<double, 4>;
-    // this will only recompute the renderer's CompositeProjectionTransformMatrix
-    // if it is not cached
-    const auto dataCache = this->ViewScaleFactorAtPositionCalculationDataCache.GetCache();
-    if (!dataCache)
-      {
-      return viewScaleFactorMmPerPixel;
-      }
-
-    //get view to display scaling and put in 4x4 matrix
-    const double* viewport = this->Renderer->GetViewport();
-    const int* displaySize = this->Renderer->GetVTKWindow()->GetSize();
-
-    // This is essentially a reimplementation of vtkRenderer::WorldToDisplay.
-    // We don't use vtkRenderer::WorldToDisplay because it recomputes the
-    // CompositeProjectionTransformMatrix each time it is called, with no option
-    // for caching for multiple computations.
-    const auto worldToDisplay = [&](const PointType& worldPoint) {
-      PointType result;
-      // world to view
-      vtkMatrix4x4::MultiplyPoint(dataCache->worldToViewTransform, worldPoint.data(), result.data());
-      if (result[3] != 0.0)
-        {
-        result[0] /= result[3];
-        result[1] /= result[3];
-        result[2] /= result[3];
-        result[3] = 1.0;
-        }
-
-      // view to display
-      result[0] = (result[0] + 1.0) * (displaySize[0] * (viewport[2] - viewport[0])) / 2.0
-        + displaySize[0] * viewport[0];
-      result[1] = (result[1] + 1.0) * (displaySize[1] * (viewport[3] - viewport[1])) / 2.0
-        + displaySize[1] * viewport[1];
-      result[2] = 0.0;
-      return result;
-    };
-
-    const double cameraFP[4] = { positionWorld[0], positionWorld[1], positionWorld[2], 1.0 };
+    const double cameraFP[] = { positionWorld[0], positionWorld[1], positionWorld[2], 1.0};
     double cameraViewUp[3] = { 0 };
     cam->GetViewUp(cameraViewUp);
     vtkMath::Normalize(cameraViewUp);
 
-    // Get distance in pixels between two points at unit distance above and below the focal point
-    PointType topCenterPoint{cameraFP[0] + cameraViewUp[0], cameraFP[1] + cameraViewUp[1], cameraFP[2] + cameraViewUp[2], cameraFP[3]};
-    const PointType myTopCenter = worldToDisplay(topCenterPoint);
-    PointType bottomCenterPoint{cameraFP[0] - cameraViewUp[0], cameraFP[1] - cameraViewUp[1], cameraFP[2] - cameraViewUp[2], cameraFP[3]};
-    const PointType myBottomCenter = worldToDisplay(bottomCenterPoint);
-    const double distInPixels = sqrt(vtkMath::Distance2BetweenPoints(myTopCenter.data(), myBottomCenter.data()));
+    const double topCenterWorld[] = {cameraFP[0] + cameraViewUp[0], cameraFP[1] + cameraViewUp[1], cameraFP[2] + cameraViewUp[2], cameraFP[3]};
+    double topCenterDisplay[4];
+    const double bottomCenterWorld[] = {cameraFP[0] - cameraViewUp[0], cameraFP[1] - cameraViewUp[1], cameraFP[2] - cameraViewUp[2], cameraFP[3]};
+    double bottomCenterDisplay[4];
 
+    // the WorldToDisplay in interactionEventData is faster if someone has already
+    // called it once
+    if (interactionEventData)
+      {
+      interactionEventData->WorldToDisplay(topCenterWorld, topCenterDisplay);
+      interactionEventData->WorldToDisplay(bottomCenterWorld, bottomCenterDisplay);
+      }
+    else
+      {
+      std::copy(std::begin(topCenterWorld), std::end(topCenterWorld), std::begin(topCenterDisplay));
+      this->Renderer->WorldToDisplay(topCenterDisplay[0], topCenterDisplay[1], topCenterDisplay[2]);
+      topCenterDisplay[2] = 0.0;
+
+      std::copy(std::begin(bottomCenterWorld), std::end(bottomCenterWorld), std::begin(bottomCenterDisplay));
+      this->Renderer->WorldToDisplay(bottomCenterDisplay[0], bottomCenterDisplay[1], bottomCenterDisplay[2]);
+      bottomCenterDisplay[2] = 0.0;
+      }
+
+    const double distInPixels = sqrt(vtkMath::Distance2BetweenPoints(topCenterDisplay, bottomCenterDisplay));
     // if render window is not initialized yet then distInPixels == 0.0,
     // in that case just leave the default viewScaleFactorMmPerPixel
     if (distInPixels > 1e-3)

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -379,6 +379,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(
     return;
     }
 
+  const auto viewScaleFactorAtPositionInitCache = this->ViewScaleFactorAtPositionCalculationDataCache.InitCache();
   if (markupsNode->GetNumberOfControlPoints() > 2 && this->CurveClosed)
     {
     // Check if center is selected
@@ -1206,6 +1207,7 @@ void vtkSlicerMarkupsWidgetRepresentation3D::SetRenderer(vtkRenderer *ren)
     }
 
   Superclass::SetRenderer(ren);
+  this->ViewScaleFactorAtPositionCalculationDataCache.SetRenderer(ren);
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
     {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[controlPointType]);
@@ -1251,6 +1253,42 @@ bool vtkSlicerMarkupsWidgetRepresentation3D::AccuratePick(int x, int y, double p
 }
 
 //----------------------------------------------------------------------
+vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::InitCacheObject
+vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::InitCache()
+{
+  InitCacheObject result;
+  result.cache = this->NewCache();
+  this->CurrentCache = result.cache;
+  return result;
+}
+
+//----------------------------------------------------------------------
+std::shared_ptr<vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::Cache>
+vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::GetCache()
+{
+  if (std::shared_ptr<Cache> locked = this->CurrentCache.lock()) {
+    return locked;
+  }
+  return this->NewCache();
+}
+
+//----------------------------------------------------------------------
+std::shared_ptr<vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::Cache>
+vtkSlicerMarkupsWidgetRepresentation3D::ViewScaleFactorAtPositionCalculationDataCacheObject::NewCache()
+{
+  std::shared_ptr<Cache> cache = std::make_shared<Cache>();
+  // the following was taken from vtkRenderer::WorldToView
+  if (this->Renderer && this->Renderer->GetActiveCamera())
+    {
+    vtkMatrix4x4::DeepCopy(cache->worldToViewTransform,
+      this->Renderer->GetActiveCamera()->
+      GetCompositeProjectionTransformMatrix(
+        this->Renderer->GetTiledAspectRatio(),0,1));
+    }
+  return cache;
+}
+
+//----------------------------------------------------------------------
 double vtkSlicerMarkupsWidgetRepresentation3D::GetViewScaleFactorAtPosition(double positionWorld[3])
 {
   double viewScaleFactorMmPerPixel = 1.0;
@@ -1277,24 +1315,55 @@ double vtkSlicerMarkupsWidgetRepresentation3D::GetViewScaleFactorAtPosition(doub
     }
   else
     {
-    double cameraFP[4] = { positionWorld[0], positionWorld[1], positionWorld[2], 1.0 };
+    using PointType = std::array<double, 4>;
+    // this will only recompute the renderer's CompositeProjectionTransformMatrix
+    // if it is not cached
+    const auto dataCache = this->ViewScaleFactorAtPositionCalculationDataCache.GetCache();
+    if (!dataCache)
+      {
+      return viewScaleFactorMmPerPixel;
+      }
 
+    //get view to display scaling and put in 4x4 matrix
+    const double* viewport = this->Renderer->GetViewport();
+    const int* displaySize = this->Renderer->GetVTKWindow()->GetSize();
+
+    // This is essentially a reimplementation of vtkRenderer::WorldToDisplay.
+    // We don't use vtkRenderer::WorldToDisplay because it recomputes the
+    // CompositeProjectionTransformMatrix each time it is called, with no option
+    // for caching for multiple computations.
+    const auto worldToDisplay = [&](const PointType& worldPoint) {
+      PointType result;
+      // world to view
+      vtkMatrix4x4::MultiplyPoint(dataCache->worldToViewTransform, worldPoint.data(), result.data());
+      if (result[3] != 0.0)
+        {
+        result[0] /= result[3];
+        result[1] /= result[3];
+        result[2] /= result[3];
+        result[3] = 1.0;
+        }
+
+      // view to display
+      result[0] = (result[0] + 1.0) * (displaySize[0] * (viewport[2] - viewport[0])) / 2.0
+        + displaySize[0] * viewport[0];
+      result[1] = (result[1] + 1.0) * (displaySize[1] * (viewport[3] - viewport[1])) / 2.0
+        + displaySize[1] * viewport[1];
+      result[2] = 0.0;
+      return result;
+    };
+
+    const double cameraFP[4] = { positionWorld[0], positionWorld[1], positionWorld[2], 1.0 };
     double cameraViewUp[3] = { 0 };
     cam->GetViewUp(cameraViewUp);
     vtkMath::Normalize(cameraViewUp);
 
     // Get distance in pixels between two points at unit distance above and below the focal point
-    this->Renderer->SetWorldPoint(cameraFP[0] + cameraViewUp[0], cameraFP[1] + cameraViewUp[1], cameraFP[2] + cameraViewUp[2], cameraFP[3]);
-    this->Renderer->WorldToDisplay();
-    double topCenter[3] = { 0 };
-    this->Renderer->GetDisplayPoint(topCenter);
-    topCenter[2] = 0.0;
-    this->Renderer->SetWorldPoint(cameraFP[0] - cameraViewUp[0], cameraFP[1] - cameraViewUp[1], cameraFP[2] - cameraViewUp[2], cameraFP[3]);
-    this->Renderer->WorldToDisplay();
-    double bottomCenter[3] = { 0 };
-    this->Renderer->GetDisplayPoint(bottomCenter);
-    bottomCenter[2] = 0.0;
-    double distInPixels = sqrt(vtkMath::Distance2BetweenPoints(topCenter, bottomCenter));
+    PointType topCenterPoint{cameraFP[0] + cameraViewUp[0], cameraFP[1] + cameraViewUp[1], cameraFP[2] + cameraViewUp[2], cameraFP[3]};
+    const PointType myTopCenter = worldToDisplay(topCenterPoint);
+    PointType bottomCenterPoint{cameraFP[0] - cameraViewUp[0], cameraFP[1] - cameraViewUp[1], cameraFP[2] - cameraViewUp[2], cameraFP[3]};
+    const PointType myBottomCenter = worldToDisplay(bottomCenterPoint);
+    const double distInPixels = sqrt(vtkMath::Distance2BetweenPoints(myTopCenter.data(), myBottomCenter.data()));
 
     // if render window is not initialized yet then distInPixels == 0.0,
     // in that case just leave the default viewScaleFactorMmPerPixel

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -30,7 +30,6 @@
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation.h"
 
-#include <memory>
 #include <map>
 
 class vtkActor;
@@ -99,36 +98,7 @@ protected:
   vtkSlicerMarkupsWidgetRepresentation3D();
   ~vtkSlicerMarkupsWidgetRepresentation3D() override;
 
-  double GetViewScaleFactorAtPosition(double positionWorld[3]);
-
-  class ViewScaleFactorAtPositionCalculationDataCacheObject {
-  public:
-    inline void SetRenderer(vtkRenderer* renderer)
-    {
-      this->Renderer = renderer;
-    }
-    struct Cache {
-      double worldToViewTransform[16]; // matrix for the World to View transformation
-    };
-    struct InitCacheObject {
-      std::shared_ptr<Cache> cache;
-    };
-
-    /// Initializes the cache, doing needed computations. As long the returned object is
-    /// alive, GetCache will not redo any computations.
-    InitCacheObject InitCache();
-
-    /// Gets the cache, if exists, or computes the data
-    /// \returns A cache to the data needed by GetViewScaleFactorAtPosition
-    std::shared_ptr<Cache> GetCache();
-  private:
-    /// Creates a new cache object, doing needed computations
-    std::shared_ptr<Cache> NewCache();
-
-    vtkRenderer* Renderer;
-    std::weak_ptr<Cache> CurrentCache;
-  };
-  ViewScaleFactorAtPositionCalculationDataCacheObject ViewScaleFactorAtPositionCalculationDataCache;
+  double GetViewScaleFactorAtPosition(double positionWorld[3], vtkMRMLInteractionEventData* interactionEventData = nullptr);
 
   void UpdateViewScaleFactor() override;
 


### PR DESCRIPTION
Added fast `WorldToDisplay` to `vtkMRMLInteractionEventData` which will cache the Composite Projection Transform matrix from the camera on first use.

This seems to increase the FPS of scenes with high amounts of fiducial markups by 1-2 FPS. Therefore I do not think this solves the whole of the performance problem mentioned in https://github.com/Slicer/Slicer/issues/5752, but is a marginal improvement towards it.