### PR TITLE
BUG: Update interaction handle orientation when transform is hardened

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -1417,6 +1417,8 @@ bool vtkMRMLMarkupsNode::CanApplyNonLinearTransforms()const
 //---------------------------------------------------------------------------
 void vtkMRMLMarkupsNode::ApplyTransform(vtkAbstractTransform* transform)
 {
+  MRMLNodeModifyBlocker blocker(this);
+
   int numControlPoints = this->GetNumberOfControlPoints();
   double xyzIn[3];
   double xyzOut[3];
@@ -1871,6 +1873,7 @@ void vtkMRMLMarkupsNode::OnTransformNodeReferenceChanged(vtkMRMLTransformNode* t
 {
   vtkMRMLTransformNode::GetTransformBetweenNodes(this->GetParentTransformNode(), nullptr, this->CurvePolyToWorldTransform);
   Superclass::OnTransformNodeReferenceChanged(transformNode);
+  this->UpdateInteractionHandleToWorldMatrix();
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
The plane node interaction handle to world matrix was not updated when the transform was hardened.
Fixed by updating the matrix in vtkMRMLMarkupNode::OnTransformNodeReferenceChanged.

Also prevents the plane position from "flickering" by pausing modified events while vtkMRMLNode::ApplyTransform is being called.

Fix #5539