### PR TITLE
ENH: Incorporate ExportAs module into Slicer core

### DIFF
--- a/Modules/Loadable/Data/CMakeLists.txt
+++ b/Modules/Loadable/Data/CMakeLists.txt
@@ -7,6 +7,9 @@ string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
 #-----------------------------------------------------------------------------
 add_subdirectory(Logic)
+if(Slicer_USE_PYTHONQT)
+  add_subdirectory(SubjectHierarchyPlugins)
+endif()
 
 #-----------------------------------------------------------------------------
 set(MODULE_EXPORT_DIRECTIVE "Q_SLICER_QTMODULES_${MODULE_NAME_UPPER}_EXPORT")

--- a/Modules/Loadable/Data/SubjectHierarchyPlugins/CMakeLists.txt
+++ b/Modules/Loadable/Data/SubjectHierarchyPlugins/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(${MODULE_NAME}SubjectHierarchyPlugins_PYTHON_SCRIPTS
+  ${MODULE_NAME}SubjectHierarchyPlugin
+  )
+
+ctkMacroCompilePythonScript(
+  TARGET_NAME ${MODULE_NAME}SubjectHierarchyPlugins
+  SCRIPTS "${${MODULE_NAME}SubjectHierarchyPlugins_PYTHON_SCRIPTS}"
+  RESOURCES "${${MODULE_NAME}SubjectHierarchyPlugins_PYTHON_RESOURCES}"
+  DESTINATION_DIR ${Slicer_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}/SubjectHierarchyPlugins
+  INSTALL_DIR ${Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR}/SubjectHierarchyPlugins
+  NO_INSTALL_SUBDIR
+  )

--- a/Modules/Loadable/Data/SubjectHierarchyPlugins/DataSubjectHierarchyPlugin.py
+++ b/Modules/Loadable/Data/SubjectHierarchyPlugins/DataSubjectHierarchyPlugin.py
@@ -1,0 +1,147 @@
+import logging
+import vtk, qt, ctk, slicer
+from slicer.ScriptedLoadableModule import *
+
+from SubjectHierarchyPlugins import AbstractScriptedSubjectHierarchyPlugin
+
+class DataSubjectHierarchyPlugin(AbstractScriptedSubjectHierarchyPlugin):
+  """ Scripted subject hierarchy plugin for the ExportAs module.
+  """
+
+  # Necessary static member to be able to set python source to scripted subject hierarchy plugin
+  filePath = __file__
+
+  def __init__(self, scriptedPlugin):
+    AbstractScriptedSubjectHierarchyPlugin.__init__(self, scriptedPlugin)
+
+    pluginHandlerSingleton = slicer.qSlicerSubjectHierarchyPluginHandler.instance()
+    self.subjectHierarchyNode = pluginHandlerSingleton.subjectHierarchyNode()
+
+    self.exportAsAction = qt.QAction(f"Export as...", scriptedPlugin)
+    self.exportTransformedAsAction = qt.QAction(f"Export transformed as...", scriptedPlugin)
+    self.menu = qt.QMenu("Plugin menu")
+    self.transformedMenu = qt.QMenu("Transformed plugin menu")
+    self.exportAsAction.setMenu(self.menu)
+    self.exportTransformedAsAction.setMenu(self.transformedMenu)
+
+  #
+  # item context menus are what happens when you right click on a selected line
+  #
+  def itemContextMenuActions(self):
+    """the actions that could be shown for any of this plugins items"""
+    return [self.exportAsAction, self.exportTransformedAsAction]
+
+  def showContextMenuActionsForItem(self, itemID):
+    """Set actions visible that are valid for this itemID"""
+    # reset all menus
+    self.exportAsAction.visible = False
+    self.exportAsAction.enabled = False
+    self.exportTransformedAsAction.visible = False
+    self.exportTransformedAsAction.enabled = False
+    self.menu.clear()
+    self.transformedMenu.clear()
+    # check if this is parent or leaf
+    childIdList = vtk.vtkIdList()
+    self.subjectHierarchyNode.GetItemChildren(itemID, childIdList)
+    if childIdList.GetNumberOfIds() > 0:
+      self.showContextMenuActionsForParentItem(itemID, childIdList)
+    else:
+      self.showContextMenuActionsForLeafItem(itemID)
+
+  def parseWriteFormats(self, writeFormats):
+    # convert ('Markups JSON (.json)', 'Markups Fiducial CSV (.fcsv)')
+    # to "Markups *.mrk.json *.json *.fcsv"
+    # and {'.mrk.json': 'Markups JSON *.mrk.json', '.fcsv': 'Markups Fiducial CSV *.fcsv')
+    allExtensionsFilter = ""
+    filtersByExtension = {}
+    formatsByExtension = {}
+    for writerExtension in writeFormats:
+      extension = writerExtension.split()[-1][1:-1]
+      formatsByExtension[extension] = writerExtension
+      allExtensionsFilter += " *" + extension
+      filtersByExtension[extension] = f"{' '.join(writerExtension.split()[:-1])} *{extension}"
+    return allExtensionsFilter, filtersByExtension, formatsByExtension
+
+  def showContextMenuActionsForParentItem(self, itemID, childIdList):
+    # only enable if all children are same class
+    itemDataNodes = []
+    for childIDIndex in range(childIdList.GetNumberOfIds()):
+      childID = childIdList.GetId(childIDIndex)
+      itemDataNode = self.subjectHierarchyNode.GetItemDataNode(childID)
+      itemDataNodes.append(itemDataNode)
+      if itemDataNode is None or itemDataNode.GetClassName() != itemDataNodes[0].GetClassName():
+        return
+    self.exportAsAction.visible = True
+    self.exportAsAction.enabled = True
+    writeFormats = slicer.app.coreIOManager().fileWriterExtensions(itemDataNodes[0])
+    allExtensionsFilter, filtersByExtension, formatsByExtension = self.parseWriteFormats(writeFormats)
+    itemDataNode = itemDataNodes[0]
+    if itemDataNode is not None and itemDataNode.IsA("vtkMRMLStorableNode"):
+      allExtensionsFilter = itemDataNode.GetNodeTagName() + allExtensionsFilter
+      self.exportAsAction.enabled = True
+      for extension in filtersByExtension.keys():
+        a = self.menu.addAction(formatsByExtension[extension])
+        a.connect("triggered()", lambda extension=extension, writerFilter=filtersByExtension[extension], allExtensionsFilter=allExtensionsFilter,
+                  transformedFlag=False : self.exportNodes(itemDataNodes, extension, writerFilter, allExtensionsFilter))
+
+  def showContextMenuActionsForLeafItem(self, itemID):
+    self.exportAsAction.visible = True
+    self.exportAsAction.enabled = False
+    self.exportTransformedAsAction.visible = False
+    self.exportTransformedAsAction.enabled = False
+    self.menu.clear()
+    self.transformedMenu.clear()
+    itemDataNode = self.subjectHierarchyNode.GetItemDataNode(itemID)
+    writeFormats = slicer.app.coreIOManager().fileWriterExtensions(itemDataNode)
+    allExtensionsFilter, filtersByExtension, formatsByExtension = self.parseWriteFormats(writeFormats)
+    menuAndFlags = [[self.menu, False]]
+    if itemDataNode is not None and itemDataNode.IsA("vtkMRMLTransformableNode") and itemDataNode.GetTransformNodeID():
+      self.exportTransformedAsAction.visible = True
+      self.exportTransformedAsAction.enabled = True
+      menuAndFlags.append([self.transformedMenu, True])
+    # export without transforming menu entries
+    if itemDataNode is not None and itemDataNode.IsA("vtkMRMLStorableNode"):
+      allExtensionsFilter = itemDataNode.GetNodeTagName() + allExtensionsFilter
+      self.exportAsAction.enabled = True
+      for menu,transformedFlag in menuAndFlags:
+        for extension in filtersByExtension.keys():
+          a = menu.addAction(formatsByExtension[extension])
+          a.connect("triggered()", lambda extension=extension, writerFilter=filtersByExtension[extension], allExtensionsFilter=allExtensionsFilter,
+                    transformedFlag=transformedFlag : self.exportNode(itemDataNode, extension, writerFilter, allExtensionsFilter, transformedFlag))
+
+  def exportNode(self, node, extension, writerFilter, allExtensionsFilter = "", transformedFlag = False, filePath = None):
+    if transformedFlag:
+      shNode = slicer.vtkMRMLSubjectHierarchyNode.GetSubjectHierarchyNode(slicer.mrmlScene)
+      itemIDToClone = shNode.GetItemByDataNode(node)
+      clonedItemID = slicer.modules.subjecthierarchy.logic().CloneSubjectHierarchyItem(shNode, itemIDToClone)
+      clonedNode = shNode.GetItemDataNode(clonedItemID)
+      transformNode = slicer.mrmlScene.GetNodeByID(node.GetTransformNodeID())
+      clonedNode.SetAndObserveTransformNodeID(transformNode.GetID())
+      transformLogic = slicer.vtkSlicerTransformLogic()
+      transformLogic.hardenTransform(clonedNode)
+      node = clonedNode
+    if not filePath:
+      fileFilter = allExtensionsFilter + ";;" + writerFilter + ";;All files *"
+      filePath = qt.QFileDialog.getSaveFileName(slicer.util.mainWindow(),
+                                            "Export As...", node.GetName()+extension, fileFilter, None, qt.QFileDialog.DontUseNativeDialog)
+    if not filePath.endswith(extension):
+      filePath = filePath + extension
+    if filePath == "":
+      return
+    writerType = slicer.app.coreIOManager().fileWriterFileType(node)
+    success = slicer.app.coreIOManager().saveNodes(writerType, {"nodeID": node.GetID(), "fileName": filePath})
+    if success:
+      logging.info(f"Exported {node.GetName()} to {filePath}")
+    else:
+      slicer.util.errorDisplay(f"Could not save {node.GetName()} to {filePath}")
+    if transformedFlag:
+      slicer.mrmlScene.RemoveNode(clonedNode.GetStorageNode())
+      slicer.mrmlScene.RemoveNode(clonedNode.GetDisplayNode())
+      slicer.mrmlScene.RemoveNode(clonedNode)
+
+  def exportNodes(self, itemDataNodes, extension, writerFilter, allExtensionsFilter):
+    directoryPath = qt.QFileDialog.getExistingDirectory(slicer.util.mainWindow(),
+                                            "Export As...", qt.QFileDialog.DontUseNativeDialog)
+    for itemDataNode in itemDataNodes:
+      self.exportNode(itemDataNode, extension, writerFilter, allExtensionsFilter,
+                      transformedFlag=False, filePath=directoryPath+"/"+itemDataNode.GetName()+extension)

--- a/Modules/Loadable/Data/qSlicerDataModule.cxx
+++ b/Modules/Loadable/Data/qSlicerDataModule.cxx
@@ -46,6 +46,11 @@
 // VTK includes
 #include <vtkSmartPointer.h>
 
+// PythonQt includes
+#ifdef Slicer_USE_PYTHONQT
+#include "PythonQt.h"
+#endif
+
 //-----------------------------------------------------------------------------
 class qSlicerDataModulePrivate
 {
@@ -111,6 +116,20 @@ void qSlicerDataModule::setup()
   // Dialogs
   ioManager->registerDialog(new qSlicerDataDialog(this));
   ioManager->registerDialog(new qSlicerSaveDataDialog(this));
+
+  // Initialize subject hierarchy plugin
+#ifdef Slicer_USE_PYTHONQT
+  if (!qSlicerCoreApplication::testAttribute(qSlicerCoreApplication::AA_DisablePython))
+    {
+    PythonQt::init();
+    PythonQtObjectPtr context = PythonQt::self()->getMainModule();
+    context.evalScript( QString(
+      "from SubjectHierarchyPlugins import DataSubjectHierarchyPlugin \n"
+      "scriptedPlugin = slicer.qSlicerSubjectHierarchyScriptedPlugin(None) \n"
+      "scriptedPlugin.setPythonSource(DataSubjectHierarchyPlugin.filePath) \n"
+      ) );
+    }
+#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
See issue #4989

[ExportAs](https://github.com/SlicerMorph/SlicerMorph/tree/master/ExportAs) is a Slicer module that was created for the extension SlicerMorph.
This commit incorporates ExportAs into Slicer core, renaming the module from
`ExportAs` to `DataSubjectHierarchyPlugin`.

This subject hierarchy plugin is associated with the Data module as a whole,
rather than with any specific module. This is why I am organizing it as
a `SubjectHierarchyPlugin` under `Modules/Loadable/Data`. Please let me know if
there are better ways to go about organizing this.  

I followed `Modules/Loadable/Annotations/SubjectHierarchyPlugins/`
as a model for how to set this up, since it is an example of a subject hierarchy
plugin that is written in python and added under a loadable module. 

cc: @pieper 

---

Some problems:

(1) Since the module is now initialized in
`Modules/Loadable/Data/qSlicerDataModule.cxx`, the class derived from
`ScriptedLoadableModule` is no longer needed. But removing it did away with
data that attributes the module code to the original author. Here is the part
that was deleted:
```
class ExportAs(ScriptedLoadableModule):
    def __init__(self, parent):
        ScriptedLoadableModule.__init__(self, parent)
        parent.title = "SlicerMorph ExportAs Plugin"
        parent.categories = [""]
        parent.contributors = ["Steve Pieper, Isomics, Inc."]
        parent.helpText = ""
        parent.hidden = not slicer.util.settingsValue('Developer/DeveloperMode', False, converter=slicer.util.toBool)

        #
        # register subject hierarchy plugin once app is initialized
        #
        def onStartupCompleted():
            import SubjectHierarchyPlugins
            from ExportAs import ExportAsSubjectHierarchyPlugin
            scriptedPlugin = slicer.qSlicerSubjectHierarchyScriptedPlugin(None)
            scriptedPlugin.name = "ExportAs"
            scriptedPlugin.setPythonSource(ExportAsSubjectHierarchyPlugin.filePath)
        slicer.app.connect("startupCompleted()", onStartupCompleted)
```
I wonder, how should the attribution be incorporated?

(2) While the *Export as* context menu option seems to work great, I wasn't
able to test the *Export transformed as* option. It didn't show up when I
thought it should. We can probably move forward and address that feature later.
Or maybe I misunderstood how it's meant to work.

(3) Not all tests pass on my linux system. However CDash shows that there is currently a handful of failing tests on linux,
so this might not be due to my changes. Some tests may be failing because of quirks in my particular environment.
Here are the tests that failed on my system:
```
cmake_slicer_generate_extension_description_test (Failed)
py_cmake_slicer_extensions_index_build_with_upload (Failed)
py_cmake_slicer_extensions_index_build_with_upload_using_ctest (Failed)
qMRMLLayoutManagerVisibilityTest (Failed)
qMRMLNavigationViewTest1 (Failed)
qMRMLThreeDWidgetTest1 (Failed)
qMRMLNavigationViewEventTranslatorPlayerTest1 (Failed)
qMRMLThreeDWidgetEventTranslatorPlayerTest1 (Failed)
qSlicerUtilsTest1 (Failed)
qSlicerExtensionsManagerModelTest (Failed)
py_AnnotationsTestingAddManyROIs (Failed)
py_PluggableMarkupsSelfTest (Failed)
py_nomainwindow_SegmentationsModuleTest2 (Failed)
py_SlicerRestoreSceneViewCrashIssue3445 (Failed)
py_SurfaceToolbox (Failed)
```