### PR TITLE
DOC: Add debug instructions

### DIFF
--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -1,4 +1,4 @@
-# GNU/Linux Systems
+# GNU/Linux systems
 
 The instructions to build Slicer for GNU/Linux systems are slightly different
 depending on the linux distribution and the specific configuration of the

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -95,52 +95,8 @@ Slicer.exe --VisualStudioProject
 
 ## Debug Slicer
 
-1. To run Slicer, the launcher needs to set certain environment variables. The easiest is to use the launcher to set these and start Visual Studio in this environment. All these can be accomplished by running the following command in `<Slicer_BUILD>/c:\D\S4R\Slicer-build` folder:
-
-```
-Slicer.exe --VisualStudioProject
-```
-
-Notes:
-- If you just want to start VisualStudio with the launcher (and then load project file manually), run: `Slicer.exe --VisualStudio`
-- To debug an extension that builds third-party DLLs, also specify `--launcher-additional-settings` option.
-- While you can launch debugger using Slicer's solution file, it is usually more convenient to load your extension's solution file (because your extension solution is smaller and most likely you want to have that solution open anyway for making changes in your code). For example, you can launch Visual Studio to debug your extension like this:
-
-```
-.\S4D\Slicer-build\Slicer.exe --VisualStudio --launcher-no-splash --launcher-additional-settings ./SlicerRT_D/inner-build/AdditionalLauncherSettings.ini c:\d\_Extensions\SlicerRT_D\inner-build\SlicerRT.sln
-```
-
-2. In Solution Explorer window in Visual Studio, expand `App-Slicer`, right-click on `SlicerApp` (NOT qSlicerApp) and select "Set as Startup Project"
-
-To debug in an extension's solution: set `ALL_BUILD` project as startup project and in project settings, set `Debugging` / `Command` field to the full path of `SlicerApp-real.exe` - something like `.../Slicer-build/bin/Debug/SlicerApp-real.exe`
-
-3. Run Slicer in debug mode by Start Debugging command (in Debug menu).
-
-Note that because CMake re-creates the solution file from within the build process, Visual Studio will sometimes need to stop and reload the project, requiring manual button pressing on your part (just press Yes or OK whenever you are asked). To avoid this, you can use a script to complete the build process and then re-start the Visual Studio.
-
-For more debugging tips and tricks, check out [this page](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/Troubleshooting).
-
-### Debug a test
-
-Once VisualStudio is open with the Slicer environment loaded, it is possible to run and debug tests. To run all tests, build the `RUN_TESTS` project.
-
-- To debug a test, find its project:
-  - `Libs/MRML/Core` tests are in the `MRMLCoreCxxTests` project
-  - CLI module tests are in `<CLI_NAME>Test` project (e.g. `ThresholdScalarVolumeTest`)
-  Loadable module tests are in `qSlicer<LOADABLE_NAME>CxxTests` project (e.g. `qSlicerVolumeRenderingCxxTests`)
-  - Module logic tests are in `<MODULE_NAME>LogicCxxTests` project (e.g. `VolumeRenderingLogicCxxTests`)
-  - Module widgets tests are in `<MODULE_NAME>WidgetsCxxTests` project (e.g. `VolumesWidgetsCxxTests`)
-- Go to the project debugging properties (right click -> Properties, then Configuration Properties/Debugging)
-- In `Command Arguments`, type the name of the test (e.g. `vtkMRMLSceneImportTest` for project `MRMLCoreCxxTests`)
-- If the test takes argument(s), enter the argument(s) after the test name in `Command Arguments` (e.g. `vtkMRMLSceneImportTest C:\Path\To\Slicer4\Libs\MRML\Core\Testing\vol_and_cube.mrml`)
-  - You can see what arguments are passed by the dashboards by looking at the test details in CDash.
-  - Most VTK and Qt tests support the `-I` argument, it allows the test to be run in "interactive" mode. It doesn't exit at the end of the test.
-- Make the project Set As Startup Project
-- Start Debugging (F5)
-
-### Debugging Python scripts
-
-See [Python scripting page](https://slicer.readthedocs.io/en/latest/developer_guide/build_instructions/windows.html#debugging-python-scripts) for detailed instructions.
+- C++ debugging: Visual Studio is recommended on Windows, see [instructions](../debugging/windowscpp).
+- Python debugging: multiple development environments can be used, see [instructions](../debugging/overview.md#python-debugging).
 
 ## Common errors
 

--- a/Docs/developer_guide/debugging/codelitecpp.md
+++ b/Docs/developer_guide/debugging/codelitecpp.md
@@ -1,0 +1,37 @@
+# C++ debugging with CodeLite
+
+[CodeLite](http://www.codelite.org) is a relatively lightweight, cross-platform IDE.
+
+## Configure build
+
+Right-click on project name and select Settings, then Customize
+
+- Enable Custom Build: check
+- Working Directory: enter path to Slicer-build, for example `~/Slicer-SuperBuild-Debug/Slicer-build`
+- For target `Build`: enter `make`
+
+To configure the binary for the Run command, set Program: `~/Slicer-SuperBuild-Debug/Slicer-build/Slicer` under the General tab.
+
+## Configure debugger
+
+This requires the use of a wrapper script, as [detailed here](linux.md#gdb-debug-by-using-exec-wrapper).
+
+After setting up the wrapper script (`WrapSlicer` below), change the following options:
+
+Under Settings->General:
+
+- Program: `~/Slicer-SuperBuild-Debug/Slicer-build/WrapSlicer`
+- Working folder: `~/Slicer-SuperBuild-Debug/Slicer-build`
+
+    ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/debugging_codelite_1.png)
+
+Under Settings->Debugger
+
+- "Enter here any commands passed to debugger on startup:"
+
+    ```txt
+    set exec-wrapper `~/Slicer-SuperBuild-Debug/Slicer-build/WrapSlicer`
+    exec-file `~/Slicer-SuperBuild-Debug/Slicer-build/bin/SlicerApp-real`
+    ```
+
+    ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/debugging_codelite_2.png)

--- a/Docs/developer_guide/debugging/index.md
+++ b/Docs/developer_guide/debugging/index.md
@@ -1,0 +1,12 @@
+# Debugging
+
+```{toctree}
+:maxdepth: 2
+overview.md
+windowscpp.md
+linuxcpp.md
+macoscpp.md
+vscodecpp.md
+qtcreatorcpp.md
+codelitecpp.md
+```

--- a/Docs/developer_guide/debugging/linuxcpp.md
+++ b/Docs/developer_guide/debugging/linuxcpp.md
@@ -1,0 +1,304 @@
+# C++ debugging on GNU/Linux systems
+
+## GDB debug by attaching to running process (recommended)
+
+1. Starting with Ubuntu 10.10, ptracing of non-child processes by non-root users as been disabled -ie. only a process which is a parent of another process can ptrace it for normal users. More details [here](http://askubuntu.com/questions/41629/after-upgrade-gdb-wont-attach-to-process).
+
+    - You can temporarily disable this restriction by:
+      ```bash
+      $ echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+      ```
+    - To permanently allow it to edit `/etc/sysctl.d/10-ptrace.conf` and change the line:
+      ```txt
+      kernel.yama.ptrace_scope = 1
+      ```
+      to read:
+      ```txt
+      kernel.yama.ptrace_scope = 0
+      ```
+
+2. Running Slicer with the following command line argument will allow you to easily obtain the associated PID:
+
+    ```bash
+    $ ./Slicer --attach-process
+    ```
+
+    This will bring up a window with the `PID` before loading any modules, which is also helpful for debugging the loading process.
+
+3. Then, you can attach the process to `gdb` using the following command:
+
+    ```bash
+    $ gdb --pid $PIDABOVE
+    ```
+
+4. Finally type the following gdb command
+
+    ```txt
+    (gdb) continue
+    ```
+
+    If not using the `--attach-process`, the `PID` could be obtain using the following command:
+
+    ```bash
+    $ ps -Afww | grep SlicerApp-real
+    ```
+
+:::{tip}
+
+How to print QString using GDB?
+
+See <http://silmor.de/qtstuff.printqstring.php>.
+
+:::
+
+## GDB debug with launch arguments
+
+The Slicer app launcher provides options to start other programs with the Slicer environment settings.
+
+- `--launch <executable> [<parameters>]`: executes an arbitrary program. For example, `Slicer --launch /usr/bin/gnome-terminal` starts gnome-terminal (then run GDB directly on SlicerApp-real)
+- `--gdb`: runs GDB then executes SlicerApp-real from within the debugger environment.
+
+## GDB debug by using exec-wrapper
+
+An alternative approach is to use a wrapper script to emulate the functionality of the app launcher. This will allow you to use gdb or a gdb-controlling program such as an IDE, in order to interactively debug directly from GDB without attaching.
+
+The general idea of the wrapper is to set all of the appropriate environment variables as they would be set by the app launcher. From SlicerLauncherSettings:
+
+- `[LibraryPath]` contents should be in `LD_LIBRARY_PATH`
+- `[Paths]` contents should be in `PATH`
+- `[EnvironmentVariables]` should each be set
+
+Now, start gdb and do the following:
+
+```txt
+(gdb) set exec-wrapper ./WrapSlicer
+(gdb) exec-file ./bin/SlicerQT-real
+(gdb) run
+```
+
+Since VTK and ITK include many multithreaded filters, by default you will see lots of messages like the following from gdb during rendering and processing:
+
+```txt
+[New Thread 0x7fff8378f700 (LWP 20510)]
+[Thread 0x7fff8b0aa700 (LWP 20506) exited]
+```
+
+These can be turned off with this command:
+
+```txt
+set print thread-events off
+```
+
+### Example wrapper script
+
+To make a wrapper script, run
+
+```bash
+Slicer --launch `which gnome-terminal`
+```
+
+or
+
+```bash
+Slicer --gnome-terminal
+```
+
+and check the value of `LD_LIBRARY_PATH` (note, it doesn't seem to be set using xterm). Then check the other environment variables as listed in `[EnvironmentVariables]`.
+
+See the examples below.
+
+SlicerLaunchSettings.ini
+
+```txt
+[General]
+launcherSplashImagePath=/cmn/git/Slicer4/Applications/SlicerQT/Resources/Images/SlicerSplashScreen.png
+launcherSplashScreenHideDelayMs=3000
+additionalLauncherHelpShortArgument=-h
+additionalLauncherHelpLongArgument=--help
+additionalLauncherNoSplashArguments=--no-splash,--help,--version,--home,--program-path,--no-main-window
+
+[Application]
+path=<APPLAUNCHER_DIR>/bin/./SlicerQT-real
+arguments=
+
+[ExtraApplicationToLaunch]
+
+designer/shortArgument=
+designer/help=Start Qt designer using Slicer plugins
+designer/path=/usr/bin/designer-qt4
+designer/arguments=
+
+gnome-terminal/shortArgument=
+gnome-terminal/help=Start gnome-terminal
+gnome-terminal/path=/usr/bin/gnome-terminal
+gnome-terminal/arguments=
+
+xterm/shortArgument=
+xterm/help=Start xterm
+xterm/path=/usr/bin/xterm
+xterm/arguments=
+
+ddd/shortArgument=
+ddd/help=Start ddd
+ddd/path=/usr/bin/ddd
+ddd/arguments=
+
+gdb/shortArgument=
+gdb/help=Start gdb
+gdb/path=/usr/bin/gdb
+gdb/arguments=
+
+
+[LibraryPaths]
+1\path=/cmn/git/Slicer4-sb/VTK-build/bin/.
+2\path=/cmn/git/Slicer4-sb/CTK-build/CTK-build/bin/.
+3\path=/usr/lib
+4\path=/cmn/git/Slicer4-sb/ITKv3-build/bin/.
+5\path=/cmn/git/Slicer4-sb/SlicerExecutionModel-build/ModuleDescriptionParser/bin/.
+6\path=/cmn/git/Slicer4-sb/teem-build/bin/.
+7\path=/cmn/git/Slicer4-sb/LibArchive-install/lib
+8\path=<APPLAUNCHER_DIR>/bin/.
+9\path=../lib/Slicer-4.0/qt-loadable-modules
+10\path=<APPLAUNCHER_DIR>/lib/Slicer-4.0/cli-modules/.
+11\path=<APPLAUNCHER_DIR>/lib/Slicer-4.0/qt-loadable-modules/.
+12\path=/cmn/git/Slicer4-sb/tcl-build/lib
+13\path=/cmn/git/Slicer4-sb/OpenIGTLink-build
+14\path=/cmn/git/Slicer4-sb/OpenIGTLink-build/bin/.
+15\path=/cmn/git/Slicer4-sb/CTK-build/PythonQt-build/.
+16\path=/cmn/git/Slicer4-sb/python-build/lib
+17\path=/cmn/git/Slicer4-sb/python-build/lib/python2.6/site-packages/numpy/core
+18\path=/cmn/git/Slicer4-sb/python-build/lib/python2.6/site-packages/numpy/lib
+size=18
+
+[Paths]
+1\path=<APPLAUNCHER_DIR>/bin/.
+2\path=/cmn/git/Slicer4-sb/teem-build/bin/.
+3\path=/usr/bin
+4\path=<APPLAUNCHER_DIR>/lib/Slicer-4.0/cli-modules/.
+5\path=/cmn/git/Slicer4-sb/tcl-build/bin
+size=5
+
+[EnvironmentVariables]
+QT_PLUGIN_PATH=<APPLAUNCHER_DIR>/bin<PATHSEP>/cmn/git/Slicer4-sb/CTK-build/CTK-build/bin<PATHSEP>/usr/lib/qt4/plugins
+SLICER_HOME=/cmn/git/Slicer4-sb/Slicer-build
+PYTHONHOME=/cmn/git/Slicer4-sb/python-build
+PYTHONPATH=<APPLAUNCHER_DIR>/bin<PATHSEP><APPLAUNCHER_DIR>/bin/Python<PATHSEP>/cmn/git/Slicer4-sb/python-build/lib/python2.6/site-packages<PATHSEP><APPLAUNCHER_DIR>/lib/Slicer-4.0/qt-loadable-modules/.<PATHSEP><APPLAUNCHER_DIR>/lib/Slicer-4.0/qt-loadable-modules/Python
+TCL_LIBRARY=/cmn/git/Slicer4-sb/tcl-build/lib/tcl8.4
+TK_LIBRARY=/cmn/git/Slicer4-sb/tcl-build/lib/tk8.4
+TCLLIBPATH=/cmn/git/Slicer4-sb/tcl-build/lib/itcl3.2 /cmn/git/Slicer4-sb/tcl-build/lib/itk3.2
+```
+
+It's easier to just check `LD_LIBRARY_PATH` using `--launch`. If this is somehow not available, the above settings translate directly to:
+
+```
+#!/bin/bash
+BASE_DIR=/cmn/git/Slicer4-sb/
+APPLAUNCHER_DIR=$BASE_DIR/Slicer-build
+
+LD_PATHS="
+/cmn/git/Slicer4-sb/VTK-build/bin/.
+/cmn/git/Slicer4-sb/CTK-build/CTK-build/bin/.
+/usr/lib
+/cmn/git/Slicer4-sb/ITKv3-build/bin/.
+/cmn/git/Slicer4-sb/SlicerExecutionModel-build/ModuleDescriptionParser/bin/.
+/cmn/git/Slicer4-sb/teem-build/bin/.
+/cmn/git/Slicer4-sb/LibArchive-install/lib
+$APPLAUNCHER_DIR/bin/.
+../lib/Slicer-4.0/qt-loadable-modules
+$APPLAUNCHER_DIR/lib/Slicer-4.0/cli-modules/.
+$APPLAUNCHER_DIR/lib/Slicer-4.0/qt-loadable-modules/.
+/cmn/git/Slicer4-sb/tcl-build/lib
+/cmn/git/Slicer4-sb/OpenIGTLink-build
+/cmn/git/Slicer4-sb/OpenIGTLink-build/bin/.
+/cmn/git/Slicer4-sb/CTK-build/PythonQt-build/.
+/cmn/git/Slicer4-sb/python-build/lib
+/cmn/git/Slicer4-sb/python-build/lib/python2.6/site-packages/numpy/core
+/cmn/git/Slicer4-sb/python-build/lib/python2.6/site-packages/numpy/lib
+"
+for STR in $LD_PATHS; do LD_LIBRARY_PATH="${STR}:${LD_LIBRARY_PATH}"; done
+
+QT_PLUGIN_PATH=$APPLAUNCHER_DIR/bin:/cmn/git/Slicer4-sb/CTK-build/CTK-build/bin:/usr/lib/qt4/plugins
+SLICER_HOME=/cmn/git/Slicer4-sb/Slicer-build
+PYTHONHOME=/cmn/git/Slicer4-sb/python-build
+PYTHONPATH=$APPLAUNCHER_DIR:/bin:$APPLAUNCHER_DIR:/bin/Python:/cmn/git/Slicer4-sb/python-build/lib/python2.6/site-packages:$APPLAUNCHER_DIR/lib/Slicer-4.0/qt-loadable-modules/.:$APPLAUNCHER_DIR/lib/Slicer-4.0/qt-loadable-modules/Python
+TCL_LIBRARY=/cmn/git/Slicer4-sb/tcl-build/lib/tcl8.4
+TK_LIBRARY=/cmn/git/Slicer4-sb/tcl-build/lib/tk8.4
+TCLLIBPATH=/cmn/git/Slicer4-sb/tcl-build/lib/itcl3.2:/cmn/git/Slicer4-sb/tcl-build/lib/itk3.2
+
+export QTPLUGIN_PATH=$QT_PLUGIN_PATH
+export SLICER_HOME=$SLICER_HOME
+export PYTHONHOME=$PYTHONHOME
+export PYTHONPATH=$PYTHONPATH
+export TCL_LIBRARY=$TCL_LIBRARY
+export TK_LIBRARY=$TK_LIBRARY
+export TCLLIBPATH=$TCLLIBPATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+
+exec "$@"
+```
+
+## Analyze a segmentation fault
+
+```bash
+$ ulimit -c unlimited
+$ ./Slicer
+... make it crash
+$ ./Slicer --gdb ./bin/SlicerApp-real
+(gdb) core core
+(gdb) backtrace
+...
+```
+
+### With systemd
+
+In linux distros with systemd, coredumps are managed by the systemd daemon.
+And stored, in a compressed format (.lz4), in
+
+```txt
+/var/lib/systemd/coredump/core.SlicerApp-real.xxxx.lz4
+```
+
+It can happen that even with ulimit -c unlimited, the coredump files are still truncated.
+You can check latest coredumps, and the correspoding PID with:
+
+```bash
+coredumpctl list
+Thu 2018-05-24 16:37:46 EDT   22544  1000  1000  11 missing   /usr/lib/firefox/firefox
+Fri 2018-05-25 15:50:52 EDT   14721  1000  1000   6 truncated /path/Slicer-build/bin/SlicerApp-real
+Mon 2018-05-28 11:35:43 EDT   17249  1000  1000   6 present   /path/Slicer-build/bin/SlicerApp-real
+```
+
+You can modify systemd coredump to increase the default max file size in `/etc/systemd/coredump.conf`:
+
+```txt
+[Coredump]
+#Storage=external
+#Compress=yes
+ProcessSizeMax=8G
+ExternalSizeMax=8G
+JournalSizeMax=6G
+#MaxUse=
+#KeepFree=
+```
+
+After that change, make Slicer crash again, and the core file will be present, instead of truncated.
+
+You can launch gdb with a coredump file with the command:
+
+```bash
+coredumpctl gdb $PID
+```
+
+If no $PID is provided, the latest coredump is used. PID can be retrieved using `coredumpctl list`.
+
+To decompress the coredump file to use with other IDE or ddd, change the coredump.conf Compress option, or use:
+
+```bash
+coredumpctl dump $PID > /tmp/corefile
+```
+
+## Debugging using cross-platform IDEs
+
+- [Debugging using CodeLite](codelitecpp.md)
+- [Debugging using Qt Creator](qtcreatorcpp.md)
+- [Debugging using Visual Studio Code](vscodecpp.md)

--- a/Docs/developer_guide/debugging/macoscpp.md
+++ b/Docs/developer_guide/debugging/macoscpp.md
@@ -1,0 +1,65 @@
+# C++ debugging on macOS
+
+## Debugging using Xcode
+
+We do not support building using Xcode, however if you build slicer using traditional unix Makefiles you can still debug using the powerful source debugging features of Xcode.
+
+:::{note}
+
+You need to set up a dummy project in Xcode just to enable some of the options. This means that Xcode will create a macOS code template, but you won't use it directly (instead you will point to the code you build with cmake/make).
+
+![](https://github.com/Slicer/Slicer/releases/download/docs-resources/debugging_xcode.png)
+
+:::
+
+### Attaching to a running process
+
+You can use the Attach to Process option in the Xcode Product menu for debugging. This will allow you to get browsable stack traces for crashes.
+
+Steps:
+- Start Slicer
+- Start Xcode
+- Use the Product->Attach to Process... menu
+
+### Setting Breakpoints
+
+To set a breakpoint in code that is not crashing, you can set it via the command line interface.  For the lldb debugger, first attach to the process and break the program.  Then at the (lldb) prompt, stop at a method as follows:
+
+```txt
+breakpoint set -M vtkMRMLScene::Clear
+```
+
+then you can single step and/or set other breakpoints in that file.
+
+Alternatively, you can use the Product->Debug->Create a Symbolic Breakpoint... option.  This is generally preferable to the lldb level debugging, since it shows up in the Breakpoints pane and can be toggled/deleted with the GUI.
+
+### Debugging the Startup Process
+
+To debug startup issues you can set up a *Scheme* and select the `Slicer.app` in your `Slicer-build` directory (see screenshot). You can set up multiple schemes with different command line arguments and executables (for example to debug tests).
+
+Since you are using a dummy project but want to debug the slicer application, you need to do the following:
+
+- Start Xcode and open dummy project
+- Pick Product->Edit Scheme...
+- Select the Run section
+- Select the Info tab
+- Pick Slicer.app as the Executable
+- Click OK
+- Now the Run button will start Slicer for debugging
+
+:::{tip}
+
+You can create multiple schemes, each various command line options to pass to slicer so you can easily get back to a debugging environment.
+
+:::
+
+### Profiling
+
+The [Instruments](http://en.wikipedia.org/wiki/Instruments_%28application%29) tool is very useful for profiling.
+
+## Debugging using cross-platform IDEs
+
+On Windows, Visual Studio is the most feature-rich and powerful debugger, but in case somebody wants to use cross-platform tools then these instructions may help:
+
+- [Debugging using Qt Creator](qtcreatorcpp.md)
+- [Debugging using Visual Studio Code](vscodecpp.md)

--- a/Docs/developer_guide/debugging/overview.md
+++ b/Docs/developer_guide/debugging/overview.md
@@ -1,0 +1,32 @@
+#  Overview
+
+## Python debugging
+
+Python code running in Slicer can be debugged (execute code line-by-line, inspect variables, browse the call stack, etc.) by attaching a debugger to the running Slicer application. Detailed instructions are provided in documentation of [DebuggingTools extension](https://github.com/SlicerRt/SlicerDebuggingTools).
+
+![](https://raw.githubusercontent.com/SlicerRt/SlicerDebuggingTools/master/Docs/VisualStudioCodePythonDebuggerExample.png)
+
+## C++ debugging
+
+Debugging C++ code requires building 3D Slicer in Debug mode by following the [build instructions](../build_instructions.md).
+
+The executable Slicer application (`Slicer` or `Slicer.exe`) is the launcher of the real application binary (`SlicerApp-real`). The launcher sets up paths for dynamically-loaded libraries that on Windows and Linux are required to run the real application library.
+
+Detailed instructions for setting up debuggers are available for [Windows](windowscpp.md), [GNU/Linux](linuxcpp.md), and [macOS](macoscpp.md).
+
+### Debugging tests
+
+- To debug a test, find the test executable:
+  - `Libs/MRML/Core` tests are in the `MRMLCoreCxxTests` project
+  - CLI module tests are in `<MODULE_NAME>Test` project (e.g. `ThresholdScalarVolumeTest`)
+  - Loadable module tests are in `qSlicer<MODULE_NAME>CxxTests` project (e.g. `qSlicerVolumeRenderingCxxTests`)
+  - Module logic tests are in `<MODULE_NAME>LogicCxxTests` project (e.g. `VolumeRenderingLogicCxxTests`)
+  - Module widgets tests are in `<MODULE_NAME>WidgetsCxxTests` project (e.g. `VolumesWidgetsCxxTests`)
+- Make the project the startup project (right-click -> Set As Startup Project)
+- Specify test name and additional input arguments:
+  - Go to the project debugging properties (right click -> Properties, then Configuration Properties/Debugging)
+  - In `Command Arguments`, type the name of the test (e.g. `vtkMRMLSceneImportTest` for project `MRMLCoreCxxTests`)
+  - If the test takes argument(s), enter the argument(s) after the test name in `Command Arguments` (e.g. `vtkMRMLSceneImportTest C:\Path\To\Slicer4\Libs\MRML\Core\Testing\vol_and_cube.mrml`)
+    - You can see what arguments are passed by the dashboards by looking at the test details in CDash.
+    - Most VTK and Qt tests support the `-I` argument, it allows the test to be run in "interactive" mode. It doesn't exit at the end of the test.
+- Start Debugging (F5)

--- a/Docs/developer_guide/debugging/qtcreatorcpp.md
+++ b/Docs/developer_guide/debugging/qtcreatorcpp.md
@@ -1,0 +1,46 @@
+# C++ debugging with Qt Creator
+
+Qt Creator is a cross-platform IDE that fully integrates Qt into the development of applications. Slicer CMake project is supported by Qt Creator, the following items aim at describing how it could be used.
+
+:::{tip}
+
+For debugging on Windows, Visual Studio is recommended as it has much better performance and many more features than Visual Studio Code.
+
+:::
+
+## Prerequisites
+
+- Build 3D Slicer in Debug mode, outside of Qt Creator, by following the [build instructions](../build_instructions.md).
+- Install Qt SDK with Qt Creator.
+
+## Running the debugger
+
+1. From a terminal, launch QtCreator through Slicer to setup environment. This will allow qtcreator to design UI using CTK and Slicer custom designer plugins.
+
+    - Linux:
+      ```bash
+      cd /path/to/Slicer-Superbuild/Slicer-build
+      ./Slicer --launch /path/to/qtcreator
+      ```
+    - Windows:
+      ```txt
+      cd c:\path\to\Slicer-Superbuild\Slicer-build
+      .\Slicer.exe --launch /path/to/qtcreator.exe
+      ```
+
+2. Open `/path/to/Slicer-src/CMakeLists.txt` in qtcreator, when prompted, choose the build directory where Slicer was configured and compiled
+
+    :::{note}
+
+    You can select either the binary tree of the SuperBuild or the binary tree of the Slicer-build that is inside the binary tree of the SuperBuild.
+    - choosing superbuild build directory `/path/to/Slicer-Superbuild`: allows building all of the packages that Slicer depends on and build Slicer itself, all from within Qt Creator.
+    - choosing inner build directory `/path/to/Slicer-Superbuild/Slicer-build`: provides a better IDE experience when working on Slicer itself (recognizing types, pulling up documentation, cross-referencing the code, ...).
+
+    :::
+
+3. Click the `Run CMake` button (no arguments needed), wait until CMake has finished, then click the `Finish` button
+
+4. Optional steps:
+
+    - Specify make arguments (for example: `-j8`) by clicking the `Projects` tab on the left hand side, click the `Build Settings` tab at the top, click the `Details` button beside the Make build step, and add your additional arguments. This is useful if you want to build from within Qt Creator.
+    - Specify run configuration by clicking the `Projects` tab on the left hand side, click the `Run Settings` tab at the top, and select your Run configuration (ex. choose SlicerApp-real). This is useful if you want to run Slicer from within Qt Creator.

--- a/Docs/developer_guide/debugging/vscodecpp.md
+++ b/Docs/developer_guide/debugging/vscodecpp.md
@@ -1,0 +1,69 @@
+# C++ debugging with Visual Studio Code
+
+Visual Studio Code is a cross-platform IDE that can be used for debugging C++ and Python code.
+
+
+:::{tip}
+
+For debugging on Windows, Visual Studio is recommended as it has much better performance and many more features than Visual Studio Code.
+
+:::
+
+## Prerequisites
+
+- Build 3D Slicer in Debug mode, outside of Visual Studio Code, by following the [build instructions](../build_instructions.md).
+- Install Visual Studio Code
+- Install the `C/C++` extension in Visual Studio Code
+
+````{note}
+
+Visual Studio Code uses GDB for debugging on Linux, which requires Python. However, Python that is linked into GDB is not the same as Slicer's Python, which may cause issues. If GDB does not start because `_sysconfigdata__linux_x86_64-linux-gnu.py` file is missing then Slicer's sysconfigdata file must be copied to the expected filename. For example:
+
+```bash
+cp ~/D/Slicer-SuperBuild-Debug/python-install/lib/python3.6/_sysconfigdata_m_linux2_.py \
+~/D/Slicer-SuperBuild-Debug/python-install/lib/python3.6/_sysconfigdata__linux_x86_64-linux-gnu.py
+```
+
+````
+
+## Running the debugger on Linux
+
+1. From a terminal, launch Visual Studio Code through the Slicer launcher to setup environment to set up the directory paths necessary for running the Slicer application. For example:
+
+    ```bash
+    cd ~/D/Slicer-SuperBuild-Debug/Slicer-build
+    ./Slicer --launch code
+    ```
+
+2. Set up settings.json. For example:
+
+    ```json
+    {
+        "launch": {
+            "configurations": [
+                      {
+                        "name": "Slicer debug",
+                        "type": "cppdbg",
+                        "request": "launch",
+                        "program": "/home/perklab/D/Slicer-SuperBuild-Debug/Slicer-build/bin/SlicerApp-real",
+                        "args": [],
+                        "stopAtEntry": false,
+                        "cwd": ".",
+                        "environment": [],
+                        "externalConsole": false,
+                        "MIMode": "gdb",
+                        "setupCommands": [
+                          {
+                            "description": "Enable pretty-printing for gdb",
+                            "text": "-enable-pretty-printing",
+                            "ignoreFailures": true
+                          }
+                        ],
+                        "miDebuggerPath": "/usr/bin/gdb"
+                      }
+            ]
+        }
+    }
+    ```
+
+3. Choose Run / Start debugging in the menu to start Slicer application with the debugger attached

--- a/Docs/developer_guide/debugging/windowscpp.md
+++ b/Docs/developer_guide/debugging/windowscpp.md
@@ -1,0 +1,58 @@
+# C++ debugging on Windows
+
+## Debugging using Visual Studio
+
+Prerequisites:
+- Build 3D Slicer in Debug by following the [build instructions](../build_instructions.md).
+
+1. To run Slicer, the launcher needs to set certain environment variables. The easiest is to use the launcher to set these and start Visual Studio in this environment. All these can be accomplished by running the following command in `<Slicer_BUILD>/c:\D\S4R\Slicer-build` folder:
+
+    ```txt
+    Slicer.exe --VisualStudioProject
+    ```
+
+    ````{note}
+
+    - If you just want to start VisualStudio with the launcher (and then load project file manually), run: `Slicer.exe --VisualStudio`
+    - To debug an extension that builds third-party DLLs, also specify `--launcher-additional-settings` option.
+    - While you can launch debugger using Slicer's solution file, it is usually more convenient to load your extension's solution file (because your extension solution is smaller and most likely you want to have that solution open anyway for making changes in your code). For example, you can launch Visual Studio to debug your extension like this:
+
+        ```txt
+        .\S4D\Slicer-build\Slicer.exe --VisualStudio --launcher-no-splash --launcher-additional-settings ./SlicerRT_D/inner-build/AdditionalLauncherSettings.ini c:\d\_Extensions\SlicerRT_D\inner-build\SlicerRT.sln
+        ```
+
+    ````
+
+2. In Solution Explorer window in Visual Studio, expand `App-Slicer`, right-click on `SlicerApp` (NOT qSlicerApp) and select "Set as Startup Project"
+
+    To debug in an extension's solution: set `ALL_BUILD` project as startup project and in project settings, set `Debugging` / `Command` field to the full path of `SlicerApp-real.exe` - something like `.../Slicer-build/bin/Debug/SlicerApp-real.exe`
+
+3. Run Slicer in debug mode by Start Debugging command (in Debug menu).
+
+    Note that because CMake re-creates the solution file from within the build process, Visual Studio will sometimes need to stop and reload the project, requiring manual button pressing on your part (just press Yes or OK whenever you are asked). To avoid this, you can use a script to complete the build process and then re-start the Visual Studio.
+
+    For more debugging tips and tricks, check out [this page](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/Troubleshooting).
+
+### Debugging tests
+
+Once VisualStudio is open with the Slicer environment loaded, it is possible to run and debug tests. See general information about running tests [here](overview.md#debugging-tests). Specific instructions for Visual Studio:
+
+- To debug a test, find its project in the Solution explorer tree.
+- Make the project the startup project (right-click -> Set As Startup Project).
+- Specify test name and additional input arguments:
+  - Go to the project debugging properties (right click -> Properties, then Configuration Properties/Debugging)
+  - In `Command Arguments`, type the name of the test (e.g. `vtkMRMLSceneImportTest` for project `MRMLCoreCxxTests`) followed by additional arguments (if any).
+- Start debugging by choosing `Start debugging` in Edit menu.
+
+:::{tip}
+
+To run all tests, build the `RUN_TESTS` project.
+
+:::
+
+## Debugging using cross-platform IDEs
+
+On Windows, Visual Studio is the most feature-rich and powerful debugger, but in case somebody wants to use cross-platform tools then these instructions may help:
+
+- [Debugging using Qt Creator](qtcreatorcpp.md)
+- [Debugging using Visual Studio Code](vscodecpp.md)

--- a/Docs/developer_guide/index.md
+++ b/Docs/developer_guide/index.md
@@ -10,6 +10,7 @@ extensions
 python_faq
 script_repository
 build_instructions/index
+debugging/index
 contributing
 authors
 ```


### PR DESCRIPTION
Moved from Slicer wiki - https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/Debug_Instructions and related pages.