### PR TITLE
Enable GrowCut remote module in ITK

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -146,6 +146,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DModule_ITKIOMINC:BOOL=ON
       -DModule_IOScanco:BOOL=ON
       -DModule_MorphologicalContourInterpolation:BOOL=ON
+      -DModule_GrowCut:BOOL=ON
       -DModule_SimpleITKFilters:BOOL=${Slicer_USE_SimpleITK}
       -DModule_GenericLabelInterpolator:BOOL=ON
       -DModule_AdaptiveDenoising:BOOL=ON


### PR DESCRIPTION
GrowCut remote module in ITK has recently been updated to mirror Slicer's improvements. This PR contains pre-requisites to removing this code from Slicer and refactoring it to use the version coming from ITK.

I have not begun the Slicer refactoring, and I would prefer if somebody else did that. I could support them by making changes inside `ITKGrowCut`.