### PR TITLE
COMP: Update FindVcvars with MSVC 1929 support

### DIFF
--- a/CMake/FindVcvars.cmake
+++ b/CMake/FindVcvars.cmake
@@ -116,7 +116,7 @@ cmake_minimum_required(VERSION 3.13.4)
 # Global variables used only in this script (unset at the end)
 set(_Vcvars_MSVC_ARCH_REGEX "^(32|64)$")
 set(_Vcvars_MSVC_VERSION_REGEX "^[0-9][0-9][0-9][0-9]$")
-set(_Vcvars_SUPPORTED_MSVC_VERSIONS 1928 1927 1926 1925 1924 1923 1922 1921 1920
+set(_Vcvars_SUPPORTED_MSVC_VERSIONS 1929 1928 1927 1926 1925 1924 1923 1922 1921 1920
                                     1916 1915 1914 1913 1912 1911 1910 1900
                                     1800 1700 1600 1500 1400)
 
@@ -131,38 +131,10 @@ function(Vcvars_ConvertMsvcVersionToVsVersion msvc_version output_var)
     message(FATAL_ERROR "msvc_version is expected to match `${_Vcvars_MSVC_VERSION_REGEX}`")
   endif()
   # See https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-  if(msvc_version EQUAL 1928)     # VS 2019
-    set(vs_version "16.8")
-  elseif(msvc_version EQUAL 1927) # VS 2019
-    set(vs_version "16.7")
-  elseif(msvc_version EQUAL 1926) # VS 2019
-    set(vs_version "16.6")
-  elseif(msvc_version EQUAL 1925) # VS 2019
-    set(vs_version "16.5")
-  elseif(msvc_version EQUAL 1924) # VS 2019
-    set(vs_version "16.4")
-  elseif(msvc_version EQUAL 1923) # VS 2019
-    set(vs_version "16.3")
-  elseif(msvc_version EQUAL 1922) # VS 2019
-    set(vs_version "16.2")
-  elseif(msvc_version EQUAL 1921) # VS 2019
-    set(vs_version "16.1")
-  elseif(msvc_version EQUAL 1920) # VS 2019
-    set(vs_version "16.0")
-  elseif(msvc_version EQUAL 1916) # VS 2017
-    set(vs_version "15.9")
-  elseif(msvc_version EQUAL 1915) # VS 2017
-    set(vs_version "15.8")
-  elseif(msvc_version EQUAL 1914) # VS 2017
-    set(vs_version "15.7")
-  elseif(msvc_version EQUAL 1913) # VS 2017
-    set(vs_version "15.6")
-  elseif(msvc_version EQUAL 1912) # VS 2017
-    set(vs_version "15.5")
-  elseif(msvc_version EQUAL 1911) # VS 2017
-    set(vs_version "15.3")
-  elseif(msvc_version EQUAL 1910) # VS 2017
-    set(vs_version "15.0")
+  if((msvc_version GREATER_EQUAL 1920) AND (msvc_version LESS 1930)) # VS 2019
+    set(vs_version "16")
+  elseif((msvc_version GREATER_EQUAL 1910) AND (msvc_version LESS 1920)) # VS 2017
+    set(vs_version "15")
   elseif(msvc_version EQUAL 1900) # VS 2015
     set(vs_version "14.0")
   elseif(msvc_version EQUAL 1800) # VS 2013

--- a/CMake/FindVcvars.cmake
+++ b/CMake/FindVcvars.cmake
@@ -116,7 +116,8 @@ cmake_minimum_required(VERSION 3.13.4)
 # Global variables used only in this script (unset at the end)
 set(_Vcvars_MSVC_ARCH_REGEX "^(32|64)$")
 set(_Vcvars_MSVC_VERSION_REGEX "^[0-9][0-9][0-9][0-9]$")
-set(_Vcvars_SUPPORTED_MSVC_VERSIONS 1929 1928 1927 1926 1925 1924 1923 1922 1921 1920
+set(_Vcvars_SUPPORTED_MSVC_VERSIONS 1930
+                                    1929 1928 1927 1926 1925 1924 1923 1922 1921 1920
                                     1916 1915 1914 1913 1912 1911 1910 1900
                                     1800 1700 1600 1500 1400)
 
@@ -131,7 +132,9 @@ function(Vcvars_ConvertMsvcVersionToVsVersion msvc_version output_var)
     message(FATAL_ERROR "msvc_version is expected to match `${_Vcvars_MSVC_VERSION_REGEX}`")
   endif()
   # See https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-  if((msvc_version GREATER_EQUAL 1920) AND (msvc_version LESS 1930)) # VS 2019
+  if((msvc_version GREATER_EQUAL 1930) AND (msvc_version LESS 1940))     # VS 2022
+    set(vs_version "17")
+  elseif((msvc_version GREATER_EQUAL 1920) AND (msvc_version LESS 1930)) # VS 2019
     set(vs_version "16")
   elseif((msvc_version GREATER_EQUAL 1910) AND (msvc_version LESS 1920)) # VS 2017
     set(vs_version "15")


### PR DESCRIPTION
Based on https://github.com/scikit-build/cmake-FindVcvars/pull/1

Required to successfully build an extension such as SlicerRadiomics with latest version of Visual Studio.