### PR TITLE
BUG: Fix crash when erasing regions outside segmentation

### DIFF
--- a/Libs/vtkSegmentationCore/vtkSegmentationModifier.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationModifier.h
@@ -87,6 +87,10 @@ protected:
   /// \param extentIntersection computed intersection of the two input extents
   static void GetExtentIntersection(const int extentA[6], const int extentB[6], int extentIntersection[6]);
 
+  /// Returns true if the extent is valid, false otherwise
+  /// \param Extent to be validated
+  static bool IsExtentValid(int extent[6]);
+
 protected:
   vtkSegmentationModifier();
   ~vtkSegmentationModifier() override;


### PR DESCRIPTION
If the modifier labelmap and resampled segmentation labelmaps do not overlap, then GetExtentIntersection will generate an invalid extent. Passing this extent to vtkImageThreshold::UpdateExtent will cause a crash.

Fixed by not applying the segment mask to the modifier if the extent is invalid. This should not cause any issues since if there is no overlap between the modifier/segment labelmaps, nothing should need to be erased.

Fix: #5812