### PR TITLE
ENH: Move module panel logo into DataProbe collapsible area

### DIFF
--- a/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
+++ b/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
@@ -46,13 +46,6 @@
       <number>0</number>
      </property>
      <item>
-      <widget class="QLabel" name="LogoLabel">
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="qSlicerModulePanel" name="ModulePanel"/>
      </item>
      <item>
@@ -66,7 +59,15 @@
        <property name="text">
         <string>Data Probe</string>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout"/>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="LogoLabel">
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignBottom</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -52,7 +52,7 @@ indicated by the mouse position.
       print("No Data Probe frame - cannot create DataProbe")
       return
     self.infoWidget = DataProbeInfoWidget(parent)
-    parent.layout().insertWidget(0,self.infoWidget.frame)
+    parent.layout().addWidget(self.infoWidget.frame)
 
   def showZoomedSlice(self, value=False):
     self.showZoomedSlice = value
@@ -68,6 +68,7 @@ class DataProbeInfoWidget:
     self.CrosshairNodeObserverTag = None
 
     self.frame = qt.QFrame(parent)
+    self.frame.hide()  # have hidden by default until event triggered to show
     self.frame.setLayout(qt.QVBoxLayout())
 
     modulePath = slicer.modules.dataprobe.path.replace("DataProbe.py","")
@@ -206,11 +207,15 @@ class DataProbeInfoWidget:
       self.viewerColor.hide()
       self.viewInfo.hide()
       self.viewerFrame.hide()
+      self.frame.hide()
+      slicer.util.setApplicationLogoVisible(True)
       return
 
     self.viewerColor.show()
     self.viewInfo.show()
     self.viewerFrame.show()
+    self.frame.show()
+    slicer.util.setApplicationLogoVisible(False)
 
     # populate the widgets
     self.viewerColor.setText( " " )

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -203,17 +203,14 @@ class DataProbeInfoWidget:
         self.layerNames[layer].setText( "" )
         self.layerIJKs[layer].setText( "" )
         self.layerValues[layer].setText( "" )
-      self.imageLabel.hide()
       self.viewerColor.hide()
       self.viewInfo.hide()
       self.viewerFrame.hide()
-      self.showImageFrame.show()
       return
 
     self.viewerColor.show()
     self.viewInfo.show()
     self.viewerFrame.show()
-    self.showImageFrame.hide()
 
     # populate the widgets
     self.viewerColor.setText( " " )
@@ -266,14 +263,6 @@ class DataProbeInfoWidget:
       self.displayableManagerInfo.show()
     else:
       self.displayableManagerInfo.hide()
-
-    # set image
-    if (not slicer.mrmlScene.IsBatchProcessing()) and sliceLogic and hasVolume and self.showImage:
-      pixmap = self._createMagnifiedPixmap(
-        xyz, sliceLogic.GetBlend().GetOutputPort(), self.imageLabel.size, color)
-      if pixmap:
-        self.imageLabel.setPixmap(pixmap)
-        self.onShowImage(self.showImage)
 
     if hasattr(self.frame.parent(), 'text'):
       sceneName = slicer.mrmlScene.GetURL()
@@ -382,31 +371,6 @@ class DataProbeInfoWidget:
     # hide this for now - there's not much to see in the module itself
     self.goToModule.hide()
 
-    # image view: To ensure the height of the checkbox matches the height of the
-    # viewerFrame, it is added to a frame setting the layout and hard-coding the
-    # content margins.
-    # TODO: Revisit the approach and avoid hard-coding content margins
-    self.showImageFrame = qt.QFrame(self.frame)
-    self.frame.layout().addWidget(self.showImageFrame)
-    self.showImageFrame.setLayout(qt.QHBoxLayout())
-    self.showImageFrame.layout().setContentsMargins(0, 3, 0, 3)
-    self.showImageBox = qt.QCheckBox('Show Zoomed Slice', self.showImageFrame)
-    self.showImageFrame.layout().addWidget(self.showImageBox)
-    self.showImageBox.connect("toggled(bool)", self.onShowImage)
-    self.showImageBox.setChecked(False)
-
-    self.imageLabel = qt.QLabel()
-
-    # qt.QSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding)
-    # fails on some systems, therefore set the policies using separate method calls
-    qSize = qt.QSizePolicy()
-    qSize.setHorizontalPolicy(qt.QSizePolicy.Expanding)
-    qSize.setVerticalPolicy(qt.QSizePolicy.Expanding)
-    self.imageLabel.setSizePolicy(qSize)
-    #self.imageLabel.setScaledContents(True)
-    self.frame.layout().addWidget(self.imageLabel)
-    self.onShowImage(False)
-
     # top row - things about the viewer itself
     self.viewerFrame = qt.QFrame(self.frame)
     self.viewerFrame.setLayout(qt.QHBoxLayout())
@@ -474,15 +438,6 @@ class DataProbeInfoWidget:
   def onGoToModule(self):
     m = slicer.util.mainWindow()
     m.moduleSelector().selectModule('DataProbe')
-
-  def onShowImage(self, value=False):
-    self.showImage = value
-    if value:
-      self.imageLabel.show()
-    else:
-      self.imageLabel.hide()
-      pixmap = qt.QPixmap()
-      self.imageLabel.setPixmap(pixmap)
 
 #
 # DataProbe widget


### PR DESCRIPTION
This closes #3797.

This is motivated to better utilize valuable vertical space in the module panel.

Originally discussed in https://discourse.slicer.org/t/segment-editor-user-interface-improvements/9029
> the 3DSlicer logo on the top left of every module (as it is now) is using up valuable space and it is not necessary. We all know what software we are using.

I am setting the logo label hidden by default rather than removing the label entirely because Slicer custom apps may still want the logo utilized. Is this an appropriate assumption? Or should it be removed and Slicer custom apps reimplement if they feel they need a logo at the top of the module panel?