### PR TITLE
ENH: Left/Right dock widgets given ownership to bottom corner areas

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -496,6 +496,17 @@ void qSlicerMainWindowPrivate::setupUi(QMainWindow * mainWindow)
     qWarning("qSlicerMainWindowPrivate::setupUi: Failed to create Python console");
     }
 #endif
+
+  //----------------------------------------------------------------------------
+  // Dockable Widget Area Definitions
+  //----------------------------------------------------------------------------
+  // Setting the left and right dock widget area to occupy the bottom corners
+  // means the module panel is able to have more vertical space since it is the
+  // usual left/right dockable widget. Since the module panel is typically not a
+  // majority of the width dimension, this means the python interactor in the
+  // bottom widget area still has a wide aspect ratio.
+  q->setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
+  q->setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -505,6 +505,8 @@ void qSlicerMainWindowPrivate::setupUi(QMainWindow * mainWindow)
   // usual left/right dockable widget. Since the module panel is typically not a
   // majority of the width dimension, this means the python interactor in the
   // bottom widget area still has a wide aspect ratio.
+  // If application window is narrow then the Python interactor can be docked to the top
+  // to use the full width of the application window.
   q->setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
   q->setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
 }


### PR DESCRIPTION
Originally discussed at today's hangout with @pieper @lassoan 
Note that this is somewhat related to #5820 which is also improving the defaults to value module panel vertical space more. That PR achieves more space given back to the module panel by moving the application logo to a new spot. That PR has quite the conversation going on as it relates to the logo so I wasn't going to add the changes in this PR there to avoid multiple conversations going on at once especially if this proposed change is as controversial.

Since the module panel is typically not a majority of the width dimension, this means the python interactor in the bottom widget area still has a wide aspect ratio. From my time using the python interactor I find that of typical screen size (1920x1080 at 100 to 125% scale) and aspect ratio (16:9), that the full width of the widget hasn't been used. Therefore, making it slightly less wide where it only docks below the central widget still seems appropriate.

This change maintains the current Slicer default of having the python interactor dock widget shown.

The screenshot here is also showing changes from #5820 FYI.

|Current where bottom dock widget in control of corners| This PR Docked on the left | This PR Docked on the right |
|--------------------------------------------------------------|----------------------|------------------------|
|![image](https://user-images.githubusercontent.com/15837524/131585076-f1ff45e3-3e4d-4c2d-91b0-6ef9814c12be.png)|![image](https://user-images.githubusercontent.com/15837524/131584436-cbcccbfb-719c-462b-9d50-e79fba3dbfe6.png)|![image](https://user-images.githubusercontent.com/15837524/131584484-66f08b04-873f-4531-a222-ed3862d6bd62.png)|

