### PR TITLE
BUG: Fix crash by disabling drag&drop in SH combobox

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -94,6 +94,7 @@ void qMRMLSubjectHierarchyComboBoxPrivate::init()
   this->TreeView->setColumnHidden(this->TreeView->model()->idColumn(), true);
   this->TreeView->setHeaderHidden(true);
   this->TreeView->setContextMenuEnabled(false);
+  this->TreeView->setDragDropMode(QAbstractItemView::NoDragDrop);
 
   // No item label
   this->NoItemLabel = new QLabel("No items");


### PR DESCRIPTION
In Subject Hierarchy combobox when the user started a drag, a crash occurred. Since comboboxes are intended only for selection of items and not reorganizing them, and even if we want to drag&drop it is quite inconvenient and hard to control, it makes sense to simply disable the drag&drop feature.