### PR TITLE
ENH: Add GitHub workflow for updating Slicer.crt certificate bundle

### DIFF
--- a/.github/workflows/slicerbot.yml
+++ b/.github/workflows/slicerbot.yml
@@ -1,0 +1,50 @@
+name: Slicer Bot
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 11 * * 2"
+
+jobs:
+  update-slicer-certificate-bundle:
+    name: Update Slicer.crt certificate bundle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download certdata.txt from https://github.com/mozilla/gecko-dev
+        run: |
+          cd Base/QTCore/Resources/Certs                           &&
+          certhost='https://github.com/mozilla/gecko-dev'          &&
+          certdir='/blob/master/security/nss/lib/ckfw/builtins'    &&
+          url="$certhost$certdir/certdata.txt?raw=true"            &&
+          wget --output-document certdata.txt $url
+
+      - name: Generate Slicer.crt
+        run: |
+          cd Base/QTCore/Resources/Certs                           &&
+          make-ca.sh
+
+      - name: Cleanup
+        run: |
+          cd Base/QTCore/Resources/Certs                           &&
+          rm certdata.txt
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.SLICERBOT_GITHUB_TOKEN }}
+          commit-message: "ENH: Update Slicer.crt CA bundle"
+          committer: Slicer Bot <slicerbot@slicer.org>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: slicerbot/update-slicer-certificate-bundle
+          delete-branch: true
+          title: "Update Slicer.crt CA bundle"
+          draft: false
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
Supersede  https://github.com/Slicer/Slicer/pull/5856. This new pull request is created directly from a branch created in Slicer repository hoping we can dispatch the workflow manually.