### PR TITLE
COMP: Fix qSlicerExtensionsInstallWidget build error adding  missing include

### DIFF
--- a/Base/QTGUI/qSlicerExtensionsInstallWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsInstallWidget.cxx
@@ -21,6 +21,7 @@
 // Qt includes
 #include <QDebug>
 #include <QDesktopServices>
+#include <QStyle>
 #include <QUrlQuery>
 #include <QWebEngineView>
 


### PR DESCRIPTION
This commit fixes the following error reported when building against Qt > 5.10
and introduced by 98af6f222d (ENH: ExtensionsManager: Ensure theme of
extension catalog webpage is updated):

```
Base/QTGUI/qSlicerExtensionsInstallWidget.cxx:161:39: error: invalid use of incomplete type ‘class QStyle’
```