### PR TITLE
ENH: Always prefer executable CLIs

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.cxx
+++ b/Base/QTApp/qSlicerApplicationHelper.cxx
@@ -175,9 +175,12 @@ void qSlicerApplicationHelper::setupModuleFactoryManager(qSlicerModuleFactoryMan
     QString tempDirectory =
       qSlicerCoreApplication::application()->temporaryPath();
 
-    // Option to prefer executable CLIs to limit memory consumption.
-    bool preferExecutableCLIs =
-      app->userSettings()->value("Modules/PreferExecutableCLI", Slicer_CLI_PREFER_EXECUTABLE_DEFAULT).toBool();
+    // Always prefer executable CLIs. While launching a new process and transfer data via files may take slightly
+    // longer, the file transfer is more robust, the CLI module can be stopped at any time (while a thread may be
+    // requested to stop, but there is no way to force it to stop cleanly), errors in the CLI module cannot crash
+    // the application, and startup time and memory usage is reduced by avoiding loading all CLI modules into the
+    // main process. See more information in https://github.com/Slicer/Slicer/issues/4893.
+    const bool preferExecutableCLIs = true;
 
     qSlicerCLILoadableModuleFactory* cliLoadableFactory = new qSlicerCLILoadableModuleFactory();
     cliLoadableFactory->setTempDirectory(tempDirectory);

--- a/Base/QTGUI/Resources/UI/qSlicerSettingsModulesPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsModulesPanel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>458</width>
-    <height>506</height>
+    <width>535</width>
+    <height>609</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,19 +20,6 @@
    <string>Module</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
-   <item row="3" column="0">
-    <widget class="QLabel" name="LoadBuildInModulesLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Skip loading of builtin:</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="LoadModulesLabel">
      <property name="sizePolicy">
@@ -100,6 +87,19 @@
      </layout>
     </widget>
    </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="LoadBuildInModulesLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Skip loading of builtin:</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="1">
     <widget class="QWidget" name="SkipLoadingBuiltinContainerWidget" native="true">
      <property name="sizePolicy">
@@ -155,53 +155,6 @@
     </widget>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="PreferExecutableCLILabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>To limit memory consumption, loading executable CLIs is preferred as they don't load in Slicer's memory</string>
-     </property>
-     <property name="text">
-      <string>Prefer Executable CLIs:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QWidget" name="PreferExecutableContainerWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QCheckBox" name="PreferExecutableCLICheckBox">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="5" column="0">
     <widget class="QLabel" name="ShowHiddenModulesLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -214,7 +167,7 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="4" column="1">
     <widget class="QWidget" name="ShowHiddenContainerWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -245,7 +198,7 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="TemporaryDirectoryLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -258,7 +211,7 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="5" column="1">
     <widget class="QWidget" name="TempDirContainerWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -273,7 +226,7 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="AdditionalModulePathsLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -282,14 +235,14 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Additional module paths:</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Additional module paths:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;(drag-and-drop&lt;br/&gt;files or folders)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="6" column="1">
     <widget class="QWidget" name="AdditionalModulePathsWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -369,7 +322,7 @@
      </layout>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="DisableModulesLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -388,7 +341,7 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="7" column="1">
     <widget class="QWidget" name="ModuleListContainerWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
@@ -663,7 +616,7 @@
      </layout>
     </widget>
    </item>
-   <item row="9" column="0">
+   <item row="8" column="0">
     <widget class="QLabel" name="HomeModuleLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -676,7 +629,7 @@
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="8" column="1">
     <widget class="QWidget" name="DefaultStartupContainerWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -707,7 +660,7 @@
      </layout>
     </widget>
    </item>
-   <item row="10" column="0">
+   <item row="9" column="0">
     <widget class="QLabel" name="FavoritesModulesLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -726,7 +679,7 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="1">
+   <item row="9" column="1">
     <widget class="QWidget" name="FavoriteModulesContainerWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -944,7 +944,6 @@ void qSlicerApplication::logApplicationInformation() const
       << "VTK configuration "
       << "Qt configuration "
       << "Developer mode enabled "
-      << "Prefer executable CLI "
       << "Application path "
       << "Additional module paths ";
 
@@ -1114,12 +1113,6 @@ void qSlicerApplication::logApplicationInformation() const
   qDebug("%s: %s",
          qPrintable(titles.at(titleIndex++).leftJustified(titleWidth, '.')),
          developerModeEnabled ? "yes" : "no");
-
-  // Prefer executable CLI
-  bool preferExecutableCli = settings.value("Modules/PreferExecutableCLI", Slicer_CLI_PREFER_EXECUTABLE_DEFAULT).toBool();
-  qDebug("%s: %s",
-         qPrintable(titles.at(titleIndex++).leftJustified(titleWidth, '.')),
-         preferExecutableCli ? "yes" : "no");
 
   // Additional module paths
   // These paths are not converted to absolute path, because the raw values are moreuseful for troubleshooting.

--- a/Base/QTGUI/qSlicerApplication.h
+++ b/Base/QTGUI/qSlicerApplication.h
@@ -132,7 +132,6 @@ public:
   ///   - Memory
   ///   - CPU
   ///   - Developer mode enabled
-  ///   - Prefer executable CLI
   ///   - Additional module paths
   ///
   /// \note Starting the application with `--application-information` will

--- a/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
@@ -120,7 +120,6 @@ void qSlicerSettingsModulesPanelPrivate::init()
   this->FavoritesMoreButton->setChecked(false);
 
   // Default values
-  this->PreferExecutableCLICheckBox->setChecked(Slicer_CLI_PREFER_EXECUTABLE_DEFAULT);
   this->TemporaryDirectoryButton->setDirectory(coreApp->defaultTemporaryPath());
   this->DisableModulesListView->setFactoryManager( factoryManager );
   this->FavoritesModulesListView->setFactoryManager( factoryManager );
@@ -153,8 +152,6 @@ void qSlicerSettingsModulesPanelPrivate::init()
   q->registerProperty("disable-builtin-cli-modules", this->LoadBuiltInCommandLineModulesCheckBox,
                       "checked", SIGNAL(toggled(bool)));
 
-  q->registerProperty("Modules/PreferExecutableCLI", this->PreferExecutableCLICheckBox,
-                      "checked", SIGNAL(toggled(bool)));
   q->registerProperty("Modules/HomeModule", this->ModulesMenu,
                       "currentModule", SIGNAL(currentModuleChanged(QString)));
   q->registerProperty("Modules/FavoriteModules", this->FavoritesModulesListView->filterModel(),

--- a/Docs/user_guide/settings.md
+++ b/Docs/user_guide/settings.md
@@ -20,10 +20,6 @@ For example, this command will start Slicer without any CLI loaded:
 
     Slicer.exe --disable-cli-modules
 
-#### Prefer Executable CLIs
-
-Use the executable version of a CLI instead of its shared version. CLI modules typically come in 2 forms, as shared (dll)and as executable (exe). By default, if there is a shared version, it is the one loaded by Slicer, ignoring the executable version. Loading a shared runs the module faster but increases the memory consumption. For some configurations (e.g. Windows 32b), memory is critical. Toggling this option to ON skips the loading of shared CLIs and loads executable version of CLIs instead. If there is no executable for a given CLI, the shared version is used.
-
 #### Show hidden modules
 
 Some modules don't have a user interface, they are hidden from the module's list. For debugging purpose, it is possible to force their display


### PR DESCRIPTION
Always prefer executable CLIs. While launching a process and transfer data via files may take slightly longer than passing a memory pointer and calling a DLL function, running CLI modules in separate process have several important advantages:
- the file transfer is more robust (the MRMLIDIO infrastructure was fragile and took a lot of effort to maintain)
- CLI modules can be stopped at any time (while a thread within the process may be requested to stop, there is no way to force it to stop cleanly)
- CLI module errors cannot crash the application
- application startup time and memory usage is slightly reduced by avoiding loading all CLI modules into the main process.

For now, CLI modules that only available as DLLs are still loaded, in the future this option will be removed completely.

Fixes #4893

Migration guide updated: https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide/Slicer#Slicer_5.0_:_Always_prefer_executable_CLIs