### PR TITLE
COMP: Fix -Wreturn-type in vtkMRMLMarkupsNode::GetNthControlPointNormal

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -1237,13 +1237,12 @@ void vtkMRMLMarkupsNode::SetNthControlPointOrientationMatrixWorld(int n, vtkMatr
 }
 
 //-----------------------------------------------------------
-double* vtkMRMLMarkupsNode::GetNthControlPointNormal(int n, double normal[3])
+void vtkMRMLMarkupsNode::GetNthControlPointNormal(int n, double normal[3])
 {
   ControlPoint *controlPoint = this->GetNthControlPointCustomLog(n, "GetNthControlPointNormal");
   if (!controlPoint)
     {
-    static double identity[3] = { 0.0, 0.0, 1.0 };
-    return identity;
+    return;
     }
   double* orientationMatrix = this->GetNthControlPoint(n)->OrientationMatrix;
   normal[0] = orientationMatrix[2];

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -450,7 +450,7 @@ public:
   /// Get orientation as a vtkMatrix3x3
   void GetNthControlPointOrientationMatrixWorld(int n, vtkMatrix3x3* matrix);
   /// Get normal direction (orientation of z axis) in local coordinate system.
-  double* GetNthControlPointNormal(int n, double normal[3]);
+  void GetNthControlPointNormal(int n, double normal[3]);
   /// Get normal direction (orientation of z axis) in world coordinate system.
   void GetNthControlPointNormalWorld(int n, double normalWorld[3]);
   /// Get the WXYZ orientation for the Nth control point


### PR DESCRIPTION
This commit fixes a warning originally introduced in ecc32d495 (ENH: Improve
handling of markups control point orientation).

```
  /path/to/Slicer/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx: In member function ‘double* vtkMRMLMarkupsNode::GetNthControlPointNormal(int, double*)’:
  /path/to/Slicer/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx:1252:1: warning: control reaches end of non-void function [-Wreturn-type]
   }
   ^
```