### PR TITLE
ENH: Undo Redo segment editor buttons stay in same position

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
@@ -168,6 +168,9 @@
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="spacing">
+        <number>7</number>
+       </property>
        <item>
         <widget class="QFrame" name="EffectsGroupBox">
          <property name="frameShape">
@@ -176,6 +179,46 @@
          <property name="frameShadow">
           <enum>QFrame::Raised</enum>
          </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="UndoRedoGroupBox">
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QGridLayout" name="UndoRedoLayout">
+          <item row="0" column="0">
+           <widget class="QToolButton" name="UndoButton">
+            <property name="toolTip">
+             <string>Undo last editing operation</string>
+            </property>
+            <property name="text">
+             <string>Undo</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
+              <normaloff>:/Icons/Medium/SlicerUndo.png</normaloff>:/Icons/Medium/SlicerUndo.png</iconset>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QToolButton" name="RedoButton">
+            <property name="toolTip">
+             <string>Redo last editing operation</string>
+            </property>
+            <property name="text">
+             <string>Redo</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
+              <normaloff>:/Icons/Medium/SlicerRedo.png</normaloff>:/Icons/Medium/SlicerRedo.png</iconset>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
@@ -295,38 +338,6 @@
           </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <layout class="QHBoxLayout" name="UndoRedoLayout">
-         <item>
-          <widget class="QPushButton" name="UndoButton">
-           <property name="toolTip">
-            <string>Undo last editing operation</string>
-           </property>
-           <property name="text">
-            <string>Undo</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
-             <normaloff>:/Icons/Medium/SlicerUndo.png</normaloff>:/Icons/Medium/SlicerUndo.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="RedoButton">
-           <property name="toolTip">
-            <string>Redo last editing operation</string>
-           </property>
-           <property name="text">
-            <string>Redo</string>
-           </property>
-           <property name="icon">
-            <iconset resource="../../../../../../Base/QTGUI/Resources/qSlicerBaseQTGUI.qrc">
-             <normaloff>:/Icons/Medium/SlicerRedo.png</normaloff>:/Icons/Medium/SlicerRedo.png</iconset>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </item>
        <item>
         <widget class="ctkCollapsibleGroupBox" name="MaskingGroupBox">

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -260,6 +260,9 @@ public:
   /// Button group for the effects
   QButtonGroup EffectButtonGroup;
 
+  /// Button group for the UndoRedoGroupBox
+  QButtonGroup UndoRedoButtonGroup;
+
   /// These volumes are owned by this widget and a pointer is given to each effect
   /// so that they can access and modify it
   vtkOrientedImageData* AlignedMasterVolume;
@@ -497,6 +500,9 @@ void qMRMLSegmentEditorWidgetPrivate::init()
 
   this->EffectButtonGroup.setExclusive(true);
   QObject::connect(&this->EffectButtonGroup, SIGNAL(buttonClicked(QAbstractButton*)), q, SLOT(onEffectButtonClicked(QAbstractButton*) ) );
+
+  this->UndoRedoButtonGroup.addButton(this->UndoButton);
+  this->UndoRedoButtonGroup.addButton(this->RedoButton);
 
   // Create layout for effect options
   QVBoxLayout* layout = new QVBoxLayout(this->EffectsOptionsFrame);
@@ -1179,14 +1185,33 @@ void qMRMLSegmentEditorWidget::updateEffectList()
     auto gridLayout = dynamic_cast<QGridLayout*>(d->EffectsGroupBox->layout());
     gridLayout->addWidget(effectButton, rowIndex, columnIndex);
     if(columnIndex == d->EffectColumnCount - 1)
-    {
+      {
       columnIndex = 0;
       ++rowIndex;
-    }
+      }
     else
-    {
+      {
       ++columnIndex;
+      }
     }
+
+  // Set UndoRedoGroupBox buttons with same column count as EffectsGroupBox
+  rowIndex = 0;
+  columnIndex = 0;
+  QList<QAbstractButton*> undoRedoButtons = d->UndoRedoButtonGroup.buttons();
+  foreach(QAbstractButton* button, undoRedoButtons)
+    {
+    auto undoRedoGridLayout = dynamic_cast<QGridLayout*>(d->UndoRedoGroupBox->layout());
+    undoRedoGridLayout->addWidget(button, rowIndex, columnIndex);
+    if(columnIndex == d->EffectColumnCount - 1)
+      {
+      columnIndex = 0;
+      ++rowIndex;
+      }
+    else
+      {
+      ++columnIndex;
+      }
     }
 }
 
@@ -3038,7 +3063,7 @@ void qMRMLSegmentEditorWidget::setSwitchToSegmentationsButtonVisible(bool visibl
 bool qMRMLSegmentEditorWidget::undoEnabled() const
 {
   Q_D(const qMRMLSegmentEditorWidget);
-  return (d->UndoButton->isVisible() || d->RedoButton->isVisible());
+  return d->UndoRedoGroupBox->isVisible();
 }
 
 //-----------------------------------------------------------------------------
@@ -3049,8 +3074,7 @@ void qMRMLSegmentEditorWidget::setUndoEnabled(bool enabled)
     {
     d->SegmentationHistory->RemoveAllStates();
     }
-  d->UndoButton->setVisible(enabled);
-  d->RedoButton->setVisible(enabled);
+  d->UndoRedoGroupBox->setVisible(enabled);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This moves the Undo and Redo buttons in the Segment Editor module to be under the effects groupbox. This is motivated by the desire for these buttons to not move when different segment editor effects are selected.

See https://discourse.slicer.org/t/new-segment-editor-layout-vertical-effect-toolbar/19649/9?u=jamesobutler for more details about this development.

| Current | This PR |
|----------|---------|
|![image](https://user-images.githubusercontent.com/15837524/133895687-bbf355b0-63a4-4e8f-8139-4832499b87d5.png)|![image](https://user-images.githubusercontent.com/15837524/133895637-9b5d8e05-0de0-4f1d-9e9a-28bbd744d613.png)|