### PR TITLE
Export individual nodes

### DIFF
--- a/Base/QTGUI/CMakeLists.txt
+++ b/Base/QTGUI/CMakeLists.txt
@@ -34,6 +34,8 @@ set(KIT_SRCS
   qSlicerDataDialog.h
   qSlicerDirectoryListView.cxx
   qSlicerDirectoryListView.h
+  qSlicerExportNodeDialog.cxx
+  qSlicerExportNodeDialog.h
 
   qSlicerFileDialog.cxx
   qSlicerFileDialog.h
@@ -189,6 +191,8 @@ set(KIT_MOC_SRCS
   qSlicerDataDialog.h
   qSlicerDataDialog_p.h
   qSlicerDirectoryListView.h
+  qSlicerExportNodeDialog.h
+  qSlicerExportNodeDialog_p.h
   qSlicerFileDialog.h
   qSlicerFileWriterOptionsWidget.h
   qSlicerIOManager.h
@@ -278,6 +282,7 @@ endif()
 set(KIT_UI_SRCS
   Resources/UI/qSlicerActionsDialog.ui
   Resources/UI/qSlicerDataDialog.ui
+  Resources/UI/qSlicerExportNodeDialog.ui
   Resources/UI/qSlicerModelsDialog.ui
   Resources/UI/qSlicerModuleFinderDialog.ui
   Resources/UI/qSlicerModulePanel.ui

--- a/Base/QTGUI/Resources/UI/qSlicerExportNodeDialog.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerExportNodeDialog.ui
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qSlicerExportNodeDialog</class>
+ <widget class="QDialog" name="qSlicerExportNodeDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>450</width>
+    <height>192</height>
+   </rect>
+  </property>
+  <property name="cursor">
+   <cursorShape>ArrowCursor</cursorShape>
+  </property>
+  <property name="windowTitle">
+   <string>Export node</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../qSlicerBaseQTGUI.qrc">
+    <normaloff>:/Icons/SaveScene.png</normaloff>:/Icons/SaveScene.png</iconset>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>false</bool>
+  </property>
+  <layout class="QFormLayout" name="formLayout_2">
+   <property name="verticalSpacing">
+    <number>6</number>
+   </property>
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>14</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="FilenameLabel">
+     <property name="text">
+      <string>Filename</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="FilenameLineEdit">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="DirectoryLabel">
+     <property name="text">
+      <string>Directory</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="ctkPathLineEdit" name="DirectoryPathLineEdit" native="true"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="ExportFormatLabel">
+     <property name="text">
+      <string>Export format</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QComboBox" name="ExportFormatComboBox"/>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="OptionsLabel">
+     <property name="text">
+      <string>Options</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="QWidget" name="OptionsContainer" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::TabFocus</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QCheckBox" name="HardenTransformCheckBox">
+       <property name="text">
+        <string>Apply transforms</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="10" column="1">
+    <widget class="QDialogButtonBox" name="ButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ctkPathLineEdit</class>
+   <extends>QWidget</extends>
+   <header>ctkPathLineEdit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>FilenameLineEdit</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../qSlicerBaseQTGUI.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>ButtonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>qSlicerExportNodeDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>429</x>
+     <y>93</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ButtonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>qSlicerExportNodeDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>497</x>
+     <y>93</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Base/QTGUI/qSlicerExportNodeDialog.cxx
+++ b/Base/QTGUI/qSlicerExportNodeDialog.cxx
@@ -362,7 +362,9 @@ bool qSlicerExportNodeDialogPrivate::exportNode()
     if (errorFound)
       {
       QMessageBox::critical(this, tr("Export error"), messagesStr);
-      success = false; // If there was an error, this should never have been considered a success.
+      // If there was an error, this should never have been considered a success.
+      success = false;
+      qWarning() << Q_FUNC_INFO << " warning: node write returned success, while there were error messages during write.";
       }
     else if (warningFound)
       {

--- a/Base/QTGUI/qSlicerExportNodeDialog.cxx
+++ b/Base/QTGUI/qSlicerExportNodeDialog.cxx
@@ -1,0 +1,631 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+/// Qt includes
+#include <QApplication>
+#include <QComboBox>
+#include <QDebug>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
+
+/// CTK includes
+#include <ctkPathLineEdit.h>
+
+/// Slicer includes
+#include "qSlicerApplication.h"
+#include "qSlicerCoreIOManager.h"
+#include "qSlicerFileWriterOptionsWidget.h"
+#include "qSlicerExportNodeDialog_p.h"
+
+/// MRML includes
+#include <vtkDataFileFormatHelper.h> // for GetFileExtensionFromFormatString()
+#include <vtkMRMLMessageCollection.h>
+#include <vtkMRMLScene.h>
+#include <vtkMRMLStorageNode.h>
+#include <vtkMRMLTransformableNode.h>
+#include <vtkMRMLSceneViewNode.h>
+
+
+//-----------------------------------------------------------------------------
+static QString forceFileNameExtension(const QString& fileName, const QString& extension, vtkMRMLNode* node)
+{
+  qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
+  QString strippedFileName = qSlicerCoreIOManager::forceFileNameValidCharacters(fileName);
+  strippedFileName = coreIOManager->stripKnownExtension(strippedFileName, node) + extension;
+  return strippedFileName;
+}
+
+
+//-----------------------------------------------------------------------------
+qSlicerExportNodeDialogPrivate::qSlicerExportNodeDialogPrivate(QWidget* parentWidget)
+  : QDialog(parentWidget),
+    lastUsedDirectory{},
+    lastUsedFormats{},
+    lastUsedHardenTransform{false},
+    formatToOptionsWidget{}
+{
+  this->setupUi(this);
+
+  connect(this->FilenameLineEdit, SIGNAL(editingFinished()),
+          this, SLOT(onFilenameEditingFinished()));
+
+  QObject::connect(this->ExportFormatComboBox, &QComboBox::currentTextChanged,
+                   this, &qSlicerExportNodeDialogPrivate::formatChangedSlot);
+
+  // Set up DirectoryPathLineEdit widget to be a directory selector
+  this->DirectoryPathLineEdit->setLabel("Output folder");
+  this->DirectoryPathLineEdit->setFilters(ctkPathLineEdit::Dirs);
+}
+
+//-----------------------------------------------------------------------------
+qSlicerExportNodeDialogPrivate::~qSlicerExportNodeDialogPrivate() = default;
+
+//-----------------------------------------------------------------------------
+bool qSlicerExportNodeDialogPrivate::setup(vtkMRMLScene* scene, vtkMRMLNode* node)
+{
+
+  this->MRMLScene = scene;
+  this->MRMLNode = node;
+
+  this->DirectoryPathLineEdit->setCurrentPath(
+    this->lastUsedDirectory.isEmpty() ? this->MRMLScene->GetRootDirectory() : this->lastUsedDirectory
+  );
+
+  qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
+  if (!coreIOManager)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: Core IO manager not found.";
+    return false;
+    }
+
+  this->setWindowTitle(QString("Export ")+QString(this->MRMLNode->GetName()));
+
+  // Now we will work on filling up the export formats dropdown box
+  // with the various choices and initializaing a choice
+
+  this->ExportFormatComboBox->clear();
+
+  vtkMRMLStorableNode* storableNode = vtkMRMLStorableNode::SafeDownCast(this->MRMLNode);
+  if (!storableNode)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: Node is not storable.";
+    return false;
+    }
+
+  // Get the favored extension according to the storage node (if there is one)
+  QString extensionInStorageNode;
+  vtkMRMLStorageNode* storageNode = storableNode->GetStorageNode();
+  if (storageNode)
+    {
+    if (storageNode->GetDefaultWriteFileExtension() != nullptr)
+      {
+      extensionInStorageNode = storageNode->GetDefaultWriteFileExtension();
+      }
+    }
+  else { // If there wasn't a storage node, we make a temporary one just to get default extension information from it
+    const std::string defaultStorageNodeClassName = storableNode->GetDefaultStorageNodeClassName();
+    if (!defaultStorageNodeClassName.empty())
+      {
+      vtkSmartPointer<vtkMRMLNode> defaultStorageNodeAsNode = vtkSmartPointer<vtkMRMLNode>::Take(
+        this->MRMLScene->CreateNodeByClass(defaultStorageNodeClassName.c_str())
+      );
+      vtkMRMLStorageNode* defaultStorageNode = vtkMRMLStorageNode::SafeDownCast(defaultStorageNodeAsNode);
+      extensionInStorageNode = defaultStorageNode->GetDefaultWriteFileExtension();
+      }
+  }
+
+  QString currentExtension = storageNode ?
+    coreIOManager->completeSlicerWritableFileNameSuffix(storableNode) : QString(".");
+  // (Checking that storageNode is not null allows us to dodge a warning from completeSlicerWritableFileNameSuffix)
+  int suggestedFormatIndex = -1; // will be index corresponding to format corresponding to currentExtension
+  foreach(QString nameFilter, coreIOManager->fileWriterExtensions(storableNode))
+  {
+    // extract extension (e.g. ".ext") from format description string (e.g. "Blahblahblah (.ext)")
+    QString extension = QString::fromStdString(
+      vtkDataFileFormatHelper::GetFileExtensionFromFormatString(nameFilter.toUtf8()));
+
+    // add the entry to the dropdown menu
+    this->ExportFormatComboBox->addItem(nameFilter, extension);
+
+    // if it was the current extension, remember the index
+    if (extension == currentExtension)
+      {
+      suggestedFormatIndex = this->ExportFormatComboBox->count() - 1;
+      }
+  }
+
+  // If it turns out currentExtension was not any of the choices,
+  // then look for extensionInStorageNode
+  if (suggestedFormatIndex == -1 && !extensionInStorageNode.isEmpty())
+    {
+    for (int i = 0; i < this->ExportFormatComboBox->count(); ++i)
+      {
+      if (this->ExportFormatComboBox->itemData(i).toString() ==  QString('.') + extensionInStorageNode)
+        {
+        suggestedFormatIndex = i;
+        break;
+        }
+      }
+    }
+
+  // Look for the most recently used extension that is part of the dropdown list
+  int previouslyUsedFormatIndex = -1;
+  for (const QString & format : this->lastUsedFormats)
+    {
+    int formatIndex = this->ExportFormatComboBox->findText(format);
+    if (formatIndex != -1)
+      {
+      previouslyUsedFormatIndex = formatIndex;
+      break;
+      }
+    }
+
+  // Prefer to use last used extension, then suggested extension found above,
+  // then if all else fails just leave a prompt for the user to select a format
+  if (previouslyUsedFormatIndex != -1)
+    {
+    this->ExportFormatComboBox->setCurrentIndex(previouslyUsedFormatIndex);
+    }
+  else if (suggestedFormatIndex != -1)
+    {
+    this->ExportFormatComboBox->setCurrentIndex(suggestedFormatIndex);
+    }
+  else
+    {
+    this->ExportFormatComboBox->blockSignals(true); // avoid triggering a formatChanged here
+    this->ExportFormatComboBox->setCurrentIndex(-1);
+    this->ExportFormatComboBox->setEditable(true); // so we can set custom text below
+    this->ExportFormatComboBox->lineEdit()->setReadOnly(true);
+    this->ExportFormatComboBox->setEditText("Select a format");
+    this->ExportFormatComboBox->blockSignals(false);
+    }
+
+  // Initialize filename
+  const QString unsafeNodeName(this->MRMLNode->GetName() ? this->MRMLNode->GetName() : "");
+  const QString safeNodeName = qSlicerCoreIOManager::forceFileNameValidCharacters(unsafeNodeName);
+  this->FilenameLineEdit->setText(
+    forceFileNameExtension(safeNodeName, this->extension(), this->MRMLNode)
+  );
+
+  // Now that we have initialized the ExportFormatComboBox with a format,
+  // we can initialize the options widget
+  this->updateOptionsWidget();
+
+  // Set keyboard focus to the filename textbox
+  this->FilenameLineEdit->setFocus(Qt::ActiveWindowFocusReason);
+
+  // Set coordinate system option visibility and initial state
+  vtkMRMLTransformableNode* nodeAsTransformable = vtkMRMLTransformableNode::SafeDownCast(this->MRMLNode);
+  if (nodeAsTransformable && nodeAsTransformable->GetParentTransformNode())
+    {
+    this->HardenTransformCheckBox->show();
+    this->HardenTransformCheckBox->setChecked(this->lastUsedHardenTransform);
+    }
+  else
+    {
+    this->HardenTransformCheckBox->hide();
+    this->HardenTransformCheckBox->setChecked(false);
+    }
+
+
+  return true; // success
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExportNodeDialogPrivate::accept()
+{
+  this->saveWidgetStates();
+
+  if (!this->exportNode())
+    {
+    return;
+    }
+  this->done(QDialog::Accepted);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExportNodeDialogPrivate::saveWidgetStates()
+{
+  this->lastUsedDirectory = this->DirectoryPathLineEdit->currentPath();
+
+  if (this->HardenTransformCheckBox->isVisible())
+    {
+    this->lastUsedHardenTransform = this->HardenTransformCheckBox->isChecked();
+    }
+
+  // Save export format dropdown data into front of lastUsedFormats,
+  // and pop the back if the list is long
+  this->lastUsedFormats.push_front(this->formatText());
+  if (this->lastUsedFormats.size()>20)
+    {
+    this->lastUsedFormats.pop_back();
+    }
+  // QList is similar to std::deque, prepend and append are fast:
+  // https://doc.qt.io/qt-5/containers.html#algorithmic-complexity
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerExportNodeDialogPrivate::exportNode()
+{
+  // If the current filename isn't the suggested one, give a prompt that suggests changing it
+  // The user can either proceed without change
+  // or the user can accept the change (in which case we make the change and proceed normally)
+  // or the user can cancel the export (in which case we return false here, so they can return to the export dialog)
+  QString betterFilename = this->recommendedFilename();
+  if (this->FilenameLineEdit->text() != betterFilename)
+    {
+    QMessageBox messageBox(
+      QMessageBox::Warning, // icon
+      tr("Filename not standard"), // title
+      tr("The following filename is recommended:\n")+betterFilename, // message text
+      QMessageBox::NoButton, // buttons; they will be added after
+      this // parent
+    );
+    QAbstractButton* acceptButton = messageBox.addButton("Accept recommended", QMessageBox::YesRole);
+    messageBox.addButton("Keep my filename", QMessageBox::NoRole);
+    QAbstractButton* cancelButton = messageBox.addButton(QMessageBox::Cancel);
+    messageBox.exec();
+
+    if (messageBox.clickedButton() == acceptButton)
+      {
+      this->FilenameLineEdit->setText(betterFilename);
+      }
+    else if (messageBox.clickedButton() == cancelButton)
+      {
+      return false;
+      }
+    }
+
+  // file properties
+  QFileInfo file = this->file();
+  QString formatText = this->formatText();
+  qSlicerFileWriterOptionsWidget* options = this->getOptionsWidget();
+
+  if (file.fileName().isEmpty())
+    {
+    QMessageBox::critical(this, tr("Export error"),
+        tr("Failed to export node %1; filename is empty.")
+          .arg(this->MRMLNode->GetName())
+    );
+    return false;
+    }
+
+  if (file.exists())
+    {
+    QMessageBox::StandardButton answer = QMessageBox::question(this, tr("Exporting node..."),
+      tr("The file %1 already exists. Do you want to replace it?").arg(file.absoluteFilePath()),
+      QMessageBox::Yes | QMessageBox::No,
+      QMessageBox::Yes
+    );
+    if (answer != QMessageBox::Yes)
+      {
+      return false;
+      }
+    }
+
+  // export the node
+  qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
+
+  QList<QString> nodesToExport;
+  nodesToExport.push_back(QString(this->MRMLNode->GetID()));
+
+  QList<QString> filePaths;
+  filePaths.push_back(file.absoluteFilePath());
+
+  qSlicerIO::IOProperties savingParameters;
+  if (options)
+    {
+    savingParameters = options->properties();
+    }
+  savingParameters["fileFormat"] = formatText;
+  savingParameters["hardenTransforms"] = this->HardenTransformCheckBox->isChecked();
+
+  vtkNew<vtkMRMLMessageCollection> userMessages;
+
+  QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
+  bool success = coreIOManager->exportNodes(nodesToExport, filePaths, savingParameters, userMessages);
+  QApplication::restoreOverrideCursor();
+
+  if (!success)
+    {
+    // Make sure an error message is added if saving returns with error
+    userMessages->AddMessage(vtkCommand::ErrorEvent,
+      (tr("Cannot write data file: %1.").arg(file.absoluteFilePath())).toStdString());
+
+    QString messagesStr = QString::fromStdString(userMessages->GetAllMessagesAsString());
+
+    // display messagesStr as an error message
+    QMessageBox::critical(this, tr("Export error"), messagesStr);
+    }
+  // In case there are any errors or warnings in storage node, make sure to alert even in case of success:
+  else if (userMessages->GetNumberOfMessages() > 0)
+    {
+    bool warningFound = false;
+    bool errorFound = false;
+    QString messagesStr = QString::fromStdString(userMessages->GetAllMessagesAsString(&errorFound, &warningFound));
+
+    if (errorFound)
+      {
+      QMessageBox::critical(this, tr("Export error"), messagesStr);
+      success = false; // If there was an error, this should never have been considered a success.
+      }
+    else if (warningFound)
+      {
+      QMessageBox::warning(this, tr("Export warning"), messagesStr);
+      }
+    else
+      {
+      QMessageBox::information(this, tr("Export information"), messagesStr);
+      }
+    }
+
+  return success;
+}
+
+//-----------------------------------------------------------------------------
+QFileInfo qSlicerExportNodeDialogPrivate::file() const
+{
+  QDir directory = this->DirectoryPathLineEdit->currentPath();
+  QString filename = this->FilenameLineEdit->text();
+  return QFileInfo(directory, filename);
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerExportNodeDialogPrivate::formatText() const
+{
+  return this->ExportFormatComboBox->currentText();
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerExportNodeDialogPrivate::extension() const
+{
+  return this->ExportFormatComboBox->itemData(
+    this->ExportFormatComboBox->currentIndex()
+  ).toString();
+}
+
+//-----------------------------------------------------------------------------
+qSlicerFileWriterOptionsWidget* qSlicerExportNodeDialogPrivate::getOptionsWidget() const
+{
+  if (this->OptionsContainer->findChildren<QWidget*>(QString(),Qt::FindDirectChildrenOnly).size() > 1)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: OptionsContainer should always have at most one child.";
+    return nullptr;
+    }
+
+  QWidget* optionsContainerChild = this->OptionsContainer->findChild<QWidget*>(QString(), Qt::FindDirectChildrenOnly);
+  if (!optionsContainerChild)
+    {
+    return nullptr;
+    }
+
+  qSlicerFileWriterOptionsWidget* options = dynamic_cast<qSlicerFileWriterOptionsWidget*>(optionsContainerChild);
+  if (!options)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: child of OptionsContainer should always be a qSlicerFileWriterOptionsWidget";
+    }
+
+  return options;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExportNodeDialogPrivate::formatChangedSlot()
+{
+  this->formatChanged(true);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExportNodeDialogPrivate::formatChanged(bool updateFilename)
+{
+  // In case the combobox was editable (hack to display custom text), we now
+  // don't need this property anymore.
+  this->ExportFormatComboBox->setEditable(false);
+
+  if (updateFilename)
+    {
+    this->FilenameLineEdit->setText(this->recommendedFilename());
+    }
+
+  this->updateOptionsWidget();
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerExportNodeDialogPrivate::recommendedFilename() const
+{
+  // Get the extension associated with the currently selected format
+  QString extension = QString::fromStdString(vtkDataFileFormatHelper::GetFileExtensionFromFormatString(
+    this->formatText().toUtf8()));
+  if (extension == "*")
+    {
+    extension = QString();
+    }
+
+  return forceFileNameExtension(this->FilenameLineEdit->text(), extension, this->MRMLNode);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExportNodeDialogPrivate::updateOptionsWidget()
+{
+  // If there is already an options widget corresponding to the format currently being used,
+  // then just use that. Otherwise we go ahead and create a new options widget.
+  auto iterator = this->formatToOptionsWidget.find(this->formatText());
+  if (iterator != this->formatToOptionsWidget.end())
+    {
+    this->setOptionsWidget(*iterator);
+    return;
+    }
+
+
+  // Create new options widget for the present node type
+  qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
+  qSlicerIOOptions* options = coreIOManager->fileWriterOptions(this->MRMLNode, this->formatText());
+
+  // We can only use options that are also widgets. If the following cast succeeds, we pass ownership
+  // of the options widget to the export dialog, and if it fails we immediatly delete and give up.
+  qSlicerFileWriterOptionsWidget* optionsWidget = dynamic_cast<qSlicerFileWriterOptionsWidget*>(options);
+  if (!optionsWidget)
+    {
+    delete options;
+    return;
+    }
+
+  // The optionsWidget can use the filename to initialize some options.
+  optionsWidget->setFileName(this->file().absoluteFilePath());
+  optionsWidget->setObject(this->MRMLNode);
+
+  this->setOptionsWidget(optionsWidget); // pass ownership of optionsWidget to the qSlicerExportNodeDialog widget
+
+  this->formatToOptionsWidget.insert(this->formatText(),optionsWidget);
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExportNodeDialogPrivate::setOptionsWidget(qSlicerFileWriterOptionsWidget* optionsWidget)
+{
+  if (!optionsWidget)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: optionsWidget is null";
+    return;
+    }
+
+  // If there's already a widget in the container, set it aside
+  QWidget* optionsContainerChild = this->OptionsContainer->findChild<QWidget*>(QString(), Qt::FindDirectChildrenOnly);
+  if (optionsContainerChild)
+    {
+    // This "stows away" the options widget. It still has its memory managed by Qt.
+    optionsContainerChild->hide();
+    optionsContainerChild->setParent(this);
+    }
+
+  // Container should be empty now; it should never contain more than one widget
+  if ( ! this->OptionsContainer->findChildren<QWidget*>().isEmpty())
+    {
+    qWarning() << Q_FUNC_INFO << " assumption failing: OptionsContainer should now have no children.";
+    }
+
+  // Now ready to inject the new optionsWidget into the container
+  optionsWidget->setParent(this->OptionsContainer); // passes ownership of optionsWidget
+  optionsWidget->show(); // setting parent made it invisible
+
+  // Make it so that tabbing into OptionsContainer sets focus to the first item in optionsWidget
+  this->OptionsContainer->setFocusProxy(optionsWidget);
+  QWidget* firstTabbableOptionChild = optionsWidget->nextInFocusChain();
+  if (firstTabbableOptionChild) // unclear whether this can be null; check just in case
+    {
+    this->OptionsContainer->setFocusPolicy(Qt::TabFocus);
+    optionsWidget->setFocusProxy(firstTabbableOptionChild);
+    }
+  else
+    {
+    this->OptionsContainer->setFocusPolicy(Qt::NoFocus);
+    }
+
+  // Sometimes optionsWidget isn't wide enough to show the full label for each option:
+  optionsWidget->setMinimumSize(optionsWidget->sizeHint());
+  OptionsContainer->setMinimumSize(optionsWidget->sizeHint());
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerExportNodeDialogPrivate::onFilenameEditingFinished()
+{
+  // When the filename in the text box is changed, we check whether it matches a supported
+  // file extension. If so, we update the file format selector.
+  // If not, then the current file extension will be added
+  // (this way when the user just enters extensionless filename,
+  // the extension is added automatically).
+  QString strippedFileName = qSlicerCoreIOManager::forceFileNameValidCharacters(this->FilenameLineEdit->text());
+
+  // Determine current file extension
+  // (switch to lowercase because the data in the ExportFormatComboBox entries are all lowercase)
+  qSlicerCoreIOManager* coreIOManager = qSlicerCoreApplication::application()->coreIOManager();
+  QString currentExtensionLower = coreIOManager->extractKnownExtension(strippedFileName.toLower(), this->MRMLNode);
+
+  // Update file format selector according to current extension
+  int newFormat = this->ExportFormatComboBox->findData(currentExtensionLower);
+  if (newFormat >= 0)
+    {
+    // current extension matches a supported format, update the format selector widget accordingly
+    this->ExportFormatComboBox->blockSignals(true);
+    this->ExportFormatComboBox->setCurrentIndex(newFormat);
+    this->formatChanged(false); // We blocked signals so we can manually call formatChanged
+    // with updateFilename set to false. This way the filename that the user just typed is not rudely changed.
+    this->ExportFormatComboBox->blockSignals(false);
+    }
+}
+
+//-----------------------------------------------------------------------------
+qSlicerExportNodeDialog::qSlicerExportNodeDialog(QObject* parentObject)
+  : qSlicerFileDialog(parentObject)
+  , d_ptr(new qSlicerExportNodeDialogPrivate(nullptr))
+{
+}
+
+//-----------------------------------------------------------------------------
+qSlicerExportNodeDialog::~qSlicerExportNodeDialog() = default;
+
+//-----------------------------------------------------------------------------
+qSlicerIO::IOFileType qSlicerExportNodeDialog::fileType()const
+{
+  return QString("GenericNodeExport");
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerExportNodeDialog::description()const
+{
+  return tr("Export an individual node");
+}
+
+//-----------------------------------------------------------------------------
+qSlicerFileDialog::IOAction qSlicerExportNodeDialog::action()const
+{
+  return qSlicerFileDialog::Write;
+}
+
+//-----------------------------------------------------------------------------
+bool qSlicerExportNodeDialog::exec(const qSlicerIO::IOProperties& readerProperties)
+{
+  Q_D(qSlicerExportNodeDialog);
+
+  vtkMRMLScene* scene = qSlicerCoreApplication::application()->mrmlScene();
+
+  QString nodeID;
+  if (readerProperties.contains("nodeID"))
+    {
+    nodeID = readerProperties["nodeID"].toString();
+    }
+
+
+  if (nodeID.isEmpty())
+    {
+    qCritical() << Q_FUNC_INFO << " failed: No nodeID property found.";
+    return false;
+    }
+
+  vtkMRMLNode * node = scene->GetNodeByID(nodeID.toUtf8().constData());
+
+  if (!d->setup(scene, node))
+    {
+    return false;
+    }
+
+  if (d->exec() != QDialog::Accepted)
+    {
+    return false;
+    }
+
+  return true;
+}

--- a/Base/QTGUI/qSlicerExportNodeDialog.h
+++ b/Base/QTGUI/qSlicerExportNodeDialog.h
@@ -1,0 +1,53 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __qSlicerExportNodeDialog_h
+#define __qSlicerExportNodeDialog_h
+
+// Slicer includes
+#include "qSlicerFileDialog.h"
+#include "qSlicerBaseQTGUIExport.h"
+
+/// Forward declarations
+class qSlicerExportNodeDialogPrivate;
+
+//------------------------------------------------------------------------------
+class Q_SLICER_BASE_QTGUI_EXPORT qSlicerExportNodeDialog : public qSlicerFileDialog
+{
+  Q_OBJECT
+public:
+  typedef QObject Superclass;
+  qSlicerExportNodeDialog(QObject* parent = nullptr);
+  ~qSlicerExportNodeDialog() override;
+
+  qSlicerIO::IOFileType fileType()const override;
+  QString description()const override;
+  qSlicerFileDialog::IOAction action()const override;
+
+  /*! Open the data dialog and save the nodes/scene */
+  bool exec(const qSlicerIO::IOProperties& readerProperties =
+                    qSlicerIO::IOProperties()) override;
+
+protected:
+  QScopedPointer<qSlicerExportNodeDialogPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerExportNodeDialog);
+  Q_DISABLE_COPY(qSlicerExportNodeDialog);
+};
+
+#endif

--- a/Base/QTGUI/qSlicerExportNodeDialog_p.h
+++ b/Base/QTGUI/qSlicerExportNodeDialog_p.h
@@ -1,0 +1,94 @@
+#ifndef __qSlicerExportNodeDialog_p_h
+#define __qSlicerExportNodeDialog_p_h
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Slicer API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+// Qt includes
+#include <QDialog>
+#include <QFileInfo>
+#include <QHash>
+#include <QList>
+
+// Slicer includes
+#include "qSlicerExportNodeDialog.h"
+#include "ui_qSlicerExportNodeDialog.h"
+
+class vtkMRMLNode;
+class qSlicerFileWriterOptionsWidget;
+
+//-----------------------------------------------------------------------------
+class qSlicerExportNodeDialogPrivate
+  : public QDialog
+  , public Ui_qSlicerExportNodeDialog
+{
+  Q_OBJECT
+public:
+  typedef qSlicerExportNodeDialogPrivate Self;
+  explicit qSlicerExportNodeDialogPrivate(QWidget* _parent=nullptr);
+  ~qSlicerExportNodeDialogPrivate() override;
+
+  /* Set the node being exported and fill out the
+     dialog widgets with a reasonable initial state */
+  bool setup(vtkMRMLScene* scene, vtkMRMLNode* node);
+
+  /* Save the states of some widgets
+  so that they can be restored next time the dialog
+  is activated. Note that the options widget state
+  is not involved here-- instead of saving options widget state
+  we save the options widgets themselves in updateOptionsWidget.
+  This prevents things from breaking as people make changes to
+  options widgets. */
+  void saveWidgetStates();
+
+public slots:
+  bool exportNode();
+  void accept() override; // overrides QDialog::accept()
+
+protected slots:
+  void formatChangedSlot();
+  void onFilenameEditingFinished();
+
+protected:
+
+  void formatChanged(bool updateFilename);
+  void updateOptionsWidget();
+  QFileInfo file() const;
+
+  void setOptionsWidget(qSlicerFileWriterOptionsWidget*);
+  qSlicerFileWriterOptionsWidget* getOptionsWidget() const;
+
+  // return the actual text of the currently selected option
+  // in the format dropdown. e.g. "NRRD (.nrrd)"
+  QString formatText() const;
+
+  // return extension corresponding to format selected in dropdown
+  // e.g. ".nrrd"
+  QString extension() const;
+
+  // return the recommended filename based on current filename and the
+  // format selected in the dropdown
+  QString recommendedFilename() const;
+
+
+  vtkMRMLScene* MRMLScene;
+  vtkMRMLNode* MRMLNode;
+
+  QString lastUsedDirectory;
+  QList<QString> lastUsedFormats;
+  bool lastUsedHardenTransform;
+
+  // mapping from formats to options widgets, to save them as they get created
+  QHash<QString,qSlicerFileWriterOptionsWidget*> formatToOptionsWidget;
+};
+
+
+#endif

--- a/Base/QTGUI/qSlicerNodeWriter.h
+++ b/Base/QTGUI/qSlicerNodeWriter.h
@@ -66,7 +66,7 @@ public:
 
   virtual vtkMRMLNode* getNodeByID(const char *id)const;
 
-  /// Return a qSlicerIONodeWriterOptionsWidget
+  /// Return a qSlicerNodeWriterOptionsWidget
   qSlicerIOOptions* options()const override;
 
 protected:

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -442,7 +442,7 @@ void qSlicerSaveDataDialogPrivate::populateNode(vtkMRMLNode* node)
 */
   // Get absolute filename and create storage node if needed
   QFileInfo fileInfo = this->nodeFileInfo(storableNode);
-  if (fileInfo == QFileInfo())
+  if (fileInfo.filePath().isEmpty())
     {
     return;
     }

--- a/Base/QTGUI/qSlicerSaveDataDialog.cxx
+++ b/Base/QTGUI/qSlicerSaveDataDialog.cxx
@@ -78,28 +78,10 @@ qSlicerFileNameItemDelegate::qSlicerFileNameItemDelegate( QObject * parent )
 }
 
 //-----------------------------------------------------------------------------
-QString qSlicerFileNameItemDelegate::forceFileNameValidCharacters(const QString& filename)
-{
-  // Remove characters that are likely to cause problems in filename
-  QString sanitizedFilename;
-  QRegExp regExp = qSlicerFileNameItemDelegate::fileNameRegExp();
-  for (int i = 0; i < filename.size(); ++i)
-    {
-    if (regExp.exactMatch(QString(filename[i])))
-      {
-      sanitizedFilename += filename[i];
-      }
-    }
-  // Remove leading and trailing spaces
-  sanitizedFilename = sanitizedFilename.trimmed();
-  return sanitizedFilename;
-}
-
-//-----------------------------------------------------------------------------
 QString qSlicerFileNameItemDelegate::forceFileNameExtension(const QString& fileName, const QString& extension,
                                                    vtkMRMLScene* mrmlScene, const QString& nodeID)
 {
-  QString strippedFileName = qSlicerFileNameItemDelegate::forceFileNameValidCharacters(fileName);
+  QString strippedFileName = qSlicerCoreIOManager::forceFileNameValidCharacters(fileName);
   if(!mrmlScene)
     {
     // no scene is set, cannot check extension
@@ -115,20 +97,10 @@ QString qSlicerFileNameItemDelegate::forceFileNameExtension(const QString& fileN
     qCritical() << Q_FUNC_INFO << " failed: node not found by ID " << qPrintable(nodeID);
     return QString();
     }
-  strippedFileName = qSlicerSaveDataDialogPrivate::stripKnownExtension(strippedFileName, object) + extension;
+  qSlicerCoreIOManager* coreIOManager =
+    qSlicerCoreApplication::application()->coreIOManager();
+  strippedFileName = coreIOManager->stripKnownExtension(strippedFileName, object) + extension;
   return strippedFileName;
-}
-
-//-----------------------------------------------------------------------------
-QRegExp qSlicerFileNameItemDelegate::fileNameRegExp(const QString& extension)
-{
-  QRegExp regExp("[A-Za-z0-9\\ \\-\\_\\.\\(\\)\\$\\!\\~\\#\\'\\%\\^\\{\\}]{1,255}");
-
-  if (!extension.isEmpty())
-    {
-    regExp.setPattern(regExp.pattern() + extension);
-    }
-  return regExp;
 }
 
 //-----------------------------------------------------------------------------
@@ -364,7 +336,7 @@ void qSlicerSaveDataDialogPrivate::populateScene()
   // Scene Format
   QComboBox* sceneComboBoxWidget = new QComboBox(this->FileWidget);
   int currentFormat = -1;
-  QString currentExtension = Self::extractKnownExtension(sceneFileInfo.fileName(), this->MRMLScene);
+  QString currentExtension = coreIOManager->extractKnownExtension(sceneFileInfo.fileName(), this->MRMLScene);
   foreach(const QString& nameFilter,
           coreIOManager->fileWriterExtensions(this->MRMLScene))
     {
@@ -511,7 +483,7 @@ QFileInfo qSlicerSaveDataDialogPrivate::nodeFileInfo(vtkMRMLStorableNode* node)
   // Remove characters from node name that cannot be used in file names
   // (same method as in qSlicerFileNameItemDelegate::forceFileNameExtension)
   QString inputNodeName(node->GetName() ? node->GetName() : "");
-  QString safeNodeName = qSlicerFileNameItemDelegate::forceFileNameValidCharacters(inputNodeName);
+  QString safeNodeName = qSlicerCoreIOManager::forceFileNameValidCharacters(inputNodeName);
 
   vtkMRMLStorageNode* snode = node->GetStorageNode();
   if (snode == nullptr)
@@ -737,45 +709,6 @@ void qSlicerSaveDataDialogPrivate
       snode->GetUserMessages()->ClearMessages();
       }
     }
-}
-
-//-----------------------------------------------------------------------------
-QString qSlicerSaveDataDialogPrivate::extractKnownExtension(const QString& fileName, vtkObject* object)
-{
-  qSlicerCoreIOManager* coreIOManager =
-    qSlicerCoreApplication::application()->coreIOManager();
-
-  foreach(const QString& nameFilter,
-          coreIOManager->fileWriterExtensions(object))
-    {
-    QString extension = QString::fromStdString(
-      vtkDataFileFormatHelper::GetFileExtensionFromFormatString(nameFilter.toUtf8()));
-    if (!extension.isEmpty() && fileName.endsWith(extension))
-      {
-      return extension;
-      }
-    }
-  return QString();
-}
-
-//-----------------------------------------------------------------------------
-QString qSlicerSaveDataDialogPrivate::stripKnownExtension(const QString& fileName, vtkObject* object)
-{
-  QString strippedFileName(fileName);
-
-  QString knownExtension = Self::extractKnownExtension(fileName, object);
-  if (!knownExtension.isEmpty())
-    {
-    strippedFileName.chop(knownExtension.length());
-    // check that the extension wasn't doubled by having the file name be
-    // constructed from a node name that included the extension
-    if (strippedFileName.endsWith(knownExtension))
-      {
-      return Self::stripKnownExtension(strippedFileName, object);
-      }
-    return strippedFileName;
-    }
-  return strippedFileName;
 }
 
 //-----------------------------------------------------------------------------
@@ -1402,7 +1335,7 @@ void qSlicerSaveDataDialogPrivate::onItemChanged(QTableWidgetItem* widgetItem)
   /// If it does not match any of the file extensions then the current file extension will
   /// be added (this way when the user just enters filename, the extension is added automatically).
   QTableWidgetItem* fileNameItem = this->FileWidget->item(widgetItem->row(), FileNameColumn);
-  QString strippedFileName = qSlicerFileNameItemDelegate::forceFileNameValidCharacters(fileNameItem->text());
+  QString strippedFileName = qSlicerCoreIOManager::forceFileNameValidCharacters(fileNameItem->text());
 
   // Determine current file extension
   vtkObject* objectToSave = mrmlScene;
@@ -1416,7 +1349,9 @@ void qSlicerSaveDataDialogPrivate::onItemChanged(QTableWidgetItem* widgetItem)
       return;
       }
     }
-  QString currentExtension = Self::extractKnownExtension(strippedFileName, objectToSave);
+  qSlicerCoreIOManager* coreIOManager =
+    qSlicerCoreApplication::application()->coreIOManager();
+  QString currentExtension = coreIOManager->extractKnownExtension(strippedFileName, objectToSave);
 
   // Update file format selector according to current extension
   QComboBox* fileFormatsWidget = qobject_cast<QComboBox*>(this->FileWidget->cellWidget(widgetItem->row(), FileFormatColumn));

--- a/Base/QTGUI/qSlicerSaveDataDialog_p.h
+++ b/Base/QTGUI/qSlicerSaveDataDialog_p.h
@@ -115,9 +115,6 @@ protected:
   ctkPathLineEdit*  createFileDirectoryWidget(const QFileInfo& fileInfo);
   void              clearUserMessagesInStorageNodes();
 
-  static QString extractKnownExtension(const QString& fileName, vtkObject* object);
-  static QString stripKnownExtension(const QString& fileName, vtkObject* object);
-
   QFileInfo         file(int row)const;
   vtkObject*        object(int row)const;
   QString           format(int row)const;
@@ -151,14 +148,6 @@ public:
   qSlicerFileNameItemDelegate( QObject * parent = nullptr );
   static QString forceFileNameExtension(const QString& fileName, const QString& extension,
                                vtkMRMLScene *mrmlScene, const QString &nodeID);
-  static QString forceFileNameValidCharacters(const QString& filename);
-
-  /// Generate a regular expression that can ensure a filename has a valid
-  /// extension.
-  /// Example of supported extensions:
-  /// "", "*", ".*", ".jpg", ".png" ".tar.gz"...
-  /// An empty extension or "*" means any filename (or directory) is valid
-  static QRegExp fileNameRegExp(const QString& extension = QString());
 
   vtkMRMLScene* MRMLScene;
 };

--- a/Libs/MRML/Core/vtkMRMLMeasurement.cxx
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.cxx
@@ -546,7 +546,7 @@ vtkMRMLUnitNode* vtkMRMLMeasurement::GetUnitNode(const char* quantityName)
     scene->GetNodeByID("vtkMRMLSelectionNodeSingleton"));
   if (!selectionNode)
     {
-    vtkWarningMacro("vtkMRMLMarkupsNode::GetUnitNode failed: selection node not found");
+    vtkWarningMacro("vtkMRMLMeasurement::GetUnitNode failed: selection node not found");
     return nullptr;
     }
   vtkMRMLUnitNode* unitNode = vtkMRMLUnitNode::SafeDownCast(scene->GetNodeByID(

--- a/Libs/MRML/Core/vtkMRMLStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.cxx
@@ -1313,15 +1313,23 @@ int vtkMRMLStorageNode::WriteData(vtkMRMLNode* refNode)
     return 0;
     }
 
-  int res = this->WriteDataInternal(refNode);
+  int success = this->WriteDataInternal(refNode);
 
-  if (res)
+  // If there were error messages, then do not return that we were successful
+  if (success
+      && this->GetUserMessages()
+      && this->GetUserMessages()->GetNumberOfMessagesOfType(vtkCommand::ErrorEvent)>0)
+    {
+    success = 0;
+    }
+
+  if (success)
     {
     this->StageWriteData(refNode);
     this->StoredTime->Modified();
     }
 
-  return res;
+  return success;
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLStorageNode.h
@@ -62,7 +62,8 @@ public:
   ///
   /// Write data from a  referenced node
   /// Return 1 on success, 0 on failure.
-  /// NOTE: Subclasses should implement this method
+  /// NOTE: Subclasses should implement WriteDataInternal(), not this method.
+  /// \sa WriteDataInternal()
   virtual int WriteData(vtkMRMLNode *refNode);
 
   ///

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -818,7 +818,7 @@ std::string vtkMRMLVolumeArchetypeStorageNode::UpdateFileList(vtkMRMLNode *refNo
   if (!vtksys::SystemTools::MakeDirectory(tempDir.c_str()))
     {
     vtkErrorToMessageCollectionMacro(this->GetUserMessages(), "vtkMRMLVolumeArchetypeStorageNode::UpdateFileList",
-      "Failed to create directory" << tempDir);
+      "Failed to create directory " << tempDir);
     return "";
     }
   // make a new name,

--- a/Modules/Loadable/Data/qSlicerDataModule.cxx
+++ b/Modules/Loadable/Data/qSlicerDataModule.cxx
@@ -30,6 +30,7 @@
 #include "qSlicerDataModule.h"
 #include "qSlicerDataModuleWidget.h"
 #include "qSlicerSaveDataDialog.h"
+#include "qSlicerExportNodeDialog.h"
 #include "qSlicerSceneBundleReader.h"
 #include "qSlicerSceneReader.h"
 #include "qSlicerSceneWriter.h"
@@ -111,6 +112,7 @@ void qSlicerDataModule::setup()
   // Dialogs
   ioManager->registerDialog(new qSlicerDataDialog(this));
   ioManager->registerDialog(new qSlicerSaveDataDialog(this));
+  ioManager->registerDialog(new qSlicerExportNodeDialog(this));
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
@@ -45,10 +45,9 @@
 class qSlicerSegmentationsNodeWriterPrivate
 {
 public:
-  QString Description;
+  QString Description; // These member variables don't get used anywhere.
   qSlicerIO::IOFileType FileType;
   QStringList NodeClassNames;
-  bool SupportUseCompression;
 };
 
 //----------------------------------------------------------------------------
@@ -90,6 +89,6 @@ qSlicerIOOptions* qSlicerSegmentationsNodeWriter::options() const
 {
   Q_D(const qSlicerSegmentationsNodeWriter);
   qSlicerSegmentationsNodeWriterOptionsWidget* options = new qSlicerSegmentationsNodeWriterOptionsWidget;
-  options->setShowUseCompression(d->SupportUseCompression);
+  options->setShowUseCompression(this->supportUseCompression());
   return options;
 }

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
@@ -41,21 +41,10 @@
 #include <vtkStdString.h>
 #include <vtkStringArray.h>
 
-//-----------------------------------------------------------------------------
-class qSlicerSegmentationsNodeWriterPrivate
-{
-public:
-  QString Description; // These member variables don't get used anywhere.
-  qSlicerIO::IOFileType FileType;
-  QStringList NodeClassNames;
-};
-
 //----------------------------------------------------------------------------
 qSlicerSegmentationsNodeWriter::qSlicerSegmentationsNodeWriter(QObject* parentObject)
   : qSlicerNodeWriter("Segmentation", QString("SegmentationFile"), QStringList() << "vtkMRMLSegmentationNode", true, parentObject)
-  , d_ptr(new qSlicerSegmentationsNodeWriterPrivate)
 {
-  Q_D(qSlicerSegmentationsNodeWriter);
 }
 
 //----------------------------------------------------------------------------
@@ -87,7 +76,6 @@ bool qSlicerSegmentationsNodeWriter::write(const qSlicerIO::IOProperties& proper
 //-----------------------------------------------------------------------------
 qSlicerIOOptions* qSlicerSegmentationsNodeWriter::options() const
 {
-  Q_D(const qSlicerSegmentationsNodeWriter);
   qSlicerSegmentationsNodeWriterOptionsWidget* options = new qSlicerSegmentationsNodeWriterOptionsWidget;
   options->setShowUseCompression(this->supportUseCompression());
   return options;

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.h
@@ -38,7 +38,7 @@ public:
   qSlicerSegmentationsNodeWriter(QObject* parent);
   ~qSlicerSegmentationsNodeWriter() override;
 
-  /// Return a qSlicerIOSegmentationNodeWriterOptionsWidget
+  /// Return a new qSlicerSegmentationsNodeWriterOptionsWidget
   qSlicerIOOptions* options()const override;
 
   /// Write the node referenced by "nodeID" into the "fileName" file.

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.h
@@ -25,7 +25,6 @@
 #include "qSlicerSegmentationsModuleExport.h"
 #include "qSlicerNodeWriter.h"
 
-class qSlicerSegmentationsNodeWriterPrivate;
 class vtkMRMLNode;
 
 /// Utility class that is ready to use for most of the nodes.
@@ -47,11 +46,7 @@ public:
   /// Create a storage node if the storable node doesn't have any.
   bool write(const qSlicerIO::IOProperties& properties) override;
 
-protected:
-  QScopedPointer<qSlicerSegmentationsNodeWriterPrivate> d_ptr;
-
 private:
-  Q_DECLARE_PRIVATE(qSlicerSegmentationsNodeWriter);
   Q_DISABLE_COPY(qSlicerSegmentationsNodeWriter);
 };
 

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriterOptionsWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriterOptionsWidget.cxx
@@ -34,21 +34,21 @@ class qSlicerSegmentationsNodeWriterOptionsWidgetPrivate
 {
 public:
   void setupUi(QWidget* widget) override;
-  QCheckBox* UseReferenceGeometryCheckBox;
+  QCheckBox* CropToMinimumExtentCheckbox;
 };
 
 //------------------------------------------------------------------------------
 void qSlicerSegmentationsNodeWriterOptionsWidgetPrivate::setupUi(QWidget* widget)
 {
   this->qSlicerNodeWriterOptionsWidgetPrivate::setupUi(widget);
-  this->UseReferenceGeometryCheckBox = new QCheckBox(widget);
-  this->UseReferenceGeometryCheckBox->setObjectName(QStringLiteral("CropToMinimumExtentCheckBox"));
-  this->UseReferenceGeometryCheckBox->setText("Crop to minimum extent");
-  this->UseReferenceGeometryCheckBox->setToolTip("If enabled then segmentation labelmap representation is"
+  this->CropToMinimumExtentCheckbox = new QCheckBox(widget);
+  this->CropToMinimumExtentCheckbox->setObjectName(QStringLiteral("CropToMinimumExtentCheckBox"));
+  this->CropToMinimumExtentCheckbox->setText("Crop to minimum extent");
+  this->CropToMinimumExtentCheckbox->setToolTip("If enabled then segmentation labelmap representation is"
     " cropped to the minimum necessary size. This saves storage space but changes voxel coordinate system"
     " (physical coordinate system is not affected).");
-  horizontalLayout->addWidget(UseReferenceGeometryCheckBox);
-  QObject::connect(this->UseReferenceGeometryCheckBox, SIGNAL(toggled(bool)),
+  horizontalLayout->addWidget(CropToMinimumExtentCheckbox);
+  QObject::connect(this->CropToMinimumExtentCheckbox, SIGNAL(toggled(bool)),
     widget, SLOT(setCropToMinimumExtent(bool)));
 }
 
@@ -74,7 +74,7 @@ void qSlicerSegmentationsNodeWriterOptionsWidget::setObject(vtkObject* object)
       storableNode->GetStorageNode());
     if (storageNode)
       {
-      d->UseReferenceGeometryCheckBox->setChecked(storageNode->GetCropToMinimumExtent());
+      d->CropToMinimumExtentCheckbox->setChecked(storageNode->GetCropToMinimumExtent());
       }
     }
   Superclass::setObject(object);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
@@ -47,6 +47,8 @@ set(${KIT}_SRCS
   qSlicerSubjectHierarchyViewContextMenuPlugin.h
   qSlicerSubjectHierarchyVisibilityPlugin.cxx
   qSlicerSubjectHierarchyVisibilityPlugin.h
+  qSlicerSubjectHierarchyExportPlugin.cxx
+  qSlicerSubjectHierarchyExportPlugin.h
   )
 if(Slicer_USE_PYTHONQT)
   list(APPEND ${KIT}_SRCS
@@ -71,6 +73,7 @@ set(${KIT}_MOC_SRCS
   qMRMLSubjectHierarchyComboBox.h
   qMRMLSubjectHierarchyModel.h
   qMRMLSortFilterSubjectHierarchyProxyModel.h
+  qSlicerSubjectHierarchyExportPlugin.h
   )
 if(Slicer_USE_PYTHONQT)
   list(APPEND ${KIT}_MOC_SRCS

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExportPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExportPlugin.cxx
@@ -1,0 +1,183 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+
+==============================================================================*/
+
+// SubjectHierarchy Plugins includes
+#include "qSlicerSubjectHierarchyPluginHandler.h"
+#include "qSlicerSubjectHierarchyExportPlugin.h"
+
+// SubjectHierarchy logic includes
+#include "vtkSlicerSubjectHierarchyModuleLogic.h"
+
+// Slicer includes
+#include "qSlicerApplication.h"
+#include "qSlicerIOManager.h"
+#include "vtkSlicerApplicationLogic.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+
+// Qt includes
+#include <QDebug>
+#include <QStandardItem>
+#include <QAction>
+
+// MRML includes
+#include <vtkMRMLStorableNode.h>
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
+class qSlicerSubjectHierarchyExportPluginPrivate: public QObject
+{
+  Q_DECLARE_PUBLIC(qSlicerSubjectHierarchyExportPlugin);
+protected:
+  qSlicerSubjectHierarchyExportPlugin* const q_ptr;
+public:
+  qSlicerSubjectHierarchyExportPluginPrivate(qSlicerSubjectHierarchyExportPlugin& object);
+  ~qSlicerSubjectHierarchyExportPluginPrivate() override;
+  void init();
+public:
+  QAction* ExportItemAction;
+};
+
+//-----------------------------------------------------------------------------
+// qSlicerSubjectHierarchyExportPluginPrivate methods
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyExportPluginPrivate::qSlicerSubjectHierarchyExportPluginPrivate(qSlicerSubjectHierarchyExportPlugin& object)
+: q_ptr(&object)
+{
+  this->ExportItemAction = nullptr;
+}
+
+//------------------------------------------------------------------------------
+void qSlicerSubjectHierarchyExportPluginPrivate::init()
+{
+  Q_Q(qSlicerSubjectHierarchyExportPlugin);
+
+  this->ExportItemAction = new QAction("Export to file...",q);
+  this->ExportItemAction->setToolTip("Export this node to a file");
+  // Put towards end of the list, where export features typically would go
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ExportItemAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 3);
+  QObject::connect(this->ExportItemAction, SIGNAL(triggered()), q, SLOT(exportCurrentItem()));
+}
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyExportPluginPrivate::~qSlicerSubjectHierarchyExportPluginPrivate() = default;
+
+//-----------------------------------------------------------------------------
+// qSlicerSubjectHierarchyExportPlugin methods
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyExportPlugin::qSlicerSubjectHierarchyExportPlugin(QObject* parent)
+ : Superclass(parent)
+ , d_ptr( new qSlicerSubjectHierarchyExportPluginPrivate(*this) )
+{
+  this->m_Name = QString("Export");
+
+  Q_D(qSlicerSubjectHierarchyExportPlugin);
+  d->init();
+}
+
+//-----------------------------------------------------------------------------
+qSlicerSubjectHierarchyExportPlugin::~qSlicerSubjectHierarchyExportPlugin() = default;
+
+//---------------------------------------------------------------------------
+QList<QAction*> qSlicerSubjectHierarchyExportPlugin::itemContextMenuActions()const
+{
+  Q_D(const qSlicerSubjectHierarchyExportPlugin);
+
+  QList<QAction*> actions;
+  actions << d->ExportItemAction;
+  return actions;
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyExportPlugin::showContextMenuActionsForItem(vtkIdType itemID)
+{
+  Q_D(qSlicerSubjectHierarchyExportPlugin);
+
+  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
+  if (!shNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
+    return;
+    }
+
+  if (!itemID || itemID == shNode->GetSceneItemID())
+    {
+    return; // no export for scene node
+    }
+
+  vtkIdType parentItemID = shNode->GetItemParent(itemID);
+  if (parentItemID && shNode->IsItemVirtualBranchParent(parentItemID))
+    {
+    return; // no export for virtual branch items
+    }
+
+  vtkMRMLNode* node = shNode->GetItemDataNode(itemID);
+  vtkMRMLStorableNode* storableNode = vtkMRMLStorableNode::SafeDownCast(node);
+
+  if (!storableNode)
+    {
+    return; // only export storable nodes
+    }
+
+
+  d->ExportItemAction->setVisible(true);
+
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyExportPlugin::exportCurrentItem()
+{
+  // Get currently selected node and scene
+  vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
+  if (!shNode)
+    {
+    qCritical() << Q_FUNC_INFO << ": Failed to access subject hierarchy node";
+    return;
+    }
+  vtkIdType currentItemID = qSlicerSubjectHierarchyPluginHandler::instance()->currentItem();
+  if (!currentItemID)
+    {
+    qCritical() << Q_FUNC_INFO << ": Invalid current subject hierarchy item!";
+    return;
+    }
+
+  vtkMRMLNode* node = shNode->GetItemDataNode(currentItemID);
+  if (!node)
+    {
+    qCritical() << Q_FUNC_INFO << ": No node associated to current subject hierarchy item ID!";
+    return;
+    }
+
+  qSlicerIO::IOProperties properties{};
+  properties["nodeID"] = QString(node->GetID());
+
+  qSlicerApplication::application()->ioManager()->openDialog(
+    QString("GenericNodeExport"),
+    qSlicerFileDialog::Write,
+    properties
+  );
+
+}

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExportPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExportPlugin.h
@@ -1,0 +1,65 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Csaba Pinter, PerkLab, Queen's University
+  and was supported through the Applied Cancer Research Unit program of Cancer Care
+  Ontario with funds provided by the Ontario Ministry of Health and Long-Term Care
+
+==============================================================================*/
+
+#ifndef __qSlicerSubjectHierarchyExportPlugin_h
+#define __qSlicerSubjectHierarchyExportPlugin_h
+
+// SubjectHierarchy Plugins includes
+#include "qSlicerSubjectHierarchyAbstractPlugin.h"
+
+#include "qSlicerSubjectHierarchyModuleWidgetsExport.h"
+
+class qSlicerSubjectHierarchyExportPluginPrivate;
+
+/// \ingroup Slicer_QtModules_SubjectHierarchy_Widgets
+class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qSlicerSubjectHierarchyExportPlugin : public qSlicerSubjectHierarchyAbstractPlugin
+{
+public:
+  Q_OBJECT
+
+public:
+  typedef qSlicerSubjectHierarchyAbstractPlugin Superclass;
+  qSlicerSubjectHierarchyExportPlugin(QObject* parent = nullptr);
+  ~qSlicerSubjectHierarchyExportPlugin() override;
+
+
+public:
+  /// Get item context menu item actions to add to tree view
+  QList<QAction*> itemContextMenuActions()const override;
+
+  /// Show context menu actions valid for  given subject hierarchy node.
+  /// \param node Subject Hierarchy node to show the context menu items for. If nullptr, then shows menu items for the scene
+  void showContextMenuActionsForItem(vtkIdType itemID) override;
+
+protected slots:
+  /// Export currently selected subject hierarchy item
+  void exportCurrentItem();
+
+protected:
+  QScopedPointer<qSlicerSubjectHierarchyExportPluginPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qSlicerSubjectHierarchyExportPlugin);
+  Q_DISABLE_COPY(qSlicerSubjectHierarchyExportPlugin);
+};
+
+#endif

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -36,6 +36,7 @@
 #include "qSlicerSubjectHierarchyOpacityPlugin.h"
 #include "qSlicerSubjectHierarchyViewContextMenuPlugin.h"
 #include "qSlicerSubjectHierarchyVisibilityPlugin.h"
+#include "qSlicerSubjectHierarchyExportPlugin.h"
 
 // MRML includes
 #include "vtkMRMLAbstractViewNode.h"
@@ -146,6 +147,8 @@ void qSlicerSubjectHierarchyPluginLogic::registerCorePlugins()
     new qSlicerSubjectHierarchyOpacityPlugin());
   qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(
     new qSlicerSubjectHierarchyVisibilityPlugin());
+  qSlicerSubjectHierarchyPluginHandler::instance()->registerPlugin(
+    new qSlicerSubjectHierarchyExportPlugin());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This is my second go at addressing #4989. Related links:
- [first try](https://github.com/Slicer/Slicer/pull/5805)
- [my comment](https://github.com/Slicer/Slicer/issues/4989#issuecomment-904779802) that followed discussion about the first PR
- [related SlicerMorph issue](https://github.com/SlicerMorph/SlicerMorph/issues/72)

This time the export module is a loadable module written in C++, and it gets its own `qSlicerFileDialog` that is opened via `qSlicerApplication::application()->ioManager()->openDialog`.

@lassoan @pieper @cpinter @smrolfe  @sjh26  

# Demo

Right click on an item in the subject hierarchy view, and there will be an "Export" action available if it is a storable node. This brings up a simple export dialog.

![sc1](https://user-images.githubusercontent.com/1879759/133942768-61e70efa-a35e-4c7d-8950-0b679f209ffc.png)

![sc2](https://user-images.githubusercontent.com/1879759/133942770-8e7a9ba0-9a95-4264-8740-67f1d72bcd64.png)




# Commits

I will squash all "WIP" commits into one "ENH" commit if this becomes ready to be merged. The non-WIP commits were minor unrelated things that I'll keep as separate commits.

# Choices made

*Reporting various errors while saving:* Where the save dialog has error/warning icons with tooltips containing error messages, I went with `QMessageBox`s to display error messages. I think it makes sense here, since it's just one node that the errors can be for, and since users would probably expect a message box in the failure case for a single task. The error messages are sometimes not pretty, because they are often just a dump of what is in `storageNode->GetUserMessages()`. But they get the job done.

![sc3](https://user-images.githubusercontent.com/1879759/133942771-8ccb3c8d-4294-43cd-9866-07999106f0fb.png)

# Remaining problems, missing features

There are some things I am leaving to be addressed while this PR is looked at, or afterwards in a different PR.

1. ~~Last used export settings (file format, options, and directory) for a given node type should be remembered during the session. This shouldn't be difficult to do.~~ **Update: This is done.**
2. Selecting multiple nodes of the same type, or a folder with child nodes all the same time, should provide the export action. This is a big feature that would be in a separate PR. **Update: The non-GUI part of this is actually done, so implementing it later will not be an API change.**
3. ~~From [here](https://github.com/SlicerMorph/SlicerMorph/issues/72) I'm not sure how to allow the user to specify a coordinate system. My first thought is that a checkbox+tooltip should be added to `qSlicerNodeWriterOptionsWidget` and made visible for certain nodes, but I would definitely need help with making it do the right thing. We can look into this later.~~
    **Update: This is done. There's now a checkbox for transform hardening.**
4. Is there some way in which exporting needs to be linked up to the python side of things in order to be extensible by scripting? I don't know much about this!
5. Some formats are shown that don't make sense, e.g. ".bmp" as an export format for 3D volumes. The problem here comes from the list of extensions provided by [this](https://github.com/Slicer/Slicer/blob/bcaab0a249d444d55aa6fc808bd43837cd8f5db7/Base/QTCore/qSlicerCoreIOManager.h#L72), and it's a problem that is shared with the scene save dialog. Should be looked at in a different PR, or opened as an issue on its own.
6. I'm not sure that the compress option should really be shown as often as it is. For a format like `.nrrd`, the compress option clearly does something. However with `.nii` and `.nii.gz` I would think that whether or not there is compression is built into the choice of file type. If that's the case then a compress option shouldn't be displayed for these, but I don't really know how it works.
7. ~~You might see the visibility of the "compress" checkbox for segmentation exports randomly fluctuate from time to time. It happened in the main save dialog too. This is due to an uninitialized variable bug [here](https://github.com/Slicer/Slicer/blob/bcaab0a249d444d55aa6fc808bd43837cd8f5db7/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx#L51). Should be an easy fix, and I can include it in this PR if that seems fine.~~ **Update: This is done in 565ba958bdba265de78314c888aa865de3d00025.**
8. ~~*Typing a filename and hitting enter sometimes has unintuitive behavior.* When I type a filename into an export dialog and hit *enter*, then if the dialog closes what I expect is that the file was saved with the exact name that I typed in. Currently that's not always the case, and I think it's not acceptable for it to remain this way. For example, if I type "MRHead.NRRD" and hit enter, it will save as "MRHead.nrrd". If I type "MRHead.nrr" while the "(.nrrd)" option is selected in the format dropdown menu, then hitting enter will save the file as "MRHead.nrr.nrrd". This is just imitating the filename editing behavior in the main save dialog, but it was okay in the main save dialog because hitting *enter* while editing a filename just finalized the edit in the `QTableWidget` cell. I'm facing a conflict here between following the way the main save dialog handles things (for the sake of consistent behavior across the application) and avoiding unintuitive/intrusive behaviors. To clarify: if the user clicks out of the filename editing box, then they will see the filename being corrected. The problem here is that they can hit *enter* without ever clicking out of the box. Ideas:~~
	- ~~Don't change the user-given filename, and let them get away with anything (besides characters that are not legal in filenames). If they want to export to a nifti file and call it "MRHead.bmp," then they can do that.~~
	- ~~Don't change the user-given filename, but if they try to export to a nifti file named "MRHead.bmp", then they get a prompt offering to set a better name, which they can answer "yes/no/cancel".~~
	**Update: This is handled now, via the latter idea.** 
9. Somewhat related to above, and this is a problem with the main save dialog too: It's a little weird that we display differently-cased extensions as separate items in the format list (e.g. ".png" and ".PNG" are separate entries), but we only accept an extension when the user types it in lowercase (e.g. trying to use "MRHead.PNG" as a filename can result in something like "MRHead.PNG.png"). It should really be the other way around: only display lowercase in the format dropdown menu, but accept any case the user chooses to type in. Maybe this should be a separate PR/issue.