### PR TITLE
ENH: Add a property to disable Record and Snapshot button

### DIFF
--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
@@ -37,6 +37,7 @@ protected:
   qMRMLSequenceBrowserPlayWidget* const q_ptr;
 public:
   qMRMLSequenceBrowserPlayWidgetPrivate(qMRMLSequenceBrowserPlayWidget& object);
+  bool RecordingControlsVisible;
   void init();
 
   vtkWeakPointer<vtkMRMLSequenceBrowserNode> SequenceBrowserNode;
@@ -147,9 +148,10 @@ void qMRMLSequenceBrowserPlayWidget::updateWidgetFromMRML()
   bool recordingAllowed = d->SequenceBrowserNode->IsAnySequenceNodeRecording();
   bool playbackActive = d->SequenceBrowserNode->GetPlaybackActive();
   bool recordingActive = d->SequenceBrowserNode->GetRecordingActive();
-  d->pushButton_VcrRecord->setVisible(recordingAllowed);
+
+  d->pushButton_VcrRecord->setVisible(recordingAllowed && this->RecordingControlsVisible);
   d->pushButton_VcrRecord->setEnabled(!playbackActive);
-  d->pushButton_Snapshot->setVisible(recordingAllowed);
+  d->pushButton_Snapshot->setVisible(recordingAllowed && this->RecordingControlsVisible);
   d->pushButton_Snapshot->setEnabled(!playbackActive && !recordingActive);
 
   foreach( QObject*w, vcrPlaybackControls ) { w->setProperty( "enabled", vcrControlsEnabled ); }
@@ -324,3 +326,19 @@ void qMRMLSequenceBrowserPlayWidget::setNextFrameShortcut(QString keySequence)
   QObject::connect(new QShortcut(QKeySequence(keySequence), this), SIGNAL(activated()), SLOT(onVcrNext()));
   d->pushButton_VcrNext->setToolTip(d->pushButton_VcrNext->toolTip() + " (" + keySequence + ")");
 }
+
+//---------------------------------------------------------------------------
+void qMRMLSequenceBrowserPlayWidget::setRecordingControlsVisible(bool show)
+{
+  Q_D(qMRMLSequenceBrowserPlayWidget);
+  d->RecordingControlsVisible = show;
+  this->updateWidgetFromMRML();
+}
+
+//---------------------------------------------------------------------------
+bool qMRMLSequenceBrowserPlayWidget::recordingControlsVisible() const
+{
+  Q_D(const qMRMLSequenceBrowserPlayWidget);
+  return d->RecordingControlsVisible;
+}
+

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.h
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.h
@@ -44,6 +44,10 @@ class Q_SLICER_MODULE_SEQUENCES_WIDGETS_EXPORT qMRMLSequenceBrowserPlayWidget
   Q_OBJECT
   QVTK_OBJECT
 
+  /// Enable or disable recording control buttons when recording
+  Q_PROPERTY(bool RecordingControlsVisible READ recordingControlsVisible WRITE setRecordingControlsVisible)
+
+
 public:
   typedef qMRMLWidget Superclass;
   qMRMLSequenceBrowserPlayWidget(QWidget *newParent = 0);
@@ -58,6 +62,9 @@ public:
   /// Add a keyboard shortcut for next frame button
   void setNextFrameShortcut(QString keySequence);
 
+  /// Get RecordingControlsVisible value
+  bool recordingControlsVisible() const;
+
 public slots:
   void setMRMLSequenceBrowserNode(vtkMRMLSequenceBrowserNode* browserNode);
   void setMRMLSequenceBrowserNode(vtkMRMLNode* browserNode);
@@ -65,6 +72,7 @@ public slots:
   void setRecordingEnabled(bool play);
   void setPlaybackRateFps(double playbackRateFps);
   void setPlaybackLoopEnabled(bool loopEnabled);
+  void setRecordingControlsVisible(bool show);
   void onVcrFirst();
   void onVcrPrevious();
   void onVcrNext();

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.h
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.h
@@ -44,7 +44,9 @@ class Q_SLICER_MODULE_SEQUENCES_WIDGETS_EXPORT qMRMLSequenceBrowserPlayWidget
   Q_OBJECT
   QVTK_OBJECT
 
-  /// Enable or disable recording control buttons when recording
+  /// Enable displaying recording control buttons (record and snapshot).
+  /// The buttons are only visible if this flag is enabled and there is at least one sequence that
+  /// has recording enabled.
   Q_PROPERTY(bool RecordingControlsVisible READ recordingControlsVisible WRITE setRecordingControlsVisible)
 
 


### PR DESCRIPTION
Implement this [discussion](https://discourse.slicer.org/t/disable-snapshot-and-record-push-buttons-in-sequencebrowserplaywidget-while-recordning/19711/7)
