### PR TITLE
PERF: Update VTK with backported fix improving renderer and viewport perf

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -177,7 +177,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "a271aa906716c9e752d2e59a8ae9e1c2268da1b6") # slicer-v9.0.20201111-733234c785
+    set(_git_tag "f457af0f84259518413b265e81a992c0adbf6582") # slicer-v9.0.20201111-733234c785
     set(vtk_egg_info_version "9.0.20201111")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
* [Backport 8371] Fix expansion of stl template args in wrapping

See #5752 (Improve markups rendering performance)

Co-authored-by: Connor Bowley <connor.bowley@kitware.com>