### PR TITLE
BUG: Do not hide SH combobox popup when selected item is modified

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -108,6 +108,8 @@ void qMRMLSubjectHierarchyComboBoxPrivate::init()
   // Make connections
   QObject::connect(this->TreeView, SIGNAL(currentItemChanged(vtkIdType)),
                    q, SLOT(updateComboBoxTitleAndIcon(vtkIdType)));
+  QObject::connect(this->TreeView, SIGNAL(currentItemChanged(vtkIdType)),
+                   q, SLOT(hidePopup()));
   QObject::connect(this->TreeView, SIGNAL(currentItemModified(vtkIdType)),
                    q, SLOT(updateComboBoxTitleAndIcon(vtkIdType)));
   QObject::connect(this->TreeView, SIGNAL(currentItemChanged(vtkIdType)),
@@ -658,6 +660,17 @@ void qMRMLSubjectHierarchyComboBox::showPopup()
   container->update();
 }
 
+//-----------------------------------------------------------------------------
+void qMRMLSubjectHierarchyComboBox::hidePopup()
+{
+  // Hide popup
+  QFrame* container = qobject_cast<QFrame*>(this->view()->parentWidget());
+  if (container)
+    {
+    container->hide();
+    }
+}
+
 //------------------------------------------------------------------------------
 void qMRMLSubjectHierarchyComboBox::mousePressEvent(QMouseEvent* e)
 {
@@ -675,13 +688,6 @@ void qMRMLSubjectHierarchyComboBox::mousePressEvent(QMouseEvent* e)
 void qMRMLSubjectHierarchyComboBox::updateComboBoxTitleAndIcon(vtkIdType selectedShItemID)
 {
   Q_D(qMRMLSubjectHierarchyComboBox);
-
-  // Hide popup
-  QFrame* container = qobject_cast<QFrame*>(this->view()->parentWidget());
-  if (container)
-    {
-    container->hide();
-    }
 
   vtkMRMLSubjectHierarchyNode* shNode = d->TreeView->subjectHierarchyNode();
   if (!shNode)

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.h
@@ -214,6 +214,8 @@ signals:
 protected slots:
   void updateComboBoxTitleAndIcon(vtkIdType selectedShItemID);
 
+  void hidePopup();
+
 protected:
   /// Handle mouse press event (disable context menu)
   void mousePressEvent(QMouseEvent* event) override;


### PR DESCRIPTION
The popup was hidden both when selection was changed and when selected item was modified. Now it is not hidden when the item is modified, because it prevented selection when streaming data into Slicer. In that case if the proxy node was selected and it was modified because of the new data item appearing in the corresponding sequence, the popup was collapsed, and if the stream was fast, it could disappear in a fraction of a second.