### PR TITLE
ENH: Add object name to center button in 3D view header

### DIFF
--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -274,6 +274,7 @@ void qMRMLThreeDViewControllerWidgetPrivate::init()
   this->CenterToolButton->setAutoRaise(true);
   this->CenterToolButton->setDefaultAction(this->actionCenter);
   this->CenterToolButton->setFixedSize(15, 15);
+  this->CenterToolButton->setObjectName("CenterButton_Header");
   this->BarLayout->insertWidget(2, this->CenterToolButton);
 
   this->ViewLabel->setText(qMRMLThreeDViewControllerWidget::tr("1"));


### PR DESCRIPTION
An object name facilitates unambiguous access for the widget.

The name "CenterButton_Header" was chosen in order to differ from the "CenterButton" in the popup of the same toolbar.