### PR TITLE
BUG: Corrects fixed point number property on loading markups

### DIFF
--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -145,8 +145,8 @@ void qSlicerMouseModeToolBarPrivate::init()
   // Place mode
   this->ToolBarAction = new QAction(this);
   this->ToolBarAction->setObjectName("ToolBarAction");
-  this->ToolBarAction->setToolTip(qSlicerMouseModeToolBar::tr("Display Markups Toolbar"));
-  this->ToolBarAction->setText(qSlicerMouseModeToolBar::tr("Display Markups Toolbar"));
+  this->ToolBarAction->setToolTip(qSlicerMouseModeToolBar::tr("Toggle Markups Toolbar"));
+  this->ToolBarAction->setText(qSlicerMouseModeToolBar::tr("Toggle Markups Toolbar"));
   this->ToolBarAction->setEnabled(true);
   this->ToolBarAction->setIcon(QIcon(":/Icons/MarkupsDisplayToolBar.png"));
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -607,11 +607,6 @@ bool vtkMRMLMarkupsJsonStorageNode::vtkInternal::UpdateMarkupsNodeFromJsonValue(
     markupsNode->SetLocked(markupObject["locked"].GetBool());
     }
 
-  if (markupObject.HasMember("fixedNumberOfControlPoints"))
-    {
-    markupsNode->SetFixedNumberOfControlPoints(markupObject["fixedPointNumber"].GetBool());
-    }
-
   if (markupObject.HasMember("labelFormat"))
     {
     markupsNode->SetMarkupLabelFormat(markupObject["labelFormat"].GetString());
@@ -637,6 +632,11 @@ bool vtkMRMLMarkupsJsonStorageNode::vtkInternal::UpdateMarkupsNodeFromJsonValue(
         "Markups reading failed: invalid measurements item.");
       return  false;
       }
+    }
+
+  if (markupObject.HasMember("fixedPointNumber"))
+    {
+    markupsNode->SetFixedNumberOfControlPoints(markupObject["fixedPointNumber"].GetBool());
     }
 
   return true;

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerMarkupsPlaceWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerMarkupsPlaceWidget.ui
@@ -26,7 +26,7 @@
    <item>
     <widget class="ctkColorPickerButton" name="ColorButton">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -90,6 +90,7 @@ void qMRMLMarkupsToolBarPrivate::init()
   this->MarkupsNodeSelector->setEditEnabled(true);
   this->MarkupsNodeSelector->setMaximumWidth(150);
   this->MarkupsNodeSelector->setEnabled(true);
+  this->MarkupsNodeSelector->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
 
   connect(this->MarkupsNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)), q, SIGNAL(activeMarkupsNodeChanged(vtkMRMLNode*)) );
   connect(this->MarkupsNodeSelector, SIGNAL(nodeActivated(vtkMRMLNode*)), q, SLOT(onMarkupsNodeChanged(vtkMRMLNode*)));


### PR DESCRIPTION
This commit fixes a bug causing the fixed point number property to not be read while loading a markup node from file. This bug is documented in issue #5889