### PR TITLE
Fix python install rules ensuring "excluded" files are not packaged and exclude `/tests/`

### DIFF
--- a/CMake/SlicerBlockInstallPython.cmake
+++ b/CMake/SlicerBlockInstallPython.cmake
@@ -42,6 +42,7 @@ To create a Slicer package including python libraries, you can *NOT* provide you
     REGEX "lib[-]old/" EXCLUDE
     REGEX "plat[-].*" EXCLUDE
     REGEX "/test/" EXCLUDE
+    REGEX "/tests/" EXCLUDE
     ${extra_exclude_pattern}
     )
   # Strip symbols of selected libraries for which ones (1) stripping has a

--- a/CMake/SlicerFunctionInstallLibrary.cmake
+++ b/CMake/SlicerFunctionInstallLibrary.cmake
@@ -94,7 +94,8 @@ function(slicerInstallLibrary)
       DESTINATION ${_slicerInstallLibrary_DESTINATION} COMPONENT ${_slicerInstallLibrary_COMPONENT}
       FILES_MATCHING PATTERN "${lib_name}*" ${install_permissions}
       PATTERN "${lib_name}*.a" EXCLUDE
-      PATTERN "${lib_name}*.debug" EXCLUDE)
+      PATTERN "${lib_name}*.debug" EXCLUDE
+      REGEX "${lib_dir}/.+/" EXCLUDE)
 
     if(_slicerInstallLibrary_STRIP)
       slicerStripInstalledLibrary(


### PR DESCRIPTION
This commits make sure directories like these ones are not packaged:

```
  ./lib/python3.6/test/
  ./lib/python3.6/site-packages/scipy/io/tests/
  ./lib/python3.6/site-packages/scipy/signal/tests/
  ./lib/python3.6/site-packages/numpy/linalg/tests/
  ./lib/python3.6/site-packages/numpy/random/tests/
```