### PR TITLE
COMP: Fix qMRMLSequenceBrowserPlayWidget build error

### DIFF
--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
@@ -149,9 +149,9 @@ void qMRMLSequenceBrowserPlayWidget::updateWidgetFromMRML()
   bool playbackActive = d->SequenceBrowserNode->GetPlaybackActive();
   bool recordingActive = d->SequenceBrowserNode->GetRecordingActive();
 
-  d->pushButton_VcrRecord->setVisible(recordingAllowed && this->RecordingControlsVisible);
+  d->pushButton_VcrRecord->setVisible(recordingAllowed && d->RecordingControlsVisible);
   d->pushButton_VcrRecord->setEnabled(!playbackActive);
-  d->pushButton_Snapshot->setVisible(recordingAllowed && this->RecordingControlsVisible);
+  d->pushButton_Snapshot->setVisible(recordingAllowed && d->RecordingControlsVisible);
   d->pushButton_Snapshot->setEnabled(!playbackActive && !recordingActive);
 
   foreach( QObject*w, vcrPlaybackControls ) { w->setProperty( "enabled", vcrControlsEnabled ); }


### PR DESCRIPTION
This commit fixes a regression introduced in 85e6328aa0 (ENH: Add a property
to hide Record and Snapshot buttons in qMRMLSequenceBrowserPlayWidget)

See #5878