### PR TITLE
Markups Toolbar build error and Annotations place fixes

### DIFF
--- a/Modules/Loadable/Annotations/Resources/UI/qSlicerAnnotationModuleWidget.ui
+++ b/Modules/Loadable/Annotations/Resources/UI/qSlicerAnnotationModuleWidget.ui
@@ -48,7 +48,7 @@
              <string>Create-and-place</string>
            </property>
            <layout class="QGridLayout" name="createLayout">
-             <item row="0" column="1" >
+             <item row="0" column="0" >
                <widget class="QLabel" name="createNodeLabel">
                  <property name="toolTip">
                    <string>Select node types to create and place annotations.</string>
@@ -58,7 +58,7 @@
                  </property>
                </widget>
              </item>
-             <item row="0" column="3" colspan="2">
+             <item row="0" column="1">
                <widget class="QPushButton" name="createLineButton">
                  <property name="sizePolicy">
                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -91,7 +91,7 @@
                  </property>
                </widget>
              </item>
-             <item row="0" column="5" colspan="2">
+             <item row="0" column="2">
                <widget class="QPushButton" name="createROIButton">
                  <property name="sizePolicy">
                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -122,6 +122,19 @@
                    </iconset>
                  </property>
                </widget>
+             </item>
+             <item row="0" column="3">
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
            </layout>
          </widget>

--- a/Modules/Loadable/Annotations/Resources/UI/qSlicerAnnotationModuleWidget.ui
+++ b/Modules/Loadable/Annotations/Resources/UI/qSlicerAnnotationModuleWidget.ui
@@ -79,7 +79,7 @@
                    </size>
                  </property>
                  <property name="toolTip">
-                   <string>Create-and-place a line annotation node.</string>
+                   <string>Create-and-place an annotation ruler node.</string>
                  </property>
                  <property name="text">
                    <string/>
@@ -111,7 +111,7 @@
                      <height>32</height>
                    </size>
                  </property>
-                 <property name="toolTip"><string>Create-and-place a line annotation node.</string>
+                 <property name="toolTip"><string>Create-and-place an annotation ROI node.</string>
                  </property>
                  <property name="text">
                    <string/>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -27,7 +27,6 @@
 #include <QSplitter>
 #include <QShortcut>
 #include <QKeySequence>
-#include <QTest>
 
 // Slicer includes
 #include "qSlicerCoreApplication.h"


### PR DESCRIPTION
This fixes a build error I ran into. I was building Slicer latest (cfc69c5fcd8e119dcf3060561c999c8a9baebd93).

> 33>C:\Slicer\Modules\Loadable\Markups\Widgets\qMRMLMarkupsToolBar.cxx(30,10): fatal error C1083: Cannot open include file: 'QTest': No such file or directory

I also noticed some incorrect tooltips when placing Annotation ruler and Annotation ROI node. 

Also have made slight layout improvement so annotations place buttons are compressed together.
| Current | This PR |
|----------|---------|
|![image](https://user-images.githubusercontent.com/15837524/134786880-bb69b5b6-32b1-4222-ba3d-fe440d4d7efd.png)|![image](https://user-images.githubusercontent.com/15837524/134786886-ec64d11e-e50a-462b-93d8-4861f1feaae8.png)|

cc: @lassoan, @smrolfe 