### PR TITLE
Consistent markup control point terminology

### DIFF
--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -662,7 +662,7 @@ void qSlicerMouseModeToolBar::toggleMarkupsToolBar()
   QMainWindow* mainWindow = qSlicerApplication::application()->mainWindow();
   if (mainWindow == nullptr)
     {
-    qDebug("qSlicerSequencesModulePrivate::addToolBar: no main window is available, toolbar is not added");
+    qDebug("qSlicerMouseModeToolBar::toggleMarkupsToolBar: no main window is available, toolbar is not added");
     return;
     }
   foreach(QToolBar * toolBar, mainWindow->findChildren<QToolBar*>())

--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -353,7 +353,7 @@ void qSlicerMouseModeToolBarPrivate::updatePlaceWidget()
   this->PlaceWidgetAction->setIcon(QIcon(placeNodeResource));
   this->PlaceWidgetAction->setText(placeNodeIconName);
   this->PlaceWidgetAction->setData(vtkMRMLInteractionNode::Place);
-  QString tooltip = QString("Use mouse to place a ") + placeNodeIconName;
+  QString tooltip = QString("Place a control point");
   this->PlaceWidgetAction->setToolTip(tooltip);
   this->PlaceWidgetAction->setCheckable(true);
 

--- a/Docs/user_guide/modules/markups.md
+++ b/Docs/user_guide/modules/markups.md
@@ -16,7 +16,7 @@ Click the down-arrow icon on the button to choose markups type.
 
 ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_markups_place_toolbar.png)
 
-Click "Persistent" checkbox to keep placing more points after the current markups is completed.
+Click "Place multiple control points" checkbox to keep placing control points continuously, without the need to click the place button after each point.
 
 2. Left-click in the slice or 3D views to place points
 
@@ -27,8 +27,8 @@ Click "Persistent" checkbox to keep placing more points after the current markup
 - Make sure that the correct markups node is selected in Markups module.
 - Left-click-and drag a control point to move it
 - Left-click a control point to show it in all slice viewers. This helps in adjusting its position along all axes.
-- Right-click to delete or rename a point or change node properties.
-- Ctrl + Left-click to place a new point on a curve.
+- Right-click to delete or rename a control point or change node properties.
+- Ctrl + Left-click to place a new control point on a curve.
 - Enable Display / Interaction / Visible to show a widget that allows translation/rotation of the entire widget.
 
 ### Edit properties of a markups node that is picked in a view
@@ -46,29 +46,29 @@ To pick a markups node in a viewer so that its properties can be edited in Marku
 
 ## Panels and their use
 
-- Create: click on any of the buttons to create a new markup. Click in any of the viewers to place markup points.
-- Markups list: Select a markups node to populate the GUI and allow modifications. When markup placement is activated on the toolbar, then points are added to this selected markups node.
+- Create: click on any of the buttons to create a new markup. Click in any of the viewers to place control points.
+- Markups list: Select a markups node to populate the GUI and allow modifications. When control point placement is activated on the toolbar, then points are added to this selected markups node.
 
 Display section:
-- Visibility: Toggle the markups visibility, which will override the individual markup visibility settings. If the eye icon is open, the list is visible, and pressing it will make it invisible. If the eye icon is closed, the list is invisible and pressing the button will make it visible.
-- Opacity: overall opacity of the selected markups.
+- Visibility: Toggle the markup visibility, which will override the individual control point visibility settings. If the eye icon is open, the list is visible, and pressing it will make it invisible. If the eye icon is closed, the list is invisible and pressing the button will make it visible.
+- Opacity: overall opacity of the selected markup.
 - Glyph Size: Set control point glyph size relative to the screen size (if `absolute` button is not pressed) or as an absolute size (if `absolute` button is depressed).
 - Text Scale: Label size relative to screen size.
 - Interaction: check `Visible` to enable translation of the entire markups in slice and 3D views with an interactive widget.
 - Advanced:
-  - View: select which views the markups is displayed in
+  - View: Select which views the markup is displayed in
   - Selected Color: Select the color that will be used to display the glyph and text when the markup is marked as selected.
   - Unselected Color: Select the color that will be used to display the glyph and text when the markup is not marked as selected.
   - Glyph Type: Select the symbol that will be used to mark each location. Default is the Sphere3D.
-  - Point Labels: check to display label for each control point.
-  - Fiducial projection: A widget that controls the projection of the fiducials in the 2D viewers onto slices around the one on which the fiducial has been placed.
-    - 2D Projection: Toggle the eye icon open or closed to enable or disable visualization of projected fiducial on 2D viewers.
-    - Use Fiducial Color: If checked, color the projections the same color as the fiducials.
-    - Projection Color: If not using fiducial color for the projection, use this color.
-    - Outlined Behind Slice Plane: Fiducial projection is displayed filled (opacity = Projection Opacity) when on top of slice plane, outlined when behind, and with full opacity when in the plane. Outline isn't used for some glyphs (Dash2D, Cross2D, Starburst).
-    - Projection Opacity: A value between 0 (invisible) and 1 (fully visible) for displaying the fiducial projection.
+  - Control Point Labels: check to display a label for each control point.
+  - Control Point Projection: Controls the projection of the control points in the 2D viewers onto slices around the one on which the control points have been placed.
+    - 2D Projection: Toggle the eye icon open or closed to enable or disable visualization of the projected control points on 2D viewers.
+    - Use Markup Color: If checked, color the projections the same color as the markup.
+    - Projection Color: If not using markup color for the projection, use this color.
+    - Outlined Behind Slice Plane: Control point projection is displayed filled (opacity = Projection Opacity) when on top of slice plane, outlined when behind, and with full opacity when in the plane. Outline isn't used for some glyphs (Dash2D, Cross2D, Starburst).
+    - Projection Opacity: A value between 0 (invisible) and 1 (fully visible) for displaying the control point projection.
     - Reset to Defaults: Reset the display properties of this markups node to the system defaults.
-    - Save to Defaults: Save the display properties of this markups node to be the new system defaults. Point labels visibility and properties label visibility setting is not saved to defaults, as typically it is better to initialize these based on the node type (point labels are more useful for fiducials, while properties label is more useful for other markups).
+    - Save to Defaults: Save the display properties of this markups node to be the new system defaults. Control point labels visibility and properties label visibility settings are not saved to defaults, as typically it is better to initialize these based on the node type (control point labels are more useful for markups fiducial nodes, while properties label is more useful for other markups nodes).
 - Scalars: Color markup according to a scalar, e.g. a per-control-point measurement (see Measurements section below)
   - Visible: Whether scalar coloring should be shown or the original color of the markup
   - Active Scalar: Which scalar array to use for coloring
@@ -76,30 +76,30 @@ Display section:
   - Scalar Range Mode: Method for determining the range of the scalars (automatic range calculation based on the data is the default)
 
 Control points section:
-- Interaction in views: toggle the markups lock state (if it can be moved by mouse interactions in the viewers), which will override the individual markup lock settings.
-- Click to Jump Slices: If checked, click in name column to jump slices to that point. The radio buttons control if the slice is centered on the markup or not after the jump. Right click in the table allows jumping 2D slices to a highlighted fiducial (uses the center/offset radio button settings). Once checked, arrow keys moving the highlighted row will also jump slice viewers to that markup position.
-- Buttons: These buttons apply changes to markups in the selected list.
-  - Toggle visibility flag: Toggle visibility flag on all markups in list. Use the drop down menu to set all to visible or invisible.
-  - Toggle selected flag: Toggle selected flag on all markups in list. Use the drop down menu to set all to selected or deselected. Only selected markups will be passed to command line modules.
-  - Toggle lock flag: Toggle lock flag on all markups in list, use drop down menu to set all to locked or unlocked.
-  - Delete the highlighted markups from the active list: After highlighting rows in the table to select markups, press this button to delete them from the list.
-  - Remove all markups from the active list: Pressing this button will delete all of the markups in the active list, leaving it with a list length of 0.
+- Interaction in views: toggle the markups lock state (if it can be moved by mouse interactions in the viewers), which will override the individual control points lock settings.
+- Click to Jump Slices: If checked, click in name column to jump slices to that point. The radio buttons control if the slice is centered on the control point or not after the jump. Right click in the table allows jumping 2D slices to a highlighted control point (uses the center/offset radio button settings). Once checked, arrow keys moving the highlighted row will also jump slice viewers to that control point position.
+- Buttons: These buttons apply changes to control points in the selected list.
+  - Toggle visibility flag: Toggle visibility flag on all control points in the list. Use the drop down menu to set all to visible or invisible.
+  - Toggle selected flag: Toggle selected flag on all control points in the list. Use the drop down menu to set all to selected or deselected. Only selected markups will be passed to command line modules.
+  - Toggle lock flag: Toggle lock flag on all control points in the list. Use the drop down menu to set all to locked or unlocked.
+  - Delete the highlighted control points from the active list: After highlighting rows in the table to select control points, press this button to delete them from the list.
+  - Remove all control points from the active list: Pressing this button will delete all of the control points in the active list, leaving it with a list length of 0.
   - Transformed: Check to show the transformed coordinates in the table. This will apply any transform nodes to the points in the list and show that result. Keep unchecked to show the raw RAS values that are stored in MRML. If you harden the transform the transformed coordinates will be the same as the non transformed coordinates.
   - Hide RAS: Check to hide the coordinate columns in the table and uncheck to show them. Right click in rows to see coordinates.
-- Control points table: Right click on rows in the table to bring up a context menu to show the full precision coordinates, distance between multiple highlighted fiducials, delete the highlighted markup, jump slice viewers to that location, refocus 3D viewers to that location, or if there are other lists, to copy or move the markup to another list.
-  - Selected: A check box is shown in this column, it's check state depends on if the markup is selected or not. Click to toggle the selected state. Only selected markups will be passed to command line modules.
-  - Locked: An open or closed padlock is shown in this column, depending on if the markup is unlocked or locked. Click it to toggle the locked state.
-  - Visibility: An open or closed eye icon is shown in this column, depending on if the markup is visible or not. Click it to toggle the visibility state.
-  - Name: A short name for this markup, displayed in the viewers as text next to the glyphs.
-  - Description: A longer description for this markup, not displayed in the viewers.
-  - X, Y, Z: The RAS coordinates of this markup, 3 places of precision are shown.
+- Control points table: Right click on rows in the table to bring up a context menu to show the full precision coordinates, distance between multiple highlighted control points, delete the highlighted control point, jump slice viewers to that location, refocus 3D viewers to that location, or if there are other lists, to copy or move the control point to another list.
+  - Selected: A check box is shown in this column, it's check state depends on if the control point is selected or not. Click to toggle the selected state. Only selected control points will be passed to command line modules.
+  - Locked: An open or closed padlock is shown in this column, depending on if the control point is unlocked or locked. Click it to toggle the locked state.
+  - Visibility: An open or closed eye icon is shown in this column, depending on if the control point is visible or not. Click it to toggle the visibility state.
+  - Name: A short name for this control point, displayed in the viewers as text next to the glyphs.
+  - Description: A longer description for this control point, not displayed in the viewers.
+  - X, Y, Z: The RAS coordinates of this control point, 3 places of precision are shown.
 - Advanced section:
-  - Move Up: Move a highlighted markup up one spot in the list.
-  - Move Down: Move a highlighted markup down one spot in the list.
-  - Add Markup: Add a new markup to the selected list, placing it at the origin
+  - Move Up: Move a highlighted control point up one spot in the list.
+  - Move Down: Move a highlighted control point down one spot in the list.
+  - Add Control Point: Add a new control point to the selected list, placing it at the origin
   - Naming:
-    - Name Format: Format for creating names of new markups, using sprintf format style. %N is replaced by the list name, %d by an integer.
-    - Apply: Rename all markups in this list according to the current name format, trying to preserve numbers. A quick way to re-number all the fiducials according to their index is to use a name format with no number in it, rename, then add the number format specifier %d to the format and rename one more time.
+    - Name Format: Format for creating names of new control points, using sprintf format style. %N is replaced by the list name, %d by an integer.
+    - Apply: Rename all control points in this list according to the current name format, trying to preserve numbers. A quick way to re-number all the control points according to their index is to use a name format with no number in it, rename, then add the number format specifier %d to the format and rename one more time.
     - Reset: Reset the name format field to the default value, %N-%d.
 
 Measurements section:

--- a/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
+++ b/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
@@ -278,7 +278,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Toggle visibility flag on all markups in list, use drop down menu to set all to visible or invisible.</string>
+             <string>Toggle visibility flag on all control points in the list. Use the drop down menu to set all to visible or invisible.</string>
             </property>
            </widget>
           </item>
@@ -303,7 +303,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Toggle selected flag on all markups in list, use drop down menu to set all to selected or deselected.</string>
+             <string>Toggle selected flag on all control points in the list. Use the drop down menu to set all to selected or deselected.</string>
             </property>
            </widget>
           </item>
@@ -328,7 +328,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Toggle lock flag on all markups in list, use drop down menu to set all to locked or unlocked.</string>
+             <string>Toggle lock flag on all control points in the list. Use the drop down menu to set all to locked or unlocked.</string>
             </property>
            </widget>
           </item>
@@ -356,7 +356,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Always skip highlighted markup(s) from the active list (missing position status).</string>
+             <string>Always skip highlighted control point(s) from the active list (missing position status).</string>
             </property>
             <property name="text">
              <string/>
@@ -391,7 +391,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Undefine position of highlighted markup(s) from the active list</string>
+             <string>Undefine position of highlighted control point(s) from the active list</string>
             </property>
             <property name="text">
              <string/>
@@ -426,7 +426,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Delete the highlighted markup(s) from the active list</string>
+             <string>Delete the highlighted control point(s) from the active list</string>
             </property>
             <property name="text">
              <string/>
@@ -461,7 +461,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Remove all markups from the active list</string>
+             <string>Remove all control points from the active list</string>
             </property>
             <property name="icon">
              <iconset resource="../qSlicerMarkupsModule.qrc">
@@ -551,10 +551,10 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>The markups in the currently active markups node. Right click in a row for delete, jump, copy, move.</string>
+         <string>The control points in the currently active markups node. Right click in a row for delete, jump, copy, move.</string>
         </property>
         <property name="accessibleName">
-         <string>active markup table</string>
+         <string>active markup control point table</string>
         </property>
         <property name="alternatingRowColors">
          <bool>true</bool>
@@ -599,7 +599,7 @@
                 </size>
                </property>
                <property name="toolTip">
-                <string>Move a highlighted markup up one spot in the list</string>
+                <string>Move a highlighted control point up one spot in the list</string>
                </property>
                <property name="text">
                 <string/>
@@ -631,7 +631,7 @@
                 </size>
                </property>
                <property name="toolTip">
-                <string>Move a highlighted markup down one spot in the list</string>
+                <string>Move a highlighted control point down one spot in the list</string>
                </property>
                <property name="text">
                 <string/>
@@ -663,7 +663,7 @@
                 </size>
                </property>
                <property name="toolTip">
-                <string>Add a new markup to the active list, at origin</string>
+                <string>Add a new control point to the active list, at origin</string>
                </property>
                <property name="icon">
                 <iconset resource="../qSlicerMarkupsModule.qrc">
@@ -692,7 +692,7 @@
               <item row="2" column="1">
                <widget class="QLineEdit" name="nameFormatLineEdit">
                 <property name="toolTip">
-                 <string>Format for creating names of new markups, using sprintf format style. %N is replaced by the list name, %S is replaced by the markup's short name and %d by an integer.</string>
+                 <string>Format for creating names of new control points, using sprintf format style. %N is replaced by the list name, %S is replaced by the markup's short name and %d by an integer.</string>
                 </property>
                </widget>
               </item>
@@ -709,7 +709,7 @@
               <item row="2" column="2">
                <widget class="QPushButton" name="renameAllWithCurrentNameFormatPushButton">
                 <property name="toolTip">
-                 <string>Rename all markups in this list according to the current name format, trying to preserve numbers.</string>
+                 <string>Rename all control points in this list according to the current name format, trying to preserve numbers.</string>
                 </property>
                 <property name="text">
                  <string>Apply</string>

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsDisplayNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsDisplayNodeTest1.cxx
@@ -142,7 +142,7 @@ int vtkMRMLMarkupsDisplayNodeTest1(int , char * [] )
   node1->SliceProjectionUseFiducialColorOn();
   if (node1->GetSliceProjectionUseFiducialColor() != true)
     {
-    std::cerr << "Failed to turn use fiducial color on with slice projections"
+    std::cerr << "Failed to turn use markup color on with slice projections"
               << ", slice projection = " << node1->GetSliceProjection()
               << std::endl;
     return EXIT_FAILURE;

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -443,7 +443,7 @@
       <item row="11" column="0">
        <widget class="QLabel" name="PointLabelsVisibilityLabel">
         <property name="text">
-         <string>Point Labels:</string>
+         <string>Control Point Labels:</string>
         </property>
        </widget>
       </item>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsFiducialProjectionPropertyWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsFiducialProjectionPropertyWidget.ui
@@ -38,7 +38,7 @@
    <item row="1" column="0">
     <widget class="QLabel" name="point2DProjectionLabel">
      <property name="toolTip">
-      <string>Turn on/off visualization of projected fiducial on 2D viewers</string>
+      <string>If enabled then all control points will be displayed in 2D viewers, by projecting them to the slice plane.</string>
      </property>
      <property name="text">
       <string>Projection Visibility:</string>
@@ -48,7 +48,7 @@
    <item row="3" column="0">
     <widget class="QLabel" name="pointProjectionColorLabel">
      <property name="toolTip">
-      <string>Color of the projected fiducial on 2D viewers</string>
+      <string>Color of the projected control points on 2D viewers</string>
      </property>
      <property name="text">
       <string>Projection Color:</string>
@@ -64,7 +64,7 @@
       </size>
      </property>
      <property name="toolTip">
-      <string>Color of the projected fiducial on 2D viewers. Only used if Use Fiducial Color is not checked, otherwise the projection uses the selected or unselected fiducial color.</string>
+      <string>Color of the projected control points on 2D viewers. Only used if "Use Markup Color" is not checked, otherwise the projection uses the selected or unselected markup color.</string>
      </property>
      <property name="color">
       <color>
@@ -84,7 +84,7 @@
    <item row="5" column="0">
     <widget class="QLabel" name="pointOutlinedBehindSlicePlaneLabel">
      <property name="toolTip">
-      <string>Fiducial projection is displayed filled (opacity = Projection Opacity) when on top of slice plane, outlined when behind, and with full opacity when in the plane. Outline isn't used for some glyphs (Dash2D, Cross2D, Starburst).</string>
+      <string>Projected control points are displayed filled (opacity = Projection Opacity) when above the slice plane, outlined when behind, and with full opacity when in the plane. Outline isn't used for some glyphs (Dash2D, Cross2D, Starburst).</string>
      </property>
      <property name="text">
       <string>Outlined Behind Slice Plane:</string>
@@ -94,7 +94,7 @@
    <item row="5" column="1">
     <widget class="QCheckBox" name="pointOutlinedBehindSlicePlaneCheckBox">
      <property name="toolTip">
-      <string>Fiducial projection is displayed filled (opacity = Projection Opacity) when on top of slice plane, outlined when behind, and with full opacity when in the plane. Outline isn't used for some glyphs (Dash2D, Cross2D, Starburst).</string>
+      <string>Projected control points are displayed filled (opacity = Projection Opacity) when above the slice plane, outlined when behind, and with full opacity when in the plane. Outline isn't used for some glyphs (Dash2D, Cross2D, Starburst).</string>
      </property>
      <property name="text">
       <string/>
@@ -107,17 +107,17 @@
    <item row="2" column="0">
     <widget class="QLabel" name="pointUseFiducialColorLabel">
      <property name="toolTip">
-      <string>Use the same color as fiducial</string>
+      <string>Use the same color as the markup</string>
      </property>
      <property name="text">
-      <string>Use Fiducial Color:</string>
+      <string>Use Markup Color:</string>
      </property>
     </widget>
    </item>
    <item row="2" column="1">
     <widget class="QCheckBox" name="pointUseFiducialColorCheckBox">
      <property name="toolTip">
-      <string>Use the same color as fiducial</string>
+      <string>Use the same color as the markup</string>
      </property>
      <property name="text">
       <string/>
@@ -132,7 +132,7 @@
      <item>
       <widget class="ctkCheckBox" name="point2DProjectionCheckBox">
        <property name="toolTip">
-        <string>Turn on/off visualization of projected fiducial on 2D viewers</string>
+        <string>If enabled then all control points will be displayed in 2D viewers, by projecting them to the slice plane.</string>
        </property>
        <property name="indicatorIconSize">
         <size>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerMarkupsPlaceWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerMarkupsPlaceWidget.ui
@@ -54,7 +54,7 @@
         <enum>QToolButton::MenuButtonPopup</enum>
       </property>
       <property name="toolTip">
-      <string>Place a markup point</string>
+      <string>Place a control point</string>
      </property>
      <property name="text">
       <string>...</string>
@@ -80,7 +80,7 @@
       <enum>QToolButton::MenuButtonPopup</enum>
      </property>
      <property name="toolTip">
-      <string>Delete last added markup point</string>
+      <string>Delete last added control point</string>
      </property>
      <property name="text">
       <string>...</string>
@@ -132,10 +132,10 @@
      <normaloff>:/Icons/MarkupsDeleteAllRows.png</normaloff>:/Icons/MarkupsDeleteAllRows.png</iconset>
    </property>
    <property name="text">
-    <string>Delete all markups</string>
+    <string>Delete all control points</string>
    </property>
    <property name="toolTip">
-    <string>Delete all markups in the list</string>
+    <string>Delete all control points in the list</string>
    </property>
   </action>
   <action name="ActionUnsetLast">
@@ -144,10 +144,10 @@
      <normaloff>:/Icons/MarkupsUnset.png</normaloff>:/Icons/MarkupsUnset.png</iconset>
    </property>
     <property name="text">
-    <string>Unset last point</string>
+    <string>Unset last control point</string>
    </property>
    <property name="toolTip">
-    <string>Unset position of the last point placed without deletion</string>
+    <string>Unset position of the last control point placed (the control point will not be deleted).</string>
    </property>
   </action>
   <action name="ActionUnsetAll">
@@ -157,10 +157,10 @@
     </iconset>
    </property>
    <property name="text">
-    <string>Unset all points</string>
+    <string>Unset all control points</string>
    </property>
    <property name="toolTip">
-    <string>Unset position of all points in the list without deletion</string>
+    <string>Unset position of all control points in the list (the control points will not be deleted).</string>
    </property>
   </action>
   <action name="ActionVisibility">
@@ -173,7 +173,7 @@
     <string>Visibility</string>
    </property>
    <property name="toolTip">
-    <string>Toggle markups visibility</string>
+    <string>Toggle markup visibility</string>
    </property>
   </action>
   <action name="ActionLocked">
@@ -186,7 +186,7 @@
     <string>Locked</string>
    </property>
    <property name="toolTip">
-    <string>Toggle markup point positions lock</string>
+    <string>Toggle control point positions lock</string>
    </property>
   </action>
   <action name="ActionFixedNumberOfControlPoints">
@@ -196,10 +196,10 @@
      <normalon>:/Icons/Small/SlicerPointNumberLock.png</normalon>:/Icons/Small/SlicerPointNumberUnlock.png</iconset>
    </property>
    <property name="text">
-    <string>Point Number Locked</string>
+    <string>Control point number locked</string>
    </property>
    <property name="toolTip">
-    <string>Toggle markup point number lock</string>
+    <string>Toggle control point number lock. If locked then it is not possible to add or delete control points. Instead of deleting, position control points can be unset.</string>
    </property>
   </action>
  </widget>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -90,6 +90,7 @@ void qMRMLMarkupsToolBarPrivate::init()
   this->MarkupsNodeSelector->setMaximumWidth(150);
   this->MarkupsNodeSelector->setEnabled(true);
   this->MarkupsNodeSelector->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+  this->MarkupsNodeSelector->setToolTip("Select active markup");
 
   connect(this->MarkupsNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)), q, SIGNAL(activeMarkupsNodeChanged(vtkMRMLNode*)) );
   connect(this->MarkupsNodeSelector, SIGNAL(nodeActivated(vtkMRMLNode*)), q, SLOT(onMarkupsNodeChanged(vtkMRMLNode*)));

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -549,7 +549,7 @@ void qSlicerMarkupsPlaceWidget::updateWidget()
     {
     d->ActionFixedNumberOfControlPoints->setIcon(QIcon(":/Icons/Small/SlicerPointNumberLock.png"));
     d->DeleteButton->setIcon(QIcon(":/Icons/MarkupsUnset.png"));
-    d->DeleteButton->setToolTip("Unset position of the last point placed without deletion");
+    d->DeleteButton->setToolTip("Unset position of the last control point placed (the control point will not be deleted).");
     d->DeleteMenu->removeAction(d->ActionUnsetLast);
     d->DeleteMenu->removeAction(d->ActionDeleteAll);
     }
@@ -557,7 +557,7 @@ void qSlicerMarkupsPlaceWidget::updateWidget()
     {
     d->ActionFixedNumberOfControlPoints->setIcon(QIcon(":/Icons/Small/SlicerPointNumberUnlock.png"));
     d->DeleteButton->setIcon(QIcon(":/Icons/MarkupsDelete.png"));
-    d->DeleteButton->setToolTip("Delete last added markup point");
+    d->DeleteButton->setToolTip("Delete last added control point");
     d->DeleteMenu->addAction(d->ActionUnsetLast);
     d->DeleteMenu->addAction(d->ActionDeleteAll);
     }

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -559,6 +559,7 @@ void qSlicerMarkupsPlaceWidget::updateWidget()
     d->DeleteButton->setIcon(QIcon(":/Icons/MarkupsDelete.png"));
     d->DeleteButton->setToolTip("Delete last added control point");
     d->DeleteMenu->addAction(d->ActionUnsetLast);
+    d->DeleteMenu->addAction(d->ActionUnsetAll);
     d->DeleteMenu->addAction(d->ActionDeleteAll);
     }
 

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -462,25 +462,25 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
   QTableWidgetItem *selectedHeader = this->activeMarkupTableWidget->horizontalHeaderItem(this->columnIndex("Selected"));
   selectedHeader->setText("");
   selectedHeader->setIcon(QIcon(":/Icons/MarkupsSelected.png"));
-  selectedHeader->setToolTip(QString("Click in this column to select/deselect markups for passing to CLI modules"));
+  selectedHeader->setToolTip(QString("Click in this column to select/deselect control points for passing to CLI modules"));
   this->activeMarkupTableWidget->setColumnWidth(this->columnIndex("Selected"), 30);
   // locked is an open and closed lock
   QTableWidgetItem *lockedHeader = this->activeMarkupTableWidget->horizontalHeaderItem(this->columnIndex("Locked"));
   lockedHeader->setText("");
   lockedHeader->setIcon(QIcon(":/Icons/Small/SlicerLockUnlock.png"));
-  lockedHeader->setToolTip(QString("Click in this column to lock/unlock markups to prevent them from being moved by mistake"));
+  lockedHeader->setToolTip(QString("Click in this column to lock/unlock control points to prevent them from being moved by mistake"));
   this->activeMarkupTableWidget->setColumnWidth(this->columnIndex("Locked"), 30);
   // visible is an open and closed eye
   QTableWidgetItem *visibleHeader = this->activeMarkupTableWidget->horizontalHeaderItem(this->columnIndex("Visible"));
   visibleHeader->setText("");
   visibleHeader->setIcon(QIcon(":/Icons/Small/SlicerVisibleInvisible.png"));
-  visibleHeader->setToolTip(QString("Click in this column to show/hide markups in 2D and 3D"));
+  visibleHeader->setToolTip(QString("Click in this column to show/hide control points in 2D and 3D"));
   this->activeMarkupTableWidget->setColumnWidth(this->columnIndex("Visible"), 30);
   // position is a location bubble
   QTableWidgetItem *positionHeader = this->activeMarkupTableWidget->horizontalHeaderItem(this->columnIndex("Position"));
   positionHeader->setText("");
   positionHeader->setIcon(QIcon(":/Icons/Large/MarkupsPositionStatus.png"));
-  positionHeader->setToolTip(QString("Position status of point. Click in this column to toggle."));
+  positionHeader->setToolTip(QString("Click in this column to set/unset control points."));
   this->activeMarkupTableWidget->setColumnWidth(this->columnIndex("Position"), 10);
 
   // listen for changes so can update mrml node
@@ -996,12 +996,12 @@ void qSlicerMarkupsModuleWidget::updateWidgetFromMRML()
   if (d->MarkupsNode->GetLocked())
     {
     d->listLockedUnlockedPushButton->setIcon(QIcon(":Icons/Medium/SlicerLock.png"));
-    d->listLockedUnlockedPushButton->setToolTip(QString("Click to unlock this markup list so that the markups can be moved by the mouse"));
+    d->listLockedUnlockedPushButton->setToolTip(QString("Click to unlock this control point list so points can be moved by the mouse"));
     }
   else
     {
     d->listLockedUnlockedPushButton->setIcon(QIcon(":Icons/Medium/SlicerUnlock.png"));
-    d->listLockedUnlockedPushButton->setToolTip(QString("Click to lock this markup list so that the markups cannot be moved by the mouse"));
+    d->listLockedUnlockedPushButton->setToolTip(QString("Click to lock this control point list so points cannot be moved by the mouse"));
     }
 
   if (d->MarkupsNode->GetFixedNumberOfControlPoints())

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.h
@@ -163,7 +163,7 @@ public slots:
   /// make sure that a display node is added
   void onActiveMarkupMRMLNodeAdded(vtkMRMLNode *markupsNode);
 
-  /// Create markup by class.
+  /// Create markups node by class.
   void onCreateMarkupByClass(const QString& className);
 
   /// Toggle the markups node visibility flag
@@ -172,7 +172,7 @@ public slots:
   /// Toggle the markups node locked flag
   void onListLockedUnlockedPushButtonClicked();
 
-  /// Toggle the markups node point number locked flag
+  /// Toggle the markups node control point number locked flag
   void onFixedNumberOfControlPointsPushButtonClicked();
 
   /// Update the markup label from the line edit entry

--- a/Modules/Loadable/Tables/Widgets/Resources/UI/qSlicerTableColumnPropertiesWidget.ui
+++ b/Modules/Loadable/Tables/Widgets/Resources/UI/qSlicerTableColumnPropertiesWidget.ui
@@ -245,10 +245,10 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Place multiple markups</string>
+    <string>Place multiple control points</string>
    </property>
    <property name="toolTip">
-    <string>Place multiple markups</string>
+    <string>Place multiple control points</string>
    </property>
   </action>
   <action name="ActionDeleteAll">
@@ -257,10 +257,10 @@
      <normaloff>:/Icons/MarkupsDeleteAllRows.png</normaloff>:/Icons/MarkupsDeleteAllRows.png</iconset>
    </property>
    <property name="text">
-    <string>Delete all markups</string>
+    <string>Delete all control points</string>
    </property>
    <property name="toolTip">
-    <string>Delete all markups in the list</string>
+    <string>Delete all control points in the list</string>
    </property>
   </action>
   <action name="ActionVisibility">
@@ -273,7 +273,7 @@
     <string>Visibility</string>
    </property>
    <property name="toolTip">
-    <string>Toggle markups visibility</string>
+    <string>Toggle control point visibility</string>
    </property>
   </action>
   <action name="ActionLocked">
@@ -286,7 +286,7 @@
     <string>Locked</string>
    </property>
    <property name="toolTip">
-    <string>Toggle markup point positions lock</string>
+    <string>Toggle control point positions lock</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This addresses https://github.com/Slicer/Slicer/issues/5889#issuecomment-927207824.  For usability reasons, items should be consistently referred to with the same name in the UI and in the documentation. This allows for easier learning when users can connect that "this term over here" matches and is for "this same term over there". When different terminology is used it is natural to assume they are different objects and that can lead to confusion when they are not different. My goal here is to make Slicer more user-friendly for users to understand what is a Markup vs a Control Point across various places in the UI. At times advanced users can get a little lazy with using specific and clear terminology and that can be confusing to users trying to learn.

"Control Point" is the clear and consistent terminology to refer to the objects within a markup node.
![image](https://user-images.githubusercontent.com/15837524/134815940-11ea0bad-5159-469e-9e51-567b8bd9dbb7.png)


I've also included an additional minor commit `ENH: Move unset all points action after unset last` to set the "All" action after the individual/single action as seen below.

| Before | After |
|---------|-------|
|![image](https://user-images.githubusercontent.com/15837524/134815749-52876060-7e74-450e-b402-e52fcc8f839f.png)|![image](https://user-images.githubusercontent.com/15837524/134815757-e2213587-837f-4872-8f61-833bd2f36ea4.png)|