### PR TITLE
ENH: Create markups node put into menu for toolbar

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -106,6 +106,11 @@ void qMRMLMarkupsToolBarPrivate::init()
   q->setMRMLScene(qSlicerApplication::application()->mrmlScene());
 
   this->MarkupsNodeSelector->setMRMLScene(qSlicerApplication::application()->mrmlScene());
+
+  this->CreateMarkupToolButton = new QToolButton();
+  this->CreateMarkupToolButton->setObjectName("CreateToolButton");
+  this->CreateMarkupToolButton->setPopupMode(QToolButton::MenuButtonPopup);
+  QObject::connect(this->CreateMarkupToolButton, SIGNAL(triggered(QAction*)), this->CreateMarkupToolButton, SLOT(setDefaultAction(QAction*)));
 }
 
 // --------------------------------------------------------------------------
@@ -462,18 +467,23 @@ void qMRMLMarkupsToolBar::addNodeActions(vtkSlicerMarkupsLogic* markupsLogic)
       markupsLogic->GetNodeByMarkupsType(markupName.c_str());
     if (markupsNode && markupsLogic->GetCreateMarkupsPushButton(markupName.c_str()))
       {
+      QAction* markupCreateAction = new QAction();
+      markupCreateAction->setObjectName(QString("Create") + QString(markupsNode->GetMarkupType()) + QString("Action"));
+      markupCreateAction->setText("Create " + QString(markupsNode->GetMarkupTypeDisplayName()));
+      markupCreateAction->setToolTip("Create " + QString(markupsNode->GetMarkupTypeDisplayName()));
+      markupCreateAction->setIcon(QIcon(markupsNode->GetPlaceAddIcon()));
+      d->CreateMarkupToolButton->addAction(markupCreateAction);
+      if (markupName == "Fiducial")
+      {
+        d->CreateMarkupToolButton->setDefaultAction(markupCreateAction);
+      }
       QSignalMapper* mapper = new QSignalMapper(this);
-      QPushButton* markupCreateButton = new QPushButton();
-      markupCreateButton->setObjectName(QString("Create") + QString(markupsNode->GetMarkupType()) + QString("PushButton"));
-      markupCreateButton->setToolTip("Create " + QString(markupsNode->GetMarkupTypeDisplayName()));
-      markupCreateButton->setIcon(QIcon(markupsNode->GetPlaceAddIcon()));
-      this->addWidget(markupCreateButton);
-      QObject::connect(markupCreateButton, SIGNAL(clicked()), mapper, SLOT(map()));
-      mapper->setMapping(markupCreateButton, markupsNode->GetClassName());
+      QObject::connect(markupCreateAction, SIGNAL(triggered()), mapper, SLOT(map()));
+      mapper->setMapping(markupCreateAction, markupsNode->GetClassName());
       QObject::connect(mapper, SIGNAL(mapped(const QString&)), this, SLOT(onAddNewMarkupsNodeByClass(const QString&)));
       }
     }
-
+  this->addWidget(d->CreateMarkupToolButton);
   this->addSeparator();
   this->addWidget(d->MarkupsNodeSelector);
 

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar_p.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar_p.h
@@ -104,6 +104,7 @@ public:
   QString DefaultPlaceClassName;
 
   qMRMLNodeComboBox* MarkupsNodeSelector;
+  QToolButton* CreateMarkupToolButton;
   qSlicerMarkupsPlaceWidget* MarkupsPlaceWidget;
 };
 


### PR DESCRIPTION
This addresses https://github.com/Slicer/Slicer/issues/5889#issuecomment-927342225 to put the create markup node actions in the Markups Toolbar within a menu of a QToolButton. Markups is a pluggable framework where more markups can be registered and added into Slicer and creating a new button in the toolbar for each registered markup is not sustainable as it will only make the Markups toolbar larger.

|Current | This PR |
|---------|----------|
| ![image](https://user-images.githubusercontent.com/15837524/134817956-a21c85d7-3c8f-4d0f-8466-df7741ec9b7e.png)| ![image](https://user-images.githubusercontent.com/15837524/134822338-408934f2-a2e4-4ce5-a60c-308ff0d9b0c6.png)|