### PR TITLE
ENH: check DICOM instance before stopping listener

### DIFF
--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -803,7 +803,8 @@ class DICOMWidget(ScriptedLoadableModuleWidget):
       wasBlocked = self.ui.toggleListener.blockSignals(True)
       self.ui.toggleListener.checked = False
       self.ui.toggleListener.blockSignals(wasBlocked)
-      slicer.modules.DICOMInstance.stopListener()
+      if hasattr(slicer.modules, 'DICOMInstance'):
+        slicer.modules.DICOMInstance.stopListener()
     if newState == 1:
       self.ui.listenerStateLabel.text = "starting"
     if newState == 2:

--- a/Modules/Scripted/DICOM/DICOM.py
+++ b/Modules/Scripted/DICOM/DICOM.py
@@ -803,7 +803,7 @@ class DICOMWidget(ScriptedLoadableModuleWidget):
       wasBlocked = self.ui.toggleListener.blockSignals(True)
       self.ui.toggleListener.checked = False
       self.ui.toggleListener.blockSignals(wasBlocked)
-      if hasattr(slicer.modules, 'DICOMInstance'):
+      if hasattr(slicer.modules, 'DICOMInstance'):  # custom applications may not have the standard DICOM module
         slicer.modules.DICOMInstance.stopListener()
     if newState == 1:
       self.ui.listenerStateLabel.text = "starting"


### PR DESCRIPTION
Using a slicelet with a custom DICOM browser and closing the app with this DICOM browser open triggers a python error caused by the dicom listener stopped as it does not have any DICOMInstance.
This simple check fix this error.