### PR TITLE
ENH: Add mouse gesture to finish markup point placement by double-click

### DIFF
--- a/Docs/user_guide/modules/markups.md
+++ b/Docs/user_guide/modules/markups.md
@@ -18,9 +18,9 @@ Click the down-arrow icon on the button to choose markups type.
 
 Click "Place multiple control points" checkbox to keep placing control points continuously, without the need to click the place button after each point.
 
-2. Left-click in the slice or 3D views to place points
+2. Left-click in the slice or 3D views to place points.
 
-3. Right-click to finish point placement
+3. Double-left-click or right-click to finish point placement.
 
 ### Edit point positions in existing markups
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -59,6 +59,7 @@ vtkSlicerMarkupsWidget::vtkSlicerMarkupsWidget()
   this->SetEventTranslation(WidgetStateDefine, vtkCommand::LeftButtonReleaseEvent, vtkEvent::NoModifier, WidgetEventControlPointPlace);
   this->SetEventTranslation(WidgetStateDefine, vtkCommand::RightButtonPressEvent, vtkEvent::NoModifier, WidgetEventReserved);
   this->SetEventTranslation(WidgetStateDefine, vtkCommand::RightButtonReleaseEvent, vtkEvent::NoModifier, WidgetEventStopPlace);
+  this->SetEventTranslation(WidgetStateDefine, vtkCommand::LeftButtonDoubleClickEvent, vtkEvent::NoModifier, WidgetEventStopPlace);
 
   // Manipulate
   this->SetEventTranslationClickAndDrag(WidgetStateOnWidget, vtkCommand::LeftButtonPressEvent, vtkEvent::NoModifier,


### PR DESCRIPTION
Double-click is used in many software (PowerPoint, Inkscape, Gimp, ...) to finish point editing. It also makes double-click a more useful action during point placement (previously, a double-click resulted in placing a control point and maximizing/restoring the view).

See discussion here: https://discourse.slicer.org/t/new-feature-maximize-view/19581