### PR TITLE
ENH: Reorder and rename control point position status options for clarity

### DIFF
--- a/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
+++ b/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
@@ -356,7 +356,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Always skip highlighted control point(s) from the active list (missing position status).</string>
+             <string>Skip placement of highlighted control point(s) from the active list (will clear current position).</string>
             </property>
             <property name="text">
              <string/>
@@ -391,7 +391,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>Undefine position of highlighted control point(s) from the active list</string>
+             <string>Clear the position of highlighted control point(s) from the active list (the control points will not be deleted).</string>
             </property>
             <property name="text">
              <string/>

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -136,35 +136,35 @@ void qSlicerSubjectHierarchyMarkupsPluginPrivate::init()
 
   // View context menu
 
-  this->RenamePointAction = new QAction("Rename point...", q);
+  this->RenamePointAction = new QAction("Rename control point...", q);
   this->RenamePointAction->setObjectName("RenamePointAction");
   q->setActionPosition(this->RenamePointAction, qSlicerSubjectHierarchyAbstractPlugin::SectionComponent);
   QObject::connect(this->RenamePointAction, SIGNAL(triggered()), q, SLOT(renamePoint()));
 
-  this->ToggleSelectPointAction = new QAction("Toggle select point", q);
+  this->ToggleSelectPointAction = new QAction("Toggle select control point", q);
   this->ToggleSelectPointAction->setObjectName("ToggleSelectPointAction");
   q->setActionPosition(this->ToggleSelectPointAction, qSlicerSubjectHierarchyAbstractPlugin::SectionComponent);
   QObject::connect(this->ToggleSelectPointAction, SIGNAL(triggered()), q, SLOT(toggleSelectPoint()));
 
-  this->JumpToPreviousPointAction = new QAction("Jump to previous point", q);
+  this->JumpToPreviousPointAction = new QAction("Jump to previous control point", q);
   this->JumpToPreviousPointAction->setToolTip("Jump slice views to the previous control point");
   this->JumpToPreviousPointAction->setObjectName("JumpToPreviousPointAction");
   q->setActionPosition(this->JumpToPreviousPointAction, qSlicerSubjectHierarchyAbstractPlugin::SectionComponent);
   QObject::connect(this->JumpToPreviousPointAction, SIGNAL(triggered()), q, SLOT(jumpToPreviousPoint()));
 
-  this->JumpToNextPointAction = new QAction("Jump to next point", q);
+  this->JumpToNextPointAction = new QAction("Jump to next control point", q);
   this->JumpToNextPointAction->setToolTip("Jump slice views to the next control point");
   this->JumpToNextPointAction->setObjectName("JumpToNextPointAction");
   q->setActionPosition(this->JumpToNextPointAction, qSlicerSubjectHierarchyAbstractPlugin::SectionComponent);
   QObject::connect(this->JumpToNextPointAction, SIGNAL(triggered()), q, SLOT(jumpToNextPoint()));
 
-  this->JumpToClosestPointAction = new QAction("Jump to closest point", q);
+  this->JumpToClosestPointAction = new QAction("Jump to closest control point", q);
   this->JumpToClosestPointAction->setToolTip("Jump slice views to the closest control point");
   this->JumpToClosestPointAction->setObjectName("JumpToClosestPointAction");
   q->setActionPosition(this->JumpToClosestPointAction, qSlicerSubjectHierarchyAbstractPlugin::SectionComponent);
   QObject::connect(this->JumpToClosestPointAction, SIGNAL(triggered()), q, SLOT(jumpToClosestPoint()));
 
-  this->DeletePointAction = new QAction("Delete point", q);
+  this->DeletePointAction = new QAction("Delete control point", q);
   this->DeletePointAction->setObjectName("DeletePointAction");
   q->setActionPosition(this->DeletePointAction, qSlicerSubjectHierarchyAbstractPlugin::SectionComponent);
   QObject::connect(this->DeletePointAction, SIGNAL(triggered()), q, SLOT(deletePoint()));
@@ -657,7 +657,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::showViewContextMenuActionsForItem(vtk
       }
     else
       {
-      d->DeletePointAction->setText("Delete point");
+      d->DeletePointAction->setText("Delete control point");
       }
     }
   d->DeleteNodeAction->setVisible(true);
@@ -1150,5 +1150,5 @@ void qSlicerSubjectHierarchyMarkupsPlugin::editProperties(vtkIdType itemID)
   else
     {
     qSlicerApplication::application()->openNodeModule(shNode->GetItemDataNode(itemID));
-    }  
+    }
 }

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -653,7 +653,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::showViewContextMenuActionsForItem(vtk
     {
     if (associatedNode->GetFixedNumberOfControlPoints())
       {
-      d->DeletePointAction->setText("Unset point position");
+      d->DeletePointAction->setText("Clear control point position");
       }
     else
       {

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerMarkupsPlaceWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerMarkupsPlaceWidget.ui
@@ -144,10 +144,10 @@
      <normaloff>:/Icons/MarkupsUnset.png</normaloff>:/Icons/MarkupsUnset.png</iconset>
    </property>
     <property name="text">
-    <string>Unset last control point</string>
+    <string>Clear last control point position</string>
    </property>
    <property name="toolTip">
-    <string>Unset position of the last control point placed (the control point will not be deleted).</string>
+    <string>Clear the position of the last control point placed (the control point will not be deleted).</string>
    </property>
   </action>
   <action name="ActionUnsetAll">
@@ -157,10 +157,10 @@
     </iconset>
    </property>
    <property name="text">
-    <string>Unset all control points</string>
+    <string>Clear all control point positions</string>
    </property>
    <property name="toolTip">
-    <string>Unset position of all control points in the list (the control points will not be deleted).</string>
+    <string>Clear the position of all control points in the list (the control points will not be deleted).</string>
    </property>
   </action>
   <action name="ActionVisibility">

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -480,7 +480,11 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
   QTableWidgetItem *positionHeader = this->activeMarkupTableWidget->horizontalHeaderItem(this->columnIndex("Position"));
   positionHeader->setText("");
   positionHeader->setIcon(QIcon(":/Icons/Large/MarkupsPositionStatus.png"));
-  positionHeader->setToolTip(QString("Click in this column to set/unset control points."));
+  positionHeader->setToolTip(QString("Click in this column to modify the control point position state.\n\n"
+                                     "- Edit: Enter place mode to modify the control point position in the slice views\n"
+                                     "- Skip: 'Place multiple control points' mode skips over the control point entry\n"
+                                     "- Restore: Set the control point position to its last known set position\n"
+                                     "- Clear: Clear the defined control point position, but do not delete the control point"));
   this->activeMarkupTableWidget->setColumnWidth(this->columnIndex("Position"), 10);
 
   // listen for changes so can update mrml node
@@ -2253,27 +2257,28 @@ void qSlicerMarkupsModuleWidget::onRightClickActiveMarkupTableWidget(QPoint pos)
   menu.addSeparator();
   // Change position status
   QAction* resetFiducialAction =
-      new QAction(QString("Edit position of highlighted fiducial(s)"), &menu);
+      new QAction(QIcon(":/Icons/XSmall/MarkupsInProgress.png"), QString("Edit position of highlighted fiducial(s)"), &menu);
   menu.addAction(resetFiducialAction);
   QObject::connect(resetFiducialAction, SIGNAL(triggered()),
       this, SLOT(onResetMarkupPushButtonClicked()));
-  QAction* unsetFiducialAction =
-      new QAction(QString("Unset position of highlighted fiducial(s)"), &menu);
-  menu.addAction(unsetFiducialAction);
-  QObject::connect(unsetFiducialAction, SIGNAL(triggered()),
-      this, SLOT(onUnsetMarkupPushButtonClicked()));
 
   QAction* missingFiducialAction =
-      new QAction(QString("Set position missing for highlighted fiducial(s)"), &menu);
+      new QAction(QIcon(":/Icons/XSmall/MarkupsMissing.png"), QString("Skip placement of highlighted fiducial(s)"), &menu);
   menu.addAction(missingFiducialAction);
   QObject::connect(missingFiducialAction, SIGNAL(triggered()),
       this, SLOT(onMissingMarkupPushButtonClicked()));
 
   QAction* restoreFiducialAction =
-      new QAction(QString("Restore position of highlighted fiducial(s)"), &menu);
+      new QAction(QIcon(":/Icons/XSmall/MarkupsDefined.png"), QString("Restore position of highlighted fiducial(s)"), &menu);
   menu.addAction(restoreFiducialAction);
   QObject::connect(restoreFiducialAction, SIGNAL(triggered()),
       this, SLOT(onRestoreMarkupPushButtonClicked()));
+
+  QAction* unsetFiducialAction =
+      new QAction(QIcon(":/Icons/XSmall/MarkupsUndefined.png"), QString("Clear position of highlighted fiducial(s)"), &menu);
+  menu.addAction(unsetFiducialAction);
+  QObject::connect(unsetFiducialAction, SIGNAL(triggered()),
+      this, SLOT(onUnsetMarkupPushButtonClicked()));
 
   menu.addSeparator();
   this->addSelectedCoordinatesToMenu(&menu);

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -1569,10 +1569,10 @@ void qSlicerMarkupsModuleWidget::onDeleteMarkupPushButtonClicked(bool confirm /*
   if (confirm)
     {
     ctkMessageBox deleteAllMsgBox;
-    deleteAllMsgBox.setWindowTitle("Delete Markups in this list?");
+    deleteAllMsgBox.setWindowTitle("Delete control points in this list?");
     QString labelText = QString("Delete ")
       + QString::number(rows.size())
-        + QString(" Markups from this list?");
+        + QString(" control points from this list?");
     // don't show again check box conflicts with informative text, so use
     // a long text
     deleteAllMsgBox.setText(labelText);


### PR DESCRIPTION
Originally from discussion starting at https://discourse.slicer.org/t/changes-to-the-markups-module/19871/3?u=jamesobutler

"Clear" is chosen over "Unset" since it is less technical. Action order is based on the cycle order when click in the position status column of the markups control point table.

| Current | This PR |
|----------|---------|
| ![image](https://user-images.githubusercontent.com/15837524/135353453-fecd3318-5cf7-40e8-a6e8-c34011e5dec3.png)| ![image](https://user-images.githubusercontent.com/15837524/135353330-bf9ee5cd-2885-494b-96a0-3936350a31b0.png)|
|![image](https://user-images.githubusercontent.com/15837524/135351384-e9c090ea-6880-4e68-a7c7-d7951b08aa5a.png)|![image](https://user-images.githubusercontent.com/15837524/135353255-f23b08b8-8708-4186-a9b1-b19ba1ab57c5.png)|

Also including minor commit `STYLE: Use control point terminology in context menu` which should been included in 1669e8c94d54d6763e381e837ae90113ed31deb7 as it relates to consistently using the "control point" terminology rather than "point" or some other incorrect uses such as "fiducial" or "markup".

| Current | This PR |
|----------|---------|
|![image](https://user-images.githubusercontent.com/15837524/135354587-5d57f5d4-4a88-41e2-9ab9-3569d19c785c.png)|![image](https://user-images.githubusercontent.com/15837524/135354613-928c0f8a-65ca-4d5b-a3fa-29fecb3c2193.png)|

`STYLE: Use correct control point terminology in dialog`
| Current | This PR |
|----------|---------|
|![image](https://user-images.githubusercontent.com/15837524/135382718-808005cf-b169-40a0-b104-374c0cdf95ae.png)|![image](https://user-images.githubusercontent.com/15837524/135382682-6b3f6d31-71ed-4994-b099-4e3e58265353.png)|
