### PR TITLE
BUG: Fix crash in Markups storage node if setting point beyond maximum

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -304,6 +304,12 @@ bool vtkMRMLMarkupsFiducialStorageNode::SetPointFromString(vtkMRMLMarkupsNode *m
     return false;
     }
 
+  if (pointIndex >= markupsNode->GetMaximumNumberOfControlPoints())
+    {
+    vtkGenericWarningMacro("vtkMRMLMarkupsFiducialStorageNode::SetMarkupFromString failed: index beyond control point maximum");
+    return false;
+    }
+
   if (this->GetCoordinateSystem() != vtkMRMLStorageNode::CoordinateSystemRAS
     && this->GetCoordinateSystem() != vtkMRMLStorageNode::CoordinateSystemLPS)
     {
@@ -397,6 +403,12 @@ bool vtkMRMLMarkupsFiducialStorageNode::SetPointFromString(vtkMRMLMarkupsNode *m
     {
     vtkVector3d point(0, 0, 0);
     markupsNode->AddControlPoint(point);
+    }
+
+  if (markupsNode->GetNthControlPoint(pointIndex) == nullptr)
+    {
+    vtkGenericWarningMacro("vtkMRMLMarkupsFiducialStorageNode::SetMarkupFromString failed: could not get/add control point");
+    return false;
     }
 
   if (id.empty())


### PR DESCRIPTION
Calling vtkMRMLMarkupsFiducialStorageNode::SetPointFromString() with an index beyond the maximum number of control points would result in a crash. To reproduce, place a line and then copy+paste a control point using the Markups module widget.

Fixed by checking that the specified index is under the maximum, and that the control point exists before attempting to access it.