### PR TITLE
Update python packages to latest Sept 2021

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -122,7 +122,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "v2.1.0"
+    "v2.1.1"
     QUIET
     )
 

--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -41,18 +41,20 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pydicom]
-  pydicom==2.1.2 --hash=sha256:d97f53a7b269dbd7414d18342f1b70f80d7d35dc4e479316bab146daac0e0c15
+  pydicom==2.2.1 --hash=sha256:444b5b7289135ff5ea76dfc69d3597dcfde1cd050ca387f709d777f35701242d
   # [/pydicom]
   # [Pillow]
   # Hashes correspond to the following packages:
-  #  - Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl
-  #  - Pillow-8.2.0-cp36-cp36m-manylinux1_x86_64.whl
-  #  - Pillow-8.2.0-cp36-cp36m-manylinux2014_aarch64.whl
-  #  - Pillow-8.2.0-cp36-cp36m-win_amd64.whl
-  Pillow==8.2.0 --hash=sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9 \
-                --hash=sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b \
-                --hash=sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9 \
-                --hash=sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f
+  #  - Pillow-8.3.2-cp36-cp36m-macosx_10_10_x86_64.whl
+  #  - Pillow-8.3.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - Pillow-8.3.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
+  #  - Pillow-8.3.2-cp36-cp36m-win_amd64.whl
+  Pillow==8.3.2 --hash=sha256:11eb7f98165d56042545c9e6db3ce394ed8b45089a67124298f0473b29cb60b2 \
+                --hash=sha256:2f23b2d3079522fdf3c09de6517f625f7a964f916c956527bed805ac043799b8 \
+                --hash=sha256:e5a31c07cea5edbaeb4bdba6f2b87db7d3dc0f446f379d907e51cc70ea375629 \
+                --hash=sha256:8f284dc1695caf71a74f24993b7c7473d77bc760be45f776a2c2f4e04c170550 \
+                --hash=sha256:a048dad5ed6ad1fad338c02c609b862dfaa921fcd065d747194a6805f91f2196
   # [/Pillow]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
@@ -61,7 +63,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b
   # [/retrying]
   # [dicomweb-client]
-  dicomweb-client==0.52.0 --hash=sha256:2fd1e6f599198246ca082f25561dce406d9ec32fda0bcec757910c79481e54c9
+  dicomweb-client==0.53.0 --hash=sha256:f68434122d1ec02fdb35e37ce355d8c511183d79f1752b50cf53517c6d9be1d0
   # [/dicomweb-client]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -46,10 +46,10 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   smmap==4.0.0 --hash=sha256:a9a7479e4c572e2e775c404dcd3080c8dc49f39918c2cf74913d30c4c478e3c2
   # [/smmap]
   # [typing-extensions]
-  typing-extensions==3.10.0.0 --hash=sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84
+  typing-extensions==3.10.0.2 --hash=sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34
   # [/typing-extensions]
   # [GitPython]
-  GitPython==3.1.17 --hash=sha256:29fe82050709760081f588dd50ce83504feddbebdc4da6956d02351552b1c135
+  GitPython==3.1.18 --hash=sha256:fce760879cd2aebd2991b3542876dc5c4a909b30c9d69dfc488e504a8db37ee8
   # [/GitPython]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -39,7 +39,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   wrapt==1.12.1 --hash=sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7
   # [/wrapt]
   # [Deprecated]
-  Deprecated==1.2.12 --hash=sha256:08452d69b6b5bc66e8330adde0a4f8642e969b9e1702904d137eeb29c8ffc771
+  Deprecated==1.2.13 --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
   # [/Deprecated]
   # [PyGithub]
   PyGithub==1.54.1 --hash=sha256:87afd6a67ea582aa7533afdbf41635725f13d12581faed7e3e04b1579c0c0627

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==21.1.2 --hash=sha256:f8ea1baa693b61c8ad1c1d8715e59ab2b93cd3c4769bacab84afcc4279e7a70e
+  pip==21.2.4 --hash=sha256:fa9ebb85d3fd607617c0c44aca302b1b45d87f9c2a1649b46c26167ca4296323
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -32,7 +32,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [packaging]
-  packaging==20.9 --hash=sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a
+  packaging==21.0 --hash=sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14
   # [/packaging]
   # [pyparsing]
   pyparsing==2.4.7 --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -30,16 +30,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   certifi==2021.5.30 --hash=sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8
   # [/certifi]
   # [idna]
-  idna==2.10 --hash=sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0
+  idna==3.2 --hash=sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a
   # [/idna]
-  # [chardet]
-  chardet==4.0.0 --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
-  # [/chardet]
+  # [charset_normalizer]
+  charset_normalizer==2.0.6 --hash=sha256:5d209c0a931f215cee683b6445e2d77677e7e75e159f78def0db09d68fafcaa6
+  # [/charset_normalizer]
   # [urllib3]
-  urllib3==1.26.5 --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c
+  urllib3==1.26.7 --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
   # [/urllib3]
   # [requests]
-  requests==2.25.1 --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
+  requests==2.26.0 --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24
   # [/requests]
   ]===])
 

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==57.0.0 --hash=sha256:c8b9f1a457949002e358fea7d3f2a1e1b94ddc0354b2e40afc066bf95d21bf7b
+  setuptools==58.1.0 --hash=sha256:7324fd4b66efa05cdfc9c89174573a4410acc7848f318cc0565c7fb659dfdc81
   # [/setuptools]
   ]===])
 

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [wheel]
-  wheel==0.36.2 --hash=sha256:78b5b185f0e5763c26ca1e324373aadd49182ca90e825f7853f4b2509215dc0e
+  wheel==0.37.0 --hash=sha256:21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd
   # [/wheel]
   ]===])
 

--- a/Utilities/Scripts/SlicerWizard/Utilities.py
+++ b/Utilities/Scripts/SlicerWizard/Utilities.py
@@ -25,7 +25,7 @@ def haveGit():
   return _haveGit
 
 try:
-  import chardet
+  from charset_normalizer import detect
   _haveCharDet = True
 
 except ImportError:
@@ -239,7 +239,7 @@ def detectEncoding(data):
   """
 
   if _haveCharDet:
-    result = chardet.detect(data)
+    result = detect(data)
     return result["encoding"], result["confidence"]
 
   else:


### PR DESCRIPTION
Python packages were last updated June 15th, 2021. Outdated python packages were discovered and updated using the python_package_updater.py script in the Slicer repo and then dependencies new/conflicting were manually reviewed.

```
PS C:\Users\JamesButler\AppData\Local\NA-MIC\Slicer 4.13.0-2021-09-27\bin> ./PythonSlicer "C:\Users\JamesButler\Documents\GitHub\Slicer\Utilities\Scripts\python_package_updater.py"
WARNING: You are using pip version 21.1.2; however, version 21.2.4 is available.
You should consider upgrading via the 'C:\Users\JamesButler\AppData\Local\NA-MIC\Slicer 4.13.0-2021-09-27\bin\python-real.exe -m pip install --upgrade pip' command.
Package           Version  Latest   Type
----------------- -------- -------- -----
Deprecated        1.2.12   1.2.13   wheel
dicomweb-client   0.52.0   0.53.0   wheel
GitPython         3.1.17   3.1.18   wheel
idna              2.10     3.2      wheel
packaging         20.9     21.0     wheel
Pillow            8.2.0    8.3.2    wheel
pip               21.1.2   21.2.4   wheel
pydicom           2.1.2    2.2.1    wheel
PyGithub          1.54.1   1.55     wheel
PyJWT             1.7.1    2.1.0    wheel
requests          2.25.1   2.26.0   wheel
setuptools        57.0.0   58.1.0   wheel
simpleitk         2.1.0    2.1.1    wheel
typing-extensions 3.10.0.0 3.10.0.2 wheel
urllib3           1.26.5   1.26.7   wheel
wheel             0.36.2   0.37.0   wheel

  Deprecated==1.2.13 --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
  dicomweb-client==0.53.0 --hash=sha256:f68434122d1ec02fdb35e37ce355d8c511183d79f1752b50cf53517c6d9be1d0
  GitPython==3.1.18 --hash=sha256:fce760879cd2aebd2991b3542876dc5c4a909b30c9d69dfc488e504a8db37ee8
  idna==3.2 --hash=sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a
  packaging==21.0 --hash=sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14
  # Hashes correspond to the following packages:
  #  - Pillow-8.3.2-cp36-cp36m-macosx_10_10_x86_64.whl
  #  - Pillow-8.3.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - Pillow-8.3.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
  #  - Pillow-8.3.2-cp36-cp36m-win_amd64.whl
  Pillow==8.3.2 --hash=sha256:11eb7f98165d56042545c9e6db3ce394ed8b45089a67124298f0473b29cb60b2 \
                --hash=sha256:2f23b2d3079522fdf3c09de6517f625f7a964f916c956527bed805ac043799b8 \
                --hash=sha256:e5a31c07cea5edbaeb4bdba6f2b87db7d3dc0f446f379d907e51cc70ea375629 \
                --hash=sha256:8f284dc1695caf71a74f24993b7c7473d77bc760be45f776a2c2f4e04c170550 \
                --hash=sha256:a048dad5ed6ad1fad338c02c609b862dfaa921fcd065d747194a6805f91f2196
  pip==21.2.4 --hash=sha256:fa9ebb85d3fd607617c0c44aca302b1b45d87f9c2a1649b46c26167ca4296323
  pydicom==2.2.1 --hash=sha256:444b5b7289135ff5ea76dfc69d3597dcfde1cd050ca387f709d777f35701242d
  PyGithub==1.55 --hash=sha256:2caf0054ea079b71e539741ae56c5a95e073b81fa472ce222e81667381b9601b
  PyJWT==2.1.0 --hash=sha256:934d73fbba91b0483d3857d1aff50e96b2a892384ee2c17417ed3203f173fca1
  requests==2.26.0 --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24
  setuptools==58.1.0 --hash=sha256:7324fd4b66efa05cdfc9c89174573a4410acc7848f318cc0565c7fb659dfdc81
  typing-extensions==3.10.0.2 --hash=sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34
  urllib3==1.26.7 --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844
  wheel==0.37.0 --hash=sha256:21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd
```

- Did not upgrade `PyGithub` to 1.55 because it introduces a new dependency `PyNaCl` that only has wheels for the Windows platform for the Python 3.6 version. Continuing to stay with `PyGithub` 1.54.1 means we must continue to use `PyJWT`<2.

Packages I'm unable to upgrade to their latest release because they dropped support for Python 3.6 (see https://github.com/Slicer/Slicer/issues/5014#issuecomment-742599890):
- `numpy` >= v1.20.0
- `scipy` >= v1.6.0
- `GitPython` >= 3.1.22 