### PR TITLE
BUG: Fix control point copy paste with 0 maximum control points

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -53,7 +53,7 @@ void vtkMRMLMarkupsFiducialNode::WriteXML(ostream& of, int nIndent)
 //----------------------------------------------------------------------------
 void vtkMRMLMarkupsFiducialNode::ReadXMLAttributes(const char** atts)
 {
-  int disabledModify = this->StartModify();
+  MRMLNodeModifyBlocker blocker(this);
 
   Superclass::ReadXMLAttributes(atts);
 
@@ -62,7 +62,12 @@ void vtkMRMLMarkupsFiducialNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLIntMacro(requiredNumberOfControlPoints, RequiredNumberOfControlPoints);
   vtkMRMLReadXMLEndMacro();
 
-  this->EndModify(disabledModify);
+  // In scenes created by Slicer version version 4.13.0 revision 30287 (built 2021 - 10 - 05).
+  // The value used to represent unlimited control points has been changed to -1.
+  if (this->MaximumNumberOfControlPoints == 0)
+    {
+    this->MaximumNumberOfControlPoints = -1;
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -62,7 +62,7 @@ void vtkMRMLMarkupsFiducialNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLIntMacro(requiredNumberOfControlPoints, RequiredNumberOfControlPoints);
   vtkMRMLReadXMLEndMacro();
 
-  // In scenes created by Slicer version version 4.13.0 revision 30287 (built 2021 - 10 - 05).
+  // In scenes created by Slicer version version 4.13.0 revision 30287 (built 2021-10-05).
   // The value used to represent unlimited control points has been changed to -1.
   if (this->MaximumNumberOfControlPoints == 0)
     {

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -304,7 +304,7 @@ bool vtkMRMLMarkupsFiducialStorageNode::SetPointFromString(vtkMRMLMarkupsNode *m
     return false;
     }
 
-  if (pointIndex >= markupsNode->GetMaximumNumberOfControlPoints())
+  if (markupsNode->GetMaximumNumberOfControlPoints() >= 0 && pointIndex >= markupsNode->GetMaximumNumberOfControlPoints())
     {
     vtkGenericWarningMacro("vtkMRMLMarkupsFiducialStorageNode::SetMarkupFromString failed: index beyond control point maximum");
     return false;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -300,7 +300,7 @@ void vtkMRMLMarkupsNode::PrintSelf(ostream& os, vtkIndent indent)
   os << this->GetFixedNumberOfControlPoints() << "\n";
 
   os << indent << "MaximumNumberOfControlPoints: ";
-  if (this->MaximumNumberOfControlPoints>0)
+  if (this->MaximumNumberOfControlPoints >= 0)
     {
     os << this->MaximumNumberOfControlPoints << "\n";
     }
@@ -580,7 +580,7 @@ std::vector< vtkMRMLMarkupsNode::ControlPoint* > * vtkMRMLMarkupsNode::GetContro
 //-----------------------------------------------------------
 int vtkMRMLMarkupsNode::AddControlPoint(ControlPoint *controlPoint, bool autoLabel/*=true*/)
 {
-  if (this->MaximumNumberOfControlPoints != 0 &&
+  if (this->MaximumNumberOfControlPoints >= 0 &&
       this->GetNumberOfControlPoints() + 1 > this->MaximumNumberOfControlPoints)
     {
     vtkErrorMacro("AddNControlPoints: number of points major than maximum number of control points allowed.");
@@ -642,7 +642,7 @@ int vtkMRMLMarkupsNode::AddNControlPoints(int n, std::string label /*=std::strin
     return -1;
     }
 
-  if (this->MaximumNumberOfControlPoints != 0 &&  this->GetNumberOfControlPoints() + n > this->MaximumNumberOfControlPoints)
+  if (this->MaximumNumberOfControlPoints >= 0 && this->GetNumberOfControlPoints() + n > this->MaximumNumberOfControlPoints)
     {
     vtkErrorMacro("AddNControlPoints: number of existing points (" << this->GetNumberOfControlPoints()
       << ") plus requested number of new points (" << n << ") are more than maximum number of control points allowed ("

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -749,7 +749,7 @@ protected:
   int RequiredNumberOfControlPoints{0};
   /// Used for limiting number of control points that may be placed.
   /// This is a hard limit at which new control points cannot be added.
-  int MaximumNumberOfControlPoints{0};
+  int MaximumNumberOfControlPoints{-1};
 
   bool CurveClosed{false};
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
@@ -44,7 +44,7 @@
 #include <vtkTransformPolyDataFilter.h>
 
 const int NUMBER_OF_BOX_CONTROL_POINTS = 2; // 2 points used for initial ROI definition, then removed
-const int NUMBER_OF_BOUNDING_BOX_CONTROL_POINTS = 1e6; // Any number of points
+const int NUMBER_OF_BOUNDING_BOX_CONTROL_POINTS = -1; // Any number of points
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLMarkupsROINode);
@@ -55,7 +55,7 @@ vtkMRMLMarkupsROINode::vtkMRMLMarkupsROINode()
   this->PropertiesLabelText = "";
 
   this->RequiredNumberOfControlPoints = NUMBER_OF_BOX_CONTROL_POINTS;
-  this->MaximumNumberOfControlPoints = 0;
+  this->MaximumNumberOfControlPoints = -1;
   this->IsUpdatingControlPointsFromROI = false;
   this->IsUpdatingROIFromControlPoints = false;
 
@@ -517,7 +517,7 @@ void vtkMRMLMarkupsROINode::SetROIType(int roiType)
     {
     case vtkMRMLMarkupsROINode::ROITypeBox:
       this->RequiredNumberOfControlPoints = NUMBER_OF_BOX_CONTROL_POINTS;
-      this->MaximumNumberOfControlPoints = 0;
+      this->MaximumNumberOfControlPoints = -1;
       break;
     case vtkMRMLMarkupsROINode::ROITypeBoundingBox:
       this->RequiredNumberOfControlPoints = NUMBER_OF_BOUNDING_BOX_CONTROL_POINTS;

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
@@ -847,7 +847,7 @@ vtkSlicerMarkupsWidget* vtkMRMLMarkupsDisplayableManager::GetWidgetForPlacement(
       }
     }
 
-  if (activeMarkupsNode && activeMarkupsNode->GetMaximumNumberOfControlPoints() > 0
+  if (activeMarkupsNode && activeMarkupsNode->GetMaximumNumberOfControlPoints() >= 0
     && activeMarkupsNode->GetNumberOfDefinedControlPoints() >= activeMarkupsNode->GetMaximumNumberOfControlPoints())
     {
     // maybe reached maximum number of points - if yes, then create a new widget

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
@@ -94,7 +94,7 @@ int TestStoragNode(vtkMRMLMarkupsNode* markupsNode, vtkMRMLMarkupsStorageNode* s
   int emptyLabelIndex = -1;
   int commaIndex = -1;
   int quotesIndex = -1;
-  bool testManyPoints = markupsNode->GetMaximumNumberOfControlPoints() <= 0 || markupsNode->GetMaximumNumberOfControlPoints() > 5;
+  bool testManyPoints = markupsNode->GetMaximumNumberOfControlPoints() < 0 || markupsNode->GetMaximumNumberOfControlPoints() > 5;
   if (testManyPoints)
     {
     // and another one unsetting the label

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -1477,8 +1477,8 @@ void qSlicerMarkupsModuleWidget::onAddMarkupPushButtonClicked()
     return;
     }
   // get the active node
-  bool definedStatus = d->MarkupsNode->GetMaximumNumberOfControlPoints() != 0;
-  if ((d->MarkupsNode->GetNumberOfControlPoints() >= d->MarkupsNode->GetMaximumNumberOfControlPoints()) && definedStatus)
+  if ((d->MarkupsNode->GetNumberOfControlPoints() >= d->MarkupsNode->GetMaximumNumberOfControlPoints()) &&
+       d->MarkupsNode->GetMaximumNumberOfControlPoints() >= 0)
     {
     return;
     }


### PR DESCRIPTION
Fixes a bug introduced by the fix in 1b21b7208594f3b6c1ed387ae648c3e9d757f1d0.
Pasting a control point from the Markups module widget would be prevented in markups nodes that had MaximumNumberOfControlPoints of 0.
Fixed by also checking that MaximumNumberOfControlPoints is greater than 0 before returning.