### PR TITLE
BUG: Fix slice intersection representation point default case

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
@@ -632,8 +632,8 @@ double* vtkMRMLSliceIntersectionRepresentation2D::GetSliceIntersectionPoint()
     // No slice intersections, use slice centerpoint
     int* sliceDimension = this->Internal->SliceNode->GetDimensions();
     this->SliceIntersectionPoint[0] = sliceDimension[0] / 2.0;
-    this->SliceIntersectionPoint[0] = sliceDimension[1] / 2.0;
-    this->SliceIntersectionPoint[0] = 0.0;
+    this->SliceIntersectionPoint[1] = sliceDimension[1] / 2.0;
+    this->SliceIntersectionPoint[2] = 0.0;
     }
   return this->SliceIntersectionPoint;
 }


### PR DESCRIPTION
When no intersection point was detected, return the center of slice view.
But the index was wrong before