### PR TITLE
COMP: Support VS2022 (v143 toolset) compiling against TBB built with VS2015

### DIFF
--- a/SuperBuild/External_tbb.cmake
+++ b/SuperBuild/External_tbb.cmake
@@ -50,6 +50,9 @@ if (WIN32)
   elseif (NOT MSVC_VERSION VERSION_GREATER 1929)
     # VS2019 is expected to be binary compatible with VS2015
     set(tbb_vsdir vc14)
+  elseif (NOT MSVC_VERSION VERSION_GREATER 1939)
+    # VS2022 is expected to be binary compatible with VS2015
+    set(tbb_vsdir vc14)
   elseif (tbb_enabled)
     message(FATAL_ERROR "TBB does not support your Visual Studio compiler. [MSVC_VERSION: ${MSVC_VERSION}]")
   endif ()


### PR DESCRIPTION
Visual Studio 2022 with toolset v143 is to be ABI compatible with older toolsets back to Visual Studio 2015 v140 toolset.  This allows for Slicer to start successfully after building with the v143 toolset currently included with Visual Studio 2022 Preview 4.1.