### PR TITLE
ENH: Remove unnecessary axes labels reset in MRML

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -243,11 +243,6 @@ void vtkMRMLAbstractViewNode::Reset(vtkMRMLNode* defaultNode)
   this->DisableModifiedEventOn();
   this->SetLayoutLabel(layoutLabel.c_str());
   this->SetViewGroup(viewGroup);
-  this->AxisLabels->Reset();
-  for (int i=0; i<vtkMRMLAbstractViewNode::AxisLabelsCount; i++)
-    {
-    this->AxisLabels->InsertNextValue(DEFAULT_AXIS_LABELS[i]);
-    }
   this->DisableModifiedEventOff();
 }
 


### PR DESCRIPTION
Removed lines are excessive and moreover they makes this function inapropriate to use in any SlicerCAT that uses other axes labels than medical (XYZ for example). 
Axes labels are set from default node via `Superclass::Reset(defaultNode)`