### PR TITLE
BUG: Workaround for Slicer startup hang on Windows11

### DIFF
--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -52,6 +52,20 @@ for kit in available_kits:
   del kit
 
 #-----------------------------------------------------------------------------
+# Import numpy early, as a workaround for application startup hang on Windows11
+# due to output redirection (only needed for embedded Python, not for standalone).
+# See details in https://github.com/Slicer/Slicer/issues/5945
+# While the workaroudn is only needed for Windows11, it is performed on
+# all operating systems to minimize differences of the startup process
+# between different platforms.
+
+if not standalone_python:
+  try:
+    import numpy
+  except ImportError as detail:
+    print(detail)
+
+#-----------------------------------------------------------------------------
 # Cleanup: Removing things the user shouldn't have to see.
 
 del _createModule


### PR DESCRIPTION
numpy has to be loaded early to avoid hang when loading openblas library.
This is a temporary workaround and may be removed if the related issue is fixed in Windows11 or numpy (or we find a nicer solution in Slicer).

fixes https://github.com/Slicer/Slicer/issues/5945