### PR TITLE
ENH: Add custom lib `_INCLUDE_DIRS` to `SlicerConfig.cmake`

### DIFF
--- a/CMake/SlicerConfig.cmake.in
+++ b/CMake/SlicerConfig.cmake.in
@@ -217,6 +217,9 @@ set(Slicer_Libs_VTK_WRAPPED_LIBRARIES "@Slicer_Libs_VTK_WRAPPED_LIBRARIES@")
 # Slicer VTK version
 set(Slicer_VTK_VERSION_MAJOR "@Slicer_VTK_VERSION_MAJOR@")
 
+# Slicer include directories for custom targets
+@Slicer_INCLUDE_CUSTOM_TARGET_DIRS_CONFIG@
+
 # Slicer include directories for module
 @Slicer_INCLUDE_MODULE_DIRS_CONFIG@
 

--- a/CMake/SlicerGenerateSlicerConfig.cmake
+++ b/CMake/SlicerGenerateSlicerConfig.cmake
@@ -46,6 +46,17 @@ set(Slicer_EXTENSION_CPACK_BUNDLE_FIXUP_CONFIG ${Slicer_SOURCE_DIR}/CMake/Slicer
 set(Slicer_GUI_LIBRARY_CONFIG ${Slicer_GUI_LIBRARY})
 set(Slicer_CORE_LIBRARY_CONFIG ${Slicer_CORE_LIBRARY})
 
+get_property(_custom_targets GLOBAL PROPERTY SLICER_CUSTOM_TARGETS)
+if(_custom_targets)
+  foreach(target ${_custom_targets})
+    set(Slicer_INCLUDE_CUSTOM_TARGET_DIRS_CONFIG
+"${Slicer_INCLUDE_CUSTOM_TARGET_DIRS_CONFIG}
+set(${target}_INCLUDE_DIRS
+  \"${${target}_INCLUDE_DIRS}\")"
+)
+  endforeach()
+endif()
+
 get_property(_module_targets GLOBAL PROPERTY SLICER_MODULE_TARGETS)
 if(_module_targets)
   foreach(target ${_module_targets})

--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -103,6 +103,16 @@ macro(slicerMacroBuildAppLibrary)
   # Include dirs
   # --------------------------------------------------------------------------
 
+  if(NOT DEFINED ${lib_name}_SOURCE_DIR)
+    set(${lib_name}_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "" FORCE)
+  endif()
+
+  if(NOT DEFINED ${lib_name}_BINARY_DIR)
+    set(${lib_name}_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "" FORCE)
+  endif()
+
+  set(${lib_name}_INCLUDE_DIRS ${${lib_name}_SOURCE_DIR} ${${lib_name}_BINARY_DIR} CACHE INTERNAL "" FORCE)
+
   set(include_dirs
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
@@ -218,9 +228,11 @@ macro(slicerMacroBuildAppLibrary)
     ${SLICERAPPLIB_TARGET_LIBRARIES}
     )
 
+  set_property(GLOBAL APPEND PROPERTY SLICER_CUSTOM_TARGETS ${SLICERAPPLIB_NAME})
+
   # Folder
   set_target_properties(${lib_name} PROPERTIES FOLDER ${SLICERAPPLIB_FOLDER})
-
+  
   #-----------------------------------------------------------------------------
   # Install library
   #-----------------------------------------------------------------------------


### PR DESCRIPTION
The commit introduces new target type `SLICER_CUSTOM_TARGETS`.
SlicerCAT lib (`slicerMacroBuildApplication()`) is  an example of that.
It adds `${lib_name}_INCLUDE_DIRS` to the `SlicerConfig.cmake`.
This allow to easilly link to the library from external modules.

It also possible to set this prop to any custom lib target, set `${lib_name}_INCLUDE_DIRS` cache var and then this `_INCLUDE_DIRS` var will be added to `SlicerConfig.cmake`. This makes possible to easilly add custom libraries and link to them from external modules.