### PR TITLE
COMP: Update VTK to fix configuration of projects indirectly depending on VTK

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -177,7 +177,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "558ee1c5be28853cf2316bc3dcc75dc66bf81243") # slicer-v9.0.20201111-733234c785-3
+    set(_git_tag "558ee1c5be28853cf2316bc3dcc75dc66bf81243") # slicer-v9.0.20201111-733234c785-v3
     set(vtk_egg_info_version "9.0.20201111")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of changes:

```
$ git shortlog a271aa9067..558ee1c5be --no-merges
Ben Boeckel (1):
      [Backport MR-8554] vtkInstallCMakePackageHelpers: help with Python packages
```

Fixes #5498