### PR TITLE
Markups context menu specific text based on type and improved options based on active selection

### DIFF
--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -666,10 +666,14 @@ void qSlicerSubjectHierarchyMarkupsPlugin::showViewContextMenuActionsForItem(vtk
   d->JumpToClosestPointAction->setVisible(componentType == vtkMRMLMarkupsDisplayNode::ComponentLine
     && d->ViewContextMenuEventData.find("WorldPosition") != d->ViewContextMenuEventData.end());
 
-  if (componentType == vtkMRMLMarkupsDisplayNode::ComponentControlPoint)
+  bool isControlPoint = componentType == vtkMRMLMarkupsDisplayNode::ComponentControlPoint;
+  d->RenamePointAction->setVisible(isControlPoint);
+  d->ToggleSelectPointAction->setVisible(isControlPoint);
+  d->DeletePointAction->setVisible(isControlPoint);
+  d->JumpToPreviousPointAction->setVisible(isControlPoint);
+  d->JumpToNextPointAction->setVisible(isControlPoint);
+  if (isControlPoint)
     {
-    d->JumpToPreviousPointAction->setVisible(true);
-    d->JumpToNextPointAction->setVisible(true);
     d->JumpToPreviousPointAction->setEnabled(false);
     d->JumpToNextPointAction->setEnabled(false);
     int currentControlPointIndex = d->ViewContextMenuEventData["ComponentIndex"].toInt();
@@ -695,11 +699,6 @@ void qSlicerSubjectHierarchyMarkupsPlugin::showViewContextMenuActionsForItem(vtk
         break;
         }
       }
-    }
-  else
-    {
-    d->JumpToPreviousPointAction->setVisible(false);
-    d->JumpToNextPointAction->setVisible(false);
     }
 
   d->EditNodeTerminologyAction->setVisible(!pointActionsDisabled);


### PR DESCRIPTION
Originally discussed over at https://discourse.slicer.org/t/ambiguous-control-point-in-right-click-context-menu/20274

| | Before | This PR |
|-|---------|---------|
|Right-click point|![image](https://user-images.githubusercontent.com/15837524/138571657-98c0ed20-90ad-4aa8-a478-11dfe2444c64.png)|![image](https://user-images.githubusercontent.com/15837524/138571663-04f5ab62-6b76-4080-a4b8-ee80051ba1a4.png)|
|Right-click node|![image](https://user-images.githubusercontent.com/15837524/138571682-47a484de-454b-44a1-b8db-8a2abaf2eb3c.png)|![image](https://user-images.githubusercontent.com/15837524/138571688-ed341910-1cdc-4dbc-8196-12a796ab2d63.png)|

