### PR TITLE
ENH: Intuitive volume presets

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
@@ -7,6 +7,7 @@ set(${KIT}_EXPORT_DIRECTIVE "Q_SLICER_MODULE_${MODULE_NAME_UPPER}_WIDGETS_EXPORT
 set(${KIT}_INCLUDE_DIRECTORIES
   ${vtkSlicerSubjectHierarchyModuleLogic_INCLUDE_DIRS}
   ${qSlicerTerminologiesModuleWidgets_INCLUDE_DIRS}
+  ${vtkSlicerVolumesModuleLogic_INCLUDE_DIRS}
   ${MRMLCore_INCLUDE_DIRS}
   )
 if(Slicer_BUILD_CLI_SUPPORT)
@@ -95,6 +96,7 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleLogic
   qSlicerTerminologiesModuleWidgets
   MRMLCore
+  vtkSlicerVolumesModuleLogic
   )
 if(Slicer_BUILD_CLI_SUPPORT)
   list(APPEND ${KIT}_TARGET_LIBRARIES

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
@@ -50,6 +50,15 @@ public:
 
 public:
 
+  enum {
+       ID_CTBone,
+       ID_CTAir,
+       ID_PET,
+       ID_CTAbdomen,
+       ID_CTBrain,
+       ID_CTLung,
+       ID_DTI,
+  };
   /// Get view context menu item actions that are available when right-clicking an object in the views.
   /// These item context menu actions can be shown in the implementations of \sa showViewContextMenuActionsForItem
   QList<QAction*> viewContextMenuActions()const override;
@@ -64,6 +73,7 @@ protected slots:
   void saveScreenshot();
   void configureSliceViewAnnotationsAction();
   void maximizeView();
+  void setVolumePreset(int which);
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyViewContextMenuPluginPrivate> d_ptr;

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
@@ -35,6 +35,9 @@
 #include <cstdlib>
 #include <list>
 
+// QT includes
+#include <QString>
+
 #include "vtkSlicerVolumesModuleLogicExport.h"
 
 class vtkMRMLLabelMapVolumeNode;
@@ -279,6 +282,13 @@ public:
   /// value is set when setting the compare volume geometry epsilon.
   /// \sa SetCompareVolumeGeometryEpsilon
   vtkGetMacro(CompareVolumeGeometryPrecision, int);
+
+  ///  Method to set Window/level
+  bool SetVolumeWindowLevel(vtkMRMLScalarVolumeNode* volumeNode, double window, double level, bool isAutoWindowLevel);
+  ///  Method to set Window/level presets according to predefined strings
+  void setWindowLevelPreset(vtkMRMLScalarVolumeNode* volumeNode, const QString& presetName);
+  ///  Method to set color node
+  void setColorNode(vtkMRMLNode* colorNode);
 
 protected:
   vtkSlicerVolumesLogic();


### PR DESCRIPTION
Add functionality to display volume presets from the slice view right-click menu.  
Do not display the preset menu in 3D view.   
Let it only display if a scalarvolume is displayed in slice view.   
Make the presets checkable and setcheck(true) them upon selection  
Make this work even if several scalar volumes are loaded.  
Set the presets by a function call to  [Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx](https://github.com/Slicer/Slicer/compare/master...rbumm:master#diff-e66332c76fe962dd310d54e008ed379b062f3fec8a74f0969d4706d96b362ad4) 

To do:

find a way to define a default window/level preset that the user can define by special action and that be used as default upon every start of Slicer.  

Limitations:

*   qSlicerScalarVolumeDisplayWidget has still its hard coded setPreset() function, pls advise what to do here
*   setting the colornode seems to have different results if done from the right click menu compared to qSlicerScalarVolumeDisplayWidget.