### PR TITLE
ENH: Add intuitive volume presets

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeNode.cxx
@@ -124,7 +124,7 @@ void vtkMRMLScalarVolumeNode::CreateNoneNode(vtkMRMLScene *scene)
 //----------------------------------------------------------------------------
 vtkMRMLScalarVolumeDisplayNode* vtkMRMLScalarVolumeNode::GetScalarVolumeDisplayNode()
 {
-  return vtkMRMLScalarVolumeDisplayNode::SafeDownCast(this->GetDisplayNode());
+  return vtkMRMLScalarVolumeDisplayNode::SafeDownCast(this->GetVolumeDisplayNode());
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -1186,9 +1186,13 @@ bool vtkMRMLSliceIntersectionWidget::ProcessWidgetMenu(vtkMRMLInteractionEventDa
   vtkNew<vtkMRMLInteractionEventData> pickEventData;
   pickEventData->SetType(vtkMRMLInteractionNode::ShowViewContextMenuEvent);
   pickEventData->SetViewNode(this->SliceNode);
-  if (pickEventData->IsDisplayPositionValid())
+  if (eventData->IsDisplayPositionValid())
     {
     pickEventData->SetDisplayPosition(eventData->GetDisplayPosition());
+    }
+  if (eventData->IsWorldPositionValid())
+    {
+    pickEventData->SetWorldPosition(eventData->GetWorldPosition(), eventData->IsWorldPositionAccurate());
     }
   interactionNode->ShowViewContextMenu(pickEventData);
   return true;

--- a/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
@@ -394,77 +394,19 @@ void vtkMRMLWindowLevelWidget::ProcessAdjustWindowLevel(vtkMRMLInteractionEventD
 //----------------------------------------------------------------------------
 int vtkMRMLWindowLevelWidget::GetEditableLayerAtEventPosition(vtkMRMLInteractionEventData* eventData)
 {
-  vtkMRMLSliceLogic* sliceLogic = this->GetSliceLogic();
-  if (!sliceLogic)
+  double worldPos[3] = { 0.0, 0.0, 0.0 };
+  eventData->GetWorldPosition(worldPos);
+  if (!eventData->IsWorldPositionValid())
     {
+    vtkErrorMacro("vtkMRMLWindowLevelWidget::GetEditableLayerAtEventPosition failed: invalid world position");
     return vtkMRMLSliceLogic::LayerNone;
     }
-  vtkMRMLSliceNode *sliceNode = this->SliceLogic->GetSliceNode();
-  if (!sliceNode)
+  if (!this->GetSliceLogic())
     {
+    vtkErrorMacro("vtkMRMLWindowLevelWidget::GetEditableLayerAtEventPosition failed: invalid slice logic");
     return vtkMRMLSliceLogic::LayerNone;
     }
-  vtkMRMLSliceCompositeNode *sliceCompositeNode = sliceLogic->GetSliceCompositeNode();
-  if (!sliceCompositeNode)
-    {
-    return vtkMRMLSliceLogic::LayerNone;
-    }
-
-  bool foregroundEditable = this->VolumeWindowLevelEditable(sliceCompositeNode->GetForegroundVolumeID())
-    && this->ForegroundVolumeEditable;
-  bool backgroundEditable = this->VolumeWindowLevelEditable(sliceCompositeNode->GetBackgroundVolumeID())
-    && this->BackgroundVolumeEditable;
-
-  if (!foregroundEditable && !backgroundEditable)
-    {
-    // window/level editing is disabled on both volumes
-    return vtkMRMLSliceLogic::LayerNone;
-    }
-  // By default adjust background volume, if available
-  bool adjustForeground = !backgroundEditable;
-
-  // If both foreground and background volumes are visible then choose adjustment of
-  // foreground volume, if foreground volume is visible in current mouse position
-  if (foregroundEditable && backgroundEditable)
-    {
-    adjustForeground = (sliceCompositeNode->GetForegroundOpacity() > 0.0)
-      && this->IsEventInsideVolume(true, eventData)   // inside background (used as mask for displaying foreground)
-      && this->IsEventInsideVolume(false, eventData); // inside foreground
-    }
-
-  return (adjustForeground ? vtkMRMLSliceLogic::LayerForeground : vtkMRMLSliceLogic::LayerBackground);
-}
-
-//----------------------------------------------------------------------------
-bool vtkMRMLWindowLevelWidget::VolumeWindowLevelEditable(const char* volumeNodeID)
-{
-  if (!volumeNodeID)
-    {
-    return false;
-    }
-  vtkMRMLSliceLogic* sliceLogic = this->GetSliceLogic();
-  if (!sliceLogic)
-    {
-    return false;
-    }
-  vtkMRMLScene *scene = sliceLogic->GetMRMLScene();
-  if (!scene)
-    {
-    return false;
-    }
-  vtkMRMLVolumeNode* volumeNode =
-    vtkMRMLVolumeNode::SafeDownCast(scene->GetNodeByID(volumeNodeID));
-  if (volumeNode == nullptr)
-    {
-    return false;
-    }
-  vtkMRMLScalarVolumeDisplayNode* scalarVolumeDisplayNode =
-    vtkMRMLScalarVolumeDisplayNode::SafeDownCast(volumeNode->GetDisplayNode());
-  if (!scalarVolumeDisplayNode)
-    {
-    return false;
-    }
-  return !scalarVolumeDisplayNode->GetWindowLevelLocked();
+  return this->GetSliceLogic()->GetEditableLayerAtWorldPosition(worldPos, this->BackgroundVolumeEditable, this->ForegroundVolumeEditable);
 }
 
 //----------------------------------------------------------------------------
@@ -647,7 +589,7 @@ bool vtkMRMLWindowLevelWidget::UpdateWindowLevelFromRectangle(int layer, int cor
   vtkMRMLSliceLogic* sliceLogic = this->GetSliceLogic();
   if (!sliceLogic)
     {
-    return vtkMRMLSliceLogic::LayerNone;
+    return false;
     }
   vtkMRMLSliceNode *sliceNode = sliceLogic->GetSliceNode();
   if (!sliceNode)
@@ -716,48 +658,6 @@ bool vtkMRMLWindowLevelWidget::UpdateWindowLevelFromRectangle(int layer, int cor
   // It is more robust than taking the minimum and maximum - a few outlier voxels do not throw off the range.
   double* intensityRange = stats->GetAutoRange();
   displayNode->SetWindowLevelMinMax(intensityRange[0], intensityRange[1]);
-  return true;
-}
-
-//----------------------------------------------------------------------------
-bool vtkMRMLWindowLevelWidget::IsEventInsideVolume(bool background, vtkMRMLInteractionEventData* eventData)
-{
-  vtkMRMLSliceLogic* sliceLogic = this->GetSliceLogic();
-  if (!sliceLogic)
-    {
-    return false;
-    }
-  vtkMRMLSliceNode *sliceNode = sliceLogic->GetSliceNode();
-  if (!sliceNode)
-    {
-    return false;
-    }
-  vtkMRMLSliceLayerLogic* layerLogic = background ?
-    sliceLogic->GetBackgroundLayer() : sliceLogic->GetForegroundLayer();
-  if (!layerLogic)
-    {
-    return false;
-    }
-  vtkMRMLVolumeNode* volumeNode = layerLogic->GetVolumeNode();
-  if (!volumeNode || !volumeNode->GetImageData())
-    {
-    return false;
-    }
-  const int* eventPosition = eventData->GetDisplayPosition();
-  double xyz[3] = { 0 };
-  vtkMRMLAbstractSliceViewDisplayableManager::ConvertDeviceToXYZ(this->GetRenderer(), sliceNode, eventPosition[0], eventPosition[1], xyz);
-  vtkGeneralTransform* xyToBackgroundIJK = layerLogic->GetXYToIJKTransform();
-  double mousePositionIJK[3] = { 0 };
-  xyToBackgroundIJK->TransformPoint(xyz, mousePositionIJK);
-  int volumeExtent[6] = { 0 };
-  volumeNode->GetImageData()->GetExtent(volumeExtent);
-  for (int i = 0; i < 3; i++)
-    {
-    if (mousePositionIJK[i]<volumeExtent[i * 2] || mousePositionIJK[i]>volumeExtent[i * 2 + 1])
-      {
-      return false;
-      }
-    }
   return true;
 }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.h
@@ -151,14 +151,6 @@ protected:
 
   int GetEditableLayerAtEventPosition(vtkMRMLInteractionEventData* eventData);
 
-  /// Returns true if mouse is inside the selected layer volume.
-  /// Use background flag to choose between foreground/background layer.
-  bool IsEventInsideVolume(bool background, vtkMRMLInteractionEventData* eventData);
-
-  /// Returns true if the volume's window/level values are editable
-  /// on the GUI
-  bool VolumeWindowLevelEditable(const char* volumeNodeID);
-
   vtkMRMLVolumeNode* GetVolumeNodeFromSliceLayer(int editedLayer);
 
   bool SetVolumeWindowLevel(double window, double level, bool isAutoWindowLevel);

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -33,6 +33,7 @@
 #include <vtkAlgorithmOutput.h>
 #include <vtkCallbackCommand.h>
 #include <vtkCollection.h>
+#include <vtkGeneralTransform.h>
 #include <vtkImageAppendComponents.h>
 #include <vtkImageBlend.h>
 #include <vtkImageResample.h>
@@ -809,7 +810,7 @@ void vtkMRMLSliceLogic
     imageData->GetScalarRange(range);
     rangeLow = range[0];
     rangeHigh = range[1];
-    autoWindowLevel = (volumeDisplayNode->GetAutoScalarRange() != 0);
+    autoWindowLevel = (volumeDisplayNode->GetAutoWindowLevel() != 0);
     }
 }
 
@@ -845,7 +846,7 @@ void vtkMRMLSliceLogic
     imageData->GetScalarRange(range);
     rangeLow = range[0];
     rangeHigh = range[1];
-    autoWindowLevel = (volumeDisplayNode->GetAutoScalarRange() != 0);
+    autoWindowLevel = (volumeDisplayNode->GetAutoWindowLevel() != 0);
     }
 }
 
@@ -2397,4 +2398,117 @@ void vtkMRMLSliceLogic::RotateSliceToLowestVolumeAxes(bool forceSlicePlaneToSing
     }
   sliceNode->RotateToVolumePlane(volumeNode, forceSlicePlaneToSingleSlice);
   this->SnapSliceOffsetToIJK();
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLSliceLogic::GetEditableLayerAtWorldPosition(double worldPos[3],
+  bool backgroundVolumeEditable/*=true*/, bool foregroundVolumeEditable/*=true*/)
+{
+  vtkMRMLSliceNode *sliceNode = this->GetSliceNode();
+  if (!sliceNode)
+    {
+    return vtkMRMLSliceLogic::LayerNone;
+    }
+  vtkMRMLSliceCompositeNode *sliceCompositeNode = this->GetSliceCompositeNode();
+  if (!sliceCompositeNode)
+    {
+    return vtkMRMLSliceLogic::LayerNone;
+    }
+
+  bool foregroundEditable = this->VolumeWindowLevelEditable(sliceCompositeNode->GetForegroundVolumeID())
+    && foregroundVolumeEditable;
+  bool backgroundEditable = this->VolumeWindowLevelEditable(sliceCompositeNode->GetBackgroundVolumeID())
+    && backgroundVolumeEditable;
+
+  if (!foregroundEditable && !backgroundEditable)
+    {
+    // window/level editing is disabled on both volumes
+    return vtkMRMLSliceLogic::LayerNone;
+    }
+  // By default adjust background volume, if available
+  bool adjustForeground = !backgroundEditable;
+
+  // If both foreground and background volumes are visible then choose adjustment of
+  // foreground volume, if foreground volume is visible in current mouse position
+  if (foregroundEditable && backgroundEditable)
+    {
+    adjustForeground = (sliceCompositeNode->GetForegroundOpacity() >= 0.01)
+      && this->IsEventInsideVolume(true, worldPos)   // inside background (used as mask for displaying foreground)
+      && this->vtkMRMLSliceLogic::IsEventInsideVolume(false, worldPos); // inside foreground
+    }
+
+  return (adjustForeground ? vtkMRMLSliceLogic::LayerForeground : vtkMRMLSliceLogic::LayerBackground);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLSliceLogic::VolumeWindowLevelEditable(const char* volumeNodeID)
+{
+  if (!volumeNodeID)
+    {
+    return false;
+    }
+  vtkMRMLScene *scene = this->GetMRMLScene();
+  if (!scene)
+    {
+    return false;
+    }
+  vtkMRMLVolumeNode* volumeNode =
+    vtkMRMLVolumeNode::SafeDownCast(scene->GetNodeByID(volumeNodeID));
+  if (volumeNode == nullptr)
+    {
+    return false;
+    }
+  vtkMRMLScalarVolumeDisplayNode* scalarVolumeDisplayNode =
+    vtkMRMLScalarVolumeDisplayNode::SafeDownCast(volumeNode->GetVolumeDisplayNode());
+  if (!scalarVolumeDisplayNode)
+    {
+    return false;
+    }
+  return !scalarVolumeDisplayNode->GetWindowLevelLocked();
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLSliceLogic::IsEventInsideVolume(bool background, double worldPos[3])
+{
+  vtkMRMLSliceNode *sliceNode = this->GetSliceNode();
+  if (!sliceNode)
+    {
+    return false;
+    }
+  vtkMRMLSliceLayerLogic* layerLogic = background ?
+    this->GetBackgroundLayer() : this->GetForegroundLayer();
+  if (!layerLogic)
+    {
+    return false;
+    }
+  vtkMRMLVolumeNode* volumeNode = layerLogic->GetVolumeNode();
+  if (!volumeNode || !volumeNode->GetImageData())
+    {
+    return false;
+    }
+
+  vtkNew<vtkGeneralTransform> inputVolumeIJKToWorldTransform;
+  inputVolumeIJKToWorldTransform->PostMultiply();
+
+  vtkNew<vtkMatrix4x4> inputVolumeIJK2RASMatrix;
+  volumeNode->GetIJKToRASMatrix(inputVolumeIJK2RASMatrix);
+  inputVolumeIJKToWorldTransform->Concatenate(inputVolumeIJK2RASMatrix);
+
+  vtkNew<vtkGeneralTransform> inputVolumeRASToWorld;
+  vtkMRMLTransformNode::GetTransformBetweenNodes(volumeNode->GetParentTransformNode(), nullptr, inputVolumeRASToWorld);
+  inputVolumeIJKToWorldTransform->Concatenate(inputVolumeRASToWorld);
+
+  double ijkPos[3] = { 0.0, 0.0, 0.0 };
+  inputVolumeIJKToWorldTransform->GetInverse()->TransformPoint(worldPos, ijkPos);
+
+  int volumeExtent[6] = { 0 };
+  volumeNode->GetImageData()->GetExtent(volumeExtent);
+  for (int i = 0; i < 3; i++)
+    {
+    if (ijkPos[i]<volumeExtent[i * 2] || ijkPos[i]>volumeExtent[i * 2 + 1])
+      {
+      return false;
+      }
+    }
+  return true;
 }

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -370,6 +370,12 @@ public:
   /// is present and not equal to zero
   static bool IsSliceModelDisplayNode(vtkMRMLDisplayNode *mrmlDisplayNode);
 
+  /// Get volume at the specified world position that should be used
+  /// for interactions, such as window/level adjustments.
+  /// backgroundVolumeEditable and foregroundVolumeEditable can be used specify that
+  /// a volume is not editable (even if it is visible at the given position).
+  int GetEditableLayerAtWorldPosition(double worldPos[3], bool backgroundVolumeEditable = true, bool foregroundVolumeEditable = true);
+
 protected:
 
   vtkMRMLSliceLogic();
@@ -409,6 +415,13 @@ protected:
   /// re-add an input if it is not changed) because rebuilding of the pipeline
   /// is a relatively expensive operation.
   bool UpdateBlendLayers(vtkImageBlend* blend, const std::deque<SliceLayerInfo> &layers);
+
+  /// Returns true if position is inside the selected layer volume.
+  /// Use background flag to choose between foreground/background layer.
+  bool IsEventInsideVolume(bool background, double worldPos[3]);
+
+  /// Returns true if the volume's window/level values are editable on the GUI.
+  bool VolumeWindowLevelEditable(const char* volumeNodeID);
 
   bool                        AddingSliceModelNodes;
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -532,7 +532,6 @@ void vtkSlicerMarkupsWidget::UpdatePreviewPointIndex(vtkMRMLInteractionEventData
       {
       return;
       }
-    int previewIndex = this->PreviewPointIndex;
     int numberOfControlPoints = markupsNode->GetNumberOfControlPoints();
     for (int i = 0; i < numberOfControlPoints; i++)
       {

--- a/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/CMakeLists.txt
@@ -92,6 +92,7 @@ set(${KIT}_TARGET_LIBRARIES
   vtkSlicer${MODULE_NAME}ModuleLogic
   qSlicerTerminologiesModuleWidgets
   MRMLCore
+  vtkSlicerVolumesModuleLogic
   )
 if(Slicer_BUILD_CLI_SUPPORT)
   list(APPEND ${KIT}_TARGET_LIBRARIES

--- a/Modules/Loadable/Volumes/Logic/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/Logic/CMakeLists.txt
@@ -5,6 +5,7 @@ set(KIT ${PROJECT_NAME})
 set(${KIT}_EXPORT_DIRECTIVE "VTK_SLICER_${MODULE_NAME_UPPER}_MODULE_LOGIC_EXPORT")
 
 set(${KIT}_INCLUDE_DIRECTORIES
+  ${RapidJSON_INCLUDE_DIR}
   )
 
 set(${KIT}_SRCS
@@ -24,3 +25,12 @@ SlicerMacroBuildModuleLogic(
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
   )
+
+#-----------------------------------------------------------------------------
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../Resources/VolumeDisplayPresets.json
+  ${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_SHARE_DIR}/${MODULE_NAME}/VolumeDisplayPresets.json
+  COPYONLY)
+install(
+  FILES ${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_SHARE_DIR}/${MODULE_NAME}/VolumeDisplayPresets.json
+  DESTINATION ${Slicer_INSTALL_QTLOADABLEMODULES_SHARE_DIR}/${MODULE_NAME} COMPONENT Runtime)

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -57,6 +57,20 @@
 #include <vtkWeakPointer.h>
 #include <vtkImageReslice.h>
 #include <vtkTransform.h>
+#include <vtksys/RegularExpression.hxx>
+
+// JSON includes
+#include "rapidjson/document.h"
+#include "rapidjson/filereadstream.h"
+
+namespace
+{
+  const std::string MARKUPS_SCHEMA =
+    "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.0.json#";
+  const std::string ACCEPTED_VOLUME_DISPLAY_PRESETS_SCHEMA_REGEX =
+    "^https://raw\\.githubusercontent\\.com/slicer/slicer/master/Modules/Loadable/Volumes/Resources/Schema/"
+    "volumes-display-presets-schema-v1\\.[0-9]+\\.[0-9]+\\.json#";
+}
 
 /// CTK includes
 /// to avoid CTK includes which pull in a dependency on Qt, rehome some CTK
@@ -1544,4 +1558,181 @@ vtkSlicerVolumesLogic
   outputVolumeNode->SetAndObserveImageData(resliceFilter->GetOutput());
 
   return outputVolumeNode;
+}
+
+// --------------------------------------------------------------------------
+std::vector<std::string> vtkSlicerVolumesLogic::GetVolumeDisplayPresetIDs()
+{
+  std::vector<std::string> presetNamesVector;
+
+  if (this->VolumeDisplayPresets.empty())
+    {
+    InitializeDefaultVolumeDisplayPresets();
+    }
+
+  for (const auto& preset : VolumeDisplayPresets)
+    {
+    presetNamesVector.push_back(preset.PresetName);
+    }
+  return(presetNamesVector);
+}
+
+// --------------------------------------------------------------------------
+void vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets()
+{
+  if (!this->VolumeDisplayPresets.empty())
+    {
+    // already initialized
+    return;
+    }
+
+  // Volume presets are stored in a JSON file, read them from there
+  std::string displayPresetsFilename = this->GetModuleShareDirectory() + "/VolumeDisplayPresets.json";
+  FILE* fp = fopen(displayPresetsFilename.c_str(), "r");
+  if (!fp)
+    {
+    vtkErrorMacro("vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error opening the file '" << displayPresetsFilename << "'");
+    return;
+    }
+  std::unique_ptr<rapidjson::Document> jsonRoot = std::unique_ptr<rapidjson::Document>(new rapidjson::Document);
+  char buffer[4096];
+  rapidjson::FileReadStream fs(fp, buffer, sizeof(buffer));
+  if (jsonRoot->ParseStream(fs).HasParseError())
+    {
+    vtkErrorMacro("vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error parsing the file '" << displayPresetsFilename << "'.");
+    fclose(fp);
+    }
+  fclose(fp);
+
+  // Verify schema
+  if (!(*jsonRoot).HasMember("@schema"))
+    {
+    vtkErrorMacro("vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error reading '" << displayPresetsFilename << "'."
+      " File does not contain schema information.");
+    return;
+    }
+  rapidjson::Value& schema = (*jsonRoot)["@schema"];
+  vtksys::RegularExpression filterProgressRegExp(ACCEPTED_VOLUME_DISPLAY_PRESETS_SCHEMA_REGEX);
+  if (!filterProgressRegExp.find(schema.GetString()))
+    {
+    vtkErrorMacro("vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error reading '" << displayPresetsFilename << "'."
+      " File is expected to contain @schema: "
+      << MARKUPS_SCHEMA << " (different minor and patch version numbers are accepted).");
+    return;
+    }
+
+  if (!jsonRoot->IsObject())
+    {
+    vtkErrorMacro("vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error reading '" << displayPresetsFilename << "'."
+      " Syntax error in root element.");
+    return;
+    }
+
+  const rapidjson::Value& volumeDisplayPresets = (*jsonRoot)["volumeDisplayPresets"];
+  if (!volumeDisplayPresets.IsArray())
+    {
+    vtkErrorMacro("vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error reading '" << displayPresetsFilename << "'."
+      " volumeDisplayPresets element is not found or not an array.");
+    return;
+    }
+
+  // iterate all available presets
+  for (rapidjson::Value::ConstValueIterator presetIt = volumeDisplayPresets.Begin(); presetIt != volumeDisplayPresets.End(); ++presetIt)
+    {
+    const rapidjson::Value& preset = *presetIt;
+    if (!preset.IsObject())
+      {
+      vtkErrorMacro("vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error reading '" << displayPresetsFilename << "'."
+        " Syntax error reading preset " << (presetIt - volumeDisplayPresets.Begin() + 1) << ".");
+      continue;
+      }
+    if (!preset.HasMember("name") || !preset.HasMember("id") || !preset.HasMember("window") || !preset.HasMember("level") || !preset.HasMember("color"))
+      {
+      vtkErrorMacro("vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error reading '" << displayPresetsFilename << "'."
+        " Error reading preset " << (presetIt - volumeDisplayPresets.Begin() + 1) << ". Missing required property name, id, window, level, or color.");
+      continue;
+      }
+    if (!preset["name"].IsString() || !preset["id"].IsString() || !preset["window"].IsDouble() || !preset["level"].IsDouble() || !preset["color"].IsString())
+      {
+      vtkErrorMacro("vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error reading '" << displayPresetsFilename << "'."
+        " Error reading preset " << (presetIt - volumeDisplayPresets.Begin() + 1) << ". Wrong type for property name, id, window, level, or color.");
+      continue;
+      }
+    VolumeDisplayPreset wlp = VolumeDisplayPreset(preset["name"].GetString(), preset["id"].GetString(),
+      preset["window"].GetDouble(), preset["level"].GetDouble(), preset["color"].GetString());
+    this->VolumeDisplayPresets.push_back(wlp);
+    }
+}
+
+// --------------------------------------------------------------------------
+vtkSlicerVolumesLogic::VolumeDisplayPreset vtkSlicerVolumesLogic::GetVolumeDisplayPreset(const std::string& presetId)
+{
+  if (this->VolumeDisplayPresets.empty())
+    {
+    this->InitializeDefaultVolumeDisplayPresets();
+    }
+  for (const auto& preset : this->VolumeDisplayPresets)
+    {
+    if (preset.PresetID == presetId)
+      {
+      return preset;
+      }
+    }
+
+  // not found, create an invalid preset
+  VolumeDisplayPreset preset;
+  return preset;
+}
+
+// --------------------------------------------------------------------------
+bool vtkSlicerVolumesLogic::ApplyVolumeDisplayPreset(vtkMRMLVolumeDisplayNode* displayNode, std::string presetId)
+{
+  VolumeDisplayPreset preset = this->GetVolumeDisplayPreset(presetId);
+  if (!preset.Valid)
+    {
+    vtkErrorMacro("vtkSlicerVolumesLogic::ApplyVolumeDisplayPreset failed: Could not find preset ID " << presetId);
+    return false;
+    }
+
+  vtkMRMLScalarVolumeDisplayNode* volumeDisplayNode = vtkMRMLScalarVolumeDisplayNode::SafeDownCast(displayNode);
+  if (!volumeDisplayNode)
+    {
+    vtkErrorMacro("vtkSlicerVolumesLogic::ApplyVolumeDisplayPreset failed: Invalid display node");
+    return false;
+    }
+  int disabledModify = volumeDisplayNode->StartModify();
+  volumeDisplayNode->SetAutoWindowLevel(0);
+  volumeDisplayNode->SetWindowLevel(preset.Window, preset.Level);
+  volumeDisplayNode->SetAndObserveColorNodeID(preset.ColorNodeID);
+  volumeDisplayNode->EndModify(disabledModify);
+  return true;
+}
+
+
+// --------------------------------------------------------------------------
+std::string vtkSlicerVolumesLogic::GetAppliedVolumeDisplayPresetId(vtkMRMLVolumeDisplayNode* displayNode)
+{
+  vtkMRMLScalarVolumeDisplayNode* volumeDisplayNode = vtkMRMLScalarVolumeDisplayNode::SafeDownCast(displayNode);
+  if (!volumeDisplayNode)
+    {
+    return "";
+    }
+
+  if (this->VolumeDisplayPresets.empty())
+    {
+    this->InitializeDefaultVolumeDisplayPresets();
+    }
+  for (const auto& preset : this->VolumeDisplayPresets)
+    {
+    if (preset.Window == volumeDisplayNode->GetWindow()
+      && preset.Level == volumeDisplayNode->GetLevel()
+      && preset.ColorNodeID == volumeDisplayNode->GetColorNodeID())
+      {
+      // found it
+      return preset.PresetID;
+      }
+    }
+
+  // no matching preset was found
+  return "";
 }

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.h
@@ -68,8 +68,34 @@ public:
   static vtkSlicerVolumesLogic *New();
   vtkTypeMacro(vtkSlicerVolumesLogic,vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent) override;
-
   typedef vtkSlicerVolumesLogic Self;
+
+  struct VolumeDisplayPreset
+    {
+    std::string PresetName;
+    std::string PresetID;
+    double Window{0.0};
+    double Level{0.0};
+    std::string ColorNodeID;
+    bool Valid{false};
+
+    VolumeDisplayPreset()
+      {
+      this->Valid = false;
+      }
+
+    VolumeDisplayPreset(std::string presetName, std::string presetID, double window, double level, std::string colorNodeID)
+      {
+      this->PresetName = presetName;
+      this->PresetID = presetID;
+      this->Window = window;
+      this->Level = level;
+      this->ColorNodeID = colorNodeID;
+      this->Valid = true;
+      }
+
+    };
+  std::vector<VolumeDisplayPreset> VolumeDisplayPresets;
 
   /// Loading options, bitfield
   enum LoadingOptions {
@@ -280,11 +306,29 @@ public:
   /// \sa SetCompareVolumeGeometryEpsilon
   vtkGetMacro(CompareVolumeGeometryPrecision, int);
 
+  /// Method to set volume window/level based on a volume display preset.
+  /// Returns true on success.
+  bool ApplyVolumeDisplayPreset(vtkMRMLVolumeDisplayNode* displayNode, std::string presetId);
+
+  /// Get ID of the volume display preset that matches current display settings.
+  /// Returns empty string if there is no match.
+  std::string GetAppliedVolumeDisplayPresetId(vtkMRMLVolumeDisplayNode* displayNode);
+
+  ///  Method to get a vector to currently defined window level preset IDs.
+  std::vector<std::string> GetVolumeDisplayPresetIDs();
+
+  /// Get volume display preset based on ID.
+  /// If not found then the returned preset will have Valid member set to false.
+  VolumeDisplayPreset GetVolumeDisplayPreset(const std::string& presetId);
+
 protected:
   vtkSlicerVolumesLogic();
   ~vtkSlicerVolumesLogic() override;
   vtkSlicerVolumesLogic(const vtkSlicerVolumesLogic&);
   void operator=(const vtkSlicerVolumesLogic&);
+
+  /// Read default volume display presets from configuration file
+  void InitializeDefaultVolumeDisplayPresets();
 
   void ProcessMRMLNodesEvents(vtkObject * caller,
                                   unsigned long event,

--- a/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.0.json
+++ b/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.0.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.0.json#",
+    "type": "object",
+    "title": "Schema for storing presets for displaying image volumes",
+    "description": "Currently only window and level values are stored.",
+    "required": ["@schema", "volumeDisplayPresets"],
+    "additionalProperties": true,
+    "properties": {
+        "@schema": {
+            "$id": "#schema",
+            "type": "string",
+            "title": "Schema",
+            "description": "URL of versioned schema."
+        },
+        "volumeDisplayPresets": {
+            "$id": "#presets",
+            "type": "array",
+            "title": "Presets",
+            "description": "Stores a list of named display presets.",
+            "additionalItems": true,
+            "items": {
+                "$id": "#presetItems",
+                "anyOf": [
+                    {
+                        "$id": "#preset",
+                        "type": "object",
+                        "title": "Presets",
+                        "description": "Stores a single display preset.",
+                        "default": {},
+                        "required": ["id", "name", "window", "level", "color"],
+                        "additionalProperties": true,
+                        "properties": {
+                            "id": {
+                                "$id": "#preset/id",
+                                "type": "string",
+                                "title": "Id",
+                                "description": "Unique identifier of the preset. Must not start with underscore character (those are reserved for internal use)."
+                            },
+                            "name": {
+                                "$id": "#preset/name",
+                                "type": "string",
+                                "title": "Name",
+                                "description": "Human-readable name of the preset."
+                            },
+                            "window": {
+                                "$id": "#preset/window",
+                                "type": "number",
+                                "title": "Window",
+                                "description": "Width of the voxel value range that will be mapped to the full dynamic range of the display. Negative value means inverse mapping (higher voxel values appear darker).",
+                                "examples": [1000.0, -50.0]
+                            },
+                            "level": {
+                                "$id": "#preset/level",
+                                "type": "number",
+                                "title": "Level",
+                                "description": "Center of the voxel value range that will be mapped to the full dynamic range of the display.",
+                                "examples": [426.0, -500.0]
+                            },
+                            "color": {
+                                "$id": "#preset/color",
+                                "type": "string",
+                                "title": "Color",
+                                "description": "Color node ID, specifying the lookup table that will be used to map voxel values to colors."
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/Modules/Loadable/Volumes/Resources/VolumeDisplayPresets.json
+++ b/Modules/Loadable/Volumes/Resources/VolumeDisplayPresets.json
@@ -1,0 +1,54 @@
+{
+    "@schema": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Volumes/Resources/Schema/volumes-display-presets-schema-v1.0.0.json#",
+    "volumeDisplayPresets": [
+        {
+            "name": "CT-Bone",
+            "id": "CT-Bone",
+            "window": 1000.0,
+            "level": 400.0,
+            "color": "vtkMRMLColorTableNodeGrey"
+        },
+        {
+            "name": "CT-Air",
+            "id": "CT-Air",
+            "window": 1000.0,
+            "level": -426.0,
+            "color": "vtkMRMLColorTableNodeGrey"
+        },
+        {
+            "name": "CT-Abdomen",
+            "id": "CT-Abdomen",
+            "window": 350.0,
+            "level": 40.0,
+            "color": "vtkMRMLColorTableNodeGrey"
+        },
+        {
+            "name": "CT-Brain",
+            "id": "CT-Brain",
+            "window": 100.0,
+            "level": 50.0,
+            "color": "vtkMRMLColorTableNodeGrey"
+        },
+        {
+            "name": "CT-Lung",
+            "id": "CT-Lung",
+            "window": 1400.0,
+            "level": -500.0,
+            "color": "vtkMRMLColorTableNodeGrey"
+        },
+        {
+            "name": "PET",
+            "id": "PET",
+            "window": 10000.0,
+            "level": 6000.0,
+            "color": "vtkMRMLColorTableNodeRainbow"
+        },
+        {
+            "name": "DTI",
+            "id": "DTI",
+            "window": 1.0,
+            "level": 0.5,
+            "color": "vtkMRMLColorTableNodeRainbow"
+        }
+    ]
+}

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/CMakeLists.txt
@@ -10,6 +10,7 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${qMRMLWidgets_INCLUDE_DIRS}
   ${MRMLLogic_INCLUDE_DIRS}
   ${MRMLCore_INCLUDE_DIRS}
+  ${vtkSlicerVolumesModuleLogic_INCLUDE_DIRS}
   )
 
 set(${KIT}_SRCS

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
@@ -50,6 +50,16 @@ public:
   ~qSlicerSubjectHierarchyVolumesPlugin() override;
 
 public:
+
+  /// Get view context menu item actions that are available when right-clicking an object in the views.
+  /// These item context menu actions can be shown in the implementations of \sa showViewContextMenuActionsForItem
+  QList<QAction*> viewContextMenuActions()const override;
+
+  /// Show context menu actions valid for a given subject hierarchy item to be shown in the view.
+  /// \param itemID Subject Hierarchy item to show the context menu items for
+  /// \param eventData Supplementary data for the item that may be considered for the menu (sub-item ID, attribute, etc.)
+  void showViewContextMenuActionsForItem(vtkIdType itemID, QVariantMap eventData);
+
   /// Determines if a data node can be placed in the hierarchy using the actual plugin,
   /// and gets a confidence value for a certain MRML node (usually the type and possibly attributes are checked).
   /// \param node Node to be added to the hierarchy
@@ -143,6 +153,9 @@ protected slots:
   /// closest to the view's default view axis when showing a volume in subject hierarchy.
   /// By default it is on. State is stored in the application settings.
   void toggleResetViewOrientationOnShowAction(bool);
+
+  /// Set window/level by mapped menu signal
+  void setVolumePreset(const QString& presetId);
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyVolumesPluginPrivate> d_ptr;

--- a/Modules/Loadable/Volumes/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/Widgets/CMakeLists.txt
@@ -44,6 +44,7 @@ set(${KIT}_RESOURCES
   )
 
 set(${KIT}_TARGET_LIBRARIES
+  vtkSlicerVolumesModuleLogic
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
@@ -24,6 +24,13 @@
 #include <vtkPointData.h>
 #include <vtkSmartPointer.h>
 
+// Qt includes
+#include <QDebug>
+
+// Slicer includes
+#include "qSlicerApplication.h"
+#include "vtkSlicerVolumesLogic.h"
+
 // STD includes
 #include <limits>
 
@@ -400,77 +407,18 @@ void qSlicerScalarVolumeDisplayWidget::onLockWindowLevelButtonClicked()
 void qSlicerScalarVolumeDisplayWidget::onPresetButtonClicked()
 {
   QToolButton* preset = qobject_cast<QToolButton*>(this->sender());
-  this->setPreset(preset->accessibleName());
+  this->setPreset(preset->objectName());
 }
 
 // --------------------------------------------------------------------------
-void qSlicerScalarVolumeDisplayWidget::setPreset(const QString& presetName)
+void qSlicerScalarVolumeDisplayWidget::setPreset(const QString& presetId)
 {
   Q_D(qSlicerScalarVolumeDisplayWidget);
-  QString colorNodeID;
-  double window = -1.;
-  double level = std::numeric_limits<double>::max();
-  if (presetName == "CT-Bone")
+  vtkSlicerVolumesLogic* volumesModuleLogic = vtkSlicerVolumesLogic::SafeDownCast(qSlicerApplication::application()->moduleLogic("Volumes"));
+  if (!volumesModuleLogic)
     {
-    colorNodeID = "vtkMRMLColorTableNodeGrey";
-    window = 1000.;
-    level = 400.;
+    qCritical() << Q_FUNC_INFO << " failed: volumes module logic is not available";
+    return;
     }
-  else if (presetName == "CT-Air")
-    {
-    colorNodeID = "vtkMRMLColorTableNodeGrey";
-    window = 1000.;
-    level = -426.;
-    }
-  else if (presetName == "PET")
-    {
-    colorNodeID = "vtkMRMLColorTableNodeRainbow";
-    window = 10000.;
-    level = 6000.;
-    }
-  else if (presetName == "CT-Abdomen")
-    {
-    colorNodeID = "vtkMRMLColorTableNodeGrey";
-    window = 350.;
-    level = 40.;
-    }
-  else if (presetName == "CT-Brain")
-    {
-    colorNodeID = "vtkMRMLColorTableNodeGrey";
-    window = 100.;
-    level = 50.;
-    }
-  else if (presetName == "CT-Lung")
-    {
-    colorNodeID = "vtkMRMLColorTableNodeGrey";
-    window = 1400.;
-    level = -500.;
-    }
-  else if (presetName == "DTI")
-    {
-    colorNodeID = "vtkMRMLColorTableNodeRainbow";
-    window = 1.0;
-    level = 0.5;
-    }
-  vtkMRMLNode* colorNode = this->mrmlScene()->GetNodeByID(colorNodeID.toUtf8());
-  if (colorNode)
-    {
-    this->setColorNode(colorNode);
-    }
-  if (window != -1 || level!= std::numeric_limits<double>::max())
-    {
-    d->MRMLWindowLevelWidget->setAutoWindowLevel(qMRMLWindowLevelWidget::Manual);
-    }
-  if (window != -1 && level != std::numeric_limits<double>::max())
-    {
-    d->MRMLWindowLevelWidget->setWindowLevel(window, level);
-    }
-  else if (window != -1)
-    {
-    d->MRMLWindowLevelWidget->setWindow(window);
-    }
-  else if (level != std::numeric_limits<double>::max())
-    {
-    d->MRMLWindowLevelWidget->setLevel(level);
-    }
+  volumesModuleLogic->ApplyVolumeDisplayPreset(this->volumeDisplayNode(), presetId.toStdString());
 }


### PR DESCRIPTION
Add functionality to display volume presets from the slice view right-click menu.  
Do not display the preset menu in 3D view.   
Let it only display if a scalarvolume is displayed in slice view.   
Make the presets checkable and setcheck(true) them upon selection  
Make this work even if several scalar volumes are loaded.  
Set the presets by a function call to  [Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx](https://github.com/Slicer/Slicer/compare/master...rbumm:master#diff-e66332c76fe962dd310d54e008ed379b062f3fec8a74f0969d4706d96b362ad4) 

![](https://user-images.githubusercontent.com/18140094/139442405-7fab1660-7414-4cb1-9aa8-15c237f53f51.png)

![](https://user-images.githubusercontent.com/18140094/139446279-48726161-2584-45cd-b0ed-36b6c482236c.png)

To do:

find a way to define a default window/level preset that the user can define by special action and that be used as default upon every start of Slicer.  

Limitations:

*   qSlicerScalarVolumeDisplayWidget has still its hard coded setPreset() function, pls advise what to do here
*   setting the colornode seems to have different results if done from the right click menu compared to qSlicerScalarVolumeDisplayWidget.