### PR TITLE
ENH: Add additional plane modes to vtkMRMLMarkupsPlaneNode

### DIFF
--- a/Docs/user_guide/modules/markups.md
+++ b/Docs/user_guide/modules/markups.md
@@ -37,6 +37,16 @@ To pick a markups node in a viewer so that its properties can be edited in Marku
 
 ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_markups_context_menu_properties.png)
 
+### Edit Plane markups
+
+- Planes can be defined using 3 "plane types": Point normal (default, place one or two points defining the origin and normal), 3 points (place 3 points to define the origin and plane axes), and plane fit (place any number of points that will be fit to a plane).
+- When placing a plane with the "point normal" plane type, Alt + Left-click will allow the placement of 2 points. Placing the first point will define the origin of the plane, while the second point will define the normal vector.
+- If the handles are not visible, right-click on the plane outline, or on a control point, and check "Interaction handles visible".
+- Plane size can be changed using handles on the corners and edges of the plane.
+- Left-click-and-drag on interaction handles to change the plane size.
+- Resizing a plane will change the size mode to "absolute", preventing changes in the control points from affecting the plane size.
+- Plane type and size mode can be changed from the "Plane settings" section of the markups module.
+
 ### Edit ROI markups
 
 - ROI size can be changed using handles on the corners and faces of the ROI.

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -29,12 +29,13 @@
 #include "vtkMRMLMarkupsFiducialNode.h"
 #include "vtkMRMLMarkupsFiducialStorageNode.h"
 #include "vtkMRMLMarkupsJsonStorageNode.h"
-#include "vtkMRMLMarkupsPlaneJsonStorageNode.h"
-#include "vtkMRMLMarkupsROIDisplayNode.h"
-#include "vtkMRMLMarkupsROIJsonStorageNode.h"
 #include "vtkMRMLMarkupsLineNode.h"
 #include "vtkMRMLMarkupsNode.h"
+#include "vtkMRMLMarkupsPlaneDisplayNode.h"
+#include "vtkMRMLMarkupsPlaneJsonStorageNode.h"
 #include "vtkMRMLMarkupsPlaneNode.h"
+#include "vtkMRMLMarkupsROIDisplayNode.h"
+#include "vtkMRMLMarkupsROIJsonStorageNode.h"
 #include "vtkMRMLMarkupsROINode.h"
 #include "vtkMRMLMarkupsStorageNode.h"
 
@@ -369,6 +370,7 @@ void vtkSlicerMarkupsLogic::RegisterNodes()
   // Display nodes
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsDisplayNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsFiducialDisplayNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsPlaneDisplayNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsROIDisplayNode>::New());
 
   // Storage Nodes

--- a/Modules/Loadable/Markups/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRML/CMakeLists.txt
@@ -23,11 +23,12 @@ set(${KIT}_SRCS
   vtkMRML${MODULE_NAME}JsonStorageNode.cxx
   vtkMRML${MODULE_NAME}LineNode.cxx
   vtkMRML${MODULE_NAME}Node.cxx
-  vtkMRML${MODULE_NAME}PlaneNode.cxx
+  vtkMRML${MODULE_NAME}PlaneDisplayNode.cxx
   vtkMRML${MODULE_NAME}PlaneJsonStorageNode.cxx
-  vtkMRML${MODULE_NAME}ROINode.cxx
+  vtkMRML${MODULE_NAME}PlaneNode.cxx
   vtkMRML${MODULE_NAME}ROIDisplayNode.cxx
   vtkMRML${MODULE_NAME}ROIJsonStorageNode.cxx
+  vtkMRML${MODULE_NAME}ROINode.cxx
   vtkCurveGenerator.cxx
   vtkCurveGenerator.h
   vtkCurveMeasurementsCalculator.cxx

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -1664,14 +1664,27 @@ void vtkMRMLMarkupsNode::ApplyTransform(vtkAbstractTransform* transform)
 {
   MRMLNodeModifyBlocker blocker(this);
 
+  vtkLinearTransform* linearTransform = vtkLinearTransform::SafeDownCast(transform);
+  if (linearTransform)
+    {
+    // The orientation of some markup types are not fully defined by their control points (line, etc.).
+    // For these cases, we need to manually apply a rotation to the interaction handles.
+    vtkNew<vtkTransform> handleToWorldTransform;
+    handleToWorldTransform->PostMultiply();
+    handleToWorldTransform->Concatenate(this->InteractionHandleToWorldMatrix);
+    handleToWorldTransform->Concatenate(linearTransform);
+    this->InteractionHandleToWorldMatrix->DeepCopy(handleToWorldTransform->GetMatrix());
+    }
+
   int numControlPoints = this->GetNumberOfControlPoints();
   double xyzIn[3];
   double xyzOut[3];
-  for (int controlpointIndex = 0; controlpointIndex < numControlPoints; controlpointIndex++)
+  for (int controlPointIndex = 0; controlPointIndex < numControlPoints; controlPointIndex++)
     {
-    this->GetNthControlPointPosition(controlpointIndex, xyzIn);
+    this->GetNthControlPointPosition(controlPointIndex, xyzIn);
     transform->TransformPoint(xyzIn,xyzOut);
-    this->SetNthControlPointPositionFromArray(controlpointIndex, xyzOut);
+    int status = this->GetNthControlPointPositionStatus(controlPointIndex);
+    this->SetNthControlPointPositionFromArray(controlPointIndex, xyzOut, status);
     }
   this->StorableModifiedTime.Modified();
   this->Modified();
@@ -2748,6 +2761,7 @@ void vtkMRMLMarkupsNode::UpdateInteractionHandleToWorldMatrix()
     return;
     }
   vtkMath::Cross(handleZ_World, normal_World, rotationVector_World);
+  vtkMath::Normalize(rotationVector_World);
 
   vtkNew<vtkTransform> handleToWorldMatrix;
   handleToWorldMatrix->PostMultiply();

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneDisplayNode.cxx
@@ -1,0 +1,37 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLMarkupsPlaneDisplayNode.h"
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLMarkupsPlaneDisplayNode);
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsPlaneDisplayNode::vtkMRMLMarkupsPlaneDisplayNode()
+{
+  this->HandlesInteractive = true;
+  this->TranslationHandleVisibility = false;
+  this->RotationHandleVisibility= false;
+  this->ScaleHandleVisibility = true;
+}
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsPlaneDisplayNode::~vtkMRMLMarkupsPlaneDisplayNode() = default;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneDisplayNode.h
@@ -1,0 +1,97 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+// .NAME vtkMRMLMarkupsPlaneDisplayNode - MRML node to represent display properties for markups Plane
+// .SECTION Description
+// Adjusts default display parameters for Plane such as fill opacity.
+//
+
+#ifndef __vtkMRMLMarkupsPlaneDisplayNode_h
+#define __vtkMRMLMarkupsPlaneDisplayNode_h
+
+// Markups MRML includes
+#include "vtkMRMLMarkupsDisplayNode.h"
+#include "vtkSlicerMarkupsModuleMRMLExport.h"
+
+/// \ingroup Slicer_QtModules_Markups
+class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsPlaneDisplayNode : public vtkMRMLMarkupsDisplayNode
+{
+public:
+  static vtkMRMLMarkupsPlaneDisplayNode* New();
+  vtkTypeMacro(vtkMRMLMarkupsPlaneDisplayNode, vtkMRMLMarkupsDisplayNode);
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  // Get node XML tag name (like Volume, Markups)
+  const char* GetNodeTagName() override { return "MarkupsPlaneDisplay"; };
+
+  /// Copy node content (excludes basic data, such as name and node references).
+  /// \sa vtkMRMLNode::CopyContent
+  vtkMRMLCopyContentDefaultMacro(vtkMRMLMarkupsPlaneDisplayNode);
+
+  enum
+  {
+    ComponentPlane = vtkMRMLMarkupsDisplayNode::Component_Last,
+    ComponentPlane_Last
+  };
+
+  /// Indexes of the scale handles
+  enum
+  {
+    HandleLEdge,
+    HandleREdge,
+    HandlePEdge,
+    HandleAEdge,
+
+    HandleLPCorner,
+    HandleRPCorner,
+    HandleLACorner,
+    HandleRACorner,
+
+    HandlePlane_Last
+  };
+
+  //@{
+  /// Get/Set the visibility of the plane normal arrow.
+  vtkSetMacro(NormalVisibility, bool);
+  vtkGetMacro(NormalVisibility, bool);
+  vtkBooleanMacro(NormalVisibility, bool);
+  //@}
+
+  //@{
+  /// Get/Set the opacity of the plane normal arrow.
+  vtkSetMacro(NormalOpacity, double);
+  vtkGetMacro(NormalOpacity, double);
+  //@}
+
+protected:
+
+  bool NormalVisibility{ true };
+  double NormalOpacity{ 1.0 };
+
+  vtkMRMLMarkupsPlaneDisplayNode();
+  ~vtkMRMLMarkupsPlaneDisplayNode() override;
+  vtkMRMLMarkupsPlaneDisplayNode(const vtkMRMLMarkupsPlaneDisplayNode&);
+  void operator= (const vtkMRMLMarkupsPlaneDisplayNode&);
+};
+#endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.cxx
@@ -19,21 +19,23 @@
 ==============================================================================*/
 
 // MRML includes
-#include "vtkMRMLMarkupsDisplayNode.h"
+#include "vtkMRMLMarkupsPlaneDisplayNode.h"
 #include "vtkMRMLMarkupsPlaneNode.h"
 #include "vtkMRMLMeasurementArea.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLStorageNode.h"
 #include "vtkMRMLTransformNode.h"
 
+// vtkAddon includes
+#include <vtkAddonMathUtilities.h>
+
 // VTK includes
+#include <vtkCallbackCommand.h>
 #include <vtkCollection.h>
 #include <vtkGeneralTransform.h>
-#include <vtkMatrix4x4.h>
-#include <vtkNew.h>
-#include <vtkObjectFactory.h>
+#include <vtkPlane.h>
 #include <vtkTransform.h>
-#include <vtkTriangle.h>
+#include <vtkTransformPolyDataFilter.h>
 
 // STD includes
 #include <sstream>
@@ -44,11 +46,16 @@ vtkMRMLNodeNewMacro(vtkMRMLMarkupsPlaneNode);
 //----------------------------------------------------------------------------
 vtkMRMLMarkupsPlaneNode::vtkMRMLMarkupsPlaneNode()
 {
-  this->MaximumNumberOfControlPoints = 3;
-  this->RequiredNumberOfControlPoints = 3;
-  this->SizeMode = SizeModeAuto;
-  this->AutoSizeScalingFactor = 1.0;
+  this->RequiredNumberOfControlPoints = 1;
+  this->MaximumNumberOfControlPoints = 1;
+
   this->ObjectToBaseMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+  this->BaseToNodeMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+
+  // Add observers so that we can update the plane/control points
+  this->CurveInputPoly->GetPoints()->AddObserver(vtkCommand::ModifiedEvent, this->MRMLCallbackCommand);
+  this->ObjectToBaseMatrix->AddObserver(vtkCommand::ModifiedEvent, this->MRMLCallbackCommand);
+  this->BaseToNodeMatrix->AddObserver(vtkCommand::ModifiedEvent, this->MRMLCallbackCommand);
 
   // Setup measurements calculated for this markup type
   vtkNew<vtkMRMLMeasurementArea> areaMeasurement;
@@ -66,10 +73,8 @@ void vtkMRMLMarkupsPlaneNode::WriteXML(ostream& of, int nIndent)
 {
   Superclass::WriteXML(of,nIndent);
   vtkMRMLWriteXMLBeginMacro(of);
-  vtkMRMLWriteXMLEnumMacro(sizeMode, SizeMode);
-  vtkMRMLWriteXMLVectorMacro(size, Size, double, 2);
-  vtkMRMLWriteXMLFloatMacro(autoSizeScalingFactor, AutoSizeScalingFactor);
-  vtkMRMLWriteXMLMatrix4x4Macro(objectToBaseMatrix, ObjectToBaseMatrix);
+  vtkMRMLWriteXMLIntMacro(maximumNumberOfControlPoints, MaximumNumberOfControlPoints);
+  vtkMRMLWriteXMLIntMacro(requiredNumberOfControlPoints, RequiredNumberOfControlPoints);
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -79,11 +84,16 @@ void vtkMRMLMarkupsPlaneNode::ReadXMLAttributes(const char** atts)
   MRMLNodeModifyBlocker blocker(this);
   Superclass::ReadXMLAttributes(atts);
   vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLIntMacro(maximumNumberOfControlPoints, MaximumNumberOfControlPoints);
+  vtkMRMLReadXMLIntMacro(requiredNumberOfControlPoints, RequiredNumberOfControlPoints);
+
+  // Now handled by storage node
   vtkMRMLReadXMLEnumMacro(sizeMode, SizeMode);
   vtkMRMLReadXMLVectorMacro(size, Size, double, 2);
   vtkMRMLReadXMLFloatMacro(autoSizeScalingFactor, AutoSizeScalingFactor);
   vtkMRMLReadXMLOwnedMatrix4x4Macro(planeTobaseMatrix, ObjectToBaseMatrix); // Backwards compatible with old name
   vtkMRMLReadXMLOwnedMatrix4x4Macro(objectToBaseMatrix, ObjectToBaseMatrix);
+
   vtkMRMLReadXMLEndMacro();
 }
 
@@ -91,12 +101,23 @@ void vtkMRMLMarkupsPlaneNode::ReadXMLAttributes(const char** atts)
 void vtkMRMLMarkupsPlaneNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
 {
   MRMLNodeModifyBlocker blocker(this);
-  Superclass::CopyContent(anode, deepCopy);
   vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyEnumMacro(PlaneType);
+  vtkMRMLCopyIntMacro(MaximumNumberOfControlPoints);
+  vtkMRMLCopyIntMacro(RequiredNumberOfControlPoints);
   vtkMRMLCopyEnumMacro(SizeMode);
   vtkMRMLCopyVectorMacro(Size, double, 2);
+  vtkMRMLCopyVectorMacro(Normal, double, 3);
+  vtkMRMLCopyVectorMacro(Center, double, 3);
   vtkMRMLCopyFloatMacro(AutoSizeScalingFactor);
+  vtkMRMLCopyEndMacro();
+
+  Superclass::CopyContent(anode, deepCopy);
+
+  // Copy the plane orientation matrices after the points have been copied
+  vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyOwnedMatrix4x4Macro(ObjectToBaseMatrix);
+  vtkMRMLCopyOwnedMatrix4x4Macro(BaseToNodeMatrix);
   vtkMRMLCopyEndMacro();
 }
 
@@ -113,6 +134,86 @@ void vtkMRMLMarkupsPlaneNode::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::ApplyTransform(vtkAbstractTransform* transform)
+{
+  if (!transform)
+    {
+    return;
+    }
+
+  MRMLNodeModifyBlocker blocker(this);
+
+  bool wasUpdatingControlPointsFromPlane = this->IsUpdatingControlPointsFromPlane;
+  this->IsUpdatingControlPointsFromPlane = true;
+
+  bool wasUpdatingPlaneFromControlPoints = this->IsUpdatingPlaneFromControlPoints;
+  this->IsUpdatingPlaneFromControlPoints = true;
+
+  vtkNew<vtkMatrix4x4> oldBaseToNodeMatrix;
+  oldBaseToNodeMatrix->DeepCopy(this->BaseToNodeMatrix);
+
+  Superclass::ApplyTransform(transform);
+
+  vtkNew<vtkMatrix4x4> newBaseToNodeMatrix;
+  this->GenerateOrthogonalMatrix(oldBaseToNodeMatrix, newBaseToNodeMatrix, transform, false);
+  this->BaseToNodeMatrix->DeepCopy(newBaseToNodeMatrix);
+
+  double newXAxis_Node[3] = { 1.0, 0.0, 0.0 };
+  double newYAxis_Node[3] = { 0.0, 1.0, 0.0 };
+  double newZAxis_Node[3] = { 0.0, 0.0, 1.0 };
+  double newCenter_Node[3] = { 0.0, 0.0, 0.0 };
+  this->GetAxes(newXAxis_Node, newYAxis_Node, newZAxis_Node);
+  this->GetCenter(newCenter_Node);
+
+  // Update size by calculating diffference in scaling between transformed/untransformed axes
+  vtkAbstractTransform* transformInverse = transform->GetInverse();
+  this->Size[0] /= vtkMath::Norm(transformInverse->TransformVectorAtPoint(newCenter_Node, newXAxis_Node));
+  this->Size[1] /= vtkMath::Norm(transformInverse->TransformVectorAtPoint(newCenter_Node, newYAxis_Node));
+
+  this->IsUpdatingControlPointsFromPlane = wasUpdatingControlPointsFromPlane;
+  this->IsUpdatingPlaneFromControlPoints = wasUpdatingPlaneFromControlPoints;
+
+  this->Modified();
+}
+
+//----------------------------------------------------------------------------
+const char* vtkMRMLMarkupsPlaneNode::GetPlaneTypeAsString(int planeType)
+{
+  switch (planeType)
+    {
+    case vtkMRMLMarkupsPlaneNode::PlaneType3Points:
+      return "threePoints";
+    case vtkMRMLMarkupsPlaneNode::PlaneTypePointNormal:
+      return "pointNormal";
+    case vtkMRMLMarkupsPlaneNode::PlaneTypePlaneFit:
+      return "planeFit";
+    default:
+    break;
+    }
+  return "";
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMarkupsPlaneNode::GetPlaneTypeFromString(const char* planeType)
+{
+  if (planeType == nullptr)
+    {
+    // invalid name
+    return -1;
+    }
+  for (int i = 0; i < vtkMRMLMarkupsPlaneNode::PlaneType_Last; i++)
+    {
+    if (strcmp(planeType, vtkMRMLMarkupsPlaneNode::GetPlaneTypeAsString(i)) == 0)
+      {
+      // found a matching name
+      return i;
+      }
+    }
+  // unknown plane type
+  return -1;
+}
+
+//----------------------------------------------------------------------------
 const char* vtkMRMLMarkupsPlaneNode::GetSizeModeAsString(int sizeMode)
 {
   switch (sizeMode)
@@ -124,43 +225,100 @@ const char* vtkMRMLMarkupsPlaneNode::GetSizeModeAsString(int sizeMode)
   default:
     break;
     }
-  return "unknown";
+  return "";
 }
 
 //----------------------------------------------------------------------------
 int vtkMRMLMarkupsPlaneNode::GetSizeModeFromString(const char* sizeMode)
 {
+  if (sizeMode == nullptr)
+    {
+    // invalid size mode
+    return -1;
+    }
   for (int i = 0; i < SizeMode_Last; ++i)
     {
-    if (strcmp(this->GetSizeModeAsString(i), sizeMode) == 0)
+    if (strcmp(vtkMRMLMarkupsPlaneNode::GetSizeModeAsString(i), sizeMode) == 0)
       {
       return i;
       }
     }
+  // unknown size mode
   return -1;
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::GetNormal(double normal[3])
+void vtkMRMLMarkupsPlaneNode::SetSizeMode(int sizeMode)
 {
-  if (!normal)
+  if (this->SizeMode == sizeMode)
+    {
+    return;
+    }
+  this->SizeMode = sizeMode;
+
+  MRMLNodeModifyBlocker blocker(this);
+  this->UpdateControlPointsFromPlane();
+  this->UpdatePlaneFromControlPoints();
+  this->Modified();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::SetPlaneType(int planeType)
+{
+  if (this->PlaneType == planeType)
+    {
+    return;
+    }
+
+  this->PlaneType = planeType;
+
+  switch (this->PlaneType)
+    {
+    case PlaneTypePointNormal:
+      this->RequiredNumberOfControlPoints = this->NormalPointRequired ? 2 : 1;
+      this->MaximumNumberOfControlPoints = this->NormalPointRequired ? 2 : 1;
+      break;
+    case PlaneType3Points:
+      this->RequiredNumberOfControlPoints = 3;
+      this->MaximumNumberOfControlPoints = 3;
+      break;
+    case PlaneTypePlaneFit:
+      this->RequiredNumberOfControlPoints = 0;
+      this->MaximumNumberOfControlPoints = -1;
+      break;
+    }
+
+  MRMLNodeModifyBlocker blocker(this);
+  this->UpdateControlPointsFromPlane();
+  this->UpdatePlaneFromControlPoints();
+  this->Modified();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::SetNormalPointRequired(bool normalPointRequired)
+{
+  if (normalPointRequired == this->NormalPointRequired)
+    {
+    return;
+    }
+
+  this->NormalPointRequired = normalPointRequired;
+  this->RequiredNumberOfControlPoints = this->NormalPointRequired ? 2 : 1;
+  this->MaximumNumberOfControlPoints = this->NormalPointRequired ? 2 : 1;
+
+  this->Modified();
+}
+
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::GetNormal(double normal_Node[3])
+{
+  if (!normal_Node)
     {
     vtkErrorMacro("GetNormal: Invalid normal argument");
     return;
     }
-
-  if (this->GetNumberOfControlPoints() < 3)
-    {
-    normal[0] = 0;
-    normal[1] = 0;
-    normal[2] = 1;
-    vtkWarningMacro("GetNormal: Not enough points to define plane");
-    return;
-    }
-
-  double x[3] = { 0 };
-  double y[3] = { 0 };
-  this->GetAxes(x, y, normal);
+  this->GetAxes(nullptr, nullptr, normal_Node);
 }
 
 //----------------------------------------------------------------------------
@@ -178,19 +336,7 @@ void vtkMRMLMarkupsPlaneNode::GetNormalWorld(double normalWorld[3])
     vtkErrorMacro("GetNormalWorld: Invalid normal argument");
     return;
     }
-
-  if (this->GetNumberOfControlPoints() < 3)
-    {
-    normalWorld[0] = 0;
-    normalWorld[1] = 0;
-    normalWorld[2] = 1;
-    vtkWarningMacro("GetNormalWorld: Not enough points to define plane");
-    return;
-    }
-
-  double x[3] = { 0 };
-  double y[3] = { 0 };
-  this->GetAxesWorld(x, y, normalWorld);
+  this->GetAxesWorld(nullptr, nullptr, normalWorld);
 }
 
 //----------------------------------------------------------------------------
@@ -209,24 +355,34 @@ void vtkMRMLMarkupsPlaneNode::SetNormal(const double normal_Node[3])
     return;
     }
 
-  MRMLNodeModifyBlocker blocker(this);
-  this->CreatePlane();
+  double epsilon = 0.0001;
 
   double newNormal_Node[3] = { normal_Node[0], normal_Node[1], normal_Node[2] };
-  vtkMath::Normalize(newNormal_Node);
+  double normalLength = vtkMath::Normalize(newNormal_Node);
+  if (normalLength < epsilon)
+    {
+    vtkErrorMacro("SetNormal: Invalid normal");
+    return;
+    }
+
+  MRMLNodeModifyBlocker blocker(this);
+
+  if (this->GetPlaneType() != PlaneTypePlaneFit)
+    {
+    // If we are not using plane fit, then we can generate the control points
+    // base on the current parameters.
+    this->SetIsPlaneValid(true);
+    }
 
   double currentNormal_Node[3] = { 0.0, 0.0, 0.0 };
   this->GetNormal(currentNormal_Node);
 
-  double epsilon = 0.0001;
   if (vtkMath::Dot(newNormal_Node, currentNormal_Node) >= 1.0 - epsilon)
     {
     // Normal vectors are equivalent, no change required.
+    this->UpdateControlPointsFromPlane();
     return;
     }
-
-  vtkNew<vtkMatrix4x4> objectToNodeMatrix;
-  this->GetObjectToNodeMatrix(objectToNodeMatrix);
 
   double angleRadians = vtkMath::AngleBetweenVectors(currentNormal_Node, newNormal_Node);
   double rotationAxis_Node[3] = { 0.0, 0.0, 0.0 };
@@ -245,8 +401,9 @@ void vtkMRMLMarkupsPlaneNode::SetNormal(const double normal_Node[3])
   oldToNewNormalTransform->RotateWXYZ(vtkMath::DegreesFromRadians(angleRadians), rotationAxis_Node);
   vtkMath::MultiplyScalar(origin_Node, -1.0);
   oldToNewNormalTransform->Translate(origin_Node);
-
   this->ApplyTransform(oldToNewNormalTransform);
+
+  this->UpdateControlPointsFromPlane();
 }
 
 //----------------------------------------------------------------------------
@@ -296,12 +453,6 @@ void vtkMRMLMarkupsPlaneNode::GetOrigin(double origin_Node[3])
   origin_Node[1] = 0.0;
   origin_Node[2] = 0.0;
 
-  if (this->GetNumberOfControlPoints() < 1)
-    {
-    vtkWarningMacro("GetOrigin: Not enough points to define plane origin");
-    return;
-    }
-
   double origin_Object[3] = { 0.0, 0.0, 0.0 };
 
   vtkNew<vtkMatrix4x4> objectToNodeMatrix;
@@ -315,7 +466,13 @@ void vtkMRMLMarkupsPlaneNode::GetOrigin(double origin_Node[3])
 //----------------------------------------------------------------------------
 double* vtkMRMLMarkupsPlaneNode::GetOrigin()
 {
-  this->GetOrigin(this->Origin);
+  vtkNew<vtkMatrix4x4> objectToNodeMatrix;
+  this->GetObjectToNodeMatrix(objectToNodeMatrix);
+
+  vtkNew<vtkTransform> objectToNodeTransform;
+  objectToNodeTransform->SetMatrix(objectToNodeMatrix);
+  double originObject[3] = { 0.0, 0.0, 0.0 };
+  objectToNodeTransform->TransformPoint(originObject, this->Origin);
   return this->Origin;
 }
 
@@ -325,16 +482,6 @@ void vtkMRMLMarkupsPlaneNode::GetOriginWorld(double origin_World[3])
   if (!origin_World)
     {
     vtkErrorMacro("GetOriginWorld: Invalid origin argument");
-    return;
-    }
-
-  origin_World[0] = 0.0;
-  origin_World[1] = 0.0;
-  origin_World[2] = 0.0;
-
-  if (this->GetNumberOfControlPoints() < 1)
-    {
-    vtkWarningMacro("GetOriginWorld: Not enough points to define plane origin");
     return;
     }
 
@@ -351,7 +498,13 @@ void vtkMRMLMarkupsPlaneNode::GetOriginWorld(double origin_World[3])
 //----------------------------------------------------------------------------
 double* vtkMRMLMarkupsPlaneNode::GetOriginWorld()
 {
-  this->GetOriginWorld(this->OriginWorld);
+  vtkNew<vtkMatrix4x4> objectToWorldMatrix;
+  this->GetObjectToWorldMatrix(objectToWorldMatrix);
+
+  vtkNew<vtkTransform> objectToWorldTransform;
+  objectToWorldTransform->SetMatrix(objectToWorldMatrix);
+  double originObject[3] = { 0.0, 0.0, 0.0 };
+  objectToWorldTransform->TransformPoint(originObject, this->OriginWorld);
   return this->OriginWorld;
 }
 
@@ -365,9 +518,11 @@ void vtkMRMLMarkupsPlaneNode::SetOrigin(const double origin_Node[3])
     }
 
   MRMLNodeModifyBlocker blocker(this);
-  if (this->GetNumberOfControlPoints() < 1)
+  if (this->GetPlaneType() != PlaneTypePlaneFit)
     {
-    this->AddNControlPoints(1);
+    // If we are not using plane fit, then we can generate the control points
+    // base on the current parameters.
+    this->SetIsPlaneValid(true);
     }
 
   double previousOrigin_Node[3] = { 0.0, 0.0, 0.0 };
@@ -379,6 +534,7 @@ void vtkMRMLMarkupsPlaneNode::SetOrigin(const double origin_Node[3])
   vtkNew<vtkTransform> oldToNewOriginTransform;
   oldToNewOriginTransform->Translate(displacementVector_Node);
   this->ApplyTransform(oldToNewOriginTransform);
+  this->UpdateControlPointsFromPlane();
 }
 
 //----------------------------------------------------------------------------
@@ -428,38 +584,13 @@ void vtkMRMLMarkupsPlaneNode::GetBaseToNodeMatrix(vtkMatrix4x4* baseToNodeMatrix
     return;
     }
 
-  if (this->GetNumberOfControlPoints() < 1)
-    {
-    baseToNodeMatrix->Identity();
-    return;
-    }
+  baseToNodeMatrix->DeepCopy(this->BaseToNodeMatrix);
+}
 
-  double point0_Node[3] = { 0.0 };
-  this->GetNthControlPointPosition(0, point0_Node);
-  for (int i = 0; i < 3; ++i)
-    {
-    baseToNodeMatrix->SetElement(i, 3, point0_Node[i]);
-    }
-
-  if (this->GetNumberOfControlPoints() >= 3)
-    {
-    double point1_Node[3] = { 0.0 };
-    double point2_Node[3] = { 0.0 };
-
-    this->GetNthControlPointPosition(1, point1_Node);
-    this->GetNthControlPointPosition(2, point2_Node);
-
-    double xAxis_Node[3] = { 0.0 };
-    double yAxis_Node[3] = { 0.0 };
-    double zAxis_Node[3] = { 0.0 };
-    this->CalculateAxesFromPoints(point0_Node, point1_Node, point2_Node, xAxis_Node, yAxis_Node, zAxis_Node);
-    for (int i = 0; i < 3; ++i)
-      {
-      baseToNodeMatrix->SetElement(i, 0, xAxis_Node[i]);
-      baseToNodeMatrix->SetElement(i, 1, yAxis_Node[i]);
-      baseToNodeMatrix->SetElement(i, 2, zAxis_Node[i]);
-      }
-    }
+//----------------------------------------------------------------------------
+vtkMatrix4x4* vtkMRMLMarkupsPlaneNode::GetBaseToNodeMatrix()
+{
+  return this->BaseToNodeMatrix;
 }
 
 //----------------------------------------------------------------------------
@@ -471,19 +602,10 @@ void vtkMRMLMarkupsPlaneNode::GetObjectToNodeMatrix(vtkMatrix4x4* objectToNodeMa
     return;
     }
 
-  if (this->GetNumberOfControlPoints() < 1)
-    {
-    objectToNodeMatrix->Identity();
-    return;
-    }
-
-  vtkNew<vtkMatrix4x4> baseToNodeMatrix;
-  this->GetBaseToNodeMatrix(baseToNodeMatrix);
-
   vtkNew<vtkTransform> objectToNodeTransform;
   objectToNodeTransform->PostMultiply();
   objectToNodeTransform->Concatenate(this->ObjectToBaseMatrix);
-  objectToNodeTransform->Concatenate(baseToNodeMatrix);
+  objectToNodeTransform->Concatenate(this->BaseToNodeMatrix);
   objectToNodeMatrix->DeepCopy(objectToNodeTransform->GetMatrix());
 }
 
@@ -495,123 +617,157 @@ void vtkMRMLMarkupsPlaneNode::GetObjectToWorldMatrix(vtkMatrix4x4* objectToWorld
     return;
     }
 
-  if (this->GetNumberOfControlPoints() < 1)
+  vtkNew<vtkTransform> objectToWorldTransform;
+  objectToWorldTransform->PostMultiply();
+  objectToWorldTransform->Concatenate(this->ObjectToBaseMatrix);
+  objectToWorldTransform->Concatenate(this->BaseToNodeMatrix);
+  if (this->GetParentTransformNode())
+    {
+    vtkNew<vtkGeneralTransform> transformToWorld;
+    this->GetParentTransformNode()->GetTransformToWorld(transformToWorld);
+    this->GenerateOrthogonalMatrix(objectToWorldTransform->GetMatrix(), objectToWorldMatrix, transformToWorld);
+    }
+  else
+    {
+    objectToWorldMatrix->DeepCopy(objectToWorldTransform->GetMatrix());
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::GetBaseToWorldMatrix(vtkMatrix4x4* baseToWorldMatrix)
+{
+  if (!baseToWorldMatrix)
     {
     return;
     }
 
-  double point0_World[3] = { 0.0 };
-  this->GetNthControlPointPositionWorld(0, point0_World);
-
-  vtkNew<vtkMatrix4x4> baseToWorldMatrix;
-  for (int i = 0; i < 3; ++i)
+  vtkNew<vtkTransform> objectToWorldTransform;
+  objectToWorldTransform->PostMultiply();
+  objectToWorldTransform->Concatenate(this->BaseToNodeMatrix);
+  if (this->GetParentTransformNode())
     {
-    baseToWorldMatrix->SetElement(i, 3, point0_World[i]);
+    vtkNew<vtkGeneralTransform> transformToWorld;
+    this->GetParentTransformNode()->GetTransformToWorld(transformToWorld);
+    this->GenerateOrthogonalMatrix(objectToWorldTransform->GetMatrix(), baseToWorldMatrix, transformToWorld);
     }
-
-  if (this->GetNumberOfControlPoints() >= 3)
+  else
     {
-    double point1_World[3] = { 0.0 };
-    double point2_World[3] = { 0.0 };
-
-    this->GetNthControlPointPositionWorld(1, point1_World);
-    this->GetNthControlPointPositionWorld(2, point2_World);
-
-    double xAxis_World[3] = { 0.0 };
-    double yAxis_World[3] = { 0.0 };
-    double zAxis_World[3] = { 0.0 };
-    this->CalculateAxesFromPoints(point0_World, point1_World, point2_World, xAxis_World, yAxis_World, zAxis_World);
-    for (int i = 0; i < 3; ++i)
-      {
-      baseToWorldMatrix->SetElement(i, 0, xAxis_World[i]);
-      baseToWorldMatrix->SetElement(i, 1, yAxis_World[i]);
-      baseToWorldMatrix->SetElement(i, 2, zAxis_World[i]);
-      }
+    baseToWorldMatrix->DeepCopy(objectToWorldTransform->GetMatrix());
     }
-
-  vtkNew<vtkTransform> objectToNodeTransform;
-  objectToNodeTransform->PostMultiply();
-  objectToNodeTransform->Concatenate(this->ObjectToBaseMatrix);
-  objectToNodeTransform->Concatenate(baseToWorldMatrix);
-  objectToWorldMatrix->DeepCopy(objectToNodeTransform->GetMatrix());
 }
+
 
 //----------------------------------------------------------------------------
 void vtkMRMLMarkupsPlaneNode::GetAxes(double xAxis_Node[3], double yAxis_Node[3], double zAxis_Node[3])
 {
-  if (!xAxis_Node || !yAxis_Node || !zAxis_Node)
+  if (!xAxis_Node && !yAxis_Node && !zAxis_Node)
     {
-    vtkErrorMacro("GetAxes: Invalid input argument");
+    vtkErrorMacro("GetAxes: Invalid input arguments");
     return;
     }
 
-  if (this->GetNumberOfControlPoints() < 3)
-    {
-    vtkWarningMacro("GetAxes: Not enough points to define plane axis");
-    return;
-    }
+  if (xAxis_Node)
+      {
+      xAxis_Node[0] = 1.0;
+      xAxis_Node[1] = 0.0;
+      xAxis_Node[2] = 0.0;
+      }
 
-  for (int i = 0; i < 3; ++i)
-    {
-    xAxis_Node[i] = 0.0;
-    yAxis_Node[i] = 0.0;
-    zAxis_Node[i] = 0.0;
-    }
-  xAxis_Node[0] = 1.0;
-  yAxis_Node[1] = 1.0;
-  zAxis_Node[2] = 1.0;
+  if (yAxis_Node)
+      {
+      yAxis_Node[0] = 0.0;
+      yAxis_Node[1] = 1.0;
+      yAxis_Node[2] = 0.0;
+      }
 
-  double xAxis_Object[3] = { 1.0, 0.0, 0.0 };
-  double yAxis_Object[3] = { 0.0, 1.0, 0.0 };
-  double zAxis_Object[3] = { 0.0, 0.0, 1.0 };
+  if (zAxis_Node)
+      {
+      zAxis_Node[0] = 0.0;
+      zAxis_Node[1] = 0.0;
+      zAxis_Node[2] = 1.0;
+      }
 
   vtkNew<vtkMatrix4x4> objectToNodeMatrix;
   this->GetObjectToNodeMatrix(objectToNodeMatrix);
 
   vtkNew<vtkTransform> objectToNodeTransform;
   objectToNodeTransform->SetMatrix(objectToNodeMatrix);
-  objectToNodeTransform->TransformVector(xAxis_Object, xAxis_Node);
-  objectToNodeTransform->TransformVector(yAxis_Object, yAxis_Node);
-  objectToNodeTransform->TransformVector(zAxis_Object, zAxis_Node);
+
+  if (xAxis_Node)
+    {
+    double xAxis_Object[3] = { 1.0, 0.0, 0.0 };
+    objectToNodeTransform->TransformVector(xAxis_Object, xAxis_Node);
+    }
+
+  if (yAxis_Node)
+    {
+    double yAxis_Object[3] = { 0.0, 1.0, 0.0 };
+    objectToNodeTransform->TransformVector(yAxis_Object, yAxis_Node);
+    }
+
+  if (zAxis_Node)
+    {
+    double zAxis_Object[3] = { 0.0, 0.0, 1.0 };
+    objectToNodeTransform->TransformVector(zAxis_Object, zAxis_Node);
+    }
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLMarkupsPlaneNode::GetAxesWorld(double xAxis_World[3], double yAxis_World[3], double zAxis_World[3])
 {
-  if (!xAxis_World || !yAxis_World || !zAxis_World)
+  if (!xAxis_World && !yAxis_World && !zAxis_World)
     {
-    vtkErrorMacro("GetAxesWorld: Invalid input argument");
+    vtkErrorMacro("GetAxesWorld: Invalid input arguments");
     return;
     }
 
-  if (this->GetNumberOfControlPoints() < 3)
-    {
-    vtkWarningMacro("GetAxes: Not enough points to define plane axis");
-    return;
-    }
+  if (xAxis_World)
+      {
+      xAxis_World[0] = 1.0;
+      xAxis_World[1] = 0.0;
+      xAxis_World[2] = 0.0;
+      }
 
-  for (int i = 0; i < 3; ++i)
-    {
-    xAxis_World[i] = 0.0;
-    yAxis_World[i] = 0.0;
-    zAxis_World[i] = 0.0;
-    }
-  xAxis_World[0] = 1.0;
-  yAxis_World[1] = 1.0;
-  zAxis_World[2] = 1.0;
+  if (yAxis_World)
+      {
+      yAxis_World[0] = 0.0;
+      yAxis_World[1] = 1.0;
+      yAxis_World[2] = 0.0;
+      }
 
-  double xAxis_Object[3] = { 1.0, 0.0, 0.0 };
-  double yAxis_Object[3] = { 0.0, 1.0, 0.0 };
-  double zAxis_Object[3] = { 0.0, 0.0, 1.0 };
+  if (zAxis_World)
+      {
+      zAxis_World[0] = 0.0;
+      zAxis_World[1] = 0.0;
+      zAxis_World[2] = 1.0;
+      }
 
   vtkNew<vtkMatrix4x4> objectToWorldMatrix;
   this->GetObjectToWorldMatrix(objectToWorldMatrix);
 
   vtkNew<vtkTransform> objectToWorldTransform;
   objectToWorldTransform->SetMatrix(objectToWorldMatrix);
-  objectToWorldTransform->TransformVector(xAxis_Object, xAxis_World);
-  objectToWorldTransform->TransformVector(yAxis_Object, yAxis_World);
-  objectToWorldTransform->TransformVector(zAxis_Object, zAxis_World);
+
+  if (xAxis_World)
+    {
+    double xAxis_Object[3] = { 1.0, 0.0, 0.0 };
+    objectToWorldTransform->TransformVector(xAxis_Object, xAxis_World);
+    vtkMath::Normalize(xAxis_World);
+    }
+
+  if (yAxis_World)
+    {
+    double yAxis_Object[3] = { 0.0, 1.0, 0.0 };
+    objectToWorldTransform->TransformVector(yAxis_Object, yAxis_World);
+    vtkMath::Normalize(yAxis_World);
+    }
+
+  if (zAxis_World)
+    {
+    double zAxis_Object[3] = { 0.0, 0.0, 1.0 };
+    objectToWorldTransform->TransformVector(zAxis_Object, zAxis_World);
+    vtkMath::Normalize(zAxis_World);
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -646,7 +802,13 @@ void vtkMRMLMarkupsPlaneNode::SetAxes(const double xAxis_Node[3], const double y
     }
 
   MRMLNodeModifyBlocker blocker(this);
-  this->CreatePlane();
+
+  if (this->GetPlaneType() != PlaneTypePlaneFit)
+    {
+    // If we are not using plane fit, then we can generate the control points
+    // base on the current parameters.
+    this->SetIsPlaneValid(true);
+    }
 
   double previousXAxis_Node[3] = { 0.0 };
   double previousYAxis_Node[3] = { 0.0 };
@@ -683,6 +845,7 @@ void vtkMRMLMarkupsPlaneNode::SetAxes(const double xAxis_Node[3], const double y
   oldToNewAxesTransform->Translate(origin_Node);
 
   this->ApplyTransform(oldToNewAxesTransform);
+  this->UpdateControlPointsFromPlane();
 }
 
 //----------------------------------------------------------------------------
@@ -693,7 +856,6 @@ void vtkMRMLMarkupsPlaneNode::SetAxesWorld(const double xAxis_World[3], const do
   double zAxis_Node[3] = { zAxis_World[0], zAxis_World[1], zAxis_World[2] };
 
   MRMLNodeModifyBlocker blocker(this);
-  this->CreatePlane();
 
   vtkMRMLTransformNode* transformNode = this->GetParentTransformNode();
   if (transformNode)
@@ -712,181 +874,103 @@ void vtkMRMLMarkupsPlaneNode::SetAxesWorld(const double xAxis_World[3], const do
   this->SetAxes(xAxis_Node, yAxis_Node, zAxis_Node);
 }
 
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::UpdateSize()
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::ProcessMRMLEvents(vtkObject* caller, unsigned long event, void* callData)
 {
-  // Size mode auto means we need to recalculate the diameter of the plane from the control points.
-  if (this->SizeMode == vtkMRMLMarkupsPlaneNode::SizeModeAuto)
+  if (caller == this->CurveInputPoly->GetPoints() || caller == this->GetParentTransformNode())
     {
-    if (this->GetNumberOfControlPoints() >= 3)
+    if (!this->IsUpdatingControlPointsFromPlane && !this->IsUpdatingPlaneFromControlPoints)
       {
-      // Get plane size in world coordinate system units
-
-      double point0_World[3] = { 0.0, 0.0, 0.0 };
-      double point1_World[3] = { 0.0, 0.0, 0.0 };
-      double point2_World[3] = { 0.0, 0.0, 0.0 };
-      this->GetNthControlPointPositionWorld(0, point0_World);
-      this->GetNthControlPointPositionWorld(1, point1_World);
-      this->GetNthControlPointPositionWorld(2, point2_World);
-
-      vtkNew<vtkMatrix4x4> objectToWorldMatrix;
-      this->GetObjectToWorldMatrix(objectToWorldMatrix);
-
-      vtkNew<vtkTransform> worldToObjectTransform;
-      worldToObjectTransform->SetMatrix(objectToWorldMatrix);
-      worldToObjectTransform->Inverse();
-
-      double point0_Object[3] = { 0.0, 0.0, 0.0 };
-      double point1_Object[3] = { 0.0, 0.0, 0.0 };
-      double point2_Object[3] = { 0.0, 0.0, 0.0 };
-      worldToObjectTransform->TransformPoint(point0_World, point0_Object);
-      worldToObjectTransform->TransformPoint(point1_World, point1_Object);
-      worldToObjectTransform->TransformPoint(point2_World, point2_Object);
-
-      double xMax = std::max({ std::abs(point0_Object[0]), std::abs(point1_Object[0]), std::abs(point2_Object[0]) });
-      double yMax = std::max({ std::abs(point0_Object[1]), std::abs(point1_Object[1]), std::abs(point2_Object[1]) });
-
-      this->Size[0] = 2.0 * xMax * this->AutoSizeScalingFactor;
-      this->Size[1] = 2.0 * yMax * this->AutoSizeScalingFactor;
-      }
-    else
-      {
-      this->Size[0] = 0.0;
-      this->Size[1] = 0.0;
+      this->UpdatePlaneFromControlPoints();
       }
     }
-
-  this->PlaneBounds[0] = -0.5 * this->Size[0];
-  this->PlaneBounds[1] =  0.5 * this->Size[0];
-  this->PlaneBounds[2] = -0.5 * this->Size[1];
-  this->PlaneBounds[3] =  0.5 * this->Size[1];
-  this->PlaneBounds[4] = 0.0;
-  this->PlaneBounds[5] = 0.0;
+  else if (event == vtkCommand::ModifiedEvent && caller == this->BaseToNodeMatrix.GetPointer())
+    {
+    if (!this->IsUpdatingControlPointsFromPlane && !this->IsUpdatingPlaneFromControlPoints)
+      {
+      this->UpdateInteractionHandleToWorldMatrix();
+      this->UpdateControlPointsFromPlane();
+      }
+    }
+  else if (event == vtkCommand::ModifiedEvent && caller == this->ObjectToBaseMatrix.GetPointer())
+    {
+    this->Modified();
+    }
+  Superclass::ProcessMRMLEvents(caller, event, callData);
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::GetSize(double planeSize_Object[2])
+void vtkMRMLMarkupsPlaneNode::GetSize(double planeSize[2])
 {
-  this->UpdateSize();
-
-  planeSize_Object[0] = this->Size[0];
-  planeSize_Object[1] = this->Size[1];
+  planeSize[0] = this->Size[0];
+  planeSize[1] = this->Size[1];
 }
 
 //----------------------------------------------------------------------------
 double* vtkMRMLMarkupsPlaneNode::GetSize()
 {
-  this->UpdateSize();
   return this->Size;
 }
 
 //----------------------------------------------------------------------------
-double* vtkMRMLMarkupsPlaneNode::GetPlaneBounds()
+void vtkMRMLMarkupsPlaneNode::SetSize(double x, double y)
 {
-  this->UpdateSize();
-  return this->PlaneBounds;
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::GetPlaneBounds(double planeBounds[6])
-{
-  if (!planeBounds)
+  if (this->Size[0] == x && this->Size[1] == y)
     {
-    vtkErrorMacro("GetPlaneBounds: Invalid argument");
     return;
     }
 
-  this->UpdateSize();
-  for (int i = 0; i < 6; ++i)
+  if (this->Size[0] > 0.0)
     {
-    planeBounds[i] = this->PlaneBounds[i];
+    this->PlaneBounds[0] /= this->Size[0];
+    this->PlaneBounds[1] /= this->Size[0];
     }
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::SetPlaneBounds(double planeBounds[6])
-{
-  if (!planeBounds)
+  else
     {
-    vtkErrorMacro("SetPlaneBounds: Invalid argument");
-    return;
+    this->PlaneBounds[0] = -0.5;
+    this->PlaneBounds[1] = 0.5;
     }
 
-  for (int i = 0; i < 6; ++i)
+  if (this->Size[1] > 0.0)
     {
-    this->PlaneBounds[i] = planeBounds[i];
+    this->PlaneBounds[2] /= this->Size[1];
+    this->PlaneBounds[3] /= this->Size[1];
     }
-  for (int i = 0; i < 2; ++i)
+  else
     {
-    this->Size[i] = this->PlaneBounds[2*i+1] - this->PlaneBounds[2*i];
+    this->PlaneBounds[2] = -0.5;
+    this->PlaneBounds[3] = 0.5;
     }
+
+  this->Size[0] = x;
+  this->Size[1] = y;
+
+  this->PlaneBounds[0] *= this->Size[0];
+  this->PlaneBounds[1] *= this->Size[0];
+  this->PlaneBounds[2] *= this->Size[1];
+  this->PlaneBounds[3] *= this->Size[1];
+
   this->Modified();
 }
 
 //----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::SetPlaneBounds(double minX, double maxX, double minY, double maxY, double minZ, double maxZ)
+void vtkMRMLMarkupsPlaneNode::SetPlaneBounds(double x0, double x1, double y0, double y1)
 {
-  double bounds[6] = { minX, maxX, minY, maxY, minZ, maxZ };
-  this->SetPlaneBounds(bounds);
-}
-
-//----------------------------------------------------------------------------
-void vtkMRMLMarkupsPlaneNode::CreatePlane()
-{
-  if (this->GetNumberOfControlPoints() < 3)
+  if (this->PlaneBounds[0] == x0 && this->PlaneBounds[1] == x1
+    && this->PlaneBounds[2] == y0 && this->PlaneBounds[3] == y1)
     {
-    this->AddNControlPoints(3 - this->GetNumberOfControlPoints());
+    return;
     }
 
-  double point0_Node[3] = { 0.0 };
-  double point1_Node[3] = { 0.0 };
-  double point2_Node[3] = { 0.0 };
-  this->GetNthControlPointPosition(0, point0_Node);
-  this->GetNthControlPointPosition(1, point1_Node);
-  this->GetNthControlPointPosition(2, point2_Node);
+  this->PlaneBounds[0] = std::min(x0, x1);
+  this->PlaneBounds[1] = std::max(x0, x1);
+  this->PlaneBounds[2] = std::min(y0, y1);
+  this->PlaneBounds[3] = std::max(y0, y1);
 
-  // Check if existing vectors are unique.
-  double vectorPoint0ToPoint1_Node[3] = { 0.0 };
-  double vectorPoint0ToPoint2_Node[3] = { 0.0 };
-  vtkMath::Subtract(point1_Node, point0_Node, vectorPoint0ToPoint1_Node);
-  vtkMath::Subtract(point2_Node, point0_Node, vectorPoint0ToPoint2_Node);
+  this->Size[0] = std::max(0.0, this->PlaneBounds[1] - this->PlaneBounds[0]);
+  this->Size[1] = std::max(0.0, this->PlaneBounds[3] - this->PlaneBounds[2]);
 
-  bool pointChanged = false;
-  double epsilon = 1e-5;
-  if (vtkMath::Norm(vectorPoint0ToPoint1_Node) <= epsilon)
-    {
-    // Point1 is at same position as point0.
-    // Move point1 away in x axis.
-    double xVector[3] = { 1,0,0 };
-    vtkMath::Add(point1_Node, xVector, point1_Node);
-    pointChanged = true;
-    }
-
-  if (vtkMath::Norm(vectorPoint0ToPoint2_Node) <= epsilon)
-    {
-    // Point2 is at same position as point0.
-    // Move point2 away in y axis.
-    double yVector[3] = { 0,1,0 };
-    vtkMath::Add(point2_Node, yVector, point2_Node);
-    pointChanged = true;
-    }
-
-  vtkMath::Subtract(point1_Node, point0_Node, vectorPoint0ToPoint1_Node);
-  vtkMath::Subtract(point2_Node, point0_Node, vectorPoint0ToPoint2_Node);
-  if (vtkMath::Dot(vectorPoint0ToPoint1_Node, vectorPoint0ToPoint2_Node) >= 1.0 - epsilon)
-    {
-    // Point1 and point2 are along the same vector from point0.
-    // Find a perpendicular vector and move point2.
-    double perpendicular_Node[3] = { 0.0 };
-    vtkMath::Perpendiculars(vectorPoint0ToPoint2_Node, perpendicular_Node, nullptr, 0.0);
-    vtkMath::Add(point0_Node, perpendicular_Node, point2_Node);
-    }
-
-  if (pointChanged)
-    {
-    this->SetNthControlPointPosition(1, point1_Node[0], point1_Node[1], point1_Node[2]);
-    this->SetNthControlPointPosition(2, point2_Node[0], point2_Node[1], point2_Node[2]);
-    }
+  this->Modified();
 }
 
 //----------------------------------------------------------------------------
@@ -896,16 +980,18 @@ vtkMatrix4x4* vtkMRMLMarkupsPlaneNode::GetObjectToBaseMatrix()
 }
 
 //---------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::OnTransformNodeReferenceChanged(vtkMRMLTransformNode* transformNode)
+{
+  Superclass::OnTransformNodeReferenceChanged(transformNode);
+  this->UpdateInteractionHandleToWorldMatrix();
+}
+
+//---------------------------------------------------------------------------
 void vtkMRMLMarkupsPlaneNode::UpdateInteractionHandleToWorldMatrix()
 {
   double handleX_World[3] = { 0.0, 0.0, 0.0 };
   double handleY_World[3] = { 0.0, 0.0, 0.0 };
   double handleZ_World[3] = { 0.0, 0.0, 0.0 };
-  if (this->GetNumberOfControlPoints() < 3)
-    {
-    return;
-    }
-
   this->GetAxesWorld(handleX_World, handleY_World, handleZ_World);
 
   double origin_World[3] = { 0.0, 0.0, 0.0 };
@@ -979,4 +1065,665 @@ vtkMRMLStorageNode* vtkMRMLMarkupsPlaneNode::CreateDefaultStorageNode()
     }
   return vtkMRMLStorageNode::SafeDownCast(
     scene->CreateNodeByClass("vtkMRMLMarkupsPlaneJsonStorageNode"));
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::CreateDefaultDisplayNodes()
+{
+  if (this->GetDisplayNode() != nullptr &&
+    vtkMRMLMarkupsPlaneDisplayNode::SafeDownCast(this->GetDisplayNode()) != nullptr)
+    {
+    // display node already exists
+    return;
+    }
+  if (this->GetScene() == nullptr)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsPlaneNode::CreateDefaultDisplayNodes failed: scene is invalid");
+    return;
+    }
+  vtkMRMLMarkupsPlaneDisplayNode* dispNode = vtkMRMLMarkupsPlaneDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLMarkupsPlaneDisplayNode"));
+  if (!dispNode)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsPlaneNode::CreateDefaultDisplayNodes failed: scene failed to instantiate a vtkMRMLMarkupsPlaneDisplayNode node");
+    return;
+    }
+  this->SetAndObserveDisplayNodeID(dispNode->GetID());
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::GetRASBounds(double bounds[6])
+{
+  if (!bounds)
+    {
+    vtkErrorMacro("Invalid bounds argument");
+    return;
+    }
+
+  double xAxis_World[3] = { 0.0, 0.0, 0.0 };
+  double yAxis_World[3] = { 0.0, 0.0, 0.0 };
+  this->GetAxesWorld(xAxis_World, yAxis_World, nullptr);
+
+  double centerWorld[3] = { 0.0, 0.0, 0.0 };
+  this->GetCenterWorld(centerWorld);
+
+  double planeBounds[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  this->CalculatePlaneBounds(planeBounds, xAxis_World, yAxis_World, centerWorld, this->Size);
+
+  // Get bounds from control points
+  Superclass::GetRASBounds(bounds);
+  bounds[0] = std::min(bounds[0], planeBounds[0]);
+  bounds[1] = std::max(bounds[1], planeBounds[1]);
+  bounds[2] = std::min(bounds[2], planeBounds[2]);
+  bounds[3] = std::max(bounds[3], planeBounds[3]);
+  bounds[4] = std::min(bounds[4], planeBounds[4]);
+  bounds[5] = std::max(bounds[5], planeBounds[5]);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::GetBounds(double bounds[6])
+{
+  if (!bounds)
+    {
+    vtkErrorMacro("Invalid bounds argument");
+    return;
+    }
+
+  double xAxis_Node[3] = { 0.0, 0.0, 0.0 };
+  double yAxis_Node[3] = { 0.0, 0.0, 0.0 };
+  this->GetAxes(xAxis_Node, yAxis_Node, nullptr);
+
+  double center_Node[3] = { 0.0, 0.0, 0.0 };
+  this->GetCenterWorld(center_Node);
+
+  double planeBounds[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  this->CalculatePlaneBounds(planeBounds, xAxis_Node, yAxis_Node, center_Node, this->Size);
+
+  // Get bounds from control points
+  Superclass::GetBounds(bounds);
+  bounds[0] = std::min(bounds[0], planeBounds[0]);
+  bounds[1] = std::max(bounds[1], planeBounds[1]);
+  bounds[2] = std::min(bounds[2], planeBounds[2]);
+  bounds[3] = std::max(bounds[3], planeBounds[3]);
+  bounds[4] = std::min(bounds[4], planeBounds[4]);
+  bounds[5] = std::max(bounds[5], planeBounds[5]);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::CalculatePlaneBounds(double bounds[6], double xAxis[3], double yAxis[3], double center[3], double size[2])
+{
+  if (!bounds || !xAxis || !yAxis || !center || !size)
+    {
+    vtkErrorMacro("CalculatePlaneBounds: Invalid arguments");
+    return;
+    }
+
+  double xVector[3] = { xAxis[0], xAxis[1], xAxis[2] };
+  vtkMath::MultiplyScalar(xVector, 0.5 * size[0]);
+
+  double yVector[3] = { yAxis[0], yAxis[1], yAxis[2] };
+  vtkMath::MultiplyScalar(yVector, 0.5 * size[1]);
+
+  vtkBoundingBox box;
+  for (int j = 0; j < 2; ++j)
+    {
+    for (int i = 0; i < 2; ++i)
+      {
+      double cornerPoint[3] = { 0.0, 0.0, 0.0 };
+      vtkMath::Add(cornerPoint, center, cornerPoint);
+      if (i == 0)
+        {
+        vtkMath::Subtract(cornerPoint, xVector, cornerPoint);
+        }
+      else
+        {
+        vtkMath::Add(cornerPoint, xVector, cornerPoint);
+        }
+
+      if (j == 0)
+        {
+        vtkMath::Subtract(cornerPoint, yVector, cornerPoint);
+        }
+      else
+        {
+        vtkMath::Add(cornerPoint, yVector, cornerPoint);
+        }
+
+      box.AddPoint(cornerPoint);
+      }
+    }
+  box.GetBounds(bounds);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdatePlaneFromControlPoints()
+{
+  if (this->IsUpdatingControlPointsFromPlane || this->IsUpdatingPlaneFromControlPoints)
+    {
+    return;
+    }
+
+  this->IsUpdatingPlaneFromControlPoints = true;
+    {
+    // Block events in this scope
+    MRMLNodeModifyBlocker blocker(this);
+
+    switch (this->PlaneType)
+      {
+      case PlaneTypePointNormal:
+        this->UpdatePlaneFromPointNormal();
+        break;
+      case PlaneType3Points:
+        this->UpdatePlaneFrom3Points();
+        break;
+      case PlaneTypePlaneFit:
+        this->UpdatePlaneFromPlaneFit();
+        break;
+      default:
+        break;
+      }
+    }
+  this->IsUpdatingPlaneFromControlPoints = false;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdatePlaneFromPointNormal()
+{
+  double origin_Node[3] = { 0.0, 0.0, 0.0 };
+  if (this->GetNumberOfControlPoints() > 0)
+    {
+    this->GetNthControlPointPosition(0, origin_Node);
+    }
+
+  vtkNew<vtkTransform> baseToNodeTransform;
+  baseToNodeTransform->PostMultiply();
+  baseToNodeTransform->Concatenate(this->BaseToNodeMatrix);
+
+  double oldOrigin_Node[3] = { 0.0, 0.0, 0.0 };
+  baseToNodeTransform->TransformPoint(oldOrigin_Node, oldOrigin_Node);
+
+  baseToNodeTransform->Translate(-oldOrigin_Node[0], -oldOrigin_Node[1], -oldOrigin_Node[2]);
+
+  double oldZ_Node[3] = { 0.0, 0.0, 1.0 };
+  baseToNodeTransform->TransformVector(oldZ_Node, oldZ_Node);
+
+  double newX_Node[3] = { 1.0, 0.0, 0.0 };
+  double newY_Node[3] = { 0.0, 1.0, 0.0 };
+  double newZ_Node[3] = { 0.0, 0.0, 1.0 };
+  if (this->GetNumberOfControlPoints() > 1)
+    {
+    double normalPoint_Node[3] = { 0.0, 0.0, 0.0 };
+    this->GetNthControlPointPosition(1, normalPoint_Node);
+    vtkMath::Subtract(normalPoint_Node, origin_Node, newZ_Node);
+    vtkMath::Normalize(newZ_Node);
+
+    vtkMath::Perpendiculars(newZ_Node, newX_Node, newY_Node, 0.0);
+    }
+  else
+    {
+    baseToNodeTransform->TransformVector(newX_Node, newX_Node);
+    baseToNodeTransform->TransformVector(newY_Node, newY_Node);
+    baseToNodeTransform->TransformVector(newZ_Node, newZ_Node);
+    }
+
+  double angle = vtkMath::DegreesFromRadians(vtkMath::AngleBetweenVectors(oldZ_Node, newZ_Node));
+  double epsilon = 0.001;
+  if (angle > epsilon)
+    {
+    double rotationVector_Node[3] = { 1.0, 0.0, 0.0 };
+    vtkMath::Cross(oldZ_Node, newZ_Node, rotationVector_Node);
+    vtkMath::Normalize(rotationVector_Node);
+    baseToNodeTransform->RotateWXYZ(angle, rotationVector_Node);
+    }
+  baseToNodeTransform->Translate(origin_Node);
+  this->BaseToNodeMatrix->DeepCopy(baseToNodeTransform->GetMatrix());
+
+  if (this->GetNumberOfDefinedControlPoints() >= 1 && this->Size[0] >= 0.0 && this->Size[1] >= 0.0)
+    {
+    this->SetIsPlaneValid(true);
+    }
+  else
+    {
+    this->SetIsPlaneValid(false);
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdatePlaneFrom3Points()
+{
+  if (this->GetNumberOfControlPoints() < 3)
+    {
+    // Not enough points to define the plane
+    this->SetIsPlaneValid(false);
+    return;
+    }
+
+  double point0_Node[3] = { 0.0 };
+  this->GetNthControlPointPosition(0, point0_Node);
+
+  vtkNew<vtkMatrix4x4> baseToNodeMatrix;
+  for (int i = 0; i < 3; ++i)
+    {
+    baseToNodeMatrix->SetElement(i, 3, point0_Node[i]);
+    }
+
+  if (this->GetNumberOfControlPoints() >= 3)
+    {
+    double point1_Node[3] = { 0.0 };
+    double point2_Node[3] = { 0.0 };
+
+    this->GetNthControlPointPosition(1, point1_Node);
+    this->GetNthControlPointPosition(2, point2_Node);
+
+    double xAxis_Node[3] = { 0.0 };
+    double yAxis_Node[3] = { 0.0 };
+    double zAxis_Node[3] = { 0.0 };
+    this->CalculateAxesFromPoints(point0_Node, point1_Node, point2_Node, xAxis_Node, yAxis_Node, zAxis_Node);
+    for (int i = 0; i < 3; ++i)
+      {
+      baseToNodeMatrix->SetElement(i, 0, xAxis_Node[i]);
+      baseToNodeMatrix->SetElement(i, 1, yAxis_Node[i]);
+      baseToNodeMatrix->SetElement(i, 2, zAxis_Node[i]);
+      }
+    }
+  this->BaseToNodeMatrix->DeepCopy(baseToNodeMatrix);
+
+  this->SetIsPlaneValid(true);
+  this->UpdatePlaneSize();
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLMarkupsPlaneNode::GetClosestFitPlaneFromControlPoints(vtkMatrix4x4* closestFitPlane)
+{
+  // The orientation of the coordinate system is adjusted so that the z axis aligns with the normal of the
+  // best fit plane defined by the control points.
+
+  int numberOfControlPoints = this->GetNumberOfMarkups();
+  vtkNew<vtkPoints> controlPoints_Node;
+  for (int i = 0; i < numberOfControlPoints; ++i)
+    {
+    double controlPointPosition_Node[3] = { 0.0 };
+    this->GetNthControlPointPosition(i, controlPointPosition_Node);
+    controlPoints_Node->InsertNextPoint(controlPointPosition_Node);
+    }
+
+  vtkNew<vtkPlane> bestFitPlane_Node;
+  if (!vtkAddonMathUtilities::FitPlaneToPoints(controlPoints_Node, bestFitPlane_Node))
+    {
+    vtkErrorMacro("GetClosestFitPlaneFromControlPoints: Could not fit plane to points");
+    return false;
+    }
+
+  double newZ_Node[3] = { 0.0, 0.0, 0.0 };
+  bestFitPlane_Node->GetNormal(newZ_Node);
+
+  vtkNew<vtkMatrix4x4> oldBaseToNodeMatrix;
+  this->GetBaseToNodeMatrix(oldBaseToNodeMatrix);
+
+  vtkNew<vtkTransform> oldBaseToNodeTransform;
+  oldBaseToNodeTransform->SetMatrix(oldBaseToNodeMatrix);
+
+  double oldZ_Node[3] = { 0.0, 0.0, 1.0 };
+  oldBaseToNodeTransform->TransformVector(oldZ_Node, oldZ_Node);
+
+  if (vtkMath::Dot(oldZ_Node, newZ_Node) < -0.9)
+    {
+    vtkMath::MultiplyScalar(newZ_Node, -1.0);
+    }
+
+  double oldOrigin_Node[3] = { 0.0, 0.0, 0.0 };
+  oldBaseToNodeTransform->TransformPoint(oldOrigin_Node, oldOrigin_Node);
+
+  vtkNew<vtkTransform> baseToNodeTransform;
+  baseToNodeTransform->PostMultiply();
+  baseToNodeTransform->Concatenate(oldBaseToNodeMatrix);
+  baseToNodeTransform->Translate(-oldOrigin_Node[0], -oldOrigin_Node[1], -oldOrigin_Node[2]);
+
+  double angle = vtkMath::DegreesFromRadians(vtkMath::AngleBetweenVectors(oldZ_Node, newZ_Node));
+  double epsilon = 0.001;
+  if (angle > epsilon)
+    {
+    double rotationVector_Node[3] = { 1.0, 0.0, 0.0 };
+    vtkMath::Cross(oldZ_Node, newZ_Node, rotationVector_Node);
+    vtkMath::Normalize(rotationVector_Node);
+    baseToNodeTransform->RotateWXYZ(angle, rotationVector_Node);
+    }
+  baseToNodeTransform->Translate(bestFitPlane_Node->GetOrigin());
+  closestFitPlane->DeepCopy(baseToNodeTransform->GetMatrix());
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdatePlaneFromPlaneFit()
+{
+  // The origin of the coordinate system is at the center of mass of the control points
+  if (this->GetNumberOfControlPoints() < 3)
+    {
+    this->BaseToNodeMatrix->Identity();
+    if (this->SizeMode == vtkMRMLMarkupsPlaneNode::SizeModeAuto)
+      {
+      this->SetSize(0.0, 0.0);
+      }
+    this->SetIsPlaneValid(false);
+    return;
+    }
+
+  // The orientation of the coordinate system is adjusted so that the z axis aligns with the normal of the
+  // best fit plane defined by the control points.
+  vtkNew<vtkMatrix4x4> bestFitMatrix_Node;
+  bool valid = this->GetClosestFitPlaneFromControlPoints(this->BaseToNodeMatrix);
+  this->SetIsPlaneValid(valid);
+  this->UpdatePlaneSize();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdatePlaneSize()
+{
+  if (this->SizeMode != vtkMRMLMarkupsPlaneNode::SizeModeAuto)
+    {
+    return;
+    }
+
+  if (!this->GetIsPlaneValid())
+    {
+    this->SetSize(0.0, 0.0);
+    return;
+    }
+
+  vtkNew<vtkMatrix4x4> objectToBaseMatrix;
+  this->GetBaseToWorldMatrix(objectToBaseMatrix);
+
+  vtkNew<vtkTransform> worldToBaseTransform;
+  worldToBaseTransform->SetMatrix(objectToBaseMatrix);
+  worldToBaseTransform->Inverse();
+
+  double xMax_Base = 0.0;
+  double yMax_Base = 0.0;
+
+  // Size mode auto means we need to recalculate the diameter of the plane from the control points.
+  // Get plane size in world coordinate system units
+  for (int i = 0; i < this->GetNumberOfControlPoints(); ++i)
+    {
+    double point_World[3] = { 0.0, 0.0, 0.0 };
+    this->GetNthControlPointPositionWorld(i, point_World);
+
+    double point_Base[3] = { 0.0, 0.0, 0.0 };
+    worldToBaseTransform->TransformPoint(point_World, point_Base);
+
+    xMax_Base = std::max({ std::abs(point_Base[0]), xMax_Base });
+    yMax_Base = std::max({ std::abs(point_Base[1]), yMax_Base });
+    }
+
+  double xRadius = xMax_Base * this->AutoSizeScalingFactor;
+  double yRadius = yMax_Base * this->AutoSizeScalingFactor;
+  this->SetPlaneBounds(-xRadius, xRadius, -yRadius, yRadius);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdateControlPointsFromPlane()
+{
+  if (this->IsUpdatingControlPointsFromPlane || this->IsUpdatingPlaneFromControlPoints || !this->GetIsPlaneValid())
+    {
+    return;
+    }
+
+  this->IsUpdatingControlPointsFromPlane = true;
+
+  {
+    // Block events in this scope
+    MRMLNodeModifyBlocker blocker(this);
+
+    switch (this->PlaneType)
+      {
+      case vtkMRMLMarkupsPlaneNode::PlaneTypePointNormal:
+        this->UpdateControlPointsFromPointNormal();
+        break;
+      case vtkMRMLMarkupsPlaneNode::PlaneType3Points:
+        this->UpdateControlPointsFrom3Points();
+        break;
+      case vtkMRMLMarkupsPlaneNode::PlaneTypePlaneFit:
+        this->UpdateControlPointsFromPlaneFit();
+        break;
+      default:
+        break;
+      }
+  }
+
+  this->IsUpdatingControlPointsFromPlane = false;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdateControlPointsFromPointNormal()
+{
+  if (!this->NormalPointRequired && this->GetNumberOfDefinedControlPoints() > 1)
+    {
+    while (this->GetNumberOfDefinedControlPoints() > 1)
+      {
+      this->RemoveNthControlPoint(1);
+      }
+    }
+
+  if (this->GetIsPlaneValid() && this->GetNumberOfControlPoints() == 0)
+    {
+    this->AddControlPoint(vtkVector3d());
+    }
+
+  if (this->GetIsPlaneValid() && this->GetNumberOfControlPoints() > 0)
+    {
+    vtkNew<vtkMatrix4x4> baseToWorldMatrix;
+    this->GetBaseToWorldMatrix(baseToWorldMatrix);
+
+    vtkNew<vtkTransform> baseToWorldTransform;
+    baseToWorldTransform->SetMatrix(baseToWorldMatrix);
+
+    double origin_World[3] = { 0,0,0 };
+    baseToWorldTransform->TransformPoint(origin_World, origin_World);
+
+    this->SetNthControlPointPositionWorldFromArray(0, origin_World, this->GetNthControlPointPositionStatus(0));
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdateControlPointsFrom3Points()
+{
+  if (!this->GetIsPlaneValid())
+    {
+    return;
+    }
+
+  if (this->Size[0] <= 0.0 || this->Size[1] <= 0.0)
+    {
+    return;
+    }
+
+  if (this->GetNumberOfDefinedControlPoints() > 3)
+    {
+    // If we switch from another plane type, we may have more than 3 points
+    // Remove them until we only have 3.
+    while (this->GetNumberOfDefinedControlPoints() > 3)
+      {
+      this->RemoveNthControlPoint(3);
+      }
+    }
+
+  vtkNew<vtkMatrix4x4> baseToWorldMatrix;
+  this->GetBaseToWorldMatrix(baseToWorldMatrix);
+
+  vtkNew<vtkTransform> baseToWorldTransform;
+  baseToWorldTransform->SetMatrix(baseToWorldMatrix);
+
+  double origin_World[3]{ 0.0, 0.0, 0.0 };
+  baseToWorldTransform->TransformPoint(origin_World, origin_World);
+
+  double xAxis_World[3] = { 1.0, 0.0, 0.0 };
+  baseToWorldTransform->TransformVector(xAxis_World, xAxis_World);
+
+  double yAxis_World[3] = { 0.0, 1.0, 0.0 };
+  baseToWorldTransform->TransformVector(yAxis_World, yAxis_World);
+
+  /// If the plane is valid but doesn't have all 3 points placed, then place the remaining points
+  if (this->GetNumberOfControlPoints() < 3)
+    {
+    this->AddNControlPoints(3 - this->GetNumberOfControlPoints());
+
+    double point1_World[3] = { 0.0, 0.0, 0.0 };
+    vtkMath::MultiplyScalar(xAxis_World, this->Size[0] * 0.5);
+    vtkMath::Add(origin_World, xAxis_World, point1_World);
+
+    double point2_World[3] = { 0.0, 0.0, 0.0 };
+    vtkMath::MultiplyScalar(yAxis_World, this->Size[1] * 0.5);
+    vtkMath::Add(origin_World, yAxis_World, point2_World);
+
+    this->SetNthControlPointPositionWorldFromArray(0, origin_World);
+    this->SetNthControlPointPositionWorldFromArray(1, point1_World);
+    this->SetNthControlPointPositionWorldFromArray(2, point2_World);
+    }
+
+  double point0_World[3] = { 0.0, 0.0, 0.0 };
+  double point1_World[3] = { 0.0, 0.0, 0.0 };
+  double point2_World[3] = { 0.0, 0.0, 0.0 };
+  this->GetNthControlPointPositionWorld(0, point0_World);
+  this->GetNthControlPointPositionWorld(1, point1_World);
+  this->GetNthControlPointPositionWorld(2, point2_World);
+
+  // Check if existing vectors are unique.
+  double vectorPoint0ToPoint1_World[3] = { 0.0, 0.0, 0.0 };
+  vtkMath::Subtract(point1_World, point0_World, vectorPoint0ToPoint1_World);
+  double distancePoint0ToPoint1_World = vtkMath::Normalize(vectorPoint0ToPoint1_World);
+
+  double vectorPoint0ToPoint2_World[3] = { 0.0, 0.0, 0.0 };
+  vtkMath::Subtract(point2_World, point0_World, vectorPoint0ToPoint2_World);
+  double distancePoint0ToPoint2_World = vtkMath::Normalize(vectorPoint0ToPoint2_World);
+
+  bool pointChanged = false;
+  double epsilon = 1e-5;
+  if (distancePoint0ToPoint1_World <= epsilon)
+    {
+    // Point1 is at same position as point0.
+    // Move point1 away in x axis.
+    vtkMath::Add(point1_World, xAxis_World, point1_World);
+    pointChanged = true;
+    }
+
+  if (distancePoint0ToPoint2_World <= epsilon)
+    {
+    // Point2 is at same position as point0.
+    // Move point2 away in y axis.
+    vtkMath::Add(point2_World, yAxis_World, point2_World);
+    pointChanged = true;
+    }
+
+  if (vtkMath::Dot(vectorPoint0ToPoint1_World, vectorPoint0ToPoint2_World) >= 1.0 - epsilon)
+    {
+    // Point1 and point2 are along the same vector from point0.
+    // Find a perpendicular vector and move point2.
+    double perpendicularAxis_World[3] = { 0.0, 0.0, 0.0 };
+    vtkMath::Perpendiculars(vectorPoint0ToPoint2_World, perpendicularAxis_World, nullptr, 0.0);
+    vtkMath::Add(point0_World, perpendicularAxis_World, point2_World);
+    }
+
+  if (pointChanged)
+    {
+    this->SetNthControlPointPositionWorldFromArray(0, point0_World);
+    this->SetNthControlPointPositionWorldFromArray(1, point1_World);
+    this->SetNthControlPointPositionWorldFromArray(2, point2_World);
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::UpdateControlPointsFromPlaneFit()
+{
+  // Determine the plane origin and normal using the current control points
+  vtkNew<vtkMatrix4x4> bestFitMatrix_Node;
+  this->GetClosestFitPlaneFromControlPoints(bestFitMatrix_Node);
+
+  vtkNew<vtkMatrix4x4> oldNodeToBase;
+  vtkMatrix4x4::Invert(bestFitMatrix_Node, oldNodeToBase);
+
+  vtkNew<vtkTransform> oldToNewTransform;
+  oldToNewTransform->PostMultiply();
+  oldToNewTransform->Concatenate(oldNodeToBase);
+  oldToNewTransform->Concatenate(this->BaseToNodeMatrix);
+
+  vtkNew<vtkTransformPolyDataFilter> transformPoints;
+  transformPoints->SetInputData(this->CurveInputPoly);
+  transformPoints->SetTransform(oldToNewTransform);
+  transformPoints->Update();
+  this->SetControlPointPositionsWorld(transformPoints->GetOutput()->GetPoints());
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::GenerateOrthogonalMatrix(vtkMatrix4x4* inputMatrix,
+  vtkMatrix4x4* outputMatrix, vtkAbstractTransform* transform/*=nullptr*/, bool applyScaling/*=true*/)
+{
+  double xAxis[3] = { 0.0, 0.0, 0.0 };
+  double yAxis[3] = { 0.0, 0.0, 0.0 };
+  double zAxis[3] = { 0.0, 0.0, 0.0 };
+  double origin[3] = { 0.0,0.0, 0.0 };
+  for (int i = 0; i < 3; ++i)
+    {
+    xAxis[i] = inputMatrix->GetElement(i, 0);
+    yAxis[i] = inputMatrix->GetElement(i, 1);
+    zAxis[i] = inputMatrix->GetElement(i, 2);
+    origin[i] = inputMatrix->GetElement(i, 3);
+    }
+  vtkMRMLMarkupsPlaneNode::GenerateOrthogonalMatrix(xAxis, yAxis, zAxis, origin, outputMatrix, transform, applyScaling);
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLMarkupsPlaneNode::GenerateOrthogonalMatrix(double xAxis[3], double yAxis[3], double zAxis[3], double origin[3],
+  vtkMatrix4x4* outputMatrix, vtkAbstractTransform* transform/*=nullptr*/, bool applyScaling/*=true*/)
+{
+  if (!xAxis || !yAxis || !zAxis || !origin || !transform || !outputMatrix)
+    {
+    vtkGenericWarningMacro("GenerateOrthogonalMatrix: Invalid arguments");
+    return;
+    }
+
+  double xAxisTransformed[3] = { xAxis[0],  xAxis[1], xAxis[2] };
+  double yAxisTransformed[3] = { yAxis[0],  yAxis[1], yAxis[2] };
+  double zAxisTransformed[3] = { zAxis[0],  zAxis[1], zAxis[2] };
+  double originTransformed[3] = { origin[0],  origin[1], origin[2] };
+
+  double xAxisScale = vtkMath::Norm(xAxis);
+  double yAxisScale = vtkMath::Norm(yAxis);
+  double zAxisScale = vtkMath::Norm(zAxis);
+
+  if (transform)
+    {
+    transform->TransformVectorAtPoint(origin, xAxis, xAxisTransformed);
+    transform->TransformVectorAtPoint(origin, yAxis, yAxisTransformed);
+    transform->TransformVectorAtPoint(origin, zAxis, zAxisTransformed);
+    transform->TransformPoint(origin, originTransformed);
+    }
+
+  vtkMath::Cross(xAxisTransformed, yAxisTransformed, zAxisTransformed);
+  vtkMath::Normalize(zAxisTransformed);
+  vtkMath::Cross(zAxisTransformed, xAxisTransformed, yAxisTransformed);
+  vtkMath::Normalize(yAxisTransformed);
+  vtkMath::Cross(yAxisTransformed, zAxisTransformed, xAxisTransformed);
+  vtkMath::Normalize(xAxisTransformed);
+
+  if (applyScaling)
+    {
+    if (transform)
+      {
+      vtkAbstractTransform* inverseTransform = transform->GetInverse();
+      xAxisScale /= vtkMath::Norm(inverseTransform->TransformVectorAtPoint(originTransformed, xAxisTransformed));
+      yAxisScale /= vtkMath::Norm(inverseTransform->TransformVectorAtPoint(originTransformed, yAxisTransformed));
+      zAxisScale /= vtkMath::Norm(inverseTransform->TransformVectorAtPoint(originTransformed, zAxisTransformed));
+      }
+    vtkMath::MultiplyScalar(xAxisTransformed, xAxisScale);
+    vtkMath::MultiplyScalar(yAxisTransformed, yAxisScale);
+    vtkMath::MultiplyScalar(zAxisTransformed, zAxisScale);
+    }
+
+  for (int i = 0; i < 3; ++i)
+    {
+    outputMatrix->SetElement(i, 0, xAxisTransformed[i]);
+    outputMatrix->SetElement(i, 1, yAxisTransformed[i]);
+    outputMatrix->SetElement(i, 2, zAxisTransformed[i]);
+    outputMatrix->SetElement(i, 3, originTransformed[i]);
+    }
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
@@ -25,9 +25,9 @@
 #include "vtkMRMLDisplayableNode.h"
 
 // Markups includes
-#include "vtkSlicerMarkupsModuleMRMLExport.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
 #include "vtkMRMLMarkupsNode.h"
+#include "vtkSlicerMarkupsModuleMRMLExport.h"
 
 // VTK includes
 #include <vtkMatrix4x4.h>
@@ -75,6 +75,15 @@ public:
     SizeMode_Last,
   };
 
+  /// Plane type defines the calculation method that should be used to convert to and from control points.
+  enum
+  {
+    PlaneType3Points,
+    PlaneTypePointNormal,
+    PlaneTypePlaneFit,
+    PlaneType_Last
+  };
+
   vtkMRMLNode* CreateNodeInstance() override;
   /// Get node XML tag name (like Volume, Model)
   const char* GetNodeTagName() override {return "MarkupsPlane";}
@@ -98,15 +107,18 @@ public:
   /// \sa vtkMRMLNode::CopyContent
   vtkMRMLCopyContentMacro(vtkMRMLMarkupsPlaneNode);
 
+  /// Apply the passed transformation to the ROI
+  void ApplyTransform(vtkAbstractTransform* transform) override;
+
   //@{
   /// Method for calculating the size of the plane along the direction vectors.
   /// With size mode auto, the size of the plane is automatically calculated so that it ecompasses all of the points.
   /// Size mode absolute will never be recalculated.
   /// Default is SizeModeAuto.
-  vtkSetMacro(SizeMode, int);
+  void SetSizeMode(int sizeMode);
   vtkGetMacro(SizeMode, int);
-  const char* GetSizeModeAsString(int sizeMode);
-  int GetSizeModeFromString(const char* sizeMode);
+  static const char* GetSizeModeAsString(int sizeMode);
+  static int GetSizeModeFromString(const char* sizeMode);
   //@}
 
   /// The plane size multiplier used to calculate the size of the plane.
@@ -117,24 +129,21 @@ public:
   //@}
 
   //@{
-  /// Get/Set bounds of the plane in the object coordinate system.
-  /// The size is defined in world coordinate system units.
-  /// When the size mode is auto, plane bounds are updated automatically
-  /// from the input control points.
-  void GetPlaneBounds(double bounds[6]);
-  double* GetPlaneBounds() VTK_SIZEHINT(6);
-  void SetPlaneBounds(double bounds[6]);
-  void SetPlaneBounds(double, double, double, double, double, double);
-  //@}
-
-  //@{
   /// Get/Set size of the plane in the object coordinate system.
   /// The size is defined in world coordinate system units.
   /// When the size mode is auto, plane size is updated automatically
   /// from the input control points.
   void GetSize(double size[2]);
   double* GetSize() VTK_SIZEHINT(2);
-  vtkSetVector2Macro(Size, double);
+  virtual void SetSize(double x, double y);
+  virtual void SetSize(double size[2]) { this->SetSize(size[0], size[1]); }
+  //@}
+
+  //@{
+  /// Get/Set the bounds of the plane in Object coordinates
+  vtkGetVector4Macro(PlaneBounds, double);
+  virtual void SetPlaneBounds(double x0, double x1, double y0, double y1);
+  virtual void SetPlaneBounds(double bounds[4]) { this->SetPlaneBounds(bounds[0], bounds[1], bounds[2], bounds[3]); };
   //@}
 
   //@{
@@ -185,12 +194,17 @@ public:
   void SetAxesWorld(const double x[3], const double y[3], const double z[3]);
   //@}
 
-  // Mapping from XYZ plane coordinates to local coordinates
-  virtual void GetObjectToNodeMatrix(vtkMatrix4x4* planeToNodeMatrix);
-  // Mapping from XYZ plane coordinates to world coordinates
-  virtual void GetObjectToWorldMatrix(vtkMatrix4x4* planeToWorldMatrix);
-  // Mapping from Base plane coordinates to local coordinates
+  /// Mapping from XYZ plane coordinates to local coordinates
+  virtual void GetObjectToNodeMatrix(vtkMatrix4x4* objectToNodeMatrix);
+  /// Mapping from XYZ plane coordinates to world coordinates
+  virtual void GetObjectToWorldMatrix(vtkMatrix4x4* objectToWorldMatrix);
+  /// Mapping from Base plane coordinates to world coordinates
+  virtual void GetBaseToWorldMatrix(vtkMatrix4x4* baseToWorldMatrix);
+  //@{
+  /// Mapping from Base plane coordinates to local coordinates
   virtual void GetBaseToNodeMatrix(vtkMatrix4x4* matrix);
+  virtual vtkMatrix4x4* GetBaseToNodeMatrix();
+  //@}
 
   /// 4x4 matrix specifying the relative (rotation/translation) of the plane from the base coordinate system defined by the markup points.
   /// Default is the identity matrix.
@@ -208,19 +222,94 @@ public:
   /// Create default storage node or nullptr if does not have one
   vtkMRMLStorageNode* CreateDefaultStorageNode() override;
 
+  /// Create default display node or nullptr if does not have one
+  void CreateDefaultDisplayNodes() override;
+
+  //@{
+  /// Reimplemented to recalculate the axis-aligned bounds of the plane.
+  /// \sa GetPlanes(), GetPlanesWorld()
+  void GetRASBounds(double bounds[6]) override;
+  void GetBounds(double bounds[6]) override;
+  //@}
+
+  //@{
+  /// PlaneType is an enum that represents the method that is used to calculate the size of the ROI.
+  /// PlaneType3Points: Use 3 points to define the plane. Point 0 defines the origin, point 1 defines
+  ///   the x-axis, and the final point completes plane definition.
+  /// PlaneTypePointNormal (default): Origin (point 0). Normal (vector from point 0 to point1).
+  /// PlaneTypePlaneFit: Plane is fit to any number of control points.
+  vtkGetMacro(PlaneType, int);
+  void SetPlaneType(int planeType);
+  static const char* GetPlaneTypeAsString(int planeType);
+  static int GetPlaneTypeFromString(const char* planeType);
+  //@}
+
+  /// Get plane validity flag. True if the plane is fully defined.
+  vtkGetMacro(IsPlaneValid, bool);
+
+  //@{
+  /// Helper method for generating an orthogonal right handed matrix from axes.
+  /// Transform can optionally be specified to apply an additional transform on the vectors before generating the matrix.
+  static void GenerateOrthogonalMatrix(vtkMatrix4x4* inputMatrix,
+    vtkMatrix4x4* outputMatrix, vtkAbstractTransform* transform = nullptr, bool applyScaling = true);
+  static void GenerateOrthogonalMatrix(double xAxis[3], double yAxis[3], double zAxis[3], double origin[3],
+    vtkMatrix4x4* outputMatrix, vtkAbstractTransform* transform = nullptr, bool applyScaling = true);
+  //@}
+
+  /// Re-implemented to react to changes in internal matrices or control points.
+  void ProcessMRMLEvents(vtkObject* caller, unsigned long event, void* callData) override;
+
 protected:
+
+  vtkSetMacro(MaximumNumberOfControlPoints, int);
+  vtkSetMacro(RequiredNumberOfControlPoints, int);
+
+  // Set plane validity flag. True if the plane is fully defined.
+  vtkSetMacro(IsPlaneValid, bool);
+
+  /// Reimplemented to recalculate InteractionHandleToWorld matrix when parent transform is changed.
+  void OnTransformNodeReferenceChanged(vtkMRMLTransformNode* transformNode) override;
 
   /// Calculates the x y and z axis of the plane from the 3 input points.
   void CalculateAxesFromPoints(const double point0[3], const double point1[3], const double point2[3], double x[3], double y[3], double z[3]);
 
-  // Updates the plane bounds based on SizeMode and AutoSizeScalingFactor.
-  void UpdateSize();
+  /// Calculates the axis-aligned bounds defined by the corners of the plane.
+  void CalculatePlaneBounds(double bounds[6], double xAxis[3], double yAxis[3], double center[3], double size[2]);
 
-  int SizeMode;
-  double AutoSizeScalingFactor;
-  double Size[2] = { 0.0, 0.0 };
+  /// Updates the plane based on plane type and control point position.
+  virtual void UpdatePlaneFromControlPoints();
+  virtual void UpdatePlaneFromPointNormal();
+  virtual void UpdatePlaneFrom3Points();
+  virtual void UpdatePlaneFromPlaneFit();
+  virtual void UpdatePlaneSize();
+
+  /// Calculate the position of control points from the ROI
+  virtual void UpdateControlPointsFromPlane();
+  virtual void UpdateControlPointsFromPointNormal();
+  virtual void UpdateControlPointsFrom3Points();
+  virtual void UpdateControlPointsFromPlaneFit();
+  bool GetClosestFitPlaneFromControlPoints(vtkMatrix4x4* closestFitPlane);
+
+  vtkMRMLMarkupsPlaneNode();
+  ~vtkMRMLMarkupsPlaneNode() override;
+  vtkMRMLMarkupsPlaneNode(const vtkMRMLMarkupsPlaneNode&);
+  void operator=(const vtkMRMLMarkupsPlaneNode&);
+
+  virtual void SetNormalPointRequired(bool);
+  vtkGetMacro(NormalPointRequired, bool);
+
+protected:
+  bool IsUpdatingControlPointsFromPlane{ false };
+  bool IsUpdatingPlaneFromControlPoints{ false };
+
+  int SizeMode{ SizeModeAuto };
+  double AutoSizeScalingFactor{ 1.0 };
+
   vtkSmartPointer<vtkMatrix4x4> ObjectToBaseMatrix;
-  double PlaneBounds[6] = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
+  vtkSmartPointer<vtkMatrix4x4> BaseToNodeMatrix;
+
+  double Size[2] = { 100.0, 100.0 };
+  double PlaneBounds[4] = { -50.0, 50.0, -50.0, 50.0 };
 
   // Arrays used to return pointers from GetNormal/GetOrigin functions.
   double Normal[3] = { 0.0, 0.0, 0.0 };
@@ -228,18 +317,16 @@ protected:
   double Origin[3] = { 0.0,0.0,0.0 };
   double OriginWorld[3] = { 0.0,0.0,0.0 };
 
-  /// Helper method for ensuring that the plane has enough points and that the points/vectors are not coincident.
-  /// Used when calling SetNormal(), SetVectors() to ensure that the plane is valid before transforming to the new
-  /// orientation.
-  void CreatePlane();
+  int PlaneType{ PlaneTypePointNormal };
+  bool IsPlaneValid{ false };
+  bool NormalPointRequired{ false };
 
   /// Calculates the handle to world matrix based on the current control points
   void UpdateInteractionHandleToWorldMatrix() override;
 
-  vtkMRMLMarkupsPlaneNode();
-  ~vtkMRMLMarkupsPlaneNode() override;
-  vtkMRMLMarkupsPlaneNode(const vtkMRMLMarkupsPlaneNode&);
-  void operator=(const vtkMRMLMarkupsPlaneNode&);
+  friend class vtkSlicerPlaneWidget; // To directly access plane update functions
+  friend class vtkSlicerPlaneRepresentation3D; // To directly access plane update functions
+  friend class vtkSlicerPlaneRepresentation2D; // To directly access plane update functions
 };
 
 #endif

--- a/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
+++ b/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
@@ -1,6 +1,6 @@
     {
         "$schema": "http://json-schema.org/draft-07/schema",
-        "$id": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-v1.0.2-schema.json#",
+        "$id": "https://raw.githubusercontent.com/slicer/slicer/master/Modules/Loadable/Markups/Resources/Schema/markups-v1.0.3-schema.json#",
         "type": "object",
         "title": "Schema for storing one or more markups",
         "description": "Stores points, lines, curves, etc.",
@@ -102,6 +102,13 @@
                                     "description": "Method used to determine ROI bounds from control points. Ex. 'Box', 'BoundingBox'.",
                                     "default": "Box"
                                 },
+                                "planeType": {
+                                    "$id": "#markup/planeType",
+                                    "type": "string",
+                                    "title": "Plane type",
+                                    "description": "Method used to determine dimensions from control points. Ex. 'PointNormal', '3Points'.",
+                                    "default": "Box"
+                                },
                                 "sizeMode": {
                                     "$id": "#markup/sizeMode",
                                     "type": "string",
@@ -149,11 +156,36 @@
                                     "minItems": 3,
                                     "maxItems": 3
                                 },
+                                "planeBounds": {
+                                    "$id": "#markup/planeBounds",
+                                    "type": "array",
+                                    "title": "Plane bounds",
+                                    "description": "The bounds of the plane representation.",
+                                    "examples": [[-50, 50, -50, 50]],
+                                    "additionalItems": false,
+                                    "items": { "type": "number" },
+                                    "minItems": 4,
+                                    "maxItems": 4
+                                },
                                 "objectToBase": {
                                     "$id": "#markup/objectToBase",
                                     "type": "array",
                                     "title": "Object to Base matrix",
                                     "description": "4x4 transform matrix from the object representation to the coordinate system defined by the control points.",
+                                    "examples": [[-0.9744254538021788, -0.15660098593235834, -0.16115572030626558, 26.459385388492746,
+                                                  -0.08525118065879463, -0.4059244688892957, 0.9099217338613386, -48.04154530201596,
+                                                  -0.20791169081775938, 0.9003896138683279, 0.3821927158637956, -53.35829266424462,
+                                                  0.0, 0.0, 0.0, 1.0]],
+                                    "additionalItems": false,
+                                    "items": { "type": "number" },
+                                    "minItems": 16,
+                                    "maxItems": 16
+                                },
+                                "baseToNode": {
+                                    "$id": "#markup/baseToNode",
+                                    "type": "array",
+                                    "title": "Base to Node matrix",
+                                    "description": "4x4 transform matrix from the base representation to the node coordinate system.",
                                     "examples": [[-0.9744254538021788, -0.15660098593235834, -0.16115572030626558, 26.459385388492746,
                                                   -0.08525118065879463, -0.4059244688892957, 0.9099217338613386, -48.04154530201596,
                                                   -0.20791169081775938, 0.9003896138683279, 0.3821927158637956, -53.35829266424462,
@@ -190,7 +222,7 @@
                                                 "$id": "#markup/controlPoint",
                                                 "type": "object",
                                                 "title": "The first anyOf schema",
-                                                "description": "An explanation about the purpose of this instance.",
+                                                "description": "Object containing the properties of a single control point.",
                                                 "default": {},
                                                 "required": [],
                                                 "additionalProperties": true,
@@ -266,14 +298,14 @@
                                                         "$id": "#markup/controlPoint/visibility",
                                                         "type": "boolean",
                                                         "title": "The visibility schema",
-                                                        "description": "An explanation about the purpose of this instance.",
+                                                        "description": "Visibility of the control point.",
                                                         "default": true
                                                     },
                                                     "positionStatus": {
                                                         "$id": "#markup/controlPoint/positionStatus",
                                                         "type": "string",
                                                         "title": "The positionStatus schema",
-                                                        "description": "An explanation about the purpose of this instance.",
+                                                        "description": "Status of the control point position.",
                                                         "enum": ["undefined", "preview", "defined"],
                                                         "default": "defined"
                                                     }
@@ -286,7 +318,7 @@
                                     "$id": "#display",
                                     "type": "object",
                                     "title": "The display schema",
-                                    "description": "An explanation about the purpose of this instance.",
+                                    "description": "Object holding markups display properties.",
                                     "default": {},
                                     "required": [],
                                     "additionalProperties": true,
@@ -364,7 +396,7 @@
                                             "$id": "#display/glyphType",
                                             "type": "string",
                                             "title": "The glyphType schema",
-                                            "description": "An explanation about the purpose of this instance.",
+                                            "description": "Enum representing the displayed glyph type.",
                                             "default": "Sphere3D",
                                             "enum": ["Vertex2D", "Dash2D", "Cross2D", "ThickCross2D", "Triangle2D", "Square2D",
                                                 "Circle2D", "Diamond2D", "Arrow2D", "ThickArrow2D", "HookedArrow2D", "StarBurst2D",
@@ -477,6 +509,27 @@
                                             "type": "boolean",
                                             "title": "Handles interactive",
                                             "description": "Show interactive handles to transform this markup.",
+                                            "default": false
+                                        },
+                                        "translationHandleVisibility": {
+                                            "$id": "#display/translationHandleVisibility",
+                                            "type": "boolean",
+                                            "title": "Translation handle visibility",
+                                            "description": "Visibility of the translation interaction handles",
+                                            "default": false
+                                        },
+                                        "rotationHandleVisibility": {
+                                            "$id": "#display/rotationHandleVisibility",
+                                            "type": "boolean",
+                                            "title": "Rotation handle visibility",
+                                            "description": "Visibility of the rotation interaction handles",
+                                            "default": false
+                                        },
+                                        "scaleHandleVisibility": {
+                                            "$id": "#display/scaleHandleVisibility",
+                                            "type": "boolean",
+                                            "title": "Scale handle visibility",
+                                            "description": "Visibility of the scale interaction handles",
                                             "default": false
                                         },
                                         "snapMode": {

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -47,6 +47,7 @@
 #include <vtkMRMLDisplayableNode.h>
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLMarkupsDisplayNode.h>
+#include <vtkMRMLMarkupsPlaneDisplayNode.h>
 #include <vtkMRMLMarkupsROIDisplayNode.h>
 #include <vtkMRMLMarkupsNode.h>
 #include <vtkMRMLScene.h>
@@ -711,7 +712,9 @@ void qSlicerSubjectHierarchyMarkupsPlugin::showViewContextMenuActionsForItem(vtk
   vtkMRMLMarkupsDisplayNode* displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(associatedNode->GetDisplayNode());
   d->ToggleHandleInteractive->setVisible(displayNode != nullptr);
   d->HandleVisibilityAction->setVisible(displayNode != nullptr);
-  d->ToggleScaleHandleVisible->setVisible(vtkMRMLMarkupsROIDisplayNode::SafeDownCast(displayNode) != nullptr);
+  vtkMRMLMarkupsROIDisplayNode* roiDisplayNode = vtkMRMLMarkupsROIDisplayNode::SafeDownCast(displayNode);
+  vtkMRMLMarkupsPlaneDisplayNode* planeDisplayNode = vtkMRMLMarkupsPlaneDisplayNode::SafeDownCast(displayNode);
+  d->ToggleScaleHandleVisible->setVisible(roiDisplayNode != nullptr || planeDisplayNode != nullptr);
   if (displayNode)
     {
     d->ToggleHandleInteractive->setChecked(displayNode->GetHandlesInteractive());

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest4.cxx
@@ -35,7 +35,7 @@
 
 static const double EPSILON = 1e-5;
 
-bool ComparePlane(double xAxisExpected_World[3], double yAxisExpected_World[3], double zAxisExpected_World[3],
+int ComparePlane(double xAxisExpected_World[3], double yAxisExpected_World[3], double zAxisExpected_World[3],
   double originExpected_World[3], vtkMRMLMarkupsPlaneNode* planeNode, double epsilon)
 {
   double xAxisActual_World[3] = { 0.0 };
@@ -43,30 +43,18 @@ bool ComparePlane(double xAxisExpected_World[3], double yAxisExpected_World[3], 
   double zAxisActual_World[3] = { 0.0 };
   planeNode->GetAxesWorld(xAxisActual_World, yAxisActual_World, zAxisActual_World);
 
-  if (vtkMath::Dot(xAxisExpected_World, xAxisActual_World) < 1.0 - epsilon)
-    {
-    return false;
-    }
-  if (vtkMath::Dot(yAxisExpected_World, yAxisActual_World) < 1.0 - epsilon)
-    {
-    return false;
-    }
-  if (vtkMath::Dot(zAxisExpected_World, zAxisActual_World) < 1.0 - epsilon)
-    {
-    return false;
-    }
+  CHECK_DOUBLE_TOLERANCE(vtkMath::Dot(xAxisExpected_World, xAxisActual_World), 1.0, epsilon);
+  CHECK_DOUBLE_TOLERANCE(vtkMath::Dot(yAxisExpected_World, yAxisActual_World), 1.0, epsilon);
+  CHECK_DOUBLE_TOLERANCE(vtkMath::Dot(zAxisExpected_World, zAxisActual_World), 1.0, epsilon);
 
   double originActual_World[3] = { 0.0 };
   planeNode->GetOriginWorld(originActual_World);
   double originDifference_World[3] = { 0.0 };
   vtkMath::Subtract(originExpected_World, originActual_World, originDifference_World);
 
-  if (vtkMath::Norm(originDifference_World) > epsilon)
-    {
-    return false;
-    }
+  CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(originDifference_World), 0.0, epsilon);
 
-  return true;
+  return EXIT_SUCCESS;
 }
 
 int vtkMRMLMarkupsNodeTest4(int , char * [] )
@@ -77,67 +65,73 @@ int vtkMRMLMarkupsNodeTest4(int , char * [] )
   vtkNew<vtkMRMLMarkupsPlaneNode> planeNode;
   scene->AddNode(planeNode);
 
-  double xAxis_World[3] = { 0.0, 0.0, 1.0 };
-  double yAxis_World[3] = { -1.0, 0.0, 0.0 };
-  double zAxis_World[3] = { 0.0, -1.0, 0.0 };
-  double origin_World[3] = { 50.0, 150.0, 200.0 };
+  for (int planeType = vtkMRMLMarkupsPlaneNode::PlaneType3Points; planeType < vtkMRMLMarkupsPlaneNode::PlaneTypePlaneFit; ++planeType)
+    {
+    std::cout << "Testing plane type: " << planeNode->GetPlaneTypeAsString(planeType) << "." << std::endl;
+    planeNode->SetPlaneType(planeType);
 
-  /////////////
-  std::cout << "Test set axes/origin" << std::endl;
-  planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
-  planeNode->SetOriginWorld(origin_World);
-  CHECK_BOOL(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON), true);
+    double xAxis_World[3] = { 0.0, 0.0, 1.0 };
+    double yAxis_World[3] = { -1.0, 0.0, 0.0 };
+    double zAxis_World[3] = { 0.0, -1.0, 0.0 };
+    double origin_World[3] = { 50.0, 150.0, 200.0 };
 
-  /////////////
-  std::cout << "Test set axes/origin with plane offset" << std::endl;
-  vtkNew<vtkTransform> objectToBase;
-  objectToBase->Translate(1.0, 2.0, 3.0);
-  objectToBase->RotateX(50.0);
-  objectToBase->RotateY(12.0);
-  objectToBase->RotateZ(5.0);
-  objectToBase->Translate(5.0, 3.0, 10.0);
-  planeNode->GetObjectToBaseMatrix()->DeepCopy(objectToBase->GetMatrix());
-  planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
-  planeNode->SetOriginWorld(origin_World);
-  CHECK_BOOL(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON), true);
+    /////////////
+    std::cout << "Test set axes/origin" << std::endl;
+    planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+    planeNode->SetOriginWorld(origin_World);
+    CHECK_EXIT_SUCCESS(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON));
 
-  /////////////
-  std::cout << "Test set axes/origin with plane offset and transform node" << std::endl;
-  vtkNew<vtkMRMLLinearTransformNode> transformNode;
-  scene->AddNode(transformNode);
-  planeNode->SetAndObserveTransformNodeID(transformNode->GetID());
+    /////////////
+    std::cout << "Test set axes/origin with plane offset" << std::endl;
+    vtkNew<vtkTransform> objectToBase;
+    objectToBase->Translate(1.0, 2.0, 3.0);
+    objectToBase->RotateX(50.0);
+    objectToBase->RotateY(12.0);
+    objectToBase->RotateZ(5.0);
+    objectToBase->Translate(5.0, 3.0, 10.0);
+    planeNode->GetObjectToBaseMatrix()->DeepCopy(objectToBase->GetMatrix());
+    planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+    planeNode->SetOriginWorld(origin_World);
+    CHECK_EXIT_SUCCESS(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON));
 
-  vtkNew<vtkTransform> localToWorldTransform;
-  localToWorldTransform->Translate(30.0, 60.0, 90.0);
-  localToWorldTransform->RotateZ(30.0);
-  localToWorldTransform->RotateY(60.0);
-  localToWorldTransform->RotateX(90.0);
-  localToWorldTransform->Translate(90.0, 60.0, 30.0);
-  transformNode->SetMatrixTransformToParent(localToWorldTransform->GetMatrix());
-  planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
-  planeNode->SetOriginWorld(origin_World);
-  CHECK_BOOL(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON), true);
+    /////////////
+    std::cout << "Test set axes/origin with plane offset and transform node" << std::endl;
+    vtkNew<vtkMRMLLinearTransformNode> transformNode;
+    scene->AddNode(transformNode);
+    planeNode->SetAndObserveTransformNodeID(transformNode->GetID());
 
-  /////////////
-  std::cout << "Test set norm with plane offset and transform node" << std::endl;
-  double expectedNormal_World[3] = { 1.0, -3.0, 5.0 };
-  vtkMath::Normalize(expectedNormal_World);
-  planeNode->SetNormalWorld(expectedNormal_World);
-  double actualNormal_World[3] = { 0.0 };
-  planeNode->GetNormalWorld(actualNormal_World);
-  double normalDifference_World[3] = { 0.0 };
-  vtkMath::Subtract(actualNormal_World, expectedNormal_World, normalDifference_World);
-  CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(normalDifference_World), 0.0, EPSILON);
+    vtkNew<vtkTransform> localToWorldTransform;
+    localToWorldTransform->Translate(30.0, 60.0, 90.0);
+    localToWorldTransform->RotateZ(30.0);
+    localToWorldTransform->RotateY(60.0);
+    localToWorldTransform->RotateX(90.0);
+    localToWorldTransform->Translate(90.0, 60.0, 30.0);
+    transformNode->SetMatrixTransformToParent(localToWorldTransform->GetMatrix());
+    planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+    planeNode->SetOriginWorld(origin_World);
+    CHECK_EXIT_SUCCESS(ComparePlane(xAxis_World, yAxis_World, zAxis_World, origin_World, planeNode, EPSILON));
 
-  /////////////
-  std::cout << "Test set origin with plane offset and transform node" << std::endl;
-  double expectedOrigin_World[3] = { -123.0, 456.0, -789.0 };
-  planeNode->SetOriginWorld(expectedOrigin_World);
-  double actualOrigin_World[3] = { 0.0 };
-  planeNode->GetOriginWorld(actualOrigin_World);
-  double originDifference_World[3] = { 0.0 };
-  vtkMath::Subtract(actualOrigin_World, expectedOrigin_World, originDifference_World);
-  CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(originDifference_World), 0.0, EPSILON);
+    /////////////
+    std::cout << "Test set norm with plane offset and transform node" << std::endl;
+    double expectedNormal_World[3] = { 1.0, -3.0, 5.0 };
+    vtkMath::Normalize(expectedNormal_World);
+    planeNode->SetNormalWorld(expectedNormal_World);
+    double actualNormal_World[3] = { 0.0 };
+    planeNode->GetNormalWorld(actualNormal_World);
+    double normalDifference_World[3] = { 0.0 };
+    vtkMath::Subtract(actualNormal_World, expectedNormal_World, normalDifference_World);
+    CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(normalDifference_World), 0.0, EPSILON);
+
+    /////////////
+    std::cout << "Test set origin with plane offset and transform node" << std::endl;
+    double expectedOrigin_World[3] = { -123.0, 456.0, -789.0 };
+    planeNode->SetOriginWorld(expectedOrigin_World);
+    double actualOrigin_World[3] = { 0.0 };
+    planeNode->GetOriginWorld(actualOrigin_World);
+    double originDifference_World[3] = { 0.0 };
+    vtkMath::Subtract(actualOrigin_World, expectedOrigin_World, originDifference_World);
+    CHECK_DOUBLE_TOLERANCE(vtkMath::Norm(originDifference_World), 0.0, EPSILON);
+    }
 
   std::cout << "Success." << std::endl;
 

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
@@ -25,7 +25,12 @@
 #include "vtkMRMLMarkupsFiducialNode.h"
 #include "vtkMRMLMarkupsJsonStorageNode.h"
 #include "vtkMRMLMarkupsLineNode.h"
+#include "vtkMRMLMarkupsPlaneDisplayNode.h"
 #include "vtkMRMLMarkupsPlaneNode.h"
+#include "vtkMRMLMarkupsPlaneJsonStorageNode.h"
+#include "vtkMRMLMarkupsROIDisplayNode.h"
+#include "vtkMRMLMarkupsROINode.h"
+#include "vtkMRMLMarkupsROIJsonStorageNode.h"
 #include "vtkURIHandler.h"
 #include "vtkMRMLScene.h"
 #include "vtkPolyData.h"
@@ -88,8 +93,11 @@ int TestStoragNode(vtkMRMLMarkupsNode* markupsNode, vtkMRMLMarkupsStorageNode* s
   markupsNode->SetNthControlPointPositionFromArray(modifiedPointIndex, inputPoint);
 
   // and add a markup with 1 point, default values
-  int defaultPointIndex = markupsNode->AddNControlPoints(1);
-  CHECK_INT(defaultPointIndex, 1);
+  if (markupsNode->GetMaximumNumberOfControlPoints() != 1)
+    {
+    int defaultPointIndex = markupsNode->AddNControlPoints(1);
+    CHECK_INT(defaultPointIndex, 1);
+    }
 
   int emptyLabelIndex = -1;
   int commaIndex = -1;
@@ -288,7 +296,10 @@ int vtkMRMLMarkupsStorageNodeTest2(int argc, char* argv[])
     vtkSmartPointer<vtkMRMLMarkupsJsonStorageNode>::New(), tempFolder + "/vtkMRMLMarkupsStorageNodeTest2-closedcurve-temp.mrk.json"));
   CHECK_EXIT_SUCCESS(TestStoragNode(
     vtkSmartPointer<vtkMRMLMarkupsPlaneNode>::New(),
-    vtkSmartPointer<vtkMRMLMarkupsJsonStorageNode>::New(), tempFolder + "/vtkMRMLMarkupsStorageNodeTest2-plane-temp.mrk.json"));
+    vtkSmartPointer<vtkMRMLMarkupsPlaneJsonStorageNode>::New(), tempFolder + "/vtkMRMLMarkupsStorageNodeTest2-plane-temp.mrk.json"));
+  CHECK_EXIT_SUCCESS(TestStoragNode(
+    vtkSmartPointer<vtkMRMLMarkupsROINode>::New(),
+    vtkSmartPointer<vtkMRMLMarkupsROIJsonStorageNode>::New(), tempFolder + "/vtkMRMLMarkupsStorageNodeTest2-roi-temp.mrk.json"));
 
   // Test if markups node can be instantiated correctly
   vtkNew<vtkMRMLScene> scene;
@@ -300,9 +311,14 @@ int vtkMRMLMarkupsStorageNodeTest2(int argc, char* argv[])
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsAngleNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsCurveNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsClosedCurveNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsPlaneNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsDisplayNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsPlaneDisplayNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsPlaneNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsPlaneJsonStorageNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsFiducialDisplayNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsROIDisplayNode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsROINode>::New());
+  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsROIJsonStorageNode>::New());
 
   scene->AddNode(storageNodeJson);
 
@@ -335,6 +351,12 @@ int vtkMRMLMarkupsStorageNodeTest2(int argc, char* argv[])
     std::string(tempFolder + "/vtkMRMLMarkupsStorageNodeTest2-plane-temp.mrk.json").c_str());
   CHECK_NOT_NULL(planeNode);
   CHECK_STRING(planeNode->GetClassName(), "vtkMRMLMarkupsPlaneNode");
+
+  vtkMRMLMarkupsNode* roiNode = storageNodeJson->AddNewMarkupsNodeFromFile(
+    std::string(tempFolder + "/vtkMRMLMarkupsStorageNodeTest2-roi-temp.mrk.json").c_str());
+  CHECK_NOT_NULL(roiNode);
+  CHECK_STRING(roiNode->GetClassName(), "vtkMRMLMarkupsROINode");
+
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
@@ -26,7 +26,7 @@ curveNode = slicer.util.getNode('C')
 # Check number of arrays in the curve node
 curvePointData = curveNode.GetCurveWorld().GetPointData()
 if curvePointData.GetNumberOfArrays() != 1:
-  exceptionMessage = "Unexpected number of data arrays in curve: " + str(curvePointData.GetNumberOfArrays())
+  exceptionMessage = "Unexpected number of data arrays in curve: {0} (expected {1})".format(curvePointData.GetNumberOfArrays(), 1)
   raise Exception(exceptionMessage)
 
 # Turn on curvature calculation in curve node
@@ -35,11 +35,11 @@ curveNode.GetMeasurement("curvature max").SetEnabled(True)
 # Check curvature computation result
 curvePointData = curveNode.GetCurveWorld().GetPointData()
 if curvePointData.GetNumberOfArrays() != 2:
-  exceptionMessage = "Unexpected number of data arrays in curve: " + str(curvePointData.GetNumberOfArrays())
+  exceptionMessage = "Unexpected number of data arrays in curve: {0} (expected {1})".format(curvePointData.GetNumberOfArrays(), 2)
   raise Exception(exceptionMessage)
 
 if curvePointData.GetArrayName(1) != 'Curvature':
-  exceptionMessage = "Unexpected data array name in curve: " + str(curvePointData.GetArrayName(1))
+  exceptionMessage = "Unexpected data array name in curve: {0} (expected {1})".format(curvePointData.GetArrayName(1), 'Curvature')
   raise Exception(exceptionMessage)
 
 curvatureArray = curvePointData.GetArray(1)

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsMeasurementsTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsMeasurementsTest.py
@@ -92,6 +92,7 @@ if not preserveFiles:
 #
 
 markupsNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsPlaneNode')
+markupsNode.SetPlaneType(slicer.vtkMRMLMarkupsPlaneNode.PlaneType3Points)
 markupsNode.AddControlPoint(vtk.vtkVector3d(30, -22.4, 13.8))
 markupsNode.AddControlPoint(vtk.vtkVector3d(50, -22.4, 13.8))
 markupsNode.AddControlPoint(vtk.vtkVector3d(30, -62.4, 13.8))

--- a/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
@@ -131,6 +131,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
     return [
       slicer.qMRMLMarkupsCurveSettingsWidget(),
       slicer.qMRMLMarkupsAngleMeasurementsWidget(),
+      slicer.qMRMLMarkupsPlaneWidget(),
       slicer.qMRMLMarkupsROIWidget(),
       slicer.qMRMLMarkupsTestLineWidget()
     ]

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -18,7 +18,6 @@
 
 #include "vtkSlicerMarkupsWidget.h"
 
-#include "vtkMRMLApplicationLogic.h"
 #include "vtkMRMLInteractionEventData.h"
 #include "vtkMRMLInteractionNode.h"
 #include "vtkMRMLScene.h"
@@ -545,6 +544,7 @@ void vtkSlicerMarkupsWidget::UpdatePreviewPointIndex(vtkMRMLInteractionEventData
     // if no preview points found, set to -1
     this->PreviewPointIndex = -1;
 }
+
 //-------------------------------------------------------------------------
 void vtkSlicerMarkupsWidget::UpdatePreviewPoint(vtkMRMLInteractionEventData* eventData, const char* associatedNodeID, int positionStatus)
 {
@@ -793,6 +793,12 @@ bool vtkSlicerMarkupsWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData
 {
   unsigned long widgetEvent = this->TranslateInteractionEventToWidgetEvent(eventData);
 
+  if (this->ApplicationLogic)
+    {
+    this->ApplicationLogic->PauseRender();
+    }
+
+
   bool processedEvent = false;
   switch (widgetEvent)
     {
@@ -860,6 +866,11 @@ bool vtkSlicerMarkupsWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData
   if (!processedEvent)
     {
     processedEvent = this->ProcessButtonClickEvent(eventData);
+    }
+
+  if (this->ApplicationLogic)
+    {
+    this->ApplicationLogic->ResumeRender();
     }
 
   return processedEvent;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.h
@@ -98,7 +98,7 @@ public:
   // Places a new markup point.
   // Reuses current preview point, if possible.
   // Returns true if the event is processed.
-  bool PlacePoint(vtkMRMLInteractionEventData* eventData);
+  virtual bool PlacePoint(vtkMRMLInteractionEventData* eventData);
 
   /// Add a point to the current active Markup at input World coordinates.
   virtual int AddPointFromWorldCoordinate(const double worldCoordinates[3]);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -1221,9 +1221,14 @@ void vtkSlicerMarkupsWidgetRepresentation3D::SetRenderer(vtkRenderer *ren)
 }
 
 //---------------------------------------------------------------------------
-bool vtkSlicerMarkupsWidgetRepresentation3D::AccuratePick(int x, int y, double pickPoint[3])
+bool vtkSlicerMarkupsWidgetRepresentation3D::AccuratePick(int x, int y, double pickPoint[3], double pickNormal[3]/*=nullptr*/)
 {
-  if (!this->AccuratePicker->Pick(x, y, 0, this->Renderer))
+  bool success = this->AccuratePicker->Pick(x, y, 0, this->Renderer);
+  if (pickNormal)
+    {
+    this->AccuratePicker->GetPickNormal(pickNormal);
+    }
+  if (!success)
     {
     return false;
     }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -80,7 +80,7 @@ public:
   void CanInteractWithLine(vtkMRMLInteractionEventData* interactionEventData,
     int &foundComponentType, int &foundComponentIndex, double &closestDistance2);
 
-  bool AccuratePick(int x, int y, double pickPoint[3]);
+  bool AccuratePick(int x, int y, double pickPoint[3], double pickNormal[3]=nullptr);
 
   /// Return true if the control point is actually visible
   /// (displayed and not occluded by other objects in the view).

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
@@ -53,9 +53,9 @@
 // MRML includes
 #include "vtkMRMLInteractionEventData.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
-#include "vtkMRMLProceduralColorNode.h"
-
+#include "vtkMRMLMarkupsPlaneDisplayNode.h"
 #include "vtkMRMLMarkupsPlaneNode.h"
+#include "vtkMRMLProceduralColorNode.h"
 
 vtkStandardNewMacro(vtkSlicerPlaneRepresentation2D);
 
@@ -170,7 +170,7 @@ void vtkSlicerPlaneRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   this->BuildPlane();
 
   bool visible = true;
-  if (markupsNode->GetNumberOfControlPoints() < 3)
+  if (!markupsNode->GetIsPlaneValid())
     {
     visible = false;
     }
@@ -186,9 +186,19 @@ void vtkSlicerPlaneRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
       }
     }
 
-  this->PlaneFillActor->SetVisibility(visible);
-  this->PlaneOutlineActor->SetVisibility(visible);
-  this->ArrowActor->SetVisibility(visible);
+  this->PlaneFillActor->SetVisibility(visible && this->MarkupsDisplayNode->GetFillVisibility());
+  this->PlaneOutlineActor->SetVisibility(visible && this->MarkupsDisplayNode->GetOutlineVisibility());
+
+  vtkMRMLMarkupsPlaneDisplayNode* planeDisplayNode = vtkMRMLMarkupsPlaneDisplayNode::SafeDownCast(this->MarkupsDisplayNode);
+  if (planeDisplayNode)
+    {
+    this->ArrowActor->SetVisibility(visible && planeDisplayNode->GetNormalVisibility());
+    this->ArrowActor->GetProperty()->SetOpacity(planeDisplayNode->GetOpacity() * planeDisplayNode->GetNormalOpacity());
+    }
+  else
+    {
+    this->ArrowActor->SetVisibility(visible);
+    }
 
   // Properties label display
   if (visible && this->MarkupsDisplayNode->GetPropertiesLabelVisibility()
@@ -287,8 +297,8 @@ void vtkSlicerPlaneRepresentation2D::CanInteract(
   int &foundComponentType, int &foundComponentIndex, double &closestDistance2)
 {
   foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentNone;
-  vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
-  if ( !markupsNode || markupsNode->GetLocked() || markupsNode->GetNumberOfControlPoints() < 1
+  vtkMRMLMarkupsPlaneNode* markupsNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if ( !markupsNode || markupsNode->GetLocked() || !markupsNode->GetIsPlaneValid()
     || !this->GetVisibility() || !interactionEventData )
     {
     return;
@@ -533,18 +543,18 @@ void vtkSlicerPlaneRepresentation2D::PrintSelf(ostream& os, vtkIndent indent)
 //----------------------------------------------------------------------
 void vtkSlicerPlaneRepresentation2D::BuildPlane()
 {
-  vtkMRMLMarkupsPlaneNode* markupsNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
-  if (!markupsNode || markupsNode->GetNumberOfControlPoints() != 3)
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (!planeNode || !planeNode->GetIsPlaneValid())
     {
     this->PlaneFillMapper->SetInputData(vtkNew<vtkPolyData>());
     this->ArrowMapper->SetInputData(vtkNew<vtkPolyData>());
     return;
     }
 
-  double xAxis_World[3] = { 0.0 };
-  double yAxis_World[3] = { 0.0 };
-  double zAxis_World[3] = { 0.0 };
-  markupsNode->GetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+  double xAxis_World[3] = { 0.0, 0.0, 0.0 };
+  double yAxis_World[3] = { 0.0, 0.0, 0.0 };
+  double zAxis_World[3] = { 0.0, 0.0, 0.0 };
+  planeNode->GetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
 
   double epsilon = 1e-5;
   if (vtkMath::Norm(xAxis_World) <= epsilon ||
@@ -560,34 +570,33 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
   this->ArrowMapper->SetInputConnection(this->ArrowGlypher->GetOutputPort());
 
   double origin_World[3] = { 0.0 };
-  markupsNode->GetOriginWorld(origin_World);
+  planeNode->GetOriginWorld(origin_World);
+
+  vtkNew<vtkMatrix4x4> objectToWorldMatrix;
+  planeNode->GetObjectToWorldMatrix(objectToWorldMatrix);
+
+  vtkNew<vtkTransform> objectToWorldTransform;
+  objectToWorldTransform->SetMatrix(objectToWorldMatrix);
 
   // Update the plane
-  double size_Object[2] = { 0.0 };
-  markupsNode->GetSize(size_Object);
+  double bounds_Object[4] = { 0.0, -1.0, 0.0, -1.0 };
+  planeNode->GetPlaneBounds(bounds_Object);
 
-  double bounds_Object[4] = { -0.5 * size_Object[0], 0.5 * size_Object[0] , -0.5 * size_Object[1] , 0.5 * size_Object[1] };
+  double planePoint0_Object[3] = { bounds_Object[0], bounds_Object[2], 0.0 };
+  double planePoint0_World[3] = { 0.0, 0.0, 0.0 };
+  objectToWorldTransform->TransformPoint(planePoint0_Object, planePoint0_World);
 
-  double planePoint1_World[3] = { 0.0 };
-  double planePoint2_World[3] = { 0.0 };
-  double planePoint3_World[3] = { 0.0 };
-  for (int i = 0; i < 3; ++i)
-    {
-    planePoint1_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Object[0])
-      + (yAxis_World[i] * bounds_Object[2]); // Bottom left corner (Plane filter origin)
+  double planePoint1_Object[3] = { bounds_Object[0], bounds_Object[3], 0.0 };
+  double planePoint1_World[3] = { 0.0, 0.0, 0.0 };
+  objectToWorldTransform->TransformPoint(planePoint1_Object, planePoint1_World);
 
-    planePoint2_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Object[0])
-      + (yAxis_World[i] * bounds_Object[3]); // Top left corner
+  double planePoint2_Object[3] = { bounds_Object[1], bounds_Object[2], 0.0 };
+  double planePoint2_World[3] = { 0.0, 0.0, 0.0 };
+  objectToWorldTransform->TransformPoint(planePoint2_Object, planePoint2_World);
 
-    planePoint3_World[i] = origin_World[i]
-      + (xAxis_World[i] * bounds_Object[1])
-      + (yAxis_World[i] * bounds_Object[2]); // Bottom right corner
-    }
-  this->PlaneFilter->SetOrigin(planePoint1_World);
-  this->PlaneFilter->SetPoint1(planePoint2_World);
-  this->PlaneFilter->SetPoint2(planePoint3_World);
+  this->PlaneFilter->SetOrigin(planePoint0_World);
+  this->PlaneFilter->SetPoint1(planePoint1_World);
+  this->PlaneFilter->SetPoint2(planePoint2_World);
 
   double* arrowVectorSlice = this->WorldToSliceTransform->TransformDoubleVector(zAxis_World);
 
@@ -633,7 +642,7 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
   this->ArrowGlypher->SetInputData(arrowPolyData_World);
   this->ArrowGlypher->SetScaleFactor(this->ControlPointSize*2);
 
-  vtkMRMLMarkupsDisplayNode* displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(markupsNode->GetDisplayNode());
+  vtkMRMLMarkupsDisplayNode* displayNode = vtkMRMLMarkupsDisplayNode::SafeDownCast(planeNode->GetDisplayNode());
   if (!displayNode)
     {
     return;
@@ -665,19 +674,72 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
 }
 
 //----------------------------------------------------------------------
+void vtkSlicerPlaneRepresentation2D::SetupInteractionPipeline()
+{
+  this->InteractionPipeline = new MarkupsInteractionPipelinePlane2D(this);
+  this->InteractionPipeline->InitializePipeline();
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerPlaneRepresentation2D::UpdateInteractionPipeline()
 {
+  Superclass::UpdateInteractionPipeline();
+
   vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
-  if (!planeNode || planeNode->GetNumberOfControlPoints() < 3)
-    {
-    this->InteractionPipeline->Actor->SetVisibility(false);
-    return;
-    }
-  if (!this->PlaneFillActor->GetVisibility())
+  if (!planeNode || !planeNode->GetIsPlaneValid())
     {
     this->InteractionPipeline->Actor->SetVisibility(false);
     return;
     }
 
-  Superclass::UpdateInteractionPipeline();
+  if (!this->PlaneFillActor->GetVisibility() && !this->PlaneOutlineActor->GetVisibility())
+    {
+    this->InteractionPipeline->Actor->SetVisibility(false);
+    return;
+    }
+
+  this->InteractionPipeline->Actor->SetVisibility(this->MarkupsDisplayNode->GetVisibility()
+    && this->MarkupsDisplayNode->GetVisibility2D()
+    && this->MarkupsDisplayNode->GetHandlesInteractive());
+
+  vtkNew<vtkTransform> handleToWorldTransform;
+  handleToWorldTransform->SetMatrix(planeNode->GetInteractionHandleToWorldMatrix());
+  this->InteractionPipeline->HandleToWorldTransform->DeepCopy(handleToWorldTransform);
+
+  MarkupsInteractionPipelinePlane2D* interactionPipeline = dynamic_cast<MarkupsInteractionPipelinePlane2D*>(this->InteractionPipeline);
+  interactionPipeline->UpdateScaleHandles();
+  interactionPipeline->WorldToSliceTransformFilter->SetTransform(this->WorldToSliceTransform);
+}
+
+//----------------------------------------------------------------------
+vtkSlicerPlaneRepresentation2D::MarkupsInteractionPipelinePlane2D::MarkupsInteractionPipelinePlane2D(vtkSlicerMarkupsWidgetRepresentation* representation)
+  : vtkSlicerPlaneRepresentation3D::MarkupsInteractionPipelinePlane(representation)
+{
+  this->WorldToSliceTransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+  this->WorldToSliceTransformFilter->SetTransform(vtkNew<vtkTransform>());
+  this->WorldToSliceTransformFilter->SetInputConnection(this->HandleToWorldTransformFilter->GetOutputPort());
+  this->Mapper->SetInputConnection(this->WorldToSliceTransformFilter->GetOutputPort());
+  this->Mapper->SetTransformCoordinate(nullptr);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerPlaneRepresentation2D::MarkupsInteractionPipelinePlane2D::GetViewPlaneNormal(double viewPlaneNormal[3])
+{
+  if (!viewPlaneNormal)
+    {
+    return;
+    }
+
+  double viewPlaneNormal4[4] = { 0.0, 0.0, 1.0, 0.0 };
+  if (this->Representation)
+    {
+    vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(this->Representation->GetViewNode());
+    if (sliceNode)
+      {
+      sliceNode->GetSliceToRAS()->MultiplyPoint(viewPlaneNormal4, viewPlaneNormal4);
+      }
+    }
+  viewPlaneNormal[0] = viewPlaneNormal4[0];
+  viewPlaneNormal[1] = viewPlaneNormal4[1];
+  viewPlaneNormal[2] = viewPlaneNormal4[2];
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
@@ -34,6 +34,7 @@
 
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation2D.h"
+#include "vtkSlicerPlaneRepresentation3D.h"
 #include "vtkGlyphSource2D.h"
 
 class vtkAppendPolyData;
@@ -82,6 +83,9 @@ public:
 
   void BuildPlane();
 
+  // Initialize interaction handle pipeline
+  void SetupInteractionPipeline() override;
+
   // Update visibility of interaction handles for representation
   void UpdateInteractionPipeline() override;
 
@@ -123,6 +127,18 @@ protected:
   vtkNew<vtkDiscretizableColorTransferFunction> PlaneFillColorMap;
   vtkNew<vtkSampleImplicitFunctionFilter> PlaneSliceDistance;
   std::string LabelFormat;
+
+  class MarkupsInteractionPipelinePlane2D : public vtkSlicerPlaneRepresentation3D::MarkupsInteractionPipelinePlane
+  {
+  public:
+    MarkupsInteractionPipelinePlane2D(vtkSlicerMarkupsWidgetRepresentation* representation);
+    ~MarkupsInteractionPipelinePlane2D() override = default;;
+
+    void GetViewPlaneNormal(double viewPlaneNormal[3]) override;
+
+    vtkSmartPointer<vtkTransformPolyDataFilter> WorldToSliceTransformFilter;
+  };
+
 
 private:
   vtkSlicerPlaneRepresentation2D(const vtkSlicerPlaneRepresentation2D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
@@ -108,8 +108,33 @@ protected:
   // Setup the pipeline for plane display
   void BuildPlane();
 
+
+  // Initialize interaction handle pipeline
+  void SetupInteractionPipeline() override;
+
   // Update visibility of interaction handles for representation
   void UpdateInteractionPipeline() override;
+
+  class VTK_SLICER_MARKUPS_MODULE_VTKWIDGETS_EXPORT MarkupsInteractionPipelinePlane : public MarkupsInteractionPipeline
+  {
+  public:
+    MarkupsInteractionPipelinePlane(vtkSlicerMarkupsWidgetRepresentation* representation);
+    ~MarkupsInteractionPipelinePlane() override = default;
+
+    // Initialize scale handles
+    void CreateScaleHandles() override;
+
+    HandleInfoList GetHandleInfoList() override;
+
+    // Update scale handle positions
+    virtual void UpdateScaleHandles();
+
+    void GetHandleColor(int type, int index, double color[4]) override;
+    double GetHandleOpacity(int type, int index) override;
+
+    void GetInteractionHandleAxisWorld(int type, int index, double axis[3]) override;
+  };
+  friend class vtkSlicerPlaneRepresentation2D;
 
 private:
   vtkSlicerPlaneRepresentation3D(const vtkSlicerPlaneRepresentation3D&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
@@ -21,15 +21,22 @@
 #include "vtkSlicerPlaneWidget.h"
 
 #include "vtkMRMLInteractionEventData.h"
+#include "vtkMRMLInteractionNode.h"
+#include "vtkMRMLMarkupsPlaneDisplayNode.h"
 #include "vtkMRMLMarkupsPlaneNode.h"
+#include "vtkMRMLScene.h"
 #include "vtkMRMLSliceNode.h"
+#include "vtkSlicerApplicationLogic.h"
 #include "vtkSlicerPlaneRepresentation2D.h"
 #include "vtkSlicerPlaneRepresentation3D.h"
 
 // VTK includes
-#include <vtkCommand.h>
+#include <vtkCamera.h>
 #include <vtkEvent.h>
+#include <vtkMatrix4x4.h>
+#include <vtkPlane.h>
 #include <vtkPointPlacer.h>
+#include <vtkRenderer.h>
 #include <vtkTransform.h>
 
 vtkStandardNewMacro(vtkSlicerPlaneWidget);
@@ -37,8 +44,12 @@ vtkStandardNewMacro(vtkSlicerPlaneWidget);
 //----------------------------------------------------------------------
 vtkSlicerPlaneWidget::vtkSlicerPlaneWidget()
 {
+  this->SetEventTranslation(WidgetStateDefine, vtkCommand::LeftButtonReleaseEvent, vtkEvent::AltModifier, WidgetEventControlPointPlacePlaneNormal);
+
   this->SetEventTranslationClickAndDrag(WidgetStateOnWidget, vtkCommand::LeftButtonPressEvent, vtkEvent::ShiftModifier,
     WidgetStateTranslatePlane, WidgetEventPlaneMoveStart, WidgetEventPlaneMoveEnd);
+  this->SetEventTranslationClickAndDrag(WidgetStateOnScaleHandle, vtkCommand::LeftButtonPressEvent, vtkEvent::AltModifier,
+    WidgetStateSymmetricScale, WidgetEventSymmetricScaleStart, WidgetEventSymmetricScaleEnd);
 }
 
 //----------------------------------------------------------------------
@@ -77,6 +88,11 @@ bool vtkSlicerPlaneWidget::CanProcessInteractionEvent(vtkMRMLInteractionEventDat
     distance2 = 0.0;
     return true;
     }
+  else if (this->WidgetState == WidgetStateSymmetricScale)
+    {
+    distance2 = 0.0;
+    return true;
+    }
   else if (eventData->GetType() == vtkCommand::LeftButtonPressEvent &&
            !(eventData->GetModifiers() & vtkEvent::ShiftModifier))
     {
@@ -89,6 +105,7 @@ bool vtkSlicerPlaneWidget::CanProcessInteractionEvent(vtkMRMLInteractionEventDat
       return false;
       }
     }
+
   return Superclass::CanProcessInteractionEvent(eventData, distance2);
 }
 
@@ -96,10 +113,14 @@ bool vtkSlicerPlaneWidget::CanProcessInteractionEvent(vtkMRMLInteractionEventDat
 bool vtkSlicerPlaneWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData)
 {
   unsigned long widgetEvent = this->TranslateInteractionEventToWidgetEvent(eventData);
+  this->ApplicationLogic->PauseRender();
 
   bool processedEvent = false;
   switch (widgetEvent)
   {
+  case WidgetEventControlPointPlacePlaneNormal:
+    processedEvent = this->PlacePlaneNormal(eventData);
+    break;
   case WidgetEventPlaneMoveStart:
     processedEvent = this->ProcessPlaneMoveStart(eventData);
     break;
@@ -109,6 +130,12 @@ bool vtkSlicerPlaneWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* 
   case WidgetEventPlaneMoveEnd:
     processedEvent = this->ProcessPlaneMoveEnd(eventData);
     break;
+  case WidgetEventSymmetricScaleStart:
+    processedEvent = ProcessWidgetSymmetricScaleStart(eventData);
+    break;
+  case WidgetEventSymmetricScaleEnd:
+    processedEvent = ProcessEndMouseDrag(eventData);
+    break;
   }
 
   if (!processedEvent)
@@ -116,6 +143,7 @@ bool vtkSlicerPlaneWidget::ProcessInteractionEvent(vtkMRMLInteractionEventData* 
     processedEvent = Superclass::ProcessInteractionEvent(eventData);
     }
 
+  this->ApplicationLogic->ResumeRender();
   return processedEvent;
 }
 
@@ -145,6 +173,123 @@ bool vtkSlicerPlaneWidget::ProcessPlaneMoveEnd(vtkMRMLInteractionEventData* vtkN
   return true;
 }
 
+//-------------------------------------------------------------------------
+bool vtkSlicerPlaneWidget::ProcessUpdatePlaneFromViewNormal(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (!planeNode)
+    {
+    return false;
+    }
+
+  // Get world position
+  double eventPos_World[3] = { 0.0 };
+  double eventOrientation_World[9] = { 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 };
+  if (eventData->IsWorldPositionValid() && eventData->IsWorldPositionAccurate())
+    {
+    eventData->GetWorldPosition(eventPos_World);
+
+    double worldOrientationQuaternion[4] = { 0.0 };
+    eventData->GetWorldOrientation(worldOrientationQuaternion);
+    vtkMRMLMarkupsNode::ConvertOrientationWXYZToMatrix(worldOrientationQuaternion, eventOrientation_World);
+    }
+  else if (eventData->IsDisplayPositionValid())
+    {
+    int displayPos[2] = { 0 };
+    eventData->GetDisplayPosition(displayPos);
+    if (!this->ConvertDisplayPositionToWorld(displayPos, eventPos_World, eventOrientation_World))
+      {
+      eventData->GetWorldPosition(eventPos_World);
+      }
+    }
+  eventData->SetWorldPosition(eventPos_World);
+
+  vtkSlicerPlaneRepresentation2D* rep2d = vtkSlicerPlaneRepresentation2D::SafeDownCast(this->WidgetRep);
+  vtkSlicerPlaneRepresentation3D* rep3d = vtkSlicerPlaneRepresentation3D::SafeDownCast(this->WidgetRep);
+
+  if (rep2d)
+    {
+    vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(rep2d->GetViewNode());
+    if (sliceNode)
+      {
+      // Orient the plane so that the axes of the plane line up with the axes of the slice.
+
+      vtkNew<vtkTransform> sliceToRASTransform;
+      sliceToRASTransform->SetMatrix(sliceNode->GetSliceToRAS());
+
+      double yAxis_World[3] = { 0.0, 1.0, 0.0 };
+      sliceToRASTransform->TransformVector(yAxis_World, yAxis_World);
+      double zAxis_World[3] = { 0.0, 0.0, 1.0 };
+      sliceToRASTransform->TransformVector(zAxis_World, zAxis_World);
+      double xAxis_World[3] = { 1.0, 0.0, 0.0 };
+      vtkMath::Cross(yAxis_World, zAxis_World, xAxis_World);
+      vtkMath::Normalize(xAxis_World);
+
+      planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+      }
+    }
+  else if (rep3d)
+    {
+    int displayPos[2] = { 0, 0 };
+    eventData->GetDisplayPosition(displayPos);
+    double pickPos[3] = { 0.0, 0.0, 0.0 };
+    double zAxis_World[3] = { 0.0, 0.0, 0.0 };
+    bool pickSuccessful = rep3d->AccuratePick(displayPos[0], displayPos[1], pickPos, zAxis_World);
+
+    double yAxis_World[3] = { 0.0, 1.0, 0.0 };
+    vtkCamera* camera = this->Renderer->GetActiveCamera();
+    if (camera)
+      {
+      camera->GetViewUp(yAxis_World);
+      }
+
+    if (camera && !pickSuccessful)
+      {
+      // Did not find any pickable surface.
+      // Face plane towards the camera.
+      camera->GetDirectionOfProjection(zAxis_World);
+      vtkMath::MultiplyScalar(zAxis_World, -1.0);
+      }
+    vtkMath::Normalize(zAxis_World);
+
+    double epsilon = 1e-2;
+    if (vtkMath::Dot(zAxis_World, yAxis_World) >= 1.0 - epsilon)
+      {
+      // If the up vector and normal vector are pointing in the same direction, then just set the normal.
+      // The plane node will sort out the other new axes directions.
+      planeNode->SetNormalWorld(zAxis_World);
+      }
+    else
+      {
+      // Ensure that the axes are orthogonal
+      double xAxis_World[3] = { 1.0, 0.0, 0.0 };
+      vtkMath::Cross(yAxis_World, zAxis_World, xAxis_World);
+      vtkMath::Normalize(xAxis_World);
+      vtkMath::Cross(zAxis_World, xAxis_World, yAxis_World);
+      vtkMath::Normalize(yAxis_World);
+      planeNode->SetAxesWorld(xAxis_World, yAxis_World, zAxis_World);
+      }
+
+    }
+
+  planeNode->SetIsPlaneValid(true);
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkSlicerPlaneWidget::ProcessWidgetSymmetricScaleStart(vtkMRMLInteractionEventData* eventData)
+{
+  if ((this->WidgetState != vtkSlicerMarkupsWidget::WidgetStateOnWidget && this->WidgetState != vtkSlicerMarkupsWidget::WidgetStateOnScaleHandle)
+    || this->IsAnyControlPointLocked())
+    {
+    return false;
+    }
+
+  this->SetWidgetState(WidgetStateSymmetricScale);
+  this->StartWidgetInteraction(eventData);
+  return true;
+}
+
 //----------------------------------------------------------------------
 bool vtkSlicerPlaneWidget::ProcessMouseMove(vtkMRMLInteractionEventData* eventData)
 {
@@ -152,7 +297,22 @@ bool vtkSlicerPlaneWidget::ProcessMouseMove(vtkMRMLInteractionEventData* eventDa
     {
     return this->ProcessPlaneTranslate(eventData);
     }
-  return Superclass::ProcessMouseMove(eventData);
+  else if (this->WidgetState == WidgetStateSymmetricScale)
+    {
+    return this->ProcessPlaneSymmetricScale(eventData);
+    }
+
+  bool processed = Superclass::ProcessMouseMove(eventData);
+
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (planeNode && this->WidgetState == WidgetStateDefine && planeNode->GetPlaneType() == vtkMRMLMarkupsPlaneNode::PlaneTypePointNormal &&
+      planeNode->GetNumberOfControlPoints() == 1 && this->PreviewPointIndex == 0)
+    {
+    // If we are using a point-normal plane type, then update the plane so that its normal is aligned with the view normal
+    processed |= this->ProcessUpdatePlaneFromViewNormal(eventData);
+    }
+
+  return processed;
 }
 
 //----------------------------------------------------------------------
@@ -255,5 +415,582 @@ bool vtkSlicerPlaneWidget::ProcessPlaneTranslate(vtkMRMLInteractionEventData* ev
 
   this->LastEventPosition[0] = eventPos[0];
   this->LastEventPosition[1] = eventPos[1];
+  return true;
+}
+
+//----------------------------------------------------------------------
+bool vtkSlicerPlaneWidget::ProcessPlaneSymmetricScale(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
+  vtkSlicerMarkupsWidgetRepresentation* rep = this->GetMarkupsRepresentation();
+  if (!rep || !markupsNode || !eventData)
+    {
+    return false;
+    }
+
+  // Process the motion
+  // Based on the displacement vector (computed in display coordinates) and
+  // the cursor state (which corresponds to which part of the widget has been
+  // selected), the widget points are modified.
+  // First construct a local coordinate system based on the display coordinates
+  // of the widget.
+  double eventPos[2]
+    {
+    static_cast<double>(eventData->GetDisplayPosition()[0]),
+    static_cast<double>(eventData->GetDisplayPosition()[1]),
+    };
+
+  this->ScaleWidget(eventPos, true);
+
+  this->LastEventPosition[0] = eventPos[0];
+  this->LastEventPosition[1] = eventPos[1];
+
+  return true;
+}
+
+//-------------------------------------------------------------------------
+bool vtkSlicerPlaneWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData)
+{
+  if (!this->WidgetRep)
+    {
+    return false;
+    }
+
+  if (this->WidgetState == vtkSlicerPlaneWidget::WidgetStateSymmetricScale)
+    {
+    int activeComponentType = this->GetActiveComponentType();
+    if (activeComponentType == vtkMRMLMarkupsDisplayNode::ComponentScaleHandle)
+      {
+      this->SetWidgetState(WidgetStateOnScaleHandle);
+      }
+    else
+      {
+      this->SetWidgetState(WidgetStateOnWidget);
+      }
+    this->EndWidgetInteraction();
+    }
+
+  return Superclass::ProcessEndMouseDrag(eventData);
+}
+
+//-------------------------------------------------------------------------
+bool vtkSlicerPlaneWidget::ProcessWidgetStopPlace(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLMarkupsPlaneNode* markupsNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (markupsNode)
+    {
+    markupsNode->SetNormalPointRequired(false);
+    }
+  return Superclass::ProcessWidgetStopPlace(eventData);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerPlaneWidget::RotateWidget(double eventPos[2])
+{
+  vtkMRMLMarkupsPlaneNode* markupsNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (!markupsNode)
+    {
+    return;
+    }
+
+  double eventPos_World[3] = { 0. };
+  double lastEventPos_World[3] = { 0. };
+  double orientation_World[9] = { 0. };
+  double eventPos_Display[2] = { 0. };
+
+  vtkSlicerMarkupsWidgetRepresentation* rep = vtkSlicerMarkupsWidgetRepresentation::SafeDownCast(this->WidgetRep);
+  vtkSlicerMarkupsWidgetRepresentation2D* rep2d = vtkSlicerMarkupsWidgetRepresentation2D::SafeDownCast(this->WidgetRep);
+  vtkSlicerMarkupsWidgetRepresentation3D* rep3d = vtkSlicerMarkupsWidgetRepresentation3D::SafeDownCast(this->WidgetRep);
+  if (rep2d)
+    {
+    double eventPos_Slice[3] = { 0. };
+    eventPos_Slice[0] = this->LastEventPosition[0];
+    eventPos_Slice[1] = this->LastEventPosition[1];
+    rep2d->GetSliceToWorldCoordinates(eventPos_Slice, lastEventPos_World);
+
+    eventPos_Slice[0] = eventPos[0];
+    eventPos_Slice[1] = eventPos[1];
+    rep2d->GetSliceToWorldCoordinates(eventPos_Slice, eventPos_World);
+
+    eventPos_Display[0] = eventPos_Slice[0];
+    eventPos_Display[1] = eventPos_Slice[1];
+    }
+  else if (rep3d)
+    {
+    eventPos_Display[0] = this->LastEventPosition[0];
+    eventPos_Display[1] = this->LastEventPosition[1];
+
+    if (rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
+      eventPos_Display, eventPos_World, lastEventPos_World,
+      orientation_World))
+      {
+      for (int i = 0; i < 3; i++)
+        {
+        eventPos_World[i] = lastEventPos_World[i];
+        }
+      }
+    else
+      {
+      return;
+      }
+    eventPos_Display[0] = eventPos[0];
+    eventPos_Display[1] = eventPos[1];
+
+    if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
+      eventPos_Display, eventPos_World, eventPos_World,
+      orientation_World))
+      {
+      return;
+      }
+    }
+
+  double origin_World[3] = { 0.0 };
+  rep->GetInteractionHandleOriginWorld(origin_World);
+
+  double epsilon = 1e-5;
+  double d2 = vtkMath::Distance2BetweenPoints(eventPos_World, origin_World);
+  if (d2 < epsilon)
+    {
+    return;
+    }
+
+  for (int i = 0; i < 3; i++)
+    {
+    lastEventPos_World[i] -= origin_World[i];
+    eventPos_World[i] -= origin_World[i];
+    }
+
+  double angle = vtkMath::DegreesFromRadians(
+    vtkMath::AngleBetweenVectors(lastEventPos_World, eventPos_World));
+  double rotationNormal_World[3] = { 0.0 };
+  vtkMath::Cross(lastEventPos_World, eventPos_World, rotationNormal_World);
+  double rotationAxis_World[3] = { 0.0, 1.0, 0.0 };
+  int type = this->GetActiveComponentType();
+  if (type == vtkMRMLMarkupsDisplayNode::ComponentRotationHandle)
+    {
+    int index = this->GetMarkupsDisplayNode()->GetActiveComponentIndex();
+    double eventPositionOnAxisPlane_World[3] = { 0.0, 0.0, 0.0 };
+    if (!this->GetIntersectionOnAxisPlane(type, index, eventPos, eventPositionOnAxisPlane_World))
+      {
+      vtkWarningMacro("RotateWidget: Could not calculate intended orientation");
+      return;
+      }
+
+    rep->GetInteractionHandleAxisWorld(type, index, rotationAxis_World); // Axis of rotation
+    double origin_World[3] = { 0.0, 0.0, 0.0 };
+    rep->GetInteractionHandleOriginWorld(origin_World);
+
+    double lastEventPositionOnAxisPlane_World[3] = { 0.0, 0.0, 0.0 };
+    if (!this->GetIntersectionOnAxisPlane(
+      vtkMRMLMarkupsDisplayNode::ComponentRotationHandle, index, this->LastEventPosition,lastEventPositionOnAxisPlane_World))
+      {
+      vtkWarningMacro("RotateWidget: Could not calculate previous orientation");
+      return;
+      }
+
+    double rotationHandleVector_World[3] = { 0.0, 0.0, 0.0 };
+    vtkMath::Subtract(lastEventPositionOnAxisPlane_World, origin_World, rotationHandleVector_World);
+
+    double destinationVector_World[3] = { 0.0, 0.0, 0.0 };
+    vtkMath::Subtract(eventPositionOnAxisPlane_World, origin_World, destinationVector_World);
+
+    angle = vtkMath::DegreesFromRadians(vtkMath::AngleBetweenVectors(rotationHandleVector_World, destinationVector_World));
+    vtkMath::Cross(rotationHandleVector_World, destinationVector_World, rotationNormal_World);
+    }
+  else
+    {
+    rotationAxis_World[0] = rotationNormal_World[0];
+    rotationAxis_World[1] = rotationNormal_World[1];
+    rotationAxis_World[2] = rotationNormal_World[2];
+    }
+
+  if (vtkMath::Dot(rotationNormal_World, rotationAxis_World) < 0.0)
+    {
+    angle *= -1.0;
+    }
+
+  vtkNew<vtkMatrix4x4> objectToNodeMatrix;
+  markupsNode->GetObjectToNodeMatrix(objectToNodeMatrix);
+
+  vtkNew<vtkMatrix4x4> nodeToObjectMatrix;
+  vtkMatrix4x4::Invert(objectToNodeMatrix, nodeToObjectMatrix);
+
+  vtkNew<vtkTransform> objectToNodeTransform;
+  objectToNodeTransform->SetMatrix(objectToNodeMatrix);
+
+  vtkNew<vtkMatrix4x4> worldToObjectMatrix;
+  markupsNode->GetObjectToWorldMatrix(worldToObjectMatrix);
+  worldToObjectMatrix->Invert();
+  vtkNew<vtkTransform> worldToObjectTransform;
+  worldToObjectTransform->SetMatrix(worldToObjectMatrix);
+
+  double rotationAxis_Object[3] = { 0.0, 0.0, 0.0 };
+  worldToObjectTransform->TransformVector(rotationAxis_World, rotationAxis_Object);
+
+  vtkNew<vtkTransform> rotateTransform;
+  rotateTransform->PostMultiply();
+  rotateTransform->Concatenate(nodeToObjectMatrix);
+  rotateTransform->RotateWXYZ(angle, rotationAxis_Object);
+  rotateTransform->Concatenate(objectToNodeMatrix);
+  markupsNode->ApplyTransform(rotateTransform);
+}
+
+
+//----------------------------------------------------------------------
+void vtkSlicerPlaneWidget::ScaleWidget(double eventPos[2])
+{
+  this->ScaleWidget(eventPos, false);
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerPlaneWidget::ScaleWidget(double eventPos[2], bool symmetricScale)
+{
+  vtkMRMLMarkupsDisplayNode* displayNode = this->GetMarkupsDisplayNode();
+  vtkMRMLMarkupsPlaneNode* markupsNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (!markupsNode || !displayNode)
+    {
+    return;
+    }
+
+  double lastEventPos_World[3] = { 0.0 };
+  double eventPos_World[3] = { 0.0 };
+  double orientation_World[9] = { 0.0 };
+
+  vtkSlicerPlaneRepresentation2D* rep2d = vtkSlicerPlaneRepresentation2D::SafeDownCast(this->WidgetRep);
+  vtkSlicerPlaneRepresentation3D* rep3d = vtkSlicerPlaneRepresentation3D::SafeDownCast(this->WidgetRep);
+  if (rep2d)
+    {
+    // 2D view
+    double eventPos_Slice[3] = { 0. };
+    eventPos_Slice[0] = this->LastEventPosition[0];
+    eventPos_Slice[1] = this->LastEventPosition[1];
+    rep2d->GetSliceToWorldCoordinates(eventPos_Slice, lastEventPos_World);
+
+    eventPos_Slice[0] = eventPos[0];
+    eventPos_Slice[1] = eventPos[1];
+    rep2d->GetSliceToWorldCoordinates(eventPos_Slice, eventPos_World);
+    }
+  else if (rep3d)
+    {
+    // 3D view
+    double eventPos_Display[2] = { 0. };
+    eventPos_Display[0] = this->LastEventPosition[0];
+    eventPos_Display[1] = this->LastEventPosition[1];
+
+    if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
+      eventPos_Display, lastEventPos_World, eventPos_World,
+      orientation_World))
+      {
+      return;
+      }
+    lastEventPos_World[0] = eventPos_World[0];
+    lastEventPos_World[1] = eventPos_World[1];
+    lastEventPos_World[2] = eventPos_World[2];
+
+    eventPos_Display[0] = eventPos[0];
+    eventPos_Display[1] = eventPos[1];
+
+    if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
+      eventPos_Display, lastEventPos_World, eventPos_World,
+      orientation_World))
+      {
+      return;
+      }
+    }
+
+  if (this->GetActiveComponentType() == vtkMRMLMarkupsDisplayNode::ComponentScaleHandle)
+    {
+    vtkNew<vtkMatrix4x4> worldToObjectMatrix;
+    markupsNode->GetObjectToWorldMatrix(worldToObjectMatrix);
+    worldToObjectMatrix->Invert();
+    vtkNew<vtkTransform> worldToObjectTransform;
+    worldToObjectTransform->SetMatrix(worldToObjectMatrix);
+
+    int index = displayNode->GetActiveComponentIndex();
+    if (index <= vtkMRMLMarkupsPlaneDisplayNode::HandleAEdge)
+      {
+      // We are interacting with one of the edges.
+      // Restrict scaling to apply only in that direction.
+      this->GetClosestPointOnInteractionAxis(
+        vtkMRMLMarkupsDisplayNode::ComponentScaleHandle, index, this->LastEventPosition, lastEventPos_World);
+      this->GetClosestPointOnInteractionAxis(
+        vtkMRMLMarkupsDisplayNode::ComponentScaleHandle, index, eventPos, eventPos_World);
+      }
+    else
+      {
+      // We are interacting with one of the corners
+      // Restrict scaling so that the projection of the interaction handle and the event position will be at the same display position.
+      double cameraDirectionEventPos_World[3] = { 0.0, 0.0, 0.0 };
+      double cameraDirectionLastEventPos_World[3] = { 0.0, 0.0, 0.0 };
+      if (rep2d)
+        {
+        vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(rep2d->GetViewNode());
+        if (sliceNode)
+          {
+          // Get the slice view normal
+          double normal4_World[4] = { 0.0, 0.0, 1.0, 0.0 };
+          sliceNode->GetSliceToRAS()->MultiplyPoint(normal4_World, normal4_World);
+          cameraDirectionEventPos_World[0] = normal4_World[0];
+          cameraDirectionEventPos_World[1] = normal4_World[1];
+          cameraDirectionEventPos_World[2] = normal4_World[2];
+          cameraDirectionLastEventPos_World[0] = normal4_World[0];
+          cameraDirectionLastEventPos_World[1] = normal4_World[1];
+          cameraDirectionLastEventPos_World[2] = normal4_World[2];
+          }
+        }
+      else if (rep3d)
+        {
+        vtkCamera* camera = this->Renderer->GetActiveCamera();
+        if (camera && camera->GetParallelProjection())
+          {
+          camera->GetDirectionOfProjection(cameraDirectionEventPos_World);
+          camera->GetDirectionOfProjection(cameraDirectionLastEventPos_World);
+          }
+        else if (camera)
+          {
+          // Camera position
+          double cameraPosition_World[4] = { 0.0 };
+          camera->GetPosition(cameraPosition_World);
+
+          //  Compute the ray endpoints. The ray is along the line running from
+          //  the camera position to the selection point, starting where this line
+          //  intersects the front clipping plane, and terminating where this
+          //  line intersects the back clipping plane.
+          vtkMath::Subtract(cameraPosition_World, eventPos_World, cameraDirectionEventPos_World);
+          vtkMath::Subtract(cameraPosition_World, lastEventPos_World, cameraDirectionLastEventPos_World);
+          }
+        }
+
+      // Create a second point running along the line from the camera to the event position
+      double eventPos2_World[3];
+      vtkMath::Add(eventPos_World, cameraDirectionEventPos_World, eventPos2_World);
+      double lastEventPos2_World[3];
+      vtkMath::Add(lastEventPos_World, cameraDirectionLastEventPos_World, lastEventPos2_World);
+      double t; // not used
+
+      double normal_World[3] = { 0.0, 0.0, 0.0 };
+      markupsNode->GetNormalWorld(normal_World);
+      double origin_World[3] = { 0.0, 0.0, 0.0 };
+      markupsNode->GetOriginWorld(origin_World);
+
+      // Find the intersection of the vector from event positions, along the vector from the camera at that point
+      vtkNew<vtkPlane> plane;
+      plane->SetOrigin(origin_World);
+      plane->SetNormal(normal_World);
+      plane->IntersectWithLine(eventPos_World, eventPos2_World, t, eventPos_World);
+      plane->IntersectWithLine(lastEventPos_World, lastEventPos2_World, t, lastEventPos_World);
+      }
+
+    double scaleVector_World[3] = { 0.0, 0.0, 0.0 };
+    vtkMath::Subtract(eventPos_World, lastEventPos_World, scaleVector_World);
+
+    double scaleVector_Object[3] = { 0.0, 0.0, 0.0 };
+    worldToObjectTransform->TransformVector(scaleVector_World, scaleVector_Object);
+
+    double bounds_Plane[4] = { 0.0, -1.0, 0.0, -1.0 };
+    markupsNode->GetPlaneBounds(bounds_Plane);
+
+    switch (index)
+      {
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLEdge:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLACorner:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLPCorner:
+        bounds_Plane[0] += scaleVector_Object[0];
+        if (symmetricScale)
+          {
+          bounds_Plane[1] -= scaleVector_Object[0];
+          }
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleREdge:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRACorner:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRPCorner:
+        bounds_Plane[1] += scaleVector_Object[0];
+        if (symmetricScale)
+          {
+          bounds_Plane[0] -= scaleVector_Object[0];
+          }
+        break;
+      default:
+        break;
+      }
+
+    switch (index)
+      {
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleAEdge:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLACorner:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRACorner:
+        bounds_Plane[2] += scaleVector_Object[1];
+        if (symmetricScale)
+          {
+          bounds_Plane[3] -= scaleVector_Object[1];
+          }
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandlePEdge:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLPCorner:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRPCorner:
+        bounds_Plane[3] += scaleVector_Object[1];
+        if (symmetricScale)
+          {
+          bounds_Plane[2] -= scaleVector_Object[1];
+          }
+        break;
+      default:
+        break;
+      }
+
+    // If we have crossed over the origin, we need to flip the selected handle accros the Right and/or Anterior axis.
+    bool flipLRHandle = bounds_Plane[1] < bounds_Plane[0];
+    bool flipPAHandle = bounds_Plane[3] < bounds_Plane[2];
+    if (flipLRHandle || flipPAHandle)
+      {
+      this->FlipPlaneHandles(flipLRHandle, flipPAHandle);
+      }
+
+    if (bounds_Plane[1] < bounds_Plane[0])
+      {
+      double tempBounds_Plane0 = bounds_Plane[0];
+      bounds_Plane[0] = bounds_Plane[1];
+      bounds_Plane[1] = tempBounds_Plane0;
+      }
+
+    if (bounds_Plane[3] < bounds_Plane[2])
+      {
+      double tempBounds_Plane2 = bounds_Plane[2];
+      bounds_Plane[2] = bounds_Plane[3];
+      bounds_Plane[3] = tempBounds_Plane2;
+      }
+
+    markupsNode->SetPlaneBounds(bounds_Plane);
+    markupsNode->SetSizeMode(vtkMRMLMarkupsPlaneNode::SizeModeAbsolute);
+    }
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerPlaneWidget::FlipPlaneHandles(bool flipLRHandle, bool flipPAHandle)
+{
+  vtkMRMLMarkupsDisplayNode* displayNode = this->GetMarkupsDisplayNode();
+  vtkMRMLMarkupsPlaneNode* markupsNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (!markupsNode || !displayNode)
+    {
+    return;
+    }
+
+  int index = displayNode->GetActiveComponentIndex();
+  if (flipLRHandle)
+    {
+    switch (index)
+      {
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLEdge:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleREdge;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleREdge:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleLEdge;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLACorner:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleRACorner;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLPCorner:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleRPCorner;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRACorner:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleLACorner;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRPCorner:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleLPCorner;
+        break;
+      default:
+        break;
+      }
+    }
+
+  if (flipPAHandle)
+    {
+    switch (index)
+      {
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleAEdge:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandlePEdge;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandlePEdge:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleAEdge;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLACorner:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleLPCorner;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLPCorner:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleLACorner;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRACorner:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleRPCorner;
+        break;
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRPCorner:
+        index = vtkMRMLMarkupsPlaneDisplayNode::HandleRACorner;
+        break;
+      default:
+        break;
+      }
+    }
+
+  displayNode->SetActiveComponent(displayNode->GetActiveComponentType(), index);
+}
+
+//---------------------------------------------------------------------------
+bool vtkSlicerPlaneWidget::PlacePoint(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (!planeNode)
+    {
+      return false;
+    }
+
+  if (planeNode->GetPlaneType() == vtkMRMLMarkupsPlaneNode::PlaneTypePointNormal &&
+    planeNode->GetNumberOfDefinedControlPoints() > 0)
+    {
+    planeNode->SetNormalPointRequired(false);
+    }
+
+  bool success = Superclass::PlacePoint(eventData);
+  if (!success)
+    {
+    return false;
+    }
+
+  // We have returned to place mode. Need to delete the uneccesary points
+  if (planeNode->GetPlaneType() == vtkMRMLMarkupsPlaneNode::PlaneTypePointNormal)
+    {
+    planeNode->UpdateControlPointsFromPlane();
+    }
+
+  return true;
+}
+
+//---------------------------------------------------------------------------
+bool vtkSlicerPlaneWidget::PlacePlaneNormal(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->GetMarkupsNode());
+  if (!planeNode)
+    {
+    return false;
+    }
+
+  if (planeNode->GetPlaneType() != vtkMRMLMarkupsPlaneNode::PlaneTypePointNormal)
+    {
+    // We don't do anything different if we are not in point normal mode.
+    return this->PlacePoint(eventData);
+    }
+
+  if (planeNode->GetNumberOfDefinedControlPoints() == 0)
+    {
+    planeNode->SetNormalPointRequired(true);
+    }
+  else
+    {
+    planeNode->SetNormalPointRequired(false);
+    }
+
+  if (!this->PlacePoint(eventData))
+    {
+    return false;
+    }
+
   return true;
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.h
@@ -51,31 +51,53 @@ public:
   /// Widget states
   enum
   {
-    WidgetStateDefine = WidgetStateUser + 50, // click in empty area will place a new point
-    WidgetStateTranslatePlane, // translating the plane
+    WidgetStateTranslatePlane = WidgetStateMarkups_Last, // translating the plane
+    WidgetStateSymmetricScale, // Scaling the plane without moving the center
+    WidgetStateMarkupsPlane_Last
   };
 
   /// Widget events
   enum
   {
-    WidgetEventControlPointPlace = WidgetEventUser + 50,
+    WidgetEventControlPointPlace = WidgetEventMarkups_Last,
+    WidgetEventControlPointPlacePlaneNormal,
     WidgetEventPlaneMoveStart,
     WidgetEventPlaneMoveEnd,
+    WidgetEventSymmetricScaleStart,
+    WidgetEventSymmetricScaleEnd,
+    WidgetEventMarkupsPlane_Last
   };
 
   /// Create the default widget representation and initializes the widget and representation.
   void CreateDefaultRepresentation(vtkMRMLMarkupsDisplayNode* markupsDisplayNode, vtkMRMLAbstractViewNode* viewNode, vtkRenderer* renderer) override;
 
-protected:
-  vtkSlicerPlaneWidget();
-  ~vtkSlicerPlaneWidget() override;
+  bool PlacePoint(vtkMRMLInteractionEventData* eventData) override;
+  virtual bool PlacePlaneNormal(vtkMRMLInteractionEventData* eventData);
 
   bool CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double& distance2) override;
   bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
+  bool ProcessUpdatePlaneFromViewNormal(vtkMRMLInteractionEventData* event);
   bool ProcessPlaneMoveStart(vtkMRMLInteractionEventData* event);
   bool ProcessPlaneMoveEnd(vtkMRMLInteractionEventData* event);
   bool ProcessMouseMove(vtkMRMLInteractionEventData* eventData) override;
   bool ProcessPlaneTranslate(vtkMRMLInteractionEventData* event);
+  bool ProcessWidgetSymmetricScaleStart(vtkMRMLInteractionEventData* eventData);
+  bool ProcessPlaneSymmetricScale(vtkMRMLInteractionEventData* event);
+  bool ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData) override;
+  bool ProcessWidgetStopPlace(vtkMRMLInteractionEventData* eventData) override;
+
+protected:
+  vtkSlicerPlaneWidget();
+  ~vtkSlicerPlaneWidget() override;
+
+  void ScaleWidget(double eventPos[2]) override;
+  virtual void ScaleWidget(double eventPos[2], bool symmetricScale);
+  void RotateWidget(double eventPos[2]) override;
+
+  /// Flip the selected index across the specified axis.
+  /// Ex. Switch between L--R face.
+  /// Used when the user drags an ROI handle across the ROI origin.
+  void FlipPlaneHandles(bool flipLRHandle, bool flipAPHandle);
 
 private:
   vtkSlicerPlaneWidget(const vtkSlicerPlaneWidget&) = delete;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
@@ -416,7 +416,7 @@ void vtkSlicerROIRepresentation2D::UpdateInteractionPipeline()
     }
 
   this->InteractionPipeline->Actor->SetVisibility(this->MarkupsDisplayNode->GetVisibility()
-    && this->MarkupsDisplayNode->GetVisibility3D()
+    && this->MarkupsDisplayNode->GetVisibility2D()
     && this->MarkupsDisplayNode->GetHandlesInteractive());
 
   vtkNew<vtkTransform> handleToWorldTransform;

--- a/Modules/Loadable/Markups/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Widgets/CMakeLists.txt
@@ -19,6 +19,8 @@ set(${KIT}_SRCS
   qMRML${MODULE_NAME}ToolBar.cxx
   qMRML${MODULE_NAME}ToolBar.h
   qMRML${MODULE_NAME}ToolBar_p.h
+  qMRML${MODULE_NAME}PlaneWidget.cxx
+  qMRML${MODULE_NAME}PlaneWidget.h
   qMRML${MODULE_NAME}ROIWidget.cxx
   qMRML${MODULE_NAME}ROIWidget.h
   qMRML${MODULE_NAME}AbstractOptionsWidget.cxx
@@ -41,6 +43,7 @@ set(${KIT}_MOC_SRCS
   qMRML${MODULE_NAME}InteractionHandleWidget.h
   qMRML${MODULE_NAME}ToolBar.h
   qMRML${MODULE_NAME}ToolBar_p.h
+  qMRML${MODULE_NAME}PlaneWidget.h
   qMRML${MODULE_NAME}ROIWidget.h
   qMRML${MODULE_NAME}AbstractOptionsWidget.h
   qMRML${MODULE_NAME}AngleMeasurementsWidget.h
@@ -54,6 +57,7 @@ set(${KIT}_UI_SRCS
   Resources/UI/qMRML${MODULE_NAME}DisplayNodeWidget.ui
   Resources/UI/qMRML${MODULE_NAME}FiducialProjectionPropertyWidget.ui
   Resources/UI/qMRML${MODULE_NAME}InteractionHandleWidget.ui
+  Resources/UI/qMRML${MODULE_NAME}PlaneWidget.ui
   Resources/UI/qMRML${MODULE_NAME}ROIWidget.ui
   Resources/UI/qMRML${MODULE_NAME}AngleMeasurementsWidget.ui
   Resources/UI/qMRML${MODULE_NAME}CurveSettingsWidget.ui

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsPlaneWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsPlaneWidget.ui
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qMRMLMarkupsPlaneWidget</class>
+ <widget class="QWidget" name="qMRMLMarkupsPlaneWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>362</width>
+    <height>201</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="ctkCollapsibleButton" name="planeSettingsCollapseButton">
+     <property name="text">
+      <string>Plane settings</string>
+     </property>
+     <property name="collapsed">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <item>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_10">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="planeTypeComboBox"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Size mode:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="planeSizeModeComboBox"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Size:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>X:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="ctkDoubleSpinBox" name="sizeXSpinBox">
+            <property name="maximum">
+             <double>1000000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_4">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Y:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="ctkDoubleSpinBox" name="sizeYSpinBox">
+            <property name="maximum">
+             <double>1000000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Bounds:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="2">
+           <widget class="QLabel" name="label_9">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>X max:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="ctkDoubleSpinBox" name="boundsXMinSpinBox">
+            <property name="minimum">
+             <double>-1000000000.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1000000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="ctkDoubleSpinBox" name="boundsXMaxSpinBox">
+            <property name="minimum">
+             <double>-1000000000.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1000000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>X min:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Y min:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="ctkDoubleSpinBox" name="boundsYMinSpinBox">
+            <property name="minimum">
+             <double>-1000000000.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1000000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="ctkDoubleSpinBox" name="boundsYMaxSpinBox">
+            <property name="minimum">
+             <double>-1000000000.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1000000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QLabel" name="label_13">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Y max:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Normal:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="normalVisibilityCheckBox">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Opacity:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="ctkSliderWidget" name="normalOpacitySlider">
+            <property name="singleStep">
+             <double>0.010000000000000</double>
+            </property>
+            <property name="pageStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkDoubleSpinBox</class>
+   <extends>QWidget</extends>
+   <header>ctkDoubleSpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
@@ -97,12 +97,6 @@ void qMRMLMarkupsInteractionHandleWidget::setMRMLDisplayNode(vtkMRMLMarkupsDispl
 }
 
 // --------------------------------------------------------------------------
-void qMRMLMarkupsInteractionHandleWidget::setMRMLDisplayNode(vtkMRMLNode* roiNode)
-{
-  this->setMRMLDisplayNode(vtkMRMLMarkupsNode::SafeDownCast(roiNode));
-}
-
-// --------------------------------------------------------------------------
 void qMRMLMarkupsInteractionHandleWidget::updateWidgetFromMRML()
 {
   Q_D(qMRMLMarkupsInteractionHandleWidget);

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.h
@@ -53,7 +53,6 @@ public:
 
 public slots:
   /// Set the MRML display node
-  void setMRMLDisplayNode(vtkMRMLNode* node);
   void setMRMLDisplayNode(vtkMRMLMarkupsDisplayNode* node);
 
 protected slots:

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsPlaneWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsPlaneWidget.cxx
@@ -1,0 +1,327 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+  ==============================================================================*/
+
+// qMRML includes
+#include "qMRMLMarkupsPlaneWidget.h"
+#include "ui_qMRMLMarkupsPlaneWidget.h"
+
+// MRML includes
+#include <vtkMRMLMarkupsPlaneDisplayNode.h>
+#include <vtkMRMLMarkupsPlaneNode.h>
+
+// STD includes
+#include <vector>
+
+// --------------------------------------------------------------------------
+class qMRMLMarkupsPlaneWidgetPrivate:
+  public Ui_qMRMLMarkupsPlaneWidget
+{
+public:
+  qMRMLMarkupsPlaneWidgetPrivate(qMRMLMarkupsPlaneWidget& object);
+  void setupUi(qMRMLMarkupsPlaneWidget* widget);
+
+  const char* getPlaneTypeName(int planeType);
+
+protected:
+  qMRMLMarkupsPlaneWidget* const q_ptr;
+
+private:
+  Q_DECLARE_PUBLIC(qMRMLMarkupsPlaneWidget);
+};
+
+// --------------------------------------------------------------------------
+qMRMLMarkupsPlaneWidgetPrivate::qMRMLMarkupsPlaneWidgetPrivate(qMRMLMarkupsPlaneWidget& widget)
+  : q_ptr(&widget)
+{
+}
+
+// --------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidgetPrivate::setupUi(qMRMLMarkupsPlaneWidget* widget)
+{
+  Q_Q(qMRMLMarkupsPlaneWidget);
+
+  this->Ui_qMRMLMarkupsPlaneWidget::setupUi(widget);
+
+  this->planeTypeComboBox->clear();
+  for (int planeType = 0; planeType < vtkMRMLMarkupsPlaneNode::PlaneType_Last; ++planeType)
+    {
+    this->planeTypeComboBox->addItem(this->getPlaneTypeName(planeType), planeType);
+    }
+
+  this->planeSizeModeComboBox->clear();
+  for (int sizeMode = 0; sizeMode < vtkMRMLMarkupsPlaneNode::SizeMode_Last; ++sizeMode)
+    {
+    this->planeSizeModeComboBox->addItem(vtkMRMLMarkupsPlaneNode::GetSizeModeAsString(sizeMode), sizeMode);
+    }
+
+  QObject::connect(this->planeTypeComboBox, SIGNAL(currentIndexChanged(int)),
+                   q, SLOT(onPlaneTypeIndexChanged()));
+  QObject::connect(this->planeSizeModeComboBox, SIGNAL(currentIndexChanged(int)),
+    q, SLOT(onPlaneSizeModeIndexChanged()));
+
+  QObject::connect(this->sizeXSpinBox, SIGNAL(valueChanged(double)),
+    q, SLOT(onPlaneSizeSpinBoxChanged()));
+  QObject::connect(this->sizeYSpinBox, SIGNAL(valueChanged(double)),
+    q, SLOT(onPlaneSizeSpinBoxChanged()));
+
+
+  QObject::connect(this->boundsXMinSpinBox, SIGNAL(valueChanged(double)),
+    q, SLOT(onPlaneBoundsSpinBoxChanged()));
+  QObject::connect(this->boundsXMaxSpinBox, SIGNAL(valueChanged(double)),
+    q, SLOT(onPlaneBoundsSpinBoxChanged()));
+  QObject::connect(this->boundsYMinSpinBox, SIGNAL(valueChanged(double)),
+    q, SLOT(onPlaneBoundsSpinBoxChanged()));
+  QObject::connect(this->boundsYMaxSpinBox, SIGNAL(valueChanged(double)),
+    q, SLOT(onPlaneBoundsSpinBoxChanged()));
+
+  QObject::connect(this->normalVisibilityCheckBox, SIGNAL(stateChanged(int)), q, SLOT(onNormalVisibilityCheckBoxChanged()));
+  QObject::connect(this->normalOpacitySlider, SIGNAL(valueChanged(double)), q, SLOT(onNormalOpacitySliderChanged()));
+
+  q->setEnabled(vtkMRMLMarkupsPlaneNode::SafeDownCast(q->MarkupsNode) != nullptr);
+  q->setVisible(vtkMRMLMarkupsPlaneNode::SafeDownCast(q->MarkupsNode) != nullptr);
+}
+
+// --------------------------------------------------------------------------
+const char* qMRMLMarkupsPlaneWidgetPrivate::getPlaneTypeName(int planeType)
+{
+  switch (planeType)
+    {
+    case vtkMRMLMarkupsPlaneNode::PlaneType3Points:
+      return "Three points";
+    case vtkMRMLMarkupsPlaneNode::PlaneTypePointNormal:
+      return "Point normal";
+    case vtkMRMLMarkupsPlaneNode::PlaneTypePlaneFit:
+      return "Plane fit";
+    default:
+      break;
+    }
+  return "";
+}
+
+// --------------------------------------------------------------------------
+// qMRMLMarkupsPlaneWidget methods
+
+// --------------------------------------------------------------------------
+qMRMLMarkupsPlaneWidget::qMRMLMarkupsPlaneWidget(QWidget* parent)
+  : Superclass(parent), d_ptr(new qMRMLMarkupsPlaneWidgetPrivate(*this))
+{
+  this->setup();
+}
+
+// --------------------------------------------------------------------------
+qMRMLMarkupsPlaneWidget::~qMRMLMarkupsPlaneWidget() = default;
+
+// --------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::setup()
+{
+  Q_D(qMRMLMarkupsPlaneWidget);
+  d->setupUi(this);
+}
+
+// --------------------------------------------------------------------------
+vtkMRMLMarkupsPlaneNode* qMRMLMarkupsPlaneWidget::mrmlPlaneNode()const
+{
+  Q_D(const qMRMLMarkupsPlaneWidget);
+  return vtkMRMLMarkupsPlaneNode::SafeDownCast(this->MarkupsNode);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::setMRMLMarkupsNode(vtkMRMLMarkupsNode* markupsNode)
+{
+  this->qvtkReconnect(this->MarkupsNode, markupsNode, vtkCommand::ModifiedEvent,
+    this, SLOT(updateWidgetFromMRML()));
+
+  this->MarkupsNode = markupsNode;
+  this->updateWidgetFromMRML();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::updateWidgetFromMRML()
+{
+  Q_D(qMRMLMarkupsPlaneWidget);
+
+  this->setEnabled(this->canManageMRMLMarkupsNode(this->MarkupsNode));
+  this->setVisible(this->canManageMRMLMarkupsNode(this->MarkupsNode));
+
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->MarkupsNode);
+  if (!planeNode)
+    {
+    return;
+    }
+
+  bool wasBlocked = d->planeTypeComboBox->blockSignals(true);
+  d->planeTypeComboBox->setCurrentIndex(d->planeTypeComboBox->findData(planeNode->GetPlaneType()));
+  d->planeTypeComboBox->blockSignals(wasBlocked);
+
+  wasBlocked = d->planeSizeModeComboBox->blockSignals(true);
+  d->planeSizeModeComboBox->setCurrentIndex(d->planeSizeModeComboBox->findData(planeNode->GetSizeMode()));
+  d->planeSizeModeComboBox->blockSignals(wasBlocked);
+
+  double* size = planeNode->GetSize();
+
+  wasBlocked = d->sizeXSpinBox->blockSignals(true);
+  d->sizeXSpinBox->setValue(size[0]);
+  d->sizeXSpinBox->blockSignals(wasBlocked);
+  d->sizeXSpinBox->setEnabled(planeNode->GetSizeMode() != vtkMRMLMarkupsPlaneNode::SizeModeAuto);
+
+  wasBlocked = d->sizeYSpinBox->blockSignals(true);
+  d->sizeYSpinBox->setValue(size[1]);
+  d->sizeYSpinBox->blockSignals(wasBlocked);
+  d->sizeYSpinBox->setEnabled(planeNode->GetSizeMode() != vtkMRMLMarkupsPlaneNode::SizeModeAuto);
+
+  double* bounds = planeNode->GetPlaneBounds();
+
+  wasBlocked = d->boundsXMinSpinBox->blockSignals(true);
+  d->boundsXMinSpinBox->setValue(bounds[0]);
+  d->boundsXMinSpinBox->blockSignals(wasBlocked);
+  d->boundsXMinSpinBox->setEnabled(planeNode->GetSizeMode() != vtkMRMLMarkupsPlaneNode::SizeModeAuto);
+
+  wasBlocked = d->boundsXMaxSpinBox->blockSignals(true);
+  d->boundsXMaxSpinBox->setValue(bounds[1]);
+  d->boundsXMaxSpinBox->blockSignals(wasBlocked);
+  d->boundsXMaxSpinBox->setEnabled(planeNode->GetSizeMode() != vtkMRMLMarkupsPlaneNode::SizeModeAuto);
+
+  wasBlocked = d->boundsYMinSpinBox->blockSignals(true);
+  d->boundsYMinSpinBox->setValue(bounds[2]);
+  d->boundsYMinSpinBox->blockSignals(wasBlocked);
+  d->boundsYMinSpinBox->setEnabled(planeNode->GetSizeMode() != vtkMRMLMarkupsPlaneNode::SizeModeAuto);
+
+  wasBlocked = d->boundsYMaxSpinBox->blockSignals(true);
+  d->boundsYMaxSpinBox->setValue(bounds[3]);
+  d->boundsYMaxSpinBox->blockSignals(wasBlocked);
+  d->boundsYMaxSpinBox->setEnabled(planeNode->GetSizeMode() != vtkMRMLMarkupsPlaneNode::SizeModeAuto);
+
+  vtkMRMLMarkupsPlaneDisplayNode* planeDisplayNode = vtkMRMLMarkupsPlaneDisplayNode::SafeDownCast(planeNode->GetDisplayNode());
+  if (planeDisplayNode)
+    {
+    wasBlocked = d->normalVisibilityCheckBox->blockSignals(true);
+    d->normalVisibilityCheckBox->setChecked(planeDisplayNode->GetNormalVisibility());
+    d->normalVisibilityCheckBox->blockSignals(wasBlocked);
+
+    wasBlocked = d->normalOpacitySlider->blockSignals(true);
+    d->normalOpacitySlider->setValue(planeDisplayNode->GetNormalOpacity());
+    d->normalOpacitySlider->blockSignals(wasBlocked);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::onPlaneTypeIndexChanged()
+{
+  Q_D(qMRMLMarkupsPlaneWidget);
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->MarkupsNode);
+  if (!planeNode)
+    {
+    return;
+    }
+  planeNode->SetPlaneType(d->planeTypeComboBox->currentData().toInt());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::onPlaneSizeModeIndexChanged()
+{
+  Q_D(qMRMLMarkupsPlaneWidget);
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->MarkupsNode);
+  if (!planeNode)
+    {
+    return;
+    }
+  planeNode->SetSizeMode(d->planeSizeModeComboBox->currentData().toInt());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::onPlaneSizeSpinBoxChanged()
+{
+  Q_D(qMRMLMarkupsPlaneWidget);
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->MarkupsNode);
+  if (!planeNode)
+    {
+    return;
+    }
+  planeNode->SetSize(d->sizeXSpinBox->value(), d->sizeYSpinBox->value());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::onPlaneBoundsSpinBoxChanged()
+{
+  Q_D(qMRMLMarkupsPlaneWidget);
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->MarkupsNode);
+  if (!planeNode)
+  {
+    return;
+  }
+  double xMin = std::min(d->boundsXMinSpinBox->value(), d->boundsXMaxSpinBox->value());
+  double xMax = std::max(d->boundsXMinSpinBox->value(), d->boundsXMaxSpinBox->value());
+  double yMin = std::min(d->boundsYMinSpinBox->value(), d->boundsYMaxSpinBox->value());
+  double yMax = std::max(d->boundsYMinSpinBox->value(), d->boundsYMaxSpinBox->value());
+  planeNode->SetPlaneBounds(xMin, xMax, yMin, yMax);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::onNormalVisibilityCheckBoxChanged()
+{
+  Q_D(qMRMLMarkupsPlaneWidget);
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->MarkupsNode);
+  if (!planeNode)
+    {
+    return;
+    }
+
+  vtkMRMLMarkupsPlaneDisplayNode* displayNode = vtkMRMLMarkupsPlaneDisplayNode::SafeDownCast(planeNode->GetDisplayNode());
+  if (!displayNode)
+    {
+    return;
+    }
+
+  displayNode->SetNormalVisibility(d->normalVisibilityCheckBox->checkState() == Qt::Checked);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsPlaneWidget::onNormalOpacitySliderChanged()
+{
+  Q_D(qMRMLMarkupsPlaneWidget);
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(this->MarkupsNode);
+  if (!planeNode)
+    {
+    return;
+    }
+
+  vtkMRMLMarkupsPlaneDisplayNode* displayNode = vtkMRMLMarkupsPlaneDisplayNode::SafeDownCast(planeNode->GetDisplayNode());
+  if (!displayNode)
+    {
+    return;
+    }
+
+  displayNode->SetNormalOpacity(d->normalOpacitySlider->value());
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLMarkupsPlaneWidget::canManageMRMLMarkupsNode(vtkMRMLMarkupsNode *markupsNode) const
+{
+  Q_D(const qMRMLMarkupsPlaneWidget);
+
+  vtkMRMLMarkupsPlaneNode* planeNode = vtkMRMLMarkupsPlaneNode::SafeDownCast(markupsNode);
+  if (!planeNode)
+    {
+    return false;
+    }
+
+  return true;
+}

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsPlaneWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsPlaneWidget.h
@@ -1,0 +1,94 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#ifndef __qMRMLMarkupsPlaneWidget_h
+#define __qMRMLMarkupsPlaneWidget_h
+
+// Qt includes
+#include <QWidget>
+
+// Markups widgets includes
+#include "qMRMLMarkupsAbstractOptionsWidget.h"
+#include "qSlicerMarkupsModuleWidgetsExport.h"
+
+// CTK includes
+#include <ctkPimpl.h>
+#include <ctkVTKObject.h>
+
+class vtkMRMLAnnotationPlaneNode;
+class vtkMRMLNode;
+class vtkMRMLMarkupsPlaneNode;
+class qMRMLMarkupsPlaneWidgetPrivate;
+
+class Q_SLICER_MODULE_MARKUPS_WIDGETS_EXPORT qMRMLMarkupsPlaneWidget : public qMRMLMarkupsAbstractOptionsWidget
+{
+  Q_OBJECT
+  QVTK_OBJECT
+
+public:
+  typedef qMRMLMarkupsAbstractOptionsWidget Superclass;
+  qMRMLMarkupsPlaneWidget(QWidget* parent=nullptr);
+  ~qMRMLMarkupsPlaneWidget() override;
+
+  /// Returns the current MRML Plane node
+  vtkMRMLMarkupsPlaneNode* mrmlPlaneNode()const;
+
+  /// Gets the name of the additional options widget type
+  const QString className() const override { return "qMRMLMarkupsPlaneWidget"; }
+
+  /// Checks whether a given node can be handled by the widget
+  bool canManageMRMLMarkupsNode(vtkMRMLMarkupsNode *markupsNode) const override;
+
+public slots:
+  /// Updates the widget based on information from MRML.
+  void updateWidgetFromMRML() override;
+
+  /// Set the MRML node of interest
+  void setMRMLMarkupsNode(vtkMRMLMarkupsNode* node) override;
+
+  /// Returns an instance of the widget
+  qMRMLMarkupsAbstractOptionsWidget* createInstance() const override
+  {
+    return new qMRMLMarkupsPlaneWidget();
+  }
+
+protected slots:
+  /// Internal function to update type of Plane
+  void onPlaneTypeIndexChanged();
+  void onPlaneSizeModeIndexChanged();
+  void onPlaneSizeSpinBoxChanged();
+  void onPlaneBoundsSpinBoxChanged();
+  void onNormalVisibilityCheckBoxChanged();
+  void onNormalOpacitySliderChanged();
+
+protected:
+  void setup();
+
+protected:
+  QScopedPointer<qMRMLMarkupsPlaneWidgetPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qMRMLMarkupsPlaneWidget);
+  Q_DISABLE_COPY(qMRMLMarkupsPlaneWidget);
+
+};
+
+#endif

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -66,9 +66,10 @@
 #include "vtkSlicerROIWidget.h"
 
 // Markups widgets
-#include "qMRMLMarkupsROIWidget.h"
-#include "qMRMLMarkupsCurveSettingsWidget.h"
 #include "qMRMLMarkupsAngleMeasurementsWidget.h"
+#include "qMRMLMarkupsCurveSettingsWidget.h"
+#include "qMRMLMarkupsPlaneWidget.h"
+#include "qMRMLMarkupsROIWidget.h"
 #include "qMRMLMarkupsToolBar.h"
 #include "qMRMLMarkupsOptionsWidgetsFactory.h"
 #include "qMRMLNodeComboBox.h"
@@ -302,6 +303,7 @@ qSlicerAbstractModuleRepresentation* qSlicerMarkupsModule::createWidgetRepresent
   auto optionsWidgetFactory = qMRMLMarkupsOptionsWidgetsFactory::instance();
   optionsWidgetFactory->registerOptionsWidget(new qMRMLMarkupsAngleMeasurementsWidget());
   optionsWidgetFactory->registerOptionsWidget(new qMRMLMarkupsCurveSettingsWidget());
+  optionsWidgetFactory->registerOptionsWidget(new qMRMLMarkupsPlaneWidget());
   optionsWidgetFactory->registerOptionsWidget(new qMRMLMarkupsROIWidget());
 
   // Create and configure module widget.


### PR DESCRIPTION
Previously planes were only defined with 3 points (origin, x-axis, plane defining 3rd point).
This commit adds 2 other types of plane modes:
  - Point + Normal: Single control point managing plane origin, with normal managed internally
  - Plane fit: Plane defined by a plane fitting function on any number of points > 3

When using the Point + Normal plane mode, using Left Click + Alt will fully define the plane so that the normal direction is facing towards the user.

This commit also adds scaling interaction handles that can be used to change the size of the plane.

![image](https://user-images.githubusercontent.com/9222709/139137155-5e1c8554-31f4-4a8f-bb43-80ea8620e2fc.png)
