### PR TITLE
BUG: Fix missing curvature scalar for markups

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -312,6 +312,7 @@ protected:
   vtkSmartPointer<vtkArrayCalculator> SurfaceScalarCalculator;
   vtkSmartPointer<vtkPassThroughFilter> SurfaceScalarPassThroughFilter;
   vtkSmartPointer<vtkCurveMeasurementsCalculator> CurveMeasurementsCalculator;
+  vtkSmartPointer<vtkPassThroughFilter> WorldOutput;
   const char* ShortestDistanceSurfaceActiveScalar;
 
   /// Filter that changes the active scalar of the input mesh using the ActiveScalarName


### PR DESCRIPTION
Update vtkMRMLMarkupsCurveNode to allow curvature scalar array to be
available from GetCurveWorld and GetCurveWorldConnection

Fixes https://github.com/Slicer/Slicer/issues/5969