### PR TITLE
ENH: Move RobustStatisticsSegmenter and SimpleRegionGrowingSegmentation modules to legacy category

### DIFF
--- a/Modules/CLI/RobustStatisticsSegmenter/RobustStatisticsSegmenter.xml
+++ b/Modules/CLI/RobustStatisticsSegmenter/RobustStatisticsSegmenter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <executable>
-  <category>Segmentation.Specialized</category>
+  <category>Legacy.Segmentation</category>
   <title>Robust Statistics Segmenter</title>
   <description><![CDATA[Active contour segmentation using robust statistic.]]></description>
   <version>1.0</version>

--- a/Modules/CLI/SimpleRegionGrowingSegmentation/SimpleRegionGrowingSegmentation.xml
+++ b/Modules/CLI/SimpleRegionGrowingSegmentation/SimpleRegionGrowingSegmentation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <executable>
-  <category>Segmentation</category>
+  <category>Legacy.Segmentation</category>
   <title>Simple Region Growing Segmentation</title>
   <description><![CDATA[A simple region growing segmentation algorithm based on intensity statistics. To create a list of fiducials (Seeds) for this algorithm, click on the tool bar icon of an arrow pointing to a sphere fiducial to enter the 'place a new object mode' and then use the Markups module. This module uses the Slicer Command Line Interface (CLI) and the ITK filters CurvatureFlowImageFilter and ConfidenceConnectedImageFilter.]]></description>
   <version>0.1.0.$Revision$(alpha)</version>


### PR DESCRIPTION
While RobustStatisticsSegmenter and SimpleRegionGrowingSegmentation modules work quite nicely for easy segmentation tasks (segmenting single structure with good contrast compared to surrounding structures), they are much less versatile and convenient than current tools in the Segment Editor. Specifically, Grow from seeds effect allows segmenting multiple structures at once, it is fast and offers even quicker incremental updates, masking, live 3D preview, etc.

To make it more clear for users, that we recommend to use the Segment Editor, it makes sense to de-emphasize these old modules by showing them under Legacy category in the module tree.

See details in this discussion: https://github.com/Slicer/Slicer/pull/5971