### PR TITLE
BUG: Initialize sequence browser widget recording controls visibility

### DIFF
--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserPlayWidget.cxx
@@ -37,7 +37,7 @@ protected:
   qMRMLSequenceBrowserPlayWidget* const q_ptr;
 public:
   qMRMLSequenceBrowserPlayWidgetPrivate(qMRMLSequenceBrowserPlayWidget& object);
-  bool RecordingControlsVisible;
+  bool RecordingControlsVisible{ true };
   void init();
 
   vtkWeakPointer<vtkMRMLSequenceBrowserNode> SequenceBrowserNode;


### PR DESCRIPTION
The qMRMLSequenceBrowserPlayWidgetPrivate::RecordingControlsVisible variable was not initialized, causing initial visibility to be non-deterministic. Fixed by initializing to "true".