### PR TITLE
ENH: Update VTK9 from 9.0.20201111 to 9.1.20220125

### DIFF
--- a/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
+++ b/CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake
@@ -55,7 +55,7 @@ macro(SlicerMacroConfigureModuleCxxTestDriver)
     set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN "")
     set(CMAKE_TESTDRIVER_AFTER_TESTMAIN "")
 
-    set(EXTRA_INCLUDE "vtkWin32OutputWindow.h")
+    set(EXTRA_INCLUDE "vtkWin32OutputWindow.h\"\n\#include \"vtkVersionMacros.h")
 
     if(SLICER_TEST_DRIVER_WITH_VTK_ERROR_OUTPUT_CHECK)
       set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -157,8 +157,9 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     )
   list(APPEND EXTERNAL_PROJECT_OPTIONAL_VTK9_CMAKE_CACHE_ARGS
     -DVTK_BUILD_TESTING:STRING=OFF
-    -DVTK_MODULE_ENABLE_VTK_AcceleratorsVTKm:BOOL=OFF
+    -DVTK_MODULE_ENABLE_VTK_AcceleratorsVTKm:BOOL=NO
     -DCMAKE_INSTALL_LIBDIR:STRING=lib # Force value to prevent lib64 from being used on Linux
+    -DVTK_MODULE_ENABLE_VTK_GUISupportQtQuick:BOOL=NO
     # These options have been removed in VTK >= 8.90:
     # - BUILD_EXAMPLE
     # - BUILD_SHARED_LIBS
@@ -177,8 +178,8 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "98d686bb509f46543ebe04fdd5d120fdab87893b") # slicer-v9.0.20201111-733234c785-v3
-    set(vtk_egg_info_version "9.0.20201111")
+    set(_git_tag "c9cc3a5d9747891f6c4e8a498b0a33234d3fc4f8") # slicer-v9.1.20220125-efbe2afc2
+    set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
   endif()

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -178,7 +178,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "c9cc3a5d9747891f6c4e8a498b0a33234d3fc4f8") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "e0d1851e22db9ae1d39096464964e7f1fe333436") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
Addresses issue #5956 

### VTK Branches

Current:

* [Slicer/VTK@slicer-v9.1.20220125-efbe2afc2](https://github.com/Slicer/VTK/tree/slicer-v9.1.20220125-efbe2afc2) 

Previously associated with this pull request:

* [Slicer/VTK@slicer-v9.1.20211022-1172cdd2e](https://github.com/Slicer/VTK/tree/slicer-v9.1.20211022-1172cdd2e)

### Changes



* `CMake/SlicerMacroConfigureModuleCxxTestDriver.cmake:` Included `vtkVersionsMacro.h` header in the generated tests to correctly resolve the `VTK_MAJOR_VERSION` and `VTK_MINOR_VERSION` macros. Needs further investigation to determine why it was not required before.

### Related changes integrated in separate PRs 

* https://github.com/Slicer/Slicer/pull/6059

  * `Libs/MRML/Core/vtkArchive.cxx`: Earlier, call to `vtksys::SystemTools::ChangeDirectory()` returned `int(0)` for success, same as the system call `chdir()`. New changes to VTK now return a `vtkSys::Status` object. This requires a check through a call to `status.IsSuccess()` member function.

  * `Libs/MRML/Core/vtkCacheManager.cxx`, `Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx`: Functions of `vtksys::SystemTools` now return a `vtksys::Status` object in place of bool or int. This requires a call to `.IsSuccess()` for correctly resolving condition predicates.

### Testing results

#### 2022.01.27: :hourglass: build in progress

See https://slicer.cdash.org/index.php?project=SlicerPreview&date=2022-01-27&filtercount=2&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Experimental&field2=site&compare2=63&value2=kitware

#### 2021.11.01

<details>
<summary>11 test cases are currently failing (3 new, 8 pre-existing failures) in release build.</summary>

```
---Failing new tests---
165 - vtkMRMLThreeDViewDisplayableManagerFactoryTest1 (Failed)
318 - py_SubjectHierarchyGenericSelfTest (Failed)
379 - py_MarkupsMeasurementsTest (Failed)
```

Logs:
* [Slicer_Release_Failing_New_Tests_11_01_2021.txt](https://github.com/Slicer/Slicer/files/7456254/Slicer_Release_Failing_New_Tests_11_01_2021.txt)
* [verbose_output.log](https://github.com/Slicer/Slicer/files/7456340/verbose_output.log)

</details>

### Notes

* Currently only updating VTK external project. We will have to asses with 

