### PR TITLE
COMP: Fix macOS build error updating SlicerSurfaceToolbox

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -362,7 +362,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
   # When updating the GIT_TAG, consider updating documentation in Docs/user_guide (see https://github.com/Slicer/Slicer/issues/5669)
-  GIT_TAG 8dd9ce0532dcb5e5c5f50d095bd15954192d02cb
+  GIT_TAG df684ae1ac9f446ef1f863814bf7dd0ce40b3daf
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
This commit fixes a regression introduced in a15cbacbb9 (ENH: Add "Select
by points" tool to Dynamic Modeler module)

List of SlicerSurfaceToolbox changes:

```
$ git shortlog 8dd9ce053..df684ae --no-merges
Jean-Christophe Fillion-Robin (20):
      COMP: Simplify setting of position independent flag for MeshGeodesics target
      COMP: Fix -Wunknown-pragmas in DynamicModeler/Logic/FastMarching
      COMP: Fix -Wunused-parameter in DynamicModeler/Logic/FastMarching
      COMP: Fix -Wreorder in DynamicModeler/Logic/FastMarching
      BUG: Fix GW_Face::GetEdgeNumber to return -1 if edge is not found
      COMP: Fix -Wunused-variable in GW_Mesh::BuildCurvatureData
      COMP: Fix -Wsign-compare in GW_VectorStatic.h
      COMP: Fix -Woverloaded-virtual in DynamicModeler/Logic/FastMarching
      COMP: Fix -Wdelete-non-virtual-dtor in GW_GeodesicFace.inl
      COMP: Fix -Wunused-variable in GW_GeodesicPath
      COMP: Fix -Wunused-local-typedefs in vtkFastMarchingGeodesicDistance
      COMP: Fix -Wunused-variable in GW_TriangularInterpolation_(Cubic|Quadratic)
      COMP: Fix -Wformat-security in GW_OutputStream
      COMP: Fix DynamicModeler/Logic/FastMarching build error on macOS
      COMP: Fix -Winconsistent-missing-override in DynamicModeler/Logic/FastMarching
      BUG: Fix -Woverloaded-virtual in DynamicModeler/Logic/FastMarching/gw_geodesic/GW_GeodesicMesh.h
      BUG: Fix -Wparentheses in GW_GeodesicPath::AddNewPoint()
      COMP: Fix -Wsign-compare in vtkFastMarchingGeodesicDistance::SetupCallbacks()
      Revert "BUG: Fix GW_Face::GetEdgeNumber to return -1 if edge is not found"
      ENH: Re-add GW_GeodesicMesh::GetRandomVertex(GW_Bool bForceFar) for debugging
```