### PR TITLE
COMP: Update Markups module and SurfaceToolbox project to support VTK8 build

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkProjectMarkupsCurvePointsFilter.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkProjectMarkupsCurvePointsFilter.cxx
@@ -23,6 +23,7 @@
 
 #include <vtkBoundingBox.h>
 #include <vtkDoubleArray.h>
+#include <vtkGenericCell.h>
 #include <vtkGeneralTransform.h>
 #include <vtkInformationVector.h>
 #include <vtkMathUtilities.h>

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -362,7 +362,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
   # When updating the GIT_TAG, consider updating documentation in Docs/user_guide (see https://github.com/Slicer/Slicer/issues/5669)
-  GIT_TAG df684ae1ac9f446ef1f863814bf7dd0ce40b3daf
+  GIT_TAG c7cf164eed8725626b088f7f36b6ea4ad51ad7b0
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
List of SlicerSurfaceToolbox changes:

```
$ git shortlog df684ae..c7cf164 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Update DynamicModeler/Logic/FastMarching to support VTK8
```

This commit fixes the following errors:

```
  /path/to/S-r/VTK/Common/Core/vtkNew.h:62:21: error: incomplete type 'vtkGenericCell' named in nested name specifier
    vtkNew() : Object(T::New())
                      ^~~
  /path/to/S/Modules/Loadable/Markups/MRML/vtkProjectMarkupsCurvePointsFilter.cxx:186:29: note: in instantiation of member function 'vtkNew<vtkGenericCell>::vtkNew' requested
        here
      vtkNew <vtkGenericCell> cell;
                              ^

  /path/to/S-r/SurfaceToolbox/DynamicModeler/Logic/FastMarching/vtkPolygonalSurfaceContourLineInterpolator2.cxx:148:11: error: no member named 'SetInput' in
        'vtkDijkstraGraphGeodesicPath'
      dggp->SetInput( nodeBegin->PolyData );
      ~~~~  ^

  /path/to/S-r/SurfaceToolbox/DynamicModeler/Logic/FastMarching/vtkPolygonalSurfaceContourLineInterpolator2.cxx:162:11: error: no member named 'SetInput' in
        'vtkFastMarchingGeodesicPath'
      fmgp->SetInput( nodeBegin->PolyData );
      ~~~~  ^

  /path/to/S-r/SurfaceToolbox/DynamicModeler/Logic/FastMarching/vtkPolygonalSurfaceContourLineInterpolator2.cxx:199:19: error: no matching member function for call to
        'GetNextCell'
    pd->GetLines()->GetNextCell( npts, pts);
    ~~~~~~~~~~~~~~~~^~~~~~~~~~~
```

See #5974