### PR TITLE
COMP: Fix QList::to/fromSet deprecation warnings

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.txx
+++ b/Base/QTApp/qSlicerApplicationHelper.txx
@@ -36,6 +36,7 @@
 #ifdef Slicer_USE_PYTHONQT
 # include <ctkPythonConsole.h>
 #endif
+#include <ctkUtils.h>
 
 #ifdef Slicer_BUILD_CLI_SUPPORT
 # include "qSlicerCLIExecutableModuleFactory.h"
@@ -166,8 +167,8 @@ int qSlicerApplicationHelper::postInitializeApplication(
              << moduleFactoryManager->instantiatedModuleNames().count();
     }
 
-  QStringList failedToBeInstantiatedModuleNames = QStringList::fromSet(
-        moduleFactoryManager->registeredModuleNames().toSet() - moduleFactoryManager->instantiatedModuleNames().toSet());
+  QStringList failedToBeInstantiatedModuleNames = ctk::qSetToQStringList(
+        ctk::qStringListToQSet(moduleFactoryManager->registeredModuleNames()) - ctk::qStringListToQSet(moduleFactoryManager->instantiatedModuleNames()));
   if (!failedToBeInstantiatedModuleNames.isEmpty())
     {
     qCritical() << "The following modules failed to be instantiated:";

--- a/Modules/Loadable/Data/qSlicerSceneReader.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneReader.cxx
@@ -33,6 +33,9 @@
 #include <vtkMRMLMessageCollection.h>
 #include <vtkMRMLScene.h>
 
+// CTK includes
+#include <ctkUtils.h>
+
 // Slicer includes
 #include "qSlicerCoreApplication.h"
 #include "qSlicerCoreIOManager.h"
@@ -159,13 +162,13 @@ bool qSlicerSceneReader::load(const qSlicerIO::IOProperties& properties)
       {
       QStringList extensionsList = QString::fromStdString(extensions).split(";");
       QStringList lastLoadedExtensionsList = QString::fromStdString(lastLoadedExtensions).split(";");
-      QSet<QString> notInstalledExtensions = lastLoadedExtensionsList.toSet().subtract(extensionsList.toSet());
+      QSet<QString> notInstalledExtensions = ctk::qStringListToQSet(lastLoadedExtensionsList).subtract(ctk::qStringListToQSet(extensionsList));
       if (!notInstalledExtensions.isEmpty())
         {
         QString extensionsInformation =
           tr("These extensions were installed when the scene was saved but not installed now: %1."
              " These extensions may be required for successful loading of the scene.")
-          .arg(QStringList::fromSet(notInstalledExtensions).join(", "));
+          .arg(ctk::qSetToQStringList(notInstalledExtensions).join(", "));
         this->userMessages()->AddMessage(vtkCommand::MessageEvent, extensionsInformation.toStdString());
         }
       }


### PR DESCRIPTION
This commit fixes warning like the following reported when
building against Qt >= 5.14.

* `fromSet` deprecation warning:

```
  /path/to/S/Base/QTApp/qSlicerApplicationHelper.txx:169:64: warning: 'fromSet' is deprecated: Use QList<T>(set.begin(), set.end()) instead. [-Wdeprecated-declarations]
    QStringList failedToBeInstantiatedModuleNames = QStringList::fromSet(
                                                                 ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qlist.h:410:5: note: 'fromSet' has been explicitly marked deprecated here
      QT_DEPRECATED_VERSION_X_5_14("Use QList<T>(set.begin(), set.end()) instead.")
      ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:366:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_5_14'
  # define QT_DEPRECATED_VERSION_X_5_14(text) QT_DEPRECATED_X(text)
                                              ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
  #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                  ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
  #    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                        ^
```

* `toSet` deprecation warning:

```
  /path/to/S/Base/QTApp/qSlicerApplicationHelper.txx:170:55: warning: 'toSet' is deprecated: Use QSet<T>(list.begin(), list.end()) instead. [-Wdeprecated-declarations]
          moduleFactoryManager->registeredModuleNames().toSet() - moduleFactoryManager->instantiatedModuleNames().toSet());
                                                        ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qlist.h:412:5: note: 'toSet' has been explicitly marked deprecated here
      QT_DEPRECATED_VERSION_X_5_14("Use QSet<T>(list.begin(), list.end()) instead.")
      ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:366:45: note: expanded from macro 'QT_DEPRECATED_VERSION_X_5_14'
  # define QT_DEPRECATED_VERSION_X_5_14(text) QT_DEPRECATED_X(text)
                                              ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
  #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                  ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
  #    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
                                                        ^
```