### PR TITLE
COMP: Fix CMake CMP0115 warning specifying extensions with "add_executable"

### DIFF
--- a/Base/QTCore/Testing/Cxx/CMakeLists.txt
+++ b/Base/QTCore/Testing/Cxx/CMakeLists.txt
@@ -55,7 +55,7 @@ if(BUILD_TESTING)
   set(CMAKE_TESTDRIVER_BEFORE_TESTMAIN "DEBUG_LEAKS_ENABLE_EXIT_ERROR();" )
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
   set(KIT_TEST_SRCS
-    qSlicerAbstractCoreModuleTest1
+    qSlicerAbstractCoreModuleTest1.cxx
     qSlicerCoreApplicationTest1.cxx
     qSlicerCoreIOManagerTest1.cxx
     qSlicerLoadableModuleFactoryTest1.cxx

--- a/Modules/Loadable/Data/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Data/Testing/Cxx/CMakeLists.txt
@@ -5,7 +5,7 @@ set(MODEL_FILE "${MRMLCore_SOURCE_DIR}/Testing/TestData/cube.vtk")
 
 #-----------------------------------------------------------------------------
 set(KIT_TEST_SRCS
-  vtkSlicerDataLogicAutoRemoveTest
+  vtkSlicerDataLogicAutoRemoveTest.cxx
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Models/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Models/Testing/Cxx/CMakeLists.txt
@@ -6,10 +6,10 @@ set(MODEL_SCENE "${MRMLCore_SOURCE_DIR}/Testing/modelHierarchy.mrml")
 
 #-----------------------------------------------------------------------------
 set(KIT_TEST_SRCS
-  qSlicerModelsModuleWidgetTest
-  qSlicerModelsModuleWidgetTest1
-  qSlicerModelsModuleWidgetTestScene
-  vtkSlicerModelsLogicAddFileTest
+  qSlicerModelsModuleWidgetTest.cxx
+  qSlicerModelsModuleWidgetTest1.cxx
+  qSlicerModelsModuleWidgetTestScene.cxx
+  vtkSlicerModelsLogicAddFileTest.cxx
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes warning like the following:

```
  CMake Warning (dev) at /path/to/S-r/CTK/CMake/ctkFunctionAddExecutableUtf8.cmake:18 (add_executable):
    Policy CMP0115 is not set: Source file extensions must be explicit.  Run
    "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
    command to set the policy and suppress this warning.

    File:

      /path/to/S/Base/QTCore/Testing/Cxx/qSlicerAbstractCoreModuleTest1.cxx
  Call Stack (most recent call first):
    Base/QTCore/Testing/Cxx/CMakeLists.txt:114 (ctk_add_executable_utf8)
```