### PR TITLE
ENH: Update CTK to fix python autocomplete and add DICOM browser select API

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -75,7 +75,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ec9fcee532fd9cdff74f96479197f626d8c71fe5"
+    "19c36e250e5dc31c67a053f8bcba23e3d4ded67a"
     QUIET
     )
 


### PR DESCRIPTION

Summary:
* Fix python autocomplete
* Add DICOM browser select API
* Fix misc build warnings
* Add ctk::qStringListToQSet and ctk::qSetToQStringList


List of changes:

```
$ git shortlog ec9fcee532..19c36e25 --no-merges
Andras Lasso (3):
      BUG: Fix autocomplete in Python console
      ENH: Improve Python autocomplete list ordering
      ENH: Add API to select items in the DICOM browser

Jean-Christophe Fillion-Robin (7):
      COMP: Fix -Wreorder in ctkDICOMDatabasePrivate class
      COMP: Fix -Wunused-parameter in ctkDICOMDisplayedFieldGenerator classes
      COMP: Fix -Wsign-compare and -Wunused-variable in ctkDICOMItem class
      COMP: Fix -Wdeprecated-declarations related to Qt::KeyboardModifiers
      COMP: Fix -Winconsistent-missing-override in ctkCheckablePushButton
      ENH: Add ctk::qStringListToQSet
      ENH: Add ctk::qSetToQStringList
```