### PR TITLE
COMP: Update to fix both endl and CMake qt5_*_moc deprecation warnings

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -75,7 +75,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "19c36e250e5dc31c67a053f8bcba23e3d4ded67a"
+    "03575a0325992e10958a74fbe05ee313e58eadce"
     QUIET
     )
 


### PR DESCRIPTION
This commit also fixes the build by ensuring the`ctk::endl` function
required by previous commit da61c65a59 (`COMP: Fix endl deprecation warning
in qMRMLLabelComboBox`) is available.

List of CTK changes:

```
$ git shortlog 19c36e250..03575a03 --no-merges
Jean-Christophe Fillion-Robin (4):
      COMP: Consistently export global and namespace symbols
      ENH: Add ctk::flush and ctk::endl to fix deprecation warnings with Qt >= 5.14
      COMP: Fix endl deprecation warning using ctk::end
      COMP: Fix qt5_get_moc_flags/qt5_create_moc_command deprecation CMake warnings
```