### PR TITLE
COMP: Update CTK to fix deprecation warnings

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -75,7 +75,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "03575a0325992e10958a74fbe05ee313e58eadce"
+    "27f89406aa8aa4fd490605aab3c9ca6c186422b5"
     QUIET
     )
 


### PR DESCRIPTION
List of changes:

```
$ git shortlog 03575a032..27f89406 --no-merges
Jean-Christophe Fillion-Robin (5):
      COMP: Fix QFlags deprecation warnings related to Qt::ColorDialogOptions
      COMP: Fix QAtomicInt::load() deprecation warning in ctkErrorLogQtMessageHandler
      COMP: Fix QTime::start(), QTime::elasped() deprecation warnings
      COMP: Fix QFlags deprecation warnings related to ctkColorPickerButton::ColorDialogOptions
      COMP: Fix QPixmapCache::find deprecation warnings in ctkPixmapIconEngine
```