### PR TITLE
ENH: Remove Edit Box action

### DIFF
--- a/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
+++ b/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
@@ -485,17 +485,6 @@
     <string>Ctrl+Y</string>
    </property>
   </action>
-  <action name="EditEditBoxAction">
-   <property name="text">
-    <string>Edit Box</string>
-   </property>
-   <property name="toolTip">
-    <string>Raise the Edit-box, a lightweight image editing tool.</string>
-   </property>
-   <property name="shortcut">
-    <string>Space</string>
-   </property>
-  </action>
   <action name="EditNewFiducialListAction">
    <property name="text">
     <string>New Fiducial List</string>


### PR DESCRIPTION
The Edit Box class was removed when the legacy "Editor" module was removed from Slicer in https://github.com/Slicer/Slicer/commit/39283db420baf502fa99865c9d5d58d0e5295a6e.

The Edit Box action was visible in Help->Keyboard Shortcuts and is now removed with this PR.

![image](https://user-images.githubusercontent.com/15837524/140789876-6f465167-28c2-433e-8332-b5d2bc4aa8d3.png)
