### PR TITLE
ENH: Disable prompt for non-existing git repos

### DIFF
--- a/Extensions/CMake/Testing/CMakeLists.txt
+++ b/Extensions/CMake/Testing/CMakeLists.txt
@@ -53,7 +53,7 @@ function(add_slicer_extensions_index_test testname)
     NAME py_${prefix}${testname}
     # Test assume the CMake based midas client is used.
     # See Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake
-    COMMAND ${CMAKE_COMMAND} -E env --unset=SLICER_EXTENSION_MANAGER_SKIP_MIDAS_UPLOAD
+    COMMAND ${CMAKE_COMMAND} -E env GIT_TERMINAL_PROMPT=0  --unset=SLICER_EXTENSION_MANAGER_SKIP_MIDAS_UPLOAD
       ${PYTHON_EXECUTABLE} -c "${code}" ${CMAKE_CFG_INTDIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )


### PR DESCRIPTION
By default, non-existing github repositories using https will prompt for authentication under https (e.g., `Username for 'https://github.com':`). Some of the underlying extension tests rely on testing non-existing repositories, which trigger authentication prompts.

This disables the authentication prompts by setting the
`GIT_TERMINAL_PROMPT` variable to `0` during testing of relevant tests.

The authentication prompt triggered on the following tests:
  - Test   7: py_cmake_slicer_extensions_index_build_without_upload
  - Test   8: py_cmake_slicer_extensions_index_build_with_upload
  - Test   9: py_cmake_slicer_extensions_index_build_with_upload_using_ctest
  - Test  10: py_cmake_slicer_extensions_index_build_without_upload_using_ctest
