### PR TITLE
COMP: Attempt to fix launching of designer in macOS package

### DIFF
--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -386,7 +386,7 @@ function(fixup_bundle_with_plugins app)
      endforeach()
      # Update executable
      execute_process(COMMAND install_name_tool
-       -rpath "@executable_path/Frameworks" "@loader_path/../../../../"
+       -rpath "@executable_path/../Frameworks" "@loader_path/../../../../"
        ${changes} "${designer_executable}"
        )
      # Generate qt.conf file to override plugin paths and ensure plugins provided


### PR DESCRIPTION
After inspecting the history of Slicer/DashboardScripts project (see [1]),
the regression was likely introduced when transitioning from Qt 5.10 to
5.15.0 in June 2020.

[1] https://github.com/Slicer/DashboardScripts/commits/master/factory-south-macos-slicer_preview_nightly.cmake

Issue was identified following this process:

(1) Copy relevant code from the configured "SlicerCPackBundleFixup.cmake"
    into a CMake script where calls to "file(COPY ..." and "execute_process"
    were changed to be no-op by using "message()" statements.

(2) Copy first command into a bash script and attempt to execute in a
    standalone way.


Doing so led to the following command and error message:

```
install_name_tool \
  -rpath "@executable_path/Frameworks" "@loader_path/../../../../" \
  -change \
    /Volumes/D/Support/qt-everywhere-build-5.15.2/lib/QtCore.framework/Versions/5/QtCore \
    @rpath/Frameworks/QtCore.framework/Versions/5/QtCore \
  -change \
    /Volumes/D/Support/qt-everywhere-build-5.15.2/lib/QtDesigner.framework/Versions/5/QtDesigner \
    @rpath/Frameworks/QtDesigner.framework/Versions/5/QtDesigner \
  -change \
    /Volumes/D/Support/qt-everywhere-build-5.15.2/lib/QtDesignerComponents.framework/Versions/5/QtDesignerComponents \
    @rpath/Frameworks/QtDesignerComponents.framework/Versions/5/QtDesignerComponents \
  -change \
    /Volumes/D/Support/qt-everywhere-build-5.15.2/lib/QtGui.framework/Versions/5/QtGui \
    @rpath/Frameworks/QtGui.framework/Versions/5/QtGui \
  -change \
    /Volumes/D/Support/qt-everywhere-build-5.15.2/lib/QtNetwork.framework/Versions/5/QtNetwork \
    @rpath/Frameworks/QtNetwork.framework/Versions/5/QtNetwork \
  -change \
    /Volumes/D/Support/qt-everywhere-build-5.15.2/lib/QtPrintSupport.framework/Versions/5/QtPrintSupport \
    @rpath/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport \
  -change \
    /Volumes/D/Support/qt-everywhere-build-5.15.2/lib/QtWidgets.framework/Versions/5/QtWidgets \
    @rpath/Frameworks/QtWidgets.framework/Versions/5/QtWidgets \
  -change \
    /Volumes/D/Support/qt-everywhere-build-5.15.2/lib/QtXml.framework/Versions/5/QtXml \
    @rpath/Frameworks/QtXml.framework/Versions/5/QtXml \
  "/Volumes/D/P/S-0-build/Slicer-build/_CPack_Packages/macosx-amd64/DragNDrop/Slicer-4.13.0-2021-11-09-macosx-amd64/Slicer.app//Contents/bin/Designer.app/Contents/MacOS/Designer"
```

```
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: no LC_RPATH load command with path: @executable_path/Frameworks found in: /Volumes/D/P/S-0-build/Slicer-build/_CPack_Packages/macosx-amd64/DragNDrop/Slicer-4.13.0-2021-11-09-macosx-amd64/Slicer.app//Contents/bin/Designer.app/Contents/MacOS/Designer (for architecture x86_64), required for specified option "-rpath @executable_path/Frameworks @loader_path/../../../../"
```

Then, running the following command allowed to identify what should be the
correct rpath to  be updated:

```
otool -l /Volumes/D/P/S-0-build/Slicer-build/_CPack_Packages/macosx-amd64/DragNDrop/Slicer-4.13.0-2021-11-09-macosx-amd64/Slicer.app//Contents/bin/Designer.app/Contents/MacOS/Designer | grep -A 3 LC_RPATH
          cmd LC_RPATH
      cmdsize 48
         path @executable_path/../Frameworks (offset 12)
Load command 29

```

See #4700