### PR TITLE
DOC: Update build instructions with references to VS2022

### DIFF
--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -24,7 +24,7 @@ code of slicer, generating the project files and build the project.
 In addition, Slicer requires a set of support libraries that are not includes as
 part of the *superbuild*:
 
-- Qt5 with the components listed below. Qt version 5.15.1 is recommended, other Qt versions are not tested and may cause build errors or may cause problems when running the application.
+- Qt5 with the components listed below. Qt version 5.15.2 is recommended, other Qt versions are not tested and may cause build errors or may cause problems when running the application.
   - Multimedia
   - UiTools
   - XMLPatterns

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -7,7 +7,7 @@
   - Note: CMake must be able to find `git.exe` and `patch.exe`. If git is installed in the default location then they may be found there, but if they are not found then either add the folder that contains them to `PATH` environment variable; or set `GIT_EXECUTABLE` and `Patch_EXECUTABLE` as environment variables or as CMake variables at configure time.
 - [Visual Studio](https://visualstudio.microsoft.com/downloads/)
   - any edition can be used (including the free Community edition)
-  - when configuring the installer, enable `Desktop development with C++` and in installation details, check `MSVC v142 - VS2019 C++ x64...` (Visual Studio 2019 v142 toolset with 64-bit support) - in some distributions, this option is not enabled by default
+  - when configuring the installer, enable `Desktop development with C++` and in installation details, check `MSVC v143 - VS2022 C++ x64...` (Visual Studio 2022 v143 toolset with 64-bit support) - in some distributions, this option is not enabled by default
 - [Qt5](https://www.qt.io/download-open-source): Download Qt universal installer and install Qt 5.15.1 components: `MSVC2019 64-bit`, `Qt Script`, `Qt WebEngine`. Installing Sources and Qt Debug Information Files are recommended for debugging (they allow stepping into Qt files with the debugger in debug-mode builds).
   - Note: These are all free, open-source components with LGPL license which allow free usage for any purpose, for any individuals or companies.
 - [NSIS](http://nsis.sourceforge.net/Download) (optional): Needed if packaging Slicer. Make sure you install the language packs.
@@ -16,6 +16,7 @@
 
 **Other compiler versions**
 
+- Visual Studio 2019 (v142) toolset is not tested anymore but probably still works.
 - Visual Studio 2017 (v141) toolset is not tested anymore but probably still works. Qt-5.15.1 requires v142 redistributables, so either these extra DLL files need to be added to the installation package or each user may need to install "Microsoft Visual C++ Redistributable" package.
 - Visual Studio 2015 (v140) toolset is not tested anymore and probably does not work. Requires Qt 5.10.x to build due to QtWebEngine.
 - Cygwin: not tested and not recommended. Building with cygwin gcc not supported, but the cygwin shell environment can be used to run git, svn, etc.
@@ -47,7 +48,7 @@ Release mode:
 ```
 mkdir C:\D\S4R
 cd /d C:\D\S4R
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.1\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 17 2022" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.1\msvc2019_64\lib\cmake\Qt5 C:\D\S4
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Release
 ```
 
@@ -56,7 +57,7 @@ Debug mode:
 ```
 mkdir C:\D\S4D
 cd /d C:\D\S4D
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.1\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 17 2022" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.1\msvc2019_64\lib\cmake\Qt5 C:\D\S4
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Debug
 ```
 
@@ -67,7 +68,7 @@ cd /d C:\D\S4D
 - Set `Where to build the binaries` to `<Slicer_BUILD>` location. Do not configure yet!
 - Add `Qt5_DIR` variable pointing to Qt5 folder: click Add entry button, set `Name` to `Qt5_DIR`, set `Type` to `PATH`, and set `Value` to the Qt5 folder, such as `C:\Qt\5.15.1\msvc2019_64\lib\cmake\Qt5`.
 - Click `Configure`
-- Select your compiler: `Visual Studio 16 2019`, and click `Finish`
+- Select your compiler: `Visual Studio 17 2022`, and click `Finish`
 - Click `Generate` and wait for project generation to finish (may take a few minues)
 - Click `Open Project`
 - If building in release mode:

--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -8,7 +8,7 @@
 - [Visual Studio](https://visualstudio.microsoft.com/downloads/)
   - any edition can be used (including the free Community edition)
   - when configuring the installer, enable `Desktop development with C++` and in installation details, check `MSVC v143 - VS2022 C++ x64...` (Visual Studio 2022 v143 toolset with 64-bit support) - in some distributions, this option is not enabled by default
-- [Qt5](https://www.qt.io/download-open-source): Download Qt universal installer and install Qt 5.15.1 components: `MSVC2019 64-bit`, `Qt Script`, `Qt WebEngine`. Installing Sources and Qt Debug Information Files are recommended for debugging (they allow stepping into Qt files with the debugger in debug-mode builds).
+- [Qt5](https://www.qt.io/download-open-source): Download Qt universal installer and install Qt 5.15.2 components: `MSVC2019 64-bit`, `Qt Script`, `Qt WebEngine`. Installing Sources and Qt Debug Information Files are recommended for debugging (they allow stepping into Qt files with the debugger in debug-mode builds).
   - Note: These are all free, open-source components with LGPL license which allow free usage for any purpose, for any individuals or companies.
 - [NSIS](http://nsis.sourceforge.net/Download) (optional): Needed if packaging Slicer. Make sure you install the language packs.
 
@@ -17,7 +17,7 @@
 **Other compiler versions**
 
 - Visual Studio 2019 (v142) toolset is not tested anymore but probably still works.
-- Visual Studio 2017 (v141) toolset is not tested anymore but probably still works. Qt-5.15.1 requires v142 redistributables, so either these extra DLL files need to be added to the installation package or each user may need to install "Microsoft Visual C++ Redistributable" package.
+- Visual Studio 2017 (v141) toolset is not tested anymore but probably still works. Qt-5.15.2 requires v142 redistributables, so either these extra DLL files need to be added to the installation package or each user may need to install "Microsoft Visual C++ Redistributable" package.
 - Visual Studio 2015 (v140) toolset is not tested anymore and probably does not work. Requires Qt 5.10.x to build due to QtWebEngine.
 - Cygwin: not tested and not recommended. Building with cygwin gcc not supported, but the cygwin shell environment can be used to run git, svn, etc.
 
@@ -48,7 +48,7 @@ Release mode:
 ```
 mkdir C:\D\S4R
 cd /d C:\D\S4R
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 17 2022" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.1\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 17 2022" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Release
 ```
 
@@ -57,7 +57,7 @@ Debug mode:
 ```
 mkdir C:\D\S4D
 cd /d C:\D\S4D
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 17 2022" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.1\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 17 2022" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Debug
 ```
 
@@ -66,7 +66,7 @@ cd /d C:\D\S4D
 - Run `CMake (cmake-gui)` from the Windows Start menu
 - Set `Where is the source code` to `<Slicer_SOURCE>` location
 - Set `Where to build the binaries` to `<Slicer_BUILD>` location. Do not configure yet!
-- Add `Qt5_DIR` variable pointing to Qt5 folder: click Add entry button, set `Name` to `Qt5_DIR`, set `Type` to `PATH`, and set `Value` to the Qt5 folder, such as `C:\Qt\5.15.1\msvc2019_64\lib\cmake\Qt5`.
+- Add `Qt5_DIR` variable pointing to Qt5 folder: click Add entry button, set `Name` to `Qt5_DIR`, set `Type` to `PATH`, and set `Value` to the Qt5 folder, such as `C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5`.
 - Click `Configure`
 - Select your compiler: `Visual Studio 17 2022`, and click `Finish`
 - Click `Generate` and wait for project generation to finish (may take a few minues)

--- a/SuperBuild/External_OpenSSL.cmake
+++ b/SuperBuild/External_OpenSSL.cmake
@@ -245,7 +245,7 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
       # VS2013
       set(OpenSSL_1.0.1h_1800_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1800-32.tar.gz)
       set(OpenSSL_1.0.1h_1800_MD5 f10ceb422ab37f2b0bd5e225c74fd1d4)
-      # VS2015, VS2017 and VS2019
+      # VS2015, VS2017, VS2019 and VS2022
       if(${MSVC_VERSION} VERSION_GREATER_EQUAL 1900)
         set(OpenSSL_1.0.1h_${MSVC_VERSION}_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-32.tar.gz)
         set(OpenSSL_1.0.1h_${MSVC_VERSION}_MD5 e0e26ae6ac5693d266c804e738d7aa14)
@@ -263,7 +263,7 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
     elseif(CMAKE_SIZEOF_VOID_P EQUAL 8) # 64-bit
 
       # OpenSSL 1.1.1g
-      # VS2015, VS2017 and VS2019
+      # VS2015, VS2017, VS2019 and VS2022
       if(${MSVC_VERSION} VERSION_GREATER_EQUAL 1900)
         set(OpenSSL_1.1.1g_${MSVC_VERSION}_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.1.1g/OpenSSL_1_1_1g-install-msvc1900-64.tar.gz)
         set(OpenSSL_1.1.1g_${MSVC_VERSION}_MD5 f89ea6a4fcfb279af30cbe01c1d7f879)
@@ -279,7 +279,7 @@ this version of visual studio [${MSVC_VERSION}]. You could either:
       # VS2013
       set(OpenSSL_1.0.1h_1800_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1800-64.tar.gz)
       set(OpenSSL_1.0.1h_1800_MD5 7aefdd94babefbe603cca48ff86da768)
-      # VS2015, VS2017 and VS2019
+      # VS2015, VS2017, VS2019 and VS2022
       if(${MSVC_VERSION} VERSION_GREATER_EQUAL 1900)
         set(OpenSSL_1.0.1h_${MSVC_VERSION}_URL https://github.com/Slicer/Slicer-OpenSSL/releases/download/1.0.1h/OpenSSL_1_0_1h-install-msvc1900-64.tar.gz)
         set(OpenSSL_1.0.1h_${MSVC_VERSION}_MD5 f93d266def384926015550452573e824)


### PR DESCRIPTION
This updates the Windows build instructions with instructions on how to use Visual Studio 2022. This new version has been released and is the primary download available at https://visualstudio.microsoft.com/downloads/ so people building Slicer for the first time will now be downloading this version. I have tested and Slicer builds successfully with Visual Studio 2022 and using the latest v143 toolset. Visual Studio 2022's biggest change is itself is now a 64-bit application.

I've also included another commit to recommend the usage of Qt 5.15.2 instead of 5.15.1.