### PR TITLE
COMP: Update CTK to fix QModelIndex::child() deprecation warnings

### DIFF
--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
@@ -29,6 +29,7 @@
 
 // CTK includes
 #include <ctkComboBox.h>
+#include <ctkUtils.h>
 
 // MRMLWidgets includes
 #include "qMRMLNodeComboBoxDelegate.h"
@@ -853,7 +854,7 @@ void qMRMLNodeComboBox::setCurrentNodeID(const QString& nodeID)
     // it (in popup()), however we want the view to be always synchronized
     // with the currentIndex as we use it to know if it has changed. This is
     // why we set it here.
-    QModelIndex noneIndex = sceneIndex.child(0, d->ComboBox->modelColumn());
+    QModelIndex noneIndex = ctk::modelChildIndex(d->ComboBox->model(), sceneIndex, 0, d->ComboBox->modelColumn());
     d->ComboBox->view()->setCurrentIndex(
       d->NoneEnabled ? noneIndex : sceneIndex);
     d->ComboBox->setCurrentIndex(d->NoneEnabled ? 0 : -1);

--- a/Libs/MRML/Widgets/qMRMLSceneCategoryModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneCategoryModel.cxx
@@ -20,6 +20,9 @@
 
 // Qt includes
 
+// CTK includes
+#include <ctkUtils.h>
+
 // qMRML includes
 #include "qMRMLSceneCategoryModel.h"
 #include "qMRMLSceneModel_p.h"
@@ -85,7 +88,7 @@ QStandardItem* qMRMLSceneCategoryModel::itemFromCategory(const QString& category
 //------------------------------------------------------------------------------
 int qMRMLSceneCategoryModel::categoryCount()const
 {
-  return this->match(this->mrmlSceneIndex().child(0,0),
+  return this->match(ctk::modelChildIndex(const_cast<qMRMLSceneCategoryModel*>(this), this->mrmlSceneIndex(), 0, 0),
                      qMRMLSceneModel::UIDRole,
                      QString("category"),
                      -1,

--- a/Libs/MRML/Widgets/qMRMLSceneModel.cxx
+++ b/Libs/MRML/Widgets/qMRMLSceneModel.cxx
@@ -22,6 +22,9 @@
 #include <QDebug>
 #include <QTimer>
 
+// CTK includes
+#include <ctkUtils.h>
+
 // qMRML includes
 #include "qMRMLSceneModel_p.h"
 
@@ -125,7 +128,7 @@ void qMRMLSceneModelPrivate::listenNodeModifiedEvent()
   const int count = q->rowCount(sceneIndex);
   for (int i = 0; i < count; ++i)
     {
-    vtkMRMLNode* node = q->mrmlNodeFromIndex(sceneIndex.child(i,0));
+    vtkMRMLNode* node = q->mrmlNodeFromIndex(ctk::modelChildIndex(q, sceneIndex, i, 0));
     q->qvtkDisconnect(node, vtkCommand::NoEvent, q, nullptr);
     if (this->ListenNodeModifiedEvent == qMRMLSceneModel::AllNodes)
       {
@@ -217,7 +220,7 @@ void qMRMLSceneModelPrivate::removeAllExtraItems(QStandardItem* parent, const QS
     {
     return;
     }
-  QModelIndex start = parent ? parent->index().child(0,0) : QModelIndex().child(0,0);
+  QModelIndex start = parent ? ctk::modelChildIndex(q, parent->index(), 0, 0) : ctk::modelChildIndex(q, QModelIndex(), 0, 0);
   QModelIndexList indexes =
     q->match(start, qMRMLSceneModel::UIDRole, extraType, 1, Qt::MatchExactly);
   while (start != QModelIndex() && indexes.size())
@@ -226,7 +229,7 @@ void qMRMLSceneModelPrivate::removeAllExtraItems(QStandardItem* parent, const QS
     int row = indexes[0].row();
     q->removeRow(row, parentIndex);
     // don't start the whole search from scratch, only from where we ended it
-    start = parentIndex.child(row,0);
+    start = ctk::modelChildIndex(q, parentIndex, row, 0);
     indexes = q->match(start, qMRMLSceneModel::UIDRole, extraType, 1, Qt::MatchExactly);
     }
   extraItems[extraType] = QStringList();
@@ -491,7 +494,7 @@ QModelIndex qMRMLSceneModel::indexFromNode(vtkMRMLNode* node, int column)const
   const int row = nodeIndex.row();
   QModelIndex nodeParentIndex = nodeIndex.parent();
   Q_ASSERT( column < this->columnCount(nodeParentIndex) );
-  return nodeParentIndex.child(row, column);
+  return ctk::modelChildIndex(const_cast<qMRMLSceneModel*>(this), nodeParentIndex, row, column);
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyModel.cxx
@@ -28,6 +28,9 @@
 #include <QTimer>
 #include <QUrl>
 
+// CTK includes
+#include <ctkUtils.h>
+
 // qMRML includes
 #include "qMRMLSubjectHierarchyModel_p.h"
 
@@ -424,7 +427,7 @@ QModelIndex qMRMLSubjectHierarchyModel::indexFromSubjectHierarchyItem(vtkIdType 
     qCritical() << Q_FUNC_INFO << ": Invalid column " << column;
     return QModelIndex();
     }
-  return nodeParentIndex.child(row, column);
+  return ctk::modelChildIndex(const_cast<qMRMLSubjectHierarchyModel*>(this), nodeParentIndex, row, column);
 }
 
 //------------------------------------------------------------------------------

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -75,7 +75,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "27f89406aa8aa4fd490605aab3c9ca6c186422b5"
+    "04a3fd3b88e60aceb1a95d79d326a004af88b90f"
     QUIET
     )
 


### PR DESCRIPTION
List of CTK changes:

```
$ git shortlog 27f89406..04a3fd3b --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix QModelIndex::child() deprecation warnings
```

This commit introduces `ctk::modelChildIndex()` function so that the
same code compiles without deprecation warnings pre and post Qt 5.8.

It fixes warnings like the following:

```
  /path/to/S-r/CTK/Libs/DICOM/Core/ctkDICOMModel.cpp:745:32: warning: 'child' is deprecated: Use QAbstractItemModel::index [-Wdeprecated-declarations]
        this->setChildData(index.child(i,0), value, role);
                                 ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qabstractitemmodel.h:71:5: note: 'child' has been explicitly marked deprecated here
      QT_DEPRECATED_X("Use QAbstractItemModel::index") inline QModelIndex child(int row, int column) const;
      ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qglobal.h:294:33: note: expanded from macro 'QT_DEPRECATED_X'
  #  define QT_DEPRECATED_X(text) Q_DECL_DEPRECATED_X(text)
                                  ^
  /path/to/Support/Qt/5.15.2/clang_64/lib/QtCore.framework/Headers/qcompilerdetection.h:675:55: note: expanded from macro 'Q_DECL_DEPRECATED_X'
  #    define Q_DECL_DEPRECATED_X(text) __attribute__ ((__deprecated__(text)))
```