### PR TITLE
BUG: Fix null segment editor effect cursor icon overwriting mouse mode icon

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -1781,8 +1781,13 @@ void qMRMLSegmentEditorWidget::updateEffectsSectionFromMRML()
       }
     }
 
-  // Set cursor for active effect
-  d->setEffectCursor(activeEffect);
+  // Set cursor for active effect, but only when in view/transform node.
+  // In other mouse modes, the application sets a custom cursor and the Segment Editor must not override that.
+  if (!d->InteractionNode
+    || d->InteractionNode->GetCurrentInteractionMode() == vtkMRMLInteractionNode::ViewTransform)
+    {
+    d->setEffectCursor(activeEffect);
+    }
 
   // Set active effect
   d->LastActiveEffect = d->ActiveEffect;


### PR DESCRIPTION
This closes #5599.

When there was an active segment editor effect cursor icon and then the interaction mode was changed away from ViewTransform, it would set the new interaction mode icon and then set the active segment editor effect to None where setting the null effect arrow cursor icon would overwrite the newly set interaction mode icon.