### PR TITLE
ENH: Move Annotations module to Legacy category

### DIFF
--- a/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
+++ b/Modules/Loadable/Annotations/qSlicerAnnotationsModule.cxx
@@ -161,7 +161,7 @@ QIcon qSlicerAnnotationsModule::icon() const
 //-----------------------------------------------------------------------------
 QStringList qSlicerAnnotationsModule::categories() const
 {
-  return QStringList() << "" << "Informatics";
+  return QStringList() << "Legacy";
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Annotations module has been replaced by the Markups module. This moves the Annotations module to the legacy category to make it clear that any remaining objects are legacy and will be removed in the future.

Deprecating of the Annotations module is mentioned in the [Slicer roadmap](https://github.com/Slicer/Slicer/wiki/Roadmap). Moving it to the Legacy category does not hide the module from users, but does put it into a more appropriate category rather than being the first "main" module in the module selector menu.

| Current | This PR |
|----------|---------|
|![image](https://user-images.githubusercontent.com/15837524/141374683-120fe743-aa00-4bc5-828a-ad98173c29d3.png)|![image](https://user-images.githubusercontent.com/15837524/141374708-1d7dd181-346a-4f80-b9c9-a44fd3ebdbc7.png)|
