### PR TITLE
BUG: Fix place control point button menu button always visible

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -643,6 +643,8 @@ void qSlicerMarkupsPlaceWidget::setPlaceMultipleMarkups(PlaceMultipleMarkupsType
   if (d->PlaceButton)
     {
     d->PlaceButton->setMenu(d->PlaceMultipleMarkups == ShowPlaceMultipleMarkupsOption ? d->PlaceMenu : nullptr);
+    // Changing to DelayedPopup mode will hide menu button to avoid confusion of empty menu
+    d->PlaceButton->setPopupMode(d->PlaceMultipleMarkups == ShowPlaceMultipleMarkupsOption ? QToolButton::MenuButtonPopup : QToolButton::DelayedPopup);
     }
   if (this->placeModeEnabled())
     {


### PR DESCRIPTION
This closes #5914.

The Place control point QToolButton was changed in https://github.com/Slicer/Slicer/commit/09d12ae6f7598fe8490b691d17a35dcca5bd344a (specifically [here](https://github.com/Slicer/Slicer/commit/09d12ae6f7598fe8490b691d17a35dcca5bd344a#diff-b15fee96f47b8f3a2987141a9caae794d55d9a578a07a32a1febafac506d523eR53-R55)) to use the `QToolButton::MenuButtonPopup` type for [ToolButtonPopupMode](https://doc.qt.io/qt-5/qtoolbutton.html#ToolButtonPopupMode-enum). Previously it was the default `QToolButton::DelayedPopup`. DelayedPopup would automatically hide the menu arrow when there was no menu, however the `QToolButton::MenuButtonPopup` option always shows the button even when there is no menu.

To avoid showing a menu button with no menu, we can switch to the `QToolButton::DelayedPopup` mode when we do not have a menu for the QToolButton.

```python
place_widget = slicer.qSlicerMarkupsPlaceWidget()
place_widget.setMRMLScene(slicer.mrmlScene)
place_widget.setCurrentNode(slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode"))
place_widget.show()
```
![image](https://user-images.githubusercontent.com/15837524/141385909-71519148-6451-4792-84db-84b76bde1b50.png)

```python
place_widget.setPlaceMultipleMarkups(place_widget.ForcePlaceMultipleMarkups)
place_widget.show()
```
![image](https://user-images.githubusercontent.com/15837524/141385981-e881c9ba-bf9d-4b93-bc84-57fe6ab423b8.png)

```python
place_widget.setPlaceMultipleMarkups(place_widget.ShowPlaceMultipleMarkupsOption)
place_widget.show()
```
![image](https://user-images.githubusercontent.com/15837524/141386083-ee2c5b33-74ca-4be2-a0d0-2194363c4065.png)
