### PR TITLE
BUG: Fix unset control point position options visible in default place widget

### DIFF
--- a/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
+++ b/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
@@ -171,10 +171,15 @@ class MarkupsWidgetsSelfTestTest(ScriptedLoadableModuleTest):
     placeWidget.deleteAllMarkupsOptionVisible = True
     self.assertTrue(placeWidget.deleteAllMarkupsOptionVisible)
 
-    placeWidget.deleteAllMarkupsOptionVisible = False
-    self.assertFalse(placeWidget.deleteAllMarkupsOptionVisible)
-    placeWidget.deleteAllMarkupsOptionVisible = True
-    self.assertTrue(placeWidget.deleteAllMarkupsOptionVisible)
+    placeWidget.unsetLastControlPointOptionVisible = False
+    self.assertFalse(placeWidget.unsetLastControlPointOptionVisible)
+    placeWidget.unsetLastControlPointOptionVisible = True
+    self.assertTrue(placeWidget.unsetLastControlPointOptionVisible)
+
+    placeWidget.unsetAllControlPointsOptionVisible = False
+    self.assertFalse(placeWidget.unsetAllControlPointsOptionVisible)
+    placeWidget.unsetAllControlPointsOptionVisible = True
+    self.assertTrue(placeWidget.unsetAllControlPointsOptionVisible)
 
     placeWidget.placeMultipleMarkups = slicer.qSlicerMarkupsPlaceWidget.ForcePlaceSingleMarkup
     placeWidget.placeModeEnabled = True

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -479,6 +479,8 @@ void qMRMLMarkupsToolBar::addNodeActions(vtkSlicerMarkupsLogic* markupsLogic)
 
   d->MarkupsPlaceWidget = new qSlicerMarkupsPlaceWidget;
   d->MarkupsPlaceWidget->setDeleteAllMarkupsOptionVisible(true);
+  d->MarkupsPlaceWidget->setUnsetLastControlPointOptionVisible(true);
+  d->MarkupsPlaceWidget->setUnsetAllControlPointsOptionVisible(true);
   d->MarkupsPlaceWidget->setPlaceMultipleMarkups(qSlicerMarkupsPlaceWidget::ShowPlaceMultipleMarkupsOption);
   connect(d->MarkupsPlaceWidget, SIGNAL(activeMarkupsPlaceModeChanged(bool)), this, SIGNAL(activeMarkupsPlaceModeChanged(bool)));
   connect(d->MarkupsNodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)), d->MarkupsPlaceWidget, SLOT(setCurrentNode(vtkMRMLNode*)));

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -80,8 +80,8 @@ qSlicerMarkupsPlaceWidgetPrivate::qSlicerMarkupsPlaceWidgetPrivate( qSlicerMarku
 {
   this->DeleteMarkupsButtonVisible = true;
   this->DeleteAllMarkupsOptionVisible = true;
-  this->UnsetLastControlPointOptionVisible = true;
-  this->UnsetAllControlPointsOptionVisible = true;
+  this->UnsetLastControlPointOptionVisible = false;
+  this->UnsetAllControlPointsOptionVisible = false;
   this->PlaceMultipleMarkups = qSlicerMarkupsPlaceWidget::ShowPlaceMultipleMarkupsOption;
   this->PlaceMenu = nullptr;
   this->DeleteMenu = nullptr;

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.h
@@ -45,6 +45,8 @@ qSlicerMarkupsPlaceWidget : public qSlicerWidget
   Q_ENUMS(PlaceMultipleMarkupsType)
   Q_PROPERTY(bool buttonsVisible READ buttonsVisible WRITE setButtonsVisible)
   Q_PROPERTY(bool deleteAllMarkupsOptionVisible READ deleteAllMarkupsOptionVisible WRITE setDeleteAllMarkupsOptionVisible)
+  Q_PROPERTY(bool unsetLastControlPointOptionVisible READ unsetLastControlPointOptionVisible WRITE setUnsetLastControlPointOptionVisible)
+  Q_PROPERTY(bool unsetAllControlPointsOptionVisible READ unsetAllControlPointsOptionVisible WRITE setUnsetAllControlPointsOptionVisible)
   Q_PROPERTY(PlaceMultipleMarkupsType placeMultipleMarkups READ placeMultipleMarkups WRITE setPlaceMultipleMarkups)
   Q_PROPERTY(QColor nodeColor READ nodeColor WRITE setNodeColor)
   Q_PROPERTY(QColor defaultNodeColor READ defaultNodeColor WRITE setDefaultNodeColor)
@@ -93,6 +95,12 @@ public:
   /// Returns true if the Delete all option on the Delete button is visible.
   bool deleteAllMarkupsOptionVisible() const;
 
+  /// Returns true if the Unset last control point option on the Delete button is visible.
+  bool unsetLastControlPointOptionVisible() const;
+
+  /// Returns true if the Unset all control points option on the Delete button is visible.
+  bool unsetAllControlPointsOptionVisible() const;
+
   /// Get the selected color of the currently selected markups node.
   QColor nodeColor() const;
 
@@ -138,6 +146,12 @@ public slots:
   /// Set visibility of Delete all markups option.
   void setDeleteAllMarkupsOptionVisible(bool visible);
 
+  /// Set visibility of Unset last control point option.
+  void setUnsetLastControlPointOptionVisible(bool visible);
+
+  /// Set visibility of Unset all control point option
+  void setUnsetAllControlPointsOptionVisible(bool visible);
+
   /// Set place mode to persistent (remains active until deactivated). Does not enable or disable placement mode.
   void setPlaceModePersistency(bool);
 
@@ -168,6 +182,9 @@ protected slots:
 
   /// Update the GUI to reflect the currently selected markups node.
   void updateWidget();
+
+  /// Update the Delete Button to reflect the currently visible delete button options.
+  void updateDeleteButton();
 
   /// Update the currently selected markups node to have its selected color changed.
   void onColorButtonChanged(QColor);


### PR DESCRIPTION
This closes #5917.

Having unset control point position options visible in the place widget by default can lead to weird situations such as the functionality enabled for the SurfaceCut effect. This effect doesn't have a set number of control points and would not benefit from unsetting points. Having unset points not visible by default will maintain previous behavior prior to 09d12ae.

The options is turned on only for the Markups toolbar.

```python
place_widget =slicer.qSlicerMarkupsPlaceWidget()
place_widget.setMRMLScene(slicer.mrmlScene)
place_widget.setCurrentNode(slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode"))
place_widget.show()
```
Place a point and then you will see the default place widget does not have unset options shown by default.

![image](https://user-images.githubusercontent.com/15837524/141400680-89fda2f7-cff8-4916-a967-e00d42417e5b.png)

Markups ToolBar has the unset options shown by default.
![image](https://user-images.githubusercontent.com/15837524/141400759-f5b65ca3-fda4-478c-aba8-56bb5ed037ae.png)
