### PR TITLE
ENH: Add deprecation warnings to deprecated Markups API methods

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -667,21 +667,21 @@ int vtkSlicerMarkupsLogic::AddFiducial(double r, double a, double s)
   // get the active list id
   std::string listID = this->GetActiveListID();
 
-  // is there no active fiducial list?
+  // is there no active point list?
   if (listID.size() == 0)
     {
-    vtkDebugMacro("AddFiducial: no list is active, adding one first!");
+    vtkDebugMacro("AddFiducial: no point list is active, adding one first!");
     std::string newListID = this->AddNewFiducialNode();
     if (newListID.size() == 0)
       {
-      vtkErrorMacro("AddFiducial: failed to add a new fiducial list to the scene.");
+      vtkErrorMacro("AddFiducial: failed to add a new point list to the scene.");
       return -1;
       }
     // try to get the id again
     listID = this->GetActiveListID();
     if (listID.size() == 0)
       {
-      vtkErrorMacro("AddFiducial: failed to create a new list to add to!");
+      vtkErrorMacro("AddFiducial: failed to create a new point list to add to!");
       return -1;
       }
     }
@@ -690,18 +690,18 @@ int vtkSlicerMarkupsLogic::AddFiducial(double r, double a, double s)
   vtkMRMLNode *listNode = this->GetMRMLScene()->GetNodeByID(listID.c_str());
   if (!listNode)
     {
-    vtkErrorMacro("AddFiducial: failed to get the active list with id " << listID);
+    vtkErrorMacro("AddFiducial: failed to get the active point list with id " << listID);
     return -1;
     }
   vtkMRMLMarkupsFiducialNode *fiducialNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(listNode);
   if (!fiducialNode)
     {
-    vtkErrorMacro("AddFiducial: active list is not a fiducial list: " << listNode->GetClassName());
+    vtkErrorMacro("AddFiducial: active list is not a point list: " << listNode->GetClassName());
     return -1;
     }
-  vtkDebugMacro("AddFiducial: adding a fiducial to the list " << listID);
-  // add the point to the active fiducial list
-  return fiducialNode->AddFiducial(r,a,s);
+  vtkDebugMacro("AddFiducial: adding a control point to the list " << listID);
+  // add a control point to the active point list
+  return fiducialNode->AddControlPoint(vtkVector3d(r,a,s), std::string());
 }
 
 //---------------------------------------------------------------------------
@@ -1357,9 +1357,8 @@ void vtkSlicerMarkupsLogic::ConvertAnnotationFiducialsToMarkups()
           }
         double coord[3];
         annotNode->GetFiducialCoordinates(coord);
-        int fidIndex = markupsNode->AddFiducial(coord[0], coord[1], coord[2]);
-        vtkDebugMacro("Added a fiducial at index " << fidIndex);
-        markupsNode->SetNthControlPointLabel(fidIndex, std::string(annotNode->GetName()));
+        int fidIndex = markupsNode->AddControlPoint(vtkVector3d(coord), std::string(annotNode->GetName()));
+        vtkDebugMacro("Added a control point at index " << fidIndex);
         char *desc = annotNode->GetDescription();
         if (desc)
           {

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -99,9 +99,7 @@ int vtkMRMLMarkupsFiducialNode::AddFiducial(double x, double y, double z,
                                             std::string label)
 {
   vtkWarningMacro("AddFiducial method is deprecated, please use AddControlPoint instead");
-  vtkVector3d point;
-  point.Set(x, y, z);
-  return this->AddControlPoint(point, label);
+  return this->AddControlPoint(vtkVector3d(x, y, z), label);
 }
 
 //-------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -98,6 +98,7 @@ int vtkMRMLMarkupsFiducialNode::AddFiducial(double x, double y, double z)
 int vtkMRMLMarkupsFiducialNode::AddFiducial(double x, double y, double z,
                                             std::string label)
 {
+  vtkWarningMacro("AddFiducial method is deprecated, please use AddControlPoint instead");
   vtkVector3d point;
   point.Set(x, y, z);
   return this->AddControlPoint(point, label);
@@ -114,94 +115,11 @@ int vtkMRMLMarkupsFiducialNode::AddFiducialFromArray(double pos[3], std::string 
 //-------------------------------------------------------------------------
 void vtkMRMLMarkupsFiducialNode::GetNthFiducialPosition(int n, double pos[3])
 {
+  vtkWarningMacro("GetNthFiducialPosition method is deprecated, please use GetNthControlPointPositionVector instead");
   vtkVector3d point= this->GetNthControlPointPositionVector(n);
   pos[0] = point.GetX();
   pos[1] = point.GetY();
   pos[2] = point.GetZ();
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::SetNthFiducialPositionFromArray(int n, double pos[3])
-{
-  this->SetNthControlPointPositionFromArray(n, pos);
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::SetNthFiducialPosition(int n, double x, double y, double z)
-{
-  this->SetNthControlPointPosition(n, x, y, z);
-}
-
-//-------------------------------------------------------------------------
-bool vtkMRMLMarkupsFiducialNode::GetNthFiducialSelected(int n)
-{
-  return this->GetNthControlPointSelected(n);
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::SetNthFiducialSelected(int n, bool flag)
-{
-  this->SetNthControlPointSelected(n, flag);
-}
-
-//-------------------------------------------------------------------------
-bool vtkMRMLMarkupsFiducialNode::GetNthFiducialLocked(int n)
-{
-  return this->GetNthControlPointLocked(n);
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::SetNthFiducialLocked(int n, bool flag)
-{
-  this->SetNthControlPointLocked(n, flag);
-}
-
-//-------------------------------------------------------------------------
-bool vtkMRMLMarkupsFiducialNode::GetNthFiducialVisibility(int n)
-{
-  return this->GetNthControlPointVisibility(n);
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::SetNthFiducialVisibility(int n, bool flag)
-{
-  this->SetNthControlPointVisibility(n, flag);
-}
-
-//-------------------------------------------------------------------------
-std::string vtkMRMLMarkupsFiducialNode::GetNthFiducialLabel(int n)
-{
-  return this->GetNthControlPointLabel(n);
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::SetNthFiducialLabel(int n, std::string label)
-{
-  this->SetNthControlPointLabel(n, label);
-}
-
-//-------------------------------------------------------------------------
-std::string vtkMRMLMarkupsFiducialNode::GetNthFiducialAssociatedNodeID(int n)
-{
-  return this->GetNthControlPointAssociatedNodeID(n);
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::SetNthFiducialAssociatedNodeID(int n, const char* id)
-{
-  this->SetNthControlPointAssociatedNodeID(n, (id ? std::string(id) : ""));
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::SetNthFiducialWorldCoordinates(int n, double coords[4])
-{
-  this->SetNthControlPointPositionWorld(n, coords[0], coords[1], coords[2]);
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::GetNthFiducialWorldCoordinates(int n, double coords[4])
-{
-  this->GetNthControlPointPositionWorld(n, coords);
 }
 
 //-------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -90,49 +90,74 @@ public:
   /// If the number is set to 0 then no it means there is no preference (this is the default value).
   vtkSetMacro(RequiredNumberOfControlPoints, int);
 
-  /// Get the number of fiducials in this node
-  int GetNumberOfFiducials() { return this->GetNumberOfControlPoints(); } ;
-  /// Add a new fiducial from x,y,z coordinates and return the fiducial index
+  /// \deprecated Use GetNumberOfControlPoints instead.
+  int GetNumberOfFiducials() {
+    vtkWarningMacro("GetNumberOfFiducials method is deprecated, please use GetNumberOfControlPoints instead");
+    return this->GetNumberOfControlPoints();};
+  /// \deprecated Use AddControlPoint instead.
   int AddFiducial(double x, double y, double z);
+  /// \deprecated Use AddControlPoint instead.
   int AddFiducial(double x, double y, double z, std::string label);
   /// Add a new fiducial from an array and return the fiducial index
   int AddFiducialFromArray(double pos[3], std::string label = std::string());
-  /// Get the position of the nth fiducial, returning it in the pos array
+  /// \deprecated Use GetNthControlPointPositionVector instead.
   void GetNthFiducialPosition(int n, double pos[3]);
-  /// Set the position of the nth fiducial from x, y, z coordinates
-  void SetNthFiducialPosition(int n, double x, double y, double z);
-  /// Set the position of the nth fiducial from a double array
-  void SetNthFiducialPositionFromArray(int n, double pos[3]);
-  /// Get selected property on Nth fiducial
-  bool GetNthFiducialSelected(int n = 0);
-  /// Set selected property on Nth fiducial
-  void SetNthFiducialSelected(int n, bool flag);
-  /// Get locked property on Nth fiducial
-  bool GetNthFiducialLocked(int n = 0);
-  /// Set locked property on Nth fiducial
-  void SetNthFiducialLocked(int n, bool flag);
-  /// Get visibility property on Nth fiducial
-  bool GetNthFiducialVisibility(int n = 0);
-  /// Set visibility property on Nth fiducial. If the visibility is set to
-  /// true on the node/list as a whole, the nth fiducial visibility is used to
-  /// determine if it is visible. If the visibility is set to false on the node
-  /// as a whole, all fiducials are hidden but keep this value for when the
-  /// list as a whole is turned visible.
-  /// \sa vtkMRMLDisplayableNode::SetDisplayVisibility
-  /// \sa vtkMRMLDisplayNode::SetVisibility
-  void SetNthFiducialVisibility(int n, bool flag);
-  /// Get label on nth fiducial
-  std::string GetNthFiducialLabel(int n = 0);
-  /// Set label on nth fiducial
-  void SetNthFiducialLabel(int n, std::string label);
-  /// Get associated node id on nth fiducial
-  std::string GetNthFiducialAssociatedNodeID(int n = 0);
-  /// Set associated node id on nth fiducial
-  void SetNthFiducialAssociatedNodeID(int n, const char* id);
-  /// Set world coordinates on nth fiducial
-  void SetNthFiducialWorldCoordinates(int n, double coords[4]);
-  /// Get world coordinates on nth fiducial
-  void GetNthFiducialWorldCoordinates(int n, double coords[4]);
+  /// \deprecated Use SetNthControlPointPosition instead.
+  void SetNthFiducialPosition(int n, double x, double y, double z){
+    vtkWarningMacro("SetNthFiducialPosition method is deprecated, please use SetNthControlPointPosition instead");
+    this->SetNthControlPointPosition(n, x, y, z);};
+  /// \deprecated Use SetNthControlPointPositionFromArray instead.
+  void SetNthFiducialPositionFromArray(int n, double pos[3]){
+    vtkWarningMacro("SetNthFiducialPositionFromArray method is deprecated, please use SetNthControlPointPositionFromArray instead");
+    this->SetNthControlPointPositionFromArray(n, pos);};
+  /// \deprecated Use GetNthControlPointSelected instead.
+  bool GetNthFiducialSelected(int n = 0){
+    vtkWarningMacro("GetNthFiducialSelected method is deprecated, please use GetNthControlPointSelected instead");
+    return this->GetNthControlPointSelected(n);};
+  /// \deprecated Use SetNthControlPointSelected instead.
+  void SetNthFiducialSelected(int n, bool flag){
+    vtkWarningMacro("SetNthFiducialSelected method is deprecated, please use SetNthControlPointSelected instead");
+    this->SetNthControlPointSelected(n, flag);};
+  /// \deprecated Use GetNthControlPointLocked instead.
+  bool GetNthFiducialLocked(int n = 0){
+    vtkWarningMacro("GetNthFiducialLocked method is deprecated, please use GetNthControlPointLocked instead");
+    return this->GetNthControlPointLocked(n);};
+  /// \deprecated Use SetNthControlPointLocked instead.
+  void SetNthFiducialLocked(int n, bool flag){
+    vtkWarningMacro("SetNthFiducialLocked method is deprecated, please use SetNthControlPointLocked instead");
+    this->SetNthControlPointLocked(n, flag);};
+  /// \deprecated Use GetNthControlPointVisibility instead.
+  bool GetNthFiducialVisibility(int n = 0){
+    vtkWarningMacro("GetNthFiducialVisibility method is deprecated, please use GetNthControlPointVisibility instead");
+    return this->GetNthControlPointVisibility(n);};
+  /// \deprecated Use SetNthControlPointVisibility instead.
+  void SetNthFiducialVisibility(int n, bool flag){
+    vtkWarningMacro("SetNthFiducialVisibility method is deprecated, please use SetNthControlPointVisibility instead");
+    this->SetNthControlPointVisibility(n, flag);};
+  /// \deprecated Use GetNthControlPointLabel instead.
+  std::string GetNthFiducialLabel(int n = 0){
+    vtkWarningMacro("GetNthFiducialLabel method is deprecated, please use GetNthControlPointLabel instead");
+    return this->GetNthControlPointLabel(n);};
+  /// \deprecated Use SetNthControlPointLabel instead.
+  void SetNthFiducialLabel(int n, std::string label){
+    vtkWarningMacro("SetNthFiducialLabel method is deprecated, please use SetNthControlPointLabel instead");
+    this->SetNthControlPointLabel(n, label);};
+  /// \deprecated Use GetNthControlPointAssociatedNodeID instead.
+  std::string GetNthFiducialAssociatedNodeID(int n = 0){
+    vtkWarningMacro("GetNthFiducialAssociatedNodeID method is deprecated, please use GetNthControlPointAssociatedNodeID instead");
+    return this->GetNthControlPointAssociatedNodeID(n);};
+  /// \deprecated Use SetNthControlPointAssociatedNodeID instead.
+  void SetNthFiducialAssociatedNodeID(int n, const char* id){
+    vtkWarningMacro("SetNthFiducialAssociatedNodeID method is deprecated, please use SetNthControlPointAssociatedNodeID instead");
+    this->SetNthControlPointAssociatedNodeID(n, (id ? std::string(id) : ""));};
+  /// \deprecated Use SetNthControlPointPositionWorld instead.
+  void SetNthFiducialWorldCoordinates(int n, double coords[4]){
+    vtkWarningMacro("SetNthFiducialWorldCoordinates method is deprecated, please use SetNthControlPointPositionWorld instead");
+    this->SetNthControlPointPositionWorld(n, coords[0], coords[1], coords[2]);};
+  /// \deprecated Use GetNthControlPointPositionWorld instead.
+  void GetNthFiducialWorldCoordinates(int n, double coords[4]){
+    vtkWarningMacro("GetNthFiducialWorldCoordinates method is deprecated, please use GetNthControlPointPositionWorld instead");
+    this->GetNthControlPointPositionWorld(n, coords);};
 
   /// Create and observe default display node(s)
   void CreateDefaultDisplayNodes() override;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -2697,7 +2697,7 @@ void vtkMRMLMarkupsNode::UpdateInteractionHandleToWorldMatrix()
 {
   // The origin of the coordinate system is at the center of mass of the control points
   double origin_World[3] = { 0 };
-  int numberOfControlPoints = this->GetNumberOfMarkups();
+  int numberOfControlPoints = this->GetNumberOfControlPoints();
   vtkNew<vtkPoints> controlPoints_World;
   for (int i = 0; i < numberOfControlPoints; ++i)
     {

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -2043,6 +2043,7 @@ void vtkMRMLMarkupsNode::GetBounds(double bounds[6])
 //---------------------------------------------------------------------------
 void vtkMRMLMarkupsNode::GetMarkupPoint(int markupIndex, int pointIndex, double point[3])
 {
+  vtkWarningMacro("GetMarkupPoint method is deprecated, please use GetNthControlPointPosition instead");
   if (markupIndex == 0)
     {
     this->GetNthControlPointPosition(pointIndex, point);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -281,7 +281,9 @@ public:
   virtual void UnsetAllControlPoints();
 
   /// \deprecated Use RemoveAllControlPoints instead.
-  void RemoveAllMarkups() { this->RemoveAllControlPoints(); };
+  void RemoveAllMarkups() {
+    vtkWarningMacro("RemoveAllMarkups method is deprecated, please use RemoveAllControlPoints instead");
+    this->RemoveAllControlPoints();};
 
   /// Get the Locked property on the markupNode/list of control points.
   vtkGetMacro(Locked, int);
@@ -303,8 +305,10 @@ public:
   /// Return true if n is a valid control point, false otherwise.
   bool ControlPointExists(int n);
 
-  /// Deprecated. Use ControlPointExists instead.
-  bool MarkupExists(int n) { return this->ControlPointExists(n); }
+  /// \deprecated Use ControlPointExists instead.
+  bool MarkupExists(int n) {
+    vtkWarningMacro("MarkupExists method is deprecated, please use ControlPointExists instead");
+    return this->ControlPointExists(n);};
   /// Return the number of control points that are stored in this node
   int GetNumberOfControlPoints();
   /// Return the number of control points that are already placed (not being previewed or undefined).
@@ -312,9 +316,13 @@ public:
   /// Return the number of control points that have not been placed (not being previewed or skipped).
   int GetNumberOfUndefinedControlPoints(bool includePreview = false);
   /// \deprecated Use GetNumberOfControlPoints() instead.
-  int GetNumberOfMarkups() { return this->GetNumberOfControlPoints(); };
+  int GetNumberOfMarkups() {
+    vtkWarningMacro("GetNumberOfMarkups method is deprecated, please use GetNumberOfControlPoints instead");
+    return this->GetNumberOfControlPoints();};
   /// \deprecated Use GetNumberOfControlPoints() instead.
-  int GetNumberOfPointsInNthMarkup(int) { return this->GetNumberOfControlPoints(); };
+  int GetNumberOfPointsInNthMarkup(int) {
+    vtkWarningMacro("GetNumberOfPointsInNthMarkup method is deprecated, please use GetNumberOfControlPoints instead");
+    return this->GetNumberOfControlPoints();};
   /// Return a pointer to the Nth control point stored in this node, null if n is out of bounds
   ControlPoint* GetNthControlPoint(int n);
   /// Return a pointer to the std::vector of control points stored in this node
@@ -343,7 +351,9 @@ public:
   vtkVector3d GetNthControlPointPositionVector(int pointIndex);
 
   /// \deprecated Use GetNthControlPointPositionVector() method instead.
-  vtkVector3d GetMarkupPointVector(int markupIndex, int) { return this->GetNthControlPointPositionVector(markupIndex); };
+  vtkVector3d GetMarkupPointVector(int markupIndex, int) {
+    vtkWarningMacro("GetMarkupPointVector method is deprecated, please use GetNthControlPointPositionVector instead");
+    return this->GetNthControlPointPositionVector(markupIndex);};
 
   /// \deprecated Use GetNthControlPointPosition method instead.
   void GetMarkupPoint(int markupIndex, int pointIndex, double point[3]);
@@ -387,7 +397,9 @@ public:
   void RemoveNthControlPoint(int pointIndex);
 
   /// \deprecated Use RemoveNthControlPoint instead.
-  void RemoveMarkup(int pointIndex) { this->RemoveNthControlPoint(pointIndex); };
+  void RemoveMarkup(int pointIndex) {
+    vtkWarningMacro("RemoveMarkup method is deprecated, please use RemoveNthControlPoint instead");
+    this->RemoveNthControlPoint(pointIndex);};
 
   /// Insert a control point in this list at targetIndex.
   /// If targetIndex is < 0, insert at the start of the list.
@@ -495,15 +507,21 @@ public:
   void SetNthControlPointAssociatedNodeID(int n, std::string id);
 
   /// \deprecated Use GetNthControlPointAssociatedNodeID instead.
-  std::string GetNthMarkupAssociatedNodeID(int n = 0) { return this->GetNthControlPointAssociatedNodeID(n); }
+  std::string GetNthMarkupAssociatedNodeID(int n = 0) {
+    vtkWarningMacro("GetNthMarkupAssociatedNodeID method is deprecated, please use GetNthControlPointAssociatedNodeID instead");
+    return this->GetNthControlPointAssociatedNodeID(n);};
   /// \deprecated Use SetNthControlPointAssociatedNodeID instead.
-  void SetNthMarkupAssociatedNodeID(int n, std::string id) { this->SetNthControlPointAssociatedNodeID(n,id); }
+  void SetNthMarkupAssociatedNodeID(int n, std::string id) {
+    vtkWarningMacro("SetNthMarkupAssociatedNodeID method is deprecated, please use SetNthControlPointAssociatedNodeID instead");
+    this->SetNthControlPointAssociatedNodeID(n,id);};
 
   /// Get the id for the Nth control point
   std::string GetNthControlPointID(int n);
 
   /// \deprecated Use GetNthControlPointID instead.
-  std::string GetNthMarkupID(int n = 0) { return this->GetNthControlPointID(n); }
+  std::string GetNthMarkupID(int n = 0) {
+    vtkWarningMacro("GetNthMarkupID method is deprecated, please use GetNthControlPointID instead");
+    return this->GetNthControlPointID(n);};
 
   /// Get the Nth control point index based on it's ID
   int GetNthControlPointIndexByID(const char* controlPointID);
@@ -529,9 +547,13 @@ public:
   void SetNthControlPointLocked(int n, bool flag);
 
   /// \deprecated Use GetNthControlPointLocked instead.
-  bool GetNthMarkupLocked(int n = 0) { return this->GetNthControlPointLocked(n); };
+  bool GetNthMarkupLocked(int n = 0) {
+    vtkWarningMacro("GetNthMarkupLocked method is deprecated, please use GetNthControlPointLocked instead");
+    return this->GetNthControlPointLocked(n);};
   /// \deprecated Use SetNthControlPointLocked instead.
-  void SetNthMarkupLocked(int n, bool flag) { this->SetNthControlPointLocked(n, flag);  }
+  void SetNthMarkupLocked(int n, bool flag) {
+    vtkWarningMacro("SetNthMarkupLocked method is deprecated, please use SetNthControlPointLocked instead");
+    this->SetNthControlPointLocked(n, flag);};
 
   /// Get the Visibility flag on the Nth control point,
   /// returns false if control point doesn't exist
@@ -558,9 +580,13 @@ public:
   void SetNthControlPointLabel(int n, std::string label);
 
   /// \deprecated Use GetNthControlPointLabel instead.
-  std::string GetNthMarkupLabel(int n = 0) { return this->GetNthControlPointLabel(n); }
+  std::string GetNthMarkupLabel(int n = 0) {
+    vtkWarningMacro("GetNthMarkupLabel method is deprecated, please use GetNthControlPointLabel instead");
+    return this->GetNthControlPointLabel(n);};
   /// \deprecated Use SetNthControlPointLabel instead.
-  void SetNthMarkupLabel(int n, std::string label) { this->SetNthControlPointLabel(n, label); }
+  void SetNthMarkupLabel(int n, std::string label) {
+    vtkWarningMacro("SetNthMarkupLabel method is deprecated, please use SetNthControlPointLabel instead");
+    this->SetNthControlPointLabel(n, label);};
 
   /// Get the Description flag on the Nth control point,
   /// returns false if control point doesn't exist

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialNodeTest1.cxx
@@ -38,21 +38,20 @@ int vtkMRMLMarkupsFiducialNodeTest1(int , char * [] )
 
   // set position
   double inPos[3] = {0.33, 1.55, -99.0};
-  int fidIndex = node1->AddFiducial(inPos[0], inPos[1], inPos[2]);
-  double outPos[3];
-  node1->GetNthFiducialPosition(0, outPos);
-  double diff = sqrt(vtkMath::Distance2BetweenPoints(inPos, outPos));
-  std::cout << "Diff between AddFiducial and GetNthFiducialPosition = " << diff << std::endl;
+  int fidIndex = node1->AddControlPoint(vtkVector3d(inPos), std::string());
+  vtkVector3d posVector= node1->GetNthControlPointPositionVector(0);
+  double diff = sqrt(vtkMath::Distance2BetweenPoints(inPos, posVector.GetData()));
+  std::cout << "Diff between AddControlPoint and GetNthControlPointPositionVector = " << diff << std::endl;
   if (diff > 0.1)
     {
     return EXIT_FAILURE;
     }
   inPos[1] = 15.55;
-  int fidIndex2 = node1->AddFiducialFromArray(inPos);
+  int fidIndex2 = node1->AddControlPoint(vtkVector3d(inPos), std::string());
 
   // selected
-  node1->SetNthFiducialSelected(fidIndex2, false);
-  bool retval = node1->GetNthFiducialSelected(fidIndex2);
+  node1->SetNthControlPointSelected(fidIndex2, false);
+  bool retval = node1->GetNthControlPointSelected(fidIndex2);
   if (retval != false)
     {
     std::cerr << "Error setting/getting selected to false on fid " << fidIndex << std::endl;
@@ -60,8 +59,8 @@ int vtkMRMLMarkupsFiducialNodeTest1(int , char * [] )
     }
 
   // visibility
-  node1->SetNthFiducialVisibility(fidIndex2, false);
-  retval = node1->GetNthFiducialVisibility(fidIndex2);
+  node1->SetNthControlPointVisibility(fidIndex2, false);
+  retval = node1->GetNthControlPointVisibility(fidIndex2);
   if (retval != false)
     {
     std::cerr << "Error setting/getting visibility to false on fid " << fidIndex << std::endl;
@@ -69,8 +68,8 @@ int vtkMRMLMarkupsFiducialNodeTest1(int , char * [] )
     }
 
   // label
-  node1->SetNthFiducialLabel(fidIndex2, std::string("TestingLabelHere"));
-  std::string returnLabel = node1->GetNthFiducialLabel(fidIndex2);
+  node1->SetNthControlPointLabel(fidIndex2, std::string("TestingLabelHere"));
+  std::string returnLabel = node1->GetNthControlPointLabel(fidIndex2);
   if (returnLabel.compare("TestingLabelHere") != 0)
     {
     std::cerr << "Failure to set/get label for fid " << fidIndex2 << ", got '" << returnLabel.c_str() << "'" << std::endl;
@@ -79,8 +78,8 @@ int vtkMRMLMarkupsFiducialNodeTest1(int , char * [] )
 
   // associated node id
   std::string inID = "vtkMRMLScalarVolumeNode21";
-  node1->SetNthFiducialAssociatedNodeID(fidIndex2, inID.c_str());
-  std::string outID = node1->GetNthFiducialAssociatedNodeID(fidIndex2);
+  node1->SetNthControlPointAssociatedNodeID(fidIndex2, (inID.c_str() ? std::string(inID.c_str()) : ""));
+  std::string outID = node1->GetNthControlPointAssociatedNodeID(fidIndex2);
   if (outID.compare(inID) != 0)
     {
     std::cerr << "Failed to set fid " << fidIndex2 << " assoc node id to " << inID.c_str() << ", got '" << outID << "'" << std::endl;
@@ -89,9 +88,9 @@ int vtkMRMLMarkupsFiducialNodeTest1(int , char * [] )
 
   // world coords
   double inCoords[4] = {0.4, 10.5, -8, 1.0};
-  node1->SetNthFiducialWorldCoordinates(fidIndex2, inCoords);
+  node1->SetNthControlPointPositionWorld(fidIndex2, inCoords[0], inCoords[1], inCoords[2]);
   double outCoords[4];
-  node1->GetNthFiducialWorldCoordinates(fidIndex2, outCoords);
+  node1->GetNthControlPointPositionWorld(fidIndex2, outCoords);
   diff = sqrt(vtkMath::Distance2BetweenPoints(inCoords, outCoords));
   std::cout << "Diff between set world and get world coords = " << diff << std::endl;
   if (diff > 0.1)
@@ -104,21 +103,20 @@ int vtkMRMLMarkupsFiducialNodeTest1(int , char * [] )
   p0[0] = 0.99;
   p0[1] = 1.33;
   p0[2] = -9.0;
-  node1->SetNthFiducialPositionFromArray(fidIndex2, p0);
-  double p1[3];
-  node1->GetNthFiducialPosition(fidIndex2, p1);
-  diff = sqrt(vtkMath::Distance2BetweenPoints(p0, p1));
-  std::cout << "Diff between set nth fiducial position array and get = " << diff << std::endl;
+  node1->SetNthControlPointPositionFromArray(fidIndex2, p0);
+  vtkVector3d posVector2 = node1->GetNthControlPointPositionVector(fidIndex2);
+  diff = sqrt(vtkMath::Distance2BetweenPoints(p0, posVector2.GetData()));
+  std::cout << "Diff between set nth control point position array and get = " << diff << std::endl;
   if (diff > 0.1)
     {
     return EXIT_FAILURE;
     }
   // position as points
   p0[1] = -4.5;
-  node1->SetNthFiducialPosition(fidIndex2, p0[0], p0[1], p0[2]);
-  node1->GetNthFiducialPosition(fidIndex2, p1);
-  diff = sqrt(vtkMath::Distance2BetweenPoints(p0, p1));
-  std::cout << "Diff between set nth fiducial position and get = " << diff << std::endl;
+  node1->SetNthControlPointPosition(fidIndex2, p0[0], p0[1], p0[2]);
+  vtkVector3d posVector3 = node1->GetNthControlPointPositionVector(fidIndex2);
+  diff = sqrt(vtkMath::Distance2BetweenPoints(p0, posVector3.GetData()));
+  std::cout << "Diff between set nth control point position and get = " << diff << std::endl;
   if (diff > 0.1)
     {
     return EXIT_FAILURE;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest2.cxx
@@ -74,8 +74,8 @@ int vtkMRMLMarkupsFiducialStorageNodeTest2(int argc, char * argv[] )
 
   // test values on the first markup
   double inputPoint[3] = {12.5, -93.5, 7.5};
-  double outputPoint[3];
-  markupsFiducialNode->GetNthFiducialPosition(0, outputPoint);
+  vtkVector3d posVector = markupsFiducialNode->GetNthControlPointPositionVector(0);
+  double* outputPoint = posVector.GetData();
   double diff = fabs(outputPoint[0] - inputPoint[0]) + fabs(outputPoint[1] - inputPoint[1]) + fabs(outputPoint[2] - inputPoint[2]);
   if (diff > 0.1)
     {

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest3.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialStorageNodeTest3.cxx
@@ -76,8 +76,8 @@ int vtkMRMLMarkupsFiducialStorageNodeTest3(int argc, char * argv[] )
 
   // test values on the first markup
   double inputPoint[3] = {64.2531, 3.69, 62.886};
-  double outputPoint[3];
-  markupsFiducialNode->GetNthFiducialPosition(0, outputPoint);
+  vtkVector3d posVector = markupsFiducialNode->GetNthControlPointPositionVector(0);
+  double* outputPoint = posVector.GetData();
   double diff = fabs(outputPoint[0] - inputPoint[0]) + fabs(outputPoint[1] - inputPoint[1]) + fabs(outputPoint[2] - inputPoint[2]);
   if (diff > 0.1)
     {

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMarkupsAnnotationSceneTest.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMarkupsAnnotationSceneTest.cxx
@@ -157,8 +157,8 @@ int vtkMarkupsAnnotationSceneTest(int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  double markupPosition[3] = {0.0, 0.0, 0.0};
-  mfnode->GetNthFiducialPosition(0, markupPosition);
+  vtkVector3d posVector= mfnode->GetNthControlPointPositionVector(0);
+  double* markupPosition = posVector.GetData();
   double diff = vtkMath::Distance2BetweenPoints(annotationPosition1, markupPosition);
   if (diff > 0.01)
     {
@@ -172,8 +172,8 @@ int vtkMarkupsAnnotationSceneTest(int argc, char * argv[] )
     return EXIT_FAILURE;
     }
 
-  double markupPosition2[3] = {0.0, 0.0, 0.0};
-  mfnode->GetNthFiducialPosition(1, markupPosition2);
+  vtkVector3d posVector2 = mfnode->GetNthControlPointPositionVector(1);
+  double* markupPosition2 = posVector2.GetData();
   diff = vtkMath::Distance2BetweenPoints(annotationPosition2, markupPosition2);
   if (diff > 0.01)
     {

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest3.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest3.cxx
@@ -142,8 +142,8 @@ int vtkSlicerMarkupsLogicTest3(int , char * [] )
                   << assocNodeID.c_str() << std::endl;
         return EXIT_FAILURE;
         }
-      double pos[3];
-      markupsFid->GetNthFiducialPosition(0, pos);
+      vtkVector3d posVector = markupsFid->GetNthControlPointPositionVector(0);
+      double* pos = posVector.GetData();
       double expectedPos[3] = {5.5, -6.6, 0.0};
       if (vtkMath::Distance2BetweenPoints(pos, expectedPos) > 0.01)
         {

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestManyLists.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestManyLists.py
@@ -48,7 +48,7 @@ if numFidNodesAfterRestore != numFidNodesBeforeStore:
   raise Exception(exceptionMessage)
 
 fid1AfterRestore = slicer.mrmlScene.GetFirstNodeByName("FidNode1")
-numFidsInList1AfterRestore = fid1AfterRestore.GetNumberOfMarkups()
+numFidsInList1AfterRestore = fid1AfterRestore.GetNumberOfControlPoints()
 print("After restore, list with name FidNode1 has id ", fid1AfterRestore.GetID(), " and num fids = ", numFidsInList1AfterRestore)
 if numFidsInList1AfterRestore != numFidsInList1:
   exceptionMessage = "After restoring list 1, id = " + fid1AfterRestore.GetID()
@@ -57,7 +57,7 @@ if numFidsInList1AfterRestore != numFidsInList1:
   raise Exception(exceptionMessage)
 
 fid2AfterRestore = slicer.mrmlScene.GetFirstNodeByName("FidNode2")
-numFidsInList2AfterRestore = fid2AfterRestore.GetNumberOfMarkups()
+numFidsInList2AfterRestore = fid2AfterRestore.GetNumberOfControlPoints()
 print("After restore, list with name FidNode2 has id ", fid2AfterRestore.GetID(), " and num fids = ", numFidsInList2AfterRestore)
 if numFidsInList2AfterRestore != numFidsInList2:
   exceptionMessage = "After restoring list 2,  id = " + fid2AfterRestore.GetID()


### PR DESCRIPTION
This closes #5990 by providing warnings of deprecated methods. Developers are alerted of the deprecation at runtime which is a lot more helpful than only documented in the source code.

Deprecation with runtime warnings is like what is already done for `SetSliceIntersectionVisibility`.

https://github.com/Slicer/Slicer/blob/6582c1f0b0ec5772776564e5c2704e78b82ea261/Libs/MRML/Core/vtkMRMLDisplayNode.cxx#L932-L935