### PR TITLE
BUG: Fix bad alloc error from sequence string validation on Linux

### DIFF
--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
@@ -43,7 +43,6 @@
 // STD includes
 #include <sstream>
 #include <algorithm> // for std::find
-#include <regex>
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #  define SNPRINTF _snprintf
 #else
@@ -1556,28 +1555,18 @@ bool vtkMRMLSequenceBrowserNode::ValidateFormatString(std::string& validatedForm
                                                              const std::string& requestedFormat, const std::string& typeString)
 {
   // This regex finds sprintf specifications. Only the first is used to format the index value
-  std::regex specifierRegex;
-  std::smatch specifierMatch;
-  try
-    {
-    // Regex from: https://stackoverflow.com/a/8915445
-    specifierRegex = std::regex(R"###(%(?:\d+\$)?[+-]?(?:[ 0]|'.{1})?-?\d*(?:\.\d+)?[)###" + typeString + "]");
-    std::regex_search(requestedFormat, specifierMatch, specifierRegex);
-    }
-  catch (const std::regex_error& e)
-    {
-    vtkErrorWithObjectMacro(nullptr, "Sequence browser regex error " << e.what());
-    return false;
-    }
-
-  if (specifierMatch.size() < 1)
+  // Regex from: https://stackoverflow.com/a/8915445
+  std::string regexString = "%([0-9]\$)?[+-]?([ 0]|'.{1})?-?[0-9]*(\.[0-9]+)?[" + typeString + "]";
+  vtksys::RegularExpression specifierRegex = vtksys::RegularExpression(regexString);
+  vtksys::RegularExpressionMatch specifierMatch;
+  if (!specifierRegex.find(requestedFormat.c_str(), specifierMatch))
     {
     return false;
     }
 
-  validatedFormat = specifierMatch.str(0);
-  prefix = specifierMatch.prefix().str();
-  suffix = specifierMatch.suffix().str();
+  validatedFormat = specifierMatch.match(0);
+  prefix = requestedFormat.substr(0, specifierMatch.start());
+  suffix = requestedFormat.substr(specifierMatch.end(), requestedFormat.length() - specifierMatch.end());
   return true;
 }
 


### PR DESCRIPTION
std::regex was causing a bad alloc error with the updated gcc compiler.
To fix the error, the regex used for format string validation is switched from std::regex to kwsys.

Re: #6011