### PR TITLE
Update Slicer python to 3.9.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ mark_as_superbuild(Slicer_REQUIRED_QT_VERSION)
 # Python requirements
 #-----------------------------------------------------------------------------
 if(NOT DEFINED Slicer_REQUIRED_PYTHON_VERSION)
-  set(Slicer_REQUIRED_PYTHON_VERSION "3.6.7")
+  set(Slicer_REQUIRED_PYTHON_VERSION "3.9.10")
 endif()
 mark_as_superbuild(Slicer_REQUIRED_PYTHON_VERSION)
 

--- a/SuperBuild/External_LibFFI.cmake
+++ b/SuperBuild/External_LibFFI.cmake
@@ -1,0 +1,80 @@
+
+set(proj LibFFI)
+
+# Set dependency list
+set(${proj}_DEPENDENCIES "")
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
+
+if(Slicer_USE_SYSTEM_${proj})
+  unset(LibFFI_INCLUDE_DIR CACHE)
+  find_path(LibFFI_INCLUDE_DIR ffi.h)
+
+  unset(LibFFI_LIBRARY CACHE)
+  find_library(LibFFI_LIBRARY NAMES ffi libffi)
+endif()
+
+# Sanity checks
+if(DEFINED ${proj}_DIR AND NOT EXISTS ${${proj}_DIR})
+  message(FATAL_ERROR "${proj}_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+  set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_REPOSITORY
+    "${EP_GIT_PROTOCOL}://github.com/python-cmake-buildsystem/libffi.git"
+    QUIET
+    )
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_TAG
+    "cb4a78e39009646935badbeddb48d54c1fe97d63" # libffi-cmake-buildsystem-v3.4.2-2021-06-28-f9ea416
+    QUIET
+    )
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${Slicer_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    INSTALL_DIR ${EP_INSTALL_DIR}
+    CMAKE_CACHE_ARGS
+      # Compiler settings
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      # Install directories
+      -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+    )
+
+  ExternalProject_GenerateProjectDescription_Step(${proj})
+
+  set(LibFFI_DIR ${EP_INSTALL_DIR})
+  set(LibFFI_INCLUDE_DIR ${LibFFI_DIR}/include)
+  if(WIN32)
+    set(LibFFI_LIBRARY ${LibFFI_DIR}/lib/ffi_static.lib)
+  else()
+    set(LibFFI_LIBRARY ${LibFFI_DIR}/lib/libffi.a)
+  endif()
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDENCIES})
+endif()
+
+mark_as_superbuild(
+  VARS
+    LibFFI_INCLUDE_DIR:PATH
+    LibFFI_LIBRARY:FILEPATH
+  LABELS "FIND_PACKAGE"
+  )
+
+ExternalProject_Message(${proj} "LibFFI_INCLUDE_DIR:${LibFFI_INCLUDE_DIR}")
+ExternalProject_Message(${proj} "LibFFI_LIBRARY:${LibFFI_LIBRARY}")
+

--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -41,24 +41,24 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pydicom]
-  pydicom==2.2.1 --hash=sha256:444b5b7289135ff5ea76dfc69d3597dcfde1cd050ca387f709d777f35701242d
+  pydicom==2.2.2 --hash=sha256:6ecb9c6d56a20b2104099b8ef8fe0f3664d797b08a0e0548fe0311b515b32308
   # [/pydicom]
-  # [Pillow]
-  # Hashes correspond to the following packages:
-  #  - Pillow-8.3.2-cp36-cp36m-macosx_10_10_x86_64.whl
-  #  - Pillow-8.3.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - Pillow-8.3.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - Pillow-8.3.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-  #  - Pillow-8.3.2-cp36-cp36m-win_amd64.whl
-  Pillow==8.3.2 --hash=sha256:11eb7f98165d56042545c9e6db3ce394ed8b45089a67124298f0473b29cb60b2 \
-                --hash=sha256:2f23b2d3079522fdf3c09de6517f625f7a964f916c956527bed805ac043799b8 \
-                --hash=sha256:e5a31c07cea5edbaeb4bdba6f2b87db7d3dc0f446f379d907e51cc70ea375629 \
-                --hash=sha256:8f284dc1695caf71a74f24993b7c7473d77bc760be45f776a2c2f4e04c170550 \
-                --hash=sha256:a048dad5ed6ad1fad338c02c609b862dfaa921fcd065d747194a6805f91f2196
-  # [/Pillow]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   # [/six]
+  # [Pillow]
+  # Hashes correspond to the following packages:
+  #  - Pillow-8.4.0-cp39-cp39-macosx_10_10_x86_64.whl
+  #  - Pillow-8.4.0-cp39-cp39-macosx_11_0_arm64.whl
+  #  - Pillow-8.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - Pillow-8.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - Pillow-8.4.0-cp39-cp39-win_amd64.whl
+  Pillow==8.4.0 --hash=sha256:5503c86916d27c2e101b7f71c2ae2cddba01a2cf55b8395b0255fd33fa4d1f1a \
+                --hash=sha256:4acc0985ddf39d1bc969a9220b51d94ed51695d455c228d8ac29fcdb25810e6e \
+                --hash=sha256:0b052a619a8bfcf26bd8b3f48f45283f9e977890263e4571f2393ed8898d331b \
+                --hash=sha256:b8831cb7332eda5dc89b21a7bce7ef6ad305548820595033a4b03cf3091235ed \
+                --hash=sha256:3eb1ce5f65908556c2d8685a8f0a6e989d887ec4057326f6c22b24e8a172c66b
+  # [/Pillow]
   # [retrying]
   retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b
   # [/retrying]

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -33,17 +33,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   nose==1.3.7 --hash=sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac  # needed for NumPy unit tests
   # [/nose]
   # [numpy]
-  # Hashes correspond to the following packages:
-  #  - numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl
-  #  - numpy-1.19.5-cp36-cp36m-manylinux1_x86_64.whl
-  #  - numpy-1.19.5-cp36-cp36m-manylinux2010_x86_64.whl
-  #  - numpy-1.19.5-cp36-cp36m-manylinux2014_aarch64.whl
-  #  - numpy-1.19.5-cp36-cp36m-win_amd64.whl
-  numpy==1.19.5 --hash=sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff \
-                --hash=sha256:8b5e972b43c8fc27d56550b4120fe6257fdc15f9301914380b27f74856299fea \
-                --hash=sha256:a4646724fba402aa7504cd48b4b50e783296b5e10a524c7a6da62e4a8ac9698d \
-                --hash=sha256:2e55195bc1c6b705bfd8ad6f288b38b11b1af32f3c8289d6c50d47f950c12e76 \
-                --hash=sha256:dbd18bcf4889b720ba13a27ec2f2aac1981bd41203b3a3b27ba7a33f88ae4827
+  #  - numpy-1.21.4-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - numpy-1.21.4-cp39-cp39-macosx_11_0_arm64.whl
+  #  - numpy-1.21.4-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+  #  - numpy-1.21.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - numpy-1.21.4-cp39-cp39-win_amd64.whl
+  numpy==1.21.4 --hash=sha256:c885bfc07f77e8fee3dc879152ba993732601f1f11de248d4f357f0ffea6a6d4 \
+                --hash=sha256:9e6f5f50d1eff2f2f752b3089a118aee1ea0da63d56c44f3865681009b0af162 \
+                --hash=sha256:c74c699b122918a6c4611285cc2cad4a3aafdb135c22a16ec483340ef97d573c \
+                --hash=sha256:9864424631775b0c052f3bd98bc2712d131b3e2cd95d1c0c68b91709170890b0 \
+                --hash=sha256:e3c3e990274444031482a31280bf48674441e0a5b55ddb168f3a6db3e0c38ec8
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==21.2.4 --hash=sha256:fa9ebb85d3fd607617c0c44aca302b1b45d87f9c2a1649b46c26167ca4296323
+  pip==21.3.1 --hash=sha256:deaf32dcd9ab821e359cd8330786bcd077604b5c5730c0b096eda46f95c24a2d
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -31,14 +31,14 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [scipy]
   # Hashes correspond to the following packages:
-  #  - scipy-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl
-  #  - scipy-1.5.4-cp36-cp36m-manylinux1_x86_64.whl
-  #  - scipy-1.5.4-cp36-cp36m-manylinux2014_aarch64.whl
-  #  - scipy-1.5.4-cp36-cp36m-win_amd64.whl
-  scipy==1.5.4 --hash=sha256:4f12d13ffbc16e988fa40809cbbd7a8b45bc05ff6ea0ba8e3e41f6f4db3a9e47 \
-               --hash=sha256:368c0f69f93186309e1b4beb8e26d51dd6f5010b79264c0f1e9ca00cd92ea8c9 \
-               --hash=sha256:4598cf03136067000855d6b44d7a1f4f46994164bcd450fb2c3d481afc25dd06 \
-               --hash=sha256:65923bc3809524e46fb7eb4d6346552cbb6a1ffc41be748535aa502a2e3d3389
+  #  - scipy-1.7.2-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - scipy-1.7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - scipy-1.7.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - scipy-1.7.2-cp39-cp39-win_amd64.whl
+  scipy==1.7.2 --hash=sha256:1ea6233f5a365cb7945b4304bd06323ece3ece85d6a3fa8598d2f53e513467c9 \
+               --hash=sha256:2d25272c03ee3c0fe5e0dff1bb7889280bb6c9e1766fa9c7bde81ad8a5f78694 \
+               --hash=sha256:5273d832fb9cd5724ee0d335c16a903b923441107dd973d27fc4293075a9f4e3 \
+               --hash=sha256:a80eb01c43fd98257ec7a49ff5cec0edba32031b5f86503f55399a48cb2c5379
   # [/scipy]
   ]===])
 

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==58.1.0 --hash=sha256:7324fd4b66efa05cdfc9c89174573a4410acc7848f318cc0565c7fb659dfdc81
+  setuptools==58.5.3 --hash=sha256:a481fbc56b33f5d8f6b33dce41482e64c68b668be44ff42922903b03872590bf
   # [/setuptools]
   ]===])
 

--- a/SuperBuild/External_python.cmake
+++ b/SuperBuild/External_python.cmake
@@ -9,6 +9,7 @@ if(NOT Slicer_USE_SYSTEM_python)
   list(APPEND ${proj}_DEPENDENCIES
     bzip2
     CTKAPPLAUNCHER
+    LibFFI
     LZMA
     zlib
     sqlite
@@ -50,8 +51,8 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
 
   set(python_SOURCE_DIR "${CMAKE_BINARY_DIR}/Python-${Slicer_REQUIRED_PYTHON_VERSION}")
 
-  set(_download_3.6.7_url "https://www.python.org/ftp/python/3.6.7/Python-3.6.7.tgz")
-  set(_download_3.6.7_md5 "c83551d83bf015134b4b2249213f3f85")
+  set(_download_3.9.10_url "https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tgz")
+  set(_download_3.9.10_md5 "1440acb71471e2394befdb30b1a958d1")
 
   ExternalProject_Add(python-source
     URL ${_download_${Slicer_REQUIRED_PYTHON_VERSION}_url}
@@ -122,7 +123,7 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "1feb43e4bb2f3461747487a85234bdd9839d44e3"
+    "bb45aa7a4cfc7a5a93bc490c6158f702d1a2226f"
     QUIET
     )
 
@@ -161,6 +162,8 @@ if((NOT DEFINED PYTHON_INCLUDE_DIR
       -DLZMA_LIBRARY:FILEPATH=${LZMA_LIBRARY}
       -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
       -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}
+      -DLibFFI_INCLUDE_DIR:PATH=${LibFFI_INCLUDE_DIR}
+      -DLibFFI_LIBRARY:FILEPATH=${LibFFI_LIBRARY}
       -DSQLite3_INCLUDE_DIR:PATH=${sqlite_INCLUDE_DIR}
       -DSQLite3_LIBRARY:FILEPATH=${sqlite_LIBRARY}
       -DENABLE_SSL:BOOL=${PYTHON_ENABLE_SSL}


### PR DESCRIPTION
Most part of the work was done on project python-cmake-buildsystem. I've opened a [PR](https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/282) over there as well. This current PR is linking to the commit on the tip of the branch over there. I've based my work on a branch by colleagues including @jcfr @dbrnz Dan Dees. Thank you. 

Updating to 3.9 was preferred to 3.10 as discussed on #5014 

Summary of changes:

1. Added libffi as a dependency to build python and use it as an external lib. We need to check if it works on other environments as well. It should, because I've only configured to set the include dirs and lib variables. It is hosted on my personal github for now. I don't mind keeping it there forever, but if you think we should move to anywhere else feel free to suggest modifications. ffi is needed by ctypes which dropped the sources of ffi sometime in the past few years.
2. Added a script to set the dll search dirs, as of python > 3.8  does not search the PATH anymore for dlls, so we need to explicitly call os.add_dll_directory on windows. I've done that by installing a script at python-install/bin and calling this script every time there is the need to install libs. Also the applauncher sets the PYTHONSTARTUP as the mentioned script and sets the LibraryPaths as an environment variable to be passed to python so the script knows what to add to the dll search path.
3. Updated python packages
4. Updated python version wherever I could find a reference to 3.6.x, 3.6 or 36
5. Fixed a bug on defining the zlib include dirs and lib path