### PR TITLE
BUG: Fix Segment table update for Segmentation replay in Sequences

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.cxx
@@ -235,7 +235,9 @@ void vtkMRMLSegmentationNode::SetAndObserveSegmentation(vtkSegmentation* segment
       this->Segmentation, vtkSegmentation::RepresentationModified, this, this->SegmentationModifiedCallbackCommand);
     vtkEventBroker::GetInstance()->AddObservation(
       this->Segmentation, vtkSegmentation::SegmentsOrderModified, this, this->SegmentationModifiedCallbackCommand);
-  }
+    }
+
+  this->InvokeCustomModifiedEvent(vtkMRMLSegmentationNode::SegmentationChangedEvent);
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLSegmentationNode.h
+++ b/Libs/MRML/Core/vtkMRMLSegmentationNode.h
@@ -291,9 +291,11 @@ public:
   vtkMRMLColorTableNode* GetLabelmapConversionColorTableNode();
 
   /// ReferenceImageGeometryChangedEvent is fired when the ReferenceImageGeometry node reference is Added, Modified, or Removed
+  /// SegmentationChangedEvent is fired when a different vtkSegmentation object is set into the node.
   enum
   {
-    ReferenceImageGeometryChangedEvent = 23000
+    ReferenceImageGeometryChangedEvent = 23000,
+    SegmentationChangedEvent
   };
 
 protected:

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -1270,9 +1270,16 @@ void qMRMLSegmentEditorWidget::updateWidgetFromMRML()
   d->SurfaceSmoothingSlider->blockSignals(wasBlocked);
 
   QString selectedSegmentID;
-  if (d->ParameterSetNode->GetSelectedSegmentID())
+  if (d->ParameterSetNode->GetSelectedSegmentID() && strcmp(d->ParameterSetNode->GetSelectedSegmentID(), "") != 0)
     {
     selectedSegmentID = QString(d->ParameterSetNode->GetSelectedSegmentID());
+
+    // Check if selected segment ID is invalid.
+    if (!d->SegmentationNode->GetSegmentation()
+      || d->SegmentationNode->GetSegmentation()->GetSegmentIndex(d->ParameterSetNode->GetSelectedSegmentID()) < 0)
+      {
+      selectedSegmentID.clear();
+      }
     }
 
   // Disable adding new segments until master volume is set (or reference geometry is specified for the segmentation).

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
@@ -241,6 +241,7 @@ void qMRMLSegmentsModel::setSegmentationNode(vtkMRMLSegmentationNode* segmentati
     d->SegmentationNode->AddObserver(vtkSegmentation::SegmentModified, d->CallBack, -10.0);
     d->SegmentationNode->AddObserver(vtkSegmentation::SegmentsOrderModified, d->CallBack, -15.0);
     d->SegmentationNode->AddObserver(vtkMRMLDisplayableNode::DisplayModifiedEvent, d->CallBack, -15.0);
+    d->SegmentationNode->AddObserver(vtkMRMLSegmentationNode::SegmentationChangedEvent, d->CallBack);
     }
 }
 
@@ -344,6 +345,8 @@ void qMRMLSegmentsModel::rebuildFromSegments()
 {
   Q_D(qMRMLSegmentsModel);
 
+  this->beginResetModel();
+
   // Enabled so it can be interacted with
   this->invisibleRootItem()->setFlags(Qt::ItemIsEnabled);
 
@@ -362,6 +365,8 @@ void qMRMLSegmentsModel::rebuildFromSegments()
     {
     d->insertSegment(QString::fromStdString(segmentID));
     }
+
+  this->endResetModel();
 }
 
 //------------------------------------------------------------------------------
@@ -774,6 +779,9 @@ void qMRMLSegmentsModel::onEvent(
       break;
     case vtkMRMLDisplayableNode::DisplayModifiedEvent:
       model->onDisplayNodeModified();
+      break;
+    case vtkMRMLSegmentationNode::SegmentationChangedEvent:
+      model->rebuildFromSegments();
       break;
     }
 }

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsTableView.h
@@ -210,6 +210,10 @@ protected slots:
   /// Update the filter parameters in the vtkMRMLSegmentationNode
   void updateMRMLFromFilterParameters();
 
+  /// Signals to save/restore segment ID selection when the model is reset
+  void modelAboutToBeReset();
+  void modelReset();
+
 protected:
   /// Convenience function to set segment visibility options from event handlers
   /// \sa onVisibilityButtonToggled \sa onVisibility3DActionToggled \sa onVisibility2DFillActionToggled \sa onVisibility2DOutlineActionToggled


### PR DESCRIPTION
When vtkMRMLSegmentationNode were copied from recorded sequences, no events were emitted that would cause the table to update. This commit adds SegmentationChangedEvent to vtkMRMLSegmentationNode, which is triggered whenever the vtkSegmentation object is changed. If the event is observed by qMRMLSegmentsModel, it will trigger a reset of the model.

This commit also makes some changes to qMRMLSegmentsTableView and qMRMLSegmentEditorWidget to ensure that the widget states are consistent during Segmentation node Sequence replay.

Fixes #5953