### PR TITLE
BUG: Fix markups toolbar node selector not using specific node label

### DIFF
--- a/Libs/MRML/Core/vtkMRMLNode.h
+++ b/Libs/MRML/Core/vtkMRMLNode.h
@@ -325,6 +325,14 @@ public:
   /// \note Subclasses should implement this method.
   virtual const char* GetNodeTagName() = 0;
 
+  /// Get node type display name (like "Closed Curve", "Markup", etc).
+  ///
+  /// \note Subclasses should override this method to provide a more appropriate and translatable name.
+  virtual const char* GetTypeDisplayName()
+  {
+    return this->GetNodeTagName();
+  }
+
   /// \brief Set a name value pair attribute.
   ///
   /// Fires a vtkCommand::ModifiedEvent.

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -640,6 +640,24 @@ const char* vtkMRMLScene::GetTagByClassName(const char *className)
 }
 
 //------------------------------------------------------------------------------
+const char* vtkMRMLScene::GetTypeDisplayNameByClassName(const char *className)
+{
+  if ( !className )
+    {
+    vtkErrorMacro("GetTypeDisplayNameByClassName: className is null");
+    return nullptr;
+    }
+  for (unsigned int i=0; i<this->RegisteredNodeClasses.size(); i++)
+    {
+    if (!strcmp(this->RegisteredNodeClasses[i]->GetClassName(), className))
+      {
+      return (this->RegisteredNodeClasses[i])->GetTypeDisplayName();
+      }
+    }
+  return nullptr;
+}
+
+//------------------------------------------------------------------------------
 vtkCollection* vtkMRMLScene::GetNodes()
 {
   return this->Nodes;

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -164,6 +164,9 @@ public:
   /// Add a path to the list.
   const char* GetTagByClassName(const char *className);
 
+  /// Get type display name which is shown in the GUI.
+  const char* GetTypeDisplayNameByClassName(const char *className);
+
   /// Set a default node for node creation and reset.
   /// One default node can be specified for each node class.
   /// It is useful for overriding default values that are set in a node's constructor.

--- a/Libs/MRML/Core/vtkMRMLScene.h
+++ b/Libs/MRML/Core/vtkMRMLScene.h
@@ -158,6 +158,15 @@ public:
   /// \sa RegisterNodeClass(vtkMRMLNode* node, const char* tagName)
   void RegisterNodeClass(vtkMRMLNode* node);
 
+  /// \brief Register abstract node type display name.
+  ///
+  /// This is used by GetTypeDisplayNameByClassName for an abstract class (Volume, Markups, etc),
+  /// for example in a node selector. Since abstract base classes cannot be instantiated, RegisterNodeClass
+  /// cannot be used for this purpose.
+  ///
+  /// \sa RegisterNodeClass(vtkMRMLNode* node), GetTypeDisplayNameByClassName
+  void RegisterAbstractNodeClass(std::string className, std::string typeDisplayName);
+
   /// Add a path to the list.
   const char* GetClassNameByTag(const char *tagName);
 
@@ -165,7 +174,7 @@ public:
   const char* GetTagByClassName(const char *className);
 
   /// Get type display name which is shown in the GUI.
-  const char* GetTypeDisplayNameByClassName(const char *className);
+  std::string GetTypeDisplayNameByClassName(std::string className);
 
   /// Set a default node for node creation and reset.
   /// One default node can be specified for each node class.
@@ -337,6 +346,17 @@ public:
   ///
   /// \sa RegisterNodeClass(vtkMRMLNode* node)
   bool IsNodeClassRegistered(const std::string& className);
+
+  /// Get the number of registered abstract node classes
+  int GetNumberOfRegisteredAbstractNodeClasses();
+
+  /// Get the nth registered abstract node class name.
+  /// Returns empty string if out of range.
+  std::string GetNthRegisteredAbstractNodeClassName(int n);
+
+  /// Get the nth registered abstract node type display name.
+  /// Returns empty string if out of range.
+  std::string GetNthRegisteredAbstractNodeTypeDisplayName(int n);
 
   /// \brief Generate a node name that is unique in the scene.
   /// Calling this function successively with the same baseName returns a
@@ -656,6 +676,7 @@ public:
     NodeAddedEvent,
     NodeAboutToBeRemovedEvent,
     NodeRemovedEvent,
+    NodeClassRegisteredEvent,
 
     NewSceneEvent = 66030,
     MetadataAddedEvent = 66032, // ### Slicer 4.5: Simplify - Do not explicitly set for backward compat. See issue #3472
@@ -917,6 +938,7 @@ protected:
 
   std::vector< vtkMRMLNode* > RegisteredNodeClasses;
   std::vector< std::string >  RegisteredNodeTags;
+  std::map< std::string, std::string > RegisteredAbstractNodeClassTypeDisplayNames; // map class name to type display name
 
   NodeReferencesType NodeReferences; // ReferencedIDs (string), ReferencingNodes (node pointer)
   std::map< std::string, std::string > ReferencedIDChanges;

--- a/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox.cxx
@@ -562,7 +562,7 @@ QString qMRMLNodeComboBox::nodeTypeLabel(const QString& nodeType)const
   // Otherwise use the node tag
   if (this->mrmlScene())
     {
-    QString label = this->mrmlScene()->GetTagByClassName(nodeType.toUtf8());
+    QString label = this->mrmlScene()->GetTypeDisplayNameByClassName(nodeType.toUtf8());
     if (!label.isEmpty())
       {
       return label;

--- a/Libs/MRML/Widgets/qMRMLNodeComboBox_p.h
+++ b/Libs/MRML/Widgets/qMRMLNodeComboBox_p.h
@@ -41,6 +41,8 @@ class QComboBox;
 class qMRMLNodeFactory;
 class qMRMLSceneModel;
 
+#include "vtkCallbackCommand.h"
+#include "vtkSmartPointer.h"
 #include "vtkWeakPointer.h"
 
 // -----------------------------------------------------------------------------
@@ -66,6 +68,8 @@ public:
 
   bool hasPostItem(const QString& name)const;
 
+  static void onMRMLSceneEvent(vtkObject* vtk_obj, unsigned long event, void* client_data, void* call_data);
+
   QComboBox*        ComboBox;
   qMRMLNodeFactory* MRMLNodeFactory;
   qMRMLSceneModel*  MRMLSceneModel;
@@ -75,6 +79,9 @@ public:
   bool              EditEnabled;
   bool              RenameEnabled;
   QString           InteractionNodeSingletonTag;
+
+  vtkWeakPointer<vtkMRMLScene> MRMLScene;
+  vtkSmartPointer<vtkCallbackCommand> CallBack;
 
   QHash<QString, QString> NodeTypeLabels;
 

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -358,7 +358,7 @@ void vtkSlicerMarkupsLogic::RegisterNodes()
   vtkMRMLScene *scene = this->GetMRMLScene();
 
   // Nodes
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsNode>::New());
+  scene->RegisterAbstractNodeClass("vtkMRMLMarkupsNode", "Markup");
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsFiducialNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsLineNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsAngleNode>::New());

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsAngleNode.h
@@ -69,7 +69,7 @@ public:
   const char* GetMarkupType() override {return "Angle";};
 
   // Get markup type GUI display name
-  const char* GetMarkupTypeDisplayName() override {return "Angle";};
+  const char* GetTypeDisplayName() override {return "Angle";};
 
   /// Get markup short name
   const char* GetDefaultNodeNamePrefix() override {return "A";};

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsClosedCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsClosedCurveNode.h
@@ -55,7 +55,7 @@ public:
   const char* GetMarkupType() override {return "ClosedCurve";};
 
   // Get markup type GUI display name
-  const char* GetMarkupTypeDisplayName() override {return "Closed Curve";};
+  const char* GetTypeDisplayName() override {return "Closed Curve";};
 
   /// Get markup short name
   const char* GetDefaultNodeNamePrefix() override {return "CC";};

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -110,7 +110,7 @@ public:
   const char* GetMarkupType() override {return "Curve";};
 
   // Get markup type GUI display name
-  const char* GetMarkupTypeDisplayName() override {return "Curve";};
+  const char* GetTypeDisplayName() override {return "Curve";};
 
   /// Get markup short name
   const char* GetDefaultNodeNamePrefix() override {return "OC";};

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -60,7 +60,7 @@ public:
   const char* GetMarkupType() override {return "Fiducial";};
 
   // Get markup type GUI display name
-  const char* GetMarkupTypeDisplayName() override {return "Point List";};
+  const char* GetTypeDisplayName() override {return "Point List";};
 
   /// Get markup short name
   const char* GetDefaultNodeNamePrefix() override {return "F";};

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.h
@@ -57,7 +57,7 @@ public:
   const char* GetMarkupType() override {return "Line";};
 
   // Get markup type GUI display name
-  const char* GetMarkupTypeDisplayName() override {return "Line";};
+  const char* GetTypeDisplayName() override {return "Line";};
 
   /// Get markup short name
   const char* GetDefaultNodeNamePrefix() override {return "L";};

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -59,9 +59,6 @@
 #include <algorithm>
 
 //----------------------------------------------------------------------------
-vtkMRMLNodeNewMacro(vtkMRMLMarkupsNode);
-
-//----------------------------------------------------------------------------
 vtkMRMLMarkupsNode::vtkMRMLMarkupsNode()
 {
   this->TextList = vtkSmartPointer<vtkStringArray>::New();

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -36,27 +36,31 @@ class vtkMatrix3x3;
 class vtkMRMLUnitNode;
 class vtkParallelTransportFrame;
 
-/// \brief MRML node to represent an interactive widget.
-/// MarkupsNodes contains a list of points (ControlPoint).
-/// Each markupNode is defined by a certain number of control points:
-/// N for fiducials, 2 for rulers, 3 for angles and N for curves.
-/// MarkupNodes are strictly connected with the VTKWidget representations. For each
-/// MarkupNode there is a representation in each view. The representations are handled
-/// by the VTKWidget (there is one widget for each MRMLMarkupsNode per view).
+/// \brief Abstract base class to represent an interactive widget.
+///
+/// Markups nodes contains a list of points (ControlPoint).
+/// Each markups node is defined by a certain number of control points:
+/// N for fiducials (point lists) and curves, 2 for rulers, 3 for angles.
+/// Each ControlPoint has a unique ID, position, orientation, .
+/// an associated node id (set when the ControlPoint is placed to the node that was visible
+/// at that position). Position of a control point may be undefined, because it is not placed
+/// yet or because it cannot be placed (e.g., an anatomical landmark point is not visible),
+/// in which cases the position and orientation values of the control point must be ignored.
+///
+/// Each ControlPoint can also be individually un/selected, un/locked, in/visible,
+/// and have a label (short, shown in the viewers) and description (longer, shown in the GUI).
+///
+/// Each markups node is associated with a vtkSlicerMarkupsWidget, which is responsible for
+/// displaying an interactive widget in each view. The representations are handled
+/// by the VTKWidget (there is one widget for each markups node per view).
+///
 /// Visualization parameters for these nodes are controlled by the
 /// vtkMRMLMarkupsDisplayNode class.
-/// Each ControlPoint has a unique ID.
-/// Each ControlPoint has an orientation defined by a by a 4 element vector:
-/// [0] = the angle of rotation in degrees, [1,2,3] = the axis of rotation.
-/// Default is 0.0, 0.0, 0.0, 1.0.
-/// Each ControlPoint also has an associated node id, set when the ControlPoint
-/// is placed on a data set to link the ControlPoint to the volume or model.
-/// Each ControlPoint can also be individually un/selected, un/locked, in/visible,
-/// and have a label (short, shown in the viewers) and description (longer,
-/// shown in the GUI).
+///
 /// Coordinate systems used:
 ///   - Local: Local coordinates
 ///   - World: All parent transforms on node applied to local.
+///
 /// \sa vtkMRMLMarkupsDisplayNode
 /// \ingroup Slicer_QtModules_Markups
 
@@ -129,7 +133,6 @@ public:
 
   typedef std::vector<ControlPoint*> ControlPointsListType;
 
-  static vtkMRMLMarkupsNode *New();
   vtkTypeMacro(vtkMRMLMarkupsNode,vtkMRMLDisplayableNode);
 
   void PrintSelf(ostream& os, vtkIndent indent) override;
@@ -141,10 +144,6 @@ public:
   //--------------------------------------------------------------------------
   // MRMLNode methods
   //--------------------------------------------------------------------------
-
-  vtkMRMLNode* CreateNodeInstance() override;
-  /// Get node XML tag name (like Volume, Model)
-  const char* GetNodeTagName() override {return "Markups";};
 
   /// Get markup type internal name. This type name is the same regardless of the
   /// chosen application language and should not be displayed to end users.

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
@@ -92,7 +92,7 @@ public:
   const char* GetMarkupType() override {return "Plane";};
 
   // Get markup type GUI display name
-  const char* GetMarkupTypeDisplayName() override {return "Plane";};
+  const char* GetTypeDisplayName() override {return "Plane";};
 
   /// Get markup short name
   const char* GetDefaultNodeNamePrefix() override {return "P";};

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
@@ -78,7 +78,7 @@ public:
   const char* GetMarkupType() override {return "ROI";};
 
   // Get markup type GUI display name
-  const char* GetMarkupTypeDisplayName() override {return "ROI";};
+  const char* GetTypeDisplayName() override {return "ROI";};
 
   /// Get markup short name
   const char* GetDefaultNodeNamePrefix() override {return "R";};

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -705,7 +705,7 @@ void qSlicerSubjectHierarchyMarkupsPlugin::showViewContextMenuActionsForItem(vtk
   d->EditNodeTerminologyAction->setVisible(!pointActionsDisabled);
 
   // Update action text with relevant markup type
-  QString markup_type = associatedNode->GetMarkupTypeDisplayName();
+  QString markup_type = associatedNode->GetTypeDisplayName();
   d->DeleteNodeAction->setText("Delete " + markup_type);
   d->EditNodeTerminologyAction->setText("Edit " + markup_type + " terminology...");
 

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
@@ -17,7 +17,7 @@
 
 // MRML includes
 #include "vtkMRMLCoreTestingMacros.h"
-#include "vtkMRMLMarkupsNode.h"
+#include "vtkMRMLMarkupsFiducialNode.h"
 #include "vtkMRMLStaticMeasurement.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLStorageNode.h"
@@ -34,7 +34,7 @@
 
 int vtkMRMLMarkupsNodeTest1(int , char * [] )
 {
-  vtkNew<vtkMRMLMarkupsNode> node1;
+  vtkNew<vtkMRMLMarkupsFiducialNode> node1;
   vtkNew<vtkMRMLScene> scene;
   scene->AddNode(node1.GetPointer());
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest2.cxx
@@ -16,7 +16,7 @@
 ==============================================================================*/
 
 // MRML includes
-#include "vtkMRMLMarkupsNode.h"
+#include "vtkMRMLMarkupsFiducialNode.h"
 
 // VTK includes
 #include <vtkNew.h>
@@ -25,7 +25,7 @@
 // test copy and swap
 int vtkMRMLMarkupsNodeTest2(int , char * [] )
 {
-  vtkNew<vtkMRMLMarkupsNode> node1;
+  vtkNew<vtkMRMLMarkupsFiducialNode> node1;
   vtkIndent indent;
 
   // now try with some data

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest2.cxx
@@ -17,7 +17,7 @@
 
 // MRML includes
 #include "vtkMRMLCoreTestingMacros.h"
-#include "vtkMRMLMarkupsNode.h"
+#include "vtkMRMLMarkupsFiducialNode.h"
 #include "vtkSlicerMarkupsLogic.h"
 
 // VTK includes
@@ -41,8 +41,8 @@ int vtkSlicerMarkupsLogicTest2(int , char * [] )
   vtkNew<vtkSlicerMarkupsLogic> logic1;
 
   // Test moving markups between lists
-  vtkSmartPointer<vtkMRMLMarkupsNode> source = vtkSmartPointer<vtkMRMLMarkupsNode>::New();
-  vtkSmartPointer<vtkMRMLMarkupsNode> dest = vtkSmartPointer<vtkMRMLMarkupsNode>::New();
+  vtkSmartPointer<vtkMRMLMarkupsFiducialNode> source = vtkSmartPointer<vtkMRMLMarkupsFiducialNode>::New();
+  vtkSmartPointer<vtkMRMLMarkupsFiducialNode> dest = vtkSmartPointer<vtkMRMLMarkupsFiducialNode>::New();
 
   // null cases
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -465,7 +465,7 @@ void qMRMLMarkupsToolBar::addNodeActions(vtkSlicerMarkupsLogic* markupsLogic)
       QSignalMapper* mapper = new QSignalMapper(this);
       QPushButton* markupCreateButton = new QPushButton();
       markupCreateButton->setObjectName(QString("Create") + QString(markupsNode->GetMarkupType()) + QString("PushButton"));
-      markupCreateButton->setToolTip("Create " + QString(markupsNode->GetMarkupTypeDisplayName()));
+      markupCreateButton->setToolTip("Create " + QString(markupsNode->GetTypeDisplayName()));
       markupCreateButton->setIcon(QIcon(markupsNode->GetPlaceAddIcon()));
       this->addWidget(markupCreateButton);
       QObject::connect(markupCreateButton, SIGNAL(clicked()), mapper, SLOT(map()));

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -89,7 +89,7 @@ void qMRMLMarkupsToolBarPrivate::init()
   this->MarkupsNodeSelector->setAddEnabled(false);
   this->MarkupsNodeSelector->setRenameEnabled(true);
   this->MarkupsNodeSelector->setEditEnabled(true);
-  this->MarkupsNodeSelector->setMaximumWidth(150);
+  this->MarkupsNodeSelector->setMaximumWidth(165);
   this->MarkupsNodeSelector->setEnabled(true);
   this->MarkupsNodeSelector->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
   this->MarkupsNodeSelector->setToolTip("Select active markup");

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -801,8 +801,8 @@ void qSlicerMarkupsModuleWidgetPrivate::createMarkupsPushButtons()
                                             QString("PushButton"));
       markupCreatePushButton->setIcon(QIcon(markupsNode->GetPlaceAddIcon()));
       markupCreatePushButton->setToolTip(QString("Create ") +
-                                         QString(markupsNode->GetMarkupTypeDisplayName()));
-      markupCreatePushButton->setText(QString(markupsNode->GetMarkupTypeDisplayName()));
+                                         QString(markupsNode->GetTypeDisplayName()));
+      markupCreatePushButton->setText(QString(markupsNode->GetTypeDisplayName()));
       layout->addWidget(markupCreatePushButton,
                         i / this->createMarkupsButtonsColumns,
                         i % this->createMarkupsButtonsColumns);

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -1993,7 +1993,12 @@ void qSlicerMarkupsModuleWidget::onResetNameFormatToDefaultPushButtonClicked()
     this->mrmlScene()->GetDefaultNodeByClass(d->MarkupsNode->GetClassName()));
   if (!defaultNode)
     {
-    defaultNode = vtkSmartPointer<vtkMRMLMarkupsNode>::New();
+    defaultNode = vtkSmartPointer<vtkMRMLMarkupsNode>::Take(vtkMRMLMarkupsNode::SafeDownCast(
+      this->mrmlScene()->CreateNodeByClass(d->MarkupsNode->GetClassName())));
+    }
+  if (!defaultNode)
+    {
+    qCritical() << Q_FUNC_INFO << " failed: invalid default markups node";
     }
   d->MarkupsNode->SetMarkupLabelFormat(defaultNode->GetMarkupLabelFormat());
 }

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/MRML/vtkMRMLMarkupsTestLineNode.h
@@ -50,7 +50,7 @@ public:
   const char* GetMarkupType() override {return "TestLine";}
 
   // Get markup type GUI display name
-  const char* GetMarkupTypeDisplayName() override {return "Test Line";};
+  const char* GetTypeDisplayName() override {return "Test Line";};
 
   /// Get markup short name
   const char* GetDefaultNodeNamePrefix() override {return "SC";}


### PR DESCRIPTION
The markups toolbar node selector was not getting a specific nodeTypeLabel from GetTagByClassName so it was just using the fallback "node" term.

| Current | This PR |
|----------|----------|
| ![image](https://user-images.githubusercontent.com/15837524/142306753-193a54f0-bd83-4802-b715-0b126687e628.png)| ![image](https://user-images.githubusercontent.com/15837524/142306621-aa19ea64-6929-4e8e-a84f-f1bbc2f32fa5.png)|

It is weird that `GetTagByClassName("vtkMRMLMarkupsNode")` is returning an empty string during startup which is why it was proceeding to the end of `qMRMLNodeComboBox::nodeTypeLabel()` to then get the "node" term. I would have expected it to get the node tag name of "Markups" (as seen below). I'm assuming it has something to do with the creation of the Markups ToolBar prior to the markups nodes being registered where it just doesn't know what "vtkMRMLMarkupsNode" is yet. Maybe something weird with "Volumes" is similar which is why there is that same type special case of "Volume" specified at the end of `nodeTypeLabel()`.
https://github.com/Slicer/Slicer/blob/19ed4f21a6bc3b17b418d49174080b4dea49908f/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h#L146-L147

I'm not using what GetNodeTagName would return unlike other nodes as it would produce statements such as "Select a Markups" which is weird since  "Markups" is a plural term and "Select a" expects to have a singular term like "Markup" to follow it.