### PR TITLE
BUG: Unblock segment table signals when no Segmentation node is set

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentsModel.cxx
@@ -355,6 +355,7 @@ void qMRMLSegmentsModel::rebuildFromSegments()
 
   if (!d->SegmentationNode)
     {
+    this->endResetModel();
     return;
     }
 


### PR DESCRIPTION
If no Segmentation node was set, endResetModel() was not called. This left the table signals blocked, since qMRMLSegmentsTableView::modelReset() was not triggered.