### PR TITLE
BUG: Fix Markups ROI visibility when all control points are removed

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
@@ -517,7 +517,7 @@ void vtkMRMLMarkupsROINode::SetROIType(int roiType)
     {
     case vtkMRMLMarkupsROINode::ROITypeBox:
       this->RequiredNumberOfControlPoints = NUMBER_OF_BOX_CONTROL_POINTS;
-      this->MaximumNumberOfControlPoints = -1;
+      this->MaximumNumberOfControlPoints = NUMBER_OF_BOX_CONTROL_POINTS;
       break;
     case vtkMRMLMarkupsROINode::ROITypeBoundingBox:
       this->RequiredNumberOfControlPoints = NUMBER_OF_BOUNDING_BOX_CONTROL_POINTS;
@@ -738,6 +738,7 @@ void vtkMRMLMarkupsROINode::UpdateBoxROIFromControlPoints()
   int numberOfControlPoints = this->GetNumberOfControlPoints();
   if (numberOfControlPoints == 0)
     {
+    this->SetSize(0.0,  0.0, 0.0);
     return;
     }
 
@@ -793,6 +794,7 @@ void vtkMRMLMarkupsROINode::UpdateBoxROIFromControlPoints()
     }
   else if (this->GetNumberOfDefinedControlPoints() == 0)
     {
+    this->RequiredNumberOfControlPoints = NUMBER_OF_BOX_CONTROL_POINTS;
     this->MaximumNumberOfControlPoints = NUMBER_OF_BOX_CONTROL_POINTS;
     }
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
@@ -122,6 +122,9 @@ void vtkSlicerROIRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigned 
       return;
     }
 
+  this->ROIActor->SetVisibility(roiNode->GetNumberOfControlPoints() > 0 && this->MarkupsDisplayNode->GetFillVisibility());
+  this->ROIOutlineActor->SetVisibility(roiNode->GetNumberOfControlPoints() > 0 && this->MarkupsDisplayNode->GetOutlineVisibility());
+
   this->ROIToWorldTransform->SetMatrix(roiNode->GetInteractionHandleToWorldMatrix());
 
   int controlPointType = Active;
@@ -132,13 +135,11 @@ void vtkSlicerROIRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigned 
 
   double opacity = this->MarkupsDisplayNode->GetOpacity();
 
-  double fillOpacity = this->MarkupsDisplayNode->GetFillVisibility()
-    ? opacity * this->MarkupsDisplayNode->GetFillOpacity() : 0.0;
+  double fillOpacity = opacity * this->MarkupsDisplayNode->GetFillOpacity();
   this->ROIProperty->DeepCopy(this->GetControlPointsPipeline(controlPointType)->Property);
   this->ROIProperty->SetOpacity(fillOpacity);
 
-  double outlineOpacity = this->MarkupsDisplayNode->GetOutlineVisibility()
-    ? opacity * this->MarkupsDisplayNode->GetOutlineOpacity() : 0.0;
+  double outlineOpacity = opacity * this->MarkupsDisplayNode->GetOutlineOpacity();
   this->ROIOutlineProperty->DeepCopy(this->GetControlPointsPipeline(controlPointType)->Property);
   this->ROIOutlineProperty->SetOpacity(outlineOpacity);
 
@@ -416,6 +417,7 @@ void vtkSlicerROIRepresentation2D::UpdateInteractionPipeline()
     }
 
   this->InteractionPipeline->Actor->SetVisibility(this->MarkupsDisplayNode->GetVisibility()
+    && roiNode->GetNumberOfControlPoints() > 0
     && this->MarkupsDisplayNode->GetVisibility2D()
     && this->MarkupsDisplayNode->GetHandlesInteractive());
 


### PR DESCRIPTION
When all control points were removed from the ROI node, the ROI would remain visible. In addition, attempting to re-place the ROI would only allow one point to be placed.

Fixed visibility issues by disabling the ROI actors if there are no control points.
Fixed the re-placement issue by changing the maximum number of control points from -1 to 2 for "Box" type ROI when all control points were removed.

Fixes #5898