### PR TITLE
DOC: Remove Editor module documentation

### DIFF
--- a/Docs/developer_guide/script_repository/volumes.md
+++ b/Docs/developer_guide/script_repository/volumes.md
@@ -452,7 +452,7 @@ print(point_Ras)
 
 ### Get the values of all voxels for a label value
 
-If you have a background image called ‘Volume’ and a mask called ‘Volume-label’ created with the Editor you could do something like this:
+If you have a background image called ‘Volume’ and a mask called ‘Volume-label’ created with the Segment Editor you could do something like this:
 
 ```python
 import numpy

--- a/Docs/user_guide/modules/data.md
+++ b/Docs/user_guide/modules/data.md
@@ -76,7 +76,7 @@ Operations (accessible in the context menu of the nodes by right-clicking them):
 - Operations for specific node types:
     - **Volumes**: icon, Edit properties and additional information in tooltip
         - **'Register this...'** action to select fixed image for registration. Right-click the moving image to initiate registration
-        - **'Segment this...'** action allows segmenting the volume, for example, in the Editor module
+        - **'Segment this...'** action allows segmenting the volume, for example, in the Segment Editor module
         - **'Toggle labelmap outline display'** for labelmaps
     - **Models**: icon, Edit properties and additional information in tooltip
     - **SceneViews**: icon, Edit properties and Restore scene view

--- a/Docs/user_guide/modules/editor.md
+++ b/Docs/user_guide/modules/editor.md
@@ -1,3 +1,0 @@
-# Editor
-
-This module is deprecated and will be removed from the application. It is replaced by [Segment editor module](segmenteditor.md), which offers many more features and significantly better performance.

--- a/Docs/user_guide/modules/index.md
+++ b/Docs/user_guide/modules/index.md
@@ -159,7 +159,6 @@ extensionwizard.md
 :maxdepth: 1
 annotations.md
 datastore.md
-editor.md
 expertautomatedregistration.md
 labelstatistics.md
 brainslabelstats.md

--- a/Docs/user_guide/modules/segmentations.md
+++ b/Docs/user_guide/modules/segmentations.md
@@ -170,7 +170,6 @@ See Script repository's [Segmentations section](../../developer_guide/script_rep
 ## Related modules
 
 - [Segment Editor](segmenteditor) module is for editing segments of a segmentation node
-- Editor module: the legacy Editor module has been replaced by Segment Editor module.
 
 ## References
 

--- a/Docs/user_guide/modules/segmenteditor.md
+++ b/Docs/user_guide/modules/segmenteditor.md
@@ -12,7 +12,7 @@ To cite the Segment Editor in scientific publications, you can cite [3D Slicer](
 
 ## Keyboard shortcuts
 
-The following keyboard shortcuts are active when you are in the Editor module.  They are intended to allow two-handed editing, where on hand is on the mouse and the other hand uses the keyboard to switch modes.
+The following keyboard shortcuts are active when you are in the Segment Editor module.  They are intended to allow two-handed editing, where on hand is on the mouse and the other hand uses the keyboard to switch modes.
 
 | Key                       | Operation                              |
 | ------------------------- | -------------------------------------- |
@@ -256,7 +256,6 @@ Segment Editor allows editing of segmentation on slices of arbitrary orientation
 - [Segment Statistics](segmentstatistics) module computes volume, surface, mean intensity, and various other metrics for each segment.
 - [Segmentations](segmentations) module allows changing visualization options, exporting/importing segments to/from other nodes (models, labelmap volumes), and moving or copying segments between segmentation nodes.
 - [Data](data) module shows all segmentations and segments in a tree structure. Commonly used operations are available by right-clicking on an item in the tree.
-- Editor module is the predecessor of this module. Segment Editor provides all its features and many more.
 
 ## Information for Developers
 


### PR DESCRIPTION
re #5664

The Editor module was removed in https://github.com/Slicer/Slicer/commit/39283db420baf502fa99865c9d5d58d0e5295a6e. The Segment Editor module was the replacement.