### PR TITLE
ENH: Clean up markups node API

### DIFF
--- a/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
+++ b/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
@@ -17,7 +17,7 @@ class FiducialLayoutSwitchBug1914(ScriptedLoadableModule):
     parent.dependencies = []
     parent.contributors = ["Nicole Aucoin (BWH)"]
     parent.helpText = """
-    Test for bug 1914, misplaced fiducial after switching layouts.
+    Test for bug 1914, misplaced control point after switching layouts.
     """
     parent.acknowledgementText = """
     This file was originally developed by Nicole Aucoin, BWH  and was partially funded by NIH grant 3P41RR013218-12S1.
@@ -47,7 +47,7 @@ class FiducialLayoutSwitchBug1914Logic(ScriptedLoadableModuleLogic):
   def __init__(self):
     ScriptedLoadableModuleLogic.__init__(self)
 
-  def getFiducialSliceDisplayableManagerHelper(self,sliceName='Red'):
+  def getPointSliceDisplayableManagerHelper(self,sliceName='Red'):
     sliceWidget = slicer.app.layoutManager().sliceWidget(sliceName)
     sliceView = sliceWidget.sliceView()
     collection = vtk.vtkCollection()
@@ -98,13 +98,11 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
     import SampleData
     mrHeadVolume = SampleData.downloadSample("MRHead")
 
-    # Place a fiducial on the red slice
-    markupsLogic = slicer.modules.markups.logic()
+    # Place a point on the red slice
     eye = [33.4975, 79.4042, -10.2143]
-    fidIndex = markupsLogic.AddFiducial(eye[0], eye[1], eye[2])
-    fidID = markupsLogic.GetActiveListID()
-    fidNode = slicer.mrmlScene.GetNodeByID(fidID)
-    self.delayDisplay(f"Placed a fiducial at {eye[0]:g}, {eye[1]:g}, {eye[2]:g}")
+    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    markupNode.AddControlPoint(eye)
+    self.delayDisplay(f"Placed a point at {eye[0]:g}, {eye[1]:g}, {eye[2]:g}")
 
     # Pan and zoom
     sliceWidget = slicer.app.layoutManager().sliceWidget('Red')
@@ -117,14 +115,14 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
 
     # Get the seed widget seed location
     startingSeedDisplayCoords = [0.0, 0.0, 0.0]
-    helper = logic.getFiducialSliceDisplayableManagerHelper('Red')
+    helper = logic.getPointSliceDisplayableManagerHelper('Red')
     if helper is not None:
-     seedWidget = helper.GetWidget(fidNode)
+     seedWidget = helper.GetWidget(markupNode)
      seedRepresentation = seedWidget.GetSeedRepresentation()
      handleRep = seedRepresentation.GetHandleRepresentation(fidIndex)
      startingSeedDisplayCoords = handleRep.GetDisplayPosition()
      print('Starting seed display coords = %d, %d, %d' % (startingSeedDisplayCoords[0], startingSeedDisplayCoords[1], startingSeedDisplayCoords[2]))
-    self.takeScreenshot('FiducialLayoutSwitchBug1914-StartingPosition','Fiducial starting position',slicer.qMRMLScreenShotDialog.Red)
+    self.takeScreenshot('FiducialLayoutSwitchBug1914-StartingPosition','Point starting position',slicer.qMRMLScreenShotDialog.Red)
 
     # Switch to red slice only
     lm.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutOneUpRedSliceView)
@@ -138,14 +136,14 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
 
     # Get the current seed widget seed location
     endingSeedDisplayCoords = [0.0, 0.0, 0.0]
-    helper = logic.getFiducialSliceDisplayableManagerHelper('Red')
+    helper = logic.getPointSliceDisplayableManagerHelper('Red')
     if helper is not None:
-     seedWidget = helper.GetWidget(fidNode)
+     seedWidget = helper.GetWidget(markupNode)
      seedRepresentation = seedWidget.GetSeedRepresentation()
      handleRep = seedRepresentation.GetHandleRepresentation(fidIndex)
      endingSeedDisplayCoords = handleRep.GetDisplayPosition()
      print('Ending seed display coords = %d, %d, %d' % (endingSeedDisplayCoords[0], endingSeedDisplayCoords[1], endingSeedDisplayCoords[2]))
-    self.takeScreenshot('FiducialLayoutSwitchBug1914-EndingPosition','Fiducial ending position',slicer.qMRMLScreenShotDialog.Red)
+    self.takeScreenshot('FiducialLayoutSwitchBug1914-EndingPosition','Point ending position',slicer.qMRMLScreenShotDialog.Red)
 
     # Compare to original seed widget location
     diff = math.pow((startingSeedDisplayCoords[0] - endingSeedDisplayCoords[0]),2) + math.pow((startingSeedDisplayCoords[1] - endingSeedDisplayCoords[1]),2) + math.pow((startingSeedDisplayCoords[2] - endingSeedDisplayCoords[2]),2)
@@ -158,12 +156,12 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
       sliceView = sliceWidget.sliceView()
       volumeRAS = sliceView.convertXYZToRAS(endingSeedDisplayCoords)
       seedRAS = [0,0,0]
-      fidNode.GetNthFiducialPosition(0,seedRAS)
+      markupNode.GetNthControlPointPosition(0,seedRAS)
       rasDiff = math.pow((seedRAS[0] - volumeRAS[0]),2) + math.pow((seedRAS[1] - volumeRAS[1]),2) + math.pow((seedRAS[2] - volumeRAS[2]),2)
       if rasDiff != 0.0:
         rasDiff = math.sqrt(rasDiff)
-      print('Checking the difference between fiducial RAS position',seedRAS,
-            'and volume RAS as derived from the fiducial display position',volumeRAS,': ',rasDiff)
+      print('Checking the difference between point RAS position',seedRAS,
+            'and volume RAS as derived from the point display position',volumeRAS,': ',rasDiff)
       if rasDiff > maximumRASDifference:
         raise Exception(f"RAS coordinate difference is too large as well!\nExpected < {maximumRASDifference:g} but got {rasDiff:g}")
       else:
@@ -183,7 +181,7 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
       shotDiff = imageMath.GetOutput()
       # save it as a scene view
       annotationLogic = slicer.modules.annotations.logic()
-      annotationLogic.CreateSnapShot("FiducialLayoutSwitchBug1914-Diff", "Difference between starting and ending fiducial seed positions",
+      annotationLogic.CreateSnapShot("FiducialLayoutSwitchBug1914-Diff", "Difference between starting and ending point positions",
                                      slicer.qMRMLScreenShotDialog.Red, screenshotScaleFactor, shotDiff)
       # calculate the image difference
       imageStats = vtk.vtkImageHistogramStatistics()

--- a/Applications/SlicerApp/Testing/Python/ShaderProperties.py
+++ b/Applications/SlicerApp/Testing/Python/ShaderProperties.py
@@ -104,7 +104,7 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
 
     #------------------------------------------------------
     # Utility functions to get the position of the first
-    # fiducial point in the scene and the shader property
+    # markup line in the scene and the shader property
     # node
     #------------------------------------------------------
     def GetLineEndpoints():
@@ -160,7 +160,7 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
     shaderProp.AddFragmentShaderReplacement("//VTK::Cropping::Impl", True, croppingImplShaderCode, False)
 
     #------------------------------------------------------
-    # Add a callback when the fiducial moves to adjust
+    # Add a callback when the line moves to adjust
     # the endpoints of the carving sphere accordingly
     #------------------------------------------------------
     def onControlPointMoved():
@@ -199,21 +199,21 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
 
     self.delayDisplay('GPU Ray Casting on')
 
-    markupNode = slicer.mrmlScene.AddNode(slicer.vtkMRMLMarkupsFiducialNode())
-    markupNode.AddFiducial(0.0, 100.0, 0.0)
+    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    markupNode.AddControlPoint([0.0, 100.0, 0.0])
 
-    self.delayDisplay('Fiducial added')
+    self.delayDisplay('Point list added')
 
 
     #------------------------------------------------------
     # Utility functions to get the position of the first
-    # fiducial point in the scene and the shader property
+    # markups point list in the scene and the shader property
     # node
     #------------------------------------------------------
-    def GetFiducialPosition():
+    def GetPointPosition():
         fn = slicer.util.getNode('vtkMRMLMarkupsFiducialNode1')
-        p=[0]*3
-        fn.GetNthFiducialPosition(0,p)
+        p = [0.0, 0.0, 0.0]
+        fn.GetNthControlPointPosition(0, p)
         return p
 
     def GetShaderPropertyNode():
@@ -239,8 +239,8 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
     #------------------------------------------------------
     shaderUniforms = shaderPropNode.GetFragmentUniforms()
     shaderUniforms.RemoveAllUniforms()
-    fiducialPos = GetFiducialPosition()
-    shaderUniforms.SetUniform3f("center",fiducialPos)
+    pointPos = GetPointPosition()
+    shaderUniforms.SetUniform3f("center",pointPos)
     shaderUniforms.SetUniformf("radius",50.)
 
     #------------------------------------------------------
@@ -256,16 +256,16 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
     shaderProp.AddFragmentShaderReplacement("//VTK::Cropping::Impl", True, croppingImplShaderCode, False)
 
     #------------------------------------------------------
-    # Add a callback when the fiducial moves to adjust
+    # Add a callback when the point moves to adjust
     # the center of the carving sphere accordingly
     #------------------------------------------------------
-    def onFiducialMoved():
-        p = GetFiducialPosition()
+    def onPointMoved():
+        p = GetPointPosition()
         propNode = GetShaderPropertyNode()
         propNode.GetFragmentUniforms().SetUniform3f("center",p)
 
     fn = slicer.util.getNode('vtkMRMLMarkupsFiducialNode1')
-    fn.AddObserver(fn.PointModifiedEvent, lambda caller,event: onFiducialMoved())
+    fn.AddObserver(fn.PointModifiedEvent, lambda caller,event: onPointMoved())
 
 
     self.delayDisplay("Should be a carved out nose now")

--- a/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
@@ -202,12 +202,11 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
     """ Test the GetRASBounds & GetBounds method on a markup.
     """
     #self.delayDisplay("Starting test_Markup")
-    markupNode = slicer.mrmlScene.AddNode(slicer.vtkMRMLMarkupsFiducialNode())
-
-    markupNode.AddFiducial(1.0, 0.0, 0.0)
-    markupNode.AddFiducial(-45.0, -90.0, -180.0)
-    markupNode.AddFiducial(-200.0, 500.0, -0.23)
-    markupNode.AddFiducial(1.0, 1003.01, 0.0)
+    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    markupNode.AddControlPoint([1.0, 0.0, 0.0])
+    markupNode.AddControlPoint([-45.0, -90.0, -180.0])
+    markupNode.AddControlPoint([-200.0, 500.0, -0.23])
+    markupNode.AddControlPoint([1.0, 1003.01, 0.0])
 
     bounds = list(range(6))
     markupNode.GetRASBounds(bounds)

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
@@ -48,7 +48,7 @@ class SlicerMRBMultipleSaveRestoreLoop(ScriptedLoadableModuleTest):
 
   def __init__(self, methodName='runTest', numberOfIterations=5, uniqueDirectory=True, strict=False):
     """
-    Tests the use of mrml and mrb save formats with volumes and fiducials.
+    Tests the use of mrml and mrb save formats with volumes and point lists.
     Checks that scene views are saved and restored as expected after multiple
     MRB saves and loads.
 
@@ -91,19 +91,17 @@ class SlicerMRBMultipleSaveRestoreLoop(ScriptedLoadableModuleTest):
     import SampleData
     mrHeadVolume = SampleData.downloadSample("MRHead")
 
-    # Place a fiducial
-    markupsLogic = slicer.modules.markups.logic()
+    # Place a control point
+    pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "F")
+    pointListNode.CreateDefaultDisplayNodes()
     fid1 = [0.0, 0.0, 0.0]
-    fidIndex1 = markupsLogic.AddFiducial(fid1[0], fid1[1], fid1[2])
-    fidID = markupsLogic.GetActiveListID()
-    fidNode = slicer.mrmlScene.GetNodeByID(fidID)
+    fidIndex1 = pointListNode.AddControlPoint(fid1)
 
-
-    self.delayDisplay('Finished with download and placing fiducials')
+    self.delayDisplay('Finished with download and placing points')
 
     ioManager = slicer.app.ioManager()
     widget = slicer.app.layoutManager().viewport()
-    self.fiducialPosition = fid1
+    self.pointPosition = fid1
     for i in range(self.numberOfIterations):
 
       print('\n\nIteration %s' % i)
@@ -136,22 +134,22 @@ class SlicerMRBMultipleSaveRestoreLoop(ScriptedLoadableModuleTest):
       self.assertEqual(redComposite.GetBackgroundVolumeID(), mrHead.GetID())
       self.delayDisplay('The MRHead volume is AGAIN in the background of the Red viewer')
 
-      # confirm that the fiducial list exists with 1 points
-      fidNode = slicer.util.getNode('F')
-      self.assertEqual(fidNode.GetNumberOfFiducials(), 1)
-      self.delayDisplay('The fiducial list has 1 point in it')
+      # confirm that the point list exists with 1 points
+      pointListNode = slicer.util.getNode('F')
+      self.assertEqual(pointListNode.GetNumberOfControlPoints(), 1)
+      self.delayDisplay('The point list has 1 point in it')
 
       # adjust the fid list location
-      self.fiducialPosition = [i, i, i]
-      print((i, ': reset fiducial position array to ', self.fiducialPosition))
-      fidNode.SetNthFiducialPositionFromArray(0, self.fiducialPosition)
+      self.pointPosition = [i, i, i]
+      print((i, ': reset point position array to ', self.pointPosition))
+      pointListNode.SetNthControlPointPosition(0, self.pointPosition)
     self.delayDisplay("Loop Finished")
 
-    print(('Fiducial position from loop = ',self.fiducialPosition))
-    fidNode = slicer.util.getNode('F')
-    finalFiducialPosition = [ 0,0,0 ]
-    fidNode.GetNthFiducialPosition(0, finalFiducialPosition)
-    print(('Final fiducial scene pos = ',finalFiducialPosition))
-    self.assertEqual(self.fiducialPosition, finalFiducialPosition)
+    print(('Point position from loop = ',self.pointPosition))
+    pointListNode = slicer.util.getNode('F')
+    finalPointPosition = [ 0,0,0 ]
+    pointListNode.GetNthControlPointPosition(0, finalPointPosition)
+    print(('Final point scene pos = ',finalPointPosition))
+    self.assertEqual(self.pointPosition, finalPointPosition)
 
     self.delayDisplay("Test Finished")

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
@@ -49,7 +49,7 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
 
   def __init__(self,methodName='runTest',uniqueDirectory=True,strict=False):
     """
-    Tests the use of mrml and mrb save formats with volumes and fiducials.
+    Tests the use of mrml and mrb save formats with volumes and markups points lists.
     Checks that scene views are saved and restored as expected.
     Checks that after a scene view restore, MRB save and reload works as expected.
 
@@ -88,17 +88,15 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
     import SampleData
     mrHeadVolume = SampleData.downloadSample("MRHead")
 
-    # Place a fiducial
-    markupsLogic = slicer.modules.markups.logic()
+    # Place a control point
+    pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode","F")
+    pointListNode.CreateDefaultDisplayNodes()
     eye = [33.4975, 79.4042, -10.2143]
     nose = [-2.145, 116.14, -43.31]
-    fidIndexEye = markupsLogic.AddFiducial(eye[0], eye[1], eye[2])
-    fidIndexNose = markupsLogic.AddFiducial(nose[0], nose[1], nose[2])
-    fidID = markupsLogic.GetActiveListID()
-    fidNode = slicer.mrmlScene.GetNodeByID(fidID)
+    fidIndexEye = pointListNode.AddControlPoint(eye)
+    fidIndexNose = pointListNode.AddControlPoint(nose)
 
-
-    self.delayDisplay('Finished with download and placing fiducials\n')
+    self.delayDisplay('Finished with download and placing markups points\n')
 
     # confirm that MRHead is in the background of the Red slice
     redComposite = slicer.util.getNode('vtkMRMLSliceCompositeNodeRed')
@@ -108,12 +106,12 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
 
 
     # turn off visibility save scene view
-    fidNode.SetDisplayVisibility(0)
-    self.delayDisplay('Not showing fiducials')
-    self.storeSceneView('Invisible-view', "Not showing fiducials")
-    fidNode.SetDisplayVisibility(1)
-    self.delayDisplay('Showing fiducials')
-    self.storeSceneView('Visible-view', "Showing fiducials")
+    pointListNode.SetDisplayVisibility(0)
+    self.delayDisplay('Not showing markup points')
+    self.storeSceneView('Invisible-view', "Not showing markup points")
+    pointListNode.SetDisplayVisibility(1)
+    self.delayDisplay('Showing markup points')
+    self.storeSceneView('Visible-view', "Showing markup points")
 
     #
     # save the mrml scene to a temp directory, then zip it
@@ -150,22 +148,22 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
     self.assertEqual( redComposite.GetBackgroundVolumeID(), mrHead.GetID() )
     self.delayDisplay('The MRHead volume is AGAIN in the background of the Red viewer')
 
-    # confirm that the fiducial list exists with two points
-    self.delayDisplay('Does the fiducial list have 2 points in it?')
-    fidNode = slicer.util.getNode('F')
-    self.assertEqual(fidNode.GetNumberOfFiducials(), 2)
-    self.delayDisplay('The fiducial list has 2 points in it')
+    # confirm that the point list exists with two points
+    self.delayDisplay('Does the point list have 2 points in it?')
+    pointListNode = slicer.util.getNode('F')
+    self.assertEqual(pointListNode.GetNumberOfControlPoints(), 2)
+    self.delayDisplay('The point list has 2 points in it')
 
     # Restore the invisible scene view
     self.delayDisplay('About to restore Invisible-view scene')
     sceneView = slicer.util.getNode('Invisible-view')
     sceneView.RestoreScene()
-    fidNode = slicer.util.getNode('F')
-    self.assertEqual(fidNode.GetDisplayVisibility(), 0)
-    self.delayDisplay("NOT seeing the fiducials")
-    self.delayDisplay('Does the fiducial list still have 2 points in it after restoring a scenen view?')
-    self.assertEqual(fidNode.GetNumberOfFiducials(), 2)
-    self.delayDisplay('The fiducial list has 2 points in it after scene view restore')
+    pointListNode = slicer.util.getNode('F')
+    self.assertEqual(pointListNode.GetDisplayVisibility(), 0)
+    self.delayDisplay("NOT seeing the points")
+    self.delayDisplay('Does the point list still have 2 points in it after restoring a scenen view?')
+    self.assertEqual(pointListNode.GetNumberOfControlPoints(), 2)
+    self.delayDisplay('The point list has 2 points in it after scene view restore')
 
     #
     # Save it again
@@ -204,12 +202,12 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
     self.delayDisplay('Yes, the MRHead volume is back in the background of the Red viewer')
 
 
-    # confirm that the fiducial list exists with two points
-    fidNode = slicer.util.getNode('F')
-    self.assertEqual(fidNode.GetNumberOfFiducials(), 2)
-    self.delayDisplay('The fiducial list has 2 points in it after scene view restore, save and MRB reload')
-    self.assertEqual(fidNode.GetDisplayVisibility(), 0)
-    self.delayDisplay("NOT seeing the fiducials")
+    # confirm that the point list exists with two points
+    pointListNode = slicer.util.getNode('F')
+    self.assertEqual(pointListNode.GetNumberOfControlPoints(), 2)
+    self.delayDisplay('The point list has 2 points in it after scene view restore, save and MRB reload')
+    self.assertEqual(pointListNode.GetDisplayVisibility(), 0)
+    self.delayDisplay("NOT seeing the points")
 
     self.delayDisplay("Test Finished")
 

--- a/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
@@ -417,15 +417,15 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
     #self.delayDisplay('Starting test_3D_parentTransform')
     #
     # Setup:
-    #  - Use a markup fiducial node
+    #  - Use a markup control points list node
     #  - Create a parent transform
     #  - Create another transform under the parent transform
     #
 
-    markupNode = slicer.mrmlScene.AddNode(slicer.vtkMRMLMarkupsFiducialNode())
-    markupNode.AddFiducial(500.0, -1000.0, 0.0)
-    markupNode.AddFiducial(1000.0, 1000.0, 200.0)
-    markupNode.AddFiducial(-1500.0, -200.0, -100.0)
+    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    markupNode.AddControlPoint([500.0, -1000.0, 0.0])
+    markupNode.AddControlPoint([1000.0, 1000.0, 200.0])
+    markupNode.AddControlPoint([-1500.0, -200.0, -100.0])
 
     logic = SlicerTransformInteractionTest1Logic()
     parentNode, parendDisplayNode = logic.addTransform()

--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
     std::cerr << "No input transform found! Specified transform ID = " << transform1ID << std::endl;
     return EXIT_FAILURE;
     }
-  // fiducials
+  // Control point lists
   std::cout << "Have an input seed list of size " << seed.size() << std::endl;
   for (unsigned int i = 0; i < seed.size(); ++i)
     {
@@ -116,11 +116,12 @@ int main(int argc, char* argv[])
     vtkNew<vtkMRMLMarkupsFiducialStorageNode> fiducialStorageNode;
     fiducialStorageNode->SetFileName(seedsFile.c_str());
     fiducialStorageNode->ReadData(fiducialNode.GetPointer());
-    std::cout << "Number of fids read = " << fiducialNode->GetNumberOfFiducials() << ", coordinate system flag = " << fiducialStorageNode->GetCoordinateSystem() << std::endl;
-    for (int i = 0; i < fiducialNode->GetNumberOfFiducials(); ++i)
+    std::cout << "Number of fids read = " << fiducialNode->GetNumberOfControlPoints()
+      << ", coordinate system flag = " << fiducialStorageNode->GetCoordinateSystem() << std::endl;
+    for (int i = 0; i < fiducialNode->GetNumberOfControlPoints(); ++i)
       {
       double pos[3];
-      fiducialNode->GetNthFiducialPosition(i, pos);
+      fiducialNode->GetNthControlPointPosition(i, pos);
       std::cout << i << "\t" << pos[0] << "\t" << pos[1] << "\t" << pos[2] << std::endl;
       }
     }
@@ -132,13 +133,13 @@ int main(int argc, char* argv[])
   for (unsigned int i = 0; i < seed.size(); ++i)
     {
     std::cout << "Copying seed list to output file list: " << seed[i][0] << ", " << seed[i][1] << ", " << seed[i][2] << std::endl;
-    copiedFiducialNode->AddFiducial(seed[i][0], seed[i][1], seed[i][2]);
+    copiedFiducialNode->AddControlPoint(vtkVector3d(seed[i][0], seed[i][1], seed[i][2]));
     // toggle some settings
     if (i == 0)
       {
-      copiedFiducialNode->SetNthFiducialLocked(i, true);
-      copiedFiducialNode->SetNthFiducialSelected(i, false);
-      copiedFiducialNode->SetNthFiducialVisibility(i, false);
+      copiedFiducialNode->SetNthControlPointLocked(i, true);
+      copiedFiducialNode->SetNthControlPointSelected(i, false);
+      copiedFiducialNode->SetNthControlPointVisibility(i, false);
       }
     }
   // write out the copy

--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.cxx
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.cxx
@@ -592,7 +592,7 @@ int vtkSlicerCropVolumeLogic::CropInterpolated(vtkMRMLDisplayableNode* roi, vtkM
 
   vtkNew<vtkMRMLMarkupsFiducialNode> originMarkupNode;
   // Markups are transformed from RAS to LPS by the CLI infrastructure, so we pass them in RAS
-  originMarkupNode->AddFiducial(outputOrigin_RAS[0], outputOrigin_RAS[1], outputOrigin_RAS[2]);
+  originMarkupNode->AddControlPoint(outputOrigin_RAS);
   this->GetMRMLScene()->AddNode(originMarkupNode.GetPointer());
   cmdNode->SetParameterAsString("outputImageOrigin", originMarkupNode->GetID());
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -752,7 +752,7 @@ int vtkMRMLMarkupsDisplayNode::UpdateActiveControlPointWorld(
   else
     {
     // Update existing control point
-    markupsNode->SetNthControlPointPositionOrientationWorldFromArray(controlPointIndex,
+    markupsNode->SetNthControlPointPositionOrientationWorld(controlPointIndex,
       pointWorld, orientationMatrixWorld, associatedNodeID, positionStatus);
     if (positionStatus == vtkMRMLMarkupsNode::PositionUndefined)
       {

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -88,37 +88,6 @@ void vtkMRMLMarkupsFiducialNode::PrintSelf(ostream& os, vtkIndent indent)
   Superclass::PrintSelf(os,indent);
 }
 
-//-------------------------------------------------------------------------
-int vtkMRMLMarkupsFiducialNode::AddFiducial(double x, double y, double z)
-{
-  return this->AddFiducial(x, y, z, std::string());
-}
-
-//-------------------------------------------------------------------------
-int vtkMRMLMarkupsFiducialNode::AddFiducial(double x, double y, double z,
-                                            std::string label)
-{
-  vtkWarningMacro("AddFiducial method is deprecated, please use AddControlPoint instead");
-  return this->AddControlPoint(vtkVector3d(x, y, z), label);
-}
-
-//-------------------------------------------------------------------------
-
-//-------------------------------------------------------------------------
-int vtkMRMLMarkupsFiducialNode::AddFiducialFromArray(double pos[3], std::string label)
-{
-  return this->AddFiducial(pos[0], pos[1], pos[2], label);
-}
-
-//-------------------------------------------------------------------------
-void vtkMRMLMarkupsFiducialNode::GetNthFiducialPosition(int n, double pos[3])
-{
-  vtkWarningMacro("GetNthFiducialPosition method is deprecated, please use GetNthControlPointPositionVector instead");
-  vtkVector3d point= this->GetNthControlPointPositionVector(n);
-  pos[0] = point.GetX();
-  pos[1] = point.GetY();
-  pos[2] = point.GetZ();
-}
 
 //-------------------------------------------------------------------------
 void vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes()

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -90,77 +90,126 @@ public:
   /// If the number is set to 0 then no it means there is no preference (this is the default value).
   vtkSetMacro(RequiredNumberOfControlPoints, int);
 
-  /// \deprecated Use GetNumberOfControlPoints instead.
-  int GetNumberOfFiducials() {
-    vtkWarningMacro("GetNumberOfFiducials method is deprecated, please use GetNumberOfControlPoints instead");
-    return this->GetNumberOfControlPoints();};
-  /// \deprecated Use AddControlPoint instead.
-  int AddFiducial(double x, double y, double z);
-  /// \deprecated Use AddControlPoint instead.
-  int AddFiducial(double x, double y, double z, std::string label);
-  /// Add a new fiducial from an array and return the fiducial index
-  int AddFiducialFromArray(double pos[3], std::string label = std::string());
-  /// \deprecated Use GetNthControlPointPositionVector instead.
-  void GetNthFiducialPosition(int n, double pos[3]);
-  /// \deprecated Use SetNthControlPointPosition instead.
-  void SetNthFiducialPosition(int n, double x, double y, double z){
-    vtkWarningMacro("SetNthFiducialPosition method is deprecated, please use SetNthControlPointPosition instead");
-    this->SetNthControlPointPosition(n, x, y, z);};
-  /// \deprecated Use SetNthControlPointPositionFromArray instead.
-  void SetNthFiducialPositionFromArray(int n, double pos[3]){
-    vtkWarningMacro("SetNthFiducialPositionFromArray method is deprecated, please use SetNthControlPointPositionFromArray instead");
-    this->SetNthControlPointPositionFromArray(n, pos);};
-  /// \deprecated Use GetNthControlPointSelected instead.
-  bool GetNthFiducialSelected(int n = 0){
-    vtkWarningMacro("GetNthFiducialSelected method is deprecated, please use GetNthControlPointSelected instead");
-    return this->GetNthControlPointSelected(n);};
-  /// \deprecated Use SetNthControlPointSelected instead.
-  void SetNthFiducialSelected(int n, bool flag){
-    vtkWarningMacro("SetNthFiducialSelected method is deprecated, please use SetNthControlPointSelected instead");
-    this->SetNthControlPointSelected(n, flag);};
-  /// \deprecated Use GetNthControlPointLocked instead.
-  bool GetNthFiducialLocked(int n = 0){
-    vtkWarningMacro("GetNthFiducialLocked method is deprecated, please use GetNthControlPointLocked instead");
-    return this->GetNthControlPointLocked(n);};
-  /// \deprecated Use SetNthControlPointLocked instead.
-  void SetNthFiducialLocked(int n, bool flag){
-    vtkWarningMacro("SetNthFiducialLocked method is deprecated, please use SetNthControlPointLocked instead");
-    this->SetNthControlPointLocked(n, flag);};
-  /// \deprecated Use GetNthControlPointVisibility instead.
-  bool GetNthFiducialVisibility(int n = 0){
-    vtkWarningMacro("GetNthFiducialVisibility method is deprecated, please use GetNthControlPointVisibility instead");
-    return this->GetNthControlPointVisibility(n);};
-  /// \deprecated Use SetNthControlPointVisibility instead.
-  void SetNthFiducialVisibility(int n, bool flag){
-    vtkWarningMacro("SetNthFiducialVisibility method is deprecated, please use SetNthControlPointVisibility instead");
-    this->SetNthControlPointVisibility(n, flag);};
-  /// \deprecated Use GetNthControlPointLabel instead.
-  std::string GetNthFiducialLabel(int n = 0){
-    vtkWarningMacro("GetNthFiducialLabel method is deprecated, please use GetNthControlPointLabel instead");
-    return this->GetNthControlPointLabel(n);};
-  /// \deprecated Use SetNthControlPointLabel instead.
-  void SetNthFiducialLabel(int n, std::string label){
-    vtkWarningMacro("SetNthFiducialLabel method is deprecated, please use SetNthControlPointLabel instead");
-    this->SetNthControlPointLabel(n, label);};
-  /// \deprecated Use GetNthControlPointAssociatedNodeID instead.
-  std::string GetNthFiducialAssociatedNodeID(int n = 0){
-    vtkWarningMacro("GetNthFiducialAssociatedNodeID method is deprecated, please use GetNthControlPointAssociatedNodeID instead");
-    return this->GetNthControlPointAssociatedNodeID(n);};
-  /// \deprecated Use SetNthControlPointAssociatedNodeID instead.
-  void SetNthFiducialAssociatedNodeID(int n, const char* id){
-    vtkWarningMacro("SetNthFiducialAssociatedNodeID method is deprecated, please use SetNthControlPointAssociatedNodeID instead");
-    this->SetNthControlPointAssociatedNodeID(n, (id ? std::string(id) : ""));};
-  /// \deprecated Use SetNthControlPointPositionWorld instead.
-  void SetNthFiducialWorldCoordinates(int n, double coords[4]){
-    vtkWarningMacro("SetNthFiducialWorldCoordinates method is deprecated, please use SetNthControlPointPositionWorld instead");
-    this->SetNthControlPointPositionWorld(n, coords[0], coords[1], coords[2]);};
-  /// \deprecated Use GetNthControlPointPositionWorld instead.
-  void GetNthFiducialWorldCoordinates(int n, double coords[4]){
-    vtkWarningMacro("GetNthFiducialWorldCoordinates method is deprecated, please use GetNthControlPointPositionWorld instead");
-    this->GetNthControlPointPositionWorld(n, coords);};
-
   /// Create and observe default display node(s)
   void CreateDefaultDisplayNodes() override;
+
+  //-----------------------------------------------------------
+  // All public methods below are deprecated
+  //
+  // These methods are either deprecated because they use old terms (markup instead of control point),
+  // or include "array", "vector", "pointer" in the name (it is redundant, as input arguments can be
+  // deduced from the type; and return type for vectors is always vtkVectorNd).
+  //
+
+  /// \deprecated Use GetNumberOfControlPoints instead.
+  int GetNumberOfFiducials()
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNumberOfFiducials method is deprecated, please use GetNumberOfControlPoints instead");
+    return this->GetNumberOfControlPoints();
+    };
+  /// \deprecated Use AddControlPoint instead.
+  int AddFiducial(double x, double y, double z, std::string label = std::string())
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::AddFiducial method is deprecated, please use AddControlPoint instead");
+    return this->AddControlPoint(vtkVector3d(x, y, z), label);
+    }
+  /// Add a new fiducial from an array and return the fiducial index
+  /// \deprecated Use AddControlPoint instead.
+  int AddFiducialFromArray(double pos[3], std::string label = std::string())
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::AddFiducialFromArray method is deprecated, please use AddControlPoint instead");
+    return this->AddFiducial(pos[0], pos[1], pos[2], label);
+    }
+  /// \deprecated Use GetNthControlPointPositionVector instead.
+  void GetNthFiducialPosition(int n, double pos[3])
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNthFiducialPosition method is deprecated, please use GetNthControlPointPositionVector instead");
+    this->GetNthControlPointPosition(n, pos);
+    }
+  /// \deprecated Use SetNthControlPointPosition instead.
+  void SetNthFiducialPosition(int n, double x, double y, double z)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::SetNthFiducialPosition method is deprecated, please use SetNthControlPointPosition instead");
+    this->SetNthControlPointPosition(n, x, y, z);
+    };
+  /// \deprecated Use SetNthControlPointPositionFromArray instead.
+  void SetNthFiducialPositionFromArray(int n, double pos[3])
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::SetNthFiducialPositionFromArray method is deprecated, please use SetNthControlPointPositionFromArray instead");
+    this->SetNthControlPointPositionFromArray(n, pos);
+    };
+  /// \deprecated Use GetNthControlPointSelected instead.
+  bool GetNthFiducialSelected(int n = 0)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNthFiducialSelected method is deprecated, please use GetNthControlPointSelected instead");
+    return this->GetNthControlPointSelected(n);
+    };
+  /// \deprecated Use SetNthControlPointSelected instead.
+  void SetNthFiducialSelected(int n, bool flag)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::SetNthFiducialSelected method is deprecated, please use SetNthControlPointSelected instead");
+    this->SetNthControlPointSelected(n, flag);
+    };
+  /// \deprecated Use GetNthControlPointLocked instead.
+  bool GetNthFiducialLocked(int n = 0)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNthFiducialLocked method is deprecated, please use GetNthControlPointLocked instead");
+    return this->GetNthControlPointLocked(n);
+    };
+  /// \deprecated Use SetNthControlPointLocked instead.
+  void SetNthFiducialLocked(int n, bool flag)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::SetNthFiducialLocked method is deprecated, please use SetNthControlPointLocked instead");
+    this->SetNthControlPointLocked(n, flag);
+    };
+  /// \deprecated Use GetNthControlPointVisibility instead.
+  bool GetNthFiducialVisibility(int n = 0)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNthFiducialVisibility method is deprecated, please use GetNthControlPointVisibility instead");
+    return this->GetNthControlPointVisibility(n);
+    };
+  /// \deprecated Use SetNthControlPointVisibility instead.
+  void SetNthFiducialVisibility(int n, bool flag)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::SetNthFiducialVisibility method is deprecated, please use SetNthControlPointVisibility instead");
+    this->SetNthControlPointVisibility(n, flag);
+    };
+  /// \deprecated Use GetNthControlPointLabel instead.
+  std::string GetNthFiducialLabel(int n = 0)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNthFiducialLabel method is deprecated, please use GetNthControlPointLabel instead");
+    return this->GetNthControlPointLabel(n);
+    };
+  /// \deprecated Use SetNthControlPointLabel instead.
+  void SetNthFiducialLabel(int n, std::string label)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::SetNthFiducialLabel method is deprecated, please use SetNthControlPointLabel instead");
+    this->SetNthControlPointLabel(n, label);
+    };
+  /// \deprecated Use GetNthControlPointAssociatedNodeID instead.
+  std::string GetNthFiducialAssociatedNodeID(int n = 0)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNthFiducialAssociatedNodeID method is deprecated, please use GetNthControlPointAssociatedNodeID instead");
+    return this->GetNthControlPointAssociatedNodeID(n);
+    };
+  /// \deprecated Use SetNthControlPointAssociatedNodeID instead.
+  void SetNthFiducialAssociatedNodeID(int n, const char* id)
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::SetNthFiducialAssociatedNodeID method is deprecated, please use SetNthControlPointAssociatedNodeID instead");
+    this->SetNthControlPointAssociatedNodeID(n, (id ? std::string(id) : ""));
+    };
+  /// \deprecated Use SetNthControlPointPositionWorld instead.
+  void SetNthFiducialWorldCoordinates(int n, double coords[4])
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::SetNthFiducialWorldCoordinates method is deprecated, please use SetNthControlPointPositionWorld instead");
+    this->SetNthControlPointPositionWorld(n, coords[0], coords[1], coords[2]);
+    };
+  /// \deprecated Use GetNthControlPointPositionWorld instead.
+  void GetNthFiducialWorldCoordinates(int n, double coords[4])
+    {
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNthFiducialWorldCoordinates method is deprecated, please use GetNthControlPointPositionWorld instead");
+    this->GetNthControlPointPositionWorld(n, coords);
+    };
 
 protected:
   vtkMRMLMarkupsFiducialNode();

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -158,7 +158,7 @@ public:
   virtual const char* GetDefaultNodeNamePrefix() {return "M";};
 
   /// Read node attributes from XML file
-  void ReadXMLAttributes( const char** atts) override;
+  void ReadXMLAttributes(const char** atts) override;
 
   /// Write this node's information to a MRML file in XML format.
   void WriteXML(ostream& of, int indent) override;
@@ -280,24 +280,18 @@ public:
   virtual void RemoveAllControlPoints();
   virtual void UnsetAllControlPoints();
 
-  /// \deprecated Use RemoveAllControlPoints instead.
-  void RemoveAllMarkups() {
-    vtkWarningMacro("RemoveAllMarkups method is deprecated, please use RemoveAllControlPoints instead");
-    this->RemoveAllControlPoints();};
-
-  /// Get the Locked property on the markupNode/list of control points.
-  vtkGetMacro(Locked, int);
-  /// Set the Locked property on the markupNode/list of control points
+  ///@{
+  /// Get/Set the Locked property on the markupNode/list of control points
   /// If set to 1 then parameters should not be changed, and dragging the
   /// control points is disabled in 2d and 3d.
   /// Overrides the Locked flag on individual control points in that when the node is
   /// set to be locked, all the control points in the list are locked. When the node
   /// is unlocked, use the locked flag on the individual control points to determine
   /// their locked state.
+  vtkGetMacro(Locked, int);
   void SetLocked(int locked);
-  /// Get/Set the Locked property on the markupNode.
-  /// If set to 1 then parameters should not be changed
   vtkBooleanMacro(Locked, int);
+  ///@}
 
   /// Return a cast display node, returns null if none
   vtkMRMLMarkupsDisplayNode *GetMarkupsDisplayNode();
@@ -305,28 +299,19 @@ public:
   /// Return true if n is a valid control point, false otherwise.
   bool ControlPointExists(int n);
 
-  /// \deprecated Use ControlPointExists instead.
-  bool MarkupExists(int n) {
-    vtkWarningMacro("MarkupExists method is deprecated, please use ControlPointExists instead");
-    return this->ControlPointExists(n);};
   /// Return the number of control points that are stored in this node
   int GetNumberOfControlPoints();
   /// Return the number of control points that are already placed (not being previewed or undefined).
   int GetNumberOfDefinedControlPoints(bool includePreview=false);
   /// Return the number of control points that have not been placed (not being previewed or skipped).
   int GetNumberOfUndefinedControlPoints(bool includePreview = false);
-  /// \deprecated Use GetNumberOfControlPoints() instead.
-  int GetNumberOfMarkups() {
-    vtkWarningMacro("GetNumberOfMarkups method is deprecated, please use GetNumberOfControlPoints instead");
-    return this->GetNumberOfControlPoints();};
-  /// \deprecated Use GetNumberOfControlPoints() instead.
-  int GetNumberOfPointsInNthMarkup(int) {
-    vtkWarningMacro("GetNumberOfPointsInNthMarkup method is deprecated, please use GetNumberOfControlPoints instead");
-    return this->GetNumberOfControlPoints();};
+
   /// Return a pointer to the Nth control point stored in this node, null if n is out of bounds
   ControlPoint* GetNthControlPoint(int n);
   /// Return a pointer to the std::vector of control points stored in this node
   std::vector<ControlPoint*>* GetControlPoints();
+
+  ///@{
   /// Add n control points.
   /// If point is specified then all control point positions will be initialized to that position,
   /// otherwise control point positions are initialized to (0,0,0).
@@ -334,11 +319,25 @@ public:
   /// then no points are added at all.
   /// Return index of the last placed control point, -1 on failure.
   int AddNControlPoints(int n, std::string label = std::string(), vtkVector3d* point = nullptr);
-  /// Add a new control point, defined in the world coordinate system.
-  /// Return index of point index, -1 on failure.
-  int AddControlPointWorld(vtkVector3d point, std::string label = std::string());
+  int AddNControlPoints(int n, std::string label, double point[3]);
+  ///@}
+
+  /// Set all control point positions from a point list.
+  /// If points is nullptr then all control points are removed.
+  /// New control points are added if needed.
+  /// Existing control points are updated with the new positions.
+  /// Any extra existing control points are removed.
+  void SetControlPointPositionsWorld(vtkPoints* points);
+
+  /// Get a copy of all control point positions in world coordinate system
+  void GetControlPointPositionsWorld(vtkPoints* points);
+
+  ///@{
   /// Add a new control point, returning the point index, -1 on failure.
   int AddControlPoint(vtkVector3d point, std::string label = std::string());
+  int AddControlPoint(double point[3], std::string label = std::string());
+  ///@}
+
   /// Add a controlPoint to the end of the list. Return index
   /// of new controlPoint, -1 on failure.
   /// Markups node takes over ownership of the pointer (markups node will delete it)
@@ -346,25 +345,122 @@ public:
   /// replaced with automatically generated label.
   int AddControlPoint(ControlPoint *controlPoint, bool autoLabel=true);
 
-  /// Get the position of the Nth control point
-  /// returning it as a vtkVector3d, return (0,0,0) if not found
-  vtkVector3d GetNthControlPointPositionVector(int pointIndex);
+  ///@{
+  /// Add a new control point, defined in the world coordinate system.
+  /// Return index of point index, -1 on failure.
+  int AddControlPointWorld(vtkVector3d point, std::string label = std::string());
+  int AddControlPointWorld(double point[3], std::string label = std::string());
+  ///@}
 
-  /// \deprecated Use GetNthControlPointPositionVector() method instead.
-  vtkVector3d GetMarkupPointVector(int markupIndex, int) {
-    vtkWarningMacro("GetMarkupPointVector method is deprecated, please use GetNthControlPointPositionVector instead");
-    return this->GetNthControlPointPositionVector(markupIndex);};
+  ///@{
+  /// Insert a control point in this list at targetIndex.
+  /// If targetIndex is < 0, insert at the start of the list.
+  /// If targetIndex is > list size - 1, append to end of list.
+  /// If the insertion is successful, ownership of the controlPoint
+  /// is transferred to the markups node.
+  /// Returns true on success, false on failure.
+  bool InsertControlPoint(ControlPoint* controlPoint, int targetIndex);
+  bool InsertControlPoint(int n, vtkVector3d point, std::string label = std::string());
+  bool InsertControlPoint(int n, double point[3], std::string label = std::string());
+  ///@}
 
-  /// \deprecated Use GetNthControlPointPosition method instead.
-  void GetMarkupPoint(int markupIndex, int pointIndex, double point[3]);
+  ///@{
+  //Add and insert control point at index, defined in the world coordinate system.
+  //\sa InsertControlPoint
+  bool InsertControlPointWorld(int n, vtkVector3d pointWorld, std::string label = std::string());
+  bool InsertControlPointWorld(int n, double pointWorld[3], std::string label = std::string());
+  ///@}
 
+  /// Remove Nth Control Point
+  void RemoveNthControlPoint(int pointIndex);
+
+  /// Swap two control points (position data and all other properties).
+  void SwapControlPoints(int m1, int m2);
+
+  ///@{
+  /// Get/Set control point auto-created status. Set to true if point was generated automatically
+  bool GetNthControlPointAutoCreated(int n);
+  void SetNthControlPointAutoCreated(int n, bool flag);
+  ///@}
+
+  ///@{
   /// Get the position of the Nth control point
   /// setting the elements of point
   void GetNthControlPointPosition(int pointIndex, double point[3]);
   double* GetNthControlPointPosition(int pointIndex) VTK_SIZEHINT(3);
+  ///@}
+
+  /// Get the position of the Nth control point
+  /// returning it as a vtkVector3d, return (0,0,0) if not found
+  // Note: this method is not redundant because GetNthControlPointPosition returns a double*
+  // (as it is safe to do so) and so the method that returns a vtkVector3d cannot have the same name.
+  vtkVector3d GetNthControlPointPositionVector(int pointIndex);
+
+  ///@{
   /// Get the position of the Nth control point in World coordinate system
   /// Returns 0 on failure, 1 on success.
   int GetNthControlPointPositionWorld(int pointIndex, double worldxyz[3]);
+  vtkVector3d GetNthControlPointPositionWorld(int pointIndex);
+  ///@}
+
+
+    ///@{
+  /// Set of the Nth control point position from coordinates
+  void SetNthControlPointPosition(const int pointIndex, const double x, const double y, const double z, int positionStatus = PositionDefined);
+  void SetNthControlPointPosition(const int pointIndex, const double position[3], int positionStatus = PositionDefined);
+  ///@}
+
+  ///@{
+  /// Set of the Nth control point position using World coordinate system
+  /// Calls SetNthControlPointPosition after transforming the passed in coordinate
+  /// \sa SetNthControlPointPosition
+  void SetNthControlPointPositionWorld(const int pointIndex, const double x, const double y, const double z, int positionStatus = PositionDefined);
+  void SetNthControlPointPositionWorld(const int pointIndex, const double position[3], int positionStatus = PositionDefined);
+  ///@}
+
+  /// Set of the Nth control point position and orientation from an array using World coordinate system.
+  /// Orientation: x (0, 3, 6), y (1, 4, 7), z (2, 5, 8)
+  /// \sa SetNthControlPointPosition
+  void SetNthControlPointPositionOrientationWorld(const int pointIndex,
+    const double pos[3], const double orientationMatrix[9], const char* associatedNodeID, int positionStatus = PositionDefined);
+
+  ///@{
+  /// Set the orientation for the Nth control point from a WXYZ orientation.
+  /// The value W is in degrees.
+  void SetNthControlPointOrientation(int n, double w, double x, double y, double z);
+  void SetNthControlPointOrientation(int n, const double wxyz[4]);
+  ///@}
+
+  /// Get the WXYZ orientation for the Nth control point
+  /// The value W is in degrees.
+  void GetNthControlPointOrientation(int n, double orientationWXYZ[4]);
+
+  ///@{
+  /// Get/Set orientation as 9 values: x, y, and z axis directions, respectively:
+  /// x (0, 3, 6), y (1, 4, 7), z (2, 5, 8)
+  double* GetNthControlPointOrientationMatrix(int n) VTK_SIZEHINT(9);
+  void SetNthControlPointOrientationMatrix(int n, double orientationMatrix[9]);
+  ///@}
+
+  ///@{
+  /// Get/Set orientation as a vtkMatrix3x3.
+  void GetNthControlPointOrientationMatrix(int n, vtkMatrix3x3* matrix);
+  void SetNthControlPointOrientationMatrix(int n, vtkMatrix3x3* matrix);
+  ///@}
+
+  ///@{
+  /// Get/Set orientation in world coordinate system as 9 values: x, y, and z axis directions, respectively:
+  /// x (0, 3, 6), y (1, 4, 7), z (2, 5, 8)
+  void GetNthControlPointOrientationMatrixWorld(int n, double orientationMatrix[9]);
+  vtkVector<double, 9> GetNthControlPointOrientationMatrixWorld(int n);
+  void SetNthControlPointOrientationMatrixWorld(int n, const double orientationMatrix[9]);
+  ///@}
+
+  ///@{
+  /// Get/Set orientation in world coordinate system as a vtkMatrix3x3.
+  void GetNthControlPointOrientationMatrixWorld(int n, vtkMatrix3x3* matrix);
+  void SetNthControlPointOrientationMatrixWorld(int n, vtkMatrix3x3* matrix);
+  ///@}
 
   /// Get control point position status (PositionUndefined, PositionPreview, PositionDefined)
   int GetNthControlPointPositionStatus(int pointIndex);
@@ -387,141 +483,53 @@ public:
   /// Set control point status to defined and return to the previous position
   void RestoreNthControlPointPosition(int n);
 
-  /// Get control point auto-created status. Set to true if point was generated automatically
-  void SetNthControlPointAutoCreated(int n, bool flag);
+  /// Get the position of the center.
+  /// Return (0,0,0) if not found.
+  vtkVector3d GetCenterPosition();
 
-  /// Get control point auto-created status. Returns true if point was generated automatically
-  bool GetNthControlPointAutoCreated(int n);
-
-  /// Remove Nth Control Point
-  void RemoveNthControlPoint(int pointIndex);
-
-  /// \deprecated Use RemoveNthControlPoint instead.
-  void RemoveMarkup(int pointIndex) {
-    vtkWarningMacro("RemoveMarkup method is deprecated, please use RemoveNthControlPoint instead");
-    this->RemoveNthControlPoint(pointIndex);};
-
-  /// Insert a control point in this list at targetIndex.
-  /// If targetIndex is < 0, insert at the start of the list.
-  /// If targetIndex is > list size - 1, append to end of list.
-  /// If the insertion is successful, ownership of the controlPoint
-  /// is transferred to the markups node.
-  /// Returns true on success, false on failure.
-  bool InsertControlPoint(ControlPoint* controlPoint, int targetIndex);
-
-  //Add and insert control point at index, defined in the world coordinate system.
-  //\sa InsertControlPoint
-  bool InsertControlPointWorld(int n, vtkVector3d pointWorld, std::string label = std::string());
-
-  //Add and insert control point at index
-  //\sa InsertControlPoint
-  bool InsertControlPoint(int n, vtkVector3d point, std::string label = std::string());
-
-  /// Swap the position of two control points
-  void SwapControlPoints(int m1, int m2);
-
-  /// Set of the Nth control point position from a pointer to an array
-  /// \sa SetNthControlPointPosition
-  void SetNthControlPointPositionFromPointer(const int pointIndex, const double *pos);
-  /// Set of the Nth control point position from an array
-  /// \sa SetNthControlPointPosition
-  void SetNthControlPointPositionFromArray(const int pointIndex, const double pos[3], int positionStatus = PositionDefined);
-  /// Set of the Nth control point position from coordinates
-  /// \sa SetNthControlPointPositionFromPointer, SetNthControlPointPositionFromArray
-  void SetNthControlPointPosition(const int pointIndex, const double x, const double y, const double z, int positionStatus = PositionDefined);
-  /// Set of the Nth control point position using World coordinate system
-  /// Calls SetNthControlPointPosition after transforming the passed in coordinate
-  /// \sa SetNthControlPointPosition
-  void SetNthControlPointPositionWorld(const int pointIndex, const double x, const double y, const double z);
-  /// Set of the Nth control point position from an array using World coordinate system
-  /// \sa SetNthControlPointPosition
-  void SetNthControlPointPositionWorldFromArray(const int pointIndex, const double pos[3], int positionStatus = PositionDefined);
-  /// Set of the Nth control point position and orientation from an array using World coordinate system.
-  /// Orientation: x (0, 3, 6), y (1, 4, 7), z (2, 5, 8)
-  /// \sa SetNthControlPointPosition
-  void SetNthControlPointPositionOrientationWorldFromArray(const int pointIndex,
-    const double pos[3], const double orientationMatrix[9], const char* associatedNodeID, int positionStatus = PositionDefined);
-
-  /// Get the position of the center
-  /// returning it as a vtkVector3d, return (0,0,0) if not found
-  vtkVector3d GetCenterPositionVector();
-  /// Get the position of the center
+  /// Get the position of the center.
   /// setting the elements of point
-  void GetCenterPosition(double point[3]);
+  /// Returns false if center position is undefined.
+  bool GetCenterPosition(double point[3]);
+
   /// Get the position of the center in World coordinate system
-  /// Returns 0 on failure, 1 on success.
-  int GetCenterPositionWorld(double worldxyz[3]);
-  /// Set the center position from a pointer to an array
-  /// \sa SetCenterPosition
-  void SetCenterPositionFromPointer(const double *pos);
-  /// Set the center position position from an array
-  /// \sa SetCenterPosition
-  void SetCenterPositionFromArray(const double pos[3]);
+  /// Returns true on success.
+  bool GetCenterPositionWorld(double worldxyz[3]);
+
+  ///@{
   /// Set the center position position from coordinates
-  /// \sa SetCenterPositionFromPointer, SetCenterPositionFromArray
   void SetCenterPosition(const double x, const double y, const double z);
+  void SetCenterPosition(const double position[3]);
+  ///@}
+
+  ///@{
   /// Set the center position position using World coordinate system
   /// Calls SetCenterPosition after transforming the passed in coordinate
   /// \sa SetCenterPosition
   void SetCenterPositionWorld(const double x, const double y, const double z);
+  void SetCenterPositionWorld(const double positionWorld[3]);
+  ///@}
 
-  /// Set the orientation for the Nth control point from a WXYZ orientation.
-  /// The value W is in degrees.
-  void SetNthControlPointOrientationFromPointer(int n, const double *orientationWXYZ);
-  void SetNthControlPointOrientationFromArray(int n, const double orientationWXYZ[4]);
-  void SetNthControlPointOrientation(int n, double w, double x, double y, double z);
-  /// Get the WXYZ orientation for the Nth control point
-  /// The value W is in degrees.
-  void GetNthControlPointOrientation(int n, double orientationWXYZ[4]);
-  /// Get orientation as 9 values: x, y, and z axis directions, respectively:
-  /// x (0, 3, 6), y (1, 4, 7), z (2, 5, 8)
-  double* GetNthControlPointOrientationMatrix(int n) VTK_SIZEHINT(9);
-  void GetNthControlPointOrientationMatrix(int n, vtkMatrix3x3* matrix);
-  /// Set orientation as 9 values: x, y, and z axis directions, respectively.
-  /// x (0, 3, 6), y (1, 4, 7), z (2, 5, 8)
-  void SetNthControlPointOrientationMatrix(int n, double orientationMatrix[9]);
-  /// Set orientation from a vtkMatrix3x3
-  void SetNthControlPointOrientationMatrix(int n, vtkMatrix3x3* matrix);
-  /// Set orientation as 9 values: x, y, and z axis directions, respectively, in world coordinates.
-  /// x (0, 3, 6), y (1, 4, 7), z (2, 5, 8)
-  void SetNthControlPointOrientationMatrixWorld(int n, double orientationMatrix[9]);
-  /// Set orientation from a vtkMatrix3x3 in world coordinates
-  void SetNthControlPointOrientationMatrixWorld(int n, vtkMatrix3x3* matrix);
-  /// Get orientation as 9 values: x, y, and z axis directions, respectively.
-  /// x (0, 3, 6), y (1, 4, 7), z (2, 5, 8)
-  void GetNthControlPointOrientationMatrixWorld(int n, double orientationMatrix[9]);
-  /// Get orientation as a vtkMatrix3x3
-  void GetNthControlPointOrientationMatrixWorld(int n, vtkMatrix3x3* matrix);
-  /// Get normal direction (orientation of z axis) in local coordinate system.
+  ///@{
+  /// Get/Set normal direction (orientation of z axis) in local coordinate system.
   void GetNthControlPointNormal(int n, double normal[3]);
+  vtkVector3d GetNthControlPointNormal(int n);
+  ///@}
+
+  ///@{
   /// Get normal direction (orientation of z axis) in world coordinate system.
   void GetNthControlPointNormalWorld(int n, double normalWorld[3]);
-  /// Get the WXYZ orientation for the Nth control point
-  /// returning it as a vtkVector4d, return (0,0,0,0) if not found.
-  /// Note that vtkVector4d stores components in the order XYZW
-  /// (in all other methods we get/set components in WXYZ order).
-  vtkVector4d GetNthControlPointOrientationVector(int pointIndex);
+  vtkVector3d GetNthControlPointNormalWorld(int n);
+  ///@}
 
+  ///@{
   /// Get/Set the associated node id for the Nth control point
   std::string GetNthControlPointAssociatedNodeID(int n = 0);
   void SetNthControlPointAssociatedNodeID(int n, std::string id);
-
-  /// \deprecated Use GetNthControlPointAssociatedNodeID instead.
-  std::string GetNthMarkupAssociatedNodeID(int n = 0) {
-    vtkWarningMacro("GetNthMarkupAssociatedNodeID method is deprecated, please use GetNthControlPointAssociatedNodeID instead");
-    return this->GetNthControlPointAssociatedNodeID(n);};
-  /// \deprecated Use SetNthControlPointAssociatedNodeID instead.
-  void SetNthMarkupAssociatedNodeID(int n, std::string id) {
-    vtkWarningMacro("SetNthMarkupAssociatedNodeID method is deprecated, please use SetNthControlPointAssociatedNodeID instead");
-    this->SetNthControlPointAssociatedNodeID(n,id);};
+  ///@}
 
   /// Get the id for the Nth control point
   std::string GetNthControlPointID(int n);
-
-  /// \deprecated Use GetNthControlPointID instead.
-  std::string GetNthMarkupID(int n = 0) {
-    vtkWarningMacro("GetNthMarkupID method is deprecated, please use GetNthControlPointID instead");
-    return this->GetNthControlPointID(n);};
 
   /// Get the Nth control point index based on it's ID
   int GetNthControlPointIndexByID(const char* controlPointID);
@@ -546,15 +554,6 @@ public:
   /// \sa vtMRMLMarkupsNode::SetLocked
   void SetNthControlPointLocked(int n, bool flag);
 
-  /// \deprecated Use GetNthControlPointLocked instead.
-  bool GetNthMarkupLocked(int n = 0) {
-    vtkWarningMacro("GetNthMarkupLocked method is deprecated, please use GetNthControlPointLocked instead");
-    return this->GetNthControlPointLocked(n);};
-  /// \deprecated Use SetNthControlPointLocked instead.
-  void SetNthMarkupLocked(int n, bool flag) {
-    vtkWarningMacro("SetNthMarkupLocked method is deprecated, please use SetNthControlPointLocked instead");
-    this->SetNthControlPointLocked(n, flag);};
-
   /// Get the Visibility flag on the Nth control point,
   /// returns false if control point doesn't exist
   bool GetNthControlPointVisibility(int n = 0);
@@ -573,53 +572,41 @@ public:
   /// \sa vtkMRMLDisplayNode::SetVisibility
   void SetNthControlPointVisibility(int n, bool flag);
 
-  /// Get the Label on the Nth control point,
-  /// returns false if control point doesn't exist
+  ///@{
+  /// Get/Set the Label on the Nth control point.
   std::string GetNthControlPointLabel(int n = 0);
-  /// Set the Label on the Nth control point
   void SetNthControlPointLabel(int n, std::string label);
+  ///@}
 
-  /// \deprecated Use GetNthControlPointLabel instead.
-  std::string GetNthMarkupLabel(int n = 0) {
-    vtkWarningMacro("GetNthMarkupLabel method is deprecated, please use GetNthControlPointLabel instead");
-    return this->GetNthControlPointLabel(n);};
-  /// \deprecated Use SetNthControlPointLabel instead.
-  void SetNthMarkupLabel(int n, std::string label) {
-    vtkWarningMacro("SetNthMarkupLabel method is deprecated, please use SetNthControlPointLabel instead");
-    this->SetNthControlPointLabel(n, label);};
+  /// Get all control point labels at once.
+  void GetControlPointLabels(vtkStringArray* labels);
 
-  /// Get the Description flag on the Nth control point,
+  ///@{
+  /// Get/Set the Description flag on the Nth control point,
   /// returns false if control point doesn't exist
   std::string GetNthControlPointDescription(int n = 0);
-  /// Set the Description on the Nth control point
   void SetNthControlPointDescription(int n, std::string description);
+  ///@}
 
   /// Returns true since can apply non linear transforms
   /// \sa ApplyTransform
   bool CanApplyNonLinearTransforms()const override;
+
   /// Apply the passed transformation to all of the control points
   /// \sa CanApplyNonLinearTransforms
   void ApplyTransform(vtkAbstractTransform* transform) override;
 
-  /// Get the markup node label format string that defines the markup names.
-  /// \sa SetMarkupLabelFormat
-  std::string GetMarkupLabelFormat();
-  /// Set the markup node label format string that defines the markup names,
-  /// then invoke the LabelFormatModifedEvent
+  ///@{
+  /// Get/Set the markup node label format string that defines the markup names.
   /// In standard printf notation, with the addition of %N being replaced
   /// by the list name.
   /// %d will resolve to the highest not yet used list index integer.
   /// Character strings will otherwise pass through
-  /// Defaults to %N-%d which will yield markup names of Name-0, Name-1,
-  /// Name-2
-  /// \sa GetMarkupLabelFormat
+  /// Defaults to %N-%d which will yield markup names of Name-0, Name-1, Name-2.
+  /// If format string is changed then LabelFormatModifedEvent event is invoked.
+  std::string GetMarkupLabelFormat();
   void SetMarkupLabelFormat(std::string format);
-
-  // Get markup control point number locked status
-  bool GetFixedNumberOfControlPoints();
-
-  // Set markup control point number locked status
-  void SetFixedNumberOfControlPoints(bool fixed);
+  ///@}
 
   /// If the MarkupLabelFormat contains the string %N, return a string
   /// in which that has been replaced with the list name. If the list name is
@@ -641,6 +628,14 @@ public:
   /// scene. Returns false if n out of bounds, true on success.
   bool ResetNthControlPointID(int n);
 
+  ///@{
+  /// Get/Set locking of control point count.
+  /// If number of control points is fixed then points cannot be added or removed
+  /// only their position can be set/unset.
+  bool GetFixedNumberOfControlPoints();
+  void SetFixedNumberOfControlPoints(bool fixed);
+  ///@}
+
   /// Return the number of control points that are required for defining this widget.
   /// Interaction mode remains in "place" mode until this number is reached.
   /// If the number is set to 0 then no it means there is no preference (this is the default value).
@@ -656,23 +651,27 @@ public:
   /// 2 for line, and 3 for angle Markups
   vtkGetMacro(MaximumNumberOfControlPoints, int);
 
-  // WXYZ: W rotation angle in degrees, XYZ is rotation axis.
+  ///@{
+  /// Helper methods for converting orientation between WXYZ quaternion and 3x3 matrix representation.
+  /// WXYZ: W rotation angle in degrees, XYZ is rotation axis.
   static void ConvertOrientationMatrixToWXYZ(const double orientationMatrix[9], double orientationWXYZ[4]);
-  static void ConvertOrientationWXYZToMatrix(double orientationWXYZ[4], double orientationMatrix[9]);
+  static void ConvertOrientationWXYZToMatrix(const double orientationWXYZ[4], double orientationMatrix[9]);
+  ///@}
 
-  void GetControlPointLabels(vtkStringArray* labels);
-
+  ///@{
+  /// Get markup control points.
   virtual vtkPoints* GetCurvePoints();
   virtual vtkPoints* GetCurvePointsWorld();
-
   virtual vtkPolyData* GetCurve();
   virtual vtkPolyData* GetCurveWorld();
-
   virtual vtkAlgorithmOutput* GetCurveWorldConnection();
+  ///@}
 
-  vtkGetMacro(CurveClosed, bool);
-
+  /// Converts curve point index to control point index.
   int GetControlPointIndexFromInterpolatedPointIndex(vtkIdType interpolatedPointIndex);
+
+  /// Returns true if the curve generator creates a closed curve.
+  vtkGetMacro(CurveClosed, bool);
 
   /// The internal instance of the curve generator to allow
   /// use of the curve for other computations.
@@ -686,19 +685,11 @@ public:
   /// If visibleOnly is set to true then index of the closest visible control point will be returned.
   int GetClosestControlPointIndexToPositionWorld(double pos[3], bool visibleOnly=false);
 
-  /// Set all control point positions from a point list.
-  /// If points is nullptr then all control points are removed.
-  /// New control points are added if needed.
-  /// Existing control points are updated with the new positions.
-  /// Any extra existing control points are removed.
-  void SetControlPointPositionsWorld(vtkPoints* points);
-
-  /// Get a copy of all control point positions in world coordinate system
-  void GetControlPointPositionsWorld(vtkPoints* points);
-
   /// 4x4 matrix detailing the orientation and position in world coordinates of the interaction handles.
   virtual vtkMatrix4x4* GetInteractionHandleToWorldMatrix();
 
+  /// Get displayable string of the properties label (containing name, measurements, etc.) that
+  /// identifies the node and provides basic information.
   virtual std::string GetPropertiesLabelText();
 
   /// Utility function to get unit node from scene
@@ -711,6 +702,7 @@ public:
   /// Returns true if no additional control points can be added to this node.
   virtual bool GetControlPointPlacementComplete();
 
+  ///@{
   /// Set the index of the control point that will be placed next.
   ///
   /// Currently, this property is not stored persistently in the scene and modifying it does not trigger
@@ -719,6 +711,178 @@ public:
   /// undo/redo.
   int GetControlPointPlacementStartIndex();
   void SetControlPointPlacementStartIndex(int);
+  ///@}
+
+  //-----------------------------------------------------------
+  // All public methods below are deprecated
+  //
+  // These methods are either deprecated because they use old terms (markup instead of control point),
+  // or include "array", "vector", "pointer" in the name (it is redundant, as input arguments can be
+  // deduced from the type; and return type for vectors is always vtkVectorNd).
+  //
+
+  /// \deprecated Use RemoveAllControlPoints instead.
+  void RemoveAllMarkups()
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::RemoveAllMarkups method is deprecated, please use RemoveAllControlPoints instead");
+    this->RemoveAllControlPoints();
+  };
+
+  /// \deprecated Use ControlPointExists instead.
+  bool MarkupExists(int n)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::MarkupExists method is deprecated, please use ControlPointExists instead");
+    return this->ControlPointExists(n);
+  };
+
+  /// \deprecated Use GetNumberOfControlPoints() instead.
+  int GetNumberOfMarkups()
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::GetNumberOfMarkups method is deprecated, please use GetNumberOfControlPoints instead");
+    return this->GetNumberOfControlPoints();
+  };
+  /// \deprecated Use GetNumberOfControlPoints() instead.
+  int GetNumberOfPointsInNthMarkup(int)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::GetNumberOfPointsInNthMarkup method is deprecated, please use GetNumberOfControlPoints instead");
+    return this->GetNumberOfControlPoints();
+  };
+
+  /// \deprecated Use GetNthControlPointPositionVector() method instead.
+  vtkVector3d GetMarkupPointVector(int markupIndex, int)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::GetMarkupPointVector method is deprecated, please use GetNthControlPointPositionVector instead");
+    return this->GetNthControlPointPositionVector(markupIndex);
+  };
+
+  /// \deprecated Use GetNthControlPointPosition method instead.
+  void GetMarkupPoint(int markupIndex, int pointIndex, double point[3]);
+
+  /// \deprecated Use RemoveNthControlPoint instead.
+  void RemoveMarkup(int pointIndex)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::RemoveMarkup method is deprecated, please use RemoveNthControlPoint instead");
+    this->RemoveNthControlPoint(pointIndex);
+  };
+
+  /// Set of the Nth control point position from a pointer to an array
+  /// \deprecated Use SetNthControlPointPosition instead.
+  /// \sa SetNthControlPointPosition
+  void SetNthControlPointPositionFromPointer(const int pointIndex, const double* pos);
+
+  /// Set of the Nth control point position from an array
+  /// \deprecated Use SetNthControlPointPosition instead.
+  void SetNthControlPointPositionFromArray(const int pointIndex, const double pos[3], int positionStatus = PositionDefined)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::SetNthControlPointPositionFromArray method is deprecated, please use SetNthControlPointPosition instead");
+    this->SetNthControlPointPosition(pointIndex, pos[0], pos[1], pos[2], positionStatus);
+  }
+
+  /// Set of the Nth control point position from an array using World coordinate system
+  /// \deprecated Use SetNthControlPointPositionWorld instead.
+  /// \sa SetNthControlPointPosition
+  void SetNthControlPointPositionWorldFromArray(const int pointIndex, const double pos[3], int positionStatus = PositionDefined);
+
+  /// Set of the Nth control point position and orientation from an array using World coordinate system.
+  /// \deprecated Use SetNthControlPointPositionOrientationWorld instead.
+  /// Orientation: x (0, 3, 6), y (1, 4, 7), z (2, 5, 8)
+  /// \sa SetNthControlPointPosition
+  void SetNthControlPointPositionOrientationWorldFromArray(const int pointIndex,
+    const double positionWorld[3], const double orientationMatrix_World[9],
+    const char* associatedNodeID, int positionStatus = PositionDefined)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::SetNthControlPointPositionOrientationWorldFromArray method is deprecated,"
+      << " please use SetNthControlPointPositionOrientationWorld instead");
+    this->SetNthControlPointPositionOrientationWorld(
+      pointIndex, positionWorld, orientationMatrix_World, associatedNodeID, positionStatus);
+  }
+
+  /// Get the WXYZ orientation for the Nth control point
+  /// returning it as a vtkVector4d, return (0,0,0,0) if not found.
+  /// Note that vtkVector4d stores components in the order XYZW
+  /// (in all other methods we get/set components in WXYZ order).
+  /// \deprecated Use GetNthControlPointOrientation instead - with a different XYZW/WXYZ component order!
+  vtkVector4d GetNthControlPointOrientationVector(int pointIndex);
+
+  /// Get the position of the center.
+  /// \deprecated Use GetCenterPosition instead.
+  /// Return (0,0,0) if center position is undefined.
+  vtkVector3d GetCenterPositionVector()
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::GetCenterPositionVector method is deprecated, please use GetCenterPosition instead");
+    return this->GetCenterPosition();
+  }
+
+  /// Set the center position from a pointer to an array
+  /// \deprecated Use SetCenterPosition instead.
+  /// \sa SetCenterPosition
+  void SetCenterPositionFromPointer(const double* pos);
+  /// Set the center position position from an array
+  /// \deprecated Use SetCenterPosition instead.
+  /// \sa SetCenterPosition
+  void SetCenterPositionFromArray(const double pos[3])
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::SetCenterPositionFromArray method is deprecated, please use SetCenterPosition instead");
+    this->SetCenterPosition(pos[0], pos[1], pos[2]);
+  }
+
+  ///@{
+  /// Set the orientation for the Nth control point from a WXYZ orientation.
+  /// The value W is in degrees.
+  /// \deprecated Use SetNthControlPointOrientation instead.
+  void SetNthControlPointOrientationFromPointer(int n, const double* orientationWXYZ);
+  void SetNthControlPointOrientationFromArray(int n, const double orientationWXYZ[4])
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::SetNthControlPointOrientationFromArray method is deprecated, please use SetNthControlPointOrientation instead");
+    this->SetNthControlPointOrientation(n, orientationWXYZ[0], orientationWXYZ[1], orientationWXYZ[2], orientationWXYZ[3]);
+  }
+  ///@}
+
+  /// \deprecated Use GetNthControlPointAssociatedNodeID instead.
+  std::string GetNthMarkupAssociatedNodeID(int n = 0)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::GetNthMarkupAssociatedNodeID method is deprecated, please use GetNthControlPointAssociatedNodeID instead");
+    return this->GetNthControlPointAssociatedNodeID(n);
+  };
+  /// \deprecated Use SetNthControlPointAssociatedNodeID instead.
+  void SetNthMarkupAssociatedNodeID(int n, std::string id)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::SetNthMarkupAssociatedNodeID method is deprecated, please use SetNthControlPointAssociatedNodeID instead");
+    this->SetNthControlPointAssociatedNodeID(n, id);
+  };
+
+  /// \deprecated Use GetNthControlPointID instead.
+  std::string GetNthMarkupID(int n = 0)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::GetNthMarkupID method is deprecated, please use GetNthControlPointID instead");
+    return this->GetNthControlPointID(n);
+  };
+
+  /// \deprecated Use GetNthControlPointLocked instead.
+  bool GetNthMarkupLocked(int n = 0)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::GetNthMarkupLocked method is deprecated, please use GetNthControlPointLocked instead");
+    return this->GetNthControlPointLocked(n);
+  };
+  /// \deprecated Use SetNthControlPointLocked instead.
+  void SetNthMarkupLocked(int n, bool flag)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::SetNthMarkupLocked method is deprecated, please use SetNthControlPointLocked instead");
+    this->SetNthControlPointLocked(n, flag);
+  };
+
+  /// \deprecated Use GetNthControlPointLabel instead.
+  std::string GetNthMarkupLabel(int n = 0)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::GetNthMarkupLabel method is deprecated, please use GetNthControlPointLabel instead");
+    return this->GetNthControlPointLabel(n);
+  };
+  /// \deprecated Use SetNthControlPointLabel instead.
+  void SetNthMarkupLabel(int n, std::string label)
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::SetNthMarkupLabel method is deprecated, please use SetNthControlPointLabel instead");
+    this->SetNthControlPointLabel(n, label);
+  };
 
 protected:
   vtkMRMLMarkupsNode();

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.cxx
@@ -780,9 +780,9 @@ void vtkMRMLMarkupsPlaneNode::SetAxes(const double xAxis_Node[3], const double y
     }
 
   double epsilon = 1e-5;
-  double tempX[3] = { 0.0 };
-  double tempY[3] = { 0.0 };
-  double tempZ[3] = { 0.0 };
+  double tempX[3] = { 0.0, 0.0, 0.0 };
+  double tempY[3] = { 0.0, 0.0, 0.0 };
+  double tempZ[3] = { 0.0, 0.0, 0.0 };
   vtkMath::Cross(yAxis_Node, zAxis_Node, tempX);
   vtkMath::Cross(zAxis_Node, xAxis_Node, tempY);
   vtkMath::Cross(xAxis_Node, yAxis_Node, tempZ);
@@ -794,9 +794,9 @@ void vtkMRMLMarkupsPlaneNode::SetAxes(const double xAxis_Node[3], const double y
     return;
     }
 
-  if (vtkMath::Dot(xAxis_Node, yAxis_Node) >= epsilon ||
-      vtkMath::Dot(yAxis_Node, zAxis_Node) >= epsilon ||
-      vtkMath::Dot(zAxis_Node, xAxis_Node) >= epsilon)
+  if (fabs(vtkMath::Dot(xAxis_Node, yAxis_Node)) >= epsilon ||
+      fabs(vtkMath::Dot(yAxis_Node, zAxis_Node)) >= epsilon ||
+      fabs(vtkMath::Dot(zAxis_Node, xAxis_Node)) >= epsilon)
     {
     vtkErrorMacro("SetAxes: Invalid vectors");
     }
@@ -810,9 +810,9 @@ void vtkMRMLMarkupsPlaneNode::SetAxes(const double xAxis_Node[3], const double y
     this->SetIsPlaneValid(true);
     }
 
-  double previousXAxis_Node[3] = { 0.0 };
-  double previousYAxis_Node[3] = { 0.0 };
-  double previousZAxis_Node[3] = { 0.0 };
+  double previousXAxis_Node[3] = { 0.0, 0.0, 0.0 };
+  double previousYAxis_Node[3] = { 0.0, 0.0, 0.0 };
+  double previousZAxis_Node[3] = { 0.0, 0.0, 0.0 };
   this->GetAxes(previousXAxis_Node, previousYAxis_Node, previousZAxis_Node);
 
   vtkNew<vtkMatrix4x4> previousAxisToIdentity;
@@ -832,16 +832,14 @@ void vtkMRMLMarkupsPlaneNode::SetAxes(const double xAxis_Node[3], const double y
     identityToNewAxis->SetElement(i, 2, zAxis_Node[i]);
     }
 
-  double origin_Node[3] = { 0 };
+  double origin_Node[3] = { 0.0, 0.0, 0.0 };
   this->GetOrigin(origin_Node);
 
   vtkNew<vtkTransform> oldToNewAxesTransform;
   oldToNewAxesTransform->PostMultiply();
-  vtkMath::MultiplyScalar(origin_Node, -1);
-  oldToNewAxesTransform->Translate(origin_Node);
+  oldToNewAxesTransform->Translate(-origin_Node[0], -origin_Node[1], -origin_Node[2]);
   oldToNewAxesTransform->Concatenate(previousAxisToIdentity);
   oldToNewAxesTransform->Concatenate(identityToNewAxis);
-  vtkMath::MultiplyScalar(origin_Node, -1);
   oldToNewAxesTransform->Translate(origin_Node);
 
   this->ApplyTransform(oldToNewAxesTransform);
@@ -1520,7 +1518,7 @@ void vtkMRMLMarkupsPlaneNode::UpdateControlPointsFromPointNormal()
     double origin_World[3] = { 0,0,0 };
     baseToWorldTransform->TransformPoint(origin_World, origin_World);
 
-    this->SetNthControlPointPositionWorldFromArray(0, origin_World, this->GetNthControlPointPositionStatus(0));
+    this->SetNthControlPointPositionWorld(0, origin_World, this->GetNthControlPointPositionStatus(0));
     }
 }
 
@@ -1575,9 +1573,9 @@ void vtkMRMLMarkupsPlaneNode::UpdateControlPointsFrom3Points()
     vtkMath::MultiplyScalar(yAxis_World, this->Size[1] * 0.5);
     vtkMath::Add(origin_World, yAxis_World, point2_World);
 
-    this->SetNthControlPointPositionWorldFromArray(0, origin_World);
-    this->SetNthControlPointPositionWorldFromArray(1, point1_World);
-    this->SetNthControlPointPositionWorldFromArray(2, point2_World);
+    this->SetNthControlPointPositionWorld(0, origin_World);
+    this->SetNthControlPointPositionWorld(1, point1_World);
+    this->SetNthControlPointPositionWorld(2, point2_World);
     }
 
   double point0_World[3] = { 0.0, 0.0, 0.0 };
@@ -1625,9 +1623,9 @@ void vtkMRMLMarkupsPlaneNode::UpdateControlPointsFrom3Points()
 
   if (pointChanged)
     {
-    this->SetNthControlPointPositionWorldFromArray(0, point0_World);
-    this->SetNthControlPointPositionWorldFromArray(1, point1_World);
-    this->SetNthControlPointPositionWorldFromArray(2, point2_World);
+    this->SetNthControlPointPositionWorld(0, point0_World);
+    this->SetNthControlPointPositionWorld(1, point1_World);
+    this->SetNthControlPointPositionWorld(2, point2_World);
     }
 }
 

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsFiducialNodeTest1.cxx
@@ -103,7 +103,7 @@ int vtkMRMLMarkupsFiducialNodeTest1(int , char * [] )
   p0[0] = 0.99;
   p0[1] = 1.33;
   p0[2] = -9.0;
-  node1->SetNthControlPointPositionFromArray(fidIndex2, p0);
+  node1->SetNthControlPointPosition(fidIndex2, p0);
   vtkVector3d posVector2 = node1->GetNthControlPointPositionVector(fidIndex2);
   diff = sqrt(vtkMath::Distance2BetweenPoints(p0, posVector2.GetData()));
   std::cout << "Diff between set nth control point position array and get = " << diff << std::endl;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
@@ -192,7 +192,7 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
     }
 
   testOrientation[0] = 0.333;
-  node1->SetNthControlPointOrientationFromArray(0, testOrientation);
+  node1->SetNthControlPointOrientation(0, testOrientation);
   node1->GetNthControlPointOrientation(0, newOrientation);
   for (int r = 0; r < 4; r++)
     {
@@ -218,7 +218,7 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
   testOrientation[2] = 1.0;
   testOrientation[3] = 0.0;
   double *orientationPointer = testOrientation;
-  node1->SetNthControlPointOrientationFromPointer(0, orientationPointer);
+  node1->SetNthControlPointOrientation(0, orientationPointer);
   node1->GetNthControlPointOrientation(0, newOrientation);
   for (int r = 0; r < 4; r++)
     {

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest2.cxx
@@ -60,7 +60,7 @@ int vtkMRMLMarkupsNodeTest2(int , char * [] )
   pos0[0] = 3.0;
   pos0[1] = 5.5;
   pos0[2] = -2.6;
-  node1->SetNthControlPointPositionFromArray(0, pos0);
+  node1->SetNthControlPointPosition(0, pos0);
 
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   node1->SwapControlPoints(-1,100);
@@ -76,7 +76,7 @@ int vtkMRMLMarkupsNodeTest2(int , char * [] )
   pos1[0] = -3.9;
   pos1[1] = 15.5;
   pos1[2] = 2.666;
-  node1->SetNthControlPointPositionFromArray(1, pos1);
+  node1->SetNthControlPointPosition(1, pos1);
 
   std::cout << "Swapping markups 0 and 1, num markups = " << node1->GetNumberOfControlPoints() << std::endl;
   node1->PrintSelf(std::cout, indent);
@@ -114,7 +114,7 @@ int vtkMRMLMarkupsNodeTest2(int , char * [] )
   pos1New[0] = pos1New[0] * 0.33;
   pos1New[1] = pos1New[1] * 100.5;
   pos1New[2] = pos1New[2] * -10.67;
-  node1->SetNthControlPointPositionFromArray(1, pos1New);
+  node1->SetNthControlPointPosition(1, pos1New);
   node1->GetNthControlPointPosition(0, pos0New);
   if (pos0New[0] != pos1[0] ||
       pos0New[1] != pos1[1] ||

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsStorageNodeTest2.cxx
@@ -75,7 +75,7 @@ int TestStoragNode(vtkMRMLMarkupsNode* markupsNode, vtkMRMLMarkupsStorageNode* s
   // add a markup with one point with non default values
   int modifiedPointIndex =  markupsNode->AddNControlPoints(1);
   double orientation[4] = {0.2, 1.0, 0.0, 0.0};
-  markupsNode->SetNthControlPointOrientationFromArray(modifiedPointIndex, orientation);
+  markupsNode->SetNthControlPointOrientation(modifiedPointIndex, orientation);
   markupsNode->ResetNthControlPointID(modifiedPointIndex);
   std::string associatedNodeID = std::string("testingAssociatedID");
   markupsNode->SetNthControlPointAssociatedNodeID(modifiedPointIndex,associatedNodeID);
@@ -90,7 +90,7 @@ int TestStoragNode(vtkMRMLMarkupsNode* markupsNode, vtkMRMLMarkupsStorageNode* s
   // NAN should not be present, but we test this case anyway
   // to make sure that having a NAN does not break reading or writing.
   double inputPoint[3] = {-9.9, 1.1, NAN};
-  markupsNode->SetNthControlPointPositionFromArray(modifiedPointIndex, inputPoint);
+  markupsNode->SetNthControlPointPosition(modifiedPointIndex, inputPoint);
 
   // and add a markup with 1 point, default values
   if (markupsNode->GetMaximumNumberOfControlPoints() != 1)

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
@@ -16,7 +16,7 @@ class MarkupsInCompareViewersSelfTest(ScriptedLoadableModule):
     parent.dependencies = []
     parent.contributors = ["Nicole Aucoin (BWH)"]
     parent.helpText = """
-    This is a test case that exercises the fiducials with compare viewers.
+    This is a test case that exercises the control points lists with compare viewers.
     """
     parent.acknowledgementText = """
     This file was originally developed by Nicole Aucoin, BWH and was partially funded by NIH grant 3P41RR013218-12S1.
@@ -103,7 +103,7 @@ class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
     lm = slicer.app.layoutManager()
     lm.setLayout(2)
 
-    # create a fiducial list
+    # create a control points list
     displayNode = slicer.vtkMRMLMarkupsDisplayNode()
     slicer.mrmlScene.AddNode(displayNode)
     fidNode = slicer.vtkMRMLMarkupsFiducialNode()
@@ -119,14 +119,14 @@ class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
     eye1 = [33.4975, 79.4042, -10.2143]
     eye2 = [-31.283, 80.9652, -16.2143]
     nose = [4.61944, 114.526, -33.2143]
-    index = fidNode.AddFiducialFromArray(eye1)
-    fidNode.SetNthFiducialLabel(index, "eye-1")
-    index = fidNode.AddFiducialFromArray(eye2)
-    fidNode.SetNthFiducialLabel(index, "eye-2")
-    index = fidNode.AddFiducialFromArray(nose)
-    fidNode.SetNthFiducialLabel(index, "nose")
+    index = fidNode.AddControlPoint(eye1)
+    fidNode.SetNthControlPointLabel(index, "eye-1")
+    index = fidNode.AddControlPoint(eye2)
+    fidNode.SetNthControlPointLabel(index, "eye-2")
+    index = fidNode.AddControlPoint(nose)
+    fidNode.SetNthControlPointLabel(index, "nose")
 
-    slicer.util.delayDisplay("Placed 3 fiducials")
+    slicer.util.delayDisplay("Placed 3 control points")
 
     #
     # switch to 2 viewers compare layout
@@ -148,11 +148,11 @@ class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
     # make it visible in 3D
     compareLogic1.GetSliceNode().SetSliceVisible(1)
 
-    # scroll to a fiducial location
+    # scroll to a control point location
     compareLogic1.StartSliceOffsetInteraction()
     compareLogic1.SetSliceOffset(eye1[2])
     compareLogic1.EndSliceOffsetInteraction()
-    slicer.util.delayDisplay("MH Head in background, scrolled to a fiducial")
+    slicer.util.delayDisplay("MH Head in background, scrolled to a control point")
 
     # scroll around through the range of points
     offset = nose[2]

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
@@ -16,7 +16,7 @@ class MarkupsInViewsSelfTest(ScriptedLoadableModule):
     parent.dependencies = []
     parent.contributors = ["Nicole Aucoin (BWH)"]
     parent.helpText = """
-    This is a test case that exercises the fiducials with different settings on the display node to show only in certain views.
+    This is a test case that exercises the control points nodes with different settings on the display node to show only in certain views.
     """
     parent.acknowledgementText = """
     This file was originally developed by Nicole Aucoin, BWH and was partially funded by NIH grant 3P41RR013218-12S1.
@@ -170,7 +170,7 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     lm = slicer.app.layoutManager()
     lm.setLayout(2)
 
-    # create a fiducial list
+    # create a control points list
     fidNode = slicer.vtkMRMLMarkupsFiducialNode()
     slicer.mrmlScene.AddNode(fidNode)
     fidNode.CreateDefaultDisplayNodes()
@@ -193,22 +193,22 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     eye1 = [33.4975, 79.4042, -10.2143]
     eye2 = [-31.283, 80.9652, -16.2143]
     nose = [4.61944, 114.526, -33.2143]
-    controlPointIndex = fidNode.AddFiducialFromArray(eye1)
+    controlPointIndex = fidNode.AddControlPoint(eye1)
     slicer.nodeEvents = self.nodeEvents
     assert(len(self.nodeEvents) == 1)
     assert(self.nodeEvents[0] == slicer.vtkMRMLMarkupsNode.PointPositionDefinedEvent)
-    fidNode.SetNthFiducialLabel(controlPointIndex, "eye-1")
-    controlPointIndex = fidNode.AddFiducialFromArray(eye2)
-    fidNode.SetNthFiducialLabel(controlPointIndex, "eye-2")
+    fidNode.SetNthControlPointLabel(controlPointIndex, "eye-1")
+    controlPointIndex = fidNode.AddControlPoint(eye2)
+    fidNode.SetNthControlPointLabel(controlPointIndex, "eye-2")
     # hide the second eye as a test of visibility flags
-    fidNode.SetNthFiducialVisibility(controlPointIndex, controlPointIndex)
-    controlPointIndex = fidNode.AddFiducialFromArray(nose)
-    fidNode.SetNthFiducialLabel(controlPointIndex, "nose")
+    fidNode.SetNthControlPointVisibility(controlPointIndex, controlPointIndex)
+    controlPointIndex = fidNode.AddControlPoint(nose)
+    fidNode.SetNthControlPointLabel(controlPointIndex, "nose")
 
     for tag in fidNodeObserverTags:
       fidNode.RemoveObserver(tag)
 
-    slicer.util.delayDisplay("Placed 3 fiducials")
+    slicer.util.delayDisplay("Placed 3 control points")
 
     # self.printViewAndSliceNodes()
 
@@ -281,7 +281,7 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     # test of the visibility in slice views
     displayNode.RemoveAllViewNodeIDs()
 
-    # jump to the last fiducial
+    # jump to the last control point
     slicer.modules.markups.logic().JumpSlicesToNthPointInMarkup(fidNode.GetID(), controlPointIndex, True)
     # refocus the 3D cameras as well
     slicer.modules.markups.logic().FocusCamerasOnNthPointInMarkup(fidNode.GetID(), controlPointIndex)

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestManyLists.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestManyLists.py
@@ -1,23 +1,22 @@
-# Test restoring a scene with multiple lists with different number
-# of fiducials
+# Test restoring a scene with multiple lists with different number control points
 
-# first fiducial list
+# first control point list
 fidNode1 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "FidNode1")
 fidNode1.CreateDefaultDisplayNodes()
 coords = [0.0, 0.0, 0.0]
 numFidsInList1 = 5
 for i in range(numFidsInList1):
-  fidNode1.AddFiducialFromArray(coords)
+  fidNode1.AddControlPoint(coords)
   coords[0] += 1.0
   coords[1] += 2.0
   coords[2] += 1.0
 
-# second fiducial list
+# second control point list
 fidNode2 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "FidNode2")
 fidNode2.CreateDefaultDisplayNodes()
 numFidsInList2 = 10
 for i in range(numFidsInList2):
-  fidNode2.AddFiducialFromArray(coords)
+  fidNode2.AddControlPoint(coords)
   coords[0] += 1.0
   coords[1] += 1.0
   coords[2] += 3.0
@@ -28,12 +27,12 @@ sv = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSceneViewNode")
 sv.StoreScene()
 
 # add a third list that will get removed on restore
-# second fiducial list
+# second control point list
 fidNode3 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "FidNode3")
 fidNode3.CreateDefaultDisplayNodes()
 numFidsInList3 = 2
 for i in range(numFidsInList3):
-  fidNode3.AddFiducialFromArray(coords)
+  fidNode3.AddControlPoint(coords)
   coords[0] += 1.0
   coords[1] += 2.0
   coords[2] += 3.0
@@ -43,8 +42,8 @@ sv.RestoreScene()
 
 numFidNodesAfterRestore = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsFiducialNode')
 if numFidNodesAfterRestore != numFidNodesBeforeStore:
-  print("After restoring the scene, expected ", numFidNodesBeforeStore, " fiducial nodes, but have ", numFidNodesAfterRestore)
-  exceptionMessage = "After restoring the scene, expected " + str(numFidNodesBeforeStore) + " fiducial nodes, but have " + str(numFidNodesAfterRestore)
+  print("After restoring the scene, expected ", numFidNodesBeforeStore, " control points nodes, but have ", numFidNodesAfterRestore)
+  exceptionMessage = "After restoring the scene, expected " + str(numFidNodesBeforeStore) + " control points nodes, but have " + str(numFidNodesAfterRestore)
   raise Exception(exceptionMessage)
 
 fid1AfterRestore = slicer.mrmlScene.GetFirstNodeByName("FidNode1")
@@ -91,7 +90,7 @@ for markupsNode in [fid1AfterRestore, fid2AfterRestore]:
     worldPos = controlPointsPoly.GetPoint(s)
     print("control point ",s," world position = ",worldPos)
     fidPos = [0.0,0.0,0.0]
-    markupsNode.GetNthFiducialPosition(s,fidPos)
+    markupsNode.GetNthControlPointPosition(s,fidPos)
     xdiff = fidPos[0] - worldPos[0]
     ydiff = fidPos[1] - worldPos[1]
     zdiff = fidPos[2] - worldPos[2]

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestSimple.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestSimple.py
@@ -10,28 +10,28 @@ slicer.mrmlScene.AddNode(fid)
 fid.SetAndObserveDisplayNodeID(displayNode.GetID())
 
 startCoords = [1.0, 2.0, 3.0]
-fid.AddFiducialFromArray(startCoords)
+fid.AddControlPoint(startCoords)
 
-fid.GetNthFiducialPosition(0,startCoords)
-print("Starting fiducial coordinates = ",startCoords)
+fid.GetNthControlPointPosition(0,startCoords)
+print(f"Starting control point coordinates = {startCoords}")
 
 sv = slicer.mrmlScene.AddNode(slicer.vtkMRMLSceneViewNode())
 
 sv.StoreScene()
 
 afterStoreSceneCoords = [11.1,22.2,33.3]
-fid.SetNthFiducialPositionFromArray(0, afterStoreSceneCoords)
+fid.SetNthControlPointPosition(0, afterStoreSceneCoords)
 
-fid.GetNthFiducialPosition(0,afterStoreSceneCoords)
-print("After storing the scene, set fiducial coords to ",afterStoreSceneCoords)
+fid.GetNthControlPointPosition(0,afterStoreSceneCoords)
+print(f"After storing the scene, set control point coords to {afterStoreSceneCoords}")
 
 sv.RestoreScene()
 
 fidAfterRestore =  slicer.mrmlScene.GetNodeByID("vtkMRMLMarkupsFiducialNode1")
 
 coords = [0,0,0]
-fidAfterRestore.GetNthFiducialPosition(0,coords)
-print("After restoring the scene, fiducial coordinates = ", coords)
+fidAfterRestore.GetNthControlPointPosition(0,coords)
+print("After restoring the scene, control point coordinates = ", coords)
 
 xdiff = coords[0] - startCoords[0]
 ydiff = coords[1] - startCoords[1]

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -1052,7 +1052,7 @@ void vtkSlicerMarkupsWidget::TranslatePoint(double eventPos[2], bool snapToSlice
     worldPos[2] += worldPosProjDiff[2];
     }
 
-  markupsNode->SetNthControlPointPositionWorldFromArray(activeControlPointIndex, worldPos);
+  markupsNode->SetNthControlPointPositionWorld(activeControlPointIndex, worldPos);
 }
 
 //----------------------------------------------------------------------
@@ -1675,7 +1675,7 @@ int vtkSlicerMarkupsWidget::AddPointFromWorldCoordinate(const double worldCoordi
     {
     // convert point preview to final point
     addedControlPoint = this->PreviewPointIndex;
-    markupsNode->SetNthControlPointPositionWorldFromArray(addedControlPoint, worldCoordinates);
+    markupsNode->SetNthControlPointPositionWorld(addedControlPoint, worldCoordinates);
     this->PreviewPointIndex = -1;
     }
   else

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -382,7 +382,7 @@ void vtkSlicerMarkupsWidgetRepresentation::UpdateCenter()
   centerWorldPos[1] *= inv_N;
   centerWorldPos[2] *= inv_N;
 
-  markupsNode->SetCenterPositionFromPointer(centerWorldPos);
+  markupsNode->SetCenterPosition(centerWorldPos);
 }
 
 //----------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
+++ b/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
@@ -139,7 +139,7 @@ class MarkupsWidgetsSelfTestTest(ScriptedLoadableModuleTest):
 
     numberOfFiducialsAdded = 5
     for i in range(numberOfFiducialsAdded):
-      self.markupsLogic.AddFiducial()
+      self.markupsNode3.AddControlPoint([i*20, i*15, i*5])
 
     tableWidget = simpleMarkupsWidget.tableWidget()
     self.assertEqual(tableWidget.rowCount, numberOfFiducialsAdded)

--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
@@ -541,7 +541,7 @@ void qSlicerSimpleMarkupsWidget::onMarkupsControlPointEdited(int row, int column
     currentControlPointPosition[ 2 ] = newControlPointPosition;
     }
 
-  currentMarkupsNode->SetNthControlPointPositionFromArray( row, currentControlPointPosition );
+  currentMarkupsNode->SetNthControlPointPosition( row, currentControlPointPosition );
 
   this->updateWidget(); // This may not be necessary the widget is updated whenever a control point is changed
 }

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -2112,7 +2112,7 @@ void qSlicerMarkupsModuleWidget::onActiveMarkupTableCellChanged(int row, int col
         }
       else
         {
-        d->MarkupsNode->SetNthControlPointPositionFromArray(n, newPoint);
+        d->MarkupsNode->SetNthControlPointPosition(n, newPoint);
         }
       }
     else

--- a/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
+++ b/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
@@ -138,9 +138,11 @@ class AddStorableDataAfterSceneViewTestTest(ScriptedLoadableModuleTest):
     slicer.util.delayDisplay("Starting the test")
 
     #
-    # add a fiducial
+    # add a markups control point list
     #
-    slicer.modules.markups.logic().AddFiducial()
+
+    pointList = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsFiducialNode')
+    pointList.AddControlPoint([10,20,15])
 
     #
     # save a scene view

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -1275,7 +1275,8 @@ void qMRMLSegmentEditorWidget::updateWidgetFromMRML()
     selectedSegmentID = QString(d->ParameterSetNode->GetSelectedSegmentID());
 
     // Check if selected segment ID is invalid.
-    if (!d->SegmentationNode->GetSegmentation()
+    if (!d->SegmentationNode
+      || !d->SegmentationNode->GetSegmentation()
       || d->SegmentationNode->GetSegmentation()->GetSegmentIndex(d->ParameterSetNode->GetSelectedSegmentID()) < 0)
       {
       selectedSegmentID.clear();

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationConversionParametersWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationConversionParametersWidget.cxx
@@ -388,6 +388,11 @@ void qMRMLSegmentationConversionParametersWidget::applyConversion()
     return;
     }
 
+  // In case Enter was clicked while a parameter value was being edited,
+  // the editing is not yet finished by the time this method is called.
+  // Force finish editing now by unsetting current item.
+  d->ParametersTable->setCurrentItem(nullptr);
+
   MRMLNodeModifyBlocker blocker(d->SegmentationNode);
 
   // Perform conversion using selected path and chosen conversion parameters

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
@@ -119,7 +119,7 @@ class SubjectHierarchyCorePluginsSelfTestTest(ScriptedLoadableModuleTest):
     slicer.mrmlScene.AddNode(markupsNode)
     markupsNode.SetName(self.sampleMarkupName)
     fiducialPosition = [100.0, 0.0, 0.0]
-    markupsNode.AddFiducialFromArray(fiducialPosition)
+    markupsNode.AddControlPoint(fiducialPosition)
     markupsShItemID = shNode.GetItemByDataNode(markupsNode)
     self.assertIsNotNone( markupsShItemID )
     self.assertEqual( shNode.GetItemOwnerPluginName(markupsShItemID), 'Markups' )

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
@@ -151,11 +151,9 @@ void qSlicerSubjectHierarchyVolumesPluginPrivate::init()
   this->VolumeDisplayPresetAction->setObjectName("VolumeDisplayPresetAction");
   q->setActionPosition(this->VolumeDisplayPresetAction, qSlicerSubjectHierarchyAbstractPlugin::SectionBottom);
 
-  vtkSlicerVolumesLogic* volumesModuleLogic = nullptr;
-
   // read volume preset names from volumes logic
-  volumesModuleLogic = vtkSlicerVolumesLogic::SafeDownCast(
-    qSlicerApplication::application()->moduleLogic("Volumes"));
+  vtkSlicerVolumesLogic* volumesModuleLogic = (qSlicerCoreApplication::application() ? vtkSlicerVolumesLogic::SafeDownCast(
+    qSlicerCoreApplication::application()->moduleLogic("Volumes")) : nullptr);
   if (!volumesModuleLogic)
     {
     qWarning() << Q_FUNC_INFO << " failed: Module logic 'Volumes' not found.";

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
@@ -95,8 +95,8 @@ void qSlicerScalarVolumeDisplayWidgetPrivate::init()
   // Add mapping from presets defined in the Volumes module logic (VolumeDisplayPresets.json)
 
     // read volume preset names from volumes logic
-  vtkSlicerVolumesLogic* volumesModuleLogic = vtkSlicerVolumesLogic::SafeDownCast(
-    qSlicerApplication::application()->moduleLogic("Volumes"));
+  vtkSlicerVolumesLogic* volumesModuleLogic = (qSlicerCoreApplication::application() ? vtkSlicerVolumesLogic::SafeDownCast(
+    qSlicerCoreApplication::application()->moduleLogic("Volumes")) : nullptr);
   if (volumesModuleLogic)
   {
     QLayout* volumeDisplayPresetsLayout = this->PresetsWidget->layout();


### PR DESCRIPTION
Deprecate all method names for that either of these applies:
- use old terms: fiducial or markup (instead of control point)
- include "array", "vector", "pointer" in the name: this is redundant, as input arguments can be deduced from the type, and return type for vectors is almost always vtkVectorNd (as it is safe, and simple to use)

For methods that return a 3D vector, add a Python friendly variant that returns a vtkVector3d. This allows the user to get a vector in one line instead of two lines (first line creates a vector, second line sets its value).