### PR TITLE
COMP: Fix CMake extension description tests

### DIFF
--- a/Extensions/CMake/SlicerExtensionDescriptionSpec.cmake
+++ b/Extensions/CMake/SlicerExtensionDescriptionSpec.cmake
@@ -164,7 +164,7 @@ function(slicer_extension_description_spec_defaults_test)
   list(LENGTH Slicer_EXT_REQUIRED_METADATA_NAMES required_metadata_count)
   list(LENGTH Slicer_EXT_OPTIONAL_METADATA_NAMES optional_metadata_count)
 
-  set(expected 15)
+  set(expected 13)
   set(actual ${metadata_count})
   if(NOT ${actual} EQUAL ${expected})
     message(FATAL_ERROR
@@ -178,7 +178,7 @@ function(slicer_extension_description_spec_defaults_test)
       "Problem with metadata_count. Expected: ${expected}, actual: ${actual}")
   endif()
 
-  set(expected 12)
+  set(expected 10)
   set(actual ${optional_metadata_count})
   if(NOT ${actual} EQUAL ${expected})
     message(FATAL_ERROR

--- a/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
+++ b/Extensions/CMake/SlicerFunctionGenerateExtensionDescription.cmake
@@ -135,6 +135,7 @@ function(slicer_generate_extension_description_test)
     EXTENSION_ICONURL "http://www.slicer.org/slicerWiki/images/6/64/SlicerToKiwiExporterLogo.png"
     EXTENSION_NAME "SlicerToKiwiExporter"
     EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/images/9/9e/SlicerToKiwiExporter_Kiwiviewer_8.PNG http://www.slicer.org/slicerWiki/images/a/ab/SlicerToKiwiExporter_Kiwiviewer_9.PNG http://www.slicer.org/slicerWiki/images/9/9a/SlicerToKiwiExporter_SaveDialog_Select-file-format_1.png"
+    EXTENSION_STATUS "Development"
     EXTENSION_WC_REVISION "9d7341e978df954a2c875240290833d7528ef29c"
     EXTENSION_WC_ROOT "https://github.com/jcfr/SlicerToKiwiExporter.git"
     EXTENSION_WC_TYPE "git"
@@ -149,7 +150,6 @@ function(slicer_generate_extension_description_test)
     #EXTENSION_BUILD_SUBDIRECTORY
     #EXTENSION_DEPENDS
     #EXTENSION_ENABLED
-    EXTENSION_STATUS "Development"
     )
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
@@ -169,7 +169,6 @@ function(slicer_generate_extension_description_test)
     EXTENSION_BUILD_SUBDIRECTORY "inner/inner-inner-build"
     EXTENSION_DEPENDS "Foo Bar"
     EXTENSION_ENABLED 0
-    EXTENSION_STATUS ""
     )
   execute_process(
     COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol

--- a/Extensions/CMake/Testing/extension_description_with_depends.s4ext
+++ b/Extensions/CMake/Testing/extension_description_with_depends.s4ext
@@ -6,7 +6,7 @@
 
 # This is source code manager
 scm git
-scmurl git://github.com/jcfr/SlicerToKiwiExporter.git
+scmurl https://github.com/jcfr/SlicerToKiwiExporter.git
 scmrevision 9d7341e978df954a2c875240290833d7528ef29c
 
 # list dependencies
@@ -32,7 +32,7 @@ iconurl http://www.slicer.org/slicerWiki/images/6/64/SlicerToKiwiExporterLogo.pn
 
 # Give people an idea what to expect from this code
 #  - Is it just a test or something you stand behind?
-status
+status Development
 
 # One line stating what the module does
 description The SlicerToKiwiExporter module provides Slicer user with any easy way to export models into a KiwiViewer scene file.

--- a/Extensions/CMake/Testing/extension_description_without_depends.s4ext
+++ b/Extensions/CMake/Testing/extension_description_without_depends.s4ext
@@ -6,7 +6,7 @@
 
 # This is source code manager
 scm git
-scmurl git://github.com/jcfr/SlicerToKiwiExporter.git
+scmurl https://github.com/jcfr/SlicerToKiwiExporter.git
 scmrevision 9d7341e978df954a2c875240290833d7528ef29c
 
 # list dependencies


### PR DESCRIPTION
This commit fixes the following tests:

* `cmake_slicer_extension_description_spec_defaults_test`
* `cmake_slicer_generate_extension_description_test`

by implementing the following changes:

* Fix regression introduced in d1a182641 (STYLE: Trim trailing whitespace)
  by specifying a status value for both "with" and "without" depends tests

* Update s4ext baseline to use "https" instead of "git". This fixes
  a regression introduced in 99578c69e (COMP: Use https protocol for
  git by default) and fb404815f (ENH: Replace git:// by https://)

* Update expected metadata count in description spec test. This fixes
  a regression introduced in 7f533d3d0 (STYLE: Remove svn references
  from extension description file).