### PR TITLE
BUG: Fix intensity masking for Islands effect

### DIFF
--- a/Libs/MRML/Logic/vtkImageLabelOutline.cxx
+++ b/Libs/MRML/Logic/vtkImageLabelOutline.cxx
@@ -254,6 +254,10 @@ void vtkImageLabelOutline::ThreadedExecute(vtkImageData *inData,
     vtkImageLabelOutlineExecute(this, inData, (char *)(inPtr),
       outData, outExt, id);
     break;
+  case VTK_SIGNED_CHAR:
+    vtkImageLabelOutlineExecute(this, inData, (signed char *)(inPtr),
+      outData, outExt, id);
+    break;
   case VTK_UNSIGNED_CHAR:
     vtkImageLabelOutlineExecute(this, inData, (unsigned char *)(inPtr),
       outData, outExt, id);

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorAbstractEffect.cxx
@@ -403,6 +403,7 @@ void qSlicerSegmentEditorAbstractEffect::modifySegmentByLabelmap(vtkMRMLSegmenta
         vtkNew<vtkOrientedImageData> segmentOutsideMask;
         segmentOutsideMask->ShallowCopy(segmentThreshold->GetOutput());
         segmentOutsideMask->CopyDirections(segmentLayerLabelmap);
+        vtkOrientedImageDataResample::ModifyImage(segmentOutsideMask, maskImage, vtkOrientedImageDataResample::OPERATION_MINIMUM);
         vtkOrientedImageDataResample::ModifyImage(modifierLabelmap, segmentOutsideMask, vtkOrientedImageDataResample::OPERATION_MAXIMUM);
         }
       }


### PR DESCRIPTION
Segment editor effects that use "ModificationModeSet" restore the existing segment outside of the masking region. The mask was not being applied, and so the entire segment was restored. Fixed by only restoring the segment outside the mask area.

This commit also adds tests for intensity masking with island effects, and fixes issues that caused the test to fail when run with a main window. (Uninitialized labelmaps + unhandled VTK_SIGNED_CHAR data type in vtkImageLabelOutline).

Fixes #6043