### PR TITLE
ENH: Improve Markups rotation handle appearance

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -959,6 +959,27 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateRot
   this->AxisRotationTubeFilter->SetNumberOfSides(16);
   this->AxisRotationTubeFilter->SetCapping(true);
 
+  vtkNew<vtkPoints> rotationGlyphInteriorAnglePoints;
+  rotationGlyphInteriorAnglePoints->InsertNextPoint(this->AxisRotationArcSource->GetPoint1());
+  rotationGlyphInteriorAnglePoints->InsertNextPoint(-INTERACTION_HANDLE_ROTATION_ARC_RADIUS, 0, 0);
+  rotationGlyphInteriorAnglePoints->InsertNextPoint(this->AxisRotationArcSource->GetPoint2());
+
+  vtkNew<vtkIdList> rotationGlyphInteriorAngleLine;
+  rotationGlyphInteriorAngleLine->SetNumberOfIds(3);
+  rotationGlyphInteriorAngleLine->SetId(0, 0);
+  rotationGlyphInteriorAngleLine->SetId(1, 1);
+  rotationGlyphInteriorAngleLine->SetId(2, 2);
+
+  this->AxisRotationInteriorAnglePolyData = vtkSmartPointer<vtkPolyData>::New();
+  this->AxisRotationInteriorAnglePolyData->SetPoints(rotationGlyphInteriorAnglePoints);
+  this->AxisRotationInteriorAnglePolyData->SetLines(vtkNew<vtkCellArray>());
+  this->AxisRotationInteriorAnglePolyData->InsertNextCell(VTK_LINE, rotationGlyphInteriorAngleLine);
+
+  this->AxisRotationInterorAngleTubeFilter = vtkSmartPointer<vtkTubeFilter>::New();
+  this->AxisRotationInterorAngleTubeFilter->SetInputData(this->AxisRotationInteriorAnglePolyData);
+  this->AxisRotationInterorAngleTubeFilter->SetRadius(INTERACTION_HANDLE_ROTATION_ARC_TUBE_RADIUS);
+  this->AxisRotationInterorAngleTubeFilter->SetNumberOfSides(16);
+
   this->RotationHandlePoints = vtkSmartPointer<vtkPolyData>::New();
 
   this->RotationScaleTransform = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
@@ -968,6 +989,7 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateRot
   this->AxisRotationGlyphSource = vtkSmartPointer <vtkAppendPolyData>::New();
   this->AxisRotationGlyphSource->AddInputConnection(this->AxisRotationHandleSource->GetOutputPort());
   this->AxisRotationGlyphSource->AddInputConnection(this->AxisRotationTubeFilter->GetOutputPort());
+  this->AxisRotationGlyphSource->AddInputConnection(this->AxisRotationInterorAngleTubeFilter->GetOutputPort());
   this->AxisRotationGlypher = vtkSmartPointer<vtkTensorGlyph>::New();
   this->AxisRotationGlypher->SetInputConnection(this->RotationScaleTransform->GetOutputPort());
   this->AxisRotationGlypher->SetSourceConnection(this->AxisRotationGlyphSource->GetOutputPort());

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -196,9 +196,11 @@ protected:
     vtkSmartPointer<vtkSphereSource>                    AxisRotationHandleSource;
     vtkSmartPointer<vtkArcSource>                       AxisRotationArcSource;
     vtkSmartPointer<vtkTubeFilter>                      AxisRotationTubeFilter;
-    vtkSmartPointer<vtkAppendPolyData>                  AxisRotationGlyphSource;
+    vtkSmartPointer<vtkPolyData>                        AxisRotationInteriorAnglePolyData;
+    vtkSmartPointer<vtkTubeFilter>                      AxisRotationInterorAngleTubeFilter;
     vtkSmartPointer<vtkPolyData>                        RotationHandlePoints;
     vtkSmartPointer<vtkTransformPolyDataFilter>         RotationScaleTransform;
+    vtkSmartPointer<vtkAppendPolyData>                  AxisRotationGlyphSource;
     vtkSmartPointer<vtkTensorGlyph>                     AxisRotationGlypher;
 
     vtkSmartPointer<vtkArrowSource>                     AxisTranslationGlyphSource;


### PR DESCRIPTION
Currently the Markups rotation handle "hangs" as a single arc around the rotation axis, which looks strange if the translation handles are hidden. This commit connects the arc with a right angle so that it forms an enclosed shape.

Before:
![image](https://user-images.githubusercontent.com/9222709/143504564-feaabc13-5d2c-4f6d-9ac1-55f33e6885b7.png)

After:
![image](https://user-images.githubusercontent.com/9222709/143504744-817fefb7-29c5-4b4d-b4c2-9ca0561487ac.png)

Re #5061