### PR TITLE
ENH: Enhance the right-click menu in Slicer views

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.cxx
@@ -1113,3 +1113,15 @@ bool vtkMRMLCameraWidget::ProcessMaximizeView(vtkMRMLInteractionEventData* event
 
   return true;
 }
+
+//----------------------------------------------------------------------------
+bool vtkMRMLCameraWidget::GetTiltLocked()
+{
+  return this->CameraTiltLocked;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLCameraWidget::SetTiltLocked(bool lockState)
+{
+  this->CameraTiltLocked = lockState;
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
@@ -68,6 +68,13 @@ public:
   /// Process interaction event.
   bool ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData) override;
 
+  //@{
+  /// Get set tilt lock. It tilt is locked then the view cannot be rotated around the horizontal axis
+  /// (can only be rotated along the vertical axis).
+  bool GetTiltLocked();
+  void SetTiltLocked(bool lockState);
+  //@}
+
   /// Widget states
   enum
     {

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
@@ -430,7 +430,7 @@
         <item>
          <widget class="QToolButton" name="SliceLinkButton">
           <property name="toolTip">
-           <string>Link/Unlink the slice controls (except scales) across all Slice Viewers.</string>
+           <string>Link slice views. Synchronizes properties of all slice views in the same view group.</string>
           </property>
           <property name="text">
            <string/>
@@ -707,7 +707,7 @@
     <string>Fit to window</string>
    </property>
    <property name="toolTip">
-    <string>Adjust the Slice Viewer's field of view to match the extent of lowest non-None volume layer (bg, then fg, then label).</string>
+    <string>Reset field of view. Adjusts the slice view's field of view to match the extent of lowest volume layer (background, then foreground, then label).</string>
    </property>
   </action>
   <action name="actionRotate_to_volume_plane">

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLThreeDViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLThreeDViewControllerWidget.ui
@@ -254,14 +254,14 @@
         <bool>false</bool>
        </property>
        <property name="toolTip">
-        <string>Center the 3D view on the scene.</string>
+        <string>Center view</string>
        </property>
       </widget>
      </item>
      <item row="0" column="0">
       <widget class="QToolButton" name="ViewLinkButton">
        <property name="toolTip">
-        <string>Link/Unlink the view controls across all 3D Viewers.</string>
+        <string>Link 3D views. Synchronizes properties of all 3D views in the same view group.</string>
        </property>
        <property name="text">
         <string/>
@@ -398,7 +398,7 @@
     <string>Center</string>
    </property>
    <property name="toolTip">
-    <string>Center the 3D view on the scene</string>
+    <string>Center view</string>
    </property>
   </action>
   <action name="actionUseDepthPeeling">

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
@@ -41,6 +41,7 @@
 #include <vtkMRMLLayoutNode.h>
 #include <vtkMRMLScene.h>
 #include <vtkMRMLSliceNode.h>
+#include <qMRMLThreeDViewControllerWidget.h>
 
 // Slicer includes
 #include <qSlicerApplication.h>
@@ -49,6 +50,8 @@
 // VTK includes
 #include <vtkObjectFactory.h>
 #include <vtkSmartPointer.h>
+#include <vtkMRMLCameraDisplayableManager.h>
+#include <vtkMRMLCameraWidget.h>
 
 // CTK includes
 #include "ctkSignalMapper.h"
@@ -73,12 +76,16 @@ public:
   QAction* InteractionModePlaceAction = nullptr;
 
   QAction* MaximizeViewAction = nullptr;
+  QAction* FitSliceViewAction = nullptr;
+  QAction* CenterThreeDViewAction = nullptr;
   QAction* CopyImageAction = nullptr;
   QAction* ConfigureSliceViewAnnotationsAction = nullptr;
+  QAction* ToggleTiltLockAction = nullptr;
 
   vtkWeakPointer<vtkMRMLInteractionNode> InteractionNode;
   vtkWeakPointer<vtkMRMLAbstractViewNode> ViewNode;
   vtkWeakPointer<vtkMRMLLayoutNode> LayoutNode;
+  vtkWeakPointer<vtkMRMLCameraWidget> CameraWidget;
 };
 
 //-----------------------------------------------------------------------------
@@ -131,26 +138,50 @@ void qSlicerSubjectHierarchyViewContextMenuPluginPrivate::init()
 
   // Other
 
+  this->CenterThreeDViewAction = new QAction(tr("Center view"), q);
+  this->CenterThreeDViewAction->setObjectName("CenterViewAction");
+  this->CenterThreeDViewAction->setToolTip(tr("Center the slice on the currently visible 3D view content and all loaded volumes."));
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CenterThreeDViewAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 0);
+  QObject::connect(this->CenterThreeDViewAction, SIGNAL(triggered()), q, SLOT(centerThreeDView()));
+
+  this->FitSliceViewAction = new QAction(tr("Reset field of view"), q);
+  this->FitSliceViewAction->setObjectName("FitViewAction");
+  this->FitSliceViewAction->setToolTip(tr("Center the slice view on the currently displayed volume."));
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->FitSliceViewAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 1);
+  QObject::connect(this->FitSliceViewAction, SIGNAL(triggered()), q, SLOT(fitSliceView()));
+
   this->MaximizeViewAction = new QAction(tr("Maximize view"), q);
   this->MaximizeViewAction->setObjectName("MaximizeViewAction");
   this->MaximizeViewAction->setToolTip(tr("Show this view maximized in the view layout"));
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->MaximizeViewAction,
-    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 0);
+    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 2);
   QObject::connect(this->MaximizeViewAction, SIGNAL(triggered()), q, SLOT(maximizeView()));
 
-  this->CopyImageAction = new QAction(tr("Copy image"), q);
-  this->CopyImageAction->setObjectName("CopyImageAction");
-  this->CopyImageAction->setToolTip(tr("Copy a screenshot of this view to the clipboard"));
-  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CopyImageAction,
-    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 1);
-  QObject::connect(this->CopyImageAction, SIGNAL(triggered()), q, SLOT(saveScreenshot()));
+  this->ToggleTiltLockAction = new QAction(tr("Tilt lock"), q);
+  this->ToggleTiltLockAction->setObjectName("TiltLockAction");
+  this->ToggleTiltLockAction->setToolTip(tr("Prevent rotation around the horizontal axis when rotating this view."));
+  this->ToggleTiltLockAction->setShortcut(QKeySequence(tr("Ctrl+b")));
+  this->ToggleTiltLockAction->setCheckable(true);
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ToggleTiltLockAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 3);
+  QObject::connect(this->ToggleTiltLockAction, SIGNAL(triggered()), q, SLOT(toggleTiltLock()));
 
   this->ConfigureSliceViewAnnotationsAction = new QAction(tr("Configure slice view annotations..."), q);
   this->ConfigureSliceViewAnnotationsAction->setObjectName("ConfigureSliceViewAnnotationsAction");
   this->ConfigureSliceViewAnnotationsAction->setToolTip(tr("Configures display of corner annotations and color bar."));
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ConfigureSliceViewAnnotationsAction,
-    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 2);
+    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 4);
   QObject::connect(this->ConfigureSliceViewAnnotationsAction, SIGNAL(triggered()), q, SLOT(configureSliceViewAnnotationsAction()));
+
+  this->CopyImageAction = new QAction(tr("Copy image"), q);
+  this->CopyImageAction->setObjectName("CopyImageAction");
+  this->CopyImageAction->setToolTip(tr("Copy a screenshot of this view to the clipboard"));
+  qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CopyImageAction,
+    qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 20); // set to 20 to make it the last item in the action group
+  QObject::connect(this->CopyImageAction, SIGNAL(triggered()), q, SLOT(saveScreenshot()));
+
 }
 
 //-----------------------------------------------------------------------------
@@ -182,7 +213,10 @@ QList<QAction*> qSlicerSubjectHierarchyViewContextMenuPlugin::viewContextMenuAct
     << d->InteractionModeAdjustWindowLevelAction
     << d->InteractionModePlaceAction
     << d->MaximizeViewAction
+    << d->FitSliceViewAction
+    << d->CenterThreeDViewAction
     << d->CopyImageAction
+    << d->ToggleTiltLockAction
     << d->ConfigureSliceViewAnnotationsAction;
   return actions;
 }
@@ -256,12 +290,44 @@ void qSlicerSubjectHierarchyViewContextMenuPlugin::showViewContextMenuActionsFor
 
   d->CopyImageAction->setVisible(true);
 
-  bool isSliceViewNode = (vtkMRMLSliceNode::SafeDownCast(viewNode) != nullptr);
-  d->ConfigureSliceViewAnnotationsAction->setVisible(isSliceViewNode);
-
   // Cache nodes to have them available for the menu action execution.
   d->InteractionNode = interactionNode;
   d->ViewNode = viewNode;
+
+  // Check tilt lock in camera widget and set menu item accordingly
+  bool isSliceViewNode = (vtkMRMLSliceNode::SafeDownCast(viewNode) != nullptr);
+  d->ConfigureSliceViewAnnotationsAction->setVisible(isSliceViewNode);
+  d->FitSliceViewAction->setVisible(isSliceViewNode);
+  d->CenterThreeDViewAction->setVisible(!isSliceViewNode);
+
+  d->ToggleTiltLockAction->setVisible(!isSliceViewNode);
+  if (!qSlicerApplication::application()
+    || !qSlicerApplication::application()->layoutManager())
+    {
+    qWarning() << Q_FUNC_INFO << " failed: cannot get layout manager";
+    return;
+    }
+  QWidget* widget = qSlicerApplication::application()->layoutManager()->viewWidget(d->ViewNode);
+
+  qMRMLThreeDWidget* threeDWidget = qobject_cast<qMRMLThreeDWidget*>(widget);
+  vtkMRMLCameraWidget* cameraWidget = nullptr;
+  if (threeDWidget)
+    {
+    vtkMRMLCameraDisplayableManager* cameraDisplayableManager = vtkMRMLCameraDisplayableManager::SafeDownCast(threeDWidget->
+      threeDView()->displayableManagerByClassName("vtkMRMLCameraDisplayableManager"));
+    if (!cameraDisplayableManager)
+      {
+      qWarning() << Q_FUNC_INFO << " failed: cannot get cameraDisplayableManager";
+      return;
+      }
+    else
+      {
+      cameraWidget = cameraDisplayableManager->GetCameraWidget();
+      d->ToggleTiltLockAction->setChecked(cameraWidget->GetTiltLocked());
+      // Cache camera widget pointer to have it available for the menu action execution.
+      d->CameraWidget = cameraWidget;
+      }
+    }
 }
 
 //---------------------------------------------------------------------------
@@ -347,4 +413,66 @@ void qSlicerSubjectHierarchyViewContextMenuPlugin::maximizeView()
     {
     d->LayoutNode->SetMaximizedViewNode(nullptr);
     }
+}
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyViewContextMenuPlugin::fitSliceView()
+{
+  Q_D(qSlicerSubjectHierarchyViewContextMenuPlugin);
+
+  if (!qSlicerApplication::application()
+    || !qSlicerApplication::application()->layoutManager())
+    {
+    qWarning() << Q_FUNC_INFO << " failed: cannot get layout manager";
+    return;
+    }
+  QWidget* widget = qSlicerApplication::application()->layoutManager()->viewWidget(d->ViewNode);
+
+  qMRMLSliceWidget* sliceWidget = qobject_cast<qMRMLSliceWidget*>(widget);
+  if (sliceWidget)
+  {
+    sliceWidget->fitSliceToBackground();
+  }
+  else
+  {
+    qWarning() << Q_FUNC_INFO << " failed: sliceWidget not found";
+    return;
+  }
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyViewContextMenuPlugin::centerThreeDView()
+{
+  Q_D(qSlicerSubjectHierarchyViewContextMenuPlugin);
+
+  if (!qSlicerApplication::application()
+    || !qSlicerApplication::application()->layoutManager())
+  {
+    qWarning() << Q_FUNC_INFO << " failed: cannot get layout manager";
+    return;
+  }
+  QWidget* widget = qSlicerApplication::application()->layoutManager()->viewWidget(d->ViewNode);
+
+  qMRMLThreeDWidget* threeDWidget = qobject_cast<qMRMLThreeDWidget*>(widget);
+  if (threeDWidget)
+  {
+    qMRMLThreeDViewControllerWidget* threeDWidgetController = threeDWidget->threeDController();
+    threeDWidgetController->resetFocalPoint();
+  }
+  else
+  {
+    qWarning() << Q_FUNC_INFO << " failed: threeDWidget not found";
+    return;
+  }
+}
+
+//---------------------------------------------------------------------------
+void qSlicerSubjectHierarchyViewContextMenuPlugin::toggleTiltLock()
+{
+  Q_D(qSlicerSubjectHierarchyViewContextMenuPlugin);
+  if (!d->CameraWidget)
+  {
+    qWarning() << Q_FUNC_INFO << " failed: camera widget not found.";
+    return;
+  }
+  d->CameraWidget->SetTiltLocked(!d->CameraWidget->GetTiltLocked());
 }

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
@@ -64,6 +64,9 @@ protected slots:
   void saveScreenshot();
   void configureSliceViewAnnotationsAction();
   void maximizeView();
+  void fitSliceView();
+  void centerThreeDView();
+  void toggleTiltLock();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyViewContextMenuPluginPrivate> d_ptr;


### PR DESCRIPTION
Using the right-click menu is a convenient way to interact with the Slicer views. The top 'center view' icon is probably the one most used in Slicer, but the icon itself is small and a small but significant amount of time is needed to focus the mouse on this spot. The tilt-lock key combination is a little hard to grab and the status of the tilt-lock is not displayed. So this PR is about:       

*   Add 'Fit View' menu entry in scalar volume view
*   Add 'Center 3D view' menu entry  in 3D view
*   Add a checkable 'Tilt lock' menu entry in 3D view and connect it to the camera widget

Tested for several days, works well.

![](https://user-images.githubusercontent.com/18140094/143775979-77d55667-5e0b-4eab-888c-b15fe0b76571.png)

![](https://user-images.githubusercontent.com/18140094/143776067-fa93e46a-1eae-4803-aa59-d6cf71f072a1.png)