### PR TITLE
BUG: Prevent data probe from expanding horizontally

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -69,6 +69,10 @@ class DataProbeInfoWidget:
 
     self.frame = qt.QFrame(parent)
     self.frame.setLayout(qt.QVBoxLayout())
+    # Set horizontal policy to Ignored to prevent a long segment or volume name making the widget wider.
+    # If the module panel made larger then the image viewers would move and the mouse pointer position
+    # would change in the image, potentially pointing outside the node with the long name, resulting in the
+    # module panel collapsing to the original size, causing an infinite oscillation.
     qSize = qt.QSizePolicy()
     qSize.setHorizontalPolicy(qt.QSizePolicy.Ignored)
     qSize.setVerticalPolicy(qt.QSizePolicy.Preferred)

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -69,6 +69,10 @@ class DataProbeInfoWidget:
 
     self.frame = qt.QFrame(parent)
     self.frame.setLayout(qt.QVBoxLayout())
+    qSize = qt.QSizePolicy()
+    qSize.setHorizontalPolicy(qt.QSizePolicy.Ignored)
+    qSize.setVerticalPolicy(qt.QSizePolicy.Preferred)
+    self.frame.setSizePolicy(qSize)
 
     modulePath = slicer.modules.dataprobe.path.replace("DataProbe.py","")
     self.iconsDIR = modulePath + '/Resources/Icons'


### PR DESCRIPTION
By setting the the horizontal size policy of the data probe widget to "Ignored", the widget will use as much space as is provided horizontally, but will never cause the module panel to change size.
The widget can still expand vertically, allowing strings that are too long to be displayed in a single line to be wrapped and not truncated.