### PR TITLE
COMP: Improve "CI" GitHub Action workflow uploading package as artifact

### DIFF
--- a/.github/actions/slicer-build/entrypoint.sh
+++ b/.github/actions/slicer-build/entrypoint.sh
@@ -10,7 +10,7 @@ cp -r $GITHUB_WORKSPACE /usr/src/Slicer
 package_filepath=$(head -n1 /usr/src/Slicer-build/Slicer-build/PACKAGE_FILE.txt)
 echo "package_filepath [${package_filepath}]"
 
-mv ${package_filepath} $RUNNER_TEMP/
+mv ${package_filepath} $GITHUB_WORKSPACE/
 
 package=$(basename $package_filepath)
 echo "package [${package}]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,9 @@ jobs:
       - name: 'Build Slicer'
         uses: ./.github/actions/slicer-build
 
+      - name: 'Upload Slicer package'
+        uses: actions/upload-artifact@v2
+        with:
+          name: slicer-package
+          path: ${{ github.workspace }}/${{ steps.slicer-build.outputs.package }}
+          retention-days: 1


### PR DESCRIPTION
This commit copies the package to `GITHUB_WORKSPACE` instead of `RUNNER_TEMP`. This
is required to workaround issue discussed in actions/runner#965 (Incorrect context
paths in container)

It also adds a step for uploading the generated Slicer package as an
artifact with a retention time of 1 day.