### PR TITLE
ENH: Use markup type internal name when display name not specified

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -152,7 +152,7 @@ public:
 
   /// Get markup type GUI display name. This name can be shown to the user
   /// (and may be translated to different language in the application).
-  virtual const char* GetMarkupTypeDisplayName() {return "Markup";};
+  virtual const char* GetMarkupTypeDisplayName() {return GetMarkupType();};
 
   /// Get markup short name
   virtual const char* GetDefaultNodeNamePrefix() {return "M";};


### PR DESCRIPTION
A custom markup "GridSurface" did not specify a `GetMarkupTypeDisplayName`, so in Slicer it was shown as "Markup" in the Markups module. This isn't helpful so it should fallback to use the internal markup type name of "GridSurface" even though it should have a `GetMarkupTypeDisplayName` method that defines it as "Grid Surface" (see https://github.com/cpinter/SlicerSurfaceMarkup/pull/3).

| Current | This PR |
|----------|---------|
|![image](https://user-images.githubusercontent.com/15837524/144295645-3adf5fc5-e643-42ba-ba8e-bce18253a76a.png)|![image](https://user-images.githubusercontent.com/15837524/144297410-8e5539ba-32bb-40a8-bd7e-693d9447d8e9.png)|