### PR TITLE
DOC: Clarify "size" description in markups JSON schema

### DIFF
--- a/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
+++ b/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
@@ -149,7 +149,7 @@
                                     "$id": "#markup/size",
                                     "type": "array",
                                     "title": "Size",
-                                    "description": "The size of the markups representation. Ex. size of the ROI or plane markups.",
+                                    "description": "The size of the markups representation. Ex. size (=axis-aligned edge lengths) of the ROI or plane markups.",
                                     "examples": [[5.0, 5.0, 4.0], [5.0, 5.0, 0.0]],
                                     "additionalItems": false,
                                     "items": { "type": "number" },

--- a/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
+++ b/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
@@ -149,7 +149,7 @@
                                     "$id": "#markup/size",
                                     "type": "array",
                                     "title": "Size",
-                                    "description": "The size of the markups representation. Ex. size (=axis-aligned edge lengths) of the ROI or plane markups.",
+                                    "description": "The size of the markups representation. For example, axis-aligned edge lengths of the ROI or plane markups.",
                                     "examples": [[5.0, 5.0, 4.0], [5.0, 5.0, 0.0]],
                                     "additionalItems": false,
                                     "items": { "type": "number" },


### PR DESCRIPTION
Attempted to modify the description of the "size" item so that it more clearly distinguished between characterizing the size of a markups object as a radius from a center point vs a diameter across a center point.  Schema change was suggested here: https://discourse.slicer.org/t/explanation-needed-for-json-files-created-by-markup/20842/7