### PR TITLE
COMP: Update SystemTools use anticipating update from VTK 9.0 to 9.1

### DIFF
--- a/Libs/MRML/Core/vtkArchive.cxx
+++ b/Libs/MRML/Core/vtkArchive.cxx
@@ -532,7 +532,11 @@ bool vtkArchive::UnZip(const char* zipFileName, const char* destinationDirectory
 
   std::string cwd = vtksys::SystemTools::GetCurrentWorkingDirectory();
 
+#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
+  if ( !vtksys::SystemTools::ChangeDirectory(destinationDirectory) )
+#else
   if ( vtksys::SystemTools::ChangeDirectory(destinationDirectory) )
+#endif
     {
     vtkArchiveTools::Error("Unzip:", "could not change to destination directory");
     return false;
@@ -641,8 +645,11 @@ bool vtkArchive::UnZip(const char* zipFileName, const char* destinationDirectory
     return false;
     }
 
-
+#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
+  if ( !vtksys::SystemTools::ChangeDirectory(cwd.c_str()) )
+#else
   if ( vtksys::SystemTools::ChangeDirectory(cwd.c_str()) )
+#endif
     {
     vtkArchiveTools::Error("Unzip:", "could not change back to working directory");
     return false;

--- a/Libs/MRML/Core/vtkCacheManager.cxx
+++ b/Libs/MRML/Core/vtkCacheManager.cxx
@@ -643,7 +643,11 @@ int vtkCacheManager::ClearCache()
     this->MarkNodesBeforeDeletingDataFromCache ( this->RemoteCacheDirectory.c_str() );
     vtksys::SystemTools::RemoveADirectory ( this->RemoteCacheDirectory.c_str() );
     }
+#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
+  if ( !vtksys::SystemTools::MakeDirectory ( this->RemoteCacheDirectory.c_str() ) )
+#else
   if ( vtksys::SystemTools::MakeDirectory ( this->RemoteCacheDirectory.c_str() ) == false )
+#endif
     {
     vtkWarningMacro ( "Cache cleared: Error: unable to recreate cache directory after deleting its contents." );
     return 0;

--- a/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeArchetypeStorageNode.cxx
@@ -634,7 +634,11 @@ int vtkMRMLVolumeArchetypeStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
         }
       }
     // delete the temporary dir and all remaining contents
+#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
+    bool dirRemoved = vtksys::SystemTools::RemoveADirectory(moveFromDir.c_str()).IsSuccess();
+#else
     bool dirRemoved = vtksys::SystemTools::RemoveADirectory(moveFromDir.c_str());
+#endif
     if (!dirRemoved)
       {
       vtkWarningMacro("Failed to remove temporary write directory " << moveFromDir);
@@ -880,7 +884,11 @@ std::string vtkMRMLVolumeArchetypeStorageNode::UpdateFileList(vtkMRMLNode *refNo
 
   // look through the new dir and populate the file list
   vtksys::Directory dir;
+#if (VTK_MAJOR_VERSION >= 9 && VTK_MINOR_VERSION >= 0 && VTK_BUILD_VERSION >= 20210806)
+  success = dir.Load(tempDir.c_str()).IsSuccess();
+#else
   success = dir.Load(tempDir.c_str());
+#endif
   vtkDebugMacro("UpdateFileList: tempdir " << tempDir.c_str() << " has " << dir.GetNumberOfFiles() << " in it");
   if (!success)
     {


### PR DESCRIPTION
This commit addresses build issues related to the KWSys updates related
to return result of function like SystemTools::MakeDirectory introduced in
commit Kitware/VTK@8cb5e736a (Merge branch 'upstream-KWSys' into HEAD).