### PR TITLE
ENH: added check for accepted event

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -1097,7 +1097,7 @@ void qSlicerMainWindow::closeEvent(QCloseEvent *event)
     }
   d->IsClosing = true;
 
-  if (d->confirmCloseApplication())
+  if (event->isAccepted() || d->confirmCloseApplication())
     {
     // Proceed with closing the application
 


### PR DESCRIPTION
If the close event was treated at an event filter and accepted, do not show the confirmation dialog and perform the remaining on close routines.