### PR TITLE
ENH: Add vtkMRMLMarkupsDisplayNode interaction handle scale property

### DIFF
--- a/Docs/user_guide/modules/markups.md
+++ b/Docs/user_guide/modules/markups.md
@@ -64,7 +64,10 @@ Display section:
 - Opacity: overall opacity of the selected markup.
 - Glyph Size: Set control point glyph size relative to the screen size (if `absolute` button is not pressed) or as an absolute size (if `absolute` button is depressed).
 - Text Scale: Label size relative to screen size.
-- Interaction: check `Visible` to enable translation of the entire markups in slice and 3D views with an interactive widget.
+- Interaction handles:
+  - Visibilty: check `Visible` to enable translation/rotation/scaling of the entire markups in slice and 3D views with an interactive widget.
+  - Translate, Rotate, Scale: enable/disable adjustment types.
+  - Size: size of the handles (relative to the application window size).
 - Advanced:
   - View: Select which views the markup is displayed in
   - Selected Color: Select the color that will be used to display the glyph and text when the markup is marked as selected.

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -1125,6 +1125,8 @@ void vtkSlicerMarkupsLogic::CopyBasicDisplayProperties(vtkMRMLMarkupsDisplayNode
   targetDisplayNode->SetColor(sourceDisplayNode->GetColor());
   targetDisplayNode->SetActiveColor(sourceDisplayNode->GetActiveColor());
   targetDisplayNode->SetOpacity(sourceDisplayNode->GetOpacity());
+
+  targetDisplayNode->SetInteractionHandleScale(sourceDisplayNode->GetInteractionHandleScale());
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -130,6 +130,7 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->TranslationHandleVisibility = true;
   this->RotationHandleVisibility = true;
   this->ScaleHandleVisibility = true;
+  this->InteractionHandleScale = 3.0; // size of the handles as percent in screen size
 
   // Line color node
   vtkNew<vtkIntArray> events;
@@ -176,6 +177,7 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(translationHandleVisibility, TranslationHandleVisibility);
   vtkMRMLWriteXMLBooleanMacro(rotationHandleVisibility, RotationHandleVisibility);
   vtkMRMLWriteXMLBooleanMacro(scaleHandleVisibility, ScaleHandleVisibility);
+  vtkMRMLWriteXMLFloatMacro(interactionHandleScale, InteractionHandleScale);
   vtkMRMLWriteXMLBooleanMacro(fillVisibility, FillVisibility);
   vtkMRMLWriteXMLBooleanMacro(outlineVisibility, OutlineVisibility);
   vtkMRMLWriteXMLFloatMacro(fillOpacity, FillOpacity);
@@ -222,6 +224,7 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(translationHandleVisibility, TranslationHandleVisibility);
   vtkMRMLReadXMLBooleanMacro(rotationHandleVisibility, RotationHandleVisibility);
   vtkMRMLReadXMLBooleanMacro(scaleHandleVisibility, ScaleHandleVisibility);
+  vtkMRMLReadXMLFloatMacro(interactionHandleScale, InteractionHandleScale);
   vtkMRMLReadXMLBooleanMacro(fillVisibility, FillVisibility);
   vtkMRMLReadXMLBooleanMacro(outlineVisibility, OutlineVisibility);
   vtkMRMLReadXMLFloatMacro(fillOpacity, FillOpacity);
@@ -300,6 +303,7 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   vtkMRMLCopyBooleanMacro(TranslationHandleVisibility);
   vtkMRMLCopyBooleanMacro(RotationHandleVisibility);
   vtkMRMLCopyBooleanMacro(ScaleHandleVisibility);
+  vtkMRMLCopyFloatMacro(InteractionHandleScale);
   vtkMRMLCopyBooleanMacro(FillVisibility);
   vtkMRMLCopyBooleanMacro(OutlineVisibility);
   vtkMRMLCopyFloatMacro(FillOpacity);
@@ -494,6 +498,7 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBooleanMacro(TranslationHandleVisibility);
   vtkMRMLPrintBooleanMacro(RotationHandleVisibility);
   vtkMRMLPrintBooleanMacro(ScaleHandleVisibility);
+  vtkMRMLPrintFloatMacro(InteractionHandleScale);
   vtkMRMLPrintBooleanMacro(FillVisibility);
   vtkMRMLPrintBooleanMacro(OutlineVisibility);
   vtkMRMLPrintFloatMacro(FillOpacity);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -438,6 +438,11 @@ public:
   void SetHandleVisibility(int handleType, bool visibility);
   bool GetHandleVisibility(int handleType);
 
+  /// Get/Set interaction handle size relative to the window size.
+  /// Diameter of the interaction handle points is defined as "scale" percentage of diagonal size of the window.
+  vtkSetMacro(InteractionHandleScale, double);
+  vtkGetMacro(InteractionHandleScale, double);
+
   /// Get data set containing the scalar arrays for this node type.
   /// For markups it is the curve poly data
   virtual vtkDataSet* GetScalarDataSet() override;
@@ -521,5 +526,6 @@ protected:
   bool TranslationHandleVisibility;
   bool RotationHandleVisibility;
   bool ScaleHandleVisibility;
+  double InteractionHandleScale;
 };
 #endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -793,6 +793,10 @@ bool vtkMRMLMarkupsJsonStorageNode::vtkInternal::UpdateMarkupsDisplayNodeFromJso
     {
     displayNode->SetScaleHandleVisibility(displayItem["scaleHandleVisibility"].GetBool());
     }
+  if (displayItem.HasMember("interactionHandleScale"))
+    {
+    displayNode->SetInteractionHandleScale(displayItem["interactionHandleScale"].GetDouble());
+    }
   if (displayItem.HasMember("snapMode"))
     {
     int snapMode = vtkMRMLMarkupsDisplayNode::GetSnapModeFromString(displayItem["snapMode"].GetString());
@@ -1078,6 +1082,8 @@ bool vtkMRMLMarkupsJsonStorageNode::vtkInternal::WriteDisplayProperties(
   writer.Key("translationHandleVisibility"); writer.Bool(markupsDisplayNode->GetTranslationHandleVisibility());
   writer.Key("rotationHandleVisibility"); writer.Bool(markupsDisplayNode->GetRotationHandleVisibility());
   writer.Key("scaleHandleVisibility"); writer.Bool(markupsDisplayNode->GetScaleHandleVisibility());
+  writer.Key("interactionHandleScale"); writer.Double(markupsDisplayNode->GetInteractionHandleScale());
+
   writer.Key("snapMode"); writer.String(markupsDisplayNode->GetSnapModeAsString(markupsDisplayNode->GetSnapMode()));
 
   writer.EndObject();

--- a/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
+++ b/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
@@ -532,6 +532,13 @@
                                             "description": "Visibility of the scale interaction handles",
                                             "default": false
                                         },
+                                        "interactionHandleScale": {
+                                            "$id": "#display/interactionHandleScale",
+                                            "type": "number",
+                                            "title": "Interaction handle glyph scale",
+                                            "description": "Interaction handle size as percentage of window size.",
+                                            "default": 3.0
+                                        },
                                         "snapMode": {
                                             "$id": "#display/snapMode",
                                             "type": "string",

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -224,7 +224,7 @@ protected:
 
     double                                              StartFadeAngle{30};
     double                                              EndFadeAngle{20};
-    double                                              InteractionHandleScaleFactor{7.0};
+    double                                              InteractionHandleSize{1.0};
 
     virtual void InitializePipeline();
     virtual void CreateRotationHandles();
@@ -296,6 +296,9 @@ protected:
   virtual void UpdateViewScaleFactor() = 0;
 
   virtual void UpdateControlPointSize() = 0;
+
+  // Update the size of the interaction handle based on screen size + vtkMRMLMarkupsDisplayNode::InteractionHandleScale parameter.
+  virtual void UpdateInteractionHandleSize();
 
   double ViewScaleFactorMmPerPixel;
   double ScreenSizePixel; // diagonal size of the screen

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -466,6 +466,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller,
     }
 
   this->UpdateControlPointSize();
+  this->UpdateInteractionHandleSize();
 
   // Points widgets have only one Markup/Representation
   this->AnyPointVisibilityOnSlice = false;
@@ -586,7 +587,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::CanInteractWithHandles(
     return;
     }
 
-  double maxPickingDistanceFromControlPoint2 = this->GetMaximumControlPointPickingDistance2();
+  double maxPickingDistanceFromInteractionHandle2 = this->GetMaximumInteractionHandlePickingDistance2();
 
   const int* displayPosition = interactionEventData->GetDisplayPosition();
   double displayPosition3[3] = { static_cast<double>(displayPosition[0]), static_cast<double>(displayPosition[1]), 0.0 };
@@ -609,7 +610,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::CanInteractWithHandles(
     rasToxyMatrix->MultiplyPoint(handleWorldPos, handleDisplayPos);
     handleDisplayPos[2] = displayPosition3[2]; // Handles are always projected
     double dist2 = vtkMath::Distance2BetweenPoints(handleDisplayPos, displayPosition3);
-    if (dist2 < maxPickingDistanceFromControlPoint2 && dist2 < closestDistance2)
+    if (dist2 < maxPickingDistanceFromInteractionHandle2 && dist2 < closestDistance2)
       {
       closestDistance2 = dist2;
       foundComponentType = handleInfo.ComponentType;
@@ -641,7 +642,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::CanInteractWithHandles(
       double t = 0;
       double lineDistance = vtkLine::DistanceToLine(displayPosition3, originDisplayPos, handleDisplayPos, t);
       double lineDistance2 = lineDistance * lineDistance;
-      if (lineDistance2 < maxPickingDistanceFromControlPoint2 / 2.0 && lineDistance2 < closestDistance2)
+      if (lineDistance2 < maxPickingDistanceFromInteractionHandle2 / 2.0 && lineDistance2 < closestDistance2)
         {
         closestDistance2 = lineDistance2;
         foundComponentType = handleInfo.ComponentType;
@@ -764,9 +765,8 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderOpaqueGeometry(
   if (this->InteractionPipeline && this->InteractionPipeline->Actor->GetVisibility())
     {
     this->InteractionPipeline->UpdateHandleColors();
-    double interactionWidgetScale = this->InteractionPipeline->InteractionHandleScaleFactor *
-      this->ControlPointSize * this->ViewScaleFactorMmPerPixel;
-    this->InteractionPipeline->SetWidgetScale(interactionWidgetScale);
+    this->UpdateInteractionHandleSize();
+    this->InteractionPipeline->SetWidgetScale(this->InteractionPipeline->InteractionHandleSize);
     count += this->InteractionPipeline->Actor->RenderOpaqueGeometry(viewport);
     }
   if (this->TextActor->GetVisibility())
@@ -1257,11 +1257,23 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateControlPointSize()
     this->ControlPointSize = this->MarkupsDisplayNode->GetGlyphSize() / this->ViewScaleFactorMmPerPixel;
     }
 }
+
 //----------------------------------------------------------------------
 double vtkSlicerMarkupsWidgetRepresentation2D::GetMaximumControlPointPickingDistance2()
 {
   double maximumControlPointPickingDistance = this->ControlPointSize / 2.0 + this->PickingTolerance * this->ScreenScaleFactor;
   return maximumControlPointPickingDistance * maximumControlPointPickingDistance;
+}
+
+//----------------------------------------------------------------------
+double vtkSlicerMarkupsWidgetRepresentation2D::GetMaximumInteractionHandlePickingDistance2()
+{
+  if (!this->InteractionPipeline)
+    {
+    return 0.0;
+    }
+  double maximumInteractionHandlePickingDistance = this->InteractionPipeline->InteractionHandleSize / 2.0 + this->PickingTolerance * this->ScreenScaleFactor;
+  return maximumInteractionHandlePickingDistance * maximumInteractionHandlePickingDistance;
 }
 
 //----------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
@@ -118,6 +118,9 @@ protected:
   // Return squared distance of maximum distance for picking a control point,
   // in pixels.
   double GetMaximumControlPointPickingDistance2();
+  // Return squared distance of maximum distance for picking an interaction handle,
+  // in pixels.
+  double GetMaximumInteractionHandlePickingDistance2();
 
   bool GetAllControlPointsVisible() override;
 

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsInteractionHandleWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsInteractionHandleWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>462</width>
-    <height>38</height>
+    <width>233</width>
+    <height>66</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -32,10 +32,10 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="1" column="1">
-    <widget class="QCheckBox" name="overallVisibilityCheckBox">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string/>
+      <string>Size:</string>
      </property>
     </widget>
    </item>
@@ -52,7 +52,20 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1" colspan="2">
+    <widget class="ctkSliderWidget" name="interactionHandleScaleSlider">
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>20.000000000000000</double>
+     </property>
+     <property name="suffix">
+      <string> %</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QCheckBox" name="translateVisibilityCheckBox">
@@ -77,6 +90,13 @@
      </item>
     </layout>
    </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QCheckBox" name="overallVisibilityCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -85,6 +105,11 @@
    <extends>QWidget</extends>
    <header>qMRMLWidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
@@ -60,6 +60,7 @@ void qMRMLMarkupsInteractionHandleWidgetPrivate::init()
   QObject::connect(this->translateVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
   QObject::connect(this->rotateVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
   QObject::connect(this->scaleVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->interactionHandleScaleSlider, SIGNAL(valueChanged(double)), q, SLOT(updateMRMLFromWidget()));
 }
 
 // --------------------------------------------------------------------------
@@ -105,6 +106,7 @@ void qMRMLMarkupsInteractionHandleWidget::updateWidgetFromMRML()
   d->translateVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
   d->rotateVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
   d->scaleVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->interactionHandleScaleSlider->setEnabled(d->DisplayNode != nullptr);
   if (!d->DisplayNode)
     {
     return;
@@ -141,6 +143,14 @@ void qMRMLMarkupsInteractionHandleWidget::updateWidgetFromMRML()
   wasBlocking = d->scaleVisibilityCheckBox->blockSignals(true);
   d->scaleVisibilityCheckBox->setChecked(d->DisplayNode->GetScaleHandleVisibility());
   d->scaleVisibilityCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->interactionHandleScaleSlider->blockSignals(true);
+  if (d->DisplayNode->GetInteractionHandleScale() > d->interactionHandleScaleSlider->maximum())
+    {
+    d->interactionHandleScaleSlider->setMaximum(d->DisplayNode->GetInteractionHandleScale());
+    }
+  d->interactionHandleScaleSlider->setValue(d->DisplayNode->GetInteractionHandleScale());
+  wasBlocking = d->interactionHandleScaleSlider->blockSignals(wasBlocking);
 }
 
 // --------------------------------------------------------------------------
@@ -157,4 +167,5 @@ void qMRMLMarkupsInteractionHandleWidget::updateMRMLFromWidget()
   d->DisplayNode->SetTranslationHandleVisibility(d->translateVisibilityCheckBox->isChecked());
   d->DisplayNode->SetRotationHandleVisibility(d->rotateVisibilityCheckBox->isChecked());
   d->DisplayNode->SetScaleHandleVisibility(d->scaleVisibilityCheckBox->isChecked());
+  d->DisplayNode->SetInteractionHandleScale(d->interactionHandleScaleSlider->value());
 }

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -506,6 +506,11 @@ void qSlicerMarkupsModule::readDefaultMarkupsDisplaySettings(vtkMRMLMarkupsDispl
     {
     markupsDisplayNode->SetOpacity(settings.value("Markups/Opacity").toDouble());
     }
+  if (settings.contains("Markups/InteractionHandleScale"))
+    {
+    markupsDisplayNode->SetInteractionHandleScale(settings.value("Markups/InteractionHandleScale").toDouble());
+    }
+
 }
 
 //-----------------------------------------------------------------------------
@@ -560,6 +565,8 @@ void qSlicerMarkupsModule::writeDefaultMarkupsDisplaySettings(vtkMRMLMarkupsDisp
   color = markupsDisplayNode->GetActiveColor();
   settings.setValue("Markups/ActiveColor", QColor::fromRgbF(color[0], color[1], color[2]));
   settings.setValue("Markups/Opacity", markupsDisplayNode->GetOpacity());
+
+  settings.setValue("Markups/InteractionHandleScale", markupsDisplayNode->GetInteractionHandleScale());
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Previously the size of the interaction handles was controlled using the vtkMRMLMarkupsDisplayNode::GlyphScale/GlyphSize properties.

This commit adds the vtkMRMLMarkupsDisplayNode::InteractionHandleScale property, which behaves in the same way as GlyphScale except only affects the interaction handle. The interaction handles are no longer affected by Glyph properties.

Also cleans up the constants used to define the size of the interaction widget.

Re #5061