### PR TITLE
ENH: Center "Save before exit?" window on main window

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -630,7 +630,7 @@ bool qSlicerMainWindowPrivate::confirmCloseApplication()
   bool close = false;
   if (!question.isEmpty())
     {
-    QMessageBox* messageBox = new QMessageBox(QMessageBox::Warning, qSlicerMainWindow::tr("Save before exit?"), question, QMessageBox::NoButton);
+    QMessageBox* messageBox = new QMessageBox(QMessageBox::Warning, qSlicerMainWindow::tr("Save before exit?"), question, QMessageBox::NoButton, q);
     QAbstractButton* saveButton =
        messageBox->addButton(qSlicerMainWindow::tr("Save"), QMessageBox::ActionRole);
     QAbstractButton* exitButton =


### PR DESCRIPTION
To center "Save before exit?" window on main window even if the main window is not maximized.