### PR TITLE
DOC: Update link to Slicer Stable CDash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ blog post.
 
 After changes are integrated, every evening at 10pm EST (3am UTC), Slicer build bots (aka factories)
 will build, test and package the Slicer application and all its extensions on Linux, macOS
-and Windows. Results are published daily on CDash ([Stable](http://slicer.cdash.org/index.php?project=Slicer4) & [Preview](http://slicer.cdash.org/index.php?project=SlicerPreview))
+and Windows. Results are published daily on CDash ([Stable](http://slicer.cdash.org/index.php?project=SlicerStable) & [Preview](http://slicer.cdash.org/index.php?project=SlicerPreview))
 and developers that introduced changes resulting in build or test failures are notified by
 email.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ blog post.
 
 After changes are integrated, every evening at 10pm EST (3am UTC), Slicer build bots (aka factories)
 will build, test and package the Slicer application and all its extensions on Linux, macOS
-and Windows. Results are published daily on CDash ([Stable](http://slicer.cdash.org/index.php?project=SlicerStable) & [Preview](http://slicer.cdash.org/index.php?project=SlicerPreview))
+and Windows. Results are published daily on CDash ([Stable](https://slicer.cdash.org/index.php?project=SlicerStable) & [Preview](https://slicer.cdash.org/index.php?project=SlicerPreview))
 and developers that introduced changes resulting in build or test failures are notified by
 email.
 

--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -124,18 +124,18 @@ Replace `Release` with the build mode of your extension build (`Debug`, `Release
 ### Continuous integration
 
 If you shared your extension by using the ExtensionWizard, make sure you know about the Slicer testing dashboard:
-- [Dashboard for Slicer Stable Releases](http://slicer.cdash.org/index.php?project=SlicerStable)
-- [Dashboard for Slicer Preview Releases](http://slicer.cdash.org/index.php?project=SlicerPreview)
+- [Dashboard for Slicer Stable Releases](https://slicer.cdash.org/index.php?project=SlicerStable)
+- [Dashboard for Slicer Preview Releases](https://slicer.cdash.org/index.php?project=SlicerPreview)
 
 The dashboard will attempt to check out the source code of your extension, build, test and package it on Linux, macOS and Windows platforms.
 
 To find your extension, use the following link replacing `SlicerMyExtension` with the name of your extension:
 
-`http://slicer.cdash.org/index.php?project=SlicerStable&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=SlicerMyExtension`
+`https://slicer.cdash.org/index.php?project=SlicerStable&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=SlicerMyExtension`
 
 For example, here is the link to check the status of the `SlicerDMRI` extension:
 
-`http://slicer.cdash.org/index.php?project=SlicerStable&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=SlicerDMRI`
+`https://slicer.cdash.org/index.php?project=SlicerStable&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=SlicerDMRI`
 
 If you see red in any of the columns for your extension, click on the hyperlinked number of errors to see the details.
 
@@ -395,7 +395,7 @@ Note: MIDAS server has been replaced by Girder. To upload to a custom Girder ser
 
 Continuous and nightly extension dashboards are setup on the Slicer factory machine maintained by [http://www.kitware.com Kitware]. Developers can set up similar infrastructure privately for their custom applications.
 
-By customizing the [extension template dashboard script](https://github.com/Slicer/Slicer/blob/master/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake), it is possible to easily setup dashboard client submitting to [CDash](http://slicer.cdash.org/index.php?project=SlicerPreview). See example dashboard scripts that are used on official Slicer build machines [here](https://github.com/Slicer/DashboardScripts). Note that these scripts are more complex than the template to allow code reuse between different configurations, but they are tested regularly and so guaranteed to work.
+By customizing the [extension template dashboard script](https://github.com/Slicer/Slicer/blob/master/Extensions/CMake/SlicerExtensionsDashboardScript.TEMPLATE.cmake), it is possible to easily setup dashboard client submitting to [CDash](https://slicer.cdash.org/index.php?project=SlicerPreview). See example dashboard scripts that are used on official Slicer build machines [here](https://github.com/Slicer/DashboardScripts). Note that these scripts are more complex than the template to allow code reuse between different configurations, but they are tested regularly and so guaranteed to work.
 
 ## Frequently asked questions
 

--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -124,18 +124,18 @@ Replace `Release` with the build mode of your extension build (`Debug`, `Release
 ### Continuous integration
 
 If you shared your extension by using the ExtensionWizard, make sure you know about the Slicer testing dashboard:
-- [Dashboard for Slicer Stable Releases](http://slicer.cdash.org/index.php?project=Slicer4)
+- [Dashboard for Slicer Stable Releases](http://slicer.cdash.org/index.php?project=SlicerStable)
 - [Dashboard for Slicer Preview Releases](http://slicer.cdash.org/index.php?project=SlicerPreview)
 
 The dashboard will attempt to check out the source code of your extension, build, test and package it on Linux, macOS and Windows platforms.
 
 To find your extension, use the following link replacing `SlicerMyExtension` with the name of your extension:
 
-`http://slicer.cdash.org/index.php?project=Slicer4&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=SlicerMyExtension`
+`http://slicer.cdash.org/index.php?project=SlicerStable&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=SlicerMyExtension`
 
 For example, here is the link to check the status of the `SlicerDMRI` extension:
 
-`http://slicer.cdash.org/index.php?project=Slicer4&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=SlicerDMRI`
+`http://slicer.cdash.org/index.php?project=SlicerStable&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=SlicerDMRI`
 
 If you see red in any of the columns for your extension, click on the hyperlinked number of errors to see the details.
 
@@ -389,7 +389,7 @@ cmake -DSlicer_DIR:PATH=~/Slicer-SuperBuild-Release/Slicer-build \
 make
 ```
 
-Note: MIDAS server has been replaced by Girder. To upload to a custom Girder server, look up new variables in extensions build system source 
+Note: MIDAS server has been replaced by Girder. To upload to a custom Girder server, look up new variables in extensions build system source
 
 ### Build complete Extensions Index with dashboard submission
 
@@ -497,7 +497,7 @@ Sometimes it is desirable to build the same source code in two different modes: 
 
 Slicer extensions are built and uploaded to the extensions server every day.
 
-- Packages for Slicer stable release are rebuilt and uploaded during the day (Eastern time). Results are available at <https://slicer.cdash.org/index.php?project=Slicer4>
+- Packages for Slicer stable release are rebuilt and uploaded during the day (Eastern time). Results are available at <https://slicer.cdash.org/index.php?project=SlicerStable>
 - Packages for the latest Slicer Preview Release is built every night (Eastern time). Results are available at <https://slicer.cdash.org/index.php?project=SlicerPreview>
 
 Note that packages are not updated for previous Slicer Preview Releases. To get latest extensions for a Slicer Preview Release, install the latest Slicer Preview Release.

--- a/Docs/user_guide/getting_started.md
+++ b/Docs/user_guide/getting_started.md
@@ -185,7 +185,7 @@ Terms used in various fields of medical and biomedical image computing and clini
 - **Color bar** (or scalar bar): a widget overlaid on slice or 3D views that displays a color bar, indicating mapping between color and data value.
 - **Coordinate system** (or coordinate frame, reference frame, space): Specified by position of origin, axis directions, and distance unit. All coordinate systems in 3D Slicer are right-handed.
 - **Extension** (or Slicer extension): A collection of modules that is not bundled with the core application but can be downloaded and installed using the Extensions manager.
-- [**Extensions manager**](extensions_manager): A software component of Slicer that allows browsing, installing, uninstalling extensions in the [Extensions catalog (also known as the Slicer app store)](http://slicer.kitware.com/midas3/slicerappstore) directly from the application.
+- [**Extensions manager**](extensions_manager): A software component of Slicer that allows browsing, installing, uninstalling extensions in the [Extensions catalog (also known as the Slicer app store)](https://extensions.slicer.org) directly from the application.
 - [**Extensions index**](https://github.com/Slicer/ExtensionsIndex): A repository that contains description of each extension that the Extension catalog is built from.
 - **Extent**: Range of integer coordinates along 3 axes. Defined in VTK by 6 values, for IJK axes: `I_min`, `I_max`, `J_min`, `J_max`, `K_min`, `K_max`. Both minimum and maximum values are inclusive, therefore size of an array is `(I_max - I_min + 1)` x `(J_max - J_min + 1)` x `(K_max - K_min + 1)`.
 - **Fiducial**: Represents a point in 3D space. The term originates from image-guided surgery, where "fiducial markers" are used to mark point positions.

--- a/Utilities/Doxygen/SlicerMainPage.dox
+++ b/Utilities/Doxygen/SlicerMainPage.dox
@@ -9,7 +9,7 @@
  * \subsection implinks Important Links
  * - <a href="https://slicer.readthedocs.io/en/latest/developer_guide/index.html">Developer Guide</a>
  * - <a href="https://github.com/Slicer/Slicer/issues">Issue tracker</a>
- * - <a href="http://slicer.cdash.org/index.php?project=SlicerPreview">CDash quality dashboard</a>
+ * - <a href="https://slicer.cdash.org/index.php?project=SlicerPreview">CDash quality dashboard</a>
  *
  * \subsection other Other
  * For more information on using Slicer browse to https://www.slicer.org


### PR DESCRIPTION
This is a followup commit to [62e4d85](https://github.com/Slicer/Slicer/commit/62e4d8544f2a6f30b707a87288a5e1b9fc5a5a86). That commit should've been titled `ENH: Rename CDash project name from "Slicer4" to "SlicerStable"` instead of `ENH: Rename CDash project name from "Slicer4" to "SlicerPreview"`.

Also added a commit to update extensions catalog link from outdated midas link. This extensions catalog link is located on the User Guide Getting Started doc page.