### PR TITLE
ENH: Clean up markups API further

### DIFF
--- a/Docs/developer_guide/api.md
+++ b/Docs/developer_guide/api.md
@@ -48,10 +48,10 @@ This documentation is generated using the Doxygen tool, which uses C++ syntax. T
 
   ```python
   >>> w = slicer.qSlicerMarkupsPlaceWidget()
-  >>> w.deleteAllMarkupsOptionVisible
+  >>> w.deleteAllControlPointsOptionVisible
   True
-  >>> w.deleteAllMarkupsOptionVisible=False
-  >>> w.deleteAllMarkupsOptionVisible
+  >>> w.deleteAllControlPointsOptionVisible=False
+  >>> w.deleteAllControlPointsOptionVisible
   False
   ```
 

--- a/Docs/developer_guide/script_repository/markups.md
+++ b/Docs/developer_guide/script_repository/markups.md
@@ -13,13 +13,13 @@ slicer.util.loadMarkupsFiducialList("/path/to/list/F.fcsv")
 Markups control points can be added to the currently active point list from the python console by using the following module logic command:
 
 ```python
-slicer.modules.markups.logic().AddFiducial()
+slicer.modules.markups.logic().AddControlPoint()
 ```
 
 The command with no arguments will place a new control point at the origin. You can also pass it an initial location:
 
 ```python
-slicer.modules.markups.logic().AddFiducial(1.0, -2.0, 3.3)
+slicer.modules.markups.logic().AddControlPoint(1.0, -2.0, 3.3)
 ```
 
 ### How to draw a curve using control points stored in a numpy array
@@ -87,7 +87,7 @@ Each vtkMRMLMarkupsFiducialNode has a vector of control points in it which can b
 
 ```python
 pointListNode = getNode("vtkMRMLMarkupsFiducialNode1")
-n = pointListNode.AddControlPoint(vtk.vtkVector3d(4.0, 5.5, -6.0))
+n = pointListNode.AddControlPoint([4.0, 5.5, -6.0])
 pointListNode.SetNthControlPointLabel(n, "new label")
 # each control point is given a unique id which can be accessed from the superclass level
 id1 = pointListNode.GetNthControlPointID(n)
@@ -418,7 +418,7 @@ def onMarkupEndInteraction(caller, event):
   logging.info("End interaction: point ID = {0}, slice view = {1}".format(movingMarkupIndex, sliceView))
 
 pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
-pointListNode.AddFiducial(0,0,0)
+pointListNode.AddControlPoint([0,0,0])
 pointListNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointModifiedEvent, onMarkupChanged)
 pointListNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointStartInteractionEvent, onMarkupStartInteraction)
 pointListNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointEndInteractionEvent, onMarkupEndInteraction)
@@ -538,7 +538,7 @@ def copyLineMeasurementsToClipboard():
   for lineNode in lineNodes:
     # Get node filename that the length was measured on
     try:
-      volumeNode = slicer.mrmlScene.GetNodeByID(lineNode.GetNthMarkupAssociatedNodeID(0))
+      volumeNode = slicer.mrmlScene.GetNodeByID(lineNode.GetNthControlPointAssociatedNodeID(0))
       imagePath = volumeNode.GetStorageNode().GetFileName()
     except:
       imagePath = ''

--- a/Docs/developer_guide/script_repository/models.md
+++ b/Docs/developer_guide/script_repository/models.md
@@ -119,7 +119,7 @@ def onMouseMoved(observer,eventid):
   ras=[0,0,0]
   crosshairNode.GetCursorPositionRAS(ras)
   if pointListNode.GetNumberOfControlPoints() == 0:
-    pointListNode.AddFiducial(*ras)
+    pointListNode.AddControlPoint(ras)
   else:
     pointListNode.SetNthContorlPointPosition(0,*ras)
   closestPointId = pointsLocator.FindClosestPoint(ras)

--- a/Docs/developer_guide/script_repository/volumes.md
+++ b/Docs/developer_guide/script_repository/volumes.md
@@ -446,7 +446,7 @@ slicer.vtkMRMLTransformNode.GetTransformBetweenNodes(volumeNode.GetParentTransfo
 point_Ras = transformVolumeRasToRas.TransformPoint(point_VolumeRas[0:3])
 
 # Add a markup at the computed position and print its coordinates
-pointListNode.AddFiducial(point_Ras[0], point_Ras[1], point_Ras[2], "max")
+pointListNode.AddControlPoint((point_Ras[0], point_Ras[1], point_Ras[2]), "max")
 print(point_Ras)
 ```
 

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -683,11 +683,11 @@ std::string vtkSlicerMarkupsLogic::AddNewFiducialNode(const char *name, vtkMRMLS
 }
 
 //---------------------------------------------------------------------------
-int vtkSlicerMarkupsLogic::AddFiducial(double r, double a, double s)
+int vtkSlicerMarkupsLogic::AddControlPoint(double r, double a, double s)
 {
   if (!this->GetMRMLScene())
     {
-    vtkErrorMacro("AddFiducial: no scene defined!");
+    vtkErrorMacro("AddControlPoint: no scene defined!");
     return -1;
     }
 
@@ -697,18 +697,18 @@ int vtkSlicerMarkupsLogic::AddFiducial(double r, double a, double s)
   // is there no active point list?
   if (listID.size() == 0)
     {
-    vtkDebugMacro("AddFiducial: no point list is active, adding one first!");
+    vtkDebugMacro("AddControlPoint: no point list is active, adding one first!");
     std::string newListID = this->AddNewFiducialNode();
     if (newListID.size() == 0)
       {
-      vtkErrorMacro("AddFiducial: failed to add a new point list to the scene.");
+      vtkErrorMacro("AddControlPoint: failed to add a new point list to the scene.");
       return -1;
       }
     // try to get the id again
     listID = this->GetActiveListID();
     if (listID.size() == 0)
       {
-      vtkErrorMacro("AddFiducial: failed to create a new point list to add to!");
+      vtkErrorMacro("AddControlPoint: failed to create a new point list to add to!");
       return -1;
       }
     }
@@ -717,16 +717,16 @@ int vtkSlicerMarkupsLogic::AddFiducial(double r, double a, double s)
   vtkMRMLNode *listNode = this->GetMRMLScene()->GetNodeByID(listID.c_str());
   if (!listNode)
     {
-    vtkErrorMacro("AddFiducial: failed to get the active point list with id " << listID);
+    vtkErrorMacro("AddControlPoint: failed to get the active point list with id " << listID);
     return -1;
     }
   vtkMRMLMarkupsFiducialNode *fiducialNode = vtkMRMLMarkupsFiducialNode::SafeDownCast(listNode);
   if (!fiducialNode)
     {
-    vtkErrorMacro("AddFiducial: active list is not a point list: " << listNode->GetClassName());
+    vtkErrorMacro("AddControlPoint: active list is not a point list: " << listNode->GetClassName());
     return -1;
     }
-  vtkDebugMacro("AddFiducial: adding a control point to the list " << listID);
+  vtkDebugMacro("AddControlPoint: adding a control point to the list " << listID);
   // add a control point to the active point list
   return fiducialNode->AddControlPoint(vtkVector3d(r,a,s), std::string());
 }
@@ -1015,11 +1015,11 @@ char * vtkSlicerMarkupsLogic::LoadMarkupsFromFcsv(const char* fileName, const ch
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::SetAllMarkupsVisibility(vtkMRMLMarkupsNode *node, bool flag)
+void vtkSlicerMarkupsLogic::SetAllControlPointsVisibility(vtkMRMLMarkupsNode *node, bool flag)
 {
   if (!node)
     {
-    vtkDebugMacro("SetAllMarkupsVisibility: No list");
+    vtkDebugMacro("SetAllControlPointsVisibility: No list");
     return;
     }
 
@@ -1030,11 +1030,11 @@ void vtkSlicerMarkupsLogic::SetAllMarkupsVisibility(vtkMRMLMarkupsNode *node, bo
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::ToggleAllMarkupsVisibility(vtkMRMLMarkupsNode *node)
+void vtkSlicerMarkupsLogic::ToggleAllControlPointsVisibility(vtkMRMLMarkupsNode *node)
 {
   if (!node)
     {
-    vtkDebugMacro("ToggleAllMarkupsVisibility: No list");
+    vtkDebugMacro("ToggleAllControlPointsVisibility: No list");
     return;
     }
 
@@ -1045,11 +1045,11 @@ void vtkSlicerMarkupsLogic::ToggleAllMarkupsVisibility(vtkMRMLMarkupsNode *node)
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::SetAllMarkupsLocked(vtkMRMLMarkupsNode *node, bool flag)
+void vtkSlicerMarkupsLogic::SetAllControlPointsLocked(vtkMRMLMarkupsNode *node, bool flag)
 {
   if (!node)
     {
-    vtkDebugMacro("SetAllMarkupsLocked: No list");
+    vtkDebugMacro("SetAllControlPointsLocked: No list");
     return;
     }
 
@@ -1060,11 +1060,11 @@ void vtkSlicerMarkupsLogic::SetAllMarkupsLocked(vtkMRMLMarkupsNode *node, bool f
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::ToggleAllMarkupsLocked(vtkMRMLMarkupsNode *node)
+void vtkSlicerMarkupsLogic::ToggleAllControlPointsLocked(vtkMRMLMarkupsNode *node)
 {
   if (!node)
     {
-    vtkDebugMacro("ToggleAllMarkupsLocked: No list");
+    vtkDebugMacro("ToggleAllControlPointsLocked: No list");
     return;
     }
 
@@ -1075,11 +1075,11 @@ void vtkSlicerMarkupsLogic::ToggleAllMarkupsLocked(vtkMRMLMarkupsNode *node)
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::SetAllMarkupsSelected(vtkMRMLMarkupsNode *node, bool flag)
+void vtkSlicerMarkupsLogic::SetAllControlPointsSelected(vtkMRMLMarkupsNode *node, bool flag)
 {
   if (!node)
     {
-    vtkDebugMacro("SetAllMarkupsSelected: No list");
+    vtkDebugMacro("SetAllControlPointsSelected: No list");
     return;
     }
 
@@ -1090,11 +1090,11 @@ void vtkSlicerMarkupsLogic::SetAllMarkupsSelected(vtkMRMLMarkupsNode *node, bool
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::ToggleAllMarkupsSelected(vtkMRMLMarkupsNode *node)
+void vtkSlicerMarkupsLogic::ToggleAllControlPointsSelected(vtkMRMLMarkupsNode *node)
 {
   if (!node)
     {
-    vtkDebugMacro("ToggleAllMarkupsSelected: No list");
+    vtkDebugMacro("ToggleAllControlPointsSelected: No list");
     return;
     }
 
@@ -1198,13 +1198,13 @@ bool vtkSlicerMarkupsLogic::MoveNthControlPointToNewListAtIndex(int n, vtkMRMLMa
 {
   if (!markupsNode || !newMarkupsNode)
     {
-    vtkErrorMacro("MoveNthMarkupToNewListAtIndex: at least one of the markup list nodes are null!");
+    vtkErrorMacro("MoveNthControlPointToNewListAtIndex: at least one of the markup list nodes are null!");
     return false;
     }
 
   if (!markupsNode->ControlPointExists(n))
     {
-    vtkErrorMacro("MoveNthMarkupToNewListAtIndex: source index n " << n
+    vtkErrorMacro("MoveNthControlPointToNewListAtIndex: source index n " << n
                   << " is not in list of size " << markupsNode->GetNumberOfControlPoints());
     return false;
     }
@@ -1217,7 +1217,7 @@ bool vtkSlicerMarkupsLogic::MoveNthControlPointToNewListAtIndex(int n, vtkMRMLMa
   bool insertVal = newMarkupsNode->InsertControlPoint(newControlPoint, newIndex);
   if (!insertVal)
     {
-    vtkErrorMacro("MoveNthMarkupToNewListAtIndex: failed to insert new control point at " << newIndex <<
+    vtkErrorMacro("MoveNthControlPointToNewListAtIndex: failed to insert new control point at " << newIndex <<
                   ", control point is still on source list.");
     return false;
     }
@@ -1234,7 +1234,7 @@ bool vtkSlicerMarkupsLogic::CopyNthControlPointToNewList(int n, vtkMRMLMarkupsNo
 {
   if (!markupsNode || !newMarkupsNode)
     {
-    vtkErrorMacro("CopyNthMarkupToNewList: at least one of the markup list nodes are null!");
+    vtkErrorMacro("CopyNthControlPointToNewList: at least one of the markup list nodes are null!");
     return false;
     }
 
@@ -1460,7 +1460,7 @@ void vtkSlicerMarkupsLogic::ConvertAnnotationFiducialsToMarkups()
 }
 
 //---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::RenameAllMarkupsFromCurrentFormat(vtkMRMLMarkupsNode *markupsNode)
+void vtkSlicerMarkupsLogic::RenameAllControlPointsFromCurrentFormat(vtkMRMLMarkupsNode *markupsNode)
 {
   if (!markupsNode)
     {
@@ -1469,7 +1469,7 @@ void vtkSlicerMarkupsLogic::RenameAllMarkupsFromCurrentFormat(vtkMRMLMarkupsNode
 
   int numberOfControlPoints = markupsNode->GetNumberOfControlPoints();
   // get the format string with the list name replaced
-  std::string formatString = markupsNode->ReplaceListNameInMarkupLabelFormat();
+  std::string formatString = markupsNode->ReplaceListNameInControlPointLabelFormat();
   bool numberInFormat = false;
   std::vector<char> buffVector(vtkMRMLMarkupsFiducialStorageNode::GetMaximumLineLength());
   char* buff = &(buffVector[0]);
@@ -1501,7 +1501,7 @@ void vtkSlicerMarkupsLogic::RenameAllMarkupsFromCurrentFormat(vtkMRMLMarkupsNode
         }
       if (secondNumber != std::string::npos)
         {
-        vtkWarningMacro("RenameAllMarkupsFromCurrentFormat: more than one number in markup " << n << ", keeping second one: " << oldLabel.c_str());
+        vtkWarningMacro("RenameAllControlPointsFromCurrentFormat: more than one number in markup " << n << ", keeping second one: " << oldLabel.c_str());
         keepNumberStart = secondNumber;
         keepNumberEnd = oldLabel.find_first_not_of(numbers, keepNumberStart);
         }

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -100,11 +100,11 @@ public:
   /// On success, return the id, on failure return an empty string.
   std::string AddNewFiducialNode(const char *name = "F", vtkMRMLScene *scene = nullptr);
 
-  /// Add a new fiducial to the currently active list at the given RAS
-  /// coordinates (default 0,0,0). Will create a list is one is not active.
-  /// Returns -1 on failure, index of the added fiducial
+  /// Add a new control point to the currently active markups fiducial node at the given RAS
+  /// coordinates (default 0,0,0). Will create a markups fiducial node if one is not active.
+  /// Returns -1 on failure, index of the added control point
   /// on success.
-  int AddFiducial(double r=0.0, double a=0.0, double s=0.0);
+  int AddControlPoint(double r=0.0, double a=0.0, double s=0.0);
 
   /// jump the slice windows to the given coordinate
   /// If viewGroup is -1 then all all slice views are updated, otherwise only those views
@@ -121,7 +121,7 @@ public:
   /// \sa FocusCamerasOnNthPointInMarkup
   void FocusCameraOnNthPointInMarkup(const char *cameraNodeID, const char *markupNodeID, int n);
 
-  /// Load a markups fiducial list from fileName, return nullptr on error, node ID string
+  /// Load a markups node from fileName, return nullptr on error, node ID string
   /// otherwise. Adds the appropriate storage and display nodes to the scene
   /// as well.
   char* LoadMarkups(const char* fileName, const char* fidsName=nullptr, vtkMRMLMessageCollection* userMessages=nullptr);
@@ -132,13 +132,15 @@ public:
   char* LoadMarkupsFromFcsv(const char* fileName, const char* nodeName=nullptr, vtkMRMLMessageCollection* userMessages=nullptr);
   char* LoadMarkupsFromJson(const char* fileName, const char* nodeName=nullptr, vtkMRMLMessageCollection* userMessages=nullptr);
 
-  /// Utility methods to operate on all markups in a markups node
-  void SetAllMarkupsVisibility(vtkMRMLMarkupsNode *node, bool flag);
-  void ToggleAllMarkupsVisibility(vtkMRMLMarkupsNode *node);
-  void SetAllMarkupsLocked(vtkMRMLMarkupsNode *node, bool flag);
-  void ToggleAllMarkupsLocked(vtkMRMLMarkupsNode *node);
-  void SetAllMarkupsSelected(vtkMRMLMarkupsNode *node, bool flag);
-  void ToggleAllMarkupsSelected(vtkMRMLMarkupsNode *node);
+  /// Utility methods to operate on all control points in a markups node
+  /// @{
+  void SetAllControlPointsVisibility(vtkMRMLMarkupsNode *node, bool flag);
+  void ToggleAllControlPointsVisibility(vtkMRMLMarkupsNode *node);
+  void SetAllControlPointsLocked(vtkMRMLMarkupsNode *node, bool flag);
+  void ToggleAllControlPointsLocked(vtkMRMLMarkupsNode *node);
+  void SetAllControlPointsSelected(vtkMRMLMarkupsNode *node, bool flag);
+  void ToggleAllControlPointsSelected(vtkMRMLMarkupsNode *node);
+  /// @}
 
   /// Utility method to set up a display node from the defaults.
   /// Point labels visibility and properties label visibility setting is not saved to defaults,
@@ -156,13 +158,6 @@ public:
   bool CopyNthControlPointToNewList(int n, vtkMRMLMarkupsNode *markupsNode,
                               vtkMRMLMarkupsNode *newMarkupsNode);
 
-  /// \deprecated Use CopyNthControlPointToNewList instead.
-  bool CopyNthMarkupToNewList(int n, vtkMRMLMarkupsNode *markupsNode,
-                              vtkMRMLMarkupsNode *newMarkupsNode)
-    {
-    return this->CopyNthControlPointToNewList(n, markupsNode, newMarkupsNode);
-    }
-
   /// utility method to move a control point from one list to another, trying to
   /// insert it at the given new index. If the new index is larger than the
   /// number of control points in the list, adds it to the end. If new index is
@@ -173,13 +168,6 @@ public:
   bool MoveNthControlPointToNewListAtIndex(int n, vtkMRMLMarkupsNode *markupsNode,
                                    vtkMRMLMarkupsNode *newMarkupsNode, int newIndex);
 
-  /// \deprecated Use MoveNthControlPointToNewList instead.
-  bool MoveNthMarkupToNewList(int n, vtkMRMLMarkupsNode *markupsNode,
-                              vtkMRMLMarkupsNode *newMarkupsNode, int newIndex)
-    {
-    return this->MoveNthControlPointToNewListAtIndex(n, markupsNode, newMarkupsNode, newIndex);
-    }
-
   /// Searches the scene for annotation fidicual nodes, collecting a list
   /// of annotation hierarchy nodes. Then iterates through those hierarchy nodes
   /// and moves the fiducials that are under them into new markups nodes. Leaves
@@ -187,11 +175,11 @@ public:
   /// ROIs but deletes the 1:1 hierarchy nodes.
   void ConvertAnnotationFiducialsToMarkups();
 
-  /// Iterate over the markups in the list and reset the markup labels using
-  /// the current MarkupLabelFormat setting. Try to keep current numbering.
+  /// Iterate over the control points in the list and reset the control point labels using
+  /// the current ControlPointLabelFormat setting. Try to keep current numbering.
   /// Will work if there's a %d, %g or %f in the format string, but precision
   /// is not handled.
-  void RenameAllMarkupsFromCurrentFormat(vtkMRMLMarkupsNode *markupsNode);
+  void RenameAllControlPointsFromCurrentFormat(vtkMRMLMarkupsNode *markupsNode);
 
   /// Put the interaction node into place mode, and set the persistence of
   /// place mode according to the persistent flag.
@@ -305,6 +293,74 @@ public:
 
   static bool ExportControlPointsToTable(vtkMRMLMarkupsNode* markupsNode, vtkMRMLTableNode* tableNode,
     int coordinateSystem = vtkMRMLStorageNode::CoordinateSystemRAS);
+
+  //-----------------------------------------------------------
+  // All public methods below are deprecated
+  //
+  // These methods are deprecated because they use old terms (markup instead of control point),
+
+  /// \deprecated Use CopyNthControlPointToNewList instead.
+  bool CopyNthMarkupToNewList(int n, vtkMRMLMarkupsNode *markupsNode,
+                              vtkMRMLMarkupsNode *newMarkupsNode)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::CopyNthMarkupToNewList method is deprecated, please use CopyNthControlPointToNewList instead");
+    return this->CopyNthControlPointToNewList(n, markupsNode, newMarkupsNode);
+    }
+  /// \deprecated Use MoveNthControlPointToNewList instead.
+  bool MoveNthMarkupToNewList(int n, vtkMRMLMarkupsNode *markupsNode,
+                              vtkMRMLMarkupsNode *newMarkupsNode, int newIndex)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::MoveNthMarkupToNewList method is deprecated, please use MoveNthControlPointToNewListAtIndex instead");
+    return this->MoveNthControlPointToNewListAtIndex(n, markupsNode, newMarkupsNode, newIndex);
+    }
+  /// \deprecated Use AddControlPoint instead.
+  int AddFiducial(double r=0.0, double a=0.0, double s=0.0)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::AddFiducial method is deprecated, please use AddControlPoint instead");
+    return this->AddControlPoint(r, a, s);
+    };
+  /// \deprecated Use SetAllControlPointsVisibility instead.
+  void SetAllMarkupsVisibility(vtkMRMLMarkupsNode *node, bool flag)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::SetAllMarkupsVisibility method is deprecated, please use SetAllControlPointsVisibility instead");
+    this->SetAllControlPointsVisibility(node, flag);
+    };
+  /// \deprecated Use ToggleAllControlPointsVisibility instead.
+  void ToggleAllMarkupsVisibility(vtkMRMLMarkupsNode *node)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::ToggleAllMarkupsVisibility method is deprecated, please use ToggleAllControlPointsVisibility instead");
+    this->ToggleAllControlPointsVisibility(node);
+    };
+  /// \deprecated Use SetAllControlPointsLocked instead.
+  void SetAllMarkupsLocked(vtkMRMLMarkupsNode *node, bool flag)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::SetAllMarkupsLocked method is deprecated, please use SetAllControlPointsLocked instead");
+    this->SetAllControlPointsLocked(node, flag);
+    };
+  /// \deprecated Use ToggleAllControlPointsLocked instead.
+  void ToggleAllMarkupsLocked(vtkMRMLMarkupsNode *node)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::ToggleAllMarkupsLocked method is deprecated, please use ToggleAllControlPointsLocked instead");
+    this->ToggleAllControlPointsLocked(node);
+    };
+  /// \deprecated Use SetAllControlPointsSelected instead.
+  void SetAllMarkupsSelected(vtkMRMLMarkupsNode *node, bool flag)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::SetAllMarkupsSelected method is deprecated, please use SetAllControlPointsSelected instead");
+    this->SetAllControlPointsSelected(node, flag);
+    };
+  /// \deprecated Use ToggleAllControlPointsSelected instead.
+  void ToggleAllMarkupsSelected(vtkMRMLMarkupsNode *node)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::ToggleAllMarkupsSelected method is deprecated, please use ToggleAllControlPointsSelected instead");
+    this->ToggleAllControlPointsSelected(node);
+    };
+  /// \deprecated Use RenameAllControlPointsFromCurrentFormat instead.
+  void RenameAllMarkupsFromCurrentFormat(vtkMRMLMarkupsNode *markupsNode)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::RenameAllMarkupsFromCurrentFormat method is deprecated, please use RenameAllControlPointsFromCurrentFormat instead");
+    this->RenameAllControlPointsFromCurrentFormat(markupsNode);
+    };
 
 protected:
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -118,7 +118,7 @@ public:
   int AddFiducialFromArray(double pos[3], std::string label = std::string())
     {
     vtkWarningMacro("vtkMRMLMarkupsFiducialNode::AddFiducialFromArray method is deprecated, please use AddControlPoint instead");
-    return this->AddFiducial(pos[0], pos[1], pos[2], label);
+    return this->AddControlPoint(pos, label);
     }
   /// \deprecated Use GetNthControlPointPositionVector instead.
   void GetNthFiducialPosition(int n, double pos[3])

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -614,7 +614,7 @@ bool vtkMRMLMarkupsJsonStorageNode::vtkInternal::UpdateMarkupsNodeFromJsonValue(
 
   if (markupObject.HasMember("labelFormat"))
     {
-    markupsNode->SetMarkupLabelFormat(markupObject["labelFormat"].GetString());
+    markupsNode->SetControlPointLabelFormat(markupObject["labelFormat"].GetString());
     }
 
   if (markupObject.HasMember("lastUsedControlPointNumber"))
@@ -870,7 +870,7 @@ bool vtkMRMLMarkupsJsonStorageNode::vtkInternal::WriteBasicProperties(
   writer.Bool(markupsNode->GetFixedNumberOfControlPoints());
 
   writer.Key("labelFormat");
-  writer.String(markupsNode->GetMarkupLabelFormat().c_str());
+  writer.String(markupsNode->GetControlPointLabelFormat().c_str());
 
   writer.Key("lastUsedControlPointNumber");
   writer.Int(markupsNode->GetLastUsedControlPointNumber());

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -115,7 +115,7 @@ void vtkMRMLMarkupsNode::WriteXML(ostream& of, int nIndent)
 
   vtkMRMLWriteXMLBeginMacro(of);
   vtkMRMLWriteXMLBooleanMacro(locked, Locked);
-  vtkMRMLWriteXMLStdStringMacro(markupLabelFormat, MarkupLabelFormat);
+  vtkMRMLWriteXMLStdStringMacro(controlPointLabelFormat, ControlPointLabelFormat);
   vtkMRMLWriteXMLMatrix4x4Macro(interactionHandleToWorldMatrix, InteractionHandleToWorldMatrix);
   vtkMRMLWriteXMLEndMacro();
 
@@ -139,6 +139,7 @@ void vtkMRMLMarkupsNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBeginMacro(atts);
   vtkMRMLReadXMLBooleanMacro(locked, Locked);
   vtkMRMLReadXMLStdStringMacro(markupLabelFormat, MarkupLabelFormat);
+  vtkMRMLReadXMLStdStringMacro(controlPointLabelFormat, ControlPointLabelFormat);
   vtkMRMLReadXMLOwnedMatrix4x4Macro(interactionHandleToWorldMatrix, InteractionHandleToWorldMatrix);
   vtkMRMLReadXMLEndMacro();
 
@@ -174,7 +175,7 @@ void vtkMRMLMarkupsNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
 
   vtkMRMLCopyBeginMacro(anode);
   vtkMRMLCopyBooleanMacro(Locked);
-  vtkMRMLCopyStdStringMacro(MarkupLabelFormat);
+  vtkMRMLCopyStdStringMacro(ControlPointLabelFormat);
   vtkMRMLCopyOwnedMatrix4x4Macro(InteractionHandleToWorldMatrix);
   vtkMRMLCopyEndMacro();
 
@@ -291,7 +292,7 @@ void vtkMRMLMarkupsNode::PrintSelf(ostream& os, vtkIndent indent)
 
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintBooleanMacro(Locked);
-  vtkMRMLPrintStdStringMacro(MarkupLabelFormat);
+  vtkMRMLPrintStdStringMacro(ControlPointLabelFormat);
   vtkMRMLPrintMatrix4x4Macro(InteractionHandleToWorldMatrix)
   vtkMRMLPrintEndMacro();
 
@@ -1838,7 +1839,7 @@ std::string vtkMRMLMarkupsNode::GenerateUniqueControlPointID()
 //---------------------------------------------------------------------------
 std::string vtkMRMLMarkupsNode::GenerateControlPointLabel(int controlPointIndex)
 {
-  std::string formatString = this->ReplaceListNameInMarkupLabelFormat();
+  std::string formatString = this->ReplaceListNameInControlPointLabelFormat();
   char buf[128];
   buf[sizeof(buf) - 1] = 0; // make sure the string is zero-terminated
   snprintf(buf, sizeof(buf) - 1, formatString.c_str(), controlPointIndex);
@@ -1846,28 +1847,28 @@ std::string vtkMRMLMarkupsNode::GenerateControlPointLabel(int controlPointIndex)
 }
 
 //---------------------------------------------------------------------------
-std::string vtkMRMLMarkupsNode::GetMarkupLabelFormat()
+std::string vtkMRMLMarkupsNode::GetControlPointLabelFormat()
 {
-  return this->MarkupLabelFormat;
+  return this->ControlPointLabelFormat;
 }
 
 //---------------------------------------------------------------------------
-void vtkMRMLMarkupsNode::SetMarkupLabelFormat(std::string format)
+void vtkMRMLMarkupsNode::SetControlPointLabelFormat(std::string format)
 {
-  if (this->MarkupLabelFormat.compare(format) == 0)
+  if (this->ControlPointLabelFormat.compare(format) == 0)
     {
     return;
     }
-  this->MarkupLabelFormat = format;
+  this->ControlPointLabelFormat = format;
 
   this->Modified();
   this->InvokeCustomModifiedEvent(vtkMRMLMarkupsNode::LabelFormatModifiedEvent);
 }
 
 //---------------------------------------------------------------------------
-std::string vtkMRMLMarkupsNode::ReplaceListNameInMarkupLabelFormat()
+std::string vtkMRMLMarkupsNode::ReplaceListNameInControlPointLabelFormat()
 {
-  std::string newFormatString = this->MarkupLabelFormat;
+  std::string newFormatString = this->ControlPointLabelFormat;
 
   // Long-name replacement
   size_t replacePos = newFormatString.find("%N");

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -585,22 +585,22 @@ public:
   void ApplyTransform(vtkAbstractTransform* transform) override;
 
   ///@{
-  /// Get/Set the markup node label format string that defines the markup names.
+  /// Get/Set the ControlPointLabelFormat string that defines the control point names.
   /// In standard printf notation, with the addition of %N being replaced
   /// by the list name.
   /// %d will resolve to the highest not yet used list index integer.
   /// Character strings will otherwise pass through
-  /// Defaults to %N-%d which will yield markup names of Name-0, Name-1, Name-2.
+  /// Defaults to %N-%d which will yield control point names of Name-0, Name-1, Name-2.
   /// If format string is changed then LabelFormatModifedEvent event is invoked.
-  std::string GetMarkupLabelFormat();
-  void SetMarkupLabelFormat(std::string format);
+  std::string GetControlPointLabelFormat();
+  void SetControlPointLabelFormat(std::string format);
   ///@}
 
-  /// If the MarkupLabelFormat contains the string %N, return a string
+  /// If the ControlPointLabelFormat contains the string %N, return a string
   /// in which that has been replaced with the list name. If the list name is
-  /// nullptr, replace it with an empty string. If the MarkupLabelFormat doesn't
-  /// contain %N, return MarkupLabelFormat
-  std::string ReplaceListNameInMarkupLabelFormat();
+  /// nullptr, replace it with an empty string. If the ControlPointLabelFormat doesn't
+  /// contain %N, return ControlPointLabelFormat
+  std::string ReplaceListNameInControlPointLabelFormat();
 
   /// Reimplemented to take into account the modified time of the markups
   /// Returns true if the node (default behavior) or the markups are modified
@@ -879,6 +879,25 @@ public:
     vtkWarningMacro("vtkMRMLMarkupsNode::SetNthMarkupLabel method is deprecated, please use SetNthControlPointLabel instead");
     this->SetNthControlPointLabel(n, label);
   };
+  /// \deprecated Use GetControlPointLabelFormat instead.
+  std::string GetMarkupLabelFormat()
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::GetMarkupLabelFormat method is deprecated, please use GetControlPointLabelFormat instead");
+    return this->GetControlPointLabelFormat();
+  };
+  /// \deprecated Use SetControlPointLabelFormat instead.
+  void SetMarkupLabelFormat(std::string format)
+  {
+    // Not warning this at the moment as existing scene files will contain the markupLabelFormat attribute name and would warn on load
+    // vtkWarningMacro("vtkMRMLMarkupsNode::SetMarkupLabelFormat method is deprecated, please use SetControlPointLabelFormat instead");
+    return this->SetControlPointLabelFormat(format);
+  };
+  /// \deprecated Use ReplaceListNameInControlPointLabelFormat instead.
+  std::string ReplaceListNameInMarkupLabelFormat()
+  {
+    vtkWarningMacro("vtkMRMLMarkupsNode::ReplaceListNameInMarkupLabelFormat method is deprecated, please use ReplaceListNameInControlPointLabelFormat instead");
+    return this->ReplaceListNameInControlPointLabelFormat();
+  };
 
 protected:
   vtkMRMLMarkupsNode();
@@ -974,7 +993,7 @@ protected:
   /// Point position can be unset instead of deleting the point.
   bool FixedNumberOfControlPoints{false};
 
-  std::string MarkupLabelFormat{"%N-%d"};
+  std::string ControlPointLabelFormat{"%N-%d"};
 
   /// Keep track of the number of markups that were added to the list, always
   /// incrementing, not decreasing when they're removed. Used to help create

--- a/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
+++ b/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
@@ -253,7 +253,7 @@
         <item row="3" column="0" colspan="2">
          <layout class="QHBoxLayout" name="horizontalLayout_6">
           <item>
-           <widget class="ctkMenuButton" name="visibilityAllMarkupsInListMenuButton">
+           <widget class="ctkMenuButton" name="visibilityAllControlPointsInListMenuButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -278,7 +278,7 @@
            </widget>
           </item>
           <item>
-           <widget class="ctkMenuButton" name="selectedAllMarkupsInListMenuButton">
+           <widget class="ctkMenuButton" name="selectedAllControlPointsInListMenuButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -303,7 +303,7 @@
            </widget>
           </item>
           <item>
-           <widget class="ctkMenuButton" name="lockAllMarkupsInListMenuButton">
+           <widget class="ctkMenuButton" name="lockAllControlPointsInListMenuButton">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -328,7 +328,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="missingMarkupPushButton">
+           <widget class="QPushButton" name="missingControlPointPushButton">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -363,7 +363,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="unsetMarkupPushButton">
+           <widget class="QPushButton" name="unsetControlPointPushButton">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -398,7 +398,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="deleteMarkupPushButton">
+           <widget class="QPushButton" name="deleteControlPointPushButton">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -433,7 +433,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="deleteAllMarkupsInListPushButton">
+           <widget class="QPushButton" name="deleteAllControlPointsInListPushButton">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -465,7 +465,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QToolButton" name="CutMarkupsToolButton">
+           <widget class="QToolButton" name="CutControlPointsToolButton">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -475,7 +475,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QToolButton" name="CopyMarkupsToolButton">
+           <widget class="QToolButton" name="CopyControlPointsToolButton">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -485,7 +485,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QToolButton" name="PasteMarkupsToolButton">
+           <widget class="QToolButton" name="PasteControlPointsToolButton">
             <property name="enabled">
              <bool>true</bool>
             </property>
@@ -574,7 +574,7 @@
            <item>
             <layout class="QHBoxLayout" name="horizontalLayout_7">
              <item>
-              <widget class="QPushButton" name="moveMarkupUpPushButton">
+              <widget class="QPushButton" name="moveControlPointUpPushButton">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
@@ -606,7 +606,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="moveMarkupDownPushButton">
+              <widget class="QPushButton" name="moveControlPointDownPushButton">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
@@ -638,7 +638,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="addMarkupPushButton">
+              <widget class="QPushButton" name="addControlPointPushButton">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMRMLMarkupsNodeTest1.cxx
@@ -41,9 +41,9 @@ int vtkMRMLMarkupsNodeTest1(int , char * [] )
 
   TEST_SET_GET_BOOLEAN(node1, Locked);
 
-  node1->SetMarkupLabelFormat(std::string("%N-%d"));
+  node1->SetControlPointLabelFormat(std::string("%N-%d"));
   node1->SetName("testingname");
-  std::string formatTest = node1->ReplaceListNameInMarkupLabelFormat();
+  std::string formatTest = node1->ReplaceListNameInControlPointLabelFormat();
   CHECK_STD_STRING(formatTest, "testingname-%d");
 
   vtkNew<vtkMRMLStaticMeasurement> measurement1;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
@@ -44,7 +44,7 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
   CHECK_STD_STRING(id, "");
 
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
-  int fidIndex = logic1->AddFiducial();
+  int fidIndex = logic1->AddControlPoint();
   TESTING_OUTPUT_ASSERT_ERRORS_END();
   // should be invalid if scene is not set
   CHECK_INT(fidIndex, -1);
@@ -79,35 +79,35 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
   CHECK_NOT_NULL(markupsNode);
 
   // test the list stuff
-  logic1->SetAllMarkupsVisibility(nullptr, true);
-  logic1->ToggleAllMarkupsVisibility(nullptr);
-  logic1->SetAllMarkupsLocked(nullptr, false);
-  logic1->ToggleAllMarkupsLocked(nullptr);
-  logic1->SetAllMarkupsSelected(nullptr, true);
-  logic1->ToggleAllMarkupsSelected(nullptr);
+  logic1->SetAllControlPointsVisibility(nullptr, true);
+  logic1->ToggleAllControlPointsVisibility(nullptr);
+  logic1->SetAllControlPointsLocked(nullptr, false);
+  logic1->ToggleAllControlPointsLocked(nullptr);
+  logic1->SetAllControlPointsSelected(nullptr, true);
+  logic1->ToggleAllControlPointsSelected(nullptr);
 
   // no points
-  logic1->SetAllMarkupsVisibility(markupsNode, false);
-  logic1->SetAllMarkupsVisibility(markupsNode, true);
-  logic1->ToggleAllMarkupsVisibility(markupsNode);
-  logic1->SetAllMarkupsLocked(markupsNode, true);
-  logic1->SetAllMarkupsLocked(markupsNode, false);
-  logic1->ToggleAllMarkupsLocked(markupsNode);
-  logic1->SetAllMarkupsSelected(markupsNode, false);
-  logic1->SetAllMarkupsSelected(markupsNode, true);
-  logic1->ToggleAllMarkupsSelected(markupsNode);
+  logic1->SetAllControlPointsVisibility(markupsNode, false);
+  logic1->SetAllControlPointsVisibility(markupsNode, true);
+  logic1->ToggleAllControlPointsVisibility(markupsNode);
+  logic1->SetAllControlPointsLocked(markupsNode, true);
+  logic1->SetAllControlPointsLocked(markupsNode, false);
+  logic1->ToggleAllControlPointsLocked(markupsNode);
+  logic1->SetAllControlPointsSelected(markupsNode, false);
+  logic1->SetAllControlPointsSelected(markupsNode, true);
+  logic1->ToggleAllControlPointsSelected(markupsNode);
 
   // add some points
   markupsNode->AddNControlPoints(5);
-  logic1->SetAllMarkupsVisibility(markupsNode, false);
-  logic1->SetAllMarkupsVisibility(markupsNode, true);
-  logic1->ToggleAllMarkupsVisibility(markupsNode);
-  logic1->SetAllMarkupsLocked(markupsNode, true);
-  logic1->SetAllMarkupsLocked(markupsNode, false);
-  logic1->ToggleAllMarkupsLocked(markupsNode);
-  logic1->SetAllMarkupsSelected(markupsNode, false);
-  logic1->SetAllMarkupsSelected(markupsNode, true);
-  logic1->ToggleAllMarkupsSelected(markupsNode);
+  logic1->SetAllControlPointsVisibility(markupsNode, false);
+  logic1->SetAllControlPointsVisibility(markupsNode, true);
+  logic1->ToggleAllControlPointsVisibility(markupsNode);
+  logic1->SetAllControlPointsLocked(markupsNode, true);
+  logic1->SetAllControlPointsLocked(markupsNode, false);
+  logic1->ToggleAllControlPointsLocked(markupsNode);
+  logic1->SetAllControlPointsSelected(markupsNode, false);
+  logic1->SetAllControlPointsSelected(markupsNode, true);
+  logic1->ToggleAllControlPointsSelected(markupsNode);
 
   // test the default display node settings
   vtkSmartPointer<vtkMRMLMarkupsDisplayNode> displayNode = vtkSmartPointer<vtkMRMLMarkupsDisplayNode>::New();
@@ -136,7 +136,7 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
 
   // test without a selection node
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
-  fidIndex = logic1->AddFiducial(5.0, 6.0, -7.0);
+  fidIndex = logic1->AddControlPoint(5.0, 6.0, -7.0);
   TESTING_OUTPUT_ASSERT_ERRORS_END(); // error is expected to be reported due to lack of selection node
   CHECK_INT(fidIndex, -1);
 
@@ -151,13 +151,13 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
   CHECK_BOOL(logic1->StartPlaceMode(1), true);
 
   // test adding a fiducial to an active list - no app logic
-  fidIndex = logic1->AddFiducial(-1.1, 100.0, 500.0);
+  fidIndex = logic1->AddControlPoint(-1.1, 100.0, 500.0);
   CHECK_BOOL(fidIndex >= 0, true);
   std::cout << "Added a fid to the active fid list, index = " << fidIndex << std::endl;
 
   // adding with app logic
   logic1->SetMRMLApplicationLogic(applicationLogic.GetPointer());
-  fidIndex = logic1->AddFiducial(-11, 10.0, 50.0);
+  fidIndex = logic1->AddControlPoint(-11, 10.0, 50.0);
   CHECK_BOOL(fidIndex >= 0, true);
   std::cout << "Added a fid to the active fid list, index = " << fidIndex << std::endl;
 
@@ -176,8 +176,8 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
     }
 
   activeMarkupsNode->SetName("RenamingTest");
-  activeMarkupsNode->SetMarkupLabelFormat("T %d %N");
-  logic1->RenameAllMarkupsFromCurrentFormat(activeMarkupsNode);
+  activeMarkupsNode->SetControlPointLabelFormat("T %d %N");
+  logic1->RenameAllControlPointsFromCurrentFormat(activeMarkupsNode);
   std::string newLabel = activeMarkupsNode->GetNthControlPointLabel(0);
   std::string expectedLabel = std::string("T 1 RenamingTest");
   CHECK_STD_STRING(newLabel, expectedLabel);

--- a/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
+++ b/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
@@ -166,10 +166,10 @@ class MarkupsWidgetsSelfTestTest(ScriptedLoadableModuleTest):
     placeWidget.buttonsVisible = True
     self.assertTrue(placeWidget.buttonsVisible)
 
-    placeWidget.deleteAllMarkupsOptionVisible = False
-    self.assertFalse(placeWidget.deleteAllMarkupsOptionVisible)
-    placeWidget.deleteAllMarkupsOptionVisible = True
-    self.assertTrue(placeWidget.deleteAllMarkupsOptionVisible)
+    placeWidget.deleteAllControlPointsOptionVisible = False
+    self.assertFalse(placeWidget.deleteAllControlPointsOptionVisible)
+    placeWidget.deleteAllControlPointsOptionVisible = True
+    self.assertTrue(placeWidget.deleteAllControlPointsOptionVisible)
 
     placeWidget.unsetLastControlPointOptionVisible = False
     self.assertFalse(placeWidget.unsetLastControlPointOptionVisible)

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -454,7 +454,7 @@ void qMRMLMarkupsToolBar::initializeToolBarLayout()
   // Markups place widget
   d->MarkupsPlaceWidget = new qSlicerMarkupsPlaceWidget(this);
   d->MarkupsPlaceWidget->setObjectName(QString("MarkupsPlaceWidget"));
-  d->MarkupsPlaceWidget->setDeleteAllMarkupsOptionVisible(true);
+  d->MarkupsPlaceWidget->setDeleteAllControlPointsOptionVisible(true);
   d->MarkupsPlaceWidget->setPlaceMultipleMarkups(qSlicerMarkupsPlaceWidget::ShowPlaceMultipleMarkupsOption);
   d->MarkupsPlaceWidget->setMRMLScene(qSlicerApplication::application()->mrmlScene());
   this->addWidget(d->MarkupsPlaceWidget);

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -66,7 +66,7 @@ public:
   QList < QWidget* > OptionsWidgets;
   QColor DefaultNodeColor;
   bool DeleteMarkupsButtonVisible;
-  bool DeleteAllMarkupsOptionVisible;
+  bool DeleteAllControlPointsOptionVisible;
   bool UnsetLastControlPointOptionVisible;
   bool UnsetAllControlPointsOptionVisible;
   bool LastSignaledPlaceModeEnabled; // if placeModeEnabled changes compared to this value then a activeMarkupsPlaceModeChanged signal will be emitted
@@ -79,7 +79,7 @@ qSlicerMarkupsPlaceWidgetPrivate::qSlicerMarkupsPlaceWidgetPrivate( qSlicerMarku
   : q_ptr(&object)
 {
   this->DeleteMarkupsButtonVisible = true;
-  this->DeleteAllMarkupsOptionVisible = true;
+  this->DeleteAllControlPointsOptionVisible = true;
   this->UnsetLastControlPointOptionVisible = false;
   this->UnsetAllControlPointsOptionVisible = false;
   this->PlaceMultipleMarkups = qSlicerMarkupsPlaceWidget::ShowPlaceMultipleMarkupsOption;
@@ -154,7 +154,7 @@ void qSlicerMarkupsPlaceWidget::setup()
   d->DeleteMenu->addAction(d->ActionDeleteAll);
   QObject::connect(d->ActionDeleteAll, SIGNAL(triggered()), this, SLOT(deleteAllPoints()));
 
-  d->ActionDeleteAll->setVisible(d->DeleteAllMarkupsOptionVisible);
+  d->ActionDeleteAll->setVisible(d->DeleteAllControlPointsOptionVisible);
   d->ActionUnsetLast->setVisible(d->UnsetLastControlPointOptionVisible);
   d->ActionUnsetAll->setVisible(d->UnsetAllControlPointsOptionVisible);
   updateDeleteButton();
@@ -323,12 +323,6 @@ void qSlicerMarkupsPlaceWidget::unsetLastDefinedPoint()
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerMarkupsPlaceWidget::deleteLastMarkup()
-{
-  this->deleteLastPoint();
-}
-
-//-----------------------------------------------------------------------------
 void qSlicerMarkupsPlaceWidget::deleteAllPoints()
 {
   vtkMRMLMarkupsNode* currentMarkupsNode = this->currentMarkupsNode();
@@ -349,12 +343,6 @@ void qSlicerMarkupsPlaceWidget::unsetAllPoints()
     return;
     }
   currentMarkupsNode->UnsetAllControlPoints();
-}
-
-//-----------------------------------------------------------------------------
-void qSlicerMarkupsPlaceWidget::deleteAllMarkups()
-{
-  this->deleteAllPoints();
 }
 
 //-----------------------------------------------------------------------------
@@ -565,7 +553,7 @@ void qSlicerMarkupsPlaceWidget::updateWidget()
     d->DeleteButton->setToolTip("Delete last added control point");
     }
   d->ActionUnsetLast->setVisible(!fixedNumberControlPoints && d->UnsetLastControlPointOptionVisible); // QToolButton button action does this so don't also have in menu
-  d->ActionDeleteAll->setVisible(!fixedNumberControlPoints && d->DeleteAllMarkupsOptionVisible);
+  d->ActionDeleteAll->setVisible(!fixedNumberControlPoints && d->DeleteAllControlPointsOptionVisible);
   this->updateDeleteButton();
 
   d->ActionVisibility->setEnabled(currentMarkupsNode->GetDisplayNode() != nullptr);
@@ -680,17 +668,17 @@ void qSlicerMarkupsPlaceWidget::setPlaceMultipleMarkups(PlaceMultipleMarkupsType
 }
 
 //-----------------------------------------------------------------------------
-bool qSlicerMarkupsPlaceWidget::deleteAllMarkupsOptionVisible() const
+bool qSlicerMarkupsPlaceWidget::deleteAllControlPointsOptionVisible() const
 {
   Q_D(const qSlicerMarkupsPlaceWidget);
-  return d->DeleteAllMarkupsOptionVisible;
+  return d->DeleteAllControlPointsOptionVisible;
 }
 
 //------------------------------------------------------------------------------
-void qSlicerMarkupsPlaceWidget::setDeleteAllMarkupsOptionVisible(bool visible)
+void qSlicerMarkupsPlaceWidget::setDeleteAllControlPointsOptionVisible(bool visible)
 {
   Q_D(qSlicerMarkupsPlaceWidget);
-  d->DeleteAllMarkupsOptionVisible = visible;
+  d->DeleteAllControlPointsOptionVisible = visible;
   if (d->DeleteButton)
     {
     d->ActionDeleteAll->setVisible(visible);

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.h
@@ -44,7 +44,7 @@ qSlicerMarkupsPlaceWidget : public qSlicerWidget
   Q_OBJECT
   Q_ENUMS(PlaceMultipleMarkupsType)
   Q_PROPERTY(bool buttonsVisible READ buttonsVisible WRITE setButtonsVisible)
-  Q_PROPERTY(bool deleteAllMarkupsOptionVisible READ deleteAllMarkupsOptionVisible WRITE setDeleteAllMarkupsOptionVisible)
+  Q_PROPERTY(bool deleteAllControlPointsOptionVisible READ deleteAllControlPointsOptionVisible WRITE setDeleteAllControlPointsOptionVisible)
   Q_PROPERTY(bool unsetLastControlPointOptionVisible READ unsetLastControlPointOptionVisible WRITE setUnsetLastControlPointOptionVisible)
   Q_PROPERTY(bool unsetAllControlPointsOptionVisible READ unsetAllControlPointsOptionVisible WRITE setUnsetAllControlPointsOptionVisible)
   Q_PROPERTY(PlaceMultipleMarkupsType placeMultipleMarkups READ placeMultipleMarkups WRITE setPlaceMultipleMarkups)
@@ -53,6 +53,9 @@ qSlicerMarkupsPlaceWidget : public qSlicerWidget
   Q_PROPERTY(bool currentNodeActive READ currentNodeActive WRITE setCurrentNodeActive)
   Q_PROPERTY(bool placeModeEnabled READ placeModeEnabled WRITE setPlaceModeEnabled)
   Q_PROPERTY(bool placeModePersistency READ placeModePersistency WRITE setPlaceModePersistency)
+
+  /// \deprecated Use deleteAllControlPointsOptionVisible instead.
+  Q_PROPERTY(bool deleteAllMarkupsOptionVisible READ deleteAllMarkupsOptionVisible WRITE setDeleteAllMarkupsOptionVisible)
 
 public:
   typedef qSlicerWidget Superclass;
@@ -93,7 +96,7 @@ public:
   bool buttonsVisible() const;
 
   /// Returns true if the Delete all option on the Delete button is visible.
-  bool deleteAllMarkupsOptionVisible() const;
+  bool deleteAllControlPointsOptionVisible() const;
 
   /// Returns true if the Unset last control point option on the Delete button is visible.
   bool unsetLastControlPointOptionVisible() const;
@@ -114,6 +117,19 @@ public:
 
   // Button to delete control point(s) or unset their position
   Q_INVOKABLE QToolButton* deleteButton() const;
+
+  //-----------------------------------------------------------
+  // All public methods below are deprecated
+  //
+  // These methods are deprecated because they use old terms (markup instead of control point),
+
+  /// \deprecated Use deleteAllControlPointsOptionVisible instead.
+  bool deleteAllMarkupsOptionVisible() const
+  {
+    qWarning("qSlicerMarkupsPlaceWidget::deleteAllMarkupsOptionVisible method is deprecated, please use deleteAllControlPointsOptionVisible instead");
+    return this->deleteAllControlPointsOptionVisible();
+  };
+
 
 public slots:
 
@@ -144,7 +160,7 @@ public slots:
   void setButtonsVisible(bool visible);
 
   /// Set visibility of Delete all markups option.
-  void setDeleteAllMarkupsOptionVisible(bool visible);
+  void setDeleteAllControlPointsOptionVisible(bool visible);
 
   /// Set visibility of Unset last control point option.
   void setUnsetLastControlPointOptionVisible(bool visible);
@@ -166,17 +182,35 @@ public slots:
   /// Delete all points from the markups node.
   void deleteAllPoints();
 
-  /// \deprecated Use deleteLastPoint instead.
-  void deleteLastMarkup();
-
-  /// \deprecated Use deleteLastPoint instead.
-  void deleteAllMarkups();
-
   /// Unset the position status of the last placed markup point.
   void unsetLastDefinedPoint();
 
   /// Unset the position of all points from the markups node.
   void unsetAllPoints();
+
+  //-----------------------------------------------------------
+  // All public methods below are deprecated
+  //
+  // These methods are deprecated because they use old terms (markup instead of control point),
+
+  /// \deprecated Use deleteLastPoint instead.
+  void deleteLastMarkup()
+  {
+  qWarning("qSlicerMarkupsPlaceWidget::deleteLastMarkup method is deprecated, please use deleteLastPoint instead");
+  this->deleteLastPoint();
+  };
+  /// \deprecated Use deleteAllPoints instead.
+  void deleteAllMarkups()
+  {
+  qWarning("qSlicerMarkupsPlaceWidget::deleteAllMarkups method is deprecated, please use deleteAllPoints instead");
+  this->deleteAllPoints();
+  };
+  /// \deprecated Use setDeleteAllControlPointsOptionVisible instead.
+  void setDeleteAllMarkupsOptionVisible(bool visible)
+  {
+  qWarning("qSlicerMarkupsPlaceWidget::setDeleteAllMarkupsOptionVisible method is deprecated, please use setDeleteAllControlPointsOptionVisible instead");
+  this->setDeleteAllControlPointsOptionVisible(visible);
+  };
 
 protected slots:
 

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -245,7 +245,7 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
   // set up the list buttons
   // visibility
   // first add actions to the menu, then hook them up
-  visibilityMenu = new QMenu(qSlicerMarkupsModuleWidget::tr("Visibility"), this->visibilityAllMarkupsInListMenuButton);
+  visibilityMenu = new QMenu(qSlicerMarkupsModuleWidget::tr("Visibility"), this->visibilityAllControlPointsInListMenuButton);
   // visibility on
   this->visibilityOnAllControlPointsInListAction =
     new QAction(QIcon(":/Icons/Small/SlicerVisible.png"), "Visibility On", visibilityMenu);
@@ -264,16 +264,16 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
 
   this->visibilityMenu->addAction(this->visibilityOnAllControlPointsInListAction);
   this->visibilityMenu->addAction(this->visibilityOffAllControlPointsInListAction);
-  this->visibilityAllMarkupsInListMenuButton->setMenu(this->visibilityMenu);
-  this->visibilityAllMarkupsInListMenuButton->setIcon(QIcon(":/Icons/VisibleOrInvisible.png"));
+  this->visibilityAllControlPointsInListMenuButton->setMenu(this->visibilityMenu);
+  this->visibilityAllControlPointsInListMenuButton->setIcon(QIcon(":/Icons/VisibleOrInvisible.png"));
 
   // visibility toggle
-  QObject::connect(this->visibilityAllMarkupsInListMenuButton, SIGNAL(clicked()),
+  QObject::connect(this->visibilityAllControlPointsInListMenuButton, SIGNAL(clicked()),
                    q, SLOT(onVisibilityAllControlPointsInListToggled()));
 
   // lock
   // first add actions to the menu, then hook them up
-  lockMenu = new QMenu(qSlicerMarkupsModuleWidget::tr("Lock"), this->lockAllMarkupsInListMenuButton);
+  lockMenu = new QMenu(qSlicerMarkupsModuleWidget::tr("Lock"), this->lockAllControlPointsInListMenuButton);
   // lock
   this->lockAllControlPointsInListAction =
     new QAction(QIcon(":/Icons/Small/SlicerLock.png"), "Lock", lockMenu);
@@ -292,16 +292,16 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
 
   this->lockMenu->addAction(this->lockAllControlPointsInListAction);
   this->lockMenu->addAction(this->unlockAllControlPointsInListAction);
-  this->lockAllMarkupsInListMenuButton->setMenu(this->lockMenu);
-  this->lockAllMarkupsInListMenuButton->setIcon(QIcon(":/Icons/Small/SlicerLockUnlock.png"));
+  this->lockAllControlPointsInListMenuButton->setMenu(this->lockMenu);
+  this->lockAllControlPointsInListMenuButton->setIcon(QIcon(":/Icons/Small/SlicerLockUnlock.png"));
 
   // lock toggle
-  QObject::connect(this->lockAllMarkupsInListMenuButton, SIGNAL(clicked()),
+  QObject::connect(this->lockAllControlPointsInListMenuButton, SIGNAL(clicked()),
                    q, SLOT(onLockAllControlPointsInListToggled()));
 
   // selected
   // first add actions to the menu, then hook them up
-  selectedMenu = new QMenu(qSlicerMarkupsModuleWidget::tr("Selected"), this->selectedAllMarkupsInListMenuButton);
+  selectedMenu = new QMenu(qSlicerMarkupsModuleWidget::tr("Selected"), this->selectedAllControlPointsInListMenuButton);
   // selected on
   this->selectedOnAllControlPointsInListAction =
     new QAction(QIcon(":/Icons/MarkupsSelected.png"), "Selected On", selectedMenu);
@@ -320,30 +320,30 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
 
   this->selectedMenu->addAction(this->selectedOnAllControlPointsInListAction);
   this->selectedMenu->addAction(this->selectedOffAllControlPointsInListAction);
-  this->selectedAllMarkupsInListMenuButton->setMenu(this->selectedMenu);
-  this->selectedAllMarkupsInListMenuButton->setIcon(QIcon(":/Icons/MarkupsSelectedOrUnselected.png"));
+  this->selectedAllControlPointsInListMenuButton->setMenu(this->selectedMenu);
+  this->selectedAllControlPointsInListMenuButton->setIcon(QIcon(":/Icons/MarkupsSelectedOrUnselected.png"));
 
   // selected toggle
-  QObject::connect(this->selectedAllMarkupsInListMenuButton, SIGNAL(clicked()),
+  QObject::connect(this->selectedAllControlPointsInListMenuButton, SIGNAL(clicked()),
                    q, SLOT(onSelectedAllControlPointsInListToggled()));
 
   // add
-  QObject::connect(this->addMarkupPushButton, SIGNAL(clicked()),
+  QObject::connect(this->addControlPointPushButton, SIGNAL(clicked()),
                    q, SLOT(onAddControlPointPushButtonClicked()));
   // move
-  QObject::connect(this->moveMarkupUpPushButton, SIGNAL(clicked()),
+  QObject::connect(this->moveControlPointUpPushButton, SIGNAL(clicked()),
                    q, SLOT(onMoveControlPointUpPushButtonClicked()));
-  QObject::connect(this->moveMarkupDownPushButton, SIGNAL(clicked()),
+  QObject::connect(this->moveControlPointDownPushButton, SIGNAL(clicked()),
                    q, SLOT(onMoveControlPointDownPushButtonClicked()));
   // position status
-  QObject::connect(this->missingMarkupPushButton, SIGNAL(clicked()),
+  QObject::connect(this->missingControlPointPushButton, SIGNAL(clicked()),
       q, SLOT(onMissingControlPointPushButtonClicked()));
-  QObject::connect(this->unsetMarkupPushButton, SIGNAL(clicked()),
+  QObject::connect(this->unsetControlPointPushButton, SIGNAL(clicked()),
       q, SLOT(onUnsetControlPointPushButtonClicked()));
   // delete
-  QObject::connect(this->deleteMarkupPushButton, SIGNAL(clicked()),
+  QObject::connect(this->deleteControlPointPushButton, SIGNAL(clicked()),
                    q, SLOT(onDeleteControlPointPushButtonClicked()));
-  QObject::connect(this->deleteAllMarkupsInListPushButton, SIGNAL(clicked()),
+  QObject::connect(this->deleteAllControlPointsInListPushButton, SIGNAL(clicked()),
       q, SLOT(onDeleteAllControlPointsInListPushButtonClicked()));
 
   this->cutAction = new QAction(q);
@@ -353,7 +353,7 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
   this->cutAction->setShortcuts(QKeySequence::Cut);
   this->cutAction->setToolTip(qSlicerMarkupsModuleWidget::tr("Cut"));
   q->addAction(this->cutAction);
-  this->CutMarkupsToolButton->setDefaultAction(this->cutAction);
+  this->CutControlPointsToolButton->setDefaultAction(this->cutAction);
   QObject::connect(this->cutAction, SIGNAL(triggered()), q, SLOT(cutSelectedToClipboard()));
 
   this->copyAction = new QAction(q);
@@ -363,7 +363,7 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
   this->copyAction->setShortcuts(QKeySequence::Copy);
   this->copyAction->setToolTip(qSlicerMarkupsModuleWidget::tr("Copy"));
   q->addAction(this->copyAction);
-  this->CopyMarkupsToolButton->setDefaultAction(this->copyAction);
+  this->CopyControlPointsToolButton->setDefaultAction(this->copyAction);
   QObject::connect(this->copyAction, SIGNAL(triggered()), q, SLOT(copySelectedToClipboard()));
 
   this->pasteAction = new QAction(q);
@@ -373,7 +373,7 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
   this->pasteAction->setShortcuts(QKeySequence::Paste);
   this->pasteAction->setToolTip(qSlicerMarkupsModuleWidget::tr("Paste"));
   q->addAction(this->pasteAction);
-  this->PasteMarkupsToolButton->setDefaultAction(this->pasteAction);
+  this->PasteControlPointsToolButton->setDefaultAction(this->pasteAction);
   QObject::connect(this->pasteAction, SIGNAL(triggered()), q, SLOT(pasteSelectedFromClipboard()));
 
   // set up the active markups node selector
@@ -1047,21 +1047,21 @@ void qSlicerMarkupsModuleWidget::updateWidgetFromMRML()
     {
     d->fixedNumberOfControlPointsPushButton->setIcon(QIcon(":Icons/Medium/SlicerPointNumberLock.png"));
     d->fixedNumberOfControlPointsPushButton->setToolTip(QString("Click to unlock the number of control points so points can be added or deleted"));
-    d->deleteMarkupPushButton->setEnabled(false);
-    d->deleteAllMarkupsInListPushButton->setEnabled(false);
+    d->deleteControlPointPushButton->setEnabled(false);
+    d->deleteAllControlPointsInListPushButton->setEnabled(false);
     }
   else
     {
     d->fixedNumberOfControlPointsPushButton->setIcon(QIcon(":Icons/Medium/SlicerPointNumberUnlock.png"));
     d->fixedNumberOfControlPointsPushButton->setToolTip(QString("Click to lock the number of control points so no points can be added or deleted"));
-    d->deleteMarkupPushButton->setEnabled(true);
-    d->deleteAllMarkupsInListPushButton->setEnabled(true);
+    d->deleteControlPointPushButton->setEnabled(true);
+    d->deleteAllControlPointsInListPushButton->setEnabled(true);
     }
   // update slice intersections
   d->sliceIntersectionsVisibilityCheckBox->setChecked(this->sliceIntersectionsVisible());
 
   // update the list name format
-  QString nameFormat = QString(d->MarkupsNode->GetMarkupLabelFormat().c_str());
+  QString nameFormat = QString(d->MarkupsNode->GetControlPointLabelFormat().c_str());
   d->nameFormatLineEdit->setText(nameFormat);
 
    // update the table
@@ -1410,7 +1410,7 @@ void qSlicerMarkupsModuleWidget::onVisibilityOnAllControlPointsInListPushButtonC
     {
     return;
     }
-  this->markupsLogic()->SetAllMarkupsVisibility(d->MarkupsNode, true);
+  this->markupsLogic()->SetAllControlPointsVisibility(d->MarkupsNode, true);
   d->MarkupsNode->SetDisplayVisibility(true);
 }
 
@@ -1422,7 +1422,7 @@ void qSlicerMarkupsModuleWidget::onVisibilityOffAllControlPointsInListPushButton
     {
     return;
     }
-  this->markupsLogic()->SetAllMarkupsVisibility(d->MarkupsNode, false);
+  this->markupsLogic()->SetAllControlPointsVisibility(d->MarkupsNode, false);
   d->MarkupsNode->SetDisplayVisibility(false);
 }
 
@@ -1434,7 +1434,7 @@ void qSlicerMarkupsModuleWidget::onVisibilityAllControlPointsInListToggled()
     {
     return;
     }
-  this->markupsLogic()->ToggleAllMarkupsVisibility(d->MarkupsNode);
+  this->markupsLogic()->ToggleAllControlPointsVisibility(d->MarkupsNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -1445,7 +1445,7 @@ void qSlicerMarkupsModuleWidget::onLockAllControlPointsInListPushButtonClicked()
     {
     return;
     }
-  this->markupsLogic()->SetAllMarkupsLocked(d->MarkupsNode, true);
+  this->markupsLogic()->SetAllControlPointsLocked(d->MarkupsNode, true);
 }
 
 //-----------------------------------------------------------------------------
@@ -1456,7 +1456,7 @@ void qSlicerMarkupsModuleWidget::onUnlockAllControlPointsInListPushButtonClicked
     {
     return;
     }
-  this->markupsLogic()->SetAllMarkupsLocked(d->MarkupsNode, false);
+  this->markupsLogic()->SetAllControlPointsLocked(d->MarkupsNode, false);
 }
 
 //-----------------------------------------------------------------------------
@@ -1467,7 +1467,7 @@ void qSlicerMarkupsModuleWidget::onLockAllControlPointsInListToggled()
     {
     return;
     }
-  this->markupsLogic()->ToggleAllMarkupsLocked(d->MarkupsNode);
+  this->markupsLogic()->ToggleAllControlPointsLocked(d->MarkupsNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -1478,7 +1478,7 @@ void qSlicerMarkupsModuleWidget::onSelectAllControlPointsInListPushButtonClicked
     {
     return;
     }
-  this->markupsLogic()->SetAllMarkupsSelected(d->MarkupsNode, true);
+  this->markupsLogic()->SetAllControlPointsSelected(d->MarkupsNode, true);
 }
 
 //-----------------------------------------------------------------------------
@@ -1489,7 +1489,7 @@ void qSlicerMarkupsModuleWidget::onDeselectAllControlPointsInListPushButtonClick
     {
     return;
     }
-  this->markupsLogic()->SetAllMarkupsSelected(d->MarkupsNode, false);
+  this->markupsLogic()->SetAllControlPointsSelected(d->MarkupsNode, false);
 }
 
 //-----------------------------------------------------------------------------
@@ -1500,7 +1500,7 @@ void qSlicerMarkupsModuleWidget::onSelectedAllControlPointsInListToggled()
     {
     return;
     }
-  this->markupsLogic()->ToggleAllMarkupsSelected(d->MarkupsNode);
+  this->markupsLogic()->ToggleAllControlPointsSelected(d->MarkupsNode);
 }
 
 //-----------------------------------------------------------------------------
@@ -1810,10 +1810,10 @@ void qSlicerMarkupsModuleWidget::onDeleteAllControlPointsInListPushButtonClicked
     }
 
   ctkMessageBox deleteAllMsgBox;
-  deleteAllMsgBox.setWindowTitle("Delete All Markups in this list?");
+  deleteAllMsgBox.setWindowTitle("Delete all control points in this list?");
   QString labelText = QString("Delete all ")
     + QString::number(d->MarkupsNode->GetNumberOfControlPoints())
-    + QString(" Markups in this list?");
+    + QString(" control points in this list?");
   // don't show again check box conflicts with informative text, so use
   // a long text
   deleteAllMsgBox.setText(labelText);
@@ -1938,7 +1938,7 @@ void qSlicerMarkupsModuleWidget::onListVisibileInvisiblePushButtonClicked()
 
   if (this->markupsLogic())
     {
-    this->markupsLogic()->SetAllMarkupsVisibility(d->MarkupsNode, visibleFlag);
+    this->markupsLogic()->SetAllControlPointsVisibility(d->MarkupsNode, visibleFlag);
     }
 }
 
@@ -1977,7 +1977,7 @@ void qSlicerMarkupsModuleWidget::onNameFormatLineEditTextEdited(const QString te
     {
     return;
     }
-  d->MarkupsNode->SetMarkupLabelFormat(std::string(text.toUtf8()));
+  d->MarkupsNode->SetControlPointLabelFormat(std::string(text.toUtf8()));
 }
 
 //-----------------------------------------------------------------------------
@@ -2000,7 +2000,7 @@ void qSlicerMarkupsModuleWidget::onResetNameFormatToDefaultPushButtonClicked()
     {
     qCritical() << Q_FUNC_INFO << " failed: invalid default markups node";
     }
-  d->MarkupsNode->SetMarkupLabelFormat(defaultNode->GetMarkupLabelFormat());
+  d->MarkupsNode->SetControlPointLabelFormat(defaultNode->GetControlPointLabelFormat());
 }
 
 //-----------------------------------------------------------------------------
@@ -2011,7 +2011,7 @@ void qSlicerMarkupsModuleWidget::onRenameAllWithCurrentNameFormatPushButtonClick
      {
      return;
      }
-   this->markupsLogic()->RenameAllMarkupsFromCurrentFormat(d->MarkupsNode);
+   this->markupsLogic()->RenameAllControlPointsFromCurrentFormat(d->MarkupsNode);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
I did this work of additional markups API cleanup after noticing the Markups module documentation beginning at the top with an example of how to add a control point and it doing `slicer.modules.markups.logic().AddFiducial()` instead of something like `slicer.modules.markups.logic().AddControlPoint()`.

Ran all tests on Windows and only the currently failing tests are still failing.

```
Deprecate all method names for that either of these applies:
- use old terms: fiducial or markup (instead of control point)
```