### PR TITLE
ENH: Add Markups ROI InsideOut flag

### DIFF
--- a/Docs/user_guide/modules/markups.md
+++ b/Docs/user_guide/modules/markups.md
@@ -142,6 +142,15 @@ Resample section:
 - Advanced:
   - Maximum projection distance: The maximum search radius tolerance defining the allowable projection distance for projecting resampled control points. It is specified as a percentage of the model's bounding box diagonal in world coordinate system.
 
+ROI settings section:
+- ROI type:
+  - Box: ROI is specified by a single control point in the center, axis directions, and size along each axis direction.
+  - BoundingBox: ROI is specified as the bounding box of all the control points.
+- Inside out: If enabled then the selected region is outside the ROI boundary. It is up to each module to decide if this information is used. For example, if ROI is used for cropping a volume then this flag is ignored, as an image cannot have a hole in it; but for example inside out can make sense for blanking out region of a volume.
+- L-R, P-A, I-S Range: Extents of the ROI box along the ROI axes.
+- Display ROI: show/hide the ROI in all views.
+- Interactive mode: allow changing the ROI position, orientation, and size in views using interaction handles. If interaction handles are disabled, the ROI may still be changed by moving control points (unless control points are locked, too).
+
 ## Information for developers
 
 See examples and other developer information in [Developer guide](../../developer_guide/modules/markups.md) and [Script repository](../../developer_guide/script_repository.md#markups).

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIJsonStorageNode.cxx
@@ -113,6 +113,9 @@ bool vtkMRMLMarkupsROIJsonStorageNode::vtkInternalROI::WriteROIProperties(
   writer.Key("size");
   this->WriteVector(writer, size);
 
+  writer.Key("insideOut");
+  writer.Bool(roiNode->GetInsideOut());
+
   return true;
 }
 
@@ -193,6 +196,13 @@ bool vtkMRMLMarkupsROIJsonStorageNode::vtkInternalROI::UpdateMarkupsNodeFromJson
     objectToNodeMatrix->SetElement(i, 3, center_Node[i]);
     }
   roiNode->GetObjectToNodeMatrix()->DeepCopy(objectToNodeMatrix);
+
+  if (markupsObject.HasMember("insideOut"))
+    {
+    rapidjson::Value& insideOutItem = markupsObject["insideOut"];
+    bool insideOut = insideOutItem.GetBool();
+    roiNode->SetInsideOut(insideOut);
+    }
 
   return vtkInternal::UpdateMarkupsNodeFromJsonValue(markupsNode, markupsObject);
 }

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
@@ -31,6 +31,7 @@
 #include "vtkMRMLMarkupsNode.h"
 
 // VTK includes
+#include <vtkImplicitFunction.h>;
 #include <vtkMatrix4x4.h>
 #include <vtkSmartPointer.h>
 #include <vtkStringArray.h>
@@ -39,7 +40,6 @@
 // std includes
 #include <vector>
 
-class vtkImplicitFunction;
 class vtkPlanes;
 
 /// \brief MRML node to represent an ROI markup
@@ -90,6 +90,7 @@ public:
   /// Apply the passed transformation to the ROI
   void ApplyTransform(vtkAbstractTransform* transform) override;
 
+  //@{
   /// Length of the ROI sides
   vtkGetVector3Macro(Size, double);
   void SetSize(const double size[3]);
@@ -97,7 +98,9 @@ public:
   void GetSizeWorld(double size_World[3]);
   void SetSizeWorld(const double size_World[3]);
   void SetSizeWorld(double x_World, double y_World, double z_World);
+  //@}
 
+  //@{
   /// Center of the ROI
   void GetCenter(double center[3]);
   void GetCenterWorld(double center[3]);
@@ -105,7 +108,9 @@ public:
   void SetCenterWorld(double x, double y, double z);
   void SetCenter(const double center[3]);
   void SetCenter(double x, double y, double z);
+  //@}
 
+  //@{
   /// The directional axis of the ROI that are defined by ObjectToNodeMatrix.
   /// \sa GetObjectToNodeMatrix()
   void GetXAxisWorld(double axis_World[3]);
@@ -116,13 +121,16 @@ public:
   void GetYAxis(double axis_Node[3]);
   void GetZAxis(double axis_Node[3]);
   void GetAxis(int axisIndex, double axis_Node[3]);
+  //@}
 
+  //@{
   /// 4x4 matrix defining the object center and axis directions within the node coordinate system.
   vtkMatrix4x4* GetObjectToNodeMatrix()
     {
     return this->ObjectToNodeMatrix;
     };
   void SetAndObserveObjectToNodeMatrix(vtkMatrix4x4* objectToNodeMatrix);
+  //@}
 
   /// 4x4 matrix defining the object center and axis directions within the world coordinate system.
   /// Changes made to the matrix will not be applied.
@@ -131,28 +139,34 @@ public:
     return this->ObjectToWorldMatrix;
     };
 
+  //@{
   /// ROIType represents the method that is used to calculate the size of the ROI.
   /// BOX ROI does not require control points to define a region, while the size of a BOUNDING_BOX ROI will be defined by the control points.
   vtkGetMacro(ROIType, int);
   void SetROIType(int roiType);
   static const char* GetROITypeAsString(int roiType);
   static int GetROITypeFromString(const char* roiType);
+  //@}
 
+  //@{
   /// Calculate the ROI dimensions from the control points
   virtual void UpdateROIFromControlPoints();
   virtual void UpdateBoxROIFromControlPoints();
   virtual void UpdateBoundingBoxROIFromControlPoints();
+  //@}
 
+  //@{
   /// Calculate the position of control points from the ROI
   virtual void UpdateControlPointsFromROI();
   virtual void UpdateControlPointsFromBoundingBoxROI();
   virtual void UpdateControlPointsFromBoxROI();
+  //@}
 
   // ROI type enum defines the calculation method that should be used to convert to and from control points.
   enum
     {
-    ROITypeBox, // Requires two Control points that are removed after they have been placed.
-    ROITypeBoundingBox, // ROI forms a bounding box around the control points.
+    ROITypeBox, ///< Requires two Control points that are removed after they have been placed.
+    ROITypeBoundingBox, ///< ROI forms a bounding box around the control points.
     ROIType_Last
     };
 
@@ -170,6 +184,7 @@ public:
   /// Create default display node or nullptr if does not have one
   void CreateDefaultDisplayNodes() override;
 
+  //@{
   /// Reimplemented to recalculate the axis-aligned bounds of the ROI.
   /// If the ROI is rotated, this function will not reflect the oriented bounds defined by the ROI.
   /// To get the planes that define the oriented bounding box, use GetPlanes()/GetPlanesWorld().
@@ -178,22 +193,52 @@ public:
   /// \sa GetPlanes(), GetPlanesWorld()
   void GetRASBounds(double bounds[6]) override;
   void GetBounds(double bounds[6]) override;
+  //@}
 
+  //@{
   /// Returns the planes that define each of the 6 faces of the ROI.
+  /// If InsideOut property of the node is true the normals of the plane will face inward,
+  /// otherwise the plane normals face outward.
   /// \param planes: Output planes object
-  /// \param insideOut: If false the normals of the planes will face outward so that the inside is "in"
-  ///   if true the normals of the plane will face inward so that the inside is "out".
-  void GetPlanes(vtkPlanes* planes, bool insideOut=false);
-  void GetPlanesWorld(vtkPlanes* planes, bool insideOut=false);
+  void GetPlanes(vtkPlanes* planes) { this->GetPlanes(planes, this->GetInsideOut()); }
+  void GetPlanesWorld(vtkPlanes* planes) { this->GetPlanesWorld(planes, this->GetInsideOut()); }
+  //@}
 
+  //@{
+  /// Returns the planes that define each of the 6 faces of the ROI.
+  /// \param insideOut: Overrides the InsideOut node property of the node.
+  ///   If false the normals of the planes will face outward so that the inside is "in",
+  ///   if true the normals of the plane will face inward so that the inside is "out".
+  void GetPlanes(vtkPlanes* planes, bool insideOut);
+  void GetPlanesWorld(vtkPlanes* planes, bool insideOut);
+  //@}
+
+  //@{
   /// Returns true if the specified point is within the ROI.
   bool IsPointInROI(double point_Node[3]);
   bool IsPointInROIWorld(double point_World[3]);
+  //@}
+
+  //@{
+  /// Get/Set the ROI inside out flag.
+  /// Used for computing ImplicitFunction and bounding planes.
+  /// It may be also used for rendering the ROI differently (e.g., filling inside or outside).
+  /// \sa GetImplicitFunction, GetImplicitFunctionWorld, GetPlanes
+  void SetInsideOut(bool insideOut);
+  vtkGetMacro(InsideOut, bool);
+  vtkBooleanMacro(InsideOut, bool);
+  //@}
+
+  /// Get the implicit function that represents the ROI in node coordinates.
+  vtkGetObjectMacro(ImplicitFunction, vtkImplicitFunction);
+  /// Get the implicit function that represents the ROI in world coordinates.
+  vtkGetObjectMacro(ImplicitFunctionWorld, vtkImplicitFunction);
 
   ///
   /// Legacy vtkMRMLAnnotationROINode methods
   ///
 
+  //@{
   /// Legacy method from vtkMRMLAnnotationROINode
   /// Get/Set for ROI Position in RAS coordinates
   /// Note: The ROI Position is the center of the ROI
@@ -206,7 +251,9 @@ public:
   int SetXYZ(double center[3]);
   int SetXYZ(double x, double y, double z);
   bool GetXYZ(double center[3]);
+  //@}
 
+  //@{
   /// Legacy method from vtkMRMLAnnotationROINode
   /// Get/Set for radius of the ROI in RAS coordinates
   /// Old API:
@@ -217,17 +264,20 @@ public:
   void SetRadiusXYZ(double radiusXYZ[3]);
   void SetRadiusXYZ(double x, double y, double z);
   void GetRadiusXYZ(double radiusXYZ[3]);
+  //@}
 
   /// Legacy method from vtkMRMLAnnotationROINode
   /// \sa GetPlanes(), GetPlanesWorld(), vtkMRMLAnnotationROINode::GetTransformedPlanes()
   void GetTransformedPlanes(vtkPlanes* planes, bool insideOut=false);
 
+  //@{
   /// Helper method for generating an orthogonal right handed matrix from axes.
   /// Transform can optionally be specified to apply an additional transform on the vectors before generating the matrix.
   static void GenerateOrthogonalMatrix(vtkMatrix4x4* inputMatrix,
     vtkMatrix4x4* outputMatrix, vtkAbstractTransform* transform = nullptr, bool applyScaling = true);
   static void GenerateOrthogonalMatrix(double xAxis[3], double yAxis[3], double zAxis[3], double origin[3],
     vtkMatrix4x4* outputMatrix, vtkAbstractTransform* transform = nullptr, bool applyScaling = true);
+  //@}
 
 protected:
   int ROIType{vtkMRMLMarkupsROINode::ROITypeBox};
@@ -237,15 +287,22 @@ protected:
   bool IsUpdatingControlPointsFromROI{false};
   bool IsUpdatingROIFromControlPoints{false};
   bool IsUpdatingInteractionHandleToWorldMatrix{false};
+  bool InsideOut{false};
 
   vtkSmartPointer<vtkMatrix4x4> ObjectToNodeMatrix { nullptr };
   vtkSmartPointer<vtkMatrix4x4> ObjectToWorldMatrix { nullptr };
+
+  vtkSmartPointer<vtkImplicitFunction> ImplicitFunction { nullptr };
+  vtkSmartPointer<vtkImplicitFunction> ImplicitFunctionWorld { nullptr };
 
   /// Fills the specified vtkPoints with the points for all of the box ROI corners
   void GenerateBoxBounds(double bounds[6], double xAxis[3], double yAxis[3], double zAxis[3], double center[3], double size[3]);
 
   /// Calculates the transform from the Object (ROI) to World coordinates.
   void UpdateObjectToWorldMatrix();
+
+  /// Updates the parameters of the internal implicit functions
+  void UpdateImplicitFunction();
 
   vtkMRMLMarkupsROINode();
   ~vtkMRMLMarkupsROINode() override;

--- a/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
+++ b/Modules/Loadable/Markups/Resources/Schema/markups-schema-v1.0.3.json
@@ -102,12 +102,19 @@
                                     "description": "Method used to determine ROI bounds from control points. Ex. 'Box', 'BoundingBox'.",
                                     "default": "Box"
                                 },
+                               "insideOut": {
+                                    "$id": "#markup/insideOut",
+                                    "type": "boolean",
+                                    "title": "Inside out",
+                                    "description": "ROI is inside out. Objects that would normally be inside are considered outside and vice versa.",
+                                    "default": false
+                                },
                                 "planeType": {
                                     "$id": "#markup/planeType",
                                     "type": "string",
                                     "title": "Plane type",
                                     "description": "Method used to determine dimensions from control points. Ex. 'PointNormal', '3Points'.",
-                                    "default": "Box"
+                                    "default": "PointNormal"
                                 },
                                 "sizeMode": {
                                     "$id": "#markup/sizeMode",

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsROIWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsROIWidget.ui
@@ -27,12 +27,12 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="ctkCollapsibleButton" name="roiSettingsCollapseButton" native="true">
-     <property name="text" stdset="0">
+    <widget class="ctkCollapsibleButton" name="roiSettingsCollapseButton">
+     <property name="text">
       <string>ROI Settings</string>
      </property>
-     <property name="collapsed" stdset="0">
-      <bool>true</bool>
+     <property name="collapsed">
+      <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
@@ -53,6 +53,20 @@
         <item row="0" column="1">
          <widget class="QComboBox" name="roiTypeComboBox"/>
         </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Inside out:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="insideOutCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>
@@ -68,20 +82,20 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="qMRMLRangeWidget" name="LRRangeWidget" native="true">
-          <property name="minimum" stdset="0">
+         <widget class="qMRMLRangeWidget" name="LRRangeWidget">
+          <property name="minimum">
            <double>-100.000000000000000</double>
           </property>
-          <property name="maximum" stdset="0">
+          <property name="maximum">
            <double>100.000000000000000</double>
           </property>
-          <property name="minimumValue" stdset="0">
+          <property name="minimumValue">
            <double>-50.000000000000000</double>
           </property>
-          <property name="maximumValue" stdset="0">
+          <property name="maximumValue">
            <double>50.000000000000000</double>
           </property>
-          <property name="minimumHandlePalette" stdset="0">
+          <property name="minimumHandlePalette">
            <palette>
             <active>
              <colorrole role="WindowText">
@@ -388,7 +402,7 @@
             </disabled>
            </palette>
           </property>
-          <property name="maximumHandlePalette" stdset="0">
+          <property name="maximumHandlePalette">
            <palette>
             <active>
              <colorrole role="WindowText">
@@ -695,7 +709,7 @@
             </disabled>
            </palette>
           </property>
-          <property name="quantity" stdset="0">
+          <property name="quantity">
            <string>length</string>
           </property>
          </widget>
@@ -711,20 +725,20 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="qMRMLRangeWidget" name="PARangeWidget" native="true">
-          <property name="minimum" stdset="0">
+         <widget class="qMRMLRangeWidget" name="PARangeWidget">
+          <property name="minimum">
            <double>-100.000000000000000</double>
           </property>
-          <property name="maximum" stdset="0">
+          <property name="maximum">
            <double>100.000000000000000</double>
           </property>
-          <property name="minimumValue" stdset="0">
+          <property name="minimumValue">
            <double>-50.000000000000000</double>
           </property>
-          <property name="maximumValue" stdset="0">
+          <property name="maximumValue">
            <double>50.000000000000000</double>
           </property>
-          <property name="minimumHandlePalette" stdset="0">
+          <property name="minimumHandlePalette">
            <palette>
             <active>
              <colorrole role="WindowText">
@@ -1031,7 +1045,7 @@
             </disabled>
            </palette>
           </property>
-          <property name="maximumHandlePalette" stdset="0">
+          <property name="maximumHandlePalette">
            <palette>
             <active>
              <colorrole role="WindowText">
@@ -1338,26 +1352,26 @@
             </disabled>
            </palette>
           </property>
-          <property name="quantity" stdset="0">
+          <property name="quantity">
            <string>length</string>
           </property>
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="qMRMLRangeWidget" name="ISRangeWidget" native="true">
-          <property name="minimum" stdset="0">
+         <widget class="qMRMLRangeWidget" name="ISRangeWidget">
+          <property name="minimum">
            <double>-100.000000000000000</double>
           </property>
-          <property name="maximum" stdset="0">
+          <property name="maximum">
            <double>100.000000000000000</double>
           </property>
-          <property name="minimumValue" stdset="0">
+          <property name="minimumValue">
            <double>-50.000000000000000</double>
           </property>
-          <property name="maximumValue" stdset="0">
+          <property name="maximumValue">
            <double>50.000000000000000</double>
           </property>
-          <property name="minimumHandlePalette" stdset="0">
+          <property name="minimumHandlePalette">
            <palette>
             <active>
              <colorrole role="WindowText">
@@ -1664,7 +1678,7 @@
             </disabled>
            </palette>
           </property>
-          <property name="maximumHandlePalette" stdset="0">
+          <property name="maximumHandlePalette">
            <palette>
             <active>
              <colorrole role="WindowText">
@@ -1971,7 +1985,7 @@
             </disabled>
            </palette>
           </property>
-          <property name="quantity" stdset="0">
+          <property name="quantity">
            <string>length</string>
           </property>
          </widget>
@@ -2073,11 +2087,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ctkRangeWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkRangeWidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>qMRMLRangeWidget</class>
    <extends>ctkRangeWidget</extends>
    <header>qMRMLRangeWidget.h</header>
@@ -2087,6 +2096,11 @@
    <extends>QWidget</extends>
    <header>ctkCollapsibleButton.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkRangeWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkRangeWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsROIWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsROIWidget.cxx
@@ -80,6 +80,8 @@ void qMRMLMarkupsROIWidgetPrivate::setupUi(qMRMLMarkupsROIWidget* widget)
 
   QObject::connect(this->roiTypeComboBox, SIGNAL(currentIndexChanged(int)),
                    q, SLOT(onROITypeParameterChanged()));
+  QObject::connect(this->insideOutCheckBox, SIGNAL(toggled(bool)),
+                   q, SLOT(setInsideOut(bool)));
   QObject::connect(this->DisplayClippingBoxButton, SIGNAL(toggled(bool)),
                    q, SLOT(setDisplayClippingBox(bool)));
   QObject::connect(this->InteractiveModeCheckBox, SIGNAL(toggled(bool)),
@@ -275,6 +277,34 @@ void qMRMLMarkupsROIWidget::onROITypeParameterChanged()
 }
 
 //-----------------------------------------------------------------------------
+bool qMRMLMarkupsROIWidget::insideOut()
+{
+  Q_D(qMRMLMarkupsROIWidget);
+
+  auto roiNode = vtkMRMLMarkupsROINode::SafeDownCast(this->MarkupsNode);
+  if (!roiNode)
+    {
+    return false;
+    }
+  return roiNode->GetInsideOut();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsROIWidget::setInsideOut(bool insideOut)
+{
+  Q_D(qMRMLMarkupsROIWidget);
+
+  auto roiNode = vtkMRMLMarkupsROINode::SafeDownCast(this->MarkupsNode);
+  if (!roiNode)
+    {
+    return;
+    }
+
+  MRMLNodeModifyBlocker blocker(roiNode);
+  roiNode->SetInsideOut(insideOut);
+}
+
+//-----------------------------------------------------------------------------
 void qMRMLMarkupsROIWidget::updateWidgetFromMRML()
 {
   Q_D(qMRMLMarkupsROIWidget);
@@ -335,6 +365,10 @@ void qMRMLMarkupsROIWidget::updateWidgetFromMRML()
   bool wasBlocked = d->roiTypeComboBox->blockSignals(true);
   d->roiTypeComboBox->setCurrentIndex(d->roiTypeComboBox->findData(roiNode->GetROIType()));
   d->roiTypeComboBox->blockSignals(wasBlocked);
+
+  wasBlocked = d->insideOutCheckBox->blockSignals(true);
+  d->insideOutCheckBox->setChecked(roiNode->GetInsideOut());
+  d->insideOutCheckBox->blockSignals(wasBlocked);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsROIWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsROIWidget.h
@@ -62,6 +62,9 @@ public:
   /// Checks whether a given node can be handled by the widget
   bool canManageMRMLMarkupsNode(vtkMRMLMarkupsNode *markupsNode) const override;
 
+  /// Get the inside out state.
+  bool insideOut();
+
 public slots:
   /// Turn on/off the visibility of the ROI node
   void setDisplayClippingBox(bool visible);
@@ -69,6 +72,9 @@ public slots:
   /// Turn on/off the tracking mode of the sliders.
   /// The ROI node will be updated only when the slider handles are released.
   void setInteractiveMode(bool interactive);
+
+  /// Turn on/off inside out state.
+  void setInsideOut(bool insideOut);
 
   /// Updates the widget on MRML changes
   void updateWidgetFromMRML() override;


### PR DESCRIPTION
The inside out function can be used to invert the ROI so that points inside the ROI are considered outside, and vice versa. This state is reflected in GetPlanes()/GetPlanesWorld() and IsPointInROI()/IsPointInROIWorld().

This commit also adds implicit functions to the ROI node that can be used by other nodes, and that will invert their sign based on the InsideOut state.

Re #5061