### PR TITLE
ENH: Add ability to toggle segment editor tool button style

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -2133,10 +2133,10 @@ void qMRMLSegmentEditorWidget::onMasterVolumeNodeChanged(vtkMRMLNode* node)
 //-----------------------------------------------------------------------------
 void qMRMLSegmentEditorWidget::onEffectButtonClicked(QAbstractButton* button)
 {
+  Q_D(qMRMLSegmentEditorWidget);
   // Get effect that was just clicked
   qSlicerSegmentEditorAbstractEffect* clickedEffect = qobject_cast<qSlicerSegmentEditorAbstractEffect*>(
     button->property("Effect").value<QObject*>() );
-
   this->setActiveEffect(clickedEffect);
 }
 
@@ -3144,6 +3144,23 @@ void qMRMLSegmentEditorWidget::toggleMasterVolumeIntensityMaskEnabled()
     !d->ParameterSetNode->GetMasterVolumeIntensityMask());
 }
 
+//------------------------------------------------------------------------------
+void qMRMLSegmentEditorWidget::toggleEffectButtonLabelVisibility()
+{
+  Q_D(qMRMLSegmentEditorWidget);
+
+  if (d->EffectButtonStyle == Qt::ToolButtonIconOnly)
+    {
+    this->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    this->setEffectButtonStyle(Qt::ToolButtonTextUnderIcon);
+    }
+  else
+    {
+    this->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
+    this->setEffectButtonStyle(Qt::ToolButtonIconOnly);
+    }
+}
+
 //-----------------------------------------------------------------------------
 void qMRMLSegmentEditorWidget::undo()
 {
@@ -3264,9 +3281,15 @@ void qMRMLSegmentEditorWidget::installKeyboardShortcuts(QWidget* parent /*=nullp
     QObject::connect(nextShortcut, SIGNAL(activated()), this, SLOT(onSelectSegmentShortcut()));
     }
 
+  // Key i
   QShortcut* toggleMasterVolumeIntensityMaskShortcut = new QShortcut(QKeySequence(Qt::Key_I), parent);
   d->KeyboardShortcuts.push_back(toggleMasterVolumeIntensityMaskShortcut);
   QObject::connect(toggleMasterVolumeIntensityMaskShortcut, SIGNAL(activated()), this, SLOT(toggleMasterVolumeIntensityMaskEnabled()));
+
+  // Key t
+  QShortcut* toggleToolButtonStyleShortcut = new QShortcut(QKeySequence(Qt::Key_L), parent);
+  d->KeyboardShortcuts.push_back(toggleToolButtonStyleShortcut);
+  QObject::connect(toggleToolButtonStyleShortcut, SIGNAL(activated()), this, SLOT(toggleEffectButtonLabelVisibility()));
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
@@ -276,6 +276,9 @@ public slots:
   /// Enable/disable masking using master volume intensity
   void toggleMasterVolumeIntensityMaskEnabled();
 
+  /// Toggle style of effect buttons to see button labels if needed.
+  void  toggleEffectButtonLabelVisibility();
+
   /// Restores previous saved state of the segmentation
   void undo();
 


### PR DESCRIPTION
by pressing the "t" key.

The new tool button layout in the segment editor is elegant, but the icons are hard to remember and will be even more if new effects are added. The tool texts are too slow. This small change adds a shortcut to the "t" key to bring back all button bottom labels for a short moment if needed.