### PR TITLE
BUG: Update SurfaceToolbox to fix linking Dynamic Modeler logic

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -351,7 +351,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
   # When updating the GIT_TAG, consider updating documentation in Docs/user_guide (see https://github.com/Slicer/Slicer/issues/5669)
-  GIT_TAG c7cf164eed8725626b088f7f36b6ea4ad51ad7b0
+  GIT_TAG ba4a56c083f627fbe026fdbf29c0039edf9facef
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
$ git shortlog c7cf164..ba4a56c
Andras Lasso (1):
      ENH: Set more user-friendly name for boundary cut tool

Kyle Sunderland (1):
      BUG: Fix error linking vtkSlicerDynamicModelerModuleLogic in extensions