### PR TITLE
COMP: Fix warning in vtkMRMLMarkupsROINode removing extra semicolon

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
@@ -31,7 +31,7 @@
 #include "vtkMRMLMarkupsNode.h"
 
 // VTK includes
-#include <vtkImplicitFunction.h>;
+#include <vtkImplicitFunction.h>
 #include <vtkMatrix4x4.h>
 #include <vtkSmartPointer.h>
 #include <vtkStringArray.h>


### PR DESCRIPTION
This commit fixes the following warning introduced in fdc587cbb9 (ENH: Add InsideOut
flag to markups ROI).

```
  /path/to/Slicer/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h:34:33: warning: extra tokens at end of #include directive
   #include <vtkImplicitFunction.h>;
                                   ^
```