### PR TITLE
BUG: Fix vtkMRMLMarkupsNode::GetCenterPositionWorld deprecation warning

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -1182,7 +1182,7 @@ bool vtkMRMLMarkupsNode::GetCenterPosition(double point[3])
 bool vtkMRMLMarkupsNode::GetCenterPositionWorld(double worldxyz[3])
 {
   vtkVector3d world;
-  this->TransformPointToWorld(this->GetCenterPositionVector(), world);
+  this->TransformPointToWorld(this->GetCenterPosition(), world);
   worldxyz[0] = world[0];
   worldxyz[1] = world[1];
   worldxyz[2] = world[2];


### PR DESCRIPTION
Whenever a Markups closed curve node is modified the displayable manager calls vtkMRMLMarkupsNode::GetCenterPositionWorld. This logs a warning due to the use of the deprecated GetCenterPositionVector method.

Fixed by using the non-deprecated GetCenterPosition.