### PR TITLE
DOC: Update CMake Prerequisite to 3.21.1

### DIFF
--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -2,7 +2,7 @@
 
 ## Install prerequisites
 
-- [CMake](http://www.cmake.org/cmake/resources/software.html) >= 3.15.1
+- [CMake](http://www.cmake.org/cmake/resources/software.html) >= 3.21.1
 - [Git](https://git-scm.com/download/win) >= 1.7.10
   - Note: CMake must be able to find `git.exe` and `patch.exe`. If git is installed in the default location then they may be found there, but if they are not found then either add the folder that contains them to `PATH` environment variable; or set `GIT_EXECUTABLE` and `Patch_EXECUTABLE` as environment variables or as CMake variables at configure time.
 - [Visual Studio](https://visualstudio.microsoft.com/downloads/)


### PR DESCRIPTION
I was unable to build Slicer because of many `PDB API call failed` errors. It turns out C-Make > 3.20.4 and < 3.21.1 do not add the `/FS` flag to the command line. I was unlucky enough to be using one of these versions of C-Make, and ITK uses that flag, so it failed to build.

https://discourse.itk.org/t/itk-installation-error/3032/9
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6390