### PR TITLE
BUG: duplicated subfolder on scripted modules

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/CMakeLists.txt
@@ -43,4 +43,5 @@ ctkMacroCompilePythonScript(
   RESOURCES "${SegmentEditorEffects_PYTHON_RESOURCES}"
   DESTINATION_DIR ${Slicer_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}/SegmentEditorEffects
   INSTALL_DIR ${Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR}/SegmentEditorEffects
+  NO_INSTALL_SUBDIR
   )

--- a/Modules/Loadable/SubjectHierarchy/Widgets/Python/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/Python/CMakeLists.txt
@@ -14,4 +14,5 @@ ctkMacroCompilePythonScript(
   RESOURCES "${SubjectHierarchyWidgets_PYTHON_RESOURCES}"
   DESTINATION_DIR ${Slicer_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}/SubjectHierarchyPlugins
   INSTALL_DIR ${Slicer_INSTALL_QTSCRIPTEDMODULES_LIB_DIR}/SubjectHierarchyPlugins
+  NO_INSTALL_SUBDIR
   )


### PR DESCRIPTION
scripted modules were getting a subfolder with duplicated content on final windows build.
![image](https://user-images.githubusercontent.com/4790289/146974302-aba16bc4-11e9-42d1-ab2c-74a949485ccc.png)
