### PR TITLE
BUG: Fix Markups place widget not enabled when active node is not set

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -507,9 +507,9 @@ void qSlicerMarkupsPlaceWidget::updateWidget()
     }
 
   bool activePlaceNodePlacementValid = false;
-  if (d->SelectionNode)
+  if (currentMarkupsNode)
     {
-    activePlaceNodePlacementValid = d->SelectionNode->GetActivePlaceNodePlacementValid();
+    activePlaceNodePlacementValid = !currentMarkupsNode->GetControlPointPlacementComplete();
     }
   d->PlaceButton->setEnabled(activePlaceNodePlacementValid);
 


### PR DESCRIPTION
When using a qSlicerMarkupsPlaceWidget, the place button would be disabled unless placement for the active place node was valid (vtkMRMLSelectionNode::GetActivePlaceNodePlacementValid). This could cause the place button to be disabled even when placement for the widget's current Markups node was valid.

Fixed by checking place mode validity for the current markups node in the widget, rather than the active node.