### PR TITLE
ENH: Added variant radius to markups curve

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -104,8 +104,7 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->LineThickness = 0.2;
   this->LineDiameter = 1.0;
 
-  this->VaryRadius = 0;
-  this->RadiusFactor = 10;
+  this->LineDiameterMode = 0;
 
   // Line color variables
   this->LineColorFadingStart = 1.;
@@ -172,8 +171,7 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLEnumMacro(curveLineSizeMode, CurveLineSizeMode);
   vtkMRMLWriteXMLFloatMacro(lineThickness, LineThickness);
   vtkMRMLWriteXMLFloatMacro(lineDiameter, LineDiameter);
-  vtkMRMLWriteXMLIntMacro(varyRadius, VaryRadius);
-  vtkMRMLWriteXMLFloatMacro(radiusFactor, RadiusFactor);
+  vtkMRMLWriteXMLIntMacro(lineDiameterMode, LineDiameterMode);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingStart, LineColorFadingStart);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
@@ -221,8 +219,7 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLEnumMacro(curveLineSizeMode, CurveLineSizeMode);
   vtkMRMLReadXMLFloatMacro(lineThickness, LineThickness);
   vtkMRMLReadXMLFloatMacro(lineDiameter, LineDiameter);
-  vtkMRMLReadXMLIntMacro(varyRadius, VaryRadius);
-  vtkMRMLReadXMLFloatMacro(radiusFactor, RadiusFactor);
+  vtkMRMLReadXMLIntMacro(lineDiameterMode, LineDiameterMode);
   vtkMRMLReadXMLFloatMacro(lineColorFadingStart, LineColorFadingStart);
   vtkMRMLReadXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLReadXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
@@ -302,8 +299,7 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   vtkMRMLCopyEnumMacro(CurveLineSizeMode);
   vtkMRMLCopyFloatMacro(LineThickness);
   vtkMRMLCopyFloatMacro(LineDiameter);
-  vtkMRMLCopyIntMacro(VaryRadius);
-  vtkMRMLCopyFloatMacro(RadiusFactor);
+  vtkMRMLCopyIntMacro(LineDiameterMode);
   vtkMRMLCopyFloatMacro(LineColorFadingStart);
   vtkMRMLCopyFloatMacro(LineColorFadingEnd);
   vtkMRMLCopyFloatMacro(LineColorFadingSaturation);
@@ -499,8 +495,7 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintEnumMacro(CurveLineSizeMode);
   vtkMRMLPrintFloatMacro(LineThickness);
   vtkMRMLPrintFloatMacro(LineDiameter);
-  vtkMRMLPrintIntMacro(VaryRadius);
-  vtkMRMLPrintFloatMacro(RadiusFactor);
+  vtkMRMLPrintIntMacro(LineDiameterMode);
   vtkMRMLPrintFloatMacro(LineColorFadingStart);
   vtkMRMLPrintFloatMacro(LineColorFadingEnd);
   vtkMRMLPrintFloatMacro(LineColorFadingSaturation);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -104,6 +104,9 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->LineThickness = 0.2;
   this->LineDiameter = 1.0;
 
+  this->VaryRadius = 0;
+  this->RadiusFactor = 10;
+
   // Line color variables
   this->LineColorFadingStart = 1.;
   this->LineColorFadingEnd = 10.;
@@ -169,6 +172,8 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLEnumMacro(curveLineSizeMode, CurveLineSizeMode);
   vtkMRMLWriteXMLFloatMacro(lineThickness, LineThickness);
   vtkMRMLWriteXMLFloatMacro(lineDiameter, LineDiameter);
+  vtkMRMLWriteXMLIntMacro(varyRadius, VaryRadius);
+  vtkMRMLWriteXMLFloatMacro(radiusFactor, RadiusFactor);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingStart, LineColorFadingStart);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLWriteXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
@@ -216,6 +221,8 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLEnumMacro(curveLineSizeMode, CurveLineSizeMode);
   vtkMRMLReadXMLFloatMacro(lineThickness, LineThickness);
   vtkMRMLReadXMLFloatMacro(lineDiameter, LineDiameter);
+  vtkMRMLReadXMLIntMacro(varyRadius, VaryRadius);
+  vtkMRMLReadXMLFloatMacro(radiusFactor, RadiusFactor);
   vtkMRMLReadXMLFloatMacro(lineColorFadingStart, LineColorFadingStart);
   vtkMRMLReadXMLFloatMacro(lineColorFadingEnd, LineColorFadingEnd);
   vtkMRMLReadXMLFloatMacro(lineColorFadingSaturation, LineColorFadingSaturation);
@@ -295,6 +302,8 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   vtkMRMLCopyEnumMacro(CurveLineSizeMode);
   vtkMRMLCopyFloatMacro(LineThickness);
   vtkMRMLCopyFloatMacro(LineDiameter);
+  vtkMRMLCopyIntMacro(VaryRadius);
+  vtkMRMLCopyFloatMacro(RadiusFactor);
   vtkMRMLCopyFloatMacro(LineColorFadingStart);
   vtkMRMLCopyFloatMacro(LineColorFadingEnd);
   vtkMRMLCopyFloatMacro(LineColorFadingSaturation);
@@ -490,6 +499,8 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintEnumMacro(CurveLineSizeMode);
   vtkMRMLPrintFloatMacro(LineThickness);
   vtkMRMLPrintFloatMacro(LineDiameter);
+  vtkMRMLPrintIntMacro(VaryRadius);
+  vtkMRMLPrintFloatMacro(RadiusFactor);
   vtkMRMLPrintFloatMacro(LineColorFadingStart);
   vtkMRMLPrintFloatMacro(LineColorFadingEnd);
   vtkMRMLPrintFloatMacro(LineColorFadingSaturation);

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -351,6 +351,14 @@ public:
   static const char* GetCurveLineSizeModeAsString(int mode);
   static int GetCurveLineSizeModeFromString(const char*);
 
+  /// Set variant radius for tube filter.
+  /// Values are given from 'VTK_VARY_RADIUS_' macro
+  vtkSetMacro(VaryRadius, int);
+  vtkGetMacro(VaryRadius, int);
+
+  vtkSetMacro(RadiusFactor, double);
+  vtkGetMacro(RadiusFactor, double);
+
   /// Configure line thickness
   /// Thickness is specified relative to markup point size
   /// (1.0 means line diameter is the same as diameter of point glyphs).
@@ -509,6 +517,9 @@ protected:
   int CurveLineSizeMode;
   double LineThickness;
   double LineDiameter;
+
+  int VaryRadius;
+  double RadiusFactor;
 
   double LineColorFadingStart;
   double LineColorFadingEnd;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -342,6 +342,14 @@ public:
     CurveLineSizeMode_Last // insert new types above this line
     };
 
+  /// Reimplements VTK_VARY_RADIUS_ macros
+  enum LineDiameterMode
+    {
+    Constant = 0, // VTK_VARY_RADIUS_OFF
+    FromScalars = 1, // VTK_VARY_RADIUS_BY_SCALAR
+    AbsoluteFromScalars = 3 // VTK_VARY_RADIUS_BY_ABSOLUTE_SCALAR
+    };
+
   /// Configure mode of determining line radius of markup curves.
   /// Default is relative thickness. Available modes in \sa CurveLineSizeModes
   vtkSetMacro(CurveLineSizeMode, int);
@@ -353,11 +361,8 @@ public:
 
   /// Set variant radius for tube filter.
   /// Values are given from 'VTK_VARY_RADIUS_' macro
-  vtkSetMacro(VaryRadius, int);
-  vtkGetMacro(VaryRadius, int);
-
-  vtkSetMacro(RadiusFactor, double);
-  vtkGetMacro(RadiusFactor, double);
+  vtkSetMacro(LineDiameterMode, int);
+  vtkGetMacro(LineDiameterMode, int);
 
   /// Configure line thickness
   /// Thickness is specified relative to markup point size
@@ -518,8 +523,7 @@ protected:
   double LineThickness;
   double LineDiameter;
 
-  int VaryRadius;
-  double RadiusFactor;
+  int LineDiameterMode;
 
   double LineColorFadingStart;
   double LineColorFadingEnd;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
@@ -103,8 +103,7 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
     this->MarkupsDisplayNode->GetLineDiameter() / this->ViewScaleFactorMmPerPixel : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
   this->TubeFilter->SetRadius(diameter * 0.5);
-  this->TubeFilter->SetVaryRadius(this->MarkupsDisplayNode->GetVaryRadius());
-  this->TubeFilter->SetRadiusFactor(this->MarkupsDisplayNode->GetRadiusFactor());
+  this->TubeFilter->SetVaryRadius(this->MarkupsDisplayNode->GetLineDiameterMode());
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() >= 2);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.cxx
@@ -103,6 +103,8 @@ void vtkSlicerCurveRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
     this->MarkupsDisplayNode->GetLineDiameter() / this->ViewScaleFactorMmPerPixel : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
   this->TubeFilter->SetRadius(diameter * 0.5);
+  this->TubeFilter->SetVaryRadius(this->MarkupsDisplayNode->GetVaryRadius());
+  this->TubeFilter->SetRadiusFactor(this->MarkupsDisplayNode->GetRadiusFactor());
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() >= 2);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
@@ -144,6 +144,8 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
     this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
   this->TubeFilter->SetRadius(diameter * 0.5);
+  this->TubeFilter->SetVaryRadius(this->MarkupsDisplayNode->GetVaryRadius());
+  this->TubeFilter->SetRadiusFactor(this->MarkupsDisplayNode->GetRadiusFactor());
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() >= 2);
 
@@ -291,6 +293,8 @@ int vtkSlicerCurveRepresentation3D::RenderOpaqueGeometry(
     double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
       this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
     this->TubeFilter->SetRadius(diameter * 0.5);
+    this->TubeFilter->SetVaryRadius(this->MarkupsDisplayNode->GetVaryRadius());
+    this->TubeFilter->SetRadiusFactor(this->MarkupsDisplayNode->GetRadiusFactor());
     count += this->LineActor->RenderOpaqueGeometry(viewport);
     }
   if (this->LineOccludedActor->GetVisibility())

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.cxx
@@ -144,8 +144,7 @@ void vtkSlicerCurveRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
     this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
   this->TubeFilter->SetRadius(diameter * 0.5);
-  this->TubeFilter->SetVaryRadius(this->MarkupsDisplayNode->GetVaryRadius());
-  this->TubeFilter->SetRadiusFactor(this->MarkupsDisplayNode->GetRadiusFactor());
+  this->TubeFilter->SetVaryRadius(this->MarkupsDisplayNode->GetLineDiameterMode());
 
   this->LineActor->SetVisibility(markupsNode->GetNumberOfControlPoints() >= 2);
 
@@ -293,8 +292,7 @@ int vtkSlicerCurveRepresentation3D::RenderOpaqueGeometry(
     double diameter = ( this->MarkupsDisplayNode->GetCurveLineSizeMode() == vtkMRMLMarkupsDisplayNode::UseLineDiameter ?
       this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
     this->TubeFilter->SetRadius(diameter * 0.5);
-    this->TubeFilter->SetVaryRadius(this->MarkupsDisplayNode->GetVaryRadius());
-    this->TubeFilter->SetRadiusFactor(this->MarkupsDisplayNode->GetRadiusFactor());
+    this->TubeFilter->SetVaryRadius(this->MarkupsDisplayNode->GetLineDiameterMode());
     count += this->LineActor->RenderOpaqueGeometry(viewport);
     }
   if (this->LineOccludedActor->GetVisibility())

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>368</width>
-    <height>186</height>
+    <width>622</width>
+    <height>919</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -116,10 +116,10 @@
       <string>Advanced</string>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="collapsed">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="topMargin">
@@ -131,7 +131,332 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="12" column="0" colspan="2">
+      <item row="8" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QCheckBox" name="FillVisibilityCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="OpacityLabel3">
+          <property name="text">
+           <string>Opacity:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="FillOpacitySliderWidget">
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="PropertiesLabelVisibilityLabel">
+        <property name="text">
+         <string>Properties Label:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
+        <property name="toolTip">
+         <string>Show control point labels</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="14" column="0" colspan="2">
+       <widget class="ctkCollapsibleGroupBox" name="ThreeDDisplayGroupBox">
+        <property name="title">
+         <string>3D Display</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="1" column="0">
+          <widget class="QLabel" name="OccludedVisibilityLabel">
+           <property name="text">
+            <string>Occluded Visibility:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="QCheckBox" name="OccludedVisibilityCheckBox">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="OpacityLabel">
+             <property name="text">
+              <string>Opacity:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="ctkSliderWidget" name="OccludedOpacitySliderWidget">
+             <property name="singleStep">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="pageStep">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="PointLabelsVisibilityLabel_2">
+           <property name="text">
+            <string>Placement mode:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="SnapModeComboBox"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="activeColorPickerLabel">
+        <property name="text">
+         <string>Active Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
+        <property name="toolTip">
+         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="ctkColorPickerButton" name="activeColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="selectedColorLabel">
+        <property name="text">
+         <string>Selected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QCheckBox" name="OutlineVisibilityCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="OpacityLabel2">
+          <property name="text">
+           <string>Opacity:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="OutlineOpacitySliderWidget">
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="FillLabel">
+        <property name="text">
+         <string>Fill:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="glyphTypeComboBox"/>
+      </item>
+      <item row="12" column="0">
+       <widget class="QLabel" name="PointLabelsVisibilityLabel">
+        <property name="text">
+         <string>Control Point Labels:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="lineThicknessLabel">
+        <property name="text">
+         <string>Line Thickness:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="glyphTypeLabel">
+        <property name="text">
+         <string>Glyph Type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QPushButton" name="curveLineSizeIsAbsoluteButton">
+          <property name="toolTip">
+           <string>If button is pressed then line thickness is specified in physical length unit, otherwise as percentage of glyph size</string>
+          </property>
+          <property name="text">
+           <string>absolute</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="curveLineThicknessSliderWidget">
+          <property name="singleStep">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>20.000000000000000</double>
+          </property>
+          <property name="suffix">
+           <string> %</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="qMRMLSliderWidget" name="curveLineDiameterSliderWidget">
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="quantity">
+           <string>length</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="15" column="0" colspan="2">
+       <widget class="ctkCollapsibleGroupBox" name="TwoDDisplayGroupBox">
+        <property name="title">
+         <string>2D Display</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="qMRMLMarkupsFiducialProjectionPropertyWidget" name="pointFiducialProjectionWidget"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="unselectedColorLabel">
+        <property name="text">
+         <string>Unselected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="OutlineLabel">
+        <property name="text">
+         <string>Outline:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="DisplayNodeViewLabel">
+        <property name="text">
+         <string>View:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QCheckBox" name="PropertiesLabelVisibilityCheckBox">
+        <property name="toolTip">
+         <string>Show node name and measurements</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="TextDisplayGroupBox">
         <property name="title">
          <string>Text Display</string>
@@ -219,166 +544,34 @@
         </layout>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QComboBox" name="glyphTypeComboBox"/>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
-        <property name="toolTip">
-         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="activeColorPickerLabel">
+      <item row="6" column="0">
+       <widget class="QLabel" name="variantLineThicknessLabel">
         <property name="text">
-         <string>Active Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="14" column="0" colspan="2">
-       <widget class="ctkCollapsibleGroupBox" name="TwoDDisplayGroupBox">
-        <property name="title">
-         <string>2D Display</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_4">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="qMRMLMarkupsFiducialProjectionPropertyWidget" name="pointFiducialProjectionWidget"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="FillLabel">
-        <property name="text">
-         <string>Fill:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="glyphTypeLabel">
-        <property name="text">
-         <string>Glyph Type:</string>
+         <string>Variant Thickness:</string>
         </property>
        </widget>
       </item>
       <item row="6" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
         <item>
-         <widget class="QCheckBox" name="OutlineVisibilityCheckBox">
+         <widget class="QCheckBox" name="variantLineThicknessCheckBox">
           <property name="text">
            <string/>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="OpacityLabel2">
+         <widget class="QLabel" name="maxLineThicknessLabel">
           <property name="text">
-           <string>Opacity:</string>
+           <string>Max:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="ctkSliderWidget" name="OutlineOpacitySliderWidget">
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="DisplayNodeViewLabel">
-        <property name="text">
-         <string>View:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="unselectedColorLabel">
-        <property name="text">
-         <string>Unselected Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="OutlineLabel">
-        <property name="text">
-         <string>Outline:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="11" column="1">
-       <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
-        <property name="toolTip">
-         <string>Show control point labels</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QPushButton" name="curveLineSizeIsAbsoluteButton">
+         <widget class="qMRMLSliderWidget" name="curveLineMaxThicknessSliderWidget">
           <property name="toolTip">
-           <string>If button is pressed then line thickness is specified in physical length unit, otherwise as percentage of glyph size</string>
+           <string>Set the maximum line thickness in terms of a multiple of the minimum thickness</string>
           </property>
-          <property name="text">
-           <string>absolute</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ctkSliderWidget" name="curveLineThicknessSliderWidget">
-          <property name="singleStep">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>100.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>20.000000000000000</double>
-          </property>
-          <property name="suffix">
-           <string> %</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="qMRMLSliderWidget" name="curveLineDiameterSliderWidget">
           <property name="singleStep">
            <double>0.100000000000000</double>
           </property>
@@ -386,163 +579,14 @@
            <double>1.000000000000000</double>
           </property>
           <property name="value">
-           <double>5.000000000000000</double>
+           <double>10.000000000000000</double>
           </property>
           <property name="quantity">
-           <string>length</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="lineThicknessLabel">
-        <property name="text">
-         <string>Line Thickness:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="selectedColorLabel">
-        <property name="text">
-         <string>Selected Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QCheckBox" name="FillVisibilityCheckBox">
-          <property name="text">
            <string/>
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QLabel" name="OpacityLabel3">
-          <property name="text">
-           <string>Opacity:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ctkSliderWidget" name="FillOpacitySliderWidget">
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
        </layout>
-      </item>
-      <item row="11" column="0">
-       <widget class="QLabel" name="PointLabelsVisibilityLabel">
-        <property name="text">
-         <string>Control Point Labels:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="13" column="0" colspan="2">
-       <widget class="ctkCollapsibleGroupBox" name="ThreeDDisplayGroupBox">
-        <property name="title">
-         <string>3D Display</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>5</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item row="1" column="0">
-          <widget class="QLabel" name="OccludedVisibilityLabel">
-           <property name="text">
-            <string>Occluded Visibility:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
-           <item>
-            <widget class="QCheckBox" name="OccludedVisibilityCheckBox">
-             <property name="text">
-              <string/>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="OpacityLabel">
-             <property name="text">
-              <string>Opacity:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="ctkSliderWidget" name="OccludedOpacitySliderWidget">
-             <property name="singleStep">
-              <double>0.010000000000000</double>
-             </property>
-             <property name="pageStep">
-              <double>0.100000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1.000000000000000</double>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="PointLabelsVisibilityLabel_2">
-           <property name="text">
-            <string>Placement mode:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="SnapModeComboBox"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="PropertiesLabelVisibilityLabel">
-        <property name="text">
-         <string>Properties Label:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="ctkColorPickerButton" name="activeColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <widget class="QCheckBox" name="PropertiesLabelVisibilityCheckBox">
-        <property name="toolTip">
-         <string>Show node name and measurements</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>
@@ -646,6 +690,12 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>qMRMLMarkupsInteractionHandleWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLMarkupsInteractionHandleWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>ctkCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>ctkCollapsibleGroupBox.h</header>
@@ -660,12 +710,6 @@
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLMarkupsInteractionHandleWidget</class>
-   <extends>qMRMLWidget</extends>
-   <header>qMRMLMarkupsInteractionHandleWidget.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>622</width>
-    <height>919</height>
+    <height>953</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -131,7 +131,21 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="8" column="1">
+      <item row="0" column="1">
+       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
+        <property name="toolTip">
+         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
          <widget class="QCheckBox" name="FillVisibilityCheckBox">
@@ -162,24 +176,73 @@
         </item>
        </layout>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="selectedColorLabel">
+        <property name="text">
+         <string>Selected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QCheckBox" name="OutlineVisibilityCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="OpacityLabel2">
+          <property name="text">
+           <string>Opacity:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="OutlineOpacitySliderWidget">
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="unselectedColorLabel">
+        <property name="text">
+         <string>Unselected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="lineThicknessLabel">
+        <property name="text">
+         <string>Line Thickness:</string>
+        </property>
+       </widget>
+      </item>
       <item row="9" column="0">
-       <widget class="QLabel" name="PropertiesLabelVisibilityLabel">
+       <widget class="QLabel" name="FillLabel">
         <property name="text">
-         <string>Properties Label:</string>
+         <string>Fill:</string>
         </property>
        </widget>
       </item>
-      <item row="12" column="1">
-       <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
-        <property name="toolTip">
-         <string>Show control point labels</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="14" column="0" colspan="2">
+      <item row="15" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="ThreeDDisplayGroupBox">
         <property name="title">
          <string>3D Display</string>
@@ -245,93 +308,13 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="activeColorPickerLabel">
-        <property name="text">
-         <string>Active Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
+      <item row="13" column="1">
+       <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
         <property name="toolTip">
-         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
+         <string>Show control point labels</string>
         </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="ctkColorPickerButton" name="activeColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="selectedColorLabel">
         <property name="text">
-         <string>Selected Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QCheckBox" name="OutlineVisibilityCheckBox">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="OpacityLabel2">
-          <property name="text">
-           <string>Opacity:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ctkSliderWidget" name="OutlineOpacitySliderWidget">
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="FillLabel">
-        <property name="text">
-         <string>Fill:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QComboBox" name="glyphTypeComboBox"/>
-      </item>
-      <item row="12" column="0">
-       <widget class="QLabel" name="PointLabelsVisibilityLabel">
-        <property name="text">
-         <string>Control Point Labels:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="lineThicknessLabel">
-        <property name="text">
-         <string>Line Thickness:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="glyphTypeLabel">
-        <property name="text">
-         <string>Glyph Type:</string>
+         <string/>
         </property>
        </widget>
       </item>
@@ -387,7 +370,64 @@
         </item>
        </layout>
       </item>
-      <item row="15" column="0" colspan="2">
+      <item row="10" column="1">
+       <widget class="QCheckBox" name="PropertiesLabelVisibilityCheckBox">
+        <property name="toolTip">
+         <string>Show node name and measurements</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="glyphTypeLabel">
+        <property name="text">
+         <string>Glyph Type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="OutlineLabel">
+        <property name="text">
+         <string>Outline:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QComboBox" name="lineDiameterModeComboBox">
+        <item>
+         <property name="text">
+          <string>Constant</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>From Scalars</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Absolute From Scalars</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="activeColorPickerLabel">
+        <property name="text">
+         <string>Active Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0">
+       <widget class="QLabel" name="PointLabelsVisibilityLabel">
+        <property name="text">
+         <string>Control Point Labels:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="16" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="TwoDDisplayGroupBox">
         <property name="title">
          <string>2D Display</string>
@@ -411,34 +451,6 @@
         </layout>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="unselectedColorLabel">
-        <property name="text">
-         <string>Unselected Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="OutlineLabel">
-        <property name="text">
-         <string>Outline:</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="DisplayNodeViewLabel">
         <property name="text">
@@ -446,17 +458,7 @@
         </property>
        </widget>
       </item>
-      <item row="9" column="1">
-       <widget class="QCheckBox" name="PropertiesLabelVisibilityCheckBox">
-        <property name="toolTip">
-         <string>Show node name and measurements</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="13" column="0" colspan="2">
+      <item row="14" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="TextDisplayGroupBox">
         <property name="title">
          <string>Text Display</string>
@@ -544,49 +546,29 @@
         </layout>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="variantLineThicknessLabel">
-        <property name="text">
-         <string>Variant Thickness:</string>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="glyphTypeComboBox"/>
+      </item>
+      <item row="3" column="1">
+       <widget class="ctkColorPickerButton" name="activeColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QCheckBox" name="variantLineThicknessCheckBox">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="maxLineThicknessLabel">
-          <property name="text">
-           <string>Max:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="qMRMLSliderWidget" name="curveLineMaxThicknessSliderWidget">
-          <property name="toolTip">
-           <string>Set the maximum line thickness in terms of a multiple of the minimum thickness</string>
-          </property>
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="quantity">
-           <string/>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="10" column="0">
+       <widget class="QLabel" name="PropertiesLabelVisibilityLabel">
+        <property name="text">
+         <string>Properties Label:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="lineDiameterModeLabel">
+        <property name="text">
+         <string>Line Diameter Mode:</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -98,10 +98,9 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
     q, SLOT(onCurveLineThicknessSliderWidgetChanged(double)));
   QObject::connect(this->curveLineDiameterSliderWidget, SIGNAL(valueChanged(double)),
     q, SLOT(onCurveLineDiameterSliderWidgetChanged(double)));
-  QObject::connect(this->variantLineThicknessCheckBox, SIGNAL(toggled(bool)),
-    q, SLOT(setCurveLineVariantThickness(bool)));
-  QObject::connect(this->curveLineMaxThicknessSliderWidget, SIGNAL(valueChanged(double)),
-    q, SLOT(onCurveLineMaxThicknessSliderWidgetChanged(double)));
+  QObject::connect(this->lineDiameterModeComboBox, SIGNAL(currentIndexChanged(QString)),
+    q, SLOT(onLineDiameterModeComboBoxChanged(QString)));
+
   QObject::connect(this->PropertiesLabelVisibilityCheckBox, SIGNAL(toggled(bool)),
     q, SLOT(setPropertiesLabelVisibility(bool)));
   QObject::connect(this->PointLabelsVisibilityCheckBox, SIGNAL(toggled(bool)),
@@ -513,17 +512,6 @@ void qMRMLMarkupsDisplayNodeWidget::setCurveLineSizeIsAbsolute(bool absolute)
 }
 
 //------------------------------------------------------------------------------
-void qMRMLMarkupsDisplayNodeWidget::setCurveLineVariantThickness(bool val)
-{
-  Q_D(qMRMLMarkupsDisplayNodeWidget);
-  if (!d->MarkupsDisplayNode.GetPointer())
-    {
-    return;
-    }
-  d->MarkupsDisplayNode->SetVaryRadius(val);
-}
-
-//------------------------------------------------------------------------------
 bool qMRMLMarkupsDisplayNodeWidget::curveLineSizeIsAbsolute()const
 {
   Q_D(const qMRMLMarkupsDisplayNodeWidget);
@@ -623,14 +611,26 @@ void qMRMLMarkupsDisplayNodeWidget::onCurveLineDiameterSliderWidgetChanged(doubl
 }
 
 //-----------------------------------------------------------------------------
-void qMRMLMarkupsDisplayNodeWidget::onCurveLineMaxThicknessSliderWidgetChanged(double radiusFactor)
+void qMRMLMarkupsDisplayNodeWidget::onLineDiameterModeComboBoxChanged(QString text)
 {
   Q_D(qMRMLMarkupsDisplayNodeWidget);
-  if (!d->MarkupsDisplayNode.GetPointer())
+  if (!d->MarkupsDisplayNode)
     {
     return;
     }
-  d->MarkupsDisplayNode->SetRadiusFactor(radiusFactor);
+
+  if (text == "Constant")
+    {
+    d->MarkupsDisplayNode->SetLineDiameterMode(vtkMRMLMarkupsDisplayNode::Constant);
+    }
+  else if (text == "From Scalars")
+    {
+    d->MarkupsDisplayNode->SetLineDiameterMode(vtkMRMLMarkupsDisplayNode::FromScalars);
+    }
+  else if (text == "Absolute From Scalars")
+    {
+    d->MarkupsDisplayNode->SetLineDiameterMode(vtkMRMLMarkupsDisplayNode::AbsoluteFromScalars);
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -98,6 +98,10 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
     q, SLOT(onCurveLineThicknessSliderWidgetChanged(double)));
   QObject::connect(this->curveLineDiameterSliderWidget, SIGNAL(valueChanged(double)),
     q, SLOT(onCurveLineDiameterSliderWidgetChanged(double)));
+  QObject::connect(this->variantLineThicknessCheckBox, SIGNAL(toggled(bool)),
+    q, SLOT(setCurveLineVariantThickness(bool)));
+  QObject::connect(this->curveLineMaxThicknessSliderWidget, SIGNAL(valueChanged(double)),
+    q, SLOT(onCurveLineMaxThicknessSliderWidgetChanged(double)));
   QObject::connect(this->PropertiesLabelVisibilityCheckBox, SIGNAL(toggled(bool)),
     q, SLOT(setPropertiesLabelVisibility(bool)));
   QObject::connect(this->PointLabelsVisibilityCheckBox, SIGNAL(toggled(bool)),
@@ -509,6 +513,17 @@ void qMRMLMarkupsDisplayNodeWidget::setCurveLineSizeIsAbsolute(bool absolute)
 }
 
 //------------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::setCurveLineVariantThickness(bool val)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode.GetPointer())
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetVaryRadius(val);
+}
+
+//------------------------------------------------------------------------------
 bool qMRMLMarkupsDisplayNodeWidget::curveLineSizeIsAbsolute()const
 {
   Q_D(const qMRMLMarkupsDisplayNodeWidget);
@@ -605,6 +620,17 @@ void qMRMLMarkupsDisplayNodeWidget::onCurveLineDiameterSliderWidgetChanged(doubl
     return;
     }
   d->MarkupsDisplayNode->SetLineDiameter(value);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::onCurveLineMaxThicknessSliderWidgetChanged(double radiusFactor)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode.GetPointer())
+    {
+    return;
+    }
+  d->MarkupsDisplayNode->SetRadiusFactor(radiusFactor);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
@@ -78,8 +78,6 @@ public slots:
   void setGlyphSizeIsAbsolute(bool absolute);
   void setCurveLineSizeIsAbsolute(bool absolute);
 
-  void setCurveLineVariantThickness(bool val);
-
   void setPropertiesLabelVisibility(bool visible);
   void setPointLabelsVisibility(bool visible);
 
@@ -105,7 +103,7 @@ protected slots:
   void onGlyphSizeSliderWidgetChanged(double value);
   void onCurveLineThicknessSliderWidgetChanged(double percentValue);
   void onCurveLineDiameterSliderWidgetChanged(double value);
-  void onCurveLineMaxThicknessSliderWidgetChanged(double radiusFactor);
+  void onLineDiameterModeComboBoxChanged(QString text);
   void onTextScaleSliderWidgetChanged(double value);
   void onOpacitySliderWidgetChanged(double value);
   void onSnapModeWidgetChanged();

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
@@ -78,6 +78,8 @@ public slots:
   void setGlyphSizeIsAbsolute(bool absolute);
   void setCurveLineSizeIsAbsolute(bool absolute);
 
+  void setCurveLineVariantThickness(bool val);
+
   void setPropertiesLabelVisibility(bool visible);
   void setPointLabelsVisibility(bool visible);
 
@@ -103,6 +105,7 @@ protected slots:
   void onGlyphSizeSliderWidgetChanged(double value);
   void onCurveLineThicknessSliderWidgetChanged(double percentValue);
   void onCurveLineDiameterSliderWidgetChanged(double value);
+  void onCurveLineMaxThicknessSliderWidgetChanged(double radiusFactor);
   void onTextScaleSliderWidgetChanged(double value);
   void onOpacitySliderWidgetChanged(double value);
   void onSnapModeWidgetChanged();


### PR DESCRIPTION
Before that line thickness of markups curve could only be fixed.
Now it is possible to use scalars values as a variant radius.
In this case we control:
- minimal radius (by absolute or relative value);
- maximum radius in the sense of multiple minimum radius (`vtkTubeFilter::RadiusFactor`)
Two aspects were not solved yet:
- if scalars contain negative values then it would be nice to add some offset before so that all values become > 0;
- seems that slice views may incorrectly display variant radius markups. Need to be checked in the future
[The discussion](https://discourse.slicer.org/t/implement-variable-radius-curve/21334/4)