### PR TITLE
BUG: Fix truncation of Segmentations when saving at reference geometry

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationStorageNode.cxx
@@ -1181,7 +1181,8 @@ int vtkMRMLSegmentationStorageNode::WriteBinaryLabelmapRepresentation(vtkMRMLSeg
   if (segmentation->GetNumberOfSegments() > 0)
     {
     std::string commonGeometryString = segmentation->DetermineCommonLabelmapGeometry(
-      this->CropToMinimumExtent ? vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS : vtkSegmentation::EXTENT_REFERENCE_GEOMETRY);
+      this->CropToMinimumExtent ?
+        vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS : vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS_AND_REFERENCE_GEOMETRY);
     vtkSegmentationConverter::DeserializeImageGeometry(commonGeometryString, commonGeometryImage, true, scalarType, 1);
     commonGeometryImage->GetExtent(commonGeometryExtent);
     }

--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -122,7 +122,9 @@ public:
     /// Extent is computed as union of effective extent of all segments
     EXTENT_UNION_OF_EFFECTIVE_SEGMENTS,
     /// Extent is computed as union of effective extent of all segments, with a single-voxel padding added on each side
-    EXTENT_UNION_OF_EFFECTIVE_SEGMENTS_PADDED
+    EXTENT_UNION_OF_EFFECTIVE_SEGMENTS_PADDED,
+    /// Extent is computed as the reference geometry, expanded to contain the union of all segments
+    EXTENT_UNION_OF_EFFECTIVE_SEGMENTS_AND_REFERENCE_GEOMETRY
     };
 
   /// Container type for segments. Maps segment IDs to segment objects

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.cxx
@@ -953,7 +953,8 @@ bool qSlicerSegmentationsModuleWidget::exportFromCurrentSegmentation()
     // Export selected segments into a multi-label labelmap volume
     QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
     bool success = vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(currentSegmentationNode, segmentIDs, labelmapNode,
-      vtkMRMLVolumeNode::SafeDownCast(d->MRMLNodeComboBox_ExportLabelmapReferenceVolume->currentNode()), vtkSegmentation::EXTENT_REFERENCE_GEOMETRY,
+      vtkMRMLVolumeNode::SafeDownCast(d->MRMLNodeComboBox_ExportLabelmapReferenceVolume->currentNode()),
+        vtkSegmentation::EXTENT_UNION_OF_EFFECTIVE_SEGMENTS_AND_REFERENCE_GEOMETRY,
       colorTableNode);
     QApplication::restoreOverrideCursor();
     if (!success)


### PR DESCRIPTION
Previously, saving a Segmentation with "Crop to minimum extent" disabled, the segmentation would be cropped to exactly the reference geometry extent. This could result in the segment being truncated if the reference geometry was smaller than the effective extent of the segmentation.

Fixed by saving the segmentation using an extent that contains both the reference and effective extents.
The same behavior is fixed when exporting segments to labelmap nodes.

Fix #6102
See discussion: https://discourse.slicer.org/t/editing-segmentation-of-model-and-saving-it/21338