### PR TITLE
ENH: Exporting multiple nodes

### DIFF
--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -161,27 +161,22 @@ public:
   /// \sa qSlicerNodeWriter, qSlicerIO::IOProperties, qSlicerIO::IOFileType,
   /// loadNodes(), exportNodes()
   Q_INVOKABLE bool saveNodes(qSlicerIO::IOFileType fileType,
-                             const qSlicerIO::IOProperties& parameters,
-                              vtkMRMLMessageCollection* userMessages=nullptr,
-                              vtkMRMLScene* scene=nullptr);
+    const qSlicerIO::IOProperties& parameters,
+    vtkMRMLMessageCollection* userMessages=nullptr,
+    vtkMRMLScene* scene=nullptr
+  );
 
   /// Export nodes using the registered writers. Return true on success, false otherwise.
-  /// Unlike saveNodes(), this function creates a temporary scene while saving,
-  /// in order to to avoid modifying storage nodes in the current scene.
-  /// Saving parameters like fileFormat should be in \a parameters, just like for saveNodes(),
-  /// except that the nodes to be saved are specified in the list \a nodeIDs
-  /// and that the absolute file paths to save them to are specified in \a filePaths.
-  /// The boolean parameter 'hardenTransforms' may also be included in \a parameters to temporarily apply transform hardening before export.
-  /// Any error messages that would normally be found in a storage node will instead be added to \a userMessages.
-  /// \param nodeIDs A list of IDs of nodes to be exported
-  /// \param filePaths A list of absolute file paths corresponding to \a nodeIDs. These are the export destinations.
-  /// \param parameters A dictionary/map of parameters that will get passed to qSlicerCoreIOManager::saveNodes.
+  /// Unlike saveNodes(), this function creates a temporary scene while saving, in order to to avoid modifying storage nodes in the current scene.
+  /// The list \a parameterMaps should consist of maps that each specify a "nodeID" (ID of a node in the main scene),
+  /// a "fileName" (an absolute file path), a "fileFormat" (e.g. "NRRD (.nrrd)"), and any other options that the associated writer may end up using.
+  /// \param parameterMaps For each node to exported, a map of parameters that will get passed to qSlicerCoreIOManager::saveNodes.
+  /// \param hardenTransforms Whether to temporarily apply transform hardening before export.
   /// \param userMessages If a valid pointer is passed, then error messages may be returned in it.
   /// \sa qSlicerNodeWriter, qSlicerIO::IOProperties, qSlicerIO::IOFileType, vtkMRMLStorageNode, saveNodes().
   Q_INVOKABLE bool exportNodes(
-    const QList<QString>& nodeIDs,
-    const QList<QString>& filePaths,
-    const qSlicerIO::IOProperties& parameters,
+    const QList<qSlicerIO::IOProperties>& parameterMaps,
+    bool hardenTransforms,
     vtkMRMLMessageCollection* userMessages=nullptr
   );
 

--- a/Base/QTGUI/Resources/UI/qSlicerExportNodeDialog.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerExportNodeDialog.ui
@@ -42,16 +42,6 @@
    <property name="rightMargin">
     <number>10</number>
    </property>
-   <item row="6" column="1">
-    <widget class="QDialogButtonBox" name="ButtonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="FilenameLabel">
      <property name="text">
@@ -86,62 +76,21 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <spacer name="verticalSpacer1">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Minimum</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLabel" name="PlaceholderText">
+   <item row="2" column="0">
+    <widget class="QLabel" name="ExportFormatsLabel">
      <property name="text">
-      <string>This is a dummy label indicating the row of
-this QFormLayout at which additional widgets will be
-inserted from code.</string>
+      <string>Export Formats</string>
      </property>
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="Placeholder">
-     <property name="text">
-      <string>PLACEHOLDER</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <spacer name="verticalSpacer2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Minimum</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="0">
     <widget class="QLabel" name="GeneralOptionsLabel">
      <property name="text">
-      <string>General options</string>
+      <string>Options</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="3" column="1">
     <widget class="QWidget" name="GeneralOptionsWidget" native="true">
      <property name="focusPolicy">
       <enum>Qt::NoFocus</enum>
@@ -190,6 +139,16 @@ inserted from code.</string>
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QDialogButtonBox" name="ButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
     </widget>
    </item>
   </layout>

--- a/Base/QTGUI/Resources/UI/qSlicerExportNodeDialog.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerExportNodeDialog.ui
@@ -7,8 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>450</width>
-    <height>192</height>
+    <height>300</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>450</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="cursor">
    <cursorShape>ArrowCursor</cursorShape>
@@ -23,7 +29,7 @@
   <property name="sizeGripEnabled">
    <bool>false</bool>
   </property>
-  <layout class="QFormLayout" name="formLayout_2">
+  <layout class="QFormLayout" name="formLayout">
    <property name="verticalSpacing">
     <number>6</number>
    </property>
@@ -36,6 +42,16 @@
    <property name="rightMargin">
     <number>10</number>
    </property>
+   <item row="6" column="1">
+    <widget class="QDialogButtonBox" name="ButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="FilenameLabel">
      <property name="text">
@@ -50,68 +66,130 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="1" column="0">
     <widget class="QLabel" name="DirectoryLabel">
      <property name="text">
       <string>Directory</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="ctkPathLineEdit" name="DirectoryPathLineEdit" native="true"/>
+   <item row="1" column="1">
+    <widget class="ctkPathLineEdit" name="DirectoryPathLineEdit" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>10</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Destination directory</string>
+     </property>
+    </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="ExportFormatLabel">
+   <item row="2" column="1">
+    <spacer name="verticalSpacer1">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Minimum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="PlaceholderText">
      <property name="text">
-      <string>Export format</string>
+      <string>This is a dummy label indicating the row of
+this QFormLayout at which additional widgets will be
+inserted from code.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="Placeholder">
+     <property name="text">
+      <string>PLACEHOLDER</string>
      </property>
     </widget>
    </item>
    <item row="4" column="1">
-    <widget class="QComboBox" name="ExportFormatComboBox"/>
+    <spacer name="verticalSpacer2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Minimum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="5" column="0">
-    <widget class="QLabel" name="OptionsLabel">
+    <widget class="QLabel" name="GeneralOptionsLabel">
      <property name="text">
-      <string>Options</string>
+      <string>General options</string>
      </property>
     </widget>
    </item>
    <item row="5" column="1">
-    <widget class="QWidget" name="OptionsContainer" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
+    <widget class="QWidget" name="GeneralOptionsWidget" native="true">
      <property name="focusPolicy">
-      <enum>Qt::TabFocus</enum>
+      <enum>Qt::NoFocus</enum>
      </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <widget class="QCheckBox" name="HardenTransformCheckBox">
-       <property name="text">
-        <string>Apply transforms</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="10" column="1">
-    <widget class="QDialogButtonBox" name="ButtonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
-     </property>
+     <layout class="QVBoxLayout" name="GeneralOptionsLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="IncludeChildrenCheckBox">
+        <property name="toolTip">
+         <string>Uncheck this to include only the node you selected</string>
+        </property>
+        <property name="text">
+         <string>Include children</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="RecursiveChildrenCheckBox">
+        <property name="toolTip">
+         <string>Uncheck this to include only direct children of the selected node</string>
+        </property>
+        <property name="text">
+         <string>Recursively include children</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="HardenTransformCheckBox">
+        <property name="toolTip">
+         <string>Temporarily harden any transforms for export</string>
+        </property>
+        <property name="text">
+         <string>Apply transforms</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
@@ -124,9 +202,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>FilenameLineEdit</tabstop>
- </tabstops>
  <resources>
   <include location="../qSlicerBaseQTGUI.qrc"/>
  </resources>

--- a/Base/QTGUI/qSlicerExportNodeDialog.cxx
+++ b/Base/QTGUI/qSlicerExportNodeDialog.cxx
@@ -718,7 +718,7 @@ bool qSlicerExportNodeDialogPrivate::populateNodeTypeWidgetSets()
 
     this->ButtonBox->setFocus(Qt::ActiveWindowFocusReason);
 
-    this->setWindowTitle(QString("Export Multiple Nodes"));
+    this->setWindowTitle(QString("Export ") + QString::number(this->nodeList().size()) + QString(" Nodes"));
     }
   else if (this->nodeList().size()==1)
     {

--- a/Base/QTGUI/qSlicerExportNodeDialog.h
+++ b/Base/QTGUI/qSlicerExportNodeDialog.h
@@ -38,7 +38,7 @@ public:
   QString description()const override;
   qSlicerFileDialog::IOAction action()const override;
 
-  /*! Open the data dialog and save the nodes/scene */
+  /*! Open the export dialog */
   bool exec(const qSlicerIO::IOProperties& readerProperties =
                     qSlicerIO::IOProperties()) override;
 

--- a/Base/QTGUI/qSlicerExportNodeDialog_p.h
+++ b/Base/QTGUI/qSlicerExportNodeDialog_p.h
@@ -18,6 +18,7 @@
 #include <QHash>
 #include <QList>
 #include <QStackedWidget>
+#include <QVBoxLayout>
 
 // Slicer includes
 #include "qSlicerExportNodeDialog.h"
@@ -42,8 +43,8 @@ public:
   // storableNode is a prototype node used to determine node type and used to help initialize some parameters
   NodeTypeWidgetSet(QWidget* parent, vtkMRMLStorableNode* storableNode, vtkMRMLScene* scene);
 
-  // Set text on the QLabel member widgets to show the given node type display name in parentheses
-  // Passing an empty string results in no parenthetical
+  // Set text on the QLabel member widget to show the given node type display name
+  // Passing an empty string results sets appropriate label text that doesn't mention node type
   void setLabelText(QString nodeTypeDisplayName);
 
   // Return extension corresponding to format selected in dropdown, e.g. ".nrrd"
@@ -81,15 +82,21 @@ public:
   // WARNING: This pointer is not always reliable. User of this class is responsible for updating this pointer.
   vtkMRMLStorableNode* prototypeNode;
 
+  // Set different display style and margin for the frame that contains the widgets
+  enum class FrameStyle {NoFrame, Frame};
+  void setFrameStyle(FrameStyle);
+
   // Node type that the member widgets will be configured for.
   NodeType nodeType;
 
   // Member widgets
-  QComboBox* exportFormatComboBox = nullptr;
-  qSlicerFileWriterOptionsWidget* optionsWidget = nullptr;
-  QStackedWidget* optionsStackedWidget;
-  QLabel* exportFormatLabel = nullptr;
-  QLabel* optionsLabel = nullptr;
+  QLabel* label = nullptr; // The label in front of our frame in the form layout
+  QFrame* frame = nullptr; // The widget that will go into the form layout
+  QVBoxLayout* frameLayout = nullptr; // The layout that frame will have
+  QComboBox* exportFormatComboBox = nullptr; // Goes into frameLayout
+  QStackedWidget* optionsStackedWidget; // Goes into frameLayout
+  qSlicerFileWriterOptionsWidget* optionsWidget = nullptr; // The current options widget, if any, that should be on display by optionsStackedWidget
+
 
   // Mapping from formats to options widgets, to keep track of and reuse options widgets as they get created
   QHash<QString,qSlicerFileWriterOptionsWidget*> formatToOptionsWidget;
@@ -193,9 +200,8 @@ protected:
 
   // List of node types (in the sense of NodeTypeWidgetSet::NodeType) that correspond to node-type-specific widget sets
   // that are currently visible in the dialog. The i^th item in this list has widgets that are meant to go into
-  // row numbers (nodeTypeWidgetSetStartRow + 2*i) and (nodeTypeWidgetSetStartRow + 2*i + 1)
-  // of the QFormLayout associated to this dialog. This dialog class manages the insertion and removal of the rows,
-  // and while doing so it keeps the following list up to date.
+  // row number (nodeTypeWidgetSetStartRow + i) of the QFormLayout associated to this dialog. This dialog class manages
+  // the insertion and removal of the rows, and while doing so it keeps the following list up to date.
   QList<NodeTypeWidgetSet::NodeType> nodeTypesInDialog;
 
   // Used to prevent a signal feedback loop coming from the fact that

--- a/Base/QTGUI/qSlicerExportNodeDialog_p.h
+++ b/Base/QTGUI/qSlicerExportNodeDialog_p.h
@@ -17,13 +17,86 @@
 #include <QFileInfo>
 #include <QHash>
 #include <QList>
+#include <QStackedWidget>
 
 // Slicer includes
 #include "qSlicerExportNodeDialog.h"
 #include "ui_qSlicerExportNodeDialog.h"
 
-class vtkMRMLNode;
+class vtkMRMLStorableNode;
 class qSlicerFileWriterOptionsWidget;
+
+//-----------------------------------------------------------------------------
+// Helper class to represent widgets that need to be displayed separately for each node type
+// To add NodeTypeWidgetSets to the dialog: use NodeTypeWidgetSets::insertWidgetsAtRow
+// To remove them from the dialog: do manually using QFormLayout::takeRow, and call NodeTypeWidgetSets::notifyRemovedFromDialog
+class NodeTypeWidgetSet : public QObject
+{
+  Q_OBJECT
+public:
+  // Node types will be represnted by class name QStrings.
+  using NodeType = QString;
+
+  // Create a set of widgets that are node-type-specific. They will be parented to the given parent, which is expected
+  // to be the dialog that contains the QFormLayout the widgets are going to be inserted into.
+  // storableNode is a prototype node used to determine node type and used to help initialize some parameters
+  NodeTypeWidgetSet(QWidget* parent, vtkMRMLStorableNode* storableNode, vtkMRMLScene* scene);
+
+  // Set text on the QLabel member widgets to show the given node type display name in parentheses
+  // Passing an empty string results in no parenthetical
+  void setLabelText(QString nodeTypeDisplayName);
+
+  // Return extension corresponding to format selected in dropdown, e.g. ".nrrd"
+  QString extension() const;
+
+  // Return the actual text of the currently selected option in the format dropdown, e.g. "NRRD (.nrrd)"
+  QString formatText() const;
+
+  // Set given options widget to be the current one for this NodeTypeWidgetSet, i.e. the one displayed in the options stacked widget
+  // Passing nullptr is okay: that means there is no options widget, and it blanks out the stacked widget
+  void changeCurrentOptionsWidget(qSlicerFileWriterOptionsWidget*);
+
+  // Set the options stacked widget to a blank widget
+  void makeOptionsStackedWidgetBlank();
+
+  // Set visibility of all member widgets.
+  void setMemberWidgetVisibility(bool visible);
+
+  // Insert member widgets into the given form layout starting from the given row.
+  void insertWidgetsAtRow(int row, QFormLayout* formLayout);
+
+  // Tell the NodeTypeWidgetSet instance that its member widgets have been removed from the form layout they were in
+  void notifyRemovedFromDialog();
+
+  // Set the current options widget based on the format text in exportFormatComboBox.
+  // Finds the correct options widget in the map formatToOptionsWidget, creating one if there isn't one.
+  // prototypeNode must be valid to use this.
+  bool updateOptionsWidget();
+
+  // Get display name associated to the node type (e.g. if node type is "vtkMRMLScalarVolumeNode", display name is "Volume")
+  // prototypeNode must be valid to use this.
+  QString getTypeDisplayName() const;
+
+  // A node used to represent its node type; helps with initializing some export dialog parameters.
+  // WARNING: This pointer is not always reliable. User of this class is responsible for updating this pointer.
+  vtkMRMLStorableNode* prototypeNode;
+
+  // Node type that the member widgets will be configured for.
+  NodeType nodeType;
+
+  // Member widgets
+  QComboBox* exportFormatComboBox = nullptr;
+  qSlicerFileWriterOptionsWidget* optionsWidget = nullptr;
+  QStackedWidget* optionsStackedWidget;
+  QLabel* exportFormatLabel = nullptr;
+  QLabel* optionsLabel = nullptr;
+
+  // Mapping from formats to options widgets, to keep track of and reuse options widgets as they get created
+  QHash<QString,qSlicerFileWriterOptionsWidget*> formatToOptionsWidget;
+
+public slots:
+  void formatChangedSlot();
+};
 
 //-----------------------------------------------------------------------------
 class qSlicerExportNodeDialogPrivate
@@ -36,58 +109,98 @@ public:
   explicit qSlicerExportNodeDialogPrivate(QWidget* _parent=nullptr);
   ~qSlicerExportNodeDialogPrivate() override;
 
-  /* Set the node being exported and fill out the
-     dialog widgets with a reasonable initial state */
-  bool setup(vtkMRMLScene* scene, vtkMRMLNode* node);
-
-  /* Save the states of some widgets
-  so that they can be restored next time the dialog
-  is activated. Note that the options widget state
-  is not involved here-- instead of saving options widget state
-  we save the options widgets themselves in updateOptionsWidget.
-  This prevents things from breaking as people make changes to
-  options widgets. */
-  void saveWidgetStates();
+  /* Set the nodes being exported and fill out the
+  dialog widgets with a reasonable initial state.
+  Two lists of node pointers must be given, one based on
+  recursively including the storable node child items of the selected node in the
+  subject hierarchy tree, and one based on nonrecursively doing so.
+  selectedNode is the single storable node that was selected in the subject hierarchy to
+  trigger this export, if there is one; can be null if there isn't. */
+  bool setup(
+    vtkMRMLScene* scene,
+    const QList<vtkMRMLStorableNode*> & nodesNonrecursive,
+    const QList<vtkMRMLStorableNode*> & nodesRecursive,
+    vtkMRMLStorableNode* selectedNode = nullptr
+  );
 
 public slots:
-  bool exportNode();
   void accept() override; // overrides QDialog::accept()
 
 protected slots:
   void formatChangedSlot();
   void onFilenameEditingFinished();
+  void onNodeInclusionCheckboxStateChanged(int state);
 
 protected:
 
-  void formatChanged(bool updateFilename);
-  void updateOptionsWidget();
-  QFileInfo file() const;
+  // Exports nodes based on parameters set in dialog. To be called when the dialog is accepted.
+  bool exportNodes();
 
-  void setOptionsWidget(qSlicerFileWriterOptionsWidget*);
-  qSlicerFileWriterOptionsWidget* getOptionsWidget() const;
+  // Save the states of some widgets so that they can be restored next time the dialog is activated.
+  void saveWidgetStates();
 
-  // return the actual text of the currently selected option
-  // in the format dropdown. e.g. "NRRD (.nrrd)"
-  QString formatText() const;
+  // Clear any node-type-specific widgets out of the form layout and then repopulate the form layout
+  // with widgets that are selected based on the current state of this->nodeList()
+  bool populateNodeTypeWidgetSets();
 
-  // return extension corresponding to format selected in dropdown
-  // e.g. ".nrrd"
-  QString extension() const;
+  // Update the tabbing order to a top-to-bottom order, which can get messed up as we insert and remove widgets
+  void adjustTabbingOrder();
 
-  // return the recommended filename based on current filename and the
+  // Return the recommended filename based on current filename and the
   // format selected in the dropdown
-  QString recommendedFilename() const;
+  QString recommendedFilename(vtkMRMLStorableNode*) const;
 
+  // Return the list of nodes to be exported, based on the status of RecursiveChildrenCheckBox
+  const QList<vtkMRMLStorableNode*>& nodeList() const;
+
+  // Get an entry from the hash map nodeTypeToNodeTypeWidgetSet, but make sure the key
+  // is in the table, returning nullptr if not. Enabling logError prints a message into Qt message handling.
+  NodeTypeWidgetSet* getNodeTypeWidgetSetSafe(NodeTypeWidgetSet::NodeType nodeType, bool logError=false) const;
+
+  // Validate that there is exactly one node to export, and get that node
+  // error if validation fails, returning null result; use this only when it is guaranteed to succeed
+  vtkMRMLStorableNode* theOnlyNode() const;
+
+  // Validate that there is exactly one NodeTypeWidgetSet, get it
+  // error if validation fails, returning null result; use this only when it is guaranteed to succeed
+  NodeTypeWidgetSet* theOnlyNodeTypeWidgetSet() const;
+
+  // Validate that there is exactly one NodeTypeWidgetSet, and get its export format dropdown widget
+  // error if validation fails, returning null result; use this only when it is guaranteed to succeed
+  QComboBox* theOnlyExportFormatComboBox() const;
 
   vtkMRMLScene* MRMLScene;
-  vtkMRMLNode* MRMLNode;
+
+  // The list of nodes to export in each of the two cases: recursively including children of the selected item or not
+  QList<vtkMRMLStorableNode*> nodesRecursive;
+  QList<vtkMRMLStorableNode*> nodesNonrecursive;
+
+  // The storable node that was selected in the subject hierarchy to trigger this export, if there is one;
+  // can be empty if there isn't. It is conveniently a list so that a uniform interface can be provided by nodeList().
+  QList<vtkMRMLStorableNode*> nodesSelectedOnly;
 
   QString lastUsedDirectory;
   QList<QString> lastUsedFormats;
   bool lastUsedHardenTransform;
+  bool lastUsedRecursiveChildren;
+  bool lastUsedIncludeChildren;
 
-  // mapping from formats to options widgets, to save them as they get created
-  QHash<QString,qSlicerFileWriterOptionsWidget*> formatToOptionsWidget;
+  // Mapping from node type to widget sets that are specific to a node type
+  QHash<NodeTypeWidgetSet::NodeType,NodeTypeWidgetSet*> nodeTypeToNodeTypeWidgetSet;
+
+  // The row of the QFormLayout that contains the placeholder label. This is the row where NodeTypeWidgetSets will be inserted.
+  int nodeTypeWidgetSetStartRow = -1;
+
+  // List of node types (in the sense of NodeTypeWidgetSet::NodeType) that correspond to node-type-specific widget sets
+  // that are currently visible in the dialog. The i^th item in this list has widgets that are meant to go into
+  // row numbers (nodeTypeWidgetSetStartRow + 2*i) and (nodeTypeWidgetSetStartRow + 2*i + 1)
+  // of the QFormLayout associated to this dialog. This dialog class manages the insertion and removal of the rows,
+  // and while doing so it keeps the following list up to date.
+  QList<NodeTypeWidgetSet::NodeType> nodeTypesInDialog;
+
+  // Used to prevent a signal feedback loop coming from the fact that
+  // modifying file name can change export format and vice versa.
+  bool protectFilenameLineEdit;
 };
 
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExportPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyExportPlugin.h
@@ -43,16 +43,15 @@ public:
 
 
 public:
-  /// Get item context menu item actions to add to tree view
-  QList<QAction*> itemContextMenuActions()const override;
+  /// Get context menu actions to add to tree view
+  QList<QAction*> itemContextMenuActions() const override;
 
-  /// Show context menu actions valid for  given subject hierarchy node.
-  /// \param node Subject Hierarchy node to show the context menu items for. If nullptr, then shows menu items for the scene
+  /// Show context menu actions valid for given subject hierarchy item
   void showContextMenuActionsForItem(vtkIdType itemID) override;
 
 protected slots:
-  /// Export currently selected subject hierarchy item
-  void exportCurrentItem();
+  /// Export currently selected subject hierarchy item and/or its children
+  void exportItems();
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyExportPluginPrivate> d_ptr;


### PR DESCRIPTION
# Description

This PR addresses #6074 and extends the export functionality from #5876 by allowing multiple nodes to be exported in one batch. If you right click a a subject hierarchy item that has children, then "Export to file..." will allow you export the storable nodes that occur in the subtree rooted at your selection. You can choose to include children recursively, or to just include direct children. Multi-select is not supported here; only selecting a single subject hierarchy item with children can lead to the multiple-node-export functionality.

![image](https://user-images.githubusercontent.com/1879759/148829433-49207228-0e7e-4087-8168-1c379eb03201.png)


Each node _type_ occurring within the set of nodes slated for export will have its own options widget and its own export format dropdown box. 

![image](https://user-images.githubusercontent.com/1879759/148829753-0dfa7c40-4d3e-4215-9c3e-d97bad692ad7.png)

The example in these screenshots does not show the "include children" or "recursively include children" checkboxes, because in this particular example:
- not including children would result in no nodes to export, so it is not an option
- the subtree rooted at the selected node has depth 1, so it doesn't make a difference whether you recursively include children or not-- hence the option is not displayed

So these options are only displayed when they matter. For example:

![image](https://user-images.githubusercontent.com/1879759/148830828-d173c975-d2a9-42c9-b580-40f4e3bd0e94.png)

Notice that the filename entry textbox is disabled when multiple nodes are being exported. In that case, filenames are automatically set based on node name. The textbox is enabled when exporting a single node.

# Summary of changes
- The subject hierarchy export plugin has been modified to pass along lists of node IDs, rather than just a single node ID.
- The export dialog has been heavily reworked to handle lists of nodes. There is a checkbox for including children and a checkbox for doing so recursively. When nodes of multiple types are included, some widgets get created per node type.
- The export function in `qSlicerCoreIOManager` has been modified to accept a list of parameter sets, rather than just one parameter set. This allows us to pass to it multiple formats for different node types.
- A serious export-related bug (that I introduced) has been fixed where node IDs were sometimes being looked up in the main scene rather than in the temporary scene used for export.
- A mild export-related bug has been fixed where plane markups would get written by `vtkMRMLMarkupsJsonStorageNode` rather than `vtkMRMLMarkupsPlaneJsonStorageNode`, and similarly for ROIs. This caused them to be written incorrectly.

# Problems found

1. I found one case where exporting a transform fails silently, because success is returned by the storage node even when nothing is written. To see this happen, create a `vtkMRMLTransformNode` (not a subtype of it) and immediately try to export it, without modifying its parameters. Success is returned [because of these lines](https://github.com/Slicer/Slicer/blob/master/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx#L489-L493), whose intention I'm not understanding.

_This problem does not prevent this contribution from being merged._ It is non-critical and I think its a separate issue.

2. "Node type" currently means "class name". One possibly annoying consequence of this is that different types of markups (line, closed curve, etc.) are considered to be different node types, and therefore get their own export format dropdown and options widget, while in most cases the user would want the same settings for all of them. So when you go to export a folder that contains all your markups, you have to set your desired options separately for each markup subtype. Perhaps the same issue applies to different types of transforms. 

_This problem may need to be resolved_, depending on feedback as to how much of a problem it is. I'm looking for suggestions here. It would not be hard to redefine "node type" in my code, but I'm not sure what definition would make the most sense. It would be nice if there were a solution to this that doesn't treat markups as a special case.