### PR TITLE
Fix missing return statement in Volume Rendering logic.

### DIFF
--- a/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
+++ b/Modules/Loadable/VolumeRendering/Logic/vtkSlicerVolumeRenderingLogic.cxx
@@ -1151,6 +1151,8 @@ vtkMRMLDisplayableNode* vtkSlicerVolumeRenderingLogic::CreateROINode(vtkMRMLVolu
     }
   displayNode->SetAndObserveROINodeID(roiNode->GetID());
   this->FitROIToVolume(displayNode);
+
+  return displayNode->GetROINode();
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
@pieper ,

Please consider this tiny patch.

It fixes Slicer crashing when showing a Volume Rendering markups ROI, in self built Slicer on Arch Linux. Report referenced [here](https://discourse.slicer.org/t/volume-rendering-displaying-roi-leads-to-a-crash-on-self-built-slicer/21389?u=chir.set).

Thank you.
