### PR TITLE
BUG: tbb installation in `Debug` mode

### DIFF
--- a/CMake/SlicerBlockInstallTBB.cmake
+++ b/CMake/SlicerBlockInstallTBB.cmake
@@ -17,6 +17,14 @@ if(WIN32)
       ${TBB_BIN_DIR}/tbb.dll
       ${TBB_BIN_DIR}/tbbmalloc.dll
       ${TBB_BIN_DIR}/tbbmalloc_proxy.dll
+    CONFIGURATIONS Release
+    DESTINATION bin COMPONENT Runtime)
+  install(
+    FILES
+      ${TBB_BIN_DIR}/tbb_debug.dll
+      ${TBB_BIN_DIR}/tbbmalloc_debug.dll
+      ${TBB_BIN_DIR}/tbbmalloc_proxy_debug.dll
+    CONFIGURATIONS Debug
     DESTINATION bin COMPONENT Runtime)
 elseif(APPLE)
   install(
@@ -24,6 +32,14 @@ elseif(APPLE)
       ${TBB_LIB_DIR}/libtbb.dylib
       ${TBB_LIB_DIR}/libtbbmalloc.dylib
       ${TBB_LIB_DIR}/libtbbmalloc_proxy.dylib
+    CONFIGURATIONS Release
+    DESTINATION ${TBB_INSTALL_LIB_DIR} COMPONENT Runtime)
+  install(
+    FILES
+      ${TBB_LIB_DIR}/libtbb_debug.dylib
+      ${TBB_LIB_DIR}/libtbbmalloc_debug.dylib
+      ${TBB_LIB_DIR}/libtbbmalloc_proxy_debug.dylib
+    CONFIGURATIONS Debug
     DESTINATION ${TBB_INSTALL_LIB_DIR} COMPONENT Runtime)
 elseif(UNIX)
   install(
@@ -31,11 +47,28 @@ elseif(UNIX)
       ${TBB_LIB_DIR}/libtbb.so.2
       ${TBB_LIB_DIR}/libtbbmalloc.so.2
       ${TBB_LIB_DIR}/libtbbmalloc_proxy.so.2
+    CONFIGURATIONS Release
     DESTINATION ${TBB_INSTALL_LIB_DIR} COMPONENT Runtime)
-  slicerStripInstalledLibrary(
+  install(
     FILES
-      "${TBB_INSTALL_LIB_DIR}/libtbb.so.2"
-      "${TBB_INSTALL_LIB_DIR}/libtbbmalloc.so.2"
-      "${TBB_INSTALL_LIB_DIR}/libtbbmalloc_proxy.so.2"
-    COMPONENT Runtime)
+      ${TBB_LIB_DIR}/libtbb_debug.so.2
+      ${TBB_LIB_DIR}/libtbbmalloc_debug.so.2
+      ${TBB_LIB_DIR}/libtbbmalloc_proxy_debug.so.2
+    CONFIGURATIONS Debug
+    DESTINATION ${TBB_INSTALL_LIB_DIR} COMPONENT Runtime)
+  if (CMAKE_BUILD_TYPE EQUAL "Debug")
+    slicerStripInstalledLibrary(
+      FILES
+        "${TBB_INSTALL_LIB_DIR}/libtbb_debug.so.2"
+        "${TBB_INSTALL_LIB_DIR}/libtbbmalloc_debug.so.2"
+        "${TBB_INSTALL_LIB_DIR}/libtbbmalloc_proxy_debug.so.2"
+      COMPONENT Runtime)
+  else ()
+    slicerStripInstalledLibrary(
+      FILES
+        "${TBB_INSTALL_LIB_DIR}/libtbb.so.2"
+        "${TBB_INSTALL_LIB_DIR}/libtbbmalloc.so.2"
+        "${TBB_INSTALL_LIB_DIR}/libtbbmalloc_proxy.so.2"
+      COMPONENT Runtime)
+  endif()
 endif()


### PR DESCRIPTION
`tbb` lib has naming convention for `Debug/Release` modes.
Slicer used to handle only `Release` tbb libs.
Thus if you try to install Slicer built in `Debug` then it will be impossible to run it.
Or you have to manually copy `Debug` libs to the installation folder.
This commit fixes that so two modes are supported: `Debug` and `Release`