### PR TITLE
BUG: Fix labels shift for color legend in vertical orientation

### DIFF
--- a/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.cxx
+++ b/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.cxx
@@ -36,7 +36,7 @@
 #include <vtksys/RegularExpression.hxx>
 #include <vtkTextActor.h>
 
-#include <stdio.h> // for snprintf
+#include <cstdio> // for snprintf
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #  define SNPRINTF _snprintf
@@ -96,7 +96,7 @@ void vtkSlicerScalarBarActor::LayoutTicks()
     this->P->TextActors[i].TakeReference(vtkTextActor::New());
 
     double val = 0.0;
-    char labelString[512];
+    char labelString[512] = {};
     // default in case of error with the annotations
     SNPRINTF(labelString, 511, "(none)");
 
@@ -232,8 +232,18 @@ void vtkSlicerScalarBarActor::LayoutTicks()
       // Tick height could be adjusted if title text is
       // lowered by box constraints, but we won't bother:
       this->P->TickBox.Size[1] = this->P->Frame.Size[1] -
-        this->P->TitleBox.Size[1] - 3 * this->TextPad -
-        this->VerticalTitleSeparation;
+        this->P->TitleBox.Size[1] - this->VerticalTitleSeparation;
+
+      // Tick box height for labels that precede scalar bar in vertical orientation
+      if (this->TextPosition == vtkScalarBarActor::PrecedeScalarBar && this->TextPad < 0)
+        {
+        this->P->TickBox.Size[1] += 3 * this->TextPad;
+        }
+      else // all other states
+        {
+        this->P->TickBox.Size[1] -= 3 * this->TextPad;
+        }
+
       // Tick box height also reduced by NaN swatch size, if present:
       if (this->DrawNanAnnotation)
         {


### PR DESCRIPTION
Possible fix for the #6111 BUG issue.

Apologies for reopening the PR, previous branch was deleted.

I think the vertical shift is fixed now.

ParaView and DataProbe scalar bar is more complex and will require more time to adopt.

I will add description of a new color legend features on the forum later. 
