### PR TITLE
ENH: add python libs and headers for source package install

### DIFF
--- a/CMake/SlicerBlockInstallPython.cmake
+++ b/CMake/SlicerBlockInstallPython.cmake
@@ -139,11 +139,19 @@ To create a Slicer package including python libraries, you can *NOT* provide you
 
   # Install headers
   set(python_include_subdir /Include/)
+
   if(UNIX)
-    set(python_include_subdir /include/python3.6m/)
+    set(python_include_subdir /include/python${Slicer_PYTHON_VERSION_DOT}${Slicer_PYTHON_ABIFLAGS}/)
+  elseif(WIN32)
+    # installing dev libs to enable package compiling via pip source install
+    install(DIRECTORY "${PYTHON_DIR}/libs/"
+    DESTINATION ${Slicer_INSTALL_ROOT}lib/Python/libs
+    COMPONENT Runtime
+    )
   endif()
 
-  install(FILES "${PYTHON_DIR}${python_include_subdir}/pyconfig.h"
+  # installing all includes to enable package compiling via pip source install
+  install(DIRECTORY "${PYTHON_DIR}${python_include_subdir}/"
     DESTINATION ${Slicer_INSTALL_ROOT}lib/Python${python_include_subdir}
     COMPONENT Runtime
     )


### PR DESCRIPTION
I've had an issue when installing a package from source via pip. For example:

```python
.\PythonSlicer.exe -m pip install "git+https://github.com/seung-lab/euclidean-distance-transform-3d@2.1.2#egg=edt&subdirectory=python"
```

Used to fail due to missing files such as Python.h and python39.lib. After the change proposed, the command above works.
This should also help when pre built wheels of a package are not available for a particular version of python.
I am not sure if all files are needed but everything adds 1.56MB to the final installation folder on Windows.

If someone would be so kind to help me with this issue for linux and macOS it would be great.
I don't know which files are created and needed for those platforms.
Thanks in advance