### PR TITLE
Fix clear selection in subject hierarchy combo box

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -94,6 +94,7 @@ void qMRMLSubjectHierarchyComboBoxPrivate::init()
   this->TreeView->setColumnHidden(this->TreeView->model()->idColumn(), true);
   this->TreeView->setHeaderHidden(true);
   this->TreeView->setContextMenuEnabled(false);
+  this->TreeView->setEditTriggers(QAbstractItemView::NoEditTriggers);
   this->TreeView->setDragDropMode(QAbstractItemView::NoDragDrop);
 
   // No item label

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -178,6 +178,9 @@ void qMRMLSubjectHierarchyComboBox::clearSelection()
 {
   Q_D(const qMRMLSubjectHierarchyComboBox);
   d->TreeView->clearSelection();
+
+  // Clear title and icon
+  this->updateComboBoxTitleAndIcon(vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID);
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -192,6 +192,9 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
   q->QTreeView::setModel(this->SortFilterModel);
   QObject::connect( q->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
                     q, SLOT(onSelectionChanged(QItemSelection,QItemSelection)) );
+  // selectionChanged signal is not triggered when the same item is selected. This connection handles the case when the same item is re-selected.
+  QObject::connect( q, SIGNAL(pressed(const QModelIndex&)), q, SLOT(onCurrentSelection(const QModelIndex&)) );
+
   this->SortFilterModel->setParent(q);
   this->SortFilterModel->setSourceModel(this->Model);
 
@@ -1502,6 +1505,23 @@ void qMRMLSubjectHierarchyTreeView::onSelectionChanged(const QItemSelection& sel
   // Emit current item changed signal
   emit currentItemChanged(selectedShItems[0]);
   emit currentItemsChanged(selectedShItems);
+}
+
+//------------------------------------------------------------------------------
+void qMRMLSubjectHierarchyTreeView::onCurrentSelection(const QModelIndex &currentItemIndex)
+{
+  Q_D(qMRMLSubjectHierarchyTreeView);
+  if (!d->SortFilterModel)
+    {
+    return;
+    }
+
+  vtkIdType itemID = d->SortFilterModel->subjectHierarchyItemFromIndex(currentItemIndex);
+  // Emit current item signal only if the current item is pressed to avoid duplicated signals when the item is changed
+  if (itemID == d->SelectedItems[0])
+    {
+    emit currentItemChanged(d->SelectedItems[0]);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -300,6 +300,7 @@ signals:
 
 protected slots:
   virtual void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
+  virtual void onCurrentSelection(const QModelIndex &currentItemIndex);
 
   /// Updates subject hierarchy item expanded property when item is expanded
   virtual void onItemExpanded(const QModelIndex &expandedItemIndex);


### PR DESCRIPTION
**Steps to reproduce**
- Create a subject hierarchy combo box
- Select a node
- Remove this node
- Node is still selected in the hierarchy combo box
- Call clearSelection()

**Expected results**
subject hierarchy combo box is cleared and set to None

**Actual results**
no effect, node is still selected in the hierarchy combo box 