### PR TITLE
Enable i18n

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1941,25 +1941,43 @@ void qSlicerCoreApplication::loadTranslations(const QString& dir)
 }
 
 //----------------------------------------------------------------------------
+QStringList qSlicerCoreApplication::translationFolders()
+{
+#ifdef Slicer_BUILD_I18N_SUPPORT
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
+  if (!app)
+    {
+    return QStringList();
+    }
+
+  QStringList qmDirs;
+  qmDirs << qSlicerCoreApplication::application()->toSlicerHomeAbsolutePath(QString(Slicer_QM_DIR));
+
+  // we check if the application is installed or not.
+  if (!app->isInstalled())
+    {
+    qmDirs << QString(Slicer_QM_OUTPUT_DIRS).split(";");
+    }
+
+  return qmDirs;
+#else
+  return QStringList();
+#endif
+}
+
+//----------------------------------------------------------------------------
 void qSlicerCoreApplication::loadLanguage()
 {
 #ifdef Slicer_BUILD_I18N_SUPPORT
-  qSlicerCoreApplication * app = qSlicerCoreApplication::application();
-  Q_ASSERT(app);
-
-  // we check if the application is installed or not.
-  if (app->isInstalled())
+  qSlicerCoreApplication* app = qSlicerCoreApplication::application();
+  if (!app)
     {
-    QString qmDir = QString(Slicer_QM_DIR);
-    app->loadTranslations(qmDir);
+    return;
     }
-  else
+  QStringList qmDirs = qSlicerCoreApplication::translationFolders();
+  foreach(QString qmDir, qmDirs)
     {
-    QStringList qmDirs = QString(Slicer_QM_OUTPUT_DIRS).split(";");
-    foreach(QString qmDir, qmDirs)
-      {
-      app->loadTranslations(qmDir);
-      }
+    app->loadTranslations(qmDir);
     }
 #endif
 }

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -500,15 +500,22 @@ public:
   QSharedPointer<ctkDICOMDatabase> dicomDatabaseShared() const;
 #endif
 
-  static void loadTranslations(const QString& dir);
+  /// Return list of folders where the application looks for translations (*.qm files)
+  Q_INVOKABLE static QStringList translationFolders();
 
-  static void loadLanguage();
+  /// Load translations from all *.qm files in the specified folders.
+  /// \sa loadLanguage()
+  Q_INVOKABLE static void loadTranslations(const QString& dir);
+
+  /// Load translations from all *.qm files in translation folders.
+  /// \sa translationFolders(), loadTranslations
+  Q_INVOKABLE static void loadLanguage();
 
   /// Load certificates bundled into '<slicerHome>/<SLICER_SHARE_DIR>/Slicer.crt'.
   /// For more details, see Slicer/Base/QTCore/Resources/Certs/README
   /// Returns \a False if 'Slicer.crt' failed to be loaded.
   /// \sa QSslSocket::defaultCaCertificates()
-  static bool loadCaCertificates(const QString& slicerHome);
+  Q_INVOKABLE static bool loadCaCertificates(const QString& slicerHome);
 
   Q_INVOKABLE int registerResource(const QByteArray& data);
 

--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -126,6 +126,17 @@ public:
   /// Parse arguments
   void parseArguments();
 
+  /// \brief Returns list of translation files contained in given \a dir for the input \a settingsLanguage
+  ///
+  /// If \a settingsLanguage is empty returns an empty list (application default language)
+  /// If \a settingsLanguage is not empty try to find the translation files from specific extension to generic extension
+  /// For example when \a settingsLanguage = "en_US", translation files ending with "en_US.qm" will be searched first
+  /// if no files are found then files ending with "en.qm" will be searched.
+  static QStringList findTranslationFiles(const QString& dir, const QString& settingsLanguage);
+
+  /// \brief Returns list of translation files contained in given \a dir for the input \a languageExtension
+  static QStringList findTranslationFilesWithLanguageExtension(const QString& dir, const QString& languageExtension);
+
 public:
   /// MRMLScene and AppLogic pointers
   vtkSmartPointer<vtkMRMLScene>               MRMLScene;

--- a/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
@@ -76,18 +76,17 @@ void qSlicerSettingsGeneralPanelPrivate::init()
 
 #ifdef Slicer_BUILD_I18N_SUPPORT
   bool internationalizationEnabled =
-      qSlicerApplication::application()->userSettings()->value("Internationalization/Enabled").toBool();
+      qSlicerApplication::application()->userSettings()->value("Internationalization/Enabled", true).toBool();
 
   this->LanguageLabel->setVisible(internationalizationEnabled);
   this->LanguageComboBox->setVisible(internationalizationEnabled);
 
   if (internationalizationEnabled)
     {
-    /// Default values
+    // Disable showing country flags because not all regions have a flag (e.g., Latin America)
+    this->LanguageComboBox->setCountryFlagsVisible(false);
     this->LanguageComboBox->setDefaultLanguage("en");
-    /// set the directory where all the translations files are.
-    this->LanguageComboBox->setDirectory(
-        QString(Slicer_QM_OUTPUT_DIRS).split(";").at(0));
+    this->LanguageComboBox->setDirectories(qSlicerCoreApplication::translationFolders());
     }
 #else
   this->LanguageLabel->setVisible(false);

--- a/CMake/SlicerDirectories.cmake
+++ b/CMake/SlicerDirectories.cmake
@@ -61,7 +61,7 @@ set(Slicer_INCLUDE_DIR "include/${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer
 set(Slicer_SHARE_DIR "share/${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}")
 set(Slicer_LIBEXEC_DIR "libexec/${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}")
 set(Slicer_ITKFACTORIES_DIR "${Slicer_LIB_DIR}/ITKFactories")
-set(Slicer_QM_DIR "${Slicer_BIN_DIR}/Translations")
+set(Slicer_QM_DIR "${Slicer_BIN_DIR}/translations")
 
 # for install tree
 set(Slicer_INSTALL_ROOT "./")

--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -178,7 +178,6 @@ macro(slicerMacroBuildAppLibrary)
     set(TS_DIR
       "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/"
     )
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(

--- a/CMake/SlicerMacroBuildBaseQtLibrary.cmake
+++ b/CMake/SlicerMacroBuildBaseQtLibrary.cmake
@@ -177,7 +177,6 @@ macro(SlicerMacroBuildBaseQtLibrary)
     set(TS_DIR
       "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/"
     )
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(

--- a/CMake/SlicerMacroBuildLoadableModule.cmake
+++ b/CMake/SlicerMacroBuildLoadableModule.cmake
@@ -168,7 +168,6 @@ macro(slicerMacroBuildLoadableModule)
   # --------------------------------------------------------------------------
   if(Slicer_BUILD_I18N_SUPPORT)
     set(TS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/")
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(

--- a/CMake/SlicerMacroBuildModuleWidgets.cmake
+++ b/CMake/SlicerMacroBuildModuleWidgets.cmake
@@ -84,7 +84,6 @@ macro(SlicerMacroBuildModuleWidgets)
   #-----------------------------------------------------------------------------
   if(Slicer_BUILD_I18N_SUPPORT)
     set(TS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/")
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(

--- a/CMake/SlicerMacroTranslation.cmake
+++ b/CMake/SlicerMacroTranslation.cmake
@@ -85,7 +85,19 @@ function(SlicerMacroTranslation)
     if(Slicer_UPDATE_TRANSLATION)
       QT5_CREATE_TRANSLATION(QM_OUTPUT_FILES ${FILES_TO_TRANSLATE} ${TS_FILES})
     else()
-      QT5_ADD_TRANSLATION(QM_OUTPUT_FILES ${TS_FILES})
+      # Find existing TS files and only add translation if at least one translation file exist to avoid error
+      # (Case may exist if Slicer_UPDATE_TRANSLATION is disabled and translation files were never
+      # generated for the input language)
+      set(EXISTING_TS_FILES)
+      foreach(TS_FILE ${TS_FILES})
+        if(EXISTS ${TS_FILE})
+          list(APPEND EXISTING_TS_FILES ${TS_FILE})
+        endif()
+      endforeach()
+
+      if(EXISTING_TS_FILES)
+        QT5_ADD_TRANSLATION(QM_OUTPUT_FILES ${EXISTING_TS_FILES})
+      endif()
     endif()
 
   # ---------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,8 +436,10 @@ include(SlicerFunctionAddPythonQtResources)
 if(Slicer_BUILD_I18N_SUPPORT)
   set(Slicer_LANGUAGES
     "fr"
+    CACHE STRING "Semicolon separated list of supported Slicer languages. Expected format : language[_country] (both en and en_US are supported)."
     )
-  set_property(GLOBAL PROPERTY Slicer_LANGUAGES ${Slicer_LANGUAGES})
+  mark_as_advanced(Slicer_LANGUAGES)
+  mark_as_superbuild(Slicer_LANGUAGES)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ mark_as_superbuild(Slicer_BUILD_DICOM_SUPPORT)
 option(Slicer_BUILD_DIFFUSION_SUPPORT "Build Slicer with diffusion (DWI, DTI) support" ON)
 mark_as_superbuild(Slicer_BUILD_DIFFUSION_SUPPORT)
 
-option(Slicer_BUILD_I18N_SUPPORT "Build Slicer with Internationalization support" OFF)
+option(Slicer_BUILD_I18N_SUPPORT "Build Slicer with Internationalization support" ON)
 mark_as_superbuild(Slicer_BUILD_I18N_SUPPORT)
 
 option(Slicer_BUILD_WEBENGINE_SUPPORT "Build Slicer with Qt WebEngine support" ON)

--- a/Libs/MRML/Widgets/CMakeLists.txt
+++ b/Libs/MRML/Widgets/CMakeLists.txt
@@ -439,7 +439,6 @@ endif()
     set(TS_DIR
       "${CMAKE_CURRENT_SOURCE_DIR}/Resources/Translations/"
     )
-    get_property(Slicer_LANGUAGES GLOBAL PROPERTY Slicer_LANGUAGES)
 
     include(SlicerMacroTranslation)
     SlicerMacroTranslation(

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -75,7 +75,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "4839f18fb7cf1486b0f16e88f031137ce15ff550"
+    "4bdd45e3f1038907aab31b40e536b2f51120f80d"
     QUIET
     )
 


### PR DESCRIPTION
Build Slicer with i18n enabled by default.

It is marked as draft because first need to merge this CTK language box improvement (https://github.com/commontk/CTK/pull/1019), but otherwise it is fully ready for review.

It should get into today's nightly build so that it can be shown at the project presentations tomorrow.
