### PR TITLE
ENH: Add interactive slice intersections widget

### DIFF
--- a/Base/QTGUI/qSlicerViewersToolBar_p.h
+++ b/Base/QTGUI/qSlicerViewersToolBar_p.h
@@ -51,6 +51,7 @@
 
 // MRML includes
 #include <vtkMRMLScene.h>
+#include <vtkMRMLCrosshairNode.h>
 
 // VTK includes
 #include <vtkSmartPointer.h>
@@ -74,7 +75,6 @@ public:
 
   void init();
   void setMRMLScene(vtkMRMLScene* newScene);
-  void updateWidgetFromMRML();
 
 public slots:
 
@@ -82,43 +82,52 @@ public slots:
   void OnMRMLSceneEndImport();
   void OnMRMLSceneEndClose();
   void onCrosshairNodeModeChangedEvent();
-  void onSliceCompositeNodeChangedEvent();
+  void onSliceDisplayNodeChangedEvent();
+  void updateWidgetFromMRML();
 
   void setCrosshairMode(int);
   void setCrosshairEnabled(bool); // used to toggle between last style and off
   void setCrosshairThickness(int);
   void setCrosshairJumpSlicesMode(int);
-  void setSliceIntersectionVisible(bool);
+  void setIntersectingSlicesVisibility(bool);
+  void setIntersectingSlicesInteractive(bool);
+  void setIntersectingSlicesRotationEnabled(bool);
+  void setIntersectingSlicesTranslationEnabled(bool);
 
 public:
-  vtkSmartPointer<vtkMRMLScene>            MRMLScene;
+  vtkSmartPointer<vtkMRMLScene> MRMLScene;
   vtkSmartPointer<vtkMRMLApplicationLogic> MRMLAppLogic;
 
   /// Crosshair
-  QToolButton *CrosshairToolButton;
-  QMenu*        CrosshairMenu;
+  QToolButton* CrosshairToolButton{nullptr};
+  QMenu* CrosshairMenu{nullptr};
 
-  ctkSignalMapper* CrosshairJumpSlicesMapper;
-  QAction*      CrosshairJumpSlicesDisabledAction;
-  QAction*      CrosshairJumpSlicesOffsetAction;
-  QAction*      CrosshairJumpSlicesCenteredAction;
+  ctkSignalMapper* CrosshairJumpSlicesMapper{nullptr};
+  QAction* CrosshairJumpSlicesDisabledAction{nullptr};
+  QAction* CrosshairJumpSlicesOffsetAction{nullptr};
+  QAction* CrosshairJumpSlicesCenteredAction{nullptr};
 
-  ctkSignalMapper* CrosshairMapper;
-  QAction*      CrosshairNoAction;
-  QAction*      CrosshairBasicAction;
-  QAction*      CrosshairBasicIntersectionAction;
-  QAction*      CrosshairSmallBasicAction;
-  QAction*      CrosshairSmallBasicIntersectionAction;
-  QAction*      CrosshairSliceIntersectionsAction;
+  ctkSignalMapper* CrosshairMapper{nullptr};
+  QAction* CrosshairNoAction{nullptr};
+  QAction* CrosshairBasicAction{nullptr};
+  QAction* CrosshairBasicIntersectionAction{nullptr};
+  QAction* CrosshairSmallBasicAction{nullptr};
+  QAction* CrosshairSmallBasicIntersectionAction{nullptr};
 
-  ctkSignalMapper* CrosshairThicknessMapper;
-  QAction*      CrosshairFineAction;
-  QAction*      CrosshairMediumAction;
-  QAction*      CrosshairThickAction;
+  QAction* IntersectingSlicesVisibleAction{nullptr};
+  QAction* IntersectingSlicesInteractiveAction{nullptr};
+  QAction* IntersectingSlicesTranslationEnabledAction{nullptr};
+  QAction* IntersectingSlicesRotationEnabledAction{nullptr};
+  QMenu* IntersectingSlicesInteractionModesMenu{nullptr};
 
-  QAction*      CrosshairToggleAction;
+  ctkSignalMapper* CrosshairThicknessMapper{nullptr};
+  QAction* CrosshairFineAction{nullptr};
+  QAction* CrosshairMediumAction{nullptr};
+  QAction* CrosshairThickAction{nullptr};
 
-  int           CrosshairLastMode;
+  QAction* CrosshairToggleAction{nullptr};
+
+  int CrosshairLastMode{vtkMRMLCrosshairNode::ShowBasic};
 };
 
 #endif

--- a/Libs/MRML/Core/CMakeLists.txt
+++ b/Libs/MRML/Core/CMakeLists.txt
@@ -195,6 +195,7 @@ set(MRMLCore_SRCS
   vtkMRMLSequenceStorageNode.h
   vtkMRMLSelectionNode.cxx
   vtkMRMLSliceCompositeNode.cxx
+  vtkMRMLSliceDisplayNode.cxx
   vtkMRMLSliceNode.cxx
   vtkMRMLSnapshotClipNode.cxx
   vtkMRMLStorableNode.cxx

--- a/Libs/MRML/Core/vtkMRMLScene.cxx
+++ b/Libs/MRML/Core/vtkMRMLScene.cxx
@@ -56,6 +56,7 @@ Version:   $Revision: 1.18 $
 #include "vtkMRMLSequenceNode.h"
 #include "vtkMRMLSequenceStorageNode.h"
 #include "vtkMRMLSliceCompositeNode.h"
+#include "vtkMRMLSliceDisplayNode.h"
 #include "vtkMRMLSliceNode.h"
 #include "vtkMRMLSnapshotClipNode.h"
 #include "vtkMRMLSubjectHierarchyNode.h"
@@ -170,7 +171,7 @@ vtkMRMLScene::vtkMRMLScene()
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLModelStorageNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLModelDisplayNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLClipModelsNode >::New() );
-  this->RegisterNodeClass(vtkSmartPointer< vtkMRMLFolderDisplayNode >::New());
+  this->RegisterNodeClass( vtkSmartPointer< vtkMRMLFolderDisplayNode >::New());
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLROINode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLROIListNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSliceCompositeNode >::New() );
@@ -179,6 +180,7 @@ vtkMRMLScene::vtkMRMLScene()
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSegmentationNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSegmentationStorageNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSelectionNode >::New() );
+  this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSliceDisplayNode >::New());
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLSliceNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLVolumeArchetypeStorageNode >::New() );
   this->RegisterNodeClass( vtkSmartPointer< vtkMRMLScalarVolumeDisplayNode >::New() );

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.cxx
@@ -41,21 +41,6 @@ vtkMRMLSliceCompositeNode::vtkMRMLSliceCompositeNode()
   this->AddNodeReferenceRole(BackgroundVolumeNodeReferenceRole, BackgroundVolumeNodeReferenceMRMLAttributeName);
   this->AddNodeReferenceRole(ForegroundVolumeNodeReferenceRole, ForegroundVolumeNodeReferenceMRMLAttributeName);
   this->AddNodeReferenceRole(LabelVolumeNodeReferenceRole, LabelVolumeNodeReferenceMRMLAttributeName);
-
-  this->Compositing = 0;
-  this->ForegroundOpacity = 0.0; // start by showing only the background volume
-  this->LabelOpacity = 1.0; // Show the label if there is one
-  this->LinkedControl = 0;
-  this->FiducialVisibility = 1;
-  this->FiducialLabelVisibility = 1;
-  this->AnnotationSpace = vtkMRMLSliceCompositeNode::IJKAndRAS;
-  this->AnnotationMode = vtkMRMLSliceCompositeNode::All;
-  this->SliceIntersectionVisibility = 0;
-  this->DoPropagateVolumeSelection = true;
-  this->Interacting = 0;
-  this->InteractionFlags = 0;
-  this->HotLinkedControl = 0;
-  this->InteractionFlagsModifier = (unsigned int) -1;
 }
 
 //----------------------------------------------------------------------------
@@ -76,7 +61,6 @@ void vtkMRMLSliceCompositeNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLIntMacro(hotLinkedControl, HotLinkedControl);
   vtkMRMLWriteXMLIntMacro(fiducialVisibility, FiducialVisibility);
   vtkMRMLWriteXMLIntMacro(fiducialLabelVisibility, FiducialLabelVisibility);
-  vtkMRMLWriteXMLIntMacro(sliceIntersectionVisibility, SliceIntersectionVisibility);
   vtkMRMLWriteXMLStringMacro(layoutName, LayoutName);
   vtkMRMLWriteXMLEnumMacro(annotationSpace, AnnotationSpace);
   vtkMRMLWriteXMLEnumMacro(annotationMode, AnnotationMode);
@@ -110,11 +94,11 @@ int vtkMRMLSliceCompositeNode::GetAnnotationSpaceFromString(const char* name)
   for (int i = 0; i < AnnotationSpace_Last; i++)
     {
     if (strcmp(name, this->GetAnnotationSpaceAsString(i)) == 0)
-    {
+      {
       // found a matching name
       return i;
+      }
     }
-  }
   // unknown name
   return -1;
 }
@@ -123,33 +107,33 @@ int vtkMRMLSliceCompositeNode::GetAnnotationSpaceFromString(const char* name)
 const char* vtkMRMLSliceCompositeNode::GetAnnotationModeAsString(int id)
 {
   switch (id)
-  {
-  case vtkMRMLSliceCompositeNode::NoAnnotation: return "NoAnnotation";
-  case vtkMRMLSliceCompositeNode::All: return "All";
-  case vtkMRMLSliceCompositeNode::LabelValuesOnly: return "LabelValuesOnly";
-  case vtkMRMLSliceCompositeNode::LabelAndVoxelValuesOnly: return "LabelAndVoxelValuesOnly";
-  default:
-    // invalid id
-    return "";
-  }
+    {
+    case vtkMRMLSliceCompositeNode::NoAnnotation: return "NoAnnotation";
+    case vtkMRMLSliceCompositeNode::All: return "All";
+    case vtkMRMLSliceCompositeNode::LabelValuesOnly: return "LabelValuesOnly";
+    case vtkMRMLSliceCompositeNode::LabelAndVoxelValuesOnly: return "LabelAndVoxelValuesOnly";
+    default:
+      // invalid id
+      return "";
+    }
 }
 
 //-----------------------------------------------------------
 int vtkMRMLSliceCompositeNode::GetAnnotationModeFromString(const char* name)
 {
   if (name == nullptr)
-  {
+    {
     // invalid name
     return -1;
-  }
+    }
   for (int i = 0; i < AnnotationMode_Last; i++)
-  {
-    if (strcmp(name, this->GetAnnotationModeAsString(i)) == 0)
     {
+    if (strcmp(name, this->GetAnnotationModeAsString(i)) == 0)
+      {
       // found a matching name
       return i;
+      }
     }
-  }
   // unknown name
   return -1;
 }
@@ -197,7 +181,6 @@ void vtkMRMLSliceCompositeNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLIntMacro(hotLinkedControl, HotLinkedControl);
   vtkMRMLReadXMLIntMacro(fiducialVisibility, FiducialVisibility);
   vtkMRMLReadXMLIntMacro(fiducialLabelVisibility, FiducialLabelVisibility);
-  vtkMRMLReadXMLIntMacro(sliceIntersectionVisibility, SliceIntersectionVisibility);
   vtkMRMLReadXMLStringMacro(layoutName, LayoutName);
   vtkMRMLReadXMLEnumMacro(annotationSpace, AnnotationSpace);
   vtkMRMLReadXMLEnumMacro(annotationMode, AnnotationMode);
@@ -223,7 +206,6 @@ void vtkMRMLSliceCompositeNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   vtkMRMLCopyIntMacro(HotLinkedControl);
   vtkMRMLCopyIntMacro(FiducialVisibility);
   vtkMRMLCopyIntMacro(FiducialLabelVisibility);
-  vtkMRMLCopyIntMacro(SliceIntersectionVisibility);
   // To avoid breaking current implementation, copy of the "LayoutName" attribute
   // will be enabled after revisiting the view initialization pipeline.
   //vtkMRMLCopyStringMacro(LayoutName);
@@ -249,7 +231,6 @@ void vtkMRMLSliceCompositeNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintIntMacro(HotLinkedControl);
   vtkMRMLPrintIntMacro(FiducialVisibility);
   vtkMRMLPrintIntMacro(FiducialLabelVisibility);
-  vtkMRMLPrintIntMacro(SliceIntersectionVisibility);
   vtkMRMLPrintStringMacro(LayoutName);
   vtkMRMLPrintEnumMacro(AnnotationSpace);
   vtkMRMLPrintEnumMacro(AnnotationMode);

--- a/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceCompositeNode.h
@@ -23,7 +23,7 @@
 /// vtkMRMLVolumes into a single display image.
 class VTK_MRML_EXPORT vtkMRMLSliceCompositeNode : public vtkMRMLNode
 {
-  public:
+public:
   static vtkMRMLSliceCompositeNode *New();
   vtkTypeMacro(vtkMRMLSliceCompositeNode,vtkMRMLNode);
   void PrintSelf(ostream& os, vtkIndent indent) override;
@@ -103,11 +103,6 @@ class VTK_MRML_EXPORT vtkMRMLSliceCompositeNode : public vtkMRMLNode
   vtkSetMacro (FiducialVisibility, int );
   vtkGetMacro (FiducialLabelVisibility, int );
   vtkSetMacro (FiducialLabelVisibility, int );
-
-  ///
-  /// toggles visibility of intersections of other slices in the slice viewer
-  vtkGetMacro (SliceIntersectionVisibility, int );
-  vtkSetMacro (SliceIntersectionVisibility, int );
 
   /// Get annotation space.
   vtkGetMacro ( AnnotationSpace, int );
@@ -239,27 +234,27 @@ protected:
   vtkMRMLSliceCompositeNode(const vtkMRMLSliceCompositeNode&);
   void operator=(const vtkMRMLSliceCompositeNode&);
 
-  double ForegroundOpacity;
+  // start by showing only the background volume
+  double ForegroundOpacity{ 0.0 };
 
-  int Compositing;
+  int Compositing{ Alpha };
 
-  double LabelOpacity;
-  int LinkedControl;
-  int HotLinkedControl;
+  // Show the label if there is one
+  double LabelOpacity{ 1.0 };
+  int LinkedControl{ 0 };
+  int HotLinkedControl{ 0 };
 
-  int FiducialVisibility;
-  int FiducialLabelVisibility;
+  int FiducialVisibility{ 1 };
+  int FiducialLabelVisibility{ 1 };
 
-  int SliceIntersectionVisibility;
+  int AnnotationSpace{ IJKAndRAS };
+  int AnnotationMode{ All };
 
-  int AnnotationSpace;
-  int AnnotationMode;
+  bool DoPropagateVolumeSelection{ true };
 
-  bool DoPropagateVolumeSelection;
-
-  int Interacting;
-  unsigned int InteractionFlags;
-  unsigned int InteractionFlagsModifier;
+  int Interacting{ 0 };
+  unsigned int InteractionFlags{ 0 };
+  unsigned int InteractionFlagsModifier{ (unsigned int)-1 };
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLSliceDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSliceDisplayNode.cxx
@@ -1,0 +1,264 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Ebatinca S.L., Las Palmas de Gran Canaria, Spain
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLSliceDisplayNode.h"
+
+// VTK includes
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLSliceDisplayNode);
+
+//-----------------------------------------------------------------------------
+vtkMRMLSliceDisplayNode::vtkMRMLSliceDisplayNode()
+{
+  // Set active component defaults for mouse (identified by empty string)
+  this->ActiveComponents[GetDefaultContextName()] = ComponentInfo();
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLSliceDisplayNode::~vtkMRMLSliceDisplayNode()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os, indent);
+
+  vtkMRMLPrintBeginMacro(os, indent);
+  vtkMRMLPrintBooleanMacro(IntersectingSlicesInteractive);
+  vtkMRMLPrintBooleanMacro(IntersectingSlicesTranslationEnabled);
+  vtkMRMLPrintBooleanMacro(IntersectingSlicesRotationEnabled);
+  vtkMRMLPrintIntMacro(IntersectingSlicesInteractiveHandlesVisibilityMode);
+  {
+  os << indent << "ActiveComponents:";
+  for (std::map<std::string, ComponentInfo>::iterator it = this->ActiveComponents.begin(); it != this->ActiveComponents.end(); ++it)
+    {
+    os << indent << indent;
+    if (it->first.empty())
+      {
+      os << "(default)";
+      }
+    else
+      {
+      os << it->first;
+      }
+    os << ": " << it->second.Type << ", " << it->second.Index;
+    }
+  os << "\n";
+  }
+  vtkMRMLPrintEndMacro();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceDisplayNode::WriteXML(ostream& of, int nIndent)
+{
+  // Write all attributes not equal to their defaults
+  this->Superclass::WriteXML(of, nIndent);
+
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLBooleanMacro(intersectingSlicesInteractive, IntersectingSlicesInteractive);
+  vtkMRMLWriteXMLBooleanMacro(intersectingSlicesTranslationEnabled, IntersectingSlicesTranslationEnabled);
+  vtkMRMLWriteXMLBooleanMacro(intersectingSlicesRotationEnabled, IntersectingSlicesRotationEnabled);
+  vtkMRMLWriteXMLIntMacro(intersectingSlicesInteractiveHandlesVisibilityMode, IntersectingSlicesInteractiveHandlesVisibilityMode);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceDisplayNode::ReadXMLAttributes(const char** atts)
+{
+  int disabledModify = this->StartModify();
+  this->Superclass::ReadXMLAttributes(atts);
+
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLBooleanMacro(intersectingSlicesInteractive, IntersectingSlicesInteractive);
+  vtkMRMLReadXMLBooleanMacro(intersectingSlicesTranslationEnabled, IntersectingSlicesTranslationEnabled);
+  vtkMRMLReadXMLBooleanMacro(intersectingSlicesRotationEnabled, IntersectingSlicesRotationEnabled);
+  vtkMRMLReadXMLIntMacro(intersectingSlicesInteractiveHandlesVisibilityMode, IntersectingSlicesInteractiveHandlesVisibilityMode);
+  vtkMRMLReadXMLEndMacro();
+
+  this->EndModify(disabledModify);
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  vtkMRMLSliceDisplayNode* node = vtkMRMLSliceDisplayNode::SafeDownCast(anode);
+  if (!node)
+    {
+    return;
+    }
+
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyBooleanMacro(IntersectingSlicesInteractive);
+  vtkMRMLCopyBooleanMacro(IntersectingSlicesTranslationEnabled);
+  vtkMRMLCopyBooleanMacro(IntersectingSlicesRotationEnabled);
+  vtkMRMLCopyIntMacro(IntersectingSlicesInteractiveHandlesVisibilityMode);
+  vtkMRMLCopyEndMacro();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLSliceDisplayNode::SetIntersectingSlicesInteractiveModeEnabled(
+  IntersectingSlicesInteractiveMode mode, bool enabled)
+{
+  switch (mode)
+    {
+    case vtkMRMLSliceDisplayNode::ModeTranslation:
+      this->SetIntersectingSlicesTranslationEnabled(enabled);
+      break;
+    case vtkMRMLSliceDisplayNode::ModeRotation:
+      this->SetIntersectingSlicesRotationEnabled(enabled);
+      break;
+    default:
+      vtkErrorMacro("Unknown mode");
+      break;
+    }
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLSliceDisplayNode::GetIntersectingSlicesInteractiveModeEnabled(
+  IntersectingSlicesInteractiveMode mode)
+{
+  switch (mode)
+    {
+    case vtkMRMLSliceDisplayNode::ModeTranslation:
+      return this->GetIntersectingSlicesTranslationEnabled();
+    case vtkMRMLSliceDisplayNode::ModeRotation:
+      return this->GetIntersectingSlicesRotationEnabled();
+    default:
+      vtkErrorMacro("Unknown mode");
+    }
+  return false;
+}
+
+//----------------------------------------------------------------------------
+const char* vtkMRMLSliceDisplayNode::GetIntersectingSlicesInteractiveHandlesVisibilityModeAsString()
+  {
+  return vtkMRMLSliceDisplayNode::GetIntersectingSlicesInteractiveHandlesVisibilityModeAsString(this->IntersectingSlicesInteractiveHandlesVisibilityMode);
+  }
+
+//----------------------------------------------------------------------------
+void vtkMRMLSliceDisplayNode::SetIntersectingSlicesInteractiveHandlesVisibilityModeFromString(const char* handlesVisibilityModeString)
+  {
+  this->SetIntersectingSlicesInteractiveHandlesVisibilityMode(
+    vtkMRMLSliceDisplayNode::GetIntersectingSlicesInteractiveHandlesVisibilityModeFromString(handlesVisibilityModeString));
+  }
+
+//-----------------------------------------------------------
+int vtkMRMLSliceDisplayNode::GetIntersectingSlicesInteractiveHandlesVisibilityModeFromString(const char* name)
+  {
+  if (name == nullptr)
+    {
+    // invalid name
+    return -1;
+    }
+  for (int ii = 0; ii < HandlesVisibilityMode_Last; ii++)
+    {
+    if (strcmp(name, GetIntersectingSlicesInteractiveHandlesVisibilityModeAsString(ii)) == 0)
+      {
+      // found a matching name
+      return ii;
+      }
+    }
+  // unknown name
+  return -1;
+  }
+
+//---------------------------------------------------------------------------
+const char* vtkMRMLSliceDisplayNode::GetIntersectingSlicesInteractiveHandlesVisibilityModeAsString(int id)
+  {
+  switch (id)
+    {
+    case NeverVisible: return "NeverVisible";
+    case NearbyVisible: return "NearbyVisible";
+    case AlwaysVisible: return "AlwaysVisible";
+    //case FadingVisible: return "FadingVisible";
+    default:
+      // invalid id
+      return "Invalid";
+    }
+  }
+
+//---------------------------------------------------------------------------
+int vtkMRMLSliceDisplayNode::GetActiveComponentType(std::string context/*=GetDefaultContextName()*/)
+{
+  if (this->ActiveComponents.find(context) == this->ActiveComponents.end())
+    {
+    vtkErrorMacro("GetActiveComponentType: No interaction context with identifier '" << context << "' was found");
+    return ComponentNone;
+    }
+
+  return this->ActiveComponents[context].Type;
+}
+
+//---------------------------------------------------------------------------
+int vtkMRMLSliceDisplayNode::GetActiveComponentIndex(std::string context/*=GetDefaultContextName()*/)
+{
+  if (this->ActiveComponents.find(context) == this->ActiveComponents.end())
+    {
+    vtkErrorMacro("GetActiveComponentIndex: No interaction context with identifier '" << context << "' was found");
+    return -1;
+    }
+
+  return this->ActiveComponents[context].Index;
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLSliceDisplayNode::SetActiveComponent(int componentType, int componentIndex, std::string context/*=GetDefaultContextName()*/)
+{
+  if ( this->ActiveComponents.find(context) != this->ActiveComponents.end()
+    && this->ActiveComponents[context].Type == componentType
+    && this->ActiveComponents[context].Index == componentIndex )
+    {
+    // no change
+    return;
+    }
+  this->ActiveComponents[context].Index = componentIndex;
+  this->ActiveComponents[context].Type = componentType;
+  this->Modified();
+}
+
+//---------------------------------------------------------------------------
+bool vtkMRMLSliceDisplayNode::HasActiveComponent()
+{
+  for (std::map<std::string, ComponentInfo>::iterator it = this->ActiveComponents.begin(); it != this->ActiveComponents.end(); ++it)
+    {
+    if (it->second.Type != ComponentNone)
+      {
+      return true;
+      }
+    }
+  return false;
+}
+
+//---------------------------------------------------------------------------
+std::vector<std::string> vtkMRMLSliceDisplayNode::GetActiveComponentInteractionContexts()
+{
+  std::vector<std::string> interactionContextVector;
+  for (std::map<std::string, ComponentInfo>::iterator it = this->ActiveComponents.begin(); it != this->ActiveComponents.end(); ++it)
+    {
+    if (it->second.Type != ComponentNone)
+      {
+      interactionContextVector.push_back(it->first);
+      }
+    }
+  return interactionContextVector;
+}

--- a/Libs/MRML/Core/vtkMRMLSliceDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLSliceDisplayNode.h
@@ -1,0 +1,159 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Ebatinca S.L., Las Palmas de Gran Canaria, Spain
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLSliceDisplayNode_h
+#define __vtkMRMLSliceDisplayNode_h
+
+// MRML includes
+#include "vtkMRMLModelDisplayNode.h"
+
+/// \brief MRML node to store display properties of slice nodes.
+///
+/// This node controls appearance of slice intersections in slice views
+/// and slices in 3D views.
+class VTK_MRML_EXPORT vtkMRMLSliceDisplayNode : public vtkMRMLModelDisplayNode
+{
+public:
+  static vtkMRMLSliceDisplayNode *New();
+  vtkTypeMacro(vtkMRMLSliceDisplayNode,vtkMRMLModelDisplayNode);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  ///
+  /// Read node attributes from XML file
+  void ReadXMLAttributes(const char** atts) override;
+
+  ///
+  /// Write this node's information to a MRML file in XML format.
+  void WriteXML(ostream& of, int indent) override;
+
+  /// Copy node content (excludes basic data, such as name and node references).
+  /// \sa vtkMRMLNode::CopyContent
+  vtkMRMLCopyContentMacro(vtkMRMLSliceDisplayNode);
+
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  /// Get node XML tag name (like Volume, Model)
+  const char* GetNodeTagName() override {return "SliceDisplay";}
+
+  /// toggles visibility of intersections of other slices in the slice viewer
+  bool GetIntersectingSlicesVisibility() { return this->GetVisibility2D(); };
+  void SetIntersectingSlicesVisibility(bool visible) { this->SetVisibility2D(visible); };
+  vtkBooleanMacro(IntersectingSlicesVisibility, bool);
+
+  /// toggles interaction with slice intersections
+  vtkGetMacro(IntersectingSlicesInteractive, bool);
+  vtkSetMacro(IntersectingSlicesInteractive, bool);
+  vtkBooleanMacro(IntersectingSlicesInteractive, bool);
+
+  // Interaction handles
+  enum IntersectingSlicesInteractiveMode
+  {
+    ModeRotation,
+    ModeTranslation
+  };
+  vtkGetMacro(IntersectingSlicesTranslationEnabled, bool);
+  vtkSetMacro(IntersectingSlicesTranslationEnabled, bool);
+  vtkBooleanMacro(IntersectingSlicesTranslationEnabled, bool);
+  vtkGetMacro(IntersectingSlicesRotationEnabled, bool);
+  vtkSetMacro(IntersectingSlicesRotationEnabled, bool);
+  vtkBooleanMacro(IntersectingSlicesRotationEnabled, bool);
+  void SetIntersectingSlicesInteractiveModeEnabled(IntersectingSlicesInteractiveMode mode, bool enabled);
+  bool GetIntersectingSlicesInteractiveModeEnabled(IntersectingSlicesInteractiveMode mode);
+
+  // Interaction handles visibility mode
+  enum HandlesVisibilityMode
+    {
+    NeverVisible = 0,
+    NearbyVisible,
+    AlwaysVisible,
+    //FadingVisible, // Handles' opacity increases as the mouse gets closer to them
+    HandlesVisibilityMode_Last // insert new types above this line
+    };
+  vtkGetMacro(IntersectingSlicesInteractiveHandlesVisibilityMode, int);
+  vtkSetMacro(IntersectingSlicesInteractiveHandlesVisibilityMode, int);
+
+  /// Return a string representing the handles visibility mode, set it from a string
+  const char* GetIntersectingSlicesInteractiveHandlesVisibilityModeAsString();
+  void SetIntersectingSlicesInteractiveHandlesVisibilityModeFromString(const char* handlesVisibilityModeString);
+
+  static const char* GetIntersectingSlicesInteractiveHandlesVisibilityModeAsString(int id);
+  static int GetIntersectingSlicesInteractiveHandlesVisibilityModeFromString(const char*);
+
+  /// Get name of the default interaction context (typically the mouse)
+  static const std::string GetDefaultContextName() { return ""; };
+
+  /// Active component (that the mouse or other interaction context is hovered over).
+  /// This property is computed on-the-fly and saved to file.
+  /// \param context Name of the interaction context. By default it is empty string, meaning mouse.
+  ///   Additional devices, such as virtual reality controllers can specify additional context names.
+  ///   This mechanism allows interacting with multiple markups at the same time (user can grab
+  ///   different markup points with each controller at the same time).
+  int GetActiveComponentType(std::string context = vtkMRMLSliceDisplayNode::GetDefaultContextName());
+  enum ComponentType
+    {
+    ComponentNone = 0, ///< no component of the slice or slice intersection widget is active
+    ComponentTranslateIntersectingSlicesHandle, ///< mouse is near the intersection point of slice intersections
+    ComponentRotateIntersectingSlicesHandle, ///< mouse is near the end of the slice intersection (rotation section)
+    ComponentTranslateSingleIntersectingSliceHandle, ///< mouse is near the middle of the slice intersection (translation section)
+    ComponentSliceIntersection, ///< slice intersection is active (not any handle), e.g., because user is interacting with the widget
+    Component_Last
+    };
+  struct ComponentInfo
+    {
+    ComponentInfo()
+      {
+      this->Type = ComponentNone;
+      this->Index = -1;
+      }
+    int Type;
+    int Index;
+    };
+
+  /// Index of active component (that the mouse or other interaction context is hovered over).
+  /// This property is computed on-the-fly and saved to file.
+  /// \param context Name of the interaction context. By default it is empty string, meaning mouse
+  int GetActiveComponentIndex(std::string context= vtkMRMLSliceDisplayNode::GetDefaultContextName());
+
+  /// Set active component type and index for interaction context (empty by default, meaning mouse)
+  void SetActiveComponent(int componentType, int componentIndex,
+                          std::string context= vtkMRMLSliceDisplayNode::GetDefaultContextName());
+
+  /// Query if there is an active component for any interaction context
+  bool HasActiveComponent();
+
+  /// Get list of interaction context names that have active components
+  /// \return List of interaction context names that have active components
+  std::vector<std::string> GetActiveComponentInteractionContexts();
+
+protected:
+  vtkMRMLSliceDisplayNode();
+  ~vtkMRMLSliceDisplayNode() override;
+  vtkMRMLSliceDisplayNode(const vtkMRMLSliceDisplayNode&);
+  void operator=(const vtkMRMLSliceDisplayNode&);
+
+  bool IntersectingSlicesInteractive{ false };
+  bool IntersectingSlicesTranslationEnabled{ true };
+  bool IntersectingSlicesRotationEnabled{ true };
+
+  int IntersectingSlicesInteractiveHandlesVisibilityMode{ NeverVisible };
+
+  /// Current active point or widget component type and index (hovered by the mouse or other interaction context)
+  /// Map interaction context identifier (empty string for mouse) to component type enum
+  std::map<std::string, ComponentInfo> ActiveComponents;
+};
+
+#endif

--- a/Libs/MRML/DisplayableManager/CMakeLists.txt
+++ b/Libs/MRML/DisplayableManager/CMakeLists.txt
@@ -114,6 +114,8 @@ set(KIT_SRCS
   vtkMRMLCameraWidget.cxx
   vtkMRMLSliceIntersectionWidget.cxx
   vtkMRMLSliceIntersectionRepresentation2D.cxx
+  vtkMRMLSliceIntersectionInteractionRepresentation.cxx
+  vtkMRMLSliceIntersectionInteractionRepresentationHelper.cxx
   vtkMRMLRubberBandWidgetRepresentation.cxx
   vtkMRMLWindowLevelWidget.cxx
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.cxx
@@ -88,11 +88,11 @@ public:
   void AddCrosshairLine(vtkPoints *pts, vtkCellArray *cellArray,
                         int p1x, int p1y, int p2x, int p2y);
 
-  // Did crosshair position change?
-  bool DidCrosshairPositionChange();
+  // Has crosshair position changed?
+  bool HasCrosshairPositionChanged();
 
-  // Did crosshair property change?
-  bool DidCrosshairPropertyChange();
+  // Has crosshair property changed?
+  bool HasCrosshairPropertyChanged();
 
   vtkMRMLCrosshairDisplayableManager*        External;
   int                                        PickState;
@@ -158,7 +158,7 @@ void vtkMRMLCrosshairDisplayableManager::vtkInternal::Modified()
 }
 
 //---------------------------------------------------------------------------
-bool vtkMRMLCrosshairDisplayableManager::vtkInternal::DidCrosshairPositionChange()
+bool vtkMRMLCrosshairDisplayableManager::vtkInternal::HasCrosshairPositionChanged()
 {
   if (this->CrosshairNode.GetPointer() == nullptr)
     {
@@ -182,7 +182,7 @@ bool vtkMRMLCrosshairDisplayableManager::vtkInternal::DidCrosshairPositionChange
 }
 
 //---------------------------------------------------------------------------
-bool vtkMRMLCrosshairDisplayableManager::vtkInternal::DidCrosshairPropertyChange()
+bool vtkMRMLCrosshairDisplayableManager::vtkInternal::HasCrosshairPropertyChanged()
 {
   if (this->CrosshairNode.GetPointer() == nullptr)
     {
@@ -201,8 +201,7 @@ bool vtkMRMLCrosshairDisplayableManager::vtkInternal::DidCrosshairPropertyChange
 }
 
 //---------------------------------------------------------------------------
-vtkMRMLSliceNode* vtkMRMLCrosshairDisplayableManager::vtkInternal
-::GetSliceNode()
+vtkMRMLSliceNode* vtkMRMLCrosshairDisplayableManager::vtkInternal::GetSliceNode()
 {
   return this->External->GetMRMLSliceNode();
 }
@@ -226,9 +225,10 @@ void vtkMRMLCrosshairDisplayableManager::vtkInternal::UpdateIntersectingSliceNod
     return;
     }
 
+  vtkMRMLApplicationLogic *mrmlAppLogic = this->External->GetMRMLApplicationLogic();
+
   if (!this->SliceIntersectionWidget->GetRenderer())
     {
-    vtkMRMLApplicationLogic *mrmlAppLogic = this->External->GetMRMLApplicationLogic();
     this->SliceIntersectionWidget->SetMRMLApplicationLogic(mrmlAppLogic);
     this->SliceIntersectionWidget->CreateDefaultRepresentation();
     this->SliceIntersectionWidget->SetRenderer(this->External->GetRenderer());
@@ -423,7 +423,6 @@ void vtkMRMLCrosshairDisplayableManager::vtkInternal::AddCrosshairLine(vtkPoints
   cellArray->InsertCellPoint(p2);
 }
 
-
 //---------------------------------------------------------------------------
 // vtkMRMLCrosshairDisplayableManager methods
 
@@ -472,14 +471,14 @@ void vtkMRMLCrosshairDisplayableManager::OnMRMLNodeModified(
 {
   // update the properties and style of the crosshair
   bool builtCrosshair = false;
-  if (this->Internal->DidCrosshairPropertyChange())
+  if (this->Internal->HasCrosshairPropertyChanged())
     {
     this->Internal->BuildCrosshair();
     builtCrosshair = true;
     }
 
   // update the position of the actor
-  if ((this->Internal->DidCrosshairPositionChange() || builtCrosshair)
+  if ((this->Internal->HasCrosshairPositionChanged() || builtCrosshair)
       && this->Internal->Actor)
     {
     double xyz[3];
@@ -568,13 +567,27 @@ void vtkMRMLCrosshairDisplayableManager::OnMRMLSliceNodeModifiedEvent()
 //---------------------------------------------------------------------------
 bool vtkMRMLCrosshairDisplayableManager::CanProcessInteractionEvent(vtkMRMLInteractionEventData* eventData, double &closestDistance2)
 {
+  if (!this->Internal->SliceIntersectionWidget)
+    {
+    return false;
+    }
   return this->Internal->SliceIntersectionWidget->CanProcessInteractionEvent(eventData, closestDistance2);
 }
 
 //---------------------------------------------------------------------------
 bool vtkMRMLCrosshairDisplayableManager::ProcessInteractionEvent(vtkMRMLInteractionEventData* eventData)
 {
-  return this->Internal->SliceIntersectionWidget->ProcessInteractionEvent(eventData);
+  if (!this->Internal->SliceIntersectionWidget)
+    {
+    return false;
+    }
+  bool processed = this->Internal->SliceIntersectionWidget->ProcessInteractionEvent(eventData);
+  if (this->Internal->SliceIntersectionWidget && this->Internal->SliceIntersectionWidget->GetNeedToRender())
+    {
+    this->Internal->SliceIntersectionWidget->NeedToRenderOff();
+    this->RequestRender();
+    }
+  return processed;
 }
 
 //---------------------------------------------------------------------------
@@ -593,4 +606,23 @@ int vtkMRMLCrosshairDisplayableManager::GetActionsEnabled()
 vtkMRMLSliceIntersectionWidget* vtkMRMLCrosshairDisplayableManager::GetSliceIntersectionWidget()
 {
   return this->Internal->SliceIntersectionWidget;
+}
+
+//---------------------------------------------------------------------------
+int vtkMRMLCrosshairDisplayableManager::GetMouseCursor()
+{
+  if (!this->Internal->SliceIntersectionWidget)
+    {
+    return VTK_CURSOR_DEFAULT;
+    }
+  return this->Internal->SliceIntersectionWidget->GetMouseCursor();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLCrosshairDisplayableManager::SetHasFocus(bool hasFocus)
+{
+  if (this->Internal->SliceIntersectionWidget)
+    {
+    this->Internal->SliceIntersectionWidget->Leave(nullptr);
+    }
 }

--- a/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCrosshairDisplayableManager.h
@@ -52,6 +52,12 @@ public:
 
   vtkMRMLSliceIntersectionWidget* GetSliceIntersectionWidget();
 
+  /// Displayable manager returns ID of the mouse cursor shape that should be displayed
+  virtual int GetMouseCursor();
+
+  // Called to notify the displayable manager that it has got or lost the focus.
+  void SetHasFocus(bool hasFocus) override;
+
 protected:
   vtkMRMLCrosshairDisplayableManager();
   ~vtkMRMLCrosshairDisplayableManager() override;

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
@@ -1,0 +1,2161 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Ebatinca S.L., Las Palmas de Gran Canaria, Spain
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+
+#include "vtkMRMLSliceIntersectionInteractionRepresentation.h"
+
+#include "vtkMRMLSliceIntersectionInteractionRepresentationHelper.h"
+
+#include <deque>
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+#include "vtkMRMLApplicationLogic.h"
+#include "vtkMRMLDisplayableNode.h"
+#include "vtkMRMLInteractionNode.h"
+#include "vtkMRMLModelDisplayNode.h"
+#include "vtkMRMLScene.h"
+#include "vtkMRMLSliceDisplayNode.h"
+#include "vtkMRMLSliceLogic.h"
+#include "vtkMRMLSliceNode.h"
+#include "vtkMRMLViewNode.h"
+
+#include "vtkActor2D.h"
+#include "vtkArcSource.h"
+#include "vtkAppendPolyData.h"
+#include "vtkAssemblyPath.h"
+#include "vtkCallbackCommand.h"
+#include "vtkCamera.h"
+#include "vtkCellArray.h"
+#include "vtkCommand.h"
+#include "vtkConeSource.h"
+#include "vtkCoordinate.h"
+#include "vtkCursor2D.h"
+#include "vtkCylinderSource.h"
+#include "vtkGlyph2D.h"
+#include "vtkInteractorObserver.h"
+#include "vtkLeaderActor2D.h"
+#include "vtkLine.h"
+#include "vtkLineSource.h"
+#include "vtkMath.h"
+#include "vtkMatrix3x3.h"
+#include "vtkMatrix4x4.h"
+#include "vtkObjectFactory.h"
+#include "vtkPoints.h"
+#include "vtkPolyDataAlgorithm.h"
+#include "vtkPolyDataMapper2D.h"
+#include "vtkProperty2D.h"
+#include "vtkPlane.h"
+#include "vtkRenderer.h"
+#include "vtkRenderWindow.h"
+#include "vtkSphereSource.h"
+#include "vtkTransform.h"
+#include "vtkTransformPolyDataFilter.h"
+#include "vtkTextMapper.h"
+#include "vtkTextProperty.h"
+#include "vtkTubeFilter.h"
+#include "vtkWindow.h"
+
+// MRML includes
+#include <vtkMRMLInteractionEventData.h>
+
+// Visualization modes
+enum
+  {
+  ShowIntersection = 0,
+  HideIntersection = 1,
+  };
+
+// Handles type
+enum
+  {
+  Arrows = 0,
+  Circles = 1,
+  };
+
+// Settings
+static const int INTERSECTION_VISUALIZATION_MODE = HideIntersection;
+static const int HANDLES_TYPE = Arrows;
+static const double OPACITY_RANGE = 1000.0;
+static const double FOV_HANDLES_MARGIN = 0.03; // 3% margin
+static const double HIDE_INTERSECTION_GAP_SIZE = 0.05; // 5.0% of the slice view width
+static const double INTERACTION_SIZE_PIXELS = 20.0;
+static const double HANDLES_MIN_LINE_LENGTH = 50.0;
+
+// Intersection line
+static const double INTERSECTION_LINE_RESOLUTION = 50; // default = 8
+static const double INTERSECTION_LINE_EXTRA_THICKNESS = 1.0; // extra thickness with respect to normal slice intersection display
+
+// Handles
+static const double HANDLES_CIRCLE_THETA_RESOLUTION = 100; // default = 8
+static const double HANDLES_CIRCLE_PHI_RESOLUTION = 100; // default = 8
+static const double SLICEOFSSET_HANDLE_DEFAULT_POSITION[3] = { 0.0,0.0,0.0 };
+static const double SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION[3] = { 0.0,1.0,0.0 };
+static const double SLICEOFSSET_HANDLE_CIRCLE_RADIUS = 7.0;
+static const double SLICEOFSSET_HANDLE_ARROW_RADIUS = 3.0;
+static const double SLICEOFSSET_HANDLE_ARROW_LENGTH = 60.0;
+static const double SLICEOFSSET_HANDLE_ARROW_TIP_ANGLE = 27; // degrees
+static const double ROTATION_HANDLE_DEFAULT_POSITION[3] = { 0.0,0.0,0.0 };
+static const double ROTATION_HANDLE_DEFAULT_ORIENTATION[3] = { 0.0,1.0,0.0 };
+static const double ROTATION_HANDLE_CIRCLE_RADIUS = 10.0;
+static const double ROTATION_HANDLE_ARROW_RADIUS = 3.0;
+static const double ROTATION_HANDLE_ARROW_LENGTH = 60.0;
+static const double ROTATION_HANDLE_ARROW_TIP_ANGLE = 27; // degrees
+static const double TRANSLATION_HANDLE_OUTER_RADIUS = 9.0;
+static const double TRANSLATION_HANDLE_INNER_RADIUS = 7.0;
+
+vtkStandardNewMacro(vtkMRMLSliceIntersectionInteractionRepresentation);
+vtkCxxSetObjectMacro(vtkMRMLSliceIntersectionInteractionRepresentation, MRMLApplicationLogic, vtkMRMLApplicationLogic);
+
+class SliceIntersectionInteractionDisplayPipeline
+{
+  public:
+
+    //----------------------------------------------------------------------
+    SliceIntersectionInteractionDisplayPipeline()
+    {
+      // Intersection line 1
+      this->IntersectionLine1 = vtkSmartPointer<vtkLineSource>::New();
+      this->IntersectionLine1->SetResolution(INTERSECTION_LINE_RESOLUTION);
+      this->IntersectionLine1->Update();
+      this->IntersectionLine1Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+      this->IntersectionLine1Property = vtkSmartPointer<vtkProperty2D>::New();
+      this->IntersectionLine1Actor = vtkSmartPointer<vtkActor2D>::New();
+      this->IntersectionLine1Actor->SetVisibility(false); // invisible until slice node is set
+      this->IntersectionLine1Mapper->SetInputConnection(this->IntersectionLine1->GetOutputPort());
+      this->IntersectionLine1Actor->SetMapper(this->IntersectionLine1Mapper);
+      this->IntersectionLine1Actor->SetProperty(this->IntersectionLine1Property);
+
+      // Intersection line 2
+      this->IntersectionLine2 = vtkSmartPointer<vtkLineSource>::New();
+      this->IntersectionLine2->SetResolution(INTERSECTION_LINE_RESOLUTION);
+      this->IntersectionLine2->Update();
+      this->IntersectionLine2Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+      this->IntersectionLine2Property = vtkSmartPointer<vtkProperty2D>::New();
+      this->IntersectionLine2Actor = vtkSmartPointer<vtkActor2D>::New();
+      this->IntersectionLine2Actor->SetVisibility(false); // invisible until slice node is set
+      this->IntersectionLine2Mapper->SetInputConnection(this->IntersectionLine2->GetOutputPort());
+      this->IntersectionLine2Actor->SetMapper(this->IntersectionLine2Mapper);
+      this->IntersectionLine2Actor->SetProperty(this->IntersectionLine2Property);
+
+      // Center sphere
+      this->TranslationOuterHandle = vtkSmartPointer<vtkSphereSource>::New();
+      this->TranslationOuterHandle->SetRadius(TRANSLATION_HANDLE_OUTER_RADIUS);
+      this->TranslationOuterHandle->SetThetaResolution(HANDLES_CIRCLE_THETA_RESOLUTION);
+      this->TranslationOuterHandle->SetPhiResolution(HANDLES_CIRCLE_PHI_RESOLUTION);
+      this->TranslationOuterHandle->Update();
+      this->TranslationOuterHandleMapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+      this->TranslationOuterHandleProperty = vtkSmartPointer<vtkProperty2D>::New();
+      this->TranslationOuterHandleActor = vtkSmartPointer<vtkActor2D>::New();
+      this->TranslationOuterHandleActor->SetVisibility(false); // invisible until slice node is set
+      this->TranslationOuterHandleMapper->SetInputConnection(this->TranslationOuterHandle->GetOutputPort());
+      this->TranslationOuterHandleActor->SetMapper(this->TranslationOuterHandleMapper);
+      this->TranslationOuterHandleActor->SetProperty(this->TranslationOuterHandleProperty);
+      this->TranslationInnerHandle = vtkSmartPointer<vtkSphereSource>::New();
+      this->TranslationInnerHandle->SetRadius(TRANSLATION_HANDLE_INNER_RADIUS);
+      this->TranslationInnerHandle->SetThetaResolution(HANDLES_CIRCLE_THETA_RESOLUTION);
+      this->TranslationInnerHandle->SetPhiResolution(HANDLES_CIRCLE_PHI_RESOLUTION);
+      this->TranslationInnerHandle->Update();
+      this->TranslationInnerHandleMapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+      this->TranslationInnerHandleProperty = vtkSmartPointer<vtkProperty2D>::New();
+      this->TranslationInnerHandleActor = vtkSmartPointer<vtkActor2D>::New();
+      this->TranslationInnerHandleActor->SetVisibility(false); // invisible until slice node is set
+      this->TranslationInnerHandleMapper->SetInputConnection(this->TranslationInnerHandle->GetOutputPort());
+      this->TranslationInnerHandleActor->SetMapper(this->TranslationInnerHandleMapper);
+      this->TranslationInnerHandleActor->SetProperty(this->TranslationInnerHandleProperty);
+
+      // Initialize handles
+      this->CreateRotationHandles();
+      this->CreateSliceOffsetHandles();
+      this->SetHandlesVisibility(false);
+      this->NeedToRender = true;
+
+      // Handle points
+      this->RotationHandlePoints = vtkSmartPointer<vtkPolyData>::New();
+      this->TranslationHandlePoints = vtkSmartPointer<vtkPolyData>::New();
+      this->SliceOffsetHandlePoints = vtkSmartPointer<vtkPolyData>::New();
+    }
+
+    //----------------------------------------------------------------------
+    virtual ~SliceIntersectionInteractionDisplayPipeline()
+    {
+      this->SetAndObserveSliceLogic(nullptr, nullptr);
+    }
+
+    //----------------------------------------------------------------------
+    void CreateRotationHandles()
+      {
+      // Create list of points to store position of handles
+      this->RotationHandle1Points = vtkSmartPointer<vtkPoints>::New();
+      this->RotationHandle2Points = vtkSmartPointer<vtkPoints>::New();
+
+      // We don't know if there is enough space, will set it later.
+      this->RotationHandle1Displayable = false;
+      this->RotationHandle2Displayable = false;
+
+      // Handle default position and orientation
+      double handleOriginDefault[3] = { ROTATION_HANDLE_DEFAULT_POSITION[0],
+                                        ROTATION_HANDLE_DEFAULT_POSITION[1],
+                                        ROTATION_HANDLE_DEFAULT_POSITION[2] };
+      double handleOrientationDefault[3] = { ROTATION_HANDLE_DEFAULT_ORIENTATION[0],
+                                             ROTATION_HANDLE_DEFAULT_ORIENTATION[1],
+                                             ROTATION_HANDLE_DEFAULT_ORIENTATION[2] };
+      double handleOrientationDefaultInv[3] = { -ROTATION_HANDLE_DEFAULT_ORIENTATION[0],
+                                                -ROTATION_HANDLE_DEFAULT_ORIENTATION[1],
+                                                -ROTATION_HANDLE_DEFAULT_ORIENTATION[2] };
+      double handleOrientationPerpendicular[3] = { ROTATION_HANDLE_DEFAULT_ORIENTATION[1],
+                                                   -ROTATION_HANDLE_DEFAULT_ORIENTATION[0],
+                                                   ROTATION_HANDLE_DEFAULT_ORIENTATION[2] };
+
+      if (HANDLES_TYPE == Arrows)
+        {
+        // Define cone size
+        double coneAngleRad = (ROTATION_HANDLE_ARROW_TIP_ANGLE * M_PI) / 180.0;
+        double coneRadius = 2 * ROTATION_HANDLE_ARROW_RADIUS;
+        double coneLength = coneRadius / tan(coneAngleRad);
+
+        // Define arc points
+        double arcTipR[3] = { handleOrientationDefault[0], handleOrientationDefault[1], handleOrientationDefault[2] };
+        vtkMath::MultiplyScalar(arcTipR, ROTATION_HANDLE_ARROW_LENGTH / 2.0);
+        double arcTipL[3] = { handleOrientationDefaultInv[0], handleOrientationDefaultInv[1], handleOrientationDefaultInv[2] };
+        vtkMath::MultiplyScalar(arcTipL, ROTATION_HANDLE_ARROW_LENGTH / 2.0);
+        double arcCenter[3] = { handleOrientationPerpendicular[0], handleOrientationPerpendicular[1], handleOrientationPerpendicular[2] };
+        vtkMath::MultiplyScalar(arcCenter, -ROTATION_HANDLE_ARROW_LENGTH / 3.0);
+
+        // Translate arc to origin
+        double arcRadiusVector[3] = { arcTipR[0] - arcCenter[0], arcTipR[1] - arcCenter[1], arcTipR[2] - arcCenter[2] };
+        double arcRadius = vtkMath::Norm(arcRadiusVector);
+        double arcChordVector[3] = { arcTipR[0] - arcTipL[0], arcTipR[1] - arcTipL[1], arcTipR[2] - arcTipL[2] };
+        double arcChord = vtkMath::Norm(arcChordVector);
+        double arcSagitta1 = arcRadius + sqrt(pow(arcRadius,2) - pow(arcChord / 2, 2));
+        double arcSagitta2 = arcRadius - sqrt(pow(arcRadius, 2) - pow(arcChord / 2, 2));
+        double arcSagitta[3] = { handleOrientationPerpendicular[0], handleOrientationPerpendicular[1], handleOrientationPerpendicular[2] };
+        if (arcSagitta1 > arcSagitta2) // keep shortest sagitta
+          {
+          vtkMath::MultiplyScalar(arcSagitta, arcSagitta2);
+          }
+        else // keep shortest sagitta
+          {
+          vtkMath::MultiplyScalar(arcSagitta, arcSagitta1);
+          }
+        arcTipR[0] = arcTipR[0] - arcSagitta[0];
+        arcTipR[1] = arcTipR[1] - arcSagitta[1];
+        arcTipR[2] = arcTipR[2] - arcSagitta[2];
+        arcTipL[0] = arcTipL[0] - arcSagitta[0];
+        arcTipL[1] = arcTipL[1] - arcSagitta[1];
+        arcTipL[2] = arcTipL[2] - arcSagitta[2];
+        arcCenter[0] = arcCenter[0] - arcSagitta[0];
+        arcCenter[1] = arcCenter[1] - arcSagitta[1];
+        arcCenter[2] = arcCenter[2] - arcSagitta[2];
+
+        // Define intermediate points for interaction
+        double arcMidR[3] = { arcTipR[0] / 2.0, arcTipR[1] / 2.0, arcTipR[2] / 2.0 };
+        double arcMidL[3] = { arcTipL[0] / 2.0, arcTipL[1] / 2.0, arcTipL[2] / 2.0 };
+
+        // Define arc tangent vectors
+        double arcRadiusVectorR[3] = { arcTipR[0] - arcCenter[0], arcTipR[1] - arcCenter[1], arcTipR[2] - arcCenter[2] };
+        double arcRadiusVectorL[3] = { arcTipL[0] - arcCenter[0], arcTipL[1] - arcCenter[1], arcTipL[2] - arcCenter[2] };
+        double arcTangentVectorR[3] = { -arcRadiusVectorR[1], arcRadiusVectorR[0], 0.0 };
+        double arcTangentVectorL[3] = { arcRadiusVectorL[1], -arcRadiusVectorL[0], 0.0 };
+        vtkMath::Normalize(arcTangentVectorR);
+        vtkMath::Normalize(arcTangentVectorL);
+
+        // Define cone positions to construct arrows
+        double coneCenterR[3] = { arcTipR[0] + arcTangentVectorR[0] * (coneLength / 2.0),
+                                  arcTipR[1] + arcTangentVectorR[1] * (coneLength / 2.0),
+                                  arcTipR[2] + arcTangentVectorR[2] * (coneLength / 2.0) };
+        double coneCenterL[3] = { arcTipL[0] + arcTangentVectorL[0] * (coneLength / 2.0),
+                                  arcTipL[1] + arcTangentVectorL[1] * (coneLength / 2.0),
+                                  arcTipL[2] + arcTangentVectorL[2] * (coneLength / 2.0) };
+
+        // Rotation handle 1
+        vtkNew<vtkArcSource> rotationHandle1ArcSource;
+        rotationHandle1ArcSource->SetResolution(50);
+        rotationHandle1ArcSource->SetPoint1(arcTipR);
+        rotationHandle1ArcSource->SetPoint2(arcTipL);
+        rotationHandle1ArcSource->SetCenter(arcCenter);
+        vtkNew<vtkTubeFilter> rotationHandle1ArcTubeFilter;
+        rotationHandle1ArcTubeFilter->SetInputConnection(rotationHandle1ArcSource->GetOutputPort());
+        rotationHandle1ArcTubeFilter->SetRadius(ROTATION_HANDLE_ARROW_RADIUS);
+        rotationHandle1ArcTubeFilter->SetNumberOfSides(16);
+        rotationHandle1ArcTubeFilter->SetCapping(true);
+        vtkNew<vtkConeSource> rotationHandle1RightConeSource;
+        rotationHandle1RightConeSource->SetResolution(50);
+        rotationHandle1RightConeSource->SetRadius(coneRadius);
+        rotationHandle1RightConeSource->SetDirection(arcTangentVectorR);
+        rotationHandle1RightConeSource->SetHeight(coneLength);
+        rotationHandle1RightConeSource->SetCenter(coneCenterR);
+        vtkNew<vtkConeSource> rotationHandle1LeftConeSource;
+        rotationHandle1LeftConeSource->SetResolution(50);
+        rotationHandle1LeftConeSource->SetRadius(coneRadius);
+        rotationHandle1LeftConeSource->SetDirection(arcTangentVectorL);
+        rotationHandle1LeftConeSource->SetHeight(coneLength);
+        rotationHandle1LeftConeSource->SetCenter(coneCenterL);
+        this->RotationHandle1 = vtkSmartPointer<vtkAppendPolyData>::New();
+        this->RotationHandle1->AddInputConnection(rotationHandle1ArcTubeFilter->GetOutputPort());
+        this->RotationHandle1->AddInputConnection(rotationHandle1RightConeSource->GetOutputPort());
+        this->RotationHandle1->AddInputConnection(rotationHandle1LeftConeSource->GetOutputPort());
+        this->RotationHandle1ToWorldTransform = vtkSmartPointer<vtkTransform>::New();
+        this->RotationHandle1TransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+        this->RotationHandle1TransformFilter->SetInputConnection(this->RotationHandle1->GetOutputPort());
+        this->RotationHandle1TransformFilter->SetTransform(this->RotationHandle1ToWorldTransform);
+        this->RotationHandle1Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+        this->RotationHandle1Property = vtkSmartPointer<vtkProperty2D>::New();
+        this->RotationHandle1Actor = vtkSmartPointer<vtkActor2D>::New();
+        this->RotationHandle1Actor->SetVisibility(false); // invisible until slice node is set
+        this->RotationHandle1Mapper->SetInputConnection(this->RotationHandle1TransformFilter->GetOutputPort());
+        this->RotationHandle1Actor->SetMapper(this->RotationHandle1Mapper);
+        this->RotationHandle1Actor->SetProperty(this->RotationHandle1Property);
+
+        // Rotation handle 2
+        vtkNew<vtkArcSource> rotationHandle2ArcSource;
+        rotationHandle2ArcSource->SetResolution(50);
+        rotationHandle2ArcSource->SetPoint1(arcTipR);
+        rotationHandle2ArcSource->SetPoint2(arcTipL);
+        rotationHandle2ArcSource->SetCenter(arcCenter);
+        vtkNew<vtkTubeFilter> rotationHandle2ArcTubeFilter;
+        rotationHandle2ArcTubeFilter->SetInputConnection(rotationHandle2ArcSource->GetOutputPort());
+        rotationHandle2ArcTubeFilter->SetRadius(ROTATION_HANDLE_ARROW_RADIUS);
+        rotationHandle2ArcTubeFilter->SetNumberOfSides(16);
+        rotationHandle2ArcTubeFilter->SetCapping(true);
+        vtkNew<vtkConeSource> rotationHandle2RightConeSource;
+        rotationHandle2RightConeSource->SetResolution(50);
+        rotationHandle2RightConeSource->SetRadius(coneRadius);
+        rotationHandle2RightConeSource->SetDirection(arcTangentVectorR);
+        rotationHandle2RightConeSource->SetHeight(coneLength);
+        rotationHandle2RightConeSource->SetCenter(coneCenterR);
+        vtkNew<vtkConeSource> rotationHandle2LeftConeSource;
+        rotationHandle2LeftConeSource->SetResolution(50);
+        rotationHandle2LeftConeSource->SetRadius(coneRadius);
+        rotationHandle2LeftConeSource->SetDirection(arcTangentVectorL);
+        rotationHandle2LeftConeSource->SetHeight(coneLength);
+        rotationHandle2LeftConeSource->SetCenter(coneCenterL);
+        this->RotationHandle2 = vtkSmartPointer<vtkAppendPolyData>::New();
+        this->RotationHandle2->AddInputConnection(rotationHandle2ArcTubeFilter->GetOutputPort());
+        this->RotationHandle2->AddInputConnection(rotationHandle2RightConeSource->GetOutputPort());
+        this->RotationHandle2->AddInputConnection(rotationHandle2LeftConeSource->GetOutputPort());
+        this->RotationHandle2ToWorldTransform = vtkSmartPointer<vtkTransform>::New();
+        this->RotationHandle2TransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+        this->RotationHandle2TransformFilter->SetInputConnection(this->RotationHandle2->GetOutputPort());
+        this->RotationHandle2TransformFilter->SetTransform(this->RotationHandle2ToWorldTransform);
+        this->RotationHandle2Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+        this->RotationHandle2Property = vtkSmartPointer<vtkProperty2D>::New();
+        this->RotationHandle2Actor = vtkSmartPointer<vtkActor2D>::New();
+        this->RotationHandle2Actor->SetVisibility(false); // invisible until slice node is set
+        this->RotationHandle2Mapper->SetInputConnection(this->RotationHandle2TransformFilter->GetOutputPort());
+        this->RotationHandle2Actor->SetMapper(this->RotationHandle2Mapper);
+        this->RotationHandle2Actor->SetProperty(this->RotationHandle2Property);
+
+        // Handle points
+        this->RotationHandle1Points->InsertNextPoint(handleOriginDefault);
+        this->RotationHandle1Points->InsertNextPoint(arcTipR);
+        this->RotationHandle1Points->InsertNextPoint(arcMidR);
+        this->RotationHandle1Points->InsertNextPoint(coneCenterR);
+        this->RotationHandle1Points->InsertNextPoint(arcTipL);
+        this->RotationHandle1Points->InsertNextPoint(arcMidL);
+        this->RotationHandle1Points->InsertNextPoint(coneCenterL);
+        this->RotationHandle2Points->InsertNextPoint(handleOriginDefault);
+        this->RotationHandle2Points->InsertNextPoint(arcTipR);
+        this->RotationHandle2Points->InsertNextPoint(arcMidR);
+        this->RotationHandle2Points->InsertNextPoint(coneCenterR);
+        this->RotationHandle2Points->InsertNextPoint(arcTipL);
+        this->RotationHandle2Points->InsertNextPoint(arcMidL);
+        this->RotationHandle2Points->InsertNextPoint(coneCenterL);
+        }
+      else if (HANDLES_TYPE == Circles)
+        {
+        // Rotation sphere 1
+        vtkNew<vtkSphereSource> rotationHandle1SphereSource;
+        rotationHandle1SphereSource->SetRadius(ROTATION_HANDLE_CIRCLE_RADIUS);
+        rotationHandle1SphereSource->SetThetaResolution(HANDLES_CIRCLE_THETA_RESOLUTION);
+        rotationHandle1SphereSource->SetPhiResolution(HANDLES_CIRCLE_PHI_RESOLUTION);
+        rotationHandle1SphereSource->SetCenter(handleOriginDefault);
+        rotationHandle1SphereSource->Update();
+        this->RotationHandle1 = vtkSmartPointer<vtkAppendPolyData>::New();
+        this->RotationHandle1->AddInputConnection(rotationHandle1SphereSource->GetOutputPort());
+        this->RotationHandle1ToWorldTransform = vtkSmartPointer<vtkTransform>::New();
+        this->RotationHandle1TransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+        this->RotationHandle1TransformFilter->SetInputConnection(this->RotationHandle1->GetOutputPort());
+        this->RotationHandle1TransformFilter->SetTransform(this->RotationHandle1ToWorldTransform);
+        this->RotationHandle1Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+        this->RotationHandle1Property = vtkSmartPointer<vtkProperty2D>::New();
+        this->RotationHandle1Actor = vtkSmartPointer<vtkActor2D>::New();
+        this->RotationHandle1Actor->SetVisibility(false); // invisible until slice node is set
+        this->RotationHandle1Mapper->SetInputConnection(this->RotationHandle1TransformFilter->GetOutputPort());
+        this->RotationHandle1Actor->SetMapper(this->RotationHandle1Mapper);
+        this->RotationHandle1Actor->SetProperty(this->RotationHandle1Property);
+
+        // Rotation sphere 2
+        vtkNew<vtkSphereSource> rotationHandle2SphereSource;
+        rotationHandle2SphereSource->SetRadius(ROTATION_HANDLE_CIRCLE_RADIUS);
+        rotationHandle2SphereSource->SetThetaResolution(HANDLES_CIRCLE_THETA_RESOLUTION);
+        rotationHandle2SphereSource->SetPhiResolution(HANDLES_CIRCLE_PHI_RESOLUTION);
+        rotationHandle2SphereSource->SetCenter(handleOriginDefault);
+        rotationHandle2SphereSource->Update();
+        this->RotationHandle2 = vtkSmartPointer<vtkAppendPolyData>::New();
+        this->RotationHandle2->AddInputConnection(rotationHandle2SphereSource->GetOutputPort());
+        this->RotationHandle2ToWorldTransform = vtkSmartPointer<vtkTransform>::New();
+        this->RotationHandle2TransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+        this->RotationHandle2TransformFilter->SetInputConnection(this->RotationHandle2->GetOutputPort());
+        this->RotationHandle2TransformFilter->SetTransform(this->RotationHandle2ToWorldTransform);
+        this->RotationHandle2Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+        this->RotationHandle2Property = vtkSmartPointer<vtkProperty2D>::New();
+        this->RotationHandle2Actor = vtkSmartPointer<vtkActor2D>::New();
+        this->RotationHandle2Actor->SetVisibility(false); // invisible until slice node is set
+        this->RotationHandle2Mapper->SetInputConnection(this->RotationHandle2TransformFilter->GetOutputPort());
+        this->RotationHandle2Actor->SetMapper(this->RotationHandle2Mapper);
+        this->RotationHandle2Actor->SetProperty(this->RotationHandle2Property);
+
+        // Handle points
+        this->RotationHandle1Points->InsertNextPoint(handleOriginDefault);
+        this->RotationHandle2Points->InsertNextPoint(handleOriginDefault);
+        }
+      }
+
+    //----------------------------------------------------------------------
+    void CreateSliceOffsetHandles()
+    {
+      // Create list of points to store position of handles
+      this->SliceOffsetHandle1Points = vtkSmartPointer<vtkPoints>::New();
+      this->SliceOffsetHandle2Points = vtkSmartPointer<vtkPoints>::New();
+
+      // We don't know if there is enough space, will set it later.
+      this->SliceOffsetHandle1Displayable = false;
+      this->SliceOffsetHandle2Displayable = false;
+
+      // Handle default position and orientation
+      double handleOriginDefault[3] = { SLICEOFSSET_HANDLE_DEFAULT_POSITION[0],
+                                        SLICEOFSSET_HANDLE_DEFAULT_POSITION[1],
+                                        SLICEOFSSET_HANDLE_DEFAULT_POSITION[2] };
+      double handleOrientationDefault[3] = { SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION[0],
+                                             SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION[1],
+                                             SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION[2] };
+      double handleOrientationDefaultInv[3] = { -SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION[0],
+                                                -SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION[1],
+                                                -SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION[2] };
+
+      if (HANDLES_TYPE == Arrows)
+        {
+        // Define cone size
+        double coneAngleRad = (SLICEOFSSET_HANDLE_ARROW_TIP_ANGLE * M_PI) / 180.0;
+        double coneRadius = 2 * SLICEOFSSET_HANDLE_ARROW_RADIUS;
+        double coneLength = coneRadius / tan(coneAngleRad);
+
+        // Define cylinder size
+        double cylinderLength = SLICEOFSSET_HANDLE_ARROW_LENGTH - coneLength * 2;
+        double cylinderRadius = SLICEOFSSET_HANDLE_ARROW_RADIUS;
+
+        // Define cone positions to construct arrows
+        double coneCenterR[3] = { handleOrientationDefault[0], handleOrientationDefault[1], handleOrientationDefault[2] };
+        vtkMath::MultiplyScalar(coneCenterR, cylinderLength / 2 + coneLength / 2);
+        double coneTipR[3] = { handleOrientationDefault[0], handleOrientationDefault[1], handleOrientationDefault[2] };
+        vtkMath::MultiplyScalar(coneTipR, cylinderLength / 2 + coneLength);
+        double coneBaseR[3] = { handleOrientationDefault[0], handleOrientationDefault[1], handleOrientationDefault[2] };
+        vtkMath::MultiplyScalar(coneBaseR, cylinderLength / 2);
+        double coneCenterL[3] = { handleOrientationDefaultInv[0], handleOrientationDefaultInv[1], handleOrientationDefaultInv[2] };
+        vtkMath::MultiplyScalar(coneCenterL, cylinderLength / 2 + coneLength / 2);
+        double coneTipL[3] = { handleOrientationDefaultInv[0], handleOrientationDefaultInv[1], handleOrientationDefaultInv[2] };
+        vtkMath::MultiplyScalar(coneTipL, cylinderLength / 2 + coneLength);
+        double coneBaseL[3] = { handleOrientationDefaultInv[0], handleOrientationDefaultInv[1], handleOrientationDefaultInv[2] };
+        vtkMath::MultiplyScalar(coneBaseL, cylinderLength / 2);
+
+        // Translation handle 1
+        vtkNew<vtkLineSource> sliceOffsetHandle1LineSource;
+        sliceOffsetHandle1LineSource->SetResolution(50);
+        sliceOffsetHandle1LineSource->SetPoint1(coneBaseR);
+        sliceOffsetHandle1LineSource->SetPoint2(coneBaseL);
+        vtkNew<vtkTubeFilter> sliceOffsetHandle1LineTubeFilter;
+        sliceOffsetHandle1LineTubeFilter->SetInputConnection(sliceOffsetHandle1LineSource->GetOutputPort());
+        sliceOffsetHandle1LineTubeFilter->SetRadius(SLICEOFSSET_HANDLE_ARROW_RADIUS);
+        sliceOffsetHandle1LineTubeFilter->SetNumberOfSides(16);
+        sliceOffsetHandle1LineTubeFilter->SetCapping(true);
+        vtkNew<vtkConeSource> sliceOffsetHandle1RightConeSource;
+        sliceOffsetHandle1RightConeSource->SetResolution(50);
+        sliceOffsetHandle1RightConeSource->SetRadius(coneRadius);
+        sliceOffsetHandle1RightConeSource->SetDirection(handleOrientationDefault);
+        sliceOffsetHandle1RightConeSource->SetHeight(coneLength);
+        sliceOffsetHandle1RightConeSource->SetCenter(coneCenterR);
+        vtkNew<vtkConeSource> sliceOffsetHandle1LeftConeSource;
+        sliceOffsetHandle1LeftConeSource->SetResolution(50);
+        sliceOffsetHandle1LeftConeSource->SetRadius(coneRadius);
+        sliceOffsetHandle1LeftConeSource->SetDirection(handleOrientationDefaultInv);
+        sliceOffsetHandle1LeftConeSource->SetHeight(coneLength);
+        sliceOffsetHandle1LeftConeSource->SetCenter(coneCenterL);
+        this->SliceOffsetHandle1 = vtkSmartPointer<vtkAppendPolyData>::New();
+        this->SliceOffsetHandle1->AddInputConnection(sliceOffsetHandle1LineTubeFilter->GetOutputPort());
+        this->SliceOffsetHandle1->AddInputConnection(sliceOffsetHandle1RightConeSource->GetOutputPort());
+        this->SliceOffsetHandle1->AddInputConnection(sliceOffsetHandle1LeftConeSource->GetOutputPort());
+        this->SliceOffsetHandle1ToWorldTransform = vtkSmartPointer<vtkTransform>::New();
+        this->SliceOffsetHandle1TransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+        this->SliceOffsetHandle1TransformFilter->SetInputConnection(this->SliceOffsetHandle1->GetOutputPort());
+        this->SliceOffsetHandle1TransformFilter->SetTransform(this->SliceOffsetHandle1ToWorldTransform);
+        this->SliceOffsetHandle1Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+        this->SliceOffsetHandle1Property = vtkSmartPointer<vtkProperty2D>::New();
+        this->SliceOffsetHandle1Actor = vtkSmartPointer<vtkActor2D>::New();
+        this->SliceOffsetHandle1Actor->SetVisibility(false); // invisible until slice node is set
+        this->SliceOffsetHandle1Mapper->SetInputConnection(this->SliceOffsetHandle1TransformFilter->GetOutputPort());
+        this->SliceOffsetHandle1Actor->SetMapper(this->SliceOffsetHandle1Mapper);
+        this->SliceOffsetHandle1Actor->SetProperty(this->SliceOffsetHandle1Property);
+
+        // Translation handle 2
+        vtkNew<vtkLineSource> sliceOffsetHandle2LineSource;
+        sliceOffsetHandle2LineSource->SetResolution(50);
+        sliceOffsetHandle2LineSource->SetPoint1(coneBaseR);
+        sliceOffsetHandle2LineSource->SetPoint2(coneBaseL);
+        vtkNew<vtkTubeFilter> sliceOffsetHandle2LineTubeFilter;
+        sliceOffsetHandle2LineTubeFilter->SetInputConnection(sliceOffsetHandle2LineSource->GetOutputPort());
+        sliceOffsetHandle2LineTubeFilter->SetRadius(SLICEOFSSET_HANDLE_ARROW_RADIUS);
+        sliceOffsetHandle2LineTubeFilter->SetNumberOfSides(16);
+        sliceOffsetHandle2LineTubeFilter->SetCapping(true);
+        vtkNew<vtkConeSource> sliceOffsetHandle2RightConeSource;
+        sliceOffsetHandle2RightConeSource->SetResolution(50);
+        sliceOffsetHandle2RightConeSource->SetRadius(coneRadius);
+        sliceOffsetHandle2RightConeSource->SetDirection(handleOrientationDefault);
+        sliceOffsetHandle2RightConeSource->SetHeight(coneLength);
+        sliceOffsetHandle2RightConeSource->SetCenter(coneCenterR);
+        vtkNew<vtkConeSource> sliceOffsetHandle2LeftConeSource;
+        sliceOffsetHandle2LeftConeSource->SetResolution(50);
+        sliceOffsetHandle2LeftConeSource->SetRadius(coneRadius);
+        sliceOffsetHandle2LeftConeSource->SetDirection(handleOrientationDefaultInv);
+        sliceOffsetHandle2LeftConeSource->SetHeight(coneLength);
+        sliceOffsetHandle2LeftConeSource->SetCenter(coneCenterL);
+        this->SliceOffsetHandle2 = vtkSmartPointer<vtkAppendPolyData>::New();
+        this->SliceOffsetHandle2->AddInputConnection(sliceOffsetHandle2LineTubeFilter->GetOutputPort());
+        this->SliceOffsetHandle2->AddInputConnection(sliceOffsetHandle2RightConeSource->GetOutputPort());
+        this->SliceOffsetHandle2->AddInputConnection(sliceOffsetHandle2LeftConeSource->GetOutputPort());
+        this->SliceOffsetHandle2ToWorldTransform = vtkSmartPointer<vtkTransform>::New();
+        this->SliceOffsetHandle2TransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+        this->SliceOffsetHandle2TransformFilter->SetInputConnection(this->SliceOffsetHandle2->GetOutputPort());
+        this->SliceOffsetHandle2TransformFilter->SetTransform(this->SliceOffsetHandle2ToWorldTransform);
+        this->SliceOffsetHandle2Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+        this->SliceOffsetHandle2Property = vtkSmartPointer<vtkProperty2D>::New();
+        this->SliceOffsetHandle2Actor = vtkSmartPointer<vtkActor2D>::New();
+        this->SliceOffsetHandle2Actor->SetVisibility(false); // invisible until slice node is set
+        this->SliceOffsetHandle2Mapper->SetInputConnection(this->SliceOffsetHandle2TransformFilter->GetOutputPort());
+        this->SliceOffsetHandle2Actor->SetMapper(this->SliceOffsetHandle2Mapper);
+        this->SliceOffsetHandle2Actor->SetProperty(this->SliceOffsetHandle2Property);
+
+        // Handle points
+        this->SliceOffsetHandle1Points->InsertNextPoint(handleOriginDefault);
+        this->SliceOffsetHandle1Points->InsertNextPoint(coneTipR);
+        this->SliceOffsetHandle1Points->InsertNextPoint(coneCenterR);
+        this->SliceOffsetHandle1Points->InsertNextPoint(coneBaseR);
+        this->SliceOffsetHandle1Points->InsertNextPoint(coneTipL);
+        this->SliceOffsetHandle1Points->InsertNextPoint(coneCenterL);
+        this->SliceOffsetHandle1Points->InsertNextPoint(coneBaseL);
+        this->SliceOffsetHandle2Points->InsertNextPoint(handleOriginDefault);
+        this->SliceOffsetHandle2Points->InsertNextPoint(coneTipR);
+        this->SliceOffsetHandle2Points->InsertNextPoint(coneCenterR);
+        this->SliceOffsetHandle2Points->InsertNextPoint(coneBaseR);
+        this->SliceOffsetHandle2Points->InsertNextPoint(coneTipL);
+        this->SliceOffsetHandle2Points->InsertNextPoint(coneCenterL);
+        this->SliceOffsetHandle2Points->InsertNextPoint(coneBaseL);
+        }
+      else if (HANDLES_TYPE == Circles)
+        {
+        // Translation sphere 1
+        vtkNew<vtkSphereSource> sliceOffsetHandle1SphereSource;
+        sliceOffsetHandle1SphereSource->SetRadius(SLICEOFSSET_HANDLE_CIRCLE_RADIUS);
+        sliceOffsetHandle1SphereSource->SetThetaResolution(HANDLES_CIRCLE_THETA_RESOLUTION);
+        sliceOffsetHandle1SphereSource->SetPhiResolution(HANDLES_CIRCLE_PHI_RESOLUTION);
+        sliceOffsetHandle1SphereSource->SetCenter(handleOriginDefault);
+        sliceOffsetHandle1SphereSource->Update();
+        this->SliceOffsetHandle1 = vtkSmartPointer<vtkAppendPolyData>::New();
+        this->SliceOffsetHandle1->AddInputConnection(sliceOffsetHandle1SphereSource->GetOutputPort());
+        this->SliceOffsetHandle1ToWorldTransform = vtkSmartPointer<vtkTransform>::New();
+        this->SliceOffsetHandle1TransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+        this->SliceOffsetHandle1TransformFilter->SetInputConnection(this->SliceOffsetHandle1->GetOutputPort());
+        this->SliceOffsetHandle1TransformFilter->SetTransform(this->SliceOffsetHandle1ToWorldTransform);
+        this->SliceOffsetHandle1Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+        this->SliceOffsetHandle1Property = vtkSmartPointer<vtkProperty2D>::New();
+        this->SliceOffsetHandle1Actor = vtkSmartPointer<vtkActor2D>::New();
+        this->SliceOffsetHandle1Actor->SetVisibility(false); // invisible until slice node is set
+        this->SliceOffsetHandle1Mapper->SetInputConnection(this->SliceOffsetHandle1TransformFilter->GetOutputPort());
+        this->SliceOffsetHandle1Actor->SetMapper(this->SliceOffsetHandle1Mapper);
+        this->SliceOffsetHandle1Actor->SetProperty(this->SliceOffsetHandle1Property);
+
+        // Translation sphere 2
+        vtkNew<vtkSphereSource> sliceOffsetHandle2SphereSource;
+        sliceOffsetHandle2SphereSource->SetRadius(SLICEOFSSET_HANDLE_CIRCLE_RADIUS);
+        sliceOffsetHandle2SphereSource->SetThetaResolution(HANDLES_CIRCLE_THETA_RESOLUTION);
+        sliceOffsetHandle2SphereSource->SetPhiResolution(HANDLES_CIRCLE_PHI_RESOLUTION);
+        sliceOffsetHandle2SphereSource->SetCenter(handleOriginDefault);
+        sliceOffsetHandle2SphereSource->Update();
+        this->SliceOffsetHandle2 = vtkSmartPointer<vtkAppendPolyData>::New();
+        this->SliceOffsetHandle2->AddInputConnection(sliceOffsetHandle2SphereSource->GetOutputPort());
+        this->SliceOffsetHandle2ToWorldTransform = vtkSmartPointer<vtkTransform>::New();
+        this->SliceOffsetHandle2TransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+        this->SliceOffsetHandle2TransformFilter->SetInputConnection(this->SliceOffsetHandle2->GetOutputPort());
+        this->SliceOffsetHandle2TransformFilter->SetTransform(this->SliceOffsetHandle2ToWorldTransform);
+        this->SliceOffsetHandle2Mapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+        this->SliceOffsetHandle2Property = vtkSmartPointer<vtkProperty2D>::New();
+        this->SliceOffsetHandle2Actor = vtkSmartPointer<vtkActor2D>::New();
+        this->SliceOffsetHandle2Actor->SetVisibility(false); // invisible until slice node is set
+        this->SliceOffsetHandle2Mapper->SetInputConnection(this->SliceOffsetHandle2TransformFilter->GetOutputPort());
+        this->SliceOffsetHandle2Actor->SetMapper(this->SliceOffsetHandle2Mapper);
+        this->SliceOffsetHandle2Actor->SetProperty(this->SliceOffsetHandle2Property);
+
+        // Handle points
+        this->SliceOffsetHandle1Points->InsertNextPoint(handleOriginDefault);
+        this->SliceOffsetHandle2Points->InsertNextPoint(handleOriginDefault);
+        }
+    }
+
+    //----------------------------------------------------------------------
+    void SetAndObserveSliceLogic(vtkMRMLSliceLogic* sliceLogic, vtkCallbackCommand* callback)
+    {
+      if (sliceLogic != this->SliceLogic || callback != this->Callback)
+        {
+        if (this->SliceLogic && this->Callback)
+          {
+          this->SliceLogic->RemoveObserver(this->Callback);
+          }
+        if (sliceLogic)
+          {
+          sliceLogic->AddObserver(vtkCommand::ModifiedEvent, callback);
+          sliceLogic->AddObserver(vtkMRMLSliceLogic::CompositeModifiedEvent, callback);
+          }
+        this->SliceLogic = sliceLogic;
+        }
+      this->Callback = callback;
+    }
+
+    //----------------------------------------------------------------------
+    void GetActors2D(vtkPropCollection* pc)
+    {
+      pc->AddItem(this->IntersectionLine1Actor);
+      pc->AddItem(this->IntersectionLine2Actor);
+      pc->AddItem(this->TranslationOuterHandleActor);
+      pc->AddItem(this->TranslationInnerHandleActor);
+      pc->AddItem(this->RotationHandle1Actor);
+      pc->AddItem(this->RotationHandle2Actor);
+      pc->AddItem(this->SliceOffsetHandle1Actor);
+      pc->AddItem(this->SliceOffsetHandle2Actor);
+    }
+
+    //----------------------------------------------------------------------
+    void AddActors(vtkRenderer* renderer)
+    {
+      if (!renderer)
+        {
+        return;
+        }
+      renderer->AddViewProp(this->IntersectionLine1Actor);
+      renderer->AddViewProp(this->IntersectionLine2Actor);
+      renderer->AddViewProp(this->TranslationOuterHandleActor);
+      renderer->AddViewProp(this->TranslationInnerHandleActor);
+      renderer->AddViewProp(this->RotationHandle1Actor);
+      renderer->AddViewProp(this->RotationHandle2Actor);
+      renderer->AddViewProp(this->SliceOffsetHandle1Actor);
+      renderer->AddViewProp(this->SliceOffsetHandle2Actor);
+    }
+
+    //----------------------------------------------------------------------
+    void ReleaseGraphicsResources(vtkWindow* win)
+    {
+      this->IntersectionLine1Actor->ReleaseGraphicsResources(win);
+      this->IntersectionLine2Actor->ReleaseGraphicsResources(win);
+      this->TranslationOuterHandleActor->ReleaseGraphicsResources(win);
+      this->TranslationInnerHandleActor->ReleaseGraphicsResources(win);
+      this->RotationHandle1Actor->ReleaseGraphicsResources(win);
+      this->RotationHandle2Actor->ReleaseGraphicsResources(win);
+      this->SliceOffsetHandle1Actor->ReleaseGraphicsResources(win);
+      this->SliceOffsetHandle2Actor->ReleaseGraphicsResources(win);
+    }
+
+    //----------------------------------------------------------------------
+    void RemoveActors(vtkRenderer* renderer)
+    {
+      if (!renderer)
+        {
+        return;
+        }
+      renderer->RemoveViewProp(this->IntersectionLine1Actor);
+      renderer->RemoveViewProp(this->IntersectionLine2Actor);
+      renderer->RemoveViewProp(this->TranslationOuterHandleActor);
+      renderer->RemoveViewProp(this->TranslationInnerHandleActor);
+      renderer->RemoveViewProp(this->RotationHandle1Actor);
+      renderer->RemoveViewProp(this->RotationHandle2Actor);
+      renderer->RemoveViewProp(this->SliceOffsetHandle1Actor);
+      renderer->RemoveViewProp(this->SliceOffsetHandle2Actor);
+    }
+
+    //----------------------------------------------------------------------
+    int RenderOverlay(vtkViewport* viewport)
+    {
+      int count = 0;
+      if (this->IntersectionLine1Actor->GetVisibility())
+        {
+        this->IntersectionLine1Actor->RenderOverlay(viewport);
+        }
+      if (this->IntersectionLine2Actor->GetVisibility())
+        {
+      this->IntersectionLine2Actor->RenderOverlay(viewport);
+        }
+      if (this->TranslationOuterHandleActor->GetVisibility())
+        {
+        this->TranslationOuterHandleActor->RenderOverlay(viewport);
+        }
+      if (this->TranslationInnerHandleActor->GetVisibility())
+        {
+        this->TranslationInnerHandleActor->RenderOverlay(viewport);
+        }
+      if (this->RotationHandle1Actor->GetVisibility())
+        {
+        this->RotationHandle1Actor->RenderOverlay(viewport);
+        }
+      if (this->RotationHandle2Actor->GetVisibility())
+        {
+        this->RotationHandle2Actor->RenderOverlay(viewport);
+        }
+      if (this->SliceOffsetHandle1Actor->GetVisibility())
+        {
+        this->SliceOffsetHandle1Actor->RenderOverlay(viewport);
+        }
+      if (this->SliceOffsetHandle2Actor->GetVisibility())
+        {
+        this->SliceOffsetHandle2Actor->RenderOverlay(viewport);
+        }
+      this->NeedToRender = false;
+      return count;
+    }
+
+    //----------------------------------------------------------------------
+    void SetIntersectionsVisibility(bool visibility)
+      {
+      if (static_cast<bool>(this->IntersectionLine1Actor->GetVisibility()) != visibility
+        || static_cast<bool>(this->IntersectionLine2Actor->GetVisibility()) != visibility)
+        {
+        this->NeedToRender = true;
+        }
+      this->IntersectionLine1Actor->SetVisibility(visibility);
+      this->IntersectionLine2Actor->SetVisibility(visibility);
+      }
+
+    //----------------------------------------------------------------------
+    void SetHandlesVisibility(bool visibility)
+      {
+      bool rotationHandle1Visible = visibility && (this->HandlesVisibilityMode != vtkMRMLSliceDisplayNode::NeverVisible)
+        && this->RotationHandlesVisible && this->RotationHandle1Displayable;
+      bool rotationHandle2Visible = visibility && (this->HandlesVisibilityMode != vtkMRMLSliceDisplayNode::NeverVisible)
+        && this->RotationHandlesVisible && this->RotationHandle2Displayable;
+      bool sliceOffsetHandle1Visible = visibility && (this->HandlesVisibilityMode != vtkMRMLSliceDisplayNode::NeverVisible)
+        && this->TranslationHandlesVisible && this->SliceOffsetHandle1Displayable;
+      bool sliceOffsetHandle2Visible = visibility && (this->HandlesVisibilityMode != vtkMRMLSliceDisplayNode::NeverVisible)
+        && this->TranslationHandlesVisible && this->SliceOffsetHandle2Displayable;
+      bool translationHandleVisible = visibility && (this->HandlesVisibilityMode != vtkMRMLSliceDisplayNode::NeverVisible)
+        && this->TranslationHandlesVisible && INTERSECTION_VISUALIZATION_MODE == ShowIntersection;
+
+      if (static_cast<bool>(this->RotationHandle1Actor->GetVisibility()) != rotationHandle1Visible
+        || static_cast<bool>(this->RotationHandle2Actor->GetVisibility()) != rotationHandle2Visible
+        || static_cast<bool>(this->SliceOffsetHandle1Actor->GetVisibility()) != sliceOffsetHandle1Visible
+        || static_cast<bool>(this->SliceOffsetHandle2Actor->GetVisibility()) != sliceOffsetHandle2Visible
+        || static_cast<bool>(this->TranslationOuterHandleActor->GetVisibility()) != translationHandleVisible
+        || static_cast<bool>(this->TranslationInnerHandleActor->GetVisibility()) != translationHandleVisible)
+        {
+        this->NeedToRender = true;
+        }
+      this->RotationHandle1Actor->SetVisibility(rotationHandle1Visible);
+      this->RotationHandle2Actor->SetVisibility(rotationHandle2Visible);
+      this->SliceOffsetHandle1Actor->SetVisibility(sliceOffsetHandle1Visible);
+      this->SliceOffsetHandle2Actor->SetVisibility(sliceOffsetHandle2Visible);
+      this->TranslationOuterHandleActor->SetVisibility(translationHandleVisible);
+      this->TranslationInnerHandleActor->SetVisibility(translationHandleVisible);
+      }
+
+    //----------------------------------------------------------------------
+    void SetHandlesOpacity(double opacity)
+      {
+      this->TranslationOuterHandleProperty->SetOpacity(opacity);
+      this->TranslationInnerHandleProperty->SetOpacity(opacity);
+      this->RotationHandle1Property->SetOpacity(opacity);
+      this->RotationHandle2Property->SetOpacity(opacity);
+      this->SliceOffsetHandle1Property->SetOpacity(opacity);
+      this->SliceOffsetHandle2Property->SetOpacity(opacity);
+      }
+
+    //----------------------------------------------------------------------
+    bool GetVisibility()
+    {
+      return this->IntersectionLine1Actor->GetVisibility();
+    }
+
+    vtkSmartPointer<vtkLineSource> IntersectionLine1;
+    vtkSmartPointer<vtkPolyDataMapper2D> IntersectionLine1Mapper;
+    vtkSmartPointer<vtkProperty2D> IntersectionLine1Property;
+    vtkSmartPointer<vtkActor2D> IntersectionLine1Actor;
+
+    vtkSmartPointer<vtkLineSource> IntersectionLine2;
+    vtkSmartPointer<vtkPolyDataMapper2D> IntersectionLine2Mapper;
+    vtkSmartPointer<vtkProperty2D> IntersectionLine2Property;
+    vtkSmartPointer<vtkActor2D> IntersectionLine2Actor;
+
+    vtkSmartPointer<vtkSphereSource> TranslationOuterHandle;
+    vtkSmartPointer<vtkPolyDataMapper2D> TranslationOuterHandleMapper;
+    vtkSmartPointer<vtkProperty2D> TranslationOuterHandleProperty;
+    vtkSmartPointer<vtkActor2D> TranslationOuterHandleActor;
+    vtkSmartPointer<vtkSphereSource> TranslationInnerHandle;
+    vtkSmartPointer<vtkPolyDataMapper2D> TranslationInnerHandleMapper;
+    vtkSmartPointer<vtkProperty2D> TranslationInnerHandleProperty;
+    vtkSmartPointer<vtkActor2D> TranslationInnerHandleActor;
+
+    vtkSmartPointer<vtkAppendPolyData> RotationHandle1;
+    vtkSmartPointer<vtkTransform> RotationHandle1ToWorldTransform;
+    vtkSmartPointer<vtkTransformPolyDataFilter> RotationHandle1TransformFilter;
+    vtkSmartPointer<vtkPolyDataMapper2D> RotationHandle1Mapper;
+    vtkSmartPointer<vtkProperty2D> RotationHandle1Property;
+    vtkSmartPointer<vtkActor2D> RotationHandle1Actor;
+
+    vtkSmartPointer<vtkAppendPolyData> RotationHandle2;
+    vtkSmartPointer<vtkTransform> RotationHandle2ToWorldTransform;
+    vtkSmartPointer<vtkTransformPolyDataFilter> RotationHandle2TransformFilter;
+    vtkSmartPointer<vtkPolyDataMapper2D> RotationHandle2Mapper;
+    vtkSmartPointer<vtkProperty2D> RotationHandle2Property;
+    vtkSmartPointer<vtkActor2D> RotationHandle2Actor;
+
+    vtkSmartPointer<vtkAppendPolyData> SliceOffsetHandle1;
+    vtkSmartPointer<vtkTransform> SliceOffsetHandle1ToWorldTransform;
+    vtkSmartPointer<vtkTransformPolyDataFilter> SliceOffsetHandle1TransformFilter;
+    vtkSmartPointer<vtkPolyDataMapper2D> SliceOffsetHandle1Mapper;
+    vtkSmartPointer<vtkProperty2D> SliceOffsetHandle1Property;
+    vtkSmartPointer<vtkActor2D> SliceOffsetHandle1Actor;
+
+    vtkSmartPointer<vtkAppendPolyData> SliceOffsetHandle2;
+    vtkSmartPointer<vtkTransform> SliceOffsetHandle2ToWorldTransform;
+    vtkSmartPointer<vtkTransformPolyDataFilter> SliceOffsetHandle2TransformFilter;
+    vtkSmartPointer<vtkPolyDataMapper2D> SliceOffsetHandle2Mapper;
+    vtkSmartPointer<vtkProperty2D> SliceOffsetHandle2Property;
+    vtkSmartPointer<vtkActor2D> SliceOffsetHandle2Actor;
+
+    vtkWeakPointer<vtkMRMLSliceLogic> SliceLogic;
+    vtkWeakPointer<vtkCallbackCommand> Callback;
+
+    vtkSmartPointer<vtkPolyData> RotationHandlePoints;
+    vtkSmartPointer<vtkPolyData> TranslationHandlePoints;
+    vtkSmartPointer<vtkPolyData> SliceOffsetHandlePoints;
+
+    vtkSmartPointer<vtkPoints> SliceOffsetHandle1Points;
+    vtkSmartPointer<vtkPoints> SliceOffsetHandle2Points;
+    vtkSmartPointer<vtkPoints> RotationHandle1Points;
+    vtkSmartPointer<vtkPoints> RotationHandle2Points;
+
+    bool SliceOffsetHandle1Displayable = false;
+    bool SliceOffsetHandle2Displayable = false;
+    bool RotationHandle1Displayable = false;
+    bool RotationHandle2Displayable = false;
+    bool RotationHandlesVisible = false;
+    bool TranslationHandlesVisible = false;
+    int  HandlesVisibilityMode = vtkMRMLSliceDisplayNode::NeverVisible;
+    // Indicates that this representation has changed and thus re-rendering is needed
+    bool NeedToRender = true;
+  };
+
+class vtkMRMLSliceIntersectionInteractionRepresentation::vtkInternal
+{
+  public:
+    vtkInternal(vtkMRMLSliceIntersectionInteractionRepresentation* external);
+    ~vtkInternal();
+
+    vtkMRMLSliceIntersectionInteractionRepresentation* External;
+
+    vtkSmartPointer<vtkMRMLSliceNode> SliceNode;
+    vtkSmartPointer<vtkMRMLSliceDisplayNode> SliceDisplayNode;
+
+    std::deque<SliceIntersectionInteractionDisplayPipeline*> SliceIntersectionInteractionDisplayPipelines;
+    vtkNew<vtkCallbackCommand> SliceNodeModifiedCommand;
+};
+
+//---------------------------------------------------------------------------
+// vtkInternal methods
+
+//---------------------------------------------------------------------------
+vtkMRMLSliceIntersectionInteractionRepresentation::vtkInternal
+::vtkInternal(vtkMRMLSliceIntersectionInteractionRepresentation* external)
+{
+  this->External = external;
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLSliceIntersectionInteractionRepresentation::vtkInternal::~vtkInternal() = default;
+
+//----------------------------------------------------------------------
+vtkMRMLSliceIntersectionInteractionRepresentation::vtkMRMLSliceIntersectionInteractionRepresentation()
+{
+  this->MRMLApplicationLogic = nullptr;
+
+  this->Internal = new vtkInternal(this);
+  this->Internal->SliceNodeModifiedCommand->SetClientData(this);
+  this->Internal->SliceNodeModifiedCommand->SetCallback(vtkMRMLSliceIntersectionInteractionRepresentation::SliceNodeModifiedCallback);
+
+  this->SliceIntersectionPoint[0] = 0.0;
+  this->SliceIntersectionPoint[1] = 0.0;
+  this->SliceIntersectionPoint[2] = 0.0;
+  this->SliceIntersectionPoint[3] = 1.0; // to allow easy homogeneous transformations
+
+  // Set interaction size. Determines the maximum distance for interaction.
+  this->InteractionSize = INTERACTION_SIZE_PIXELS;
+
+  // Helper
+  vtkNew<vtkMRMLSliceIntersectionInteractionRepresentationHelper> helper;
+  this->Helper = helper;
+}
+
+//----------------------------------------------------------------------
+vtkMRMLSliceIntersectionInteractionRepresentation::~vtkMRMLSliceIntersectionInteractionRepresentation()
+{
+  this->SetSliceNode(nullptr);
+  this->SetMRMLApplicationLogic(nullptr);
+  delete this->Internal;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::GetActors2D(vtkPropCollection * pc)
+{
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    (*sliceIntersectionIt)->GetActors2D(pc);
+    }
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::ReleaseGraphicsResources(vtkWindow * win)
+{
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    (*sliceIntersectionIt)->ReleaseGraphicsResources(win);
+    }
+}
+
+//----------------------------------------------------------------------
+int vtkMRMLSliceIntersectionInteractionRepresentation::RenderOverlay(vtkViewport * viewport)
+{
+  int count = 0;
+
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    count += (*sliceIntersectionIt)->RenderOverlay(viewport);
+    }
+  return count;
+}
+
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::PrintSelf(ostream & os, vtkIndent indent)
+{
+  //Superclass typedef defined in vtkTypeMacro() found in vtkSetGet.h
+  this->Superclass::PrintSelf(os, indent);
+}
+
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::SliceNodeModifiedCallback(
+  vtkObject * caller, unsigned long vtkNotUsed(eid), void* clientData, void* vtkNotUsed(callData))
+{
+  vtkMRMLSliceIntersectionInteractionRepresentation* self = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast((vtkObject*)clientData);
+  vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(caller);
+  if (sliceNode)
+    {
+    // The slice view's node is modified
+    self->SliceNodeModified(sliceNode);
+    return;
+    }
+
+  // One of the intersecting slices are modified, update all slice intersections
+  self->SliceNodeModified(self->Internal->SliceNode);
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::SliceNodeModified(vtkMRMLSliceNode * sliceNode)
+{
+  if (!sliceNode)
+    {
+    return;
+    }
+  if (sliceNode == this->Internal->SliceNode)
+    {
+    // update all slice intersection
+    for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+      sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+      sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+      {
+      this->UpdateSliceIntersectionDisplay(*sliceIntersectionIt);
+      }
+    bool handlesVisible = false;
+    vtkMRMLSliceDisplayNode* displayNode = this->GetSliceDisplayNode();
+    if (displayNode)
+      {
+      int componentType = displayNode->GetActiveComponentType();
+      handlesVisible = componentType != vtkMRMLSliceDisplayNode::ComponentNone
+        && componentType != vtkMRMLSliceDisplayNode::ComponentSliceIntersection; // hide handles during interaction:
+      }
+    this->SetPipelinesHandlesVisibility(handlesVisible);
+    }
+}
+
+//----------------------------------------------------------------------
+SliceIntersectionInteractionDisplayPipeline* vtkMRMLSliceIntersectionInteractionRepresentation::GetDisplayPipelineFromSliceLogic(vtkMRMLSliceLogic * sliceLogic)
+{
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    if (!(*sliceIntersectionIt)->SliceLogic)
+      {
+      continue;
+      }
+    if (sliceLogic == (*sliceIntersectionIt)->SliceLogic)
+      {
+      // found it
+      return *sliceIntersectionIt;
+      }
+    }
+  return nullptr;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::UpdateSliceIntersectionDisplay(SliceIntersectionInteractionDisplayPipeline * pipeline)
+{
+  if (!pipeline || !this->Internal->SliceNode || pipeline->SliceLogic == nullptr)
+    {
+    return;
+    }
+  vtkMRMLSliceNode* intersectingSliceNode = pipeline->SliceLogic->GetSliceNode();
+  if (!pipeline->SliceLogic || !this->GetVisibility()
+    || !intersectingSliceNode
+    || this->Internal->SliceNode->GetViewGroup() != intersectingSliceNode->GetViewGroup()
+    || !intersectingSliceNode->IsMappedInLayout())
+    {
+    pipeline->SetIntersectionsVisibility(false);
+    pipeline->SetHandlesVisibility(false);
+    if (pipeline->NeedToRender)
+      {
+      this->NeedToRenderOn();
+      }
+    return;
+    }
+
+  // Set properties of slice intersection lines
+  vtkMRMLSliceDisplayNode* displayNode = this->GetSliceDisplayNode(intersectingSliceNode);
+  if (displayNode)
+    {
+    bool sliceInteractionHandlesInteractive =
+      (displayNode->GetIntersectingSlicesVisibility() && displayNode->GetIntersectingSlicesInteractive());
+    if (!sliceInteractionHandlesInteractive)
+      {
+      pipeline->SetIntersectionsVisibility(false);
+      pipeline->SetHandlesVisibility(false);
+      if (pipeline->NeedToRender)
+        {
+        this->NeedToRenderOn();
+        }
+      return;
+      }
+    pipeline->TranslationHandlesVisible = displayNode->GetIntersectingSlicesTranslationEnabled();
+    pipeline->RotationHandlesVisible = displayNode->GetIntersectingSlicesRotationEnabled();
+
+    pipeline->HandlesVisibilityMode = displayNode->GetIntersectingSlicesInteractiveHandlesVisibilityMode();
+
+    pipeline->IntersectionLine1Property->SetLineWidth(displayNode->GetLineWidth() + INTERSECTION_LINE_EXTRA_THICKNESS);
+    pipeline->IntersectionLine2Property->SetLineWidth(displayNode->GetLineWidth() + INTERSECTION_LINE_EXTRA_THICKNESS);
+    }
+
+  // Set color of handles
+  pipeline->IntersectionLine1Property->SetColor(intersectingSliceNode->GetLayoutColor());
+  pipeline->IntersectionLine2Property->SetColor(intersectingSliceNode->GetLayoutColor());
+  pipeline->TranslationOuterHandleProperty->SetColor(0, 0, 0); // black color
+  pipeline->TranslationInnerHandleProperty->SetColor(255, 255, 255); // white color
+  pipeline->RotationHandle1Property->SetColor(intersectingSliceNode->GetLayoutColor());
+  pipeline->RotationHandle2Property->SetColor(intersectingSliceNode->GetLayoutColor());
+  pipeline->SliceOffsetHandle1Property->SetColor(intersectingSliceNode->GetLayoutColor());
+  pipeline->SliceOffsetHandle2Property->SetColor(intersectingSliceNode->GetLayoutColor());
+
+  // Get slice node transforms
+  vtkMatrix4x4* xyToRAS = this->Internal->SliceNode->GetXYToRAS();
+  vtkNew<vtkMatrix4x4> rasToXY;
+  vtkMatrix4x4::Invert(xyToRAS, rasToXY);
+
+  // Get slice intersection point XY
+  this->GetSliceIntersectionPoint();
+  double sliceIntersectionPoint[4] = { this->SliceIntersectionPoint[0], this->SliceIntersectionPoint[1], this->SliceIntersectionPoint[2], 1 };
+
+  // Get outer intersection line tips
+  vtkMatrix4x4* intersectingXYToRAS = intersectingSliceNode->GetXYToRAS();
+  vtkNew<vtkMatrix4x4> intersectingXYToXY;
+  vtkMatrix4x4::Multiply4x4(rasToXY, intersectingXYToRAS, intersectingXYToXY);
+  double intersectionLineTip1[3] = { 0.0, 0.0, 0.0};
+  double intersectionLineTip2[3] = { 0.0, 0.0, 0.0};
+  int intersectionFound = this->Helper->GetLineTipsFromIntersectingSliceNode(intersectingSliceNode, intersectingXYToXY,
+    intersectionLineTip1, intersectionLineTip2);
+  if (!intersectionFound) // Pipelines not visible if no intersection is found
+    {
+    pipeline->SetIntersectionsVisibility(false);
+    pipeline->SetHandlesVisibility(false);
+    if (pipeline->NeedToRender)
+      {
+      this->NeedToRenderOn();
+      }
+    return;
+    }
+
+  // Get current slice view bounds
+  vtkMRMLSliceNode* currentSliceNode = this->GetSliceNode();
+  double sliceViewBounds[4] = {};
+  this->Helper->GetSliceViewBoundariesXY(currentSliceNode, sliceViewBounds);
+  double sliceViewWidth = sliceViewBounds[1] - sliceViewBounds[0];
+
+  // Add margin to slice view bounds
+  sliceViewBounds[0] = sliceViewBounds[0] + (sliceViewBounds[1] - sliceViewBounds[0]) * FOV_HANDLES_MARGIN;
+  sliceViewBounds[1] = sliceViewBounds[1] - (sliceViewBounds[1] - sliceViewBounds[0]) * FOV_HANDLES_MARGIN;
+  sliceViewBounds[2] = sliceViewBounds[2] + (sliceViewBounds[3] - sliceViewBounds[2]) * FOV_HANDLES_MARGIN;
+  sliceViewBounds[3] = sliceViewBounds[3] - (sliceViewBounds[3] - sliceViewBounds[2]) * FOV_HANDLES_MARGIN;
+
+  // Get outer intersection line tips adjusted to FOV margins
+  double intersectionOuterLineTip1[3] = { intersectionLineTip1[0], intersectionLineTip1[1], intersectionLineTip1[2] };
+  double intersectionOuterLineTip2[3] = { intersectionLineTip2[0], intersectionLineTip2[1], intersectionLineTip2[2] };
+  if ((sliceIntersectionPoint[0] > sliceViewBounds[0]) && // If intersection point is within FOV
+      (sliceIntersectionPoint[0] < sliceViewBounds[1]) &&
+      (sliceIntersectionPoint[1] > sliceViewBounds[2]) &&
+      (sliceIntersectionPoint[1] < sliceViewBounds[3]))
+    {
+    if ((intersectionOuterLineTip1[0] < sliceViewBounds[0]) || // If line tip 1 is outside the FOV
+        (intersectionOuterLineTip1[0] > sliceViewBounds[1]) ||
+        (intersectionOuterLineTip1[1] < sliceViewBounds[2]) ||
+        (intersectionOuterLineTip1[1] > sliceViewBounds[3]))
+      {
+      this->Helper->GetIntersectionWithSliceViewBoundaries(intersectionOuterLineTip1, sliceIntersectionPoint,
+                                                                                  sliceViewBounds, intersectionOuterLineTip1);
+      }
+    if ((intersectionOuterLineTip2[0] < sliceViewBounds[0]) || // If line tip 2 is outside the FOV
+        (intersectionOuterLineTip2[0] > sliceViewBounds[1]) ||
+        (intersectionOuterLineTip2[1] < sliceViewBounds[2]) ||
+        (intersectionOuterLineTip2[1] > sliceViewBounds[3]))
+      {
+      this->Helper->GetIntersectionWithSliceViewBoundaries(intersectionOuterLineTip2, sliceIntersectionPoint,
+                                                                                  sliceViewBounds, intersectionOuterLineTip2);
+      }
+    }
+
+  // Get inner intersection line tips
+  double intersectionInnerLineTip1[3] = { 0.0, 0.0, 0.0 };
+  double intersectionInnerLineTip2[3] = { 0.0, 0.0, 0.0 };
+  if (INTERSECTION_VISUALIZATION_MODE == ShowIntersection)
+    {
+    intersectionInnerLineTip1[0] = sliceIntersectionPoint[0];
+    intersectionInnerLineTip1[1] = sliceIntersectionPoint[1];
+    intersectionInnerLineTip2[0] = sliceIntersectionPoint[0];
+    intersectionInnerLineTip2[1] = sliceIntersectionPoint[1];
+    }
+  else if (INTERSECTION_VISUALIZATION_MODE == HideIntersection)
+    {
+    double intersectionPointToOuterLineTip1[3] = { intersectionOuterLineTip1[0] - sliceIntersectionPoint[0],
+                                                   intersectionOuterLineTip1[1] - sliceIntersectionPoint[1], 0.0 };
+    double intersectionPointToOuterLineTip2[3] = { intersectionOuterLineTip2[0] - sliceIntersectionPoint[0],
+                                                   intersectionOuterLineTip2[1] - sliceIntersectionPoint[1], 0.0 };
+    double intersectionPointToOuterLineTip1Distance = vtkMath::Norm(intersectionPointToOuterLineTip1);
+    double intersectionPointToOuterLineTip2Distance = vtkMath::Norm(intersectionPointToOuterLineTip2);
+    vtkMath::Normalize(intersectionPointToOuterLineTip1);
+    vtkMath::Normalize(intersectionPointToOuterLineTip2);
+    double gapSize = sliceViewWidth * HIDE_INTERSECTION_GAP_SIZE; // gap size computed according to slice view size
+    if (intersectionPointToOuterLineTip1Distance > gapSize) // line segment visible
+      {
+      intersectionInnerLineTip1[0] = sliceIntersectionPoint[0] + intersectionPointToOuterLineTip1[0] * gapSize;
+      intersectionInnerLineTip1[1] = sliceIntersectionPoint[1] + intersectionPointToOuterLineTip1[1] * gapSize;
+      }
+    else // line segment not visible
+      {
+      intersectionInnerLineTip1[0] = intersectionOuterLineTip1[0];
+      intersectionInnerLineTip1[1] = intersectionOuterLineTip1[1];
+      }
+    if (intersectionPointToOuterLineTip2Distance > gapSize) // line segment visible
+      {
+      intersectionInnerLineTip2[0] = sliceIntersectionPoint[0] + intersectionPointToOuterLineTip2[0] * gapSize;
+      intersectionInnerLineTip2[1] = sliceIntersectionPoint[1] + intersectionPointToOuterLineTip2[1] * gapSize;
+      }
+    else // line segment not visible
+      {
+      intersectionInnerLineTip2[0] = intersectionOuterLineTip2[0];
+      intersectionInnerLineTip2[1] = intersectionOuterLineTip2[1];
+      }
+    }
+  else
+    {
+    vtkWarningMacro("vtkMRMLSliceIntersectionInteractionRepresentation::UpdateSliceIntersectionDisplay failed: unknown visualization mode.");
+    if (pipeline->NeedToRender)
+      {
+      this->NeedToRenderOn();
+      }
+    return;
+    }
+
+  // Define intersection lines
+  pipeline->IntersectionLine1->SetPoint1(intersectionLineTip1);
+  pipeline->IntersectionLine1->SetPoint2(intersectionInnerLineTip1);
+  pipeline->IntersectionLine2->SetPoint1(intersectionLineTip2);
+  pipeline->IntersectionLine2->SetPoint2(intersectionInnerLineTip2);
+
+  // Determine visibility of handles according to line spacing
+  double line1Vector[2] = { intersectionOuterLineTip1[0] - intersectionInnerLineTip1[0],
+                            intersectionOuterLineTip1[1] - intersectionInnerLineTip1[1]};
+  double line1VectorNorm = vtkMath::Norm2D(line1Vector);
+  double line2Vector[2] = { intersectionOuterLineTip2[0] - intersectionInnerLineTip2[0],
+                            intersectionOuterLineTip2[1] - intersectionInnerLineTip2[1]};
+  double line2VectorNorm = vtkMath::Norm2D(line2Vector);
+  vtkMath::Normalize2D(line1Vector);
+  vtkMath::Normalize2D(line2Vector);
+  double dotProduct = vtkMath::Dot2D(line1Vector, line2Vector);
+  if (line1VectorNorm > HANDLES_MIN_LINE_LENGTH)
+    {
+    pipeline->RotationHandle1Displayable = true;
+    pipeline->SliceOffsetHandle1Displayable = true;
+    }
+  else // hide handles if there is no sufficient space in line
+    {
+    pipeline->RotationHandle1Displayable = false;
+    pipeline->SliceOffsetHandle1Displayable = false;
+    }
+  if (line2VectorNorm > HANDLES_MIN_LINE_LENGTH)
+    {
+    pipeline->RotationHandle2Displayable = true;
+    pipeline->SliceOffsetHandle2Displayable = true;
+    }
+  else // hide handles if there is no sufficient space in line
+    {
+    pipeline->RotationHandle2Displayable = false;
+    pipeline->SliceOffsetHandle2Displayable = false;
+    }
+  if (dotProduct > 0.0)
+  // this means vectors are oriented towards the same direction
+  // This may occur when using "HideIntersection" mode.
+    {
+    if (line1VectorNorm < line2VectorNorm)
+    // hide handles closer to intersection point
+      {
+      pipeline->RotationHandle1Displayable = false;
+      pipeline->SliceOffsetHandle1Displayable = false;
+      }
+    else
+    // hide handles closer to intersection point
+      {
+      pipeline->RotationHandle2Displayable = false;
+      pipeline->SliceOffsetHandle2Displayable = false;
+      }
+    }
+
+  // Set translation handle position
+  vtkNew<vtkPoints> translationHandlePoints;
+  double translationHandlePosition[3] = { sliceIntersectionPoint[0], sliceIntersectionPoint[1], 0.0 };
+  pipeline->TranslationOuterHandle->SetCenter(translationHandlePosition[0], translationHandlePosition[1], translationHandlePosition[2]);
+  pipeline->TranslationInnerHandle->SetCenter(translationHandlePosition[0], translationHandlePosition[1], translationHandlePosition[2]);
+  translationHandlePoints->InsertNextPoint(translationHandlePosition);
+  pipeline->TranslationHandlePoints->SetPoints(translationHandlePoints);
+
+  // Set position of rotation handles
+  double rotationHandle1Position[2] = { intersectionOuterLineTip1[0], intersectionOuterLineTip1[1] };
+  double rotationHandle2Position[2] = { intersectionOuterLineTip2[0], intersectionOuterLineTip2[1] };
+  double rotationHandle1Orientation[2] = { intersectionInnerLineTip1[1] - intersectionOuterLineTip1[1],
+                                           intersectionOuterLineTip1[0] - intersectionInnerLineTip1[0] }; // perpendicular to intersection line segment
+  double rotationHandle2Orientation[2] = { intersectionInnerLineTip2[1] - intersectionOuterLineTip2[1],
+                                           intersectionOuterLineTip2[0] - intersectionInnerLineTip2[0] }; // perpendicular to intersection line segment
+  vtkNew<vtkMatrix4x4> rotationHandle1ToWorldMatrix, rotationHandle2ToWorldMatrix; // Compute transformation matrix (rotation + translation)
+  this->Helper->ComputeHandleToWorldTransformMatrix(rotationHandle1Position, rotationHandle1Orientation, rotationHandle1ToWorldMatrix);
+  this->Helper->ComputeHandleToWorldTransformMatrix(rotationHandle2Position, rotationHandle2Orientation, rotationHandle2ToWorldMatrix);
+  pipeline->RotationHandle1ToWorldTransform->Identity();
+  pipeline->RotationHandle1ToWorldTransform->SetMatrix(rotationHandle1ToWorldMatrix); // Update handles to world transform
+  pipeline->RotationHandle2ToWorldTransform->Identity();
+  pipeline->RotationHandle2ToWorldTransform->SetMatrix(rotationHandle2ToWorldMatrix); // Update handles to world transform
+
+  // Update rotation handle interaction points
+  vtkNew<vtkPoints> rotationHandlePoints;
+  if (pipeline->RotationHandle1Displayable) // Handle 1
+    {
+    double rotationHandle1Point[3] = { 0.0, 0.0, 0.0 };
+    double rotationHandle1Point_h[4] = { 0.0, 0.0, 0.0, 1.0 }; //homogeneous coordinates
+    for (int i = 0; i < pipeline->RotationHandle1Points->GetNumberOfPoints(); i++)
+      {
+      pipeline->RotationHandle1Points->GetPoint(i, rotationHandle1Point);
+      rotationHandle1Point_h[0] = rotationHandle1Point[0];
+      rotationHandle1Point_h[1] = rotationHandle1Point[1];
+      rotationHandle1Point_h[2] = rotationHandle1Point[2];
+      rotationHandle1ToWorldMatrix->MultiplyPoint(rotationHandle1Point_h, rotationHandle1Point_h);
+      rotationHandle1Point[0] = rotationHandle1Point_h[0];
+      rotationHandle1Point[1] = rotationHandle1Point_h[1];
+      rotationHandle1Point[2] = rotationHandle1Point_h[2];
+      rotationHandlePoints->InsertNextPoint(rotationHandle1Point);
+      }
+    }
+  if (pipeline->RotationHandle2Displayable) // Handle 2
+    {
+    double rotationHandle2Point[3] = { 0.0, 0.0, 0.0 };
+    double rotationHandle2Point_h[4] = { 0.0, 0.0, 0.0, 1.0 }; //homogeneous coordinates
+    for (int j = 0; j < pipeline->RotationHandle2Points->GetNumberOfPoints(); j++)
+      {
+      pipeline->RotationHandle2Points->GetPoint(j, rotationHandle2Point);
+      rotationHandle2Point_h[0] = rotationHandle2Point[0];
+      rotationHandle2Point_h[1] = rotationHandle2Point[1];
+      rotationHandle2Point_h[2] = rotationHandle2Point[2];
+      rotationHandle2ToWorldMatrix->MultiplyPoint(rotationHandle2Point_h, rotationHandle2Point_h);
+      rotationHandle2Point[0] = rotationHandle2Point_h[0];
+      rotationHandle2Point[1] = rotationHandle2Point_h[1];
+      rotationHandle2Point[2] = rotationHandle2Point_h[2];
+      rotationHandlePoints->InsertNextPoint(rotationHandle2Point);
+      }
+    }
+
+  // Set position of slice offset handles
+  double sliceOffsetHandle1Position[2] = { (rotationHandle1Position[0] + sliceIntersectionPoint[0]) / 2 ,
+                                             (rotationHandle1Position[1] + sliceIntersectionPoint[1]) / 2 };
+  double sliceOffsetHandle2Position[2] = { (rotationHandle2Position[0] + sliceIntersectionPoint[0]) / 2 ,
+                                             (rotationHandle2Position[1] + sliceIntersectionPoint[1]) / 2 };
+  double sliceOffsetHandleOrientation2D[2] = { intersectionOuterLineTip2[1] - intersectionOuterLineTip1[1],
+                                               intersectionOuterLineTip1[0] - intersectionOuterLineTip2[0] }; // perpendicular to intersection line
+  vtkNew<vtkMatrix4x4> sliceOffsetHandle1ToWorldMatrix, sliceOffsetHandle2ToWorldMatrix; // Compute transformation matrix (rotation + translation)
+  this->Helper->ComputeHandleToWorldTransformMatrix(sliceOffsetHandle1Position, sliceOffsetHandleOrientation2D, sliceOffsetHandle1ToWorldMatrix);
+  this->Helper->ComputeHandleToWorldTransformMatrix(sliceOffsetHandle2Position, sliceOffsetHandleOrientation2D, sliceOffsetHandle2ToWorldMatrix);
+  pipeline->SliceOffsetHandle1ToWorldTransform->Identity();
+  pipeline->SliceOffsetHandle1ToWorldTransform->SetMatrix(sliceOffsetHandle1ToWorldMatrix); // Update handles to world transform
+  pipeline->SliceOffsetHandle2ToWorldTransform->Identity();
+  pipeline->SliceOffsetHandle2ToWorldTransform->SetMatrix(sliceOffsetHandle2ToWorldMatrix); // Update handles to world transform
+
+  // Update slice offset handle interaction points
+  vtkNew<vtkPoints> sliceOffsetHandlePoints;
+  double sliceOffsetHandlePoint[3] = { 0.0, 0.0, 0.0 };
+  double sliceOffsetHandlePoint_h[4] = { 0.0, 0.0, 0.0, 1.0 }; //homogeneous coordinates
+  if (pipeline->SliceOffsetHandle1Displayable) // Handle 1
+    {
+    for (int i = 0; i < pipeline->SliceOffsetHandle1Points->GetNumberOfPoints(); i++)
+      {
+      pipeline->SliceOffsetHandle1Points->GetPoint(i, sliceOffsetHandlePoint);
+      sliceOffsetHandlePoint_h[0] = sliceOffsetHandlePoint[0];
+      sliceOffsetHandlePoint_h[1] = sliceOffsetHandlePoint[1];
+      sliceOffsetHandlePoint_h[2] = sliceOffsetHandlePoint[2];
+      sliceOffsetHandle1ToWorldMatrix->MultiplyPoint(sliceOffsetHandlePoint_h, sliceOffsetHandlePoint_h);
+      sliceOffsetHandlePoint[0] = sliceOffsetHandlePoint_h[0];
+      sliceOffsetHandlePoint[1] = sliceOffsetHandlePoint_h[1];
+      sliceOffsetHandlePoint[2] = sliceOffsetHandlePoint_h[2];
+      sliceOffsetHandlePoints->InsertNextPoint(sliceOffsetHandlePoint);
+      }
+    }
+  if (pipeline->SliceOffsetHandle2Displayable) // Handle 2
+    {
+    for (int j = 0; j < pipeline->SliceOffsetHandle2Points->GetNumberOfPoints(); j++)
+      {
+      pipeline->SliceOffsetHandle2Points->GetPoint(j, sliceOffsetHandlePoint);
+      sliceOffsetHandlePoint_h[0] = sliceOffsetHandlePoint[0];
+      sliceOffsetHandlePoint_h[1] = sliceOffsetHandlePoint[1];
+      sliceOffsetHandlePoint_h[2] = sliceOffsetHandlePoint[2];
+      sliceOffsetHandle2ToWorldMatrix->MultiplyPoint(sliceOffsetHandlePoint_h, sliceOffsetHandlePoint_h);
+      sliceOffsetHandlePoint[0] = sliceOffsetHandlePoint_h[0];
+      sliceOffsetHandlePoint[1] = sliceOffsetHandlePoint_h[1];
+      sliceOffsetHandlePoint[2] = sliceOffsetHandlePoint_h[2];
+      sliceOffsetHandlePoints->InsertNextPoint(sliceOffsetHandlePoint);
+      }
+    }
+
+  // Define points along intersection lines for interaction
+  vtkPoints* line1PointsDefault;
+  vtkPoints* line2PointsDefault;
+  line1PointsDefault = pipeline->IntersectionLine1->GetOutput()->GetPoints();
+  line2PointsDefault = pipeline->IntersectionLine2->GetOutput()->GetPoints();
+
+  // Get closer handles to intersection line 1
+  vtkIdType numLinePoints;
+  double linePoint[3] = { 0.0, 0.0, 0.0 };
+  double linePointToRotationHandle1[2] = { 0.0, 0.0 };
+  double linePointToSliceOffsetHandle1[2] = { 0.0, 0.0 };
+  double linePointToRotationHandle1Distance;
+  double linePointToSliceOffsetHandle1Distance;
+  numLinePoints = line1PointsDefault->GetNumberOfPoints();
+  for (int i = 0; i < numLinePoints; i++)
+    {
+    // Get line point coordinates
+    line1PointsDefault->GetPoint(i, linePoint);
+    // Distance to rotation handle
+    linePointToRotationHandle1[0] = rotationHandle1Position[0] - linePoint[0];
+    linePointToRotationHandle1[1] = rotationHandle1Position[1] - linePoint[1];
+    linePointToRotationHandle1Distance = vtkMath::Norm2D(linePointToRotationHandle1);
+    // Distance to slice offset handle
+    linePointToSliceOffsetHandle1[0] = sliceOffsetHandle1Position[0] - linePoint[0];
+    linePointToSliceOffsetHandle1[1] = sliceOffsetHandle1Position[1] - linePoint[1];
+    linePointToSliceOffsetHandle1Distance = vtkMath::Norm2D(linePointToSliceOffsetHandle1);
+    // Determine closer handle and insert interaction points
+    if (linePointToRotationHandle1Distance < linePointToSliceOffsetHandle1Distance)
+      {
+      rotationHandlePoints->InsertNextPoint(linePoint);
+      }
+    else
+      {
+      sliceOffsetHandlePoints->InsertNextPoint(linePoint);
+      }
+    }
+
+  // Get closer handles to intersection line 2
+  double linePointToRotationHandle2[2] = { 0.0, 0.0 };
+  double linePointToSliceOffsetHandle2[2] = { 0.0, 0.0 };
+  double linePointToRotationHandle2Distance;
+  double linePointToSliceOffsetHandle2Distance;
+  numLinePoints = line2PointsDefault->GetNumberOfPoints();
+  for (int i = 0; i < numLinePoints; i++)
+    {
+    // Get line point coordinates
+    line2PointsDefault->GetPoint(i, linePoint);
+    // Distance to rotation handle
+    linePointToRotationHandle2[0] = rotationHandle2Position[0] - linePoint[0];
+    linePointToRotationHandle2[1] = rotationHandle2Position[1] - linePoint[1];
+    linePointToRotationHandle2Distance = vtkMath::Norm2D(linePointToRotationHandle2);
+    // Distance to slice offset handle
+    linePointToSliceOffsetHandle2[0] = sliceOffsetHandle2Position[0] - linePoint[0];
+    linePointToSliceOffsetHandle2[1] = sliceOffsetHandle2Position[1] - linePoint[1];
+    linePointToSliceOffsetHandle2Distance = vtkMath::Norm2D(linePointToSliceOffsetHandle2);
+    // Determine closer handle and insert interaction points
+    if (linePointToRotationHandle2Distance < linePointToSliceOffsetHandle2Distance)
+      {
+      rotationHandlePoints->InsertNextPoint(linePoint);
+      }
+    else
+      {
+      sliceOffsetHandlePoints->InsertNextPoint(linePoint);
+      }
+    }
+
+  // Set interaction points
+  pipeline->RotationHandlePoints->SetPoints(rotationHandlePoints);
+  pipeline->SliceOffsetHandlePoints->SetPoints(sliceOffsetHandlePoints);
+
+  // Visibility
+  pipeline->SetIntersectionsVisibility(true);
+  pipeline->SetHandlesVisibility(true);
+  this->NeedToRenderOn();
+}
+
+
+//----------------------------------------------------------------------
+vtkMRMLSliceDisplayNode* vtkMRMLSliceIntersectionInteractionRepresentation::GetSliceDisplayNode()
+{
+  if (this->Internal->SliceDisplayNode)
+    {
+    return this->Internal->SliceDisplayNode;
+    }
+  vtkMRMLSliceDisplayNode* sliceDisplayNode = this->GetSliceDisplayNode(this->Internal->SliceNode);
+  this->SetSliceDisplayNode(sliceDisplayNode);
+  return sliceDisplayNode;
+}
+
+//----------------------------------------------------------------------
+vtkMRMLSliceDisplayNode* vtkMRMLSliceIntersectionInteractionRepresentation::GetSliceDisplayNode(vtkMRMLSliceNode* sliceNode)
+{
+  vtkMRMLApplicationLogic* mrmlAppLogic = this->GetMRMLApplicationLogic();
+  if (!mrmlAppLogic)
+    {
+    return nullptr;
+    }
+  vtkMRMLSliceLogic* sliceLogic = mrmlAppLogic->GetSliceLogic(sliceNode);
+  if (!sliceLogic)
+    {
+    return nullptr;
+    }
+  return sliceLogic->GetSliceDisplayNode();
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::SetSliceNode(vtkMRMLSliceNode * sliceNode)
+{
+  if (sliceNode == this->Internal->SliceNode)
+    {
+    // no change
+    return;
+    }
+  if (this->Internal->SliceNode)
+    {
+    this->Internal->SliceNode->RemoveObserver(this->Internal->SliceNodeModifiedCommand);
+    }
+  if (sliceNode)
+    {
+    sliceNode->AddObserver(vtkCommand::ModifiedEvent, this->Internal->SliceNodeModifiedCommand.GetPointer());
+    }
+  this->Internal->SliceNode = sliceNode;
+
+  this->SetSliceDisplayNode(nullptr);
+  vtkMRMLSliceDisplayNode* sliceDisplayNode = this->GetSliceDisplayNode(sliceNode);
+  this->SetSliceDisplayNode(sliceDisplayNode);
+
+  this->UpdateIntersectingSliceNodes();
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::SetSliceDisplayNode(vtkMRMLSliceDisplayNode* sliceDisplayNode)
+{
+  if (this->Internal->SliceDisplayNode == sliceDisplayNode)
+    {
+    // no change
+    return;
+    }
+  if (this->Internal->SliceDisplayNode)
+    {
+    this->Internal->SliceDisplayNode->RemoveObserver(this->Internal->SliceNodeModifiedCommand);
+    }
+  if (sliceDisplayNode)
+    {
+    sliceDisplayNode->AddObserver(vtkCommand::ModifiedEvent, this->Internal->SliceNodeModifiedCommand.GetPointer());
+    }
+  this->Internal->SliceDisplayNode = sliceDisplayNode;
+  this->UpdateIntersectingSliceNodes();
+}
+
+//----------------------------------------------------------------------
+vtkMRMLSliceNode* vtkMRMLSliceIntersectionInteractionRepresentation::GetSliceNode()
+{
+  return this->Internal->SliceNode;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::AddIntersectingSliceLogic(vtkMRMLSliceLogic * sliceLogic)
+{
+  if (!sliceLogic)
+    {
+    return;
+    }
+  if (sliceLogic->GetSliceNode() == this->Internal->SliceNode)
+    {
+    // it is the slice itself, not an intersecting slice
+    return;
+    }
+  if (this->GetDisplayPipelineFromSliceLogic(sliceLogic))
+    {
+    // slice node already added
+    return;
+    }
+
+  SliceIntersectionInteractionDisplayPipeline* pipeline = new SliceIntersectionInteractionDisplayPipeline;
+  pipeline->SetAndObserveSliceLogic(sliceLogic, this->Internal->SliceNodeModifiedCommand);
+  pipeline->AddActors(this->Renderer);
+  this->Internal->SliceIntersectionInteractionDisplayPipelines.push_back(pipeline);
+  this->UpdateSliceIntersectionDisplay(pipeline);
+  this->SliceNodeModified(this->Internal->SliceNode);
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::RemoveIntersectingSliceNode(vtkMRMLSliceNode * sliceNode)
+{
+  if (!sliceNode)
+    {
+    return;
+    }
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    if (!(*sliceIntersectionIt)->SliceLogic)
+      {
+      continue;
+      }
+    if (sliceNode == (*sliceIntersectionIt)->SliceLogic->GetSliceNode())
+      {
+      // found it
+      (*sliceIntersectionIt)->RemoveActors(this->Renderer);
+      delete (*sliceIntersectionIt);
+      this->Internal->SliceIntersectionInteractionDisplayPipelines.erase(sliceIntersectionIt);
+      break;
+      }
+    }
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::UpdateIntersectingSliceNodes()
+{
+  this->RemoveAllIntersectingSliceNodes();
+  if (!this->GetSliceNode() || !this->MRMLApplicationLogic)
+    {
+    return;
+    }
+  vtkCollection* sliceLogics = this->MRMLApplicationLogic->GetSliceLogics();
+  if (!sliceLogics)
+    {
+    return;
+    }
+  vtkMRMLSliceLogic* sliceLogic;
+  vtkCollectionSimpleIterator it;
+  for (sliceLogics->InitTraversal(it);
+    (sliceLogic = vtkMRMLSliceLogic::SafeDownCast(sliceLogics->GetNextItemAsObject(it)));)
+    {
+    this->AddIntersectingSliceLogic(sliceLogic);
+    }
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::RemoveAllIntersectingSliceNodes()
+{
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    (*sliceIntersectionIt)->RemoveActors(this->Renderer);
+    delete (*sliceIntersectionIt);
+    }
+  this->Internal->SliceIntersectionInteractionDisplayPipelines.clear();
+}
+
+//----------------------------------------------------------------------
+double* vtkMRMLSliceIntersectionInteractionRepresentation::GetSliceIntersectionPoint()
+{
+  this->SliceIntersectionPoint[0] = 0.0;
+  this->SliceIntersectionPoint[1] = 0.0;
+  this->SliceIntersectionPoint[2] = 0.0;
+
+  size_t numberOfIntersections = this->Internal->SliceIntersectionInteractionDisplayPipelines.size();
+  int numberOfFoundIntersectionPoints = 0;
+  if (!this->Internal->SliceNode)
+    {
+    return this->SliceIntersectionPoint;
+    }
+
+  // XY to RAS
+  vtkMatrix4x4* xyToRAS = this->Internal->SliceNode->GetXYToRAS();
+
+  // Get intersection point
+  for (size_t slice1Index = 0; slice1Index < numberOfIntersections - 1; slice1Index++)
+    {
+    if (!this->Internal->SliceIntersectionInteractionDisplayPipelines[slice1Index]->GetVisibility())
+      {
+      continue;
+      }
+    // Get line 1 points
+    vtkLineSource* line1R = this->Internal->SliceIntersectionInteractionDisplayPipelines[slice1Index]->IntersectionLine1;
+    vtkLineSource* line1L = this->Internal->SliceIntersectionInteractionDisplayPipelines[slice1Index]->IntersectionLine2;
+    double* line1PointR = line1R->GetPoint1();
+    double* line1PointL = line1L->GetPoint1();
+
+    // Get extended line 1 points
+    double line1Direction[3] = { line1PointR[0] - line1PointL[0],
+                                 line1PointR[1] - line1PointL[1],
+                                 line1PointR[2] - line1PointL[2] };
+    double line1DirectionInv[3] = { -line1Direction[0], -line1Direction[1], -line1Direction[2] };
+    double line1Length = vtkMath::Norm(line1Direction);
+    vtkMath::Normalize(line1Direction);
+    vtkMath::Normalize(line1DirectionInv);
+    double extendLineFactor = 100;
+    double extendedLine1PointR[3] = { line1PointL[0] + line1Direction[0] * line1Length * extendLineFactor,
+                                      line1PointL[1] + line1Direction[1] * line1Length * extendLineFactor,
+                                      line1PointL[2] + line1Direction[2] * line1Length * extendLineFactor };
+    double extendedLine1PointL[3] = { line1PointR[0] + line1DirectionInv[0] * line1Length * extendLineFactor,
+                                      line1PointR[1] + line1DirectionInv[1] * line1Length * extendLineFactor,
+                                      line1PointR[2] + line1DirectionInv[2] * line1Length * extendLineFactor };
+
+    for (size_t slice2Index = slice1Index + 1; slice2Index < numberOfIntersections; slice2Index++)
+      {
+      if (!this->Internal->SliceIntersectionInteractionDisplayPipelines[slice2Index]->GetVisibility())
+        {
+        continue;
+        }
+      // Get line 2 points
+      vtkLineSource* line2R = this->Internal->SliceIntersectionInteractionDisplayPipelines[slice2Index]->IntersectionLine1;
+      vtkLineSource* line2L = this->Internal->SliceIntersectionInteractionDisplayPipelines[slice2Index]->IntersectionLine2;
+      double* line2PointR = line2R->GetPoint1();
+      double* line2PointL = line2L->GetPoint1();
+
+      // Get extended line 2 points
+      double line2Direction[3] = { line2PointR[0] - line2PointL[0],
+                                   line2PointR[1] - line2PointL[1],
+                                   line2PointR[2] - line2PointL[2] };
+      double line2DirectionInv[3] = { -line2Direction[0], -line2Direction[1], -line2Direction[2] };
+      double line2Length = vtkMath::Norm(line2Direction);
+      vtkMath::Normalize(line2Direction);
+      vtkMath::Normalize(line2DirectionInv);
+      double extendedLine2PointR[3] = { line2PointL[0] + line2Direction[0] * line2Length * extendLineFactor,
+                                        line2PointL[1] + line2Direction[1] * line2Length * extendLineFactor,
+                                        line2PointL[2] + line2Direction[2] * line2Length * extendLineFactor };
+      double extendedLine2PointL[3] = { line2PointR[0] + line2DirectionInv[0] * line2Length * extendLineFactor,
+                                        line2PointR[1] + line2DirectionInv[1] * line2Length * extendLineFactor,
+                                        line2PointR[2] + line2DirectionInv[2] * line2Length * extendLineFactor };
+
+      // Compute intersection
+      double line1ParametricPosition = 0;
+      double line2ParametricPosition = 0;
+      if (vtkLine::Intersection(extendedLine1PointR, extendedLine1PointL, extendedLine2PointR, extendedLine2PointL,
+        line1ParametricPosition, line2ParametricPosition))
+        {
+        this->SliceIntersectionPoint[0] += extendedLine1PointR[0] + line1ParametricPosition * (extendedLine1PointL[0] - extendedLine1PointR[0]);
+        this->SliceIntersectionPoint[1] += extendedLine1PointR[1] + line1ParametricPosition * (extendedLine1PointL[1] - extendedLine1PointR[1]);
+        this->SliceIntersectionPoint[2] += extendedLine1PointR[2] + line1ParametricPosition * (extendedLine1PointL[2] - extendedLine1PointR[2]);
+        numberOfFoundIntersectionPoints++;
+        }
+      }
+    }
+  if (numberOfFoundIntersectionPoints > 0)
+    {
+    this->SliceIntersectionPoint[0] /= numberOfFoundIntersectionPoints;
+    this->SliceIntersectionPoint[1] /= numberOfFoundIntersectionPoints;
+    this->SliceIntersectionPoint[2] /= numberOfFoundIntersectionPoints;
+    }
+  else
+    {
+    // No slice intersections, use slice centerpoint
+    int* sliceDimension = this->Internal->SliceNode->GetDimensions();
+    this->SliceIntersectionPoint[0] = sliceDimension[0] / 2.0;
+    this->SliceIntersectionPoint[1] = sliceDimension[1] / 2.0;
+    this->SliceIntersectionPoint[2] = 0.0;
+    }
+  return this->SliceIntersectionPoint;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::TransformIntersectingSlices(vtkMatrix4x4 * rotatedSliceToSliceTransformMatrix)
+{
+  std::deque<int> wasModified;
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    if (!(*sliceIntersectionIt)
+      || !(*sliceIntersectionIt)->GetVisibility())
+      {
+      continue;
+      }
+    vtkMRMLSliceNode* sliceNode = (*sliceIntersectionIt)->SliceLogic->GetSliceNode();
+    wasModified.push_back(sliceNode->StartModify());
+
+    vtkNew<vtkMatrix4x4> rotatedSliceToRAS;
+    vtkMatrix4x4::Multiply4x4(rotatedSliceToSliceTransformMatrix, sliceNode->GetSliceToRAS(),
+      rotatedSliceToRAS);
+
+    sliceNode->GetSliceToRAS()->DeepCopy(rotatedSliceToRAS);
+    }
+
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    if (!(*sliceIntersectionIt)
+      || !(*sliceIntersectionIt)->GetVisibility())
+      {
+      continue;
+      }
+    vtkMRMLSliceNode* sliceNode = (*sliceIntersectionIt)->SliceLogic->GetSliceNode();
+    sliceNode->UpdateMatrices();
+    sliceNode->EndModify(wasModified.front());
+    wasModified.pop_front();
+    }
+}
+
+//----------------------------------------------------------------------
+double vtkMRMLSliceIntersectionInteractionRepresentation::GetMaximumHandlePickingDistance2()
+{
+  double maximumHandlePickingDistance = this->InteractionSize / 2.0 + this->PickingTolerance * this->ScreenScaleFactor;
+  return maximumHandlePickingDistance * maximumHandlePickingDistance;
+}
+
+//-----------------------------------------------------------------------------
+std::string vtkMRMLSliceIntersectionInteractionRepresentation::CanInteract(vtkMRMLInteractionEventData* interactionEventData,
+  int& foundComponentType, int& foundComponentIndex, double& closestDistance2, double& handleOpacity)
+{
+  foundComponentType = vtkMRMLSliceDisplayNode::ComponentNone;
+  closestDistance2 = VTK_DOUBLE_MAX; // in display coordinate system
+  foundComponentIndex = -1;
+  handleOpacity = 0.0; // Value to encode handles opacity value as a function of the distance of the mouse cursor to the handle position
+  std::string intersectingSliceNodeID;
+  double maxPickingDistanceFromControlPoint2 = this->GetMaximumHandlePickingDistance2();
+  double extendedPickingDistanceFromControlPoint2 = maxPickingDistanceFromControlPoint2 + OPACITY_RANGE;
+  double displayPosition3[3] = { 0.0, 0.0, 0.0 };
+  // Display position is valid in case of desktop interactions. Otherwise it is a 3D only context such as
+  // virtual reality, and then we expect a valid world position in the absence of display position.
+  if (interactionEventData->IsDisplayPositionValid())
+    {
+    const int* displayPosition = interactionEventData->GetDisplayPosition();
+    displayPosition3[0] = static_cast<double>(displayPosition[0]);
+    displayPosition3[1] = static_cast<double>(displayPosition[1]);
+    }
+  else if (!interactionEventData->IsWorldPositionValid())
+    {
+    return nullptr;
+    }
+
+  bool intersectingSlicesTranslationEnabled = true;
+  bool intersectingSlicesRotationEnabled = true;
+  vtkMRMLSliceDisplayNode* sliceDisplayNode = this->GetSliceDisplayNode();
+  if (sliceDisplayNode)
+    {
+    intersectingSlicesTranslationEnabled = sliceDisplayNode->GetIntersectingSlicesTranslationEnabled();
+    intersectingSlicesRotationEnabled = sliceDisplayNode->GetIntersectingSlicesRotationEnabled();
+    }
+
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    if (!(*sliceIntersectionIt)
+      || !(*sliceIntersectionIt)->GetVisibility())
+      {
+      continue;
+      }
+    vtkMRMLSliceNode* sliceNode = this->GetSliceNode();
+    if (sliceNode)
+      {
+      double handleDisplayPos[4] = { 0.0, 0.0, 0.0, 1.0 };
+
+      vtkNew<vtkMatrix4x4> rasToxyMatrix;
+      vtkMatrix4x4::Invert(sliceNode->GetXYToRAS(), rasToxyMatrix);
+
+      bool handlePicked = false;
+      double opacity = 0.0;
+      HandleInfoList handleInfoList = this->GetHandleInfoList((*sliceIntersectionIt));
+      for (HandleInfo handleInfo : handleInfoList)
+        {
+
+        // Ignore handle if the corresponding interaction mode is disabled
+        if (!intersectingSlicesTranslationEnabled
+          && (handleInfo.ComponentType == vtkMRMLSliceDisplayNode::ComponentTranslateIntersectingSlicesHandle
+            || handleInfo.ComponentType == vtkMRMLSliceDisplayNode::ComponentTranslateSingleIntersectingSliceHandle))
+          {
+          // translation is disabled and this is a translation handle
+          continue;
+          }
+        if (!intersectingSlicesRotationEnabled
+          && handleInfo.ComponentType == vtkMRMLSliceDisplayNode::ComponentRotateIntersectingSlicesHandle)
+          {
+          // rotation is disabled and this is a translation handle
+          continue;
+          }
+
+        double* handleWorldPos = handleInfo.PositionWorld;
+        rasToxyMatrix->MultiplyPoint(handleWorldPos, handleDisplayPos);
+        handleDisplayPos[2] = displayPosition3[2]; // Handles are always projected
+        double dist2 = vtkMath::Distance2BetweenPoints(handleDisplayPos, displayPosition3);
+        if (dist2 < extendedPickingDistanceFromControlPoint2)
+          {
+          if (dist2 < maxPickingDistanceFromControlPoint2)
+            {
+            handleOpacity = 1.0;
+            if (dist2 < closestDistance2)
+              {
+              closestDistance2 = dist2;
+              foundComponentType = handleInfo.ComponentType;
+              foundComponentIndex = handleInfo.Index;
+              intersectingSliceNodeID = handleInfo.IntersectingSliceNodeID;
+              handlePicked = true;
+              }
+            }
+          else
+            {
+            opacity = (dist2 - extendedPickingDistanceFromControlPoint2) / ( - OPACITY_RANGE);
+            if (opacity > handleOpacity)
+              {
+              handleOpacity = opacity;
+              }
+            }
+          }
+        }
+      }
+    else
+      {
+      bool handlePicked = false;
+      HandleInfoList handleInfoList = this->GetHandleInfoList((*sliceIntersectionIt));
+      for (HandleInfo handleInfo : handleInfoList)
+        {
+        double* handleWorldPos = handleInfo.PositionWorld;
+        double handleDisplayPos[3] = { 0 };
+
+        if (interactionEventData->IsDisplayPositionValid())
+          {
+          double pixelTolerance = this->InteractionSize / 2.0 / this->GetViewScaleFactorAtPosition(handleWorldPos)
+            + this->PickingTolerance * this->ScreenScaleFactor;
+          this->Renderer->SetWorldPoint(handleWorldPos);
+          this->Renderer->WorldToDisplay();
+          this->Renderer->GetDisplayPoint(handleDisplayPos);
+          handleDisplayPos[2] = 0.0;
+          double dist2 = vtkMath::Distance2BetweenPoints(handleDisplayPos, displayPosition3);
+          if (dist2 < pixelTolerance * pixelTolerance && dist2 < closestDistance2)
+            {
+            closestDistance2 = dist2;
+            foundComponentType = handleInfo.ComponentType;
+            foundComponentIndex = handleInfo.Index;
+            intersectingSliceNodeID = handleInfo.IntersectingSliceNodeID;
+            handlePicked = true;
+            }
+          }
+        else
+          {
+          const double* worldPosition = interactionEventData->GetWorldPosition();
+          double worldTolerance = this->InteractionSize / 2.0 +
+            this->PickingTolerance / interactionEventData->GetWorldToPhysicalScale();
+          double dist2 = vtkMath::Distance2BetweenPoints(handleWorldPos, worldPosition);
+          if (dist2 < worldTolerance * worldTolerance && dist2 < closestDistance2)
+            {
+            closestDistance2 = dist2;
+            foundComponentType = handleInfo.ComponentType;
+            foundComponentIndex = handleInfo.Index;
+            intersectingSliceNodeID = handleInfo.IntersectingSliceNodeID;
+            }
+          }
+        }
+      }
+    }
+  return intersectingSliceNodeID;
+}
+
+//----------------------------------------------------------------------
+vtkMRMLSliceIntersectionInteractionRepresentation::HandleInfoList
+vtkMRMLSliceIntersectionInteractionRepresentation::GetHandleInfoList(SliceIntersectionInteractionDisplayPipeline* pipeline)
+{
+  vtkMRMLSliceNode* currentSliceNode = this->GetSliceNode(); // Get slice node
+  vtkMRMLSliceNode* intersectingSliceNode = pipeline->SliceLogic->GetSliceNode(); // Get intersecting slice node
+  std::string intersectingSliceNodeID = intersectingSliceNode->GetID(); // Get intersection slice node ID
+  vtkMatrix4x4* currentXYToRAS = currentSliceNode->GetXYToRAS(); // Get XY to RAS transform matrix
+  HandleInfoList handleInfoList;
+  for (int i = 0; i < pipeline->RotationHandlePoints->GetNumberOfPoints(); ++i)
+    {
+    double handlePositionLocal[3] = { 0 };
+    double handlePositionLocal_h[4] = { 0.0,0.0,0.0,1.0 };
+    double handlePositionWorld[3] = { 0 };
+    double handlePositionWorld_h[4] = { 0.0,0.0,0.0,1.0 };
+    pipeline->RotationHandlePoints->GetPoint(i, handlePositionLocal);
+    handlePositionLocal_h[0] = handlePositionLocal[0];
+    handlePositionLocal_h[1] = handlePositionLocal[1];
+    handlePositionLocal_h[2] = handlePositionLocal[2];
+    currentXYToRAS->MultiplyPoint(handlePositionLocal_h, handlePositionWorld_h);
+    handlePositionWorld[0] = handlePositionWorld_h[0];
+    handlePositionWorld[1] = handlePositionWorld_h[1];
+    handlePositionWorld[2] = handlePositionWorld_h[2];
+    HandleInfo info(i, vtkMRMLSliceDisplayNode::ComponentRotateIntersectingSlicesHandle,
+      intersectingSliceNodeID, handlePositionWorld, handlePositionLocal);
+    handleInfoList.push_back(info);
+    }
+
+  for (int i = 0; i < pipeline->TranslationHandlePoints->GetNumberOfPoints(); ++i)
+    {
+    double handlePositionLocal[3] = { 0 };
+    double handlePositionLocal_h[4] = { 0.0,0.0,0.0,1.0 };
+    double handlePositionWorld[3] = { 0 };
+    double handlePositionWorld_h[4] = { 0.0,0.0,0.0,1.0 };
+    pipeline->TranslationHandlePoints->GetPoint(i, handlePositionLocal);
+    handlePositionLocal_h[0] = handlePositionLocal[0];
+    handlePositionLocal_h[1] = handlePositionLocal[1];
+    handlePositionLocal_h[2] = handlePositionLocal[2];
+    currentXYToRAS->MultiplyPoint(handlePositionLocal_h, handlePositionWorld_h);
+    handlePositionWorld[0] = handlePositionWorld_h[0];
+    handlePositionWorld[1] = handlePositionWorld_h[1];
+    handlePositionWorld[2] = handlePositionWorld_h[2];
+    HandleInfo info(i, vtkMRMLSliceDisplayNode::ComponentTranslateIntersectingSlicesHandle,
+      intersectingSliceNodeID, handlePositionWorld, handlePositionLocal);
+    handleInfoList.push_back(info);
+    }
+
+  for (int i = 0; i < pipeline->SliceOffsetHandlePoints->GetNumberOfPoints(); ++i)
+    {
+    double handlePositionLocal[3] = { 0 };
+    double handlePositionLocal_h[4] = { 0.0,0.0,0.0,1.0 };
+    double handlePositionWorld[3] = { 0 };
+    double handlePositionWorld_h[4] = { 0.0,0.0,0.0,1.0 };
+    pipeline->SliceOffsetHandlePoints->GetPoint(i, handlePositionLocal);
+    handlePositionLocal_h[0] = handlePositionLocal[0];
+    handlePositionLocal_h[1] = handlePositionLocal[1];
+    handlePositionLocal_h[2] = handlePositionLocal[2];
+    currentXYToRAS->MultiplyPoint(handlePositionLocal_h, handlePositionWorld_h);
+    handlePositionWorld[0] = handlePositionWorld_h[0];
+    handlePositionWorld[1] = handlePositionWorld_h[1];
+    handlePositionWorld[2] = handlePositionWorld_h[2];
+    HandleInfo info(i, vtkMRMLSliceDisplayNode::ComponentTranslateSingleIntersectingSliceHandle,
+      intersectingSliceNodeID, handlePositionWorld, handlePositionLocal);
+    handleInfoList.push_back(info);
+    }
+
+  return handleInfoList;
+}
+
+//----------------------------------------------------------------------
+double vtkMRMLSliceIntersectionInteractionRepresentation::GetViewScaleFactorAtPosition(double positionWorld[3])
+{
+  double viewScaleFactorMmPerPixel = 1.0;
+  if (!this->Renderer || !this->Renderer->GetActiveCamera())
+    {
+    return viewScaleFactorMmPerPixel;
+    }
+
+  vtkCamera* cam = this->Renderer->GetActiveCamera();
+  if (cam->GetParallelProjection())
+    {
+    // Viewport: xmin, ymin, xmax, ymax; range: 0.0-1.0; origin is bottom left
+    // Determine the available renderer size in pixels
+    double minX = 0;
+    double minY = 0;
+    this->Renderer->NormalizedDisplayToDisplay(minX, minY);
+    double maxX = 1;
+    double maxY = 1;
+    this->Renderer->NormalizedDisplayToDisplay(maxX, maxY);
+    int rendererSizeInPixels[2] = { static_cast<int>(maxX - minX), static_cast<int>(maxY - minY) };
+    // Parallel scale: height of the viewport in world-coordinate distances.
+    // Larger numbers produce smaller images.
+    viewScaleFactorMmPerPixel = (cam->GetParallelScale() * 2.0) / double(rendererSizeInPixels[1]);
+    }
+  else
+    {
+    double cameraFP[4] = { positionWorld[0], positionWorld[1], positionWorld[2], 1.0 };
+
+    double cameraViewUp[3] = { 0 };
+    cam->GetViewUp(cameraViewUp);
+    vtkMath::Normalize(cameraViewUp);
+
+    // Get distance in pixels between two points at unit distance above and below the focal point
+    this->Renderer->SetWorldPoint(cameraFP[0] + cameraViewUp[0], cameraFP[1] + cameraViewUp[1], cameraFP[2] + cameraViewUp[2], cameraFP[3]);
+    this->Renderer->WorldToDisplay();
+    double topCenter[3] = { 0 };
+    this->Renderer->GetDisplayPoint(topCenter);
+    topCenter[2] = 0.0;
+    this->Renderer->SetWorldPoint(cameraFP[0] - cameraViewUp[0], cameraFP[1] - cameraViewUp[1], cameraFP[2] - cameraViewUp[2], cameraFP[3]);
+    this->Renderer->WorldToDisplay();
+    double bottomCenter[3] = { 0 };
+    this->Renderer->GetDisplayPoint(bottomCenter);
+    bottomCenter[2] = 0.0;
+    double distInPixels = sqrt(vtkMath::Distance2BetweenPoints(topCenter, bottomCenter));
+
+    // if render window is not initialized yet then distInPixels == 0.0,
+    // in that case just leave the default viewScaleFactorMmPerPixel
+    if (distInPixels > 1e-3)
+      {
+      // 2.0 = 2x length of viewUp vector in mm (because viewUp is unit vector)
+      viewScaleFactorMmPerPixel = 2.0 / distInPixels;
+      }
+    }
+  return viewScaleFactorMmPerPixel;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::SetPipelinesHandlesVisibility(bool visible)
+{
+  // Update handles visibility in all display pipelines
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    if ((*sliceIntersectionIt)->HandlesVisibilityMode == vtkMRMLSliceDisplayNode::AlwaysVisible)
+      {
+      visible = true;
+      }
+    else if ((*sliceIntersectionIt)->HandlesVisibilityMode == vtkMRMLSliceDisplayNode::NeverVisible)
+      {
+      visible = false;
+      }
+    (*sliceIntersectionIt)->SetHandlesVisibility(visible);
+    if ((*sliceIntersectionIt)->NeedToRender)
+      {
+      this->NeedToRenderOn();
+      }
+    }
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::SetPipelinesHandlesOpacity(double opacity)
+{
+  // Update handles visibility in all display pipelines
+  for (std::deque<SliceIntersectionInteractionDisplayPipeline*>::iterator
+    sliceIntersectionIt = this->Internal->SliceIntersectionInteractionDisplayPipelines.begin();
+    sliceIntersectionIt != this->Internal->SliceIntersectionInteractionDisplayPipelines.end(); ++sliceIntersectionIt)
+    {
+    // Force visible handles in the "handles always visible" mode is activated
+    if ((*sliceIntersectionIt)->HandlesVisibilityMode == vtkMRMLSliceDisplayNode::AlwaysVisible)
+      {
+      opacity = 1.0;
+      }
+
+    (*sliceIntersectionIt)->SetHandlesOpacity(opacity);
+    if ((*sliceIntersectionIt)->NeedToRender)
+      {
+      this->NeedToRenderOn();
+      }
+    }
+}
+
+//----------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionInteractionRepresentation::IsMouseCursorInSliceView(double cursorPosition[2])
+{
+  // Get current slice view bounds
+  vtkMRMLSliceNode* currentSliceNode = this->GetSliceNode();
+  double sliceViewBounds[4] = {};
+  this->Helper->GetSliceViewBoundariesXY(currentSliceNode, sliceViewBounds);
+
+  // Check mouse cursor position
+  bool inSliceView;
+  if ((cursorPosition[0] > sliceViewBounds[0]) &&
+    (cursorPosition[0] < sliceViewBounds[1]) &&
+    (cursorPosition[1] > sliceViewBounds[2]) &&
+    (cursorPosition[1] < sliceViewBounds[3]))
+    {
+    inSliceView = true;
+    }
+  else
+    {
+    inSliceView = false;
+    }
+  return inSliceView;
+}
+
+//-----------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionInteractionRepresentation::IsDisplayable()
+{
+  vtkMRMLSliceDisplayNode* sliceDisplayNode = this->GetSliceDisplayNode();
+  if (!sliceDisplayNode
+    || !this->ViewNode
+    || !sliceDisplayNode->GetVisibility()
+    || !sliceDisplayNode->IsDisplayableInView(this->ViewNode->GetID()))
+    {
+    return false;
+    }
+
+  if (vtkMRMLSliceNode::SafeDownCast(this->ViewNode))
+    {
+    if (!sliceDisplayNode->GetVisibility2D())
+      {
+      return false;
+      }
+    }
+  if (vtkMRMLViewNode::SafeDownCast(this->ViewNode))
+    {
+    if (!sliceDisplayNode->GetVisibility3D())
+      {
+      return false;
+      }
+    }
+  return true;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentation::UpdateFromMRML(vtkMRMLNode* caller, unsigned long event, void *callData /*=nullptr*/)
+{
+  Superclass::UpdateFromMRML(caller, event, callData);
+
+  this->NeedToRenderOn();
+
+  vtkMRMLSliceIntersectionInteractionRepresentation* self = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast((vtkObject*)callData);
+
+  vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(caller);
+  if (sliceNode)
+    {
+    self->SliceNodeModified(sliceNode);
+    return;
+    }
+
+  vtkMRMLSliceLogic* sliceLogic = vtkMRMLSliceLogic::SafeDownCast(caller);
+  if (sliceLogic)
+    {
+    self->UpdateSliceIntersectionDisplay(self->GetDisplayPipelineFromSliceLogic(sliceLogic));
+    return;
+    }
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.h
@@ -1,0 +1,189 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Ebatinca S.L., Las Palmas de Gran Canaria, Spain
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+/**
+ * @class   vtkMRMLSliceIntersectionInteractionRepresentation
+ * @brief   represent intersections of other slice views in the current slice view
+ *
+ * @sa
+ * vtkSliceIntersectionWidget vtkWidgetRepresentation vtkAbstractWidget
+*/
+
+#ifndef vtkMRMLSliceIntersectionInteractionRepresentation_h
+#define vtkMRMLSliceIntersectionInteractionRepresentation_h
+
+#include "vtkMRMLDisplayableManagerExport.h" // For export macro
+#include "vtkMRMLAbstractWidgetRepresentation.h"
+#include "vtkMRMLSliceIntersectionInteractionRepresentationHelper.h"
+
+#include "vtkMRMLSliceDisplayNode.h"
+#include "vtkMRMLSliceNode.h"
+
+class vtkMRMLApplicationLogic;
+class vtkMRMLModelDisplayNode;
+class vtkMRMLSliceLogic;
+
+class vtkProperty2D;
+class vtkActor2D;
+class vtkPolyDataMapper2D;
+class vtkPolyData;
+class vtkPoints;
+class vtkCellArray;
+class vtkTextProperty;
+class vtkLeaderActor2D;
+class vtkTextMapper;
+class vtkTransform;
+class vtkActor2D;
+
+class SliceIntersectionInteractionDisplayPipeline;
+class vtkMRMLInteractionEventData;
+
+class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionInteractionRepresentation : public vtkMRMLAbstractWidgetRepresentation
+{
+  public:
+    /**
+     * Instantiate this class.
+     */
+    static vtkMRMLSliceIntersectionInteractionRepresentation* New();
+
+    //@{
+    /**
+     * Standard methods for instances of this class.
+     */
+    vtkTypeMacro(vtkMRMLSliceIntersectionInteractionRepresentation, vtkMRMLAbstractWidgetRepresentation);
+    void PrintSelf(ostream& os, vtkIndent indent) override;
+    //@}
+
+    void SetSliceNode(vtkMRMLSliceNode* sliceNode);
+    vtkMRMLSliceNode* GetSliceNode();
+
+    vtkMRMLSliceDisplayNode* GetSliceDisplayNode();
+
+    bool IsDisplayable();
+    void UpdateFromMRML(vtkMRMLNode* caller, unsigned long event, void* callData = nullptr) override;
+
+    void AddIntersectingSliceLogic(vtkMRMLSliceLogic* sliceLogic);
+    void RemoveIntersectingSliceNode(vtkMRMLSliceNode* sliceNode);
+    void UpdateIntersectingSliceNodes();
+    void RemoveAllIntersectingSliceNodes();
+
+    //@{
+    /**
+     * Methods to make this class behave as a vtkProp.
+     */
+    void GetActors2D(vtkPropCollection*) override;
+    void ReleaseGraphicsResources(vtkWindow*) override;
+    int RenderOverlay(vtkViewport* viewport) override;
+    //@}
+
+    void SetMRMLApplicationLogic(vtkMRMLApplicationLogic*);
+    vtkGetObjectMacro(MRMLApplicationLogic, vtkMRMLApplicationLogic);
+
+    /// Get slice intersection point between red, green and yellow slice nodes
+    double* GetSliceIntersectionPoint();
+
+    /// Check whether the mouse cursor is within the slice view or not
+    bool IsMouseCursorInSliceView(double cursorPosition[2]);
+
+    void SetPipelinesHandlesVisibility(bool visible);
+    void SetPipelinesHandlesOpacity(double opacity);
+
+    void TransformIntersectingSlices(vtkMatrix4x4* rotatedSliceToSliceTransformMatrix);
+
+    /// Return found component type (as vtkMRMLInteractionDisplayNode::ComponentType).
+    /// closestDistance2 is the squared distance in display coordinates from the closest position where interaction is possible.
+    /// componentIndex returns index of the found component (e.g., if control point is found then control point index is returned).
+    virtual std::string CanInteract(vtkMRMLInteractionEventData* interactionEventData,
+        int& foundComponentType, int& foundComponentIndex, double& closestDistance2, double& handleOpacity);
+
+    virtual double GetMaximumHandlePickingDistance2();
+
+    class HandleInfo
+      {
+      public:
+        HandleInfo(int index, int componentType, const std::string& intersectingSliceNodeID, double positionWorld[3], double positionLocal[3])
+          : Index(index)
+          , ComponentType(componentType)
+          , IntersectingSliceNodeID(intersectingSliceNodeID)
+          {
+          for (int i = 0; i < 3; ++i)
+            {
+            this->PositionWorld[i] = positionWorld[i];
+            }
+          this->PositionWorld[3] = 1.0;
+          for (int i = 0; i < 3; ++i)
+            {
+            this->PositionLocal[i] = positionLocal[i];
+            }
+          this->PositionLocal[3] = 1.0;
+          }
+        int Index;
+        int ComponentType;
+        std::string IntersectingSliceNodeID;
+        double PositionLocal[4];
+        double PositionWorld[4];
+      };
+
+    /// Get the list of info for all interaction handles
+    typedef std::vector<HandleInfo> HandleInfoList;
+    virtual HandleInfoList GetHandleInfoList(SliceIntersectionInteractionDisplayPipeline* pipeline);
+
+  protected:
+    vtkMRMLSliceIntersectionInteractionRepresentation();
+    ~vtkMRMLSliceIntersectionInteractionRepresentation() override;
+
+    SliceIntersectionInteractionDisplayPipeline* GetDisplayPipelineFromSliceLogic(vtkMRMLSliceLogic* sliceLogic);
+
+    static void SliceNodeModifiedCallback(vtkObject* caller, unsigned long eid, void* clientData, void* callData);
+    void SliceNodeModified(vtkMRMLSliceNode* sliceNode);
+    void SliceModelDisplayNodeModified(vtkMRMLModelDisplayNode* sliceNode);
+
+    void UpdateSliceIntersectionDisplay(SliceIntersectionInteractionDisplayPipeline* pipeline);
+
+    vtkMRMLSliceDisplayNode* GetSliceDisplayNode(vtkMRMLSliceNode* sliceNode);
+
+    void SetSliceDisplayNode(vtkMRMLSliceDisplayNode* sliceDisplayNode);
+
+    double GetSliceRotationAngleRad(int eventPos[2]);
+
+    /// Support picking
+    double LastEventPosition[2];
+
+    /// Slice intersection point in XY
+    double SliceIntersectionPoint[4];
+
+    /// Handle size, specified in renderer world coordinate system.
+    /// For slice views, renderer world coordinate system is the display coordinate system, so it is measured in pixels.
+    /// For 3D views, renderer world coordinate system is the Slicer world coordinate system, so it is measured in the
+    /// scene length unit (typically millimeters).
+    double InteractionSize{ 3.0 };
+
+    double GetViewScaleFactorAtPosition(double positionWorld[3]);
+
+    vtkMRMLApplicationLogic* MRMLApplicationLogic;
+
+    class vtkInternal;
+    vtkInternal* Internal;
+
+    vtkMRMLSliceIntersectionInteractionRepresentationHelper* Helper;
+
+  private:
+    vtkMRMLSliceIntersectionInteractionRepresentation(const vtkMRMLSliceIntersectionInteractionRepresentation&) = delete;
+    void operator=(const vtkMRMLSliceIntersectionInteractionRepresentation&) = delete;
+};
+
+#endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.cxx
@@ -1,0 +1,454 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Ebatinca S.L., Las Palmas de Gran Canaria, Spain
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#include "vtkMRMLSliceIntersectionInteractionRepresentationHelper.h"
+
+
+#include <deque>
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+#include "vtkMRMLApplicationLogic.h"
+#include "vtkMRMLDisplayableNode.h"
+#include "vtkMRMLInteractionNode.h"
+#include "vtkMRMLModelDisplayNode.h"
+#include "vtkMRMLScene.h"
+#include "vtkMRMLSliceLogic.h"
+#include "vtkMRMLSliceNode.h"
+#include "vtkMRMLSliceCompositeNode.h"
+
+#include "vtkActor2D.h"
+#include "vtkArcSource.h"
+#include "vtkAppendPolyData.h"
+#include "vtkAssemblyPath.h"
+#include "vtkCallbackCommand.h"
+#include "vtkCamera.h"
+#include "vtkCellArray.h"
+#include "vtkCommand.h"
+#include "vtkConeSource.h"
+#include "vtkCoordinate.h"
+#include "vtkCursor2D.h"
+#include "vtkCylinderSource.h"
+#include "vtkGlyph2D.h"
+#include "vtkInteractorObserver.h"
+#include "vtkLeaderActor2D.h"
+#include "vtkLine.h"
+#include "vtkLineSource.h"
+#include "vtkMath.h"
+#include "vtkMatrix3x3.h"
+#include "vtkMatrix4x4.h"
+#include "vtkObjectFactory.h"
+#include "vtkPoints.h"
+#include "vtkPolyDataAlgorithm.h"
+#include "vtkPolyDataMapper2D.h"
+#include "vtkProperty2D.h"
+#include "vtkPlane.h"
+#include "vtkRenderer.h"
+#include "vtkRenderWindow.h"
+#include "vtkSphereSource.h"
+#include "vtkTransform.h"
+#include "vtkTransformPolyDataFilter.h"
+#include "vtkTextMapper.h"
+#include "vtkTextProperty.h"
+#include "vtkTubeFilter.h"
+#include "vtkWindow.h"
+
+// MRML includes
+#include <vtkMRMLInteractionEventData.h>
+
+// Handles
+static const double SLICEOFSSET_HANDLE_DEFAULT_POSITION[3] = { 0.0,0.0,0.0 };
+static const double SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION[3] = { 0.0,1.0,0.0 };
+
+vtkStandardNewMacro(vtkMRMLSliceIntersectionInteractionRepresentationHelper);
+
+//----------------------------------------------------------------------
+vtkMRMLSliceIntersectionInteractionRepresentationHelper::vtkMRMLSliceIntersectionInteractionRepresentationHelper()
+{
+}
+
+//----------------------------------------------------------------------
+vtkMRMLSliceIntersectionInteractionRepresentationHelper::~vtkMRMLSliceIntersectionInteractionRepresentationHelper()
+{
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentationHelper::PrintSelf(ostream & os, vtkIndent indent)
+{
+  //Superclass typedef defined in vtkTypeMacro() found in vtkSetGet.h
+  this->Superclass::PrintSelf(os, indent);
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentationHelper::GetSliceViewBoundariesXY(vtkMRMLSliceNode* sliceNode, double* sliceViewBounds)
+{
+  // Get FOV of current slice node in mm
+  char* sliceNodeName = sliceNode->GetName();
+  double sliceFOVMm[3] = { 0.0,0.0,0.0 };
+  sliceNode->GetFieldOfView(sliceFOVMm);
+
+  // Get XYToRAS and RASToXY transform matrices
+  vtkMatrix4x4* currentXYToRAS = sliceNode->GetXYToRAS();
+  vtkNew<vtkMatrix4x4> currentRASToXY;
+  vtkMatrix4x4::Invert(currentXYToRAS, currentRASToXY);
+
+  // Get slice view axes in RAS
+  double sliceOrigin[4] = { 0.0,0.0,0.0,1.0 };
+  double slicePointAxisX[4] = { 100.0,0.0,0.0,1.0 };
+  double slicePointAxisY[4] = { 0.0,100.0,0.0,1.0 };
+  currentXYToRAS->MultiplyPoint(sliceOrigin, sliceOrigin);
+  currentXYToRAS->MultiplyPoint(slicePointAxisX, slicePointAxisX);
+  currentXYToRAS->MultiplyPoint(slicePointAxisY, slicePointAxisY);
+  double sliceAxisX[3] = { slicePointAxisX[0] - sliceOrigin[0],
+                           slicePointAxisX[1] - sliceOrigin[1],
+                           slicePointAxisX[2] - sliceOrigin[2] };
+  double sliceAxisY[3] = { slicePointAxisY[0] - sliceOrigin[0],
+                           slicePointAxisY[1] - sliceOrigin[1],
+                           slicePointAxisY[2] - sliceOrigin[2] };
+  vtkMath::Normalize(sliceAxisX);
+  vtkMath::Normalize(sliceAxisY);
+
+  // Calculate corners of FOV in RAS coordinate system
+  double bottomLeftCornerRAS[4] = { 0.0,0.0,0.0,1.0 };
+  double topLeftCornerRAS[4] = { 0.0,0.0,0.0,1.0 };
+  double bottomRightCornerRAS[4] = { 0.0,0.0,0.0,1.0 };
+  double topRightCornerRAS[4] = { 0.0,0.0,0.0,1.0 };
+
+  // Get slice view corners RAS
+  bottomLeftCornerRAS[0] = sliceOrigin[0];
+  bottomLeftCornerRAS[1] = sliceOrigin[1];
+  bottomLeftCornerRAS[2] = sliceOrigin[2];
+  topLeftCornerRAS[0] = sliceOrigin[0] + sliceAxisY[0] * sliceFOVMm[1];
+  topLeftCornerRAS[1] = sliceOrigin[1] + sliceAxisY[1] * sliceFOVMm[1];
+  topLeftCornerRAS[2] = sliceOrigin[2] + sliceAxisY[2] * sliceFOVMm[1];
+  bottomRightCornerRAS[0] = sliceOrigin[0] + sliceAxisX[0] * sliceFOVMm[0];
+  bottomRightCornerRAS[1] = sliceOrigin[1] + sliceAxisX[1] * sliceFOVMm[0];
+  bottomRightCornerRAS[2] = sliceOrigin[2] + sliceAxisX[2] * sliceFOVMm[0];
+  topRightCornerRAS[0] = sliceOrigin[0] + sliceAxisY[0] * sliceFOVMm[1] + sliceAxisX[0] * sliceFOVMm[0];
+  topRightCornerRAS[1] = sliceOrigin[1] + sliceAxisY[1] * sliceFOVMm[1] + sliceAxisX[1] * sliceFOVMm[0];
+  topRightCornerRAS[2] = sliceOrigin[2] + sliceAxisY[2] * sliceFOVMm[1] + sliceAxisX[2] * sliceFOVMm[0];
+
+  // Calculate corners of FOV in XY coordinate system
+  double bottomLeftCornerXY[4] = { 0.0,0.0,0.0,1.0 };
+  double topLeftCornerXY[4] = { 0.0,0.0,0.0,1.0 };
+  double bottomRightCornerXY[4] = { 0.0,0.0,0.0,1.0 };
+  double topRightCornerXY[4] = { 0.0,0.0,0.0,1.0 };
+  currentRASToXY->MultiplyPoint(bottomLeftCornerRAS, bottomLeftCornerXY);
+  currentRASToXY->MultiplyPoint(topLeftCornerRAS, topLeftCornerXY);
+  currentRASToXY->MultiplyPoint(bottomRightCornerRAS, bottomRightCornerXY);
+  currentRASToXY->MultiplyPoint(topRightCornerRAS, topRightCornerXY);
+
+  // Get slice view range XY
+  sliceViewBounds[0] = bottomLeftCornerXY[0]; // Min value of X
+  sliceViewBounds[1] = topRightCornerXY[0]; // Max value of X
+  sliceViewBounds[2] = bottomLeftCornerXY[1]; //  Min value of Y
+  sliceViewBounds[3] = topRightCornerXY[1]; //  Max value of Y
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentationHelper::GetIntersectionWithSliceViewBoundaries(double* pointA, double* pointB,
+      double* sliceViewBounds, double* intersectionPoint)
+{
+    // Get line equation -> y = slope * x + intercept
+    double xA = pointA[0];
+    double yA = pointA[1];
+    double xB = pointB[0];
+    double yB = pointB[1];
+    double dx, dy, slope, intercept;
+    dx = xB - xA;
+    dy = yB - yA;
+    slope = dy / dx;
+    intercept = yA - slope * xA;
+
+    // Get line bounding box
+    double lineBounds[4] = { std::min(xA, xB), std::max(xA, xB), std::min(yA, yB), std::max(yA, yB) };
+
+    // Slice view bounds
+    double xMin = sliceViewBounds[0];
+    double xMax = sliceViewBounds[1];
+    double yMin = sliceViewBounds[2];
+    double yMax = sliceViewBounds[3];
+
+    // Get intersection point using line equation
+    double x0, y0;
+    if ((xMin > lineBounds[0]) && (xMin < lineBounds[1]))
+      {
+      y0 = slope * xMin + intercept;
+      if ((y0 > yMin) && (y0 < yMax))
+        {
+        intersectionPoint[0] = xMin;
+        intersectionPoint[1] = y0;
+        return;
+        }
+      }
+    if ((xMax > lineBounds[0]) && (xMax < lineBounds[1]))
+      {
+      y0 = slope * xMax + intercept;
+      if ((y0 > yMin) && (y0 < yMax))
+        {
+        intersectionPoint[0] = xMax;
+        intersectionPoint[1] = y0;
+        return;
+        }
+      }
+    if ((yMin > lineBounds[2]) && (yMin < lineBounds[3]))
+      {
+      if (std::isfinite(slope)) // check if slope is finite
+        {
+        x0 = (yMin - intercept)/slope;
+        if ((x0 > xMin) && (x0 < xMax))
+          {
+          intersectionPoint[0] = x0;
+          intersectionPoint[1] = yMin;
+          return;
+          }
+        }
+      else // infinite slope = vertical line
+        {
+          intersectionPoint[0] = lineBounds[0]; // or lineBounds[1] (if the line is vertical, then both points A and B have the same value of X)
+          intersectionPoint[1] = yMin;
+          return;
+        }
+      }
+    if ((yMax > lineBounds[2]) && (yMax < lineBounds[3]))
+      {
+      if (std::isfinite(slope)) // check if slope is finite
+        {
+        x0 = (yMax - intercept)/slope;
+        if ((x0 > xMin) && (x0 < xMax))
+          {
+          intersectionPoint[0] = x0;
+          intersectionPoint[1] = yMax;
+          return;
+          }
+        }
+      else // infinite slope = vertical line
+        {
+          intersectionPoint[0] = lineBounds[0]; // or lineBounds[1] (if the line is vertical, then both points A and B have the same value of X)
+          intersectionPoint[1] = yMax;
+          return;
+        }
+      }
+    return;
+}
+
+//---------------------------------------------------------------------------
+int vtkMRMLSliceIntersectionInteractionRepresentationHelper::IntersectWithFinitePlane(double n[3], double o[3],
+  double pOrigin[3], double px[3], double py[3],
+  double x0[3], double x1[3])
+{
+  // Since we are dealing with convex shapes, if there is an intersection a
+  // single line is produced as output. So all this is necessary is to
+  // intersect the four bounding lines of the finite line and find the two
+  // intersection points.
+  int numInts = 0;
+  double t, * x = x0;
+  double xr0[3], xr1[3];
+
+  // First line
+  xr0[0] = pOrigin[0];
+  xr0[1] = pOrigin[1];
+  xr0[2] = pOrigin[2];
+  xr1[0] = px[0];
+  xr1[1] = px[1];
+  xr1[2] = px[2];
+  if (vtkPlane::IntersectWithLine(xr0, xr1, n, o, t, x))
+    {
+    numInts++;
+    x = x1;
+    }
+
+  // Second line
+  xr1[0] = py[0];
+  xr1[1] = py[1];
+  xr1[2] = py[2];
+  if (vtkPlane::IntersectWithLine(xr0, xr1, n, o, t, x))
+    {
+    numInts++;
+    x = x1;
+    }
+  if (numInts == 2)
+    {
+    return 1;
+    }
+
+  // Third line
+  xr0[0] = -pOrigin[0] + px[0] + py[0];
+  xr0[1] = -pOrigin[1] + px[1] + py[1];
+  xr0[2] = -pOrigin[2] + px[2] + py[2];
+  if (vtkPlane::IntersectWithLine(xr0, xr1, n, o, t, x))
+    {
+    numInts++;
+    x = x1;
+    }
+  if (numInts == 2)
+    {
+    return 1;
+    }
+
+  // Fourth and last line
+  xr1[0] = px[0];
+  xr1[1] = px[1];
+  xr1[2] = px[2];
+  if (vtkPlane::IntersectWithLine(xr0, xr1, n, o, t, x))
+    {
+    numInts++;
+    }
+  if (numInts == 2)
+    {
+    return 1;
+    }
+
+  // No intersection has occurred, or a single degenerate point
+  return 0;
+}
+
+//----------------------------------------------------------------------
+int vtkMRMLSliceIntersectionInteractionRepresentationHelper::GetLineTipsFromIntersectingSliceNode(vtkMRMLSliceNode* intersectingSliceNode,
+    vtkMatrix4x4* intersectingXYToXY, double intersectionOuterLineTip1[3], double intersectionOuterLineTip2[3])
+{
+  // Define current slice plane
+  double slicePlaneNormal[3] = { 0.,0.,1. };
+  double slicePlaneOrigin[3] = { 0., 0., 0. };
+
+  // Define slice size dimensions
+  int* intersectingSliceSizeDimensions = intersectingSliceNode->GetDimensions();
+  double intersectingPlaneOrigin[4] = { 0, 0, 0, 1 };
+  double intersectingPlaneX[4] = { double(intersectingSliceSizeDimensions[0]), 0., 0., 1. };
+  double intersectingPlaneY[4] = { 0., double(intersectingSliceSizeDimensions[1]), 0., 1. };
+  intersectingXYToXY->MultiplyPoint(intersectingPlaneOrigin, intersectingPlaneOrigin);
+  intersectingXYToXY->MultiplyPoint(intersectingPlaneX, intersectingPlaneX);
+  intersectingXYToXY->MultiplyPoint(intersectingPlaneY, intersectingPlaneY);
+
+  // Compute intersection
+  int intersectionFound = this->IntersectWithFinitePlane(slicePlaneNormal, slicePlaneOrigin,
+    intersectingPlaneOrigin, intersectingPlaneX, intersectingPlaneY, intersectionOuterLineTip1, intersectionOuterLineTip2);
+
+  return intersectionFound;
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentationHelper::ComputeHandleToWorldTransformMatrix(double handlePosition[2], double handleOrientation[2],
+  vtkMatrix4x4* handleToWorldTransformMatrix)
+{
+  // Reset handle to world transform
+  handleToWorldTransformMatrix->Identity();
+
+  // Get rotation matrix
+  double handleOrientationDefault[2] = { SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION[0],
+                                         SLICEOFSSET_HANDLE_DEFAULT_ORIENTATION [1]};
+  this->RotationMatrixFromVectors(handleOrientationDefault, handleOrientation, handleToWorldTransformMatrix);
+
+  // Add translation to matrix
+  double handleTranslation[2] = { handlePosition[0] - SLICEOFSSET_HANDLE_DEFAULT_POSITION[0],
+                                  handlePosition[1] - SLICEOFSSET_HANDLE_DEFAULT_POSITION[1]};
+  handleToWorldTransformMatrix->SetElement(0, 3, handleTranslation[0]); // Translation X
+  handleToWorldTransformMatrix->SetElement(1, 3, handleTranslation[1]); // Translation Y
+}
+
+//----------------------------------------------------------------------
+void vtkMRMLSliceIntersectionInteractionRepresentationHelper::RotationMatrixFromVectors(double vector1[2], double vector2[2], vtkMatrix4x4* rotationMatrixHom)
+{
+  // 3D vectors
+  double vector1_3D[3] = { vector1[0], vector1[1], 0.0};
+  double vector2_3D[3] = { vector2[0], vector2[1], 0.0 };
+
+  // Normalize input vectos
+  vtkMath::Normalize(vector1_3D);
+  vtkMath::Normalize(vector2_3D);
+
+  // Cross and dot products
+  double v[3];
+  vtkMath::Cross(vector1_3D, vector2_3D, v);
+  double c = vtkMath::Dot(vector1_3D, vector2_3D);
+  double s = vtkMath::Norm(v);
+
+  // Compute rotation matrix
+  if (s == 0.0) // If vectors are aligned (i.e., cross product = 0)
+    {
+    if (c > 0.0) // Same direction
+      {
+      rotationMatrixHom->Identity();
+      }
+    else // Opposite direction
+      {
+      vtkNew<vtkTransform> transform;
+      transform->RotateZ(180); // invert direction
+      rotationMatrixHom->SetElement(0, 0, transform->GetMatrix()->GetElement(0, 0));
+      rotationMatrixHom->SetElement(0, 1, transform->GetMatrix()->GetElement(0, 1));
+      rotationMatrixHom->SetElement(0, 2, transform->GetMatrix()->GetElement(0, 2));
+      rotationMatrixHom->SetElement(0, 3, 0.0);
+      rotationMatrixHom->SetElement(1, 0, transform->GetMatrix()->GetElement(1, 0));
+      rotationMatrixHom->SetElement(1, 1, transform->GetMatrix()->GetElement(1, 1));
+      rotationMatrixHom->SetElement(1, 2, transform->GetMatrix()->GetElement(1, 2));
+      rotationMatrixHom->SetElement(1, 3, 0.0);
+      rotationMatrixHom->SetElement(2, 0, transform->GetMatrix()->GetElement(2, 0));
+      rotationMatrixHom->SetElement(2, 1, transform->GetMatrix()->GetElement(2, 1));
+      rotationMatrixHom->SetElement(2, 2, transform->GetMatrix()->GetElement(2, 2));
+      rotationMatrixHom->SetElement(2, 3, 0.0);
+      rotationMatrixHom->SetElement(3, 0, 0.0);
+      rotationMatrixHom->SetElement(3, 1, 0.0);
+      rotationMatrixHom->SetElement(3, 2, 0.0);
+      rotationMatrixHom->SetElement(3, 3, 1.0);
+      }
+    }
+  else // If vectors are not aligned
+    {
+    vtkNew<vtkMatrix3x3> rotationMatrix;
+    vtkNew<vtkMatrix3x3> identityMatrix;
+    vtkNew<vtkMatrix3x3> kmat;
+    kmat->SetElement(0, 0, 0.0);
+    kmat->SetElement(0, 1, -v[2]);
+    kmat->SetElement(0, 2, v[1]);
+    kmat->SetElement(1, 0, v[2]);
+    kmat->SetElement(1, 1, 0.0);
+    kmat->SetElement(1, 2, -v[0]);
+    kmat->SetElement(2, 0, -v[1]);
+    kmat->SetElement(2, 1, v[0]);
+    kmat->SetElement(2, 2, 0.0);
+    vtkNew<vtkMatrix3x3> kmat2;
+    vtkMatrix3x3::Multiply3x3(kmat, kmat, kmat2);
+    vtkNew<vtkMatrix3x3> kmat2x;
+    rotationMatrix->SetElement(0, 0, identityMatrix->GetElement(0, 0) + kmat->GetElement(0, 0) + kmat2->GetElement(0, 0) * ((1 - c) / (pow(s, 2.0))));
+    rotationMatrix->SetElement(0, 1, identityMatrix->GetElement(0, 1) + kmat->GetElement(0, 1) + kmat2->GetElement(0, 1) * ((1 - c) / (pow(s, 2.0))));
+    rotationMatrix->SetElement(0, 2, identityMatrix->GetElement(0, 2) + kmat->GetElement(0, 2) + kmat2->GetElement(0, 2) * ((1 - c) / (pow(s, 2.0))));
+    rotationMatrix->SetElement(1, 0, identityMatrix->GetElement(1, 0) + kmat->GetElement(1, 0) + kmat2->GetElement(1, 0) * ((1 - c) / (pow(s, 2.0))));
+    rotationMatrix->SetElement(1, 1, identityMatrix->GetElement(1, 1) + kmat->GetElement(1, 1) + kmat2->GetElement(1, 1) * ((1 - c) / (pow(s, 2.0))));
+    rotationMatrix->SetElement(1, 2, identityMatrix->GetElement(1, 2) + kmat->GetElement(1, 2) + kmat2->GetElement(1, 2) * ((1 - c) / (pow(s, 2.0))));
+    rotationMatrix->SetElement(2, 0, identityMatrix->GetElement(2, 0) + kmat->GetElement(2, 0) + kmat2->GetElement(2, 0) * ((1 - c) / (pow(s, 2.0))));
+    rotationMatrix->SetElement(2, 1, identityMatrix->GetElement(2, 1) + kmat->GetElement(2, 1) + kmat2->GetElement(2, 1) * ((1 - c) / (pow(s, 2.0))));
+    rotationMatrix->SetElement(2, 2, identityMatrix->GetElement(2, 2) + kmat->GetElement(2, 2) + kmat2->GetElement(2, 2) * ((1 - c) / (pow(s, 2.0))));
+
+    // Convert to 4x4 matrix
+    rotationMatrixHom->SetElement(0, 0, rotationMatrix->GetElement(0, 0));
+    rotationMatrixHom->SetElement(0, 1, rotationMatrix->GetElement(0, 1));
+    rotationMatrixHom->SetElement(0, 2, rotationMatrix->GetElement(0, 2));
+    rotationMatrixHom->SetElement(0, 3, 0.0);
+    rotationMatrixHom->SetElement(1, 0, rotationMatrix->GetElement(1, 0));
+    rotationMatrixHom->SetElement(1, 1, rotationMatrix->GetElement(1, 1));
+    rotationMatrixHom->SetElement(1, 2, rotationMatrix->GetElement(1, 2));
+    rotationMatrixHom->SetElement(1, 3, 0.0);
+    rotationMatrixHom->SetElement(2, 0, rotationMatrix->GetElement(2, 0));
+    rotationMatrixHom->SetElement(2, 1, rotationMatrix->GetElement(2, 1));
+    rotationMatrixHom->SetElement(2, 2, rotationMatrix->GetElement(2, 2));
+    rotationMatrixHom->SetElement(2, 3, 0.0);
+    rotationMatrixHom->SetElement(3, 0, 0.0);
+    rotationMatrixHom->SetElement(3, 1, 0.0);
+    rotationMatrixHom->SetElement(3, 2, 0.0);
+    rotationMatrixHom->SetElement(3, 3, 1.0);
+    }
+}

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.h
@@ -1,0 +1,90 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Ebatinca S.L., Las Palmas de Gran Canaria, Spain
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+/**
+ * @class   vtkMRMLSliceIntersectionInteractionRepresentationHelper
+ * @brief   represent intersections of other slice views in the current slice view
+ *
+ * @sa
+ * vtkSliceIntersectionWidget vtkWidgetRepresentation vtkAbstractWidget
+*/
+
+#ifndef vtkMRMLSliceIntersectionInteractionRepresentationHelper_h
+#define vtkMRMLSliceIntersectionInteractionRepresentationHelper_h
+
+#include "vtkMRMLDisplayableManagerExport.h" // For export macro
+#include "vtkMRMLAbstractWidgetRepresentation.h"
+
+#include "vtkMRMLSliceNode.h"
+
+class vtkMRMLApplicationLogic;
+class vtkMRMLModelDisplayNode;
+class vtkMRMLSliceLogic;
+
+class vtkProperty2D;
+class vtkActor2D;
+class vtkPolyDataMapper2D;
+class vtkPolyData;
+class vtkPoints;
+class vtkCellArray;
+class vtkTextProperty;
+class vtkLeaderActor2D;
+class vtkTextMapper;
+class vtkTransform;
+class vtkActor2D;
+class vtkMRMLInteractionEventData;
+
+class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionInteractionRepresentationHelper : public vtkMRMLAbstractWidgetRepresentation
+{
+  public:
+    /**
+     * Instantiate this class.
+     */
+    static vtkMRMLSliceIntersectionInteractionRepresentationHelper* New();
+
+    //@{
+    /**
+     * Standard methods for instances of this class.
+     */
+    vtkTypeMacro(vtkMRMLSliceIntersectionInteractionRepresentationHelper, vtkMRMLAbstractWidgetRepresentation);
+    void PrintSelf(ostream& os, vtkIndent indent) override;
+    //@}
+
+    int IntersectWithFinitePlane(double n[3], double o[3], double pOrigin[3], double px[3], double py[3], double x0[3], double x1[3]);
+
+    /// Compute intersection between a 2D line and the slice view boundaries
+    void GetIntersectionWithSliceViewBoundaries(double* pointA, double* pointB, double* sliceViewBounds, double* intersectionPoint);
+
+    /// Get boundaries of the slice view associated with a given vtkMRMLSliceNode
+    void GetSliceViewBoundariesXY(vtkMRMLSliceNode* sliceNode, double* sliceViewBounds);
+
+    int GetLineTipsFromIntersectingSliceNode(vtkMRMLSliceNode* intersectingSliceNode, vtkMatrix4x4* intersectingXYToXY,
+        double intersectionLineTip1[3], double intersectionLineTip2[3]);
+
+    void ComputeHandleToWorldTransformMatrix(double handlePosition[2], double handleOrientation[2], vtkMatrix4x4* handleToWorldTransformMatrix);
+    void RotationMatrixFromVectors(double vector1[2], double vector2[2], vtkMatrix4x4* rotationMatrixHom);
+
+  protected:
+    vtkMRMLSliceIntersectionInteractionRepresentationHelper();
+    ~vtkMRMLSliceIntersectionInteractionRepresentationHelper() override;
+
+  private:
+    vtkMRMLSliceIntersectionInteractionRepresentationHelper(const vtkMRMLSliceIntersectionInteractionRepresentationHelper&) = delete;
+    void operator=(const vtkMRMLSliceIntersectionInteractionRepresentationHelper&) = delete;
+};
+
+#endif

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
@@ -20,7 +20,7 @@
 #include "vtkMRMLApplicationLogic.h"
 #include "vtkMRMLDisplayableNode.h"
 #include "vtkMRMLInteractionNode.h"
-#include "vtkMRMLModelDisplayNode.h"
+#include "vtkMRMLSliceDisplayNode.h"
 #include "vtkMRMLScene.h"
 #include "vtkMRMLSliceLogic.h"
 #include "vtkMRMLSliceNode.h"
@@ -342,6 +342,7 @@ void vtkMRMLSliceIntersectionRepresentation2D::SliceNodeModifiedCallback(
   vtkMRMLSliceNode* sliceNode = vtkMRMLSliceNode::SafeDownCast(caller);
   if (sliceNode)
     {
+    // The slice view's node is modified
     self->SliceNodeModified(sliceNode);
     return;
     }
@@ -349,6 +350,7 @@ void vtkMRMLSliceIntersectionRepresentation2D::SliceNodeModifiedCallback(
   vtkMRMLSliceLogic* sliceLogic = vtkMRMLSliceLogic::SafeDownCast(caller);
   if (sliceLogic)
     {
+    // One of the intersecting slice views is modified
     self->UpdateSliceIntersectionDisplay(self->GetDisplayPipelineFromSliceLogic(sliceLogic));
     return;
     }
@@ -408,7 +410,7 @@ void vtkMRMLSliceIntersectionRepresentation2D::UpdateSliceIntersectionDisplay(Sl
     return;
     }
 
-  vtkMRMLModelDisplayNode* displayNode = nullptr;
+  vtkMRMLSliceDisplayNode* displayNode = nullptr;
   vtkMRMLSliceLogic *sliceLogic = nullptr;
   vtkMRMLApplicationLogic *mrmlAppLogic = this->GetMRMLApplicationLogic();
   if (mrmlAppLogic)
@@ -417,11 +419,13 @@ void vtkMRMLSliceIntersectionRepresentation2D::UpdateSliceIntersectionDisplay(Sl
     }
   if (sliceLogic)
     {
-    displayNode = sliceLogic->GetSliceModelDisplayNode();
+    displayNode = sliceLogic->GetSliceDisplayNode();
     }
   if (displayNode)
     {
-    if (!displayNode->GetSliceIntersectionVisibility())
+    bool showNonInteractiveSliceIntersection = (displayNode->GetIntersectingSlicesVisibility()
+      && !displayNode->GetIntersectingSlicesInteractive());
+    if (!showNonInteractiveSliceIntersection)
       {
       pipeline->SetVisibility(false);
       return;
@@ -433,8 +437,6 @@ void vtkMRMLSliceIntersectionRepresentation2D::UpdateSliceIntersectionDisplay(Sl
 
   vtkMatrix4x4* intersectingXYToRAS = intersectingSliceNode->GetXYToRAS();
   vtkMatrix4x4* xyToRAS = this->Internal->SliceNode->GetXYToRAS();
-
-  //double slicePlaneAngleDifference = vtkMath::AngleBetweenVectors()
 
   vtkNew<vtkMatrix4x4> rasToXY;
   vtkMatrix4x4::Invert(xyToRAS, rasToXY);
@@ -615,11 +617,11 @@ double* vtkMRMLSliceIntersectionRepresentation2D::GetSliceIntersectionPoint()
       double v2[3] = {line2Point1[0] - line2Point2[0], line2Point1[1] - line2Point2[1], line2Point1[2] - line2Point2[2]};
       double angleRadBetweenTwoLines = vtkMath::AngleBetweenVectors(v1, v2);
 
-      const double angleThresholdForParallel = vtkMath::Pi()/60; // roughly 3 degree
+      const double angleThresholdForParallel = vtkMath::RadiansFromDegrees(3.0);
       if (angleRadBetweenTwoLines < angleThresholdForParallel || angleThresholdForParallel > vtkMath::Pi() - angleThresholdForParallel)
         {
-        // Two lines intesecting under roughly 3 degree are
-        // considered to be parallel and not considered as intersecting.
+        // Two lines intesecting under the threshold are
+        // considered to be parallel and not as intersecting.
         continue;
         }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.cxx
@@ -25,6 +25,8 @@
 #include "vtkMRMLScene.h"
 #include "vtkMRMLSegmentationDisplayNode.h"
 #include "vtkMRMLSliceCompositeNode.h"
+#include "vtkMRMLSliceDisplayNode.h"
+#include "vtkMRMLSliceIntersectionInteractionRepresentation.h"
 #include "vtkMRMLSliceIntersectionRepresentation2D.h"
 #include "vtkMRMLSliceLayerLogic.h"
 #include "vtkMRMLVolumeNode.h"
@@ -64,6 +66,19 @@ vtkMRMLSliceIntersectionWidget::vtkMRMLSliceIntersectionWidget()
   this->StartRotationCenter_RAS[2] = 0.0;
   this->StartRotationCenter_RAS[3] = 1.0; // to allow easy homogeneous transformations
 
+  // Interactive slice intersection widget
+
+  this->StartTranslationPoint[0] = 0.0;
+  this->StartTranslationPoint[1] = 0.0;
+
+  this->StartTranslationPoint_RAS[0] = 0.0;
+  this->StartTranslationPoint_RAS[1] = 0.0;
+  this->StartTranslationPoint_RAS[2] = 0.0;
+
+  this->CurrentTranslationPoint_RAS[0] = 0.0;
+  this->CurrentTranslationPoint_RAS[1] = 0.0;
+  this->CurrentTranslationPoint_RAS[2] = 0.0;
+
   this->StartActionFOV[0] = 0.;
   this->StartActionFOV[1] = 0.;
   this->StartActionFOV[2] = 0.;
@@ -87,6 +102,9 @@ vtkMRMLSliceIntersectionWidget::vtkMRMLSliceIntersectionWidget()
   this->TotalTouchTranslation = 0.0;
   this->TouchTranslationEnabled = false;
 
+  this->SliceModifiedCommand->SetClientData(this);
+  this->SliceModifiedCommand->SetCallback(vtkMRMLSliceIntersectionWidget::SliceModifiedCallback);
+
   this->SliceLogicsModifiedCommand->SetClientData(this);
   this->SliceLogicsModifiedCommand->SetCallback(vtkMRMLSliceIntersectionWidget::SliceLogicsModifiedCallback);
 
@@ -97,6 +115,7 @@ vtkMRMLSliceIntersectionWidget::vtkMRMLSliceIntersectionWidget()
 //----------------------------------------------------------------------------------
 vtkMRMLSliceIntersectionWidget::~vtkMRMLSliceIntersectionWidget()
 {
+  this->SetSliceNode(nullptr);
   this->SetMRMLApplicationLogic(nullptr);
 }
 
@@ -105,20 +124,22 @@ void vtkMRMLSliceIntersectionWidget::UpdateInteractionEventMapping()
 {
   this->EventTranslators.clear();
 
+  // Interactions without handles
+
   if (this->GetActionEnabled(ActionRotateSliceIntersection))
     {
     // Touch gesture slice rotate
     this->SetEventTranslation(WidgetStateIdle, vtkCommand::StartRotateEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureStart);
     this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::RotateEvent, vtkEvent::AnyModifier, WidgetEventTouchRotateSliceIntersection);
     this->SetEventTranslation(WidgetStateTouchGesture, vtkCommand::EndRotateEvent, vtkEvent::AnyModifier, WidgetEventTouchGestureEnd);
-
-    this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::LeftButtonPressEvent,
-      vtkEvent::AltModifier+vtkEvent::ControlModifier, WidgetStateRotate, WidgetEventRotateStart, WidgetEventRotateEnd);
+    // Ctrl-alt-left-click-and-drag rotate
+    this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::LeftButtonPressEvent, vtkEvent::AltModifier + vtkEvent::ControlModifier,
+      WidgetStateRotateIntersectingSlices, WidgetEventRotateIntersectingSlicesStart, WidgetEventRotateIntersectingSlicesEnd);
     }
   if (this->GetActionEnabled(ActionTranslateSliceIntersection))
     {
     this->SetEventTranslationClickAndDrag(WidgetStateIdle, vtkCommand::LeftButtonPressEvent,
-      vtkEvent::AltModifier+vtkEvent::ShiftModifier, WidgetStateTranslate, WidgetEventTranslateStart, WidgetEventTranslateEnd);
+      vtkEvent::AltModifier + vtkEvent::ShiftModifier, WidgetStateTranslate, WidgetEventTranslateStart, WidgetEventTranslateEnd);
     }
   if (this->GetActionEnabled(ActionSetCrosshairPosition))
     {
@@ -183,10 +204,42 @@ void vtkMRMLSliceIntersectionWidget::UpdateInteractionEventMapping()
     }
 
   // Context menu
-  this->SetEventTranslation(WidgetStateIdle, vtkMRMLInteractionEventData::RightButtonClickEvent, vtkEvent::NoModifier, WidgetEventMenu);
+  this->SetEventTranslation(WidgetStateAny, vtkMRMLInteractionEventData::RightButtonClickEvent, vtkEvent::NoModifier, WidgetEventMenu);
 
   // Maximize/restore view
   this->SetEventTranslation(WidgetStateIdle, vtkCommand::LeftButtonDoubleClickEvent, vtkEvent::NoModifier, WidgetEventMaximizeView);
+
+  // Interactions with slice intersection handles
+
+  // Update active component
+  this->SetEventTranslation(WidgetStateIdle, vtkCommand::MouseMoveEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::MouseMoveEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  this->SetEventTranslation(WidgetStateIdle, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  this->SetEventTranslation(WidgetStateOnWidget, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  // Update active interaction handle component
+  this->SetEventTranslation(WidgetStateOnTranslateIntersectingSlicesHandle, vtkCommand::MouseMoveEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  this->SetEventTranslation(WidgetStateOnTranslateIntersectingSlicesHandle, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  this->SetEventTranslation(WidgetStateOnRotateIntersectingSlicesHandle, vtkCommand::MouseMoveEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  this->SetEventTranslation(WidgetStateOnRotateIntersectingSlicesHandle, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  this->SetEventTranslation(WidgetStateOnTranslateSingleIntersectingSliceHandle, vtkCommand::MouseMoveEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+  this->SetEventTranslation(WidgetStateOnTranslateSingleIntersectingSliceHandle, vtkCommand::Move3DEvent, vtkEvent::NoModifier, WidgetEventMouseMove);
+
+  if (this->GetActionEnabled(ActionRotateSliceIntersection))
+    {
+    this->SetEventTranslationClickAndDrag(WidgetStateOnRotateIntersectingSlicesHandle, vtkCommand::LeftButtonPressEvent, vtkEvent::NoModifier,
+      WidgetStateRotateIntersectingSlicesHandle, WidgetEventRotateIntersectingSlicesHandleStart, WidgetEventRotateIntersectingSlicesHandleEnd);
+    }
+  if (this->GetActionEnabled(ActionTranslateSliceIntersection))
+    {
+    this->SetEventTranslationClickAndDrag(WidgetStateOnTranslateIntersectingSlicesHandle, vtkCommand::LeftButtonPressEvent, vtkEvent::NoModifier,
+      WidgetStateTranslateIntersectingSlicesHandle, WidgetEventTranslateIntersectingSlicesHandleStart, WidgetEventTranslateIntersectingSlicesHandleEnd);
+    }
+  if (this->GetActionEnabled(ActionTranslate))
+    {
+    this->SetEventTranslationClickAndDrag(WidgetStateOnTranslateSingleIntersectingSliceHandle, vtkCommand::LeftButtonPressEvent, vtkEvent::NoModifier,
+      WidgetStateTranslateSingleIntersectingSliceHandle,
+      WidgetEventTranslateSingleIntersectingSliceHandleStart, WidgetEventTranslateSingleIntersectingSliceHandleEnd);
+    }
 }
 
 //----------------------------------------------------------------------
@@ -203,10 +256,24 @@ void vtkMRMLSliceIntersectionWidget::CreateDefaultRepresentation()
     vtkWarningMacro("vtkMRMLSliceIntersectionWidget::CreateDefaultRepresentation failed: application logic invalid");
     return;
     }
-  vtkNew<vtkMRMLSliceIntersectionRepresentation2D> newRep;
-  newRep->SetMRMLApplicationLogic(mrmlAppLogic);
-  newRep->SetSliceNode(this->SliceNode);
-  this->WidgetRep = newRep;
+
+  if (this->IsSliceIntersectionInteractive())
+    {
+    vtkNew<vtkMRMLSliceIntersectionInteractionRepresentation> newRepInteraction;
+    newRepInteraction->SetMRMLApplicationLogic(mrmlAppLogic);
+    newRepInteraction->SetRenderer(this->GetRenderer());
+    newRepInteraction->SetSliceNode(this->SliceNode);
+    this->WidgetRep = newRepInteraction;
+    }
+  else
+    {
+    vtkNew<vtkMRMLSliceIntersectionRepresentation2D> newRep;
+    newRep->SetMRMLApplicationLogic(mrmlAppLogic);
+    newRep->SetRenderer(this->GetRenderer());
+    newRep->SetSliceNode(this->SliceNode);
+    this->WidgetRep = newRep;
+    }
+
 }
 
 //-----------------------------------------------------------------------------
@@ -223,6 +290,13 @@ bool vtkMRMLSliceIntersectionWidget::CanProcessInteractionEvent(vtkMRMLInteracti
     // so when we are outside then we should assume that modifier
     // is not just "stuck".
     this->ModifierKeyPressedSinceLastClickAndDrag = true;
+
+    if (this->GetSliceDisplayNode() && this->GetSliceDisplayNode()->HasActiveComponent())
+      {
+      // this widget has active component, therefore leave event is relevant
+      distance2 = 0.0;
+      return true;
+      }
     }
   if (eventData->GetType() == vtkCommand::KeyPressEvent)
     {
@@ -244,7 +318,7 @@ bool vtkMRMLSliceIntersectionWidget::CanProcessInteractionEvent(vtkMRMLInteracti
 
   // If we are currently dragging a point then we interact everywhere
   if (this->WidgetState == WidgetStateTranslate
-    || this->WidgetState == WidgetStateRotate
+    || this->WidgetState == WidgetStateRotateIntersectingSlices
     || this->WidgetState == WidgetStateBlend
     || this->WidgetState == WidgetStateTranslateSlice
     || this->WidgetState == WidgetStateZoomSlice)
@@ -265,6 +339,38 @@ bool vtkMRMLSliceIntersectionWidget::CanProcessInteractionEvent(vtkMRMLInteracti
     this->ProcessSetCrosshair(eventData);
     }
 
+
+  // Representation
+  vtkMRMLSliceIntersectionInteractionRepresentation* rep = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->GetRepresentation());
+  if (rep)
+    {
+    // Currently interacting
+    if (this->WidgetState == WidgetStateTranslate
+      || this->WidgetState == WidgetStateRotateIntersectingSlicesHandle
+      || this->WidgetState == WidgetStateTranslateSingleIntersectingSliceHandle)
+      {
+      distance2 = 0.0;
+      return true;
+      }
+
+    // Interaction
+    int foundComponentType = vtkMRMLSliceDisplayNode::ComponentNone;
+    int foundComponentIndex = -1;
+    double closestDistance2 = 0.0;
+    double handleOpacity = 0.0;
+    std::string intersectingSliceNodeID = rep->CanInteract(eventData, foundComponentType, foundComponentIndex, closestDistance2, handleOpacity);
+
+    if (foundComponentType != vtkMRMLSliceDisplayNode::ComponentNone)
+      {
+      // Store closest squared distance
+      distance2 = closestDistance2;
+
+      // Store last intersecting slice node index
+      this->LastIntersectingSliceNodeID = intersectingSliceNodeID;
+      return true;
+      }
+    }
+
   distance2 = 1e10; // we can process this event but we let more specific widgets to claim it (if they are closer)
   return true;
 }
@@ -275,6 +381,13 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
   if (!this->SliceLogic)
     {
     return false;
+    }
+
+  if (eventData->GetType() == vtkCommand::LeaveEvent)
+    {
+    // If a widget component was still active when the mouse left the view then this will deactivate it.
+    this->Leave(eventData);
+    return true;
     }
 
   unsigned long widgetEvent = this->TranslateInteractionEventToWidgetEvent(eventData);
@@ -310,11 +423,11 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
     case WidgetEventTranslateEnd:
       processedEvent = this->ProcessEndMouseDrag(eventData);
       break;
-    case WidgetEventRotateStart:
+    case WidgetEventRotateIntersectingSlicesStart:
       this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
-      processedEvent = this->ProcessRotateStart(eventData);
+      processedEvent = this->ProcessRotateIntersectingSlicesStart(eventData);
       break;
-    case WidgetEventRotateEnd:
+    case WidgetEventRotateIntersectingSlicesEnd:
       processedEvent = this->ProcessEndMouseDrag(eventData);
       break;
     case WidgetEventTranslateSliceStart:
@@ -359,7 +472,8 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
       {
       this->StartActionSegmentationDisplayNode = nullptr;
       this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
-      this->StartActionSegmentationDisplayNode = nullptr;      double opacity = this->GetLabelOpacity();
+      this->StartActionSegmentationDisplayNode = nullptr;
+      double opacity = this->GetLabelOpacity();
       if (opacity != 0.0)
         {
         this->LastLabelOpacity = opacity;
@@ -441,6 +555,28 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
       processedEvent = this->ProcessMaximizeView(eventData);
       break;
 
+    case WidgetEventRotateIntersectingSlicesHandleStart:
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
+      processedEvent = this->ProcessRotateIntersectingSlicesHandleStart(eventData);
+      break;
+    case WidgetEventRotateIntersectingSlicesHandleEnd:
+      processedEvent = this->ProcessEndMouseDrag(eventData);
+      break;
+    case WidgetEventTranslateIntersectingSlicesHandleStart:
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
+      processedEvent = this->ProcessTranslateIntersectingSlicesHandleStart(eventData);
+      break;
+    case WidgetEventTranslateIntersectingSlicesHandleEnd:
+      processedEvent = this->ProcessEndMouseDrag(eventData);
+      break;
+    case WidgetEventTranslateSingleIntersectingSliceHandleStart:
+      this->SliceLogic->GetMRMLScene()->SaveStateForUndo();
+      processedEvent = this->ProcessTranslateSingleIntersectingSliceHandleStart(eventData);
+      break;
+    case WidgetEventTranslateSingleIntersectingSliceHandleEnd:
+      processedEvent = this->ProcessEndMouseDrag(eventData);
+      break;
+
     default:
       processedEvent = false;
     }
@@ -456,12 +592,36 @@ bool vtkMRMLSliceIntersectionWidget::ProcessInteractionEvent(vtkMRMLInteractionE
 //-------------------------------------------------------------------------
 void vtkMRMLSliceIntersectionWidget::Leave(vtkMRMLInteractionEventData* eventData)
 {
+  // Ensure that EndInteractionEvent is invoked, even if interrupted by an unexpected event
+  if (this->WidgetState == WidgetStateTranslate
+    || this->WidgetState == WidgetStateTranslateSlice
+    || this->WidgetState == WidgetStateZoomSlice
+    || this->WidgetState == WidgetStateBlend
+    || this->WidgetState == WidgetStateRotateIntersectingSlices
+    || this->WidgetState == WidgetStateTranslateIntersectingSlicesHandle
+    || this->WidgetState == WidgetStateTranslateSingleIntersectingSliceHandle
+    || this->WidgetState == WidgetStateRotateIntersectingSlicesHandle)
+    {
+    this->ProcessEndMouseDrag(eventData);
+    }
+
+  vtkMRMLSliceDisplayNode* sliceDisplayNode = this->GetSliceDisplayNode();
+  if (sliceDisplayNode)
+    {
+    std::string interactionContext;
+    if (eventData)
+      {
+      interactionContext = eventData->GetInteractionContextName();
+      }
+    sliceDisplayNode->SetActiveComponent(vtkMRMLSliceDisplayNode::ComponentNone, -1, interactionContext);
+    }
   this->Superclass::Leave(eventData);
 }
 
 //-------------------------------------------------------------------------
 bool vtkMRMLSliceIntersectionWidget::ProcessMouseMove(vtkMRMLInteractionEventData* eventData)
 {
+  vtkMRMLSliceIntersectionInteractionRepresentation* interactiveRep = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->WidgetRep);
   if (!this->WidgetRep || !eventData)
     {
     return false;
@@ -469,8 +629,8 @@ bool vtkMRMLSliceIntersectionWidget::ProcessMouseMove(vtkMRMLInteractionEventDat
 
   switch (this->WidgetState)
     {
-    case WidgetStateRotate:
-      this->ProcessRotate(eventData);
+    case WidgetStateRotateIntersectingSlices:
+      this->ProcessRotateIntersectingSlices(eventData);
       break;
     case WidgetStateTranslate:
       {
@@ -487,6 +647,101 @@ bool vtkMRMLSliceIntersectionWidget::ProcessMouseMove(vtkMRMLInteractionEventDat
     case WidgetStateZoomSlice:
       this->ProcessZoomSlice(eventData);
       break;
+    case WidgetStateIdle: // if moving over an intersection in idle mode then this will change the widget state to WidgetStateOn...
+    case WidgetStateOnWidget:
+    case WidgetStateOnTranslateIntersectingSlicesHandle:
+    case WidgetStateOnRotateIntersectingSlicesHandle:
+    case WidgetStateOnTranslateSingleIntersectingSliceHandle:
+      if (interactiveRep)
+        {
+        // Update widget state according to distance to interaction handles
+        int foundComponentType = vtkMRMLSliceDisplayNode::ComponentNone;
+        int foundComponentIndex = -1;
+        double closestDistance2 = 0.0;
+        double handleOpacity = 0.0;
+        std::string intersectingSliceNodeID = interactiveRep->CanInteract(eventData, foundComponentType, foundComponentIndex, closestDistance2, handleOpacity);
+        if (foundComponentType == vtkMRMLSliceDisplayNode::ComponentNone)
+          {
+          if (this->WidgetState != WidgetStateIdle)
+            {
+            this->SetWidgetState(WidgetStateIdle);
+            this->SliceLogic->EndSliceNodeInteraction();
+            }
+          }
+        else if (foundComponentType == vtkMRMLSliceDisplayNode::ComponentTranslateIntersectingSlicesHandle)
+          {
+          this->SetWidgetState(WidgetStateOnTranslateIntersectingSlicesHandle);
+          }
+        else if (foundComponentType == vtkMRMLSliceDisplayNode::ComponentRotateIntersectingSlicesHandle)
+          {
+          this->SetWidgetState(WidgetStateOnRotateIntersectingSlicesHandle);
+          }
+        else if (foundComponentType == vtkMRMLSliceDisplayNode::ComponentTranslateSingleIntersectingSliceHandle)
+          {
+          this->SetWidgetState(WidgetStateOnTranslateSingleIntersectingSliceHandle);
+          }
+        else
+          {
+          this->SetWidgetState(WidgetStateOnWidget);
+          }
+
+        // Store last intersecting slice node index
+        if (foundComponentType != vtkMRMLSliceDisplayNode::ComponentNone)
+          {
+          this->LastIntersectingSliceNodeID = intersectingSliceNodeID;
+          }
+
+        vtkMRMLSliceDisplayNode* sliceDisplayNode = this->GetSliceDisplayNode();
+        if (sliceDisplayNode)
+          {
+          sliceDisplayNode->SetActiveComponent(foundComponentType, foundComponentIndex, eventData->GetInteractionContextName());
+          }
+        }
+        break;
+    case WidgetStateTranslateIntersectingSlicesHandle:
+    case WidgetStateTranslateSingleIntersectingSliceHandle:
+    case WidgetStateRotateIntersectingSlicesHandle:
+      {
+      // Process the motion
+      // Based on the displacement vector (computed in display coordinates) and
+      // the cursor state (which corresponds to which part of the widget has been
+      // selected), the widget points are modified.
+      // First construct a local coordinate system based on the display coordinates
+      // of the widget.
+      double eventPos[2]
+        {
+        static_cast<double>(eventData->GetDisplayPosition()[0]),
+        static_cast<double>(eventData->GetDisplayPosition()[1]),
+        };
+      bool inSliceView = interactiveRep->IsMouseCursorInSliceView(eventPos);
+
+      // Make handles disappear during interaction
+      vtkMRMLSliceDisplayNode* sliceDisplayNode = this->GetSliceDisplayNode();
+      if (sliceDisplayNode)
+        {
+        sliceDisplayNode->SetActiveComponent(vtkMRMLSliceDisplayNode::ComponentSliceIntersection, 0, eventData->GetInteractionContextName());
+        }
+
+      if (this->WidgetState == WidgetStateTranslateIntersectingSlicesHandle)
+        {
+        if (inSliceView) // Stop interaction if mouse cursor is outside of the slice view
+          {
+          const double* worldPos = eventData->GetWorldPosition();
+          this->GetSliceNode()->JumpAllSlices(worldPos[0], worldPos[1], worldPos[2]);
+          }
+        }
+      else if (this->WidgetState == WidgetStateTranslateSingleIntersectingSliceHandle)
+        {
+        if (inSliceView) // Stop interaction if mouse cursor is outside of the slice view
+          {
+          this->ProcessTranslateSingleIntersectingSliceHandle(eventData);
+          }
+        }
+      else if (this->WidgetState == WidgetStateRotateIntersectingSlicesHandle)
+        {
+        this->ProcessRotateIntersectingSlicesHandle(eventData);
+        }
+      }
     }
 
   return true;
@@ -495,8 +750,7 @@ bool vtkMRMLSliceIntersectionWidget::ProcessMouseMove(vtkMRMLInteractionEventDat
 //-------------------------------------------------------------------------
 bool vtkMRMLSliceIntersectionWidget::ProcessStartMouseDrag(vtkMRMLInteractionEventData* eventData)
 {
-  vtkMRMLSliceIntersectionRepresentation2D* rep = vtkMRMLSliceIntersectionRepresentation2D::SafeDownCast(this->WidgetRep);
-  if (!rep)
+  if (!this->WidgetRep)
     {
     return false;
     }
@@ -510,6 +764,10 @@ bool vtkMRMLSliceIntersectionWidget::ProcessStartMouseDrag(vtkMRMLInteractionEve
   this->PreviousEventPosition[1] = this->StartEventPosition[1];
 
   this->ProcessMouseMove(eventData);
+
+  // Indicate interaction in the slice node to make behavior similar to the 3D reformat widget
+  this->SliceLogic->StartSliceNodeInteraction(vtkMRMLSliceNode::MultiplanarReformatFlag);
+
   return true;
 }
 
@@ -524,6 +782,11 @@ double vtkMRMLSliceIntersectionWidget::GetSliceRotationAngleRad(double eventPos[
 //-------------------------------------------------------------------------
 bool vtkMRMLSliceIntersectionWidget::ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData)
 {
+  if (!this->WidgetRep)
+    {
+    return false;
+    }
+
   if (this->WidgetState == WidgetStateIdle)
     {
     return false;
@@ -535,6 +798,17 @@ bool vtkMRMLSliceIntersectionWidget::ProcessEndMouseDrag(vtkMRMLInteractionEvent
 
   // only claim this as processed if the mouse was moved (this lets the event interpreted as button click)
   bool processedEvent = eventData->GetMouseMovedSinceButtonDown();
+
+  this->SliceLogic->EndSliceNodeInteraction();
+
+  // Simulate a mousemove event to update the widget state according to the current position.
+  // Without this, handles would always disappear at the end of drag-and-drop, even if the mouse pointer is over the widget
+  // (which would break Nearby handle visible mode).
+  int originalEventType = eventData->GetType();
+  eventData->SetType(vtkCommand::MouseMoveEvent);
+  this->ProcessMouseMove(eventData);
+  eventData->SetType(originalEventType);
+
   return processedEvent;
 }
 
@@ -593,7 +867,6 @@ bool vtkMRMLSliceIntersectionWidget::ProcessTouchTranslate(vtkMRMLInteractionEve
     xyToSlice->GetElement(0, 0) * translate[0],
     xyToSlice->GetElement(1, 1) * translate[1]
   };
-
 
   this->TotalTouchTranslation += vtkMath::Norm2D(translate);
 
@@ -660,11 +933,60 @@ void vtkMRMLSliceIntersectionWidget::SliceLogicsModifiedCallback(vtkObject* vtkN
     {
     rep->UpdateIntersectingSliceNodes();
     }
+  vtkMRMLSliceIntersectionInteractionRepresentation* repInteraction = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(self->WidgetRep);
+  if (repInteraction)
+    {
+    repInteraction->UpdateIntersectingSliceNodes();
+    }
   self->SliceLogic = nullptr;
   if (self->GetMRMLApplicationLogic())
     {
     self->SliceLogic = self->GetMRMLApplicationLogic()->GetSliceLogic(self->GetSliceNode());
     }
+}
+
+//----------------------------------------------------------------------------------
+void vtkMRMLSliceIntersectionWidget::SliceModifiedCallback(vtkObject* vtkNotUsed(caller),
+  unsigned long vtkNotUsed(eid), void* clientData, void* vtkNotUsed(callData))
+{
+  vtkMRMLSliceIntersectionWidget* self = vtkMRMLSliceIntersectionWidget::SafeDownCast((vtkObject*)clientData);
+  if (!self)
+    {
+    return;
+    }
+
+  vtkMRMLSliceNode* sliceNode = self->GetSliceNode();
+  if (!sliceNode)
+    {
+    return;
+    }
+
+  bool needToUpdateRepresentation = false;
+
+
+  if (self->IsSliceIntersectionInteractive())
+    {
+    needToUpdateRepresentation = !vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(self->WidgetRep);
+    }
+  else
+    {
+    needToUpdateRepresentation = !vtkMRMLSliceIntersectionRepresentation2D::SafeDownCast(self->WidgetRep);
+    }
+  if (needToUpdateRepresentation)
+    {
+    self->WidgetRep = nullptr;
+    self->CreateDefaultRepresentation();
+    }
+}
+
+//----------------------------------------------------------------------------------
+vtkMRMLSliceDisplayNode* vtkMRMLSliceIntersectionWidget::GetSliceDisplayNode()
+{
+  if (!this->SliceLogic)
+    {
+    return nullptr;
+    }
+  return this->SliceLogic->GetSliceDisplayNode();
 }
 
 //----------------------------------------------------------------------------------
@@ -675,6 +997,16 @@ void vtkMRMLSliceIntersectionWidget::SetSliceNode(vtkMRMLSliceNode* sliceNode)
     // no change
     return;
     }
+
+  if (this->SliceNode)
+    {
+    this->SliceNode->RemoveObserver(this->SliceModifiedCommand);
+    }
+  if (sliceNode)
+    {
+    sliceNode->AddObserver(vtkCommand::ModifiedEvent, this->SliceModifiedCommand);
+    }
+
   this->SliceNode = sliceNode;
 
   // Update slice logic
@@ -690,6 +1022,11 @@ void vtkMRMLSliceIntersectionWidget::SetSliceNode(vtkMRMLSliceNode* sliceNode)
     {
     rep->SetSliceNode(sliceNode);
     }
+  vtkMRMLSliceIntersectionInteractionRepresentation* repInteraction = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->WidgetRep);
+  if (repInteraction)
+    {
+    repInteraction->SetSliceNode(sliceNode);
+    }
 }
 
 //----------------------------------------------------------------------------------
@@ -699,18 +1036,27 @@ vtkMRMLSliceNode* vtkMRMLSliceIntersectionWidget::GetSliceNode()
 }
 
 //----------------------------------------------------------------------
-bool vtkMRMLSliceIntersectionWidget::ProcessRotateStart(vtkMRMLInteractionEventData* eventData)
+bool vtkMRMLSliceIntersectionWidget::ProcessRotateIntersectingSlicesStart(vtkMRMLInteractionEventData* eventData)
 {
   vtkMRMLSliceIntersectionRepresentation2D* rep = vtkMRMLSliceIntersectionRepresentation2D::SafeDownCast(this->WidgetRep);
-  if (!rep)
+  vtkMRMLSliceIntersectionInteractionRepresentation* repInteraction = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->WidgetRep);
+  if ((!rep) && (!repInteraction))
     {
     return false;
     }
 
-  this->SetWidgetState(WidgetStateRotate);
+  this->SetWidgetState(WidgetStateRotateIntersectingSlices);
 
   // Save rotation center
-  double* sliceIntersectionPoint = rep->GetSliceIntersectionPoint();
+  double* sliceIntersectionPoint = {};
+  if (rep)
+    {
+    sliceIntersectionPoint = rep->GetSliceIntersectionPoint();
+    }
+  else
+    {
+    sliceIntersectionPoint = repInteraction->GetSliceIntersectionPoint();
+    }
   this->StartRotationCenter[0] = sliceIntersectionPoint[0];
   this->StartRotationCenter[1] = sliceIntersectionPoint[1];
   double startRotationCenterXY[4] = { sliceIntersectionPoint[0] , sliceIntersectionPoint[1], 0.0, 1.0 };
@@ -725,10 +1071,11 @@ bool vtkMRMLSliceIntersectionWidget::ProcessRotateStart(vtkMRMLInteractionEventD
 }
 
 //----------------------------------------------------------------------
-bool vtkMRMLSliceIntersectionWidget::ProcessRotate(vtkMRMLInteractionEventData* eventData)
+bool vtkMRMLSliceIntersectionWidget::ProcessRotateIntersectingSlices(vtkMRMLInteractionEventData* eventData)
 {
   vtkMRMLSliceIntersectionRepresentation2D* rep = vtkMRMLSliceIntersectionRepresentation2D::SafeDownCast(this->WidgetRep);
-  if (!rep)
+  vtkMRMLSliceIntersectionInteractionRepresentation* repInteraction = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->WidgetRep);
+  if ((!rep) && (!repInteraction))
     {
     return false;
     }
@@ -750,7 +1097,14 @@ bool vtkMRMLSliceIntersectionWidget::ProcessRotate(vtkMRMLInteractionEventData* 
   this->PreviousEventPosition[0] = displayPos[0];
   this->PreviousEventPosition[1] = displayPos[1];
 
-  rep->TransformIntersectingSlices(rotatedSliceToSliceTransform->GetMatrix());
+  if (rep)
+    {
+    rep->TransformIntersectingSlices(rotatedSliceToSliceTransform->GetMatrix());
+    }
+  else
+    {
+    repInteraction->TransformIntersectingSlices(rotatedSliceToSliceTransform->GetMatrix());
+    }
 
   return true;
 }
@@ -1233,4 +1587,309 @@ bool vtkMRMLSliceIntersectionWidget::ProcessMaximizeView(vtkMRMLInteractionEvent
   this->ModifierKeyPressedSinceLastClickAndDrag = true;
 
   return true;
+}
+
+//-------------------------------------------------------------------------
+int vtkMRMLSliceIntersectionWidget::GetMouseCursor()
+{
+  switch (this->WidgetState)
+    {
+    case WidgetStateOnTranslateIntersectingSlicesHandle:
+    case WidgetStateOnTranslateSingleIntersectingSliceHandle:
+      return VTK_CURSOR_SIZEALL;
+      break;
+    case WidgetStateOnRotateIntersectingSlicesHandle:
+      return VTK_CURSOR_HAND;
+      break;
+    default:
+      return VTK_CURSOR_DEFAULT;
+      break;
+    }
+}
+
+//----------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessTranslateIntersectingSlicesHandleStart(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLSliceIntersectionInteractionRepresentation* rep = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->WidgetRep);
+  if (!rep)
+    {
+    return false;
+    }
+
+  this->SetWidgetState(WidgetStateTranslateIntersectingSlicesHandle);
+
+  // Save start translation point XY
+  const int* displayPos = eventData->GetDisplayPosition();
+  double displayPosDouble[2] = { static_cast<double>(displayPos[0]), static_cast<double>(displayPos[1]) };
+  this->StartTranslationPoint[0] = displayPosDouble[0];
+  this->StartTranslationPoint[1] = displayPosDouble[1];
+
+  // Save start translation point RAS
+  vtkMatrix4x4* xyToRAS = this->GetSliceNode()->GetXYToRAS();
+  double displayPosDouble_XY[4] = { displayPosDouble[0], displayPosDouble[1], 0, 1 };
+  double displayPosDouble_RAS[4] = { 0, 0, 0, 1 };
+  xyToRAS->MultiplyPoint(displayPosDouble_XY, displayPosDouble_RAS);
+  this->StartTranslationPoint_RAS[0] = displayPosDouble_RAS[0];
+  this->StartTranslationPoint_RAS[1] = displayPosDouble_RAS[1];
+  this->StartTranslationPoint_RAS[2] = displayPosDouble_RAS[2];
+
+  return this->ProcessStartMouseDrag(eventData);
+}
+
+
+//----------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessTranslateIntersectingSlicesHandle(vtkMRMLInteractionEventData* eventData)
+{
+  // Get current slice node and scene
+  vtkMRMLSliceNode* sliceNode = this->SliceLogic->GetSliceNode();
+  vtkMRMLScene* scene = sliceNode->GetScene();
+
+  // Get event position
+  const int* eventPosition = eventData->GetDisplayPosition();
+  double displayPosDouble[2] = { static_cast<double>(eventPosition[0]), static_cast<double>(eventPosition[1]) };
+  const double* worldPos = eventData->GetWorldPosition();
+
+  // Get event position RAS
+  vtkMatrix4x4* xyToRAS = this->GetSliceNode()->GetXYToRAS();
+  double eventPos_XY[4] = { displayPosDouble[0], displayPosDouble[1], 0, 1 };
+  double eventPos_RAS[4] = { 0, 0, 0, 1 };
+  xyToRAS->MultiplyPoint(eventPos_XY, eventPos_RAS);
+  this->CurrentTranslationPoint_RAS[0] = eventPos_RAS[0];
+  this->CurrentTranslationPoint_RAS[1] = eventPos_RAS[1];
+  this->CurrentTranslationPoint_RAS[2] = eventPos_RAS[2];
+
+  // Get representation
+  vtkMRMLSliceIntersectionInteractionRepresentation* rep = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->GetRepresentation());
+  if (!rep)
+    {
+    return false;
+    }
+
+  // Get intersecting slice node
+  vtkMRMLSliceNode* intersectingSliceNode = vtkMRMLSliceNode::SafeDownCast(scene->GetNodeByID(this->LastIntersectingSliceNodeID));
+  if (!intersectingSliceNode)
+    {
+    return false;
+    }
+
+  // Get translation offset
+  double translationOffset[3] = { this->CurrentTranslationPoint_RAS[0] - this->StartTranslationPoint_RAS[0],
+                                  this->CurrentTranslationPoint_RAS[1] - this->StartTranslationPoint_RAS[1],
+                                  this->CurrentTranslationPoint_RAS[2] - this->StartTranslationPoint_RAS[2] };
+
+  double translationOffsetNorm = vtkMath::Norm(translationOffset);
+  if (translationOffsetNorm == 0) // to avoid translation when no mouse dragging was done
+    {
+    return false;
+    }
+
+  // Jump slice in intersecting slice node
+  intersectingSliceNode->JumpSlice(worldPos[0], worldPos[1], worldPos[2]);
+
+  // Store previous event position
+  this->PreviousEventPosition[0] = eventPosition[0];
+  this->PreviousEventPosition[1] = eventPosition[1];
+
+  return true;
+}
+
+
+//----------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessTranslateSingleIntersectingSliceHandleStart(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLSliceIntersectionInteractionRepresentation* rep = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->WidgetRep);
+  if (!rep)
+    {
+    return false;
+    }
+
+  this->SetWidgetState(WidgetStateTranslateSingleIntersectingSliceHandle);
+
+  // Save start translation point XY
+  const int* displayPos = eventData->GetDisplayPosition();
+  double displayPosDouble[2] = { static_cast<double>(displayPos[0]), static_cast<double>(displayPos[1]) };
+  this->StartTranslationPoint[0] = displayPosDouble[0];
+  this->StartTranslationPoint[1] = displayPosDouble[1];
+
+  // Save start translation point RAS
+  vtkMatrix4x4* xyToRAS = this->GetSliceNode()->GetXYToRAS();
+  double displayPosDouble_XY[4] = { displayPosDouble[0], displayPosDouble[1], 0, 1 };
+  double displayPosDouble_RAS[4] = { 0, 0, 0, 1 };
+  xyToRAS->MultiplyPoint(displayPosDouble_XY, displayPosDouble_RAS);
+  this->StartTranslationPoint_RAS[0] = displayPosDouble_RAS[0];
+  this->StartTranslationPoint_RAS[1] = displayPosDouble_RAS[1];
+  this->StartTranslationPoint_RAS[2] = displayPosDouble_RAS[2];
+
+  return this->ProcessStartMouseDrag(eventData);
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessTranslateSingleIntersectingSliceHandle(vtkMRMLInteractionEventData* eventData)
+{
+  // Get current slice node and scene
+  vtkMRMLSliceNode* sliceNode = this->SliceLogic->GetSliceNode();
+  vtkMRMLScene* scene = sliceNode->GetScene();
+
+  // Get event position
+  const int* eventPosition = eventData->GetDisplayPosition();
+  double displayPosDouble[2] = { static_cast<double>(eventPosition[0]), static_cast<double>(eventPosition[1]) };
+  const double* worldPos = eventData->GetWorldPosition();
+
+  // Get event position RAS
+  vtkMatrix4x4* xyToRAS = this->GetSliceNode()->GetXYToRAS();
+  double eventPos_XY[4] = { displayPosDouble[0], displayPosDouble[1], 0, 1 };
+  double eventPos_RAS[4] = { 0, 0, 0, 1 };
+  xyToRAS->MultiplyPoint(eventPos_XY, eventPos_RAS);
+  this->CurrentTranslationPoint_RAS[0] = eventPos_RAS[0];
+  this->CurrentTranslationPoint_RAS[1] = eventPos_RAS[1];
+  this->CurrentTranslationPoint_RAS[2] = eventPos_RAS[2];
+
+  // Get representation
+  vtkMRMLSliceIntersectionInteractionRepresentation* rep = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->GetRepresentation());
+  if (!rep)
+    {
+    return false;
+    }
+
+  // Get intersecting slice node
+  std::string intersectingSliceNodeID = this->LastIntersectingSliceNodeID;
+  vtkMRMLSliceNode* intersectingSliceNode = vtkMRMLSliceNode::SafeDownCast(scene->GetNodeByID(intersectingSliceNodeID));
+  if (!intersectingSliceNode)
+    {
+    return false;
+    }
+
+  this->SetWidgetState(WidgetStateTranslateSingleIntersectingSliceHandle);
+
+  // Get translation offset
+  double translationOffset[3] = { this->CurrentTranslationPoint_RAS[0] - this->StartTranslationPoint_RAS[0],
+                                  this->CurrentTranslationPoint_RAS[1] - this->StartTranslationPoint_RAS[1],
+                                  this->CurrentTranslationPoint_RAS[2] - this->StartTranslationPoint_RAS[2] };
+
+  double translationOffsetNorm = vtkMath::Norm(translationOffset);
+  if (translationOffsetNorm == 0) // to avoid translation when no mouse dragging was done
+    {
+    return false;
+    }
+
+  // Jump slice in intersecting slice node
+  intersectingSliceNode->JumpSlice(worldPos[0], worldPos[1], worldPos[2]);
+
+  // Store previous event position
+  this->PreviousEventPosition[0] = eventPosition[0];
+  this->PreviousEventPosition[1] = eventPosition[1];
+
+  return true;
+}
+
+//----------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessRotateIntersectingSlicesHandleStart(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLSliceIntersectionInteractionRepresentation* rep = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->WidgetRep);
+  if (!rep)
+    {
+    return false;
+    }
+
+  this->SetWidgetState(WidgetStateRotateIntersectingSlicesHandle);
+
+  // Save rotation center RAS
+  double* sliceIntersectionPoint_XY = rep->GetSliceIntersectionPoint(); // in RAS coordinate system
+  this->StartRotationCenter[0] = sliceIntersectionPoint_XY[0];
+  this->StartRotationCenter[1] = sliceIntersectionPoint_XY[1];
+
+  // Save rotation center XY
+  vtkMatrix4x4* xyToRAS = this->GetSliceNode()->GetXYToRAS();
+  double sliceIntersectionPoint_RAS[4] = { 0, 0, 0, 1 };
+  xyToRAS->MultiplyPoint(sliceIntersectionPoint_XY, sliceIntersectionPoint_RAS);
+  this->StartRotationCenter_RAS[0] = sliceIntersectionPoint_RAS[0];
+  this->StartRotationCenter_RAS[1] = sliceIntersectionPoint_RAS[1];
+  this->StartRotationCenter_RAS[2] = sliceIntersectionPoint_RAS[2];
+
+  // Save initial rotation angle
+  const int* displayPos = eventData->GetDisplayPosition();
+  double displayPosDouble[2] = { static_cast<double>(displayPos[0]), static_cast<double>(displayPos[1]) };
+  this->PreviousRotationAngleRad = this->GetSliceRotationAngleRad(displayPosDouble);
+
+  return this->ProcessStartMouseDrag(eventData);
+}
+
+/*
+//----------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessRotate(double sliceRotationAngleRad)
+{
+  vtkMRMLSliceIntersectionRepresentation2D* rep = vtkMRMLSliceIntersectionRepresentation2D::SafeDownCast(this->WidgetRep);
+  if (!rep)
+    {
+    return false;
+    }
+  vtkMatrix4x4* sliceToRAS = this->GetSliceNode()->GetSliceToRAS();
+  vtkNew<vtkTransform> rotatedSliceToSliceTransform;
+
+  // Save rotation center RAS
+  double* sliceIntersectionPoint_XY = rep->GetSliceIntersectionPoint(); // in RAS coordinate system
+  this->StartRotationCenter[0] = sliceIntersectionPoint_XY[0];
+  this->StartRotationCenter[1] = sliceIntersectionPoint_XY[1];
+
+  // Save rotation center XY
+  vtkMatrix4x4* xyToRAS = this->GetSliceNode()->GetXYToRAS();
+  double sliceIntersectionPoint_RAS[4] = { 0, 0, 0, 1 };
+  xyToRAS->MultiplyPoint(sliceIntersectionPoint_XY, sliceIntersectionPoint_RAS);
+  this->StartRotationCenter_RAS[0] = sliceIntersectionPoint_RAS[0];
+  this->StartRotationCenter_RAS[1] = sliceIntersectionPoint_RAS[1];
+  this->StartRotationCenter_RAS[2] = sliceIntersectionPoint_RAS[2];
+
+  rotatedSliceToSliceTransform->Translate(this->StartRotationCenter_RAS[0], this->StartRotationCenter_RAS[1], this->StartRotationCenter_RAS[2]);
+  double rotationDirection = vtkMath::Determinant3x3(sliceToRAS->Element[0], sliceToRAS->Element[1], sliceToRAS->Element[2]) >= 0 ? 1.0 : -1.0;
+  rotatedSliceToSliceTransform->RotateWXYZ(rotationDirection * vtkMath::DegreesFromRadians(sliceRotationAngleRad),
+    sliceToRAS->GetElement(0, 2), sliceToRAS->GetElement(1, 2), sliceToRAS->GetElement(2, 2));
+  rotatedSliceToSliceTransform->Translate(-this->StartRotationCenter_RAS[0], -this->StartRotationCenter_RAS[1], -this->StartRotationCenter_RAS[2]);
+
+  this->PreviousRotationAngleRad = sliceRotationAngleRad;
+
+  rep->TransformIntersectingSlices(rotatedSliceToSliceTransform->GetMatrix());
+  return true;
+}
+*/
+
+//----------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::ProcessRotateIntersectingSlicesHandle(vtkMRMLInteractionEventData* eventData)
+{
+  vtkMRMLSliceIntersectionInteractionRepresentation* rep = vtkMRMLSliceIntersectionInteractionRepresentation::SafeDownCast(this->WidgetRep);
+  if (!rep)
+    {
+    return false;
+    }
+
+  const int* displayPos = eventData->GetDisplayPosition();
+  double displayPosDouble[2] = { static_cast<double>(displayPos[0]), static_cast<double>(displayPos[1]) };
+  double sliceRotationAngleRad = this->GetSliceRotationAngleRad(displayPosDouble);
+
+  vtkMatrix4x4* sliceToRAS = this->GetSliceNode()->GetSliceToRAS();
+  vtkNew<vtkTransform> rotatedSliceToSliceTransform;
+
+  rotatedSliceToSliceTransform->Translate(this->StartRotationCenter_RAS[0], this->StartRotationCenter_RAS[1], this->StartRotationCenter_RAS[2]);
+  double rotationDirection = vtkMath::Determinant3x3(sliceToRAS->Element[0], sliceToRAS->Element[1], sliceToRAS->Element[2]) >= 0 ? 1.0 : -1.0;
+  rotatedSliceToSliceTransform->RotateWXYZ(rotationDirection * vtkMath::DegreesFromRadians(sliceRotationAngleRad - this->PreviousRotationAngleRad),
+    sliceToRAS->GetElement(0, 2), sliceToRAS->GetElement(1, 2), sliceToRAS->GetElement(2, 2));
+  rotatedSliceToSliceTransform->Translate(-this->StartRotationCenter_RAS[0], -this->StartRotationCenter_RAS[1], -this->StartRotationCenter_RAS[2]);
+
+  this->PreviousRotationAngleRad = sliceRotationAngleRad;
+  this->PreviousEventPosition[0] = displayPos[0];
+  this->PreviousEventPosition[1] = displayPos[1];
+
+  rep->TransformIntersectingSlices(rotatedSliceToSliceTransform->GetMatrix());
+
+  return true;
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLSliceIntersectionWidget::IsSliceIntersectionInteractive()
+{
+  vtkMRMLApplicationLogic* mrmlAppLogic = this->GetMRMLApplicationLogic();
+  if (!mrmlAppLogic)
+    {
+    return false;
+    }
+  return mrmlAppLogic->GetIntersectingSlicesEnabled(vtkMRMLApplicationLogic::IntersectingSlicesInteractive);
 }

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
@@ -38,7 +38,7 @@
 class vtkSliceIntersectionRepresentation2D;
 class vtkMRMLApplicationLogic;
 class vtkMRMLSegmentationDisplayNode;
-
+class vtkMRMLSliceDisplayNode;
 
 class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionWidget : public vtkMRMLAbstractWidget
 {
@@ -64,6 +64,8 @@ public:
   void SetSliceNode(vtkMRMLSliceNode* sliceNode);
   vtkMRMLSliceNode* GetSliceNode();
 
+  vtkMRMLSliceDisplayNode* GetSliceDisplayNode();
+
   void SetMRMLApplicationLogic(vtkMRMLApplicationLogic* applicationLogic) override;
 
   /// Return true if the widget can process the event.
@@ -78,16 +80,29 @@ public:
   /// Widget states
   enum
     {
-    WidgetStateFollowCursor = WidgetStateUser,
-    WidgetStateBlend,
-    WidgetStateTranslateSlice,
-    WidgetStateZoomSlice,
-    WidgetStateTouchGesture,
+    // Interactions without handles
+    WidgetStateFollowCursor = WidgetStateUser, ///< Set intersecting slices to current cursor position
+    WidgetStateBlend, ///< Fade between foreground/background volumes
+    WidgetStateTranslateSlice, ///< Pan (translate in-plane) the current slice (using shift+left-click-and-drag or middle-click-and-drag)
+    WidgetStateRotateIntersectingSlices, ///< Rotate all intersecting slices (ctrl+alt+left-click-and-drag)
+    WidgetStateZoomSlice, ///< Zoom slice (using right-button or mouse wheel)
+    WidgetStateTouchGesture, ///< Pinch/zoom/pan using touch gestures
+
+    // Interactions with slice intersection handles
+    WidgetStateOnTranslateIntersectingSlicesHandle, ///< hovering over a slice intersection point
+    WidgetStateTranslateIntersectingSlicesHandle, ///< translating all intersecting slices by drag-and-dropping handle
+    WidgetStateOnRotateIntersectingSlicesHandle, ///< hovering over a rotation interaction handle
+    WidgetStateRotateIntersectingSlicesHandle, ///< rotating all intersecting slices by drag-and-dropping handle
+    WidgetStateOnTranslateSingleIntersectingSliceHandle, ///< hovering over a single-slice translation interaction handle
+    WidgetStateTranslateSingleIntersectingSliceHandle, ///< translating a single slice by drag-and-dropping handle
+
+    WidgetState_Last
     };
 
   /// Widget events
   enum
     {
+    // Interactions without handles
     WidgetEventTouchGestureStart = WidgetEventUser,
     WidgetEventTouchGestureEnd,
     WidgetEventTouchRotateSliceIntersection,
@@ -108,17 +123,30 @@ public:
     WidgetEventShowPreviousBackgroundVolume,
     WidgetEventShowNextForegroundVolume,
     WidgetEventShowPreviousForegroundVolume,
+    WidgetEventRotateIntersectingSlicesStart, // rotate all intersecting slices (ctrl-alt-left-click-and-drag)
+    WidgetEventRotateIntersectingSlicesEnd,
     WidgetEventTranslateSliceStart,
     WidgetEventTranslateSliceEnd,
     WidgetEventZoomSliceStart,
     WidgetEventZoomSliceEnd,
     WidgetEventSetCrosshairPosition,
     WidgetEventMaximizeView,
+
+    // Interactions with slice intersection handles
+    // WidgetStateOnTranslateIntersectingSlicesHandle/WidgetStateTranslateIntersectingSlicesHandle
+    WidgetEventTranslateIntersectingSlicesHandleStart,
+    WidgetEventTranslateIntersectingSlicesHandleEnd,
+    // WidgetStateOnRotateIntersectingSlicesHandle/WidgetStateRotateIntersectingSlicesHandle
+    WidgetEventRotateIntersectingSlicesHandleStart,
+    WidgetEventRotateIntersectingSlicesHandleEnd,
+    // WidgetStateOnTranslateSingleIntersectingSliceHandle/WidgetStateOnTranslateSingleIntersectingSliceHandle
+    WidgetEventTranslateSingleIntersectingSliceHandleStart,
+    WidgetEventTranslateSingleIntersectingSliceHandleEnd,
     };
 
   /// Action State values and management
   enum
-  {
+    {
     ActionNone = 0,
     ActionTranslate = 1,
     ActionZoom = 2,
@@ -136,7 +164,7 @@ public:
     | ActionBrowseSlice | ActionShowSlice | ActionAdjustLightbox | ActionSelectVolume
     | ActionSetCursorPosition | ActionSetCrosshairPosition
     | ActionTranslateSliceIntersection | ActionRotateSliceIntersection
-  };
+    };
 
   /// Set exact list of actions to enable.
   void SetActionsEnabled(int actions);
@@ -155,6 +183,9 @@ public:
 
   void UpdateInteractionEventMapping();
 
+  // Allows the widget to request a cursor shape
+  int GetMouseCursor() override;
+
 protected:
   vtkMRMLSliceIntersectionWidget();
   ~vtkMRMLSliceIntersectionWidget() override;
@@ -164,12 +195,12 @@ protected:
   bool ProcessEndMouseDrag(vtkMRMLInteractionEventData* eventData);
   bool ProcessBlend(vtkMRMLInteractionEventData* eventData);
 
-  bool ProcessRotateStart(vtkMRMLInteractionEventData* eventData);
-  bool ProcessRotate(vtkMRMLInteractionEventData* eventData);
+  bool ProcessRotateIntersectingSlicesStart(vtkMRMLInteractionEventData* eventData);
+  bool ProcessRotateIntersectingSlices(vtkMRMLInteractionEventData* eventData);
   bool ProcessSetCrosshair(vtkMRMLInteractionEventData* eventData);
   double GetSliceRotationAngleRad(double eventPos[2]);
 
-  // Move slice in-plane by click-and-drag
+  // Pan (move slice in-plane) by click-and-drag
   bool ProcessTranslateSlice(vtkMRMLInteractionEventData* eventData);
 
   bool ProcessZoomSlice(vtkMRMLInteractionEventData* eventData);
@@ -179,6 +210,13 @@ protected:
   bool ProcessTouchRotate(vtkMRMLInteractionEventData* eventData);
   bool ProcessTouchZoom(vtkMRMLInteractionEventData* eventData);
   bool ProcessTouchTranslate(vtkMRMLInteractionEventData* eventData);
+
+  bool ProcessTranslateIntersectingSlicesHandleStart(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTranslateIntersectingSlicesHandle(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTranslateSingleIntersectingSliceHandleStart(vtkMRMLInteractionEventData* eventData);
+  bool ProcessTranslateSingleIntersectingSliceHandle(vtkMRMLInteractionEventData* eventData);
+  bool ProcessRotateIntersectingSlicesHandleStart(vtkMRMLInteractionEventData* eventData);
+  bool ProcessRotateIntersectingSlicesHandle(vtkMRMLInteractionEventData* eventData);
 
   bool ProcessWidgetMenu(vtkMRMLInteractionEventData* eventData);
 
@@ -202,12 +240,14 @@ protected:
 
   vtkMRMLSegmentationDisplayNode* GetVisibleSegmentationDisplayNode();
 
+  static void SliceModifiedCallback(vtkObject* caller, unsigned long eid, void* clientData, void* callData);
   static void SliceLogicsModifiedCallback(vtkObject* caller, unsigned long eid, void* clientData, void* callData);
 
   vtkWeakPointer<vtkCollection> SliceLogics;
   vtkWeakPointer<vtkMRMLSliceNode> SliceNode;
   vtkWeakPointer<vtkMRMLSliceLogic> SliceLogic;
   vtkNew<vtkCallbackCommand> SliceLogicsModifiedCommand;
+  vtkNew<vtkCallbackCommand> SliceModifiedCommand;
 
   double StartEventPosition[2];
   double PreviousRotationAngleRad;
@@ -215,15 +255,19 @@ protected:
   double StartRotationCenter[2];
   double StartRotationCenter_RAS[4];
 
+  double StartTranslationPoint[2];
+  double StartTranslationPoint_RAS[3];
+  double CurrentTranslationPoint_RAS[3];
+
   double StartActionFOV[3];
   double VolumeScalarRange[2];
 
   enum
-  {
+    {
     LayerBackground,
     LayerForeground,
     LayerLabelmap
-  };
+    };
 
   // Blend
   double LastForegroundOpacity;
@@ -247,6 +291,8 @@ protected:
   ///  - direction: positive or negative (wraps through volumes in scene)
   void CycleVolumeLayer(int layer, int direction);
 
+  bool IsSliceIntersectionInteractive();
+
   /// Indicates whether the shift key was used during the previous action.
   /// This is used to require shift-up after a click-and-drag before accepting shift+mousemove.
   bool ModifierKeyPressedSinceLastClickAndDrag;
@@ -262,6 +308,9 @@ protected:
   bool TouchTranslationEnabled;
   double TotalTouchZoom;
   bool TouchZoomEnabled;
+
+  // Last intersecting slice node where interaction occurred
+  std::string LastIntersectingSliceNodeID;
 
 private:
   vtkMRMLSliceIntersectionWidget(const vtkMRMLSliceIntersectionWidget&) = delete;

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -35,6 +35,7 @@
 #include "vtkMRMLScene.h"
 #include "vtkMRMLSelectionNode.h"
 #include "vtkMRMLSliceCompositeNode.h"
+#include "vtkMRMLSliceDisplayNode.h"
 #include "vtkMRMLSliceNode.h"
 #include "vtkMRMLStorableNode.h"
 #include "vtkMRMLStorageNode.h"
@@ -916,4 +917,105 @@ void vtkMRMLApplicationLogic::OnMRMLSceneStartRestore()
 void vtkMRMLApplicationLogic::OnMRMLSceneEndRestore()
 {
   this->ResumeRender();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLApplicationLogic::SetIntersectingSlicesEnabled(
+  vtkMRMLApplicationLogic::IntersectingSlicesOperation operation, bool enabled)
+{
+  vtkMRMLScene* scene = this->GetMRMLScene();
+  if (!scene)
+    {
+    vtkWarningMacro("vtkMRMLApplicationLogic::SetIntersectingSlicesEnabled failed: invalid scene");
+    return;
+    }
+
+  vtkSmartPointer<vtkCollection> sliceDisplayNodes =
+    vtkSmartPointer<vtkCollection>::Take(scene->GetNodesByClass("vtkMRMLSliceDisplayNode"));
+  if (sliceDisplayNodes.GetPointer())
+    {
+    vtkMRMLSliceDisplayNode* sliceDisplayNode = nullptr;
+    vtkCollectionSimpleIterator it;
+    for (sliceDisplayNodes->InitTraversal(it);
+      (sliceDisplayNode = static_cast<vtkMRMLSliceDisplayNode*>(sliceDisplayNodes->GetNextItemAsObject(it)));)
+      {
+      switch (operation)
+        {
+        case vtkMRMLApplicationLogic::IntersectingSlicesVisibility:
+          sliceDisplayNode->SetIntersectingSlicesVisibility(enabled);
+          break;
+        case vtkMRMLApplicationLogic::IntersectingSlicesInteractive:
+          sliceDisplayNode->SetIntersectingSlicesInteractive(enabled);
+          break;
+        case vtkMRMLApplicationLogic::IntersectingSlicesTranslation:
+          sliceDisplayNode->SetIntersectingSlicesTranslationEnabled(enabled);
+          break;
+        case vtkMRMLApplicationLogic::IntersectingSlicesRotation:
+          sliceDisplayNode->SetIntersectingSlicesRotationEnabled(enabled);
+          break;
+        }
+      }
+    }
+
+  // The vtkMRMLSliceIntersectionWidget should observe slice display node modifications
+  // but as a workaround for now, trigger update by modifying all the slice nodes.
+  vtkSmartPointer<vtkCollection> sliceNodes =
+    vtkSmartPointer<vtkCollection>::Take(scene->GetNodesByClass("vtkMRMLSliceNode"));
+  if (sliceNodes.GetPointer())
+    {
+    vtkMRMLSliceNode* sliceNode = nullptr;
+    vtkCollectionSimpleIterator it;
+    for (sliceNodes->InitTraversal(it);
+      (sliceNode = static_cast<vtkMRMLSliceNode*>(sliceNodes->GetNextItemAsObject(it)));)
+      {
+      sliceNode->Modified();
+      }
+    }
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLApplicationLogic::GetIntersectingSlicesEnabled(
+  vtkMRMLApplicationLogic::IntersectingSlicesOperation operation)
+{
+  vtkMRMLScene* scene = this->GetMRMLScene();
+  if (!scene)
+    {
+    vtkWarningMacro("vtkMRMLApplicationLogic::GetIntersectingSlicesEnabled failed: invalid scene");
+    return false;
+    }
+  vtkMRMLSliceDisplayNode* sliceDisplayNode = vtkMRMLSliceDisplayNode::SafeDownCast(
+    scene->GetFirstNodeByClass("vtkMRMLSliceDisplayNode"));
+  if (!sliceDisplayNode)
+    {
+    // No slice display nodes are in the scene yet, use the scene default node instead.
+    // Developers can set the default appearance of intersecting slices by modifying the
+    // default slice display node.
+    vtkSmartPointer<vtkMRMLSliceDisplayNode> defaultSliceDisplayNode =
+      vtkMRMLSliceDisplayNode::SafeDownCast(scene->GetDefaultNodeByClass("vtkMRMLSliceDisplayNode"));
+    if (!defaultSliceDisplayNode.GetPointer())
+      {
+      defaultSliceDisplayNode = vtkSmartPointer<vtkMRMLSliceDisplayNode>::New();
+      scene->AddDefaultNode(defaultSliceDisplayNode);
+      }
+    sliceDisplayNode = defaultSliceDisplayNode;
+    if (!sliceDisplayNode)
+      {
+      vtkErrorMacro("vtkMRMLApplicationLogic::GetIntersectingSlicesEnabled failed: cannot get slice display node");
+      return false;
+      }
+    }
+
+  switch (operation)
+    {
+    case vtkMRMLApplicationLogic::IntersectingSlicesVisibility:
+      return sliceDisplayNode->GetIntersectingSlicesVisibility();
+    case vtkMRMLApplicationLogic::IntersectingSlicesInteractive:
+      return sliceDisplayNode->GetIntersectingSlicesInteractive();
+    case vtkMRMLApplicationLogic::IntersectingSlicesTranslation:
+      return sliceDisplayNode->GetIntersectingSlicesTranslationEnabled();
+    case vtkMRMLApplicationLogic::IntersectingSlicesRotation:
+      return sliceDisplayNode->GetIntersectingSlicesRotationEnabled();
+    }
+
+  return false;
 }

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -25,6 +25,7 @@
 #include "vtkMRMLAbstractLogic.h"
 
 #include "vtkMRMLLogicExport.h"
+#include "vtkMRMLSliceCompositeNode.h"
 
 class vtkMRMLColorLogic;
 class vtkMRMLModelDisplayNode;
@@ -249,6 +250,17 @@ public:
   /// \return constant pointer to vtkMRMLAbstractLogic corresponding to the
   /// logic associated to th logic
   vtkMRMLAbstractLogic* GetModuleLogic(const char* moduleName) const;
+
+  enum IntersectingSlicesOperation
+  {
+    IntersectingSlicesVisibility,
+    IntersectingSlicesInteractive,
+    IntersectingSlicesTranslation,
+    IntersectingSlicesRotation,
+  };
+
+  void SetIntersectingSlicesEnabled(IntersectingSlicesOperation operation, bool enabled);
+  bool GetIntersectingSlicesEnabled(IntersectingSlicesOperation operation);
 
 protected:
 

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -27,6 +27,7 @@ class vtkMRMLLinearTransformNode;
 class vtkMRMLModelDisplayNode;
 class vtkMRMLModelNode;
 class vtkMRMLSliceCompositeNode;
+class vtkMRMLSliceDisplayNode;
 class vtkMRMLSliceLayerLogic;
 class vtkMRMLSliceNode;
 class vtkMRMLVolumeNode;
@@ -141,8 +142,13 @@ public:
   vtkGetObjectMacro(SliceModelNode, vtkMRMLModelNode);
 
   ///
-  /// Model slice plane display props
+  /// Model slice plane display properties.
+  /// The method is deprecated, use SliceDisplayNode instead.
   vtkGetObjectMacro(SliceModelDisplayNode, vtkMRMLModelDisplayNode);
+
+  ///
+  /// Slice plane display properties
+  vtkMRMLSliceDisplayNode* GetSliceDisplayNode();
 
   ///
   /// Model slice plane transform from xy to RAS

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -36,6 +36,7 @@
 #include <qMRMLThreeDWidget.h>
 
 // MRMLLogic includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLColorLogic.h>
 #include <vtkMRMLSliceLogic.h>
 #include <vtkMRMLViewLogic.h>
@@ -250,11 +251,10 @@ QWidget* qMRMLLayoutSliceViewFactory::createViewFromNode(vtkMRMLAbstractViewNode
   qMRMLSliceWidget * sliceWidget = new qMRMLSliceWidget(this->layoutManager()->viewport());
   sliceWidget->sliceController()->setControllerButtonGroup(this->SliceControllerButtonGroup);
   sliceWidget->setObjectName(QString("qMRMLSliceWidget%1").arg(viewNode->GetLayoutName()));
-  sliceWidget->setMRMLScene(this->mrmlScene());
+  // set slice node before setting the scene to allow using slice node names in the slice transform, display, and model nodes
   sliceWidget->setMRMLSliceNode(vtkMRMLSliceNode::SafeDownCast(viewNode));
+  sliceWidget->setMRMLScene(this->mrmlScene());
   sliceWidget->setSliceLogics(this->sliceLogics());
-  vtkMRMLApplicationLogic* applicationLogic = vtkMRMLSliceViewDisplayableManagerFactory::GetInstance()->GetMRMLApplicationLogic();
-  sliceWidget->sliceLogic()->SetMRMLApplicationLogic(applicationLogic);
   this->sliceLogics()->AddItem(sliceWidget->sliceLogic());
 
   return sliceWidget;

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -440,6 +440,8 @@ void qMRMLSliceControllerWidgetPrivate::init()
   this->MoreButton->setChecked(false);
 
   vtkNew<vtkMRMLSliceLogic> defaultLogic;
+  defaultLogic->SetMRMLApplicationLogic(vtkMRMLSliceViewDisplayableManagerFactory::GetInstance()->GetMRMLApplicationLogic());
+
   q->setSliceLogic(defaultLogic.GetPointer());
 }
 

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -1590,67 +1590,6 @@ bool vtkSlicerMarkupsLogic::StartPlaceMode(bool persistent, vtkMRMLInteractionNo
 }
 
 //---------------------------------------------------------------------------
-int vtkSlicerMarkupsLogic::GetSliceIntersectionsVisibility()
-{
-  if (!this->GetMRMLScene())
-    {
-    vtkErrorMacro("GetSliceIntersectionsVisibility: no scene");
-    return -1;
-    }
-  int numVisible = 0;
-  vtkSmartPointer<vtkCollection> nodes;
-  nodes.TakeReference(this->GetMRMLScene()->GetNodesByClass("vtkMRMLSliceCompositeNode"));
-  if (!nodes.GetPointer())
-    {
-    return -1;
-    }
-  vtkMRMLSliceCompositeNode* node = nullptr;
-  vtkCollectionSimpleIterator it;
-  for (nodes->InitTraversal(it);(node = static_cast<vtkMRMLSliceCompositeNode*>(
-                                   nodes->GetNextItemAsObject(it)));)
-    {
-    if (node->GetSliceIntersectionVisibility())
-      {
-      numVisible++;
-      }
-    }
-  if (numVisible == 0)
-    {
-    return 0;
-    }
-  else if (numVisible == nodes->GetNumberOfItems())
-    {
-    return 1;
-    }
-  else
-    {
-    return 2;
-    }
-}
-
-//---------------------------------------------------------------------------
-void vtkSlicerMarkupsLogic::SetSliceIntersectionsVisibility(bool flag)
-{
-  if (!this->GetMRMLScene())
-    {
-    return;
-    }
-  vtkSmartPointer<vtkCollection> nodes;
-  nodes.TakeReference(this->GetMRMLScene()->GetNodesByClass("vtkMRMLSliceCompositeNode"));
-  if (!nodes.GetPointer())
-    {
-    return;
-    }
-  vtkMRMLSliceCompositeNode* node = nullptr;
-  vtkCollectionSimpleIterator it;
-  for (nodes->InitTraversal(it);(node = static_cast<vtkMRMLSliceCompositeNode*>(
-                                   nodes->GetNextItemAsObject(it)));)
-    {
-    node->SetSliceIntersectionVisibility(flag);
-    }
-}
-
-//---------------------------------------------------------------------------
 vtkMRMLMarkupsDisplayNode* vtkSlicerMarkupsLogic::GetDefaultMarkupsDisplayNode()
 {
   if (!this->GetMRMLScene())

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -188,14 +188,6 @@ public:
   /// \sa SetActiveIDList
   bool StartPlaceMode(bool persistent, vtkMRMLInteractionNode* interactionNode = nullptr);
 
-  /// Inspect all the slice composite nodes in the scene. Return 1 if all have
-  /// SliceIntersectionVisibility set to true, 0 if all have it set to false,
-  /// 2 if it's a combination of true and false, -1 on error
-  int GetSliceIntersectionsVisibility();
-  /// Set the slice intersections visbility on all the slice composite nodes
-  /// in the scene
-  void SetSliceIntersectionsVisibility(bool flag);
-
   vtkSetMacro(AutoCreateDisplayNodes, bool);
   vtkGetMacro(AutoCreateDisplayNodes, bool);
   vtkBooleanMacro(AutoCreateDisplayNodes, bool);

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
@@ -49,13 +49,6 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
   // should be invalid if scene is not set
   CHECK_INT(fidIndex, -1);
 
-  TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
-  int sliceIntersectionVisibility = logic1->GetSliceIntersectionsVisibility();
-  TESTING_OUTPUT_ASSERT_ERRORS_END();
-  // should be invalid if scene is not set
-  CHECK_INT(sliceIntersectionVisibility, -1);
-  logic1->SetSliceIntersectionsVisibility(true);
-
   // test with a scene
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   logic1->SetMRMLScene(scene);
@@ -198,20 +191,6 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
   logic1->SetActiveListID(activeMarkupsNode);
   activeListID = logic1->GetActiveListID();
   CHECK_STD_STRING(activeListID, activeMarkupsNode->GetID());
-
-  sliceIntersectionVisibility = logic1->GetSliceIntersectionsVisibility();
-  CHECK_INT(sliceIntersectionVisibility, 0);
-
-  logic1->SetSliceIntersectionsVisibility(true);
-  sliceIntersectionVisibility = logic1->GetSliceIntersectionsVisibility();
-  CHECK_INT(sliceIntersectionVisibility, 0);
-
-  // now add a slice composite node
-  vtkNew<vtkMRMLSliceCompositeNode> compNode;
-  scene->AddNode(compNode.GetPointer());
-  logic1->SetSliceIntersectionsVisibility(true);
-  sliceIntersectionVisibility = logic1->GetSliceIntersectionsVisibility();
-  CHECK_INT(sliceIntersectionVisibility, 1);
 
   return EXIT_SUCCESS;
 }

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -408,7 +408,7 @@ void qSlicerMarkupsModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
     this->jumpModeComboBox->setCurrentIndex(JUMP_MODE_COMBOBOX_INDEX_CENTERED);
     }
   // update the checked state of showing the slice intersections
-  // vtkSlicerMarkupsLogic::GetSliceIntersectionsVisibility() cannot be called, as the scene
+  // vtkMRMLApplicationLogic::GetIntersectingSlicesEnabled cannot be called, as the scene
   // is not yet set, so just set to the default value (slice intersections not visible).
   this->sliceIntersectionsVisibilityCheckBox->setChecked(false);
   QObject::connect(this->sliceIntersectionsVisibilityCheckBox,
@@ -2870,12 +2870,12 @@ void qSlicerMarkupsModuleWidget::onActiveMarkupsNodeTransformModifiedEvent()
 //-----------------------------------------------------------------------------
 void qSlicerMarkupsModuleWidget::onSliceIntersectionsVisibilityToggled(bool flag)
 {
-  if (!this->markupsLogic())
+  if (!this->appLogic())
     {
-    qWarning() << "Unable to get markups logic";
+    qWarning() << "Unable to get application logic";
     return;
     }
-  this->markupsLogic()->SetSliceIntersectionsVisibility(flag);
+  return this->appLogic()->SetIntersectingSlicesEnabled(vtkMRMLApplicationLogic::IntersectingSlicesVisibility, flag);
 }
 
 //-----------------------------------------------------------------------------
@@ -2938,21 +2938,12 @@ void qSlicerMarkupsModuleWidget::onNewMarkupWithCurrentDisplayPropertiesTriggere
 //-----------------------------------------------------------------------------
 bool qSlicerMarkupsModuleWidget::sliceIntersectionsVisible()
 {
-  if (!this->markupsLogic())
+  if (!this->appLogic())
     {
-    qWarning() << "Unable to get markups logic";
+    qWarning() << "Unable to get application logic";
     return false;
     }
-  int flag = this->markupsLogic()->GetSliceIntersectionsVisibility();
-  if (flag == 0 || flag == -1)
-    {
-    return false;
-    }
-  else
-    {
-    // if all or some are visible, return true
-    return true;
-    }
+  return this->appLogic()->GetIntersectingSlicesEnabled(vtkMRMLApplicationLogic::IntersectingSlicesVisibility);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.h
@@ -67,6 +67,8 @@ protected slots:
   void fitSliceView();
   void centerThreeDView();
   void toggleTiltLock();
+  void setIntersectingSlicesVisible(bool);
+  void setIntersectingSlicesHandlesVisible(bool);
 
 protected:
   QScopedPointer<qSlicerSubjectHierarchyViewContextMenuPluginPrivate> d_ptr;


### PR DESCRIPTION
If "Interaction" flag is enabled then slice intersections can be drag-and-dropped in slice views.

Re #5544

Co-authored-by: Andras Lasso <lasso@queensu.ca>
Co-authored-by: Csaba Pinter <pinter.csaba@gmail.com>

Continuation of https://github.com/Slicer/Slicer/pull/6008