### PR TITLE
ENH: Add setMRMLScene to qMRMLCollapsibleButton

### DIFF
--- a/Libs/MRML/Widgets/Testing/CMakeLists.txt
+++ b/Libs/MRML/Widgets/Testing/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_SOURCES
   qMRMLCheckableNodeComboBoxTest.cxx
   qMRMLCheckableNodeComboBoxTest1.cxx
   qMRMLClipNodeWidgetTest1.cxx
+  qMRMLCollapsibleButtonTest.cxx
   qMRMLColorListViewTest1.cxx
   qMRMLColorModelTest.cxx
   qMRMLColorModelTest1.cxx
@@ -138,6 +139,7 @@ set(Tests_UtilityFiles
 
 set(KIT_TEST_GENERATE_MOC_SRCS
   qMRMLCheckableNodeComboBoxTest.cxx
+  qMRMLCollapsibleButtonTest.cxx
   qMRMLColorModelTest.cxx
   qMRMLDisplayNodeViewComboBoxTest.cxx
   qMRMLLabelComboBoxTest.cxx
@@ -189,6 +191,7 @@ endfunction()
 simple_test( qMRMLCheckableNodeComboBoxTest )
 simple_test( qMRMLCheckableNodeComboBoxTest1 )
 simple_test( qMRMLClipNodeWidgetTest1 )
+simple_test( qMRMLCollapsibleButtonTest)
 simple_test( qMRMLColorListViewTest1 )
 simple_test( qMRMLColorModelTest )
 simple_test( qMRMLColorModelTest1 )

--- a/Libs/MRML/Widgets/Testing/qMRMLCollapsibleButtonTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLCollapsibleButtonTest.cxx
@@ -1,0 +1,66 @@
+/*==============================================================================
+
+  Copyright (c) The Intervention Centre
+  Oslo University Hospital, Oslo, Norway. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Rafael Palomar (The Intervention Centre,
+  Oslo University Hospital), based on qMRMLMarkupsOptionsWidgetsFactory.h by
+  Csaba Pinter (Perklab, Queen's University), and was supported by The Research
+  Council of Norway through the ALive project (grant nr. 311393).
+
+  ==============================================================================*/
+
+// Qt includes
+#include <QScopedPointer>
+#include <QSignalSpy>
+#include <QTest>
+
+// CTK includes
+#include "ctkTest.h"
+
+// VTK includes
+#include <vtkNew.h>
+
+// qMRML includes
+#include "qMRMLCollapsibleButton.h"
+#include "qMRMLWidget.h"
+
+// vtkMRML includes
+#include "vtkMRMLScene.h"
+
+// ----------------------------------------------------------------------------
+class qMRMLCollapsibleButtonTester: public QObject
+{
+  Q_OBJECT
+private slots:
+  void testSetMRMLScene(); //Test setMRMLScene and propagation of qt signal
+};
+
+
+// ----------------------------------------------------------------------------
+void qMRMLCollapsibleButtonTester::testSetMRMLScene()
+{
+  QScopedPointer<qMRMLCollapsibleButton> collapsibleButton(new qMRMLCollapsibleButton);
+  QSignalSpy registeredSignalSpy(collapsibleButton.data(), SIGNAL(mrmlSceneChanged(vtkMRMLScene* )));
+  vtkNew<vtkMRMLScene> scene;
+
+  // Trigger the mrmlsceneChanged signal
+  collapsibleButton->setMRMLScene(scene.GetPointer());
+
+  // Make sure the signal triggers only 1 time.
+  QCOMPARE(registeredSignalSpy.count(), 1);
+  // Verify that the original pointer and the stored in the collapsible button are the same
+  QVERIFY(collapsibleButton->mrmlScene() == scene.GetPointer());
+}
+
+CTK_TEST_MAIN(qMRMLCollapsibleButtonTest)
+#include "moc_qMRMLCollapsibleButtonTest.cxx"

--- a/Libs/MRML/Widgets/qMRMLCollapsibleButton.cxx
+++ b/Libs/MRML/Widgets/qMRMLCollapsibleButton.cxx
@@ -22,14 +22,51 @@
 #include <QEvent>
 #include <QStyle>
 
+// VTK includes
+#include <vtkSmartPointer.h>
+
+// MRML includes
+#include "vtkMRMLScene.h"
+
 // qMRML includes
 #include "qMRMLCollapsibleButton.h"
+
+
+// --------------------------------------------------------------------------
+class qMRMLCollapsibleButtonPrivate
+{
+public:
+  vtkSmartPointer<vtkMRMLScene> MRMLScene;
+};
 
 // --------------------------------------------------------------------------
 // qMRMLCollapsibleButton methods
 
 // --------------------------------------------------------------------------
 qMRMLCollapsibleButton::qMRMLCollapsibleButton(QWidget* parentWidget)
-  :Superclass(parentWidget)
+  :Superclass(parentWidget), d_ptr(new qMRMLCollapsibleButtonPrivate)
 {
+}
+
+//-----------------------------------------------------------------------------
+qMRMLCollapsibleButton::~qMRMLCollapsibleButton() = default;
+
+//-----------------------------------------------------------------------------
+void qMRMLCollapsibleButton::setMRMLScene(vtkMRMLScene* scene)
+{
+  Q_D(qMRMLCollapsibleButton);
+  if (scene == d->MRMLScene)
+    {
+    return ;
+    }
+  d->MRMLScene = scene;
+
+  emit mrmlSceneChanged(scene);
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLScene* qMRMLCollapsibleButton::mrmlScene()const
+{
+  Q_D(const qMRMLCollapsibleButton);
+  return d->MRMLScene;
 }

--- a/Libs/MRML/Widgets/qMRMLCollapsibleButton.h
+++ b/Libs/MRML/Widgets/qMRMLCollapsibleButton.h
@@ -27,6 +27,9 @@
 // qMRMLWidget includes
 #include "qMRMLWidgetsExport.h"
 
+class qMRMLCollapsibleButtonPrivate;
+class vtkMRMLScene;
+
 /// This class is intended to improve visual appearance of ctkCollapsibleButton,
 /// but currently it works exactly as its base class ctkCollapsibleButton.
 class QMRML_WIDGETS_EXPORT qMRMLCollapsibleButton : public ctkCollapsibleButton
@@ -38,7 +41,23 @@ public:
 
   /// Constructors
   explicit qMRMLCollapsibleButton(QWidget* parent = nullptr);
-  ~qMRMLCollapsibleButton() override = default;
+  ~qMRMLCollapsibleButton() override;
+
+  /// Return a pointer on the MRML scene
+  vtkMRMLScene* mrmlScene() const;
+
+public slots:
+  void setMRMLScene(vtkMRMLScene* scene);
+
+signals:
+  void mrmlSceneChanged(vtkMRMLScene*);
+
+protected:
+  QScopedPointer<qMRMLCollapsibleButtonPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qMRMLCollapsibleButton);
+  Q_DISABLE_COPY(qMRMLCollapsibleButton);
 };
 
 #endif


### PR DESCRIPTION
This adds the`setMRMLScene` function to `qMRMLCollapsibleButton`, as well
as the qt signaling to propagate the changes of the MRMLScene. This is
useful to propagate the change of MRMLScene to children of
`qMRMLCollapsibleButton`, which is particularly useful when defining UIs
with Qt designer.