### PR TITLE
COMP: Update LibFFI to fix macOS link error related to HAVE_AS_X86_PCREL test

### DIFF
--- a/SuperBuild/External_LibFFI.cmake
+++ b/SuperBuild/External_LibFFI.cmake
@@ -34,7 +34,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "cb4a78e39009646935badbeddb48d54c1fe97d63" # libffi-cmake-buildsystem-v3.4.2-2021-06-28-f9ea416
+    "e8599d9d5a50841c11a5ff8e3438dd12f080b096" # libffi-cmake-buildsystem-v3.4.2-2021-06-28-f9ea416
     QUIET
     )
 


### PR DESCRIPTION
This commit fixes a regression introduced in 34e48e8ae (ENH: Upgrade
from python 3.6.7 to 3.9.10)

List of LibFFI changes:

```
$ git shortlog cb4a78e..e8599d9 --no-merges
Jean-Christophe Fillion-Robin (1):
      cmake: Fix HAVE_AS_X86_PCREL test on macOS ensuring linking is disabled
```