### PR TITLE
COMP: Fix windows build updating SimpleITK install step

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -94,6 +94,18 @@ if(NOT Slicer_USE_SYSTEM_${proj})
 # Added by '${CMAKE_CURRENT_LIST_FILE}'
 set(ENV{${_varname}} \"${_paths}${_path_sep}\$ENV{${_varname}}\")
 ")
+  if(WIN32)
+    file(APPEND ${_env_script}
+"#------------------------------------------------------------------------------
+# Added by '${CMAKE_CURRENT_LIST_FILE}' to ensure the function 'slicer_dll_directories.add()'
+# called from sitecustomize can add all the directories associated with the SimpleITK
+# dependencies.
+#
+# This is required when executing the SimpleITK external project install command below to
+# ensure the _SimpleITK module can resolve its dependencies.
+set(ENV{LibraryPaths} \"${_paths}${_path_sep}\$ENV{${_varname}}\")
+")
+  endif()
 
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 


### PR DESCRIPTION
This commit fixes a regression introduced in 34e48e8ae (ENH: Upgrade
from python 3.6.7 to 3.9.10) by integrating a fix originally contributed
in the pull request Slicer#6026 (Update Slicer python to 3.9.10).

It ensures the "LibraryPaths" env. variables read by "slicer_dll_directories.add()"
is set in the file "SimpleITK_Env.cmake" included from "SimpleITK_install_step.cmake"