### PR TITLE
BUG: Fix use of removed `time.clock()` method

### DIFF
--- a/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyFiducials.py
+++ b/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyFiducials.py
@@ -24,15 +24,15 @@ def TestFiducialAdd(renameFlag=1, visibilityFlag=1, numToAdd=20):
 #    print "i = ", i, "/", numToAdd, ", r = ", r, ", a = ", a, ", s = ", s
     fidNode = slicer.vtkMRMLAnnotationFiducialNode()
     fidNode.SetFiducialCoordinates(r, a, s)
-    t1 = time.clock()
+    t1 = time.process_time()
     fidNode.Initialize(slicer.mrmlScene)
-    t2 = time.clock()
+    t2 = time.process_time()
     timeToAddThisFid = t2 - t1
     dt = timeToAddThisFid - timeToAddLastFid
     if renameFlag > 0:
-      t3 = time.clock()
+      t3 = time.process_time()
       fidNode.SetName(str(i))
-      t4 = time.clock()
+      t4 = time.process_time()
       timeToRenameThisFid = t4 - t3
       dt2 = timeToRenameThisFid - timeToRenameLastFid
       print('%(index)04d\t' % {'index': i}, timeToAddThisFid, "\t", dt, "\t", timeToRenameThisFid, "\t", dt2)
@@ -44,9 +44,9 @@ def TestFiducialAdd(renameFlag=1, visibilityFlag=1, numToAdd=20):
     s = s + 1.0
     timeToAddLastFid = timeToAddThisFid
 
-testStartTime = time.clock()
+testStartTime = time.process_time()
 TestFiducialAdd()
-testEndTime = time.clock()
+testEndTime = time.process_time()
 testTime = testEndTime - testStartTime
 print("Test total time = ", testTime)
 

--- a/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyROIs.py
+++ b/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyROIs.py
@@ -28,15 +28,15 @@ def TestROIAdd(renameFlag=1, visibilityFlag=1, numToAdd=20):
     roiNode = slicer.vtkMRMLAnnotationROINode()
     roiNode.SetXYZ(cx, cy, cz)
     roiNode.SetRadiusXYZ(rx, ry, rz)
-    t1 = time.clock()
+    t1 = time.process_time()
     roiNode.Initialize(slicer.mrmlScene)
-    t2 = time.clock()
+    t2 = time.process_time()
     timeToAddThisROI = t2 - t1
     dt = timeToAddThisROI - timeToAddLastROI
     if renameFlag > 0:
-      t3 = time.clock()
+      t3 = time.process_time()
       roiNode.SetName(str(i))
-      t4 = time.clock()
+      t4 = time.process_time()
       timeToRenameThisROI = t4 - t3
       dt2 = timeToRenameThisROI - timeToRenameLastROI
       print('%(index)04d\t' % {'index': i}, timeToAddThisROI, "\t", dt, "\t", timeToRenameThisROI, "\t", dt2)
@@ -51,9 +51,9 @@ def TestROIAdd(renameFlag=1, visibilityFlag=1, numToAdd=20):
     cz = cz + 2.0
     timeToAddLastROI = timeToAddThisROI
 
-testStartTime = time.clock()
+testStartTime = time.process_time()
 TestROIAdd()
-testEndTime = time.clock()
+testEndTime = time.process_time()
 testTime = testEndTime - testStartTime
 print("Test total time = ", testTime)
 

--- a/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyRulers.py
+++ b/Modules/Loadable/Annotations/Testing/Python/AnnotationsTestingAddManyRulers.py
@@ -28,15 +28,15 @@ def TestRulerAdd(renameFlag=1, visibilityFlag=1, numToAdd=20):
     rulerNode = slicer.vtkMRMLAnnotationRulerNode()
     rulerNode.SetPosition1(r1, a1, s1)
     rulerNode.SetPosition2(r2, a2, s2)
-    t1 = time.clock()
+    t1 = time.process_time()
     rulerNode.Initialize(slicer.mrmlScene)
-    t2 = time.clock()
+    t2 = time.process_time()
     timeToAddThisRuler = t2 - t1
     dt = timeToAddThisRuler - timeToAddLastRuler
     if renameFlag > 0:
-      t3 = time.clock()
+      t3 = time.process_time()
       rulerNode.SetName(str(i))
-      t4 = time.clock()
+      t4 = time.process_time()
       timeToRenameThisRuler = t4 - t3
       dt2 = timeToRenameThisRuler - timeToRenameLastRuler
       print('%(index)04d\t' % {'index': i}, timeToAddThisRuler, "\t", dt, "\t", timeToRenameThisRuler, "\t", dt2)
@@ -51,9 +51,9 @@ def TestRulerAdd(renameFlag=1, visibilityFlag=1, numToAdd=20):
     s2 = s2 + 1.5
     timeToAddLastRuler = timeToAddThisRuler
 
-testStartTime = time.clock()
+testStartTime = time.process_time()
 TestRulerAdd()
-testEndTime = time.clock()
+testEndTime = time.process_time()
 testTime = testEndTime - testStartTime
 print("Test total time = ", testTime)
 

--- a/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
@@ -157,7 +157,7 @@ class AddManyMarkupsFiducialTestLogic(ScriptedLoadableModuleLogic):
     timeToAddThisFid = 0
     timeToAddLastFid = 0
 
-    testStartTime = time.clock()
+    testStartTime = time.process_time()
 
     import random
 
@@ -182,9 +182,9 @@ class AddManyMarkupsFiducialTestLogic(ScriptedLoadableModuleLogic):
 
       for controlPointIndex in range(numberOfControlPoints):
         #    print "controlPointIndex = ", controlPointIndex, "/", numberOfControlPoints, ", r = ", r, ", a = ", a, ", s = ", s
-        t1 = time.clock()
+        t1 = time.process_time()
         markupsNode.AddControlPoint(vtk.vtkVector3d(r,a,s))
-        t2 = time.clock()
+        t2 = time.process_time()
         timeToAddThisFid = t2 - t1
         dt = timeToAddThisFid - timeToAddLastFid
         #print '%(index)04d\t' % {'index': controlPointIndex}, timeToAddThisFid, "\t", dt
@@ -200,7 +200,7 @@ class AddManyMarkupsFiducialTestLogic(ScriptedLoadableModuleLogic):
       print("Resume render")
       slicer.app.resumeRender()
 
-    testEndTime = time.clock()
+    testEndTime = time.process_time()
     testTime = testEndTime - testStartTime
     print("Total time to add ",numberOfControlPoints," = ", testTime)
 


### PR DESCRIPTION
This closes #6136.

`time.clock()` became unavailable in Slicer due to the recent upgrade of Python 3.6.7 to Python 3.9.10 in https://github.com/Slicer/Slicer/commit/34e48e8aef5dad19ec8a955d6f48a1940846e3f3.

From https://docs.python.org/3.7/library/time.html#time.clock:

> Deprecated since version 3.3, will be removed in version 3.8: The behaviour of this function depends on the platform: use perf_counter() or process_time() instead, depending on your requirements, to have a well defined behaviour.

Co-authored-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>