### PR TITLE
ENH: Add focus camera to control point right-click menu

### DIFF
--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.h
@@ -113,6 +113,8 @@ public:
 protected slots:
   /// Called when clicking on rename point action
   void renamePoint();
+  /// Called when clicking on refocus camera action
+  void refocusCamera();
   /// Called when clicking on delete point action
   void deletePoint();
   /// Called when clicking on delete node action


### PR DESCRIPTION
Added context menu option for control points in 2d/3d view to focus camera on clicked-on point. Functionally equivalent to same menu option in control point list.