### PR TITLE
BUG: Adds varying colors to ROIs added as a single node

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -30,6 +30,9 @@
 // MRML includes
 #include "vtkMRMLStorageNode.h"
 
+// VTK includes
+#include "vtkVector.h"
+
 // STD includes
 #include <cstdlib>
 #include <string>
@@ -99,6 +102,10 @@ public:
   /// add to the passed scene.
   /// On success, return the id, on failure return an empty string.
   std::string AddNewFiducialNode(const char *name = "F", vtkMRMLScene *scene = nullptr);
+
+  /// Create a new markups node and associated display node, adding both to the scene.
+  /// For ROI nodes, each new node will have a unique color.
+  vtkMRMLMarkupsNode* AddNewMarkupsNode(std::string className, std::string nodeName=std::string(), vtkMRMLScene* scene = nullptr);
 
   /// Add a new control point to the currently active markups fiducial node at the given RAS
   /// coordinates (default 0,0,0). Will create a markups fiducial node if one is not active.
@@ -353,6 +360,14 @@ public:
     vtkWarningMacro("vtkSlicerMarkupsLogic::RenameAllMarkupsFromCurrentFormat method is deprecated, please use RenameAllControlPointsFromCurrentFormat instead");
     this->RenameAllControlPointsFromCurrentFormat(markupsNode);
     };
+
+  //@{
+  /// Generate a unique color for a markup node.
+  /// In the current implementaiton, the color is not globally unique, but colors are generated
+  /// by iterating through the items in "MediumChart" color table.
+  vtkVector3d GenerateUniqueColor();
+  void GenerateUniqueColor(double color[3]);
+  //@}
 
 protected:
 

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.cxx
@@ -44,7 +44,6 @@
 #include <vtkSphereSource.h>
 #include <vtkTextProperty.h>
 #include <vtkWidgetRepresentation.h>
-#include <vtkMRMLColorTableNode.h>
 
 // STD includes
 #include <algorithm>
@@ -75,7 +74,6 @@ vtkMRMLMarkupsDisplayableManager::vtkMRMLMarkupsDisplayableManager()
   this->LastClickWorldCoordinates[2]=0.0;
   this->LastClickWorldCoordinates[3]=1.0;
 
-  this->currentColorTableIndex = 3;
 }
 
 //---------------------------------------------------------------------------
@@ -571,27 +569,6 @@ bool vtkMRMLMarkupsDisplayableManager::IsManageable(const char* nodeClassName)
 }
 
 //---------------------------------------------------------------------------
-vtkMRMLMarkupsNode* vtkMRMLMarkupsDisplayableManager::CreateNewMarkupsNode(
-  const std::string &markupsNodeClassName)
-{
-  vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(
-    this->GetMRMLScene()->AddNewNodeByClass(markupsNodeClassName));
-  std::string nodeName =
-    this->GetMRMLScene()->GenerateUniqueName(markupsNode->GetDefaultNodeNamePrefix());
-  markupsNode->SetName(nodeName.c_str());
-  markupsNode->AddDefaultStorageNode();
-  markupsNode->CreateDefaultDisplayNodes();
-
-  if (markupsNodeClassName == "vtkMRMLMarkupsROINode")
-    {
-    double currentColor[3];
-    this->GetNewMarkupsColor(currentColor);
-    markupsNode->GetDisplayNode()->SetSelectedColor(currentColor);
-    }
-  return markupsNode;
-}
-
-//---------------------------------------------------------------------------
 vtkSlicerMarkupsWidget* vtkMRMLMarkupsDisplayableManager::FindClosestWidget(vtkMRMLInteractionEventData *callData, double &closestDistance2)
 {
   vtkSlicerMarkupsWidget* closestWidget = nullptr;
@@ -873,8 +850,20 @@ vtkSlicerMarkupsWidget* vtkMRMLMarkupsDisplayableManager::GetWidgetForPlacement(
   // If there is no active markups node then create a new one
   if (!activeMarkupsNode)
     {
-    activeMarkupsNode = this->CreateNewMarkupsNode(placeNodeClassName);
-    selectionNode->SetReferenceActivePlaceNodeID(activeMarkupsNode->GetID());
+    vtkSlicerMarkupsLogic* markupsLogic =
+      vtkSlicerMarkupsLogic::SafeDownCast(this->GetMRMLApplicationLogic()->GetModuleLogic("Markups"));
+    if (markupsLogic)
+      {
+      activeMarkupsNode = markupsLogic->AddNewMarkupsNode(placeNodeClassName);
+      }
+    if (activeMarkupsNode)
+      {
+      selectionNode->SetReferenceActivePlaceNodeID(activeMarkupsNode->GetID());
+      }
+    else
+      {
+      vtkErrorMacro("GetWidgetForPlacement failed to create new markups node by class " << placeNodeClassName);
+      }
     }
 
   if (!activeMarkupsNode)
@@ -956,37 +945,3 @@ void vtkMRMLMarkupsDisplayableManager::ConvertDeviceToXYZ(double x, double y, do
 {
   vtkMRMLAbstractSliceViewDisplayableManager::ConvertDeviceToXYZ(this->GetInteractor(), this->GetMRMLSliceNode(), x, y, xyz);
 }
-
-//---------------------------------------------------------------------------
-void vtkMRMLMarkupsDisplayableManager::UpdateCurrentColorTableIndex()
-  {
-
-  if (this->currentColorTableIndex < 255)
-    {
-    this->currentColorTableIndex += 1;
-    }
-  else
-    {
-    this->currentColorTableIndex = 0;
-    }
-  }
-//-----------------------------------------------------------------------------
-bool vtkMRMLMarkupsDisplayableManager::GetNewMarkupsColor(double currentColor[3])
-  {
-  vtkMRMLColorTableNode* randomIntegers = vtkMRMLColorTableNode::SafeDownCast(
-    this->GetMRMLScene()->GetNodeByID("vtkMRMLColorTableNodeRandom"));
-  double currentColorArray[4];
-  bool success = randomIntegers->GetColor(this->currentColorTableIndex, currentColorArray);
-  if (success)
-    {
-    currentColor[0] = currentColorArray[0];
-    currentColor[1] = currentColorArray[1];
-    currentColor[2] = currentColorArray[2];
-    this->UpdateCurrentColorTableIndex();
-    return true;
-    }
-  else
-    {
-    return false;
-    }
-  }

--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManager.h
@@ -86,17 +86,10 @@ public:
   /// Get the widget of a node.
   vtkSlicerMarkupsWidget* GetWidget(vtkMRMLMarkupsDisplayNode * node);
 
-  // Utilities for changing markup color
-  void UpdateCurrentColorTableIndex();
-  bool GetNewMarkupsColor(double currentColor[3]);
-
 protected:
 
   vtkMRMLMarkupsDisplayableManager();
   ~vtkMRMLMarkupsDisplayableManager() override;
-
-  // stores index for generating new markup colors
-  int currentColorTableIndex;
 
   vtkSlicerMarkupsWidget* FindClosestWidget(vtkMRMLInteractionEventData *callData, double &closestDistance2);
 
@@ -155,8 +148,6 @@ protected:
   vtkSmartPointer<vtkMRMLMarkupsDisplayableManagerHelper> Helper;
 
   double LastClickWorldCoordinates[4];
-
-  vtkMRMLMarkupsNode* CreateNewMarkupsNode(const std::string &markupsNodeClassName);
 
   vtkWeakPointer<vtkSlicerMarkupsWidget> LastActiveWidget;
 

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar_p.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar_p.h
@@ -93,7 +93,6 @@ public slots:
   void onActivePlaceNodeClassNameChangedEvent();
   void onPlaceNodeClassNameListModifiedEvent();
   void onSetModule(const QString& moduleName);
-  void onAddNewMarkupsNodeByClass(const QString& className);
 
 public:
   vtkSmartPointer<vtkMRMLScene>            MRMLScene;

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -1950,20 +1950,14 @@ void qSlicerMarkupsModuleWidget::enableMarkupTableButtons(bool enable)
 void qSlicerMarkupsModuleWidget::onCreateMarkupByClass(const QString& className)
 {
   Q_D(qSlicerMarkupsModuleWidget);
-  if (this->mrmlScene())
+  if (!this->markupsLogic())
     {
-    vtkMRMLNode* node = this->mrmlScene()->AddNewNodeByClass(className.toStdString().c_str());
-    vtkMRMLMarkupsNode* markupsNode = vtkMRMLMarkupsNode::SafeDownCast(node);
-
-    if (!markupsNode)
-      {
-      qCritical() << Q_FUNC_INFO << ": node added is not a vtkMRMLMarkupsNode.";
-      return;
-      }
-
-    std::string nodeName =
-      this->mrmlScene()->GenerateUniqueName(markupsNode->GetDefaultNodeNamePrefix());
-    markupsNode->SetName(nodeName.c_str());
+    qWarning() << Q_FUNC_INFO << " failed: invalid markups logic";
+    return;
+    }
+  vtkMRMLMarkupsNode* markupsNode = this->markupsLogic()->AddNewMarkupsNode(className.toStdString());
+  if (markupsNode)
+    {
     this->onActiveMarkupMRMLNodeAdded(markupsNode);
     }
 }


### PR DESCRIPTION
This commit addresses issue: https://github.com/Slicer/Slicer/issues/5912

The color assigned to a ROI created using the single node placement buttons in the Markups module and Markups Toolbar are varied to be consistent with the varying color of nodes created using continuous placement mode.

The colormap used for the ROIs is changed from the vtkMRMLColorTableNodeRandom to MediumChartColors, which are more distinguishable.