### PR TITLE
DOC: Update snippet to turn on slice intersections

### DIFF
--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -544,9 +544,9 @@ layoutSwitchAction.setToolTip("3D and slice view")
 ### Turn on slice intersections
 
 ```python
-viewNodes = slicer.util.getNodesByClass("vtkMRMLSliceCompositeNode")
-for viewNode in viewNodes:
-  viewNode.SetSliceIntersectionVisibility(1)
+sliceDisplayNodes = slicer.util.getNodesByClass("vtkMRMLSliceDisplayNode")
+for sliceDisplayNode in sliceDisplayNodes:
+  sliceDisplayNode.SetIntersectingSlicesVisibility(1)
 ```
 
 :::{note}


### PR DESCRIPTION
Update snippet to turn on slice intersections. This update is needed since the visibility of the slice intersections is not handled anymore from the _vtkMRMLSliceCompositeNode_. Instead, a new node type is used for that: _vtkMRMLSliceDisplayNode_.

More info regarding these changes: [here](https://github.com/Slicer/Slicer/pull/6124).