### PR TITLE
BUG: Fix Segmentation test failing on Linux due with long scalar type

### DIFF
--- a/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
+++ b/Libs/vtkSegmentationCore/vtkOrientedImageDataResample.cxx
@@ -1877,36 +1877,24 @@ void vtkOrientedImageDataResample::CastImageForValue(vtkOrientedImageData* image
 
   if (typeIsSigned)
     {
-    if (value > VTK_FLOAT_MAX || value < VTK_FLOAT_MIN)
+    if (value > VTK_INT_MAX || value < VTK_INT_MIN)
       {
       scalarType = VTK_DOUBLE;
       }
-    else if (value > VTK_LONG_MAX || value < VTK_LONG_MIN)
-      {
-      scalarType = VTK_FLOAT;
-      }
-    else if (value > VTK_INT_MAX || value < VTK_INT_MIN)
-      {
-      scalarType = VTK_LONG;
-      }
     else if (value > VTK_SHORT_MAX || value < VTK_SHORT_MIN)
+      {
+      scalarType = VTK_INT;
+      }
+    else if (value > VTK_SIGNED_CHAR_MAX || value < VTK_SIGNED_CHAR_MIN)
       {
       scalarType = VTK_SHORT;
       }
     }
   else
     {
-    if (value > VTK_FLOAT_MAX)
+    if (value > VTK_UNSIGNED_INT_MAX)
       {
       scalarType = VTK_DOUBLE;
-      }
-    else if (value > static_cast<double>(VTK_UNSIGNED_LONG_MAX))
-      {
-      scalarType = VTK_FLOAT;
-      }
-    else if (value > VTK_UNSIGNED_INT_MAX)
-      {
-      scalarType = VTK_UNSIGNED_LONG;
       }
     else if (value > VTK_UNSIGNED_SHORT_MAX)
       {

--- a/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
+++ b/Modules/Loadable/Segmentations/Testing/Python/SegmentationsModuleTest2.py
@@ -280,9 +280,9 @@ class SegmentationsModuleTest2(unittest.TestCase):
       vtk.VTK_UNSIGNED_SHORT,
       vtk.VTK_INT,
       vtk.VTK_UNSIGNED_INT,
-      vtk.VTK_LONG,
-      vtk.VTK_UNSIGNED_LONG,
-      vtk.VTK_FLOAT,
+      #vtk.VTK_LONG, # On linux, VTK_LONG has the same size as VTK_LONG_LONG. This causes issues in vtkImageThreshold.
+      #vtk.VTK_UNSIGNED_LONG, See https://github.com/Slicer/Slicer/issues/5427
+      #vtk.VTK_FLOAT, # Since float can't represent all int, we jump straight to double.
       vtk.VTK_DOUBLE,
       #vtk.VTK_LONG_LONG, # These types are unsupported in ITK
       #vtk.VTK_UNSIGNED_LONG_LONG,


### PR DESCRIPTION
Due to limitations in casting VTK_LONG_MAX from double to long on Linux, it is not possible to erase from VTK_LONG segments in the Segment Editor. This issue comes up when trying to fill outside a segment with VTK_LONG_MAX using vtkImageThreshold (see https://github.com/Slicer/Slicer/blob/3edd84ddba681786be9e916124126fc858592598/Libs/vtkSegmentationCore/vtkSegmentationModifier.cxx#L370-L376).

Since VTK_LONG Segmentation are not likely to be used anyway, it makes sense to remove them rather than to find a workaround.

This commit removes VTK(_UNSIGNED)_LONG from SegmentationsModuleTest2, and removes the scalar type from vtkOrientedImageDataResample::CastImageForValue so that long type labelmaps won't be created.

Closes #5427