### PR TITLE
ENH: Add PBR rendering mode to models, segmentations, transforms display

### DIFF
--- a/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.cxx
@@ -56,6 +56,8 @@ vtkMRMLDisplayNode::vtkMRMLDisplayNode()
   this->Diffuse = 1.0;
   this->Specular = 0;
   this->Power = 1;
+  this->Metallic = 0.0;
+  this->Roughness = 0.5;
   this->SelectedAmbient = 0.4;
   this->SelectedSpecular = 0.5;
 
@@ -139,6 +141,8 @@ void vtkMRMLDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(selectedSpecular, SelectedSpecular);
   vtkMRMLWriteXMLFloatMacro(specular, Specular);
   vtkMRMLWriteXMLFloatMacro(power, Power);
+  vtkMRMLWriteXMLFloatMacro(metallic, Metallic);
+  vtkMRMLWriteXMLFloatMacro(roughness, Roughness);
   vtkMRMLWriteXMLFloatMacro(opacity, Opacity);
   vtkMRMLWriteXMLFloatMacro(sliceIntersectionOpacity, SliceIntersectionOpacity);
   vtkMRMLWriteXMLFloatMacro(pointSize, PointSize);
@@ -191,6 +195,8 @@ void vtkMRMLDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(selectedSpecular, SelectedSpecular);
   vtkMRMLReadXMLFloatMacro(specular, Specular);
   vtkMRMLReadXMLFloatMacro(power, Power);
+  vtkMRMLReadXMLFloatMacro(metallic, Metallic);
+  vtkMRMLReadXMLFloatMacro(roughness, Roughness);
   vtkMRMLReadXMLFloatMacro(opacity, Opacity);
   vtkMRMLReadXMLFloatMacro(sliceIntersectionOpacity, SliceIntersectionOpacity);
   vtkMRMLReadXMLFloatMacro(pointSize, PointSize);
@@ -274,10 +280,13 @@ void vtkMRMLDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
   this->SetSelectedSpecular(node->SelectedSpecular);
   this->SetOpacity(node->Opacity);
   this->SetSliceIntersectionOpacity(node->SliceIntersectionOpacity);
+  this->SetInterpolation(node->Interpolation);
   this->SetAmbient(node->Ambient);
   this->SetDiffuse(node->Diffuse);
   this->SetSpecular(node->Specular);
   this->SetPower(node->Power);
+  this->SetMetallic(node->Metallic);
+  this->SetRoughness(node->Roughness);
   this->SetVisibility(node->Visibility);
   this->SetVisibility2D(node->Visibility2D);
   this->SetVisibility3D(node->Visibility3D);
@@ -312,6 +321,8 @@ void vtkMRMLDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(SelectedSpecular);
   vtkMRMLPrintFloatMacro(Specular);
   vtkMRMLPrintFloatMacro(Power);
+  vtkMRMLPrintFloatMacro(Metallic);
+  vtkMRMLPrintFloatMacro(Roughness);
   vtkMRMLPrintFloatMacro(Opacity);
   vtkMRMLPrintFloatMacro(SliceIntersectionOpacity);
   vtkMRMLPrintFloatMacro(PointSize);

--- a/Libs/MRML/Core/vtkMRMLDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.h
@@ -49,12 +49,13 @@ public:
     SurfaceRepresentation
   } RepresentationType;
 
-  /// Interpolation models
+  /// Interpolation modes
   /// \sa GetInterpolation(), SetInterpolation()
   typedef enum {
     FlatInterpolation = 0,
     GouraudInterpolation,
-    PhongInterpolation
+    PhongInterpolation,
+    PBRInterpolation
   } InterpolationType;
 
   /// Scalar range options for displaying data associated with this display
@@ -230,6 +231,20 @@ public:
   /// Get the specular power coef of the display node.
   /// \sa Power, SetPower()
   vtkGetMacro(Power, double);
+
+  //@{
+  /// The metalness of the material; values range from 0.0 (non-metal) to 1.0 (metal).
+  /// Only used in PBR interpolation mode.
+  vtkSetMacro(Metallic, double);
+  vtkGetMacro(Metallic, double);
+  //@}
+
+  //@{
+  /// The roughness of the material; values range from 0.0 (smooth) to 1.0 (rough).
+  /// Only used in PBR interpolation mode.
+  vtkSetMacro(Roughness, double);
+  vtkGetMacro(Roughness, double);
+  //@}
 
   /// Set the visibility of the display node.
   /// \sa Visibility, GetVisibility(), VisibilityOn(), VisibilityOff()
@@ -692,6 +707,10 @@ protected:
   /// 0.4 by default.
   /// \sa SetSelectedAmbient(), GetSelectedAmbient(),
   /// SelectedColor, Ambient, SelectedSpecular
+
+  double Metallic;
+  double Roughness;
+
   double SelectedAmbient;
   /// Node's selected specular.
   /// 0.5 by default.

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -1540,6 +1540,8 @@ void vtkMRMLModelDisplayableManager::SetModelDisplayProperty(vtkMRMLDisplayableN
       actorProperties->SetOpacity(hierarchyOpacity * modelDisplayNode->GetOpacity());
       actorProperties->SetDiffuse(displayNode->GetDiffuse());
       actorProperties->SetSpecularPower(displayNode->GetPower());
+      actorProperties->SetMetallic(displayNode->GetMetallic());
+      actorProperties->SetRoughness(displayNode->GetRoughness());
       actorProperties->SetEdgeVisibility(displayNode->GetEdgeVisibility());
       actorProperties->SetEdgeColor(displayNode->GetEdgeColor());
       if (displayNode->GetTextureImageDataConnection() != nullptr)

--- a/Libs/MRML/Widgets/qMRMLDisplayNodeWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLDisplayNodeWidget.cxx
@@ -353,6 +353,8 @@ void qMRMLDisplayNodeWidget::updateWidgetFromMRML()
   d->Property->SetDiffuse(d->MRMLDisplayNode->GetDiffuse());
   d->Property->SetSpecular(d->MRMLDisplayNode->GetSpecular());
   d->Property->SetSpecularPower(d->MRMLDisplayNode->GetPower());
+  d->Property->SetMetallic(d->MRMLDisplayNode->GetMetallic());
+  d->Property->SetRoughness(d->MRMLDisplayNode->GetRoughness());
   qvtkUnblock(d->Property, vtkCommand::ModifiedEvent, this);
 }
 

--- a/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
+++ b/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
@@ -248,6 +248,11 @@
              <string>Phong</string>
             </property>
            </item>
+           <item>
+            <property name="text">
+             <string>PBR</string>
+            </property>
+           </item>
           </widget>
          </item>
          <item row="6" column="0" colspan="2">

--- a/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Models/Widgets/qMRMLModelDisplayNodeWidget.cxx
@@ -64,6 +64,8 @@ public:
   qMRMLModelDisplayNodeWidgetPrivate(qMRMLModelDisplayNodeWidget& object);
   void init();
 
+  bool IsUpdatingWidgetFromMRML{ false };
+
   QList<vtkMRMLModelDisplayNode*> modelDisplayNodesFromSelection()const;
   QList<vtkMRMLDisplayNode*> displayNodesFromSelection()const;
 
@@ -396,6 +398,12 @@ void qMRMLModelDisplayNodeWidget::updateWidgetFromMRML()
     return;
     }
 
+  if (d->IsUpdatingWidgetFromMRML)
+    {
+    return;
+    }
+  d->IsUpdatingWidgetFromMRML = true;
+
   d->VisibilityCheckBox->setChecked(d->CurrentDisplayNode->GetVisibility());
   d->DisplayNodeViewComboBox->setMRMLDisplayNode(d->CurrentDisplayNode);
   d->ClippingCheckBox->setChecked(d->CurrentDisplayNode->GetClipping());
@@ -511,9 +519,13 @@ void qMRMLModelDisplayNodeWidget::updateWidgetFromMRML()
   d->Property->SetDiffuse(d->CurrentDisplayNode->GetDiffuse());
   d->Property->SetSpecular(d->CurrentDisplayNode->GetSpecular());
   d->Property->SetSpecularPower(d->CurrentDisplayNode->GetPower());
+  d->Property->SetMetallic(d->CurrentDisplayNode->GetMetallic());
+  d->Property->SetRoughness(d->CurrentDisplayNode->GetRoughness());
 
   // Scalars
   d->ScalarsDisplayWidget->updateWidgetFromMRML();
+
+  d->IsUpdatingWidgetFromMRML = false;
 
   emit displayNodeChanged();
 }
@@ -619,6 +631,11 @@ void qMRMLModelDisplayNodeWidget::updateDisplayNodesFromProperty()
 {
   Q_D(qMRMLModelDisplayNodeWidget);
 
+  if (d->IsUpdatingWidgetFromMRML)
+    {
+    return;
+    }
+
   QList<vtkMRMLDisplayNode*> displayNodesInSelection = d->displayNodesFromSelection();
   foreach (vtkMRMLDisplayNode* displayNode, displayNodesInSelection)
     {
@@ -632,6 +649,8 @@ void qMRMLModelDisplayNodeWidget::updateDisplayNodesFromProperty()
     displayNode->SetDiffuse(d->Property->GetDiffuse());
     displayNode->SetSpecular(d->Property->GetSpecular());
     displayNode->SetPower(d->Property->GetSpecularPower());
+    displayNode->SetMetallic(d->Property->GetMetallic());
+    displayNode->SetRoughness(d->Property->GetRoughness());
     displayNode->EndModify(wasModifying);
     }
 }
@@ -864,10 +883,18 @@ void qMRMLModelDisplayNodeWidget::setInterpolation(int newInterpolation)
 {
   Q_D(qMRMLModelDisplayNodeWidget);
   if (!d->CurrentDisplayNode.GetPointer())
-  {
+    {
     return;
-  }
-  d->Property->SetInterpolation(newInterpolation);
+    }
+  switch (newInterpolation)
+    {
+    case vtkMRMLDisplayNode::FlatInterpolation: d->Property->SetInterpolationToFlat(); break;
+    case vtkMRMLDisplayNode::GouraudInterpolation: d->Property->SetInterpolationToGouraud(); break;
+    case vtkMRMLDisplayNode::PhongInterpolation: d->Property->SetInterpolationToPhong(); break;
+    case vtkMRMLDisplayNode::PBRInterpolation: d->Property->SetInterpolationToPBR(); break;
+    default:
+      qWarning() << Q_FUNC_INFO << " failed: invalid interpolation mode " << newInterpolation;
+    }
 }
 
 // --------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Segmentations/MRMLDM/vtkMRMLSegmentationsDisplayableManager3D.cxx
@@ -581,6 +581,8 @@ void vtkMRMLSegmentationsDisplayableManager3D::vtkInternal::UpdateDisplayNodePip
       }
     pipeline->Actor->GetProperty()->SetDiffuse(genericDisplayNode->GetDiffuse());
     pipeline->Actor->GetProperty()->SetSpecularPower(genericDisplayNode->GetPower());
+    pipeline->Actor->GetProperty()->SetMetallic(displayNode->GetMetallic());
+    pipeline->Actor->GetProperty()->SetRoughness(displayNode->GetRoughness());
     pipeline->Actor->GetProperty()->SetEdgeVisibility(genericDisplayNode->GetEdgeVisibility());
     pipeline->Actor->GetProperty()->SetEdgeColor(genericDisplayNode->GetEdgeColor());
 

--- a/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager3D.cxx
+++ b/Modules/Loadable/Transforms/MRMLDM/vtkMRMLTransformsDisplayableManager3D.cxx
@@ -445,6 +445,8 @@ void vtkMRMLTransformsDisplayableManager3D::vtkInternal::SetTransformDisplayProp
   actor->GetProperty()->SetOpacity(displayNode->GetOpacity());
   actor->GetProperty()->SetDiffuse(displayNode->GetDiffuse());
   actor->GetProperty()->SetSpecularPower(displayNode->GetPower());
+  actor->GetProperty()->SetMetallic(displayNode->GetMetallic());
+  actor->GetProperty()->SetRoughness(displayNode->GetRoughness());
   actor->GetProperty()->SetEdgeVisibility(displayNode->GetEdgeVisibility());
   actor->GetProperty()->SetEdgeColor(displayNode->GetEdgeColor());
 

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -75,7 +75,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "4bdd45e3f1038907aab31b40e536b2f51120f80d"
+    "7b48c481ab831215f7b3a98852e5540ff97c5531"
     QUIET
     )
 


### PR DESCRIPTION
In Models module, Display / 3D Display / Advanced section, Interpolation can be set to PBR (physically based rendering).
When PBR interpolation mode is selected then the user can edit diffuse, metallic, and roughness material parameters.

PBR is useful for building models that will be exported in glTF or other software that only supports PBR interpolation.
It also allows leveraging many more rendering features in VTK, including image-based lighting, various textures (base, normal, occlusion, emission, etc.), coats, etc. described in:
https://www.kitware.com/vtk-pbr/
https://www.kitware.com/pbrj1/
https://www.kitware.com/pbr-journey-part-3-clear-coat-model-with-vtk/

Updated CTK to latest master version to get the updated material editor that supports PBR parameter settings.