### PR TITLE
ENH: Jump slices when markups interaction handle is clicked

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -892,6 +892,12 @@ void vtkSlicerMarkupsWidgetRepresentation::GetInteractionHandleOriginWorld(doubl
 }
 
 //----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::GetInteractionHandlePositionWorld(int type, int index, double position[3])
+{
+  this->InteractionPipeline->GetInteractionHandlePositionWorld(type, index, position);
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation::UpdateInteractionHandleSize()
 {
   if (this->InteractionPipeline)
@@ -1628,7 +1634,6 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::GetIntera
   else if (type == vtkMRMLMarkupsDisplayNode::ComponentScaleHandle)
     {
     this->ScaleHandlePoints->GetPoint(index, positionWorld);
-    this->ScaleScaleTransform->GetTransform()->TransformPoint(positionWorld, positionWorld);
     this->HandleToWorldTransform->TransformPoint(positionWorld, positionWorld);
     }
 }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -151,6 +151,8 @@ public:
   virtual void GetInteractionHandleAxisWorld(int type, int index, double axis[3]);
   /// Get the origin of the interaction handle widget
   virtual void GetInteractionHandleOriginWorld(double origin[3]);
+  /// Get the position of an interaction handle in world coordinates
+  virtual void GetInteractionHandlePositionWorld(int type, int index, double position[3]);
 
 protected:
   vtkSlicerMarkupsWidgetRepresentation();


### PR DESCRIPTION
This commit adds event translations that will jump to the position of an interaction handle when it is left-clicked. This is the same behavior as with control points.

Re #5061