### PR TITLE
ENH: Add startupWorkingPath property to qSlicerCoreApplication

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -163,6 +163,7 @@ qSlicerCoreApplicationPrivate::qSlicerCoreApplicationPrivate(
   this->DICOMDatabase = QSharedPointer<ctkDICOMDatabase>(new ctkDICOMDatabase);
 #endif
   this->NextResourceHandle = 0;
+  this->StartupWorkingPath = QDir::currentPath();
 }
 
 //-----------------------------------------------------------------------------
@@ -1182,6 +1183,7 @@ QSettings* qSlicerCoreApplication::revisionUserSettings()const
 
 //-----------------------------------------------------------------------------
 CTK_GET_CPP(qSlicerCoreApplication, QString, intDir, IntDir);
+CTK_GET_CPP(qSlicerCoreApplication, QString, startupWorkingPath, StartupWorkingPath);
 
 //-----------------------------------------------------------------------------
 bool qSlicerCoreApplication::isInstalled()const

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -74,6 +74,7 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerCoreApplication : public QApplication
   Q_PROPERTY(QString slicerSharePath READ slicerSharePath CONSTANT)
   Q_PROPERTY(QString temporaryPath READ temporaryPath WRITE setTemporaryPath)
   Q_PROPERTY(QString cachePath READ cachePath WRITE setCachePath)
+  Q_PROPERTY(QString startupWorkingPath READ startupWorkingPath CONSTANT)
   Q_PROPERTY(QString launcherExecutableFilePath READ launcherExecutableFilePath CONSTANT)
   Q_PROPERTY(QString launcherSettingsFilePath READ launcherSettingsFilePath CONSTANT)
   Q_PROPERTY(QString slicerDefaultSettingsFilePath READ slicerDefaultSettingsFilePath CONSTANT)
@@ -146,6 +147,9 @@ public:
   /// \sa repositoryRevision()
   /// \sa environment()
   Q_INVOKABLE QProcessEnvironment startupEnvironment() const;
+
+  /// Current working directory at the time the application was started.
+  QString startupWorkingPath() const;
 
   /// \brief Returns the current environment.
   ///

--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -152,6 +152,9 @@ public:
   /// Release, RelWithDebInfo, MinSizeRel or any other custom build type.
   QString                                     IntDir;
 
+  /// Current working directory at the time the application was started.
+  QString StartupWorkingPath;
+
   QSettings*                                  DefaultSettings;
   QSettings*                                  UserSettings;
   QSettings*                                  RevisionUserSettings;

--- a/Docs/developer_guide/advanced_topics.md
+++ b/Docs/developer_guide/advanced_topics.md
@@ -99,3 +99,21 @@ n = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLLinearTransformNode')
 ```
 
 Note: MRML scene's `CreateNodeByClass` creates a node with the default settings set in the scene for that node type (using [vtkMRMLScene::AddDefaultNode](https://www.slicer.org/doc/html/classvtkMRMLScene.html#ae302c5ed4aabb2910bc35dcc9aa2513f)).
+
+## Working directory
+
+Similarly to other software, the current directory associated with Slicer corresponds to the folder the application executable is started from.
+
+Since the current working directory can be changed anytime by any module or Python package (e.g., to more conveniently write files in a specific directory) and it is not possible to enforce that the directory is restored to the original.
+
+Slicer provides a way to reliably access the working directory at startup time, through the `startupWorkingPath` application property:
+
+In Python:
+```python
+slicer.app.startupWorkingPath
+```
+
+In C++:
+```cpp
+qSlicerCoreApplication::startupWorkingPath()
+```

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -693,6 +693,12 @@ int vtkMRMLMarkupsNode::AddNControlPoints(int n, std::string label /*=std::strin
 }
 
 //-----------------------------------------------------------
+int vtkMRMLMarkupsNode::AddControlPointWorld(double x, double y, double z, std::string label /*=std::string()*/)
+{
+  return this->AddControlPointWorld(vtkVector3d(x, y, z), label);
+}
+
+//-----------------------------------------------------------
 int vtkMRMLMarkupsNode::AddControlPointWorld(double pointWorld[3], std::string label /*=std::string()*/)
 {
   return this->AddControlPointWorld(vtkVector3d(pointWorld), label);
@@ -704,6 +710,12 @@ int vtkMRMLMarkupsNode::AddControlPointWorld(vtkVector3d pointWorld, std::string
   vtkVector3d point;
   this->TransformPointFromWorld(pointWorld, point);
   return this->AddNControlPoints(1, label, &point);
+}
+
+//-----------------------------------------------------------
+int vtkMRMLMarkupsNode::AddControlPoint(double x, double y, double z, std::string label /*=std::string()*/)
+{
+  return this->AddControlPoint(vtkVector3d(x, y, z), label);
 }
 
 //-----------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -321,6 +321,7 @@ public:
   /// Add a new control point, returning the point index, -1 on failure.
   int AddControlPoint(vtkVector3d point, std::string label = std::string());
   int AddControlPoint(double point[3], std::string label = std::string());
+  int AddControlPoint(double x, double y, double z, std::string label = std::string());
   ///@}
 
   /// Add a controlPoint to the end of the list. Return index
@@ -335,6 +336,7 @@ public:
   /// Return index of point index, -1 on failure.
   int AddControlPointWorld(vtkVector3d point, std::string label = std::string());
   int AddControlPointWorld(double point[3], std::string label = std::string());
+  int AddControlPointWorld(double x, double y, double z, std::string label = std::string());
   ///@}
 
   ///@{


### PR DESCRIPTION
The current working directory can be changed by any module at any time (for example, because some algorithms or executables use the current working directory for their inputs or outputs).
Therefore, modules that wanted to use the current working directory to interpret command-line arguments, or the Slicer Jupyter kernel that relies on knowing the working directory could not reliably get it.

A new property `startupWorkingPath` was added to qSlicerCoreApplication. This property is initialized from the current working directory at startup and cannot be changed later, therefore it is a reliable way of getting the original working directory.

The name is derived from "current working directory", with "current" replaced by "startup" (similarly to `startupEnvironment` property) and "directory" replaced by "path" (as all other directory path strings are referred to as `...path` in qSlicerCoreApplication and in Qt in general).