### PR TITLE
ENH: Skip message boxes when testing

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2306,7 +2306,8 @@ def delayDisplay(message, autoCloseMsec=1000):
 def infoDisplay(text, windowTitle=None, parent=None, standardButtons=None, **kwargs):
   """Display popup with a info message.
 
-  If there is no main window then the text is only logged (at info level).
+  If there is no main window, or if the application is running in testing mode (slicer.app.testingEnabled()==True),
+  then the text is only logged (at info level).
   """
   import qt, slicer
   import logging
@@ -2314,6 +2315,9 @@ def infoDisplay(text, windowTitle=None, parent=None, standardButtons=None, **kwa
     windowTitle = slicer.app.applicationName + " information"
   logging.info(text)
   mw = mainWindow()
+  if slicer.app.testingEnabled():
+    logging.info("Testing mode is enabled: Skipping info popup [%s]" % windowTitle)
+    return
   if mw:
     standardButtons = standardButtons if standardButtons else qt.QMessageBox.Ok
     messageBox(text, parent, windowTitle=windowTitle, icon=qt.QMessageBox.Information, standardButtons=standardButtons, **kwargs)
@@ -2321,7 +2325,8 @@ def infoDisplay(text, windowTitle=None, parent=None, standardButtons=None, **kwa
 def warningDisplay(text, windowTitle=None, parent=None, standardButtons=None, **kwargs):
   """Display popup with a warning message.
 
-  If there is no main window then the text is only logged (at warning level).
+  If there is no main window, or if the application is running in testing mode (slicer.app.testingEnabled()==True),
+  then the text is only logged (at warning level).
   """
   import qt, slicer
   import logging
@@ -2329,6 +2334,9 @@ def warningDisplay(text, windowTitle=None, parent=None, standardButtons=None, **
     windowTitle = slicer.app.applicationName + " warning"
   logging.warning(text)
   mw = mainWindow()
+  if slicer.app.testingEnabled():
+    logging.info("Testing mode is enabled: Skipping warning popup [%s]" % windowTitle)
+    return
   if mw:
     standardButtons = standardButtons if standardButtons else qt.QMessageBox.Ok
     messageBox(text, parent, windowTitle=windowTitle, icon=qt.QMessageBox.Warning, standardButtons=standardButtons, **kwargs)
@@ -2336,41 +2344,74 @@ def warningDisplay(text, windowTitle=None, parent=None, standardButtons=None, **
 def errorDisplay(text, windowTitle=None, parent=None, standardButtons=None, **kwargs):
   """Display an error popup.
 
-  If there is no main window then the text is only logged (at error level).
+  If there is no main window, or if the application is running in testing mode (slicer.app.testingEnabled()==True),
+  then the text is only logged (at error level).
   """
   import qt, slicer
   import logging
   if not windowTitle:
     windowTitle = slicer.app.applicationName + " error"
   logging.error(text)
+  if slicer.app.testingEnabled():
+    logging.info("Testing mode is enabled: Skipping error popup [%s]" % windowTitle)
+    return
   mw = mainWindow()
   if mw:
     standardButtons = standardButtons if standardButtons else qt.QMessageBox.Ok
     messageBox(text, parent, windowTitle=windowTitle, icon=qt.QMessageBox.Critical, standardButtons=standardButtons, **kwargs)
 
 def confirmOkCancelDisplay(text, windowTitle=None, parent=None, **kwargs):
-  """Display an confirmation popup. Return if confirmed with OK."""
+  """Display a confirmation popup. Return if confirmed with OK.
+
+  When the application is running in testing mode (slicer.app.testingEnabled()==True),
+  the popup is skipped and True ("Ok") is returned, with a message being logged to indicate this.
+  """
   import qt, slicer
+  import logging
   if not windowTitle:
     windowTitle = slicer.app.applicationName + " confirmation"
+  if slicer.app.testingEnabled():
+    result = True
+    logging.info("Testing mode is enabled: Skipping confirmation popup [%s] and returning %s." % (windowTitle, result))
+    return result
   result = messageBox(text, parent=parent, windowTitle=windowTitle, icon=qt.QMessageBox.Question,
                        standardButtons=qt.QMessageBox.Ok | qt.QMessageBox.Cancel, **kwargs)
   return result == qt.QMessageBox.Ok
 
 def confirmYesNoDisplay(text, windowTitle=None, parent=None, **kwargs):
-  """Display an confirmation popup. Return if confirmed with Yes."""
+  """Display a confirmation popup. Return if confirmed with Yes.
+
+  When the application is running in testing mode (slicer.app.testingEnabled()==True),
+  the popup is skipped and True ("Yes") is returned, with a message being logged to indicate this.
+  """
   import qt, slicer
+  import logging
   if not windowTitle:
     windowTitle = slicer.app.applicationName + " confirmation"
+  if slicer.app.testingEnabled():
+    result = True
+    logging.info("Testing mode is enabled: Skipping question popup [%s] and returning %s." % (windowTitle, result))
+    return result
   result = messageBox(text, parent=parent, windowTitle=windowTitle, icon=qt.QMessageBox.Question,
                        standardButtons=qt.QMessageBox.Yes | qt.QMessageBox.No, **kwargs)
   return result == qt.QMessageBox.Yes
 
 def confirmRetryCloseDisplay(text, windowTitle=None, parent=None, **kwargs):
-  """Display an confirmation popup. Return if confirmed with Retry."""
+  """Display an error popup asking whether to retry, logging the text at error level.
+  Return if confirmed with Retry.
+
+  When the application is running in testing mode (slicer.app.testingEnabled()==True),
+  the popup is skipped and False ("Close") is returned, with a message being logged to indicate this.
+  """
   import qt, slicer
+  import logging
+  logging.error(text)
   if not windowTitle:
     windowTitle = slicer.app.applicationName + " error"
+  if slicer.app.testingEnabled():
+    result = False
+    logging.info("Testing mode is enabled: Skipping retry popup [%s] and returning %s." % (windowTitle, result))
+    return result
   result = messageBox(text, parent=parent, windowTitle=windowTitle, icon=qt.QMessageBox.Critical,
                        standardButtons=qt.QMessageBox.Retry | qt.QMessageBox.Close, **kwargs)
   return result == qt.QMessageBox.Retry

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2306,115 +2306,105 @@ def delayDisplay(message, autoCloseMsec=1000):
 def infoDisplay(text, windowTitle=None, parent=None, standardButtons=None, **kwargs):
   """Display popup with a info message.
 
-  If there is no main window, or if the application is running in testing mode (slicer.app.testingEnabled()==True),
+  If there is no main window, or if the application is running in testing mode (``slicer.app.testingEnabled() == True``),
   then the text is only logged (at info level).
   """
-  import qt, slicer
-  import logging
-  if not windowTitle:
-    windowTitle = slicer.app.applicationName + " information"
-  logging.info(text)
-  mw = mainWindow()
-  if slicer.app.testingEnabled():
-    logging.info("Testing mode is enabled: Skipping info popup [%s]" % windowTitle)
-    return
-  if mw:
-    standardButtons = standardButtons if standardButtons else qt.QMessageBox.Ok
-    messageBox(text, parent, windowTitle=windowTitle, icon=qt.QMessageBox.Information, standardButtons=standardButtons, **kwargs)
+  import qt, logging
+  standardButtons = standardButtons if standardButtons else qt.QMessageBox.Ok
+  _messageDisplay(logging.INFO, text, None, parent=parent, windowTitle=windowTitle, mainWindowNeeded=True,
+                   icon=qt.QMessageBox.Information, standardButtons=standardButtons, **kwargs)
 
 def warningDisplay(text, windowTitle=None, parent=None, standardButtons=None, **kwargs):
   """Display popup with a warning message.
 
-  If there is no main window, or if the application is running in testing mode (slicer.app.testingEnabled()==True),
+  If there is no main window, or if the application is running in testing mode (``slicer.app.testingEnabled() == True``),
   then the text is only logged (at warning level).
   """
-  import qt, slicer
-  import logging
-  if not windowTitle:
-    windowTitle = slicer.app.applicationName + " warning"
-  logging.warning(text)
-  mw = mainWindow()
-  if slicer.app.testingEnabled():
-    logging.info("Testing mode is enabled: Skipping warning popup [%s]" % windowTitle)
-    return
-  if mw:
-    standardButtons = standardButtons if standardButtons else qt.QMessageBox.Ok
-    messageBox(text, parent, windowTitle=windowTitle, icon=qt.QMessageBox.Warning, standardButtons=standardButtons, **kwargs)
+  import qt, logging
+  standardButtons = standardButtons if standardButtons else qt.QMessageBox.Ok
+  _messageDisplay(logging.WARNING, text, None, parent=parent, windowTitle=windowTitle, mainWindowNeeded=True,
+                   icon=qt.QMessageBox.Warning, standardButtons=standardButtons, **kwargs)
 
 def errorDisplay(text, windowTitle=None, parent=None, standardButtons=None, **kwargs):
   """Display an error popup.
 
-  If there is no main window, or if the application is running in testing mode (slicer.app.testingEnabled()==True),
+  If there is no main window, or if the application is running in testing mode (``slicer.app.testingEnabled() == True``),
   then the text is only logged (at error level).
   """
-  import qt, slicer
-  import logging
-  if not windowTitle:
-    windowTitle = slicer.app.applicationName + " error"
-  logging.error(text)
-  if slicer.app.testingEnabled():
-    logging.info("Testing mode is enabled: Skipping error popup [%s]" % windowTitle)
-    return
-  mw = mainWindow()
-  if mw:
-    standardButtons = standardButtons if standardButtons else qt.QMessageBox.Ok
-    messageBox(text, parent, windowTitle=windowTitle, icon=qt.QMessageBox.Critical, standardButtons=standardButtons, **kwargs)
+  import qt, logging
+  standardButtons = standardButtons if standardButtons else qt.QMessageBox.Ok
+  _messageDisplay(logging.ERROR, text, None, parent=parent, windowTitle=windowTitle, mainWindowNeeded=True,
+                     icon=qt.QMessageBox.Critical, standardButtons=standardButtons, **kwargs)
 
 def confirmOkCancelDisplay(text, windowTitle=None, parent=None, **kwargs):
   """Display a confirmation popup. Return if confirmed with OK.
 
-  When the application is running in testing mode (slicer.app.testingEnabled()==True),
+  When the application is running in testing mode (``slicer.app.testingEnabled() == True``),
   the popup is skipped and True ("Ok") is returned, with a message being logged to indicate this.
   """
-  import qt, slicer
-  import logging
+  import qt, slicer, logging
   if not windowTitle:
     windowTitle = slicer.app.applicationName + " confirmation"
-  if slicer.app.testingEnabled():
-    result = True
-    logging.info("Testing mode is enabled: Skipping confirmation popup [%s] and returning %s." % (windowTitle, result))
-    return result
-  result = messageBox(text, parent=parent, windowTitle=windowTitle, icon=qt.QMessageBox.Question,
-                       standardButtons=qt.QMessageBox.Ok | qt.QMessageBox.Cancel, **kwargs)
+  result = _messageDisplay(logging.INFO, text, True, parent=parent, windowTitle=windowTitle, icon=qt.QMessageBox.Question,
+                            standardButtons=qt.QMessageBox.Ok | qt.QMessageBox.Cancel, **kwargs)
   return result == qt.QMessageBox.Ok
 
 def confirmYesNoDisplay(text, windowTitle=None, parent=None, **kwargs):
   """Display a confirmation popup. Return if confirmed with Yes.
 
-  When the application is running in testing mode (slicer.app.testingEnabled()==True),
+  When the application is running in testing mode (``slicer.app.testingEnabled() == True``),
   the popup is skipped and True ("Yes") is returned, with a message being logged to indicate this.
   """
-  import qt, slicer
-  import logging
+  import qt, slicer, logging
   if not windowTitle:
     windowTitle = slicer.app.applicationName + " confirmation"
-  if slicer.app.testingEnabled():
-    result = True
-    logging.info("Testing mode is enabled: Skipping question popup [%s] and returning %s." % (windowTitle, result))
-    return result
-  result = messageBox(text, parent=parent, windowTitle=windowTitle, icon=qt.QMessageBox.Question,
-                       standardButtons=qt.QMessageBox.Yes | qt.QMessageBox.No, **kwargs)
+  result = _messageDisplay(logging.INFO, text, True, parent=parent, windowTitle=windowTitle, icon=qt.QMessageBox.Question,
+                            standardButtons=qt.QMessageBox.Yes | qt.QMessageBox.No, **kwargs)
   return result == qt.QMessageBox.Yes
 
 def confirmRetryCloseDisplay(text, windowTitle=None, parent=None, **kwargs):
   """Display an error popup asking whether to retry, logging the text at error level.
   Return if confirmed with Retry.
 
-  When the application is running in testing mode (slicer.app.testingEnabled()==True),
+  When the application is running in testing mode (``slicer.app.testingEnabled() == True``),
   the popup is skipped and False ("Close") is returned, with a message being logged to indicate this.
   """
-  import qt, slicer
-  import logging
-  logging.error(text)
-  if not windowTitle:
-    windowTitle = slicer.app.applicationName + " error"
-  if slicer.app.testingEnabled():
-    result = False
-    logging.info("Testing mode is enabled: Skipping retry popup [%s] and returning %s." % (windowTitle, result))
-    return result
-  result = messageBox(text, parent=parent, windowTitle=windowTitle, icon=qt.QMessageBox.Critical,
-                       standardButtons=qt.QMessageBox.Retry | qt.QMessageBox.Close, **kwargs)
+  import qt, logging
+  result = _messageDisplay(logging.ERROR, text, False, parent=parent, windowTitle=windowTitle,
+                            icon=qt.QMessageBox.Critical, standardButtons=qt.QMessageBox.Retry | qt.QMessageBox.Close, **kwargs)
   return result == qt.QMessageBox.Retry
+
+def _messageDisplay(logLevel, text, testingReturnValue, mainWindowNeeded=False, parent=None, windowTitle=None, **kwargs):
+  """Displays a messagebox and logs message text; knows what to do in testing mode.
+
+  :param logLevel: The level at which to log text, e.g. ``logging.INFO``, ``logging.ERROR``
+  :param text: Message text
+  :type text: str
+  :param testingReturnValue: When the application is in testing mode, this value is returned instead of raising the message box.
+  :param mainWindowNeeded: If True then the message box will not be raised if there is no mainWindow, but the text is still logged.
+  :type mainWindowNeeded: bool, optional
+  :param parent: The message box parent; by default it is set to main window by slicer.util.messageBox
+  :type parent: QWidget, optional
+  :param windowTitle: Window title; defaults to a generic title based on log level.
+  :type windowTitle: str, optional
+  :param kwargs: passed to :func:`messageBox`
+
+  Returns:
+    The output of :func:`messageBox`, with two exceptions:
+    - If the application is running in testing mode, then ``testingReturnValue`` is returned.
+    - Otherwise, if ``mainWindowNeeded`` is True and there is no main window, then None is returned.
+  """
+  import qt, slicer, logging
+  logging.log(logLevel, text)
+  logLevelString = logging.getLevelName(logLevel).lower() # e.g. this is "error" when logLevel is logging.ERROR
+  if not windowTitle:
+    windowTitle = slicer.app.applicationName + " " + logLevelString
+  if slicer.app.testingEnabled():
+    logging.info("Testing mode is enabled: Returning %s and skipping message box [%s]." % (testingReturnValue, windowTitle))
+    return testingReturnValue
+  if mainWindowNeeded and mainWindow() is None:
+    return
+  return messageBox(text, parent=parent, windowTitle=windowTitle, **kwargs)
 
 def messageBox(text, parent=None, **kwargs):
   """Displays a messagebox.
@@ -2550,6 +2540,7 @@ class WaitCursor:
 class MessageDialog:
   def __init__(self, message, show=True, logLevel=None):
     """Log the message and show a message box while the code in the context manager is being run.
+    When the application is running in testing mode (``slicer.app.testingEnabled() == True``), the message box is skipped.
 
     :param message: Text shown in the message box.
     :param show: If show is False, no dialog is shown.


### PR DESCRIPTION
# Summary

The message box utility functions such as `slicer.util.confirmOkCancelDisplay` are used in some extensions in such a way that tests can end up timing out and failing; this is due to the expectation of user interaction.

[SlicerAuto3dgm example that started this discussion](https://github.com/ToothAndClaw/SlicerAuto3dgm/issues/6)
[SlicerMorph example](https://slicer.cdash.org/test/21233619)

This commit addresses the issue by having message box functions such as `slicer.util.confirmOkCancelDisplay` behave differently in a testing situation: they can skip the dialog and return a default result.

# Tests

I tested my changes by running the tests for SlicerAuto3dgm and SlicerMorph and seeing that they indeed skip the message boxes, while still raising those message boxes outside of a testing situation. The failing SlicerMorph test still failed for me for other reasons, but at least it wasn't a timeout.

# Details

The following functions produce informational message boxes with no choice for the user, so they could simply be skipped under testing:

- `infoDisplay` 
- `warningDisplay` 
- `errorDisplay` 

The following functions provide a choice and have a return value, so in order to skip the user interaction I had to make a choice about the default value to be returned:

- `confirmOkCancelDisplay`: We default to Ok (return `True`), ~~but this can be changed by the caller with an optional argument~~
- `confirmRetryCloseDisplay`: We default to Cancel (return `False`).
  - Side note: I added error logging to this one, since the message text is typically some kind of error text.
- `confirmYesNoDisplay`: ~~Caller must specify the test-time return value in a required argument.~~ We default to `Yes`.

# Problem

~~The last one, `confirmYesNoDisplay`, I'm less sure about how to deal with. There's no good reason the user should expect a test to default to `Yes` or `No`, so it makes sense to me that they would have to specify the test-time value. However the required argument makes this an API change, and it makes `confirmYesNoDisplay` more annoying to use. That's why this is a draft at the moment.~~

Resolved; just going with `Yes` as a default.
 