### PR TITLE
COMP: Add Concurrent and Test as Qt requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,7 @@ endif()
     UiTools #no dll
     Xml XmlPatterns
     Svg Sql
+    Concurrent Test #Required by CTK
     )
 
   if(Slicer_BUILD_MULTIMEDIA_SUPPORT)


### PR DESCRIPTION
Qt modules Concurrent and Test are explicit requirements for CTK. This
commit adds these as requirements for Slicer too.