### PR TITLE
ENH: Add options to toggle individual markups interaction handle axes

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.cxx
@@ -127,6 +127,16 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->ScaleHandleVisibility = true;
   this->InteractionHandleScale = 3.0; // size of the handles as percent in screen size
 
+  // By default, all interaction handle axes are visible
+  for (int i = 0; i < 4; ++i)
+    {
+    this->RotationHandleComponentVisibility[i] = true;
+    this->ScaleHandleComponentVisibility[i] = true;
+    this->TranslationHandleComponentVisibility[i] = true;
+    }
+
+  this->CanDisplayScaleHandles = false;
+
   // Line color node
   vtkNew<vtkIntArray> events;
   events->InsertNextValue(vtkCommand::ModifiedEvent);
@@ -181,6 +191,30 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(occludedOpacity, OccludedOpacity);
   vtkMRMLWriteXMLStdStringMacro(textProperty, TextPropertyAsString);
   vtkMRMLWriteXMLVectorMacro(activeColor, ActiveColor, double, 3);
+
+  // Only write the handle axes properties if any of them are different from the default (all enabled).
+  if (!this->TranslationHandleComponentVisibility[0] ||
+      !this->TranslationHandleComponentVisibility[1] ||
+      !this->TranslationHandleComponentVisibility[2] ||
+      !this->TranslationHandleComponentVisibility[3])
+    {
+    vtkMRMLWriteXMLVectorMacro(translationHandleAxes, TranslationHandleComponentVisibility, bool, 4);
+    }
+  if (!this->RotationHandleComponentVisibility[0] ||
+      !this->RotationHandleComponentVisibility[1] ||
+      !this->RotationHandleComponentVisibility[2] ||
+      !this->RotationHandleComponentVisibility[3])
+    {
+    vtkMRMLWriteXMLVectorMacro(rotationHandleAxes, RotationHandleComponentVisibility, bool, 4);
+    }
+  if (!this->ScaleHandleComponentVisibility[0] ||
+      !this->ScaleHandleComponentVisibility[1] ||
+      !this->ScaleHandleComponentVisibility[2] ||
+      !this->ScaleHandleComponentVisibility[3])
+    {
+    vtkMRMLWriteXMLVectorMacro(scaleHandleAxes, ScaleHandleComponentVisibility, bool, 4);
+    }
+
   vtkMRMLWriteXMLEndMacro();
 }
 
@@ -225,6 +259,9 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(occludedOpacity, OccludedOpacity);
   vtkMRMLReadXMLStdStringMacro(textProperty, TextPropertyFromString);
   vtkMRMLReadXMLVectorMacro(activeColor, ActiveColor, double, 3);
+  vtkMRMLReadXMLVectorMacro(rotationHandleAxes, RotationHandleComponentVisibility, bool, 4);
+  vtkMRMLReadXMLVectorMacro(scaleHandleAxes, ScaleHandleComponentVisibility, bool, 4);
+  vtkMRMLReadXMLVectorMacro(translationHandleAxes, TranslationHandleComponentVisibility, bool, 4);
   vtkMRMLReadXMLEndMacro();
 
   // Fix up legacy markups fiducial nodes
@@ -305,6 +342,9 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
   // The name is misleading, this ShallowCopy method actually creates a deep copy
   this->TextProperty->ShallowCopy(this->SafeDownCast(copySourceNode)->GetTextProperty());
   vtkMRMLCopyVectorMacro(ActiveColor, double, 3);
+  vtkMRMLCopyVectorMacro(RotationHandleComponentVisibility, bool, 4);
+  vtkMRMLCopyVectorMacro(ScaleHandleComponentVisibility, bool, 4);
+  vtkMRMLCopyVectorMacro(TranslationHandleComponentVisibility, bool, 4);
   vtkMRMLCopyEndMacro();
 }
 
@@ -500,6 +540,9 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(OccludedOpacity);
   vtkMRMLPrintStdStringMacro(TextPropertyAsString);
   vtkMRMLPrintVectorMacro(ActiveColor, double, 3);
+  vtkMRMLPrintVectorMacro(RotationHandleComponentVisibility, bool, 4);
+  vtkMRMLPrintVectorMacro(ScaleHandleComponentVisibility, bool, 4);
+  vtkMRMLPrintVectorMacro(TranslationHandleComponentVisibility, bool, 4);
   vtkMRMLPrintEndMacro();
 }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsDisplayNode.h
@@ -422,6 +422,7 @@ public:
   /// Get the active color of the markup. This color is used when the mouse pointer hovers over a markup.
   vtkGetVector3Macro(ActiveColor, double);
 
+  //@{
   /// The visibility and interactability of the interaction handles
   vtkGetMacro(HandlesInteractive, bool);
   vtkSetMacro(HandlesInteractive, bool);
@@ -437,11 +438,27 @@ public:
   vtkBooleanMacro(ScaleHandleVisibility, bool);
   void SetHandleVisibility(int handleType, bool visibility);
   bool GetHandleVisibility(int handleType);
+  //@}
 
+  //@{
   /// Get/Set interaction handle size relative to the window size.
   /// Diameter of the interaction handle points is defined as "scale" percentage of diagonal size of the window.
   vtkSetMacro(InteractionHandleScale, double);
   vtkGetMacro(InteractionHandleScale, double);
+  //@}
+
+  //@{
+  /// Get/Set the visibility of the individual handle axes
+  /// The order of the vector is: [X, Y, Z, ViewPlane]
+  /// "ViewPlane" scale/translation allows transformations to take place along the active view plane.
+  /// (ex. center translation point and ROI corner scale handles.
+  vtkSetVector4Macro(RotationHandleComponentVisibility, bool);
+  vtkGetVector4Macro(RotationHandleComponentVisibility, bool);
+  vtkSetVector4Macro(ScaleHandleComponentVisibility, bool);
+  vtkGetVector4Macro(ScaleHandleComponentVisibility, bool);
+  vtkSetVector4Macro(TranslationHandleComponentVisibility, bool);
+  vtkGetVector4Macro(TranslationHandleComponentVisibility, bool);
+  //@}
 
   /// Get data set containing the scalar arrays for this node type.
   /// For markups it is the curve poly data
@@ -453,6 +470,9 @@ public:
   virtual void UpdateAssignedAttribute() override;
 
   virtual void SetScalarVisibility(int visibility) override;
+
+  /// Get flag indicating if the markups node can display scale handles
+  vtkGetMacro(CanDisplayScaleHandles, bool);
 
 protected:
   vtkMRMLMarkupsDisplayNode();
@@ -518,5 +538,11 @@ protected:
   bool RotationHandleVisibility;
   bool ScaleHandleVisibility;
   double InteractionHandleScale;
+
+  bool RotationHandleComponentVisibility[4];
+  bool ScaleHandleComponentVisibility[4];
+  bool TranslationHandleComponentVisibility[4];
+
+  bool CanDisplayScaleHandles;
 };
 #endif

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneDisplayNode.cxx
@@ -31,6 +31,7 @@ vtkMRMLMarkupsPlaneDisplayNode::vtkMRMLMarkupsPlaneDisplayNode()
   this->TranslationHandleVisibility = false;
   this->RotationHandleVisibility= false;
   this->ScaleHandleVisibility = true;
+  this->CanDisplayScaleHandles = true;
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROIDisplayNode.cxx
@@ -29,9 +29,13 @@ vtkMRMLMarkupsROIDisplayNode::vtkMRMLMarkupsROIDisplayNode()
 {
   this->FillOpacity = 0.2;
   this->HandlesInteractive = true;
-  this->TranslationHandleVisibility = false;
+  this->TranslationHandleVisibility = true;
   this->RotationHandleVisibility= false;
   this->ScaleHandleVisibility = true;
+  this->TranslationHandleComponentVisibility[0] = false;
+  this->TranslationHandleComponentVisibility[1] = false;
+  this->TranslationHandleComponentVisibility[2] = false;
+  this->CanDisplayScaleHandles = true;
 }
 
 //----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -592,6 +592,7 @@ void vtkSlicerMarkupsWidgetRepresentation::UpdateInteractionPipeline()
     }
 
   this->InteractionPipeline->Actor->SetVisibility(this->MarkupsDisplayNode->GetHandlesInteractive());
+  this->InteractionPipeline->UpdateHandleVisibility();
 
   vtkNew<vtkTransform> handleToWorldTransform;
   handleToWorldTransform->SetMatrix(markupsNode->GetInteractionHandleToWorldMatrix());
@@ -954,6 +955,7 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::Initializ
   this->CreateRotationHandles();
   this->CreateTranslationHandles();
   this->CreateScaleHandles();
+  this->UpdateHandleVisibility();
   this->UpdateHandleColors();
 }
 
@@ -1062,6 +1064,13 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateRot
                                      zRotationMatrix->GetElement(0, 2), zRotationMatrix->GetElement(1, 2), zRotationMatrix->GetElement(2, 2));
   this->RotationHandlePoints->GetPointData()->AddArray(orientationArray);
 
+  vtkNew<vtkIdTypeArray> visibilityArray;
+  visibilityArray->SetName("visibility");
+  visibilityArray->SetNumberOfComponents(1);
+  visibilityArray->SetNumberOfValues(this->RotationHandlePoints->GetNumberOfPoints());
+  visibilityArray->Fill(1);
+  this->RotationHandlePoints->GetPointData()->AddArray(visibilityArray);
+
   this->Append->AddInputConnection(this->AxisRotationGlypher->GetOutputPort());
 }
 
@@ -1107,7 +1116,7 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateTra
   points->InsertNextPoint(INTERACTION_WIDGET_RADIUS, 0, 0); // X-axis
   points->InsertNextPoint(0, INTERACTION_WIDGET_RADIUS, 0); // Y-axis
   points->InsertNextPoint(0, 0, INTERACTION_WIDGET_RADIUS); // Z-axis
-  points->InsertNextPoint(0, 0, 0); // Free translation
+  points->InsertNextPoint(0, 0, 0); // View plane translation
   this->TranslationHandlePoints->SetPoints(points);
 
   vtkNew<vtkDoubleArray> orientationArray;
@@ -1116,7 +1125,7 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateTra
   orientationArray->InsertNextTuple3(1, 0, 0);
   orientationArray->InsertNextTuple3(0, 1, 0);
   orientationArray->InsertNextTuple3(0, 0, 1);
-  orientationArray->InsertNextTuple3(1, 0, 0); // Free translation
+  orientationArray->InsertNextTuple3(1, 0, 0); // View plane translation
   this->TranslationHandlePoints->GetPointData()->AddArray(orientationArray);
 
   vtkNew<vtkDoubleArray> glyphIndexArray;
@@ -1127,6 +1136,13 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateTra
   glyphIndexArray->InsertNextTuple1(0);
   glyphIndexArray->InsertNextTuple1(1);
   this->TranslationHandlePoints->GetPointData()->AddArray(glyphIndexArray);
+
+  vtkNew<vtkIdTypeArray> visibilityArray;
+  visibilityArray->SetName("visibility");
+  visibilityArray->SetNumberOfComponents(1);
+  visibilityArray->SetNumberOfValues(this->TranslationHandlePoints->GetNumberOfPoints());
+  visibilityArray->Fill(1);
+  this->TranslationHandlePoints->GetPointData()->AddArray(visibilityArray);
 
   this->Append->AddInputConnection(this->AxisTranslationGlypher->GetOutputPort());
 }
@@ -1167,6 +1183,41 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateSca
   this->ScaleHandlePoints->GetPointData()->AddArray(visibilityArray);
 
   this->Append->AddInputConnection(this->AxisScaleGlypher->GetOutputPort());
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::UpdateHandleVisibility()
+{
+  vtkSlicerMarkupsWidgetRepresentation* markupsRepresentation = vtkSlicerMarkupsWidgetRepresentation::SafeDownCast(this->Representation);
+  vtkMRMLMarkupsDisplayNode* displayNode = nullptr;
+  if (markupsRepresentation)
+    {
+    displayNode = markupsRepresentation->GetMarkupsDisplayNode();
+    }
+  if (!displayNode)
+    {
+    vtkGenericWarningMacro("UpdateHandleVisibility: Invalid display node");
+    return;
+    }
+
+  vtkIdTypeArray* rotationVisibilityArray = vtkIdTypeArray::SafeDownCast(this->RotationHandlePoints->GetPointData()->GetArray("visibility"));
+  if (rotationVisibilityArray)
+    {
+    bool* rotationVisibility = displayNode->GetRotationHandleComponentVisibility();
+    rotationVisibilityArray->SetValue(0, rotationVisibility[0]);
+    rotationVisibilityArray->SetValue(1, rotationVisibility[1]);
+    rotationVisibilityArray->SetValue(2, rotationVisibility[2]);
+    }
+
+  vtkIdTypeArray* translationVisibilityArray = vtkIdTypeArray::SafeDownCast(this->TranslationHandlePoints->GetPointData()->GetArray("visibility"));
+  if (translationVisibilityArray)
+    {
+    bool* translationVisibility = displayNode->GetTranslationHandleComponentVisibility();
+    translationVisibilityArray->SetValue(0, translationVisibility[0]);
+    translationVisibilityArray->SetValue(1, translationVisibility[1]);
+    translationVisibilityArray->SetValue(2, translationVisibility[2]);
+    translationVisibilityArray->SetValue(3, translationVisibility[3]);
+    }
 }
 
 //----------------------------------------------------------------------
@@ -1356,7 +1407,7 @@ double vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::GetHand
   double opacity = 1.0;
   if (type == vtkMRMLMarkupsDisplayNode::ComponentTranslationHandle && index == 3)
     {
-    // Free transform handle is always visible regardless of angle
+    // View plane transform handle is always visible regardless of angle
     return opacity;
     }
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -230,6 +230,7 @@ protected:
     virtual void CreateRotationHandles();
     virtual void CreateTranslationHandles();
     virtual void CreateScaleHandles();
+    virtual void UpdateHandleVisibility();
     virtual void UpdateHandleColors();
 
     /// Set the scale of the interaction handles in world coordinates

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.cxx
@@ -729,7 +729,6 @@ vtkSlicerPlaneRepresentation3D::HandleInfoList vtkSlicerPlaneRepresentation3D::M
   return handleInfoList;
 }
 
-
 //-----------------------------------------------------------------------------
 void vtkSlicerPlaneRepresentation3D::MarkupsInteractionPipelinePlane::UpdateScaleHandles()
 {
@@ -766,6 +765,41 @@ void vtkSlicerPlaneRepresentation3D::MarkupsInteractionPipelinePlane::UpdateScal
   vtkIdTypeArray* visibilityArray = vtkIdTypeArray::SafeDownCast(this->ScaleHandlePoints->GetPointData()->GetArray("visibility"));
   visibilityArray->SetNumberOfValues(roiPoints->GetNumberOfPoints());
   visibilityArray->Fill(1);
+  this->UpdateHandleVisibility();
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerPlaneRepresentation3D::MarkupsInteractionPipelinePlane::UpdateHandleVisibility()
+{
+  MarkupsInteractionPipeline::UpdateHandleVisibility();
+
+  vtkSlicerMarkupsWidgetRepresentation* markupsRepresentation = vtkSlicerMarkupsWidgetRepresentation::SafeDownCast(this->Representation);
+  vtkMRMLMarkupsDisplayNode* displayNode = nullptr;
+  if (markupsRepresentation)
+    {
+    displayNode = markupsRepresentation->GetMarkupsDisplayNode();
+    }
+  if (!displayNode)
+    {
+    vtkGenericWarningMacro("UpdateHandleVisibility: Invalid display node");
+    return;
+    }
+
+  vtkIdTypeArray* scaleVisibilityArray = vtkIdTypeArray::SafeDownCast(this->ScaleHandlePoints->GetPointData()->GetArray("visibility"));
+  if (scaleVisibilityArray)
+    {
+    bool* scaleHandleAxes = displayNode->GetScaleHandleComponentVisibility();
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsPlaneDisplayNode::HandleLEdge, scaleHandleAxes[0]);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsPlaneDisplayNode::HandleREdge, scaleHandleAxes[0]);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsPlaneDisplayNode::HandlePEdge, scaleHandleAxes[1]);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsPlaneDisplayNode::HandleAEdge, scaleHandleAxes[1]);
+
+    bool viewPlaneScaleVisibility = scaleHandleAxes[3];
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsPlaneDisplayNode::HandleLPCorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsPlaneDisplayNode::HandleRPCorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsPlaneDisplayNode::HandleLACorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsPlaneDisplayNode::HandleRACorner, viewPlaneScaleVisibility);
+    }
 }
 
 //----------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
@@ -129,6 +129,9 @@ protected:
     // Update scale handle positions
     virtual void UpdateScaleHandles();
 
+    // Update scale handle visibilities
+    void UpdateHandleVisibility() override;
+
     void GetHandleColor(int type, int index, double color[4]) override;
     double GetHandleOpacity(int type, int index) override;
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
@@ -582,6 +582,7 @@ void vtkSlicerROIRepresentation2D::MarkupsInteractionPipelineROI2D::UpdateScaleH
   vtkIdTypeArray* visibilityArray = vtkIdTypeArray::SafeDownCast(this->ScaleHandlePoints->GetPointData()->GetArray("visibility"));
   visibilityArray->SetNumberOfValues(scaleHandlePoints_Object->GetNumberOfPoints());
   visibilityArray->Fill(displayNode ? displayNode->GetScaleHandleVisibility() : 1.0);
+  this->UpdateHandleVisibility();
 
   // Corner handles are not visibile in 2D
   for (int i = vtkMRMLMarkupsROIDisplayNode::HandleLPICorner; i <= vtkMRMLMarkupsROIDisplayNode::HandleRASCorner; ++i)

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
@@ -669,6 +669,65 @@ void vtkSlicerROIRepresentation3D::MarkupsInteractionPipelineROI::UpdateScaleHan
   vtkIdTypeArray* visibilityArray = vtkIdTypeArray::SafeDownCast(this->ScaleHandlePoints->GetPointData()->GetArray("visibility"));
   visibilityArray->SetNumberOfValues(roiPoints->GetNumberOfPoints());
   visibilityArray->Fill(1);
+  this->UpdateHandleVisibility();
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerROIRepresentation3D::MarkupsInteractionPipelineROI::UpdateHandleVisibility()
+{
+  MarkupsInteractionPipeline::UpdateHandleVisibility();
+
+  vtkSlicerMarkupsWidgetRepresentation* markupsRepresentation = vtkSlicerMarkupsWidgetRepresentation::SafeDownCast(this->Representation);
+  vtkMRMLMarkupsDisplayNode* displayNode = nullptr;
+  if (markupsRepresentation)
+    {
+    displayNode = markupsRepresentation->GetMarkupsDisplayNode();
+    }
+  if (!displayNode)
+    {
+    vtkGenericWarningMacro("UpdateHandleVisibility: Invalid display node");
+    return;
+    }
+
+  bool* scaleHandleAxes = displayNode->GetScaleHandleComponentVisibility();
+
+  vtkIdTypeArray* scaleVisibilityArray = vtkIdTypeArray::SafeDownCast(this->ScaleHandlePoints->GetPointData()->GetArray("visibility"));
+  if (scaleVisibilityArray)
+    {
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLFace, scaleHandleAxes[0]);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRFace, scaleHandleAxes[0]);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandlePFace, scaleHandleAxes[1]);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleAFace, scaleHandleAxes[1]);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleIFace, scaleHandleAxes[2]);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleSFace, scaleHandleAxes[2]);
+
+    bool viewPlaneScaleVisibility = scaleHandleAxes[3];
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLPICorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRPICorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLAICorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRAICorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLPSCorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRPSCorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLASCorner, viewPlaneScaleVisibility);
+    scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRASCorner, viewPlaneScaleVisibility);
+
+    if (scaleVisibilityArray->GetNumberOfValues() > vtkMRMLMarkupsROIDisplayNode::HandleASEdge)
+      {
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLPEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRPEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLAEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRAEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLIEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRIEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleLSEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleRSEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandlePIEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleAIEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandlePSEdge, viewPlaneScaleVisibility);
+      scaleVisibilityArray->SetValue(vtkMRMLMarkupsROIDisplayNode::HandleASEdge, viewPlaneScaleVisibility);
+      }
+
+    }
 }
 
 //----------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
@@ -138,6 +138,9 @@ protected:
     // Update scale handle positions
     virtual void UpdateScaleHandles();
 
+    // Update scale handle visibilities
+    void UpdateHandleVisibility() override;
+
     // Get handle opacity
     double GetHandleOpacity(int type, int index) override;
 

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -594,6 +594,9 @@
      <property name="title">
       <string>Interaction handles</string>
      </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <widget class="qMRMLMarkupsInteractionHandleWidget" name="InteractionHandleWidget"/>
@@ -646,6 +649,12 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>qMRMLMarkupsInteractionHandleWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLMarkupsInteractionHandleWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>ctkCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>ctkCollapsibleGroupBox.h</header>
@@ -660,12 +669,6 @@
    <class>ctkSliderWidget</class>
    <extends>QWidget</extends>
    <header>ctkSliderWidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>qMRMLMarkupsInteractionHandleWidget</class>
-   <extends>qMRMLWidget</extends>
-   <header>qMRMLMarkupsInteractionHandleWidget.h</header>
-   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsInteractionHandleWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsInteractionHandleWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>233</width>
-    <height>66</height>
+    <width>370</width>
+    <height>115</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -32,15 +32,97 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="1" column="2">
+    <widget class="QLabel" name="translationEnableLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="text">
-      <string>Size:</string>
+      <string>Enable translation:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
+   <item row="0" column="6">
+    <widget class="QLabel" name="yLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Y</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="6" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="translateYCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="7" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="scaleZCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="7" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="rotateZCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="5" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="scaleXCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="5">
+    <widget class="QLabel" name="xLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>X</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="7">
+    <widget class="QLabel" name="zLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Z</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="3">
+    <widget class="QCheckBox" name="scaleVisibilityCheckBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -48,11 +130,54 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Visibility:</string>
+      <string/>
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="2">
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Size:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="10">
+    <widget class="QPushButton" name="moreOptionsCheckBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>More options...</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QCheckBox" name="overallVisibilityCheckBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="8" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="scaleViewPlaneCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="2" colspan="9">
     <widget class="ctkSliderWidget" name="interactionHandleScaleSlider">
      <property name="singleStep">
       <double>0.100000000000000</double>
@@ -65,37 +190,157 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QCheckBox" name="translateVisibilityCheckBox">
-       <property name="text">
-        <string>Translate</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="rotateVisibilityCheckBox">
-       <property name="text">
-        <string>Rotate</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="scaleVisibilityCheckBox">
-       <property name="text">
-        <string>Scale</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QCheckBox" name="overallVisibilityCheckBox">
+   <item row="3" column="6" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="rotateYCheckBox">
      <property name="text">
       <string/>
      </property>
     </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Visibility:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="7" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="translateZCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QCheckBox" name="translateVisibilityCheckBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="8">
+    <widget class="QLabel" name="viewPlaneLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>View plane</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="8" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="translateViewPlaneCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="5" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="rotateXCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLabel" name="scaleEnableLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Enable scaling:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="5" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="translateXCheckBox">
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QLabel" name="rotateEnableLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Enable rotation:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="3">
+    <widget class="QCheckBox" name="rotateVisibilityCheckBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="6" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="scaleYCheckBox">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="9">
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -113,5 +358,246 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>translateXCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>210</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>135</x>
+     <y>60</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>scaleViewPlaneCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>307</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>303</x>
+     <y>140</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>scaleZCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>307</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>246</x>
+     <y>140</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>scaleYCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>307</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>211</x>
+     <y>140</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>scaleXCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>307</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>176</x>
+     <y>140</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>rotateZCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>307</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>246</x>
+     <y>98</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>rotateYCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>307</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>211</x>
+     <y>98</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>rotateXCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>307</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>176</x>
+     <y>98</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>translateViewPlaneCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>210</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>262</x>
+     <y>60</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>translateZCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>210</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>205</x>
+     <y>60</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>translateYCheckBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>210</x>
+     <y>11</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>170</x>
+     <y>60</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>xLabel</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>111</x>
+     <y>12</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>225</x>
+     <y>12</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>yLabel</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>111</x>
+     <y>12</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>244</x>
+     <y>12</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>zLabel</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>111</x>
+     <y>12</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>263</x>
+     <y>12</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>moreOptionsCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>viewPlaneLabel</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>111</x>
+     <y>12</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>301</x>
+     <y>12</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsInteractionHandleWidget.cxx
@@ -27,7 +27,7 @@
 
 // MRML includes
 #include <vtkMRMLMarkupsNode.h>
-#include <vtkMRMLMarkupsROIDisplayNode.h>
+#include <vtkMRMLMarkupsDisplayNode.h>
 
 // --------------------------------------------------------------------------
 class qMRMLMarkupsInteractionHandleWidgetPrivate: public Ui_qMRMLMarkupsInteractionHandleWidget
@@ -58,9 +58,36 @@ void qMRMLMarkupsInteractionHandleWidgetPrivate::init()
 
   QObject::connect(this->overallVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
   QObject::connect(this->translateVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->translateXCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->translateYCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->translateZCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->translateViewPlaneCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
   QObject::connect(this->rotateVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->rotateXCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->rotateYCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->rotateZCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
   QObject::connect(this->scaleVisibilityCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->scaleXCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->scaleYCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->scaleZCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
+  QObject::connect(this->scaleViewPlaneCheckBox, SIGNAL(clicked()), q, SLOT(updateMRMLFromWidget()));
   QObject::connect(this->interactionHandleScaleSlider, SIGNAL(valueChanged(double)), q, SLOT(updateMRMLFromWidget()));
+
+  this->xLabel->hide();
+  this->yLabel->hide();
+  this->zLabel->hide();
+  this->viewPlaneLabel->hide();
+  this->translateXCheckBox->hide();
+  this->translateYCheckBox->hide();
+  this->translateZCheckBox->hide();
+  this->translateViewPlaneCheckBox->hide();
+  this->rotateXCheckBox->hide();
+  this->rotateYCheckBox->hide();
+  this->rotateZCheckBox->hide();
+  this->scaleXCheckBox->hide();
+  this->scaleYCheckBox->hide();
+  this->scaleZCheckBox->hide();
+  this->scaleViewPlaneCheckBox->hide();
 }
 
 // --------------------------------------------------------------------------
@@ -104,45 +131,106 @@ void qMRMLMarkupsInteractionHandleWidget::updateWidgetFromMRML()
   this->setEnabled(d->DisplayNode != nullptr);
   d->overallVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
   d->translateVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->translateXCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->translateYCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->translateZCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->translateViewPlaneCheckBox->setEnabled(d->DisplayNode != nullptr);
   d->rotateVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->rotateXCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->rotateYCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->rotateZCheckBox->setEnabled(d->DisplayNode != nullptr);
   d->scaleVisibilityCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->scaleXCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->scaleYCheckBox->setEnabled(d->DisplayNode != nullptr);
+  d->scaleZCheckBox->setEnabled(d->DisplayNode != nullptr);
   d->interactionHandleScaleSlider->setEnabled(d->DisplayNode != nullptr);
+
   if (!d->DisplayNode)
     {
     return;
     }
 
-  // Scale handles currently not implemented for representations other than ROI
-  // Disable by default.
-  if (!vtkMRMLMarkupsROIDisplayNode::SafeDownCast(d->DisplayNode))
-    {
-    // Scale handles not currently implemented for non ROI nodes
-    d->scaleVisibilityCheckBox->setVisible(false);
-    }
-  else
-    {
-    d->scaleVisibilityCheckBox->setVisible(true);
-    }
+  // Scale handles currently not implemented for all representations
+  bool canDisplayScaleHandles = d->DisplayNode->GetCanDisplayScaleHandles();
+  d->scaleVisibilityCheckBox->setEnabled(canDisplayScaleHandles);
+  d->scaleXCheckBox->setEnabled(canDisplayScaleHandles);
+  d->scaleYCheckBox->setEnabled(canDisplayScaleHandles);
+  d->scaleZCheckBox->setEnabled(canDisplayScaleHandles);
+  d->scaleViewPlaneCheckBox->setEnabled(canDisplayScaleHandles);
+  d->scaleEnableLabel->setEnabled(canDisplayScaleHandles);
 
   bool wasBlocking = false;
 
+  ////////
   // Interactive Mode
   wasBlocking = d->overallVisibilityCheckBox->blockSignals(true);
   d->overallVisibilityCheckBox->setChecked(d->DisplayNode->GetHandlesInteractive());
   d->overallVisibilityCheckBox->blockSignals(wasBlocking);
 
-
+  //
+  // Translation
   wasBlocking = d->translateVisibilityCheckBox->blockSignals(true);
   d->translateVisibilityCheckBox->setChecked(d->DisplayNode->GetTranslationHandleVisibility());
   d->translateVisibilityCheckBox->blockSignals(wasBlocking);
 
+  bool* translationHandleAxes = d->DisplayNode->GetTranslationHandleComponentVisibility();
+  wasBlocking = d->translateXCheckBox->blockSignals(true);
+  d->translateXCheckBox->setChecked(translationHandleAxes[0]);
+  d->translateXCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->translateYCheckBox->blockSignals(true);
+  d->translateYCheckBox->setChecked(translationHandleAxes[1]);
+  d->translateYCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->translateZCheckBox->blockSignals(true);
+  d->translateZCheckBox->setChecked(translationHandleAxes[2]);
+  d->translateZCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->translateViewPlaneCheckBox->blockSignals(true);
+  d->translateViewPlaneCheckBox->setChecked(translationHandleAxes[3]);
+  d->translateViewPlaneCheckBox->blockSignals(wasBlocking);
+
+  //
+  // Rotation
   wasBlocking = d->rotateVisibilityCheckBox->blockSignals(true);
   d->rotateVisibilityCheckBox->setChecked(d->DisplayNode->GetRotationHandleVisibility());
   d->rotateVisibilityCheckBox->blockSignals(wasBlocking);
 
+  bool* rotationHandleAxes = d->DisplayNode->GetRotationHandleComponentVisibility();
+  wasBlocking = d->rotateXCheckBox->blockSignals(true);
+  d->rotateXCheckBox->setChecked(rotationHandleAxes[0]);
+  d->rotateXCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->rotateYCheckBox->blockSignals(true);
+  d->rotateYCheckBox->setChecked(rotationHandleAxes[1]);
+  d->rotateYCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->rotateZCheckBox->blockSignals(true);
+  d->rotateZCheckBox->setChecked(rotationHandleAxes[2]);
+  d->rotateZCheckBox->blockSignals(wasBlocking);
+
+  //
+  // Scaling
   wasBlocking = d->scaleVisibilityCheckBox->blockSignals(true);
-  d->scaleVisibilityCheckBox->setChecked(d->DisplayNode->GetScaleHandleVisibility());
+  d->scaleVisibilityCheckBox->setChecked(d->DisplayNode->GetScaleHandleVisibility() && canDisplayScaleHandles);
   d->scaleVisibilityCheckBox->blockSignals(wasBlocking);
+
+  bool* scaleHandleAxes = d->DisplayNode->GetScaleHandleComponentVisibility();
+  wasBlocking = d->scaleXCheckBox->blockSignals(true);
+  d->scaleXCheckBox->setChecked(scaleHandleAxes[0] && canDisplayScaleHandles);
+  d->scaleXCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->scaleYCheckBox->blockSignals(true);
+  d->scaleYCheckBox->setChecked(scaleHandleAxes[1] && canDisplayScaleHandles);
+  d->scaleYCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->scaleZCheckBox->blockSignals(true);
+  d->scaleZCheckBox->setChecked(scaleHandleAxes[2] && canDisplayScaleHandles);
+  d->scaleZCheckBox->blockSignals(wasBlocking);
+
+  wasBlocking = d->scaleViewPlaneCheckBox->blockSignals(true);
+  d->scaleViewPlaneCheckBox->setChecked(scaleHandleAxes[3] && canDisplayScaleHandles);
+  d->scaleViewPlaneCheckBox->blockSignals(wasBlocking);
 
   wasBlocking = d->interactionHandleScaleSlider->blockSignals(true);
   if (d->DisplayNode->GetInteractionHandleScale() > d->interactionHandleScaleSlider->maximum())
@@ -164,8 +252,26 @@ void qMRMLMarkupsInteractionHandleWidget::updateMRMLFromWidget()
 
   MRMLNodeModifyBlocker displayNodeBlocker(d->DisplayNode);
   d->DisplayNode->SetHandlesInteractive(d->overallVisibilityCheckBox->isChecked());
+
+  bool translationHandleAxes[4] = { d->translateXCheckBox->isChecked(),
+                                    d->translateYCheckBox->isChecked(),
+                                    d->translateZCheckBox->isChecked(),
+                                    d->translateViewPlaneCheckBox->isChecked() };
+  d->DisplayNode->SetTranslationHandleComponentVisibility(translationHandleAxes);
   d->DisplayNode->SetTranslationHandleVisibility(d->translateVisibilityCheckBox->isChecked());
+
+  bool rotationHandleAxes[4] = { d->rotateXCheckBox->isChecked(),
+                                 d->rotateYCheckBox->isChecked(),
+                                 d->rotateZCheckBox->isChecked(), true };
+  d->DisplayNode->SetRotationHandleComponentVisibility(rotationHandleAxes);
   d->DisplayNode->SetRotationHandleVisibility(d->rotateVisibilityCheckBox->isChecked());
+
+  bool scaleHandleAxes[4] = { d->scaleXCheckBox->isChecked(),
+                              d->scaleYCheckBox->isChecked(),
+                              d->scaleZCheckBox->isChecked(),
+                              d->scaleViewPlaneCheckBox->isChecked() };
+  d->DisplayNode->SetScaleHandleComponentVisibility(scaleHandleAxes);
   d->DisplayNode->SetScaleHandleVisibility(d->scaleVisibilityCheckBox->isChecked());
+
   d->DisplayNode->SetInteractionHandleScale(d->interactionHandleScaleSlider->value());
 }


### PR DESCRIPTION
Previously, all of the interaction handles could only be enabled/disabled with others of the same type (rotation, translation, scaling).
This commit adds options for enabling disabling the individual XYZ axes for each of the handle types, as well has the handles that allow free transformation.

ROI nodes now display translation handles by default, but only display the free translation point in the center of the ROI.

Closes #5558
Re #5061