### PR TITLE
BUG: Fix Markups toolbar not using display names

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -493,7 +493,7 @@ void qMRMLMarkupsToolBar::updateToolBarLayout()
         QPushButton* markupCreateButton = new QPushButton();
         QSignalMapper* mapper = new QSignalMapper(markupCreateButton);
         std::string markupType = markupsNode->GetMarkupType() ? markupsNode->GetMarkupType() : "";
-        std::string markupDisplayName = markupsNode->GetMarkupType() ? markupsNode->GetMarkupType() : "";
+        std::string markupDisplayName = markupsNode->GetTypeDisplayName() ? markupsNode->GetTypeDisplayName() : "";
         markupCreateButton->setObjectName(QString::fromStdString("Create"+markupType+"PushButton"));
         markupCreateButton->setToolTip("Create new " + QString::fromStdString(markupDisplayName));
         markupCreateButton->setIcon(QIcon(markupsNode->GetPlaceAddIcon()));


### PR DESCRIPTION
The tooltip "Create new ClosedCurve" is now "Create new Closed Curve".

| Current | This PR |
|----------|---------|
|![image](https://user-images.githubusercontent.com/15837524/153914728-f3b51505-0010-4af4-85cd-abbbcfe2add0.png)|![image](https://user-images.githubusercontent.com/15837524/153914753-550bb70a-a683-42c3-8a27-942d38700975.png)|