### PR TITLE
ENH: Add Markups Point List Node

### DIFF
--- a/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
+++ b/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
@@ -101,7 +101,7 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
     # Place a point on the red slice
     eye = [33.4975, 79.4042, -10.2143]
     markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
-    markupNode.AddControlPoint(eye)
+    fidIndex = markupNode.AddControlPoint(eye)
     self.delayDisplay(f"Placed a point at {eye[0]:g}, {eye[1]:g}, {eye[2]:g}")
 
     # Pan and zoom

--- a/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
+++ b/Applications/SlicerApp/Testing/Python/FiducialLayoutSwitchBug1914.py
@@ -100,7 +100,7 @@ class FiducialLayoutSwitchBug1914Test(ScriptedLoadableModuleTest):
 
     # Place a point on the red slice
     eye = [33.4975, 79.4042, -10.2143]
-    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
     markupNode.AddControlPoint(eye)
     self.delayDisplay(f"Placed a point at {eye[0]:g}, {eye[1]:g}, {eye[2]:g}")
 

--- a/Applications/SlicerApp/Testing/Python/ShaderProperties.py
+++ b/Applications/SlicerApp/Testing/Python/ShaderProperties.py
@@ -199,7 +199,7 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
 
     self.delayDisplay('GPU Ray Casting on')
 
-    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
     markupNode.AddControlPoint([0.0, 100.0, 0.0])
 
     self.delayDisplay('Point list added')
@@ -211,7 +211,7 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
     # node
     #------------------------------------------------------
     def GetPointPosition():
-        fn = slicer.util.getNode('vtkMRMLMarkupsFiducialNode1')
+        fn = slicer.util.getNode('vtkMRMLMarkupsPointListNode1')
         p = [0.0, 0.0, 0.0]
         fn.GetNthControlPointPosition(0, p)
         return p
@@ -264,7 +264,7 @@ class ShaderPropertiesTest(ScriptedLoadableModuleTest):
         propNode = GetShaderPropertyNode()
         propNode.GetFragmentUniforms().SetUniform3f("center",p)
 
-    fn = slicer.util.getNode('vtkMRMLMarkupsFiducialNode1')
+    fn = slicer.util.getNode('vtkMRMLMarkupsPointListNode1')
     fn.AddObserver(fn.PointModifiedEvent, lambda caller,event: onPointMoved())
 
 

--- a/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerBoundsTest.py
@@ -202,7 +202,7 @@ class SlicerBoundsTestTest(ScriptedLoadableModuleTest):
     """ Test the GetRASBounds & GetBounds method on a markup.
     """
     #self.delayDisplay("Starting test_Markup")
-    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
     markupNode.AddControlPoint([1.0, 0.0, 0.0])
     markupNode.AddControlPoint([-45.0, -90.0, -180.0])
     markupNode.AddControlPoint([-200.0, 500.0, -0.23])

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreLoopTest.py
@@ -92,7 +92,7 @@ class SlicerMRBMultipleSaveRestoreLoop(ScriptedLoadableModuleTest):
     mrHeadVolume = SampleData.downloadSample("MRHead")
 
     # Place a control point
-    pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "F")
+    pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode", "F")
     pointListNode.CreateDefaultDisplayNodes()
     fid1 = [0.0, 0.0, 0.0]
     fidIndex1 = pointListNode.AddControlPoint(fid1)

--- a/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerMRBMultipleSaveRestoreTest.py
@@ -89,7 +89,7 @@ class SlicerMRBMultipleSaveRestore(ScriptedLoadableModuleTest):
     mrHeadVolume = SampleData.downloadSample("MRHead")
 
     # Place a control point
-    pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode","F")
+    pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode","F")
     pointListNode.CreateDefaultDisplayNodes()
     eye = [33.4975, 79.4042, -10.2143]
     nose = [-2.145, 116.14, -43.31]

--- a/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
+++ b/Applications/SlicerApp/Testing/Python/SlicerTransformInteractionTest1.py
@@ -422,7 +422,7 @@ class SlicerTransformInteractionTest1Test(ScriptedLoadableModuleTest):
     #  - Create another transform under the parent transform
     #
 
-    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+    markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
     markupNode.AddControlPoint([500.0, -1000.0, 0.0])
     markupNode.AddControlPoint([1000.0, 1000.0, 200.0])
     markupNode.AddControlPoint([-1500.0, -200.0, -100.0])

--- a/Applications/SlicerApp/Testing/Python/UtilTest.py
+++ b/Applications/SlicerApp/Testing/Python/UtilTest.py
@@ -386,7 +386,7 @@ class UtilTestTest(ScriptedLoadableModuleTest):
 
     self.delayDisplay('Test arrayFromMarkupsControlPoints')
 
-    markupsNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsFiducialNode')
+    markupsNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsPointListNode')
     markupsNode.AddControlPoint(vtk.vtkVector3d(10,20,30))
     markupsNode.AddControlPoint(vtk.vtkVector3d(21,21,31))
     markupsNode.AddControlPoint(vtk.vtkVector3d(32,33,44))
@@ -458,7 +458,7 @@ class UtilTestTest(ScriptedLoadableModuleTest):
     self.assertEqual(narray.shape, (50, 3))
 
     self.delayDisplay('Test array with markups fiducials')
-    markupsNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsFiducialNode')
+    markupsNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsPointListNode')
     markupsNode.AddControlPoint(vtk.vtkVector3d(10,20,30))
     markupsNode.AddControlPoint(vtk.vtkVector3d(21,21,31))
     markupsNode.AddControlPoint(vtk.vtkVector3d(32,33,44))

--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -278,6 +278,7 @@ void qSlicerCLIModuleUIHelperPrivate::initializeMaps()
 
   // Markups type attribute mapping
   Self::PointTypeAttributeToNodeType["point"] = "vtkMRMLMarkupsFiducialNode";
+  Self::PointTypeAttributeToNodeType["point"] = "vtkMRMLMarkupsPointListNode";
   Self::PointTypeAttributeToNodeType["line"] = "vtkMRMLMarkupsLineNode";
   Self::PointTypeAttributeToNodeType["angle"] = "vtkMRMLMarkupsAngleNode";
   Self::PointTypeAttributeToNodeType["curve"] = "vtkMRMLMarkupsCurveNode";
@@ -550,10 +551,9 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createPointTagWidget(const ModuleParam
   QString _name = QString::fromStdString(moduleParameter.GetName());
   qMRMLNodeComboBox* widget = new qMRMLNodeComboBox;
   QStringList nodeTypes;
-  nodeTypes += "vtkMRMLMarkupsFiducialNode";
+  nodeTypes += "vtkMRMLMarkupsPointListNode";
 
   widget->setNodeTypes(nodeTypes);
-  //TODO - title + " FiducialList"
   widget->setNoneEnabled(this->isNoneEnabled(moduleParameter));
   widget->setBaseName(_label);
   // Markups can be added without switching to another module
@@ -586,6 +586,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createPointFileTagWidget(const ModuleP
     // and add all nodes that are derived from vtkMRMLVolumeNode.
     widget->setNodeTypes(QStringList()
       << "vtkMRMLMarkupsFiducialNode"
+      << "vtkMRMLMarkupsPointListNode"
       << "vtkMRMLMarkupsLineNode"
       << "vtkMRMLMarkupsCurveNode"
       << "vtkMRMLMarkupsClosedCurveNode"
@@ -594,7 +595,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createPointFileTagWidget(const ModuleP
     }
   else
     {
-    QString nodeType = Self::nodeTypeFromMap(Self::PointTypeAttributeToNodeType, type, "vtkMRMLMarkupsFiducialNode");
+    QString nodeType = Self::nodeTypeFromMap(Self::PointTypeAttributeToNodeType, type, "vtkMRMLMarkupsPointListNode");
     widget->setNodeTypes(QStringList(nodeType));
     }
 

--- a/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
@@ -109,13 +109,13 @@ int qSlicerMouseModeToolBarTest1(int argc, char * argv[] )
   CHECK_NOT_NULL(selectionNode);
 
   // add markups/annotation
-  selectionNode->AddNewPlaceNodeClassNameToList("vtkMRMLMarkupsFiducialNode", ":/Icons/MarkupsFiducialMouseModePlace.png", "Point List");
+  selectionNode->AddNewPlaceNodeClassNameToList("vtkMRMLMarkupsPointListNode", ":/Icons/MarkupsFiducialMouseModePlace.png", "Point List");
   selectionNode->AddNewPlaceNodeClassNameToList("vtkMRMLMarkupsCurveNode", ":/Icons/MarkupsCurveMouseModePlace.png", "Curve");
   selectionNode->AddNewPlaceNodeClassNameToList("vtkMRMLAnnotationROINode", ":/Icons/AnnotationROIWithArrow.png", "ROI");
   selectionNode->AddNewPlaceNodeClassNameToList("vtkMRMLAnnotationRulerNode", ":/Icons/AnnotationDistanceWithArrow.png", "Ruler");
 
-  selectionNode->SetReferenceActivePlaceNodeClassName("vtkMRMLMarkupsFiducialNode");
-  selectionNode->SetActivePlaceNodeID("vtkMRMLMarkupsFiducialNode1");
+  selectionNode->SetReferenceActivePlaceNodeClassName("vtkMRMLMarkupsPointListNode");
+  selectionNode->SetActivePlaceNodeID("vtkMRMLMarkupsPointListNode1");
   selectionNode->SetActivePlaceNodePlacementValid(true);
   CHECK_PLACE_ACTION_TEXT("Point List", mouseToolBar);
 
@@ -134,8 +134,8 @@ int qSlicerMouseModeToolBarTest1(int argc, char * argv[] )
   selectionNode->SetActivePlaceNodePlacementValid(true);
   CHECK_PLACE_ACTION_TEXT("Ruler", mouseToolBar);
 
-  selectionNode->SetReferenceActivePlaceNodeClassName("vtkMRMLMarkupsFiducialNode");
-  selectionNode->SetActivePlaceNodeID("vtkMRMLMarkupsFiducialNode1");
+  selectionNode->SetReferenceActivePlaceNodeClassName("vtkMRMLMarkupsPointListNode");
+  selectionNode->SetActivePlaceNodeID("vtkMRMLMarkupsPointListNode1");
   selectionNode->SetActivePlaceNodePlacementValid(true);
   CHECK_PLACE_ACTION_TEXT("Point List", mouseToolBar);
 

--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -62,7 +62,7 @@ qSlicerMouseModeToolBarPrivate::qSlicerMouseModeToolBarPrivate(qSlicerMouseModeT
   this->PlaceWidgetAction = nullptr;
 
   this->InteractionModesActionGroup = nullptr;
-  this->DefaultPlaceClassName = "vtkMRMLMarkupsFiducialNode";
+  this->DefaultPlaceClassName = "vtkMRMLMarkupsPointListNode";
 }
 
 //---------------------------------------------------------------------------

--- a/Docs/developer_guide/python_faq.md
+++ b/Docs/developer_guide/python_faq.md
@@ -60,7 +60,7 @@ head = sampleDataLogic.downloadMRHead()
 volumesLogic = slicer.modules.volumes.logic()
 headLabel = volumesLogic.CreateLabelVolume(slicer.mrmlScene, head, 'head-label')
 
-pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
 pointListNode.AddControlPoint(vtk.vtkVector3d(1,0,5))
 pointListNode.SetName('Seed Point')
 

--- a/Docs/developer_guide/script_repository/markups.md
+++ b/Docs/developer_guide/script_repository/markups.md
@@ -43,7 +43,7 @@ The [qSlicerMarkupsPlaceWidget widget](http://apidocs.slicer.org/master/classqSl
 ```python
 w=slicer.qSlicerMarkupsPlaceWidget()
 w.setMRMLScene(slicer.mrmlScene)
-markupsNodeID = slicer.modules.markups.logic().AddNewFiducialNode()
+markupsNodeID = slicer.modules.markups.logic().AddNewPointListNode()
 w.setCurrentNode(slicer.mrmlScene.GetNodeByID(markupsNodeID))
 # Hide all buttons and only show place button
 w.buttonsVisible=False
@@ -64,7 +64,7 @@ A lower level way to do this is via the selection and interaction nodes:
 
 ```python
 selectionNode = slicer.mrmlScene.GetNodeByID("vtkMRMLSelectionNodeSingleton")
-selectionNode.SetReferenceActivePlaceNodeClassName("vtkMRMLMarkupsFiducialNode")
+selectionNode.SetReferenceActivePlaceNodeClassName("vtkMRMLMarkupsPointListNode")
 interactionNode = slicer.mrmlScene.GetNodeByID("vtkMRMLInteractionNodeSingleton")
 placeModePersistence = 1
 interactionNode.SetPlaceModePersistence(placeModePersistence)
@@ -83,10 +83,10 @@ interactionNode.SetPlaceModePersistence(0)
 
 ### Access to markups point list Properties
 
-Each vtkMRMLMarkupsFiducialNode has a vector of control points in it which can be accessed from python:
+Each vtkMRMLMarkupsPointListNode has a vector of control points in it which can be accessed from python:
 
 ```python
-pointListNode = getNode("vtkMRMLMarkupsFiducialNode1")
+pointListNode = getNode("vtkMRMLMarkupsPointListNode1")
 n = pointListNode.AddControlPoint([4.0, 5.5, -6.0])
 pointListNode.SetNthControlPointLabel(n, "new label")
 # each control point is given a unique id which can be accessed from the superclass level
@@ -394,8 +394,8 @@ To activate control point placement mode for a point list, both interaction mode
 ```python
 interactionNode = slicer.app.applicationLogic().GetInteractionNode()
 selectionNode = slicer.app.applicationLogic().GetSelectionNode()
-selectionNode.SetReferenceActivePlaceNodeClassName("vtkMRMLMarkupsFiducialNode")
-pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+selectionNode.SetReferenceActivePlaceNodeClassName("vtkMRMLMarkupsPointListNode")
+pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
 selectionNode.SetActivePlaceNodeID(pointListNode.GetID())
 interactionNode.SetCurrentInteractionMode(interactionNode.Place)
 ```
@@ -404,7 +404,7 @@ Alternatively, *qSlicerMarkupsPlaceWidget* widget can be used to initiate markup
 
 ```python
 # Temporary markups point list node
-pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
 
 def placementModeChanged(active):
   print("Placement: " +("active" if active else "inactive"))
@@ -465,7 +465,7 @@ def onMarkupEndInteraction(caller, event):
   movingMarkupIndex = markupsNode.GetDisplayNode().GetActiveControlPoint()
   logging.info("End interaction: point ID = {0}, slice view = {1}".format(movingMarkupIndex, sliceView))
 
-pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
 pointListNode.AddControlPoint([0,0,0])
 pointListNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointModifiedEvent, onMarkupChanged)
 pointListNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointStartInteractionEvent, onMarkupStartInteraction)

--- a/Docs/developer_guide/script_repository/models.md
+++ b/Docs/developer_guide/script_repository/models.md
@@ -109,7 +109,7 @@ modelPointValues = modelNode.GetPolyData().GetPointData().GetArray("Normals")
 pointListNode = slicer.mrmlScene.GetFirstNodeByName("F")
 
 if not pointListNode:
-  pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode","F")
+  pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode","F")
 
 pointsLocator = vtk.vtkPointLocator() # could try using vtk.vtkStaticPointLocator() if need to optimize
 pointsLocator.SetDataSet(modelNode.GetPolyData())
@@ -197,7 +197,7 @@ def onPointsModified(observer=None, eventid=None):
 # Initial update
 onPointsModified()
 # Automatic update each time when a markup point is modified
-pointListNodeObserverTag = markupsNode.AddObserver(slicer.vtkMRMLMarkupsFiducialNode.PointModifiedEvent, onPointsModified)
+pointListNodeObserverTag = markupsNode.AddObserver(slicer.vtkMRMLMarkupsPointListNode.PointModifiedEvent, onPointsModified)
 
 # To stop updating selection, run this:
 # pointListNode.RemoveObserver(pointListNodeObserverTag)

--- a/Docs/developer_guide/script_repository/segmentations.md
+++ b/Docs/developer_guide/script_repository/segmentations.md
@@ -421,7 +421,7 @@ Show in the console names of segments visible at a markups control point positio
 
 ```python
 segmentationNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLSegmentationNode")
-pointListNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLMarkupsFiducialNode")
+pointListNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLMarkupsPointListNode")
 sliceViewLabel = "Red"  # any slice view where segmentation node is visible works
 
 def printSegmentNames(unused1=None, unused2=None):
@@ -585,7 +585,7 @@ segStatLogic.computeStatistics()
 stats = segStatLogic.getStatistics()
 
 # Place a markup point in each centroid
-pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+pointListNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode")
 pointListNode.CreateDefaultDisplayNodes()
 for segmentId in stats["SegmentIDs"]:
   centroid_ras = stats[segmentId,"LabelmapSegmentStatisticsPlugin.centroid_ras"]

--- a/Modules/CLI/ACPCTransform/ACPCTransform.cxx
+++ b/Modules/CLI/ACPCTransform/ACPCTransform.cxx
@@ -20,7 +20,7 @@
 #include <vtkMRMLTransformStorageNode.h>
 
 // Markups includes
-#include <vtkMRMLMarkupsFiducialNode.h>
+#include <vtkMRMLMarkupsPointListNode.h>
 #include <vtkMRMLMarkupsJsonStorageNode.h>
 #include <vtkMRMLMarkupsLineNode.h>
 
@@ -55,7 +55,7 @@ int main(int argc, char * argv[])
       }
     }
 
-  vtkNew<vtkMRMLMarkupsFiducialNode> midlinePointsNode;
+  vtkNew<vtkMRMLMarkupsPointListNode> midlinePointsNode;
   if (!Midline.empty())
     {
     vtkNew<vtkMRMLMarkupsJsonStorageNode> storageNode;

--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.cxx
@@ -11,7 +11,7 @@
 #include <vtkTable.h>
 
 // Markups includes
-#include <vtkMRMLMarkupsFiducialNode.h>
+#include <vtkMRMLMarkupsPointListNode.h>
 #include <vtkMRMLMarkupsFiducialStorageNode.h>
 
 int main(int argc, char* argv[])
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
     {
     // read the input seeds file
     std::cout << "Have an input seeds file with name " << seedsFile.c_str() << std::endl;
-    vtkNew<vtkMRMLMarkupsFiducialNode> fiducialNode;
+    vtkNew<vtkMRMLMarkupsPointListNode> fiducialNode;
     vtkNew<vtkMRMLMarkupsFiducialStorageNode> fiducialStorageNode;
     fiducialStorageNode->SetFileName(seedsFile.c_str());
     fiducialStorageNode->ReadData(fiducialNode.GetPointer());
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
       }
     }
   // copy the seeds list
-  vtkNew<vtkMRMLMarkupsFiducialNode> copiedFiducialNode;
+  vtkNew<vtkMRMLMarkupsPointListNode> copiedFiducialNode;
   // set the node name so that fiducials have names that don't just
   // start with -1, -2 etc
   copiedFiducialNode->SetName("seedsCopy");

--- a/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.cxx
+++ b/Modules/Loadable/CropVolume/Logic/vtkSlicerCropVolumeLogic.cxx
@@ -30,7 +30,7 @@
 #include <vtkMRMLDiffusionWeightedVolumeDisplayNode.h>
 #include <vtkMRMLLabelMapVolumeNode.h>
 #include <vtkMRMLLinearTransformNode.h>
-#include <vtkMRMLMarkupsFiducialNode.h>
+#include <vtkMRMLMarkupsPointListNode.h>
 #include <vtkMRMLMarkupsROINode.h>
 #include <vtkMRMLVectorVolumeNode.h>
 #include <vtkMRMLVectorVolumeDisplayNode.h>
@@ -590,7 +590,7 @@ int vtkSlicerCropVolumeLogic::CropInterpolated(vtkMRMLDisplayableNode* roi, vtkM
   double outputOrigin_RAS[4] = { 0.0, 0.0, 0.0, 1.0 };
   outputIJKToRAS->MultiplyPoint(outputOrigin_IJK, outputOrigin_RAS);
 
-  vtkNew<vtkMRMLMarkupsFiducialNode> originMarkupNode;
+  vtkNew<vtkMRMLMarkupsPointListNode> originMarkupNode;
   // Markups are transformed from RAS to LPS by the CLI infrastructure, so we pass them in RAS
   originMarkupNode->AddControlPoint(outputOrigin_RAS);
   this->GetMRMLScene()->AddNode(originMarkupNode.GetPointer());

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -34,6 +34,7 @@
 #include "vtkMRMLMarkupsPlaneDisplayNode.h"
 #include "vtkMRMLMarkupsPlaneJsonStorageNode.h"
 #include "vtkMRMLMarkupsPlaneNode.h"
+#include "vtkMRMLMarkupsPointListNode.h"
 #include "vtkMRMLMarkupsROIDisplayNode.h"
 #include "vtkMRMLMarkupsROIJsonStorageNode.h"
 #include "vtkMRMLMarkupsROINode.h"
@@ -386,10 +387,13 @@ void vtkSlicerMarkupsLogic::RegisterNodes()
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsJsonStorageNode>::New());
 
   // NOTE: the order of registration determines the order of the create push buttons in the GUI
+  vtkNew<vtkMRMLMarkupsPointListNode> pointListNode;
+  vtkNew<vtkSlicerPointsWidget> pointsWidget;
+  this->RegisterMarkupsNode(pointListNode, pointsWidget);
 
   vtkNew<vtkMRMLMarkupsFiducialNode> fiducialNode;
-  vtkNew<vtkSlicerPointsWidget> pointsWidget;
-  this->RegisterMarkupsNode(fiducialNode, pointsWidget);
+  vtkNew<vtkSlicerPointsWidget> pointsWidget2;
+  this->RegisterMarkupsNode(fiducialNode, pointsWidget2);
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsFiducialDisplayNode>::New());
   scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLMarkupsFiducialStorageNode>::New());
 

--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -96,12 +96,12 @@ public:
   /// node.
   std::string AddNewDisplayNodeForMarkupsNode(vtkMRMLNode *mrmlNode);
 
-  /// Create a new markups fiducial node and associated display node, adding both to
+  /// Create a new markups point list node and associated display node, adding both to
   /// the scene. If the scene argument is null use the scene set on the logic
   /// class, and also make it the active on on the selection node, otherwise
   /// add to the passed scene.
   /// On success, return the id, on failure return an empty string.
-  std::string AddNewFiducialNode(const char *name = "F", vtkMRMLScene *scene = nullptr);
+  std::string AddNewPointListNode(const char *name = "F", vtkMRMLScene *scene = nullptr);
 
   /// Create a new markups node and associated display node, adding both to the scene.
   /// For ROI nodes, each new node will have a unique color.
@@ -296,7 +296,14 @@ public:
   //-----------------------------------------------------------
   // All public methods below are deprecated
   //
-  // These methods are deprecated because they use old terms (markup instead of control point),
+  // These methods are deprecated because they use old terms (markup/fiducial instead of control point),
+
+  /// \deprecated Use AddNewPointListNode instead.
+  std::string AddNewFiducialNode(const char *name = "F", vtkMRMLScene *scene = nullptr)
+    {
+    vtkWarningMacro("vtkSlicerMarkupsLogic::AddNewFiducialNode method is deprecated, please use AddNewPointListNode instead");
+    return this->AddNewPointListNode(name, scene);
+    }
 
   /// \deprecated Use CopyNthControlPointToNewList instead.
   bool CopyNthMarkupToNewList(int n, vtkMRMLMarkupsNode *markupsNode,

--- a/Modules/Loadable/Markups/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Markups/MRML/CMakeLists.txt
@@ -23,6 +23,7 @@ set(${KIT}_SRCS
   vtkMRML${MODULE_NAME}JsonStorageNode.cxx
   vtkMRML${MODULE_NAME}LineNode.cxx
   vtkMRML${MODULE_NAME}Node.cxx
+  vtkMRML${MODULE_NAME}PointListNode.cxx
   vtkMRML${MODULE_NAME}PlaneDisplayNode.cxx
   vtkMRML${MODULE_NAME}PlaneJsonStorageNode.cxx
   vtkMRML${MODULE_NAME}PlaneNode.cxx

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -24,7 +24,7 @@
 // Markups includes
 #include "vtkSlicerMarkupsModuleMRMLExport.h"
 #include "vtkMRMLMarkupsDisplayNode.h"
-#include "vtkMRMLMarkupsNode.h"
+#include "vtkMRMLMarkupsPointListNode.h"
 
 /// \brief MRML node to represent a fiducial markup
 /// Fiducial Markups nodes contain a list of control points.
@@ -35,17 +35,13 @@
 /// but performance is optimal if there are less than 2000 points.
 ///
 /// \ingroup Slicer_QtModules_Markups
-class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsFiducialNode : public vtkMRMLMarkupsNode
+class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsFiducialNode : public vtkMRMLMarkupsPointListNode
 {
 public:
   static vtkMRMLMarkupsFiducialNode *New();
   vtkTypeMacro(vtkMRMLMarkupsFiducialNode,vtkMRMLMarkupsNode);
   /// Print out the node information to the output stream
   void PrintSelf(ostream& os, vtkIndent indent) override;
-
-  const char* GetIcon() override {return ":/Icons/MarkupsFiducial.png";}
-  const char* GetAddIcon() override {return ":/Icons/MarkupsFiducialMouseModePlace.png";}
-  const char* GetPlaceAddIcon() override {return ":/Icons/MarkupsFiducialMouseModePlaceAdd.png";}
 
   //--------------------------------------------------------------------------
   // MRMLNode methods
@@ -58,12 +54,6 @@ public:
 
   /// Get markup type internal name
   const char* GetMarkupType() override {return "Fiducial";};
-
-  // Get markup type GUI display name
-  const char* GetTypeDisplayName() override {return "Point List";};
-
-  /// Get markup short name
-  const char* GetDefaultNodeNamePrefix() override {return "F";};
 
   /// Read node attributes from XML file
   void ReadXMLAttributes( const char** atts) override;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -283,6 +283,7 @@ void vtkMRMLMarkupsFiducialStorageNode::Copy(vtkMRMLNode *anode)
 bool vtkMRMLMarkupsFiducialStorageNode::CanReadInReferenceNode(vtkMRMLNode *refNode)
 {
   return refNode->IsA("vtkMRMLMarkupsFiducialNode") ||
+         refNode->IsA("vtkMRMLMarkupsPointListNode") ||
          refNode->IsA("vtkMRMLMarkupsLineNode") ||
          refNode->IsA("vtkMRMLMarkupsAngleNode") ||
          refNode->IsA("vtkMRMLMarkupsCurveNode") ||

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPointListNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPointListNode.cxx
@@ -1,0 +1,114 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// MRML includes
+#include "vtkMRMLMarkupsFiducialDisplayNode.h"
+#include "vtkMRMLMarkupsPointListNode.h"
+#include "vtkMRMLMarkupsFiducialStorageNode.h"
+#include "vtkMRMLScene.h"
+
+// VTK includes
+#include <vtkBoundingBox.h>
+#include <vtkNew.h>
+#include <vtkObjectFactory.h>
+
+// STD includes
+#include <sstream>
+
+//----------------------------------------------------------------------------
+vtkMRMLNodeNewMacro(vtkMRMLMarkupsPointListNode);
+
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsPointListNode::vtkMRMLMarkupsPointListNode() = default;
+
+//----------------------------------------------------------------------------
+vtkMRMLMarkupsPointListNode::~vtkMRMLMarkupsPointListNode() = default;
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPointListNode::WriteXML(ostream& of, int nIndent)
+{
+  Superclass::WriteXML(of,nIndent);
+
+  vtkMRMLWriteXMLBeginMacro(of);
+  vtkMRMLWriteXMLIntMacro(maximumNumberOfControlPoints, MaximumNumberOfControlPoints);
+  vtkMRMLWriteXMLIntMacro(requiredNumberOfControlPoints, RequiredNumberOfControlPoints);
+  vtkMRMLWriteXMLEndMacro();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPointListNode::ReadXMLAttributes(const char** atts)
+{
+  MRMLNodeModifyBlocker blocker(this);
+
+  Superclass::ReadXMLAttributes(atts);
+
+  vtkMRMLReadXMLBeginMacro(atts);
+  vtkMRMLReadXMLIntMacro(maximumNumberOfControlPoints, MaximumNumberOfControlPoints);
+  vtkMRMLReadXMLIntMacro(requiredNumberOfControlPoints, RequiredNumberOfControlPoints);
+  vtkMRMLReadXMLEndMacro();
+
+  // In scenes created by Slicer version version 4.13.0 revision 30287 (built 2021-10-05).
+  // The value used to represent unlimited control points has been changed to -1.
+  if (this->MaximumNumberOfControlPoints == 0)
+    {
+    this->MaximumNumberOfControlPoints = -1;
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPointListNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
+{
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+
+  vtkMRMLCopyBeginMacro(anode);
+  vtkMRMLCopyIntMacro(MaximumNumberOfControlPoints);
+  vtkMRMLCopyIntMacro(RequiredNumberOfControlPoints);
+  vtkMRMLCopyEndMacro();
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLMarkupsPointListNode::PrintSelf(ostream& os, vtkIndent indent)
+{
+  Superclass::PrintSelf(os,indent);
+}
+
+
+//-------------------------------------------------------------------------
+void vtkMRMLMarkupsPointListNode::CreateDefaultDisplayNodes()
+{
+  if (this->GetDisplayNode() != nullptr &&
+    vtkMRMLMarkupsDisplayNode::SafeDownCast(this->GetDisplayNode()) != nullptr)
+    {
+    // display node already exists
+    return;
+    }
+  if (this->GetScene() == nullptr)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsPointListNode::CreateDefaultDisplayNodes failed: scene is invalid");
+    return;
+    }
+  vtkMRMLMarkupsFiducialDisplayNode* dispNode = vtkMRMLMarkupsFiducialDisplayNode::SafeDownCast(
+    this->GetScene()->AddNewNodeByClass("vtkMRMLMarkupsFiducialDisplayNode"));
+  if (!dispNode)
+    {
+    vtkErrorMacro("vtkMRMLMarkupsPointListNode::CreateDefaultDisplayNodes failed: unable to create vtkMRMLMarkupsFiducialDisplayNode");
+    return;
+    }
+  this->SetAndObserveDisplayNodeID(dispNode->GetID());
+}

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPointListNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPointListNode.h
@@ -1,0 +1,104 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Portions (c) Copyright Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkMRMLMarkupsPointListNode_h
+#define __vtkMRMLMarkupsPointListNode_h
+
+// MRML includes
+#include "vtkMRMLDisplayableNode.h"
+
+// Markups includes
+#include "vtkSlicerMarkupsModuleMRMLExport.h"
+#include "vtkMRMLMarkupsDisplayNode.h"
+#include "vtkMRMLMarkupsNode.h"
+
+/// \brief MRML node to represent a fiducial markup
+/// Fiducial Markups nodes contain a list of control points.
+/// Visualization parameters are set in the vtkMRMLMarkupsDisplayNode class.
+///
+/// Markups is intended to be used for manual marking/editing of point positions.
+/// There is no specific limit for number of points that can be added to a list,
+/// but performance is optimal if there are less than 2000 points.
+///
+/// \ingroup Slicer_QtModules_Markups
+class  VTK_SLICER_MARKUPS_MODULE_MRML_EXPORT vtkMRMLMarkupsPointListNode : public vtkMRMLMarkupsNode
+{
+public:
+  static vtkMRMLMarkupsPointListNode *New();
+  vtkTypeMacro(vtkMRMLMarkupsPointListNode,vtkMRMLMarkupsNode);
+  /// Print out the node information to the output stream
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  const char* GetIcon() override {return ":/Icons/MarkupsFiducial.png";}
+  const char* GetAddIcon() override {return ":/Icons/MarkupsFiducialMouseModePlace.png";}
+  const char* GetPlaceAddIcon() override {return ":/Icons/MarkupsFiducialMouseModePlaceAdd.png";}
+
+  //--------------------------------------------------------------------------
+  // MRMLNode methods
+  //--------------------------------------------------------------------------
+
+  vtkMRMLNode* CreateNodeInstance() override;
+
+  /// Get node XML tag name (like Volume, Model)
+  const char* GetNodeTagName() override {return "MarkupsPointList";}
+
+  /// Get markup type internal name
+  const char* GetMarkupType() override {return "PointList";};
+
+  // Get markup type GUI display name
+  const char* GetTypeDisplayName() override {return "Point List";};
+
+  /// Get markup short name
+  const char* GetDefaultNodeNamePrefix() override {return "F";};
+
+  /// Read node attributes from XML file
+  void ReadXMLAttributes( const char** atts) override;
+
+  /// Write this node's information to a MRML file in XML format.
+  void WriteXML(ostream& of, int indent) override;
+
+  /// Copy node content (excludes basic data, such as name and node references).
+  /// \sa vtkMRMLNode::CopyContent
+  vtkMRMLCopyContentMacro(vtkMRMLMarkupsPointListNode);
+
+  /// Maximum number of control points limits the number of markups allowed in the node.
+  /// If maximum number of control points is set to 0 then no it means there
+  /// is no limit (this is the default value).
+  /// The value is an indication to the user interface and does not affect
+  /// prevent adding markups to a node programmatically.
+  /// If value is set to lower value than the number of markups in the node, then
+  /// existing markups are not deleted.
+  /// 2 for line, and 3 for angle Markups
+  vtkSetMacro(MaximumNumberOfControlPoints, int);
+
+  /// Set the number of control points that are required for defining this widget.
+  /// Interaction mode remains in "place" mode until this number is reached.
+  /// If the number is set to 0 then no it means there is no preference (this is the default value).
+  vtkSetMacro(RequiredNumberOfControlPoints, int);
+
+  /// Create and observe default display node(s)
+  void CreateDefaultDisplayNodes() override;
+
+protected:
+  vtkMRMLMarkupsPointListNode();
+  ~vtkMRMLMarkupsPointListNode() override;
+  vtkMRMLMarkupsPointListNode(const vtkMRMLMarkupsPointListNode&);
+  void operator=(const vtkMRMLMarkupsPointListNode&);
+
+};
+
+#endif

--- a/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
+++ b/Modules/Loadable/Markups/SubjectHierarchyPlugins/qSlicerSubjectHierarchyMarkupsPlugin.cxx
@@ -48,6 +48,7 @@
 #include <vtkMRMLDisplayNode.h>
 #include <vtkMRMLMarkupsDisplayNode.h>
 #include <vtkMRMLMarkupsPlaneDisplayNode.h>
+#include <vtkMRMLMarkupsPointListNode.h>
 #include <vtkMRMLMarkupsROIDisplayNode.h>
 #include <vtkMRMLMarkupsNode.h>
 #include <vtkMRMLScene.h>

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkMarkupsAnnotationSceneTest.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkMarkupsAnnotationSceneTest.cxx
@@ -18,7 +18,7 @@
 // Markups includes
 #include "vtkMRMLMarkupsFiducialDisplayNode.h"
 #include "vtkMRMLMarkupsFiducialStorageNode.h"
-#include "vtkMRMLMarkupsFiducialNode.h"
+#include "vtkMRMLMarkupsPointListNode.h"
 #include "vtkSlicerMarkupsLogic.h"
 
 // Annotation includes
@@ -127,30 +127,30 @@ int vtkMarkupsAnnotationSceneTest(int argc, char * argv[] )
   markupsLogic->ConvertAnnotationFiducialsToMarkups();
 
   //
-  // test that we have 1 markup fiducial list and no annotation fiducials
+  // test that we have 1 markup point list and no annotation fiducials
   //
   int numAnnotationNodes = scene->GetNumberOfNodesByClass("vtkMRMLAnnotationFiducialNode");
-  int numMarkupsNodes = scene->GetNumberOfNodesByClass("vtkMRMLMarkupsFiducialNode");
+  int numMarkupsNodes = scene->GetNumberOfNodesByClass("vtkMRMLMarkupsPointListNode");
   if (numAnnotationNodes != 0 ||
       numMarkupsNodes != 1)
     {
     std::cerr << "Failed to translate annotation fiducial nodes "
-              << " into markup fiducial nodes, still have "
+              << " into markup point list nodes, still have "
               << numAnnotationNodes
               << " annotation fiducial nodes in the scene, with "
-              << numMarkupsNodes << " markups fiducial nodes." << std::endl;
+              << numMarkupsNodes << " markups point list nodes." << std::endl;
     return EXIT_FAILURE;
     }
   std::vector<vtkMRMLNode *> nodes;
-  scene->GetNodesByClass("vtkMRMLMarkupsFiducialNode", nodes);
+  scene->GetNodesByClass("vtkMRMLMarkupsPointListNode", nodes);
   if (nodes.size() != 1)
     {
-    std::cerr << "Failed to get the markup fiducial nodes from the read in scene, collection size = " << nodes.size() << std::endl;
+    std::cerr << "Failed to get the markup point list nodes from the read in scene, collection size = " << nodes.size() << std::endl;
     return EXIT_FAILURE;
     }
 
   // check the control point positions
-  vtkMRMLMarkupsFiducialNode *mfnode = vtkMRMLMarkupsFiducialNode::SafeDownCast(nodes[0]);
+  vtkMRMLMarkupsPointListNode *mfnode = vtkMRMLMarkupsPointListNode::SafeDownCast(nodes[0]);
   if (!mfnode)
     {
     std::cerr << "Failed to get first markups fiducial node" << std::endl;

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest1.cxx
@@ -38,7 +38,7 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
 
   // test without a scene
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
-  std::string id = logic1->AddNewFiducialNode();
+  std::string id = logic1->AddNewPointListNode();
   TESTING_OUTPUT_ASSERT_ERRORS_END();
   // should be invalid if scene is not set
   CHECK_STD_STRING(id, "");
@@ -52,12 +52,12 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
   // test with a scene
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
   logic1->SetMRMLScene(scene);
-  TESTING_OUTPUT_ASSERT_ERRORS(17); // error messages are expected to be reported due to lack of selection node
+  TESTING_OUTPUT_ASSERT_ERRORS(19); // error messages are expected to be reported due to lack of selection node
   TESTING_OUTPUT_ASSERT_ERRORS_END();
 
   const char *testName = "Test node 2";
   TESTING_OUTPUT_ASSERT_ERRORS_BEGIN();
-  id = logic1->AddNewFiducialNode(testName);
+  id = logic1->AddNewPointListNode(testName);
   TESTING_OUTPUT_ASSERT_ERRORS_END(); // error is expected to be reported due to lack of selection node
   CHECK_STD_STRING_DIFFERENT(id, "");
 
@@ -183,7 +183,7 @@ int vtkSlicerMarkupsLogicTest1(int , char * [] )
     }
 
   // test setting active list id
-  std::string newID = logic1->AddNewFiducialNode("New list", scene);
+  std::string newID = logic1->AddNewPointListNode("New list", scene);
   activeListID = logic1->GetActiveListID();
   CHECK_STD_STRING(activeListID, newID);
 

--- a/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest3.cxx
+++ b/Modules/Loadable/Markups/Testing/Cxx/vtkSlicerMarkupsLogicTest3.cxx
@@ -23,7 +23,7 @@
 
 // Markups includes
 #include "vtkMRMLMarkupsNode.h"
-#include "vtkMRMLMarkupsFiducialNode.h"
+#include "vtkMRMLMarkupsPointListNode.h"
 #include "vtkSlicerMarkupsLogic.h"
 
 // MRML includes
@@ -92,25 +92,25 @@ int vtkSlicerMarkupsLogicTest3(int , char * [] )
   logic1->ConvertAnnotationFiducialsToMarkups();
 
   int numAnnotationFiducials = scene->GetNumberOfNodesByClass("vtkMRMLAnnotationFiducialNode");
-  int numMarkupsFiducials = scene->GetNumberOfNodesByClass("vtkMRMLMarkupsFiducialNode");
+  int numMarkupsPointLists = scene->GetNumberOfNodesByClass("vtkMRMLMarkupsPointListNode");
   if (numAnnotationFiducials != 0 ||
-      numMarkupsFiducials != 2)
+      numMarkupsPointLists != 2)
     {
     std::cerr << "Failed to convert 15 annotation fiducials in two hierarchies "
-    << " to 2 markup lists, have " << numAnnotationFiducials
-    << " annotation fiduicals and " << numMarkupsFiducials
-    << " markups fiducial lists" << std::endl;
+    << " to 2 markups point lists, have " << numAnnotationFiducials
+    << " annotation fiduicals and " << numMarkupsPointLists
+    << " markups point lists" << std::endl;
     return EXIT_FAILURE;
     }
   else
     {
-    std::cout << "Converted annotation fiducials to " << numMarkupsFiducials
-              << " markups fiducial lists" << std::endl;
+    std::cout << "Converted annotation fiducials to " << numMarkupsPointLists
+              << " markups point lists" << std::endl;
     }
 //  vtkIndent indent;
-//  for (int n = 0; n < numMarkupsFiducials; ++n)
+//  for (int n = 0; n < numMarkupsPointLists; ++n)
 //    {
-//    vtkMRMLNode *mrmlNode = scene->GetNthNodeByClass(n, "vtkMRMLMarkupsFiducialNode");
+//    vtkMRMLNode *mrmlNode = scene->GetNthNodeByClass(n, "vtkMRMLMarkupsPointListNode");
 //    std::cout << "\nConverted Markups node " << n << ":" << std::endl;
 //    mrmlNode->PrintSelf(std::cout, indent);
 //    }
@@ -122,27 +122,27 @@ int vtkSlicerMarkupsLogicTest3(int , char * [] )
   applicationLogic->Delete();
 
   // check the second list
-  vtkMRMLNode *mrmlNode = scene->GetNthNodeByClass(1, "vtkMRMLMarkupsFiducialNode");
+  vtkMRMLNode *mrmlNode = scene->GetNthNodeByClass(1, "vtkMRMLMarkupsPointListNode");
   if (mrmlNode)
     {
-    vtkMRMLMarkupsFiducialNode *markupsFid = vtkMRMLMarkupsFiducialNode::SafeDownCast(mrmlNode);
-    if (markupsFid)
+    vtkMRMLMarkupsPointListNode *markupsPointList = vtkMRMLMarkupsPointListNode::SafeDownCast(mrmlNode);
+    if (markupsPointList)
       {
-      std::string desc = markupsFid->GetNthControlPointDescription(3);
+      std::string desc = markupsPointList->GetNthControlPointDescription(3);
       if (desc.compare("testing description") != 0)
         {
         std::cerr << "Failed to get the expected description on markup 3, got: "
                   << desc.c_str() << std::endl;
         return EXIT_FAILURE;
         }
-      std::string assocNodeID = markupsFid->GetNthControlPointAssociatedNodeID(4);
+      std::string assocNodeID = markupsPointList->GetNthControlPointAssociatedNodeID(4);
       if (assocNodeID.compare("vtkMRMLScalarVolumeNode4") != 0)
         {
         std::cerr << "Failed to get the expected associated node id on markup 4, got: "
                   << assocNodeID.c_str() << std::endl;
         return EXIT_FAILURE;
         }
-      vtkVector3d posVector = markupsFid->GetNthControlPointPositionVector(0);
+      vtkVector3d posVector = markupsPointList->GetNthControlPointPositionVector(0);
       double* pos = posVector.GetData();
       double expectedPos[3] = {5.5, -6.6, 0.0};
       if (vtkMath::Distance2BetweenPoints(pos, expectedPos) > 0.01)
@@ -151,7 +151,7 @@ int vtkSlicerMarkupsLogicTest3(int , char * [] )
                   << pos[0] << "," << pos[1] << "," << pos[2] << std::endl;
         return EXIT_FAILURE;
         }
-      vtkMRMLMarkupsDisplayNode *dispNode = markupsFid->GetMarkupsDisplayNode();
+      vtkMRMLMarkupsDisplayNode *dispNode = markupsPointList->GetMarkupsDisplayNode();
       if (dispNode)
         {
         double col[3];
@@ -180,7 +180,7 @@ int vtkSlicerMarkupsLogicTest3(int , char * [] )
       }
     else
       {
-      std::cerr << "Unable to get second markups fiducial node for testing!" << std::endl;
+      std::cerr << "Unable to get second markups point list node for testing!" << std::endl;
       return EXIT_FAILURE;
       }
     }

--- a/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/AddManyMarkupsFiducialTest.py
@@ -50,6 +50,7 @@ class AddManyMarkupsFiducialTestWidget(ScriptedLoadableModuleWidget):
     #
     self.nodeTypeComboBox = qt.QComboBox()
     self.nodeTypeComboBox.addItem("vtkMRMLMarkupsFiducialNode")
+    self.nodeTypeComboBox.addItem("vtkMRMLMarkupsPointListNode")
     self.nodeTypeComboBox.addItem("vtkMRMLMarkupsLineNode")
     self.nodeTypeComboBox.addItem("vtkMRMLMarkupsAngleNode")
     self.nodeTypeComboBox.addItem("vtkMRMLMarkupsCurveNode")
@@ -234,10 +235,10 @@ class AddManyMarkupsFiducialTestTest(ScriptedLoadableModuleTest):
     m.moduleSelector().selectModule('Welcome')
 
     logic = AddManyMarkupsFiducialTestLogic()
-    logic.run('vtkMRMLMarkupsFiducialNode', numberOfNodes = 1, numberOfControlPoints=100, rOffset=0)
+    logic.run('vtkMRMLMarkupsPointListNode', numberOfNodes = 1, numberOfControlPoints=100, rOffset=0)
 
     self.delayDisplay("Now running it while the Markups Module is open")
     m.moduleSelector().selectModule('Markups')
-    logic.run('vtkMRMLMarkupsFiducialNode', numberOfNodes = 1, numberOfControlPoints=100, rOffset=100)
+    logic.run('vtkMRMLMarkupsPointListNode', numberOfNodes = 1, numberOfControlPoints=100, rOffset=100)
 
     self.delayDisplay('Test passed!')

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInCompareViewersSelfTest.py
@@ -106,7 +106,7 @@ class MarkupsInCompareViewersSelfTestLogic(ScriptedLoadableModuleLogic):
     # create a control points list
     displayNode = slicer.vtkMRMLMarkupsDisplayNode()
     slicer.mrmlScene.AddNode(displayNode)
-    fidNode = slicer.vtkMRMLMarkupsFiducialNode()
+    fidNode = slicer.vtkMRMLMarkupsPointListNode()
     slicer.mrmlScene.AddNode(fidNode)
     fidNode.SetAndObserveDisplayNodeID(displayNode.GetID())
 

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsInViewsSelfTest.py
@@ -171,7 +171,7 @@ class MarkupsInViewsSelfTestLogic(ScriptedLoadableModuleLogic):
     lm.setLayout(2)
 
     # create a control points list
-    fidNode = slicer.vtkMRMLMarkupsFiducialNode()
+    fidNode = slicer.vtkMRMLMarkupsPointListNode()
     slicer.mrmlScene.AddNode(fidNode)
     fidNode.CreateDefaultDisplayNodes()
     displayNode = fidNode.GetDisplayNode()

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestManyLists.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestManyLists.py
@@ -1,7 +1,7 @@
 # Test restoring a scene with multiple lists with different number control points
 
 # first control point list
-fidNode1 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "FidNode1")
+fidNode1 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode", "FidNode1")
 fidNode1.CreateDefaultDisplayNodes()
 coords = [0.0, 0.0, 0.0]
 numFidsInList1 = 5
@@ -12,7 +12,7 @@ for i in range(numFidsInList1):
   coords[2] += 1.0
 
 # second control point list
-fidNode2 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "FidNode2")
+fidNode2 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode", "FidNode2")
 fidNode2.CreateDefaultDisplayNodes()
 numFidsInList2 = 10
 for i in range(numFidsInList2):
@@ -22,13 +22,13 @@ for i in range(numFidsInList2):
   coords[2] += 3.0
 
 # Create scene view
-numFidNodesBeforeStore = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsFiducialNode')
+numFidNodesBeforeStore = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsPointListNode')
 sv = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSceneViewNode")
 sv.StoreScene()
 
 # add a third list that will get removed on restore
 # second control point list
-fidNode3 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", "FidNode3")
+fidNode3 = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode", "FidNode3")
 fidNode3.CreateDefaultDisplayNodes()
 numFidsInList3 = 2
 for i in range(numFidsInList3):
@@ -40,7 +40,7 @@ for i in range(numFidsInList3):
 # Restore scene view
 sv.RestoreScene()
 
-numFidNodesAfterRestore = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsFiducialNode')
+numFidNodesAfterRestore = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsPointListNode')
 if numFidNodesAfterRestore != numFidNodesBeforeStore:
   print("After restoring the scene, expected ", numFidNodesBeforeStore, " control points nodes, but have ", numFidNodesAfterRestore)
   exceptionMessage = "After restoring the scene, expected " + str(numFidNodesBeforeStore) + " control points nodes, but have " + str(numFidNodesAfterRestore)

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestSimple.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsSceneViewRestoreTestSimple.py
@@ -4,7 +4,7 @@
 displayNode = slicer.vtkMRMLMarkupsDisplayNode()
 slicer.mrmlScene.AddNode(displayNode)
 
-fid = slicer.vtkMRMLMarkupsFiducialNode()
+fid = slicer.vtkMRMLMarkupsPointListNode()
 slicer.mrmlScene.AddNode(fid)
 
 fid.SetAndObserveDisplayNodeID(displayNode.GetID())
@@ -27,7 +27,7 @@ print(f"After storing the scene, set control point coords to {afterStoreSceneCoo
 
 sv.RestoreScene()
 
-fidAfterRestore =  slicer.mrmlScene.GetNodeByID("vtkMRMLMarkupsFiducialNode1")
+fidAfterRestore =  slicer.mrmlScene.GetNodeByID("vtkMRMLMarkupsPointListNode1")
 
 coords = [0,0,0]
 fidAfterRestore.GetNthControlPointPosition(0,coords)

--- a/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/PluggableMarkupsSelfTest.py
@@ -121,6 +121,7 @@ class PluggableMarkupsSelfTestLogic(ScriptedLoadableModuleLogic):
       slicer.vtkMRMLMarkupsClosedCurveNode(): slicer.vtkSlicerCurveWidget(),
       slicer.vtkMRMLMarkupsCurveNode(): slicer.vtkSlicerCurveWidget(),
       slicer.vtkMRMLMarkupsFiducialNode(): slicer.vtkSlicerPointsWidget(),
+      slicer.vtkMRMLMarkupsPointListNode(): slicer.vtkSlicerPointsWidget(),
       slicer.vtkMRMLMarkupsLineNode(): slicer.vtkSlicerLineWidget(),
       slicer.vtkMRMLMarkupsPlaneNode(): slicer.vtkSlicerPlaneWidget(),
       slicer.vtkMRMLMarkupsROINode(): slicer.vtkSlicerROIWidget(),

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerSimpleMarkupsWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerSimpleMarkupsWidget.ui
@@ -50,6 +50,7 @@
        </property>
        <property name="nodeTypes">
         <stringlist>
+         <string>vtkMRMLMarkupsPointListNode</string>
          <string>vtkMRMLMarkupsFiducialNode</string>
         </stringlist>
        </property>

--- a/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
+++ b/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py
@@ -82,10 +82,10 @@ class MarkupsWidgetsSelfTestTest(ScriptedLoadableModuleTest):
     self.markupsLogic = slicer.modules.markups.logic()
 
     # Create sample markups node
-    self.markupsNode1 = slicer.mrmlScene.GetNodeByID(self.markupsLogic.AddNewFiducialNode())
+    self.markupsNode1 = slicer.mrmlScene.GetNodeByID(self.markupsLogic.AddNewPointListNode())
     self.markupsNode1.SetName(self.sampleMarkupsNodeName1)
 
-    self.markupsNode2 = slicer.mrmlScene.GetNodeByID(self.markupsLogic.AddNewFiducialNode())
+    self.markupsNode2 = slicer.mrmlScene.GetNodeByID(self.markupsLogic.AddNewPointListNode())
     self.markupsNode2.SetName(self.sampleMarkupsNodeName2)
 
   # ------------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -29,7 +29,7 @@
 #include <vtkMRMLScene.h>
 #include <vtkMRMLColorTableNode.h>
 #include <vtkMRMLMarkupsDisplayNode.h>
-#include <vtkMRMLMarkupsFiducialNode.h>
+#include <vtkMRMLMarkupsPointListNode.h>
 #include <vtkMRMLMarkupsNode.h>
 #include <vtkMRMLSelectionNode.h>
 
@@ -328,7 +328,7 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
   d->curveLineDiameterSliderWidget->setValue(lineDiameter);
 
   // Only enable line size editing if not fiducial node
-  bool lineSizeEnabled = (vtkMRMLMarkupsFiducialNode::SafeDownCast(markupsDisplayNode->GetDisplayableNode()) == nullptr);
+  bool lineSizeEnabled = (vtkMRMLMarkupsPointListNode::SafeDownCast(markupsDisplayNode->GetDisplayableNode()) == nullptr);
   d->curveLineSizeIsAbsoluteButton->setEnabled(lineSizeEnabled);
   d->curveLineDiameterSliderWidget->setEnabled(lineSizeEnabled);
   d->curveLineThicknessSliderWidget->setEnabled(lineSizeEnabled);

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -70,7 +70,7 @@
 qMRMLMarkupsToolBarPrivate::qMRMLMarkupsToolBarPrivate(qMRMLMarkupsToolBar& object)
   : q_ptr(&object)
 {
-  this->DefaultPlaceClassName = "vtkMRMLMarkupsFiducialNode";
+  this->DefaultPlaceClassName = "vtkMRMLMarkupsPointListNode";
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -476,6 +476,11 @@ void qMRMLMarkupsToolBar::updateToolBarLayout()
   for (const auto markupName : markupsLogic->GetRegisteredMarkupsTypes())
     {
     vtkMRMLMarkupsNode* markupsNode = markupsLogic->GetNodeByMarkupsType(markupName.c_str());
+
+    if (markupsNode->GetMarkupType() == QString("Fiducial"))
+      {
+      continue;  // deprecated in favor of vtkMRMLMarkupsPointListNode
+      }
     if (markupsNode && markupsLogic->GetCreateMarkupsPushButton(markupName.c_str()))
       {
       bool buttonExists = false;

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -50,6 +50,7 @@
 #include "vtkMRMLMarkupsClosedCurveNode.h"
 #include "vtkMRMLMarkupsCurveNode.h"
 #include "vtkMRMLMarkupsFiducialNode.h"
+#include "vtkMRMLMarkupsPointListNode.h"
 #include "vtkMRMLMarkupsLineNode.h"
 #include "vtkMRMLMarkupsPlaneNode.h"
 #include "vtkMRMLMarkupsROINode.h"

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -2638,7 +2638,7 @@ void qSlicerMarkupsModuleWidget::pasteSelectedFromClipboard()
     {
     // No point list is selected - create a new one
     // Assume a markups point list
-    this->onCreateMarkupByClass("vtkMRMLMarkupsFiducialNode");
+    this->onCreateMarkupByClass("vtkMRMLMarkupsPointListNode");
     if (!d->MarkupsNode)
       {
       return;
@@ -2862,7 +2862,7 @@ void qSlicerMarkupsModuleWidget::onNewMarkupWithCurrentDisplayPropertiesTriggere
     {
     // if there's no currently active markups list, trigger the default add
     // node
-    this->onCreateMarkupByClass("vtkMRMLMarkupsFiducialNode");
+    this->onCreateMarkupByClass("vtkMRMLMarkupsPointListNode");
     return;
     }
 

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -793,6 +793,11 @@ void qSlicerMarkupsModuleWidgetPrivate::createMarkupsPushButtons()
     vtkMRMLMarkupsNode* markupsNode =
       markupsLogic->GetNodeByMarkupsType(markupName.c_str());
 
+    if (markupsNode->GetMarkupType() == QString("Fiducial"))
+      {
+      continue;  // deprecated in favor of vtkMRMLMarkupsPointListNode
+      }
+
     // Create markups add buttons.
     if (markupsNode && q->markupsLogic()->GetCreateMarkupsPushButton(markupName.c_str()))
       {

--- a/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
+++ b/Modules/Loadable/SceneViews/Testing/Python/AddStorableDataAfterSceneViewTest.py
@@ -141,7 +141,7 @@ class AddStorableDataAfterSceneViewTestTest(ScriptedLoadableModuleTest):
     # add a markups control point list
     #
 
-    pointList = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsFiducialNode')
+    pointList = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLMarkupsPointListNode')
     pointList.AddControlPoint([10,20,15])
 
     #

--- a/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
+++ b/Modules/Loadable/SubjectHierarchy/Testing/Python/SubjectHierarchyCorePluginsSelfTest.py
@@ -115,7 +115,7 @@ class SubjectHierarchyCorePluginsSelfTestTest(ScriptedLoadableModuleTest):
     self.assertIsNotNone( shNode )
 
     # Create sample markups node
-    markupsNode = slicer.vtkMRMLMarkupsFiducialNode()
+    markupsNode = slicer.vtkMRMLMarkupsPointListNode()
     slicer.mrmlScene.AddNode(markupsNode)
     markupsNode.SetName(self.sampleMarkupName)
     fiducialPosition = [100.0, 0.0, 0.0]
@@ -165,7 +165,7 @@ class SubjectHierarchyCorePluginsSelfTestTest(ScriptedLoadableModuleTest):
     # Get clone node context menu action and trigger
     cloneNodePlugin.itemContextMenuActions()[0].activate(qt.QAction.Trigger)
 
-    self.assertEqual( slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsFiducialNode'), 2 )
+    self.assertEqual( slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsPointListNode'), 2 )
     self.assertEqual( slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsDisplayNode'), 2 )
     self.assertEqual( slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLMarkupsFiducialStorageNode'), 2 )
 

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -85,7 +85,7 @@ class EndoscopyWidget(ScriptedLoadableModuleWidget):
     inputFiducialsNodeSelector = slicer.qMRMLNodeComboBox()
     inputFiducialsNodeSelector.objectName = 'inputFiducialsNodeSelector'
     inputFiducialsNodeSelector.toolTip = "Select a fiducial list to define control points for the path."
-    inputFiducialsNodeSelector.nodeTypes = ['vtkMRMLMarkupsFiducialNode', 'vtkMRMLMarkupsCurveNode',
+    inputFiducialsNodeSelector.nodeTypes = ['vtkMRMLMarkupsPointListNode', 'vtkMRMLMarkupsFiducialNode', 'vtkMRMLMarkupsCurveNode',
       'vtkMRMLAnnotationHierarchyNode']
     inputFiducialsNodeSelector.noneEnabled = False
     inputFiducialsNodeSelector.addEnabled = False
@@ -388,7 +388,7 @@ class EndoscopyComputePath:
         coords = [0,0,0]
         f.GetFiducialCoordinates(coords)
         self.p[i] = coords
-    elif self.fids.GetClassName() == "vtkMRMLMarkupsFiducialNode":
+    elif self.fids.GetClassName() in ["vtkMRMLMarkupsPointListNode", "vtkMRMLMarkupsFiducialNode"]:
       # slicer4 Markups node
       self.n = self.fids.GetNumberOfControlPoints()
       n = self.n
@@ -551,7 +551,7 @@ class EndoscopyPathModel:
 
       if self.cursorType == "markups":
         # Markups cursor
-        cursor = scene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode", scene.GenerateUniqueName("Cursor-%s" % fids.GetName()))
+        cursor = scene.AddNewNodeByClass("vtkMRMLMarkupsPointListNode", scene.GenerateUniqueName("Cursor-%s" % fids.GetName()))
         cursor.CreateDefaultDisplayNodes()
         cursor.GetDisplayNode().SetSelectedColor(1,0,0)  # red
         cursor.GetDisplayNode().SetSliceProjection(True)


### PR DESCRIPTION
This is work for #5989.

In https://github.com/Slicer/Slicer/commit/8e294598acddf71414bc2f1c2ff7c67b2e871683 the vtkMRMLMarkupsFiducialNode's were given a display name of "Point List" instead of "Fiducial". This PR continues on this work by making an actual Markups Point List node that will be the replacement for Markups Fiducial nodes. The markups module and markups toolbar now create vtkMRMLMarkupsPointListNodes instead of vtkMRMLMarkupsFiducialNodes. I have also updated script repository documentation to use these new vtkMRMLMarkupsPointListNode objects where now the API matches the GUI terminology.

vtkMRMLMarkupsFiducialNode is now a derived class of vtkMRMLMarkupsPointListNode with the plan to ultimately remove this derived class in the future upon giving time to transition to vtkMRMLMarkupsPointListNode.

![image](https://user-images.githubusercontent.com/15837524/154180161-902439a3-0db0-4664-89f2-96f87b8523aa.png)
