### PR TITLE
BUG: Fix plane/ROI measurements to account for parent transform scaling

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.cxx
@@ -2342,6 +2342,7 @@ void vtkMRMLMarkupsNode::OnTransformNodeReferenceChanged(vtkMRMLTransformNode* t
   vtkMRMLTransformNode::GetTransformBetweenNodes(this->GetParentTransformNode(), nullptr, this->CurvePolyToWorldTransform);
   Superclass::OnTransformNodeReferenceChanged(transformNode);
   this->UpdateInteractionHandleToWorldMatrix();
+  this->UpdateAllMeasurements();
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsPlaneNode.h
@@ -140,6 +140,17 @@ public:
   //@}
 
   //@{
+  /// Get/Set size of the plane in the world coordinate system.
+  /// The size is defined in world coordinate system units.
+  /// When the size mode is auto, plane size is updated automatically
+  /// from the input control points.
+  void GetSizeWorld(double size[2]);
+  double* GetSizeWorld() VTK_SIZEHINT(2);
+  void SetSizeWorld(const double normal[2]);
+  void SetSizeWorld(double x, double y);
+  //@}
+
+  //@{
   /// Get/Set the bounds of the plane in Object coordinates
   vtkGetVector4Macro(PlaneBounds, double);
   virtual void SetPlaneBounds(double x0, double x1, double y0, double y1);
@@ -259,6 +270,12 @@ public:
   /// Re-implemented to react to changes in internal matrices or control points.
   void ProcessMRMLEvents(vtkObject* caller, unsigned long event, void* callData) override;
 
+  //@{
+  /// Retrieves the list of points that define the corners of the plane.
+  void GetPlaneCornerPoints(vtkPoints* points_Node);
+  void GetPlaneCornerPointsWorld(vtkPoints* points_World);
+  //@}
+
 protected:
 
   vtkSetMacro(MaximumNumberOfControlPoints, int);
@@ -274,7 +291,10 @@ protected:
   void CalculateAxesFromPoints(const double point0[3], const double point1[3], const double point2[3], double x[3], double y[3], double z[3]);
 
   /// Calculates the axis-aligned bounds defined by the corners of the plane.
-  void CalculatePlaneBounds(double bounds[6], double xAxis[3], double yAxis[3], double center[3], double size[2]);
+  void CalculatePlaneBounds(vtkPoints* cornerPoints, double bounds[6]);
+
+  /// Calculates the axis-aligned bounds defined by the corners of the plane.
+  void CalculatePlaneCornerPoints(vtkPoints* points, double xAxis[3], double yAxis[3], double center[3], double size[2]);
 
   /// Updates the plane based on plane type and control point position.
   virtual void UpdatePlaneFromControlPoints();
@@ -314,8 +334,9 @@ protected:
   // Arrays used to return pointers from GetNormal/GetOrigin functions.
   double Normal[3] = { 0.0, 0.0, 0.0 };
   double NormalWorld[3] = { 0.0, 0.0, 0.0 };
-  double Origin[3] = { 0.0,0.0,0.0 };
-  double OriginWorld[3] = { 0.0,0.0,0.0 };
+  double Origin[3] = { 0.0, 0.0, 0.0 };
+  double OriginWorld[3] = { 0.0, 0.0, 0.0 };
+  double SizeWorld[2] = { 0.0, 0.0 };
 
   int PlaneType{ PlaneTypePointNormal };
   bool IsPlaneValid{ false };

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
@@ -445,6 +445,7 @@ void vtkMRMLMarkupsROINode::OnTransformNodeReferenceChanged(vtkMRMLTransformNode
   Superclass::OnTransformNodeReferenceChanged(transformNode);
   this->UpdateObjectToWorldMatrix();
   this->UpdateInteractionHandleToWorldMatrix();
+  this->UpdateAllMeasurements();
 }
 
 //---------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementArea.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementArea.cxx
@@ -79,9 +79,9 @@ void vtkMRMLMeasurementArea::Compute()
     }
   else if (planeNode)
     {
-    double size[2] = { 0.0 };
-    planeNode->GetSize(size);
-    area = size[0] * size[1];
+    double size_world[2] = { 0.0, 0.0 };
+    planeNode->GetSizeWorld(size_world);
+    area = size_world[0] * size_world[1];
     }
   else
     {

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementVolume.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementVolume.cxx
@@ -61,7 +61,7 @@ void vtkMRMLMeasurementVolume::Compute()
     }
 
   double size[3] = { 0.0, 0.0, 0.0 };
-  roiNode->GetSize(size);
+  roiNode->GetSizeWorld(size);
   double volume = size[0] * size[1] * size[2];
 
   this->SetValue(volume, "volume");

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.cxx
@@ -1163,7 +1163,7 @@ void vtkSlicerMarkupsWidgetRepresentation::MarkupsInteractionPipeline::CreateSca
 
   this->AxisScaleGlypher = vtkSmartPointer<vtkGlyph3D>::New();
   this->AxisScaleGlypher->SetInputConnection(this->ScaleScaleTransform->GetOutputPort());
-  this->AxisScaleGlypher->SetSourceConnection(this->AxisRotationHandleSource->GetOutputPort());
+  this->AxisScaleGlypher->SetSourceConnection(this->AxisScaleHandleSource->GetOutputPort());
   this->AxisScaleGlypher->ScalingOn();
   this->AxisScaleGlypher->SetScaleModeToDataScalingOff();
   this->AxisScaleGlypher->SetIndexModeToScalar();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.cxx
@@ -579,24 +579,11 @@ void vtkSlicerPlaneRepresentation2D::BuildPlane()
   objectToWorldTransform->SetMatrix(objectToWorldMatrix);
 
   // Update the plane
-  double bounds_Object[4] = { 0.0, -1.0, 0.0, -1.0 };
-  planeNode->GetPlaneBounds(bounds_Object);
-
-  double planePoint0_Object[3] = { bounds_Object[0], bounds_Object[2], 0.0 };
-  double planePoint0_World[3] = { 0.0, 0.0, 0.0 };
-  objectToWorldTransform->TransformPoint(planePoint0_Object, planePoint0_World);
-
-  double planePoint1_Object[3] = { bounds_Object[0], bounds_Object[3], 0.0 };
-  double planePoint1_World[3] = { 0.0, 0.0, 0.0 };
-  objectToWorldTransform->TransformPoint(planePoint1_Object, planePoint1_World);
-
-  double planePoint2_Object[3] = { bounds_Object[1], bounds_Object[2], 0.0 };
-  double planePoint2_World[3] = { 0.0, 0.0, 0.0 };
-  objectToWorldTransform->TransformPoint(planePoint2_Object, planePoint2_World);
-
-  this->PlaneFilter->SetOrigin(planePoint0_World);
-  this->PlaneFilter->SetPoint1(planePoint1_World);
-  this->PlaneFilter->SetPoint2(planePoint2_World);
+  vtkNew<vtkPoints> planeCornerPoints_World;
+  planeNode->GetPlaneCornerPointsWorld(planeCornerPoints_World);
+  this->PlaneFilter->SetOrigin(planeCornerPoints_World->GetPoint(0));
+  this->PlaneFilter->SetPoint1(planeCornerPoints_World->GetPoint(1));
+  this->PlaneFilter->SetPoint2(planeCornerPoints_World->GetPoint(3));
 
   double* arrowVectorSlice = this->WorldToSliceTransform->TransformDoubleVector(zAxis_World);
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
@@ -816,18 +816,18 @@ void vtkSlicerPlaneWidget::ScaleWidget(double eventPos[2], bool symmetricScale)
 
     switch (index)
       {
-      case vtkMRMLMarkupsPlaneDisplayNode::HandleAEdge:
-      case vtkMRMLMarkupsPlaneDisplayNode::HandleLACorner:
-      case vtkMRMLMarkupsPlaneDisplayNode::HandleRACorner:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandlePEdge:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLPCorner:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRPCorner:
         bounds_Plane[2] += scaleVector_Object[1];
         if (symmetricScale)
           {
           bounds_Plane[3] -= scaleVector_Object[1];
           }
         break;
-      case vtkMRMLMarkupsPlaneDisplayNode::HandlePEdge:
-      case vtkMRMLMarkupsPlaneDisplayNode::HandleLPCorner:
-      case vtkMRMLMarkupsPlaneDisplayNode::HandleRPCorner:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleAEdge:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleLACorner:
+      case vtkMRMLMarkupsPlaneDisplayNode::HandleRACorner:
         bounds_Plane[3] += scaleVector_Object[1];
         if (symmetricScale)
           {


### PR DESCRIPTION
Previously the plane and ROI Markups did not account for parent transform scaling when calculating the volume/area. Fixed by using GetSizeWorld methods.
The measurements now also automatically update if the parent transform node is changed.

Also fixes the position of plane scale handles when scaled by a parent transform.

Re #5061