### PR TITLE
COMP: Update LibArchive from 3.4.3 to 3.5.2 to support GCC v11

### DIFF
--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -44,7 +44,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "34940ef6ea0b21d77cb501d235164ad88f19d40c"  # master (v3.4.3) with fix-enum-cases
+    "1b2c437b99b361c7692538fa373e99955e9b93ae" # master v3.5.2
     QUIET
     )
 


### PR DESCRIPTION
This commit fixes the following error reported when LibArchive
external project is compiled gcc-11.2.0 in Gentoo Linux:

```
  FAILED: libarchive/CMakeFiles/archive_static.dir/archive_read_support_format_warc.c.o
  [...]
  /home/rafael/src/Slicer/Slicer-master/build/LibArchive/libarchive/archive_read_support_format_warc.c:610:25: error: argument 1 of type ‘const char *’ declared as a pointer [-Werror=array-parameter=]
    610 | _warc_rdver(const char *buf, size_t bsz)
        |             ~~~~~~~~~~~~^~~
  /home/rafael/src/Slicer/Slicer-master/build/LibArchive/libarchive/archive_read_support_format_warc.c:130:44: note: previously declared as an array ‘const char[10]’
    130 | static unsigned int _warc_rdver(const char buf[10], size_t bsz);
        |                                 ~~~~~~~~~~~^~~~~~~
```

The specific commit addressing the issue is libarchive/libarchive@22568630f (Repair
gcc11 build error in archive_read_support_format_warc.c)

Fixes #6144

```
List of changes:

$ git shortlog 34940ef6e..1b2c437b9 --no-merges
Adrian Ebeling (2):
      7zip: Use compression settings for file header
      Use tabs for indentation

Alex Richardson (3):
      Avoid mismatch between library and test crypto configuration
      warc: Fix undefined behaviour in deconst() function
      Silence stderr in test_read_append_filter_program

Alexandre Janniaux (2):
      configure.ac: add AC_PROG_CPP
      configure.ac: remove trailing characters

Andy Brown (1):
      Windows: Use full path including prefix when looking up file handle

Anton Kochkov (1):
      archive_entry.c is not 3-clause UC Regents License

Brad King (1):
      Use uint8_t instead of u_char

Christos Zoulas (11):
      Extract common transfer setting code for statfs and statvfs. 1. Makes detection of f_iosize constent. 2. Avoid infinite loops by detecting 0 sizes and converting to -1.    This happens with FUSE. NetBSD PR/56083.
      Fix typo
      Put the statvfs code in a separate block so that it can by shared by linux and NetBSD
      Fix typo
      Fix FreeBSD which has both statfs and statvfs
      Make setter functions inline
      Not all statfs's have f_iosize
      Add __LA_UNUSED because clang warns for static inline functions that are not used.
      NetBSD provides a statfs symbol for binary compatibility but does not provide a visible struct statfs. Check for that.
      Cast isprint(3) argument to unsigned char to avoid undefined behavior.
      Catch up with autoconf changes:     HAVE_STRUCT_STATFS     HAVE_STRUCT_STATFS_F_IOSIZE

Joerg Sonnenberger (1):
      Restore comment formatting

Kyle Evans (1):
      tests: mark failed_filename and tests static to fix WARNS=6 build

Luis Henriques (2):
      tests: add new assertion for chmod()
      Fix test clean-up

Martin Matuska (29):
      archive_cryptor: silence Nettle 3.5+ warnings
      CI: update Ubuntu image to 20.04
      CI: fix homebrew errors in MacOS build
      archive_cryptor: use new Nettle AES interface on Nettle 3.0 and higher
      Introduce archive_write_open2() with free callback
      Update archive_write_open.3 manpage
      Fix typo in archive_write_open.3
      Build release with Ubuntu 20.04
      Release 3.5.0
      Libarchive 3.5.1dev
      Add missing ifdef to unbreak build withot lzma
      Do not use C99 for loop scoping in test_archive_read_support.c
      Repair gcc11 build error in archive_read_support_format_warc.c
      Bump minor version in contrib/libarchive.spec
      Use built-in strnlen on platforms where not available
      Add HAVE_STRNLEN to config_freebsd.h
      CI: use FreeBSD 12.2 image in Cirrus CI build
      CI: use xz 5.2.5 in Windows build
      Release 3.5.1
      Libarchive 3.5.2dev
      CI: Add FreeBSD 13.0 to Cirrus CI build
      Add ability to skip atime test in directory traversals
      Fix extracting hardlinks to symlinks
      write_disk_posix: rename variable in check_symlinks_fsobj()
      Fix handling of symbolic link ACLs
      Never follow symlinks when setting file flags on Linux
      Do not follow symlinks when processing the fixup list
      Skip archive_write_disk_fixup test on Windows
      Release 3.5.2

Masalskaya, Anna (8):
      Add support for decompression of symbolic links in zipx archives
      more comments
      applying remarks
      adjust formatting
      unit test added
      move test to another place
      fix test failure
      Added support of deflate algorithm in symbolic link decompression for zip archives

Oleg Smirnov (1):
      Fix #1486: build fails on Windows with VS2013 toolset (v120)

Oliver Ford (1):
      Add null check to string in archive_pathmatch

Ondrej Dubaj (2):
      Fixed double free when calling lzx_huffman_init frees pointer ds-
      Fixed leak of rar before ending with error

Owen W. Taylor (2):
      Avoid getcwd(0, PATH_MAX) for GNU libc
      On close, handle short writes from archive_write_callback

Rolf Eike Beer (1):
      cpio test: add source file extension

Russell Mullens (3):
      Calculate where the Central Directory is based on the size of the Central Directory in EOCD and where the OECD was found. This prevents large reads when a zip archive is preceded by other data.
      Fix excessive disk read for padded zip.
      Fix declaration of variables, mostly to trigger a new check for what seems like an unrelated issue.

Samanta Navarro (3):
      Handle all negative int64_t values in mtree/tar
      Fix typos
      Fix mutual check in tar sparse handling

Shawn Webb (4):
      HBSD: Teach libarchive about the system extended attribute namespace
      HBSD: wrap function declaration in an ifdef to appease CI
      HBSD: Teach libarchive about the system extended attribute namespace
      HBSD: Ignore UFS shenanigans

Tom Ivar Helbekkmo (9):
      rearrange cpio output format selection
      add support for reading and writing PWB and V7 cpio archives
      be PDP-endian host compatible when writing binary cpio headers
      add a missing file entry to libarchive/CMakeLists.txt
      add -7 option to bsdcpio for symmetry
      fix output format handling and symlink detection for PWB
      update cpio documentation, add basic test of binary format
      update top level docs with binary cpio support
      update "-h" output with new formats

Wei-Cheng Pan (1):
      fix rar header skiming

lutianxiong (1):
      Add a loop checker in read_data_compressed to avoid stack overflow.

r0ptr (1):
      Fix truncation of size values during 7zip archive extraction on 32bit architectures

uyjulian (1):
      Fill in Unknown for the system identifier if there is no utsname and not Windows
```