### PR TITLE
ENH: Skip empty colors with (none) label in color legend

### DIFF
--- a/Libs/MRML/Logic/Testing/Cxx/vtkMRMLColorLogicTest1.cxx
+++ b/Libs/MRML/Logic/Testing/Cxx/vtkMRMLColorLogicTest1.cxx
@@ -204,7 +204,8 @@ bool TestCopy()
   originalNode->NamesInitialisedOff();
   originalNode->SetNumberOfColors(6);
   originalNode->GetLookupTable()->SetTableRange(0, 5);
-  originalNode->SetColor(0, "background", 0.0, 0.0, 0.0, 0.0);
+  // Use NoName as color name to not list the "background" color in the color legend.
+  originalNode->SetColor(0, originalNode->GetNoName(), 0.0, 0.0, 0.0, 0.0);
   originalNode->SetColor(1, "one", 0.5, 1.0, 0.0, 0.1);
   originalNode->SetColor(2, "two", 0.5, 0.5, 0.0, 0.3);
   originalNode->SetColor(3, "three", 0.33, 0.0, 0.5, 0.5);

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -1126,7 +1126,8 @@ bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(vtkMRMLSegm
     newColorTable->SetNumberOfColors(1);
     newColorTable->GetLookupTable()->SetRange(0, 0);
     newColorTable->GetLookupTable()->SetNumberOfTableValues(1);
-    newColorTable->SetColor(0, "Background", 0.0, 0.0, 0.0, 0.0);
+    // Use NoName as color name to not list the "background" color in the color legend.
+    newColorTable->SetColor(0, newColorTable->GetNoName(), 0.0, 0.0, 0.0, 0.0);
     labelmapNode->GetScene()->AddNode(newColorTable);
     labelmapNode->GetDisplayNode()->SetAndObserveColorNodeID(newColorTable->GetID());
     }
@@ -1165,7 +1166,8 @@ bool vtkSlicerSegmentationsModuleLogic::ExportSegmentsToLabelmapNode(vtkMRMLSegm
   colorTableNode->SetNumberOfColors(numberOfColors);
   colorTableNode->GetLookupTable()->SetRange(0, numberOfColors - 1);
   colorTableNode->GetLookupTable()->SetNumberOfTableValues(numberOfColors);
-  colorTableNode->SetColor(0, "Background", 0.0, 0.0, 0.0, 0.0);
+  // Use NoName as color name to not list the "background" color in the color legend.
+  colorTableNode->SetColor(0, colorTableNode->GetNoName(), 0.0, 0.0, 0.0, 0.0);
 
   for (int i = colorFillStartIndex; i < colorTableNode->GetNumberOfColors(); ++i)
     {


### PR DESCRIPTION
This PR prevents empty colors with "(none)" label from displaying in color legend. Part of the issue #6111.

"Hide empty Colors" check box controls the behavior.
Left: Empty colors are shown; Right: Empty colors are hidden.
![image](https://user-images.githubusercontent.com/3785912/154756820-596baf53-c396-4cd4-b571-6ca1df1600cb.png)
