### PR TITLE
DOC: Fix internal link in retired modules list

### DIFF
--- a/Docs/developer_guide/debugging/codelitecpp.md
+++ b/Docs/developer_guide/debugging/codelitecpp.md
@@ -14,7 +14,7 @@ To configure the binary for the Run command, set Program: `~/Slicer-SuperBuild-D
 
 ## Configure debugger
 
-This requires the use of a wrapper script, as [detailed here](linux.md#gdb-debug-by-using-exec-wrapper).
+This requires the use of a wrapper script, as [detailed here](linuxcpp.md#gdb-debug-by-using-exec-wrapper).
 
 After setting up the wrapper script (`WrapSlicer` below), change the following options:
 

--- a/Docs/developer_guide/debugging/overview.md
+++ b/Docs/developer_guide/debugging/overview.md
@@ -8,7 +8,7 @@ Python code running in Slicer can be debugged (execute code line-by-line, inspec
 
 ## C++ debugging
 
-Debugging C++ code requires building 3D Slicer in Debug mode by following the [build instructions](../build_instructions.md).
+Debugging C++ code requires building 3D Slicer in Debug mode by following the [build instructions](../build_instructions/overview.md).
 
 The executable Slicer application (`Slicer` or `Slicer.exe`) is the launcher of the real application binary (`SlicerApp-real`). The launcher sets up paths for dynamically-loaded libraries that on Windows and Linux are required to run the real application library.
 

--- a/Docs/developer_guide/debugging/qtcreatorcpp.md
+++ b/Docs/developer_guide/debugging/qtcreatorcpp.md
@@ -10,7 +10,7 @@ For debugging on Windows, Visual Studio is recommended as it has much better per
 
 ## Prerequisites
 
-- Build 3D Slicer in Debug mode, outside of Qt Creator, by following the [build instructions](../build_instructions.md).
+- Build 3D Slicer in Debug mode, outside of Qt Creator, by following the [build instructions](../build_instructions/overview.md).
 - Install Qt SDK with Qt Creator.
 
 ## Running the debugger

--- a/Docs/developer_guide/debugging/vscodecpp.md
+++ b/Docs/developer_guide/debugging/vscodecpp.md
@@ -11,7 +11,7 @@ For debugging on Windows, Visual Studio is recommended as it has much better per
 
 ## Prerequisites
 
-- Build 3D Slicer in Debug mode, outside of Visual Studio Code, by following the [build instructions](../build_instructions.md).
+- Build 3D Slicer in Debug mode, outside of Visual Studio Code, by following the [build instructions](../build_instructions/overview.md).
 - Install Visual Studio Code
 - Install the `C/C++` extension in Visual Studio Code
 

--- a/Docs/developer_guide/debugging/windowscpp.md
+++ b/Docs/developer_guide/debugging/windowscpp.md
@@ -3,7 +3,7 @@
 ## Debugging using Visual Studio
 
 Prerequisites:
-- Build 3D Slicer in Debug by following the [build instructions](../build_instructions.md).
+- Build 3D Slicer in Debug by following the [build instructions](../build_instructions/overview.md).
 
 1. To run Slicer, the launcher needs to set certain environment variables. The easiest is to use the launcher to set these and start Visual Studio in this environment. All these can be accomplished by running the following command in `<Slicer_BUILD>/Slicer-build` folder:
 

--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -628,7 +628,7 @@ See the labs topic on [upgrading compiler infrastructure](https://www.slicer.org
 
 ### How do I publish a paper about my extension?
 
-Consider publishing a paper describing your extension. [This page](http://www.software.ac.uk/resources/guides/which-journals-should-i-publish-my-software) contains a list of journals that publish papers about software. [Citing 3D Slicer](../user_guide/about.html#how-to-cite) in all papers that use 3D Slicer is greatly appreciated.
+Consider publishing a paper describing your extension. [This page](http://www.software.ac.uk/resources/guides/which-journals-should-i-publish-my-software) contains a list of journals that publish papers about software. [Citing 3D Slicer](../user_guide/about.md#how-to-cite) in all papers that use 3D Slicer is greatly appreciated.
 
 ### How to force Slicer to download extensions corresponding to a different Slicer revision?
 

--- a/Docs/developer_guide/python_faq.md
+++ b/Docs/developer_guide/python_faq.md
@@ -111,7 +111,7 @@ cliNode.AddObserver('ModifiedEvent', onProcessingStatusUpdate)
 
 ## How to find a Python function for any Slicer features
 
-All features of Slicer are available via Python scripts. [Slicer script repository](../script_repository.md) contains examples for the most commonly used features.
+All features of Slicer are available via Python scripts. [Slicer script repository](script_repository.md) contains examples for the most commonly used features.
 
 To find out what Python commands correspond to a feature that is visible on the graphical user interface, search in Slicer's source code where that text occurs, find the corresponding widget or action name, then search for that widget or action name in the source code to find out what commands it triggers.
 

--- a/Docs/user_guide/modules/retiredmodules.md
+++ b/Docs/user_guide/modules/retiredmodules.md
@@ -2,15 +2,15 @@
 
 The modules listed below have been retired and are no longer present in 3D Slicer. This page exists as a convenient marker for historical details about retired modules.
 
-Retiring modules reduces burden on Slicer developers.
+Retiring modules reduces burden on Slicer developers. Most common reason for retiring a module is that a new, improved module is introduced.
+A module may also be retired if it no longer works properly (for example due to changes in Slicer core or third-party libraries) and it is not worth investing time into fixing the issue, because the module is not widely used or alternatives exist.
 
-A short list of reasons why a module may have been retired:
-
-- The module has been superseded with another, and is not recommended
-- The module has no development support, and no longer runs properly
-
-| Date       | Module Name                   | Commit                                                             | Retire reason  |
-|------------|-------------------------------|--------------------------------------------------------------------|---------------------|
-| 2021-11-05 | Editor                        | [39283db](https://github.com/Slicer/Slicer/commit/39283db420baf502fa99865c9d5d58d0e5295a6e)| No longer running properly ([source](https://github.com/Slicer/Slicer/issues/5962)). Superseded by the [Segment Editor](segmenteditor.md) module.|
-| 2021-11-05 | Label Statistics              | [cf62bcf](https://github.com/Slicer/Slicer/commit/cf62bcfc89d4fc2606a84ac51f741a93d7037299)| Superseded by the [Segment Statistics](segmentstatistics.md) module.|
-| 2022-02-19 | Expert Automated Registration | [87fd349](https://github.com/Slicer/Slicer/commit/87fd349334e6414c28ba373bbc45d03c7345ad0c) | BRAINS, Elastix, and ANTs registration toolkits offer superior registration results - see [Automatic Image Registration](../registration.md#automatic-image-registration) page for details.|
+- **Editor**
+  - Retired: 2021-11-05, [commit 39283db](https://github.com/Slicer/Slicer/commit/39283db420baf502fa99865c9d5d58d0e5295a6e)
+  - Reason: [No longer running properly](https://github.com/Slicer/Slicer/issues/5962) and superseded by the [Segment Editor](segmenteditor.md) module.
+- **Label Statistics**
+  - Retired: 2021-11-05, [commit cf62bcf](https://github.com/Slicer/Slicer/commit/cf62bcfc89d4fc2606a84ac51f741a93d7037299)
+  - Reason: Superseded by the [Segment Statistics](segmentstatistics.md) module.
+- **Expert Automated Registration**
+  - Retired: 2022-02-19, [commit 87fd349](https://github.com/Slicer/Slicer/commit/87fd349334e6414c28ba373bbc45d03c7345ad0c)
+  - Reason: [No longer running properly](https://github.com/Slicer/Slicer/pull/6200#issuecomment-1045962304). BRAINS, Elastix, and ANTs registration toolkits offer superior registration results, see [Automatic Image Registration](../registration.md) section for details.


### PR DESCRIPTION
Found this broken link to the registration documentation page. Published readthedocs pages are html unless there is seemingly an index to pick the markdown name.