### PR TITLE
DOC: C++14 language features are allowed in extensions

### DIFF
--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -618,9 +618,9 @@ Also, starting with [Slicer r25959](http://viewvc.slicer.org/viewvc.cgi/Slicer4?
 
 These relative paths are the one that the extensions manager will consider when generating the launcher and application settings for a given extension.
 
-### Can I use C++11/14/17 language features?
+### Can I use C++14/17/20 language features?
 
-We try to balance between compatibility and using new features. As a result, currently C++11 features are allowed, but usage of C++14/17 language features are discouraged in extensions (relying on C++14/17 features may lead to build errors on some build configurations).
+We try to balance between compatibility and using new features. As a result, currently C++14 features are allowed, but usage of C++17/20 language features are discouraged in extensions (relying on C++17/20 features may lead to build errors on some build configurations).
 
 If your extension can be compiled as a standalone project where you would like to use newer feature, you could rely on CMake detecting compile features. See [cmake-compile-features](https://cmake.org/cmake/help/v3.5/manual/cmake-compile-features.7.html) for more details.
 

--- a/SuperBuild/External_DCMTK.cmake
+++ b/SuperBuild/External_DCMTK.cmake
@@ -33,21 +33,6 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       )
   endif()
 
-  set(ep_cxx_standard_args)
-  # XXX: On MSVC disable building DCMTK with C++11. DCMTK checks C++11.
-  # compiler compatibility by inspecting __cplusplus, but MSVC doesn't set __cplusplus.
-  # See https://blogs.msdn.microsoft.com/vcblog/2016/06/07/standards-version-switches-in-the-compiler/.
-  # Microsoft: "We won’t update __cplusplus until the compiler fully conforms to
-  # the standard. Until then, you can check the value of _MSVC_LANG."
-  if(CMAKE_CXX_STANDARD AND UNIX)
-    list(APPEND ep_cxx_standard_args
-      -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
-      -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
-      -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
-      -DDCMTK_ENABLE_CXX11:BOOL=ON
-      )
-  endif()
-
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
     "${EP_GIT_PROTOCOL}://github.com/commontk/DCMTK.git"
@@ -85,7 +70,9 @@ if(NOT DEFINED DCMTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
       -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
       -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
-      ${ep_cxx_standard_args}
+      -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
+      -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
+      -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
       -DBUILD_SHARED_LIBS:BOOL=ON
       -DDCMTK_WITH_DOXYGEN:BOOL=OFF
       -DDCMTK_WITH_ZLIB:BOOL=OFF # see CTK github issue #25


### PR DESCRIPTION
This updates some extension documentation and a DCMTK comment about C++ standard usage. The C++ standard was updated to C++14 in Slicer and had a minimum Visual Studio version updated in https://github.com/Slicer/Slicer/commit/bc2b3f4049ef32486cf43ad16903820fc8767f27.