### PR TITLE
COMP: Update ITK to fix packaging of libITKznz and libITKniftiio libraries

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -30,13 +30,13 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/InsightSoftwareConsortium/ITK"
+    "${EP_GIT_PROTOCOL}://github.com/Slicer/ITK"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "be81e6223240508642b963511e6441203df6375e"
+    "be81e6223240508642b963511e6441203df6375e" # slicer-v5.3rc03-2022-02-10-be81e62
     QUIET
     )
 


### PR DESCRIPTION
This commit is a follow up of b1c235939e (COMP: Update ITK to post-5.3rc03
and SimpleITK to post-2.2rc2).

It reverts NIFTI-Imaging/nifti_clib@3bd6afc7f (fix issues with
config/targets files) integrated in ITK through
InsightSoftwareConsortium/ITK@faa754cbc (Merge branch 'upstream-nifti'
into nifticlib3.0)

List of changes:

```
$ git shortlog be81e62232..027fd5ce0c --no-merges
Jean-Christophe Fillion-Robin (1):
      BUG: Fix install of libITK(znz|niftiio) libraries specifying component
```

See #6202