### PR TITLE
COMP: Fix LibArchive external project install step on macOS

### DIFF
--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -97,7 +97,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
     )
   if(APPLE)
     ExternalProject_Add_Step(${proj} fix_rpath
-      COMMAND install_name_tool -id ${EP_INSTALL_DIR}/lib/libarchive.17.dylib ${EP_INSTALL_DIR}/lib/libarchive.17.dylib
+      COMMAND install_name_tool -id ${EP_INSTALL_DIR}/lib/libarchive.18.dylib ${EP_INSTALL_DIR}/lib/libarchive.18.dylib
       DEPENDEES install
       )
   endif()


### PR DESCRIPTION
This commit fixes a regression introduced in e5c5ad780 (COMP: Update
LibArchive from 3.4.3 to 3.5.2 to support GCC v11), it addresses the
following error by updating the interface number hard-coded in the library
path used in the "fix_rpath" external project step specific to macOS.

Error:

```
  error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool:
  can't open file: /path/to/S-0-build/LibArchive-install/lib/libarchive.17.dylib (No such file or directory)
```

See #6219