### PR TITLE
Simplify LibArchive external project and improve associated documentation

### DIFF
--- a/Docs/developer_guide/build_instructions/macos.md
+++ b/Docs/developer_guide/build_instructions/macos.md
@@ -164,18 +164,6 @@ warning: target '@rpath/QtGui.framework/Versions/5/QtGui' does not exist...
 
 is present during packaging - doublecheck that Slicer was built with Qt that was built from source and not Qt that was installed from a web-installer or homebrew.
 
-#### LibArchive pointing to a nonexistent path
-
-If a packaged Slicer is launched on another mac and it crashes with the error log saying that
-
-```
-Library not loaded: /usr/local/opt/zstd/lib/libzstd.1.dylib
-  Referenced from: Slicer.app/Contents/lib/Slicer-4.13/libarchive.17.dylib
-```
-
-It means that `libarchive` has has found homebrew versions of some of it's requirements, rather than local ones. For the packaged version of Slicer to run on other machines none of the prerequisites should be installed via homebrew. For example `lz4` and `zstd` are bundled with `subversion` and `rsync` so if you have these two application installed via homebrew, `libarchive` will grab them from `/usr/local/opt/` and the packaged Slicer will not run on other machines. The solution is either to remove them from from homebrew with `brew remove lz4` and `brew remove zsdt` or to change the `$PATH` so that the local build folder goes before `/usr/local/opt/`. After doing this Slicer should be rebuilt and repackaged.
-See [Relevant issue that's tracking this error](https://github.com/Slicer/Slicer/issues/5415)
-
 ## Update Homebrew packages
 
 Slicer can be installed with a single command using [Homebrew](https://brew.sh/), as described in the [installation documentation](../../user_guide/getting_started.md#installing-using-homebrew).

--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -23,18 +23,7 @@ endif()
 if((NOT DEFINED LibArchive_INCLUDE_DIR
    OR NOT DEFINED LibArchive_LIBRARY) AND NOT Slicer_USE_SYSTEM_${proj})
 
-  #
-  # NOTE: - a stable, recent release (3.3.2) of LibArchive is now checked out from git
-  #         for all platforms.  For notes on cross-platform issues with earlier versions
-  #         of LibArchive, see the repository for earlier revisions of this file.
-
   set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
-
-  # CMake arguments specific to LibArchive >= 2.8.4
-  list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
-    -DBUILD_TESTING:BOOL=OFF
-    -DENABLE_OPENSSL:BOOL=OFF
-    )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
@@ -75,6 +64,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
       -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
       -DBUILD_SHARED_LIBS:BOOL=ON
+      -DBUILD_TESTING:BOOL=OFF
       -DENABLE_ACL:BOOL=OFF
       -DENABLE_BZip2:BOOL=OFF
       -DENABLE_CAT:BOOL=OFF

--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -48,6 +48,16 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
     QUIET
     )
 
+  # When updating the version of LibArchive, consider also
+  # updating the soversion number hard-coded below in the
+  # "fix_rpath" macOS external project step.
+  #
+  # To find out if the soversion number should be updated,
+  # review the logic computing INTERFACE_VERSION in the
+  # top-level LibArchive CMakeLists.txt and/or inspect the
+  # prefix associated with the library generated in the build
+  # tree.
+
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
   set(EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/${proj}-install)


### PR DESCRIPTION
STYLE: Simplify LibArchive external project consolidating options
    
This commit removes obsolete comment from 2012 originally introduced
in c463d49680 (COMP: switch to newer LibArchive (3.0.4))

Option ENABLE_OPENSSL became redundant following 1f0f6f9b5 (COMP: Explicitly
set LibArchive options to avoid implicit finding of libraries)

Conditional passing of BUILD_TESTING was first introduced in
b50007add3 (COMP: On unix: use LibArchive 2.7.1 patched, on windows:
use LibArchive 2.8.4) and became irrelevant with c463d49680 (COMP:
switch to newer LibArchive (3.0.4))

-----

DOC: Update macOS build instructions removing obsolete LibArchive workaround

Considering that (1) the build instruction section "LibArchive pointing to
a nonexistent path" was added on Feb 2021 by 5dd8e7f71 (DOC: Update macOS
build instructions) and (2) the related issue #5415 was fixed in pull-request
#5854 from Sep 2021, this commit removes the now obsolete section.

Note that the list of LibArchive options explicitly disabled in the external
project has also been reviewed based on LibArchive update introduced in
e5c5ad7 (COMP: Update LibArchive from 3.4.3 to 3.5.2 to support GCC v11).

-----

DOC: Add note about hard-coded soversion to External_LibArchive.cmake

Since forgetting to update the soversion is a recurrent error (see [1]),
this commit attempt to explicit document was need to be done.

[1] A similar fix was integrated in Nov 2019 by 36c83c838 (COMP: Fix macOS
packaging to account for LibArchive version update).

