### PR TITLE
COMP: Effectively update ITK version to fix ITKznz & ITKniftiio packaging

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "be81e6223240508642b963511e6441203df6375e" # slicer-v5.3rc03-2022-02-10-be81e62
+    "027fd5ce0c7044c33eb56bf7530466488109390b" # slicer-v5.3rc03-2022-02-10-be81e62
     QUIET
     )
 


### PR DESCRIPTION
This commit is a follow-up of 7da002489 (COMP: Update ITK to fix
packaging of libITKznz and libITKniftiio libraries) where the ITK
SHA is effectively updated to address #6202.

List of changes:

```
$ git shortlog be81e62232..027fd5ce0c --no-merges
Jean-Christophe Fillion-Robin (1):
      BUG: Fix install of libITK(znz|niftiio) libraries specifying component
```