### PR TITLE
DOC: Update build instructions to specify using Visual Studio 2022

### DIFF
--- a/Docs/developer_guide/build_instructions/windows.md
+++ b/Docs/developer_guide/build_instructions/windows.md
@@ -7,7 +7,7 @@
   - Note: CMake must be able to find `git.exe` and `patch.exe`. If git is installed in the default location then they may be found there, but if they are not found then either add the folder that contains them to `PATH` environment variable; or set `GIT_EXECUTABLE` and `Patch_EXECUTABLE` as environment variables or as CMake variables at configure time.
 - [Visual Studio](https://visualstudio.microsoft.com/downloads/)
   - any edition can be used (including the free Community edition)
-  - when configuring the installer, enable `Desktop development with C++` and in installation details, check `MSVC v142 - VS2019 C++ x64...` (Visual Studio 2019 v142 toolset with 64-bit support) - in some distributions, this option is not enabled by default
+  - when configuring the installer, enable `Desktop development with C++` and in installation details, check `MSVC v143 - VS2022 C++ x64...` (Visual Studio 2022 v143 toolset with 64-bit support) - in some distributions, this option is not enabled by default
 - [Qt5](https://www.qt.io/download-open-source): Download Qt universal installer and install Qt 5.15.2 components: `MSVC2019 64-bit`, `Qt Script`, `Qt WebEngine`. Installing Sources and Qt Debug Information Files are recommended for debugging (they allow stepping into Qt files with the debugger in debug-mode builds).
   - Note: These are all free, open-source components with LGPL license which allow free usage for any purpose, for any individuals or companies.
 - [NSIS](http://nsis.sourceforge.net/Download) (optional): Needed if packaging Slicer. Make sure you install the language packs.
@@ -16,9 +16,7 @@
 
 **Other Visual Studio IDE and compiler toolset versions**
 
-- Visual Studio 2022 (v143) toolset is occasionally tested and appears to work well.
-  When configuring the Visual Studio Installer, enable `Desktop development with C++` and in installation details, check `MSVC v143 - VS2022 C++ x64...` (Visual Studio 2022 v143 toolset with 64-bit support) - in some distributions, this option is not enabled by default.
-  Use `Visual Studio 17 2022` instead of `Visual Studio 16 2019` in the build instructions below.
+- Visual Studio 2019 (v142) toolset is not tested anymore but probably still works.
 - Visual Studio 2017 (v141) toolset is not tested anymore but probably still works. Qt-5.15.2 requires v142 redistributables, so either these extra DLL files need to be added to the installation package or each user may need to install "Microsoft Visual C++ Redistributable" package.
 - Cygwin and Mingw: not tested and not recommended. Building with cygwin gcc not supported, but the cygwin shell environment can be used to run utilities such as git.
 
@@ -49,7 +47,7 @@ Release mode:
 ```
 mkdir C:\D\S4R
 cd /d C:\D\S4R
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 17 2022" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Release
 ```
 
@@ -58,7 +56,7 @@ Debug mode:
 ```
 mkdir C:\D\S4D
 cd /d C:\D\S4D
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 16 2019" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 17 2022" -A x64 -DQt5_DIR:PATH=C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5 C:\D\S4
 "C:\Program Files\CMake\bin\cmake.exe" --build . --config Debug
 ```
 
@@ -69,7 +67,7 @@ cd /d C:\D\S4D
 - Set `Where to build the binaries` to `<Slicer_BUILD>` location. Do not configure yet!
 - Add `Qt5_DIR` variable pointing to Qt5 folder: click Add entry button, set `Name` to `Qt5_DIR`, set `Type` to `PATH`, and set `Value` to the Qt5 folder, such as `C:\Qt\5.15.2\msvc2019_64\lib\cmake\Qt5`.
 - Click `Configure`
-- Select your compiler: `Visual Studio 16 2019`, and click `Finish`
+- Select your compiler: `Visual Studio 17 2022`, and click `Finish`
 - Click `Generate` and wait for project generation to finish (may take a few minues)
 - Click `Open Project`
 - If building in release mode:


### PR DESCRIPTION
The factory build machine has been using Visual Studio 2022 and the v143 toolset for the past month as of https://github.com/Slicer/DashboardScripts/commit/7cd961df84997f22bb684d7d2a185a610f23d6a1.

This PR is updating the documentation based on the comment at https://github.com/Slicer/Slicer/pull/6012#issuecomment-983050373 to update it once the factory machines were using VS2022 and the v143 toolset.