### PR TITLE
BUG: Fix py_standalonepython_import_slicer test on windows

### DIFF
--- a/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+++ b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
@@ -71,7 +71,11 @@ set(SLICER_LIBRARY_PATHS_BUILD
   )
 
 if(NOT Slicer_USE_SYSTEM_QT)
-  list(APPEND SLICER_LIBRARY_PATHS_BUILD ${QT_LIBRARY_DIR})
+  if(WIN32)
+    list(APPEND SLICER_LIBRARY_PATHS_BUILD ${QT_BINARY_DIR})
+  else()
+    list(APPEND SLICER_LIBRARY_PATHS_BUILD ${QT_LIBRARY_DIR})
+  endif()
 endif()
 
 # The following lines allow Slicer to load a CLI module extension that depends

--- a/CMake/SlicerBlockFindQtAndCheckVersion.cmake
+++ b/CMake/SlicerBlockFindQtAndCheckVersion.cmake
@@ -81,3 +81,7 @@ message(STATUS "Configuring ${_project_name} with Qt ${_major}.${_minor}.${_patc
   set(QT_BINARY_DIR "${Qt5_DIR}/../../../bin")
   get_filename_component(QT_BINARY_DIR ${QT_BINARY_DIR} ABSOLUTE)
   message(STATUS "Setting QT_BINARY_DIR: ${QT_BINARY_DIR}")
+
+set(QT_LIBRARY_DIR "${Qt5_DIR}/../../../lib")
+get_filename_component(QT_LIBRARY_DIR ${QT_LIBRARY_DIR} ABSOLUTE)
+message(STATUS "Setting QT_LIBRARY_DIR: ${QT_LIBRARY_DIR}")


### PR DESCRIPTION
This commit fixes the test and ensures that python modules compiled
on windows and depending on Qt (e.g `vtkRenderingQt`) can be imported
using PythonSlicer when executed from a Slicer build tree.

See #6228

It sets `QT_LIBRARY_DIR` variable and updates the `LibraryPaths`
launcher settings to append `QT_LIBRARY_DIR` on Unix and `QT_BINARY_DIR`
on Windows.

Running these commands on windows now work as expected:

```
  cd C:\D\S4R
  python-install\bin\PythonSlicer.exe -c "import slicer"

  cd C:\D\S4R\Slicer-build
  ctest.exe -C Release -R py_standalonepython_import_slicer
```

### Background

When configured against Qt4, the variables `QT_PLUGINS_DIR`, `QT_BINARY_DIR`
and `QT_LIBRARY_DIR` were set by the `FindQt4` CMake module.

Considering these variables are not set by the Qt5 modules, following
commit e88cb6649 (ENH: Add preliminary support for Qt5), the
variables `QT_PLUGINS_DIR` and `QT_BINARY_DIR` were explicitly set.

Until the introduction of the `slicer_dll_directories` module in
commit 34e48e8ae (ENH: Upgrade from python 3.6.7 to 3.9.10), there were
no issues with either

1. the missing `QT_BINARY_DIR` from the `LibraryPaths` launcher settings

2. the empty `QT_LIBRARY_DIR` variable

because:

* for build tree:
  - on Linux & macOS, library paths are resolved relying on rpath
    hard-coded in libraries and executables
  - on Windows, the `Paths` launcher settings was already properly set
    with `QT_BINARY_DIR`

* for install tree:
  - Qt libraries were installed in common location already associated
    with `LibraryPaths` and `Paths`