### PR TITLE
BUG: Fix linux package ensuring OpenGL_GL_PREFERENCE is considered with VTK9.1

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -178,7 +178,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "e0d1851e22db9ae1d39096464964e7f1fe333436") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "6a92c520ff927ff21047911445fe6113c1462f0e") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This commit is similar to c1a94fc83 that was fixing the same issue
for VTK 9.0.

To ensure the Slicer can run on system where only libGL is available,
this commit updates VTK to make sure setting `OpenGL_GL_PREFERENCE`
to LEGACY works as expected.

For reference, setting to LEGACY value was originally introduced
in 23d8144 (BUG: Fix linux package removing dependency to GLVND
libraries).

List of VTK changes:

```
$ git shortlog  e0d1851e22..fc49db9756 --no-merges
Jean-Christophe Fillion-Robin (2):
      COMP: Remove custom FindOpenGL to ensure OpenGL_GL_PREFERENCE is considered
      [Backport MR-8945] COMP: Ensure project depending on VTK link against correct OpenGL libraries
```