### PR TITLE
BUG: Workaround for Slicer hang on scipy import on Windows 11

### DIFF
--- a/Base/Python/slicer/__init__.py
+++ b/Base/Python/slicer/__init__.py
@@ -52,16 +52,18 @@ for kit in available_kits:
   del kit
 
 #-----------------------------------------------------------------------------
-# Import numpy early, as a workaround for application startup hang on Windows11
-# due to output redirection (only needed for embedded Python, not for standalone).
+# Import numpy and scipy early, as a workaround for application hang in import
+# of numpy or scipy at application startup on Windows 11 due to output redirection
+# (only needed for embedded Python, not for standalone).
 # See details in https://github.com/Slicer/Slicer/issues/5945
-# While the workaroudn is only needed for Windows11, it is performed on
+# While the workaround is only needed for Windows 11, it is performed on
 # all operating systems to minimize differences of the startup process
 # between different platforms.
 
 if not standalone_python:
   try:
     import numpy
+    import scipy
   except ImportError as detail:
     print(detail)
 


### PR DESCRIPTION
This is related to https://github.com/Slicer/Slicer/commit/542f53c5ba9bf650119707f990e36d74a6c8d36a.

I attempted `import scipy` in the latest Slicer preview 4.13.0-2022-02-28 and the Slicer application would then just hang. This is on my Windows 11 machine so I attempted the same type workaround as https://github.com/Slicer/Slicer/commit/542f53c5ba9bf650119707f990e36d74a6c8d36a and it no longer would cause the application to hang.

An unfortunate side-effect of this workaround is that there is no auto-complete for available methods. `numpy` has nothing show up on `numpy.[tab]` in the python interactor and `scipy` only has `scipy.test()` as an option. If I manually type out some known thing like `scipy.__version__` then it does appropriately print out:
```
>>> scipy.__version__
'1.7.3'
```