### PR TITLE
BUG: Fix interpolation reset issue in slice views

### DIFF
--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -1335,7 +1335,9 @@ void qMRMLSliceControllerWidgetPrivate::updateFromForegroundDisplayNode(vtkObjec
     {
     return;
     }
+  bool wasBlocked = this->actionForegroundInterpolation->blockSignals(true);
   this->actionForegroundInterpolation->setChecked(displayNode->GetInterpolate());
+  this->actionForegroundInterpolation->blockSignals(wasBlocked);
 }
 
 //---------------------------------------------------------------------------
@@ -1359,7 +1361,9 @@ void qMRMLSliceControllerWidgetPrivate::updateFromBackgroundDisplayNode(vtkObjec
     {
     return;
     }
+  bool wasBlocked = this->actionBackgroundInterpolation->blockSignals(true);
   this->actionBackgroundInterpolation->setChecked(displayNode->GetInterpolate());
+  this->actionBackgroundInterpolation->blockSignals(wasBlocked);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
When the interpolation was different for the previous and new (background or foreground) volume in the slice views when changing, the previous volume display node was set the interpolation value of the new volume display node. It was because of a signal that was emitted when setting the interpolation on the checkbox in the slice view controller, which triggered setting that interpolation value. By adding blockSignals calls this issue is fixed.

Fixes https://github.com/Slicer/Slicer/issues/6240