### PR TITLE
BUG: Fix broken multiple inheritance in ScriptedLoadableModule classes

### DIFF
--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -8,6 +8,7 @@ __all__ = ['ScriptedLoadableModule', 'ScriptedLoadableModuleWidget', 'ScriptedLo
 
 class ScriptedLoadableModule:
   def __init__(self, parent):
+    super().__init__()
     self.parent = parent
     self.moduleName = self.__class__.__name__
 
@@ -76,6 +77,7 @@ class ScriptedLoadableModuleWidget:
     """If parent widget is not specified: a top-level widget is created automatically;
     the application has to delete this widget (by calling widget.parent.deleteLater() to avoid memory leaks.
     """
+    super().__init__()
     # Get module name by stripping 'Widget' from the class name
     self.moduleName = self.__class__.__name__
     if self.moduleName.endswith('Widget'):
@@ -211,6 +213,7 @@ class ScriptedLoadableModuleWidget:
 
 class ScriptedLoadableModuleLogic:
   def __init__(self, parent = None):
+    super().__init__()
     # Get module name by stripping 'Logic' from the class name
     self.moduleName = self.__class__.__name__
     if self.moduleName.endswith('Logic'):


### PR DESCRIPTION
Missing calls to `super().__init__()` in the `ScriptedLoadableModule` classes break multiple inheritance. The init method is skipped in any derived classes that come after the ScriptedLoadableModule class in the MRO.

Adding super calls to each of the ScriptedLoadableModule classes fixes this issue and correctly supports multiple inheritance.

- `ScriptedLoadableModule.__init__`
- `ScriptedLoadableModuleWidget.__init__`
- `ScriptedLoadableModuleLogic.__init__`

---

For example, this class fails to initialize VTKObservationMixin:

```python
class MyModuleLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
  def __init__(self):
    super().__init__()
    
    self.addObserver(...)  # AttributeError on self.Observations
```

_In this case_, swapping the base class order avoids the error as `VTKObservationMixin` _does_ include a super call, however that solution is not perfect. `MyModuleLogic.__base__` is not `ScriptedLoadableModuleLogic` as it should be, and it is impossible to pass the optional `parent` parameter to `ScriptedLoadableModuleLogic.__init__`.

---

This change should not have any backwards compatibility issues, as currently the only way to support mixins is to explicitly call the mixin initializer, in which case the behavior of `super()` is ignored.

---

`ScriptedLoadableModuleTest` cannot be fixed because its base class, `unittest.TestCase`, [does not have a super call](https://github.com/python/cpython/blob/3.10/Lib/unittest/case.py#L357-L387). For such cases it would still be necessary to explicitly call the mixin initializer.
