### PR TITLE
ENH: Added a color legend item to the slice view context menu for volumes

### DIFF
--- a/Docs/user_guide/modules/colors.md
+++ b/Docs/user_guide/modules/colors.md
@@ -39,9 +39,10 @@ The loaded color table will appear in the "File" category at the top. Click on t
 ### Show color legend
 
 There are several ways of showing/hiding color legend:
-- In Data module, right-clicking on an eye icon in the data tree opens the visibility menu. In that menu, "Show color legend" option can be used for showing/hiding the color legend in all views. The option only appears if a color lookup table is already associated with the selected item.
-- Colors module allows adding/removing color legend to any displayable node at one place: open the Color Legend section, select a displayable node (volume, model, markup). Click `Create` to create a color legend, and adjust visualization options.
-- Color Legend section in Volumes, Models, Markups modules can be used to show legend for the selected node.
+- In Data module: Right-click on an eye icon in the data tree to open the visibility menu. In that menu, "Show color legend" option can be used for showing/hiding the color legend in all views. The option only appears if a color lookup table is already associated with the selected item.
+- In Colors module: Color legend can be added/hidden for any displayable node at one place. Open the Color Legend section, select a displayable node (volume, model, markup). Click `Create` to create a color legend, and adjust visualization options.
+- In Volumes, Models, Markups modules: Color Legend section can be used to show legend for the selected node.
+- In slice views: Right-click on a volume to open the view context menu. In that menu, "Show color legend" option can be used to show/hide color legend for that volume in slice views.
 
 For displaying mapping from numeric values to colors (for example, for displaying a parametric image), choose `Label text` -> `Value`. For displaying color names (for example, names of anatomical structures for a labelmap volume), choose `Label text` -> `Color name`.
 

--- a/Modules/Loadable/Colors/Logic/vtkSlicerColorLogic.h
+++ b/Modules/Loadable/Colors/Logic/vtkSlicerColorLogic.h
@@ -75,7 +75,7 @@ public:
 
   /// Get color legend node corresponding to the first valid display node of the input displayable node.
   /// Valid display node is any non-color-legend display node.
-  /// If not found then nulltr is returned.
+  /// If not found then nullptr is returned.
   static vtkMRMLColorLegendDisplayNode* GetColorLegendDisplayNode(vtkMRMLDisplayableNode* displayableNode);
 
   /// Get color legend node corresponding to a display node.

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/CMakeLists.txt
@@ -11,6 +11,8 @@ set(${KIT}_INCLUDE_DIRECTORIES
   ${MRMLLogic_INCLUDE_DIRS}
   ${MRMLCore_INCLUDE_DIRS}
   ${vtkSlicerVolumesModuleLogic_INCLUDE_DIRS}
+  ${vtkSlicerColorsModuleLogic_INCLUDE_DIRS}
+  ${vtkSlicerColorsModuleMRML_INCLUDE_DIRS}
   )
 
 set(${KIT}_SRCS
@@ -39,6 +41,7 @@ set(${KIT}_RESOURCES
 set(${KIT}_TARGET_LIBRARIES
   qSlicerSubjectHierarchyModuleWidgets
   vtkSlicerSubjectHierarchyModuleLogic
+  vtkSlicerColorsModuleLogic
   qMRMLWidgets
   MRMLLogic
   MRMLCore

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.h
@@ -157,6 +157,9 @@ protected slots:
   /// Set window/level by mapped menu signal
   void setVolumePreset(const QString& presetId);
 
+  /// Toggle color legend option for current volume item in a slice view
+  void toggleVisibilityForCurrentItem(bool);
+
 protected:
   QScopedPointer<qSlicerSubjectHierarchyVolumesPluginPrivate> d_ptr;
 


### PR DESCRIPTION
The item is visible if slice view has a volume on it, and volume has valid color node and primary display node. Part of the #6111 issue.

Example of the context menu item.

![image](https://user-images.githubusercontent.com/3785912/157093339-e379d52c-1eef-4c1d-bfa0-6de53487998d.png)
