### PR TITLE
COMP: Update LibFFI external project to accept INCLUDE_DIR and LIBRARY vars

### DIFF
--- a/SuperBuild/External_LibFFI.cmake
+++ b/SuperBuild/External_LibFFI.cmake
@@ -16,11 +16,15 @@ if(Slicer_USE_SYSTEM_${proj})
 endif()
 
 # Sanity checks
-if(DEFINED ${proj}_DIR AND NOT EXISTS ${${proj}_DIR})
-  message(FATAL_ERROR "${proj}_DIR variable is defined but corresponds to nonexistent directory")
+if(DEFINED LibFFI_INCLUDE_DIR AND NOT EXISTS ${LibFFI_INCLUDE_DIR})
+  message(FATAL_ERROR "LibFFI_INCLUDE_DIR variable is defined but corresponds to nonexistent directory")
+endif()
+if(DEFINED LibFFI_LIBRARY AND NOT EXISTS ${LibFFI_LIBRARY})
+  message(FATAL_ERROR "LibFFI_LIBRARY variable is defined but corresponds to nonexistent file")
 endif()
 
-if(NOT DEFINED ${proj}_DIR AND NOT Slicer_USE_SYSTEM_${proj})
+if((NOT DEFINED LibFFI_INCLUDE_DIR
+   OR NOT DEFINED LibFFI_LIBRARY) AND NOT Slicer_USE_SYSTEM_${proj})
 
   set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
   set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)


### PR DESCRIPTION
This commit updates the LibFFI external project originally introduced
in 34e48e8aef (ENH: Upgrade from python 3.6.7 to 3.9.10) to also check
if the variables `LibFFI_INCLUDE_DIR` and `LibFFI_LIBRARY` are set.