### PR TITLE
BUG: Fix broken multiple inheritance in ScriptedLoadableModuleTest 

### DIFF
--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -299,7 +299,12 @@ class ScriptedLoadableModuleTest(unittest.TestCase):
   """
 
   def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs)
+    super(ScriptedLoadableModuleTest, self).__init__(*args, **kwargs)
+
+    # See https://github.com/Slicer/Slicer/pull/6243#issuecomment-1061800718 for more information.
+    # Do not pass *args, **kwargs since there is no base class after `unittest.TestCase`. This is only relevant to
+    # mixins of derived classes, which should each have the same signature as `object()`.
+    super(unittest.TestCase, self).__init__()
 
     # takeScreenshot default parameters
     self.enableScreenshots = False

--- a/Base/Python/slicer/tests/test_slicer_util_VTKObservationMixin.py
+++ b/Base/Python/slicer/tests/test_slicer_util_VTKObservationMixin.py
@@ -1,7 +1,9 @@
 import unittest
+import unittest.mock
 
 import vtk
 
+from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 
 
@@ -155,3 +157,70 @@ class SlicerUtilVTKObservationMixinTests(unittest.TestCase):
 
     foo.removeObservers(method=callback)
     self.assertEqual(len(foo.Observations), 1)
+
+  def test_moduleWidgetMixin(self):
+    class MyModule(ScriptedLoadableModuleWidget, VTKObservationMixin):
+      pass
+
+    parent = unittest.mock.Mock()
+    module = MyModule(parent)
+
+    obj = vtk.vtkObject()
+    event = vtk.vtkCommand.ModifiedEvent
+    callback = unittest.mock.Mock()
+
+    module.addObserver(obj, event, callback)
+
+    callback.assert_not_called()
+    obj.Modified()
+    callback.assert_called()
+
+  def test_moduleLogicMixin(self):
+    class MyModuleLogic(ScriptedLoadableModuleLogic, VTKObservationMixin):
+      pass
+
+    logic = MyModuleLogic()
+
+    obj = vtk.vtkObject()
+    event = vtk.vtkCommand.ModifiedEvent
+    callback = unittest.mock.Mock()
+
+    logic.addObserver(obj, event, callback)
+
+    callback.assert_not_called()
+    obj.Modified()
+    callback.assert_called()
+
+  def test_moduleTestMixin(self):
+    class MyModuleTest(ScriptedLoadableModuleTest, VTKObservationMixin):
+      pass
+
+    test = MyModuleTest()
+
+    obj = vtk.vtkObject()
+    event = vtk.vtkCommand.ModifiedEvent
+    callback = unittest.mock.Mock()
+
+    test.addObserver(obj, event, callback)
+
+    callback.assert_not_called()
+    obj.Modified()
+    callback.assert_called()
+
+  def test_moduleTestInitCount(self):
+    # if this fails, then unittest.TestCase.__init__ may have added a super().__init__() call.
+    # See https://github.com/Slicer/Slicer/pull/6243#issuecomment-1061800718 for more information.
+
+    class CountInitCalls:
+      count = 0
+
+      def __init__(self):
+        super().__init__()
+
+        self.count += 1
+
+    class MyModuleTest(ScriptedLoadableModuleTest, CountInitCalls):
+      pass
+
+    test = MyModuleTest()
+    self.assertEqual(test.count, 1)


### PR DESCRIPTION
See my comment here: https://github.com/Slicer/Slicer/pull/6243#issuecomment-1061800718

> > ScriptedLoadableModuleTest cannot be fixed because its base class, unittest.TestCase, [does not have a super call](https://github.com/python/cpython/blob/3.10/Lib/unittest/case.py#L357-L387). For such cases it would still be necessary to explicitly call the mixin initializer.
> 
> > https://docs.python.org/3/library/functions.html#super
> 
> Reading through that documentation more carefully, it seems it _is_ possible to fix the behavior for `ScriptedLoadableModuleTest` as well. @jcfr thanks for posting the link! It helps to read things even if you already know the bulk of it, I learned something new!
> 
> > The object-or-type determines the [method resolution order](https://docs.python.org/3/glossary.html#term-method-resolution-order) to be searched. The search starts from the class right after the type.
> 
> This indicates that `super(UnitTest, self)` would take the next base type of `self` _after `UnitTest`_.
> 
> ***[...]***
> 
> There is a risk in this implementation: if a super call is ever added to the `UnitTest` class, then `Mixin.__init__` (and `object.__init__`) would be invoked twice.

I have introduced the above change (c582589a3a75be4028477c681ca0c0dd83049ae5) and added tests corresponding with this and #6243 (44779801c54528a572e9baa217432a1844cfba67).