### PR TITLE
COMP: Update VTK to improve support for externally build VTK modules

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -178,7 +178,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "6a92c520ff927ff21047911445fe6113c1462f0e") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "0ba7af6306aa5f2dd2d50a5b7bb7fe28800c0917") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of VTK changes:

* Improve build-system support for externally built modules
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8123

* vtk-config: Add find_package hints for OpenVR
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8977

```
$ git shortlog 6a92c520f..0ba7af6306 --no-merges
Jean-Christophe Fillion-Robin (4):
      [Backport MR-8977] vtkInstallCMakePackageHelpers: add find_package hints for OpenVR
      [Backport MR-8123] Do not generate files in source tree when building module externally
      [Backport MR-8123] vtk_module_build: Update CMake function fixing use of quotes and indentation
      [Backport MR-8123] vtk_module_build: Ensure external modules build directory are not overwritten
```