### PR TITLE
ENH: improve dataprobe magnifier borders

### DIFF
--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -6,7 +6,6 @@ import vtkTeem
 import DataProbeLib
 from slicer.ScriptedLoadableModule import *
 from slicer.util import TESTING_DATA_URL
-import numpy
 
 #
 # DataProbe
@@ -369,8 +368,9 @@ class DataProbeInfoWidget:
       imageCrop.SetVOI(imin, imax, jmin, jmax, 0,0)
       imageCrop.Update()
       vtkImageCropped = imageCrop.GetOutput()
-      xyzBounds = numpy.zeros(6, dtype=int)
+      xyzBounds = [0]*6
       vtkImageCropped.GetBounds(xyzBounds)
+      xyzBounds = [_roundInt(value) for value in xyzBounds]
       canvas.DrawImage(xyzBounds[0], xyzBounds[2], vtkImageCropped)
       canvas.Update()
       vtkImageFromCanvas = canvas.GetOutput()

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -355,6 +355,10 @@ class DataProbeInfoWidget:
     imax = xyzInt[0]+imageSize
     jmin = xyzInt[1]-imageSize
     jmax = xyzInt[1]+imageSize
+    imin_trunc = max(0,imin)
+    imax_trunc = min(dims[0]-1, imax)
+    jmin_trunc = max(0, jmin)
+    jmax_trunc = min(dims[1]-1, jmax)
     # The extra complexity of the canvas is used here to maintain a fixed size
     # output due to the imageCrop returning a smaller image if the limits are
     # outside the input image bounds. Specially useful when zooming at the borders.
@@ -364,8 +368,8 @@ class DataProbeInfoWidget:
     canvas.SetExtent(imin, imax, jmin , jmax, 0 ,0)
     canvas.FillBox(imin, imax, jmin , jmax)
     canvas.Update()
-    if (imin <= min(dims[0]-1,  imax)) and (jmin <= min(dims[1]-1,  jmax)):
-      imageCrop.SetVOI(imin, imax, jmin, jmax, 0,0)
+    if (imin_trunc <= imax_trunc) and (jmin_trunc <= jmax_trunc):
+      imageCrop.SetVOI(imin_trunc, imax_trunc, jmin_trunc, jmax_trunc, 0,0)
       imageCrop.Update()
       vtkImageCropped = imageCrop.GetOutput()
       xyzBounds = [0]*6

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -356,24 +356,27 @@ class DataProbeInfoWidget:
     imax = xyzInt[0]+imageSize
     jmin = xyzInt[1]-imageSize
     jmax = xyzInt[1]+imageSize
+    # The extra complexity of the canvas is used here to maintain a fixed size
+    # output due to the imageCrop returning a smaller image if the limits are
+    # outside the input image bounds. Specially useful when zooming at the borders.
     canvas = self.canvas
     canvas.SetScalarType(producer.GetOutput().GetScalarType())
     canvas.SetNumberOfScalarComponents(producer.GetOutput().GetNumberOfScalarComponents())
     canvas.SetExtent(imin, imax, jmin , jmax, 0 ,0)
     canvas.FillBox(imin, imax, jmin , jmax)
     canvas.Update()
-    if (imin <= imax) and (jmin <= jmax):
+    if (imin <= min(dims[0]-1,  imax)) and (jmin <= min(dims[1]-1,  jmax)):
       imageCrop.SetVOI(imin, imax, jmin, jmax, 0,0)
       imageCrop.Update()
-      vtkImage2 = imageCrop.GetOutput()
+      vtkImageCropped = imageCrop.GetOutput()
       xyzBounds = numpy.zeros(6, dtype=int)
-      vtkImage2.GetBounds(xyzBounds)
-      canvas.DrawImage(xyzBounds[0], xyzBounds[2], vtkImage2)
+      vtkImageCropped.GetBounds(xyzBounds)
+      canvas.DrawImage(xyzBounds[0], xyzBounds[2], vtkImageCropped)
       canvas.Update()
-      vtkImage = canvas.GetOutput()
-      if vtkImage:
+      vtkImageFromCanvas = canvas.GetOutput()
+      if vtkImageFromCanvas:
         qImage = qt.QImage()
-        slicer.qMRMLUtils().vtkImageDataToQImage(vtkImage, qImage)
+        slicer.qMRMLUtils().vtkImageDataToQImage(vtkImageFromCanvas, qImage)
         imagePixmap = qt.QPixmap.fromImage(qImage)
         imagePixmap = imagePixmap.scaled(outputSize, qt.Qt.KeepAspectRatio, qt.Qt.FastTransformation)
 


### PR DESCRIPTION
The DataProbe magnifier currently has an odd behavior when the mouse approach the corners of the slice views:
![image](https://user-images.githubusercontent.com/4790289/157307301-4a511658-abd4-4e98-bde6-2be1e02b9862.png)

This PR uses a 2D canvas with a fixed size and draws the crop imagedata on it at the right position.