### PR TITLE
BUG: Update VTK to backport fixes for vtkOBJExporter/vtkPLYWriter/HiDPI+Qt

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -178,7 +178,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "0ba7af6306aa5f2dd2d50a5b7bb7fe28800c0917") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "48ac9c0cba5c3cfeefa297587e77a659e6f029c6") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of VTK changes:

```
$ git shortlog 0ba7af630..48ac9c0cba --no-merges
Andras Lasso (3):
      [Backport] Fix vtkOBJExporter file corruption when writing triangle strips
      [Backport] Fix ScreenSize setting when using Qt on HiDPI display
      [Backport] Refactor and fix vtkSelectPolyData bugs

Csaba Pinter (1):
      [Backport] Fix "Can't follow edge" error in vtkSelectPolyData

Junpeng Kang (1):
      [Backport] Make vtkPLYWriter write point normals
```