### PR TITLE
ENH:Make vtkMRMLMarkupsFiducialStorageNode generic

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -282,11 +282,7 @@ void vtkMRMLMarkupsFiducialStorageNode::Copy(vtkMRMLNode *anode)
 //----------------------------------------------------------------------------
 bool vtkMRMLMarkupsFiducialStorageNode::CanReadInReferenceNode(vtkMRMLNode *refNode)
 {
-  return refNode->IsA("vtkMRMLMarkupsFiducialNode") ||
-         refNode->IsA("vtkMRMLMarkupsLineNode") ||
-         refNode->IsA("vtkMRMLMarkupsAngleNode") ||
-         refNode->IsA("vtkMRMLMarkupsCurveNode") ||
-         refNode->IsA("vtkMRMLMarkupsPlaneNode");
+  return refNode->IsA("vtkMRMLMarkupsNode");
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This allows `vtkMRMLMarkupsFiducialStorageNode` to be used by markups
defined in external modules (pluggable markups)