### PR TITLE
ENH: Improve robustness check in vtkSlicerSegmentationGeometryLogic

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationGeometryLogic.cxx
@@ -118,6 +118,10 @@ std::string vtkSlicerSegmentationGeometryLogic::CalculateOutputGeometry()
     {
     return "No input segmentation specified";
     }
+  if (!this->SourceGeometryNode)
+    {
+    return "No source geometry specified";
+    }
 
   // Determine source type
   vtkMRMLScalarVolumeNode* sourceVolumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(this->SourceGeometryNode);


### PR DESCRIPTION
It will prevent a crash in CalculateOutputGeometryFromBounds if the source geometry is not set.