### PR TITLE
DOC: Add explanation of exporting markups

### DIFF
--- a/Docs/developer_guide/script_repository/markups.md
+++ b/Docs/developer_guide/script_repository/markups.md
@@ -8,6 +8,12 @@ Markups point list can be loaded from file:
 slicer.util.loadMarkupsFiducialList("/path/to/list/F.fcsv")
 ```
 
+### Save markups to .fcsv file
+```python
+markups_node = slicer.mrmlScene.GetNodeByID("vtkMRMLMarkupsFiducialNode1")
+slicer.util.saveNode(markups_node, "/path/to/markpus/file.fcsv")
+```
+
 ### Adding control points Programmatically
 
 Markups control points can be added to the currently active point list from the python console by using the following module logic command:


### PR DESCRIPTION
Added two lines of code showing how to export/save markups to an .fcsv file

I thought it would be useful to add this to the script repository - it is already explained how an .fcsv file can be loaded but not how it can be created