### PR TITLE
BUG: Fix Markups curve picking

### DIFF
--- a/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
+++ b/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
@@ -115,6 +115,8 @@ vtkMRMLColorLegendDisplayableManager::vtkInternal::vtkInternal(vtkMRMLColorLegen
 : External(external)
 {
   this->ColorLegendRenderer = vtkSmartPointer<vtkRenderer>::New();
+  // Prevent erasing Z-buffer (important for quick picking and markup label visibility assessment)
+  this->ColorLegendRenderer->EraseOff();
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
The color legend renderer was erasing the Z-buffer, making it impossible to interact with markups curves outside of the view plane.
Fixed by setting setting disabling the Erase flag on the color legend renderer.