### PR TITLE
ENH: Move "Application settings" action to the top of Edit menu

### DIFF
--- a/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
+++ b/Base/QTApp/Resources/UI/qSlicerMainWindow.ui
@@ -234,14 +234,14 @@
     <property name="title">
      <string>&amp;Edit</string>
     </property>
+    <addaction name="EditApplicationSettingsAction"/>
+    <addaction name="separator"/>
     <addaction name="CutAction"/>
     <addaction name="CopyAction"/>
     <addaction name="PasteAction"/>
     <addaction name="separator"/>
     <addaction name="EditRecordMacroAction"/>
     <addaction name="EditPlayMacroAction"/>
-    <addaction name="separator"/>
-    <addaction name="EditApplicationSettingsAction"/>
    </widget>
    <widget class="QMenu" name="ViewMenu">
     <property name="title">


### PR DESCRIPTION
Edit menu's Cut/Copy/Paste actions are not useful (with a few exceptions, copy-paste is only supported in textboxes where keyboard shortcuts and right-click menu are more convenient to use).
It is fine to have them there to make menu sizes a bit more balanced.

In contrast, "Application Settings" action is used often and it is much harder to click at the bottom of the menu than at the top.

Therefore, this commit moves "Application Settings" action to the top of the Edit menu.

Before this commit:

![image](https://user-images.githubusercontent.com/307929/158267227-1e9feebb-b889-474f-8514-45a6a8b2414a.png)

After this commit:

![image](https://user-images.githubusercontent.com/307929/158267186-33ddf2b9-c1e5-4909-8df6-f5886029434f.png)
