### PR TITLE
BUG: segfault invoked by SettingsDialog deletion

### DIFF
--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -141,8 +141,8 @@ public:
   QSettings* newSettings() override;
 
   QPointer<qSlicerLayoutManager> LayoutManager;
-  ctkToolTipTrapper*      ToolTipTrapper;
-  ctkSettingsDialog*      SettingsDialog;
+  ctkToolTipTrapper* ToolTipTrapper;
+  QPointer<ctkSettingsDialog> SettingsDialog;
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
   qSlicerExtensionsManagerDialog* ExtensionsManagerDialog;
   bool IsExtensionsManagerDialogOpen;
@@ -178,9 +178,11 @@ qSlicerApplicationPrivate::qSlicerApplicationPrivate(
 qSlicerApplicationPrivate::~qSlicerApplicationPrivate()
 {
   // Delete settings dialog. deleteLater would cause memory leaks on exit.
-  this->SettingsDialog->setParent(nullptr);
-  delete this->SettingsDialog;
-  this->SettingsDialog = nullptr;
+  if (this->SettingsDialog)
+    {
+    this->SettingsDialog->setParent(nullptr);
+    delete this->SettingsDialog;
+    }
 
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
   if(this->ExtensionsManagerDialog)

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -142,6 +142,10 @@ public:
 
   QPointer<qSlicerLayoutManager> LayoutManager;
   ctkToolTipTrapper* ToolTipTrapper;
+  // If MainWindow exists and the dialog is displayed then the MainWindow 
+  // must be set as parent to ensure correct Z order; 
+  // but that also transfers the ownership of the object, therefore we use QPointer
+  // to keep track if the object is deleted already by the MainWindow.
   QPointer<ctkSettingsDialog> SettingsDialog;
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
   qSlicerExtensionsManagerDialog* ExtensionsManagerDialog;
@@ -178,6 +182,9 @@ qSlicerApplicationPrivate::qSlicerApplicationPrivate(
 qSlicerApplicationPrivate::~qSlicerApplicationPrivate()
 {
   // Delete settings dialog. deleteLater would cause memory leaks on exit.
+  // Settings dialog is displayed then MainWindow becomes its parent and 
+  // thus MainWindow is responsible for deleting it.
+  // Set the parent to 'nullptr' removes this responsibility.
   if (this->SettingsDialog)
     {
     this->SettingsDialog->setParent(nullptr);


### PR DESCRIPTION
Previous implementation worked only when when mainwindow is deleted after app.
If mainwindow is deleted before app then we get seg fault in destructor.
I.e. we are trying to set parent to destroyed SettingsDialog.
This used to happen with SlicerCAT.

QPointer helps to track the lifetime of a pointer.
So we always know if it is alive.

Steps to reproduce:
1) launch SlicerCAT from command line
1) open `Application settings`
2) close it
3) close application
4) see output to command line