### PR TITLE
BUG: Fix vtk referenced before assignment error in GE ABUS DICOM plugin

### DIFF
--- a/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMGeAbusPlugin.py
@@ -251,6 +251,7 @@ class DICOMGeAbusPluginClass(DICOMPlugin):
 
     # create a grid transform with one vector at the corner of each slice
     # the transform is in the same space and orientation as the volume node
+    import vtk
     gridImage = vtk.vtkImageData()
     gridImage.SetOrigin(*volumeNode.GetOrigin())
     gridImage.SetDimensions(samplingPoints_shape[:3])


### PR DESCRIPTION
This commit fixes this error (occurs when trying to load a GE ABUS image):

```
Warning in DICOM plugin GE ABUS when examining loadable 1: US TEST1 [1]: Loading of this image type is experimental. Please verify image size and orientation and report any problem is found.
Warnings detected during load.  Examine data in Advanced mode for details.  Load anyway?
DICOM plugin failed to load '1: US TEST1 [1]' as a 'GE ABUS'.
Traceback (most recent call last):
  File "C:\Users\andra\AppData\Local\NA-MIC\Slicer 4.13.0-2022-03-19\lib\Slicer-4.13\qt-scripted-modules\DICOMLib\DICOMUtils.py", line 790, in loadLoadables
    loadSuccess = plugin.load(loadable)
  File "C:/Users/andra/AppData/Local/NA-MIC/Slicer 4.13.0-2022-03-19/bin/../lib/Slicer-4.13/qt-scripted-modules/DICOMGeAbusPlugin.py", line 212, in load
    acquisitionTransform = self.createAcquisitionTransform(volumeNode, metadata)
  File "C:/Users/andra/AppData/Local/NA-MIC/Slicer 4.13.0-2022-03-19/bin/../lib/Slicer-4.13/qt-scripted-modules/DICOMGeAbusPlugin.py", line 254, in createAcquisitionTransform
    gridImage = vtk.vtkImageData()
UnboundLocalError: local variable 'vtk' referenced before assignment
```