### PR TITLE
COMP: Update VTK to include inline namespace support

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -178,8 +178,8 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "684e8a602bd57dd6aaf4a7e086c2ea5d76e8e8b5") # slicer-v9.1.20220125-efbe2afc2
-    set(vtk_egg_info_version "9.1.20220125")
+    set(_git_tag "d943ac20a10e2882c556f0f0bed57c930e3780c2") # slicer-v9.1.20220309-574bf95bd-namespace_vtk_9_1_0
+    set(vtk_egg_info_version "9.1.20220309")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")
   endif()


### PR DESCRIPTION
The purpose of this pull request is to proactively test changed being proposed at https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8993

See https://discourse.vtk.org/t/wrapping-vtk-in-an-inline-namespace/8072/9

Note that since the integration of VTK within Slicer required few patches, a new branch based of [VTK MR#8993](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8993) and including the relevant Slicer changes has been published here:

https://github.com/Slicer/VTK/commits/slicer-v9.1.20220309-574bf95bd-namespace_vtk_9_1_0

List of `Slicer/VTK` changes:

```
$ git shortlog 574bf95bde..d943ac20a1 --no-merges
Jean-Christophe Fillion-Robin (11):
      BUG: Update vtkPythonUtil to disable relative import causing crash for Slicer modules
      COMP: Remove FindTBB and expect VTK to be configured with TBB_DIR
      COMP: Add support for specifying vtk-m library install components
      STYLE: Remove CMake message debug statements from vtkvtkm/CMakeLists.txt
      COMP: Update vtk-m submodule url to use github.com/KitwareMedical/vtk-m
      COMP: Remove custom FindOpenGL to ensure OpenGL_GL_PREFERENCE is considered
      [Backport MR-8945] COMP: Ensure project depending on VTK link against correct OpenGL libraries
      [Backport MR-8977] vtkInstallCMakePackageHelpers: add find_package hints for OpenVR
      [Backport MR-8123] Do not generate files in source tree when building module externally
      [Backport MR-8123] vtk_module_build: Update CMake function fixing use of quotes and indentation
      [Backport MR-8123] vtk_module_build: Ensure external modules build directory are not overwritten

Ryan Krattiger (26):
      Add CMake option for namespace
      Make wrapping ignore inline namespace declarations
      Add namespace macros
      Manually namespace Utilities/DICOMParser
      Include vtkABINamespace header in relevant files.
      Namespace Python wrappings
      Rendering fixup
      Web fixup
      GUISupport/Views fixup
      IOImage fixup
      Testing fixup
      Boost/vtkm/mics fixup
      Domains/GDal fixup
      CI: add -k 1000 to build to be more efficient
      Unnamespace python wrappings
      AutoInit fixes
      Fixes for CI builds.
      Auto Init namespace in macros automatically.
      OpenTURNS and WinMain fixes
      Add release note for ABI namespace.
      Fix LIC Composite operator <<
      CMake default cleanup
      Move CMake to Common/Core and fixups
      Add CommonCore dep to targets for vtkABINamespace
      Fixes to examples.
      Try I_MPI_SHM=0

Shreeraj Jadhav (1):
      vtkm: Update diy install rules, support TBB_DIR
```

List of upstream VTK changes:

```
$ git shortlog 684e8a602..574bf95bde --no-merges
Alexy Pellegrini (1):
      Reencode arial fonts in order to correct the license

Andras Lasso (4):
      Fix writing of PBR material in vtkGLTFExporter for PBR interpolation
      Fix ScreenSize setting when using Qt on HiDPI display
      Fix vtkOBJExporter file corruption when writing triangle strips
      Refactor and fix vtkSelectPolyData bugs

Andreas Buykx (1):
      Object name for reporting

Ben Boeckel (19):
      vtkPythonInterpreter: ensure the argument list is `nullptr`-terminated
      vtkPythonInterpreter: pass pruned arguments to Py_Main
      Utilities/Python: drop `--unresolved-symbols=` with Intel OneAPI
      ci: add a Docker image for Intel compiler builds
      gitlab-ci: add an Intel compiler build
      vtkTesting: fix typo in deprecation warning
      TestSimplePCompositeZPass: use a smaller message tag
      IntelLLVM: disable fastmath for all relevant builds
      ioss: update to use vtkfmt instead of the embedded copy
      vtkCompilerExtraFlags: skip using `vtkbuild` if it doesn't exist
      vtkPythonInterpreter: fix narrowing cast warnings
      vtkTable: fix `emplace_back` usage lints
      CTestCustom: ignore some lints from wrapper code
      vtkExodusIIReader: unhide `GetObjectName` from superclass
      PyVTKObject: remove unnecessary `.c_str()` call
      ci: always set the CUDA launcher
      vtkSphericalPointIterator: include `<memory>` for `std::unique_ptr`
      ci: exclude TestCookieCutter4 on Windows with STDThread
      ci: exclude TestCookieCutter4 on all stdthread builds

Berk Geveci (3):
      Added ability to overwrite a VTK class with a Python subclass.
      Several fixes to subclass overriding.
      Added release notes.

Boonthanome Nouanesengsy (2):
      H5Rage bug with warnings in parallel
      support for even/odd/restart dumps for pio reader

Caitlin Ross (2):
      vtkPIOReader: fix segfault in PIOAdaptor
      vtkPIOReader: fix segfault in PIOAdaptor

Charles Gueunet (7):
      Add install target on the wrapping example
      Generate better __init__.py
      Rename vtk filter to avoid naming confusion
      Rename vtk filter to avoid naming confusion
      Add a way to print the array type
      Refactoring to use a single mapper in the HTG Mapper
      Enforce multiblock in mapper

Cory Quammen (1):
      vtkPIOReader: fix hang during parallel execution of reader

Csaba Pinter (1):
      Fix "Can't follow edge" error in vtkSelectPolyData

Dan Lipsa (1):
      This description is now part of VTK File Formats in vtk-examples.

David Gobbi (6):
      Restore vtkPythonInterpreter Python2 compatibility
      Add a vtkPythonUtil::IsInitialized() check
      Search for vtkRenderingTk within vtkmodules
      Add implementation modules to Python GUI examples
      Allow Python class override to be None
      Use absolute path for LICENSE_FILES property

Gaspard Thevenon (1):
      Fix shader crash in Multi Volume Rendering without GradientTF

Jaswant Panchumarti (1):
      Code updates to CamOrientWidget

Jean-Christophe Fillion-Robin (2):
      BUG: Rename vtkInteractionCallback class to avoid symbol clash
      DOC: Add release note documenting vtkInteractionCallback symbol clash

John Patchett (1):
      require basename/problemname begin the filenames matched as dumps

Junpeng Kang (1):
      Make vtkPLYWriter write point normals

Ken Martin (1):
      feat(Rendering): add coordinate systems to Prop3D

Kitware Robot (43):
      VTK Nightly Date Stamp
      [...]

Laurenn Lam (1):
      ENH: Add slicing scale factor when scrolling in vtkResliceImageViewer

Lucas Gandel (3):
      Include algorithm for std::max/std::min
      Fix reslice cursor widget interactions and testing
      Update TestResliceCursorWidget baseline images

Mathieu Westphal (7):
      Fix warnings with stream surface
      Fix non mpi adios build include
      Adding licenses for all modules that needs it
      Adding license support for python modules
      Remove outdated remote modules that do not build anymore
      Remove unmaintained remote modules
      Update remote modules for licenses

Menno Deij - van Rijswijk (2):
      Read/Write partitioned dataset name in vtkCompositeDataReader/Writer
      vtkDIYUtilities with non-standard memory layout array handling

Nicolas Vuaille (3):
      Update vtkCamera ParallelProjectionScale documentation
      Array Rename move sanity check
      vtkMergeTimeFilter correctly supports non-temporal input

Peter Franz (4):
      Remove shadow parameter in vtkPlotBar.
      Fix build warnings.
      Remove BuildTime shadow parameters.
      Reorder initializations to match interface declaration order.

Sankhesh Jhaveri (11):
      Fix regex in doxygen generating perl scripts
      Use GitLab link to VTK repository on doxygen pages
      Use MathJax to render latex formulae in doxygen documentation
      Use the standard vtk logo for examples with no images
      Ensure that dangling references are cleaned up
      Fix Windows issue with pre-defined keyword `NO_ERROR`
      Remove use of deprecated cell types API for ospray
      Conditionally use deprecated API for Qt < 6.0
      Avoid name collisions in Qt tests
      Deprecated API from Qt v5.14
      Added release note for enum change in vtkUnstructuedGridQuadricDecimation

Seacas Upstream (2):
      ioss 2022-02-11 (3ddeaef1)
      ioss 2022-02-11 (3ddeaef1)

Sean McBride (5):
      Suppress some -Wreserved-identifier warnings
      Suppress some new false positives from cppcheck 2.7
      Fixed various compiler warnings on cdash
      Fixed -Wshadow warnings by renaming variable
      Fixed compiler error with pre-10.13 macOS SDK

Sjors Peterse (1):
      Change vtkProp to vtkProp3D in documentation

Spiros Tsalikis (29):
      vtkFrustumSelector: Perform the minimum number of new operations
      vtkSelection/vtkSelectionNode: Use vtk Licence header
      vtkSelection: Use std::to_string()
      vtkSelectionSource: Add ElementType and ProcessId, remove PreserveTopology
      vtkExtractSelection: Preserve selection nodeProcessId == ProcessId
      vtkSelectionSource: Can generate many nodes
      vtkAppendSelection: Allow setting an expression and input names
      vtkSelection: Support boolean xor
      vtkContextScene: Create named enum SelectionModifier
      vtkDataObjectTree: Add using Superclass::GetDataSet
      vtkTriQuadraticPyramid: Fix typo
      vtkConvertSelection: Support conversion from Block selection to Indices
      vtkExtractSelected*: Deprecate extraction classes that are no longer used
      vtkUniformGridAMR: Improve documentation
      vtkHierarchicalBoxDataIterator: Deprecate, use vtkUniformGridAMRDataIterator
      Fix selection extraction for vtkUniformGridAMR-based datasets
      vtkCompositePolyDataMapper2: Accepts only vtkDataObjectTree composite dataset
      vtkOpenGLHardwareSelector: Code simplifications
      Add changelog
      verdict: Remove old repository
      tpl: Add tpl harness for verdict
      vtkMeshQuality/vtkCellQuality: Update to the latest verdict version
      vtkMeshQuality/vtkCellQuality: Add new metrics and support for pyramid, wedge
      vtkMeshQuality/vtkCellQuality: Multithread using vtkSMPTools
      vtkCellQuality/vtkMeshQuality: Make QualityMeasureTypes enum class
      vtkMeshQuality: Remove redundant documentation
      Add changelog
      Add API changes
      vtkMeshQuality: Fix typo

Stephen Hogarth (3):
      Cell Links: Parallel Memory Allocation
      Add Faster AddRGBPoints Routine
      Add Widget Polygon Background Option

Stephen McDowell (1):
      glTF exporter needs to invert the camera model view transform

Sujin Philip (1):
      Add VTK-m overrides for VTK filters

Thomas Galland (2):
      Add 1D convolution function
      Make template version of convolution1D + add tests + add doc

Tiffany Chhim (1):
      Fix wrong indexation in constrained 2D Delaunay triangulation

Timothee Chabat (1):
      Makes vtkColorLegend ticks now use hard limits

Todd Martin (2):
      Consistently decode utf-8 args into wchar_t args for the Python interpreter
      Make initialisation work with wide args for all versions of Python

Utkarsh Ayachit (1):
      vtkIOSSUtilities: read side-set arrays

Verdict Upstream (1):
      verdict 2022-03-03 (3f2672f6)

Will Schroeder (4):
      Cleaned up dashboard warnings
      First pass
      SMPTools support for performance on large models
      Updated methods and removed warnings based on dashboard feedback

Xinhua Zhang (2):
      Fixed Bugs About Computing 3D Surface
      Fixed a Bug About the Initialization of vtkAMRInterpolatedVelocityField

Yaz Saito (2):
      Add vtkOffscreenOpenGLRenderWindow to render_window_serializer
      render_window_serializer: support discretized ColorTransferFunctions

Yohann Bearzi (17):
      Revert "Fix ChartXY Axis auto behavior and log scale issue."
      vtkDIYGhostUtilities: loosen bounding boxes
      vtkDIYGhostUtilities: loosen bounding boxes
      vtkDIYUtilities: fix int ambiguity when saving arrays
      PIOAdaptor: handling input files with no dumps
      PIOAdaptor: handling input files with no dumps
      Removing saving logs in TestOverlappingCellsDetector from home
      vtkRenderWindowInteractor: Setting `InteractorStyle` as `vtkSmartPointer`
      Adding a sum output to `vtkExtractDataArraysOverTime`
      cell locators: compatibility for polyhedra-polygon
      vtkRenderWindowInteractor::InteractorStyle handling fix
      TestDataArraySerialization: renaming and fixing compile issue
      vtkGhostCellsGenerator: allowing to request 0 layers of ghost cells
      DIYGhostUtilities: fixing grid synchronization for image data
      TestUniformGridGhostDataGenerator enhancements
      vtkExtractDataArraysOverTime: Removing ExtractSum
      PIOAdaptor: Adding dump_filename as vtkFieldData
```