### PR TITLE
ENH: Close application after save

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.cxx
+++ b/Base/QTApp/qSlicerMainWindow.cxx
@@ -642,9 +642,9 @@ bool qSlicerMainWindowPrivate::confirmCloseApplication()
     messageBox->exec();
     if (messageBox->clickedButton() == saveButton)
       {
-      // \todo Check if the save data dialog was "applied" and close the
-      // app in that case
+      // Save data and close the app
       this->FileSaveSceneAction->trigger();
+      close = true;
       }
     else if (messageBox->clickedButton() == exitButton)
       {


### PR DESCRIPTION
After closing the application, a pop-up appears (if data have not been saved previously). After clicking on save, the application does not close.
This PR fixes this issue: after saving, the application closes.
 