### PR TITLE
ENH: harmonising slider step sizes in Model module.

### DIFF
--- a/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
+++ b/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
@@ -315,8 +315,6 @@
              </property>
              <property name="singleStep">
               <double>0.050000000000000</double>
-             <property name="pageStep">
-              <double>0.100000000000000</double>
              </property>
             </widget>
            </item>
@@ -336,8 +334,6 @@
              </property>
              <property name="singleStep">
               <double>0.050000000000000</double>
-             <property name="pageStep">
-              <double>0.100000000000000</double>
              </property>
             </widget>
            </item>

--- a/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
+++ b/Modules/Loadable/Models/Widgets/Resources/UI/qMRMLModelDisplayNodeWidget.ui
@@ -315,6 +315,8 @@
              </property>
              <property name="singleStep">
               <double>0.050000000000000</double>
+             <property name="pageStep">
+              <double>0.100000000000000</double>
              </property>
             </widget>
            </item>
@@ -334,6 +336,8 @@
              </property>
              <property name="singleStep">
               <double>0.050000000000000</double>
+             <property name="pageStep">
+              <double>0.100000000000000</double>
              </property>
             </widget>
            </item>
@@ -378,10 +382,10 @@
       <item row="1" column="1">
        <widget class="ctkSliderWidget" name="SliceIntersectionOpacitySlider">
         <property name="singleStep">
-         <double>0.100000000000000</double>
+         <double>0.050000000000000</double>
         </property>
         <property name="pageStep">
-         <double>0.250000000000000</double>
+         <double>0.100000000000000</double>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>
@@ -393,7 +397,7 @@
          <double>1.000000000000000</double>
         </property>
         <property name="SingleStep" stdset="0">
-         <double>0.010000000000000</double>
+         <double>0.050000000000000</double>
         </property>
         <property name="Decimals" stdset="0">
          <number>2</number>
@@ -540,10 +544,10 @@
         <item>
          <widget class="ctkSliderWidget" name="OpacitySliderWidget">
           <property name="singleStep">
-           <double>0.100000000000000</double>
+           <double>0.050000000000000</double>
           </property>
           <property name="pageStep">
-           <double>0.250000000000000</double>
+           <double>0.100000000000000</double>
           </property>
           <property name="maximum">
            <double>1.000000000000000</double>


### PR DESCRIPTION
Can maybe also delete 
`````
<property name="SingleStep" stdset="0">
         <double>0.050000000000000</double>
`````
as duplication.