### PR TITLE
Allow removing subject hierachy plugin

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.cxx
@@ -118,6 +118,17 @@ qSlicerSubjectHierarchyPluginHandler::~qSlicerSubjectHierarchyPluginHandler()
 }
 
 //---------------------------------------------------------------------------
+bool qSlicerSubjectHierarchyPluginHandler::unRegisterPlugin(QString name)
+{
+  qSlicerSubjectHierarchyAbstractPlugin* currentPlugin = pluginByName(name);
+  foreach(QAction* action, currentPlugin->viewContextMenuActions())
+    {
+    this->m_PluginLogic->unRegisterViewMenuAction(action);
+    }
+  return true;
+}
+
+//---------------------------------------------------------------------------
 bool qSlicerSubjectHierarchyPluginHandler::registerPlugin(qSlicerSubjectHierarchyAbstractPlugin* pluginToRegister)
 {
   if (pluginToRegister == nullptr)

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginHandler.h
@@ -135,6 +135,10 @@ public:
   /// \return True if plugin registered successfully, false otherwise
   Q_INVOKABLE bool registerPlugin(qSlicerSubjectHierarchyAbstractPlugin* plugin);
 
+  /// Unregister a plugin
+  /// \return True if plugin is unregistered successfully, false otherwise
+  Q_INVOKABLE bool unRegisterPlugin(QString name);
+
   /// Get list of registered plugins
   Q_INVOKABLE QList<qSlicerSubjectHierarchyAbstractPlugin*> registeredPlugins() { return m_RegisteredPlugins; };
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.cxx
@@ -69,6 +69,8 @@ public:
 
   /// Menu shown when right-clicking in a slice or 3D view
   QMenu* ViewContextMenu;
+  /// Enable properties action
+  bool editPropertiesActionEnabled = true;
   /// Edit properties action
   QAction* EditPropertiesAction;
   /// Actions from the registered plugins
@@ -591,6 +593,10 @@ void qSlicerSubjectHierarchyPluginLogic::onDisplayMenuEvent(vtkObject* displayNo
       {
       editActionVisible = ownerPlugin->canEditProperties(itemID);
       }
+    if (d->editPropertiesActionEnabled)
+      {
+      d->ViewMenu->addAction(d->EditPropertiesAction);
+      }
     }
   d->EditPropertiesAction->setVisible(editActionVisible);
 
@@ -683,6 +689,27 @@ void qSlicerSubjectHierarchyPluginLogic::addSupportedDataNodesToSubjectHierarchy
 void qSlicerSubjectHierarchyPluginLogic::registerViewContextMenuAction(QAction* action)
 {
   Q_D(qSlicerSubjectHierarchyPluginLogic);
+
+  if (action)
+    {
+    const int viewMenuActionsCount = d->ViewMenuActions.count();
+
+    for(int i = 0; i < viewMenuActionsCount; i++)
+      {
+      if(action == d->ViewMenuActions.at(i))
+        {
+        d->ViewMenuActions.removeAt(i);
+        break;
+        }
+      }
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyPluginLogic::registerViewMenuAction(QAction* action)
+{
+  Q_D(qSlicerSubjectHierarchyPluginLogic);
+
   if (action)
     {
     d->ViewContextMenuActions << action;
@@ -726,8 +753,19 @@ QStringList qSlicerSubjectHierarchyPluginLogic::registeredViewContextMenuActionN
     {
     registeredActionNames << action->objectName();
     }
+  if (d->editPropertiesActionEnabled)
+    {
+    registeredActionNames << d->EditPropertiesAction->objectName();
+    }
 
   return registeredActionNames;
+}
+
+//-----------------------------------------------------------------------------
+void qSlicerSubjectHierarchyPluginLogic::setEditPropertiesEnabled(bool enable)
+{
+    Q_D(qSlicerSubjectHierarchyPluginLogic);
+    d->editPropertiesActionEnabled = enable;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyPluginLogic.h
@@ -83,6 +83,8 @@ public:
   void registerCorePlugins();
 
   /// Get all view context menu actions available
+  Q_INVOKABLE void setEditPropertiesEnabled(bool enable);
+
   /// \return List of object names of all registered view menu actions
   QStringList registeredViewContextMenuActionNames();
 
@@ -127,6 +129,8 @@ protected:
 
   /// Add view menu action. Called by plugin handler when registering a plugin
   void registerViewContextMenuAction(QAction* action);
+  /// Remove menu action.
+  void unRegisterViewMenuAction(QAction* action);
 
 protected slots:
   /// Called when a node is added to the scene so that a plugin can create an item for it


### PR DESCRIPTION
This development comes from the need to remove the right click on markups (in MPR views) in a slicelet application.
Users that implement slicelet may want to have their own  right click  actions.
It is also important to avoid switching into slicer when clicking on "edit properties" action.