### PR TITLE
Improve python_package_updater to support updating extension external project

### DIFF
--- a/Utilities/Scripts/python_package_updater.py
+++ b/Utilities/Scripts/python_package_updater.py
@@ -135,12 +135,15 @@ if __name__ == '__main__':
     """
     parser.add_argument('-s', '--search-directory', metavar="Path/To/Directory", required=False, help="Directory to search and replace python version info")
     parser.add_argument('-c', '--cpython-tag', metavar="cp{Major}.{Minor}", required=False, help="CPython version of python packages to check for")
+    parser.add_argument('--from-installed-packages', action='store_true', required=False, help="Update external projects based on installed packages")
     args = parser.parse_args()
 
     search_directory = args.search_directory
     if not search_directory:
         # Assume script is in cloned Slicer repo, so choose the SuperBuild directory to search
         search_directory = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "SuperBuild")
+
+    print(f"Searching external projects in {search_directory} ")
 
     python_version_info = sys.version_info
     interpreter_cpython_tag = f"cp{python_version_info.major}{python_version_info.minor}"
@@ -150,7 +153,9 @@ if __name__ == '__main__':
         # Assume script is updating python package versions for same cpython version being used to run script
         cpython_tag = interpreter_cpython_tag
 
-    if cpython_tag == interpreter_cpython_tag:
+    if args.from_installed_packages:
+        packages_to_update = parse_pip_list_output(get_installed_packages())
+    elif cpython_tag == interpreter_cpython_tag:
         packages_to_update = parse_pip_list_output(get_outdated_packages())
     else:
         packages_to_update = parse_pip_list_output(get_installed_packages())

--- a/Utilities/Scripts/python_package_updater.py
+++ b/Utilities/Scripts/python_package_updater.py
@@ -73,7 +73,7 @@ def update_external_project_python_packages(packages_to_update, directory, cpyth
 
         filenames = []
         hashes = []
-        desired_version_files = data["releases"][desired_version]
+        desired_version_files = data["releases"].get(desired_version, [])
         for release_file in desired_version_files:
             if release_file["python_version"] not in ["py3", "py2.py3", cpython_tag] and "abi3" not in release_file["filename"]:
                 # e.g. PyNaCl-1.5.0-cp36-abi3-win_amd64.whl has python_version tag of py36, but is abi compatible for Python 3.6 and later for the Windows platform


### PR DESCRIPTION
This commit adds a new option called `--from-installed-packages` allowing
to systematically update all external project independently of their current
status.

Assuming the external project files of a SuperBuild extension include the
relevant `[<package_name>]` hints, they may be updated by:

1. installing the extension specific packages in a dedicated prefix

2. running "python_package_updater" script setting `PYTHONPATH` to account for the custom prefix

For example:

```
# Set common variables
SLICER_SOURCE_DIR=~/Projects/Slicer
SLICER_DIR=~/Projects/Slicer-Release/Slicer-build
PYTHONSLICER_EXECUTABLE=${SLICER_DIR}/../python-install/bin/PythonSlicer

EXTENSION_SOURCE_DIR=/home/jcfr/Projects/ShapeVariationAnalyzer
EXTENSION_BINARY_DIR=/home/jcfr/Projects/ShapeVariationAnalyzer-Release
```

```
# Install packages into the prefix

PYTHON_INSTALL_PREFIX=${EXTENSION_BINARY_DIR}/python-packages-install
${PYTHONSLICER_EXECUTABLE} -m pip install --prefix ${PYTHON_INSTALL_PREFIX} scikit_learn
```

```
# Update extension external projects
UPDATER_SCRIPT=${SLICER_SOURCE_DIR}/Utilities/Scripts/python_package_updater.py

EXTENSION_PYTHONPATH=${PYTHON_INSTALL_PREFIX}/lib/python3.9:${PYTHON_INSTALL_PREFIX}/lib/python3.9/lib-dynload:${PYTHON_INSTALL_PREFIX}/lib/python3.9/site-packages

PYTHONPATH=${EXTENSION_PYTHONPATH}             \
  ${PYTHONSLICER_EXECUTABLE} ${UPDATER_SCRIPT} \
    -s ${EXTENSION_SOURCE_DIR}/SuperBuild      \
    --from-installed-packages
```

Allowing to have the following changes automatically done after only adding the missing `[joblib]`, `[threadpoolctl]` and `[scikit-learn]` hints:

```diff
diff --git a/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake b/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake
index e1780a1..1b13843 100644
--- a/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake
+++ b/SuperBuild/External_python-ShapeVariationAnalyzer-requirements.cmake
@@ -46,16 +46,22 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   joblib==0.16.0 --hash=sha256:d348c5d4ae31496b2aa060d6d9b787864dd204f9480baaa52d18850cb43e9f49
   # [/joblib]
   # [threadpoolctl]
-  threadpoolctl==2.1.0 --hash=sha256:38b74ca20ff3bb42caca8b00055111d74159ee95c4370882bbff2b93d24da725
+  threadpoolctl==3.1.0 --hash=sha256:8b99adda265feb6773280df41eece7b2e6561b772d21ffd52e372f999024907b
   # [/threadpoolctl]
   # [scikit-learn]
   # Hashes correspond to the following packages:
-  # - scikit_learn-0.23.1-cp36-cp36m-win_amd64.whl
-  # - scikit_learn-0.23.1-cp36-cp36m-macosx_10_9_x86_64.whl 
-  # - scikit_learn-0.23.1-cp36-cp36m-manylinux1_x86_64.whl
-  scikit-learn==0.23.1 --hash=sha256:e585682e37f2faa81ad6cd4472fff646bf2fd0542147bec93697a905db8e6bd2 \
-                       --hash=sha256:058d213092de4384710137af1300ed0ff030b8c40459a6c6f73c31ccd274cc39 \
-                       --hash=sha256:e9879ba9e64ec3add41bf201e06034162f853652ef4849b361d73b0deb3153ad
+  #  - scikit_learn-1.0.2-cp39-cp39-macosx_10_13_x86_64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-macosx_12_0_arm64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - scikit_learn-1.0.2-cp39-cp39-win_amd64.whl
+  scikit-learn==1.0.2 --hash=sha256:a90b60048f9ffdd962d2ad2fb16367a87ac34d76e02550968719eb7b5716fd10 \
+                      --hash=sha256:7a93c1292799620df90348800d5ac06f3794c1316ca247525fa31169f6d25855 \
+                      --hash=sha256:55f2f3a8414e14fbee03782f9fe16cca0f141d639d2b1c1a36779fa069e1db57 \
+                      --hash=sha256:80095a1e4b93bd33261ef03b9bc86d6db649f988ea4dbcf7110d0cded8d7213d \
+                      --hash=sha256:ff746a69ff2ef25f62b36338c615dd15954ddc3ab8e73530237dd73235e76d62 \
+                      --hash=sha256:b54a62c6e318ddbfa7d22c383466d38d2ee770ebdb5ddb668d56a099f6eaf75f
   # [/scikit-learn]
   ]===])
```
