### PR TITLE
COMP: Fix linting by pinning flake8-bugbear used in pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,4 +12,4 @@ repos:
   rev: "4.0.1"
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear]
+    additional_dependencies: [flake8-bugbear==22.1.11]


### PR DESCRIPTION
This commit follows up configuration originally introduced in
pull request #6262 (Update GitHub Actions to leverage pre-commit
hook framework and integrate flake8 hook)