### PR TITLE
Show3d button in segmentations module

### DIFF
--- a/Libs/MRML/Core/vtkMRMLModelStorageNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelStorageNode.h
@@ -51,6 +51,10 @@ public:
   static const char* GetCoordinateSystemAsString(int id);
   static int GetCoordinateSystemFromString(const char* name);
 
+  /// Helper function that can convert a mesh (polydata, unstructured grid, or even just a point cloud)
+  /// between RAS and LPS coordinate system.
+  static void ConvertBetweenRASAndLPS(vtkPointSet* inputMesh, vtkPointSet* outputMesh);
+
 protected:
   vtkMRMLModelStorageNode();
   ~vtkMRMLModelStorageNode() override;
@@ -71,8 +75,6 @@ protected:
 
   /// Write data from a  referenced node
   int WriteDataInternal(vtkMRMLNode *refNode) override;
-
-  static void ConvertBetweenRASAndLPS(vtkPointSet* inputMesh, vtkPointSet* outputMesh);
 
   static int GetCoordinateSystemFromFileHeader(const char* header);
 

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>340</width>
-    <height>756</height>
+    <height>870</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -127,9 +127,15 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="pushButton_EditSelected">
+         <widget class="qMRMLSegmentationShow3DButton" name="show3DButton"/>
+        </item>
+        <item>
+         <widget class="QToolButton" name="toolButton_Edit">
+          <property name="toolTip">
+           <string>Go to Segment Editor module</string>
+          </property>
           <property name="text">
-           <string>Edit selected</string>
+           <string>...</string>
           </property>
           <property name="icon">
            <iconset resource="../../Widgets/Resources/qSlicerSegmentationsModuleWidgets.qrc">
@@ -849,6 +855,7 @@
    <class>qMRMLSegmentsTableView</class>
    <extends>qMRMLWidget</extends>
    <header>qMRMLSegmentsTableView.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>qMRMLSegmentationRepresentationsListView</class>
@@ -864,6 +871,11 @@
    <class>qMRMLSegmentationFileExportWidget</class>
    <extends>qMRMLWidget</extends>
    <header>qMRMLSegmentationFileExportWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSegmentationShow3DButton</class>
+   <extends>QPushButton</extends>
+   <header>qMRMLSegmentationShow3DButton.h</header>
   </customwidget>
   <customwidget>
    <class>qMRMLSubjectHierarchyComboBox</class>
@@ -930,8 +942,8 @@
      <y>3</y>
     </hint>
     <hint type="destinationlabel">
-     <x>346</x>
-     <y>643</y>
+     <x>329</x>
+     <y>632</y>
     </hint>
    </hints>
   </connection>
@@ -946,8 +958,8 @@
      <y>136</y>
     </hint>
     <hint type="destinationlabel">
-     <x>137</x>
-     <y>289</y>
+     <x>145</x>
+     <y>456</y>
     </hint>
    </hints>
   </connection>
@@ -962,8 +974,8 @@
      <y>634</y>
     </hint>
     <hint type="destinationlabel">
-     <x>343</x>
-     <y>730</y>
+     <x>326</x>
+     <y>739</y>
     </hint>
    </hints>
   </connection>
@@ -1026,8 +1038,8 @@
      <y>431</y>
     </hint>
     <hint type="destinationlabel">
-     <x>224</x>
-     <y>699</y>
+     <x>325</x>
+     <y>741</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Segmentations/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/Widgets/CMakeLists.txt
@@ -12,19 +12,15 @@ set(${KIT}_INCLUDE_DIRECTORIES
   )
 
 set(${KIT}_SRCS
-  qMRMLSegmentsTableView.cxx
-  qMRMLSegmentsTableView.h
+  qMRMLDoubleSpinBoxDelegate.h
+  qMRMLDoubleSpinBoxDelegate.cxx
   qMRMLSegmentsModel.cxx
   qMRMLSegmentsModel.h
   qMRMLSegmentsModel_p.h
-  qMRMLSortFilterSegmentsProxyModel.cxx
-  qMRMLSortFilterSegmentsProxyModel.h
-  qMRMLSegmentationRepresentationsListView.cxx
-  qMRMLSegmentationRepresentationsListView.h
+  qMRMLSegmentsTableView.cxx
+  qMRMLSegmentsTableView.h
   qMRMLSegmentationConversionParametersWidget.cxx
   qMRMLSegmentationConversionParametersWidget.h
-  qMRMLSegmentEditorWidget.cxx
-  qMRMLSegmentEditorWidget.h
   qMRMLSegmentationDisplayNodeWidget.cxx
   qMRMLSegmentationDisplayNodeWidget.h
   qMRMLSegmentationFileExportWidget.cxx
@@ -33,32 +29,39 @@ set(${KIT}_SRCS
   qMRMLSegmentationGeometryWidget.h
   qMRMLSegmentationGeometryDialog.cxx
   qMRMLSegmentationGeometryDialog.h
-  qMRMLDoubleSpinBoxDelegate.h
-  qMRMLDoubleSpinBoxDelegate.cxx
+  qMRMLSegmentationRepresentationsListView.cxx
+  qMRMLSegmentationRepresentationsListView.h
+  qMRMLSegmentationShow3DButton.h
+  qMRMLSegmentationShow3DButton.cxx
+  qMRMLSegmentEditorWidget.cxx
+  qMRMLSegmentEditorWidget.h
+  qMRMLSortFilterSegmentsProxyModel.cxx
+  qMRMLSortFilterSegmentsProxyModel.h
   )
 
 set(${KIT}_MOC_SRCS
   qMRMLSegmentsTableView.h
   qMRMLSegmentsModel.h
-  qMRMLSortFilterSegmentsProxyModel.h
-  qMRMLSegmentationRepresentationsListView.h
   qMRMLSegmentationConversionParametersWidget.h
-  qMRMLSegmentEditorWidget.h
   qMRMLSegmentationDisplayNodeWidget.h
   qMRMLSegmentationFileExportWidget.h
   qMRMLSegmentationGeometryWidget.h
   qMRMLSegmentationGeometryDialog.h
+  qMRMLSegmentationRepresentationsListView.h
+  qMRMLSegmentationShow3DButton.h
+  qMRMLSegmentEditorWidget.h
+  qMRMLSortFilterSegmentsProxyModel.h
   qMRMLDoubleSpinBoxDelegate.h
 )
 
 set(${KIT}_UI_SRCS
-  Resources/UI/qMRMLSegmentsTableView.ui
   Resources/UI/qMRMLSegmentationRepresentationsListView.ui
   Resources/UI/qMRMLSegmentationConversionParametersWidget.ui
   Resources/UI/qMRMLSegmentEditorWidget.ui
   Resources/UI/qMRMLSegmentationDisplayNodeWidget.ui
   Resources/UI/qMRMLSegmentationFileExportWidget.ui
   Resources/UI/qMRMLSegmentationGeometryWidget.ui
+  Resources/UI/qMRMLSegmentsTableView.ui
   )
 
 set(${KIT}_RESOURCES
@@ -66,10 +69,10 @@ set(${KIT}_RESOURCES
   )
 
 set(${KIT}_TARGET_LIBRARIES
-  vtkSlicerSegmentationsModuleMRML
-  vtkSlicerSegmentationsModuleLogic
   qSlicerSegmentationsEditorEffects
   qSlicerTerminologiesModuleWidgets
+  vtkSlicerSegmentationsModuleMRML
+  vtkSlicerSegmentationsModuleLogic
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/CMakeLists.txt
@@ -13,6 +13,8 @@ set(${KIT}_SRCS
   qMRMLSegmentationRepresentationsListViewPlugin.h
   qMRMLSegmentationConversionParametersWidgetPlugin.cxx
   qMRMLSegmentationConversionParametersWidgetPlugin.h
+  qMRMLSegmentationShow3DButtonPlugin.cxx
+  qMRMLSegmentationShow3DButtonPlugin.h
   qMRMLSegmentSelectorWidgetPlugin.cxx
   qMRMLSegmentSelectorWidgetPlugin.h
   qMRMLSegmentEditorWidgetPlugin.cxx
@@ -32,6 +34,7 @@ set(${KIT}_MOC_SRCS
   qMRMLSegmentEditorWidgetPlugin.h
   qMRMLSegmentationDisplayNodeWidgetPlugin.h
   qMRMLSegmentationFileExportWidgetPlugin.h
+  qMRMLSegmentationShow3DButtonPlugin.h
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationShow3DButtonPlugin.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationShow3DButtonPlugin.cxx
@@ -1,0 +1,54 @@
+/*=auto=========================================================================
+
+ Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH)
+ All Rights Reserved.
+
+ See COPYRIGHT.txt
+ or http://www.slicer.org/copyright/copyright.txt for details.
+
+ Program:   3D Slicer
+
+=========================================================================auto=*/
+
+#include "qMRMLSegmentationShow3DButtonPlugin.h"
+#include "qMRMLSegmentationShow3DButton.h"
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationShow3DButtonPlugin::qMRMLSegmentationShow3DButtonPlugin(QObject* pluginParent)
+  : QObject(pluginParent)
+{
+}
+
+//-----------------------------------------------------------------------------
+QWidget *qMRMLSegmentationShow3DButtonPlugin::createWidget(QWidget* parentWidget)
+{
+  qMRMLSegmentationShow3DButton* pluginWidget =
+    new qMRMLSegmentationShow3DButton(parentWidget);
+  return pluginWidget;
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSegmentationShow3DButtonPlugin::domXml() const
+{
+  return "<widget class=\"qMRMLSegmentationShow3DButton\" \
+          name=\"SegmentationShow3DButton\">\n"
+          "</widget>\n";
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSegmentationShow3DButtonPlugin::includeFile() const
+{
+  return "qMRMLSegmentationShow3DButton.h";
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationShow3DButtonPlugin::isContainer() const
+{
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSegmentationShow3DButtonPlugin::name() const
+{
+  return "qMRMLSegmentationShow3DButton";
+}

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationShow3DButtonPlugin.h
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationShow3DButtonPlugin.h
@@ -1,0 +1,35 @@
+/*=auto=========================================================================
+
+ Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH)
+ All Rights Reserved.
+
+ See COPYRIGHT.txt
+ or http://www.slicer.org/copyright/copyright.txt for details.
+
+ Program:   3D Slicer
+
+=========================================================================auto=*/
+
+#ifndef __qMRMLSegmentationShow3DButtonPlugin_h
+#define __qMRMLSegmentationShow3DButtonPlugin_h
+
+#include "qSlicerSegmentationsModuleWidgetsAbstractPlugin.h"
+
+class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_PLUGINS_EXPORT qMRMLSegmentationShow3DButtonPlugin
+  : public QObject
+  , public qSlicerSegmentationsModuleWidgetsAbstractPlugin
+{
+  Q_OBJECT
+
+public:
+  qMRMLSegmentationShow3DButtonPlugin(QObject* parent = nullptr);
+
+  QWidget *createWidget(QWidget* parent) override;
+  QString  domXml() const override;
+  QString  includeFile() const override;
+  bool     isContainer() const override;
+  QString  name() const override;
+
+};
+
+#endif

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qSlicerSegmentationsModuleWidgetsPlugin.h
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qSlicerSegmentationsModuleWidgetsPlugin.h
@@ -32,6 +32,7 @@
 #include "qMRMLSegmentEditorWidgetPlugin.h"
 #include "qMRMLSegmentationDisplayNodeWidgetPlugin.h"
 #include "qMRMLSegmentationFileExportWidgetPlugin.h"
+#include "qMRMLSegmentationShow3DButtonPlugin.h"
 
 // \class Group the plugins in one library
 class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_PLUGINS_EXPORT qSlicerSegmentationsModuleWidgetsPlugin
@@ -52,7 +53,8 @@ public:
       << new qMRMLSegmentSelectorWidgetPlugin
       << new qMRMLSegmentEditorWidgetPlugin
       << new qMRMLSegmentationDisplayNodeWidgetPlugin
-      << new qMRMLSegmentationFileExportWidgetPlugin;
+      << new qMRMLSegmentationFileExportWidgetPlugin
+      << new qMRMLSegmentationShow3DButtonPlugin;
     return plugins;
     }
 };

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
@@ -136,18 +136,7 @@
       </widget>
      </item>
      <item>
-      <widget class="ctkMenuButton" name="Show3DButton">
-       <property name="text">
-        <string> Show 3D</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../qSlicerSegmentationsModuleWidgets.qrc">
-         <normaloff>:/Icons/MakeModel.png</normaloff>:/Icons/MakeModel.png</iconset>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-      </widget>
+      <widget class="qMRMLSegmentationShow3DButton" name="Show3DButton"/>
      </item>
      <item>
       <widget class="QToolButton" name="SwitchToSegmentationsButton">
@@ -478,6 +467,11 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>qMRMLSegmentationShow3DButton</class>
+   <extends>QPushButton</extends>
+   <header>qMRMLSegmentationShow3DButton.h</header>
+  </customwidget>
+  <customwidget>
    <class>ctkCheckBox</class>
    <extends>QCheckBox</extends>
    <header>ctkCheckBox.h</header>
@@ -498,11 +492,6 @@
    <class>ctkFittedTextBrowser</class>
    <extends>QTextBrowser</extends>
    <header>ctkFittedTextBrowser.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ctkMenuButton</class>
-   <extends>QPushButton</extends>
-   <header>ctkMenuButton.h</header>
   </customwidget>
   <customwidget>
    <class>ctkRangeWidget</class>

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -110,10 +110,8 @@
 #include <QTableView>
 #include <QToolButton>
 #include <QVBoxLayout>
-#include <QWidgetAction>
 
 // CTK includes
-#include <ctkSliderWidget.h>
 #include <ctkCollapsibleButton.h>
 
 static const int BINARY_LABELMAP_SCALAR_TYPE = VTK_UNSIGNED_CHAR;
@@ -207,10 +205,6 @@ public:
   /// then false is returned;
   bool segmentationIJKToRAS(vtkMatrix4x4* ijkToRas);
 
-  /// Updates surface smoothing factor in segmentation node and updates surface representation
-  /// if it is enabled.
-  bool setSurfaceSmoothingFactor(double smoothingFactor);
-
 public:
   /// Segment editor parameter set node containing all selections and working images
   vtkWeakPointer<vtkMRMLSegmentEditorNode> ParameterSetNode;
@@ -298,9 +292,6 @@ public:
   // Qt does not have an API to check if a widget is in a layout, therefore we store this
   // information in this flag.
   bool RotateWarningInNodeSelectorLayout;
-
-  QAction* SurfaceSmoothingEnabledAction;
-  ctkSliderWidget* SurfaceSmoothingSlider;
 
   QString DefaultTerminologyEntrySettingsKey;
   QString DefaultTerminologyEntry;
@@ -425,35 +416,6 @@ void qMRMLSegmentEditorWidgetPrivate::init()
 
   this->SwitchToSegmentationsButton->setMenu(segmentationsButtonMenu);
 
-  QMenu* show3DButtonMenu = new QMenu(qMRMLSegmentEditorWidget::tr("Show 3D"), this->Show3DButton);
-
-  this->SurfaceSmoothingEnabledAction = new QAction(qMRMLSegmentEditorWidget::tr("Surface smoothing"), show3DButtonMenu);
-  this->SurfaceSmoothingEnabledAction->setToolTip(qMRMLSegmentEditorWidget::tr("Apply smoothing when converting binary labelmap to closed surface representation."));
-  this->SurfaceSmoothingEnabledAction->setCheckable(true);
-  show3DButtonMenu->addAction(this->SurfaceSmoothingEnabledAction);
-  QObject::connect(this->SurfaceSmoothingEnabledAction, SIGNAL(toggled(bool)), q, SLOT(onEnableSurfaceSmoothingToggled(bool)));
-
-  QMenu* surfaceSmoothingFactorMenu = new QMenu(qMRMLSegmentEditorWidget::tr("Smoothing factor"), show3DButtonMenu);
-  surfaceSmoothingFactorMenu->setObjectName("slicerSpacingManualMode");
-  surfaceSmoothingFactorMenu->setIcon(QIcon(":/Icon/SlicerManualSliceSpacing.png"));
-
-  this->SurfaceSmoothingSlider = new ctkSliderWidget(surfaceSmoothingFactorMenu);
-  this->SurfaceSmoothingSlider->setToolTip(qMRMLSegmentEditorWidget::tr("Higher value means stronger smoothing during closed surface representation conversion."));
-  this->SurfaceSmoothingSlider->setDecimals(2);
-  this->SurfaceSmoothingSlider->setRange(0.0, 1.0);
-  this->SurfaceSmoothingSlider->setSingleStep(0.1);
-  this->SurfaceSmoothingSlider->setValue(0.5);
-  this->SurfaceSmoothingSlider->setTracking(false);
-  QObject::connect(this->SurfaceSmoothingSlider, SIGNAL(valueChanged(double)),
-    q, SLOT(onSurfaceSmoothingFactorChanged(double)));
-  QWidgetAction* sliceSpacingAction = new QWidgetAction(surfaceSmoothingFactorMenu);
-  sliceSpacingAction->setCheckable(true);
-  sliceSpacingAction->setDefaultWidget(this->SurfaceSmoothingSlider);
-  surfaceSmoothingFactorMenu->addAction(sliceSpacingAction);
-  show3DButtonMenu->addMenu(surfaceSmoothingFactorMenu);
-
-  this->Show3DButton->setMenu(show3DButtonMenu);
-
   // Make connections
   QObject::connect( this->SegmentationNodeComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
     q, SLOT(onSegmentationNodeChanged(vtkMRMLNode*)) );
@@ -470,7 +432,6 @@ void qMRMLSegmentEditorWidgetPrivate::init()
   QObject::connect( this->AddSegmentButton, SIGNAL(clicked()), q, SLOT(onAddSegment()) );
   QObject::connect( this->RemoveSegmentButton, SIGNAL(clicked()), q, SLOT(onRemoveSegment()) );
   QObject::connect( this->SwitchToSegmentationsButton, SIGNAL(clicked()), q, SLOT(onSwitchToSegmentations()) );
-  QObject::connect( this->Show3DButton, SIGNAL(toggled(bool)), q, SLOT(onCreateSurfaceToggled(bool)) );
 
   QObject::connect( this->MaskModeComboBox, SIGNAL(currentIndexChanged(int)), q, SLOT(onMaskModeChanged(int)));
   QObject::connect( this->MasterVolumeIntensityMaskCheckBox, SIGNAL(toggled(bool)), q, SLOT(onMasterVolumeIntensityMaskChecked(bool)));
@@ -491,7 +452,6 @@ void qMRMLSegmentEditorWidgetPrivate::init()
   this->SegmentsTableView->setOpacityColumnVisible(false);
   this->AddSegmentButton->setEnabled(false);
   this->RemoveSegmentButton->setEnabled(false);
-  this->Show3DButton->setEnabled(false);
   this->SwitchToSegmentationsButton->setEnabled(false);
   this->EffectsGroupBox->setEnabled(false);
   this->OptionsGroupBox->setEnabled(false);
@@ -1027,37 +987,6 @@ bool qMRMLSegmentEditorWidgetPrivate::segmentationIJKToRAS(vtkMatrix4x4* ijkToRa
   return true;
 }
 
-//-----------------------------------------------------------------------------
-bool qMRMLSegmentEditorWidgetPrivate::setSurfaceSmoothingFactor(double smoothingFactor)
-{
-  if (!this->ParameterSetNode)
-    {
-    return false;
-    }
-  vtkMRMLSegmentationNode* segmentationNode = this->ParameterSetNode->GetSegmentationNode();
-  if (!segmentationNode || !segmentationNode->GetSegmentation())
-    {
-    return false;
-    }
-
-  MRMLNodeModifyBlocker blocker(segmentationNode);
-
-  segmentationNode->GetSegmentation()->SetConversionParameter(
-    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSmoothingFactorParameterName(),
-    QVariant(smoothingFactor).toString().toUtf8().constData());
-
-  bool closedSurfacePresent = segmentationNode->GetSegmentation()->ContainsRepresentation(
-    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
-  if (closedSurfacePresent)
-    {
-    QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
-    segmentationNode->GetSegmentation()->CreateRepresentation(
-      vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), true);
-    segmentationNode->Modified();
-    QApplication::restoreOverrideCursor();
-    }
-  return true;
-}
 
 //-----------------------------------------------------------------------------
 // qMRMLSegmentEditorWidget methods
@@ -1254,21 +1183,6 @@ void qMRMLSegmentEditorWidget::updateWidgetFromMRML()
   d->EffectsOptionsFrame->setEnabled(d->SegmentationNode != nullptr);
   d->MasterVolumeNodeComboBox->setEnabled(d->SegmentationNode != nullptr);
 
-  double surfaceSmoothingFactor = 0.5;
-  if (d->SegmentationNode && d->SegmentationNode->GetSegmentation())
-    {
-    surfaceSmoothingFactor = QString(d->SegmentationNode->GetSegmentation()->GetConversionParameter(
-      vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSmoothingFactorParameterName()).c_str()).toDouble();
-    }
-  bool wasBlocked = d->SurfaceSmoothingEnabledAction->blockSignals(true);
-  d->SurfaceSmoothingEnabledAction->setChecked(surfaceSmoothingFactor >= 0.0);
-  d->SurfaceSmoothingEnabledAction->blockSignals(wasBlocked);
-
-  wasBlocked = d->SurfaceSmoothingSlider->blockSignals(true);
-  d->SurfaceSmoothingSlider->setValue(surfaceSmoothingFactor);
-  d->SurfaceSmoothingSlider->setEnabled(surfaceSmoothingFactor >= 0.0);
-  d->SurfaceSmoothingSlider->blockSignals(wasBlocked);
-
   QString selectedSegmentID;
   if (d->ParameterSetNode->GetSelectedSegmentID() && strcmp(d->ParameterSetNode->GetSelectedSegmentID(), "") != 0)
     {
@@ -1292,7 +1206,7 @@ void qMRMLSegmentEditorWidget::updateWidgetFromMRML()
   // Only enable remove button if a segment is selected
   d->RemoveSegmentButton->setEnabled(!selectedSegmentID.isEmpty() && (!d->Locked));
 
-  d->Show3DButton->setEnabled(!d->Locked);
+  d->Show3DButton->setLocked(d->Locked);
   d->SwitchToSegmentationsButton->setEnabled(true);
 
   // Segments list section
@@ -1528,6 +1442,8 @@ void qMRMLSegmentEditorWidget::updateWidgetFromSegmentationNode()
     bool wasBlocked = d->SegmentsTableView->blockSignals(true);
     d->SegmentsTableView->setSegmentationNode(d->SegmentationNode);
     d->SegmentsTableView->blockSignals(wasBlocked);
+
+    d->Show3DButton->setSegmentationNode(d->SegmentationNode);
 
     if (segmentationNode)
       {
@@ -2394,28 +2310,7 @@ void qMRMLSegmentEditorWidget::onSegmentAddedRemoved()
     qCritical() << Q_FUNC_INFO << ": Invalid segment editor parameter set node";
     }
 
-  // Update state of Show3DButton
-  if (segmentationNode)
-    {
-    // Enable button if there is at least one segment in the segmentation
-    d->Show3DButton->setEnabled( !d->Locked
-      && segmentationNode->GetSegmentation()->GetNumberOfSegments() > 0
-      && segmentationNode->GetSegmentation()->GetMasterRepresentationName() !=
-        vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName() );
-    d->SwitchToSegmentationsButton->setEnabled(true);
-
-    // Change button state based on whether it contains closed surface representation
-    bool closedSurfacePresent = segmentationNode->GetSegmentation()->ContainsRepresentation(
-      vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName() );
-    d->Show3DButton->blockSignals(true);
-    d->Show3DButton->setChecked(closedSurfacePresent);
-    d->Show3DButton->blockSignals(false);
-    }
-  else
-    {
-    d->Show3DButton->setEnabled(false);
-    d->SwitchToSegmentationsButton->setEnabled(false);
-    }
+  d->SwitchToSegmentationsButton->setEnabled(segmentationNode!= nullptr);
 
   // Update mask mode combo box with current segment names
 
@@ -3471,88 +3366,6 @@ void qMRMLSegmentEditorWidget::masterVolumeNodeSelectorRemoveAttribute(const QSt
   d->MasterVolumeNodeComboBox->removeAttribute(nodeType, attributeName);
 }
 
-//-----------------------------------------------------------------------------
-void qMRMLSegmentEditorWidget::onEnableSurfaceSmoothingToggled(bool smoothingEnabled)
-{
-  Q_D(qMRMLSegmentEditorWidget);
-
-  // Get segmentation node
-  vtkMRMLSegmentationNode* segmentationNode = nullptr;
-  if (d->ParameterSetNode)
-    {
-    segmentationNode = d->ParameterSetNode->GetSegmentationNode();
-    }
-  else
-    {
-    qCritical() << Q_FUNC_INFO << ": Invalid segment editor parameter set node";
-    }
-  if (!segmentationNode || !segmentationNode->GetSegmentation())
-    {
-    qCritical() << Q_FUNC_INFO << ": No segmentation selected";
-    return;
-    }
-
-  // Get smoothing factor
-  double originalSmoothingFactor = QString( segmentationNode->GetSegmentation()->GetConversionParameter(
-    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSmoothingFactorParameterName() ).c_str() ).toDouble();
-  double newSmoothingFactor = fabs(originalSmoothingFactor);
-  if (originalSmoothingFactor == 0.0)
-    {
-    // if original smoothing factor was 0 then we cannot toggle smoothing
-    // therefore we reset it to the default
-    newSmoothingFactor = 0.5;
-    }
-  if (!smoothingEnabled)
-    {
-    newSmoothingFactor *= -1;
-    }
-
-  // Set smoothing factor
-  if (newSmoothingFactor != originalSmoothingFactor)
-    {
-    d->setSurfaceSmoothingFactor(newSmoothingFactor);
-    this->updateWidgetFromMRML();
-    }
-}
-
-//---------------------------------------------------------------------------
-void qMRMLSegmentEditorWidget::onSurfaceSmoothingFactorChanged(double newSmoothingFactor)
-{
-  Q_D(qMRMLSegmentEditorWidget);
-  // Get segmentation node
-  vtkMRMLSegmentationNode* segmentationNode = nullptr;
-  if (d->ParameterSetNode)
-    {
-    segmentationNode = d->ParameterSetNode->GetSegmentationNode();
-    }
-  else
-    {
-    qCritical() << Q_FUNC_INFO << ": Invalid segment editor parameter set node";
-    }
-  if (!segmentationNode || !segmentationNode->GetSegmentation())
-    {
-    qCritical() << Q_FUNC_INFO << ": No segmentation selected";
-    return;
-    }
-
-  // Get smoothing factor
-  double originalSmoothingFactor = QString( segmentationNode->GetSegmentation()->GetConversionParameter(
-    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSmoothingFactorParameterName() ).c_str() ).toDouble();
-
-  // Sign of smoothing factor is used to indicate that smoothing is enabled or not.
-  // if smoothing factor is negative then it means smoothing is disabled.
-  // Here we allow changing the absolute value of the smoothing factor, while maintaining its sign.
-
-  // Set smoothing factor
-  if (newSmoothingFactor != fabs(originalSmoothingFactor))
-    {
-    if (originalSmoothingFactor < 0.0)
-      {
-      newSmoothingFactor = -newSmoothingFactor;
-      }
-    d->setSurfaceSmoothingFactor(newSmoothingFactor);
-    }
-}
 
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
@@ -416,9 +416,6 @@ protected slots:
   /// Update GUI if segmentation history is changed (e.g., undo/redo button states)
   void onSegmentationHistoryChanged();
 
-  /// Enable/disable surface smoothing
-  void onEnableSurfaceSmoothingToggled(bool enabled);
-  void onSurfaceSmoothingFactorChanged(double newSmoothingFactor);
   /// Switch to Segmentations module and jump to Import/Export section
   void onImportExportActionClicked();
   /// Open Export to files dialog

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.cxx
@@ -1,0 +1,324 @@
+/*=auto=========================================================================
+
+ Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH)
+ All Rights Reserved.
+
+ See COPYRIGHT.txt
+ or http://www.slicer.org/copyright/copyright.txt for details.
+
+ Program:   3D Slicer
+
+=========================================================================auto=*/
+
+// Segmentation includes
+#include "qMRMLSegmentationShow3DButton.h"
+#include "vtkBinaryLabelmapToClosedSurfaceConversionRule.h"
+#include "vtkMRMLSegmentationDisplayNode.h"
+#include "vtkMRMLSegmentationNode.h"
+#include "vtkSegmentationConverter.h"
+
+// CTK includes
+#include <ctkSliderWidget.h>
+
+// VTK includes
+#include "vtkWeakPointer.h"
+
+// Qt includes
+#include <QAction>
+#include <QApplication>
+#include <QDebug>
+#include <QIcon>
+#include <QMenu>
+#include <QWidgetAction>
+
+class qMRMLSegmentationShow3DButtonPrivate
+{
+  Q_DECLARE_PUBLIC(qMRMLSegmentationShow3DButton);
+protected:
+  qMRMLSegmentationShow3DButton* const q_ptr;
+public:
+  qMRMLSegmentationShow3DButtonPrivate(qMRMLSegmentationShow3DButton& object);
+  void init();
+
+  /// Updates surface smoothing factor in segmentation node and updates surface representation
+  /// if it is enabled.
+  bool setSurfaceSmoothingFactor(double smoothingFactor);
+
+  QAction* SurfaceSmoothingEnabledAction{ nullptr };
+  ctkSliderWidget* SurfaceSmoothingSlider{ nullptr };
+  bool Locked{ false };
+  vtkWeakPointer<vtkMRMLSegmentationNode> SegmentationNode;
+};
+
+//-----------------------------------------------------------------------------
+CTK_SET_CPP(qMRMLSegmentationShow3DButton, bool, setLocked, Locked);
+CTK_GET_CPP(qMRMLSegmentationShow3DButton, bool, locked, Locked);
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationShow3DButtonPrivate::qMRMLSegmentationShow3DButtonPrivate(qMRMLSegmentationShow3DButton& object)
+  : q_ptr(&object)
+{
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationShow3DButtonPrivate::init()
+{
+  Q_Q(qMRMLSegmentationShow3DButton);
+  q->setIcon(QIcon(":/Icons/MakeModel.png"));
+  q->setCheckable(true);
+  q->setText(qMRMLSegmentationShow3DButton::tr("Show 3D"));
+  QObject::connect(q, SIGNAL(toggled(bool)), q, SLOT(onToggled(bool)));
+
+  QMenu* show3DButtonMenu = new QMenu(qMRMLSegmentationShow3DButton::tr("Show 3D"), q);
+
+  this->SurfaceSmoothingEnabledAction = new QAction(qMRMLSegmentationShow3DButton::tr("Surface smoothing"), show3DButtonMenu);
+  this->SurfaceSmoothingEnabledAction->setToolTip(
+    qMRMLSegmentationShow3DButton::tr("Apply smoothing when converting binary labelmap to closed surface representation."));
+  this->SurfaceSmoothingEnabledAction->setCheckable(true);
+  show3DButtonMenu->addAction(this->SurfaceSmoothingEnabledAction);
+  QObject::connect(this->SurfaceSmoothingEnabledAction, SIGNAL(toggled(bool)), q, SLOT(onEnableSurfaceSmoothingToggled(bool)));
+
+  QMenu* surfaceSmoothingFactorMenu = new QMenu(qMRMLSegmentationShow3DButton::tr("Smoothing factor"), show3DButtonMenu);
+  surfaceSmoothingFactorMenu->setObjectName("slicerSpacingManualMode");
+  surfaceSmoothingFactorMenu->setIcon(QIcon(":/Icon/SlicerManualSliceSpacing.png"));
+
+  this->SurfaceSmoothingSlider = new ctkSliderWidget(surfaceSmoothingFactorMenu);
+  this->SurfaceSmoothingSlider->setToolTip(
+    qMRMLSegmentationShow3DButton::tr("Higher value means stronger smoothing during closed surface representation conversion."));
+  this->SurfaceSmoothingSlider->setDecimals(2);
+  this->SurfaceSmoothingSlider->setRange(0.0, 1.0);
+  this->SurfaceSmoothingSlider->setSingleStep(0.1);
+  this->SurfaceSmoothingSlider->setValue(0.5);
+  this->SurfaceSmoothingSlider->setTracking(false);
+  QObject::connect(this->SurfaceSmoothingSlider, SIGNAL(valueChanged(double)),
+    q, SLOT(onSurfaceSmoothingFactorChanged(double)));
+  QWidgetAction* smoothingFactorAction = new QWidgetAction(surfaceSmoothingFactorMenu);
+  smoothingFactorAction->setCheckable(true);
+  smoothingFactorAction->setDefaultWidget(this->SurfaceSmoothingSlider);
+  surfaceSmoothingFactorMenu->addAction(smoothingFactorAction);
+  show3DButtonMenu->addMenu(surfaceSmoothingFactorMenu);
+
+  q->setMenu(show3DButtonMenu);
+
+  q->setEnabled(false);
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSegmentationShow3DButtonPrivate::setSurfaceSmoothingFactor(double smoothingFactor)
+{
+  if (!this->SegmentationNode || !this->SegmentationNode->GetSegmentation())
+    {
+    return false;
+    }
+
+  MRMLNodeModifyBlocker blocker(this->SegmentationNode);
+
+  this->SegmentationNode->GetSegmentation()->SetConversionParameter(
+    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSmoothingFactorParameterName(),
+    QVariant(smoothingFactor).toString().toUtf8().constData());
+
+  bool closedSurfacePresent = this->SegmentationNode->GetSegmentation()->ContainsRepresentation(
+    vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
+  if (closedSurfacePresent)
+    {
+    QApplication::setOverrideCursor(QCursor(Qt::BusyCursor));
+    this->SegmentationNode->GetSegmentation()->CreateRepresentation(
+      vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName(), true);
+    this->SegmentationNode->Modified();
+    QApplication::restoreOverrideCursor();
+    }
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLSegmentationNode* qMRMLSegmentationShow3DButton::segmentationNode() const
+{
+  Q_D(const qMRMLSegmentationShow3DButton);
+  return d->SegmentationNode;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationShow3DButton::setSegmentationNode(vtkMRMLSegmentationNode* node)
+{
+  Q_D(qMRMLSegmentationShow3DButton);
+
+  if (d->SegmentationNode == node)
+    {
+    return;
+    }
+
+  qvtkReconnect(d->SegmentationNode, node, vtkCommand::ModifiedEvent, this, SLOT(updateWidgetFromMRML()));
+  qvtkReconnect(d->SegmentationNode, node, vtkSegmentation::SegmentAdded, this, SLOT(updateWidgetFromMRML()));
+  qvtkReconnect(d->SegmentationNode, node, vtkSegmentation::SegmentRemoved, this, SLOT(updateWidgetFromMRML()));
+  qvtkReconnect(d->SegmentationNode, node, vtkSegmentation::ContainedRepresentationNamesModified, this, SLOT(updateWidgetFromMRML()));
+
+  vtkMRMLSegmentationNode* segmentationNode = vtkMRMLSegmentationNode::SafeDownCast(node);
+  d->SegmentationNode = segmentationNode;
+
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationShow3DButton::updateWidgetFromMRML()
+{
+  Q_D(qMRMLSegmentationShow3DButton);
+
+  // Update state of Show3DButton
+  if (d->SegmentationNode && d->SegmentationNode->GetSegmentation())
+    {
+    // Enable button if there is at least one segment in the segmentation
+    this->setEnabled(!d->Locked
+      && d->SegmentationNode->GetSegmentation()->GetNumberOfSegments() > 0
+      && d->SegmentationNode->GetSegmentation()->GetMasterRepresentationName() !=
+        vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
+
+    // Change button state based on whether it contains closed surface representation
+    bool closedSurfacePresent = d->SegmentationNode->GetSegmentation()->ContainsRepresentation(
+      vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
+    bool wasBlocked = this->blockSignals(true);
+    this->setChecked(closedSurfacePresent);
+    this->blockSignals(wasBlocked);
+    }
+  else
+    {
+    this->setEnabled(false);
+    }
+
+  double surfaceSmoothingFactor = 0.5;
+  if (d->SegmentationNode && d->SegmentationNode->GetSegmentation())
+    {
+    surfaceSmoothingFactor = QString(d->SegmentationNode->GetSegmentation()->GetConversionParameter(
+      vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSmoothingFactorParameterName()).c_str()).toDouble();
+    }
+  bool wasBlocked = d->SurfaceSmoothingEnabledAction->blockSignals(true);
+  d->SurfaceSmoothingEnabledAction->setChecked(surfaceSmoothingFactor >= 0.0);
+  d->SurfaceSmoothingEnabledAction->blockSignals(wasBlocked);
+
+  wasBlocked = d->SurfaceSmoothingSlider->blockSignals(true);
+  d->SurfaceSmoothingSlider->setValue(surfaceSmoothingFactor);
+  d->SurfaceSmoothingSlider->setEnabled(surfaceSmoothingFactor >= 0.0);
+  d->SurfaceSmoothingSlider->blockSignals(wasBlocked);
+}
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationShow3DButton::qMRMLSegmentationShow3DButton(QWidget* _parent)
+  : ctkMenuButton(_parent)
+  , d_ptr(new qMRMLSegmentationShow3DButtonPrivate(*this))
+{
+  Q_D(qMRMLSegmentationShow3DButton);
+  d->init();
+}
+
+//-----------------------------------------------------------------------------
+qMRMLSegmentationShow3DButton::~qMRMLSegmentationShow3DButton() = default;
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationShow3DButton::onToggled(bool on)
+{
+  Q_D(qMRMLSegmentationShow3DButton);
+  if (!d->SegmentationNode || !d->SegmentationNode->GetSegmentation())
+    {
+    return;
+    }
+
+  MRMLNodeModifyBlocker segmentationNodeBlocker(d->SegmentationNode);
+
+  if (on)
+    {
+    // Button is pressed, create closed surface representation and show it.
+    // Make sure closed surface representation exists
+    if (d->SegmentationNode->GetSegmentation()->CreateRepresentation(
+      vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName() ))
+      {
+      vtkMRMLSegmentationDisplayNode* displayNode = vtkMRMLSegmentationDisplayNode::SafeDownCast(
+        d->SegmentationNode->GetDisplayNode());
+      if (displayNode)
+        {
+        // Set closed surface as displayed poly data representation
+        displayNode->SetPreferredDisplayRepresentationName3D(
+          vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
+        }
+      // But keep binary labelmap for 2D
+      bool binaryLabelmapPresent = d->SegmentationNode->GetSegmentation()->ContainsRepresentation(
+        vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName());
+      if (binaryLabelmapPresent && displayNode)
+        {
+        displayNode->SetPreferredDisplayRepresentationName2D(
+          vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName() );
+        }
+      }
+    }
+  else
+    {
+    // Button is released, remove the closed surface representation
+    // (but only if it's not the master representation).
+    if (d->SegmentationNode->GetSegmentation()->GetMasterRepresentationName() !=
+      vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName())
+      {
+      d->SegmentationNode->GetSegmentation()->RemoveRepresentation(
+        vtkSegmentationConverter::GetSegmentationClosedSurfaceRepresentationName());
+      }
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSegmentationShow3DButton::onEnableSurfaceSmoothingToggled(bool smoothingEnabled)
+{
+  Q_D(qMRMLSegmentationShow3DButton);
+  if (!d->SegmentationNode || !d->SegmentationNode->GetSegmentation())
+    {
+    qCritical() << Q_FUNC_INFO << ": No segmentation selected";
+    return;
+    }
+
+  // Get smoothing factor
+  double originalSmoothingFactor = QString(d->SegmentationNode->GetSegmentation()->GetConversionParameter(
+    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSmoothingFactorParameterName()).c_str()).toDouble();
+  double newSmoothingFactor = fabs(originalSmoothingFactor);
+  if (originalSmoothingFactor == 0.0)
+    {
+    // if original smoothing factor was 0 then we cannot toggle smoothing
+    // therefore we reset it to the default
+    newSmoothingFactor = 0.5;
+    }
+  if (!smoothingEnabled)
+    {
+    newSmoothingFactor *= -1;
+    }
+
+  // Set smoothing factor
+  if (newSmoothingFactor != originalSmoothingFactor)
+    {
+    d->setSurfaceSmoothingFactor(newSmoothingFactor);
+    this->updateWidgetFromMRML();
+    }
+}
+
+//---------------------------------------------------------------------------
+void qMRMLSegmentationShow3DButton::onSurfaceSmoothingFactorChanged(double newSmoothingFactor)
+{
+  Q_D(qMRMLSegmentationShow3DButton);
+  if (!d->SegmentationNode || !d->SegmentationNode->GetSegmentation())
+    {
+    qCritical() << Q_FUNC_INFO << ": No segmentation selected";
+    return;
+    }
+
+  // Get smoothing factor
+  double originalSmoothingFactor = QString(d->SegmentationNode->GetSegmentation()->GetConversionParameter(
+    vtkBinaryLabelmapToClosedSurfaceConversionRule::GetSmoothingFactorParameterName() ).c_str() ).toDouble();
+
+  // Sign of smoothing factor is used to indicate that smoothing is enabled or not.
+  // if smoothing factor is negative then it means smoothing is disabled.
+  // Here we allow changing the absolute value of the smoothing factor, while maintaining its sign.
+
+  // Set smoothing factor
+  if (newSmoothingFactor != fabs(originalSmoothingFactor))
+    {
+    if (originalSmoothingFactor < 0.0)
+      {
+      newSmoothingFactor = -newSmoothingFactor;
+      }
+    d->setSurfaceSmoothingFactor(newSmoothingFactor);
+    }
+}

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationShow3DButton.h
@@ -1,0 +1,66 @@
+/*=auto=========================================================================
+
+ Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH)
+ All Rights Reserved.
+
+ See COPYRIGHT.txt
+ or http://www.slicer.org/copyright/copyright.txt for details.
+
+ Program:   3D Slicer
+
+=========================================================================auto=*/
+
+#ifndef __qMRMLSegmentationShow3DButton_h
+#define __qMRMLSegmentationShow3DButton_h
+
+// CTK includes
+#include <ctkMenuButton.h>
+#include <ctkPimpl.h>
+#include <ctkVTKObject.h>
+
+// Segmentations includes
+#include "qSlicerSegmentationsModuleWidgetsExport.h"
+
+class qMRMLSegmentationShow3DButtonPrivate;
+class vtkMRMLSegmentationNode;
+
+/// \brief Button that shows/hide segmentation in 3D
+/// It creates or removes closed surface representation.
+class Q_SLICER_MODULE_SEGMENTATIONS_WIDGETS_EXPORT qMRMLSegmentationShow3DButton : public ctkMenuButton
+{
+  Q_OBJECT
+  QVTK_OBJECT
+
+  /// Disables the button. It is useful for preventing segmentation from editing.
+  /// Using QWidget::setEnabled would only temporarily disable the button.
+  Q_PROPERTY(bool locked READ locked WRITE setLocked)
+
+public:
+  explicit qMRMLSegmentationShow3DButton(QWidget* parent=nullptr);
+  ~qMRMLSegmentationShow3DButton() override;
+
+  /// Get current segmentation node
+  Q_INVOKABLE vtkMRMLSegmentationNode* segmentationNode() const;
+
+  bool locked() const;
+
+public slots:
+  /// Set current segmentation node
+  Q_INVOKABLE void setSegmentationNode(vtkMRMLSegmentationNode* node);
+
+  void setLocked(bool);
+
+protected slots:
+  void onToggled(bool toggled=true);
+  void onEnableSurfaceSmoothingToggled(bool smoothingEnabled);
+  void onSurfaceSmoothingFactorChanged(double newSmoothingFactor);
+  void updateWidgetFromMRML();
+
+protected:
+  QScopedPointer<qMRMLSegmentationShow3DButtonPrivate> d_ptr;
+private :
+  Q_DECLARE_PRIVATE(qMRMLSegmentationShow3DButton);
+  Q_DISABLE_COPY(qMRMLSegmentationShow3DButton);
+};
+
+#endif

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModuleWidget.h
@@ -112,7 +112,7 @@ protected slots:
   void onSegmentationNodeReferenceChanged();
 
   void onAddSegment();
-  void onEditSelectedSegment();
+  void onEditSegmentation();
   void onRemoveSelectedSegments();
 
   void updateLayerWidgets();

--- a/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
+++ b/Modules/Scripted/SegmentStatistics/SegmentStatistics.py
@@ -556,11 +556,11 @@ class SegmentStatisticsLogic(ScriptedLoadableModuleLogic):
           name += ' ['+units+']'
       headerNames.append(name)
     uniqueHeaderNames = list(headerNames)
-    for name in {name for name in uniqueHeaderNames if uniqueHeaderNames.count(name)>1}:
+    for duplicateName in {name for name in uniqueHeaderNames if uniqueHeaderNames.count(name)>1}:
       j = 1
       for i in range(len(uniqueHeaderNames)):
-        if uniqueHeaderNames[i]==name:
-          uniqueHeaderNames[i] = name+' ('+str(j)+')'
+        if uniqueHeaderNames[i]==duplicateName:
+          uniqueHeaderNames[i] = duplicateName+' ('+str(j)+')'
           j += 1
     headerNames = {keys[i]: headerNames[i] for i in range(len(keys))}
     uniqueHeaderNames = {keys[i]: uniqueHeaderNames[i] for i in range(len(keys))}


### PR DESCRIPTION
Display "Show 3D" button in Segmentations module similarly to Segment Editor module.

When a segmentation was loaded and the user did not want to edit the segmentation, only show it in 3D it was not intuitive that the user had to go to Segment Editor module (or click on Create button of Closed surface representation).

Implemented by creating a qMRMLSegmentationShow3DButton widget for showing/hiding the segmentation in 3D.
It is used now in both Segmentations and Segment Editor module and can be used in custom modules, too.

Segmentations (new):

![image](https://user-images.githubusercontent.com/307929/162589745-a407755a-7f49-4740-a819-f4dd70ff7c00.png)

Segment Editor (for reference):

![image](https://user-images.githubusercontent.com/307929/162589705-3de798a5-44e5-4a22-865b-8cec2596bee5.png)
