### PR TITLE
BUG: Fix stuck disable state in Segment Editor effect list

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
@@ -468,7 +468,7 @@
   </customwidget>
   <customwidget>
    <class>qMRMLSegmentationShow3DButton</class>
-   <extends>QPushButton</extends>
+   <extends>ctkMenuButton</extends>
    <header>qMRMLSegmentationShow3DButton.h</header>
   </customwidget>
   <customwidget>

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.cxx
@@ -2107,6 +2107,8 @@ void qMRMLSegmentEditorWidget::onAddSegment()
     QStringList segmentIDList;
     segmentIDList << QString(addedSegmentID.c_str());
     d->SegmentsTableView->setSelectedSegmentIDs(segmentIDList);
+    // Make sure update of the effect buttons happens if the selected segment IDs do not change
+    this->updateEffectsSectionFromMRML();
     }
 
   // Assign the new segment the terminology of the (now second) last segment


### PR DESCRIPTION
- When the new selected segment ID is the same as the old one, the necessary updates were sometimes not called, because the SetSelectedSegmentID method did not trigger updateWidgetFromMRML on the segment editor widget
- Fixed widget base class in ui file to prevent Qt Designer warning