### PR TITLE
COMP: Allow building with C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 message(STATUS "${_msg} - C++${CMAKE_CXX_STANDARD}")
-if(NOT CMAKE_CXX_STANDARD MATCHES "^(14|17)$")
-  message(FATAL_ERROR "CMAKE_CXX_STANDARD must be set to 14 or 17")
+if(NOT CMAKE_CXX_STANDARD MATCHES "^(14|17|20)$")
+  message(FATAL_ERROR "CMAKE_CXX_STANDARD must be set to 14, 17 or 20")
 endif()
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Visual Studio 2019 16.11 now has the /std:c++20 switch
https://devblogs.microsoft.com/cppblog/msvc-cpp20-and-the-std-cpp20-switch/

This PR allows the standard to be set to C++20 as an option for testing. C++20 built Slicer on Windows 10 using Visual Studio 2022 with v143 toolset failed in some dependencies such as ITK as C++20 has removed some syntax options that were deprecated in earlier C++ versions. However, this PR allows to begin testing and finding areas where there are incompatibilities.