### PR TITLE
ENH : Markups line addon - draw an optional circle

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsLineNode.h
@@ -75,6 +75,20 @@ public:
   /// Return line length (distance between the two line endpoints) in world coordinate system.
   virtual double GetLineLengthWorld();
 
+  ///@{
+  /// Controls whether a circle should be drawn around point 0 in 2D, with radius being the line length
+  vtkGetMacro(DiskVisibility2D, int);
+  vtkSetMacro(DiskVisibility2D, int);
+  vtkBooleanMacro(DiskVisibility2D, int);
+  ///@}
+
+  ///@{
+  /// Controls whether a circle should be drawn around point 0 in 3D, with radius being the line length
+  vtkGetMacro(DiskVisibility3D, int);
+  vtkSetMacro(DiskVisibility3D, int);
+  vtkBooleanMacro(DiskVisibility3D, int);
+  ///@}
+
 protected:
   vtkMRMLMarkupsLineNode();
   ~vtkMRMLMarkupsLineNode() override;
@@ -83,6 +97,9 @@ protected:
 
   /// Calculates the handle to world matrix based on the current control points
   void UpdateInteractionHandleToWorldMatrix() override;
+
+  int DiskVisibility2D { 0 };
+  int DiskVisibility3D { 0 };
 };
 
 #endif

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.h
@@ -32,6 +32,7 @@
 
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation2D.h"
+#include "vtkDiskSource.h"
 
 class vtkTubeFilter;
 class vtkSampleImplicitFunctionFilter;
@@ -83,6 +84,9 @@ protected:
   vtkSmartPointer<vtkDiscretizableColorTransferFunction> LineColorMap;
 
   vtkSmartPointer<vtkTubeFilter> TubeFilter;
+  vtkSmartPointer<vtkDiskSource> DiskSource;
+  vtkSmartPointer<vtkPolyDataMapper2D> DiskMapper;
+  vtkSmartPointer<vtkActor2D> DiskActor;
 
   vtkSmartPointer<vtkTransformPolyDataFilter> WorldToSliceTransformer;
   vtkSmartPointer<vtkSampleImplicitFunctionFilter> SliceDistance;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
@@ -32,6 +32,7 @@
 
 #include "vtkSlicerMarkupsModuleVTKWidgetsExport.h"
 #include "vtkSlicerMarkupsWidgetRepresentation3D.h"
+#include "vtkDiskSource.h"
 
 class vtkActor;
 class vtkPolyDataMapper;
@@ -78,6 +79,10 @@ protected:
 
   vtkSmartPointer<vtkPolyData> Line;
   vtkSmartPointer<vtkTubeFilter> TubeFilter;
+
+  vtkSmartPointer<vtkDiskSource> DiskSource;
+  vtkSmartPointer<vtkPolyDataMapper> DiskMapper;
+  vtkSmartPointer<vtkActor> DiskActor;
 
   vtkSmartPointer<vtkPolyDataMapper> LineMapper;
   vtkSmartPointer<vtkPolyDataMapper> LineOccludedMapper;


### PR DESCRIPTION
@lassoan @pieper @coreDevs

Hi,

Following [this](https://discourse.slicer.org/t/draw-specific-dimension/22934) discussion, I came up with this patch that does the following :

 - use a markups line to draw a circle
 - use control point 0 as centre of the circle
 - set the circle's radius equal to the line length
 - use a vtkDiskSource to draw the circle
 - dynamically update the circle as control points are updated
 - orient the circle's axis orthogonal to the line
 - control the circle's visibility independently in 2D and 3D views
 
It is not yet controllable via UI, only by API. I don't have any clue how
to provide a UI control for this. Your suggestions are most welcome.

Please note that I'm still using a vtkDiskSource in 3D also, and not a
vtkSphereSource. This allows direct access to the markups line control points.
Moreover, orienting the disk's axis perpendicular to the line is quite
straightforward.

It is here proposed as a draft pull request, if you find it worthwhile of course. Else,
no problem at all, it has been a good opportunity to better understand things.
 
Please let me know how you consider this PR.

Regards.
