### PR TITLE
BUG: Fix infinite loop loading markups node under singleton transforms

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTransformNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformNode.cxx
@@ -527,6 +527,13 @@ void vtkMRMLTransformNode::GetTransformBetweenNodes(vtkMRMLTransformNode* source
     return;
     }
 
+  // If the number of transforms between the nodes exceeds the max depth threshold, then begin to search
+  // for duplicate transform nodes to ensure that the transform nodes don't contain a loop.
+  // See issue https://github.com/Slicer/Slicer/issues/6355.
+  int maxDepth = 100;
+  int currentDepth = 0;
+  std::set<vtkMRMLTransformNode*> visitedTransformNodes;
+
   if (sourceNode != nullptr && sourceNode->IsTransformNodeMyParent(targetNode))
     {
     // traverse the transform tree from bottom to top, from sourceNode to targetNode
@@ -536,6 +543,16 @@ void vtkMRMLTransformNode::GetTransformBetweenNodes(vtkMRMLTransformNode* source
       if (transformToParent)
         {
         transformSourceToTarget->Concatenate(transformToParent);
+        }
+
+      ++currentDepth;
+      if (currentDepth > maxDepth && !visitedTransformNodes.insert(current).second)
+        {
+        // Max depth exceeded and duplicate transform found. Loop detected.
+        // See issue https://github.com/Slicer/Slicer/issues/6355.
+        vtkGenericWarningMacro("vtkMRMLTransformNode::GetTransformBetweenNodes: Loop detected between transform nodes");
+        transformSourceToTarget->Identity();
+        break;
         }
       }
     }
@@ -548,6 +565,16 @@ void vtkMRMLTransformNode::GetTransformBetweenNodes(vtkMRMLTransformNode* source
       if (transformToParent)
         {
         transformSourceToTarget->Concatenate(transformToParent);
+        }
+
+      ++currentDepth;
+      if (currentDepth > maxDepth && !visitedTransformNodes.insert(current).second)
+        {
+        // Max depth exceeded and duplicate transform found. Loop detected.
+        // See issue https://github.com/Slicer/Slicer/issues/6355.
+        vtkGenericWarningMacro("vtkMRMLTransformNode::GetTransformBetweenNodes: Loop detected between transform nodes");
+        transformSourceToTarget->Identity();
+        break;
         }
       }
     // in transformSourceToTarget we have transform targetNode->sourceNode,


### PR DESCRIPTION
When loading a scene that contains markups transformed by singleton transform nodes it is possible to enter an infinite loop calling vtkMRMLTransformNode::GetTransformBetweenNodes(). This can happen if a circular loop is created between the transform nodes as their references are being updated.

Fixed by not processing TransformModifiedEvent events in vtkMRMLMarkupsNode during scene import.