### PR TITLE
BUG: Fix saving of scalar volume sequence with only one frame

### DIFF
--- a/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.cxx
@@ -425,6 +425,10 @@ int vtkMRMLVolumeSequenceStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
   // Use here the NRRD Writer
 #if Slicer_VERSION_MAJOR > 4 || (Slicer_VERSION_MAJOR == 4 && Slicer_VERSION_MINOR >= 9)
   vtkNew<vtkTeemNRRDWriter> writer;
+  // ForceRangeAxis needs to be emabled for the writer to correctly write image sequences that contain only a single frame.
+  // Without this option the range axis would be omitted for single frame sequences, causing the first axis to be a spatial dimension, rather than range.
+  // This would cause an error when attempting to set units on the first axis.
+  writer->SetForceRangeAxis(true);
   writer->SetVectorAxisKind(nrrdKindList);
 #else
   vtkNew<vtkNRRDWriter> writer;

--- a/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
+++ b/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
@@ -39,6 +39,7 @@ vtkTeemNRRDWriter::vtkTeemNRRDWriter()
   this->AxisUnits = new AxisInfoMapType;
   this->VectorAxisKind = nrrdKindUnknown;
   this->Space = nrrdSpaceRightAnteriorSuperior;
+  this->ForceRangeAxis = false;
 }
 
 //----------------------------------------------------------------------------
@@ -220,7 +221,7 @@ void* vtkTeemNRRDWriter::MakeNRRD()
   double spaceDir[NRRD_DIM_MAX][NRRD_SPACE_DIM_MAX] = { 0.0 };
   unsigned int baseDim = 0;
   const unsigned int spaceDim = 3; // VTK is always 3D volumes.
-  if (size[0] > 1)
+  if (size[0] > 1 || this->ForceRangeAxis)
     {
     // the range axis has no space direction
     for (unsigned int saxi=0; saxi < spaceDim; saxi++)

--- a/Libs/vtkTeem/vtkTeemNRRDWriter.h
+++ b/Libs/vtkTeem/vtkTeemNRRDWriter.h
@@ -96,6 +96,12 @@ public:
   void vtkSetSpaceToLPS()  { this->SetSpace(nrrdSpaceLeftPosteriorSuperior); };
   void vtkSetSpaceToLPST() { this->SetSpace(nrrdSpaceLeftPosteriorSuperiorTime); };
 
+  /// Force the addition of a range axis, even when the size of the first image dimension (components, or frame list) is 1.
+  /// This is useful when attempting to write an image sequence with a single frame, as otherwise the range dimension would be omitted.
+  vtkSetMacro(ForceRangeAxis, bool);
+  vtkGetMacro(ForceRangeAxis, bool);
+  vtkBooleanMacro(ForceRangeAxis, bool);
+
   /// Utility function to return image as a Nrrd*
   void* MakeNRRD();
 
@@ -130,6 +136,8 @@ protected:
   AxisInfoMapType *AxisUnits;
   int VectorAxisKind;
   int Space;
+
+  bool ForceRangeAxis;
 
 private:
   vtkTeemNRRDWriter(const vtkTeemNRRDWriter&) = delete;

--- a/Modules/Loadable/Sequences/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Sequences/Testing/Cxx/CMakeLists.txt
@@ -14,7 +14,9 @@ slicerMacroConfigureModuleCxxTestDriver(
   WITH_VTK_DEBUG_LEAKS_CHECK
   )
 
+set(TEMP "${CMAKE_BINARY_DIR}/Testing/Temporary")
+
 #-----------------------------------------------------------------------------
 simple_test(vtkMRMLSequenceBrowserNodeTest1)
 simple_test(vtkMRMLSequenceNodeTest1)
-simple_test(vtkMRMLSequenceStorageNodeTest1)
+simple_test(vtkMRMLSequenceStorageNodeTest1 ${TEMP})

--- a/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceStorageNodeTest1.cxx
+++ b/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceStorageNodeTest1.cxx
@@ -19,6 +19,8 @@
 ==============================================================================*/
 
 // MRML includes
+#include <vtkCacheManager.h>
+#include <vtkDataIOManager.h>
 #include <vtkMRMLLinearTransformNode.h>
 #include <vtkMRMLLinearTransformSequenceStorageNode.h>
 #include <vtkMRMLModelNode.h>
@@ -30,19 +32,56 @@
 #include <vtkMRMLVolumeSequenceStorageNode.h>
 
 // VTK includes
+#include <vtkImageData.h>
 #include <vtkMatrix4x4.h>
 #include <vtkNew.h>
+#include <vtkPolyData.h>
 
 #include "vtkMRMLCoreTestingMacros.h"
 
 //-----------------------------------------------------------------------------
-int vtkMRMLSequenceStorageNodeTest1( int, char * [] )
+int TestWriteReadSequence(const std::string& tempDir, vtkMRMLSequenceNode* sequenceNode, vtkMRMLStorageNode* storageNode, std::string fileName)
 {
+  std::stringstream fullFilePathSS;
+  fullFilePathSS << tempDir << "/" << fileName << "." << storageNode->GetDefaultWriteFileExtension();
+  std::string fullFilePath = fullFilePathSS.str();
+  if (vtksys::SystemTools::FileExists(fullFilePath.c_str(), true))
+    {
+    vtksys::SystemTools::RemoveFile(fullFilePath.c_str());
+    }
+
+  std::cout << "Testing sequence write: " << fullFilePath << std::endl;
+  storageNode->SetFileName(fullFilePath.c_str());
+  CHECK_BOOL(storageNode->WriteData(sequenceNode), true);
+
+  vtkSmartPointer<vtkMRMLScene> scene = sequenceNode->GetScene();
+
+  vtkSmartPointer<vtkMRMLSequenceNode> readSequenceNode = vtkSmartPointer<vtkMRMLSequenceNode>::Take(
+    vtkMRMLSequenceNode::SafeDownCast(sequenceNode->CreateNodeInstance()));
+  scene->AddNode(readSequenceNode);
+  vtkSmartPointer<vtkMRMLStorageNode> readStorageNode = vtkSmartPointer<vtkMRMLStorageNode>::Take(
+    vtkMRMLStorageNode::SafeDownCast(storageNode->CreateNodeInstance()));
+  scene->AddNode(readStorageNode);
+
+  std::cout << "Testing sequence read: " << fullFilePath << std::endl;
+  readStorageNode->SetFileName(fullFilePath.c_str());
+  CHECK_BOOL(readStorageNode->ReadData(readSequenceNode), true);
+  CHECK_INT(readSequenceNode->GetNumberOfDataNodes(), sequenceNode->GetNumberOfDataNodes());
+  return EXIT_SUCCESS;
+}
+
+//-----------------------------------------------------------------------------
+int vtkMRMLSequenceStorageNodeTest1( int argc, char * argv[] )
+{
+  std::string tempDir = ".";
+  if (argc > 1)
+    {
+    tempDir = argv[1];
+    }
+
   vtkNew<vtkMRMLScene> scene;
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLLinearTransformSequenceStorageNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLSequenceNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLSequenceStorageNode>::New());
-  scene->RegisterNodeClass(vtkSmartPointer<vtkMRMLVolumeSequenceStorageNode>::New());
+  scene->SetDataIOManager(vtkNew<vtkDataIOManager>());
+  scene->GetDataIOManager()->SetCacheManager(vtkNew<vtkCacheManager>());
 
   // Add generic node sequence
   {
@@ -52,17 +91,22 @@ int vtkMRMLSequenceStorageNodeTest1( int, char * [] )
     genericSequenceNode->AddDefaultStorageNode();
     vtkSmartPointer<vtkMRMLSequenceStorageNode> addedGenericStorageNode = vtkMRMLSequenceStorageNode::SafeDownCast(genericSequenceNode->GetStorageNode());
     CHECK_NOT_NULL(addedGenericStorageNode);
+    CHECK_EXIT_SUCCESS(TestWriteReadSequence(tempDir, genericSequenceNode, addedGenericStorageNode, "TestGenericSequence"));
   }
 
   // Add volume node sequence
   {
     vtkSmartPointer<vtkMRMLSequenceNode> imageSequenceNode = vtkMRMLSequenceNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLSequenceNode"));
+    vtkNew<vtkImageData> image;
+    image->SetDimensions(10, 10, 1);
+    image->AllocateScalars(VTK_CHAR, 1);
     vtkSmartPointer<vtkMRMLScalarVolumeNode> volumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(scene->AddNewNodeByClass("vtkMRMLScalarVolumeNode"));
+    volumeNode->SetAndObserveImageData(image);
     imageSequenceNode->SetDataNodeAtValue(volumeNode.GetPointer(), "0");
     imageSequenceNode->AddDefaultStorageNode();
     vtkSmartPointer<vtkMRMLVolumeSequenceStorageNode> addedVolumeStorageNode
       = vtkMRMLVolumeSequenceStorageNode::SafeDownCast(imageSequenceNode->GetStorageNode());
-    CHECK_NOT_NULL(addedVolumeStorageNode);
+    CHECK_EXIT_SUCCESS(TestWriteReadSequence(tempDir, imageSequenceNode, addedVolumeStorageNode, "TestImageSequence"));
   }
 
   // Add transform node sequence
@@ -75,6 +119,7 @@ int vtkMRMLSequenceStorageNodeTest1( int, char * [] )
     vtkSmartPointer<vtkMRMLLinearTransformSequenceStorageNode> addedTransformStorageNode
       = vtkMRMLLinearTransformSequenceStorageNode::SafeDownCast(transformSequenceNode->GetStorageNode());
     CHECK_NOT_NULL(addedTransformStorageNode);
+    CHECK_EXIT_SUCCESS(TestWriteReadSequence(tempDir, transformSequenceNode, addedTransformStorageNode, "TestTransformSequence"));
   }
 
   // Create generic node sequence


### PR DESCRIPTION
When trying to save a volume sequence with a single frame, vtkTeemNRRDWriter raises the following error:
```
[nrrd] nrrdSave:
[nrrd] nrrdWrite: trouble
[nrrd] _nrrdWrite:
[nrrd] nrrdCheck: trouble
[nrrd] _nrrdCheck: trouble with space field
[nrrd] _nrrdFieldCheck_space: trouble
[nrrd] _nrrdFieldCheckSpaceInfo: axis[0] has a direction vector, and so can't have min, max, spacing, or units set
```

This is because the range dimension is omitted by the writer when the size of the first dimension is 1. This results in an error when units are instead assigned to the first spatial dimension.
Fixed by adding an option (vtkTeemNRRDWriter::ForceRangeAxis) to force the writer to include a range axis, even when the size of the first dimension is 1. This option remains disabled by default, and is only enabled by vtkMRMLVolumeSequenceStorageNode.