### PR TITLE
COMP: Define Slicer icon for package and installed details

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -390,6 +390,10 @@ if(CPACK_GENERATOR STREQUAL "NSIS")
   set(PACKAGE_APPLICATION_NAME "${APPLICATION_NAME} ${CPACK_PACKAGE_VERSION}")
   slicer_verbose_set(CPACK_PACKAGE_EXECUTABLES "..\\\\${EXECUTABLE_NAME}" "${PACKAGE_APPLICATION_NAME}")
 
+  get_property(${app_name}_CPACK_NSIS_MUI_ICON GLOBAL PROPERTY ${app_name}_WIN_ICON_FILE)
+  slicer_cpack_set("CPACK_NSIS_MUI_ICON")
+  slicer_verbose_set(CPACK_NSIS_INSTALLED_ICON_NAME "${app_name}.exe")
+
   # -------------------------------------------------------------------------
   # File extensions
   # -------------------------------------------------------------------------


### PR DESCRIPTION
This closes #5885:

## Installer icon:
![image](https://user-images.githubusercontent.com/15837524/165128791-9db9cc2e-1391-4cd7-814c-39fe03788e25.png)

## Installed icon:
![image](https://user-images.githubusercontent.com/15837524/165128850-2cd0ff05-db73-4801-ac67-2fc007350a3e.png)
![image](https://user-images.githubusercontent.com/15837524/165128867-28afc961-90e3-4a9d-8dfe-e604efbeac51.png)
