### PR TITLE
COMP: Update ITK to fix CTest false positive when building ITK standalone module

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "027fd5ce0c7044c33eb56bf7530466488109390b" # slicer-v5.3rc03-2022-02-10-be81e62
+    "a87ecfc37711d7dec1d60bfd0958cf93a41c3604" # slicer-v5.3rc03-2022-02-10-be81e62
     QUIET
     )
 


### PR DESCRIPTION
This commit updates ITK to avoid false positive like the following
reported when building extension like `SlicerITKUltrasound` bundling
ITK standalone modules like `ITKHigherOrderAccurateGradient` or
`ITKUltrasound`:

```
    CMake Warning at D:/D/P/S-0-build/ITK/CMake/ITKModuleExternal.cmake:12 (message):
    -- This is needed to allow proper setting of CMAKE_MSVC_RUNTIME_LIBRARY.
    -- Do not be surprised if you run into link errors of the style:

  CUSTOMBUILD : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_Static' doesn't match value 'MDd_Dynamic' in module.obj [D:\D\P\S-0-E-b\SlicerITKUltrasound-build\ITKHigherOrderAccurateGradient.vcxproj]

      cmake_minimum_required must be at least 3.16.3
    Call Stack (most recent call first):
      CMakeLists.txt:7 (include)
```

List of ITK changes:

```
$ git shortlog 027fd5ce0c..a87ecfc377 --no-merges
Jean-Christophe Fillion-Robin (1):
      [Backport PR-3395] COMP: Update ITKModuleExternal CMake message to avoid CTest false positive
```