### PR TITLE
ENH: Update bzip2 from version 1.0.6 (Sept 2010) to 1.0.8 (July 2019)

### DIFF
--- a/SuperBuild/External_bzip2.cmake
+++ b/SuperBuild/External_bzip2.cmake
@@ -34,7 +34,7 @@ if((NOT DEFINED BZIP2_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "1c34e31d50ccad5b49ab435695ed0369c1830a5e"
+    "391dddabd24aee4a06e10ab6636f26dd93c21308"
     QUIET
     )
 

--- a/SuperBuild/External_bzip2.cmake
+++ b/SuperBuild/External_bzip2.cmake
@@ -34,7 +34,7 @@ if((NOT DEFINED BZIP2_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "0e735f23032ececcf52ed49b27928390fff28e50"
+    "1c34e31d50ccad5b49ab435695ed0369c1830a5e"
     QUIET
     )
 


### PR DESCRIPTION
* Fix `-Wmaybe-uninitialized` warnings

* Fix handling of large (> 4GB) files on Windows.

* Fix undefined behavior in the macros `SET_BH`, `CLEAR_BH`, & `ISSET_BH`

* Make sure nSelectors is not out of range ([CVE-2019-12900](https://nvd.nist.gov/vuln/detail/cve-2019-12900))

* Accept as many selectors as the file format allows. This relaxes the fix for [CVE-2019-12900](https://nvd.nist.gov/vuln/detail/cve-2019-12900) from 1.0.7 so that bzip2 allows decompression of bz2 files that use (too) many selectors again.