### PR TITLE
BUG: Retire DataStore module

### DIFF
--- a/Docs/user_guide/modules/index.md
+++ b/Docs/user_guide/modules/index.md
@@ -172,7 +172,6 @@ Deprecated modules are not recommended to be used anymore, typically because oth
 ```{toctree}
 :maxdepth: 1
 annotations.md
-datastore.md
 resamplescalarvolume.md
 robuststatisticssegmenter.md
 simpleregiongrowingsegmentation.md

--- a/Docs/user_guide/modules/retiredmodules.md
+++ b/Docs/user_guide/modules/retiredmodules.md
@@ -14,3 +14,6 @@ A module may also be retired if it no longer works properly (for example due to 
 - **Expert Automated Registration**
   - Retired: 2022-02-19, [commit 87fd349](https://github.com/Slicer/Slicer/commit/87fd349334e6414c28ba373bbc45d03c7345ad0c)
   - Reason: [No longer running properly](https://github.com/Slicer/Slicer/pull/6200#issuecomment-1045962304). BRAINS, Elastix, and ANTs registration toolkits offer superior registration results, see [Automatic Image Registration](../registration.md) section for details.
+- **DataStore**
+  - Retired: 2022-04-26
+  - Reason: Infrastructure for uploading and organizing datasets was based on the obsolete Slicer server based on Midas. Associated datasets are available as release assets associated with the [Slicer/SlicerDataStore](https://github.com/Slicer/SlicerDataStore) GitHub project.

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -317,15 +317,6 @@ if(Slicer_BUILD_BRAINSTOOLS)
   mark_as_superbuild(BRAINSCommonLib_DIR:PATH)
 endif()
 
-Slicer_Remote_Add(DataStore
-  GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/Slicer-DataStore"
-  GIT_TAG 7b31153c7ec4c23966646275d10d5c109b2e463c
-  OPTION_NAME Slicer_BUILD_DataStore
-  OPTION_DEPENDS "Slicer_BUILD_WEBENGINE_SUPPORT"
-  LABELS REMOTE_MODULE
-  )
-list_conditional_append(Slicer_BUILD_DataStore Slicer_REMOTE_DEPENDENCIES DataStore)
-
 Slicer_Remote_Add(CompareVolumes
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/pieper/CompareVolumes"
   GIT_TAG 7e5530930282a5f99c746df331538e431f3609b4


### PR DESCRIPTION
In March 2020, the Slicer community decided [^1] to retire the DataStore module and instead store the corresponding data files as GitHub release assets into the Slicer/SlicerDataStore [^2] GitHub project.

In September 2021, the Slicer legacy extensions catalog has been updated[^3] to include the `/midas3/slicerdatastore` and `/midas3/slicerdatastore/user/login` endpoints displaying instructions referencing the GitHub release assets.

Finally, in April 2022, the module was completely removed.


[^1]: https://github.com/Slicer/Slicer/issues/4602
[^2]: https://github.com/Slicer/SlicerDataStore
[^3]: https://github.com/Slicer/Slicer/issues/5845