### PR TITLE
BUG: Fix remote cache directory in vtkMRMLSequenceStorageNodeTest1

### DIFF
--- a/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceStorageNodeTest1.cxx
+++ b/Modules/Loadable/Sequences/Testing/Cxx/vtkMRMLSequenceStorageNodeTest1.cxx
@@ -82,6 +82,7 @@ int vtkMRMLSequenceStorageNodeTest1( int argc, char * argv[] )
   vtkNew<vtkMRMLScene> scene;
   scene->SetDataIOManager(vtkNew<vtkDataIOManager>());
   scene->GetDataIOManager()->SetCacheManager(vtkNew<vtkCacheManager>());
+  scene->GetDataIOManager()->GetCacheManager()->SetRemoteCacheDirectory(tempDir.c_str());
 
   // Add generic node sequence
   {


### PR DESCRIPTION
Because the remote cache directory was not specified for the scene in vtkMRMLSequenceStorageNodeTest1, attempting to unzip and read the seq.mrb would fail on Linux and Mac as the application would not have permission to write to the directory.

Fixed by setting the remote cache directory to the temporary testing directory.