### PR TITLE
BUG: Fix Slicer crash upon hiding delete all control points option

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -604,6 +604,10 @@ void qSlicerMarkupsPlaceWidget::updateDeleteButton()
     d->DeleteButton->setPopupMode(showMenu ? QToolButton::MenuButtonPopup : QToolButton::DelayedPopup);
 
     vtkMRMLMarkupsNode* currentMarkupsNode = this->currentMarkupsNode();
+    if ( currentMarkupsNode == nullptr )
+      {
+      return;
+      }
     d->DeleteButton->setVisible(showMenu || !currentMarkupsNode->GetFixedNumberOfControlPoints()); // hide when no options to show
     }
   }


### PR DESCRIPTION
Slicer would crash when following this example in the Slicer developer guide documentation.
https://github.com/Slicer/Slicer/blob/a61c805427e9af8cef631ce6e5ff2e297c3a3325/Docs/developer_guide/api.md?plain=1#L49-L56

This was not caught by the Markups widget test because a node is already set to the widget upon customizing the delete all control points action.
https://github.com/Slicer/Slicer/blob/a61c805427e9af8cef631ce6e5ff2e297c3a3325/Modules/Loadable/Markups/Widgets/Testing/Python/MarkupsWidgetsSelfTest.py#L162-L176
## Steps to reproduce
