### PR TITLE
DOC: Include workaround to force visual update of intersecting slices

### DIFF
--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -554,7 +554,7 @@ sliceDisplayNodes = slicer.util.getNodesByClass("vtkMRMLSliceDisplayNode")
 for sliceDisplayNode in sliceDisplayNodes:
   sliceDisplayNode.SetIntersectingSlicesVisibility(1)
 
-# Workaround to force visual update
+# Workaround to force visual update (see https://github.com/Slicer/Slicer/issues/6338)
 sliceNodes = slicer.util.getNodesByClass('vtkMRMLSliceNode')
 for sliceNode in sliceNodes:
     sliceNode.Modified()

--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -553,6 +553,11 @@ layoutSwitchAction.setToolTip("3D and slice view")
 sliceDisplayNodes = slicer.util.getNodesByClass("vtkMRMLSliceDisplayNode")
 for sliceDisplayNode in sliceDisplayNodes:
   sliceDisplayNode.SetIntersectingSlicesVisibility(1)
+
+# Workaround to force visual update
+sliceNodes = slicer.util.getNodesByClass('vtkMRMLSliceNode')
+for sliceNode in sliceNodes:
+    sliceNode.Modified()
 ```
 
 :::{note}


### PR DESCRIPTION
Based on https://discourse.slicer.org/t/previous-turning-on-individual-slice-intersection-not-working/23183/4.

This updates the example for updating slice intersecting visibility with the currently required force update to see the change. This is to document the current situation until #6338 can be completed.