### PR TITLE
BUG: Fix deprecation warning suggesting method not actually used

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2118,7 +2118,7 @@ def arrayFromMarkupsCurveData(markupsNode, arrayName, world=False):
     (effect of parent transform to the node is applied).
   :raises ValueError: in case of failure
 
-  Note that not all array may be available in both node and world coordinate sytems.
+  Note that not all array may be available in both node and world coordinate systems.
   For example, `Curvature` is only computed for the curve in world coordinate system.
 
   The returned array is not intended to be modified, as arrays are expected to be written only

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.h
@@ -120,10 +120,10 @@ public:
     vtkWarningMacro("vtkMRMLMarkupsFiducialNode::AddFiducialFromArray method is deprecated, please use AddControlPoint instead");
     return this->AddControlPoint(pos, label);
     }
-  /// \deprecated Use GetNthControlPointPositionVector instead.
+  /// \deprecated Use GetNthControlPointPosition instead.
   void GetNthFiducialPosition(int n, double pos[3])
     {
-    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNthFiducialPosition method is deprecated, please use GetNthControlPointPositionVector instead");
+    vtkWarningMacro("vtkMRMLMarkupsFiducialNode::GetNthFiducialPosition method is deprecated, please use GetNthControlPointPosition instead");
     this->GetNthControlPointPosition(n, pos);
     }
   /// \deprecated Use SetNthControlPointPosition instead.


### PR DESCRIPTION
I noticed this mismatch in the suggestion versus what was actually being used while I was updating some old code to use newer API.

This mismatch of the recommendation versus what is actually used was introduced in https://github.com/Slicer/Slicer/commit/e667de230fb41aca7efa576ebcdeb2621f300aa5.