### PR TITLE
ENH: Add slicer.util.chdir context manager

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -273,6 +273,12 @@ slicer_add_python_unittest(
   )
 
 slicer_add_python_unittest(
+  SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_util_chdir.py
+  SLICER_ARGS --no-main-window --disable-modules
+  TESTNAME_PREFIX nomainwindow_
+  )
+
+slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_util_save.py
   SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules DATA{${INPUT}/MR-head.nrrd}
   TESTNAME_PREFIX nomainwindow_

--- a/Base/Python/slicer/tests/test_slicer_util_chdir.py
+++ b/Base/Python/slicer/tests/test_slicer_util_chdir.py
@@ -1,0 +1,47 @@
+import os
+import unittest
+import slicer
+
+
+class SlicerUtilChdirTests(unittest.TestCase):
+  """Available in Python 3.11 as ``TestChdir`` found in ``Lib/test/test_contextlib.py``
+  and adapted from https://github.com/python/cpython/pull/28271
+  """
+  def test_simple(self):
+    old_cwd = os.getcwd()
+    target = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../slicer"))
+    self.assertNotEqual(old_cwd, target)
+
+    with slicer.util.chdir(target):
+      self.assertEqual(os.getcwd(), target)
+    self.assertEqual(os.getcwd(), old_cwd)
+
+  def test_reentrant(self):
+    old_cwd = os.getcwd()
+    target1 = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../slicer"))
+    target2 = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../tests"))
+    self.assertNotIn(old_cwd, (target1, target2))
+    chdir1, chdir2 = slicer.util.chdir(target1), slicer.util.chdir(target2)
+
+    with chdir1:
+      self.assertEqual(os.getcwd(), target1)
+      with chdir2:
+        self.assertEqual(os.getcwd(), target2)
+        with chdir1:
+          self.assertEqual(os.getcwd(), target1)
+        self.assertEqual(os.getcwd(), target2)
+      self.assertEqual(os.getcwd(), target1)
+    self.assertEqual(os.getcwd(), old_cwd)
+
+  def test_exception(self):
+    old_cwd = os.getcwd()
+    target = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../slicer"))
+    self.assertNotEqual(old_cwd, target)
+
+    try:
+      with slicer.util.chdir(target):
+        self.assertEqual(os.getcwd(), target)
+        raise RuntimeError("boom")
+    except RuntimeError as re:
+      self.assertEqual(str(re), "boom")
+    self.assertEqual(os.getcwd(), old_cwd)

--- a/Base/Python/slicer/tests/test_slicer_util_chdir.py
+++ b/Base/Python/slicer/tests/test_slicer_util_chdir.py
@@ -9,7 +9,7 @@ class SlicerUtilChdirTests(unittest.TestCase):
   """
   def test_simple(self):
     old_cwd = os.getcwd()
-    target = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../slicer"))
+    target = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../slicer"))
     self.assertNotEqual(old_cwd, target)
 
     with slicer.util.chdir(target):
@@ -18,8 +18,8 @@ class SlicerUtilChdirTests(unittest.TestCase):
 
   def test_reentrant(self):
     old_cwd = os.getcwd()
-    target1 = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../slicer"))
-    target2 = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../tests"))
+    target1 = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../slicer"))
+    target2 = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../tests"))
     self.assertNotIn(old_cwd, (target1, target2))
     chdir1, chdir2 = slicer.util.chdir(target1), slicer.util.chdir(target2)
 
@@ -35,7 +35,7 @@ class SlicerUtilChdirTests(unittest.TestCase):
 
   def test_exception(self):
     old_cwd = os.getcwd()
-    target = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../slicer"))
+    target = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../slicer"))
     self.assertNotEqual(old_cwd, target)
 
     try:

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -3095,6 +3095,29 @@ def getFilesInDirectory(directory, absolutePath=True):
   return allFiles
 
 
+class chdir:
+  """Non thread-safe context manager to change the current working directory.
+
+  .. note::
+
+    Available in Python 3.11 as ``contextlib.chdir`` and adapted from https://github.com/python/cpython/pull/28271
+
+    Available in CTK as ``ctkScopedCurrentDir`` C++ class
+  """
+  def __init__(self, path):
+    self.path = path
+    self._old_cwd = []
+
+  def __enter__(self):
+    import os
+    self._old_cwd.append(os.getcwd())
+    os.chdir(self.path)
+
+  def __exit__(self, *excinfo):
+    import os
+    os.chdir(self._old_cwd.pop())
+
+
 def plot(narray, xColumnIndex = -1, columnNames = None, title = None, show = True, nodes = None):
   """Create a plot from a numpy array that contains two or more columns.
 


### PR DESCRIPTION
This commit implements a non thread-safe context manager to change
the current working directory.

Available in Python 3.11 as ``contextlib.chdir`` and adapted from
https://github.com/python/cpython/pull/28271.