### PR TITLE
COMP: Ensure ExternalData_OBJECT_STORES cache variable is read

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,7 +735,9 @@ set(ExternalData_OBJECT_STORES_DEFAULT "${Slicer_BINARY_DIR}/ExternalData/Object
 if(DEFINED "ENV{ExternalData_OBJECT_STORES}")
   set(ExternalData_OBJECT_STORES_DEFAULT $ENV{ExternalData_OBJECT_STORES})
 endif()
-set(ExternalData_OBJECT_STORES "${ExternalData_OBJECT_STORES_DEFAULT}")
+if(NOT DEFINED ExternalData_OBJECT_STORES)
+  set(ExternalData_OBJECT_STORES "${ExternalData_OBJECT_STORES_DEFAULT}")
+endif()
 message(STATUS "Setting ExternalData_OBJECT_STORES to '${ExternalData_OBJECT_STORES}'")
 
 set(Slicer_ExternalData_DATA_MANAGEMENT_TARGET ${PROJECT_NAME}Data)


### PR DESCRIPTION
This commit ensures that re-configuring the inner build accounts for the
`ExternalData_OBJECT_STORES` value stored in the CMake cache.