### PR TITLE
Begin 5.1.0 development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(NOT DEFINED Slicer_VERSION_MAJOR)
   set(Slicer_VERSION_MAJOR "5")
 endif()
 if(NOT DEFINED Slicer_VERSION_MINOR)
-  set(Slicer_VERSION_MINOR "0")
+  set(Slicer_VERSION_MINOR "1")
 endif()
 if(NOT DEFINED Slicer_VERSION_PATCH)
   set(Slicer_VERSION_PATCH "0")
@@ -312,6 +312,8 @@ set(_commit_count_offsets
   # at SVN revision=28825 / git hash 47deb76d7556e40de4e25e585c4b24a63a153da5 in official Slicer repository
   # (https://github.com/Slicer/Slicer.git).
   "3037"
+  # Allocate revisions for patch releases between v5.0.0 and v5.1.0
+  "100"
   )
 list(JOIN _commit_count_offsets "+" _commit_count_offsets_expr)
 math(EXPR _commit_count_offset "${_commit_count_offsets_expr}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,10 +305,17 @@ set_property(CACHE Slicer_REVISION_TYPE PROPERTY STRINGS
 mark_as_advanced(Slicer_REVISION_TYPE)
 mark_as_superbuild(Slicer_REVISION_TYPE)
 
-# Default Slicer_WC_COMMIT_COUNT_OFFSET is chosen to provide continuity of revisions when switching from SVN to git
-# at SVN revision=28825 / git hash 47deb76d7556e40de4e25e585c4b24a63a153da5 in official Slicer repository
-# (https://github.com/Slicer/Slicer.git).
-set(Slicer_WC_COMMIT_COUNT_OFFSET "3037" CACHE STRING
+# Default Slicer_WC_COMMIT_COUNT_OFFSET
+
+set(_commit_count_offsets
+  # Value is chosen to provide continuity of revisions when switching from SVN to git
+  # at SVN revision=28825 / git hash 47deb76d7556e40de4e25e585c4b24a63a153da5 in official Slicer repository
+  # (https://github.com/Slicer/Slicer.git).
+  "3037"
+  )
+list(JOIN _commit_count_offsets "+" _commit_count_offsets_expr)
+math(EXPR _commit_count_offset "${_commit_count_offsets_expr}")
+set(Slicer_WC_COMMIT_COUNT_OFFSET "${_commit_count_offset}" CACHE STRING
   "This value is added to commit count to compute Slicer_COMMIT_COUNT (that may be used to set Slicer_REVISION).")
 mark_as_advanced(Slicer_WC_COMMIT_COUNT_OFFSET)
 mark_as_superbuild(Slicer_WC_COMMIT_COUNT_OFFSET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,11 +208,6 @@ set(Slicer_BUILD_SHARED ${BUILD_SHARED_LIBS})
 include(SlicerApplicationOptions)
 
 #-----------------------------------------------------------------------------
-# Slicer version number
-#-----------------------------------------------------------------------------
-include(SlicerVersion)
-
-#-----------------------------------------------------------------------------
 # Append the library version information to the library target properties.
 #------------------------------------------------------------------------------
 option(Slicer_WITH_LIBRARY_VERSION "Build with library version information" OFF)
@@ -321,6 +316,11 @@ mark_as_superbuild(Slicer_WC_COMMIT_COUNT_OFFSET)
 option(Slicer_USE_FOLDERS "Organize build targets into folders" ON)
 mark_as_superbuild(Slicer_USE_FOLDERS)
 mark_as_advanced(Slicer_USE_FOLDERS)
+
+#-----------------------------------------------------------------------------
+# Slicer version number
+#-----------------------------------------------------------------------------
+include(SlicerVersion)
 
 #-----------------------------------------------------------------------------
 # External projects related options

--- a/Utilities/Scripts/SlicerWizard/__version__.py
+++ b/Utilities/Scripts/SlicerWizard/__version__.py
@@ -1,8 +1,8 @@
 __version_info__ = (
   5,
+  1,
   0,
-  0,
-  0
+  "dev0"
 )
 
 __version__ = ".".join(map(str, __version_info__))


### PR DESCRIPTION
### Summary

* Ensure revision displayed during configuration is always correct

This commit is a follow-up of https://github.com/Slicer/Slicer/commit/3814f1af649d63a1737005304b0924a03393446a (`ENH: Use commit count as working copy revision`). It ensures the commit count offset and the revision type are set before displaying revision information during top-level configuration.

|                | Before | After | Command                                 |
|----------------|--------|-------|-----------------------------------------|
| Initial config | 27775  | 30812 |`cmake -U Slicer_WC_COMMIT_COUNT_OFFSET .` |
| Re-config      | 30812  | 30812 |`cmake  .`                                 |


* Generalize logic for specifying additional commit count offsets 

* Begin 5.1.0 development and allocate 250 revisions for patch releases between 5.0.0 and 5.1.0

### Caveat

Since `Slicer_WC_COMMIT_COUNT_OFFSET` is a cache variable initialized with a default value after initiating the release of the next version along with defining a new offset, developer will not see the correct value because the cache value is persistent .... developer would have to either do a clean build or call `cmake -U Slicer_WC_COMMIT_COUNT_OFFSET .`

https://github.com/jcfr/Slicer/blob/begin-5.1.0-development/CMakeLists.txt#L320-L323

* Invalid value displayed ...

```
$ cmake .
[...]
-- Configuring Slicer release type [Experimental]
-- Configuring Slicer version [5.1.0-2022-04-29]
-- Configuring Slicer revision [30814]
```

* Correct value displayed after removing the cache entry ...

```
$ cmake -U Slicer_WC_COMMIT_COUNT_OFFSET .
[...]
-- Configuring Slicer release type [Experimental]
-- Configuring Slicer version [5.1.0-2022-04-29]
-- Configuring Slicer revision [31064]

```

