### PR TITLE
BUG: Fix on exit Segfault ensuring ExtensionsManagerDialog is deleted once

### DIFF
--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -148,7 +148,7 @@ public:
   // to keep track if the object is deleted already by the MainWindow.
   QPointer<ctkSettingsDialog> SettingsDialog;
 #ifdef Slicer_BUILD_EXTENSIONMANAGER_SUPPORT
-  qSlicerExtensionsManagerDialog* ExtensionsManagerDialog;
+  QPointer<qSlicerExtensionsManagerDialog> ExtensionsManagerDialog;
   bool IsExtensionsManagerDialogOpen;
 #endif
 #ifdef Slicer_USE_QtTesting


### PR DESCRIPTION
This commit applies a fix similar to acc618074 (BUG: Segfault at application
exit due to SettingsDialog deletion) and fixes a regression likely introduced
in abd2544d4 (BUG: Fixed application window not clickable when popup is
displayed) where the extension manager instance is associated with the
parent window.

See https://discourse.slicer.org/t/help-for-package-testing-on-macos-monterrey-or-bigsur-system/23249