### PR TITLE
ENH: add nearest neighbor interpolation mode to labelmapvolume

### DIFF
--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.cxx
@@ -72,3 +72,11 @@ void vtkMRMLLabelMapVolumeNode::CreateDefaultDisplayNodes()
   dispNode->SetDefaultColorMap();
   this->SetAndObserveDisplayNodeID(dispNode->GetID());
 }
+
+//----------------------------------------------------------------------------
+int vtkMRMLLabelMapVolumeNode::GetResamplingInterpolationMode()
+{
+  // Labelmap volumes must be resampled using nearest neighbor method to avoid
+  // introducing new label values at boundaries.
+  return VTK_NEAREST_INTERPOLATION;
+}

--- a/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLLabelMapVolumeNode.h
@@ -58,6 +58,8 @@ protected:
   ~vtkMRMLLabelMapVolumeNode() override;
   vtkMRMLLabelMapVolumeNode(const vtkMRMLLabelMapVolumeNode&);
   void operator=(const vtkMRMLLabelMapVolumeNode&);
+
+  int GetResamplingInterpolationMode() override;
 };
 
 #endif

--- a/Libs/MRML/Core/vtkMRMLVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLVolumeNode.h
@@ -285,6 +285,10 @@ protected:
   /// If useParentTransform is false then parent transform is ignored.
   void GetCenterPositionRAS(double* centerPositionRAS, bool useParentTransform=true);
 
+  /// Returns the interpolation algorithm that should be used for resampling the volume.
+  /// The value is one of VTK_NEAREST_INTERPOLATION, VTK_LINEAR_INTERPOLATION, or VTK_CUBIC_INTERPOLATION.
+  virtual int GetResamplingInterpolationMode();
+
   /// these are unit length direction cosines
   double IJKToRASDirections[3][3];
 


### PR DESCRIPTION
Hardening a non-linear transform on a labelmap results in a linear interpolation of the labels which is undesired.
Relative to [issue discussed on the forums](https://discourse.slicer.org/t/landmark-registration-transform-resampling/23243)