### PR TITLE
ENH: Increase maximum number of colors loaded from colortable files

### DIFF
--- a/Libs/MRML/Core/vtkMRMLColorTableNode.h
+++ b/Libs/MRML/Core/vtkMRMLColorTableNode.h
@@ -212,6 +212,10 @@ public:
   /// Set a color into the User color table. Return 1 on success, 0 on failure.
   int SetColor(int entry, const char* name, double r, double g, double b, double a = 1.0);
 
+  /// Set many entries to the same name and color in one batch (with one ModifiedEvent).
+  /// This is much more efficient than setting many color entries one by one using SetColor().
+  int SetColors(int firstEntry, int lastEntry, const char* name, double r, double g, double b, double a = 1.0);
+
   /// Set a color into the User color table. Return 1 on success, 0 on failure.
   int SetColor(int entry, double r, double g, double b, double a);
   int SetColor(int entry, double r, double g, double b);

--- a/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLColorTableStorageNode.cxx
@@ -31,8 +31,10 @@ vtkMRMLNodeNewMacro(vtkMRMLColorTableStorageNode);
 //----------------------------------------------------------------------------
 vtkMRMLColorTableStorageNode::vtkMRMLColorTableStorageNode()
 {
-  // use 32K as a maximum color id for now
-  this->MaximumColorID = 32768;
+  // When a color table file contains very large numbers then most likely
+  // it is not a valid file (probably it is some other text file and not
+  // a color table). The highest acceptable color ID is specified in MaximumColorID.
+  this->MaximumColorID = 1000000;
   this->DefaultWriteFileExtension = "ctbl";
 }
 
@@ -150,11 +152,7 @@ int vtkMRMLColorTableStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
       colorNode->GetLookupTable()->SetTableRange(0, maxID);
       }
     // init the table to black/opacity 0 with no name, just in case we're missing values
-    const char *noName = colorNode->GetNoName();
-    for (int i = 0; i < maxID+1; i++)
-      {
-      colorNode->SetColor(i, noName, 0.0, 0.0, 0.0, 0.0);
-      }
+    colorNode->SetColors(0, maxID, colorNode->GetNoName(), 0.0, 0.0, 0.0, 0.0);
     // We are sure that all the names are initialized here, flag it as such
     // to prevent unnecessary recomputation
     colorNode->NamesInitialisedOn();


### PR DESCRIPTION
File loading performance is fixed by implementing bulk setting of color values.

Increased maximum number of accepted entries to 1 million as requested in #6354.
Loading of a file with 1 million as the maximum ID takes only a few seconds.
Colors module performance is not great with such huge tables. It takes about 20 seconds
to display a color table with 1 million entries.

fixes #6354