### PR TITLE
BUG: vtk_to_numpy function missing in Endoscopy

### DIFF
--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -365,7 +365,7 @@ class EndoscopyComputePath:
       if originalPointsPerSegment<pointsPerSegment:
         self.fids.SetNumberOfPointsPerInterpolatingSegment(originalPointsPerSegment)
       # Get it as a numpy array as an independent copy
-      self.path = vtk.util.numpy_support(resampledPoints.GetData())
+      self.path = vtk.util.numpy_support.vtk_to_numpy(resampledPoints.GetData())
       return
 
     # hermite interpolation functions
@@ -534,7 +534,7 @@ class EndoscopyPathModel:
       linesIDArray.SetTuple1( 0, linesIDArray.GetNumberOfTuples() - 1 )
       lines.SetNumberOfCells(1)
 
-    pointsArray = vtk.util.numpy_support(points.GetData())
+    pointsArray = vtk.util.numpy_support.vtk_to_numpy(points.GetData())
     self.planePosition, self.planeNormal = self.planeFit(pointsArray.T)
 
     # Create model node


### PR DESCRIPTION
the bug was introduced in a258951f473d74f24a93cff95673ea6163a7b5e1, and it's fixed here

corresponding to the Issue:

https://github.com/Slicer/Slicer/issues/6360