### PR TITLE
COMP: Do not require building extension from git repository (alternative approach)

### DIFF
--- a/CMake/FindGit.cmake
+++ b/CMake/FindGit.cmake
@@ -35,6 +35,7 @@
 #  <var-prefix>_WC_REVISION_NAME - Name associated with <var-prefix>_WC_REVISION_HASH
 #  <var-prefix>_WC_URL - output of command `git config --get remote.origin.url'
 #  <var-prefix>_WC_ROOT - Same value as working copy URL
+#  <var-prefix>_WC_COMMIT_COUNT - number of commits in current branch
 #  <var-prefix>_WC_LAST_CHANGED_DATE - date of last commit
 #  <var-prefix>_WC_GITSVN - Set to false
 #
@@ -48,7 +49,6 @@
 #  <var-prefix>_WC_LAST_CHANGED_DATE - date of last commit
 #  <var-prefix>_WC_LAST_CHANGED_REV - revision of last commit
 #  <var-prefix>_WC_LAST_CHANGED_LOG - last log of base revision
-#  <var-prefix>_WC_COMMIT_COUNT - number of commits in current branch
 #
 # Example usage:
 #   find_package(Git)

--- a/CMake/SlicerMacroExtractRepositoryInfo.cmake
+++ b/CMake/SlicerMacroExtractRepositoryInfo.cmake
@@ -39,12 +39,23 @@
 #  <var-prefix>_WC_REVISION_NAME - Name associated with <var-prefix>_WC_REVISION_HASH
 #  <var-prefix>_WC_REVISION_HASH - current revision
 #  <var-prefix>_WC_REVISION - Equal to <var-prefix>_WC_REVISION_HASH
+#  <var-prefix>_WC_COMMIT_COUNT - number of commits in current branch
+#  <var-prefix>_WC_LAST_CHANGED_DATE - date of last commit
 #
-# If source directory is not GIT, the macro will return early
-# displaying an warning message:
+# If the source directory is not a GIT repository, the macro will
+# display a warning message like the following:
 #
 #   -- Skipping repository info extraction: directory [/path/to/src] is not a GIT checkout
 
+# and set the following variables:
+#
+#   <var-prefix>_WC_TYPE: "local"
+#   <var-prefix>_WC_URL: "NA"
+#   <var-prefix>_ROOT: "NA"
+#   <var-prefix>_WC_REVISION_NAME: "NA"
+#   <var-prefix>_WC_REVISION_HASH: "NA"
+#   <var-prefix>_WC_REVISION: "NA"
+#
 macro(SlicerMacroExtractRepositoryInfo)
   include(CMakeParseArguments)
   set(options)

--- a/CMake/SlicerMacroExtractRepositoryInfo.cmake
+++ b/CMake/SlicerMacroExtractRepositoryInfo.cmake
@@ -67,12 +67,13 @@ macro(SlicerMacroExtractRepositoryInfo)
   set(${wc_info_prefix}_WC_TYPE local)
   set(${wc_info_prefix}_WC_URL "NA")
   set(${wc_info_prefix}_WC_ROOT "NA")
+  set(${wc_info_prefix}_WC_REVISION "NA")
   set(${wc_info_prefix}_WC_REVISION_NAME "NA")
   set(${wc_info_prefix}_WC_REVISION_HASH "NA")
 
   if(NOT EXISTS ${MY_SOURCE_DIR}/.git)
 
-    message(AUTHOR_WARNING "Skipping repository info extraction: directory [${MY_SOURCE_DIR}] is not a GIT or SVN checkout")
+    message(AUTHOR_WARNING "Skipping repository info extraction: directory [${MY_SOURCE_DIR}] is not a GIT checkout")
 
   else()
 

--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -683,12 +683,3 @@ It most likely means that the test driver is not linking against `ITKFactoryRegi
 
 For more details, read [What is the ITKFactoryRegistration library?](https://www.slicer.org/wiki/Documentation/Nightly/Developers/FAQ#What_is_the_ITKFactoryRegistration_library_.3F).
 
-### My extension build fails with `CMake variable EXTENSION_WC_REVISION is empty` error
-
-When an extension is built, a description file is generated that contains the extension's version. The extension source code is expected to be stored in a git repository and the version information is automatically extracted from that. If the extension source code is in an uncontrolled folder (e.g., the source code was downloaded as a zip file instead of cloning the git repository) then the build system detects this and stops with the error `CMake variable EXTENSION_WC_REVISION is empty`.
-
-The recommended solution is to store the extension's source code in a git repository.
-
-To bypass automatic version detection, specify then the version using CMake variables manually when you configure your project - either using the CMake GUI or by adding these arguments when you call cmake.exe:
-
-    -DYourExtensionName_WC_REVISION:STRING=100 -DEXTENSION_WC_REVISION:STRING=100


### PR DESCRIPTION
Developers often complained that their extension build failed for some
unknown reason and frequently the issue was that they did not store the
source code in a git repository.

It is good to encourage developers to use best practices, such as version
control, but making the build fail if they build from a non-version-controlled
repository was unnecessarily strong measure.

This commit changes the behavior so that if an extension is built from a
non-git folder then the build succeeds, just a warning is displayed during
project configuration step and `NA` is used as the extension's WC revision.