### PR TITLE
COMP: Revert changes inadvertently integrated

### DIFF
--- a/CMake/SlicerMacroExtractRepositoryInfo.cmake
+++ b/CMake/SlicerMacroExtractRepositoryInfo.cmake
@@ -72,13 +72,7 @@ macro(SlicerMacroExtractRepositoryInfo)
 
   if(NOT EXISTS ${MY_SOURCE_DIR}/.git)
 
-    if(DEFINED ${wc_info_prefix}_WC_REVISION)
-      message(STATUS "Using manually defined WC revision: ${wc_info_prefix}_WC_REVISION=${${wc_info_prefix}_WC_REVISION}")
-    else()
-      message(AUTHOR_WARNING "Skipping repository info extraction: directory [${MY_SOURCE_DIR}] is not a git repository."
-        "To resolve this warning store the extension source code in a git repository or set ${wc_info_prefix}_WC_REVISION CMake variable.")
-      set(${wc_info_prefix}_WC_REVISION "NA")
-    endif()
+    message(AUTHOR_WARNING "Skipping repository info extraction: directory [${MY_SOURCE_DIR}] is not a GIT or SVN checkout")
 
   else()
 

--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -682,3 +682,13 @@ It most likely means that the test driver is not linking against `ITKFactoryRegi
 - call `itk::itkFactoryRegistration();` in its main function.
 
 For more details, read [What is the ITKFactoryRegistration library?](https://www.slicer.org/wiki/Documentation/Nightly/Developers/FAQ#What_is_the_ITKFactoryRegistration_library_.3F).
+
+### My extension build fails with `CMake variable EXTENSION_WC_REVISION is empty` error
+
+When an extension is built, a description file is generated that contains the extension's version. The extension source code is expected to be stored in a git repository and the version information is automatically extracted from that. If the extension source code is in an uncontrolled folder (e.g., the source code was downloaded as a zip file instead of cloning the git repository) then the build system detects this and stops with the error `CMake variable EXTENSION_WC_REVISION is empty`.
+
+The recommended solution is to store the extension's source code in a git repository.
+
+To bypass automatic version detection, specify then the version using CMake variables manually when you configure your project - either using the CMake GUI or by adding these arguments when you call cmake.exe:
+
+    -DYourExtensionName_WC_REVISION:STRING=100 -DEXTENSION_WC_REVISION:STRING=100


### PR DESCRIPTION
This commit reverts 9b15994e5 (Do not require building
extension from git repository) inadvertently integrated
as part of the unrelated pull request #6371.