### PR TITLE
Upgrade python syntax to 3.9 and newer

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CLISerializationTest.py
+++ b/Applications/SlicerApp/Testing/Python/CLISerializationTest.py
@@ -70,9 +70,9 @@ if __name__ == '__main__':
     temp_dir = os.path.expanduser(getattr(args, "/path/to/temp_dir"))
 
     # Create input/output
-    serializeSeedsOutFile = '%s/%s.acsv' % (temp_dir, 'SeedsSerialized')
-    deserializeSeedsOutFile = '%s/%s.acsv' % (temp_dir, 'SeedsDeSerialized')
-    json_file = '%s/%s.json' % (temp_dir, 'ExecutionModelTourSerialized')
+    serializeSeedsOutFile = f'{temp_dir}/SeedsSerialized.acsv'
+    deserializeSeedsOutFile = f'{temp_dir}/SeedsDeSerialized.acsv'
+    json_file = f'{temp_dir}/ExecutionModelTourSerialized.json'
 
     # Copy .mrml file to prevent modification of source tree
     mrml_source_path = os.path.join(data_dir, 'ExecutionModelTourTest.mrml')

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -299,7 +299,7 @@ class ScriptedLoadableModuleTest(unittest.TestCase):
     """
 
     def __init__(self, *args, **kwargs):
-        super(ScriptedLoadableModuleTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # See https://github.com/Slicer/Slicer/pull/6243#issuecomment-1061800718 for more information.
         # Do not pass *args, **kwargs since there is no base class after `unittest.TestCase`. This is only relevant to

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2716,7 +2716,7 @@ def _messageDisplay(logLevel, text, testingReturnValue, mainWindowNeeded=False, 
     if not windowTitle:
         windowTitle = slicer.app.applicationName + " " + logLevelString
     if slicer.app.testingEnabled():
-        logging.info("Testing mode is enabled: Returning %s and skipping message box [%s]." % (testingReturnValue, windowTitle))
+        logging.info(f"Testing mode is enabled: Returning {testingReturnValue} and skipping message box [{windowTitle}].")
         return testingReturnValue
     if mainWindowNeeded and mainWindow() is None:
         return
@@ -2739,7 +2739,7 @@ def messageBox(text, parent=None, **kwargs):
     import logging, qt, slicer
     if slicer.app.testingEnabled():
         testingReturnValue = qt.QMessageBox.Ok
-        logging.info("Testing mode is enabled: Returning %s (qt.QMessageBox.Ok) and displaying an auto-closing message box [%s]." % (testingReturnValue, text))
+        logging.info(f"Testing mode is enabled: Returning {testingReturnValue} (qt.QMessageBox.Ok) and displaying an auto-closing message box [{text}].")
         slicer.util.delayDisplay(text, autoCloseMsec=3000, parent=parent, **kwargs)
         return testingReturnValue
 

--- a/Modules/Scripted/DICOMPlugins/DICOMEnhancedUSVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMEnhancedUSVolumePlugin.py
@@ -1,4 +1,3 @@
-
 import vtk
 
 import slicer

--- a/Modules/Scripted/DataProbe/DataProbe.py
+++ b/Modules/Scripted/DataProbe/DataProbe.py
@@ -169,7 +169,7 @@ class DataProbeInfoWidget:
             value = self.calculateTensorScalars(tensor, operation=operation)
             if value is not None:
                 valueString = ("%f" % value).rstrip('0').rstrip('.')
-                return "%s %s" % (scalarVolumeDisplayNode.GetScalarInvariantAsString(), valueString)
+                return f"{scalarVolumeDisplayNode.GetScalarInvariantAsString()} {valueString}"
             else:
                 return scalarVolumeDisplayNode.GetScalarInvariantAsString()
 

--- a/Modules/Scripted/ImportItkSnapLabel/ImportItkSnapLabel.py
+++ b/Modules/Scripted/ImportItkSnapLabel/ImportItkSnapLabel.py
@@ -26,7 +26,7 @@ class ImportItkSnapLabel(ScriptedLoadableModule):
 # (identified by its special name <moduleName>FileReader)
 #
 
-class ImportItkSnapLabelFileReader(object):
+class ImportItkSnapLabelFileReader:
 
     def __init__(self, parent):
         self.parent = parent
@@ -115,7 +115,7 @@ class ImportItkSnapLabelFileReader(object):
         colors = []
 
         lineIndex = 0
-        with open(filename, "r") as fileobj:
+        with open(filename) as fileobj:
             for line in fileobj:
                 lineIndex += 1
                 commentLine = commentLineRegex.search(line)

--- a/Modules/Scripted/WebServer/WebServer.py
+++ b/Modules/Scripted/WebServer/WebServer.py
@@ -299,10 +299,10 @@ class SlicerHTTPServer(HTTPServer):
         self.requestCommunicators = {}
         self.enableCORS = enableCORS
 
-    class DummyRequestHandler(object):
+    class DummyRequestHandler:
         pass
 
-    class SlicerRequestCommunicator(object):
+    class SlicerRequestCommunicator:
         """
         Encapsulate elements for handling event driven read of request.
         An instance is created for each client connection to our web server.
@@ -374,7 +374,7 @@ class SlicerHTTPServer(HTTPServer):
                             self.logMessage('Found end of header with no content, so body is empty')
                             requestHeader = self.requestSoFar[:-2]
                             requestComplete = True
-            except socket.error as e:
+            except OSError as e:
                 print('Socket error: ', e)
                 print('So far:\n', self.requestSoFar)
                 requestComplete = True
@@ -475,7 +475,7 @@ class SlicerHTTPServer(HTTPServer):
                 self.response = self.response[sent:]
                 self.sentSoFar += sent
                 self.logMessage('sent: %d (%d of %d, %f%%)' % (sent, self.sentSoFar, self.toSend, 100. * self.sentSoFar / self.toSend))
-            except socket.error as e:
+            except OSError as e:
                 self.logMessage('Socket error while sending: %s' % e)
                 sendError = True
 
@@ -493,8 +493,8 @@ class SlicerHTTPServer(HTTPServer):
             fileno = connectionSocket.fileno()
             self.requestCommunicators[fileno] = self.SlicerRequestCommunicator(connectionSocket, self.requestHandlers, self.docroot, self.logMessage, self.enableCORS)
             self.logMessage('Connected on %s fileno %d' % (connectionSocket, connectionSocket.fileno()))
-        except socket.error as e:
-            self.logMessage('Socket Error', socket.error, e)
+        except OSError as e:
+            self.logMessage('Socket Error', OSError, e)
 
     def start(self):
         """start the server
@@ -537,7 +537,7 @@ class SlicerHTTPServer(HTTPServer):
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 s.bind(("", port))
-            except socket.error as e:
+            except OSError as e:
                 portFree = False
                 port += 1
             finally:

--- a/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
@@ -5,7 +5,7 @@ import urllib
 import slicer
 
 
-class DICOMRequestHandler(object):
+class DICOMRequestHandler:
     """
     Implements the mapping between DICOMweb endpoints
     and ctkDICOMDatabase api calls.
@@ -104,13 +104,13 @@ class DICOMRequestHandler(object):
                     firstInstance = instances[0]
                     dataset = pydicom.dcmread(slicer.dicomDatabase.fileForInstance(firstInstance), stop_before_pixels=True)
                     studyDataset = pydicom.dataset.Dataset()
-                    studyDataset.SpecificCharacterSet = [u'ISO_IR 100']
+                    studyDataset.SpecificCharacterSet = ['ISO_IR 100']
                     studyDataset.StudyDate = dataset.StudyDate
                     studyDataset.StudyTime = dataset.StudyTime
                     studyDataset.StudyDescription = dataset.StudyDescription if hasattr(studyDataset, 'StudyDescription') else None
                     studyDataset.StudyInstanceUID = dataset.StudyInstanceUID
                     studyDataset.AccessionNumber = dataset.AccessionNumber
-                    studyDataset.InstanceAvailability = u'ONLINE'
+                    studyDataset.InstanceAvailability = 'ONLINE'
                     studyDataset.ModalitiesInStudy = list(modalitiesInStudy)
                     studyDataset.ReferringPhysicianName = dataset.ReferringPhysicianName
                     studyDataset[self.retrieveURLTag] = pydicom.dataelem.DataElement(
@@ -164,10 +164,10 @@ class DICOMRequestHandler(object):
             for instance in instances:
                 dataset = pydicom.dcmread(slicer.dicomDatabase.fileForInstance(instance), stop_before_pixels=True)
                 instanceDataset = pydicom.dataset.Dataset()
-                instanceDataset.SpecificCharacterSet = [u'ISO_IR 100']
+                instanceDataset.SpecificCharacterSet = ['ISO_IR 100']
                 instanceDataset.SOPClassUID = dataset.SOPClassUID
                 instanceDataset.SOPInstanceUID = dataset.SOPInstanceUID
-                instanceDataset.InstanceAvailability = u'ONLINE'
+                instanceDataset.InstanceAvailability = 'ONLINE'
                 instanceDataset[self.retrieveURLTag] = pydicom.dataelem.DataElement(
                     0x00080190, "UR", "http://example.com")  # TODO: provide WADO-RS RetrieveURL
                 instanceDataset.StudyInstanceUID = dataset.StudyInstanceUID
@@ -219,7 +219,7 @@ class DICOMRequestHandler(object):
                 firstInstance = instances[0]
                 dataset = pydicom.dcmread(slicer.dicomDatabase.fileForInstance(firstInstance), stop_before_pixels=True)
                 seriesDataset = pydicom.dataset.Dataset()
-                seriesDataset.SpecificCharacterSet = [u'ISO_IR 100']
+                seriesDataset.SpecificCharacterSet = ['ISO_IR 100']
                 seriesDataset.Modality = dataset.Modality
                 seriesDataset.SeriesInstanceUID = dataset.SeriesInstanceUID
                 seriesDataset.SeriesNumber = dataset.SeriesNumber

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -397,7 +397,7 @@ import vtk.util.numpy_support
 import slicer
 
 
-class SlicerRequestHandler(object):
+class SlicerRequestHandler:
     """Implements the Slicer REST api"""
 
     def __init__(self, enableExec=False):
@@ -810,7 +810,7 @@ class SlicerRequestHandler(object):
         supportedScalarTypes = ["short", "double"]
         scalarType = imageData.GetScalarTypeAsString()
         if scalarType not in supportedScalarTypes:
-            self.logMessage('Can only get volumes of types %s, not %s' % (str(supportedScalarTypes), scalarType))
+            self.logMessage(f'Can only get volumes of types {str(supportedScalarTypes)}, not {scalarType}')
             self.logMessage('Converting to short, but may cause data loss.')
             volumeArray = numpy.array(volumeArray, dtype='int16')
             scalarType = 'short'

--- a/Modules/Scripted/WebServer/WebServerLib/StaticPagesRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/StaticPagesRequestHandler.py
@@ -4,7 +4,7 @@ import os
 import re
 
 
-class StaticPagesRequestHandler(object):
+class StaticPagesRequestHandler:
     """Serves static pages content (files) from the configured docroot
 
     uriRewriteRules member variable contain a list of string pairs. iI each pair,
@@ -71,6 +71,6 @@ class StaticPagesRequestHandler(object):
                 fp = open(path, 'rb')
                 responseBody = fp.read()
                 fp.close()
-            except IOError:
+            except OSError:
                 responseBody = None
         return contentType, responseBody

--- a/Utilities/Scripts/genqrc.py
+++ b/Utilities/Scripts/genqrc.py
@@ -18,7 +18,7 @@ def writeFile(path, content):
             pass
 
     # Write file
-    with open(path, "wt") as f:
+    with open(path, "w") as f:
         f.write(content)
 
 


### PR DESCRIPTION
<s>This continually enforces changes made in https://github.com/Slicer/Slicer/commit/4483cc0e6f288b0816b6329f1829d9ef8c5aa81a and https://github.com/Slicer/Slicer/commit/1a85ebabd543907072c72c34247aae849489d33b.

Changes were applied automatically by running:
pre_commit run --all-files</s>

---------

**EDIT**

Similarly to 1a85eba (introduced through PR #6132) and 4483cc0 (introduced through PR #5625), this PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to also automatically upgrade python syntax.

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py39-plus MyPythonFile.py`
  - On multiple files, there are few options:
    - on unix system:
      ```
      PythonSlicer -m pyupgrade --py39-plus $(find . -type f -name "*.py")
      ```
    - on any system, use @jamesobutler `pyupgrade-script.py` written to automate running pyupgrade across all python files in the Slicer repo. It was run by `PythonSlicer pyupgrade-script.py`.
      ```python
      # pyupgrade-script.py
      import os
      import subprocess

      search_directory = "C:/Users/JamesButler/Documents/GitHub/Slicer"
      for root, _, files in os.walk(search_directory):
          for file_item in files:
              file_path = os.path.join(root, file_item)
              if os.path.isfile(file_path) and file_path.endswith(".py"):
                  subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py39-plus", file_path])
      ```