### PR TITLE
BUG: Make built-in procedural color nodes (such as PET-DICOM) read only

### DIFF
--- a/Modules/Loadable/Colors/qSlicerColorsModuleWidget.cxx
+++ b/Modules/Loadable/Colors/qSlicerColorsModuleWidget.cxx
@@ -269,11 +269,9 @@ void qSlicerColorsModuleWidget::onMRMLColorNodeChanged(vtkMRMLNode* newColorNode
     d->EditColorsCollapsibleButton->setText(tr("Continuous scale"));
 
     // set the color transfer function to the widget
-    d->ContinuousScalarsToColorsWidget->view()->setColorTransferFunctionToPlots(procColorNode->GetColorTransferFunction());
-
-    // only allow editing of user types
-    d->ContinuousScalarsToColorsWidget->setEnabled(
-        procColorNode->GetType() == vtkMRMLColorNode::User);
+    bool editable = procColorNode->GetType() == vtkMRMLColorNode::User; // only allow editing of user types
+    d->ContinuousScalarsToColorsWidget->view()->setColorTransferFunctionToPlots(procColorNode->GetColorTransferFunction(), editable);
+    d->ContinuousScalarsToColorsWidget->setEnabled(editable);
     }
   else
     {

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -75,7 +75,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "4f87cd0a0b0f2d604189afc79effc7283dc27193"
+    "ec816cbb77986f6ee28c41a495e82238dee0e2d3"
     QUIET
     )
 


### PR DESCRIPTION
Possible fix of the first bug in #6111.

CommonTK PR [#1032](https://github.com/commontk/CTK/pull/1032) must be applied as well.

Drawback: Colour transfer function thumbnail icon and widget representation (ColorNode) isn't updated on the fly. Only if you hover a mouse arrow above it.

Read only for build-in CTF nodes (not editable)
![image](https://user-images.githubusercontent.com/3785912/168556510-411be310-ab87-477b-8d3e-64cbd26fe48a.png)

Node is editable after being copied.
![image](https://user-images.githubusercontent.com/3785912/168556770-55be627f-6e06-4ff3-84ab-454d0d95ddad.png)
