### PR TITLE
COMP: Update VTK backporting fix for vtkSphericalPointIterator gcc build error

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -178,7 +178,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
     set(_git_tag "97904fdcc7e73446b3131f32eac9fc9781b23c2d") # slicer-v8.2.0-2018-10-02-74d9488523
     set(vtk_egg_info_version "8.2.0")
   elseif("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "684e8a602bd57dd6aaf4a7e086c2ea5d76e8e8b5") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "efbbf9c02e989a8f2f12395634044779653f6f0e") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of changes:

```
$ git shortlog 684e8a602..efbbf9c02e --no-merges
Ben Boeckel (1):
      [Backport] vtkSphericalPointIterator: include `<memory>` for `std::unique_ptr`
```

Rational:

    Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile.
    The following headers are used less widely in libstdc++ and may need to be included explicitly when compiled with GCC 11:

        (for std::numeric_limits)
        (for std::unique_ptr, std::shared_ptr etc.)
        (for std::pair, std::tuple_size, std::index_sequence etc.)
        (for members of namespace std::this_thread.)

Source: https://gcc.gnu.org/gcc-11/porting_to.html