### PR TITLE
COMP: fix building error with gcc 11

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode_Private.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode_Private.h
@@ -15,6 +15,9 @@
 
 ==============================================================================*/
 
+// STD includes
+#include <memory>
+
 // MRML includes
 #include "vtkMRMLMarkupsJsonStorageNode.h"
 

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -14,6 +14,7 @@
 
 // STD includes
 #include <algorithm>
+#include <memory>
 
 // Volumes includes
 #include "vtkSlicerVolumesLogic.h"


### PR DESCRIPTION
Add header `<memory>` for `std::unique_ptr`, see also gcc guide: https://gcc.gnu.org/gcc-11/porting_to.html.
Related https://github.com/Slicer/Slicer/issues/6367 and https://github.com/Slicer/Slicer/pull/6383.