### PR TITLE
BUG: Improve slicer.util.messageBox() to avoid blocking in testing mode

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2480,7 +2480,7 @@ def tempDirectory(key='__SlicerTemp__',tempDir=None,includeDateTime=True):
   return dirPath
 
 
-def delayDisplay(message, autoCloseMsec=1000, parent=None):
+def delayDisplay(message, autoCloseMsec=1000, parent=None, **kwargs):
   """Display an information message in a popup window for a short time.
 
   If ``autoCloseMsec < 0`` then the window is not closed until the user clicks on it
@@ -2496,6 +2496,9 @@ def delayDisplay(message, autoCloseMsec=1000, parent=None):
     slicer.app.processEvents()
     return
   messagePopup = qt.QDialog(parent if parent else mainWindow())
+  for key, value in kwargs.items():
+    if hasattr(messagePopup, key):
+      setattr(messagePopup, key, value)
   layout = qt.QVBoxLayout()
   messagePopup.setLayout(layout)
   label = qt.QLabel(message,messagePopup)
@@ -2636,12 +2639,14 @@ def messageBox(text, parent=None, **kwargs):
     slicer.util.messageBox("Some message", dontShowAgainSettingsKey = "MainWindow/DontShowSomeMessage")
 
   When the application is running in testing mode (``slicer.app.testingEnabled() == True``),
-  the popup is skipped and ``qt.QMessageBox.Ok`` is returned, with the text being logged to indicate this.
+  an auto-closing popup with a delay of 3s is shown using :func:`delayDisplay()` and ``qt.QMessageBox.Ok``
+  is returned, with the text being logged to indicate this.
   """
   import logging, qt, slicer
   if slicer.app.testingEnabled():
     testingReturnValue = qt.QMessageBox.Ok
-    logging.info("Testing mode is enabled: Returning %s (qt.QMessageBox.Ok) and skipping message box [%s]." % (testingReturnValue, text))
+    logging.info("Testing mode is enabled: Returning %s (qt.QMessageBox.Ok) and displaying an auto-closing message box [%s]." % (testingReturnValue, text))
+    slicer.util.delayDisplay(text, autoCloseMsec=3000, parent=parent, **kwargs)
     return testingReturnValue
 
   import ctk

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2506,6 +2506,13 @@ def delayDisplay(message, autoCloseMsec=1000, parent=None):
     okButton = qt.QPushButton("OK")
     layout.addWidget(okButton)
     okButton.connect('clicked()', messagePopup.close)
+  # Windows 10 peek feature in taskbar shows all hidden but not destroyed windows
+  # (after creating and closing a messagebox, hovering over the mouse on Slicer icon, moving up the
+  # mouse to the peek thumbnail would show it again).
+  # Popup windows in other Qt applications often show closed popups (such as
+  # Paraview's Edit / Find data dialog, MeshMixer's File/Preferences dialog).
+  # By calling deleteLater, the messagebox is permanently deleted when the current call is completed.
+  messagePopup.deleteLater()
   messagePopup.exec_()
 
 

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2480,7 +2480,7 @@ def tempDirectory(key='__SlicerTemp__',tempDir=None,includeDateTime=True):
   return dirPath
 
 
-def delayDisplay(message, autoCloseMsec=1000):
+def delayDisplay(message, autoCloseMsec=1000, parent=None):
   """Display an information message in a popup window for a short time.
 
   If ``autoCloseMsec < 0`` then the window is not closed until the user clicks on it
@@ -2495,7 +2495,7 @@ def delayDisplay(message, autoCloseMsec=1000):
   if 0 <= autoCloseMsec < 400:
     slicer.app.processEvents()
     return
-  messagePopup = qt.QDialog()
+  messagePopup = qt.QDialog(parent if parent else mainWindow())
   layout = qt.QVBoxLayout()
   messagePopup.setLayout(layout)
   label = qt.QLabel(message,messagePopup)

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2627,7 +2627,16 @@ def messageBox(text, parent=None, **kwargs):
   For example::
 
     slicer.util.messageBox("Some message", dontShowAgainSettingsKey = "MainWindow/DontShowSomeMessage")
+
+  When the application is running in testing mode (``slicer.app.testingEnabled() == True``),
+  the popup is skipped and ``qt.QMessageBox.Ok`` is returned, with the text being logged to indicate this.
   """
+  import logging, qt, slicer
+  if slicer.app.testingEnabled():
+    testingReturnValue = qt.QMessageBox.Ok
+    logging.info("Testing mode is enabled: Returning %s (qt.QMessageBox.Ok) and skipping message box [%s]." % (testingReturnValue, text))
+    return testingReturnValue
+
   import ctk
   mbox = ctk.ctkMessageBox(parent if parent else mainWindow())
   mbox.text = text


### PR DESCRIPTION
This commit is a follow up of c47d816c7 (ENH: Skip message boxes when testing)
and 70bb3b2ce (ENH: Refactor message box utility functions)