### PR TITLE
BUG: Ensure vtkMRMLCameraNode layout name can be updated

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLCameraNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLCameraNodeTest1.cxx
@@ -14,9 +14,67 @@
 #include "vtkMRMLCameraNode.h"
 #include "vtkMRMLCoreTestingMacros.h"
 
+namespace {
+
+//---------------------------------------------------------------------------
+int ExerciseBasicMethods();
+int TestGetSetLayoutName();
+
+}
+
+//---------------------------------------------------------------------------
 int vtkMRMLCameraNodeTest1(int , char * [] )
+{
+  CHECK_EXIT_SUCCESS(ExerciseBasicMethods());
+  CHECK_EXIT_SUCCESS(TestGetSetLayoutName());
+  return EXIT_SUCCESS;
+}
+
+namespace {
+
+//---------------------------------------------------------------------------
+int ExerciseBasicMethods()
 {
   vtkNew<vtkMRMLCameraNode> node1;
   EXERCISE_ALL_BASIC_MRML_METHODS(node1.GetPointer());
   return EXIT_SUCCESS;
+}
+
+//---------------------------------------------------------------------------
+int TestGetSetLayoutName()
+{
+  vtkNew<vtkMRMLCameraNode> node1;
+
+  vtkNew<vtkMRMLCoreTestingUtilities::vtkMRMLNodeCallback> callback;
+  node1->AddObserver(vtkCommand::AnyEvent, callback.GetPointer());
+
+  CHECK_NULL(node1->GetLayoutName());
+
+  node1->SetLayoutName(nullptr);
+  CHECK_INT(callback->GetTotalNumberOfEvents(), 0);
+
+  node1->SetLayoutName("1");
+  CHECK_INT(callback->GetNumberOfEvents(vtkMRMLCameraNode::LayoutNameModifiedEvent), 1);
+  CHECK_INT(callback->GetNumberOfModified(), 1);
+  CHECK_INT(callback->GetTotalNumberOfEvents(), 2);
+
+  callback->ResetNumberOfEvents();
+  node1->SetLayoutName("1");
+  CHECK_INT(callback->GetTotalNumberOfEvents(), 0);
+
+  callback->ResetNumberOfEvents();
+  node1->SetLayoutName("2");
+  CHECK_INT(callback->GetNumberOfEvents(vtkMRMLCameraNode::LayoutNameModifiedEvent), 1);
+  CHECK_INT(callback->GetNumberOfModified(), 1);
+  CHECK_INT(callback->GetTotalNumberOfEvents(), 2);
+
+  callback->ResetNumberOfEvents();
+  node1->SetLayoutName(nullptr);
+  CHECK_INT(callback->GetNumberOfEvents(vtkMRMLCameraNode::LayoutNameModifiedEvent), 1);
+  CHECK_INT(callback->GetNumberOfModified(), 1);
+  CHECK_INT(callback->GetTotalNumberOfEvents(), 2);
+
+  return EXIT_SUCCESS;
+}
+
 }

--- a/Libs/MRML/Core/vtkMRMLCameraNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLCameraNode.cxx
@@ -440,16 +440,16 @@ void vtkMRMLCameraNode::SetLayoutName(const char* layoutName)
       {
       // no change
       return;
+      }
     }
-    }
-  else if (this->GetSingletonTag() != nullptr && strcmp(layoutName, this->GetSingletonTag()))
+  else if (this->GetSingletonTag() != nullptr && strcmp(layoutName, this->GetSingletonTag()) == 0)
     {
     // no change
     return;
-      }
+    }
   this->SetSingletonTag(layoutName);
   this->InvokeEvent(vtkMRMLCameraNode::LayoutNameModifiedEvent, nullptr);
-    }
+}
 
 //-----------------------------------------------------------
 char* vtkMRMLCameraNode::GetLayoutName()


### PR DESCRIPTION
This commit is a follow up of e78f557cd (ENH: Simplify view widgets
initialization from view nodes) that originally introduced the
`vtkMRMLCameraNode::GetLayoutName/SetLayoutName`.

It makes sure that the layout name associated with a given camera node
can be set to a different value after it had already been set once.