### PR TITLE
Fix macOS build error updating libarchive from 3.5.2 to 3.6.1

### DIFF
--- a/SuperBuild/External_LibArchive.cmake
+++ b/SuperBuild/External_LibArchive.cmake
@@ -33,7 +33,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "1b2c437b99b361c7692538fa373e99955e9b93ae" # master v3.5.2
+    "6c3301111caa75c76e1b2acb1afb2d71341932ef" # master v3.6.1
     QUIET
     )
 
@@ -97,7 +97,7 @@ if((NOT DEFINED LibArchive_INCLUDE_DIR
     )
   if(APPLE)
     ExternalProject_Add_Step(${proj} fix_rpath
-      COMMAND install_name_tool -id ${EP_INSTALL_DIR}/lib/libarchive.18.dylib ${EP_INSTALL_DIR}/lib/libarchive.18.dylib
+      COMMAND install_name_tool -id ${EP_INSTALL_DIR}/lib/libarchive.19.dylib ${EP_INSTALL_DIR}/lib/libarchive.19.dylib
       DEPENDEES install
       )
   endif()


### PR DESCRIPTION
This commit updates libarchive to fix a macOS build error specific to
debug builds.

For reference, commit libarchive/libarchive@a4c3c90bb (Remove the unused variable detected_bytes) fixes the following build error:

```
/opt/s/LibArchive/libarchive/archive_read_support_format_mtree.c:695:10: error: variable 'detected_bytes' set but not used [-Werror,-Wunused-but-set-variable]
        ssize_t detected_bytes = 0, len, nl;
                ^
1 error generated.
```

List of changes:

```
$ git shortlog 1b2c437b9..6c3301111 --no-merges
AdamKorcz (1):
      Add CIFuzz

Alex Richardson (2):
      Reduce test_write_format_7zip_large_lzma1 buffer size
      Avoid millions of rand() calls() when running tests

Alex Xu (1):
      libarchive.3: update archive format list

Alexey Pelykh (1):
      Include android_lf.h only for libarchive sources

Brad King (1):
      windows: include archive_platform.h first in blake2s sources

Charly C (1):
      fix the archive_write_disk.3 man page

Christian Hesse (1):
      unescape when extracting link

Dustin Howett (3):
      windows: make sure we use the right calling convention for libc
      fix: include archive_platform in ...cpio to ensure calling convention
      Remove dependency on user32

Emil Velikov (20):
      mtree reader: return early, remove fallthrough chain
      editorconfig: add simple top-level file
      archive: constify the archive::vtable dispatch
      reader: remove unused read_filter_bidder::options
      reader: remove archive_read_filter_bidder_vtable::free stubs
      reader: remove the return type of archive_read_filter_bidder_vtable::free
      reader: introduce archive_read_filter_bidder::vtable
      reader: transform get_bidder into register_bidder
      archive: remove ::compression_{code,name}
      reader: reuse client_{open,close}_proxy more
      reader: track read_filter "can_seek" with a flag
      reader: track read_filter "can_skip" with a flag
      reader: remove unused archive_read_filter callbacks
      reader: introduce struct archive_read_filter_vtable
      cmake: fold gcc/clang sections
      cmake: drop -rdynamic aka CMP0065 NEW
      tar: demote -xa from error to a warning
      cmake: enable -fdata/function-sections and --gc-sections
      autotools: enable -fdata/function-sections and --gc-sections
      archive_digest: check return value of EVP_DigestInit()

Graham Percival (1):
      Fix Y2038 check

Grzegorz Antoniak (3):
      RAR5 reader: fixed out of bounds read in some files
      RAR5 reader: fix invalid memory access in some files
      RAR5 reader: add more checks for invalid extraction parameters

IohannRabeson (1):
      Make all the implicit cast explicit.

JFranklin13 (1):
      Add support for rar5 sfx files

Jairo (3):
      Windows support
      Update untar.c
      Update untar.c

Joerg Sonnenberger (1):
      Support ARCHIVE_EXTRACT_SECURE_NODOTDOT on Windows

Jonas Witschel (4):
      Add ARCHIVE_READDISK_NO_SPARSE to suppress reading sparse file info
      tar: expose ARCHIVE_READDISK_NO_SPARSE as --no-read-sparse
      test_sparse_basic: do not assume that holes can be read in one go
      test_sparse_basic: test ARCHIVE_READDISK_NO_SPARSE

Jung-uk Kim (2):
      Enable LZMA support for FreeBSD
      bsdtar(1): Document threads options for zstd and xz

Ken Matsui (1):
      Remove the unused variable `detected_bytes`

Martin Matuska (25):
      Libarchive 3.5.3dev
      CI: provide a more complete Ubuntu package list
      Fix following symlinks when processing the fixup list
      archive_write_set_format_cpio_binary: fix compilation on OpenBSD
      archive_write_disk_posix: fix writing fflags broken in 8a1bd5c
      CI: fix ubuntu distcheck
      dist: add missing zipx-zstd test files to Makefile.am
      zip: fix possible endless loop if reading a truncated zstd archive
      tar: fix format name typo in creation_set.c
      untar.c: style fixes
      tests: fix style in test_utils/test_main.c
      CI: add dist-artifact
      Libarchive 3.6.0dev
      Release 3.6.0
      Libarchive 3.6.1dev
      tests: reduce sample size for RAR filter test
      RAR reader: fix heap-use-after-free in RAR (v4) filter code
      ci (GitHub Actions): build on Windows 2022 and use Visual Studio 17 2022
      7zip reader: style fixes after 3962d596d
      RAR reader: fix null-dereference in RAR (v4) filter code
      build: fix detection of readdir_r() and dirfd() in configure.ac
      ISO reader: fix possible heap buffer overflow in read_children()
      RAR reader: fix heap-use-after-free in run_filters()
      Release 3.6.1
      CI: Update dependencies for Windows build

Mateusz Piotrowski (1):
      Fix use of At mdoc(7) macro

Michael Osipov (1):
      Add macro for dirfd() on HP-UX because no full POSIX.1-2008 coverage exists

Michał Górny (2):
      Fix expected error messages in test_read_format_zip_winzip_aes*
      Handle missing zlib in test_read_format_zip_7z_deflate

Peter Pentchev (1):
      Raise the lzip max dictionary size to 512MB.

Petr Malat (1):
      Support libzstd compiled with compressor disabled

Russell Greene (2):
      zstd filter writer: add threads option
      fix --threads commandline

Ryan Libby (2):
      tar: respect --ignore-zeros in c r & u modes when reading archives
      tar/test/test_option_ignore_zeros.c: test tar --ignore-zeros

Samanta Navarro (3):
      Fix size_t cast in read_mac_metadata_blob
      Ignore size of directories with regular type
      Added test case for ustar directory handling

Theo Buehler (1):
      Remove OpenSSL compat code that misuses the API

Tim Kientzle (2):
      Reorganize test code a bit
      ZIP reader: fix possible out-of-bounds read in zipx_lzma_alone_init()

Todd Richmond (1):
      zip size entry of -1 should be treated the same as 0

Walter Lozano (2):
      Add path fallback in tar
      Fix check for tape device

Wei-Cheng Pan (2):
      support rar filters
      add test

Younes El-karama (1):
      Fix typo in libarchive/archive_read_support_filter_lzop.c

Zdenek Zambersky (1):
      Fixed size filed in pax header

cielavenir (2):
      Fix 7z PPMD reading beyond boundary
      code review

jiat75 (15):
      added missing checks for canLzip, canLzma, and canXz
      Added all exported but undocumented functions to man pages
      Removed unused function.
      Added bin folder to .gitignore
      Only use deflate when size is not set if the user did not specify a compression algorithm
      Added test for writing an zip file without entry size and no compression
      Added assertions for folder
      Added new test to cmake lists
      Added copyright to new test file.
      Adding test to Makefile.am
      Reusing code from zip size known and adjusting comments
      Using the new .editorconfig to fix formatting on size unset store test
      Fixing typo in archive_read_disk man page
      Cleaned up archive_read_disk_descend functions.
      Added error message when archive extraction fails

jo620kix (2):
      ZIP reader: added support for Zstd decompression
      Add offset variable to zip_read_data_zipx_zstd

linear cannon (4):
      define printf format specifiers if not present
      import m4_ax_compile_check_sizeof.m4 from autoconf archive
      update CMake sizeof definitions to match autotools
      update BLAKE2_PACKED macro with a non-GCCism fallback
```