### PR TITLE
BUG: Escape HTML chars in CLI output

### DIFF
--- a/Base/QTCLI/qSlicerCLIProgressBar.cxx
+++ b/Base/QTCLI/qSlicerCLIProgressBar.cxx
@@ -368,7 +368,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
     if (!errorText.empty())
       {
       detailsText += "<span style = \"color:#FF0000;\">";
-      detailsText += errorText.c_str();
+      detailsText += QString::fromStdString(errorText).toHtmlEscaped();
       detailsText += "</span>";
       }
     if (!errorText.empty() && !outputText.empty())
@@ -377,7 +377,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
       }
     if (!outputText.empty())
       {
-      detailsText += node->GetOutputText().c_str();
+      detailsText += QString::fromStdString(node->GetOutputText()).toHtmlEscaped();
       }
     detailsText += "</pre>";
     d->DetailsTextBrowser->setText(detailsText);


### PR DESCRIPTION
Characters such as `<` in CLI output are interpreted as HTML. This causes some lines to become truncated, or displayed in wrong color (such as red instead of white for standard output).