### PR TITLE
ENH: Optimize processing Segment Editor updates during Batch Processing

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentEditorWidget.h
@@ -494,6 +494,9 @@ protected slots:
   /// Clean up when scene is closed
   void onMRMLSceneEndCloseEvent();
 
+  /// Updates needed after batch processing is done
+  void onMRMLSceneEndBatchProcessEvent();
+
   /// Set default parameters in parameter set node (after setting or closing scene)
   void initializeParameterSetNode();
 


### PR DESCRIPTION
Originally discussed in https://discourse.slicer.org/t/optimizing-performance-of-events-when-clearing-nodes/23588/5. A `masterVolumeNodeChanged` call in SegmentEditor was 25% of the time when clearing a set of volume nodes from the scene in some custom code that I have.

For example when removing volume nodes, this can trigger a change of the current Master Volume node specification in the Segment Editor module if the current volume node is removed from the scene. When this happens over and over during batch processing there was frequent updating of the master volume node for SegmentEditor logic which can be an expensive operation, especially the masterVolumeNodeChanged call for SegmentEditorThresholdEffect.