### PR TITLE
Allow multiple qSlicerWebWidget instance by injecting scripts into page

### DIFF
--- a/Base/QTGUI/qSlicerWebWidget.cxx
+++ b/Base/QTGUI/qSlicerWebWidget.cxx
@@ -114,12 +114,13 @@ void qSlicerWebWidgetPrivate::init()
 
   this->PythonProxy = new qSlicerWebPythonProxy(q);
   QWebEngineProfile* profile = QWebEngineProfile::defaultProfile();
-  this->initializeWebEngineProfile(profile);
 
   this->WebEnginePage = new qSlicerWebEnginePage(profile, this->WebView);
   this->WebEnginePage->JavaScriptConsoleMessageLoggingEnabled = developerModeEnabled;
   this->WebEnginePage->WebWidget = q;
   this->WebView->setPage(this->WebEnginePage);
+
+  this->initializeWebEngineProfile(profile);
 
   this->WebChannel = new QWebChannel(this->WebView->page());
   this->initializeWebChannel(this->WebChannel);
@@ -196,7 +197,7 @@ void qSlicerWebWidgetPrivate::initializeWebEngineProfile(QWebEngineProfile* prof
     return;
     }
 
-  if (!profile->scripts()->findScript("qwebchannel_appended.js").isNull())
+  if (!this->WebEnginePage->scripts().findScript("qwebchannel_appended.js").isNull())
     {
     // profile is already initialized
     return;
@@ -218,7 +219,7 @@ void qSlicerWebWidgetPrivate::initializeWebEngineProfile(QWebEngineProfile* prof
     script.setWorldId(QWebEngineScript::MainWorld);
     script.setInjectionPoint(QWebEngineScript::DocumentCreation);
     script.setRunsOnSubFrames(false);
-    profile->scripts()->insert(script);
+    this->WebEnginePage->scripts().insert(script);
     }
 
   // setup default download handler shared across all widgets


### PR DESCRIPTION
Since the script injection associated with `qSlicerWebWidget` was done globally
and only once at the profile level, instantiating first `qSlicerWebWidget`
and then `qSlicerExtensionsInstallWidget` was preventing the customization
done in `qSlicerExtensionsInstallWidget::initializeWebChannelTransport()`
from being effective.

This commit addresses this by injecting the `qwebchannel_appended.js` script
on per page basis. Doing so ensures each `qSlicerWebWidget` (and derived
object like `qSlicerExtensionsInstallWidget`) will inject the expected script.

It follows up on da201359b (ENH: WIP - WebEngine support for
extension manager).