### PR TITLE
BUG: Ensure download request are handled by web widget triggering the request

### DIFF
--- a/Base/QTGUI/qSlicerWebWidget.cxx
+++ b/Base/QTGUI/qSlicerWebWidget.cxx
@@ -240,6 +240,14 @@ void qSlicerWebWidgetPrivate::handleDownload(QWebEngineDownloadItem* download)
 {
   Q_Q(qSlicerWebWidget);
 
+  if (this->WebEnginePage != download->page())
+    {
+    // Since the download request is emitted by the default profile observed by
+    // all web widget instances, we ignore the request if it does not originate
+    // from the page associated with this web widget instance.
+    return;
+    }
+
   qSlicerWebDownloadWidget *downloader = new qSlicerWebDownloadWidget(q);
   downloader->setAttribute(Qt::WA_DeleteOnClose);
   downloader->show();


### PR DESCRIPTION
This commit fixes a regression introduced in 9c0ae2ad8 (BUG: Allow multiple
`qSlicerWebWidget` instance injecting scripts into page) where the observation
of the profile `downloadRequested()` signal was done multiple time.

Since the download request is emitted by the default profile observed by
all web widget instances, this change ignores the request if it does not
originate from the page associated with this web widget instance.