### PR TITLE
ENH: Remove SlicerPython launcher

### DIFF
--- a/CMake/SlicerBlockInstallPython.cmake
+++ b/CMake/SlicerBlockInstallPython.cmake
@@ -134,9 +134,6 @@ To create a Slicer package including python libraries, you can *NOT* provide you
 
   _install_python_launcher(PythonSlicer)
 
-  # SlicerPython executable is deprecated, see details in External_python.cmake
-  _install_python_launcher(SlicerPython)
-
   # Install headers
   set(python_include_subdir /Include/)
   if(UNIX)

--- a/SuperBuild/python_configure_python_launcher.cmake
+++ b/SuperBuild/python_configure_python_launcher.cmake
@@ -269,16 +269,3 @@ ctkAppLauncherConfigureForExecutable(
   APPLICATION_NAME PythonSlicer
   ${_python_launcher_config_params}
   )
-
-# SlicerPython executable name is deprecated and will be removed in the future
-# (name is not compatible with some development environments - see the comment above).
-file(WRITE "${python_bin_dir}/SlicerPython-is-obsolete.py" [==[
-exit("""SlicerPython executable is obsolete and will be removed. Use PythonSlicer executable instead.
-For more details, see https://github.com/Slicer/Slicer/issues/4843
-""")
-]==])
-ctkAppLauncherConfigureForExecutable(
-  APPLICATION_NAME SlicerPython
-  APPLICATION_DEFAULT_ARGUMENTS "${python_bin_dir}/SlicerPython-is-obsolete.py"
-  ${_python_launcher_config_params}
-  )


### PR DESCRIPTION
This closes #4849, a Slicer 5.1 milestone issue.

In July 2018, PythonSlicer replaced SlicerPython as the primary python executable in https://github.com/Slicer/Slicer/commit/f63a450ba3d4390e422ab9b8902e5d6784d70603 with SlicerPython kept for backwards compatibility.

In April 2020, SlicerPython was marked as obsolete in https://github.com/Slicer/Slicer/commit/d9c5ba6cf5641cdac7289d37b7238d2c1fd741d4 and scheduled for removal.

This commits executes on the removal of SlicerPython.