### PR TITLE
ENH: Enable new custom mouse gestures for moving crosshair

### DIFF
--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -1007,6 +1007,40 @@ cameraWidget.SetEventTranslationClickAndDrag(cameraWidget.WidgetStateIdle, vtk.v
   cameraWidget.WidgetStateRotate, cameraWidget.WidgetEventRotateStart, cameraWidget.WidgetEventRotateEnd)
 ```
 
+#### Custom shortcut for moving crosshair in a slice view
+
+```python
+# Red slice view
+sliceViewLabel = "Red"
+sliceViewWidget = slicer.app.layoutManager().sliceWidget(sliceViewLabel)
+displayableManager = sliceViewWidget.sliceView().displayableManagerByClassName("vtkMRMLCrosshairDisplayableManager")
+widget = displayableManager.GetSliceIntersectionWidget()
+
+# Set crosshair position by left-click
+widget.SetEventTranslation(widget.WidgetStateIdle, slicer.vtkMRMLInteractionEventData.LeftButtonClickEvent, vtk.vtkEvent.NoModifier, widget.WidgetEventSetCrosshairPosition)
+widget.SetEventTranslation(widget.WidgetStateIdle, slicer.vtkMRMLInteractionEventData.LeftButtonClickEvent, vtk.vtkEvent.NoModifier, widget.WidgetEventSetCrosshairPosition)
+
+# Move crosshair by Alt+left-click-and-drag
+widget.SetEventTranslationClickAndDrag(widget.WidgetStateIdle, vtk.vtkCommand.LeftButtonPressEvent, vtk.vtkEvent.AltModifier,
+  widget.WidgetStateMoveCrosshair, widget.WidgetEventMoveCrosshairStart, widget.WidgetEventMoveCrosshairEnd)
+```
+
+#### Custom shortcut for moving crosshair in a 3D view
+
+```python
+# 3D view
+threeDViewWidget = slicer.app.layoutManager().threeDWidget(0)
+cameraDisplayableManager = threeDViewWidget.threeDView().displayableManagerByClassName("vtkMRMLCameraDisplayableManager")
+widget = cameraDisplayableManager.GetCameraWidget()
+
+# Set crosshair position by left-click
+widget.SetEventTranslation(widget.WidgetStateIdle, slicer.vtkMRMLInteractionEventData.LeftButtonClickEvent, vtk.vtkEvent.NoModifier, widget.WidgetEventSetCrosshairPosition)
+
+# Move crosshair by Alt+left-click-and-drag
+widget.SetEventTranslationClickAndDrag(widget.WidgetStateIdle, vtk.vtkCommand.LeftButtonPressEvent, vtk.vtkEvent.AltModifier,
+  widget.WidgetStateMoveCrosshair, widget.WidgetEventMoveCrosshairStart, widget.WidgetEventMoveCrosshairEnd)
+```
+
 #### Add shortcut to adjust window/level in any mouse mode
 
 Makes Ctrl + Right-click-and-drag gesture adjust window/level in red slice view. This gesture works even when not in "Adjust window/level" mouse mode.

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
@@ -458,6 +458,38 @@ vtkMRMLInteractionNode* vtkMRMLAbstractWidget::GetInteractionNode()
 }
 
 //---------------------------------------------------------------------------
+bool vtkMRMLAbstractWidget::CanProcessButtonClickEvent(vtkMRMLInteractionEventData* eventData, double& distance2)
+{
+  if (eventData->GetMouseMovedSinceButtonDown())
+    {
+    return false;
+    }
+
+  int clickEvent = 0;
+  switch (eventData->GetType())
+    {
+    case vtkCommand::LeftButtonReleaseEvent:
+      clickEvent = vtkMRMLInteractionEventData::LeftButtonClickEvent;
+      break;
+    case vtkCommand::MiddleButtonReleaseEvent:
+      clickEvent = vtkMRMLInteractionEventData::MiddleButtonClickEvent;
+      break;
+    case vtkCommand::RightButtonReleaseEvent:
+      clickEvent = vtkMRMLInteractionEventData::RightButtonClickEvent;
+      break;
+    default:
+      return false;
+    }
+
+  // Temporarily change the event ID to click, and process the event
+  int originalEventType = eventData->GetType();
+  eventData->SetType(clickEvent);
+  bool canProcessEvent = this->CanProcessInteractionEvent(eventData, distance2);
+  eventData->SetType(originalEventType);
+  return canProcessEvent;
+}
+
+//---------------------------------------------------------------------------
 int vtkMRMLAbstractWidget::ProcessButtonClickEvent(vtkMRMLInteractionEventData* eventData)
 {
   if (eventData->GetMouseMovedSinceButtonDown())

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.h
@@ -194,6 +194,9 @@ protected:
   unsigned long TranslateInteractionEventToWidgetEvent(
     vtkWidgetEventTranslator* translator, vtkMRMLInteractionEventData* eventData);
 
+  /// Generate a button click event and checks if it can be processed with CanProcessInteractionEvent.
+  bool CanProcessButtonClickEvent(vtkMRMLInteractionEventData* eventData, double& distance2);
+
   /// Generate a button click event and get it processed with ProcessInteractionEvent.
   /// Returns true if the event was processed.
   virtual int ProcessButtonClickEvent(vtkMRMLInteractionEventData* eventData);

--- a/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLCameraWidget.h
@@ -78,9 +78,9 @@ public:
   /// Widget states
   enum
     {
-    WidgetStateFollowCursor = WidgetStateUser,
+    WidgetStateMoveCrosshair = WidgetStateUser, ///< Move crosshair position, can be used for moving the crosshair with click-and-drag.
     WidgetStateSpin,
-    WidgetStateTouchGesture,
+    WidgetStateTouchGesture
     };
 
   /// Widget events
@@ -88,6 +88,9 @@ public:
     {
     WidgetEventSpinStart = WidgetEventUser,
     WidgetEventSpinEnd,
+
+    WidgetEventMoveCrosshairStart,
+    WidgetEventMoveCrosshairEnd,
 
     WidgetEventCameraRotateToRight,
     WidgetEventCameraRotateToLeft,
@@ -132,6 +135,7 @@ public:
     WidgetEventTouchPanTranslate,
 
     WidgetEventSetCrosshairPosition,
+    WidgetEventSetCrosshairPositionBackground, //< set crosshair position without consuming the event (so that other widgets can process the event)
     WidgetEventMaximizeView,
     };
 
@@ -156,6 +160,7 @@ protected:
   bool ProcessScale(vtkMRMLInteractionEventData* eventData);
   bool ProcessSpin(vtkMRMLInteractionEventData* eventData);
   bool ProcessSetCrosshair(vtkMRMLInteractionEventData* eventData);
+  bool ProcessSetCrosshairBackground(vtkMRMLInteractionEventData* eventData);
 
   bool ProcessTouchGestureStart(vtkMRMLInteractionEventData* eventData);
   bool ProcessTouchGestureEnd(vtkMRMLInteractionEventData* eventData);

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionWidget.h
@@ -81,7 +81,7 @@ public:
   enum
     {
     // Interactions without handles
-    WidgetStateFollowCursor = WidgetStateUser, ///< Set intersecting slices to current cursor position
+    WidgetStateMoveCrosshair = WidgetStateUser, ///< Move crosshair position, can be used for moving the crosshair with click-and-drag.
     WidgetStateBlend, ///< Fade between foreground/background volumes
     WidgetStateTranslateSlice, ///< Pan (translate in-plane) the current slice (using shift+left-click-and-drag or middle-click-and-drag)
     WidgetStateRotateIntersectingSlices, ///< Rotate all intersecting slices (ctrl+alt+left-click-and-drag)
@@ -108,6 +108,8 @@ public:
     WidgetEventTouchRotateSliceIntersection,
     WidgetEventTouchZoomSlice,
     WidgetEventTouchTranslateSlice,
+    WidgetEventMoveCrosshairStart,
+    WidgetEventMoveCrosshairEnd,
     WidgetEventBlendStart,
     WidgetEventBlendEnd,
     WidgetEventToggleLabelOpacity,
@@ -130,6 +132,7 @@ public:
     WidgetEventZoomSliceStart,
     WidgetEventZoomSliceEnd,
     WidgetEventSetCrosshairPosition,
+    WidgetEventSetCrosshairPositionBackground, //< set crosshair position without consuming the event (so that other widgets can process the event)
     WidgetEventMaximizeView,
 
     // Interactions with slice intersection handles
@@ -198,6 +201,7 @@ protected:
   bool ProcessRotateIntersectingSlicesStart(vtkMRMLInteractionEventData* eventData);
   bool ProcessRotateIntersectingSlices(vtkMRMLInteractionEventData* eventData);
   bool ProcessSetCrosshair(vtkMRMLInteractionEventData* eventData);
+  bool ProcessSetCrosshairBackground(vtkMRMLInteractionEventData* eventData);
   double GetSliceRotationAngleRad(double eventPos[2]);
 
   // Pan (move slice in-plane) by click-and-drag

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -670,7 +670,8 @@ bool vtkSlicerMarkupsWidget::CanProcessInteractionEvent(vtkMRMLInteractionEventD
   unsigned long widgetEvent = this->TranslateInteractionEventToWidgetEvent(eventData);
   if (widgetEvent == WidgetEventNone)
     {
-    return false;
+    // If this event is not recognized then give a chance to process it as a click event.
+    return this->CanProcessButtonClickEvent(eventData, distance2);
     }
   vtkSlicerMarkupsWidgetRepresentation* rep = this->GetMarkupsRepresentation();
   if (!rep)


### PR DESCRIPTION
Custom event translation can now be specified to make click or click-and-drag set the crosshair position.