### PR TITLE
COMP: Fix inner project config removing invalid CMake statement

### DIFF
--- a/CMake/SlicerBlockInstallExternalPythonModules.cmake
+++ b/CMake/SlicerBlockInstallExternalPythonModules.cmake
@@ -13,8 +13,6 @@ install(FILES ${VTK_PYTHON_MODULE}/vtk.py
   DESTINATION ${Slicer_INSTALL_BIN_DIR}/Python
   COMPONENT Runtime)
 
-endif()
-
 # Install CTK python modules
 install(DIRECTORY ${CTK_DIR}/CTK-build/bin/Python/ctk ${CTK_DIR}/CTK-build/bin/Python/qt
   DESTINATION ${Slicer_INSTALL_BIN_DIR}/Python


### PR DESCRIPTION
This commit updates "SlicerBlockInstallExternalPythonModules"
CMake module fixing the following regression introduced
in b9ac6ed61 (COMP: Remove support for VTK8)

```
  CMake Error at CMake/SlicerBlockInstallExternalPythonModules.cmake:16 (endif):
    Flow control statements are not properly nested.
  Call Stack (most recent call first):
    CMake/SlicerCPack.cmake:172 (include)
    CMake/LastConfigureStep/CMakeLists.txt:44 (include)
```