### PR TITLE
COMP: Update qRestAPI to fix windows link error

### DIFF
--- a/SuperBuild/External_qRestAPI.cmake
+++ b/SuperBuild/External_qRestAPI.cmake
@@ -33,7 +33,7 @@ if(NOT DEFINED qRestAPI_DIR)
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "98c858cc658b5b8e648bbf8861d74077ef132ded"
+    "ea5e85a1ecfb05174ab604d66fa3186ae9a45eda"
     QUIET
     )
 


### PR DESCRIPTION
This commit fixes the following link error introduced
by 69f8d8505 (STYLE: Simplify ExtensionsManagerModelTest removing duplicated function)

Link error:

```
    error LNK2019: unresolved external symbol "__declspec(dllimport) public:
    static class QMap<class QString,class QVariant> __cdecl
    qRestAPI::qVariantMapFlattened(class QMap<class QString,class QVariant> const &)" (...)
    referenced in function "private: static class QMap<class QString,class QVariant>
    __cdecl qSlicerExtensionsManagerModelTester::extensionMetadata(class QString const &,int,bool,bool)" (...)
```

List of changes:

```
$ git shortlog 98c858c..ea5e85a --no-merges
Jean-Christophe Fillion-Robin (5):
      cmake: Update minimum required version to 3.5.0
      cmake: Re-organize code
      cmake: Simplify code by automatically including current directories
      Update README and add CONTRIBUTING guidelines
      COMP: Fix export header to support linking of static qRestAPI
```