### PR TITLE
ENH: Added doc to build Slicer for CentOS 7

### DIFF
--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -85,6 +85,27 @@ Install the development tools and the support libraries:
 sudo pacman -S git make patch subversion gcc cmake \
   qt5-base qt5-multimedia qt5-tools qt5-xmlpatterns qt5-svg qt5-webengine qt5-script qt5-x11extras libxt
 ```
+
+### CentOS 7
+:::{note}
+
+Slicer built on CentOS 7 will be available for many Linux distributions and releases
+
+:::
+
+Install Qt and CMake as described in [Any Distribution](./linux.md#any-distribution) section.
+
+CentOS 7 comes with pretty old devtoolset (gcc 4.8.5). Install and activate newer toolset (11 in this case):
+```console
+sudo yum install centos-release-scl
+sudo yum install devtoolset-11-gcc*
+scl enable devtoolset-11 bash         # activatation is needed for every terminal session
+```
+Install pre-requisites:
+```console
+sudo yum install patch mesa-libGL-devel libuuid-devel
+```
+
 ### Any Distribution
 
 This section describes how to install Qt as distributed by *The QT Company*, which can be used for any GNU/Linux distribution.

--- a/Docs/user_guide/getting_started.md
+++ b/Docs/user_guide/getting_started.md
@@ -92,6 +92,23 @@ The following may be needed on fresh debian or ubuntu:
     sudo apt-get install libpulse-dev libnss3 libglu1-mesa
     sudo apt-get install --reinstall libxcb-xinerama0
 
+:::{note} Warning
+:class: warning
+
+Debian 10.12 users may encounter an error when launching Slicer: 
+
+    Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
+    qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
+    This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
+
+    Available platform plugins are: xcb.
+
+[The solution](https://forum.qt.io/topic/93247/qt-qpa-plugin-could-not-load-the-qt-platform-plugin-xcb-in-even-though-it-was-found/81) is to create symlink:
+
+    sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
+
+:::
+
 #### ArchLinux
 ArchLinux runs the `strip` utility by default; this needs to be disabled in order to run Slicer binaries.  For more information see [this thread on the Slicer Forum](https://discourse.slicer.org/t/could-not-load-dicom-data/14211/5).
 


### PR DESCRIPTION
Slicer built on CentOS 7 will be available for many Linux distros.
Also on Debian 10.12 some trick is needed to solve `xinerama` issue.
See [discussion](https://discourse.slicer.org/t/build-and-package-slicercat-on-manylinux/23443/3).