### PR TITLE
ENH: Improve robustness of condition check if testing is enabled

### DIFF
--- a/Base/QTApp/qSlicerApplicationHelper.txx
+++ b/Base/QTApp/qSlicerApplicationHelper.txx
@@ -179,7 +179,7 @@ int qSlicerApplicationHelper::postInitializeApplication(
     }
 
   // Exit if testing module is enabled and not all modules are instantiated
-  if (!failedToBeInstantiatedModuleNames.isEmpty() && app.commandOptions()->isTestingEnabled())
+  if (!failedToBeInstantiatedModuleNames.isEmpty() && app.testAttribute(qSlicerCoreApplication::AA_EnableTesting))
     {
     return EXIT_FAILURE;
     }

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -1928,7 +1928,7 @@ void qSlicerCoreApplication::onAboutToQuit()
 
 #ifdef Slicer_USE_PYTHONQT
   // Override return code only if testing mode is enabled
-  if (this->corePythonManager()->pythonErrorOccured() && this->coreCommandOptions()->isTestingEnabled())
+  if (this->corePythonManager()->pythonErrorOccured() && this->testAttribute(AA_EnableTesting))
     {
     d->ReturnCode = qSlicerCoreApplication::ExitFailure;
     }

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -215,7 +215,6 @@ public:
   /// cleanup happens only if testing mode is enabled.
   ///
   /// \sa QApplication::exec(), returnCode()
-  /// \sa qSlicerCoreCommandOptions::isTestingEnabled()
   static int exec();
 
   /// Get MRML Scene

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -449,7 +449,7 @@ bool qSlicerApplication::notify(QObject *receiver, QEvent *event)
     errorMessage += tr("The message detail is:\n\n");
     errorMessage += tr("Exception thrown in event: ") + exception.what();
     qCritical() << errorMessage;
-    if (this->commandOptions()->isTestingEnabled())
+    if (this->testAttribute(AA_EnableTesting))
       {
       this->exit(EXIT_FAILURE);
       }
@@ -468,7 +468,7 @@ bool qSlicerApplication::notify(QObject *receiver, QEvent *event)
     errorMessage += tr("The message detail is:\n\n");
     errorMessage += tr("Exception thrown in event: ") + exception.what();
     qCritical() << errorMessage;
-    if (this->commandOptions()->isTestingEnabled())
+    if (this->testAttribute(AA_EnableTesting))
       {
       this->exit(EXIT_FAILURE);
       }


### PR DESCRIPTION
This commit ensures that the code path expected to be executed when testing
is enabled is done so when the AA_EnableTesting attribute is set and not
only when the command line parameter "--testing-enabled" is passed.

This allows to programmatically enable testing in test without having to
explicitly pass the argument.