### PR TITLE
COMP: Update ITK to post-v5.3rc04 version and SimpleITK to post-v2.2.0 

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -30,13 +30,13 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/Slicer/ITK"
+    "${EP_GIT_PROTOCOL}://github.com/InsightSoftwareConsortium/ITK"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "46a71c744d4856a5166df227e13c76e8c3ef55cc" # slicer-v5.3rc03-2022-02-10-be81e62
+    "05adf2d1f617c2c4b206cb119f72cbb0904158e4" # post-v5.3rc04 2022-08-30
     QUIET
     )
 

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -123,7 +123,7 @@ set(ENV{LibraryPaths} \"${_paths}${_path_sep}\$ENV{${_varname}}\")
   file(WRITE ${_install_script}
 "include(\"${_env_script}\")
 set(${proj}_WORKING_DIR \"${EP_BINARY_DIR}/SimpleITK-build/Wrapping/Python\")
-ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py install)
+ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" \"-m\" \"pip\" \"install\" \".\")
 ")
 
   ExternalProject_SetIfNotDefined(
@@ -134,7 +134,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" setup.py in
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ffd48e274e2112928e95e5dfc802d8ca3121c840"
+    "1c0cf5de03fd8b8279a6522e910bbce67a4d8bf8"  # post-v2.2.0 2022-08-30
     QUIET
     )
 


### PR DESCRIPTION
It has been almost 5 months since the base version of ITK that Slicer uses has been updated. This PR updates to use a recent ITK version to help test prior to ITK officially tagging version 5.3.0 (cc: @dzenanz). 

The Slicer fork of ITK has maintained one custom commit in https://github.com/Slicer/ITK/commit/027fd5ce0c7044c33eb56bf7530466488109390b to fix an issue on the Linux platform. @dzenanz can you take a look to see if this commit is valid as an upstream fix or if a different handling of the issue is better than the revert made in the Slicer commit? 

The most recent SimpleITK release candidate is also being used here for compatibility with latest ITK (cc: @blowekamp).

From my testing on the Windows platform, there were no build errors or testing errors introduced with this update to latest ITK and SimpleITK.

```
ITK list of changes:
$ git shortlog --no-merges 46a71c7..05adf2d
Alex (1):
      BUG: GitHub Workflows security hardening

Brad King (2):
      ENH: Update double-conversion import script to record prior import
      ENH: Update double-conversion import script to get latest version

Bradley Lowekamp (12):
      BUG: Fix numeric overflow in SLIC initialization
      BUG: Add DOXYGEN_(FORMAT) options to DoxygenConfig.cmake
      BUG: Fix Doxygen configuration for output formats
      BUG: Remove doxygen syntax markup for cmake lists
      ENH: Add option to disable the server side searching
      ENH: Adding GTest for LabelOverlapMeasuresImageFilter
      BUG: Use named inputs for LabelOverlapMeasuresImageFilter
      ENH: Update LabelOverlapMeasures to use dynamic threading
      ENH: Use ImageSink for LabelOverlapMeasures base class
      BUG: Update LabelOverlapMeasures internal class
      PERF: improve map usage and increment prefix
      BUG: initialize image buffer in Nifti direction test

Bryn Lloyd (1):
      BUG: ReconstructBiasField is setting bias field regions incorrectly

Butui Hu (1):
      COMP: use sysconfig.get_path as PEP 632 deprecate distutils module

Dženan Zukić (25):
      ENH: Refactor SpatialOrientation enumeration classes
      ENH: Add a Python test which demonstrates use of spatial orientation
      DOC: VLV CanBeDivided struct divides, not multiplies
      COMP: Update use of SpatialOrientation in non-default module PhilipsREC
      ENH: Follow-up to SpatialOrientationEnums refactoring
      ENH: Update remote modules by using the script
      ENH: Updating remote modules using the script
      ENH: Update Remote modules using the script
      ENH: Git hooks were updated
      ENH: Add Python wrapping for SpatialOrientationAdapter
      ENH: Make OrientationAdapterBase deprecated
      ENH: Mark CMake variables as advanced
      ENH: Update UpdateRemoteModules.sh to use authenticated Git protocol
      ENH: UpdateRemoteModules.sh now handles both master and main branches
      ENH: Updating remote modules to latest versions using the script
      ENH: Mark more zlib-ng options as advanced CMake variables
      COMP: Fix GPUCommon compile errors
      ENH: Simplify Nifti IO test 13 using ReadImage and testing macros
      ENH: Add more symbols to HDF5 name mangling
      COMP: Previous commit was pushed erroneously
      ENH: Refactor UpdateDoubleConversionFromGoogle.sh
      ENH: Enable building HL library for the bundled HDF5
      COMP: Set CMake Policy 135 to NEW to suppress warnings in CMake 3.24
      ENH: Update remote modules using the script
      COMP: WindowedSincInterpolate OffsetTable return type [VS2017 fix]

GDCM Upstream (1):
      GDCM 2022-02-24 (ae0591f2)

Gabriel A. Devenyi (1):
      BUG: Fix isAffine insuffcient precision in caluclations

Google double-conversion Maintainers (3):
      DoubleConversion 2017-03-06 (4abe3267)
      DoubleConversion 2020-12-17 (0d3733a4)
      DoubleConversion 2022-07-07 (af09fd65)

Hans J. Johnson (19):
      COMP: Remove single use variable alias
      COMP: Inline single use macros and unset local variables
      COMP: Simplify submodule loading logic
      COMP: Inline single use macros
      COMP: Inline code for add_subdirectory that acted like a macro
      STYLE: Give error message when deprecated filename is encountered
      STYLE: Make local variable names consistent
      COMP: Simply prefix based on internal/external
      STYLE: Remove variable that is always set to OFF
      STYLE: Prefer list mutation commands in cmake
      STYLE: Simplify the candidate generators list
      ENH: Force test failure on bad file writing
      ENH: Isolate img that is being corrupted.
      BUG: Provide itk::Exception for invalid NIFTI write
      DOC: Fix Exception message suggestion
      STYLE: Place large block of common code in single file
      ENH: Run script for Python3 find_package upgrade
      ENH: Huge file needed for zlib library
      DOC: Remove outdated migration information

Hans Johnson (53):
      COMP: Missing semi-colon after macro
      COMP: C++20 ambiguous overloaded operator
      ENH: Remove alias cmake macro
      COMP: Simplify single use macros for wrapping
      ENH: Remove support for wrapping with TCL
      ENH: Remove support for wrapping with PERL
      ENH: Remove support for wrapping with JAVA
      ENH: Remove support for wrapping with RUBY
      ENH: Remove empty macro call function
      COMP: Increased allowed size of doxygen.config.in
      ENH: Update doxygen.config.in with new options
      COMP: Remove deprecated WRAPPER_LIBRARY_GROUPS
      ENH: Remove support for wrapping with WRAP_EXPLICIT
      STYLE: Use vtk .clang-format for code style
      STYLE: Convert CMake-language commands to lower case
      STYLE: Remove CMake-language block-end command arguments
      STYLE: Remove SVN revision number tracking in code
      STYLE: Manually syncronize trivial fixes from VTK to ITK
      COMP: Use same cmake_minimum_required values as ITK.
      DOC: Document that ITK_WRAPPING is equivalent to ITK_WRAP_PYTHON
      STYLE: Prefer constexpr for zeroVector
      BUG: Fix generated file name pattern
      COMP: Use modern doxygen_add_docs command ITK_WRAP_DOCS
      STYLE: Remove debugging script and support code
      COMP: Use modern doxygen_add_docs for BUILD_DOCUMENTAITON
      ENH: Make conditional compilations
      STYLE: Simplify wrapping macro variable scope
      ENH: Use function scoping for wrapping
      BUG: XMLFileOutputWindowTest failed subsequent runs
      STYLE: Remove unnecessary files from tree
      DOC: Provide a comment for required file
      BUG: RecursiveGaussianImageFilterEnums double wrapped
      ENH: Rewrite python generation files with comments
      BUG: Add dependancy for bulding castxml before using it.
      BUG: DTITubeSpatialObjectTest was not run
      ENH: Improve diagnostic reporting for tests
      BUG: Fix unstable mathematical computations
      COMP: Allow changing CMAKE_INSTALL_LIBDIR
      COMP: Allow install lib directory name changes
      BUG: Avoid dangerous use of putenv
      ENH: Convert unspecified exceptions to itk
      STYLE: Fix test debugging statement format.
      ENH: Consolidate resetting IO object for reuse
      BUG: A temporary work-around for HDF5 testing
      COMP: Missing "\ingroup ITKMesh" doxygen setting
      COMP: Suppress uninitialed variable warning
      ENH: Add script for Python3 find_package upgrade
      BUG: _Python3_EXECUTABLE -> _specified_Python3_EXECUTABLE
      STYLE: Make Python3_ROOT_DIR user-visible
      COMP: ITK_WRAP_PYTHON_VERSION is used for remote modules
      ENH: Specify minimum allowed python version
      ENH: Provide install of itk-stub pyi files
      ENH: Add typehints to python wheel packages

Jean-Christophe Fillion-Robin (4):
      COMP: Fix build against ITK install adding "expat_external.h" install rule
      COMP: Update ITKModuleExternal CMake message to avoid CTest false positive
      COMP: Fix older gcc build error including "cstddef" for "ptrdiff_t"
      COMP: Mangle hdf5 static symbols

Joey Cho (1):
      ENH: Improve LabelOverlapMeasuresImageFilter

Jon Haitz Legarreta Gorroño (94):
      ENH: Test streaming `itk::SpatialOrientation` enum class types
      ENH: Increase `itk::SumOfSquaresImageFunction` class coverage
      STYLE: Prefer using `EXPECT_EQ` in GTest value check
      ENH: Check GTest test method return value
      ENH: Add `itk::LaplacianSharpeningImageFilter` unit test
      ENH: Improve `itk::ScalarImageKmeansImageFilter` testing
      ENH: Add `itk::PointSetToImageFilter` unit tests
      BUG: Set image origin according to point set bounding box
      COMP: Fix missing initialization braces warning
      ENH: Remove unnecessary/unused include statements
      STYLE: Use the `itkNameOfTestExecutableMacro` macro in tests
      STYLE: Prefer using `ITK_TRY_EXPECT_NO_EXCEPTION` macro in tests
      STYLE: Improve style in tests
      ENH: Increase coverage for miscellaneous classes
      BUG: Set mesh to join facet function in split facet function test
      BUG: Fix Superclass name in RTTI macro
      ENH: Increase coverage for miscellaneous classes
      BUG: Fix gradient direction vector index
      BUG: Fix Superclass name in RTTI macro
      STYLE: Prefer using `ITK_TRY_EXPECT_NO_EXCEPTION` macro in tests
      STYLE: Rename `itkImageToHistogramFilterTest3` to honor tested class
      BUG: Set number of targets for FMUG image filter
      STYLE: Improve style in FMUG filter test file
      DOC: Document methods in header file
      STYLE: Remove unnecessary empty comment blocks
      ENH: Remove duplicate, commented `ITK_MANUAL_INSTANTIATION` guard
      DOC: Fix typos and grammar in class and method documentation
      DOC: Increase `itk::MRASlabIdentifier` description Doxygen syntax use
      DOC: Fix typo in warning macro message
      DOC: Fix typos in miscellaneous comments
      DOC: Fix typo in variable names in test input argument usage
      STYLE: Allow a whitespace after variable in warning macro message
      COMP: Add missing semicolon to `itkExceptionMacro` statement end
      ENH: Increase `itk::MaskFeaturePointSelectionFilter` class coverage
      ENH: Remove unreachable condition in FMUG all target reached mode
      ENH: Refactor FMUG filter target reached mode verification
      STYLE: Add a missing parameter message in test
      STYLE: Improve the `itkFastMarchingBaseTest.cxx` style
      ENH: Increase `itk::FastMarchingBase` class coverage
      ENH: Increase `itk::XMLFileOutputWindow` class coverage
      DOC: Add `Writers` group to Doxygen documentation
      DOC: Prefer using ITK class names for syntax highlighting in Doxygen
      DOC: Fix typos and improve Doxygen related pages documentation
      BUG: Fix class name in RTTI
      ENH: Increase coverage for miscellaneous classes
      COMP: Remove duplicate include file
      STYLE: Use standard library exit codes in tests
      STYLE: Check test input arguments at the beginning
      STYLE: Remove uninformative/unnecessary print messages in tests
      STYLE: Prefer using `ITK_TRY_EXPECT_NO_EXCEPTION` macro in tests
      STYLE: Use the `itkNameOfTestExecutableMacro` macro in tests
      STYLE: Prefer removing unused input arguments in tests
      STYLE: Conform to ITK style in constant and variable naming in tests
      STYLE: Improve variable value testing information
      BUG: Fix variable type
      BUG: Fix `itkXMLFileOutputWindowTest` regression
      DOC: Fix typo in method documentation
      ENH: Fix typo in direction value exception macro message
      ENH: Prefer using the `itkTypeMacroNoParent` macro for RTTI
      STYLE: Use the superclass name in `itkTypeMacro`
      BUG: Fix Superclass type alias and name in RTTI macro
      BUG: Fix Superclass name in RTTI macro
      ENH: Add `itkBooleanMacro` to `IFrameSafe` boolean ivar
      ENH: Add getter macro for boolean ivar
      ENH: Increase coverage for miscellaneous classes
      BUG: Provide appropriate enum value to `itkCellVisitMacro`
      DOC: Improve Doxygen modules documentation
      ENH: Prefer using existing file for unsupported format test
      STYLE: Remove unnecessary `nullptr` assignment to smart pointer
      STYLE: Make style consistent with the ITK style
      STYLE: Use the `itkNameOfTestExecutableMacro` macro in tests
      DOC: Fix typos in documentation, comments and exception messages
      STYLE: Improve wording in `itk::GiftiMeshIO` exception messages
      ENH: Add boolean macros to `itk::MeshIOBase` data update ivars
      BUG: Avoid querying about null variable size
      BUG: Fix test driver name for `MeshOBJ` and `MeshOFF`
      ENH: Increase coverage for `MeshIO` classes
      ENH: Call superclass `PrintSelf` method in child `PrintSelf`
      BUG: Fix `itkRegionalMinimaImageFilterTest` calls in test driver
      STYLE: Increase test style consistency
      BUG: Match iterations array size value to number of levels
      ENH: Increase coverage for miscellaneous classes
      ENH: Increase coverage for `itk::GDCMSeriesFileNames`
      BUG: Fix test method call argument order
      ENH: Switch Azure Pipelines macOS environment version
      ENH: Switch Azure Pipelines Linux environment version
      DOC: Remove wrong class names from test documentation
      STYLE: Improve the ivar printing in `PrintSelf` method
      STYLE: Prefer using `ITK_TRY_EXPECT_NO_EXCEPTION` macro in tests
      STYLE: Conform to ITK style in variable naming in tests
      STYLE: Conform to ITK style guidelines in test ending message
      ENH: Add `itkBooleanMacro` for boolean ivar
      ENH: Increase coverage for miscellaneous classes
      STYLE: Improve the first interaction message style

Kian Weimer (8):
      STYLE: refactored itk_end_wrap_submodule_python macro
      STYLE: consistent use of lib in wrapping macros.
      STYLE: Unset local vars and added comments
      STYLE: Inlined macro that was called once.
      STYLE: Removed empty macros
      STYLE: Inlined single call macro.
      STYLE: Inlined single call macro
      BUG: Prevent append from duplicating arrays contents.

Lee Newberg (18):
      STYLE: Fix several spelling errors
      STYLE: Ignore git commit that is only STYLE
      STYLE: Change template parameter name prefix N to V
      DOC: Specify ```language in markdown.  Clang-format code examples.
      BUG: FEM module has incorrect public member name
      COMP: Fix "warning: type qualifiers ignored on cast result type"
      ENH: Introduce itk::Boolean for use with std::vector
      STYLE: Invoke pyupgrade --py37-plus on Python files
      STYLE: Remove `std::` prefix from types that work without it
      DOC: Do not end the subject line with a period
      COMP: Add #include "itkNumericTraitsVectorPixel.h"
      STYLE: Avoid old, C-style cast
      STYLE: Drop `int` from `long int` and `short int`
      STYLE: Drop `signed` from `signed short`, `signed int`, `signed long`
      COMP: Fix overly narrow cast
      ENH: Use https instead of http when https works
      ENH: Use https instead of http when https works
      COMP: Add 9cd0f2053f0cf18 to .git-blame-ignore-revs

Mark Asselin (1):
      COMP: Fix Slicer vtkITK build on macOS

Matt McCormick (43):
      DOC: Update Doxygen tarball URLs for new server
      ENH: Load factories in Python at runtime
      ENH: Add MeshToPolyData remote module
      BUG: Provide module name with ITK_WRAP_DOC enabled
      BUG: Replace WRAPPER_MODULE_NAME use in CastXML wrapping configuration
      COMP: Add an option to not build the itkTestDriver executable
      COMP: Do not enable ITK_DYNAMIC_LOADING by default with Emscripten, WASI
      COMP: Do not use ExternalData symlinks with WASI builds
      COMP: Do not set instruction optimizations with WASI-SDK
      BUG: Remove duplicate Size entry in ImportImageFilter PrintSelf
      ENH: Add support for IPFS CID ExternalData content links
      ENH: Add WebAssemblyInterface remote module
      COMP: Do not use ITK_AUTOLOAD_PATH when ITK_WRAP_PYTHON is set
      DOC: Use full URL logo in README
      ENH: Add Cleaver remote module
      ENH: Transfer object name in xarray.DataArray conversion
      ENH: Refactor xarray support into separate module
      STYLE: Apply black to base.py, helpers.py
      BUG: Correct xarray_from_image image_dims type
      COMP: Build errors when only ITK_WRAP_covariant_vector_double is enabled
      BUG: Doxygen tarball links must be https
      BUG: Ignore third party *.h.in files for style checks
      BUG: Skip whitespace checks for ZLIB ghostflow
      DOC: Website Doxygen download is a tar.gz instead of a zip
      BUG: Prevent Image corruption in Dask serialization
      BUG: Add missing name to image_to_dict
      BUG: Remove extra dimension member from Mesh, PointSet dict's
      ENH: Add IOMeshSWC remote module.
      BUG: Do not use assert in Python wrapping builds
      BUG: Remove wrapping configuration loading debug statement
      DOC: Update Linux aarch Python wheel base image for manylinux_2_28
      ENH: ITK 5.3rc04 content links
      BUG: Use absolute module path PyCapsule_Import
      COMP: PointsLocator wrapping on Windows
      BUG: PointLocator wrapping should not wrap superclasses
      ENH: ST, IT, OT for SizeValueType, IdentifierType, OffsetType
      BUG: itkPointsLocatorTest.py supports Windows, multiple PointsLocator types
      COMP: Add -fno-sized-deallocation for GCC 12
      DOC: Add First Interaction GitHub Action
      BUG: Add GitHub Action permissions for the labeller
      BUG: Add permissions to apply clang format action
      COMP: ARM Eigen copying an object of non-trivial type
      DOC: Update Sphinx example URL in README

MetaIO Maintainers (1):
      MetaIO 2022-03-10 (0b8c5284)

Mihail Isakov (3):
      DOC: typo in itkMath comment
      BUG: fixed memory leak in Nifti IO
      BUG: fixed memory leaks in MINC IO

NIFTI Upstream (3):
      nifti 2022-07-27 (3aa22540)
      nifti 2022-08-02 (11eb262d)
      nifti 2022-08-03 (3146cac8)

Natalie Johnston (1):
      ENH: PointSet metric and registration method supports perspective proj.

Niels Dekker (82):
      ENH: Add itk::BooleanStdVectorType as alternative to `std::vector<bool>`
      STYLE: Use type alias `BooleanStdVectorType` for `std::vector<uint8_t>`
      STYLE: Remove unused `EnabledArrayType = std::vector<bool>` from test
      STYLE: Replace `std::vector<bool>` with `std::unique_ptr<bool[]>`
      STYLE: Apply C++ "Rule of Zero" to `itk::FixedArray` and derived classes
      STYLE: Rename `ColorTable` template parameter `TPixel` to `TComponent`
      BUG: Fix `ColorTableTestSpecialConditionChecker` component/pixel mix-up
      BUG: Quick-fix ContourSpatialObject::Update(), LINEAR_INTERPOLATION case
      STYLE: Avoid `T var = elementValue` syntax to initialize a filled array
      BUG: Fix `SetCenterInObjectSpace` calls in Registration test
      STYLE: Fix SetIn/OutsideValue calls ConnectedComponentImageFilterTestRGB
      BUG: Fix `TransformToDisplacementFieldFilter` displacementPoint/Vector
      STYLE: Clarify estimation ray position `RayCastInterpolateImageFunction`
      STYLE: Use direct-initialization for component-to-RGBPixel conversion
      ENH: Declare converting `Point(v)` constructors `explicit`
      STYLE: Remove function-style casts to iterator from Index, Offset, Size
      ENH: Add `cbegin()` and `cend()` member functions to Index, Offset, Size
      ENH: Declare begin(), end() of FixedArray, Index, Offset, Size constexpr
      ENH: Test constexpr begin(), end() of FixedArray, Index, Offset, Size
      ENH: Declare RGBPixel, RGBAPixel constructors from component `explicit`
      STYLE: Replace type aliases with `using`-declarations, in itkIntTypes.h
      ENH: Add `itk::MakeFilled<TContainer>(value)`, requested by issue # 3230
      STYLE: Use MakeFilled in Filled member functions FixedArray, Index, Size
      BUG: Remove implicit conversions from a single value to `itk::Vector`
      ENH: Make Vector constructor from scalar explicit, unless LEGACY enabled
      DOC: Mention changes scalar-to-container conversion in migration guide
      COMP: Add #include "itkNumericTraitsVectorPixel.h", for `MeanVectorType`
      STYLE: Use MakeFilled, () or {}, instead of `Vector(const ValueType &)`
      COMP: Fix ImageBufferRange GTest clang `tautological-compare` warnings
      STYLE: Use MakeFilled, () or {}, instead of `Point(const ValueType &)`
      STYLE: Use MakeFilled instead of component-to-RGB/RGBAPixel constructors
      STYLE: Use MakeFilled in any fixed array `NumericTraits` specialization
      ENH: Add `NumberToString<>` specialization, deducing its parameter type
      ENH: Add explicit `Matrix(const T (&)[VRows][VColumns])` constructor
      ENH: Support C-style arrays as MetaDataObjectType for MetaDataDictionary
      ENH: Add `itk::ConvertNumberToString<TValue>(val)` convenience function
      STYLE: Use ConvertNumberToString instead of local NumberToString objects
      STYLE: Remove CMake checks on old MSVC versions (before version 1910)
      STYLE: Encapsulate NiftiImage qto_xyz mat44 data as `Matrix<float,4,4>`
      STYLE: Remove CMake code for old Apple compilers (GCC < 4.3/Clang < 3.2)
      STYLE: Remove CMake workaround `ITK_REQUIRED_CXX_FLAGS` for GCC 4.8
      STYLE: Remove duplicate MSVC `/bigobj` flags from GPU test projects
      STYLE: Replace unsafe `(T)x` and `T(x)` casts with `T{x}` in Common/src
      STYLE: Remove casts from `MersenneTwisterRandomVariateGenerator::hash`
      ENH: Add `itk::bit_cast<TDestination>(source)` function
      BUG: Replace C-style casts from `_beginthreadex` with `bit_cast<HANDLE>`
      STYLE: Remove unnecessary `using` type aliases from struct definitions
      STYLE: Remove unnecessary `using` type aliases from `enum` definitions
      BUG: Replace `bit_cast<HANDLE>` calls with `reinterpret_cast<HANDLE>`
      STYLE: Catch exceptions by _const_ reference
      STYLE: Use `bit_cast` to convert random seeds from uint32_t to int32_t
      STYLE: Remove unnecessary `(void *)` casts from `ByteSwapper`
      STYLE: Use the `Self` type alias within `ByteSwapper<T>`
      STYLE: Reduce code redundancy from `ByteSwapper` member functions
      STYLE: Use `unique_ptr` in "SwapWrite" member functions of `ByteSwapper`
      STYLE: Add const to first parameter of ByteSwapper "SwapWrite" functions
      STYLE: Use `std::swap` within `ByteSwapper`
      STYLE: Use `constexpr` and `bit_cast` within `GE4ImageIO::MvtSunf(int)`
      STYLE: Remove `this->` and `static_cast<__int64>` from `RealTimeClock`
      STYLE: Clean-up code Windows version default-constructor `RealTimeClock`
      STYLE: Remove extra spaces between parentheses of CMake command calls
      STYLE: Pass `bool` parameters by (const) value, not by `const` reference
      STYLE: Pass numeric parameters by (const) value, not by const reference
      STYLE: Call convenience member function, `ImageBase::SetRegions(region)`
      BUG: Let MeshIOTestHelper AllocateBuffer return `std::shared_ptr<void>`
      STYLE: Replace postfix with prefix increment, decrement (`++`, `--`)
      STYLE: Replace both occurrences of `(&e)->Print(os)` with `e.Print(os)`
      STYLE: Replace all occurrences in tests of `(&x)->Print` with `x.Print`
      STYLE: Rethrow caught exceptions just by `throw;` without argument
      STYLE: Replace `(*p).member` with `p->member` in library code
      STYLE: Replace `(*p).member` with `p->member` in unit tests
      BUG: VTKPolyDataMeshIO should not hang on inf and NaN in ASCII .vtk file
      ENH: Add VTKPolyDataMeshIO GTest tests, testing lossless write and read
      STYLE: Clean up code by ReadPointsUsingMeshIO(), ReadCellsUsingMeshIO()
      ENH: Support reading a mesh of non-3D points from a .vtk PolyData file
      STYLE: Declare Ellipsoid SpatialFunction orientations as a fixed matrix
      STYLE: Use `unique_ptr` for `OrthogonalSwath2DPathFilter` data members
      STYLE: Declare WindowedSincInterpolateImageFunction data as fixed arrays
      STYLE: Declare `NormalVariateGenerator::m_Vec1` as fixed array
      STYLE: Replace pointers initialized by `new T[N]` with fixed arrays
      STYLE: Replace pointers initialized by `new T[N]` with arrays, in tests
      STYLE: Use unique_ptr to avoid the same delete[] on multiple exit paths

Paul Elliott (1):
      STYLE: Use ReadImage and WriteImage in a few iterator examples

Pranjal Sahu (34):
      ENH: Adding SetPoints in PointSet for 1D input array
      ENH: Adding Set/GetCellsArray in Mesh
      ENH: Adding set/getstate in Python for Mesh serialization
      ENH: Adding test for Mesh serialization
      ENH: Adding set/getstate in Python for PointSet serialization
      ENH: Adding test for PointSet serialization
      BUG: Use itk.ULL type for Python Windows test
      ENH: Handle itk.ULL in _get_itk_pixelid for Windows
      COMP: Remove un-necessary wrapping to remove Windows warnings
      ENH: Adding Support for Transform Serialization
      ENH: Adding Module Dependency for Windows Python Test
      ENH: Adding itk::PolyLineCell
      ENH: Adding changes for testing itk::PolyLineCell
      STYLE: Use proper capital letters following ITK convention
      BUG: First set fixed parameters then parameters
      ENH: Initialize PolyLineCell with 2 points
      BUG: Solves intermittent corrupted cells during serialization
      ENH: Moving PointSet Vector wrapping to itkPointSet.wrap
      ENH: Add InputSpaceName and OutputSpaceName in Transform
      ENH: Remove TransformType key from Transform serialization
      ENH: Add test for de-serialized transform output
      PERF: Set parameters in one function call
      ENH: Adding Python wrapping for itkPointsLocator
      ENH: Adding Python test for itkPointsLocator
      ENH: Add distances of returned ids in PointsLocator
      ENH: Add test for itkPointsLocator with distances
      ENH: Add Similarity3DTransform in itkLandmarkBasedTransformInitializer
      ENH: Add Similarity3DTransform itkLandmarkBasedTransformInitializer test
      ENH: Add MetaDataObject wrapping with Matrix
      ENH: Add float combinations for vnl_matrix_fixed Python wrap
      ENH: Add test for vnl_matrix_fixed Python wrap
      ENH: Add itk.Point wrapping for dimension 6
      BUG: Fix for wrong cell type when LINE and POLY_LINE present
      ENH: Add new test for LINE and POLY_LINE cell

Roland Bruggmann (1):
      STYLE: Member method DICOMParser::CloseFile added

Sean McBride (6):
      COMP: Remove GDCM-specific .gitattributes since they are in GDCM's own
      COMP: be sure to import GDCM's .gitattributes file
      ENH: bug # 3241: Add qfac and qto_xyz to itkNiftiImageIO metadata
      COMP: Fixed issue # 1821 by conditionalizing ITKGPUCommon_* per-OS
      ENH: replaced all sprintf usage with safer snprintf
      STYLE: removed obsolete and confusing old comment

Simon Rit (1):
      COMP: add missing trailing semicolon after itkExceptionMacro

Stefan Dinkelacker (1):
      COMP: Change IOComponentType to IOComponentEnum

Stephen R. Aylward (10):
      ENH: Bump TubeTK to v1.1
      ENH: Updated to latest TubeTK that supports itk::BooleanStdVector
      BUG: Proper CastXML 0.45 hash for Windows
      ENH: Bump TubeTK to support pending ITK53rc04 release
      ENH: Update TubeTK to support Write3DImagesAs4DImage in python
      ENH: SurfaceSpatialObject templated over point type (# 3417)
      ENH: Bump ITKMinimalPathExtraction tag
      ENH: Bump MinimalPathExtraction module to v1.2.2 (# 3535)
      ENH: Bump TubeTK to v1.3.1 (# 3537)
      ENH: Bump TubeTK and MinimalPathExtraction for v5.3rc04.post2 wheels (# 3543)

Tabish Syed (1):
      ENH: Enable LZW compression

Thomas Greer (1):
      COMP: Support VectorImage input to DisplacementFieldTransform

Tom Birdsong (22):
      ENH: Expose `itk::VariableLengthVector` operators in Python wrapping
      ENH: Expose FFT factory image template parameters
      BUG: Fix `PythonVerifyGetOutputAPIConsistency` test on Windows
      ENH: Add configuration to disable Python factory loading
      ENH: Add ITKVkFFTBackend remote module
      ENH: Resolve remote module CMake failures
      BUG: Delete non-virtual function in DisplacementFieldTransform
      ENH: Consider requested output region in FFT convolution
      ENH: Add ConvolutionImageFilter streaming test
      BUG: Fix largest possible output region in `itk::ConvolutionImageFilter`
      BUG: Re-add coverage for `itk::RegistrationParameterScales` types
      ENH: Add kernel helper methods to `itk::DiscreteGaussianImageFilter`
      PERF: Reduce verbosity of `itk::GaussianOperator` warning
      BUG: Remove broken warning in `itk::GaussianOperator`
      BUG: Add `itk::GaussianOperator` debug methods
      BUG: Copy to xarray by default
      COMP: Resolve `itkDiscreteGaussianImageFilter` warnings
      COMP: Resolve MSVC Python stub file generation
      COMP: Fix license in `NiftiImageIOTest13.cxx`
      ENH: Update `ApplyScriptToRemotes.sh` for Github auth token protocol
      ENH: Add utility scripts for managing remote modules
      ENH: Update list of http -> https links

Ziv Yaniv (3):
      BUG: GDCMImageIO accepted images with non-orthogonal direction cosine.
      DOC: Improve/correct TransformGeometryFilter documentation.
      ENH: Issue warning when NIFTI IO coerces matrix to orthonormal

Zlib-ng Upstream (3):
      zlib-ng 2022-04-27 (d41f8ead)
      zlib-ng 2022-05-12 (41d67396)
      zlib-ng 2022-08-17 (89763032)

ferdymercury (1):
      ENH: Extend RawImage wrapper to other data types (# 3190)

luz paz (7):
      DOC: Fix typos in documentation
      DOC: Fix typos in Wrapping/ subdirectory
      DOC: Fix typos in Modules/Core subdirectory
      DOC: Fix typos in Modules/Remote subdirectory
      DOC: Fix typos in various subdirectories
      DOC: Fix typos in Modules/Numerics
      DOC: fix typos in Modules/Filtering

=======================
SimpleITK list of changes:
$ git shortlog --no-merges ffd48e2..1c0cf5d
Bradley Lowekamp (76):
      Python Resample procedure fix keyword exception
      Update Doxygen URLs to itk.org
      Add WhichDimensions to GridImageSource
      Enable CSharp on AZP CI builds
      Add to AZP Packaging CSharp build for OSX
      Set CSharp arch to macosx
      Add CSharp build and packaging to manylinux docker builds
      Update ITK version to post ITKv5.3rc3 with fix for SLIC filter
      Add publishing of linux CSharp artifact
      On AZP Default CentOS agents use devtoolset-7
      AZP is deprecating the macos-10.14 agent
      AZP update Python version used to 3.8
      AZP Update CI to use windows 2019 and VS 16 2019
      Explictly specify latest Ubuntu version
      Add Python 3.10 wrapping
      AZP Packaging use macos-10.15
      AZP update package and batch to windows 2019 and VS 2019
      Increase AZP MacOS package timeout to 300
      Use manylinux2010's cmake version
      Remove old manylinux1 builds
      Add docker file to build manylinux2014 on AZP for packaging
      Update version configuration to 2.1.1.1
      Upgrade pip in virtual environment
      Remove builds for manyliunx 2010 python packages
      Remove builds for python 3.6 packages
      Update version configuration to 2.1.1.2
      Add typelist2 with variadic templates
      Replace old typelist with typelist2
      Refactor ImageExplict to use member function factory.
      Remove old TypeList.h header
      use exec over import in setup.py
      COMP: Fix using "not" in preprocessor
      Update Super build ITK post 5.3rc3 with FFT factory changes
      On Apple OSX use .dylib extension for C# native library
      Address CMake endif mismatch warning.
      Fix unresolved symbol for Image::DispatchedInternalInitialization
      Update ITK version in superbuild
      Update CircleCI docker images
      Update Elastix to include ElastixTargets.cmake install
      Add Elastix superbuild dependency on ITK
      STYLE: fix spelling of sitk prefix
      AZP Windows move wrapping to separate space
      Add XCode 13.4 on macos-12 to AZP batch builds
      Correct package XCode version to 12.4
      Update SimpleITK superbuild to use BUILD_ALWAYS
      Set ITK Superbuild version to v5.3rc04
      Correct SinRegularizedHeaviside option
      Use unique_ptr over raw in Transform class
      Use std::unique_ptr over raw pointer to pimple for Image class
      Add Elastix build option to AZP Batch jobs.
      Update to macos-12 for GHA
      AZP update macosx version for CI and package builds
      GHA Add window2019 build wiht Elastix
      Fix undefined behavior in BasicFilters.Cast test
      Add test cast for casting from uint8 types
      Add self hosted ARM build to github actions.
      Use pip to install SimpleITK
      Add test for converting from native numpy scalar types
      Fix conversion of native numpy scalar and dtypes
      Add GHA for building packages with docker images
      Adding JSON docs updates from ITK which contain removal of old hdl URL
      Update SimpleITK JSON docs from ITK XML doxygen
      JSONValidate explicitly open with UTF-8 encoding
      Update doxy2swig print
      Run black on doxy2swig
      Address docstring issues with "..." and &&
      Update Java and Python docstrings from Doxygen xml
      Explicit set utf-8 encoding for java compilation
      Address JavaDoc warning of '&' in docstrings
      Update doxy2swig to use parse_Text for definitions
      AZP Batch update OSX version and XCode
      Set the CMake Policy version for the superbuild
      Set CMake Policy version up to 3.20
      Explicitly set CMP0135 in Superbuild
      Fix computation of R version at tag
      Fix error with itk::LabelOverlapMeasuresImageFilter::SetInput

Dave Chen (6):
      remove obsolete py2.7 print_function
      added py3.10 build for mac arm
      Dockerfile to build on linux-aarch64
      Output full resolution image; Added C++ and C# to docs
      Exclude some characters for temp file name
      Reformatted Python examples using black

Martin Reuter (1):
      bugfix (typo in sitkUint8)

Niels Dekker (6):
      ENH: Support adding Elastix component by CMake SimpleITK_USE_ELASTIX=ON
      STYLE: Use `unique_ptr` for Elastix and Transformix Pimpl data members
      STYLE: Remove include guards from cxx files
      ENH: Make Elastix and Transformix `GetName()` members const-correct
      Add `sitkExceptionsTest.TestDestructionAfterAssignment` unit test
      Fix GenericException assignment crash by using `shared_ptr` internally

Ziv Yaniv (3):
      DOC: document the meaning of the structuring element constants.
      DOC: Adding an entry to the FAQ.
      DOC: Updating the documentation for a corner case.
```