### PR TITLE
BUG: Fix issue with invalid markup handle interaction

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidget.cxx
@@ -1123,27 +1123,13 @@ void vtkSlicerMarkupsWidget::TranslateWidget(double eventPos[2])
   else if (rep3d)
     {
     // 3D view
-    double eventPos_Display[2] = { 0. };
-
-    eventPos_Display[0] = this->LastEventPosition[0];
-    eventPos_Display[1] = this->LastEventPosition[1];
-
     if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, lastEventPos_World, eventPos_World,
-      orientation_World))
+      this->LastEventPosition, lastEventPos_World, orientation_World))
       {
       return;
       }
-    lastEventPos_World[0] = eventPos_World[0];
-    lastEventPos_World[1] = eventPos_World[1];
-    lastEventPos_World[2] = eventPos_World[2];
-
-    eventPos_Display[0] = eventPos[0];
-    eventPos_Display[1] = eventPos[1];
-
     if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, lastEventPos_World, eventPos_World,
-      orientation_World))
+      eventPos, lastEventPos_World, eventPos_World, orientation_World))
       {
       return;
       }
@@ -1322,12 +1308,8 @@ void vtkSlicerMarkupsWidget::RotateWidget(double eventPos[2])
     }
   else if (rep3d)
     {
-    eventPos_Display[0] = this->LastEventPosition[0];
-    eventPos_Display[1] = this->LastEventPosition[1];
-
     if (rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, eventPos_World, lastEventPos_World,
-      orientation_World))
+      this->LastEventPosition, lastEventPos_World, orientation_World))
       {
       for (int i = 0; i < 3; i++)
         {
@@ -1340,10 +1322,8 @@ void vtkSlicerMarkupsWidget::RotateWidget(double eventPos[2])
       }
     eventPos_Display[0] = eventPos[0];
     eventPos_Display[1] = eventPos[1];
-
     if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, eventPos_World, eventPos_World,
-      orientation_World))
+      eventPos_Display, eventPos_World, eventPos_World, orientation_World))
       {
       return;
       }
@@ -1878,8 +1858,8 @@ int vtkSlicerMarkupsWidget::GetActiveComponentIndex()
 
 //-----------------------------------------------------------------------------
 vtkMRMLSelectionNode* vtkSlicerMarkupsWidget::selectionNode()
-  {
+{
   return vtkMRMLSelectionNode::SafeDownCast(
     this->GetMarkupsNode()->GetScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton"));
 
-  }
+}

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneWidget.cxx
@@ -517,12 +517,8 @@ void vtkSlicerPlaneWidget::RotateWidget(double eventPos[2])
     }
   else if (rep3d)
     {
-    eventPos_Display[0] = this->LastEventPosition[0];
-    eventPos_Display[1] = this->LastEventPosition[1];
-
     if (rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, eventPos_World, lastEventPos_World,
-      orientation_World))
+      this->LastEventPosition, lastEventPos_World, orientation_World))
       {
       for (int i = 0; i < 3; i++)
         {
@@ -533,12 +529,9 @@ void vtkSlicerPlaneWidget::RotateWidget(double eventPos[2])
       {
       return;
       }
-    eventPos_Display[0] = eventPos[0];
-    eventPos_Display[1] = eventPos[1];
 
     if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, eventPos_World, eventPos_World,
-      orientation_World))
+      eventPos, eventPos_World, eventPos_World, orientation_World))
       {
       return;
       }
@@ -673,26 +666,14 @@ void vtkSlicerPlaneWidget::ScaleWidget(double eventPos[2], bool symmetricScale)
   else if (rep3d)
     {
     // 3D view
-    double eventPos_Display[2] = { 0. };
-    eventPos_Display[0] = this->LastEventPosition[0];
-    eventPos_Display[1] = this->LastEventPosition[1];
-
     if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, lastEventPos_World, eventPos_World,
-      orientation_World))
+      this->LastEventPosition, lastEventPos_World, orientation_World))
       {
       return;
       }
-    lastEventPos_World[0] = eventPos_World[0];
-    lastEventPos_World[1] = eventPos_World[1];
-    lastEventPos_World[2] = eventPos_World[2];
-
-    eventPos_Display[0] = eventPos[0];
-    eventPos_Display[1] = eventPos[1];
 
     if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, lastEventPos_World, eventPos_World,
-      orientation_World))
+      eventPos, lastEventPos_World, eventPos_World, orientation_World))
       {
       return;
       }

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIWidget.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIWidget.cxx
@@ -237,21 +237,13 @@ void vtkSlicerROIWidget::ScaleWidget(double eventPos[2], bool symmetricScale)
     eventPos_Display[1] = this->LastEventPosition[1];
 
     if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, lastEventPos_World, eventPos_World,
-      orientation_World))
+      this->LastEventPosition, lastEventPos_World, orientation_World))
       {
       return;
       }
-    lastEventPos_World[0] = eventPos_World[0];
-    lastEventPos_World[1] = eventPos_World[1];
-    lastEventPos_World[2] = eventPos_World[2];
-
-    eventPos_Display[0] = eventPos[0];
-    eventPos_Display[1] = eventPos[1];
 
     if (!rep3d->GetPointPlacer()->ComputeWorldPosition(this->Renderer,
-      eventPos_Display, lastEventPos_World, eventPos_World,
-      orientation_World))
+      eventPos, lastEventPos_World, eventPos_World, orientation_World))
       {
       return;
       }


### PR DESCRIPTION
In some camera positions the behaviour of the interaction handles is incorrect.
Fixed by ensuring that the reference position is not specified when calculating the last world position using vtkPointPlacer::ComputeWorldPosition.

Re #6459