### PR TITLE
BUG: in SlicerCAT within build tree Python and Designer additional settings point to wrong `.ini` file 

### DIFF
--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -77,6 +77,8 @@ if(Slicer_BUILD_QT_DESIGNER_PLUGINS)
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${Slicer_BIN_DIR})
   # Configure designer launcher
   find_package(CTKAppLauncher REQUIRED)
+  # At the time this script is executed for both Slicer's and SlicerCAT's binary dir 
+  # is set to './d/Slicer-build' and there application settings resides
   ctkAppLauncherConfigureForExecutable(
     APPLICATION_NAME ${executablename}
     SPLASHSCREEN_DISABLED
@@ -85,11 +87,11 @@ if(Slicer_BUILD_QT_DESIGNER_PLUGINS)
     # Launcher settings specific to build tree
     APPLICATION_EXECUTABLE ${build_designer_executable}
     DESTINATION_DIR ${CMAKE_BINARY_DIR}/${Slicer_BIN_DIR}
-    ADDITIONAL_SETTINGS_FILEPATH_BUILD "${Slicer_BINARY_DIR}/${Slicer_BINARY_INNER_SUBDIR}/SlicerLauncherSettings.ini"
+    ADDITIONAL_SETTINGS_FILEPATH_BUILD "${Slicer_BINARY_DIR}/${Slicer_MAIN_PROJECT_APPLICATION_NAME}LauncherSettings.ini"
     # Launcher settings specific to install tree
     APPLICATION_INSTALL_EXECUTABLE_NAME "${installed_designer_executable}"
     APPLICATION_INSTALL_SUBDIR "${installed_designer_subdir}"
-    ADDITIONAL_SETTINGS_FILEPATH_INSTALLED "<APPLAUNCHER_SETTINGS_DIR>/SlicerLauncherSettings.ini"
+    ADDITIONAL_SETTINGS_FILEPATH_INSTALLED "<APPLAUNCHER_SETTINGS_DIR>/${Slicer_MAIN_PROJECT_APPLICATION_NAME}LauncherSettings.ini"
     )
   # Install designer launcher settings
   install(

--- a/SuperBuild/python_configure_python_launcher.cmake
+++ b/SuperBuild/python_configure_python_launcher.cmake
@@ -228,6 +228,15 @@ set(PYTHONLAUNCHER_PYTHONPATH_INSTALLED
 #  explicitly updated to "Slicer" in a second step using the action "replace_application_name"
 #  implemented above.
 #
+# At the time this script is executed Slicer's binary dir is set to './d'
+# while SlicerCAT's binary dir is set to './d/slicersources-build'
+# and the application settings resides in './d/Slicer-build'
+set(slicer_app_settings_dir "${Slicer_BINARY_DIR}/${Slicer_BINARY_INNER_SUBDIR}")
+if(DEFINED Slicer_MAIN_PROJECT_APPLICATION_NAME AND
+  NOT ${Slicer_MAIN_PROJECT_APPLICATION_NAME} STREQUAL "Slicer")
+  set(slicer_app_settings_dir "${Slicer_BINARY_DIR}/../${Slicer_BINARY_INNER_SUBDIR}")
+endif()
+
 set(_python_launcher_config_params
 
   # Application properties required to lookup user revision settings
@@ -251,7 +260,7 @@ set(_python_launcher_config_params
   LIBRARY_PATHS_BUILD "${PYTHONLAUNCHER_LIBRARY_PATHS_BUILD}"
   ENVVARS_BUILD "${PYTHONLAUNCHER_ENVVARS_BUILD}"
   ADDITIONAL_PATH_ENVVARS_BUILD "${PYTHONLAUNCHER_ADDITIONAL_PATH_ENVVARS_BUILD}"
-  ADDITIONAL_SETTINGS_FILEPATH_BUILD "${Slicer_BINARY_DIR}/${Slicer_BINARY_INNER_SUBDIR}/${Slicer_MAIN_PROJECT_APPLICATION_NAME}LauncherSettings.ini"
+  ADDITIONAL_SETTINGS_FILEPATH_BUILD "${slicer_app_settings_dir}/${Slicer_MAIN_PROJECT_APPLICATION_NAME}LauncherSettings.ini"
 
   # Launcher settings specific to install tree
   APPLICATION_INSTALL_EXECUTABLE_NAME python-real${CMAKE_EXECUTABLE_SUFFIX}


### PR DESCRIPTION
Slicer (and SlicerCAT) comes with Python and Designer launchers. Thus they have `.ini` settings files that aimed to preliminary set environment variables and do other preparation before launching real executable.
Those files have `additionalSettingsFilePath=/path/to/other/settings.ini` field that is used to load additional environment.

In SlicerCAT within build tree the main executable with its `.ini` file are stored in `C:/D/S4R/Slicer-build/` dir. 
Thus Python settings should look like: `additionalSettingsFilePath=C:/D/S4R/Slicer-build/SlicerCAT.ini`.
But instead now we have `additionalSettingsFilePath=C:/D/S4R/slicersources-build/Slicer-build/SlicerCAT.ini`.

This PR is dedicated to fix this bug (reopened #6274).