### PR TITLE
BUG: Fix wrong signal emitted by SubjectHierarchy if same item is selected

### DIFF
--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyComboBox.cxx
@@ -109,7 +109,7 @@ void qMRMLSubjectHierarchyComboBoxPrivate::init()
   // Make connections
   QObject::connect(this->TreeView, SIGNAL(currentItemChanged(vtkIdType)),
                    q, SLOT(updateComboBoxTitleAndIcon(vtkIdType)));
-  QObject::connect(this->TreeView, SIGNAL(currentItemChanged(vtkIdType)),
+  QObject::connect(this->TreeView, SIGNAL(pressed(QModelIndex)),
                    q, SLOT(hidePopup()));
   QObject::connect(this->TreeView, SIGNAL(currentItemModified(vtkIdType)),
                    q, SLOT(updateComboBoxTitleAndIcon(vtkIdType)));

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -192,8 +192,6 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
   q->QTreeView::setModel(this->SortFilterModel);
   QObject::connect( q->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
                     q, SLOT(onSelectionChanged(QItemSelection,QItemSelection)) );
-  // selectionChanged signal is not triggered when the same item is selected. This connection handles the case when the same item is re-selected.
-  QObject::connect( q, SIGNAL(pressed(const QModelIndex&)), q, SLOT(onCurrentSelection(const QModelIndex&)) );
 
   this->SortFilterModel->setParent(q);
   this->SortFilterModel->setSourceModel(this->Model);
@@ -1505,23 +1503,6 @@ void qMRMLSubjectHierarchyTreeView::onSelectionChanged(const QItemSelection& sel
   // Emit current item changed signal
   emit currentItemChanged(selectedShItems[0]);
   emit currentItemsChanged(selectedShItems);
-}
-
-//------------------------------------------------------------------------------
-void qMRMLSubjectHierarchyTreeView::onCurrentSelection(const QModelIndex &currentItemIndex)
-{
-  Q_D(qMRMLSubjectHierarchyTreeView);
-  if (!d->SortFilterModel)
-    {
-    return;
-    }
-
-  vtkIdType itemID = d->SortFilterModel->subjectHierarchyItemFromIndex(currentItemIndex);
-  // Emit current item signal only if the current item is pressed to avoid duplicated signals when the item is changed
-  if (itemID == d->SelectedItems[0])
-    {
-    emit currentItemChanged(d->SelectedItems[0]);
-    }
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.h
@@ -313,7 +313,6 @@ signals:
 
 protected slots:
   virtual void onSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
-  virtual void onCurrentSelection(const QModelIndex &currentItemIndex);
 
   /// Updates subject hierarchy item expanded property when item is expanded
   virtual void onItemExpanded(const QModelIndex &expandedItemIndex);


### PR DESCRIPTION
Signal currentItemChanged was emitted by qMRMLSubjectHierarchyComboBox even if
the same item was selected.