### PR TITLE
ENH: customizable Box Color in 3D view

### DIFF
--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -802,6 +802,13 @@ viewNode.SetBackgroundColor(1,0,0)
 viewNode.SetBackgroundColor2(1,0,0)
 ```
 
+### Change box color in 3D view
+
+```python
+viewNode = slicer.app.layoutManager().threeDWidget(0).mrmlViewNode()
+viewNode.SetBoxColor(1,0,0)
+```
+
 ### Show a slice view outside the view layout
 
 ```python

--- a/Libs/MRML/Core/vtkMRMLViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLViewNode.cxx
@@ -29,6 +29,7 @@ vtkMRMLNodeNewMacro(vtkMRMLViewNode);
 vtkMRMLViewNode::vtkMRMLViewNode()
 {
   this->BoxVisible = 1;
+  this->GetDefaultBoxColor(this->BoxColor);
   this->AxisLabelsVisible = 1;
   this->AxisLabelsCameraDependent = 1;
   this->FiducialsVisible = 1;
@@ -86,6 +87,7 @@ void vtkMRMLViewNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLFloatMacro(fieldOfView, FieldOfView);
   vtkMRMLWriteXMLFloatMacro(letterSize, LetterSize);
   vtkMRMLWriteXMLBooleanMacro(boxVisible, BoxVisible);
+  vtkMRMLWriteXMLVectorMacro(boxColor, BoxColor, double, 3);
   vtkMRMLWriteXMLBooleanMacro(fiducialsVisible, FiducialsVisible);
   vtkMRMLWriteXMLBooleanMacro(fiducialLabelsVisible, FiducialLabelsVisible);
   vtkMRMLWriteXMLBooleanMacro(axisLabelsVisible, AxisLabelsVisible);
@@ -123,6 +125,7 @@ void vtkMRMLViewNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLFloatMacro(fieldOfView, FieldOfView);
   vtkMRMLReadXMLFloatMacro(letterSize, LetterSize);
   vtkMRMLReadXMLBooleanMacro(boxVisible, BoxVisible);
+  vtkMRMLReadXMLVectorMacro(boxColor, BoxColor, double, 3);
   vtkMRMLReadXMLBooleanMacro(fiducialsVisible, FiducialsVisible);
   vtkMRMLReadXMLBooleanMacro(fiducialLabelsVisible, FiducialLabelsVisible);
   vtkMRMLReadXMLBooleanMacro(axisLabelsVisible, AxisLabelsVisible);
@@ -161,6 +164,7 @@ void vtkMRMLViewNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
   vtkMRMLCopyFloatMacro(FieldOfView);
   vtkMRMLCopyFloatMacro(LetterSize);
   vtkMRMLCopyBooleanMacro(BoxVisible);
+  vtkMRMLCopyVectorMacro(BoxColor, double, 3);
   vtkMRMLCopyBooleanMacro(FiducialsVisible);
   vtkMRMLCopyBooleanMacro(FiducialLabelsVisible);
   vtkMRMLCopyBooleanMacro(AxisLabelsVisible);
@@ -196,6 +200,7 @@ void vtkMRMLViewNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintFloatMacro(FieldOfView);
   vtkMRMLPrintFloatMacro(LetterSize);
   vtkMRMLPrintBooleanMacro(BoxVisible);
+  vtkMRMLPrintVectorMacro(BoxColor, double, 3);
   vtkMRMLPrintBooleanMacro(FiducialsVisible);
   vtkMRMLPrintBooleanMacro(FiducialLabelsVisible);
   vtkMRMLPrintBooleanMacro(AxisLabelsVisible);
@@ -240,6 +245,14 @@ double* vtkMRMLViewNode::defaultBackgroundColor2()
                                        0.4705882352941176,
                                        0.7450980392156863};
   return backgroundColor2;
+}
+
+//------------------------------------------------------------------------------
+void vtkMRMLViewNode::GetDefaultBoxColor(double color[3])
+{
+  color[0] = 1.0;
+  color[1] = 0.0;
+  color[2] = 1.0;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/Core/vtkMRMLViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLViewNode.h
@@ -52,9 +52,16 @@ public:
   static double* defaultBackgroundColor();
   static double* defaultBackgroundColor2();
 
+  /// Return default box color
+  static void GetDefaultBoxColor(double color[3]);
+
   /// Indicates if the box is visible
   vtkGetMacro(BoxVisible, int);
   vtkSetMacro(BoxVisible, int);
+
+  /// Box color as RGB
+  vtkSetVector3Macro(BoxColor, double);
+  vtkGetVector3Macro(BoxColor, double);
 
   /// Indicates if the axis labels are visible
   vtkGetMacro(AxisLabelsVisible, int);
@@ -282,6 +289,7 @@ public:
     AnimationModeFlag,
     RenderModeFlag,
     BoxVisibleFlag,
+    BoxColorFlag,
     BoxLabelVisibileFlag,
     BackgroundColorFlag,
     StereoTypeFlag,
@@ -316,6 +324,7 @@ protected:
   int FiducialsVisible;
   int FiducialLabelsVisible;
   int BoxVisible;
+  double BoxColor[3];
   int AxisLabelsVisible;
   int AxisLabelsCameraDependent;
   double FieldOfView;

--- a/Libs/MRML/DisplayableManager/vtkMRMLViewDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLViewDisplayableManager.cxx
@@ -69,6 +69,7 @@ public:
   void UpdateRASBounds(double bounds[6]);
 
   void UpdateAxisVisibility();
+  void UpdateAxisColor();
   void UpdateAxisLabelVisibility();
   void UpdateAxisLabelText();
   void SetAxisLabelColor(double newAxisLabelColor[3]);
@@ -116,7 +117,17 @@ void vtkMRMLViewDisplayableManager::vtkInternal::CreateAxis()
   this->BoxAxisActor = vtkSmartPointer<vtkActor>::New();
   this->BoxAxisActor->SetMapper(boxMapper.GetPointer());
   this->BoxAxisActor->SetScale(1.0, 1.0, 1.0);
-  this->BoxAxisActor->GetProperty()->SetColor(1.0, 0.0, 1.0);
+
+  double boxColor[3];
+  if (this->External->GetMRMLViewNode())
+    {
+    this->External->GetMRMLViewNode()->GetBoxColor(boxColor);
+    }
+  else
+    {
+    vtkMRMLViewNode::GetDefaultBoxColor(boxColor);
+    }
+  this->BoxAxisActor->GetProperty()->SetColor(boxColor);
   this->BoxAxisActor->SetPickable(0);
 
   this->AxisLabelActors.clear();
@@ -244,6 +255,9 @@ void vtkMRMLViewDisplayableManager::vtkInternal::UpdateAxis(vtkRenderer * render
     {
     return;
     }
+
+  // Update box color
+  this->BoxAxisActor->GetProperty()->SetColor(this->External->GetMRMLViewNode()->GetBoxColor());
 
   // Turn off box and axis labels to compute bounds
   int boxVisibility = this->BoxAxisActor->GetVisibility();
@@ -391,6 +405,17 @@ void vtkMRMLViewDisplayableManager::vtkInternal::UpdateAxisVisibility()
   int visible = this->External->GetMRMLViewNode()->GetBoxVisible();
   vtkDebugWithObjectMacro(this->External, << "UpdateAxisVisibility:" << visible);
   this->BoxAxisActor->SetVisibility(visible);
+  this->External->RequestRender();
+}
+
+//---------------------------------------------------------------------------
+void vtkMRMLViewDisplayableManager::vtkInternal::UpdateAxisColor()
+{
+  double boxColor[3] = {1.0, 0.0, 1.0};
+  vtkMRMLViewNode::GetDefaultBoxColor(boxColor);
+  this->External->GetMRMLViewNode()->GetBoxColor(boxColor);
+  vtkDebugWithObjectMacro(this->External, << "UpdateAxisColor:" << boxColor[0] << "\t" << boxColor[1] << "\t" << boxColor[2]);
+  this->BoxAxisActor->GetProperty()->SetColor(boxColor);
   this->External->RequestRender();
 }
 
@@ -645,6 +670,7 @@ void vtkMRMLViewDisplayableManager::UpdateFromViewNode()
   this->Internal->UpdateRenderMode();
   this->Internal->UpdateAxisLabelVisibility();
   this->Internal->UpdateAxisVisibility();
+  this->Internal->UpdateAxisColor();
   this->Internal->UpdateAxisLabelText();
   this->Internal->UpdateStereoType();
   this->Internal->UpdateBackgroundColor();

--- a/Libs/MRML/Logic/vtkMRMLViewLinkLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLViewLinkLogic.cxx
@@ -403,6 +403,13 @@ void vtkMRMLViewLinkLogic::BroadcastViewNodeEvent(vtkMRMLViewNode* viewNode)
       {
       vNode->SetBoxVisible(viewNode->GetBoxVisible());
       }
+    // Box color
+    else if (viewNode->GetInteractionFlags() == vtkMRMLViewNode::BoxColorFlag)
+      {
+      int wasModifying = vNode->StartModify();
+      vNode->SetBoxColor(viewNode->GetBoxColor());
+      vNode->EndModify(wasModifying);
+      }
     // Box labels visibility
     else if (viewNode->GetInteractionFlags() == vtkMRMLViewNode::BoxLabelVisibileFlag)
       {

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -828,6 +828,26 @@ void qMRMLThreeDViewControllerWidget::setBackgroundColor(
 }
 
 // --------------------------------------------------------------------------
+void qMRMLThreeDViewControllerWidget::setBoxColor(
+  const QColor& newColor)
+{
+  Q_D(qMRMLThreeDViewControllerWidget);
+  if (!this->mrmlThreeDViewNode())
+    {
+    return;
+    }
+
+  d->ViewLogic->StartViewNodeInteraction(vtkMRMLViewNode::BoxColorFlag);
+
+  int wasModifying = this->mrmlThreeDViewNode()->StartModify();
+  // The ThreeDView displayable manager will change the color of BoxAxisActor
+  this->mrmlThreeDViewNode()->SetBoxColor(newColor.redF(), newColor.greenF(), newColor.blueF());
+  this->mrmlThreeDViewNode()->EndModify(wasModifying);
+
+  d->ViewLogic->EndViewNodeInteraction();
+}
+
+// --------------------------------------------------------------------------
 void qMRMLThreeDViewControllerWidget::setStereoType(int newStereoType)
 {
   Q_D(qMRMLThreeDViewControllerWidget);

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.h
@@ -114,6 +114,9 @@ public slots:
   void setBackgroundColor(const QColor& color,
                           QColor color2 = QColor());
 
+  /// Utility function to change color of the box
+  void setBoxColor(const QColor& color);
+
   void setStereoType(int newStereoType);
   void setOrientationMarkerType(int type);
   void setOrientationMarkerSize(int size);


### PR DESCRIPTION
Box in 3D view is an actor controlled by vtkMRMLViewDisplayableManager.
This manager also controls the renderer background color as well.
Thus it was pretty easy to introduce this feature in the same way.
`vtkMRMLViewNode` now have attribute `double BoxColor[3]`.
User is able to modify box color through vtkMRMLViewNode::SetBoxColor().

Probably it would be good to add the example to [Slicer script repository](https://slicer.readthedocs.io/en/latest/developer_guide/script_repository.html#change-3d-view-background-color):
```python
viewNode = slicer.app.layoutManager().threeDWidget(0).mrmlViewNode()
viewNode.SetBoxColor(1,0,0)
```