### PR TITLE
BUG: Fix sampling distance computation for multi-volume rendering

### DIFF
--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerVolumeRenderingModuleWidget.cxx
@@ -1031,7 +1031,6 @@ void qSlicerVolumeRenderingModuleWidget::onEffectiveRangeModified()
   vtkMRMLVolumePropertyNode* volumePropertyNode = this->mrmlVolumePropertyNode();
   if (!volumePropertyNode)
     {
-    qCritical() << Q_FUNC_INFO << ": Invalid volume property node";
     return;
     }
 


### PR DESCRIPTION
Multi-volume rendering quality was always quite low because always "adaptive" rendering mode was used (regardless of what was set in the GUI) and the sampling distance was not computed correctly.

fixes #5238
fixes #5312