### PR TITLE
COMP: Fix sphinx documentation build due to breaking change in markdown

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,6 +5,7 @@ myst-parser
 pygments
 sphinx
 sphinx-issues
-sphinx-markdown-tables
+# Workaround for https://github.com/ryanfox/sphinx-markdown-tables/issues/36
+git+https://github.com/Dzordzu/sphinx-markdown-tables.git@3bc0849cf6dc0e1b7fe52aafadc2e2ccca698a01
 sphinx-notfound-page
 sphinx_rtd_theme>=0.5.2


### PR DESCRIPTION
This commit workarounds backward incompatible change introduced in
Markdown 3.4 through Python-Markdown/markdown@659a43659 (Update th/td
to use style attribute)

It addresses error like the following:

```
  Extension error (sphinx_markdown_tables):
  Handler <function process_tables at 0x7f12fd69dc20> for event 'source-read' threw an exception (exception: __init__() missing 1 required positional argument: 'config')
```

See https://github.com/ryanfox/sphinx-markdown-tables/issues/36
and https://python-markdown.github.io/change_log/release-3.4/

## Caveats

The current approach depends on a change associated with branch called `markdown-patch` and available in a fork maintained by @Dzordzu at https://github.com/Dzordzu/sphinx-markdown-tables/tree/markdown-patch and contributed through https://github.com/ryanfox/sphinx-markdown-tables/pull/37

Following the integration of the pull request and/or rewrite of the history of the `markdown-patch` branch, the reference to commit Dzordzu/sphinx-markdown-tables@3bc0849cf6dc0e1b7fe52aafadc2e2ccca698a01 may not be available anymore. This means that a follow-up fix may have to be contributed to Slicer.

To mitigate this, we would also consider forking `sphinx-markdown-tables` into the `Slicer` or `KitwareMedical` GitHub organization.


## Alternatives considered

An alternative approach would be to update `requirements-docs.txt` and require a version of markdown < 3.4.