### PR TITLE
ENH: Display git diff when extension update is available

### DIFF
--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -817,6 +817,9 @@ void qSlicerApplication::openExtensionsManagerDialog()
   // This call takes most of the startup time
   d->ExtensionsManagerDialog->setExtensionsManagerModel(this->extensionsManagerModel());
 
+  // Allow user to start typing immediately to locate an extension.
+  d->ExtensionsManagerDialog->setFocusToSearchBox();
+
   QApplication::restoreOverrideCursor();
 
   bool accepted = (d->ExtensionsManagerDialog->exec() == QDialog::Accepted);

--- a/Base/QTGUI/qSlicerExtensionsManagerDialog.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerDialog.cxx
@@ -233,3 +233,10 @@ void qSlicerExtensionsManagerDialog::reject()
     Superclass::reject(); // close window
     }
 }
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerDialog::setFocusToSearchBox()
+{
+  Q_D(qSlicerExtensionsManagerDialog);
+  d->ExtensionsManagerWidget->setFocusToSearchBox();
+}

--- a/Base/QTGUI/qSlicerExtensionsManagerDialog.h
+++ b/Base/QTGUI/qSlicerExtensionsManagerDialog.h
@@ -58,6 +58,11 @@ public:
   void accept() override;
   void reject() override;
 
+public slots:
+
+  /// Set focus to search box (so that user can find a module just by start typing its name)
+  void setFocusToSearchBox();
+
 protected slots:
   void onModelUpdated();
   void onBatchProcessingChanged();

--- a/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsManagerWidget.cxx
@@ -860,3 +860,10 @@ void qSlicerExtensionsManagerWidget::onMessagesAcknowledged()
   d->Messages.clear();
   d->MessageWidget->setIcon(QMessageBox::NoIcon);
 }
+
+// --------------------------------------------------------------------------
+void qSlicerExtensionsManagerWidget::setFocusToSearchBox()
+{
+  Q_D(qSlicerExtensionsManagerWidget);
+  d->ToolsWidget->SearchBox->setFocus();
+}

--- a/Base/QTGUI/qSlicerExtensionsManagerWidget.h
+++ b/Base/QTGUI/qSlicerExtensionsManagerWidget.h
@@ -68,8 +68,11 @@ signals:
 public slots:
   void refreshInstallWidget();
 
-  // Request update state of automatic extension update check and install checkbox states
+  /// Request update state of automatic extension update check and install checkbox states
   void updateAutoUpdateWidgetsFromModel();
+
+  /// Set focus to search box (so that user can find a module just by start typing its name)
+  void setFocusToSearchBox();
 
 protected slots:
   void onModelUpdated();


### PR DESCRIPTION
When an extension update is available then a link is added to the extension description to list all the changes between the installed and current version (if the repository is hosted on github and version information is available).

![image](https://user-images.githubusercontent.com/307929/181191768-f1a49c9d-9a88-49ea-83ad-5f6d5b3b9825.png)

When the user clicks the link then the change log is displayed in the default browser:

![image](https://user-images.githubusercontent.com/307929/181192258-7947cd2d-58e6-48b9-a1d4-6dd97150f915.png)
