### PR TITLE
ENH: Allow selecting volume sequence nodes as CLI module input

### DIFF
--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -689,8 +689,19 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createImageTagWidget(const ModuleParam
   else
     {
     QString nodeType = Self::nodeTypeFromMap(Self::ImageTypeAttributeToNodeType, type, "vtkMRMLScalarVolumeNode");
-    widget->setNodeTypes(QStringList(nodeType));
-    }
+    // If node type is vtkMRMLMultiVolumeNode then allow selecting volume sequences, too
+    if (nodeType == "vtkMRMLMultiVolumeNode")
+      {
+      QStringList nodeTypes;
+      nodeTypes << nodeType << "vtkMRMLSequenceNode";
+      widget->setNodeTypes(nodeTypes);
+      widget->addAttribute("vtkMRMLSequenceNode", "DataNodeClassName", "vtkMRMLScalarVolumeNode");
+      }
+    else
+      {
+      widget->setNodeTypes(QStringList(nodeType));
+      }
+  }
 
   // TODO - title + " Volume"
 

--- a/Libs/MRML/Core/vtkMRMLSequenceNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSequenceNode.cxx
@@ -403,6 +403,7 @@ vtkMRMLNode* vtkMRMLSequenceNode::SetDataNodeAtValue(vtkMRMLNode* node, const st
     vtkErrorMacro("vtkMRMLSequenceNode::SetDataNodeAtValue failed, invalid node");
     return nullptr;
     }
+  MRMLNodeModifyBlocker blocker(this);
   // Make sure the sequence scene is created
   this->GetSequenceScene();
   // Add a copy of the node to the sequence's scene
@@ -419,6 +420,12 @@ vtkMRMLNode* vtkMRMLSequenceNode::SetDataNodeAtValue(vtkMRMLNode* node, const st
     }
   this->IndexEntries[seqItemIndex].DataNode = newNode;
   this->IndexEntries[seqItemIndex].DataNodeID.clear();
+  // Save the sequence data node class namein a node attribute to allow easy access
+  // (e.g., for filtering on the GUI).
+  if (this->GetNumberOfDataNodes() <= 1)
+    {
+    this->SetAttribute("DataNodeClassName", this->GetDataNodeClassName().c_str());
+    }
   this->Modified();
   this->StorableModifiedTime.Modified();
   return newNode;

--- a/Libs/MRML/Core/vtkMRMLSequenceNode.h
+++ b/Libs/MRML/Core/vtkMRMLSequenceNode.h
@@ -39,6 +39,10 @@
 ///
 /// If an index is numeric then it is sorted differently and equality determined using
 /// a numerical tolerance instead of exact string matching.
+///
+/// Class name of data nodes stored in the sequence is set into the `DataNodeClassName`
+/// node attribute, which may be used for attribute-based filters (for example,
+/// to show only certain type of sequence node in a node selector).
 
 class VTK_MRML_EXPORT vtkMRMLSequenceNode : public vtkMRMLStorableNode
 {

--- a/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
+++ b/Modules/CLI/ExecutionModelTour/ExecutionModelTour.xml
@@ -127,6 +127,12 @@
       <label>Input image</label>
       <channel>input</channel>
     </image>
+    <image type="dynamic-contrast-enhanced">
+      <longflag>image4d</longflag>
+      <label>Input 4D Image</label>
+      <channel>input</channel>
+      <description><![CDATA[Input 4D Image (txyz)]]></description>
+    </image>
     <image reference="image1">
       <longflag>image2</longflag>
       <description><![CDATA[An output image]]></description>


### PR DESCRIPTION
If an input `image` parameter's `type` is set to "dynamic-contrast-enhanced", "signal", or "multichannel" then the generated node selector allows selection of `vtkMRMLSequenceNode` node that contains `vtkMRMLScalarVolume` nodes in it.

![image](https://user-images.githubusercontent.com/307929/181193632-c29c9038-04ad-4026-94fc-3598ece4ccf4.png)

This is useful for allowing running CLI modules such as [PkModeling](https://github.com/QIICR/PkModeling/blob/master/CLI/PkModeling.xml) on volume sequences.
