### PR TITLE
BUG: Make sure ProcessMRMLEvents is called all the way to the base no…

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformableNode.cxx
@@ -130,8 +130,10 @@ bool vtkMRMLTransformableNode::SetAndObserveTransformNodeID(const char *transfor
 //---------------------------------------------------------------------------
 void vtkMRMLTransformableNode::ProcessMRMLEvents ( vtkObject *caller,
                                                   unsigned long event,
-                                                  void *vtkNotUsed(callData) )
+                                                  void *callData )
 {
+  Superclass::ProcessMRMLEvents(caller, event, callData);
+
   // as retrieving the parent transform node can be costly (browse the scene)
   // do some checks here to prevent retrieving the node for nothing.
   if (caller == nullptr ||


### PR DESCRIPTION
…de class

The transformable node did not call the ProcessMRMLEvents function from its superclass, so the storable node and base MRML node classes did not have a chance to handle some events.