### PR TITLE
Restore widget name in qMRMLSegmentEditorWidget

### DIFF
--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
@@ -240,7 +240,7 @@
      <item>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
-        <widget class="ctkExpandableWidget" name="Form">
+        <widget class="ctkExpandableWidget" name="SegmentsTableResizableFrame">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
@@ -492,6 +492,11 @@
    <class>ctkFittedTextBrowser</class>
    <extends>QTextBrowser</extends>
    <header>ctkFittedTextBrowser.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkMenuButton</class>
+   <extends>QPushButton</extends>
+   <header>ctkMenuButton.h</header>
   </customwidget>
   <customwidget>
    <class>ctkRangeWidget</class>


### PR DESCRIPTION
This commit fixes a regression introduced in 1b94b0d53 (ENH: Improve Segment Editor widget layout)

It restores the object name from `Form` to `SegmentsTableResizableFrame`.

Using an explicit widget name is relevant in the context of prototyping and/or custom application development.

Additionally, it adds the missing `customwidget` definition associated with the `ctkMenuButton` custom widget. Sew https://doc.qt.io/qt-5/designer-creating-custom-widgets.html
