### PR TITLE
STYLE: Add recent python formatting to ignored list for git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -32,3 +32,9 @@ a1335408963ecfc5e96b35ee8d55fea0801c2291
 67295561c7f33b65bc763dd6282ecacd7e8c410d
 # STYLE: Fix inconsistent indentation
 18a414db3e7064cbcb485f7dc3043ad1df9f379c
+# STYLE: Update python code with whitespace fixes
+5b0fc5cecb16636980ab3f0119184485961d74c9
+# STYLE: Update python code with indentation fixes
+9390be6bf76e048e6fd384d8bfd607eba2857b5a
+# STYLE: Update python code with statement fixes
+34696fbccdd6efea5f94f5d628dbb902d60a046d


### PR DESCRIPTION
This adds a few of the recent python formatting commits to the git blame ignore list.