### PR TITLE
STYLE: Add recent python formatting to ignored list for git blame (5.0)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -32,3 +32,9 @@ a1335408963ecfc5e96b35ee8d55fea0801c2291
 67295561c7f33b65bc763dd6282ecacd7e8c410d
 # STYLE: Fix inconsistent indentation
 b9114dbef485d7b99b11f41243bd1594d6b06dda
+# STYLE: Update python code with whitespace fixes
+a57091fdbef34659926a6a363949b0b4fe11f0af
+# STYLE: Update python code with indentation fixes
+b60049e66126bd62c02a1a42520249a85d86eb40
+# STYLE: Update python code with statement fixes
+6c11e7af5ff962ed3359ec88982ca0609d32a98a


### PR DESCRIPTION
Similar to #6498, but with the appropriate git hashes for the commits on the `5.0` branch.