### PR TITLE
BUG: Update sphinx custom 404 page to handle redirect of vX.Y URL without slash

### DIFF
--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -100,7 +100,14 @@ if os.environ.get('EXCLUDE_API_REFERENCE', False) == 'True':
 # https://github.com/readthedocs/sphinx-notfound-page
 notfound_context = {
     'title': 'Page Not Found',
-    'body': '''
+    'body': r'''
+<script type="text/javascript">
+  // Workaround https://github.com/readthedocs/readthedocs.org/issues/9507
+  const regex = /^https:\/\/slicer\.readthedocs\.io\/\w+\/v\d\.\d$/;
+  if (regex.test(window.location)) {
+    window.location.replace(window.location + "/");
+  }
+</script>
 <h1>Page Not Found</h1>
 <p>Sorry, we couldn't find that page.</p>
 <p>Try using the search box or go to the homepage.</p>


### PR DESCRIPTION
This commit adds a javascript redirect to handle the redirection of page
like https://slicer.readthedocs.io/en/v5.0 to https://slicer.readthedocs.io/en/v5.0/
and workaround limitation documented in https://github.com/readthedocs/readthedocs.org/issues/9507

Indeed, despite of adding the following "Exact Redirect" to the readthedocs
configuration:

```
/en/v5.0 -> /en/5.0
/en/v5.0/$rest -> /en/5.0/
```
, specifying https://slicer.readthedocs.io/en/v5.0 doesn't redirect to
https://slicer.readthedocs.io/en/5.0