### PR TITLE
ENH: Expose segment conversion paths in Python

### DIFF
--- a/Libs/vtkSegmentationCore/CMakeLists.txt
+++ b/Libs/vtkSegmentationCore/CMakeLists.txt
@@ -39,6 +39,10 @@ set(vtkSegmentationCore_SRCS
   vtkSegment.h
   vtkSegmentation.cxx
   vtkSegmentation.h
+  vtkSegmentationConversionParameters.cxx
+  vtkSegmentationConversionParameters.h
+  vtkSegmentationConversionPath.cxx
+  vtkSegmentationConversionPath.h
   vtkSegmentationConverter.cxx
   vtkSegmentationConverter.h
   vtkSegmentationConverterFactory.cxx

--- a/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkBinaryLabelmapToClosedSurfaceConversionRule.cxx
@@ -69,15 +69,15 @@ vtkSegmentationConverterRuleNewMacro(vtkBinaryLabelmapToClosedSurfaceConversionR
 //----------------------------------------------------------------------------
 vtkBinaryLabelmapToClosedSurfaceConversionRule::vtkBinaryLabelmapToClosedSurfaceConversionRule()
 {
-  this->ConversionParameters[GetDecimationFactorParameterName()] = std::make_pair("0.0",
+  this->ConversionParameters->SetParameter(GetDecimationFactorParameterName(), "0.0",
     "Desired reduction in the total number of polygons. Range: 0.0 (no decimation) to 1.0 (as much simplification as possible)."
     " Value of 0.8 typically reduces data set size by 80% without losing too much details.");
-  this->ConversionParameters[GetSmoothingFactorParameterName()] = std::make_pair("0.5",
+  this->ConversionParameters->SetParameter(GetSmoothingFactorParameterName(), "0.5",
     "Smoothing factor. Range: 0.0 (no smoothing) to 1.0 (strong smoothing).");
-  this->ConversionParameters[GetComputeSurfaceNormalsParameterName()] = std::make_pair("1",
+  this->ConversionParameters->SetParameter(GetComputeSurfaceNormalsParameterName(), "1",
     "Compute surface normals. 1 (default) = surface normals are computed. "
     "0 = surface normals are not computed (slightly faster but produces less smooth surface display).");
-  this->ConversionParameters[GetJointSmoothingParameterName()] = std::make_pair("0",
+  this->ConversionParameters->SetParameter(GetJointSmoothingParameterName(), "0",
     "Perform joint smoothing.");
 }
 
@@ -150,8 +150,8 @@ bool vtkBinaryLabelmapToClosedSurfaceConversionRule::Convert(vtkSegment* segment
     return false;
     }
 
-  double smoothingFactor = vtkVariant(this->ConversionParameters[GetSmoothingFactorParameterName()].first).ToDouble();
-  int jointSmoothing = vtkVariant(this->ConversionParameters[GetJointSmoothingParameterName()].first).ToInt();
+  double smoothingFactor = this->ConversionParameters->GetValueAsDouble(GetSmoothingFactorParameterName());
+  int jointSmoothing = this->ConversionParameters->GetValueAsInt(GetJointSmoothingParameterName());
 
   if (jointSmoothing > 0 && smoothingFactor > 0)
     {
@@ -285,9 +285,9 @@ bool vtkBinaryLabelmapToClosedSurfaceConversionRule::CreateClosedSurface(vtkOrie
   binaryLabelmapWithIdentityGeometry->SetSpacing(1.0, 1.0, 1.0);
 
   // Get conversion parameters
-  double decimationFactor = vtkVariant(this->ConversionParameters[GetDecimationFactorParameterName()].first).ToDouble();
-  double smoothingFactor = vtkVariant(this->ConversionParameters[GetSmoothingFactorParameterName()].first).ToDouble();
-  int computeSurfaceNormals = vtkVariant(this->ConversionParameters[GetComputeSurfaceNormalsParameterName()].first).ToInt();
+  double decimationFactor = this->ConversionParameters->GetValueAsDouble(GetDecimationFactorParameterName());
+  double smoothingFactor = this->ConversionParameters->GetValueAsDouble(GetSmoothingFactorParameterName());
+  int computeSurfaceNormals = this->ConversionParameters->GetValueAsInt(GetComputeSurfaceNormalsParameterName());
 
   vtkNew<vtkDiscreteFlyingEdges3D> marchingCubes;
   marchingCubes->SetInputData(binaryLabelmapWithIdentityGeometry);

--- a/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkClosedSurfaceToBinaryLabelmapConversionRule.cxx
@@ -57,19 +57,19 @@ vtkClosedSurfaceToBinaryLabelmapConversionRule::vtkClosedSurfaceToBinaryLabelmap
   this->ReplaceTargetRepresentation = true;
 
   // Reference image geometry parameter
-  this->ConversionParameters[vtkSegmentationConverter::GetReferenceImageGeometryParameterName()] = std::make_pair("",
+  this->ConversionParameters->SetParameter(vtkSegmentationConverter::GetReferenceImageGeometryParameterName(), "",
     "Image geometry description string determining the geometry of the labelmap that is created in course of conversion."
     " Can be copied from a volume, using the button.");
   // Oversampling factor parameter
-  this->ConversionParameters[GetOversamplingFactorParameterName()] = std::make_pair("1",
+  this->ConversionParameters->SetParameter(GetOversamplingFactorParameterName(), "1",
     "Determines the oversampling of the reference image geometry. If it's a number, then all segments are oversampled"
     " with the same value (value of 1 means no oversampling). If it has the value \"A\", then automatic oversampling is calculated.");
   // Crop to reference geometry parameter
-  this->ConversionParameters[GetCropToReferenceImageGeometryParameterName()] = std::make_pair("0",
+  this->ConversionParameters->SetParameter(GetCropToReferenceImageGeometryParameterName(), "0",
     "Crop the model to the extent of reference geometry. 0 (default) = created labelmap will contain the entire model."
     " 1 = created labelmap extent will be within reference image extent.");
   // Collapse labelmaps parameter
-  this->ConversionParameters[GetCollapseLabelmapsParameterName()] = std::make_pair("1",
+  this->ConversionParameters->SetParameter(GetCollapseLabelmapsParameterName(), "1",
     "Merge the labelmaps into as few shared labelmaps as possible"
     " 1 = created labelmaps will be shared if possible without overwriting each other.");
 }
@@ -255,7 +255,7 @@ bool vtkClosedSurfaceToBinaryLabelmapConversionRule::Convert(vtkSegment* segment
 //----------------------------------------------------------------------------
 bool vtkClosedSurfaceToBinaryLabelmapConversionRule::PostConvert(vtkSegmentation* segmentation)
 {
-  int collapseLabelmaps = vtkVariant(this->ConversionParameters[GetCollapseLabelmapsParameterName()].first).ToInt();
+  int collapseLabelmaps = this->ConversionParameters->GetValueAsInt(GetCollapseLabelmapsParameterName());
   if (collapseLabelmaps > 0)
     {
     segmentation->CollapseBinaryLabelmaps(false);
@@ -278,7 +278,7 @@ bool vtkClosedSurfaceToBinaryLabelmapConversionRule::CalculateOutputGeometry(vtk
     }
 
   // Get reference image geometry from parameters
-  std::string geometryString = this->ConversionParameters[vtkSegmentationConverter::GetReferenceImageGeometryParameterName()].first;
+  std::string geometryString = this->ConversionParameters->GetValue(vtkSegmentationConverter::GetReferenceImageGeometryParameterName());
   if (geometryString.empty() || !vtkSegmentationConverter::DeserializeImageGeometry(geometryString, geometryImageData))
     {
     geometryString = this->GetDefaultImageGeometryStringForPolyData(closedSurfacePolyData);
@@ -299,7 +299,7 @@ bool vtkClosedSurfaceToBinaryLabelmapConversionRule::CalculateOutputGeometry(vtk
     }
 
   // Get oversampling factor
-  std::string oversamplingString = this->ConversionParameters[GetOversamplingFactorParameterName()].first;
+  std::string oversamplingString = this->ConversionParameters->GetValue(GetOversamplingFactorParameterName());
   double oversamplingFactor = 1.0;
   if (!oversamplingString.compare("A"))
     {
@@ -334,7 +334,7 @@ bool vtkClosedSurfaceToBinaryLabelmapConversionRule::CalculateOutputGeometry(vtk
 
   int cropToReferenceImageGeometry = 0;
     {
-    std::string cropToReferenceImageGeometryString = this->ConversionParameters[GetCropToReferenceImageGeometryParameterName()].first;
+    std::string cropToReferenceImageGeometryString = this->ConversionParameters->GetValue(GetCropToReferenceImageGeometryParameterName());
     std::stringstream ss;
     ss << cropToReferenceImageGeometryString;
     ss >> cropToReferenceImageGeometry;

--- a/Libs/vtkSegmentationCore/vtkFractionalLabelmapToClosedSurfaceConversionRule.cxx
+++ b/Libs/vtkSegmentationCore/vtkFractionalLabelmapToClosedSurfaceConversionRule.cxx
@@ -47,8 +47,10 @@ vtkSegmentationConverterRuleNewMacro(vtkFractionalLabelmapToClosedSurfaceConvers
 vtkFractionalLabelmapToClosedSurfaceConversionRule::vtkFractionalLabelmapToClosedSurfaceConversionRule()
   : vtkBinaryLabelmapToClosedSurfaceConversionRule()
 {
-  this->ConversionParameters[this->GetFractionalLabelMapOversamplingFactorParameterName()] = std::make_pair("1", "Determines the oversampling of the reference image geometry. All segments are oversampled with the same value (value of 1 means no oversampling).");
-  this->ConversionParameters[this->GetThresholdFractionParameterName()] = std::make_pair("0.5", "Determines the threshold that the closed surface is created at as a fractional value between 0 and 1.");
+  this->ConversionParameters->SetParameter(this->GetFractionalLabelMapOversamplingFactorParameterName(), "1",
+    "Determines the oversampling of the reference image geometry. All segments are oversampled with the same value (value of 1 means no oversampling).");
+  this->ConversionParameters->SetParameter(this->GetThresholdFractionParameterName(), "0.5",
+    "Determines the threshold that the closed surface is created at as a fractional value between 0 and 1.");
 }
 
 //----------------------------------------------------------------------------
@@ -144,11 +146,11 @@ bool vtkFractionalLabelmapToClosedSurfaceConversionRule::Convert(vtkSegment* seg
     }
 
   // Get conversion parameters
-  double decimationFactor = vtkVariant(this->ConversionParameters[this->GetDecimationFactorParameterName()].first).ToDouble();
-  double smoothingFactor = vtkVariant(this->ConversionParameters[this->GetSmoothingFactorParameterName()].first).ToDouble();
-  int computeSurfaceNormals = vtkVariant(this->ConversionParameters[GetComputeSurfaceNormalsParameterName()].first).ToInt();
-  double fractionalOversamplingFactor = vtkVariant(this->ConversionParameters[this->GetFractionalLabelMapOversamplingFactorParameterName()].first).ToDouble();
-  double fractionalThreshold = vtkVariant(this->ConversionParameters[this->GetThresholdFractionParameterName()].first).ToDouble();
+  double decimationFactor = this->ConversionParameters->GetValueAsDouble(this->GetDecimationFactorParameterName());
+  double smoothingFactor = this->ConversionParameters->GetValueAsDouble(this->GetSmoothingFactorParameterName());
+  int computeSurfaceNormals = this->ConversionParameters->GetValueAsInt(GetComputeSurfaceNormalsParameterName());
+  double fractionalOversamplingFactor = this->ConversionParameters->GetValueAsDouble(this->GetFractionalLabelMapOversamplingFactorParameterName());
+  double fractionalThreshold = this->ConversionParameters->GetValueAsDouble(this->GetThresholdFractionParameterName());
 
   if (fractionalThreshold < 0 || fractionalThreshold > 1)
     {

--- a/Libs/vtkSegmentationCore/vtkSegmentation.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentation.h
@@ -41,6 +41,7 @@ class vtkAbstractTransform;
 class vtkCallbackCommand;
 class vtkCollection;
 class vtkIntArray;
+class vtkSegmentationConversionPath;
 class vtkStringArray;
 
 /// \ingroup SegmentationCore
@@ -422,8 +423,8 @@ public:
   /// Conversion starts from the master representation, and all representations along the
   /// path get overwritten.
   /// \return true on success
-  bool CreateRepresentation(vtkSegmentationConverter::ConversionPathType path,
-                            vtkSegmentationConverterRule::ConversionParameterListType parameters);
+  bool CreateRepresentation(vtkSegmentationConversionPath* path,
+    vtkSegmentationConversionParameters* parameters);
 
   /// Removes a representation from all segments if present
   void RemoveRepresentation(const std::string& representationName);
@@ -447,7 +448,7 @@ public:
 
   /// Get all possible conversions between the master representation and a specified target representation
   void GetPossibleConversions(const std::string& targetRepresentationName,
-    vtkSegmentationConverter::ConversionPathAndCostListType &pathsCosts);
+    vtkSegmentationConversionPaths* paths);
 
   /// Set a conversion parameter to all rules having this parameter
   void SetConversionParameter(const std::string& name, const std::string& value) { this->Converter->SetConversionParameter(name, value); };
@@ -457,8 +458,8 @@ public:
   std::string GetConversionParameter(const std::string& name) { return this->Converter->GetConversionParameter(name); };
 
   /// Get names of all conversion parameters used by the selected conversion path
-  void GetConversionParametersForPath(vtkSegmentationConverterRule::ConversionParameterListType& conversionParameters,
-    const vtkSegmentationConverter::ConversionPathType& path) { this->Converter->GetConversionParametersForPath(conversionParameters, path); };
+  void GetConversionParametersForPath(vtkSegmentationConversionParameters* conversionParameters,
+    vtkSegmentationConversionPath* path) { this->Converter->GetConversionParametersForPath(conversionParameters, path); };
 
   /// Serialize all conversion parameters.
   /// The resulting string can be parsed in a segmentation object using /sa DeserializeConversionParameters
@@ -483,7 +484,7 @@ public:
     std::map<vtkDataObject*, vtkDataObject*>& cachedRepresentations);
 
 protected:
-  bool ConvertSegmentsUsingPath(std::vector<std::string> segmentIDs, vtkSegmentationConverter::ConversionPathType path, bool overwriteExisting = false);
+  bool ConvertSegmentsUsingPath(std::vector<std::string> segmentIDs, vtkSegmentationConversionPath* path, bool overwriteExisting = false);
 
   /// Convert given segment along a specified path
   /// \param segment Segment to convert
@@ -491,7 +492,7 @@ protected:
   /// \param overwriteExisting If true then do each conversion step regardless the target representation
   ///   exists. If false then skip those conversion steps that would overwrite existing representation
   /// \return Success flag
-  bool ConvertSegmentUsingPath(vtkSegment* segment, vtkSegmentationConverter::ConversionPathType path, bool overwriteExisting = false);
+  bool ConvertSegmentUsingPath(vtkSegment* segment, vtkSegmentationConversionPath* path, bool overwriteExisting = false);
 
   /// Converts a single segment to a representation.
   bool ConvertSingleSegment(std::string segmentId, std::string targetRepresentationName);

--- a/Libs/vtkSegmentationCore/vtkSegmentationConversionParameters.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConversionParameters.cxx
@@ -1,0 +1,266 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// SegmentationCore includes
+#include "vtkSegmentationConversionParameters.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+#include <vtkVariant.h>
+
+//----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkSegmentationConversionParameters);
+
+//----------------------------------------------------------------------------
+vtkSegmentationConversionParameters::vtkSegmentationConversionParameters()
+{
+}
+
+//----------------------------------------------------------------------------
+vtkSegmentationConversionParameters::~vtkSegmentationConversionParameters()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::PrintSelf(ostream& os, vtkIndent indent)
+{
+  for (const ConversionParameterType& parameter : this->ParameterList)
+    {
+    os << indent << parameter.Name << ": " << parameter.Value
+      << "  (" << parameter.Description << ")\n";
+    }
+}
+
+//----------------------------------------------------------------------------
+std::string vtkSegmentationConversionParameters::GetName(int index)
+{
+  if (index < 0 || index >= this->GetNumberOfParameters())
+    {
+    return "";
+    }
+  return this->ParameterList[index].Name;
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::SetName(int index, const std::string& name) VTK_EXPECTS(0 <= index && index < GetNumberOfParameters())
+{
+  if (index < 0 || index >= this->GetNumberOfParameters())
+    {
+    vtkErrorMacro("SetName failed: invalid index");
+    return;
+    }
+  this->ParameterList[index].Name = name;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkSegmentationConversionParameters::GetDescription(int index)
+{
+  if (index < 0 || index >= this->GetNumberOfParameters())
+    {
+    return "";
+    }
+  return this->ParameterList[index].Description;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkSegmentationConversionParameters::GetDescription(const std::string& name)
+{
+  int index = this->GetIndexFromName(name);
+  if (index < 0)
+    {
+    return "";
+    }
+  else
+    {
+    return this->ParameterList[index].Description;
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::SetDescription(int index, const std::string& description)
+{
+  if (index < 0 || index >= this->GetNumberOfParameters())
+    {
+    vtkErrorMacro("SetDescription failed: invalid index");
+    return;
+    }
+  this->ParameterList[index].Description = description;
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::SetDescription(const std::string& name, const std::string& description)
+{
+  int index = this->GetIndexFromName(name);
+  if (index < 0)
+    {
+    ConversionParameterType parameter;
+    parameter.Name = name;
+    parameter.Description = description;
+    this->ParameterList.push_back(parameter);
+    }
+  else
+    {
+    this->ParameterList[index].Description = description;
+    }
+}
+
+//----------------------------------------------------------------------------
+std::string vtkSegmentationConversionParameters::GetValue(int index)
+{
+  if (index < 0 || index >= this->GetNumberOfParameters())
+    {
+    return "";
+    }
+  return this->ParameterList[index].Value;
+}
+
+//----------------------------------------------------------------------------
+double vtkSegmentationConversionParameters::GetValueAsDouble(const std::string& name)
+{
+  double value = vtkVariant(this->GetValue(name)).ToDouble();
+  return value;
+}
+
+//----------------------------------------------------------------------------
+int vtkSegmentationConversionParameters::GetValueAsInt(const std::string& name)
+{
+  double value = vtkVariant(this->GetValue(name)).ToInt();
+  return value;
+}
+
+//----------------------------------------------------------------------------
+std::string vtkSegmentationConversionParameters::GetValue(const std::string& name)
+{
+  int index = this->GetIndexFromName(name);
+  if (index < 0)
+    {
+    return "";
+    }
+  else
+    {
+    return this->ParameterList[index].Value;
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::SetValue(int index, const std::string& value)
+{
+  if (index < 0 || index >= this->GetNumberOfParameters())
+    {
+    vtkErrorMacro("SetValue failed: invalid index");
+    return;
+    }
+  this->ParameterList[index].Value = value;
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::SetValue(const std::string& name, const std::string& value)
+{
+  int index = this->GetIndexFromName(name);
+  if (index < 0)
+    {
+    ConversionParameterType parameter;
+    parameter.Name = name;
+    parameter.Value = value;
+    this->ParameterList.push_back(parameter);
+    }
+  else
+    {
+    this->ParameterList[index].Value = value;
+    }
+}
+
+//----------------------------------------------------------------------------
+int vtkSegmentationConversionParameters::GetIndexFromName(const std::string name)
+{
+  int index = 0;
+  for (const ConversionParameterType& parameter : ParameterList)
+    {
+    if (parameter.Name == name)
+      {
+      return index;
+      }
+    index += 1;
+    }
+  return -1;
+}
+
+//----------------------------------------------------------------------------
+int vtkSegmentationConversionParameters::GetNumberOfParameters()
+{
+  return this->ParameterList.size();
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::RemoveAllParameters()
+{
+  this->ParameterList.clear();
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::RemoveParameter(int index)
+{
+  if (index < 0 || index >= this->GetNumberOfParameters())
+    {
+    vtkErrorMacro("RemoveParameter failed: invalid index");
+    return;
+    }
+  this->ParameterList.erase(this->ParameterList.begin()+index);
+}
+
+//----------------------------------------------------------------------------
+int vtkSegmentationConversionParameters::SetParameter(const std::string& name,
+  const std::string& value, const std::string& description/*=""*/)
+{
+  int parameterIndex = this->GetIndexFromName(name);
+  if (parameterIndex < 0)
+    {
+    ConversionParameterType newParameter;
+    this->ParameterList.push_back(newParameter);
+    parameterIndex = this->ParameterList.size() - 1;
+    }
+  ConversionParameterType parameter;
+  parameter.Name = name;
+  parameter.Value = value;
+  parameter.Description = description;
+  this->ParameterList[parameterIndex] = parameter;
+  return parameterIndex;
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::DeepCopy(vtkSegmentationConversionParameters* source)
+{
+  if (!source)
+    {
+    vtkErrorMacro("DeepCopy failed: invalid source object");
+    return;
+    }
+  this->ParameterList = source->ParameterList;
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionParameters::CopyParameter(vtkSegmentationConversionParameters* source, int sourceIndex)
+{
+  if (!source || sourceIndex < 0 || sourceIndex >= source->GetNumberOfParameters())
+    {
+    vtkErrorMacro("DeepCopy failed: invalid source object or index");
+    return;
+    }
+  this->SetParameter(
+    source->ParameterList[sourceIndex].Name,
+    source->ParameterList[sourceIndex].Value,
+    source->ParameterList[sourceIndex].Description);
+}

--- a/Libs/vtkSegmentationCore/vtkSegmentationConversionParameters.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConversionParameters.h
@@ -1,0 +1,108 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkSegmentationConversionParameters_h
+#define __vtkSegmentationConversionParameters_h
+
+// VTK includes
+#include <vtkObject.h>
+
+// STD includes
+#include <vector>
+
+// Segmentation includes
+#include "vtkSegmentationCoreConfigure.h"
+
+/// \ingroup SegmentationCore
+/// \brief Store a list of conversion parameters.
+/// \details
+/// Stores properties, such as name, description (that may be displayed
+/// as tooltip in the GUI) and value (current value or default value)
+/// of multiple segmentation conversion parameters.
+class vtkSegmentationCore_EXPORT vtkSegmentationConversionParameters : public vtkObject
+{
+public:
+  static vtkSegmentationConversionParameters* New();
+  vtkTypeMacro(vtkSegmentationConversionParameters, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// @{
+  /// Get/Set parameter name
+  std::string GetName(int index) VTK_EXPECTS(0 <= index && index < GetNumberOfParameters());
+  void SetName(int index, const std::string& name) VTK_EXPECTS(0 <= index && index < GetNumberOfParameters());
+  /// @}
+
+  /// @{
+  /// Get/Set parameter description
+  std::string GetDescription(int index) VTK_EXPECTS(0 <= index && index < GetNumberOfParameters());
+  std::string GetDescription(const std::string& name);
+  void SetDescription(int index, const std::string& description) VTK_EXPECTS(0 <= index && index < GetNumberOfParameters());
+  void SetDescription(const std::string& name, const std::string& description);
+  /// @}
+
+  /// @{
+  /// Get/Set parameter default value
+  std::string GetValue(int index) VTK_EXPECTS(0 <= index && index < GetNumberOfParameters());
+  std::string GetValue(const std::string& name);
+  double GetValueAsDouble(const std::string& name);
+  int GetValueAsInt(const std::string& name);
+  void SetValue(int index, const std::string& value) VTK_EXPECTS(0 <= index && index < GetNumberOfParameters());
+  void SetValue(const std::string& name, const std::string& value);
+  /// @}
+
+  /// Get parameter index from name.
+  /// Returns -1 if parameter is not found.
+  int GetIndexFromName(const std::string name);
+
+  /// Return number of parameters
+  int GetNumberOfParameters();
+
+  /// Delete all parameters
+  void RemoveAllParameters();
+
+  /// Delete parameter
+  void RemoveParameter(int index) VTK_EXPECTS(0 <= index && index < GetNumberOfParameters());
+
+  /// Set a conversion parameter
+  int SetParameter(const std::string& name, const std::string& value, const std::string& description = "");
+
+  /// Replace parameters with content of another parameter list
+  void DeepCopy(vtkSegmentationConversionParameters* source);
+
+  /// Replace parameters with content of another parameter list
+  void CopyParameter(vtkSegmentationConversionParameters* source, int sourceIndex);
+
+protected:
+
+  struct ConversionParameterType
+    {
+    std::string Name;
+    std::string Description;
+    std::string Value;
+    };
+
+  std::vector<ConversionParameterType> ParameterList;
+
+protected:
+  vtkSegmentationConversionParameters();
+  ~vtkSegmentationConversionParameters() override;
+
+private:
+  vtkSegmentationConversionParameters(const vtkSegmentationConversionParameters&) = delete;
+  void operator=(const vtkSegmentationConversionParameters&) = delete;
+};
+
+#endif // __vtkSegment_h

--- a/Libs/vtkSegmentationCore/vtkSegmentationConversionPath.cxx
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConversionPath.cxx
@@ -1,0 +1,142 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// SegmentationCore includes
+#include "vtkSegmentationConversionPath.h"
+#include "vtkSegmentationConverterRule.h"
+
+// VTK includes
+#include <vtkObjectFactory.h>
+#include <vtkSmartPointer.h>
+#include <vtkVariant.h>
+
+//----------------------------------------------------------------------------
+vtkStandardNewMacro(vtkSegmentationConversionPath);
+vtkStandardNewMacro(vtkSegmentationConversionPaths);
+
+//----------------------------------------------------------------------------
+vtkSegmentationConversionPath::vtkSegmentationConversionPath()
+{
+}
+
+//----------------------------------------------------------------------------
+vtkSegmentationConversionPath::~vtkSegmentationConversionPath()
+{
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionPath::PrintSelf(ostream& os, vtkIndent indent)
+{
+  os << indent << "Cost: " << this->GetCost() << "\n";
+  for (const vtkSmartPointer<vtkSegmentationConverterRule>& rule : this->Rules)
+    {
+    os << indent << "Rule:\n";
+    rule->PrintSelf(os, indent.GetNextIndent());
+    }
+}
+
+//----------------------------------------------------------------------------
+int vtkSegmentationConversionPath::GetNumberOfRules()
+{
+  return this->Rules.size();
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionPath::RemoveAllRules()
+{
+  this->Rules.clear();
+}
+
+//----------------------------------------------------------------------------
+vtkSegmentationConverterRule* vtkSegmentationConversionPath::GetRule(int index)
+{
+  if (index < 0 || index >= this->GetNumberOfRules())
+    {
+    vtkErrorMacro("GetRule failed: invalid index: " << index);
+    return nullptr;
+    }
+  return this->Rules[index].GetPointer();
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionPath::RemoveRule(int index)
+{
+  if (index < 0 || index >= this->GetNumberOfRules())
+    {
+    vtkErrorMacro("RemoveRule failed: invalid index: " << index);
+    return;
+    }
+  this->Rules.erase(this->Rules.begin()+index);
+}
+
+//----------------------------------------------------------------------------
+int vtkSegmentationConversionPath::AddRule(vtkSegmentationConverterRule* rule)
+{
+  this->Rules.push_back(rule);
+  return this->GetNumberOfRules() - 1;
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionPath::AddRules(vtkSegmentationConversionPath* path)
+{
+  int numberOfRules = path->GetNumberOfRules();
+  for (int ruleIndex = 0; ruleIndex < numberOfRules; ++ruleIndex)
+    {
+    this->AddRule(path->GetRule(ruleIndex));
+    }
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionPath::Copy(vtkSegmentationConversionPath* source)
+{
+  if (!source)
+    {
+    vtkErrorMacro("DeepCopy failed: invalid source object");
+    return;
+    }
+  this->Rules = source->Rules;
+}
+
+//----------------------------------------------------------------------------
+unsigned int vtkSegmentationConversionPath::GetCost()
+{
+  unsigned int cost = 0;
+  for (const vtkSmartPointer<vtkSegmentationConverterRule>& rule : this->Rules)
+    {
+    cost += rule->GetConversionCost();
+    }
+  return cost;
+}
+
+//----------------------------------------------------------------------------
+void vtkSegmentationConversionPaths::PrintSelf(ostream& os, vtkIndent indent)
+{
+  this->Superclass::PrintSelf(os, indent);
+
+  vtkSegmentationConversionPath* path = nullptr;
+  vtkCollectionSimpleIterator it;
+  for (this->InitTraversal(it); (path = this->GetNextPath(it));)
+    {
+    os << indent << "Path:\n";
+    path->PrintSelf(os, indent.GetNextIndent());
+    }
+}
+
+//----------------------------------------------------------------------------
+vtkSegmentationConversionPath* vtkSegmentationConversionPaths::GetNextPath(vtkCollectionSimpleIterator& cookie)
+{
+  return vtkSegmentationConversionPath::SafeDownCast(this->GetNextItemAsObject(cookie));
+}

--- a/Libs/vtkSegmentationCore/vtkSegmentationConversionPath.h
+++ b/Libs/vtkSegmentationCore/vtkSegmentationConversionPath.h
@@ -1,0 +1,150 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __vtkSegmentationConversionPath_h
+#define __vtkSegmentationConversionPath_h
+
+// VTK includes
+#include <vtkCollection.h>
+#include <vtkObject.h>
+
+// STD includes
+#include <vector>
+
+// Segmentation includes
+#include "vtkSegmentationCoreConfigure.h"
+
+class vtkSegmentationConverterRule;
+
+/// \ingroup SegmentationCore
+/// \brief Store a segmentation conversion path.
+/// \details
+/// Stores conversion path as a list of conversion rules and their parameters.
+class vtkSegmentationCore_EXPORT vtkSegmentationConversionPath : public vtkObject
+{
+public:
+  static vtkSegmentationConversionPath* New();
+  vtkTypeMacro(vtkSegmentationConversionPath, vtkObject);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Get conversion "cost". The lower the cost is the better (faster computation,
+  /// higher accuracy, etc). The cost can be used to choose the best conversion paths
+  /// when multiple paths are available.
+  unsigned int GetCost();
+
+  /// Add a rule to the end of the rule list. Return the index of this rule.
+  int AddRule(vtkSegmentationConverterRule* rule);
+
+  /// Concatenate all rules in "path" and to this conversion path.
+  void AddRules(vtkSegmentationConversionPath* path);
+
+  /// Return number of rules that make up this conversion path.
+  int GetNumberOfRules();
+
+  /// Get index-th rule.
+  vtkSegmentationConverterRule* GetRule(int index) VTK_EXPECTS(0 <= index && index < GetNumberOfRules());
+
+  /// Remove index-th rule.
+  void RemoveRule(int index) VTK_EXPECTS(0 <= index && index < GetNumberOfRules());
+
+  /// Remove all rules from this path.
+  void RemoveAllRules();
+
+  /// Replace paths with content of the source path.
+  /// The rules are shallow-copied.
+  void Copy(vtkSegmentationConversionPath* source);
+
+protected:
+
+  std::vector< vtkSmartPointer<vtkSegmentationConverterRule> > Rules;
+
+protected:
+  vtkSegmentationConversionPath();
+  ~vtkSegmentationConversionPath() override;
+
+private:
+  vtkSegmentationConversionPath(const vtkSegmentationConversionPath&) = delete;
+  void operator=(const vtkSegmentationConversionPath&) = delete;
+};
+
+
+/// \ingroup SegmentationCore
+/// \brief Store multiple segmentation conversion paths.
+/// \details
+/// Stores multiple conversion paths, each defined by a list of segmentation conversion rules.
+class vtkSegmentationCore_EXPORT vtkSegmentationConversionPaths : public vtkCollection
+{
+public:
+  vtkTypeMacro(vtkSegmentationConversionPaths, vtkCollection);
+  static vtkSegmentationConversionPaths* New();
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  /// Add a path to the list.
+  void AddPath(vtkSegmentationConversionPath*);
+
+  /// Add paths to the list.
+  void AddPaths(vtkSegmentationConversionPaths*);
+
+  /// Get the next path in the list.
+  vtkSegmentationConversionPath* GetNextPath();
+
+  /// Get the index-th path the list.
+  vtkSegmentationConversionPath* GetPath(int index) { return vtkSegmentationConversionPath::SafeDownCast(this->GetItemAsObject(index)); }
+
+  /// Reentrant safe way to get an object in a collection. Just pass the
+  /// same cookie back and forth.
+  vtkSegmentationConversionPath* GetNextPath(vtkCollectionSimpleIterator& cookie);
+
+  /// Get number of conversion paths stored in the collection.
+  int GetNumberOfPaths() { return this->GetNumberOfItems(); };
+
+protected:
+  vtkSegmentationConversionPaths() = default;
+  ~vtkSegmentationConversionPaths() override = default;
+
+private:
+  // hide the standard AddItem from the user and the compiler.
+  void AddItem(vtkObject* o) { this->vtkCollection::AddItem(o); }
+
+private:
+  vtkSegmentationConversionPaths(const vtkSegmentationConversionPaths&) = delete;
+  void operator=(const vtkSegmentationConversionPaths&) = delete;
+};
+
+//----------------------------------------------------------------------------
+inline void vtkSegmentationConversionPaths::AddPath(vtkSegmentationConversionPath* f)
+{
+  this->vtkCollection::AddItem(f);
+}
+
+//----------------------------------------------------------------------------
+inline void vtkSegmentationConversionPaths::AddPaths(vtkSegmentationConversionPaths* paths)
+{
+  vtkSegmentationConversionPath* path = nullptr;
+  vtkCollectionSimpleIterator it;
+  for (paths->InitTraversal(it); (path = paths->GetNextPath(it));)
+    {
+    this->AddItem(path);
+    }
+}
+
+//----------------------------------------------------------------------------
+inline vtkSegmentationConversionPath* vtkSegmentationConversionPaths::GetNextPath()
+{
+  return static_cast<vtkSegmentationConversionPath*>(this->GetNextItemAsObject());
+}
+
+#endif // __vtkSegment_h

--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -1910,12 +1910,12 @@ bool vtkSlicerSegmentationsModuleLogic::SetBinaryLabelmapToSegment(
       std::string targetRepresentationName = (*reprIt);
       if (targetRepresentationName.compare(vtkSegmentationConverter::GetSegmentationBinaryLabelmapRepresentationName()))
         {
-        vtkSegmentationConverter::ConversionPathAndCostListType pathCosts;
-        segmentation->GetPossibleConversions(targetRepresentationName, pathCosts);
+        vtkNew<vtkSegmentationConversionPaths> paths;
+        segmentation->GetPossibleConversions(targetRepresentationName, paths);
 
         // Get cheapest path from found conversion paths
-        vtkSegmentationConverter::ConversionPathType cheapestPath = vtkSegmentationConverter::GetCheapestPath(pathCosts);
-        if (cheapestPath.empty())
+        vtkSegmentationConversionPath* cheapestPath = vtkSegmentationConverter::GetCheapestPath(paths);
+        if (!cheapestPath)
           {
           continue;
           }
@@ -2647,12 +2647,12 @@ bool vtkSlicerSegmentationsModuleLogic::ReconvertAllRepresentations(vtkMRMLSegme
     std::string targetRepresentationName = (*reprIt);
     if (targetRepresentationName.compare(segmentation->MasterRepresentationName))
       {
-      vtkSegmentationConverter::ConversionPathAndCostListType pathCosts;
-      segmentation->GetPossibleConversions(targetRepresentationName, pathCosts);
+      vtkNew<vtkSegmentationConversionPaths> paths;
+      segmentation->GetPossibleConversions(targetRepresentationName, paths);
 
       // Get cheapest path from found conversion paths
-      vtkSegmentationConverter::ConversionPathType cheapestPath = vtkSegmentationConverter::GetCheapestPath(pathCosts);
-      if (!cheapestPath.empty())
+      vtkSegmentationConversionPath* cheapestPath = vtkSegmentationConverter::GetCheapestPath(paths);
+      if (cheapestPath)
         {
         conversionHappened |= segmentationNode->GetSegmentation()->ConvertSegmentsUsingPath(segmentIDsToConvert, cheapestPath, true);
         }

--- a/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationConversionParametersWidget.h
+++ b/Modules/Loadable/Segmentations/Widgets/qMRMLSegmentationConversionParametersWidget.h
@@ -61,10 +61,11 @@ public:
   QString targetRepresentationName();
 
   /// Return selected path
-  vtkSegmentationConverter::ConversionPathType selectedPath();
+  vtkSegmentationConversionPath* selectedPath();
 
-  /// Return chosen conversion parameters
-  vtkSegmentationConverterRule::ConversionParameterListType conversionParameters();
+  /// Get chosen conversion parameters.
+  /// Always returns a valid object.
+  vtkSegmentationConversionParameters* conversionParameters();
 
 signals:
   /// Emitted when conversion is done

--- a/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesReader.cxx
@@ -166,7 +166,9 @@ bool qSlicerVolumesReader::load(const IOProperties& properties)
       }
     }
   Q_ASSERT(d->Logic);
-  vtkMRMLVolumeNode* node = d->Logic->AddArchetypeVolume(
+  // Weak pointer is used because the node may be deleted if the scene is closed
+  // right after reading.
+  vtkWeakPointer<vtkMRMLVolumeNode> node = d->Logic->AddArchetypeVolume(
     fileName.toUtf8(),
     name.toUtf8(),
     options,


### PR DESCRIPTION
Previously, complex STL containers were used that were not Python-wrappable. Now conversion paths and parameters are all VTK objects.
This allows converting segmentations using a custom path, when there are multiple conversion paths are available.
For example, multiple conversion paths are available after installing SlicerRT extension, which provides additional segment representations and conversion rules.