### PR TITLE
ENH: Reorder favorite modules by drag-and-drop

### DIFF
--- a/Base/QTApp/qSlicerMainWindow.h
+++ b/Base/QTApp/qSlicerMainWindow.h
@@ -138,6 +138,9 @@ public slots:
 
   virtual void addFileToRecentFiles(const qSlicerIO::IOProperties& fileProperties);
 
+  /// Refresh favorite modules toolbar from application settings
+  virtual void on_FavoriteModulesChanged();
+
 signals:
   /// Emitted when the window is first shown to the user.
   /// \sa showEvent(QShowEvent *)

--- a/Base/QTApp/qSlicerMainWindow_p.h
+++ b/Base/QTApp/qSlicerMainWindow_p.h
@@ -66,6 +66,9 @@ public:
 
   void updatePythonConsolePalette();
 
+  // Add module action to the favorite modules toolbar
+  void addFavoriteModule(const QString& moduleName);
+
 #ifdef Slicer_USE_PYTHONQT
   QDockWidget*                    PythonConsoleDockWidget;
   QAction*                        PythonConsoleToggleViewAction;

--- a/Base/QTGUI/Resources/UI/qSlicerSettingsModulesPanel.ui
+++ b/Base/QTGUI/Resources/UI/qSlicerSettingsModulesPanel.ui
@@ -235,7 +235,11 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Additional module paths:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;(drag-and-drop&lt;br/&gt;files or folders)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
+&lt;p&gt;Additional module paths:&lt;/p&gt;
+&lt;p style=&quot;margin-left: 10px;&quot;&gt;&lt;span style=&quot; font-size:small; font-style:italic;&quot;&gt;Drag &amp;amp; drop files or folders&lt;br/&gt;from File Explorer&lt;/span&gt;&lt;/p&gt;
+&lt;/body&gt;&lt;/html&gt;
+</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -672,7 +676,7 @@
       <string>Add to the list by dragging modules from the above &quot;Modules&quot; list. Note: modules with no icons will not appear in the toolbar.</string>
      </property>
      <property name="text">
-      <string>Favorite Modules:&lt;br&gt;&lt;small&gt;&lt;i&gt;Drag &amp;amp; drop from &lt;/i&gt;Modules&lt;i&gt; list&lt;/i&gt;&lt;/small&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Favorite Modules:&lt;/p&gt;&lt;p style=&quot;margin-left: 10px;&quot;&gt;&lt;span style=&quot; font-size:small; font-style:italic;&quot;&gt;Drag &amp;amp; drop modules&lt;br/&gt;from &lt;/span&gt;&lt;span style=&quot; font-size:small;&quot;&gt;Modules&lt;/span&gt;&lt;span style=&quot; font-size:small; font-style:italic;&quot;&gt; list&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -791,7 +795,7 @@
       <item>
        <widget class="ctkExpandButton" name="FavoritesMoreButton">
         <property name="checked">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="mirrorOnExpand">
          <bool>true</bool>
@@ -856,8 +860,8 @@
    <slot>setVisible(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>451</x>
-     <y>217</y>
+     <x>525</x>
+     <y>267</y>
     </hint>
     <hint type="destinationlabel">
      <x>438</x>
@@ -872,12 +876,28 @@
    <slot>setVisible(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>449</x>
-     <y>261</y>
+     <x>525</x>
+     <y>482</y>
     </hint>
     <hint type="destinationlabel">
-     <x>391</x>
-     <y>229</y>
+     <x>507</x>
+     <y>482</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>FavoritesMoreButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>FavoritesMoreGroupBox</receiver>
+   <slot>setVisible(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>520</x>
+     <y>545</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>389</x>
+     <y>527</y>
     </hint>
    </hints>
   </connection>

--- a/Base/QTGUI/qSlicerApplication.cxx
+++ b/Base/QTGUI/qSlicerApplication.cxx
@@ -752,6 +752,16 @@ void qSlicerApplication::openSettingsDialog(const QString& settingsPanel/*=QStri
     Qt::WindowFlags windowFlags = d->SettingsDialog->windowFlags();
     d->SettingsDialog->setParent(this->mainWindow());
     d->SettingsDialog->setWindowFlags(windowFlags);
+
+    // Make favorite module list changes update the module toolbar immediately
+    // (without application restart).
+    ctkSettingsPanel* settingsModulesPanel = d->SettingsDialog->panel(qSlicerApplication::tr("Modules"));
+    if (settingsModulesPanel)
+      {
+      QObject::connect(settingsModulesPanel, SIGNAL(favoriteModulesChanged()),
+        this->mainWindow(), SLOT(on_FavoriteModulesChanged()));
+      }
+
     }
 
   // Reload settings to apply any changes that have been made outside of the

--- a/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
+++ b/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
@@ -367,14 +367,9 @@ bool qSlicerModuleFactoryFilterModel::dropMimeData(const QMimeData *data, Qt::Dr
   // check if the format is supported
   QString format = QLatin1String("application/x-qstandarditemmodeldatalist");
   if (!data->hasFormat(format))
+    {
     return QAbstractItemModel::dropMimeData(data, action, row, column, parent);
-
-  if (row > rowCount(parent))
-    row = rowCount(parent);
-  if (row == -1)
-    row = rowCount(parent);
-  if (column == -1)
-    column = 0;
+    }
 
   // decode and insert
   QByteArray encoded = data->data(format);
@@ -405,11 +400,29 @@ bool qSlicerModuleFactoryFilterModel::dropMimeData(const QMimeData *data, Qt::Dr
     bottom = qMax(r, bottom);
     right = qMax(c, right);
     }
+
   QStringList newShowModules = this->showModules();
+
+  // Determine where to insert
+  int insertionPosition = parent.row();
+  if (insertionPosition > newShowModules.size())
+    {
+    insertionPosition = newShowModules.size();
+    }
+  else if (insertionPosition < 0)
+    {
+    insertionPosition = 0;
+    }
+
+  // Insert new items
   foreach(QStandardItem* item, items)
     {
-    newShowModules << item->data(Qt::UserRole).toString();
+    QString moduleName = item->data(Qt::UserRole).toString();
+    newShowModules.removeAll(moduleName);
+    newShowModules.insert(insertionPosition, moduleName);
+    insertionPosition++;
     }
+
   newShowModules.removeDuplicates();
   this->setShowModules(newShowModules);
   return true;

--- a/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsModulesPanel.cxx
@@ -126,6 +126,8 @@ void qSlicerSettingsModulesPanelPrivate::init()
 
   this->ModulesMenu->setCurrentModule(Slicer_DEFAULT_HOME_MODULE);
 
+  // Allow reordering of favorite modules by drag-and-drop within the favorite modules list
+  this->FavoritesModulesListView->filterModel()->setDynamicSortFilter(false);
   // Slicer_DEFAULT_FAVORITE_MODULES contains module names in a comma-separated list
   // (chosen this format because the same format is used for storing the favorites list in the .ini file).
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
@@ -160,6 +162,11 @@ void qSlicerSettingsModulesPanelPrivate::init()
                       "currentModule", SIGNAL(currentModuleChanged(QString)));
   q->registerProperty("Modules/FavoriteModules", this->FavoritesModulesListView->filterModel(),
                       "showModules", SIGNAL(showModulesChanged(QStringList)));
+  // Emit signal when favorite modules are updated to allow immediate update of the application GUI
+  // (e.g., favorite module toolbar)
+  QObject::connect(this->FavoritesModulesListView->filterModel(), SIGNAL(showModulesChanged(QStringList)),
+    q, SIGNAL(favoriteModulesChanged()));
+
   qSlicerRelativePathMapper* relativePathMapper = new qSlicerRelativePathMapper(
     this->TemporaryDirectoryButton, "directory", SIGNAL(directoryChanged(QString)));
   q->registerProperty("TemporaryPath", relativePathMapper,

--- a/Base/QTGUI/qSlicerSettingsModulesPanel.h
+++ b/Base/QTGUI/qSlicerSettingsModulesPanel.h
@@ -84,6 +84,8 @@ protected slots:
 
 signals:
   void modulesToAlwaysIgnoreChanged(const QStringList& modulesNames);
+  /// Emitted when list of favorite modules have changed
+  void favoriteModulesChanged();
 
 protected:
   QScopedPointer<qSlicerSettingsModulesPanelPrivate> d_ptr;


### PR DESCRIPTION
Favorite modules (in Application settings / Modules) can now be reordered by drag-and-drop.
When a module is drag-and-dropped into the favorite list, the drop position is used (instead of adding the module to the end of the list).
Adding/removing/reordering a module shortcut takes effect immediately (no need to restart the application).

fixes #6511
fixes #6510