### PR TITLE
STYLE: Replace (*p).member with p->member

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogicRequests.h
+++ b/Base/Logic/vtkSlicerApplicationLogicRequests.h
@@ -301,8 +301,8 @@ public:
 
     while (sit != m_SourceNodes.end())
       {
-      vtkMRMLNode *source = miniscene->GetNodeByID((*sit).c_str());
-      vtkMRMLNode *target = appLogic->GetMRMLScene()->GetNodeByID( (*tit).c_str() );
+      vtkMRMLNode *source = miniscene->GetNodeByID(sit->c_str());
+      vtkMRMLNode *target = appLogic->GetMRMLScene()->GetNodeByID( tit->c_str() );
 
       if (source && target)
         {

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -143,9 +143,9 @@ void vtkMRMLCommandLineModuleNode::WriteXML(ostream& of, int nIndent)
     {
     // iterate over each parameter in this group
     std::vector<ModuleParameter>::const_iterator pbeginit
-      = (*pgit).GetParameters().begin();
+      = pgit->GetParameters().begin();
     std::vector<ModuleParameter>::const_iterator pendit
-      = (*pgit).GetParameters().end();
+      = pgit->GetParameters().end();
     std::vector<ModuleParameter>::const_iterator pit;
 
     for (pit = pbeginit; pit != pendit; ++pit)
@@ -153,8 +153,8 @@ void vtkMRMLCommandLineModuleNode::WriteXML(ostream& of, int nIndent)
       // two calls, as the mrml node method saves the new string in a member
       // variable and it was getting over written when used twice before the
       // buffer was flushed.
-      of << " " << this->URLEncodeString ( (*pit).GetName().c_str() );
-      of  << "=\"" << this->URLEncodeString ( (*pit).GetValue().c_str() ) << "\"";
+      of << " " << this->URLEncodeString ( pit->GetName().c_str() );
+      of  << "=\"" << this->URLEncodeString ( pit->GetValue().c_str() ) << "\"";
       }
     }
 
@@ -287,11 +287,11 @@ void vtkMRMLCommandLineModuleNode::PrintSelf(ostream& os, vtkIndent indent)
   std::vector<ModuleParameterGroup>::const_iterator pgendit = this->GetModuleDescription().GetParameterGroups().end();
   for (std::vector<ModuleParameterGroup>::const_iterator pgit = pgbeginit; pgit != pgendit; ++pgit)
     {
-    std::vector<ModuleParameter>::const_iterator pbeginit = (*pgit).GetParameters().begin();
-    std::vector<ModuleParameter>::const_iterator pendit = (*pgit).GetParameters().end();
+    std::vector<ModuleParameter>::const_iterator pbeginit = pgit->GetParameters().begin();
+    std::vector<ModuleParameter>::const_iterator pendit = pgit->GetParameters().end();
     for (std::vector<ModuleParameter>::const_iterator pit = pbeginit; pit != pendit; ++pit)
       {
-      os << indent << " " << (*pit).GetName() << " = " << (*pit).GetValue() << "\n";
+      os << indent << " " << pit->GetName() << " = " << pit->GetValue() << "\n";
       }
     }
 }
@@ -699,7 +699,7 @@ const char* vtkMRMLCommandLineModuleNode::GetRegisteredModuleNameByIndex( int id
   int count = 0;
   while ( mit != vtkInternal::RegisteredModules.end() )
     {
-    if ( count == idx ) { return (*mit).first.c_str(); }
+    if ( count == idx ) { return mit->first.c_str(); }
     ++mit;
     ++count;
     }
@@ -715,7 +715,7 @@ ModuleDescription vtkMRMLCommandLineModuleNode
 
   if (mit != vtkMRMLCommandLineModuleNode::vtkInternal::RegisteredModules.end())
     {
-    return (*mit).second;
+    return mit->second;
     }
 
   return ModuleDescription();

--- a/Libs/MRML/Core/Testing/vtkMRMLVolumeNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLVolumeNodeTest1.cxx
@@ -82,7 +82,7 @@ int vtkMRMLVolumeNodeTest1(int , char * [])
     {
     ijkToRAS->Identity();
     vtkMRMLVolumeNode::ComputeIJKToRASFromScanOrder(
-          (*it).c_str(), spacing, dimensions, /* centerImage= */ false,
+          it->c_str(), spacing, dimensions, /* centerImage= */ false,
           ijkToRAS.GetPointer());
 
     const char* computedScanOrder =

--- a/Libs/MRML/Core/vtkArchive.cxx
+++ b/Libs/MRML/Core/vtkArchive.cxx
@@ -448,8 +448,8 @@ bool vtkArchive::Zip(const char* zipFileName, const char* directoryToZip)
   sit = files.begin();
   while (sit != files.end() && success)
     {
-    vtkArchiveTools::Message("Zip: adding:", (*sit).c_str());
-    const char *fileName = (*sit).c_str();
+    vtkArchiveTools::Message("Zip: adding:", sit->c_str());
+    const char *fileName = sit->c_str();
     ++sit;
 
     //
@@ -481,7 +481,7 @@ bool vtkArchive::Zip(const char* zipFileName, const char* directoryToZip)
     FILE *fd = fopen(fileName, "rb");
     if (!fd)
       {
-      vtkArchiveTools::Error("Zip: cannot open input file:", (*sit).c_str());
+      vtkArchiveTools::Error("Zip: cannot open input file:", sit->c_str());
       success = false;
       }
     else

--- a/Libs/MRML/Core/vtkDataFileFormatHelper.cxx
+++ b/Libs/MRML/Core/vtkDataFileFormatHelper.cxx
@@ -160,7 +160,7 @@ void vtkDataFileFormatHelper::PopulateITKSupportedWriteFileTypes()
         // Once we have the GetSupportedWriteGenericNames() ready, we will used that.
         // For now, just use the class name.
         ITKImageFileFormat structFileFormat =
-          {io->GetNameOfClass(), io->GetNameOfClass(), io->GetNameOfClass(),(*writeItr).c_str()};
+          {io->GetNameOfClass(), io->GetNameOfClass(), io->GetNameOfClass(), writeItr->c_str()};
         this->AddSupportedWriterFileFormat(structFileFormat);
         ++writeItr;
         }

--- a/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLNRRDStorageNode.cxx
@@ -288,7 +288,7 @@ int vtkMRMLNRRDStorageNode::ReadDataInternal(vtkMRMLNode *refNode)
   for ( std::vector<std::string>::iterator kit = keys.begin();
         kit != keys.end(); ++kit)
     {
-    volNode->SetAttribute((*kit).c_str(), reader->GetHeaderValue((*kit).c_str()));
+    volNode->SetAttribute(kit->c_str(), reader->GetHeaderValue(kit->c_str()));
     }
 
 
@@ -392,7 +392,7 @@ int vtkMRMLNRRDStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
   std::vector<std::string>::iterator ait = attributeNames.begin();
   for (; ait != attributeNames.end(); ++ait)
     {
-    writer->SetAttribute((*ait), volNode->GetAttribute((*ait).c_str()));
+    writer->SetAttribute((*ait), volNode->GetAttribute(ait->c_str()));
     }
 
   writer->Write();

--- a/Libs/MRML/Core/vtkMRMLSubjectHierarchyLegacyNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSubjectHierarchyLegacyNode.cxx
@@ -309,7 +309,7 @@ std::vector<vtkMRMLSubjectHierarchyLegacyNode*> vtkMRMLSubjectHierarchyLegacyNod
     if (referencedNodes.empty())
       {
       vtkMRMLSubjectHierarchyLegacyNode* node = vtkMRMLSubjectHierarchyLegacyNode::GetSubjectHierarchyLegacyNodeByUIDList(
-        scene, vtkMRMLSubjectHierarchyConstants::GetDICOMInstanceUIDName(), (*uidIt).c_str() );
+        scene, vtkMRMLSubjectHierarchyConstants::GetDICOMInstanceUIDName(), uidIt->c_str() );
       if (node)
         {
         referencedNodes.push_back(node);
@@ -335,7 +335,7 @@ std::vector<vtkMRMLSubjectHierarchyLegacyNode*> vtkMRMLSubjectHierarchyLegacyNod
       if (!foundUidInFoundReferencedNodes)
         {
         vtkMRMLSubjectHierarchyLegacyNode* node = vtkMRMLSubjectHierarchyLegacyNode::GetSubjectHierarchyLegacyNodeByUIDList(
-          scene, vtkMRMLSubjectHierarchyConstants::GetDICOMInstanceUIDName(), (*uidIt).c_str() );
+          scene, vtkMRMLSubjectHierarchyConstants::GetDICOMInstanceUIDName(), uidIt->c_str() );
         if (node)
           {
           referencedNodes.push_back(node);

--- a/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTransformStorageNode.cxx
@@ -172,7 +172,7 @@ int vtkMRMLTransformStorageNode::ReadFromITKv3BSplineTransformFile(vtkMRMLNode *
     {
     vtkWarningMacro(<< "More than two transform in the file: "<< fullName.c_str()<< ". Using only the first two transforms.");
     }
-  TransformListType::iterator it = (*transforms).begin();
+  TransformListType::iterator it = transforms->begin();
   TransformType::Pointer transform = (*it);
   if (!transform)
     {
@@ -181,7 +181,7 @@ int vtkMRMLTransformStorageNode::ReadFromITKv3BSplineTransformFile(vtkMRMLNode *
     }
   ++it;
   TransformType::Pointer transform2=nullptr;
-  if( it != (*transforms).end() )
+  if( it != transforms->end() )
     {
     transform2 = (*it);
     if (!transform2)
@@ -371,7 +371,7 @@ vtkAbstractTransform* ReadFromTransformFile(vtkObject* loggerObject, const std::
       for( typename ConstTransformListType::const_iterator it = transformList.begin();
         it != end; ++it )
         {
-        typename TransformType::Pointer transformComponentItk = const_cast< TransformType* >((*it).GetPointer());
+        typename TransformType::Pointer transformComponentItk = const_cast< TransformType* >(it->GetPointer());
         vtkAbstractTransform* transformComponent = vtkITKTransformConverter::CreateVTKTransformFromITK<T>(loggerObject, transformComponentItk);
         if (transformComponent!=nullptr)
           {

--- a/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLVolumeSequenceStorageNode.cxx
@@ -109,18 +109,18 @@ int vtkMRMLVolumeSequenceStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
 #ifdef NRRD_CHUNK_IO_AVAILABLE
     if (*kit == "axis 0 index type")
       {
-      volSequenceNode->SetIndexTypeFromString(reader->GetHeaderValue((*kit).c_str()));
+      volSequenceNode->SetIndexTypeFromString(reader->GetHeaderValue(kit->c_str()));
       frameAxis = 0;
       }
     else if (*kit == "axis 3 index type")
       {
-      volSequenceNode->SetIndexTypeFromString(reader->GetHeaderValue((*kit).c_str()));
+      volSequenceNode->SetIndexTypeFromString(reader->GetHeaderValue(kit->c_str()));
       frameAxis = 3;
       }
     else if (*kit == "axis 0 index values" || *kit == "axis 3 index values")
       {
       std::string indexValue;
-      for (std::istringstream indexValueList(reader->GetHeaderValue((*kit).c_str()));
+      for (std::istringstream indexValueList(reader->GetHeaderValue(kit->c_str()));
         indexValueList >> indexValue;)
         {
         // Encode string to make sure there are no spaces in the serialized index value (space is used as separator)
@@ -129,12 +129,12 @@ int vtkMRMLVolumeSequenceStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
 #else
     if (*kit == "axis 0 index type")
       {
-      volSequenceNode->SetIndexTypeFromString(reader->GetHeaderValue((*kit).c_str()));
+      volSequenceNode->SetIndexTypeFromString(reader->GetHeaderValue(kit->c_str()));
       }
     else if (*kit == "axis 0 index values")
       {
       std::string indexValue;
-      for (std::istringstream indexValueList(reader->GetHeaderValue((*kit).c_str()));
+      for (std::istringstream indexValueList(reader->GetHeaderValue(kit->c_str()));
         indexValueList >> indexValue;)
         {
         // Encode string to make sure there are no spaces in the serialized index value (space is used as separator)
@@ -144,7 +144,7 @@ int vtkMRMLVolumeSequenceStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
       }
     else
       {
-      volSequenceNode->SetAttribute((*kit).c_str(), reader->GetHeaderValue((*kit).c_str()));
+      volSequenceNode->SetAttribute(kit->c_str(), reader->GetHeaderValue(kit->c_str()));
       }
     }
 
@@ -491,7 +491,7 @@ int vtkMRMLVolumeSequenceStorageNode::WriteDataInternal(vtkMRMLNode *refNode)
   std::vector<std::string>::iterator ait = attributeNames.begin();
   for (; ait != attributeNames.end(); ++ait)
     {
-    writer->SetAttribute((*ait), volSequenceNode->GetAttribute((*ait).c_str()));
+    writer->SetAttribute((*ait), volSequenceNode->GetAttribute(ait->c_str()));
     }
 
 #ifdef NRRD_CHUNK_IO_AVAILABLE

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.cxx
@@ -351,7 +351,7 @@ vtkMRMLModelDisplayableManager::~vtkMRMLModelDisplayableManager()
   for (tit = this->Internal->DisplayNodeTransformFilters.begin();
        tit != this->Internal->DisplayNodeTransformFilters.end(); tit++ )
     {
-    vtkTransformFilter  *transformFilter = (*tit).second;
+    vtkTransformFilter  *transformFilter = tit->second;
     transformFilter->SetInputConnection(nullptr);
     transformFilter->SetTransform(nullptr);
     transformFilter->Delete();
@@ -1065,7 +1065,7 @@ void vtkMRMLModelDisplayableManager::UpdateModelMesh(vtkMRMLDisplayableNode *dis
         }
       else
         {
-        transformFilter = (*tit).second;
+        transformFilter = tit->second;
         }
       }
 
@@ -1093,7 +1093,7 @@ void vtkMRMLModelDisplayableManager::UpdateModelMesh(vtkMRMLDisplayableNode *dis
       }
     else
       {
-      prop = (*ait).second;
+      prop = ait->second;
       std::map<std::string, int>::iterator cit = this->Internal->DisplayedClipState.end();
       if (modelDisplayNode)
         {

--- a/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
+++ b/Libs/MRML/IDImageIO/itkMRMLIDImageIO.cxx
@@ -894,7 +894,7 @@ MRMLIDImageIO
   for (std::vector<std::string>::iterator it = keys.begin();
        it != keys.end(); ++it)
     {
-    if ((*it).find(diffusionGradientKey) != std::string::npos)
+    if (it->find(diffusionGradientKey) != std::string::npos)
       {
       // found a gradient
       std::string gradientString;

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.cxx
@@ -740,7 +740,7 @@ int vtkMRMLApplicationLogic::LoadDefaultParameterSets(vtkMRMLScene* scene,
   std::vector<std::string>::iterator fit;
   for (fit = filesToLoad.begin(); fit != filesToLoad.end(); ++fit)
     {
-    scene->SetURL( (*fit).c_str() );
+    scene->SetURL( fit->c_str() );
     scene->Import();
     }
 

--- a/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotViewControllerWidget.cxx
@@ -185,13 +185,13 @@ void qMRMLPlotViewControllerWidgetPrivate::onPlotSeriesNodesSelected()
     std::vector<std::string>::iterator it = plotSeriesNodesIDs.begin();
     for (; it != plotSeriesNodesIDs.end(); ++it)
       {
-      if (!strcmp(dn->GetID(), (*it).c_str()))
+      if (!strcmp(dn->GetID(), it->c_str()))
         {
         if (!checked)
           {
           // plot is not checked but currently in the LayoutPlot, remove it
           // (might want to cache the old name in case user adds it back)
-          this->PlotChartNode->RemovePlotSeriesNodeID((*it).c_str());
+          this->PlotChartNode->RemovePlotSeriesNodeID(it->c_str());
           }
         found = true;
         break;

--- a/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
+++ b/Libs/vtkTeem/vtkTeemNRRDWriter.cxx
@@ -324,7 +324,7 @@ void* vtkTeemNRRDWriter::MakeNRRD()
     // Don't set `space` as k-v. it is handled above, and needs to be a nrrd *field*.
     if (ait->first == "space") { continue; }
 
-    nrrdKeyValueAdd(nrrd, (*ait).first.c_str(), (*ait).second.c_str());
+    nrrdKeyValueAdd(nrrd, ait->first.c_str(), ait->second.c_str());
     }
 
   // 1. Measurement Frame

--- a/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
+++ b/Modules/CLI/OrientScalarVolume/OrientScalarVolume.cxx
@@ -128,7 +128,7 @@ int DoIt( int argc, char * argv[], T )
 
   filter->SetInput( reader1->GetOutput() );
   filter->UseImageDirectionOn();
-  filter->SetDesiredCoordinateOrientation( (*o).second);
+  filter->SetDesiredCoordinateOrientation( o->second);
   filter->Update();
 
   // Compute a new origin for the volume such that the output aligns

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -124,7 +124,7 @@ std::unique_ptr<rapidjson::Document> vtkMRMLMarkupsJsonStorageNode::vtkInternal:
   fclose(fp);
 
   // Verify schema
-  if (!(*jsonRoot).HasMember("@schema"))
+  if (!jsonRoot->HasMember("@schema"))
     {
     vtkErrorToMessageCollectionWithObjectMacro(this->External, this->External->GetUserMessages(), "vtkMRMLMarkupsJsonStorageNode::ReadDataInternal",
       "File reading failed. File '" << filePath << "' does not contain schema information");

--- a/Modules/Loadable/Plots/Widgets/qMRMLPlotChartPropertiesWidget.cxx
+++ b/Modules/Loadable/Plots/Widgets/qMRMLPlotChartPropertiesWidget.cxx
@@ -222,7 +222,7 @@ void qMRMLPlotChartPropertiesWidgetPrivate::updateWidgetFromMRML()
     it != plotSeriesNodesIDs.end(); ++it)
     {
     vtkMRMLPlotSeriesNode *plotSeriesNode = vtkMRMLPlotSeriesNode::SafeDownCast
-      (q->mrmlScene()->GetNodeByID((*it).c_str()));
+      (q->mrmlScene()->GetNodeByID(it->c_str()));
     if (plotSeriesNode == nullptr)
       {
       continue;
@@ -311,13 +311,13 @@ void qMRMLPlotChartPropertiesWidgetPrivate::onPlotSeriesNodesSelected()
     std::vector<std::string>::iterator it = plotSeriesNodesIDs.begin();
     for (; it != plotSeriesNodesIDs.end(); ++it)
       {
-      if (!strcmp(dn->GetID(), (*it).c_str()))
+      if (!strcmp(dn->GetID(), it->c_str()))
         {
         if (!checked)
           {
           // plot is not checked but currently in the LayoutPlot, remove it
           // (might want to cache the old name in case user adds it back)
-          this->PlotChartNode->RemovePlotSeriesNodeID((*it).c_str());
+          this->PlotChartNode->RemovePlotSeriesNodeID(it->c_str());
           }
         found = true;
         break;

--- a/Modules/Loadable/Sequences/qSlicerSequencesModuleWidget.cxx
+++ b/Modules/Loadable/Sequences/qSlicerSequencesModuleWidget.cxx
@@ -1194,7 +1194,7 @@ void qSlicerSequencesModuleWidget::onRemoveSequenceNodesButtonClicked()
   std::vector<std::string> selectedSequenceIDs;
   for (QModelIndexList::iterator index = modelIndexList.begin(); index!=modelIndexList.end(); index++)
     {
-    QWidget* proxyNodeComboBox = d->tableWidget_SynchronizedSequenceNodes->cellWidget((*index).row(), SYNCH_NODES_PROXY_COLUMN);
+    QWidget* proxyNodeComboBox = d->tableWidget_SynchronizedSequenceNodes->cellWidget(index->row(), SYNCH_NODES_PROXY_COLUMN);
     std::string currSelectedSequenceID = proxyNodeComboBox->property("MRMLNodeID").toString().toLatin1().constData();
     selectedSequenceIDs.push_back(currSelectedSequenceID);
     disconnect(proxyNodeComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)), this,
@@ -1204,7 +1204,7 @@ void qSlicerSequencesModuleWidget::onRemoveSequenceNodesButtonClicked()
   std::vector<std::string>::iterator sequenceIDItr;
   for (sequenceIDItr = selectedSequenceIDs.begin(); sequenceIDItr != selectedSequenceIDs.end(); sequenceIDItr++)
     {
-    d->ActiveBrowserNode->RemoveSynchronizedSequenceNode((*sequenceIDItr).c_str());
+    d->ActiveBrowserNode->RemoveSynchronizedSequenceNode(sequenceIDItr->c_str());
     }
 }
 

--- a/Modules/Loadable/ViewControllers/qSlicerViewControllersModuleWidget.cxx
+++ b/Modules/Loadable/ViewControllers/qSlicerViewControllersModuleWidget.cxx
@@ -183,23 +183,23 @@ qSlicerViewControllersModuleWidgetPrivate::removeController(vtkMRMLNode *n)
   vtkMRMLSliceNode *sn = vtkMRMLSliceNode::SafeDownCast(n);
   if (sn)
     {
-    SliceControllersLayout->removeWidget((*cit).second);
+    SliceControllersLayout->removeWidget(cit->second);
     }
 
   vtkMRMLViewNode *vn = vtkMRMLViewNode::SafeDownCast(n);
   if (vn)
     {
-    ThreeDViewControllersLayout->removeWidget((*cit).second);
+    ThreeDViewControllersLayout->removeWidget(cit->second);
     }
 
   vtkMRMLPlotViewNode *pn = vtkMRMLPlotViewNode::SafeDownCast(n);
   if (pn)
     {
-    PlotViewControllersLayout->removeWidget((*cit).second);
+    PlotViewControllersLayout->removeWidget(cit->second);
     }
 
   // delete the widget
-  delete (*cit).second;
+  delete cit->second;
 
   // remove entry from the map
   this->ControllerMap.erase(cit);
@@ -426,10 +426,10 @@ void qSlicerViewControllersModuleWidget::onLayoutChanged(int)
   for (cit = d->ControllerMap.begin(); cit != d->ControllerMap.end(); ++cit)
     {
     // is mananaged Node not currently displayed in the layout?
-    if (!visibleViews->IsItemPresent((*cit).first))
+    if (!visibleViews->IsItemPresent(cit->first))
       {
       // hide it
-      (*cit).second->hide();
+      cit->second->hide();
       }
     }
 
@@ -448,7 +448,7 @@ void qSlicerViewControllersModuleWidget::onLayoutChanged(int)
       if (cit != d->ControllerMap.end())
         {
         // show it
-        (*cit).second->show();
+        cit->second->show();
         }
       }
     }

--- a/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
+++ b/Modules/Loadable/Volumes/Logic/vtkSlicerVolumesLogic.cxx
@@ -1607,7 +1607,7 @@ void vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets()
   std::string errorPrefix = "vtkSlicerVolumesLogic::InitializeDefaultVolumeDisplayPresets failed: Error reading '" + displayPresetsFilename + "'.";
 
   // Verify schema
-  if (!(*jsonRoot).HasMember("@schema"))
+  if (!jsonRoot->HasMember("@schema"))
     {
     vtkErrorMacro(<< errorPrefix << " File does not contain schema information.");
     return;


### PR DESCRIPTION
Simplified code by using the arrow operator, instead of using
parentheses, asterisk and dot operators.

Did so by replacing the regular expression `\(\*(\w+)\)\.` with `->`,
followed by a few manual fixes.

```
find . \( -iname "*.cxx" -or -iname "*.hxx" -or -iname "*.h" \) -exec perl -pi -w -e 's/\(\*(\w+)\)\./->/g' {} \;
```