### PR TITLE
ENH: support markups with distorted zoom

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -1001,6 +1001,12 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateControlPointGlyphScale()
   double camScale[3] = {1.0, 1.0, 1.0};
   camTransform->GetScale(camScale);
 
+  if (camScale[0] == camScale[1] && camScale[0] == camScale[2])
+    {
+    // view is not distorted
+    return;
+    }
+
   for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; controlPointType++)
     {
     ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[controlPointType]);
@@ -1017,17 +1023,55 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateControlPointGlyphScale()
       return;
       }
 
+    auto computeDistanceToPointOnEllipsoid = [](const vtkQuaterniond& orientationQuaternion, const double ellipsoid_abc[3], const double p[3]) {
+      double p_rot[3] = { 0.0 };
+      vtkMath::RotateVectorByNormalizedQuaternion(p, orientationQuaternion.GetData(), p_rot);
+      double theta = std::acos(p_rot[2]/std::hypot(p_rot[0], p_rot[1], p_rot[2]));
+      double phi = 0.0;
+      double pi = 3.14159265358979323846;
+      if (p_rot[0] > 0) {
+        phi = std::atan2(p_rot[1], p_rot[0]);
+      } else if (p_rot[0] < 0 && p_rot[1] >= 0) {
+        phi = std::atan2(p_rot[1], p_rot[0]) + pi;
+      } else if (p_rot[0] < 0 && p_rot[1] < 0) {
+        phi = std::atan2(p_rot[1], p_rot[0]) - pi;
+      } else if (p_rot[0] == 0 && p_rot[1] > 0) {
+        phi = pi/2.0;
+      } else if (p_rot[0] == 0 && p_rot[1] < 0) {
+        phi = -pi/2.0;
+      }
+
+      double px_rot = ellipsoid_abc[0]*sin(theta)*cos(phi);
+      double py_rot = ellipsoid_abc[1]*sin(theta)*sin(phi);
+      double pz_rot = ellipsoid_abc[2]*cos(theta);
+      return std::hypot(px_rot, py_rot, pz_rot);
+    };
+
+    double i[3] = { 1.0, 0.0, 0.0 };
+    double j[3] = { 0.0, 1.0, 0.0 };
+    double k[3] = { 0.0, 0.0, 1.0 };
+
     for (int pointIndex = 0; pointIndex < numPoints; ++pointIndex)
       {
       // GlypthScaleArray is applied to the local markups coordinates
       // (markups always oriented away from the camera: X-to the left, Y-up, Z-away from camera)
       // Thus camera scaling array must be projected on the markups point coordinate system.
       vtkQuaterniond orientationQuaternion = vtkQuaterniond(controlPoints->GlyphOrientationArray->GetTuple4(pointIndex));
-      // Invert quaternion so that projection was from world coordinates to the markups point coords.
-      orientationQuaternion.Invert();
+
+      // The inequal scale along three axes transfroms the sphere to ellipsoid with semi-minor/major axes equal to scale.
+      // Thus we need to find values on this ellipsoid at points represented by given orientation matrix (quaternion).
+      // And this will be the scale affecting oriented markups point.
+      // To do that we will rotate i,j,k unit vectors to find spherical coordinates (theta, phi)
+      // and calculate ellipsoid coordinates (sphere angles are the same as ellipsoid angles).
+      // Finally compute distance to that point.
+      // Notation from wikipedia (theta, phi):
+      // https://en.wikipedia.org/wiki/Spherical_coordinate_system
+      // https://en.wikipedia.org/wiki/Ellipsoid
 
       double camScaleRot[3] = { 0.0 };
-      vtkMath::RotateVectorByNormalizedQuaternion(camScale, orientationQuaternion.GetData(), camScaleRot);
+      camScaleRot[0] = computeDistanceToPointOnEllipsoid(orientationQuaternion, camScale, i);
+      camScaleRot[1] = computeDistanceToPointOnEllipsoid(orientationQuaternion, camScale, j);
+      camScaleRot[2] = computeDistanceToPointOnEllipsoid(orientationQuaternion, camScale, k);
 
       controlPoints->GlyphScaleArray->SetTuple3(pointIndex,
        std::abs(1/camScaleRot[0]),

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -114,6 +114,8 @@ protected:
 
     /// Orientation of the glyphs, represented as an array of quaternions
     vtkSmartPointer<vtkDoubleArray>   GlyphOrientationArray;
+    /// Glyph scale: scaling depends on orientation (that is why we can't simply use transform on SphereSource)
+    vtkSmartPointer<vtkDoubleArray>   GlyphScaleArray;
 
     vtkSmartPointer<vtkGlyph3DMapper> GlyphMapper;
 
@@ -143,6 +145,8 @@ protected:
   ControlPointsPipeline3D* GetControlPointsPipeline(int controlPointType);
 
   virtual void UpdateControlPointGlyphOrientation();
+
+  virtual void UpdateControlPointGlyphScale();
 
   virtual void UpdateNthPointAndLabelFromMRML(int n);
 


### PR DESCRIPTION
Fix markups representation when camera non-equally scaled along different axes.
Markups is designed to be always oriented away from camera.
Orientation is done with `GlyphOrientationArray`.
Scaling is designed to be similar to orientation.
With Glyph Mapper `SetScaleModeToScaleByVectorComponents`.
As orientation is updated with `UpdateControlPointGlyphOrientation`,
Scaling is updated with `UpdateControlPointGlyphScale` function. Anytime camera is changed `UpdateControlPointGlyphScale` is called.

Now it is a draft as I can't correctly project camera scaling from global coords to markups point coordinates.

**If you feel comfortable with coordinate transformation I would appreciate for any help (see `vtkSlicerMarkupsWidgetRepresentation3D::UpdateControlPointGlyphScale` function).**

To test markups with distorted camera scaling I usually do the following:
```python
layoutManager = slicer.app.layoutManager()
view = layoutManager.threeDWidget(0).threeDView()
threeDViewNode = view.mrmlViewNode()
cameraNode = slicer.modules.cameras.logic().GetViewActiveCameraNode(threeDViewNode)
camera=cameraNode.GetCamera()

# Scale Z-axis
transform = vtk.vtkTransform()
transform.Scale(1, 1, 2)
camera.SetModelTransformMatrix(transform.GetMatrix())
```

[See discussion](https://discourse.slicer.org/t/markups-distorted-when-zoom-isnt-constant-along-different-axes/24879)