### PR TITLE
BUG: Make node names and quantity identifiers non-translatable

### DIFF
--- a/Base/QTCLI/Resources/UI/qSlicerCLIModuleWidget.ui
+++ b/Base/QTCLI/Resources/UI/qSlicerCLIModuleWidget.ui
@@ -55,7 +55,7 @@
             <item row="0" column="1">
              <widget class="qMRMLNodeComboBox" name="MRMLCommandLineModuleNodeSelector" native="true">
               <property name="nodeTypes" stdset="0">
-               <stringlist>
+               <stringlist notr="true">
                 <string>vtkMRMLCommandLineModuleNode</string>
                </stringlist>
               </property>

--- a/Base/QTGUI/DesignerPlugins/qSlicerMouseModeToolBarPlugin.cxx
+++ b/Base/QTGUI/DesignerPlugins/qSlicerMouseModeToolBarPlugin.cxx
@@ -34,9 +34,11 @@ QWidget *qSlicerMouseModeToolBarPlugin::createWidget(QWidget* parentWidget)
 
 QString qSlicerMouseModeToolBarPlugin::domXml() const
 {
-  return "<widget class=\"qSlicerMouseModeToolBar\" \
-          name=\"SlicerMouseModeToolBar\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qSlicerMouseModeToolBar\" name=\"SlicerMouseModeToolBar\">\n"
+    "  <property name=\"defaultPlaceClassName\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 QString qSlicerMouseModeToolBarPlugin::includeFile() const

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLCoordinatesWidgetPlugin.cxx
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLCoordinatesWidgetPlugin.cxx
@@ -34,13 +34,14 @@ QWidget *qMRMLCoordinatesWidgetPlugin::createWidget(QWidget *_parent)
   return _widget;
 }
 
-
 // --------------------------------------------------------------------------
 QString qMRMLCoordinatesWidgetPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLCoordinatesWidget\" \
-                  name=\"MRMLCoordinatesWidget\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLCoordinatesWidget\" name=\"MRMLCoordinatesWidget\">\n"
+    "  <property name=\"quantity\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLNodeComboBoxPlugin.cxx
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLNodeComboBoxPlugin.cxx
@@ -34,9 +34,13 @@ QWidget *qMRMLNodeComboBoxPlugin::createWidget(QWidget *_parent)
 
 QString qMRMLNodeComboBoxPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLNodeComboBox\" \
-                  name=\"MRMLNodeComboBox\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLNodeComboBox\" name=\"MRMLNodeComboBox\">\n"
+    "  <property name=\"hideChildNodeTypes\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"nodeTypes\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"interactionNodeSingletonTag\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 QIcon qMRMLNodeComboBoxPlugin::icon() const

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLRangeWidgetPlugin.cxx
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLRangeWidgetPlugin.cxx
@@ -34,9 +34,11 @@ QWidget *qMRMLRangeWidgetPlugin::createWidget(QWidget *parentWidget)
 
 QString qMRMLRangeWidgetPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLRangeWidget\" \
-          name=\"MRMLRangeWidget\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLRangeWidget\" name=\"MRMLRangeWidget\">\n"
+    "  <property name=\"quantity\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 QIcon qMRMLRangeWidgetPlugin::icon() const

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliceControllerWidgetPlugin.cxx
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliceControllerWidgetPlugin.cxx
@@ -17,9 +17,12 @@ QWidget *qMRMLSliceControllerWidgetPlugin::createWidget(QWidget *_parent)
 // --------------------------------------------------------------------------
 QString qMRMLSliceControllerWidgetPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLSliceControllerWidget\" \
-          name=\"MRMLSliceControllerWidget\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSliceControllerWidget\" name=\"MRMLSliceControllerWidget\">\n"
+    "  <property name=\"sliceViewName\"> <string notr=\"true\"/> </property>\n"
+    "  <property name=\"sliceOrientation\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliceWidgetPlugin.cxx
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliceWidgetPlugin.cxx
@@ -18,17 +18,20 @@ QWidget *qMRMLSliceWidgetPlugin::createWidget(QWidget *_parent)
 //-----------------------------------------------------------------------------
 QString qMRMLSliceWidgetPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLSliceWidget\" \
-          name=\"MRMLSliceViewWidget\">\n"
-          " <property name=\"geometry\">\n"
-          "  <rect>\n"
-          "   <x>0</x>\n"
-          "   <y>0</y>\n"
-          "   <width>200</width>\n"
-          "   <height>200</height>\n"
-          "  </rect>\n"
-          " </property>\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSliceWidget\" name=\"MRMLSliceViewWidget\">\n"
+    "  <property name=\"geometry\">\n"
+    "    <rect>\n"
+    "      <x>0</x>\n"
+    "      <y>0</y>\n"
+    "      <width>200</width>\n"
+    "      <height>200</height>\n"
+    "    </rect>\n"
+    "  </property>\n"
+    "  <property name=\"sliceViewName\"> <string notr=\"true\"/> </property>\n"
+    "  <property name=\"sliceOrientation\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliderWidgetPlugin.cxx
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliderWidgetPlugin.cxx
@@ -37,9 +37,11 @@ QWidget *qMRMLSliderWidgetPlugin::createWidget(QWidget *_parent)
 // --------------------------------------------------------------------------
 QString qMRMLSliderWidgetPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLSliderWidget\" \
-                  name=\"MRMLSliderWidget\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSliderWidget\" name=\"MRMLSliderWidget\">\n"
+    "  <property name=\"quantity\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLSpinBoxPlugin.cxx
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLSpinBoxPlugin.cxx
@@ -37,9 +37,11 @@ QWidget *qMRMLSpinBoxPlugin::createWidget(QWidget *_parent)
 // --------------------------------------------------------------------------
 QString qMRMLSpinBoxPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLSpinBox\" \
-                  name=\"MRMLSpinBox\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSpinBox\" name=\"MRMLSpinBox\">\n"
+    "  <property name=\"quantity\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLTreeViewPlugin.cxx
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLTreeViewPlugin.cxx
@@ -37,9 +37,12 @@ QWidget *qMRMLTreeViewPlugin::createWidget(QWidget *_parent)
 // --------------------------------------------------------------------------
 QString qMRMLTreeViewPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLTreeView\" \
-          name=\"MRMLTreeView\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLTreeView\" name=\"MRMLTreeView\">\n"
+    "  <property name=\"nodeTypes\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"sceneModelType\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLPlotViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLPlotViewControllerWidget.ui
@@ -24,7 +24,7 @@
             <string>Select the PlotChartNode which handles the general Properties of the Plot and allow to select multiple PlotSeriesNodes.</string>
            </property>
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLPlotChartNode</string>
             </stringlist>
            </property>
@@ -63,7 +63,7 @@
         <string>Add/Remove plots data series to/from the current chart.</string>
        </property>
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLPlotSeriesNode</string>
         </stringlist>
        </property>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLROIWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLROIWidget.ui
@@ -669,7 +669,7 @@
                 </palette>
               </property>
               <property name="quantity">
-                <string>length</string>
+                <string notr="true">length</string>
               </property>
             </widget>
           </item>
@@ -1315,7 +1315,7 @@
                 </palette>
               </property>
               <property name="quantity">
-                <string>length</string>
+                <string notr="true">length</string>
               </property>
             </widget>
           </item>
@@ -1961,7 +1961,7 @@
                 </palette>
               </property>
               <property name="quantity">
-                <string>length</string>
+                <string notr="true">length</string>
               </property>
             </widget>
           </item>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSegmentSelectorWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSegmentSelectorWidget.ui
@@ -105,7 +105,7 @@
    <item row="0" column="0">
     <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_Segmentation">
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLSegmentationNode</string>
       </stringlist>
      </property>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceControllerWidget.ui
@@ -51,7 +51,7 @@
       <string>Select the label map</string>
      </property>
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLLabelMapVolumeNode</string>
       </stringlist>
      </property>
@@ -179,7 +179,7 @@
       <string>Select the foreground</string>
      </property>
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLVolumeNode</string>
       </stringlist>
      </property>
@@ -319,7 +319,7 @@
       <string>Select the background</string>
      </property>
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLVolumeNode</string>
       </stringlist>
      </property>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLTableViewControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLTableViewControllerWidget.ui
@@ -25,7 +25,7 @@
      <item>
       <widget class="qMRMLNodeComboBox" name="tableComboBox">
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLTableNode</string>
         </stringlist>
        </property>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLTestModelViews.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLTestModelViews.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox">
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLCameraNode</string>
       </stringlist>
      </property>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLTransformSliders.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLTransformSliders.ui
@@ -186,7 +186,7 @@
               <double>-200.000000000000000</double>
              </property>
              <property name="quantity">
-              <string>length</string>
+              <string notr="true">length</string>
              </property>
              <property name="unitAwareProperties">
               <set>qMRMLSpinBox::Precision|qMRMLSpinBox::Prefix|qMRMLSpinBox::Scaling|qMRMLSpinBox::Suffix</set>
@@ -241,7 +241,7 @@
               <double>200.000000000000000</double>
              </property>
              <property name="quantity">
-              <string>length</string>
+              <string notr="true">length</string>
              </property>
              <property name="unitAwareProperties">
               <set>qMRMLSpinBox::Precision|qMRMLSpinBox::Prefix|qMRMLSpinBox::Scaling|qMRMLSpinBox::Suffix</set>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLVolumeInfoWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLVolumeInfoWidget.ui
@@ -77,7 +77,7 @@
       <string>0,0,0</string>
      </property>
      <property name="quantity">
-      <string>length</string>
+      <string notr="true">length</string>
      </property>
      <property name="unitAwareProperties">
       <set>qMRMLCoordinatesWidget::Precision|qMRMLCoordinatesWidget::Prefix|qMRMLCoordinatesWidget::Scaling|qMRMLCoordinatesWidget::Suffix</set>
@@ -106,7 +106,7 @@
       <double>1000000000.000000000000000</double>
      </property>
      <property name="quantity">
-      <string>length</string>
+      <string notr="true">length</string>
      </property>
      <property name="unitAwareProperties">
       <set>qMRMLCoordinatesWidget::Precision|qMRMLCoordinatesWidget::Prefix|qMRMLCoordinatesWidget::Scaling|qMRMLCoordinatesWidget::Suffix</set>

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
@@ -96,7 +96,7 @@ public:
 
   /// Set slice view name
   /// \note SliceViewName should be set before setMRMLSliceNode() is called
-  /// "Red" by default.
+  /// "Red" by default. This is an identifier, not to be translated.
   void setSliceViewName(const QString& newSliceViewName);
 
   /// Get slice view name
@@ -169,6 +169,7 @@ public slots:
 
   /// Set slice orientation.
   /// \note Orientation could be either "Axial, "Sagittal", "Coronal" or "Reformat".
+  /// This is an identifier, not to be translated.
   void setSliceOrientation(const QString& orientation);
 
   /// Set slice \a offset. Used to set a single value.

--- a/Modules/Loadable/Annotations/Resources/UI/qSlicerAnnotationModulePropertyDialog.ui
+++ b/Modules/Loadable/Annotations/Resources/UI/qSlicerAnnotationModulePropertyDialog.ui
@@ -236,7 +236,7 @@
      <item row="2" column="4">
       <widget class="qMRMLCoordinatesWidget" name="RASCoordinatesWidget">
        <property name="quantity">
-        <string>length</string>
+        <string notr="true">length</string>
        </property>
        <property name="unitAwareProperties">
         <set>qMRMLCoordinatesWidget::MaximumValue|qMRMLCoordinatesWidget::MinimumValue|qMRMLCoordinatesWidget::Precision|qMRMLCoordinatesWidget::Prefix|qMRMLCoordinatesWidget::Scaling|qMRMLCoordinatesWidget::Suffix</set>
@@ -920,7 +920,7 @@
             <item row="3" column="2">
              <widget class="qMRMLSliderWidget" name="lineTickSpacingSlider">
               <property name="quantity">
-               <string>length</string>
+               <string notr="true">length</string>
               </property>
               <property name="unitAwareProperties">
                <set>qMRMLSliderWidget::Prefix|qMRMLSliderWidget::Suffix|qMRMLSliderWidget::Scaling</set>

--- a/Modules/Loadable/Annotations/Widgets/Resources/UI/qMRMLAnnotationROIWidget.ui
+++ b/Modules/Loadable/Annotations/Widgets/Resources/UI/qMRMLAnnotationROIWidget.ui
@@ -669,7 +669,7 @@
                 </palette>
               </property>
               <property name="quantity">
-                <string>length</string>
+                <string notr="true">length</string>
               </property>
             </widget>
           </item>
@@ -1316,7 +1316,7 @@
                 </palette>
               </property>
               <property name="quantity">
-                <string>length</string>
+                <string notr="true">length</string>
               </property>
             </widget>
           </item>
@@ -1962,7 +1962,7 @@
                 </palette>
               </property>
               <property name="quantity">
-                <string>length</string>
+                <string notr="true">length</string>
               </property>
             </widget>
           </item>

--- a/Modules/Loadable/Cameras/Resources/UI/qSlicerCamerasModuleWidget.ui
+++ b/Modules/Loadable/Cameras/Resources/UI/qSlicerCamerasModuleWidget.ui
@@ -43,7 +43,7 @@
       <item row="0" column="1">
        <widget class="qMRMLNodeComboBox" name="ViewNodeSelector">
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLViewNode</string>
          </stringlist>
         </property>
@@ -71,7 +71,7 @@
       <item row="1" column="1">
        <widget class="qMRMLNodeComboBox" name="CameraNodeSelector">
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLCameraNode</string>
          </stringlist>
         </property>

--- a/Modules/Loadable/Colors/Resources/UI/qSlicerColorsModuleWidget.ui
+++ b/Modules/Loadable/Colors/Resources/UI/qSlicerColorsModuleWidget.ui
@@ -100,7 +100,7 @@
            </sizepolicy>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLScalarVolumeNode</string>
             <string>vtkMRMLModelNode</string>
            </stringlist>

--- a/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
+++ b/Modules/Loadable/CropVolume/Resources/UI/qSlicerCropVolumeModuleWidget.ui
@@ -75,7 +75,7 @@
          </sizepolicy>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLCropVolumeParametersNode</string>
          </stringlist>
         </property>
@@ -145,7 +145,7 @@
          </sizepolicy>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLScalarVolumeNode</string>
          </stringlist>
         </property>
@@ -176,7 +176,7 @@
          </sizepolicy>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLMarkupsROINode</string>
           <string>vtkMRMLAnnotationROINode</string>
          </stringlist>
@@ -259,7 +259,7 @@
          </sizepolicy>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLScalarVolumeNode</string>
           <string>vtkMRMLVectorVolumeNode</string>
          </stringlist>
@@ -557,7 +557,7 @@
             <string>0,0,0</string>
            </property>
            <property name="quantity">
-            <string>length</string>
+            <string notr="true">length</string>
            </property>
            <property name="unitAwareProperties">
             <set>qMRMLCoordinatesWidget::Precision|qMRMLCoordinatesWidget::Prefix|qMRMLCoordinatesWidget::Scaling|qMRMLCoordinatesWidget::Suffix</set>
@@ -636,7 +636,7 @@
             <string>0,0,0</string>
            </property>
            <property name="quantity">
-            <string>length</string>
+            <string notr="true">length</string>
            </property>
            <property name="unitAwareProperties">
             <set>qMRMLCoordinatesWidget::Precision|qMRMLCoordinatesWidget::Prefix|qMRMLCoordinatesWidget::Scaling|qMRMLCoordinatesWidget::Suffix</set>

--- a/Modules/Loadable/Data/Resources/UI/qSlicerDataModuleWidget.ui
+++ b/Modules/Loadable/Data/Resources/UI/qSlicerDataModuleWidget.ui
@@ -270,7 +270,7 @@
           <number>10</number>
          </property>
          <property name="nodeTypes">
-          <stringlist>
+          <stringlist notr="true">
            <string>vtkMRMLTransformableNode</string>
           </stringlist>
          </property>

--- a/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
+++ b/Modules/Loadable/Markups/Resources/UI/qSlicerMarkupsModule.ui
@@ -871,7 +871,7 @@
         <item row="1" column="1">
          <widget class="qMRMLNodeComboBox" name="exportedImportedNodeComboBox">
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLTableNode</string>
            </stringlist>
           </property>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsCurveSettingsWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsCurveSettingsWidget.ui
@@ -72,7 +72,7 @@
            <item row="1" column="1">
             <widget class="qMRMLNodeComboBox" name="modelNodeSelector" native="true">
              <property name="nodeTypes" stdset="0">
-              <stringlist>
+              <stringlist notr="true">
                <string>vtkMRMLModelNode</string>
               </stringlist>
              </property>
@@ -303,7 +303,7 @@
          <string>Select a node to store the resampled curve </string>
         </property>
         <property name="nodeTypes" stdset="0">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLMarkupsCurveNode</string>
          </stringlist>
         </property>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -104,7 +104,7 @@
         <double>5.000000000000000</double>
        </property>
        <property name="quantity">
-        <string>length</string>
+        <string notr="true">length</string>
        </property>
       </widget>
      </item>
@@ -389,7 +389,7 @@
            <double>5.000000000000000</double>
           </property>
           <property name="quantity">
-           <string>length</string>
+           <string notr="true">length</string>
           </property>
          </widget>
         </item>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsROIWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsROIWidget.ui
@@ -710,7 +710,7 @@
            </palette>
           </property>
           <property name="quantity">
-           <string>length</string>
+           <string notr="true">length</string>
           </property>
          </widget>
         </item>
@@ -1353,7 +1353,7 @@
            </palette>
           </property>
           <property name="quantity">
-           <string>length</string>
+           <string notr="true">length</string>
           </property>
          </widget>
         </item>
@@ -1986,7 +1986,7 @@
            </palette>
           </property>
           <property name="quantity">
-           <string>length</string>
+           <string notr="true">length</string>
           </property>
          </widget>
         </item>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerSimpleMarkupsWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qSlicerSimpleMarkupsWidget.ui
@@ -49,7 +49,7 @@
         </sizepolicy>
        </property>
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLMarkupsFiducialNode</string>
         </stringlist>
        </property>

--- a/Modules/Loadable/Models/Resources/UI/qSlicerModelsModuleWidget.ui
+++ b/Modules/Loadable/Models/Resources/UI/qSlicerModelsModuleWidget.ui
@@ -110,7 +110,7 @@
          <bool>true</bool>
         </property>
         <property name="hideChildNodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLAnnotationNode</string>
          </stringlist>
         </property>
@@ -186,7 +186,7 @@
    <item>
     <widget class="qMRMLNodeComboBox" name="ClipModelsNodeComboBox">
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLClipModelsNode</string>
       </stringlist>
      </property>

--- a/Modules/Loadable/Plots/Resources/UI/qSlicerPlotsModuleWidget.ui
+++ b/Modules/Loadable/Plots/Resources/UI/qSlicerPlotsModuleWidget.ui
@@ -67,7 +67,7 @@
          <item>
           <widget class="qMRMLNodeComboBox" name="PlotChartNodeSelector">
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLPlotChartNode</string>
             </stringlist>
            </property>
@@ -124,7 +124,7 @@
        <item row="0" column="1">
         <widget class="qMRMLNodeComboBox" name="PlotSeriesNodeSelector">
          <property name="nodeTypes">
-          <stringlist>
+          <stringlist notr="true">
            <string>vtkMRMLPlotSeriesNode</string>
           </stringlist>
          </property>

--- a/Modules/Loadable/Plots/Widgets/Resources/UI/qMRMLPlotChartPropertiesWidget.ui
+++ b/Modules/Loadable/Plots/Widgets/Resources/UI/qMRMLPlotChartPropertiesWidget.ui
@@ -45,7 +45,7 @@
       <string>Add/Remove plots data series to/from the current chart.</string>
      </property>
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLPlotSeriesNode</string>
       </stringlist>
      </property>

--- a/Modules/Loadable/Plots/Widgets/Resources/UI/qMRMLPlotSeriesPropertiesWidget.ui
+++ b/Modules/Loadable/Plots/Widgets/Resources/UI/qMRMLPlotSeriesPropertiesWidget.ui
@@ -45,7 +45,7 @@
       <string/>
      </property>
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLTableNode</string>
       </stringlist>
      </property>

--- a/Modules/Loadable/Reformat/Resources/UI/qSlicerReformatModuleWidget.ui
+++ b/Modules/Loadable/Reformat/Resources/UI/qSlicerReformatModuleWidget.ui
@@ -46,7 +46,7 @@
         <bool>false</bool>
        </property>
        <property name="nodeTypes" stdset="0">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLSliceNode</string>
         </stringlist>
        </property>

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsIOOptionsWidget.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsIOOptionsWidget.ui
@@ -61,7 +61,7 @@
       </sizepolicy>
      </property>
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLColorTableNode</string>
       </stringlist>
      </property>

--- a/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
+++ b/Modules/Loadable/Segmentations/Resources/UI/qSlicerSegmentationsModule.ui
@@ -54,7 +54,7 @@
      <item row="0" column="1">
       <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_Segmentation">
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLSegmentationNode</string>
         </stringlist>
        </property>
@@ -416,7 +416,7 @@
              <string>Select Segmentation node to copy/move segments to/from.</string>
             </property>
             <property name="nodeTypes">
-             <stringlist>
+             <stringlist notr="true">
               <string>vtkMRMLSegmentationNode</string>
              </stringlist>
             </property>
@@ -625,7 +625,7 @@
             <string>Exported labelmap geometry will match this volume's geometry</string>
            </property>
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLVolumeNode</string>
             </stringlist>
            </property>
@@ -659,7 +659,7 @@
            <item>
             <widget class="qMRMLNodeComboBox" name="ColorTableNodeSelector">
              <property name="nodeTypes">
-              <stringlist>
+              <stringlist notr="true">
                <string>vtkMRMLColorTableNode</string>
               </stringlist>
              </property>

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentEditorWidgetPlugin.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentEditorWidgetPlugin.cxx
@@ -38,9 +38,11 @@ QWidget *qMRMLSegmentEditorWidgetPlugin::createWidget(QWidget* parentWidget)
 //-----------------------------------------------------------------------------
 QString qMRMLSegmentEditorWidgetPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLSegmentEditorWidget\" \
-          name=\"SegmentEditorWidget\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSegmentEditorWidget\" name=\"SegmentEditorWidget\">\n"
+    "  <property name=\"defaultTerminologyEntrySettingsKey\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationConversionParametersWidgetPlugin.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationConversionParametersWidgetPlugin.cxx
@@ -38,9 +38,11 @@ QWidget *qMRMLSegmentationConversionParametersWidgetPlugin::createWidget(QWidget
 //-----------------------------------------------------------------------------
 QString qMRMLSegmentationConversionParametersWidgetPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLSegmentationConversionParametersWidget\" \
-          name=\"SegmentationConversionParametersWidget\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSegmentationConversionParametersWidget\" name=\"SegmentationConversionParametersWidget\">\n"
+    "  <property name=\"targetRepresentationName\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationFileExportWidgetPlugin.cxx
+++ b/Modules/Loadable/Segmentations/Widgets/DesignerPlugins/qMRMLSegmentationFileExportWidgetPlugin.cxx
@@ -38,9 +38,11 @@ QWidget *qMRMLSegmentationFileExportWidgetPlugin::createWidget(QWidget* parentWi
 //-----------------------------------------------------------------------------
 QString qMRMLSegmentationFileExportWidgetPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLSegmentationFileExportWidget\" \
-          name=\"SegmentationDisplayNodeWidget\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSegmentationFileExportWidget\" name=\"SegmentationDisplayNodeWidget\">\n"
+    "  <property name=\"settingsKey\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentEditorWidget.ui
@@ -26,12 +26,12 @@
      <item row="1" column="1">
       <widget class="qMRMLNodeComboBox" name="SourceVolumeNodeComboBox">
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLScalarVolumeNode</string>
         </stringlist>
        </property>
        <property name="hideChildNodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLSegmentationNode</string>
         </stringlist>
        </property>
@@ -75,7 +75,7 @@
        <item>
         <widget class="qMRMLNodeComboBox" name="SegmentationNodeComboBox">
          <property name="nodeTypes">
-          <stringlist>
+          <stringlist notr="true">
            <string>vtkMRMLSegmentationNode</string>
           </stringlist>
          </property>

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationFileExportWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationFileExportWidget.ui
@@ -76,7 +76,7 @@
      <item>
       <widget class="qMRMLNodeComboBox" name="ColorTableNodeSelector">
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLColorTableNode</string>
         </stringlist>
        </property>
@@ -319,7 +319,7 @@
    <item row="4" column="1">
     <widget class="qMRMLNodeComboBox" name="ReferenceVolumeComboBox">
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLVolumeNode</string>
       </stringlist>
      </property>

--- a/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationGeometryWidget.ui
+++ b/Modules/Loadable/Segmentations/Widgets/Resources/UI/qMRMLSegmentationGeometryWidget.ui
@@ -63,7 +63,7 @@
       <item row="0" column="1">
        <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_SourceGeometryNode">
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLScalarVolumeNode</string>
           <string>vtkMRMLSegmentationNode</string>
           <string>vtkMRMLModelNode</string>
@@ -207,7 +207,7 @@
          <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::DecimalsByValue|ctkDoubleSpinBox::InsertDecimals|ctkDoubleSpinBox::ReplaceDecimals</set>
         </property>
         <property name="quantity">
-         <string>length</string>
+         <string notr="true">length</string>
         </property>
        </widget>
       </item>
@@ -313,7 +313,7 @@
          <number>2</number>
         </property>
         <property name="quantity">
-         <string>length</string>
+         <string notr="true">length</string>
         </property>
        </widget>
       </item>

--- a/Modules/Loadable/Sequences/Resources/UI/qSlicerSequencesModuleWidget.ui
+++ b/Modules/Loadable/Sequences/Resources/UI/qSlicerSequencesModuleWidget.ui
@@ -36,7 +36,7 @@
          <item>
           <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_ActiveBrowser">
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLSequenceBrowserNode</string>
             </stringlist>
            </property>
@@ -79,7 +79,7 @@
             <item>
              <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_SynchronizeSequenceNode">
               <property name="nodeTypes">
-               <stringlist>
+               <stringlist notr="true">
                 <string>vtkMRMLSequenceNode</string>
                </stringlist>
               </property>
@@ -318,7 +318,7 @@
           <item row="2" column="1">
            <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_MasterSequence">
             <property name="nodeTypes">
-             <stringlist>
+             <stringlist notr="true">
               <string>vtkMRMLSequenceNode</string>
              </stringlist>
             </property>
@@ -410,7 +410,7 @@
          <item row="0" column="1">
           <widget class="qMRMLNodeComboBox" name="MRMLNodeComboBox_Sequence">
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLSequenceNode</string>
             </stringlist>
            </property>

--- a/Modules/Loadable/SubjectHierarchy/Widgets/DesignerPlugins/qMRMLSubjectHierarchyComboBoxPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/DesignerPlugins/qMRMLSubjectHierarchyComboBoxPlugin.cxx
@@ -40,9 +40,14 @@ QWidget *qMRMLSubjectHierarchyComboBoxPlugin::createWidget(QWidget* parentWidget
 //-----------------------------------------------------------------------------
 QString qMRMLSubjectHierarchyComboBoxPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLSubjectHierarchyComboBox\" \
-          name=\"SubjectHierarchyComboBox\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSubjectHierarchyComboBox\" name=\"SubjectHierarchyComboBox\">\n"
+    "  <property name=\"includeItemAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"includeNodeAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"excludeItemAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"excludeNodeAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/SubjectHierarchy/Widgets/DesignerPlugins/qMRMLSubjectHierarchyTreeViewPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/DesignerPlugins/qMRMLSubjectHierarchyTreeViewPlugin.cxx
@@ -40,9 +40,17 @@ QWidget *qMRMLSubjectHierarchyTreeViewPlugin::createWidget(QWidget* parentWidget
 //-----------------------------------------------------------------------------
 QString qMRMLSubjectHierarchyTreeViewPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLSubjectHierarchyTreeView\" \
-          name=\"SubjectHierarchyTreeView\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSubjectHierarchyTreeView\" name=\"SubjectHierarchyTreeView\">\n"
+    "  <property name=\"levelFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"nodeTypes\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"hideChildNodeTypes\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"includeItemAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"includeNodeAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"excludeItemAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "  <property name=\"excludeNodeAttributeNamesFilter\"> <stringlist notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Tables/Resources/UI/qSlicerTablesModuleWidget.ui
+++ b/Modules/Loadable/Tables/Resources/UI/qSlicerTablesModuleWidget.ui
@@ -44,7 +44,7 @@
      <item>
       <widget class="qMRMLNodeComboBox" name="TableNodeSelector" native="true">
        <property name="nodeTypes" stdset="0">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLTableNode</string>
         </stringlist>
        </property>

--- a/Modules/Loadable/Texts/Resources/UI/qSlicerTextsModuleWidget.ui
+++ b/Modules/Loadable/Texts/Resources/UI/qSlicerTextsModuleWidget.ui
@@ -48,7 +48,7 @@
      <item row="1" column="1">
       <widget class="qMRMLNodeComboBox" name="TextNodeSelector">
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLTextNode</string>
         </stringlist>
        </property>

--- a/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
+++ b/Modules/Loadable/Transforms/Resources/UI/qSlicerTransformsModuleWidget.ui
@@ -39,7 +39,7 @@
      <item>
       <widget class="qMRMLNodeComboBox" name="TransformNodeSelector">
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLLinearTransformNode</string>
          <string>vtkMRMLBSplineTransformNode</string>
          <string>vtkMRMLGridTransformNode</string>
@@ -342,7 +342,7 @@
            <bool>true</bool>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLTransformableNode</string>
            </stringlist>
           </property>
@@ -470,7 +470,7 @@
          <string>Volume that defines origin, spacing, and axis directions of the exported displacement field. If the reference volume is under a non-linear transform then the non-transformed geometry is used as reference.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLVolumeNode</string>
          </stringlist>
         </property>
@@ -516,7 +516,7 @@
          <string>Volume or transform node that will store the displacement field. If scalar volume node is chosen then only displacement magnitude is saved. In vector volume or transform node 3D displacement vector is saved.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLTransformNode</string>
           <string>vtkMRMLScalarVolumeNode</string>
           <string>vtkMRMLVectorVolumeNode</string>

--- a/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
+++ b/Modules/Loadable/Transforms/Widgets/Resources/UI/qMRMLTransformDisplayNodeWidget.ui
@@ -470,7 +470,7 @@
            <string>Region for visualizing transform nodes (will only use size, orientation and position)</string>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLSliceNode</string>
             <string>vtkMRMLModelNode</string>
             <string>vtkMRMLVolumeNode</string>
@@ -609,7 +609,7 @@
                <double>10.000000000000000</double>
               </property>
               <property name="quantity">
-               <string>length</string>
+               <string notr="true">length</string>
               </property>
               <property name="unitAwareProperties">
                <set>qMRMLSliderWidget::Precision|qMRMLSliderWidget::Prefix|qMRMLSliderWidget::Scaling|qMRMLSliderWidget::Suffix</set>
@@ -780,7 +780,7 @@
                   <double>5.000000000000000</double>
                  </property>
                  <property name="quantity">
-                  <string>length</string>
+                  <string notr="true">length</string>
                  </property>
                  <property name="unitAwareProperties">
                   <set>qMRMLSliderWidget::Precision|qMRMLSliderWidget::Prefix|qMRMLSliderWidget::Scaling|qMRMLSliderWidget::Suffix</set>
@@ -905,7 +905,7 @@
                <string>Markups node that defines glyph starting positions. If specified then 3D view 'Region' is ignored.</string>
               </property>
               <property name="nodeTypes">
-               <stringlist>
+               <stringlist notr="true">
                 <string>vtkMRMLMarkupsNode</string>
                </stringlist>
               </property>
@@ -975,7 +975,7 @@
                <double>10.000000000000000</double>
               </property>
               <property name="quantity">
-               <string>length</string>
+               <string notr="true">length</string>
               </property>
               <property name="unitAwareProperties">
                <set>qMRMLSliderWidget::Precision|qMRMLSliderWidget::Prefix|qMRMLSliderWidget::Scaling|qMRMLSliderWidget::Suffix</set>
@@ -1057,7 +1057,7 @@
                <double>1.000000000000000</double>
               </property>
               <property name="quantity">
-               <string>length</string>
+               <string notr="true">length</string>
               </property>
               <property name="unitAwareProperties">
                <set>qMRMLSliderWidget::Precision|qMRMLSliderWidget::Prefix|qMRMLSliderWidget::Scaling|qMRMLSliderWidget::Suffix</set>
@@ -1098,7 +1098,7 @@
                <double>5.000000000000000</double>
               </property>
               <property name="quantity">
-               <string>length</string>
+               <string notr="true">length</string>
               </property>
               <property name="unitAwareProperties">
                <set>qMRMLSliderWidget::Precision|qMRMLSliderWidget::Prefix|qMRMLSliderWidget::Scaling|qMRMLSliderWidget::Suffix</set>
@@ -1206,7 +1206,7 @@
                <double>5.000000000000000</double>
               </property>
               <property name="quantity">
-               <string>length</string>
+               <string notr="true">length</string>
               </property>
               <property name="unitAwareProperties">
                <set>qMRMLSliderWidget::Precision|qMRMLSliderWidget::Prefix|qMRMLSliderWidget::Scaling|qMRMLSliderWidget::Suffix</set>

--- a/Modules/Loadable/Units/Widgets/DesignerPlugins/qMRMLUnitWidgetPlugin.cxx
+++ b/Modules/Loadable/Units/Widgets/DesignerPlugins/qMRMLUnitWidgetPlugin.cxx
@@ -37,9 +37,11 @@ QWidget *qMRMLUnitWidgetPlugin::createWidget(QWidget *_parent)
 //------------------------------------------------------------------------------
 QString qMRMLUnitWidgetPlugin::domXml() const
 {
-  return "<widget class=\"qMRMLUnitWidget\" \
-          name=\"MRMLUnitWidget\">\n"
-          "</widget>\n";
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLUnitWidget\" name=\"MRMLUnitWidget\">\n"
+    "  <property name=\"quantity\"> <string notr=\"true\"/> </property>\n"
+    "</widget>\n"
+    "</ui>\n";
 }
 
 //------------------------------------------------------------------------------

--- a/Modules/Loadable/Units/Widgets/Resources/UI/qMRMLSettingsUnitWidget.ui
+++ b/Modules/Loadable/Units/Widgets/Resources/UI/qMRMLSettingsUnitWidget.ui
@@ -33,7 +33,7 @@
       <string>Select the current unit node to modify.</string>
      </property>
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLUnitNode</string>
       </stringlist>
      </property>

--- a/Modules/Loadable/Units/Widgets/Resources/UI/qMRMLUnitWidget.ui
+++ b/Modules/Loadable/Units/Widgets/Resources/UI/qMRMLUnitWidget.ui
@@ -27,7 +27,7 @@
    <item row="1" column="1">
     <widget class="qMRMLNodeComboBox" name="PresetNodeComboBox">
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLUnitNode</string>
       </stringlist>
      </property>

--- a/Modules/Loadable/ViewControllers/Resources/UI/qSlicerViewControllersModuleWidget.ui
+++ b/Modules/Loadable/ViewControllers/Resources/UI/qSlicerViewControllersModuleWidget.ui
@@ -64,7 +64,7 @@
            <string>Select a view from the current scene. Each element corresponds to a specific widget. View nodes are connected with 3D rendering widgets. PlotView with Plotting widgets. Slices (Red, Green, Yellow) with 2D rendering widgets.</string>
           </property>
           <property name="nodeTypes">
-           <stringlist>
+           <stringlist notr="true">
             <string>vtkMRMLSliceNode</string>
             <string>vtkMRMLViewNode</string>
             <string>vtkMRMLPlotViewNode</string>

--- a/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
+++ b/Modules/Loadable/VolumeRendering/Resources/UI/qSlicerVolumeRenderingModuleWidget.ui
@@ -60,12 +60,12 @@
    <item row="1" column="1">
     <widget class="qMRMLNodeComboBox" name="VolumeNodeComboBox">
      <property name="nodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLScalarVolumeNode</string>
       </stringlist>
      </property>
      <property name="hideChildNodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLDiffusionWeightedVolumeNode</string>
        <string>vtkMRMLDiffusionTensorVolumeNode</string>
        <string>vtkMRMLMultiVolumeNode</string>
@@ -119,7 +119,7 @@
       <item row="0" column="1">
        <widget class="qMRMLNodeComboBox" name="ROINodeComboBox">
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLMarkupsROINode</string>
           <string>vtkMRMLAnnotationROINode</string>
          </stringlist>
@@ -142,7 +142,7 @@
       <item row="1" column="1">
        <widget class="qMRMLNodeComboBox" name="VolumePropertyNodeComboBox">
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLVolumePropertyNode</string>
          </stringlist>
         </property>

--- a/Modules/Loadable/VolumeRendering/Widgets/qSlicerGPUMemoryComboBox.h
+++ b/Modules/Loadable/VolumeRendering/Widgets/qSlicerGPUMemoryComboBox.h
@@ -34,7 +34,7 @@ class Q_SLICER_MODULE_VOLUMERENDERING_WIDGETS_EXPORT qSlicerGPUMemoryComboBox
 {
   Q_OBJECT
   Q_PROPERTY(double currentGPUMemory READ currentGPUMemory WRITE setCurrentGPUMemory)
-  Q_PROPERTY(QString currentGPUMemoryString READ currentGPUMemoryAsString WRITE setCurrentGPUMemoryFromString)
+  Q_PROPERTY(QString currentGPUMemoryString READ currentGPUMemoryAsString WRITE setCurrentGPUMemoryFromString DESIGNABLE false)
 
 public:
   /// Constructors

--- a/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesModuleWidget.ui
+++ b/Modules/Loadable/Volumes/Resources/UI/qSlicerVolumesModuleWidget.ui
@@ -45,7 +45,7 @@
      <item>
       <widget class="qMRMLNodeComboBox" name="ActiveVolumeNodeSelector">
        <property name="nodeTypes">
-        <stringlist>
+        <stringlist notr="true">
          <string>vtkMRMLVolumeNode</string>
         </stringlist>
        </property>
@@ -118,7 +118,7 @@
          <item>
           <widget class="qMRMLNodeComboBox" name="ConvertVolumeTargetSelector">
            <property name="nodeTypes">
-            <stringlist>
+            <stringlist notr="true">
              <string>vtkMRMLLabelMapVolumeNode</string>
             </stringlist>
            </property>

--- a/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerDTISliceDisplayWidget.ui
+++ b/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerDTISliceDisplayWidget.ui
@@ -76,7 +76,7 @@
    <item row="2" column="1">
     <widget class="qMRMLColorTableComboBox" name="GlyphScalarColorTableComboBox">
      <property name="hideChildNodeTypes">
-      <stringlist>
+      <stringlist notr="true">
        <string>vtkMRMLDiffusionTensorDisplayPropertiesNode</string>
       </stringlist>
      </property>

--- a/Modules/Scripted/DICOMLib/Widgets/Resources/UI/qSlicerDICOMExportDialog.ui
+++ b/Modules/Scripted/DICOMLib/Widgets/Resources/UI/qSlicerDICOMExportDialog.ui
@@ -341,7 +341,7 @@ If unchecked, the exported dataset will be added to the DICOM database.</string>
          <set>ctkPathLineEdit::ShowDirsOnly</set>
         </property>
         <property name="settingKey">
-         <string>DICOM/ExportFolder</string>
+         <string notr="true">DICOM/ExportFolder</string>
         </property>
        </widget>
       </item>

--- a/Utilities/Templates/Modules/Scripted/Resources/UI/TemplateKey.ui
+++ b/Utilities/Templates/Modules/Scripted/Resources/UI/TemplateKey.ui
@@ -30,7 +30,7 @@
          <string>Pick the input to the algorithm.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLScalarVolumeNode</string>
          </stringlist>
         </property>
@@ -93,7 +93,7 @@
          <string>Pick the output to the algorithm.</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLScalarVolumeNode</string>
          </stringlist>
         </property>
@@ -124,7 +124,7 @@
          <string>Result with inverted threshold will be written into this volume</string>
         </property>
         <property name="nodeTypes">
-         <stringlist>
+         <stringlist notr="true">
           <string>vtkMRMLScalarVolumeNode</string>
          </stringlist>
         </property>


### PR DESCRIPTION
In Qt .ui files, strings and stringlists are marked as translatable by default, which makes MRML node names and quantity identifier show up in translation source (.ts) files as a translatable string. This may be confusing for translators and if the strings are actually translated then it can cause issues.

Fixed the issue by marking all existing node class string lists and quantities as non-translatable. As a preventive measure, updated all custom widget plugins so that non-translatable string and stringlist properties are set to non-translatable by default.

Note: Qt has the option to prevent string translation options to show up in Qt designer by making domXml() method return stringpropertyspecification like this:

```
  return  "<ui language=\"c++\">\n"
    // Set default widget property attributes
    "<widget class=\"qMRMLCoordinatesWidget\" name=\"MRMLCoordinatesWidget\">\n"
    "</widget>\n"
    "<customwidgets>\n"
    "  <customwidget> <class>qMRMLNodeComboBox</class>\n"
    "    <propertyspecifications>\n"
    "      <stringpropertyspecification name=\"quantity\" notr=\"true\" type=\"singleline\" />\n"
    "    </propertyspecifications>\n"
    "  </customwidget>\n"
    "</customwidgets>\n"
    "</ui>\n";
```

However, we did not choose to use this mechanism because it has two limitations:
- it does not prevent non-translatable strings from showing up in .ts files
- it only works for string properties (not for stringlist)