### PR TITLE
BUG: Fix vtkMRMLMarkupsROINode::GetRASBounds not accounting for scaling

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.cxx
@@ -234,15 +234,17 @@ void vtkMRMLMarkupsROINode::GetRASBounds(double bounds[6])
 
   if (this->ROIType == ROITypeBox || this->ROIType == ROITypeBoundingBox)
     {
-    double xAxisWorld[3] = { 0.0, 0.0, 0.0 };
-    this->GetXAxisWorld(xAxisWorld);
-    double yAxisWorld[3] = { 0.0, 0.0, 0.0 };
-    this->GetYAxisWorld(yAxisWorld);
-    double zAxisWorld[3] = { 0.0, 0.0, 0.0 };
-    this->GetZAxisWorld(zAxisWorld);
-    double centerWorld[3] = { 0.0, 0.0, 0.0 };
-    this->GetCenterWorld(centerWorld);
-    this->GenerateBoxBounds(bounds, xAxisWorld, yAxisWorld, zAxisWorld, centerWorld, this->Size);
+    double xAxis_World[3] = { 0.0, 0.0, 0.0 };
+    this->GetXAxisWorld(xAxis_World);
+    double yAxis_World[3] = { 0.0, 0.0, 0.0 };
+    this->GetYAxisWorld(yAxis_World);
+    double zAxis_World[3] = { 0.0, 0.0, 0.0 };
+    this->GetZAxisWorld(zAxis_World);
+    double center_World[3] = { 0.0, 0.0, 0.0 };
+    this->GetCenterWorld(center_World);
+    double size_World[3] = { 0.0, 0.0, 0.0 };
+    this->GetSizeWorld(size_World);
+    this->GenerateBoxBounds(bounds, xAxis_World, yAxis_World, zAxis_World, center_World, size_World);
     }
 }
 


### PR DESCRIPTION
Previously GetRASBounds did not take the scaled "world" size of the ROI into account when calculating axis-aligned RAS bounds. Fixed by using the GetSizeWorld method to get the size of the ROI in world coordinates.

Fix #6523