### PR TITLE
ENH: Update scissors "Apply to visible segments" label

### DIFF
--- a/Docs/user_guide/modules/segmenteditor.md
+++ b/Docs/user_guide/modules/segmenteditor.md
@@ -157,19 +157,19 @@ Notes:
 
 Grows or shrinks the selected segment by the specified margin.
 
-By enabling `Apply to all segments`, all visible segments of the segmentation will be processed (in the order of the segment list).
+By enabling `Apply to visible segments`, all visible segments of the segmentation will be processed (in the order of the segment list).
 
 ### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_hollow.png) Hollow
 
 Makes the selected visible segment hollow by replacing the segment with a uniform-thickness shell defined by the segment boundary.
 
-By enabling `Apply to all segments`, all visible segments of the segmentation will be processed (in the order of the segment list).
+By enabling `Apply to visible segments`, all visible segments of the segmentation will be processed (in the order of the segment list).
 
 ### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_smoothing.png) Smoothing
 
 Smoothes segments by filling in holes and/or removing extrusions.
 
-By default, the current segment will be smoothed. By enabling `Apply to all segments`, all visible segments of the segmentation will be smoothed (in the order of the segment list). This operation may be time-consuming for complex segmentations. The `Joint smoothing` method always smoothes all visible segments.
+By default, the current segment will be smoothed. By enabling `Apply to visible segments`, all visible segments of the segmentation will be smoothed (in the order of the segment list). This operation may be time-consuming for complex segmentations. The `Joint smoothing` method always smoothes all visible segments.
 
 By clicking `Apply` button, the entire segmentation is smoothed. To smooth a specific region, left click and drag in any slice or 3D view. Same smoothing method and strength is used as for the whole-segmentation mode (size of the brush does not affect smoothing strength, just makes it easier to designate a larger region).
 
@@ -187,7 +187,7 @@ Clip segments to the specified region or fill regions of a segment (typically us
 - Left click to start drawing (free-form or rubber band circle or rectangle)
 - Release button to apply
 
-By enabling `Apply to all segments`, all visible segments of the segmentation will be processed (in the order of the segment list).
+By enabling `Apply to visible segments`, all visible segments of the segmentation will be processed (in the order of the segment list).
 
 ### ![](https://github.com/Slicer/Slicer/releases/download/docs-resources/module_segmenteditor_islands.png) Islands
 

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorHollowEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorHollowEffect.py
@@ -66,7 +66,7 @@ class SegmentEditorHollowEffect(AbstractScriptedSegmentEditorEffect):
         self.applyToAllVisibleSegmentsCheckBox.setToolTip("Apply hollow effect to all visible segments in this segmentation node. \
                                                       This operation may take a while.")
         self.applyToAllVisibleSegmentsCheckBox.objectName = self.__class__.__name__ + 'ApplyToAllVisibleSegments'
-        self.applyToAllVisibleSegmentsLabel = self.scriptedEffect.addLabeledOptionsWidget("Apply to all segments:", self.applyToAllVisibleSegmentsCheckBox)
+        self.applyToAllVisibleSegmentsLabel = self.scriptedEffect.addLabeledOptionsWidget("Apply to visible segments:", self.applyToAllVisibleSegmentsCheckBox)
 
         self.applyButton = qt.QPushButton("Apply")
         self.applyButton.objectName = self.__class__.__name__ + 'Apply'

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorMarginEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorMarginEffect.py
@@ -64,7 +64,7 @@ class SegmentEditorMarginEffect(AbstractScriptedSegmentEditorEffect):
         self.applyToAllVisibleSegmentsCheckBox.setToolTip("Grow or shrink all visible segments in this segmentation node. \
                                                       This operation may take a while.")
         self.applyToAllVisibleSegmentsCheckBox.objectName = self.__class__.__name__ + 'ApplyToAllVisibleSegments'
-        self.applyToAllVisibleSegmentsLabel = self.scriptedEffect.addLabeledOptionsWidget("Apply to all segments:", self.applyToAllVisibleSegmentsCheckBox)
+        self.applyToAllVisibleSegmentsLabel = self.scriptedEffect.addLabeledOptionsWidget("Apply to visible segments:", self.applyToAllVisibleSegmentsCheckBox)
 
         self.applyButton = qt.QPushButton("Apply")
         self.applyButton.objectName = self.__class__.__name__ + 'Apply'

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
@@ -89,7 +89,7 @@ If segments overlap, segment higher in the segments table will have priority. <b
         self.applyToAllVisibleSegmentsCheckBox.setToolTip("Apply smoothing effect to all visible segments in this segmentation node. \
                                                       This operation may take a while.")
         self.applyToAllVisibleSegmentsCheckBox.objectName = self.__class__.__name__ + 'ApplyToAllVisibleSegments'
-        self.applyToAllVisibleSegmentsLabel = self.scriptedEffect.addLabeledOptionsWidget("Apply to all segments:", self.applyToAllVisibleSegmentsCheckBox)
+        self.applyToAllVisibleSegmentsLabel = self.scriptedEffect.addLabeledOptionsWidget("Apply to visible segments:", self.applyToAllVisibleSegmentsCheckBox)
 
         self.applyButton = qt.QPushButton("Apply")
         self.applyButton.objectName = self.__class__.__name__ + 'Apply'

--- a/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
+++ b/Modules/Loadable/Segmentations/EditorEffects/qSlicerSegmentEditorScissorsEffect.cxx
@@ -1240,7 +1240,7 @@ void qSlicerSegmentEditorScissorsEffect::setupOptionsFrame()
   d->gridLayout->addWidget(d->symmetricRadioButton, 4, 2);
   d->gridLayout->addWidget(d->sliceCutDepthSpinBox, 5, 2);
 
-  QLabel* applyToAllVisibleSegmentsLabel = new QLabel(tr("Apply to all segments:"));
+  QLabel* applyToAllVisibleSegmentsLabel = new QLabel(tr("Apply to visible segments:"));
   applyToAllVisibleSegmentsLabel->setToolTip(tr("Apply scissor effect to all visible segments from top to bottom. \
                                           After pressing 'Apply': Please be patient - this may be time-consuming. \
                                           Progress will be shown as status message. "));


### PR DESCRIPTION
The "Apply to all segments" label was misleading, since enabling it caused the scissors effect to only apply on all visible segments.
Changed label from "Apply to all segments" to "Apply to visible segments".

See: https://discourse.slicer.org/t/erase-using-a-segment-as-only-editable-area/20519/13