### PR TITLE
BUG: Prevent creation of duplicate markup representations

### DIFF
--- a/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.cxx
+++ b/Modules/Loadable/Markups/MRMLDM/vtkMRMLMarkupsDisplayableManagerHelper.cxx
@@ -291,6 +291,14 @@ void vtkMRMLMarkupsDisplayableManagerHelper::AddDisplayNode(vtkMRMLMarkupsDispla
     return;
     }
 
+  int wasModified = 0;
+  if (markupsDisplayNode->GetDisplayableNode())
+    {
+    // Prevent potential recursive calls during UpdateFromMRML call before the new widget is stored
+    // in MarkupsDisplayNodesToWidgets.
+    wasModified = markupsDisplayNode->GetDisplayableNode()->StartModify();
+    }
+
   vtkSlicerMarkupsWidget* newWidget = this->DisplayableManager->CreateWidget(markupsDisplayNode);
   if (!newWidget)
     {
@@ -304,10 +312,12 @@ void vtkMRMLMarkupsDisplayableManagerHelper::AddDisplayNode(vtkMRMLMarkupsDispla
   // Build representation
   newWidget->UpdateFromMRML(markupsDisplayNode, 0); // no specific event triggers full rebuild
 
-  this->DisplayableManager->RequestRender();
+  if (markupsDisplayNode->GetDisplayableNode())
+    {
+    markupsDisplayNode->GetDisplayableNode()->EndModify(wasModified);
+    }
 
-  // Update cached matrices. Calls UpdateWidget
-  //this->UpdateDisplayableTransforms(mNode);
+  this->DisplayableManager->RequestRender();
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
In some cases, when the creation of the markups widget triggers modified event on the markups node, in a recursive call of vtkMRMLMarkupsDisplayableManagerHelper::AddDisplayNode, a second representation is created, which then will be orphaned, because the map MarkupsDisplayNodesToWidgets will point only to the first one. This causes problems in the form of duplicate, stuck actors. Solved by not allowing modified events to be handled until the creation of the widget is finished.