### PR TITLE
ENH: Add option to hide the maximize view button

### DIFF
--- a/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
+++ b/Libs/MRML/Widgets/qMRMLViewControllerBar.cxx
@@ -49,13 +49,6 @@ qMRMLViewControllerBarPrivate::qMRMLViewControllerBarPrivate(
   : QObject(nullptr)
   , q_ptr(&object)
 {
-  this->PinButton = nullptr;
-  this->ViewLabel = nullptr;
-  this->PopupWidget = nullptr;
-  this->BarLayout = nullptr;
-  this->BarWidget = nullptr;
-  this->ControllerLayout = nullptr;
-  this->LayoutBehavior = qMRMLViewControllerBar::Popup;
 }
 
 //---------------------------------------------------------------------------
@@ -371,8 +364,8 @@ void qMRMLViewControllerBar::updateWidgetFromMRMLView()
     d->ViewNode->GetMaximizedState(isMaximized, canBeMaximized);
     }
 
-  d->MaximizeViewButton->setVisible(canBeMaximized);
-  if (canBeMaximized)
+  d->MaximizeViewButton->setVisible(canBeMaximized && d->ShowMaximizeViewButton);
+  if (canBeMaximized && d->ShowMaximizeViewButton)
     {
     if (isMaximized)
       {
@@ -385,4 +378,19 @@ void qMRMLViewControllerBar::updateWidgetFromMRMLView()
       d->MaximizeViewButton->setIcon(d->ViewMaximizeIcon);
       }
     }
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLViewControllerBar::showMaximizeViewButton()const
+{
+  Q_D(const qMRMLViewControllerBar);
+  return d->ShowMaximizeViewButton;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLViewControllerBar::setShowMaximizeViewButton(bool show)
+{
+  Q_D(qMRMLViewControllerBar);
+  d->ShowMaximizeViewButton = show;
+  this->updateWidgetFromMRMLView();
 }

--- a/Libs/MRML/Widgets/qMRMLViewControllerBar.h
+++ b/Libs/MRML/Widgets/qMRMLViewControllerBar.h
@@ -57,6 +57,7 @@ class QMRML_WIDGETS_EXPORT qMRMLViewControllerBar
 {
   Q_OBJECT
   QVTK_OBJECT
+  Q_PROPERTY(bool showMaximizeViewButton READ showMaximizeViewButton WRITE setShowMaximizeViewButton)
 
 public:
   /// Superclass typedef
@@ -92,8 +93,12 @@ public:
   /// Label that displays the view's name.
   Q_INVOKABLE QLabel* viewLabel();
 
+  bool showMaximizeViewButton()const;
+
 public slots:
   void maximizeView();
+
+  void setShowMaximizeViewButton(bool show);
 
 protected slots:
   virtual void updateWidgetFromMRMLView();

--- a/Libs/MRML/Widgets/qMRMLViewControllerBar_p.h
+++ b/Libs/MRML/Widgets/qMRMLViewControllerBar_p.h
@@ -75,17 +75,18 @@ public:
   vtkWeakPointer<vtkMRMLAbstractViewNode> ViewNode;
   vtkWeakPointer<vtkMRMLLayoutNode> LayoutNode;
 
-  QToolButton*                     PinButton;
-  QLabel*                          ViewLabel;
-  QToolButton*                     MaximizeViewButton;
-  ctkPopupWidget*                  PopupWidget;
-  QWidget*                         BarWidget;
-  QHBoxLayout*                     BarLayout;
-  QVBoxLayout*                     ControllerLayout;
-  qMRMLViewControllerBar::LayoutBehavior  LayoutBehavior;
+  QToolButton*                     PinButton{nullptr};
+  QLabel*                          ViewLabel{nullptr};
+  QToolButton*                     MaximizeViewButton{nullptr};
+  ctkPopupWidget*                  PopupWidget{nullptr};
+  QWidget*                         BarWidget{nullptr};
+  QHBoxLayout*                     BarLayout{nullptr};
+  QVBoxLayout*                     ControllerLayout{nullptr};
+  qMRMLViewControllerBar::LayoutBehavior  LayoutBehavior{qMRMLViewControllerBar::Popup};
   QColor                           BarColor;
   QIcon                            ViewMaximizeIcon;
   QIcon                            ViewRestoreIcon;
+  bool                             ShowMaximizeViewButton{true};
 
   bool eventFilter(QObject* object, QEvent* event) override;
 


### PR DESCRIPTION
In custom apps usually it is easy to simply find unwanted toolbar elements by object name and hide it. However, in the case of the maximize view button, it is automatically shown if the view can be maximized, which makes it reappear in the custom apps. It is possible to remove it from the layout but it does not work properly in all cases. By adding such an option it is possible to hide it appropriately.