### PR TITLE
BUG: Make Web Server module DICOMweb endpoint more robust

### DIFF
--- a/Modules/Scripted/WebServer/CMakeLists.txt
+++ b/Modules/Scripted/WebServer/CMakeLists.txt
@@ -14,7 +14,9 @@ set(MODULE_PYTHON_SCRIPTS
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/WebServer.svg  # source: Google Material Icon set (api_black_24dp.svg)
   Resources/docroot/index.html
+  Resources/docroot/db.html
   Resources/docroot/favicon.ico
+  Resources/docroot/package.json
   Resources/docroot/images/3DSlicer-DesktopIcon.png
   Resources/docroot/ServerTests/glMatrix-0.9.5.min.js
   Resources/docroot/ServerTests/index.html

--- a/Modules/Scripted/WebServer/Resources/docroot/db.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/db.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8" />
+
+	<meta name="description" content="Open Health Imaging Foundation DICOM Viewer" />
+	<meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1,maximum-scale=1,user-scalable=no" />
+	<meta name="theme-color" content="#000000" />
+	<meta http-equiv="cleartype" content="on" />
+	<meta name="MobileOptimized" content="320" />
+	<meta name="HandheldFriendly" content="True" />
+	<meta name="apple-mobile-web-app-capable" content="yes" />
+
+	<!-- WEB FONTS -->
+	<link href="https://fonts.googleapis.com/css?family=Sanchez" rel="stylesheet" />
+
+	<title>OHIF Standalone Viewer</title>
+</head>
+
+<body>
+	<noscript> You need to enable JavaScript to run this app. </noscript>
+
+	<div id="root"></div>
+
+  <script src="https://unpkg.com/@ohif/viewer@1.0.3/dist/index.umd.js" crossorigin></script>
+  <script>
+    var containerId = "root";
+    var componentRenderedOrUpdatedCallback = function(){
+      console.log('OHIF Viewer rendered/updated');
+    }
+    window.OHIFViewer.installViewer(
+      {
+      routerBasename: '/db.html',
+      servers: {
+        dicomWeb: [
+          {
+            name: 'DCM4CHEE',
+            wadoUriRoot: 'http://localhost:2016/dicom',
+            qidoRoot: 'http://localhost:2016/dicom',
+            wadoRoot: 'http://localhost:2016/dicom',
+            qidoSupportsIncludeField: true,
+            imageRendering: 'wadouri',
+            thumbnailRendering: 'wadouri',
+            enableStudyLazyLoad: true,
+            supportsFuzzyMatching: true,
+          },
+        ],
+      },
+    }, containerId, componentRenderedOrUpdatedCallback);
+	</script>
+</body>
+
+</html>

--- a/Modules/Scripted/WebServer/Resources/docroot/index.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/index.html
@@ -71,6 +71,14 @@
 
   <ul>
     <li>
+      <h3>Remote DICOM viewer</h3>
+      <p>Allow remote browsing and viewing of images stored in the Slicer DICOM database using <a href="https://ohif.org/">OHIF</a>.</p>
+      <h3><a href='./db.html'>DICOM database viewer</a></h3>
+    </li>
+  </ul>
+
+  <ul>
+    <li>
       <h3>Studies</h3>
       <p>Get list of all studies.</p>
       <a href='./dicom/studies'>dicom/studies</a><br>

--- a/Modules/Scripted/WebServer/Resources/docroot/package.json
+++ b/Modules/Scripted/WebServer/Resources/docroot/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "viewer-script-tag",
+    "version": "1.0.0",
+    "description": "",
+    "main": "db.html",
+    "scripts": {
+      "start": "parcel db.html --open",
+      "build": "parcel build db.html"
+    },
+    "dependencies": {},
+    "devDependencies": {
+      "@babel/core": "7.2.0",
+      "parcel-bundler": "^1.6.1"
+    },
+    "keywords": []
+  }

--- a/Modules/Scripted/WebServer/WebServer.py
+++ b/Modules/Scripted/WebServer/WebServer.py
@@ -10,6 +10,7 @@ import qt
 
 import slicer
 from slicer.ScriptedLoadableModule import *
+from slicer.util import settingsValue, toBool
 
 #
 # WebServer
@@ -163,15 +164,15 @@ class WebServerWidget(ScriptedLoadableModuleWidget):
         self.updateGUIFromLogic()
 
     def updateGUIFromSettings(self):
-        self.logToConsole.checked = slicer.app.userSettings().value("WebServer/logToConsole", False)
-        self.logToGUI.checked = slicer.app.userSettings().value("WebServer/logToGUI", True)
-        self.enableSlicerHandler.checked = slicer.app.userSettings().value("WebServer/enableSlicerHandler", True)
-        self.enableSlicerHandlerExec.checked = slicer.app.userSettings().value("WebServer/enableSlicerHandlerExec", False)
+        self.logToConsole.checked = settingsValue('WebServer/logToConsole', False, converter=toBool)
+        self.logToGUI.checked = settingsValue("WebServer/logToGUI", False, converter=toBool)
+        self.enableSlicerHandler.checked = settingsValue("WebServer/enableSlicerHandler", True, converter=toBool)
+        self.enableSlicerHandlerExec.checked = settingsValue("WebServer/enableSlicerHandlerExec", False, converter=toBool)
         if hasattr(slicer.modules, "dicom"):
-            self.enableDICOMHandler.checked = slicer.app.userSettings().value("WebServer/enableDICOMHandler", True)
+            self.enableDICOMHandler.checked = settingsValue("WebServer/enableDICOMHandler", True, converter=toBool)
         else:
             self.enableDICOMHandler.checked = False
-        self.enableStaticPagesHandler.checked = slicer.app.userSettings().value("WebServer/enableStaticPagesHandler", True)
+        self.enableStaticPagesHandler.checked = settingsValue("WebServer/enableStaticPagesHandler", True, converter=toBool)
 
     def updateGUIFromLogic(self):
         self.startServerButton.setEnabled(not self.logic.serverStarted)

--- a/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/DICOMRequestHandler.py
@@ -104,7 +104,7 @@ class DICOMRequestHandler(object):
                     studyDataset.SpecificCharacterSet = [u'ISO_IR 100']
                     studyDataset.StudyDate = dataset.StudyDate
                     studyDataset.StudyTime = dataset.StudyTime
-                    studyDataset.StudyDescription = dataset.StudyDescription
+                    studyDataset.StudyDescription = dataset.StudyDescription if hasattr(studyDataset, 'StudyDescription') else None
                     studyDataset.StudyInstanceUID = dataset.StudyInstanceUID
                     studyDataset.AccessionNumber = dataset.AccessionNumber
                     studyDataset.InstanceAvailability = u'ONLINE'
@@ -116,7 +116,7 @@ class DICOMRequestHandler(object):
                     studyDataset.PatientID = dataset.PatientID
                     studyDataset.PatientBirthDate = dataset.PatientBirthDate
                     studyDataset.PatientSex = dataset.PatientSex
-                    studyDataset.StudyID = dataset.StudyID
+                    studyDataset.StudyID = dataset.StudyID if hasattr(studyDataset, 'StudyID') else None
                     studyDataset[self.numberOfStudyRelatedSeriesTag] = pydicom.dataelem.DataElement(
                         self.numberOfStudyRelatedSeriesTag, "IS", str(numberOfStudyRelatedSeries))
                     studyDataset[self.numberOfStudyRelatedInstancesTag] = pydicom.dataelem.DataElement(


### PR DESCRIPTION
Fixed incorrect reading of logging flags from settings (logging was always enabled). Fixed study list loading for cases when optional DICOM fields were not present.

Added OHIF viewer to Web Server API examples.

![image](https://user-images.githubusercontent.com/307929/191301196-15e78d12-baef-46cc-9ef8-69c3c276b274.png)
