### PR TITLE
COMP: Fix workflows not running on pushed commits on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   # Triggers the workflow on push or pull request events
   push:
     branches:
-      - "master"
+      - "main"
     paths-ignore:
       - "COPYRIGHT.txt"
       - "License.txt"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
The `master` branch was renamed to `main` on June 23rd 2022. https://discourse.slicer.org/t/slicer-to-use-more-inclusive-language-in-code/23972/4