### PR TITLE
ENH: Update ITK to allow opening a wider range of NIFTI files

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "05adf2d1f617c2c4b206cb119f72cbb0904158e4" # post-v5.3rc04 2022-08-30
+    "62eb5ca265c56a5fb447e1e167b44411a9c38992" # post-v5.3rc04 2022-09-19
     QUIET
     )
 


### PR DESCRIPTION
Nifti with different spacing in sform and qform are now allowed. Qform is used.

git shortlog 05adf2d..62eb5ca

Bradley Lowekamp (1):
      Merge branch 'upstream-GoogleTest'

Dave Chen (1):
      DOC: Fixed Midas Journal link to use HTTPS

Dženan Zukić (4):
      COMP: Fix build with ITK_USE_SYSTEM_HDF5=ON
      Merge pull request 3615 from blowekamp/UpdateGoogleTest
      ENH: Add a test for different spacing in NIFTI's qform and sform
      STYLE: Make NIFTI test CMakeLists.txt more readable

GoogleTest Upstream (1):
      GoogleTest 2022-06-27 (58d77fa8)

Jon Haitz Legarreta Gorroño (37):
      BUG: Fix Superclass name in RTTI macro
      STYLE: Use the superclass name in itkTypeMacro
      COMP: Remove duplicate include file
      STYLE: Conform to ITK style in variable naming in tests
      STYLE: Prefer using exception checking macros in tests
      ENH: Add `itkBooleanMacro` for boolean ivar
      ENH: Increase coverage for miscellaneous classes
      DOC: Fix spelling mistake in printed message
      STYLE: Conform to ITK style guidelines in test ending message
      STYLE: Remove unnecessary test printed message
      DOC: Fix typos and grammar
      BUG: Fix variable typo `MultiphaseDenseFiniteDifferenceImageFilter` test
      STYLE: Improve `itkUniformRandomSpatialNeighborSubsamplerTest` style
      ENH: Increase `itk::UniformRandomSpatialNeighborSubsampler` coverage
      STYLE: Make flow control variables have a local scope
      STYLE: Conform to ITK style in variable naming in tests
      STYLE: Declare variables closer to where they are instantiated
      ENH: Increase `itk::STAPLEImageFilter` coverage
      ENH: Add `FastMarchingImageToNodePairContainerAdaptor` getter methods
      STYLE: Use `ITK_TRY_EXPECT_NO_EXCEPTION` macro in tests
      STYLE: Use the superclass name in itkTypeMacro
      STYLE: Conform to ITK style guidelines in test ending message
      STYLE: Remove unnecessary message in argumentless test
      STYLE: Use `ITK_TRY_EXPECT_NO_EXCEPTION` macro in tests
      ENH: Increase `itk::RegularStepGradientDescentOptimizerv4` coverage
      ENH: Increase coverage for `itk::ImageRegistrationMethodv4`
      BUG: Set the maximum number of iterations to a non-zero value in test
      ENH: Increase `itk::MultiLabelSTAPLEImageFilter` coverage
      STYLE: Conform to ITK style guidelines in test ending message
      STYLE: Use `ITK_TRY_EXPECT_NO_EXCEPTION` macro in tests
      STYLE: Improve style in `itkMultiLabelSTAPLEImageFilterTest` file
      DOC: Conform to ITK SW Guidelines in comments
      BUG: Fix `itk::STAPLEImageFilter` test argument order
      DOC: Document methods in header file
      STYLE: Remove unnecessary empty comment blocks
      STYLE: Prefer using the `ITK_TRY_EXPECT` macros in tests
      STYLE: Increase test argument check and ending message consistency

Mihail Isakov (1):
      ENH: allow Nifti with wrong scales in sform

Niels Dekker (20):
      ENH: Mimic C++20 `std::make_unique_for_overwrite` for dynamic arrays
      STYLE: Replace `new T[n]` with `make_unique_for_overwrite` in cxx files
      STYLE: More make_unique_for_overwrite, less delete[], on local variables
      STYLE: Make unique_ptr by make_unique_for_overwrite, instead of new T[]
      STYLE: Let Operator Fill allocate temp_slice on the stack, without `new`
      STYLE: Use unique_ptr and make_unique_for_overwrite in Review module
      STYLE: PointSet, LevelSetBase call Superclass::UpdateOutputInformation()
      STYLE: `UpdateOutputInformation()` should call `GetSource()` just once
      ENH: Add DataObject::UpdateSource() alternative to GetSource()->Update()
      STYLE: Call DataObject::UpdateSource(), avoid calling GetSource() twice
      STYLE: Allocate local variables (cells) Mesh on the stack, without `new`
      STYLE: Allocate `Directory::m_Internal` without `new`
      STYLE: Declare `RGBGibbsPriorFilter` data members as `unique_ptr<T[]>`
      STYLE: Declare `ImageGaussianModelEstimator::m_Covariance` as unique_ptr
      STYLE: Remove `mutable` from private "per thread" pointers of metrics
      STYLE: Declare metric "per thread" data members as `unique_ptr<T[]>`
      STYLE: Remove unreachable code from GE5ImageIO `if (buffer == nullptr)`
      STYLE: Declare local `buffer` in `GE5ImageIO::ReadHeader` as unique_ptr
      STYLE: Declare local GEImageHeader pointers in GE5ImageIO as unique_ptr
      BUG: `Object::InvokeEvent` should not use a dangling Observer pointer

Richard Beare (5):
      DOC: Consolidated documentation between parent and child classes
      STYLE: Removing sections of the code relating to an old paper
      STYLE: Removed redundant PAMI macro
      PERF: Using stl stable_sort instead of a custom class and sort
      STYLE: removing commented code and fixing grammar in documentation

Stephen R. Aylward (1):
      ENH: Bump TubeTK to v1.3.3