### PR TITLE
ENH: Display available application version in "About" box

### DIFF
--- a/Base/QTApp/qSlicerAboutDialog.cxx
+++ b/Base/QTApp/qSlicerAboutDialog.cxx
@@ -25,6 +25,10 @@
 #include "qSlicerApplication.h"
 #include "ui_qSlicerAboutDialog.h"
 
+#ifdef Slicer_BUILD_APPLICATIONUPDATE_SUPPORT
+#include "qSlicerApplicationUpdateManager.h"
+#endif
+
 //-----------------------------------------------------------------------------
 class qSlicerAboutDialogPrivate: public Ui_qSlicerAboutDialog
 {
@@ -54,8 +58,23 @@ qSlicerAboutDialog::qSlicerAboutDialog(QWidget* parentWidget)
     d->CreditsTextBrowser->append(slicer->applicationVersion() + " " + "r" + slicer->revision()
       + " / " + slicer->repositoryRevision());
     d->CreditsTextBrowser->append("");
+#ifdef Slicer_BUILD_APPLICATIONUPDATE_SUPPORT
+    if (qSlicerApplicationUpdateManager::isApplicationUpdateEnabled())
+      {
+      qSlicerApplicationUpdateManager* applicationUpdateManager = slicer->applicationUpdateManager();
+      if (applicationUpdateManager && applicationUpdateManager->isUpdateAvailable())
+        {
+        QString appUpdateText = tr("New application version is available: %1").arg(applicationUpdateManager->latestReleaseVersion());
+        d->CreditsTextBrowser->insertHtml(QString("<b><a href=\"%1\"><font color=\"orange\">%2</font></a></b>")
+          .arg(applicationUpdateManager->applicationDownloadPageUrl().toString())
+          .arg(appUpdateText));
+        d->CreditsTextBrowser->append("");
+        }
+      }
+#else
+    d->CreditsTextBrowser->insertHtml("Visit the <a href=\"https://download.slicer.org/\">download site</a> to check if a new version is available.");
     d->CreditsTextBrowser->append("");
-    d->CreditsTextBrowser->insertHtml("<a href=\"https://download.slicer.org/\">Download</a> a newer version<br />");
+#endif
     d->CreditsTextBrowser->append("");
     }
   else

--- a/Base/QTCore/qSlicerApplicationUpdateManager.cxx
+++ b/Base/QTCore/qSlicerApplicationUpdateManager.cxx
@@ -366,13 +366,12 @@ bool qSlicerApplicationUpdateManager::onReleaseInfoQueryFinished(const QUuid& re
       success = true;
       }
 
-    //releaseInfo = qRestAPI::qVariantMapFlattened(restResult.data()->response);
     success = success && qSlicerApplicationUpdateManagerPrivate::validateReleaseInfo(releaseInfo);
     }
   if (!success)
     {
-    // Query failed
-    qWarning() << Q_FUNC_INFO << "Failed to download application update information from server";
+    // Query failed, probably no network connection.
+    // Do not pollute the application output with a warning or error message.
     d->ReleaseInfoQueryUID = QUuid();
     this->refreshUpdateAvailable();
     emit updateCheckCompleted(false);

--- a/Modules/Loadable/SlicerWelcome/Resources/UI/qSlicerWelcomeModuleWidget.ui
+++ b/Modules/Loadable/SlicerWelcome/Resources/UI/qSlicerWelcomeModuleWidget.ui
@@ -322,7 +322,7 @@
       <string>Updates</string>
      </property>
      <property name="collapsed">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <layout class="QFormLayout" name="formLayout">
       <property name="horizontalSpacing">
@@ -355,7 +355,7 @@
         <item>
          <widget class="QCheckBox" name="CheckForUpdatesAutomaticallyCheckBox">
           <property name="toolTip">
-           <string>Periodically check for updates. Note that anonymized usage statistics will be recorded.</string>
+           <string>Periodically check for updates. Note that anonymized usage statistics will be recorded. If the box appears as partially checked it means that automatic updates are only checked for the application or for extensions, but not both - click the checkbox to enable/disable all automatic update checks.</string>
           </property>
           <property name="text">
            <string>Automatically</string>


### PR DESCRIPTION
If application update is found then display the available version number and link to the download page. If no application update is found then do not display link to download page.

Clarify partially checked meaning in "automatic" update check button.

See discussion: https://discourse.slicer.org/t/stable-update-notification/23655/22