### PR TITLE
DOC: Remove sphinx-markdown-tables workaround

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -3,7 +3,8 @@ linkify-it-py
 lxml
 myst-parser
 pygments
-sphinx
+# Workaround for readthedocs bug (https://github.com/readthedocs/sphinx_rtd_theme/issues/1343)
+sphinx~=5.0,!=5.2.0.post0
 sphinx-issues
 sphinx_markdown_tables>=0.0.17
 sphinx-notfound-page

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -5,7 +5,6 @@ myst-parser
 pygments
 sphinx
 sphinx-issues
-# Workaround for https://github.com/ryanfox/sphinx-markdown-tables/issues/36
-git+https://github.com/Dzordzu/sphinx-markdown-tables.git@3bc0849cf6dc0e1b7fe52aafadc2e2ccca698a01
+sphinx_markdown_tables>=0.0.17
 sphinx-notfound-page
 sphinx_rtd_theme>=0.5.2


### PR DESCRIPTION
Fix was integrated into the official release (https://github.com/ryanfox/sphinx-markdown-tables/issues/36), use that instead of a private patch version (which is no longer available).