### PR TITLE
ENH: Color legend is to be shown for slice view, visible in the 3D view

### DIFF
--- a/Docs/developer_guide/script_repository/gui.md
+++ b/Docs/developer_guide/script_repository/gui.md
@@ -466,7 +466,7 @@ slicer.mrmlScene.AddNode(invertedocean)
 
 ### Show color legend for a volume node
 
-Display color legend for a volume node in slice views:
+Display color legend for a volume node in slice views (and in 3D views, if the slice is displayed in 3D):
 
 ```python
 volumeNode = getNode('MRHead')


### PR DESCRIPTION
Color legend is to be shown in 3D view for volumes that are shown in slice views, that are visible in the 3D view. Part of #6111 issue.

Single color bar in 3D.
![image](https://user-images.githubusercontent.com/3785912/192298535-35e1d28f-5aa0-4cc3-90a6-b5fd5d64d831.png)

Multiple color bars in 3D.
![image](https://user-images.githubusercontent.com/3785912/192300632-56c059d6-cb7c-4a96-8446-1d8734a05413.png)

