### PR TITLE
BUG: Ensure default JSON storage node is used in qSlicerMarkupsWriter

### DIFF
--- a/Modules/Loadable/Markups/qSlicerMarkupsWriter.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsWriter.cxx
@@ -128,7 +128,7 @@ bool qSlicerMarkupsWriter::write(const qSlicerIO::IOProperties& properties)
   else
     {
     // json file needs to be written
-    this->setStorageNodeClass(node, "vtkMRMLMarkupsJsonStorageNode");
+    this->setStorageNodeClass(node, QString::fromStdString(node->GetDefaultStorageNodeClassName()));
     }
 
   return Superclass::write(properties);


### PR DESCRIPTION
qSlicerMarkupsWriter was explicitly setting the markups storage node to use vtkMRMLMarkupsJsonStorageNode for writing markups to json. Since some markup types used other storage nodes (ex. vtkMRMLMarkupsROIJsonStorageNode), this caused an issue when trying to save those node types.

See: https://discourse.slicer.org/t/markups-roi-cannot-be-loaded-from-json-file/25430