### PR TITLE
ENH: Allow using segmentation nodes directly as CLI module input/output

### DIFF
--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -672,7 +672,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createImageTagWidget(const ModuleParam
     // and add all nodes that are derived from vtkMRMLVolumeNode.
     widget->setNodeTypes(QStringList()
       << "vtkMRMLScalarVolumeNode"
-      << "vtkMRMLLabelMapVolumeNode"
+      << "vtkMRMLLabelMapVolumeNode" << "vtkMRMLSegmentationNode"
       << "vtkMRMLVectorVolumeNode"
       << "vtkMRMLDiffusionTensorVolumeNode"
       << "vtkMRMLDiffusionWeightedVolumeNode"
@@ -697,11 +697,17 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createImageTagWidget(const ModuleParam
       widget->setNodeTypes(nodeTypes);
       widget->addAttribute("vtkMRMLSequenceNode", "DataNodeClassName", "vtkMRMLScalarVolumeNode");
       }
+    if (nodeType == "vtkMRMLLabelMapVolumeNode")
+      {
+      QStringList nodeTypes;
+      nodeTypes << nodeType << "vtkMRMLSegmentationNode";
+      widget->setNodeTypes(nodeTypes);
+      }
     else
       {
       widget->setNodeTypes(QStringList(nodeType));
       }
-  }
+    }
 
   // TODO - title + " Volume"
 

--- a/Modules/CLI/LabelMapSmoothing/LabelMapSmoothing.xml
+++ b/Modules/CLI/LabelMapSmoothing/LabelMapSmoothing.xml
@@ -51,7 +51,7 @@
   <parameters>
     <label>IO</label>
     <description><![CDATA[Input/output parameters]]></description>
-    <image>
+    <image type="label">
       <name>inputVolume</name>
       <label>Input Volume</label>
       <channel>input</channel>


### PR DESCRIPTION
Wherever a labelmap volume node can be chosen as CLI module input or output, now segmentation module can be used, too.

see #6555
