### PR TITLE
BUG: Minor VectorToScalarVolume module improvements

### DIFF
--- a/Modules/Scripted/VectorToScalarVolume/CMakeLists.txt
+++ b/Modules/Scripted/VectorToScalarVolume/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 #-----------------------------------------------------------------------------
 set(MODULE_NAME VectorToScalarVolume)
 
@@ -8,6 +7,8 @@ set(MODULE_PYTHON_SCRIPTS
   )
 
 set(MODULE_PYTHON_RESOURCES
+  Resources/Icons/${MODULE_NAME}.svg
+  Resources/UI/${MODULE_NAME}.ui
   )
 
 #-----------------------------------------------------------------------------

--- a/Modules/Scripted/VectorToScalarVolume/Resources/Icons/VectorToScalarVolume.svg
+++ b/Modules/Scripted/VectorToScalarVolume/Resources/Icons/VectorToScalarVolume.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg4520"
+   sodipodi:docname="VectorToScalarVolume.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata4526">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4524">
+    <linearGradient
+       id="linearGradient6765"
+       inkscape:collect="always">
+      <stop
+         id="stop6755"
+         offset="0"
+         style="stop-color:#8b8b8b;stop-opacity:0" />
+      <stop
+         style="stop-color:#8b8b8b;stop-opacity:0.90196079"
+         offset="0.17328063"
+         id="stop6757" />
+      <stop
+         style="stop-color:#919191;stop-opacity:0.81176472"
+         offset="0.43722689"
+         id="stop6759" />
+      <stop
+         id="stop6761"
+         offset="0.86030245"
+         style="stop-color:#686868;stop-opacity:0.85882354" />
+      <stop
+         id="stop6763"
+         offset="1"
+         style="stop-color:#676768;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6711">
+      <stop
+         style="stop-color:#ee3128;stop-opacity:0"
+         offset="0"
+         id="stop6707" />
+      <stop
+         id="stop6717"
+         offset="0.16527361"
+         style="stop-color:#ee3128;stop-opacity:0.90289611" />
+      <stop
+         id="stop6713"
+         offset="0.43722689"
+         style="stop-color:#f26b31;stop-opacity:0.81260645" />
+      <stop
+         style="stop-color:#1f65b0;stop-opacity:0.85860306"
+         offset="0.86030245"
+         id="stop6715" />
+      <stop
+         style="stop-color:#1f65b0;stop-opacity:0"
+         offset="1"
+         id="stop6709" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6711"
+       id="linearGradient6705"
+       x1="10.348662"
+       y1="16.467363"
+       x2="38.313293"
+       y2="36.733341"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6765"
+       id="linearGradient6705-6"
+       x1="10.463038"
+       y1="16.86768"
+       x2="37.283909"
+       y2="35.989895"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2256"
+     inkscape:window-height="1410"
+     id="namedview4522"
+     showgrid="false"
+     inkscape:zoom="6.1822917"
+     inkscape:cx="-27.318072"
+     inkscape:cy="-1.3320208"
+     inkscape:window-x="-11"
+     inkscape:window-y="-11"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4520" />
+  <path
+     style="fill:url(#linearGradient6705);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 24.190558,6.3098897 8.120707,7.9491433 4.289106,4.632234 1.830019,4.632235 C 39.584233,27.574886 39.083631,30.389002 37.85,34.2 37.636241,34.636259 36.227396,31.434486 35.6,31.95 20.69148,16.938535 34.787537,31.011408 17.95,14.3 l -1.193893,-3.2435 z"
+     id="path4528"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="fill:url(#linearGradient6705-6);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 33.641658,36.647818 -5.676687,3.517415 -5.66162,0.171564 -4.918175,-1.258137 -5.890372,-4.689423 -1.5440781,-4.803799 -0.6862569,-5.318491 1.20095,-3.488473 1.372514,-2.859404 1.819016,-1.809204 c 7.496871,7.823199 10.737468,10.676642 19.984709,20.537952 z"
+     id="path4528-8"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccc" />
+  <path
+     d="m37.85 34.2-2.25-2.25q.6-1.2 1-2.85.4-1.65.4-2.85 0-2.5-1.1-4.95t-2.85-4.15L24 8.2l-6.05 6.1-2.15-2.15L24 4l11.25 11.1q2.2 2.2 3.475 5.1Q40 23.1 40 26.25q0 1.95-.6 4.075T37.85 34.2Zm2.45 11-6.5-6.5q-1.95 1.6-4.525 2.45Q26.7 42 24 42q-6.6 0-11.3-4.575Q8 32.85 8 26.25q0-2.85.85-5.3.85-2.45 2.65-4.55L2.85 7.75 5 5.6l37.45 37.45ZM24 39q2.3 0 4.275-.6 1.975-.6 3.425-1.85L13.65 18.5q-1.2 1.45-1.925 3.375Q11 23.8 11 26.25q0 5.35 3.825 9.05Q18.65 39 24 39Zm-1.3-12.1Zm5.1-4.8Z"
+     id="path4518" />
+</svg>

--- a/Modules/Scripted/VectorToScalarVolume/Resources/UI/VectorToScalarVolume.ui
+++ b/Modules/Scripted/VectorToScalarVolume/Resources/UI/VectorToScalarVolume.ui
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>VectorToScalarVolume</class>
+ <widget class="qMRMLWidget" name="VectorToScalarVolume">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>279</width>
+    <height>286</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="ctkCollapsibleButton" name="selectionCollapsibleButton">
+     <property name="text">
+      <string>Parameters</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Input vector volume:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLNodeComboBox" name="inputSelector">
+        <property name="toolTip">
+         <string>Pick the input to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLVectorVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Conversion Method: </string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Output scalar Volume:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="qMRMLNodeComboBox" name="outputSelector">
+        <property name="toolTip">
+         <string>Pick the output to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLScalarVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="hideChildNodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLVectorVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="noneEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="editEnabled">
+         <bool>true</bool>
+        </property>
+        <property name="renameEnabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QComboBox" name="methodSelectorComboBox"/>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="componentsSpinBox"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="applyButton">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLNodeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qMRMLNodeComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>VectorToScalarVolume</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>inputSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>248</x>
+     <y>61</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>VectorToScalarVolume</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>outputSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>82</x>
+     <y>135</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>220</x>
+     <y>161</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
+++ b/Modules/Scripted/VectorToScalarVolume/VectorToScalarVolume.py
@@ -1,13 +1,11 @@
-import logging
 from contextlib import contextmanager
-
-import ctk
+import logging
 import qt
 import vtk
 
 import slicer
 from slicer.ScriptedLoadableModule import *
-from slicer.util import NodeModify, VTKObservationMixin
+from slicer.util import VTKObservationMixin
 
 
 @contextmanager
@@ -40,24 +38,15 @@ def MyObjectsBlockSignals(*qobjects):
         qobject.blockSignals(previousValue)
 
 
-def getNode(nodeID):
-    if nodeID is None:
-        return None
-    return slicer.mrmlScene.GetNodeByID(nodeID)
-
-
-def getNodeID(node):
-    if node is None:
-        return ""
-    else:
-        return node.GetID()
-
-
 #
 # VectorToScalarVolume
 #
 
 class VectorToScalarVolume(ScriptedLoadableModule):
+    """Uses ScriptedLoadableModule base class, available at:
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
+    """
+
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
         self.parent.title = "Vector to Scalar Volume"
@@ -89,248 +78,209 @@ NIH Roadmap for Medical Research, Grant U54 EB005149."""
 #
 
 class VectorToScalarVolumeWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
-    """
-    The user selected parameters are stored in a parameterNode.
+    """Uses ScriptedLoadableModuleWidget base class, available at:
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
 
     def __init__(self, parent=None):
+        """
+        Called when the user opens the module the first time and the widget is initialized.
+        """
         ScriptedLoadableModuleWidget.__init__(self, parent)
-        VTKObservationMixin.__init__(self)
+        VTKObservationMixin.__init__(self)  # needed for parameter node observation
         self.logic = None
         self._parameterNode = None
+        self._updatingGUIFromParameterNode = False
 
     def setup(self):
+        """
+        Called when the user opens the module the first time and the widget is initialized.
+        """
         ScriptedLoadableModuleWidget.setup(self)
 
+        # Load widget from .ui file (created by Qt Designer).
+        # Additional widgets can be instantiated manually and added to self.layout.
+        uiWidget = slicer.util.loadUI(self.resourcePath('UI/VectorToScalarVolume.ui'))
+        self.layout.addWidget(uiWidget)
+        self.ui = slicer.util.childWidgetVariables(uiWidget)
+
+        self.ui.methodSelectorComboBox.addItem("Luminance", VectorToScalarVolumeLogic.LUMINANCE)
+        self.ui.methodSelectorComboBox.setItemData(0, '(RGB,RGBA) Luminance from first three components: 0.30*R + 0.59*G + 0.11*B + 0.0*A)', qt.Qt.ToolTipRole)
+        self.ui.methodSelectorComboBox.addItem("Average", VectorToScalarVolumeLogic.AVERAGE)
+        self.ui.methodSelectorComboBox.setItemData(1, 'Average all the components.', qt.Qt.ToolTipRole)
+        self.ui.methodSelectorComboBox.addItem("Single Component Extraction", VectorToScalarVolumeLogic.SINGLE_COMPONENT)
+        self.ui.methodSelectorComboBox.setItemData(2, 'Extract single component', qt.Qt.ToolTipRole)
+
+        # Set scene in MRML widgets. Make sure that in Qt designer the top-level qMRMLWidget's
+        # "mrmlSceneChanged(vtkMRMLScene*)" signal in is connected to each MRML widget's.
+        # "setMRMLScene(vtkMRMLScene*)" slot.
+        uiWidget.setMRMLScene(slicer.mrmlScene)
+
+        # Create logic class. Logic implements all computations that should be possible to run
+        # in batch mode, without a graphical user interface.
         self.logic = VectorToScalarVolumeLogic()
-        # This will use createParameterNode with the provided default options
-        self.setParameterNode(self.logic.getParameterNode())
-
-        self.parameterSetSelectionCollapsibleButton = ctk.ctkCollapsibleButton()
-        self.parameterSetSelectionCollapsibleButton.text = "Parameter set"
-        self.layout.addWidget(self.parameterSetSelectionCollapsibleButton)
-
-        # Layout within the "Selection" collapsible button
-        parameterSetSelectionFormLayout = qt.QFormLayout(self.parameterSetSelectionCollapsibleButton)
-
-        # Parameter set selector (inspired by SegmentStatistics.py)
-        self.parameterNodeSelector = slicer.qMRMLNodeComboBox()
-        self.parameterNodeSelector.nodeTypes = (("vtkMRMLScriptedModuleNode"), "")
-        self.parameterNodeSelector.addAttribute("vtkMRMLScriptedModuleNode", "ModuleName", "VectorToScalarVolume")
-        self.parameterNodeSelector.selectNodeUponCreation = True
-        self.parameterNodeSelector.addEnabled = True
-        self.parameterNodeSelector.renameEnabled = True
-        self.parameterNodeSelector.removeEnabled = True
-        self.parameterNodeSelector.noneEnabled = False
-        self.parameterNodeSelector.showHidden = True
-        self.parameterNodeSelector.showChildNodeTypes = False
-        self.parameterNodeSelector.baseName = "VectorToScalarVolume"
-        self.parameterNodeSelector.setMRMLScene(slicer.mrmlScene)
-        self.parameterNodeSelector.toolTip = "Pick parameter set"
-        parameterSetSelectionFormLayout.addRow("Parameter set: ", self.parameterNodeSelector)
-
-        # Parameters
-        self.selectionCollapsibleButton = ctk.ctkCollapsibleButton()
-        self.selectionCollapsibleButton.text = "Conversion settings"
-        self.layout.addWidget(self.selectionCollapsibleButton)
-
-        # Layout within the "Selection" collapsible button
-        parametersFormLayout = qt.QFormLayout(self.selectionCollapsibleButton)
-
-        #
-        # the volume selectors
-        #
-        self.inputSelector = slicer.qMRMLNodeComboBox()
-        self.inputSelector.nodeTypes = ["vtkMRMLVectorVolumeNode"]
-        self.inputSelector.addEnabled = False
-        self.inputSelector.removeEnabled = False
-        self.inputSelector.setMRMLScene(slicer.mrmlScene)
-        parametersFormLayout.addRow("Input Vector Volume: ", self.inputSelector)
-
-        self.outputSelector = slicer.qMRMLNodeComboBox()
-        self.outputSelector.nodeTypes = ["vtkMRMLScalarVolumeNode"]
-        self.outputSelector.hideChildNodeTypes = ["vtkMRMLVectorVolumeNode"]
-        self.outputSelector.setMRMLScene(slicer.mrmlScene)
-        self.outputSelector.addEnabled = True
-        self.outputSelector.renameEnabled = True
-        self.outputSelector.baseName = "Scalar Volume"
-        parametersFormLayout.addRow("Output Scalar Volume: ", self.outputSelector)
-
-        #
-        # Options to extract single components
-        #
-        self.conversionMethodWidget = VectorToScalarVolumeConversionMethodWidget()
-        parametersFormLayout.addRow("Conversion Method: ", self.conversionMethodWidget)
-        # Apply button
-        self.applyButton = qt.QPushButton("Apply")
-        self.applyButton.toolTip = "Run Convert the vector to scalar."
-        parametersFormLayout.addRow(self.applyButton)
-
-        # Add vertical spacer
-        self.layout.addStretch(1)
 
         # Connections
-        self.parameterNodeSelector.connect('currentNodeChanged(vtkMRMLNode*)', self.setParameterNode)
-        self.parameterNodeSelector.connect('currentNodeChanged(vtkMRMLNode*)', self.updateGuiFromMRML)
 
-        # updateParameterNodeFromGui
-        self.inputSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGui)
-        self.outputSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGui)
+        # These connections ensure that we update parameter node when scene is closed
+        self.addObserver(slicer.mrmlScene, slicer.mrmlScene.StartCloseEvent, self.onSceneStartClose)
+        self.addObserver(slicer.mrmlScene, slicer.mrmlScene.EndCloseEvent, self.onSceneEndClose)
 
-        self.applyButton.connect('clicked(bool)', self.onApply)
+        # These connections ensure that whenever user changes some settings on the GUI, that is saved in the MRML scene
+        # (in the selected parameter node).
+        self.ui.inputSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
+        self.ui.outputSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.updateParameterNodeFromGUI)
+        self.ui.methodSelectorComboBox.connect('currentIndexChanged(int)', self.updateParameterNodeFromGUI)
+        self.ui.componentsSpinBox.connect('valueChanged(int)', self.updateParameterNodeFromGUI)
 
-        # conversion widget
-        self.conversionMethodWidget.methodSelectorComboBox.connect('currentIndexChanged(int)', self.updateParameterNodeFromGui)
-        self.conversionMethodWidget.componentsComboBox.connect('currentIndexChanged(int)', self.updateParameterNodeFromGui)
+        # Buttons
+        self.ui.applyButton.connect('clicked(bool)', self.onApplyButton)
 
-        # The parameter node had defaults at creation, propagate them to the GUI.
-        self.updateGuiFromMRML()
+        # Make sure parameter node is initialized (needed for module reload)
+        self.initializeParameterNode()
 
     def cleanup(self):
+        """
+        Called when the application closes and the module widget is destroyed.
+        """
         self.removeObservers()
 
-    def parameterNode(self):
-        return self._parameterNode
+    def enter(self):
+        """
+        Called each time the user opens this module.
+        """
+        # Make sure parameter node exists and observed
+        self.initializeParameterNode()
+
+    def exit(self):
+        """
+        Called each time the user opens a different module.
+        """
+        # Do not react to parameter node changes (GUI wlil be updated when the user enters into the module)
+        self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
+
+    def onSceneStartClose(self, caller, event):
+        """
+        Called just before the scene is closed.
+        """
+        # Parameter node will be reset, do not use it anymore
+        self.setParameterNode(None)
+
+    def onSceneEndClose(self, caller, event):
+        """
+        Called just after the scene is closed.
+        """
+        # If this module is shown while the scene is closed then recreate a new parameter node immediately
+        if self.parent.isEntered:
+            self.initializeParameterNode()
+
+    def initializeParameterNode(self):
+        """
+        Ensure parameter node exists and observed.
+        """
+        # Parameter node stores all user choices in parameter values, node selections, etc.
+        # so that when the scene is saved and reloaded, these settings are restored.
+
+        self.setParameterNode(self.logic.getParameterNode())
+
+        # Select default input nodes if nothing is selected yet to save a few clicks for the user
+        if not self._parameterNode.GetNodeReference("InputVolume"):
+            firstVolumeNode = slicer.mrmlScene.GetFirstNodeByClass("vtkMRMLVectorVolumeNode")
+            if firstVolumeNode:
+                self._parameterNode.SetNodeReferenceID("InputVolume", firstVolumeNode.GetID())
 
     def setParameterNode(self, inputParameterNode):
-        if inputParameterNode == self._parameterNode:
-            return
+        """
+        Set and observe parameter node.
+        Observation is needed because when the parameter node is changed then the GUI must be updated immediately.
+        """
+
+        if inputParameterNode:
+            self.logic.setDefaultParameters(inputParameterNode)
+
+        # Unobserve previously selected parameter node and add an observer to the newly selected.
+        # Changes of parameter node are observed so that whenever parameters are changed by a script or any other module
+        # those are reflected immediately in the GUI.
         if self._parameterNode is not None:
-            self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGuiFromMRML)
-        if inputParameterNode is not None:
-            self.addObserver(inputParameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGuiFromMRML)
+            self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
         self._parameterNode = inputParameterNode
+        if self._parameterNode is not None:
+            self.addObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
 
-    def inputVolumeNode(self):
-        return self.inputSelector.currentNode()
+        # Initial GUI update
+        self.updateGUIFromParameterNode()
 
-    def setInputVolumeNode(self, node):
-        if isinstance(node, str):
-            node = getNode(node)
-        self.inputSelector.setCurrentNode(node)
+    def updateGUIFromParameterNode(self, caller=None, event=None):
+        """
+        This method is called whenever parameter node is changed.
+        The module GUI is updated to show the current state of the parameter node.
+        """
 
-    def outputVolumeNode(self):
-        return self.outputSelector.currentNode()
+        if self._parameterNode is None or self._updatingGUIFromParameterNode:
+            return
 
-    def setOutputVolumeNode(self, node):
-        if isinstance(node, str):
-            node = getNode(node)
-        self.outputSelector.setCurrentNode(node)
+        # Make sure GUI changes do not call updateParameterNodeFromGUI (it could cause infinite loop)
+        self._updatingGUIFromParameterNode = True
 
-    def updateButtonStates(self):
+        # Update node selectors and sliders
+        inputVolume = self._parameterNode.GetNodeReference("InputVolume")
+        outputVolume = self._parameterNode.GetNodeReference("OutputVolume")
+        self.ui.inputSelector.setCurrentNode(inputVolume)
+        self.ui.outputSelector.setCurrentNode(outputVolume)
+        self.ui.methodSelectorComboBox.setCurrentIndex(
+            self.ui.methodSelectorComboBox.findData(
+                self._parameterNode.GetParameter("ConversionMethod")))
+        self.ui.componentsSpinBox.value = int(self._parameterNode.GetParameter("ComponentToExtract"))
 
         isMethodSingleComponent = self._parameterNode.GetParameter("ConversionMethod") == VectorToScalarVolumeLogic.SINGLE_COMPONENT
+        self.ui.componentsSpinBox.visible = isMethodSingleComponent
 
         # Update apply button state and tooltip
         applyErrorMessage = ""
-        if not self.inputVolumeNode():
+        if not inputVolume:
             applyErrorMessage = "Please select Input Vector Volume"
-        elif not self.outputVolumeNode():
+        elif not outputVolume:
             applyErrorMessage = "Please select Output Scalar Volume"
-        elif not self.parameterNode():
-            applyErrorMessage = "Please select Parameter set"
         elif isMethodSingleComponent and (int(self._parameterNode.GetParameter("ComponentToExtract")) < 0):
             applyErrorMessage = "Please select a component to extract"
+        self.ui.applyButton.enabled = (not applyErrorMessage)
+        self.ui.applyButton.toolTip = applyErrorMessage
 
-        self.applyButton.enabled = (not applyErrorMessage)
-        self.applyButton.toolTip = applyErrorMessage
+        # All the GUI updates are done
+        self._updatingGUIFromParameterNode = False
 
-        self.conversionMethodWidget.componentsComboBox.visible = isMethodSingleComponent
-
-        if (self.inputVolumeNode() is not None) and isMethodSingleComponent:
-            imageComponents = self.inputVolumeNode().GetImageData().GetNumberOfScalarComponents()
-            wasBlocked = self.conversionMethodWidget.componentsComboBox.blockSignals(True)
-            if self.conversionMethodWidget.componentsComboBox.count != imageComponents:
-                self.conversionMethodWidget.componentsComboBox.clear()
-                for comp in range(imageComponents):
-                    self.conversionMethodWidget.componentsComboBox.insertItem(comp, str(comp))
-            self.conversionMethodWidget.componentsComboBox.blockSignals(wasBlocked)
-
-    def updateGuiFromMRML(self, caller=None, event=None):
+    def updateParameterNodeFromGUI(self, caller=None, event=None):
         """
-        Query all the parameters in the parameterNode,
-        and update the GUI state accordingly if something has changed.
+        This method is called when the user makes any change in the GUI.
+        The changes are saved into the parameter node (so that they are restored when the scene is saved and loaded).
         """
 
-        self.updateButtonStates()
-
-        if not self.parameterNode():
+        if self._parameterNode is None or self._updatingGUIFromParameterNode:
             return
 
-        self.setInputVolumeNode(self._parameterNode.GetParameter("InputVectorVolume"))
-        self.setOutputVolumeNode(self._parameterNode.GetParameter("OutputScalarVolume"))
-        self.conversionMethodWidget.methodSelectorComboBox.setCurrentIndex(
-            self.conversionMethodWidget.methodSelectorComboBox.findData(
-                self._parameterNode.GetParameter("ConversionMethod")))
-        self.conversionMethodWidget.componentsComboBox.setCurrentIndex(
-            int(self._parameterNode.GetParameter("ComponentToExtract")))
+        wasModified = self._parameterNode.StartModify()  # Modify all properties in a single batch
 
-    def updateParameterNodeFromGui(self):
+        self._parameterNode.SetNodeReferenceID("InputVolume", self.ui.inputSelector.currentNodeID)
+        self._parameterNode.SetNodeReferenceID("OutputVolume", self.ui.outputSelector.currentNodeID)
+        self._parameterNode.SetParameter("ConversionMethod", self.ui.methodSelectorComboBox.currentData)
+        self._parameterNode.SetParameter("ComponentToExtract", str(self.ui.componentsSpinBox.value))
 
-        self.updateButtonStates()
+        self._parameterNode.EndModify(wasModified)
 
-        if self._parameterNode is None:
-            return
+    def onApplyButton(self):
+        """
+        Run processing when user clicks "Apply" button.
+        """
+        with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
 
-        with NodeModify(self._parameterNode):
-            self._parameterNode.SetParameter("InputVectorVolume", getNodeID(self.inputVolumeNode()))
-            self._parameterNode.SetParameter("OutputScalarVolume", getNodeID(self.outputVolumeNode()))
-            self._parameterNode.SetParameter("ConversionMethod", self.conversionMethodWidget.conversionMethod())
-            self._parameterNode.SetParameter("ComponentToExtract", str(self.conversionMethodWidget.componentToExtract()))
+            # Compute output
+            self.logic.run(self._parameterNode)
 
-    def onApply(self):
-
-        with MyScopedQtPropertySetter(self.applyButton, {"enabled": False, "text": "Working..."}):
-            success = self.logic.run(self._parameterNode)
-
-        # make the output volume appear in all the slice views
-        if success:
+            # make the output volume appear in all the slice views
             selectionNode = slicer.app.applicationLogic().GetSelectionNode()
-            selectionNode.SetActiveVolumeID(self.outputVolumeNode().GetID())
+            outputVolume = self._parameterNode.GetNodeReference("OutputVolume")
+            selectionNode.SetActiveVolumeID(outputVolume.GetID())
             slicer.app.applicationLogic().PropagateVolumeSelection(0)
-
-
-#
-# VectorToScalarVolumeConversionMethodWidget
-#
-
-class VectorToScalarVolumeConversionMethodWidget(qt.QWidget):
-    """
-    Widget to interact with conversion parameters only.
-    It is separated from VectorToScalarVolumeWidget to enable GUI reusability in other modules.
-    """
-
-    def __init__(self, parent=None):
-        qt.QWidget.__init__(self, parent)
-        self.setup()
-
-    def setup(self):
-        self.methodLayout = qt.QHBoxLayout(self)
-        self.methodLayout.setContentsMargins(0, 0, 0, 0)
-        self.methodSelectorComboBox = qt.QComboBox()
-
-        self.methodSelectorComboBox.addItem("Luminance", VectorToScalarVolumeLogic.LUMINANCE)
-        self.methodSelectorComboBox.setItemData(0, '(RGB,RGBA) Luminance from first three components: 0.30*R + 0.59*G + 0.11*B + 0.0*A)', qt.Qt.ToolTipRole)
-        self.methodSelectorComboBox.addItem("Average", VectorToScalarVolumeLogic.AVERAGE)
-        self.methodSelectorComboBox.setItemData(1, 'Average all the components.', qt.Qt.ToolTipRole)
-        self.methodSelectorComboBox.addItem("Single Component Extraction", VectorToScalarVolumeLogic.SINGLE_COMPONENT)
-        self.methodSelectorComboBox.setItemData(2, 'Extract single component', qt.Qt.ToolTipRole)
-
-        self.methodLayout.addWidget(self.methodSelectorComboBox)
-
-        # ComponentToExtract
-        singleComponentLayout = qt.QHBoxLayout()
-        self.componentsComboBox = qt.QComboBox()
-        singleComponentLayout.addWidget(self.componentsComboBox)
-        self.methodLayout.addLayout(singleComponentLayout)
-
-    def componentToExtract(self):
-        " returns current index. -1 is invalid or disabled combo box"
-        return self.componentsComboBox.currentIndex
-
-    def conversionMethod(self):
-        " returns data (str)"
-        return self.methodSelectorComboBox.currentData
 
 
 #
@@ -346,19 +296,23 @@ class VectorToScalarVolumeLogic(ScriptedLoadableModuleLogic):
     LUMINANCE = 'LUMINANCE'
     AVERAGE = 'AVERAGE'
     SINGLE_COMPONENT = 'SINGLE_COMPONENT'
-    EXTRACT_COMPONENT_NONE = -1
 
     CONVERSION_METHODS = (LUMINANCE, AVERAGE, SINGLE_COMPONENT)
 
-    def __init__(self, parent=None):
-        ScriptedLoadableModuleLogic.__init__(self, parent)
+    def __init__(self):
+        """
+        Called when the logic class is instantiated. Can be used for initializing member variables.
+        """
+        ScriptedLoadableModuleLogic.__init__(self)
 
-    def createParameterNode(self):
-        """ Override base class method to provide default parameters. """
-        node = ScriptedLoadableModuleLogic.createParameterNode(self)
-        node.SetParameter("ConversionMethod", self.LUMINANCE)
-        node.SetParameter("ComponentToExtract", str(self.EXTRACT_COMPONENT_NONE))
-        return node
+    def setDefaultParameters(self, parameterNode):
+        """
+        Initialize parameter node with default settings.
+        """
+        if not parameterNode.GetParameter("ConversionMethod"):
+            parameterNode.SetParameter("ConversionMethod", self.LUMINANCE)
+        if not parameterNode.GetParameter("ComponentToExtract"):
+            parameterNode.SetParameter("ComponentToExtract", "0")
 
     @staticmethod
     def isValidInputOutputData(inputVolumeNode, outputVolumeNode, conversionMethod, componentToExtract):
@@ -419,21 +373,17 @@ class VectorToScalarVolumeLogic(ScriptedLoadableModuleLogic):
         Run the conversion with given parameterNode.
         """
         if parameterNode is None:
-            slicer.util.errorDisplay('Invalid Parameter Node: None')
-            return False
+            raise ValueError('Invalid Parameter Node: None')
 
-        inputVolumeNode = getNode(parameterNode.GetParameter("InputVectorVolume"))
-        outputVolumeNode = getNode(parameterNode.GetParameter("OutputScalarVolume"))
+        inputVolumeNode = parameterNode.GetNodeReference("InputVolume")
+        outputVolumeNode = parameterNode.GetNodeReference("OutputVolume")
         conversionMethod = parameterNode.GetParameter("ConversionMethod")
-        componentToExtract = parameterNode.GetParameter("ComponentToExtract")
-        if componentToExtract == '':
-            componentToExtract = str(self.EXTRACT_COMPONENT_NONE)
-        componentToExtract = int(componentToExtract)
+        componentToExtractStr = parameterNode.GetParameter("ComponentToExtract")
+        componentToExtract = int(componentToExtractStr) if componentToExtractStr else -1
 
         valid, msg = self.isValidInputOutputData(inputVolumeNode, outputVolumeNode, conversionMethod, componentToExtract)
         if not valid:
-            slicer.util.errorDisplay(msg)
-            return False
+            raise ValueError(msg)
 
         logging.debug('Conversion mode is %s' % conversionMethod)
         logging.debug('ComponentToExtract is %s' % componentToExtract)
@@ -447,14 +397,12 @@ class VectorToScalarVolumeLogic(ScriptedLoadableModuleLogic):
         if conversionMethod == VectorToScalarVolumeLogic.AVERAGE:
             self.runConversionMethodAverage(inputVolumeNode, outputVolumeNode)
 
-        return True
-
-    def runWithVariables(self, inputVolumeNode, outputVolumeNode, conversionMethod, componentToExtract):
+    def runWithVariables(self, inputVolumeNode, outputVolumeNode, conversionMethod, componentToExtract=0):
         """ Convenience method to run with variables, it creates a new parameterNode with these values. """
 
         parameterNode = self.getParameterNode()
-        parameterNode.SetParameter("InputVectorVolume", getNodeID(inputVolumeNode))
-        parameterNode.SetParameter("OutputScalarVolume", getNodeID(outputVolumeNode))
+        parameterNode.SetNodeReferenceID("InputVolume", inputVolumeNode.GetID())
+        parameterNode.SetNodeReferenceID("OutputVolume", outputVolumeNode.GetID())
         parameterNode.SetParameter("ConversionMethod", conversionMethod)
         parameterNode.SetParameter("ComponentToExtract", str(componentToExtract))
         return self.run(parameterNode)
@@ -506,16 +454,110 @@ class VectorToScalarVolumeLogic(ScriptedLoadableModuleLogic):
             extract.Update()
             # Cast component to Double
             compToDouble = vtk.vtkImageCast()
-            compToDouble.SetInputConnection(0, extract.GetOutputPort())
+            compToDouble.SetInputConnection(extract.GetOutputPort())
             compToDouble.SetOutputScalarTypeToDouble()
             # Add to the weighted sum
             weightedSum.AddInputConnection(compToDouble.GetOutputPort())
 
         logging.debug("TotalInputConnections in weightedSum: %s" % weightedSum.GetTotalNumberOfInputConnections())
         weightedSum.SetNormalizeByWeight(False)  # It is already normalized in the evenWeight case.
-        weightedSum.Update()
+
         # Cast back to the type of the InputVolume, for consistency with other ConversionMethods
         castBack = vtk.vtkImageCast()
-        castBack.SetInputConnection(0, weightedSum.GetOutputPort())
-        castBack.SetOutputScalarType(inputVolumeNode.GetImageData().GetScalarType())
-        outputVolumeNode.SetImageDataConnection(castBack.GetOutputPort())
+        scalarType = inputVolumeNode.GetImageData().GetScalarType()
+        castBack.SetOutputScalarType(scalarType)
+        if scalarType == vtk.VTK_FLOAT or scalarType == vtk.VTK_DOUBLE:
+            # floating type
+            castBack.SetInputConnection(weightedSum.GetOutputPort())
+        else:
+            # integer type, need to round the result by adding 0.5 before casting
+            addConstant = vtk.vtkImageMathematics()
+            addConstant.SetOperationToAddConstant()
+            addConstant.SetConstantC(0.5)
+            addConstant.SetInputConnection(weightedSum.GetOutputPort())
+            castBack.SetInputConnection(addConstant.GetOutputPort())
+        castBack.Update()
+        outputVolumeNode.SetAndObserveImageData(castBack.GetOutput())
+
+
+#
+# VectorToScalarVolumeTest
+#
+
+class VectorToScalarVolumeTest(ScriptedLoadableModuleTest):
+    """
+    This is the test case for your scripted module.
+    Uses ScriptedLoadableModuleTest base class, available at:
+    https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
+    """
+
+    def setUp(self):
+        """ Do whatever is needed to reset the state - typically a scene clear will be enough.
+        """
+        slicer.mrmlScene.Clear()
+
+    def runTest(self):
+        """Run as few or as many tests as needed here.
+        """
+        self.setUp()
+        self.test_VectorToScalarVolume1()
+
+    def test_VectorToScalarVolume1(self):
+        """ Ideally you should have several levels of tests.  At the lowest level
+        tests should exercise the functionality of the logic with different inputs
+        (both valid and invalid).  At higher levels your tests should emulate the
+        way the user would interact with your code and confirm that it still works
+        the way you intended.
+        One of the most important features of the tests is that it should alert other
+        developers when their changes will have an impact on the behavior of your
+        module.  For example, if a developer removes a feature that you depend on,
+        your test should break so they know that the feature is needed.
+        """
+
+        self.delayDisplay("Starting the test")
+
+        # Create input data
+
+        self.delayDisplay("Create input data")
+
+        import numpy as np
+        inputVolume = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLVectorVolumeNode')
+        voxels = np.zeros([7, 8, 9, 3], np.uint8)
+        voxels[:, :, :, 0] = 30
+        voxels[:, :, :, 1] = 50
+        voxels[:, :, :, 2] = 100
+        slicer.util.updateVolumeFromArray(inputVolume, voxels)
+
+        outputVolume = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode")
+
+        # Test the module logic
+
+        logic = VectorToScalarVolumeLogic()
+
+        self.delayDisplay("Test SINGLE_COMPONENT")
+
+        logic.runWithVariables(inputVolume, outputVolume, VectorToScalarVolumeLogic.SINGLE_COMPONENT, 0)
+        outputScalarRange = outputVolume.GetImageData().GetScalarRange()
+        self.assertEqual(outputScalarRange[0], 30)
+        self.assertEqual(outputScalarRange[1], 30)
+
+        logic.runWithVariables(inputVolume, outputVolume, VectorToScalarVolumeLogic.SINGLE_COMPONENT, 1)
+        outputScalarRange = outputVolume.GetImageData().GetScalarRange()
+        self.assertEqual(outputScalarRange[0], 50)
+        self.assertEqual(outputScalarRange[1], 50)
+
+        self.delayDisplay("Test LUMINANCE")
+
+        logic.runWithVariables(inputVolume, outputVolume, VectorToScalarVolumeLogic.LUMINANCE)
+        outputScalarRange = outputVolume.GetImageData().GetScalarRange()
+        self.assertEqual(outputScalarRange[0], 49)
+        self.assertEqual(outputScalarRange[1], 49)
+
+        self.delayDisplay("Test AVERAGE")
+
+        logic.runWithVariables(inputVolume, outputVolume, VectorToScalarVolumeLogic.AVERAGE)
+        outputScalarRange = outputVolume.GetImageData().GetScalarRange()
+        self.assertEqual(outputScalarRange[0], 60)
+        self.assertEqual(outputScalarRange[1], 60)
+
+        self.delayDisplay('Test passed')


### PR DESCRIPTION
When scene was closed or the module was reloaded then the module threw exceptions. Fixed by updating the module to use the latest scripted module template.

Average computation was not correct for integer volumes. For example for a volume containing 30, 50, 100 in 3 channels the average is 60 but it was computed to be 59 (due to casting to int). Fixed by rounding of the average computation result instead of just casting the floating-point value.

fixes #6478