### PR TITLE
Fix lupdate warnings related to tr function calls on private classes

### DIFF
--- a/Base/QTGUI/qSlicerActionsDialog.cxx
+++ b/Base/QTGUI/qSlicerActionsDialog.cxx
@@ -70,7 +70,7 @@ void qSlicerActionsDialogPrivate::init()
   this->WebView->setObjectName("WebView");
   this->gridLayout->addWidget(this->WebView, 0, 0);
   qSlicerCoreApplication* app = qSlicerCoreApplication::application();
-  QString shortcutsUrl = QString(q->tr("%1/user_guide/user_interface.html#mouse-keyboard-shortcuts")).arg(app->documentationBaseUrl());
+  QString shortcutsUrl = QString(qSlicerActionsDialog::tr("%1/user_guide/user_interface.html#mouse-keyboard-shortcuts")).arg(app->documentationBaseUrl());
   this->WebView->setUrl( shortcutsUrl );
 #else
   this->tabWidget->setTabEnabled(this->tabWidget->indexOf(this->WikiTab), false);

--- a/Base/QTGUI/qSlicerModuleFinderDialog.cxx
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.cxx
@@ -93,7 +93,7 @@ void qSlicerModuleFinderDialogPrivate::init()
   this->ModuleListView->viewport()->installEventFilter(q);
 
   QPushButton* okButton = this->ButtonBox->button(QDialogButtonBox::Ok);
-  okButton->setText(q->tr("Switch to module"));
+  okButton->setText(qSlicerModuleFinderDialog::tr("Switch to module"));
 
   if (filterModel->rowCount() > 0)
     {

--- a/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+++ b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
@@ -142,6 +142,13 @@ if(Slicer_USE_PYTHONQT_WITH_OPENSSL)
     "SSL_CERT_FILE=<APPLAUNCHER_SETTINGS_DIR>/${Slicer_SHARE_DIR}/Slicer.crt"
     )
 endif()
+if(UNIX AND NOT APPLE)
+  # Disable Chromium Sandboxing on Linux because not all systems support it
+  # (see https://github.com/Slicer/Slicer/issues/6577)
+  list(APPEND SLICER_ENVVARS_BUILD
+    "QTWEBENGINE_DISABLE_SANDBOX=1"
+    )
+endif()
 
 # External projects - environment variables
 foreach(varname IN LISTS Slicer_EP_LABEL_ENVVARS_LAUNCHER_BUILD)

--- a/Docs/user_guide/extensions_manager.md
+++ b/Docs/user_guide/extensions_manager.md
@@ -122,8 +122,6 @@ This can be due to several reasons:
   - Alternative solution: download extension package using a web browser (possibly on a different computer) and install the extension manually. See instructions [here](#install-extensions-without-network-connection).
 - On macOS: on some older macbooks, the extension manager window appears very bright, washed out (more information is in [this issue](https://github.com/Slicer/Slicer/issues/5118))
   - Recommended action: setting the operating system to dark mode fixed the issue for several users.
-- On Linux: `Install Extensions` tab is blank if your linux kernel may not fulfill [Chromium sandboxing requirements](https://doc.qt.io/Qt-5/qtwebengine-platform-notes.html#sandboxing-support).
-  - Recommended action: turn off sandboxing by setting this environment variable before launching Slicer `QTWEBENGINE_DISABLE_SANDBOX=1`
 
 ### Extension is not found for current Slicer version
 

--- a/Docs/user_guide/getting_started.md
+++ b/Docs/user_guide/getting_started.md
@@ -83,7 +83,6 @@ brew uninstall slicer-preview       # to uninstall
 
 **Notes:**
 - Slicer is expected to work on the vast majority of desktop and server Linux distributions. The system is required to provide at least GLIBC 2.17 and GLIBCCC 3.4.19. For more details, read [here](https://www.python.org/dev/peps/pep-0599/#the-manylinux2014-policy).
-- The Extension Manager uses QtWebengine to display the list of extensions. If your linux kernel does not fulfill [sandboxing requirements](https://doc.qt.io/Qt-5/qtwebengine-platform-notes.html#sandboxing-support) then you can turn off sandboxing by this command: `export QTWEBENGINE_DISABLE_SANDBOX=1`
 - Getting command-line arguments and process output containing non-ASCII characters requires the system to use a UTF-8 locale. If the system uses a different locale then the `export LANG="C.UTF-8"` command may be used before launching the application to switch to an acceptable locale.
 
 #### Debian / Ubuntu

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -198,8 +198,9 @@ qSlicerMarkupsModuleWidgetPrivate::qSlicerMarkupsModuleWidgetPrivate(qSlicerMark
 {
   Q_Q(qSlicerMarkupsModuleWidget);
 
-  this->columnLabels << q->tr("Selected") << q->tr("Locked") << q->tr("Visible")
-    << q->tr("Name") << q->tr("Description") << q->tr("R") << q->tr("A") << q->tr("S") << q->tr("Position");
+  this->columnLabels << qSlicerMarkupsModuleWidget::tr("Selected") << qSlicerMarkupsModuleWidget::tr("Locked") << qSlicerMarkupsModuleWidget::tr("Visible")
+    << qSlicerMarkupsModuleWidget::tr("Name") << qSlicerMarkupsModuleWidget::tr("Description") << qSlicerMarkupsModuleWidget::tr("R")
+    << qSlicerMarkupsModuleWidget::tr("A") << qSlicerMarkupsModuleWidget::tr("S") << qSlicerMarkupsModuleWidget::tr("Position");
 
   this->newMarkupWithCurrentDisplayPropertiesAction = nullptr;
   this->visibilityMenu = nullptr;

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qMRMLSubjectHierarchyTreeView.cxx
@@ -250,22 +250,22 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
 
   this->TransformInteractionInViewAction = new QAction("Interaction in 3D view", this->TransformMenu);
   this->TransformInteractionInViewAction->setCheckable(true);
-  this->TransformInteractionInViewAction->setToolTip(q->tr("Allow interactively modify the transform in 3D views"));
+  this->TransformInteractionInViewAction->setToolTip(qMRMLSubjectHierarchyTreeView::tr("Allow interactively modify the transform in 3D views"));
   this->TransformMenu->addAction(this->TransformInteractionInViewAction);
   QObject::connect(this->TransformInteractionInViewAction, SIGNAL(toggled(bool)), q, SLOT(onTransformInteractionInViewToggled(bool)));
 
   this->TransformEditPropertiesAction = new QAction("Edit transform properties...", this->TransformMenu);
-  this->TransformEditPropertiesAction->setToolTip(q->tr("Edit properties of the current transform"));
+  this->TransformEditPropertiesAction->setToolTip(qMRMLSubjectHierarchyTreeView::tr("Edit properties of the current transform"));
   this->TransformMenu->addAction(this->TransformEditPropertiesAction);
   QObject::connect(this->TransformEditPropertiesAction, SIGNAL(triggered()), q, SLOT(onTransformEditProperties()));
 
   this->TransformHardenAction = new QAction("Harden transform", this->TransformMenu);
-  this->TransformHardenAction->setToolTip(q->tr("Harden current transform on this node and all children nodes"));
+  this->TransformHardenAction->setToolTip(qMRMLSubjectHierarchyTreeView::tr("Harden current transform on this node and all children nodes"));
   this->TransformMenu->addAction(this->TransformHardenAction);
   QObject::connect(this->TransformHardenAction, SIGNAL(triggered()), this->Model, SLOT(onHardenTransformOnBranchOfCurrentItem()));
 
   this->CreateNewTransformAction = new QAction("Create new transform", this->TransformMenu);
-  this->CreateNewTransformAction->setToolTip(q->tr("Create and apply new transform"));
+  this->CreateNewTransformAction->setToolTip(qMRMLSubjectHierarchyTreeView::tr("Create and apply new transform"));
   this->TransformMenu->addAction(this->CreateNewTransformAction);
   QObject::connect(this->CreateNewTransformAction, SIGNAL(triggered()), q, SLOT(onCreateNewTransform()));
 
@@ -273,7 +273,7 @@ void qMRMLSubjectHierarchyTreeViewPrivate::init()
 
   this->NoTransformAction = new QAction("None", this->TransformMenu);
   this->NoTransformAction->setCheckable(true);
-  this->NoTransformAction->setToolTip(q->tr("Remove parent transform from all the nodes in this branch"));
+  this->NoTransformAction->setToolTip(qMRMLSubjectHierarchyTreeView::tr("Remove parent transform from all the nodes in this branch"));
   this->TransformMenu->addAction(this->NoTransformAction);
   QObject::connect(this->NoTransformAction, SIGNAL(triggered()), this->Model, SLOT(onRemoveTransformsFromBranchOfCurrentItem()));
 

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
@@ -110,10 +110,11 @@ void qSlicerScalarVolumeDisplayWidgetPrivate::init()
       {
       vtkSlicerVolumesLogic::VolumeDisplayPreset preset = volumesModuleLogic->GetVolumeDisplayPreset(presetId);
       QString presetIdStr = QString::fromStdString(presetId);
-      QString presetName = q->tr(preset.name.c_str());
+      QString presetName = qSlicerScalarVolumeDisplayWidget::tr(preset.name.c_str());
       QToolButton* presetButton = new QToolButton();
       presetButton->setObjectName(presetIdStr);
-      presetButton->setToolTip(q->tr(preset.name.c_str()) + "\n" + q->tr(preset.description.c_str()));
+      presetButton->setToolTip(qSlicerScalarVolumeDisplayWidget::tr(preset.name.c_str()) + "\n"
+        + qSlicerScalarVolumeDisplayWidget::tr(preset.description.c_str()));
       if (!preset.icon.empty())
         {
         presetButton->setIcon(QIcon(QString::fromStdString(preset.icon)));


### PR DESCRIPTION
In the [3D Slicer in My Language](https://chanzuckerberg.com/eoss/proposals/3d-slicer-in-my-language-internationalization-and-usability-improvements/) project, we use the _QT **lupdate** tool_ to extract traductible strings. However, when we run that tool on the [current source code](https://github.com/Slicer/Slicer), we note the presence of some warnings that may affect the translation quality. 

This commit fixes the `cannot invoke tr() like this` warning that is related to _tr function calls_ on private classes. 

More details in this issue can be found [here](https://github.com/mhdiop/Sliceriml/issues/1).

CC: @lassoan @pieper