### PR TITLE
Support itk python module switching to custom itk namespace

### DIFF
--- a/Libs/ITKFactoryRegistration/itkFactoryRegistration.h
+++ b/Libs/ITKFactoryRegistration/itkFactoryRegistration.h
@@ -4,6 +4,7 @@
 #define itkFactoryRegistration_h
 
 #include "itkFactoryRegistrationConfigure.h"
+#include "itkNamespace.h"
 
 namespace itk {
 

--- a/Libs/vtkITK/vtkITK.h
+++ b/Libs/vtkITK/vtkITK.h
@@ -15,6 +15,7 @@
 #ifndef __vtkITK_h
 #define __vtkITK_h
 
+#include "itkNamespace.h"
 #include "vtkITKExport.h"
 #include "vtkITKNumericTraits.h"
 

--- a/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.cxx
@@ -188,11 +188,15 @@ int vtkITKArchetypeDiffusionTensorImageReaderFile::RequestData(
 
 //----------------------------------------------------------------------------
 void vtkITKArchetypeDiffusionTensorImageReaderFile
-::ReadProgressCallback(itk::ProcessObject* obj,
-                       const itk::ProgressEvent&,void* data)
+::ReadProgressCallback(itk::Object* obj, const itk::EventObject&, void* data)
 {
+  itk::ProcessObject::Pointer p(dynamic_cast<itk::ProcessObject *>(obj));
+  if (p.IsNull())
+  {
+    return;
+  }
   vtkITKArchetypeDiffusionTensorImageReaderFile* me =
     reinterpret_cast<vtkITKArchetypeDiffusionTensorImageReaderFile*>(data);
-  me->Progress=obj->GetProgress();
+  me->Progress = p->GetProgress();
   me->InvokeEvent(vtkCommand::ProgressEvent,&me->Progress);
 }

--- a/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.h
+++ b/Libs/vtkITK/vtkITKArchetypeDiffusionTensorImageReaderFile.h
@@ -28,7 +28,7 @@ class VTK_ITK_EXPORT vtkITKArchetypeDiffusionTensorImageReaderFile
   ~vtkITKArchetypeDiffusionTensorImageReaderFile() override;
 
   int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
-  static void ReadProgressCallback(itk::ProcessObject* obj,const itk::ProgressEvent&, void* data);
+  static void ReadProgressCallback(itk::Object* obj, const itk::EventObject&, void* data);
   /// private:
 
 private:

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.cxx
@@ -265,9 +265,14 @@ int vtkITKArchetypeImageSeriesScalarReader::RequestData(
 }
 
 
-void vtkITKArchetypeImageSeriesScalarReader::ReadProgressCallback(itk::ProcessObject* obj,const itk::ProgressEvent&,void* data)
+void vtkITKArchetypeImageSeriesScalarReader::ReadProgressCallback(itk::Object* obj, const itk::EventObject&, void* data)
 {
+  itk::ProcessObject::Pointer p(dynamic_cast<itk::ProcessObject *>(obj));
+  if (p.IsNull())
+  {
+    return;
+  }
   vtkITKArchetypeImageSeriesScalarReader* me=reinterpret_cast<vtkITKArchetypeImageSeriesScalarReader*>(data);
-  me->Progress=obj->GetProgress();
+  me->Progress = p->GetProgress();
   me->InvokeEvent(vtkCommand::ProgressEvent,&me->Progress);
 }

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesScalarReader.h
@@ -32,7 +32,7 @@ class VTK_ITK_EXPORT vtkITKArchetypeImageSeriesScalarReader : public vtkITKArche
   ~vtkITKArchetypeImageSeriesScalarReader() override;
 
   int RequestData(vtkInformation* request, vtkInformationVector** inputVector, vtkInformationVector* outputVector) override;
-  static void ReadProgressCallback(itk::ProcessObject* obj,const itk::ProgressEvent&, void* data);
+  static void ReadProgressCallback(itk::Object* obj, const itk::EventObject&, void* data);
   /// private:
 
 private:

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.cxx
@@ -132,9 +132,14 @@ void vtkITKArchetypeImageSeriesVectorReaderFile::ExecuteDataWithInformation(vtkD
 }
 
 
-void vtkITKArchetypeImageSeriesVectorReaderFile::ReadProgressCallback(itk::ProcessObject* obj,const itk::ProgressEvent&,void* data)
+void vtkITKArchetypeImageSeriesVectorReaderFile::ReadProgressCallback(itk::Object* obj, const itk::EventObject&, void* data)
 {
+  itk::ProcessObject::Pointer p(dynamic_cast<itk::ProcessObject *>(obj));
+  if (p.IsNull())
+  {
+    return;
+  }
   vtkITKArchetypeImageSeriesVectorReaderFile* me=reinterpret_cast<vtkITKArchetypeImageSeriesVectorReaderFile*>(data);
-  me->Progress=obj->GetProgress();
+  me->Progress = p->GetProgress();
   me->InvokeEvent(vtkCommand::ProgressEvent,&me->Progress);
 }

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderFile.h
@@ -27,7 +27,7 @@ class VTK_ITK_EXPORT vtkITKArchetypeImageSeriesVectorReaderFile : public vtkITKA
   ~vtkITKArchetypeImageSeriesVectorReaderFile() override;
 
   void ExecuteDataWithInformation(vtkDataObject *output, vtkInformation *outInfo) override;
-  static void ReadProgressCallback(itk::ProcessObject* obj,const itk::ProgressEvent&, void* data);
+  static void ReadProgressCallback(itk::Object* obj, const itk::EventObject&, void* data);
 
 private:
   vtkITKArchetypeImageSeriesVectorReaderFile(const vtkITKArchetypeImageSeriesVectorReaderFile&) = delete;

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.cxx
@@ -169,9 +169,14 @@ void vtkITKArchetypeImageSeriesVectorReaderSeries::ExecuteDataWithInformation(vt
 }
 
 
-void vtkITKArchetypeImageSeriesVectorReaderSeries::ReadProgressCallback(itk::ProcessObject* obj,const itk::ProgressEvent&,void* data)
+void vtkITKArchetypeImageSeriesVectorReaderSeries::ReadProgressCallback(itk::Object* obj, const itk::EventObject &, void* data)
 {
+  itk::ProcessObject::Pointer p(dynamic_cast<itk::ProcessObject *>(obj));
+  if (p.IsNull())
+  {
+    return;
+  }
   vtkITKArchetypeImageSeriesVectorReaderSeries* me=reinterpret_cast<vtkITKArchetypeImageSeriesVectorReaderSeries*>(data);
-  me->Progress=obj->GetProgress();
+  me->Progress = p->GetProgress();
   me->InvokeEvent(vtkCommand::ProgressEvent,&me->Progress);
 }

--- a/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.h
+++ b/Libs/vtkITK/vtkITKArchetypeImageSeriesVectorReaderSeries.h
@@ -14,7 +14,7 @@
 #include <vtkVersion.h>
 namespace itk
 {
-  class ProcessObject;
+  class Object;
   class ProgressEvent;
 };
 
@@ -25,8 +25,8 @@ public:
   vtkTypeMacro(vtkITKArchetypeImageSeriesVectorReaderSeries,vtkITKArchetypeImageSeriesReader);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  static void ReadProgressCallback(itk::ProcessObject* obj,
-                                   const itk::ProgressEvent&,
+  static void ReadProgressCallback(itk::Object* obj,
+                                   const itk::EventObject &,
                                    void* data);
 protected:
   vtkITKArchetypeImageSeriesVectorReaderSeries();

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -30,13 +30,13 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/InsightSoftwareConsortium/ITK"
+    "${EP_GIT_PROTOCOL}://github.com/Slicer/ITK"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "62eb5ca265c56a5fb447e1e167b44411a9c38992" # post-v5.3rc04 2022-09-19
+    "69e52f05c482012b95228c3fe46f299b1735ca99" # slicer-v5.3rc04-2022-09-19-62eb5ca
     QUIET
     )
 

--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -128,13 +128,13 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" \"-m\" \"pi
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/SimpleITK/SimpleITK.git"
+    "${EP_GIT_PROTOCOL}://github.com/Slicer/SimpleITK.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "1c0cf5de03fd8b8279a6522e910bbce67a4d8bf8"  # post-v2.2.0 2022-08-30
+    "c7f151412205e086a47bfa5d521ec6beec481218"  # slicer-v2.2.0-2022-08-30-1c0cf5de
     QUIET
     )
 


### PR DESCRIPTION
## Remaining tasks
* [x] Complete build on linux, macOS and Windows factories.
  * `metroplex` (linux) :heavy_check_mark:
  * `computron` (macOS) :hourglass_flowing_sand:
    * _The clang compiled has been failing with segfault. Factory has been restarted and build re-triggered_
  * `factory-south-macos` (macOS) :heavy_check_mark: : 
  * `overload` (Windows) :heavy_check_mark: 
* [ ] Test build on linux, macOS and Windows factories.
  * `metroplex` (linux) :hourglass_flowing_sand:
    * [ ] CLI executable works (`GaussianBlurImageFilter`) :question: 
    * [ ] SimpleFilter works (`DiscreteGaussianImageFilter`) :question: 
    * [ ] Install ITK python + test filtering of node :question: 
  * `computron` (macOS) :hourglass_flowing_sand:
    * [ ] CLI executable works (`GaussianBlurImageFilter`) :question: 
    * [ ] SimpleFilter works (`DiscreteGaussianImageFilter`) :question: 
    * [ ] Install ITK python + test filtering of node :question: 
  * `factory-south-macos` (macOS) :hourglass_flowing_sand:
    * [x] CLI executable works (`GaussianBlurImageFilter`) :heavy_check_mark: 
    * [x] SimpleFilter works (`DiscreteGaussianImageFilter`) :heavy_check_mark: 
    * [x] Install ITK python + test filtering of node :x:. See https://discourse.itk.org/t/itk-5-3rc4-post3-failure-to-load-libtbb-library-observed-on-macos-10-13/5405
  * `overload` (Windows)
    * [x] CLI executable works (`GaussianBlurImageFilter`) :heavy_check_mark: 
    * [x] SimpleFilter works (`DiscreteGaussianImageFilter`) :heavy_check_mark: 
    * [x] Install ITK python + test filtering of node :heavy_check_mark: 
* [ ] Create pull-request in upstream ITK

## Installing the ITK wheels

_To avoid modifying the local Slicer environment, ITK wheels can be installed in a dedicated prefix_

```bash
itk_wheels_install_prefix=/home/jcfr/Downloads/itk-wheels-installed
echo "itk_wheels_install_prefix [${itk_wheels_install_prefix}]"

mkdir -p $itk_wheels_install_prefix

config=RelWithDebInfo
slicer_build_dir=/home/jcfr/Projects/Slicer-$config
echo "slicer_build_dir [${slicer_build_dir}]"

cd $slicer_build_dir
./python-install/bin/PythonSlicer -m pip install \
  --prefix $itk_wheels_install_prefix \
  itk==5.3rc4.post3 --pre
```

## Start Slicer

```bash
config=RelWithDebInfo
slicer_build_dir=/home/jcfr/Projects/Slicer-$config
echo "slicer_build_dir [${slicer_build_dir}]"

slicer_dir=$slicer_build_dir/Slicer-build

PYTHONPATH=$itk_wheels_install_prefix/lib/python3.9/site-packages/:$itk_wheels_install_prefix/lib/python3.9/site-packages/itk \
$slicer_dir/Slicer
```

## Example of ITK filtering

```python
def updateMatrix3x3From4x4(matrix3x3, matrix4x4):
  for i_idx in range(3):
    for j_idx in range(3):
      matrix3x3.SetElement(i_idx, j_idx, matrix4x4.GetElement(i_idx, j_idx))

# Input node
import SampleData
input_volume_node = SampleData.SampleDataLogic().downloadMRHead()

# (1) Create VTK image data with expected metadata
input_vtk_image = vtk.vtkImageData()
input_vtk_image.ShallowCopy(input_volume_node.GetImageData())
input_vtk_image.SetOrigin(input_volume_node.GetOrigin())
input_vtk_image.SetSpacing(input_volume_node.GetSpacing())

directionMatrix4x4 = vtk.vtkMatrix4x4()
input_volume_node.GetIJKToRASDirectionMatrix(directionMatrix4x4)
directionMatrix3x3 = vtk.vtkMatrix3x3()
updateMatrix3x3From4x4(directionMatrix3x3, directionMatrix4x4)
input_vtk_image.SetDirectionMatrix(directionMatrix3x3)

# (2) Create ITK image data from VTK image data
import itk
input_itk_image = itk.image_from_vtk_image(input_vtk_image)

# (3) Filter ITK image
output_itk_image = itk.discrete_gaussian_image_filter(input_itk_image, variance=5.0)

# (4) Create output node
output_volume_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", "MRHead-Filtered")

# (5) Apply ITK filtering
vtk_output_image = itk.vtk_image_from_image(output_itk_image)

# (6) Update output node using on VTK output image spacing/origin/direction
ijkToRASMatrix = vtk.vtkMatrix4x4()
import vtkAddon
vtkAddon.vtkAddonMathUtilities.SetOrientationMatrix(vtk_output_image.GetDirectionMatrix(), ijkToRASMatrix)
output_volume_node.SetIJKToRASMatrix(ijkToRASMatrix)
output_volume_node.SetOrigin(*vtk_output_image.GetOrigin())
output_volume_node.SetSpacing(*vtk_output_image.GetSpacing())

# (7) Reset spacing/origin/direction from VTK output image
vtk_output_image.SetOrigin((0, 0, 0))
vtk_output_image.SetSpacing((1., 1., 1.))
identidyMatrix = vtk.vtkMatrix3x3()
vtk_output_image.SetDirectionMatrix(identidyMatrix)

# (8) Update output node setting VTK image data
output_volume_node.SetAndObserveImageData(vtk_output_image)
```

Cc: @lassoan @pieper @thewtex 
