### PR TITLE
BUG: Fix bug in closed curve resampling

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsCurveSettingsWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsCurveSettingsWidget.cxx
@@ -318,7 +318,7 @@ void qMRMLMarkupsCurveSettingsWidget::onApplyCurveResamplingPushButtonClicked()
     {
     return;
     }
-  bool isClosed = (vtkMRMLMarkupsClosedCurveNode::SafeDownCast(inputNode) != nullptr);
+  bool isClosed = inputNode->GetCurveClosed();
   vtkMRMLMarkupsCurveNode* outputNode = vtkMRMLMarkupsCurveNode::SafeDownCast(d->resampleCurveOutputNodeSelector->currentNode());
   if (!outputNode)
     {

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsCurveSettingsWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsCurveSettingsWidget.cxx
@@ -318,6 +318,7 @@ void qMRMLMarkupsCurveSettingsWidget::onApplyCurveResamplingPushButtonClicked()
     {
     return;
     }
+  bool isClosed = (vtkMRMLMarkupsClosedCurveNode::SafeDownCast(inputNode) != nullptr);
   vtkMRMLMarkupsCurveNode* outputNode = vtkMRMLMarkupsCurveNode::SafeDownCast(d->resampleCurveOutputNodeSelector->currentNode());
   if (!outputNode)
     {
@@ -338,7 +339,8 @@ void qMRMLMarkupsCurveSettingsWidget::onApplyCurveResamplingPushButtonClicked()
     outputNode->SetSurfaceCostFunctionType(inputNode->GetSurfaceCostFunctionType());
     outputNode->SetSurfaceDistanceWeightingFunction(inputNode->GetSurfaceDistanceWeightingFunction());
     }
-  double sampleDist = outputNode->GetCurveLengthWorld() / (resampleNumberOfPoints - 1);
+  unsigned int numberOfSegments = (isClosed ? resampleNumberOfPoints : resampleNumberOfPoints - 1);
+  double sampleDist = outputNode->GetCurveLengthWorld() / numberOfSegments;
   outputNode->ResampleCurveWorld(sampleDist);
 }
 


### PR DESCRIPTION
The number of segments when resampling a curve was "number of given points - 1", which is fine for open curves, but for closed curves it has to be just the number of given points. Added a simple fix in the widget function.