### PR TITLE
Update VTK, vtkAdon and CTK to backport OpenXR and OpenXRRemoting updates 

### DIFF
--- a/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.h
+++ b/Modules/Loadable/Annotations/MRMLDM/vtkMRMLAnnotationDisplayableManagerHelper.h
@@ -33,6 +33,7 @@ class vtkMRMLInteractionNode;
 
 // STD includes
 #include <map>
+#include <vector>
 
 /// \ingroup Slicer_QtModules_Annotation
 class VTK_SLICER_ANNOTATIONS_MODULE_MRMLDISPLAYABLEMANAGER_EXPORT

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -48,7 +48,7 @@
 #include <vtkOBBTree.h>
 #include <vtkObjectFactory.h>
 #include <vtkParallelTransportFrame.h>
-#include <vtkPassThroughFilter.h>
+#include <vtkPassThrough.h>
 #include <vtkPlane.h>
 #include <vtkPointData.h>
 #include <vtkPointLocator.h>
@@ -89,7 +89,7 @@ vtkMRMLMarkupsCurveNode::vtkMRMLMarkupsCurveNode()
   this->SurfaceScalarCalculator->SetResultArrayType(VTK_FLOAT);
   this->SetSurfaceDistanceWeightingFunction("activeScalar");
 
-  this->SurfaceScalarPassThroughFilter = vtkSmartPointer<vtkPassThroughFilter>::New();
+  this->SurfaceScalarPassThroughFilter = vtkSmartPointer<vtkPassThrough>::New();
   this->SurfaceScalarPassThroughFilter->SetInputConnection(this->SurfaceToLocalTransformer->GetOutputPort());
 
   this->CurveGenerator->SetCurveTypeToCardinalSpline();
@@ -113,7 +113,7 @@ vtkMRMLMarkupsCurveNode::vtkMRMLMarkupsCurveNode()
   this->CurveMeasurementsCalculator->SetInputConnection(this->ProjectPointsFilter->GetOutputPort());
   this->CurveMeasurementsCalculator->AddObserver(vtkCommand::ModifiedEvent, this->MRMLCallbackCommand);
 
-  this->WorldOutput = vtkSmartPointer<vtkPassThroughFilter>::New();
+  this->WorldOutput = vtkSmartPointer<vtkPassThrough>::New();
   this->WorldOutput->SetInputConnection(this->CurveMeasurementsCalculator->GetOutputPort());
 
   this->CurveCoordinateSystemGeneratorWorld->SetInputConnection(this->WorldOutput->GetOutputPort());

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -38,7 +38,7 @@ class vtkAssignAttribute;
 class vtkCallbackCommand;
 class vtkCleanPolyData;
 class vtkCurveMeasurementsCalculator;
-class vtkPassThroughFilter;
+class vtkPassThrough;
 class vtkPlane;
 class vtkProjectMarkupsCurvePointsFilter;
 class vtkTransformPolyDataFilter;
@@ -306,9 +306,9 @@ protected:
   vtkSmartPointer<vtkTriangleFilter> TriangleFilter;
   vtkSmartPointer<vtkTransformPolyDataFilter> SurfaceToLocalTransformer;
   vtkSmartPointer<vtkArrayCalculator> SurfaceScalarCalculator;
-  vtkSmartPointer<vtkPassThroughFilter> SurfaceScalarPassThroughFilter;
+  vtkSmartPointer<vtkPassThrough> SurfaceScalarPassThroughFilter;
   vtkSmartPointer<vtkCurveMeasurementsCalculator> CurveMeasurementsCalculator;
-  vtkSmartPointer<vtkPassThroughFilter> WorldOutput;
+  vtkSmartPointer<vtkPassThrough> WorldOutput;
   const char* ShortestDistanceSurfaceActiveScalar;
 
   /// Filter that changes the active scalar of the input mesh using the ActiveScalarName

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.cxx
@@ -30,7 +30,7 @@
 #include <vtkMatrix4x4.h>
 #include <vtkObjectFactory.h>
 #include <vtkOutlineFilter.h>
-#include <vtkPassThroughFilter.h>
+#include <vtkPassThrough.h>
 #include <vtkPlane.h>
 #include <vtkPoints.h>
 #include <vtkPointData.h>
@@ -56,7 +56,7 @@ vtkSlicerROIRepresentation2D::vtkSlicerROIRepresentation2D()
 {
   this->ROISource = nullptr;
 
-  this->ROIPipelineInputFilter = vtkSmartPointer<vtkPassThroughFilter>::New();
+  this->ROIPipelineInputFilter = vtkSmartPointer<vtkPassThrough>::New();
 
   this->ROIToWorldTransform = vtkSmartPointer<vtkTransform>::New();
   this->ROIToWorldTransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
@@ -96,7 +96,7 @@ protected:
 
   vtkSmartPointer<vtkPolyDataAlgorithm>       ROISource;
 
-  vtkSmartPointer<vtkPassThroughFilter>       ROIPipelineInputFilter;
+  vtkSmartPointer<vtkPassThrough>       ROIPipelineInputFilter;
   vtkSmartPointer<vtkTransform>               ROIToWorldTransform;
   vtkSmartPointer<vtkTransformPolyDataFilter> ROIToWorldTransformFilter;
   vtkSmartPointer<vtkCutter>                  ROIOutlineCutter;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.cxx
@@ -27,7 +27,7 @@
 #include <vtkGlyph3D.h>
 #include <vtkLine.h>
 #include <vtkOutlineFilter.h>
-#include <vtkPassThroughFilter.h>
+#include <vtkPassThrough.h>
 #include <vtkPointData.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkProperty.h>
@@ -53,7 +53,7 @@ vtkSlicerROIRepresentation3D::vtkSlicerROIRepresentation3D()
 {
   this->ROISource = nullptr;
 
-  this->ROIPipelineInputFilter = vtkSmartPointer<vtkPassThroughFilter>::New();
+  this->ROIPipelineInputFilter = vtkSmartPointer<vtkPassThrough>::New();
 
   this->ROIToWorldTransform = vtkSmartPointer<vtkTransform>::New();
   this->ROITransformFilter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
@@ -44,7 +44,7 @@ class vtkLookupTable;
 class vtkMRMLInteractionEventData;
 class vtkMRMLMarkupsROINode;
 class vtkOutlineFilter;
-class vtkPassThroughFilter;
+class vtkPassThrough;
 class vtkPlaneSource;
 class vtkPolyDataAlgorithm;
 class vtkPolyDataMapper;
@@ -101,7 +101,7 @@ protected:
 
   vtkSmartPointer<vtkPolyDataAlgorithm> ROISource;
 
-  vtkSmartPointer<vtkPassThroughFilter> ROIPipelineInputFilter;
+  vtkSmartPointer<vtkPassThrough> ROIPipelineInputFilter;
 
   vtkSmartPointer<vtkTransformPolyDataFilter>    ROITransformFilter;
   vtkSmartPointer<vtkTransform>                  ROIToWorldTransform;

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,7 +202,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 8b5c4b2336a4d2d2aaafe87db3642b5302ddcaa5
+  GIT_TAG fb7edc86fc16ace43398f6743eff5a47f8ca0328
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ec816cbb77986f6ee28c41a495e82238dee0e2d3"
+    "25ffa494156414856c8db417ec71c60deab25d65"
     QUIET
     )
 

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "fb5f0740500a5bc251da4e19f3c162700c8b560a") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "73ca81bb45d24dad5fa8316d6f7df45f5cfffa52") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
To minimize changes prior to Slicer 5.2 release, this pull request attempts to backport the minimum set of VTK commits allowing to integrate OpenXR and OpenXRRemoting update.

## Build and testing

  * [ ] `metroplex` (linux) :question:
  * [ ] `computron` (macOS) :question:
  * [ ] `factory-south-macos` (macOS) :question: 
  * [ ] `overload` (Windows) :question: