### PR TITLE
COMP: Update SlicerSurfaceToolbox to fix build error introduced by VTK update

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -337,7 +337,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG 3515c3ccaf0380ef1efd7ccaaf71decb3584a263
+  GIT_TAG 74af7b5abb4af28c23c0ce3fe495a5c99bbb0be1
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
This commit fixes a regression introduced in previous commit by updating `vtkSlicerDynamicModelerSelectByPointsTool` to use updated `vtkThreshold` API.

List of SlicerSurfaceToolbox changes:

```
$ git shortlog 3515c3cca..74af7b5ab --no-merges
Jean-Christophe Fillion-Robin (3):
      COMP: Fix -Wdeprecated-copy in Simplify.h reported with gcc 9.x
      DOC: Add module documentation
      COMP: Remove use of deprecated vtkThreshold API
```