### PR TITLE
ENH: When setting window/level mode also activate it

### DIFF
--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -698,6 +698,11 @@ void qSlicerMouseModeToolBar::setAdjustWindowLevelMode(int adjustWindowLevelMode
     }
   interactionNode->SetAttribute(vtkMRMLWindowLevelWidget::GetInteractionNodeAdjustWindowLevelModeAttributeName(),
     vtkMRMLWindowLevelWidget::GetAdjustWindowLevelModeAsString(adjustWindowLevelMode));
+
+   // Activate window/level action when setting its mode.
+   // This is done to save a button click and reduce user confusion, similarly how it is done elsewhere in Slicer
+   // and other software, where adjusting an option of a feature activates that feature.
+   d->AdjustWindowLevelAction->trigger();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
It can be assumed that when the user wants to change the mode of the window/level mouse mode, they also want to use it right afterwards. Thus, it makes sense to activate it along with setting the mode, to save extra clicks and possible confusion.