### PR TITLE
COMP: Fix SimpleITK installation ensuring its uses newer version of pip

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -2,7 +2,13 @@
 set(proj SimpleITK)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES ITK Swig python python-setuptools)
+set(${proj}_DEPENDENCIES
+  ITK
+  python
+  python-pip
+  python-setuptools
+  Swig
+  )
 
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)


### PR DESCRIPTION
This commit fixes a regression introduced in 4d1c98ef8 (COMP: Update ITK to post-v5.3rc04 version and SimpleITK to post-v2.2.0) where SimpleITK installation method was changed to use "pip install" instead of "setup.py".

See discussion at https://discourse.slicer.org/t/windows-nightly-build-error-pip-install-of-simpleitk-build-failing/25629

Since by default the project "python-ensurepip" leads to the installation of pip 21.2.4, SimpleITK was installed using a version of pip older than 21.3 and didn't have the "in-tree-build" feature enabled by default.

To address the problem, this commit adds the dependency to the python-pip project and ensures that pip >= 21.3 is used.