### PR TITLE
BUG: Fix blank Extensions manager on Linux due to Chromium sandboxing

### DIFF
--- a/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+++ b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
@@ -142,6 +142,13 @@ if(Slicer_USE_PYTHONQT_WITH_OPENSSL)
     "SSL_CERT_FILE=<APPLAUNCHER_SETTINGS_DIR>/${Slicer_SHARE_DIR}/Slicer.crt"
     )
 endif()
+if(UNIX AND NOT APPLE)
+  # Disable Chromium Sandboxing on Linux because not all systems support it
+  # (see https://github.com/Slicer/Slicer/issues/6577)
+  list(APPEND SLICER_ENVVARS_BUILD
+    "QTWEBENGINE_DISABLE_SANDBOX=1"
+    )
+endif()
 
 # External projects - environment variables
 foreach(varname IN LISTS Slicer_EP_LABEL_ENVVARS_LAUNCHER_BUILD)

--- a/Docs/user_guide/extensions_manager.md
+++ b/Docs/user_guide/extensions_manager.md
@@ -122,8 +122,6 @@ This can be due to several reasons:
   - Alternative solution: download extension package using a web browser (possibly on a different computer) and install the extension manually. See instructions [here](#install-extensions-without-network-connection).
 - On macOS: on some older macbooks, the extension manager window appears very bright, washed out (more information is in [this issue](https://github.com/Slicer/Slicer/issues/5118))
   - Recommended action: setting the operating system to dark mode fixed the issue for several users.
-- On Linux: `Install Extensions` tab is blank if your linux kernel may not fulfill [Chromium sandboxing requirements](https://doc.qt.io/Qt-5/qtwebengine-platform-notes.html#sandboxing-support).
-  - Recommended action: turn off sandboxing by setting this environment variable before launching Slicer `QTWEBENGINE_DISABLE_SANDBOX=1`
 
 ### Extension is not found for current Slicer version
 

--- a/Docs/user_guide/getting_started.md
+++ b/Docs/user_guide/getting_started.md
@@ -83,7 +83,6 @@ brew uninstall slicer-preview       # to uninstall
 
 **Notes:**
 - Slicer is expected to work on the vast majority of desktop and server Linux distributions. The system is required to provide at least GLIBC 2.17 and GLIBCCC 3.4.19. For more details, read [here](https://www.python.org/dev/peps/pep-0599/#the-manylinux2014-policy).
-- The Extension Manager uses QtWebengine to display the list of extensions. If your linux kernel does not fulfill [sandboxing requirements](https://doc.qt.io/Qt-5/qtwebengine-platform-notes.html#sandboxing-support) then you can turn off sandboxing by this command: `export QTWEBENGINE_DISABLE_SANDBOX=1`
 - Getting command-line arguments and process output containing non-ASCII characters requires the system to use a UTF-8 locale. If the system uses a different locale then the `export LANG="C.UTF-8"` command may be used before launching the application to switch to an acceptable locale.
 
 #### Debian / Ubuntu


### PR DESCRIPTION
fixes #6577

@jcfr Please test this, as I've made this change without actually testing it on linux. It would be also nice if you could add some more details to the commit comment (and/or into the code) about why this change is appropriate. Thank you!