### PR TITLE
BUG: Fix lupdate warnings related to missing Q_OBJECT macro

### DIFF
--- a/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx
@@ -153,17 +153,17 @@ public:
     if (installed && !loaded)
       {
       this->StatusLabel->setVisible(true);
-      this->StatusLabel->setText(tr("Install pending restart"));
+      this->StatusLabel->setText(qSlicerExtensionsLocalWidget::tr("Install pending restart"));
       }
     else if (scheduledForUpdate)
       {
       this->StatusLabel->setVisible(true);
-      this->StatusLabel->setText(tr("Update pending restart"));
+      this->StatusLabel->setText(qSlicerExtensionsLocalWidget::tr("Update pending restart"));
       }
     else if (scheduledForUninstall)
       {
       this->StatusLabel->setVisible(true);
-      this->StatusLabel->setText(tr("Uninstall pending restart"));
+      this->StatusLabel->setText(qSlicerExtensionsLocalWidget::tr("Uninstall pending restart"));
       }
     else
       {
@@ -340,7 +340,7 @@ public:
     QTextOption textOption = this->Text.defaultTextOption();
     textOption.setWrapMode(QTextOption::NoWrap);
     this->Text.setDefaultTextOption(textOption);
-    this->MoreLinkText = tr("More...");
+    this->MoreLinkText = qSlicerExtensionsLocalWidget::tr("More...");
     }
 
   // --------------------------------------------------------------------------
@@ -382,7 +382,7 @@ protected:
       }
     else if (revision.isEmpty() && formattedDate.isEmpty())
       {
-      return tr("unknown");
+      return qSlicerExtensionsLocalWidget::tr("unknown");
       }
     else
       {
@@ -442,16 +442,17 @@ protected:
       QString changeLogUrl = this->WidgetItem->data(qSlicerExtensionsLocalWidgetPrivate::ChangeLogUrlRole).toString();
       if (!changeLogUrl.isEmpty())
         {
-        changeLogText = tr(" <a href=\"%1\">Change log...</a>").arg(changeLogUrl);
+        changeLogText = QString(" <a href=\"%1\">%2</a>")
+          .arg(changeLogUrl)
+          .arg(qSlicerExtensionsLocalWidget::tr("Change log..."));
         }
       statusText += QString("<p style=\"font-weight: bold; font-size: 80%; color: %1;\">"
         "<img style=\"float: left\""
-        " src=\":/Icons/ExtensionUpdateAvailable.svg\"/> "
-        "An update is available. Installed: %2. Available: %3.%4</p>")
-        .arg(this->InfoColor)
+        " src=\":/Icons/ExtensionUpdateAvailable.svg\"/> ").arg(this->InfoColor);
+      statusText += qSlicerExtensionsLocalWidget::tr("An update is available. Installed: %1. Available: %2.")
         .arg(installedVersion)
-        .arg(onServerVersion)
-        .arg(changeLogText);
+        .arg(onServerVersion);
+      statusText += changeLogText + QLatin1Literal("/p>");
       }
     if (statusText.isEmpty())
       {
@@ -462,17 +463,25 @@ protected:
 
         if (!enabled || !compatible)
           {
-          statusText += tr("<p>Version: %1. Disabled.</p>").arg(installedVersion);
+          statusText +=
+            QLatin1Literal("<p>")+
+            qSlicerExtensionsLocalWidget::tr("Version: %1. Disabled.").arg(installedVersion)
+            + QLatin1Literal("</p>");
           }
         else
           {
-          statusText += tr("<p>Version: %1</p>").arg(installedVersion);
+          statusText +=
+            QLatin1Literal("<p>") +
+            qSlicerExtensionsLocalWidget::tr("Version: %1").arg(installedVersion)
+            + QLatin1Literal("</p>");
           }
         }
       else
         {
-        //labelText += "<p>&nbsp;</p>";
-        statusText += "<p>Not installed.</p>";
+        statusText +=
+          QLatin1Literal("<p>") +
+          qSlicerExtensionsLocalWidget::tr("Not installed.")
+          + QLatin1Literal("</p>");
         }
       }
     labelText += statusText;

--- a/Modules/Loadable/Colors/Widgets/qMRMLColorLegendDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Colors/Widgets/qMRMLColorLegendDisplayNodeWidget.cxx
@@ -78,7 +78,7 @@ void qMRMLColorLegendDisplayNodeWidgetPrivate::init()
   Q_Q(qMRMLColorLegendDisplayNodeWidget);
 
   // Set tooltip in label format widget
-  this->LabelTextPropertyWidget->textEditWidget()->setToolTip(tr(
+  this->LabelTextPropertyWidget->textEditWidget()->setToolTip(qMRMLColorLegendDisplayNodeWidget::tr(
     "<html><head><body>Format field uses printf function syntax. Example formats:<br>\
     - display with 1 fractional digits: <b>%.1f</b><br>\
     - display integer: <b>%.0f</b><br>\

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -115,8 +115,8 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
   QObject::connect(this->OutlineOpacitySliderWidget, SIGNAL(valueChanged(double)),
     q, SLOT(onOutlineOpacitySliderWidgetChanged(double)));
 
-  this->SnapModeComboBox->addItem(tr("unconstrained"), vtkMRMLMarkupsDisplayNode::SnapModeUnconstrained);
-  this->SnapModeComboBox->addItem(tr("snap to visible surface"), vtkMRMLMarkupsDisplayNode::SnapModeToVisibleSurface);
+  this->SnapModeComboBox->addItem(qMRMLMarkupsDisplayNodeWidget::tr("unconstrained"), vtkMRMLMarkupsDisplayNode::SnapModeUnconstrained);
+  this->SnapModeComboBox->addItem(qMRMLMarkupsDisplayNodeWidget::tr("snap to visible surface"), vtkMRMLMarkupsDisplayNode::SnapModeToVisibleSurface);
   QObject::connect(this->SnapModeComboBox, SIGNAL(currentIndexChanged(int)), q, SLOT(onSnapModeWidgetChanged()));
 
   QObject::connect(this->OccludedVisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setOccludedVisibility(bool)));

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyOpacityPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyOpacityPlugin.cxx
@@ -79,7 +79,7 @@ void qSlicerSubjectHierarchyOpacityPluginPrivate::init()
 {
   Q_Q(qSlicerSubjectHierarchyOpacityPlugin);
 
-  this->OpacityMenu = new QMenu(tr("Opacity"));
+  this->OpacityMenu = new QMenu(qSlicerSubjectHierarchyOpacityPlugin::tr("Opacity"));
   this->OpacitySlider = new ctkDoubleSlider(this->OpacityMenu);
   this->OpacitySlider->setOrientation(Qt::Horizontal);
   this->OpacitySlider->setRange(0.0, 1.0);

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyRegisterPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyRegisterPlugin.cxx
@@ -92,7 +92,7 @@ void qSlicerSubjectHierarchyRegisterPluginPrivate::init()
 
   // Initial action
   this->RegisterThisAction = new QAction("Register this...",q);
-  this->RegisterThisAction->setToolTip(tr("Select volume as moving image for registration. "
+  this->RegisterThisAction->setToolTip(qSlicerSubjectHierarchyRegisterPlugin::tr("Select volume as moving image for registration. "
                                           "Second volume can be selected from context menu after the first one has been set."));
   QObject::connect(this->RegisterThisAction, SIGNAL(triggered()), q, SLOT(registerCurrentItemTo()));
 
@@ -116,7 +116,7 @@ void qSlicerSubjectHierarchyRegisterPluginPrivate::init()
 
   // Cancel action
   this->CancelAction = new QAction("Cancel registration (or right-click another volume to start registration)",q);
-  this->CancelAction->setToolTip(tr("Right-click another volume to select second volume and start registration"));
+  this->CancelAction->setToolTip(qSlicerSubjectHierarchyRegisterPlugin::tr("Right-click another volume to select second volume and start registration"));
   QObject::connect(this->CancelAction, SIGNAL(triggered()), q, SLOT(cancel()));
 }
 

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyViewContextMenuPlugin.cxx
@@ -142,54 +142,58 @@ void qSlicerSubjectHierarchyViewContextMenuPluginPrivate::init()
 
   // Other
 
-  this->CenterThreeDViewAction = new QAction(tr("Center view"), q);
+  this->CenterThreeDViewAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Center view"), q);
   this->CenterThreeDViewAction->setObjectName("CenterViewAction");
-  this->CenterThreeDViewAction->setToolTip(tr("Center the slice on the currently visible 3D view content and all loaded volumes."));
+  this->CenterThreeDViewAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Center the slice on "
+                                            "the currently visible 3D view content and all loaded volumes."));
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CenterThreeDViewAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 0);
   QObject::connect(this->CenterThreeDViewAction, SIGNAL(triggered()), q, SLOT(centerThreeDView()));
 
-  this->FitSliceViewAction = new QAction(tr("Reset field of view"), q);
+  this->FitSliceViewAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Reset field of view"), q);
   this->FitSliceViewAction->setObjectName("FitViewAction");
-  this->FitSliceViewAction->setToolTip(tr("Center the slice view on the currently displayed volume."));
+  this->FitSliceViewAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Center the slice view on the currently displayed volume."));
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->FitSliceViewAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 1);
   QObject::connect(this->FitSliceViewAction, SIGNAL(triggered()), q, SLOT(fitSliceView()));
 
-  this->MaximizeViewAction = new QAction(tr("Maximize view"), q);
+  this->MaximizeViewAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Maximize view"), q);
   this->MaximizeViewAction->setObjectName("MaximizeViewAction");
-  this->MaximizeViewAction->setToolTip(tr("Show this view maximized in the view layout"));
+  this->MaximizeViewAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Show this view maximized in the view layout"));
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->MaximizeViewAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 2);
   QObject::connect(this->MaximizeViewAction, SIGNAL(triggered()), q, SLOT(maximizeView()));
 
-  this->ToggleTiltLockAction = new QAction(tr("Tilt lock"), q);
+  this->ToggleTiltLockAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Tilt lock"), q);
   this->ToggleTiltLockAction->setObjectName("TiltLockAction");
-  this->ToggleTiltLockAction->setToolTip(tr("Prevent rotation around the horizontal axis when rotating this view."));
-  this->ToggleTiltLockAction->setShortcut(QKeySequence(tr("Ctrl+b")));
+  this->ToggleTiltLockAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Prevent rotation "
+                                          "around the horizontal axis when rotating this view."));
+  this->ToggleTiltLockAction->setShortcut(QKeySequence(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Ctrl+b")));
   this->ToggleTiltLockAction->setCheckable(true);
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ToggleTiltLockAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 3);
   QObject::connect(this->ToggleTiltLockAction, SIGNAL(triggered()), q, SLOT(toggleTiltLock()));
 
-  this->ConfigureSliceViewAnnotationsAction = new QAction(tr("Configure slice view annotations..."), q);
+  this->ConfigureSliceViewAnnotationsAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Configure slice view annotations..."), q);
   this->ConfigureSliceViewAnnotationsAction->setObjectName("ConfigureSliceViewAnnotationsAction");
-  this->ConfigureSliceViewAnnotationsAction->setToolTip(tr("Configures display of corner annotations and color legend."));
+  this->ConfigureSliceViewAnnotationsAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Configures display of corner annotations"
+                                                        " and color legend."));
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->ConfigureSliceViewAnnotationsAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 4);
   QObject::connect(this->ConfigureSliceViewAnnotationsAction, SIGNAL(triggered()), q, SLOT(configureSliceViewAnnotationsAction()));
 
-  this->CopyImageAction = new QAction(tr("Copy image"), q);
+  this->CopyImageAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Copy image"), q);
   this->CopyImageAction->setObjectName("CopyImageAction");
-  this->CopyImageAction->setToolTip(tr("Copy a screenshot of this view to the clipboard"));
+  this->CopyImageAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Copy a screenshot of this view to the clipboard"));
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->CopyImageAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionDefault, 20); // set to 20 to make it the last item in the action group
   QObject::connect(this->CopyImageAction, SIGNAL(triggered()), q, SLOT(saveScreenshot()));
 
   // Slice intersections
-  this->IntersectingSlicesVisibilityAction = new QAction(tr("Slice intersections"), q);
+  this->IntersectingSlicesVisibilityAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Slice intersections"), q);
   this->IntersectingSlicesVisibilityAction->setObjectName("IntersectingSlicesAction");
-  this->IntersectingSlicesVisibilityAction->setToolTip(tr("Show how the other slice planes intersect each slice plane."));
+  this->IntersectingSlicesVisibilityAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Show how the "
+                                                        "other slice planes intersect each slice plane."));
   this->IntersectingSlicesVisibilityAction->setCheckable(true);
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->IntersectingSlicesVisibilityAction,
     qSlicerSubjectHierarchyAbstractPlugin::SectionDefault + 5); // set section to +5 to allow placing other sections above
@@ -197,9 +201,9 @@ void qSlicerSubjectHierarchyViewContextMenuPluginPrivate::init()
     q, SLOT(setIntersectingSlicesVisible(bool)));
 
   // Interactive slice intersections
-  this->IntersectingSlicesInteractiveAction = new QAction(tr("Interaction"), q);
+  this->IntersectingSlicesInteractiveAction = new QAction(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Interaction"), q);
   this->IntersectingSlicesInteractiveAction->setObjectName("IntersectingSlicesHandlesAction");
-  this->IntersectingSlicesInteractiveAction->setToolTip(tr("Show handles for slice interaction."));
+  this->IntersectingSlicesInteractiveAction->setToolTip(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Show handles for slice interaction."));
   this->IntersectingSlicesInteractiveAction->setCheckable(true);
   this->IntersectingSlicesInteractiveAction->setEnabled(false);
   qSlicerSubjectHierarchyAbstractPlugin::setActionPosition(this->IntersectingSlicesInteractiveAction,
@@ -306,11 +310,11 @@ void qSlicerSubjectHierarchyViewContextMenuPlugin::showViewContextMenuActionsFor
     d->MaximizeViewAction->setProperty("maximize", QVariant(!isMaximized));
     if (isMaximized)
       {
-      d->MaximizeViewAction->setText(tr("Restore view layout"));
+      d->MaximizeViewAction->setText(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Restore view layout"));
       }
     else
       {
-      d->MaximizeViewAction->setText(tr("Maximize view"));
+      d->MaximizeViewAction->setText(qSlicerSubjectHierarchyViewContextMenuPlugin::tr("Maximize view"));
       }
     }
 

--- a/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.cxx
+++ b/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.cxx
@@ -96,7 +96,8 @@ void qSlicerSubjectHierarchyVolumeRenderingPluginPrivate::init()
   this->ToggleVolumeRenderingAction->setChecked(false);
 
   this->VolumeRenderingOptionsAction = new QAction("Volume rendering options...",q);
-  this->VolumeRenderingOptionsAction->setToolTip(tr("Switch to Volume Rendering module to manage display options"));
+  this->VolumeRenderingOptionsAction->setToolTip(qSlicerSubjectHierarchyVolumeRenderingPlugin::tr("Switch to Volume Rendering "
+                                                  "module to manage display options"));
   QObject::connect(this->VolumeRenderingOptionsAction, SIGNAL(triggered()), q, SLOT(showVolumeRenderingOptionsForCurrentItem()));
 }
 

--- a/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
+++ b/Modules/Loadable/Volumes/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumesPlugin.cxx
@@ -151,7 +151,7 @@ void qSlicerSubjectHierarchyVolumesPluginPrivate::init()
 
   // Add color legend action
 
-  this->ShowColorLegendAction = new QAction(tr("Show color legend"), q);
+  this->ShowColorLegendAction = new QAction(qSlicerSubjectHierarchyVolumesPlugin::tr("Show color legend"), q);
   this->ShowColorLegendAction->setObjectName("ShowColorLegendAction");
   q->setActionPosition(this->ShowColorLegendAction, qSlicerSubjectHierarchyAbstractPlugin::SectionBottom);
   QObject::connect(this->ShowColorLegendAction, SIGNAL(toggled(bool)), q, SLOT(toggleVisibilityForCurrentItem(bool)));
@@ -184,7 +184,7 @@ void qSlicerSubjectHierarchyVolumesPluginPrivate::init()
     QString presetIdStr = QString("%1%2").arg(QString::fromStdString(DISPLAY_NODE_PRESET_PREFIX)).arg(displayNodePresetIndex);
     QAction* presetAction = new QAction();
     presetAction->setObjectName(presetIdStr);
-    presetAction->setToolTip(tr("Default preset for the selected volume"));
+    presetAction->setToolTip(qSlicerSubjectHierarchyVolumesPlugin::tr("Default preset for the selected volume"));
     presetAction->setCheckable(true);
     this->PresetSubmenu->addAction(presetAction);
     presetModeActions->addAction(presetAction);
@@ -192,9 +192,9 @@ void qSlicerSubjectHierarchyVolumesPluginPrivate::init()
     }
 
   // Add Automatic preset
-  QAction* autoAction = new QAction(tr("Automatic"));
+  QAction* autoAction = new QAction(qSlicerSubjectHierarchyVolumesPlugin::tr("Automatic"));
   autoAction->setObjectName(QString::fromStdString(PRESET_AUTO));
-  autoAction->setToolTip(tr("Display the full intensity range of the volume."));
+  autoAction->setToolTip(qSlicerSubjectHierarchyVolumesPlugin::tr("Display the full intensity range of the volume."));
   autoAction->setCheckable(true);
   this->PresetSubmenu->addAction(autoAction);
   presetModeActions->addAction(autoAction);
@@ -204,11 +204,11 @@ void qSlicerSubjectHierarchyVolumesPluginPrivate::init()
   for (const auto& presetId : presetIds)
     {
     vtkSlicerVolumesLogic::VolumeDisplayPreset preset = volumesModuleLogic->GetVolumeDisplayPreset(presetId);
-    QString presetName = tr(preset.name.c_str());
+    QString presetName = qSlicerSubjectHierarchyVolumesPlugin::tr(preset.name.c_str());
     QString presetIdStr = QString::fromStdString(presetId);
     QAction* presetAction = new QAction(presetName);
     presetAction->setObjectName(presetIdStr);
-    presetAction->setToolTip(tr(preset.description.c_str()));
+    presetAction->setToolTip(qSlicerSubjectHierarchyVolumesPlugin::tr(preset.description.c_str()));
     if (!preset.icon.empty())
       {
       presetAction->setIcon(QIcon(QString::fromStdString(preset.icon)));


### PR DESCRIPTION
In the [3D Slicer in My Language](https://chanzuckerberg.com/eoss/proposals/3d-slicer-in-my-language-internationalization-and-usability-improvements/) project, we use the QT _lupdate_ tool to extract traductible strings. However, when we run that tool on the [current source code](https://github.com/Slicer/Slicer), we note the presence of some warnings that may affect the translation quality.

This commit fixes the `Class 'SomeClassName' lacks Q_OBJECT macro` warning that is related to tr function calls on classes with no Q_OBJET macro declaration.

More details in this issue can be found [here](https://github.com/mhdiop/Sliceriml/issues/1).


@lassoan As discussed during the meeting, the Q_OBJECT macro introduced in `Base/QTGUI/qSlicerExtensionsLocalWidget.cxx` is still causing a compilation issue on my side with the following error message : `'staticMetaObject': variable with internal linkage declared but not defined`. There may be usefull to verify if it's related to my development environment or something else.

CC: @lassoan @pieper