### PR TITLE
BUG: Update VTK to include OpenVR/OpenXR volume rendering fix

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "73ca81bb45d24dad5fa8316d6f7df45f5cfffa52") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "97a187572d4000cd820f9fc887f21eaf0bde857c") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
See https://github.com/KitwareMedical/SlicerVirtualReality/issues/91

Copied from "Fix projection matrix computation in VR" commit:

> Fix all mappers that use the VCDC matrix, e.g. GPUVolume, PointGaussian;
>
> The VCDC matrix must be transposed before being sent to the GPU.
> Also make sure that GetKeyMatrices is idempotent, and remove useless calls
> to it.

List of VTK changes:

$ git shortlog 73ca81bb4..97a187572 --no-merges
Lucas Gandel (1):
      [Backport MR-9620] Fix projection matrix computation in VR

Co-authored-by: Lucas Gandel <lucas.gandel@kitware.com>