### PR TITLE
COMP: Fix build error for Application Update off and I18N on

### DIFF
--- a/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
+++ b/Base/QTGUI/qSlicerSettingsGeneralPanel.cxx
@@ -95,7 +95,7 @@ void qSlicerSettingsGeneralPanelPrivate::init()
 #endif
 
   bool applicationUpdateEnabled = false;
-#ifdef Slicer_BUILD_I18N_SUPPORT
+#ifdef Slicer_BUILD_APPLICATIONUPDATE_SUPPORT
   applicationUpdateEnabled = qSlicerApplicationUpdateManager::isApplicationUpdateEnabled();
   if (applicationUpdateEnabled)
     {
@@ -254,6 +254,7 @@ void qSlicerSettingsGeneralPanel::openSlicerRCFile()
 // --------------------------------------------------------------------------
 void qSlicerSettingsGeneralPanel::updateAutoUpdateApplicationFromManager()
 {
+#ifdef Slicer_BUILD_APPLICATIONUPDATE_SUPPORT
   Q_D(qSlicerSettingsGeneralPanel);
   qSlicerApplication* app = qSlicerApplication::application();
   if (!app->applicationUpdateManager())
@@ -262,4 +263,5 @@ void qSlicerSettingsGeneralPanel::updateAutoUpdateApplicationFromManager()
     }
   QSignalBlocker blocker1(d->ApplicationAutoUpdateCheckCheckBox);
   d->ApplicationAutoUpdateCheckCheckBox->setChecked(app->applicationUpdateManager()->autoUpdateCheck());
+#endif
 }


### PR DESCRIPTION
This appears to have been a typo introduced in https://github.com/Slicer/Slicer/commit/3ce46788cde6d74167cd5bb7639855dc1e59401e

I ran into this issue while testing https://github.com/KitwareMedical/SlicerCustomAppTemplate/pull/43 where I had `Slicer_BUILD_APPLICATIONUPDATE_SUPPORT` set to `OFF` and `Slicer_BUILD_I18N_SUPPORT` set to `ON`.