### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -69,7 +69,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b
   # [/retrying]
   # [dicomweb-client]
-  dicomweb-client==0.56.2 --hash=sha256:7cb314f5dc899613ddacbc8481256416793ccf3ff503d0105c508e2116a1639c
+  dicomweb-client==0.57.1 --hash=sha256:191f39a06ac5b256ec0c160e6a9c54c9af0d8256eea1d5cb39781939381e3969
   # [/dicomweb-client]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -46,7 +46,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   smmap==5.0.0 --hash=sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94
   # [/smmap]
   # [GitPython]
-  GitPython==3.1.27 --hash=sha256:5b68b000463593e05ff2b261acff0ff0972df8ab1b70d3cdbd41b546c8b8fc3d
+  GitPython==3.1.29 --hash=sha256:41eea0deec2deea139b459ac03656f0dd28fc4a3387240ec1d3c259a2c47850f
   # [/GitPython]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -33,7 +33,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [PyJWT]
-  PyJWT==2.4.0 --hash=sha256:72d1d253f32dbd4f5c88eaf1fdc62f3a19f676ccbadb9dbc5d07e951b2b26daf
+  PyJWT==2.5.0 --hash=sha256:8d82e7087868e94dd8d7d418e5088ce64f7daab4b36db654cbaedb46f9d1ca80
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:
@@ -93,7 +93,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                 --hash=sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93
   # [/PyNaCl]
   # [PyGithub]
-  PyGithub==1.55 --hash=sha256:2caf0054ea079b71e539741ae56c5a95e073b81fa472ce222e81667381b9601b
+  PyGithub==1.56 --hash=sha256:d15f13d82165306da8a68aefc0f848a6f6432d5febbff13b60a94758ce3ef8b5
   # [/PyGithub]
   ]===])
 

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -34,16 +34,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/nose]
   # [numpy]
   # Hashes correspond to the following packages:
-  #  - numpy-1.23.1-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - numpy-1.23.1-cp39-cp39-macosx_11_0_arm64.whl
-  #  - numpy-1.23.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - numpy-1.23.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - numpy-1.23.1-cp39-cp39-win_amd64.whl
-  numpy==1.23.1 --hash=sha256:173f28921b15d341afadf6c3898a34f20a0569e4ad5435297ba262ee8941e77b \
-                --hash=sha256:876f60de09734fbcb4e27a97c9a286b51284df1326b1ac5f1bf0ad3678236b22 \
-                --hash=sha256:35590b9c33c0f1c9732b3231bb6a72d1e4f77872390c47d50a615686ae7ed3fd \
-                --hash=sha256:a35c4e64dfca659fe4d0f1421fc0f05b8ed1ca8c46fb73d9e5a7f175f85696bb \
-                --hash=sha256:37ece2bd095e9781a7156852e43d18044fd0d742934833335599c583618181b9
+  #  - numpy-1.23.4-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - numpy-1.23.4-cp39-cp39-macosx_11_0_arm64.whl
+  #  - numpy-1.23.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - numpy-1.23.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - numpy-1.23.4-cp39-cp39-win_amd64.whl
+  numpy==1.23.4 --hash=sha256:c67b833dbccefe97cdd3f52798d430b9d3430396af7cdb2a0c32954c3ef73894 \
+                --hash=sha256:f76025acc8e2114bb664294a07ede0727aa75d63a06d2fae96bf29a81747e4a7 \
+                --hash=sha256:12ac457b63ec8ded85d85c1e17d85efd3c2b0967ca39560b307a35a6703a4735 \
+                --hash=sha256:95de7dc7dc47a312f6feddd3da2500826defdccbc41608d0031276a24181a2c0 \
+                --hash=sha256:f260da502d7441a45695199b4e7fd8ca87db659ba1c78f2bbf31f934fe76ae0e
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==22.2 --hash=sha256:9abf423d5d64f3289ab9d5bf31da9e6234f2e9c5d8dcf1423bcb46b809a02c2c
+  pip==22.3 --hash=sha256:1daab4b8d3b97d1d763caeb01a4640a2250a0ea899e257b1e44b9eded91e15ab
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -27,16 +27,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [certifi]
-  certifi==2022.6.15 --hash=sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412
+  certifi==2022.9.24 --hash=sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382
   # [/certifi]
   # [idna]
-  idna==3.3 --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff
+  idna==3.4 --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
   # [/idna]
   # [charset-normalizer]
-  charset-normalizer==2.1.0 --hash=sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5
+  charset-normalizer==2.1.1 --hash=sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
   # [/charset-normalizer]
   # [urllib3]
-  urllib3==1.26.10 --hash=sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec
+  urllib3==1.26.12 --hash=sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997
   # [/urllib3]
   # [requests]
   requests==2.28.1 --hash=sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -31,18 +31,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [scipy]
   # Hashes correspond to the following packages:
-  #  - scipy-1.8.1-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - scipy-1.8.1-cp39-cp39-macosx_12_0_arm64.whl
-  #  - scipy-1.8.1-cp39-cp39-macosx_12_0_universal2.macosx_10_9_x86_64.whl
-  #  - scipy-1.8.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - scipy-1.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - scipy-1.8.1-cp39-cp39-win_amd64.whl
-  scipy==1.8.1 --hash=sha256:f3e7a8867f307e3359cc0ed2c63b61a1e33a19080f92fe377bc7d49f646f2ec1 \
-               --hash=sha256:2ef0fbc8bcf102c1998c1f16f15befe7cffba90895d6e84861cd6c6a33fb54f6 \
-               --hash=sha256:83606129247e7610b58d0e1e93d2c5133959e9cf93555d3c27e536892f1ba1f2 \
-               --hash=sha256:d3b3c8924252caaffc54d4a99f1360aeec001e61267595561089f8b5900821bb \
-               --hash=sha256:70de2f11bf64ca9921fda018864c78af7147025e467ce9f4a11bc877266900a6 \
-               --hash=sha256:9dd4012ac599a1e7eb63c114d1eee1bcfc6dc75a29b589ff0ad0bb3d9412034f
+  #  - scipy-1.9.2-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - scipy-1.9.2-cp39-cp39-macosx_12_0_arm64.whl
+  #  - scipy-1.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - scipy-1.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - scipy-1.9.2-cp39-cp39-win_amd64.whl
+  scipy==1.9.2 --hash=sha256:1e3b23a82867018cd26255dc951789a7c567921622073e1113755866f1eae928 \
+               --hash=sha256:82e8bfb352aa9dce9a0ffe81f4c369a2c87c85533519441686f59f21d8c09697 \
+               --hash=sha256:61b95283529712101bfb7c87faf94cb86ed9e64de079509edfe107e5cfa55733 \
+               --hash=sha256:8c8c29703202c39d699b0d6b164bde5501c212005f20abf46ae322b9307c8a41 \
+               --hash=sha256:7b2608b3141c257d01ae772e23b3de9e04d27344e6b68a890883795229cb7191
   # [/scipy]
   ]===])
 

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==63.2.0 --hash=sha256:0d33c374d41c7863419fc8f6c10bfe25b7b498aa34164d135c622e52580c6b16
+  setuptools==65.5.0 --hash=sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356
   # [/setuptools]
   ]===])
 


### PR DESCRIPTION
it's been about 3 months since python packages were last updated. Python packages were last updated on July 21st 2022. This PR updates python packages to their latest versions. This type of update is something I usually do on about a quarterly cadence (every 3 months).

Note that SimpleITK isn't being updated here as we build it from source rather than using the provided whl on pypi. VTK is also not updated as we use build VTK and its python wrapping as well from source rather than installing from whl.

```
PS C:\Users\butlej30383\AppData\Local\NA-MIC\Slicer 5.1.0-2022-10-15\bin> ./PythonSlicer.exe "C:\Slicer\Utilities\Scripts\python_package_updater.py"
Searching external projects in C:\Slicer\SuperBuild
Package            Version         Latest    Type
------------------ --------------- --------- -----
certifi            2022.6.15       2022.9.24 wheel
charset-normalizer 2.1.0           2.1.1     wheel
dicomweb-client    0.56.2          0.57.1    wheel
GitPython          3.1.27          3.1.29    wheel
idna               3.3             3.4       wheel
numpy              1.23.1          1.23.4    wheel
pip                22.2            22.3      wheel
PyGithub           1.55            1.56      wheel
PyJWT              2.4.0           2.5.0     wheel
scipy              1.8.1           1.9.2     wheel
setuptools         63.2.0          65.5.0    wheel
SimpleITK          2.2.0rc2.dev367 2.2.0     wheel
urllib3            1.26.10         1.26.12   wheel
vtk                9.1.20220125    9.2.2     wheel

[notice] A new release of pip available: 22.2 -> 22.3
[notice] To update, run: python-real.exe -m pip install --upgrade pip

  certifi==2022.9.24 --hash=sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382
  charset-normalizer==2.1.1 --hash=sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
  dicomweb-client==0.57.1 --hash=sha256:191f39a06ac5b256ec0c160e6a9c54c9af0d8256eea1d5cb39781939381e3969
  GitPython==3.1.29 --hash=sha256:41eea0deec2deea139b459ac03656f0dd28fc4a3387240ec1d3c259a2c47850f
  idna==3.4 --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
  # Hashes correspond to the following packages:
  #  - numpy-1.23.4-cp39-cp39-macosx_10_9_x86_64.whl
  #  - numpy-1.23.4-cp39-cp39-macosx_11_0_arm64.whl
  #  - numpy-1.23.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - numpy-1.23.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - numpy-1.23.4-cp39-cp39-win_amd64.whl
  numpy==1.23.4 --hash=sha256:c67b833dbccefe97cdd3f52798d430b9d3430396af7cdb2a0c32954c3ef73894 \
                --hash=sha256:f76025acc8e2114bb664294a07ede0727aa75d63a06d2fae96bf29a81747e4a7 \
                --hash=sha256:12ac457b63ec8ded85d85c1e17d85efd3c2b0967ca39560b307a35a6703a4735 \
                --hash=sha256:95de7dc7dc47a312f6feddd3da2500826defdccbc41608d0031276a24181a2c0 \
                --hash=sha256:f260da502d7441a45695199b4e7fd8ca87db659ba1c78f2bbf31f934fe76ae0e
  pip==22.3 --hash=sha256:1daab4b8d3b97d1d763caeb01a4640a2250a0ea899e257b1e44b9eded91e15ab
  PyGithub==1.56 --hash=sha256:d15f13d82165306da8a68aefc0f848a6f6432d5febbff13b60a94758ce3ef8b5
  PyJWT==2.5.0 --hash=sha256:8d82e7087868e94dd8d7d418e5088ce64f7daab4b36db654cbaedb46f9d1ca80
  # Hashes correspond to the following packages:
  #  - scipy-1.9.2-cp39-cp39-macosx_10_9_x86_64.whl
  #  - scipy-1.9.2-cp39-cp39-macosx_12_0_arm64.whl
  #  - scipy-1.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - scipy-1.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - scipy-1.9.2-cp39-cp39-win_amd64.whl
  scipy==1.9.2 --hash=sha256:1e3b23a82867018cd26255dc951789a7c567921622073e1113755866f1eae928 \
               --hash=sha256:82e8bfb352aa9dce9a0ffe81f4c369a2c87c85533519441686f59f21d8c09697 \
               --hash=sha256:61b95283529712101bfb7c87faf94cb86ed9e64de079509edfe107e5cfa55733 \
               --hash=sha256:8c8c29703202c39d699b0d6b164bde5501c212005f20abf46ae322b9307c8a41 \
               --hash=sha256:7b2608b3141c257d01ae772e23b3de9e04d27344e6b68a890883795229cb7191
  setuptools==65.5.0 --hash=sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356
  # Hashes correspond to the following packages:
  #  - SimpleITK-2.2.0-cp39-cp39-macosx_10_9_x86_64.whl
  #  - SimpleITK-2.2.0-cp39-cp39-macosx_11_0_arm64.whl
  #  - SimpleITK-2.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - SimpleITK-2.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - SimpleITK-2.2.0-cp39-cp39-win_amd64.whl
  SimpleITK==2.2.0 --hash=sha256:160a5e2743ab16b1fe201766ec3aed9587a19dcce534953736d4af7a77216628 \
                   --hash=sha256:a712f4b205a0c2bbd9bfbefbe27f83ad892904f6cf9e165644dec0fb2320c508 \
                   --hash=sha256:dc82050f78bfed95af20683a10bb2a0caf8c3c798aa2ccd43099f338baa2ec55 \
                   --hash=sha256:ffaa51d88a75048bc759f6147c87695987914764ac411095f63c0d4ebde2365b \
                   --hash=sha256:b607f118b061744a7dcf656ccd93245029c312318df7fd88063356287784fbc8
  urllib3==1.26.12 --hash=sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997
```
