### PR TITLE
Update GitHub actions to avoid deprecations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
       with:
         python-version: '3.9'
 
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
 


### PR DESCRIPTION
This fixes some warnings observed in GitHub actions runs such as the one observed in https://github.com/Slicer/Slicer/actions/runs/3274861579.