### PR TITLE
ENH: separate slice doubleclick operations

### DIFF
--- a/Docs/user_guide/user_interface.md
+++ b/Docs/user_guide/user_interface.md
@@ -122,7 +122,7 @@ Window/level can be manually adjusted anytime by clicking on "Adjust window/leve
 
 [![](https://img.youtube.com/vi/u1B0F1KcVsk/0.jpg)](https://youtu.be/u1B0F1KcVsk "Demo video of how to adjust image window/level")
 
-Additional window/level options, presets, intensity histogram, automatic adjustments are available in Display section of [Volumes](modules/volumes.md) module.  Presets are also available in the context menu of the Slice views.  You can reset to the automatically calculated window/level settings using the context menu or by using `Control-left-doubleclick` on the Slice view.
+Additional window/level options, presets, intensity histogram, automatic adjustments are available in Display section of [Volumes](modules/volumes.md) module.  Presets are also available in the context menu of the Slice views.  You can reset to the automatically calculated window/level settings using the context menu or by using `Ctrl` + `left-double-click` on the Slice view.
 
 ### 3D View
 

--- a/Docs/user_guide/user_interface.md
+++ b/Docs/user_guide/user_interface.md
@@ -119,9 +119,10 @@ By default 3D Slicer uses window/level setting that is specified in the DICOM fi
 
 Window/level can be manually adjusted anytime by clicking on "Adjust window/level" button on the toolbar then left-click-and-drag in any of the slice viewers. Optimal window/level can be computed for a chosen area by lef-click-and-dragging while holding down <kbd>Ctrl</kbd> key.
 
+
 [![](https://img.youtube.com/vi/u1B0F1KcVsk/0.jpg)](https://youtu.be/u1B0F1KcVsk "Demo video of how to adjust image window/level")
 
-Additional window/level options, presets, intensity histogram, automatic adjustments are available in Display section of [Volumes](modules/volumes.md) module.
+Additional window/level options, presets, intensity histogram, automatic adjustments are available in Display section of [Volumes](modules/volumes.md) module.  Presets are also available in the context menu of the Slice views.  You can reset the the automatically calculated window/level settings using the context menu or by using the `Control-left-doubleclick` on the Slice view.
 
 ### 3D View
 

--- a/Docs/user_guide/user_interface.md
+++ b/Docs/user_guide/user_interface.md
@@ -122,7 +122,7 @@ Window/level can be manually adjusted anytime by clicking on "Adjust window/leve
 
 [![](https://img.youtube.com/vi/u1B0F1KcVsk/0.jpg)](https://youtu.be/u1B0F1KcVsk "Demo video of how to adjust image window/level")
 
-Additional window/level options, presets, intensity histogram, automatic adjustments are available in Display section of [Volumes](modules/volumes.md) module.  Presets are also available in the context menu of the Slice views.  You can reset the the automatically calculated window/level settings using the context menu or by using the `Control-left-doubleclick` on the Slice view.
+Additional window/level options, presets, intensity histogram, automatic adjustments are available in Display section of [Volumes](modules/volumes.md) module.  Presets are also available in the context menu of the Slice views.  You can reset to the automatically calculated window/level settings using the context menu or by using `Control-left-doubleclick` on the Slice view.
 
 ### 3D View
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLWindowLevelWidget.cxx
@@ -88,7 +88,7 @@ vtkMRMLWindowLevelWidget::vtkMRMLWindowLevelWidget()
   this->SetEventTranslation(WidgetStateAdjustWindowLevelAlternative, vtkCommand::RightButtonPressEvent, vtkEvent::AnyModifier,
     WidgetEventAdjustWindowLevelAlternativeCancel);
 
-  this->SetEventTranslation(WidgetStateIdle, vtkCommand::LeftButtonDoubleClickEvent, vtkEvent::NoModifier, WidgetEventResetWindowLevel);
+  this->SetEventTranslation(WidgetStateIdle, vtkCommand::LeftButtonDoubleClickEvent, vtkEvent::ControlModifier, WidgetEventResetWindowLevel);
 }
 
 //----------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #6592 by changing the window/level reset opation to be control-left-doubleclick so that it doesn't interfere with the default view operation of maximizing/restoring view size using left-double-click.