### PR TITLE
ENH: Add commit message github actions workflow

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -25,3 +25,12 @@ jobs:
           error: 'The first line has to start with the type (e.g "ENH: Add support for awesome feature"). For more details, see https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html#commits'
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
+      - name: Check Line Length
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^[^#].{1,78}$'
+          error: 'The maximum line length of 78 characters is exceeded. For more details, see https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html#commits'
+          excludeDescription: 'true' # optional: this excludes the description body of a pull request
+          excludeTitle: 'true' # optional: this excludes the title of a pull request
+          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,27 @@
+name: 'Commit Message Check'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Commit Prefix
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^(ENH|PERF|BUG|STYLE|DOC|COMP): ([A-Z])+'
+          flags: 'gm'
+          excludeDescription: 'true' # optional: this excludes the description body of a pull request
+          excludeTitle: 'true' # optional: this excludes the title of a pull request
+          error: 'The first line has to start with the type (e.g "ENH: Add support for awesome feature"). For more details, see https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html#commits'
+          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true

--- a/Docs/developer_guide/style_guide.md
+++ b/Docs/developer_guide/style_guide.md
@@ -280,7 +280,7 @@ vtkDebugMacro("This variable has the value: "<< value);
 ## Commits
 
 - Separate the subject from body with a blank line
-- Limit the subject line to 50 characters
+- Limit the subject line to 78 characters
 - Capitalize the subject line
 - Do not end the subject line with a period
 - Use the imperative mood in the subject line
@@ -291,7 +291,7 @@ vtkDebugMacro("This variable has the value: "<< value);
 
 ### Commit message prefix
 
-Subversion Commits to Slicer require commit type in the comment.
+Commits to the Slicer repository require commit type in the comment.
 
 Valid commit types are:
 


### PR DESCRIPTION
This replaces the usage of https://github.com/marketplace/commitcheck which has been unreliable at times and also difficult to see what is required to pass a failing check. I had to find https://discourse.slicer.org/t/commit-message-prefix/10921 to see the previously used regex. The unreliable can be observed in recent PR #6601 where the installed CommitCheck app is not responding and the https://www.commitcheck.com/ site is unresponsive.

![image](https://user-images.githubusercontent.com/15837524/196832991-25df73fb-f861-4746-92d3-fa0b6d1a6b42.png)


This check is based on content at https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html#commits.