### PR TITLE
ENH: Add https support to vtkHTTPHandler

### DIFF
--- a/Base/QTCore/Testing/Cxx/qSlicerSslTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerSslTest.cxx
@@ -33,7 +33,8 @@ void qSlicerSslTester::testSupportsSsl()
 void qSlicerSslTester::testLoadCaCertificates()
 {
   QVERIFY(qSlicerCoreApplication::loadCaCertificates(
-            QProcessEnvironment::systemEnvironment().value("SLICER_HOME")));
+    qSlicerCoreApplication::caCertificatesPath(
+            QProcessEnvironment::systemEnvironment().value("SLICER_HOME"))));
 }
 
 // ----------------------------------------------------------------------------
@@ -69,7 +70,8 @@ void qSlicerSslTester::testHttpsConnection()
   QFETCH(int, expectedStatusCode);
 
   qSlicerCoreApplication::loadCaCertificates(
-        QProcessEnvironment::systemEnvironment().value("SLICER_HOME"));
+    qSlicerCoreApplication::caCertificatesPath(
+        QProcessEnvironment::systemEnvironment().value("SLICER_HOME")));
 
   QNetworkAccessManager * manager = new QNetworkAccessManager(this);
 

--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -294,7 +294,7 @@ void qSlicerCoreApplicationPrivate::init()
     {
     qWarning() << "[SSL] SSL support disabled - Failed to load SSL library !";
     }
-  if (!qSlicerCoreApplication::loadCaCertificates(this->SlicerHome))
+  if (!qSlicerCoreApplication::loadCaCertificates(qSlicerCoreApplication::caCertificatesPath(this->SlicerHome)))
     {
     qWarning() << "[SSL] Failed to load Slicer.crt";
     }
@@ -545,6 +545,8 @@ void qSlicerCoreApplicationPrivate::initDataIO()
 
   // Create MRMLRemoteIOLogic
   this->MRMLRemoteIOLogic = vtkSmartPointer<vtkMRMLRemoteIOLogic>::New();
+
+  this->MRMLRemoteIOLogic->SetCaCertificatesPath(q->caCertificatesPath(this->SlicerHome).toStdString().c_str());
 
   // Ensure cache folder is writable
   {
@@ -2052,20 +2054,24 @@ void qSlicerCoreApplication::loadLanguage()
 }
 
 //----------------------------------------------------------------------------
-bool qSlicerCoreApplication::loadCaCertificates(const QString& slicerHome)
+bool qSlicerCoreApplication::loadCaCertificates(const QString& caCertificatesPath)
 {
 #ifdef Slicer_USE_PYTHONQT_WITH_OPENSSL
   if (QSslSocket::supportsSsl())
     {
-    QSslSocket::setDefaultCaCertificates(
-          QSslCertificate::fromPath(
-            slicerHome + "/" Slicer_SHARE_DIR "/Slicer.crt"));
+    QSslSocket::setDefaultCaCertificates(QSslCertificate::fromPath(caCertificatesPath));
     }
   return !QSslSocket::defaultCaCertificates().empty();
 #else
   Q_UNUSED(slicerHome);
   return false;
 #endif
+}
+
+//----------------------------------------------------------------------------
+QString qSlicerCoreApplication::caCertificatesPath(const QString& slicerHome)
+{
+  return QString("%1/%2/Slicer.crt").arg(slicerHome).arg(Slicer_SHARE_DIR);
 }
 
 //----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -524,11 +524,16 @@ public:
   /// \sa translationFolders(), loadTranslations
   Q_INVOKABLE static void loadLanguage();
 
-  /// Load certificates bundled into '<slicerHome>/<SLICER_SHARE_DIR>/Slicer.crt'.
+  /// Load SSL certificates bundle.
+  /// Path to the certificates bundle file can be retrieved using caCertificatesPath() method.
   /// For more details, see Slicer/Base/QTCore/Resources/Certs/README
-  /// Returns \a False if 'Slicer.crt' failed to be loaded.
+  /// Returns \a False if the certificate failed to be loaded.
   /// \sa QSslSocket::defaultCaCertificates()
   Q_INVOKABLE static bool loadCaCertificates(const QString& slicerHome);
+
+  /// Return path of certificates bundle.
+  /// The path is '<slicerHome>/<SLICER_SHARE_DIR>/Slicer.crt'.
+  Q_INVOKABLE static QString caCertificatesPath(const QString& slicerHome);
 
   Q_INVOKABLE int registerResource(const QByteArray& data);
 

--- a/Libs/MRML/Logic/vtkMRMLRemoteIOLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLRemoteIOLogic.cxx
@@ -91,8 +91,9 @@ void vtkMRMLRemoteIOLogic::AddDataIOToScene()
 #if !defined(REMOTEIO_DEBUG)
   // register all existing uri handlers (add to collection)
   vtkHTTPHandler *httpHandler = vtkHTTPHandler::New();
-  httpHandler->SetPrefix ( "http://" );
-  httpHandler->SetName ( "HTTPHandler");
+  httpHandler->SetPrefix("http://");
+  httpHandler->SetName("HTTPHandler");
+  httpHandler->SetCaCertificatesPath(this->GetCaCertificatesPath());
   this->GetMRMLScene()->AddURIHandler(httpHandler);
   httpHandler->Delete();
 

--- a/Libs/MRML/Logic/vtkMRMLRemoteIOLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLRemoteIOLogic.h
@@ -53,6 +53,10 @@ public:
   vtkGetObjectMacro (DataIOManager, vtkDataIOManager);
   virtual void SetDataIOManager(vtkDataIOManager*);
 
+  /// CA Certificates path for https protocol.
+  vtkSetStringMacro(CaCertificatesPath);
+  vtkGetStringMacro(CaCertificatesPath);
+
 protected:
   vtkMRMLRemoteIOLogic();
   ~vtkMRMLRemoteIOLogic() override;
@@ -60,8 +64,9 @@ protected:
   vtkMRMLRemoteIOLogic(const vtkMRMLRemoteIOLogic&);
   void operator=(const vtkMRMLRemoteIOLogic&);
 
-  vtkCacheManager *          CacheManager;
-  vtkDataIOManager *         DataIOManager;
+  vtkCacheManager* CacheManager{nullptr};
+  vtkDataIOManager* DataIOManager{nullptr};
+  char* CaCertificatesPath{nullptr};
 };
 
 #endif

--- a/Libs/RemoteIO/vtkHTTPHandler.cxx
+++ b/Libs/RemoteIO/vtkHTTPHandler.cxx
@@ -132,7 +132,7 @@ int vtkHTTPHandler::CanHandleURI ( const char *uri )
       //--- we adopt the gwe "[filename.ext]:" prefix.
       prefix = prefix.substr ( index+2 );
       }
-    if ( !strcmp(prefix.c_str(), "http"))
+    if ( !strcmp(prefix.c_str(), "http") || !strcmp(prefix.c_str(), "https"))
       {
       vtkDebugMacro("vtkHTTPHandler: CanHandleURI: can handle this file: " << uriString.c_str());
       return (1);
@@ -218,6 +218,16 @@ void vtkHTTPHandler::StageFileRead(const char * source, const char * destination
 //  curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_PROGRESSDATA, nullptr);
 //  curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_PROGRESSFUNCTION, ProgressCallback);
 
+  if (this->CaCertificatesPath)
+    {
+    curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_CAINFO, this->CaCertificatesPath);
+    }
+  else
+    {
+    curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_SSL_VERIFYHOST, 0);
+    }
+
   // quick timeout during connection phase if URL is not accessible (e.g. blocked by a firewall)
   curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_CONNECTTIMEOUT, 3); // in seconds (type long)
 
@@ -288,6 +298,15 @@ void vtkHTTPHandler::StageFileWrite(const char * source, const char * destinatio
   curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_READDATA, this->LocalFile);
 //  curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_PROGRESSDATA, nullptr);
   //curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_PROGRESSFUNCTION, ProgressCallback);
+  if (this->CaCertificatesPath)
+    {
+    curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_CAINFO, this->CaCertificatesPath);
+    }
+  else
+    {
+    curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_easy_setopt(this->Internal->CurlHandle, CURLOPT_SSL_VERIFYHOST, 0);
+    }
   CURLcode retval = curl_easy_perform(this->Internal->CurlHandle);
 
    if (retval == CURLE_OK)

--- a/Libs/RemoteIO/vtkHTTPHandler.h
+++ b/Libs/RemoteIO/vtkHTTPHandler.h
@@ -40,6 +40,10 @@ public:
   void InitTransfer () override;
   int CloseTransfer () override;
 
+  /// CA Certificates path for https protocol.
+  vtkSetStringMacro(CaCertificatesPath);
+  vtkGetStringMacro(CaCertificatesPath);
+
 protected:
   vtkHTTPHandler();
   ~vtkHTTPHandler() override;
@@ -49,6 +53,7 @@ protected:
 private:
   class vtkInternal;
   vtkInternal* Internal;
+  char* CaCertificatesPath{nullptr};
 };
 
 #endif


### PR DESCRIPTION
It allows referring to files hosted on https servers in the MRML scene.

May be useful to distribute scene files with remote data - see https://discourse.slicer.org/t/embedding-uri-in-a-mrml-scene-file-for-viewing-the-mrml-scene-on-a-remote-slicer-application/25373/9