### PR TITLE
ENH: Update pre-commit config to include pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,9 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear==22.9.23]
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.1.0
+  hooks:
+  - id: pyupgrade
+    args: [--py39-plus]


### PR DESCRIPTION
By adding `pyupgrade` to the pre-commit configuration, it enables the following:

* GitHub Action report: Suggested changes are reported in the error log associated with the pre-commit GitHub Action workflow.

* Consolidated local pre-commit checks and updates by running:

  ```
  PythonSlicer -m pip install pyupgrade
  PythonSlicer -m pre_commit run --all-files
  ```

As described in a4ea79909 (STYLE: Upgrade python syntax to 3.9 and newer), note that:

1. Running the command twice may be needed to ensure that strings associated with `logging` package are updated to use f-string.

2. Revisiting some of the changes automatically proposed may be required.
