### PR TITLE
BUG: Update SimpleITK to fix test_sitkUtils

### DIFF
--- a/SuperBuild/External_SimpleITK.cmake
+++ b/SuperBuild/External_SimpleITK.cmake
@@ -140,7 +140,7 @@ ExternalProject_Execute(${proj} \"install\" \"${PYTHON_EXECUTABLE}\" \"-m\" \"pi
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "48cddfb0109e8028dbb1d2b78c73ec71762050d2"  # slicer-v2.2.0-2022-08-30-1c0cf5de
+    "ca0c09386219dfff61975437b7ea32b246adb724"  # slicer-v2.2.0-2022-08-30-1c0cf5de
     QUIET
     )
 


### PR DESCRIPTION
See https://discourse.slicer.org/t/sitkutils-pullvolumefromslicer-does-not-create-sitk-image-in-slicer-5-1/25669

This commit fixes a regression introduced by Slicer@8f67453b0 (ENH: Add support for importing "itk" from python wheels installed from PyPI)

It ensures the type checks associated with "sitk.SetImageFromArray()" and "sitk.GetMemoryViewFromImage()" functions do not report errors like the following:

```
  Traceback (most recent call last):
    File "<console>", line 1, in <module>
    File "/path/to/lib/Python/Lib/site-packages/SimpleITK/extra.py", line 269, in GetArrayFromImage
      array_view = GetArrayViewFromImage(image)
    File "/path/to/lib/Python/Lib/site-packages/SimpleITK/extra.py", line 255, in GetArrayViewFromImage
      image_memory_view = _GetMemoryViewFromImage(image)
  TypeError: in method 'GetByteArrayFromImage', argument needs to be of type 'sitk::Image *'
```

List of SimpleITK changes:

```
$ git shortlog 48cddfb0..ca0c0938 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Update Swig interface files to use "slicer_itk" namespace
```