### PR TITLE
BUG: Fix vtkMRMLDisplayableNodeTest1-TestDisplayModifiedEvent

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLDisplayableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLDisplayableNodeTest1.cxx
@@ -464,7 +464,8 @@ int TestDisplayModifiedEvent()
 
   displayNode1->Modified();
 
-  CHECK_INT(spy->GetTotalNumberOfEvents(), 1);
+  CHECK_INT(spy->GetTotalNumberOfEvents(), 2);
+  CHECK_INT(spy->GetNumberOfEvents(vtkMRMLNode::ReferencedNodeModifiedEvent), 1);
   CHECK_INT(spy->GetNumberOfEvents(vtkMRMLDisplayableNode::DisplayModifiedEvent), 1);
   spy->ResetNumberOfEvents();
 


### PR DESCRIPTION
This commit updates the test to account for change introduced in abe976107 (BUG: Make sure ProcessMRMLEvents is called all the way to the base node class).

Considering that...

* the spy is associated with `displayableNode`
* `displayableNode` has a reference to `displayNode1`
* the modified event associated with `displayNode1` is triggered
* the fix abe976107 ensures events associated with references are processed in vtkMRMLNode::ProcessMRMLEvents

... updating the test to expect "DisplayModifiedEvent" and "ReferencedNodeModifiedEvent" is sensible.