### PR TITLE
Fix VTKObservationMixin so that observers are removed if object reference is not kept in Python

### DIFF
--- a/Base/Python/slicer/tests/test_slicer_util_VTKObservationMixin.py
+++ b/Base/Python/slicer/tests/test_slicer_util_VTKObservationMixin.py
@@ -123,7 +123,21 @@ class SlicerUtilVTKObservationMixinTests(unittest.TestCase):
         self.assertEqual(group, group_)
         self.assertEqual(priority, priority_)
 
+    @unittest.expectedFailure
     def test_releaseNodes(self):
+        """test_releaseNodes
+
+        This test was originally added following the introduction of :class:`weakref.WeakKeyDictionary`
+        ensuring the observed vtkObjects are garbage collected if all other references have been lost.
+        See https://github.com/Slicer/Slicer/issues/6406
+
+        The problem is that if an observer is attached to an object through :class:`slicer.util.VTKObservationMixin`,
+        and if a reference to the object is not kept in Python, then the observer was automatically garbage collected
+        from the :class:`weakref.WeakKeyDictionary` even if the VTK object still exists.
+        See https://github.com/Slicer/Slicer/issues/6610
+
+        Approaches for fixing this test are discussed in https://github.com/Slicer/Slicer/issues/6679
+        """
         foo = Foo()
         node = vtk.vtkObject()
         callback = unittest.mock.Mock()
@@ -163,7 +177,6 @@ class SlicerUtilVTKObservationMixinTests(unittest.TestCase):
         foo.removeObserver(object2, event, callback2)
         self.assertEqual(len(foo.Observations), 0)
 
-    @unittest.expectedFailure
     def test_removeObserver_issue6610(self):
         """test_removeObserver_issue6610
 

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2470,11 +2470,9 @@ def dataframeFromMarkups(markupsNode):
 
 class VTKObservationMixin:
     def __init__(self):
-        from weakref import WeakKeyDictionary
-
         super().__init__()
 
-        self.__observations = WeakKeyDictionary()
+        self.__observations = {}
         # {obj: {event: {method: (group, tag, priority)}}}
 
     @property


### PR DESCRIPTION
If an observer is attached to an object through `VTKObservationMixin`, and if a reference to the object is not kept in Python, then the observer was automatically garbage collected from the `WeakKeyDictionary` even if the VTK object still exists. This means the observer cannot be removed with `removeObserver()`/`removeObservers()`.
    
This commit partially reverts 1e6d068 (BUG: Fix VTKObservationMixin preventing observed nodes from being released) by removing the use of `WeakKeyDictionary`.
    
It also marks `test_releaseNodes` as expected to fail and `test_removeObserver_issue6610` as expected to pass.
