### PR TITLE
BUG: Fix crash when exporting segment model node

### DIFF
--- a/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
+++ b/Modules/Loadable/Segmentations/SubjectHierarchyPlugins/qSlicerSubjectHierarchySegmentationsPlugin.cxx
@@ -1073,9 +1073,9 @@ void qSlicerSubjectHierarchySegmentationsPlugin::exportToClosedSurface()
   std::string newFolderName = std::string(segmentationNode->GetName()) + "-models";
   vtkMRMLSubjectHierarchyNode* shNode = qSlicerSubjectHierarchyPluginHandler::instance()->subjectHierarchyNode();
   // Since segmentationNode is not nullptr, we can be sure that shNode is valid.
-  vtkIdType currentItemID = qSlicerSubjectHierarchyPluginHandler::instance()->currentItem();
+  vtkIdType segmentationItemID = shNode->GetItemByDataNode(segmentationNode);
   vtkIdType folderItemID = shNode->CreateFolderItem(
-    shNode->GetItemParent(currentItemID),
+    shNode->GetItemParent(segmentationItemID),
     shNode->GenerateUniqueItemName(newFolderName) );
 
   // Export visible segments into a models


### PR DESCRIPTION
Exporting visible segments to model nodes could cause a crash when exporting using the action on the virtual "Segment" items, but wouldn't crash when exporting from the "Segmentation" item. When exporting from segment, the segment parent (the segmentation node) was used as the parent of the folder node. This seems to cause an invalid SH item parent, and could cause a crash later when the model is updated.

Fixed by using the parent of the Segmentation node for the export folder parent.

Fixes #6570