### PR TITLE
COMP: Update CTK to fix build error and update python console shortcut

### DIFF
--- a/Docs/user_guide/user_interface.md
+++ b/Docs/user_guide/user_interface.md
@@ -270,7 +270,7 @@ The following shortcuts are available in the Python console.
 | `Tab` | auto-complete |
 | `up arrow` / `down arrow` | command history |
 | `Esc` | clear selection, return to current command line, clear current command line |
-| `Ctrl` + `r` | run Python script from a file |
+| `Ctrl` + `g` | run Python script from a file |
 | `Ctrl` + `v` | paste Python script from clipboard and run it |
 
 Note that when code is pasted into an empty line then all the code in the clipboard is executed *at once*. If the current command line is not empty then the code from the clipboard is pasted into the console and executed *line by line*. When code is executed line by line, the behavior is different in that an empty input line immediately closes the current block, and output is printed after executing each line.

--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "65a0555120de6681959b43f9154a77fd7ccf1d47"
+    "95d735d1d77ad2c9aa0d16de50d2e7db2bf4f3eb"
     QUIET
     )
 


### PR DESCRIPTION
See https://discourse.slicer.org/t/load-python-script-from-harddisk-in-slicers-s-python-interactor/17399/10

List of changes:

```
$ git shortlog 65a055512..95d735d1d --no-merges
Andras Lasso (3):
      COMP: Fix build error introduced in previous commit
      ENH: Change run file keyboard shortcut in Python console
      BUG: Fix unnecessary warning in ctkVTKHistogram::resetRange()
```