### PR TITLE
BUG: Fix terminology JSON schema URLs

### DIFF
--- a/Modules/Loadable/Terminologies/Resources/AnatomicRegionAndModifier-DICOM-Master.json
+++ b/Modules/Loadable/Terminologies/Resources/AnatomicRegionAndModifier-DICOM-Master.json
@@ -1,6 +1,6 @@
 {
   "AnatomicContextName": "Anatomic codes - DICOM master list",
-  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/anatomic-context-schema.json#",
+  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/anatomic-context-schema.json#",
   "AnatomicCodes": {
     "AnatomicRegion": [
       {

--- a/Modules/Loadable/Terminologies/Resources/SegmentationCategoryTypeModifier-DICOM-Master.json
+++ b/Modules/Loadable/Terminologies/Resources/SegmentationCategoryTypeModifier-DICOM-Master.json
@@ -1,6 +1,6 @@
 {
   "SegmentationCategoryTypeContextName": "Segmentation category and type - DICOM master list",
-  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/segment-context-schema.json#",
+  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/segment-context-schema.json#",
   "SegmentationCodes": {
     "Category": [
       {

--- a/Modules/Loadable/Terminologies/Resources/SegmentationCategoryTypeModifier-SlicerGeneralAnatomy.json
+++ b/Modules/Loadable/Terminologies/Resources/SegmentationCategoryTypeModifier-SlicerGeneralAnatomy.json
@@ -1,6 +1,6 @@
 {
   "SegmentationCategoryTypeContextName": "Segmentation category and type - 3D Slicer General Anatomy list",
-  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/segment-context-schema.json#",
+  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/segment-context-schema.json#",
   "SegmentationCodes": {
     "Category": [
       {


### PR DESCRIPTION
The schema files have been moved into a subdirectory so the URL became invalid. This commit fixes them.