### PR TITLE
Document slicer python api

### DIFF
--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -40,6 +40,12 @@ extensions = [
     'notfound.extension',  # Show a better 404 page when an invalid address is entered
 ]
 
+autodoc_mock_imports = [
+    "ctk",
+    "qt",
+    "vtk",
+]
+
 myst_enable_extensions = [
     "colon_fence",  # Allow code fence using ::: (see https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html#syntax-colon-fence)
     "linkify",  # Allow automatic creation of links from URLs (it is sufficient to write https://google.com instead of <https://google.com>)

--- a/Docs/developer_guide/api.md
+++ b/Docs/developer_guide/api.md
@@ -16,7 +16,7 @@ Documentation of these classes are available at: https://apidocs.slicer.org/main
 Python-style documentation is available for the following packages:
 
 ```{toctree}
-:maxdepth: 4
+:maxdepth: 2
 
 mrml
 slicer

--- a/Docs/developer_guide/mrml.md
+++ b/Docs/developer_guide/mrml.md
@@ -1,4 +1,6 @@
-# mrml module
+# mrml
+
+This module corresponds to the Python wrapped ``MRML`` C++ classes.
 
 ```{eval-rst}
 .. automodule:: mrml

--- a/Docs/developer_guide/slicer.md
+++ b/Docs/developer_guide/slicer.md
@@ -1,0 +1,58 @@
+# slicer
+
+## slicer.cli
+
+```{eval-rst}
+.. automodule:: slicer.cli
+    :members:
+    :undoc-members:
+    :show-inheritance:
+```
+
+## slicer.logic
+
+```{eval-rst}
+.. automodule:: slicer.logic
+    :members:
+    :undoc-members:
+    :show-inheritance:
+```
+
+## slicer.ScriptedLoadableModule
+
+```{eval-rst}
+.. automodule:: slicer.ScriptedLoadableModule
+    :members:
+    :undoc-members:
+    :show-inheritance:
+```
+
+% Commented out for now, because it breaks documentation building on Windows
+% (Sphinx returns with an error code and nothing is generated)
+%
+% ## slicer.slicerqt
+%
+% ```{eval-rst}
+% .. automodule:: slicer.slicerqt
+%     :members:
+%     :undoc-members:
+%     :show-inheritance:
+% ```
+
+## slicer.testing
+
+```{eval-rst}
+.. automodule:: slicer.testing
+    :members:
+    :undoc-members:
+    :show-inheritance:
+```
+
+## slicer.util
+
+```{eval-rst}
+.. automodule:: slicer.util
+    :members:
+    :undoc-members:
+    :show-inheritance:
+```

--- a/Docs/developer_guide/vtk.md.dis
+++ b/Docs/developer_guide/vtk.md.dis
@@ -1,4 +1,6 @@
-# vtk module
+# vtk
+
+This module corresponds to the Python wrapped ``VTK`` C++ classes.
 
 ```{automodule} vtk
 :members:

--- a/Docs/developer_guide/vtkAddon.md
+++ b/Docs/developer_guide/vtkAddon.md
@@ -1,4 +1,6 @@
-# vtkAddon module
+# vtkAddon
+
+This module corresponds to the Python wrapped ``vtkAddon`` C++ classes.
 
 ```{eval-rst}
 .. automodule:: vtkAddonPython

--- a/Docs/developer_guide/vtkITK.md
+++ b/Docs/developer_guide/vtkITK.md
@@ -1,4 +1,6 @@
-# vtkITK module
+# vtkITK
+
+This module corresponds to the Python wrapped ``vtkITK`` C++ classes.
 
 ```{eval-rst}
 .. automodule:: vtkITK

--- a/Docs/developer_guide/vtkTeem.md
+++ b/Docs/developer_guide/vtkTeem.md
@@ -1,4 +1,6 @@
-# vtkTeem module
+# vtkTeem
+
+This module corresponds to the Python wrapped ``vtkTeem`` C++ classes.
 
 ```{eval-rst}
 .. automodule:: vtkTeemPython


### PR DESCRIPTION
Re-introduces the documentation of the slicer python packages originally added using ``automodule`` in b82b68f43 (ENH: Add automatically generated CLI module documentation) and removed in dc149534a (DOC: Add a few missing module documentation).

To avoid having a long list of documented functions listed on the main "api" documentation page, the `maxdepth` is changed from 4 to 2.

To ensure the documentation can be generated without having the "real" compiled python modules available, it set the `autodoc_mock_imports`[^1] setting.

The setting `autodoc_mock_imports` addresses warning like the following:

```
  WARNING: autodoc: failed to import module 'ScriptedLoadableModule' from module 'slicer'; the following exception was raised:
  No module named 'ctk'
```

[^1]: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports
