### PR TITLE
Add resourcepath helper to scripted module

### DIFF
--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -49,6 +49,12 @@ This work is partially supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colon
             slicer.selfTests = {}
         slicer.selfTests[self.moduleName] = self.runTest
 
+    def resourcePath(self, filename):
+        """Return the absolute path of the module ``Resources`` directory.
+        """
+        scriptedModulesPath = os.path.dirname(slicer.util.modulePath(self.moduleName))
+        return os.path.join(scriptedModulesPath, 'Resources', filename)
+
     def getDefaultModuleDocumentationLink(self, docPage=None):
         """Return string that can be inserted into the application help text that contains
         link to the module's documentation in current Slicer version's documentation.

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -105,6 +105,8 @@ class ScriptedLoadableModuleWidget:
             'moduleAboutToBeUnloaded(QString)', self._onModuleAboutToBeUnloaded)
 
     def resourcePath(self, filename):
+        """Return the absolute path of the module ``Resources`` directory.
+        """
         scriptedModulesPath = os.path.dirname(slicer.util.modulePath(self.moduleName))
         return os.path.join(scriptedModulesPath, 'Resources', filename)
 

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -1267,10 +1267,8 @@ def getModuleLogic(module):
 
 
 def modulePath(moduleName):
-    """Get module logic object.
+    """Return the path where the module was discovered and loaded from.
 
-    Module logic allows a module to use features offered by another module.
-    Throws a RuntimeError exception if the module does not have widget.
     :param moduleName: module name
     :return: file path of the module
     """


### PR DESCRIPTION
In addition of few docstring fixes, this pull request streamline referencing of resources during them module `setup()`, this function adds the function `resourcePath` to `ScriptedLoadableModule` similar to the one already available in `ScriptedLoadableModuleWidget`.