### PR TITLE
BUG: Fix mouse cursor not being changed for views not mapped in layout

### DIFF
--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -542,10 +542,11 @@ void qSlicerMouseModeToolBar::changeCursorTo(QCursor cursor)
   for (int i=0; i < layoutManager->threeDViewCount(); ++i)
     {
     qMRMLThreeDView* threeDView = layoutManager->threeDWidget(i)->threeDView();
-    if (!threeDView->mrmlViewNode()->IsMappedInLayout())
-      {
-      continue;
-      }
+
+    // The cursor should be updated in all views, not only ones that are in the current layout.
+    // If it is only updated for views that are mapped in the current layout, then the cursor will be incorrect
+    // if we switch to a layout with different views.
+
     // Update cursor only if view interaction node corresponds to the one associated with the mouse toolbar
     if (threeDView->mrmlViewNode()->GetInteractionNode() != this->interactionNode())
       {
@@ -559,10 +560,11 @@ void qSlicerMouseModeToolBar::changeCursorTo(QCursor cursor)
   foreach(const QString& viewerName, layoutManager->sliceViewNames())
     {
     qMRMLSliceView* sliceView = layoutManager->sliceWidget(viewerName)->sliceView();
-    if (!sliceView->mrmlSliceNode()->IsMappedInLayout())
-      {
-      continue;
-      }
+
+    // The cursor should be updated in all views, not only ones that are in the current layout.
+    // If it is only updated for views that are mapped in the current layout, then the cursor will be incorrect
+    // if we switch to a layout with different views.
+
     // Update cursor only if view interaction node corresponds to the one associated with the mouse toolbar
     if (sliceView->mrmlSliceNode()->GetInteractionNode() != this->interactionNode())
       {


### PR DESCRIPTION
When changing mouse modes, the cursor is not updated for views that are not mapped in the current layout. This causes an incorrect cursor to be displayed in views that are not part of the layout when the mouse mode is changed.

Example:
- Start in four-up layout
- Change to window/level mouse mode
- Maximize red slice view
- Change to view transform mouse mode
- Restore view layout
- Mouse cursor still shows window/level cursor in all views except the red slice == *Error*

Fixed by updating view cursors even when the view is not mapped in the current layout.