### PR TITLE
COMP: Fix Qt dependencies for application update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,7 +621,9 @@ endif()
       WebChannel
       )
   endif()
-  if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT)
+  # Both "extension manager" and "application update" require qRestApi external
+  # project itself depending on Qt's Script module
+  if(Slicer_BUILD_EXTENSIONMANAGER_SUPPORT OR Slicer_BUILD_APPLICATIONUPDATE_SUPPORT)
     list(APPEND Slicer_REQUIRED_QT_MODULES Script)
   endif()
   if(Slicer_BUILD_I18N_SUPPORT)


### PR DESCRIPTION
When building with Slicer_BUILD_APPLICATIONUPDATE_SUPPORT the commontk/qRestApi is used. The qRestApi depends on the Script module of Qt. This commit expresses that dependency and allows Slicer to be built with extension manager support off and application update support on.