### PR TITLE
ENH: Replace deprecated lookFromAxis usage

### DIFF
--- a/Libs/MRML/Widgets/qMRMLThreeDView.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.cxx
@@ -431,20 +431,6 @@ vtkMRMLViewNode* qMRMLThreeDView::mrmlViewNode()const
 }
 
 // --------------------------------------------------------------------------
-void qMRMLThreeDView::lookFromViewAxis(const ctkAxesWidget::Axis& axis)
-{
-  Q_D(qMRMLThreeDView);
-  if (!d->MRMLViewNode)
-    {
-    qCritical() << "qMRMLThreeDView::lookFromViewAxis: no valid view node.";
-    return;
-    }
-  double fov = d->MRMLViewNode->GetFieldOfView();
-  Q_ASSERT(fov >= 0.0);
-  this->lookFromAxis(axis, fov);
-}
-
-// --------------------------------------------------------------------------
 void qMRMLThreeDView::resetFocalPoint()
 {
   Q_D(qMRMLThreeDView);

--- a/Libs/MRML/Widgets/qMRMLThreeDView.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDView.h
@@ -107,8 +107,12 @@ public slots:
   /// Set the current \a viewNode to observe
   void setMRMLViewNode(vtkMRMLViewNode* newViewNode);
 
-  /// Look from a given axis, need a mrml view node to be set
-  void lookFromViewAxis(const ctkAxesWidget::Axis& axis);
+  /// \deprecated Use lookFromAxis instead.
+  void lookFromViewAxis(const ctkAxesWidget::Axis& axis)
+  {
+    qWarning("This function is deprecated. Use lookFromAxis(const ctkAxesWidget::Axis& axis) instead.");
+    this->lookFromAxis(axis);
+  };
 
   /// Reimplemented to hide items to not take into
   /// account when computing the boundaries

--- a/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDViewControllerWidget.cxx
@@ -615,7 +615,7 @@ void qMRMLThreeDViewControllerWidget::lookFromAxis(const ctkAxesWidget::Axis& ax
     }
 
   d->ViewLogic->StartCameraNodeInteraction(vtkMRMLCameraNode::LookFromAxis);
-  d->ThreeDView->lookFromViewAxis(axis);
+  d->ThreeDView->lookFromAxis(axis);
   d->ViewLogic->EndCameraNodeInteraction();
 }
 

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -937,7 +937,7 @@ space origin: %%origin%%
             axes = ['None', 'r', 'l', 's', 'i', 'a', 'p']
             try:
                 axis = axes.index(lookFromAxis[0].lower())
-                view.lookFromViewAxis(axis)
+                view.lookFromAxis(axis)
             except ValueError:
                 pass
 


### PR DESCRIPTION
This fixes the following warning which began to be displayed with the CTK update in https://github.com/Slicer/Slicer/commit/2e02a3581f25db91edd23a82a59cc91833512dcd

"This function is deprecated. Use lookFromAxis(const ctkAxesWidget::Axis& axis) instead"

The above deprecation can be seen when using latest Slicer preview and running
`slicer.app.layoutManager().threeDWidget(0).threeDController().lookFromAxis(ctk.ctkAxesWidget.Anterior)`.