### PR TITLE
ENH: Update VTK to allow setting vtkPoissonDiskSampler seed

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "97a187572d4000cd820f9fc887f21eaf0bde857c") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "5ae31a60d3f6047fce1ff2bc8311e6975ce07ec2") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of VTK changes:

```
$ git shortlog 97a187572..5ae31a60d --no-merges
Pranjal Sahu (1):
      [Backport MR-9653] Add seed for reproducible sampling in vtkPoissonDiskSampler
```

Corresponding VTK change can be reviewed using this link:
https://github.com/Kitware/VTK/compare/97a187572...Slicer:VTK:slicer-v9.1.20220125-efbe2afc2?expand=1