### PR TITLE
BUG: Update CTK to fix cursor position during auto-complete

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "95d735d1d77ad2c9aa0d16de50d2e7db2bf4f3eb"
+    "2c89539632e503e7cf9b7c53adccd8f1f71b2ead"
     QUIET
     )
 


### PR DESCRIPTION
List of CTK changes:

-----
commit commontk/CTK@2c89539632e503e7cf9b7c53adccd8f1f71b2ead
Author: Andras Lasso <lasso@queensu.ca>
Date:   Tue Nov 1 20:09:08 2022 -0400

BUG: Fix cursor position during auto-complete

When error messages were printed during auto-complete, the error messages got mixed up with the entered command.

Fixed by inserting text into the correct position (this->textCursor()  was called twice in ctkConsolePrivate::printString() and so the movePosition() call had no effect); also changed the code to use this->textCursor() consistently to get the cursor (sometimes the equivalent `QTextCursor c(this->document())` call was used)

Also fixed output printing: always print pending messages before displaying the prompt.

See https://github.com/Slicer/Slicer/issues/6630
-----