### PR TITLE
ENH: Replace deprecated markups API usage

### DIFF
--- a/Docs/developer_guide/script_repository/volumes.md
+++ b/Docs/developer_guide/script_repository/volumes.md
@@ -407,13 +407,13 @@ pointListNode = getNode("F")
 markupsIndex = 0
 
 # Get point coordinate in RAS
-point_Ras = [0, 0, 0, 1]
-pointListNode.GetNthFiducialWorldCoordinates(markupsIndex, point_Ras)
+point_Ras = [0, 0, 0]
+pointListNode.GetNthControlPointPositionWorld(markupsIndex, point_Ras)
 
 # If volume node is transformed, apply that transform to get volume's RAS coordinates
 transformRasToVolumeRas = vtk.vtkGeneralTransform()
 slicer.vtkMRMLTransformNode.GetTransformBetweenNodes(None, volumeNode.GetParentTransformNode(), transformRasToVolumeRas)
-point_VolumeRas = transformRasToVolumeRas.TransformPoint(point_Ras[0:3])
+point_VolumeRas = transformRasToVolumeRas.TransformPoint(point_Ras)
 
 # Get voxel coordinates from physical coordinates
 volumeRasToIjk = vtk.vtkMatrix4x4()

--- a/Modules/Scripted/Endoscopy/Endoscopy.py
+++ b/Modules/Scripted/Endoscopy/Endoscopy.py
@@ -402,17 +402,6 @@ class EndoscopyComputePath:
                 coord = [0.0, 0.0, 0.0]
                 self.fids.GetNthControlPointPositionWorld(i, coord)
                 self.p[i] = coord
-        else:
-            # slicer3 style fiducial lists
-            self.n = self.fids.GetNumberOfFiducials()
-            n = self.n
-            if n == 0:
-                return
-            # get control point data
-            # sets self.p
-            self.p = numpy.zeros((n, 3))
-            for i in range(n):
-                self.p[i] = self.fids.GetNthFiducialXYZ(i)
 
         # calculate the tangent vectors
         # - fm is forward difference

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -561,7 +561,7 @@ space origin: %%origin%%
                 markupsNode.GetNthControlPointPosition(markupIndex, position)
                 position
                 node['markups'].append({
-                    'label': markupsNode.GetNthFiducialLabel(markupIndex),
+                    'label': markupsNode.GetNthControlPointLabel(markupIndex),
                     'position': position
                 })
             fiducials[markupsNode.GetID()] = node


### PR DESCRIPTION
Some deprecated usage of Markups API is being fixed here. 

During this I found some leftover Slicer3 code that should've been removed in https://github.com/Slicer/Slicer/commit/22456c5fc21881b806ed517630c78762470a989c.