### PR TITLE
ENH: Make viewer font file configurable

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -511,6 +511,25 @@ void qSlicerCoreApplicationPrivate::init()
     qSlicerCoreApplication::loadLanguage();
     }
 
+  // Default VTK fonts do not support Chinese characters. Allow setting custom font files from application settings.
+  // Slicer core does not provide GUI to set these fonts yet, but extensions (e.g, LanguagePacks) can provide modules
+  // to edit these settings and/or set font files automatically based on the chosen language.
+  QString viewsFontFileSansSerif = q->userSettings()->value("Views/FontFile/SansSerif").toString();
+  QString viewsFontFileMonospaced = q->userSettings()->value("Views/FontFile/Monospaced").toString();
+  QString viewsFontFileSerif = q->userSettings()->value("Views/FontFile/Serif").toString();
+  if (!viewsFontFileSansSerif.isEmpty())
+    {
+    this->AppLogic->SetFontFileName(VTK_ARIAL, viewsFontFileSansSerif.toStdString());
+    }
+  if (!viewsFontFileMonospaced.isEmpty())
+    {
+    this->AppLogic->SetFontFileName(VTK_COURIER, viewsFontFileMonospaced.toStdString());
+    }
+  if (!viewsFontFileSerif.isEmpty())
+    {
+    this->AppLogic->SetFontFileName(VTK_TIMES, viewsFontFileSerif.toStdString());
+    }
+
   q->connect(q, SIGNAL(aboutToQuit()), q, SLOT(onAboutToQuit()));
 }
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidget.cxx
@@ -154,11 +154,16 @@ void vtkMRMLAbstractWidget::SetRepresentation(vtkMRMLAbstractWidgetRepresentatio
 
   this->WidgetRep = rep;
 
-  if (this->Renderer != nullptr && this->WidgetRep != nullptr)
+  if (this->WidgetRep)
     {
-    this->WidgetRep->SetRenderer(this->Renderer);
-    this->Renderer->AddViewProp(this->WidgetRep);
+    if (this->Renderer)
+      {
+      this->WidgetRep->SetRenderer(this->Renderer);
+      this->Renderer->AddViewProp(this->WidgetRep);
+      }
+    this->WidgetRep->SetApplicationLogic(this->ApplicationLogic);
     }
+
 }
 
 //-------------------------------------------------------------------------
@@ -434,6 +439,10 @@ const char* vtkMRMLAbstractWidget::GetAssociatedNodeID(vtkMRMLInteractionEventDa
 void vtkMRMLAbstractWidget::SetMRMLApplicationLogic(vtkMRMLApplicationLogic* applicationLogic)
 {
   this->ApplicationLogic = applicationLogic;
+  if (this->GetRepresentation())
+    {
+    this->GetRepresentation()->SetApplicationLogic(applicationLogic);
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.cxx
@@ -75,6 +75,23 @@ vtkRenderer* vtkMRMLAbstractWidgetRepresentation::GetRenderer()
 }
 
 //-----------------------------------------------------------------------------
+void vtkMRMLAbstractWidgetRepresentation::SetApplicationLogic(vtkMRMLApplicationLogic* appLogic)
+{
+  if (appLogic == this->ApplicationLogic)
+    {
+    return;
+    }
+  this->ApplicationLogic = appLogic;
+  this->Modified();
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLApplicationLogic* vtkMRMLAbstractWidgetRepresentation::GetApplicationLogic()
+{
+  return this->ApplicationLogic;
+}
+
+//-----------------------------------------------------------------------------
 void vtkMRMLAbstractWidgetRepresentation::SetViewNode(vtkMRMLAbstractViewNode* viewNode)
 {
   if (viewNode == this->ViewNode)

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
@@ -45,6 +45,7 @@
 #include "vtkWidgetRepresentation.h"
 
 #include "vtkMRMLAbstractViewNode.h"
+#include "vtkMRMLApplicationLogic.h"
 
 #include <vector>
 
@@ -92,6 +93,14 @@ public:
   */
   virtual void SetRenderer(vtkRenderer *ren);
   virtual vtkRenderer* GetRenderer();
+  //@}
+
+  //@{
+  /**
+  * Set the application logic. Used for retrieving custom font file, etc.
+  */
+  virtual void SetApplicationLogic(vtkMRMLApplicationLogic* appLogic);
+  virtual vtkMRMLApplicationLogic* GetApplicationLogic();
   //@}
 
   //@{
@@ -149,6 +158,8 @@ public:
 
   /// The renderer in which this widget is placed
   vtkWeakPointer<vtkRenderer> Renderer;
+
+  vtkWeakPointer<vtkMRMLApplicationLogic> ApplicationLogic;
 
   bool NeedToRender;
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLRulerDisplayableManager.cxx
@@ -22,6 +22,7 @@
 
 // MRML includes
 #include <vtkMRMLAbstractViewNode.h>
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLLogic.h>
 #include <vtkMRMLSliceNode.h>
 #include <vtkMRMLViewNode.h>
@@ -231,6 +232,10 @@ void vtkMRMLRulerDisplayableManager::vtkInternal::SetupRuler()
   vtkTextProperty* textProperty = this->RulerTextActor->GetTextProperty();
   textProperty->SetFontSize(RULER_BASE_FONT_SIZE);
   textProperty->SetFontFamilyToArial();
+  if (this->External->GetMRMLApplicationLogic())
+    {
+    this->External->GetMRMLApplicationLogic()->UseCustomFontFile(textProperty);
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.cxx
@@ -65,8 +65,6 @@
 #include "vtkSphereSource.h"
 #include "vtkTransform.h"
 #include "vtkTransformPolyDataFilter.h"
-#include "vtkTextMapper.h"
-#include "vtkTextProperty.h"
 #include "vtkTubeFilter.h"
 #include "vtkWindow.h"
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentationHelper.cxx
@@ -62,8 +62,6 @@
 #include "vtkSphereSource.h"
 #include "vtkTransform.h"
 #include "vtkTransformPolyDataFilter.h"
-#include "vtkTextMapper.h"
-#include "vtkTextProperty.h"
 #include "vtkTubeFilter.h"
 #include "vtkWindow.h"
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.cxx
@@ -35,7 +35,6 @@
 #include "vtkActor2D.h"
 #include "vtkObjectFactory.h"
 #include "vtkProperty2D.h"
-#include "vtkTextProperty.h"
 #include "vtkAssemblyPath.h"
 #include "vtkMath.h"
 #include "vtkInteractorObserver.h"
@@ -49,7 +48,6 @@
 #include "vtkCellArray.h"
 #include "vtkLeaderActor2D.h"
 #include "vtkTransform.h"
-#include "vtkTextMapper.h"
 #include "vtkActor2D.h"
 #include "vtkWindow.h"
 

--- a/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLApplicationLogic.h
@@ -37,6 +37,7 @@ class vtkMRMLStorageNode;
 class vtkMRMLInteractionNode;
 class vtkMRMLViewLogic;
 class vtkMRMLViewNode;
+class vtkTextProperty;
 
 // VTK includes
 class vtkCollection;
@@ -267,6 +268,25 @@ public:
 
   void SetIntersectingSlicesLineThicknessMode(int mode);
   int GetIntersectingSlicesLineThicknessMode();
+
+  /// @{
+  /// Set custom font file name for rendering views.
+  /// fontFamily can be VTK_ARIAL, VTK_COURIER, VTK_TIMES.
+  /// Font file must be in GetFontsDirectory().
+  void SetFontFileName(int fontFamily, const std::string& fontFileName);
+  std::string GetFontFileName(int fontFamily);
+  /// @}
+
+  /// Get full path to custom font file for rendering views from font file name.
+  std::string GetFontFilePath(const std::string& fontFileName);
+
+  /// Get folder where font files are stored ("Fonts" subfolder in application share folder).
+  std::string GetFontsDirectory();
+
+  /// Update text property to use custom font file.
+  /// Font family is set from arial/courier/times font family to custom fontfile.
+  /// Font file path is set to the one specified in FontFileName property in this object.
+  void UseCustomFontFile(vtkTextProperty* textProperty);
 
 protected:
 

--- a/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
+++ b/Modules/Loadable/Colors/MRMLDM/vtkMRMLColorLegendDisplayableManager.cxx
@@ -309,8 +309,21 @@ bool vtkMRMLColorLegendDisplayableManager::vtkInternal::UpdateActor(vtkMRMLColor
   std::string title = colorLegendDisplayNode->GetTitleText();
   actor->SetTitle(title.c_str());
 
-  actor->SetTitleTextProperty(colorLegendDisplayNode->GetTitleTextProperty());
-  actor->SetLabelTextProperty(colorLegendDisplayNode->GetLabelTextProperty());
+  vtkNew<vtkTextProperty> titleTextProperty;
+  titleTextProperty->ShallowCopy(colorLegendDisplayNode->GetTitleTextProperty());
+  if (this->External->GetMRMLApplicationLogic())
+    {
+    this->External->GetMRMLApplicationLogic()->UseCustomFontFile(titleTextProperty);
+    }
+  actor->SetTitleTextProperty(titleTextProperty);
+
+  vtkNew<vtkTextProperty> labelTextProperty;
+  labelTextProperty->ShallowCopy(colorLegendDisplayNode->GetLabelTextProperty());
+  if (this->External->GetMRMLApplicationLogic())
+    {
+    this->External->GetMRMLApplicationLogic()->UseCustomFontFile(labelTextProperty);
+    }
+  actor->SetLabelTextProperty(labelTextProperty);
 
   std::string format = colorLegendDisplayNode->GetLabelFormat();
   actor->SetLabelFormat(format.c_str());

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -437,6 +437,10 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateFromMRML(vtkMRMLNode* caller,
     controlPoints->Property->SetOpacity(opacity);
 
     controlPoints->TextProperty->ShallowCopy(this->MarkupsDisplayNode->GetTextProperty());
+    if (this->GetApplicationLogic())
+      {
+      this->GetApplicationLogic()->UseCustomFontFile(controlPoints->TextProperty);
+      }
     controlPoints->TextProperty->SetColor(color);
     controlPoints->TextProperty->SetOpacity(opacity);
     controlPoints->TextProperty->SetFontSize(static_cast<int>(this->MarkupsDisplayNode->GetTextProperty()->GetFontSize()

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -44,6 +44,7 @@
 #include "vtkTransformPolyDataFilter.h"
 
 // MRML includes
+#include <vtkMRMLApplicationLogic.h>
 #include <vtkMRMLFolderDisplayNode.h>
 #include <vtkMRMLInteractionEventData.h>
 #include <vtkMRMLViewNode.h>
@@ -713,6 +714,10 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller,
     controlPoints->Property->SetOpacity(opacity);
 
     controlPoints->TextProperty->ShallowCopy(this->MarkupsDisplayNode->GetTextProperty());
+    if (this->GetApplicationLogic())
+      {
+      this->GetApplicationLogic()->UseCustomFontFile(controlPoints->TextProperty);
+      }
     controlPoints->TextProperty->SetColor(color);
     controlPoints->TextProperty->SetOpacity(opacity);
     controlPoints->TextProperty->SetFontSize(static_cast<int>(this->MarkupsDisplayNode->GetTextProperty()->GetFontSize()

--- a/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
+++ b/Modules/Scripted/DataProbe/DataProbeLib/SliceViewAnnotations.py
@@ -358,6 +358,7 @@ class SliceAnnotations(VTKObservationMixin):
                 textProperty.SetFontFamilyToTimes()
             else:
                 textProperty.SetFontFamilyToArial()
+            slicer.app.applicationLogic().UseCustomFontFile(textProperty)
             # Text
             self.makeAnnotationText(sliceLogic)
         else:
@@ -604,8 +605,6 @@ class SliceAnnotations(VTKObservationMixin):
                         if (cornerText[key]['category'] == 'A'):
                             cornerAnnotation = cornerAnnotation + text + '\n'
             sliceCornerAnnotation = self.sliceViews[sliceViewName].cornerAnnotation()
-            # encode to avoid 'unicode conversion error' for patient names containing international characters
-            cornerAnnotation = cornerAnnotation
             sliceCornerAnnotation.SetText(i, cornerAnnotation)
             textProperty = sliceCornerAnnotation.GetTextProperty()
             textProperty.SetShadow(1)


### PR DESCRIPTION
VTK's default font file does not support Chinese characters. This commit allows setting a custom font file (such as Google's Noto font - https://fonts.google.com/noto/fonts?noto.continent=Asia&noto.region=CN&noto.script=Hant) in application settings. Since these font files are relatively large (about 5MB for each font family) and it is not clear yet which formats will work the best, the fonts are not yet bundled with the application but for now it will be installed by LanguagePacks extension.

![image](https://user-images.githubusercontent.com/307929/199639814-12ba0509-0b07-45e3-9e8a-ed90b0da0683.png)
