### PR TITLE
COMP: Update ITK to fix superbuild of extensions with ITK modules

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "69e52f05c482012b95228c3fe46f299b1735ca99" # slicer-v5.3rc04-2022-09-19-62eb5ca
+    "be914a8b57b581735f2655098431dab61ded01c5" # slicer-v5.3rc04-2022-09-19-62eb5ca
     QUIET
     )
 


### PR DESCRIPTION
This commit fixes a regression introduced in InsightSoftwareConsortium/ITK@5b09d5466 (COMP: Allow install lib directory name changes) through 4d1c98ef8 (COMP: Update ITK to post-v5.3rc04 version and SimpleITK to post-v2.2.0).

It backports the changes introduced in upstream ITK through https://github.com/InsightSoftwareConsortium/ITK/pull/3722

List of ITK changes:

```
$ git shortlog 69e52f05c4..be914a8b57 --no-merges
Jean-Christophe Fillion-Robin (1):
      [Backport PR-3722] COMP: Ensure client project can find externally build ITK module
```

### Related issues and pull requests
* https://github.com/Slicer/Slicer/issues/6587
* https://github.com/Slicer/Slicer/pull/6454
* https://github.com/InsightSoftwareConsortium/ITK/pull/3722