### PR TITLE
ENH: Add ability to quickly open to log file location

### DIFF
--- a/Base/QTApp/Resources/UI/qSlicerErrorReportDialog.ui
+++ b/Base/QTApp/Resources/UI/qSlicerErrorReportDialog.ui
@@ -70,7 +70,7 @@
      <item>
       <widget class="ctkPushButton" name="LogCopyToClipboardPushButton">
        <property name="text">
-        <string>Copy log messages to clipboard</string>
+        <string>Copy log to clipboard</string>
        </property>
        <property name="autoDefault">
         <bool>false</bool>
@@ -80,7 +80,17 @@
      <item>
       <widget class="ctkPushButton" name="LogFileOpenPushButton">
        <property name="text">
-        <string>Open log file in editor</string>
+        <string>Open log in editor</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ctkPushButton" name="LogOpenFileLocationPushButton">
+       <property name="text">
+        <string>Open log location</string>
        </property>
        <property name="autoDefault">
         <bool>false</bool>

--- a/Base/QTApp/qSlicerErrorReportDialog.cxx
+++ b/Base/QTApp/qSlicerErrorReportDialog.cxx
@@ -24,6 +24,7 @@
 #include <QFile>
 #include <QTextStream>
 #include <QUrl>
+#include <QFileInfo>
 
 // SlicerApp includes
 #include "qSlicerErrorReportDialog.h"
@@ -67,6 +68,7 @@ qSlicerErrorReportDialog::qSlicerErrorReportDialog(QWidget* parentWidget)
   //QObject::connect(d->RecentLogFilesComboBox, SIGNAL(currentTextChanged(QString)), this, SLOT(onLogFileSelectionChanged()));
   QObject::connect(d->RecentLogFilesComboBox, SIGNAL(currentPathChanged(QString,QString)), this, SLOT(onLogFileSelectionChanged()));
   QObject::connect(d->LogCopyToClipboardPushButton, SIGNAL(clicked()), this, SLOT(onLogCopy()));
+  QObject::connect(d->LogOpenFileLocationPushButton, SIGNAL(clicked()), this, SLOT(onLogFileLocationOpen()));
   QObject::connect(d->LogFileOpenPushButton, SIGNAL(clicked()), this, SLOT(onLogFileOpen()));
   QObject::connect(d->LogFileEditCheckBox, SIGNAL(clicked(bool)), this, SLOT(onLogFileEditClicked(bool)));
 
@@ -101,6 +103,14 @@ void qSlicerErrorReportDialog::onLogFileSelectionChanged()
     {
     d->LogText->clear();
     }
+}
+
+// --------------------------------------------------------------------------
+void qSlicerErrorReportDialog::onLogFileLocationOpen()
+{
+  Q_D(qSlicerErrorReportDialog);
+  QFileInfo fileInfo(d->RecentLogFilesComboBox->currentPath());
+  QDesktopServices::openUrl(QUrl(fileInfo.absolutePath(), QUrl::TolerantMode));
 }
 
 // --------------------------------------------------------------------------

--- a/Base/QTApp/qSlicerErrorReportDialog.h
+++ b/Base/QTApp/qSlicerErrorReportDialog.h
@@ -43,6 +43,7 @@ public:
 
 protected slots:
   void onLogFileOpen();
+  void onLogFileLocationOpen();
   void onLogCopy();
   void onLogFileSelectionChanged();
   void onLogFileEditClicked(bool editable);


### PR DESCRIPTION
## Motivation and Changes
The main motivation behind this is that adding the ability to open file log locations makes it far easier for slicer users to send entire log files to the developers that make various slicer apps/extensions/modules. This PR updates the 'report a bug' dialog by replacing the `Copy log message to clipboard` button with a `Open log file location` button. I could have opted to add another button, however for the sake of space I decided to simply replace the former button. 

### Before this PR
![image](https://user-images.githubusercontent.com/105175523/200044928-ba054f92-295f-45fb-8341-c80d7ddd8d75.png)

### After this PR
![image](https://user-images.githubusercontent.com/105175523/200046059-3815458f-396c-427a-b2fc-75955dcb84f2.png)

