### PR TITLE
ENH: Regularize acquisition geometry by default for DICOM image loading

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMUtils.py
+++ b/Modules/Scripted/DICOMLib/DICOMUtils.py
@@ -664,7 +664,7 @@ def getSortedImageFiles(filePaths, epsilon=0.01):
 
     # Get acquisition geometry regularization setting value
     settings = qt.QSettings()
-    acquisitionGeometryRegularizationEnabled = (settings.value("DICOM/ScalarVolume/AcquisitionGeometryRegularization", "default") == "transform")
+    acquisitionGeometryRegularizationEnabled = (settings.value("DICOM/ScalarVolume/AcquisitionGeometryRegularization", "default") != "none")
 
     # Confirm equal spacing between slices
     # - use variable 'epsilon' to determine the tolerance

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -85,10 +85,12 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
         importFormatsComboBox.toolTip = ("Enable adding non-linear transform to regularize images acquired irregular geometry:"
                                          " non-rectilinear grid (such as tilted gantry CT acquisitions) and non-uniform slice spacing."
                                          " If no regularization is applied then image may appear distorted if it was acquired with irregular geometry.")
-        importFormatsComboBox.addItem("default (none)", "default")
+
+        importFormatsComboBox.addItem("default (apply regularization transform)", "default")
         importFormatsComboBox.addItem("none", "none")
         importFormatsComboBox.addItem("apply regularization transform", "transform")
-        # in the future additional option, such as "resample" may be added
+        # In the future additional option, such as "resample" (harden the applied transform) may be added.
+
         importFormatsComboBox.currentIndex = 0
         formLayout.addRow("Acquisition geometry regularization:", importFormatsComboBox)
         panel.registerProperty(
@@ -131,7 +133,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
 
     def acquisitionGeometryRegularizationEnabled(self):
         settings = qt.QSettings()
-        return (settings.value("DICOM/ScalarVolume/AcquisitionGeometryRegularization", "default") == "transform")
+        return (settings.value("DICOM/ScalarVolume/AcquisitionGeometryRegularization", "default") != "none")
 
     def allowLoadingByTime(self):
         settings = qt.QSettings()


### PR DESCRIPTION
Image acquisition geometry regularization has proven to work well over the past several years (it allows loading unusual image geometries correctly and does not seem to result in extra complications), therefore it makes sense to enable it by default.

See the most recent related discussion at https://discourse.slicer.org/t/distorted-malaligned-volumes-after-loading-dicom-sets/26088/8

It is probably safe to include this in Slicer-5.2 stable, but waiting until Slicer-5.3 preview should not be a problem either (then we could integrate it along with a fix for https://github.com/Slicer/Slicer/issues/6648).