### PR TITLE
BUG: CopyContent should call Modified

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScriptedModuleNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScriptedModuleNode.cxx
@@ -109,7 +109,11 @@ void vtkMRMLScriptedModuleNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=
     }
 
   this->SetModuleName(node->GetModuleName());
-  this->Parameters = node->Parameters;
+  if (this->Parameters != node->Parameters)
+    {
+    this->Parameters = node->Parameters;
+    this->Modified();
+    }
 }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
vtkMRMLScriptedModuleNode copies parameters from the other node not through the SetParameter function, so it needs to properly call Modified if anything changes.