### PR TITLE
BUG: Fix fixedNumberOfControlPoints property value in exported markup nodes

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialNode.cxx
@@ -73,13 +73,7 @@ void vtkMRMLMarkupsFiducialNode::ReadXMLAttributes(const char** atts)
 //----------------------------------------------------------------------------
 void vtkMRMLMarkupsFiducialNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
 {
-  MRMLNodeModifyBlocker blocker(this);
   Superclass::CopyContent(anode, deepCopy);
-
-  vtkMRMLCopyBeginMacro(anode);
-  vtkMRMLCopyIntMacro(MaximumNumberOfControlPoints);
-  vtkMRMLCopyIntMacro(RequiredNumberOfControlPoints);
-  vtkMRMLCopyEndMacro();
 }
 
 //----------------------------------------------------------------------------
@@ -87,7 +81,6 @@ void vtkMRMLMarkupsFiducialNode::PrintSelf(ostream& os, vtkIndent indent)
 {
   Superclass::PrintSelf(os,indent);
 }
-
 
 //-------------------------------------------------------------------------
 void vtkMRMLMarkupsFiducialNode::CreateDefaultDisplayNodes()

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -562,6 +562,9 @@ bool vtkMRMLMarkupsJsonStorageNode::vtkInternal::UpdateMarkupsNodeFromJsonValue(
 
   MRMLNodeModifyBlocker blocker(markupsNode);
 
+  // Need to disable control point lock (the actual value will be set in the end of the method)
+  markupsNode->SetFixedNumberOfControlPoints(false);
+
   // clear out the list
   markupsNode->RemoveAllControlPoints();
 
@@ -668,6 +671,7 @@ bool vtkMRMLMarkupsJsonStorageNode::vtkInternal::UpdateMarkupsNodeFromJsonValue(
       }
     }
 
+  // SetFixedNumberOfControlPoints() must be called after control points are already set
   if (markupObject.HasMember("fixedNumberOfControlPoints"))
     {
     markupsNode->SetFixedNumberOfControlPoints(markupObject["fixedNumberOfControlPoints"].GetBool());

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsNode.h
@@ -632,7 +632,7 @@ public:
   vtkGetMacro(RequiredNumberOfControlPoints, int);
 
   /// Maximum number of control points limits the number of markups allowed in the node.
-  /// If maximum number of control points is set to 0 then no it means there
+  /// If maximum number of control points is set to -1 then no it means there
   /// is no limit (this is the default value).
   /// The value is an indication to the user interface and does not affect
   /// prevent adding markups to a node programmatically.

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -1566,12 +1566,18 @@ void qSlicerMarkupsModuleWidget::onAddControlPointPushButtonClicked()
     {
     return;
     }
-  // get the active node
-  if ((d->MarkupsNode->GetNumberOfControlPoints() >= d->MarkupsNode->GetMaximumNumberOfControlPoints()) &&
-       d->MarkupsNode->GetMaximumNumberOfControlPoints() >= 0)
+
+  if (d->MarkupsNode->GetFixedNumberOfControlPoints())
     {
     return;
     }
+
+  if (d->MarkupsNode->GetMaximumNumberOfControlPoints() >= 0
+    && (d->MarkupsNode->GetNumberOfControlPoints() >= d->MarkupsNode->GetMaximumNumberOfControlPoints()) )
+    {
+    return;
+    }
+
   int index = d->MarkupsNode->AddControlPoint(vtkVector3d(0,0,0));
   d->MarkupsNode->UnsetNthControlPointPosition(index);
   d->setPlaceModeEnabled(false);


### PR DESCRIPTION
The FixedNumberOfControlPoints flag was not copied and at node export a copy of the node is exported.

Also made FixedNumberOfControlPoints and MaximumNumberOfControlPoints properties completely independent. Modifying MaximumNumberOfControlPoints when FixedNumberOfControlPoints flag was changed was unnecessary and had very complicated side effects.

Fixes error reported at https://discourse.slicer.org/t/export-file-as-bug-for-markup-control-points/26188