### PR TITLE
BUG: Fix PerformanceTests removing invalid reference to web tests

### DIFF
--- a/Modules/Scripted/PerformanceTests/PerformanceTests.py
+++ b/Modules/Scripted/PerformanceTests/PerformanceTests.py
@@ -35,8 +35,6 @@ class PerformanceTestsWidget(ScriptedLoadableModuleWidget):
             ('Get Sample Data', self.downloadMRHead),
             ('Reslicing', self.reslicing),
             ('Crosshair Jump', self.crosshairJump),
-            ('Web View Test', self.webViewTest),
-            ('Fill Out Web Form Test', self.webViewFormTest),
             ('Memory Check', self.memoryCheck),
         )
 


### PR DESCRIPTION
This commit fixes a regression introduced in 96ad8dfc0b (BUG: Update PerformanceTests module removing obsolete "webview" test cases)

Error fixed:

```
test_widgetRepresentation (qSlicerPerformanceTestsModuleGenericTest.qSlicerPerformanceTestsModuleGenericTest) ... Traceback (most recent call last):
  File "/work/Preview/Slicer-0-build/Slicer-build/lib/Slicer-5.1/qt-scripted-modules/PerformanceTests.py", line 38, in setup
    ('Web View Test', self.webViewTest),
AttributeError: 'PerformanceTestsWidget' object has no attribute 'webViewTest'
ok
```

See https://slicer.cdash.org/test/23424820