### PR TITLE
ENH: Support disconnecting markups toolbar from mouse mode toolbar

### DIFF
--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -169,6 +169,8 @@ void qSlicerMouseModeToolBarPrivate::init()
 
   connect(this->PlaceWidgetAction, SIGNAL(triggered()), q, SLOT(switchPlaceMode()));
   this->InteractionModesActionGroup->addAction(this->PlaceWidgetAction);
+  this->PlaceWidgetAction->setVisible(false);
+  q->addAction(this->PlaceWidgetAction);
 
 }
 
@@ -327,16 +329,16 @@ void qSlicerMouseModeToolBarPrivate::updatePlaceWidget()
   bool validNodeForPlacement = selectionNode->GetActivePlaceNodePlacementValid();
   if (!validNodeForPlacement || activePlaceNodeClassName.isEmpty())
     {
-    q->removeAction(this->PlaceWidgetAction);
-    q->addAction(this->ToolBarAction);
+    this->PlaceWidgetAction->setVisible(false);
+    this->ToolBarAction->setVisible(true);
     return;
     }
 
   QString activePlaceNodeID = selectionNode->GetActivePlaceNodeID();
   if (activePlaceNodeID.isEmpty())
     {
-    q->removeAction(this->PlaceWidgetAction);
-    q->addAction(this->ToolBarAction);
+    this->PlaceWidgetAction->setVisible(false);
+    this->ToolBarAction->setVisible(true);
     return;
     }
 
@@ -352,7 +354,7 @@ void qSlicerMouseModeToolBarPrivate::updatePlaceWidget()
       break;
       }
     }
-  q->removeAction(this->ToolBarAction);
+  this->ToolBarAction->setVisible(false);
 
   QIcon icon(placeNodeResource);
   if (icon.availableSizes().empty())
@@ -367,7 +369,7 @@ void qSlicerMouseModeToolBarPrivate::updatePlaceWidget()
   this->PlaceWidgetAction->setCheckable(true);
 
   connect(this->PlaceWidgetAction, SIGNAL(triggered()), q, SLOT(switchPlaceMode()));
-  q->addAction(this->PlaceWidgetAction);
+  this->PlaceWidgetAction->setVisible(true);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This change allows for calling to removeAction(ToolBarAction) to remove the markups toolbar connection and have it remain disconnected. Previously it would always add the action back, overwriting the customization. Now the action is always in the set of mouse mode actions, but selectively shown/hidden

This doesn't introduce a change in functionality of how things are currently. It changes from removing/adding actions to showing/hiding actions in the Mouse mode toolbar. In the case of my custom app where we don't use the markups toolbar (reducing functionality on purpose), this PR allows for me to remove the toggle markups toolbar action from the Mouse Mode toolbar and have the place widget action still show/hide, but not reshow the toggle markups button in my custom app.