### PR TITLE
BUG: Ensure ScriptedLoadableModule.resourcePath() works in __init__()

### DIFF
--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleA.py
@@ -1,3 +1,5 @@
+import os
+
 from slicer.ScriptedLoadableModule import *
 
 SOMEVAR = 'A'
@@ -15,6 +17,7 @@ class ModuleA(ScriptedLoadableModule):
     Developed by Jean-Christophe Fillion-Robin, Kitware Inc.,
     partially funded by NIH grant 3P41RR013218-12S1.
     """
+        assert os.path.exists(self.resourcePath("resource.txt"))
 
     def somevar(self):
         return SOMEVAR
@@ -23,6 +26,7 @@ class ModuleA(ScriptedLoadableModule):
 class ModuleAWidget(ScriptedLoadableModuleWidget):
     def __init__(self, parent=None):
         ScriptedLoadableModuleWidget.__init__(self, parent)
+        assert os.path.exists(self.resourcePath("resource.txt"))
 
     def setup(self):
         ScriptedLoadableModuleWidget.setup(self)

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/Resources/resource.txt
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/Resources/resource.txt
@@ -1,0 +1,1 @@
+Content of resource.txt

--- a/Base/Python/slicer/ScriptedLoadableModule.py
+++ b/Base/Python/slicer/ScriptedLoadableModule.py
@@ -52,7 +52,7 @@ This work is partially supported by PAR-07-249: R01CA131718 NA-MIC Virtual Colon
     def resourcePath(self, filename):
         """Return the absolute path of the module ``Resources`` directory.
         """
-        scriptedModulesPath = os.path.dirname(slicer.util.modulePath(self.moduleName))
+        scriptedModulesPath = os.path.dirname(self.parent.path)
         return os.path.join(scriptedModulesPath, 'Resources', filename)
 
     def getDefaultModuleDocumentationLink(self, docPage=None):


### PR DESCRIPTION
This commit is a follow-up of 3c1b69de4 (ENH: Add convenient ScriptedLoadableModule.resourcePath() function)

It ensures the function can be called from the module constructor. Prior to this commit it was failing because the `slicer.modules` was updated only after the module was fully instantiated and after it was loaded (see function `setSlicerModules` in `slicerqt.py`).
