### PR TITLE
ENH: Make all text in built-in CLI modules translatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ tags
 # Documentation
 Docs/_build
 Docs/_moduledescriptions
+
+# CLI module translation files
+Docs/_extraCLI/*_tr.h
+Modules/CLI/*/*_tr.h

--- a/Base/QTCLI/qSlicerCLIModule.h
+++ b/Base/QTCLI/qSlicerCLIModule.h
@@ -100,6 +100,9 @@ public:
   /// the module properties.
   ModuleDescription& moduleDescription();
 
+  /// Translate string from source language to current application language
+  QString translate(const std::string& sourceText)const;
+
 protected:
   ///
   void setup() override;

--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -314,7 +314,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createIntegerTagWidget(const ModulePar
   int min = std::numeric_limits<int>::min() / 100;
   int max = std::numeric_limits<int>::max() / 100;
   bool withConstraints = !QString::fromStdString(moduleParameter.GetConstraints()).isEmpty();
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
 
   QWidget * widget = nullptr;
@@ -361,7 +361,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createBooleanTagWidget(const ModulePar
 
   QString valueAsStr = QString::fromStdString(moduleParameter.GetValue());
   QCheckBox * widget = new QCheckBox;
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   widget->setChecked(valueAsStr == "true");
   INSTANCIATE_WIDGET_VALUE_WRAPPER(Boolean, _name, _label, widget);
@@ -385,7 +385,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createFloatTagWidget(const ModuleParam
   float min = -std::numeric_limits<float>::max() / 100;
   float max = std::numeric_limits<float>::max() / 100;
   bool withConstraints = !QString::fromStdString(moduleParameter.GetConstraints()).isEmpty();
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   int decimals = valueAsStr.indexOf('.') != -1 ? valueAsStr.length() - valueAsStr.indexOf('.') -1 : 2;
 
@@ -465,7 +465,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createDoubleTagWidget(const ModulePara
   double min = -std::numeric_limits<double>::max() / 100;
   double max = std::numeric_limits<double>::max() / 100;
   bool withConstraints = !QString::fromStdString(moduleParameter.GetConstraints()).isEmpty();
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   int decimals = valueAsStr.indexOf('.') != -1 ? valueAsStr.length() - valueAsStr.indexOf('.') -1 : 2;
 
@@ -532,7 +532,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createStringTagWidget(const ModulePara
 {
   QString valueAsStr = QString::fromStdString(moduleParameter.GetValue());
   QLineEdit * widget = new QLineEdit;
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   widget->setText(valueAsStr);
   if (isOutputChannel(moduleParameter))
@@ -546,7 +546,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createStringTagWidget(const ModulePara
 //-----------------------------------------------------------------------------
 QWidget* qSlicerCLIModuleUIHelperPrivate::createPointTagWidget(const ModuleParameter& moduleParameter)
 {
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   qMRMLNodeComboBox* widget = new qMRMLNodeComboBox;
   QStringList nodeTypes;
@@ -574,7 +574,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createPointTagWidget(const ModuleParam
 //-----------------------------------------------------------------------------
 QWidget* qSlicerCLIModuleUIHelperPrivate::createPointFileTagWidget(const ModuleParameter& moduleParameter)
 {
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   qMRMLNodeComboBox* widget = new qMRMLNodeComboBox;
 
@@ -627,7 +627,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createPointFileTagWidget(const ModuleP
 //-----------------------------------------------------------------------------
 QWidget* qSlicerCLIModuleUIHelperPrivate::createRegionTagWidget(const ModuleParameter& moduleParameter)
 {
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   qMRMLNodeComboBox* widget = new qMRMLNodeComboBox;
   QStringList nodeTypes;
@@ -711,7 +711,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createImageTagWidget(const ModuleParam
 
   // TODO - title + " Volume"
 
-  QString imageLabel = QString::fromStdString(moduleParameter.GetLabel());
+  QString imageLabel = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString imageName = QString::fromStdString(moduleParameter.GetName());
 
   // If "type" is specified, only display nodes of type nodeType
@@ -765,7 +765,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createGeometryTagWidget(const ModulePa
 
   // TODO - title + " Model"
 
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   qMRMLNodeComboBox * widget = new qMRMLNodeComboBox;
   widget->setShowHidden(false);
@@ -803,7 +803,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createTableTagWidget(const ModuleParam
 
   // TODO - title + " Table"
 
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   qMRMLNodeComboBox * widget = new qMRMLNodeComboBox;
   widget->setNodeTypes(QStringList(nodeType));
@@ -840,7 +840,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createMeasurementTagWidget(const Modul
 
   // TODO - title + " Measurement"
 
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   qMRMLNodeComboBox * widget = new qMRMLNodeComboBox;
   widget->setNodeTypes(QStringList(nodeType));
@@ -874,7 +874,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createTransformTagWidget(const ModuleP
       type, defaultNodeType);
   // TODO - title + " Transform"
 
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   qMRMLNodeComboBox * widget = new qMRMLNodeComboBox;
   widget->setNoneEnabled(this->isNoneEnabled(moduleParameter));
@@ -908,7 +908,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createTransformTagWidget(const ModuleP
 //-----------------------------------------------------------------------------
 QWidget* qSlicerCLIModuleUIHelperPrivate::createDirectoryTagWidget(const ModuleParameter& moduleParameter)
 {
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
 
   ctkDirectoryButton* widget = new ctkDirectoryButton();
@@ -923,7 +923,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createDirectoryTagWidget(const ModuleP
 //-----------------------------------------------------------------------------
 QWidget* qSlicerCLIModuleUIHelperPrivate::createFileTagWidget(const ModuleParameter& moduleParameter)
 {
-  QString label = QString::fromStdString(moduleParameter.GetLabel());
+  QString label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString name = QString::fromStdString(moduleParameter.GetName());
 
   QStringList fileExtensions;
@@ -978,7 +978,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createEnumerationTagWidget(const Modul
   ElementConstIterator sBeginIt = moduleParameter.GetElements().begin();
   ElementConstIterator sEndIt = moduleParameter.GetElements().end();
 
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
+  QString _label = this->CLIModuleWidget->translate(moduleParameter.GetLabel());
   QString _name = QString::fromStdString(moduleParameter.GetName());
   ButtonGroupWidgetWrapper * widget = new ButtonGroupWidgetWrapper;
   ctkFlowLayout * _layout = new ctkFlowLayout(widget);
@@ -987,7 +987,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createEnumerationTagWidget(const Modul
   for (ElementConstIterator sIt = sBeginIt; sIt != sEndIt; ++sIt)
     {
     QString value = QString::fromStdString(*sIt);
-    QRadioButton * radio = new QRadioButton(value, widget);
+    QRadioButton * radio = new QRadioButton(this->CLIModuleWidget->translate(value.toStdString()), widget);
     _layout->addWidget(radio);
     radio->setChecked(defaultValue == value);
     // enumValue may differ from displayed text when the application is
@@ -1123,7 +1123,7 @@ QWidget* qSlicerCLIModuleUIHelper::createTagWidget(const ModuleParameter& module
 
   if (widget)
     {
-    QString description = QString::fromStdString(moduleParameter.GetDescription());
+    QString description = d->CLIModuleWidget->translate(moduleParameter.GetDescription());
     widget->setToolTip(description);
     QString widgetName = QString::fromStdString(moduleParameter.GetName());
     widget->setObjectName(widgetName);

--- a/Base/QTCLI/qSlicerCLIModuleWidget.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleWidget.cxx
@@ -20,6 +20,7 @@
 
 // Qt includes
 #include <QAction>
+#include <QCoreApplication>
 #include <QDebug>
 #include <QFormLayout>
 #include <QMenu>
@@ -77,15 +78,17 @@ void qSlicerCLIModuleWidgetPrivate::setupUi(qSlicerWidget* widget)
 
   this->Ui_qSlicerCLIModuleWidget::setupUi(widget);
 
-  QString title = QString::fromStdString(
+  QString title = q->translate(
     this->logic()->GetDefaultModuleDescription().GetTitle());
   this->ModuleCollapsibleButton->setText(title);
 
   this->MRMLCommandLineModuleNodeSelector->setBaseName(title);
-  /// Use the title of the CLI to filter all the command line module node
+  /// Use the non-translated title of the CLI to filter all the command line module node
   /// It is not very robust but there shouldn't be twice the same title.
+  QString sourceLanguageTitle = QString(
+    this->logic()->GetDefaultModuleDescription().GetTitle().c_str());
   this->MRMLCommandLineModuleNodeSelector->addAttribute(
-    "vtkMRMLCommandLineModuleNode", "CommandLineModule", title);
+    "vtkMRMLCommandLineModuleNode", "CommandLineModule", sourceLanguageTitle);
 
   this->MRMLCommandLineModuleNodeSelector->setNodeTypeLabel("Parameter set", "vtkMRMLCommandLineModuleNode");
 
@@ -255,10 +258,11 @@ void qSlicerCLIModuleWidgetPrivate::addParameterGroups()
 void qSlicerCLIModuleWidgetPrivate::addParameterGroup(QBoxLayout* _layout,
                                                      const ModuleParameterGroup& parameterGroup)
 {
+  Q_Q(qSlicerCLIModuleWidget);
   Q_ASSERT(_layout);
 
   ctkCollapsibleButton * collapsibleWidget = new ctkCollapsibleButton();
-  collapsibleWidget->setText(QString::fromStdString(parameterGroup.GetLabel()));
+  collapsibleWidget->setText(q->translate(parameterGroup.GetLabel()));
   collapsibleWidget->setCollapsed(parameterGroup.GetAdvanced() == "true");
 
   // Create a vertical layout and add parameter to it
@@ -290,6 +294,7 @@ void qSlicerCLIModuleWidgetPrivate::addParameters(QFormLayout* _layout,
 void qSlicerCLIModuleWidgetPrivate::addParameter(QFormLayout* _layout,
                                                const ModuleParameter& moduleParameter)
 {
+  Q_Q(qSlicerCLIModuleWidget);
   Q_ASSERT(_layout);
 
   if (moduleParameter.GetHidden() == "true")
@@ -297,8 +302,8 @@ void qSlicerCLIModuleWidgetPrivate::addParameter(QFormLayout* _layout,
     return;
     }
 
-  QString _label = QString::fromStdString(moduleParameter.GetLabel());
-  QString description = QString::fromStdString(moduleParameter.GetDescription());
+  QString _label = q->translate(moduleParameter.GetLabel());
+  QString description = q->translate(moduleParameter.GetDescription());
 
   // TODO Parameters with flags can support the None node because they are optional
   //int noneEnabled = 0;
@@ -609,4 +614,11 @@ double qSlicerCLIModuleWidget::nodeEditable(vtkMRMLNode* node)
     {
     return 0.0;
     }
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCLIModuleWidget::translate(const std::string& sourceText)const
+{
+  QString contextName = QStringLiteral("CLI_") + this->moduleName();
+  return QCoreApplication::translate(contextName.toStdString().c_str(), sourceText.c_str());
 }

--- a/Base/QTCLI/qSlicerCLIModuleWidget.h
+++ b/Base/QTCLI/qSlicerCLIModuleWidget.h
@@ -52,6 +52,9 @@ public:
   bool setEditedNode(vtkMRMLNode* node, QString role = QString(), QString context = QString()) override;
   double nodeEditable(vtkMRMLNode* node) override;
 
+  /// Translate string from source language to current application language
+  QString translate(const std::string& sourceText)const;
+
 public slots:
   /// Set the current \a commandLineModuleNode
   void setCurrentCommandLineModuleNode(vtkMRMLNode* commandLineModuleNode);

--- a/Docs/_extracli/DWIConvert.xml
+++ b/Docs/_extracli/DWIConvert.xml
@@ -161,7 +161,7 @@
       <longflag>allowLossyConversion</longflag>
       <label>Allow lossy image conversion</label>
       <default>false</default>
-      <description><![CDATA[The only supported output type is 'short'. Conversion from images of a different type may cause data loss due to rounding or truncation. Use with caution!"]]></description>
+      <description><![CDATA[The only supported output type is 'short'. Conversion from images of a different type may cause data loss due to rounding or truncation. Use with caution!]]></description>
     </boolean>
   </parameters>
   <parameters advanced="true">

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -324,6 +324,9 @@ void vtkMRMLCommandLineModuleNode::SetModuleDescription(const ModuleDescription&
 
   // Set an attribute on the node so that we can select nodes that
   // have the same command line module (program)
+  // The title is intentionally not translated, to allow using the scene regardless of the chosen
+  // application GUI language. It would be more appropriate to use the module name, but we
+  // use the module title for compatibility with existing scenes.
   this->SetAttribute("CommandLineModule", description.GetTitle().c_str());
 
   this->Modified();

--- a/Utilities/Scripts/update_translations.py
+++ b/Utilities/Scripts/update_translations.py
@@ -50,8 +50,11 @@ def _generate_translation_header_from_cli_xml(cli_xml_filename):
 
     def to_translation_header(translation_context, text):
         """Takes a single or a list of strings or XML elements and creates a line for each item
-        that can be placed in the .h file that lupdate will parse for translations. Example line:
-        `QT_TRANSLATE_NOOP("CLI_ACPCTransform", "ACPC Transform")`
+        that can be placed in the .h file that lupdate will parse for translations.
+
+        Example line::
+     
+            QT_TRANSLATE_NOOP("CLI_ACPCTransform", "ACPC Transform")
         """
         if type(text) != list:
             text_list = [text]

--- a/Utilities/Scripts/update_translations.py
+++ b/Utilities/Scripts/update_translations.py
@@ -45,6 +45,94 @@ def update_translations(source_code_dir, translations_dir, lupdate_path, languag
         shutil.move(ts_file_path_in_source_tree, ts_file_path)
 
 
+def _generate_translation_header_from_cli_xml(cli_xml_filename):
+    logging.debug(f"Generating header file for Qt translation from {cli_xml_filename}")
+
+    def to_translation_header(translation_context, text):
+        """Takes a single or a list of strings or XML elements and creates a line for each item
+        that can be placed in the .h file that lupdate will parse for translations. Example line:
+        `QT_TRANSLATE_NOOP("CLI_ACPCTransform", "ACPC Transform")`
+        """
+        if type(text) != list:
+            text_list = [text]
+        else:
+            text_list = text
+        result = ""
+        for text_item in text_list:
+            if text_item is None:
+                continue
+            try:
+                element_text = text_item.text
+            except AttributeError:
+                element_text = text_item
+            if element_text is None:
+                continue
+            element_text = element_text.replace('\n', '\\n')
+            element_text = element_text.replace('\"', '\\"')
+            result += f'QT_TRANSLATE_NOOP("{translation_context}", "{element_text}")\n'
+        return result
+
+    import xml.etree.ElementTree as ET
+    tree = ET.parse(cli_xml_filename)
+    root = tree.getroot()
+
+    translation_context = "CLI_" + os.path.splitext(os.path.basename(cli_xml_filename))[0]
+
+    cpp_header_str = f"// Generated automatically by update_translations.py from {os.path.basename(cli_xml_filename)}\n\n"
+
+    # Module information
+    cpp_header_str += to_translation_header("qSlicerAbstractCoreModule", root.find('category').text.split('.'))
+    cpp_header_str += to_translation_header(translation_context, root.find('title'))
+    cpp_header_str += to_translation_header(translation_context, root.find('description'))
+    cpp_header_str += to_translation_header(translation_context, root.find('acknowledgements'))
+
+    # Parameters
+    for parameter in root.findall('parameters'):
+        cpp_header_str += to_translation_header(translation_context, parameter.find('label'))
+        cpp_header_str += to_translation_header(translation_context, parameter.find('description'))
+        for elem in parameter.findall('./*/label'):
+            cpp_header_str += to_translation_header(translation_context, elem)
+        for elem in parameter.findall('./*/description'):
+            cpp_header_str += to_translation_header(translation_context, elem)
+        for elem in parameter.findall('./string-enumeration/default'):
+            cpp_header_str += to_translation_header(translation_context, elem)
+        for elem in parameter.findall('./string-enumeration/element'):
+            cpp_header_str += to_translation_header(translation_context, elem)
+
+    # Write to file
+    cpp_header_path = os.path.splitext(cli_xml_filename)[0] + "_tr.h"
+    logging.info("Writing output file: " + cpp_header_path)
+    with open(cpp_header_path, 'w', encoding='utf8') as cpp_header_file:
+        cpp_header_file.write(cpp_header_str)
+
+
+def extract_translatable_from_cli_modules(source_code_dir):
+    """For each CLI *.xml files it creates a *_tr.h file that Qt lupdate can consume.
+    """
+
+    # List of folders that contain CLI module descriptor XML files.
+    inputpaths = [
+        os.path.join(source_code_dir, "Modules", "CLI"),
+        os.path.join(source_code_dir, "Docs", "_extracli"),
+    ]
+
+    # List of modules to be excluded from documentation generation
+    # (for example, testing modules only).
+    excludenames = [
+        'CLIROITest.xml',
+        'TestGridTransformRegistration.xml',
+        'DiffusionTensorTest.xml',
+    ]
+
+    for inputpath in inputpaths:
+        for root, dirs, files in os.walk(inputpath):
+            for name in files:
+                if name in excludenames:
+                    continue
+                if name.endswith(".xml"):
+                    _generate_translation_header_from_cli_xml(os.path.join(root, name))
+
+
 def main(argv):
     parser = argparse.ArgumentParser(description="Update Qt translation files")
     parser.add_argument("--lupdate", default="lupdate", dest="lupdate_path",
@@ -58,6 +146,7 @@ def main(argv):
                         help="choose specific ts file to update by language (e.g., use en-US to update only US English translation file)")
     args = parser.parse_args(argv)
 
+    extract_translatable_from_cli_modules(args.source_code_dir)
     update_translations(args.source_code_dir, args.translations_dir, args.lupdate_path, args.language)
 
 


### PR DESCRIPTION
From CLI .xml files _generate_translation_header_from_cli_xml() (in update_translations.py) creates .h files that Qt lupdate tool recognizes. For example: Modules\CLI\ACPCTransform\ACPCTransform_tr.h is created with this content:

    // Generated automatically by update_translations.py from ACPCTransform.xml
    QT_TRANSLATE_NOOP("qSlicerAbstractCoreModule", "Registration")
    QT_TRANSLATE_NOOP("qSlicerAbstractCoreModule", "Specialized")
    QT_TRANSLATE_NOOP("CLI_ACPCTransform", "ACPC Transform")
    ...
    QT_TRANSLATE_NOOP("CLI_ACPCTransform", "Input landmarks")
    QT_TRANSLATE_NOOP("CLI_ACPCTransform", "Anatomical landmarks that will be used for computing the ACPC transform.")

qSlicerCLIModule* classes use `CLI_<modulename>` context to retrieve translations.

The *_tr.h files are placed into the source tree to make the location extracted by lupdate close to the original source file. For example, for the Modules/CLI/ACPCTransform/ACPCTransform.xml description, the location in the .ts file is:

    <location filename="Modules/CLI/ACPCTransform/ACPCTransform_tr.h" line="10"/>

re #6177