### PR TITLE
ENH: Use column name for plot title when none specified

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -3405,6 +3405,10 @@ def plot(narray, xColumnIndex=-1, columnNames=None, title=None, show=True, nodes
         seriesNode.SetYColumnName(yColumnName)
         if title:
             seriesNode.SetName(title + " " + yColumnName)
+        else:
+            # When only columnNames are set (no `title` parameter), the user should see
+            # the name of the column as the name of the series.
+            seriesNode.SetName(yColumnName)
         if not chartNode.HasPlotSeriesNodeID(seriesNode.GetID()):
             chartNode.AddAndObservePlotSeriesNodeID(seriesNode.GetID())
 


### PR DESCRIPTION
Without this fix there can be situation in which when `columnNames` are provided, but no `title`, the name of the created series is not affected. I would expect that column names would be used as `seriesNode` names.

I tested this fix in my Slicer installation and it worked.

Fixes #6671