### PR TITLE
Parameter node wrapper

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,6 +19,7 @@ per-file-ignores = \
   # Module imported but unused
   Base/Python/mrml.py:F401 \
   Base/Python/slicer/logic.py:F401 \
+  Base/Python/slicer/parameterNodeWrapper/__init__.py:F401 \
   Base/Python/vtkAddon.py:F401 \
   Base/Python/vtkITK.py:F401 \
   Base/Python/vtkSegmentationCore.py:F401 \

--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -296,6 +296,12 @@ slicer_add_python_unittest(
   TESTNAME_PREFIX nomainwindow_
   )
 
+  slicer_add_python_unittest(
+    SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
+    SLICER_ARGS --no-main-window --disable-modules
+    TESTNAME_PREFIX nomainwindow_
+    )
+
 ## Test reading MGH file format types.
 slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_mgh.py

--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -2,6 +2,12 @@
 set(Slicer_PYTHON_SCRIPTS
   slicer/__init__
   slicer/logic
+  slicer/parameterNodeWrapper/__init__
+  slicer/parameterNodeWrapper/default
+  slicer/parameterNodeWrapper/serializers
+  slicer/parameterNodeWrapper/util
+  slicer/parameterNodeWrapper/validators
+  slicer/parameterNodeWrapper/wrapper
   slicer/ScriptedLoadableModule
   slicer/slicerqt
   slicer/testing

--- a/Base/Python/slicer/parameterNodeWrapper/__init__.py
+++ b/Base/Python/slicer/parameterNodeWrapper/__init__.py
@@ -1,0 +1,4 @@
+from .default import *
+from .serializers import *
+from .validators import *
+from .wrapper import *

--- a/Base/Python/slicer/parameterNodeWrapper/default.py
+++ b/Base/Python/slicer/parameterNodeWrapper/default.py
@@ -1,0 +1,21 @@
+class Default:
+    """
+    Annotation to denote the default value for a parameter.
+    """
+
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self) -> str:
+        return f"Default({self.value})"
+
+
+def extractDefault(annotations):
+    """
+    Given a list of annotations, returns the first Default annotation, if any
+    """
+    defaults = [x for x in annotations if isinstance(x, Default)]
+    nonDefaults = [x for x in annotations if not isinstance(x, Default)]
+    if len(defaults) > 1:
+        raise Exception("Multiple defaults found")
+    return (defaults[0] if defaults else None, nonDefaults)

--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -1,0 +1,601 @@
+import abc
+import collections
+import pathlib
+import typing
+
+import slicer
+
+from .util import splitAnnotations
+from .validators import *
+
+
+class Serializer(abc.ABC):
+    """
+    Base class from which all serializers derive.
+    The serializer is responsible for reading and writing objects of a type to the parameter node.
+    Serializers are typically constant after construction.
+    """
+
+    @staticmethod
+    @abc.abstractmethod
+    def canSerialize(type_) -> bool:
+        """
+        Whether the serializer can serialize the given type if it is properly instantiated.
+
+        E.g. a ListSerializer can serialize list[int] or list[str] if the right serializer is put into its constructor.
+        """
+        raise NotImplementedError("canSerialize is not implemented")
+
+    @staticmethod
+    @abc.abstractmethod
+    def create(type_):
+        """
+        Creates a new serializer object based on the given type. If this class does not support the given type,
+        None is returned.
+
+        It is common for the returned type to actually be a ValidatedSerializer wrapping this serializer that implements
+        any default validators (NotNone and IsInstance are common).
+        """
+        raise NotImplementedError("create is not implemented")
+
+    @abc.abstractmethod
+    def default(self):
+        """
+        The default value to use if another default is not specified.
+        """
+        raise NotImplementedError("default is not implemented")
+
+    @abc.abstractmethod
+    def isIn(self, parameterNode, name: str) -> bool:
+        """
+        Whether the parameterNode contains a parameter of the given name.
+        Note that most implementations can just use parameterNode.HasParameter(name), but certain ones
+        like NodeSerializer cannot.
+        """
+        raise NotImplementedError("isIn is not implemented")
+
+    @abc.abstractmethod
+    def write(self, parameterNode, name: str, value) -> None:
+        """
+        Writes the value to the parameterNode under the given name.
+        Note: It is acceptable to mangle the name as long the same name can be used for reading.
+        For example ListSerializer does this.
+        """
+        raise NotImplementedError("write is not implemented")
+
+    @abc.abstractmethod
+    def read(self, parameterNode, name: str):
+        """
+        Reads and returns the value with the given name from the parameterNode.
+        """
+        raise NotImplementedError("read is not implemented")
+
+    @abc.abstractmethod
+    def remove(self, parameterNode, name: str) -> None:
+        """
+        Removes the value of the given name from the parameterNode.
+        """
+        raise NotImplementedError("remove is not implemented")
+
+    @staticmethod
+    def supportsCaching() -> bool:
+        """
+        Whether this serializer works with caching.
+
+        Converting from str to a value can be costly, so caching can be used to speed up reads.
+        However, if a cached value is returned and that value is an class object, modifying the
+        returned object can modify the cache without modifying the underlying parameterNode,
+        which can lead to unexpected behavior.
+
+        Serializers that support caching typically return objects that are able to update the
+        parameterNode (usually through this serializer) whenever their state changes. See
+        ListSerializer and ObservedList for an example. Alternatively, types that do not return by
+        reference (int, float) or are immutable (str) are good candidates for caching.
+        """
+        return False
+
+
+class ValidatedSerializer(Serializer):
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        """
+        ValidatedSerializer can technically serialize anything since it is a pass through to
+        another serializer, but it should not be registered to be chosen as a serializer on its own.
+        """
+        return False
+
+    @staticmethod
+    def create(type_):
+        raise Exception("ValidatedSerializer does not support create!")
+
+    def __init__(self, serializer, validators):
+        if isinstance(serializer, ValidatedSerializer):
+            # if we are nesting ValidatedSerializers, flatten them and make the inner validators
+            # come first
+            self.serializer = serializer.serializer
+            self.validators = serializer.validators + (validators or [])
+        else:
+            self.serializer = serializer
+            self.validators = validators
+
+    def default(self):
+        return self.serializer.default()
+
+    def isIn(self, parameterNode, name):
+        return self.serializer.isIn(parameterNode, name)
+
+    def validate(self, value):
+        for validator in self.validators:
+            validator.validate(value)
+
+    def write(self, parameterNode, name, value):
+        self.validate(value)
+        self.serializer.write(parameterNode, name, value)
+
+    def read(self, parameterNode, name):
+        return self.serializer.read(parameterNode, name)
+
+    def remove(self, parameterNode, name):
+        self.serializer.remove(parameterNode, name)
+
+    def supportsCaching(self) -> bool:
+        return self.serializer.supportsCaching()
+
+
+_registeredSerializers = []
+
+
+def _processSerializer(classtype):
+    if not issubclass(classtype, Serializer):
+        raise Exception("Must be a serializer type.")
+    global _registeredSerializers
+    _registeredSerializers.append(classtype)
+    return classtype
+
+
+def parameterNodeSerializer(classtype=None):
+    """
+    Class decorator to register a new parameter node serializer
+    """
+    def wrap(cls):
+        return _processSerializer(cls)
+
+    # See if we're being called as @parameterNode or @parameterNode().
+    if classtype is None:
+        return wrap
+    return wrap(classtype)
+
+
+def extractSerializer(annotations):
+    def isSerializer(x):
+        return isinstance(x, Serializer) or (isinstance(x, type) and issubclass(x, Serializer))
+
+    serializers = [x for x in annotations if isSerializer(x)]
+    nonSerializers = [x for x in annotations if not isSerializer(x)]
+    if len(serializers) > 1:
+        raise Exception("Multiple serializers found")
+    return (serializers[0] if serializers else None, nonSerializers)
+
+
+def _makeAppropriateSerializer(type_):
+    for serializerFactory in _registeredSerializers:
+        if serializerFactory.canSerialize(type_):
+            return serializerFactory.create(type_)
+    raise Exception(f"Unable to create serializer for type: {str(type_)}")
+
+
+def createSerializer(type_, annotations):
+    validators, annotations = extractValidators(annotations)
+    serializer, annotations = extractSerializer(annotations)
+
+    serializer = serializer or _makeAppropriateSerializer(type_)
+    return (ValidatedSerializer(serializer, validators), annotations)
+
+
+@parameterNodeSerializer
+class NumberSerializer(Serializer):
+    """
+    Serializer for numeric types (e.g. int, float).
+    """
+
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        return type_ in (int, float)
+
+    @staticmethod
+    def create(type_):
+        if NumberSerializer.canSerialize(type_):
+            defaultValidators = [NotNone(), IsInstance((int, float) if type_ == float else int)]
+            return ValidatedSerializer(NumberSerializer(type_), defaultValidators)
+        return None
+
+    def __init__(self, type):
+        """
+        Constructs a serializer for the given numeric type.
+        """
+        self.type = type
+
+    def default(self):
+        return 0
+
+    def isIn(self, parameterNode, name: str) -> bool:
+        return parameterNode.HasParameter(name)
+
+    def write(self, parameterNode, name: str, value) -> None:
+        parameterNode.SetParameter(name, str(value))
+
+    def read(self, parameterNode, name: str):
+        return self.type(parameterNode.GetParameter(name))
+
+    def remove(self, parameterNode, name: str) -> None:
+        parameterNode.UnsetParameter(name)
+
+    @staticmethod
+    def supportsCaching() -> bool:
+        return True
+
+
+@parameterNodeSerializer
+class StringSerializer(Serializer):
+    """
+    Serializer for str. Strings are the type that parameterNode.GetParameter/SetParameter use
+    so it is mainly a pass through.
+    """
+
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        return type_ == str
+
+    @staticmethod
+    def create(type_):
+        if StringSerializer.canSerialize(type_):
+            return ValidatedSerializer(StringSerializer(),
+                                       [NotNone(), IsInstance(type_)])
+        return None
+
+    def default(self):
+        return ""
+
+    def isIn(self, parameterNode, name: str) -> bool:
+        return parameterNode.HasParameter(name)
+
+    def write(self, parameterNode, name: str, value) -> None:
+        parameterNode.SetParameter(name, str(value))
+
+    def read(self, parameterNode, name: str):
+        return parameterNode.GetParameter(name)
+
+    def remove(self, parameterNode, name: str) -> None:
+        parameterNode.UnsetParameter(name)
+
+    def supportsCaching(self) -> bool:
+        return True
+
+
+@parameterNodeSerializer
+class PathSerializer(Serializer):
+    """
+    Serializer for pathlib types (Path, PosixPath, WindowsPath, PurePath, PurePosixPath, PureWindowsPath).
+    """
+
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        return type_ in (pathlib.Path, pathlib.PosixPath, pathlib.WindowsPath,
+                         pathlib.PurePath, pathlib.PurePosixPath, pathlib.PureWindowsPath)
+
+    @staticmethod
+    def create(type_):
+        if PathSerializer.canSerialize(type_):
+            return ValidatedSerializer(PathSerializer(type_),
+                                       [NotNone(), IsInstance(type_)])
+        return None
+
+    def __init__(self, pathtype):
+        """
+        Constructs a serializer for the given pathlib type.
+        """
+        self.type = pathtype
+
+    def default(self):
+        return self.type()
+
+    def isIn(self, parameterNode, name: str) -> bool:
+        return parameterNode.HasParameter(name)
+
+    def write(self, parameterNode, name: str, value) -> None:
+        parameterNode.SetParameter(name, str(value))
+
+    def read(self, parameterNode, name: str):
+        return self.type(parameterNode.GetParameter(name))
+
+    def remove(self, parameterNode, name: str) -> None:
+        parameterNode.UnsetParameter(name)
+
+    def supportsCaching(self) -> bool:
+        return True
+
+
+@parameterNodeSerializer
+class BoolSerializer(Serializer):
+    """
+    Serializer for bool.
+    """
+
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        return type_ == bool
+
+    @staticmethod
+    def create(type_):
+        if BoolSerializer.canSerialize(type_):
+            return ValidatedSerializer(BoolSerializer(),
+                                       [NotNone(), IsInstance(type_)])
+        return None
+
+    def default(self):
+        return False
+
+    def isIn(self, parameterNode, name: str) -> bool:
+        return parameterNode.HasParameter(name)
+
+    def write(self, parameterNode, name: str, value: bool) -> None:
+        parameterNode.SetParameter(name, "True" if value else "False")
+
+    def read(self, parameterNode, name: str) -> bool:
+        return parameterNode.GetParameter(name) == "True"
+
+    def remove(self, parameterNode, name: str) -> None:
+        parameterNode.UnsetParameter(name)
+
+    def supportsCaching(self) -> bool:
+        return True
+
+
+@parameterNodeSerializer
+class NodeSerializer(Serializer):
+    """
+    Serializer for any instance (including subclasses) of slicer.vtkMRMLNode.
+    """
+
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        return issubclass(type_, slicer.vtkMRMLNode)
+
+    @staticmethod
+    def create(type_):
+        if NodeSerializer.canSerialize(type_):
+            return ValidatedSerializer(NodeSerializer(),
+                                       [IsInstance(type_)])
+        return None
+
+    def default(self):
+        return None
+
+    def isIn(self, parameterNode, name: str) -> bool:
+        return parameterNode.GetNodeReferenceID(name) is not None
+
+    def write(self, parameterNode, name: str, value: slicer.vtkMRMLNode) -> None:
+        return parameterNode.SetNodeReferenceID(name, value.GetID() if value is not None else None)
+
+    def read(self, parameterNode, name) -> slicer.vtkMRMLNode:
+        return parameterNode.GetNodeReference(name)
+
+    def remove(self, parameterNode, name) -> None:
+        """Removes this parameter from the node if it exists."""
+        parameterNode.RemoveNodeReferenceIDs(name)
+
+    def supportsCaching(self) -> bool:
+        return True
+
+
+class ObservedList(collections.abc.MutableSequence):
+    """
+    A list-like object that updates its associated parameter node when the container is updated.
+    Modification operations are supported (append, +=, __setitem__, etc), but non-modifying list
+    operations are not (+, *) as it would be too easy to accidentally make non-observable changes.
+    """
+
+    def __init__(self, parameterNode, listSerializer, name, startingValue):
+        self._parameterNode = parameterNode
+        self._serializer = listSerializer
+        self._name = name
+        self._list = startingValue
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __str__(self):
+        return f"ObservedList({str(self._list)})"
+
+    def _saveList(self) -> None:
+        try:
+            self._serializer.write(self._parameterNode, self._name, self._list)
+        finally:
+            # resetting the _list here helps if there are nested lists and someone does something like
+            #    m = parameterNode.listOfLists
+            #    m.append([1]) <-- this will seamlessly become an ObservedList so the next line works
+            #    m[0][0] = 2
+            self._list = self._serializer.read(self._parameterNode, self._name)._list
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, ObservedList):
+            return self._list == other._list
+        else:
+            return self._list == other
+
+    def __len__(self):
+        return self._list.__len__()
+
+    def __getitem__(self, index):
+        return self._list.__getitem__(index)
+
+    def __delitem__(self, index):
+        self._list.__delitem__(index)
+        self._saveList()
+
+    def __setitem__(self, index, item):
+        self._list.__setitem__(index, item)
+        self._saveList()
+
+    def __iadd__(self, other):
+        self._list.__iadd__(other)
+        self._saveList()
+        return self
+
+    def __add__(self, other):
+        raise NotImplementedError("Adding an ObservedList is not supported. However, += is supported.")
+
+    def __radd__(self, other):
+        raise NotImplementedError("Adding an ObservedList is not supported. However, += is supported.")
+
+    def __imul__(self, other):
+        self._list.__imul__(other)
+        self._saveList()
+        return self
+
+    def __mul__(self, other):
+        raise NotImplementedError("Multiplying an ObservedList is not supported. However, *= is supported.")
+
+    def __rmul__(self, other):
+        raise NotImplementedError("Multiplying an ObservedList is not supported. However, *= is supported.")
+
+    def append(self, item) -> None:
+        self._list.append(item)
+        self._saveList()
+
+    def extend(self, other) -> None:
+        self._list.extend(other)
+        self._saveList()
+
+    def insert(self, index, item) -> None:
+        self._list.insert(index, item)
+        self._saveList()
+
+    def remove(self, item) -> None:
+        self._list.remove(item)
+        self._saveList()
+
+    def pop(self, i=-1):
+        val = self._list.pop(i)
+        self._saveList()
+        return val
+
+    def clear(self, ) -> None:
+        self._list.clear()
+        self._saveList()
+
+    def sort(self, *args, **kwargs) -> None:
+        self._list.sort(*args, **kwargs)
+        self._saveList()
+
+    def reverse(self) -> None:
+        self._list.reverse()
+        self._saveList()
+
+
+@parameterNodeSerializer
+class ListSerializer(Serializer):
+    """
+    Serializer for lists of a type.
+    """
+
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        return typing.get_origin(type_) == list
+
+    @staticmethod
+    def create(type_):
+        if ListSerializer.canSerialize(type_):
+            args = typing.get_args(type_)
+            if len(args) != 1:
+                print("Unexpected list[] type arg length")
+            if len(args) == 0:
+                Exception("Unsure how to handle a typed list with no discernible type")
+            elementType, elementAnnotations = splitAnnotations(args[0])
+            serializer, annotations = createSerializer(elementType, elementAnnotations)
+            if annotations:
+                print(f"Warning: Unused annotations: {annotations}")
+            return ListSerializer(serializer)
+        return None
+
+    def __init__(self, elementTypeSerializer):
+        """
+        Constructs a ListSerializer. The elements will be serialized/deserialized with the
+        given elementTypeSerializer.
+        """
+        self._elementSerializer = elementTypeSerializer
+        self._lenSerializer = NumberSerializer(int)
+
+    def default(self):
+        return []
+
+    def _lenName(self, name):
+        return f"{name}_len"
+
+    def _paramName(self, name, index):
+        return f"{name}_{index}"
+
+    def _len(self, parameterNode, name) -> int:
+        if self.isIn(parameterNode, name):
+            return self._lenSerializer.read(parameterNode, self._lenName(name))
+        else:
+            return 0
+
+    def _setLen(self, parameterNode, name, length):
+        self._lenSerializer.write(parameterNode, self._lenName(name), length)
+
+    def isIn(self, parameterNode, name: str) -> bool:
+        return self._lenSerializer.isIn(parameterNode, self._lenName(name))
+
+    def write(self, parameterNode, name: str, values) -> None:
+        def paramName(index):
+            return self._paramName(name, index)
+        with slicer.util.NodeModify(parameterNode):
+            oldValues = self.read(parameterNode, name) if self.isIn(parameterNode, name) else None
+            oldLen = self._len(parameterNode, name)
+            newLen = len(values)
+
+            try:
+                for index, value in enumerate(values):
+                    self._elementSerializer.write(parameterNode, paramName(index), value)
+
+                self._setLen(parameterNode, name, newLen)
+                # unset any items that we no longer have indices for
+                for index in range(newLen, oldLen):
+                    self._elementSerializer.remove(parameterNode, paramName(index))
+            except Exception:
+                # reset our state back to what it was on exception
+                if oldValues is None:
+                    self.remove(parameterNode, name)
+                else:
+                    self.write(parameterNode, name, oldValues)
+                raise
+
+    def read(self, parameterNode, name):
+        def paramName(index):
+            return self._paramName(name, index)
+
+        ret = [self._elementSerializer.read(parameterNode, paramName(index))
+               for index in range(self._len(parameterNode, name))]
+        return ObservedList(parameterNode, self, name, ret)
+
+    def remove(self, parameterNode, name: str) -> None:
+        """Removes this parameter from the node if it exists."""
+        def paramName(index):
+            return self._paramName(name, index)
+        with slicer.util.NodeModify(parameterNode):
+            for index in range(self._len(parameterNode, name)):
+                self._elementSerializer.remove(parameterNode, paramName(index))
+            self._lenSerializer.remove(parameterNode, self._lenName(name))
+
+    def supportsCaching(self) -> bool:
+        """
+        Whether this ListSerializer support caching depends on if its elementTypeSerializer
+        supports caching.
+
+        Caching is very much preferred for lists, it makes reads so much faster for large lists.
+        However, if the element itself does not support caching we shouldn't cache by default
+        because it might lead to unexpected behavior. In this case modifying the _list_ will
+        write to the parameterNode, but modifying the _element_ will not, which can be confusing.
+        """
+        return self._elementSerializer.supportsCaching()

--- a/Base/Python/slicer/parameterNodeWrapper/util.py
+++ b/Base/Python/slicer/parameterNodeWrapper/util.py
@@ -1,0 +1,18 @@
+import typing
+from typing import Annotated
+
+
+def splitAnnotations(possiblyAnnotatedType):
+    # Annotated types flatten, so
+    #   Annotated[Annotated[int, 0], 1] == Annotated[int, 0, 1]
+    # Wrapping the type (Annotated or not) in an Annotated gives a consistent interface
+    # regardless of whether the type was Annotated or not, and it makes args[0] the same for both
+    # list[int] and Annotated[list[int], annotations] (note that get_args(list[int]) == (int)).
+    # We will drop the "0" off the end when we get the annotations. The value means nothing; there just
+    # needs to be some annotation added for syntax reasons.
+    annotatedType = Annotated[possiblyAnnotatedType, "stub annotation"]
+    args = typing.get_args(annotatedType)
+
+    actualtype = args[0]
+    annotations = args[1:-1]
+    return (actualtype, annotations)

--- a/Base/Python/slicer/parameterNodeWrapper/validators.py
+++ b/Base/Python/slicer/parameterNodeWrapper/validators.py
@@ -1,0 +1,135 @@
+import abc
+
+
+class Validator(abc.ABC):
+    """
+    Base class from which all parameterNodeWrapper validators derive.
+    Validators must derive from this class to be used.
+    """
+    @abc.abstractmethod
+    def validate(self, value):
+        """
+        Validates that the input value is valid.
+        Raises an exception (recommended ValueError) if it is not valid.
+        """
+        raise NotImplementedError("validate is not implemented")
+
+
+def extractValidators(annotations):
+    def isValidator(x):
+        return isinstance(x, Validator) or (isinstance(x, type) and issubclass(x, Validator))
+
+    return (
+        [x for x in annotations if isValidator(x)],
+        [x for x in annotations if not isValidator(x)]
+    )
+
+
+class NotNone(Validator):
+    """
+    Validates that any input value is not None.
+    """
+
+    def __repr__(self) -> str:
+        return f"NotNone()"
+
+    def validate(self, value):
+        if value is None:
+            raise ValueError("Value must not be None")
+
+
+class IsInstance(Validator):
+    """
+    Validates that any input value is an instance of a given type.
+    """
+
+    def __init__(self, classtype):
+        self.classtype = classtype
+
+    def __repr__(self) -> str:
+        return f"IsInstance({self.classtype})"
+
+    def validate(self, value):
+        if value is not None and not isinstance(value, self.classtype):
+            raise ValueError(f"Value must be of type '{self.classtype}', is type 'type({value})'")
+
+
+class WithinRange(Validator):
+    """
+    Validates that any input value is within the given range (inclusive).
+    """
+
+    def __init__(self, minimum, maximum):
+        self.minimum = minimum
+        self.maximum = maximum
+
+    def __repr__(self) -> str:
+        return f"WithinRange({self.minimum}, {self.maximum})"
+
+    def validate(self, value):
+        if not self.minimum <= value <= self.maximum:
+            raise ValueError(f"Value must be within range [{self.minimum}, {self.maximum}], is {value}")
+
+
+class Minimum(Validator):
+    """
+    Validates that any input value is greater than or equal to the given value.
+    """
+
+    def __init__(self, minimum):
+        self.minimum = minimum
+
+    def __repr__(self) -> str:
+        return f"Minimum({self.minimum})"
+
+    def validate(self, value):
+        if value < self.minimum:
+            raise ValueError(f"Value must be greater than {self.minimum}, is {value}")
+
+
+class Maximum(Validator):
+    """
+    Validates that any input value is less than or equal to the given value.
+    """
+
+    def __init__(self, maximum):
+        self.maximum = maximum
+
+    def __repr__(self) -> str:
+        return f"Maximum({self.maximum})"
+
+    def validate(self, value):
+        if value > self.maximum:
+            raise ValueError(f"Value must be greater than {self.maximum}, is {value}")
+
+
+class Choice(Validator):
+    """
+    Validates that any input value is in the list of valid choices.
+    """
+
+    def __init__(self, choices):
+        self.choices = choices
+
+    def __repr__(self) -> str:
+        return f"Choice({self.choices})"
+
+    def validate(self, value):
+        if value not in self.choices:
+            raise ValueError(f"Value is {value}, but must be in one of the following: {self.choices}")
+
+
+class Exclude(Validator):
+    """
+    Validates that any input value is not in the list of invalid choices.
+    """
+
+    def __init__(self, excludedValues):
+        self.excludedValues = excludedValues
+
+    def __repr__(self) -> str:
+        return f"Exclude({self.excludedValues})"
+
+    def validate(self, value):
+        if value in self.excludedValues:
+            raise ValueError(f"Value is {value}, but must not be an excluded value: excluded values {self.excludedValues}")

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -1,0 +1,176 @@
+import typing
+
+import vtk
+
+from .default import *
+from .serializers import *
+from .util import *
+from .validators import *
+
+
+__all__ = ["parameterNodeWrapper"]
+
+
+class _ParameterInfo:
+    def __init__(self, basename: str, serializer: Serializer, default):
+        self.basename = basename
+        self.serializer = serializer
+        self.default = default
+
+
+class _Parameter:
+    def __init__(self, parameterInfo, prefix=None):
+        self.name = f"{prefix or ''}{parameterInfo.basename}"
+        self.serializer = parameterInfo.serializer
+        self.default = parameterInfo.default
+
+    def isIn(self, parameterNode):
+        return self.serializer.isIn(parameterNode, self.name)
+
+    def write(self, parameterNode, value):
+        self.serializer.write(parameterNode, self.name, value)
+
+    def read(self, parameterNode):
+        if self.serializer.isIn(parameterNode, self.name):
+            return self.serializer.read(parameterNode, self.name)
+        else:
+            return self.default
+
+    def remove(self, parameterNode):
+        self.serializer.remove(parameterNode, self.name)
+
+    def supportsCaching(self) -> bool:
+        return self.serializer.supportsCaching()
+
+
+class _ParameterWrapper:
+    def __init__(self, parameter, parameterNode):
+        assert parameterNode is not None
+        self.parameter = parameter
+        self.parameterNode = parameterNode
+
+    def default(self):
+        return self.parameter.default
+
+    def isIn(self):
+        """Whether this parameter has a value in the parameter node given to the constructor."""
+        return self.parameter.isIn(self.parameterNode)
+
+    def read(self):
+        """
+        Gets the value of this parameter in the given parameter node.
+        """
+        return self.parameter.read(self.parameterNode)
+
+    def write(self, value):
+        """Sets the value of this parameter in the parameter node given to the constructor."""
+        self.parameter.write(self.parameterNode, value)
+
+    def remove(self):
+        """Removes this parameter from the parameter node given to the constructor if it exists."""
+        self.parameter.remove(self.parameterNode)
+
+    def supportsCaching(self) -> bool:
+        return self.parameter.supportsCaching()
+
+
+class _CachedParameterWrapper(_ParameterWrapper):
+    def __init__(self, parameter, parameterNode):
+        super().__init__(parameter, parameterNode)
+        self._value = self.parameter.read(self.parameterNode)
+        self._observerTag = parameterNode.AddObserver(vtk.vtkCommand.ModifiedEvent, self._onModified)
+
+    def _onModified(self, caller, event):
+        self._value = self.parameter.read(self.parameterNode)
+
+    def read(self):
+        """
+        Gets the value of this parameter in the given parameter node.
+        Caches the value for efficiency.
+        """
+        return self._value
+
+
+def _makeProperty(name):
+    return property(
+        lambda self: getattr(self, f"_{name}_impl").read(),
+        lambda self, value: getattr(self, f"_{name}_impl").write(value)
+    )
+
+
+def _initMethod(self, parameterNode, prefix=None):
+    self.parameterNode = parameterNode
+    for parameterInfo in self.__allParameters:
+        parameter = _Parameter(parameterInfo, prefix)
+        if not parameter.isIn(self.parameterNode):
+            parameter.write(self.parameterNode, parameter.default)
+
+        if parameter.supportsCaching():
+            setattr(self, f"_{parameterInfo.basename}_impl", _CachedParameterWrapper(parameter, parameterNode))
+        else:
+            setattr(self, f"_{parameterInfo.basename}_impl", _ParameterWrapper(parameter, parameterNode))
+
+
+def _checkParamName(paramNameInstance, paramName: str):
+    if not hasattr(paramNameInstance, f"_{paramName}_impl"):
+        raise ValueError(f"Cannot find a param with the given name: {paramName}"
+                         + "\n  Found parameters ["
+                         + "".join([f"\n    {p.basename}," for p in paramNameInstance.__allParameters])
+                         + "\n  ]")
+
+
+def _isCached(self, paramName: str):
+    _checkParamName(self, paramName)
+    return isinstance(getattr(self, f"_{paramName}_impl"), _CachedParameterWrapper)
+
+
+def _default(self, paramName: str):
+    _checkParamName(self, paramName)
+    return getattr(self, f"_{paramName}_impl").parameter.default
+
+
+def _processClass(classtype):
+    members = typing.get_type_hints(classtype, include_extras=True)
+    allParameters = []
+    for name, nametype in members.items():
+        membertype, annotations = splitAnnotations(nametype)
+
+        serializer, annotations = createSerializer(membertype, annotations)
+        default, annotations = extractDefault(annotations)
+        default = default.value if default is not None else serializer.default()
+
+        if annotations:
+            print("Warning: unused annotations", annotations)
+        try:
+            serializer.validate(default)
+        except Exception as e:
+            raise Exception(f"The default parameter of '{default}' fails the validation checks:\n  {str(e)}")
+
+        parameter = _ParameterInfo(name, serializer, default)
+        allParameters.append(parameter)
+        setattr(classtype, parameter.basename, _makeProperty(parameter.basename))
+
+    setattr(classtype, "__allParameters", allParameters)
+
+    setattr(classtype, "__init__", _initMethod)
+    setattr(classtype, "default", _default)
+    setattr(classtype, "isCached", _isCached)
+    setattr(classtype, "StartModify", lambda self: self.parameterNode.StartModify())
+    setattr(classtype, "EndModify", lambda self, wasModified: self.parameterNode.EndModify(wasModified))
+    setattr(classtype, "AddObserver", lambda self, event, callback, priority=0.0: self.parameterNode.AddObserver(event, callback, priority))
+    setattr(classtype, "RemoveObserver", lambda self, tag: self.parameterNode.RemoveObserver(tag))
+    setattr(classtype, "Modified", lambda self: self.parameterNode.Modified())
+    return classtype
+
+
+def parameterNodeWrapper(classtype=None):
+    """
+    Class decorator to make a parameter node wrapper that supports typed property access.
+    """
+    def wrap(cls):
+        return _processClass(cls)
+
+    # See if we're being called as @parameterNode or @parameterNode().
+    if classtype is None:
+        return wrap
+    return wrap(classtype)

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
@@ -1,0 +1,749 @@
+import dataclasses
+import pathlib
+from typing import Annotated
+import unittest
+
+import vtk
+import slicer
+
+from MRMLCorePython import (
+    vtkMRMLNode,
+    vtkMRMLModelNode,
+    vtkMRMLScalarVolumeNode,
+)
+from slicer.parameterNodeWrapper import *
+
+
+def newParameterNode():
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScriptedModuleNode")
+    return node
+
+
+@dataclasses.dataclass
+class CustomClass:
+    x: int
+    y: int
+    z: int
+
+
+@parameterNodeSerializer
+class CustomClassSerializer(Serializer):
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        return type_ == CustomClass
+
+    @staticmethod
+    def create(type_):
+        if CustomClassSerializer.canSerialize(type_):
+            return ValidatedSerializer(CustomClassSerializer(), [NotNone(), IsInstance(CustomClass)])
+        return None
+
+    def default(self):
+        return None
+
+    def isIn(self, parameterNode, name: str) -> bool:
+        return parameterNode.HasParameter(name)
+
+    def write(self, parameterNode, name: str, value) -> None:
+        parameterNode.SetParameter(name, f"{value.x},{value.y},{value.z}")
+
+    def read(self, parameterNode, name: str):
+        val = parameterNode.GetParameter(name)
+        vals = val.split(',')
+        return CustomClass(int(vals[0]), int(vals[1]), int(vals[2]))
+
+    def remove(self, parameterNode, name: str) -> None:
+        parameterNode.UnsetParameter(name)
+
+
+@dataclasses.dataclass
+class AnotherCustomClass:
+    a: int
+    b: int
+    c: int
+
+
+# the big difference between this and CustomClassSerializer, is that the
+# default for this is not None
+@parameterNodeSerializer
+class AnotherCustomClassSerializer(Serializer):
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        return type_ == AnotherCustomClass
+
+    @staticmethod
+    def create(type_):
+        if AnotherCustomClassSerializer.canSerialize(type_):
+            return ValidatedSerializer(AnotherCustomClassSerializer(), [IsInstance(AnotherCustomClass)])
+        return None
+
+    def default(self):
+        return AnotherCustomClass(0, 0, 0)
+
+    def isIn(self, parameterNode, name: str) -> bool:
+        return parameterNode.HasParameter(name)
+
+    def write(self, parameterNode, name: str, value) -> None:
+        parameterNode.SetParameter(name, f"{value.a},{value.b},{value.c}" if value is not None else "None")
+
+    def read(self, parameterNode, name: str):
+        val = parameterNode.GetParameter(name)
+        if val == "None":
+            return None
+        else:
+            vals = val.split(',')
+            return AnotherCustomClass(int(vals[0]), int(vals[1]), int(vals[2]))
+
+    def remove(self, parameterNode, name: str) -> None:
+        parameterNode.UnsetParameter(name)
+
+
+# not registering as a @parameterNodeSerializer because we are overriding
+# the serialization of a built in type and we don't want anyone else to accidentally
+# use this.
+class CustomIntSerializer(Serializer):
+    """
+    Stores ints as their negative.
+    Used to test being able to use a specific serializer.
+    """
+    @staticmethod
+    def canSerialize(type_) -> bool:
+        return type_ == int
+
+    @staticmethod
+    def create(type_):
+        if CustomIntSerializer.canSerialize(type_):
+            return ValidatedSerializer(CustomIntSerializer(), [NotNone(), IsInstance(int)])
+        return None
+
+    def default(self):
+        return 0
+
+    def isIn(self, parameterNode, name: str) -> bool:
+        return parameterNode.HasParameter(name)
+
+    def write(self, parameterNode, name: str, value) -> None:
+        parameterNode.SetParameter(name, str(-value))
+
+    def read(self, parameterNode, name: str):
+        return -int(parameterNode.GetParameter(name))
+
+    def remove(self, parameterNode, name: str) -> None:
+        parameterNode.UnsetParameter(name)
+
+
+class TypedParameterNodeTest(unittest.TestCase):
+    def setUp(self):
+        slicer.mrmlScene.Clear(0)
+
+    def test_removes(self):
+        # for each serializer, make sure that calling remove from it
+        # erases all trace of it in the parameterNode
+        numberSerializer = NumberSerializer(int)
+        stringSerializer = StringSerializer()
+        pathSerializer = PathSerializer(pathlib.Path)
+        boolSerializer = BoolSerializer()
+        listSerializer = ListSerializer(NumberSerializer(float))
+
+        parameterNode = newParameterNode()
+
+        numberSerializer.write(parameterNode, "number", 1)
+        stringSerializer.write(parameterNode, "string", "1")
+        pathSerializer.write(parameterNode, "path", pathlib.Path("."))
+        boolSerializer.write(parameterNode, "bool", True)
+        listSerializer.write(parameterNode, "list", [1])
+
+        numberSerializer.remove(parameterNode, "number")
+        stringSerializer.remove(parameterNode, "string")
+        pathSerializer.remove(parameterNode, "path")
+        boolSerializer.remove(parameterNode, "bool")
+        listSerializer.remove(parameterNode, "list")
+
+        self.assertFalse(parameterNode.GetParameterNames())
+
+    def test_isCached(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            int_: int
+            listInt: list[int]
+            custom: Annotated[CustomClass, Default(CustomClass(0, 0, 0))]
+            listCustom: list[CustomClass]
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertTrue(param.isCached("int_"))
+        self.assertTrue(param.isCached("listInt"))
+        self.assertFalse(param.isCached("custom"))
+        self.assertFalse(param.isCached("listCustom"))
+        with self.assertRaises(ValueError):
+            param.isCached("notExistentParameter")
+
+    def test_custom_validator(self):
+        class Is777Or778(Validator):
+            @staticmethod
+            def validate(value):
+                if value != 777 and value != 778:
+                    raise ValueError("Twas not 777 or 778")
+
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            i: Annotated[int, Is777Or778, Default(777)]
+
+        param = ParameterNodeType(newParameterNode())
+
+        with self.assertRaises(ValueError):
+            param.i = -2
+        param.i = 778
+
+    def test_custom_serializer(self):
+        @parameterNodeWrapper
+        class CustomClassParameterNode:
+            # serializer for custom type will be found because it was decorate with @parameterNodeSerializer
+            custom: Annotated[CustomClass, Default(CustomClass(0, 0, 0))]
+
+            # custom serializer for built in type
+            customInt: Annotated[int, CustomIntSerializer()]
+
+        param = CustomClassParameterNode(newParameterNode())
+        self.assertEqual(param.custom.x, 0)
+        self.assertEqual(param.custom.y, 0)
+        self.assertEqual(param.custom.z, 0)
+
+        self.assertEqual(param.customInt, 0)
+
+        param.customInt = 4
+        self.assertEqual(param.parameterNode.GetParameter("customInt"), "-4")
+        self.assertEqual(param.customInt, 4)
+
+    def test_custom_serializer2(self):
+        @parameterNodeWrapper
+        class AnotherCustomClassParameterNode:
+            normalDefault: AnotherCustomClass
+            noneDefault: Annotated[AnotherCustomClass, Default(None)]
+            nonNoneDefault: Annotated[AnotherCustomClass, Default(AnotherCustomClass(1, 2, 3))]
+
+        param = AnotherCustomClassParameterNode(newParameterNode())
+        self.assertEqual(param.normalDefault, AnotherCustomClass(0, 0, 0))
+        self.assertIsNone(param.noneDefault)
+        self.assertEqual(param.nonNoneDefault, AnotherCustomClass(1, 2, 3))
+
+    def test_primitives(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            int1: int
+            float1: float
+            bool1: bool
+            string1: str
+            int2: Annotated[int, Default(4)]
+            float2: Annotated[float, Default(9.9)]
+            bool2: Annotated[bool, Default(True)]
+            string2: Annotated[str, Default("TypedParam")]
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertTrue(param.isCached("int1"))
+        self.assertTrue(param.isCached("int2"))
+        self.assertTrue(param.isCached("float1"))
+        self.assertTrue(param.isCached("float2"))
+        self.assertTrue(param.isCached("bool1"))
+        self.assertTrue(param.isCached("bool2"))
+        self.assertTrue(param.isCached("string1"))
+        self.assertTrue(param.isCached("string2"))
+
+        self.assertEqual(param.int1, 0)
+        self.assertEqual(param.int2, 4)
+        self.assertAlmostEqual(param.float1, 0.0)
+        self.assertAlmostEqual(param.float2, 9.9)
+        self.assertFalse(param.bool1)
+        self.assertTrue(param.bool2)
+        self.assertEqual(param.string1, "")
+        self.assertEqual(param.string2, "TypedParam")
+
+        param.int1 = 7
+        self.assertEqual(param.int1, 7)
+        param.float2 = 4  # allow implicit conversion from int
+        self.assertAlmostEqual(param.float2, 4.0)
+        param.float2 = 7.5
+        self.assertAlmostEqual(param.float2, 7.5)
+        param.bool1 = True
+        self.assertTrue(param.bool1)
+        param.string1 = "Python"
+        self.assertEqual(param.string1, "Python")
+
+        with self.assertRaises(ValueError):
+            param.int1 = None
+        with self.assertRaises(ValueError):
+            param.float1 = None
+        with self.assertRaises(ValueError):
+            param.bool1 = None
+        with self.assertRaises(ValueError):
+            param.string1 = None
+
+        param2 = ParameterNodeType(param.parameterNode)
+
+        self.assertEqual(param2.int1, 7)
+        self.assertEqual(param2.int2, 4)
+        self.assertAlmostEqual(param2.float1, 0.0)
+        self.assertAlmostEqual(param2.float2, 7.5)
+        self.assertTrue(param2.bool1)
+        self.assertTrue(param2.bool2)
+        self.assertEqual(param.string1, "Python")
+        self.assertEqual(param2.string2, "TypedParam")
+
+    def test_pathlib(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            path: pathlib.Path
+            purePath: pathlib.PurePath
+            purePosixPath: Annotated[pathlib.PurePosixPath, Default(pathlib.PurePosixPath("/root"))]
+            pureWindowsPath: pathlib.PureWindowsPath
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertTrue(param.isCached("path"))
+        self.assertTrue(param.isCached("purePath"))
+        self.assertTrue(param.isCached("purePosixPath"))
+        self.assertTrue(param.isCached("pureWindowsPath"))
+
+        self.assertEqual(param.path, pathlib.Path())
+        self.assertEqual(param.purePath, pathlib.PurePath())
+        self.assertEqual(param.purePosixPath, pathlib.PurePosixPath("/root"))
+        self.assertEqual(param.pureWindowsPath, pathlib.PureWindowsPath())
+
+        self.assertIsInstance(param.path, pathlib.Path)
+        self.assertIsInstance(param.purePath, pathlib.PurePath)
+        self.assertIsInstance(param.purePosixPath, pathlib.PurePosixPath)
+        self.assertIsInstance(param.pureWindowsPath, pathlib.PureWindowsPath)
+
+        param.path = pathlib.Path("relativePath/folder")
+        param.purePath = pathlib.PurePath("relativePath/folder")
+        param.purePosixPath = pathlib.PurePosixPath("relativePath/folder")
+        param.pureWindowsPath = pathlib.PureWindowsPath("relativePath/folder")
+
+        self.assertEqual(param.path, pathlib.Path("relativePath/folder"))
+        self.assertEqual(param.purePath, pathlib.PurePath("relativePath/folder"))
+        self.assertEqual(param.purePosixPath, pathlib.PurePosixPath("relativePath/folder"))
+        self.assertEqual(param.pureWindowsPath, pathlib.PureWindowsPath("relativePath/folder"))
+
+        # test that it saved and can be read elsewhere
+        param2 = ParameterNodeType(param.parameterNode)
+
+        self.assertEqual(param2.path, pathlib.Path("relativePath/folder"))
+        self.assertEqual(param2.purePath, pathlib.PurePath("relativePath/folder"))
+        self.assertEqual(param2.purePosixPath, pathlib.PurePosixPath("relativePath/folder"))
+        self.assertEqual(param2.pureWindowsPath, pathlib.PureWindowsPath("relativePath/folder"))
+
+    def test_multiple_instances_are_independent(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            single: str
+            multi: list[int]
+
+        param1 = ParameterNodeType(newParameterNode())
+        param2 = ParameterNodeType(newParameterNode())
+
+        param1.single = "hi"
+        param1.multi = [1, 2, 3]
+        param2.single = "hello"
+        param2.multi = [4, 5, 6]
+
+        self.assertEqual(param1.single, "hi")
+        self.assertEqual(param1.multi, [1, 2, 3])
+        self.assertEqual(param2.single, "hello")
+        self.assertEqual(param2.multi, [4, 5, 6])
+
+    def test_list_int(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            p: list[int]
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertTrue(param.isCached("p"))
+
+        p = param.p
+        self.assertEqual(len(p), 0)
+
+        p.append(4)
+        p.append(1)
+        p.append(7)
+        self.assertEqual(param.p, [4, 1, 7])
+
+        with self.assertRaises(ValueError):
+            p.append("hi")
+        self.assertEqual(param.p, [4, 1, 7])
+
+        p.reverse()
+        self.assertEqual(param.p, [7, 1, 4])
+
+        p.sort()
+        self.assertEqual(param.p, [1, 4, 7])
+
+        self.assertEqual(4, p.pop(1))
+        self.assertEqual(param.p, [1, 7])
+
+        p.remove(7)
+        self.assertEqual(param.p, [1])
+
+        with self.assertRaises(ValueError):
+            p.remove(44)  # not in the list
+        self.assertEqual(param.p, [1])
+
+        p += [3, 4, 5]
+        self.assertEqual(param.p, [1, 3, 4, 5])
+
+        p *= 2
+        self.assertEqual(param.p, [1, 3, 4, 5, 1, 3, 4, 5])
+
+        del p[2]
+        self.assertEqual(param.p, [1, 3, 5, 1, 3, 4, 5])
+
+        p.insert(4, 66)
+        self.assertEqual(param.p, [1, 3, 5, 1, 66, 3, 4, 5])
+
+        p.clear()
+        self.assertEqual(param.p, [])
+
+        p.extend([2, 3, 4])
+        self.assertEqual(param.p, [2, 3, 4])
+
+        p[0] = 7
+        self.assertEqual(param.p, [7, 3, 4])
+
+        self.assertEqual(param.p[0], 7)
+        self.assertEqual(param.p[1], 3)
+        self.assertEqual(param.p[2], 4)
+
+        with self.assertRaises(NotImplementedError):
+            _ = p + [4]
+        with self.assertRaises(NotImplementedError):
+            _ = [4] + p
+        with self.assertRaises(NotImplementedError):
+            _ = p * 2
+        with self.assertRaises(NotImplementedError):
+            _ = 2 * p
+
+        p += [4, 5, 6]
+        self.assertEqual(param.p, [7, 3, 4, 4, 5, 6])
+
+        p *= 2
+        self.assertEqual(param.p, [7, 3, 4, 4, 5, 6, 7, 3, 4, 4, 5, 6])
+
+        # setting param.p will invalidate p
+        param.p = [5, 1, 2]
+        self.assertEqual(param.p, [5, 1, 2])
+
+        # set from tuple
+        param.p = (7, 3, 4)
+        self.assertEqual(param.p, [7, 3, 4])
+
+        param2 = ParameterNodeType(param.parameterNode)
+        self.assertEqual(param2.p, [7, 3, 4])
+
+        # allow explicit conversion to list, which breaks observation
+        nonObserved = list(param.p)
+        self.assertIsInstance(nonObserved, list)
+        self.assertEqual(nonObserved, [7, 3, 4])
+
+        nonObserved.append(1)
+        self.assertEqual(nonObserved, [7, 3, 4, 1])
+        self.assertEqual(param.p, [7, 3, 4])
+
+    def test_list_custom(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            p: list[CustomClass]
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertFalse(param.isCached("p"))
+
+        p = param.p
+        self.assertEqual(len(p), 0)
+
+        param.p = [CustomClass(1, 2, 3), CustomClass(4, 5, 6)]
+        self.assertEqual(param.p, [CustomClass(1, 2, 3), CustomClass(4, 5, 6)])
+
+        # test that it saved and can be read elsewhere
+        param2 = ParameterNodeType(param.parameterNode)
+        self.assertEqual(len(param2.p), 2)
+        self.assertEqual(param2.p, [CustomClass(1, 2, 3), CustomClass(4, 5, 6)])
+
+    def test_list_of_annotated(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            choices: list[Annotated[str, Choice(["yes", "no", "maybe"])]]
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertTrue(param.isCached("choices"))
+
+        param.choices.append("yes")
+
+        self.assertEqual(param.choices, ["yes"])
+        with self.assertRaises(ValueError):
+            param.choices.append("invalid")
+        self.assertEqual(param.choices, ["yes"])
+        with self.assertRaises(ValueError):
+            param.choices += ["no", "invalid"]
+        self.assertEqual(param.choices, ["yes"])
+
+        param.choices.extend(["maybe", "no"])
+        self.assertEqual(param.choices, ["yes", "maybe", "no"])
+
+    def test_list_of_lists(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            p: list[list[int]]
+        param = ParameterNodeType(newParameterNode())
+        self.assertTrue(param.isCached("p"))
+
+        pl = param.p
+
+        pl.append([])
+        pl[0] = [1, 2, 3]
+        pl.append([4, 5, 6])
+        pl[1].append(7)
+
+        pl[1][2] = 0
+
+        self.assertEqual(param.p, [[1, 2, 3], [4, 5, 0, 7]])
+
+        del pl[0]
+        self.assertEqual(param.p, [[4, 5, 0, 7]])
+
+        pl.insert(0, [6, 7])
+        self.assertEqual(param.p, [[6, 7], [4, 5, 0, 7]])
+
+        pl.pop(0)
+        self.assertEqual(param.p, [[4, 5, 0, 7]])
+
+        param2 = ParameterNodeType(param.parameterNode)
+        self.assertEqual(param2.p, [[4, 5, 0, 7]])
+
+    def test_node(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            inputs: list[vtkMRMLModelNode]
+            output: vtkMRMLModelNode
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertTrue(param.isCached("inputs"))
+        self.assertTrue(param.isCached("output"))
+
+        inputs = [slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelNode') for _ in range(5)]
+        param.inputs = inputs
+        self.assertEqual(param.inputs, inputs)
+
+        self.assertIsInstance(param.inputs[0], vtkMRMLModelNode)
+
+        output = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelNode')
+        param.output = output
+        self.assertEqual(param.output, output)
+
+        # cannot set a model to a markup
+        with self.assertRaises(ValueError):
+            param.output = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScalarVolumeNode')
+
+        param.output = None
+        self.assertIsNone(param.output)
+
+    def test_node_baseclass(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            node: vtkMRMLNode
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertTrue(param.isCached("node"))
+
+        param.node = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelNode')
+        self.assertIsInstance(param.node, vtkMRMLModelNode)
+        param.node = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScalarVolumeNode')
+        self.assertIsInstance(param.node, vtkMRMLScalarVolumeNode)
+
+        with self.assertRaises(ValueError):
+            param.node = 4
+
+    def test_events(self):
+        class _Callback:
+            def __init__(self):
+                self.called = 0
+
+            def call(self, caller, event):
+                self.called += 1
+        callback = _Callback()
+
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            i: int
+            s: list[str]
+            n: vtkMRMLNode
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertTrue(param.isCached("i"))
+        self.assertTrue(param.isCached("s"))
+        self.assertTrue(param.isCached("n"))
+
+        tag = param.AddObserver(vtk.vtkCommand.ModifiedEvent, callback.call)
+
+        param.i = 4
+        self.assertEqual(1, callback.called)
+
+        obs = param.s
+        obs += ('string1', 'string2')
+        self.assertEqual(2, callback.called)
+
+        list(param.s).append('Should not cause an event')
+        self.assertEqual(2, callback.called)
+
+        param.s = ['a', 'b', 'c']
+        self.assertEqual(3, callback.called)
+
+        param.n = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelNode')
+        self.assertEqual(4, callback.called)
+
+        param.n = None
+        self.assertEqual(5, callback.called)
+
+        param.RemoveObserver(tag)
+        param.i = 7
+        self.assertEqual(5, callback.called)
+
+    def test_validators(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            min0: Annotated[int, Minimum(0)]
+            max0: Annotated[int, Maximum(0)]
+            within0_10: Annotated[float, WithinRange(0, 10)]
+            choiceStr: Annotated[str, Choice(['a', 'b', 'c']), Default('a')]
+            excludeStr: Annotated[str, Exclude(['a', 'b', 'c'])]
+
+        param = ParameterNodeType(newParameterNode())
+
+        param.min0 = 0
+        param.min0 = 4
+        with self.assertRaises(ValueError):
+            param.min0 = -1
+        self.assertEqual(param.min0, 4)
+
+        param.max0 = 0
+        param.max0 = -4
+        with self.assertRaises(ValueError):
+            param.max0 = 1
+        self.assertEqual(param.max0, -4)
+
+        param.within0_10 = 0
+        param.within0_10 = 10
+        param.within0_10 = 5
+        with self.assertRaises(ValueError):
+            param.within0_10 = 11
+        with self.assertRaises(ValueError):
+            param.within0_10 = -1
+        self.assertEqual(param.within0_10, 5)
+
+        param.choiceStr = 'a'
+        param.choiceStr = 'b'
+        param.choiceStr = 'c'
+        with self.assertRaises(ValueError):
+            param.choiceStr = 'd'
+
+        param.excludeStr = 'd'
+        param.excludeStr = ''
+        param.excludeStr = 'e'
+        with self.assertRaises(ValueError):
+            param.excludeStr = 'a'
+        with self.assertRaises(ValueError):
+            param.excludeStr = 'b'
+        with self.assertRaises(ValueError):
+            param.excludeStr = 'c'
+
+    def test_overlapping_members(self):
+        @parameterNodeWrapper
+        class ParameterNodeType1:
+            x: int
+            y: int
+
+        @parameterNodeWrapper
+        class ParameterNodeType2:
+            x: Annotated[int, Default(6)]
+            z: int
+
+        parameterNode = newParameterNode()
+        param1 = ParameterNodeType1(parameterNode, prefix="type1")
+        param2 = ParameterNodeType2(parameterNode, prefix="type2")
+
+        self.assertEqual(param1.x, 0)
+        self.assertEqual(param1.y, 0)
+        self.assertEqual(param2.x, 6)
+        self.assertEqual(param2.z, 0)
+
+        param1.x = 4
+        param1.y = 3
+        param2.x = 7
+        param2.z = 8
+
+        self.assertEqual(param1.x, 4)
+        self.assertEqual(param1.y, 3)
+        self.assertEqual(param2.x, 7)
+        self.assertEqual(param2.z, 8)
+
+    def test_parameter_node_reuse(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            x: int
+            y: list[int]
+
+        parameterNode = newParameterNode()
+        param1 = ParameterNodeType(parameterNode, prefix="use1")
+        param2 = ParameterNodeType(parameterNode, prefix="use2")
+
+        self.assertEqual(param1.x, 0)
+        self.assertEqual(param1.y, [])
+        self.assertEqual(param2.x, 0)
+        self.assertEqual(param2.y, [])
+
+        param1.x = 4
+        param1.y = [3]
+        param2.x = 7
+        param2.y = [8, 99]
+
+        self.assertEqual(param1.x, 4)
+        self.assertEqual(param1.y, [3])
+        self.assertEqual(param2.x, 7)
+        self.assertEqual(param2.y, [8, 99])
+
+    def timing_test_timeit_read_int(self):
+        """
+        Manual test function that prints some benchmark timings.
+        Can be used to test the speed of different MakeTypedParameterNode
+        implementations.
+        """
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            i: int
+            mi: list[int]
+            f: float
+            mf: list[float]
+
+        param = ParameterNodeType(newParameterNode())
+        param.mi = [7] * 100
+        param.mf = [7.0] * 100
+
+        def seti():
+            param.i = 7
+
+        def setf():
+            param.f = 7.0
+
+        def setmi():
+            param.mi = [7] * 100
+
+        def setmf():
+            param.mf = [7.0] * 100
+
+        import timeit
+        print("get int              ", timeit.timeit(lambda: param.i, number=100_000))
+        print("set int              ", timeit.timeit(seti, number=100_000))
+        print("get float            ", timeit.timeit(lambda: param.f, number=100_000))
+        print("set float            ", timeit.timeit(setf, number=100_000))
+        print("get list of 100 int  ", timeit.timeit(lambda: param.mi, number=100_000))
+        print("set list of 100 int  ", timeit.timeit(setmi, number=100_000))
+        print("get list of 100 float", timeit.timeit(lambda: param.mf, number=100_000))
+        print("set list of 100 float", timeit.timeit(setmf, number=100_000))
+
+        # failure so it shows up with ctest --output-on-failure
+        self.assertTrue(False)

--- a/Docs/developer_guide/index.md
+++ b/Docs/developer_guide/index.md
@@ -6,6 +6,7 @@
 api
 mrml_overview
 module_overview
+parameter_nodes
 modules/index
 extensions
 python_faq

--- a/Docs/developer_guide/mrml_overview.md
+++ b/Docs/developer_guide/mrml_overview.md
@@ -76,6 +76,10 @@ For more details, see [this page](https://www.slicer.org/wiki/Documentation/Nigh
 
 ## Advanced topics
 
+### Parameter Nodes
+
+Parameter nodes are a specific use of MRML nodes to store parameters for a given function/module. For more info see [Parameter Nodes](parameter_nodes.md#parameter-nodes).
+
 ### Scene undo/redo
 
 MRML Scene provides Undo/Redo mechanism that restores a previous state of the scene and individual nodes. By default, undo/redo is disabled and not displayed on the user interface, as it increased memory usage and was not tested thoroughly.

--- a/Docs/developer_guide/parameter_nodes.md
+++ b/Docs/developer_guide/parameter_nodes.md
@@ -1,0 +1,368 @@
+# Parameter Nodes
+
+## Overview
+
+Parameter nodes are often used in scripted modules to store data such that it can be easily saved to the MRML scene. They are simply MRML nodes that exist in a scene and store data. One of their most common uses is to save GUI state in module widgets.
+
+The parameter node concept is implemented in C++ in the `vtkMRMLScriptedModuleNode` which has `GetParameter` and `SetParameter` methods for saving arbitrary string data to the scene. While the base `vtkMRMLScriptedModuleNode` is
+great for scene saving, treating all data as strings is not ideal, so a parameter node wrapper was implemented.
+
+## Parameter Node Wrapper Classes
+
+The parameter node wrapper allows wrapping around a `vtkMRMLScriptedModuleNode` parameter node with typed member access. A simple example is as follows.
+
+```py
+import slicer
+from slicer.parameterNodeWrapper import *
+from MRMLCorePython import vtkMRMLModelNode
+
+@parameterNodeWrapper
+class CustomParameterNode:
+  numIterations: int
+  inputs: list[vtkMRMLModelNode]
+  output: vtkMRMLModelNode
+```
+
+This will create a new class called `CustomParameterNode` that has 3 members properties, an `int` named `numIterations`,
+a `list` of `vtkMRMLModelNode`s named `inputs`, and a `vtkMRMLModelNode` named `output`.
+
+The `@parameterNodeWrapper` decorator will generate a constructor for this class that takes one argument, a `vtkMRMLScriptedModuleNode` parameter node.
+
+Usage would be as follows:
+
+```py
+parameterNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScriptedModuleNode')
+param = CustomParameterNode(parameterNode)
+
+# can set the property directly from a variable of appropriate type
+param.numIterations = 500
+param.inputs = [slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelNode') for _ in range(5)]
+param.output = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelNode')
+
+# pythonic list usage
+for inputModel in param.inputs:
+  mesh = inputModel.GetMesh()
+  # ...
+
+for iteration in range(param.numIterations):
+  # run iteration
+
+param.output.SetAndObserveMesh(...)
+```
+
+### Syntax and usage
+
+The `@parameterNodeWrapper` decorator keys off of the type hints given in the class definition, similar to python's [dataclasses.dataclass](https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass) class.
+
+The classes that are recognized by default are
+
+- `int`
+- `float`
+- `str`
+- `bool`
+- `vtkMRMLNode` (including subclasses)
+- `list` (hinted as `list[int]`, `list[str]`, etc)
+- `pathlib.Path`
+- `pathlib.PosixPath`
+- `pathlib.WindowsPath`
+- `pathlib.PurePath`
+- `pathlib.PurePosixPath`
+- `pathlib.PureWindowsPath`
+
+Only lists of these types are recognized by default. For using lists of other types see [Custom Parameter Types](#custom-parameter-types). Nested lists are available via `list[list[int]]`.
+
+#### MRML nodes
+
+MRML nodes from non-core modules are supported, but to define a `parameterNodeWrapper` in the global space of a module (i.e. not inside a function) you can't use the classes from `slicer` namespace. This is because they are not added to the slicer namespace until after the class is created. Here is an example on how to use `vtkMRMLMarkupsFiducialNode`.
+
+```py
+from slicer.parameterNodeWrapper import *
+
+# Import from actual package instead of importing from "slicer"
+from vtkSlicerMarkupsModuleMRMLPython import vtkMRMLMarkupsFiducialNode
+
+@parameterNodeWrapper
+class CustomParameterNode:
+  markup: vtkMRMLMarkupsFiducialNode
+  markups: list[vtkMRMLMarkupsFiducialNode]
+```
+
+It is possible to use core MRML classes like `vtkMRMLModelNode` from the `slicer` namespace, but in these examples we've elected to get it from `MRMLCorePython` for consistency.
+
+#### Default values
+
+More information can be given to the `@parameterNodeWrapper` decorator by using Annotated types.
+`Annotated` is from the Python `typing` module and has the syntax
+`Annotated[actualtype, annotation1, annotation2, ...]`. The `typing` module doesn't give any
+annotations, so a number of type annotations were added to `slicer.parameterNodeWrapper`.
+For instance, default values can be given via the `Default` annotation.
+
+```py
+from typing import Annotated
+from slicer.parameterNodeWrapper import parameterNodeWrapper, Default
+
+@parameterNodeWrapper
+class CustomParameterNode:
+  numIterations: Annotated[int, Default(500)]
+```
+
+This will make the default value of the `numIterations` parameter 500. If the `numIterations` parameter already has a value in the `vtkMRMLScriptedModuleNode` passed to the constructor, then that value is used instead of the default.
+
+If a default is not set explicitly, the following values will be used:
+
+| Type                                             | Implicit default                                             |
+|--------------------------------------------------|--------------------------------------------------------------|
+| `int`                                            | `0`                                                          |
+| `float`                                          | `0.0`                                                        |
+| `str`                                            | `""`                                                         |
+| `bool`                                           | `False`                                                      |
+| `vtkMRMLNode` (including subclasses)             | `None`                                                       |
+| `list` (hinted as `list[int]`, `list[str]`, etc) | `[]` (empty list)                                            |
+| `pathlib.Path`                                   | `pathlib.Path()` (which is the current directory)            |
+| `pathlib.PosixPath`                              | `pathlib.PosixPath()` (which is the current directory)       |
+| `pathlib.WindowsPath`                            | `pathlib.WindowsPath()` (which is the current directory)     |
+| `pathlib.PurePath`                               | `pathlib.PurePath()` (which is the current directory)        |
+| `pathlib.PurePosixPath`                          | `pathlib.PurePosixPath()` (which is the current directory)   |
+| `pathlib.PureWindowsPath`                        | `pathlib.PureWindowsPath()` (which is the current directory) |
+
+#### Validators
+
+It can be useful to restrict the set of that values passed to a parameter node. These can be done with `Validator` annotations.
+
+```py
+from typing import Annotated
+from slicer.parameterNodeWrapper import parameterNodeWrapper, Minimum, Default
+
+@parameterNodeWrapper
+class CustomParameterNode:
+  numIterations: Annotated[int, Minimum(0), Default(500)]
+
+  # To have a list where the values in the list need to be validated
+  chosenFeatures: list[Annotated[str, Choice(["feat1", "feat2", "feat3"])]]
+```
+
+This will cause a `ValueError` to be raised if someone tried setting `numIterations` to a negative value.
+
+Multiple validators can be placed in the `Annotated` block and they will be run in the order they were placed.
+
+The list of built-in validators is as follows:
+
+| Class name                                                    | Description                                                                                                    |
+|---------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+|`NotNone()`                                                    | Ensures the value is not `None`.                                                                               |
+|`IsInstance(classtype)`/`IsInstance((class1type, class2type))` | Ensures the value is an instance of particular type or set of types.                                           |
+|`Minimum(value)`                                               | Ensures the value is greater than or equal to the given value.                                                 |
+|`Maximum(value)`                                               | Ensures the value is less than or equal to the given value.                                                    |
+|`WithinRange(minimum, maximum)`                                | Ensures the value is within the range given by minimum and maximum, inclusive.                                 |
+|`Choice(validChoices)`                                         | Ensures the value is contained in the given list of valid choices. `validChoices` can be any iterable.         |
+|`Exclude(invalidChoices)`                                      | Ensures the value is not contained in the given list of invalid choices. `invalidChoices` can be any iterable. |
+
+The built-in types have the following validators applied to them by default:
+
+| Type                                                  | Default validators                                                                 |
+|-------------------------------------------------------|------------------------------------------------------------------------------------|
+| `int`, `str`, `bool`, any of the `pathlib` path types | `NotNone()`, `IsInstance(type)`                                                    |
+| `float`                                               | `NotNone()`, `IsInstance((float, int))` (this allows implicit conversion from int) |
+| `vtkMRMLModelNode` (and subclasses)                   | `IsInstance(type)`                                                                 |
+
+### Custom Validators
+
+Custom validators can easily be created and used with the `parameterNodeWrapper`.
+
+```py
+import re
+from typing import Annotated
+from slicer.parameterNodeWrapper import parameterNodeWrapper, Validator
+
+# Custom validators must derive from the Validator class.
+class MatchesRegex(Validator):
+  def __init__(self, regex):
+    self.regex = regex
+  # Custom validators must implement a validate function that raises an Exception
+  # if the given value is invalid.
+  def validate(self, value):
+    if re.match(self.regex, value) is None:
+      raise ValueError("Did not match regex")
+
+@parameterNodeWrapper
+class CustomParameterNode:
+  value: Annotated[str, MatchesRegex("[abc]+"), Default("abcba")]
+
+
+param = CustomParameterNode(slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScriptedModuleNode'))
+
+param.value = "abcabc" # ok
+param.value = "d" # ValueError raised
+```
+
+### Custom Parameter Types
+
+Custom parameters can be supported with a little bit of work.
+
+```py
+import dataclasses
+from typing import Annotated
+import slicer
+from slicer.parameterNodeWrapper import parameterNodeWrapper, Serializer, ValidatedSerializer
+
+@dataclasses.dataclass
+class CustomClass:
+  x: int
+  y: int
+  z: int
+
+# The Serializer class is used to read and write the values to the underlying 
+# vtkMRMLScriptedModuleNode. There are built-in serializers for each of the support built-in types.
+# Adding a new serializer involves deriving from Serializer and implementing the following methods.
+# The @parameterNodeSerializer decorator registers the serializer so it can be found by a
+# parameterNodeWrapper.
+@parameterNodeSerializer
+class CustomClassSerializer(Serializer):
+  @staticmethod
+  def canSerialize(type_) -> bool:
+    """
+    Whether the serializer can serialize the given type if it is properly instantiated.
+    """
+    return type_ == CustomClass
+
+  @staticmethod
+  def create(type_):
+    """
+    Creates a new serializer object based on the given type. If this class does not support the given type,
+    None is returned.
+
+    It is common for the returned type to actually be a ValidatedSerializer wrapping this serializer that implements
+    any default validators (NotNone and IsInstance are common).
+    """
+    if CustomClassSerializer.canSerialize(type_):
+      # in our example, lets say that we don't allow None. We will use NotNone() to enforce this
+      return ValidatedSerializer(CustomClassSerializer(), [NotNone(), IsInstance(CustomClass)])
+    return None
+
+  def default(self):
+    """
+    The default value to use if another default is not specified.
+    """
+    return CustomClass(0, 0, 0)
+
+  def isIn(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> bool:
+    """
+    Whether the parameterNode contains a parameter of the given name.
+    Note that most implementations can just use parameterNode.HasParameter(name).
+    """
+    return parameterNode.HasParameter(name)
+  def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value) -> None:
+    """
+    Writes the value to the parameterNode under the given name.
+    Note: It is acceptable to mangle the name as long the same name can be used for reading.
+    For example the built-in ListSerializer does this.
+    """
+    parameterNode.SetParameter(name, f"{value.x},{value.y},{value.z}")
+  def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str):
+    """
+    Reads and returns the value with the given name from the parameterNode.
+    """
+    val = parameterNode.GetParameter(name)
+    vals = val.split(',')
+    return CustomClass(int(vals[0]), int(vals[1]), int(vals[2]))
+  def remove(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> None:
+    """
+    Removes the value of the given name from the parameterNode.
+    """
+    parameterNode.UnsetParameter(name)
+
+@parameterNodeWrapper
+class CustomClassParameterNode(object):
+  # can now use CustomClass like any other type for building parameterNodeWrappers
+  custom: Annotated[CustomClass, Default(CustomClass(1,2,3))]
+  listOfCustom: list[CustomClass]
+
+```
+
+### Caching
+
+The `vtkMRMLScriptedModuleNode` stores its values as strings, but converting from string to another
+type can be slow. Caching is used to reduce repeated costly reads under the hood. If a value hasn't been written through the _parameter node wrapper_ since the last read, then it will use the cached value. Note this means if the underlying `vtkMRMLScriptedModuleNode` parameter node changes outside of the wrapper, the cache will not be updated and the cached value will be wrong.
+
+This is the chosen behavior for the following reasons:
+
+- Mixed usage of the parameter node wrapper and the `vtkMRMLScriptedModuleNode` parameter node for the same parameter node is not expected.
+- The `vtkMRMLScriptedModuleNode` parameter node does not offer per parameter VTK event callbacks. Therefore, if a callback was setup off the `ModifiedEvent`, _all_ parameters would be re-read for _every_ write to _any_ parameter in the node.
+    - The `vtkMRMLScriptedModuleNode` parameter node may be updated in the future to give a `ParameterModifiedEvent` that gives the parameter that was modified. If this happens, the caching behavior may be revisited.
+
+
+Because Python objects are returned by reference, when a cached value is returned and then modified, the modification needs to be written back to the parameter node. Otherwise, the cached value and the parameter node will get out of sync.
+
+This write-on-change behavior has been implemented for the ListSerializer. The ListSerializer does not actually return a `list`, it returns an `ObservedList` that updates the parameter node whenever it is modified. `ObservedList` implements most `list` functions. This allows the following to work seamlessly:
+
+```py
+@parameterNodeWrapper
+class ParameterNodeType(object):
+  values: list[int]
+
+param = ParameterNodeType(slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScriptedModuleNode'))
+values = param.values
+values.append(4)
+values += [7, 10]
+
+param.values == values # True
+param.values == [4, 7, 10] # True
+```
+
+The following methods are available for `ObservedList`:
+- `__repr__`
+- `__str__`
+- `__eq__` (this will compare the contents of the list for equality)
+- `__len__`
+- `__getitem__`
+- `__delitem__`
+- `__setitem__`
+- `__iadd__`
+- `__imul__`
+- `append`
+- `extend`
+- `insert`
+- `remove`
+- `pop`
+- `clear`
+- `sort`
+- `reverse`
+
+Similarly for a parameter of `list[list[type]]`, an `ObservedList[ObservedList[type]]` is returned.
+When calling `param.values.append`, `param.values[index] = object` or `+=` in these cases, a normal `list` can be passed in and it will be converted to an `ObservedList`.
+
+#### Caching for custom classes
+
+Caching is disabled for classes that use custom serializers by default, as we do not assume that they have implemented a write-on-change functionality for their cached values. For this reason, if the `ListSerializer` uses a custom serializer for its elements, it will also disable caching by default.
+
+If a custom serializer does implement write-on-change functionality, it can take advantage of the built-in caching mechanism quite easily (including for lists of the custom class).
+
+```py
+class CustomClassSerializer(Serializer):
+  @staticmethod
+  def canSerialize(type_) -> bool:
+    # implementation
+  @staticmethod
+  def create(type_):
+    # implementation
+  def default(self):
+    # implementation
+  def isIn(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> bool:
+    # implementation
+  def write(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str, value) -> None:
+    # implementation
+  def read(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str):
+    # implementation that supports caching
+  def remove(self, parameterNode: slicer.vtkMRMLScriptedModuleNode, name: str) -> None:
+    # implementation
+
+  # Add the following method override to enable caching in cases of "value: CustomClass" and "value: list[CustomClass]" (and list[list[CustomClass]] and so on).
+  def supportsCaching(self):
+    return True
+```
+
+## Troubleshooting
+
+### 'slicer' has no attribute '\<MRML node name\>'
+
+You can't use non-core MRML nodes out of the slicer namespace. See [MRML nodes](#mrml-nodes) for more info.

--- a/Libs/MRML/Core/vtkMRMLScriptedModuleNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScriptedModuleNode.cxx
@@ -138,6 +138,12 @@ void vtkMRMLScriptedModuleNode::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
+bool vtkMRMLScriptedModuleNode::HasParameter(const std::string& name) const
+{
+  return this->Parameters.count(name) > 0;
+}
+
+//----------------------------------------------------------------------------
 void vtkMRMLScriptedModuleNode
 ::SetParameter(const std::string& name, const std::string& value)
 {

--- a/Libs/MRML/Core/vtkMRMLScriptedModuleNode.h
+++ b/Libs/MRML/Core/vtkMRMLScriptedModuleNode.h
@@ -51,6 +51,11 @@ public:
   vtkGetStringMacro (ModuleName);
   vtkSetStringMacro (ModuleName);
 
+  /// Whether the parameter has been set.
+  ///
+  /// If the parameter has been set and then unset, this will return false.
+  bool HasParameter(const std::string& name) const;
+
   /// Set module parameter
   void SetParameter(const std::string& name, const std::string& value);
 

--- a/Modules/Scripted/VectorToScalarVolume/CMakeLists.txt
+++ b/Modules/Scripted/VectorToScalarVolume/CMakeLists.txt
@@ -18,3 +18,12 @@ slicerMacroBuildScriptedModule(
   RESOURCES ${MODULE_PYTHON_RESOURCES}
   WITH_GENERIC_TESTS
   )
+
+#-----------------------------------------------------------------------------
+if(BUILD_TESTING)
+
+  # Register the unittest subclass in the main script as a ctest.
+  # Note that the test will also be available at runtime.
+  slicer_add_python_unittest(SCRIPT ${MODULE_NAME}.py)
+
+endif()


### PR DESCRIPTION
Adds a Python parameter node wrapper that offers access to typed properties instead of going through strings and manually serializing/deserializing to string manually.

Adds tests for the wrapper.

Updates VectorToScalarVolume to use new parameter node as an example of use (the tests also serve as example).

I have added a `parameter_nodes.md` file documenting purpose, usage, and extensibility, but would like recommendations on where would be good to link to it from.

Closes https://github.com/Slicer/Slicer/issues/6665