### PR TITLE
COMP: Fix macOS signing with webengine support disabled

### DIFF
--- a/CMake/SlicerCPackBundleFixup.cmake.in
+++ b/CMake/SlicerCPackBundleFixup.cmake.in
@@ -319,10 +319,11 @@ function(fixup_bundle_with_plugins app)
     # Since BundleUtilities function do not copy the "Helpers" directory found
     # in frameworks. The following will explicitly copy and fixup
     # QtWebEngineCore.framework/Versions/5/Helpers/QtWebEngineProcess.app
+    set(Slicer_BUILD_WEBENGINE_SUPPORT "@Slicer_BUILD_WEBENGINE_SUPPORT@")
     set(qtwebenginecore_app_subdir "Helpers/QtWebEngineProcess.app")
     set(qtwebenginecore_src_dir "${qt_root_dir}/QtWebEngineCore.framework/${qtwebenginecore_app_subdir}")
     set(qtwebenginecore_dest_dir "${app_dir}/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/${qtwebenginecore_app_subdir}")
-    if(EXISTS ${qtwebenginecore_src_dir})
+    if(Slicer_BUILD_WEBENGINE_SUPPORT AND EXISTS ${qtwebenginecore_src_dir})
       file(COPY "${qtwebenginecore_src_dir}/Contents" DESTINATION "${qtwebenginecore_dest_dir}/" USE_SOURCE_PERMISSIONS)
       set(qtwebengineprocess_executable "${qtwebenginecore_dest_dir}/Contents/MacOS/QtWebEngineProcess")
       # Collect list of Qt framework dependencies


### PR DESCRIPTION
This commit fix the following `codesign` error reported when attempting to sign a Slicer application package build with `Slicer_BUILD_WEBENGINE_SUPPORT` set to `OFF`.

For reference, the regression was introduced in 100f8268d (`BUG: Update macOS fixup script to package QtWebEngineProcess.app`) and exerted following the updated of the macOS signing server to macOS 12.

Error:

```
$ ./slicer-macos-codesign-scripts/sign.bash \
  ${identifier} ${version} \
[...]
--   Signing App
/Volumes/tmp.9dkIOBNj/Slicer.app: bundle format unrecognized, invalid, or unsuitable
In subcomponent: /Volumes/tmp.9dkIOBNj/Slicer.app/Contents/Frameworks/QtWebEngineCore.framework
```