### PR TITLE
BUG: Remove custom handling for redirect of vX.Y URL without slash

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -21,7 +21,7 @@ Checklist **Installers Release**:
 * [ ] `CMakeLists.txt`: [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#cmakeliststxt-update-the-slicer-version-information-for-the-development) the Slicer version information for the development.
 * [ ] [Tag and publish](https://github.com/Slicer/Slicer/wiki/Release-Process#tag-and-publish-slicerbuildenvironment-docker-image) SlicerBuildEnvironment docker image.
 * [ ] Create maintenance branch called `X.Y` (e.g `5.0`) based of the first tag of the `X.Y` series.
-* [ ] Update readthedocs: [Activate](https://readthedocs.org/projects/slicer/versions/) the build of the `X.Y` maintenance branch in readthedocs, and add a [redirect](https://readthedocs.org/dashboard/slicer/redirects/) of type _Exact Redirects_ from `/en/vX.Y/$rest` to `/en/X.Y/` (for example `/en/v5.0/$rest` to `/en/5.0/`).
+* [ ] Update readthedocs: [Activate](https://readthedocs.org/projects/slicer/versions/) the build of the `X.Y` maintenance branch in readthedocs, and add a [redirect](https://readthedocs.org/dashboard/slicer/redirects/) of type _Exact Redirects_ from `/en/vX.Y$rest` to `/en/X.Y`.
 * [ ] [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#update-release-scripts) release scripts.
 * [ ] [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#update-extensionsindex) ExtensionsIndex: Create `5.0` branch
 * [ ] Update CDash: Add `Extensions-X.Y-Nightly` group (e.g `Extensions-5.0-Nightly`) to https://slicer.cdash.org/index.php?project=SlicerStable

--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -112,14 +112,7 @@ if os.environ.get('EXCLUDE_API_REFERENCE', False) == 'True':
 # https://github.com/readthedocs/sphinx-notfound-page
 notfound_context = {
     'title': 'Page Not Found',
-    'body': r'''
-<script type="text/javascript">
-  // Workaround https://github.com/readthedocs/readthedocs.org/issues/9507
-  const regex = /^https:\/\/slicer\.readthedocs\.io\/\w+\/v\d\.\d$/;
-  if (regex.test(window.location)) {
-    window.location.replace(window.location + "/");
-  }
-</script>
+    'body': '''
 <h1>Page Not Found</h1>
 <p>Sorry, we couldn't find that page.</p>
 <p>Try using the search box or go to the homepage.</p>


### PR DESCRIPTION
This reverts commit a3b7544ec (`BUG: Update sphinx custom 404 page to handle redirect of vX.Y URL without slash`) and instead update the readthedoc configuration setting up the redirect:

```
/en/v5.0$rest -> /en/5.0
```

instead of

```
/en/v5.0/$rest -> /en/5.0/
```

Related issues and pull requests:

* https://github.com/readthedocs/readthedocs.org/issues/9507#issuecomment-1322888048
* https://github.com/Slicer/Slicer/pull/6504