### PR TITLE
[5.2.1] BUG: Fix joint smoothing in Segment Editor

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorSmoothingEffect.py
@@ -456,7 +456,9 @@ If segments overlap, segment higher in the segments table will have priority. <b
         oldOverwriteMode = self.scriptedEffect.parameterSetNode().GetOverwriteMode()
         self.scriptedEffect.parameterSetNode().SetOverwriteMode(slicer.vtkMRMLSegmentEditorNode.OverwriteVisibleSegments)
         for segmentId, labelValue in segmentLabelValues:
-            threshold.ThresholdBetween(labelValue, labelValue)
+            threshold.SetLowerThreshold(labelValue)
+            threshold.SetUpperThreshold(labelValue)
+            threshold.SetThresholdFunction(vtk.vtkThreshold.THRESHOLD_BETWEEN)
             stencil.Update()
             smoothedBinaryLabelMap = slicer.vtkOrientedImageData()
             smoothedBinaryLabelMap.ShallowCopy(stencil.GetOutput())


### PR DESCRIPTION
Regression occurred due to VTK API change (ThresholdBetween method was removed from vtkThreshold).

This is a pretty important feature, so we'll need a 5.2.1 patch release soon.