### PR TITLE
DOC: Tweak "patch-release" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch-release.md
+++ b/.github/ISSUE_TEMPLATE/patch-release.md
@@ -11,25 +11,33 @@ assignees: ''
 
 _Based on the state of the relevant sub-tasks, consider updating the issue description changing `:question:` (:question:)  into either `:hourglass:` (:hourglass:) or `:heavy_check_mark:` (:heavy_check_mark:)._
 
-Checklist **Patch Release**:
+Checklist **Installers Release**:
 
 * [ ] [Pin](https://docs.github.com/en/enterprise-cloud@latest/issues/tracking-your-work-with-issues/pinning-an-issue-to-your-repository) this issue
+* [ ] [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#update-release-in-progress-post) the `Release in progress` post.
+* [ ] [Disable](https://github.com/Slicer/Slicer/wiki/Release-Process#enable-or-disable-regular-nightly-builds) regular nightly builds
 * [ ] `CMakeLists.txt`: [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#cmakeliststxt-update-the-slicer-version-information-for-the-release) the Slicer version information for the release.
 * [ ] [Tag](https://github.com/Slicer/Slicer/wiki/Release-Process#tag-the-repository) the repository with `vX.Y.Z`.
-* [ ] `CMakeLists.txt`: [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#cmakeliststxt-update-the-slicer-version-information-for-the-development) the Slicer version information for the development.
 * [ ] [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#update-release-scripts) release scripts.
 * [ ] [Generate](https://github.com/Slicer/Slicer/wiki/Release-Process#generate-application-and-extension-packages) application and extension packages. See https://slicer.cdash.org/index.php?project=SlicerStable&date=YYYY-MM-DD
   * Linux: :question:
   * macOS: :question:
   * Windows: :question:
+* [ ] Update [Release Details](https://github.com/Slicer/Slicer/wiki/Release-Details) on the Slicer GitHub wiki.
+
+Checklist **Post Release**:
+
+_These steps will take place in the week following **Installers Release** steps_
+
+* [ ] [Re-enable](https://github.com/Slicer/Slicer/wiki/Release-Process#enable-or-disable-regular-nightly-builds) regular nightly builds
 * [ ] Manually [sign the packages](https://github.com/Slicer/Slicer/wiki/Signing-Application-Packages)
   * Linux: NA
   * macOS: signed :question:, notarized :question:
   * Windows: :question:
 * [ ] [Create](https://github.com/Slicer/Slicer/wiki/Release-Process#create-release-or-patch-release-on-slicer-packageskitwarecom) release `X.Y.Z` on [slicer-packages.kitware.com](https://slicer-packages.kitware.com/#folder/5f4474d0e1d8c75dfc705482).
-* [ ] [Copy](https://slicer-package-manager.readthedocs.io/en/latest/faq.html#how-to-create-a-new-release-with-existing-uploaded-packages) application & extension packages from `draft` into the new release created on `slicer-packages.kitware.com`.
+* [ ] [Copy](https://github.com/Slicer/Slicer/wiki/Release-Process#copy-draft-application--extension-packages-into-the-new-release-folder) application & extension packages from `draft` into the new release created on `slicer-packages.kitware.com`.
 * [ ] Upload signed release packages in the release folder: For the relevant `Slicer_<os>_<arch>_<revision>` items, replace the content by uploading the signed release packages. The _Replace file content_ action is available in the `Files & links`.
 * [ ] [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#update-extensionstats-module) `ExtensionStats` module from
 * [ ] [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#update-external-websites) external websites
-* [ ] Update [Release Details](https://github.com/Slicer/Slicer/wiki/Release-Details) on the Slicer GitHub wiki.
+* [ ] Finalize Slicer Announcement
 * [ ] Unpin this issue

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -21,7 +21,7 @@ Checklist **Installers Release**:
 * [ ] [Tag](https://github.com/Slicer/Slicer/wiki/Release-Process#tag-the-repository) the repository with `vX.Y.0`.
 * [ ] `CMakeLists.txt`: [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#cmakeliststxt-update-the-slicer-version-information-for-the-development) the Slicer version information for the development.
 * [ ] [Tag and publish](https://github.com/Slicer/Slicer/wiki/Release-Process#tag-and-publish-slicerbuildenvironment-docker-image) SlicerBuildEnvironment docker image.
-* [ ] [Create](https://github.com/Slicer/Slicer/wiki/Release-Process#create-maintenance-branch) maintenance branch called `X.Y` based of the first tag of the `X.Y` series.
+* [ ] [Create](https://github.com/Slicer/Slicer/wiki/Release-Process#create-maintenance-branch) maintenance branch called `X.Y` based on the first tag of the `X.Y` series.
 * [ ] Update readthedocs: [Activate](https://readthedocs.org/projects/slicer/versions/) the build of the `X.Y` maintenance branch in readthedocs, and add a [redirect](https://readthedocs.org/dashboard/slicer/redirects/) of type _Exact Redirects_ from `/en/vX.Y$rest` to `/en/X.Y`.
 * [ ] [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#update-release-scripts) release scripts.
 * [ ] [Update](https://github.com/Slicer/Slicer/wiki/Release-Process#update-extensionsindex) ExtensionsIndex: Create `X.Y` branch


### PR DESCRIPTION
Integrates changes collected while working on the `5.2.1` patch release.

Split **Patch Release** into **Installers Release** and **Post Release** to mirror the [release](https://github.com/Slicer/Slicer/blob/main/.github/ISSUE_TEMPLATE/release.md) issue template.

-------------

In **Installers Release** checklist:

* Add update of `Release in progress` post See https://github.com/Slicer/Slicer/wiki/Release-Process#update-release-in-progress-post

* Add "Disable regular nightly builds"

* Remove the update of the Slicer version information for the development. This is irrelevant in the context of patch releases since the commit are directly added to the X.Y maintenance branch.

* Move update of "Release Details" into this section.

-------------

In **Post Release** checklist:

* Add "Re-enable of regular nightly builds" to go with their disablement

* Add dedicated wiki section for copying packages. See https://github.com/Slicer/Slicer/wiki/Release-Process#copy-draft-application--extension-packages-into-the-new-release-folder