### PR TITLE
STYLE: Fix python linting issue

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -27,46 +27,46 @@ per-file-ignores = \
   Extensions/*/__init__.py:F401 \
   Utilities/*/__init__.py:F401
 
-ignore = \
+ignore =
   # Do not use bare `except:`, it also catches unexpected events like memory errors, interrupts, system exit, and so on.
-  B001, \
+  B001,
   # Do not use mutable data structures for argument defaults.
-  B006, \
+  B006,
   # Loop control variable not used within the loop body.
-  B007, \
+  B007,
   # Do not perform function calls in argument defaults.
-  B008, \
+  B008,
   # Do not call getattr(x, 'attr'), instead use normal property access: x.attr.
-  B009, \
-  # B010] Do not call setattr with a constant attribute value, it is not any safer than normal property access.
-  B010, \
+  B009,
+  # Do not call setattr with a constant attribute value, it is not any safer than normal property access.
+  B010,
   # multiple imports on one line
-  E401, \
+  E401,
   # module level import not at top of file
-  E402, \
+  E402,
   # the backslash is redundant between bracket
-  E502, \
+  E502,
   # do not use bare 'except'
-  E722, \
+  E722,
   # do not assign a lambda expression, use a def
-  E731, \
+  E731,
   # 'from module import *' used; unable to detect undefined names
-  F403, \
+  F403,
   # Name may be undefined, or defined from star import
-  F405, \
+  F405,
   # f-string is missing placeholders
-  F541, \
+  F541,
   # Redefinition of unused name from line n
-  F811, \
+  F811,
   # Undefined name name
-  F821, \
+  F821,
   # local variable 'inside_segment' is assigned to but never used
-  F841, \
+  F841,
   # trailing whitespace
-  W291, \
+  W291,
   # blank line contains whitespace
-  W293, \
+  W293,
   # line break before binary operator
-  W503, \
+  W503,
   # line break after binary operator
   W504

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: "v4.3.0"
+  rev: "v4.4.0"
   hooks:
   - id: check-added-large-files
     args: ['--maxkb=1024']
@@ -9,13 +9,13 @@ repos:
   - id: check-symlinks
 
 - repo: https://github.com/PyCQA/flake8
-  rev: "5.0.4"
+  rev: "6.0.0"
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear==22.9.23]
+    additional_dependencies: [flake8-bugbear==22.10.27]
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.1.0
+  rev: v3.2.2
   hooks:
   - id: pyupgrade
     args: [--py39-plus]

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -3478,7 +3478,6 @@ def logProcessOutput(proc):
     :param proc: process object.
     """
     from subprocess import CalledProcessError
-    import logging
     try:
         from slicer import app
         guiApp = app


### PR DESCRIPTION
Base/Python/slicer/util.py:3481: [F401] 'logging' imported but unused

Introduced in https://github.com/Slicer/Slicer/commit/f9dcc53b560a5f1d3f933a81c514175aed65a127

`ENH: Update pre--commit hook versions to latest` manually updates the hooks. An automated method of updating these has not been completed and is work captured in #6599.