### PR TITLE
COMP: Switch from zlib 1.2.3 to maintained zlib-ng 2.2.4 fork

### DIFF
--- a/SuperBuild/External_zlib.cmake
+++ b/SuperBuild/External_zlib.cmake
@@ -27,13 +27,13 @@ if(NOT DEFINED ZLIB_ROOT AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/commontk/zlib.git"
+    "${EP_GIT_PROTOCOL}://github.com/Slicer/zlib-ng.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "66a753054b356da85e1838a081aa94287226823e"
+    "de0aca6040339aad56d96ab1c29850b00ec36a9b"  # slicer-2.2.4-2025-02-10-860e4cf
     QUIET
     )
 
@@ -45,11 +45,17 @@ if(NOT DEFINED ZLIB_ROOT AND NOT Slicer_USE_SYSTEM_${proj})
     BINARY_DIR ${EP_BINARY_DIR}
     INSTALL_DIR ${EP_INSTALL_DIR}
     CMAKE_CACHE_ARGS
+      # Compiler settings
       ## CXX should not be needed, but it a cmake default test
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
       -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
-      -DZLIB_MANGLE_PREFIX:STRING=slicer_zlib_
+      # Options
+      -DBUILD_SHARED_LIBS:BOOL=OFF
+      -DZLIB_SYMBOL_PREFIX:STRING=slicer_zlib_
+      -DZLIB_COMPAT:BOOL=ON
+      -DZLIB_ENABLE_TESTS:BOOL=OFF
+      # Install directories
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     DEPENDS
       ${${proj}_DEPENDENCIES}
@@ -63,7 +69,7 @@ if(NOT DEFINED ZLIB_ROOT AND NOT Slicer_USE_SYSTEM_${proj})
   if(WIN32)
     set(ZLIB_LIBRARY ${zlib_DIR}/lib/zlib.lib)
   else()
-    set(ZLIB_LIBRARY ${zlib_DIR}/lib/libzlib.a)
+    set(ZLIB_LIBRARY ${zlib_DIR}/lib/libz.a)
   endif()
 else()
   # The project is provided using zlib_DIR, nevertheless since other project may depend on zlib,


### PR DESCRIPTION
## Background
Slicer is currently using zlib version 1.2.3 originally released July 18th, 2005. Slicer has been using a [fork](https://github.com/commontk/zlib) in the CommonTK repo where zlib was CMake'ified since at least 2012. Since then zlib has made it onto GitHub at https://github.com/madler/zlib and also utilizes CMake. The latest release is [1.2.13](https://github.com/madler/zlib/tree/v1.2.13) released on Oct 13th, 2022.

## Changes in this PR
This PR updates zlib used in Slicer to now be the modern forked version known as [zlib-ng](https://github.com/zlib-ng/zlib-ng).  Read the [history](https://github.com/zlib-ng/zlib-ng#history) about zlib-ng. I have configured zlib-ng to be built in zlib-compat mode rather than zlib-ng native mode. This decision matches what ITK has done as they switched to using zlib-ng as part of the ITK 5.3.0 release. You can review the [PORTING](https://github.com/zlib-ng/zlib-ng/blob/b3dcf11b4204a16fde71fa8224d7b7054e225b93/PORTING.md) instructions to learn more about the advantages/disadvantages/considerations about the two main build options.

The version of zlib-ng being used here is based on https://github.com/zlib-ng/zlib-ng/commit/b3dcf11b4204a16fde71fa8224d7b7054e225b93 which is the same version that ITK 5.3.0 is using. This is along the zlib-ng 2.1.0 development period and zlib-ng is currently using zlib version 1.2.12 as their base. I'm currently using a fork of zlib-ng with a slight code change that matches https://github.com/InsightSoftwareConsortium/ITK/commit/3bcc933052bbe0c5d303af6ab948704450471788 to make it work in Slicer, but someone might find a better configuration or other changes to avoid this slight code change. If the code change is maintained, I suggest creating a new forked version of zlib-ng in the Slicer GitHub organization rather than using the one under my name.

Using the Slicer python console, the zlib version can be reviewed by doing the following:
```python
import zlib
# [Qt] Python console user input: import zlib
zlib.ZLIB_VERSION
# '1.2.12.zlib-ng'
# [Qt] Python console user input: zlib.ZLIB_VERSION
```

## Testing:
I have built on Windows successfully and all tests continued to pass for me (`1>100% tests passed, 0 tests failed out of 662`). If someone could provide additional testing on the macOS and Linux platforms that would be great.

## Other references:
- zlib-ng [license](https://github.com/zlib-ng/zlib-ng/blob/develop/LICENSE.md)
- ITK's implementation https://github.com/InsightSoftwareConsortium/ITK/tree/v5.3.0/Modules/ThirdParty/ZLIB/src

## Proposed Next Steps:
- Archive the https://github.com/commontk/zlib project and point users to https://github.com/madler/zlib or the more modern replacement https://github.com/zlib-ng/zlib-ng