### PR TITLE
ENH: add simple vertical slice controller widget

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -2525,3 +2525,43 @@ vtkMRMLSliceDisplayNode* vtkMRMLSliceLogic::GetSliceDisplayNode()
 {
   return vtkMRMLSliceDisplayNode::SafeDownCast(this->GetSliceModelDisplayNode());
 }
+
+
+//----------------------------------------------------------------------------
+bool vtkMRMLSliceLogic::GetSliceOffsetRangeResolution(double range[2], double& resolution)
+{
+  // Calculate the number of slices in the current range.
+  // Extent is between the farthest voxel centers (not voxel sides).
+  double sliceBounds[6] = {0, -1, 0, -1, 0, -1};
+  this->GetLowestVolumeSliceBounds(sliceBounds, true);
+
+  const double * sliceSpacing = this->GetLowestVolumeSliceSpacing();
+  if (!sliceSpacing)
+    {
+    range[0] = -1.0;
+    range[1] = 1.0;
+    resolution = 1.0;
+    return false;
+    }
+
+  // Set the scale increments to match the z spacing (rotated into slice space)
+  resolution = sliceSpacing ? sliceSpacing[2] : 1.0;
+
+  bool singleSlice = ((sliceBounds[5] - sliceBounds[4]) < resolution);
+  if (singleSlice)
+    {
+    // add one blank slice before and after the current slice to make the slider appear in the center when
+    // we are centered on the slice
+    double centerPos = (sliceBounds[4] + sliceBounds[5]) / 2.0;
+    range[0] = centerPos - resolution;
+    range[1] = centerPos + resolution;
+    }
+  else
+    {
+    // there are at least two slices in the range
+    range[0] = sliceBounds[4];
+    range[1] = sliceBounds[5];
+    }
+
+  return true;
+}

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -382,6 +382,10 @@ public:
   /// a volume is not editable (even if it is visible at the given position).
   int GetEditableLayerAtWorldPosition(double worldPos[3], bool backgroundVolumeEditable = true, bool foregroundVolumeEditable = true);
 
+  /// Get range and resolution for slice offset sliders.
+  /// Returns false if the information cannot be determined.
+  bool GetSliceOffsetRangeResolution(double range[2], double& resolution);
+
 protected:
 
   vtkMRMLSliceLogic();

--- a/Libs/MRML/Widgets/CMakeLists.txt
+++ b/Libs/MRML/Widgets/CMakeLists.txt
@@ -170,6 +170,8 @@ set(MRMLWidgets_SRCS
   qMRMLSliceInformationWidget.cxx
   qMRMLSliceInformationWidget.h
   qMRMLSliceInformationWidget_p.h
+  qMRMLSliceVerticalControllerWidget.cxx
+  qMRMLSliceVerticalControllerWidget.h
   qMRMLSliceView.cxx
   qMRMLSliceView.h
   qMRMLSliceView_p.h
@@ -294,6 +296,7 @@ set(MRMLWidgets_MOC_SRCS
   qMRMLSliceControllerWidget_p.h
   qMRMLSliceInformationWidget.h
   qMRMLSliceInformationWidget_p.h
+  qMRMLSliceVerticalControllerWidget.h
   qMRMLSliceView.h
   qMRMLSliceView_p.h
   qMRMLSliceWidget.h
@@ -351,6 +354,7 @@ set(MRMLWidgets_UI_SRCS
   Resources/UI/qMRMLSegmentSelectorWidget.ui
   Resources/UI/qMRMLSliceControllerWidget.ui
   Resources/UI/qMRMLSliceInformationWidget.ui
+  Resources/UI/qMRMLSliceVerticalControllerWidget.ui
   Resources/UI/qMRMLSliceWidget.ui
   Resources/UI/qMRMLTableViewControllerWidget.ui
   Resources/UI/qMRMLThreeDViewControllerWidget.ui

--- a/Libs/MRML/Widgets/DesignerPlugins/CMakeLists.txt
+++ b/Libs/MRML/Widgets/DesignerPlugins/CMakeLists.txt
@@ -75,6 +75,8 @@ set(${KIT}_SRCS
   qMRMLSliceControllerWidgetPlugin.h
   qMRMLSliceInformationWidgetPlugin.cxx
   qMRMLSliceInformationWidgetPlugin.h
+  qMRMLSliceVerticalControllerWidgetPlugin.cxx
+  qMRMLSliceVerticalControllerWidgetPlugin.h
   qMRMLSliceWidgetPlugin.cxx
   qMRMLSliceWidgetPlugin.h
   qMRMLSliderWidgetPlugin.cxx
@@ -142,6 +144,7 @@ set(${KIT}_MOC_SRCS
   qMRMLSceneFactoryWidgetPlugin.h
   qMRMLSliceControllerWidgetPlugin.h
   qMRMLSliceInformationWidgetPlugin.h
+  qMRMLSliceVerticalControllerWidgetPlugin.h
   qMRMLSliceWidgetPlugin.h
   qMRMLSliderWidgetPlugin.h
   qMRMLSpinBoxPlugin.h

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliceVerticalControllerWidgetPlugin.cxx
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliceVerticalControllerWidgetPlugin.cxx
@@ -1,0 +1,48 @@
+#include "qMRMLSliceVerticalControllerWidgetPlugin.h"
+#include "qMRMLSliceVerticalControllerWidget.h"
+
+// --------------------------------------------------------------------------
+qMRMLSliceVerticalControllerWidgetPlugin::qMRMLSliceVerticalControllerWidgetPlugin(QObject *_parent)
+  : QObject(_parent)
+{
+}
+
+// --------------------------------------------------------------------------
+QWidget *qMRMLSliceVerticalControllerWidgetPlugin::createWidget(QWidget *_parent)
+{
+  qMRMLSliceVerticalControllerWidget* _widget = new qMRMLSliceVerticalControllerWidget(_parent);
+  return _widget;
+}
+
+// --------------------------------------------------------------------------
+QString qMRMLSliceVerticalControllerWidgetPlugin::domXml() const
+{
+  return  "<ui language=\"c++\">\n"
+    "<widget class=\"qMRMLSliceVerticalControllerWidget\" name=\"MRMLSliceVerticalControllerWidget\">\n"
+    "</widget>\n"
+    "</ui>\n";
+}
+
+// --------------------------------------------------------------------------
+QIcon qMRMLSliceVerticalControllerWidgetPlugin::icon() const
+{
+  return QIcon();
+}
+
+// --------------------------------------------------------------------------
+QString qMRMLSliceVerticalControllerWidgetPlugin::includeFile() const
+{
+  return "qMRMLSliceVerticalControllerWidget.h";
+}
+
+// --------------------------------------------------------------------------
+bool qMRMLSliceVerticalControllerWidgetPlugin::isContainer() const
+{
+  return false;
+}
+
+// --------------------------------------------------------------------------
+QString qMRMLSliceVerticalControllerWidgetPlugin::name() const
+{
+  return "qMRMLSliceVerticalControllerWidget";
+}

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliceVerticalControllerWidgetPlugin.h
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLSliceVerticalControllerWidgetPlugin.h
@@ -1,0 +1,23 @@
+#ifndef __qMRMLSliceVerticalControllerWidgetPlugin_h
+#define __qMRMLSliceVerticalControllerWidgetPlugin_h
+
+#include "qMRMLWidgetsAbstractPlugin.h"
+
+class QMRML_WIDGETS_PLUGINS_EXPORT qMRMLSliceVerticalControllerWidgetPlugin : public QObject,
+                                                                              public qMRMLWidgetsAbstractPlugin
+{
+  Q_OBJECT
+
+public:
+  qMRMLSliceVerticalControllerWidgetPlugin(QObject *_parent = nullptr);
+
+  QWidget *createWidget(QWidget *_parent) override;
+  QString  domXml() const override;
+  QIcon    icon() const override;
+  QString  includeFile() const override;
+  bool     isContainer() const override;
+  QString  name() const override;
+
+};
+
+#endif

--- a/Libs/MRML/Widgets/DesignerPlugins/qMRMLWidgetsPlugin.h
+++ b/Libs/MRML/Widgets/DesignerPlugins/qMRMLWidgetsPlugin.h
@@ -62,6 +62,7 @@
 #include "qMRMLScalarsDisplayWidgetPlugin.h"
 #include "qMRMLSliceControllerWidgetPlugin.h"
 #include "qMRMLSliceInformationWidgetPlugin.h"
+#include "qMRMLSliceVerticalControllerWidgetPlugin.h"
 #include "qMRMLSliceWidgetPlugin.h"
 #include "qMRMLSliderWidgetPlugin.h"
 #include "qMRMLSpinBoxPlugin.h"
@@ -124,6 +125,7 @@ public:
             << new qMRMLSceneFactoryWidgetPlugin
             << new qMRMLSliceControllerWidgetPlugin
             << new qMRMLSliceInformationWidgetPlugin
+            << new qMRMLSliceVerticalControllerWidgetPlugin
             << new qMRMLSliceWidgetPlugin
             << new qMRMLSliderWidgetPlugin
             << new qMRMLSpinBoxPlugin

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceVerticalControllerWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceVerticalControllerWidget.ui
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qMRMLSliceVerticalControllerWidget</class>
+ <widget class="qMRMLWidget" name="qMRMLSliceVerticalControllerWidget">
+  <property name="enabled">
+   <bool>false</bool>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>84</width>
+    <height>319</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>16777215</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Vertical Slice Controller</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="qMRMLSliderWidget" name="SliceVerticalOffsetSlider">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">QSlider::groove:vertical {
+	background-color: black;
+    margin: 0px 0px 0px 0px;
+	border: none;
+	 width: 12px;
+}
+
+QSlider::handle:vertical {
+	background-color: rgba(200, 200, 200, 200);;
+	border-width: 1px;
+   margin-top: -5px;
+	margin-bottom: -5px;
+	height: 50px;
+	border-radius: 5px;
+}
+
+QSlider::handle:vertical:hover {
+	background-color: rgba(150, 150, 150, 200);
+    border-radius: 5px;
+}
+
+QSlider::handle:vertical:pressed {
+	background-color: rgba(0, 150, 150, 200);
+    border-radius: 5px;
+}</string>
+     </property>
+     <property name="spinBoxVisible">
+      <bool>false</bool>
+     </property>
+     <property name="quantity">
+      <string notr="true">length</string>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>qMRMLSliderWidget</class>
+   <extends>ctkSliderWidget</extends>
+   <header>qMRMLSliderWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLWidget</class>
+   <extends>QWidget</extends>
+   <header>qMRMLWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>595</width>
-    <height>518</height>
+    <height>351</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,39 +17,72 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
-    <widget class="qMRMLSliceControllerWidget" name="SliceController"/>
+    <widget class="qMRMLSliceControllerWidget" name="SliceController">
+     <property name="showSliceOffsetSlider">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
-    <widget class="QFrame" name="frame">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="qMRMLSliceView" name="SliceView">
-        <property name="renderEnabled">
-         <bool>true</bool>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QFrame" name="frame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="spacing">
+         <number>0</number>
         </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="qMRMLSliceView" name="SliceView" native="true">
+          <property name="renderEnabled" stdset="0">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="qMRMLSliceVerticalControllerWidget" name="SliceVerticalController">
+       <property name="showSliceOffsetSlider">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
@@ -58,6 +91,11 @@
    <class>qMRMLSliceControllerWidget</class>
    <extends>qMRMLWidget</extends>
    <header>qMRMLSliceControllerWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>qMRMLSliceVerticalControllerWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLSliceVerticalControllerWidget.h</header>
   </customwidget>
   <customwidget>
    <class>qMRMLWidget</class>

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.h
@@ -61,6 +61,7 @@ class QMRML_WIDGETS_EXPORT qMRMLSliceControllerWidget
   Q_PROPERTY(double sliceOffsetResolution READ sliceOffsetResolution WRITE setSliceOffsetResolution)
   Q_PROPERTY(bool moreButtonVisibility READ isMoreButtonVisible WRITE setMoreButtonVisible)
   Q_PROPERTY(QString sliceOrientation READ sliceOrientation WRITE setSliceOrientation)
+  Q_PROPERTY(bool showSliceOffsetSlider READ showSliceOffsetSlider WRITE setShowSliceOffsetSlider)
 public:
   /// Superclass typedef
   typedef qMRMLViewControllerBar Superclass;
@@ -150,6 +151,9 @@ public:
   /// Get the fit to window button (shown in the controller bar).
   Q_INVOKABLE QToolButton* fitToWindowToolButton();
 
+  /// Get the slice offset slider visibility.
+  bool showSliceOffsetSlider()const;
+
 public slots:
 
   void setMRMLScene(vtkMRMLScene* newScene) override;
@@ -171,6 +175,9 @@ public slots:
   /// \note Orientation could be either "Axial, "Sagittal", "Coronal" or "Reformat".
   /// This is an identifier, not to be translated.
   void setSliceOrientation(const QString& orientation);
+
+  /// Set slice offset slider visibility.
+  void setShowSliceOffsetSlider(bool show);
 
   /// Set slice \a offset. Used to set a single value.
   void setSliceOffsetValue(double offset);

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
@@ -51,6 +51,7 @@
 #include <vtkSmartPointer.h>
 #include <vtkWeakPointer.h>
 
+class ctkDynamicSpacer;
 class ctkSignalMapper;
 class ctkDoubleSpinBox;
 class ctkVTKSliceView;
@@ -164,6 +165,8 @@ public slots:
 
   void applyCustomLightbox();
 
+  void updateSliceOffsetSliderVisibility();
+
 protected:
   void setupPopupUi() override;
   void setMRMLSliceCompositeNodeInternal(vtkMRMLSliceCompositeNode* sliceComposite);
@@ -180,6 +183,7 @@ public:
 
   QToolButton*                        FitToWindowToolButton;
   qMRMLSliderWidget*                  SliceOffsetSlider;
+  ctkDynamicSpacer*                   SliderSpacer;
   /// Slicer offset resolution without applying display scaling.
   double                              SliceOffsetResolution{1.0};
   double                              LastLabelMapOpacity;
@@ -216,6 +220,8 @@ public:
 
   ctkSignalMapper*                    RulerTypesMapper;
   ctkSignalMapper*                    RulerColorMapper;
+
+  bool                                ShowSliceOffsetSlider{true};
 };
 
 #endif

--- a/Libs/MRML/Widgets/qMRMLSliceVerticalControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceVerticalControllerWidget.cxx
@@ -1,0 +1,341 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Davide Punzo, punzodavide@hotmail.it,
+  and development was supported by CI3.
+
+==============================================================================*/
+
+// qMRML includes
+#include "qMRMLSliceVerticalControllerWidget.h"
+#include "ui_qMRMLSliceVerticalControllerWidget.h"
+#include "qMRMLSliderWidget.h"
+
+// CTK includes
+#include <ctkDoubleSpinBox.h>
+#include <ctkDoubleSlider.h>
+
+// MRMLLogic includes
+#include <vtkMRMLSliceLogic.h>
+#include <vtkMRMLSliceLayerLogic.h>
+
+// MRML includes
+#include <vtkMRMLApplicationLogic.h>
+#include <vtkMRMLSelectionNode.h>
+#include <vtkMRMLScene.h>
+#include <vtkMRMLSliceViewDisplayableManagerFactory.h>
+#include <vtkMRMLUnitNode.h>
+
+//------------------------------------------------------------------------------
+class qMRMLSliceVerticalControllerWidgetPrivate: public Ui_qMRMLSliceVerticalControllerWidget
+{
+  Q_DECLARE_PUBLIC(qMRMLSliceVerticalControllerWidget);
+
+public:
+  qMRMLSliceVerticalControllerWidgetPrivate(qMRMLSliceVerticalControllerWidget& object);
+  ~qMRMLSliceVerticalControllerWidgetPrivate();
+
+  void init();
+  void setSelectionNode();
+  void onSliceLogicModifiedEvent();
+  void updateSliceOffsetSliderVisibility();
+
+protected:
+  qMRMLSliceVerticalControllerWidget* const q_ptr;
+  vtkSmartPointer<vtkMRMLSliceLogic>  SliceLogic;
+  vtkMRMLSelectionNode*               SelectionNode;
+  /// Slicer offset resolution without applying display scaling.
+  double                              SliceOffsetResolution{1.0};
+  bool                                ShowSliceOffsetSlider{true};
+};
+
+//---------------------------------------------------------------------------
+qMRMLSliceVerticalControllerWidgetPrivate::qMRMLSliceVerticalControllerWidgetPrivate(qMRMLSliceVerticalControllerWidget& object)
+  : q_ptr(&object)
+{
+}
+
+//---------------------------------------------------------------------------
+qMRMLSliceVerticalControllerWidgetPrivate::~qMRMLSliceVerticalControllerWidgetPrivate() = default;
+
+//---------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidgetPrivate::init()
+{
+  Q_Q(qMRMLSliceVerticalControllerWidget);
+  this->setupUi(q);
+
+  this->SliceVerticalOffsetSlider->setTracking(false);
+  this->SliceVerticalOffsetSlider->setToolTip(qMRMLSliceVerticalControllerWidget::tr("Slice distance from RAS origin"));
+  this->updateSliceOffsetSliderVisibility();
+
+  // Connect Slice offset slider
+  QObject::connect(this->SliceVerticalOffsetSlider, SIGNAL(valueChanged(double)),
+                   q, SLOT(setSliceOffsetValue(double)), Qt::QueuedConnection);
+  QObject::connect(this->SliceVerticalOffsetSlider, SIGNAL(valueIsChanging(double)),
+                   q, SLOT(trackSliceOffsetValue(double)), Qt::QueuedConnection);
+
+  vtkNew<vtkMRMLSliceLogic> defaultLogic;
+  defaultLogic->SetMRMLApplicationLogic(vtkMRMLSliceViewDisplayableManagerFactory::GetInstance()->GetMRMLApplicationLogic());
+  q->setSliceLogic(defaultLogic.GetPointer());
+  q->setFixedWidth(12);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidgetPrivate::setSelectionNode()
+{
+  Q_Q(qMRMLSliceVerticalControllerWidget);
+
+  vtkMRMLSelectionNode* selectionNode = nullptr;
+  if (q->mrmlScene())
+    {
+    selectionNode = vtkMRMLSelectionNode::SafeDownCast(
+      q->mrmlScene()->GetNodeByID("vtkMRMLSelectionNodeSingleton"));
+    }
+
+  this->SelectionNode = selectionNode;
+}
+
+// --------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidgetPrivate::onSliceLogicModifiedEvent()
+{
+  Q_Q(qMRMLSliceVerticalControllerWidget);
+
+  vtkMRMLSliceNode* newSliceNode = this->SliceLogic ? this->SliceLogic->GetSliceNode() : nullptr;
+  // Enable/disable widget
+  q->setDisabled(newSliceNode == nullptr);
+
+  double offsetRange[2] = {-1.0, 1.0};
+  double offsetResolution = 1.0;
+  if (!this->SliceLogic || !this->SliceLogic->GetSliceOffsetRangeResolution(offsetRange, offsetResolution))
+    {
+    return;
+    }
+
+  bool wasBlocking = this->SliceVerticalOffsetSlider->blockSignals(true);
+  q->setSliceOffsetRange(offsetRange[0], offsetRange[1]);
+  q->setSliceOffsetResolution(offsetResolution);
+  this->SliceVerticalOffsetSlider->setValue(this->SliceLogic->GetSliceOffset());
+  this->SliceVerticalOffsetSlider->blockSignals(wasBlocking);
+
+  emit q->renderRequested();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidgetPrivate::updateSliceOffsetSliderVisibility()
+{
+  Q_Q(qMRMLSliceVerticalControllerWidget);
+
+  this->SliceVerticalOffsetSlider->setVisible(this->ShowSliceOffsetSlider);
+  q->setVisible(this->ShowSliceOffsetSlider);
+}
+
+// --------------------------------------------------------------------------
+// qMRMLSliceVerticalControllerWidget methods
+
+// --------------------------------------------------------------------------
+qMRMLSliceVerticalControllerWidget::qMRMLSliceVerticalControllerWidget(QWidget *_parent)
+  : qMRMLWidget(_parent)
+  , d_ptr(new qMRMLSliceVerticalControllerWidgetPrivate(*this))
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  d->init();
+}
+
+// --------------------------------------------------------------------------
+qMRMLSliceVerticalControllerWidget::~qMRMLSliceVerticalControllerWidget() = default;
+
+//---------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidget::setMRMLScene(vtkMRMLScene* newScene)
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+
+  if (this->mrmlScene() == newScene)
+    {
+    return;
+    }
+
+  d->SliceLogic->SetMRMLScene(newScene);
+  d->setSelectionNode();
+
+  this->Superclass::setMRMLScene(newScene);
+}
+
+//---------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidget::setMRMLSliceNode(vtkMRMLSliceNode* newSliceNode)
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  // eventually calls vtkMRMLSliceLogic::ModifiedEvent which
+  // eventually calls onSliceLogicModified.
+  d->SliceLogic->SetSliceNode(newSliceNode);
+  if (newSliceNode && newSliceNode->GetScene())
+    {
+    this->setMRMLScene(newSliceNode->GetScene());
+    }
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLSliceNode* qMRMLSliceVerticalControllerWidget::mrmlSliceNode()const
+{
+  Q_D(const qMRMLSliceVerticalControllerWidget);
+  return d->SliceLogic->GetSliceNode();
+}
+
+//---------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidget::setSliceLogic(vtkMRMLSliceLogic * newSliceLogic)
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  if (d->SliceLogic == newSliceLogic)
+    {
+    return;
+    }
+
+  this->qvtkReconnect(d->SliceLogic, newSliceLogic, vtkCommand::ModifiedEvent,
+                      this, SLOT(onSliceLogicModifiedEvent()));
+
+  d->SliceLogic = newSliceLogic;
+
+  if (d->SliceLogic && d->SliceLogic->GetMRMLScene())
+    {
+    this->setMRMLScene(d->SliceLogic->GetMRMLScene());
+    }
+
+  this->onSliceLogicModifiedEvent();
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLSliceLogic *qMRMLSliceVerticalControllerWidget::sliceLogic()
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  return d->SliceLogic;
+}
+
+//---------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidget::setSliceOffsetRange(double min, double max)
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  d->SliceVerticalOffsetSlider->setRange(min, max);
+}
+
+//---------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidget::setSliceOffsetResolution(double resolution)
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  d->SliceOffsetResolution = resolution;
+  resolution = qMax(resolution, 0.00000001);
+  double displayCoeffiecient = 1.0;
+  if (d->SelectionNode && this->mrmlScene())
+    {
+    vtkMRMLUnitNode* unitNode = vtkMRMLUnitNode::SafeDownCast(this->mrmlScene()->GetNodeByID(d->SelectionNode->GetUnitNodeID("length")));
+    if (unitNode)
+      {
+      displayCoeffiecient = unitNode->GetDisplayCoefficient();
+      }
+    }
+  d->SliceVerticalOffsetSlider->setSingleStep(resolution * displayCoeffiecient);
+  d->SliceVerticalOffsetSlider->setPageStep(resolution * displayCoeffiecient);
+}
+
+//---------------------------------------------------------------------------
+double qMRMLSliceVerticalControllerWidget::sliceOffsetResolution()
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  return d->SliceOffsetResolution;
+}
+
+// --------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidget::setSliceOffsetValue(double offset)
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  if (!d->SliceLogic)
+    {
+    return;
+    }
+  //qDebug() << "qMRMLSliceVerticalControllerWidget::setSliceOffsetValue:" << offset;
+
+  // This prevents desynchronized update of displayable managers during user interaction
+  // (ie. slice intersection widget or segmentations lagging behind during slice translation)
+  vtkMRMLApplicationLogic* applicationLogic =
+    vtkMRMLSliceViewDisplayableManagerFactory::GetInstance()->GetMRMLApplicationLogic();
+  if (applicationLogic)
+    {
+    applicationLogic->PauseRender();
+    }
+
+  d->SliceLogic->StartSliceOffsetInteraction();
+  d->SliceLogic->SetSliceOffset(offset);
+  d->SliceLogic->EndSliceOffsetInteraction();
+
+  if (applicationLogic)
+    {
+    applicationLogic->ResumeRender();
+    }
+}
+
+// --------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidget::trackSliceOffsetValue(double offset)
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  if (!d->SliceLogic)
+    {
+    return;
+    }
+  //qDebug() << "qMRMLSliceVerticalControllerWidget::trackSliceOffsetValue";
+
+  // This prevents desynchronized update of displayable managers during user interaction
+  // (ie. slice intersection widget or segmentations lagging behind during slice translation)
+    vtkMRMLApplicationLogic* applicationLogic =
+    vtkMRMLSliceViewDisplayableManagerFactory::GetInstance()->GetMRMLApplicationLogic();
+  if (applicationLogic)
+    {
+    applicationLogic->PauseRender();
+    }
+
+  d->SliceLogic->StartSliceOffsetInteraction();
+  d->SliceLogic->SetSliceOffset(offset);
+
+  if (applicationLogic)
+    {
+    applicationLogic->ResumeRender();
+  }
+}
+
+// --------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidget::onSliceLogicModifiedEvent()
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  d->onSliceLogicModifiedEvent();
+}
+
+// --------------------------------------------------------------------------
+qMRMLSliderWidget* qMRMLSliceVerticalControllerWidget::sliceVerticalOffsetSlider()
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  return d->SliceVerticalOffsetSlider;
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSliceVerticalControllerWidget::showSliceOffsetSlider()const
+{
+  Q_D(const qMRMLSliceVerticalControllerWidget);
+  return d->ShowSliceOffsetSlider;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSliceVerticalControllerWidget::setShowSliceOffsetSlider(bool show)
+{
+  Q_D(qMRMLSliceVerticalControllerWidget);
+  d->ShowSliceOffsetSlider = show;
+  d->updateSliceOffsetSliderVisibility();
+}

--- a/Libs/MRML/Widgets/qMRMLSliceVerticalControllerWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceVerticalControllerWidget.h
@@ -1,0 +1,114 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Davide Punzo, punzodavide@hotmail.it,
+  and development was supported by CI3.
+
+==============================================================================*/
+
+#ifndef __qMRMLSliceVerticalControllerWidget_h
+#define __qMRMLSliceVerticalControllerWidget_h
+
+// qMRMLWidget includes
+#include "qMRMLWidget.h"
+#include "qMRMLWidgetsExport.h"
+#include <vtkVersion.h>
+
+// CTK includes
+#include <ctkVTKObject.h>
+
+class qMRMLSliceVerticalControllerWidgetPrivate;
+class qMRMLSliderWidget;
+class vtkMRMLScene;
+class vtkMRMLSliceLogic;
+class vtkMRMLSliceNode;
+
+/// qMRMLSliceVerticalControllerWidget offers controls to a slice view (vtkMRMLSliceNode).
+///
+/// To be valid, it needs at least a MRML scene and a MRML slice node:
+/// \code
+/// qMRMLSliceVerticalControllerWidget controllerWidget;
+/// controllerWidget.setMRMLScene(scene);
+/// controllerWidget.setMRMLSliceNode(sliceNode);
+/// \endcode
+class QMRML_WIDGETS_EXPORT qMRMLSliceVerticalControllerWidget : public qMRMLWidget
+{
+  Q_OBJECT
+  QVTK_OBJECT
+  Q_PROPERTY(bool showSliceOffsetSlider READ showSliceOffsetSlider WRITE setShowSliceOffsetSlider)
+public:
+  /// Superclass typedef
+  typedef qMRMLWidget Superclass;
+
+  /// Constructors
+  qMRMLSliceVerticalControllerWidget(QWidget* parent = nullptr);
+  ~qMRMLSliceVerticalControllerWidget() override;
+
+  /// Get \a sliceNode
+  /// \sa setMRMLSliceCompositeNode();
+  Q_INVOKABLE vtkMRMLSliceNode* mrmlSliceNode()const;
+
+  /// Set slice offset range
+  Q_INVOKABLE void setSliceOffsetRange(double min, double max);
+
+  /// Set slice offset \a resolution (increment)
+  void setSliceOffsetResolution(double resolution);
+
+  /// Get slice offset \a resolution (increment)
+  double sliceOffsetResolution();
+
+  /// Get SliceLogic
+  Q_INVOKABLE vtkMRMLSliceLogic* sliceLogic();
+
+  /// Set \a newSliceLogic
+  Q_INVOKABLE void setSliceLogic(vtkMRMLSliceLogic * newSliceLogic);
+
+  /// Get the slice slider widget (shown in the controller bar).
+  Q_INVOKABLE qMRMLSliderWidget* sliceVerticalOffsetSlider();
+
+  /// Get the slice offset slider visibility.
+  bool showSliceOffsetSlider()const;
+
+public slots:
+
+  void setMRMLScene(vtkMRMLScene* newScene) override;
+
+  /// Set a new SliceNode.
+  void setMRMLSliceNode(vtkMRMLSliceNode* newSliceNode);
+
+  /// Set slice offset slider visibility.
+  void setShowSliceOffsetSlider(bool show);
+
+  /// Set slice \a offset. Used to set a single value.
+  void setSliceOffsetValue(double offset);
+
+  /// Set slice offset. Used when events will come is rapid succession.
+  void trackSliceOffsetValue(double offset);
+
+protected slots:
+  void onSliceLogicModifiedEvent();
+
+signals:
+  void renderRequested();
+
+protected:
+  QScopedPointer<qMRMLSliceVerticalControllerWidgetPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qMRMLSliceVerticalControllerWidget);
+  Q_DISABLE_COPY(qMRMLSliceVerticalControllerWidget);
+};
+
+#endif

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
@@ -69,6 +69,18 @@ void qMRMLSliceWidgetPrivate::init()
           this, SLOT(setImageDataConnection(vtkAlgorithmOutput*)));
   connect(this->SliceController, SIGNAL(renderRequested()),
           this->SliceView, SLOT(scheduleRender()), Qt::QueuedConnection);
+  connect(this->SliceVerticalController, SIGNAL(renderRequested()),
+          this->SliceView, SLOT(scheduleRender()), Qt::QueuedConnection);
+
+  this->updateSliceOffsetSliderOrientation();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLSliceWidgetPrivate::updateSliceOffsetSliderOrientation()
+{
+  bool horizontal = (this->SliceOffsetSliderOrientation == Qt::Horizontal);
+  this->SliceController->setShowSliceOffsetSlider(horizontal);
+  this->SliceVerticalController->setShowSliceOffsetSlider(!horizontal);
 }
 
 // --------------------------------------------------------------------------
@@ -139,6 +151,7 @@ void qMRMLSliceWidget::setMRMLSliceNode(vtkMRMLSliceNode* newSliceNode)
 {
   Q_D(qMRMLSliceWidget);
   d->SliceController->setMRMLSliceNode(newSliceNode);
+  d->SliceVerticalController->setMRMLSliceNode(newSliceNode);
   d->SliceView->setMRMLSliceNode(newSliceNode);
 }
 
@@ -253,6 +266,14 @@ void qMRMLSliceWidget::fitSliceToBackground()
 }
 
 // --------------------------------------------------------------------------
+void qMRMLSliceWidget::setSliceOffsetSliderOrientation(Qt::Orientation orientation)
+{
+  Q_D(qMRMLSliceWidget);
+  d->SliceOffsetSliderOrientation = orientation;
+  d->updateSliceOffsetSliderOrientation();
+}
+
+// --------------------------------------------------------------------------
 qMRMLSliceView* qMRMLSliceWidget::sliceView()const
 {
   Q_D(const qMRMLSliceWidget);
@@ -260,10 +281,24 @@ qMRMLSliceView* qMRMLSliceWidget::sliceView()const
 }
 
 // --------------------------------------------------------------------------
+Qt::Orientation qMRMLSliceWidget::sliceOffsetSliderOrientation()const
+{
+  Q_D(const qMRMLSliceWidget);
+  return d->SliceOffsetSliderOrientation;
+}
+
+// --------------------------------------------------------------------------
 qMRMLSliceControllerWidget* qMRMLSliceWidget::sliceController()const
 {
   Q_D(const qMRMLSliceWidget);
   return d->SliceController;
+}
+
+// --------------------------------------------------------------------------
+qMRMLSliceVerticalControllerWidget *qMRMLSliceWidget::sliceVerticalController() const
+{
+  Q_D(const qMRMLSliceWidget);
+  return d->SliceVerticalController;
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.h
@@ -33,6 +33,7 @@
 class qMRMLSliceView;
 class qMRMLSliceWidgetPrivate;
 class qMRMLSliceControllerWidget;
+class qMRMLSliceVerticalControllerWidget;
 class vtkCollection;
 class vtkMRMLScene;
 class vtkMRMLNode;
@@ -53,6 +54,7 @@ class QMRML_WIDGETS_EXPORT qMRMLSliceWidget : public qMRMLWidget
   Q_PROPERTY(QString sliceViewName READ sliceViewName WRITE setSliceViewName)
   Q_PROPERTY(QString sliceViewLabel READ sliceViewLabel WRITE setSliceViewLabel)
   Q_PROPERTY(QColor sliceViewColor READ sliceViewColor WRITE setSliceViewColor)
+  Q_PROPERTY(Qt::Orientation sliceOffsetSliderOrientation READ sliceOffsetSliderOrientation WRITE setSliceOffsetSliderOrientation)
 
 public:
   /// Superclass typedef
@@ -64,6 +66,9 @@ public:
 
   /// Get slice controller
   Q_INVOKABLE qMRMLSliceControllerWidget* sliceController()const;
+
+  /// Get vertical slice controller
+  Q_INVOKABLE qMRMLSliceVerticalControllerWidget* sliceVerticalController()const;
 
   /// \sa qMRMLSliceControllerWidget::mrmlSliceNode()
   /// \sa setMRMLSliceNode()
@@ -124,6 +129,10 @@ public:
   /// \sa sliceController()
   Q_INVOKABLE qMRMLSliceView* sliceView()const;
 
+  /// This property holds the orientation of the slice offset slider.
+  /// The orientation must be Qt::Horizontal (the default) or Qt::Vertical.
+  Qt::Orientation sliceOffsetSliderOrientation() const;
+
 public slots:
   void setMRMLScene(vtkMRMLScene * newScene) override;
 
@@ -141,6 +150,10 @@ public slots:
 
   /// Fit slices to background
   void fitSliceToBackground();
+
+  /// This property holds the orientation of the slice offset slider.
+  /// The orientation must be Qt::Horizontal (the default) or Qt::Vertical.
+  void setSliceOffsetSliderOrientation(Qt::Orientation orientation);
 
 signals:
   /// Signal emitted when editing of a node is requested from within the slice widget

--- a/Libs/MRML/Widgets/qMRMLSliceWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget_p.h
@@ -56,11 +56,15 @@ class QMRML_WIDGETS_EXPORT qMRMLSliceWidgetPrivate
   Q_DECLARE_PUBLIC(qMRMLSliceWidget);
 protected:
   qMRMLSliceWidget* const q_ptr;
+
+  Qt::Orientation SliceOffsetSliderOrientation{Qt::Horizontal};
+
 public:
   qMRMLSliceWidgetPrivate(qMRMLSliceWidget& object);
   ~qMRMLSliceWidgetPrivate() override;
 
   void init();
+  void updateSliceOffsetSliderOrientation();
 
 public slots:
   void setSliceViewSize(const QSize& size);
@@ -68,8 +72,6 @@ public slots:
   void endProcessing();
   /// Set the image data to the slice view
   void setImageDataConnection(vtkAlgorithmOutput * imageDataConnection);
-
-
 };
 
 #endif

--- a/Libs/MRML/Widgets/qMRMLSliderWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliderWidget.cxx
@@ -23,6 +23,7 @@
 // CTK includes
 #include <ctkLinearValueProxy.h>
 #include <ctkUtils.h>
+#include <ctkDoubleSlider.h>
 
 // MRML includes
 #include <vtkMRMLNode.h>
@@ -60,12 +61,14 @@ public:
 qMRMLSliderWidgetPrivate::qMRMLSliderWidgetPrivate(qMRMLSliderWidget& object)
   : q_ptr(&object)
 {
+  Q_Q(qMRMLSliderWidget);
   this->Quantity = "";
   this->MRMLScene = nullptr;
   this->SelectionNode = nullptr;
   this->Flags = qMRMLSliderWidget::Prefix | qMRMLSliderWidget::Suffix
     | qMRMLSliderWidget::Precision | qMRMLSliderWidget::Scaling;
   this->Proxy = new ctkLinearValueProxy;
+  q->setOrientation(Qt::Horizontal);
 }
 
 // --------------------------------------------------------------------------
@@ -276,4 +279,20 @@ void qMRMLSliderWidget::setRange(double newMinimumValue, double newMaximumValue)
     {
     this->updateWidgetFromUnitNode();
     }
+}
+
+// --------------------------------------------------------------------------
+Qt::Orientation qMRMLSliderWidget::orientation()
+{
+  return this->slider()->orientation();
+}
+
+// --------------------------------------------------------------------------
+void qMRMLSliderWidget::setOrientation(Qt::Orientation newOrientation)
+{
+  if (this->slider()->orientation() == newOrientation)
+    {
+    return;
+    }
+  this->slider()->setOrientation(newOrientation);
 }

--- a/Libs/MRML/Widgets/qMRMLSliderWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliderWidget.h
@@ -72,7 +72,7 @@ class QMRML_WIDGETS_EXPORT qMRMLSliderWidget : public ctkSliderWidget
   // \sa setUnitAwareProperties(), unitAwareProperties()
   Q_FLAGS(UnitAwareProperty UnitAwareProperties)
   Q_PROPERTY(UnitAwareProperties unitAwareProperties READ unitAwareProperties WRITE setUnitAwareProperties)
-
+  Q_PROPERTY(Qt::Orientation orientation READ orientation WRITE setOrientation)
 public:
   typedef ctkSliderWidget Superclass;
 
@@ -112,6 +112,10 @@ public:
   void setMaximum(double) override;
   void setRange(double, double) override;
 
+  /// This property holds the orientation of the slider.
+  /// The orientation must be Qt::Horizontal (the default) or Qt::Vertical.
+  Qt::Orientation orientation();
+
 public slots:
   void setQuantity(const QString& baseName);
 
@@ -120,6 +124,10 @@ public slots:
   virtual void setMRMLScene(vtkMRMLScene* scene);
 
   void setUnitAwareProperties(UnitAwareProperties flags);
+
+  /// This property holds the orientation of the slider.
+  /// The orientation must be Qt::Horizontal (the default) or Qt::Vertical.
+  void setOrientation(Qt::Orientation orientation);
 
 protected slots:
   void updateWidgetFromUnitNode();


### PR DESCRIPTION
This adds a vertical slice controller slider to slice widgets.

In default it is not visible, and it can be shown with:

`slicer.app.layoutManager().sliceWidget("Red").setShowSliceVerticalOffsetSlider(True)`

The horizontal slide selector (or the whole slice controller) can then be hidden:

`slicer.app.layoutManager().sliceWidget("Red").sliceController().hide()`
