### PR TITLE
BUG: Update vtkMRMLParser to support custom type ending with "Node" string

### DIFF
--- a/Libs/MRML/Core/vtkMRMLParser.cxx
+++ b/Libs/MRML/Core/vtkMRMLParser.cxx
@@ -127,7 +127,7 @@ void vtkMRMLParser::StartElement(const char* tagName, const char** atts)
     className = "vtkMRML";
     className += tagName;
     // Append 'Node' prefix only if required
-    if (className.find("Node") != className.size() - 4)
+    if (className.rfind("Node") != className.size() - 4)
       {
       className += "Node";
       }


### PR DESCRIPTION
For module names that contain multiple "Node" substrings, For example: vtkMRMLROS2NodeNode, the previous implementation using .find() would be restrictive. Considering that the logic is to check whether the className ends with "Node" from the end ( using .rfind() ) is better.