### PR TITLE
BUG: Fix scripted module template observer warning

### DIFF
--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -210,7 +210,7 @@ class TemplateKeyWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Unobserve previously selected parameter node and add an observer to the newly selected.
         # Changes of parameter node are observed so that whenever parameters are changed by a script or any other module
         # those are reflected immediately in the GUI.
-        if self._parameterNode is not None:
+        if self._parameterNode is not None and self.hasObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode):
             self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
         self._parameterNode = inputParameterNode
         if self._parameterNode is not None:


### PR DESCRIPTION
Whenever the user leaves the template module, the parameter node observers are removed. If the module is entering after that, setParameterNode() will attempt to remove the observer again, and throw a warning message.

Fixed by checking if the observer exists before removing in setParameterNode().

See: https://discourse.slicer.org/t/warning-of-observer-from-scripted-module-in-slicer-5-0-3/