### PR TITLE
ENH: Allow getting process output during CLI execution

### DIFF
--- a/Base/QTCLI/qSlicerCLIProgressBar.cxx
+++ b/Base/QTCLI/qSlicerCLIProgressBar.cxx
@@ -194,7 +194,7 @@ QString qSlicerCLIProgressBarPrivate::getLastNLines(const std::string& str, int 
     return QString();
     }
   const char lineSeparator = '\n';
-  size_t linesStartPosition = str.size()-1;
+  size_t linesStartPosition = str.size() - 1;
   for (int line = 0; line <= numberOfLines; ++line)
     {
     linesStartPosition = str.find_last_of(lineSeparator, linesStartPosition - 1);

--- a/Base/QTCLI/qSlicerCLIProgressBar.cxx
+++ b/Base/QTCLI/qSlicerCLIProgressBar.cxx
@@ -26,7 +26,7 @@
 #include <QLabel>
 #include <QProgressBar>
 #include <QScrollBar>
-#include <QTextBrowser.h>
+#include <QTextBrowser>
 #include <QTime>
 
 // CTK includes

--- a/Base/QTCLI/qSlicerCLIProgressBar.cxx
+++ b/Base/QTCLI/qSlicerCLIProgressBar.cxx
@@ -25,10 +25,12 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QProgressBar>
+#include <QScrollBar>
+#include <QTextBrowser.h>
+#include <QTime>
 
 // CTK includes
 #include <ctkExpandButton.h>
-#include <ctkFittedTextBrowser.h>
 
 // Slicer includes
 #include "qSlicerCLIProgressBar.h"
@@ -57,6 +59,8 @@ public:
 
   bool isVisible(qSlicerCLIProgressBar::Visibility visibility)const;
 
+  QString getLastNLines(const std::string& str, int numberOfLines, int maxLength=5000);
+
 private:
 
   QGridLayout *  GridLayout;
@@ -64,7 +68,8 @@ private:
   QLabel *       StatusLabelLabel;
   QLabel *       StatusLabel;
   ctkExpandButton * DetailsTextExpandButton;
-  ctkFittedTextBrowser * DetailsTextBrowser;
+  QTextBrowser * DetailsTextBrowser;
+  QTime DetailsLastUpdateTime;
   QProgressBar * ProgressBar;
   QProgressBar * StageProgressBar;
 
@@ -126,7 +131,7 @@ void qSlicerCLIProgressBarPrivate::init()
 
   this->GridLayout->addWidget(DetailsTextExpandButton, 1, 2, 1, 1);
 
-  this->DetailsTextBrowser = new ctkFittedTextBrowser();
+  this->DetailsTextBrowser = new QTextBrowser();
   this->DetailsTextBrowser->setObjectName(QString::fromUtf8("DetailsTextBrowser"));
   this->DetailsTextBrowser->setVisible(false);
 
@@ -179,6 +184,38 @@ bool qSlicerCLIProgressBarPrivate
        this->CommandLineModuleNode->GetStatus() == vtkMRMLCommandLineModuleNode::CompletedWithErrors) : false;
     }
   return true;
+}
+
+//-----------------------------------------------------------------------------
+QString qSlicerCLIProgressBarPrivate::getLastNLines(const std::string& str, int numberOfLines, int maxLength)
+{
+  if (numberOfLines < 1 || str.size() < 1)
+    {
+    return QString();
+    }
+  const char lineSeparator = '\n';
+  size_t linesStartPosition = str.size()-1;
+  for (int line = 0; line <= numberOfLines; ++line)
+    {
+    linesStartPosition = str.find_last_of(lineSeparator, linesStartPosition - 1);
+    if (linesStartPosition == std::string::npos || linesStartPosition == 0)
+      {
+      // we need the full string
+      if (str.size() <= maxLength)
+        {
+        return QString::fromStdString(str);
+        }
+      else
+        {
+        return QStringLiteral("...") + QString::fromStdString(str.substr(str.size() - maxLength, maxLength)).trimmed();
+        }
+      }
+    }
+  if (str.size() - linesStartPosition > maxLength)
+    {
+    linesStartPosition = str.size() - maxLength;
+    }
+  return QStringLiteral("...") + QString::fromStdString(str.substr(linesStartPosition + 1, str.size() - linesStartPosition)).trimmed();
 }
 
 //-----------------------------------------------------------------------------
@@ -279,7 +316,25 @@ void qSlicerCLIProgressBar::setCommandLineModuleNode(
     vtkCommand::ModifiedEvent,
     this, SLOT(updateUiFromCommandLineModuleNode(vtkObject*)));
 
+  if (d->CommandLineModuleNode)
+    {
+    // UpdateOutputTextDuringExecution was enabled because the details button was open
+    if (d->DetailsTextExpandButton->isChecked())
+      {
+      d->CommandLineModuleNode->EndContinuousOutputUpdate();
+      }
+    }
+
   d->CommandLineModuleNode = commandLineModuleNode;
+
+  if (d->CommandLineModuleNode)
+    {
+      if (d->DetailsTextExpandButton->isChecked())
+      {
+      d->CommandLineModuleNode->StartContinuousOutputUpdate();
+      }
+    }
+
   this->updateUiFromCommandLineModuleNode(d->CommandLineModuleNode);
 }
 
@@ -304,6 +359,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
     d->ProgressBar->setMaximum(0);
     d->StageProgressBar->setMaximum(0);
     d->DetailsTextBrowser->setVisible(d->DetailsTextExpandButton->isChecked());
+    d->DetailsLastUpdateTime = QTime();
     return;
     }
 
@@ -313,6 +369,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
 
   // Update Progress
   ModuleProcessInformation* info = node->GetModuleDescription().GetProcessInformation();
+  QString statusLabelFormat = tr("%1 (%2s)");
   switch (node->GetStatus())
     {
     case vtkMRMLCommandLineModuleNode::Cancelled:
@@ -326,7 +383,7 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
       d->ProgressBar->setValue(info->Progress * 100.);
       if (info->ElapsedTime != 0.)
         {
-        d->StatusLabel->setText(QString("%1 (%2)").arg(node->GetStatusString()).arg(info->ElapsedTime));
+        d->StatusLabel->setText(statusLabelFormat.arg(node->GetStatusString()).arg(info->ElapsedTime, 0, 'f', 1));
         }
       // We keep StageProgressBar maximum at 100, because if it was set to 0
       // then the progress message would not be displayed.
@@ -336,6 +393,10 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
       break;
     case vtkMRMLCommandLineModuleNode::Completed:
     case vtkMRMLCommandLineModuleNode::CompletedWithErrors:
+      if (info->ElapsedTime != 0.)
+        {
+        d->StatusLabel->setText(statusLabelFormat.arg(node->GetStatusString()).arg(info->ElapsedTime, 0, 'f', 1));
+        }
       d->ProgressBar->setMaximum(100);
       d->ProgressBar->setValue(100);
       break;
@@ -350,7 +411,17 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
     || (node->GetStatus() == vtkMRMLCommandLineModuleNode::CompletedWithErrors
     && !errorText.empty()));
   d->DetailsTextBrowser->setVisible(showDetails);
-  if (showDetails)
+
+  // While the module is running, avoid too frequent updates of the process output
+  // as long output can cause slowdowns.
+  const double minRefreshTimeMsec = 3000.0;
+  bool updateDetails = showDetails
+    && (
+      (node->GetStatus() != vtkMRMLCommandLineModuleNode::Running)
+      ||
+      (!d->DetailsLastUpdateTime.isValid() || d->DetailsLastUpdateTime.elapsed() > minRefreshTimeMsec));
+
+  if (showDetails && updateDetails)
     {
     std::string outputText;
     int maxNumberOfLinesShown = 5;
@@ -361,32 +432,67 @@ void qSlicerCLIProgressBar::updateUiFromCommandLineModuleNode(
       }
     // Limit number of text lines shown (more shown if user clicked to show more details)
     int lineSpacing = QFontMetrics(d->DetailsTextBrowser->document()->defaultFont()).lineSpacing();
+    d->DetailsTextBrowser->setMinimumHeight(lineSpacing * maxNumberOfLinesShown);
     d->DetailsTextBrowser->setMaximumHeight(lineSpacing * maxNumberOfLinesShown);
 
     QString detailsText;
     detailsText = "<pre>";
-    if (!errorText.empty())
+    if (!outputText.empty())
       {
-      detailsText += "<span style = \"color:#FF0000;\">";
-      detailsText += QString::fromStdString(errorText).toHtmlEscaped();
-      detailsText += "</span>";
+      if (node->GetStatus() == vtkMRMLCommandLineModuleNode::Running)
+        {
+        // Limit output text while running, to reduce time spent with updating the GUI and reduce need for scrolling.
+        detailsText += d->getLastNLines(node->GetOutputText(), 30).toHtmlEscaped();
+        }
+      else
+        {
+        detailsText += QString::fromStdString(node->GetOutputText()).toHtmlEscaped();
+        }
       }
     if (!errorText.empty() && !outputText.empty())
       {
-      detailsText += "\n";
+      detailsText += "<hr/>";
       }
-    if (!outputText.empty())
+    if (!errorText.empty())
       {
-      detailsText += QString::fromStdString(node->GetOutputText()).toHtmlEscaped();
+      detailsText += "<span style = \"color:#FF0000;\">";
+      if (node->GetStatus() == vtkMRMLCommandLineModuleNode::Running)
+        {
+        // Limit output text while running, to reduce time spent with updating the GUI and reduce need for scrolling.
+        detailsText += d->getLastNLines(errorText, 10).toHtmlEscaped();
+        }
+      else
+        {
+        detailsText += QString::fromStdString(errorText).toHtmlEscaped();
+        }
+      detailsText += "</span>";
       }
+
     detailsText += "</pre>";
     d->DetailsTextBrowser->setText(detailsText);
+    QScrollBar* vScrollBar = d->DetailsTextBrowser->verticalScrollBar();
+    if (vScrollBar)
+      {
+      vScrollBar->setValue(vScrollBar->maximum());
+      }
+    d->DetailsLastUpdateTime.restart();
     }
 }
 
 //-----------------------------------------------------------------------------
-void qSlicerCLIProgressBar::showDetails(bool)
+void qSlicerCLIProgressBar::showDetails(bool show)
 {
   Q_D(qSlicerCLIProgressBar);
+  if (d->CommandLineModuleNode)
+    {
+    if (show)
+      {
+      d->CommandLineModuleNode->StartContinuousOutputUpdate();
+      }
+    else
+      {
+      d->CommandLineModuleNode->EndContinuousOutputUpdate();
+      }
+    }
   this->updateUiFromCommandLineModuleNode(d->CommandLineModuleNode);
 }

--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.h
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.h
@@ -149,6 +149,10 @@ protected:
   // Communicate progress back to the node
   static void ProgressCallback(void *);
 
+  /// Remove progress reporting information from process output
+  /// (XML data elements, such as filter-progress, filter-stage-progress, filter-name, filter-comment)
+  static void RemoveProgressInfoFromProcessOutput(std::string& text);
+
   /// Return true if the commandlinemodule node can update the
   /// selection node with the outputs of the CLI
   bool IsCommandLineModuleNodeUpdatingDisplay(

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -41,7 +41,7 @@ class vtkMRMLCommandLineModuleNode::vtkInternal
 {
 public:
 
-  // This mutex is allows thread-safe reading/writing of node properties.
+  // This mutex allows the thread-safe reading/writing of node properties.
   // This is needed because these process outputa and error may be written
   // in a worker thread.
   std::recursive_mutex NodeAccessMutex;

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -1079,7 +1079,7 @@ std::string vtkMRMLCommandLineModuleNode::GetOutputText() const
 void vtkMRMLCommandLineModuleNode::SetErrorText(const std::string& text, bool modify)
 {
   {
-    std::lock_guard<std::recursive_mutex> lk(this->Internal->NodeAccessMutex);
+    std::lock_guard<std::recursive_mutex> lock(this->Internal->NodeAccessMutex);
     if (this->Internal->ErrorText == text)
       {
       return;

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -1069,7 +1069,7 @@ std::string vtkMRMLCommandLineModuleNode::GetOutputText() const
 {
   std::string text;
     {
-    std::lock_guard<std::recursive_mutex> lk(this->Internal->NodeAccessMutex);
+    std::lock_guard<std::recursive_mutex> lock(this->Internal->NodeAccessMutex);
     text = this->Internal->OutputText;
     }
   return text;

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -28,6 +28,7 @@ Version:   $Revision: 1.2 $
 #include <vtkObjectFactory.h>
 
 // STD includes
+#include <mutex>
 #include <sstream>
 
 
@@ -39,6 +40,11 @@ class ModuleDescriptionMap : public std::map<std::string, ModuleDescription> {};
 class vtkMRMLCommandLineModuleNode::vtkInternal
 {
 public:
+
+  // This mutex is allows thread-safe reading/writing of node properties.
+  // This is needed because these process outputa and error may be written
+  // in a worker thread.
+  std::recursive_mutex NodeAccessMutex;
 
   ModuleDescription ModuleDescriptionObject;
 
@@ -63,7 +69,7 @@ public:
   /// Flag to trigger or not the StatusModifiedEvent
   mutable bool InvokeStatusModifiedEvent;
 
-  /// Output messages of last execution (printed to stdout)
+  /// Output messages of last execution (progress messages excluded)
   std::string OutputText;
   /// Error messages of last execution (printed to stderr)
   std::string ErrorText;
@@ -1046,25 +1052,38 @@ void vtkMRMLCommandLineModuleNode::Modified()
 }
 
 //----------------------------------------------------------------------------
-const std::string vtkMRMLCommandLineModuleNode::GetErrorText() const
+std::string vtkMRMLCommandLineModuleNode::GetErrorText() const
 {
-  return this->Internal->ErrorText;
+  std::string text;
+    {
+    std::lock_guard<std::recursive_mutex> lk(this->Internal->NodeAccessMutex);
+    text = this->Internal->ErrorText;
+    }
+  return text;
 }
 
 //----------------------------------------------------------------------------
-const std::string vtkMRMLCommandLineModuleNode::GetOutputText() const
+std::string vtkMRMLCommandLineModuleNode::GetOutputText() const
 {
-  return this->Internal->OutputText;
+  std::string text;
+    {
+    std::lock_guard<std::recursive_mutex> lk(this->Internal->NodeAccessMutex);
+    text = this->Internal->OutputText;
+    }
+  return text;
 }
 
 //----------------------------------------------------------------------------
 void vtkMRMLCommandLineModuleNode::SetErrorText(const std::string& text, bool modify)
 {
-  if (this->Internal->ErrorText == text)
-    {
-    return;
-    }
-  this->Internal->ErrorText = text;
+  {
+    std::lock_guard<std::recursive_mutex> lk(this->Internal->NodeAccessMutex);
+    if (this->Internal->ErrorText == text)
+      {
+      return;
+      }
+    this->Internal->ErrorText = text;
+  }
   if (modify)
     {
     this->Modified();
@@ -1074,13 +1093,39 @@ void vtkMRMLCommandLineModuleNode::SetErrorText(const std::string& text, bool mo
 //----------------------------------------------------------------------------
 void vtkMRMLCommandLineModuleNode::SetOutputText(const std::string& text, bool modify)
 {
-  if (this->Internal->OutputText == text)
-    {
-    return;
-    }
-  this->Internal->OutputText = text;
+  {
+    std::lock_guard<std::recursive_mutex> lk(this->Internal->NodeAccessMutex);
+    if (this->Internal->OutputText == text)
+      {
+      return;
+      }
+    this->Internal->OutputText = text;
+  }
   if (modify)
     {
     this->Modified();
     }
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLCommandLineModuleNode::StartContinuousOutputUpdate()
+{
+  this->ContinuousOutputUpdateInProgressCount++;
+}
+
+//----------------------------------------------------------------------------
+void vtkMRMLCommandLineModuleNode::EndContinuousOutputUpdate()
+{
+  this->ContinuousOutputUpdateInProgressCount--;
+  if (this->ContinuousOutputUpdateInProgressCount < 0)
+    {
+    vtkWarningMacro("Unexpected EndContinuousOutputUpdate");
+    this->ContinuousOutputUpdateInProgressCount = 0;
+    }
+}
+
+//----------------------------------------------------------------------------
+bool vtkMRMLCommandLineModuleNode::IsContinuousOutputUpdate()
+{
+  return (this->ContinuousOutputUpdateInProgressCount > 0);
 }

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -69,7 +69,9 @@ public:
   /// Flag to trigger or not the StatusModifiedEvent
   mutable bool InvokeStatusModifiedEvent;
 
-  /// Output messages of last execution (progress messages excluded)
+  /// Output text of last execution (without progress info)
+  ///
+  /// \sa vtkSlicerCLIModuleLogic::RemoveProgressInfoFromProcessOutput
   std::string OutputText;
   /// Error messages of last execution (printed to stderr)
   std::string ErrorText;

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -1058,7 +1058,7 @@ std::string vtkMRMLCommandLineModuleNode::GetErrorText() const
 {
   std::string text;
     {
-    std::lock_guard<std::recursive_mutex> lk(this->Internal->NodeAccessMutex);
+    std::lock_guard<std::recursive_mutex> lock(this->Internal->NodeAccessMutex);
     text = this->Internal->ErrorText;
     }
   return text;

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -42,7 +42,7 @@ class vtkMRMLCommandLineModuleNode::vtkInternal
 public:
 
   // This mutex allows the thread-safe reading/writing of node properties.
-  // This is needed because these process outputa and error may be written
+  // This is needed because process output and error texts may be written
   // in a worker thread.
   std::recursive_mutex NodeAccessMutex;
 

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.cxx
@@ -1096,7 +1096,7 @@ void vtkMRMLCommandLineModuleNode::SetErrorText(const std::string& text, bool mo
 void vtkMRMLCommandLineModuleNode::SetOutputText(const std::string& text, bool modify)
 {
   {
-    std::lock_guard<std::recursive_mutex> lk(this->Internal->NodeAccessMutex);
+    std::lock_guard<std::recursive_mutex> lock(this->Internal->NodeAccessMutex);
     if (this->Internal->OutputText == text)
       {
       return;

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -115,15 +115,37 @@ public:
   /// \sa GetStatus(), IsBusy()
   const char* GetStatusString() const;
 
-  /// Set output messages generated during latest execution.
-  void SetOutputText(const std::string& text, bool modify = true);
-  /// Set output messages generated during latest execution.
-  const std::string GetOutputText() const;
+  //@{
+  /// Start/stop continuous updating of output text and error text during execution.
+  ///
+  /// If ContinuousOutputUpdate is not active then output and error text are only
+  /// updated when execution is completed. If continuous update is active, then
+  /// output and error text are updated continuously, which may be useful
+  /// for close monitoring of the execution, but may impact the performance
+  /// if the process output is very long.
+  ///
+  /// Modified event is not invoked when the value is changed and
+  /// the value is not stored persistently in the scene file.
+  void StartContinuousOutputUpdate();
+  void EndContinuousOutputUpdate();
+  bool IsContinuousOutputUpdate();
+  //@}
 
-  /// Set error messages generated during latest execution.
+  //@{
+  /// Get/set output messages generated during latest execution.
+  /// This value is not stored persistently in the scene file.
+  /// It is safe to call this method from a non-main thread (with modify=false).
+  void SetOutputText(const std::string& text, bool modify = true);
+  std::string GetOutputText() const;
+  //@}
+
+  //@{
+  /// Get/set error messages generated during latest execution.
+  /// This value is not stored persistently in the scene file.
+  /// It is safe to call this method from a non-main thread (with modify=false).
   void SetErrorText(const std::string& text, bool modify = true);
-  /// Get error messages generated during latest execution.
-  const std::string GetErrorText() const;
+  std::string GetErrorText() const;
+  //@}
 
   /// Return true if the module is in a busy state: Scheduled, Running,
   /// Cancelling, Completing.
@@ -297,6 +319,8 @@ protected:
   void AbortProcess();
   void ProcessMRMLEvents(vtkObject *caller, unsigned long event,
                                  void *callData) override;
+
+  int ContinuousOutputUpdateInProgressCount{0};
 
 private:
   vtkMRMLCommandLineModuleNode();

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -120,7 +120,7 @@ public:
   ///
   /// If ContinuousOutputUpdate is not active then output and error text are only
   /// updated when execution is completed. If continuous update is active, then
-  /// output and error text are updated continuously, which may be useful
+  /// output and error texts are updated continuously, which may be useful
   /// for close monitoring of the execution, but may impact the performance
   /// if the process output is very long.
   ///

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -116,7 +116,7 @@ public:
   const char* GetStatusString() const;
 
   //@{
-  /// Start/stop continuous updating of output text and error text during execution.
+  /// Start/stop continuous updating of output and error texts during execution.
   ///
   /// If ContinuousOutputUpdate is not active then output and error texts are only
   /// updated when execution is completed. If continuous update is active, then

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -140,7 +140,7 @@ public:
   //@}
 
   //@{
-  /// Get/set error messages generated during latest execution.
+  /// Get/set error text generated during latest execution.
   /// This value is not stored persistently in the scene file.
   /// It is safe to call this method from a non-main thread (with modify=false).
   void SetErrorText(const std::string& text, bool modify = true);

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -118,7 +118,7 @@ public:
   //@{
   /// Start/stop continuous updating of output text and error text during execution.
   ///
-  /// If ContinuousOutputUpdate is not active then output and error text are only
+  /// If ContinuousOutputUpdate is not active then output and error texts are only
   /// updated when execution is completed. If continuous update is active, then
   /// output and error texts are updated continuously, which may be useful
   /// for close monitoring of the execution, but may impact the performance

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -132,7 +132,7 @@ public:
   //@}
 
   //@{
-  /// Get/set output messages generated during latest execution.
+  /// Get/set output text generated during latest execution.
   /// This value is not stored persistently in the scene file.
   /// It is safe to call this method from a non-main thread (with modify=false).
   void SetOutputText(const std::string& text, bool modify = true);


### PR DESCRIPTION
Previously, CLI output was only displayed when execution completed.

Now, if StartContinuousOutputUpdate() is called on the CLI module node then the CLI module logic will keep updating the output in the node (until EndContinuousOutputUpdate() is called). Multiple components can call Start/EndContinuousOutputUpdate - the continuous update will remain effect until all EndContinuousOutputUpdate is called for each StartContinuousOutputUpdate.

This is used in every CLI module's GUI (progress detail double-arrow button) and it can be used for monitoring the output in Python scripts (for example, update a transform in real-time based on transform parameters that the module prints on its output - as discussed in https://discourse.slicer.org/t/question-about-registration/26507/7).