### PR TITLE
BUG: Support running multiple processing tasks in parallel

### DIFF
--- a/Base/Logic/vtkSlicerApplicationLogic.h
+++ b/Base/Logic/vtkSlicerApplicationLogic.h
@@ -266,7 +266,7 @@ private:
   std::mutex WriteDataQueueActiveLock;
   std::mutex WriteDataQueueLock;
   vtkTimeStamp RequestTimeStamp;
-  int ProcessingThreadId;
+  std::vector<int> ProcessingThreadIDs;
   std::vector<int> NetworkingThreadIDs;
   int ProcessingThreadActive;
   int ModifiedQueueActive;


### PR DESCRIPTION
This commit creates 2 processing threads to ensure at list two CLIS can be executed in parallel.

It was created in the context of this test project and associated discussion. See https://github.com/KitwareMedical/SlicerParallelTest and https://discourse.slicer.org/t/running-a-module-in-parallel/12641/11