### PR TITLE
Parameter node wrapper support for tuple and dict

### DIFF
--- a/Base/Python/slicer/parameterNodeWrapper/default.py
+++ b/Base/Python/slicer/parameterNodeWrapper/default.py
@@ -1,3 +1,6 @@
+__all__ = ["Default"]
+
+
 class Default:
     """
     Annotation to denote the default value for a parameter.

--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -6,7 +6,26 @@ import typing
 import slicer
 
 from .util import splitAnnotations
-from .validators import *
+from .validators import (
+    extractValidators,
+    NotNone,
+    IsInstance,
+)
+
+__all__ = [
+    "parameterNodeSerializer",
+
+    "Serializer",
+    "ValidatedSerializer",
+    "NumberSerializer",
+    "StringSerializer",
+    "PathSerializer",
+    "BoolSerializer",
+    "NodeSerializer",
+    "ListSerializer",
+    "TupleSerializer",
+    "DictSerializer",
+]
 
 
 class Serializer(abc.ABC):

--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -1,5 +1,6 @@
 import abc
 import collections
+import logging
 import pathlib
 import typing
 
@@ -215,7 +216,7 @@ def createSerializerFromAnnotatedType(annotatedType):
     type_, annotations = splitAnnotations(annotatedType)
     serializer, annotations = createSerializer(type_, annotations)
     if annotations:
-        print(f"Warning: Unused annotations: {annotations}")
+        logging.warning(f"Unused annotations: {annotations}")
     return serializer
 
 
@@ -535,7 +536,7 @@ class ListSerializer(Serializer):
         if ListSerializer.canSerialize(type_):
             args = typing.get_args(type_)
             if len(args) != 1:
-                print("Unexpected list[] type arg length")
+                logging.warning("Unexpected list[] type arg length")
             if len(args) == 0:
                 Exception("Unsure how to handle a typed list with no discernible type")
             return ListSerializer(createSerializerFromAnnotatedType(args[0]))

--- a/Base/Python/slicer/parameterNodeWrapper/util.py
+++ b/Base/Python/slicer/parameterNodeWrapper/util.py
@@ -1,6 +1,8 @@
 import typing
 from typing import Annotated
 
+__all__ = ["splitAnnotations"]
+
 
 def splitAnnotations(possiblyAnnotatedType):
     # Annotated types flatten, so

--- a/Base/Python/slicer/parameterNodeWrapper/validators.py
+++ b/Base/Python/slicer/parameterNodeWrapper/validators.py
@@ -1,5 +1,16 @@
 import abc
 
+__all__ = [
+    "Validator",
+    "NotNone",
+    "IsInstance",
+    "WithinRange",
+    "Minimum",
+    "Maximum",
+    "Choice",
+    "Exclude",
+]
+
 
 class Validator(abc.ABC):
     """

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -1,3 +1,4 @@
+import logging
 import typing
 
 import vtk
@@ -147,7 +148,7 @@ def _processClass(classtype):
         default = default.value if default is not None else serializer.default()
 
         if annotations:
-            print("Warning: unused annotations", annotations)
+            logging.warning(f"Unused annotations: {annotations}")
         try:
             serializer.validate(default)
         except Exception as e:

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -2,11 +2,9 @@ import typing
 
 import vtk
 
-from .default import *
-from .serializers import *
-from .util import *
-from .validators import *
-
+from .default import extractDefault
+from .serializers import Serializer, createSerializer
+from .util import splitAnnotations
 
 __all__ = ["parameterNodeWrapper"]
 

--- a/Docs/developer_guide/parameter_nodes.md
+++ b/Docs/developer_guide/parameter_nodes.md
@@ -63,6 +63,7 @@ The classes that are recognized by default are
 - `vtkMRMLNode` (including subclasses)
 - `list` (hinted as `list[int]`, `list[str]`, etc)
 - `tuple` (hinted as `tuple[int, bool]`, `tuple[str, vtkMRMLNode, float]`, etc)
+- `dict` (hinted as `dict[keyType, valueType]`)
 - `pathlib.Path`
 - `pathlib.PosixPath`
 - `pathlib.WindowsPath`
@@ -120,6 +121,7 @@ If a default is not set explicitly, the following values will be used:
 | `vtkMRMLNode` (including subclasses)             | `None`                                                                                 |
 | `list` (hinted as `list[int]`, `list[str]`, etc) | `[]` (empty list)                                                                      |
 | `tuple` (hinted as `tuple[int, bool]`, etc)      |  A tuple of the defaults of all the elements (e.g. `tuple[int, bool]` -> `(0, False)`) |
+| `dict` (hinted as `dict[keyType, valueType]`)    | `{}` (empty dictionary)                                                                |
 | `pathlib.Path`                                   | `pathlib.Path()` (which is the current directory)                                      |
 | `pathlib.PosixPath`                              | `pathlib.PosixPath()` (which is the current directory)                                 |
 | `pathlib.WindowsPath`                            | `pathlib.WindowsPath()` (which is the current directory)                               |
@@ -297,7 +299,7 @@ This is the chosen behavior for the following reasons:
 
 Because Python objects are returned by reference, when a cached value is returned and then modified, the modification needs to be written back to the parameter node. Otherwise, the cached value and the parameter node will get out of sync.
 
-This write-on-change behavior has been implemented for the ListSerializer. The ListSerializer does not actually return a `list`, it returns an `ObservedList` that updates the parameter node whenever it is modified. `ObservedList` implements most `list` functions. This allows the following to work seamlessly:
+This write-on-change behavior has been implemented for the serializers for `list`, `tuple`, and `dict`. The ListSerializer does not actually return a `list`, it returns an `ObservedList` that updates the parameter node whenever it is modified. `ObservedList` implements most `list` functions. This allows the following to work seamlessly:
 
 ```py
 @parameterNodeWrapper
@@ -334,6 +336,8 @@ The following methods are available for `ObservedList`:
 
 Similarly for a parameter of `list[list[type]]`, an `ObservedList[ObservedList[type]]` is returned.
 When calling `param.values.append`, `param.values[index] = object` or `+=` in these cases, a normal `list` can be passed in and it will be converted to an `ObservedList`.
+
+There are similar mechanisms in place for `tuple` and `dict`.
 
 #### Caching for custom classes
 

--- a/Docs/developer_guide/parameter_nodes.md
+++ b/Docs/developer_guide/parameter_nodes.md
@@ -62,6 +62,7 @@ The classes that are recognized by default are
 - `bool`
 - `vtkMRMLNode` (including subclasses)
 - `list` (hinted as `list[int]`, `list[str]`, etc)
+- `tuple` (hinted as `tuple[int, bool]`, `tuple[str, vtkMRMLNode, float]`, etc)
 - `pathlib.Path`
 - `pathlib.PosixPath`
 - `pathlib.WindowsPath`
@@ -110,20 +111,23 @@ This will make the default value of the `numIterations` parameter 500. If the `n
 
 If a default is not set explicitly, the following values will be used:
 
-| Type                                             | Implicit default                                             |
-|--------------------------------------------------|--------------------------------------------------------------|
-| `int`                                            | `0`                                                          |
-| `float`                                          | `0.0`                                                        |
-| `str`                                            | `""`                                                         |
-| `bool`                                           | `False`                                                      |
-| `vtkMRMLNode` (including subclasses)             | `None`                                                       |
-| `list` (hinted as `list[int]`, `list[str]`, etc) | `[]` (empty list)                                            |
-| `pathlib.Path`                                   | `pathlib.Path()` (which is the current directory)            |
-| `pathlib.PosixPath`                              | `pathlib.PosixPath()` (which is the current directory)       |
-| `pathlib.WindowsPath`                            | `pathlib.WindowsPath()` (which is the current directory)     |
-| `pathlib.PurePath`                               | `pathlib.PurePath()` (which is the current directory)        |
-| `pathlib.PurePosixPath`                          | `pathlib.PurePosixPath()` (which is the current directory)   |
-| `pathlib.PureWindowsPath`                        | `pathlib.PureWindowsPath()` (which is the current directory) |
+| Type                                             | Implicit default                                                                       |
+|--------------------------------------------------|----------------------------------------------------------------------------------------|
+| `int`                                            | `0`                                                                                    |
+| `float`                                          | `0.0`                                                                                  |
+| `str`                                            | `""`                                                                                   |
+| `bool`                                           | `False`                                                                                |
+| `vtkMRMLNode` (including subclasses)             | `None`                                                                                 |
+| `list` (hinted as `list[int]`, `list[str]`, etc) | `[]` (empty list)                                                                      |
+| `tuple` (hinted as `tuple[int, bool]`, etc)      |  A tuple of the defaults of all the elements (e.g. `tuple[int, bool]` -> `(0, False)`) |
+| `pathlib.Path`                                   | `pathlib.Path()` (which is the current directory)                                      |
+| `pathlib.PosixPath`                              | `pathlib.PosixPath()` (which is the current directory)                                 |
+| `pathlib.WindowsPath`                            | `pathlib.WindowsPath()` (which is the current directory)                               |
+| `pathlib.PurePath`                               | `pathlib.PurePath()` (which is the current directory)                                  |
+| `pathlib.PurePosixPath`                          | `pathlib.PurePosixPath()` (which is the current directory)                             |
+| `pathlib.PureWindowsPath`                        | `pathlib.PureWindowsPath()` (which is the current directory)                           |
+
+Note: For specifying the default of a tuple, use `Annotated[tuple[int, bool], Default((4, True))]`, not `tuple[Annotated[int, Default(4)], Annotated[bool, Default(True)]]`. This is mainly to keep consistency between setting default values for `tuple` and all the other classes (including other containers like `list`).
 
 #### Validators
 


### PR DESCRIPTION
Adds support for `tuple[type1, type2, type3, ...]` and `dict[keyType, valueType]`.
Adds an `ObservedDict` similar to the `ObservedList`. I did not think an `ObservedTuple` was  needed due to the immutability of `tuple`s.