### PR TITLE
BUG: Fix sample data set labels not appearing on large desktop monitors

### DIFF
--- a/Modules/Scripted/SampleData/SampleData.py
+++ b/Modules/Scripted/SampleData/SampleData.py
@@ -300,7 +300,11 @@ class SampleDataWidget(ScriptedLoadableModuleWidget):
         iconPath = os.path.join(os.path.dirname(__file__).replace('\\', '/'), 'Resources', 'Icons')
         mainWindow = slicer.util.mainWindow()
         if mainWindow:
-            iconSize = qt.QSize(int(mainWindow.width / 8), int(mainWindow.height / 6))
+            # Set thumbnail size from default icon size. This results in toolbutton size that makes
+            # two columns of buttons fit into the size of the Welcome module's minimum width
+            # on screens with a various resolution and scaling (see qt.QDesktopWidget().size,
+            # desktop.devicePixelRatioF(), qt.QDesktopWidget().physicalDpiX())
+            iconSize = qt.QSize(int(mainWindow.iconSize.width() * 6), int(mainWindow.iconSize.height() * 4))
         else:
             # There is no main window in the automated tests
             desktop = qt.QDesktopWidget()


### PR DESCRIPTION
Fixes the issue of clipped labels in Sample Data module by using the default icon size as a basis, which is more robust than computing it relative to window size.

Before the fix:

![image](https://user-images.githubusercontent.com/307929/207099469-1dc73f98-4cbe-44d7-b203-a5aafac5695a.png)

After the fix:

![image](https://user-images.githubusercontent.com/307929/207099745-2bdfb33b-7f46-4a45-a01b-92b6c443a51e.png)

Tested on both large desktop and small laptop screens.