### PR TITLE
BUG: Fix reading of default markup active color

### DIFF
--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.cxx
@@ -450,7 +450,7 @@ void qSlicerMarkupsModule::readDefaultMarkupsDisplaySettings(vtkMRMLMarkupsDispl
     {
     QVariant variant = settings.value("Markups/ActiveColor");
     QColor qcolor = variant.value<QColor>();
-    markupsDisplayNode->SetColor(qcolor.redF(), qcolor.greenF(), qcolor.blueF());
+    markupsDisplayNode->SetActiveColor(qcolor.redF(), qcolor.greenF(), qcolor.blueF());
     }
   if (settings.contains("Markups/Opacity"))
     {


### PR DESCRIPTION
Fixes issue reported at https://discourse.slicer.org/t/markups-save-to-defaults-colors-misremembered/26732