### PR TITLE
BUG: Fix blank Extensions manager for Linux package due to Chromium sandboxing

### DIFF
--- a/CMake/SlicerBlockCTKAppLauncherSettings.cmake
+++ b/CMake/SlicerBlockCTKAppLauncherSettings.cmake
@@ -284,6 +284,13 @@ if(Slicer_USE_PYTHONQT_WITH_OPENSSL)
     "SSL_CERT_FILE=<APPLAUNCHER_SETTINGS_DIR>/../${Slicer_SHARE_DIR}/Slicer.crt"
     )
 endif()
+if(UNIX AND NOT APPLE)
+  # Disable Chromium Sandboxing on Linux because not all systems support it
+  # (see https://github.com/Slicer/Slicer/issues/6577)
+  list(APPEND SLICER_ENVVARS_INSTALLED
+    "QTWEBENGINE_DISABLE_SANDBOX=1"
+    )
+endif()
 
 # External projects - environment variables
 foreach(varname IN LISTS Slicer_EP_LABEL_ENVVARS_LAUNCHER_INSTALLED)


### PR DESCRIPTION
This commit is a follow-up of 7960e2d28 (BUG: Fix blank Extensions manager on Linux due to Chromium sandboxing).

It ensures that the launcher settings associated with the generated package also set the QTWEBENGINE_DISABLE_SANDBOX environment variable.

Fixes #6577