### PR TITLE
COMP: Fix wrong variable name

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -2082,7 +2082,7 @@ bool qSlicerCoreApplication::loadCaCertificates(const QString& caCertificatesPat
     }
   return !QSslSocket::defaultCaCertificates().empty();
 #else
-  Q_UNUSED(slicerHome);
+  Q_UNUSED(caCertificatesPath);
   return false;
 #endif
 }


### PR DESCRIPTION
`slicerHome` in this context is a member function. It looks to me that the parameter for `Q_UNUSED` shoudl be `caCertificatesPath`. This has not been catched up yet because it falls into an unusual compilation path.