### PR TITLE
COMP: Fix build with OpenSSL support disabled

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -2082,7 +2082,7 @@ bool qSlicerCoreApplication::loadCaCertificates(const QString& caCertificatesPat
     }
   return !QSslSocket::defaultCaCertificates().empty();
 #else
-  Q_UNUSED(slicerHome);
+  Q_UNUSED(caCertificatesPath);
   return false;
 #endif
 }


### PR DESCRIPTION
Fix compilation with `Slicer_USE_PYTHONQT_WITH_OPENSSL` set to `OFF` by addressing a regression introduced in ea2e6f0fc (ENH: Add https support to vtkHTTPHandler).