### PR TITLE
BUG: Update VTK to reintroduce OpenVR API for retrieving last pose

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "97a187572d4000cd820f9fc887f21eaf0bde857c") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "c3337503833f2392f42a2f8af0461fffcdd0c94c") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This commit re-introduces the API removed in kitware/VTK@9bd64d666 (Cleanup and rework of the VRInteractorStyle and subclasses).

This OpenVR specific API allows SlicerVirtualReality extension to query the state of trackers.

```
$ git shortlog 97a187572d..c333750383 --no-merges
Jean-Christophe Fillion-Robin (1):
      [SlicerVirtualReality] ENH: Re-introduce OpenVR API for retrieving last OpenVR pose
```

This should help address issue reported in https://github.com/KitwareMedical/SlicerVirtualReality/issues/91