### PR TITLE
Fix 2 failing tests

### DIFF
--- a/Libs/MRML/Widgets/Resources/UI/qMRMLSliceWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLSliceWidget.ui
@@ -123,7 +123,7 @@
     </hint>
     <hint type="destinationlabel">
      <x>297</x>
-     <y>59</y>
+     <y>14</y>
     </hint>
    </hints>
   </connection>
@@ -140,6 +140,22 @@
     <hint type="destinationlabel">
      <x>297</x>
      <y>59</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qMRMLSliceWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>SliceVerticalController</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>297</x>
+     <y>175</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>5</x>
+     <y>174</y>
     </hint>
    </hints>
   </connection>

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
@@ -59,8 +59,10 @@ void qMRMLSliceWidgetPrivate::init()
   Q_Q(qMRMLSliceWidget);
   this->setupUi(q);
 
-  this->SliceView->sliceViewInteractorStyle()
-    ->SetSliceLogic(this->SliceController->sliceLogic());
+  vtkMRMLSliceLogic* sliceLogic = this->SliceController->sliceLogic();
+
+  this->SliceVerticalController->setSliceLogic(sliceLogic);
+  this->SliceView->sliceViewInteractorStyle()->SetSliceLogic(sliceLogic);
 
   connect(this->SliceView, SIGNAL(resized(QSize)),
           this, SLOT(setSliceViewSize(QSize)));

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
@@ -141,6 +141,9 @@ void qMRMLSliceWidget::setMRMLScene(vtkMRMLScene* newScene)
 
   this->Superclass::setMRMLScene(newScene);
 
+  // In SliceController and  SliceVerticalController widgets
+  // the scene is set by signals defined in the .ui file.
+
   d->qvtkReconnect(
     this->mrmlScene(), newScene,
     vtkMRMLScene::EndBatchProcessEvent, d, SLOT(endProcessing()));

--- a/Modules/Loadable/Data/qSlicerSceneReader.cxx
+++ b/Modules/Loadable/Data/qSlicerSceneReader.cxx
@@ -162,6 +162,9 @@ bool qSlicerSceneReader::load(const qSlicerIO::IOProperties& properties)
       {
       QStringList extensionsList = QString::fromStdString(extensions).split(";");
       QStringList lastLoadedExtensionsList = QString::fromStdString(lastLoadedExtensions).split(";");
+      // If extensions string is empty then it appears as a single empty item in the list. Remove the empty item.
+      extensionsList.removeAll("");
+      lastLoadedExtensionsList.removeAll("");
       QSet<QString> notInstalledExtensions = ctk::qStringListToQSet(lastLoadedExtensionsList).subtract(ctk::qStringListToQSet(extensionsList));
       if (!notInstalledExtensions.isEmpty())
         {


### PR DESCRIPTION
Fixes the two failing tests. Both tests were due to subtle errors introduced by the recently added vertical slice offset slider feature (https://github.com/Slicer/Slicer/commit/2ed9451921d937f2a73d846bd1bf19b956478492).

Also fixed a extension list difference reporting when an incompatible scene is loaded.