### PR TITLE
Parameter node wrapper support for typing.Union

### DIFF
--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -182,7 +182,7 @@ def parameterNodeSerializer(classtype=None):
     def wrap(cls):
         return _processSerializer(cls)
 
-    # See if we're being called as @parameterNode or @parameterNode().
+    # See if we're being called as @parameterNodeSerializer or @parameterNodeSerializer().
     if classtype is None:
         return wrap
     return wrap(classtype)

--- a/Base/Python/slicer/parameterNodeWrapper/validators.py
+++ b/Base/Python/slicer/parameterNodeWrapper/validators.py
@@ -75,7 +75,7 @@ class IsInstance(Validator):
 
     def validate(self, value) -> None:
         if value is not None and not isinstance(value, self.classtype):
-            raise TypeError(f"Value must be of type '{self.classtype}', is type '{type({value})}'")
+            raise TypeError(f"Value must be of type '{self.classtype}', is type '{type(value)}' value '{value}'")
 
 
 class WithinRange(Validator):

--- a/Base/Python/slicer/parameterNodeWrapper/validators.py
+++ b/Base/Python/slicer/parameterNodeWrapper/validators.py
@@ -62,7 +62,7 @@ class IsInstance(Validator):
 
     def validate(self, value) -> None:
         if value is not None and not isinstance(value, self.classtype):
-            raise ValueError(f"Value must be of type '{self.classtype}', is type '{type({value})}'")
+            raise TypeError(f"Value must be of type '{self.classtype}', is type '{type({value})}'")
 
 
 class WithinRange(Validator):

--- a/Base/Python/slicer/parameterNodeWrapper/validators.py
+++ b/Base/Python/slicer/parameterNodeWrapper/validators.py
@@ -36,6 +36,19 @@ def extractValidators(annotations):
     )
 
 
+class IsNone(Validator):
+    """
+    Validates that the input value is None.
+    """
+
+    def __repr__(self) -> str:
+        return f"IsNone()"
+
+    def validate(self, value) -> None:
+        if value is not None:
+            raise ValueError("Value must be None")
+
+
 class NotNone(Validator):
     """
     Validates that any input value is not None.

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -153,7 +153,7 @@ def _processClass(classtype):
         try:
             serializer.validate(default)
         except Exception as e:
-            raise Exception(f"The default parameter of '{default}' fails the validation checks:\n  {str(e)}")
+            raise ValueError(f"The default parameter of '{default}' fails the validation checks:\n  {str(e)}")
 
         parameter = _ParameterInfo(name, serializer, default)
         allParameters.append(parameter)

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
@@ -381,7 +381,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         p.append(7)
         self.assertEqual(param.p, [4, 1, 7])
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             p.append("hi")
         self.assertEqual(param.p, [4, 1, 7])
 
@@ -684,7 +684,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         self.assertEqual(param.output, output)
 
         # cannot set a model to a markup
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             param.output = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScalarVolumeNode')
 
         param.output = None
@@ -703,7 +703,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         param.node = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScalarVolumeNode')
         self.assertIsInstance(param.node, vtkMRMLScalarVolumeNode)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             param.node = 4
 
     def test_events(self):

--- a/Base/Python/slicer/tests/test_slicer_parameter_pack.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_pack.py
@@ -61,7 +61,7 @@ class TypedParameterNodeTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             pack.x = None
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             pack.x = "hi"
 
     def test_parameter_pack_validation(self):
@@ -82,7 +82,7 @@ class TypedParameterNodeTest(unittest.TestCase):
             ParameterPack(0, "c")
         with self.assertRaises(ValueError):
             ParameterPack(None, "a")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             ParameterPack(2.2, 4)
 
     def test_parameter_pack_nesting(self):

--- a/Docs/developer_guide/parameter_nodes.md
+++ b/Docs/developer_guide/parameter_nodes.md
@@ -70,6 +70,8 @@ The classes that are recognized by default are
 - `pathlib.PurePath`
 - `pathlib.PurePosixPath`
 - `pathlib.PureWindowsPath`
+- `typing.Union` (hinted as `typing.Union[int, str]`, `typing.Union[bool, vtkMRMLModelNode, float]`, etc)
+- `typing.Optional` (hinted as `typing.Optional[int]`, `typing.Optional[float]`, etc)
 
 Only lists of these types are recognized by default. For using lists of other types see [Custom Parameter Types](#custom-parameter-types). Nested lists are available via `list[list[int]]`.
 
@@ -112,24 +114,44 @@ This will make the default value of the `numIterations` parameter 500. If the `n
 
 If a default is not set explicitly, the following values will be used:
 
-| Type                                             | Implicit default                                                                       |
-|--------------------------------------------------|----------------------------------------------------------------------------------------|
-| `int`                                            | `0`                                                                                    |
-| `float`                                          | `0.0`                                                                                  |
-| `str`                                            | `""`                                                                                   |
-| `bool`                                           | `False`                                                                                |
-| `vtkMRMLNode` (including subclasses)             | `None`                                                                                 |
-| `list` (hinted as `list[int]`, `list[str]`, etc) | `[]` (empty list)                                                                      |
-| `tuple` (hinted as `tuple[int, bool]`, etc)      |  A tuple of the defaults of all the elements (e.g. `tuple[int, bool]` -> `(0, False)`) |
-| `dict` (hinted as `dict[keyType, valueType]`)    | `{}` (empty dictionary)                                                                |
-| `pathlib.Path`                                   | `pathlib.Path()` (which is the current directory)                                      |
-| `pathlib.PosixPath`                              | `pathlib.PosixPath()` (which is the current directory)                                 |
-| `pathlib.WindowsPath`                            | `pathlib.WindowsPath()` (which is the current directory)                               |
-| `pathlib.PurePath`                               | `pathlib.PurePath()` (which is the current directory)                                  |
-| `pathlib.PurePosixPath`                          | `pathlib.PurePosixPath()` (which is the current directory)                             |
-| `pathlib.PureWindowsPath`                        | `pathlib.PureWindowsPath()` (which is the current directory)                           |
+| Type                                                     | Implicit default                                                                       |
+|----------------------------------------------------------|----------------------------------------------------------------------------------------|
+| `int`                                                    | `0`                                                                                    |
+| `float`                                                  | `0.0`                                                                                  |
+| `str`                                                    | `""`                                                                                   |
+| `bool`                                                   | `False`                                                                                |
+| `vtkMRMLNode` (including subclasses)                     | `None`                                                                                 |
+| `list` (hinted as `list[int]`, `list[str]`, etc)         | `[]` (empty list)                                                                      |
+| `tuple` (hinted as `tuple[int, bool]`, etc)              |  A tuple of the defaults of all the elements (e.g. `tuple[int, bool]` -> `(0, False)`) |
+| `dict` (hinted as `dict[keyType, valueType]`)            | `{}` (empty dictionary)                                                                |
+| `pathlib.Path`                                           | `pathlib.Path()` (which is the current directory)                                      |
+| `pathlib.PosixPath`                                      | `pathlib.PosixPath()` (which is the current directory)                                 |
+| `pathlib.WindowsPath`                                    | `pathlib.WindowsPath()` (which is the current directory)                               |
+| `pathlib.PurePath`                                       | `pathlib.PurePath()` (which is the current directory)                                  |
+| `pathlib.PurePosixPath`                                  | `pathlib.PurePosixPath()` (which is the current directory)                             |
+| `pathlib.PureWindowsPath`                                | `pathlib.PureWindowsPath()` (which is the current directory)                           |
+| `typing.Union` (hinted as `typing.Union[int, str]`, etc) | The default value of the first item in the union.                                      |
+| `typing.Optional` (hinted as `typing.Optional[int]`, `typing.Optional[float]`, etc) | `None`                                                      |
 
-Note: For specifying the default of a tuple, use `Annotated[tuple[int, bool], Default((4, True))]`, not `tuple[Annotated[int, Default(4)], Annotated[bool, Default(True)]]`. This is mainly to keep consistency between setting default values for `tuple` and all the other classes (including other containers like `list`).
+:::{warning}
+If `typing.Union[SomeType, None]` is used, the default will be `None`. This will only happen if there are exactly 2 options in the union and the last one is `None`. In Python (not just the parameter node wrappers), writing `typing.Union[SomeType, None]` is equivalent to writing `typing.Optional[SomeType]`.
+:::
+
+:::{note}
+For specifying the default of a nested-type type like `tuple[int, bool]` or `typing.Union[int, bool]`, specify the default on the outer level. Not allowing something like `tuple[Annotated[int, Default(4)], Annotated[bool, Default(True)]]` is mainly to keep consistency between setting default values for `tuple` and all the other classes (including other containers like `list`, `dict`, and `Union`).
+
+E.g.
+
+```py
+@parameterNodeWrapper
+class ParameterNodeType:
+  validTuple: Annotated[tuple[int, bool], Default((4, True))] # good
+  invalidTuple: tuple[Annotated[int, Default(4)], Annotated[bool, Default(True)]] # bad
+
+  validUnion: Annotated[typing.Union[int, bool], Default(True)] # good
+  invalidUnion: typing.Union[int, Annotated[bool, Default(True)]] # bad
+```
+:::
 
 #### Validators
 


### PR DESCRIPTION
Adds support for `typing.Union`.
Uses better suited exception types.
Minor cleanup.