### PR TITLE
Volumes module Display options improvements and fixes

### DIFF
--- a/Docs/user_guide/modules/volumes.md
+++ b/Docs/user_guide/modules/volumes.md
@@ -101,7 +101,7 @@ Note: Consumer file formats, such as jpg, png, and tiff are not well suited for 
   - Presets: Predefined volume display presets that set window/level and the lookup table for common visualization requirements.
   - Lookup Table: Select the color mapping for scalar volumes to colors.
   - Interpolate: When checked, slice views will display linearly interpolated slices through input volumes. Unchecked indicates nearest neighbor resampling
-  - Window/Level Controls: Double slider with text input to define the range of input volume data that should be mapped to the display grayscale. Auto window level tries to estimate the intensity range of the foreground image data. On mouse over, a popup slides down to add support for large dynamic range by giving control over the range of the window level double slider.
+  - Window/Level Controls: Double slider with text input to define the range of input volume data that should be mapped to the display grayscale. Auto window level tries to estimate the intensity range of the foreground image data. An advanced options button can be clicked to display controls to add support for large dynamic range by giving control over the range of the window level double slider.
   - Threshold: Controls the range of the image that should be considered transparent when used in the foreground layer of the slice display. Same parameters also control transparency of slice models displayed in the 3D viewers.
   - Histogram: Shows the number of pixels (y axis) vs the image intensity (x axis) over a background of the current window/level and threshold mapping.
 - Diffusion Weighted Volumes: The following controls show up when a DWI volume is selected

--- a/Docs/user_guide/modules/volumes.md
+++ b/Docs/user_guide/modules/volumes.md
@@ -98,9 +98,9 @@ Note: Consumer file formats, such as jpg, png, and tiff are not well suited for 
   - Window/Level Presets: Loaded from DICOM headers defined by scanner or by technician.
   - Convert to label map / Convert to scalar volume: Convert the active volume between labelmap and scalar volume.
 - Display: Set of visualization controls appropriate for the currently selected volume. Not all controls are available for all volume types.
+  - Presets: Predefined volume display presets that set window/level and the lookup table for common visualization requirements.
   - Lookup Table: Select the color mapping for scalar volumes to colors.
   - Interpolate: When checked, slice views will display linearly interpolated slices through input volumes. Unchecked indicates nearest neighbor resampling
-  - Window Level Presets: Predefinied shortcuts to window/level and color table combinations for common visualization requirements.
   - Window/Level Controls: Double slider with text input to define the range of input volume data that should be mapped to the display grayscale. Auto window level tries to estimate the intensity range of the foreground image data. On mouse over, a popup slides down to add support for large dynamic range by giving control over the range of the window level double slider.
   - Threshold: Controls the range of the image that should be considered transparent when used in the foreground layer of the slice display. Same parameters also control transparency of slice models displayed in the 3D viewers.
   - Histogram: Shows the number of pixels (y axis) vs the image intensity (x axis) over a background of the current window/level and threshold mapping.

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -49,7 +49,6 @@ vtkMRMLScalarVolumeDisplayNode::vtkMRMLScalarVolumeDisplayNode()
 {
   // Strings
   this->Interpolate = 1;
-  this->WindowLevelLocked = false;
   this->AutoWindowLevel = 1;
   this->AutoThreshold = 0;
   this->ApplyThreshold = 0;
@@ -246,7 +245,6 @@ void vtkMRMLScalarVolumeDisplayNode::WriteXML(ostream& of, int nIndent)
   ss << this->Interpolate;
   of << " interpolate=\"" << ss.str() << "\"";
   }
-  of << " windowLevelLocked=\"" << (this->GetWindowLevelLocked() ? "true" : "false") << "\"";
   {
   std::stringstream ss;
   ss << this->AutoWindowLevel;
@@ -326,10 +324,6 @@ void vtkMRMLScalarVolumeDisplayNode::ReadXMLAttributes(const char** atts)
       ss << attValue;
       ss >> this->Interpolate;
       }
-    else if (!strcmp(attName, "windowLevelLocked"))
-      {
-      this->SetWindowLevelLocked(strcmp(attValue, "true") == 0);
-      }
     else if (!strcmp(attName, "autoWindowLevel"))
       {
       std::stringstream ss;
@@ -367,7 +361,6 @@ void vtkMRMLScalarVolumeDisplayNode::Copy(vtkMRMLNode *anode)
   Superclass::Copy(anode);
   vtkMRMLScalarVolumeDisplayNode *node = (vtkMRMLScalarVolumeDisplayNode *) anode;
 
-  this->SetWindowLevelLocked(node->GetWindowLevelLocked());
   this->SetAutoWindowLevel( node->GetAutoWindowLevel() );
   this->SetWindowLevel(node->GetWindow(), node->GetLevel());
   this->SetAutoThreshold( node->GetAutoThreshold() ); // don't want to run CalculateAutoLevel
@@ -389,7 +382,6 @@ void vtkMRMLScalarVolumeDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 
   Superclass::PrintSelf(os,indent);
 
-  os << indent << "WindowLevelLocked:   " << (this->WindowLevelLocked ? "true" : "false") << "\n";
   os << indent << "AutoWindowLevel:   " << this->AutoWindowLevel << "\n";
   os << indent << "Window:            " << this->GetWindow() << "\n";
   os << indent << "Level:             " << this->GetLevel() << "\n";

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
@@ -67,10 +67,19 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeDisplayNode : public vtkMRMLVolumeDispl
   /// Display Information
   //--------------------------------------------------------------------------
 
-  ///
-  /// Window/Level cannot be edited through the user interface
-  vtkGetMacro(WindowLevelLocked, bool);
-  vtkSetMacro(WindowLevelLocked, bool);
+  /// \deprecated
+  bool GetWindowLevelLocked()
+    {
+    vtkWarningMacro("vtkMRMLScalarVolumeDisplayNode::GetWindowLevelLocked method is deprecated. To check if the mouse mode cannot change window/level, get info from the interaction node. "
+                    "e.g. slicer.app.applicationLogic().GetInteractionNode().GetCurrentInteractionMode() == slicer.vtkMRMLInteractionNode.AdjustWindowLevel");
+    return false;
+    };
+  /// \deprecated
+  virtual void SetWindowLevelLocked(bool)
+    {
+    vtkWarningMacro("vtkMRMLScalarVolumeDisplayNode::SetWindowLevelLocked method is deprecated. To prevent the mouse from changing window/level, set the interaction node to something other than AdjustWindowLevel. "
+                    "e.g. slicer.app.applicationLogic().GetInteractionNode().SetCurrentInteractionMode(slicer.vtkMRMLInteractionNode.ViewTransform)");
+    };
 
   ///
   /// Specifies whether windowing and leveling are to be performed automatically
@@ -221,7 +230,6 @@ protected:
 
   /// Booleans
   int Interpolate;
-  bool WindowLevelLocked;
   int AutoWindowLevel;
   int ApplyThreshold;
   int AutoThreshold;

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -2471,7 +2471,8 @@ bool vtkMRMLSliceLogic::VolumeWindowLevelEditable(const char* volumeNodeID)
     {
     return false;
     }
-  return !scalarVolumeDisplayNode->GetWindowLevelLocked();
+  vtkWarningMacro("vtkMRMLSliceLogic::VolumeWindowLevelEditable method is deprecated. Volume window level can always be set programmatically.");
+  return true;
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/Resources/UI/qMRMLWindowLevelWidget.ui
+++ b/Libs/MRML/Widgets/Resources/UI/qMRMLWindowLevelWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>517</width>
-    <height>55</height>
+    <width>300</width>
+    <height>61</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,46 +19,27 @@
   <property name="windowTitle">
    <string>Window Level</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,1,0,0">
+  <layout class="QGridLayout" name="gridLayout">
    <property name="margin">
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="ctkDoubleSpinBox" name="WindowSpinBox">
-     <property name="prefix">
-      <string>W: </string>
-     </property>
-     <property name="decimals">
-      <number>2</number>
-     </property>
-     <property name="decimalsOption">
-      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Window/Level:</string>
      </property>
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="ctkDoubleSpinBox" name="MinSpinBox">
-     <property name="prefix">
-      <string>Min:</string>
-     </property>
-     <property name="decimals">
-      <number>2</number>
-     </property>
-     <property name="decimalsOption">
-      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
     <widget class="QComboBox" name="AutoManualComboBox">
      <item>
       <property name="text">
-       <string>Auto W/L</string>
+       <string>Auto</string>
       </property>
      </item>
      <item>
       <property name="text">
-       <string>Manual W/L</string>
+       <string>Manual</string>
       </property>
      </item>
      <item>
@@ -68,38 +49,58 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="3">
-    <widget class="ctkDoubleSpinBox" name="MaxSpinBox">
-     <property name="prefix">
-      <string>Max:</string>
-     </property>
-     <property name="decimals">
-      <number>2</number>
-     </property>
-     <property name="decimalsOption">
-      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="4">
-    <widget class="ctkDoubleSpinBox" name="LevelSpinBox">
-     <property name="prefix">
-      <string>L: </string>
-     </property>
-     <property name="decimals">
-      <number>2</number>
-     </property>
-     <property name="decimalsOption">
-      <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="5">
+   <item row="1" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="ctkDoubleSpinBox" name="WindowSpinBox">
+       <property name="prefix">
+        <string>W: </string>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="decimalsOption">
+        <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ctkDoubleSpinBox" name="MinSpinBox">
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="decimalsOption">
+        <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="ctkDoubleRangeSlider" name="WindowLevelRangeSlider">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ctkDoubleSpinBox" name="MaxSpinBox">
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="decimalsOption">
+        <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ctkDoubleSpinBox" name="LevelSpinBox">
+       <property name="prefix">
+        <string>L: </string>
+       </property>
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="decimalsOption">
+        <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts</set>
        </property>
       </widget>
      </item>

--- a/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
+++ b/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
@@ -26,14 +26,38 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
+   <item row="0" column="0" colspan="2">
+    <widget class="QGroupBox" name="PresetsGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Presets:</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
     <widget class="QLabel" name="LookupTableLabel">
      <property name="text">
       <string>Lookup Table:</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="1" column="1">
     <widget class="qMRMLColorTableComboBox" name="ColorTableComboBox">
      <property name="showChildNodeTypes">
       <bool>true</bool>
@@ -46,21 +70,21 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QLabel" name="InterpolateLabel">
      <property name="text">
       <string>Interpolate:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1">
     <widget class="QCheckBox" name="InterpolateCheckbox">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="WindowLevelPresetsLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -73,7 +97,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QPushButton" name="LockWindowLevelButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -148,33 +172,6 @@
         </property>
        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QWidget" name="PresetsWidget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
      </layout>
     </widget>
    </item>

--- a/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
+++ b/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
@@ -130,10 +130,40 @@
     </widget>
    </item>
    <item row="4" column="0" colspan="2">
-    <widget class="qMRMLWindowLevelWidget" name="MRMLWindowLevelWidget"/>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string/>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="qMRMLWindowLevelWidget" name="MRMLWindowLevelWidget"/>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item row="5" column="0" colspan="2">
-    <widget class="qMRMLVolumeThresholdWidget" name="MRMLVolumeThresholdWidget"/>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string/>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="qMRMLVolumeThresholdWidget" name="MRMLVolumeThresholdWidget"/>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item row="6" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="HistogramGroupBox">

--- a/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
+++ b/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
@@ -84,52 +84,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="WindowLevelPresetsLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Window/Level:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="LockWindowLevelButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>30</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="toolTip">
-      <string/>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset>
-       <normaloff>:/Icons/Medium/SlicerUnlock.png</normaloff>:/Icons/Medium/SlicerUnlock.png</iconset>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string/>
@@ -147,7 +102,7 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string/>
@@ -165,7 +120,7 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="HistogramGroupBox">
      <property name="title">
       <string>Histogram</string>

--- a/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
+++ b/Modules/Loadable/Volumes/Widgets/Resources/UI/qSlicerScalarVolumeDisplayWidget.ui
@@ -59,6 +59,9 @@
    </item>
    <item row="1" column="1">
     <widget class="qMRMLColorTableComboBox" name="ColorTableComboBox">
+     <property name="toolTip">
+      <string>Select the color mapping for scalar volumes to colors.</string>
+     </property>
      <property name="showChildNodeTypes">
       <bool>true</bool>
      </property>
@@ -79,6 +82,9 @@
    </item>
    <item row="2" column="1">
     <widget class="QCheckBox" name="InterpolateCheckbox">
+     <property name="toolTip">
+      <string>When checked, slice views will display linearly interpolated slices through input volumes. Unchecked indicates nearest neighbor resampling.</string>
+     </property>
      <property name="text">
       <string/>
      </property>
@@ -122,6 +128,9 @@
    </item>
    <item row="5" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="HistogramGroupBox">
+     <property name="toolTip">
+      <string>Shows the number of pixels (y axis) vs the image intensity (x axis) over a background of the current window/level and threshold mapping.</string>
+     </property>
      <property name="title">
       <string>Histogram</string>
      </property>

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
@@ -99,11 +99,11 @@ void qSlicerScalarVolumeDisplayWidgetPrivate::init()
     qSlicerCoreApplication::application()->moduleLogic("Volumes")) : nullptr);
   if (volumesModuleLogic)
   {
-    QLayout* volumeDisplayPresetsLayout = this->PresetsWidget->layout();
+    QLayout* volumeDisplayPresetsLayout = this->PresetsGroupBox->layout();
     if (!volumeDisplayPresetsLayout)
       {
       volumeDisplayPresetsLayout = new QHBoxLayout;
-      this->PresetsWidget->setLayout(volumeDisplayPresetsLayout);
+      this->PresetsGroupBox->setLayout(volumeDisplayPresetsLayout);
       }
     std::vector<std::string> presetIds = volumesModuleLogic->GetVolumeDisplayPresetIDs();
     for (const auto& presetId : presetIds)
@@ -247,7 +247,7 @@ void qSlicerScalarVolumeDisplayWidget::updateWidgetFromMRML()
       d->LockWindowLevelButton->setIcon(QIcon(":Icons/Medium/SlicerUnlock.png"));
       d->LockWindowLevelButton->setToolTip(tr("Click to prevent modification of Window/Level values"));
       }
-    d->PresetsWidget->setEnabled(!lockedWindowLevel);
+    d->PresetsGroupBox->setEnabled(!lockedWindowLevel);
     d->MRMLWindowLevelWidget->setEnabled(!lockedWindowLevel);
     }
   this->updateHistogram();

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.cxx
@@ -135,8 +135,6 @@ void qSlicerScalarVolumeDisplayWidgetPrivate::init()
                    q, SLOT(setInterpolate(bool)));
   QObject::connect(this->ColorTableComboBox, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
                    q, SLOT(setColorNode(vtkMRMLNode*)));
-  QObject::connect(this->LockWindowLevelButton, SIGNAL(clicked()),
-                   q, SLOT(onLockWindowLevelButtonClicked()));
   QObject::connect(this->HistogramGroupBox, SIGNAL(toggled(bool)),
                    q, SLOT(onHistogramSectionExpanded(bool)));
 }
@@ -235,20 +233,6 @@ void qSlicerScalarVolumeDisplayWidget::updateWidgetFromMRML()
     {
     d->ColorTableComboBox->setCurrentNode(displayNode->GetColorNode());
     d->InterpolateCheckbox->setChecked(displayNode->GetInterpolate());
-    bool lockedWindowLevel = displayNode->GetWindowLevelLocked();
-    d->LockWindowLevelButton->setChecked(lockedWindowLevel);
-    if (lockedWindowLevel)
-      {
-      d->LockWindowLevelButton->setIcon(QIcon(":Icons/Medium/SlicerLock.png"));
-      d->LockWindowLevelButton->setToolTip(tr("Click to enable modification of Window/Level values"));
-      }
-    else
-      {
-      d->LockWindowLevelButton->setIcon(QIcon(":Icons/Medium/SlicerUnlock.png"));
-      d->LockWindowLevelButton->setToolTip(tr("Click to prevent modification of Window/Level values"));
-      }
-    d->PresetsGroupBox->setEnabled(!lockedWindowLevel);
-    d->MRMLWindowLevelWidget->setEnabled(!lockedWindowLevel);
     }
   this->updateHistogram();
 }
@@ -409,19 +393,6 @@ void qSlicerScalarVolumeDisplayWidget::setColorNode(vtkMRMLNode* colorNode)
     }
   Q_ASSERT(vtkMRMLColorNode::SafeDownCast(colorNode));
   displayNode->SetAndObserveColorNodeID(colorNode->GetID());
-}
-
-// --------------------------------------------------------------------------
-void qSlicerScalarVolumeDisplayWidget::onLockWindowLevelButtonClicked()
-{
-  vtkMRMLScalarVolumeDisplayNode* displayNode = this->volumeDisplayNode();
-  if (!displayNode)
-    {
-    return;
-    }
-  // toggle the lock
-  int locked = displayNode->GetWindowLevelLocked();
-  displayNode->SetWindowLevelLocked(!locked);
 }
 
 // --------------------------------------------------------------------------

--- a/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.h
+++ b/Modules/Loadable/Volumes/Widgets/qSlicerScalarVolumeDisplayWidget.h
@@ -55,7 +55,6 @@ protected slots:
   void updateWidgetFromMRML();
   void updateHistogram();
   void onPresetButtonClicked();
-  void onLockWindowLevelButtonClicked();
   void onHistogramSectionExpanded(bool);
 
 protected:


### PR DESCRIPTION
| Slicer 5.2.1 | This PR |
|--------|---------|
|![image](https://user-images.githubusercontent.com/15837524/210019102-b270a764-cab7-4cfe-9ab4-b71ba66761c9.png)|![image](https://user-images.githubusercontent.com/15837524/210019156-a5aa166c-d4dc-413f-ac80-9dddad8115e6.png)|

- Display presets now have a group section which is titled to indicate they are presets. The section is moved to the top as the presets change multiple display settings below (window/level/colormap)
- Window/Level locked state removed
- Window/Level widget reorganized with familiarity of Threshold widget
- Window/Level and Threshold widgets contained in a groupbox for improved clarification about which objects are for W/L vs objects for Threshold.
- Additional tooltips added to widgets in the Display section so users don't have to go to readthedocs to read more details about what they do

------------------------------------------
- `ENH: Organize Window/Level widget similar to Threshold widget` and `ENH: Organize Volumes module W/L and threshold widgets into groupboxes` changes:

| Slicer 5.2.1 | This PR |
|-------|---------|
| ![image](https://user-images.githubusercontent.com/15837524/210018884-d278c94c-5fa6-482f-b8e0-08bb05aa3848.png)![image](https://user-images.githubusercontent.com/15837524/210018927-081085e6-4f1b-4b22-9c60-ccb64cd70f20.png)|![image](https://user-images.githubusercontent.com/15837524/210018791-7875e6bf-eb1d-4024-b305-2b165265500b.png)![image](https://user-images.githubusercontent.com/15837524/210018767-445e2077-84ed-4b5c-892c-26d86b11435c.png)|

- `ENH: Remove window level locked functionality` closes #6738

There was a bug with the window/level lock button not disabling the window/level slider due to changes made in https://github.com/Slicer/Slicer/commit/1af95e000940297c5fada31251c82f3a34264960 and associated commits. Rather than restoring this disabling functionality, the window/level lock functionality is being removed here.

Locking was originally added when left-click-and-drag used to always change Window/Level. However with the introduction of mouse modes there is no longer accidental changing of window/level with the mouse.
