### PR TITLE
BUG: Fix more than one rotation slider can be non-zero

### DIFF
--- a/Libs/MRML/Widgets/qMRMLTransformSliders.cxx
+++ b/Libs/MRML/Widgets/qMRMLTransformSliders.cxx
@@ -22,7 +22,7 @@
 #include "ui_qMRMLTransformSliders.h"
 
 // Qt includes
-#include <QStack>
+#include <QSet>
 
 // qMRML includes
 #include <qMRMLUtils.h>
@@ -47,7 +47,7 @@ public:
 
   int                                    TypeOfTransform;
   vtkMRMLTransformNode*                  MRMLTransformNode;
-  QStack<qMRMLLinearTransformSlider*>    ActiveSliders;
+  QSet<qMRMLLinearTransformSlider*>    ActiveSliders;
 };
 
 // --------------------------------------------------------------------------
@@ -485,7 +485,6 @@ void qMRMLTransformSliders::onSliderPositionChanged(double position)
   qMRMLLinearTransformSlider* slider =
     qobject_cast<qMRMLLinearTransformSlider*>(this->sender());
   Q_ASSERT(slider);
-  d->ActiveSliders.push(slider);
   QWidget* focusWidget = this->focusWidget();
 
   // If update initiated from spinbox, consider it active, too
@@ -495,17 +494,18 @@ void qMRMLTransformSliders::onSliderPositionChanged(double position)
     {
     if (focusWidget->parent() == d->LRSlider->spinBox())
       {
-      d->ActiveSliders.push(d->LRSlider);
+      slider = d->LRSlider;
       }
-    if (focusWidget->parent() == d->PASlider->spinBox())
+    else if (focusWidget->parent() == d->PASlider->spinBox())
       {
-      d->ActiveSliders.push(d->PASlider);
+      slider = d->PASlider;
       }
-    if (focusWidget->parent() == d->ISSlider->spinBox())
+    else if (focusWidget->parent() == d->ISSlider->spinBox())
       {
-      d->ActiveSliders.push(d->ISSlider);
+      slider = d->ISSlider;
       }
     }
+  d->ActiveSliders.insert(slider);
 
   if (this->typeOfTransform() == qMRMLTransformSliders::ROTATION
     || (this->typeOfTransform() == qMRMLTransformSliders::TRANSLATION && coordinateReference() == LOCAL) )
@@ -517,7 +517,7 @@ void qMRMLTransformSliders::onSliderPositionChanged(double position)
   slider->applyTransformation(position);
   emit this->valuesChanged();
 
-  d->ActiveSliders.pop();
+  d->ActiveSliders.remove(slider);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This closes #6735.

Changing spinbox values of sliders was adding duplicate references into the ActiveSliders QStack.

The expected behavior from the documentation is mentioned below and it was previously not being respected.

https://slicer.readthedocs.io/en/latest/user_guide/modules/transforms.html#edit

> "Note: Linear transform edit sliders only show relative translation and rotation because a transformation can be achieved using many different series of transforms. To make this clear to users, only one transform slider can be non-zero at a time (all previously modified sliders are reset to 0 when a slider is moved). The only exception is translation sliders in “translate first” mode (i.e., when translation in global/local coordinate system button is not depressed): in this case there is a only one way how a specific translation can be achieved, therefore transform sliders are not reset to 0."

@lassoan The issue detailed by #6735 appears to have been primarily the result of the changes made in your bug fix commit https://github.com/Slicer/Slicer/commit/48172a2034ef6069844c24f1634403f246ff1bfa. It would be great if you could confirm this bug fix is appropriate.