### PR TITLE
ENH: Replace `lib` by `CMAKE_INSTALL_LIBDIR`

### DIFF
--- a/CMake/SlicerDirectories.cmake
+++ b/CMake/SlicerDirectories.cmake
@@ -52,11 +52,19 @@ if(NOT DEFINED Slicer_MAIN_PROJECT_APPLICATION_NAME)
 endif()
 
 #-----------------------------------------------------------------------------
+# Defaults
+#-----------------------------------------------------------------------------
+if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+mark_as_superbuild(CMAKE_INSTALL_LIBDIR:PATH)
+
+#-----------------------------------------------------------------------------
 # Slicer relative directories
 #-----------------------------------------------------------------------------
 # for build tree
 set(Slicer_BIN_DIR "bin")
-set(Slicer_LIB_DIR "lib/${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}")
+set(Slicer_LIB_DIR "${CMAKE_INSTALL_LIBDIR}/${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}")
 set(Slicer_INCLUDE_DIR "include/${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}")
 set(Slicer_SHARE_DIR "share/${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}")
 set(Slicer_LIBEXEC_DIR "libexec/${Slicer_MAIN_PROJECT_APPLICATION_NAME}-${Slicer_VERSION_MAJOR}.${Slicer_VERSION_MINOR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,7 +659,7 @@ mark_as_superbuild(Slicer_USE_SYSTEM_QT:BOOL)
 #-----------------------------------------------------------------------------
 # Qt plugins (designer, imageformats, ...) relative directories
 #-----------------------------------------------------------------------------
-set(Slicer_QtPlugins_DIR "lib/QtPlugins")
+set(Slicer_QtPlugins_DIR "${CMAKE_INSTALL_LIBDIR}/QtPlugins")
 set(Slicer_INSTALL_QtPlugins_DIR "${Slicer_INSTALL_ROOT}${Slicer_QtPlugins_DIR}")
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
~~This commit modifies `SlicerDirectories.cmake` to add a new CMake variable called `Slicer_LIB_PREFIX`. This variable allows users to specify the directory prefix for installation of 3D Slicer llibraries (e.g., lib or lib64). By default, the value of this variable is set to `lib`, which preserves the previous hard-coded value.~~

This commit modifies `SlicerDirectories.cmake` to replace the hardcoded `lib` part of the library installation path by `CMAKE_INSTALL_LIBDIR`. The use of `CMAKE_INSTALL_LIBDIR` is documented in the following
references:

  - https://cmake.org/cmake/help/latest/command/install.html?highlight=cmake_install_libdire#installing-directories
  - https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#module:GNUInstallDirs

This is useful when building/installing slicer with `Slicer_SUPERBUILD=OFF`