### PR TITLE
ENH: Add missing array size hints for better Python wrapping

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -174,12 +174,12 @@ public:
   vtkSetVector3Macro(LayoutColor, double);
   vtkGetVector3Macro(LayoutColor, double);
 
-  static double* GetRedColor();
-  static double* GetYellowColor();
-  static double* GetGreenColor();
-  static double* GetCompareColor();
-  static double* GetGrayColor();
-  static double* GetThreeDViewBlueColor();
+  static double* GetRedColor() VTK_SIZEHINT(3);
+  static double* GetYellowColor() VTK_SIZEHINT(3);
+  static double* GetGreenColor() VTK_SIZEHINT(3);
+  static double* GetCompareColor() VTK_SIZEHINT(3);
+  static double* GetGrayColor() VTK_SIZEHINT(3);
+  static double* GetThreeDViewBlueColor() VTK_SIZEHINT(3);
 
   /// Tells if it is meaningful to display orientation marker in this view.
   /// It is set statically in each specific view node class and cannot be changed dynamically.

--- a/Libs/MRML/Core/vtkMRMLCameraNode.h
+++ b/Libs/MRML/Core/vtkMRMLCameraNode.h
@@ -121,7 +121,7 @@ public:
   ///
   /// Get the position of the camera in world coordinates.
   /// \sa SetPosition(), GetFocalPoint(), GetViewUp()
-  double *GetPosition();
+  double* GetPosition() VTK_SIZEHINT(3);
   void GetPosition(double position[3]);
 
   ///
@@ -134,7 +134,7 @@ public:
   ///
   /// Get the focal point of the camera in world coordinates.
   /// \sa SetFocalPoint(), GetPosition(), GetViewUp()
-  double *GetFocalPoint();
+  double* GetFocalPoint() VTK_SIZEHINT(3);
   void GetFocalPoint(double focalPoint[3]);
 
   ///
@@ -146,7 +146,7 @@ public:
   ///
   /// Get camera Up vector
   /// \sa SetViewUp(), GetPosition(), GetFocalPoint()
-  double *GetViewUp();
+  double* GetViewUp() VTK_SIZEHINT(3);
   void GetViewUp(double viewUp[3]);
 
   ///

--- a/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.h
+++ b/Libs/MRML/Core/vtkMRMLDiffusionWeightedVolumeNode.h
@@ -63,7 +63,7 @@ class VTK_MRML_EXPORT vtkMRMLDiffusionWeightedVolumeNode : public vtkMRMLScalarV
   ///
   void SetDiffusionGradient(int val, const double g[3]);
   void SetDiffusionGradients(vtkDoubleArray *grad);
-  double *GetDiffusionGradient(int val);
+  double* GetDiffusionGradient(int val) VTK_SIZEHINT(3);
   void GetDiffusionGradient(int val, double g[3]);
   vtkGetObjectMacro(DiffusionGradients,vtkDoubleArray);
 

--- a/Libs/MRML/Core/vtkMRMLModelDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelDisplayNode.h
@@ -130,7 +130,7 @@ public:
   /// Get the threshold range of the model display node.
   /// \sa SetThresholdRange()
   void GetThresholdRange(double range[2]);
-  double* GetThresholdRange();
+  double* GetThresholdRange() VTK_SIZEHINT(2);
   double GetThresholdMin();
   double GetThresholdMax();
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLAbstractWidgetRepresentation.h
@@ -68,7 +68,7 @@ public:
   * (i.e., not implementing the Render() methods properly) or leaking graphics resources
   * (i.e., not implementing ReleaseGraphicsResources() properly).
   */
-  double *GetBounds() VTK_SIZEHINT(6) override { return nullptr; }
+  double* GetBounds() VTK_SIZEHINT(6) override { return nullptr; }
   void GetActors(vtkPropCollection *) override {}
   void GetActors2D(vtkPropCollection *) override {}
   void GetVolumes(vtkPropCollection *) override {}

--- a/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLInteractionEventData.h
@@ -64,7 +64,7 @@ public:
   //@}
 
   void GetDisplayPosition(int v[2]) const;
-  const int *GetDisplayPosition() const;
+  const int* GetDisplayPosition() const VTK_SIZEHINT(2);
   void SetDisplayPosition(const int p[2]);
   bool IsDisplayPositionValid();
   void SetDisplayPositionInvalid();
@@ -97,9 +97,9 @@ public:
   void SetLastScale(double scale);
   double GetLastScale() const;
   void SetTranslation(const double translation[2]);
-  const double *GetTranslation() const;
+  const double* GetTranslation() const VTK_SIZEHINT(2);
   void SetLastTranslation(const double translation[2]);
-  const double* GetLastTranslation() const;
+  const double* GetLastTranslation() const VTK_SIZEHINT(2);
   void SetWorldToPhysicalScale(double v);
   double GetWorldToPhysicalScale() const;
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLModelDisplayableManager.h
@@ -89,7 +89,7 @@ public:
   const char* GetPickedNodeID() override;
 
   /// Get the picked RAS point, returns 0,0,0 if no pick
-  double* GetPickedRAS();
+  double* GetPickedRAS() VTK_SIZEHINT(3);
   /// Set the picked RAS point, returns 0,0,0 if no pick
   void SetPickedRAS(double* newPickedRAS);
 

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionInteractionRepresentation.h
@@ -97,7 +97,7 @@ class VTK_MRML_DISPLAYABLEMANAGER_EXPORT vtkMRMLSliceIntersectionInteractionRepr
     void ComputeSliceIntersectionPoint();
 
     /// Get slice intersection point between red, green and yellow slice nodes
-    double* GetSliceIntersectionPoint();
+    double* GetSliceIntersectionPoint() VTK_SIZEHINT(3);
 
     /// Check whether the mouse cursor is within the slice view or not
     bool IsMouseCursorInSliceView(double cursorPosition[2]);

--- a/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.h
+++ b/Libs/MRML/DisplayableManager/vtkMRMLSliceIntersectionRepresentation2D.h
@@ -84,7 +84,7 @@ public:
   void SetMRMLApplicationLogic(vtkMRMLApplicationLogic*);
   vtkGetObjectMacro(MRMLApplicationLogic, vtkMRMLApplicationLogic);
 
-  double* GetSliceIntersectionPoint();
+  double* GetSliceIntersectionPoint() VTK_SIZEHINT(3);
 
   void TransformIntersectingSlices(vtkMatrix4x4* rotatedSliceToSliceTransformMatrix);
 

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -210,7 +210,7 @@ public:
   /// Get the spacing of the volume, transformed to slice space
   /// - to be used, for example, to set the slice increment for stepping a single
   ///   voxel relative to the current slice view
-  double *GetVolumeSliceSpacing(vtkMRMLVolumeNode *volumeNode);
+  double* GetVolumeSliceSpacing(vtkMRMLVolumeNode *volumeNode) VTK_SIZEHINT(3);
 
   ///
   /// Get the min/max bounds of the volume
@@ -236,7 +236,7 @@ public:
   /// Get the spacing of the volume, transformed to slice space
   /// - to be used, for example, to set the slice increment for stepping a single
   ///   voxel relative to the current slice view
-  double *GetBackgroundSliceSpacing();
+  double* GetBackgroundSliceSpacing() VTK_SIZEHINT(3);
 
   ///
   /// Get the min/max bounds of the volume
@@ -276,7 +276,7 @@ public:
   /// - to be used, for example, to set the slice increment for stepping a single
   ///   voxel relative to the current slice view
   /// - returns first non-null layer
-  double *GetLowestVolumeSliceSpacing();
+  double* GetLowestVolumeSliceSpacing() VTK_SIZEHINT(3);
 
   ///
   /// Get the min/max bounds of the lowest volume layer (background, foreground, label)

--- a/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.h
+++ b/Libs/vtkSegmentationCore/vtkPolyDataToFractionalLabelmapFilter.h
@@ -86,7 +86,7 @@ public:
   void GetOutputImageToWorldMatrix(vtkMatrix4x4* imageToWorldMatrix);
 
   using Superclass::GetOutputOrigin;
-  double* GetOutputOrigin() override;
+  double* GetOutputOrigin() VTK_SIZEHINT(3) override;
   void GetOutputOrigin(double origin[3]) override;
 
   using Superclass::SetOutputOrigin;
@@ -94,13 +94,12 @@ public:
   void SetOutputOrigin(double x, double y, double z) override;
 
   using Superclass::GetOutputSpacing;
-  double* GetOutputSpacing() override;
+  double* GetOutputSpacing() VTK_SIZEHINT(3) override;
   void GetOutputSpacing(double spacing[3]) override;
 
   using Superclass::SetOutputSpacing;
   void SetOutputSpacing(const double spacing[3]) override;
   void SetOutputSpacing(double x, double y, double z) override;
-
 
   /// This method deletes the currently stored cache variables
   void DeleteCache();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation2D.h
@@ -66,7 +66,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
   void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
     int &foundComponentType, int &foundComponentIndex, double &closestDistance2) override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.h
@@ -65,7 +65,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
   bool GetTransformationReferencePoint(double referencePointWorld[3]) override;
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation2D.h
@@ -66,7 +66,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
   void CanInteractWithCurve(vtkMRMLInteractionEventData* interactionEventData,
     int &foundComponentType, int &componentIndex, double &closestDistance2);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerCurveRepresentation3D.h
@@ -66,7 +66,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
   void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
     int &foundComponentType, int &foundComponentIndex, double &closestDistance2) override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation2D.h
@@ -64,9 +64,8 @@ public:
   int RenderTranslucentPolygonalGeometry(vtkViewport *viewport) override;
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
-
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
 protected:
   vtkSlicerLineRepresentation2D();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.h
@@ -67,7 +67,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
 protected:
   vtkSlicerLineRepresentation3D();

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation.h
@@ -335,7 +335,7 @@ protected:
 
   vtkTimeStamp MarkupsTransformModifiedTime;
 
-  double* GetWidgetColor(int controlPointType);
+  double* GetWidgetColor(int controlPointType) VTK_SIZEHINT(3);
 
   ControlPointsPipeline* ControlPoints[NumberOfControlPointTypes]; // Unselected, Selected, Active, Project, ProjectBehind
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -66,7 +66,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
   void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
     int &foundComponentType, int &foundComponentIndex, double &closestDistance2) override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation2D.h
@@ -71,7 +71,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
   void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
     int &foundComponentType, int &foundComponentIndex, double &closestDistance2) override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerPlaneRepresentation3D.h
@@ -72,7 +72,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
   bool GetTransformationReferencePoint(double referencePointWorld[3]) override;
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation2D.h
@@ -69,7 +69,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
   void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
     int& foundComponentType, int& foundComponentIndex, double& closestDistance2) override;

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerROIRepresentation3D.h
@@ -79,7 +79,7 @@ public:
   vtkTypeBool HasTranslucentPolygonalGeometry() override;
 
   /// Return the bounds of the representation
-  double *GetBounds() override;
+  double* GetBounds() VTK_SIZEHINT(6) override;
 
   void CanInteract(vtkMRMLInteractionEventData* interactionEventData,
     int& foundComponentType, int& foundComponentIndex, double& closestDistance2) override;


### PR DESCRIPTION
VTK Python wrapper requires a size hint in the header file (such as "VTK_SIZEHINT(3)") to be able to return a double* pointer as a float vector. This commit adds the missing size hints.

Example:

    print(slicer.mrmlScene.GetFirstNodeByClass('vtkMRMLCameraNode').GetPosition())

Returns a raw pointer without size hint:

    _00000272e44bc7b0_p_void

Returns a vector if a size hint is added to the method declaration:

    (0.0, 500.0, 0.0)