### PR TITLE
DOC: Remove Pixel Medical from commercial partners

### DIFF
--- a/Docs/user_guide/about.md
+++ b/Docs/user_guide/about.md
@@ -190,10 +190,9 @@ We invite commercial entities to use 3D Slicer.
 
 ### Commercial Partners
 
-- [Ebatinca SL](https://ebatinca.com/) is an international technology company in Las Palmas, Spain focused on technology for sustainable development.
+- [Ebatinca SL](https://ebatinca.com/) is an international technology company in Las Palmas, Spain focused on technology for sustainable development. Primary areas: ultrasound navigation and training, collaborative VR, research support, custom Slicer-based solutions.
 - [Isomics](https://isomics.com/) uses 3D Slicer in a variety of academic and commercial research partnerships in fields such as planning and guidance for neurosurgery, quantitative imaging for clinical trials, clinical image informatics.
 - [Kitware](https://www.kitware.com/opensource/slicer.html) focuses on solving the world’s most complex scientific challenges through customized software solutions. The company has a long history of contributing to open source platforms that serve as the foundation of many medical visualization and data processing applications. Kitware helps customers develop commercial products based on 3D Slicer and has used the platform to rapidly prototype solutions in nearly every aspect of medical imaging.
-- [Pixel Medical](https://pixelmedical.ca) builds on and contributes to 3D Slicer to develop innovative medical software from idea to clinical prototype to finished product, and to support academic research projects. Areas of expertise include radiation therapy, image guided therapy, virtual & augmented reality, hardware & device support, and machine learning & artificial intelligence.
 
 _Listed in alphabetical order._
 


### PR DESCRIPTION
- Due to ceasing its operations, Pixel Medical is removed from the commercial partners list
- Add some details to the Ebatinca commercial partner