### PR TITLE
ENH: make error report box bigger

### DIFF
--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2765,6 +2765,11 @@ def messageBox(text, parent=None, **kwargs):
         slicer.util.delayDisplay(text, autoCloseMsec=3000, parent=parent, **kwargs)
         return testingReturnValue
 
+    # if there is detailed text, make the dialog wider by making a long title
+    if "detailedText" in kwargs:
+        windowTitle = kwargs['windowTitle'] if 'windowTitle' in kwargs else ""
+        kwargs['windowTitle'] = windowTitle + " "*(200-len(windowTitle))
+
     import ctk
     mbox = ctk.ctkMessageBox(parent if parent else mainWindow())
     mbox.text = text

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2767,8 +2767,9 @@ def messageBox(text, parent=None, **kwargs):
 
     # if there is detailed text, make the dialog wider by making a long title
     if "detailedText" in kwargs:
-        windowTitle = kwargs['windowTitle'] if 'windowTitle' in kwargs else ""
-        kwargs['windowTitle'] = windowTitle + " "*(200-len(windowTitle))
+        windowTitle = kwargs['windowTitle'] if 'windowTitle' in kwargs else slicer.app.applicationName
+        padding = " "*((150 - len(windowTitle)) // 2) # to center the title
+        kwargs['windowTitle'] = padding + windowTitle + padding
 
     import ctk
     mbox = ctk.ctkMessageBox(parent if parent else mainWindow())

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -2768,7 +2768,7 @@ def messageBox(text, parent=None, **kwargs):
     # if there is detailed text, make the dialog wider by making a long title
     if "detailedText" in kwargs:
         windowTitle = kwargs['windowTitle'] if 'windowTitle' in kwargs else slicer.app.applicationName
-        padding = " "*((150 - len(windowTitle)) // 2) # to center the title
+        padding = " " * ((150 - len(windowTitle)) // 2)  # to center the title
         kwargs['windowTitle'] = padding + windowTitle + padding
 
     import ctk


### PR DESCRIPTION
Qt doesn't offer users any way to resize a message box, even when the detailedText field is displayed with lots of text. I didn't find a good way to resize programmatically either.

This is a problem with something like a python stack trace is displayed and the word wrapping makes it hard to read.

This workraound makes the title artificially bigger so that the message box size is wider than normal.