### PR TITLE
COMP: put literal after string format for translation

### DIFF
--- a/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx
+++ b/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx
@@ -419,18 +419,18 @@ protected:
       {
       statusText += QLatin1Literal("<p style=\"font-weight: bold; font-size: 80%; color: %1;\">"
         "<img style=\"float: left\" src=\":/Icons/ExtensionIncompatible.svg\"/> ") +
-        qSlicerExtensionsLocalWidget::tr("Not found for this version of the application (r%2)") + QLatin1Literal("</p>")
+        qSlicerExtensionsLocalWidget::tr("Not found for this version of the application (r%2)")
         .arg(this->WarningColor)
-        .arg(this->SlicerRevision);
+        .arg(this->SlicerRevision) + QLatin1Literal("</p>");
       }
     if (!compatible)
       {
       statusText += QLatin1Literal("<p style=\"font-weight: bold; font-size: 80%; color: %1;\">"
         "<img style=\"float: left\" src=\":/Icons/ExtensionIncompatible.svg\"/> ") +
-        qSlicerExtensionsLocalWidget::tr("Incompatible with Slicer r%2 [built for r%3]") + QLatin1Literal("</p>")
+        qSlicerExtensionsLocalWidget::tr("Incompatible with Slicer r%2 [built for r%3]")
         .arg(this->WarningColor)
         .arg(this->SlicerRevision)
-        .arg(this->WidgetItem->data(qSlicerExtensionsLocalWidgetPrivate::InstalledExtensionSlicerVersionRole).toString());
+        .arg(this->WidgetItem->data(qSlicerExtensionsLocalWidgetPrivate::InstalledExtensionSlicerVersionRole).toString()) + QLatin1Literal("</p>");
       }
     if (this->WidgetItem->data(qSlicerExtensionsLocalWidgetPrivate::UpdateAvailableRole).toBool() && !scheduledForUpdate)
       {


### PR DESCRIPTION
Without this change I get this build error on my linux build:

```
[ 40%] Building CXX object Base/QTGUI/CMakeFiles/qSlicerBaseQTGUI.dir/qSlicerExtensionsLocalWidget.cxx.o
/home/pieper/slicer4/latest/Slicer/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx: In member function ‘void {anonymous}::qSlicerExtensionsDescriptionLabel::labelText(const QString&)’:
/home/pieper/slicer4/latest/Slicer/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx:423:10: error: ‘QLatin1Literal’ {aka ‘class QLatin1String’} has no member named ‘arg’
  423 |         .arg(this->WarningColor)
      |          ^~~
/home/pieper/slicer4/latest/Slicer/Base/QTGUI/qSlicerExtensionsLocalWidget.cxx:431:10: error: ‘QLatin1Literal’ {aka ‘class QLatin1String’} has no member named ‘arg’
  431 |         .arg(this->WarningColor)
      |          ^~~
make[2]: *** [Base/QTGUI/CMakeFiles/qSlicerBaseQTGUI.dir/build.make:1267: Base/QTGUI/CMakeFiles/qSlicerBaseQTGUI.dir/qSlicerExtensionsLocalWidget.cxx.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:6843: Base/QTGUI/CMakeFiles/qSlicerBaseQTGUI.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

The build requiring this fix is qt 5.12.8 with gcc 9.4.0.