### PR TITLE
BUG: Fix computation of offset direction label in slicer view controller

### DIFF
--- a/Docs/user_guide/user_interface.md
+++ b/Docs/user_guide/user_interface.md
@@ -166,7 +166,7 @@ View Controllers module provides an alternate way of displaying these controller
 - **Slice orientation** displays allows you to choose the orientation for this slice view.
 - **Lightbox** to select a mosiac (a.k.a. contact sheet) view.  Not all operations work in this mode and it may be removed in the future.
 - **Reformat** allows interactive manipulation of the slice orientation.
-- **Slice offset slider** allows slicing through the volume. Step size is set to the background volume's spacing by default but can be modified by clicking on "Spacing and field of view" button.
+- **Slice offset slider** allows slicing through the volume. Step size is set to the background volume's spacing by default but can be modified by clicking on "Spacing and field of view" button. The label next to the offset value (e.g., `S`, `L`, `A`, `IL`, `IRP`) reflects the slice normal direction. If the offset slider moved to the right then the slice moves in this normal direction. If the slice normal direction is not aligned with an axis then the label contains a combination of directions, with the order of axes reflecting the dominance of the axis. For example, if the plane normal points to anterior and slightly left then the label is `AL`, while if the plane normal mostly left and slightly anterior then the label is `LA`.
 - **Blending mode** specifies how foreground and background layers are mixed.
 - **Spacing and field of view** Spacing defines the increment for the slice offset slider. Field of view sets the zoom level for the slice.
 - **Rotate to volume plane** changes the orientation of the slice to match the closest acquisition orientation of the displayed volume.

--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.h
@@ -275,6 +275,12 @@ public:
   const char* GetAxisLabel(int labelIndex);
   void SetAxisLabel(int labelIndex, const char* label);
 
+  /// Returns label for the specified direction. For example, (1,0,0) direction returns
+  /// the positive x axis label "R".
+  /// toleranceDeg specifies the tolerance when when determining if the direction
+  /// is parallel with an axis.
+  std::string GetDirectionLabel(double direction[3], bool positive=true, double toleranceDeg=1.0);
+
   /// Total number of coordinate system axis labels
   static const int AxisLabelsCount;
 

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget_p.h
@@ -63,13 +63,6 @@ class vtkMRMLSegmentationDisplayNode;
 class vtkMRMLSelectionNode;
 
 //-----------------------------------------------------------------------------
-struct QMRML_WIDGETS_EXPORT qMRMLOrientation
-{
-  QString Prefix;
-  QString ToolTip;
-};
-
-//-----------------------------------------------------------------------------
 class QMRML_WIDGETS_EXPORT qMRMLSliceControllerWidgetPrivate
   : public qMRMLViewControllerBarPrivate
   , public Ui_qMRMLSliceControllerWidget
@@ -98,8 +91,6 @@ public:
   void setupMoreOptionsMenu();
   void setupOrientationMarkerMenu();
   void setupRulerMenu();
-
-  qMRMLOrientation mrmlOrientation(const QString& name);
 
   vtkSmartPointer<vtkCollection> saveNodesForUndo(const QString& nodeTypes);
 
@@ -178,7 +169,6 @@ public:
   vtkSmartPointer<vtkMRMLSliceLogic>  SliceLogic;
   vtkCollection*                      SliceLogics;
   vtkWeakPointer<vtkAlgorithmOutput>  ImageDataConnection;
-  QHash<QString, qMRMLOrientation>    SliceOrientationToDescription;
   QButtonGroup*                       ControllerButtonGroup;
 
   QToolButton*                        FitToWindowToolButton;


### PR DESCRIPTION
Sagittal plane offset direction label "R" was incorrect: moving the slider to the right did not move the slice in "R" direction (while for axial and coronal slices, moving the slider to the right moved the slice according to the direction specified in the label).

Instead of changing the incorrect "R" label to "L", this commit removes the hardcoded labels and instead computes the correct label dynamically. If the slice normal direction is not aligned with an axis then the label contains a combination of directions. The order of axes reflects the dominance of the axis. For example, if the plane normal points to anterior and slightly left then the label is AL.

fixes #6778