### PR TITLE
Parameter node wrapper gui connection

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -308,6 +308,12 @@ slicer_add_python_unittest(
   TESTNAME_PREFIX nomainwindow_
   )
 
+slicer_add_python_unittest(
+  SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
+  SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules
+  TESTNAME_PREFIX nomainwindow_
+  )
+
 ## Test reading MGH file format types.
 slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_mgh.py

--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -4,6 +4,7 @@ set(Slicer_PYTHON_SCRIPTS
   slicer/logic
   slicer/parameterNodeWrapper/__init__
   slicer/parameterNodeWrapper/default
+  slicer/parameterNodeWrapper/guiConnectors
   slicer/parameterNodeWrapper/parameterInfo
   slicer/parameterNodeWrapper/parameterPack
   slicer/parameterNodeWrapper/serializers

--- a/Base/Python/CMakeLists.txt
+++ b/Base/Python/CMakeLists.txt
@@ -4,6 +4,7 @@ set(Slicer_PYTHON_SCRIPTS
   slicer/logic
   slicer/parameterNodeWrapper/__init__
   slicer/parameterNodeWrapper/default
+  slicer/parameterNodeWrapper/parameterInfo
   slicer/parameterNodeWrapper/parameterPack
   slicer/parameterNodeWrapper/serializers
   slicer/parameterNodeWrapper/util

--- a/Base/Python/slicer/parameterNodeWrapper/__init__.py
+++ b/Base/Python/slicer/parameterNodeWrapper/__init__.py
@@ -1,5 +1,11 @@
 from .default import *
+from .guiConnectors import *
 from .parameterPack import *
 from .serializers import *
 from .validators import *
+from .util import (
+    findFirstAnnotation,
+    splitAnnotations,
+    unannotatedType,
+)
 from .wrapper import *

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -1,0 +1,709 @@
+import abc
+import enum
+import pathlib
+import logging
+
+import ctk
+import qt
+
+import slicer
+from qSlicerSubjectHierarchyModuleWidgetsPythonQt import qMRMLSubjectHierarchyTreeView
+from . import parameterPack as pack
+from . import validators
+from .util import (
+    findFirstAnnotation,
+    getNodeTypes,
+    isNodeOrUnionOfNodes,
+    splitAnnotations,
+    unannotatedType,
+)
+
+
+__all__ = [
+    "parameterNodeGuiConnector",
+    "GuiConnector",
+    "SlicerPackParameterNamePropertyName",
+]
+
+
+class GuiConnector(abc.ABC):
+    """
+    Base class for converting from widgets to a datatype.
+    """
+
+    @staticmethod
+    @abc.abstractmethod
+    def canRepresent(widget, datatype) -> bool:
+        """
+        Whether this type can represent the given datatype using the given widget.
+        The datatype may be annotated.
+        """
+        raise NotImplementedError("Must implement canRepresent")
+
+    @staticmethod
+    @abc.abstractmethod
+    def create(widget, datatype):
+        """
+        Creates a new connector adapting the given widget object to the given (possibly annotated) datatype.
+        """
+        raise NotImplementedError("Must implement create")
+
+    def __init__(self):
+        super().__init__()
+        self._callback = None
+
+    def onChanged(self, callback):
+        self._callback = callback
+        if self._callback is None:
+            # disconnect to remove the reference on this connector from
+            # widget so this connector can possibly be garbage collected.
+            self._disconnect()
+        else:
+            self._connect()
+
+    def changed(self):
+        if self._callback:
+            self._callback()
+
+    @abc.abstractmethod
+    def _connect(self):
+        """
+        Make the necessary connection(s) to the widget.
+        """
+        raise NotImplementedError("Must implement _connect")
+
+    @abc.abstractmethod
+    def _disconnect(self):
+        """
+        Make the necessary disconnection(s) to the widget.
+        """
+        raise NotImplementedError("Must implement _disconnect")
+
+    @abc.abstractmethod
+    def widget(self):
+        """
+        Returns the underlying widget.
+        """
+        raise NotImplementedError("Must implement widget")
+
+    @abc.abstractmethod
+    def read(self):
+        """
+        Returns the value from the widget as the given datatype.
+        """
+        raise NotImplementedError("Must implement read")
+
+    @abc.abstractmethod
+    def write(self, value) -> None:
+        """
+        Writes the given value to the widget.
+        """
+        raise NotImplementedError("Must implement write")
+
+
+_registeredGuiConnectors = []
+
+
+def _processGuiConnector(classtype):
+    if not issubclass(classtype, GuiConnector):
+        raise TypeError("Must be a GuiConnector subclass")
+    global _registeredGuiConnectors
+    _registeredGuiConnectors.append(classtype)
+    return classtype
+
+
+def createGuiConnector(widget, datatype) -> GuiConnector:
+    """
+    Creates an appropriate GuiConnector for the given widget object and possibly annotated datatype.
+    Raises a RuntimeError if no appropriate GuiConnector is found.
+    """
+    for possibleConnectorType in _registeredGuiConnectors:
+        if possibleConnectorType.canRepresent(widget, datatype):
+            return possibleConnectorType.create(widget, datatype)
+    raise RuntimeError(f"Unable to create GUI connector from datatype '{datatype}' to widget type '{type(widget)}'")
+
+
+def parameterNodeGuiConnector(classtype=None):
+    """
+    Class decorator to register a new parameter node gui connector.
+    """
+    def wrap(cls):
+        return _processGuiConnector(cls)
+
+    # See if we're being called as @parameterNodeGuiConnector or @parameterNodeGuiConnector().
+    if classtype is None:
+        return wrap
+    return wrap(classtype)
+
+
+@parameterNodeGuiConnector
+class QCheckBoxToBoolConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return unannotatedType(datatype) == bool and type(widget) == qt.QCheckBox
+
+    @staticmethod
+    def create(widget, datatype):
+        if QCheckBoxToBoolConnector.canRepresent(widget, datatype):
+            # no annotations are handled
+            return QCheckBoxToBoolConnector(widget)
+        return None
+
+    def __init__(self, widget: qt.QCheckBox):
+        super().__init__()
+        self._widget: qt.QCheckBox = widget
+
+    def _connect(self):
+        self._widget.stateChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.stateChanged.disconnect(self.changed)
+
+    def widget(self) -> qt.QCheckBox:
+        return self._widget
+
+    def read(self) -> bool:
+        return self._widget.checked
+
+    def write(self, value: bool) -> None:
+        self._widget.checked = value
+
+
+@parameterNodeGuiConnector
+class QCheckablePushButtonToBoolConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return unannotatedType(datatype) == bool and type(widget) == qt.QPushButton
+
+    @staticmethod
+    def create(widget, datatype):
+        if QCheckablePushButtonToBoolConnector.canRepresent(widget, datatype):
+            # no annotations are handled
+            return QCheckablePushButtonToBoolConnector(widget)
+        return None
+
+    def __init__(self, widget: qt.QPushButton):
+        super().__init__()
+        self._widget: qt.QPushButton = widget
+        if not self._widget.checkable:
+            logging.warn(f"Making push button checkable for conversion to bool: button {self._widget}, parent {self._widget.parent}")
+            self._widget.checkable = True
+
+    def _connect(self):
+        self._widget.toggled.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.toggled.disconnect(self.changed)
+
+    def widget(self) -> qt.QPushButton:
+        return self._widget
+
+    def read(self) -> bool:
+        return self._widget.checked
+
+    def write(self, value: bool) -> None:
+        self._widget.checked = value
+
+
+@parameterNodeGuiConnector
+class QSliderOrSpinBoxToIntConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return unannotatedType(datatype) == int and type(widget) in (qt.QSlider, qt.QSpinBox)
+
+    @staticmethod
+    def create(widget, datatype):
+        if QSliderOrSpinBoxToIntConnector.canRepresent(widget, datatype):
+            annotations = splitAnnotations(datatype)[1]
+            return QSliderOrSpinBoxToIntConnector(widget, annotations)
+        return None
+
+    def __init__(self, widget, annotations):
+        super().__init__()
+        self._widget = widget
+
+        minimum = findFirstAnnotation(annotations, validators.Minimum)
+        if minimum is not None:
+            self._widget.setMinimum(minimum.minimum)
+        else:
+            # was unable to set lower than this
+            self._widget.setMinimum(-2**31)
+        maximum = findFirstAnnotation(annotations, validators.Maximum)
+        if maximum is not None:
+            self._widget.setMaximum(maximum.maximum)
+        else:
+            # was unable to set higher than this
+            self._widget.setMaximum(2**31 - 1)
+        withinRange = findFirstAnnotation(annotations, validators.WithinRange)
+        if withinRange is not None:
+            self._widget.setRange(withinRange.minimum, withinRange.maximum)
+
+    def _connect(self):
+        self._widget.valueChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.valueChanged.disconnect(self.changed)
+
+    def widget(self):
+        return self._widget
+
+    def read(self) -> int:
+        return self._widget.value
+
+    def write(self, value: int) -> None:
+        self._widget.value = value
+
+
+@parameterNodeGuiConnector
+class QDoubleSpinBoxCtkSliderWidgetToFloatConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return unannotatedType(datatype) == float and type(widget) in (
+            qt.QDoubleSpinBox, ctk.ctkSliderWidget
+        )
+
+    @staticmethod
+    def create(widget, datatype):
+        if QDoubleSpinBoxCtkSliderWidgetToFloatConnector.canRepresent(widget, datatype):
+            annotations = splitAnnotations(datatype)[1]
+            return QDoubleSpinBoxCtkSliderWidgetToFloatConnector(widget, annotations)
+        return None
+
+    def __init__(self, widget, annotations):
+        super().__init__()
+        self._widget = widget
+
+        minimum = findFirstAnnotation(annotations, validators.Minimum)
+        if minimum is not None:
+            self._widget.minimum = minimum.minimum
+        else:
+            self._widget.minimum = float("-inf")
+        maximum = findFirstAnnotation(annotations, validators.Maximum)
+        if maximum is not None:
+            self._widget.maximum = maximum.maximum
+        else:
+            self._widget.maximum = float("inf")
+        withinRange = findFirstAnnotation(annotations, validators.WithinRange)
+        if withinRange is not None:
+            self._widget.minimum = withinRange.minimum
+            self._widget.maximum = withinRange.maximum
+
+    def _connect(self):
+        self._widget.valueChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.valueChanged.disconnect(self.changed)
+
+    def widget(self):
+        return self._widget
+
+    def read(self) -> float:
+        return self._widget.value
+
+    def write(self, value: float) -> None:
+        self._widget.value = value
+
+
+@parameterNodeGuiConnector
+class QComboBoxToStringableConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == qt.QComboBox and unannotatedType(datatype) in (
+            int, float, str, bool
+        )
+
+    @staticmethod
+    def create(widget, datatype):
+        if QComboBoxToStringableConnector.canRepresent(widget, datatype):
+            _, annotations = splitAnnotations(datatype)
+            choice = findFirstAnnotation(annotations, validators.Choice)
+            if choice is None:
+                raise RuntimeError("ComboBoxToStringableConnector requires the Choice annotation to be used.")
+            return QComboBoxToStringableConnector(widget, choice.choices)
+        return None
+
+    def __init__(self, widget: qt.QComboBox, choices):
+        super().__init__()
+        self._widget: qt.QComboBox = widget
+        self._choices = choices
+
+        self._widget.clear()
+        for c in self._choices:
+            self._widget.addItem(str(c))
+
+    def _connect(self):
+        self._widget.currentIndexChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.currentIndexChanged.disconnect(self.changed)
+
+    def widget(self) -> qt.QComboBox:
+        return self._widget
+
+    def read(self):
+        return self._choices[self._widget.currentIndex]
+
+    def write(self, value) -> None:
+        for index, c in enumerate(self._choices):
+            if c == value:
+                self._widget.currentIndex = index
+                break
+        else:
+            raise ValueError(f"Unable to find value {value} in choices {self._choices}")
+
+
+@parameterNodeGuiConnector
+class QComboBoxToEnumConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == qt.QComboBox and issubclass(unannotatedType(datatype), enum.Enum)
+
+    @staticmethod
+    def create(widget, datatype):
+        if QComboBoxToEnumConnector.canRepresent(widget, datatype):
+            return QComboBoxToEnumConnector(widget, datatype)
+        return None
+
+    def __init__(self, widget: qt.QComboBox, datatype: enum.Enum):
+        super().__init__()
+        self._widget: qt.QComboBox = widget
+
+        underlyingType = unannotatedType(datatype)
+        labelFunc = getattr(underlyingType, "label", lambda x: x.name)
+
+        self._labelToEnum = [(labelFunc(e), e) for e in underlyingType]
+
+        self._widget.clear()
+        for label, _ in self._labelToEnum:
+            self._widget.addItem(label)
+
+    def _connect(self):
+        self._widget.currentIndexChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.currentIndexChanged.disconnect(self.changed)
+
+    def widget(self) -> qt.QComboBox:
+        return self._widget
+
+    def read(self):
+        return self._labelToEnum[self._widget.currentIndex][1]
+
+    def write(self, value) -> None:
+        for index, (_, e) in enumerate(self._labelToEnum):
+            if e == value:
+                self._widget.currentIndex = index
+                break
+        else:
+            raise ValueError(f"Unable to find value {value} in choices {self._choices}")
+
+
+@parameterNodeGuiConnector
+class QLineEditToStrConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == qt.QLineEdit and unannotatedType(datatype) == str
+
+    @staticmethod
+    def create(widget, datatype):
+        if QLineEditToStrConnector.canRepresent(widget, datatype):
+            return QLineEditToStrConnector(widget)
+        return None
+
+    def __init__(self, widget: qt.QLineEdit):
+        super().__init__()
+        self._widget: qt.QLineEdit = widget
+
+    def _connect(self):
+        self._widget.textChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.textChanged.disconnect(self.changed)
+
+    def widget(self) -> qt.QLineEdit:
+        return self._widget
+
+    def read(self) -> str:
+        return self._widget.text
+
+    def write(self, value: str) -> None:
+        self._widget.text = value
+
+
+@parameterNodeGuiConnector
+class QTextEditPlainTextToStrConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == qt.QTextEdit and unannotatedType(datatype) == str
+
+    @staticmethod
+    def create(widget, datatype):
+        if QTextEditPlainTextToStrConnector.canRepresent(widget, datatype):
+            return QTextEditPlainTextToStrConnector(widget)
+        return None
+
+    def __init__(self, widget: qt.QTextEdit):
+        super().__init__()
+        self._widget: qt.QTextEdit = widget
+
+    def _connect(self):
+        self._widget.textChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.textChanged.disconnect(self.changed)
+
+    def widget(self) -> qt.QTextEdit:
+        return self._widget
+
+    def read(self) -> str:
+        return self._widget.toPlainText()
+
+    def write(self, value: str) -> None:
+        self._widget.setPlainText(value)
+
+
+@parameterNodeGuiConnector
+class ctkPathLineEditToPathConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == ctk.ctkPathLineEdit and unannotatedType(datatype) in (
+            pathlib.Path, pathlib.PosixPath, pathlib.WindowsPath,
+            pathlib.PurePath, pathlib.PurePosixPath, pathlib.PureWindowsPath,
+        )
+
+    @staticmethod
+    def create(widget, datatype):
+        if ctkPathLineEditToPathConnector.canRepresent(widget, datatype):
+            return ctkPathLineEditToPathConnector(widget, datatype)
+        return None
+
+    def __init__(self, widget: ctk.ctkPathLineEdit, datatype):
+        super().__init__()
+        self._widget: ctk.ctkPathLineEdit = widget
+        self._type = unannotatedType(datatype)
+
+    def _connect(self):
+        self._widget.currentPathChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.currentPathChanged.disconnect(self.changed)
+
+    def widget(self) -> ctk.ctkPathLineEdit:
+        return self._widget
+
+    def read(self):
+        return self._type(self._widget.currentPath)
+
+    def write(self, value) -> None:
+        self._widget.currentPath = str(value)
+
+
+@parameterNodeGuiConnector
+class ctkDirectoryButtonToPathConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == ctk.ctkDirectoryButton and unannotatedType(datatype) in (
+            pathlib.Path, pathlib.PosixPath, pathlib.WindowsPath,
+            pathlib.PurePath, pathlib.PurePosixPath, pathlib.PureWindowsPath,
+        )
+
+    @staticmethod
+    def create(widget, datatype):
+        if ctkDirectoryButtonToPathConnector.canRepresent(widget, datatype):
+            return ctkDirectoryButtonToPathConnector(widget, datatype)
+        return None
+
+    def __init__(self, widget: ctk.ctkDirectoryButton, datatype):
+        super().__init__()
+        self._widget: ctk.ctkDirectoryButton = widget
+        self._type = unannotatedType(datatype)
+
+    def _connect(self):
+        self._widget.directoryChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.directoryChanged.disconnect(self.changed)
+
+    def widget(self) -> ctk.ctkDirectoryButton:
+        return self._widget
+
+    def read(self):
+        return self._type(self._widget.directory)
+
+    def write(self, value) -> None:
+        self._widget.directory = str(value)
+
+
+@parameterNodeGuiConnector
+class qMRMLNodeComboBoxToNodeConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == slicer.qMRMLNodeComboBox and isNodeOrUnionOfNodes(datatype)
+
+    @staticmethod
+    def create(widget, datatype):
+        if qMRMLNodeComboBoxToNodeConnector.canRepresent(widget, datatype):
+            return qMRMLNodeComboBoxToNodeConnector(widget, datatype)
+        return None
+
+    def __init__(self, widget: slicer.qMRMLNodeComboBox, datatype):
+        self._widget: slicer.qMRMLNodeComboBox = widget
+        self._widget.nodeTypes = getNodeTypes(datatype)
+
+    def _connect(self):
+        self._widget.currentNodeChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.currentNodeChanged.disconnect(self.changed)
+
+    def widget(self) -> slicer.qMRMLNodeComboBox:
+        return self._widget
+
+    def read(self):
+        return self._widget.currentNode()
+
+    def write(self, value) -> None:
+        self._widget.setCurrentNode(value)
+
+
+@parameterNodeGuiConnector
+class qMRMLSubjectHierarchyTreeViewToNodeConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == qMRMLSubjectHierarchyTreeView and isNodeOrUnionOfNodes(datatype)
+
+    @staticmethod
+    def create(widget, datatype):
+        if qMRMLSubjectHierarchyTreeViewToNodeConnector.canRepresent(widget, datatype):
+            return qMRMLSubjectHierarchyTreeViewToNodeConnector(widget, datatype)
+        return None
+
+    def __init__(self, widget: qMRMLSubjectHierarchyTreeView, datatype):
+        self._widget: qMRMLSubjectHierarchyTreeView = widget
+        self._widget.nodeTypes = getNodeTypes(datatype)
+
+    def _connect(self):
+        self._widget.currentItemsChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.currentItemsChanged.disconnect(self.changed)
+
+    def widget(self) -> qMRMLSubjectHierarchyTreeView:
+        return self._widget
+
+    def read(self):
+        itemId = self._widget.currentItem()
+        shNode = self._widget.subjectHierarchyNode()
+        if itemId == shNode.GetInvalidItemID():
+            return None
+        else:
+            return shNode.GetItemDataNode(itemId)
+
+    def write(self, value) -> None:
+        if value is not None:
+            self._widget.setCurrentNode(value)
+        else:
+            self._widget.clearSelection()
+
+
+SlicerPackParameterNamePropertyName = "SlicerPackParameterName"
+
+
+def _makeParentStack(child, root):
+    prop = SlicerPackParameterNamePropertyName
+    stack = [child]
+    while stack[0].parent() is not root:
+        stack.insert(0, stack[0].parent())
+    return [s for s in stack if s.property(prop) is not None]
+
+
+def _extractCorrectWidgets(widget):
+    children = widget.findChildren(qt.QWidget)
+    parentStacks = [_makeParentStack(child, widget) for child in children
+                    if child.property(SlicerPackParameterNamePropertyName) is not None]
+
+    # Remove stacks that are completely contained within other stacks.
+    # note: just doing `sorted(parentStacks, key=lambda x: id(x))` wasn't sorting it right
+    ids = [[id(w) for w in ww] for ww in parentStacks]
+    parentStacks, _ = zip(*sorted(zip(parentStacks, ids), key=lambda w: w[1]))
+
+    leafParentStacks = [i for i, j in zip(parentStacks[:-1], parentStacks[1:]) if not i == j[:len(i)]] \
+        + [parentStacks[-1]]
+    return leafParentStacks
+
+
+def _getDottedParameterName(parentStack):
+    return ".".join([w.property(SlicerPackParameterNamePropertyName) for w in parentStack])
+
+
+def _getPackNameToWidgetMap(widget):
+    """
+    Returns the dotted parameter names as keys and the widgets that represents that name as values
+    """
+    parentStacks = _extractCorrectWidgets(widget)
+    return {_getDottedParameterName(p): p[-1] for p in parentStacks}
+
+
+@parameterNodeGuiConnector
+class WidgetChildrenToParameterPackConnector(GuiConnector):
+    """
+    This connector will connected a widget with the appropriate children to a parameterPack.
+
+    Typically, this connector will not be used when using a .ui file, as the SlicerParameterName
+    in the .ui file will contain the nested name (e.g. "box.topLeft.x").
+
+    This is useful when generating widgets for the parameterPack though, as it supports a more
+    nested structure where the interior widgets don't need to know anything about the their parents.
+    """
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        if not pack.isParameterPack(datatype):
+            return False
+
+        # This can support it if the widget children have appropriately nested 
+        # SlicerParameterPackPropertyNames. Not disallowing extra parameter names in the widget
+        # in case for some reason one widget is meant to support multiple packs. If that is the case
+        # the user will need to ensure there are no name clashes between the two packs.
+        widgetSupportedNames = set(_getPackNameToWidgetMap(widget).keys())
+        packNames = set(pack.nestedParameterNames(datatype))
+
+        return packNames.issubset(widgetSupportedNames)
+
+    @staticmethod
+    def create(widget, datatype):
+        if WidgetChildrenToParameterPackConnector.canRepresent(widget, datatype):
+            return WidgetChildrenToParameterPackConnector(widget, datatype)
+        return None
+
+    def __init__(self, widget: qt.QWidget, datatype):
+        super().__init__()
+        self._datatype = datatype
+        self._widget: qt.QWidget = widget
+
+        nameWidgetMap = _getPackNameToWidgetMap(widget)
+        self._packParamNames = pack.nestedParameterNames(datatype)
+        self._nameToConnectorMap = {
+            paramName: createGuiConnector(nameWidgetMap[paramName], self._datatype.dataType(paramName))
+            for paramName in self._packParamNames}
+
+    def _connect(self):
+        for connector in self._nameToConnectorMap.values():
+            connector.onChanged(self.changed)
+
+    def _disconnect(self):
+        for connector in self._nameToConnectorMap.values():
+            connector.onChanged(None)
+
+    def widget(self) -> qt.QWidget:
+        return self._widget
+
+    def read(self):
+        pack = self._datatype()
+        for name, connector in self._nameToConnectorMap.items():
+            pack.setValue(name, connector.read())
+        return pack
+
+    def write(self, value: str) -> None:
+        # self._widget.text = value
+        for name, connector in self._nameToConnectorMap.items():
+            connector.write(value.getValue(name))

--- a/Base/Python/slicer/parameterNodeWrapper/parameterInfo.py
+++ b/Base/Python/slicer/parameterNodeWrapper/parameterInfo.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+import typing
+
+from .serializers import Serializer
+
+# this is totally private to the implementation, so not exposed
+__all__ = []
+
+
+@dataclass
+class ParameterInfo:
+    basename: str
+    serializer: Serializer
+    default: typing.Any
+    unalteredType: typing.Any

--- a/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
+++ b/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
@@ -17,7 +17,12 @@ from .util import (
 )
 
 
-__all__ = ["parameterPack", "isParameterPack"]
+__all__ = [
+    "allParameters",
+    "isParameterPack",
+    "nestedParameterNames",
+    "parameterPack",
+]
 
 
 def _implName(name: str) -> str:
@@ -210,6 +215,25 @@ def _processParameterPack(classtype):
     setattr(classtype, "setValue", _setValue)
     setattr(classtype, "dataType", _makeDataTypeFunc(classtype))
     return classtype
+
+
+def allParameters(parameterPackClassOrInstance) -> dict[str, ParameterInfo]:
+    return parameterPackClassOrInstance._parameterPack_allParameters
+
+
+def nestedParameterNames(parameterPackClassOrInstance) -> list[str]:
+    if not isParameterPack(parameterPackClassOrInstance):
+        parameterPackClassOrInstance = unannotatedType(parameterPackClassOrInstance)
+
+    names = []
+    for paramName, info in allParameters(parameterPackClassOrInstance).items():
+        rawDatatype = unannotatedType(info.unalteredType)
+        if isParameterPack(rawDatatype):
+            subNames = nestedParameterNames(rawDatatype)
+            names += [f"{paramName}.{s}" for s in subNames]
+        else:
+            names.append(paramName)
+    return names
 
 
 def parameterPack(classtype=None):

--- a/Base/Python/slicer/parameterNodeWrapper/util.py
+++ b/Base/Python/slicer/parameterNodeWrapper/util.py
@@ -1,7 +1,7 @@
 import typing
 from typing import Annotated
 
-__all__ = ["splitAnnotations"]
+__all__ = ["splitAnnotations", "unannotatedType", "findFirstAnnotation"]
 
 
 def splitAnnotations(possiblyAnnotatedType):
@@ -18,3 +18,30 @@ def splitAnnotations(possiblyAnnotatedType):
     actualtype = args[0]
     annotations = args[1:-1]
     return (actualtype, annotations)
+
+
+def unannotatedType(possiblyAnnotatedType):
+    return splitAnnotations(possiblyAnnotatedType)[0]
+
+
+def findFirstAnnotation(annotationsList, annotationType):
+    """
+    Given a list of annotations, returns the first one of the given type
+    """
+    extracted = [annotation for annotation in annotationsList if isinstance(annotation, annotationType)]
+    return extracted[0] if extracted else None
+
+
+def splitPossiblyDottedName(possiblyDottedName):
+    """
+    Splits apart the name into a top level name, then the rest.
+
+    E.g.
+      "x" -> ("x", None)
+      "x.y.z" -> ("x", "y.z")
+    """
+    if '.' in possiblyDottedName:
+        split = possiblyDottedName.split('.', maxsplit=1)
+        return split[0], split[1]
+    else:
+        return possiblyDottedName, None

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -6,21 +6,15 @@ import slicer
 import vtk
 
 from .default import extractDefault
+from .parameterInfo import ParameterInfo
 from .serializers import Serializer, createSerializer
 from .util import splitAnnotations
 
 __all__ = ["parameterNodeWrapper"]
 
 
-class _ParameterInfo:
-    def __init__(self, basename: str, serializer: Serializer, default):
-        self.basename: str = basename
-        self.serializer: Serializer = serializer
-        self.default = default
-
-
 class _Parameter:
-    def __init__(self, parameterInfo: _ParameterInfo, prefix: Optional[str] = None):
+    def __init__(self, parameterInfo: ParameterInfo, prefix: Optional[str] = None):
         self.name: str = f"{prefix or ''}{parameterInfo.basename}"
         self.serializer: Serializer = parameterInfo.serializer
         self.default = parameterInfo.default
@@ -160,7 +154,7 @@ def _processClass(classtype):
         except Exception as e:
             raise ValueError(f"The default parameter of '{default}' fails the validation checks:\n  {str(e)}")
 
-        parameter = _ParameterInfo(name, serializer, default)
+        parameter = ParameterInfo(name, serializer, default, nametype)
         allParameters.append(parameter)
         setattr(classtype, parameter.basename, _makeProperty(parameter.basename))
 

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
@@ -248,6 +248,49 @@ class TypedParameterNodeTest(unittest.TestCase):
         self.assertIsNone(param.noneDefault)
         self.assertEqual(param.nonNoneDefault, AnotherCustomClass(1, 2, 3))
 
+    def test_getSetValue(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            float_: float
+            bool_: bool
+            int_: Annotated[int, Default(4), Maximum(37)]
+            string_: Annotated[str, Default("TypedParam")]
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertEqual(param.getValue("float_"), 0.0)
+        self.assertFalse(param.getValue("bool_"))
+        self.assertEqual(param.getValue("int_"), 4)
+        self.assertEqual(param.getValue("string_"), "TypedParam")
+
+        param.setValue("float_", 9.9)
+        self.assertEqual(param.getValue("float_"), 9.9)
+        param.setValue("bool_", True)
+        self.assertTrue(param.getValue("bool_"))
+        param.setValue("int_", 36)
+        self.assertEqual(param.getValue("int_"), 36)
+        param.setValue("string_", "Another string")
+        self.assertEqual(param.getValue("string_"), "Another string")
+
+        with self.assertRaises(TypeError):
+            param.setValue("float_", "this is not a float")
+        self.assertEqual(param.getValue("float_"), 9.9)
+        with self.assertRaises(ValueError):
+            param.setValue("int_", 38)
+        self.assertEqual(param.getValue("int_"), 36)
+
+    def test_dataType(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            float_: float
+            bool_: bool
+            int_: Annotated[int, Default(4)]
+            string_: Annotated[str, Default("TypedParam")]
+
+        self.assertEqual(ParameterNodeType.dataType("float_"), float)
+        self.assertEqual(ParameterNodeType.dataType("bool_"), bool)
+        self.assertEqual(ParameterNodeType.dataType("int_"), Annotated[int, Default(4)])
+        self.assertEqual(ParameterNodeType.dataType("string_"), Annotated[str, Default("TypedParam")])
+
     def test_primitives(self):
         @parameterNodeWrapper
         class ParameterNodeType:

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
@@ -1,0 +1,953 @@
+import enum
+import pathlib
+import unittest
+from typing import Annotated, Union
+
+import ctk
+import qt
+
+import slicer
+from slicer.parameterNodeWrapper import *
+
+from MRMLCorePython import vtkMRMLModelNode, vtkMRMLScalarVolumeNode
+from qSlicerSubjectHierarchyModuleWidgetsPythonQt import qMRMLSubjectHierarchyTreeView
+
+
+# This is a copy-paste of what is in wrapper.py on purpose.
+# Using "SlicerParameterName" in the .ui files will not be able to go through the variable,
+# so if someone changes the value from "SlicerParameterName" it is good for a test to fail.
+SlicerParameterNamePropertyName = "SlicerParameterName"
+
+
+def newParameterNode():
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScriptedModuleNode")
+    return node
+
+
+class ParameterNodeWrapperGuiTest(unittest.TestCase):
+    def setUp(self):
+        slicer.mrmlScene.Clear(0)
+
+    def impl_ButtonToBool(self, widgettype):
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: bool
+            bravo: Annotated[bool, Default(True)]
+
+        widgetAlpha = widgettype()
+        widgetAlpha.deleteLater()
+        widgetBravo = widgettype()
+        widgetBravo.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": widgetAlpha,
+            "bravo": widgetBravo,
+        }
+        tag = param.connectParametersToGui(mapping)
+        self.assertFalse(param.alpha)
+        self.assertFalse(widgetAlpha.checked)
+        self.assertTrue(param.bravo)
+        self.assertTrue(widgetBravo.checked)
+
+        # Phase 1 - write True to GUI
+        widgetAlpha.checked = True
+        self.assertTrue(param.alpha)
+        self.assertTrue(widgetAlpha.checked)
+        self.assertTrue(param.bravo)
+        self.assertTrue(widgetBravo.checked)
+
+        # Phase 2 - write False to parameterNode
+        param.alpha = False
+        self.assertFalse(param.alpha)
+        self.assertFalse(widgetAlpha.checked)
+        self.assertTrue(param.bravo)
+        self.assertTrue(widgetBravo.checked)
+
+        # Phase 3 - disconnect parameterNode from GUI
+        param.disconnectGui(tag)
+
+        param.alpha = True
+        self.assertTrue(param.alpha)
+        self.assertFalse(widgetAlpha.checked)
+
+        param.alpha = False
+        widgetAlpha.checked = True
+        self.assertFalse(param.alpha)
+        self.assertTrue(widgetAlpha.checked)
+
+        # Phase 4 - reconnect to GUI after changing parameterNode
+        param.alpha = True
+        widgetAlpha.checked = False
+        tag = param.connectParametersToGui(mapping)
+        self.assertTrue(param.alpha)
+        self.assertTrue(widgetAlpha.checked)
+        self.assertTrue(param.bravo)
+        self.assertTrue(widgetBravo.checked)
+
+    def test_QCheckBoxToBool(self):
+        self.impl_ButtonToBool(qt.QCheckBox)
+
+    def test_QPushButtonToBool(self):
+        self.impl_ButtonToBool(qt.QPushButton)
+
+    def impl_QSliderOrSpinBoxToIntConnector(self, widgettype):
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: int
+            bravo: Annotated[int, Default(4), Minimum(2), Maximum(5)]
+            charlie: Annotated[int, WithinRange(0, 9)]
+
+        widgetAlpha = widgettype()
+        widgetAlpha.deleteLater()
+        widgetBravo = widgettype()
+        widgetBravo.deleteLater()
+        widgetCharlie = widgettype()
+        widgetCharlie.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": widgetAlpha,
+            "bravo": widgetBravo,
+            "charlie": widgetCharlie,
+        }
+        param.connectParametersToGui(mapping)
+
+        # alpha
+        self.assertEqual(param.alpha, 0)
+        self.assertEqual(widgetAlpha.value, 0)
+        self.assertLessEqual(widgetAlpha.minimum, -2**31)
+        self.assertGreaterEqual(widgetAlpha.maximum, 2**31 - 1)
+        # bravo
+        self.assertEqual(param.bravo, 4)
+        self.assertEqual(widgetBravo.value, 4)
+        self.assertEqual(widgetBravo.minimum, 2)
+        self.assertEqual(widgetBravo.maximum, 5)
+        # charlie
+        self.assertEqual(param.charlie, 0)
+        self.assertEqual(widgetCharlie.value, 0)
+        self.assertEqual(widgetCharlie.minimum, 0)
+        self.assertEqual(widgetCharlie.maximum, 9)
+
+        # Phase 1 - write to GUI
+        widgetAlpha.value = 292
+        widgetBravo.value = 2
+        widgetCharlie.value = 9
+        # alpha
+        self.assertEqual(param.alpha, 292)
+        self.assertEqual(widgetAlpha.value, 292)
+        # bravo
+        self.assertEqual(param.bravo, 2)
+        self.assertEqual(widgetBravo.value, 2)
+        # charlie
+        self.assertEqual(param.charlie, 9)
+        self.assertEqual(widgetCharlie.value, 9)
+
+        # Phase 2 - write to parameterNode
+        param.alpha = -4444
+        param.bravo = 5
+        param.charlie = 0
+        # alpha
+        self.assertEqual(param.alpha, -4444)
+        self.assertEqual(widgetAlpha.value, -4444)
+        # bravo
+        self.assertEqual(param.bravo, 5)
+        self.assertEqual(widgetBravo.value, 5)
+        # charlie
+        self.assertEqual(param.charlie, 0)
+        self.assertEqual(widgetCharlie.value, 0)
+
+    def test_QSliderToInt(self):
+        self.impl_QSliderOrSpinBoxToIntConnector(qt.QSlider)
+
+    def test_QSpinBoxToInt(self):
+        self.impl_QSliderOrSpinBoxToIntConnector(qt.QSpinBox)
+
+    def impl_QDoubleSpinBoxCtkSliderWidgetToFloatConnector(self, widgettype):
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: float
+            bravo: Annotated[float, Default(4.2), Minimum(2.1), Maximum(5.8)]
+            charlie: Annotated[float, WithinRange(0.1, 9.5), Default(0.2)]
+
+        widgetAlpha = widgettype()
+        widgetAlpha.deleteLater()
+        widgetBravo = widgettype()
+        widgetBravo.deleteLater()
+        widgetCharlie = widgettype()
+        widgetCharlie.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": widgetAlpha,
+            "bravo": widgetBravo,
+            "charlie": widgetCharlie,
+        }
+        param.connectParametersToGui(mapping)
+
+        # alpha
+        self.assertEqual(param.alpha, 0.0)
+        self.assertEqual(widgetAlpha.value, 0.0)
+        self.assertEqual(widgetAlpha.minimum, float("-inf"))
+        self.assertEqual(widgetAlpha.maximum, float("inf"))
+        # bravo
+        self.assertEqual(param.bravo, 4.2)
+        self.assertEqual(widgetBravo.value, 4.2)
+        self.assertEqual(widgetBravo.minimum, 2.1)
+        self.assertEqual(widgetBravo.maximum, 5.8)
+        # charlie
+        self.assertEqual(param.charlie, 0.2)
+        self.assertEqual(widgetCharlie.value, 0.2)
+        self.assertEqual(widgetCharlie.minimum, 0.1)
+        self.assertEqual(widgetCharlie.maximum, 9.5)
+
+        # Phase 1 - write to GUI
+        widgetAlpha.value = 2.3e565
+        widgetBravo.value = 4.4
+        widgetCharlie.value = 9.5
+        # alpha
+        self.assertEqual(param.alpha, 2.3e565)
+        self.assertEqual(widgetAlpha.value, 2.3e565)
+        # bravo
+        self.assertEqual(param.bravo, 4.4)
+        self.assertEqual(widgetBravo.value, 4.4)
+        # charlie
+        self.assertEqual(param.charlie, 9.5)
+        self.assertEqual(widgetCharlie.value, 9.5)
+
+        # Phase 2 - write to parameterNode
+        param.alpha = -4444.4
+        param.bravo = 2.1
+        param.charlie = 0.1
+        # alpha
+        self.assertEqual(param.alpha, -4444.4)
+        self.assertEqual(widgetAlpha.value, -4444.4)
+        # bravo
+        self.assertEqual(param.bravo, 2.1)
+        self.assertEqual(widgetBravo.value, 2.1)
+        # charlie
+        self.assertEqual(param.charlie, 0.1)
+        self.assertEqual(widgetCharlie.value, 0.1)
+
+    def test_QDoubleSpinBoxToFloat(self):
+        self.impl_QDoubleSpinBoxCtkSliderWidgetToFloatConnector(qt.QDoubleSpinBox)
+
+    def test_ctkSliderWidgetToFloat(self):
+        self.impl_QDoubleSpinBoxCtkSliderWidgetToFloatConnector(ctk.ctkSliderWidget)
+
+    def test_QComboBoxToStringable(self):
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: Annotated[int, Choice([1, 2, 3]), Default(1)]
+            bravo: Annotated[float, Choice([1.1, 2.2, 3.3]), Default(3.3)]
+            charlie: Annotated[str, Choice(["a", "b", "c", "d"]), Default("a")]
+            delta: Annotated[bool, Choice([True, False]), Default(False)]
+
+        comboboxAlpha = qt.QComboBox()
+        comboboxAlpha.deleteLater()
+        comboboxBravo = qt.QComboBox()
+        comboboxBravo.deleteLater()
+        comboboxCharlie = qt.QComboBox()
+        comboboxCharlie.deleteLater()
+        comboboxDelta = qt.QComboBox()
+        comboboxDelta.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": comboboxAlpha,
+            "bravo": comboboxBravo,
+            "charlie": comboboxCharlie,
+            "delta": comboboxDelta,
+        }
+        param.connectParametersToGui(mapping)
+        # alpha
+        self.assertEqual(param.alpha, 1)
+        self.assertEqual(comboboxAlpha.currentIndex, 0)
+        self.assertEqual(comboboxAlpha.currentText, "1")
+        self.assertEqual(comboboxAlpha.count, 3)
+        self.assertEqual(comboboxAlpha.itemText(0), "1")
+        self.assertEqual(comboboxAlpha.itemText(1), "2")
+        self.assertEqual(comboboxAlpha.itemText(2), "3")
+        # bravo
+        self.assertEqual(param.bravo, 3.3)
+        self.assertEqual(comboboxBravo.currentIndex, 2)
+        self.assertEqual(comboboxBravo.currentText, "3.3")
+        self.assertEqual(comboboxBravo.count, 3)
+        self.assertEqual(comboboxBravo.itemText(0), "1.1")
+        self.assertEqual(comboboxBravo.itemText(1), "2.2")
+        self.assertEqual(comboboxBravo.itemText(2), "3.3")
+        # charlie
+        self.assertEqual(param.charlie, "a")
+        self.assertEqual(comboboxCharlie.currentIndex, 0)
+        self.assertEqual(comboboxCharlie.currentText, "a")
+        self.assertEqual(comboboxCharlie.count, 4)
+        self.assertEqual(comboboxCharlie.itemText(0), "a")
+        self.assertEqual(comboboxCharlie.itemText(1), "b")
+        self.assertEqual(comboboxCharlie.itemText(2), "c")
+        self.assertEqual(comboboxCharlie.itemText(3), "d")
+        # delta
+        self.assertEqual(param.delta, False)
+        self.assertEqual(comboboxDelta.currentIndex, 1)
+        self.assertEqual(comboboxDelta.currentText, "False")
+        self.assertEqual(comboboxDelta.count, 2)
+        self.assertEqual(comboboxDelta.itemText(0), "True")
+        self.assertEqual(comboboxDelta.itemText(1), "False")
+
+        # Phase 1 - write to GUI
+        comboboxAlpha.currentIndex = 2
+        comboboxBravo.currentIndex = 0
+        comboboxCharlie.currentIndex = 1
+        comboboxDelta.currentIndex = 0
+        # alpha
+        self.assertEqual(param.alpha, 3)
+        self.assertEqual(comboboxAlpha.currentIndex, 2)
+        self.assertEqual(comboboxAlpha.currentText, "3")
+        # bravo
+        self.assertEqual(param.bravo, 1.1)
+        self.assertEqual(comboboxBravo.currentIndex, 0)
+        self.assertEqual(comboboxBravo.currentText, "1.1")
+        # charlie
+        self.assertEqual(param.charlie, "b")
+        self.assertEqual(comboboxCharlie.currentIndex, 1)
+        self.assertEqual(comboboxCharlie.currentText, "b")
+        # delta
+        self.assertEqual(param.delta, True)
+        self.assertEqual(comboboxDelta.currentIndex, 0)
+        self.assertEqual(comboboxDelta.currentText, "True")
+
+        # Phase 2 - write to parameterNode
+        param.alpha = 2
+        param.bravo = 2.2
+        param.charlie = "c"
+        param.delta = False
+        # alpha
+        self.assertEqual(param.alpha, 2)
+        self.assertEqual(comboboxAlpha.currentIndex, 1)
+        self.assertEqual(comboboxAlpha.currentText, "2")
+        # bravo
+        self.assertEqual(param.bravo, 2.2)
+        self.assertEqual(comboboxBravo.currentIndex, 1)
+        self.assertEqual(comboboxBravo.currentText, "2.2")
+        # charlie
+        self.assertEqual(param.charlie, "c")
+        self.assertEqual(comboboxCharlie.currentIndex, 2)
+        self.assertEqual(comboboxCharlie.currentText, "c")
+        # delta
+        self.assertEqual(param.delta, False)
+        self.assertEqual(comboboxDelta.currentIndex, 1)
+        self.assertEqual(comboboxDelta.currentText, "False")
+
+    def test_QComboBoxToEnum(self):
+        class TestEnum(enum.Enum):
+            A = 'A'
+            B = 'B'
+            C = 'C'
+        
+        class TestIntEnum(enum.IntEnum):
+            X = 1
+            Y = 3
+            Z = 7
+
+        class TestLabeledEnum(enum.Enum):
+            TopLeft = 1
+            BottomRight = 2
+
+            def label(self):
+                if self is TestLabeledEnum.TopLeft:
+                    return "Top left"
+                elif self is TestLabeledEnum.BottomRight:
+                    return "Bottom right"
+                raise ValueError("Unknown enum value")
+
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            normal: TestEnum
+            integer: Annotated[TestIntEnum, Default(TestIntEnum.Z)]
+            labeled: TestLabeledEnum
+
+        comboboxNormal = qt.QComboBox()
+        comboboxNormal.deleteLater()
+        comboboxInt = qt.QComboBox()
+        comboboxInt.deleteLater()
+        comboboxLabeled = qt.QComboBox()
+        comboboxLabeled.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "normal": comboboxNormal,
+            "integer": comboboxInt,
+            "labeled": comboboxLabeled,
+        }
+        param.connectParametersToGui(mapping)
+
+        # normal
+        self.assertEqual(param.normal, TestEnum.A)
+        self.assertEqual(comboboxNormal.currentIndex, 0)
+        self.assertEqual(comboboxNormal.currentText, "A")
+        self.assertEqual(comboboxNormal.count, 3)
+        self.assertEqual(comboboxNormal.itemText(0), "A")
+        self.assertEqual(comboboxNormal.itemText(1), "B")
+        self.assertEqual(comboboxNormal.itemText(2), "C")
+        # int
+        self.assertEqual(param.integer, TestIntEnum.Z)
+        self.assertEqual(comboboxInt.currentIndex, 2)
+        self.assertEqual(comboboxInt.currentText, "Z")
+        self.assertEqual(comboboxInt.count, 3)
+        self.assertEqual(comboboxInt.itemText(0), "X")
+        self.assertEqual(comboboxInt.itemText(1), "Y")
+        self.assertEqual(comboboxInt.itemText(2), "Z")
+        # labeled
+        self.assertEqual(param.labeled, TestLabeledEnum.TopLeft)
+        self.assertEqual(comboboxLabeled.currentIndex, 0)
+        self.assertEqual(comboboxLabeled.currentText, "Top left")
+        self.assertEqual(comboboxLabeled.count, 2)
+        self.assertEqual(comboboxLabeled.itemText(0), "Top left")
+        self.assertEqual(comboboxLabeled.itemText(1), "Bottom right")
+
+        # Phase 1 - write to GUI
+        comboboxNormal.currentIndex = 1
+        comboboxInt.currentIndex = 0
+        comboboxLabeled.currentIndex = 1
+        # normal
+        self.assertEqual(param.normal, TestEnum.B)
+        self.assertEqual(comboboxNormal.currentIndex, 1)
+        self.assertEqual(comboboxNormal.currentText, "B")
+        # int
+        self.assertEqual(param.integer, TestIntEnum.X)
+        self.assertEqual(comboboxInt.currentIndex, 0)
+        self.assertEqual(comboboxInt.currentText, "X")
+        # labeled
+        self.assertEqual(param.labeled, TestLabeledEnum.BottomRight)
+        self.assertEqual(comboboxLabeled.currentIndex, 1)
+        self.assertEqual(comboboxLabeled.currentText, "Bottom right")
+
+        # Phase 2 - write to parameterNode
+        param.normal = TestEnum.C
+        param.integer = TestIntEnum.Y
+        param.labeled = TestLabeledEnum.TopLeft
+        # normal
+        self.assertEqual(param.normal, TestEnum.C)
+        self.assertEqual(comboboxNormal.currentIndex, 2)
+        self.assertEqual(comboboxNormal.currentText, "C")
+        # int
+        self.assertEqual(param.integer, TestIntEnum.Y)
+        self.assertEqual(comboboxInt.currentIndex, 1)
+        self.assertEqual(comboboxInt.currentText, "Y")
+        # labeled
+        self.assertEqual(param.labeled, TestLabeledEnum.TopLeft)
+        self.assertEqual(comboboxLabeled.currentIndex, 0)
+        self.assertEqual(comboboxLabeled.currentText, "Top left")
+
+    def test_QLineEditToStr(self):
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: str
+            bravo: Annotated[str, Default("someval")]
+
+        lineEditAlpha = qt.QLineEdit()
+        lineEditAlpha.deleteLater()
+        lineEditBravo = qt.QLineEdit()
+        lineEditBravo.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": lineEditAlpha,
+            "bravo": lineEditBravo,
+        }
+        param.connectParametersToGui(mapping)
+        self.assertEqual(param.alpha, "")
+        self.assertEqual(lineEditAlpha.text, "")
+        self.assertEqual(param.bravo, "someval")
+        self.assertEqual(lineEditBravo.text, "someval")
+
+        # Phase 1 - write to GUI
+        lineEditAlpha.text = "hello, world"
+        self.assertEqual(param.alpha, "hello, world")
+        self.assertEqual(lineEditAlpha.text, "hello, world")
+        self.assertEqual(param.bravo, "someval")
+        self.assertEqual(lineEditBravo.text, "someval")
+
+        # Phase 2 - write to parameterNode
+        param.alpha = "goodbye"
+        self.assertEqual(param.alpha, "goodbye")
+        self.assertEqual(lineEditAlpha.text, "goodbye")
+        self.assertEqual(param.bravo, "someval")
+        self.assertEqual(lineEditBravo.text, "someval")
+
+    def test_QTextEditPlainTextToStr(self):
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: str
+            bravo: Annotated[str, Default("someval\nsomeval2")]
+
+        lineEditAlpha = qt.QTextEdit()
+        lineEditAlpha.deleteLater()
+        lineEditBravo = qt.QTextEdit()
+        lineEditBravo.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": lineEditAlpha,
+            "bravo": lineEditBravo,
+        }
+        param.connectParametersToGui(mapping)
+        self.assertEqual(param.alpha, "")
+        self.assertEqual(lineEditAlpha.toPlainText(), "")
+        self.assertEqual(param.bravo, "someval\nsomeval2")
+        self.assertEqual(lineEditBravo.toPlainText(), "someval\nsomeval2")
+
+        # Phase 1 - write to GUI
+        lineEditAlpha.setPlainText("hello, world")
+        self.assertEqual(param.alpha, "hello, world")
+        self.assertEqual(lineEditAlpha.toPlainText(), "hello, world")
+        self.assertEqual(param.bravo, "someval\nsomeval2")
+        self.assertEqual(lineEditBravo.toPlainText(), "someval\nsomeval2")
+
+        lineEditAlpha.setHtml("hello,<br/>world")
+        self.assertEqual(param.alpha, "hello,\nworld")
+        self.assertEqual(lineEditAlpha.toPlainText(), "hello,\nworld")
+        self.assertEqual(param.bravo, "someval\nsomeval2")
+        self.assertEqual(lineEditBravo.toPlainText(), "someval\nsomeval2")
+
+        # Phase 2 - write to parameterNode
+        param.alpha = "goodbye"
+        self.assertEqual(param.alpha, "goodbye")
+        self.assertEqual(lineEditAlpha.toPlainText(), "goodbye")
+        self.assertEqual(param.bravo, "someval\nsomeval2")
+        self.assertEqual(lineEditBravo.toPlainText(), "someval\nsomeval2")
+
+    def test_ctkPathLineEditToPath(self):
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: pathlib.Path
+            bravo: Annotated[pathlib.Path, Default(pathlib.Path("some/path"))]
+
+        pathLineEditAlpha = ctk.ctkPathLineEdit()
+        pathLineEditAlpha.deleteLater()
+        pathLineEditBravo = ctk.ctkPathLineEdit()
+        pathLineEditBravo.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": pathLineEditAlpha,
+            "bravo": pathLineEditBravo,
+        }
+        param.connectParametersToGui(mapping)
+        self.assertEqual(param.alpha, pathlib.Path())
+        self.assertEqual(pathlib.Path(pathLineEditAlpha.currentPath), pathlib.Path())
+        self.assertEqual(param.bravo, pathlib.Path("some/path"))
+        self.assertEqual(pathlib.Path(pathLineEditBravo.currentPath), pathlib.Path("some/path"))
+
+        # Phase 1 - write to GUI
+        pathLineEditAlpha.currentPath = "pathy/path"
+        self.assertEqual(param.alpha, pathlib.Path("pathy/path"))
+        self.assertEqual(pathlib.Path(pathLineEditAlpha.currentPath), pathlib.Path("pathy/path"))
+        self.assertEqual(param.bravo, pathlib.Path("some/path"))
+        self.assertEqual(pathlib.Path(pathLineEditBravo.currentPath), pathlib.Path("some/path"))
+
+        # Phase 2 - write to parameterNode
+        param.bravo = pathlib.Path("magnificent/path/bravo")
+        self.assertEqual(param.alpha, pathlib.Path("pathy/path"))
+        self.assertEqual(pathlib.Path(pathLineEditAlpha.currentPath), pathlib.Path("pathy/path"))
+        self.assertEqual(param.bravo, pathlib.Path("magnificent/path/bravo"))
+        self.assertEqual(pathlib.Path(pathLineEditBravo.currentPath), pathlib.Path("magnificent/path/bravo"))
+
+    def test_ctkDirectoryButtonToPath(self):
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: pathlib.Path
+            bravo: Annotated[pathlib.Path, Default(pathlib.Path("some/path"))]
+
+        directoryButtonAlpha = ctk.ctkDirectoryButton()
+        directoryButtonAlpha.deleteLater()
+        directoryButtonBravo = ctk.ctkDirectoryButton()
+        directoryButtonBravo.deleteLater()
+        param = ParameterNodeWrapper(newParameterNode())
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": directoryButtonAlpha,
+            "bravo": directoryButtonBravo,
+        }
+        param.connectParametersToGui(mapping)
+        self.assertEqual(param.alpha, pathlib.Path())
+        self.assertEqual(pathlib.Path(directoryButtonAlpha.directory), pathlib.Path())
+        self.assertEqual(param.bravo, pathlib.Path("some/path"))
+        self.assertEqual(pathlib.Path(directoryButtonBravo.directory), pathlib.Path("some/path"))
+
+        # Phase 1 - write to GUI
+        directoryButtonAlpha.directory = "pathy/path"
+        self.assertEqual(param.alpha, pathlib.Path("pathy/path"))
+        self.assertEqual(pathlib.Path(directoryButtonAlpha.directory), pathlib.Path("pathy/path"))
+        self.assertEqual(param.bravo, pathlib.Path("some/path"))
+        self.assertEqual(pathlib.Path(directoryButtonBravo.directory), pathlib.Path("some/path"))
+
+        # Phase 2 - write to parameterNode
+        param.bravo = pathlib.Path("magnificent/path/bravo")
+        self.assertEqual(param.alpha, pathlib.Path("pathy/path"))
+        self.assertEqual(pathlib.Path(directoryButtonAlpha.directory), pathlib.Path("pathy/path"))
+        self.assertEqual(param.bravo, pathlib.Path("magnificent/path/bravo"))
+        self.assertEqual(pathlib.Path(directoryButtonBravo.directory), pathlib.Path("magnificent/path/bravo"))
+
+    def impl_qMRMLToNodeConnector(self, widgettype, currentNodeFunc, clearFunc):
+        """
+        The tests for the qMRMLNodeComboBox and the qMRMLSubjectHierarchyTreeView are nearly identical, but their
+        interfaces are just different enough (especially in Python) to make it difficult. In the places where
+        the interfaces differ, a function was added to abstract that away.
+        """
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            alpha: vtkMRMLModelNode
+            bravo: Union[vtkMRMLModelNode, vtkMRMLScalarVolumeNode, None]
+
+        param = ParameterNodeWrapper(newParameterNode())
+
+        widgetAlpha = widgettype()
+        widgetAlpha.setMRMLScene(slicer.mrmlScene)
+        widgetAlpha.deleteLater()
+        widgetBravo = widgettype()
+        widgetBravo.setMRMLScene(slicer.mrmlScene)
+        widgetBravo.deleteLater()
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "alpha": widgetAlpha,
+            "bravo": widgetBravo,
+        }
+        param.connectParametersToGui(mapping)
+
+        # alpha
+        self.assertIsNone(param.alpha)
+        self.assertIsNone(currentNodeFunc(widgetAlpha))
+        self.assertEqual(widgetAlpha.nodeTypes, ('vtkMRMLModelNode', ))
+        # bravo
+        self.assertIsNone(param.bravo)
+        self.assertIsNone(currentNodeFunc(widgetBravo))
+        #    order is unimportant here
+        self.assertEqual(sorted(widgetBravo.nodeTypes), sorted(['vtkMRMLModelNode', 'vtkMRMLScalarVolumeNode']))
+
+        model1 = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelNode', "model1")
+        model2 = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLModelNode', "model2")
+        volume1 = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScalarVolumeNode', "volume1")
+        volume2 = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScalarVolumeNode', "volume2")
+
+        # should not auto add
+        self.assertIsNone(param.alpha)
+        self.assertIsNone(currentNodeFunc(widgetAlpha))
+        self.assertIsNone(param.bravo)
+        self.assertIsNone(currentNodeFunc(widgetBravo))
+
+        # Phase 1 - write to GUI
+        widgetAlpha.setCurrentNode(model2)
+        self.assertIs(param.alpha, model2)
+        self.assertIs(currentNodeFunc(widgetAlpha), model2)
+
+        clearFunc(widgetAlpha)
+        self.assertIsNone(param.alpha)
+        self.assertIsNone(currentNodeFunc(widgetAlpha))
+
+        widgetBravo.setCurrentNode(model1)
+        self.assertIs(param.bravo, model1)
+        self.assertIs(currentNodeFunc(widgetBravo), model1)
+
+        widgetBravo.setCurrentNode(volume2)
+        self.assertIs(currentNodeFunc(widgetBravo), volume2)
+        self.assertIs(param.bravo, volume2)
+
+        clearFunc(widgetBravo)
+        self.assertIs(param.bravo, None)
+        self.assertIs(currentNodeFunc(widgetBravo), None)
+
+        # Phase 2 - write to parameterNode
+        param.alpha = model1
+        self.assertIs(param.alpha, model1)
+        self.assertIs(currentNodeFunc(widgetAlpha), model1)
+
+        param.alpha = None
+        self.assertIsNone(param.alpha)
+        self.assertIsNone(currentNodeFunc(widgetAlpha))
+
+        param.bravo = volume1
+        self.assertIs(param.bravo, volume1)
+        self.assertIs(currentNodeFunc(widgetBravo), volume1)
+
+        param.bravo = model2
+        self.assertIs(param.bravo, model2)
+        self.assertIs(currentNodeFunc(widgetBravo), model2)
+
+        param.bravo = None
+        self.assertIs(param.bravo, None)
+        self.assertIs(currentNodeFunc(widgetBravo), None)
+
+    def test_qMRMLNodeComboBoxToNode(self):
+        self.impl_qMRMLToNodeConnector(slicer.qMRMLNodeComboBox, lambda box: box.currentNode(), lambda box: box.setCurrentNode(None))
+
+    def test_qMRMLSubjectHierarchyTreeViewToNode(self):
+        def getNodeFromSubjectTree(tree):
+            itemId = tree.currentItem()
+            shNode = tree.subjectHierarchyNode()
+            if itemId == shNode.GetInvalidItemID():
+                return None
+            else:
+                return shNode.GetItemDataNode(itemId)
+
+        self.impl_qMRMLToNodeConnector(qMRMLSubjectHierarchyTreeView, getNodeFromSubjectTree, lambda tree: tree.clearSelection())
+
+    def test_parameterPacks_through_dotted_name(self):
+        @parameterPack
+        class Pack:
+            iterations: Annotated[int, Minimum(0)]
+            doPreprocessing: bool
+            style: Annotated[str, Choice(["forward", "backward", "sideways"]), Default("forward")]
+
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            pack: Pack
+            otherNumber: float
+
+        param = ParameterNodeWrapper(newParameterNode())
+
+        widgetIterations = qt.QSpinBox()
+        widgetIterations.deleteLater()
+        widgetDoPreprocessing = qt.QCheckBox()
+        widgetDoPreprocessing.deleteLater()
+        widgetStyle = qt.QComboBox()
+        widgetStyle.deleteLater()
+        widgetOtherNumber = ctk.ctkSliderWidget()
+        widgetOtherNumber.deleteLater()
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "pack.iterations": widgetIterations,
+            "pack.doPreprocessing": widgetDoPreprocessing,
+            "pack.style": widgetStyle,
+            "otherNumber": widgetOtherNumber,
+        }
+        param.connectParametersToGui(mapping)
+
+        self.assertEqual(param.pack.iterations, 0)
+        self.assertEqual(widgetIterations.value, 0)
+        self.assertEqual(widgetIterations.minimum, 0)
+        self.assertEqual(widgetIterations.maximum, 2**31 - 1)
+        self.assertFalse(param.pack.doPreprocessing)
+        self.assertFalse(widgetDoPreprocessing.checked)
+        self.assertEqual(param.pack.style, "forward")
+        self.assertEqual(widgetStyle.currentIndex, 0)
+        self.assertEqual(widgetStyle.currentText, "forward")
+        self.assertEqual(widgetStyle.count, 3)
+        self.assertEqual(widgetStyle.itemText(0), "forward")
+        self.assertEqual(widgetStyle.itemText(1), "backward")
+        self.assertEqual(widgetStyle.itemText(2), "sideways")
+        self.assertEqual(param.otherNumber, 0.0)
+        self.assertEqual(widgetOtherNumber.value, 0.0)
+
+        # Phase 1 - write to GUI
+        widgetIterations.value = 44
+        self.assertEqual(param.pack.iterations, 44)
+        self.assertEqual(widgetIterations.value, 44)
+        widgetDoPreprocessing.checked = True
+        self.assertTrue(param.pack.doPreprocessing)
+        self.assertTrue(widgetDoPreprocessing.checked)
+        widgetStyle.currentIndex = 2
+        self.assertEqual(param.pack.style, "sideways")
+        self.assertEqual(widgetStyle.currentIndex, 2)
+        param.otherNumber = -77.6
+        self.assertEqual(param.otherNumber, -77.6)
+        self.assertEqual(widgetOtherNumber.value, -77.6)
+
+        # Phase 2 - write to parameterNode
+        param.pack.iterations = 55
+        self.assertEqual(param.pack.iterations, 55)
+        self.assertEqual(widgetIterations.value, 55)
+        param.pack.doPreprocessing = False
+        self.assertFalse(param.pack.doPreprocessing)
+        self.assertFalse(widgetDoPreprocessing.checked)
+        param.pack.style = "backward"
+        self.assertEqual(param.pack.style, "backward")
+        self.assertEqual(widgetStyle.currentIndex, 1)
+        param.otherNumber = 3333
+        self.assertEqual(param.otherNumber, 3333)
+        self.assertEqual(widgetOtherNumber.value, 3333)
+
+        param.pack = Pack(iterations=1, doPreprocessing=True, style="forward")
+        self.assertEqual(param.pack.iterations, 1)
+        self.assertEqual(widgetIterations.value, 1)
+        self.assertTrue(param.pack.doPreprocessing)
+        self.assertTrue(widgetDoPreprocessing.checked)
+        self.assertEqual(param.pack.style, "forward")
+        self.assertEqual(widgetStyle.currentIndex, 0)
+        self.assertEqual(param.otherNumber, 3333)
+        self.assertEqual(widgetOtherNumber.value, 3333)
+
+    # Testing multiple ways of connecting parameter packs, so making the parameterNodeWrapper
+    # and running the sets/gets were factored out, so the only thing the test functions do
+    # differently is how they connect the guis to the wrapper.
+    def impl_parameterPacks_make_parameter_node_wrapper(self):
+
+        @parameterPack
+        class SubPack:
+            iterations: Annotated[int, WithinRange(1, 33), Default(15)]
+            description: str
+
+        @parameterPack
+        class Pack:
+            sub1: Annotated[SubPack, Default(SubPack(22, "submarine"))]
+            sub2: SubPack
+            useFirst: Annotated[bool, Default(True)]
+
+        @parameterNodeWrapper
+        class ParameterNodeWrapper:
+            pack: Pack
+            style: Annotated[str, Choice(["forward", "backward", "sideways"]), Default("forward")]
+
+        return ParameterNodeWrapper
+
+    def impl_parameterPacks_test_connected_parameter_node_wrapper(self, param, ui):
+        # make sure the widgets got updated with the initial values
+        self.assertEqual(param.pack.sub1.iterations, 22)
+        self.assertEqual(param.pack.sub1.description, "submarine")
+        self.assertEqual(param.pack.sub2.iterations, 15)
+        self.assertEqual(param.pack.sub2.description, "")
+        self.assertTrue(param.pack.useFirst)
+        self.assertEqual(param.style, "forward")
+
+        self.assertEqual(ui.sub1Iterations.value, 22)
+        self.assertEqual(ui.sub1Description.text, "submarine")
+        self.assertEqual(ui.sub2Iterations.value, 15)
+        self.assertEqual(ui.sub2Description.text, "")
+        self.assertTrue(ui.useFirst.checked)
+        self.assertEqual(ui.style.currentIndex, 0)
+        self.assertEqual(ui.style.currentText, "forward")
+        self.assertEqual(ui.style.count, 3)
+        self.assertEqual(ui.style.itemText(0), "forward")
+        self.assertEqual(ui.style.itemText(1), "backward")
+        self.assertEqual(ui.style.itemText(2), "sideways")
+
+        # Phase 1 - write to GUI
+        ui.sub1Iterations.value = 33
+        self.assertEqual(param.pack.sub1.iterations, 33)
+        self.assertEqual(ui.sub1Iterations.value, 33)
+        self.assertEqual(param.pack.sub2.iterations, 15)
+        self.assertEqual(ui.sub2Iterations.value, 15)
+        ui.sub2Description.text = "hello, world"
+        self.assertEqual(param.pack.sub1.description, "submarine")
+        self.assertEqual(ui.sub1Description.text, "submarine")
+        self.assertEqual(param.pack.sub2.description, "hello, world")
+        self.assertEqual(ui.sub2Description.text, "hello, world")
+
+        # Phase 2 - write to parameterNode
+        param.pack.sub2.iterations = 4
+        self.assertEqual(param.pack.sub1.iterations, 33)
+        self.assertEqual(ui.sub1Iterations.value, 33)
+        self.assertEqual(param.pack.sub2.iterations, 4)
+        self.assertEqual(ui.sub2Iterations.value, 4)
+        param.pack.sub1.description = "airplane"
+        self.assertEqual(param.pack.sub1.description, "airplane")
+        self.assertEqual(ui.sub1Description.text, "airplane")
+        self.assertEqual(param.pack.sub2.description, "hello, world")
+        self.assertEqual(ui.sub2Description.text, "hello, world")
+
+    def test_nested_parameterPacks_through_dotted_name(self):
+        ParameterNodeWrapper = self.impl_parameterPacks_make_parameter_node_wrapper()
+
+        param = ParameterNodeWrapper(newParameterNode())
+
+        ui = type('', (), {})()  # empty object
+        ui.sub1Iterations = qt.QSpinBox()
+        ui.sub1Iterations.deleteLater()
+        ui.sub1Description = qt.QLineEdit()
+        ui.sub1Description.deleteLater()
+        ui.sub2Iterations = qt.QSpinBox()
+        ui.sub2Iterations.deleteLater()
+        ui.sub2Description = qt.QLineEdit()
+        ui.sub2Description.deleteLater()
+        ui.useFirst = qt.QPushButton()
+        ui.useFirst.checkable = True
+        ui.useFirst.deleteLater()
+        ui.style = qt.QComboBox()
+        ui.style.deleteLater()
+
+        # Phase 0 - connect parameterNode to GUI
+        mapping = {
+            "pack.sub1.iterations": ui.sub1Iterations,
+            "pack.sub1.description": ui.sub1Description,
+            "pack.sub2.iterations": ui.sub2Iterations,
+            "pack.sub2.description": ui.sub2Description,
+            "pack.useFirst": ui.useFirst,
+            "style": ui.style,
+        }
+        param.connectParametersToGui(mapping)
+        self.impl_parameterPacks_test_connected_parameter_node_wrapper(param, ui)
+
+    def test_connect_via_SlicerParameterName(self):
+        ParameterNodeWrapper = self.impl_parameterPacks_make_parameter_node_wrapper()
+
+        # Phase 0 - connect parameterNode to GUI
+
+        # this is very similar to what slicer.util.childWidgetVariables does
+        ui = type('', (), {})()  # empty object
+
+        def addWidget(widget, paramName):
+            if paramName:
+                widget.setProperty(SlicerParameterNamePropertyName, paramName)
+            widget.deleteLater()
+            return widget
+
+        ui.sub1Iterations = addWidget(qt.QSpinBox(), "pack.sub1.iterations")
+        ui.sub1Description = addWidget(qt.QLineEdit(), "pack.sub1.description")
+        ui.sub2Iterations = addWidget(qt.QSpinBox(), "pack.sub2.iterations")
+        ui.sub2Description = addWidget(qt.QLineEdit(), "pack.sub2.description")
+        ui.useFirst = addWidget(qt.QCheckBox(), "pack.useFirst")
+        ui.style = addWidget(qt.QComboBox(), "style")
+        ui.unusedWidget1 = addWidget(qt.QSpinBox(), None)
+        ui.unusedWidget2 = addWidget(qt.QLineEdit(), None)
+
+        param = ParameterNodeWrapper(newParameterNode())
+        param.connectGui(ui)
+        ui.unusedWidget1.value = 10
+        ui.unusedWidget2.text = "I am unused"
+        self.impl_parameterPacks_test_connected_parameter_node_wrapper(param, ui)
+
+    def test_parameterPacks_through_widget_children(self):
+        ParameterNodeWrapper = self.impl_parameterPacks_make_parameter_node_wrapper()
+
+        param = ParameterNodeWrapper(newParameterNode())
+
+        def addWidget(widget, /, packParam):
+            widget.setProperty(SlicerPackParameterNamePropertyName, packParam)
+            return widget
+
+        ui = type('', (), {})()  # empty object
+        ui.style = qt.QComboBox()
+        ui.style.deleteLater()
+
+        # setup a widget with children that matches the structure of the pack
+        ui.pack = qt.QWidget()
+        ui.pack.deleteLater()
+        ui.sub1 = addWidget(qt.QWidget(ui.pack), packParam="sub1")
+        ui.sub1Iterations = addWidget(qt.QSpinBox(ui.sub1), packParam="iterations")
+        ui.sub1Description = addWidget(qt.QLineEdit(ui.sub1), packParam="description")
+        ui.sub2 = addWidget(qt.QWidget(ui.pack), packParam="sub2")
+        ui.sub2Iterations = addWidget(qt.QSpinBox(ui.sub2), packParam="iterations")
+        ui.sub2Description = addWidget(qt.QLineEdit(ui.sub2), packParam="description")
+        ui.useFirst = addWidget(qt.QCheckBox(ui.pack), packParam="useFirst")
+        # extra widgets that don't have a SlicerPackParameterNamePropertyName don't affect anything
+        qt.QLabel(ui.pack)
+        qt.QLabel(ui.sub1)
+        qt.QLabel(ui.sub2Iterations)
+
+        mapping = {
+            "pack": ui.pack,
+            "style": ui.style,
+        }
+        param.connectParametersToGui(mapping)
+
+        self.impl_parameterPacks_test_connected_parameter_node_wrapper(param, ui)


### PR DESCRIPTION
Essentially adds the functionality from `updateParameterNodeFromGui` and `updateGuiFromParameterNode` into the parameter node wrapper.

The parameterNodeWrapper is given a `connectGui` method that can take the `self.ui` of a module widget and connect to the widgets in the UI. The widgets that should connect to the parameter node should have a "SlicerParameterName" property added to them (this can be done in the Qt Designer). Alternatively, an explicit map from parameter name to widget can be used.

Again, I will update the TemplateKey for Scripted modules to use the parameterNodeWrapper at some point, and when I do it will use this automatic connection functionality.

The way the connections work is to define classes that know how to convert widgets to datatypes (int, str, float, etc). I added a lot of connectors, but certainly more could be added. The connectors are added via a decorator, so it is not a hardcoded list and can be extended in extensions or custom apps.

Relates https://github.com/Slicer/Slicer/issues/6724