### PR TITLE
BUG: Fix reading of vector fields from NIFTI files

### DIFF
--- a/Libs/MRML/Core/vtkITKTransformConverter.h
+++ b/Libs/MRML/Core/vtkITKTransformConverter.h
@@ -69,46 +69,66 @@ public:
   /// Create an ITK transform from a VTK transform.
   /// secondaryTransformItk: Only for backward compatibility. For BSpline transforms that have an additive bulk component, the bulk component is saved
   ///   in the secondary transform.
-  /// preferITKv3CompatibleTransforms: If true then BSpline transform will created as BSplineDeformableTransform and additive bulk transform component is always written
-  ///   in the secondary transform. If false then BSpline transform will be written as BSplineTransform (multiplicative bulk component is saved in a composite transform).
+  /// preferITKv3CompatibleTransforms: If true then BSpline transform will created as BSplineDeformableTransform and additive bulk transform component
+  //    is always written in the secondary transform. If false then BSpline transform will be written as BSplineTransform (multiplicative bulk component
+  //    is saved in a composite transform).
   /// If initialize is set to true then the transform is initialized to be readily usable.
   /// Initialization takes a long time for kernel transforms with many points,
   /// If a transform is created only to write it to file, initialization can be turned off to improve performance.
   static itk::Object::Pointer CreateITKTransformFromVTK(vtkObject* loggerObject, vtkAbstractTransform* transformVtk,
     itk::Object::Pointer& secondaryTransformItk, int preferITKv3CompatibleTransforms, bool initialize = true);
 
-  template <typename T> static bool SetVTKBSplineFromITKv3Generic(vtkObject* loggerObject, vtkOrientedBSplineTransform* bsplineVtk, typename itk::TransformBaseTemplate<T>::Pointer warpTransformItk, typename itk::TransformBaseTemplate<T>::Pointer bulkTransformItk);
+  template <typename T> static bool SetVTKBSplineFromITKv3Generic(vtkObject* loggerObject, vtkOrientedBSplineTransform* bsplineVtk,
+    typename itk::TransformBaseTemplate<T>::Pointer warpTransformItk, typename itk::TransformBaseTemplate<T>::Pointer bulkTransformItk);
 
+  /// Image grid is always in LPS but vectors may be in LPS (default) or RAS (when reading displacement field from NIFTI)
   template<typename T>
-  static bool SetVTKOrientedGridTransformFromITKImage(vtkObject* loggerObject, vtkOrientedGridTransform* grid_Ras, typename itk::DisplacementFieldTransform< T, 3 >::DisplacementFieldType::Pointer gridImage_Lps);
-  static bool SetITKImageFromVTKOrientedGridTransform(vtkObject* loggerObject, GridImageDoubleType::Pointer &gridImage_Lps, vtkOrientedGridTransform* grid_Ras);
+  static bool SetVTKOrientedGridTransformFromITKImage(vtkObject* loggerObject, vtkOrientedGridTransform* grid_Ras,
+    typename itk::DisplacementFieldTransform< T, 3 >::DisplacementFieldType::Pointer gridImage_Lps,
+    int displacementVectorCoordinateSystem = vtkMRMLStorageNode::CoordinateSystemLPS);
+  static bool SetITKImageFromVTKOrientedGridTransform(vtkObject* loggerObject, GridImageDoubleType::Pointer &gridImage_Lps,
+    vtkOrientedGridTransform* grid_Ras);
 
 protected:
 
   template<typename T>
-  static bool SetVTKLinearTransformFromITK(vtkObject* loggerObject, vtkMatrix4x4* transformVtk_RAS, typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS);
+  static bool SetVTKLinearTransformFromITK(vtkObject* loggerObject, vtkMatrix4x4* transformVtk_RAS,
+    typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS);
   static bool SetITKLinearTransformFromVTK(vtkObject* loggerObject, itk::Object::Pointer& transformItk_LPS, vtkMatrix4x4* transformVtk_RAS);
 
+  /// Image grid is always in LPS but vectors may be in LPS (default) or RAS (when reading displacement field from NIFTI)
   template<typename T>
-  static bool SetVTKOrientedGridTransformFromITK(vtkObject* loggerObject, vtkOrientedGridTransform* transformVtk_RAS, typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS);
+  static bool SetVTKOrientedGridTransformFromITK(vtkObject* loggerObject, vtkOrientedGridTransform* transformVtk_RAS,
+    typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS,
+    int displacementVectorCoordinateSystem = vtkMRMLStorageNode::CoordinateSystemLPS);
   static bool SetITKOrientedGridTransformFromVTK(vtkObject* loggerObject, itk::Object::Pointer& transformItk_LPS, vtkOrientedGridTransform* transformVtk_RAS);
 
-  static bool SetITKv3BSplineFromVTK(vtkObject* loggerObject, itk::Object::Pointer& warpTransformItk, itk::Object::Pointer& bulkTransformItk, vtkOrientedBSplineTransform* bsplineVtk, bool alwaysAddBulkTransform);
+  static bool SetITKv3BSplineFromVTK(vtkObject* loggerObject, itk::Object::Pointer& warpTransformItk, itk::Object::Pointer& bulkTransformItk,
+    vtkOrientedBSplineTransform* bsplineVtk, bool alwaysAddBulkTransform);
   static bool SetITKv4BSplineFromVTK(vtkObject* loggerObject, itk::Object::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk);
 
   template<typename T>
-  static bool SetVTKThinPlateSplineTransformFromITK(vtkObject* loggerObject, vtkThinPlateSplineTransform* transformVtk_RAS, typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS);
+  static bool SetVTKThinPlateSplineTransformFromITK(vtkObject* loggerObject, vtkThinPlateSplineTransform* transformVtk_RAS,
+    typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS);
   static bool SetITKThinPlateSplineTransformFromVTK(vtkObject* loggerObject, itk::Object::Pointer& transformItk_LPS,
     vtkThinPlateSplineTransform* transformVtk_RAS, bool initialize = true);
 
   static bool IsIdentityMatrix(vtkMatrix4x4 *matrix);
 
-  template <typename BSplineTransformType> static bool SetVTKBSplineParametersFromITKGeneric(vtkObject* loggerObject, vtkOrientedBSplineTransform* bsplineVtk, typename itk::TransformBaseTemplate<typename BSplineTransformType::ScalarType>::Pointer warpTransformItk);
-  template <typename T> static bool SetVTKBSplineFromITKv4Generic(vtkObject* loggerObject, vtkOrientedBSplineTransform* bsplineVtk, typename itk::TransformBaseTemplate<T>::Pointer warpTransformItk);
+  template <typename BSplineTransformType> static bool SetVTKBSplineParametersFromITKGeneric(vtkObject* loggerObject,
+    vtkOrientedBSplineTransform* bsplineVtk, typename itk::TransformBaseTemplate<typename BSplineTransformType::ScalarType>::Pointer warpTransformItk);
+  template <typename T> static bool SetVTKBSplineFromITKv4Generic(vtkObject* loggerObject,
+    vtkOrientedBSplineTransform* bsplineVtk, typename itk::TransformBaseTemplate<T>::Pointer warpTransformItk);
 
-  template <typename BSplineTransformType> static bool SetITKBSplineParametersFromVTKGeneric(vtkObject* loggerObject, typename itk::Transform< typename BSplineTransformType::ScalarType,VTKDimension,VTKDimension>::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk);
-  template <typename T> static bool SetITKv3BSplineFromVTKGeneric(vtkObject* loggerObject, typename itk::Transform<T,VTKDimension,VTKDimension>::Pointer& warpTransformItk, typename itk::Transform<T,VTKDimension,VTKDimension>::Pointer& bulkTransformItk, vtkOrientedBSplineTransform* bsplineVtk, bool alwaysAddBulkTransform);
-  template <typename T> static bool SetITKv4BSplineFromVTKGeneric(vtkObject* loggerObject, typename itk::Transform<T,VTKDimension,VTKDimension>::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk);
+  template <typename BSplineTransformType> static bool SetITKBSplineParametersFromVTKGeneric(vtkObject* loggerObject,
+    typename itk::Transform< typename BSplineTransformType::ScalarType, VTKDimension, VTKDimension>::Pointer& warpTransformItk,
+    vtkOrientedBSplineTransform* bsplineVtk);
+  template <typename T> static bool SetITKv3BSplineFromVTKGeneric(vtkObject* loggerObject,
+    typename itk::Transform<T,VTKDimension,VTKDimension>::Pointer& warpTransformItk,
+    typename itk::Transform<T, VTKDimension, VTKDimension>::Pointer& bulkTransformItk, vtkOrientedBSplineTransform* bsplineVtk,
+    bool alwaysAddBulkTransform);
+  template <typename T> static bool SetITKv4BSplineFromVTKGeneric(vtkObject* loggerObject,
+    typename itk::Transform<T,VTKDimension,VTKDimension>::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk);
 
 };
 
@@ -556,7 +576,8 @@ template <typename T> bool vtkITKTransformConverter::SetVTKBSplineFromITKv4Gener
 
 //----------------------------------------------------------------------------
 template <typename BSplineTransformType> bool vtkITKTransformConverter::SetITKBSplineParametersFromVTKGeneric(vtkObject* loggerObject,
-  typename itk::Transform< typename BSplineTransformType::ScalarType,VTKDimension,VTKDimension>::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk)
+  typename itk::Transform< typename BSplineTransformType::ScalarType,VTKDimension,VTKDimension>::Pointer& warpTransformItk,
+  vtkOrientedBSplineTransform* bsplineVtk)
 {
   typedef typename BSplineTransformType::ScalarType T;
   if (bsplineVtk==nullptr)
@@ -666,11 +687,13 @@ template <typename T> bool vtkITKTransformConverter::SetITKv3BSplineFromVTKGener
   bool itkTransformSetSuccessfully = false;
   if (bsplineVtk->GetInverseFlag())
     {
-    itkTransformSetSuccessfully = SetITKBSplineParametersFromVTKGeneric< itk::InverseBSplineDeformableTransform< T, VTKDimension, VTKDimension > >(loggerObject, warpTransformItk, bsplineVtk);
+    itkTransformSetSuccessfully = SetITKBSplineParametersFromVTKGeneric<
+      itk::InverseBSplineDeformableTransform< T, VTKDimension, VTKDimension > >(loggerObject, warpTransformItk, bsplineVtk);
     }
   else
     {
-    itkTransformSetSuccessfully = SetITKBSplineParametersFromVTKGeneric< itk::BSplineDeformableTransform< T, VTKDimension, VTKDimension > >(loggerObject, warpTransformItk, bsplineVtk);
+    itkTransformSetSuccessfully = SetITKBSplineParametersFromVTKGeneric<
+      itk::BSplineDeformableTransform< T, VTKDimension, VTKDimension > >(loggerObject, warpTransformItk, bsplineVtk);
     }
   if (!itkTransformSetSuccessfully)
     {
@@ -731,11 +754,13 @@ template <typename T> bool vtkITKTransformConverter::SetITKv4BSplineFromVTKGener
   bool itkTransformSetSuccessfully = false;
   if (bsplineVtk->GetInverseFlag())
     {
-    itkTransformSetSuccessfully = SetITKBSplineParametersFromVTKGeneric< itk::InverseBSplineTransform< T, VTKDimension, VTKDimension > >(loggerObject, warpTransformItk, bsplineVtk);
+    itkTransformSetSuccessfully = SetITKBSplineParametersFromVTKGeneric<
+      itk::InverseBSplineTransform< T, VTKDimension, VTKDimension > >(loggerObject, warpTransformItk, bsplineVtk);
     }
   else
     {
-    itkTransformSetSuccessfully = SetITKBSplineParametersFromVTKGeneric< itk::BSplineTransform< T, VTKDimension, VTKDimension > >(loggerObject, warpTransformItk, bsplineVtk);
+    itkTransformSetSuccessfully = SetITKBSplineParametersFromVTKGeneric<
+      itk::BSplineTransform< T, VTKDimension, VTKDimension > >(loggerObject, warpTransformItk, bsplineVtk);
     }
   if (!itkTransformSetSuccessfully)
     {
@@ -799,7 +824,8 @@ bool vtkITKTransformConverter::SetITKv3BSplineFromVTK(vtkObject* loggerObject, i
 }
 
 //----------------------------------------------------------------------------
-bool vtkITKTransformConverter::SetITKv4BSplineFromVTK(vtkObject* loggerObject, itk::Object::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk)
+bool vtkITKTransformConverter::SetITKv4BSplineFromVTK(vtkObject* loggerObject,
+  itk::Object::Pointer& warpTransformItk, vtkOrientedBSplineTransform* bsplineVtk)
 {
   if (bsplineVtk==nullptr)
     {
@@ -848,7 +874,9 @@ bool vtkITKTransformConverter::SetITKv4BSplineFromVTK(vtkObject* loggerObject, i
 
 //----------------------------------------------------------------------------
 template<typename T>
-bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITK(vtkObject* loggerObject, vtkOrientedGridTransform* transformVtk_RAS, typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS)
+bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITK(vtkObject* loggerObject,
+  vtkOrientedGridTransform* transformVtk_RAS, typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS,
+  int displacementVectorCoordinateSystem/*=vtkMRMLStorageNode::CoordinateSystemLPS*/)
 {
   typedef itk::DisplacementFieldTransform< T, 3 > DisplacementFieldTransformType;
   typedef itk::InverseDisplacementFieldTransform< T, 3 > InverseDisplacementFieldTransformType;
@@ -886,7 +914,8 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITK(vtkObject* log
     vtkDebugWithObjectMacro(loggerObject, "Not a grid transform");
     return false;
     }
-  if (!SetVTKOrientedGridTransformFromITKImage<T>(loggerObject, transformVtk_RAS, gridImageItk_Lps))
+  if (!SetVTKOrientedGridTransformFromITKImage<T>(loggerObject, transformVtk_RAS, gridImageItk_Lps,
+    displacementVectorCoordinateSystem))
     {
     return false;
     }
@@ -898,7 +927,8 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITK(vtkObject* log
 }
 
 //----------------------------------------------------------------------------
-bool vtkITKTransformConverter::SetITKOrientedGridTransformFromVTK(vtkObject* loggerObject, itk::Object::Pointer& transformItk_LPS, vtkOrientedGridTransform* transformVtk_RAS)
+bool vtkITKTransformConverter::SetITKOrientedGridTransformFromVTK(vtkObject* loggerObject,
+  itk::Object::Pointer& transformItk_LPS, vtkOrientedGridTransform* transformVtk_RAS)
 {
   GridImageDoubleType::Pointer gridImageItk_Lps;
   if (!SetITKImageFromVTKOrientedGridTransform(loggerObject, gridImageItk_Lps, transformVtk_RAS))
@@ -925,7 +955,9 @@ bool vtkITKTransformConverter::SetITKOrientedGridTransformFromVTK(vtkObject* log
 
 //----------------------------------------------------------------------------
 template<typename T>
-bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITKImage(vtkObject* loggerObject, vtkOrientedGridTransform* grid_Ras, typename itk::DisplacementFieldTransform< T, 3 >::DisplacementFieldType::Pointer gridImage_Lps)
+bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITKImage(vtkObject* loggerObject, vtkOrientedGridTransform* grid_Ras,
+  typename itk::DisplacementFieldTransform< T, 3 >::DisplacementFieldType::Pointer gridImage_Lps,
+  int displacementVectorCoordinateSystem/*=vtkMRMLStorageNode::CoordinateSystemLPS*/)
 {
   typedef itk::DisplacementFieldTransform< T, 3 > DisplacementFieldTransformType;
   typedef typename DisplacementFieldTransformType::DisplacementFieldType GridImageType;
@@ -969,15 +1001,37 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITKImage(vtkObject
   double* displacementVectors_Ras = reinterpret_cast<double*>(gridImage_Ras->GetScalarPointer());
   itk::ImageRegionConstIterator<GridImageType> inputIt(gridImage_Lps, gridImage_Lps->GetRequestedRegion());
   inputIt.GoToBegin();
-  while( !inputIt.IsAtEnd() )
-    {
-    typename GridImageType::PixelType displacementVectorLps=inputIt.Get();
-    *(displacementVectors_Ras++) = -displacementVectorLps[0];
-    *(displacementVectors_Ras++) = -displacementVectorLps[1];
-    *(displacementVectors_Ras++) =  displacementVectorLps[2];
-    ++inputIt;
-    }
 
+  if (displacementVectorCoordinateSystem == vtkMRMLStorageNode::CoordinateSystemLPS)
+    {
+    while (!inputIt.IsAtEnd())
+      {
+        // vectors are in LPS, convert them to LPS
+        typename GridImageType::PixelType displacementVector = inputIt.Get();
+        *(displacementVectors_Ras++) = -displacementVector[0];
+        *(displacementVectors_Ras++) = -displacementVector[1];
+        *(displacementVectors_Ras++) = displacementVector[2];
+        ++inputIt;
+      }
+    }
+  else if (displacementVectorCoordinateSystem == vtkMRMLStorageNode::CoordinateSystemRAS)
+    {
+    // vectors are already RAS
+    while( !inputIt.IsAtEnd() )
+      {
+      typename GridImageType::PixelType displacementVector=inputIt.Get();
+      *(displacementVectors_Ras++) = displacementVector[0];
+      *(displacementVectors_Ras++) = displacementVector[1];
+      *(displacementVectors_Ras++) = displacementVector[2];
+      ++inputIt;
+      }
+    }
+  else
+    {
+    vtkErrorWithObjectMacro(loggerObject, "Cannot load grid transform: the input displacement field vector coordinate system ID ("
+      << displacementVectorCoordinateSystem << ") is invalid.");
+    return false;
+    }
   grid_Ras->SetDisplacementGridData( gridImage_Ras.GetPointer() );
 
   // Set the interpolation to cubic to have smooth derivatives
@@ -987,7 +1041,8 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITKImage(vtkObject
 }
 
 //----------------------------------------------------------------------------
-bool vtkITKTransformConverter::SetITKImageFromVTKOrientedGridTransform(vtkObject* loggerObject, GridImageDoubleType::Pointer &gridImage_Lps, vtkOrientedGridTransform* grid_Ras)
+bool vtkITKTransformConverter::SetITKImageFromVTKOrientedGridTransform(vtkObject* loggerObject,
+  GridImageDoubleType::Pointer &gridImage_Lps, vtkOrientedGridTransform* grid_Ras)
 {
   if (grid_Ras==nullptr)
     {
@@ -1095,7 +1150,8 @@ bool vtkITKTransformConverter::SetITKImageFromVTKOrientedGridTransform(vtkObject
 
 //----------------------------------------------------------------------------
 template<typename T>
-bool vtkITKTransformConverter::SetVTKThinPlateSplineTransformFromITK(vtkObject* loggerObject, vtkThinPlateSplineTransform* transformVtk_RAS, typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS)
+bool vtkITKTransformConverter::SetVTKThinPlateSplineTransformFromITK(vtkObject* loggerObject,
+  vtkThinPlateSplineTransform* transformVtk_RAS, typename itk::TransformBaseTemplate<T>::Pointer transformItk_LPS)
 {
   typedef itk::ThinPlateSplineKernelTransform<T,3> ThinPlateSplineTransformType;
   typedef itk::InverseThinPlateSplineKernelTransform< T, 3 > InverseThinPlateSplineTransformType;
@@ -1402,7 +1458,8 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
         vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: invalid input transform");
         return nullptr;
         }
-      vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: conversion of transform type "<<singleTransformVtk->GetClassName()<<" is not supported");
+      vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: conversion of transform type "
+        << singleTransformVtk->GetClassName() << " is not supported");
       return nullptr;
       }
     }
@@ -1423,17 +1480,21 @@ itk::Object::Pointer vtkITKTransformConverter::CreateITKTransformFromVTK(vtkObje
       itk::Object::Pointer singleTransformItk = CreateITKTransformFromVTK(loggerObject, singleTransformVtk, secondaryTransformItkTmp, false );
       if (secondaryTransformItkTmp.IsNotNull())
         {
-        vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: composite transforms cannot contain legacy transforms (that contains secondary transforms). Do not harden transforms on legacy ITK transforms to avoid this error.");
+        vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed:"
+          " composite transforms cannot contain legacy transforms (that contains secondary transforms)."
+          " Do not harden transforms on legacy ITK transforms to avoid this error.");
         return nullptr;
         }
 
       if (singleTransformItk.IsNull()
           || std::string(singleTransformItk->GetNameOfClass()).find("Transform") == std::string::npos)
         {
-        vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed: invalid element found while trying to create a composite transform");
+        vtkErrorWithObjectMacro(loggerObject, "vtkITKTransformConverter::CreateITKTransformFromVTK failed:"
+          " invalid element found while trying to create a composite transform");
         return nullptr;
         }
-      CompositeTransformType::TransformType::Pointer singleTransformItkTypeChecked = static_cast< CompositeTransformType::TransformType* >( singleTransformItk.GetPointer() );
+      CompositeTransformType::TransformType::Pointer singleTransformItkTypeChecked =
+        static_cast< CompositeTransformType::TransformType* >( singleTransformItk.GetPointer() );
       compositeTransformItk->AddTransform(singleTransformItkTypeChecked.GetPointer());
       }
     return primaryTransformItk;

--- a/Libs/MRML/Core/vtkITKTransformConverter.h
+++ b/Libs/MRML/Core/vtkITKTransformConverter.h
@@ -1006,7 +1006,7 @@ bool vtkITKTransformConverter::SetVTKOrientedGridTransformFromITKImage(vtkObject
     {
     while (!inputIt.IsAtEnd())
       {
-        // vectors are in LPS, convert them to LPS
+        // vectors are in LPS, convert them to RAS
         typename GridImageType::PixelType displacementVector = inputIt.Get();
         *(displacementVectors_Ras++) = -displacementVector[0];
         *(displacementVectors_Ras++) = -displacementVector[1];

--- a/Libs/MRML/Core/vtkITKTransformConverter.h
+++ b/Libs/MRML/Core/vtkITKTransformConverter.h
@@ -69,9 +69,9 @@ public:
   /// Create an ITK transform from a VTK transform.
   /// secondaryTransformItk: Only for backward compatibility. For BSpline transforms that have an additive bulk component, the bulk component is saved
   ///   in the secondary transform.
-  /// preferITKv3CompatibleTransforms: If true then BSpline transform will created as BSplineDeformableTransform and additive bulk transform component
-  //    is always written in the secondary transform. If false then BSpline transform will be written as BSplineTransform (multiplicative bulk component
-  //    is saved in a composite transform).
+  /// preferITKv3CompatibleTransforms: If true then the BSpline transform will be created as a BSplineDeformableTransform and additive bulk transform component
+  ///  is always written in the secondary transform. If false then the BSpline transform is written as a BSplineTransform (multiplicative bulk component
+  ///  is saved in a composite transform).
   /// If initialize is set to true then the transform is initialized to be readily usable.
   /// Initialization takes a long time for kernel transforms with many points,
   /// If a transform is created only to write it to file, initialization can be turned off to improve performance.


### PR DESCRIPTION
When ITK reads a vector field from NIFTI image, it changes the index to physical to IJKToLPS, but it does not reorient the vectors from RAS to LPS. This commit handles the special case when reading a vector field from NIFTI format.

Future ITK versions might reorient the vectors - in that case this special case handling should be removed from here.

This will allow reading displacement fields in NIFTI file format, for example, created by VoxelMorph. Currently, VoxelMorph writes an invalid NIFTI file, but it should be fixed soon (see https://github.com/voxelmorph/voxelmorph/issues/438).