### PR TITLE
Fix i18n qt base regressions

### DIFF
--- a/Base/QTCore/qSlicerAbstractCoreModule.cxx
+++ b/Base/QTCore/qSlicerAbstractCoreModule.cxx
@@ -346,4 +346,5 @@ QString qSlicerAbstractCoreModule::defaultDocumentationLink()const
     + tr("For more information see the %1.").arg(
         QString("<a href=\"%1\">%2</a>").arg(url).arg(tr("online documentation")))
     + QString("</p>");
+  return linkText;
 }

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -1950,7 +1950,7 @@ bool qSlicerExtensionsManagerModel::installExtension(
       if (d->Interactive)
         {
         //: %1 is the extension name
-        QString msg = QString("<p>%1</p><ul>").arg(tr("%1 depends on the following extensions, which could not be found:")).arg(extensionName);
+        QString msg = QString("<p>%1</p><ul>").arg(tr("%1 depends on the following extensions, which could not be found:").arg(extensionName));
         foreach(const QString & dependencyName, unresolvedDependencies)
           {
           msg += QString("<li>%1</li>").arg(dependencyName);


### PR DESCRIPTION
This fixes regressions introduced in https://github.com/Slicer/Slicer/commit/1031050a0a677381ff40030a218702cd45fda668 (BUG: Mark translatable strings in Base/QTCore).

To catch issue like the one associated with the return type, we are also looking into marking `-Wreturn-type` as an error so that the CI effectively fails.