### PR TITLE
BUG: Fix crash when adding %s specifier to color legend label

### DIFF
--- a/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.h
+++ b/Modules/Loadable/Colors/VTKWidgets/vtkSlicerScalarBarActor.h
@@ -89,6 +89,12 @@ protected:
   void PrepareTitleText() override;
   void ConfigureTitle() override;
 
+  /// Parses the requestedFormat string to find a validated format for the types contained in typeString.
+  /// validatedFormat is set to the first matching sprintf for the input types
+  /// prefix and suffix are set to the non-matching components of requestedFormat
+  static bool ValidateFormatString(std::string& validatedFormat, std::string& prefix, std::string& suffix,
+    const std::string& requestedFormat, const std::string& typeString);
+
   /// flag for setting color name as label
   int UseAnnotationAsLabel;
 


### PR DESCRIPTION
If a string specifier followed by a float specifier were added to the label format string, the SNPRINTF call would crash when interpreting the double as a string pointer. Fixed by only printing the value to the first specifier, and by validating that the specifier defines a floating point type.

Fix #3802