### PR TITLE
BUG: Fix qMRMLLayoutManagerVisibilityTest

### DIFF
--- a/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
+++ b/Libs/MRML/Widgets/Testing/qMRMLLayoutManagerVisibilityTest.cxx
@@ -388,6 +388,8 @@ int qMRMLLayoutManagerVisibilityTest(int argc, char * argv[] )
   applicationLogic->SetMRMLScene(scene.GetPointer());
   layoutManager.setMRMLScene(scene.GetPointer());
 
+  qApp->processEvents();
+
   if (!runTests(scene.GetPointer(), layoutNode.GetPointer(), &layoutManager))
     {
     return EXIT_FAILURE;


### PR DESCRIPTION
This commit fixes the test failing on some system (e.g Ubuntu 20.04):

```
 Line 201 - Problem with widget visibility associated with node vtkMRMLViewNode1
   widgetVisibility: 0
   expectedWidgetVisibility: 1
```