### PR TITLE
ENH: Bundle Qt language tools

### DIFF
--- a/CMake/SlicerBlockInstallQt.cmake
+++ b/CMake/SlicerBlockInstallQt.cmake
@@ -191,3 +191,28 @@ set(QT_INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR})
       FILES "${Slicer_INSTALL_ROOT}/bin/designer-real"
       COMPONENT Runtime)
   endif()
+
+  # Bundle Qt language tools with the application if internationalization is enabled.
+  # These tools allow Slicer modules to update and process Qt translation (.ts) files
+  # without requiring installation of Qt.
+  if(Slicer_BUILD_I18N_SUPPORT)
+    foreach(tool lconvert lrelease lupdate)
+      install(PROGRAMS ${qt_root_dir}/bin/${tool}${CMAKE_EXECUTABLE_SUFFIX}
+        DESTINATION ${Slicer_INSTALL_ROOT}/bin COMPONENT Runtime
+        )
+      slicerStripInstalledLibrary(
+        FILES "${Slicer_INSTALL_ROOT}/bin/${tool}"
+        COMPONENT Runtime
+        )
+      if(APPLE)
+        set(dollar "$")
+        install(CODE
+          "set(app ${Slicer_INSTALL_BIN_DIR}/${tool})
+          set(appfilepath \"${dollar}ENV{DESTDIR}${dollar}{CMAKE_INSTALL_PREFIX}/${dollar}{app}\")
+          message(\"CPack: - Adding rpath to ${dollar}{app}\")
+          execute_process(COMMAND install_name_tool -add_rpath @loader_path/..  ${dollar}{appfilepath})"
+          COMPONENT Runtime
+          )
+      endif()
+    endforeach()
+  endif()

--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -556,6 +556,45 @@ macro(slicerMacroBuildApplication)
           OUTPUTVAR extraApplicationToLaunchListForBuildTree
           )
       endif()
+
+      # Make available Qt language tools conveniently on the command line, for example:
+      # Slicer.exe --lconvert ...
+      if(Slicer_BUILD_I18N_SUPPORT)
+        if(NOT QT_LCONVERT_EXECUTABLE)
+          find_program(QT_LCONVERT_EXECUTABLE lconvert HINTS "${QT_BINARY_DIR}" NO_DEFAULT_PATH)
+        endif()
+        if(EXISTS ${QT_LCONVERT_EXECUTABLE})
+          ctkAppLauncherAppendExtraAppToLaunchToList(
+            LONG_ARG lconvert
+            HELP "Start Qt lconvert language utility"
+            PATH ${QT_LCONVERT_EXECUTABLE}
+            OUTPUTVAR extraApplicationToLaunchListForBuildTree
+            )
+        endif()
+        if(NOT QT_LRELEASE_EXECUTABLE)
+          find_program(QT_LRELEASE_EXECUTABLE lrelease HINTS "${QT_BINARY_DIR}" NO_DEFAULT_PATH)
+        endif()
+        if(EXISTS ${QT_LRELEASE_EXECUTABLE})
+          ctkAppLauncherAppendExtraAppToLaunchToList(
+            LONG_ARG lrelease
+            HELP "Start Qt lrelease language utility"
+            PATH ${QT_LRELEASE_EXECUTABLE}
+            OUTPUTVAR extraApplicationToLaunchListForBuildTree
+            )
+        endif()
+        if(NOT QT_LUPDATE_EXECUTABLE)
+          find_program(QT_LUPDATE_EXECUTABLE lupdate HINTS "${QT_BINARY_DIR}" NO_DEFAULT_PATH)
+        endif()
+        if(EXISTS ${QT_LUPDATE_EXECUTABLE})
+          ctkAppLauncherAppendExtraAppToLaunchToList(
+            LONG_ARG lupdate
+            HELP "Start Qt lupdate language utility"
+            PATH ${QT_LUPDATE_EXECUTABLE}
+            OUTPUTVAR extraApplicationToLaunchListForBuildTree
+            )
+        endif()
+      endif()
+
       set(executables)
       if(UNIX)
         list(APPEND executables gnome-terminal xterm)
@@ -613,6 +652,35 @@ macro(slicerMacroBuildApplication)
           PATH "<APPLAUNCHER_SETTINGS_DIR>/../bin/designer-real${CMAKE_EXECUTABLE_SUFFIX}"
           OUTPUTVAR extraApplicationToLaunchListForInstallTree
           )
+      endif()
+
+      # Make available Qt language tools conveniently on the command line, for example:
+      # Slicer.exe --lconvert ...
+      if(Slicer_BUILD_I18N_SUPPORT)
+        if(EXISTS ${QT_LCONVERT_EXECUTABLE} AND NOT APPLE)
+          ctkAppLauncherAppendExtraAppToLaunchToList(
+            LONG_ARG lconvert
+            HELP "Start Qt lconvert language utility"
+            PATH "<APPLAUNCHER_SETTINGS_DIR>/../bin/lconvert${CMAKE_EXECUTABLE_SUFFIX}"
+            OUTPUTVAR extraApplicationToLaunchListForInstallTree
+            )
+        endif()
+        if(EXISTS ${QT_LRELEASE_EXECUTABLE} AND NOT APPLE)
+          ctkAppLauncherAppendExtraAppToLaunchToList(
+            LONG_ARG lrelease
+            HELP "Start Qt lrelease language utility"
+            PATH "<APPLAUNCHER_SETTINGS_DIR>/../bin/lrelease${CMAKE_EXECUTABLE_SUFFIX}"
+            OUTPUTVAR extraApplicationToLaunchListForInstallTree
+            )
+        endif()
+        if(EXISTS ${QT_LUPDATE_EXECUTABLE} AND NOT APPLE)
+          ctkAppLauncherAppendExtraAppToLaunchToList(
+            LONG_ARG lupdate
+            HELP "Start Qt lupdate language utility"
+            PATH "<APPLAUNCHER_SETTINGS_DIR>/../bin/lupdate${CMAKE_EXECUTABLE_SUFFIX}"
+            OUTPUTVAR extraApplicationToLaunchListForInstallTree
+            )
+        endif()
       endif()
 
       include(SlicerBlockCTKAppLauncherSettings)


### PR DESCRIPTION
Bundle lconvert, lrelease, lupdate tools with the application to allow Slicer modules to update and process translation (.ts) files without requiring Qt installation.

Required for https://github.com/Slicer/SlicerLanguagePacks/issues/1