### PR TITLE
BUG: Update ITK to fix read/write of displacement field in NIFTI file format

### DIFF
--- a/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.h
+++ b/Modules/Loadable/Transforms/Logic/vtkSlicerTransformLogic.h
@@ -33,6 +33,7 @@
 // MRML includes
 class vtkMRMLDisplayableNode;
 class vtkMRMLMarkupsNode;
+class vtkMRMLMessageCollection;
 class vtkMRMLScalarVolumeNode;
 class vtkMRMLScene;
 class vtkMRMLSliceNode;
@@ -66,11 +67,7 @@ class VTK_SLICER_TRANSFORMS_MODULE_LOGIC_EXPORT vtkSlicerTransformLogic : public
 
   ///
   /// Read transform from file
-  vtkMRMLTransformNode* AddTransform (const char* filename, vtkMRMLScene *scene);
-
-  ///
-  /// Write transform's data to a specified file
-  int SaveTransform (const char* filename, vtkMRMLTransformNode *transformNode);
+  vtkMRMLTransformNode* AddTransform(const char* filename, vtkMRMLScene *scene, vtkMRMLMessageCollection* userMessages=nullptr);
 
   /// Generate polydata for 2D transform visualization
   /// Return true on success.

--- a/Modules/Loadable/Transforms/qSlicerTransformsReader.cxx
+++ b/Modules/Loadable/Transforms/qSlicerTransformsReader.cxx
@@ -27,6 +27,7 @@
 #include "vtkSlicerTransformLogic.h"
 
 // MRML includes
+#include <vtkMRMLMessageCollection.h>
 #include <vtkMRMLTransformNode.h>
 
 // VTK includes
@@ -95,8 +96,10 @@ bool qSlicerTransformsReader::load(const IOProperties& properties)
     {
     return false;
     }
+
+  this->userMessages()->ClearMessages();
   vtkMRMLTransformNode* node = d->TransformLogic->AddTransform(
-    fileName.toUtf8(), this->mrmlScene());
+    fileName.toUtf8(), this->mrmlScene(), this->userMessages());
   if (node)
     {
     this->setLoadedNodes(QStringList(QString(node->GetID())));
@@ -107,5 +110,3 @@ bool qSlicerTransformsReader::load(const IOProperties& properties)
     }
   return node != nullptr;
 }
-
-// TODO: add the save() method. Use vtkSlicerTransformLogic::SaveTransform()

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "be914a8b57b581735f2655098431dab61ded01c5" # slicer-v5.3rc04-2022-09-19-62eb5ca
+    "eeb7f43c49b2e1c1b7b746a35a458ce65c080277" # slicer-v5.3rc04-2022-09-19-62eb5ca
     QUIET
     )
 

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "eeb7f43c49b2e1c1b7b746a35a458ce65c080277" # slicer-v5.3rc04-2022-09-19-62eb5ca
+    "9745ba2fae8abf31175deae87ff3e55e81c0a663" # slicer-v5.3rc04-2022-09-19-62eb5ca
     QUIET
     )
 


### PR DESCRIPTION
This commit is a follow-up of 898959159 (BUG: Fix reading of vector fields from NIFTI files)

NIFTI image containing displacement field (`intent = 1006`) was incorrectly read as scalar volume (all 3 vector components were set to the same value).

Fixed by reading NIFTI displacement vector files similarly to general-purpose vector images. For displacement vector files, vector components are converted between NIFTI file's `RAS` coordinate system and ITK's `LPS` coordinate system, unless this conversion is explicitly disabled by setting `ConvertRASDisplacementVectors` to false.

An ITK vector image can be written as NIFTI displacement vector file by setting "intent_code"="1006" in the metadata dictionary of the image.

List of ITK changes:

```
$ git shortlog be914a8b57..eeb7f43c49 --no-merges
Andras Lasso (1):
      [Backport PR-3884] BUG: Fix read/write of displacement field in NIFTI file format
```

References:
* https://github.com/Slicer/Slicer/pull/6791
* https://github.com/Slicer/ITK/pull/7