### PR TITLE
BUG: Table column type issues

### DIFF
--- a/Libs/MRML/Core/vtkMRMLTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableNode.cxx
@@ -337,7 +337,19 @@ vtkAbstractArray* vtkMRMLTableNode::AddColumn(vtkAbstractArray* column)
     newColumn = vtkSmartPointer<vtkAbstractArray>::Take(vtkAbstractArray::CreateArray(valueTypeId));
     newColumn->SetNumberOfTuples(numberOfRows);
 
-    vtkVariant emptyCell(this->GetColumnProperty(SCHEMA_DEFAULT_COLUMN_NAME, SCHEMA_COLUMN_NULL_VALUE));
+    std::string nullValue(this->GetColumnProperty(SCHEMA_DEFAULT_COLUMN_NAME, SCHEMA_COLUMN_NULL_VALUE));
+    int columnType = this->GetColumnType(SCHEMA_DEFAULT_COLUMN_NAME);
+    vtkVariant emptyCell(vtkVariant(nullValue), columnType);
+    if (!emptyCell.IsValid())
+      {
+      // This will create a valid variant for char types
+      emptyCell = vtkVariant('\0', columnType);
+      }
+    if (!emptyCell.IsValid())
+      {
+      // This will create a valid variant for the remaining numeric types
+      emptyCell = vtkVariant("0", columnType);
+      }
     for (int i=0; i<numberOfRows; i++)
       {
       newColumn->SetVariantValue(i, emptyCell);

--- a/Libs/MRML/Core/vtkMRMLTableNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableNode.cxx
@@ -968,7 +968,7 @@ int vtkMRMLTableNode::GetColumnValueTypeFromSchema(const std::string& columnName
     {
     vtkErrorMacro("Unknown column value type: " << valueTypeStr << " using string instead. Supported types: string, double, float, int, unsigned int, bit,"
       ", short, unsigned short, long, unsigned long, char, signed char, unsigned char, long long, unsigned long long"
-      ", __int64, unsigned __int64, idtype");
+      ", __int64, unsigned __int64");
     }
   return valueType;
 }
@@ -1083,7 +1083,7 @@ bool vtkMRMLTableNode::SetDefaultColumnType(const std::string& type, const std::
     vtkErrorMacro("vtkMRMLTableNode::SetDefaultColumnType failed: Unknown column value type: " << type
       << ". Supported types: string, double, float, int, unsigned int, bit,"
       ", short, unsigned short, long, unsigned long, char, signed char, unsigned char, long long, unsigned long long"
-      ", __int64, unsigned __int64, idtype");
+      ", __int64, unsigned __int64");
     return false;
     }
   this->SetColumnProperty(SCHEMA_DEFAULT_COLUMN_NAME, SCHEMA_COLUMN_TYPE, type);

--- a/Libs/MRML/Core/vtkMRMLTableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableNode.h
@@ -92,7 +92,7 @@ public:
   ///   Column name \<default\> is reserved for defining default properties for new columns.
   /// - type: data type of the column. Supported types: string, double, float, int, unsigned int, bit,
   ///   short, unsigned short, long, unsigned long, char, signed char, unsigned char, long long, unsigned long long
-  ///   __int64, unsigned __int64, idtype. Default: string.
+  ///   __int64, unsigned __int64. Default: string.
   /// - nullValue: value to be used when a value is not specified (new table row is added, blank string is entered, etc)
   /// - longName: full human-readable name of the column
   /// - description: human-readable detailed description of the column

--- a/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLTableStorageNode.cxx
@@ -874,6 +874,20 @@ bool vtkMRMLTableStorageNode::WriteSchema(std::string filename, vtkMRMLTableNode
       std::string componentNamesStr = vtkMRMLTableNode::GetComponentNamesAsString(componentNames);
       componentNamesArray->SetValue(schemaRowIndex, componentNamesStr.c_str());
       }
+    vtkNew<vtkTable> orderedSchemaTable;
+    // Copy contents to match size
+    orderedSchemaTable->DeepCopy(schemaTable);
+
+    // Preserve the <default> row, which is the first row
+    int offset = 1;
+    // Rows in schema table should preserve the order of the table's columns
+    for (int col = 0; col < table->GetNumberOfColumns(); ++col)
+    {
+        std::string columnName = table->GetColumnName(col);
+        vtkIdType schemaRowIndex = columnNameArray->LookupValue(columnName);
+        orderedSchemaTable->SetRow(offset + col, schemaTable->GetRow(schemaRowIndex));
+    }
+    schemaTable->DeepCopy(orderedSchemaTable);
     }
 
   vtkNew<vtkDelimitedTextWriter> writer;

--- a/Modules/Loadable/Tables/Widgets/Resources/UI/qSlicerTableColumnPropertiesWidget.ui
+++ b/Modules/Loadable/Tables/Widgets/Resources/UI/qSlicerTableColumnPropertiesWidget.ui
@@ -120,11 +120,6 @@
        </item>
        <item>
         <property name="text">
-         <string>idtype</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
          <string>unsigned char</string>
         </property>
        </item>


### PR DESCRIPTION
* BUG: Fix non-string table cells initialized with garbage
When a null value for a non-string type column was not specified,
new cells were showing arbitrary values. This fix tries to initialize
cells in this order:

    1. The null value specified by the user, if compatible with the column type
    1. NUL character, if column is char type
    1. 0 otherwise

* BUG: Remove idtype from column types
idtype is not supported by vtkVariant and its size is machine dependent,
so it seems simpler to remove this option.

* BUG: Fix non-str cols always loaded before str cols
When editing a table, string columns with no extra metadata are not
included in the schema. When the schema file is written, these missing
columns are appended to the schema. This commit reorders the schema
before writing so the schema preserves the order in which the columns
appear in the table.

* I have also opened a merge request for a table related problem in VTK. https://gitlab.kitware.com/vtk/vtk/-/merge_requests/9890