### PR TITLE
BUG: Fix failing qSlicerMouseModeToolBarTest1

### DIFF
--- a/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
+++ b/Base/QTGUI/Testing/Cxx/qSlicerMouseModeToolBarTest1.cxx
@@ -36,24 +36,15 @@
 
 QString activePlaceActionText(qSlicerMouseModeToolBar& mouseModeToolBar)
 {
-  QAction* placeAction = mouseModeToolBar.actions()[2];
-  if (!placeAction->isEnabled())
-    {
-    return QString();
-    }
-  return placeAction->text();
-  /*
-  return mouseModeToolBar.actions()[2]->text();
   foreach(QAction* action, mouseModeToolBar.actions())
     {
-    if (action->objectName() == QString("ToolBarAction"))
+    if (action->objectName() == QString("PlaceWidgetAction"))
       {
       return action->text();
       break;
       }
     }
   return QString();
-  */
 }
 
 QString getActiveActionText(qSlicerMouseModeToolBar& mouseModeToolBar)
@@ -100,7 +91,7 @@ int qSlicerMouseModeToolBarTest1(int argc, char * argv[] )
   // without a qSlicerApplication, setting the cursor is a noop
   mouseToolBar.changeCursorTo(QCursor(Qt::BusyCursor));
 
-  CHECK_PLACE_ACTION_TEXT("Toggle Markups Toolbar", mouseToolBar);
+  CHECK_PLACE_ACTION_TEXT("Place", mouseToolBar);
 
   // get the selection and interaction nodes that the mouse mode tool bar
   // listens to

--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -152,7 +152,6 @@ void qSlicerMouseModeToolBarPrivate::init()
 
   QObject::connect(this->ToolBarAction, SIGNAL(triggered()),
     q, SLOT(toggleMarkupsToolBar()));
-  q->addAction(this->ToolBarAction);
 
   this->PlaceWidgetMenu = new QMenu(qSlicerMouseModeToolBar::tr("Place Menu"), q);
   this->PlaceWidgetMenu->setObjectName("PlaceWidgetMenu");
@@ -172,6 +171,7 @@ void qSlicerMouseModeToolBarPrivate::init()
   this->PlaceWidgetAction->setVisible(false);
   q->addAction(this->PlaceWidgetAction);
 
+  q->addAction(this->ToolBarAction);  // add Toggle Markups ToolBar action last
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
The change in order of the actions made in https://github.com/Slicer/Slicer/commit/0ad10f0cb406d25c8d2ea62058b31dcc33173bdf caused the hardcoded index used to find the place widget action in the test to fail.

Failing qSlicerMouseModeToolBarTest1 - https://slicer.cdash.org/test/23951100