### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -41,35 +41,41 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pydicom]
-  pydicom==2.3.0 --hash=sha256:8ff31e077cc51d19ac3b8ca988ac486099cdebfaf885989079fdc7c75068cdd8
+  pydicom==2.3.1 --hash=sha256:b00bacdabc1f8a18b61a08bb6cd0f41c419446531638c895a708c22a35d69cfe
   # [/pydicom]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
   # [/six]
   # [Pillow]
   # Hashes correspond to the following packages:
-  #  - Pillow-9.2.0-cp39-cp39-macosx_10_10_x86_64.whl
-  #  - Pillow-9.2.0-cp39-cp39-macosx_11_0_arm64.whl
-  #  - Pillow-9.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - Pillow-9.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - Pillow-9.2.0-cp39-cp39-manylinux_2_28_aarch64.whl
-  #  - Pillow-9.2.0-cp39-cp39-manylinux_2_28_x86_64.whl
-  #  - Pillow-9.2.0-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - Pillow-9.2.0-cp39-cp39-win_amd64.whl
-  Pillow==9.2.0 --hash=sha256:0ed2c4ef2451de908c90436d6e8092e13a43992f1860275b4d8082667fbb2ffc \
-                --hash=sha256:4ad2f835e0ad81d1689f1b7e3fbac7b01bb8777d5a985c8962bedee0cc6d43da \
-                --hash=sha256:ea98f633d45f7e815db648fd7ff0f19e328302ac36427343e4432c84432e7ff4 \
-                --hash=sha256:9a54614049a18a2d6fe156e68e188da02a046a4a93cf24f373bffd977e943421 \
-                --hash=sha256:5aed7dde98403cd91d86a1115c78d8145c83078e864c1de1064f52e6feb61b20 \
-                --hash=sha256:13b725463f32df1bfeacbf3dd197fb358ae8ebcd8c5548faa75126ea425ccb60 \
-                --hash=sha256:808add66ea764ed97d44dda1ac4f2cfec4c1867d9efb16a33d158be79f32b8a4 \
-                --hash=sha256:fac2d65901fb0fdf20363fbd345c01958a742f2dc62a8dd4495af66e3ff502a4
+  #  - Pillow-9.4.0-1-cp39-cp39-macosx_10_10_x86_64.whl
+  #  - Pillow-9.4.0-2-cp39-cp39-macosx_10_10_x86_64.whl
+  #  - Pillow-9.4.0-cp39-cp39-macosx_10_10_x86_64.whl
+  #  - Pillow-9.4.0-cp39-cp39-macosx_11_0_arm64.whl
+  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_28_aarch64.whl
+  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_28_x86_64.whl
+  #  - Pillow-9.4.0-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - Pillow-9.4.0-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - Pillow-9.4.0-cp39-cp39-win_amd64.whl
+  Pillow==9.4.0 --hash=sha256:b8c2f6eb0df979ee99433d8b3f6d193d9590f735cf12274c108bd954e30ca858 \
+                --hash=sha256:9e5f94742033898bfe84c93c831a6f552bb629448d4072dd312306bab3bd96f1 \
+                --hash=sha256:0f3269304c1a7ce82f1759c12ce731ef9b6e95b6df829dccd9fe42912cc48569 \
+                --hash=sha256:cb362e3b0976dc994857391b776ddaa8c13c28a16f80ac6522c23d5257156bed \
+                --hash=sha256:a2e0f87144fcbbe54297cae708c5e7f9da21a4646523456b00cc956bd4c65815 \
+                --hash=sha256:0884ba7b515163a1a05440a138adeb722b8a6ae2c2b33aea93ea3118dd3a899e \
+                --hash=sha256:53dcb50fbdc3fb2c55431a9b30caeb2f7027fcd2aeb501459464f0214200a503 \
+                --hash=sha256:e8c5cf126889a4de385c02a2c3d3aba4b00f70234bfddae82a5eaa3ee6d5e3e6 \
+                --hash=sha256:6c6b1389ed66cdd174d040105123a5a1bc91d0aa7059c7261d20e583b6d8cbd2 \
+                --hash=sha256:0dd4c681b82214b36273c18ca7ee87065a50e013112eea7d78c7a1b89a739153 \
+                --hash=sha256:54614444887e0d3043557d9dbc697dbb16cfb5a35d672b7a0fcc1ed0cf1c600b
   # [/Pillow]
   # [retrying]
-  retrying==1.3.3 --hash=sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b
+  retrying==1.3.4 --hash=sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35
   # [/retrying]
   # [dicomweb-client]
-  dicomweb-client==0.57.1 --hash=sha256:191f39a06ac5b256ec0c160e6a9c54c9af0d8256eea1d5cb39781939381e3969
+  dicomweb-client==0.59.0 --hash=sha256:70a3cdae97f2ce8288e5b61baa75aa68b39da7b2712da9e248eb7b6f7f269651
   # [/dicomweb-client]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -34,19 +34,19 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [chardet]
-  chardet==5.0.0 --hash=sha256:d3e64f022d254183001eccc5db4040520c0f23b1a3f33d6413e099eb7f126557
+  chardet==5.1.0 --hash=sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9
   # [/chardet]
   # [CouchDB]
   couchdb==1.2 --hash=sha256:13a28a1159c49f8346732e8724b9a4d65cba54bec017c4a7eeb1499fe88151d1
   # [/CouchDB]
   # [gitdb]
-  gitdb==4.0.9 --hash=sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd
+  gitdb==4.0.10 --hash=sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7
   # [/gitdb]
   # [smmap]
   smmap==5.0.0 --hash=sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94
   # [/smmap]
   # [GitPython]
-  GitPython==3.1.29 --hash=sha256:41eea0deec2deea139b459ac03656f0dd28fc4a3387240ec1d3c259a2c47850f
+  GitPython==3.1.30 --hash=sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882
   # [/GitPython]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -33,7 +33,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [PyJWT]
-  PyJWT==2.5.0 --hash=sha256:8d82e7087868e94dd8d7d418e5088ce64f7daab4b36db654cbaedb46f9d1ca80
+  PyJWT==2.6.0 --hash=sha256:d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:
@@ -93,7 +93,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                 --hash=sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93
   # [/PyNaCl]
   # [PyGithub]
-  PyGithub==1.56 --hash=sha256:d15f13d82165306da8a68aefc0f848a6f6432d5febbff13b60a94758ce3ef8b5
+  PyGithub==1.57 --hash=sha256:5822febeac2391f1306c55a99af2bc8f86c8bf82ded000030cd02c18f31b731f
   # [/PyGithub]
   ]===])
 

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -34,16 +34,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/nose]
   # [numpy]
   # Hashes correspond to the following packages:
-  #  - numpy-1.23.4-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - numpy-1.23.4-cp39-cp39-macosx_11_0_arm64.whl
-  #  - numpy-1.23.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - numpy-1.23.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - numpy-1.23.4-cp39-cp39-win_amd64.whl
-  numpy==1.23.4 --hash=sha256:c67b833dbccefe97cdd3f52798d430b9d3430396af7cdb2a0c32954c3ef73894 \
-                --hash=sha256:f76025acc8e2114bb664294a07ede0727aa75d63a06d2fae96bf29a81747e4a7 \
-                --hash=sha256:12ac457b63ec8ded85d85c1e17d85efd3c2b0967ca39560b307a35a6703a4735 \
-                --hash=sha256:95de7dc7dc47a312f6feddd3da2500826defdccbc41608d0031276a24181a2c0 \
-                --hash=sha256:f260da502d7441a45695199b4e7fd8ca87db659ba1c78f2bbf31f934fe76ae0e
+  #  - numpy-1.24.1-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - numpy-1.24.1-cp39-cp39-macosx_11_0_arm64.whl
+  #  - numpy-1.24.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - numpy-1.24.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - numpy-1.24.1-cp39-cp39-win_amd64.whl
+  numpy==1.24.1 --hash=sha256:28bc9750ae1f75264ee0f10561709b1462d450a4808cd97c013046073ae64ab6 \
+                --hash=sha256:84e789a085aabef2f36c0515f45e459f02f570c4b4c4c108ac1179c34d475ed7 \
+                --hash=sha256:8e669fbdcdd1e945691079c2cae335f3e3a56554e06bbd45d7609a6cf568c700 \
+                --hash=sha256:ef85cf1f693c88c1fd229ccd1055570cb41cdf4875873b7728b6301f12cd05bf \
+                --hash=sha256:ddc7ab52b322eb1e40521eb422c4e0a20716c271a306860979d450decbb51b8e
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==22.3 --hash=sha256:1daab4b8d3b97d1d763caeb01a4640a2250a0ea899e257b1e44b9eded91e15ab
+  pip==23.0 --hash=sha256:b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-pythonqt-requirements.cmake
+++ b/SuperBuild/External_python-pythonqt-requirements.cmake
@@ -32,7 +32,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [packaging]
-  packaging==21.3 --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+  packaging==23.0 --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2
   # [/packaging]
   # [pyparsing]
   pyparsing==3.0.9 --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -27,19 +27,37 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [certifi]
-  certifi==2022.9.24 --hash=sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382
+  certifi==2022.12.7 --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
   # [/certifi]
   # [idna]
   idna==3.4 --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
   # [/idna]
   # [charset-normalizer]
-  charset-normalizer==2.1.1 --hash=sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
+  # Hashes correspond to the following packages:
+  #  - charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_universal2.whl
+  #  - charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - charset_normalizer-3.0.1-cp39-cp39-macosx_11_0_arm64.whl
+  #  - charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - charset_normalizer-3.0.1-cp39-cp39-win_amd64.whl
+  #  - charset_normalizer-3.0.1-py3-none-any.whl
+  charset-normalizer==3.0.1 --hash=sha256:8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f \
+                            --hash=sha256:8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678 \
+                            --hash=sha256:3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be \
+                            --hash=sha256:00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b \
+                            --hash=sha256:3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3 \
+                            --hash=sha256:ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d \
+                            --hash=sha256:356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786 \
+                            --hash=sha256:0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59 \
+                            --hash=sha256:7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24
   # [/charset-normalizer]
   # [urllib3]
-  urllib3==1.26.12 --hash=sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997
+  urllib3==1.26.14 --hash=sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1
   # [/urllib3]
   # [requests]
-  requests==2.28.1 --hash=sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349
+  requests==2.28.2 --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa
   # [/requests]
   ]===])
 

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==65.5.0 --hash=sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356
+  setuptools==67.0.0 --hash=sha256:9d790961ba6219e9ff7d9557622d2fe136816a264dd01d5997cfc057d804853d
   # [/setuptools]
   ]===])
 

--- a/SuperBuild/External_python-wheel.cmake
+++ b/SuperBuild/External_python-wheel.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [wheel]
-  wheel==0.37.1 --hash=sha256:4bdcd7d840138086126cd09254dc6195fb4fc6f01c050a1d7236f2630db1d22a
+  wheel==0.38.4 --hash=sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8
   # [/wheel]
   ]===])
 


### PR DESCRIPTION
It's been about 3 months since python packages were last updated. Python packages were last updated on October 18th 2022. This PR updates python packages to their latest versions. This type of update is something I usually do on about a quarterly cadence (every 3 months).

Note that SimpleITK isn't being updated here as we build it from source rather than using the provided whl on pypi. VTK is also not updated as we use build VTK and its python wrapping as well from source rather than installing from whl.

Build and Package were successful on my Windows machine and all tests currently passing were still passing with these changes.

```
PS C:\Users\butlej30383\AppData\Local\NA-MIC\Slicer 5.3.0-2023-01-29\bin> ./PythonSlicer.exe "C:\Slicer\Utilities\Scripts\python_package_updater.py"
Searching external projects in C:\Slicer\SuperBuild
Validate external projects

[notice] A new release of pip available: 22.3 -> 23.0
[notice] To update, run: python-real.exe -m pip install --upgrade pip
Package            Version         Latest    Type
------------------ --------------- --------- -----
certifi            2022.9.24       2022.12.7 wheel
chardet            5.0.0           5.1.0     wheel
charset-normalizer 2.1.1           3.0.1     wheel
dicomweb-client    0.57.1          0.59.0    wheel
gitdb              4.0.9           4.0.10    wheel
GitPython          3.1.29          3.1.30    wheel
numpy              1.23.4          1.24.1    wheel
packaging          21.3            23.0      wheel
Pillow             9.2.0           9.4.0     wheel
pip                22.3            23.0      wheel
pydicom            2.3.0           2.3.1     wheel
PyGithub           1.56            1.57      wheel
PyJWT              2.5.0           2.6.0     wheel
requests           2.28.1          2.28.2    wheel
retrying           1.3.3           1.3.4     wheel
scipy              1.9.2           1.10.0    wheel
setuptools         65.5.0          67.0.0    wheel
SimpleITK          2.2.0rc2.dev368 2.2.1     wheel
urllib3            1.26.12         1.26.14   wheel
vtk                9.1.20220125    9.2.5     wheel
wheel              0.37.1          0.38.4    wheel

  certifi==2022.12.7 --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
  chardet==5.1.0 --hash=sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9
  # Hashes correspond to the following packages:
  #  - charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_universal2.whl
  #  - charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - charset_normalizer-3.0.1-cp39-cp39-macosx_11_0_arm64.whl
  #  - charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - charset_normalizer-3.0.1-cp39-cp39-win_amd64.whl
  #  - charset_normalizer-3.0.1-py3-none-any.whl
  charset-normalizer==3.0.1 --hash=sha256:8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f \
                            --hash=sha256:8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678 \
                            --hash=sha256:3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be \
                            --hash=sha256:00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b \
                            --hash=sha256:3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3 \
                            --hash=sha256:ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d \
                            --hash=sha256:356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786 \
                            --hash=sha256:0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59 \
                            --hash=sha256:7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24
  dicomweb-client==0.59.0 --hash=sha256:70a3cdae97f2ce8288e5b61baa75aa68b39da7b2712da9e248eb7b6f7f269651
  gitdb==4.0.10 --hash=sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7
  GitPython==3.1.30 --hash=sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882
  # Hashes correspond to the following packages:
  #  - numpy-1.24.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - numpy-1.24.1-cp39-cp39-macosx_11_0_arm64.whl
  #  - numpy-1.24.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - numpy-1.24.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - numpy-1.24.1-cp39-cp39-win_amd64.whl
  numpy==1.24.1 --hash=sha256:28bc9750ae1f75264ee0f10561709b1462d450a4808cd97c013046073ae64ab6 \
                --hash=sha256:84e789a085aabef2f36c0515f45e459f02f570c4b4c4c108ac1179c34d475ed7 \
                --hash=sha256:8e669fbdcdd1e945691079c2cae335f3e3a56554e06bbd45d7609a6cf568c700 \
                --hash=sha256:ef85cf1f693c88c1fd229ccd1055570cb41cdf4875873b7728b6301f12cd05bf \
                --hash=sha256:ddc7ab52b322eb1e40521eb422c4e0a20716c271a306860979d450decbb51b8e
  packaging==23.0 --hash=sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2
  # Hashes correspond to the following packages:
  #  - Pillow-9.4.0-1-cp39-cp39-macosx_10_10_x86_64.whl
  #  - Pillow-9.4.0-2-cp39-cp39-macosx_10_10_x86_64.whl
  #  - Pillow-9.4.0-cp39-cp39-macosx_10_10_x86_64.whl
  #  - Pillow-9.4.0-cp39-cp39-macosx_11_0_arm64.whl
  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_28_aarch64.whl
  #  - Pillow-9.4.0-cp39-cp39-manylinux_2_28_x86_64.whl
  #  - Pillow-9.4.0-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - Pillow-9.4.0-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - Pillow-9.4.0-cp39-cp39-win_amd64.whl
  Pillow==9.4.0 --hash=sha256:b8c2f6eb0df979ee99433d8b3f6d193d9590f735cf12274c108bd954e30ca858 \
                --hash=sha256:9e5f94742033898bfe84c93c831a6f552bb629448d4072dd312306bab3bd96f1 \
                --hash=sha256:0f3269304c1a7ce82f1759c12ce731ef9b6e95b6df829dccd9fe42912cc48569 \
                --hash=sha256:cb362e3b0976dc994857391b776ddaa8c13c28a16f80ac6522c23d5257156bed \
                --hash=sha256:a2e0f87144fcbbe54297cae708c5e7f9da21a4646523456b00cc956bd4c65815 \
                --hash=sha256:0884ba7b515163a1a05440a138adeb722b8a6ae2c2b33aea93ea3118dd3a899e \
                --hash=sha256:53dcb50fbdc3fb2c55431a9b30caeb2f7027fcd2aeb501459464f0214200a503 \
                --hash=sha256:e8c5cf126889a4de385c02a2c3d3aba4b00f70234bfddae82a5eaa3ee6d5e3e6 \
                --hash=sha256:6c6b1389ed66cdd174d040105123a5a1bc91d0aa7059c7261d20e583b6d8cbd2 \
                --hash=sha256:0dd4c681b82214b36273c18ca7ee87065a50e013112eea7d78c7a1b89a739153 \
                --hash=sha256:54614444887e0d3043557d9dbc697dbb16cfb5a35d672b7a0fcc1ed0cf1c600b
  pip==23.0 --hash=sha256:b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c
  pydicom==2.3.1 --hash=sha256:b00bacdabc1f8a18b61a08bb6cd0f41c419446531638c895a708c22a35d69cfe
  PyGithub==1.57 --hash=sha256:5822febeac2391f1306c55a99af2bc8f86c8bf82ded000030cd02c18f31b731f
  PyJWT==2.6.0 --hash=sha256:d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14
  requests==2.28.2 --hash=sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa
  retrying==1.3.4 --hash=sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35
  # Hashes correspond to the following packages:
  #  - scipy-1.10.0-cp39-cp39-macosx_10_15_x86_64.whl
  #  - scipy-1.10.0-cp39-cp39-macosx_12_0_arm64.whl
  #  - scipy-1.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - scipy-1.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - scipy-1.10.0-cp39-cp39-win_amd64.whl
  scipy==1.10.0 --hash=sha256:3afcbddb4488ac950ce1147e7580178b333a29cd43524c689b2e3543a080a2c8 \
                --hash=sha256:6e4497e5142f325a5423ff5fda2fff5b5d953da028637ff7c704378c8c284ea7 \
                --hash=sha256:441cab2166607c82e6d7a8683779cb89ba0f475b983c7e4ab88f3668e268c143 \
                --hash=sha256:0490dc499fe23e4be35b8b6dd1e60a4a34f0c4adb30ac671e6332446b3cbbb5a \
                --hash=sha256:954ff69d2d1bf666b794c1d7216e0a746c9d9289096a64ab3355a17c7c59db54
  setuptools==67.0.0 --hash=sha256:9d790961ba6219e9ff7d9557622d2fe136816a264dd01d5997cfc057d804853d
  # Hashes correspond to the following packages:
  #  - SimpleITK-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-macosx_11_0_arm64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-win_amd64.whl
  SimpleITK==2.2.1 --hash=sha256:e032bb2e54b96ce426187f07ce5dd9733077b18005399f6fbbcd4765b386299f \
                   --hash=sha256:3ffec97db30f923788f4e19b5a6e708d68afcce8f89cb54d7c976bd099b9a580 \
                   --hash=sha256:d6f58cdf90dbd0b84be68e0b46545c92f28c650d86e9f24acb91ad1c27416357 \
                   --hash=sha256:9b90dfd94cba0b068bacddaf2550d96df2683df830b9ee71cd9440e64c701196 \
                   --hash=sha256:7e20bbc467a8fff15978fee34a97c851ec3d0caed2d01929f600a13a0ff2f955
  urllib3==1.26.14 --hash=sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1
  wheel==0.38.4 --hash=sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8
```

Backward compatible changes introduced with the numpy version update from 1.23.4 to 1.24.1 are the following:

> There are also a large number of new and expired deprecations due to changes in promotion and cleanups. This might be called a deprecation release.

- https://numpy.org/devdocs/release/1.24.0-notes.html#deprecations
- https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations

-----------------------------------------
**The scipy update has been removed from this PR and will be updated following the Slicer factory build machine for macOS switching to `computron` which supports the latest versions of macOS. This is due to the wheel changing from `scipy-1.9.2-cp39-cp39-macosx_10_9_x86_64` to `scipy-1.10.0-cp39-cp39-macosx_10_15_x86_64`. See https://github.com/Slicer/Slicer/pull/6803#discussion_r1089862963.**

Backward compatible changes introduced with the scipy version update from 1.9.2 to 1.10.0 are the following:
- https://docs.scipy.org/doc/scipy/release.1.10.0.html#deprecated-features
- https://docs.scipy.org/doc/scipy/release.1.10.0.html#expired-deprecations

Since `scipy` is not directly used in Slicer core, we may have to update extensions to account for changes.

Additionally re https://github.com/Slicer/Slicer/pull/6590#issuecomment-1282762511, on macOS, the dependent libraries shipped with scipy remain the same
```
Directory: scipy-1.9.2-cp39-cp39-macosx_10_9_x86_64\scipy\.dylibs
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         1/25/2023  12:20 PM         313744 libgcc_s.1.dylib
-a----         1/25/2023  12:20 PM        1588608 libgfortran.3.dylib
-a----         1/25/2023  12:20 PM       66118352 libopenblas.0.dylib
-a----         1/25/2023  12:20 PM         301952 libquadmath.0.dylib

Directory: scipy-1.10.0-cp39-cp39-macosx_10_15_x86_64\scipy\.dylibs
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         1/25/2023  12:20 PM         313744 libgcc_s.1.dylib
-a----         1/25/2023  12:20 PM        1588608 libgfortran.3.dylib
-a----         1/25/2023  12:20 PM       66118352 libopenblas.0.dylib
-a----         1/25/2023  12:20 PM         301952 libquadmath.0.dylib
```