### PR TITLE
Parameter node wrapper any serializer

### DIFF
--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -390,7 +390,7 @@ class NodeSerializer(Serializer):
 
     @staticmethod
     def canSerialize(type_) -> bool:
-        return issubclass(type_, slicer.vtkMRMLNode) if type(type_) == type else False
+        return issubclass(type_, slicer.vtkMRMLNode) if isinstance(type_, type) else False
 
     @staticmethod
     def create(type_):
@@ -981,7 +981,7 @@ class UnionSerializer(Serializer):
 class EnumSerializer(Serializer):
     @staticmethod
     def canSerialize(type_) -> bool:
-        return issubclass(type_, enum.Enum)
+        return issubclass(type_, enum.Enum) if isinstance(type_, type) else False
 
     @staticmethod
     def create(type_):

--- a/Base/Python/slicer/parameterNodeWrapper/serializers.py
+++ b/Base/Python/slicer/parameterNodeWrapper/serializers.py
@@ -561,10 +561,10 @@ class ListSerializer(Serializer):
         return []
 
     def _lenName(self, name):
-        return f"{name}_len"
+        return f"{name}.len"
 
     def _paramName(self, name, index):
-        return f"{name}_{index}"
+        return f"{name}.{index}"
 
     def _len(self, parameterNode, name) -> int:
         if self.isIn(parameterNode, name):
@@ -657,7 +657,7 @@ class TupleSerializer(Serializer):
 
     @staticmethod
     def _paramName(name, index):
-        return f"{name}_{index}"
+        return f"{name}.{index}"
 
     def isIn(self, parameterNode, name: str) -> bool:
         return self._serializers[0].isIn(parameterNode, self._paramName(name, 0))
@@ -908,7 +908,7 @@ class UnionSerializer(Serializer):
 
     @staticmethod
     def _paramName(name, index):
-        return f"{name}_{index}"
+        return f"{name}.{index}"
 
     def isIn(self, parameterNode, name: str) -> bool:
         for index, validatedSerializer in enumerate(self._serializers):

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -254,7 +254,10 @@ def _processClass(classtype):
     for name, nametype in members.items():
         membertype, annotations = splitAnnotations(nametype)
 
-        serializer, annotations = createSerializer(membertype, annotations)
+        try:
+            serializer, annotations = createSerializer(membertype, annotations)
+        except Exception as e:
+            raise Exception(f"Unable to create serializer for {classtype} member {name}") from e
         default, annotations = extractDefault(annotations)
         default = default.value if default is not None else serializer.default()
 

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
@@ -29,6 +29,11 @@ class CustomClass:
     z: int
 
 
+class EnumClass(enum.Enum):
+    A = 0
+    B = 1
+
+
 @parameterNodeSerializer
 class CustomClassSerializer(Serializer):
     @staticmethod
@@ -917,6 +922,38 @@ class TypedParameterNodeTest(unittest.TestCase):
         # test alias
         param.bg = Color.blue
         self.assertIs(param.bg, Color.BLUE)
+
+    def test_any(self):
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            any: typing.Any
+            anyDefaulted: Annotated[typing.Any, Default(7.7)]
+
+        param = ParameterNodeType(newParameterNode())
+        self.assertIsNone(param.any)
+        self.assertEqual(param.anyDefaulted, 7.7)
+
+        param.any = 1
+        self.assertEqual(param.any, 1)
+        param.any = "some string"
+        self.assertEqual(param.any, "some string")
+        param.any = EnumClass.B
+        self.assertEqual(param.any, EnumClass.B)
+        param.any = CustomClass(2, 3, 4)
+        self.assertEqual(param.any, CustomClass(2, 3, 4))
+        param.any = None
+        self.assertEqual(param.any, None)
+        param.any = [1, 2, 3]
+        self.assertEqual(param.any, [1, 2, 3])
+        param.any = [1, "multiple types", True]
+        self.assertEqual(param.any, [1, "multiple types", True])
+        param.any = {1: "a", "b": 2}
+        self.assertEqual(param.any, {1: "a", "b": 2})
+
+        param.anyDefaulted = 1
+        self.assertEqual(param.anyDefaulted, 1)
+        param.anyDefaulted = "some string"
+        self.assertEqual(param.anyDefaulted, "some string")
 
     def test_events(self):
         class _Callback:

--- a/Base/Python/slicer/tests/test_slicer_parameter_pack.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_pack.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Annotated, Union
+from typing import Annotated, Any, Union
 
 from MRMLCorePython import vtkMRMLModelNode
 
@@ -383,3 +383,20 @@ class TypedParameterNodeTest(unittest.TestCase):
         self.assertEqual(param.dataType("annotatedBox.topLeft"), Point)
         self.assertEqual(param.dataType("annotatedSub"), AnnotatedSub)
         self.assertEqual(param.dataType("annotatedSub.iterations"), Annotated[int, Default(44)])
+
+    def test_parameter_pack_any(self):
+        @parameterPack
+        class AnyPack:
+            any: Any
+
+        param = AnyPack()
+        self.assertIsNone(param.any)
+
+        param.any = 1
+        self.assertEqual(param.any, 1)
+        param.any = "some string"
+        self.assertEqual(param.any, "some string")
+
+        # add weird recursive use
+        param.any = AnyPack(Point(3, 4))
+        self.assertEqual(param.any.any, Point(3, 4))


### PR DESCRIPTION
Adds a new serializer for `typing.Any`

Fixes a couple bugs.