### PR TITLE
ENH: Add connector line for fiducial markup label texts

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.cxx
@@ -99,6 +99,9 @@ vtkMRMLMarkupsDisplayNode::vtkMRMLMarkupsDisplayNode()
   this->LineThickness = 0.2;
   this->LineDiameter = 1.0;
 
+  // Show point label at point position by default
+  this->PointLabelsDistanceScale = 0.0;
+
   // Line color variables
   this->LineColorFadingStart = 1.;
   this->LineColorFadingEnd = 10.;
@@ -160,6 +163,7 @@ void vtkMRMLMarkupsDisplayNode::WriteXML(ostream& of, int nIndent)
   vtkMRMLWriteXMLBooleanMacro(propertiesLabelVisibility, PropertiesLabelVisibility);
   vtkMRMLWriteXMLBooleanMacro(pointLabelsVisibility, PointLabelsVisibility);
   vtkMRMLWriteXMLFloatMacro(textScale, TextScale);
+  vtkMRMLWriteXMLFloatMacro(pointLabelsDistanceScale, PointLabelsDistanceScale);
   vtkMRMLWriteXMLFloatMacro(glyphScale, GlyphScale);
   vtkMRMLWriteXMLFloatMacro(glyphSize, GlyphSize);
   vtkMRMLWriteXMLBooleanMacro(useGlyphScale, UseGlyphScale);
@@ -209,6 +213,7 @@ void vtkMRMLMarkupsDisplayNode::ReadXMLAttributes(const char** atts)
   vtkMRMLReadXMLBooleanMacro(propertiesLabelVisibility, PropertiesLabelVisibility);
   vtkMRMLReadXMLBooleanMacro(pointLabelsVisibility, PointLabelsVisibility);
   vtkMRMLReadXMLFloatMacro(textScale, TextScale);
+  vtkMRMLReadXMLFloatMacro(pointLabelsDistanceScale, PointLabelsDistanceScale);
   vtkMRMLReadXMLFloatMacro(glyphScale, GlyphScale);
   vtkMRMLReadXMLFloatMacro(glyphSize, GlyphSize);
   vtkMRMLReadXMLBooleanMacro(useGlyphScale, UseGlyphScale);
@@ -290,6 +295,7 @@ void vtkMRMLMarkupsDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy /*
   vtkMRMLCopyBooleanMacro(PropertiesLabelVisibility);
   vtkMRMLCopyBooleanMacro(PointLabelsVisibility);
   vtkMRMLCopyFloatMacro(TextScale);
+  vtkMRMLCopyFloatMacro(PointLabelsDistanceScale);
   vtkMRMLCopyFloatMacro(GlyphScale);
   vtkMRMLCopyFloatMacro(GlyphSize);
   vtkMRMLCopyBooleanMacro(UseGlyphScale);
@@ -470,6 +476,7 @@ void vtkMRMLMarkupsDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
   vtkMRMLPrintBeginMacro(os, indent);
   vtkMRMLPrintBooleanMacro(PropertiesLabelVisibility);
   vtkMRMLPrintBooleanMacro(PointLabelsVisibility);
+  vtkMRMLPrintFloatMacro(PointLabelsDistanceScale);
   vtkMRMLPrintFloatMacro(TextScale);
   vtkMRMLPrintFloatMacro(GlyphScale);
   vtkMRMLPrintFloatMacro(GlyphSize);

--- a/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLMarkupsDisplayNode.h
@@ -171,6 +171,14 @@ public:
   //@}
 
   //@{
+  /// Control distance of point label from the point glyph.
+  /// If the label is not right at the point then a line is drawn between them.
+  /// The length of the line is defined as "scale" percentage of diagonal size of the window.
+  vtkSetMacro(PointLabelsDistanceScale, double);
+  vtkGetMacro(PointLabelsDistanceScale, double);
+  //@}
+
+  //@{
   /**
    * Control visibility of information box.
    */
@@ -510,6 +518,7 @@ protected:
 
   bool PropertiesLabelVisibility;
   bool PointLabelsVisibility;
+  double PointLabelsDistanceScale;
   bool FillVisibility;
   bool OutlineVisibility;
   double FillOpacity;

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.cxx
@@ -522,7 +522,10 @@ bool vtkMRMLMarkupsJsonStorageNode::UpdateMarkupsDisplayNodeFromJsonValue(vtkMRM
   {
     displayNode->SetPointLabelsVisibility(displayItem->GetBoolProperty("pointLabelsVisibility"));
   }
-
+  if (displayItem->HasMember("pointLabelsDistanceScale"))
+  {
+    displayNode->SetPointLabelsDistanceScale(displayItem->GetDoubleProperty("pointLabelsDistanceScale"));
+  }
   if (displayItem->HasMember("textScale"))
   {
     displayNode->SetTextScale(displayItem->GetDoubleProperty("textScale"));
@@ -1100,6 +1103,9 @@ bool vtkMRMLMarkupsJsonStorageNode::WriteDisplayProperties(vtkMRMLJsonWriter* wr
 
   writer->WriteBoolProperty("propertiesLabelVisibility", markupsDisplayNode->GetPropertiesLabelVisibility());
   writer->WriteBoolProperty("pointLabelsVisibility", markupsDisplayNode->GetPointLabelsVisibility());
+
+  writer->WriteDoubleProperty("pointLabelsDistanceScale", markupsDisplayNode->GetPointLabelsDistanceScale());
+
   writer->WriteDoubleProperty("textScale", markupsDisplayNode->GetTextScale());
   writer->WriteStringProperty("glyphType", markupsDisplayNode->GetGlyphTypeAsString(markupsDisplayNode->GetGlyphType()));
   writer->WriteDoubleProperty("glyphScale", markupsDisplayNode->GetGlyphScale());

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.cxx
@@ -23,6 +23,7 @@
 #include "vtkGlyph2D.h"
 #include "vtkLabelPlacementMapper.h"
 #include "vtkLine.h"
+#include "vtkLineSource.h"
 #include "vtkMarkupsGlyphSource2D.h"
 #include "vtkMath.h"
 #include "vtkMatrix4x4.h"
@@ -98,6 +99,21 @@ vtkSlicerMarkupsWidgetRepresentation2D::ControlPointsPipeline2D::ControlPointsPi
   this->LabelsMapper->GetAnchorTransform()->SetCoordinateSystemToNormalizedViewport();
   this->LabelsActor = vtkSmartPointer<vtkActor2D>::New();
   this->LabelsActor->SetMapper(this->LabelsMapper);
+
+  // Labels line polydata
+  this->LabelsLinePolyData = vtkSmartPointer<vtkPolyData>::New();
+
+  this->LabelsLineProperty = vtkSmartPointer<vtkProperty2D>::New();
+  this->LabelsLineProperty->SetOpacity(1.);
+  this->LabelsLineProperty->SetLineWidth(this->LabelsLineProperty->GetLineWidth());
+  this->LabelsLineMapper = vtkSmartPointer<vtkPolyDataMapper2D>::New();
+  this->LabelsLineMapper->SetInputData(this->LabelsLinePolyData);
+
+  this->LabelsLineMapper->SetScalarVisibility(true);
+
+  this->LabelsLineActor = vtkSmartPointer<vtkActor2D>::New();
+  this->LabelsLineActor->SetMapper(this->LabelsLineMapper);
+  this->LabelsLineActor->SetProperty(this->LabelsLineProperty);
 }
 
 vtkSlicerMarkupsWidgetRepresentation2D::ControlPointsPipeline2D::~ControlPointsPipeline2D() = default;
@@ -151,6 +167,24 @@ void vtkSlicerMarkupsWidgetRepresentation2D::GetSliceToWorldCoordinates(const do
 }
 
 //----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation2D::GetBackgroundVolumeXYCenter(double centerPos[2])
+{
+  if (!this->GetSliceNode())
+  {
+    return;
+  }
+
+  // TODO: get RAS bounds of the scene from the view node
+  double centerPosRAS[4] = { 0.0, 0.0, 0.0, 1.0 };
+
+  double centerPosDisplay[4] = { 0.0, 0.0, 0.0, 1.0 };
+  this->GetWorldToSliceCoordinates(centerPosRAS, centerPosDisplay);
+
+  centerPos[0] = centerPosDisplay[0];
+  centerPos[1] = centerPosDisplay[1];
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation2D::GetWorldToSliceCoordinates(const double worldPos[3], double slicePos[2])
 {
   vtkMRMLSliceNode* sliceNode = this->GetSliceNode();
@@ -175,6 +209,75 @@ void vtkSlicerMarkupsWidgetRepresentation2D::GetWorldToSliceCoordinates(const do
 }
 
 //----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation2D::GetLabelTextXYOffsets(double backgroundVolumeCenterXY[2], double slicePos[2], double leadersLineOffset[2])
+{
+  double pi = 3.14159;
+
+  class myTriangle
+  {
+  public:
+    double a = 0;
+    double b = 0;
+    double c = 0;
+    double AlphaRad = 0;
+    double BetaRad = 0;
+    double GammaRad = 0;
+    double AlphaDeg = 0;
+    double BetaDeg = 0;
+    double GammaDeg = 0;
+  };
+
+  const int* screenSize = this->Renderer->GetRenderWindow()->GetSize();
+  int screenWidth = screenSize[0];
+  int screenHeight = screenSize[1];
+
+  double sliceXCenterOffsAbs = abs(slicePos[0] - backgroundVolumeCenterXY[0]);
+  double sliceYCenterOffsAbs = abs(slicePos[1] - backgroundVolumeCenterXY[1]);
+
+  // calculating a triangle between control point and displaycenter
+  // known are two sides of the triangle
+  // a (x-offset between center and ctrl point pos)
+  // c (y-offset between center and ctrl point pos)
+  // and the 90 degree angle (beta)
+
+  myTriangle tr;
+
+  tr.a = sliceXCenterOffsAbs;
+  tr.c = sliceYCenterOffsAbs;
+  tr.BetaDeg = 90.;
+  tr.BetaRad = (tr.BetaDeg * pi) / 180.;
+
+  tr.b = sqrt(pow(tr.a, 2.) + pow(tr.c, 2.) - (2. * tr.a * tr.c * cos(tr.BetaRad)));
+  tr.AlphaRad = acos((pow(tr.b, 2.) + pow(tr.c, 2.) - pow(tr.a, 2.)) / (2 * tr.b * tr.c));
+  tr.GammaRad = acos((pow(tr.b, 2.) + pow(tr.a, 2.) - pow(tr.c, 2.)) / (2 * tr.b * tr.a));
+  tr.AlphaDeg = tr.AlphaRad * (180 / pi);
+  tr.GammaDeg = tr.GammaRad * (180 / pi);
+
+  double screenDiagonal = sqrt(pow(screenWidth, 2.) + pow(screenHeight, 2.));
+  double leaderLinesLength = (this->MarkupsDisplayNode->GetPointLabelsDistanceScale() * screenDiagonal) / 100.;
+
+  // calculating a triangle between control point and labeltext
+  // known are two angles of the triangle (alpha,gamma, see above)
+  // and one side (b, leader line length) )
+
+  myTriangle tr2;
+
+  tr2.b = leaderLinesLength;
+  tr2.GammaDeg = tr.GammaDeg;
+  tr2.GammaRad = (tr2.GammaDeg * pi) / 180.;
+  tr2.BetaDeg = 90.;
+  tr2.BetaRad = (tr2.BetaDeg * pi) / 180.;
+
+  tr2.AlphaDeg = 180. - tr2.GammaDeg - tr2.BetaDeg;
+  tr2.AlphaRad = (tr2.AlphaDeg * pi) / 180.;
+  tr2.a = tr2.b * sin(tr2.AlphaRad) / tr2.BetaRad;
+  tr2.c = tr2.b * sin(tr2.GammaRad) / tr2.BetaRad;
+
+  leadersLineOffset[0] = tr2.a;
+  leadersLineOffset[1] = tr2.c;
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(double labelsOffset)
 {
   vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
@@ -191,6 +294,10 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(do
   {
     activeControlPointIndex = activeControlPointIndices[0];
   }
+
+  vtkNew<vtkPoints> pts;
+  vtkNew<vtkCellArray> line;
+  int ptcnt = 0;
 
   int numPoints = markupsNode->GetNumberOfControlPoints();
 
@@ -225,6 +332,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(do
       {
         controlPoints->Actor->VisibilityOff();
         controlPoints->LabelsActor->VisibilityOff();
+        controlPoints->LabelsLineActor->VisibilityOff();
         continue;
       }
     }
@@ -281,13 +389,161 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(do
         continue;
       }
 
+      // get control point position
       double slicePos[3] = { 0.0 };
       this->GetNthControlPointDisplayPosition(pointIndex, slicePos);
-
       controlPoints->ControlPoints->InsertNextPoint(slicePos);
-      slicePos[0] += labelsOffset / sqrt(2.0);
-      slicePos[1] += labelsOffset / sqrt(2.0);
-      this->Renderer->SetDisplayPoint(slicePos);
+
+      // set normal label position
+      double labelPos[3] = { 0.0 };
+      labelPos[0] = slicePos[0] + labelsOffset / sqrt(2.0);
+      labelPos[1] = slicePos[1] + labelsOffset / sqrt(2.0);
+
+      std::string labelStr;
+      int labelLength = 0;
+
+      labelStr = markupsNode->GetNthControlPointLabel(pointIndex);
+
+      // make label texts multiline if <br> is used
+      std::string from = "<br>";
+      std::string to = "\n";
+      int start_pos = 0;
+      while ((start_pos = labelStr.find(from, start_pos)) != std::string::npos)
+      {
+        labelStr.replace(start_pos, from.length(), to);
+        start_pos += to.length();
+      }
+
+      // find length of longest string segment after splitting up into multiline segments
+      std::string s = labelStr;
+      std::string delimiter = "\n";
+      int longestStringLen = 0;
+      int numberLines = 1;
+
+      size_t pos = 0;
+      std::string token;
+      while ((pos = s.find(delimiter)) != std::string::npos)
+      {
+        numberLines++;
+        token = s.substr(0, pos);
+        if (token.length() > longestStringLen)
+        {
+          longestStringLen = token.length();
+        }
+        s.erase(0, pos + delimiter.length());
+      }
+      if (s.length() > longestStringLen)
+      {
+        longestStringLen = s.length();
+      }
+
+      if (this->MarkupsDisplayNode->GetPointLabelsDistanceScale() > 0.0 && markupsNode->GetNthControlPointPositionVisibility(pointIndex)
+          && this->MarkupsDisplayNode->GetPointLabelsVisibility() && !markupsNode->GetNthControlPointLabel(pointIndex).empty()) // add not occluded
+      {
+        double lineStartPos[3] = { 0.0 };
+        double lineEndPos[3] = { 0.0 };
+        const int* screenSize = this->Renderer->GetRenderWindow()->GetSize();
+        int screenWidth = screenSize[0];
+        int screenHeight = screenSize[1];
+        labelLength = longestStringLen;
+
+        // Not working correctly - giving the exact same values in _bb  wherever you place this code
+        // double _bb[4] = { 0.0 };
+        // this->TextActor->GetBoundingBox(this->Renderer, _bb);
+        // this->TextActor->SetTextScaleModeToViewport();
+        double labelCharWidth = this->MarkupsDisplayNode->GetTextScale() * 3.;
+        double labelTextWidth = labelCharWidth * labelLength;
+        double labelTextHeight = (this->MarkupsDisplayNode->GetTextScale() * 3.) * numberLines;
+
+        // center of background volume in display XY coordinates
+        double backgroundVolumeCenterXY[2] = { 0.0 };
+        this->GetBackgroundVolumeXYCenter(backgroundVolumeCenterXY);
+
+        double leadersLineOffset[2] = { 0.0 };
+
+        this->GetLabelTextXYOffsets(backgroundVolumeCenterXY, slicePos, leadersLineOffset);
+
+        // Add a function to determine the exact bounds of the label text in 2D view
+        double lineXSpacer = labelCharWidth;
+
+        // set connector lineStartPos x and y according to location of fiducial
+        lineStartPos[0] = slicePos[0];
+        lineStartPos[1] = slicePos[1];
+
+        // set lineEndPos and new labelPos according to location of fiducial
+
+        if (slicePos[0] < backgroundVolumeCenterXY[0])
+        {
+          lineEndPos[0] = slicePos[0] + labelsOffset - leadersLineOffset[0];
+          labelPos[0] = lineEndPos[0] - labelTextWidth - lineXSpacer;
+        }
+        else
+        {
+          lineEndPos[0] = slicePos[0] + labelsOffset + leadersLineOffset[0];
+          labelPos[0] = lineEndPos[0] + (lineXSpacer / 2.);
+        }
+
+        if (slicePos[1] < backgroundVolumeCenterXY[1])
+        {
+          lineEndPos[1] = (slicePos[1] + labelsOffset) - leadersLineOffset[1];
+          labelPos[1] = lineEndPos[1] - labelTextHeight;
+        }
+        else
+        {
+          lineEndPos[1] = (slicePos[1] + labelsOffset) + leadersLineOffset[1];
+          labelPos[1] = lineEndPos[1] - (labelTextHeight / 2.);
+        }
+
+        // handle label text touching slice view borders
+
+        // left screen border
+        if (labelPos[0] < 0.)
+        {
+          labelPos[0] = 0.;
+          lineEndPos[0] = labelPos[0] + labelTextWidth + lineXSpacer;
+        }
+        // right screen border
+        if (labelPos[0] > screenWidth - labelTextWidth)
+        {
+          labelPos[0] = screenWidth - labelTextWidth;
+          lineEndPos[0] = labelPos[0] - lineXSpacer;
+        }
+        // upper screen border
+        if (labelPos[1] > screenHeight - labelTextHeight * 2.)
+        {
+          labelPos[1] = screenHeight - labelTextHeight * 2.;
+          lineEndPos[1] = labelPos[1] + labelTextHeight;
+        }
+        // lower screen border
+        if (labelPos[1] < 0.)
+        {
+          labelPos[1] = 0.;
+          lineEndPos[1] = labelPos[1] + labelTextHeight;
+        }
+
+        pts->InsertPoint(ptcnt, lineStartPos[0], lineStartPos[1], 0.);
+        pts->InsertPoint(ptcnt + 1, lineEndPos[0], lineEndPos[1], 0.);
+        line->InsertNextCell(2);
+        line->InsertCellPoint(ptcnt);
+        line->InsertCellPoint(ptcnt + 1);
+        ptcnt += 2;
+
+        // make the connector line color a bit lighter then the selected glyph/text color
+        double color[3] = { 0, 0, 0 };
+        this->MarkupsDisplayNode->GetSelectedColor(color);
+        double hsv[3] = { 0, 0, 0 };
+        vtkMath::RGBToHSV(color, hsv);
+        hsv[0] *= 0.8;
+        hsv[1] *= 0.3;
+        vtkMath::HSVToRGB(hsv, color);
+        controlPoints->LabelsLineProperty->SetColor(color);
+        controlPoints->LabelsLineProperty->SetLineWidth(this->ControlPointSize * .25);
+
+        controlPoints->LabelsLineActor->SetVisibility(true);
+      }
+
+      this->Renderer->SetDisplayPoint(labelPos);
+
       this->Renderer->DisplayToView();
       double viewPos[3] = { 0.0 };
       this->Renderer->GetViewPoint(viewPos);
@@ -300,7 +556,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(do
       controlPoints->ControlPointsPolyData->GetPointData()->GetNormals()->InsertNextTuple(pointNormalWorld);
       controlPoints->LabelControlPointsPolyData->GetPointData()->GetNormals()->InsertNextTuple(pointNormalWorld);
 
-      controlPoints->Labels->InsertNextValue(markupsNode->GetNthControlPointLabel(pointIndex));
+      controlPoints->Labels->InsertNextValue(labelStr);
       controlPoints->LabelsPriority->InsertNextValue(std::to_string(pointIndex));
     }
 
@@ -311,6 +567,10 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateAllPointsAndLabelsFromMRML(do
     controlPoints->LabelControlPoints->Modified();
     controlPoints->LabelControlPointsPolyData->GetPointData()->GetNormals()->Modified();
     controlPoints->LabelControlPointsPolyData->Modified();
+
+    controlPoints->LabelsLinePolyData->Modified();
+    controlPoints->LabelsLinePolyData->SetPoints(pts);
+    controlPoints->LabelsLinePolyData->SetLines(line);
 
     if (controlPointType == Active)
     {
@@ -427,6 +687,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode*
     ControlPointsPipeline2D* controlPoints = this->GetControlPointsPipeline(controlPointType);
     controlPoints->Property->SetColor(color);
     controlPoints->Property->SetOpacity(opacity);
+    controlPoints->LabelsLineProperty->SetOpacity(opacity);
 
     controlPoints->TextProperty->ShallowCopy(this->MarkupsDisplayNode->GetTextProperty());
     if (this->GetApplicationLogic())
@@ -490,7 +751,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::UpdateFromMRMLInternal(vtkMRMLNode*
     controlPoints->Glypher->SetScaleFactor(this->ControlPointSize);
   }
 
-  // put the labels near the boundary of the glyph, slightly away from it (by half picking tolarance)
+  // by default (no connector lines) put the labels near the boundary of the glyph, slightly away from it (by half picking tolarance)
   double labelsOffset = this->ControlPointSize * 0.5 + this->PickingTolerance * 0.5 * this->GetScreenScaleFactor();
   this->UpdateAllPointsAndLabelsFromMRML(labelsOffset);
 
@@ -630,6 +891,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::GetActors(vtkPropCollection* pc)
     ControlPointsPipeline2D* controlPoints = reinterpret_cast<ControlPointsPipeline2D*>(this->ControlPoints[i]);
     controlPoints->Actor->GetActors(pc);
     controlPoints->LabelsActor->GetActors(pc);
+    controlPoints->LabelsLineActor->GetActors(pc);
   }
   this->TextActor->GetActors(pc);
 }
@@ -643,6 +905,7 @@ void vtkSlicerMarkupsWidgetRepresentation2D::ReleaseGraphicsResources(vtkWindow*
     ControlPointsPipeline2D* controlPoints = reinterpret_cast<ControlPointsPipeline2D*>(this->ControlPoints[i]);
     controlPoints->Actor->ReleaseGraphicsResources(win);
     controlPoints->LabelsActor->ReleaseGraphicsResources(win);
+    controlPoints->LabelsLineActor->ReleaseGraphicsResources(win);
   }
   this->TextActor->ReleaseGraphicsResources(win);
 }
@@ -662,12 +925,25 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderOverlay(vtkViewport* viewport)
     {
       count += controlPoints->LabelsActor->RenderOverlay(viewport);
     }
+    if (controlPoints->LabelsLineActor->GetVisibility())
+    {
+      count += controlPoints->LabelsLineActor->RenderOverlay(viewport);
+    }
   }
   if (this->TextActor->GetVisibility())
   {
-    count += this->TextActor->RenderOverlay(viewport);
+    count += controlPoints->Actor->RenderOverlay(viewport);
   }
-  return count;
+  if (controlPoints->LabelsActor->GetVisibility())
+  {
+    count += controlPoints->LabelsActor->RenderOverlay(viewport);
+  }
+}
+if (this->TextActor->GetVisibility())
+{
+  count += this->TextActor->RenderOverlay(viewport);
+}
+return count;
 }
 
 //-----------------------------------------------------------------------------
@@ -689,8 +965,17 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderOpaqueGeometry(vtkViewport* vi
     {
       count += controlPoints->LabelsActor->RenderOpaqueGeometry(viewport);
     }
+    if (controlPoints->LabelsLineActor->GetVisibility())
+    {
+      count += controlPoints->LabelsLineActor->RenderOpaqueGeometry(viewport);
+    }
   }
-  return count;
+  if (controlPoints->LabelsActor->GetVisibility())
+  {
+    count += controlPoints->LabelsActor->RenderOpaqueGeometry(viewport);
+  }
+}
+return count;
 }
 
 //-----------------------------------------------------------------------------
@@ -712,8 +997,17 @@ int vtkSlicerMarkupsWidgetRepresentation2D::RenderTranslucentPolygonalGeometry(v
     {
       count += controlPoints->LabelsActor->RenderTranslucentPolygonalGeometry(viewport);
     }
+    if (controlPoints->LabelsLineActor->GetVisibility())
+    {
+      count += controlPoints->LabelsLineActor->RenderTranslucentPolygonalGeometry(viewport);
+    }
   }
-  return count;
+  if (controlPoints->LabelsActor->GetVisibility())
+  {
+    count += controlPoints->LabelsActor->RenderTranslucentPolygonalGeometry(viewport);
+  }
+}
+return count;
 }
 
 //-----------------------------------------------------------------------------
@@ -738,8 +1032,17 @@ vtkTypeBool vtkSlicerMarkupsWidgetRepresentation2D::HasTranslucentPolygonalGeome
     {
       return true;
     }
+    if (controlPoints->LabelsLineActor->GetVisibility() && controlPoints->LabelsLineActor->HasTranslucentPolygonalGeometry())
+    {
+      return true;
+    }
   }
-  return false;
+  if (controlPoints->LabelsActor->GetVisibility() && controlPoints->LabelsActor->HasTranslucentPolygonalGeometry())
+  {
+    return true;
+  }
+}
+return false;
 }
 
 //-----------------------------------------------------------------------------
@@ -773,6 +1076,10 @@ void vtkSlicerMarkupsWidgetRepresentation2D::PrintSelf(ostream& os, vtkIndent in
     {
       os << indent << "Labels Visibility: " << controlPoints->LabelsActor->GetVisibility() << "\n";
     }
+    if (controlPoints->LabelsLineActor)
+    {
+      os << indent << "Labels Line Visibility: " << controlPoints->LabelsLineActor->GetVisibility() << "\n";
+    }
     else
     {
       os << indent << "Labels Points: (none)\n";
@@ -786,6 +1093,27 @@ void vtkSlicerMarkupsWidgetRepresentation2D::PrintSelf(ostream& os, vtkIndent in
       os << indent << "Property: (none)\n";
     }
   }
+  else
+  {
+    os << indent << "Points: (none)\n";
+  }
+  if (controlPoints->LabelsActor)
+  {
+    os << indent << "Labels Visibility: " << controlPoints->LabelsActor->GetVisibility() << "\n";
+  }
+  else
+  {
+    os << indent << "Labels Points: (none)\n";
+  }
+  if (controlPoints->Property)
+  {
+    os << indent << "Property: " << controlPoints->Property << "\n";
+  }
+  else
+  {
+    os << indent << "Property: (none)\n";
+  }
+}
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation2D.h
@@ -129,6 +129,13 @@ protected:
   void GetWorldToDisplayCoordinates(double r, double a, double s, double* displayCoordinates);
   void GetWorldToDisplayCoordinates(double* worldCoordinates, double* displayCoordinates);
 
+  /// Get xy display center of background volume in slice node
+  void GetBackgroundVolumeXYCenter(double* centerPos);
+
+  /// Calculate X and Y display coordinate offsets from control point position
+  /// in relation to display dimensions and volume center coordinates
+  void GetLabelTextXYOffsets(double* backgroundVolumeCenterXY, double* slicePos, double* leadersLineOffset);
+
   /// Check if the representation polydata intersects the slice
   bool IsRepresentationIntersectingSlice(vtkPolyData* representation, const char* arrayName);
 
@@ -143,9 +150,15 @@ protected:
     vtkSmartPointer<vtkGlyph2D> Glypher;
     vtkSmartPointer<vtkActor2D> LabelsActor;
     vtkSmartPointer<vtkLabelPlacementMapper> LabelsMapper;
+
+    vtkSmartPointer<vtkPolyData> LabelsLinePolyData;
+    vtkSmartPointer<vtkActor2D> LabelsLineActor;
+    vtkSmartPointer<vtkPolyDataMapper2D> LabelsLineMapper;
+
     // Properties used to control the appearance of selected objects and
     // the manipulator in general.
     vtkSmartPointer<vtkProperty2D> Property;
+    vtkSmartPointer<vtkProperty2D> LabelsLineProperty;
   };
 
   ControlPointsPipeline2D* GetControlPointsPipeline(int controlPointType);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.cxx
@@ -49,6 +49,11 @@
 #include <vtkMRMLFolderDisplayNode.h>
 #include <vtkMRMLInteractionEventData.h>
 #include <vtkMRMLViewNode.h>
+#include <vtkMRMLScene.h>
+#include <vtkMRMLVolumeNode.h>
+#include <vtkMRMLScalarVolumeNode.h>
+#include <vtkMRMLSliceCompositeNode.h>
+#include <vtkMRMLSliceNode.h>
 
 std::map<vtkRenderer*, vtkSmartPointer<vtkFloatArray>> vtkSlicerMarkupsWidgetRepresentation3D::CachedZBuffers;
 
@@ -95,6 +100,9 @@ vtkSlicerMarkupsWidgetRepresentation3D::ControlPointsPipeline3D::ControlPointsPi
   this->OccludedTextProperty = vtkSmartPointer<vtkTextProperty>::New();
   this->OccludedTextProperty->ShallowCopy(this->TextProperty);
   this->OccludedTextProperty->SetOpacity(0.0);
+
+  this->LabelLeaderLinesProperty = vtkSmartPointer<vtkProperty>::New();
+  this->LabelLeaderLinesProperty->SetColor(1., 1., 1.);
 
   // Label point filters
   this->ControlPointIndices = vtkSmartPointer<vtkIdTypeArray>::New();
@@ -168,6 +176,22 @@ vtkSlicerMarkupsWidgetRepresentation3D::ControlPointsPipeline3D::ControlPointsPi
   this->LabelsOccludedActor->SetMapper(this->LabelsOccludedMapper);
   this->LabelsOccludedActor->PickableOff();
   this->LabelsOccludedActor->DragableOff();
+
+  // Labels line polydata
+  this->LabelsLinePolyData = vtkSmartPointer<vtkPolyData>::New();
+  this->LabelsLineTubeFilter = vtkSmartPointer<vtkTubeFilter>::New();
+  this->LabelsLineTubeFilter->SetInputData(LabelsLinePolyData);
+  this->LabelsLineTubeFilter->SetNumberOfSides(20);
+  this->LabelsLineTubeFilter->SetRadius(this->LabelsLineTubeFilter->GetRadius());
+
+  this->LabelsLineMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  this->LabelsLineMapper->SetInputConnection(this->LabelsLineTubeFilter->GetOutputPort());
+
+  this->LabelsLineMapper->SetScalarVisibility(true);
+
+  this->LabelsLineActor = vtkSmartPointer<vtkActor>::New();
+  this->LabelsLineActor->SetMapper(this->LabelsLineMapper);
+  this->LabelsLineActor->SetProperty(this->LabelLeaderLinesProperty);
 };
 
 vtkSlicerMarkupsWidgetRepresentation3D::ControlPointsPipeline3D::~ControlPointsPipeline3D() = default;
@@ -235,8 +259,154 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateNthPointAndLabelFromMRML(int 
 }
 
 //----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation3D::GetBackgroundVolumeRASCenter(double centerPos[3])
+{
+  vtkMRMLSliceCompositeNode* compositeNode = nullptr;
+  vtkMRMLViewNode* viewNode = vtkMRMLViewNode::SafeDownCast(this->ViewNode);
+  if (viewNode)
+  {
+    compositeNode = vtkMRMLSliceCompositeNode::SafeDownCast(viewNode->GetScene()->GetFirstNodeByClass("vtkMRMLSliceCompositeNode"));
+    if (compositeNode)
+    {
+      const char* backgroundVolumeID = compositeNode->GetBackgroundVolumeID();
+
+      double volumeBounds[6] = { 0.0 };
+      double volumeCenterRAS[4] = { 0.0 };
+      double centerPosDisplay[4] = { 0.0 };
+      if (backgroundVolumeID)
+      {
+        vtkMRMLScalarVolumeNode* sliceBackgroundVolumeNode = vtkMRMLScalarVolumeNode::SafeDownCast(viewNode->GetScene()->GetNodeByID(backgroundVolumeID));
+        if (sliceBackgroundVolumeNode)
+        {
+          sliceBackgroundVolumeNode->GetRASBounds(volumeBounds);
+          // xmin,ymax,ymin,ymax,zmin,zmax
+          volumeCenterRAS[0] = (volumeBounds[1] + volumeBounds[0]) / 2.;
+          volumeCenterRAS[1] = (volumeBounds[3] + volumeBounds[2]) / 2.;
+          volumeCenterRAS[2] = (volumeBounds[5] + volumeBounds[4]) / 2.;
+          volumeCenterRAS[3] = 1.;
+        }
+      }
+      centerPos[0] = volumeCenterRAS[0];
+      centerPos[1] = volumeCenterRAS[1];
+      centerPos[2] = volumeCenterRAS[2];
+    }
+  }
+}
+
+//----------------------------------------------------------------------
+void vtkSlicerMarkupsWidgetRepresentation3D::GetLabelTextRASOffsets(double backgroundVolumeCenterRAS[3], double slicePos[3], double leadersLineOffset[3])
+{
+  double pi = 3.14159;
+
+  class myTriangle
+  {
+  public:
+    double a = 0;
+    double b = 0;
+    double c = 0;
+    double AlphaRad = 0;
+    double BetaRad = 0;
+    double GammaRad = 0;
+    double AlphaDeg = 0;
+    double BetaDeg = 0;
+    double GammaDeg = 0;
+  };
+
+  myTriangle tr, tr2;
+
+  const int* screenSize = this->Renderer->GetRenderWindow()->GetSize();
+  int screenWidth = screenSize[0];
+  int screenHeight = screenSize[1];
+
+  double sliceRCenterOffsAbs = abs(slicePos[0] - backgroundVolumeCenterRAS[0]);
+  double sliceACenterOffsAbs = abs(slicePos[1] - backgroundVolumeCenterRAS[1]);
+  double sliceSCenterOffsAbs = abs(slicePos[2] - backgroundVolumeCenterRAS[2]);
+
+  double screenDiagonal = sqrt(pow(screenWidth, 2.) + pow(screenHeight, 2.));
+  double leaderLinesLength = (this->MarkupsDisplayNode->GetPointLabelsDistanceScale() * screenDiagonal) / 100.;
+
+  // calculating a triangle between control point and displaycenter
+  // known are two sides of the triangle
+  // a (x-offset between center and ctrl point pos)
+  // c (y-offset between center and ctrl point pos)
+  // and the 90 degree angle (beta)
+
+  tr.a = sliceRCenterOffsAbs;
+  tr.c = sliceSCenterOffsAbs;
+  tr.BetaDeg = 90.;
+  tr.BetaRad = (tr.BetaDeg * pi) / 180.;
+
+  tr.b = sqrt(pow(tr.a, 2.) + pow(tr.c, 2.) - (2. * tr.a * tr.c * cos(tr.BetaRad)));
+  tr.AlphaRad = acos((pow(tr.b, 2.) + pow(tr.c, 2.) - pow(tr.a, 2.)) / (2 * tr.b * tr.c));
+  tr.GammaRad = acos((pow(tr.b, 2.) + pow(tr.a, 2.) - pow(tr.c, 2.)) / (2 * tr.b * tr.a));
+  tr.AlphaDeg = tr.AlphaRad * (180 / pi);
+  tr.GammaDeg = tr.GammaRad * (180 / pi);
+
+  // calculating a triangle between control point and labeltext
+  // known are two angles of the triangle (alpha,gamma, see above)
+  // and one side (b, leader line length) )
+
+  tr2.b = leaderLinesLength;
+  tr2.GammaDeg = tr.GammaDeg;
+  tr2.GammaRad = (tr2.GammaDeg * pi) / 180.;
+  tr2.BetaDeg = 90.;
+  tr2.BetaRad = (tr2.BetaDeg * pi) / 180.;
+
+  tr2.AlphaDeg = 180. - tr2.GammaDeg - tr2.BetaDeg;
+  tr2.AlphaRad = (tr2.AlphaDeg * pi) / 180.;
+  tr2.a = tr2.b * sin(tr2.AlphaRad) / tr2.BetaRad;
+  tr2.c = tr2.b * sin(tr2.GammaRad) / tr2.BetaRad;
+
+  // right/left offset
+  leadersLineOffset[0] = tr2.a;
+  // superior/inferior offset
+  leadersLineOffset[2] = tr2.c;
+
+  // calculating a triangle between control point and displaycenter
+  // known are two sides of the triangle
+  // a (x-offset between center and ctrl point pos)
+  // c (y-offset between center and ctrl point pos)
+  // and the 90 degree angle (beta)
+
+  tr.a = sliceRCenterOffsAbs;
+  tr.c = sliceACenterOffsAbs;
+  tr.BetaDeg = 90.;
+  tr.BetaRad = (tr.BetaDeg * pi) / 180.;
+
+  tr.b = sqrt(pow(tr.a, 2.) + pow(tr.c, 2.) - (2. * tr.a * tr.c * cos(tr.BetaRad)));
+  tr.AlphaRad = acos((pow(tr.b, 2.) + pow(tr.c, 2.) - pow(tr.a, 2.)) / (2 * tr.b * tr.c));
+  tr.GammaRad = acos((pow(tr.b, 2.) + pow(tr.a, 2.) - pow(tr.c, 2.)) / (2 * tr.b * tr.a));
+  tr.AlphaDeg = tr.AlphaRad * (180 / pi);
+  tr.GammaDeg = tr.GammaRad * (180 / pi);
+
+  // calculating a triangle between control point and labeltext
+  // known are two angles of the triangle (alpha,gamma, see above)
+  // and one side (b, leader line length) )
+
+  tr2.b = leaderLinesLength;
+  tr2.GammaDeg = tr.GammaDeg;
+  tr2.GammaRad = (tr2.GammaDeg * pi) / 180.;
+  tr2.BetaDeg = 90.;
+  tr2.BetaRad = (tr2.BetaDeg * pi) / 180.;
+
+  tr2.AlphaDeg = 180. - tr2.GammaDeg - tr2.BetaDeg;
+  tr2.AlphaRad = (tr2.AlphaDeg * pi) / 180.;
+  tr2.a = tr2.b * sin(tr2.AlphaRad) / tr2.BetaRad;
+  tr2.c = tr2.b * sin(tr2.GammaRad) / tr2.BetaRad;
+
+  // anterior/posterior offset
+  leadersLineOffset[1] = tr2.c;
+}
+
+//----------------------------------------------------------------------
 void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
 {
+  vtkNew<vtkPoints> pts;
+  vtkNew<vtkCellArray> line;
+  int ptcnt = 0;
+  std::string labelStdStr;
+  int labelLength = 0;
+
   if (!this->MarkupsDisplayNode)
   {
     return;
@@ -263,6 +433,9 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
       controlPoints->LabelsOccludedActor->SetVisibility(false);
       continue;
     }
+
+    // in order to avoid non-updated label connector lines when label scale changes
+    controlPoints->LabelsLinePolyData->Initialize();
 
     this->UpdateRelativeCoincidentTopologyOffsets(controlPoints->GlyphMapper, controlPoints->OccludedGlyphMapper);
 
@@ -310,16 +483,156 @@ void vtkSlicerMarkupsWidgetRepresentation3D::UpdateAllPointsAndLabelsFromMRML()
 
       controlPoints->ControlPoints->InsertNextPoint(worldPos);
 
-      /* No offset for 3D actors - we may revisit this in the future
-      (we could also use text margins to add some space).
-      worldPos[0] += this->ControlPointSize;
-      worldPos[1] += this->ControlPointSize;
-      worldPos[2] += this->ControlPointSize;
-      */
-      controlPoints->LabelControlPoints->InsertNextPoint(worldPos);
+      // No offset for 3D actors - we may revisit this in the future
+      //(we could also use text margins to add some space).
+
+      // double labelsOffset = this->ControlPointSize * 0.5 + this->PickingTolerance * 0.5 * this->ScreenScaleFactor * 5.;
+
+      // worldPos[0] += labelsOffset;
+      // worldPos[1] += labelsOffset;
+      // worldPos[2] += labelsOffset
+
+      std::string labelStr;
+      int labelLength = 0;
+
+      labelStr = markupsNode->GetNthControlPointLabel(pointIndex);
+
+      // make label texts multiline if they hold <br>
+      std::string from = "<br>";
+      std::string to = "\n";
+      int start_pos = 0;
+      while ((start_pos = labelStr.find(from, start_pos)) != std::string::npos)
+      {
+        labelStr.replace(start_pos, from.length(), to);
+        start_pos += to.length();
+      }
+
+      // find length of longest string segment after splitting up into multiline segments
+      std::string s = labelStr;
+      std::string delimiter = "\n";
+      int longestStringLen = 0;
+      int numberLines = 1;
+
+      size_t pos = 0;
+      std::string token;
+      while ((pos = s.find(delimiter)) != std::string::npos)
+      {
+        numberLines++;
+        token = s.substr(0, pos);
+        if (token.length() > longestStringLen)
+        {
+          longestStringLen = token.length();
+        }
+        s.erase(0, pos + delimiter.length());
+      }
+      if (s.length() > longestStringLen)
+      {
+        longestStringLen = s.length();
+      }
+
+      double labelTextPos[3] = { 0.0 };
+
+      labelTextPos[0] = worldPos[0];
+      labelTextPos[1] = worldPos[1];
+      labelTextPos[2] = worldPos[2];
+
+      if (this->MarkupsDisplayNode->GetPointLabelsDistanceScale() > 0 && markupsNode->GetNthControlPointPositionVisibility(pointIndex)
+          && this->MarkupsDisplayNode->GetPointLabelsVisibility() && !markupsNode->GetNthControlPointLabel(pointIndex).empty())
+      {
+        double lineStartPos[3] = { 0.0 };
+        double lineEndPos[3] = { 0.0 };
+
+        double rOffs = 0.;
+        double aOffs = 0.;
+        double sOffs = 0.;
+
+        double focalPoint[3] = { 0.0, 0.0, 0.0 };
+        this->Renderer->GetActiveCamera()->GetFocalPoint(focalPoint);
+
+        double centerPoint[3] = { 0.0, 0.0, 0.0 };
+        this->GetBackgroundVolumeRASCenter(centerPoint);
+
+        double _fps = this->Renderer->GetActiveCamera()->GetViewAngle();
+        const int* screenSize = this->Renderer->GetRenderWindow()->GetSize();
+        int screenWidth = screenSize[0];
+        int screenHeight = screenSize[1];
+        labelLength = longestStringLen;
+
+        double labelCharWidth = this->MarkupsDisplayNode->GetTextScale() * 3.;
+        double labelTextWidth = labelCharWidth * labelLength;
+        double labelTextHeight = this->MarkupsDisplayNode->GetTextScale() * 3.;
+        double lineRSpacer = labelCharWidth;
+        double lineSSpacer = labelTextHeight * numberLines;
+
+        lineStartPos[0] = worldPos[0];
+        lineStartPos[1] = worldPos[1];
+        lineStartPos[2] = worldPos[2];
+
+        double leaderLinesOffset[3] = { 0.0, 0.0, 0.0 };
+        this->GetLabelTextRASOffsets(centerPoint, worldPos, leaderLinesOffset);
+
+        if (worldPos[0] > centerPoint[0])
+        {
+          rOffs = leaderLinesOffset[0];
+        }
+        else
+        {
+          rOffs = leaderLinesOffset[0] * -1.;
+        }
+
+        if (worldPos[1] > centerPoint[1])
+        {
+          aOffs = leaderLinesOffset[1];
+        }
+        else
+        {
+          aOffs = leaderLinesOffset[1] * -1.;
+        }
+
+        if (worldPos[2] > centerPoint[2])
+        {
+          sOffs = leaderLinesOffset[2];
+        }
+        else
+        {
+          sOffs = leaderLinesOffset[2] * -1.;
+        }
+
+        labelTextPos[0] = worldPos[0] + rOffs;
+        labelTextPos[1] = worldPos[1] + aOffs;
+        labelTextPos[2] = worldPos[2] + sOffs;
+
+        lineEndPos[0] = worldPos[0] + rOffs;
+        lineEndPos[1] = worldPos[1] + aOffs;
+        lineEndPos[2] = worldPos[2] + sOffs;
+
+        pts->InsertPoint(ptcnt, lineStartPos[0], lineStartPos[1], lineStartPos[2]);
+        pts->InsertPoint(ptcnt + 1, lineEndPos[0], lineEndPos[1], lineEndPos[2]);
+        line->InsertNextCell(2);
+        line->InsertCellPoint(ptcnt);
+        line->InsertCellPoint(ptcnt + 1);
+        ptcnt += 2;
+        controlPoints->LabelsLinePolyData->SetPoints(pts);
+        controlPoints->LabelsLinePolyData->SetLines(line);
+
+        // make the connector tube color a bit lighter then the selected glyph/text color
+        double color[3] = { 0, 0, 0 };
+        this->MarkupsDisplayNode->GetSelectedColor(color);
+        double hsv[3] = { 0, 0, 0 };
+        vtkMath::RGBToHSV(color, hsv);
+        hsv[0] *= 0.8;
+        hsv[1] *= 0.3;
+        vtkMath::HSVToRGB(hsv, color);
+        controlPoints->LabelLeaderLinesProperty->SetColor(color);
+        controlPoints->LabelsLineTubeFilter->SetRadius(this->ControlPointSize * .25);
+
+        controlPoints->LabelsLineActor->SetVisibility(true);
+        controlPoints->LabelsLineActor->Modified();
+      }
+      controlPoints->LabelControlPoints->InsertNextPoint(labelTextPos);
       controlPoints->ControlPointsPolyData->GetPointData()->GetNormals()->InsertNextTuple(pointNormalWorld);
       controlPoints->LabelControlPointsPolyData->GetPointData()->GetNormals()->InsertNextTuple(pointNormalWorld);
-      controlPoints->Labels->InsertNextValue(markupsNode->GetNthControlPointLabel(pointIndex));
+      controlPoints->Labels->InsertNextValue(labelStr);
       controlPoints->LabelsPriority->InsertNextValue(std::to_string(pointIndex));
       controlPoints->ControlPointIndices->InsertNextValue(pointIndex);
     }
@@ -480,234 +793,243 @@ void vtkSlicerMarkupsWidgetRepresentation3D::CanInteract(vtkMRMLInteractionEvent
         foundComponentIndex = i;
       }
     }
-    else
-    {
-      const double* worldPosition = interactionEventData->GetWorldPosition();
-      double worldTolerance = this->ControlPointSize / 2.0 + this->PickingTolerance / interactionEventData->GetWorldToPhysicalScale();
-      double dist2 = vtkMath::Distance2BetweenPoints(centerPosWorld, worldPosition);
-      if (dist2 < worldTolerance * worldTolerance && dist2 < closestDistance2)
+    this->UpdateAllPointsAndLabelsFromMRML();
+    /* This would probably faster for many points:
+
+    this->BuildLocator();
+
+    double closestDistance2 = VTK_DOUBLE_MAX;
+    int closestNode = static_cast<int> (this->Locator->FindClosestPointWithinRadius(
+      this->PixelTolerance, displayPos, closestDistance2));
+
+    if (closestNode != this->GetActiveNode())
       {
-        closestDistance2 = dist2;
-        foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentControlPoint;
+      this->SetActiveNode(closestNode);
+      this->NeedToRender = 1;
+      }
+    return (this->GetActiveNode() >= 0);
+    */
+  }
+
+  //----------------------------------------------------------------------
+  void vtkSlicerMarkupsWidgetRepresentation3D::CanInteractWithLine(
+    vtkMRMLInteractionEventData * interactionEventData, int& foundComponentType, int& foundComponentIndex, double& closestDistance2)
+  {
+    foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentNone;
+    vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
+    if (!markupsNode || markupsNode->GetLocked() || markupsNode->GetNumberOfControlPoints() < 1 //
+        || !this->GetVisibility() || !interactionEventData || !interactionEventData->IsWorldPositionValid())
+    {
+      return;
+    }
+
+    vtkIdType numberOfPoints = markupsNode->GetNumberOfControlPoints();
+
+    double pointWorldPos1[4] = { 0.0, 0.0, 0.0, 1.0 };
+    double pointWorldPos2[4] = { 0.0, 0.0, 0.0, 1.0 };
+
+    double toleranceWorld = this->ControlPointSize * this->ControlPointSize;
+
+    for (int i = 0; i < numberOfPoints - 1; i++)
+    {
+      markupsNode->GetNthControlPointPositionWorld(i, pointWorldPos1);
+      markupsNode->GetNthControlPointPositionWorld(i + 1, pointWorldPos2);
+
+      double relativePositionAlongLine = -1.0; // between 0.0-1.0 if between the endpoints of the line segment
+      const double* worldPosition = interactionEventData->GetWorldPosition();
+      double distance2 = vtkLine::DistanceToLine(worldPosition, pointWorldPos1, pointWorldPos2, relativePositionAlongLine);
+      if (distance2 < toleranceWorld && distance2 < closestDistance2 && relativePositionAlongLine >= 0 && relativePositionAlongLine <= 1)
+      {
+        closestDistance2 = distance2;
+        foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentLine;
         foundComponentIndex = i;
       }
     }
   }
 
-  /* This would probably faster for many points:
-
-  this->BuildLocator();
-
-  double closestDistance2 = VTK_DOUBLE_MAX;
-  int closestNode = static_cast<int> (this->Locator->FindClosestPointWithinRadius(
-    this->PixelTolerance, displayPos, closestDistance2));
-
-  if (closestNode != this->GetActiveNode())
-    {
-    this->SetActiveNode(closestNode);
-    this->NeedToRender = 1;
-    }
-  return (this->GetActiveNode() >= 0);
-  */
-}
-
-//----------------------------------------------------------------------
-void vtkSlicerMarkupsWidgetRepresentation3D::CanInteractWithLine(vtkMRMLInteractionEventData* interactionEventData,
-                                                                 int& foundComponentType,
-                                                                 int& foundComponentIndex,
-                                                                 double& closestDistance2)
-{
-  foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentNone;
-  vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
-  if (!markupsNode || markupsNode->GetLocked() || markupsNode->GetNumberOfControlPoints() < 1 //
-      || !this->GetVisibility() || !interactionEventData || !interactionEventData->IsWorldPositionValid())
+  //----------------------------------------------------------------------
+  void vtkSlicerMarkupsWidgetRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode * caller, unsigned long event, void* callData /*=nullptr*/)
   {
-    return;
-  }
+    this->UpdateViewScaleFactor();
+    this->UpdateControlPointSize();
 
-  vtkIdType numberOfPoints = markupsNode->GetNumberOfControlPoints();
+    Superclass::UpdateFromMRMLInternal(caller, event, callData);
 
-  double pointWorldPos1[4] = { 0.0, 0.0, 0.0, 1.0 };
-  double pointWorldPos2[4] = { 0.0, 0.0, 0.0, 1.0 };
-
-  double toleranceWorld = this->ControlPointSize * this->ControlPointSize;
-
-  for (int i = 0; i < numberOfPoints - 1; i++)
-  {
-    markupsNode->GetNthControlPointPositionWorld(i, pointWorldPos1);
-    markupsNode->GetNthControlPointPositionWorld(i + 1, pointWorldPos2);
-
-    double relativePositionAlongLine = -1.0; // between 0.0-1.0 if between the endpoints of the line segment
-    const double* worldPosition = interactionEventData->GetWorldPosition();
-    double distance2 = vtkLine::DistanceToLine(worldPosition, pointWorldPos1, pointWorldPos2, relativePositionAlongLine);
-    if (distance2 < toleranceWorld && distance2 < closestDistance2 && relativePositionAlongLine >= 0 && relativePositionAlongLine <= 1)
+    vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
+    if (!markupsNode || !this->IsDisplayable())
     {
-      closestDistance2 = distance2;
-      foundComponentType = vtkMRMLMarkupsDisplayNode::ComponentLine;
-      foundComponentIndex = i;
-    }
-  }
-}
-
-//----------------------------------------------------------------------
-void vtkSlicerMarkupsWidgetRepresentation3D::UpdateFromMRMLInternal(vtkMRMLNode* caller, unsigned long event, void* callData /*=nullptr*/)
-{
-  this->UpdateViewScaleFactor();
-  this->UpdateControlPointSize();
-
-  Superclass::UpdateFromMRMLInternal(caller, event, callData);
-
-  vtkMRMLMarkupsNode* markupsNode = this->GetMarkupsNode();
-  if (!markupsNode || !this->IsDisplayable())
-  {
-    this->VisibilityOff();
-    return;
-  }
-
-  this->VisibilityOn();
-
-  // Use hierarchy information if any, and if overriding is allowed for the current display node
-  double hierarchyOpacity = 1.0;
-  if (this->MarkupsDisplayNode->GetFolderDisplayOverrideAllowed())
-  {
-    vtkMRMLDisplayableNode* displayableNode = this->MarkupsDisplayNode->GetDisplayableNode();
-    hierarchyOpacity = vtkMRMLFolderDisplayNode::GetHierarchyOpacity(displayableNode);
-  }
-
-  for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
-  {
-    double* color = this->GetWidgetColor(controlPointType);
-    double opacity = this->MarkupsDisplayNode->GetOpacity() * hierarchyOpacity;
-
-    ControlPointsPipeline3D* controlPoints = this->GetControlPointsPipeline(controlPointType);
-    controlPoints->Property->SetColor(color);
-    controlPoints->Property->SetOpacity(opacity);
-
-    controlPoints->TextProperty->ShallowCopy(this->MarkupsDisplayNode->GetTextProperty());
-    if (this->GetApplicationLogic())
-    {
-      this->GetApplicationLogic()->UseCustomFontFile(controlPoints->TextProperty);
-    }
-    controlPoints->TextProperty->SetColor(color);
-    controlPoints->TextProperty->SetOpacity(opacity);
-    controlPoints->TextProperty->SetFontSize(
-      static_cast<int>(this->MarkupsDisplayNode->GetTextProperty()->GetFontSize() * this->MarkupsDisplayNode->GetTextScale() * this->GetScreenScaleFactor() * 5.0));
-    controlPoints->TextProperty->SetBackgroundOpacity(opacity * this->MarkupsDisplayNode->GetTextProperty()->GetBackgroundOpacity());
-
-    controlPoints->OccludedProperty->SetColor(color);
-    controlPoints->OccludedTextProperty->ShallowCopy(controlPoints->TextProperty);
-    if (this->MarkupsDisplayNode->GetOccludedVisibility() && this->MarkupsDisplayNode->GetOccludedOpacity() > 0.0)
-    {
-      // To prevent some rendering artifacts, and to ensure that the occluded actor does not block point visibility,
-      // the maximum opacity of the occluded actor is required to be almost, but not fully opaque.
-      double occludedOpacity = std::min(0.99, this->MarkupsDisplayNode->GetOccludedOpacity() * opacity);
-      controlPoints->OccludedProperty->SetOpacity(occludedOpacity);
-      controlPoints->OccludedTextProperty->SetOpacity(occludedOpacity);
-      controlPoints->OccludedTextProperty->SetBackgroundOpacity(occludedOpacity * this->MarkupsDisplayNode->GetTextProperty()->GetBackgroundOpacity());
-    }
-    else
-    {
-      controlPoints->OccludedProperty->SetOpacity(0.0);
-      controlPoints->OccludedTextProperty->SetOpacity(0.0);
+      this->VisibilityOff();
+      return;
     }
 
-    if (this->MarkupsDisplayNode->GlyphTypeIs3D())
-    {
-      this->GetControlPointsPipeline(controlPointType)->GlyphMapper->SetSourceConnection(this->GetControlPointsPipeline(controlPointType)->GlyphSourceSphere->GetOutputPort());
-      this->GetControlPointsPipeline(controlPointType)
-        ->OccludedGlyphMapper->SetSourceConnection(this->GetControlPointsPipeline(controlPointType)->GlyphSourceSphere->GetOutputPort());
-    }
-    else
-    {
-      vtkMarkupsGlyphSource2D* glyphSource = this->GetControlPointsPipeline(controlPointType)->GlyphSource2D;
-      glyphSource->SetGlyphType(this->GetGlyphTypeSourceFromDisplay(this->MarkupsDisplayNode->GetGlyphType()));
-      this->GetControlPointsPipeline(controlPointType)->GlyphMapper->SetSourceConnection(glyphSource->GetOutputPort());
-      this->GetControlPointsPipeline(controlPointType)->OccludedGlyphMapper->SetSourceConnection(glyphSource->GetOutputPort());
-    }
-  }
+    this->VisibilityOn();
 
-  this->TextActor->SetTextProperty(this->GetControlPointsPipeline(Unselected)->TextProperty);
-
-  /* TODO: implement this for better performance
-  if (event ==)
+    // Use hierarchy information if any, and if overriding is allowed for the current display node
+    double hierarchyOpacity = 1.0;
+    if (this->MarkupsDisplayNode->GetFolderDisplayOverrideAllowed())
     {
-    int* nPtr = nullptr;
-    int n = -1;
-    if (callData != nullptr)
+      vtkMRMLDisplayableNode* displayableNode = this->MarkupsDisplayNode->GetDisplayableNode();
+      hierarchyOpacity = vtkMRMLFolderDisplayNode::GetHierarchyOpacity(displayableNode);
+    }
+
+    for (int controlPointType = 0; controlPointType < NumberOfControlPointTypes; ++controlPointType)
+    {
+      double* color = this->GetWidgetColor(controlPointType);
+      double opacity = this->MarkupsDisplayNode->GetOpacity() * hierarchyOpacity;
+
+      ControlPointsPipeline3D* controlPoints = this->GetControlPointsPipeline(controlPointType);
+      controlPoints->Property->SetColor(color);
+      controlPoints->Property->SetOpacity(opacity);
+
+      controlPoints->TextProperty->ShallowCopy(this->MarkupsDisplayNode->GetTextProperty());
+      if (this->GetApplicationLogic())
       {
-      nPtr = reinterpret_cast<int*>(callData);
-      if (nPtr)
-        {
-        n = *nPtr;
-        }
+        this->GetApplicationLogic()->UseCustomFontFile(controlPoints->TextProperty);
       }
-    this->UpdateNthPointAndLabelFromMRML(n);
-    }
-  else*/
-  {
-    this->UpdateAllPointsAndLabelsFromMRML();
-  }
-}
+      controlPoints->TextProperty->SetColor(color);
+      controlPoints->TextProperty->SetOpacity(opacity);
+      controlPoints->TextProperty->SetFontSize(
+        static_cast<int>(this->MarkupsDisplayNode->GetTextProperty()->GetFontSize() * this->MarkupsDisplayNode->GetTextScale() * this->GetScreenScaleFactor() * 5.0));
+      controlPoints->TextProperty->SetBackgroundOpacity(opacity * this->MarkupsDisplayNode->GetTextProperty()->GetBackgroundOpacity());
 
-//----------------------------------------------------------------------
-void vtkSlicerMarkupsWidgetRepresentation3D::GetActors(vtkPropCollection* pc)
-{
-  Superclass::GetActors(pc);
-  for (int i = 0; i < NumberOfControlPointTypes; i++)
-  {
-    ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
-    controlPoints->Actor->GetActors(pc);
-    controlPoints->OccludedActor->GetActors(pc);
-    controlPoints->LabelsActor->GetActors(pc);
-    controlPoints->LabelsOccludedActor->GetActors(pc);
-  }
-  this->TextActor->GetActors(pc);
-}
-
-//----------------------------------------------------------------------
-void vtkSlicerMarkupsWidgetRepresentation3D::ReleaseGraphicsResources(vtkWindow* win)
-{
-  Superclass::ReleaseGraphicsResources(win);
-  for (int i = 0; i < NumberOfControlPointTypes; i++)
-  {
-    ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
-    controlPoints->Actor->ReleaseGraphicsResources(win);
-    controlPoints->OccludedActor->ReleaseGraphicsResources(win);
-    controlPoints->LabelsActor->ReleaseGraphicsResources(win);
-    controlPoints->LabelsOccludedActor->ReleaseGraphicsResources(win);
-  }
-  this->TextActor->ReleaseGraphicsResources(win);
-}
-
-//----------------------------------------------------------------------
-int vtkSlicerMarkupsWidgetRepresentation3D::RenderOverlay(vtkViewport* viewport)
-{
-  vtkFloatArray* zBuffer = vtkSlicerMarkupsWidgetRepresentation3D::GetCachedZBuffer(this->Renderer);
-  int count = Superclass::RenderOverlay(viewport);
-  for (int i = 0; i < NumberOfControlPointTypes; i++)
-  {
-    ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
-    if (controlPoints->ControlPoints->GetNumberOfPoints() > 0)
-    {
-      if (!this->MarkupsDisplayNode->GetOccludedVisibility())
+      controlPoints->OccludedProperty->SetColor(color);
+      controlPoints->OccludedTextProperty->ShallowCopy(controlPoints->TextProperty);
+      if (this->MarkupsDisplayNode->GetOccludedVisibility() && this->MarkupsDisplayNode->GetOccludedOpacity() > 0.0)
       {
-        if (!zBuffer)
-        {
-          controlPoints->SelectVisiblePoints->UpdateZBuffer();
-          zBuffer = controlPoints->SelectVisiblePoints->GetZBuffer();
-          vtkSlicerMarkupsWidgetRepresentation3D::CachedZBuffers[this->Renderer] = zBuffer;
-        }
-        else
-        {
-          controlPoints->SelectVisiblePoints->SetZBuffer(zBuffer);
-        }
-        controlPoints->SelectVisiblePoints->Update();
+        // To prevent some rendering artifacts, and to ensure that the occluded actor does not block point visibility,
+        // the maximum opacity of the occluded actor is required to be almost, but not fully opaque.
+        double occludedOpacity = std::min(0.99, this->MarkupsDisplayNode->GetOccludedOpacity() * opacity);
+        controlPoints->OccludedProperty->SetOpacity(occludedOpacity);
+        controlPoints->OccludedTextProperty->SetOpacity(occludedOpacity);
+        controlPoints->OccludedTextProperty->SetBackgroundOpacity(occludedOpacity * this->MarkupsDisplayNode->GetTextProperty()->GetBackgroundOpacity());
       }
       else
       {
-        if (controlPoints->VisiblePointsPolyData->GetMTime() < controlPoints->LabelControlPointsPolyData->GetMTime())
+        controlPoints->OccludedProperty->SetOpacity(0.0);
+        controlPoints->OccludedTextProperty->SetOpacity(0.0);
+      }
+
+      if (this->MarkupsDisplayNode->GlyphTypeIs3D())
+      {
+        this->GetControlPointsPipeline(controlPointType)->GlyphMapper->SetSourceConnection(this->GetControlPointsPipeline(controlPointType)->GlyphSourceSphere->GetOutputPort());
+        this->GetControlPointsPipeline(controlPointType)
+          ->OccludedGlyphMapper->SetSourceConnection(this->GetControlPointsPipeline(controlPointType)->GlyphSourceSphere->GetOutputPort());
+      }
+      else
+      {
+        vtkMarkupsGlyphSource2D* glyphSource = this->GetControlPointsPipeline(controlPointType)->GlyphSource2D;
+        glyphSource->SetGlyphType(this->GetGlyphTypeSourceFromDisplay(this->MarkupsDisplayNode->GetGlyphType()));
+        this->GetControlPointsPipeline(controlPointType)->GlyphMapper->SetSourceConnection(glyphSource->GetOutputPort());
+        this->GetControlPointsPipeline(controlPointType)->OccludedGlyphMapper->SetSourceConnection(glyphSource->GetOutputPort());
+      }
+    }
+
+    this->TextActor->SetTextProperty(this->GetControlPointsPipeline(Unselected)->TextProperty);
+
+    /* TODO: implement this for better performance
+    if (event ==)
+      {
+      int* nPtr = nullptr;
+      int n = -1;
+      if (callData != nullptr)
         {
-          controlPoints->VisiblePointsPolyData->DeepCopy(controlPoints->LabelControlPointsPolyData);
+        nPtr = reinterpret_cast<int*>(callData);
+        if (nPtr)
+          {
+          n = *nPtr;
+          }
+        }
+      this->UpdateNthPointAndLabelFromMRML(n);
+      }
+    else*/
+    {
+      this->UpdateAllPointsAndLabelsFromMRML();
+    }
+  }
+
+  //----------------------------------------------------------------------
+  void vtkSlicerMarkupsWidgetRepresentation3D::GetActors(vtkPropCollection * pc)
+  {
+    Superclass::GetActors(pc);
+    for (int i = 0; i < NumberOfControlPointTypes; i++)
+    {
+      ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
+      controlPoints->Actor->GetActors(pc);
+      controlPoints->OccludedActor->GetActors(pc);
+      controlPoints->LabelsActor->GetActors(pc);
+      controlPoints->LabelsLineActor->GetActors(pc);
+      controlPoints->LabelsOccludedActor->GetActors(pc);
+    }
+    this->TextActor->GetActors(pc);
+  }
+
+  //----------------------------------------------------------------------
+  void vtkSlicerMarkupsWidgetRepresentation3D::ReleaseGraphicsResources(vtkWindow * win)
+  {
+    Superclass::ReleaseGraphicsResources(win);
+    for (int i = 0; i < NumberOfControlPointTypes; i++)
+    {
+      ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
+      controlPoints->Actor->ReleaseGraphicsResources(win);
+      controlPoints->OccludedActor->ReleaseGraphicsResources(win);
+      controlPoints->LabelsActor->ReleaseGraphicsResources(win);
+      controlPoints->LabelsLineActor->ReleaseGraphicsResources(win);
+      controlPoints->LabelsOccludedActor->ReleaseGraphicsResources(win);
+    }
+    this->TextActor->ReleaseGraphicsResources(win);
+  }
+
+  //----------------------------------------------------------------------
+  int vtkSlicerMarkupsWidgetRepresentation3D::RenderOverlay(vtkViewport * viewport)
+  {
+    vtkFloatArray* zBuffer = vtkSlicerMarkupsWidgetRepresentation3D::GetCachedZBuffer(this->Renderer);
+    int count = Superclass::RenderOverlay(viewport);
+    for (int i = 0; i < NumberOfControlPointTypes; i++)
+    {
+      ControlPointsPipeline3D* controlPoints = reinterpret_cast<ControlPointsPipeline3D*>(this->ControlPoints[i]);
+      if (controlPoints->ControlPoints->GetNumberOfPoints() > 0)
+      {
+        if (!this->MarkupsDisplayNode->GetOccludedVisibility())
+        {
+          if (!zBuffer)
+          {
+            controlPoints->SelectVisiblePoints->UpdateZBuffer();
+            zBuffer = controlPoints->SelectVisiblePoints->GetZBuffer();
+            vtkSlicerMarkupsWidgetRepresentation3D::CachedZBuffers[this->Renderer] = zBuffer;
+          }
+          else
+          {
+            controlPoints->SelectVisiblePoints->SetZBuffer(zBuffer);
+          }
+          controlPoints->SelectVisiblePoints->Update();
+        }
+        else
+        {
+          if (controlPoints->VisiblePointsPolyData->GetMTime() < controlPoints->LabelControlPointsPolyData->GetMTime())
+          {
+            controlPoints->VisiblePointsPolyData->DeepCopy(controlPoints->LabelControlPointsPolyData);
+          }
+        }
+
+        if (controlPoints->Actor->GetVisibility())
+        {
+          count += controlPoints->Actor->RenderOverlay(viewport);
+        }
+        if (controlPoints->OccludedActor->GetVisibility())
+        {
+          count += controlPoints->OccludedActor->RenderOverlay(viewport);
+        }
+        if (controlPoints->LabelsActor->GetVisibility())
+        {
+          count += controlPoints->LabelsActor->RenderOverlay(viewport);
+        }
+        if (controlPoints->LabelsLineActor->GetVisibility())
+        {
+          count += controlPoints->LabelsLineActor->RenderOverlay(viewport);
+        }
+        if (controlPoints->LabelsOccludedActor->GetVisibility())
+        {
+          count += controlPoints->LabelsOccludedActor->RenderOverlay(viewport);
         }
       }
 
@@ -880,6 +1202,7 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderOpaqueGeometry(vtkViewport* vi
         controlPoints->GlyphMapper->SetScaleFactor(this->ControlPointSize);
         controlPoints->OccludedGlyphMapper->SetScaleFactor(this->ControlPointSize);
         controlPoints->SelectVisiblePoints->SetToleranceWorld(this->ControlPointSize * 0.7);
+        controlPoints->LabelsLineTubeFilter->SetRadius(this->ControlPointSize * .25);
       }
       count += controlPoints->Actor->RenderOpaqueGeometry(viewport);
     }
@@ -891,14 +1214,32 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderOpaqueGeometry(vtkViewport* vi
     {
       count += controlPoints->LabelsActor->RenderOpaqueGeometry(viewport);
     }
+    if (controlPoints->LabelsLineActor->GetVisibility())
+    {
+      count += controlPoints->LabelsLineActor->RenderOpaqueGeometry(viewport);
+    }
     if (controlPoints->LabelsOccludedActor->GetVisibility())
     {
       count += controlPoints->LabelsOccludedActor->RenderOpaqueGeometry(viewport);
     }
     count += this->TextActor->RenderOpaqueGeometry(viewport);
   }
+  if (controlPoints->OccludedActor->GetVisibility())
+  {
+    count += controlPoints->OccludedActor->RenderOpaqueGeometry(viewport);
+  }
+  if (controlPoints->LabelsActor->GetVisibility())
+  {
+    count += controlPoints->LabelsActor->RenderOpaqueGeometry(viewport);
+  }
+  if (controlPoints->LabelsOccludedActor->GetVisibility())
+  {
+    count += controlPoints->LabelsOccludedActor->RenderOpaqueGeometry(viewport);
+  }
+  count += this->TextActor->RenderOpaqueGeometry(viewport);
+}
 
-  return count;
+return count;
 }
 
 //-----------------------------------------------------------------------------
@@ -924,6 +1265,10 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderTranslucentPolygonalGeometry(v
     {
       count += controlPoints->LabelsActor->RenderTranslucentPolygonalGeometry(viewport);
     }
+    if (controlPoints->LabelsLineActor->GetVisibility())
+    {
+      count += controlPoints->LabelsLineActor->RenderTranslucentPolygonalGeometry(viewport);
+    }
     if (controlPoints->LabelsOccludedActor->GetVisibility())
     {
       count += controlPoints->LabelsOccludedActor->RenderTranslucentPolygonalGeometry(viewport);
@@ -931,9 +1276,26 @@ int vtkSlicerMarkupsWidgetRepresentation3D::RenderTranslucentPolygonalGeometry(v
   }
   if (this->TextActor->GetVisibility() && !this->TextActorOccluded)
   {
-    count += this->TextActor->RenderTranslucentPolygonalGeometry(viewport);
+    count += controlPoints->Actor->RenderTranslucentPolygonalGeometry(viewport);
   }
-  return count;
+  if (controlPoints->OccludedActor->GetVisibility())
+  {
+    count += controlPoints->OccludedActor->RenderTranslucentPolygonalGeometry(viewport);
+  }
+  if (controlPoints->LabelsActor->GetVisibility())
+  {
+    count += controlPoints->LabelsActor->RenderTranslucentPolygonalGeometry(viewport);
+  }
+  if (controlPoints->LabelsOccludedActor->GetVisibility())
+  {
+    count += controlPoints->LabelsOccludedActor->RenderTranslucentPolygonalGeometry(viewport);
+  }
+}
+if (this->TextActor->GetVisibility() && !this->TextActorOccluded)
+{
+  count += this->TextActor->RenderTranslucentPolygonalGeometry(viewport);
+}
+return count;
 }
 
 //-----------------------------------------------------------------------------
@@ -958,6 +1320,10 @@ vtkTypeBool vtkSlicerMarkupsWidgetRepresentation3D::HasTranslucentPolygonalGeome
     {
       return true;
     }
+    if (controlPoints->LabelsLineActor->GetVisibility() && controlPoints->LabelsLineActor->HasTranslucentPolygonalGeometry())
+    {
+      return true;
+    }
     if (controlPoints->LabelsOccludedActor->GetVisibility() && controlPoints->LabelsOccludedActor->HasTranslucentPolygonalGeometry())
     {
       return true;
@@ -967,7 +1333,24 @@ vtkTypeBool vtkSlicerMarkupsWidgetRepresentation3D::HasTranslucentPolygonalGeome
   {
     return true;
   }
-  return false;
+  if (controlPoints->OccludedActor->GetVisibility() && controlPoints->OccludedActor->HasTranslucentPolygonalGeometry())
+  {
+    return true;
+  }
+  if (controlPoints->LabelsActor->GetVisibility() && controlPoints->LabelsActor->HasTranslucentPolygonalGeometry())
+  {
+    return true;
+  }
+  if (controlPoints->LabelsOccludedActor->GetVisibility() && controlPoints->LabelsOccludedActor->HasTranslucentPolygonalGeometry())
+  {
+    return true;
+  }
+}
+if (this->TextActor->GetVisibility() && !this->TextActorOccluded && this->TextActor->HasTranslucentPolygonalGeometry())
+{
+  return true;
+}
+return false;
 }
 
 //-----------------------------------------------------------------------------
@@ -1007,6 +1390,14 @@ void vtkSlicerMarkupsWidgetRepresentation3D::PrintSelf(ostream& os, vtkIndent in
     else
     {
       os << indent << "Labels Points: (none)\n";
+    }
+    if (controlPoints->LabelsLineActor)
+    {
+      os << indent << "Labels Line Visibility: " << controlPoints->LabelsLineActor->GetVisibility() << "\n";
+    }
+    else
+    {
+      os << indent << "Labels Line Visibility: (none)\n";
     }
     if (controlPoints->Property)
     {

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -96,6 +96,15 @@ protected:
 
   void UpdateControlPointSize() override;
 
+  void UpdateInteractionPipeline() override;
+
+  /// Calculate X, Y and Z display coordinate offsets from control point position
+  /// in relation to display dimensions and volume center coordinates
+  void GetLabelTextRASOffsets(double* backgroundVolumeCenterXY, double* slicePos, double* leadersLineOffset);
+
+  /// Get xy display center of background volume in slice node
+  void GetBackgroundVolumeRASCenter(double* centerPos);
+
   class ControlPointsPipeline3D : public ControlPointsPipeline
   {
   public:
@@ -112,6 +121,7 @@ protected:
     vtkSmartPointer<vtkProperty> Property;
     vtkSmartPointer<vtkProperty> OccludedProperty;
     vtkSmartPointer<vtkTextProperty> OccludedTextProperty;
+    vtkSmartPointer<vtkProperty> LabelLeaderLinesProperty;
 
     vtkSmartPointer<vtkPolyData> VisiblePointsPolyData;
 
@@ -128,6 +138,12 @@ protected:
     vtkSmartPointer<vtkActor> OccludedActor;
     vtkSmartPointer<vtkActor2D> LabelsActor;
     vtkSmartPointer<vtkActor2D> LabelsOccludedActor;
+
+    vtkSmartPointer<vtkPolyData> LabelsLinePolyData;
+    vtkSmartPointer<vtkTubeFilter> LabelsLineTubeFilter;
+
+    vtkSmartPointer<vtkPolyDataMapper> LabelsLineMapper;
+    vtkSmartPointer<vtkActor> LabelsLineActor;
   };
 
   ControlPointsPipeline3D* GetControlPointsPipeline(int controlPointType);

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerMarkupsWidgetRepresentation3D.h
@@ -139,6 +139,8 @@ protected:
     vtkSmartPointer<vtkActor2D> LabelsActor;
     vtkSmartPointer<vtkActor2D> LabelsOccludedActor;
 
+    vtkSmartPointer<vtkPoints> LabelsLinePoints;
+    vtkSmartPointer<vtkCellArray> LabelsLineCells;
     vtkSmartPointer<vtkPolyData> LabelsLinePolyData;
     vtkSmartPointer<vtkTubeFilter> LabelsLineTubeFilter;
 

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>368</width>
-    <height>186</height>
+    <width>350</width>
+    <height>694</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -26,6 +26,13 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="VisibilityLabel">
+     <property name="text">
+      <string>Visibility:</string>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -57,14 +64,14 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="VisibilityLabel">
+   <item row="1" column="0">
+    <widget class="QLabel" name="glyphScaleLabel">
      <property name="text">
-      <string>Visibility:</string>
+      <string>Glyph Size:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="1" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QPushButton" name="glyphSizeIsAbsoluteButton">
@@ -110,16 +117,51 @@
      </item>
     </layout>
    </item>
-   <item row="10" column="0" colspan="2">
+   <item row="2" column="0">
+    <widget class="QLabel" name="textScaleLabel">
+     <property name="text">
+      <string>Text Size:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="ctkSliderWidget" name="textScaleSliderWidget">
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>20.000000000000000</double>
+     </property>
+     <property name="suffix">
+      <string> %</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox">
+     <property name="title">
+      <string>Interaction handles</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="qMRMLMarkupsInteractionHandleWidget" name="InteractionHandleWidget"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
     <widget class="ctkCollapsibleGroupBox" name="SliceDisplayCollapsibleGroupBox">
      <property name="title">
       <string>Advanced</string>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="collapsed">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="topMargin">
@@ -131,6 +173,285 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
+      <item row="13" column="0" colspan="2">
+       <widget class="ctkCollapsibleGroupBox" name="TwoDDisplayGroupBox">
+        <property name="title">
+         <string>2D Display</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="qMRMLMarkupsFiducialProjectionPropertyWidget" name="pointFiducialProjectionWidget"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="selectedColorLabel">
+        <property name="text">
+         <string>Selected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QPushButton" name="curveLineSizeIsAbsoluteButton">
+          <property name="toolTip">
+           <string>If button is pressed then line thickness is specified in physical length unit, otherwise as percentage of glyph size</string>
+          </property>
+          <property name="text">
+           <string>absolute</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="curveLineThicknessSliderWidget">
+          <property name="singleStep">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>20.000000000000000</double>
+          </property>
+          <property name="suffix">
+           <string> %</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="qMRMLSliderWidget" name="curveLineDiameterSliderWidget">
+          <property name="singleStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="quantity">
+           <string notr="true">length</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="7" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QCheckBox" name="FillVisibilityCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="OpacityLabel3">
+          <property name="text">
+           <string>Opacity:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="FillOpacitySliderWidget">
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="DisplayNodeViewLabel">
+        <property name="text">
+         <string>View:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="ctkColorPickerButton" name="activeColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QCheckBox" name="PropertiesLabelVisibilityCheckBox">
+        <property name="toolTip">
+         <string>Show node name and measurements</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0">
+       <widget class="QLabel" name="PointLabelsVisibilityLabel">
+        <property name="text">
+         <string>Control Point Labels:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="activeColorPickerLabel">
+        <property name="text">
+         <string>Active Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
+          <property name="toolTip">
+           <string>Show control point labels</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="connectorLineScaleLabel">
+          <property name="text">
+           <string>Distance:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="pointLabelsDistanceScaleSliderWidget">
+          <property name="toolTip">
+           <string>Scale of connector line in percent of screenwidth</string>
+          </property>
+          <property name="singleStep">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>30.000000000000000</double>
+          </property>
+          <property name="suffix">
+           <string> %</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="1">
+       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
+        <property name="toolTip">
+         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="lineThicknessLabel">
+        <property name="text">
+         <string>Line Thickness:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QCheckBox" name="OutlineVisibilityCheckBox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="OpacityLabel2">
+          <property name="text">
+           <string>Opacity:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="ctkSliderWidget" name="OutlineOpacitySliderWidget">
+          <property name="singleStep">
+           <double>0.010000000000000</double>
+          </property>
+          <property name="pageStep">
+           <double>0.100000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="1">
+       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="glyphTypeLabel">
+        <property name="text">
+         <string>Glyph Type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="FillLabel">
+        <property name="text">
+         <string>Fill:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QComboBox" name="glyphTypeComboBox"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="unselectedColorLabel">
+        <property name="text">
+         <string>Unselected Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="PropertiesLabelVisibilityLabel">
+        <property name="text">
+         <string>Properties Label:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
+        <property name="displayColorName">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item row="12" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="TextDisplayGroupBox">
         <property name="title">
@@ -219,106 +540,6 @@
         </layout>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QComboBox" name="glyphTypeComboBox"/>
-      </item>
-      <item row="0" column="1">
-       <widget class="qMRMLDisplayNodeViewComboBox" name="DisplayNodeViewComboBox">
-        <property name="toolTip">
-         <string>Select views in which to show this node. All unchecked shows in all 3D and 2D views.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="activeColorPickerLabel">
-        <property name="text">
-         <string>Active Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="14" column="0" colspan="2">
-       <widget class="ctkCollapsibleGroupBox" name="TwoDDisplayGroupBox">
-        <property name="title">
-         <string>2D Display</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_4">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="qMRMLMarkupsFiducialProjectionPropertyWidget" name="pointFiducialProjectionWidget"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="7" column="0">
-       <widget class="QLabel" name="FillLabel">
-        <property name="text">
-         <string>Fill:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="glyphTypeLabel">
-        <property name="text">
-         <string>Glyph Type:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QCheckBox" name="OutlineVisibilityCheckBox">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="OpacityLabel2">
-          <property name="text">
-           <string>Opacity:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ctkSliderWidget" name="OutlineOpacitySliderWidget">
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="DisplayNodeViewLabel">
-        <property name="text">
-         <string>View:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="unselectedColorLabel">
-        <property name="text">
-         <string>Unselected Color:</string>
-        </property>
-       </widget>
-      </item>
       <item row="6" column="0">
        <widget class="QLabel" name="OutlineLabel">
         <property name="text">
@@ -326,135 +547,7 @@
         </property>
        </widget>
       </item>
-      <item row="11" column="1">
-       <widget class="QCheckBox" name="PointLabelsVisibilityCheckBox">
-        <property name="toolTip">
-         <string>Show control point labels</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="ctkColorPickerButton" name="selectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QPushButton" name="curveLineSizeIsAbsoluteButton">
-          <property name="toolTip">
-           <string>If button is pressed then line thickness is specified in physical length unit, otherwise as percentage of glyph size</string>
-          </property>
-          <property name="text">
-           <string>absolute</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ctkSliderWidget" name="curveLineThicknessSliderWidget">
-          <property name="singleStep">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>100.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>20.000000000000000</double>
-          </property>
-          <property name="suffix">
-           <string> %</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="qMRMLSliderWidget" name="curveLineDiameterSliderWidget">
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="quantity">
-           <string notr="true">length</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="lineThicknessLabel">
-        <property name="text">
-         <string>Line Thickness:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="selectedColorLabel">
-        <property name="text">
-         <string>Selected Color:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QCheckBox" name="FillVisibilityCheckBox">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="OpacityLabel3">
-          <property name="text">
-           <string>Opacity:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ctkSliderWidget" name="FillOpacitySliderWidget">
-          <property name="singleStep">
-           <double>0.010000000000000</double>
-          </property>
-          <property name="pageStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="11" column="0">
-       <widget class="QLabel" name="PointLabelsVisibilityLabel">
-        <property name="text">
-         <string>Control Point Labels:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="ctkColorPickerButton" name="unselectedColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="13" column="0" colspan="2">
+      <item row="14" column="0" colspan="2">
        <widget class="ctkCollapsibleGroupBox" name="ThreeDDisplayGroupBox">
         <property name="title">
          <string>3D Display</string>
@@ -520,58 +613,7 @@
         </layout>
        </widget>
       </item>
-      <item row="8" column="0">
-       <widget class="QLabel" name="PropertiesLabelVisibilityLabel">
-        <property name="text">
-         <string>Properties Label:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="ctkColorPickerButton" name="activeColorPickerButton">
-        <property name="displayColorName">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <widget class="QCheckBox" name="PropertiesLabelVisibilityCheckBox">
-        <property name="toolTip">
-         <string>Show node name and measurements</string>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
      </layout>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="glyphScaleLabel">
-     <property name="text">
-      <string>Glyph Size:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="ctkSliderWidget" name="textScaleSliderWidget">
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>20.000000000000000</double>
-     </property>
-     <property name="suffix">
-      <string> %</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="textScaleLabel">
-     <property name="text">
-      <string>Text Size:</string>
-     </property>
     </widget>
    </item>
    <item row="11" column="0" colspan="2">
@@ -589,24 +631,25 @@
      </layout>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
-    <widget class="ctkCollapsibleGroupBox" name="CollapsibleGroupBox">
-     <property name="title">
-      <string>Interaction handles</string>
-     </property>
-     <property name="collapsed">
-      <bool>true</bool>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="qMRMLMarkupsInteractionHandleWidget" name="InteractionHandleWidget"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>ctkCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>ctkCollapsibleGroupBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkColorPickerButton</class>
+   <extends>QPushButton</extends>
+   <header>ctkColorPickerButton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkSliderWidget</class>
+   <extends>QWidget</extends>
+   <header>ctkSliderWidget.h</header>
+  </customwidget>
   <customwidget>
    <class>qMRMLCheckableNodeComboBox</class>
    <extends>qMRMLNodeComboBox</extends>
@@ -653,22 +696,6 @@
    <extends>qMRMLWidget</extends>
    <header>qMRMLMarkupsInteractionHandleWidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>ctkCollapsibleGroupBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkColorPickerButton</class>
-   <extends>QPushButton</extends>
-   <header>ctkColorPickerButton.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ctkSliderWidget</class>
-   <extends>QWidget</extends>
-   <header>ctkSliderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
+++ b/Modules/Loadable/Markups/Widgets/Resources/UI/qMRMLMarkupsDisplayNodeWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>350</width>
-    <height>694</height>
+    <width>368</width>
+    <height>186</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -158,10 +158,10 @@
       <string>Advanced</string>
      </property>
      <property name="checked">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="collapsed">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <property name="topMargin">

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.cxx
@@ -40,6 +40,7 @@
 #include <vtkProperty.h>
 #include <vtkSmartPointer.h>
 #include <vtkTextProperty.h>
+#include <vtkSlicerMarkupsWidgetRepresentation2D.h>
 
 //------------------------------------------------------------------------------
 class qMRMLMarkupsDisplayNodeWidgetPrivate
@@ -78,6 +79,7 @@ void qMRMLMarkupsDisplayNodeWidgetPrivate::init()
 
   // set up the display properties
   QObject::connect(this->VisibilityCheckBox, SIGNAL(toggled(bool)), q, SLOT(setVisibility(bool)));
+  QObject::connect(this->pointLabelsDistanceScaleSliderWidget, SIGNAL(valueChanged(double)), q, SLOT(onPointLabelsDistanceScaleSliderWidgetChanged(double)));
   QObject::connect(this->selectedColorPickerButton, SIGNAL(colorChanged(QColor)), q, SLOT(onSelectedColorPickerButtonChanged(QColor)));
   QObject::connect(this->unselectedColorPickerButton, SIGNAL(colorChanged(QColor)), q, SLOT(onUnselectedColorPickerButtonChanged(QColor)));
   QObject::connect(this->activeColorPickerButton, SIGNAL(colorChanged(QColor)), q, SLOT(onActiveColorPickerButtonChanged(QColor)));
@@ -319,6 +321,14 @@ void qMRMLMarkupsDisplayNodeWidget::updateWidgetFromMRML()
 
   d->PropertiesLabelVisibilityCheckBox->setChecked(markupsDisplayNode->GetPropertiesLabelVisibility());
 
+  // point label line connector scale
+  double labelLeaderLinesScale = markupsDisplayNode->GetPointLabelsDistanceScale();
+  // make sure that the slider can accommodate this scale
+  if (labelLeaderLinesScale > d->pointLabelsDistanceScaleSliderWidget->maximum())
+  {
+    d->pointLabelsDistanceScaleSliderWidget->setMaximum(labelLeaderLinesScale);
+  }
+  d->pointLabelsDistanceScaleSliderWidget->setValue(labelLeaderLinesScale);
   d->PointLabelsVisibilityCheckBox->setChecked(markupsDisplayNode->GetPointLabelsVisibility());
 
   // text scale
@@ -597,6 +607,17 @@ void qMRMLMarkupsDisplayNodeWidget::onTextScaleSliderWidgetChanged(double value)
     return;
   }
   d->MarkupsDisplayNode->SetTextScale(value);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLMarkupsDisplayNodeWidget::onPointLabelsDistanceScaleSliderWidgetChanged(double value)
+{
+  Q_D(qMRMLMarkupsDisplayNodeWidget);
+  if (!d->MarkupsDisplayNode)
+  {
+    return;
+  }
+  d->MarkupsDisplayNode->SetPointLabelsDistanceScale(value);
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsDisplayNodeWidget.h
@@ -105,6 +105,7 @@ protected slots:
   void onCurveLineDiameterSliderWidgetChanged(double value);
   void onTextScaleSliderWidgetChanged(double value);
   void onOpacitySliderWidgetChanged(double value);
+  void onPointLabelsDistanceScaleSliderWidgetChanged(double value);
   void onSnapModeWidgetChanged();
   void onTextPropertyWidgetsChanged();
 


### PR DESCRIPTION
This is a continuation of https://github.com/Slicer/Slicer/pull/6188 - the branch is rebased to the latest master and a few fixes and simplifications has been made.

---

- add connector lines
- handle border collisions
- enable XML read and writer
- add connector lines in 3D view
- adjust connector line angles in 3D angles according to 3D focal point
- remove connector line color picker button and its overhead
- add automatic connector line color algorithm
- renaming leader lines label
- initialize leader lines variables in vtkMRMLMarkupsDisplayNode
- rename all "labelconnector" variables to "leaderlines"
- restore normal 2D label offest (without leaderlines)
- markup read/write test
- repositioning "Leader lines:" label to -> Advanced section in Markups Display Widget (+ indenting two spaces)
- clean up indents in qMRMLMarkupsDisplayNodeWidget.ui
- make lines only visible if ctrl pts visible and label text present
- lines in occluded state to be discussed
- set leader line to 25% of glyph size in 2D and 3D
- a change in upper and lower border collision handling 2D
- do not draw leader lines when "Control Point Labels:" is checked off in "Display"->"Advanced"
- determine background volume centers in 2D views as leader lines reference
- make leader lines fluently pointing to this center in 2D views
- trigonometry to seperate function in vtkSlicerMarkupsWidgetRepresentation2D preparing 3D
- 3D view: make leader line tube filter radius update in time
- set all 3D label text positions to end of connector line
