### PR TITLE
BUG: Make loading of legacy annotation fiducial, line, ROI nodes more robust

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.h
@@ -194,14 +194,20 @@ public:
   bool MoveNthControlPointToNewListAtIndex(int n, vtkMRMLMarkupsNode *markupsNode,
                                    vtkMRMLMarkupsNode *newMarkupsNode, int newIndex);
 
-  /// Searches the scene for annotation fidicual nodes, collecting a list
+  /// Searches the scene for annotation fiducial nodes, collecting a list
   /// of annotation hierarchy nodes. Then iterates through those hierarchy nodes
   /// and moves the fiducials that are under them into new markups nodes. Leaves
   /// the top level hierarchy nodes intact as they may be parents to ruler or
   /// ROIs but deletes the 1:1 hierarchy nodes.
-  void ConvertAnnotationFiducialsToMarkups();
+  /// If addedNodeIds or removedNodeIds are specified then IDs of data and hierarchy nodes
+  /// added or removed during conversion in the main scene are added to these arrays.
+  void ConvertAnnotationFiducialsToMarkups(vtkStringArray* addedNodeIds=nullptr, vtkStringArray* removedNodeIds=nullptr);
 
-  void ConvertAnnotationLinesROIsToMarkups();
+  /// Searches the scene for annotation ruler and ROI nodes and converts each to
+  /// markup line or ROI node.
+  /// If addedNodeIds or removedNodeIds are specified then IDs of data and hierarchy nodes
+  /// added or removed during conversion in the main scene are added to these arrays.
+  void ConvertAnnotationLinesROIsToMarkups(vtkStringArray* addedNodeIds=nullptr, vtkStringArray* removedNodeIds=nullptr);
 
   void ConvertAnnotationHierarchyToSubjectHierarchy(vtkMRMLScene* scene);
 

--- a/Modules/Loadable/Markups/qSlicerMarkupsReader.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsReader.cxx
@@ -90,8 +90,7 @@ QStringList qSlicerMarkupsReader::extensions()const
   return QStringList()
     << "Markups (*.mrk.json)"
     << "Markups (*.json)"
-    << "Markups Fiducials (*.fcsv)"
-    << "Annotation Fiducial (*.acsv)";
+    << "Markups Fiducials (*.fcsv)";
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Fixed loadAnnotationRuler function. It now returns a valid markups line node. ruler_node = slicer.util.loadAnnotationRuler(".../M_1.acsv")

Annotation fiducials, lines, ROIs can be loaded from .acsv files using "Add data" (drag-and-dropping the file to the application window).

fixes #6813