### PR TITLE
BUG: Fixes default progress callback raises user warning in send() function

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMProcesses.py
+++ b/Modules/Scripted/DICOMLib/DICOMProcesses.py
@@ -418,8 +418,10 @@ class DICOMSender(DICOMProcess):
     def __del__(self):
         super().__del__()
 
-    def defaultProgressCallback(self, s):
+    @staticmethod
+    def defaultProgressCallback(s):
         logging.debug(s)
+        return True
 
     def send(self):
         self.progressCallback("Starting send to %s using self.protocol" % self.destinationUrl.toString())


### PR DESCRIPTION
Since the return argument of the `defaultProgressCallback()` is `None`, the `send()` function of the `DICOMSender` raises a UserWarning:
```python
if not self.progressCallback(f"Sending {file} to {self.destinationUrl.toString()} using {self.protocol}"):
    raise UserWarning("Sending was cancelled, upload is incomplete.")
```

This minimal PR prevents the user warning by returning True instead.