### PR TITLE
BUG: Mark translatable strings in Base/QTCli

### DIFF
--- a/Base/QTCLI/qSlicerCLIExecutableModuleFactory.cxx
+++ b/Base/QTCLI/qSlicerCLIExecutableModuleFactory.cxx
@@ -85,7 +85,7 @@ qSlicerAbstractCoreModule* qSlicerCLIExecutableModuleFactoryItem::instanciator()
       if (python_path.isEmpty())
         {
         this->appendInstantiateErrorString(
-          QString("Failed to find python interpreter for CLI: %1").arg(this->path()));
+          qSlicerCLIModule::tr("Failed to find python interpreter for CLI: %1").arg(this->path()));
         return nullptr;
         }
 
@@ -110,8 +110,8 @@ qSlicerAbstractCoreModule* qSlicerCLIExecutableModuleFactoryItem::instanciator()
       }
     else
       {
-      this->appendInstantiateErrorString(QString("CLI description: %1").arg(xmlFilePath));
-      this->appendInstantiateErrorString("Failed to read Xml Description");
+      this->appendInstantiateErrorString(qSlicerCLIModule::tr("CLI description: %1").arg(xmlFilePath));
+      this->appendInstantiateErrorString(qSlicerCLIModule::tr("Failed to read XML Description"));
       }
     }
   else
@@ -148,35 +148,35 @@ QString qSlicerCLIExecutableModuleFactoryItem::runCLIWithXmlArgument()
   bool res = cli.waitForFinished(cliProcessTimeoutInMs);
   if (!res)
     {
-    this->appendInstantiateErrorString(QString("CLI executable: %1").arg(this->path()));
+    this->appendInstantiateErrorString(qSlicerCLIModule::tr("CLI executable: %1").arg(this->path()));
     QString errorString;
     switch(cli.error())
       {
       case QProcess::FailedToStart:
-        errorString = QLatin1String(
+        errorString = qSlicerCLIModule::tr(
               "The process failed to start. Either the invoked program is missing, or "
               "you may have insufficient permissions to invoke the program.");
         break;
       case QProcess::Crashed:
-        errorString = QLatin1String(
+        errorString = qSlicerCLIModule::tr(
               "The process crashed some time after starting successfully.");
         break;
       case QProcess::Timedout:
-        errorString = QString(
+        errorString = qSlicerCLIModule::tr(
               "The process timed out after %1 msecs.").arg(cliProcessTimeoutInMs);
         break;
       case QProcess::WriteError:
-        errorString = QLatin1String(
+        errorString = qSlicerCLIModule::tr(
               "An error occurred when attempting to read from the process. "
               "For example, the process may not be running.");
         break;
       case QProcess::ReadError:
-        errorString = QLatin1String(
+        errorString = qSlicerCLIModule::tr(
               "An error occurred when attempting to read from the process. "
               "For example, the process may not be running.");
         break;
       case QProcess::UnknownError:
-        errorString = QLatin1String(
+        errorString = qSlicerCLIModule::tr(
               "Failed to execute process. An unknown error occurred.");
         break;
       }
@@ -186,7 +186,7 @@ QString qSlicerCLIExecutableModuleFactoryItem::runCLIWithXmlArgument()
   QString errors = cli.readAllStandardError();
   if (!errors.isEmpty())
     {
-    this->appendInstantiateErrorString(QString("CLI executable: %1").arg(this->path()));
+    this->appendInstantiateErrorString(qSlicerCLIModule::tr("CLI executable: %1").arg(this->path()));
     this->appendInstantiateErrorString(errors);
     // TODO: More investigation for the following behavior:
     // on my machine (Ubuntu 10.04 with ITKv4), having standard error trims the
@@ -198,15 +198,15 @@ QString qSlicerCLIExecutableModuleFactoryItem::runCLIWithXmlArgument()
   QString xmlDescription = cli.readAllStandardOutput();
   if (xmlDescription.isEmpty())
     {
-    this->appendInstantiateErrorString(QString("CLI executable: %1").arg(this->path()));
-    this->appendInstantiateErrorString("Failed to retrieve Xml Description");
+    this->appendInstantiateErrorString(qSlicerCLIModule::tr("CLI executable: %1").arg(this->path()));
+    this->appendInstantiateErrorString(qSlicerCLIModule::tr("Failed to retrieve XML Description"));
     return QString();
     }
   if (!xmlDescription.startsWith("<?xml"))
     {
-    this->appendInstantiateWarningString(QString("CLI executable: %1").arg(this->path()));
-    this->appendInstantiateWarningString(QLatin1String("XML description doesn't start right away."));
-    this->appendInstantiateWarningString(QString("Output before '<?xml' is [%1]").arg(
+    this->appendInstantiateWarningString(qSlicerCLIModule::tr("CLI executable: %1").arg(this->path()));
+    this->appendInstantiateWarningString(qSlicerCLIModule::tr("XML description doesn't start right away."));
+    this->appendInstantiateWarningString(qSlicerCLIModule::tr("Output before '<?xml' is [%1]").arg(
                                            xmlDescription.mid(0, xmlDescription.indexOf("<?xml"))));
     xmlDescription.remove(0, xmlDescription.indexOf("<?xml"));
     }

--- a/Base/QTCLI/qSlicerCLILoadableModuleFactory.cxx
+++ b/Base/QTCLI/qSlicerCLILoadableModuleFactory.cxx
@@ -108,8 +108,8 @@ qSlicerAbstractCoreModule* qSlicerCLILoadableModuleFactoryItem::instanciator()
       }
     else
       {
-      this->appendInstantiateErrorString(QString("CLI description: %1").arg(xmlFilePath));
-      this->appendInstantiateErrorString("Failed to read Xml Description");
+      this->appendInstantiateErrorString(qSlicerCLIModule::tr("CLI description: %1").arg(xmlFilePath));
+      this->appendInstantiateErrorString(qSlicerCLIModule::tr("Failed to read XML Description"));
       return nullptr;
       }
     // Set callback to allow lazy loading of target symbols.
@@ -154,8 +154,8 @@ QString qSlicerCLILoadableModuleFactoryItem::resolveXMLModuleDescriptionSymbol()
 
   if (!xmlDescription)
     {
-    this->appendInstantiateErrorString(QString("CLI loadable: %1").arg(this->path()));
-    this->appendInstantiateErrorString("Failed to retrieve Xml Description");
+    this->appendInstantiateErrorString(qSlicerCLIModule::tr("CLI loadable: %1").arg(this->path()));
+    this->appendInstantiateErrorString(qSlicerCLIModule::tr("Failed to retrieve XML Description"));
     return QString();
     }
   return QString(xmlDescription);
@@ -172,8 +172,8 @@ bool qSlicerCLILoadableModuleFactoryItem::resolveSymbols(ModuleDescription& desc
 
   if (!moduleEntryPoint)
     {
-    this->appendInstantiateErrorString(QString("CLI loadable: %1").arg(this->path()));
-    this->appendInstantiateErrorString("Failed to retrieve Module Entry Point");
+    this->appendInstantiateErrorString(qSlicerCLIModule::tr("CLI loadable: %1").arg(this->path()));
+    this->appendInstantiateErrorString(qSlicerCLIModule::tr("Failed to retrieve Module Entry Point"));
     return false;
     }
 
@@ -233,7 +233,7 @@ bool qSlicerCLILoadableModuleFactoryItem::updateLogo(qSlicerCLILoadableModuleFac
         }
       else
         {
-        item->appendLoadErrorString(QString("Failed to resolve expected symbol '%1'").arg(symbol));
+        item->appendLoadErrorString(qSlicerCLIModule::tr("Failed to resolve expected symbol '%1'").arg(symbol));
         }
       }
     if (resolvedSymbols.count() == 4)

--- a/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
+++ b/Base/QTCLI/qSlicerCLIModuleUIHelper.cxx
@@ -929,7 +929,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createFileTagWidget(const ModuleParame
   const std::vector< std::string > fileExtensionsStd = moduleParameter.GetFileExtensions();
   if (!fileExtensionsStd.empty())
     {
-    QString customFilter("Compatible Files (");
+    QString customFilter(qSlicerCLIModuleUIHelper::tr("Compatible Files") + " (");
     for (std::vector< std::string >::const_iterator it = fileExtensionsStd.begin();
       it != fileExtensionsStd.end(); ++it)
       {
@@ -942,7 +942,7 @@ QWidget* qSlicerCLIModuleUIHelperPrivate::createFileTagWidget(const ModuleParame
     customFilter.append(")");
     fileExtensions << customFilter;
     }
-  fileExtensions << QString("All Files (*.*)");
+  fileExtensions << QString(qSlicerCLIModuleUIHelper::tr("All Files") + " (*.*)");
 
   QWidget* widget = new QWidget;
   ctkPathLineEdit* pathLineEdit =


### PR DESCRIPTION
Some user-visible strings were not marked as translatable.

see https://github.com/Slicer/SlicerLanguagePacks/issues/12