### PR TITLE
Make loadable module title translatable

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -452,6 +452,22 @@ void qSlicerCoreApplicationPrivate::init()
 
   this->createDirectory(q->extensionsInstallPath(), "extensions"); // Make sure the path exists
 
+  this->ApplicationLocaleName = "en_US";
+  this->ApplicationLocale = QLocale(ApplicationLocale);
+#ifdef Slicer_BUILD_I18N_SUPPORT
+  if (q->userSettings()->value("Internationalization/Enabled").toBool())
+    {
+    QString localeName = q->userSettings()->value("language", this->ApplicationLocaleName).toString();
+    if (!localeName.isEmpty())
+      {
+      this->ApplicationLocaleName = localeName;
+      this->ApplicationLocale = QLocale(ApplicationLocale);
+      }
+    // We load the language selected for the application
+    qSlicerCoreApplication::loadLanguage();
+    }
+#endif
+
   // Prevent extensions manager model from displaying popups during startup (don't ask for confirmation)
   bool wasInteractive = model->interactive();
   model->setInteractive(false);
@@ -505,12 +521,6 @@ void qSlicerCoreApplicationPrivate::init()
     applicationUpdateManager->checkForUpdate();
     }
 #endif
-
-  if (q->userSettings()->value("Internationalization/Enabled").toBool())
-    {
-    // We load the language selected for the application
-    qSlicerCoreApplication::loadLanguage();
-    }
 
   // Default VTK fonts do not support Chinese characters. Allow setting custom font files from application settings.
   // Slicer core does not provide GUI to set these fonts yet, but extensions (e.g, LanguagePacks) can provide modules
@@ -2015,7 +2025,7 @@ void qSlicerCoreApplication::loadTranslations(const QString& dir)
   qSlicerCoreApplication * app = qSlicerCoreApplication::application();
   Q_ASSERT(app);
 
-  QStringList qmFiles = qSlicerCoreApplicationPrivate::findTranslationFiles(dir, app->settings()->value("language").toString());
+  QStringList qmFiles = qSlicerCoreApplicationPrivate::findTranslationFiles(dir, app->applicationLocaleName());
 
   foreach(QString qmFile, qmFiles)
     {
@@ -2261,12 +2271,21 @@ QString qSlicerCoreApplication::documentationVersion() const
 // --------------------------------------------------------------------------
 QString qSlicerCoreApplication::documentationLanguage() const
 {
-  QString language = "en";
-  if (this->userSettings()->value("Internationalization/Enabled", false).toBool())
-    {
-    language = this->userSettings()->value("language", language).toString();
-    }
-  return language;
+  return this->applicationLocaleName();
+}
+
+// --------------------------------------------------------------------------
+QString qSlicerCoreApplication::applicationLocaleName() const
+{
+  Q_D(const qSlicerCoreApplication);
+  return d->ApplicationLocaleName;
+}
+
+// --------------------------------------------------------------------------
+QLocale qSlicerCoreApplication::applicationLocale() const
+{
+  Q_D(const qSlicerCoreApplication);
+  return d->ApplicationLocale;
 }
 
 // --------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerCoreApplication.h
+++ b/Base/QTCore/qSlicerCoreApplication.h
@@ -93,9 +93,11 @@ class Q_SLICER_BASE_QTCORE_EXPORT qSlicerCoreApplication : public QApplication
   Q_PROPERTY(QString revision READ revision CONSTANT)
   Q_PROPERTY(int majorVersion READ majorVersion CONSTANT)
   Q_PROPERTY(int minorVersion READ minorVersion CONSTANT)
+  Q_PROPERTY(QLocale applicationLocale READ applicationLocale CONSTANT)
+  Q_PROPERTY(QString applicationLocaleName READ applicationLocaleName CONSTANT)
   Q_PROPERTY(QString documentationBaseUrl READ documentationBaseUrl)
   Q_PROPERTY(QString documentationVersion READ documentationVersion CONSTANT)
-  Q_PROPERTY(QString documentationLanguage READ documentationLanguage)
+  Q_PROPERTY(QString documentationLanguage READ documentationLanguage CONSTANT)
   Q_PROPERTY(QString platform READ platform CONSTANT)
   Q_PROPERTY(QString arch READ arch CONSTANT)
   Q_PROPERTY(QString os READ os CONSTANT)
@@ -455,7 +457,21 @@ public:
 
   /// Return the documentation language that can be used in URLs.
   /// Returns "en" if internationalization is disabled.
+  /// Currently, it is always the same as the name of the application locale name.
+  /// \sa applicationLocaleName
   QString documentationLanguage()const;
+
+  /// Return the locale that is used for displaying localized content to users.
+  /// en_US locale is used if internationalization is disabled.
+  /// \sa applicationLocaleName, QLocale
+  QLocale applicationLocale()const;
+
+  /// Return the locale name that is used for displaying localized content to users.
+  /// en_US locale is used if internationalization is disabled.
+  /// It is different from applicationLocale in that this is just a string (so it cannot be readily
+  /// used for string formatting) and it may specify just a country code without a region.
+  /// \sa applicationLocale, QLocale
+  QString applicationLocaleName()const;
 
   /// Return the documentation base URL.
   /// By default, {documentationbaseurl}/user_guide/modules/{lowercasemodulename}.html

--- a/Base/QTCore/qSlicerCoreApplication_p.h
+++ b/Base/QTCore/qSlicerCoreApplication_p.h
@@ -190,6 +190,9 @@ public:
 
   QProcessEnvironment                         Environment;
 
+  QLocale                                     ApplicationLocale;
+  QString                                     ApplicationLocaleName;
+
 #ifdef Slicer_BUILD_DICOM_SUPPORT
   /// Application-wide database instance
   QSharedPointer<ctkDICOMDatabase>            DICOMDatabase;

--- a/Base/QTGUI/qSlicerModuleFinderDialog.cxx
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.cxx
@@ -77,6 +77,9 @@ void qSlicerModuleFinderDialogPrivate::init()
   // Hide testing modules by default
   filterModel->setShowTesting(false);
 
+  // Set default search role (not full text)
+  q->setSearchInAllText(false);
+
   QObject::connect(this->SearchInAllTextCheckBox, SIGNAL(toggled(bool)),
     q, SLOT(setSearchInAllText(bool)));
   QObject::connect(this->ShowBuiltInCheckBox, SIGNAL(toggled(bool)),
@@ -382,13 +385,13 @@ void qSlicerModuleFinderDialog::setSearchInAllText(bool searchAll)
   qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();
   if (searchAll)
     {
-    // qModuleListViewPrivate::FullTextSearchRole = Qt::UserRole + 4
-    filterModel->setFilterRole(Qt::UserRole + 4);
+    // qModuleListViewPrivate::FullTextSearchRole = Qt::UserRole + 5
+    filterModel->setFilterRole(Qt::UserRole + 5);
     }
   else
     {
-    // search in displayed module title
-    filterModel->setFilterRole(Qt::DisplayRole);
+    // qModuleListViewPrivate::SearchRole = Qt::UserRole + 4
+    filterModel->setFilterRole(Qt::UserRole + 4);
     }
   d->makeSelectedItemVisible();
 }

--- a/Base/QTGUI/qSlicerModulesListView.cxx
+++ b/Base/QTGUI/qSlicerModulesListView.cxx
@@ -56,7 +56,8 @@ public:
     IsBuiltInRole = Qt::UserRole + 1,
     IsTestingRole = Qt::UserRole + 2,
     IsHiddenRole = Qt::UserRole + 3,
-    FullTextSearchRole = Qt::UserRole + 4
+    SearchRole = Qt::UserRole + 4,
+    FullTextSearchRole = Qt::UserRole + 5
     };
 
   qSlicerModulesListViewPrivate(qSlicerModulesListView& object);
@@ -171,18 +172,25 @@ void qSlicerModulesListViewPrivate::updateItem(QStandardItem* item)
     QTextDocument acknowledgementTextDoc;
     acknowledgementTextDoc.setHtml(coreModule->acknowledgementText());
     QString contributors = coreModule->contributors().join(",");
-    QString searchText = QString("%1 %2 %3 %4 %5")
+    // Search text includes module name and title. Including module title is important to allow
+    // easier finding modules when using non-English GUI.
+    QString searchText = QString("%1 %2")
+      .arg(coreModule->title())
+      .arg(moduleName);
+    item->setData(searchText, qSlicerModulesListViewPrivate::SearchRole);
+    QString fullTextSearchText = QString("%1 %2 %3 %4 %5")
       .arg(coreModule->title())
       .arg(moduleName)
       .arg(helpTextDoc.toPlainText())
       .arg(acknowledgementTextDoc.toPlainText())
       .arg(contributors);
-    item->setData(searchText, qSlicerModulesListViewPrivate::FullTextSearchRole);
+    item->setData(fullTextSearchText, qSlicerModulesListViewPrivate::FullTextSearchRole);
     }
   else
     {
     item->setText(moduleName);
     item->setToolTip("");
+    item->setData(moduleName, qSlicerModulesListViewPrivate::SearchRole);
     item->setData(moduleName, qSlicerModulesListViewPrivate::FullTextSearchRole);
     }
 

--- a/Extensions/Testing/LoadableExtensionTemplate/LoadableModuleTemplate/CMakeLists.txt
+++ b/Extensions/Testing/LoadableExtensionTemplate/LoadableModuleTemplate/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME LoadableModuleTemplate)
-set(MODULE_TITLE ${MODULE_NAME})
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -48,7 +47,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Extensions/Testing/LoadableExtensionTemplate/LoadableModuleTemplate/qSlicerLoadableModuleTemplateModule.h
+++ b/Extensions/Testing/LoadableExtensionTemplate/LoadableModuleTemplate/qSlicerLoadableModuleTemplateModule.h
@@ -40,7 +40,7 @@ public:
   explicit qSlicerLoadableModuleTemplateModule(QObject *parent=0);
   ~qSlicerLoadableModuleTemplateModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("qSlicerLoadableModuleTemplateModule"));
 
   QString helpText()const override;
   QString acknowledgementText()const override;

--- a/Extensions/Testing/SuperBuildExtensionTemplate/SuperLoadableModuleTemplate/CMakeLists.txt
+++ b/Extensions/Testing/SuperBuildExtensionTemplate/SuperLoadableModuleTemplate/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME SuperLoadableModuleTemplate)
-set(MODULE_TITLE ${MODULE_NAME})
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -48,7 +47,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Extensions/Testing/SuperBuildExtensionTemplate/SuperLoadableModuleTemplate/qSlicerSuperLoadableModuleTemplateModule.h
+++ b/Extensions/Testing/SuperBuildExtensionTemplate/SuperLoadableModuleTemplate/qSlicerSuperLoadableModuleTemplateModule.h
@@ -40,7 +40,7 @@ public:
   explicit qSlicerSuperLoadableModuleTemplateModule(QObject *parent=0);
   ~qSlicerSuperLoadableModuleTemplateModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("qSlicerSuperLoadableModuleTemplateModule"));
 
   QString helpText()const override;
   QString acknowledgementText()const override;

--- a/Modules/Loadable/Annotations/CMakeLists.txt
+++ b/Modules/Loadable/Annotations/CMakeLists.txt
@@ -1,6 +1,5 @@
 #-----------------------------------------------------------------------------
 set(MODULE_NAME "Annotations")
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -54,7 +53,6 @@ set(MODULE_TARGET_LIBRARIES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Annotations/qSlicerAnnotationsModule.h
+++ b/Modules/Loadable/Annotations/qSlicerAnnotationsModule.h
@@ -39,7 +39,7 @@ public:
   /// Specify editable node types
   QStringList associatedNodeTypes()const override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Annotations"));
 
   /// Open the screen capture dialog
   void grabSnapShot();

--- a/Modules/Loadable/Cameras/CMakeLists.txt
+++ b/Modules/Loadable/Cameras/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Cameras)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -43,7 +42,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Cameras/qSlicerCamerasModule.h
+++ b/Modules/Loadable/Cameras/qSlicerCamerasModule.h
@@ -45,7 +45,7 @@ public:
   QStringList categories()const override;
   QIcon icon()const override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Cameras"));
 
   /// Return help/acknowledgement text
   QString helpText()const override;

--- a/Modules/Loadable/Colors/CMakeLists.txt
+++ b/Modules/Loadable/Colors/CMakeLists.txt
@@ -1,6 +1,5 @@
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Colors)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -63,7 +62,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Colors/qSlicerColorsModule.h
+++ b/Modules/Loadable/Colors/qSlicerColorsModule.h
@@ -45,7 +45,7 @@ public:
   QStringList categories()const override;
   QIcon icon()const override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Colors"));
 
   /// Return help/acknowledgement text
   QString helpText()const override;

--- a/Modules/Loadable/CropVolume/CMakeLists.txt
+++ b/Modules/Loadable/CropVolume/CMakeLists.txt
@@ -1,11 +1,8 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME CropVolume)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
-
-set(MODULE_TITLE "Crop Volume")
 
 #-----------------------------------------------------------------------------
 add_subdirectory(MRML)
@@ -51,7 +48,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/CropVolume/qSlicerCropVolumeModule.h
+++ b/Modules/Loadable/CropVolume/qSlicerCropVolumeModule.h
@@ -22,7 +22,7 @@ public:
   explicit qSlicerCropVolumeModule(QObject *parent=nullptr);
   ~qSlicerCropVolumeModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Crop Volume"));
 
   /// Return a custom icon for the module
   QIcon icon()const override;

--- a/Modules/Loadable/Data/CMakeLists.txt
+++ b/Modules/Loadable/Data/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Data)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -61,7 +60,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Data/qSlicerDataModule.h
+++ b/Modules/Loadable/Data/qSlicerDataModule.h
@@ -47,7 +47,7 @@ public:
   QStringList categories()const override;
   QStringList dependencies()const override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Data"));
 
   /// Return help/acknowledgement text
   QString helpText()const override;

--- a/Modules/Loadable/Markups/CMakeLists.txt
+++ b/Modules/Loadable/Markups/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME "Markups")
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -83,7 +82,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Markups/qSlicerMarkupsModule.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModule.h
@@ -53,7 +53,7 @@ public:
   explicit qSlicerMarkupsModule(QObject *parent=nullptr);
   ~qSlicerMarkupsModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Markups"));
 
   /// Help to use the module
   QString helpText()const override;

--- a/Modules/Loadable/Models/CMakeLists.txt
+++ b/Modules/Loadable/Models/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Models)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -67,7 +66,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Models/qSlicerModelsModule.h
+++ b/Modules/Loadable/Models/qSlicerModelsModule.h
@@ -45,7 +45,7 @@ public:
   explicit qSlicerModelsModule(QObject *parent=nullptr);
   ~qSlicerModelsModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Plots"));
 
   QString helpText()const override;
   QString acknowledgementText()const override;

--- a/Modules/Loadable/Plots/CMakeLists.txt
+++ b/Modules/Loadable/Plots/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Plots)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -54,7 +53,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Plots/qSlicerPlotsModule.h
+++ b/Modules/Loadable/Plots/qSlicerPlotsModule.h
@@ -44,7 +44,7 @@ public:
   explicit qSlicerPlotsModule(QObject *parent=nullptr);
   ~qSlicerPlotsModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Plots"));
 
   QIcon icon()const override;
   QString helpText()const override;

--- a/Modules/Loadable/Reformat/CMakeLists.txt
+++ b/Modules/Loadable/Reformat/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Reformat)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -46,7 +45,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Reformat/qSlicerReformatModule.h
+++ b/Modules/Loadable/Reformat/qSlicerReformatModule.h
@@ -42,7 +42,7 @@ public:
   explicit qSlicerReformatModule(QObject *parent=nullptr);
   ~qSlicerReformatModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Reformat"));
 
   /// Help to use the module
   QString helpText()const override;

--- a/Modules/Loadable/SceneViews/CMakeLists.txt
+++ b/Modules/Loadable/SceneViews/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------
 set(MODULE_NAME SceneViews)
-set(MODULE_TITLE "Scene Views")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -60,7 +59,6 @@ set(MODULE_TARGET_LIBRARIES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/SceneViews/qSlicerSceneViewsModule.h
+++ b/Modules/Loadable/SceneViews/qSlicerSceneViewsModule.h
@@ -37,7 +37,7 @@ public:
   /// Specify editable node types
   QStringList associatedNodeTypes()const override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Views"));
 
 public slots:
     /// a public slot to open up the scene view capture

--- a/Modules/Loadable/Segmentations/CMakeLists.txt
+++ b/Modules/Loadable/Segmentations/CMakeLists.txt
@@ -1,6 +1,5 @@
 #-----------------------------------------------------------------------------
 set(MODULE_NAME "Segmentations")
-set(MODULE_TITLE ${MODULE_NAME})
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -80,7 +79,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsModule.h
@@ -45,7 +45,7 @@ public:
   explicit qSlicerSegmentationsModule(QObject *parent=nullptr);
   ~qSlicerSegmentationsModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Segmentations"));
 
   /// Help to use the module
   QString helpText()const override;

--- a/Modules/Loadable/Sequences/CMakeLists.txt
+++ b/Modules/Loadable/Sequences/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Sequences)
-set(MODULE_TITLE "Sequences")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -52,7 +51,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Sequences/qSlicerSequencesModule.h
+++ b/Modules/Loadable/Sequences/qSlicerSequencesModule.h
@@ -58,7 +58,7 @@ public:
   explicit qSlicerSequencesModule(QObject *parent=0);
   ~qSlicerSequencesModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Sequences"));
 
   QString helpText()const override;
   QString acknowledgementText()const override;

--- a/Modules/Loadable/SlicerWelcome/CMakeLists.txt
+++ b/Modules/Loadable/SlicerWelcome/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Welcome)
-set(MODULE_TITLE "Welcome to Slicer")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -40,7 +39,6 @@ set(MODULE_TARGET_LIBRARIES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/SlicerWelcome/qSlicerWelcomeModule.h
+++ b/Modules/Loadable/SlicerWelcome/qSlicerWelcomeModule.h
@@ -45,7 +45,7 @@ public:
   qSlicerWelcomeModule(QObject *parent=nullptr);
   ~qSlicerWelcomeModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Welcome to Slicer"));
 
   QStringList categories()const override;
   QIcon icon()const override;

--- a/Modules/Loadable/SubjectHierarchy/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/CMakeLists.txt
@@ -1,6 +1,5 @@
 #-----------------------------------------------------------------------------
 set(MODULE_NAME "SubjectHierarchy")
-set(MODULE_TITLE "Subject Hierarchy")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -48,7 +47,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/qSlicerSubjectHierarchyAbstractPlugin.h
@@ -71,6 +71,7 @@ class Q_SLICER_MODULE_SUBJECTHIERARCHY_WIDGETS_EXPORT qSlicerSubjectHierarchyAbs
   /// Cannot be empty.
   /// \sa name()
   Q_PROPERTY(QString name READ name WRITE setName)
+  Q_PROPERTY(QString helpText READ helpText)
 
 public:
   typedef QObject Superclass;
@@ -97,7 +98,7 @@ public:
 
   /// Get icon of an owned subject hierarchy item
   /// \return Icon to set, empty icon if nothing to set
-  virtual QIcon icon(vtkIdType itemID);
+  Q_INVOKABLE virtual QIcon icon(vtkIdType itemID);
 
   /// Get visibility icon for a visibility state
   Q_INVOKABLE virtual QIcon visibilityIcon(int visible);
@@ -110,7 +111,7 @@ public:
 
   /// Generate displayed name for the owned subject hierarchy item corresponding to its role.
   /// The default implementation returns the associated data node's name if any, otherwise the item name
-  virtual QString displayedItemName(vtkIdType itemID)const;
+  Q_INVOKABLE virtual QString displayedItemName(vtkIdType itemID)const;
 
   /// Generate tooltip for a owned subject hierarchy item
   Q_INVOKABLE virtual QString tooltip(vtkIdType itemID)const;
@@ -184,7 +185,7 @@ public:
   ///   Default value is invalid. In that case the parent will be ignored, the confidence numbers are got based on the to-be child node alone.
   /// \return Floating point confidence number between 0 and 1, where 0 means that the plugin cannot handle the
   ///   node, and 1 means that the plugin is the only one that can handle the node (by node type or identifier attribute)
-  virtual double canAddNodeToSubjectHierarchy(
+  Q_INVOKABLE virtual double canAddNodeToSubjectHierarchy(
     vtkMRMLNode* node, vtkIdType parentItemID=vtkMRMLSubjectHierarchyNode::INVALID_ITEM_ID )const;
 
   /// Add a node to subject hierarchy under a specified parent. This is basically a convenience function to
@@ -192,7 +193,7 @@ public:
   /// \param node Node to add to subject hierarchy
   /// \param parentItemID Parent item of the added node
   /// \return True if added successfully, false otherwise
-  virtual bool addNodeToSubjectHierarchy(vtkMRMLNode* node, vtkIdType parentItemID);
+  Q_INVOKABLE virtual bool addNodeToSubjectHierarchy(vtkMRMLNode* node, vtkIdType parentItemID);
 
   /// Determines if a subject hierarchy item can be reparented in the hierarchy using the current plugin,
   /// and gets a confidence value for the reparented item.
@@ -202,17 +203,17 @@ public:
   /// \param parentItemID Prospective parent of the item to reparent.
   /// \return Floating point confidence number between 0 and 1, where 0 means that the plugin cannot handle the
   ///   item, and 1 means that the plugin is the only one that can handle the item
-  virtual double canReparentItemInsideSubjectHierarchy(vtkIdType itemID, vtkIdType parentItemID)const;
+  Q_INVOKABLE virtual double canReparentItemInsideSubjectHierarchy(vtkIdType itemID, vtkIdType parentItemID)const;
 
   /// Reparent an item that was already in the subject hierarchy under a new parent.
   /// \return True if reparented successfully, false otherwise
-  virtual bool reparentItemInsideSubjectHierarchy(vtkIdType itemID, vtkIdType parentItemID);
+  Q_INVOKABLE virtual bool reparentItemInsideSubjectHierarchy(vtkIdType itemID, vtkIdType parentItemID);
 
   /// Show an item in a selected view.
   /// List of all other item IDs that will be shown in this request is also provided, as it may help
   /// in determining the optimal view setup. For example, if multiple volume nodes will be shown
   /// then the first node may be displayed as background and the second as foreground.
-  virtual bool showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow);
+  Q_INVOKABLE virtual bool showItemInView(vtkIdType itemID, vtkMRMLAbstractViewNode* viewNode, vtkIdList* allItemsToShow);
 
 // Utility functions
 public:

--- a/Modules/Loadable/SubjectHierarchy/qSlicerSubjectHierarchyModule.h
+++ b/Modules/Loadable/SubjectHierarchy/qSlicerSubjectHierarchyModule.h
@@ -48,7 +48,7 @@ public:
   explicit qSlicerSubjectHierarchyModule(QObject *parent=nullptr);
   ~qSlicerSubjectHierarchyModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Subject Hierarchy"));
 
   /// Help to use the module
   QString helpText()const override;

--- a/Modules/Loadable/Tables/CMakeLists.txt
+++ b/Modules/Loadable/Tables/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Tables)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -57,7 +56,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Tables/qSlicerTablesModule.h
+++ b/Modules/Loadable/Tables/qSlicerTablesModule.h
@@ -44,7 +44,7 @@ public:
   explicit qSlicerTablesModule(QObject *parent=nullptr);
   ~qSlicerTablesModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Tables"));
 
   QIcon icon()const override;
   QString helpText()const override;

--- a/Modules/Loadable/Terminologies/CMakeLists.txt
+++ b/Modules/Loadable/Terminologies/CMakeLists.txt
@@ -1,6 +1,5 @@
 #-----------------------------------------------------------------------------
 set(MODULE_NAME "Terminologies")
-set(MODULE_TITLE ${MODULE_NAME})
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -47,7 +46,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Terminologies/qSlicerTerminologiesModule.h
+++ b/Modules/Loadable/Terminologies/qSlicerTerminologiesModule.h
@@ -44,7 +44,7 @@ public:
   explicit qSlicerTerminologiesModule(QObject *parent=nullptr);
   ~qSlicerTerminologiesModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("Terminologies"));
 
   /// Help to use the module
   QString helpText()const override;

--- a/Modules/Loadable/Texts/CMakeLists.txt
+++ b/Modules/Loadable/Texts/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Texts)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -57,7 +56,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Texts/qSlicerTextsModule.h
+++ b/Modules/Loadable/Texts/qSlicerTextsModule.h
@@ -52,7 +52,7 @@ public:
   QStringList dependencies()const override;
 
   /// Display name for the module
-  qSlicerGetTitleMacro("Texts");
+  qSlicerGetTitleMacro(tr("Texts"));
 
   /// Help text of the module
   QString helpText()const override;

--- a/Modules/Loadable/Transforms/CMakeLists.txt
+++ b/Modules/Loadable/Transforms/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Transforms)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -58,7 +57,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Transforms/qSlicerTransformsModule.h
+++ b/Modules/Loadable/Transforms/qSlicerTransformsModule.h
@@ -52,7 +52,7 @@ public:
   QStringList dependencies()const override;
 
   /// Display name for the module
-  qSlicerGetTitleMacro("Transforms");
+  qSlicerGetTitleMacro(tr("Transforms"));
 
   /// Help text of the module
   QString helpText()const override;

--- a/Modules/Loadable/Units/CMakeLists.txt
+++ b/Modules/Loadable/Units/CMakeLists.txt
@@ -20,7 +20,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Units)
-set(MODULE_TITLE ${MODULE_NAME})
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -66,7 +65,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Units/qSlicerUnitsModule.h
+++ b/Modules/Loadable/Units/qSlicerUnitsModule.h
@@ -44,7 +44,7 @@ public:
   explicit qSlicerUnitsModule(QObject *parent=nullptr);
   ~qSlicerUnitsModule() override;
 
-  qSlicerGetTitleMacro("Units");
+  qSlicerGetTitleMacro(tr("Units"));
 
   QString helpText()const override;
   QString acknowledgementText()const override;

--- a/Modules/Loadable/ViewControllers/CMakeLists.txt
+++ b/Modules/Loadable/ViewControllers/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME ViewControllers)
-set(MODULE_TITLE "View Controllers")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -44,7 +43,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.h
+++ b/Modules/Loadable/ViewControllers/qSlicerViewControllersModule.h
@@ -47,7 +47,7 @@ public:
   qSlicerViewControllersModule(QObject *parent=nullptr);
   ~qSlicerViewControllersModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("View Controllers"));
 
   QStringList categories()const override;
   QIcon icon()const override;

--- a/Modules/Loadable/VolumeRendering/CMakeLists.txt
+++ b/Modules/Loadable/VolumeRendering/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME VolumeRendering)
-set(MODULE_TITLE "Volume Rendering")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -65,7 +64,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.h
+++ b/Modules/Loadable/VolumeRendering/SubjectHierarchyPlugins/qSlicerSubjectHierarchyVolumeRenderingPlugin.h
@@ -46,7 +46,7 @@ public:
 
 public:
   /// Set volume rendering module logic. Required for accessing display nodes and setting up volume rendering related nodes.
-  void setVolumeRenderingLogic(vtkSlicerVolumeRenderingLogic* volumeRenderingLogic);
+  Q_INVOKABLE void setVolumeRenderingLogic(vtkSlicerVolumeRenderingLogic* volumeRenderingLogic);
 
   /// Get visibility context menu item actions to add to tree view.
   /// These item visibility context menu actions can be shown in the implementations of \sa showVisibilityContextMenuActionsForItem
@@ -64,7 +64,7 @@ public:
 
   /// Show/hide volume rendering in a view.
   /// If viewNode is nullptr then it is displayed in all 3D views in the current layout.
-  bool showVolumeRendering(bool show, vtkIdType itemID, vtkMRMLViewNode* viewNode=nullptr);
+  Q_INVOKABLE bool showVolumeRendering(bool show, vtkIdType itemID, vtkMRMLViewNode* viewNode=nullptr);
 
 protected slots:
   /// Toggle volume rendering option for current volume item

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.cxx
@@ -70,6 +70,12 @@ qSlicerVolumeRenderingModule::qSlicerVolumeRenderingModule(QObject* _parent)
 qSlicerVolumeRenderingModule::~qSlicerVolumeRenderingModule() = default;
 
 //-----------------------------------------------------------------------------
+QString qSlicerVolumeRenderingModule::title()const
+{
+  return tr("Volume Rendering");
+}
+
+//-----------------------------------------------------------------------------
 QString qSlicerVolumeRenderingModule::helpText()const
 {
   QString help = QString(

--- a/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.h
+++ b/Modules/Loadable/VolumeRendering/qSlicerVolumeRenderingModule.h
@@ -45,8 +45,8 @@ public:
   explicit qSlicerVolumeRenderingModule(QObject *parent=nullptr);
   ~qSlicerVolumeRenderingModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
-
+  /// Title of the module
+  QString title()const override;
   /// Help of the module
   QString helpText()const override;
   /// Acknowledgement for the module

--- a/Modules/Loadable/Volumes/CMakeLists.txt
+++ b/Modules/Loadable/Volumes/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME Volumes)
-set(MODULE_TITLE "${MODULE_NAME}")
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -66,7 +65,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModule.cxx
@@ -63,6 +63,12 @@ qSlicerVolumesModule::qSlicerVolumesModule(QObject* _parent)
 qSlicerVolumesModule::~qSlicerVolumesModule() = default;
 
 //-----------------------------------------------------------------------------
+QString qSlicerVolumesModule::title()const
+{
+  return tr("Volumes");
+}
+
+//-----------------------------------------------------------------------------
 QString qSlicerVolumesModule::helpText()const
 {
   QString help = tr(

--- a/Modules/Loadable/Volumes/qSlicerVolumesModule.h
+++ b/Modules/Loadable/Volumes/qSlicerVolumesModule.h
@@ -49,7 +49,7 @@ public:
   QIcon icon()const override;
   QStringList categories()const override;
   QStringList dependencies()const override;
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  QString title()const override;
 
 protected:
   /// Initialize the module. Register the volumes reader/writer

--- a/Utilities/Templates/Modules/Loadable/CMakeLists.txt
+++ b/Utilities/Templates/Modules/Loadable/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME TemplateKey)
-set(MODULE_TITLE ${MODULE_NAME})
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -48,7 +47,6 @@ set(MODULE_RESOURCES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Utilities/Templates/Modules/Loadable/qSlicerTemplateKeyModule.h
+++ b/Utilities/Templates/Modules/Loadable/qSlicerTemplateKeyModule.h
@@ -40,7 +40,7 @@ public:
   explicit qSlicerTemplateKeyModule(QObject *parent=nullptr);
   ~qSlicerTemplateKeyModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("TemplateKey"));
 
   QString helpText()const override;
   QString acknowledgementText()const override;

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/CMakeLists.txt
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/CMakeLists.txt
@@ -1,6 +1,5 @@
 #-----------------------------------------------------------------------------
 set(MODULE_NAME "TemplateKey")
-set(MODULE_TITLE ${MODULE_NAME})
 
 string(TOUPPER ${MODULE_NAME} MODULE_NAME_UPPER)
 
@@ -44,7 +43,6 @@ set(MODULE_TARGET_LIBRARIES
 #-----------------------------------------------------------------------------
 slicerMacroBuildLoadableModule(
   NAME ${MODULE_NAME}
-  TITLE ${MODULE_TITLE}
   EXPORT_DIRECTIVE ${MODULE_EXPORT_DIRECTIVE}
   INCLUDE_DIRECTORIES ${MODULE_INCLUDE_DIRECTORIES}
   SRCS ${MODULE_SRCS}

--- a/Utilities/Templates/Modules/LoadableCustomMarkups/qSlicerTemplateKeyModule.h
+++ b/Utilities/Templates/Modules/LoadableCustomMarkups/qSlicerTemplateKeyModule.h
@@ -40,7 +40,7 @@ public:
   explicit qSlicerTemplateKeyModule(QObject *parent=nullptr);
   ~qSlicerTemplateKeyModule() override;
 
-  qSlicerGetTitleMacro(QTMODULE_TITLE);
+  qSlicerGetTitleMacro(tr("TemplateKey"));
 
   bool isHidden() const override;
   QString helpText()const override;


### PR DESCRIPTION
This pull request changes how loadable module titles are specified (they are now set in the C++ source code instead of in CMakeLists.txt) to make them translatable. The pull request also contains a few related minor fixes for the problems found during developing this.