### PR TITLE
COMP: Fix vtkMarkupsAnnotationSceneTest build with SceneViews module disabled (part2)

### DIFF
--- a/Modules/Loadable/Markups/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Markups/Testing/Cxx/CMakeLists.txt
@@ -37,17 +37,31 @@ endif()
 # Include dirs
 # --------------------------------------------------------------------------
 set(KIT_TEST_INCLUDE_DIRS
-  ${vtkSlicerSceneViewsModuleLogic_SOURCE_DIR}
-  ${vtkSlicerSceneViewsModuleLogic_BINARY_DIR}
   )
+
+if(_build_scene_views_module)
+  list(APPEND KIT_TEST_INCLUDE_DIRS
+    ${vtkSlicerSceneViewsModuleLogic_SOURCE_DIR}
+    ${vtkSlicerSceneViewsModuleLogic_BINARY_DIR}
+    )
+endif()
+
+#-----------------------------------------------------------------------------
+set(KIT_TEST_TARGET_LIBRARIES
+  vtkSlicerAnnotationsModuleLogic
+  )
+
+if(_build_scene_views_module)
+  list(APPEND KIT_TEST_TARGET_LIBRARIES
+    vtkSlicerSceneViewsModuleLogic
+    )
+endif()
 
 #-----------------------------------------------------------------------------
 slicerMacroConfigureModuleCxxTestDriver(
   NAME ${KIT}
   SOURCES ${KIT_TEST_SRCS}
-  TARGET_LIBRARIES
-    vtkSlicerAnnotationsModuleLogic
-    vtkSlicerSceneViewsModuleLogic
+  TARGET_LIBRARIES ${KIT_TEST_TARGET_LIBRARIES}
   INCLUDE_DIRECTORIES ${KIT_TEST_INCLUDE_DIRS}
   WITH_VTK_DEBUG_LEAKS_CHECK
   WITH_VTK_ERROR_OUTPUT_CHECK


### PR DESCRIPTION
This is a follow-up of d4723511c effectively fixing the build by ensuring the SceneViews module logic library is not linked against the Markups tests.

This further improve change initially integrated in:
* https://github.com/Slicer/Slicer/pull/6790