### PR TITLE
BUG: Create non-existing segments in ImportLabelmapToSegmentationNode

### DIFF
--- a/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
+++ b/Modules/Loadable/Segmentations/Logic/vtkSlicerSegmentationsModuleLogic.cxx
@@ -1625,7 +1625,15 @@ bool vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode(
     vtkSegment* segment = segmentationNode->GetSegmentation()->GetSegment(segmentId);
     if (!segment)
       {
-      continue;
+      vtkNew<vtkSegment> newSegment;
+      newSegment->SetName(segmentId.c_str());
+      segment = newSegment;
+      if (!segmentationNode->GetSegmentation()->AddSegment(newSegment, segmentId))
+        {
+        vtkErrorWithObjectMacro(segmentationNode, "vtkSlicerSegmentationsModuleLogic::ImportLabelmapToSegmentationNode: "
+          "Could not add segment");
+        return false;
+        }
       }
 
     // Clear current content of the segment (before setting new label)


### PR DESCRIPTION
Previously ImportLabelmapToSegmentationNode would only import segments if the specified list of segment IDs matched pre-existing segments, and ignore other segments. This commit will insert new segments that don't match an existing segment ID.

See https://discourse.slicer.org/t/slicer-modules-segmentations-logic-importlabelmaptosegmentationnode-not-workign-with-given-segmentids/27998.