### PR TITLE
BUG: Update vtkAddon to include python module name

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,7 +202,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG fb7edc86fc16ace43398f6743eff5a47f8ca0328
+  GIT_TAG 0bcff8277cde13edc9033d2cfe5697e3036fbcd7
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)


### PR DESCRIPTION
The class module names (cls.__module__) for classes wrapped with this wrapping were incorrect. For example, vtkAddonMathUtilities.__module__ returns "vtkAddon", while the actual python package is "vtkAddonPython".

This updates module names to have the Python suffix. See Slicer/vtkAddon#34

List of vtkAddon changes:

```
$ git shortlog fb7edc86f..0bcff82 --no-merges
Connor Bowley (1):
      BUG: Fix Python module names

David Allemang (2):
      COMP: Report error on wrapping empty KIT_SRCS
      STYLE: Update CMakeLists.txt sorting values in vtkAddon_SRCS list

Jean-Christophe Fillion-Robin (1):
      COMP: vtkMacroKitPythonWrap: Remove obsolete use of PYTHON_INCLUDE_PATH
```