### PR TITLE
ENH: Allow line/angle Markups line visibility if control points hidden

### DIFF
--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerAngleRepresentation3D.cxx
@@ -211,10 +211,8 @@ void vtkSlicerAngleRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigne
   this->TubeFilter->SetRadius(diameter * 0.5);
   this->ArcTubeFilter->SetRadius(diameter * 0.5);
 
-  bool lineVisibility = this->GetAllControlPointsVisible();
-
-  this->LineActor->SetVisibility(lineVisibility);
-  this->ArcActor->SetVisibility(lineVisibility && markupsNode->GetNumberOfDefinedControlPoints(true) == 3);
+  this->LineActor->SetVisibility(true);
+  this->ArcActor->SetVisibility(markupsNode->GetNumberOfDefinedControlPoints(true) == 3);
   this->LineOccludedActor->SetVisibility(this->MarkupsDisplayNode && this->LineActor->GetVisibility() && this->MarkupsDisplayNode->GetOccludedVisibility());
   this->ArcOccludedActor->SetVisibility(this->MarkupsDisplayNode && this->ArcActor->GetVisibility() && this->MarkupsDisplayNode->GetOccludedVisibility());
 

--- a/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
+++ b/Modules/Loadable/Markups/VTKWidgets/vtkSlicerLineRepresentation3D.cxx
@@ -198,7 +198,7 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
     this->MarkupsDisplayNode->GetLineDiameter() : this->ControlPointSize * this->MarkupsDisplayNode->GetLineThickness() );
   this->TubeFilter->SetRadius(diameter * 0.5);
 
-  this->LineActor->SetVisibility(this->GetAllControlPointsVisible() && markupsNode->GetNumberOfDefinedControlPoints(true) == 2);
+  this->LineActor->SetVisibility(markupsNode->GetNumberOfDefinedControlPoints(true) == 2);
   int controlPointType = Active;
   if (this->MarkupsDisplayNode->GetActiveComponentType() != vtkMRMLMarkupsDisplayNode::ComponentLine)
     {
@@ -212,9 +212,7 @@ void vtkSlicerLineRepresentation3D::UpdateFromMRML(vtkMRMLNode* caller, unsigned
     && this->LineActor->GetVisibility()
     && this->MarkupsDisplayNode->GetOccludedVisibility());
 
-  if (markupsNode->GetNumberOfDefinedControlPoints(true) == 2 && this->MarkupsDisplayNode->GetPropertiesLabelVisibility()
-    && (this->GetAllControlPointsVisible()
-      || (this->MarkupsDisplayNode->GetOccludedVisibility() && this->MarkupsDisplayNode->GetOccludedOpacity()>0.0)))
+  if (markupsNode->GetNumberOfDefinedControlPoints(true) == 2 && this->MarkupsDisplayNode->GetPropertiesLabelVisibility())
     {
     this->TextActor->SetVisibility(true);
     double p1[3] = { 0.0 };


### PR DESCRIPTION
Previously, the line/arc in line and angle Markups was forced to be hidden if the visibility of any of the control points was disabled. This commit removes the GetAllControlPointsVisible() requirement so that line/angle markups can be displayed even when some of the control points are hidden.