### PR TITLE
Improve module finder filtering

### DIFF
--- a/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
+++ b/Base/QTGUI/qSlicerModuleFactoryFilterModel.cxx
@@ -74,7 +74,7 @@ void qSlicerModuleFactoryFilterModelPrivate::decodeDataRecursive(QDataStream &st
 }
 
 // --------------------------------------------------------------------------
-// qSlicerModulesListViewPrivate methods
+// qSlicerModuleFactoryFilterModelPrivate methods
 
 // --------------------------------------------------------------------------
 qSlicerModuleFactoryFilterModelPrivate::qSlicerModuleFactoryFilterModelPrivate(qSlicerModuleFactoryFilterModel& object)
@@ -324,24 +324,21 @@ bool qSlicerModuleFactoryFilterModel::filterAcceptsRow(int sourceRow, const QMod
     }
   if (!d->ShowBuiltIn)
     {
-    // qSlicerModulesListViewPrivate::IsBuiltInRole = Qt::UserRole+1
-    if (this->sourceModel()->data(sourceIndex, Qt::UserRole+1).toBool())
+    if (this->sourceModel()->data(sourceIndex, qSlicerModuleFactoryFilterModel::IsBuiltInRole).toBool())
       {
       return false;
       }
     }
   if (!d->ShowTesting)
     {
-    // qSlicerModulesListViewPrivate::IsTestingRole = Qt::UserRole+2
-    if (this->sourceModel()->data(sourceIndex, Qt::UserRole+2).toBool())
+    if (this->sourceModel()->data(sourceIndex, qSlicerModuleFactoryFilterModel::IsTestingRole).toBool())
       {
       return false;
       }
     }
   if (!d->ShowHidden)
     {
-    // qSlicerModulesListViewPrivate::IsHiddenRole = Qt::UserRole+3
-    if (this->sourceModel()->data(sourceIndex, Qt::UserRole+3).toBool())
+    if (this->sourceModel()->data(sourceIndex, qSlicerModuleFactoryFilterModel::IsHiddenRole).toBool())
       {
       return false;
       }

--- a/Base/QTGUI/qSlicerModuleFactoryFilterModel.h
+++ b/Base/QTGUI/qSlicerModuleFactoryFilterModel.h
@@ -59,6 +59,16 @@ public:
   /// Superclass typedef
   typedef QSortFilterProxyModel Superclass;
 
+  enum ModuleFactoryUserRoles
+    {
+    ModuleNameRole = Qt::UserRole,
+    IsBuiltInRole = Qt::UserRole + 1,
+    IsTestingRole = Qt::UserRole + 2,
+    IsHiddenRole = Qt::UserRole + 3,
+    SearchRole = Qt::UserRole + 4,
+    FullTextSearchRole = Qt::UserRole + 5
+    };
+
   /// Constructor
   explicit qSlicerModuleFactoryFilterModel(QObject* parent = nullptr);
 

--- a/Base/QTGUI/qSlicerModuleFinderDialog.cxx
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.cxx
@@ -385,13 +385,11 @@ void qSlicerModuleFinderDialog::setSearchInAllText(bool searchAll)
   qSlicerModuleFactoryFilterModel* filterModel = d->ModuleListView->filterModel();
   if (searchAll)
     {
-    // qModuleListViewPrivate::FullTextSearchRole = Qt::UserRole + 5
-    filterModel->setFilterRole(Qt::UserRole + 5);
+    filterModel->setFilterRole(qSlicerModuleFactoryFilterModel::FullTextSearchRole);
     }
   else
     {
-    // qModuleListViewPrivate::SearchRole = Qt::UserRole + 4
-    filterModel->setFilterRole(Qt::UserRole + 4);
+    filterModel->setFilterRole(qSlicerModuleFactoryFilterModel::SearchRole);
     }
   d->makeSelectedItemVisible();
 }

--- a/Base/QTGUI/qSlicerModuleFinderDialog.cxx
+++ b/Base/QTGUI/qSlicerModuleFinderDialog.cxx
@@ -21,6 +21,7 @@
 // Qt includes
 #include <QKeyEvent>
 #include <QPushButton>
+#include <QSettings>
 
 // Slicer includes
 #include "qSlicerAbstractCoreModule.h"
@@ -76,6 +77,15 @@ void qSlicerModuleFinderDialogPrivate::init()
   filterModel->setShowHidden(false);
   // Hide testing modules by default
   filterModel->setShowTesting(false);
+
+  // Only allow to show modules in Testing category if developer mode is enabled
+  // to not clutter the module list for regular users with tests
+  QSettings settings;
+  bool developerModeEnabled = settings.value("Developer/DeveloperMode", false).toBool();
+  if (!developerModeEnabled)
+    {
+    this->ShowTestingCheckBox->hide();
+    }
 
   // Set default search role (not full text)
   q->setSearchInAllText(false);

--- a/Base/QTGUI/qSlicerModulesListView.cxx
+++ b/Base/QTGUI/qSlicerModulesListView.cxx
@@ -50,16 +50,6 @@ protected:
   qSlicerModulesListView* const q_ptr;
 
 public:
-  enum CustomRole
-    {
-    ModuleNameRole = Qt::UserRole,
-    IsBuiltInRole = Qt::UserRole + 1,
-    IsTestingRole = Qt::UserRole + 2,
-    IsHiddenRole = Qt::UserRole + 3,
-    SearchRole = Qt::UserRole + 4,
-    FullTextSearchRole = Qt::UserRole + 5
-    };
-
   qSlicerModulesListViewPrivate(qSlicerModulesListView& object);
   void init();
 
@@ -108,7 +98,7 @@ void qSlicerModulesListViewPrivate::init()
 void qSlicerModulesListViewPrivate::updateItem(QStandardItem* item)
 {
   Q_Q(qSlicerModulesListView);
-  QString moduleName = item->data(qSlicerModulesListViewPrivate::ModuleNameRole).toString();
+  QString moduleName = item->data(qSlicerModuleFactoryFilterModel::ModuleNameRole).toString();
   item->setCheckable(true);
   // The module is ignored, therefore it hasn't been loaded
   if (this->FactoryManager != nullptr && this->FactoryManager->ignoredModuleNames().contains(moduleName))
@@ -177,29 +167,29 @@ void qSlicerModulesListViewPrivate::updateItem(QStandardItem* item)
     QString searchText = QString("%1 %2")
       .arg(coreModule->title())
       .arg(moduleName);
-    item->setData(searchText, qSlicerModulesListViewPrivate::SearchRole);
+    item->setData(searchText, qSlicerModuleFactoryFilterModel::SearchRole);
     QString fullTextSearchText = QString("%1 %2 %3 %4 %5")
       .arg(coreModule->title())
       .arg(moduleName)
       .arg(helpTextDoc.toPlainText())
       .arg(acknowledgementTextDoc.toPlainText())
       .arg(contributors);
-    item->setData(fullTextSearchText, qSlicerModulesListViewPrivate::FullTextSearchRole);
+    item->setData(fullTextSearchText, qSlicerModuleFactoryFilterModel::FullTextSearchRole);
     }
   else
     {
     item->setText(moduleName);
     item->setToolTip("");
-    item->setData(moduleName, qSlicerModulesListViewPrivate::SearchRole);
-    item->setData(moduleName, qSlicerModulesListViewPrivate::FullTextSearchRole);
+    item->setData(moduleName, qSlicerModuleFactoryFilterModel::SearchRole);
+    item->setData(moduleName, qSlicerModuleFactoryFilterModel::FullTextSearchRole);
     }
 
   qSlicerAbstractModule* module = qobject_cast<qSlicerAbstractModule*>(coreModule);
   if (module)
     {
-    item->setData(module->isBuiltIn(), qSlicerModulesListViewPrivate::IsBuiltInRole);
-    item->setData(qSlicerUtils::isTestingModule(module), qSlicerModulesListViewPrivate::IsTestingRole);
-    item->setData(module->isHidden(), qSlicerModulesListViewPrivate::IsHiddenRole);
+    item->setData(module->isBuiltIn(), qSlicerModuleFactoryFilterModel::IsBuiltInRole);
+    item->setData(qSlicerUtils::isTestingModule(module), qSlicerModuleFactoryFilterModel::IsTestingRole);
+    item->setData(module->isHidden(), qSlicerModuleFactoryFilterModel::IsHiddenRole);
 
     // See QTBUG-20248
     bool block = this->ModulesListModel->blockSignals(true);
@@ -244,7 +234,7 @@ QStandardItem* qSlicerModulesListViewPrivate
 {
   QModelIndex start = this->ModulesListModel->index(0, 0);
   QModelIndexList moduleIndexes = this->ModulesListModel->match(
-    start, qSlicerModulesListViewPrivate::ModuleNameRole, moduleName,
+    start, qSlicerModuleFactoryFilterModel::ModuleNameRole, moduleName,
     /* hits= */ 1, Qt::MatchExactly);
   if (moduleIndexes.count() == 0)
     {
@@ -260,7 +250,7 @@ QStringList qSlicerModulesListViewPrivate
   QStringList modules;
   foreach(const QModelIndex& index, indexes)
     {
-    modules << index.data(qSlicerModulesListViewPrivate::ModuleNameRole).toString();
+    modules << index.data(qSlicerModuleFactoryFilterModel::ModuleNameRole).toString();
     }
   return modules;
 }
@@ -489,7 +479,7 @@ void qSlicerModulesListView::addModule(const QString& moduleName)
   Q_D(qSlicerModulesListView);
   Q_ASSERT(d->moduleItem(moduleName) == nullptr);
   QStandardItem * item = new QStandardItem();
-  item->setData(moduleName, qSlicerModulesListViewPrivate::ModuleNameRole);
+  item->setData(moduleName, qSlicerModuleFactoryFilterModel::ModuleNameRole);
   d->updateItem(item);
   int index = d->sortedInsertionIndex(moduleName);
   d->ModulesListModel->insertRow(index, item);
@@ -533,7 +523,7 @@ void qSlicerModulesListView::onItemChanged(QStandardItem* item)
     {
     return;
     }
-  QString moduleName = item->data(qSlicerModulesListViewPrivate::ModuleNameRole).toString();
+  QString moduleName = item->data(qSlicerModuleFactoryFilterModel::ModuleNameRole).toString();
   qSlicerAbstractCoreModule* module = d->FactoryManager->moduleInstance(moduleName);
   if (item->checkState() == Qt::Checked)
     {


### PR DESCRIPTION
Do not allow selecting a testing module in module finder when not in developer mode.
Also fix a small programming style mistake.
