### PR TITLE
Support import type annotation from slicer during module load

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -298,13 +298,13 @@ slicer_add_python_unittest(
 
 slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
-  SLICER_ARGS --no-main-window --disable-modules
+  SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules
   TESTNAME_PREFIX nomainwindow_
   )
 
 slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_parameter_pack.py
-  SLICER_ARGS --no-main-window --disable-modules
+  SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules
   TESTNAME_PREFIX nomainwindow_
   )
 

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -9,7 +9,7 @@ import ctk
 import qt
 
 import slicer
-from qSlicerSubjectHierarchyModuleWidgetsPythonQt import qMRMLSubjectHierarchyTreeView
+from slicer import qMRMLSubjectHierarchyTreeView
 from . import parameterPack as pack
 from . import validators
 from .util import (

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
@@ -8,7 +8,7 @@ import enum
 import vtk
 import slicer
 
-from MRMLCorePython import (
+from slicer import (
     vtkMRMLNode,
     vtkMRMLModelNode,
     vtkMRMLScalarVolumeNode,

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
@@ -7,10 +7,13 @@ import ctk
 import qt
 
 import slicer
-from slicer.parameterNodeWrapper import *
 
-from MRMLCorePython import vtkMRMLModelNode, vtkMRMLScalarVolumeNode
-from qSlicerSubjectHierarchyModuleWidgetsPythonQt import qMRMLSubjectHierarchyTreeView
+from slicer import (
+    qMRMLSubjectHierarchyTreeView,
+    vtkMRMLModelNode,
+    vtkMRMLScalarVolumeNode,
+)
+from slicer.parameterNodeWrapper import *
 
 
 # This is a copy-paste of what is in wrapper.py on purpose.

--- a/Base/Python/slicer/tests/test_slicer_parameter_pack.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_pack.py
@@ -1,9 +1,8 @@
 import unittest
 from typing import Annotated, Any, Union
 
-from MRMLCorePython import vtkMRMLModelNode
-
 import slicer
+from slicer import vtkMRMLModelNode
 from slicer.parameterNodeWrapper import *
 from slicer.parameterNodeWrapper.parameterPack import ParameterPackSerializer
 

--- a/Base/QTCore/qSlicerScriptedUtils_p.h
+++ b/Base/QTCore/qSlicerScriptedUtils_p.h
@@ -47,6 +47,9 @@ struct _object;
 typedef _object PyObject;
 #endif
 
+// Slicer includes
+class qSlicerCorePythonManager;
+
 class Q_SLICER_BASE_QTCORE_EXPORT qSlicerScriptedUtils
 {
 
@@ -64,6 +67,12 @@ public:
   static bool setModuleAttribute(const QString& moduleName,
                                  const QString& attributeName,
                                  PyObject* attributeValue);
+
+  /// \sa qSlicerLoadableModule::importModulePythonExtensions
+  static bool importModulePythonExtensions(qSlicerCorePythonManager * pythonManager,
+                                           const QString& intDir,
+                                           const QString& modulePath,
+                                           bool isEmbedded=false);
 
 private:
   /// Not implemented

--- a/Docs/developer_guide/parameter_nodes/supported_types.md
+++ b/Docs/developer_guide/parameter_nodes/supported_types.md
@@ -35,9 +35,7 @@ MRML nodes from non-core modules are supported, but to define a `parameterNodeWr
 
 ```py
 from slicer.parameterNodeWrapper import *
-
-# Import from actual package instead of importing from "slicer"
-from vtkSlicerMarkupsModuleMRMLPython import vtkMRMLMarkupsFiducialNode
+from slicer import vtkMRMLMarkupsFiducialNode
 
 @parameterNodeWrapper
 class CustomParameterNode:
@@ -45,12 +43,8 @@ class CustomParameterNode:
   markups: list[vtkMRMLMarkupsFiducialNode]
 ```
 
-It is possible to use core MRML classes like `vtkMRMLModelNode` from the `slicer` namespace, but in these examples we've elected to get it from `MRMLCorePython` for consistency.
-
 :::{warning}
-For most uses of MRML nodes in Python code outside the `parameterNodeWrapper`, it is preferred to use `slicer.<node>` rather than `from <specific-mrml-package> import <node>` as this is more robust if MRML nodes change packages (e.g. from an extension to the core). However, as of this writing, the node classes are not guaranteed to be in the `slicer` namespace until after the application has finished loading, which is too late in the load process for type annotations at the Python module level.
-
-Changes to Slicer to allow the MRML nodes to be in the `slicer` namespace earlier are being investigated. If such changes are made, the recommendation will be to only ever get MRML nodes from the `slicer` namespace, and to not directly use packages like `MRMLCorePython` and `vtkSlicerMarkupsModuleMRMLPython`.
+For uses of MRML nodes in Python code, it is preferred to use `slicer.<node>` rather than `from <specific-mrml-package> import <node>` as this is more robust if MRML nodes change packages (e.g. from an extension to the core).
 :::
 
 ## Enum

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -13,7 +13,7 @@ from slicer.parameterNodeWrapper import (
     WithinRange,
 )
 
-from MRMLCorePython import vtkMRMLScalarVolumeNode
+from slicer import vtkMRMLScalarVolumeNode
 
 
 #


### PR DESCRIPTION
This commit ensures that python wrapped C++ classes implemented by loadable module (Logic, MRML, MRMLDisplayableManager, VTKWidgets, PythonQt) are imported and associated with the "slicer" package during module instantiation.

This ensures that classes that are both provided by other modules and referenced in python script associated with scripted loadable module can be successfully resolved.

Note that since wrapped C++ VTK modules explicitly import other wrapped C++ VTK modules they depend one (using `vtkPythonUtil::ImportModule`), calling `qSlicerScriptedUtils::importModulePythonExtensions` during module instantiation done independently of the module dependency graph is not a problem.

```
$ ctest -R test_slicer_parameter 
Test project /home/jcfr/Projects/Slicer-Release/Slicer-build
    Start 588: py_nomainwindow_test_slicer_parameter_node_wrapper
1/4 Test #588: py_nomainwindow_test_slicer_parameter_node_wrapper ................   Passed    3.89 sec
    Start 589: py_nomainwindow_test_slicer_parameter_pack
2/4 Test #589: py_nomainwindow_test_slicer_parameter_pack ........................   Passed    3.46 sec
    Start 590: py_nomainwindow_test_slicer_parameter_node_wrapper_guis
3/4 Test #590: py_nomainwindow_test_slicer_parameter_node_wrapper_guis ...........   Passed    3.58 sec
    Start 591: py_nomainwindow_test_slicer_parameter_node_wrapper_gui_creation
4/4 Test #591: py_nomainwindow_test_slicer_parameter_node_wrapper_gui_creation ...   Passed    3.39 sec

100% tests passed, 0 tests failed out of 4
```


<details><summary>Original description</summary>

Pending:
* [x] fix `py_nomainwindow_test_slicer_parameter_node_wrapper` 
* [x] review if out-of-order import of python modules wrapping VTK classes is a problem (indeed importing at instantiation time is done independently of the module dependency graph)

</details>

