### PR TITLE
ENH: Add Soft edge option for Mask volume Segment Editor effect

### DIFF
--- a/Docs/developer_guide/modules/segmenteditor.md
+++ b/Docs/developer_guide/modules/segmenteditor.md
@@ -49,6 +49,18 @@ Common parameters must be set using `setCommonParameter` method (others can be s
 | ApplyToAllVisibleSegments | int   | no     | 0       | 0 or 1                     |
 | MarginSizeMm              | float | no     | 3.0     | <0.0 (shrink), >0.0 (grow) |
 
+### Mask volume
+
+| Parameter                  | Type    | Common | Default | Values                     |
+|----------------------------|---------|--------|---------|----------------------------|
+| FillValue                  | float   | no     | 0       | any                        |
+| BinaryMaskFillValueOutside | float   | no     | 0       | any                        |
+| BinaryMaskFillValueInside  | float   | no     | 1       | any                        |
+| Operation                  | enum    | no     | FILL_OUTSIDE | FILL_INSIDE, FILL_OUTSIDE, FILL_INSIDE_AND_OUTSIDE |
+| SoftEdgeMm                 | float   | no     | 0.0     | >=0.0                      |
+| Mask volume.InputVolume    | noderef | no     | none    | reference to volume node   |
+| Mask volume.OutputVolume   | noderef | no     | none    | reference to volume node   |
+
 ### Paint effect and Erase effect
 
 | Parameter                    | Type  | Common | Default | Values |

--- a/Docs/user_guide/modules/segmenteditor.md
+++ b/Docs/user_guide/modules/segmenteditor.md
@@ -209,9 +209,13 @@ Apply basic copy, clear, fill, and Boolean operations to the selected segment(s)
 Blank out inside/outside of a segment in a volume or create a binary mask. Result can be saved into a new volume or overwrite the input volume.
 This is useful for removing irrelevant details from an image (for example remove patient table; or crop the volume to arbitrary shape for volume rendering) or create masks for image processing operations (such as registration or intensity correction).
 
-- Fill inside: set all voxels of the selected volume to the specified value inside the selected segment
-- Fill outside: set all voxels of the selected volume to the specified value outside the selected segment
-- Fill inside and outside: create a binary labelmap volume as output. Most image processing operations require background (outside, ignored) region to be filled with 0 value.
+- `Operation`:
+  - `Fill inside`: set all voxels of the selected volume to the specified `Fill value` inside the selected segment
+  - `Fill outside`: set all voxels of the selected volume to the specified `Fill value` outside the selected segment
+  - `Fill inside and outside`: create a binary labelmap volume as output, filled with `Outside fill value` and `Intside fill value`. Most image processing operations require background (outside, ignored) region to be filled with 0 value.
+- `Soft edge`: if set to >0 then transition between the inside/outside the mask is gradual. The value specifies the standard deviation of the Gaussian blurring function. Larger value results in softer transition.
+- `Input volume`: voxels of this volume will be used as input for the masking. Geometry and voxel type of the output volume will be the same as this volume's.
+- `Output volume`: this volume will store the result of the masking. While it can be the same as the input volume, generally it is better to use a different output volume, because then the options can be adjusted and mask can be recomputed multiple times.
 
 ## Tips
 

--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorMaskVolumeEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorMaskVolumeEffect.py
@@ -102,6 +102,17 @@ Fill inside and outside operation creates a binary labelmap volume as output, wi
         fillValuesSpinBoxLayout.addRow(fillValueLayout)
         self.scriptedEffect.addOptionsWidget(fillValuesSpinBoxLayout)
 
+        # Soft edge
+        self.softEdgeMmSpinBox = slicer.qMRMLSpinBox()
+        self.softEdgeMmSpinBox.setMRMLScene(slicer.mrmlScene)
+        self.softEdgeMmSpinBox.setToolTip("Standard deviation of the Gaussian function that blurs the edge of the mask."
+                                          " Higher value makes the edge softer.")
+        self.softEdgeMmSpinBox.quantity = "length"
+        self.softEdgeMmSpinBox.value = 0
+        self.softEdgeMmSpinBox.singleStep = 0.5
+        self.softEdgeMmLabel = self.scriptedEffect.addLabeledOptionsWidget("Soft edge:", self.softEdgeMmSpinBox)
+        self.softEdgeMmSpinBox.connect("valueChanged(double)", self.softEdgeMmChanged)
+
         # input volume selector
         self.inputVolumeSelector = slicer.qMRMLNodeComboBox()
         self.inputVolumeSelector.nodeTypes = ["vtkMRMLScalarVolumeNode"]
@@ -164,6 +175,7 @@ Fill inside and outside operation creates a binary labelmap volume as output, wi
         self.scriptedEffect.setParameterDefault("FillValue", "0")
         self.scriptedEffect.setParameterDefault("BinaryMaskFillValueInside", "1")
         self.scriptedEffect.setParameterDefault("BinaryMaskFillValueOutside", "0")
+        self.scriptedEffect.setParameterDefault("SoftEdgeMm", "0")
         self.scriptedEffect.setParameterDefault("Operation", "FILL_OUTSIDE")
 
     def isVolumeVisible(self, volumeNode):
@@ -190,6 +202,9 @@ Fill inside and outside operation creates a binary labelmap volume as output, wi
         if operationName:
             operationButton = list(self.buttonToOperationNameMap.keys())[list(self.buttonToOperationNameMap.values()).index(operationName)]
             operationButton.setChecked(True)
+
+        self.softEdgeMmSpinBox.setValue(float(self.scriptedEffect.parameter("SoftEdgeMm"))
+                                        if self.scriptedEffect.parameter("SoftEdgeMm") else 0)
 
         inputVolume = self.scriptedEffect.parameterSetNode().GetNodeReference("Mask volume.InputVolume")
         self.inputVolumeSelector.setCurrentNode(inputVolume)
@@ -228,6 +243,7 @@ Fill inside and outside operation creates a binary labelmap volume as output, wi
         self.scriptedEffect.setParameter("BinaryMaskFillValueOutside", self.binaryMaskFillOutsideEdit.value)
         self.scriptedEffect.parameterSetNode().SetNodeReferenceID("Mask volume.InputVolume", self.inputVolumeSelector.currentNodeID)
         self.scriptedEffect.parameterSetNode().SetNodeReferenceID("Mask volume.OutputVolume", self.outputVolumeSelector.currentNodeID)
+        self.scriptedEffect.setParameter("SoftEdgeMm", self.softEdgeMmSpinBox.value)
 
     def activate(self):
         self.scriptedEffect.setParameter("InputVisibility", "True")
@@ -241,6 +257,9 @@ Fill inside and outside operation creates a binary labelmap volume as output, wi
         if not toggle:
             return
         self.scriptedEffect.setParameter("Operation", operationName)
+
+    def softEdgeMmChanged(self, edgeMm):
+        self.scriptedEffect.setParameter("SoftEdgeMm", edgeMm)
 
     def getInputVolume(self):
         inputVolume = self.inputVolumeSelector.currentNode()
@@ -298,8 +317,11 @@ Fill inside and outside operation creates a binary labelmap volume as output, wi
         segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
         segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
 
+        softEdgeMm = self.scriptedEffect.doubleParameter("SoftEdgeMm")
+
         slicer.app.setOverrideCursor(qt.Qt.WaitCursor)
-        SegmentEditorMaskVolumeEffect.maskVolumeWithSegment(segmentationNode, segmentID, operationMode, fillValues, inputVolume, outputVolume)
+        SegmentEditorMaskVolumeEffect.maskVolumeWithSegment(segmentationNode, segmentID, operationMode, fillValues, inputVolume, outputVolume,
+                                                            softEdgeMm=softEdgeMm)
 
         slicer.util.setSliceViewerLayers(background=outputVolume)
         qt.QApplication.restoreOverrideCursor()
@@ -307,7 +329,7 @@ Fill inside and outside operation creates a binary labelmap volume as output, wi
         self.updateGUIFromMRML()
 
     @staticmethod
-    def maskVolumeWithSegment(segmentationNode, segmentID, operationMode, fillValues, inputVolumeNode, outputVolumeNode, maskExtent=None):
+    def maskVolumeWithSegment(segmentationNode, segmentID, operationMode, fillValues, inputVolumeNode, outputVolumeNode, maskExtent=None, softEdgeMm=0.0):
         """
         Fill voxels of the input volume inside/outside the masking model with the provided fill value
         maskExtent: optional output to return computed mask extent (expected input is a 6-element list)
@@ -315,6 +337,7 @@ Fill inside and outside operation creates a binary labelmap volume as output, wi
           If fill mode is inside&outside then the list must contain two values: first is the inside fill, second is the outside fill value.
         """
 
+        import vtk  # without this we get the error: UnboundLocalError: local variable 'vtk' referenced before assignment
         segmentIDs = vtk.vtkStringArray()
         segmentIDs.InsertNextValue(segmentID)
         maskVolumeNode = slicer.modules.volumes.logic().CreateAndAddLabelVolume(inputVolumeNode, "TemporaryVolumeMask")
@@ -335,31 +358,82 @@ Fill inside and outside operation creates a binary labelmap volume as output, wi
             import vtkSegmentationCorePython as vtkSegmentationCore
             vtkSegmentationCore.vtkOrientedImageDataResample.CalculateEffectiveExtent(img, maskExtent, 0)
 
-        maskToStencil = vtk.vtkImageToImageStencil()
-        maskToStencil.ThresholdByLower(0)
-        maskToStencil.SetInputData(maskVolumeNode.GetImageData())
+        if softEdgeMm == 0:
+            # Hard edge
+            maskToStencil = vtk.vtkImageToImageStencil()
+            maskToStencil.ThresholdByLower(0)
+            maskToStencil.SetInputData(maskVolumeNode.GetImageData())
 
-        stencil = vtk.vtkImageStencil()
+            stencil = vtk.vtkImageStencil()
 
-        if operationMode == "FILL_INSIDE_AND_OUTSIDE":
-            # Set input to constant value
-            thresh = vtk.vtkImageThreshold()
-            thresh.SetInputData(inputVolumeNode.GetImageData())
-            thresh.ThresholdByLower(0)
-            thresh.SetInValue(fillValues[1])
-            thresh.SetOutValue(fillValues[1])
-            thresh.SetOutputScalarType(inputVolumeNode.GetImageData().GetScalarType())
-            thresh.Update()
-            stencil.SetInputData(thresh.GetOutput())
+            if operationMode == "FILL_INSIDE_AND_OUTSIDE":
+                # Set input to constant value
+                thresh = vtk.vtkImageThreshold()
+                thresh.SetInputData(inputVolumeNode.GetImageData())
+                thresh.ThresholdByLower(0)
+                thresh.SetInValue(fillValues[1])
+                thresh.SetOutValue(fillValues[1])
+                thresh.SetOutputScalarType(inputVolumeNode.GetImageData().GetScalarType())
+                thresh.Update()
+                stencil.SetInputData(thresh.GetOutput())
+            else:
+                stencil.SetInputData(inputVolumeNode.GetImageData())
+
+            stencil.SetStencilConnection(maskToStencil.GetOutputPort())
+            stencil.SetReverseStencil(operationMode == "FILL_OUTSIDE")
+            stencil.SetBackgroundValue(fillValues[0])
+            stencil.Update()
+            outputVolumeNode.SetAndObserveImageData(stencil.GetOutput())
         else:
-            stencil.SetInputData(inputVolumeNode.GetImageData())
+            # Soft edge
 
-        stencil.SetStencilConnection(maskToStencil.GetOutputPort())
-        stencil.SetReverseStencil(operationMode == "FILL_OUTSIDE")
-        stencil.SetBackgroundValue(fillValues[0])
-        stencil.Update()
+            thresh = vtk.vtkImageThreshold()
+            maskMin = 0
+            maskMax = 255
+            thresh.SetOutputScalarTypeToUnsignedChar()
+            thresh.SetInputData(maskVolumeNode.GetImageData())
+            thresh.ThresholdByLower(0)
+            thresh.SetInValue(maskMin)
+            thresh.SetOutValue(maskMax)
+            thresh.Update()
 
-        outputVolumeNode.SetAndObserveImageData(stencil.GetOutput())
+            gaussianFilter = vtk.vtkImageGaussianSmooth()
+            spacing = maskVolumeNode.GetSpacing()
+            standardDeviationPixel = [1.0, 1.0, 1.0]
+            for idx in range(3):
+                standardDeviationPixel[idx] = softEdgeMm / spacing[idx]
+            gaussianFilter.SetInputConnection(thresh.GetOutputPort())
+            gaussianFilter.SetStandardDeviations(*standardDeviationPixel)
+            # Do not truncate the Gaussian kernel at the default 1.5 sigma,
+            # because it would result in edge artifacts.
+            # Larger value results in less edge artifact but increased computation time,
+            # so 3.0 is a good tradeoff.
+            gaussianFilter.SetRadiusFactor(3.0)
+            gaussianFilter.Update()
+
+            import vtk.util.numpy_support
+            maskImage = gaussianFilter.GetOutput()
+            nshape = tuple(reversed(maskImage.GetDimensions()))
+            maskArray = vtk.util.numpy_support.vtk_to_numpy(maskImage.GetPointData().GetScalars()).reshape(nshape)
+            # Normalize mask with the actual min/max values.
+            # Gaussian output is not always exactly the original minimum and maximum, so we get the actual min/max values.
+            maskMin = maskArray.min()
+            maskMax = maskArray.max()
+            mask = (maskArray.astype(float) - maskMin) / float(maskMax - maskMin)
+
+            inputArray = slicer.util.arrayFromVolume(inputVolumeNode)
+
+            if operationMode == "FILL_INSIDE_AND_OUTSIDE":
+                # Rescale the smoothed mask
+                resultArray = fillValues[0] + (fillValues[1] - fillValues[0]) * mask[:]
+            else:
+                # Compute weighted average between blanked out and input volume
+                if operationMode == "FILL_INSIDE":
+                    mask = 1.0 - mask
+                resultArray = inputArray[:] * mask[:] + float(fillValues[0]) * (1.0 - mask[:])
+
+            outputArray = slicer.util.arrayFromVolume(outputVolumeNode)
+            slicer.util.updateVolumeFromArray(outputVolumeNode, resultArray.astype(inputArray.dtype))
 
         # Set the same geometry and parent transform as the input volume
         ijkToRas = vtk.vtkMatrix4x4()


### PR DESCRIPTION
This reduces edge artifacts on the resulting masked image.

Original behavior (no soft edge):

![image](https://user-images.githubusercontent.com/307929/222041049-83863977-fea4-4d1a-82bb-7007421f1945.png)

Soft edge (less edge artifacts):

![image](https://user-images.githubusercontent.com/307929/222041088-eb19a23b-9d7f-479c-aaf6-0b854c2b1103.png)

Soft edge (very wide edge, even less edge artifacts but the transition zone somewhat eats into the image):

![image](https://user-images.githubusercontent.com/307929/222041129-496e1b55-467f-4a13-b9db-92f9d9cff35f.png)
