### PR TITLE
Table column type issues 2

### DIFF
--- a/Libs/MRML/Core/Testing/vtkMRMLTableNodeTest1.cxx
+++ b/Libs/MRML/Core/Testing/vtkMRMLTableNodeTest1.cxx
@@ -24,11 +24,48 @@
 #include "vtkMRMLTableNode.h"
 #include "vtkMRMLTableStorageNode.h"
 
+#include "vtkBitArray.h"
+#include "vtkCharArray.h"
+#include "vtkDoubleArray.h"
+#include "vtkFloatArray.h"
+#include "vtkIdTypeArray.h"
+#include "vtkIntArray.h"
+#include "vtkLongArray.h"
+#include "vtkLongLongArray.h"
+#include "vtkShortArray.h"
+#include "vtkSignedCharArray.h"
 #include "vtkStringArray.h"
+#include "vtkUnsignedCharArray.h"
+#include "vtkUnsignedIntArray.h"
+#include "vtkUnsignedLongArray.h"
+#include "vtkUnsignedLongLongArray.h"
+#include "vtkUnsignedShortArray.h"
 #include "vtkTable.h"
 #include "vtkTestErrorObserver.h"
 
 #include "vtkMRMLCoreTestingMacros.h"
+
+namespace
+{
+  template <class ArrayType, typename ValueType>
+  void checkDefaultArrayValue(vtkMRMLTableNode* tableNode, std::string columnType, std::string defaultValueString, ValueType value)
+   {
+    tableNode->SetDefaultColumnType(columnType, defaultValueString);
+    ArrayType* newArray = ArrayType::SafeDownCast(tableNode->AddColumn());
+    if (!newArray)
+      {
+      std::cerr << "checkDefaultArrayValue failed for '" << columnType << "'. Failed to create array" << std::endl;
+      exit(EXIT_FAILURE);
+      }
+    if (newArray->GetValue(0) != value)
+      {
+      std::cerr << "checkDefaultArrayValue failed for '" << columnType << "' with '" << defaultValueString
+        << "'. Expected value: '" << value << "', got: '" << newArray->GetValue(0) << "'" << std::endl;
+      exit(EXIT_FAILURE);
+      }
+    tableNode->RemoveColumn(tableNode->GetNumberOfColumns() - 1);
+    }
+}
 
 int vtkMRMLTableNodeTest1(int , char * [] )
 {
@@ -104,6 +141,116 @@ int vtkMRMLTableNodeTest1(int , char * [] )
   CHECK_NOT_NULL(node2->AddColumn(newLongArray));
   CHECK_INT(table->GetNumberOfRows(), 10);
   CHECK_INT(table->GetNumberOfColumns(), 3);
+
+  // Test if new arrays are initialized correctly
+
+  vtkNew<vtkMRMLTableNode> node3;
+  node3->AddColumn();
+  node3->AddEmptyRow();
+  node3->AddEmptyRow();
+  node3->AddEmptyRow();
+
+  checkDefaultArrayValue< vtkStringArray, std::string >(node3, "string", "test", "test");
+  checkDefaultArrayValue< vtkStringArray, std::string >(node3, "string", "", "");
+
+  checkDefaultArrayValue< vtkDoubleArray, double >(node3, "double", "3.5", 3.5);
+  checkDefaultArrayValue< vtkDoubleArray, double >(node3, "double", "", 0.0);
+  checkDefaultArrayValue< vtkDoubleArray, double >(node3, "double", "some", 0.0);
+
+  checkDefaultArrayValue< vtkFloatArray, double >(node3, "float", "3.5", 3.5);
+  checkDefaultArrayValue< vtkFloatArray, double >(node3, "float", "", 0.0);
+  checkDefaultArrayValue< vtkFloatArray, double >(node3, "float", "some", 0.0);
+
+  checkDefaultArrayValue< vtkIntArray, int >(node3, "int", "3", 3);
+  checkDefaultArrayValue< vtkIntArray, int >(node3, "int", "-5", -5);
+  checkDefaultArrayValue< vtkIntArray, int >(node3, "int", "3.3", 0);
+  checkDefaultArrayValue< vtkIntArray, int >(node3, "int", "", 0);
+  checkDefaultArrayValue< vtkIntArray, int >(node3, "int", "some", 0);
+
+  checkDefaultArrayValue< vtkUnsignedIntArray, unsigned int >(node3, "unsigned int", "3", 3);
+  // this is a bit odd (since an unsigned value accepts a negative value), but this is vtkVariant behavior:
+  checkDefaultArrayValue< vtkUnsignedIntArray, unsigned int >(node3, "unsigned int", "-5", -5);
+  checkDefaultArrayValue< vtkUnsignedIntArray, unsigned int >(node3, "unsigned int", "3.3", 0);
+  checkDefaultArrayValue< vtkUnsignedIntArray, unsigned int >(node3, "unsigned int", "", 0);
+  checkDefaultArrayValue< vtkUnsignedIntArray, unsigned int >(node3, "unsigned int", "some", 0);
+
+  checkDefaultArrayValue< vtkShortArray, short >(node3, "short", "3", 3);
+  checkDefaultArrayValue< vtkShortArray, short >(node3, "short", "-5", -5);
+  checkDefaultArrayValue< vtkShortArray, short >(node3, "short", "3.3", 0);
+  checkDefaultArrayValue< vtkShortArray, short >(node3, "short", "", 0);
+  checkDefaultArrayValue< vtkShortArray, short >(node3, "short", "some", 0);
+
+  checkDefaultArrayValue< vtkUnsignedShortArray, unsigned short >(node3, "unsigned short", "3", 3);
+  // this is a bit odd (since an unsigned value accepts a negative value), but this is vtkVariant behavior:
+  checkDefaultArrayValue< vtkUnsignedShortArray, unsigned short >(node3, "unsigned short", "-5", -5);
+  checkDefaultArrayValue< vtkUnsignedShortArray, unsigned short >(node3, "unsigned short", "3.3", 0);
+  checkDefaultArrayValue< vtkUnsignedShortArray, unsigned short >(node3, "unsigned short", "", 0);
+  checkDefaultArrayValue< vtkUnsignedShortArray, unsigned short >(node3, "unsigned short", "some", 0);
+
+  checkDefaultArrayValue< vtkLongArray, long >(node3, "long", "3", 3);
+  checkDefaultArrayValue< vtkLongArray, long >(node3, "long", "-5", -5);
+  checkDefaultArrayValue< vtkLongArray, long >(node3, "long", "3.3", 0);
+  checkDefaultArrayValue< vtkLongArray, long >(node3, "long", "", 0);
+  checkDefaultArrayValue< vtkLongArray, long >(node3, "long", "some", 0);
+
+  checkDefaultArrayValue< vtkUnsignedLongArray, unsigned long >(node3, "unsigned long", "3", 3);
+  // this is a bit odd (since an unsigned value accepts a negative value), but this is vtkVariant behavior:
+  checkDefaultArrayValue< vtkUnsignedLongArray, unsigned long >(node3, "unsigned long", "-5", -5);
+  checkDefaultArrayValue< vtkUnsignedLongArray, unsigned long >(node3, "unsigned long", "3.3", 0);
+  checkDefaultArrayValue< vtkUnsignedLongArray, unsigned long >(node3, "unsigned long", "", 0);
+  checkDefaultArrayValue< vtkUnsignedLongArray, unsigned long >(node3, "unsigned long", "some", 0);
+
+  checkDefaultArrayValue< vtkLongLongArray, long long >(node3, "long long", "3", 3);
+  checkDefaultArrayValue< vtkLongLongArray, long long >(node3, "long long", "-5", -5);
+  checkDefaultArrayValue< vtkLongLongArray, long long >(node3, "long long", "3.3", 0);
+  checkDefaultArrayValue< vtkLongLongArray, long long >(node3, "long long", "", 0);
+  checkDefaultArrayValue< vtkLongLongArray, long long >(node3, "long long", "some", 0);
+
+  checkDefaultArrayValue< vtkUnsignedLongLongArray, unsigned long long >(node3, "unsigned long long", "3", 3);
+  // this is a bit odd (since an unsigned value accepts a negative value), but this is vtkVariant behavior:
+  checkDefaultArrayValue< vtkUnsignedLongLongArray, unsigned long long >(node3, "unsigned long long", "-5", -5);
+  checkDefaultArrayValue< vtkUnsignedLongLongArray, unsigned long long >(node3, "unsigned long long", "3.3", 0);
+  checkDefaultArrayValue< vtkUnsignedLongLongArray, unsigned long long >(node3, "unsigned long long", "", 0);
+  checkDefaultArrayValue< vtkUnsignedLongLongArray, unsigned long long >(node3, "unsigned long long", "some", 0);
+
+  checkDefaultArrayValue< vtkIdTypeArray, vtkIdType >(node3, "idtype", "3", 3);
+  checkDefaultArrayValue< vtkIdTypeArray, vtkIdType >(node3, "idtype", "-5", -5);
+  checkDefaultArrayValue< vtkIdTypeArray, vtkIdType >(node3, "idtype", "3.3", 0);
+  checkDefaultArrayValue< vtkIdTypeArray, vtkIdType >(node3, "idtype", "", 0);
+  checkDefaultArrayValue< vtkIdTypeArray, vtkIdType >(node3, "idtype", "some", 0);
+
+  checkDefaultArrayValue< vtkBitArray, int >(node3, "bit", "0", false);
+  checkDefaultArrayValue< vtkBitArray, int >(node3, "bit", "1", true);
+  checkDefaultArrayValue< vtkBitArray, int >(node3, "bit", "3", true);
+  checkDefaultArrayValue< vtkBitArray, int >(node3, "bit", "-5", true);
+  checkDefaultArrayValue< vtkBitArray, int >(node3, "bit", "3.3", false);
+  checkDefaultArrayValue< vtkBitArray, int >(node3, "bit", "", false);
+  checkDefaultArrayValue< vtkBitArray, int >(node3, "bit", "some", false);
+
+  checkDefaultArrayValue< vtkCharArray, char >(node3, "char", "0", '0');
+  checkDefaultArrayValue< vtkCharArray, char >(node3, "char", "1", '1');
+  checkDefaultArrayValue< vtkCharArray, char >(node3, "char", "3", '3');
+  checkDefaultArrayValue< vtkCharArray, char >(node3, "char", "-5", 0); // invalid because not a single character
+  checkDefaultArrayValue< vtkCharArray, char >(node3, "char", "3.3", 0); // invalid because not a single character
+  checkDefaultArrayValue< vtkCharArray, char >(node3, "char", "", 0);
+  checkDefaultArrayValue< vtkCharArray, char >(node3, "char", "some", false); // invalid because not a single character
+
+  checkDefaultArrayValue< vtkSignedCharArray, signed char >(node3, "signed char", "0", '0');
+  checkDefaultArrayValue< vtkSignedCharArray, signed char >(node3, "signed char", "1", '1');
+  checkDefaultArrayValue< vtkSignedCharArray, signed char >(node3, "signed char", "3", '3');
+  checkDefaultArrayValue< vtkSignedCharArray, signed char >(node3, "signed char", "-5", 0);
+  checkDefaultArrayValue< vtkSignedCharArray, signed char >(node3, "signed char", "3.3", 0);
+  checkDefaultArrayValue< vtkSignedCharArray, signed char >(node3, "signed char", "", 0);
+  checkDefaultArrayValue< vtkSignedCharArray, signed char >(node3, "signed char", "some", 0);
+
+  // it is a bit odd that "0" get converted to '0' instead of 0 ('0x0'), but this is vtkVariant behavior:
+  checkDefaultArrayValue< vtkUnsignedCharArray, unsigned char >(node3, "unsigned char", "0", '0');
+  checkDefaultArrayValue< vtkUnsignedCharArray, unsigned char >(node3, "unsigned char", "1", '1');
+  checkDefaultArrayValue< vtkUnsignedCharArray, unsigned char >(node3, "unsigned char", "3", '3');
+  checkDefaultArrayValue< vtkUnsignedCharArray, unsigned char >(node3, "unsigned char", "-5", 0);
+  checkDefaultArrayValue< vtkUnsignedCharArray, unsigned char >(node3, "unsigned char", "3.3", 0);
+  checkDefaultArrayValue< vtkUnsignedCharArray, unsigned char >(node3, "unsigned char", "", 0);
+  checkDefaultArrayValue< vtkUnsignedCharArray, unsigned char >(node3, "unsigned char", "some", 0);
 
   // Test GetCellText
 

--- a/Libs/MRML/Core/vtkMRMLTableNode.h
+++ b/Libs/MRML/Core/vtkMRMLTableNode.h
@@ -91,8 +91,8 @@ public:
   /// - columnName: name of the data table column that properties are defined for  (required)
   ///   Column name \<default\> is reserved for defining default properties for new columns.
   /// - type: data type of the column. Supported types: string, double, float, int, unsigned int, bit,
-  ///   short, unsigned short, long, unsigned long, char, signed char, unsigned char, long long, unsigned long long
-  ///   __int64, unsigned __int64, idtype. Default: string.
+  ///   short, unsigned short, long, unsigned long, char, signed char, unsigned char, long long, unsigned long long, idtype.
+  ///   Default: string.
   /// - nullValue: value to be used when a value is not specified (new table row is added, blank string is entered, etc)
   /// - longName: full human-readable name of the column
   /// - description: human-readable detailed description of the column


### PR DESCRIPTION
Fix non-string table cells initialized with random values.
When a null value for a non-string type column was not specified,
new cells were filled with arbitrary values.
Removed __int64 type, as it is no longer supported in tables.
Added tests for all types.

Fix non-str cols always loaded before string columns.
When editing a table, string columns with no extra metadata were not
included in the schema. When the schema file is written, these missing
columns are appended to the schema.
This commit makes the columns in the table node match the order in the table file.

This pull request replaces https://github.com/Slicer/Slicer/pull/6801, which solved the same issues but it had some limitations (unnecessarily removed vtkIdType support, no tests were added; column order in table node still did not match the order in the table file).