### PR TITLE
BUG: Fix lost setValue with nested parameterPacks

### DIFF
--- a/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
+++ b/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
@@ -266,12 +266,20 @@ class ObservedParameterPack:
     def __repr__(self) -> str:
         return str(self)
 
-    def __getattr__(self, name: str):
+    def _setValue(self, name: str, value):
         myValue = super().__getattribute__('_value')
-        if hasattr(myValue, name):
-            return getattr(myValue, name)
+        myValue.setValue(name, value)
+        self._save()
+
+    def __getattr__(self, name: str):
+        if name == "setValue":
+            return super().__getattribute__('_setValue')
         else:
-            raise AttributeError(f"'{str(self._serializer.type)}' has no attribute '{name}'")
+            myValue = super().__getattribute__('_value')
+            if hasattr(myValue, name):
+                return getattr(myValue, name)
+            else:
+                raise AttributeError(f"'{str(self._serializer.type)}' has no attribute '{name}'")
 
     def __setattr__(self, name: str, value) -> None:
         myValue = super().__getattribute__('_value')

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
@@ -227,7 +227,7 @@ class ParameterNodeWrapperGuiTest(unittest.TestCase):
         # Phase 2 - write to parameterNode
         param.alpha = -4444.4
         param.bravo = 2.1
-        param.charlie = 0.1
+        param.setValue("charlie", 0.1)
         # alpha
         self.assertEqual(param.alpha, -4444.4)
         self.assertEqual(widgetAlpha.value, -4444.4)
@@ -858,7 +858,7 @@ class ParameterNodeWrapperGuiTest(unittest.TestCase):
         self.assertEqual(ui.sub1Iterations.value, 33)
         self.assertEqual(param.pack.sub2.iterations, 4)
         self.assertEqual(ui.sub2Iterations.value, 4)
-        param.pack.sub1.description = "airplane"
+        param.pack.sub1.setValue("description", "airplane")
         self.assertEqual(param.pack.sub1.description, "airplane")
         self.assertEqual(ui.sub1Description.text, "airplane")
         self.assertEqual(param.pack.sub2.description, "hello, world")

--- a/Base/Python/slicer/tests/test_slicer_parameter_pack.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_pack.py
@@ -345,6 +345,26 @@ class TypedParameterNodeTest(unittest.TestCase):
         self.assertEqual(pack.getValue("box"), BoundingBox(Point(-99, 8), Point(11, 10)))
         self.assertEqual(pack.getValue("box.topLeft.x"), -99)
 
+    def test_parameter_pack_getSetValue_updates(self):
+        @parameterPack
+        class ParameterPack:
+            box: BoundingBox
+            value: int
+
+        @parameterNodeWrapper
+        class ParameterNodeType:
+            pack: ParameterPack
+
+        param = ParameterNodeType(newParameterNode())
+
+        param.pack.setValue("value", 123)
+
+        self.assertEqual(param.pack.value, 123)
+
+        param.pack.setValue("box.bottomRight.x", 33)
+
+        self.assertEqual(param.pack.box.bottomRight.x, 33)
+
     def test_parameter_pack_dataType(self):
         @parameterPack
         class AnnotatedSub:


### PR DESCRIPTION
When using nested parameterPacks, the setValue would change the parameterPack, but not the underlying parameterNode.