### PR TITLE
COMP: Report error if unsupported CMake version 3.25.(0|1|2) is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 
+if("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.25.0" AND "${CMAKE_VERSION}" VERSION_LESS_EQUAL "3.25.2")
+  message(FATAL_ERROR "CMake version is ${CMAKE_VERSION} and using CMake >=3.25.0,<=3.25.2 is not supported.\nSee https://gitlab.kitware.com/cmake/cmake/-/issues/24567")
+endif()
+
 #-----------------------------------------------------------------------------
 # Setting C++ Standard
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Due to a regression introduced in CMake 3.25 that will be fixed in CMake 3.25.3, this commit ensures an error message is reported.

The regression was preventing the successful build and installation of the PythonQt external project integrated through CTK.

References:
* https://gitlab.kitware.com/cmake/cmake/-/issues/24567
* https://gitlab.kitware.com/cmake/cmake/-/merge_requests/7655
* https://discourse.slicer.org/t/slicer-custom-app-build-error/28026/8