### PR TITLE
BUG: Register parameterNodeWrapper plugins in corresponding module

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -310,7 +310,7 @@ slicer_add_python_unittest(
 
 slicer_add_python_unittest(
   SCRIPT ${Slicer_SOURCE_DIR}/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper_guis.py
-  SLICER_ARGS --no-main-window --disable-cli-modules --disable-scripted-loadable-modules
+  SLICER_ARGS --no-main-window --disable-cli-modules
   TESTNAME_PREFIX nomainwindow_
   )
 

--- a/Base/Python/slicer/parameterNodeWrapper/__init__.py
+++ b/Base/Python/slicer/parameterNodeWrapper/__init__.py
@@ -6,6 +6,8 @@ from .serializers import *
 from .validators import *
 from .util import (
     findFirstAnnotation,
+    getNodeTypes,
+    isNodeOrUnionOfNodes,
     splitAnnotations,
     unannotatedType,
 )

--- a/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
+++ b/Base/Python/slicer/parameterNodeWrapper/guiConnectors.py
@@ -9,7 +9,6 @@ import ctk
 import qt
 
 import slicer
-from slicer import qMRMLSubjectHierarchyTreeView
 from . import parameterPack as pack
 from . import validators
 from .util import (
@@ -619,47 +618,6 @@ class qMRMLNodeComboBoxToNodeConnector(GuiConnector):
 
     def write(self, value) -> None:
         self._widget.setCurrentNode(value)
-
-
-@parameterNodeGuiConnector
-class qMRMLSubjectHierarchyTreeViewToNodeConnector(GuiConnector):
-    @staticmethod
-    def canRepresent(widget, datatype) -> bool:
-        return type(widget) == qMRMLSubjectHierarchyTreeView and isNodeOrUnionOfNodes(datatype)
-
-    @staticmethod
-    def create(widget, datatype):
-        if qMRMLSubjectHierarchyTreeViewToNodeConnector.canRepresent(widget, datatype):
-            return qMRMLSubjectHierarchyTreeViewToNodeConnector(widget, datatype)
-        return None
-
-    def __init__(self, widget: qMRMLSubjectHierarchyTreeView, datatype):
-        super().__init__()
-        self._widget: qMRMLSubjectHierarchyTreeView = widget
-        self._widget.nodeTypes = getNodeTypes(datatype)
-
-    def _connect(self):
-        self._widget.currentItemsChanged.connect(self.changed)
-
-    def _disconnect(self):
-        self._widget.currentItemsChanged.disconnect(self.changed)
-
-    def widget(self) -> qMRMLSubjectHierarchyTreeView:
-        return self._widget
-
-    def read(self):
-        itemId = self._widget.currentItem()
-        shNode = self._widget.subjectHierarchyNode()
-        if itemId == shNode.GetInvalidItemID():
-            return None
-        else:
-            return shNode.GetItemDataNode(itemId)
-
-    def write(self, value) -> None:
-        if value is not None:
-            self._widget.setCurrentNode(value)
-        else:
-            self._widget.clearSelection()
 
 
 SlicerPackParameterNamePropertyName = "SlicerPackParameterName"

--- a/Base/Python/slicer/parameterNodeWrapper/util.py
+++ b/Base/Python/slicer/parameterNodeWrapper/util.py
@@ -3,7 +3,13 @@ from typing import Annotated
 
 import slicer
 
-__all__ = ["splitAnnotations", "unannotatedType", "findFirstAnnotation"]
+__all__ = [
+    "findFirstAnnotation",
+    "getNodeTypes",
+    "isNodeOrUnionOfNodes",
+    "splitAnnotations",
+    "unannotatedType",
+]
 
 
 def splitAnnotations(possiblyAnnotatedType):

--- a/Modules/Loadable/SubjectHierarchy/Widgets/Python/CMakeLists.txt
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/Python/CMakeLists.txt
@@ -3,6 +3,8 @@
 set(SubjectHierarchyWidgets_PYTHON_SCRIPTS
   __init__
   AbstractScriptedSubjectHierarchyPlugin
+  parameterNodeWrapper/__init__.py
+  parameterNodeWrapper/guiConnectors.py
   )
 
 set(SubjectHierarchyWidgets_PYTHON_RESOURCES

--- a/Modules/Loadable/SubjectHierarchy/Widgets/Python/__init__.py
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/Python/__init__.py
@@ -3,6 +3,8 @@ import traceback
 import logging
 import sys
 
+from . import parameterNodeWrapper  # Required to ensure parameterNodeWrapper plugins are registered
+
 currentDir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(currentDir)
 for fileName in os.listdir(currentDir):

--- a/Modules/Loadable/SubjectHierarchy/Widgets/Python/parameterNodeWrapper/__init__.py
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/Python/parameterNodeWrapper/__init__.py
@@ -1,0 +1,1 @@
+from .guiConnectors import *

--- a/Modules/Loadable/SubjectHierarchy/Widgets/Python/parameterNodeWrapper/guiConnectors.py
+++ b/Modules/Loadable/SubjectHierarchy/Widgets/Python/parameterNodeWrapper/guiConnectors.py
@@ -1,0 +1,48 @@
+from slicer import qMRMLSubjectHierarchyTreeView
+from slicer.parameterNodeWrapper import (
+    isNodeOrUnionOfNodes,
+    getNodeTypes,
+    GuiConnector,
+    parameterNodeGuiConnector,
+)
+
+
+@parameterNodeGuiConnector
+class qMRMLSubjectHierarchyTreeViewToNodeConnector(GuiConnector):
+    @staticmethod
+    def canRepresent(widget, datatype) -> bool:
+        return type(widget) == qMRMLSubjectHierarchyTreeView and isNodeOrUnionOfNodes(datatype)
+
+    @staticmethod
+    def create(widget, datatype):
+        if qMRMLSubjectHierarchyTreeViewToNodeConnector.canRepresent(widget, datatype):
+            return qMRMLSubjectHierarchyTreeViewToNodeConnector(widget, datatype)
+        return None
+
+    def __init__(self, widget: qMRMLSubjectHierarchyTreeView, datatype):
+        super().__init__()
+        self._widget: qMRMLSubjectHierarchyTreeView = widget
+        self._widget.nodeTypes = getNodeTypes(datatype)
+
+    def _connect(self):
+        self._widget.currentItemsChanged.connect(self.changed)
+
+    def _disconnect(self):
+        self._widget.currentItemsChanged.disconnect(self.changed)
+
+    def widget(self) -> qMRMLSubjectHierarchyTreeView:
+        return self._widget
+
+    def read(self):
+        itemId = self._widget.currentItem()
+        shNode = self._widget.subjectHierarchyNode()
+        if itemId == shNode.GetInvalidItemID():
+            return None
+        else:
+            return shNode.GetItemDataNode(itemId)
+
+    def write(self, value) -> None:
+        if value is not None:
+            self._widget.setCurrentNode(value)
+        else:
+            self._widget.clearSelection()


### PR DESCRIPTION
This commit fixes the following tests by ensuring parameterNodeWrapper guiConnectors specific to modules (e.g SubjectHierarchy) are registered in the corresponding modules.

```
  py_nowarning_mainwindow_noloadableTest
  py_nowarning_mainwindow_nocli_noloadableTest
  py_nowarning_nomainwindow_noloadableTest
  py_nowarning_nomainwindow_nocli_noloadableTest
  py_nomainwindow_SlicerOptionModulesToIgnoreTest
```

Note that since the test associated with `qMRMLSubjectHierarchyTreeViewToNodeConnector` is still implemented in `py_nomainwindow_test_slicer_parameter_node_wrapper_guis`, it is required to have the `SubjectHierarchy` python classes imported by removing the `--disable-scripted-loadable-modules` argument.