### PR TITLE
BUG: Fix missing toggle markups action in Markups Place button menu

### DIFF
--- a/Base/QTGUI/qSlicerMouseModeToolBar.cxx
+++ b/Base/QTGUI/qSlicerMouseModeToolBar.cxx
@@ -172,6 +172,17 @@ void qSlicerMouseModeToolBarPrivate::init()
   q->addAction(this->PlaceWidgetAction);
 
   q->addAction(this->ToolBarAction);  // add Toggle Markups ToolBar action last
+
+  this->PlaceWidgetToolBarAction = new QAction(this);
+  this->PlaceWidgetToolBarAction->setObjectName("PlaceWidgetToolBarAction");
+  this->PlaceWidgetToolBarAction->setToolTip(qSlicerMouseModeToolBar::tr("Toggle Markups Toolbar"));
+  this->PlaceWidgetToolBarAction->setText(qSlicerMouseModeToolBar::tr("Toggle Markups Toolbar"));
+  this->PlaceWidgetToolBarAction->setEnabled(true);
+  this->PlaceWidgetToolBarAction->setIcon(QIcon(":/Icons/MarkupsDisplayToolBar.png"));
+
+  QObject::connect(this->PlaceWidgetToolBarAction, SIGNAL(triggered()),
+    q, SLOT(toggleMarkupsToolBar()));
+  this->PlaceWidgetMenu->addAction(this->PlaceWidgetToolBarAction);
 }
 
 //---------------------------------------------------------------------------

--- a/Base/QTGUI/qSlicerMouseModeToolBar_p.h
+++ b/Base/QTGUI/qSlicerMouseModeToolBar_p.h
@@ -100,7 +100,12 @@ public:
   QAction* AdjustViewAction;
   QAction* AdjustWindowLevelAction;
   QAction* PlaceWidgetAction;
+
+  /// Action represented by a QToolButton in the Markups Toolbar for toggling visibility of the advanced Markups toolbar.
   QAction* ToolBarAction;
+
+  /// Action added to the place widget menu for toggling visibility of the advanced Markups toolbar.
+  QAction* PlaceWidgetToolBarAction;
 
   QMenu* PlaceWidgetMenu;
 


### PR DESCRIPTION
This closes #6830.

This fixes the following error which was introduced by https://github.com/Slicer/Slicer/commit/32675b18cb60123a7a873889f8c7383549e3ad27: [Qt] QWindowsWindow::setMouseGrabEnabled: Not setting mouse grab for invisible window QWidgetWindow/'PlaceWidgetMenuWindow'

History about the changes that were previously made and the reasoning about the changes made here: https://github.com/Slicer/Slicer/issues/6830#issuecomment-1432061086