### PR TITLE
ENH: Add support of shallow and deep copy to scalar volume display node

### DIFF
--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.cxx
@@ -352,14 +352,15 @@ void vtkMRMLScalarVolumeDisplayNode::ReadXMLAttributes(const char** atts)
 }
 
 //----------------------------------------------------------------------------
-// Copy the node\"s attributes to this object.
-// Does NOT copy: ID, FilePrefix, Name, VolumeID
-void vtkMRMLScalarVolumeDisplayNode::Copy(vtkMRMLNode *anode)
+void vtkMRMLScalarVolumeDisplayNode::CopyContent(vtkMRMLNode* anode, bool deepCopy/*=true*/)
 {
-  int disabledModify = this->StartModify();
-
-  Superclass::Copy(anode);
-  vtkMRMLScalarVolumeDisplayNode *node = (vtkMRMLScalarVolumeDisplayNode *) anode;
+  MRMLNodeModifyBlocker blocker(this);
+  Superclass::CopyContent(anode, deepCopy);
+  vtkMRMLScalarVolumeDisplayNode *node = vtkMRMLScalarVolumeDisplayNode::SafeDownCast(anode);
+  if (!node)
+    {
+    return;
+    }
 
   this->SetAutoWindowLevel( node->GetAutoWindowLevel() );
   this->SetWindowLevel(node->GetWindow(), node->GetLevel());
@@ -371,8 +372,6 @@ void vtkMRMLScalarVolumeDisplayNode::Copy(vtkMRMLNode *anode)
     {
     this->AddWindowLevelPreset(node->GetWindowPreset(p), node->GetLevelPreset(p));
     }
-
-  this->EndModify(disabledModify);
 
 }
 

--- a/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLScalarVolumeDisplayNode.h
@@ -54,9 +54,9 @@ class VTK_MRML_EXPORT vtkMRMLScalarVolumeDisplayNode : public vtkMRMLVolumeDispl
   /// Write this node's information to a MRML file in XML format.
   void WriteXML(ostream& of, int indent) override;
 
-  ///
-  /// Copy the node's attributes to this object
-  void Copy(vtkMRMLNode *node) override;
+  /// Copy node content (excludes basic data, such as name and node references).
+  /// \sa vtkMRMLNode::CopyContent
+  vtkMRMLCopyContentMacro(vtkMRMLScalarVolumeDisplayNode);
 
   ///
   /// Get node XML tag name (like Volume, Model)


### PR DESCRIPTION
This is a followup to https://github.com/Slicer/Slicer/commit/f88c110430ac818329b2806dbe3e42eeb9e0b503.

See https://discourse.slicer.org/t/data-node-display-nodes-not-maintained-when-creating-a-sequence/28146/9?u=jamesobutler

Here's the script I was using for testing.

```python
# Load sample volume
import SampleData
sampleDataLogic = SampleData.SampleDataLogic()
mrHead = sampleDataLogic.downloadMRHead()
mrHead.GetDisplayNode().ApplyThresholdOn()
mrHead.GetDisplayNode().SetAutoWindowLevel(False)
mrHead.GetDisplayNode().SetWindowLevelMinMax(10, 120)
min, max = mrHead.GetImageData().GetScalarRange()
mrHead.GetDisplayNode().SetThreshold(0, max)

mrHead2 = sampleDataLogic.downloadMRHead()
mrHead2.GetDisplayNode().SetAndObserveColorNodeID("vtkMRMLColorTableNodeRed")
mrHead2.GetDisplayNode().ApplyThresholdOn()
min, max = mrHead2.GetImageData().GetScalarRange()
mrHead2.GetDisplayNode().SetThreshold(79, max)
mrHead2.GetDisplayNode().ApplyThresholdOn()
mrHead2.GetDisplayNode().SetAutoWindowLevel(False)
mrHead2.GetDisplayNode().SetWindowLevelMinMax(20, 100)

sequence_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSequenceNode", "MySequenceNode")
sequence_node.SetDataNodeAtValue(mrHead, "0")
sequence_node.SetDataNodeAtValue(mrHead2, "1")

sequence_display_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSequenceNode", "MySequenceDisplayNode")
sequence_display_node.SetDataNodeAtValue(mrHead.GetDisplayNode(), "0")
sequence_display_node.SetDataNodeAtValue(mrHead2.GetDisplayNode(), "1")

browser_node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSequenceBrowserNode", "MyBrowserNode")
browser_node.AddSynchronizedSequenceNode(sequence_node)
browser_node.AddSynchronizedSequenceNode(sequence_display_node)
volume_proxy_node = browser_node.GetProxyNode(sequence_node)
display_proxy_node = browser_node.GetProxyNode(sequence_display_node)
volume_proxy_node.SetAndObserveDisplayNodeID(display_proxy_node.GetID())

slicer.modules.sequences.toolBar().setActiveBrowserNode(browser_node)
slicer.util.setSliceViewerLayers(background=volume_proxy_node)
```