### PR TITLE
COMP: Update python packages to latest

### DIFF
--- a/SuperBuild/External_python-dicom-requirements.cmake
+++ b/SuperBuild/External_python-dicom-requirements.cmake
@@ -75,7 +75,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   retrying==1.3.4 --hash=sha256:8cc4d43cb8e1125e0ff3344e9de678fefd85db3b750b81b2240dc0183af37b35
   # [/retrying]
   # [dicomweb-client]
-  dicomweb-client==0.59.0 --hash=sha256:70a3cdae97f2ce8288e5b61baa75aa68b39da7b2712da9e248eb7b6f7f269651
+  dicomweb-client==0.59.1 --hash=sha256:ad4af95e1bdeb3691841cf8b28894fc6d9ba7ac5b7892bff70a506eedbd20d79
   # [/dicomweb-client]
   ]===])
 

--- a/SuperBuild/External_python-extension-manager-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-requirements.cmake
@@ -46,7 +46,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   smmap==5.0.0 --hash=sha256:2aba19d6a040e78d8b09de5c57e96207b09ed71d8e55ce0959eeee6c8e190d94
   # [/smmap]
   # [GitPython]
-  GitPython==3.1.30 --hash=sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882
+  GitPython==3.1.31 --hash=sha256:f04893614f6aa713a60cbbe1e6a97403ef633103cdd0ef5eb6efe0deb98dbe8d
   # [/GitPython]
   # [six]
   six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254

--- a/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
+++ b/SuperBuild/External_python-extension-manager-ssl-requirements.cmake
@@ -37,20 +37,22 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/PyJWT]
   # [wrapt]
   # Hashes correspond to the following packages:
-  #  - wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl
-  #  - wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - wrapt-1.14.1-cp39-cp39-win_amd64.whl
-  wrapt==1.14.1 --hash=sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383 \
-                --hash=sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7 \
-                --hash=sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86 \
-                --hash=sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b \
-                --hash=sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3 \
-                --hash=sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe \
-                --hash=sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb
+  #  - wrapt-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - wrapt-1.15.0-cp39-cp39-macosx_11_0_arm64.whl
+  #  - wrapt-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - wrapt-1.15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - wrapt-1.15.0-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - wrapt-1.15.0-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - wrapt-1.15.0-cp39-cp39-win_amd64.whl
+  #  - wrapt-1.15.0-py3-none-any.whl
+  wrapt==1.15.0 --hash=sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86 \
+                --hash=sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c \
+                --hash=sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d \
+                --hash=sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29 \
+                --hash=sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a \
+                --hash=sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9 \
+                --hash=sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6 \
+                --hash=sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640
   # [/wrapt]
   # [Deprecated]
   Deprecated==1.2.13 --hash=sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d
@@ -93,7 +95,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
                 --hash=sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93
   # [/PyNaCl]
   # [PyGithub]
-  PyGithub==1.57 --hash=sha256:5822febeac2391f1306c55a99af2bc8f86c8bf82ded000030cd02c18f31b731f
+  PyGithub==1.58.0 --hash=sha256:b7bac601492a2b6c876ef326e4ffa3c1923e32707e415da76bfb8307ee8ffb7e
   # [/PyGithub]
   ]===])
 

--- a/SuperBuild/External_python-numpy.cmake
+++ b/SuperBuild/External_python-numpy.cmake
@@ -34,16 +34,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/nose]
   # [numpy]
   # Hashes correspond to the following packages:
-  #  - numpy-1.24.1-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - numpy-1.24.1-cp39-cp39-macosx_11_0_arm64.whl
-  #  - numpy-1.24.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - numpy-1.24.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - numpy-1.24.1-cp39-cp39-win_amd64.whl
-  numpy==1.24.1 --hash=sha256:28bc9750ae1f75264ee0f10561709b1462d450a4808cd97c013046073ae64ab6 \
-                --hash=sha256:84e789a085aabef2f36c0515f45e459f02f570c4b4c4c108ac1179c34d475ed7 \
-                --hash=sha256:8e669fbdcdd1e945691079c2cae335f3e3a56554e06bbd45d7609a6cf568c700 \
-                --hash=sha256:ef85cf1f693c88c1fd229ccd1055570cb41cdf4875873b7728b6301f12cd05bf \
-                --hash=sha256:ddc7ab52b322eb1e40521eb422c4e0a20716c271a306860979d450decbb51b8e
+  #  - numpy-1.24.2-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - numpy-1.24.2-cp39-cp39-macosx_11_0_arm64.whl
+  #  - numpy-1.24.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - numpy-1.24.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - numpy-1.24.2-cp39-cp39-win_amd64.whl
+  numpy==1.24.2 --hash=sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a \
+                --hash=sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f \
+                --hash=sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb \
+                --hash=sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780 \
+                --hash=sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5
   # [/numpy]
   ]===])
 

--- a/SuperBuild/External_python-pip.cmake
+++ b/SuperBuild/External_python-pip.cmake
@@ -27,7 +27,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [pip]
-  pip==23.0 --hash=sha256:b5f88adff801f5ef052bcdef3daa31b55eb67b0fccd6d0106c206fa248e0463c
+  pip==23.0.1 --hash=sha256:236bcb61156d76c4b8a05821b988c7b8c35bf0da28a4b614e8d6ab5212c25c6f
   # [/pip]
   ]===])
 

--- a/SuperBuild/External_python-requests-requirements.cmake
+++ b/SuperBuild/External_python-requests-requirements.cmake
@@ -34,24 +34,24 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   # [/idna]
   # [charset-normalizer]
   # Hashes correspond to the following packages:
-  #  - charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_universal2.whl
-  #  - charset_normalizer-3.0.1-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - charset_normalizer-3.0.1-cp39-cp39-macosx_11_0_arm64.whl
-  #  - charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - charset_normalizer-3.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_aarch64.whl
-  #  - charset_normalizer-3.0.1-cp39-cp39-musllinux_1_1_x86_64.whl
-  #  - charset_normalizer-3.0.1-cp39-cp39-win_amd64.whl
-  #  - charset_normalizer-3.0.1-py3-none-any.whl
-  charset-normalizer==3.0.1 --hash=sha256:8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f \
-                            --hash=sha256:8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678 \
-                            --hash=sha256:3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be \
-                            --hash=sha256:00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b \
-                            --hash=sha256:3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3 \
-                            --hash=sha256:ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d \
-                            --hash=sha256:356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786 \
-                            --hash=sha256:0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59 \
-                            --hash=sha256:7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24
+  #  - charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl
+  #  - charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl
+  #  - charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl
+  #  - charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl
+  #  - charset_normalizer-3.1.0-cp39-cp39-win_amd64.whl
+  #  - charset_normalizer-3.1.0-py3-none-any.whl
+  charset-normalizer==3.1.0 --hash=sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e \
+                            --hash=sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31 \
+                            --hash=sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f \
+                            --hash=sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e \
+                            --hash=sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706 \
+                            --hash=sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0 \
+                            --hash=sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f \
+                            --hash=sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b \
+                            --hash=sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d
   # [/charset-normalizer]
   # [urllib3]
   urllib3==1.26.14 --hash=sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1

--- a/SuperBuild/External_python-scipy.cmake
+++ b/SuperBuild/External_python-scipy.cmake
@@ -31,16 +31,16 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   file(WRITE ${requirements_file} [===[
   # [scipy]
   # Hashes correspond to the following packages:
-  #  - scipy-1.9.2-cp39-cp39-macosx_10_9_x86_64.whl
-  #  - scipy-1.9.2-cp39-cp39-macosx_12_0_arm64.whl
-  #  - scipy-1.9.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  #  - scipy-1.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  #  - scipy-1.9.2-cp39-cp39-win_amd64.whl
-  scipy==1.9.2 --hash=sha256:1e3b23a82867018cd26255dc951789a7c567921622073e1113755866f1eae928 \
-               --hash=sha256:82e8bfb352aa9dce9a0ffe81f4c369a2c87c85533519441686f59f21d8c09697 \
-               --hash=sha256:61b95283529712101bfb7c87faf94cb86ed9e64de079509edfe107e5cfa55733 \
-               --hash=sha256:8c8c29703202c39d699b0d6b164bde5501c212005f20abf46ae322b9307c8a41 \
-               --hash=sha256:7b2608b3141c257d01ae772e23b3de9e04d27344e6b68a890883795229cb7191
+  #  - scipy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl
+  #  - scipy-1.10.1-cp39-cp39-macosx_12_0_arm64.whl
+  #  - scipy-1.10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  #  - scipy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  #  - scipy-1.10.1-cp39-cp39-win_amd64.whl
+  scipy==1.10.1 --hash=sha256:cd9f1027ff30d90618914a64ca9b1a77a431159df0e2a195d8a9e8a04c78abf9 \
+                --hash=sha256:79c8e5a6c6ffaf3a2262ef1be1e108a035cf4f05c14df56057b64acc5bebffb6 \
+                --hash=sha256:51af417a000d2dbe1ec6c372dfe688e041a7084da4fdd350aeb139bd3fb55353 \
+                --hash=sha256:1b4735d6c28aad3cdcf52117e0e91d6b39acd4272f3f5cd9907c24ee931ad601 \
+                --hash=sha256:7ff7f37b1bf4417baca958d254e8e2875d0cc23aaadbe65b3d5b3077b0eb23ea
   # [/scipy]
   ]===])
 

--- a/SuperBuild/External_python-setuptools.cmake
+++ b/SuperBuild/External_python-setuptools.cmake
@@ -26,7 +26,7 @@ if(NOT Slicer_USE_SYSTEM_${proj})
   set(requirements_file ${CMAKE_BINARY_DIR}/${proj}-requirements.txt)
   file(WRITE ${requirements_file} [===[
   # [setuptools]
-  setuptools==67.0.0 --hash=sha256:9d790961ba6219e9ff7d9557622d2fe136816a264dd01d5997cfc057d804853d
+  setuptools==67.5.1 --hash=sha256:1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242
   # [/setuptools]
   ]===])
 


### PR DESCRIPTION
This is primarily a followup to https://github.com/Slicer/Slicer/pull/6803#discussion_r1091419077 as now `scipy` provides a whl that works with macOS 10.9 and newer rather than macOS 10.15 and newer. It was a mistake on `scipy`'s part that the whl support changed which they've fixed for the 1.10.1 release (https://github.com/scipy/scipy/commit/caf5ce86a0b2a5b35ea3522b5c72cf57e445a007).

Note that SimpleITK isn't being updated here as we build it from source rather than using the provided whl on pypi. VTK is also not updated as we use build VTK and its python wrapping as well from source rather than installing from whl.

```
PS C:\Users\butlej30383\AppData\Local\Slicer\Slicer 5.3.0-2023-03-04\bin> ./PythonSlicer.exe "C:\Slicer\Utilities\Scripts\python_package_updater.py"
Searching external projects in C:\Slicer\SuperBuild
Validate external projects

[notice] A new release of pip is available: 23.0 -> 23.0.1
[notice] To update, run: python-real.exe -m pip install --upgrade pip
Package            Version         Latest Type
------------------ --------------- ------ -----
charset-normalizer 3.0.1           3.1.0  wheel
dicomweb-client    0.59.0          0.59.1 wheel
GitPython          3.1.30          3.1.31 wheel
numpy              1.24.1          1.24.2 wheel
pip                23.0            23.0.1 wheel
PyGithub           1.57            1.58.0 wheel
scipy              1.9.2           1.10.1 wheel
setuptools         67.0.0          67.5.1 wheel
SimpleITK          2.2.0rc2.dev368 2.2.1  wheel
vtk                9.1.20220125    9.2.6  wheel
wrapt              1.14.1          1.15.0 wheel

  # Hashes correspond to the following packages:
  #  - charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl
  #  - charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl
  #  - charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl
  #  - charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - charset_normalizer-3.1.0-cp39-cp39-win_amd64.whl
  #  - charset_normalizer-3.1.0-py3-none-any.whl
  charset-normalizer==3.1.0 --hash=sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e \
                            --hash=sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31 \
                            --hash=sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f \
                            --hash=sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e \
                            --hash=sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706 \
                            --hash=sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0 \
                            --hash=sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f \
                            --hash=sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b \
                            --hash=sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d
  dicomweb-client==0.59.1 --hash=sha256:ad4af95e1bdeb3691841cf8b28894fc6d9ba7ac5b7892bff70a506eedbd20d79
  GitPython==3.1.31 --hash=sha256:f04893614f6aa713a60cbbe1e6a97403ef633103cdd0ef5eb6efe0deb98dbe8d
  # Hashes correspond to the following packages:
  #  - numpy-1.24.2-cp39-cp39-macosx_10_9_x86_64.whl
  #  - numpy-1.24.2-cp39-cp39-macosx_11_0_arm64.whl
  #  - numpy-1.24.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - numpy-1.24.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - numpy-1.24.2-cp39-cp39-win_amd64.whl
  numpy==1.24.2 --hash=sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a \
                --hash=sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f \
                --hash=sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb \
                --hash=sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780 \
                --hash=sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5
  pip==23.0.1 --hash=sha256:236bcb61156d76c4b8a05821b988c7b8c35bf0da28a4b614e8d6ab5212c25c6f
  PyGithub==1.58.0 --hash=sha256:b7bac601492a2b6c876ef326e4ffa3c1923e32707e415da76bfb8307ee8ffb7e
  # Hashes correspond to the following packages:
  #  - scipy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - scipy-1.10.1-cp39-cp39-macosx_12_0_arm64.whl
  #  - scipy-1.10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - scipy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - scipy-1.10.1-cp39-cp39-win_amd64.whl
  scipy==1.10.1 --hash=sha256:cd9f1027ff30d90618914a64ca9b1a77a431159df0e2a195d8a9e8a04c78abf9 \
                --hash=sha256:79c8e5a6c6ffaf3a2262ef1be1e108a035cf4f05c14df56057b64acc5bebffb6 \
                --hash=sha256:51af417a000d2dbe1ec6c372dfe688e041a7084da4fdd350aeb139bd3fb55353 \
                --hash=sha256:1b4735d6c28aad3cdcf52117e0e91d6b39acd4272f3f5cd9907c24ee931ad601 \
                --hash=sha256:7ff7f37b1bf4417baca958d254e8e2875d0cc23aaadbe65b3d5b3077b0eb23ea
  setuptools==67.5.1 --hash=sha256:1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242
  # Hashes correspond to the following packages:
  #  - SimpleITK-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-macosx_11_0_arm64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - SimpleITK-2.2.1-cp39-cp39-win_amd64.whl
  SimpleITK==2.2.1 --hash=sha256:e032bb2e54b96ce426187f07ce5dd9733077b18005399f6fbbcd4765b386299f \
                   --hash=sha256:3ffec97db30f923788f4e19b5a6e708d68afcce8f89cb54d7c976bd099b9a580 \
                   --hash=sha256:d6f58cdf90dbd0b84be68e0b46545c92f28c650d86e9f24acb91ad1c27416357 \
                   --hash=sha256:9b90dfd94cba0b068bacddaf2550d96df2683df830b9ee71cd9440e64c701196 \
                   --hash=sha256:7e20bbc467a8fff15978fee34a97c851ec3d0caed2d01929f600a13a0ff2f955
  # Hashes correspond to the following packages:
  #  - wrapt-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl
  #  - wrapt-1.15.0-cp39-cp39-macosx_11_0_arm64.whl
  #  - wrapt-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
  #  - wrapt-1.15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
  #  - wrapt-1.15.0-cp39-cp39-musllinux_1_1_aarch64.whl
  #  - wrapt-1.15.0-cp39-cp39-musllinux_1_1_x86_64.whl
  #  - wrapt-1.15.0-cp39-cp39-win_amd64.whl
  #  - wrapt-1.15.0-py3-none-any.whl
  wrapt==1.15.0 --hash=sha256:2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86 \
                --hash=sha256:0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c \
                --hash=sha256:76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d \
                --hash=sha256:9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29 \
                --hash=sha256:078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a \
                --hash=sha256:7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9 \
                --hash=sha256:eef4d64c650f33347c1f9266fa5ae001440b232ad9b98f1f43dfe7a79435c0a6 \
                --hash=sha256:64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640
```

Backward compatible changes introduced with the scipy version update from 1.9.2 to 1.10.0 are the following:
- https://docs.scipy.org/doc/scipy/release.1.10.0.html#deprecated-features
- https://docs.scipy.org/doc/scipy/release.1.10.0.html#expired-deprecations

Since `scipy` is not directly used in Slicer core, we may have to update extensions to account for changes.

Additionally re https://github.com/Slicer/Slicer/pull/6590#issuecomment-1282762511, on macOS, the dependent libraries shipped with scipy remain the same
```
Directory: scipy-1.9.2-cp39-cp39-macosx_10_9_x86_64\scipy\.dylibs
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         1/25/2023  12:20 PM         313744 libgcc_s.1.dylib
-a----         1/25/2023  12:20 PM        1588608 libgfortran.3.dylib
-a----         1/25/2023  12:20 PM       66118352 libopenblas.0.dylib
-a----         1/25/2023  12:20 PM         301952 libquadmath.0.dylib

Directory: scipy-1.10.1-cp39-cp39-macosx_10_9_x86_64\scipy\.dylibs
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         3/6/2023  8:54 PM         313744 libgcc_s.1.dylib
-a----         3/6/2023  8:54 PM        1588608 libgfortran.3.dylib
-a----         3/6/2023  8:54 PM       66118352 libopenblas.0.dylib
-a----         3/6/2023  8:54 PM         301952 libquadmath.0.dylib
```