### PR TITLE
ENH: ParameterNodeWrapper default by assignment

### DIFF
--- a/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
+++ b/Base/Python/slicer/parameterNodeWrapper/parameterPack.py
@@ -176,8 +176,13 @@ def _processParameterPack(classtype):
         membertype, annotations = splitAnnotations(nametype)
 
         serializer, annotations = createSerializer(membertype, annotations)
-        default, annotations = extractDefault(annotations)
-        default = default.value if default is not None else serializer.default()
+        if hasattr(classtype, name):
+            # default via equals
+            default = getattr(classtype, name)
+        else:
+            # default via "Default" class, or default default
+            default, annotations = extractDefault(annotations)
+            default = default.value if default is not None else serializer.default()
 
         if annotations:
             print("Warning: unused annotations", annotations)

--- a/Base/Python/slicer/parameterNodeWrapper/wrapper.py
+++ b/Base/Python/slicer/parameterNodeWrapper/wrapper.py
@@ -296,8 +296,14 @@ def _processClass(classtype):
             serializer, annotations = createSerializer(membertype, annotations)
         except Exception as e:
             raise Exception(f"Unable to create serializer for {classtype} member {name}") from e
-        default, annotations = extractDefault(annotations)
-        default = default if default is not None else Default(serializer.default())
+
+        if hasattr(classtype, name):
+            # default via equals
+            default = Default(getattr(classtype, name))
+        else:
+            # default via "Default" class, or default default
+            default, annotations = extractDefault(annotations)
+            default = default if default is not None else Default(serializer.default())
 
         if annotations:
             logging.warning(f"Unused annotations: {annotations}")

--- a/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_node_wrapper.py
@@ -303,12 +303,12 @@ class TypedParameterNodeTest(unittest.TestCase):
         class ParameterNodeType:
             float_: float
             bool_: bool
-            int_: Annotated[int, Default(4)]
+            int_: int = 4
             string_: Annotated[str, Default("TypedParam")]
 
         self.assertEqual(ParameterNodeType.dataType("float_"), float)
         self.assertEqual(ParameterNodeType.dataType("bool_"), bool)
-        self.assertEqual(ParameterNodeType.dataType("int_"), Annotated[int, Default(4)])
+        self.assertEqual(ParameterNodeType.dataType("int_"), int)
         self.assertEqual(ParameterNodeType.dataType("string_"), Annotated[str, Default("TypedParam")])
 
     def test_primitives(self):
@@ -318,10 +318,10 @@ class TypedParameterNodeTest(unittest.TestCase):
             float1: float
             bool1: bool
             string1: str
-            int2: Annotated[int, Default(4)]
+            int2: int = 4
             float2: Annotated[float, Default(9.9)]
             bool2: Annotated[bool, Default(True)]
-            string2: Annotated[str, Default("TypedParam")]
+            string2: str = "TypedParam"
 
         param = ParameterNodeType(newParameterNode())
         self.assertTrue(param.isCached("int1"))
@@ -621,7 +621,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         @parameterNodeWrapper
         class ParameterNodeType:
             a: tuple[Annotated[int, Minimum(0)], str]
-            b: Annotated[tuple[Annotated[float, Minimum(4)], bool], Default((44.0, False))]
+            b: tuple[Annotated[float, Minimum(4)], bool] = (44.0, False)
             c: tuple[list[int]]
 
         param = ParameterNodeType(newParameterNode())

--- a/Base/Python/slicer/tests/test_slicer_parameter_pack.py
+++ b/Base/Python/slicer/tests/test_slicer_parameter_pack.py
@@ -30,9 +30,9 @@ class BadDateException(ValueError):
 
 @parameterPack
 class Date:
-    _month: Annotated[int, Default(1)]
-    _day: Annotated[int, Default(1)]
-    _year: Annotated[int, Default(1970)]
+    _month: int = 1
+    _day: int = 1
+    _year: int = 1970
 
     @staticmethod
     def checkDate(month, day, year):
@@ -234,8 +234,7 @@ class TypedParameterNodeTest(unittest.TestCase):
     def test_serialization_of_nested(self):
         @parameterNodeWrapper
         class ParameterNodeType:
-            box: Annotated[BoundingBox,
-                           Default(BoundingBox(Point(0, 1), Point(1, 0)))]
+            box: BoundingBox = BoundingBox(Point(0, 1), Point(1, 0))
 
         param = ParameterNodeType(newParameterNode())
 
@@ -439,7 +438,7 @@ class TypedParameterNodeTest(unittest.TestCase):
             value: int
             union: Union[int, str]
             annotated: Annotated[bool, Default(True)]
-            annotatedBox: Annotated[BoundingBox, Default(BoundingBox(Point(-99, 8), Point(11, 10)))]
+            annotatedBox: BoundingBox = BoundingBox(Point(-99, 8), Point(11, 10))
             annotatedSub: AnnotatedSub
 
         self.assertEqual(ParameterPack.dataType("box"), BoundingBox)
@@ -448,8 +447,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         self.assertEqual(ParameterPack.dataType("value"), int)
         self.assertEqual(ParameterPack.dataType("union"), Union[int, str])
         self.assertEqual(ParameterPack.dataType("annotated"), Annotated[bool, Default(True)])
-        self.assertEqual(ParameterPack.dataType("annotatedBox"),
-                         Annotated[BoundingBox, Default(BoundingBox(Point(-99, 8), Point(11, 10)))])
+        self.assertEqual(ParameterPack.dataType("annotatedBox"), BoundingBox)
         self.assertEqual(ParameterPack.dataType("annotatedBox.topLeft"), Point)
         self.assertEqual(ParameterPack.dataType("annotatedSub"), AnnotatedSub)
         self.assertEqual(ParameterPack.dataType("annotatedSub.iterations"), Annotated[int, Default(44)])
@@ -461,8 +459,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         self.assertEqual(param.dataType("value"), int)
         self.assertEqual(param.dataType("union"), Union[int, str])
         self.assertEqual(param.dataType("annotated"), Annotated[bool, Default(True)])
-        self.assertEqual(param.dataType("annotatedBox"),
-                         Annotated[BoundingBox, Default(BoundingBox(Point(-99, 8), Point(11, 10)))])
+        self.assertEqual(param.dataType("annotatedBox"), BoundingBox)
         self.assertEqual(param.dataType("annotatedBox.topLeft"), Point)
         self.assertEqual(param.dataType("annotatedSub"), AnnotatedSub)
         self.assertEqual(param.dataType("annotatedSub.iterations"), Annotated[int, Default(44)])
@@ -523,7 +520,7 @@ class TypedParameterNodeTest(unittest.TestCase):
         @parameterNodeWrapper
         class ParameterNodeType:
             date: Date
-            date2: Annotated[Date, Default(Date(2, 28, 2028))]
+            date2: Date = Date(2, 28, 2028)
 
         param = ParameterNodeType(newParameterNode())
         self.assertEqual(param.date, Date())
@@ -551,3 +548,13 @@ class TypedParameterNodeTest(unittest.TestCase):
         param2 = ParameterNodeType(param.parameterNode)
         self.assertEqual(param2.date, Date(1, 31, 1980))
         self.assertEqual(param2.date2, Date(2, 28, 2028))
+
+    def test_equals_default(self):
+        @parameterPack
+        class Pack:
+            i: int = 50
+            j: Annotated[int, Default(60)]
+
+        pack = Pack()
+        self.assertEqual(pack.i, 50)
+        self.assertEqual(pack.j, 60)

--- a/Docs/developer_guide/parameter_nodes/advanced/custom_classes.md
+++ b/Docs/developer_guide/parameter_nodes/advanced/custom_classes.md
@@ -24,7 +24,6 @@ Here is an example of a custom class serializer.
 
 ```py
 import dataclasses
-from typing import Annotated
 import slicer
 from slicer.parameterNodeWrapper import parameterNodeWrapper, Serializer, ValidatedSerializer
 
@@ -101,7 +100,7 @@ class CustomClassSerializer(Serializer):
 @parameterNodeWrapper
 class CustomClassParameterNode(object):
     # can now use CustomClass like any other type for building parameterNodeWrappers
-    custom: Annotated[CustomClass, Default(CustomClass(1,2,3))]
+    custom: CustomClass = CustomClass(1,2,3)
     listOfCustom: list[CustomClass]
 ```
 

--- a/Docs/developer_guide/parameter_nodes/defaults.md
+++ b/Docs/developer_guide/parameter_nodes/defaults.md
@@ -2,43 +2,26 @@
 
 ## Default values
 
-Default values can easily be used when creating `parameterNodeWrapper`s and `parameterPack`s. This is done using Python `typing.Annotated` functionality and some Slicer specific annotations.
+Default values can easily be used when creating `parameterNodeWrapper`s and `parameterPack`s by simply assigning a value to the parameter.
 
 E.g.
 
 ```py
 from typing import Annotated
-from slicer.parameterNodeWrapper import (
-  parameterNodeWrapper,
-  Default,
-)
+from slicer.parameterNodeWrapper import parameterNodeWrapper
 
 
 @parameterNodeWrapper
 class ParameterNodeWrapper:
-    iterations: Annotated[int, Default(50)]
-    text: Annotated[str, Default("abc")]
+    iterations: int = 50
+    text: str = "abc"
+    tup: tuple[int, bool] = (7, True)
 ```
 
 :::{note}
 When constructing a `parameterNodeWrapper` using a parameter node that already has values set (e.g. when loading a .mrb or a .mrml scene file), those values will be maintained. The default will only come into play if parameter node does not have a value for the parameter.
 :::
 
-:::{note}
-For specifying the default of a nested-type type like `tuple[int, bool]` or `typing.Union[int, bool]`, specify the default on the outer level. Not allowing something like `tuple[Annotated[int, Default(4)], Annotated[bool, Default(True)]]` is mainly to keep consistency between setting default values for `tuple` and all the other classes (including other containers like `list`, `dict`, and `Union`).
-
-E.g.
-
-```py
-@parameterNodeWrapper
-class ParameterNodeType:
-  validTuple: Annotated[tuple[int, bool], Default((4, True))] # good
-  invalidTuple: tuple[Annotated[int, Default(4)], Annotated[bool, Default(True)]] # bad
-
-  validUnion: Annotated[typing.Union[int, bool], Default(True)] # good
-  invalidUnion: typing.Union[int, Annotated[bool, Default(True)]] # bad
-```
-:::
 
 ## Unspecified defaults
 

--- a/Docs/developer_guide/parameter_nodes/supported_types.md
+++ b/Docs/developer_guide/parameter_nodes/supported_types.md
@@ -96,8 +96,7 @@ class ParameterNodeType:
     #  - box.topLeft.y (default value is 1)
     #  - box.bottomRight.x (default value is 1)
     #  - box.bottomRight.y (default value is 0)
-    box: Annotated[BoundingBox,
-        Default(BoundingBox(Point(0, 1), Point(1, 0)))]
+    box: BoundingBox = BoundingBox(Point(0, 1), Point(1, 0))
 
 
 parameterNode = slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScriptedModuleNode')
@@ -121,7 +120,7 @@ The created `parameterPack` will have the following attributes:
 >>> class ParameterPack:
 >>>     # if the type is Annotated, it will treat the annotations the same as @parameterNodeWrapper
 >>>     x: Annotated[float, WithinRange(0, 10)]
->>>     option: Annotated[str, Choice(["a","b"]), Default("b")]
+>>>     option: Annotated[str, Choice(["a","b"])] = "b"
 >>> 
 >>> # with no arguments the constructor will use the given (or implied) defaults.
 >>> p1 = ParameterPack()  # == ParameterPack(x=0.0, option="b")
@@ -197,9 +196,9 @@ class BadDateException(ValueError):
 class Date:
     # Private parameters that will be written to the scene.
     # Can still set defaults on the private parameters.
-    _month: Annotated[int, Default(1)]
-    _day: Annotated[int, Default(1)]
-    _year: Annotated[int, Default(1970)]
+    _month: int = 1
+    _day: int = 1
+    _year: int = 1970
 
     # A checker for the multi-parameter invariant
     @staticmethod

--- a/Docs/developer_guide/parameter_nodes/validators.md
+++ b/Docs/developer_guide/parameter_nodes/validators.md
@@ -10,7 +10,7 @@ from slicer.parameterNodeWrapper import parameterNodeWrapper, Minimum, Default
 
 @parameterNodeWrapper
 class CustomParameterNode:
-  numIterations: Annotated[int, Minimum(0), Default(500)]
+  numIterations: Annotated[int, Minimum(0)] = 500
 
   # To have a list where the values in the list need to be validated
   chosenFeatures: list[Annotated[str, Choice(["feat1", "feat2", "feat3"])]]
@@ -64,7 +64,7 @@ class MatchesRegex(Validator):
 
 @parameterNodeWrapper
 class CustomParameterNode:
-  value: Annotated[str, MatchesRegex("[abc]+"), Default("abcba")]
+  value: Annotated[str, MatchesRegex("[abc]+")] = "abcba"
 
 
 param = CustomParameterNode(slicer.mrmlScene.AddNewNodeByClass('vtkMRMLScriptedModuleNode'))

--- a/Utilities/Templates/Modules/Scripted/TemplateKey.py
+++ b/Utilities/Templates/Modules/Scripted/TemplateKey.py
@@ -9,7 +9,6 @@ from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 from slicer.parameterNodeWrapper import (
     parameterNodeWrapper,
-    Default,
     WithinRange,
 )
 
@@ -112,8 +111,8 @@ class TemplateKeyParameterNode:
     invertedVolume - The output volume that will contain the inverted thresholded volume.
     """
     inputVolume: vtkMRMLScalarVolumeNode
-    imageThreshold: Annotated[float, WithinRange(-100, 500), Default(100)]
-    invertThreshold: Annotated[bool, Default(False)]
+    imageThreshold: Annotated[float, WithinRange(-100, 500)] = 100
+    invertThreshold: bool = False
     thresholdedVolume: vtkMRMLScalarVolumeNode
     invertedVolume: vtkMRMLScalarVolumeNode
 


### PR DESCRIPTION
Update to allow parameterPacks and parameterNodeWrappers to specify default values via assignment instead of the Default annotation. The assignment syntax is simpler and easier to read.