### PR TITLE
ENH: Add additional module paths by drag-and-drop to application

### DIFF
--- a/Base/QTGUI/qSlicerIOManager.cxx
+++ b/Base/QTGUI/qSlicerIOManager.cxx
@@ -318,11 +318,13 @@ void qSlicerIOManager::dropEvent(QDropEvent *event)
   if (supportedReaders.size() > 1)
     {
     QString title = tr("Select a reader");
-    QString label = tr("Select a reader to use for your data?");
+    QString label = tr("Select a reader to use for your data:");
     int current = 0;
     bool editable = false;
     bool ok = false;
-    selectedReader = QInputDialog::getItem(nullptr, title, label, supportedReaders, current, editable, &ok);
+    qSlicerApplication* app = qSlicerApplication::application();
+    QWidget* mainWindow = app ? app->mainWindow() : nullptr;
+    selectedReader = QInputDialog::getItem(mainWindow, title, label, supportedReaders, current, editable, &ok);
     if (!ok)
       {
       selectedReader = QString();

--- a/Docs/developer_guide/extensions.md
+++ b/Docs/developer_guide/extensions.md
@@ -80,7 +80,9 @@ Run `CMake (cmake-gui)` from the Windows Start menu.
 
 To test an extension, you need to specify location(s) where Slicer should look for additional modules.
 
-- If the extension is not built: add all source code folders that contain module .py files to "additional module paths" in modules section in application settings.
+- If the extension is not built: append all source code folders that contain module `.py` files to "additional module paths".
+  - Option A (recommended): Drag-and-drop the `.py` files (or the parent folder, or that folder's parent) to the application window, select `Add Python scripted modules to the application` in the popup window, click OK. Select which modules to add to load immediately and click `Yes`. The selected modules will be immediately loaded and made available in the module list. If you want to load the modules only in the current session, then uncheck `Add selected modules to 'Additional module paths'` option before clicking `Yes`.
+  - Option B: In menu: Edit / Application settings / Modules panel, drag-and-drop files to the `Additional module paths` list.
 - If the extension is built:
   - Option A: start the application using the `SlicerWithMyExtension` executable in your build directory. This starts Slicer, specifying additional module paths via command-line arguments.
   - Option B: specify additional module paths manually in application settings. Assuming your extension has been built into folder `MyExtension-debug`, add these module folders (if they exist) to the additional module paths in Slicer's application settings:

--- a/Docs/user_guide/settings.md
+++ b/Docs/user_guide/settings.md
@@ -30,7 +30,9 @@ Directory where modules can store their temporary outputs if needed.
 
 #### Additional module paths
 
-List of directories scanned at startup to load additional modules. Any CLI, Loadable or scripted modules located in these paths will be loaded. Extensions are listed in the list, to remove an extension, use the [Extensions Manager](extensions_manager.md) instead.
+List of directories scanned at startup to load additional modules. Any CLI, Loadable or scripted modules located in these paths will be loaded.
+
+Module folders of extensions are included in this list. To remove modules of an extension, it is recommended to use the [Extensions Manager](extensions_manager.md) instead of just removing its module paths.
 
 It is also possible to start Slicer by temporarily adding module paths (not saved in settings) by passing the arguments in the command line.
 

--- a/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/LoadModulesDialog.py
+++ b/Modules/Scripted/ExtensionWizard/ExtensionWizardLib/LoadModulesDialog.py
@@ -81,9 +81,9 @@ class LoadModulesDialog:
             self.ui.addToSearchPaths.enabled = True
 
         if moduleCount == 1:
-            self.ui.addToSearchPaths.text = "Add selected module to search paths"
+            self.ui.addToSearchPaths.text = "Add selected module to 'Additional module paths'"
         else:
-            self.ui.addToSearchPaths.text = "Add selected modules to search paths"
+            self.ui.addToSearchPaths.text = "Add selected modules to 'Additional module paths'"
 
         # If developer mode is already enabled then don't even show the option
         developerModeAlreadyEnabled = slicer.util.settingsValue('Developer/DeveloperMode', False, converter=slicer.util.toBool)


### PR DESCRIPTION
Python scripted modules folders can now be added to "Additional module paths" by drag-and-dropping module .py files or folders to the application window.

![image](https://user-images.githubusercontent.com/307929/224122596-bfb86a34-a65b-40c8-b875-6c7055bc55f4.png)

![image](https://user-images.githubusercontent.com/307929/224122683-e46b9314-a1ca-44e5-9c03-95ac1b612196.png)
