### PR TITLE
Import more series information from DICOM images

### DIFF
--- a/Modules/Scripted/DICOMLib/DICOMPlugin.py
+++ b/Modules/Scripted/DICOMLib/DICOMPlugin.py
@@ -202,6 +202,14 @@ class DICOMPlugin:
         tags['seriesInstanceUID'] = "0020,000E"
         tags['seriesModality'] = "0008,0060"
         tags['seriesNumber'] = "0020,0011"
+        tags['seriesDescription'] = "0008,103E"
+        tags['seriesDate'] = "0008,0021"
+        tags['seriesTime'] = "0008,0031"
+        tags['contentDate'] = "0008,0023"
+        tags['contentTime'] = "0008,0033"
+        tags['manufacturer'] = "0008,0070"
+        tags['model'] = "0008,1090"
+
         tags['frameOfReferenceUID'] = "0020,0052"
         tags['studyInstanceUID'] = "0020,000D"
         tags['studyID'] = "0020,0010"
@@ -242,12 +250,22 @@ class DICOMPlugin:
         # Specify details of series item
         seriesInstanceUid = slicer.dicomDatabase.fileValue(firstFile, tags['seriesInstanceUID'])
         shn.SetItemUID(seriesItemID, slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMUIDName(), seriesInstanceUid)
-        shn.SetItemAttribute(seriesItemID, slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMSeriesModalityAttributeName(),
-                             slicer.dicomDatabase.fileValue(firstFile, tags['seriesModality']))
-        shn.SetItemAttribute(seriesItemID, slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMSeriesNumberAttributeName(),
-                             slicer.dicomDatabase.fileValue(firstFile, tags['seriesNumber']))
-        shn.SetItemAttribute(seriesItemID, slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMFrameOfReferenceUIDAttributeName(),
-                             slicer.dicomDatabase.fileValue(firstFile, tags['frameOfReferenceUID']))
+        # These series attributes are specified in DICOM export
+        seriesAttributes = [
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMSeriesModalityAttributeName(), tags['seriesModality']],
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMSeriesNumberAttributeName(), tags['seriesNumber']],
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMFrameOfReferenceUIDAttributeName(), tags['frameOfReferenceUID']],
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMAttributePrefix() + "SeriesDescription", tags['seriesDescription']],
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMAttributePrefix() + "SeriesDate", tags['seriesDate']],
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMAttributePrefix() + "SeriesTime", tags['seriesTime']],
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMAttributePrefix() + "ContentDate", tags['contentDate']],
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMAttributePrefix() + "ContentTime", tags['contentTime']],
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMAttributePrefix() + "Manufacturer", tags['manufacturer']],
+            [slicer.vtkMRMLSubjectHierarchyConstants.GetDICOMAttributePrefix() + "Model", tags['model']],
+        ]
+        for attributeName, tag in seriesAttributes:
+            shn.SetItemAttribute(seriesItemID, attributeName, slicer.dicomDatabase.fileValue(firstFile, tag))
+
         # Set instance UIDs
         instanceUIDs = ""
         for file in loadable.files:

--- a/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMScalarVolumePlugin.py
@@ -567,7 +567,7 @@ class DICOMScalarVolumePluginClass(DICOMPlugin):
         exportable.setTag('SeriesTime', '')
         exportable.setTag('ContentDate', '')
         exportable.setTag('ContentTime', '')
-        exportable.setTag('SeriesNumber', '1')
+        exportable.setTag('SeriesNumber', '301')
         exportable.setTag('SeriesInstanceUID', '')
         exportable.setTag('FrameOfReferenceUID', '')
 

--- a/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
+++ b/Modules/Scripted/DICOMPlugins/DICOMVolumeSequencePlugin.py
@@ -102,7 +102,7 @@ class DICOMVolumeSequencePluginClass(DICOMPlugin):
         exportable.setTag('Manufacturer', 'Unknown manufacturer')
         exportable.setTag('Model', 'Unknown model')
         exportable.setTag('StudyID', '1')
-        exportable.setTag('SeriesNumber', '1')
+        exportable.setTag('SeriesNumber', '301')
         exportable.setTag('SeriesDate', '')
         exportable.setTag('SeriesTime', '')
 

--- a/Utilities/Scripts/update_translations.py
+++ b/Utilities/Scripts/update_translations.py
@@ -4,7 +4,8 @@
 
 Example use:
 
-    python.exe c:/D/S5/Utilities/Scripts/update_translations.py -s c:/D/S5 -t c:/D/SlicerLanguageTranslations/translations --lupdate c:/Qt/5.15.2/msvc2019_64/bin/lupdate.exe
+    python.exe c:/D/S5/Utilities/Scripts/update_translations.py -c Slicer -s c:/D/S5 -t c:/D/SlicerLanguageTranslations/translations
+      --lupdate c:/Qt/5.15.2/msvc2019_64/bin/lupdate.exe
 
 """
 
@@ -17,12 +18,12 @@ import subprocess
 import sys
 
 
-def update_translations(source_code_dir, translations_dir, lupdate_path, language=None, remove_obsolete_strings=False):
+def update_translations(component, source_code_dir, translations_dir, lupdate_path, language=None, remove_obsolete_strings=False):
 
     if language is None:
-        ts_filename_filter = "*.ts"
+        ts_filename_filter = f"{component}*.ts"
     else:
-        ts_filename_filter = f"*_{language}.ts"
+        ts_filename_filter = f"{component}*_{language}.ts"
 
     ts_file_filter = f"{translations_dir}/{ts_filename_filter}"
     ts_file_paths = glob.glob(ts_file_filter)
@@ -148,7 +149,9 @@ def main(argv):
     parser.add_argument("--lupdate", default="lupdate", dest="lupdate_path",
                         help="location of the Qt lupdate executable")
     parser.add_argument("-s", "--source-code", metavar="DIR", dest="source_code_dir",
-                        help="folder of application source code (root of https://github.com/Slicer/Slicer)")
+                        help="folder of application source code (root of repository, such as https://github.com/Slicer/Slicer)")
+    parser.add_argument("-c", "--component", dest="component", default="Slicer",
+                        help="translation component name (Slicer, CTK, ...)")
     parser.add_argument("-t", "--translations", dest="translations_dir", metavar="DIR",
                         default="-",
                         help="folder containing .ts translation files that will be updated (translations folder of https://github.com/Slicer/SlicerLanguageTranslations)")
@@ -163,8 +166,9 @@ def main(argv):
     if args.verbose:
         logging.basicConfig(format='%(message)s', level=logging.DEBUG)
 
-    extract_translatable_from_cli_modules(args.source_code_dir)
-    update_translations(args.source_code_dir, args.translations_dir, args.lupdate_path, args.language, args.remove_obsolete_strings)
+    if args.component == "Slicer":
+        extract_translatable_from_cli_modules(args.source_code_dir)
+    update_translations(args.component, args.source_code_dir, args.translations_dir, args.lupdate_path, args.language, args.remove_obsolete_strings)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In addition to series modality and series number, also read these fields from DICOM into metadata in the scene: seriesDescription, seriesDate, seriesTime, contentDate, contentTime, manufacturer, model.

This allows preserving more information when importing and then exporting DICOM images.

Also changed default series number to 301 (from 1) because values <100 are typically used for primary acquisitions, while higher numbers are used for processed data.