### PR TITLE
COMP: Update slicerMacroBuildApplication to check for valid application name

### DIFF
--- a/CMake/SlicerMacroBuildApplication.cmake
+++ b/CMake/SlicerMacroBuildApplication.cmake
@@ -344,6 +344,18 @@ macro(slicerMacroBuildApplication)
     message(STATUS "Setting ${SLICERAPP_APPLICATION_NAME} ${varname} to '${SLICERAPP_${varname}}'")
   endmacro()
 
+  # To avoid conflict between the revision specific settings folder name and the application name,
+  # the following checks that both are different.
+  #
+  # Note that while the name conflict is specific to Linux and happens only if
+  # Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR is ON (the default), the check
+  # is done unconditionally of the platform.
+  #
+  # See https://github.com/Slicer/Slicer/issues/6878
+  if(SLICERAPP_APPLICATION_NAME STREQUAL Slicer_ORGANIZATION_NAME)
+    message(FATAL_ERROR "Application name [${SLICERAPP_APPLICATION_NAME}] must be different from the organization name")
+  endif()
+
   _set_app_property("APPLICATION_NAME")
 
   macro(_set_path_var varname)


### PR DESCRIPTION
This commit adds an explicit check ensuring that the regression fixed by 17dccc679c (BUG: Change organization name and domain to slicer.org from Slicer) is not re-introduced.

To avoid conflict between the revision specific settings folder name and the application name, this commit adds a check ensuring that both are different.

Note that while the name conflict is specific to Linux and happens only if `Slicer_STORE_SETTINGS_IN_APPLICATION_HOME_DIR` is `ON` (the default), the check is done unconditionally of the platform and build option.

References:
* https://github.com/Slicer/Slicer/issues/6878
* https://discourse.slicer.org/t/install-extensions-is-not-working-on-latest-preview-release/28316/7