### PR TITLE
Migrate Read the Docs settings to file and switch from python 3.7 to 3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 # Ignore all dotfiles...
 .*
+!.codespellignore
+!.flake8
 !.gitattributes
 !.git-blame-ignore-revs
+!.pre-commit-config.yaml
 
 # Ignore all back-up files...
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !.gitattributes
 !.git-blame-ignore-revs
 !.pre-commit-config.yaml
+!.readthedocs.yaml
 
 # Ignore all back-up files...
 *~

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+sphinx:
+  builder: html
+  configuration: Docs/conf.py
+
+formats:
+  - epub
+  - pdf
+
+python:
+  install:
+  - requirements: requirements-docs.txt


### PR DESCRIPTION
Migrate Read the Docs settings to file and switch from python 3.7 to 3.9
    
This commit ensures the python version used to build the documentation matches the one available in Slicer.

References:
* https://docs.readthedocs.io/en/stable/config-file/v2.html#migrating-from-the-web-interface
* https://docs.readthedocs.io/en/stable/config-file/index.html

This should help move forward with the following pull-request:
* https://github.com/Slicer/Slicer/pull/6876