### PR TITLE
COMP: Fix missing QSslConfiguration include

### DIFF
--- a/Base/QTCore/qSlicerCoreApplication.cxx
+++ b/Base/QTCore/qSlicerCoreApplication.cxx
@@ -30,6 +30,7 @@
 #include <QNetworkProxyFactory>
 #include <QResource>
 #include <QSettings>
+#include <QSslConfiguration>
 #include <QTranslator>
 #include <QStandardPaths>
 #include <QTemporaryFile>


### PR DESCRIPTION
One of the changes introduced in Slicer/Slicer#6864 produces a compilation error (missing QSslConfiguration header) in some GNU/Linux distributions, more specifically on Gentoo, which deploys Qt 5.15.8-r3. In some versions of Qt, this might have been indirecly included in some other Qt headers, thus not producing the error.

This commit solves the issue by including `QSslConfiguration` explicitly. This change should work across operating systems.