### PR TITLE
BUG: Update CTK to fix crash when importing ctk or qt from standalone python

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "ef3d86b3b9053f4fa53e8e4a6ab9ab42db14f88b"
+    "a203172b634253cc3717346de30305ffe721d91c"
     QUIET
     )
 


### PR DESCRIPTION
List of CTK updates:

```
$ git shortlog ef3d86b3b..a203172b6 --no-merges
Jean-Christophe Fillion-Robin (2):
      STYLE: Use consistent indentation in qt/__init__.py.in
      BUG: Avoid segfault if importing qt & ctk python package in standalone python
```