### PR TITLE
BUG: Fix static control point measurements for closed curves

### DIFF
--- a/Modules/Loadable/Markups/MRML/vtkCurveMeasurementsCalculator.h
+++ b/Modules/Loadable/Markups/MRML/vtkCurveMeasurementsCalculator.h
@@ -100,7 +100,7 @@ public:
   /// using indices pedigreeIdsArray.
   /// pedigreeIdsValueScale is applied to values of pedigreeIdsArray, which can be used
   /// for converting between indices of curve points and curve control points.
-  static bool InterpolateArray(vtkDoubleArray* inputValues, vtkDoubleArray* interpolatedValues,
+  static bool InterpolateArray(vtkDoubleArray* inputValues, bool closedCurve, vtkDoubleArray* interpolatedValues,
     vtkDoubleArray* pedigreeIdsArray, double pedigreeIdsValueScale=1.0);
 
 protected:

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.cxx
@@ -394,7 +394,7 @@ void vtkMRMLMarkupsCurveNode::ResampleCurveWorld(double controlPointDistance)
   vtkNew<vtkDoubleArray> pedigreeIdsArray;
   vtkMRMLMarkupsCurveNode::ResamplePoints(points, interpolatedPoints, controlPointDistance, this->CurveClosed, pedigreeIdsArray);
   vtkMRMLMarkupsCurveNode::ResampleStaticControlPointMeasurements(this->Measurements, pedigreeIdsArray,
-    this->CurveGenerator->GetNumberOfPointsPerInterpolatingSegment());
+    this->CurveGenerator->GetNumberOfPointsPerInterpolatingSegment(), this->CurveClosed);
 
   vtkNew<vtkPoints> originalPoints;
   this->GetControlPointPositionsWorld(originalPoints);
@@ -407,7 +407,7 @@ void vtkMRMLMarkupsCurveNode::ResampleCurveWorld(double controlPointDistance)
 
 //---------------------------------------------------------------------------
 bool vtkMRMLMarkupsCurveNode::ResampleStaticControlPointMeasurements(vtkCollection* measurements,
-  vtkDoubleArray* curvePointsPedigreeIdsArray, int curvePointsPerControlPoint)
+  vtkDoubleArray* curvePointsPedigreeIdsArray, int curvePointsPerControlPoint, bool closedCurve)
 {
   if (!measurements || !curvePointsPedigreeIdsArray)
     {
@@ -438,7 +438,8 @@ bool vtkMRMLMarkupsCurveNode::ResampleStaticControlPointMeasurements(vtkCollecti
       }
     vtkNew<vtkDoubleArray> interpolatedMeasurement;
     interpolatedMeasurement->SetName(controlPointValues->GetName());
-    vtkCurveMeasurementsCalculator::InterpolateArray(controlPointValues, interpolatedMeasurement, curvePointsPedigreeIdsArray, 1.0/curvePointsPerControlPoint);
+    vtkCurveMeasurementsCalculator::InterpolateArray(controlPointValues, closedCurve,
+      interpolatedMeasurement, curvePointsPedigreeIdsArray, 1.0/curvePointsPerControlPoint);
     controlPointValues->DeepCopy(interpolatedMeasurement);
     }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsCurveNode.h
@@ -174,7 +174,8 @@ public:
     double samplingDistance, bool closedCurve, vtkDoubleArray* pedigreeIdsArray=nullptr);
 
   /// Resample static control point measurements using linear interpolation, based on fractional pedigreeIds.
-  static bool ResampleStaticControlPointMeasurements(vtkCollection* measurements, vtkDoubleArray* curvePointsPedigreeIdsArray, int curvePointsPerControlPoint);
+  static bool ResampleStaticControlPointMeasurements(vtkCollection* measurements, vtkDoubleArray* curvePointsPedigreeIdsArray,
+    int curvePointsPerControlPoint, bool closedCurve);
 
   /// Samples points along the curve at equal distances.
   /// If endPointIndex < startPointIndex then after the last point, the curve is assumed to continue at the first point.

--- a/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
+++ b/Modules/Loadable/Markups/Testing/Python/MarkupsCurveMeasurementsTest.py
@@ -178,6 +178,22 @@ for controlPointIndex in range(numberOfControlPoints):
     angle = 2.0 * math.pi * controlPointIndex / numberOfControlPoints
     closedCurveNode.AddControlPoint(vtk.vtkVector3d(radius * math.sin(angle), radius * math.cos(angle), 0.0))
 
+# Test static measurements for closed curve (differs from open curve in interpolation of the last curve segment)
+
+customStaticMeasurementArray = vtk.vtkDoubleArray()
+for controlPointIndex in range(numberOfControlPoints):
+    customStaticMeasurementArray.InsertNextValue(1 if controlPointIndex % 3 else 0)
+
+customStaticMeasurement = slicer.vtkMRMLStaticMeasurement()
+customStaticMeasurement.SetName('CustomStaticMeasurement')
+customStaticMeasurement.SetUnits('')
+customStaticMeasurement.SetPrintFormat("")
+customStaticMeasurement.SetControlPointValues(customStaticMeasurementArray)
+closedCurveNode.AddMeasurement(customStaticMeasurement)
+
+closedCurvePointData = closedCurveNode.GetCurveWorld().GetPointData()
+verifyArrays(closedCurvePointData, ["PedigreeIDs", "Tangents", "Normals", "Binormals", "CustomStaticMeasurement"])
+
 # Turn on curvature calculation in curve node
 closedCurveNode.GetMeasurement("curvature mean").SetEnabled(True)
 closedCurveNode.GetMeasurement("curvature max").SetEnabled(True)


### PR DESCRIPTION
When a custom measurement was added to a closed curve that contained control point values then the "Failed to add ... measurement array to curve" error was displayed and the measurement did not show up on the GUI.

The problem was that the pedigree IDs for the last curve segment points were considered out of range.

Fixed by accepting up to one more control point index when interpolating values on a closed curve. Values after the last control point index refer to points after the last control point that connect the curve to the first control point.