### PR TITLE
COMP: Add Dependabot workflow to update GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "COMP: "
+      prefix: "COMP"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
     name: Build Slicer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: 'Build Slicer'
         uses: ./.github/actions/slicer-build
 
       - name: 'Upload Slicer package'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
           name: slicer-package
           path: ${{ github.workspace }}/${{ steps.slicer-build.outputs.package }}

--- a/.github/workflows/update-slicer-certificate-bundle.yml
+++ b/.github/workflows/update-slicer-certificate-bundle.yml
@@ -15,7 +15,7 @@ jobs:
       CERTDATA_REPO: gecko-dev
       CERTDATA_PATH: security/nss/lib/ckfw/builtins/certdata.txt
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
       - name: Get sha and canonical download url for latest version of certdata.txt file
         id: latest_certdata
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3.14.0
         with:
           token: ${{ secrets.SLICERBOT_GITHUB_TOKEN }}
           commit-message: |


### PR DESCRIPTION
To avoid the need to manually update GitHub actions such as https://github.com/Slicer/Slicer/commit/a9b93e531c525546fce3936ea49826b03570bf95, this utilizes Dependabot to automatically issue PRs with updates.

With `COMP: Pin GitHub actions to full length commit SHA`, Dependabot will update with a pinned hash and will also [update the semver comment](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/).

Once integrated Dependabot will run and create PRs to update actions/upload-artifact and peter-evans/create-pull-request to the latest tagged version.