### PR TITLE
Generate pyi files for vtk and vtk based classes

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -202,7 +202,7 @@ endmacro()
 
 Slicer_Remote_Add(vtkAddon
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/vtkAddon"
-  GIT_TAG 4413fde380b744ab221f7beb4410e11a5158b496
+  GIT_TAG 4714c544f7912fa740e515ccfe2c8fee8e19570b # update-vtk-wrapping-to-support-pypi-generation
   OPTION_NAME Slicer_BUILD_vtkAddon
   )
 list_conditional_append(Slicer_BUILD_vtkAddon Slicer_REMOTE_DEPENDENCIES vtkAddon)

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "9b178707481f7539eb84a84e652dc48b85f60eff") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "f57a38857a0cd99d21bbba7b8580e206319d248e") # slicer-v9.1.20220125-efbe2afc2-pypi-support
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
* [ ] Publish a MR on upstream VTK with improvements to `generate_pyi` CLI (options `--include-docstrings` and `--without-package`) and finalize [Slicer/VTK@slicer-v9.1.20220125-efbe2afc2-pypi-support](https://github.com/Slicer/VTK/compare/slicer-v9.1.20220125-efbe2afc2...Slicer:VTK:slicer-v9.1.20220125-efbe2afc2-pypi-support)
* [ ] Finalize and integrate [vtkAddon@update-vtk-wrapping-to-support-pypi-generation](https://github.com/Slicer/vtkAddon/compare/update-vtk-wrapping-to-support-pypi-generation) branch
  * [ ] Check if version of VTK being used support pypi generation
  * [ ] Add option for enabling/disabling *.pyi generation
  * [ ] Add install rules (with option to disable installation). Custom application may want to have installation disabled by default.
* [ ] Look into creating a `slicer-stubs` package. See https://peps.python.org/pep-0561/#specification