### PR TITLE
ENH: Add option to disable python wrapping on loadable modules

### DIFF
--- a/Modules/Loadable/Colors/MRML/CMakeLists.txt
+++ b/Modules/Loadable/Colors/MRML/CMakeLists.txt
@@ -13,6 +13,11 @@ set(${KIT}_TARGET_LIBRARIES
   ${MRML_LIBRARIES}
   )
 
+set(DISABLE_WRAP_PYTHON)
+if(NOT Slicer_USE_PYTHONQT)
+  set(DISABLE_WRAP_PYTHON DISABLE_WRAP_PYTHON)
+endif()
+
 #-----------------------------------------------------------------------------
 SlicerMacroBuildModuleMRML(
   NAME ${KIT}
@@ -20,4 +25,5 @@ SlicerMacroBuildModuleMRML(
   INCLUDE_DIRECTORIES ${${KIT}_INCLUDE_DIRECTORIES}
   SRCS ${${KIT}_SRCS}
   TARGET_LIBRARIES ${${KIT}_TARGET_LIBRARIES}
+  ${DISABLE_WRAP_PYTHON}
   )


### PR DESCRIPTION
This makes the python wrapping for loadable module components depend on the `Slicer_USE_PYTHONQT` CMake variable. This avoids python wrapping when `Slicer_USE_PYTHONQT=OFF`, which can save generation of files that won't be used.

NOTE: For discussion purposes, so far, this PR applies the concept only to the MRML components of the Colors module, but the idea would be to apply this across modules and components. Alternatively, the `Slicer_USE_PYTHONQT` variable could be checked on the CMake SlicerBuild macros.

@pieper, @jcfr would these changes make sense to you?

