### PR TITLE
BUG: Fix warning when changing window/level with mouse mode

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -2405,57 +2405,28 @@ int vtkMRMLSliceLogic::GetEditableLayerAtWorldPosition(double worldPos[3],
     return vtkMRMLSliceLogic::LayerNone;
     }
 
-  bool foregroundEditable = this->VolumeWindowLevelEditable(sliceCompositeNode->GetForegroundVolumeID())
-    && foregroundVolumeEditable;
-  bool backgroundEditable = this->VolumeWindowLevelEditable(sliceCompositeNode->GetBackgroundVolumeID())
-    && backgroundVolumeEditable;
-
-  if (!foregroundEditable && !backgroundEditable)
+  if (!foregroundVolumeEditable && !backgroundVolumeEditable)
     {
     // window/level editing is disabled on both volumes
     return vtkMRMLSliceLogic::LayerNone;
     }
   // By default adjust background volume, if available
-  bool adjustForeground = !backgroundEditable;
+  bool adjustForeground = !backgroundVolumeEditable;
 
   // If both foreground and background volumes are visible then choose adjustment of
   // foreground volume, if foreground volume is visible in current mouse position
-  if (foregroundEditable && backgroundEditable)
+  if (foregroundVolumeEditable && backgroundVolumeEditable)
     {
     adjustForeground = (sliceCompositeNode->GetForegroundOpacity() >= 0.01)
       && this->IsEventInsideVolume(true, worldPos)   // inside background (used as mask for displaying foreground)
       && this->vtkMRMLSliceLogic::IsEventInsideVolume(false, worldPos); // inside foreground
     }
 
-  return (adjustForeground ? vtkMRMLSliceLogic::LayerForeground : vtkMRMLSliceLogic::LayerBackground);
-}
+  adjustForeground = (sliceCompositeNode->GetForegroundOpacity() >= 0.01)
+    && this->IsEventInsideVolume(true, worldPos)   // inside background (used as mask for displaying foreground)
+    && this->vtkMRMLSliceLogic::IsEventInsideVolume(false, worldPos); // inside foreground
 
-//----------------------------------------------------------------------------
-bool vtkMRMLSliceLogic::VolumeWindowLevelEditable(const char* volumeNodeID)
-{
-  if (!volumeNodeID)
-    {
-    return false;
-    }
-  vtkMRMLScene *scene = this->GetMRMLScene();
-  if (!scene)
-    {
-    return false;
-    }
-  vtkMRMLVolumeNode* volumeNode =
-    vtkMRMLVolumeNode::SafeDownCast(scene->GetNodeByID(volumeNodeID));
-  if (volumeNode == nullptr)
-    {
-    return false;
-    }
-  vtkMRMLScalarVolumeDisplayNode* scalarVolumeDisplayNode =
-    vtkMRMLScalarVolumeDisplayNode::SafeDownCast(volumeNode->GetVolumeDisplayNode());
-  if (!scalarVolumeDisplayNode)
-    {
-    return false;
-    }
-  vtkWarningMacro("vtkMRMLSliceLogic::VolumeWindowLevelEditable method is deprecated. Volume window level can always be set programmatically.");
-  return true;
+  return (adjustForeground ? vtkMRMLSliceLogic::LayerForeground : vtkMRMLSliceLogic::LayerBackground);
 }
 
 //----------------------------------------------------------------------------

--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -430,8 +430,13 @@ protected:
   /// Use background flag to choose between foreground/background layer.
   bool IsEventInsideVolume(bool background, double worldPos[3]);
 
-  /// Returns true if the volume's window/level values are editable on the GUI.
-  bool VolumeWindowLevelEditable(const char* volumeNodeID);
+  /// Deprecated. Returns true if the volume's window/level values are editable on the GUI.
+  bool VolumeWindowLevelEditable(const char* volumeNodeID)
+  {
+    vtkWarningMacro("vtkMRMLSliceLogic::VolumeWindowLevelEditable method is deprecated. Volume Window Level is always editable. Use the interaction node to check if in editing mode. "
+                    "e.g. slicer.app.applicationLogic().GetInteractionNode().GetCurrentInteractionMode() == slicer.vtkMRMLInteractionNode.AdjustWindowLevel");
+    return true;
+  };
 
   bool                        AddingSliceModelNodes;
 


### PR DESCRIPTION
This fixes an issue that would always log the following warning when changing Window/Level with the mouse mode. This issue was introduced in my commit https://github.com/Slicer/Slicer/commit/2896452063e2bcd5526934cd032f68603fd572ff where I removed the Window/Level locked state for a given volume. This logic was there to previously check if the volume in the slice viewer had an unlocked Window/Level state.
```
[VTK] Warning: In D:\D\P\S-0\Libs\MRML\Logic\vtkMRMLSliceLogic.cxx, line 2457
[VTK] vtkMRMLSliceLogic (00000246B7D8E270): vtkMRMLSliceLogic::VolumeWindowLevelEditable method is deprecated. Volume window level can always be set programmatically.
```