### PR TITLE
COMP: Pin more GitHub actions to full length commit SHA

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: Slicer/actions-codespell@2cde61fa89ae8708e737c8204a7ed50de5b4c5b8
         with:
           check_filenames: true

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Commit Prefix
-        uses: gsactions/commit-message-checker@v2
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2.0.0
         with:
           pattern: '^(ENH|PERF|BUG|STYLE|DOC|COMP): ([A-Z])+'
           flags: 'gm'
@@ -26,7 +26,7 @@ jobs:
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
           accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
       - name: Check Line Length
-        uses: gsactions/commit-message-checker@v2
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2.0.0
         with:
           pattern: '^[^#].{1,78}$'
           error: 'The maximum line length of 78 characters is exceeded. For more details, see https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html#commits'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
         python-version: '3.9'
 
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0


### PR DESCRIPTION
This is a followup to https://github.com/Slicer/Slicer/commit/73f549c1e698a087c550c193e849e7a03645113f.

GitHub's security hardening guide recommends this mitigation method. https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions