### PR TITLE
COMP: Fix -Wunused-parameter in vtkMRMLSliceLogic::VolumeWindowLevelEditable

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -431,7 +431,7 @@ protected:
   bool IsEventInsideVolume(bool background, double worldPos[3]);
 
   /// Deprecated. Returns true if the volume's window/level values are editable on the GUI.
-  bool VolumeWindowLevelEditable(const char* volumeNodeID)
+  bool VolumeWindowLevelEditable(const char* vtkNotUsed(volumeNodeID))
   {
     vtkWarningMacro("vtkMRMLSliceLogic::VolumeWindowLevelEditable method is deprecated. Volume Window Level is always editable. Use the interaction node to check if in editing mode. "
                     "e.g. slicer.app.applicationLogic().GetInteractionNode().GetCurrentInteractionMode() == slicer.vtkMRMLInteractionNode.AdjustWindowLevel");


### PR DESCRIPTION
This commit fixes the following warning introduced in 4a73c3a75 (BUG: Fix warning when changing window/level with mouse mode) through https://github.com/Slicer/Slicer/pull/6857:

```
/path/to/Slicer/Libs/MRML/Logic/vtkMRMLSliceLogic.h: In member function ‘bool vtkMRMLSliceLogic::VolumeWindowLevelEditable(const char*)’: /path/to/Slicer/Libs/MRML/Logic/vtkMRMLSliceLogic.h:434:46: warning: unused parameter ‘volumeNodeID’ [-Wunused-parameter]
  434 |   bool VolumeWindowLevelEditable(const char* volumeNodeID)
      |                                  ~~~~~~~~~~~~^~~~~~~~~~~~
```