### PR TITLE
COMP: Fix -Wrange-loop-construct in Markups module

### DIFF
--- a/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
+++ b/Modules/Loadable/Markups/Logic/vtkSlicerMarkupsLogic.cxx
@@ -1710,7 +1710,7 @@ void vtkSlicerMarkupsLogic::ConvertAnnotationLinesROIsToMarkups(vtkStringArray* 
         {
         std::vector<std::string> roles;
         referencingNode->GetNodeReferenceRoles(roles);
-        for (const std::string role : roles)
+        for (const std::string& role : roles)
           {
           std::vector<const char*> referencedNodeIds;
           referencingNode->GetNodeReferenceIDs(role.c_str(), referencedNodeIds);

--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -472,7 +472,7 @@ void qMRMLMarkupsToolBar::updateToolBarLayout()
     return;
     }
 
-  for (const auto markupName : markupsLogic->GetRegisteredMarkupsTypes())
+  for (const auto& markupName : markupsLogic->GetRegisteredMarkupsTypes())
     {
     vtkMRMLMarkupsNode* markupsNode = markupsLogic->GetNodeByMarkupsType(markupName.c_str());
     if (markupsNode && markupsLogic->GetCreateMarkupsPushButton(markupName.c_str()))
@@ -514,7 +514,7 @@ void qMRMLMarkupsToolBar::updateToolBarLayout()
       continue;
       }
     bool markupExists = false;
-    for (const auto markupName : markupsLogic->GetRegisteredMarkupsTypes())
+    for (const auto& markupName : markupsLogic->GetRegisteredMarkupsTypes())
       {
       //QString markupButtonName = QString("Create%1PushButton").arg(QString::fromStdString(markupName));
       if (QString::fromStdString("Create"+markupName+"PushButton") == buttonName)

--- a/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
+++ b/Modules/Loadable/Markups/qSlicerMarkupsModuleWidget.cxx
@@ -790,7 +790,7 @@ void qSlicerMarkupsModuleWidgetPrivate::createMarkupsPushButtons()
 
   unsigned int i=0;
 
-  for(const auto markupName: q->markupsLogic()->GetRegisteredMarkupsTypes())
+  for(const auto& markupName: q->markupsLogic()->GetRegisteredMarkupsTypes())
     {
     vtkMRMLMarkupsNode* markupsNode =
       markupsLogic->GetNodeByMarkupsType(markupName.c_str());


### PR DESCRIPTION
This adds the reference operator to the variables used in for-range loops. This removes the `-Wrange-loop-construct` warning and avoids non-needed copies of variables.