### PR TITLE
COMP: Update VTK to fix Windows build error related to .pyi files generation

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "9b178707481f7539eb84a84e652dc48b85f60eff") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "3ecff39979df7b7f4a288ba64ecccb5108fc2a8a") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This commit fixes a regression introduced in 396c8e5d0a (BUG: Fix crash in vtkPolyData::BuildCells() and add .pyi generator) where the feature for generation pyi files was inadvertently integrated.

The Windows build is fixed by removing `vtkpythonmodules_pyi` from the default target (the "ALL" parameter was commented out) in the associated custom target.

Until this is addressed, this should ensure the build succeeds.

```
Creating .pyi files for vtkpythonmodules
Traceback (most recent call last):
  File "C:\path\to\S-0-build\python-install\Lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\path\to\S-0-build\python-install\Lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\path\to\S-0-build\VTK-build\bin\Lib\site-packages\vtkmodules\generate_pyi.py", line 37, in <module>
    from vtkmodules.vtkCommonCore import vtkObject, vtkSOADataArrayTemplate
ImportError: DLL load failed while importing vtkCommonCore: The specified module could not be found.
```

List of VTK changes:

```
$ git shortlog 9b17870748..3ecff39979 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix Windows build removing vtkpythonmodules_pyi from the default target
```