### PR TITLE
COMP: Ensure Qt language tools are bundled on macOS

### DIFF
--- a/CMake/SlicerBlockInstallQt.cmake
+++ b/CMake/SlicerBlockInstallQt.cmake
@@ -191,28 +191,3 @@ set(QT_INSTALL_LIB_DIR ${Slicer_INSTALL_LIB_DIR})
       FILES "${Slicer_INSTALL_ROOT}/bin/designer-real"
       COMPONENT Runtime)
   endif()
-
-  # Bundle Qt language tools with the application if internationalization is enabled.
-  # These tools allow Slicer modules to update and process Qt translation (.ts) files
-  # without requiring installation of Qt.
-  if(Slicer_BUILD_I18N_SUPPORT)
-    foreach(tool lconvert lrelease lupdate)
-      install(PROGRAMS ${qt_root_dir}/bin/${tool}${CMAKE_EXECUTABLE_SUFFIX}
-        DESTINATION ${Slicer_INSTALL_ROOT}/bin COMPONENT Runtime
-        )
-      slicerStripInstalledLibrary(
-        FILES "${Slicer_INSTALL_ROOT}/bin/${tool}"
-        COMPONENT Runtime
-        )
-      if(APPLE)
-        set(dollar "$")
-        install(CODE
-          "set(app ${Slicer_INSTALL_BIN_DIR}/${tool})
-          set(appfilepath \"${dollar}ENV{DESTDIR}${dollar}{CMAKE_INSTALL_PREFIX}/${dollar}{app}\")
-          message(\"CPack: - Adding rpath to ${dollar}{app}\")
-          execute_process(COMMAND install_name_tool -add_rpath @loader_path/..  ${dollar}{appfilepath})"
-          COMPONENT Runtime
-          )
-      endif()
-    endforeach()
-  endif()

--- a/CMake/SlicerBlockInstallQtTools.cmake
+++ b/CMake/SlicerBlockInstallQtTools.cmake
@@ -1,0 +1,32 @@
+set(Slicer_INSTALLED_QT_TOOLS)
+
+if(Slicer_BUILD_I18N_SUPPORT)
+  # Bundle Qt language tools with the application if internationalization is enabled.
+  # These tools allow Slicer modules to update and process Qt translation (.ts) files
+  # without requiring installation of Qt.
+  list(APPEND Slicer_INSTALLED_QT_TOOLS
+    lconvert
+    lrelease
+    lupdate
+  )
+endif()
+
+foreach(tool IN LISTS Slicer_INSTALLED_QT_TOOLS)
+  install(PROGRAMS ${qt_root_dir}/bin/${tool}${CMAKE_EXECUTABLE_SUFFIX}
+    DESTINATION ${Slicer_INSTALL_ROOT}/bin COMPONENT Runtime
+    )
+  slicerStripInstalledLibrary(
+    FILES "${Slicer_INSTALL_ROOT}/bin/${tool}"
+    COMPONENT Runtime
+    )
+  if(APPLE)
+    set(dollar "$")
+    install(CODE
+      "set(app ${Slicer_INSTALL_BIN_DIR}/${tool})
+      set(appfilepath \"${dollar}ENV{DESTDIR}${dollar}{CMAKE_INSTALL_PREFIX}/${dollar}{app}\")
+      message(\"CPack: - Adding rpath to ${dollar}{app}\")
+      execute_process(COMMAND install_name_tool -add_rpath @loader_path/..  ${dollar}{appfilepath})"
+      COMPONENT Runtime
+      )
+  endif()
+endforeach()

--- a/CMake/SlicerCPack.cmake
+++ b/CMake/SlicerCPack.cmake
@@ -28,6 +28,8 @@ if(Slicer_USE_PYTHONQT AND NOT Slicer_USE_SYSTEM_python)
 endif()
 
 if(NOT Slicer_USE_SYSTEM_QT)
+  include(${Slicer_CMAKE_DIR}/SlicerBlockInstallQtTools.cmake)
+
   set(SlicerBlockInstallQtPlugins_subdirectories
     audio
     imageformats


### PR DESCRIPTION
This commit is a follow-up of 0a00473ea (ENH: Bundle Qt language tools).

It factors out the logic for installing the tools into a CMake module included on all platforms.

Notes:
* The module `SlicerBlockInstallQtTools.cmake` was designed to eventually support installing other Qt tools.
* Since the bundling of Qt designer is implemented in two files `SlicerCPack.cmake` and `SlicerCPackBundleFixup.cmake.in` included at either build or packaging time, the refactoring the associated installation code is a more involved task that does not belong to this pull request. 