### PR TITLE
COMP: Update VTK to fix packaging error due to non-existent .pyi files

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "3ecff39979df7b7f4a288ba64ecccb5108fc2a8a") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "f6bcc9d3e350df4f1d77d856be9e7484c8655f87") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This commit is a follow of fa749969c (COMP: Update VTK to fix Windows build error related to .pyi files generation) introduced through:
* https://github.com/Slicer/Slicer/pull/6903 

The packaging error copied below is resolved by commenting the rules attempting to install non-existent pyi files.

Packaging error:

```
CMake Error at VTK-build/cmake_install.cmake:3570 (file): file INSTALL cannot find
"/.../Slicer-0-build/VTK-build/lib/python3.9/site-packages/vtkmodules/vtkCommonCore.pyi": No such file or directory.
```

List of VTK changes:
```
$ git shortlog 3ecff39979..f6bcc9d3e3 --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix packaging removing install rules associated with non-existent pyi files
```