### PR TITLE
COMP: Fix packaging of Qt tools

### DIFF
--- a/CMake/SlicerBlockInstallQtTools.cmake
+++ b/CMake/SlicerBlockInstallQtTools.cmake
@@ -1,3 +1,35 @@
+
+# Get root directory
+get_property(_filepath TARGET "Qt5::Core" PROPERTY LOCATION_RELEASE)
+get_filename_component(_dir ${_filepath} PATH)
+if(APPLE)
+  # "_dir" of the form "<qt_root_dir>/lib/QtCore.framework"
+  set(qt_root_dir "${_dir}/../..")
+else()
+  # "_dir" of the form "<qt_root_dir>/lib"
+  set(qt_root_dir "${_dir}/..")
+endif()
+
+# Sanity checks
+set(expected_defined_vars
+  Slicer_BUILD_I18N_SUPPORT
+  Slicer_INSTALL_BIN_DIR
+  )
+foreach(var ${expected_defined_vars})
+  if(NOT DEFINED ${var})
+    message(FATAL_ERROR "Variable ${var} is not defined !")
+  endif()
+endforeach()
+
+set(expected_existing_vars
+  qt_root_dir
+  )
+foreach(var ${expected_existing_vars})
+  if(NOT EXISTS "${${var}}")
+    message(FATAL_ERROR "Variable ${var} is set to an inexistent directory or file ! [${${var}}]")
+  endif()
+endforeach()
+
 set(Slicer_INSTALLED_QT_TOOLS)
 
 if(Slicer_BUILD_I18N_SUPPORT)
@@ -12,11 +44,16 @@ if(Slicer_BUILD_I18N_SUPPORT)
 endif()
 
 foreach(tool IN LISTS Slicer_INSTALLED_QT_TOOLS)
-  install(PROGRAMS ${qt_root_dir}/bin/${tool}${CMAKE_EXECUTABLE_SUFFIX}
-    DESTINATION ${Slicer_INSTALL_ROOT}/bin COMPONENT Runtime
+  set(tool_executable ${qt_root_dir}/bin/${tool}${CMAKE_EXECUTABLE_SUFFIX})
+  if(NOT EXISTS "${tool_executable}")
+    message(FATAL_ERROR "Qt tool ${tool} not found: ${tool_executable}")
+  endif()
+  install(PROGRAMS ${tool_executable}
+    DESTINATION ${Slicer_INSTALL_BIN_DIR}
+    COMPONENT Runtime
     )
   slicerStripInstalledLibrary(
-    FILES "${Slicer_INSTALL_ROOT}/bin/${tool}"
+    FILES "${Slicer_INSTALL_BIN_DIR}/${tool}"
     COMPONENT Runtime
     )
   if(APPLE)


### PR DESCRIPTION
This commit fixes a regression introduced in 4c91fd052 (COMP: Ensure Qt language tools are bundled on macOS) through the pull-request:
* https://github.com/Slicer/Slicer/pull/6904


... that was originally intended to fix issue:
* https://github.com/Slicer/Slicer/issues/6896


It sets the variable `qt_root_dir` and adds the relevant checks to report an error at configuration time.