### PR TITLE
COMP: Update CTK to fix build of CTK DICOM Core library

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "c819ae7376b2c5677430ac18e430a16abfc9fa4b"
+    "04618a43f83448838b2b89dbab8b4a215308552e"
     QUIET
     )
 


### PR DESCRIPTION
This commit fixes a regression introduced in 2e4cfbd9a2 (BUG: Update CTK to make DICOM browser translatable)

It ensures the build works on case-sensitive file-system by consistently including Qt headers.

List of CTK changes:

```
$ git shortlog c819ae737..04618a43f --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Fix DICOM/Core build ensuring Qt headers can always be included
```

Related issues and pull-requests:
* https://github.com/commontk/CTK/pull/1068
* https://github.com/commontk/CTK/pull/1074