### PR TITLE
ENH: Remove exposure of `ui_*.h` files from public `.h` files 

### DIFF
--- a/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
+++ b/Modules/Loadable/Markups/Widgets/qMRMLMarkupsToolBar.cxx
@@ -19,14 +19,16 @@
 ==============================================================================*/
 
 // Qt includes
-#include <QDebug>
-#include <QToolButton>
-#include <QMenu>
 #include <QCheckBox>
+#include <QDebug>
+#include <QKeySequence>
+#include <QLayout>
+#include <QMenu>
+#include <QPushButton>
+#include <QShortcut>
 #include <QSignalMapper>
 #include <QSplitter>
-#include <QShortcut>
-#include <QKeySequence>
+#include <QToolButton>
 
 // Slicer includes
 #include "qSlicerCoreApplication.h"

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.cxx
@@ -20,6 +20,7 @@
 
 // Markups Widgets includes
 #include "qSlicerMarkupsPlaceWidget.h"
+#include "ui_qSlicerMarkupsPlaceWidget.h"
 
 // Markups includes
 #include <vtkSlicerMarkupsLogic.h>

--- a/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qSlicerMarkupsPlaceWidget.h
@@ -28,14 +28,13 @@
 
 // Markups Widgets includes
 #include "qSlicerMarkupsModuleWidgetsExport.h"
-#include "ui_qSlicerMarkupsPlaceWidget.h"
 
-
-class qSlicerMarkupsPlaceWidgetPrivate;
 class vtkMRMLInteractionNode;
 class vtkMRMLSelectionNode;
 class vtkMRMLMarkupsFiducialNode;
 class vtkMRMLMarkupsNode;
+class qSlicerMarkupsPlaceWidgetPrivate;
+class QToolButton;
 
 /// \ingroup Slicer_QtModules_CreateModels
 class Q_SLICER_MODULE_MARKUPS_WIDGETS_EXPORT

--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.cxx
@@ -20,6 +20,7 @@
 
 // Markups Widgets includes
 #include "qSlicerSimpleMarkupsWidget.h"
+#include "ui_qSlicerSimpleMarkupsWidget.h"
 
 // Markups includes
 #include <vtkSlicerMarkupsLogic.h>

--- a/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.h
+++ b/Modules/Loadable/Markups/Widgets/qSlicerSimpleMarkupsWidget.h
@@ -28,10 +28,12 @@
 
 // Markups Widgets includes
 #include "qSlicerMarkupsModuleWidgetsExport.h"
-#include "ui_qSlicerSimpleMarkupsWidget.h"
-
 
 class qSlicerSimpleMarkupsWidgetPrivate;
+class vtkMRMLInteractionNode;
+class QTableWidget;
+class qSlicerMarkupsPlaceWidget;
+class qMRMLNodeComboBox;
 
 /// \ingroup Slicer_QtModules_CreateModels
 class Q_SLICER_MODULE_MARKUPS_WIDGETS_EXPORT

--- a/Modules/Loadable/Plots/Widgets/qMRMLPlotChartPropertiesWidget.cxx
+++ b/Modules/Loadable/Plots/Widgets/qMRMLPlotChartPropertiesWidget.cxx
@@ -26,6 +26,7 @@
 // qMRML includes
 #include "qMRMLPlotChartPropertiesWidget.h"
 #include "qMRMLPlotChartPropertiesWidget_p.h"
+#include "ui_qMRMLPlotChartPropertiesWidget.h"
 
 // MRML includes
 #include <vtkMRMLColorNode.h>

--- a/Modules/Loadable/Plots/Widgets/qMRMLPlotChartPropertiesWidget.h
+++ b/Modules/Loadable/Plots/Widgets/qMRMLPlotChartPropertiesWidget.h
@@ -26,9 +26,11 @@
 // CTK includes
 #include <ctkPimpl.h>
 
+// qMRMLWidgets includes
+#include <qMRMLWidget.h>
+
 // Plots Widgets includes
 #include "qSlicerPlotsModuleWidgetsExport.h"
-#include "ui_qMRMLPlotChartPropertiesWidget.h"
 
 class qMRMLPlotChartPropertiesWidgetPrivate;
 class vtkMRMLNode;

--- a/Modules/Loadable/Plots/Widgets/qMRMLPlotSeriesPropertiesWidget.cxx
+++ b/Modules/Loadable/Plots/Widgets/qMRMLPlotSeriesPropertiesWidget.cxx
@@ -25,6 +25,7 @@
 
 // qMRML includes
 #include "qMRMLPlotSeriesPropertiesWidget_p.h"
+#include "ui_qMRMLPlotSeriesPropertiesWidget.h"
 
 // MRML includes
 #include <vtkMRMLColorNode.h>

--- a/Modules/Loadable/Plots/Widgets/qMRMLPlotSeriesPropertiesWidget.h
+++ b/Modules/Loadable/Plots/Widgets/qMRMLPlotSeriesPropertiesWidget.h
@@ -26,9 +26,11 @@
 // CTK includes
 #include <ctkPimpl.h>
 
+// qMRMLWidgets includes
+#include <qMRMLWidget.h>
+
 // Plots Widgets includes
 #include "qSlicerPlotsModuleWidgetsExport.h"
-#include "ui_qMRMLPlotSeriesPropertiesWidget.h"
 
 class qMRMLPlotSeriesPropertiesWidgetPrivate;
 class vtkMRMLNode;

--- a/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.cxx
+++ b/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.cxx
@@ -20,6 +20,7 @@
 
 // Tables Widgets includes
 #include "qSlicerTableColumnPropertiesWidget.h"
+#include "ui_qSlicerTableColumnPropertiesWidget.h"
 
 // Markups includes
 //#include <vtkSlicerTablesLogic.h>

--- a/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.h
+++ b/Modules/Loadable/Tables/Widgets/qSlicerTableColumnPropertiesWidget.h
@@ -28,8 +28,6 @@
 
 // Tables Widgets includes
 #include "qSlicerTablesModuleWidgetsExport.h"
-#include "ui_qSlicerTableColumnPropertiesWidget.h"
-
 
 class qSlicerTableColumnPropertiesWidgetPrivate;
 class vtkMRMLTableNode;

--- a/Modules/Loadable/Texts/Widgets/qMRMLTextWidget.cxx
+++ b/Modules/Loadable/Texts/Widgets/qMRMLTextWidget.cxx
@@ -20,6 +20,7 @@
 
 // Texts widgets includes
 #include "qMRMLTextWidget.h"
+#include "ui_qMRMLTextWidget.h"
 
 // MRML includes
 #include <vtkMRMLTextNode.h>

--- a/Modules/Loadable/Texts/Widgets/qMRMLTextWidget.h
+++ b/Modules/Loadable/Texts/Widgets/qMRMLTextWidget.h
@@ -26,7 +26,6 @@
 
 // Text widgets includes
 #include "qSlicerTextsModuleWidgetsExport.h"
-#include "ui_qMRMLTextWidget.h"
 
 class vtkMRMLNode;
 class vtkMRMLTextNode;


### PR DESCRIPTION
~~This adds the installation of the `ui_*.h` files as development files (headers) in `SlicerMacroBuildModuleQtLibrary`~~ This remove the inclusion of `ui_*.h` files (private) into `*.h` (public) headers. (see discussion below)

This is needed for modules building on install trees (of other modules or Slicer).