### PR TITLE
ENH: Add 3D cursor as crosshair options with fast picking

### DIFF
--- a/Base/QTGUI/qSlicerViewersToolBar.h
+++ b/Base/QTGUI/qSlicerViewersToolBar.h
@@ -55,6 +55,8 @@ public slots:
 
   void setMRMLScene(vtkMRMLScene* newScene);
 
+  void change3DViewsCursorTo(QCursor cursor);
+
 protected:
   QScopedPointer<qSlicerViewersToolBarPrivate> d_ptr;
 

--- a/Base/QTGUI/qSlicerViewersToolBar_p.h
+++ b/Base/QTGUI/qSlicerViewersToolBar_p.h
@@ -89,6 +89,7 @@ public slots:
   void setCrosshairEnabled(bool); // used to toggle between last style and off
   void setCrosshairThickness(int);
   void setCrosshairJumpSlicesMode(int);
+  void setCrosshairTrackCursor(bool);
 
   void setIntersectingSlicesIntersectionMode(int);
   void setIntersectingSlicesVisibility(bool);
@@ -121,6 +122,8 @@ public:
   QAction* CrosshairFineAction{nullptr};
   QAction* CrosshairMediumAction{nullptr};
   QAction* CrosshairThickAction{nullptr};
+
+  QAction *TrackCursorAction{nullptr};
 
   QAction* CrosshairToggleAction{nullptr};
 

--- a/Libs/MRML/Core/vtkMRMLCrosshairNode.h
+++ b/Libs/MRML/Core/vtkMRMLCrosshairNode.h
@@ -81,6 +81,13 @@ class VTK_MRML_EXPORT vtkMRMLCrosshairNode : public vtkMRMLNode
   static int GetCrosshairBehaviorFromString(const char* name);
   ///@}
 
+  ///@{
+  /// If trackCursor is enabled, the crosshair is mouse tracked.
+  vtkGetMacro(TrackCursor, bool);
+  vtkSetMacro(TrackCursor, bool);
+  vtkBooleanMacro(TrackCursor, bool);
+  ///@}
+
   ///
   /// Set cursor position in 3D.
   /// This should be called whenever the cursor is moved by using a 3D positioning device
@@ -185,6 +192,7 @@ protected:
   int CrosshairMode{NoCrosshair};
   int CrosshairThickness{Fine};
   int CrosshairBehavior{OffsetJumpSlice};
+  bool TrackCursor{false};
   float CrosshairColor[3]{1.0f, 0.8f, 0.1f}; // Light yellow
 
   double CrosshairRAS[3]{0.0, 0.0, 0.0};


### PR DESCRIPTION
Add new 3D Cursor option in crosshair toolbar.
This allows to continuously pick volume with fast picking.
The basic Qt cursor is replaced by a crosshair.

[Discourse Slicer reference for more information](https://discourse.slicer.org/t/3d-mouse-cursor-for-stereoscopic-displays/28370)


https://user-images.githubusercontent.com/11785751/227495055-829a03d7-b5ab-4d8a-890d-2c53c982fb1f.mp4


@LucasGandel 