### PR TITLE
DOC: Fix use of admonition directives in "getting started" and "build instructions"

### DIFF
--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -19,6 +19,7 @@
 import lxml.etree as ET
 import os
 import sys
+from datetime import date
 
 sys.path.insert(0, os.path.abspath('../Base/Python'))
 
@@ -73,7 +74,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = '3D Slicer'
-copyright = '2020, Slicer Community'
+copyright = f'{date.today().year}, Slicer Community'
 author = 'Slicer Community'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/Docs/developer_guide/build_instructions/linux.md
+++ b/Docs/developer_guide/build_instructions/linux.md
@@ -57,8 +57,7 @@ sudo apt update && sudo apt install git subversion build-essential cmake cmake-c
 
 ### Ubuntu 20.04 (Focal Fossa)
 
-:::{note} Warning
-:class: warning
+:::{warning}
 Since the default Qt5 packages available on Ubuntu 20.04 correspond to version 5.12.8 and version 5.15.2 is used to build and test the packages available for download. Compiling Slicer against version 5.12.8 may not succeed, and if it does, the compiled Slicer application may behave differently.
 
 To use Qt 5.15.2, we recommend you download and install following [these instructions](./linux.md#any-distribution)
@@ -74,8 +73,7 @@ sudo apt update && sudo apt install git subversion build-essential cmake cmake-c
 
 ### ArchLinux
 
-:::{note} Warning
-:class: warning
+:::{cautious}
 ArchLinux uses a rolling-release package distribution approach. This means that the versions of the packages will change over time and the following instructions might not be actual. **Last time tested: 2022-03-08.**
 :::
 
@@ -110,9 +108,7 @@ sudo yum install patch mesa-libGL-devel libuuid-devel
 
 This section describes how to install Qt as distributed by *The QT Company*, which can be used for any GNU/Linux distribution.
 
-:::{note} Warning
-:class: warning
-
+:::{important}
 This process requires an account in [qt.io](https://qt.io) 
 
 :::
@@ -141,9 +137,7 @@ export QT_ACCOUNT_PASSWORD=<set your password here>
   --email $QT_ACCOUNT_LOGIN \
   --pw $QT_ACCOUNT_PASSWORD
 ```
-:::{note} Warning
-:class: warning
-
+:::{hint}
 When configuring the Slicer build project, the CMake variable `Qt5_DIR` need to be set using the full path to the Qt5 installation directory ending with `5.15.2/gcc_64/lib/cmake/Qt5`. For example, assuming you installed Qt in `/opt/qt`, you may use `cmake -DCMAKE_BUILD_TYPE:STRING=Release -DQt5_DIR:PATH=/opt/qt/5.15.2/gcc_64/lib/cmake/Qt5 ../Slicer`.
 
 :::
@@ -159,9 +153,7 @@ git clone https://github.com/Slicer/Slicer.git
 This will create a `Slicer` directory containing the source code of Slicer.
 Hereafter we will call this directory the `source directory`.
 
-:::{note} Warning
-:class: warning
-
+:::{tip}
 It is highly recommended to **avoid** the use of the **space** character in the name of the `source directory` or any of its parent directories.
 
 :::

--- a/Docs/user_guide/getting_started.md
+++ b/Docs/user_guide/getting_started.md
@@ -91,8 +91,7 @@ The following may be needed on fresh debian or ubuntu:
     sudo apt-get install libpulse-dev libnss3 libglu1-mesa
     sudo apt-get install --reinstall libxcb-xinerama0
 
-:::{note} Warning
-:class: warning
+:::{warning}
 
 Debian 10.12 users may encounter an error when launching Slicer:
 


### PR DESCRIPTION
(1) Switch from

```
:::{note} Warning
:class: warning
```

to

```
:::{warning}
```

(2) Update the type of admonition:

* ArchLinux uses a rolling-release: warning -> cautious
* Build on any Distribution: warning -> important
* `Qt5_DIR` need to be set using the full path: warning -> hint
* recommended to avoid use of spaces: warning -> tip