### PR TITLE
ENH: Update CTK to latest version to improve translations

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "04618a43f83448838b2b89dbab8b4a215308552e"
+    "83a570aacc2ef745b595c92ff475ef314be884ff"
     QUIET
     )
 


### PR DESCRIPTION
More strings are now marked as translatable in CTK, particularly in the DICOM module.

Change log:

Revision: 83a570aacc2ef745b595c92ff475ef314be884ff
Author: Andras Lasso <lasso@queensu.ca>
Date: 2023-04-05 12:33:30 PM
Message:
BUG: Make DICOM database table view headings translatable

Revision: c5141054fd398d9945d2c8812ed19cda08859497
Author: Andras Lasso <lasso@queensu.ca>
Date: 2023-04-05 10:24:59 AM
Message:
STYLE: Removed translation from log messages

Log messages should not be translated (it is not intended for users and would make it harder for developers to interpret the logs).

Revision: e9aa74a504513ab2f77d020476f7cefc9b9f0609
Author: Andras Lasso <lasso@queensu.ca>
Date: 2023-04-05 10:22:22 AM
Message:
STYLE: Removed commented out code

The comments happened to start with colon, which Qt lupdate tool interpreted as translator comments without any translatable strings nearby. This threw warnings during text extraction. Fixed by removing the commented-out code (that should not have been left there anyway).

Revision: 896f243d3588e55eb3ce3a42c4d712dd9e1ea37c
Author: Mouhamed DIOP <mouhamed.diop@esp.sn>
Date: 2023-03-29 8:20:22 AM
Message:
BUG: Mark translatable strings in Applications folder

see Slicer/SlicerLanguagePacks#17
see Slicer/SlicerLanguagePacks#12

Revision: b6b2c584651ba725d3a7b64c7afe352a661ee756
Author: Mouhamed DIOP <mouhamed.diop@esp.sn>
Date: 2023-03-28 3:29:26 PM
Message:
BUG: Mark translatable strings in Libs/Widgets

see Slicer/SlicerLanguagePacks#17
see Slicer/SlicerLanguagePacks#12