### PR TITLE
ENH: Add transformation step before translatable string extraction

### DIFF
--- a/Utilities/Scripts/lupdate_preprocess.py
+++ b/Utilities/Scripts/lupdate_preprocess.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+
+"""
+Preprocess all python scripted modules files before they get extracted by lupdate
+It rewrites translation function calls so that they can be processed by ludpate.
+Function calls like _("Hello") becomes translate("ContextName", "Hello")
+This script is used by "update_translations.py"
+
+Example use:
+
+    python.exe c:/D/S5/Utilities/Scripts/lupdate_preprocess.py -i c:/D/S5/Base/Python -o c:/D/S5/Base/Python
+
+    For more usage details:
+
+    python.exe c:/D/S5/Utilities/Scripts/lupdate_preprocess.py -h
+
+"""
+
+import os
+import re
+import logging
+import argparse
+
+
+def get_context(source_file):
+    if os.path.isfile(source_file):
+        parent_folder = os.path.dirname(source_file)
+        init_file_path = parent_folder + os.path.sep + '__init__.py'
+
+        if os.path.isfile(init_file_path):
+            context_name = os.path.basename(parent_folder)
+            context_name += '.' + os.path.basename(source_file).replace('.py', '')
+            return context_name
+        else:
+            return os.path.basename(source_file).replace('.py', '')
+    else:
+        return os.path.basename(source_file)
+
+
+def find_all_py_files(root_dir, relative_path=True):
+    python_files = []
+    root_dir = os.path.realpath(root_dir)
+
+    for root, folders, files in os.walk(root_dir):
+        python_files += [os.path.join(root, file) for file in files if file.endswith('.py')]
+    files = [py_file.replace(root_dir, '')[1:] for py_file in python_files] if relative_path else python_files
+    return files
+
+
+def get_source_code(source_file):
+    file = open(source_file)
+    source_code = file.read()
+    file.close()
+
+    return source_code
+
+
+def save_source_code(source_code, source_file):
+    file = open(source_file, 'w')
+    file.write(source_code)
+    file.close()
+
+
+def transform_translate_function(source_file, tr_function_name='translate'):
+    context_name = get_context(source_file)
+    source_code = get_source_code(source_file)
+
+    # Search in the source code any occurrence of the translation function call pattern and replace
+    # it with the transformed translation function call.
+    # The translation function call pattern is as follows : _(FUNCTION_PARAMETER)
+    # The FUNCTION_PARAMETER is as follows :
+    # ZERO_OR_MANY_BLANK_CHARACTERS + STRING_DELIMITER + TEXT + STRING_DELIMITER + ZERO_OR_MANY_BLANK_CHARACTERS
+    # The STRING_DELIMITER might be ", ', """ or '''.
+    # That's why four different replacements that take into account those delimiters are made
+    #
+    # The proposed function call pattern excludes cases where the _() call is preceded by an underscore.
+    # It allows to avoid false positives like in : super().__init__()
+    #
+    # Example 1 : _("Hello")     ==> translate("ContextName", "Hello")
+    # Example 2 : _('Hello')     ==> translate("ContextName", 'Hello')
+    # Example 3 : _("""Hello""") ==> translate("ContextName", """Hello""")
+    # Example 4 : _('''Hello''') ==> translate("ContextName", '''Hello''')
+    # Example 5 : super().__init__("Hello") ==> super().__init__("Hello")
+
+    # \1 refers to any character that comes before the _(...), except _
+    # \2 refers to the translation function parameter, like Y in _(Y)
+    transformed_function_text = r'\1' + tr_function_name + '("' + context_name + '", ' + r'\2' + ')'
+
+    source_code = re.sub(r'([^_])_\((\s*?".+?"\s*?)\)', transformed_function_text, source_code, flags=re.DOTALL)
+    source_code = re.sub(r"([^_])_\((\s*?'.+?'\s*?)\)", transformed_function_text, source_code, flags=re.DOTALL)
+    source_code = re.sub(r'([^_])_\((\s*?""".+?"""\s*?)\)', transformed_function_text, source_code, flags=re.DOTALL)
+    source_code = re.sub(r"([^_])_\((\s*?'''.+?'''\s*?)\)", transformed_function_text, source_code, flags=re.DOTALL)
+
+    return source_code
+
+
+def transform_single_file(input_file, output_file, tr_function_name):
+    transformed_code = transform_translate_function(input_file, tr_function_name)
+    save_source_code(transformed_code, output_file)
+    logging.debug(f"\n[+] Processed file saved in <{output_file}> file")
+
+
+def transform_files_list(files_list_path, tr_function_name, root_dir=''):
+    if os.path.isfile(files_list_path):
+        with open(files_list_path) as file:
+            input_files = file.readlines()
+
+        # Filter out non python files
+        input_files = [input_file.strip() for input_file in input_files if input_file.strip().endswith('.py')]
+
+        processed_file_count = 0
+        for input_file in input_files:
+            input_file = os.path.join(root_dir, input_file)
+            output_file = input_file
+            try:
+                transform_single_file(input_file, output_file, tr_function_name)
+                processed_file_count += 1
+            except Exception as e:
+                logging.warning(f"\n\t[-] Error while saving '{output_file}': \n\t\t{str(e)}")
+        logging.debug(f"\n[+] {processed_file_count} / {len(input_files)} file(s) processed")
+    else:
+        logging.warning(f"\n\t[-] Error: the specified '{files_list_path}' is not a file")
+
+
+def transform_folder_files(input_folder, output_folder, tr_function_name):
+    if not os.path.isdir(output_folder):
+        os.mkdir(output_folder)
+
+    python_files = find_all_py_files(input_folder)
+
+    processed_file_count = 0
+    for file in python_files:
+        output_file = os.path.join(output_folder, file)
+        output_file_directory = os.path.dirname(output_file)
+        file = os.path.join(input_folder, file)
+
+        try:
+            if not os.path.isdir(output_file_directory):
+                os.makedirs(output_file_directory)
+            transform_single_file(file, output_file, tr_function_name)
+            processed_file_count += 1
+        except Exception as e:
+            logging.warning(f"\n\t[-] Error while saving '{output_file}': \n\t\t{str(e)}")
+
+    logging.debug(f"\n[+] {processed_file_count} / {len(python_files)} file(s) processed")
+    logging.debug(f"\n[+] Processed file(s) saved in <{output_folder}> folder")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog='lupdate_preprocess',
+        usage='%(prog)s [options]',
+        description="Make translation function calls suitable for lupdate extraction"
+    )
+    parser.add_argument("-i", "--input", type=str,
+                        help="input file/folder path (starts with @ when specifying a files list)")
+    parser.add_argument("-o", "--output", type=str,
+                        help="output file/folder path. Is specified only when the input path is not a files list")
+    parser.add_argument("-f", "--funcname", type=str, metavar='TR_FUNCTION_NAME', default='translate',
+                        help="the translation function name (e.g. tr/translate)")
+    parser.add_argument("-r", "--rootdir", type=str, metavar='FILES_LIST_ROOT_DIR', default='',
+                        help="used when the input path is a files list so that to specify an optional root folder path")
+    parser.add_argument("-v", "--verbose", default=False, dest="verbose", action='store_true',
+                        help="show more progress information")
+
+    args = parser.parse_args()
+    files_list_is_specified = args.input.startswith('@')
+
+    if (not args.input
+            or (args.output and files_list_is_specified)
+            or (not args.output and not files_list_is_specified)
+            or (not files_list_is_specified and args.rootdir)):
+        print("\nSyntax error, please retry by specifying the correct parameters\n")
+        parser.print_help()
+        return
+
+    if args.verbose:
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
+
+    input_path = args.input
+    tr_function_name = args.funcname
+
+    if os.path.isfile(input_path):
+        transform_single_file(input_path, args.output, tr_function_name)
+    elif files_list_is_specified:
+        files_list_path = input_path[1:]
+        transform_files_list(files_list_path, tr_function_name, args.rootdir)
+    elif os.path.isdir(input_path):
+        output_folder = args.output
+        transform_folder_files(input_path, output_folder, tr_function_name)
+    else:
+        logging.warning(f"\n\t[-] Error: the input '{input_path}' doesn't match any expectation")
+
+    logging.debug("\n[+] End of file processing...")
+
+
+if __name__ == '__main__':
+    main()

--- a/Utilities/Scripts/update_translations.py
+++ b/Utilities/Scripts/update_translations.py
@@ -6,6 +6,8 @@ Example use:
 
     python.exe c:/D/S5/Utilities/Scripts/update_translations.py -c Slicer -s c:/D/S5 -t c:/D/SlicerLanguageTranslations/translations
       --lupdate c:/Qt/6.3.0/msvc2019_64/bin/lupdate.exe
+      -p c:/D/S5/Utilities/Scripts/lupdate_preprocess.py
+      -f "/modules/,/Base/Python/slicer/util.py,/Base/Python/slicer/ScriptedLoadableModule.py"
 
 """
 
@@ -19,6 +21,76 @@ import subprocess
 import sys
 
 
+def get_python_files(source_code_dir, with_full_path=True):
+    """
+    Get python files path to transform. Assumes that a 'TranslatableFilesList.txt' that
+    contains the list of files to process is directly present in the source code folder.
+    """
+    translatableFilesListPath = source_code_dir + '/TranslatableFilesList.txt'
+
+    with open(translatableFilesListPath) as file:
+        input_files = file.readlines()
+
+    input_files = [file.strip() for file in input_files if file.strip().endswith('.py')]
+
+    if with_full_path:
+        input_files = [os.path.join(source_code_dir, file) for file in input_files]
+
+    return input_files
+
+
+def filter_source_files(source_files, files_pattern_list):
+    # Filter out Python files that don't match files list patterns. This is necessary because
+    # lupdate crashes when it tries to parse some complex Python files.
+    if files_pattern_list:
+        from pathlib import fnmatch
+        py_files = [source_file for source_file in source_files if (str(source_file).endswith('.py'))]
+        filtered_source_files = [source_file for source_file in source_files if (not str(source_file).endswith('.py'))]
+        for files_pattern in files_pattern_list:
+            files_pattern = f"**{files_pattern}**"
+            filtered_source_files += [py_file for py_file in py_files if (fnmatch.fnmatch(py_file, files_pattern))]
+        # Remove any potential duplicated file path
+        filtered_source_files = list(set(filtered_source_files))
+        return filtered_source_files
+
+    return source_files
+
+
+def save_files_to_transform(source_code_dir):
+    input_files = get_python_files(source_code_dir)
+
+    for input_file in input_files:
+        # backup files have .pyTrSource extension (py file translation source)
+        backup_file = input_file + 'TrSource'
+
+        try:
+            shutil.copy(input_file, backup_file)
+        except Exception:
+            raise RuntimeError(f"Error saving the python file '{input_file}'")
+
+
+def restore_transformed_files(source_code_dir):
+    input_files = get_python_files(source_code_dir)
+
+    for input_file in input_files:
+        backup_file = input_file + 'TrSource'  # backup files have .pyTrSource extension
+
+        try:
+            shutil.move(backup_file, input_file)
+        except Exception:
+            raise RuntimeError(f"Error restoring the python file '{input_file}'")
+
+
+def preprocess_scripted_modules_files(source_code_dir, preprocessor_path):
+    translatableFilesListPath = source_code_dir + '/TranslatableFilesList.txt'
+    command = ["python", preprocessor_path, "-i", '@' + translatableFilesListPath, "-r", source_code_dir]
+
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=sys.stderr, cwd=source_code_dir)
+    data, err = proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(f"lupdate_preprocess failed with exit code {proc.returncode}:\n\nCommand: {' '.join(command)}\n\n{data}\n\n{err}\n")
+
+
 def get_lupdate_version(lupdate_path):
     """Get version of lupdate. There are significant differences between lupdate capabilities in Qt5 and Qt6.
     """
@@ -27,7 +99,8 @@ def get_lupdate_version(lupdate_path):
     return [int(m.groups()[0]), int(m.groups()[1]), int(m.groups()[2])]
 
 
-def update_translations(component, source_code_dir, translations_dir, lupdate_path, language=None, remove_obsolete_strings=False):
+def update_translations(component, source_code_dir, translations_dir, lupdate_path, lupdate_preprocessor_path=None,
+                        files_pattern_list=[], language=None, remove_obsolete_strings=False):
 
     if language is None:
         ts_filename_filter = f"{component}*.ts"
@@ -60,12 +133,13 @@ def update_translations(component, source_code_dir, translations_dir, lupdate_pa
     for ext in extensions:
         source_files.extend(Path(source_code_dir).rglob('*.' + ext))
 
+    # Filter out some Python files when the lupdate preprocessor is specified.
+    # This is necessary because lupdate crashes when it tries to parse some complex Python files.
+    if lupdate_preprocessor_path:
+        source_files = filter_source_files(source_files, files_pattern_list)
+
     # Remove grouping based on file extension (sort based on folder structure)
     source_files.sort()
-
-    # Filter out Python files that are not in Modules folder. This is necessary because lupdate crashes when it tries to parse some complex Python files.
-    from pathlib import fnmatch
-    source_files = [source_file for source_file in source_files if (not str(source_file).endswith('.py')) or (fnmatch.fnmatch(source_file, "**/Modules/**"))]
 
     with open(translatableFilesListPath, 'w') as f:
         for source_file in source_files:
@@ -75,6 +149,13 @@ def update_translations(component, source_code_dir, translations_dir, lupdate_pa
     ts_file_paths = glob.glob(ts_file_filter)
     if not ts_file_paths:
         raise ValueError(f"No .ts files were found at {ts_file_filter}")
+
+    # Preprocess python files to make translation function calls suitable to lupdate extraction
+    # Original files are backed up before any modification
+    # This transformation is done only if the lupdate preprocessor path is specified
+    if lupdate_preprocessor_path:
+        save_files_to_transform(source_code_dir)
+        preprocess_scripted_modules_files(source_code_dir, lupdate_preprocessor_path)
 
     # Run lupdate for each language
 
@@ -99,6 +180,10 @@ def update_translations(component, source_code_dir, translations_dir, lupdate_pa
             raise RuntimeError(f"lupdate failed with exit code {proc.returncode}:\n\nCommand: {' '.join(command)}\n\n{data}\n\n{err}\n")
 
         shutil.move(ts_file_path_in_source_tree, ts_file_path)
+
+    # If transformations are made, restore transformed files after lupdate extraction
+    if lupdate_preprocessor_path:
+        restore_transformed_files(source_code_dir)
 
 
 def _generate_translation_header_from_cli_xml(cli_xml_filename):
@@ -196,6 +281,10 @@ def main(argv):
     parser = argparse.ArgumentParser(description="Update Qt translation files")
     parser.add_argument("--lupdate", default="lupdate", dest="lupdate_path",
                         help="location of the Qt lupdate executable. Qt-6.3 is required for Python translation")
+    parser.add_argument("-p", "--preprocessor", dest="preprocessor_path", default=None,
+                        help="location of the lupdate preprocessor script. It's generally present in Slicer's Utilities/Scripts folder")
+    parser.add_argument("-f", "--filter-patterns", dest="filter_patterns", default=[],
+                        help="file path patterns where lupdate preprocessor will search for python files that should be preprocessed (comma-separated paths)")
     parser.add_argument("-s", "--source-code", metavar="DIR", dest="source_code_dir",
                         help="folder of application source code (root of repository, such as https://github.com/Slicer/Slicer)")
     parser.add_argument("-c", "--component", dest="component", default="Slicer",
@@ -214,9 +303,16 @@ def main(argv):
     if args.verbose:
         logging.basicConfig(format='%(message)s', level=logging.DEBUG)
 
+    filter_patterns = args.filter_patterns
+    if args.filter_patterns:
+        filter_patterns = [file_path.strip() for file_path in args.filter_patterns.split(',')]
+
     if args.component == "Slicer":
         extract_translatable_from_cli_modules(args.source_code_dir)
-    update_translations(args.component, args.source_code_dir, args.translations_dir, args.lupdate_path, args.language, args.remove_obsolete_strings)
+        if not args.filter_patterns:
+            logging.warning("running the preprocessor on all python files (without any filter pattern) may cause lupdate crash")
+    update_translations(args.component, args.source_code_dir, args.translations_dir, args.lupdate_path,
+                        args.preprocessor_path, filter_patterns, args.language, args.remove_obsolete_strings)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make the `update_translations.py` script take into account translatable strings that are present in python scripted modules and  that are marked by the _() translation function.

Before lupdate is called on such files, some preprocessing are made so that function calls like `_("Hello")` be rewritten to `translate("SomeContext", "Hello")``. 

Related Pull Request : #6920

See also Slicer/SlicerLanguagePacks#21