### PR TITLE
Sequence editing improvements and fixes

### DIFF
--- a/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLAbstractViewNode.cxx
@@ -685,7 +685,7 @@ std::string vtkMRMLAbstractViewNode::GetDirectionLabel(double direction[3], bool
   double axisSign = positive ? 1.0 : -1.0;
   for (int axisIndex = 0; axisIndex < 3; ++axisIndex)
     {
-    double axisDirection[3] = { axisIndex == 0 ? axisSign : 0.0, axisIndex == 1 ? axisSign : 0.0, axisIndex == 2 ? axisSign : 0.0 };
+    double axisDirection[3] = { axisIndex == 0 ? 1.0 : 0.0, axisIndex == 1 ? 1.0 : 0.0, axisIndex == 2 ? 1.0 : 0.0 };
     double normalAngleDiffRad = (vtkMath::AngleBetweenVectors(direction, axisDirection) - vtkMath::Pi() / 2.0);
     double absoluteNormalAngleDiffRad = fabs(normalAngleDiffRad);
     if (absoluteNormalAngleDiffRad < toleranceRad)
@@ -694,7 +694,7 @@ std::string vtkMRMLAbstractViewNode::GetDirectionLabel(double direction[3], bool
       continue;
       }
     absoluteNormalAngleDiffsRad[axisIndex] = absoluteNormalAngleDiffRad;
-    axisLabels[axisIndex] = this->AxisLabels->GetValue(axisIndex * 2 + ((positive == (normalAngleDiffRad > 0)) ? 0 : 1));
+    axisLabels[axisIndex] = this->AxisLabels->GetValue(axisIndex * 2 + ((positive == (normalAngleDiffRad < 0)) ? 1 : 0));
     }
 
   // Concatenate labels, ordered by angle difference

--- a/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceControllerWidget.cxx
@@ -888,8 +888,8 @@ void qMRMLSliceControllerWidgetPrivate::updateWidgetFromMRMLSliceNode()
   std::string positiveAxisLabel = sliceNode->GetDirectionLabel(planeNormal, true);
   std::string negativeAxisLabel = sliceNode->GetDirectionLabel(planeNormal, false);
   this->SliceOffsetSlider->setToolTip(QString("%1 <-----> %2")
-    .arg(QString::fromStdString(positiveAxisLabel))
-    .arg(QString::fromStdString(negativeAxisLabel)));
+    .arg(QString::fromStdString(negativeAxisLabel))
+    .arg(QString::fromStdString(positiveAxisLabel)));
   this->SliceOffsetSlider->setPrefix(QString("%1: ").arg(QString::fromStdString(positiveAxisLabel)));
 
   // Update slice visibility toggle

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.cxx
@@ -1496,7 +1496,6 @@ int vtkMRMLSequenceBrowserNode::GetIndexDisplayModeFromString(const std::string&
 //-----------------------------------------------------------------------------
 std::string vtkMRMLSequenceBrowserNode::GetFormattedIndexValue(int index)
 {
-
   vtkMRMLSequenceNode* sequenceNode = this->GetMasterSequenceNode();
   if (!sequenceNode)
     {
@@ -1509,6 +1508,12 @@ std::string vtkMRMLSequenceBrowserNode::GetFormattedIndexValue(int index)
     }
 
   std::string indexValue = sequenceNode->GetNthIndexValue(index);
+
+  if (sequenceNode->GetIndexType() != vtkMRMLSequenceNode::NumericIndex)
+    {
+    return indexValue;
+    }
+
   std::string formatString = this->GetIndexDisplayFormat();
 
   std::string sprintfSpecifier;

--- a/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
+++ b/Modules/Loadable/Sequences/MRML/vtkMRMLSequenceBrowserNode.h
@@ -170,9 +170,9 @@ public:
   vtkGetMacro(IndexDisplayMode, int);
   virtual std::string GetIndexDisplayModeAsString();
 
-  /// Set format of index value display
+  /// Set format of index value display (used if index type is numeric)
   void SetIndexDisplayFormat(std::string displayFormat);
-  /// Get format of index value display
+  /// Get format of index value display (used if index type is numeric)
   vtkGetMacro(IndexDisplayFormat, std::string);
 
   /// Helper functions for converting between string and code representation of index display modes

--- a/Modules/Loadable/Sequences/Resources/UI/qSlicerSequencesModuleWidget.ui
+++ b/Modules/Loadable/Sequences/Resources/UI/qSlicerSequencesModuleWidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>411</width>
+    <width>442</width>
     <height>513</height>
    </rect>
   </property>
@@ -19,7 +19,7 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="browseSequenceTab">
       <attribute name="title">
        <string>Browse</string>
       </attribute>
@@ -143,7 +143,7 @@
              <number>6</number>
             </property>
             <attribute name="horizontalHeaderVisible">
-             <bool>true</bool>
+             <bool>false</bool>
             </attribute>
             <attribute name="horizontalHeaderCascadingSectionResizes">
              <bool>true</bool>
@@ -397,7 +397,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_2">
+     <widget class="QWidget" name="editSequenceTab">
       <attribute name="title">
        <string>Edit</string>
       </attribute>
@@ -432,275 +432,10 @@
            </property>
           </widget>
          </item>
+         <item row="1" column="0" colspan="2">
+          <widget class="qMRMLSequenceEditWidget" name="SequenceEditWidget"/>
+         </item>
         </layout>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="GroupBox_Sequence">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Index properties</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <item>
-           <widget class="QLabel" name="label_IndexName">
-            <property name="text">
-             <string>Name:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="LineEdit_IndexName">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>time</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="Label_IndexUnit">
-            <property name="text">
-             <string>Unit:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="LineEdit_IndexUnit">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>s</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_IndexType">
-            <property name="text">
-             <string>Type:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="ctkComboBox" name="ComboBox_IndexType">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="GroupBox_SequenceNodes">
-         <property name="title">
-          <string>Data nodes</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QTableWidget" name="TableWidget_DataNodes">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="selectionMode">
-             <enum>QAbstractItemView::SingleSelection</enum>
-            </property>
-            <attribute name="horizontalHeaderStretchLastSection">
-             <bool>true</bool>
-            </attribute>
-           </widget>
-          </item>
-          <item>
-           <widget class="ctkExpandButton" name="ExpandButton_DataNodes">
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-            <property name="mirrorOnExpand">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="GroupBox_NonDataNodes">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="title">
-             <string>Add/remove data nodes</string>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_4">
-             <item>
-              <layout class="QVBoxLayout" name="verticalLayout_2">
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout">
-                 <item>
-                  <widget class="QPushButton" name="PushButton_AddDataNode">
-                   <property name="toolTip">
-                    <string>Add to sequence items</string>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="Label_IndexValue">
-                   <property name="text">
-                    <string>Index value:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLineEdit" name="LineEdit_NewDataNodeIndexValue">
-                   <property name="text">
-                    <string>0</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_5">
-                 <item>
-                  <widget class="QLabel" name="Label_IndexIncrement">
-                   <property name="text">
-                    <string>Index increment:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="ctkDoubleSpinBox" name="DoubleSpinBox_IndexValueAutoIncrement">
-                   <property name="decimalsOption">
-                    <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::DecimalsByValue|ctkDoubleSpinBox::InsertDecimals</set>
-                   </property>
-                   <property name="maximum">
-                    <double>1000000.000000000000000</double>
-                   </property>
-                   <property name="value">
-                    <double>1.000000000000000</double>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>10</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QCheckBox" name="CheckBox_AutoAdvanceDataSelection">
-                   <property name="toolTip">
-                    <string>If enabled then after the selected node is added to the sequence items the selection moves to the next item</string>
-                   </property>
-                   <property name="text">
-                    <string>Auto-advance</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <widget class="QListWidget" name="ListWidget_CandidateDataNodes">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_8">
-                 <item>
-                  <widget class="QPushButton" name="PushButton_RemoveDataNode">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string/>
-                   </property>
-                   <property name="icon">
-                    <iconset resource="../qSlicerSequencesModule.qrc">
-                     <normaloff>:/Icons/DataNodeDelete.png</normaloff>:/Icons/DataNodeDelete.png</iconset>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <spacer name="horizontalSpacer_2">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>40</width>
-                     <height>20</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="Label_DataNodeType">
-                   <property name="text">
-                    <string>Node type:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="Label_DataNodeTypeValue">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>undefined</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
        </item>
       </layout>
      </widget>
@@ -727,32 +462,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ctkVTKChartView</class>
-   <extends>QOpenGLWidget</extends>
-   <header>ctkVTKChartView.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ctkCollapsibleButton</class>
-   <extends>QWidget</extends>
-   <header>ctkCollapsibleButton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkComboBox</class>
-   <extends>QComboBox</extends>
-   <header>ctkComboBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ctkDoubleSpinBox</class>
-   <extends>QWidget</extends>
-   <header>ctkDoubleSpinBox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>ctkExpandButton</class>
-   <extends>QToolButton</extends>
-   <header>ctkExpandButton.h</header>
-  </customwidget>
-  <customwidget>
    <class>qMRMLSequenceBrowserPlayWidget</class>
    <extends>qMRMLWidget</extends>
    <header>qMRMLSequenceBrowserPlayWidget.h</header>
@@ -764,44 +473,28 @@
    <header>qMRMLSequenceBrowserSeekWidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>qMRMLSequenceEditWidget</class>
+   <extends>qMRMLWidget</extends>
+   <header>qMRMLSequenceEditWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkVTKChartView</class>
+   <extends>QOpenGLWidget</extends>
+   <header>ctkVTKChartView.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <resources>
   <include location="../qSlicerSequencesModule.qrc"/>
   <include location="../../Widgets/Resources/qSlicerSequencesModuleWidgets.qrc"/>
  </resources>
  <connections>
-  <connection>
-   <sender>qSlicerSequencesModuleWidget</sender>
-   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>MRMLNodeComboBox_Sequence</receiver>
-   <slot>setMRMLScene(vtkMRMLScene*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>262</x>
-     <y>353</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>155</x>
-     <y>50</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ExpandButton_DataNodes</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>GroupBox_NonDataNodes</receiver>
-   <slot>setVisible(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>170</x>
-     <y>149</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>274</x>
-     <y>149</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>qSlicerSequencesModuleWidget</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
@@ -847,6 +540,22 @@
     <hint type="destinationlabel">
      <x>198</x>
      <y>419</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qSlicerSequencesModuleWidget</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>MRMLNodeComboBox_Sequence</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>262</x>
+     <y>353</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>155</x>
+     <y>50</y>
     </hint>
    </hints>
   </connection>

--- a/Modules/Loadable/Sequences/Widgets/CMakeLists.txt
+++ b/Modules/Loadable/Sequences/Widgets/CMakeLists.txt
@@ -16,17 +16,21 @@ set(${KIT}_SRCS
   qMRMLSequenceBrowserSeekWidget.h
   qMRMLSequenceBrowserToolBar.cxx
   qMRMLSequenceBrowserToolBar.h
+  qMRMLSequenceEditWidget.cxx
+  qMRMLSequenceEditWidget.h
   )
 
 set(${KIT}_MOC_SRCS
   qMRMLSequenceBrowserPlayWidget.h
   qMRMLSequenceBrowserSeekWidget.h
   qMRMLSequenceBrowserToolBar.h
+  qMRMLSequenceEditWidget.h
   )
 
 set(${KIT}_UI_SRCS
   Resources/UI/qMRMLSequenceBrowserPlayWidget.ui
   Resources/UI/qMRMLSequenceBrowserSeekWidget.ui
+  Resources/UI/qMRMLSequenceEditWidget.ui
   )
 
 set(${KIT}_RESOURCES

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/CMakeLists.txt
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/CMakeLists.txt
@@ -15,6 +15,8 @@ set(${KIT}_SRCS
   qMRMLSequenceBrowserSeekWidgetPlugin.h
   qMRMLSequenceBrowserToolBarPlugin.cxx
   qMRMLSequenceBrowserToolBarPlugin.h
+  qMRMLSequenceEditWidgetPlugin.cxx
+  qMRMLSequenceEditWidgetPlugin.h
   )
 
 set(${KIT}_MOC_SRCS
@@ -23,6 +25,7 @@ set(${KIT}_MOC_SRCS
   qMRMLSequenceBrowserPlayWidgetPlugin.h
   qMRMLSequenceBrowserSeekWidgetPlugin.h
   qMRMLSequenceBrowserToolBarPlugin.h
+  qMRMLSequenceEditWidgetPlugin.h
   )
 
 set(${KIT}_TARGET_LIBRARIES

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceEditWidgetPlugin.cxx
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceEditWidgetPlugin.cxx
@@ -1,0 +1,66 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Brigham and Women's Hospital
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#include "qMRMLSequenceEditWidgetPlugin.h"
+#include "qMRMLSequenceEditWidget.h"
+
+//------------------------------------------------------------------------------
+qMRMLSequenceEditWidgetPlugin
+::qMRMLSequenceEditWidgetPlugin(QObject *_parent)
+  : QObject(_parent)
+{
+
+}
+
+//------------------------------------------------------------------------------
+QWidget *qMRMLSequenceEditWidgetPlugin
+::createWidget(QWidget *_parent)
+{
+  qMRMLSequenceEditWidget* _widget
+    = new qMRMLSequenceEditWidget(_parent);
+  return _widget;
+}
+
+//------------------------------------------------------------------------------
+QString qMRMLSequenceEditWidgetPlugin
+::domXml() const
+{
+  return "<widget class=\"qMRMLSequenceEditWidget\" \
+          name=\"SequenceEditWidget\">\n"
+          "</widget>\n";
+}
+
+//------------------------------------------------------------------------------
+QString qMRMLSequenceEditWidgetPlugin
+::includeFile() const
+{
+  return "qMRMLSequenceEditWidget.h";
+}
+
+//------------------------------------------------------------------------------
+bool qMRMLSequenceEditWidgetPlugin
+::isContainer() const
+{
+  return false;
+}
+
+//------------------------------------------------------------------------------
+QString qMRMLSequenceEditWidgetPlugin
+::name() const
+{
+  return "qMRMLSequenceEditWidget";
+}

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceEditWidgetPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qMRMLSequenceEditWidgetPlugin.h
@@ -1,0 +1,40 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Brigham and Women's Hospital
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __qMRMLSequenceEditWidgetPlugin_h
+#define __qMRMLSequenceEditWidgetPlugin_h
+
+#include "qSlicerSequencesModuleWidgetsAbstractPlugin.h"
+
+class Q_SLICER_MODULE_SEQUENCES_WIDGETS_PLUGINS_EXPORT
+qMRMLSequenceEditWidgetPlugin
+  : public QObject, public qSlicerSequencesModuleWidgetsAbstractPlugin
+{
+  Q_OBJECT
+
+public:
+  qMRMLSequenceEditWidgetPlugin(QObject *_parent = 0);
+
+  QWidget *createWidget(QWidget *_parent) override;
+  QString domXml() const override;
+  QString includeFile() const override;
+  bool isContainer() const override;
+  QString name() const override;
+
+};
+
+#endif

--- a/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsPlugin.h
+++ b/Modules/Loadable/Sequences/Widgets/DesignerPlugins/qSlicerSequencesModuleWidgetsPlugin.h
@@ -33,6 +33,7 @@
 #include "qMRMLSequenceBrowserPlayWidgetPlugin.h"
 #include "qMRMLSequenceBrowserSeekWidgetPlugin.h"
 #include "qMRMLSequenceBrowserToolBarPlugin.h"
+#include "qMRMLSequenceEditWidgetPlugin.h"
 
 // \class Group the plugins in one library
 class Q_SLICER_MODULE_SEQUENCES_WIDGETS_PLUGINS_EXPORT qSlicerSequenceBrowserModuleWidgetsPlugin
@@ -52,6 +53,7 @@ public:
     plugins << new qMRMLSequenceBrowserPlayWidgetPlugin;
     plugins << new qMRMLSequenceBrowserSeekWidgetPlugin;
     plugins << new qMRMLSequenceBrowserToolBarPlugin;
+    plugins << new qMRMLSequenceEditWidgetPlugin;
     return plugins;
     }
 };

--- a/Modules/Loadable/Sequences/Widgets/Resources/UI/qMRMLSequenceEditWidget.ui
+++ b/Modules/Loadable/Sequences/Widgets/Resources/UI/qMRMLSequenceEditWidget.ui
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>qMRMLSequenceEditWidget</class>
+ <widget class="QWidget" name="qMRMLSequenceEditWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>549</width>
+    <height>429</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Edit sequence</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="GroupBox_Sequence">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Index properties</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QLabel" name="label_IndexName">
+        <property name="text">
+         <string>Name:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="LineEdit_IndexName">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string notr="true">time</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="Label_IndexUnit">
+        <property name="text">
+         <string>Unit:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="LineEdit_IndexUnit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string notr="true">s</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_IndexType">
+        <property name="text">
+         <string>Type:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkComboBox" name="ComboBox_IndexType">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QComboBox::AdjustToContents</enum>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="GroupBox_SequenceNodes">
+     <property name="title">
+      <string>Data nodes</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <widget class="QTableWidget" name="TableWidget_DataNodes">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::ExtendedSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="ctkExpandButton" name="ExpandButton_DataNodes">
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="mirrorOnExpand">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="GroupBox_CandidateNodes">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="title">
+         <string>Add/remove data nodes</string>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <layout class="QGridLayout" name="gridLayout">
+             <item row="0" column="0">
+              <widget class="QPushButton" name="PushButton_AddCandidateNode">
+               <property name="toolTip">
+                <string>Add to sequence items</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="ctkDoubleSpinBox" name="DoubleSpinBox_IndexValueAutoIncrement">
+               <property name="toolTip">
+                <string>Increment index by this much after adding a data node</string>
+               </property>
+               <property name="decimalsOption">
+                <set>ctkDoubleSpinBox::DecimalsByKey|ctkDoubleSpinBox::DecimalsByShortcuts|ctkDoubleSpinBox::DecimalsByValue|ctkDoubleSpinBox::InsertDecimals</set>
+               </property>
+               <property name="maximum">
+                <double>1000000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0" colspan="2">
+              <widget class="QLabel" name="Label_UseNodeNameAsIndexValue">
+               <property name="toolTip">
+                <string>Use node name as index value</string>
+               </property>
+               <property name="text">
+                <string>Use node name:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0" colspan="2">
+              <widget class="QLabel" name="Label_AutoAdvanceDataSelection">
+               <property name="toolTip">
+                <string>If enabled then after the selected node is added to the sequence items the selection moves to the next item</string>
+               </property>
+               <property name="text">
+                <string>Auto-advance:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="2">
+              <widget class="QCheckBox" name="CheckBox_AutoAdvanceDataSelection">
+               <property name="toolTip">
+                <string>If enabled then after the selected node is added to the sequence items the selection moves to the next item</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0" colspan="2">
+              <widget class="QLabel" name="Label_IndexIncrement">
+               <property name="toolTip">
+                <string>Increment index by this much after adding a data node</string>
+               </property>
+               <property name="text">
+                <string>Index increment:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLabel" name="Label_IndexValue">
+               <property name="text">
+                <string>Index value:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="2">
+              <widget class="QCheckBox" name="CheckBox_UseNodeNameAsIndexValue">
+               <property name="toolTip">
+                <string>Use node name as index value</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QLineEdit" name="LineEdit_NewCandidateNodeIndexValue">
+               <property name="text">
+                <string notr="true">0</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QListWidget" name="ListWidget_CandidateNodes">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="selectionMode">
+              <enum>QAbstractItemView::ExtendedSelection</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <item>
+              <widget class="QPushButton" name="PushButton_RemoveDataNode">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="icon">
+                <iconset resource="../../../Resources/qSlicerSequencesModule.qrc">
+                 <normaloff>:/Icons/DataNodeDelete.png</normaloff>:/Icons/DataNodeDelete.png</iconset>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="Label_DataNodeType">
+               <property name="text">
+                <string>Node type:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="Label_DataNodeTypeValue">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string notr="true">-</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ctkComboBox</class>
+   <extends>QComboBox</extends>
+   <header>ctkComboBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkDoubleSpinBox</class>
+   <extends>QWidget</extends>
+   <header>ctkDoubleSpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ctkExpandButton</class>
+   <extends>QToolButton</extends>
+   <header>ctkExpandButton.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../../Resources/qSlicerSequencesModule.qrc"/>
+  <include location="../qSlicerSequencesModuleWidgets.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Modules/Loadable/Sequences/Widgets/Testing/Cxx/CMakeLists.txt
+++ b/Modules/Loadable/Sequences/Widgets/Testing/Cxx/CMakeLists.txt
@@ -6,6 +6,7 @@ set(INPUT ${MRMLCore_SOURCE_DIR}/Testing)
 #-----------------------------------------------------------------------------
 set(KIT_TEST_SRCS
   qMRMLSequenceBrowserWidgetsTest1.cxx
+  qMRMLSequenceEditWidgetTest1.cxx
   )
 
 #-----------------------------------------------------------------------------
@@ -17,3 +18,4 @@ slicerMacroConfigureModuleCxxTestDriver(
 
 #-----------------------------------------------------------------------------
 simple_test( qMRMLSequenceBrowserWidgetsTest1 )
+simple_test( qMRMLSequenceEditWidgetTest1 )

--- a/Modules/Loadable/Sequences/Widgets/Testing/Cxx/qMRMLSequenceBrowserWidgetsTest1.cxx
+++ b/Modules/Loadable/Sequences/Widgets/Testing/Cxx/qMRMLSequenceBrowserWidgetsTest1.cxx
@@ -57,9 +57,6 @@ int qMRMLSequenceBrowserWidgetsTest1( int argc, char * argv [] )
   scene->AddNode(browserNode.GetPointer());
   browserNode->SetAndObserveMasterSequenceNodeID(sequenceNode->GetID());
 
-  //
-  // Create a simple gui with non-tranposed and transposed table view
-  //
   QWidget parentWidget;
   parentWidget.setWindowTitle("qMRMLSequenceBrowserWidgetsTest1");
   QVBoxLayout vbox;

--- a/Modules/Loadable/Sequences/Widgets/Testing/Cxx/qMRMLSequenceEditWidgetTest1.cxx
+++ b/Modules/Loadable/Sequences/Widgets/Testing/Cxx/qMRMLSequenceEditWidgetTest1.cxx
@@ -1,0 +1,128 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Kitware Inc.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// Qt includes
+#include <QApplication>
+#include <QTimer>
+#include <QVBoxLayout>
+
+// qMRML includes
+#include "qSlicerCoreApplication.h"
+#include "qMRMLNodeComboBox.h"
+#include "qMRMLSequenceEditWidget.h"
+
+// MRML includes
+#include "vtkMRMLModelNode.h"
+#include "vtkMRMLScene.h"
+#include "vtkMRMLSequenceNode.h"
+#include "vtkMRMLTransformNode.h"
+
+// VTK includes
+#include <vtkNew.h>
+
+int qMRMLSequenceEditWidgetTest1( int argc, char * argv [] )
+{
+  QApplication app(argc, argv);
+
+  // Set up a test scene with some sequences and data nodes
+
+  vtkNew<vtkMRMLScene> scene;
+
+  // Add two sequence nodes with some transforms in them
+  vtkNew<vtkMRMLSequenceNode> sequenceNodeNumeric;
+  sequenceNodeNumeric->SetName("Transform sequence (numeric)");
+  sequenceNodeNumeric->SetIndexType(vtkMRMLSequenceNode::NumericIndex);
+  vtkNew<vtkMRMLSequenceNode> sequenceNodeText;
+  sequenceNodeText->SetName("Transform sequence (text)");
+  sequenceNodeText->SetIndexType(vtkMRMLSequenceNode::TextIndex);
+  for (int i = 0; i < 80; i++)
+    {
+    vtkNew<vtkMRMLTransformNode> transformNode;
+    double indexValue = i * 12.345;
+    QString name = QString("Transform %1").arg(indexValue);
+    transformNode->SetName(name.toStdString().c_str());
+    sequenceNodeNumeric->SetDataNodeAtValue(transformNode, QString::number(indexValue).toStdString());
+    sequenceNodeText->SetDataNodeAtValue(transformNode, name.toStdString());
+    }
+  scene->AddNode(sequenceNodeNumeric);
+  scene->AddNode(sequenceNodeText);
+
+  vtkNew<vtkMRMLSequenceNode> sequenceNodeModels;
+  sequenceNodeModels->SetName("Model sequence");
+  for (int i = 0; i < 10; i++)
+    {
+    vtkNew<vtkMRMLModelNode> modelNode;
+    double indexValue = i * 1.5;
+    QString name = QString("Model %1").arg(i);
+    modelNode->SetName(name.toStdString().c_str());
+    sequenceNodeModels->SetDataNodeAtValue(modelNode, QString::number(indexValue).toStdString());
+    }
+  scene->AddNode(sequenceNodeModels);
+
+  vtkNew<vtkMRMLSequenceNode> sequenceNodeEmpty;
+  sequenceNodeEmpty->SetName("An empty sequence");
+  scene->AddNode(sequenceNodeEmpty);
+
+  // Add some more data nodes to the scene (to be able to test node type filtering)
+  for (int i = 0; i < 20; i++)
+    {
+    vtkNew<vtkMRMLTransformNode> transformNode;
+    double indexValue = i * 12.345;
+    QString name = QString("TestT %1").arg(indexValue);
+    transformNode->SetName(name.toStdString().c_str());
+    scene->AddNode(transformNode);
+    }
+  for (int i = 0; i < 30; i++)
+    {
+    vtkNew<vtkMRMLModelNode> modelNode;
+    double indexValue = i * 1.23;
+    QString name = QString("TestM %1").arg(indexValue);
+    modelNode->SetName(name.toStdString().c_str());
+    scene->AddNode(modelNode.GetPointer());
+    }
+
+  // Create GUI
+
+  QWidget parentWidget;
+  parentWidget.setWindowTitle("qMRMLSequenceBrowserWidgetsTest1");
+  QVBoxLayout vbox;
+  parentWidget.setLayout(&vbox);
+
+  qMRMLNodeComboBox* nodeSelector = new qMRMLNodeComboBox();
+  nodeSelector->setMRMLScene(scene);
+  nodeSelector->setNodeTypes(QStringList() << "vtkMRMLSequenceNode");
+  nodeSelector->setNoneEnabled(true);
+  nodeSelector->setCurrentNode(nullptr);
+  vbox.addWidget(nodeSelector);
+
+  qMRMLSequenceEditWidget* editWidget = new qMRMLSequenceEditWidget();
+  editWidget->setMRMLScene(scene);
+  vbox.addWidget(editWidget);
+
+  QObject::connect(nodeSelector, SIGNAL(currentNodeChanged(vtkMRMLNode*)),
+    editWidget, SLOT(setMRMLSequenceNode(vtkMRMLNode*)));
+
+  parentWidget.show();
+  parentWidget.raise();
+
+  if (argc < 2 || QString(argv[1]) != "-I")
+    {
+    QTimer::singleShot(200, &app, SLOT(quit()));
+    }
+
+  return app.exec();
+}

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserSeekWidget.cxx
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceBrowserSeekWidget.cxx
@@ -177,7 +177,7 @@ void qMRMLSequenceBrowserSeekWidget::updateWidgetFromMRML()
       indexUnit = QString::fromStdString(sequenceNode->GetIndexUnit());
       if (indexValue.length() == 0)
         {
-        qWarning() << "Item " << selectedItemNumber << " has no index value defined";
+        qWarning() << "Item" << selectedItemNumber << "has no index value defined";
         }
       }
     else

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceEditWidget.cxx
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceEditWidget.cxx
@@ -1,0 +1,768 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Brigham and Women's Hospital
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+// qMRML includes
+#include "qMRMLSequenceEditWidget.h"
+#include "ui_qMRMLSequenceEditWidget.h"
+
+// MRML includes
+#include <vtkMRMLScene.h>
+#include <vtkMRMLSequenceNode.h>
+
+// VTK includes
+#include <vtkCollection.h>
+
+// Qt includes
+#include <QDebug>
+#include <QListWidgetItem>
+
+#define FROM_CHAR_PTR_SAFE(charPtr) QString::fromStdString(charPtr == nullptr ? "" : charPtr)
+
+enum
+{
+  DATA_NODE_VALUE_COLUMN,
+  DATA_NODE_NAME_COLUMN,
+  DATA_NODE_NUMBER_OF_COLUMNS // this must be the last line in this enum
+};
+
+//-----------------------------------------------------------------------------
+/// \ingroup Slicer_QtModules_Markups
+class qMRMLSequenceEditWidgetPrivate
+: public Ui_qMRMLSequenceEditWidget
+{
+  Q_DECLARE_PUBLIC(qMRMLSequenceEditWidget);
+protected:
+  qMRMLSequenceEditWidget* const q_ptr;
+public:
+  qMRMLSequenceEditWidgetPrivate(qMRMLSequenceEditWidget& object);
+  void init();
+
+  /// Add node to the candidate node list widget.
+  void addNodeToCandidateNodes(vtkMRMLNode* node);
+
+  bool isDataNodeCandidate(vtkMRMLNode* node);
+
+  /// Get a list of MLRML nodes that are in the scene but not added to the sequences data node at the chosen index value
+  void dataNodeCandidates(std::vector< vtkSmartPointer<vtkMRMLNode> > &foundNodes, vtkMRMLSequenceNode* sequenceNode);
+
+  void setCurrentDataNodeCandidate(vtkMRMLNode* node);
+
+  void scrollToDataNodeByIndexValue(const QString& indexValue);
+
+  vtkWeakPointer<vtkMRMLSequenceNode> SequenceNode;
+  // data node class name that was used for populating the candidate node list
+  QString DataNodeCandidatesClassName;
+};
+
+//-----------------------------------------------------------------------------
+// qMRMLSequenceEditWidgetPrivate methods
+
+//-----------------------------------------------------------------------------
+qMRMLSequenceEditWidgetPrivate::qMRMLSequenceEditWidgetPrivate(qMRMLSequenceEditWidget& object)
+: q_ptr(&object)
+{
+  this->SequenceNode = nullptr;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidgetPrivate::init()
+{
+  Q_Q(qMRMLSequenceEditWidget);
+  this->setupUi(q);
+
+  if (this->ComboBox_IndexType->count() == 0)
+    {
+    for (int indexType = 0; indexType < vtkMRMLSequenceNode::NumberOfIndexTypes; indexType++)
+      {
+      this->ComboBox_IndexType->addItem(vtkMRMLSequenceNode::GetIndexTypeAsString(indexType).c_str());
+      }
+    }
+
+  this->TableWidget_DataNodes->setColumnWidth(DATA_NODE_VALUE_COLUMN, 30);
+  this->TableWidget_DataNodes->setColumnWidth(DATA_NODE_NAME_COLUMN, 100);
+
+  this->PushButton_AddCandidateNode->setIcon(QApplication::style()->standardIcon(QStyle::SP_ArrowLeft));
+  this->PushButton_RemoveDataNode->setIcon(QIcon(":/Icons/DataNodeDelete.png"));
+
+  QObject::connect(this->ExpandButton_DataNodes, SIGNAL(toggled(bool)), q, SLOT(setCandidateNodesSectionVisible(bool)));
+
+  QObject::connect(this->ListWidget_CandidateNodes, SIGNAL(itemClicked(QListWidgetItem*)), q, SLOT(candidateNodeItemClicked(QListWidgetItem*)));
+  QObject::connect(this->ListWidget_CandidateNodes, SIGNAL(itemDoubleClicked(QListWidgetItem*)), q, SLOT(candidateNodeItemDoubleClicked(QListWidgetItem*)));
+  QObject::connect(LineEdit_NewCandidateNodeIndexValue, SIGNAL(returnPressed()), q, SLOT(onAddDataNodeButtonClicked()));
+
+  QObject::connect(this->LineEdit_IndexName, SIGNAL(textEdited(const QString&)), q, SLOT(onIndexNameEdited()));
+  QObject::connect(this->LineEdit_IndexUnit, SIGNAL(textEdited(const QString&)), q, SLOT(onIndexUnitEdited()));
+  QObject::connect(this->ComboBox_IndexType, SIGNAL(currentIndexChanged(const QString&)), q, SLOT(onIndexTypeEdited(QString)));
+  QObject::connect(this->TableWidget_DataNodes, SIGNAL(cellChanged(int, int)), q, SLOT(onDataNodeEdited(int, int)));
+  QObject::connect(this->PushButton_AddCandidateNode, SIGNAL(clicked()), q, SLOT(onAddDataNodeButtonClicked()));
+  QObject::connect(this->PushButton_RemoveDataNode, SIGNAL(clicked()), q, SLOT(onRemoveDataNodeButtonClicked()));
+
+  this->ExpandButton_DataNodes->setChecked(false);
+
+  q->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidgetPrivate::addNodeToCandidateNodes(vtkMRMLNode* node)
+{
+  Q_Q(qMRMLSequenceEditWidget);
+  if (!node)
+    {
+    return;
+    }
+  QListWidgetItem* qlwi = new QListWidgetItem();
+  qlwi->setText(node->GetName());
+  qlwi->setData(Qt::UserRole, QString(node->GetID()));
+  this->ListWidget_CandidateNodes->addItem(qlwi);
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSequenceEditWidgetPrivate::isDataNodeCandidate(vtkMRMLNode* node)
+{
+  Q_Q(const qMRMLSequenceEditWidget);
+  if (node->GetHideFromEditors())
+    {
+    // don't show hidden nodes, they would clutter the view
+    return false;
+    }
+  if (node->GetSingletonTag())
+    {
+    // don't allow adding singletons (mainly because we can only store one singleton node in a scene, so we couldn't store it)
+    return false;
+    }
+  if (node == this->SequenceNode)
+    {
+    // don't allow adding itself as data node
+    return false;
+    }
+  if (!this->DataNodeCandidatesClassName.isEmpty())
+    {
+    if (this->DataNodeCandidatesClassName != node->GetClassName())
+      {
+      // class is not compatible with elements already in the sequence, don't show it
+      return false;
+      }
+    }
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidgetPrivate::setCurrentDataNodeCandidate(vtkMRMLNode* node)
+{
+  Q_Q(const qMRMLSequenceEditWidget);
+  if (!node || !node->GetID())
+    {
+    this->ListWidget_CandidateNodes->setCurrentRow(-1);
+    return;
+    }
+  QString nodeIdToFind = node->GetID();
+  int rowCount = this->ListWidget_CandidateNodes->count();
+  for (int row = 0; row < rowCount; row++)
+    {
+    QListWidgetItem* item = this->ListWidget_CandidateNodes->item(row);
+    if (item)
+      {
+      QString nodeID = item->data(Qt::UserRole).toString();
+      if (nodeID == nodeIdToFind)
+        {
+        // found the node, set it as current
+        this->ListWidget_CandidateNodes->setCurrentItem(item);
+        return;
+        }
+      }
+    }
+  // not found
+  this->ListWidget_CandidateNodes->setCurrentRow(-1);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidgetPrivate::dataNodeCandidates(std::vector< vtkSmartPointer<vtkMRMLNode> > &foundNodes, vtkMRMLSequenceNode* sequenceNode)
+{
+  Q_Q( const qMRMLSequenceEditWidget );
+  foundNodes.clear();
+  if (!sequenceNode)
+    {
+    qWarning() << Q_FUNC_INFO << "failed: invalid sequence node";
+    return;
+    }
+  vtkMRMLScene* scene = q->mrmlScene();
+  if (!scene)
+    {
+    return;
+    }
+
+  std::string dataNodeClassName = sequenceNode->GetDataNodeClassName();
+
+  for ( int i = 0; i < scene->GetNumberOfNodes(); i++ )
+    {
+    vtkMRMLNode* currentNode = vtkMRMLNode::SafeDownCast(scene->GetNthNode(i));
+    if (!this->isDataNodeCandidate(currentNode))
+      {
+      continue;
+      }
+    foundNodes.push_back(currentNode);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidgetPrivate::scrollToDataNodeByIndexValue(const QString& indexValue)
+{
+  Q_Q(const qMRMLSequenceEditWidget);
+  if (indexValue.isEmpty())
+    {
+    return;
+    }
+  int itemNumber = this->SequenceNode->GetItemNumberFromIndexValue(indexValue.toStdString());
+  if (itemNumber >= 0)
+    {
+    QModelIndex modelIndex = this->TableWidget_DataNodes->model()->index(itemNumber, 0);
+    this->TableWidget_DataNodes->scrollTo(modelIndex);
+    this->TableWidget_DataNodes->setCurrentIndex(modelIndex);
+    }
+}
+//-----------------------------------------------------------------------------
+// qMRMLSequenceEditWidget methods
+
+//-----------------------------------------------------------------------------
+qMRMLSequenceEditWidget::qMRMLSequenceEditWidget(QWidget *newParent)
+: Superclass(newParent)
+, d_ptr(new qMRMLSequenceEditWidgetPrivate(*this))
+{
+  Q_D(qMRMLSequenceEditWidget);
+  d->init();
+}
+
+//-----------------------------------------------------------------------------
+qMRMLSequenceEditWidget::~qMRMLSequenceEditWidget() = default;
+
+//------------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::setMRMLScene(vtkMRMLScene* scene)
+{
+  this->Superclass::setMRMLScene(scene);
+  this->qvtkConnect(this->mrmlScene(), vtkMRMLScene::NodeAddedEvent,
+    this, SLOT(onNodeAddedEvent(vtkObject*, vtkObject*)));
+  this->qvtkConnect(this->mrmlScene(), vtkMRMLScene::NodeRemovedEvent,
+    this, SLOT(onNodeRemovedEvent(vtkObject*, vtkObject*)));
+  this->qvtkConnect(this->mrmlScene(), vtkMRMLScene::EndImportEvent,
+    this, SLOT(onMRMLSceneEndImportEvent()));
+  this->qvtkConnect(this->mrmlScene(), vtkMRMLScene::EndBatchProcessEvent,
+    this, SLOT(onMRMLSceneEndBatchProcessEvent()));
+  this->qvtkConnect(this->mrmlScene(), vtkMRMLScene::EndCloseEvent,
+    this, SLOT(onMRMLSceneEndCloseEvent()));
+  this->qvtkConnect(this->mrmlScene(), vtkMRMLScene::EndRestoreEvent,
+    this, SLOT(onMRMLSceneEndRestoreEvent()));
+
+  this->updateWidgetFromMRML();
+  this->updateCandidateNodesWidgetFromMRML(true);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::setMRMLSequenceNode(vtkMRMLNode* browserNode)
+{
+  setMRMLSequenceNode(vtkMRMLSequenceNode::SafeDownCast(browserNode));
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::setMRMLSequenceNode(vtkMRMLSequenceNode* sequenceNode)
+{
+  Q_D(qMRMLSequenceEditWidget);
+
+  if (d->SequenceNode == sequenceNode)
+    {
+    return; // no change
+    }
+
+  // Reconnect the input node's Modified() event observer
+  this->qvtkReconnect(d->SequenceNode, sequenceNode, vtkCommand::ModifiedEvent,
+    this, SLOT(onSequenceNodeModified()));
+  d->SequenceNode = sequenceNode;
+
+  if (d->SequenceNode->GetIndexType() == vtkMRMLSequenceNode::NumericIndex)
+    {
+    d->LineEdit_NewCandidateNodeIndexValue->setText("0");
+    }
+  else
+    {
+    d->LineEdit_NewCandidateNodeIndexValue->setText("");
+    }
+
+  this->updateWidgetFromMRML();
+  this->updateCandidateNodesWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::updateWidgetFromMRML()
+{
+  Q_D(qMRMLSequenceEditWidget);
+
+  if (!d->SequenceNode || !this->mrmlScene())
+    {
+    d->Label_DataNodeTypeValue->setText("-");
+    d->LineEdit_IndexName->setText("");
+    d->LineEdit_IndexUnit->setText("");
+    d->ComboBox_IndexType->setCurrentIndex(-1);
+    d->TableWidget_DataNodes->clear();
+    d->TableWidget_DataNodes->setRowCount(0);
+    d->TableWidget_DataNodes->setColumnCount(0);
+    d->ListWidget_CandidateNodes->clear();
+    this->setEnabled(false);
+    return;
+    }
+
+  this->setEnabled(true);
+
+  // Put the correct properties in the sequence node table
+  QString nodeType = QString::fromStdString(d->SequenceNode->GetDataNodeTagName());
+  if (nodeType.isEmpty())
+    {
+    nodeType = "-";
+    }
+  d->Label_DataNodeTypeValue->setText(nodeType);
+
+  bool numericIndex = d->SequenceNode->GetIndexType() == vtkMRMLSequenceNode::NumericIndex;
+  d->Label_IndexIncrement->setVisible(numericIndex);
+  d->DoubleSpinBox_IndexValueAutoIncrement->setVisible(numericIndex);
+  d->Label_UseNodeNameAsIndexValue->setVisible(!numericIndex);
+  d->CheckBox_UseNodeNameAsIndexValue->setVisible(!numericIndex);
+
+  d->LineEdit_IndexName->setText(QString::fromStdString(d->SequenceNode->GetIndexName()));
+  d->LineEdit_IndexUnit->setText(QString::fromStdString(d->SequenceNode->GetIndexUnit()));
+  d->ComboBox_IndexType->setCurrentIndex(d->ComboBox_IndexType->findText(
+    QString::fromStdString(d->SequenceNode->GetIndexTypeAsString())));
+
+  // Display all of the sequence nodes
+  d->TableWidget_DataNodes->clear();
+  d->TableWidget_DataNodes->setRowCount(d->SequenceNode->GetNumberOfDataNodes());
+  d->TableWidget_DataNodes->setColumnCount(DATA_NODE_NUMBER_OF_COLUMNS);
+  std::stringstream valueHeader;
+  valueHeader << d->SequenceNode->GetIndexName();
+  valueHeader << " (" << d->SequenceNode->GetIndexUnit() << ")";
+  QStringList SequenceNodesTableHeader;
+  SequenceNodesTableHeader.insert(DATA_NODE_VALUE_COLUMN, valueHeader.str().c_str());
+  SequenceNodesTableHeader.insert(DATA_NODE_NAME_COLUMN, tr("Name"));
+  d->TableWidget_DataNodes->setHorizontalHeaderLabels( SequenceNodesTableHeader );
+
+  int numberOfDataNodes = d->SequenceNode->GetNumberOfDataNodes();
+  for ( int dataNodeIndex = 0; dataNodeIndex < numberOfDataNodes; dataNodeIndex++ )
+    {
+    std::string currentValue = d->SequenceNode->GetNthIndexValue( dataNodeIndex );
+    vtkMRMLNode* currentDataNode = d->SequenceNode->GetNthDataNode( dataNodeIndex );
+
+    if (currentDataNode==nullptr)
+      {
+      qCritical() << "qMRMLSequenceEditWidget::updateWidgetFromMRML invalid data node";
+      continue;
+      }
+
+    QTableWidgetItem* valueItem = new QTableWidgetItem(QString::fromStdString(currentValue));
+    valueItem->setTextAlignment(Qt::AlignHCenter|Qt::AlignVCenter);
+
+    QTableWidgetItem* nameItem = new QTableWidgetItem(FROM_CHAR_PTR_SAFE(currentDataNode->GetName()));
+
+    d->TableWidget_DataNodes->setItem( dataNodeIndex, DATA_NODE_VALUE_COLUMN, valueItem );
+    d->TableWidget_DataNodes->setItem( dataNodeIndex, DATA_NODE_NAME_COLUMN, nameItem );
+    }
+
+  //d->TableWidget_DataNodes->resizeColumnsToContents();
+  d->TableWidget_DataNodes->resizeRowsToContents();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::updateCandidateNodesWidgetFromMRML(bool forceUpdate /* =false */)
+{
+  Q_D(qMRMLSequenceEditWidget);
+
+  // If candidate nodes section is hidden then do not update candidate nodes list,
+  // because it is an expensive operation.
+  if (!d->SequenceNode || !this->isCandidateNodesSectionVisible())
+    {
+    d->ListWidget_CandidateNodes->clear();
+    d->DataNodeCandidatesClassName.clear();
+    return;
+    }
+
+  QString newDataNodeCandidatesClassName(QString::fromStdString(d->SequenceNode->GetDataNodeClassName()));
+  if (!forceUpdate && d->DataNodeCandidatesClassName == newDataNodeCandidatesClassName)
+    {
+    // already up-to-date
+    return;
+    }
+  d->DataNodeCandidatesClassName = newDataNodeCandidatesClassName;
+
+  // Display the candidate data nodes
+  std::vector< vtkSmartPointer<vtkMRMLNode> > candidateNodes;
+  d->dataNodeCandidates(candidateNodes, d->SequenceNode);
+
+  d->ListWidget_CandidateNodes->clear();
+
+  for (vtkSmartPointer<vtkMRMLNode> & currentCandidateNode : candidateNodes)
+    {
+    d->addNodeToCandidateNodes(currentCandidateNode);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onDataNodeEdited(int row, int column)
+{
+  Q_D(qMRMLSequenceEditWidget);
+
+  // Ensure that the user is editing, not the index changed programmatically
+  if (d->TableWidget_DataNodes->currentRow() != row || d->TableWidget_DataNodes->currentColumn() != column)
+    {
+    return;
+    }
+  if (!d->SequenceNode)
+    {
+    return;
+    }
+  std::string currentIndexValue = d->SequenceNode->GetNthIndexValue( d->TableWidget_DataNodes->currentRow() );
+  if ( currentIndexValue.empty() )
+    {
+    return;
+    }
+  vtkMRMLNode* currentDataNode = d->SequenceNode->GetDataNodeAtValue(currentIndexValue.c_str() );
+  if ( currentDataNode == nullptr )
+    {
+    return;
+    }
+
+  // Grab the text from the modified item
+  QTableWidgetItem* qItem = d->TableWidget_DataNodes->item(row, column);
+  QString qText = qItem->text();
+  if (column == DATA_NODE_VALUE_COLUMN)
+    {
+    d->SequenceNode->UpdateIndexValue( currentIndexValue.c_str(), qText.toStdString().c_str() );
+    }
+  if (column == DATA_NODE_NAME_COLUMN)
+    {
+    currentDataNode->SetName( qText.toStdString().c_str() );
+    }
+
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onNodeAddedEvent(vtkObject* scene, vtkObject* aNode)
+{
+  Q_D(qMRMLSequenceEditWidget);
+  Q_UNUSED(scene);
+  if (!this->mrmlScene() || this->mrmlScene()->IsBatchProcessing())
+    {
+    return;
+    }
+  vtkMRMLNode* node = vtkMRMLNode::SafeDownCast(aNode);
+  if (node && d->isDataNodeCandidate(node))
+    {
+    d->addNodeToCandidateNodes(node);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onNodeRemovedEvent(vtkObject* scene, vtkObject* aNode)
+{
+  Q_D(qMRMLSequenceEditWidget);
+  Q_UNUSED(scene);
+  if (!this->mrmlScene() || this->mrmlScene()->IsBatchProcessing())
+    {
+    return;
+    }
+  // Remove single candidate node
+  vtkMRMLNode* node = vtkMRMLNode::SafeDownCast(aNode);
+  if (!node || !node->GetID() || !d->isDataNodeCandidate(node))
+    {
+    return;
+    }
+  QString nodeIdToRemove = QString::fromStdString(node->GetID());
+  int numberOfRows = d->TableWidget_DataNodes->rowCount();
+  for (int row = 0; row < numberOfRows; row++)
+    {
+    QTableWidgetItem* item = d->TableWidget_DataNodes->item(row, 0);
+    QString nodeID = item->data(Qt::UserRole).toString();
+    if (nodeID == nodeIdToRemove)
+      {
+      d->TableWidget_DataNodes->removeRow(row);
+      return;
+      }
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onMRMLSceneEndImportEvent()
+{
+  this->updateCandidateNodesWidgetFromMRML(true);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onMRMLSceneEndRestoreEvent()
+{
+  this->updateCandidateNodesWidgetFromMRML(true);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onMRMLSceneEndBatchProcessEvent()
+{
+  if (!this->mrmlScene())
+    {
+    return;
+    }
+  this->updateCandidateNodesWidgetFromMRML(true);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onMRMLSceneEndCloseEvent()
+{
+  if (!this->mrmlScene() || this->mrmlScene()->IsBatchProcessing())
+    {
+    return;
+    }
+  this->updateCandidateNodesWidgetFromMRML(true);
+  this->updateWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onSequenceNodeModified()
+{
+  Q_D(qMRMLSequenceEditWidget);
+  this->updateWidgetFromMRML();
+  this->updateCandidateNodesWidgetFromMRML();
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onIndexNameEdited()
+{
+  Q_D(qMRMLSequenceEditWidget);
+  if (!d->SequenceNode)
+    {
+    return;
+    }
+  d->SequenceNode->SetIndexName(d->LineEdit_IndexName->text().toStdString().c_str());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onIndexUnitEdited()
+{
+  Q_D(qMRMLSequenceEditWidget);
+  if (!d->SequenceNode)
+    {
+    return;
+    }
+  d->SequenceNode->SetIndexUnit(d->LineEdit_IndexUnit->text().toStdString().c_str());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onIndexTypeEdited(QString indexTypeString)
+{
+  Q_D(qMRMLSequenceEditWidget);
+  if (!d->SequenceNode)
+    {
+    return;
+    }
+  d->SequenceNode->SetIndexTypeFromString(indexTypeString.toStdString().c_str());
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onAddDataNodeButtonClicked()
+{
+  Q_D(qMRMLSequenceEditWidget);
+  if (!d->SequenceNode)
+    {
+    return;
+    }
+  QList<QListWidgetItem*> selectedItems = d->ListWidget_CandidateNodes->selectedItems();
+  std::vector< vtkSmartPointer<vtkMRMLNode> > nodesToAdd;
+  for (QListWidgetItem* item : selectedItems)
+    {
+    QString currentCandidateNodeId = item->data(Qt::UserRole).toString();
+    vtkMRMLNode* currentCandidateNode = d->SequenceNode->GetScene()->GetNodeByID(currentCandidateNodeId.toStdString().c_str());
+    if (currentCandidateNode)
+      {
+      nodesToAdd.push_back(currentCandidateNode);
+      }
+    }
+  QString addedNodeIndexValue;
+  for (vtkSmartPointer<vtkMRMLNode> &node : nodesToAdd)
+    {
+    d->setCurrentDataNodeCandidate(node);
+    addedNodeIndexValue = this->onAddCurrentCandidateNode();
+    }
+  d->scrollToDataNodeByIndexValue(addedNodeIndexValue);
+}
+
+//-----------------------------------------------------------------------------
+QString qMRMLSequenceEditWidget::onAddCurrentCandidateNode()
+{
+  Q_D(qMRMLSequenceEditWidget);
+  if (!d->SequenceNode)
+    {
+    return QString();
+    }
+
+  std::string currentIndexValue = d->LineEdit_NewCandidateNodeIndexValue->text().toStdString();
+  if (currentIndexValue.empty())
+    {
+    qCritical() << Q_FUNC_INFO << "failed: Cannot add new data node, as Index value is not specified";
+    return QString();
+    }
+
+  // Get the selected node
+  QListWidgetItem* currentItem = d->ListWidget_CandidateNodes->currentItem();
+  if (!currentItem)
+    {
+    qCritical() << Q_FUNC_INFO << "failed: Cannot add new data node, as current data item selection is invalid";
+    return QString();
+    }
+
+  QString currentCandidateNodeId = currentItem->data(Qt::UserRole).toString();
+  vtkMRMLNode* currentCandidateNode = d->SequenceNode->GetScene()->GetNodeByID(currentCandidateNodeId.toStdString().c_str());
+  if (!currentCandidateNode)
+    {
+    qCritical() << Q_FUNC_INFO << "failed: Cannot add new data node, as current data item is invalid";
+    return QString();
+    }
+  int wasModified = d->SequenceNode->StartModify();
+  d->SequenceNode->SetDataNodeAtValue(currentCandidateNode, currentIndexValue.c_str() );
+  d->SequenceNode->EndModify(wasModified);
+
+  // Restore candidate node selection / auto-advance to the next node
+  if (d->CheckBox_AutoAdvanceDataSelection->checkState() == Qt::Checked)
+    {
+    if (d->ListWidget_CandidateNodes->currentRow() + 1 < d->ListWidget_CandidateNodes->count())
+      {
+      // not at the end of the list, so select the next item
+      d->ListWidget_CandidateNodes->setCurrentRow(d->ListWidget_CandidateNodes->currentRow() + 1);
+      // update index value from the upcoming node's name
+      if (d->SequenceNode->GetIndexType() != vtkMRMLSequenceNode::NumericIndex
+        && d->CheckBox_UseNodeNameAsIndexValue->isChecked())
+        {
+        this->candidateNodeItemClicked(d->ListWidget_CandidateNodes->currentItem());
+        }
+      }
+    else
+      {
+      // we are at the end of the list (already added the last element),
+      // so unselect the item to prevent duplicate adding of the last element
+      d->ListWidget_CandidateNodes->setCurrentRow(-1);
+      }
+    }
+
+  if (d->SequenceNode->GetIndexType() == vtkMRMLSequenceNode::NumericIndex)
+    {
+    // Auto-increment the Index value in the new data textbox
+    QString oldIndexValue = d->LineEdit_NewCandidateNodeIndexValue->text();
+    bool isIndexValueNumeric = false;
+    double oldIndexNumber = oldIndexValue.toDouble(&isIndexValueNumeric);
+    if (isIndexValueNumeric)
+      {
+      double incrementValue = d->DoubleSpinBox_IndexValueAutoIncrement->value();
+      QString newIndexValue = QString::number(oldIndexNumber + incrementValue);
+      d->LineEdit_NewCandidateNodeIndexValue->setText(newIndexValue);
+      }
+    }
+
+  return QString::fromStdString(currentIndexValue);
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::onRemoveDataNodeButtonClicked()
+{
+  Q_D(qMRMLSequenceEditWidget);
+  if (!d->SequenceNode)
+    {
+    return;
+    }
+  QList<QTableWidgetItem*> selectedItems = d->TableWidget_DataNodes->selectedItems();
+  QList<int> rowsToDelete;
+  for (QTableWidgetItem* item : selectedItems)
+    {
+    if (item->column() == DATA_NODE_VALUE_COLUMN)
+      {
+      rowsToDelete << item->row();
+      }
+    }
+  std::sort(rowsToDelete.begin(), rowsToDelete.end());
+  if (rowsToDelete.size() == 1)
+    {
+    // remove single node
+    std::string currentIndexValue = d->SequenceNode->GetNthIndexValue(rowsToDelete[0]);
+    d->SequenceNode->RemoveDataNodeAtValue(currentIndexValue);
+    }
+  else
+    {
+    // remove many nodes
+    bool wasModify = d->SequenceNode->StartModify();
+    for (QList<int>::reverse_iterator rowIt = rowsToDelete.rbegin(); rowIt != rowsToDelete.rend(); ++rowIt)
+      {
+      std::string currentIndexValue = d->SequenceNode->GetNthIndexValue(*rowIt);
+      d->SequenceNode->RemoveDataNodeAtValue(currentIndexValue);
+      }
+    d->SequenceNode->EndModify(wasModify);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::candidateNodeItemClicked(QListWidgetItem* item)
+{
+  Q_D(qMRMLSequenceEditWidget);
+  if (!d->SequenceNode || d->SequenceNode->GetIndexType() == vtkMRMLSequenceNode::NumericIndex)
+    {
+    return;
+    }
+  if (item)
+    {
+    d->LineEdit_NewCandidateNodeIndexValue->setText(item->text());
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::candidateNodeItemDoubleClicked(QListWidgetItem* item)
+{
+  Q_D(qMRMLSequenceEditWidget);
+  if (item)
+    {
+    QString addedNodeIndexValue = this->onAddCurrentCandidateNode();
+    d->scrollToDataNodeByIndexValue(addedNodeIndexValue);
+    }
+}
+
+//-----------------------------------------------------------------------------
+void qMRMLSequenceEditWidget::setCandidateNodesSectionVisible(bool show)
+{
+  Q_D(qMRMLSequenceEditWidget);
+
+  QSignalBlocker blocker(d->ExpandButton_DataNodes);
+  d->ExpandButton_DataNodes->setChecked(show);
+
+  d->GroupBox_CandidateNodes->setVisible(show);
+  if (show)
+    {
+    this->updateCandidateNodesWidgetFromMRML();
+    }
+}
+
+//-----------------------------------------------------------------------------
+bool qMRMLSequenceEditWidget::isCandidateNodesSectionVisible()
+{
+  Q_D(qMRMLSequenceEditWidget);
+  return d->GroupBox_CandidateNodes->isVisible();
+}
+
+//-----------------------------------------------------------------------------
+vtkMRMLSequenceNode* qMRMLSequenceEditWidget::mrmlSequenceNode()
+{
+  Q_D(qMRMLSequenceEditWidget);
+  return d->SequenceNode;
+}

--- a/Modules/Loadable/Sequences/Widgets/qMRMLSequenceEditWidget.h
+++ b/Modules/Loadable/Sequences/Widgets/qMRMLSequenceEditWidget.h
@@ -1,0 +1,93 @@
+/*==============================================================================
+
+  Program: 3D Slicer
+
+  Copyright (c) Brigham and Women's Hospital
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+==============================================================================*/
+
+#ifndef __qMRMLSequenceEditWidget_h
+#define __qMRMLSequenceEditWidget_h
+
+// CTK includes
+#include <ctkPimpl.h>
+#include <ctkVTKObject.h>
+
+// Slicer includes
+#include "qMRMLWidget.h"
+
+#include "qSlicerSequencesModuleWidgetsExport.h"
+
+class QListWidgetItem;
+class qMRMLSequenceEditWidgetPrivate;
+class vtkMRMLNode;
+class vtkMRMLSequenceNode;
+
+/// \ingroup Slicer_QtModules_Markups
+class Q_SLICER_MODULE_SEQUENCES_WIDGETS_EXPORT qMRMLSequenceEditWidget
+: public qMRMLWidget
+{
+  Q_OBJECT
+  QVTK_OBJECT
+  Q_PROPERTY(bool candidateNodesSectionVisible READ isCandidateNodesSectionVisible WRITE setCandidateNodesSectionVisible)
+
+public:
+  typedef qMRMLWidget Superclass;
+  qMRMLSequenceEditWidget(QWidget *newParent = 0);
+  ~qMRMLSequenceEditWidget() override;
+
+  bool isCandidateNodesSectionVisible();
+
+public slots:
+  /// Reimplemented from qMRMLWidget
+  void setMRMLScene(vtkMRMLScene* scene) override;
+
+  vtkMRMLSequenceNode* mrmlSequenceNode();
+  void setMRMLSequenceNode(vtkMRMLSequenceNode* sequenceNode);
+  void setMRMLSequenceNode(vtkMRMLNode* sequenceNode);
+
+  void setCandidateNodesSectionVisible(bool);
+
+protected slots:
+  void updateWidgetFromMRML();
+  void updateCandidateNodesWidgetFromMRML(bool forceUpdate = false);
+
+  void candidateNodeItemClicked(QListWidgetItem*);
+  void candidateNodeItemDoubleClicked(QListWidgetItem*);
+  // Returns the index value of the added candidate node
+  QString onAddCurrentCandidateNode();
+  void onDataNodeEdited(int row, int column);
+  void onIndexNameEdited();
+  void onIndexUnitEdited();
+  void onIndexTypeEdited(QString indexTypeString);
+  void onSequenceNodeModified();
+
+  void onAddDataNodeButtonClicked();
+  void onRemoveDataNodeButtonClicked();
+
+  /// Respond to the scene events
+  void onNodeAddedEvent(vtkObject* scene, vtkObject* node);
+  void onNodeRemovedEvent(vtkObject* scene, vtkObject* node);
+  void onMRMLSceneEndImportEvent();
+  void onMRMLSceneEndRestoreEvent();
+  void onMRMLSceneEndBatchProcessEvent();
+  void onMRMLSceneEndCloseEvent();
+
+protected:
+  QScopedPointer<qMRMLSequenceEditWidgetPrivate> d_ptr;
+
+private:
+  Q_DECLARE_PRIVATE(qMRMLSequenceEditWidget);
+  Q_DISABLE_COPY(qMRMLSequenceEditWidget);
+};
+
+#endif

--- a/Modules/Loadable/Sequences/qSlicerSequencesModuleWidget.h
+++ b/Modules/Loadable/Sequences/qSlicerSequencesModuleWidget.h
@@ -55,17 +55,11 @@ public:
 public slots:
 
   void setActiveSequenceNode(vtkMRMLSequenceNode* newActiveSequenceNode);
+
+protected slots:
+
   void onSequenceNodeSelectionChanged();
-  void onSequenceNodeModified();
-
-  void onIndexNameEdited();
-  void onIndexUnitEdited();
-  void onIndexTypeEdited(QString indexTypeString);
-
-  void onDataNodeEdited( int row, int column );
-
-  void onAddDataNodeButtonClicked();
-  void onRemoveDataNodeButtonClicked();
+  void onCurrentTabChanged();
 
   /// Respond to the scene events
   void onNodeAddedEvent(vtkObject* scene, vtkObject* node);
@@ -76,6 +70,7 @@ public slots:
   void onMRMLSceneEndCloseEvent();
 
 protected:
+
   void updateWidgetFromMRML();
 
   /// Refresh synchronized sequence nodes table from MRML
@@ -84,8 +79,6 @@ protected:
   QScopedPointer<qSlicerSequencesModuleWidgetPrivate> d_ptr;
 
   void setup() override;
-
-  void setEnableWidgets(bool enable);
 
 public slots:
   void setMRMLScene(vtkMRMLScene* scene) override;
@@ -113,9 +106,6 @@ protected slots:
   void synchronizedSequenceNodeSaveChangesStateChanged(int aState);
 
   void onProxyNodeChanged(vtkMRMLNode* newProxyNode);
-
-  void updateSequenceItemWidgetFromMRML();
-  void updateCandidateNodesWidgetFromMRML(bool forceUpdate = false);
 
 private:
   Q_DECLARE_PRIVATE(qSlicerSequencesModuleWidget);


### PR DESCRIPTION
In Sequences module's Edit section, multiple candidate nodes can be selected and added to the sequence at once, and multiple data nodes can be removed from the sequence at once.
Added an option to use the candidate node name as index value if index type is text.

Factored out sequence editing into a separate widget (qMRMLSequenceEditWidget). This simplifies the code and provides sequence editing GUI for other modules.

This implements the feature that was mentioned in this discussion:
https://discourse.slicer.org/t/volume-rendering-property-lock/28761/12?u=lassoan