### PR TITLE
DOC: updated run solution for Debian 10.12

### DIFF
--- a/Docs/user_guide/getting_started.md
+++ b/Docs/user_guide/getting_started.md
@@ -101,9 +101,13 @@ Debian 10.12 users may encounter an error when launching Slicer:
 
     Available platform plugins are: xcb.
 
-[The solution](https://forum.qt.io/topic/93247/qt-qpa-plugin-could-not-load-the-qt-platform-plugin-xcb-in-even-though-it-was-found/81) is to create symlink:
+[The solution](https://forum.qt.io/topic/93247/qt-qpa-plugin-could-not-load-the-qt-platform-plugin-xcb-in-even-though-it-was-found/81) is to create symlink to either `libxcb-util.so` or `libxcb-util.so.0.0.0` depending on which library is present. Thus the command should be:
 
     sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
+
+or:
+
+    sudo ln -s /usr/lib/x86_64-linux-gnu/libxcb-util.so.0.0.0 /usr/lib/x86_64-linux-gnu/libxcb-util.so.1
 
 :::
 


### PR DESCRIPTION
I just did the test of running SlicerCAT on Debian 10.12. To solve `QT_QPA_PLATFORM` error I needed to create symlink. But this time I needed to create it to `libxcb-util.so.0.0.0`. As I there was no `libxcb-util.so`.
Most likely the correct library is always `libxcb-util.so.0.0.0`. But I'm not sure.
We could leave these two options so the user could check his system.

This solution also comes from the link above.