### PR TITLE
COMP: Update VTK to support external build of RenderingOpenXRRemoting module

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "f6bcc9d3e350df4f1d77d856be9e7484c8655f87") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "7a000d76cbdafd10f4810e0027a12144a2c6f721") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of VTK changes:

```
$ git shortlog f6bcc9d3e3..7a000d76cb --no-merges
Jean-Christophe Fillion-Robin (1):
      [Backport MR-10122] RenderingOpenXRRemoting: Fix support for externally building the module
```