### PR TITLE
BUG: Fix Python wrapping of methods using enum arguments

### DIFF
--- a/Base/QTCLI/vtkSlicerCLIModuleLogic.h
+++ b/Base/QTCLI/vtkSlicerCLIModuleLogic.h
@@ -31,8 +31,6 @@ class MRMLIDMap;
 
 #include "qSlicerBaseQTCLIExport.h"
 
-typedef enum { CommandLineModule, SharedObjectModule, PythonModule } CommandLineModuleType;
-
 /// \brief Logic for running CLI
 ///
 /// vtkSlicerCLIModuleLogic logic allows to run a either synchronously or asynchronously CLI
@@ -43,6 +41,13 @@ class Q_SLICER_BASE_QTCLI_EXPORT vtkSlicerCLIModuleLogic :
   public vtkSlicerModuleLogic
 {
 public:
+  enum CommandLineModuleType
+    {
+    CommandLineModule,
+    SharedObjectModule,
+    PythonModule
+    };
+
   static vtkSlicerCLIModuleLogic *New();
   vtkTypeMacro(vtkSlicerCLIModuleLogic,vtkSlicerModuleLogic);
   void PrintSelf(ostream& os, vtkIndent indent) override;
@@ -162,9 +167,10 @@ protected:
   void AutoRun(vtkMRMLCommandLineModuleNode* cliNode);
 
     /// List of custom events fired by the class.
-  enum Events{
+  enum Events
+    {
     RequestHierarchyEditEvent = vtkCommand::UserEvent + 1
-  };
+    };
 
   // Add a model hierarchy node and all its descendents to a scene (miniscene to sent to a CLI).
   // The mapping of ids from the original scene to the mini scene is put in (added to) sceneToMiniSceneMap.

--- a/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
+++ b/Libs/MRML/CLI/vtkMRMLCommandLineModuleNode.h
@@ -47,7 +47,8 @@ public:
     {return "CommandLineModule";}
 
   /// List of events that can be fired on or by the node.
-  enum CLINodeEvent{
+  enum CLINodeEvent
+    {
     /// Event invoked anytime a parameter value is changed.
     /// \sa InputParameterModifiedEvent, SetParameterAsString(),
     /// SetParameterAsNode(), SetParameterAsInt(), SetParameterAsBool(),
@@ -64,7 +65,7 @@ public:
     AutoRunEvent,
     /// Event invoked when the CLI changes of status
     StatusModifiedEvent
-  };
+    };
 
   /// Get/Set the module description object. THe module description
   /// object is used to cache the current settings for the module.
@@ -73,7 +74,8 @@ public:
   std::string GetModuleDescriptionAsString() const;
   void SetModuleDescription(const ModuleDescription& description);
 
-  typedef enum {
+  enum StatusType
+    {
     /// Initial state of the CLI.
     Idle=0x00,
     /// State when the CLI has been requested to be executed.
@@ -98,7 +100,7 @@ public:
     CompletedWithErrors= Completed | ErrorsMask,
     /// Mask used to know if the CLI is in pending mode.
     BusyMask = Scheduled | Running | Cancelling | Completing
-  } StatusType;
+    };
 
   /// Set the status of the node (Idle, Scheduled, Running,
   /// Completed).  The "modify" parameter indicates whether the object

--- a/Libs/MRML/Core/vtkMRMLClipModelsNode.h
+++ b/Libs/MRML/Core/vtkMRMLClipModelsNode.h
@@ -84,20 +84,20 @@ public:
 
   enum
     {
-      ClipOff = 0,
-      ClipPositiveSpace = 1,
-      ClipNegativeSpace = 2,
+    ClipOff = 0,
+    ClipPositiveSpace = 1,
+    ClipNegativeSpace = 2,
     };
 
   ///
   ///Indicates what clipping method should be used
   ///Straight cut, whole cell extraction, or whole cell extraction with boundary cells
-  typedef enum
-  {
+  enum ClippingMethodType
+    {
     Straight = 0,
     WholeCells,
     WholeCellsWithBoundary,
-  } ClippingMethodType;
+    };
 
   vtkGetMacro(ClippingMethod, ClippingMethodType);
   vtkSetMacro(ClippingMethod, ClippingMethodType);

--- a/Libs/MRML/Core/vtkMRMLDisplayNode.h
+++ b/Libs/MRML/Core/vtkMRMLDisplayNode.h
@@ -43,20 +43,22 @@ public:
 
   /// Representation models
   /// \sa GetRepresentation(), SetRepresentation()
-  typedef enum {
+  enum RepresentationType
+    {
     PointsRepresentation = 0,
     WireframeRepresentation,
     SurfaceRepresentation
-  } RepresentationType;
+    };
 
   /// Interpolation modes
   /// \sa GetInterpolation(), SetInterpolation()
-  typedef enum {
+  enum InterpolationType
+    {
     FlatInterpolation = 0,
     GouraudInterpolation,
     PhongInterpolation,
     PBRInterpolation
-  } InterpolationType;
+    };
 
   /// Scalar range options for displaying data associated with this display
   /// node, this setting determines if the display node, color node, or ?
@@ -70,7 +72,8 @@ public:
   /// UseManualScalarRange - use user defined values
   /// \sa ScalarRangeFlag, GetScalarRangeFlag(), SetScalarRangeFlag(),
   /// SetScalarRange(), GetScalarRange(), GetScalarRangeFlagTypeAsString()
-  typedef enum {
+  enum ScalarRangeFlagType
+    {
     UseManualScalarRange = 0,
     UseDataScalarRange,
     UseColorNodeScalarRange,
@@ -78,14 +81,15 @@ public:
     UseDirectMapping,
     // insert types above this line
     NUM_SCALAR_RANGE_FLAGS
-  } ScalarRangeFlagType;
+    };
 
   /// Enumerated values for ShowMode.
-  typedef enum {
+  enum ShowModeType
+    {
     ShowDefault = 0, ///< set visibility of this node if user requests show of the displayable node
     ShowIgnore, ///< set visibility manually, useful for non-essential display nodes (e.g., color legend)
     ShowMode_Last
-  } ShowModeType;
+    };
 
   enum
     {

--- a/Libs/MRML/Core/vtkMRMLModelNode.h
+++ b/Libs/MRML/Core/vtkMRMLModelNode.h
@@ -114,10 +114,11 @@ public:
 
   /// Mesh Type hint
   /// \sa GetMeshType()
-  typedef enum {
+  enum MeshTypeHint
+    {
     PolyDataMeshType = 0,
     UnstructuredGridMeshType
-  } MeshTypeHint;
+    };
 
   /// Get the mesh type of that model. The safest way
   /// to know if the mesh is unstructuredGrid is to check


### PR DESCRIPTION
`typedef enum {value1, value2, ...} someTypeName;` is not supported by VTK's Python wrapper (the method that uses such enums are not Python-wrapped). Need to use `enum someTypeName {value1, value2, ...};` syntax instead.

Fixes issue reported here: https://discourse.slicer.org/t/how-to-set-clipping-method-of-vtkmrmlclipmodelsnode/28816