### PR TITLE
Update crosshair cursor position on 3D view mouse move events

### DIFF
--- a/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
+++ b/Libs/MRML/DisplayableManager/vtkMRMLThreeDViewInteractorStyle.cxx
@@ -98,6 +98,19 @@ bool vtkMRMLThreeDViewInteractorStyle::DelegateInteractionEventToDisplayableMana
     {
     // set "inaccurate" world position
     ed->SetWorldPosition(worldPosition, false);
+
+    // update the cursor position on mouse move
+    if (this->GetCameraNode() != nullptr
+      && this->GetCameraNode()->GetScene() != nullptr
+      && inputEventData->GetType() == vtkCommand::MouseMoveEvent)
+      {
+      vtkMRMLScene* scene = this->GetCameraNode()->GetScene();
+      vtkMRMLCrosshairNode* crosshairNode = vtkMRMLCrosshairDisplayableManager::FindCrosshairNode(scene);
+      if (crosshairNode)
+        {
+        crosshairNode->SetCursorPositionRAS(worldPosition);
+        }
+      }
     }
   ed->SetMouseMovedSinceButtonDown(this->MouseMovedSinceButtonDown);
   ed->SetAccuratePicker(this->AccuratePicker);


### PR DESCRIPTION
Following discussions on #6910, here is a new proposal for the addition of a virtual cursor in 3DSlicer.
The new approach consists in a model node being updated on CursorPositionModifiedEvent events.

As discussed with @lassoan, this MR:
1. applies the required changes to the 3D view interactor style for the cursor position to be updated in the 3D view too.
2. provides a small python script to test how the feature would behave once fully integrated: [TrackCursor.zip](https://github.com/Slicer/Slicer/files/11201330/TrackCursor.zip)

The goal is to confirm that such feature could be integrated in its own menu, and identify what would be the options that are exposed to users in terms of rendering properties, cursor models, Slice visibility... 

A few notes regarding the status of the example script compared to the expected feature:
- The mouse pointer should be hidden if the virtual cursor is enabled and the mouse enters the 3D view
- Picking of the cursor model must be disabled (I tried using SelectableOff but it does not seem to have any effect)
- The commented code can be added back to try a line representation, but not sure which direction makes more sense for the line
- The marker should probably have a constant size in screen space coordinates
