### PR TITLE
BUG: Update CTK to latest version to get a few minor fixes

### DIFF
--- a/SuperBuild/External_CTK.cmake
+++ b/SuperBuild/External_CTK.cmake
@@ -73,7 +73,7 @@ if(NOT DEFINED CTK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "83a570aacc2ef745b595c92ff475ef314be884ff"
+    "cd194fff1360e2da114b6b55ce963f089c6f46f2"
     QUIET
     )
 


### PR DESCRIPTION
git log:

Revision: cd194fff1360e2da114b6b55ce963f089c6f46f2
Author: Andras Lasso <lasso@queensu.ca>
Date: 2023-04-11 10:30:38 PM
Message:
BUG: Fix localization and inconsistent state in ctkModalityWidget

There were several issues with the imaging modality selector widget (ctkModalityWidget):
- when imaging modality abbreviations (CT, MRI, XA, ...) were localized then the widget did not work at all, because the checkbox text was used to identify the checkboxes
- widget state was stored redundantly in SelectedModalities and VisibleModalities variables and the checkbox properties; and these were often inconsistent

Fixed by using Qt object names to identify checkboxes; and removing SelectedModalities and VisibleModalities variables (store widget state in the checkbox properties).

Revision: 1e82ef47d2857a8f4a8bfcbc4fd6116ba5b6a376
Author: Andras Lasso <lasso@queensu.ca>
Date: 2023-04-05 9:59:12 PM
Message:
ENH: Remove irrelevant translatable strings

There were strings marked as translatable that should not have been:
- log messages
- test and example code
- symbols
- placeholder text (that is only visible in Qt designer because its actual content is set at runtime)

These texts were marked as non-translatable to avoid unnecessary burden on translators.

Revision: 3817230b07c9bdff9e332ee74a1000eceb02796b
Author: Andras Lasso <lasso@queensu.ca>
Date: 2023-04-05 4:04:44 PM
Message:
ENH: Allow instantiation of more CTK objects in Python

CTK objects that only had default constructor (no Object* parameter) were not possible to instantiate in Python:

>>> a=ctk.ctkErrorLogLevel()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
ValueError: No constructors available for ctkErrorLogLevel

The issue is fixed by passing arguments of the superclass constructor.

Revision: fa1732f6845d90c2c1076147ccce3ca2920dcc53
Author: Kerim <kerim.khemraev@mail.ru>
Date: 2021-07-25 8:01:07 AM
Message:
ENH: Added python bindings for ctkCheckableHeaderView