### PR TITLE
ENH: Initialize global pause render state for newly created views

### DIFF
--- a/Libs/MRML/Widgets/CMakeLists.txt
+++ b/Libs/MRML/Widgets/CMakeLists.txt
@@ -59,6 +59,8 @@ configure_file(
 # Sources
 #
 set(MRMLWidgets_SRCS
+  qMRMLAbstractViewWidget.cxx
+  qMRMLAbstractViewWidget.h
   qMRMLCaptureToolBar.cxx
   qMRMLCaptureToolBar.h
   qMRMLCheckableNodeComboBox.cxx
@@ -239,6 +241,7 @@ endif()
 
 # Headers that should run through moc
 set(MRMLWidgets_MOC_SRCS
+  qMRMLAbstractViewWidget.h
   qMRMLCaptureToolBar.h
   qMRMLCheckableNodeComboBox.h
   qMRMLClipNodeWidget.h

--- a/Libs/MRML/Widgets/qMRMLAbstractViewWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLAbstractViewWidget.cxx
@@ -1,0 +1,127 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+// Qt includes
+#include <QDebug>
+
+// CTK includes
+#include <ctkVTKAbstractView.h>
+
+// qMRML includes
+#include "qMRMLAbstractViewWidget.h"
+
+// MRML includes
+#include <vtkMRMLAbstractViewNode.h>
+
+// --------------------------------------------------------------------------
+// qMRMLAbstractViewWidget methods
+
+// --------------------------------------------------------------------------
+qMRMLAbstractViewWidget::qMRMLAbstractViewWidget(QWidget* parentWidget)
+  : Superclass(parentWidget)
+{
+}
+
+// --------------------------------------------------------------------------
+QColor qMRMLAbstractViewWidget::viewColor() const
+{
+  if (!this->mrmlAbstractViewNode())
+    {
+    qWarning() << Q_FUNC_INFO << " failed: view node is invalid";
+    return QColor(127, 127, 127);
+    }
+  double* layoutColorVtk = this->mrmlAbstractViewNode()->GetLayoutColor();
+  QColor layoutColor = QColor::fromRgbF(layoutColorVtk[0], layoutColorVtk[1], layoutColorVtk[2]);
+  return layoutColor;
+}
+
+// --------------------------------------------------------------------------
+void qMRMLAbstractViewWidget::setViewColor(const QColor& newViewColor)
+{
+  if (!this->mrmlAbstractViewNode())
+    {
+    qWarning() << Q_FUNC_INFO << " failed: view node is invalid";
+    return;
+    }
+  double layoutColor[3] = { newViewColor.redF(), newViewColor.greenF(), newViewColor.blueF() };
+  this->mrmlAbstractViewNode()->SetLayoutColor(layoutColor);
+}
+
+//---------------------------------------------------------------------------
+void qMRMLAbstractViewWidget::setViewLabel(const QString& newViewLabel)
+{
+  if (!this->mrmlAbstractViewNode())
+    {
+    qWarning() << Q_FUNC_INFO << " failed: view node is invalid";
+    return;
+    }
+  std::string newViewLabelString = newViewLabel.toStdString();
+  this->mrmlAbstractViewNode()->SetLayoutLabel(newViewLabelString.c_str());
+}
+
+//---------------------------------------------------------------------------
+QString qMRMLAbstractViewWidget::viewLabel() const
+{
+  if (!this->mrmlAbstractViewNode())
+    {
+    qWarning() << Q_FUNC_INFO << " failed: view node is invalid";
+    return "";
+    }
+  return this->mrmlAbstractViewNode()->GetLayoutLabel();
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLAbstractLogic* qMRMLAbstractViewWidget::logic() const
+{
+  return nullptr;
+}
+
+//---------------------------------------------------------------------------
+void qMRMLAbstractViewWidget::setRenderPaused(bool pause)
+{
+  if (pause)
+    {
+    this->pauseRender();
+    }
+  else
+    {
+    this->resumeRender();
+    }
+}
+
+//---------------------------------------------------------------------------
+void qMRMLAbstractViewWidget::pauseRender()
+{
+  ctkVTKAbstractView* view = qobject_cast<ctkVTKAbstractView*>(this->viewWidget());
+  if (view)
+    {
+    view->pauseRender();
+    }
+}
+
+//---------------------------------------------------------------------------
+void qMRMLAbstractViewWidget::resumeRender()
+{
+  ctkVTKAbstractView* view = qobject_cast<ctkVTKAbstractView*>(this->viewWidget());
+  if (view)
+    {
+    view->resumeRender();
+    }
+}

--- a/Libs/MRML/Widgets/qMRMLAbstractViewWidget.h
+++ b/Libs/MRML/Widgets/qMRMLAbstractViewWidget.h
@@ -1,0 +1,100 @@
+/*==============================================================================
+
+  Copyright (c) Laboratory for Percutaneous Surgery (PerkLab)
+  Queen's University, Kingston, ON, Canada. All Rights Reserved.
+
+  See COPYRIGHT.txt
+  or http://www.slicer.org/copyright/copyright.txt for details.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  This file was originally developed by Kyle Sunderland, PerkLab, Queen's University
+  and was supported through CANARIE's Research Software Program, Cancer
+  Care Ontario, OpenAnatomy, and Brigham and Women's Hospital through NIH grant R01MH112748.
+
+==============================================================================*/
+
+#ifndef __qMRMLAbstractViewWidget_h
+#define __qMRMLAbstractViewWidget_h
+
+// Qt includes
+class QWidget;
+
+// qMRMLWidget includes
+#include "qMRMLWidget.h"
+class qMRMLViewControllerBar;
+
+// MRML includes
+class vtkMRMLAbstractViewNode;
+
+// MRMLLogic includes
+class vtkMRMLAbstractLogic;
+
+class QMRML_WIDGETS_EXPORT qMRMLAbstractViewWidget : public qMRMLWidget
+{
+  Q_OBJECT
+
+  Q_PROPERTY(QString viewLabel READ viewLabel WRITE setViewLabel)
+  Q_PROPERTY(QColor viewColor READ viewColor WRITE setViewColor)
+
+public:
+  /// Superclass typedef
+  typedef qMRMLWidget Superclass;
+
+  /// Constructors
+  explicit qMRMLAbstractViewWidget(QWidget* parent = nullptr);
+  ~qMRMLAbstractViewWidget() override = default;
+
+  /// Get slice controller
+  virtual Q_INVOKABLE qMRMLViewControllerBar* controllerWidget() const = 0;
+
+  /// Get the View node observed by view.
+  virtual Q_INVOKABLE vtkMRMLAbstractViewNode* mrmlAbstractViewNode() const = 0;
+
+  /// \sa qMRMLSliceControllerWidget::viewLogic()
+  virtual Q_INVOKABLE vtkMRMLAbstractLogic* logic() const;
+
+  /// Get a reference to the underlying view widget.
+  /// Be careful if you change the viewWidget, you might
+  /// unsynchronize the view from the nodes/logics.
+  virtual Q_INVOKABLE QWidget* viewWidget() const = 0;
+
+  /// Get the text displayed in the controlled widget label.
+  /// \sa setViewLabel()
+  virtual Q_INVOKABLE QString viewLabel() const;
+
+  /// Set the text displayed in the controlled widget label.
+  /// \sa viewLabel()
+  virtual Q_INVOKABLE void setViewLabel(const QString& newViewLabel);
+
+  /// Get the color displayed in the controlled widget.
+  /// \sa setViewColor()
+  virtual Q_INVOKABLE QColor viewColor() const;
+
+  /// Set the color displayed in the controlled widget.
+  /// \sa viewColor()
+  virtual Q_INVOKABLE void setViewColor(const QColor& newViewColor);
+
+public slots:
+  /// Set the current \a viewNode to observe
+  virtual void setMRMLAbstractViewNode(vtkMRMLAbstractViewNode* newViewNode) = 0;
+
+  /// Calls pauseRender() if pause is true or resumeRender() if pause is false
+  /// \sa pauseRender(), resumeRender()
+  virtual void setRenderPaused(bool pause);
+  /// Increments the pause render count
+  /// \sa setPauseRender()
+  virtual void pauseRender();
+  /// De-increments the pause render count and calls scheduleRender() if one is currently pending
+  /// \sa setPauseRender()
+  virtual void resumeRender();
+
+private:
+  Q_DISABLE_COPY(qMRMLAbstractViewWidget);
+};
+
+#endif

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.cxx
@@ -1212,23 +1212,35 @@ QWidget* qMRMLLayoutManager::viewWidget(vtkMRMLNode* viewNode) const
 }
 
 //------------------------------------------------------------------------------
+QList<QWidget*> qMRMLLayoutManager::viewWidgets() const
+{
+  Q_D(const qMRMLLayoutManager);
+  QList<QWidget*> viewWidgets;
+  for (qMRMLLayoutViewFactory* factory : this->mrmlViewFactories())
+    {
+    for (int i = 0; i < factory->viewCount(); ++i)
+      {
+      viewWidgets.append(factory->viewWidget(i));
+      }
+    }
+  return viewWidgets;
+}
+
+//------------------------------------------------------------------------------
 void qMRMLLayoutManager::setRenderPaused(bool pause)
 {
   // Note: views that are instantiated between pauseRender() calls will not be affected
   // by the specified pause state
   Q_D(qMRMLLayoutManager);
-  qMRMLLayoutViewFactory* sliceViewFactory = this->mrmlViewFactory("vtkMRMLSliceNode");
-  foreach(const QString& viewName, sliceViewFactory->viewNodeNames())
-    {
-    ctkVTKAbstractView* view = this->sliceWidget(viewName)->sliceView();
-    view->setRenderPaused(pause);
-    }
 
-  qMRMLLayoutViewFactory* threeDViewFactory = this->mrmlViewFactory("vtkMRMLViewNode");
-  foreach(const QString& viewName, threeDViewFactory->viewNodeNames())
+  QList<QWidget*> viewWidgets = this->viewWidgets();
+  for (QWidget* widget : viewWidgets)
     {
-    ctkVTKAbstractView* view = this->threeDWidget(viewName)->threeDView();
-    view->setRenderPaused(pause);
+    qMRMLAbstractViewWidget* viewWidget = qobject_cast<qMRMLAbstractViewWidget*>(widget);
+    if (viewWidget)
+      {
+      viewWidget->setRenderPaused(pause);
+      }
     }
 
   if (pause)

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.h
@@ -126,6 +126,9 @@ public:
   /// qMRMLThreeDWidget respectively).
   Q_INVOKABLE QWidget* viewWidget(vtkMRMLNode* n) const;
 
+  /// Get a list of all QWidgets for all views in the layout manager.
+  Q_INVOKABLE QList<QWidget*> viewWidgets() const;
+
   /// Get slice view widget identified by \a name
   Q_INVOKABLE qMRMLSliceWidget* sliceWidget(const QString& name)const;
 
@@ -139,8 +142,12 @@ public:
 
   /// Return the number of instantiated ThreeDRenderView
   int threeDViewCount()const;
+  /// Return the number of plot views
   int tableViewCount()const;
+  /// Return the number of table views
   int plotViewCount()const;
+  /// Return the total number of views
+  int viewCount() const;
 
   /// Get ThreeDWidget identified by \a id
   /// where \a id is an integer ranging from 0 to N-1 with N being the number

--- a/Libs/MRML/Widgets/qMRMLLayoutManager.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager.h
@@ -201,6 +201,11 @@ public:
   /// activeThreeDRenderer()
   Q_INVOKABLE vtkRenderer* activePlotRenderer()const;
 
+  /// Returns the number of global pause render counts that have been called on the layout manager.
+  /// This value does not include pauseRender counts that have been called on each view individually,
+  /// and is used to set the pause render state when new views are created.
+  /// \sa pauseRender(), resumeRender(), setRenderPaused()
+  int allViewsPauseRenderCount();
 
 public slots:
   /// Set the enabled property value

--- a/Libs/MRML/Widgets/qMRMLLayoutManager_p.h
+++ b/Libs/MRML/Widgets/qMRMLLayoutManager_p.h
@@ -155,6 +155,7 @@ public:
   /// Top-level windows created and managed by this class that host additional viewports
   /// (outside the main application window).
   QMap<QString, ViewportInfo>  DetachedViewports;
+  int AllViewsPauseRenderCount{ 0 };
 };
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
@@ -28,6 +28,10 @@
 // MRMLWidgets includes
 #include "qMRMLLayoutManager.h"
 #include "qMRMLLayoutViewFactory.h"
+#include "qMRMLThreeDWidget.h"
+#include "qMRMLThreeDView.h"
+#include "qMRMLSliceWidget.h"
+#include "qMRMLSliceView.h"
 #include "qMRMLWidget.h"
 
 // MRML includes
@@ -383,7 +387,8 @@ void qMRMLLayoutViewFactory::onNodeModified(vtkObject* node)
     this->onViewNodeModified(viewNode);
     }
 }
-
+#include <qMRMLPlotWidget.h>
+#include <qMRMLPlotView.h>
 // --------------------------------------------------------------------------
 void qMRMLLayoutViewFactory::onViewNodeAdded(vtkMRMLAbstractViewNode* node)
 {
@@ -400,6 +405,26 @@ void qMRMLLayoutViewFactory::onViewNodeAdded(vtkMRMLAbstractViewNode* node)
   if (!viewWidget)
     { // The factory cannot create such view, do nothing about it
     return;
+    }
+
+  ctkVTKAbstractView* view = nullptr;
+  qMRMLThreeDWidget* threeDWidget = qobject_cast<qMRMLThreeDWidget*>(viewWidget);
+  if (threeDWidget)
+    {
+    view = threeDWidget->threeDView();
+    }
+  qMRMLSliceWidget* sliceWidget = qobject_cast<qMRMLSliceWidget*>(viewWidget);
+  if (sliceWidget)
+    {
+    view = sliceWidget->sliceView();
+    }
+
+  if (view)
+    {
+    for (int i = 0; i < d->LayoutManager->allViewsPauseRenderCount(); ++i)
+      {
+      view->pauseRender();
+      }
     }
 
   // Do not show until mapped into a view (the widget is shown/hidden only

--- a/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
+++ b/Libs/MRML/Widgets/qMRMLLayoutViewFactory.cxx
@@ -387,8 +387,7 @@ void qMRMLLayoutViewFactory::onNodeModified(vtkObject* node)
     this->onViewNodeModified(viewNode);
     }
 }
-#include <qMRMLPlotWidget.h>
-#include <qMRMLPlotView.h>
+
 // --------------------------------------------------------------------------
 void qMRMLLayoutViewFactory::onViewNodeAdded(vtkMRMLAbstractViewNode* node)
 {
@@ -401,38 +400,28 @@ void qMRMLLayoutViewFactory::onViewNodeAdded(vtkMRMLAbstractViewNode* node)
     { // The view already exists, no need to create it again.
     return;
     }
-  QWidget* viewWidget = this->createViewFromNode(node);
-  if (!viewWidget)
+  QWidget* widget = this->createViewFromNode(node);
+  if (!widget)
     { // The factory cannot create such view, do nothing about it
     return;
     }
 
-  ctkVTKAbstractView* view = nullptr;
-  qMRMLThreeDWidget* threeDWidget = qobject_cast<qMRMLThreeDWidget*>(viewWidget);
-  if (threeDWidget)
+  qMRMLAbstractViewWidget* viewWidget = qobject_cast<qMRMLAbstractViewWidget*>(widget);
+  if (viewWidget)
     {
-    view = threeDWidget->threeDView();
-    }
-  qMRMLSliceWidget* sliceWidget = qobject_cast<qMRMLSliceWidget*>(viewWidget);
-  if (sliceWidget)
-    {
-    view = sliceWidget->sliceView();
-    }
-
-  if (view)
-    {
+    // Initialize the pause render state to match the current pause render count on all views.
     for (int i = 0; i < d->LayoutManager->allViewsPauseRenderCount(); ++i)
       {
-      view->pauseRender();
+      viewWidget->pauseRender();
       }
     }
 
   // Do not show until mapped into a view (the widget is shown/hidden only
   // if it is part of the layout, but if the widget was not yet part of any layout
   // then it would show up in the top-left corner of the viewport)
-  viewWidget->setVisible(false);
+  widget->setVisible(false);
 
-  d->Views[node] = viewWidget;
+  d->Views[node] = widget;
 
   // For now, the active view is the first one
   if (this->viewCount() == 1)
@@ -441,7 +430,7 @@ void qMRMLLayoutViewFactory::onViewNodeAdded(vtkMRMLAbstractViewNode* node)
     }
   this->qvtkConnect(node, vtkCommand::ModifiedEvent,
                     this, SLOT(onNodeModified(vtkObject*)));
-  emit viewCreated(viewWidget);
+  emit viewCreated(widget);
 }
 
 // --------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLPlotWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLPlotWidget.cxx
@@ -28,6 +28,9 @@
 // CTK includes
 #include <ctkPopupWidget.h>
 
+// MRML includes
+#include <vtkMRMLPlotViewNode.h>
+
 // qMRML includes
 #include "qMRMLPlotViewControllerWidget.h"
 #include "qMRMLPlotView.h"
@@ -116,21 +119,45 @@ void qMRMLPlotWidget::setMRMLPlotViewNode(vtkMRMLPlotViewNode* newPlotViewNode)
   d->PlotController->setMRMLPlotViewNode(newPlotViewNode);
 }
 
-// --------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+void qMRMLPlotWidget::setMRMLAbstractViewNode(vtkMRMLAbstractViewNode* newViewNode)
+{
+  vtkMRMLPlotViewNode* plotViewNode = vtkMRMLPlotViewNode::SafeDownCast(newViewNode);
+  if (newViewNode && !plotViewNode)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: Invalid view node type " << newViewNode->GetClassName()
+      << ". Expected node type: vtkMRMLPlotViewNode";
+    }
+  this->setMRMLPlotViewNode(plotViewNode);
+}
+
+//--------------------------------------------------------------------------
 vtkMRMLPlotViewNode* qMRMLPlotWidget::mrmlPlotViewNode()const
 {
   Q_D(const qMRMLPlotWidget);
   return d->PlotView->mrmlPlotViewNode();
 }
 
-// --------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+vtkMRMLAbstractViewNode* qMRMLPlotWidget::mrmlAbstractViewNode()const
+{
+  return this->mrmlPlotViewNode();
+}
+
+//--------------------------------------------------------------------------
 qMRMLPlotView* qMRMLPlotWidget::plotView()const
 {
   Q_D(const qMRMLPlotWidget);
   return d->PlotView;
 }
 
-// --------------------------------------------------------------------------
+//--------------------------------------------------------------------------
+QWidget* qMRMLPlotWidget::viewWidget()const
+{
+  return this->plotView();
+}
+
+//--------------------------------------------------------------------------
 qMRMLPlotViewControllerWidget* qMRMLPlotWidget::plotController()const
 {
   Q_D(const qMRMLPlotWidget);
@@ -138,15 +165,7 @@ qMRMLPlotViewControllerWidget* qMRMLPlotWidget::plotController()const
 }
 
 //---------------------------------------------------------------------------
-void qMRMLPlotWidget::setViewLabel(const QString& newPlotViewLabel)
+qMRMLViewControllerBar* qMRMLPlotWidget::controllerWidget()const
 {
-  Q_D(qMRMLPlotWidget);
-  d->PlotController->setViewLabel(newPlotViewLabel);
-}
-
-//---------------------------------------------------------------------------
-QString qMRMLPlotWidget::viewLabel()const
-{
-  Q_D(const qMRMLPlotWidget);
-  return d->PlotController->viewLabel();
+  return this->plotController();
 }

--- a/Libs/MRML/Widgets/qMRMLPlotWidget.h
+++ b/Libs/MRML/Widgets/qMRMLPlotWidget.h
@@ -25,7 +25,7 @@
 class QResizeEvent;
 
 // qMRMLWidget includes
-#include "qMRMLWidget.h"
+#include "qMRMLAbstractViewWidget.h"
 class qMRMLPlotViewControllerWidget;
 class qMRMLPlotView;
 class qMRMLPlotWidgetPrivate;
@@ -40,13 +40,13 @@ class vtkMRMLScene;
 /// qMRMLPlotWidget provides plotting capabilities with a display
 /// canvas for the plot and a controller widget to control the
 /// content and properties of the plot.
-class QMRML_WIDGETS_EXPORT qMRMLPlotWidget : public qMRMLWidget
+class QMRML_WIDGETS_EXPORT qMRMLPlotWidget : public qMRMLAbstractViewWidget
 {
   Q_OBJECT
-  Q_PROPERTY(QString viewLabel READ viewLabel WRITE setViewLabel)
+
 public:
   /// Superclass typedef
-  typedef qMRMLWidget Superclass;
+  typedef qMRMLAbstractViewWidget Superclass;
 
   /// Constructors
   explicit qMRMLPlotWidget(QWidget* parent = nullptr);
@@ -54,28 +54,22 @@ public:
 
   /// Get the Plot node observed by view.
   Q_INVOKABLE vtkMRMLPlotViewNode* mrmlPlotViewNode()const;
+  Q_INVOKABLE vtkMRMLAbstractViewNode* mrmlAbstractViewNode() const override;
 
   /// Get a reference to the underlying Plot View
   /// Becareful if you change the PlotView, you might
   /// unsynchronize the view from the nodes/logics.
   Q_INVOKABLE qMRMLPlotView* plotView()const;
+  Q_INVOKABLE QWidget* viewWidget()const override;
 
-    /// Get plot view controller widget
+  /// Get plot view controller widget
   Q_INVOKABLE qMRMLPlotViewControllerWidget* plotController()const;
-
-  /// Get the view label for the Plot.
-  /// \sa qMRMLPlotControllerWidget::PlotViewLabel()
-  /// \sa setPlotViewLabel()
-  QString viewLabel()const;
-
-  /// Set the view label for the Plot.
-  /// \sa qMRMLPlotControllerWidget::PlotViewLabel()
-  /// \sa PlotViewLabel()
-  void setViewLabel(const QString& newPlotViewLabel);
+  Q_INVOKABLE qMRMLViewControllerBar* controllerWidget()const override;
 
 public slots:
   /// Set the current \a viewNode to observe
   void setMRMLPlotViewNode(vtkMRMLPlotViewNode* newPlotViewNode);
+  void setMRMLAbstractViewNode(vtkMRMLAbstractViewNode* newViewNode) override;
 
 protected:
   QScopedPointer<qMRMLPlotWidgetPrivate> d_ptr;

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.cxx
@@ -26,6 +26,7 @@
 
 // qMRML includes
 #include "qMRMLSliceWidget_p.h"
+#include "qMRMLSliceView.h"
 
 // MRMLDisplayableManager includes
 #include <vtkMRMLSliceViewInteractorStyle.h>
@@ -33,6 +34,9 @@
 // MRML includes
 #include <vtkMRMLSliceNode.h>
 #include <vtkMRMLScene.h>
+
+// MRML logic includes
+#include <vtkMRMLSliceLogic.h>
 
 // VTK includes
 #include <vtkNew.h>
@@ -161,6 +165,19 @@ void qMRMLSliceWidget::setMRMLSliceNode(vtkMRMLSliceNode* newSliceNode)
 }
 
 //---------------------------------------------------------------------------
+void qMRMLSliceWidget::setMRMLAbstractViewNode(vtkMRMLAbstractViewNode* newViewNode)
+{
+  Q_D(qMRMLSliceWidget);
+  vtkMRMLSliceNode* sliceViewNode = vtkMRMLSliceNode::SafeDownCast(newViewNode);
+  if (newViewNode && !sliceViewNode)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: Invalid view node type " << newViewNode->GetClassName()
+      << ". Expected node type: vtkMRMLSliceNode";
+    }
+  this->setMRMLSliceNode(sliceViewNode);
+}
+
+//---------------------------------------------------------------------------
 vtkMRMLSliceCompositeNode* qMRMLSliceWidget::mrmlSliceCompositeNode()const
 {
   Q_D(const qMRMLSliceWidget);
@@ -185,28 +202,28 @@ QString qMRMLSliceWidget::sliceViewName()const
 void qMRMLSliceWidget::setSliceViewLabel(const QString& newSliceViewLabel)
 {
   Q_D(qMRMLSliceWidget);
-  d->SliceController->setSliceViewLabel(newSliceViewLabel);
+  this->setViewLabel(newSliceViewLabel);
 }
 
 //---------------------------------------------------------------------------
 QString qMRMLSliceWidget::sliceViewLabel()const
 {
   Q_D(const qMRMLSliceWidget);
-  return d->SliceController->sliceViewLabel();
+  return this->viewLabel();
 }
 
 //---------------------------------------------------------------------------
 void qMRMLSliceWidget::setSliceViewColor(const QColor& newSliceViewColor)
 {
-  Q_D(qMRMLSliceWidget);
-  d->SliceController->setSliceViewColor(newSliceViewColor);
+  Q_D(const qMRMLSliceWidget);
+  this->setViewColor(newSliceViewColor);
 }
 
 //---------------------------------------------------------------------------
 QColor qMRMLSliceWidget::sliceViewColor()const
 {
   Q_D(const qMRMLSliceWidget);
-  return d->SliceController->sliceViewColor();
+  return this->viewColor();
 }
 
 //---------------------------------------------------------------------------
@@ -257,10 +274,24 @@ vtkMRMLSliceNode* qMRMLSliceWidget::mrmlSliceNode()const
 }
 
 //---------------------------------------------------------------------------
+vtkMRMLAbstractViewNode* qMRMLSliceWidget::mrmlAbstractViewNode()const
+{
+  Q_D(const qMRMLSliceWidget);
+  return this->mrmlSliceNode();
+}
+
+//---------------------------------------------------------------------------
 vtkMRMLSliceLogic* qMRMLSliceWidget::sliceLogic()const
 {
   Q_D(const qMRMLSliceWidget);
   return d->SliceController->sliceLogic();
+}
+
+//---------------------------------------------------------------------------
+vtkMRMLAbstractLogic* qMRMLSliceWidget::logic()const
+{
+  Q_D(const qMRMLSliceWidget);
+  return this->sliceLogic();
 }
 
 // --------------------------------------------------------------------------
@@ -286,6 +317,13 @@ qMRMLSliceView* qMRMLSliceWidget::sliceView()const
 }
 
 // --------------------------------------------------------------------------
+QWidget* qMRMLSliceWidget::viewWidget()const
+{
+  Q_D(const qMRMLSliceWidget);
+  return this->sliceView();
+}
+
+// --------------------------------------------------------------------------
 Qt::Orientation qMRMLSliceWidget::sliceOffsetSliderOrientation()const
 {
   Q_D(const qMRMLSliceWidget);
@@ -294,6 +332,13 @@ Qt::Orientation qMRMLSliceWidget::sliceOffsetSliderOrientation()const
 
 // --------------------------------------------------------------------------
 qMRMLSliceControllerWidget* qMRMLSliceWidget::sliceController()const
+{
+  Q_D(const qMRMLSliceWidget);
+  return d->SliceController;
+}
+
+// --------------------------------------------------------------------------
+qMRMLViewControllerBar* qMRMLSliceWidget::controllerWidget()const
 {
   Q_D(const qMRMLSliceWidget);
   return d->SliceController;

--- a/Libs/MRML/Widgets/qMRMLSliceWidget.h
+++ b/Libs/MRML/Widgets/qMRMLSliceWidget.h
@@ -21,33 +21,32 @@
 #ifndef __qMRMLSliceWidget_h
 #define __qMRMLSliceWidget_h
 
+// VTK includes
+class vtkAlgorithmOutput;
+class vtkCollection;
+class vtkCornerAnnotation;
+class vtkInteractorObserver;
+
 // CTK includes
 #include <ctkPimpl.h>
 #include <vtkVersion.h>
 
 // qMRMLWidget includes
-#include "qMRMLWidget.h"
-
+#include "qMRMLAbstractViewWidget.h"
 #include "qMRMLWidgetsExport.h"
-
-class qMRMLSliceView;
-class qMRMLSliceWidgetPrivate;
 class qMRMLSliceControllerWidget;
 class qMRMLSliceVerticalControllerWidget;
-class vtkCollection;
-class vtkMRMLScene;
+class qMRMLSliceView;
+class qMRMLSliceWidgetPrivate;
+
+// MRML includes
 class vtkMRMLNode;
+class vtkMRMLScene;
+class vtkMRMLSliceCompositeNode;
 class vtkMRMLSliceLogic;
 class vtkMRMLSliceNode;
-class vtkMRMLSliceCompositeNode;
 
-class vtkAlgorithmOutput;
-class vtkImageData;
-class vtkInteractorObserver;
-class vtkCornerAnnotation;
-class vtkCollection;
-
-class QMRML_WIDGETS_EXPORT qMRMLSliceWidget : public qMRMLWidget
+class QMRML_WIDGETS_EXPORT qMRMLSliceWidget : public qMRMLAbstractViewWidget
 {
   Q_OBJECT
   Q_PROPERTY(QString sliceOrientation READ sliceOrientation WRITE setSliceOrientation)
@@ -58,7 +57,7 @@ class QMRML_WIDGETS_EXPORT qMRMLSliceWidget : public qMRMLWidget
 
 public:
   /// Superclass typedef
-  typedef qMRMLWidget Superclass;
+  typedef qMRMLAbstractViewWidget Superclass;
 
   /// Constructors
   explicit qMRMLSliceWidget(QWidget* parent = nullptr);
@@ -66,6 +65,7 @@ public:
 
   /// Get slice controller
   Q_INVOKABLE qMRMLSliceControllerWidget* sliceController()const;
+  Q_INVOKABLE qMRMLViewControllerBar* controllerWidget() const override;
 
   /// Get vertical slice controller
   Q_INVOKABLE qMRMLSliceVerticalControllerWidget* sliceVerticalController()const;
@@ -73,9 +73,11 @@ public:
   /// \sa qMRMLSliceControllerWidget::mrmlSliceNode()
   /// \sa setMRMLSliceNode()
   Q_INVOKABLE vtkMRMLSliceNode* mrmlSliceNode()const;
+  Q_INVOKABLE vtkMRMLAbstractViewNode* mrmlAbstractViewNode()const override;
 
   /// \sa qMRMLSliceControllerWidget::sliceLogic()
   Q_INVOKABLE vtkMRMLSliceLogic* sliceLogic()const;
+  Q_INVOKABLE vtkMRMLAbstractLogic* logic()const override;
 
   /// \sa qMRMLSliceControllerWidget::sliceOrientation()
   /// \sa setSliceOrientation()
@@ -128,6 +130,7 @@ public:
   /// renders the view (contains vtkRenderWindow).
   /// \sa sliceController()
   Q_INVOKABLE qMRMLSliceView* sliceView()const;
+  Q_INVOKABLE QWidget* viewWidget()const override;
 
   /// This property holds the orientation of the slice offset slider.
   /// The orientation must be Qt::Horizontal (the default) or Qt::Vertical.
@@ -139,6 +142,7 @@ public slots:
   /// \sa qMRMLSliceControllerWidget::setMRMLSliceNode()
   /// \sa mrmlSliceNode()
   void setMRMLSliceNode(vtkMRMLSliceNode* newSliceNode);
+  void setMRMLAbstractViewNode(vtkMRMLAbstractViewNode* newSliceNode);
 
   /// \sa qMRMLSliceControllerWidget::setImageData()
   /// \sa imageData()

--- a/Libs/MRML/Widgets/qMRMLTableWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLTableWidget.cxx
@@ -31,6 +31,9 @@
 // CTK includes
 #include <ctkPopupWidget.h>
 
+// MRML includes
+#include <vtkMRMLTableViewNode.h>
+
 // qMRML includes
 #include "qMRMLTableViewControllerWidget.h"
 #include "qMRMLTableView.h"
@@ -109,13 +112,25 @@ qMRMLTableWidget::~qMRMLTableWidget()
   d->TableController->setMRMLScene(nullptr);
 }
 
-
 // --------------------------------------------------------------------------
 void qMRMLTableWidget::setMRMLTableViewNode(vtkMRMLTableViewNode* newTableViewNode)
 {
   Q_D(qMRMLTableWidget);
   d->TableView->setMRMLTableViewNode(newTableViewNode);
   d->TableController->setMRMLTableViewNode(newTableViewNode);
+}
+
+// --------------------------------------------------------------------------
+void qMRMLTableWidget::setMRMLAbstractViewNode(vtkMRMLAbstractViewNode* newViewNode)
+{
+  Q_D(qMRMLTableWidget);
+  vtkMRMLTableViewNode* tableViewNode = vtkMRMLTableViewNode::SafeDownCast(newViewNode);
+  if (newViewNode && !tableViewNode)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: Invalid view node type " << newViewNode->GetClassName()
+      << ". Expected node type: vtkMRMLTableViewNode";
+    }
+  this->setMRMLTableViewNode(tableViewNode);
 }
 
 // --------------------------------------------------------------------------
@@ -126,10 +141,24 @@ vtkMRMLTableViewNode* qMRMLTableWidget::mrmlTableViewNode()const
 }
 
 // --------------------------------------------------------------------------
+vtkMRMLAbstractViewNode* qMRMLTableWidget::mrmlAbstractViewNode()const
+{
+  Q_D(const qMRMLTableWidget);
+  return this->mrmlTableViewNode();
+}
+
+// --------------------------------------------------------------------------
 qMRMLTableView* qMRMLTableWidget::tableView()const
 {
   Q_D(const qMRMLTableWidget);
   return d->TableView;
+}
+
+// --------------------------------------------------------------------------
+QWidget* qMRMLTableWidget::viewWidget()const
+{
+  Q_D(const qMRMLTableWidget);
+  return this->tableView();
 }
 
 // --------------------------------------------------------------------------
@@ -139,16 +168,9 @@ qMRMLTableViewControllerWidget* qMRMLTableWidget::tableController()const
   return d->TableController;
 }
 
-//---------------------------------------------------------------------------
-void qMRMLTableWidget::setViewLabel(const QString& newTableViewLabel)
-{
-  Q_D(qMRMLTableWidget);
-  d->TableController->setViewLabel(newTableViewLabel);
-}
-
-//---------------------------------------------------------------------------
-QString qMRMLTableWidget::viewLabel()const
+// --------------------------------------------------------------------------
+qMRMLViewControllerBar* qMRMLTableWidget::controllerWidget()const
 {
   Q_D(const qMRMLTableWidget);
-  return d->TableController->viewLabel();
+  return this->tableController();
 }

--- a/Libs/MRML/Widgets/qMRMLTableWidget.h
+++ b/Libs/MRML/Widgets/qMRMLTableWidget.h
@@ -28,7 +28,7 @@
 class QResizeEvent;
 
 // qMRMLWidget includes
-#include "qMRMLWidget.h"
+#include "qMRMLAbstractViewWidget.h"
 class qMRMLTableViewControllerWidget;
 class qMRMLTableView;
 class qMRMLTableWidgetPrivate;
@@ -43,12 +43,12 @@ class vtkMRMLScene;
 /// qMRMLTableWidget provides tabling capabilities with a display
 /// canvas for the table and a controller widget to control the
 /// content and properties of the table.
-class QMRML_WIDGETS_EXPORT qMRMLTableWidget : public qMRMLWidget
+class QMRML_WIDGETS_EXPORT qMRMLTableWidget : public qMRMLAbstractViewWidget
 {
   Q_OBJECT
 public:
   /// Superclass typedef
-  typedef qMRMLWidget Superclass;
+  typedef qMRMLAbstractViewWidget Superclass;
 
   /// Constructors
   explicit qMRMLTableWidget(QWidget* parent = nullptr);
@@ -56,28 +56,22 @@ public:
 
   /// Get the table node observed by view.
   Q_INVOKABLE vtkMRMLTableViewNode* mrmlTableViewNode()const;
+  Q_INVOKABLE vtkMRMLAbstractViewNode* mrmlAbstractViewNode()const override;
 
   /// Get a reference to the underlying Table View
   /// Becareful if you change the TableView, you might
   /// unsynchronize the view from the nodes/logics.
   Q_INVOKABLE qMRMLTableView* tableView()const;
+  Q_INVOKABLE QWidget* viewWidget()const override;
 
   /// Get table view controller widget
   Q_INVOKABLE qMRMLTableViewControllerWidget* tableController()const;
-
-  /// Get the view label for the table.
-  /// \sa qMRMLTableControllerWidget::tableViewLabel()
-  /// \sa setTableViewLabel()
-  QString viewLabel()const;
-
-  /// Set the view label for the table.
-  /// \sa qMRMLTableControllerWidget::tableViewLabel()
-  /// \sa tableViewLabel()
-  void setViewLabel(const QString& newTableViewLabel);
+  Q_INVOKABLE qMRMLViewControllerBar* controllerWidget()const override;
 
 public slots:
   /// Set the current \a viewNode to observe
   void setMRMLTableViewNode(vtkMRMLTableViewNode* newTableViewNode);
+  void setMRMLAbstractViewNode(vtkMRMLAbstractViewNode* newTableViewNode) override;
 
 protected:
   QScopedPointer<qMRMLTableWidgetPrivate> d_ptr;

--- a/Libs/MRML/Widgets/qMRMLThreeDWidget.cxx
+++ b/Libs/MRML/Widgets/qMRMLThreeDWidget.cxx
@@ -139,10 +139,30 @@ void qMRMLThreeDWidget::setMRMLViewNode(vtkMRMLViewNode* newViewNode)
 }
 
 // --------------------------------------------------------------------------
+void qMRMLThreeDWidget::setMRMLAbstractViewNode(vtkMRMLAbstractViewNode* newViewNode)
+{
+  Q_D(qMRMLThreeDWidget);
+  vtkMRMLViewNode* threeDViewNode = vtkMRMLViewNode::SafeDownCast(newViewNode);
+  if (newViewNode && !threeDViewNode)
+    {
+    qWarning() << Q_FUNC_INFO << " failed: Invalid view node type " << newViewNode->GetClassName()
+      << ". Expected node type: vtkMRMLViewNode";
+    }
+  this->setMRMLViewNode(threeDViewNode);
+}
+
+// --------------------------------------------------------------------------
 vtkMRMLViewNode* qMRMLThreeDWidget::mrmlViewNode()const
 {
   Q_D(const qMRMLThreeDWidget);
   return d->ThreeDView->mrmlViewNode();
+}
+
+// --------------------------------------------------------------------------
+vtkMRMLAbstractViewNode* qMRMLThreeDWidget::mrmlAbstractViewNode()const
+{
+  Q_D(const qMRMLThreeDWidget);
+  return this->mrmlViewNode();
 }
 
 // --------------------------------------------------------------------------
@@ -154,10 +174,24 @@ vtkMRMLViewLogic* qMRMLThreeDWidget::viewLogic() const
 }
 
 // --------------------------------------------------------------------------
+vtkMRMLAbstractLogic* qMRMLThreeDWidget::logic() const
+{
+  Q_D(const qMRMLThreeDWidget);
+  return this->viewLogic();
+}
+
+// --------------------------------------------------------------------------
 qMRMLThreeDView* qMRMLThreeDWidget::threeDView()const
 {
   Q_D(const qMRMLThreeDWidget);
   return d->ThreeDView;
+}
+
+// --------------------------------------------------------------------------
+QWidget* qMRMLThreeDWidget::viewWidget()const
+{
+  Q_D(const qMRMLThreeDWidget);
+  return this->threeDView();
 }
 
 // --------------------------------------------------------------------------
@@ -168,17 +202,10 @@ qMRMLThreeDViewControllerWidget* qMRMLThreeDWidget::threeDController() const
 }
 
 //---------------------------------------------------------------------------
-void qMRMLThreeDWidget::setViewLabel(const QString& newViewLabel)
-{
-  Q_D(qMRMLThreeDWidget);
-  d->ThreeDController->setViewLabel(newViewLabel);
-}
-
-//---------------------------------------------------------------------------
-QString qMRMLThreeDWidget::viewLabel()const
+qMRMLViewControllerBar* qMRMLThreeDWidget::controllerWidget() const
 {
   Q_D(const qMRMLThreeDWidget);
-  return d->ThreeDController->viewLabel();
+  return this->threeDController();
 }
 
 //---------------------------------------------------------------------------
@@ -186,42 +213,6 @@ void qMRMLThreeDWidget::setQuadBufferStereoSupportEnabled(bool value)
 {
   Q_D(qMRMLThreeDWidget);
   d->ThreeDController->setQuadBufferStereoSupportEnabled(value);
-}
-
-//---------------------------------------------------------------------------
-void qMRMLThreeDWidget::setViewColor(const QColor& newViewColor)
-{
-  Q_D(qMRMLThreeDWidget);
-  if (!this->viewLogic() || !this->viewLogic()->GetViewNode())
-    {
-    qWarning() << Q_FUNC_INFO << " failed: view node is invalid";
-    return;
-    }
-
-  double layoutColor[3] = { newViewColor.redF(), newViewColor.greenF(), newViewColor.blueF() };
-  this->viewLogic()->GetViewNode()->SetLayoutColor(layoutColor);
-}
-
-//---------------------------------------------------------------------------
-QColor qMRMLThreeDWidget::viewColor()const
-{
-  Q_D(const qMRMLThreeDWidget);
-  if (!this->viewLogic() || !this->viewLogic()->GetViewNode())
-    {
-    qWarning() << Q_FUNC_INFO << " failed: view node is invalid";
-    return QColor(127, 127, 127);
-    }
-  double* layoutColorVtk = this->viewLogic()->GetViewNode()->GetLayoutColor();
-  QColor layoutColor = QColor::fromRgbF(layoutColorVtk[0], layoutColorVtk[1], layoutColorVtk[2]);
-  return layoutColor;
-}
-
-//---------------------------------------------------------------------------
-void qMRMLThreeDWidget::setMRMLScene(vtkMRMLScene* newScene)
-{
-  Q_D(qMRMLThreeDWidget);
-
-  this->Superclass::setMRMLScene(newScene);
 }
 
 //------------------------------------------------------------------------------

--- a/Libs/MRML/Widgets/qMRMLThreeDWidget.h
+++ b/Libs/MRML/Widgets/qMRMLThreeDWidget.h
@@ -21,18 +21,14 @@
 #ifndef __qMRMLThreeDWidget_h
 #define __qMRMLThreeDWidget_h
 
-// Qt includes
-#include <QWidget>
-class QResizeEvent;
-
 // qMRMLWidget includes
-#include "qMRMLWidget.h"
+#include "qMRMLAbstractViewWidget.h"
 class qMRMLThreeDViewControllerWidget;
 class qMRMLThreeDView;
 class qMRMLThreeDWidgetPrivate;
+class qMRMLViewControllerBar;
 
 // MRML includes
-class vtkMRMLScene;
 class vtkMRMLViewNode;
 
 // MRMLLogic includes
@@ -41,15 +37,13 @@ class vtkMRMLViewLogic;
 // VTK includes
 class vtkCollection;
 
-class QMRML_WIDGETS_EXPORT qMRMLThreeDWidget : public qMRMLWidget
+class QMRML_WIDGETS_EXPORT qMRMLThreeDWidget : public qMRMLAbstractViewWidget
 {
   Q_OBJECT
-  Q_PROPERTY(QString viewLabel READ viewLabel WRITE setViewLabel)
-  Q_PROPERTY(QColor viewColor READ viewColor WRITE setViewColor)
 
 public:
   /// Superclass typedef
-  typedef qMRMLWidget Superclass;
+  typedef qMRMLAbstractViewWidget Superclass;
 
   /// Constructors
   explicit qMRMLThreeDWidget(QWidget* parent = nullptr);
@@ -57,46 +51,33 @@ public:
 
   /// Get slice controller
   Q_INVOKABLE qMRMLThreeDViewControllerWidget* threeDController()const;
+  Q_INVOKABLE qMRMLViewControllerBar* controllerWidget() const override;
 
   /// Get the 3D View node observed by view.
   Q_INVOKABLE vtkMRMLViewNode* mrmlViewNode()const;
+  Q_INVOKABLE vtkMRMLAbstractViewNode* mrmlAbstractViewNode()const override;
 
   /// \sa qMRMLSliceControllerWidget::viewLogic()
   Q_INVOKABLE vtkMRMLViewLogic* viewLogic()const;
+  Q_INVOKABLE vtkMRMLAbstractLogic* logic()const override;
 
   /// Get a reference to the underlying ThreeD View
   /// Becareful if you change the threeDView, you might
   /// unsynchronize the view from the nodes/logics.
   Q_INVOKABLE qMRMLThreeDView* threeDView()const;
+  Q_INVOKABLE QWidget* viewWidget()const override;
 
   /// \sa qMRMLThreeDView::addDisplayableManager
   Q_INVOKABLE void addDisplayableManager(const QString& displayableManager);
   Q_INVOKABLE void getDisplayableManagers(vtkCollection* displayableManagers);
 
-  /// \sa qMRMLThreeDViewControllerWidget::viewLabel()
-  /// \sa setiewLabel()
-  QString viewLabel()const;
-
-  /// \sa qMRMLThreeDViewControllerWidget::viewLabel()
-  /// \sa viewLabel()
-  void setViewLabel(const QString& newViewLabel);
-
   /// \sa qMRMLThreeDViewControllerWidget::setQuadBufferStereoSupportEnabled
   Q_INVOKABLE void setQuadBufferStereoSupportEnabled(bool value);
 
-  /// \sa qMRMLThreeDViewControllerWidget::viewColor()
-  /// \sa setViewColor()
-  QColor viewColor()const;
-
-  /// \sa qMRMLThreeDViewControllerWidget::viewColor()
-  /// \sa viewColor()
-  void setViewColor(const QColor& newViewColor);
-
 public slots:
-  void setMRMLScene(vtkMRMLScene* newScene) override;
-
   /// Set the current \a viewNode to observe
   void setMRMLViewNode(vtkMRMLViewNode* newViewNode);
+  virtual void setMRMLAbstractViewNode(vtkMRMLAbstractViewNode* newViewNode);
 
 protected:
   QScopedPointer<qMRMLThreeDWidgetPrivate> d_ptr;


### PR DESCRIPTION
Previously, newly created views were initialized with the default pause render state of 0. This caused warning messages if the layout was changed between pauseRender/resumeRender calls as the render state of newly created views would not match the existing ones.

This commit tracks the global pauseRender count, and uses it to initialize the pauseRender state of newly created views. This removes most instances of the warning message:
> [Qt] int __cdecl ctkVTKAbstractView::resumeRender(void) Cannot resume rendering, pause render count is already 0!