### PR TITLE
BUG: Restore synchronized sequence table header visibility

### DIFF
--- a/Modules/Loadable/Sequences/Resources/UI/qSlicerSequencesModuleWidget.ui
+++ b/Modules/Loadable/Sequences/Resources/UI/qSlicerSequencesModuleWidget.ui
@@ -143,7 +143,7 @@
              <number>6</number>
             </property>
             <attribute name="horizontalHeaderVisible">
-             <bool>false</bool>
+             <bool>true</bool>
             </attribute>
             <attribute name="horizontalHeaderCascadingSectionResizes">
              <bool>true</bool>


### PR DESCRIPTION
The horizontalHeaderVisible for tableWidget_SynchronizedSequenceNodes was set to "false". Changed horizontalHeaderVisible back to "true".