### PR TITLE
ENH: Add utility function to get ROI box as vtkPolyData

### DIFF
--- a/Libs/MRML/Core/vtkMRMLMeasurement.h
+++ b/Libs/MRML/Core/vtkMRMLMeasurement.h
@@ -85,6 +85,7 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Create a new instance of this measurement type.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   virtual vtkMRMLMeasurement* CreateInstance() const = 0;
 

--- a/Libs/MRML/Core/vtkMRMLStaticMeasurement.h
+++ b/Libs/MRML/Core/vtkMRMLStaticMeasurement.h
@@ -35,6 +35,7 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Create a new instance of this measurement type.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMeasurement* CreateInstance() const override { return vtkMRMLStaticMeasurement::New(); }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonElement.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonElement.h
@@ -95,13 +95,13 @@ public:
 
   /// Get a coded entry object from a property.
   /// If no such property is found or it is not the right type then nullptr is returned.
-  /// The caller must take ownership of the returned object.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkCodedEntry* GetCodedEntryProperty(const char* propertyName);
 
   /// Get a variable-size, potentially multi-component floating-point vector from a property.
   /// If no such property is found or it is not the right type then nullptr is returned.
-  /// The caller must take ownership of the returned object.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkDoubleArray* GetDoubleArrayProperty(const char* propertyName);
 
@@ -111,13 +111,13 @@ public:
 
   /// Get an array element from a property.
   /// If no such property is found or it is not the right type then nullptr is returned.
-  /// The caller must take ownership of the returned object.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMarkupsJsonElement* GetArrayProperty(const char* arrayName);
 
   /// Get an object element from a property.
   /// If no such property is found or it is not the right type then nullptr is returned.
-  /// The caller must take ownership of the returned object.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMarkupsJsonElement* GetObjectProperty(const char* objectName);
 
@@ -128,7 +128,7 @@ public:
   int GetArraySize();
 
   /// Returns the n-th elements in this array.
-  /// The caller must take ownership of the returned object.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMarkupsJsonElement* GetArrayItem(int childItemIndex);
 
@@ -165,7 +165,7 @@ public:
 
   /// Read JSON document from file.
   /// \return JSON element on success and nullptr on failure.
-  /// The caller must take ownership of the returned object.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMarkupsJsonElement* ReadFromFile(const char* filePath);
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsJsonStorageNode.h
@@ -83,6 +83,7 @@ protected:
   /// Write data from a  referenced node.
   int WriteDataInternal(vtkMRMLNode *refNode) override;
 
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMarkupsJsonElement* ReadMarkupsFile(const char* filePath);
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsROINode.h
@@ -241,8 +241,7 @@ public:
   vtkGetObjectMacro(ImplicitFunctionWorld, vtkImplicitFunction);
 
   /// Create ROI box as surface mesh in the world coordinate system as a new vtkPolyData object.
-  /// In C++, the owner must take ownership of the returned object (delete when no longer used).
-  /// In Python, the returned object automatically takes ownership of the returned object (no need to manually delete).
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE vtkPolyData* CreateROIBoxPolyDataWorld();
 
   ///

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementAngle.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementAngle.h
@@ -34,6 +34,7 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Create a new instance of this measurement type.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMeasurement* CreateInstance() const override { return vtkMRMLMeasurementAngle::New(); }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementArea.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementArea.h
@@ -34,6 +34,7 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Create a new instance of this measurement type.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMeasurement* CreateInstance() const override { return vtkMRMLMeasurementArea::New(); }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementLength.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementLength.h
@@ -34,6 +34,7 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Create a new instance of this measurement type.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMeasurement* CreateInstance() const override { return vtkMRMLMeasurementLength::New(); }
 

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementVolume.h
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMeasurementVolume.h
@@ -34,6 +34,7 @@ public:
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Create a new instance of this measurement type.
+  /// Only in C++: The caller must take ownership of the returned object.
   VTK_NEWINSTANCE
   vtkMRMLMeasurement* CreateInstance() const override { return vtkMRMLMeasurementVolume::New(); }
 


### PR DESCRIPTION
Getting the ROI box as polydata is useful for example for creating a model or segment from an ROI node.
