### PR TITLE
ENH: Update VTK to backport "Rendering(VR|OpenVR|OpenXR)" changes

### DIFF
--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "7a000d76cbdafd10f4810e0027a12144a2c6f721") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "213951843f53d4497fa2532d3d3454e336891f2c") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
This is a first toward addressing:
* https://github.com/KitwareMedical/SlicerVirtualReality/issues/112

This will allow to update `SlicerVirtualReality` (and `SlicerMixedReality`) to make use of the new `vtkVRRenderWindowInteractor::Set/GetActionManifestDirectory`.

List of VTK changes:

```
$ git shortlog 7a000d76c..213951843 --no-merges
Ben Boeckel (4):
      [Backport] vtkVRRenderWindow: remove unnecessary `void*` casts
      [Backport] clang-tidy: fix `modernize-use-nullptr` lints
      [Backport] shaders: do not export shader symbols
      [Backport] vtkOpenXRInteractorStyle: remove excess semicolon

Bernhard Froehler (1):
      [Backport] OpenVR: Never ignore VREvent_Quit

Mathieu Westphal (1):
      [Backport] Improve OpenVR/OpenXR module and test and enable OpenXR in CI
```