### PR TITLE
COMP: Update ITK and VTK backporting fixes to support build with gcc13

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,7 +36,7 @@ if(NOT DEFINED ITK_DIR AND NOT Slicer_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "9745ba2fae8abf31175deae87ff3e55e81c0a663" # slicer-v5.3rc04-2022-09-19-62eb5ca
+    "07216c9a5babff729f3d5d08ff2bbe06f2a4203b" # slicer-v5.3rc04-2022-09-19-62eb5ca
     QUIET
     )
 

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -139,7 +139,7 @@ if((NOT DEFINED VTK_DIR OR NOT DEFINED VTK_SOURCE_DIR) AND NOT Slicer_USE_SYSTEM
 
   set(_git_tag)
   if("${Slicer_VTK_VERSION_MAJOR}" STREQUAL "9")
-    set(_git_tag "213951843f53d4497fa2532d3d3454e336891f2c") # slicer-v9.1.20220125-efbe2afc2
+    set(_git_tag "9bde2b3fa9887a801e3eec686ce591072986977f") # slicer-v9.1.20220125-efbe2afc2
     set(vtk_egg_info_version "9.1.20220125")
   else()
     message(FATAL_ERROR "error: Unsupported Slicer_VTK_VERSION_MAJOR: ${Slicer_VTK_VERSION_MAJOR}")


### PR DESCRIPTION
List of ITK changes:

```
$ git shortlog 9745ba2fae..07216c9a5b --no-merges
Noah Egnatis (1):
      [Backport] COMP: gcc-13 compatability
```

See https://github.com/Slicer/ITK/compare/9745ba2fae...07216c9a5b


List of VTK changes:

```
$ git shortlog 213951843f..9bde2b3fa9 --no-merges
Laurent Rineau (1):
      [Backport] Add #include <cstdint> to compile with gcc13

Proj Upstream (1):
      [Backport] libproj 2023-05-04 (76383737)
```

See https://github.com/Slicer/VTK/compare/213951843f...9bde2b3fa9