### PR TITLE
BUG: Make Uniform remeshing in Surface toolbox work for triangle strips

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -337,7 +337,7 @@ list_conditional_append(Slicer_BUILD_LandmarkRegistration Slicer_REMOTE_DEPENDEN
 
 Slicer_Remote_Add(SurfaceToolbox
   GIT_REPOSITORY "${EP_GIT_PROTOCOL}://github.com/Slicer/SlicerSurfaceToolbox"
-  GIT_TAG 3b556d10307c5c9ee9fd8da1ea873ddc1d48acf3
+  GIT_TAG 25999cefa2554b5fa4698b847716f75837070e33
   OPTION_NAME Slicer_BUILD_SurfaceToolbox
   OPTION_DEPENDS "Slicer_USE_PYTHONQT"
   LABELS REMOTE_MODULE


### PR DESCRIPTION
Update Surface toolbox to include a single fix that allows performing Uniform remeshing on models that contain triangle strips.

---

Revision: 25999cefa2554b5fa4698b847716f75837070e33
Author: Ben Zwick <benzwick@gmail.com>
Date: 2023-05-15 11:44:23 PM
Message:
ENH: Uniform remesh models with triangle strips (#58)

Uniform remesh using PyACVD failed if the model contained triangle strips (e.g., created by Model Maker module). Fixed by converting triangle strips to triangles using vtkTriangleFilter.