### PR TITLE
ENH: Web server examples (threejs and modelviewer)

### DIFF
--- a/Modules/Scripted/WebServer/CMakeLists.txt
+++ b/Modules/Scripted/WebServer/CMakeLists.txt
@@ -24,6 +24,7 @@ set(MODULE_PYTHON_RESOURCES
   Resources/docroot/ServerTests/timecube.html
   Resources/docroot/ServerTests/threejs.html
   Resources/docroot/ServerTests/threejs.css
+  Resources/docroot/ServerTests/modelviewer.html
   Resources/docroot/ServerTests/webgl-utils.js
   Resources/docroot/stylesheets/application.css
   )

--- a/Modules/Scripted/WebServer/CMakeLists.txt
+++ b/Modules/Scripted/WebServer/CMakeLists.txt
@@ -22,6 +22,8 @@ set(MODULE_PYTHON_RESOURCES
   Resources/docroot/ServerTests/index.html
   Resources/docroot/ServerTests/threeDCube.html
   Resources/docroot/ServerTests/timecube.html
+  Resources/docroot/ServerTests/threejs.html
+  Resources/docroot/ServerTests/threejs.css
   Resources/docroot/ServerTests/webgl-utils.js
   Resources/docroot/stylesheets/application.css
   )

--- a/Modules/Scripted/WebServer/Resources/docroot/ServerTests/modelviewer.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/ServerTests/modelviewer.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <title>3D Slicer &lt;model-viewer&gt; example</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head> 
+
+  <body>
+
+    <div id="info">
+      <a href="https://modelviewer.dev" target="_blank" rel="noopener">3D Slicer modelviewer</a>
+      <p> Please wait while content is generated and loaded... (be sure Slicer's exec API is enabled)</p>
+    </div>
+
+    <model-viewer
+      style="width:512px; height:512px"
+      src="/slicer/threeDGraphics"
+      alt="A 3D model from Slicer"
+      shadow-intensity="1"
+      auto-rotate ar
+      camera-controls>
+    </model-viewer>
+
+  <footer>
+    <span>This page is a basic demo of the <a href="https://github.com/GoogleWebComponents/model-viewer" target="_blank">&lt;model-viewer&gt;</a> web component.</span>
+  </footer>
+  
+  </body>
+
+  <script type="module" 
+    src="https://ajax.googleapis.com/ajax/libs/model-viewer/3.0.1/model-viewer.min.js">
+  </script>
+
+</html>

--- a/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.css
+++ b/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.css
@@ -1,0 +1,91 @@
+body {
+	margin: 0;
+	background-color: #000;
+	color: #fff;
+	font-family: Monospace;
+	font-size: 13px;
+	line-height: 24px;
+	overscroll-behavior: none;
+}
+
+a {
+	color: #ff0;
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
+}
+
+button {
+	cursor: pointer;
+	text-transform: uppercase;
+}
+
+#info {
+	position: absolute;
+	top: 0px;
+	width: 100%;
+	padding: 10px;
+	box-sizing: border-box;
+	text-align: center;
+	-moz-user-select: none;
+	-webkit-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	pointer-events: none;
+	z-index: 1; /* TODO Solve this in HTML */
+}
+
+a, button, input, select {
+	pointer-events: auto;
+}
+
+.lil-gui {
+	z-index: 2 !important; /* TODO Solve this in HTML */
+}
+
+@media all and ( max-width: 640px ) {
+	.lil-gui.root {
+		right: auto;
+		top: auto;
+		max-height: 50%;
+		max-width: 80%;
+		bottom: 0;
+		left: 0;
+	}
+}
+
+#overlay {
+	position: absolute;
+	font-size: 16px;
+	z-index: 2;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-direction: column;
+	background: rgba(0,0,0,0.7);
+}
+
+	#overlay button {
+		background: transparent;
+		border: 0;
+		border: 1px solid rgb(255, 255, 255);
+		border-radius: 4px;
+		color: #ffffff;
+		padding: 12px 18px;
+		text-transform: uppercase;
+		cursor: pointer;
+	}
+
+#notSupported {
+	width: 50%;
+	margin: auto;
+	background-color: #f00;
+	margin-top: 20px;
+	padding: 10px;
+}

--- a/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<title>three.js webgl - postprocessing - unreal bloom selective</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+		<link type="text/css" rel="stylesheet" href="threejs.css">
+	</head>
+	<body>
+
+		<div id="info">
+			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> Click on a sphere to toggle bloom<br>By <a href="http://github.com/Temdog007" target="_blank" rel="noopener">Temdog007</a>
+		</div>
+
+		<script type="x-shader/x-vertex" id="vertexshader">
+
+			varying vec2 vUv;
+
+			void main() {
+
+				vUv = uv;
+
+				gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+			}
+
+		</script>
+
+		<script type="x-shader/x-fragment" id="fragmentshader">
+
+			uniform sampler2D baseTexture;
+			uniform sampler2D bloomTexture;
+
+			varying vec2 vUv;
+
+			void main() {
+
+				gl_FragColor = ( texture2D( baseTexture, vUv ) + vec4( 1.0 ) * texture2D( bloomTexture, vUv ) );
+
+			}
+
+		</script>
+
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+        <!--
+		<script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "../build/three.module.js",
+					"three/addons/": "./jsm/"
+				}
+			}
+		</script>
+        -->
+        <script type="importmap">
+          {
+            "imports": {
+              "three": "https://unpkg.com/three@0.152.2/build/three.module.js",
+              "three/addons/": "https://unpkg.com/three@0.152.2/examples/jsm/"
+            }
+          }
+        </script>
+
+		<script type="module">
+
+			import * as THREE from 'three';
+
+			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+			import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+			import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+
+			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+
+			const ENTIRE_SCENE = 0, BLOOM_SCENE = 1;
+
+			const bloomLayer = new THREE.Layers();
+			bloomLayer.set( BLOOM_SCENE );
+
+			const params = {
+				exposure: 1,
+				bloomStrength: 5,
+				bloomThreshold: 0,
+				bloomRadius: 0,
+				scene: 'Scene with Glow'
+			};
+
+			const darkMaterial = new THREE.MeshBasicMaterial( { color: 'black' } );
+			const materials = {};
+
+			const renderer = new THREE.WebGLRenderer( { antialias: true } );
+			renderer.setPixelRatio( window.devicePixelRatio );
+			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
+			renderer.toneMapping = THREE.ReinhardToneMapping;
+			document.body.appendChild( renderer.domElement );
+
+			const scene = new THREE.Scene();
+
+			const camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 200 );
+			camera.position.set( 0, 0, 20 );
+			camera.lookAt( 0, 0, 0 );
+
+			const controls = new OrbitControls( camera, renderer.domElement );
+			controls.maxPolarAngle = Math.PI * 0.5;
+			controls.minDistance = 1;
+			controls.maxDistance = 100;
+			controls.addEventListener( 'change', render );
+
+			scene.add( new THREE.AmbientLight( 0x404040 ) );
+
+			const renderScene = new RenderPass( scene, camera );
+
+			const bloomPass = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85 );
+			bloomPass.threshold = params.bloomThreshold;
+			bloomPass.strength = params.bloomStrength;
+			bloomPass.radius = params.bloomRadius;
+
+			const bloomComposer = new EffectComposer( renderer );
+			bloomComposer.renderToScreen = false;
+			bloomComposer.addPass( renderScene );
+			bloomComposer.addPass( bloomPass );
+
+			const finalPass = new ShaderPass(
+				new THREE.ShaderMaterial( {
+					uniforms: {
+						baseTexture: { value: null },
+						bloomTexture: { value: bloomComposer.renderTarget2.texture }
+					},
+					vertexShader: document.getElementById( 'vertexshader' ).textContent,
+					fragmentShader: document.getElementById( 'fragmentshader' ).textContent,
+					defines: {}
+				} ), 'baseTexture'
+			);
+			finalPass.needsSwap = true;
+
+			const finalComposer = new EffectComposer( renderer );
+			finalComposer.addPass( renderScene );
+			finalComposer.addPass( finalPass );
+
+			const raycaster = new THREE.Raycaster();
+
+			const mouse = new THREE.Vector2();
+
+			window.addEventListener( 'pointerdown', onPointerDown );
+
+			const gui = new GUI();
+
+			gui.add( params, 'scene', [ 'Scene with Glow', 'Glow only', 'Scene only' ] ).onChange( function ( value ) {
+
+				switch ( value ) 	{
+
+					case 'Scene with Glow':
+						bloomComposer.renderToScreen = false;
+						break;
+					case 'Glow only':
+						bloomComposer.renderToScreen = true;
+						break;
+					case 'Scene only':
+						// nothing to do
+						break;
+
+				}
+
+				render();
+
+			} );
+
+			const folder = gui.addFolder( 'Bloom Parameters' );
+
+			folder.add( params, 'exposure', 0.1, 2 ).onChange( function ( value ) {
+
+				renderer.toneMappingExposure = Math.pow( value, 4.0 );
+				render();
+
+			} );
+
+			folder.add( params, 'bloomThreshold', 0.0, 1.0 ).onChange( function ( value ) {
+
+				bloomPass.threshold = Number( value );
+				render();
+
+			} );
+
+			folder.add( params, 'bloomStrength', 0.0, 10.0 ).onChange( function ( value ) {
+
+				bloomPass.strength = Number( value );
+				render();
+
+			} );
+
+			folder.add( params, 'bloomRadius', 0.0, 1.0 ).step( 0.01 ).onChange( function ( value ) {
+
+				bloomPass.radius = Number( value );
+				render();
+
+			} );
+
+			setupScene();
+
+			function onPointerDown( event ) {
+
+				mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
+				mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+
+				raycaster.setFromCamera( mouse, camera );
+				const intersects = raycaster.intersectObjects( scene.children, false );
+				if ( intersects.length > 0 ) {
+
+					const object = intersects[ 0 ].object;
+					object.layers.toggle( BLOOM_SCENE );
+					render();
+
+				}
+
+			}
+
+			window.onresize = function () {
+
+				const width = window.innerWidth;
+				const height = window.innerHeight;
+
+				camera.aspect = width / height;
+				camera.updateProjectionMatrix();
+
+				renderer.setSize( width, height );
+
+				bloomComposer.setSize( width, height );
+				finalComposer.setSize( width, height );
+
+				render();
+
+			};
+
+			function setupScene() {
+
+				scene.traverse( disposeMaterial );
+				scene.children.length = 0;
+
+				const geometry = new THREE.IcosahedronGeometry( 1, 15 );
+
+				for ( let i = 0; i < 50; i ++ ) {
+
+					const color = new THREE.Color();
+					color.setHSL( Math.random(), 0.7, Math.random() * 0.2 + 0.05 );
+
+					const material = new THREE.MeshBasicMaterial( { color: color } );
+					const sphere = new THREE.Mesh( geometry, material );
+					sphere.position.x = Math.random() * 10 - 5;
+					sphere.position.y = Math.random() * 10 - 5;
+					sphere.position.z = Math.random() * 10 - 5;
+					sphere.position.normalize().multiplyScalar( Math.random() * 4.0 + 2.0 );
+					sphere.scale.setScalar( Math.random() * Math.random() + 0.5 );
+					scene.add( sphere );
+
+					if ( Math.random() < 0.25 ) sphere.layers.enable( BLOOM_SCENE );
+
+				}
+
+				render();
+
+			}
+
+			function disposeMaterial( obj ) {
+
+				if ( obj.material ) {
+
+					obj.material.dispose();
+
+				}
+
+			}
+
+			function render() {
+
+				switch ( params.scene ) {
+
+					case 'Scene only':
+						renderer.render( scene, camera );
+						break;
+					case 'Glow only':
+						renderBloom( false );
+						break;
+					case 'Scene with Glow':
+					default:
+						// render scene with bloom
+						renderBloom( true );
+
+						// render the entire scene, then render bloom scene on top
+						finalComposer.render();
+						break;
+
+				}
+
+			}
+
+			function renderBloom( mask ) {
+
+				if ( mask === true ) {
+
+					scene.traverse( darkenNonBloomed );
+					bloomComposer.render();
+					scene.traverse( restoreMaterial );
+
+				} else {
+
+					camera.layers.set( BLOOM_SCENE );
+					bloomComposer.render();
+					camera.layers.set( ENTIRE_SCENE );
+
+				}
+
+			}
+
+			function darkenNonBloomed( obj ) {
+
+				if ( obj.isMesh && bloomLayer.test( obj.layers ) === false ) {
+
+					materials[ obj.uuid ] = obj.material;
+					obj.material = darkMaterial;
+
+				}
+
+			}
+
+			function restoreMaterial( obj ) {
+
+				if ( materials[ obj.uuid ] ) {
+
+					obj.material = materials[ obj.uuid ];
+					delete materials[ obj.uuid ];
+
+				}
+
+			}
+
+		</script>
+
+	</body>
+
+</html>

--- a/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
@@ -316,53 +316,26 @@
                 execXHR.responseType = 'json';
                 execXHR.onload = onLoadFn;
                 execXHR.send(`#python
-needData = False
-try:
-  slicer.util.getNode('vtkMRMLSegmentationNode*')
-except slicer.util.MRMLNodeNotFoundException:
-  needData = True
-try:
-  slicer.util.getNode('vtkMRMLModelNode*')
-except slicer.util.MRMLNodeNotFoundException:
-  needData = True
+nodePatterns = ["vtkMRMLSegmentationNode*", "vtkMRMLMarkups*Node*"]
+needDemoData = True
+for nodePattern in nodePatterns:
+  try:
+    slicer.util.getNode(nodePattern)
+    needDemoData = False
+    print(f"Found some {nodePattern}")
+  except slicer.util.MRMLNodeNotFoundException:
+    pass
 
-if needData:
-  import SampleData
-  #volumeNode = SampleData.SampleDataLogic().downloadCTACardio() # takes longer to load
-  volumeNode = SampleData.SampleDataLogic().downloadCTChest()
-  slicer.modules.volumes.logic().CenterVolume(volumeNode)
-  slicer.util.setSliceViewerLayers(background=volumeNode, fit=True)
-
-  segmentationNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
-  segmentationNode.CreateDefaultDisplayNodes()
-  segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(volumeNode)
-  segmentationNode.GetSegmentation().AddEmptySegment("Bright things")
-
-  segmentEditorWidget = slicer.qMRMLSegmentEditorWidget()
-  segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
-
-  segmentEditorNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentEditorNode")
-  segmentEditorWidget.setMRMLSegmentEditorNode(segmentEditorNode)
-  segmentEditorWidget.setSegmentationNode(segmentationNode)
-  segmentEditorWidget.setSourceVolumeNode(volumeNode)
-
-  segmentEditorWidget.setActiveEffectByName("Threshold")
-  effect = segmentEditorWidget.activeEffect()
-  effect.setParameter("MinimumThreshold", 400)
-  effect.self().onApply()
-
-  segmentEditorWidget.setActiveEffectByName("Islands")
-  effect = segmentEditorWidget.activeEffect()
-  effect.setParameter("Operation", 'SPLIT_ISLANDS_TO_SEGMENTS')
-  effect.self().onApply()
-
-  segmentationNode.CreateClosedSurfaceRepresentation()
-
-  import random
-  for index in range(20):
-    coord = lambda : -100. + 200 * random.random()
-    point = [coord(), coord(), coord()]
-    slicer.modules.markups.logic().AddControlPoint(*point)
+if needDemoData:
+  filePath = f"{slicer.util.tempDirectory()}/ctacardio-totalseg-models-2023-05-22-Scene.mrb"
+  print(f"Downloading to {filePath}")
+  demoDataURL = "https://github.com/pieper/SlicerWeb/releases/download/v0.1/ctacardio-totalseg-models-2023-05-22-Scene.mrb"
+  slicer.util.downloadFile(demoDataURL, filePath)
+  slicer.util.loadScene(filePath)
+  import os
+  os.remove(filePath)
+else:
+  print("Showing existing data from scene")
 `);
             }
 

--- a/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
@@ -9,7 +9,8 @@
     <body>
 
         <div id="info">
-            <a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> Click on a sphere to toggle bloom<br>By <a href="http://github.com/Temdog007" target="_blank" rel="noopener">Temdog007</a>
+            <a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> Click on an object to toggle bloom<br>By pieper based on example from <a href="http://github.com/Temdog007" target="_blank" rel="noopener">Temdog007</a>
+            <p> Please wait while content is generated and loaded...</p>
         </div>
 
         <script type="x-shader/x-vertex" id="vertexshader">
@@ -69,6 +70,7 @@
             import * as THREE from 'three';
 
             import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+            import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 
             import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
             import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
@@ -103,14 +105,14 @@
 
             const scene = new THREE.Scene();
 
-            const camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 200 );
-            camera.position.set( 0, 0, 20 );
+            const camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 1500 );
+            camera.position.set( 0, 0, 500 );
             camera.lookAt( 0, 0, 0 );
 
             const controls = new OrbitControls( camera, renderer.domElement );
             controls.maxPolarAngle = Math.PI * 0.5;
             controls.minDistance = 1;
-            controls.maxDistance = 100;
+            controls.maxDistance = 1000;
             controls.addEventListener( 'change', render );
 
             scene.add( new THREE.AmbientLight( 0x404040 ) );
@@ -238,41 +240,135 @@
 
             };
 
-            function setupScene() {
+            function loadThreeScene() {
 
                 scene.traverse( disposeMaterial );
                 scene.children.length = 0;
 
-                const geometry = new THREE.IcosahedronGeometry( 1, 15 );
-
-                const xhr = new XMLHttpRequest();
-
-                const url = "/slicer/fiducials";
-                xhr.open('GET', url, true);
-                xhr.responseType = 'json';
-
-                xhr.onload = function() {
-                    let node;
-                    for (node in this.response) {
+                /* fiducials as spheres
+                */
+                const geometry = new THREE.IcosahedronGeometry( 10, 15 );
+                const fiducialsXRH = new XMLHttpRequest();
+                const fiducialsURL = "/slicer/fiducials";
+                fiducialsXRH.open('GET', fiducialsURL, true);
+                fiducialsXRH.responseType = 'json';
+                fiducialsXRH.onload = function() {
+                    let nodeID;
+                    for (nodeID in this.response) {
                         let markupIndex;
-                        for (markupIndex in this.response[node].markups) {
-                            const markup = this.response[node].markups[markupIndex];
+                        for (markupIndex in this.response[nodeID].markups) {
+                            const markup = this.response[nodeID].markups[markupIndex];
                             const color = new THREE.Color();
                             color.setHSL( Math.random(), 0.7, Math.random() * 0.2 + 0.05 );
                             const material = new THREE.MeshBasicMaterial( { color: color } );
                             const sphere = new THREE.Mesh( geometry, material );
-                            sphere.position.x = markup.position[0] / 10.;
-                            sphere.position.y = markup.position[1] / 10.;
-                            sphere.position.z = markup.position[2] / 10.;
+                            sphere.position.x = markup.position[0];
+                            sphere.position.y = markup.position[1];
+                            sphere.position.z = markup.position[2];
+                            sphere.rotateX(-1 * Math.PI/2.);
+                            sphere.rotateZ(Math.PI);
                             scene.add( sphere );
-
                             if ( Math.random() < 0.25 ) sphere.layers.enable( BLOOM_SCENE );
                         }
                     }
                     render();
                 };
+                fiducialsXRH.send();
 
-                xhr.send();
+                /* graphics
+                */
+                const graphicsXRH = new XMLHttpRequest();
+                const graphicsURL = "/slicer/threeDGraphics";
+                graphicsXRH.open('GET', graphicsURL, true);
+                graphicsXRH.responseType = 'json';
+
+                graphicsXRH.onload = function() {
+                    const loader = new GLTFLoader();
+                    loader.parse(this.response,
+                      ".",
+                      function (gltf) {
+                        window.gltf = gltf;
+                        let object3D = gltf.scene.children[0];
+                        for (let child in object3D.children) {
+                            const color = new THREE.Color();
+                            color.setHSL( Math.random(), 0.7, Math.random() * 0.2 + 0.05 );
+                            const material = new THREE.MeshBasicMaterial( { color: color } );
+                            if (object3D.children[child].geometry) {
+                              const piece = new THREE.Mesh( object3D.children[child].geometry, material );
+                              piece.rotateX(-1 * Math.PI/2.);
+                              piece.rotateZ(Math.PI);
+                              scene.add( piece );
+                              if ( Math.random() < 0.25 ) piece.layers.enable( BLOOM_SCENE );
+                              render();
+                            }
+                        }
+                      }
+                    );
+                };
+                graphicsXRH.send();
+            }
+
+            function loadSlicerScene(onLoadFn) {
+
+                const execXHR = new XMLHttpRequest();
+                const url = "/slicer/exec";
+                execXHR.open('POST', url, true);
+                execXHR.responseType = 'json';
+                execXHR.onload = onLoadFn;
+                execXHR.send(`#python
+needData = False
+try:
+  slicer.util.getNode('vtkMRMLSegmentationNode*')
+except slicer.util.MRMLNodeNotFoundException:
+  needData = True
+try:
+  slicer.util.getNode('vtkMRMLModelNode*')
+except slicer.util.MRMLNodeNotFoundException:
+  needData = True
+
+if needData:
+  import SampleData
+  #volumeNode = SampleData.SampleDataLogic().downloadCTACardio() # takes longer to load
+  volumeNode = SampleData.SampleDataLogic().downloadCTChest()
+  slicer.modules.volumes.logic().CenterVolume(volumeNode)
+  slicer.util.setSliceViewerLayers(background=volumeNode, fit=True)
+
+  segmentationNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+  segmentationNode.CreateDefaultDisplayNodes()
+  segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(volumeNode)
+  segmentationNode.GetSegmentation().AddEmptySegment("Bright things")
+
+  segmentEditorWidget = slicer.qMRMLSegmentEditorWidget()
+  segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
+
+  segmentEditorNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentEditorNode")
+  segmentEditorWidget.setMRMLSegmentEditorNode(segmentEditorNode)
+  segmentEditorWidget.setSegmentationNode(segmentationNode)
+  segmentEditorWidget.setSourceVolumeNode(volumeNode)
+
+  segmentEditorWidget.setActiveEffectByName("Threshold")
+  effect = segmentEditorWidget.activeEffect()
+  effect.setParameter("MinimumThreshold", 400)
+  effect.self().onApply()
+
+  segmentEditorWidget.setActiveEffectByName("Islands")
+  effect = segmentEditorWidget.activeEffect()
+  effect.setParameter("Operation", 'SPLIT_ISLANDS_TO_SEGMENTS')
+  effect.self().onApply()
+
+  segmentationNode.CreateClosedSurfaceRepresentation()
+
+  import random
+  for index in range(20):
+    coord = lambda : -100. + 200 * random.random()
+    point = [coord(), coord(), coord()]
+    slicer.modules.markups.logic().AddControlPoint(*point)
+`);
+            }
+
+            function setupScene() {
+
+                loadSlicerScene(loadThreeScene);
 
             }
 

--- a/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
@@ -1,59 +1,59 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<title>three.js webgl - postprocessing - unreal bloom selective</title>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-		<link type="text/css" rel="stylesheet" href="threejs.css">
-	</head>
-	<body>
+    <head>
+        <title>three.js webgl - postprocessing - unreal bloom selective</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+        <link type="text/css" rel="stylesheet" href="threejs.css">
+    </head>
+    <body>
 
-		<div id="info">
-			<a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> Click on a sphere to toggle bloom<br>By <a href="http://github.com/Temdog007" target="_blank" rel="noopener">Temdog007</a>
-		</div>
+        <div id="info">
+            <a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> Click on a sphere to toggle bloom<br>By <a href="http://github.com/Temdog007" target="_blank" rel="noopener">Temdog007</a>
+        </div>
 
-		<script type="x-shader/x-vertex" id="vertexshader">
+        <script type="x-shader/x-vertex" id="vertexshader">
 
-			varying vec2 vUv;
+            varying vec2 vUv;
 
-			void main() {
+            void main() {
 
-				vUv = uv;
+                vUv = uv;
 
-				gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+                gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
 
-			}
+            }
 
-		</script>
+        </script>
 
-		<script type="x-shader/x-fragment" id="fragmentshader">
+        <script type="x-shader/x-fragment" id="fragmentshader">
 
-			uniform sampler2D baseTexture;
-			uniform sampler2D bloomTexture;
+            uniform sampler2D baseTexture;
+            uniform sampler2D bloomTexture;
 
-			varying vec2 vUv;
+            varying vec2 vUv;
 
-			void main() {
+            void main() {
 
-				gl_FragColor = ( texture2D( baseTexture, vUv ) + vec4( 1.0 ) * texture2D( bloomTexture, vUv ) );
+                gl_FragColor = ( texture2D( baseTexture, vUv ) + vec4( 1.0 ) * texture2D( bloomTexture, vUv ) );
 
-			}
+            }
 
-		</script>
+        </script>
 
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
+        <!-- Import maps polyfill -->
+        <!-- Remove this when import maps will be widely supported -->
         <!--
-		<script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
+        <script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
 
-		<script type="importmap">
-			{
-				"imports": {
-					"three": "../build/three.module.js",
-					"three/addons/": "./jsm/"
-				}
-			}
-		</script>
+        <script type="importmap">
+            {
+                "imports": {
+                    "three": "../build/three.module.js",
+                    "three/addons/": "./jsm/"
+                }
+            }
+        </script>
         -->
         <script type="importmap">
           {
@@ -64,186 +64,186 @@
           }
         </script>
 
-		<script type="module">
+        <script type="module">
 
-			import * as THREE from 'three';
+            import * as THREE from 'three';
 
-			import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+            import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 
-			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-			import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
-			import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+            import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+            import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+            import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+            import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+            import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 
-			THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
+            THREE.ColorManagement.enabled = false; // TODO: Confirm correct color management.
 
-			const ENTIRE_SCENE = 0, BLOOM_SCENE = 1;
+            const ENTIRE_SCENE = 0, BLOOM_SCENE = 1;
 
-			const bloomLayer = new THREE.Layers();
-			bloomLayer.set( BLOOM_SCENE );
+            const bloomLayer = new THREE.Layers();
+            bloomLayer.set( BLOOM_SCENE );
 
-			const params = {
-				exposure: 1,
-				bloomStrength: 5,
-				bloomThreshold: 0,
-				bloomRadius: 0,
-				scene: 'Scene with Glow'
-			};
+            const params = {
+                exposure: 1,
+                bloomStrength: 5,
+                bloomThreshold: 0,
+                bloomRadius: 0,
+                scene: 'Scene with Glow'
+            };
 
-			const darkMaterial = new THREE.MeshBasicMaterial( { color: 'black' } );
-			const materials = {};
+            const darkMaterial = new THREE.MeshBasicMaterial( { color: 'black' } );
+            const materials = {};
 
-			const renderer = new THREE.WebGLRenderer( { antialias: true } );
-			renderer.setPixelRatio( window.devicePixelRatio );
-			renderer.setSize( window.innerWidth, window.innerHeight );
-			renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
-			renderer.toneMapping = THREE.ReinhardToneMapping;
-			document.body.appendChild( renderer.domElement );
+            const renderer = new THREE.WebGLRenderer( { antialias: true } );
+            renderer.setPixelRatio( window.devicePixelRatio );
+            renderer.setSize( window.innerWidth, window.innerHeight );
+            renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
+            renderer.toneMapping = THREE.ReinhardToneMapping;
+            document.body.appendChild( renderer.domElement );
 
-			const scene = new THREE.Scene();
+            const scene = new THREE.Scene();
 
-			const camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 200 );
-			camera.position.set( 0, 0, 20 );
-			camera.lookAt( 0, 0, 0 );
+            const camera = new THREE.PerspectiveCamera( 40, window.innerWidth / window.innerHeight, 1, 200 );
+            camera.position.set( 0, 0, 20 );
+            camera.lookAt( 0, 0, 0 );
 
-			const controls = new OrbitControls( camera, renderer.domElement );
-			controls.maxPolarAngle = Math.PI * 0.5;
-			controls.minDistance = 1;
-			controls.maxDistance = 100;
-			controls.addEventListener( 'change', render );
+            const controls = new OrbitControls( camera, renderer.domElement );
+            controls.maxPolarAngle = Math.PI * 0.5;
+            controls.minDistance = 1;
+            controls.maxDistance = 100;
+            controls.addEventListener( 'change', render );
 
-			scene.add( new THREE.AmbientLight( 0x404040 ) );
+            scene.add( new THREE.AmbientLight( 0x404040 ) );
 
-			const renderScene = new RenderPass( scene, camera );
+            const renderScene = new RenderPass( scene, camera );
 
-			const bloomPass = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85 );
-			bloomPass.threshold = params.bloomThreshold;
-			bloomPass.strength = params.bloomStrength;
-			bloomPass.radius = params.bloomRadius;
+            const bloomPass = new UnrealBloomPass( new THREE.Vector2( window.innerWidth, window.innerHeight ), 1.5, 0.4, 0.85 );
+            bloomPass.threshold = params.bloomThreshold;
+            bloomPass.strength = params.bloomStrength;
+            bloomPass.radius = params.bloomRadius;
 
-			const bloomComposer = new EffectComposer( renderer );
-			bloomComposer.renderToScreen = false;
-			bloomComposer.addPass( renderScene );
-			bloomComposer.addPass( bloomPass );
+            const bloomComposer = new EffectComposer( renderer );
+            bloomComposer.renderToScreen = false;
+            bloomComposer.addPass( renderScene );
+            bloomComposer.addPass( bloomPass );
 
-			const finalPass = new ShaderPass(
-				new THREE.ShaderMaterial( {
-					uniforms: {
-						baseTexture: { value: null },
-						bloomTexture: { value: bloomComposer.renderTarget2.texture }
-					},
-					vertexShader: document.getElementById( 'vertexshader' ).textContent,
-					fragmentShader: document.getElementById( 'fragmentshader' ).textContent,
-					defines: {}
-				} ), 'baseTexture'
-			);
-			finalPass.needsSwap = true;
+            const finalPass = new ShaderPass(
+                new THREE.ShaderMaterial( {
+                    uniforms: {
+                        baseTexture: { value: null },
+                        bloomTexture: { value: bloomComposer.renderTarget2.texture }
+                    },
+                    vertexShader: document.getElementById( 'vertexshader' ).textContent,
+                    fragmentShader: document.getElementById( 'fragmentshader' ).textContent,
+                    defines: {}
+                } ), 'baseTexture'
+            );
+            finalPass.needsSwap = true;
 
-			const finalComposer = new EffectComposer( renderer );
-			finalComposer.addPass( renderScene );
-			finalComposer.addPass( finalPass );
+            const finalComposer = new EffectComposer( renderer );
+            finalComposer.addPass( renderScene );
+            finalComposer.addPass( finalPass );
 
-			const raycaster = new THREE.Raycaster();
+            const raycaster = new THREE.Raycaster();
 
-			const mouse = new THREE.Vector2();
+            const mouse = new THREE.Vector2();
 
-			window.addEventListener( 'pointerdown', onPointerDown );
+            window.addEventListener( 'pointerdown', onPointerDown );
 
-			const gui = new GUI();
+            const gui = new GUI();
 
-			gui.add( params, 'scene', [ 'Scene with Glow', 'Glow only', 'Scene only' ] ).onChange( function ( value ) {
+            gui.add( params, 'scene', [ 'Scene with Glow', 'Glow only', 'Scene only' ] ).onChange( function ( value ) {
 
-				switch ( value ) 	{
+                switch ( value )     {
 
-					case 'Scene with Glow':
-						bloomComposer.renderToScreen = false;
-						break;
-					case 'Glow only':
-						bloomComposer.renderToScreen = true;
-						break;
-					case 'Scene only':
-						// nothing to do
-						break;
+                    case 'Scene with Glow':
+                        bloomComposer.renderToScreen = false;
+                        break;
+                    case 'Glow only':
+                        bloomComposer.renderToScreen = true;
+                        break;
+                    case 'Scene only':
+                        // nothing to do
+                        break;
 
-				}
+                }
 
-				render();
+                render();
 
-			} );
+            } );
 
-			const folder = gui.addFolder( 'Bloom Parameters' );
+            const folder = gui.addFolder( 'Bloom Parameters' );
 
-			folder.add( params, 'exposure', 0.1, 2 ).onChange( function ( value ) {
+            folder.add( params, 'exposure', 0.1, 2 ).onChange( function ( value ) {
 
-				renderer.toneMappingExposure = Math.pow( value, 4.0 );
-				render();
+                renderer.toneMappingExposure = Math.pow( value, 4.0 );
+                render();
 
-			} );
+            } );
 
-			folder.add( params, 'bloomThreshold', 0.0, 1.0 ).onChange( function ( value ) {
+            folder.add( params, 'bloomThreshold', 0.0, 1.0 ).onChange( function ( value ) {
 
-				bloomPass.threshold = Number( value );
-				render();
+                bloomPass.threshold = Number( value );
+                render();
 
-			} );
+            } );
 
-			folder.add( params, 'bloomStrength', 0.0, 10.0 ).onChange( function ( value ) {
+            folder.add( params, 'bloomStrength', 0.0, 10.0 ).onChange( function ( value ) {
 
-				bloomPass.strength = Number( value );
-				render();
+                bloomPass.strength = Number( value );
+                render();
 
-			} );
+            } );
 
-			folder.add( params, 'bloomRadius', 0.0, 1.0 ).step( 0.01 ).onChange( function ( value ) {
+            folder.add( params, 'bloomRadius', 0.0, 1.0 ).step( 0.01 ).onChange( function ( value ) {
 
-				bloomPass.radius = Number( value );
-				render();
+                bloomPass.radius = Number( value );
+                render();
 
-			} );
+            } );
 
-			setupScene();
+            setupScene();
 
-			function onPointerDown( event ) {
+            function onPointerDown( event ) {
 
-				mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
-				mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
+                mouse.x = ( event.clientX / window.innerWidth ) * 2 - 1;
+                mouse.y = - ( event.clientY / window.innerHeight ) * 2 + 1;
 
-				raycaster.setFromCamera( mouse, camera );
-				const intersects = raycaster.intersectObjects( scene.children, false );
-				if ( intersects.length > 0 ) {
+                raycaster.setFromCamera( mouse, camera );
+                const intersects = raycaster.intersectObjects( scene.children, false );
+                if ( intersects.length > 0 ) {
 
-					const object = intersects[ 0 ].object;
-					object.layers.toggle( BLOOM_SCENE );
-					render();
+                    const object = intersects[ 0 ].object;
+                    object.layers.toggle( BLOOM_SCENE );
+                    render();
 
-				}
+                }
 
-			}
+            }
 
-			window.onresize = function () {
+            window.onresize = function () {
 
-				const width = window.innerWidth;
-				const height = window.innerHeight;
+                const width = window.innerWidth;
+                const height = window.innerHeight;
 
-				camera.aspect = width / height;
-				camera.updateProjectionMatrix();
+                camera.aspect = width / height;
+                camera.updateProjectionMatrix();
 
-				renderer.setSize( width, height );
+                renderer.setSize( width, height );
 
-				bloomComposer.setSize( width, height );
-				finalComposer.setSize( width, height );
+                bloomComposer.setSize( width, height );
+                finalComposer.setSize( width, height );
 
-				render();
+                render();
 
-			};
+            };
 
-			function setupScene() {
+            function setupScene() {
 
-				scene.traverse( disposeMaterial );
-				scene.children.length = 0;
+                scene.traverse( disposeMaterial );
+                scene.children.length = 0;
 
-				const geometry = new THREE.IcosahedronGeometry( 1, 15 );
+                const geometry = new THREE.IcosahedronGeometry( 1, 15 );
 
                 const xhr = new XMLHttpRequest();
 
@@ -274,83 +274,83 @@
 
                 xhr.send();
 
-			}
+            }
 
-			function disposeMaterial( obj ) {
+            function disposeMaterial( obj ) {
 
-				if ( obj.material ) {
+                if ( obj.material ) {
 
-					obj.material.dispose();
+                    obj.material.dispose();
 
-				}
+                }
 
-			}
+            }
 
-			function render() {
+            function render() {
 
-				switch ( params.scene ) {
+                switch ( params.scene ) {
 
-					case 'Scene only':
-						renderer.render( scene, camera );
-						break;
-					case 'Glow only':
-						renderBloom( false );
-						break;
-					case 'Scene with Glow':
-					default:
-						// render scene with bloom
-						renderBloom( true );
+                    case 'Scene only':
+                        renderer.render( scene, camera );
+                        break;
+                    case 'Glow only':
+                        renderBloom( false );
+                        break;
+                    case 'Scene with Glow':
+                    default:
+                        // render scene with bloom
+                        renderBloom( true );
 
-						// render the entire scene, then render bloom scene on top
-						finalComposer.render();
-						break;
+                        // render the entire scene, then render bloom scene on top
+                        finalComposer.render();
+                        break;
 
-				}
+                }
 
-			}
+            }
 
-			function renderBloom( mask ) {
+            function renderBloom( mask ) {
 
-				if ( mask === true ) {
+                if ( mask === true ) {
 
-					scene.traverse( darkenNonBloomed );
-					bloomComposer.render();
-					scene.traverse( restoreMaterial );
+                    scene.traverse( darkenNonBloomed );
+                    bloomComposer.render();
+                    scene.traverse( restoreMaterial );
 
-				} else {
+                } else {
 
-					camera.layers.set( BLOOM_SCENE );
-					bloomComposer.render();
-					camera.layers.set( ENTIRE_SCENE );
+                    camera.layers.set( BLOOM_SCENE );
+                    bloomComposer.render();
+                    camera.layers.set( ENTIRE_SCENE );
 
-				}
+                }
 
-			}
+            }
 
-			function darkenNonBloomed( obj ) {
+            function darkenNonBloomed( obj ) {
 
-				if ( obj.isMesh && bloomLayer.test( obj.layers ) === false ) {
+                if ( obj.isMesh && bloomLayer.test( obj.layers ) === false ) {
 
-					materials[ obj.uuid ] = obj.material;
-					obj.material = darkMaterial;
+                    materials[ obj.uuid ] = obj.material;
+                    obj.material = darkMaterial;
 
-				}
+                }
 
-			}
+            }
 
-			function restoreMaterial( obj ) {
+            function restoreMaterial( obj ) {
 
-				if ( materials[ obj.uuid ] ) {
+                if ( materials[ obj.uuid ] ) {
 
-					obj.material = materials[ obj.uuid ];
-					delete materials[ obj.uuid ];
+                    obj.material = materials[ obj.uuid ];
+                    delete materials[ obj.uuid ];
 
-				}
+                }
 
-			}
+            }
 
-		</script>
+        </script>
 
-	</body>
+    </body>
 
 </html>

--- a/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
@@ -245,25 +245,34 @@
 
 				const geometry = new THREE.IcosahedronGeometry( 1, 15 );
 
-				for ( let i = 0; i < 50; i ++ ) {
+                const xhr = new XMLHttpRequest();
 
-					const color = new THREE.Color();
-					color.setHSL( Math.random(), 0.7, Math.random() * 0.2 + 0.05 );
+                const url = "/slicer/fiducials";
+                xhr.open('GET', url, true);
+                xhr.responseType = 'json';
 
-					const material = new THREE.MeshBasicMaterial( { color: color } );
-					const sphere = new THREE.Mesh( geometry, material );
-					sphere.position.x = Math.random() * 10 - 5;
-					sphere.position.y = Math.random() * 10 - 5;
-					sphere.position.z = Math.random() * 10 - 5;
-					sphere.position.normalize().multiplyScalar( Math.random() * 4.0 + 2.0 );
-					sphere.scale.setScalar( Math.random() * Math.random() + 0.5 );
-					scene.add( sphere );
+                xhr.onload = function() {
+                    let node;
+                    for (node in this.response) {
+                        let markupIndex;
+                        for (markupIndex in this.response[node].markups) {
+                            const markup = this.response[node].markups[markupIndex];
+                            const color = new THREE.Color();
+                            color.setHSL( Math.random(), 0.7, Math.random() * 0.2 + 0.05 );
+                            const material = new THREE.MeshBasicMaterial( { color: color } );
+                            const sphere = new THREE.Mesh( geometry, material );
+                            sphere.position.x = markup.position[0] / 10.;
+                            sphere.position.y = markup.position[1] / 10.;
+                            sphere.position.z = markup.position[2] / 10.;
+                            scene.add( sphere );
 
-					if ( Math.random() < 0.25 ) sphere.layers.enable( BLOOM_SCENE );
+                            if ( Math.random() < 0.25 ) sphere.layers.enable( BLOOM_SCENE );
+                        }
+                    }
+                    render();
+                };
 
-				}
-
-				render();
+                xhr.send();
 
 			}
 

--- a/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/ServerTests/threejs.html
@@ -10,7 +10,7 @@
 
         <div id="info">
             <a href="https://threejs.org" target="_blank" rel="noopener">three.js</a> Click on an object to toggle bloom<br>By pieper based on example from <a href="http://github.com/Temdog007" target="_blank" rel="noopener">Temdog007</a>
-            <p> Please wait while content is generated and loaded...</p>
+            <p> Please wait while content is generated and loaded... (be sure Slicer's exec API is enabled)</p>
         </div>
 
         <script type="x-shader/x-vertex" id="vertexshader">

--- a/Modules/Scripted/WebServer/Resources/docroot/index.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/index.html
@@ -131,7 +131,7 @@
       </a>
       <p>Example of using Slicer data with Three JS.</p>
       <p>This example uses the /slicer/threeDGraphics endpoint to get a glTF representation of the threeD view.  If you have a segmentations or models in Slicer it will load your current threeD view, otherwise it will create a default scene with some segmentations and markups fiducials.</p>
-      <p>The data is loaded in <a href='https://threejs.org'>threejs</a> demo scene letting you play with a glowing neon light like rendering of your scene.  This experiment shows an option for highlighing selected objects in a complex 3D scene.  The neon light effect is one of a wide array of different rendering options available in threejs.</p>
+      <p>The data is loaded in <a href='https://threejs.org'>threejs</a> demo scene letting you play with a glowing neon light like rendering of your scene.  This experiment shows an option for highlighting selected objects in a complex 3D scene.  The neon light effect is one of a wide array of different rendering options available in threejs.</p>
       <p>The javascript source code for this demo shows how to access the threeDGraphics endpoint and how to populate the mrml scene using the exec endpoint to send python code from javascript.</p>
 
       <p>Depending on scene complexity this may take a few moments to load.</p>

--- a/Modules/Scripted/WebServer/Resources/docroot/index.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/index.html
@@ -124,6 +124,15 @@
     </li>
   </ul>
 
+  <ul>
+    <li>
+      <a href='./ServerTests/threejs.html'>
+        <h3>ThreeJS example</h3>
+      </a>
+      <p>Example of using Slicer data with Three JS.</p>
+    </li>
+  </ul>
+
 </body>
 
 </html>

--- a/Modules/Scripted/WebServer/Resources/docroot/index.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/index.html
@@ -130,6 +130,11 @@
         <h3>ThreeJS example</h3>
       </a>
       <p>Example of using Slicer data with Three JS.</p>
+      <p>This example uses the /slicer/threeDGraphics endpoint to get a glTF representation of the threeD view.  If you have a segmentations or models in Slicer it will load your current threeD view, otherwise it will create a default scene with some segmentations and markups fiducials.</p>
+      <p>The data is loaded in <a href='https://threejs.org'>threejs</a> demo scene letting you play with a glowing neon light like rendering of your scene.  This experiment shows an option for highlighing selected objects in a complex 3D scene.  The neon light effect is one of a wide array of different rendering options available in threejs.</p>
+      <p>The javascript source code for this demo shows how to access the threeDGraphics endpoint and how to populate the mrml scene using the exec endpoint to send python code from javascript.</p>
+
+      <p>Depending on scene complexity this may take a few moments to load.</p>
     </li>
   </ul>
 

--- a/Modules/Scripted/WebServer/Resources/docroot/index.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/index.html
@@ -130,8 +130,8 @@
         <h3>ThreeJS example</h3>
       </a>
       <p>Example of using Slicer data with Three JS.</p>
-      <p>This example uses the /slicer/threeDGraphics endpoint to get a glTF representation of the threeD view.  If you have a segmentations or models in Slicer it will load your current threeD view, otherwise it will create a default scene with some segmentations and markups fiducials.</p>
-      <p>The data is loaded in <a href='https://threejs.org'>threejs</a> demo scene letting you play with a glowing neon light like rendering of your scene.  This experiment shows an option for highlighting selected objects in a complex 3D scene.  The neon light effect is one of a wide array of different rendering options available in threejs.</p>
+      <p>This example uses the /slicer/threeDGraphics endpoint to get a glTF representation of the threeD view.  If you have a segmentations or models in Slicer it will load your current threeD view, otherwise it will download a scene with sample models.</p>
+      <p>The data is loaded in <a href='https://threejs.org'>threejs</a> demo scene letting you play with a glowing neon light like rendering of your scene.  This experiment shows an option for highlighting selected objects in a complex 3D scene.  Random models will be highlighted and you can toggle them by clicking.  The neon light effect is one of a wide array of different rendering options available in threejs.</p>
       <p>The javascript source code for this demo shows how to access the threeDGraphics endpoint and how to populate the mrml scene using the exec endpoint to send python code from javascript.</p>
 
       <p>Depending on scene complexity this may take a few moments to load.</p>

--- a/Modules/Scripted/WebServer/Resources/docroot/index.html
+++ b/Modules/Scripted/WebServer/Resources/docroot/index.html
@@ -138,6 +138,20 @@
     </li>
   </ul>
 
+  <ul>
+    <li>
+      <a href='./ServerTests/modelviewer.html'>
+        <h3>modelviewer example</h3>
+      </a>
+      <p>Example of using Slicer data with Google's modelviewer web component for web and XR.</p>
+      <p>This example uses the /slicer/threeDGraphics endpoint to get a glTF representation of the threeD view.  If you have a segmentations or models in Slicer it will load your current threeD view, otherwise it will download a scene with sample models.</p>
+      <p>The data is loaded in <a href='https://modelviewer.dev'>modelviewer</a> demo scene.  </p>
+      <p>The javascript source code for this demo shows how to access the threeDGraphics endpoint and how to populate the mrml scene using the exec endpoint to send python code from javascript.</p>
+
+      <p>Depending on scene complexity this may take a few moments to load.</p>
+    </li>
+  </ul>
+
 </body>
 
 </html>

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -1,6 +1,4 @@
 """
-Handler for processing Slicer REST API requests.
-
 Full specification of the Slicer REST API is available in
 Docs/user_guide/modules/webserver.md
 """
@@ -63,6 +61,8 @@ class SlicerRequestHandler:
             responseBody, contentType = self.screenshot(request)
         elif request.find(b'/slice') == 0:
             responseBody, contentType = self.slice(request)
+        elif request.find(b'/threeDGraphics') == 0:
+            responseBody, contentType = self.threeDGraphics(request)
         elif request.find(b'/threeD') == 0:
             responseBody, contentType = self.threeD(request)
         elif request.find(b'/mrml') == 0:
@@ -86,6 +86,11 @@ class SlicerRequestHandler:
             responseBody, contentType = self.fiducials(request, requestBody)
         elif request.find(b'/fiducial') == 0:
             responseBody, contentType = self.fiducial(request, requestBody)
+        elif request.find(b'/segmentations') == 0:
+            responseBody, contentType = self.segmentations(request, requestBody)
+        elif request.find(b'/segmentation') == 0:
+            responseBody, contentType = self.segmentation(request, requestBody)
+            print("responseBody", len(responseBody))
         elif request.find(b'/accessDICOMwebStudy') == 0:
             responseBody, contentType = self.accessDICOMwebStudy(request, requestBody)
         else:
@@ -556,7 +561,7 @@ space origin: %%origin%%
             node['color'] = displayNode.GetSelectedColor()
             node['scale'] = displayNode.GetGlyphScale()
             node['markups'] = []
-            for markupIndex in range(markupsNode.GetNumberOfMarkups()):
+            for markupIndex in range(markupsNode.GetNumberOfControlPoints()):
                 position = [0, ] * 3
                 markupsNode.GetNthControlPointPosition(markupIndex, position)
                 position
@@ -598,6 +603,44 @@ space origin: %%origin%%
         fiducialNode = slicer.util.getNode(fiducialID)
         fiducialNode.SetNthControlPointPosition(index, float(r), float(a), float(s))
         return b'{"success": true}', b'application/json'
+
+    def segmentations(self, request, requestBody):
+        """
+        Handle requests with path: /segmentations
+        Return basic properties of segmentations in an ad hoc json structure.
+        """
+        segmentations = {}
+        for segmentationNode in slicer.util.getNodesByClass('vtkMRMLSegmentationNode'):
+            displayNode = segmentationNode.GetDisplayNode()
+            node = {}
+            node['name'] = segmentationNode.GetName()
+            node['segmentIDs'] = segmentationNode.GetSegmentation().GetSegmentIDs()
+            segmentations[segmentationNode.GetID()] = node
+        return (json.dumps(segmentations).encode()), b'application/json'
+
+    def segmentation(self, request, requestBody):
+        """
+        Handle requests with path: /segmentation
+        Return the segmentation geometry
+        """
+        p = urllib.parse.urlparse(request.decode())
+        q = urllib.parse.parse_qs(p.query)
+        try:
+            segmentationID = q['segmentationID'][0].strip()
+        except KeyError:
+            segmentationID = 'vtkMRMLSegmentationNode*'
+        try:
+            segmentID = q['segmentationID'][0].strip()
+        except KeyError:
+            segmentID = 'Segment_1'
+        try:
+            format = q['format'][0].strip()
+        except KeyError:
+            format = "glTF"
+
+        segmentationNode = slicer.util.getNode(segmentationID)
+
+        return b'{"result": "not implemented yet"}', b'application/json'
 
     def accessDICOMwebStudy(self, request, requestBody):
         """
@@ -909,6 +952,43 @@ space origin: %%origin%%
             pngData = self.vtkImageDataToPNG(imageData)
         self.logMessage('returning an image of %d length' % len(pngData))
         return pngData, b'image/png'
+
+    def threeDGraphics(self, request):
+        """
+        Handle requests with path: /threeDGraphics
+        Return a graphics content for a threeD view.
+        Defaults to glTF.
+        """
+
+        p = urllib.parse.urlparse(request.decode())
+        q = urllib.parse.parse_qs(p.query)
+        try:
+            widgetIndex = int(q['widgetIndex'][0].strip().lower())
+        except KeyError:
+            widgetIndex = 0
+        try:
+            boxVisible = q['boxVisible'][0].strip().lower()
+        except KeyError:
+            boxVisible = 'false'
+        try:
+            format = q['format'][0].strip().lower()
+        except KeyError:
+            format = 'glTF'
+
+        if format == 'glTF':
+            lm = slicer.app.layoutManager()
+            boxWasVisible = lm.threeDWidget(widgetIndex).mrmlViewNode().GetBoxVisible()
+            lm.threeDWidget(widgetIndex).mrmlViewNode().SetBoxVisible(boxVisible != 'false')
+            renderWindow = lm.threeDWidget(widgetIndex).threeDView().renderWindow()
+            exporter = vtk.vtkGLTFExporter()
+            exporter.SetInlineData(True)
+            exporter.SetRenderWindow(renderWindow)
+            result = exporter.WriteToString()
+            lm.threeDWidget(widgetIndex).mrmlViewNode().SetBoxVisible(boxWasVisible)
+        else:
+            raise RuntimeError(f"format {format} not supported")
+
+        return result.encode(), b'application/json'
 
     def threeD(self, request):
         """

--- a/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
+++ b/Modules/Scripted/WebServer/WebServerLib/SlicerRequestHandler.py
@@ -982,6 +982,7 @@ space origin: %%origin%%
             renderWindow = lm.threeDWidget(widgetIndex).threeDView().renderWindow()
             exporter = vtk.vtkGLTFExporter()
             exporter.SetInlineData(True)
+            exporter.SetSaveNormal(True)
             exporter.SetRenderWindow(renderWindow)
             result = exporter.WriteToString()
             lm.threeDWidget(widgetIndex).mrmlViewNode().SetBoxVisible(boxWasVisible)


### PR DESCRIPTION
This adds a threeDGraphics rest endpoint that returns a glTF json of the threeD view contents.

The demos show how to use this endpoint with common web graphics tools.

There is also a stub for a segmentations endpoint that could be fleshed out later.