### PR TITLE
Misc scripted module fixes

### DIFF
--- a/Applications/SlicerApp/Testing/Python/CMakeLists.txt
+++ b/Applications/SlicerApp/Testing/Python/CMakeLists.txt
@@ -198,6 +198,17 @@ slicer_add_python_test(
 if(UNIX)
 set_tests_properties(py_nomainwindow_${testname} PROPERTIES
   PASS_REGULAR_EXPRESSION "ModuleAWidget finalized"
+  # Workaround the fact using PASS_REGULAR_EXPRESSION ignores return code
+  # by checking for output characteristics of Python exceptions.
+  #
+  # This is needed because the message "ModuleAWidget finalized" is displayed
+  # early on before potential python exceptions.
+  #
+  # Note this is a partial workaround as non-python errors would not cause
+  # the test to fail.
+  #
+  # See https://github.com/jcfr/cmake-add_test-PASS_REGULAR_EXPRESSION
+  FAIL_REGULAR_EXPRESSION "Traceback"
   )
 endif()
 

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
@@ -29,6 +29,10 @@ assert slicer.modules.modulec_withoutwidget.widgetRepresentation() is None
 assert slicer.modules.moduled_withfiledialog_withoutwidget.widgetRepresentation() is None
 assert slicer.modules.modulee_withfilewriter_withoutwidget.widgetRepresentation() is None
 
+# Check scripted file dialog registration
+assert slicer.app.ioManager().isDialogRegistered('Foo Directory', slicer.qSlicerFileDialog.Read)
+assert not slicer.app.ioManager().isDialogRegistered('Foo Directory', slicer.qSlicerFileDialog.Write)
+
 import ModuleA
 import ModuleB
 import ModuleC_WithoutWidget
@@ -52,6 +56,9 @@ assert isinstance(ModuleE_WithFileWriter_WithoutWidget.ModuleE_WithFileWriter_Wi
 # Check module widget class type
 assert isinstance(ModuleA.ModuleAWidget, type)
 assert isinstance(ModuleB.ModuleBWidget, type)
+
+# Check file dialog class type
+assert isinstance(ModuleD_WithFileDialog_WithoutWidget.ModuleD_WithFileDialog_WithoutWidgetFileDialog, type)
 
 # Check that module do not clobber each others. See issue #3549
 assert not hasattr(ModuleC_WithoutWidget, 'ModuleC_WithoutWidgetWidget')

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
@@ -1,7 +1,9 @@
 import __main__
 
+# Loaded module top-level variables should not be in the global scope
 assert not hasattr(__main__, 'SOMEVAR')
 
+# Loaded module classes should not be in the global scope
 assert not hasattr(__main__, 'ModuleA')
 assert not hasattr(__main__, 'ModuleB')
 assert not hasattr(__main__, 'ModuleC_WithoutWidget')
@@ -13,7 +15,7 @@ import slicer
 
 assert isinstance(slicer.modules, ModuleType)
 
-# Global variable
+# Module top-level variables
 assert slicer.modules.ModuleAInstance.somevar() == 'A'
 assert slicer.modules.ModuleBInstance.somevar() == 'B'
 assert slicer.modules.ModuleC_WithoutWidgetInstance.somevar() == 'C'
@@ -40,19 +42,21 @@ assert isinstance(ModuleC_WithoutWidget, ModuleType)
 assert isinstance(ModuleD_WithFileDialog_WithoutWidget, ModuleType)
 assert isinstance(ModuleE_WithFileWriter_WithoutWidget, ModuleType)
 
-# Check class type
+# Check module class type
 assert isinstance(ModuleA.ModuleA, type)
 assert isinstance(ModuleB.ModuleB, type)
 assert isinstance(ModuleC_WithoutWidget.ModuleC_WithoutWidget, type)
 assert isinstance(ModuleD_WithFileDialog_WithoutWidget.ModuleD_WithFileDialog_WithoutWidget, type)
 assert isinstance(ModuleE_WithFileWriter_WithoutWidget.ModuleE_WithFileWriter_WithoutWidget, type)
 
+# Check module widget class type
 assert isinstance(ModuleA.ModuleAWidget, type)
 assert isinstance(ModuleB.ModuleBWidget, type)
+
+# Check that module do not clobber each others. See issue #3549
 assert not hasattr(ModuleC_WithoutWidget, 'ModuleC_WithoutWidgetWidget')
 assert not hasattr(ModuleC_WithoutWidget, 'ModuleD_WithFileDialog_WithoutWidget')
 assert not hasattr(ModuleC_WithoutWidget, 'ModuleE_WithFileWriter_WithoutWidget')
-
 
 # Plugins
 # XXX Will need to extend module API to list registered plugins

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest.py
@@ -33,11 +33,16 @@ assert slicer.modules.modulee_withfilewriter_withoutwidget.widgetRepresentation(
 assert slicer.app.ioManager().isDialogRegistered('Foo Directory', slicer.qSlicerFileDialog.Read)
 assert not slicer.app.ioManager().isDialogRegistered('Foo Directory', slicer.qSlicerFileDialog.Write)
 
+# Check scripted IO registration
+assert slicer.app.ioManager().registeredFileWriterCount("MyWriterFileType") == 1
+assert slicer.app.ioManager().registeredFileReaderCount("MyReaderFileType") == 1
+
 import ModuleA
 import ModuleB
 import ModuleC_WithoutWidget
 import ModuleD_WithFileDialog_WithoutWidget
 import ModuleE_WithFileWriter_WithoutWidget
+import ModuleF_WithFileReader_WithoutWidget
 
 # Check module type
 assert isinstance(ModuleA, ModuleType)
@@ -45,6 +50,7 @@ assert isinstance(ModuleB, ModuleType)
 assert isinstance(ModuleC_WithoutWidget, ModuleType)
 assert isinstance(ModuleD_WithFileDialog_WithoutWidget, ModuleType)
 assert isinstance(ModuleE_WithFileWriter_WithoutWidget, ModuleType)
+assert isinstance(ModuleF_WithFileReader_WithoutWidget, ModuleType)
 
 # Check module class type
 assert isinstance(ModuleA.ModuleA, type)
@@ -52,6 +58,7 @@ assert isinstance(ModuleB.ModuleB, type)
 assert isinstance(ModuleC_WithoutWidget.ModuleC_WithoutWidget, type)
 assert isinstance(ModuleD_WithFileDialog_WithoutWidget.ModuleD_WithFileDialog_WithoutWidget, type)
 assert isinstance(ModuleE_WithFileWriter_WithoutWidget.ModuleE_WithFileWriter_WithoutWidget, type)
+assert isinstance(ModuleF_WithFileReader_WithoutWidget.ModuleF_WithFileReader_WithoutWidget, type)
 
 # Check module widget class type
 assert isinstance(ModuleA.ModuleAWidget, type)
@@ -59,6 +66,10 @@ assert isinstance(ModuleB.ModuleBWidget, type)
 
 # Check file dialog class type
 assert isinstance(ModuleD_WithFileDialog_WithoutWidget.ModuleD_WithFileDialog_WithoutWidgetFileDialog, type)
+
+# Check IO class type
+assert isinstance(ModuleE_WithFileWriter_WithoutWidget.ModuleE_WithFileWriter_WithoutWidgetFileWriter, type)
+assert isinstance(ModuleF_WithFileReader_WithoutWidget.ModuleF_WithFileReader_WithoutWidgetFileReader, type)
 
 # Check that module do not clobber each others. See issue #3549
 assert not hasattr(ModuleC_WithoutWidget, 'ModuleC_WithoutWidgetWidget')

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleD_WithFileDialog_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleD_WithFileDialog_WithoutWidget.py
@@ -1,3 +1,4 @@
+import slicer
 from slicer.ScriptedLoadableModule import *
 
 SOMEVAR = 'D'
@@ -6,7 +7,7 @@ SOMEVAR = 'D'
 class ModuleD_WithFileDialog_WithoutWidget(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        self.parent.title = "Module A"
+        self.parent.title = "Module D"
         self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)", ]
         self.parent.helpText = """
     This module allows to test the scripted module import.
@@ -20,7 +21,7 @@ class ModuleD_WithFileDialog_WithoutWidget(ScriptedLoadableModule):
         return SOMEVAR
 
 
-class DICOMFileDialog:
+class ModuleD_WithFileDialog_WithoutWidgetFileDialog:
 
     def __init__(self, qSlicerFileDialog):
         self.qSlicerFileDialog = qSlicerFileDialog

--- a/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleF_WithFileReader_WithoutWidget.py
+++ b/Applications/SlicerApp/Testing/Python/ScriptedModuleDiscoveryTest/ModuleF_WithFileReader_WithoutWidget.py
@@ -1,12 +1,12 @@
 from slicer.ScriptedLoadableModule import *
 
-SOMEVAR = 'E'
+SOMEVAR = 'F'
 
 
-class ModuleE_WithFileWriter_WithoutWidget(ScriptedLoadableModule):
+class ModuleF_WithFileReader_WithoutWidget(ScriptedLoadableModule):
     def __init__(self, parent):
         ScriptedLoadableModule.__init__(self, parent)
-        self.parent.title = "Module E"
+        self.parent.title = "Module F"
         self.parent.contributors = ["Jean-Christophe Fillion-Robin (Kitware)", ]
         self.parent.helpText = """
     This module allows to test the scripted module import.
@@ -20,23 +20,24 @@ class ModuleE_WithFileWriter_WithoutWidget(ScriptedLoadableModule):
         return SOMEVAR
 
 
-class ModuleE_WithFileWriter_WithoutWidgetFileWriter:
+class ModuleF_WithFileReader_WithoutWidgetFileReader:
 
     def __init__(self, parent):
         self.parent = parent
 
     def description(self):
-        return 'My writer file type'
+        return 'My reader file type'
 
     def fileType(self):
-        return 'MyWriterFileType'
+        return 'MyReaderFileType'
 
-    def extensions(self, obj):
-        print(obj)
-        return ['My writer file type (*.mwft)']
+    def extensions(self):
+        return ['My reader file type (*.mrft)']
 
-    def canWriteObject(self, obj):
+    def canLoadFile(self, filePath):
+        print(filePath)
         return False
 
-    def write(self, properties):
+    def load(self, properties):
+        print(properties)
         return True

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -1134,6 +1134,18 @@ void qSlicerCoreIOManager::registerIO(qSlicerIO* io)
 }
 
 //-----------------------------------------------------------------------------
+int qSlicerCoreIOManager::registeredFileReaderCount(const qSlicerIO::IOFileType& fileType) const
+{
+  return this->readers(fileType).count();
+}
+
+//-----------------------------------------------------------------------------
+int qSlicerCoreIOManager::registeredFileWriterCount(const qSlicerIO::IOFileType& fileType) const
+{
+  return this->writers(fileType).count();
+}
+
+//-----------------------------------------------------------------------------
 QString qSlicerCoreIOManager::defaultSceneFileType()const
 {
   Q_D(const qSlicerCoreIOManager);

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -214,6 +214,17 @@ public:
   /// Note also that the IOManager takes ownership of \a io
   void registerIO(qSlicerIO* io);
 
+  /// @{
+  /// Return the number of registered \a qSlicerIO associated with \a fileType.
+  ///
+  /// \a registerIO()
+  /// \a qSlicerScriptedLoadableModule::registerIO()
+  /// \a qSlicerScriptedLoadableModule::readers()
+  /// \a qSlicerScriptedLoadableModule::writers()
+  Q_INVOKABLE int registeredFileReaderCount(const qSlicerIO::IOFileType& fileType) const;
+  Q_INVOKABLE int registeredFileWriterCount(const qSlicerIO::IOFileType& fileType) const;
+  /// }@
+
   /// Create and add default storage node
   Q_INVOKABLE static vtkMRMLStorageNode* createAndAddDefaultStorageNode(vtkMRMLStorableNode* node);
 

--- a/Base/QTGUI/qSlicerIOManager.cxx
+++ b/Base/QTGUI/qSlicerIOManager.cxx
@@ -429,6 +429,14 @@ void qSlicerIOManager::registerDialog(qSlicerFileDialog* dialog)
 }
 
 //-----------------------------------------------------------------------------
+bool qSlicerIOManager::isDialogRegistered(qSlicerIO::IOFileType fileType, qSlicerFileDialog::IOAction action) const
+{
+  Q_D(const qSlicerIOManager);
+  qSlicerFileDialog* existingDialog = d->findDialog(fileType, action);
+  return existingDialog != nullptr;
+}
+
+//-----------------------------------------------------------------------------
 bool qSlicerIOManager::loadNodes(const qSlicerIO::IOFileType& fileType,
   const qSlicerIO::IOProperties& parameters, vtkCollection* loadedNodes,
   vtkMRMLMessageCollection* userMessages/*=nullptr*/)

--- a/Base/QTGUI/qSlicerIOManager.h
+++ b/Base/QTGUI/qSlicerIOManager.h
@@ -57,6 +57,13 @@ public:
   /// fileType (only 1 dialog per filetype) is overridden.
   void registerDialog(qSlicerFileDialog* dialog);
 
+  /// Return True if a custom file dialog was registered.
+  ///
+  /// \sa registerDialog()
+  /// \sa qSlicerScriptedLoadableModule::registerFileDialog()
+  /// \sa qSlicerScriptedFileDialog
+  Q_INVOKABLE bool isDialogRegistered(qSlicerIO::IOFileType fileType, qSlicerFileDialog::IOAction action) const;
+
   /// Displays a progress dialog if it takes too long to load
   /// There is no way to know in advance how long the loading will take, so the
   /// progress dialog listens to the scene and increment the progress anytime

--- a/CMake/SlicerMacroPythonTesting.cmake
+++ b/CMake/SlicerMacroPythonTesting.cmake
@@ -34,13 +34,15 @@ macro(slicer_add_python_test)
   if(NOT IS_ABSOLUTE ${MY_SCRIPT})
     set(MY_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/${MY_SCRIPT}")
   endif()
+  if(NOT Slicer_SOURCE_DIR)
+    list(APPEND MY_SLICER_ARGS ${UNITTEST_LIB_PATHS})
+  endif()
   ExternalData_add_test(${Slicer_ExternalData_DATA_MANAGEMENT_TARGET}
     NAME py_${MY_TESTNAME_PREFIX}${test_name}
     COMMAND ${Slicer_LAUNCHER_EXECUTABLE}
     --no-splash
     --testing
     ${Slicer_ADDITIONAL_LAUNCHER_SETTINGS}
-    ${UNITTEST_LIB_PATHS}
     ${MY_SLICER_ARGS}
     --python-script ${MY_SCRIPT} ${MY_SCRIPT_ARGS}
     )
@@ -57,6 +59,9 @@ macro(slicer_add_python_unittest)
   if("${_script_source_dir}" STREQUAL "")
     set(_script_source_dir ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
+  if(NOT Slicer_SOURCE_DIR)
+    list(APPEND MY_SLICER_ARGS ${UNITTEST_LIB_PATHS})
+  endif()
   ExternalData_add_test(${Slicer_ExternalData_DATA_MANAGEMENT_TARGET}
     NAME py_${MY_TESTNAME_PREFIX}${test_name}
     COMMAND ${Slicer_LAUNCHER_EXECUTABLE}
@@ -64,7 +69,6 @@ macro(slicer_add_python_unittest)
     --testing
     ${Slicer_ADDITIONAL_LAUNCHER_SETTINGS}
     ${MY_SLICER_ARGS}
-    ${UNITTEST_LIB_PATHS}
     --python-code "import slicer.testing\\; slicer.testing.runUnitTest(['${CMAKE_CURRENT_BINARY_DIR}', '${_script_source_dir}'], '${test_name}')"
     )
   set_property(TEST py_${MY_TESTNAME_PREFIX}${test_name} PROPERTY RUN_SERIAL TRUE)


### PR DESCRIPTION
This pull-request aims to integrate fixes & changes implemented while working toward finalizing:
* https://github.com/Slicer/Slicer/pull/6953

## Summary

* Add support for checking that scripted IOs are registered
* Add support for checking that scripted file dialogs are registered
* Ensure python exceptions in `ScriptedModuleDiscoveryTest` are considered
* Improve comments in `ScriptedModuleDiscoveryTest.py`
* Fix setting of extension module paths when `slicer_add_python` testing macros
* Fix setting module paths associated with `slicer_add_python` testing macros

## Details

### Improvements to `slicer_add_python`

* Ensures that arguments like "--disable-modules" and "--disable-*-modules" are respected when adding tests using the slicer_add_python testing macros.

### Ensure python exceptions in `ScriptedModuleDiscoveryTest` are considered

Workaround the fact using PASS_REGULAR_EXPRESSION ignores return code by checking for output characteristics of Python exceptions.
    
This is needed because the message "ModuleAWidget finalized" is displayed early on before potential python exceptions.
    
Note this is a partial workaround as non-python errors would not cause the test to fail.
    
See https://github.com/jcfr/cmake-add_test-PASS_REGULAR_EXPRESSION
