### PR TITLE
BUG: Fix unable to change foreground W/L with mouse mode

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.cxx
@@ -2483,7 +2483,9 @@ bool vtkMRMLSliceLogic::IsEventInsideVolume(bool background, double worldPos[3])
   volumeNode->GetImageData()->GetExtent(volumeExtent);
   for (int i = 0; i < 3; i++)
     {
-    if (ijkPos[i]<volumeExtent[i * 2] || ijkPos[i]>volumeExtent[i * 2 + 1])
+    // In VTK, the voxel coordinate refers to the center of the voxel and so the image bounds
+    // go beyond the position of the first and last voxels by half voxel. Therefore include 0.5 shift.
+    if (ijkPos[i] < volumeExtent[i * 2] - 0.5 || ijkPos[i] > volumeExtent[i * 2 + 1] + 0.5)
       {
       return false;
       }


### PR DESCRIPTION
Some volumes may have an extent min/max of 0/0 and the converted ijkPos could be a very close to 0 value, but not exactly 0.

Attached is a zipped MRB where adjusting window/level of foreground volume with mouse mode would not work:
[ForegroundWLData.zip](https://github.com/Slicer/Slicer/files/11619074/ForegroundWLData.zip)

In this sample data, the 3rd dimension min/max extent was 0/0, however the `ijkPos[i]` value was 7.10543e-15. This made it seem that it was outside the bounds of the max since it was >0. This resulted in the background volume Window/Level being adjusted instead of the foreground volume.
