### PR TITLE
ENH: One draw effect point does not prevent use in other slice offset

### DIFF
--- a/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
+++ b/Modules/Loadable/Segmentations/EditorEffects/Python/SegmentEditorEffects/SegmentEditorDrawEffect.py
@@ -137,6 +137,10 @@ class SegmentEditorDrawEffect(AbstractScriptedSegmentEditorLabelEffect):
             if pipeline.activeSliceOffset:
                 offset = abs(currentSliceOffset - pipeline.activeSliceOffset)
                 if offset > 0.01:
+                    if pipeline.rasPoints.GetNumberOfPoints() == 1:
+                        # One placed point is not visible to the user so clear the state upon changing slice offset
+                        pipeline.resetPolyData()
+                        return
                     lineMode = "dashed"
             pipeline.setLineMode(lineMode)
             pipeline.positionActors()


### PR DESCRIPTION
If you are in the "Draw" segment editor effect and click to place one point in the given slice offset and then you scroll to another slice offset, you will be unable to place more draw effect points in that offset. It is confusing because that single point does not create an visual UI element, so you are left confused that you actually had started drawing on another slice offset. You currently have to right-click to apply (which does nothing because there is <2 points) and then you can draw on the new slice offset. 

This was leading to confusion by our group's users. I have added code so that if you have placed a single point and then scroll to another slice offset, then the draw effect's points are cleared/reset. 

I still think it is a little confusing when there are >1 points and the draw effect goes into a "dashed" line state which is difficult to see. It currently looks like a graphical issue. I would rather the draw effect lines stay the same. 