### PR TITLE
Choose file reader writer based on confidence

### DIFF
--- a/Base/Python/slicer/tests/test_slicer_util_save.py
+++ b/Base/Python/slicer/tests/test_slicer_util_save.py
@@ -15,10 +15,118 @@ class SlicerUtilSaveTests(unittest.TestCase):
         shutil.rmtree(slicer.app.temporaryPath + '/SlicerUtilSaveTests', True)
 
     def test_saveNode(self):
-        node = slicer.util.getNode('MR-head')
+        """Test that nodes are saved correctly and that they are loaded correctly with the default reader
+        even if they are saved with generic (.nrrd) and not composite (.seg.nrrd) file extension."""
+
+        # Volume node
+        volumeNode = slicer.util.getNode('MR-head')
+        # Save
         filename = slicer.app.temporaryPath + '/SlicerUtilSaveTests.nrrd'
-        self.assertTrue(slicer.util.saveNode(node, filename))
+        self.assertTrue(slicer.util.saveNode(volumeNode, filename))
         self.assertTrue(os.path.exists(filename))
+        # Load
+        loadedVolumeNode = slicer.util.loadNodeFromFile(filename)
+        self.assertEqual(loadedVolumeNode.GetClassName(), "vtkMRMLScalarVolumeNode")
+        # Cleanup
+        os.remove(filename)
+
+        # Segmentation node
+        segmentationNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+        segmentationNode.CreateDefaultDisplayNodes()
+        segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(volumeNode)
+        import vtk
+        tumorSeed = vtk.vtkSphereSource()
+        tumorSeed.SetCenter(-6, 30, 28)
+        tumorSeed.SetRadius(10)
+        tumorSeed.Update()
+        segmentationNode.AddSegmentFromClosedSurfaceRepresentation(tumorSeed.GetOutput(), "Tumor", [1.0, 0.0, 0.0])
+        segmentationNode.CreateBinaryLabelmapRepresentation()
+        segmentationNode.SetMasterRepresentationToBinaryLabelmap()
+        # Save
+        filename = slicer.app.temporaryPath + '/SlicerUtilSaveTestsSegmentation.nrrd'
+        self.assertTrue(slicer.util.saveNode(segmentationNode, filename))
+        self.assertTrue(os.path.exists(filename))
+        # Load
+        loadedSegmentationNode = slicer.util.loadNodeFromFile(filename)
+        self.assertEqual(loadedSegmentationNode.GetClassName(), "vtkMRMLSegmentationNode")
+        # Cleanup
+        os.remove(filename)
+
+        # Markup node
+        markupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsLineNode")
+        markupNode.CreateDefaultDisplayNodes()
+        markupNode.AddControlPoint(10, 20, 30)
+        markupNode.AddControlPoint(15, 22, 46)
+        # Save
+        filename = slicer.app.temporaryPath + '/SlicerUtilSaveTestsMarkup.json'
+        self.assertTrue(slicer.util.saveNode(markupNode, filename))
+        self.assertTrue(os.path.exists(filename))
+        # Load
+        loadedMarkupNode = slicer.util.loadNodeFromFile(filename)
+        self.assertEqual(loadedMarkupNode.GetClassName(), "vtkMRMLMarkupsLineNode")
+        # Cleanup
+        os.remove(filename)
+
+        # Text node
+        textNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTextNode")
+        textNode.SetText("Some text is in here")
+        textNode.SetForceCreateStorageNode(True)  # without this, short text would not be saved in file
+        # Save
+        filename = slicer.app.temporaryPath + '/SlicerUtilSaveTestsText.txt'
+        self.assertTrue(slicer.util.saveNode(textNode, filename))
+        self.assertTrue(os.path.exists(filename))
+        # Load
+        loadedTextNode = slicer.util.loadNodeFromFile(filename)
+        self.assertEqual(loadedTextNode.GetClassName(), "vtkMRMLTextNode")
+        # Cleanup
+        os.remove(filename)
+
+        # Color node
+        colorTableNode = slicer.mrmlScene.CreateNodeByClass("vtkMRMLColorTableNode")
+        colorTableNode.SetTypeToUser()
+        colorTableNode.HideFromEditorsOff()  # make the color table selectable in the GUI outside Colors module
+        slicer.mrmlScene.AddNode(colorTableNode)
+        colorTableNode.UnRegister(None)
+        colorTableNode.SetNumberOfColors(3)
+        colorTableNode.SetNamesInitialised(True)  # prevent automatic color name generation
+        colorTableNode.SetColor(0, "some", 0.1, 0.2, 0.7, 1.0)
+        colorTableNode.SetColor(1, "color", 0.3, 0.3, 0.6, 1.0)
+        colorTableNode.SetColor(2, "here", 0.5, 0.4, 0.5, 1.0)
+        # Save
+        filename = slicer.app.temporaryPath + '/SlicerUtilSaveTestsColor.txt'
+        self.assertTrue(slicer.util.saveNode(colorTableNode, filename))
+        self.assertTrue(os.path.exists(filename))
+        # Load
+        loadedColorTableNode = slicer.util.loadNodeFromFile(filename)
+        self.assertEqual(loadedColorTableNode.GetClassName(), "vtkMRMLColorTableNode")
+        # Cleanup
+        os.remove(filename)
+
+        # Sequences node
+        sequenceNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSequenceNode")
+        sequenceNode.SetDataNodeAtValue(volumeNode, str(0))
+        sequenceNode.SetDataNodeAtValue(volumeNode, str(1))
+        sequenceNode.SetDataNodeAtValue(volumeNode, str(2))
+        # Save
+        filename = slicer.app.temporaryPath + '/SlicerUtilSaveTestsVolumeSequence.nrrd'
+        self.assertTrue(slicer.util.saveNode(sequenceNode, filename))
+        self.assertTrue(os.path.exists(filename))
+        # Load
+        loadedSequenceNode = slicer.util.loadNodeFromFile(filename)
+        self.assertEqual(loadedSequenceNode.GetClassName(), "vtkMRMLSequenceNode")
+        # Cleanup
+        os.remove(filename)
+
+        # Terminology
+        # There is no writer for terminology files, so we copy an existing terminology
+        import shutil
+        filename = slicer.app.temporaryPath + '/SlicerUtilSaveTestsTerminology.json'
+        shutil.copy(slicer.modules.terminologies.logic().GetModuleShareDirectory()
+                    + "/SegmentationCategoryTypeModifier-SlicerGeneralAnatomy.term.json", filename)
+        # Load
+        self.assertEqual(slicer.app.ioManager().fileType(filename), 'TerminologyFile')
+        loadedTerminology = slicer.util.loadNodeFromFile(filename)
+        self.assertIsNone(loadedTerminology)  # loadedTerminology will be empty, as terminology is not loaded as node
 
     def test_saveSceneAsMRMLFile(self):
         filename = slicer.app.temporaryPath + '/SlicerUtilSaveTests.mrml'

--- a/Base/Python/slicer/util.py
+++ b/Base/Python/slicer/util.py
@@ -663,11 +663,12 @@ def forceRenderAllViews():
 # IO
 #
 
-def loadNodeFromFile(filename, filetype, properties={}, returnNode=False):
+def loadNodeFromFile(filename, filetype=None, properties={}, returnNode=False):
     """Load node into the scene from a file.
 
     :param filename: full path of the file to load.
     :param filetype: specifies the file type, which determines which IO class will load the file.
+                     If not specified then the reader with the highest confidence is used.
     :param properties: map containing additional parameters for the loading.
     :param returnNode: Deprecated. If set to true then the method returns status flag and node
       instead of signalling error by throwing an exception.
@@ -680,6 +681,9 @@ def loadNodeFromFile(filename, filetype, properties={}, returnNode=False):
 
     # We need to convert the path to string now, because Qt cannot convert a pathlib.Path object to string.
     properties['fileName'] = str(filename)
+
+    if filetype is None:
+        filetype = app.coreIOManager().fileType(filename)
 
     loadedNodesCollection = vtkCollection()
     userMessages = vtkMRMLMessageCollection()
@@ -703,13 +707,14 @@ def loadNodeFromFile(filename, filetype, properties={}, returnNode=False):
     return loadedNode
 
 
-def loadNodesFromFile(filename, filetype, properties={}, returnNode=False):
+def loadNodesFromFile(filename, filetype=None, properties={}, returnNode=False):
     """Load nodes into the scene from a file.
 
     It differs from `loadNodeFromFile` in that it returns loaded node(s) in an iterator.
 
     :param filename: full path of the file to load.
     :param filetype: specifies the file type, which determines which IO class will load the file.
+                     If not specified then the reader with the highest confidence is used.
     :param properties: map containing additional parameters for the loading.
     :return: loaded node(s) in an iterator object.
     :raises RuntimeError: in case of failure
@@ -722,6 +727,8 @@ def loadNodesFromFile(filename, filetype, properties={}, returnNode=False):
 
     loadedNodesCollection = vtkCollection()
     userMessages = vtkMRMLMessageCollection()
+    if filetype is None:
+        filetype = app.coreIOManager().fileType(filename)
     success = app.coreIOManager().loadNodes(filetype, properties, loadedNodesCollection, userMessages)
     if not success:
         errorMessage = f"Failed to load node from file: {filename}"

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -135,10 +135,15 @@ QList<qSlicerFileWriter*> qSlicerCoreIOManagerPrivate::writers(
     scene = this->currentScene();
     }
 
-  vtkObject * object = scene->GetNodeByID(nodeID.toUtf8());
-  if (!object)
+  vtkObject* object = nullptr;
+  // empty nodeID means saving the scene
+  if (!nodeID.isEmpty())
     {
-    qWarning() << Q_FUNC_INFO << "warning: Unable to find node with ID" << nodeID << "in the given scene.";
+    object = scene->GetNodeByID(nodeID.toUtf8());
+    if (!object)
+      {
+      qWarning() << Q_FUNC_INFO << "warning: Unable to find node with ID" << nodeID << "in the given scene.";
+      }
     }
   QFileInfo file(fileName);
 

--- a/Base/QTCore/qSlicerCoreIOManager.cxx
+++ b/Base/QTCore/qSlicerCoreIOManager.cxx
@@ -100,24 +100,18 @@ qSlicerFileReader* qSlicerCoreIOManagerPrivate::reader(const QString& fileName)c
 QList<qSlicerFileReader*> qSlicerCoreIOManagerPrivate::readers(const QString& fileName)const
 {
   // Use a map so that we can access readers sorted by confidence.
-  // The more specific the filter that was matched, the higher confidence
-  // that the reader is more appropriate (e.g., *.seg.nrrd is more specific than *.nrrd;
-  // *.nrrd is more specific than *.*)
-  QMultiMap<int, qSlicerFileReader*> matchingReadersSortedByConfidence;
+  QMultiMap<double, qSlicerFileReader*> matchingReadersSortedByConfidence;
   foreach(qSlicerFileReader* reader, this->Readers)
     {
-    // reader->supportedNameFilters will return the length of the longest matched file extension
-    // in longestExtensionMatch variable.
-    int longestExtensionMatch = 0;
-    QStringList matchedNameFilters = reader->supportedNameFilters(fileName, &longestExtensionMatch);
-    if (!matchedNameFilters.empty() && reader->canLoadFile(fileName))
+    double confidence = reader->canLoadFileConfidence(fileName);
+    if (confidence > 0.0)
       {
-      matchingReadersSortedByConfidence.insert(longestExtensionMatch, reader);
+      matchingReadersSortedByConfidence.insert(confidence, reader);
       }
     }
   // Put matching readers in a list, with highest confidence readers pushed to the front
   QList<qSlicerFileReader*> matchingReaders;
-  QMapIterator<int, qSlicerFileReader*> i(matchingReadersSortedByConfidence);
+  QMapIterator<double, qSlicerFileReader*> i(matchingReadersSortedByConfidence);
   while (i.hasNext())
     {
     i.next();
@@ -232,27 +226,69 @@ qSlicerIO::IOFileType qSlicerCoreIOManager
   return reader ? reader->fileType() : QString("NoFile");
 }
 
+qSlicerFileWriter* qSlicerCoreIOManager
+::writer(vtkObject* object, const QString& extension/*=QString()*/)const
+{
+  Q_D(const qSlicerCoreIOManager);
+
+  // best match: the writer that supports the node type and the specific extension
+  // closest match: the writer that supports the node type but not that specific extension
+  //
+  // If there are multiple matches then the one with the highest confidence is returned.
+
+  qSlicerFileWriter* bestMatch = nullptr;
+  double bestMatchConfidence = 0.0;
+  qSlicerFileWriter* closestMatch = nullptr;
+  double closestMatchConfidence = 0.0;
+
+  foreach (qSlicerFileWriter* writer, d->Writers)
+    {
+    double confidence = writer->canWriteObjectConfidence(object);
+    if (confidence > 0.0)
+      {
+      if (confidence > closestMatchConfidence)
+        {
+        closestMatch = writer;
+        closestMatchConfidence = confidence;
+        }
+      if (extension.isEmpty() || writer->extensions(object).contains(extension))
+        {
+        if (confidence > bestMatchConfidence)
+          {
+          bestMatch = writer;
+          bestMatchConfidence = confidence;
+          }
+        }
+      }
+    }
+
+  if (bestMatch)
+    {
+    return bestMatch;
+    }
+  if (closestMatch)
+    {
+    return closestMatch;
+    }
+  // No match
+  return nullptr;
+}
+
 //-----------------------------------------------------------------------------
 qSlicerIO::IOFileType qSlicerCoreIOManager
 ::fileWriterFileType(vtkObject* object, const QString& format/*=QString()*/)const
 {
   Q_D(const qSlicerCoreIOManager);
-  QList<qSlicerIO::IOFileType> matchingFileTypes;
-  // closest match is the writer that supports the node type but not
-  // that specific extension
-  QString closestMatch = QString("NoFile");
-  foreach (const qSlicerFileWriter* writer, d->Writers)
+
+  qSlicerFileWriter* writer = this->writer(object, format);
+  if (writer)
     {
-    if (writer->canWriteObject(object))
-      {
-      closestMatch = writer->fileType();
-      if (format.isEmpty() || writer->extensions(object).contains(format))
-        {
-        return writer->fileType();
-        }
-      }
+    return writer->fileType();
     }
-  return closestMatch;
+  else
+    {
+    return QString("NoFile");
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -311,13 +347,23 @@ QStringList qSlicerCoreIOManager::fileWriterExtensions(
   vtkObject* object)const
 {
   Q_D(const qSlicerCoreIOManager);
-  QStringList matchingExtensions;
+  // Use a map so that we can access writers sorted by confidence.
+  QMultiMap<double, qSlicerFileWriter*> matchingWritersSortedByConfidence;
   foreach(qSlicerFileWriter* writer, d->Writers)
     {
-    if (writer->canWriteObject(object))
+    double confidence = writer->canWriteObjectConfidence(object);
+    if (confidence > 0.0)
       {
-      matchingExtensions << writer->extensions(object);
+      matchingWritersSortedByConfidence.insert(confidence, writer);
       }
+    }
+  // Put extensions from matching writers in a list, with highest confidence writer pushed to the front
+  QStringList matchingExtensions;
+  QMapIterator<double, qSlicerFileWriter*> i(matchingWritersSortedByConfidence);
+  while (i.hasNext())
+    {
+    i.next();
+    matchingExtensions = i.value()->extensions(object) + matchingExtensions;
     }
   matchingExtensions.removeDuplicates();
   return matchingExtensions;
@@ -488,19 +534,13 @@ qSlicerIOOptions* qSlicerCoreIOManager::fileWriterOptions(
   vtkObject* object, const QString& extension)const
 {
   Q_D(const qSlicerCoreIOManager);
-  qSlicerFileWriter* bestWriter = nullptr;
-  foreach(qSlicerFileWriter* writer, d->Writers)
+  qSlicerFileWriter* bestWriter = this->writer(object, extension);
+  if (!bestWriter)
     {
-    if (writer->canWriteObject(object))
-      {
-      if (writer->extensions(object).contains(extension))
-        {
-        writer->setMRMLScene(d->currentScene());
-        bestWriter = writer;
-        }
-      }
+    return nullptr;
     }
-  return bestWriter ? bestWriter->options() : nullptr;
+  bestWriter->setMRMLScene(d->currentScene());
+  return bestWriter->options();
 }
 
 //-----------------------------------------------------------------------------
@@ -587,7 +627,8 @@ bool qSlicerCoreIOManager::loadNodes(const qSlicerIO::IOFileType& fileType,
     timeProbe.start();
     reader->userMessages()->ClearMessages();
     reader->setMRMLScene(d->currentScene());
-    if (!reader->canLoadFile(parameters["fileName"].toString()))
+    double confidence = reader->canLoadFileConfidence(parameters["fileName"].toString());
+    if (confidence <= 0.0)
       {
       continue;
       }

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -66,8 +66,11 @@ public:
   Q_INVOKABLE QStringList fileDescriptions(const QString& file)const;
   QStringList fileDescriptionsByType(const qSlicerIO::IOFileType fileType)const;
 
-  /// Return the file type associated with an VTK \a object.
-  Q_INVOKABLE qSlicerIO::IOFileType fileWriterFileType(vtkObject* object, const QString& format=QString())const;
+  /// Return best file writer for this object
+  qSlicerFileWriter* writer(vtkObject* object, const QString& extension = QString())const;
+
+  /// Return the file type of the best file writer for the input VTK \a object.
+  Q_INVOKABLE qSlicerIO::IOFileType fileWriterFileType(vtkObject* object, const QString& extension=QString())const;
 
   Q_INVOKABLE QStringList fileWriterDescriptions(const qSlicerIO::IOFileType& fileType)const;
   Q_INVOKABLE QStringList fileWriterExtensions(vtkObject* object)const;
@@ -78,8 +81,10 @@ public:
   /// registered types of storage nodes. Includes the leading dot.
   Q_INVOKABLE QStringList allReadableFileExtensions()const;
 
-  /// Return the file option associated with a \a file type
+  /// Return the file read options for the best reader associated with a \a file type
   qSlicerIOOptions* fileOptions(const QString& fileDescription)const;
+
+  /// Return the file write options of the best file writer for the input VTK \a object.
   qSlicerIOOptions* fileWriterOptions(vtkObject* object, const QString& extension)const;
 
   /// Returns a full extension for this storable node that is recognised by Slicer IO.

--- a/Base/QTCore/qSlicerCoreIOManager.h
+++ b/Base/QTCore/qSlicerCoreIOManager.h
@@ -55,15 +55,21 @@ public:
   qSlicerCoreIOManager(QObject* parent = nullptr);
   ~qSlicerCoreIOManager() override;
 
-  /// Return the file type associated with a \a file
+  /// Return the most likely file type (SegmentationFile, TextFile, ...) for reading a \a file
   Q_INVOKABLE qSlicerIO::IOFileType fileType(const QString& file)const;
+  /// Return all supported file types for reading a \a file
   Q_INVOKABLE QList<qSlicerIO::IOFileType> fileTypes(const QString& file)const;
+
+  /// Return the most likely file description (SegmentationFile, TextFile, ...) for reading a \a file
   Q_INVOKABLE qSlicerIO::IOFileType fileTypeFromDescription(const QString& fileDescription)const;
 
-  /// Return the file description associated with a \a file
+  /// Return the file description ("Volume", "Transform", etc.) associated with a \a file
   /// Usually the description is a short text of one or two words
   /// e.g. Volume, Model, ...
   Q_INVOKABLE QStringList fileDescriptions(const QString& file)const;
+
+  /// Returns descriptions for a file type available across all readers.
+  /// Usually there is only one reader for a file type.
   QStringList fileDescriptionsByType(const qSlicerIO::IOFileType fileType)const;
 
   /// Return best file writer for this object

--- a/Base/QTCore/qSlicerFileReader.cxx
+++ b/Base/QTCore/qSlicerFileReader.cxx
@@ -58,6 +58,22 @@ bool qSlicerFileReader::canLoadFile(const QString& fileName)const
 }
 
 //----------------------------------------------------------------------------
+double qSlicerFileReader::canLoadFileConfidence(const QString& fileName)const
+{
+  if (!this->canLoadFile(fileName))
+    {
+    return 0.0;
+    }
+  int longestExtensionMatch = 0;
+  QStringList res = this->supportedNameFilters(fileName, &longestExtensionMatch);
+  // If longer extension is matched then the confidence that this is a good reader is
+  // slightly higher. For example, for "somefile.seg.nrrd", a reader that is specifically
+  // for ".seg.nrrd" files get slightly higher confidence than readers that of generic ".nrrd" files.
+  double confidence = 0.5 + 0.01 * longestExtensionMatch;
+  return confidence;
+}
+
+//----------------------------------------------------------------------------
 QStringList qSlicerFileReader::supportedNameFilters(const QString& fileName, int* longestExtensionMatchPtr /* =nullptr */)const
 {
   if (longestExtensionMatchPtr)

--- a/Base/QTCore/qSlicerFileReader.h
+++ b/Base/QTCore/qSlicerFileReader.h
@@ -48,7 +48,20 @@ public:
   /// Returns true if the reader can load this file.
   /// Default implementation is a simple and fast, it just checks
   /// if file extension matches any of the wildcards returned by extensions() method.
+  /// This method is kept for backward compatibility, readers should override
+  /// canLoadFileConfidence method instead of this method to indicate if they can
+  /// read a file.
   virtual bool canLoadFile(const QString& file)const;
+
+  /// Returns a positive number (>0) if the reader can load this file.
+  /// The higher the returned value is the more confident the reader it is
+  /// the most suitable class to load the file.
+  /// By default, the method calls canLoadFile and if it returns true then
+  /// the returned confidence value is 0.5 + 0.01 * matchedFileExtensionLength.
+  /// The additional confidence for longer matched file extensions allow prioritization of
+  /// more specific readers. For example, "*.seg.nrrd" is more specific than "*.nrrd";
+  /// "*.nrrd" is more specific than "*.*".
+  virtual double canLoadFileConfidence(const QString& file)const;
 
   /// Return the matching name filters -> if the fileName is "myimage.nrrd"
   /// and the supported extensions are "Volumes (*.mha *.nrrd *.raw)",

--- a/Base/QTCore/qSlicerFileWriter.cxx
+++ b/Base/QTCore/qSlicerFileWriter.cxx
@@ -46,6 +46,16 @@ bool qSlicerFileWriter::canWriteObject(vtkObject* object)const
 }
 
 //----------------------------------------------------------------------------
+double qSlicerFileWriter::canWriteObjectConfidence(vtkObject* object)const
+{
+  if (!this->canWriteObject(object))
+    {
+    return 0.0;
+    }
+  return 0.5;
+}
+
+//----------------------------------------------------------------------------
 bool qSlicerFileWriter::write(const qSlicerIO::IOProperties& properties)
 {
   Q_D(qSlicerFileWriter);

--- a/Base/QTCore/qSlicerFileWriter.h
+++ b/Base/QTCore/qSlicerFileWriter.h
@@ -36,7 +36,17 @@ public:
   ~qSlicerFileWriter() override;
 
   /// Return true if the object is handled by the writer.
+  /// This method is kept for backward compatibility, writers should override
+  /// canWriteObjectConfidence method instead of this method to indicate if they can
+  /// write the object.
   virtual bool canWriteObject(vtkObject* object)const;
+
+  /// Returns a positive number (>0) if the writer can write the object to file.
+  /// The higher the returned value is the more confident the writer it is
+  /// the most suitable class to write the object.
+  /// By default, the method calls canWriteObject and if it returns true then
+  /// it returns confidence value of 0.5.
+  virtual double canWriteObjectConfidence(vtkObject* object)const;
 
   /// Return a list of the supported extensions for a particular object.
   /// Please read QFileDialog::nameFilters for the allowed formats

--- a/Base/QTCore/qSlicerScriptedFileReader.cxx
+++ b/Base/QTCore/qSlicerScriptedFileReader.cxx
@@ -46,6 +46,7 @@ public:
     FileTypeMethod,
     ExtensionsMethod,
     CanLoadFileMethod,
+    CanLoadFileConfidenceMethod,
     LoadMethod,
     };
 
@@ -65,6 +66,7 @@ qSlicerScriptedFileReaderPrivate::qSlicerScriptedFileReaderPrivate()
   this->PythonCppAPI.declareMethod(Self::FileTypeMethod, "fileType");
   this->PythonCppAPI.declareMethod(Self::ExtensionsMethod, "extensions");
   this->PythonCppAPI.declareMethod(Self::CanLoadFileMethod, "canLoadFile");
+  this->PythonCppAPI.declareMethod(Self::CanLoadFileConfidenceMethod, "canLoadFileConfidence");
   this->PythonCppAPI.declareMethod(Self::LoadMethod, "load");
 }
 
@@ -260,6 +262,30 @@ bool qSlicerScriptedFileReader::canLoadFile(const QString& file)const
     return false;
     }
   return result == Py_True;
+}
+
+//-----------------------------------------------------------------------------
+double qSlicerScriptedFileReader::canLoadFileConfidence(const QString& file)const
+{
+  Q_D(const qSlicerScriptedFileReader);
+  PyObject* arguments = PyTuple_New(1);
+  PyTuple_SET_ITEM(arguments, 0, PyString_FromString(file.toUtf8()));
+  PyObject* result = d->PythonCppAPI.callMethod(d->CanLoadFileConfidenceMethod, arguments);
+  Py_DECREF(arguments);
+  if (!result)
+    {
+    // Method call failed (probably an omitted function), call default implementation
+    return this->Superclass::canLoadFileConfidence(file);
+    }
+
+  if (PyFloat_Check(result))
+    {
+    qWarning() << d->PythonSource
+               << " - In" << d->PythonClassName << "class, function 'canLoadFileConfidence' "
+               << "is expected to return a float!";
+    return 0.0;
+    }
+  return PyFloat_AsDouble(result);
 }
 
 //-----------------------------------------------------------------------------

--- a/Base/QTCore/qSlicerScriptedFileReader.h
+++ b/Base/QTCore/qSlicerScriptedFileReader.h
@@ -72,6 +72,9 @@ public:
   bool canLoadFile(const QString& file)const override;
 
   /// Reimplemented to propagate to python methods
+  /// \sa qSlicerFileReader::canLoadFileConfidence()
+  double canLoadFileConfidence(const QString& file)const override;
+
   /// \sa qSlicerFileReader::write()
   bool load(const qSlicerIO::IOProperties& properties) override;
 

--- a/Base/QTCore/qSlicerScriptedFileWriter.h
+++ b/Base/QTCore/qSlicerScriptedFileWriter.h
@@ -67,6 +67,10 @@ public:
   bool canWriteObject(vtkObject* object)const override;
 
   /// Reimplemented to propagate to python methods
+  /// \sa qSlicerFileWriter::canWriteObjectConfidence()
+  double canWriteObjectConfidence(vtkObject* object)const override;
+
+  /// Reimplemented to propagate to python methods
   /// \sa qSlicerFileWriter::extensions()
   QStringList extensions(vtkObject* object)const override;
 

--- a/Base/QTGUI/qSlicerFileDialog.cxx
+++ b/Base/QTGUI/qSlicerFileDialog.cxx
@@ -245,6 +245,7 @@ qSlicerIOOptions* qSlicerStandardFileDialog
       }
     QStringList fileDescriptions =
       ioManager->fileWriterDescriptions(this->fileType());
+    // TODO: this seems wrong, a description is provided while the method expects an extension
     options = fileDescriptions.count() ?
       ioManager->fileWriterOptions(nodeToSave, fileDescriptions[0]) : nullptr;
     }

--- a/Base/QTGUI/qSlicerNodeWriter.cxx
+++ b/Base/QTGUI/qSlicerNodeWriter.cxx
@@ -130,7 +130,7 @@ bool qSlicerNodeWriter::write(const qSlicerIO::IOProperties& properties)
 
   vtkMRMLStorableNode* node = vtkMRMLStorableNode::SafeDownCast(
     this->getNodeByID(properties["nodeID"].toString().toUtf8().data()));
-  if (!this->canWriteObject(node))
+  if (this->canWriteObjectConfidence(node) <= 0.0)
     {
     return false;
     }

--- a/Base/QTGUI/qSlicerNodeWriter.h
+++ b/Base/QTGUI/qSlicerNodeWriter.h
@@ -50,7 +50,7 @@ public:
   QString description()const override;
   IOFileType fileType()const override;
 
-  /// Return true if the object is handled by the writer.
+  /// Return true if this class can write the input object.
   bool canWriteObject(vtkObject* object)const override;
 
   /// Return a list of the supported extensions for a particular object.

--- a/Modules/Loadable/Colors/qSlicerColorsReader.cxx
+++ b/Modules/Loadable/Colors/qSlicerColorsReader.cxx
@@ -19,6 +19,7 @@
 ==============================================================================*/
 
 // Qt includes
+#include <QTextStream>
 
 // Slicer includes
 #include "qSlicerColorsReader.h"
@@ -81,6 +82,34 @@ qSlicerIO::IOFileType qSlicerColorsReader::fileType()const
 QStringList qSlicerColorsReader::extensions()const
 {
   return QStringList() << "Color (*.txt *.ctbl *.cxml)";
+}
+
+//----------------------------------------------------------------------------
+double qSlicerColorsReader::canLoadFileConfidence(const QString& fileName)const
+{
+  double confidence = Superclass::canLoadFileConfidence(fileName);
+
+  // Confidence for .txt file is 0.54 (4 characters in the file extension matched),
+  // for more specific file extensions (.ctbl, .cxml) it would be 0.55.
+  // Therefore, confidence below 0.55 means that we got a generic file extension
+  // that we need to inspect further.
+  if (confidence > 0 || confidence < 0.55)
+    {
+    // Generic file extension, inspect the content
+    QString upperCaseFileName = fileName.toUpper();
+    if (upperCaseFileName.endsWith("TXT"))
+      {
+      QFile file(fileName);
+      if (file.open(QIODevice::ReadOnly | QIODevice::Text))
+        {
+        QTextStream in(&file);
+        // Color table text files start with "# Color table file"
+        QString line = in.read(100);
+        confidence = (line.contains("# Color table file") ? 0.6 : 0.4);
+        }
+      }
+    }
+  return confidence;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Colors/qSlicerColorsReader.h
+++ b/Modules/Loadable/Colors/qSlicerColorsReader.h
@@ -45,6 +45,12 @@ public:
   IOFileType fileType()const override;
   QStringList extensions()const override;
 
+  /// Returns a positive number (>0) if the reader can load this file.
+  /// In case the file uses the generic .txt file extension then the confidence value is adjusted based on
+  /// the file content: if the file contains color table information then confidence is increased to 0.6,
+  /// otherwise the confidence is decreased to 0.4.
+  double canLoadFileConfidence(const QString& file)const override;
+
   bool load(const IOProperties& properties) override;
 protected:
   QScopedPointer<qSlicerColorsReaderPrivate> d_ptr;

--- a/Modules/Loadable/Markups/qSlicerMarkupsReader.h
+++ b/Modules/Loadable/Markups/qSlicerMarkupsReader.h
@@ -43,6 +43,12 @@ public:
   IOFileType fileType()const override;
   QStringList extensions()const override;
 
+  /// Returns a positive number (>0) if the reader can load this file.
+  /// In case the file uses a generic file extension (such as .json) then the confidence value is adjusted based on
+  /// the file content: if the file contains markups information then confidence is increased to 0.6,
+  /// otherwise the confidence is decreased to 0.4.
+  double canLoadFileConfidence(const QString& file)const override;
+
   bool load(const IOProperties& properties) override;
 
 protected:

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsNodeWriter.cxx
@@ -57,7 +57,7 @@ bool qSlicerSegmentationsNodeWriter::write(const qSlicerIO::IOProperties& proper
 
   vtkMRMLStorableNode* node = vtkMRMLStorableNode::SafeDownCast(
     this->getNodeByID(properties["nodeID"].toString().toUtf8().data()));
-  if (!this->canWriteObject(node))
+  if (this->canWriteObjectConfidence(node) <= 0.0)
     {
     return false;
     }

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.cxx
@@ -24,6 +24,7 @@
 
 // Qt includes
 #include <QFileInfo>
+#include <QTextStream>
 
 // Logic includes
 #include "vtkSlicerSegmentationsModuleLogic.h"
@@ -104,6 +105,36 @@ qSlicerIOOptions* qSlicerSegmentationsReader::options()const
   qSlicerIOOptionsWidget* options = new qSlicerSegmentationsIOOptionsWidget;
   options->setMRMLScene(this->mrmlScene());
   return options;
+}
+
+//----------------------------------------------------------------------------
+double qSlicerSegmentationsReader::canLoadFileConfidence(const QString& fileName)const
+{
+  double confidence = Superclass::canLoadFileConfidence(fileName);
+
+  // Confidence for .nrrd file is 0.55 (5 characters in the file extension matched),
+  // .vtm is 0.54; for composite file extensions (.seg.nrrd, .seg.vtm) it would be >0.58.
+  // Therefore, confidence below 0.56 means that we got a generic file extension
+  // that we need to inspect further.
+  if (confidence > 0 || confidence < 0.56)
+    {
+    // Not a composite file extension, inspect the content (for now, only nrrd).
+    QString upperCaseFileName = fileName.toUpper();
+    if (upperCaseFileName.endsWith("NRRD") || upperCaseFileName.endsWith("NHDR"))
+      {
+      QFile file(fileName);
+      if (file.open(QIODevice::ReadOnly | QIODevice::Text))
+        {
+        QTextStream in(&file);
+        // Segmentation NRRD files contain ID for each segment (such as Segment0_ID:=...)
+        // around position 500, read a bit further to account for slight variations in the header.
+        QString line = in.read(800);
+        // If this appears in the file header then declare higher confidence value.
+        confidence = (line.contains("Segment0_ID:=") ? 0.6 : 0.4);
+        }
+      }
+    }
+  return confidence;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.h
+++ b/Modules/Loadable/Segmentations/qSlicerSegmentationsReader.h
@@ -47,6 +47,12 @@ public:
   QStringList extensions()const override;
   qSlicerIOOptions* options()const override;
 
+  /// Returns a positive number (>0) if the reader can load this file.
+  /// In case the file uses a generic file extension (such as .nrrd) then the confidence value is adjusted based on
+  /// the file content: if the file contains segmentation information then confidence is increased to 0.6,
+  /// otherwise the confidence is decreased to 0.4.
+  double canLoadFileConfidence(const QString& file)const override;
+
   bool load(const IOProperties& properties) override;
 
 protected:

--- a/Modules/Loadable/Sequences/qSlicerSequencesReader.cxx
+++ b/Modules/Loadable/Sequences/qSlicerSequencesReader.cxx
@@ -19,8 +19,9 @@
 ==============================================================================*/
 
 // Qt includes
-#include <QFileInfo>
 #include <QDebug>
+#include <QFileInfo>
+#include <QTextStream>
 
 // Slicer includes
 #include "qSlicerSequencesReader.h"
@@ -93,7 +94,40 @@ QStringList qSlicerSequencesReader::extensions()const
   return QStringList()
     << tr("Sequence") + " (*.seq.mrb *.mrb)"
     << tr("Volume Sequence") + " (*.seq.nrrd *.seq.nhdr)"
-    << tr("Volume `Sequence") + " (*.nrrd *.nhdr)";
+    << tr("Volume Sequence") + " (*.nrrd *.nhdr)";
+}
+
+//----------------------------------------------------------------------------
+double qSlicerSequencesReader::canLoadFileConfidence(const QString& fileName)const
+{
+  double confidence = Superclass::canLoadFileConfidence(fileName);
+
+  // Confidence for .json file is 0.55 (5 characters in the file extension matched),
+  // for composite file extensions (.mrk.json) it would be 0.59.
+  // Therefore, confidence below 0.56 means that we got a generic file extension
+  // that we need to inspect further.
+  if (confidence > 0 || confidence < 0.56)
+    {
+    // Not a composite file extension, inspect the content
+    // Unzipping the mrb file to inspect if it looks like a sequence would be too time-consuming,
+    // therefore we only check NRRD files for now.
+    QString upperCaseFileName = fileName.toUpper();
+    if (upperCaseFileName.endsWith("NRRD") || upperCaseFileName.endsWith("NHDR"))
+      {
+      QFile file(fileName);
+      if (file.open(QIODevice::ReadOnly | QIODevice::Text))
+        {
+        QTextStream in(&file);
+        // Markups json files contain a custom field specifying the index type as
+        // "axis 0 index type:=" or "axis 3 index type:=" around position 500,
+        // read a bit further to account for slight variations in the header.
+        QString line = in.read(800);
+        bool looksLikeSequence = line.contains("axis 0 index type:=") || line.contains("axis 3 index type:=");
+        confidence = (looksLikeSequence ? 0.6 : 0.4);
+        }
+      }
+    }
+  return confidence;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Sequences/qSlicerSequencesReader.h
+++ b/Modules/Loadable/Sequences/qSlicerSequencesReader.h
@@ -46,6 +46,12 @@ public:
   IOFileType fileType()const override;
   QStringList extensions()const override;
 
+  /// Returns a positive number (>0) if the reader can load this file.
+  /// In case the file uses a generic file extension (such as .nrrd) then the confidence value is adjusted based on
+  /// the file content: if the file contains a sequence nrrd file then confidence is increased to 0.6,
+  /// otherwise the confidence is decreased to 0.4.
+  double canLoadFileConfidence(const QString& file)const override;
+
   bool load(const IOProperties& properties) override;
 
 protected:

--- a/Modules/Loadable/Tables/qSlicerTablesReader.cxx
+++ b/Modules/Loadable/Tables/qSlicerTablesReader.cxx
@@ -109,6 +109,19 @@ QStringList qSlicerTablesReader::extensions()const
     ;
 }
 
+//----------------------------------------------------------------------------
+double qSlicerTablesReader::canLoadFileConfidence(const QString& fileName)const
+{
+  double confidence = Superclass::canLoadFileConfidence(fileName);
+
+  // .txt file is more likely a simple text file than a table
+  if (confidence > 0 && fileName.toUpper().endsWith("TXT"))
+    {
+    confidence = 0.4;
+    }
+  return confidence;
+}
+
 //-----------------------------------------------------------------------------
 bool qSlicerTablesReader::load(const IOProperties& properties)
 {

--- a/Modules/Loadable/Tables/qSlicerTablesReader.h
+++ b/Modules/Loadable/Tables/qSlicerTablesReader.h
@@ -49,6 +49,12 @@ public:
   IOFileType fileType()const override;
   QStringList extensions()const override;
 
+  /// Returns a positive number (>0) if the reader can load this file.
+  /// It only differs from the default confidence (based on file extension matching)
+  /// that .txt files are recognized with a reduced confidence of 0.4, because
+  /// .txt files more likely store simple text than a table.
+  double canLoadFileConfidence(const QString& file)const override;
+
   bool load(const IOProperties& properties) override;
 protected:
   QScopedPointer<qSlicerTablesReaderPrivate> d_ptr;

--- a/Modules/Loadable/Terminologies/qSlicerTerminologiesReader.cxx
+++ b/Modules/Loadable/Terminologies/qSlicerTerminologiesReader.cxx
@@ -18,6 +18,9 @@
 
 ==============================================================================*/
 
+// Qt includes
+#include <QTextStream>
+
 // Terminologies includes
 #include "qSlicerTerminologiesReader.h"
 
@@ -79,6 +82,37 @@ qSlicerIO::IOFileType qSlicerTerminologiesReader::fileType()const
 QStringList qSlicerTerminologiesReader::extensions()const
 {
   return QStringList() << "Terminology (*.term.json)" << "Terminology (*.json)";
+}
+
+//----------------------------------------------------------------------------
+double qSlicerTerminologiesReader::canLoadFileConfidence(const QString& fileName)const
+{
+  double confidence = Superclass::canLoadFileConfidence(fileName);
+
+  // Confidence for .json file is 0.55 (5 characters in the file extension matched),
+  // for composite file extensions (.term.json) it would be 0.6.
+  // Therefore, confidence below 0.56 means that we got a generic file extension
+  // that we need to inspect further.
+  if (confidence > 0 || confidence < 0.56)
+    {
+    // Not a composite file extension, inspect the content
+    QString upperCaseFileName = fileName.toUpper();
+    if (upperCaseFileName.endsWith("JSON"))
+      {
+      QFile file(fileName);
+      if (file.open(QIODevice::ReadOnly | QIODevice::Text))
+        {
+        QTextStream in(&file);
+        // Markups json files contain a schema URL like /anatomic-context-schema.json
+        // or /segment-context-schema.json around position 200, read a bit further
+        // to account for slight variations in the header.
+        QString line = in.read(400);
+        bool looksLikeTerminology = line.contains("/anatomic-context-schema.json") || line.contains("/segment-context-schema.json");
+        confidence = (looksLikeTerminology ? 0.6 : 0.4);
+        }
+      }
+    }
+  return confidence;
 }
 
 //-----------------------------------------------------------------------------

--- a/Modules/Loadable/Terminologies/qSlicerTerminologiesReader.h
+++ b/Modules/Loadable/Terminologies/qSlicerTerminologiesReader.h
@@ -46,6 +46,12 @@ public:
   IOFileType fileType()const override;
   QStringList extensions()const override;
 
+  /// Returns a positive number (>0) if the reader can load this file.
+  /// In case the file uses a generic file extension (such as .json) then the confidence value is adjusted based on
+  /// the file content: if the file contains markups information then confidence is increased to 0.6,
+  /// otherwise the confidence is decreased to 0.4.
+  double canLoadFileConfidence(const QString& file)const override;
+
   bool load(const IOProperties& properties) override;
 
 protected:


### PR DESCRIPTION
Until now, reader and writer plugins could only return a Boolean value indicating if they can read or write a certain file. For file reading, composite file extensions (.seg.nrrd instad of just .nrrd) were used to find the most suitable plugin, but this did not work when a file was saved with a generic file extension (nrrd, json, txt, ...). It also caused an issue when a more specific reader plugin was registered before a generic plugin (e.g., segmentation reader was registered before volume reader). Finally, there was no way to prioritize writer plugins.

This commit introduces a new `canLoadFileConfidence` method to readers and writers. This allows a plugin to indicate its confidence that it is the most suitable plugin for reading/writing a file. Reader plugins are updated to determine confidence based on a quick inspection of file content when a file with generic file extension is encountered. Quick inspection means that the header is not parsed, just a few hundred bytes are read and a string is searched in it.