### PR TITLE
BUG: Set segment Pickable display property to true if not specified

### DIFF
--- a/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
+++ b/Libs/MRML/Core/vtkMRMLSegmentationDisplayNode.cxx
@@ -109,7 +109,7 @@ void vtkMRMLSegmentationDisplayNode::WriteXML(ostream& of, int nIndent)
       << " Opacity3D:" << propIt->second.Opacity3D
       << " Opacity2DFill:" << propIt->second.Opacity2DFill
       << " Opacity2DOutline:" << propIt->second.Opacity2DOutline
-      << " Pickable:" << propIt->second.Pickable << "|";
+      << " Pickable:" << (propIt->second.Pickable ? "true" : "false") << "|";
     }
   of << "\"";
 }
@@ -211,7 +211,11 @@ void vtkMRMLSegmentationDisplayNode::ReadXMLAttributes(const char** atts)
             else if (propertyName=="Visible3D") { props.Visible3D = booleanValue; }
             else if (propertyName=="Visible2DFill") { props.Visible2DFill = booleanValue; }
             else if (propertyName=="Visible2DOutline") { props.Visible2DOutline = booleanValue; }
-            else if (propertyName=="Pickable") { props.Pickable = booleanValue; }
+            else if (propertyName=="Pickable")
+              {
+              // Pickable property needs to be set to true if not specified
+              props.Pickable = booleanValueString.compare("false") ? true : false;
+              }
             }
           }
         this->SetSegmentDisplayProperties(vtkMRMLNode::URLDecodeString(id.c_str()), props);
@@ -276,7 +280,7 @@ void vtkMRMLSegmentationDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
        << ", Visible2DFill=" << (propIt->second.Visible2DFill ? "true" : "false") << ", Visible2DOutline="
        << (propIt->second.Visible2DOutline ? "true" : "false")
        << ", Opacity3D=" << propIt->second.Opacity3D << ", Opacity2DFill=" << propIt->second.Opacity2DFill
-       << ", Opacity2DOutline=" << propIt->second.Opacity2DOutline << ", Pickable=" << propIt->second.Pickable << "\n";
+       << ", Opacity2DOutline=" << propIt->second.Opacity2DOutline << ", Pickable=" << (propIt->second.Pickable ? "true" : "false") << "\n";
     }
 }
 


### PR DESCRIPTION
Pickable is a new segment display property, so when loading existing segmentations it will be missing from the display node. In this case the default true value needs to be specified, otherwise no segments will be pickable (i.e. no fiducials or other points can be placed on them).

This commit also fixes saving of the Pickable property. Now it is saved and loaded as a boolean property, as "true" or "false" instead of 0 or 1.