### PR TITLE
COMP: Speed up incremental build

### DIFF
--- a/Base/Logic/Testing/vtkSlicerVersionConfigureTest1.cxx
+++ b/Base/Logic/Testing/vtkSlicerVersionConfigureTest1.cxx
@@ -34,7 +34,7 @@ int vtkSlicerVersionConfigureTest1(int /*argc*/, char * /*argv*/ [])
   CHECK_STRING_DIFFERENT(Slicer_WC_REVISION, "");
   CHECK_STRING_DIFFERENT(Slicer_REVISION, "");
 
-  // From vtkSlicerVersionConfigureInternal
+  // From vtkSlicerVersionConfigureMinimal
   CHECK_STRING(Slicer_OS_LINUX_NAME, "linux");
   CHECK_STRING(Slicer_OS_MAC_NAME, "macosx");
   CHECK_STRING(Slicer_OS_WIN_NAME, "win");

--- a/Base/QTCore/Testing/Cxx/qSlicerApplicationUpdateManagerTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerApplicationUpdateManagerTest.cxx
@@ -29,7 +29,7 @@
 // QtCore includes
 #include "qSlicerApplicationUpdateManager.h"
 #include "vtkSlicerConfigure.h"
-#include "vtkSlicerVersionConfigure.h"
+#include "vtkSlicerVersionConfigureMinimal.h"
 
 // STD includes
 #include <iostream>

--- a/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
+++ b/Base/QTCore/Testing/Cxx/qSlicerExtensionsManagerModelTest.cxx
@@ -32,7 +32,7 @@
 // QtCore includes
 #include "qSlicerExtensionsManagerModel.h"
 #include "vtkSlicerConfigure.h"
-#include "vtkSlicerVersionConfigure.h"
+#include "vtkSlicerVersionConfigureMinimal.h"
 
 // STD includes
 #include <iostream>

--- a/Base/QTCore/qSlicerExtensionsManagerModel.cxx
+++ b/Base/QTCore/qSlicerExtensionsManagerModel.cxx
@@ -52,7 +52,7 @@
 #include "qSlicerCoreApplication.h"
 #include "qSlicerExtensionsManagerModel.h"
 #include "vtkSlicerConfigure.h"
-#include "vtkSlicerVersionConfigure.h"
+#include "vtkSlicerVersionConfigureMinimal.h"
 
 // MRML includes
 #include "vtkArchive.h"

--- a/CMake/vtkSlicerVersionConfigure.h.in
+++ b/CMake/vtkSlicerVersionConfigure.h.in
@@ -14,6 +14,15 @@
 #define __vtkSlicerVersionConfigure_h
 
 /// \file vtkSlicerVersionConfigure.h
+/// \brief Defines macros identifying the version and revision of this project.
+///
+/// The macros defined in this file are specific to the current revision of the source code,
+/// and they augment the version details provided by vtkSlicerVersionConfigureInternal.h.
+/// Note that this header internally includes `vtkSlicerVersionConfigureInternal.h`.
+///
+/// Since this header file is regenerated each time the current revision (i.e., Git commit)
+/// of the source code changes, it should be included carefully.
+///
 
 #include "vtkSlicerVersionConfigureInternal.h"
 

--- a/CMake/vtkSlicerVersionConfigure.h.in
+++ b/CMake/vtkSlicerVersionConfigure.h.in
@@ -17,14 +17,15 @@
 /// \brief Defines macros identifying the version and revision of this project.
 ///
 /// The macros defined in this file are specific to the current revision of the source code,
-/// and they augment the version details provided by vtkSlicerVersionConfigureInternal.h.
-/// Note that this header internally includes `vtkSlicerVersionConfigureInternal.h`.
+/// and they augment the version details provided by vtkSlicerVersionConfigureMinimal.h.
+/// Note that this header internally includes `vtkSlicerVersionConfigureMinimal.h`.
 ///
 /// Since this header file is regenerated each time the current revision (i.e., Git commit)
-/// of the source code changes, it should be included carefully.
+/// of the source code changes, it should be included carefully. to maintain incremental build
+/// speed. Consider including `vtkSlicerVersionConfigureMinimal.h` before including this header.
 ///
 
-#include "vtkSlicerVersionConfigureInternal.h"
+#include "vtkSlicerVersionConfigureMinimal.h"
 
 /// \def Slicer_RELEASE_TYPE
 /// \brief Type of Slicer release: `Experimental`, `Nightly` or `Stable`.

--- a/CMake/vtkSlicerVersionConfigure.h.in
+++ b/CMake/vtkSlicerVersionConfigure.h.in
@@ -27,17 +27,6 @@
 
 #include "vtkSlicerVersionConfigureMinimal.h"
 
-/// \def Slicer_RELEASE_TYPE
-/// \brief Type of Slicer release: `Experimental`, `Nightly` or `Stable`.
-#define Slicer_RELEASE_TYPE "@Slicer_RELEASE_TYPE@"
-
-//-----------------------------------------------------------------------------
-/// \def Slicer_VERSION
-/// \brief Slicer version string.
-///
-/// Format is `<Slicer_VERSION_MAJOR>.<Slicer_VERSION_MINOR>`.
-#define Slicer_VERSION "@Slicer_VERSION@"
-
 /// \def Slicer_VERSION_FULL
 /// \brief Slicer long version string.
 ///
@@ -76,13 +65,6 @@
 /// \brief Commit count identifying this project sources (custom commit count offset applied).
 /// \sa Slicer_REVISION
 #define Slicer_COMMIT_COUNT "@Slicer_COMMIT_COUNT@"
-
-//-----------------------------------------------------------------------------
-/// \def Slicer_MAIN_PROJECT_VERSION
-/// \brief Slicer main project version string.
-///
-/// Format is `<Slicer_MAIN_PROJECT_VERSION_MAJOR>.<Slicer_MAIN_PROJECT_VERSION_MINOR>`.
-#define Slicer_MAIN_PROJECT_VERSION "@Slicer_MAIN_PROJECT_VERSION@"
 
 /// \def Slicer_MAIN_PROJECT_VERSION_FULL
 /// \brief Slicer main project long version string.

--- a/CMake/vtkSlicerVersionConfigureMinimal.h.in
+++ b/CMake/vtkSlicerVersionConfigureMinimal.h.in
@@ -52,6 +52,20 @@
 #define Slicer_MAIN_PROJECT_VERSION_PATCH @Slicer_MAIN_PROJECT_VERSION_PATCH@
 
 //-----------------------------------------------------------------------------
+/// \def Slicer_VERSION
+/// \brief Slicer version string.
+///
+/// Format is `<Slicer_VERSION_MAJOR>.<Slicer_VERSION_MINOR>`.
+#define Slicer_VERSION "@Slicer_VERSION@"
+
+//-----------------------------------------------------------------------------
+/// \def Slicer_MAIN_PROJECT_VERSION
+/// \brief Slicer main project version string.
+///
+/// Format is `<Slicer_MAIN_PROJECT_VERSION_MAJOR>.<Slicer_MAIN_PROJECT_VERSION_MINOR>`.
+#define Slicer_MAIN_PROJECT_VERSION "@Slicer_MAIN_PROJECT_VERSION@"
+
+//-----------------------------------------------------------------------------
 /// \def Slicer_OS_LINUX_NAME
 /// String describing Linux operating system.
 #define Slicer_OS_LINUX_NAME "@Slicer_OS_LINUX_NAME@"
@@ -71,5 +85,9 @@
 /// \def Slicer_OS
 /// \brief String describing the operating system associated with this project binaries.
 #define Slicer_OS "@Slicer_OS@"
+
+/// \def Slicer_RELEASE_TYPE
+/// \brief Type of Slicer release: `Experimental`, `Nightly` or `Stable`.
+#define Slicer_RELEASE_TYPE "@Slicer_RELEASE_TYPE@"
 
 #endif // __vtkSlicerVersionConfigureMinimal_h

--- a/CMake/vtkSlicerVersionConfigureMinimal.h.in
+++ b/CMake/vtkSlicerVersionConfigureMinimal.h.in
@@ -10,19 +10,23 @@
 
 =========================================================================auto=*/
 
-//
-//  W A R N I N G
-//  -------------
-//
-// This file is not part of the Slicer API.  It exists purely as an
-// implementation detail.  This header file may change from version to
-// version without notice, or even be removed.
-//
-// We mean it.
-//
+#ifndef __vtkSlicerVersionConfigureMinimal_h
+#define __vtkSlicerVersionConfigureMinimal_h
 
-#ifndef __vtkSlicerVersionConfigureInternal_h
-#define __vtkSlicerVersionConfigureInternal_h
+/// \file vtkSlicerVersionConfigureMinimal.h
+/// \brief Defines macros identifying the operating system, architecture and version of this project.
+///
+/// The macros provided in this file identify the operating system, architecture, and
+/// version of this project.
+///
+/// The file is prefixed with "Minimal" because it provides a subset of the version
+/// information that rarely changes. Indeed, these macros are occasionally modified
+/// by updating the `Slicer_VERSION_*` or `Slicer_RELEASE_TYPE` CMake options
+/// (e.g., when creating a release).
+///
+/// If you need version information specific to the current revision of this project
+/// source code, consider including `vtkSlicerVersionConfigure.h` instead of this header.
+///
 
 //-----------------------------------------------------------------------------
 /// \def Slicer_VERSION_MAJOR
@@ -68,4 +72,4 @@
 /// \brief String describing the operating system associated with this project binaries.
 #define Slicer_OS "@Slicer_OS@"
 
-#endif // __vtkSlicerVersionConfigureInternal_h
+#endif // __vtkSlicerVersionConfigureMinimal_h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1180,7 +1180,7 @@ get_property(Slicer_QM_OUTPUT_DIRS GLOBAL PROPERTY Slicer_QM_OUTPUT_DIRS)
 # --------------------------------------------------------------------------
 set(files
   vtkSlicerConfigure.h
-  vtkSlicerVersionConfigureInternal.h
+  vtkSlicerVersionConfigureMinimal.h
   )
 foreach(f ${files})
   configure_file(

--- a/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
+++ b/Modules/Loadable/Markups/MRML/vtkMRMLMarkupsFiducialStorageNode.cxx
@@ -20,7 +20,7 @@
 
 #include "vtkMRMLScene.h"
 #include "vtkMRMLMessageCollection.h"
-#include "vtkSlicerVersionConfigure.h"
+#include "vtkSlicerVersionConfigureMinimal.h"
 
 #include "vtkObjectFactory.h"
 #include "vtkStringArray.h"

--- a/Utilities/Doxygen/Doxyfile.txt.in
+++ b/Utilities/Doxygen/Doxyfile.txt.in
@@ -666,7 +666,7 @@ WARN_LOGFILE           =
 
 INPUT                  = "@Slicer_SOURCE_DIR@" \
                          "@Slicer_BINARY_DIR@/vtkSlicerVersionConfigure.h" \
-                         "@Slicer_BINARY_DIR@/vtkSlicerVersionConfigureInternal.h"
+                         "@Slicer_BINARY_DIR@/vtkSlicerVersionConfigureMinimal.h"
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is


### PR DESCRIPTION
vtkSlicerVersionConfigureInternal.h is renamed vtkSlicerVersionConfigureMinimal.h.

#include "vtkSlicerVersionConfigure.h" is replaced by #include "vtkSlicerVersionConfigureMinimal.h" when it is possible, therefore no compilation is required if git commit is changed.