### PR TITLE
ENH: Add fractional addition to Add/Subtract Slice Composting pipeline

### DIFF
--- a/Libs/MRML/Logic/vtkMRMLSliceLogic.h
+++ b/Libs/MRML/Logic/vtkMRMLSliceLogic.h
@@ -37,6 +37,7 @@ class vtkCollection;
 class vtkImageBlend;
 class vtkTransform;
 class vtkImageData;
+class vtkImageMathematics;
 class vtkImageReslice;
 class vtkTransform;
 
@@ -425,6 +426,9 @@ protected:
   /// re-add an input if it is not changed) because rebuilding of the pipeline
   /// is a relatively expensive operation.
   bool UpdateBlendLayers(vtkImageBlend* blend, const std::deque<SliceLayerInfo> &layers);
+
+  /// Helper to update foreground opacity when adding/subtracting the background layer
+  bool UpdateFractions(vtkImageMathematics* fraction, double opacity);
 
   /// Returns true if position is inside the selected layer volume.
   /// Use background flag to choose between foreground/background layer.


### PR DESCRIPTION
- the Add/Subtract pipeline now respects the opacity slider used for alpha blend
- The opacity slider is used to determine the fraction of the foreground image added to the background

Alpha Blend Behavior:
![AlphaBlendPipeline](https://github.com/Slicer/Slicer/assets/25040869/e8a407cc-0a6e-4e38-919b-65c940f8e3c7)

| Old Add Behavior | New Add Behavior |
|--|--|
| ![OldAddPipeline_mid](https://github.com/Slicer/Slicer/assets/25040869/b346fd83-acfd-43c1-9a0b-3d7ef764a732) | ![NewAddPipeline](https://github.com/Slicer/Slicer/assets/25040869/5ce80d4c-ddcd-4058-8fb5-81f15ed5b137) |
