### PR TITLE
BUG: Fix handling of non-modified terminology types

### DIFF
--- a/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
+++ b/Modules/Loadable/Terminologies/Widgets/qSlicerTerminologyNavigatorWidget.cxx
@@ -399,9 +399,8 @@ void qSlicerTerminologyNavigatorWidgetPrivate::setNameFromCurrentTerminology()
 //-----------------------------------------------------------------------------
 QColor qSlicerTerminologyNavigatorWidgetPrivate::terminologyRecommendedColor()
 {
-  // Return 'invalid' color if type is not selected or the selected type has modifiers but no modifier is selected
-  if ( !this->CurrentTypeObject ||
-       (this->CurrentTypeObject->GetHasModifiers() && !this->CurrentTypeModifierObject) )
+  // Return 'invalid' color if type is not selected
+  if (!this->CurrentTypeObject)
     {
     return QColor();
     }
@@ -411,7 +410,7 @@ QColor qSlicerTerminologyNavigatorWidgetPrivate::terminologyRecommendedColor()
   unsigned char r = vtkSlicerTerminologyType::INVALID_COLOR[0];
   unsigned char g = vtkSlicerTerminologyType::INVALID_COLOR[1];
   unsigned char b = vtkSlicerTerminologyType::INVALID_COLOR[2];
-  if (!this->CurrentTypeObject->GetHasModifiers())
+  if (!this->CurrentTypeObject->GetHasModifiers() || this->CurrentTypeModifierObject->GetCodeValue() == nullptr)
     {
     this->CurrentTypeObject->GetRecommendedDisplayRGBValue(r,g,b);
     }


### PR DESCRIPTION
Selecting "No type modifier" for a terminology when modifiers exist causes the the default invalid color to be displayed, even if a non-modified color has been specified in the terminology JSON. 

This commit corrects the function terminologyRecommendedColor() to return the non-modified color if the type has modifiers and a non-modified color exists. This bug fix is related to the issue: https://github.com/Slicer/Slicer/issues/6972 and was discussed in the Slicer discourse post: https://discourse.slicer.org/t/terminologies-questions/27384.